### PR TITLE
Fix: crm_master: Avoid sending redundant "--node" options to crm_attribute

### DIFF
--- a/tools/crm_master
+++ b/tools/crm_master
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+target=`crm_node -n`
+
 TEMP=`getopt -o qDGQVN:U:v:i:l:r: --long version,help,resource:,node:,uname:,attr-value:,id:,update:,delete-attr,get-value,attr-id:,lifetime:,quiet \
      -n 'crm_master' -- "$@"`
 
@@ -10,7 +12,8 @@ eval set -- "$TEMP"
 
 while true ; do
 	case "$1" in
-	    -N|--node|-U|--uname|-v|--attr-value|--update|-i|--id|--attr-id|-l|--lifetime) options="$options $1 $2"; shift; shift;;
+	    -N|--node|-U|--uname) target="$2"; shift; shift;;
+	    -v|--attr-value|--update|-i|--id|--attr-id|-l|--lifetime) options="$options $1 $2"; shift; shift;;
 	    -Q|-q|--quiet|-D|--delete-attr|-G|--get-value|-V) options="$options $1"; shift;;
 	    -r|--resource) OCF_RESOURCE_INSTANCE=$2; shift; shift;;
 	    --version) crm_attribute --version; exit 0;;
@@ -50,4 +53,4 @@ if [ -z "$OCF_RESOURCE_INSTANCE" ]; then
     exit 1
 fi
 
-crm_attribute -N `crm_node -n` -n master-$OCF_RESOURCE_INSTANCE $options
+crm_attribute -N $target -n master-$OCF_RESOURCE_INSTANCE $options


### PR DESCRIPTION
it's trivial, only for avoiding confusion on debugging
