### PR TITLE
cman_pre_start fixes

### DIFF
--- a/mcp/pacemaker.in
+++ b/mcp/pacemaker.in
@@ -130,7 +130,7 @@ cman_pre_start()
     fi
 
     # start cman's friends if they're not running but were configured to start automatically
-    for cservice in clvmd cmirror gfs2; do
+    for cservice in cmirrord clvmd gfs2; do
 	chkconfig --list $cservice 2>/dev/null | grep -q ":on"
 	if [ $? -eq 0 ]; then
 	    service $cservice status >/dev/null 2>&1


### PR DESCRIPTION
cmirror is in fact cmirrord and needs to be started before clvmd
