### PR TITLE
Test:cts: fix RemoteBaremetal step2 move resource action failed issue

### DIFF
--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -2748,11 +2748,26 @@ class RemoteBaremetal(CTSTest):
         self.add_primitive_rsc(node)
         # this crm_resource command actually occurs on the remote node
         # which verifies that the ipc proxy works
-        rc = self.rsh(node, "crm_resource -M -r remote1-rsc -N %s" % (self.remote_node))
+        time.sleep(1)
+
+        (rc, lines) = self.rsh(node, "crm_resource -W -r remote1-rsc --quiet", None)
         if rc != 0:
-            self.fail_string = "Failed to place primitive on remote-node"
+            self.fail_string = "Failed to get location of resource remote1-rsc"
             self.failed = 1
             return
+
+        find = 0
+        for line in lines:
+            if self.remote_node in line.split():
+                find = 1
+                break
+
+        if find == 0:
+            rc = self.rsh(node, "crm_resource -M -r remote1-rsc -N %s" % (self.remote_node))
+            if rc != 0:
+                self.fail_string = "Failed to place primitive on remote-node"
+                self.failed = 1
+                return
 
         self.set_timer("remoteMetalRsc")
         watch.lookforall()


### PR DESCRIPTION
Move resource remote1-rsc action maybe failed for it has been started after added to remote node 
