### PR TITLE
Test : cts : change default cluster stack from openais to corosync

### DIFF
--- a/cts/environment.py
+++ b/cts/environment.py
@@ -56,7 +56,7 @@ class Environment:
         self["SyslogFacility"] = "daemon"
         self["LogFileName"] = "/var/log/messages"
         self["Schema"] = "pacemaker-2.0"
-        self["Stack"] = "openais"
+        self["Stack"] = "corosync"
         self["stonith-type"] = "external/ssh"
         self["stonith-params"] = "hostlist=all,livedangerously=yes"
         self["loop-minutes"] = 60


### PR DESCRIPTION
Change default cluster stack to "corosync" so that cluster stack could be set properly in the case of --stack parameters are not specified.
