### PR TITLE
doc: fix asciidoc's appendix syntax

### DIFF
--- a/doc/Clusters_from_Scratch/en-US/Ap-Configuration.txt
+++ b/doc/Clusters_from_Scratch/en-US/Ap-Configuration.txt
@@ -1,7 +1,9 @@
 [appendix]
-= Configuration Recap =
+Configuration Recap
+-------------------
 
-== Final Cluster Configuration ==
+Final Cluster Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .....
 # crm configure show
@@ -43,9 +45,8 @@ rsc_defaults $id="rsc-options" \
     resource-stickiness="100"
 .....
 
-
-== Node List ==
-
+Node List
+~~~~~~~~~
 The list of cluster nodes is automatically populated by the cluster.
 
 .....
@@ -54,8 +55,8 @@ node pcmk-2
 .....
 
 
-== Cluster Options ==
-
+Cluster Options
+~~~~~~~~~~~~~~~
 This is where the cluster automatically stores some information about
 the cluster
 
@@ -82,11 +83,11 @@ property $id="cib-bootstrap-options" \
 .....
 
 
-== Resources ==
+Resources
+~~~~~~~~~
 
-
-=== Default Options ===
-
+Default Options
+^^^^^^^^^^^^^^^
 Here we configure cluster options that apply to every resource.
 
 * resource-stickiness - Specify the aversion to moving resources to other machines
@@ -96,8 +97,8 @@ rsc_defaults $id="rsc-options" \
     resource-stickiness="100"
 .....
 
-=== Fencing ===
-
+Fencing
+^^^^^^^
 
 [NOTE]
 =======
@@ -111,8 +112,8 @@ primitive ipmi-fencing stonith::fence_ipmilan \
 clone Fencing rsa-fencing
 .....
 
-=== Service Address ===
-
+Service Address
+^^^^^^^^^^^^^^^
 Users of the services provided by the cluster require an unchanging
 address with which to access it. Additionally, we cloned the address so
 it will be active on both nodes. An iptables rule (created as part of the
@@ -136,8 +137,8 @@ clone WebIP ClusterIP
 TODO: The RA should check for globally-unique=true when cloned
 =======
 
-=== DRBD - Shared Storage ===
-
+DRBD - Shared Storage
+^^^^^^^^^^^^^^^^^^^^^
 Here we define the DRBD service and specify which DRBD resource (from
 drbd.conf) it should manage. We make it a master/slave resource and, in
 order to have an active/active setup, allow both instances to be promoted
@@ -153,8 +154,8 @@ ms WebDataClone WebData \
 .....
 
 
-=== Cluster Filesystem ===
-
+Cluster Filesystem
+^^^^^^^^^^^^^^^^^^
 The cluster filesystem ensures that files are read and written correctly.
 We need to specify the block device (provided by DRBD), where we want it
 mounted and that we are using GFS2. Again it is a clone because it is
@@ -172,8 +173,8 @@ order WebFS-after-WebData inf: WebDataClone:promote WebFSClone:start
 order start-WebFS-after-gfs-control inf: gfs-clone WebFSClone
 .....
 
-=== Apache ===
-
+Apache
+^^^^^^
 Lastly we have the actual service, Apache. We need only tell the cluster
 where to find it's main configuration file and restrict it to running on
 nodes that have the required filesystem mounted and the IP address

--- a/doc/Clusters_from_Scratch/en-US/Ap-Corosync-Conf.txt
+++ b/doc/Clusters_from_Scratch/en-US/Ap-Corosync-Conf.txt
@@ -1,5 +1,6 @@
 [appendix]
-= Sample Corosync Configuration =
+Sample Corosync Configuration
+-----------------------------
 
 .Sample Corosync.conf for a two-node cluster
 .....

--- a/doc/Clusters_from_Scratch/en-US/Ap-Reading.txt
+++ b/doc/Clusters_from_Scratch/en-US/Ap-Reading.txt
@@ -1,5 +1,6 @@
 [appendix]
-= Further Reading =
+Further Reading
+---------------
 
 - Project Website
 http://www.clusterlabs.org


### PR DESCRIPTION
Clusters_from_Scratch has syntax error on appendix.
see detail: http://www.methods.co.nz/asciidoc/userguide.html#X93 Section markup templates
