### PR TITLE
High: core: Fixes race condition in mainloop add/delete fd wrapper functions

### DIFF
--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -618,8 +618,15 @@ void
 mainloop_del_fd(mainloop_io_t *client)
 {
     if(client != NULL) {
-        crm_trace("Removing client %s[%p]", client->name, client);
-        g_io_channel_unref(client->channel);
+        if (client->channel) {
+            crm_trace("Removing client %s[%p]", client->name, client);
+            g_io_channel_unref(client->channel);
+            client->channel = NULL;
+        }
+        if (client->source) {
+            g_source_remove(client->source);
+            client->source = 0;
+        }
         /* Results in mainloop_ipcc_destroy() being called once the source is removed from mainloop? */
     }
 }


### PR DESCRIPTION
The g_io_add_watch_full id is never cancelled in mainloop_del_fd().
This means it is possible the mainloop_fd callbacks can be invoked
again after mainloop_del_fd() is executed.
