### PR TITLE
Correction of the registration from a difference.

### DIFF
--- a/fencing/main.c
+++ b/fencing/main.c
@@ -906,10 +906,18 @@ update_fencing_topology(const char *event, xmlNode * msg)
         for (change = __xml_first_child(patchset); change != NULL; change = __xml_next(change)) {
             const char *op = crm_element_value(change, XML_DIFF_OP);
             const char *xpath = crm_element_value(change, XML_DIFF_PATH);
+            xmlNode *f_topology = get_message_xml(change, XML_TAG_FENCING_TOPOLOGY);
 
-            if(op == NULL || strstr(xpath, "/fencing-topology/") == NULL) {
+            if(op == NULL) {
                 continue;
-
+            } else if (strstr(xpath, "/cib/configuration") && f_topology != NULL) {
+                if(strcmp(op, "delete") == 0 || strcmp(op, "create") == 0) {
+                    crm_info("Re-initializing fencing topology after top-level %s operation", op);
+                    fencing_topology_init(NULL);
+                }
+                return;
+            } else if (strstr(xpath, "/fencing-topology/") == NULL) {
+                continue;
             } else if(strstr(xpath, "/fencing-level/") == NULL) {
                 if(strcmp(op, "delete") == 0 || strcmp(op, "create") == 0) {
                     crm_info("Re-initializing fencing topology after top-level %s operation", op);


### PR DESCRIPTION
Hi All,

Stonith-ng gets a wrong handling of notice of the difference from cib.
fencing_topology remains empty.
It is necessary to change a judgment.

``` xml
<diff format="2" digest="f6d707001c848aeda0064a0e4b9ed639">
  <version>
    <source admin_epoch="0" epoch="2" num_updates="7"/>
    <target admin_epoch="0" epoch="3" num_updates="0"/>
  </version>
(snip)
  <change operation="create" path="/cib/configuration" position="4">
    <fencing-topology>
      <fencing-level target="srv01" devices="prmStonith2-1" index="1" id="fencing"/>
      <fencing-level target="srv01" devices="prmStonith2-2" index="2" id="fencing-0"/>
      <fencing-level target="srv02" devices="prmStonith1-1" index="1" id="fencing-1"/>
      <fencing-level target="srv02" devices="prmStonith1-2" index="2" id="fencing-2"/>
    </fencing-topology>
  </change>
(snip)
</diff>
```

Best Regards,
Hideo Yamauchi.
