### PR TITLE
Use the print function instead of the print statement

### DIFF
--- a/cts/CIB.py
+++ b/cts/CIB.py
@@ -7,6 +7,7 @@ Copyright (C) 2008 Andrew Beekhof
 
 from UserDict import UserDict
 import sys, time, types, syslog, os, struct, string, signal, traceback, warnings, socket
+from __future__ import print_function
 
 from cts.CTSvars import *
 from cts.CTS     import ClusterManager
@@ -413,4 +414,4 @@ if __name__ == '__main__':
 
     CibFactory = ConfigFactory(manager)
     cib = CibFactory.createConfig("pacemaker-1.1")
-    print cib.contents()
+    print(cib.contents())

--- a/cts/CTS.py
+++ b/cts/CTS.py
@@ -32,6 +32,7 @@ from UserDict import UserDict
 from subprocess import Popen,PIPE
 from cts.CTSvars import *
 from threading import Thread
+from __future__ import print_function
 
 trace_rsh = None
 trace_lw = None
@@ -264,7 +265,7 @@ class CtsLab(UserDict):
                 try:
                     self.Nodes[node] = gethostbyname_ex(node)
                 except:
-                    print node+" not found in DNS... aborting"
+                    print(node+" not found in DNS... aborting")
                     raise
         #
         #        List of Logging Mechanism(s)
@@ -321,7 +322,7 @@ class CtsLab(UserDict):
                 self.rsh(host, '''bash %s %s delete''' % (log_stats_bin, log_stats_file))
 
                 fname = "cts-stats-%d-nodes-%s.csv" % (len(self["nodes"]), host)
-                print "Extracted stats: %s" % fname
+                print("Extracted stats: %s" % fname)
                 fd = open(fname, "a")
                 fd.writelines(lines)
                 fd.close()
@@ -484,13 +485,13 @@ class AsyncWaitProc(Thread):
 
     def log(self, args):
         if not self.Env:
-            print (args)
+            print(args)
         else:
             self.Env.log(args)
 
     def debug(self, args):
         if not self.Env:
-            print (args)
+            print(args)
         else:
             self.Env.debug(args)
     def run(self):
@@ -554,25 +555,25 @@ class RemoteExec:
         sysname = args[0]
         command = args[1]
 
-        #print "sysname: %s, us: %s" % (sysname, self.OurNode)
+        # print("sysname: %s, us: %s" % (sysname, self.OurNode))
         if sysname == None or string.lower(sysname) == self.OurNode or sysname == "localhost":
             ret = command
         else:
             ret = self.Command + " " + sysname + " '" + self._fixcmd(command) + "'"
-        #print ("About to run %s\n" % ret)
+        # print("About to run %s\n" % ret)
         return ret
 
     def log(self, args):
         if not self.silent:
             if not self.Env:
-                print (args)
+                print(args)
             else:
                 self.Env.log(args)
 
     def debug(self, args):
         if not self.silent:
             if not self.Env:
-                print (args)
+                print(args)
             else:
                 self.Env.debug(args)
 
@@ -690,7 +691,7 @@ for i in range(0, len(args)):
         skipthis=1
 
 if not os.access(filename, os.R_OK):
-    print prefix + 'Last read: %d, limit=%d, count=%d - unreadable' % (0, limit, 0)
+    print(prefix + 'Last read: %d, limit=%d, count=%d - unreadable' % (0, limit, 0))
     sys.exit(1)
 
 logfile=open(filename, 'r')
@@ -702,7 +703,7 @@ if offset != 'EOF':
     if newsize >= offset:
         logfile.seek(offset)
     else:
-        print prefix + ('File truncated from %d to %d' % (offset, newsize))
+        print(prefix + ('File truncated from %d to %d' % (offset, newsize)))
         if (newsize*1.05) < offset:
             logfile.seek(0)
         # else: we probably just lost a few logs after a fencing op
@@ -720,10 +721,10 @@ while True:
     line = logfile.readline()
     if not line: break
 
-    print line.strip()
+    print(line.strip())
     count += 1
 
-print prefix + 'Last read: %d, limit=%d, count=%d' % (logfile.tell(), limit, count)
+print(prefix + 'Last read: %d, limit=%d, count=%d' % (logfile.tell(), limit, count))
 logfile.close()
 """
 
@@ -749,14 +750,14 @@ class SearchObj:
     def log(self, args):
         message = "lw: %s: %s" % (self, args)
         if not self.Env:
-            print (message)
+            print(message)
         else:
             self.Env.log(message)
 
     def debug(self, args):
         message = "lw: %s: %s" % (self, args)
         if not self.Env:
-            print (message)
+            print(message)
         else:
             self.Env.debug(message)
 
@@ -890,7 +891,7 @@ class LogWatcher(RemoteExec):
     def debug(self, args):
         message = "lw: %s: %s" % (self.name, args)
         if not self.Env:
-            print (message)
+            print(message)
         else:
             self.Env.debug(message)
 

--- a/cts/CTSlab.py
+++ b/cts/CTSlab.py
@@ -25,6 +25,7 @@ Licensed under the GNU GPL.
 
 from UserDict import UserDict
 import sys, types, string, string, signal, os, socket
+from __future__ import print_function
 
 pdir = os.path.dirname(sys.path[0])
 sys.path.insert(0, pdir) # So that things work from the source directory
@@ -116,51 +117,51 @@ class LabEnvironment(CtsLab):
 
 
 def usage(arg, status=1):
-    print "Illegal argument " + arg
-    print "usage: " + sys.argv[0] + " [options] number-of-iterations"
-    print "\nCommon options: "
-    print "\t [--nodes 'node list']        list of cluster nodes separated by whitespace"
-    print "\t [--group | -g 'name']        use the nodes listed in the named DSH group (~/.dsh/groups/$name)"
-    print "\t [--limit-nodes max]          only use the first 'max' cluster nodes supplied with --nodes"
-    print "\t [--stack (v0|v1|cman|corosync|heartbeat|openais)]    which cluster stack is installed"
-    print "\t [--list-tests]               list the valid tests"
-    print "\t [--benchmark]                add the timing information"
-    print "\t "
-    print "Options that CTS will usually auto-detect correctly: "
-    print "\t [--logfile path]             where should the test software look for logs from cluster nodes"
-    print "\t [--syslog-facility name]     which syslog facility should the test software log to"
-    print "\t [--at-boot (1|0)]            does the cluster software start at boot time"
-    print "\t [--test-ip-base ip]          offset for generated IP address resources"
-    print "\t "
-    print "Options for release testing: "
-    print "\t [--populate-resources | -r]  generate a sample configuration"
-    print "\t [--choose name]              run only the named test"
-    print "\t [--stonith (1 | 0 | yes | no | rhcs | ssh)]"
-    print "\t [--once]                     run all valid tests once"
-    print "\t "
-    print "Additional (less common) options: "
-    print "\t [--clobber-cib | -c ]        erase any existing configuration"
-    print "\t [--outputfile path]          optional location for the test software to write logs to"
-    print "\t [--trunc]                    truncate logfile before starting"
-    print "\t [--xmit-loss lost-rate(0.0-1.0)]"
-    print "\t [--recv-loss lost-rate(0.0-1.0)]"
-    print "\t [--standby (1 | 0 | yes | no)]"
-    print "\t [--fencing (1 | 0 | yes | no | rhcs | lha | openstack )]"
-    print "\t [--stonith-type type]"
-    print "\t [--stonith-args name=value]"
-    print "\t [--bsc]"
-    print "\t [--no-loop-tests]            dont run looping/time-based tests"
-    print "\t [--no-unsafe-tests]          dont run tests that are unsafe for use with ocfs2/drbd"
-    print "\t [--valgrind-tests]           include tests using valgrind"
-    print "\t [--experimental-tests]       include experimental tests"
-    print "\t [--container-tests]          include pacemaker_remote tests that run in lxc container resources"
-    print "\t [--oprofile 'node list']     list of cluster nodes to run oprofile on]"
-    print "\t [--qarsh]                    use the QARSH backdoor to access nodes instead of SSH"
-    print "\t [--seed random_seed]"
-    print "\t [--set option=value]"
-    print "\t "
-    print "\t Example: "
-    print "\t    python ./CTSlab.py -g virt1 --stack cs -r --stonith ssh --schema pacemaker-1.0 500"
+    print("Illegal argument " + arg)
+    print("usage: " + sys.argv[0] + " [options] number-of-iterations")
+    print("\nCommon options: ")
+    print("\t [--nodes 'node list']        list of cluster nodes separated by whitespace")
+    print("\t [--group | -g 'name']        use the nodes listed in the named DSH group (~/.dsh/groups/$name)")
+    print("\t [--limit-nodes max]          only use the first 'max' cluster nodes supplied with --nodes")
+    print("\t [--stack (v0|v1|cman|corosync|heartbeat|openais)]    which cluster stack is installed")
+    print("\t [--list-tests]               list the valid tests")
+    print("\t [--benchmark]                add the timing information")
+    print("\t ")
+    print("Options that CTS will usually auto-detect correctly: ")
+    print("\t [--logfile path]             where should the test software look for logs from cluster nodes")
+    print("\t [--syslog-facility name]     which syslog facility should the test software log to")
+    print("\t [--at-boot (1|0)]            does the cluster software start at boot time")
+    print("\t [--test-ip-base ip]          offset for generated IP address resources")
+    print("\t ")
+    print("Options for release testing: ")
+    print("\t [--populate-resources | -r]  generate a sample configuration")
+    print("\t [--choose name]              run only the named test")
+    print("\t [--stonith (1 | 0 | yes | no | rhcs | ssh)]")
+    print("\t [--once]                     run all valid tests once")
+    print("\t ")
+    print("Additional (less common) options: ")
+    print("\t [--clobber-cib | -c ]        erase any existing configuration")
+    print("\t [--outputfile path]          optional location for the test software to write logs to")
+    print("\t [--trunc]                    truncate logfile before starting")
+    print("\t [--xmit-loss lost-rate(0.0-1.0)]")
+    print("\t [--recv-loss lost-rate(0.0-1.0)]")
+    print("\t [--standby (1 | 0 | yes | no)]")
+    print("\t [--fencing (1 | 0 | yes | no | rhcs | lha | openstack )]")
+    print("\t [--stonith-type type]")
+    print("\t [--stonith-args name=value]")
+    print("\t [--bsc]")
+    print("\t [--no-loop-tests]            dont run looping/time-based tests")
+    print("\t [--no-unsafe-tests]          dont run tests that are unsafe for use with ocfs2/drbd")
+    print("\t [--valgrind-tests]           include tests using valgrind")
+    print("\t [--experimental-tests]       include experimental tests")
+    print("\t [--container-tests]          include pacemaker_remote tests that run in lxc container resources")
+    print("\t [--oprofile 'node list']     list of cluster nodes to run oprofile on]")
+    print("\t [--qarsh]                    use the QARSH backdoor to access nodes instead of SSH")
+    print("\t [--seed random_seed]")
+    print("\t [--set option=value]")
+    print("\t ")
+    print("\t Example: ")
+    print("\t    python ./CTSlab.py -g virt1 --stack cs -r --stonith ssh --schema pacemaker-1.0 500")
 
     sys.exit(status)
 
@@ -275,7 +276,7 @@ if __name__ == '__main__':
                Environment["DoStonith"] = 1
                Environment["stonith-type"] = "fence_openstack"
 
-               print "Obtaining OpenStack credentials from the current environment"
+               print("Obtaining OpenStack credentials from the current environment")
                Environment["stonith-params"] = "region=%s,tenant=%s,auth=%s,user=%s,password=%s" % (
                    os.environ['OS_REGION_NAME'],
                    os.environ['OS_TENANT_NAME'],
@@ -288,7 +289,7 @@ if __name__ == '__main__':
                Environment["DoStonith"] = 1
                Environment["stonith-type"] = "fence_rhevm"
 
-               print "Obtaining RHEV-M credentials from the current environment"
+               print("Obtaining RHEV-M credentials from the current environment")
                Environment["stonith-params"] = "login=%s,passwd=%s,ipaddr=%s,ipport=%s,ssl=1,shell_timeout=10" % (
                    os.environ['RHEVM_USERNAME'],
                    os.environ['RHEVM_PASSWORD'],
@@ -327,7 +328,7 @@ if __name__ == '__main__':
            try:
                float(args[i+1])
            except ValueError:
-               print ("--xmit-loss parameter should be float")
+               print("--xmit-loss parameter should be float")
                usage(args[i+1])
            skipthis = 1
            Environment["XmitLoss"] = args[i+1]
@@ -336,7 +337,7 @@ if __name__ == '__main__':
            try:
                float(args[i+1])
            except ValueError:
-               print ("--recv-loss parameter should be float")
+               print("--recv-loss parameter should be float")
                usage(args[i+1])
            skipthis = 1
            Environment["RecvLoss"] = args[i+1]
@@ -387,7 +388,7 @@ if __name__ == '__main__':
                Environment["DoStonith"] = 1
                Environment["stonith-type"] = "fence_rhevm"
 
-               print "Obtaining RHEV-M credentials from the current environment"
+               print("Obtaining RHEV-M credentials from the current environment")
                Environment["stonith-params"] = "login=%s,passwd=%s,ipaddr=%s,ipport=%s,ssl=1,shell_timeout=10" % (
                    os.environ['RHEVM_USERNAME'],
                    os.environ['RHEVM_PASSWORD'],
@@ -485,7 +486,7 @@ if __name__ == '__main__':
            skipthis = 1
            (name, value) = args[i+1].split('=')
            Environment[name] = value
-           print "Setting %s = %s" % (name, value)
+           print("Setting %s = %s" % (name, value))
 
        elif args[i] == "--":
            break
@@ -540,11 +541,11 @@ if __name__ == '__main__':
         Environment["use_logd"] = 0
 
     else:
-        print "Unknown stack: "+Environment["Stack"]
+        print("Unknown stack: "+Environment["Stack"])
         sys.exit(1)
 
     if len(node_list) < 1:
-        print "No nodes specified!"
+        print("No nodes specified!")
         sys.exit(1)
 
     if LimitNodes > 0:

--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -43,6 +43,7 @@ from stat import *
 from cts import CTS
 from cts.CTSaudits import *
 from cts.CTSvars   import *
+from __future__ import print_function
 
 AllTestClasses = [ ]
 
@@ -2277,7 +2278,7 @@ class BSC_AddResource(CTSTest):
         if ":" in ip:
             fields = ip.rpartition(":")
             fields[2] = str(hex(int(fields[2], 16)+1))
-            print str(hex(int(f[2], 16)+1))
+            print(str(hex(int(f[2], 16)+1)))
         else:
             fields = ip.rpartition('.')
             fields[2] = str(int(fields[2])+1)

--- a/cts/OCFIPraTest.py
+++ b/cts/OCFIPraTest.py
@@ -25,16 +25,13 @@ Licensed under the GNU GPL.
 
 import string,sys,struct,os,random,time,syslog
 from cts.CTSvars import *
+from __future__ import print_function
 
 
 def usage():
-    print "usage: " + sys.argv[0]  \
-    +  " [-2]"\
-    +  " [--ipbase|-i first-test-ip]"\
-    +  " [--ipnum|-n test-ip-num]"\
-    +  " [--help|-h]"\
-    +  " [--perform|-p op]"\
-    +  " [number-of-iterations]"
+    print("usage: %s [-2] [--ipbase|-i first-test-ip] [--ipnum|-n test-ip-num]"
+          " [--help|-h] [--perform|-p op] [number-of-iterations]"
+          % sys.argv[0])
     sys.exit(1)
 
 
@@ -71,7 +68,7 @@ def log(towrite):
     t = time.strftime("%Y/%m/%d_%H:%M:%S\t", time.localtime(time.time()))  
     logstr = t + " "+str(towrite)
     syslog.syslog(logstr)
-    print logstr
+    print(logstr)
 
 if __name__ == '__main__': 
     ra = "IPaddr"


### PR DESCRIPTION
The print statement has been replaced with a print() function,
with keyword arguments to replace most of the special syntax of
the old print statement (PEP 3105)
- http://docs.python.org/3.0/whatsnew/3.0.html
- http://legacy.python.org/dev/peps/pep-3105/
