### PR TITLE
Fix: crmd: Correctly relay messages for remote clients (bnc#805626, bnc#804704)

### DIFF
--- a/crmd/messages.c
+++ b/crmd/messages.c
@@ -466,6 +466,10 @@ relay_message(xmlNode * msg, gboolean originated_locally)
 #if SUPPORT_COROSYNC
         if (is_openais_cluster()) {
             dest = text2msg_type(sys_to);
+
+            if (dest == crm_msg_none || dest > crm_msg_stonith_ng) {
+                dest = crm_msg_crmd;
+            }
         }
 #endif
         ROUTER_RESULT("Message result: External relay");

--- a/lib/cluster/legacy.c
+++ b/lib/cluster/legacy.c
@@ -101,7 +101,7 @@ text2msg_type(const char *text)
          */
         int scan_rc = sscanf(text, "%d", &type);
 
-        if (scan_rc != 1) {
+        if (scan_rc != 1 || type <= crm_msg_stonith_ng) {
             /* Ensure its sane */
             type = crm_msg_none;
         }


### PR DESCRIPTION
For an invocation "crmadmin -D" from non-DC, when replying a CRM_OP_PING, in relay_message() , it revokes:
dest = text2msg_type(sys_to);

But in this case the "sys_to" is the client uuid of the remote crmadmin. It returns
random values due to the sscanf() in text2msg_type()

int scan_rc = sscanf(text, "%d", &type);

So that the message could be  either sent to nobody or to other daemons.

This fixes the issue.
