### PR TITLE
mainloop: fix potential segfault for fd = 0

### DIFF
--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -799,7 +799,7 @@ mainloop_add_fd(const char *name, int priority, int fd, void *userdata,
 {
     mainloop_io_t *client = NULL;
 
-    if (fd > 0) {
+    if (fd >= 0) {
         client = calloc(1, sizeof(mainloop_io_t));
         client->name = strdup(name);
         client->userdata = userdata;


### PR DESCRIPTION
Some monitoring software may explicitly _close_ stdin,
(not just redirect from /dev/null).

That led to segfault, because the next allocated new fd would be 0,
mainloop_add_fd would return NULL (and the caller would not check).

Reproduce:
    crm_mon -1 <&-

Since 0 is a legal value for fd, allow it in mainloop_add_fd, too.
