### PR TITLE
Fixed a problem that chkconfig has not been able to get a list correctly...

### DIFF
--- a/cts/CTSlab.py
+++ b/cts/CTSlab.py
@@ -561,7 +561,7 @@ if __name__ == '__main__':
             Environment["syslogd"] = rsh(discover, "systemctl list-units | grep syslog.*\.service.*active.*running | sed 's:.service.*::'", stdout=1).strip()
         else:
             # SYS-V
-            Environment["syslogd"] = rsh(discover, "chkconfig | grep syslog.*on | awk '{print $1}' | head -n 1", stdout=1).strip()
+            Environment["syslogd"] = rsh(discover, "chkconfig --list | grep syslog.*on | awk '{print $1}' | head -n 1", stdout=1).strip()
 
         if not Environment.has_key("syslogd") or not Environment["syslogd"]:
             # default
@@ -578,7 +578,7 @@ if __name__ == '__main__':
             atboot = atboot or not rsh(discover, "systemctl is-enabled pacemaker.service")
         else:
             # SYS-V
-            atboot = atboot or not rsh(discover, "chkconfig | grep -e corosync.*on -e heartbeat.*on -e pacemaker.*on")
+            atboot = atboot or not rsh(discover, "chkconfig --list | grep -e corosync.*on -e heartbeat.*on -e pacemaker.*on")
 
         Environment["at-boot"] = atboot
 


### PR DESCRIPTION
... in the environment of RHEL5.

chkconfig of RHEL5 cannot obtain the list of services, unless it attaches "--list".
In order to obtain the same result in RHEL6 and RHEL5, I want to fix it to use the "chkconfig --list".
