### PR TITLE
High: ipc: Speed up ipc event reads

### DIFF
--- a/include/crm/common/ipc.h
+++ b/include/crm/common/ipc.h
@@ -36,6 +36,8 @@ xmlNode *create_request_adv(const char *task, xmlNode * xml_data, const char *ho
 
 #include <qb/qbipcs.h>
 
+#define CRM_IPC_DEFAULT_TIMEOUT_MS 100
+
 enum crm_ipc_server_flags
 {
     crm_ipc_server_none  = 0x0000,
@@ -69,6 +71,10 @@ int crm_ipc_send(crm_ipc_t *client, xmlNode *message, enum crm_ipc_flags flags, 
 int crm_ipc_get_fd(crm_ipc_t *client);
 bool crm_ipc_connected(crm_ipc_t *client);
 int crm_ipc_ready(crm_ipc_t *client);
+
+/* Specifiy custom timeout in ms */
+long crm_ipc_read_timeout(crm_ipc_t *client, int32_t ms_timeout);
+/* Uses default timeout period */
 long crm_ipc_read(crm_ipc_t *client);
 const char *crm_ipc_buffer(crm_ipc_t *client);
 const char *crm_ipc_name(crm_ipc_t *client);

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -445,8 +445,8 @@ crm_ipc_ready(crm_ipc_t *client)
     return poll(&(client->pfd), 1, 0);
 }
 
-long
-crm_ipc_read(crm_ipc_t *client) 
+static long
+internal_ipc_read(crm_ipc_t *client, uint32_t timeout)
 {
     CRM_ASSERT(client != NULL);
     CRM_ASSERT(client->ipc != NULL);
@@ -455,7 +455,7 @@ crm_ipc_read(crm_ipc_t *client)
     crm_trace("Message recieved on %s IPC connection", client->name);
 
     client->buffer[0] = 0;
-    client->msg_size = qb_ipcc_event_recv(client->ipc, client->buffer, client->buf_size-1, 100);
+    client->msg_size = qb_ipcc_event_recv(client->ipc, client->buffer, client->buf_size-1, timeout);
     if(client->msg_size >= 0) {
         struct qb_ipc_response_header *header = (struct qb_ipc_response_header *)client->buffer;
         client->buffer[client->msg_size] = 0;
@@ -468,6 +468,18 @@ crm_ipc_read(crm_ipc_t *client)
     }
     
     return client->msg_size;
+}
+
+long
+crm_ipc_read_timeout(crm_ipc_t *client, int32_t ms_timeout)
+{
+    return internal_ipc_read(client, ms_timeout);
+}
+
+long
+crm_ipc_read(crm_ipc_t *client)
+{
+    return internal_ipc_read(client, CRM_IPC_DEFAULT_TIMEOUT_MS);
 }
 
 const char *


### PR DESCRIPTION
Mainloop attempts to batch read up to 10 events every
time it detects that an event is ready. In almost every case,
the logic that is batch reading the events adds a 100ms delay
when detecting the last message has been read.  Now, once a
single successful message has been read, the batch read loop
no longer blocks on read for 100ms.
