### PR TITLE
Fixes to the ping RA (bnc#899324)

### DIFF
--- a/extra/resources/ping
+++ b/extra/resources/ping
@@ -93,7 +93,7 @@ The list of ping nodes to count.
 Number of ping attempts, per host, before declaring it dead
 </longdesc>
 <shortdesc lang="en">no. of ping attempts</shortdesc>
-<content type="integer" default="2"/>
+<content type="integer" default="3"/>
 </parameter>
 
 <parameter name="timeout" unique="0">


### PR DESCRIPTION
- Correctly advertise multiplier default in metadata
- Correct attempts default value in metadata
- Add use_fping parameter (default to true) which allows disabling use of fping
- Remove incorrectly advertised migrate_to|migrate_from from metadata
- Pass extra options to fping as well
