### PR TITLE
Low: build: Add ability to set custom spec version for 'make rpm'

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -58,6 +58,8 @@ BUILD_COUNTER	?= build.counter
 LAST_COUNT      = $(shell test ! -e $(BUILD_COUNTER) && echo 0; test -e $(BUILD_COUNTER) && cat $(BUILD_COUNTER))
 COUNT           = $(shell expr 1 + $(LAST_COUNT))
 
+SPECVERSION	?= $(COUNT)
+
 init:
 	./autogen.sh
 
@@ -144,7 +146,7 @@ srpm-%:	export $(PACKAGE)-%.spec
 	if [ -e $(BUILD_COUNTER) ]; then					\
 		echo $(COUNT) > $(BUILD_COUNTER);				\
 	fi
-	sed -i 's/global\ specversion.*/global\ specversion\ $(COUNT)/' $(PACKAGE).spec
+	sed -i 's/global\ specversion.*/global\ specversion\ $(SPECVERSION)/' $(PACKAGE).spec
 	sed -i 's/global\ commit.*/global\ commit\ $(TAG)/' $(PACKAGE).spec
 	case "$(WITH)" in 	\
 	  *pre_release*)	\


### PR DESCRIPTION
I want to be able to set the spec version manually when running 'make rpm'
