### PR TITLE
Low: crm_report: Force grep to interpret logs as text

### DIFF
--- a/tools/report.common.in
+++ b/tools/report.common.in
@@ -307,7 +307,7 @@ get_last_time() {
 }
 
 linetime() {
-    l=`tail -n +$2 $1 | grep ":[0-5][0-9]:" | head -1`
+    l=`tail -n +$2 $1 | grep -a ":[0-5][0-9]:" | head -1`
     format=`get_time_format_for_string $l`
     t=`echo $l | get_time_$format`
     get_time "$t"


### PR DESCRIPTION
If there are unprintable characters in a log line
(for example due to corruption), grep will try to
parse it as binary data. Adding -a forces grep to
interpret the log data as text.
