### PR TITLE
Fix: Fencing: Apply correct score to the resource of group

### DIFF
--- a/fencing/main.c
+++ b/fencing/main.c
@@ -580,6 +580,7 @@ static void cib_device_update(resource_t *rsc, pe_working_set_t *data_set)
     node_t *node = NULL;
     const char *value = NULL;
     const char *rclass = NULL;
+    node_t *parent = NULL;
 
     if(rsc->children) {
         GListPtr gIter = NULL;
@@ -619,6 +620,18 @@ static void cib_device_update(resource_t *rsc, pe_working_set_t *data_set)
         }
     }
 
+    if (rsc->parent && rsc->parent->variant == pe_group) {
+        GHashTableIter iter;
+
+        g_hash_table_iter_init(&iter, rsc->parent->allowed_nodes);
+        while (g_hash_table_iter_next(&iter, NULL, (void **)&parent)) {
+            if(parent && strcmp(parent->details->uname, stonith_our_uname) == 0) {
+                break;
+            }
+            parent = NULL;
+        }
+    }
+
     if(node == NULL) {
         GHashTableIter iter;
 
@@ -630,8 +643,8 @@ static void cib_device_update(resource_t *rsc, pe_working_set_t *data_set)
 
         return;
 
-    } else if(node->weight < 0) {
-        char *score = score2char(node->weight);
+    } else if(node->weight < 0 || (parent && parent->weight < 0)) {
+        char *score = score2char((node->weight < 0) ? node->weight : parent->weight);
 
         crm_info("Device %s has been disabled on %s: score=%s", rsc->id, stonith_our_uname, score);
         free(score);


### PR DESCRIPTION
This commit applies correct score, when choosing stonith device (resource) of **group** to fence.

```
group gStonith3 F1 F2

fencing_topology \
  vm3: F1 F2

primitive F1 stonith:external/libvirt \
  meta target-role="Stopped" \
  params hostlist="vm3" hypervisor_uri="qemu+ssh://bl460g1n6/system"

primitive F2 stonith:external/ssh \
  meta target-role="Stopped" \
  params hostlist="vm3"

location l1 gStonith3 \
  rule -inf: #uname eq vm1 \
  rule  100: #uname eq vm2 \
  rule -inf: #uname eq vm3
```

In the current implementation, **F2** on **vm1** may be chosen.

```
$ grep cib_device_update /var/log/ha-log
Nov  1 17:55:21 vm1 stonith-ng[7963]:     info: cib_device_update: Device F1 has been disabled on vm1: score=-INFINITY
Nov  1 17:55:21 vm1 stonith-ng[7963]:     info: cib_device_update: Device F2 is allowed on vm1: score=0

$ for i in vm{1..2};do ssh $i 'grep "log_operation: .* Performing.* reset" /var/log/ha-log';done | sort
Nov  1 17:56:13 vm2 stonith-ng[22156]:  warning: log_operation: F1:22258 [ Performing: stonith -t external/libvirt -T reset vm3 ]
Nov  1 17:56:51 vm2 stonith-ng[22156]:  warning: log_operation: F2:22508 [ Performing: stonith -t external/ssh -T reset vm3 ]
Nov  1 17:57:00 vm2 stonith-ng[22156]:  warning: log_operation: F1:22707 [ Performing: stonith -t external/libvirt -T reset vm3 ]
Nov  1 17:57:38 vm1 stonith-ng[7963]:  warning: log_operation: F2:8790 [ Performing: stonith -t external/ssh -T reset vm3 ]
Nov  1 17:57:47 vm2 stonith-ng[22156]:  warning: log_operation: F1:22973 [ Performing: stonith -t external/libvirt -T reset vm3 ]
Nov  1 17:58:25 vm2 stonith-ng[22156]:  warning: log_operation: F2:23185 [ Performing: stonith -t external/ssh -T reset vm3 ]
Nov  1 17:58:34 vm2 stonith-ng[22156]:  warning: log_operation: F1:23399 [ Performing: stonith -t external/libvirt -T reset vm3 ]
Nov  1 17:59:11 vm1 stonith-ng[7963]:  warning: log_operation: F2:9316 [ Performing: stonith -t external/ssh -T reset vm3 ]
```

If this commit is applied, **F2** on **vm1** will not be chosen.

```
$ grep cib_device_update /var/log/ha-log
Nov  1 18:03:37 vm1 stonith-ng[12755]:     info: cib_device_update: Device F1 has been disabled on vm1: score=-INFINITY
Nov  1 18:03:37 vm1 stonith-ng[12755]:     info: cib_device_update: Device F2 has been disabled on vm1: score=-INFINITY
```
