### PR TITLE
Feature: crm_mon: Display brief output if "-b/--brief" is supplied or 'b' is toggled

### DIFF
--- a/include/crm/pengine/common.h
+++ b/include/crm/pengine/common.h
@@ -97,6 +97,7 @@ enum pe_print_options {
 	pe_print_ops		= 0x0100,
 	pe_print_suppres_nl	= 0x0200,
 	pe_print_xml		= 0x0400,
+	pe_print_brief		= 0x0800,
 };
 /* *INDENT-ON* */
 

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -265,4 +265,7 @@ gboolean is_baremetal_remote_node(node_t *node);
 gboolean is_container_remote_node(node_t *node);
 gboolean is_remote_node(node_t *node);
 resource_t * rsc_contains_remote_node(pe_working_set_t * data_set, resource_t *rsc);
+
+void print_rscs_brief(GListPtr rsc_list, const char * pre_text, long options,
+                      void * print_data, gboolean print_all);
 #endif

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -168,15 +168,20 @@ group_print(resource_t * rsc, const char *pre_text, long options, void *print_da
         status_print("\n");
     }
 
-    for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+    if (options & pe_print_brief) {
+        print_rscs_brief(rsc->children, child_text, options, print_data, TRUE);
 
-        if (options & pe_print_html) {
-            status_print("<li>\n");
-        }
-        child_rsc->fns->print(child_rsc, child_text, options, print_data);
-        if (options & pe_print_html) {
-            status_print("</li>\n");
+    } else {
+        for (; gIter != NULL; gIter = gIter->next) {
+            resource_t *child_rsc = (resource_t *) gIter->data;
+
+            if (options & pe_print_html) {
+                status_print("<li>\n");
+            }
+            child_rsc->fns->print(child_rsc, child_text, options, print_data);
+            if (options & pe_print_html) {
+                status_print("</li>\n");
+            }
         }
     }
 


### PR DESCRIPTION
It's very helpful if there are many same types of resources.

If -b/--brief is supplied, the output is like:

6      (ocf::pacemaker:Dummy): Active node1

If -r/--inactive is also supplied:

6/10   (ocf::pacemaker:Dummy): Active node1
0/5    (ocf::heartbeat:Dummy): Active

Output for a group is like:
 Resource Group: group1
     18/20  (ocf::pacemaker:Dummy): Active node1
     12/15  (ocf::heartbeat:Dummy): Active node1

If -n/--group-by-node is also supplied, the output of the node is like:

Node node1: online
        24      (ocf::pacemaker:Dummy): Active
        12      (ocf::heartbeat:Dummy): Active
