### PR TITLE
Fix: pengine: Correctly search failcount

### DIFF
--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1410,7 +1410,7 @@ get_failcount_by_prefix(gpointer key_p, gpointer value, gpointer user_data)
 
     const char *match = strstr(key, search->key);
 
-    if (match) {
+    if (safe_str_eq((key+13), match)) {
         if (strstr(key, "last-failure-") == key && (key + 13) == match) {
             search->last = crm_int_helper(value, NULL);
 


### PR DESCRIPTION
This request is instead of https://github.com/ClusterLabs/pacemaker/pull/420.
