### PR TITLE
Fix: plugin: remove memory leak in legacy code

### DIFF
--- a/lib/cluster/legacy.c
+++ b/lib/cluster/legacy.c
@@ -251,6 +251,7 @@ plugin_handle_membership(AIS_Message *msg)
             crm_update_peer(__FUNCTION__, id, born, seen, votes, procs, uname, uname, addr, state);
         }
     }
+    free_xml(xml);
 }
 
 int


### PR DESCRIPTION
The xml data structure is created, but not free'd, causing a pretty severe memory leak.
