### PR TITLE
fix reference in "data_set->ticket" of NULL.

### DIFF
--- a/pengine/constraints.c
+++ b/pengine/constraints.c
@@ -2364,6 +2364,11 @@ unpack_rsc_ticket(xmlNode * xml_obj, pe_working_set_t * data_set)
         return FALSE;
     }
 
+    if (data_set->tickets == NULL) {                                                                  
+        data_set->tickets =                                                                           
+            g_hash_table_new_full(crm_str_hash, g_str_equal, g_hash_destroy_str, destroy_ticket);
+    }  
+
     if (ticket_str == NULL) {
         crm_config_err("Invalid constraint '%s': No ticket specified", id);
         return FALSE;


### PR DESCRIPTION
In the environment where rsc_ticket is set up, I discovered the phenomenon in which stonithd aborted.

pe_flag_quick_location is set in fencing/main.c.
When pe_flag_quick_location is set, unpack_status() is not carried out.
"data_set->ticket" is made in unpack_status() .
If do_calculations is performed by this flow, "data_set->ticket" will be passed to g_hash_table_lookup() by NULL in unpack_rsc_tickets(). 

```
Jun 07 13:35:36 [5620] vm1 stonith-ng: (     utils.c:1123  )   error: crm_abort:        crm_glib_handler: Forked child 5626 to record non-fatal assert at logging.c:63 : g_hash_table_lookup: assertion `hash_table != NULL' failed
```
