### PR TITLE
Low: Core: When a definition does not exist, it corrects so that facilit...

### DIFF
--- a/mcp/corosync.c
+++ b/mcp/corosync.c
@@ -624,6 +624,7 @@ read_config(void)
     }
 
     set_daemon_option("logfacility", logging_syslog_facility);
+    setenv("HA_LOGFACILITY", logging_syslog_facility, 1);
 
     free(logging_debug);
     free(logging_logfile);

--- a/mcp/pacemaker.c
+++ b/mcp/pacemaker.c
@@ -809,7 +809,6 @@ main(int argc, char **argv)
     const char *facility = daemon_option("logfacility");
 
     setenv("LC_ALL", "C", 1);
-    setenv("HA_LOGFACILITY", facility, 1);
     setenv("HA_LOGD", "no", 1);
 
     set_daemon_option("mcp", "true");


### PR DESCRIPTION
...y of corosync may be used.

In the present position, since there was a case where HA_LOGFACILITY became empty, it corrected to the position containing a default value.
