### PR TITLE
High: crmd: cl#5051 - Fixes file leak in pe ipc connection initialization.

### DIFF
--- a/crmd/pengine.c
+++ b/crmd/pengine.c
@@ -181,7 +181,7 @@ do_pe_control(long long action,
         }
     }
 
-    if (action & start_actions) {
+    if ((action & start_actions) && (is_set(fsa_input_register, R_PE_CONNECTED) == FALSE)) {
         if (cur_state != S_STOPPING) {
             if (is_openais_cluster()) {
                 set_bit_inplace(fsa_input_register, pe_subsystem->flag_required);


### PR DESCRIPTION
It was possible for crmd to initialize the ipc connection to the pengine multiple times without tearing down the old connection.  Instead of doing this, a check was added to ignore initializing the ipc connection to the pegine if it was already connected.
