### PR TITLE
Build: exclude rc version from LAST_RELEASE and NEXT_RELEASE

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,8 +48,8 @@ TAG     ?= $(shell git log --pretty="format:%h" -n 1)
 WITH    ?= --without=doc
 #WITH    ?= --without=doc --with=gcov
 
-LAST_RELEASE	?= $(shell test -e /Volumes || git tag -l | grep Pacemaker | sort -Vr | head -n 1)
-NEXT_RELEASE	?= $(shell test -e /Volumes || git tag -l | grep Pacemaker | sort -Vr | head -n 1 | awk -F. '/[0-9]+\./{$$3+=1;OFS=".";print $$1,$$2,$$3}')
+LAST_RELEASE	?= $(shell test -e /Volumes || git tag -l | grep Pacemaker | grep -v rc | sort -Vr | head -n 1)
+NEXT_RELEASE	?= $(shell test -e /Volumes || git tag -l | grep Pacemaker | grep -v rc | sort -Vr | head -n 1 | awk -F. '/[0-9]+\./{$$3+=1;OFS=".";print $$1,$$2,$$3}')
 
 BUILD_COUNTER	?= build.counter
 LAST_COUNT      = $(shell test ! -e $(BUILD_COUNTER) && echo 0; test -e $(BUILD_COUNTER) && cat $(BUILD_COUNTER))


### PR DESCRIPTION
I made rpm files.
But their version was 1.0.11 in spite of 1.0.10.
