### PR TITLE
Fix: memory leak found by valgrind was corrected.

### DIFF
--- a/cib/messages.c
+++ b/cib/messages.c
@@ -223,6 +223,8 @@ cib_process_ping(const char *op, int options, const char *section, xmlNode * req
 
     crm_info("Reporting our current digest to %s: %s (%d)", host, digest, cs && cs->targets);
 
+    free(digest);
+
     return pcmk_ok;
 #endif
 }

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -800,9 +800,10 @@ xml_create_patchset(int format, xmlNode *source, xmlNode *target, bool *config_c
     }
 
     if(patch && with_digest) {
-        const char *digest = calculate_xml_versioned_digest(target, FALSE, TRUE, version);
+        char *digest = calculate_xml_versioned_digest(target, FALSE, TRUE, version);
 
         crm_xml_add(patch, XML_ATTR_DIGEST, digest);
+        free(digest);
     }
     return patch;
 }
@@ -1355,7 +1356,9 @@ __xml_find_path(xmlNode *top, const char *key)
 
     free(remainder);
     free(current);
+    free(section);
     free(tag);
+    free(id);
     return target;
 }
 
@@ -1559,6 +1562,7 @@ xml_apply_patchset(xmlNode *xml, xmlNode *patchset, bool check_version)
             crm_trace("Digest matched: expected %s, calculated %s", digest, new_digest);
         }
         free(new_digest);
+        free(version);
     }
     free_xml(old);
     return rc;


### PR DESCRIPTION
The memory leak found by valgrind was corrected.

stonithd:
==19352== 12 bytes in 2 blocks are definitely lost in loss record 3 of 67
==19352==    at 0x4A069EE: malloc (vg_replace_malloc.c:270)
==19352==    by 0x3F92681041: strdup (in /lib64/libc-2.12.so)
==19352==    by 0x4C4E5F6: crm_element_value_copy (xml.c:2987)
==19352==    by 0x4C478E1: xml_apply_patchset (xml.c:1536)
==19352==    by 0x574BFA8: cib_process_diff (cib_ops.c:593)
==19352==    by 0x574FB41: cib_apply_patch_event (cib_utils.c:726)
==19352==    by 0x406608: update_cib_cache_cb (main.c:875)
==19352==    by 0x574F711: cib_native_notify (cib_utils.c:644)
==19352==    by 0x3F93A3688B: g_list_foreach (in /lib64/libglib-2.0.so.0.2200.5)
==19352==    by 0x5752624: cib_native_dispatch_internal (cib_native.c:123)
==19352==    by 0x4C60520: mainloop_gio_callback (mainloop.c:639)
==19352==    by 0x3F93A38F0D: g_main_context_dispatch (in /lib64/libglib-2.0.so.0.2200.5)
==19352==    by 0x3F93A3C937: ??? (in /lib64/libglib-2.0.so.0.2200.5)
==19352==    by 0x3F93A3CD54: g_main_loop_run (in /lib64/libglib-2.0.so.0.2200.5)
==19352==    by 0x4073AE: main (main.c:1237)

==19352== 2,125,824 bytes in 519 blocks are definitely lost in loss record 66 of 67
==19352==    at 0x4A069EE: malloc (vg_replace_malloc.c:270)
==19352==    by 0x4C46868: __xml_find_path (xml.c:1303)
==19352==    by 0x4C46E44: xml_apply_patchset_v2 (xml.c:1380)
==19352==    by 0x4C4788F: xml_apply_patchset (xml.c:1524)
==19352==    by 0x574BFA8: cib_process_diff (cib_ops.c:593)
==19352==    by 0x574FB41: cib_apply_patch_event (cib_utils.c:726)
==19352==    by 0x406608: update_cib_cache_cb (main.c:875)
==19352==    by 0x574F711: cib_native_notify (cib_utils.c:644)
==19352==    by 0x3F93A3688B: g_list_foreach (in /lib64/libglib-2.0.so.0.2200.5)
==19352==    by 0x5752624: cib_native_dispatch_internal (cib_native.c:123)
==19352==    by 0x4C60520: mainloop_gio_callback (mainloop.c:639)
==19352==    by 0x3F93A38F0D: g_main_context_dispatch (in /lib64/libglib-2.0.so.0.2200.5)
==19352==    by 0x3F93A3C937: ??? (in /lib64/libglib-2.0.so.0.2200.5)
==19352==    by 0x3F93A3CD54: g_main_loop_run (in /lib64/libglib-2.0.so.0.2200.5)
==19352==    by 0x4073AE: main (main.c:1237)

==19352== 2,134,016 bytes in 521 blocks are definitely lost in loss record 67 of 67
==19352==    at 0x4A069EE: malloc (vg_replace_malloc.c:270)
==19352==    by 0x4C4684C: __xml_find_path (xml.c:1301)
==19352==    by 0x4C46E44: xml_apply_patchset_v2 (xml.c:1380)
==19352==    by 0x4C4788F: xml_apply_patchset (xml.c:1524)
==19352==    by 0x574BFA8: cib_process_diff (cib_ops.c:593)
==19352==    by 0x574FB41: cib_apply_patch_event (cib_utils.c:726)
==19352==    by 0x406608: update_cib_cache_cb (main.c:875)
==19352==    by 0x574F711: cib_native_notify (cib_utils.c:644)
==19352==    by 0x3F93A3688B: g_list_foreach (in /lib64/libglib-2.0.so.0.2200.5)
==19352==    by 0x5752624: cib_native_dispatch_internal (cib_native.c:123)
==19352==    by 0x4C60520: mainloop_gio_callback (mainloop.c:639)
==19352==    by 0x3F93A38F0D: g_main_context_dispatch (in /lib64/libglib-2.0.so.0.2200.5)
==19352==    by 0x3F93A3C937: ??? (in /lib64/libglib-2.0.so.0.2200.5)
==19352==    by 0x3F93A3CD54: g_main_loop_run (in /lib64/libglib-2.0.so.0.2200.5)
==19352==    by 0x4073AE: main (main.c:1237)

cib:
==19351== 198 bytes in 6 blocks are definitely lost in loss record 71 of 81
==19351==    at 0x4A069EE: malloc (vg_replace_malloc.c:270)
==19351==    by 0x5069E82: crm_md5sum (utils.c:2409)
==19351==    by 0x507B47F: calculate_xml_digest_v2 (xml.c:4087)
==19351==    by 0x507B90E: calculate_xml_versioned_digest (xml.c:4145)
==19351==    by 0x40821D: cib_process_ping (messages.c:205)
==19351==    by 0x52ABDD0: cib_perform_op (cib_utils.c:322)
==19351==    by 0x40FD8E: cib_process_command (callbacks.c:1115)
==19351==    by 0x40F0EF: cib_process_request (callbacks.c:943)
==19351==    by 0x410C35: cib_peer_callback (callbacks.c:1365)
==19351==    by 0x411E67: cib_cs_dispatch (main.c:403)
==19351==    by 0x3E19401F2E: cpg_dispatch (cpg.c:423)
==19351==    by 0x4C3259D: pcmk_cpg_dispatch (cpg.c:215)
==19351==    by 0x50886B9: mainloop_gio_callback (mainloop.c:650)
==19351==    by 0x3F93A38F0D: g_main_context_dispatch (in /lib64/libglib-2.0.so.0.2200.5)
==19351==    by 0x3F93A3C937: ??? (in /lib64/libglib-2.0.so.0.2200.5)
==19351==    by 0x3F93A3CD54: g_main_loop_run (in /lib64/libglib-2.0.so.0.2200.5)
==19351==    by 0x4120E9: cib_init (main.c:552)
==19351==    by 0x411BD3: main (main.c:248)
