### PR TITLE
Fix: crmd: make node_state erase correctly

### DIFF
--- a/crmd/te_actions.c
+++ b/crmd/te_actions.c
@@ -100,8 +100,8 @@ send_stonith_update(crm_action_t * action, const char *target, const char *uuid)
     /* Make sure it sticks */
     /* fsa_cib_conn->cmds->bump_epoch(fsa_cib_conn, cib_quorum_override|cib_scope_local);    */
 
-    erase_status_tag(target, XML_CIB_TAG_LRM, cib_scope_local);
-    erase_status_tag(target, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
+    erase_status_tag(peer->uname, XML_CIB_TAG_LRM, cib_scope_local);
+    erase_status_tag(peer->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
 
     free_xml(node_state);
     return;


### PR DESCRIPTION
This patch fixes the issue on which **guest02** of "UNCLEAN (offline)" state is not set to OFFLINE by 'stonith_admin -C **GUEST02**'.
- (1) STONITH failed

```
$ cat /var/log/ha-log
Mar 31 14:52:03 guest01 crmd[29181]:   notice: too_many_st_failures: Too many failures to fence guest02 (11), giving up
```
- (2) I stopped guest02, and performed stonith_admin.

```
$ crm_mon

Node guest02 (3232261520): UNCLEAN (offline)
Online: [ guest01 ]

```

```
$ stonith_admin -C GUEST02 ; echo $?
0

$ cat /var/log/ha-log
Mar 31 14:52:46 guest01 crmd[22906]:     info: erase_status_tag: Deleting xpath: //node_state[@uname='GUEST02']/lrm
Mar 31 14:52:46 guest01 crmd[22906]:     info: erase_status_tag: Deleting xpath: //node_state[@uname='GUEST02']/transient_attributes
```
- However, since crmd tried to erase "//node_state[@uname='**GUEST02**']" (xpath) at this time, node_state of **guest02** remains.

```
$ cibadmin -Q

  <node_state id="3232261520" uname="guest02" in_ccm="false" crmd="offline" crm-debug-origin="post_cache_update" join="member" expected="member">
    <transient_attributes id="3232261520">

```
