### PR TITLE
On systems without tm_gmtoff use timezone considering that it returns th...

### DIFF
--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -53,7 +53,7 @@
 #  define GMTOFF(tm) ((tm)->tm_gmtoff)
 #else
 /* Note: extern variable; macro argument not actually used.  */
-#  define GMTOFF(tm) (timezone)
+#  define GMTOFF(tm) (-timezone+daylight)
 #endif
 
 struct crm_time_s {


### PR DESCRIPTION
...e gmt offset negated and without DST adjustment.

The "timezone" variable contains the GMT offset negated (with minus for east of GMT and plus for west of GMT) and it is not daylight saving time adjusted. This commit just adjusts the calculations so that the correct GMT/UTC offset is returned by GMTOFF(tm) when called.
