### PR TITLE
Fix: xml: Prevent incorrect xml diffs from corrupting the cib

### DIFF
--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -4485,6 +4485,7 @@ subtract_xml_object(xmlNode * parent, xmlNode * left, xmlNode * right,
 
     name = crm_element_name(left);
     CRM_CHECK(name != NULL, return NULL);
+    CRM_CHECK(safe_str_eq(crm_element_name(left), crm_element_name(right)), return NULL);
 
     /* check for XML_DIFF_MARKER in a child */
     value = crm_element_value(right, XML_DIFF_MARKER);
@@ -4690,6 +4691,8 @@ add_xml_object(xmlNode * parent, xmlNode * target, xmlNode * update, gboolean as
                   crm_str(object_name), object_id ? " id=" : "", object_id ? object_id : "");
 #endif
     }
+
+    CRM_CHECK(safe_str_eq(crm_element_name(target), crm_element_name(update)), return 0);
 
     if (as_diff == FALSE) {
         /* So that expand_plus_plus() gets called */


### PR DESCRIPTION
This is found on v1.1.11 by developer's experiment:

cibadmin --query -o resources > cib-old.xml
cibadmin --query -o resources > cib-new.xml
vim cib-new.xml  # change Started to Stopped

Generate patch:
crm_diff --original cib-old.xml --new cib-new.xml > cib-diff.xml

Resulting patch:

```
# cat cib-diff.xml 
<diff crm_feature_set="3.0.8">
  <diff-removed>
    <resources>
      <group id="gp">
        <meta_attributes id="gp-meta_attributes">
          <nvpair value="Started" id="gp-meta_attributes-target-role"/>
        </meta_attributes>
      </group>
    </resources>
  </diff-removed>
  <diff-added>
    <resources>
      <group id="gp">
        <meta_attributes id="gp-meta_attributes">
          <nvpair id="gp-meta_attributes-target-role" name="target-role"
value="Stopped"/>
        </meta_attributes>
      </group>
    </resources>
  </diff-added>
</diff>
```

Applying this patch succeeds:

```
# cibadmin --patch --scope resources --xml-file cib-diff.xml
# echo #?
0
```

But the resulting CIB is broken: The patch has been applied on the root "cib" tag:

```
# cibadmin -Q --xpath "/cib/group"
<group id="gp">
  <meta_attributes id="gp-meta_attributes">
    <nvpair id="gp-meta_attributes-target-role" name="target-role"
value="Stopped"/>
  </meta_attributes>
</group>
```

-- We should prevent incorrect xml diffs from corrupting the cib. As we know,  in v1.1.12, it starts using xml_apply_patchset_() and ____xml_object() functions for applying cib diffs -- the functions are safe in this case. While it seems to still make sense to add these for subtract_xml_object() and add_xml_object().
