### PR TITLE
heartbeat: Fix a variable name

### DIFF
--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -341,7 +341,7 @@ get_uname(const char *uuid)
             char *uuid_copy = crm_strdup(uuid);
 
             cl_uuid_parse(uuid_copy, &uuid_raw);
-            crm_malloc(uname, MAX_NAME);
+            crm_malloc(hb_uname, MAX_NAME);
 
             if (heartbeat_cluster->llc_ops->get_name_by_uuid(heartbeat_cluster, &uuid_raw, hb_uname,
                                                              MAX_NAME) == HA_FAIL) {


### PR DESCRIPTION
Hi Andrew,

This request is the patch for following commit.
- https://github.com/ClusterLabs/pacemaker/commit/7304894a9ecee13d8694159f72efc3f0fb41c90b

Fixes fail-count not being updated properly with Heartbeat.

Best Regards.
