### PR TITLE
High: cib: cl#5026 - Synced cib updates should not return until the cpg broadcast is complete.

### DIFF
--- a/cib/callbacks.c
+++ b/cib/callbacks.c
@@ -47,6 +47,14 @@ extern gboolean cib_shutdown_flag;
 extern gboolean stand_alone;
 extern const char *cib_root;
 
+static unsigned long cib_local_bcast_num = 0;
+
+typedef struct cib_local_notify_s {
+    xmlNode *notify_src;
+    char *client_id;
+    gboolean from_peer;
+} cib_local_notify_t;
+
 qb_ipcs_service_t *ipcs_ro = NULL;
 qb_ipcs_service_t *ipcs_rw = NULL;
 qb_ipcs_service_t *ipcs_shm = NULL;
@@ -67,6 +75,7 @@ void cib_process_request(xmlNode * request, gboolean privileged, gboolean force_
                          gboolean from_peer, cib_client_t * cib_client);
 
 extern GHashTable *client_list;
+extern GHashTable *local_notify_queue;
 
 int next_client_id = 0;
 extern const char *cib_our_uname;
@@ -337,6 +346,52 @@ do_local_notify(xmlNode * notify_src, const char *client_id,
 }
 
 static void
+local_notify_destroy_callback(gpointer data)
+{
+    cib_local_notify_t *notify = data;
+
+    free_xml(notify->notify_src);
+    crm_free(notify->client_id);
+    crm_free(notify);
+}
+
+static void
+check_local_notify(int bcast_id)
+{
+    cib_local_notify_t *notify = NULL;
+
+    if (!local_notify_queue) {
+        return;
+    }
+
+    notify = g_hash_table_lookup(local_notify_queue, GINT_TO_POINTER(bcast_id));
+
+    if (notify) {
+        do_local_notify(notify->notify_src, notify->client_id, TRUE, notify->from_peer);
+        g_hash_table_remove(local_notify_queue, GINT_TO_POINTER(bcast_id));
+    }
+}
+
+static void
+queue_local_notify(xmlNode * notify_src, const char *client_id, gboolean from_peer)
+{
+    cib_local_notify_t *notify;
+
+    crm_malloc0(notify, sizeof(cib_local_notify_t));
+
+    notify->notify_src = notify_src;
+    notify->client_id = crm_strdup(client_id);
+    notify->from_peer = from_peer;
+
+    if (!local_notify_queue) {
+        local_notify_queue = g_hash_table_new_full(g_direct_hash,
+            g_direct_equal, NULL, local_notify_destroy_callback);
+    }
+
+    g_hash_table_insert(local_notify_queue, GINT_TO_POINTER(cib_local_bcast_num), notify);
+}
+
+static void
 parse_local_options(cib_client_t * cib_client, int call_type, int call_options, const char *host,
                     const char *op, gboolean * local_notify, gboolean * needs_reply,
                     gboolean * process, gboolean * needs_forward)
@@ -486,7 +541,7 @@ forward_request(xmlNode * request, cib_client_t * cib_client, int call_options)
     }
 }
 
-static void
+static gboolean
 send_peer_reply(xmlNode * msg, xmlNode * result_diff, const char *originator, gboolean broadcast)
 {
     CRM_ASSERT(msg != NULL);
@@ -528,14 +583,16 @@ send_peer_reply(xmlNode * msg, xmlNode * result_diff, const char *originator, gb
 
         add_message_xml(msg, F_CIB_UPDATE_DIFF, result_diff);
         crm_log_xml_trace(msg, "copy");
-        send_cluster_message(NULL, crm_msg_cib, msg, TRUE);
+        return send_cluster_message(NULL, crm_msg_cib, msg, TRUE);
 
     } else if (originator != NULL) {
         /* send reply via HA to originating node */
         crm_trace("Sending request result to originator only");
         crm_xml_add(msg, F_CIB_ISREPLY, originator);
-        send_cluster_message(originator, crm_msg_cib, msg, FALSE);
+        return send_cluster_message(originator, crm_msg_cib, msg, FALSE);
     }
+
+    return FALSE;
 }
 
 void
@@ -559,6 +616,7 @@ cib_process_request(xmlNode * request, gboolean force_synchronous, gboolean priv
     const char *op = crm_element_value(request, F_CIB_OPERATION);
     const char *originator = crm_element_value(request, F_ORIG);
     const char *host = crm_element_value(request, F_CIB_HOST);
+    const char *client_id = crm_element_value(request, F_CIB_CLIENTID);
 
     crm_trace("%s Processing msg %s", cib_our_uname, crm_element_value(request, F_SEQ));
 
@@ -676,16 +734,6 @@ cib_process_request(xmlNode * request, gboolean force_synchronous, gboolean priv
     }
     crm_trace("processing response cases %.16x %.16x", call_options, cib_sync_call);
 
-    if (local_notify) {
-        const char *client_id = crm_element_value(request, F_CIB_CLIENTID);
-
-        if (client_id && process == FALSE) {
-            do_local_notify(request, client_id, call_options & cib_sync_call, from_peer);
-        } else if (client_id) {
-            do_local_notify(op_reply, client_id, call_options & cib_sync_call, from_peer);
-        }
-    }
-
     /* from now on we are the server */
     if (needs_reply == FALSE || stand_alone) {
         /* nothing more to do...
@@ -694,7 +742,25 @@ cib_process_request(xmlNode * request, gboolean force_synchronous, gboolean priv
         crm_trace("Completed slave update");
 
     } else if (rc == cib_ok && result_diff != NULL && !(call_options & cib_inhibit_bcast)) {
-        send_peer_reply(request, result_diff, originator, TRUE);
+        gboolean broadcast = FALSE;
+
+        cib_local_bcast_num++;
+        crm_xml_add_int(request, F_CIB_LOCAL_NOTIFY_ID, cib_local_bcast_num);
+        broadcast = send_peer_reply(request, result_diff, originator, TRUE);
+
+        if (broadcast &&
+            client_id &&
+            local_notify &&
+            (call_options & cib_sync_call) &&
+            op_reply) {
+
+            /* If we have been asked to sync the reply,
+             * and a bcast msg has gone out, we queue the local notify
+             * until we know the bcast message has been received */
+            local_notify = FALSE;
+            queue_local_notify(op_reply, client_id, from_peer);
+            op_reply = NULL; /* the reply is queued, so don't free here */
+        }
 
     } else if (call_options & cib_discard_reply) {
         crm_trace("Caller isn't interested in reply");
@@ -713,6 +779,14 @@ cib_process_request(xmlNode * request, gboolean force_synchronous, gboolean priv
         }
 
         send_peer_reply(op_reply, result_diff, originator, FALSE);
+    }
+
+    if (local_notify && client_id) {
+        if (process == FALSE) {
+            do_local_notify(request, client_id, call_options & cib_sync_call, from_peer);
+        } else {
+            do_local_notify(op_reply, client_id, call_options & cib_sync_call, from_peer);
+        }
     }
 
     free_xml(op_reply);
@@ -1060,6 +1134,10 @@ cib_peer_callback(xmlNode * msg, void *private_data)
 
     if (originator == NULL || crm_str_eq(originator, cib_our_uname, TRUE)) {
         /* message is from ourselves */
+        int bcast_id = 0;
+        if (!(crm_element_value_int(msg, F_CIB_LOCAL_NOTIFY_ID, &bcast_id))) {
+            check_local_notify(bcast_id);
+        }
         return;
 
     } else if (crm_peer_cache == NULL) {

--- a/cib/main.c
+++ b/cib/main.c
@@ -86,6 +86,7 @@ extern int write_cib_contents(gpointer p);
 
 GHashTable *client_list = NULL;
 GHashTable *config_hash = NULL;
+GHashTable *local_notify_queue = NULL;
 
 char *channel1 = NULL;
 char *channel2 = NULL;
@@ -241,6 +242,9 @@ void
 cib_cleanup(void)
 {
     crm_peer_destroy();
+    if (local_notify_queue) {
+        g_hash_table_destroy(local_notify_queue);
+    }
     g_hash_table_destroy(config_hash);
     g_hash_table_destroy(client_list);
     crm_free(cib_our_uname);

--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -1950,6 +1950,13 @@ do_update_resource(lrm_rsc_t * rsc, lrm_op_t * op)
      * the alternative however means blocking here for too long, which
      * isnt acceptable
      */
+
+    if (is_set(fsa_input_register, R_SHUTDOWN)) {
+        /* The update must be synchronous when shutting down to guarantee the update
+         * is received by everyone before the crmd leaves the cpg group. */
+        call_opt |= cib_sync_call;
+    }
+
     fsa_cib_update(XML_CIB_TAG_STATUS, update, call_opt, rc, NULL);
 
     /* the return code is a call number, not an error code */

--- a/include/crm/cib.h
+++ b/include/crm/cib.h
@@ -188,6 +188,7 @@ enum cib_section {
 #  define F_CIB_NOTIFY_ACTIVATE	"cib_notify_activate"
 #  define F_CIB_UPDATE_DIFF	"cib_update_diff"
 #  define F_CIB_USER		"cib_user"
+#  define F_CIB_LOCAL_NOTIFY_ID	"cib_local_notify_id"
 
 #  define T_CIB			"cib"
 #  define T_CIB_NOTIFY		"cib_notify"


### PR DESCRIPTION
This fixes a race condition on shutdown where the final lrm
operation updates sent to the cib are not broadcast to all the
nodes before the crmd leaves the cpg.  This results in the final
lrm operations being ignored, which makes it look like the node
did not terminate properly.  When this occurs the node that just
shutdown gets fenced even though it didn't need to be.

To fix this, on shutdown all the final lrm operation updates sent
to the cib from the crmd are processed synchronously.  The function
the crmd is using to update the cib will not return until the
cib broadcast has made it out to everyone.  This guarantees that the
crmd will not leave the cpg before the cib updates are broadcast.
