### PR TITLE
fix: pcs-crmsh-quick-ref.md: Constraints manipulation

### DIFF
--- a/doc/pcs-crmsh-quick-ref.md
+++ b/doc/pcs-crmsh-quick-ref.md
@@ -224,12 +224,16 @@ With roles:
 
     crmsh # crm resource move WebSite pcmk-1
     pcs   # pcs resource move WebSite pcmk-1
-    pcs   # pcs resource ban Website pcmk-1
     
     crmsh # crm resource unmove WebSite
     pcs   # pcs resource clear WebSite
 
-Remember that moving a resource set a stickyness to -INF until unmoved    
+A resource can also be moved away from a given node:
+
+    crmsh #
+    pcs   # pcs resource ban Website pcmk-2
+
+Remember that moving a resource sets a stickyness to -INF to a given node until unmoved    
 Also, pcs deals with constraints differently. These can be manipulated by the command above as well as the following and others
 
     crmsh #


### PR DESCRIPTION
Fixed the confusion and an error on constraints manipulation for resource migration
Also added a bit more info on pcs-specific way of dealing with constraints
