### PR TITLE
Fix: Don't use deprecated ifconfig in crm_report

### DIFF
--- a/tools/report.collector
+++ b/tools/report.collector
@@ -475,8 +475,7 @@ sys_stats() {
     ps axf
     ps auxw
     top -b -n 1
-    ifconfig -a
-    ip addr list
+    ip addr
     netstat -i
     arp -an
     test -d /proc && {


### PR DESCRIPTION
ifconfig has been deprecated since Linux 2.0, and doesn't display
long interface names correctly. With predictable interface names,
this becomes more of an issue. 'ip addr' shows the same information
but doesn't clip long interface names.

'ip addr list' can be shortened to 'ip addr'.
