### PR TITLE
High: fencing: Always broadcast the origin node with fencing results.

### DIFF
--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -1216,8 +1216,10 @@ xmlNode *stonith_construct_async_reply(async_command_t *cmd, const char *output,
     crm_xml_add(reply, F_STONITH_CLIENTNAME, cmd->client_name);
     crm_xml_add(reply, F_STONITH_TARGET, cmd->victim);
     crm_xml_add(reply, F_STONITH_ACTION, cmd->op);
+    crm_xml_add(reply, F_STONITH_ORIGIN, cmd->origin);
     crm_xml_add_int(reply, F_STONITH_CALLID, cmd->id);
     crm_xml_add_int(reply, F_STONITH_CALLOPTS, cmd->options);
+
 
     crm_xml_add_int(reply, F_STONITH_RC, rc);
 

--- a/fencing/remote.c
+++ b/fencing/remote.c
@@ -284,7 +284,7 @@ void *create_remote_stonith_op(const char *client, xmlNode *request, gboolean pe
 
     op->state = st_query;
     op->action = crm_element_value_copy(dev, F_STONITH_ACTION);
-    op->originator = crm_element_value_copy(dev, F_STONITH_OWNER);
+    op->originator = crm_element_value_copy(dev, F_STONITH_ORIGIN);
 
     if(op->originator == NULL) {
         /* Local request */
@@ -346,7 +346,7 @@ remote_fencing_op_t *initiate_remote_stonith_op(stonith_client_t *client, xmlNod
     crm_xml_add(query, F_STONITH_REMOTE, op->id);
     crm_xml_add(query, F_STONITH_TARGET, op->target);
     crm_xml_add(query, F_STONITH_ACTION, op->action);
-    crm_xml_add(query, F_STONITH_OWNER,  op->originator);
+    crm_xml_add(query, F_STONITH_ORIGIN,  op->originator);
     crm_xml_add(query, F_STONITH_CLIENTID, op->client_id);
     crm_xml_add(query, F_STONITH_CLIENTNAME, op->client_name);
     crm_xml_add_int(query, F_STONITH_TIMEOUT, op->base_timeout);
@@ -541,7 +541,7 @@ void call_remote_stonith(remote_fencing_op_t *op, st_query_result_t *peer)
         crm_xml_add(query, F_STONITH_REMOTE, op->id);
         crm_xml_add(query, F_STONITH_TARGET, op->target);
         crm_xml_add(query, F_STONITH_ACTION, op->action);
-        crm_xml_add(query, F_STONITH_OWNER,  op->originator);
+        crm_xml_add(query, F_STONITH_ORIGIN,  op->originator);
         crm_xml_add(query, F_STONITH_CLIENTID, op->client_id);
         crm_xml_add(query, F_STONITH_CLIENTNAME, op->client_name);
         crm_xml_add_int(query, F_STONITH_TIMEOUT, timeout);

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -83,12 +83,15 @@ xmlNode *create_device_registration_xml(const char *id, const char *namespace, c
 #define F_STONITH_NOTIFY_ACTIVATE   "st_notify_activate"
 #define F_STONITH_NOTIFY_DEACTIVATE "st_notify_deactivate"
 #define F_STONITH_DELEGATE      "st_delegate"
+/*! The node initiating the stonith operation.  If an operation
+ * is relayed, this is the last node the operation lands on. When
+ * in standalone mode, origin is the client's id that originated the
+ * operation. */
 #define F_STONITH_ORIGIN        "st_origin"
 #define F_STONITH_HISTORY_LIST  "st_history"
 #define F_STONITH_DATE          "st_date"
 #define F_STONITH_STATE         "st_state"
 #define F_STONITH_LEVEL         "st_level"
-#define F_STONITH_OWNER         "st_owner"
 #define F_STONITH_ACTIVE        "st_active"
 
 #define F_STONITH_DEVICE        "st_device_id"


### PR DESCRIPTION
When a fencing operation completes, always broadcast the node that
initiated the fencing operation in the fencing result.  This eliminates
any possible confusion by the other nodes in the stonith cpg group as
to what node initiated the fencing operation once the results come in.
