### PR TITLE
fixed so that change of <resources> could be handled correctly.

### DIFF
--- a/fencing/main.c
+++ b/fencing/main.c
@@ -752,7 +752,7 @@ update_cib_stonith_devices_v2(const char *event, xmlNode * msg)
             stonith_device_remove(rsc_id, TRUE);
             free(mutable);
 
-        } else if(strstr(xpath, XML_CIB_TAG_RESOURCES)) {
+        } else if(strstr(xpath, "/"XML_CIB_TAG_RESOURCES)) {
             shortpath = strrchr(xpath, '/'); CRM_ASSERT(shortpath);
             reason = g_strdup_printf("%s %s", op, shortpath+1);
             needs_update = TRUE;


### PR DESCRIPTION
In present code, whenever there is change of lrm_resources, re-registration of stonith device is performed.
Apr 16 14:37:29 [11075] vm01 stonith-ng: (      main.c:770   )    info: update_cib_stonith_devices_v2:  Updating device list from the cib: create lrm_resources

I think that it should be change of "resources" that update is originally performed.
