### PR TITLE
Allow pacemaker to start without EnvironmentFile

### DIFF
--- a/mcp/pacemaker.service.in
+++ b/mcp/pacemaker.service.in
@@ -11,7 +11,7 @@ Type=simple
 KillMode=process
 NotifyAccess=main
 SysVStartPriority=99
-EnvironmentFile=@sysconfdir@/sysconfig/pacemaker
+EnvironmentFile=-@sysconfdir@/sysconfig/pacemaker
 
 ExecStart=@sbindir@/pacemakerd -f
 


### PR DESCRIPTION
The EnvironmentFile line in pacemaker.service will prevent pacemaker from starting if that file does not exist.  To prevent errors occurring from reading the EnvironmentFile from stopping pacemaker from starting, the "-" prefix can be used.

Source: http://fedoraproject.org/wiki/Packaging:Systemd

"The "-" on the EnvironmentFile= line ensures that no error messages is generated if the sysconfig file does not exist. Since traditionally sysconfig files have been optional you should always include the "-" when using this directive."
