### PR TITLE
Low: doc: Make Clusters from Scratch compile correctly

### DIFF
--- a/doc/Clusters_from_Scratch/en-US/Ch-Apache.txt
+++ b/doc/Clusters_from_Scratch/en-US/Ch-Apache.txt
@@ -125,7 +125,7 @@ it fails, the resource agent used by Pacemaker assumes the server-status
 URL is available. Look for the following in '/etc/httpd/conf/httpd.conf'
 and make sure it is not disabled or commented out:
 
-[source,Apache Configuration]
+[source,C]
 -----
 <Location /server-status>
    SetHandler server-status


### PR DESCRIPTION
This has been driving me crazy for months. Something was making CFS not compile in centos 7. I figured it out. CFS fails to compile because there is no source syntax called 'Apache Configuration'. Perhaps publican/asciidoc packages didn't start complaining about this until centos7.
