### PR TITLE
Test:cts: fix shutdown pattern not found issue

### DIFF
--- a/cts/CM_ais.py
+++ b/cts/CM_ais.py
@@ -139,7 +139,7 @@ class crm_mcp(crm_cs_v0):
         if self.Env["have_systemd"]:
             self.update({
                 # When systemd is in use, we can look for this instead
-                "Pat:We_stopped"   : "%s.*Stopped Corosync Cluster Engine",
+                "Pat:We_stopped"   : "%s.*Corosync Cluster Engine exiting normally",
             })
 
 


### PR DESCRIPTION
Systemd add patch to honour the kernel's quiet cmdline argument,
so the old message will not be output.

See http://cgit.freedesktop.org/systemd/systemd/commit/?id=e683212f049ac5d3f95fb17300cfa2fd971f78f3
