### PR TITLE
High: crmd: cl#5068 - Fixes crm_node -R option so it works with corosync 2.0

### DIFF
--- a/crmd/messages.c
+++ b/crmd/messages.c
@@ -777,6 +777,17 @@ handle_request(xmlNode * stored_msg)
         /* probably better to do this via signals on the
          * local node
          */
+
+    } else if (strcmp(op, CRM_OP_RM_NODE_CACHE) == 0) {
+        xmlNode *options = get_xpath_object("//"XML_TAG_OPTIONS, stored_msg, LOG_ERR);
+        int id = 0;
+
+        if (options) {
+           crm_element_value_int(options, XML_ATTR_ID, &id);
+        }
+        if (id) {
+            reap_crm_member(id);
+        }
     } else if (strcmp(op, CRM_OP_DEBUG_UP) == 0) {
         crm_bump_log_level();
         crm_info("Debug set to %d", get_crm_log_level());

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -146,6 +146,7 @@ extern const char *crm_system_name;
 #  define CRM_OP_REPROBE		"probe_again"
 #  define CRM_OP_CLEAR_FAILCOUNT  "clear_failcount"
 #  define CRM_OP_RELAXED_SET  "one-or-more"
+#  define CRM_OP_RM_NODE_CACHE "rm_node_cache"
 
 #  define CRMD_STATE_ACTIVE	"member"
 #  define CRMD_STATE_INACTIVE	"down"


### PR DESCRIPTION
The -R option for crm_node previously worked by connecting to the
cluster and sending out a command to all the nodes to clear
their peer cache for a specific node.  Now that cpg is used for
membership and communication between all the components across
the cluster, this method would not work.  Crm_node can not connect
to the crmd cpg to tell everyone to do something because it confuse
the membership layer of the crmd.  To enable this functionality
with use of corosync 2.0, a new ipc operation is created for crmd.
This operation allows crm_node to tell the local crmd process to
broadcast to everyone in the cgp to clear a node from their cache.
