### PR TITLE
Low: stonithd: Decrease log level of monitor

### DIFF
--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -573,7 +573,8 @@ stonith_action_create(const char *agent,
     stonith_action_t *action;
 
     action = calloc(1, sizeof(stonith_action_t));
-    crm_info("Initiating action %s for agent %s (target=%s)", _action, agent, victim);
+    do_crm_log_unlikely(safe_str_eq(_action, "monitor") ? LOG_DEBUG : LOG_INFO,
+                        "Initiating action %s for agent %s (target=%s)", _action, agent, victim);
     action->args = make_args(_action, victim, victim_nodeid, device_args, port_map);
     action->agent = strdup(agent);
     action->action = strdup(_action);


### PR DESCRIPTION
This changes Log Level of a **monitor** of stonith resources to DEBUG, because that of monitor which lrmd performs is DEBUG. I think that log level of **monitor** of lrmd and stonithd should be unified.

Log level of the following messages will be set to DEBUG by this commit.

```
stonith-ng[22732]:     info: stonith_action_create: Initiating action monitor for agent fence_legacy (target=(null))
stonith-ng[22732]:     info: log_operation: F7:22809 [ Performing: stonith -t external/ipmi -S ]
stonith-ng[22732]:     info: log_operation: F7:22809 [ success:  0 ]
stonith-ng[22732]:     info: stonith_command: Processed st_execute from lrmd.22733: Operation now in progress (-115)
```
