### PR TITLE
Fix: logging: correctly initialized default log file

### DIFF
--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -249,7 +249,7 @@ crm_add_logfile(const char *filename)
     }
 
     if(is_default && default_fd >= 0) {
-        return FALSE;           /* Nothing to do */
+        return TRUE;           /* Nothing to do */
     }
 
     /* Check the parent directory */


### PR DESCRIPTION
We were accidentally disabling the initialization of the default /var/log/pacemaker.log configuration file when no PCMK_debugfile environment variable was present.

Some code in mcp checks the return code of crm_add_logfile(). If we happened to call that function twice with no argument (happens when no corosync config or pacemaker log file is specified) it looks like  the logfile fails to be added the second time.  mcp interprets this as an error and disables the logfile.

simple fix. explains the errors i encountered during fedora 20 testing a few weeks ago.
