### PR TITLE
Build: Suppress -Wcast-align warnings/errors on arm and ppc64le

### DIFF
--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -894,7 +894,7 @@ crm_ipc_ready(crm_ipc_t * client)
 static int
 crm_ipc_decompress(crm_ipc_t * client)
 {
-    struct crm_ipc_response_header *header = (struct crm_ipc_response_header *)client->buffer;
+    struct crm_ipc_response_header *header = (struct crm_ipc_response_header *)(void *)client->buffer;
 
     if (header->size_compressed) {
         int rc = 0;
@@ -926,7 +926,7 @@ crm_ipc_decompress(crm_ipc_t * client)
         CRM_ASSERT(size_u == header->size_uncompressed);
 
         memcpy(uncompressed, client->buffer, hdr_offset);       /* Preserve the header */
-        header = (struct crm_ipc_response_header *)uncompressed;
+        header = (struct crm_ipc_response_header *)(void *)uncompressed;
 
         free(client->buffer);
         client->buf_size = new_buf_size;
@@ -957,7 +957,7 @@ crm_ipc_read(crm_ipc_t * client)
             return rc;
         }
 
-        header = (struct crm_ipc_response_header *)client->buffer;
+        header = (struct crm_ipc_response_header *)(void *)client->buffer;
         if(header->version > PCMK_IPC_VERSION) {
             crm_err("Filtering incompatible v%d IPC message, we only support versions <= %d",
                     header->version, PCMK_IPC_VERSION);
@@ -1044,7 +1044,7 @@ internal_ipc_get_reply(crm_ipc_t * client, int request_id, int ms_timeout)
                 return rc;
             }
 
-            hdr = (struct crm_ipc_response_header *)client->buffer;
+            hdr = (struct crm_ipc_response_header *)(void *)client->buffer;
             if (hdr->qb.id == request_id) {
                 /* Got it */
                 break;
@@ -1173,7 +1173,7 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
     }
 
     if (rc > 0) {
-        struct crm_ipc_response_header *hdr = (struct crm_ipc_response_header *)client->buffer;
+        struct crm_ipc_response_header *hdr = (struct crm_ipc_response_header *)(void *)client->buffer;
 
         crm_trace("Received response %d, size=%d, rc=%ld, text: %.200s", hdr->qb.id, hdr->qb.size,
                   rc, crm_ipc_buffer(client));

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -353,7 +353,7 @@ crm_remote_send(crm_remote_t * remote, xmlNode * msg)
     header->size_total = iov[0].iov_len + iov[1].iov_len;
 
     crm_trace("Sending len[0]=%d, start=%x\n",
-              (int)iov[0].iov_len, *(int*)xml_text);
+              (int)iov[0].iov_len, *(int*)(void *)xml_text);
     rc = crm_remote_sendv(remote, iov, 2);
     if (rc < 0) {
         crm_err("Failed to send remote msg, rc = %d", rc);
@@ -861,13 +861,13 @@ crm_remote_tcp_connect_async(const char *host, int port, int timeout,   /*ms */
 
         memset(buffer, 0, DIMOF(buffer));
         if (addr->sa_family == AF_INET6) {
-            struct sockaddr_in6 *addr_in = (struct sockaddr_in6 *)addr;
+            struct sockaddr_in6 *addr_in = (struct sockaddr_in6 *)(void *)addr;
 
             addr_in->sin6_port = htons(port);
             inet_ntop(addr->sa_family, &addr_in->sin6_addr, buffer, DIMOF(buffer));
 
         } else {
-            struct sockaddr_in *addr_in = (struct sockaddr_in *)addr;
+            struct sockaddr_in *addr_in = (struct sockaddr_in *)(void *)addr;
 
             addr_in->sin_port = htons(port);
             inet_ntop(addr->sa_family, &addr_in->sin_addr, buffer, DIMOF(buffer));

--- a/lrmd/tls_backend.c
+++ b/lrmd/tls_backend.c
@@ -264,11 +264,11 @@ bind_and_listen(struct addrinfo *addr)
     char buffer[256] = { 0, };
 
     if (addr->ai_family == AF_INET6) {
-        struct sockaddr_in6 *addr_in = (struct sockaddr_in6 *)addr->ai_addr;
+        struct sockaddr_in6 *addr_in = (struct sockaddr_in6 *)(void *)addr->ai_addr;
         inet_ntop(addr->ai_family, &addr_in->sin6_addr, buffer, DIMOF(buffer));
 
     } else {
-        struct sockaddr_in *addr_in = (struct sockaddr_in *)addr->ai_addr;
+        struct sockaddr_in *addr_in = (struct sockaddr_in *)(void *)addr->ai_addr;
         inet_ntop(addr->ai_family, &addr_in->sin_addr, buffer, DIMOF(buffer));
     }
 


### PR DESCRIPTION
We encountered more -Wcast-align warnings/errors like in https://github.com/ClusterLabs/pacemaker/pull/375 on arm and ppc64le. Does it make sense to suppress them like this?
