### PR TITLE
Low: Core: avoid list traverse restarts when stripping text nodes

### DIFF
--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -670,17 +670,17 @@ decompress_file(const char *filename)
 
 static void strip_text_nodes(xmlNode *xml) 
 {
-    xmlNode *iter = NULL;
-    for(iter = xml->children; iter; iter = iter->next) {
+    xmlNode *iter = xml->children;
+
+    while (iter) {
+        xmlNode *next = iter->next;
+
         switch(iter->type) {
             case XML_TEXT_NODE:
                 /* Remove it */
                 xmlUnlinkNode(iter);
                 xmlFreeNode(iter);
-
-                /* Start again since xml->children will have changed */
-                strip_text_nodes(xml);
-                return;
+                break;
 
             case XML_ELEMENT_NODE:
                 /* Search it */
@@ -691,6 +691,8 @@ static void strip_text_nodes(xmlNode *xml)
                 /* Leave it */
                 break;
         }
+
+        iter = next;
     }
 }
 


### PR DESCRIPTION
Restarting from the beginning of children list can lead to some
subtrees being unnecessarily traversed several times (once for
every text node following it). To handle node deletion, it is
sufficient to simply copy the pointer to next item before we
delete current one.
