### PR TITLE
Feature: lrmd: Support CIB secrets - allow storing parameters in local files (lf#2415, cl#5121, bnc#792140)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -264,6 +264,13 @@ AC_ARG_WITH(acl,
     [ SUPPORT_ACL=no ],
 )
 
+AC_ARG_WITH(cibsecrets,
+    [  --with-cibsecrets
+       Support CIB secrets ],
+    [ SUPPORT_CIBSECRETS=$withval ],
+    [ SUPPORT_CIBSECRETS=no ],
+)
+
 CSPREFIX=""
 AC_ARG_WITH(ais-prefix,
     [  --with-ais-prefix=DIR  Prefix used when Corosync was installed [$prefix]],
@@ -1566,6 +1573,32 @@ AM_CONDITIONAL(ENABLE_ACL, test "$SUPPORT_ACL" = "1")
 AC_DEFINE_UNQUOTED(ENABLE_ACL, $SUPPORT_ACL, Build in support for CIB ACL)
 
 dnl ========================================================================
+dnl    CIB secrets 
+dnl ========================================================================
+
+case $SUPPORT_CIBSECRETS in
+     1|yes|true|try)
+        SUPPORT_CIBSECRETS=1;;
+     *) 
+        SUPPORT_CIBSECRETS=0;;
+esac
+
+AC_DEFINE_UNQUOTED(SUPPORT_CIBSECRETS, $SUPPORT_CIBSECRETS, Support CIB secrets)
+AM_CONDITIONAL(BUILD_CIBSECRETS, test $SUPPORT_CIBSECRETS = 1)
+
+if test $SUPPORT_CIBSECRETS = 1; then
+    PCMK_FEATURES="$PCMK_FEATURES cibsecrets"
+
+    LRM_CIBSECRETS_DIR="${localstatedir}/lib/pacemaker/lrm/secrets"
+    AC_DEFINE_UNQUOTED(LRM_CIBSECRETS_DIR,"$LRM_CIBSECRETS_DIR", Location for CIB secrets)
+    AC_SUBST(LRM_CIBSECRETS_DIR)
+
+    LRM_LEGACY_CIBSECRETS_DIR="${localstatedir}/lib/heartbeat/lrm/secrets"
+    AC_DEFINE_UNQUOTED(LRM_LEGACY_CIBSECRETS_DIR,"$LRM_LEGACY_CIBSECRETS_DIR", Legacy location for CIB secrets)
+    AC_SUBST(LRM_LEGACY_CIBSECRETS_DIR)
+fi
+
+dnl ========================================================================
 dnl    GnuTLS
 dnl ========================================================================
 
@@ -1816,6 +1849,7 @@ extra/Makefile							\
 	extra/rgmanager/Makefile				\
 tools/Makefile							\
 	tools/crm_report					\
+	tools/cibsecret                                         \
 xml/Makefile							\
 lib/gnu/Makefile						\
 		)

--- a/include/crm/common/Makefile.am
+++ b/include/crm/common/Makefile.am
@@ -22,3 +22,6 @@ headerdir=$(pkgincludedir)/crm/common
 
 header_HEADERS = xml.h ipc.h util.h iso8601.h mainloop.h logging.h
 noinst_HEADERS = ipcs.h
+if BUILD_CIBSECRETS
+noinst_HEADERS += cib_secrets.h
+endif

--- a/include/crm/common/cib_secrets.h
+++ b/include/crm/common/cib_secrets.h
@@ -1,0 +1,25 @@
+/*
+ * cib_secrets.h
+ *
+ * Author: Dejan Muhamedagic <dejan@suse.de>
+ * Copyright (c) 2011 SUSE, Attachmate
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+/*
+ * load parameters from an ini file (cib_secrets.c)
+ */
+int replace_secret_params(char * rsc_id, GHashTable * params);

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -33,6 +33,9 @@ lib_LTLIBRARIES	= libcrmcommon.la
 CFLAGS		= $(CFLAGS_COPY:-Wcast-qual=) -fPIC
 
 libcrmcommon_la_SOURCES	= ipc.c utils.c xml.c iso8601.c remote.c mainloop.c logging.c
+if BUILD_CIBSECRETS
+libcrmcommon_la_SOURCES	+= cib_secrets.c
+endif
 
 libcrmcommon_la_LDFLAGS	= -version-info 4:0:1
 libcrmcommon_la_LIBADD  = -ldl $(GNUTLSLIBS)

--- a/lib/common/cib_secrets.c
+++ b/lib/common/cib_secrets.c
@@ -1,0 +1,222 @@
+/*
+ * cib_secrets.c
+ *
+ * Author: Dejan Muhamedagic <dejan@suse.de>
+ * Copyright (c) 2011 SUSE, Attachmate
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <crm_internal.h>
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#include <glib.h>
+
+#include <crm/common/util.h>
+#include <crm/common/cib_secrets.h>
+
+static int do_replace_secret_params(char *rsc_id, GHashTable *params, gboolean from_legacy_dir);
+static int is_magic_value(char *p);
+static int check_md5_hash(char *hash, char *value);
+static void add_secret_params(gpointer key, gpointer value, gpointer user_data);
+static char *read_local_file(char *local_file);
+
+#define MAX_VALUE_LEN 255
+#define MAGIC "lrm://"
+
+static int
+is_magic_value(char *p)
+{
+    return !strcmp(p, MAGIC);
+}
+
+static int
+check_md5_hash(char *hash, char *value)
+{
+    int rc = FALSE;
+    char *hash2 = NULL;
+
+    hash2 = crm_md5sum(value);
+    crm_debug("hash: %s, calculated hash: %s", hash, hash2);
+    if (safe_str_eq(hash, hash2)) {
+        rc = TRUE;
+    }
+
+    free(hash2);
+    return rc;
+}
+
+static char *
+read_local_file(char *local_file)
+{
+    FILE *fp = fopen(local_file, "r");
+    char buf[MAX_VALUE_LEN+1];
+    char *p;
+
+    if (!fp) {
+        if (errno != ENOENT) {
+            crm_perror(LOG_ERR, "cannot open %s" , local_file);
+        }
+        return NULL;
+    }
+
+    if (!fgets(buf, MAX_VALUE_LEN, fp)) {
+        crm_perror(LOG_ERR, "cannot read %s", local_file);
+        return NULL;
+    }
+
+    /* strip white space */
+    for (p = buf+strlen(buf)-1; p >= buf && isspace(*p); p--)
+		;
+    *(p+1) = '\0';
+    return g_strdup(buf);
+}
+
+/*
+ * returns 0 on success or no replacements necessary
+ * returns -1 if replacement failed for whatever reasone
+ */
+
+int
+replace_secret_params(char *rsc_id, GHashTable *params)
+{
+    if (do_replace_secret_params(rsc_id, params, FALSE) < 0
+        && do_replace_secret_params(rsc_id, params, TRUE) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int
+do_replace_secret_params(char *rsc_id, GHashTable *params, gboolean from_legacy_dir)
+{
+    char local_file[FILENAME_MAX+1], *start_pname;
+    char hash_file[FILENAME_MAX+1], *hash;
+    GList *secret_params = NULL, *l;
+    char *key, *pvalue, *secret_value;
+    int rc = 0;
+    const char *dir_prefix = NULL;
+
+    if (params == NULL) {
+        return 0;
+    }
+
+    if (from_legacy_dir) {
+        dir_prefix = LRM_LEGACY_CIBSECRETS_DIR;
+
+    } else {
+        dir_prefix = LRM_CIBSECRETS_DIR;
+    }
+
+    /* secret_params could be cached with the resource;
+     * there are also parameters sent with operations
+     * which cannot be cached
+     */
+    g_hash_table_foreach(params, add_secret_params, &secret_params);
+    if (!secret_params) { /* none found? */
+        return 0;
+    }
+
+    crm_debug("replace secret parameters for resource %s", rsc_id);
+
+    if (snprintf(local_file, FILENAME_MAX,
+        "%s/%s/", dir_prefix, rsc_id) > FILENAME_MAX) {
+        crm_err("filename size exceeded for resource %s", rsc_id);
+	return -1;
+    }
+    start_pname = local_file + strlen(local_file);
+
+    for (l = g_list_first(secret_params); l; l = g_list_next(l)) {
+        key = (char *)(l->data);
+        pvalue = g_hash_table_lookup(params, key);
+        if (!pvalue) { /* this cannot really happen */
+            crm_err("odd, no parameter %s for rsc %s found now", key, rsc_id);
+            continue;
+        }
+
+        if ((strlen(key) + strlen(local_file)) >= FILENAME_MAX-2) {
+            crm_err("%d: parameter name %s too big", key);
+            rc = -1;
+            continue;
+        }
+
+        strcpy(start_pname, key);
+        secret_value = read_local_file(local_file);
+        if (!secret_value) {
+            if (from_legacy_dir == FALSE) {
+                crm_debug("secret for rsc %s parameter %s not found in %s. "
+                          "will try "LRM_LEGACY_CIBSECRETS_DIR, rsc_id, key, dir_prefix);
+
+            } else {
+                crm_err("secret for rsc %s parameter %s not found in %s",
+                        rsc_id, key, dir_prefix);
+            }
+            rc = -1;
+            continue;
+        }
+
+        strcpy(hash_file, local_file);
+        if (strlen(hash_file) + 5 > FILENAME_MAX) {
+            crm_err("cannot build such a long name "
+                    "for the sign file: %s.sign", hash_file);
+            g_free(secret_value);
+            rc = -1;
+            continue;
+
+        } else {
+            strncat(hash_file, ".sign", 5);
+            hash = read_local_file(hash_file);
+            if (hash == NULL) {
+                crm_err("md5 sum for rsc %s parameter %s "
+                        "cannot be read from %s", rsc_id, key, hash_file);
+                g_free(secret_value);
+                rc = -1;
+                continue;
+
+            } else if (!check_md5_hash(hash, secret_value)) {
+                crm_err("md5 sum for rsc %s parameter %s "
+                        "does not match", rsc_id, key);
+                g_free(secret_value);
+                g_free(hash);
+                rc = -1;
+                continue;
+            }
+            g_free(hash);
+        }
+        g_hash_table_replace(params, g_strdup(key), secret_value);
+    }
+    g_list_free(secret_params);
+    return rc;
+}
+
+static void
+add_secret_params(gpointer key, gpointer value, gpointer user_data)
+{
+    GList **lp = (GList **)user_data;
+
+    if (is_magic_value((char *)value)) {
+	*lp = g_list_append(*lp, (char *)key);
+    }
+}

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -32,6 +32,9 @@ pcmkdir			= $(datadir)/$(PACKAGE)
 pcmk_DATA		= report.common report.collector
 
 sbin_SCRIPTS		= crm_report crm_standby crm_master crm_failcount
+if BUILD_CIBSECRETS
+sbin_SCRIPTS		+= cibsecret
+endif
 EXTRA_DIST		= $(sbin_SCRIPTS)
 
 halibdir		= $(CRM_DAEMON_DIR)

--- a/tools/cibsecret.in
+++ b/tools/cibsecret.in
@@ -1,0 +1,380 @@
+#!/bin/sh
+
+# Copyright (C) 2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# 
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+# WARNING:
+#
+# The CIB secrets interface and implementation is still being
+# discussed, it may change
+
+#
+# cibsecret: manage the secrets directory /var/lib/heartbeat/lrm/secrets
+#
+# secrets are ascii files, holding just one value per file:
+# /var/lib/heartbeat/lrm/secrets/<rsc>/<param>
+#
+# NB: this program depends on utillib.sh
+#
+
+. @OCF_ROOT_DIR@/lib/heartbeat/ocf-shellfuncs
+
+LRM_CIBSECRETS=@LRM_CIBSECRETS_DIR@
+LRM_LEGACY_CIBSECRETS=@LRM_LEGACY_CIBSECRETS_DIR@
+
+PROG=`basename $0`
+SSH_OPTS="-o StrictHostKeyChecking=no"
+
+usage() {
+	echo "cibsecret - A tool for managing cib secrets";
+	echo "";
+	echo "usage: $PROG [-C] <command> <parameters>";
+	echo "";
+	echo "-C: don't read/write the CIB"
+	echo ""
+	echo "command: set | delete | stash | unstash | get | check | sync"
+	echo ""
+	echo "	set <rsc> <param> <value>"
+	echo ""
+	echo "	get <rsc> <param>"
+	echo ""
+	echo "	check <rsc> <param>"
+	echo ""
+	echo "	stash <rsc> <param> (if not -C)"
+	echo ""
+	echo "	unstash <rsc> <param> (if not -C)"
+	echo ""
+	echo "	delete <rsc> <param>"
+	echo ""
+	echo "	sync"
+	echo ""
+	echo "stash/unstash: move the parameter from/to the CIB (if you already"
+	echo "have the parameter set in the CIB)."
+	echo ""
+	echo "set/delete: add/remove a parameter from the local file."
+	echo ""
+	echo "get: display the parameter from the local file."
+	echo ""
+	echo "check: verify MD5 hash of the parameter from the local file and the CIB."
+	echo ""
+	echo "sync: copy $LRM_CIBSECRETS to other nodes."
+	echo ""
+	echo "Examples:"
+	echo ""
+	echo "	$PROG set ipmi_node1 passwd SecreT_PASS"
+	echo ""
+	echo "	$PROG stash ipmi_node1 passwd"
+	echo ""
+	echo "	$PROG get ipmi_node1 passwd"
+	echo ""
+	echo "	$PROG check ipmi_node1 passwd"
+	echo ""
+	echo "	$PROG sync"
+
+	exit $1
+}
+fatal() {
+	echo "ERROR: $*"
+	exit 1
+}
+warn() {
+	echo "WARNING: $*"
+}
+info() {
+	echo "INFO: $*"
+}
+
+check_env() {
+	which md5sum >/dev/null 2>&1 ||
+		fatal "please install md5sum to run $PROG"
+	if which pssh >/dev/null 2>&1; then
+		rsh=pssh_fun
+		rcp=pscp_fun
+	elif which pdsh >/dev/null 2>&1; then
+		rsh=pdsh_fun
+		rcp=pdcp_fun
+	elif which ssh >/dev/null 2>&1; then
+		rsh=ssh_fun
+		rcp=scp_fun
+	else
+		fatal "please install pssh, pdsh, or ssh to run $PROG"
+	fi
+	ps -ef | grep '[c]rmd' >/dev/null ||
+		fatal "pacemaker not running? $PROG needs pacemaker"
+}
+
+get_other_nodes() {
+	crm_node -l | awk '{print $2}' | grep -v `uname -n`
+}
+
+get_live_nodes() {
+	if [ `id -u` = 0 ] && which fping >/dev/null 2>&1; then
+		fping -a $@ 2>/dev/null
+	else
+		local h
+		for h; do ping -c 2 -q $h >/dev/null 2>&1 && echo $h; done
+	fi
+}
+
+check_down_nodes() {
+	local n down_nodes
+	down_nodes=`(for n; do echo $n; done) | sort | uniq -u`
+	if [ -n "$down_nodes" ]; then
+		if [ `echo $down_nodes | wc -w` = 1 ]; then
+			warn "node $down_nodes is down"
+			warn "you'll need to update it using $PROG sync later"
+		else
+			warn "nodes `echo $down_nodes` are down"
+			warn "you'll need to update them using $PROG sync later"
+		fi
+	fi
+}
+
+pssh_fun() {
+	pssh -qi -H "$nodes" -x "$SSH_OPTS" $*
+}
+pscp_fun() {
+	pscp -q -H "$nodes" -x "-pr" -x "$SSH_OPTS" $*
+}
+pdsh_fun() {
+	local pdsh_nodes=`echo $nodes | tr ' ' ','`
+	export PDSH_SSH_ARGS_APPEND="$SSH_OPTS"
+	pdsh -w $pdsh_nodes $*
+}
+pdcp_fun() {
+	local pdsh_nodes=`echo $nodes | tr ' ' ','`
+	export PDSH_SSH_ARGS_APPEND="$SSH_OPTS"
+	pdcp -pr -w $pdsh_nodes $*
+}
+ssh_fun() {
+	local h
+	for h in $nodes; do
+		ssh $SSH_OPTS $h $* || return
+	done
+}
+scp_fun() {
+	local h src="$1" dest=$2
+	for h in $nodes; do
+		scp -pr -q $SSH_OPTS $src $h:$dest || return
+	done
+}
+# TODO: this procedure should be replaced with csync2
+# provided that csync2 has already been configured
+sync_files() {
+	local crm_nodes=`get_other_nodes`
+	local nodes=`get_live_nodes $crm_nodes`
+	check_down_nodes $nodes $crm_nodes
+	[ "$nodes" = "" ] && {
+		info "no other nodes live"
+		return
+	}
+	info "syncing $LRM_CIBSECRETS to `echo $nodes` ..."
+	$rsh rm -rf $LRM_CIBSECRETS &&
+		$rsh mkdir -p `dirname $LRM_CIBSECRETS` &&
+		$rcp $LRM_CIBSECRETS `dirname $LRM_CIBSECRETS`
+}
+sync_one() {
+	local f=$1 f_all="$1 $1.sign"
+	local crm_nodes=`get_other_nodes`
+	local nodes=`get_live_nodes $crm_nodes`
+	check_down_nodes $nodes $crm_nodes
+	[ "$nodes" = "" ] && {
+		info "no other nodes live"
+		return
+	}
+	info "syncing $f to `echo $nodes` ..."
+	$rsh mkdir -p `dirname $f` &&
+		if [ -f "$f" ]; then
+			$rcp "$f_all" `dirname $f`
+		else
+			$rsh rm -f $f_all
+		fi
+}
+
+is_secret() {
+	# assume that the secret is in the CIB if we cannot talk to
+	# cib
+	[ "$NO_CRM" ] ||
+	test "$1" = "$MAGIC"
+}
+check_cib_rsc() {
+	local rsc=$1 output
+	output=`$NO_CRM crm_resource -r $rsc -W >/dev/null 2>&1` ||
+		fatal "resource $rsc doesn't exist: $output"
+}
+get_cib_param() {
+	local rsc=$1 param=$2
+	check_cib_rsc $rsc
+	$NO_CRM crm_resource -r $rsc -g $param 2>/dev/null
+}
+set_cib_param() {
+	local rsc=$1 param=$2 value=$3
+	check_cib_rsc $rsc
+	$NO_CRM crm_resource -r $rsc -p $param -v "$value" 2>/dev/null
+}
+remove_cib_param() {
+	local rsc=$1 param=$2
+	check_cib_rsc $rsc
+	$NO_CRM crm_resource -r $rsc -d $param 2>/dev/null
+}
+
+localfiles() {
+	local cmd=$1
+	local rsc=$2 param=$3 value=$4
+	local local_file=$LRM_CIBSECRETS/$rsc/$param
+	local local_legacy_file=$LRM_LEGACY_CIBSECRETS/$rsc/$param
+	case $cmd in
+	"get")
+		cat $local_file 2>/dev/null ||
+		cat $local_legacy_file 2>/dev/null
+		true
+		;;
+	"getsum")
+		cat $local_file.sign 2>/dev/null ||
+		cat $local_legacy_file.sign 2>/dev/null
+		true
+		;;
+	"set")
+		local md5sum
+		md5sum=`printf $value | md5sum` ||
+			fatal "md5sum failed to produce hash for resource $rsc parameter $param"
+		md5sum=`echo $md5sum | awk '{print $1}'`
+		mkdir -p `dirname $local_file` &&
+			echo $value > $local_file &&
+			echo $md5sum > $local_file.sign && (
+			sync_one $local_file
+			rm -f $local_legacy_file
+			rm -f $local_legacy_file.sign
+			sync_one $local_legacy_file)
+		;;
+	"remove")
+		rm -f $local_legacy_file
+		rm -f $local_legacy_file.sign
+		sync_one $local_legacy_file
+
+		rm -f $local_file
+		rm -f $local_file.sign
+		sync_one $local_file
+	;;
+	*)
+		# not reached, this is local interface
+	;;
+	esac
+}
+get_local_param() {
+	local rsc=$1 param=$2
+	localfiles get $rsc $param
+}
+set_local_param() {
+	local rsc=$1 param=$2 value=$3
+	localfiles set $rsc $param $value
+}
+remove_local_param() {
+	local rsc=$1 param=$2
+	localfiles remove $rsc $param
+}
+
+cibsecret_set() {
+	local value=$1
+
+	if [ -z "$NO_CRM" ]; then
+		[ "$current" -a "$current" != "$MAGIC" -a "$current" != "$value" ] &&
+			fatal "CIB value <$current> different for $rsc parameter $param; please delete it first"
+	fi
+	set_local_param $rsc $param $value &&
+	set_cib_param $rsc $param "$MAGIC"
+}
+
+cibsecret_check() {
+	local md5sum local_md5sum
+	is_secret "$current" ||
+		fatal "resource $rsc parameter $param not set as secret, nothing to check"
+	local_md5sum=`localfiles getsum $rsc $param`
+	[ "$local_md5sum" ] ||
+		fatal "no MD5 hash for resource $rsc parameter $param"
+	md5sum=`printf "$current_local" | md5sum | awk '{print $1}'`
+	[ "$md5sum" = "$local_md5sum" ] ||
+		fatal "MD5 hash mismatch for resource $rsc parameter $param"
+}
+
+cibsecret_get() {
+	cibsecret_check
+	echo "$current_local"
+}
+
+cibsecret_delete() {
+	remove_local_param $rsc $param &&
+	remove_cib_param $rsc $param
+}
+
+cibsecret_stash() {
+	[ "$NO_CRM" ] &&
+		fatal "no access to Pacemaker, stash not supported"
+	[ "$current" = "" ] &&
+		fatal "nothing to stash for resource $rsc parameter $param"
+	is_secret "$current" &&
+		fatal "resource $rsc parameter $param already set as secret, nothing to stash"
+	cibsecret_set "$current"
+}
+
+cibsecret_unstash() {
+	[ "$NO_CRM" ] &&
+		fatal "no access to Pacemaker, unstash not supported"
+	[ "$current_local" = "" ] &&
+		fatal "nothing to unstash for resource $rsc parameter $param"
+	is_secret "$current" ||
+		warn "resource $rsc parameter $param not set as secret, but we have local value so proceeding anyway"
+	remove_local_param $rsc $param &&
+	set_cib_param $rsc $param $current_local
+}
+
+cibsecret_sync() {
+	sync_files
+}
+
+check_env
+
+MAGIC="lrm://"
+umask 0077
+
+if [ "$1" = "-C" ]; then
+	NO_CRM=':'
+	shift 1
+fi
+
+cmd=$1
+rsc=$2
+param=$3
+value=$4
+
+case "$cmd" in
+	set) [ $# -ne 4 ] && usage 1;;
+	get) [ $# -ne 3 ] && usage 1;;
+	check) [ $# -ne 3 ] && usage 1;;
+	stash) [ $# -ne 3 ] && usage 1;;
+	unstash) [ $# -ne 3 ] && usage 1;;
+	delete) [ $# -ne 3 ] && usage 1;;
+	sync) [ $# -ne 1 ] && usage 1;;
+	--help) usage 0;;
+	*) usage 1;
+esac
+
+# we'll need these two often
+current=`get_cib_param $rsc $param`
+current_local=`get_local_param $rsc $param`
+
+cibsecret_$cmd $value


### PR DESCRIPTION
Sensitive information contained in the CIB can be moved to local files.
The CIB values are replaced by a magic string "lrm://" to signal lrmd
that it should lookup the content elsewhere.

An MD5 hash is stored in local file, by appending ".sign" extension.
lrmd checks if the hash matches the value in local files. If there is a
mismatch, the operation fails. stop operations are exceptions and they
proceed regardless (for stonith resources stop happens in stonithd and
for and for other resource it is very probable that passwords don't
influence stop).

Local files are stored in:
/var/lib/pacemaker/lrm/secrets/<rsc>/<param>

Reading from the legacy location is still possible for compatibility:
/var/lib/heartbeat/lrm/secrets/<rsc>/<param>

and files contain just a value, there's not format. The values may not
span multiple lines and whitespace at the right is stripped.

cibsecret is a program which handles user interface. It is not necessary
to use any other tools to manage the local files storage. Users don't
need to know about how and where the files are stored.
