### PR TITLE
Log: corosync: Reduce log severity for a redundant message

### DIFF
--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -131,7 +131,7 @@ corosync_node_name(uint64_t /*cmap_handle_t */ cmap_handle, uint32_t nodeid)
     }
 
     if (name == NULL) {
-        crm_notice("Unable to get node name for nodeid %u", nodeid);
+        crm_info("Unable to get node name for nodeid %u", nodeid);
     }
     return name;
 }


### PR DESCRIPTION
The similar message will be logged in get_node_name()
