### PR TITLE
Low: Fixed crm_report to work when using custom paths in autoconf.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1815,6 +1815,7 @@ extra/Makefile							\
 	extra/rgmanager/Makefile				\
 tools/Makefile							\
 	tools/crm_report					\
+	tools/report_common					\
 xml/Makefile							\
 lib/gnu/Makefile						\
 		)

--- a/tools/report.common.in
+++ b/tools/report.common.in
@@ -99,7 +99,7 @@ fatal() {
 detect_host() {
 
     depth="-maxdepth 5"
-    local_state_dir=/var
+    local_state_dir=@localstatedir@
 
     if [ -d $local_state_dir/run ]; then
 	CRM_STATE_DIR=$local_state_dir/run/crm
@@ -116,7 +116,7 @@ detect_host() {
     debug "Pacemaker runtime data located in: $CRM_STATE_DIR"
 
     CRM_DAEMON_DIR=
-    for p in /usr /usr/local /opt/local; do
+    for p in /usr /usr/local /opt/local @exec_prefix@; do
 	for d in libexec lib64 lib; do
 	    if [ -e $p/$d/pacemaker/pengine ]; then
 		CRM_DAEMON_DIR=$p/$d/pacemaker
@@ -710,6 +710,14 @@ find_cluster_cf() {
 		    fi
 		fi
 	    done
+	    if [ -z "$best_file" ]; then
+	    	debug "Looking for corosync configuration file. This may take a while..."
+		for f in `find / -type f -name corosync.conf`; do
+		    best_file=$f
+		    break
+		done
+		debug "Located corosync config file: $best_file"
+	    fi
 	    echo "$best_file"
 	    ;;
 	openais)


### PR DESCRIPTION
This fix uses the @localstatedir@ and @execdir@ paths as setup by autoconf.

Additionally it properly tries to find the corosync.conf file. I feel as though this change might be what will be debated. I chose against using $depth as the default "--maxdepth 5" doesn't suffice on my systems. Additionally my rationale was, if it's going to try to find something and warns that it might take a while, why stop at depth 5.
Perhaps the best option would be to allow for the depth to be passed as a parameter and use it consistently.
