### PR TITLE
Low: mcp: set environment variables which the cluster-glue module needs.

### DIFF
--- a/mcp/pacemaker.c
+++ b/mcp/pacemaker.c
@@ -804,6 +804,10 @@ main(int argc, char **argv)
     qb_ipcs_service_t *ipcs = NULL;
     const char *facility = daemon_option("logfacility");
 
+    setenv("LC_ALL", "C", 1);
+    setenv("HA_LOGFACILITY", facility, 1);
+    setenv("HA_LOGD", "no", 1);
+
     set_daemon_option("mcp", "true");
     set_daemon_option("use_logd", "off");
 


### PR DESCRIPTION
The reason which needs each environment variable.
1. LC_ALL
   discussed here:
   http://www.gossamer-threads.com/lists/linuxha/pacemaker/84024
2. HA_LOGFACILITY
   discussed here:
   http://www.gossamer-threads.com/lists/linuxha/pacemaker/84026
3. HA_LOGD
   - pacemaker-1.1 : https://github.com/ClusterLabs/pacemaker/commit/1b7859d (the latest devel)
   - glue : 54ec848c43
   - RHEL6.3
   
   If plugin calls ha_log.sh, "logd is not running" will be outputted to a standard error output.
   That is, 'plugin gethosts' has the potential to output "logd is ..." in addition to value of _hostlist_ parameter.
   
   I added "ha_log.sh notice ..." to libvirt plugin on trial, and run it.
   
   ```
     $ diff -urN -U7 /usr/lib64/stonith/plugins/external/libvirt /tmp/libvirt
     --- /usr/lib64/stonith/plugins/external/libvirt 2012-12-17 09:56:37.000000000 +0900
     +++ /tmp/libvirt    2013-02-06 15:54:13.341415301 +0900
     @@ -208,14 +208,16 @@
      unset SSH_AUTH_SOCK
   
      # support , as a separator as well
      hostlist=`echo $hostlist| sed -e 's/,/ /g'`
   
      reset_method=${reset_method:-"power_cycle"}
   
     +ha_log.sh notice "TEST LOG"
     +
      case $1 in
          gethosts)
          hostnames=`echo $hostlist|sed -e 's/:[^ ]*//g'`
          for h in $hostnames
          do
              echo $h
          done
     $
   ```
   1. when I don't set environment variable HA_LOGD.
      
      ```
      $ ssh `hostname` 'export hostlist=HOST1; export PATH=/usr/share/cluster-glue:$PATH; /tmp/libvirt gethosts'
      logd is not runningHOST1
      ```
   2. when I set environment variable HA_LOGD=no.
      
      ```
      $ ssh `hostname` 'export hostlist=HOST1; export PATH=/usr/share/cluster-glue:$PATH; export HA_LOGD=no; /tmp/libvirt gethosts'
      HOST1
      ```
      
      http://www.gossamer-threads.com/lists/linuxha/pacemaker/79649
