### PR TITLE
Fix an incorrect crm_option struct in `crm_uuid` 

### DIFF
--- a/tools/crm_uuid.c
+++ b/tools/crm_uuid.c
@@ -52,8 +52,9 @@ int write_local_hb_uuid(const char *buffer);
 static struct crm_option long_options[] = {
     /* Top-level Options */
     {"help",    0, 0, '?', "\tThis text"},
-    {"version", 0, 0, '$', "\tRead the machine's Heartbeat UUID"  },
-    {"read",    0, 0, 'r', "\tChange the machine's Heartbeat UUID to a new value"  },
+    {"version", 0, 0, '$', "\t\tVersion information"  },
+    {"read",    0, 0, 'r', "\tRead the machine's Heartbeat UUID"  },
+    {"write",   1, 0, 'w', "\tChange the machine's Heartbeat UUID to a new value"  },
     
     {0, 0, 0, 0}
 };


### PR DESCRIPTION
Used this patch today to successfully modify the UUID of a replacement node.

Previous behavior:

```
# crm_uuid -?
crm_uuid - A tool for manipulating Heartbeat's UUID file
Usage: crm_uuid  [-r|-w new_ascii_value]
Options:
 -?, --help             This text
 -$, --version          Read the machine's Heartbeat UUID
 -r, --read             Change the machine's Heartbeat UUID to a new value

Report bugs to pacemaker at oss.clusterlabs.org

# crm_uuid -w 8c4082d4-7ea3-4b3f-8cad-75d2f9585d1e
crm_uuid: invalid option -- 'w'
```

Behavior of a `crm_uuid` binary built with this patch:

```
# ./crm_uuid -w 8c4082d4-7ea3-4b3f-8cad-75d2f9585d1e
$ ./crm_uuid -r
8c4082d4-7ea3-4b3f-8cad-75d2f9585d1e
```
