### PR TITLE
Low: mcp: start pacemakerd as a daemon with -d option

### DIFF
--- a/mcp/pacemaker.in
+++ b/mcp/pacemaker.in
@@ -72,7 +72,7 @@ start()
 	# required subdirectories for proper operations
 	mkdir -p @localstatedir@/run
 
-	if status $prog > /dev/null 2>&1; then
+	if status $prog -d > /dev/null 2>&1; then
 		success
 	else
 		$prog > /dev/null 2>&1


### PR DESCRIPTION
We can't use upstart on RHEL6 because glib is old.
Can you reinsert code to demonize ?
