### PR TITLE
Fix: It corrected so that the reading pipe which is not closed might be ...

### DIFF
--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -452,6 +452,9 @@ services_os_action_execute(svc_action_t * op, gboolean synchronous)
         read_output(op->opaque->stdout_fd, op);
         read_output(op->opaque->stderr_fd, op);
 
+        close(op->opaque->stdout_fd);
+        close(op->opaque->stderr_fd);
+
     } else {
         crm_trace("Async waiting for %d - %s", op->pid, op->opaque->exec);
         mainloop_add_child(op->pid, op->timeout, op->id, op, operation_finished);


### PR DESCRIPTION
...closed.

When I repeated the start stop of the resource, the number of opening pipes of crmd increases.
It seems that this occurs when crmd tends to acquire metadata of a resource.
Since I seemed not to close the pipe of this reading, after I finished using, I closed.
Remains of a pipe are prevented by this correction.
