### PR TITLE
Fix: xml: Purge diff markers even if there's no digest

### DIFF
--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1614,6 +1614,9 @@ apply_xml_diff(xmlNode * old, xmlNode * diff, xmlNode ** new)
             crm_trace("Digest matched: expected %s, calculated %s", digest, new_digest);
         }
         free(new_digest);
+
+    } else if (result) {
+        purge_diff_markers(*new);       /* Purge now so the diff is ok */
     }
 
     return result;


### PR DESCRIPTION
So that "cibadmin --patch" and "crm_diff --patch" work correctly
