### PR TITLE
Low: spelling fixes in comments and log messages

### DIFF
--- a/crmd/corosync.c
+++ b/crmd/corosync.c
@@ -113,7 +113,7 @@ crmd_cs_dispatch(cpg_handle_t handle,
                 /* If we can still talk to our peer process on that node,
                  * then its also part of the corosync membership
                  */
-                crm_warn("Recieving messages from a node we think is dead: %s[%d]", peer->uname,
+                crm_warn("Receiving messages from a node we think is dead: %s[%d]", peer->uname,
                          peer->id);
                 crm_update_peer_proc(__FUNCTION__, peer, flag, ONLINESTATUS);
             }

--- a/crmd/fsa_defines.h
+++ b/crmd/fsa_defines.h
@@ -117,7 +117,7 @@ Description:
 
       Once we have the latest CIB, we then enter the S_POLICY_ENGINE state
       where invoke the Policy Engine. It is possible that between
-      invoking the Policy Engine and recieving an answer, that we recieve
+      invoking the Policy Engine and receiving an answer, that we receive
       more input. In this case we would discard the orginal result and
       invoke it again.
 
@@ -154,7 +154,7 @@ Description:
  *	the "register" (see below) and the contents or source of messages.
  *
  *	At this point, my plan is to have a loop of some sort that keeps
- *	going until recieving I_NULL
+ *	going until receiving I_NULL
  *
  *======================================*/
 enum crmd_fsa_input {

--- a/cts/CM_ais.py
+++ b/cts/CM_ais.py
@@ -87,12 +87,12 @@ class crm_ais(crm_lha):
                 r"Unknown node -> we will not deliver message",
                 r"crm_write_blackbox",
                 r"pacemakerd.*Could not connect to Cluster Configuration Database API",
-                r"Recieving messages from a node we think is dead",
+                r"Receiving messages from a node we think is dead",
                 r"share the same cluster nodeid",
                 r"share the same name",
 
                 #r"crm_ipc_send:.*Request .* failed",
-                #r"crm_ipc_send:.*Sending to .* is disabled until pending reply is recieved",
+                #r"crm_ipc_send:.*Sending to .* is disabled until pending reply is received",
 
                 # Not inherently bad, but worth tracking
                 #r"No need to invoke the TE",

--- a/doc/msg-schema.txt
+++ b/doc/msg-schema.txt
@@ -66,7 +66,7 @@ CRM to unpack the message and pass it on to the correct sub-system.  If
 the destination sub-system is the DC and the DC is not running on the
 current node, the message is discarded without error.
 
-Where the DC recieves a message from another node, it will also keep
+Where the DC receives a message from another node, it will also keep
 track of the sending host and the reference number so that it can direct
 the replies appropriately.  The exception to this is where the message
 is from the DC.  

--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -1858,7 +1858,7 @@ handle_request(crm_client_t * client, uint32_t id, uint32_t flags, xmlNode * req
             xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, request, LOG_TRACE);
             const char *target = crm_element_value(dev, F_STONITH_TARGET);
 
-            crm_notice("Recieved manual confirmation that %s is fenced", target);
+            crm_notice("Received manual confirmation that %s is fenced", target);
             rop = initiate_remote_stonith_op(client, request, TRUE);
             rc = stonith_manual_ack(request, rop);
 

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -418,13 +418,13 @@ cib_native_perform_op_delegate(cib_t * cib, const char *op, const char *host, co
         }
 
     } else if (reply_id <= 0) {
-        crm_err("Recieved bad reply: No id set");
+        crm_err("Received bad reply: No id set");
         crm_log_xml_err(op_reply, "Bad reply");
         rc = -ENOMSG;
         goto done;
 
     } else {
-        crm_err("Recieved bad reply: %d (wanted %d)", reply_id, cib->call_id);
+        crm_err("Received bad reply: %d (wanted %d)", reply_id, cib->call_id);
         crm_log_xml_err(op_reply, "Old reply");
         rc = -ENOMSG;
         goto done;

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -417,7 +417,7 @@ check_message_sanity(const AIS_Message * msg, const char *data)
 
     } else {
         crm_trace
-            ("Verfied message %d: (dest=%s:%s, from=%s:%s.%u, compressed=%d, size=%d, total=%d)",
+            ("Verified message %d: (dest=%s:%s, from=%s:%s.%u, compressed=%d, size=%d, total=%d)",
              msg->id, ais_dest(&(msg->host)), msg_type2text(dest), ais_dest(&(msg->sender)),
              msg_type2text(msg->sender.type), msg->sender.pid, msg->is_compressed,
              ais_data_len(msg), msg->header.size);

--- a/lib/cluster/legacy.c
+++ b/lib/cluster/legacy.c
@@ -754,7 +754,7 @@ check_message_sanity(const AIS_Message * msg, const char *data)
 
     } else {
         crm_trace
-            ("Verfied message %d: (dest=%s:%s, from=%s:%s.%d, compressed=%d, size=%d, total=%d)",
+            ("Verified message %d: (dest=%s:%s, from=%s:%s.%d, compressed=%d, size=%d, total=%d)",
              msg->id, ais_dest(&(msg->host)), msg_type2text(dest), ais_dest(&(msg->sender)),
              msg_type2text(msg->sender.type), msg->sender.pid, msg->is_compressed,
              ais_data_len(msg), msg->header.size);

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -906,12 +906,12 @@ crm_ipc_read(crm_ipc_t * client)
         }
 
         header = (struct crm_ipc_response_header *)client->buffer;
-        crm_trace("Recieved %s event %d, size=%d, rc=%d, text: %.100s",
+        crm_trace("Received %s event %d, size=%d, rc=%d, text: %.100s",
                   client->name, header->qb.id, header->qb.size, client->msg_size,
                   client->buffer + hdr_offset);
 
     } else {
-        crm_trace("No message from %s recieved: %s", client->name, pcmk_strerror(client->msg_size));
+        crm_trace("No message from %s received: %s", client->name, pcmk_strerror(client->msg_size));
     }
 
     if (crm_ipc_connected(client) == FALSE || client->msg_size == -ENOTCONN) {
@@ -1039,7 +1039,7 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
         crm_trace("Trying again to obtain pending reply from %s", client->name);
         rc = qb_ipcc_recv(client->ipc, client->buffer, client->buf_size, 300);
         if (rc < 0) {
-            crm_warn("Sending to %s (%p) is disabled until pending reply is recieved", client->name,
+            crm_warn("Sending to %s (%p) is disabled until pending reply is received", client->name,
                      client->ipc);
             return -EALREADY;
 
@@ -1100,7 +1100,7 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
     if (rc > 0) {
         struct crm_ipc_response_header *hdr = (struct crm_ipc_response_header *)client->buffer;
 
-        crm_trace("Recieved response %d, size=%d, rc=%ld, text: %.200s", hdr->qb.id, hdr->qb.size,
+        crm_trace("Received response %d, size=%d, rc=%ld, text: %.200s", hdr->qb.id, hdr->qb.size,
                   rc, crm_ipc_buffer(client));
 
         if (reply) {
@@ -1108,7 +1108,7 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
         }
 
     } else {
-        crm_trace("Response not recieved: rc=%ld, errno=%d", rc, errno);
+        crm_trace("Response not received: rc=%ld, errno=%d", rc, errno);
     }
 
   send_cleanup:

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2132,13 +2132,13 @@ stonith_send_command(stonith_t * stonith, const char *op, xmlNode * data, xmlNod
         }
 
     } else if (reply_id <= 0) {
-        crm_err("Recieved bad reply: No id set");
+        crm_err("Received bad reply: No id set");
         crm_log_xml_err(op_reply, "Bad reply");
         free_xml(op_reply);
         rc = -ENOMSG;
 
     } else {
-        crm_err("Recieved bad reply: %d (wanted %d)", reply_id, stonith->call_id);
+        crm_err("Received bad reply: %d (wanted %d)", reply_id, stonith->call_id);
         crm_log_xml_err(op_reply, "Old reply");
         free_xml(op_reply);
         rc = -ENOMSG;

--- a/mcp/pacemaker.c
+++ b/mcp/pacemaker.c
@@ -778,7 +778,7 @@ mcp_cpg_deliver(cpg_handle_t handle,
     xmlNode *xml = string2xml(msg);
     const char *task = crm_element_value(xml, F_CRM_TASK);
 
-    crm_trace("Recieved %s %.200s", task, msg);
+    crm_trace("Received %s %.200s", task, msg);
     if (task == NULL && nodeid != local_nodeid) {
         uint32_t procs = 0;
         const char *uname = crm_element_value(xml, "uname");

--- a/mcp/pacemaker.sysconfig
+++ b/mcp/pacemaker.sysconfig
@@ -45,7 +45,7 @@
 
 # Enable blackbox logging globally or per-subsystem
 # The blackbox contains a rolling buffer of all logs (including info+debug+trace)
-# and is written after a crash, assertion failure and/or when SIGTRAP is recieved
+# and is written after a crash, assertion failure and/or when SIGTRAP is received
 #
 # The blackbox recorder can also be enabled for Pacemaker daemons at runtime by sending SIGUSR1
 #

--- a/pengine/master.c
+++ b/pengine/master.c
@@ -408,7 +408,7 @@ filter_anonymous_instance(resource_t * rsc, node_t * node)
         resource_t *active = parent->fns->find_rsc(child, key, node, pe_find_clone|pe_find_current);
 
         /*
-         * Look for an active instance on $node, if there is one, only it recieves the master score
+         * Look for an active instance on $node, if there is one, only it receives the master score
          * Use ->find_rsc() because we might be a cloned group
          */
         if(rsc == active) {

--- a/xml/crm-1.0.dtd
+++ b/xml/crm-1.0.dtd
@@ -304,7 +304,7 @@ Using a cloned group is a much better way of achieving the same result.
 
  * notify
    If true, inform peers before and after any clone is stopped or started.
-   If an action failed, you will (currently) not recieve a post-notification.
+   If an action failed, you will (currently) not receive a post-notification.
    Instead you can next expect to see a pre-notification for a stop.
    If a stop fails, and you have fencing you will get a post-notification for the stop after the fencing operation has completed.
    In order to use the notification service ALL decendants of the clone MUST support the notify action.

--- a/xml/crm-transitional.dtd
+++ b/xml/crm-transitional.dtd
@@ -310,7 +310,7 @@ Using a cloned group is a much better way of achieving the same result.
 
  * notify
    If true, inform peers before and after any clone is stopped or started.
-   If an action failed, you will (currently) not recieve a post-notification.
+   If an action failed, you will (currently) not receive a post-notification.
    Instead you can next expect to see a pre-notification for a stop.
    If a stop fails, and you have fencing you will get a post-notification for the stop after the fencing operation has completed.
    In order to use the notification service ALL decendants of the clone MUST support the notify action.


### PR DESCRIPTION
I know this isn't high priority, but I noticed while reading my way through a bunch of trace logs. Can't hurt. Fixed the CTS patterns, too.
