### PR TITLE
Low: mcp: Add config example to exert watchdog of corosync

### DIFF
--- a/mcp/pacemaker.combined.upstart.in
+++ b/mcp/pacemaker.combined.upstart.in
@@ -47,6 +47,10 @@ post-stop script
     [ -z "$LOCK_FILE" -a -d @sysconfdir@/default ] && LOCK_FILE="$deb_lockfile"
     rm -f $LOCK_FILE
     rm -f @localstatedir@/run/$prog.pid
+
+    # if you use watchdog of corosync, uncomment the line below.
+    #pidof corosync || false
+
     pidof crmd || stop corosync
 
     # if you want to reboot a machine by watchdog of corosync when


### PR DESCRIPTION
This request adds the config example that a watchdog of corosync works.

When pacemaker.combined (Upstart job) is used, watchdog of corosync does not work even if corosync process is terminated abnormally.
It's because pacemakerd is also terminated when corosync has terminated, so [restart](https://github.com/ClusterLabs/pacemaker/blob/d924912/mcp/pacemaker.combined.upstart.in#L6) of pacemakerd and [corosync](https://github.com/ClusterLabs/pacemaker/blob/d924912/mcp/pacemaker.combined.upstart.in#L24) is performed by Upstart.

```
$ initctl start pacemaker.combined
pacemaker.combined start/running, process 4711
$ ps -ef|egrep "coros|pacem"
root      4696     1  2 17:24 ?        00:00:00 corosync
root      4711     1  0 17:24 ?        00:00:00 pacemakerd
496       4715  4711  0 17:24 ?        00:00:00 /usr/libexec/pacemaker/cib
root      4716  4711  0 17:24 ?        00:00:00 /usr/libexec/pacemaker/stonithd
root      4717  4711  0 17:24 ?        00:00:00 /usr/libexec/pacemaker/lrmd
496       4718  4711  0 17:24 ?        00:00:00 /usr/libexec/pacemaker/attrd
496       4719  4711  0 17:24 ?        00:00:00 /usr/libexec/pacemaker/pengine
$ pkill -9 corosync
$ ps -ef|egrep "coros|pacem"
root      4717     1  0 17:24 ?        00:00:00 /usr/libexec/pacemaker/lrmd
496       4719     1  0 17:24 ?        00:00:00 /usr/libexec/pacemaker/pengine
root      4749     1  3 17:25 ?        00:00:00 corosync
root      4760     1  0 17:26 ?        00:00:00 pacemakerd
496       4764  4760  0 17:26 ?        00:00:00 /usr/libexec/pacemaker/cib
root      4765  4760  0 17:26 ?        00:00:00 /usr/libexec/pacemaker/stonithd
496       4766  4760  0 17:26 ?        00:00:00 /usr/libexec/pacemaker/attrd
496       4767  4760  0 17:26 ?        00:00:00 /usr/libexec/pacemaker/crmd
```

If corosync is terminated abnormally, I want to reboot a machine by watchdog, but cannot invalidate "respawn" stanza because I want to restart pacemakerd when pacemakerd is terminated abnormally.
