### PR TITLE
Low: lrmd: Remote lrmd resource agent script

### DIFF
--- a/crmd/crmd_lrm.h
+++ b/crmd/crmd_lrm.h
@@ -146,7 +146,6 @@ int lrm_state_unregister_rsc(lrm_state_t *lrm_state,
 /*! These functions are used to manage the remote lrmd connection resources */
 void remote_lrm_op_callback(lrmd_event_data_t * op);
 gboolean is_remote_lrmd_ra(const char *agent, const char *provider, const char *id);
-int remote_ra_get_metadata(char **output);
 lrmd_rsc_info_t * remote_ra_get_rsc_info(lrm_state_t *lrm_state, const char *rsc_id);
 int remote_ra_cancel(lrm_state_t *lrm_state, const char *rsc_id, const char *action, int interval);
 int remote_ra_exec(lrm_state_t *lrm_state,

--- a/crmd/lrm_state.c
+++ b/crmd/lrm_state.c
@@ -275,9 +275,6 @@ int lrm_state_get_metadata (lrm_state_t *lrm_state,
     if (!lrm_state->conn) {
         return -ENOTCONN;
     }
-    if (is_remote_lrmd_ra(agent, provider, NULL)) {
-        return remote_ra_get_metadata(output);
-    }
 
     /* Optimize this... only retrieve metadata from local lrmd connection. Perhaps consider
      * caching result. */

--- a/crmd/remote_lrmd_ra.c
+++ b/crmd/remote_lrmd_ra.c
@@ -431,44 +431,6 @@ is_remote_lrmd_ra(const char *agent, const char *provider, const char *id)
     return FALSE;
 }
 
-int
-remote_ra_get_metadata(char **output)
-{
-#define remote_metadata  \
-"<?xml version=\"1.0\"?>\n"\
-"<!DOCTYPE resource-agent SYSTEM \"ra-api-1.dtd\">\n"\
-"<resource-agent name=\"remote\" version=\"0.1\">\n"\
-"  <version>1.0</version>\n"\
-"  <parameters>\n"\
-"    <parameter name=\"server\" unique=\"1\">\n"\
-"    <longdesc lang=\"en\">\n"\
-"       Server location to connect to.  This can be an ip address or hostname.\n"\
-"    </longdesc>\n"\
-"    <shortdesc lang=\"en\">Server location</shortdesc>\n"\
-"    <content type=\"string\"/>\n"\
-"    </parameter>\n"\
-"    <parameter name=\"port\" unique=\"1\">\n"\
-"    <longdesc lang=\"en\">\n"\
-"       tcp port to connect to.\n"\
-"    </longdesc>\n"\
-"    <shortdesc lang=\"en\">tcp port</shortdesc>\n"\
-"    <content type=\"string\" default=\"1984\"/>\n"\
-"    </parameter>\n"\
-"  </parameters>\n"\
-"  <actions>\n"\
-"    <action name=\"start\"   timeout=\"15\" />\n"\
-"    <action name=\"stop\"    timeout=\"15\" />\n"\
-"    <action name=\"monitor\"    timeout=\"15\" />\n"\
-"    <action name=\"migrate_to\"   timeout=\"15\" />\n"\
-"    <action name=\"migrate_from\" timeout=\"15\" />\n"\
-"    <action name=\"meta-data\"  timeout=\"5\" />\n"\
-"  </actions>\n"\
-"</resource-agent>\n"
-
-    *output = strdup(remote_metadata);
-    return 0;
-}
-
 lrmd_rsc_info_t *
 remote_ra_get_rsc_info(lrm_state_t *lrm_state, const char *rsc_id)
 {

--- a/extra/resources/Makefile.am
+++ b/extra/resources/Makefile.am
@@ -32,7 +32,8 @@ ocf_SCRIPTS	     =  ClusterMon 	\
 			pingd		\
 			Stateful	\
 			SysInfo		\
-			SystemHealth
+			SystemHealth \
+			remote
 
 if BUILD_XML_HELP
 man7_MANS = $(ocf_SCRIPTS:%=ocf_pacemaker_%.7)

--- a/extra/resources/remote
+++ b/extra/resources/remote
@@ -1,0 +1,110 @@
+#!/bin/sh
+#
+#
+#	remote OCF RA. This script provides metadata for the internal
+#	pacemaker remote lrmd connection agent.  Outside of acting
+#	as a place holder so the remote ra script can be indexed and
+#	providing metadata, this script should never be invoked.  The
+#	actual functionality behind the remote lrmd connection lives
+#	within pacemaker's crmd component.
+#
+# Copyright (c) 2013 David Vossel
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it would be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# Further, this software is distributed without any warranty that it is
+# free of the rightful claim of any third person regarding infringement
+# or the like.  Any license provided herein, whether implied or
+# otherwise, applies only to this software file.  Patent licenses, if
+# any, provided herein do not apply to combinations of this program with
+# other software, or any other product whatsoever.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write the Free Software Foundation,
+# Inc., 59 Temple Place - Suite 330, Boston MA 02111-1307, USA.
+#
+
+#######################################################################
+# Initialization:
+
+: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+. ${OCF_FUNCTIONS}
+: ${__OCF_ACTION=$1}
+
+#######################################################################
+
+meta_data() {
+	cat <<END
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="remote" version="0.1">
+  <version>0.1</version>
+  <parameters>
+    <parameter name="server" unique="1">
+    <longdesc lang="en">
+       Server location to connect to.  This can be an ip address or hostname.
+    </longdesc>
+    <shortdesc lang="en">Server location</shortdesc>
+    <content type="string"/>
+    </parameter>
+    <parameter name="port" unique="1">
+    <longdesc lang="en">
+       tcp port to connect to.
+    </longdesc>
+    <shortdesc lang="en">tcp port</shortdesc>
+    <content type="string" default="1984"/>
+    </parameter>
+  </parameters>
+  <actions>
+    <action name="start"   timeout="15" />
+    <action name="stop"    timeout="15" />
+    <action name="monitor"    timeout="15" />
+    <action name="migrate_to"   timeout="15" />
+    <action name="migrate_from" timeout="15" />
+    <action name="meta-data"  timeout="5" />
+  </actions>
+</resource-agent>
+END
+}
+
+#######################################################################
+
+remote_usage() {
+	cat <<END
+usage: $0 {meta-data}
+
+Expects to have a fully populated OCF RA-compliant environment set.
+END
+}
+
+remote_unsupported() {
+	ocf_log info "This pacemaker version does not support the ocf:pacemaker:remote agent"
+	return $OCF_ERR_GENERIC
+}
+
+case $__OCF_ACTION in
+meta-data)	meta_data
+		exit $OCF_SUCCESS
+		;;
+start)		remote_unsupported;;
+stop)		remote_unsupported;;
+monitor)	remote_unsupported;;
+migrate_to)	remote_unsupported;;
+migrate_from) remote_unsupported;;
+validate-all) remote_unsupported;;
+usage|help)	remote_usage
+		exit $OCF_SUCCESS
+		;;
+*)		dummy_usage
+		exit $OCF_ERR_UNIMPLEMENTED
+		;;
+esac
+rc=$?
+ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
+exit $rc


### PR DESCRIPTION
This script is a place holder used for indexing the remote resource agent.
It also provids metadata for the pacemaker internal lrmd resource agent.
