### PR TITLE
Fix:Signal FD leak

### DIFF
--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -540,6 +540,7 @@ services_os_action_execute(svc_action_t * op, gboolean synchronous)
 
         close(op->opaque->stdout_fd);
         close(op->opaque->stderr_fd);
+        close(sfd);
 
         if (sigismember(&old_mask, SIGCHLD) == 0) {
             if (sigprocmask(SIG_UNBLOCK, &mask, NULL) < 0) {


### PR DESCRIPTION
I found Signal fd leak.
crmd make fd when RA is start. but, this fd is not release.

Signed-off-by: Yuichi SEINO seino.cluster2@gmail.com
