### PR TITLE
Fix: ipc: fix memory leak for failed ipc client connections.

### DIFF
--- a/attrd/legacy.c
+++ b/attrd/legacy.c
@@ -148,6 +148,10 @@ attrd_ipc_closed(qb_ipcs_connection_t * c)
 {
     crm_client_t *client = crm_client_get(c);
 
+    if (client == NULL) {
+        return 0;
+    }
+
     crm_trace("Connection %p", c);
     crm_client_destroy(client);
     return 0;
@@ -157,6 +161,7 @@ static void
 attrd_ipc_destroy(qb_ipcs_connection_t * c)
 {
     crm_trace("Connection %p", c);
+    attrd_ipc_closed(c);
 }
 
 struct qb_ipcs_service_handlers ipc_callbacks = {

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -232,6 +232,9 @@ static int32_t
 attrd_ipc_closed(qb_ipcs_connection_t * c)
 {
     crm_client_t *client = crm_client_get(c);
+    if (client == NULL) {
+        return 0;
+    }
 
     crm_trace("Connection %p", c);
     crm_client_destroy(client);
@@ -242,6 +245,7 @@ static void
 attrd_ipc_destroy(qb_ipcs_connection_t * c)
 {
     crm_trace("Connection %p", c);
+    attrd_ipc_closed(c);
 }
 
 struct qb_ipcs_service_handlers ipc_callbacks = {

--- a/cib/callbacks.c
+++ b/cib/callbacks.c
@@ -129,6 +129,9 @@ cib_ipc_closed(qb_ipcs_connection_t * c)
 {
     crm_client_t *client = crm_client_get(c);
 
+    if (client == NULL) {
+        return 0;
+    }
     crm_trace("Connection %p", c);
     crm_client_destroy(client);
     return 0;
@@ -138,6 +141,7 @@ static void
 cib_ipc_destroy(qb_ipcs_connection_t * c)
 {
     crm_trace("Connection %p", c);
+    cib_ipc_closed(c);
     if (cib_shutdown_flag) {
         cib_shutdown(0);
     }

--- a/crmd/control.c
+++ b/crmd/control.c
@@ -696,6 +696,10 @@ crmd_ipc_closed(qb_ipcs_connection_t * c)
     crm_client_t *client = crm_client_get(c);
     struct crm_subsystem_s *the_subsystem = NULL;
 
+    if (client == NULL) {
+        return 0;
+    }
+
     crm_trace("Connection %p", c);
 
     if (client->userdata == NULL) {
@@ -733,6 +737,7 @@ static void
 crmd_ipc_destroy(qb_ipcs_connection_t * c)
 {
     crm_trace("Connection %p", c);
+    crmd_ipc_closed(c);
 }
 
 /*	 A_STOP	*/

--- a/fencing/main.c
+++ b/fencing/main.c
@@ -143,6 +143,10 @@ st_ipc_closed(qb_ipcs_connection_t * c)
 {
     crm_client_t *client = crm_client_get(c);
 
+    if (client == NULL) {
+        return 0;
+    }
+
     crm_trace("Connection %p closed", c);
     crm_client_destroy(client);
 
@@ -154,6 +158,7 @@ static void
 st_ipc_destroy(qb_ipcs_connection_t * c)
 {
     crm_trace("Connection %p destroyed", c);
+    st_ipc_closed(c);
 }
 
 static void

--- a/lrmd/ipc_proxy.c
+++ b/lrmd/ipc_proxy.c
@@ -291,7 +291,13 @@ static int32_t
 ipc_proxy_closed(qb_ipcs_connection_t * c)
 {
     crm_client_t *client = crm_client_get(c);
-    crm_client_t *ipc_proxy = crm_client_get_by_id(client->userdata);
+    crm_client_t *ipc_proxy;
+
+    if (client == NULL) {
+        return 0;
+    }
+
+    ipc_proxy = crm_client_get_by_id(client->userdata);
 
     crm_trace("Connection %p", c);
 
@@ -315,6 +321,7 @@ static void
 ipc_proxy_destroy(qb_ipcs_connection_t * c)
 {
     crm_trace("Connection %p", c);
+    ipc_proxy_closed(c);
 }
 
 static struct qb_ipcs_service_handlers crmd_proxy_callbacks = {

--- a/lrmd/main.c
+++ b/lrmd/main.c
@@ -149,6 +149,10 @@ lrmd_ipc_closed(qb_ipcs_connection_t * c)
 {
     crm_client_t *client = crm_client_get(c);
 
+    if (client == NULL) {
+        return 0;
+    }
+
     crm_trace("Connection %p", c);
     client_disconnect_cleanup(client->id);
 #ifdef ENABLE_PCMK_REMOTE
@@ -161,6 +165,7 @@ lrmd_ipc_closed(qb_ipcs_connection_t * c)
 static void
 lrmd_ipc_destroy(qb_ipcs_connection_t * c)
 {
+    lrmd_ipc_closed(c);
     crm_trace("Connection %p", c);
 }
 

--- a/mcp/pacemaker.c
+++ b/mcp/pacemaker.c
@@ -498,6 +498,9 @@ pcmk_ipc_closed(qb_ipcs_connection_t * c)
 {
     crm_client_t *client = crm_client_get(c);
 
+    if (client == NULL) {
+        return 0;
+    }
     crm_trace("Connection %p", c);
     crm_client_destroy(client);
     return 0;
@@ -507,6 +510,7 @@ static void
 pcmk_ipc_destroy(qb_ipcs_connection_t * c)
 {
     crm_trace("Connection %p", c);
+    pcmk_ipc_closed(c);
 }
 
 struct qb_ipcs_service_handlers mcp_ipc_callbacks = {

--- a/pengine/main.c
+++ b/pengine/main.c
@@ -85,6 +85,9 @@ pe_ipc_closed(qb_ipcs_connection_t * c)
 {
     crm_client_t *client = crm_client_get(c);
 
+    if (client == NULL) {
+        return 0;
+    }
     crm_trace("Connection %p", c);
     crm_client_destroy(client);
     return 0;
@@ -94,6 +97,7 @@ static void
 pe_ipc_destroy(qb_ipcs_connection_t * c)
 {
     crm_trace("Connection %p", c);
+    pe_ipc_closed(c);
 }
 
 struct qb_ipcs_service_handlers ipc_callbacks = {


### PR DESCRIPTION
When pacemaker ipc servers accept client connections, client
state data is allocated when the libqb 'accept' callback function is
invoked.  It is possible however that even after the client
accepts the connection in the libqb 'accept' callback, the connection
could still fail to initialize fully if the client side hangs up.

Currently this results in the client state data never being
destroyed because the libqb "close" callback for client connection
is never invoked on the server side. Instead, libqb jumps directly to
the "destroy" callback because the connection never actually got created.

To account for this memory leak, pacemaker needs to verify client
state data is destroyed in the destroy callback.
