### PR TITLE
Low: Correction of a problem calling typedef two times.

### DIFF
--- a/include/crm/common/mainloop.h
+++ b/include/crm/common/mainloop.h
@@ -57,8 +57,6 @@ qb_ipcs_service_t *mainloop_add_ipc_server(
 
 void mainloop_del_ipc_server(qb_ipcs_service_t *server);
 
-typedef struct mainloop_io_s mainloop_io_t;
-
 mainloop_io_t *mainloop_add_ipc_client(
     const char *name, int priority, size_t max_size, void *userdata, struct ipc_client_callbacks *callbacks);
 


### PR DESCRIPTION
compile fails due to call double typedef.

gmake[2]: Entering directory `/root/cluster-packages/pacemaker/lib/common'
  CC     utils.lo
In file included from utils.c:54:
../../include/crm/common/mainloop.h:60: error: redefinition of typedef 'mainloop_io_t'
../../include/crm/common/ipcs.h:30: note: previous declaration of 'mainloop_io_t' was here
gmake[2]: **\* [utils.lo] Error 1
