### PR TITLE
Low: attrd: Increase log level of first update of attribute

### DIFF
--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -423,11 +423,7 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, bool filter)
     v = g_hash_table_lookup(a->values, host);
 
     if(v == NULL) {
-        crm_trace("Setting %s[%s] to %s from %s", attr, host, value, peer->uname);
         v = calloc(1, sizeof(attribute_value_t));
-        if(value) {
-            v->current = strdup(value);
-        }
         v->nodename = strdup(host);
         crm_element_value_int(xml, F_ATTRD_IS_REMOTE, &v->is_remote);
         g_hash_table_replace(a->values, v->nodename, v);
@@ -435,10 +431,9 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, bool filter)
         if (v->is_remote == TRUE) {
             crm_remote_peer_cache_add(host);
         }
+    }
 
-        changed = TRUE;
-
-    } else if(filter
+    if(filter
               && safe_str_neq(v->current, value)
               && safe_str_eq(host, attrd_cluster->uname)) {
         xmlNode *sync = create_xml_node(NULL, __FUNCTION__);


### PR DESCRIPTION
We are monitoring the log of change of specific attribute's value which ping RA etc. update.
Since the log of 'update' and 'delete' is LOG_INFO,

```
Feb 27 18:16:51 bl460g1n6 attrd[3885]:     info: attrd_peer_update: Setting pingd[bl460g1n6]: 100 -> 0 from bl460g1n6
Feb 27 18:16:58 bl460g1n6 attrd[3885]:     info: attrd_peer_update: Setting pingd[bl460g1n6]: 0 -> 100 from bl460g1n6
Feb 27 18:17:06 bl460g1n6 attrd[3885]:     info: attrd_peer_update: Setting pingd[bl460g1n6]: 100 -> (null) from bl460g1n6
```

We want log of 'first update' of LOG_INFO. By this patch, the log of 'first update' will be as follows.

```
Feb 27 18:16:33 bl460g1n6 attrd[3885]:     info: attrd_peer_update: Setting pingd[bl460g1n6]: (null) -> 100 from bl460g1n6
```
