### PR TITLE
Fix one issue uncovered during testing with the AIS plugin.

### DIFF
--- a/lib/cluster/legacy.c
+++ b/lib/cluster/legacy.c
@@ -1015,6 +1015,9 @@ init_cs_connection_classic(crm_cluster_t * cluster)
         crm_notice("If this node was part of the cluster with a different name,"
                    " you will need to remove the old entry with crm_node --remove");
     }
+    
+    cluster->nodeid = pcmk_nodeid;
+
     return TRUE;
 }
 


### PR DESCRIPTION
I found that clients signing up with AIS/pacemaker had crm_cluster.nodeid == 0, and thus couldn't identify themselves in the nodelist, which broke o2cb_controld.pcmk and others.

This patch addresses this issue.
