### PR TITLE
Low: doc: fix operarions/op attribute (disabled->enabled)

### DIFF
--- a/doc/Pacemaker_Explained/en-US/Ch-Resources.xml
+++ b/doc/Pacemaker_Explained/en-US/Ch-Resources.xml
@@ -500,13 +500,13 @@
 	<para>
 	  The easiest way to stop a recurring monitor is to just delete it.
 	  However, there can be times when you only want to disable it temporarily.
-	  In such cases, simply add <literal>disabled="true"</literal> to the operation's definition.
+	  In such cases, simply add <literal>enabled="false"</literal> to the operation's definition.
 	</para>
 	<example>
 	  <title>Example of an OCF resource with a disabled health check</title>
 	  <programlisting><![CDATA[ <primitive id="Public-IP" class="ocf" type="IPaddr" provider="heartbeat">
     <operations>
-     <op id="public-ip-check" name="monitor" interval="60s" disabled="true"/>
+     <op id="public-ip-check" name="monitor" interval="60s" enabled="false"/>
     </operations>
     <instance_attributes id="params-public-ip">
        <nvpair id="public-ip-addr" name="ip" value="1.2.3.4"/>
@@ -514,9 +514,9 @@
   </primitive> ]]> </programlisting>
 	</example>
 	<para>This can be achieved from the command-line by executing</para>
-	<programlisting><command>cibadmin -M -X ‘&lt;op id="public-ip-check" disabled="true"/>'</command></programlisting>
+	<programlisting><command>cibadmin -M -X ‘&lt;op id="public-ip-check" enabled="false"/>'</command></programlisting>
 	<para>Once you've done whatever you needed to do, you can then re-enable it with</para>
-	<programlisting><command>cibadmin -M -X ‘&lt;op id="public-ip-check" disabled="false"/>'</command></programlisting>
+	<programlisting><command>cibadmin -M -X ‘&lt;op id="public-ip-check" enabled="true"/>'</command></programlisting>
       </section>
     </section>
   </chapter>

--- a/doc/Pacemaker_Explained/pot/Ch-Resources.pot
+++ b/doc/Pacemaker_Explained/pot/Ch-Resources.pot
@@ -917,7 +917,7 @@ msgstr ""
 
 #. Tag: para
 #, no-c-format
-msgid "The easiest way to stop a recurring monitor is to just delete it. However, there can be times when you only want to disable it temporarily. In such cases, simply add <literal>disabled=\"true\"</literal> to the operation's definition."
+msgid "The easiest way to stop a recurring monitor is to just delete it. However, there can be times when you only want to disable it temporarily. In such cases, simply add <literal>enabled=\"false\"</literal> to the operation's definition."
 msgstr ""
 
 #. Tag: title
@@ -929,7 +929,7 @@ msgstr ""
 #, no-c-format
 msgid " &lt;primitive id=\"Public-IP\" class=\"ocf\" type=\"IPaddr\" provider=\"heartbeat\"&gt;\n"
 "    &lt;operations&gt;\n"
-"     &lt;op id=\"public-ip-check\" name=\"monitor\" interval=\"60s\" disabled=\"true\"/&gt;\n"
+"     &lt;op id=\"public-ip-check\" name=\"monitor\" interval=\"60s\" enabled=\"false\"/&gt;\n"
 "    &lt;/operations&gt;\n"
 "    &lt;instance_attributes id=\"params-public-ip\"&gt;\n"
 "       &lt;nvpair id=\"public-ip-addr\" name=\"ip\" value=\"1.2.3.4\"/&gt;\n"
@@ -944,7 +944,7 @@ msgstr ""
 
 #. Tag: programlisting
 #, no-c-format
-msgid "<command>cibadmin -M -X ‘&lt;op id=\"public-ip-check\" disabled=\"true\"/&gt;'</command>"
+msgid "<command>cibadmin -M -X ‘&lt;op id=\"public-ip-check\" enabled=\"false\"/&gt;'</command>"
 msgstr ""
 
 #. Tag: para
@@ -954,6 +954,6 @@ msgstr ""
 
 #. Tag: programlisting
 #, no-c-format
-msgid "<command>cibadmin -M -X ‘&lt;op id=\"public-ip-check\" disabled=\"false\"/&gt;'</command>"
+msgid "<command>cibadmin -M -X ‘&lt;op id=\"public-ip-check\" enabled=\"true\"/&gt;'</command>"
 msgstr ""
 

--- a/doc/Pacemaker_Explained/ro-RO/Ch-Resources.po
+++ b/doc/Pacemaker_Explained/ro-RO/Ch-Resources.po
@@ -1017,8 +1017,8 @@ msgstr "Dezactivarea unei Operaţiuni de Monitorizare"
 
 #. Tag: para
 #, no-c-format
-msgid "The easiest way to stop a recurring monitor is to just delete it. However, there can be times when you only want to disable it temporarily. In such cases, simply add <literal>disabled=\"true\"</literal> to the operation's definition."
-msgstr "Cel mai simplu mod de a opri un monitor recurent este să îl ştergeţi. Însă pot exista momente când vreţi doar să îl dezactivaţi temporar. În astfel de cazuri, pur şi simplu adăugaţi <literal>disabled=\"true\"</literal> la definiţia operaţiunii."
+msgid "The easiest way to stop a recurring monitor is to just delete it. However, there can be times when you only want to disable it temporarily. In such cases, simply add <literal>enabled=\"false\"</literal> to the operation's definition."
+msgstr "Cel mai simplu mod de a opri un monitor recurent este să îl ştergeţi. Însă pot exista momente când vreţi doar să îl dezactivaţi temporar. În astfel de cazuri, pur şi simplu adăugaţi <literal>enabled=\"false\"</literal> la definiţia operaţiunii."
 
 #. Tag: title
 #, no-c-format
@@ -1029,7 +1029,7 @@ msgstr "Exemplu de resursă OCF cu o verificare a sănătăţii dezactivată"
 #, no-c-format
 msgid " &lt;primitive id=\"Public-IP\" class=\"ocf\" type=\"IPaddr\" provider=\"heartbeat\"&gt;\n"
 "    &lt;operations&gt;\n"
-"     &lt;op id=\"public-ip-check\" name=\"monitor\" interval=\"60s\" disabled=\"true\"/&gt;\n"
+"     &lt;op id=\"public-ip-check\" name=\"monitor\" interval=\"60s\" enabled=\"false\"/&gt;\n"
 "    &lt;/operations&gt;\n"
 "    &lt;instance_attributes id=\"params-public-ip\"&gt;\n"
 "       &lt;nvpair id=\"public-ip-addr\" name=\"ip\" value=\"1.2.3.4\"/&gt;\n"
@@ -1038,7 +1038,7 @@ msgid " &lt;primitive id=\"Public-IP\" class=\"ocf\" type=\"IPaddr\" provider=\"
 msgstr ""
 " &lt;primitive id=\"Public-IP\" class=\"ocf\" type=\"IPaddr\" provider=\"heartbeat\"&gt;\n"
 "    &lt;operations&gt;\n"
-"     &lt;op id=\"public-ip-check\" name=\"monitor\" interval=\"60s\" disabled=\"true\"/&gt;\n"
+"     &lt;op id=\"public-ip-check\" name=\"monitor\" interval=\"60s\" enabled=\"false\"/&gt;\n"
 "    &lt;/operations&gt;\n"
 "    &lt;instance_attributes id=\"params-public-ip\"&gt;\n"
 "       &lt;nvpair id=\"public-ip-addr\" name=\"ip\" value=\"1.2.3.4\"/&gt;\n"
@@ -1052,8 +1052,8 @@ msgstr "Acest lucru poate fi realizat din linia de comanda executând"
 
 #. Tag: programlisting
 #, no-c-format
-msgid "<command>cibadmin -M -X ‘&lt;op id=\"public-ip-check\" disabled=\"true\"/&gt;'</command>"
-msgstr "<command>cibadmin -M -X ‘&lt;op id=\"public-ip-check\" disabled=\"true\"/&gt;'</command>"
+msgid "<command>cibadmin -M -X ‘&lt;op id=\"public-ip-check\" enabled=\"false\"/&gt;'</command>"
+msgstr "<command>cibadmin -M -X ‘&lt;op id=\"public-ip-check\" enabled=\"false\"/&gt;'</command>"
 
 #. Tag: para
 #, no-c-format
@@ -1062,6 +1062,6 @@ msgstr "Odată ce aţi făcut ceea ce aveaţi nevoie să faceţi, îl puteţi re
 
 #. Tag: programlisting
 #, no-c-format
-msgid "<command>cibadmin -M -X ‘&lt;op id=\"public-ip-check\" disabled=\"false\"/&gt;'</command>"
-msgstr "<command>cibadmin -M -X ‘&lt;op id=\"public-ip-check\" disabled=\"false\"/&gt;'</command>"
+msgid "<command>cibadmin -M -X ‘&lt;op id=\"public-ip-check\" enabled=\"true\"/&gt;'</command>"
+msgstr "<command>cibadmin -M -X ‘&lt;op id=\"public-ip-check\" enabled=\"true\"/&gt;'</command>"
 


### PR DESCRIPTION
In Pacemaker Explained (original + POT incl. translation).

Signed-off-by: Jan Pokorný jpokorny@redhat.com
