### PR TITLE
Fix: get_cluster_type: failing concurrent tool invocations on heartbeat

### DIFF
--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -510,7 +510,17 @@ get_cluster_type(void)
         hb = (*new_cluster) ("heartbeat");
 
         crm_debug("Testing with Heartbeat");
-        if (hb->llc_ops->signon(hb, crm_system_name) == HA_OK) {
+        /*
+         * Test as "casual" client (clientid == NULL; will be replaced by
+         * current pid).  We are trying to detect if we can communicate with
+         * heartbeat, not if we can register as some specific service.
+         * Otherwise all but one of several concurrent invocations will get
+         * HA_FAIL because of:
+         * WARN: duplicate client add request
+         * ERROR: api_process_registration_msg: cannot add client()
+         * and then likely fail :(
+         */
+        if (hb->llc_ops->signon(hb, NULL) == HA_OK) {
             hb->llc_ops->signoff(hb, FALSE);
 
             cluster_type = pcmk_cluster_heartbeat;


### PR DESCRIPTION
When we try to guess the cluster type with a "trial registration"
to the heartbeat api, try to register as "casual" (anonymous) client.

If we try to register as "non-casual", or "named" client,
from the heartbeat API point of view, we try to register as
a specific service provider.  Heartbeat does not allow multiple
registrations of the same service provider.

That results in for example
  WARN: duplicate client add request [crm_node]
  ERROR: api_process_registration_msg: cannot add client()
and all but one concurrent invokations of some tool will fail.

This seems to have been broken for quite a while now.  But since it only
triggers for concurrent invocations of the same tool, no-one seems to
have noticed, or at least not reported.

There is a simple workaround: export HA_cluster_type=heartbeat
(which avoids this trial registration probing altogether)
