### PR TITLE
Low: ipc: reduce logging about limits as long as compressed message fits

### DIFF
--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -494,6 +494,7 @@ ssize_t
 crm_ipc_prepare(uint32_t request, xmlNode * message, struct iovec ** result)
 {
     static int biggest = 0;
+    static int compressed_size_warning = 0;
 
     struct iovec *iov;
     unsigned int total = 0;
@@ -523,9 +524,9 @@ crm_ipc_prepare(uint32_t request, xmlNode * message, struct iovec ** result)
 
         if (total > biggest) {
             biggest = 2 * QB_MAX(total, biggest);
-            crm_notice("Message exceeds the configured ipc limit (%d bytes), "
-                       "consider configuring PCMK_ipc_buffer to %d or higher "
-                       "to avoid compression overheads", ipc_buffer_max, biggest);
+            crm_info("Message exceeds the configured ipc limit (%d bytes), "
+                     "consider configuring PCMK_ipc_buffer to %d or higher "
+                     "to avoid compression overheads", ipc_buffer_max, biggest);
         }
 
         if (crm_compress_string
@@ -539,6 +540,12 @@ crm_ipc_prepare(uint32_t request, xmlNode * message, struct iovec ** result)
 
             free(buffer);
 
+            if (!compressed_size_warning && (new_size * 10 > ipc_buffer_max * 8)) {
+                crm_warn("Compressed message exceeds 80%% of configured ipc limit (%d bytes), "
+                         "please increase PCMK_ipc_buffer to avoid IPC failures (%d bytes suggested)",
+                         new_size, ipc_buffer_max, iggest);
+                compressed_size_warning = 1;
+	    }
         } else {
             ssize_t rc = -EMSGSIZE;
 


### PR DESCRIPTION
Hi Andrew, as discussed on the mailing list. I went with your proposal to downgrade the message to "info", and added a harsher warning if the compressed size exceeds 80% of the buffer - but that's only printed once too.

For what it is worth, this was triggered by bnc#838358, but you don't like private bugzilla references in the git commit logs ;-)
