### PR TITLE
crm_attribute: Default --lifetime to forever when using --node

### DIFF
--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -220,6 +220,10 @@ main(int argc, char **argv)
         return crm_exit(rc);
     }
 
+    if (type == NULL && dest_uname != NULL) {
+	    type = "forever";
+    }
+
     if (safe_str_eq(type, "reboot")) {
         type = XML_CIB_TAG_STATUS;
 


### PR DESCRIPTION
None of the examples using --node in the help text will succeed
since read_attr_delegate() is passed NULL as section and fails
on an assertion. section should be set using --lifetime to either
"reboot" or "forever". This patch makes --lifetime default to
"forever" if the value was not set explicitly.
