### PR TITLE
High: RA: controld - wait for dlm_controld to be ready in start phase

### DIFF
--- a/extra/resources/controld
+++ b/extra/resources/controld
@@ -129,8 +129,28 @@ controld_start() {
 
     ${OCF_RESKEY_daemon} $OCF_RESKEY_args
 
-    sleep 1
-    controld_monitor
+    while true
+    do
+        sleep 1
+
+        controld_monitor; rc=$?
+        case $rc in
+          $OCF_SUCCESS)
+            check_dir=/sys/kernel/config/dlm/cluster/comms
+            if grep 1 $check_dir/*/local >/dev/null 2>&1; then
+                return $OCF_SUCCESS
+            fi
+            ;;
+          $OCF_NOT_RUNNING) 
+            return $OCF_NOT_RUNNING
+            ;;
+          *) 
+            return $OCF_ERR_GENERIC
+            ;;
+        esac
+
+        ocf_log debug "Waiting for ${OCF_RESKEY_daemon} to be ready"
+    done
 }
 
 controld_stop() {


### PR DESCRIPTION
This patch fixes the race between dlm_controld and clvmd start sequence.

Currently the controld RA only checks if the dlm_controld process exists
and then returns the start operation is completed successfully. While the
starting of dlm_controld might not be completed at that moment, because
the daemon is there, but dlm_controld needs to do a lot of other initialization
like adding configfs node, which might not be finished yet. So if just at that
time, clvmd is started and talks to dlm to create lockspace, it will fail.

So this fix is to add another judegement in the start operation of controld RA,
which makes sure the needed initialization in dlm_controld has been done.
