### PR TITLE
Memory leak of pacemakerd.

### DIFF
--- a/mcp/pacemaker.c
+++ b/mcp/pacemaker.c
@@ -828,6 +828,10 @@ mcp_cpg_deliver(cpg_handle_t handle,
         name = crm_element_value(xml, XML_ATTR_UNAME);
         reap_crm_member(id, name);
     }
+
+    if (xml != NULL) {
+        free_xml(xml);
+    }
 }
 
 static void


### PR DESCRIPTION
Whenever a node to constitute a cluster repeats start and a stop,
Pacemakerd of the node not to stop leaks out memory.