### PR TITLE
Feature: crm_resource: Implement resource reload command

### DIFF
--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -73,6 +73,7 @@ int cli_resource_fail(crm_ipc_t * crmd_channel, const char *host_uname, const ch
 int cli_resource_search(const char *rsc, pe_working_set_t * data_set);
 int cli_resource_delete(cib_t *cib_conn, crm_ipc_t * crmd_channel, const char *host_uname, resource_t * rsc, pe_working_set_t * data_set);
 int cli_resource_restart(resource_t * rsc, const char *host, int timeout_ms, cib_t * cib);
+int cli_resource_reload(resource_t * rsc, node_t * node, cib_t * cib_conn);
 int cli_resource_move(const char *rsc_id, const char *host_name, cib_t * cib, pe_working_set_t *data_set);
 int cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *override_hash, cib_t * cib, pe_working_set_t *data_set);
 


### PR DESCRIPTION
For resource reload, it's done by tickling the "op-digest" of the "last_0" lrm_rsc_op where the resource is running. And tickling "op-restart-digest" for resource restart.

-- I was about to push this. But suddenly i saw : https://github.com/beekhof/pacemaker/commit/aa12ff6f946f1cfd4cf28a5e1cdc84dd000ec5af

Anyway, please take a look. We'd still need the reload command ;-)
