### PR TITLE
Low: cts: Log badnews when rsyslog rate limiting occurs.

### DIFF
--- a/cts/CM_ais.py
+++ b/cts/CM_ais.py
@@ -82,6 +82,7 @@ class crm_ais(crm_lha):
                 r"Child process .* terminated with signal 11",
                 r"Executing .* fencing operation",
                 r"LogActions: Recover",
+                r"rsyslogd.* imuxsock lost .* messages from pid .* due to rate-limiting",
 
                 # Not inherently bad, but worth tracking
                 #r"No need to invoke the TE",


### PR DESCRIPTION
If rsyslog rate limiting is enabled, it will cause all kinds of inconsistencies in tests.  Tests will pass one time, then fail... or possibly pass consistently for a day then fail.  Nothing in the cts reports that log messages are being dropped right now because of rate limiting.  This patch spits out a "Badnews" error when rate limiting occurs so someone will at least have some sort of indication as to what the issue is.
