### PR TITLE
Low: crmd: Block after 10 failed fencing regardless of crmd-transition-delay

### DIFF
--- a/crmd/te_actions.c
+++ b/crmd/te_actions.c
@@ -506,11 +506,13 @@ notify_crmd(crm_graph_t * graph)
         case tg_restart:
             type = "restart";
             if (fsa_state == S_TRANSITION_ENGINE) {
-                if (transition_timer->period_ms > 0) {
-                    crm_timer_stop(transition_timer);
-                    crm_timer_start(transition_timer);
-                } else if (too_many_st_failures() == FALSE) {
-                    event = I_PE_CALC;
+                if (too_many_st_failures() == FALSE) {
+                    if (transition_timer->period_ms > 0) {
+                        crm_timer_stop(transition_timer);
+                        crm_timer_start(transition_timer);
+                    } else {
+                        event = I_PE_CALC;
+                    }
                 } else {
                     event = I_TE_SUCCESS;
                 }

--- a/crmd/te_utils.c
+++ b/crmd/te_utils.c
@@ -396,11 +396,13 @@ abort_transition_graph(int abort_priority, enum transition_action abort_action,
     fsa_pe_ref = NULL;
 
     if (transition_graph->complete) {
-        if (transition_timer->period_ms > 0) {
-            crm_timer_stop(transition_timer);
-            crm_timer_start(transition_timer);
-        } else if (too_many_st_failures() == FALSE) {
-            register_fsa_input(C_FSA_INTERNAL, I_PE_CALC, NULL);
+        if (too_many_st_failures() == FALSE) {
+            if (transition_timer->period_ms > 0) {
+                crm_timer_stop(transition_timer);
+                crm_timer_start(transition_timer);
+            } else {
+                register_fsa_input(C_FSA_INTERNAL, I_PE_CALC, NULL);
+            }
         } else {
             register_fsa_input(C_FSA_INTERNAL, I_TE_SUCCESS, NULL);
         }


### PR DESCRIPTION
When specific number of times fencing failed regardless of a value of crmd-transition-delay, I think that it is better to block fencing. (the same block operation/policy is desirable.)
