### PR TITLE
Improve display when crm_mon cannot connect

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -719,37 +719,6 @@ main(int argc, char **argv)
     return 0;                   /* never reached */
 }
 
-void
-wait_for_refresh(int offset, const char *prefix, int msec)
-{
-    int lpc = msec / 1000;
-    struct timespec sleept = { 1, 0 };
-
-    if (as_console == FALSE) {
-        timer_id = g_timeout_add(msec, mon_timer_popped, NULL);
-        return;
-    }
-
-    crm_notice("%sRefresh in %ds...", prefix ? prefix : "", lpc);
-    while (lpc > 0) {
-#if CURSES_ENABLED
-        move(offset, 0);
-/* 		printw("%sRefresh in \033[01;32m%ds\033[00m...", prefix?prefix:"", lpc); */
-        printw("%sRefresh in %ds...\n", prefix ? prefix : "", lpc);
-        clrtoeol();
-        refresh();
-#endif
-        lpc--;
-        if (lpc == 0) {
-            timer_id = g_timeout_add(1000, mon_timer_popped, NULL);
-        } else {
-            if (nanosleep(&sleept, NULL) != 0) {
-                return;
-            }
-        }
-    }
-}
-
 #define mon_warn(fmt...) do {			\
 	if (!has_warnings) {			\
 	    print_as("Warning:");		\


### PR DESCRIPTION
I think that the output of  crm_mon is little poor
when crm_mon cannot connect.
Print_dot() already makes no sense.

```
# crm_mon
Attempting connection to the cluster...Could not establish cib_ro connection: Connection refused (111)
                             .Could not establish cib_ro connection: Connection refused (111)
                    .Could not establish cib_ro connection: Connection refused (111)
           .
(snip)
```

So I make a patch to clear ncurses screen when crm_mon cannot connect.

Before pacemaker is started

```
# crm_mon
Attempting connection to the cluster...
Could not establish cib_ro connection: Connection refused (111)
```

After pacemaker is shut down

```
Reconnecting...
Could not establish cib_ro connection: Connection refused (111)
```

I tried to implement showing running status such as print_dot() on ncurses,
but I cannot :(
