### PR TITLE
 Fix: cluster: Prevent search of unames from attempting to create node entries for unknown nodes

### DIFF
--- a/crmd/te_utils.c
+++ b/crmd/te_utils.c
@@ -518,7 +518,7 @@ abort_transition_graph(int abort_priority, enum transition_action abort_action,
             const char *uname = crm_peer_uname(ID(reason));
 
             do_crm_log(level, "Transition aborted by %s '%s' on %s: %s (cib=%d.%d.%d, source=%s:%d, %d)",
-                       kind, op, uname, abort_text,
+                       kind, op, uname ? uname : ID(reason), abort_text,
                        add[0], add[1], add[2], fn, line, transition_graph->complete);
 
         } else {

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -382,10 +382,10 @@ crm_peer_uname(const char *uuid)
         if (uname_is_uuid() == FALSE && is_corosync_cluster()) {
             uint32_t id = crm_int_helper(uuid, NULL);
 
-            node = crm_get_peer(id, NULL);
+            node = crm_find_peer(id, NULL);
 
         } else {
-            node = crm_get_peer(0, uuid);
+            node = crm_find_peer(0, uuid);
         }
 
         if (node) {


### PR DESCRIPTION
When removing an offline node with "crm_node --remove",  the corresponding "node_state" will be deleted from cib, which will trigger the following in  te_legacy_update_diff():
abort_transition(INFINITY, tg_restart, "Transient attribute: removal", aborted);

Though  it'll add the removed node back into the node cache due to:
const char *uname = crm_peer_uname(ID(reason));
