### PR TITLE
Reduce the log when pacemakerd is run on command.

### DIFF
--- a/mcp/pacemaker.c
+++ b/mcp/pacemaker.c
@@ -848,7 +848,7 @@ main(int argc, char **argv)
     set_daemon_option("mcp", "true");
     set_daemon_option("use_logd", "off");
 
-    crm_log_init(NULL, LOG_INFO, TRUE, FALSE, argc, argv, FALSE);
+    crm_log_init(NULL, LOG_NOTICE, TRUE, FALSE, argc, argv, FALSE);
     crm_set_options(NULL, "mode [options]", long_options, "Start/Stop Pacemaker\n");
 
     /* Restore the original facility so that mcp_read_config() does the right thing */
@@ -896,6 +896,8 @@ main(int argc, char **argv)
     if (argerr) {
         crm_help('?', EX_USAGE);
     }
+
+    set_crm_log_level(LOG_INFO);
 
     crm_debug("Checking for old instances of %s", CRM_SYSTEM_MCP);
     old_instance = crm_ipc_new(CRM_SYSTEM_MCP, 0);


### PR DESCRIPTION
Hi, Andrew

I made the cluster which manages the replication of pgsql.
We are setting logpriority to "info", in order to obtain a log required for systems operation.
The log of the following whenever monitor of pgsql resource agent is performed is outputted.

Jun 12 18:17:49 vm01 pacemakerd[20636]:     info: crm_log_init: Changed active directory to /var/lib/heartbeat/cores/root
Jun 12 18:17:49 vm01 pacemakerd[20636]:     info: crm_xml_cleanup: Cleaning up memory from libxml2
Jun 12 18:18:00 vm01 pacemakerd[20793]:     info: crm_log_init: Changed active directory to /var/lib/heartbeat/cores/root
Jun 12 18:18:00 vm01 pacemakerd[20793]:     info: crm_xml_cleanup: Cleaning up memory from libxml2
Jun 12 18:18:12 vm01 pacemakerd[20931]:     info: crm_log_init: Changed active directory to /var/lib/heartbeat/cores/root
Jun 12 18:18:12 vm01 pacemakerd[20931]:     info: crm_xml_cleanup: Cleaning up memory from libxml2
Jun 12 18:18:23 vm01 pacemakerd[21088]:     info: crm_log_init: Changed active directory to /var/lib/heartbeat/cores/root
Jun 12 18:18:23 vm01 pacemakerd[21088]:     info: crm_xml_cleanup: Cleaning up memory from libxml2
Jun 12 18:18:34 vm01 pacemakerd[21249]:     info: crm_log_init: Changed active directory to /var/lib/heartbeat/cores/root
Jun 12 18:18:34 vm01 pacemakerd[21249]:     info: crm_xml_cleanup: Cleaning up memory from libxml2

Since "pacemakerd -$" is performed within pgsql resource agent, this is outputted.
Correction was created in order to hide these logs. 
If there is no problem in particular, I will want you to merge this correction.
