### PR TITLE
High: controld: handling startup fencing within the controld agent, not ...

### DIFF
--- a/extra/resources/controld
+++ b/extra/resources/controld
@@ -179,8 +179,8 @@ controld_start() {
         controld_monitor; rc=$?
         case $rc in
           $OCF_SUCCESS)
-            check_dir=/sys/kernel/config/dlm/cluster/comms
-            if grep 1 $check_dir/*/local >/dev/null 2>&1; then
+            local addr_list=$(cat /sys/kernel/config/dlm/cluster/comms/*/addr_list 2>/dev/null)
+            if [ $? -eq 0 ] && [ -n "$addr_list" ]; then
                 return $OCF_SUCCESS
             fi
             ;;


### PR DESCRIPTION
...the dlm

Resolves: rhbz#1064519
