### PR TITLE
Low: crm_report: search for corosync config if not found.

### DIFF
--- a/tools/report.common
+++ b/tools/report.common
@@ -710,6 +710,14 @@ find_cluster_cf() {
 		    fi
 		fi
 	    done
+	    if [ -z "$best_file" ]; then
+		debug "Looking for corosync configuration file. This may take a while..."
+		for f in `find / $depth -type f -name corosync.conf`; do
+		    best_file=$f
+		    break
+		done
+	    fi
+	    debug "Located corosync config file: $best_file"
 	    echo "$best_file"
 	    ;;
 	openais)


### PR DESCRIPTION
This commit uses the find command to search the entire directory structure for the corosync configuration it.
