### PR TITLE
Fix: cib: Do not disable cib disk writes if on-disk cib is corrupt

### DIFF
--- a/cib/io.c
+++ b/cib/io.c
@@ -195,6 +195,11 @@ validate_on_disk_cib(const char *filename, xmlNode ** on_disk_cib)
         char *sigfile = NULL;
         size_t fnsize;
 
+        if (buf.st_size == 0) {
+            crm_warn("Cluster configuration file %s is corrupt: size is zero", filename);
+            return TRUE;
+        }
+
         crm_trace("Reading cluster configuration from: %s", filename);
         root = filename2xml(filename);
 


### PR DESCRIPTION
I notice we do fflush() and fsync() when writing on-disk cib. But users have still encountered corrupt on-disk cib and digest files whose size are zero. Anyway, I think we should not disable cib disk writes in such case. Otherwise, users will never get the chance to recover cib.xml, and they could lose the up-to-date configuration if restarting cluster service.
