### PR TITLE
Fix: cib: Strip text nodes on writing CIB to disk

### DIFF
--- a/cib/io.c
+++ b/cib/io.c
@@ -681,6 +681,8 @@ write_cib_contents(gpointer p)
         }
     }
 
+    strip_text_nodes(cib_local);
+
     tmp_cib = g_strdup_printf("%s/cib.XXXXXX", cib_root);
     tmp_digest = g_strdup_printf("%s/cib.XXXXXX", cib_root);
 


### PR DESCRIPTION
The problem happens if there are any text nodes in the CIB XML.

In write_cib_contents(), after writing the CIB and the digest to disk,
it'll instantly re-check them via retrieveCib(). While the text nodes
will be stripped when reading from the on disk XML file, which will
result in a mis-matched digest. So the write fails, and cib disk write
will be disabled.

This commit strips text nodes on writing CIB to disk to ensure the
consistency.

I notice  strip_text_nodes() is always invoked in cib_perform_op() now. The problem was produced with a revision before that. While a double insurance would not be bad I guess. Anyway, I'd need to back-port this for the version that the customer is using. 
