### PR TITLE
Medium: pengine: Correctly perform partial migrations when node's uname is not equal to the id.

### DIFF
--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2230,8 +2230,6 @@ unpack_rsc_migration(resource_t *rsc, node_t *node, xmlNode *xml_op, pe_working_
             }
 
         } else {    /* Pending or complete but erased */
-            node_t *target = pe_find_node_id(data_set->nodes, migrate_target);
-
             if (target && target->details->online) {
                 pe_rsc_trace(rsc, "Marking active on %s %p %d", migrate_target, target,
                              target->details->online);


### PR DESCRIPTION
This patch looks a little funny. The target is actually set correctly earlier in the function. All we have to do is remove the line that resets the target to the wrong thing. This bug is probably the result of some code refactoring.
