### PR TITLE
Fix: membership: Avoid duplicate peer entries in the peer cache

### DIFF
--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -425,6 +425,23 @@ crm_get_peer(unsigned int id, const char *uname)
 
     node = crm_find_peer(id, uname);
 
+    /* if uname wasn't provided, and find_peer did not turn up a uname based on id.
+     * we need to do a lookup of the node name using the id in the cluster membership. */
+    if ((node == NULL || node->uname == NULL) && (uname == NULL)) { 
+        uname_lookup = get_node_name(id);
+    }
+
+    if (uname_lookup) {
+        crm_trace("Inferred a name of '%s' for node %u", uname, id);
+        uname = uname_lookup;
+
+        /* try to turn up the node one more time now that we know the uname. */
+        if (node == NULL) {
+            node = crm_find_peer(id, uname);
+        }
+    }
+
+
     if (node == NULL) {
         char *uniqueid = crm_generate_uuid();
 
@@ -434,12 +451,6 @@ crm_get_peer(unsigned int id, const char *uname)
         crm_info("Created entry %s/%p for node %s/%u (%d total)",
                  uniqueid, node, uname, id, 1 + g_hash_table_size(crm_peer_cache));
         g_hash_table_replace(crm_peer_cache, uniqueid, node);
-    }
-
-    if(id && uname == NULL && node->uname == NULL) {
-        uname_lookup = get_node_name(id);
-        uname = uname_lookup;
-        crm_trace("Inferred a name of '%s' for node %u", uname, id);
     }
 
     if(id > 0 && uname && (node->id == 0 || node->uname == NULL)) {


### PR DESCRIPTION
There's a condition that exists that makes it possible for two identical peer entries to make it into the cluster membership peer cache.

you'll see this in the logs

WARNING: Node rhel7-auto1 and rhel7-auto1 share the same cluster nodeid: 1

This occurs If crm_get_peer is called in this order with these parameters.
1. crm_get_peer with uname and no id
   this creates a peer entry with the uname
2. crm_get_peer with id only
   This creates a  new peer entry with the id, the uname is later looked up and set after the entry is stored.

At this point, we have two peer entries with the same uname, one with an id and one without.  To avoid this, we now search the peer cache using the uname we find doing the id to uname lookup when only an id is provided.

This is difficult to hit. A lot of things have to happen in the right order, and even after those things happen this might not cause a warning message if the hash table doesn't order the duplicate entries in a certain way.

so. to make this simple.

if crm_get_peer is only passed an ID, and there's no peer in the cache for that ID , we do the corosync ID to uname lookup and then check the cache for the uname too before going off and creating a new node entry.
