### PR TITLE
Low: Build: Always use a short hash for the build version.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1103,8 +1103,8 @@ AC_DEFINE_UNQUOTED(RH_STONITH_PREFIX,"$RH_STONITH_PREFIX", Prefix for Red Hat St
 AC_PATH_PROGS(GIT, git false)
 AC_MSG_CHECKING(build version)
 
-BUILD_VERSION=$Format:%H$
-if test $BUILD_VERSION != ":%H$"; then
+BUILD_VERSION=$Format:%h$
+if test $BUILD_VERSION != ":%h$"; then
    AC_MSG_RESULT(archive hash: $BUILD_VERSION)
 
 elif test -x $GIT -a -d .git; then


### PR DESCRIPTION
A long hash value (40 chars) is used only when using archive hash , while a short hash (7 chars) is used when using git hash or directory based hash.
