### PR TITLE
Fix: attrd: Fixes deleted attributes during dc election

### DIFF
--- a/tools/attrd.c
+++ b/tools/attrd.c
@@ -405,7 +405,7 @@ update_for_hash_entry(gpointer key, gpointer value, gpointer user_data)
 {
     attr_hash_entry_t *entry = value;
 
-    if (entry->value != NULL) {
+    if (entry->value != NULL || entry->stored_value != NULL) {
         attrd_timer_callback(value);
     }
 }


### PR DESCRIPTION
The stored value will be NULL once the deletion is successful. If it is not successful the refresh needs to clear the value later on.  We can detect this scenario when the value is NULL, but the stored value is not.

Without this patch, it is possible for attributes to not be removed at all on deletion.
