### PR TITLE
Fix: crmd: Prevent messages for remote crmd clients from being relayed to wrong daemons

### DIFF
--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -666,7 +666,7 @@ text2msg_type(const char *text)
          */
         int scan_rc = sscanf(text, "%d", &type);
 
-        if (scan_rc != 1) {
+        if (scan_rc != 1 || type <= crm_msg_stonith_ng) {
             /* Ensure its sane */
             type = crm_msg_none;
         }


### PR DESCRIPTION
When crmd is relaying a message for a remote client like "crmadmin -S",
the "sys_to" field is the client uuid of the crmadmin. The result of
sscanf() in text2msg_type() is random in this case. So that the message
could be sent to other daemons.

This was once fixed by:
https://github.com/ClusterLabs/pacemaker/pull/237

The sscanf() part seems to be lost during refactoring.
