### PR TITLE
High: fencing: cl#5073 - Add 'off' as an valid value for stonith-action option

### DIFF
--- a/doc/Pacemaker_Explained/en-US/Ch-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Options.txt
@@ -171,7 +171,9 @@ one or more STONITH resources have been configured also.
 | stonith-action | reboot |
 indexterm:[stonith-action Cluster Options]
 indexterm:[Cluster Options,stonith-action]
-Action to send to STONITH device. Allowed values: reboot, poweroff.
+Action to send to STONITH device. Allowed values: reboot, off.
+The value 'poweroff' is also allowed, but is only used for
+legacy devices.
 
 | cluster-delay | 60s |
 indexterm:[cluster-delay Cluster Options]

--- a/fencing/main.c
+++ b/fencing/main.c
@@ -665,7 +665,7 @@ main(int argc, char ** argv)
     int lpc = 0;
     int argerr = 0;
     int option_index = 0;
-    const char *actions[] = { "reboot", "poweroff", "list", "monitor", "status" };
+    const char *actions[] = { "reboot", "off", "list", "monitor", "status" };
 
     crm_log_init("stonith-ng", LOG_INFO, TRUE, FALSE, argc, argv, FALSE);
     crm_set_options(NULL, "mode [options]", long_options,

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -76,6 +76,9 @@ check_stonith_action(const char *value)
 
     } else if (safe_str_eq(value, "poweroff")) {
         return TRUE;
+
+    } else if (safe_str_eq(value, "off")) {
+        return TRUE;
     }
     return FALSE;
 }
@@ -118,7 +121,7 @@ pe_cluster_option pe_opts[] = {
 	/* Stonith Options */
 	{ "stonith-enabled", "stonith_enabled", "boolean", NULL, "true", &check_boolean,
 	  "Failed nodes are STONITH'd", NULL },
-	{ "stonith-action", "stonith_action", "enum", "reboot, poweroff", "reboot", &check_stonith_action,
+	{ "stonith-action", "stonith_action", "enum", "reboot, poweroff, off", "reboot", &check_stonith_action,
 	  "Action to send to STONITH device", NULL },
 	{ "stonith-timeout", NULL, "time", NULL, "60s", &check_timer,
 	  "How long to wait for the STONITH action to complete", NULL },


### PR DESCRIPTION
The fencing agent api specifies that 'off' should be used
instead of 'poweroff' when defining new fencing devices.
The stonith-action option in the cib only accepts 'reboot' and
'poweroff'.  Since 'off' is the documented operation, this
patch adds 'off' as a valid stonith-action as well. The
'poweroff' operation is left as a valid value, but is documented
as existing only for legacy purposes now.  The default stonith-action
remains 'reboot'.
