### PR TITLE
Minor tweaks to gitignore/README/CFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ include/config.h
 include/config.h.in
 include/crm_config.h
 lrmd/pacemaker_remote
+lrmd/pacemaker_remoted
 lrmd/pacemaker_remote.service
 mcp/pacemaker
 mcp/pacemaker.combined.upstart
@@ -76,6 +77,7 @@ shell/modules/ui.py
 shell/modules/vars.py
 tools/cibsecret
 tools/coverage.sh
+tools/crm_error
 tools/crm_mon.upstart
 tools/crm_report
 tools/report.common
@@ -89,6 +91,7 @@ fencing/regression.py
 *.8
 *.8.xml
 *.8.html
+attrd/attrd
 doc/*/en-US/images/*.png
 doc/*/tmp/**
 doc/*/publish
@@ -113,7 +116,6 @@ pengine/pengine.xml
 pengine/ptest
 shell/regression/testcases/confbasic-xml.filter
 scratch
-tools/attrd
 tools/attrd_updater
 tools/cibadmin
 tools/crm_attribute
@@ -130,7 +132,8 @@ tools/iso8601
 tools/crm_ticket
 tools/report.collector.1
 xml/crm.dtd
-xml/pacemaker.rng
+xml/pacemaker*.rng
+xml/versions.rng
 extra/rgmanager/ccs2cib
 extra/rgmanager/ccs_flatten
 extra/rgmanager/disable_rgmanager
@@ -149,7 +152,7 @@ lib/gnu/stdalign.h
 #Other 
 mock
 HTML
-pacemaker.spec
+pacemaker*.spec
 pengine/.regression.failed.diff
 ClusterLabs-pacemaker-*.tar.gz
 coverity-*

--- a/README.markdown
+++ b/README.markdown
@@ -57,6 +57,8 @@ This is not meant to be an exhaustive list:
 * ncurses-devel
 * openssl-devel
 * libselinux-devel
+* systemd-devel
+* dbus-devel
 * cluster-glue-libs-devel (LHA style fencing agents)
 * libesmtp-devel (Email alerts)
 * lm_sensors-devel (SNMP alerts)

--- a/doc/Clusters_from_Scratch/en-US/Ch-Stonith.txt
+++ b/doc/Clusters_from_Scratch/en-US/Ch-Stonith.txt
@@ -1,5 +1,6 @@
-[[_what_is_stonith]]
 = Configure STONITH =
+
+== What is STONITH? ==
 
 STONITH (Shoot The Other Node In The Head aka. fencing) protects your data from
 being corrupted by rogue nodes or unintended concurrent access.


### PR DESCRIPTION
These revisions take care of minor issues found in the process of doing mock builds for EL6/EL7:
* add more build targets to .gitignore
* document two more optional build dependencies  (needed by "make rpm") in README.markdown
* tweak an internal crossreference in Clusters From Scratch. The previous asciidoc syntax (added in my earlier CFS update) built fine in EL7 but failed XML validation in EL6; apparently the EL6 asciidoc doesn't handle [[anchor]] outside a paragraph. So I went back to the <<sectionname>> syntax, which builds fine on both.