### PR TITLE
Low: using $(MAKE) variable, boost parallel build time

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,15 +42,15 @@ scratch_LDADD	= $(top_builddir)/lib/common/libcrmcommon.la -lm
 
 core:
 	@echo "Building only core components: $(CORE)"
-	list='$(CORE)'; for subdir in $$list; do echo "Building $$subdir"; make -C $$subdir all || exit 1; done
+	list='$(CORE)'; for subdir in $$list; do echo "Building $$subdir"; $(MAKE) -C $$subdir all || exit 1; done
 
 core-install:
 	@echo "Installing only core components: $(CORE)"
-	list='$(CORE)'; for subdir in $$list; do echo "Installing $$subdir"; make -C $$subdir install || exit 1; done
+	list='$(CORE)'; for subdir in $$list; do echo "Installing $$subdir"; $(MAKE) -C $$subdir install || exit 1; done
 
 core-clean:
 	@echo "Cleaning only core components: $(CORE)"
-	list='$(CORE)'; for subdir in $$list; do echo "Cleaning $$subdir"; make -C $$subdir clean || exit 1; done
+	list='$(CORE)'; for subdir in $$list; do echo "Cleaning $$subdir"; $(MAKE) -C $$subdir clean || exit 1; done
 
 install-exec-local:
 	$(INSTALL) -d $(DESTDIR)/$(LCRSODIR)


### PR DESCRIPTION
which can be easily around 50% or more, depending on the HW (here
i7-3520M) and the level of parallelism:

$ ./configure; make clean; make -j3
[...]
make[1]: warning: jobserver unavailable: using -j1.  Add `+' to parent
         make rule.
[...]
real        1m7.858s
user        0m58.931s
sys 0m5.991s

$ git am Low-using-MAKE-variable-boost-parallel-build-time.patch
$ ./configure; make clean; make -j3
[...]
real        0m36.716s
user        1m15.494s
sys 0m6.016s

$ git reset HEAD^; git checkout .
$ ./configure; make clean; make -j3
[...]
make[1]: warning: jobserver unavailable: using -j1.  Add `+' to parent
         make rule.
[...]
real        1m7.698s
user        0m58.568s
sys 0m6.183s

Signed-off-by: Jan Pokorný jpokorny@redhat.com
