### PR TITLE
Fix: xml: Do not prune leaves from v1 cib diffs that are being created with digests

### DIFF
--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1439,9 +1439,9 @@ xml_repair_v1_diff(xmlNode * last, xmlNode * next, xmlNode * local_diff, gboolea
 }
 
 static xmlNode *
-xml_create_patchset_v1(xmlNode *source, xmlNode *target, bool config)
+xml_create_patchset_v1(xmlNode *source, xmlNode *target, bool config, bool with_digest)
 {
-    xmlNode *patchset = diff_xml_object(source, target, TRUE);
+    xmlNode *patchset = diff_xml_object(source, target, !with_digest);
 
     if(patchset) {
         CRM_LOG_ASSERT(xml_document_dirty(target));
@@ -1573,8 +1573,8 @@ xml_create_patchset(int format, xmlNode *source, xmlNode *target, bool *config_c
 
     switch(format) {
         case 1:
-            patch = xml_create_patchset_v1(source, target, config);
             with_digest = TRUE;
+            patch = xml_create_patchset_v1(source, target, config, with_digest);
             break;
         case 2:
             patch = xml_create_patchset_v2(source, target);


### PR DESCRIPTION
In lib/cib/cib_utils.c: cib_perform_op(), we validate the created local_diff: 
    test_rc = xml_apply_patchset(c, local_diff, manage_counters);

But if the diff was created with digest, we should not prune leaves from it. Otherwise, the validation in cib_perform_op() would fail.