### PR TITLE
Low: Build: Fix redefinition of 'lrmd_key_value_t'

### DIFF
--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -43,11 +43,11 @@
 CRM_TRACE_INIT_DATA(lrmd);
 
 static stonith_t *stonith_api = NULL;
-typedef struct lrmd_key_value_s {
+struct lrmd_key_value_s {
     char *key;
     char *value;
     struct lrmd_key_value_s *next;
-} lrmd_key_value_t;
+};
 
 typedef struct lrmd_private_s {
     int call_id;


### PR DESCRIPTION
gcc-4.3 complains (gcc-4.6 doesn't):

lrmd_client.c:50: error: redefinition of typedef ‘lrmd_key_value_t’
../../include/crm/lrmd.h:24: error: previous declaration of ‘lrmd_key_value_t’ was here

Perhaps something like this patch?
