### PR TITLE
Low: Core: Support PCMK_logpriority to set syslog priority

### DIFF
--- a/mcp/pacemaker.sysconfig
+++ b/mcp/pacemaker.sysconfig
@@ -17,6 +17,10 @@
 # The default value is 'daemon'
 # PCMK_logfacility=none|daemon|user|local0|local1|local2|local3|local4|local5|local6|local7
 
+# Specify syslog priority
+# The default value is 'notice'
+# PCMK_logpriority=emerg|alert|crit|error|warning|notice|info
+
 # Log all messages from a comma-separated list of functions
 # PCMK_trace_functions=function1,function2,function3
 


### PR DESCRIPTION
This request makes it possible to specify a syslog priority.

I am monitoring some INFO messages during production run in pacemaker-1.0. Therefore, I need those INFO messages similarly in 1.1.

The INFO messages are outputted only to _application log_ [1] in 1.1, so I checked the implementation of application log.
- [1] /etc/sysconfig/pacemaker
  
  ```
  export PCMK_debugfile=/var/log/ha-log
  ```

I figured out that 'copytruncate' is required in order to rotate the log using logrotate.
- eg. /etc/logrotate.d/ha
  
  ```
  /var/log/ha-log {
  missingok
  copytruncate
  }
  ```

Ummm... I can't use copytruncate because some logging data are lost.
Since I use syslog if the INFO messages are outputted, I wrote this patch.
