### PR TITLE
Fix: remove the mainloop_trigger that are no longer needed.

### DIFF
--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -311,6 +311,9 @@ free_device(gpointer data)
     g_list_free(device->pending_ops);
 
     g_list_free_full(device->targets, free);
+
+    mainloop_destroy_trigger(device->work);
+
     free_xml(device->agent_metadata);
     free(device->namespace);
     free(device->on_target_actions);


### PR DESCRIPTION
I think that "device->work" may free, when free_device() is performed.

I checked the memory leak using valgrind.
Movement of the resource is repeated for the check.

And it found the following portions continuing and increasing.
This is g_source made when registering device.

Since change of cib takes place when moving a resource, re-registration of device is performed.
g_source is not free by "free_device()" then performed.
I am surmising that it accumulates.

If there is no mistake in my opinion, I want you to merge the fix.

```
==26563== 3,358,200 bytes in 27,985 blocks are still reachable in loss record 212 of 212
==26563==    at 0x4A04A28: calloc (vg_replace_malloc.c:467)
==26563==    by 0x3113C41707: g_malloc0 (in /lib64/libglib-2.0.so.0.2200.5)
==26563==    by 0x3113C38544: g_source_new (in /lib64/libglib-2.0.so.0.2200.5)
==26563==    by 0x4C4F3CC: mainloop_add_trigger (mainloop.c:214)
==26563==    by 0x40A529: stonith_device_register (commands.c:608)
==26563==    by 0x403BD3: cib_device_update (main.c:662)
==26563==    by 0x4038F4: cib_device_update (main.c:586)
==26563==    by 0x403DF3: cib_devices_update (main.c:688)
==26563==    by 0x405668: update_cib_cache_cb (main.c:727)
==26563==    by 0x5716243: cib_native_notify (cib_utils.c:778)
==26563==    by 0x3113C3688B: g_list_foreach (in /lib64/libglib-2.0.so.0.2200.5)
==26563==    by 0x571C94B: cib_native_dispatch_internal (cib_native.c:123)
==26563==    by 0x4C4E92F: mainloop_gio_callback (mainloop.c:665)
==26563==    by 0x3113C38F0D: g_main_context_dispatch (in /lib64/libglib-2.0.so.0.2200.5)==26563==    by 0x3113C3C937: ??? (in /lib64/libglib-2.0.so.0.2200.5)
==26563==    by 0x3113C3CD54: g_main_loop_run (in /lib64/libglib-2.0.so.0.2200.5)
==26563==    by 0x4040E6: main (main.c:1136)
==26563==
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   fun:calloc
   fun:g_malloc0
   fun:g_source_new
   fun:mainloop_add_trigger
   fun:stonith_device_register
   fun:cib_device_update
   fun:cib_device_update
   fun:cib_devices_update
   fun:update_cib_cache_cb
   fun:cib_native_notify
   fun:g_list_foreach
   fun:cib_native_dispatch_internal
   fun:mainloop_gio_callback
   fun:g_main_context_dispatch
   obj:/lib64/libglib-2.0.so.0.2200.5
   fun:g_main_loop_run
   fun:main
}
```
