### PR TITLE
Fix bashisms in LSBDummy script

### DIFF
--- a/cts/LSBDummy.in
+++ b/cts/LSBDummy.in
@@ -37,12 +37,12 @@ desc="Dummy LSB service"
 
 success()
 {
-	echo -ne "[  OK  ]\r"
+	printf "[  OK  ]\r"
 }
 
 failure()
 {
-	echo -ne "[FAILED]\r"
+	printf "[FAILED]\r"
 }
 
 # rpm based distros


### PR DESCRIPTION
Option '-e' of 'echo' command may be unsupported in some
POSIX-complete shells.