### PR TITLE
allow to build on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -440,7 +440,9 @@ dnl
 dnl So keep this section to a bare minimum; regard as a "necessary evil".
 
 case "$host_os" in
-*bsd*)		LIBS="-L/usr/local/lib"
+*bsd*)
+		AC_DEFINE_UNQUOTED(ON_BSD, 1, Compiling for BSD platform)
+		LIBS="-L/usr/local/lib"
 		CPPFLAGS="$CPPFLAGS -I/usr/local/include"
 		INIT_EXT=".sh"
 		;;
@@ -708,6 +710,10 @@ if test "X$GLIBCONFIG" != X; then
 	AC_MSG_RESULT($GLIBLIB)
 	LIBS="$LIBS $GLIBLIB"
 fi
+
+dnl FreeBSD needs -lcompat for ftime() used by lrmd.c
+AC_CHECK_LIB([compat], [ftime], [COMPAT_LIBS='-lcompat'])
+AC_SUBST(COMPAT_LIBS)
 
 dnl ========================================================================
 dnl Headers

--- a/include/portability.h
+++ b/include/portability.h
@@ -202,6 +202,22 @@ g_list_free_full(GList * list, GDestroyNotify free_func)
 #    define ENOKEY    195
 #  endif
 
+#  ifndef ENODATA
+#    define ENODATA   196
+#  endif
+
+#  ifndef ETIME
+#    define ETIME     197
+#  endif
+
+#  ifndef ENOSR
+#    define ENOSR     198
+#  endif
+
+#  ifndef ENOSTR
+#    define ENOSTR    199
+#  endif
+
 /*
  * Some compilers (eg. Sun studio) do not define __FUNCTION__
  */

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -53,7 +53,9 @@ typedef void gnutls_session_t;
 #endif
 
 #include <arpa/inet.h>
-#include <sgtty.h>
+#ifndef ON_BSD
+#  include <sgtty.h>
+#endif
 
 #define DH_BITS 1024
 

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -38,7 +38,7 @@ libcrmcommon_la_SOURCES	+= cib_secrets.c
 endif
 
 libcrmcommon_la_LDFLAGS	= -version-info 5:0:2
-libcrmcommon_la_LIBADD  = -ldl $(GNUTLSLIBS)
+libcrmcommon_la_LIBADD  = @LIBADD_DL@ $(GNUTLSLIBS)
 libcrmcommon_la_SOURCES += $(top_builddir)/lib/gnu/md5.c
 
 clean-generic:

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netdb.h>
 

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -47,6 +47,7 @@
 #endif
 
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <netinet/ip.h>
 #include <arpa/inet.h>
 #include <netdb.h>

--- a/lrmd/Makefile.am
+++ b/lrmd/Makefile.am
@@ -45,7 +45,7 @@ lrmd_SOURCES	= main.c lrmd.c
 lrmd_LDADD		= $(top_builddir)/lib/common/libcrmcommon.la	\
 			$(top_builddir)/lib/services/libcrmservice.la \
 			$(top_builddir)/lib/lrmd/liblrmd.la  \
-			$(top_builddir)/lib/fencing/libstonithd.la
+			$(top_builddir)/lib/fencing/libstonithd.la ${COMPAT_LIBS}
 
 
 pacemaker_remoted_SOURCES	= main.c lrmd.c tls_backend.c ipc_proxy.c

--- a/lrmd/tls_backend.c
+++ b/lrmd/tls_backend.c
@@ -31,6 +31,7 @@
 #include <lrmd_private.h>
 
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <netinet/ip.h>
 #include <arpa/inet.h>
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -485,7 +485,7 @@ main(int argc, char **argv)
                     "Provides a summary of cluster's current state."
                     "\n\nOutputs varying levels of detail in a number of different formats.\n");
 
-#ifndef ON_DARWIN
+#if !defined (ON_DARWIN) && !defined (ON_BSD)
     /* prevent zombies */
     signal(SIGCLD, SIG_IGN);
 #endif


### PR DESCRIPTION
This commit makes possible to compile pacemaker on FreeBSD systems (at least 9.1), assuming all prerequisites satisfied (libqb and corosync are "alien" to FreeBSD so should be built manually).
Tested configurations: FreeBSD 9.1 (amd64, i386), Ubuntu 13.04 (i686).

N.B. Nonetheless pacemaker does not function properly yet - small investigation showed that pacemaker requires /dev/shm to be present in system (libqd does, as QB_IPC_SHM is hardcoded in several places of pacemaker).
Mounting tmpfs did not give acceptable result (error: mainloop_add_ipc_server:      Could not start pacemakerd IPC server: Operation not supported (-45)), also changing IPC type to socket was unsuccessful.
