### PR TITLE
Fix: xml: Prevent assert errors in crm_element_value() on applying a patch without version information

### DIFF
--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1950,9 +1950,11 @@ bool xml_patch_versions(xmlNode *patchset, int add[3], int del[3])
             return -EINVAL;
     }
 
-    for(lpc = 0; lpc < DIMOF(vfields); lpc++) {
-        crm_element_value_int(tmp, vfields[lpc], &(del[lpc]));
-        crm_trace("Got %d for del[%s]", del[lpc], vfields[lpc]);
+    if (tmp) {
+        for(lpc = 0; lpc < DIMOF(vfields); lpc++) {
+            crm_element_value_int(tmp, vfields[lpc], &(del[lpc]));
+            crm_trace("Got %d for del[%s]", del[lpc], vfields[lpc]);
+        }
     }
 
     switch(format) {
@@ -1973,9 +1975,11 @@ bool xml_patch_versions(xmlNode *patchset, int add[3], int del[3])
             return -EINVAL;
     }
 
-    for(lpc = 0; lpc < DIMOF(vfields); lpc++) {
-        crm_element_value_int(tmp, vfields[lpc], &(add[lpc]));
-        crm_trace("Got %d for add[%s]", add[lpc], vfields[lpc]);
+    if (tmp) {
+        for(lpc = 0; lpc < DIMOF(vfields); lpc++) {
+            crm_element_value_int(tmp, vfields[lpc], &(add[lpc]));
+            crm_trace("Got %d for add[%s]", add[lpc], vfields[lpc]);
+        }
     }
 
     return pcmk_ok;


### PR DESCRIPTION
If the patch is generated with "crm_diff --no-version/-u".
