### PR TITLE
Fix: On cluster signoff, make sure that the g_source gets disconnected.

### DIFF
--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -253,7 +253,7 @@ crm_cluster_disconnect(crm_cluster_t * cluster)
             return;
 
         } else if (cluster->hb_conn) {
-            cluster->hb_conn->llc_ops->signoff(cluster->hb_conn, FALSE);
+            cluster->hb_conn->llc_ops->signoff(cluster->hb_conn, TRUE);
             cluster->hb_conn = NULL;
             crm_info("Disconnected from %s", type_str);
             return;


### PR DESCRIPTION
With the FALSE value this didn't happen, and so spurious incoming events
could cause a segfault as the link is already destroyed, and so
s->hbchan->llc_ops in libhbclient would already be NULL but got
dereferenced.

Signed-off-by: Lars Ellenberg lars.ellenberg@linbit.com
