### PR TITLE
Fix: Build: respect ncurses lib flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -899,14 +899,16 @@ dnl Although n-library is preferred, only look for it if the n-header was found.
 CURSESLIBS=''
 if test "$ac_cv_header_ncurses_h" = "yes"; then
   AC_CHECK_LIB(ncurses, printw,
-    [CURSESLIBS='-lncurses'; AC_DEFINE(HAVE_LIBNCURSES,1, have ncurses library)]
+    [AC_DEFINE(HAVE_LIBNCURSES,1, have ncurses library)]
   )
+  CURSESLIBS=`$PKGCONFIG --libs ncurses`;
 fi
 
 if test "$ac_cv_header_ncurses_ncurses_h" = "yes"; then
   AC_CHECK_LIB(ncurses, printw,
-    [CURSESLIBS='-lncurses'; AC_DEFINE(HAVE_LIBNCURSES,1, have ncurses library)]
+    [AC_DEFINE(HAVE_LIBNCURSES,1, have ncurses library)]
   )
+  CURSESLIBS=`$PKGCONFIG --libs ncurses`;
 fi
 
 dnl Only look for non-n-library if there was no n-library.


### PR DESCRIPTION
Configure should detect ncurses' link flags and respect them to avoid compilation failure.

I used pkg-config to do so, maybe there may be a less ugly way but it works.

More info : https://bugs.gentoo.org/show_bug.cgi?id=526770