### PR TITLE
Fix: crm_resource: Wait for a reply for each request to crmd

### DIFF
--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -94,7 +94,6 @@ static void
 start_mainloop(void)
 {
     mainloop = g_main_new(FALSE);
-    crmd_replies_needed++;      /* The welcome message */
     fprintf(stderr, "Waiting for %d replies from the CRMd", crmd_replies_needed);
     crm_debug("Waiting for %d replies from the CRMd", crmd_replies_needed);
 
@@ -756,6 +755,7 @@ send_lrm_rsc_op(crm_ipc_t * crmd_channel, const char *op,
     free_xml(msg_data);
 
     if (crm_ipc_send(crmd_channel, cmd, 0, 0, NULL) > 0) {
+        crmd_replies_needed++;
         rc = 0;
 
     } else {
@@ -2134,6 +2134,7 @@ main(int argc, char **argv)
 
         crm_debug("Re-checking the state of all resources on %s", host_uname);
         if (crm_ipc_send(crmd_channel, cmd, 0, 0, NULL) > 0) {
+            crmd_replies_needed++;
             start_mainloop();
         }
 


### PR DESCRIPTION
Otherwise if it exits once it gets the first reply, the later requests will probably not be handled. For instance,  when we clean up all failed instances of a clone via a single crm_resource command, it appears that the later requests wont be able to reach crmd_ipc_dispatch().
