### PR TITLE
Low: crmd: Bug cl#5015 - Remove failure operation from lrm resource cach...

### DIFF
--- a/crmd/crmd_lrm.h
+++ b/crmd/crmd_lrm.h
@@ -18,4 +18,4 @@
 
 extern gboolean verify_stopped(enum crmd_fsa_state cur_state, int log_level);
 extern void lrm_connection_destroy(gpointer user_data);
-extern void delete_op_entry(lrm_op_t * op, const char *rsc_id, const char *key, int call_id);
+extern void lrm_clear_last_failure(const char *rsc_id);

--- a/crmd/messages.c
+++ b/crmd/messages.c
@@ -669,10 +669,7 @@ handle_failcount_op(xmlNode * stored_msg)
         update_attrd(NULL, attr, NULL, NULL);
         crm_free(attr);
 
-        attr = generate_op_key(rsc, "last_failure", 0);
-        delete_op_entry(NULL, rsc, attr, 0);
-        crm_free(attr);
-
+        lrm_clear_last_failure(rsc);
     } else {
         crm_log_xml_warn(stored_msg, "invalid failcount op");
     }


### PR DESCRIPTION
...e when failure-timeout occurs.

When the failure-timeout expired for a failed operation, the
failure was removed from the CIB but still remained in the lrm
resource cache.  In certain situations this resulted in the
failure being restored to the CIB after the failure-timeout occurred.
