### PR TITLE
Fix building with glibc-2.16

### DIFF
--- a/mcp/pacemaker.h
+++ b/mcp/pacemaker.h
@@ -21,6 +21,7 @@
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/resource.h>
 
 #include <stdint.h>
 


### PR DESCRIPTION
New version of glibc means fun with headers...
For a full build log with failure please see: http://tinyurl.com/d44jbz4
Downstream bug report: https://bugs.gentoo.org/show_bug.cgi?id=432012
