### PR TITLE
Fix: pengine: Correctly search failcount

### DIFF
--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1410,7 +1410,7 @@ get_failcount_by_prefix(gpointer key_p, gpointer value, gpointer user_data)
 
     const char *match = strstr(key, search->key);
 
-    if (match) {
+    if (safe_str_eq((key+13), match)) {
         if (strstr(key, "last-failure-") == key && (key + 13) == match) {
             search->last = crm_int_helper(value, NULL);
 


### PR DESCRIPTION
This commit searches failcount of the resource correctly.

[ issue ]
Failure of **prm10** influenced **prm1**. (**prm1** stopped.)

```
property no-quorum-policy="ignore" stonith-enabled="false" startup-fencing="false"
rsc_defaults resource-stickiness="INFINITY" migration-threshold="1"

clone clone1 prm1
primitive prm1 ocf:pacemaker:Dummy op monitor interval="10s"
primitive prm10 ocf:pacemaker:Dummy op monitor interval="10s"
```

```
Full list of resources:

prm10   (ocf::pacemaker:Dummy): Started bl460g1n7
 Clone Set: clone1 [prm1]
     Started: [ bl460g1n7 ]
     Stopped: [ bl460g1n6 ]

Migration summary:
* Node bl460g1n6:
   prm10: migration-threshold=1 fail-count=1 last-failure='Fri Jan 24 14:27:33 2014'
   prm1: migration-threshold=1 fail-count=1 last-failure='Fri Jan 24 14:27:33 2014'
* Node bl460g1n7:

Failed actions:
    prm10_monitor_10000 on bl460g1n6 'not running' (7): call=13, status=complete, last-rc-change='Fri Jan 24 14:27:33 2014', queued=0ms, exec=0ms
```

```
Jan 24 14:27:33 bl460g1n6 crmd[4954]:  warning: update_failcount: Updating failcount for prm10 on bl460g1n6 after failed monitor: rc=7 (update=value++, time=1390541253)
 :
Jan 24 14:27:35 bl460g1n6 pengine[4953]:   notice: unpack_config: On loss of CCM Quorum: Ignore
Jan 24 14:27:35 bl460g1n6 pengine[4953]:     info: determine_online_status: Node bl460g1n6 is online
Jan 24 14:27:35 bl460g1n6 pengine[4953]:     info: determine_online_status: Node bl460g1n7 is online
Jan 24 14:27:35 bl460g1n6 pengine[4953]:  warning: unpack_rsc_op_failure: Processing failed op monitor for prm10 on bl460g1n6: not running (7)
Jan 24 14:27:35 bl460g1n6 pengine[4953]:     info: native_print: prm10  (ocf::pacemaker:Dummy): FAILED bl460g1n6
Jan 24 14:27:35 bl460g1n6 pengine[4953]:     info: clone_print:  Clone Set: clone1 [prm1]
Jan 24 14:27:35 bl460g1n6 pengine[4953]:     info: short_print:      Started: [ bl460g1n6 bl460g1n7 ]
Jan 24 14:27:35 bl460g1n6 pengine[4953]:     info: get_failcount_full: prm10 has failed 1 times on bl460g1n6
Jan 24 14:27:35 bl460g1n6 pengine[4953]:  warning: common_apply_stickiness: Forcing prm10 away from bl460g1n6 after 1 failures (max=1)
Jan 24 14:27:35 bl460g1n6 pengine[4953]:     info: get_failcount_full: clone1 has failed 1 times on bl460g1n6
Jan 24 14:27:35 bl460g1n6 pengine[4953]:  warning: common_apply_stickiness: Forcing clone1 away from bl460g1n6 after 1 failures (max=1)
Jan 24 14:27:35 bl460g1n6 pengine[4953]:     info: get_failcount_full: clone1 has failed 1 times on bl460g1n6
Jan 24 14:27:35 bl460g1n6 pengine[4953]:  warning: common_apply_stickiness: Forcing clone1 away from bl460g1n6 after 1 failures (max=1)
Jan 24 14:27:35 bl460g1n6 pengine[4953]:     info: native_color: Resource prm1:0 cannot run anywhere
Jan 24 14:27:35 bl460g1n6 pengine[4953]:     info: RecurringOp:  Start recurring monitor (10s) for prm10 on bl460g1n7
Jan 24 14:27:35 bl460g1n6 pengine[4953]:   notice: LogActions: Recover prm10    (Started bl460g1n6 -> bl460g1n7)
Jan 24 14:27:35 bl460g1n6 pengine[4953]:   notice: LogActions: Stop    prm1:0   (bl460g1n6)
Jan 24 14:27:35 bl460g1n6 pengine[4953]:     info: LogActions: Leave   prm1:1   (Started bl460g1n7)
Jan 24 14:27:35 bl460g1n6 pengine[4953]:   notice: process_pe_message: Calculated Transition 3: /var/lib/pacemaker/pengine/pe-input-3.bz2
Jan 24 14:42:35 bl460g1n6 pengine[4953]:   notice: unpack_config: On loss of CCM Quorum: Ignore
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: determine_online_status: Node bl460g1n6 is online
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: determine_online_status: Node bl460g1n7 is online
Jan 24 14:42:35 bl460g1n6 pengine[4953]:  warning: unpack_rsc_op_failure: Processing failed op monitor for prm10 on bl460g1n6: not running (7)
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: native_print: prm10  (ocf::pacemaker:Dummy): Started bl460g1n7
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: clone_print:  Clone Set: clone1 [prm1]
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: short_print:      Started: [ bl460g1n7 ]
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: short_print:      Stopped: [ bl460g1n6 ]
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: get_failcount_full: prm10 has failed 1 times on bl460g1n6
Jan 24 14:42:35 bl460g1n6 pengine[4953]:  warning: common_apply_stickiness: Forcing prm10 away from bl460g1n6 after 1 failures (max=1)
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: get_failcount_full: clone1 has failed 1 times on bl460g1n6
Jan 24 14:42:35 bl460g1n6 pengine[4953]:  warning: common_apply_stickiness: Forcing clone1 away from bl460g1n6 after 1 failures (max=1)
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: get_failcount_full: clone1 has failed 1 times on bl460g1n6
Jan 24 14:42:35 bl460g1n6 pengine[4953]:  warning: common_apply_stickiness: Forcing clone1 away from bl460g1n6 after 1 failures (max=1)
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: native_color: Resource prm1:1 cannot run anywhere
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: LogActions: Leave   prm10    (Started bl460g1n7)
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: LogActions: Leave   prm1:0   (Started bl460g1n7)
Jan 24 14:42:35 bl460g1n6 pengine[4953]:     info: LogActions: Leave   prm1:1   (Stopped)
```
