### PR TITLE
Fix: legacy: Handle messages in the common way in the plugin dispatch function by default

### DIFF
--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -225,20 +225,6 @@ pcmk_cpg_dispatch(gpointer user_data)
     return 0;
 }
 
-/*
-static void
-pcmk_cpg_deliver_message(cpg_handle_t handle,
-                         const struct cpg_name *groupName,
-                         uint32_t nodeid, uint32_t pid, void *msg, size_t msg_len)
-{
-    uint32_t kind = 0;
-    const char *from = NULL;
-    char *data = pcmk_message_common_cs(handle, nodeid, pid, msg, &kind, &from);
-
-    free(data);
-}
-*/
-
 char *
 pcmk_message_common_cs(cpg_handle_t handle, uint32_t nodeid, uint32_t pid, void *content,
                         uint32_t *kind, const char **from)

--- a/lib/cluster/legacy.c
+++ b/lib/cluster/legacy.c
@@ -254,6 +254,19 @@ plugin_handle_membership(AIS_Message *msg)
     }
 }
 
+
+static void
+legacy_default_deliver_message(cpg_handle_t handle,
+                               const struct cpg_name *groupName,
+                               uint32_t nodeid, uint32_t pid, void *msg, size_t msg_len)
+{
+    uint32_t kind = 0;
+    const char *from = NULL;
+    char *data = pcmk_message_common_cs(handle, nodeid, pid, msg, &kind, &from);
+
+    free(data);
+}
+
 int
 plugin_dispatch(gpointer user_data)
 {
@@ -279,7 +292,13 @@ plugin_dispatch(gpointer user_data)
         cpg_deliver_fn_t(cpg_handle_t handle, const struct cpg_name *group_name,
                          uint32_t nodeid, uint32_t pid, void *msg, size_t msg_len);
         */
-        cluster->cpg.cpg_deliver_fn(0, NULL, 0, 0, buffer, 0);
+        if (cluster && cluster->cpg.cpg_deliver_fn) {
+            cluster->cpg.cpg_deliver_fn(0, NULL, 0, 0, buffer, 0);
+
+        } else {
+            legacy_default_deliver_message(0, NULL, 0, 0, buffer, 0);
+        }
+
         coroipcc_dispatch_put(ais_ipc_handle);
 
     } while (ais_ipc_handle);


### PR DESCRIPTION
Pacemaker plugin used to handle everything well in the default fd callback ais_dispatch(). So that dlm_controld and ocfs2_controld don't need to setup extra callbacks.  We'd probably expect the current plugin_dispatch() to do the same, right?
