### PR TITLE
High: crmd: Fixes crash when remote connection migration fails

### DIFF
--- a/crmd/remote_lrmd_ra.c
+++ b/crmd/remote_lrmd_ra.c
@@ -251,6 +251,8 @@ connection_takeover_timeout_cb(gpointer data)
     crm_debug("takeover event timed out for node %s", cmd->rsc_id);
     cmd->takeover_timeout_id = 0;
 
+    lrm_state = lrm_state_find(cmd->rsc_id);
+
     handle_remote_ra_stop(lrm_state, cmd);
     free_cmd(cmd);
 


### PR DESCRIPTION
baremetal remote-node connection resources migrate by default now. This lets the connection resources float around the cluster without requiring resources on the remote-node to stop before the connection can relocate... If however the migration fails, the crmd crashes. This patch resolves that issue.
