### PR TITLE
Low: lxc_autogen: Fix ram libvirt bug workaround now that libvirt packag...

### DIFF
--- a/cts/lxc_autogen.sh.in
+++ b/cts/lxc_autogen.sh.in
@@ -175,7 +175,7 @@ generate()
   <devices>
     <console type='pty'/>
     <filesystem type='ram'>
-        <source usage='154140672'/>
+        <source usage='150528'/>
         <target dir='/dev/shm'/>
     </filesystem>
     <filesystem type='mount'>


### PR DESCRIPTION
...es work
