### PR TITLE
Low: fix small memory leaks

### DIFF
--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -161,7 +161,7 @@ create_attribute(xmlNode *xml)
 
     if(dampen > 0) {
         a->timeout_ms = dampen;
-        a->timer = mainloop_timer_add(strdup(a->id), a->timeout_ms, FALSE, attribute_timer_cb, a);
+        a->timer = mainloop_timer_add(a->id, a->timeout_ms, FALSE, attribute_timer_cb, a);
     }
 
     g_hash_table_replace(attributes, a->id, a);

--- a/fencing/main.c
+++ b/fencing/main.c
@@ -730,7 +730,7 @@ static void
 update_cib_stonith_devices_v2(const char *event, xmlNode * msg)
 {
     xmlNode *change = NULL;
-    const char *reason = NULL;
+    char *reason = NULL;
     bool needs_update = FALSE;
     xmlNode *patchset = get_message_xml(msg, F_CIB_UPDATE_RESULT);
 
@@ -772,6 +772,7 @@ update_cib_stonith_devices_v2(const char *event, xmlNode * msg)
         crm_info("Updating device list from the cib: %s", reason);
         cib_devices_update();
     }
+    free(reason);
 }
 
 


### PR DESCRIPTION
memory leaks found by valgrind

**attrd:**

```
==28833== 17 bytes in 1 blocks are definitely lost in loss record 17 of 66
==28833==    at 0x4A069EE: malloc (vg_replace_malloc.c:270)
==28833==    by 0x33DA481171: strdup (in /lib64/libc-2.12.so)
==28833==    by 0x40396E: create_attribute (commands.c:164)
==28833==    by 0x404AD1: attrd_peer_update (commands.c:420)
==28833==    by 0x404499: attrd_peer_message (commands.c:339)
==28833==    by 0x4023E7: attrd_cpg_dispatch (main.c:87)
==28833==    by 0x313E001F2E: cpg_dispatch (in /usr/lib64/libcpg.so.4.1.0)
==28833==    by 0x313F80C775: pcmk_cpg_dispatch (cpg.c:215)
==28833==    by 0x313D04194D: mainloop_gio_callback (mainloop.c:650)
==28833==    by 0x33DB83FEB1: g_main_context_dispatch (in /lib64/libglib-2.0.so.0.2600.1)
==28833==    by 0x33DB843D67: ??? (in /lib64/libglib-2.0.so.0.2600.1)
==28833==    by 0x33DB844274: g_main_loop_run (in /lib64/libglib-2.0.so.0.2600.1)
==28833==    by 0x403077: main (main.c:343)
```

**stonithd:**

```
==28831== 17 bytes in 1 blocks are definitely lost in loss record 35 of 170
==28831==    at 0x4A069EE: malloc (vg_replace_malloc.c:270)
==28831==    by 0x33DA502217: __vasprintf_chk (in /lib64/libc-2.12.so)
==28831==    by 0x33DB883D3A: g_vasprintf (in /lib64/libglib-2.0.so.0.2600.1)
==28831==    by 0x33DB861BCF: g_strdup_vprintf (in /lib64/libglib-2.0.so.0.2600.1)
==28831==    by 0x33DB861C6C: g_strdup_printf (in /lib64/libglib-2.0.so.0.2600.1)
==28831==    by 0x4063B5: update_cib_stonith_devices_v2 (main.c:759)
==28831==    by 0x40688D: update_cib_stonith_devices (main.c:852)
==28831==    by 0x4071F0: update_cib_cache_cb (main.c:1015)
==28831==    by 0x313E80CF3A: cib_native_notify (cib_utils.c:699)
==28831==    by 0x33DB83D6BB: g_list_foreach (in /lib64/libglib-2.0.so.0.2600.1)
==28831==    by 0x313E80FF1C: cib_native_dispatch_internal (cib_native.c:123)
==28831==    by 0x313D0417B4: mainloop_gio_callback (mainloop.c:639)
==28831==    by 0x33DB83FEB1: g_main_context_dispatch (in /lib64/libglib-2.0.so.0.2600.1)
==28831==    by 0x33DB843D67: ??? (in /lib64/libglib-2.0.so.0.2600.1)
==28831==    by 0x33DB844274: g_main_loop_run (in /lib64/libglib-2.0.so.0.2600.1)
==28831==    by 0x407DE1: main (main.c:1354)
```
