### PR TITLE
Low: mcp: set environment variable which the cluster-glue module needs

### DIFF
--- a/mcp/corosync.c
+++ b/mcp/corosync.c
@@ -451,6 +451,12 @@ mcp_read_config(void)
         free(syslog_facility);
     }
 
+    const_value = daemon_option("logfacility");
+    if (const_value) {
+        /* cluster-glue module needs HA_LOGFACILITY */
+        setenv("HA_LOGFACILITY", const_value, 1);
+    }
+
 #if HAVE_CONFDB
     confdb_finalize(config);
 #elif HAVE_CMAP


### PR DESCRIPTION
Since a setup of HA_LOGFACILITY (https://github.com/ClusterLabs/pacemaker/commit/663ce49, https://github.com/ClusterLabs/pacemaker/commit/4682632) was erased by https://github.com/ClusterLabs/pacemaker/commit/b3b5a57, the log of cluster-glue stonith plugin is not outputted to target specified by PCMK_logfacility.
