### PR TITLE
High: legacy: Set to the minimum scheduling priority when using SCHED_RR policy (bnc#779259)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -595,6 +595,8 @@ AC_CHECK_LIB(rt, sched_getscheduler)            dnl -lrt (for Tru64)
 AC_CHECK_LIB(gnugetopt, getopt_long)		dnl -lgnugetopt ( if available )
 AC_CHECK_LIB(pam, pam_start)			dnl -lpam (if available)
 
+AC_CHECK_FUNCS([sched_getparam sched_setparam sched_get_priority_min])
+
 AC_CHECK_LIB(uuid, uuid_parse)			dnl load the library if necessary
 AC_CHECK_FUNCS(uuid_unparse)			dnl OSX ships uuid_* as standard functions
 


### PR DESCRIPTION
Corosync-1.4.x defaults to use SCHED_RR scheduling policy with the
maximum priority. In the plugin mode, the pacemaker's daemons inherit
this, and they have the higher priority than sbd. If there are a lot of
actions in the cluster, crmd and cib will hog the CPUs, and it's
possible that sbd will not be scheduled for quite some time, which will
cause the watchdog timer expires.

The patch sets to the minimum scheduling priority for pacemaker's daemons
when using SCHED_RR policy.
