### PR TITLE
Medium: cib: Fix compilation of ACL code

### DIFF
--- a/lib/cib/cib_acl.c
+++ b/lib/cib/cib_acl.c
@@ -684,11 +684,10 @@ acl_filter_xml(xmlNode * xml, GHashTable * xml_perms)
     }
 
     if (xml) {
-        xmlAttrPtr xIter = param_set->properties;
+        xmlAttrPtr xIter = xml->properties;
 
         while (xIter) {
             const char *prop_name = (const char *)xIter->name;
-            const char *prop_value = crm_element_value(xml, prop_name);
             gpointer mode = NULL;
 
             xIter = xIter->next;
@@ -757,7 +756,6 @@ acl_check_diff_xml(xmlNode * xml, GHashTable * xml_perms)
 
         for (xIter = xml->properties; xIter; xIter = xIter->next) {
             const char *prop_name = (const char *)xIter->name;
-            const char *prop_value = crm_element_value(xml, prop_name);
             gpointer mode = NULL;
 
             if (crm_str_eq(crm_element_name(xml), XML_TAG_CIB, TRUE)) {


### PR DESCRIPTION
Hi Andrew,

The following commit breaks compilation of ACL code:

commit 8b1b087144f60c569083156c7de3f3c915dd910f
Author: Andrew Beekhof andrew@beekhof.net
Date:   Fri Sep 2 20:09:36 2011 +1000

```
Low: Core: Remove use of the xml_prop_iter macros - they confuse parsers, analyisers and indent tools
```

The commit fixes this.
