### PR TITLE
systemd: Add alternate unit file controlling both pacemaker and corosync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ include/config.h.in
 include/crm_config.h
 mcp/pacemaker
 mcp/pacemaker.service
+mcp/pacemaker.combined.service
 pengine/regression.core.sh
 publican.cfg
 shell/modules/help.py

--- a/configure.ac
+++ b/configure.ac
@@ -1826,6 +1826,7 @@ lib/Makefile							\
 mcp/Makefile							\
 	mcp/pacemaker						\
 	mcp/pacemaker.service					\
+	mcp/pacemaker.combined.service				\
 	mcp/pacemaker.upstart					\
 	mcp/pacemaker.combined.upstart				\
 fencing/Makefile                                                \

--- a/mcp/Makefile.am
+++ b/mcp/Makefile.am
@@ -30,7 +30,7 @@ man8_MANS =	$(sbin_PROGRAMS:%=%.8)
 endif
 
 if BUILD_SYSTEMD
-systemdunit_DATA = pacemaker.service
+systemdunit_DATA = pacemaker.service pacemaker.combined.service
 endif
 
 ## SOURCES

--- a/mcp/pacemaker.combined.service.in
+++ b/mcp/pacemaker.combined.service.in
@@ -1,0 +1,43 @@
+[Unit]
+Description=Starts Corosync cluster engine and Pacemaker cluster manager
+
+After=basic.target
+After=network.target
+After=corosync.service
+
+Requires=basic.target
+Requires=network.target
+Requires=corosync.service
+
+# Uncomment the line below, if you use corosync-notifyd
+# After=corosync-notifyd.service
+# Wants=corosync-notifyd.service
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=simple
+KillMode=process
+NotifyAccess=main
+SysVStartPriority=99
+EnvironmentFile=-@sysconfdir@/sysconfig/pacemaker
+
+ExecStart=@sbindir@/pacemakerd -f
+
+# If pacemakerd doesn't stop, its probably waiting on a cluster
+# resource.  Sending -KILL will just get the node fenced
+SendSIGKILL=no
+
+# When pacemakerd disappeared unexpectedly, a machine is rebooted
+# by the watchdog of corosync
+ExecStopPost=/bin/sh -c 'pidof crmd && killall -q -9 corosync; /usr/share/corosync/corosync stop || true'
+
+# Uncomment this for older versions of systemd that didn't support
+# TimeoutStopSec
+# TimeoutSec=30min
+
+# Pacemaker can only exit after all managed services have shut down
+# A HA database could conceivably take even longer than this 
+TimeoutStopSec=30min
+TimeoutStartSec=60s

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -394,6 +394,7 @@ exit 0
 
 %if %{defined _unitdir}
 %{_unitdir}/pacemaker.service
+%{_unitdir}/pacemaker.combined.service
 %else
 %{_initrddir}/pacemaker
 %endif


### PR DESCRIPTION
I ported "pacemaker.combined.conf" of upstart job to systemd unit file.
