### PR TITLE
Build: fix "without" argument

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -45,7 +45,7 @@ ARCH    ?= $(shell test -e /etc/fedora-release && rpm --eval %{_arch})
 MOCK_CFG ?= $(shell test -e /etc/fedora-release && echo fedora-$(F)-$(ARCH))
 DISTRO  ?= $(shell test -e /etc/SuSE-release && echo suse; echo fedora)
 TAG     ?= $(shell git log --pretty="format:%h" -n 1)
-WITH    ?= --without=doc
+WITH    ?= --without doc
 #WITH    ?= --without=doc --with=gcov
 
 LAST_RC		?= $(shell test -e /Volumes || git tag -l | grep Pacemaker | sort -Vr | grep rc | head -n 1)


### PR DESCRIPTION
I failed making rpm files on RHEL6.
"--without=doc"  causes this error.

```
rpmbuild -bs --define "dist .fedora" --define "_sourcedir /home/share/repo/compile-1.1-el6/pacemaker" --define "_specdir   /home/share/repo/compile-1.1-el6/pacemaker" --define "_srcrpmdir /home/share/repo/compile-1.1-el6/pacemaker"  --without=doc  pacemaker.spec
--without=doc: unknown option
make: *** [srpm-fedora] Error 1
```

My rpm-build version is 4.8.0-27.

```
# rpm -q rpm-build
rpm-build-4.8.0-27.el6.x86_64
```
