### PR TITLE
Fix memory leak when used score2char()

### DIFF
--- a/fencing/main.c
+++ b/fencing/main.c
@@ -630,7 +630,11 @@ static void cib_device_update(resource_t *rsc, pe_working_set_t *data_set)
         return;
 
     } else if(node->weight < 0) {
-        crm_info("Device %s has been disabled on %s: score=%s", rsc->id, stonith_our_uname, score2char(node->weight));
+        char *score = score2char(node->weight);
+
+        crm_info("Device %s has been disabled on %s: score=%s", rsc->id, stonith_our_uname, score);
+        free(score);
+
         return;
 
     } else {

--- a/pengine/master.c
+++ b/pengine/master.c
@@ -298,6 +298,7 @@ master_promotion_order(resource_t * rsc, pe_working_set_t * data_set)
     gIter = rsc->children;
     for (; gIter != NULL; gIter = gIter->next) {
         resource_t *child = (resource_t *) gIter->data;
+        char *score = NULL;
 
         chosen = child->fns->location(child, NULL, FALSE);
         if (chosen == NULL || child->sort_index < 0) {
@@ -308,8 +309,10 @@ master_promotion_order(resource_t * rsc, pe_working_set_t * data_set)
         node = (node_t *) pe_hash_table_lookup(rsc->allowed_nodes, chosen->details->id);
         CRM_ASSERT(node != NULL);
         /* adds in master preferences and rsc_location.role=Master */
-        pe_rsc_trace(rsc, "Adding %s to %s from %s", score2char(child->sort_index),
+        score = score2char(child->sort_index);
+        pe_rsc_trace(rsc, "Adding %s to %s from %s", score,
                      node->details->uname, child->id);
+        free(score);
         node->weight = merge_weights(child->sort_index, node->weight);
     }
 


### PR DESCRIPTION
As a result of performing valgrind in my environment, leak of score2char() was discovered.

```
==15978== 100 bytes in 10 blocks are definitely lost in loss record 117 of 211
==15978==    at 0x4A05FDE: malloc (vg_replace_malloc.c:236)
==15978==    by 0x35B8617AD0: score2char (in /usr/lib64/libcrmcommon.so.3.2.0)
==15978==    by 0x403C59: ??? (in /usr/libexec/pacemaker/stonithd)
==15978==    by 0x4038E4: ??? (in /usr/libexec/pacemaker/stonithd)
==15978==    by 0x403DD3: ??? (in /usr/libexec/pacemaker/stonithd)
==15978==    by 0x4057A8: ??? (in /usr/libexec/pacemaker/stonithd)                                                                                                                                               
==15978==    by 0x35B920A213: cib_native_notify (in /usr/lib64/libcib.so.3.0.1)
==15978==    by 0x39C703688B: g_list_foreach (in /lib64/libglib-2.0.so.0.2200.5)                                                                                                                                 
==15978==    by 0x35B921091B: ??? (in /usr/lib64/libcib.so.3.0.1)                                                                                                                                                
==15978==    by 0x35B862BD9F: ??? (in /usr/lib64/libcrmcommon.so.3.2.0)                                                                                                                                          
==15978==    by 0x39C7038F0D: g_main_context_dispatch (in /lib64/libglib-2.0.so.0.2200.5)
==15978==    by 0x39C703C937: ??? (in /lib64/libglib-2.0.so.0.2200.5)
==15978==    by 0x39C703CD54: g_main_loop_run (in /lib64/libglib-2.0.so.0.2200.5)
==15978==    by 0x4040C6: ??? (in /usr/libexec/pacemaker/stonithd)
==15978==    by 0x3A09E1ECDC: (below main) (in /lib64/libc-2.12.so)
==15978==                                                                                                                                                                                                        
{                                                                                                                                                                                                                
   <insert_a_suppression_name_here>
   Memcheck:Leak                                                                                                                                                                                                 
   fun:malloc                                                                                                                                                                                                    
   fun:score2char                                                                                                                                                                                                
   obj:/usr/libexec/pacemaker/stonithd
   obj:/usr/libexec/pacemaker/stonithd
   obj:/usr/libexec/pacemaker/stonithd                                                                                                                                                                           
   obj:/usr/libexec/pacemaker/stonithd                                                                                                                                                                           
   fun:cib_native_notify                                                                                                                                                                                         
   fun:g_list_foreach                                                                                                                                                                                            
   obj:/usr/lib64/libcib.so.3.0.1                                                                                                                                                                                
   obj:/usr/lib64/libcrmcommon.so.3.2.0                                                                                                                                                                          
   fun:g_main_context_dispatch                                                                                                                                                                                   
   obj:/lib64/libglib-2.0.so.0.2200.5                                                                                                                                                                            
   fun:g_main_loop_run                                                                                                                                                                                           
   obj:/usr/libexec/pacemaker/stonithd                                                                                                                                                                           
   fun:(below main)                                                                                                                                                                                              
}
```

Although it did not come out in valgrind, the potential thing which is carrying out the method of the similar call was also corrected.
pengine/master.c
