### PR TITLE
Low: PE: changed a pre-fix to refer to a right value.

### DIFF
--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -425,7 +425,7 @@ get_ticket_state(gpointer key, gpointer value, gpointer user_data)
     const char *attr_key = key;
 
     const char *granted_prefix = "granted-ticket-";
-    const char *last_granted_prefix = "last-granted-ticket-";
+    const char *last_granted_prefix = "last-granted-";
     static int granted_prefix_strlen = 0;
     static int last_granted_prefix_strlen = 0;
 


### PR DESCRIPTION
This change discussed it by the following lists.
http://www.gossamer-threads.com/lists/linuxha/pacemaker/77845
