### PR TITLE
Low: mcp: Fix so that only pacemakerd restarts, at the time of pacemakerd failure

### DIFF
--- a/mcp/pacemaker.service.in
+++ b/mcp/pacemaker.service.in
@@ -32,12 +32,12 @@ SendSIGKILL=no
 # Although the node will likely end up being fenced as a result so its
 # not on by default
 #
-# ExecStopPost=killall -TERM crmd attrd fenced cib pengine lrmd
+# ExecStopPost=/usr/bin/killall -TERM crmd attrd fenced cib pengine lrmd
 
 # If you want Corosync to stop whenever Pacemaker is stopped,
 # uncomment the next line too:
 #
-# ExecStopPost=killall -TERM corosync
+# ExecStopPost=/bin/sh -c 'pidof crmd || killall -TERM corosync'
 
 # Uncomment this for older versions of systemd that didn't support
 # TimeoutStopSec


### PR DESCRIPTION
I revised two things.

1) changed the first argument of ExecStopPost to the absolute path.
- ExecStart=
  - (snip) **The first argument must be an absolute path name**.
- ExecStopPost=
  - (snip) This argument takes multiple command lines, **following the same scheme as described for ExecStart**.

2) changed it so that only pacemakerd restarts at the time of pacemakerd failure.
- in the case of `ExecStopPost=/usr/bin/killall -TERM corosync`
  - because corosync restarts at the time of pacemakerd failure, crmd and others are restarted.

```
Jul 29 14:13:21 dev1 corosync[19910]:   [SERV  ] service.c:service_exit_schedwrk_handler:373 Unloading all Corosync service engines.
Jul 29 14:13:21 dev1 crmd[19922]:    error: pcmk_cpg_dispatch: Connection to the CPG API failed: Library error (2)
Jul 29 14:13:21 dev1 crmd[19922]:    error: crmd_cs_destroy: connection terminated
Jul 29 14:13:21 dev1 crmd[19922]:   notice: crmd_exit: Forcing immediate exit: Link has been severed (67)
Jul 29 14:13:21 dev1 attrd[19920]:    error: pcmk_cpg_dispatch: Connection to the CPG API failed: Library error (2)
Jul 29 14:13:21 dev1 attrd[19920]:     crit: attrd_cs_destroy: Lost connection to Corosync service!
Jul 29 14:13:21 dev1 attrd[19920]:   notice: main: Exiting...
Jul 29 14:13:21 dev1 attrd[19920]:   notice: main: Disconnecting client 0xe5c1e0, pid=19922...
Jul 29 14:13:21 dev1 corosync[19910]:   [QB    ] ipc_setup.c:qb_ipcs_us_withdraw:427 withdrawing server sockets
Jul 29 14:13:21 dev1 corosync[19910]:   [SERV  ] service.c:corosync_service_unlink_and_exit_priority:240 Service engine unloaded: corosync vote quorum service v1.0
Jul 29 14:13:21 dev1 corosync[19910]:   [QB    ] ipc_setup.c:qb_ipcs_us_withdraw:427 withdrawing server sockets
Jul 29 14:13:21 dev1 corosync[19910]:   [SERV  ] service.c:corosync_service_unlink_and_exit_priority:240 Service engine unloaded: corosync configuration map access
Jul 29 14:13:21 dev1 stonith-ng[19918]:    error: pcmk_cpg_dispatch: Connection to the CPG API failed: Library error (2)
Jul 29 14:13:21 dev1 cib[19917]:    error: pcmk_cpg_dispatch: Connection to the CPG API failed: Library error (2)
Jul 29 14:13:21 dev1 attrd[19920]:    error: attrd_cib_connection_destroy: Connection to the CIB terminated...
Jul 29 14:13:21 dev1 corosync[19910]:   [QB    ] ipc_setup.c:qb_ipcs_us_withdraw:427 withdrawing server sockets
Jul 29 14:13:21 dev1 stonith-ng[19918]:    error: stonith_peer_cs_destroy: Corosync connection terminated
Jul 29 14:13:21 dev1 cib[19917]:    error: cib_cs_destroy: Corosync connection lost!  Exiting.
Jul 29 14:13:21 dev1 corosync[19910]:   [SERV  ] service.c:corosync_service_unlink_and_exit_priority:240 Service engine unloaded: corosync configuration service
Jul 29 14:13:21 dev1 corosync[19910]:   [QB    ] ipc_setup.c:qb_ipcs_us_withdraw:427 withdrawing server sockets
Jul 29 14:13:21 dev1 corosync[19910]:   [SERV  ] service.c:corosync_service_unlink_and_exit_priority:240 Service engine unloaded: corosync cluster closed process group service v1.01
Jul 29 14:13:21 dev1 corosync[19910]:   [QB    ] ipc_setup.c:qb_ipcs_us_withdraw:427 withdrawing server sockets
Jul 29 14:13:21 dev1 corosync[19910]:   [SERV  ] service.c:corosync_service_unlink_and_exit_priority:240 Service engine unloaded: corosync cluster quorum service v0.1
Jul 29 14:13:21 dev1 corosync[19910]:   [SERV  ] service.c:corosync_service_unlink_and_exit_priority:240 Service engine unloaded: corosync profile loading service
Jul 29 14:13:21 dev1 corosync[19910]:   [WD    ] wd.c:wd_exec_exit_fn:732 magically closing the watchdog.
Jul 29 14:13:21 dev1 corosync[19910]:   [SERV  ] service.c:corosync_service_unlink_and_exit_priority:240 Service engine unloaded: corosync watchdog service
Jul 29 14:13:21 dev1 corosync[19910]:   [MAIN  ] util.c:_corosync_exit_error:131 Corosync Cluster Engine exiting normally
Jul 29 14:13:21 dev1 corosync[19993]:   [MAIN  ] main.c:main:1173 Corosync Cluster Engine ('2.3.1'): started and ready to provide service.
:
Jul 29 14:13:21 dev1 pacemakerd[20000]:   notice: crm_add_logfile: Additional logging available in /var/log/ha-debug
```
- in the case of `ExecStopPost=/bin/sh -c 'pidof crmd || killall -TERM corosync'`
  - only corosync restarts at the time of failure of pacemakerd.

```
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: crm_add_logfile: Additional logging available in /var/log/ha-debug
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: mcp_read_config: Configured corosync to accept connections from group 989: OK (1)
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: crm_add_logfile: Additional logging available in /var/log/ha-debug
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: main: Starting Pacemaker 1.1.10 (Build: 368c726):  ncurses libqb-logging libqb-ipc lha-fencing upstart systemd nagios  corosync-native snmp
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: cluster_connect_quorum: Quorum acquired
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: corosync_node_name: Unable to get node name for nodeid 3232261525
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: get_node_name: Defaulting to uname -n for the local corosync node name
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: find_and_track_existing_processes: Tracking existing cib process (pid=20384)
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: find_and_track_existing_processes: Tracking existing stonithd process (pid=20385)
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: find_and_track_existing_processes: Tracking existing lrmd process (pid=20386)
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: find_and_track_existing_processes: Tracking existing attrd process (pid=20387)
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: find_and_track_existing_processes: Tracking existing pengine process (pid=20388)
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: find_and_track_existing_processes: Tracking existing crmd process (pid=20389)
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: corosync_node_name: Unable to get node name for nodeid 3232261523
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: crm_update_peer_state: pcmk_quorum_notification: Node (null)[3232261523] - state is now member (was (null))
Jul 29 14:18:24 dev1 pacemakerd[20420]:   notice: crm_update_peer_state: pcmk_quorum_notification: Node dev1[3232261525] - state is now member (was (null))
Jul 29 14:18:24 dev1 corosync[20377]:   [TOTEM ] totemrrp.c:timer_function_active_token_expired:1362 Incrementing problem counter for seqid 1558 iface 192.168.101.149 to [1 of 10]
Jul 29 14:18:26 dev1 corosync[20377]:   [TOTEM ] totemrrp.c:timer_function_active_problem_decrementer:1330 ring 0 active with no faults
:
```
