### PR TITLE
Medium: fencing: rhbz#801355 - Merge scheduling of fence requests for id...

### DIFF
--- a/include/crm/stonith-ng-internal.h
+++ b/include/crm/stonith-ng-internal.h
@@ -40,6 +40,7 @@ typedef struct async_command_s {
 
     GListPtr device_list;
     GListPtr device_next;
+    char *scheduled;
 
     ProcTrack_ops *pt_ops;
     ProcTrackKillInfo killseq[3];


### PR DESCRIPTION
...entical operations already in progress.

After the completion of a stonith operation, if stonith
detects that an identical operation has been scheduled
to execute immediately on the same device,
stonith will return the result of the completed operation
instead of executing the same operation multiple times.

This helps mitigate a scenario where two processes in the HA stack
respond to the same cluster event by fencing the same node.  Since
each process is responding to the event independently of
one another it is possible two fencing operations may get
scheduled at nearly the same time for the same node.  With this patch,
any duplicate operations scheduled to perform an action that is already
being executed will be merged into the executing operation.
