### PR TITLE
Fix: cluster/fencing: Fix the casts that would result in incorrect values for big-endian systems

### DIFF
--- a/fencing/remote.c
+++ b/fencing/remote.c
@@ -558,6 +558,7 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
 {
     remote_fencing_op_t *op = NULL;
     xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, request, LOG_TRACE);
+    int call_options = 0;
 
     if (remote_op_list == NULL) {
         remote_op_list = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free_remote_op);
@@ -612,7 +613,9 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
 
     op->target = crm_element_value_copy(dev, F_STONITH_TARGET);
     op->request = copy_xml(request);    /* TODO: Figure out how to avoid this */
-    crm_element_value_int(request, F_STONITH_CALLOPTS, (int *)&(op->call_options));
+    crm_element_value_int(request, F_STONITH_CALLOPTS, &call_options);
+    op->call_options = call_options;
+    
     crm_element_value_int(request, F_STONITH_CALLID, (int *)&(op->client_callid));
 
     crm_trace("%s new stonith op: %s - %s of %s for %s",

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -394,12 +394,14 @@ election_count_vote(election_t *e, xmlNode *vote, bool can_win)
     } else {
         struct timeval your_age;
         const char *your_version = crm_element_value(vote, F_CRM_VERSION);
+        int tv_sec = 0;
+        int tv_usec = 0;
 
-        your_age.tv_sec = 0;
-        your_age.tv_usec = 0;
+        crm_element_value_int(vote, F_CRM_ELECTION_AGE_S, &tv_sec);
+        crm_element_value_int(vote, F_CRM_ELECTION_AGE_US, &tv_usec);
 
-        crm_element_value_int(vote, F_CRM_ELECTION_AGE_S, (int *)&(your_age.tv_sec));
-        crm_element_value_int(vote, F_CRM_ELECTION_AGE_US, (int *)&(your_age.tv_usec));
+        your_age.tv_sec = tv_sec;
+        your_age.tv_usec = tv_usec;
 
         age = crm_compare_age(your_age);
         if(your_age.tv_sec == 0 && your_age.tv_usec == 0) {


### PR DESCRIPTION
In an s390x cluster, after the DC shuts down, the other node will go
into election loops. Because no one can win when comparing with the
incorrect huge age values of the other nodes.
