### PR TITLE
Low: services: restore SIGPIPE default behavior for child processes

### DIFF
--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -435,6 +435,14 @@ services_os_action_execute(svc_action_t * op, gboolean synchronous)
                 return FALSE;
             }
         case 0:                /* Child */
+
+        /* SIGPIPE is ignored (which is different from signal blocking) by the gnutls library.
+         * Depending on the libqb version in use, libqb may set SIGPIPE to be ignored as well. 
+         * We do not want this to be inherited by the child process. By resetting this the signal
+         * to the default behavior, we avoid some potential odd problems that occur during OCF
+         * scripts when SIGPIPE is ignored by the environment. */
+        signal(SIGPIPE, SIG_DFL);
+
 #if defined(HAVE_SCHED_SETSCHEDULER)
             if (sched_getscheduler(0) != SCHED_OTHER) {
                 struct sched_param sp;


### PR DESCRIPTION
Commands in OCF scripts behave slightly differently when SIGPIPE
is ignored versus when SIGPIPE is handled by the default behavior.
It is best to launch OCF scripts without SIGPIPE being ignored
by the environment, and let the scripts themselves handle SIGPIPE
however they want.
