### PR TITLE
Med: crm_get_msec: prevent integer overflow + test

### DIFF
--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -766,6 +766,10 @@ crm_get_msec(const char *input)
     }
 
     msec = crm_int_helper(cp, &end_text);
+    if (msec > LLONG_MAX/multiplier) {
+        /* arithmetics overflow while multiplier/divisor mutually exclusive */
+        return LLONG_MAX;
+    }
     msec *= multiplier;
     msec /= divisor;
     /* dret += 0.5; */


### PR DESCRIPTION
Before (sizeof(long long) == 8):
input: 9223372036854775807s, output: -1000 (expected 9223372036854775807)
[...]

After:
input: 9223372036854775807s, output: 9223372036854775807
[...]

Signed-off-by: Jan Pokorný jpokorny@redhat.com
