### PR TITLE
don't start dlm if stonith-enabled is false

### DIFF
--- a/extra/resources/controld
+++ b/extra/resources/controld
@@ -127,6 +127,11 @@ controld_start() {
 	   fi
     	fi
 
+    if ! ocf_is_true "`crm_attribute --type=crm_config --name=stonith-enabled --query --quiet --default=true`";then
+        ocf_log err "stonith-enalbed should be true"
+        return $OCF_ERR_CONFIGURED
+    fi
+
     ${OCF_RESKEY_daemon} $OCF_RESKEY_args
 
     while true


### PR DESCRIPTION
DLM and all services depending on it such as cLVM2,GFS2 and OCFS2 will fail to work properly if stonith-enabled is "false". This patch will check whether this property is set true, otherwise fail to start dlm.
