### PR TITLE
Low: lrmd: clean up the agent's entire process group

### DIFF
--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -878,7 +878,7 @@ child_free(mainloop_child_t *child)
 static int
 child_kill_helper(mainloop_child_t *child)
 {
-    if (kill(child->pid, SIGKILL) < 0) {
+    if (kill(-child->pid, SIGKILL) < 0) {
         crm_perror(LOG_ERR, "kill(%d, KILL) failed", child->pid);
         return -errno;
     }


### PR DESCRIPTION
Since agent will create a child process, a signal should be sent to process group.
