### PR TITLE
Low: crm_report: use paths configured in autoconf.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1816,6 +1816,7 @@ extra/Makefile							\
 	extra/rgmanager/Makefile				\
 tools/Makefile							\
 	tools/crm_report					\
+        tools/report.common                                     \
 xml/Makefile							\
 lib/gnu/Makefile						\
 		)

--- a/tools/report.common.in
+++ b/tools/report.common.in
@@ -99,7 +99,7 @@ fatal() {
 detect_host() {
 
     depth="-maxdepth 5"
-    local_state_dir=/var
+    local_state_dir=@localstatedir@
 
     if [ -d $local_state_dir/run ]; then
 	CRM_STATE_DIR=$local_state_dir/run/crm
@@ -116,7 +116,7 @@ detect_host() {
     debug "Pacemaker runtime data located in: $CRM_STATE_DIR"
 
     CRM_DAEMON_DIR=
-    for p in /usr /usr/local /opt/local; do
+    for p in /usr /usr/local /opt/local @exec_prefix@; do
 	for d in libexec lib64 lib; do
 	    if [ -e $p/$d/pacemaker/pengine ]; then
 		CRM_DAEMON_DIR=$p/$d/pacemaker


### PR DESCRIPTION
This commit enables crm_report to use the paths configured in autoconf.
