### PR TITLE
Update crm_standby options to match its documentation

### DIFF
--- a/tools/crm_standby
+++ b/tools/crm_standby
@@ -8,7 +8,12 @@ target=`crm_node -n`
 TEMP=`getopt -o qDGQVN:U:v:i:l: --long version,help,node:,uname:,id:,attr-value:,delete-attr,get-value,attr-id:,lifetime:,quiet \
      -n 'crm_standby' -- "$@"`
 
-if [ $? != 0 ] ; then echo "crm_standby - A convenience wrapper for crm_attribute"; echo ""; crm_attribute -?; exit 1 ; fi
+if [ $? -ne 0 ]; then
+    echo "crm_standby - A convenience wrapper for crm_attribute"
+    echo ""
+    crm_attribute -?
+    exit 1
+fi
 
 # Note the quotes around `$TEMP': they are essential!
 eval set -- "$TEMP"
@@ -58,11 +63,11 @@ if [ x$op = x ]; then
     options="$options -G"; op=g
 fi
 
-if [ $lifetime = 0 ]; then
+if [ $lifetime -eq 0 ]; then
     case $op in
         g)
             crm_attribute $options -l forever 2>&1 > /dev/null
-            if [ $? = 0 ]; then
+            if [ $? -eq 0 ]; then
                 options="$options -l forever"
             else
                 options="$options -l reboot -d off"

--- a/tools/crm_standby
+++ b/tools/crm_standby
@@ -14,43 +14,43 @@ if [ $? != 0 ] ; then echo "crm_standby - A convenience wrapper for crm_attribut
 eval set -- "$TEMP"
 
 while true ; do
-	case "$1" in
-	    -N|--node)  target="$2"; shift; shift;;
-	    -U|--uname) target="$2"; shift; shift;;
-	    -v|--attr-value)  options="$options $1 $2"; op=u; shift; shift;;
-	    -D|--delete-attr) options="$options $1"; op=d; shift;;
-	    -G|--get-value)   options="$options $1"; op=g; shift;;
-	    -l|--lifetime)    options="$options $1 $2"; lifetime=1; shift; shift;;
-	    -i|--id|--attr-id)     options="$options $1 $2"; shift; shift;;
-	    -Q|-q|--quiet|-V)    options="$options $1"; shift;;
-	    --version) crm_attribute --version; exit 0;;
-	    --help)
-		echo "crm_standby - A convenience wrapper for crm_attribute";
-		echo "";
-		echo "";
-		echo "Put the name node into and out of standby. Nodes in standby mode may not host cluster resources";
-		echo "";
-		echo "Usage: crm_standby crm_standby command [options]";
-		echo "Options:"
-		echo " --help 		This text"
-		echo " --version 		Version information"
-		echo " -V, --verbose 		Increase debug output"
-		echo " -q, --quiet 		Print only the value on stdout"
-		echo ""
-		echo "Commands:"
-		echo " -G, --query 		Query the current value of the attribute/option"
-		echo " -v, --update=value	Update the value of the attribute/option"
-		echo " -D, --delete 		Delete the attribute/option"
-		echo ""
-		echo "Additional Options:"
-		echo " -N, --node=value	Set an attribute for the named node (instead of the current one)."
-		echo " -l, --lifetime=value	Until when should the setting take affect."
-		echo "	       		Valid values: reboot, forever"
-		echo " -i, --id=value		(Advanced) The ID used to identify the attribute"
-		exit 0;;
-	    --) shift ; break ;;
-	    *) echo "Unknown option: $1. See --help for details." exit 1;;
-	esac
+    case "$1" in
+        -N|--node)  target="$2"; shift; shift;;
+        -U|--uname) target="$2"; shift; shift;;
+        -v|--attr-value)  options="$options $1 $2"; op=u; shift; shift;;
+        -D|--delete-attr) options="$options $1"; op=d; shift;;
+        -G|--get-value)   options="$options $1"; op=g; shift;;
+        -l|--lifetime)    options="$options $1 $2"; lifetime=1; shift; shift;;
+        -i|--id|--attr-id)     options="$options $1 $2"; shift; shift;;
+        -Q|-q|--quiet|-V)    options="$options $1"; shift;;
+        --version) crm_attribute --version; exit 0;;
+        --help)
+            echo "crm_standby - A convenience wrapper for crm_attribute";
+            echo "";
+            echo "";
+            echo "Put the name node into and out of standby. Nodes in standby mode may not host cluster resources";
+            echo "";
+            echo "Usage: crm_standby crm_standby command [options]";
+            echo "Options:"
+            echo " --help               This text"
+            echo " --version            Version information"
+            echo " -V, --verbose        Increase debug output"
+            echo " -q, --quiet          Print only the value on stdout"
+            echo ""
+            echo "Commands:"
+            echo " -G, --query          Query the current value of the attribute/option"
+            echo " -v, --update=value   Update the value of the attribute/option"
+            echo " -D, --delete         Delete the attribute/option"
+            echo ""
+            echo "Additional Options:"
+            echo " -N, --node=value     Set an attribute for the named node (instead of the current one)."
+            echo " -l, --lifetime=value Until when should the setting take affect."
+            echo "                      Valid values: reboot, forever"
+            echo " -i, --id=value       (Advanced) The ID used to identify the attribute"
+            exit 0;;
+        --) shift ; break ;;
+        *) echo "Unknown option: $1. See --help for details." exit 1;;
+    esac
 done
 
 options="-N $target -n standby $options"
@@ -60,22 +60,22 @@ fi
 
 if [ $lifetime = 0 ]; then
     case $op in
-	g)
-	    crm_attribute $options -l forever 2>&1 > /dev/null
-	    if [ $? = 0 ]; then
-		options="$options -l forever"
-	    else
-		options="$options -l reboot -d off"
-	    fi
-	    ;;
-	u)
-	    options="$options -l forever"
-	    ;;
-	d)
-	    crm_attribute $options -l forever
-	    crm_attribute $options -l reboot
-	    exit 0
-	    ;;
+        g)
+            crm_attribute $options -l forever 2>&1 > /dev/null
+            if [ $? = 0 ]; then
+                options="$options -l forever"
+            else
+                options="$options -l reboot -d off"
+            fi
+            ;;
+        u)
+            options="$options -l forever"
+            ;;
+        d)
+            crm_attribute $options -l forever
+            crm_attribute $options -l reboot
+            exit 0
+            ;;
     esac
 fi
 

--- a/tools/crm_standby
+++ b/tools/crm_standby
@@ -1,60 +1,58 @@
 #!/bin/bash
 
+HELPTEXT="crm_standby - convenience wrapper for crm_attribute
+
+Check, enable or disable standby mode for a cluster node.
+Nodes in standby mode may not host cluster resources.
+
+Usage: crm_standby <command> [options]
+
+Commands:
+ --help                 Display this text and exit
+ --version              Display version information and exit
+ -G, --query            Display the current value of standby mode (on/off)
+ -v, --update=<value>   Update the value of standby mode (on/off)
+ -D, --delete           Let standby mode use default value
+
+Options:
+ -V, --verbose          Increase debug output (may be specified multiple times)
+ -q, --quiet            Print nothing on stdout except the standby status
+ -N, --node=<value>     Operate on the named node instead of the current one
+ -l, --lifetime=<value> Until when the setting should take effect (reboot/forever)
+ -i, --id=<value>       (Advanced) ID used to identify the XML attribute"
+
 op=""
 options=""
 lifetime=0
-target=`crm_node -n`
+target=$(crm_node -n)
 
-TEMP=`getopt -o qDGQVN:U:v:i:l: --long version,help,node:,uname:,id:,attr-value:,delete-attr,get-value,attr-id:,lifetime:,quiet \
-     -n 'crm_standby' -- "$@"`
+BACKWARD_COMPATIBLE="get-value,attr-value:,delete-attr,uname:,attr-id:"
+TEMP=$(getopt -o qDGQVN:U:v:i:l: \
+    --long help,version,query,update:,delete,verbose,quiet,node:,lifetime:,id:,$BACKWARD_COMPATIBLE \
+    -n 'crm_standby' -- "$@")
 
 if [ $? -ne 0 ]; then
-    echo "crm_standby - A convenience wrapper for crm_attribute"
-    echo ""
-    crm_attribute -?
+    echo
+    echo "$HELPTEXT"
     exit 1
 fi
 
-# Note the quotes around `$TEMP': they are essential!
+# The quotes around $TEMP are essential!
 eval set -- "$TEMP"
 
 while true ; do
     case "$1" in
-        -N|--node)  target="$2"; shift; shift;;
-        -U|--uname) target="$2"; shift; shift;;
-        -v|--attr-value)  options="$options $1 $2"; op=u; shift; shift;;
-        -D|--delete-attr) options="$options $1"; op=d; shift;;
-        -G|--get-value)   options="$options $1"; op=g; shift;;
-        -l|--lifetime)    options="$options $1 $2"; lifetime=1; shift; shift;;
-        -i|--id|--attr-id)     options="$options $1 $2"; shift; shift;;
-        -Q|-q|--quiet|-V)    options="$options $1"; shift;;
-        --version) crm_attribute --version; exit 0;;
-        --help)
-            echo "crm_standby - A convenience wrapper for crm_attribute";
-            echo "";
-            echo "";
-            echo "Put the name node into and out of standby. Nodes in standby mode may not host cluster resources";
-            echo "";
-            echo "Usage: crm_standby crm_standby command [options]";
-            echo "Options:"
-            echo " --help               This text"
-            echo " --version            Version information"
-            echo " -V, --verbose        Increase debug output"
-            echo " -q, --quiet          Print only the value on stdout"
-            echo ""
-            echo "Commands:"
-            echo " -G, --query          Query the current value of the attribute/option"
-            echo " -v, --update=value   Update the value of the attribute/option"
-            echo " -D, --delete         Delete the attribute/option"
-            echo ""
-            echo "Additional Options:"
-            echo " -N, --node=value     Set an attribute for the named node (instead of the current one)."
-            echo " -l, --lifetime=value Until when should the setting take affect."
-            echo "                      Valid values: reboot, forever"
-            echo " -i, --id=value       (Advanced) The ID used to identify the attribute"
-            exit 0;;
-        --) shift ; break ;;
-        *) echo "Unknown option: $1. See --help for details." exit 1;;
+        -N|--node|-U|--uname)       target="$2"; shift 2;;
+        -G|--query|--get-value)     options="$options --query"; op=g; shift;;
+        -v|--update|--attr-value)   options="$options --update $2"; op=u; shift 2;;
+        -D|--delete|--delete-attr)  options="$options --delete"; op=d; shift;;
+        -l|--lifetime)              options="$options --lifetime $2"; lifetime=1; shift 2;;
+        -i|--id|--attr-id)          options="$options --id $2"; shift 2;;
+        -q|-Q|--quiet|-V|--verbose) options="$options $1"; shift;;
+        --version)                  crm_attribute --version; exit 0;;
+        --help)                     echo "$HELPTEXT"; exit 0;;
+        --)                         shift ; break ;;
+        *) echo "crm_standby: unrecognized option '$1'"; echo; echo "$HELPTEXT"; exit 1;;
     esac
 done
 
@@ -63,9 +61,12 @@ if [ x$op = x ]; then
     options="$options -G"; op=g
 fi
 
+# If the user didn't explicitly specify a lifetime ...
 if [ $lifetime -eq 0 ]; then
     case $op in
         g)
+            # For query, report the forever entry if one exists, otherwise
+            # report the reboot entry if one exists, otherwise report off.
             crm_attribute $options -l forever 2>&1 > /dev/null
             if [ $? -eq 0 ]; then
                 options="$options -l forever"
@@ -74,9 +75,11 @@ if [ $lifetime -eq 0 ]; then
             fi
             ;;
         u)
+            # For update, default to updating the forever entry.
             options="$options -l forever"
             ;;
         d)
+            # For delete, default to deleting both forever and reboot entries.
             crm_attribute $options -l forever
             crm_attribute $options -l reboot
             exit 0
@@ -84,5 +87,4 @@ if [ $lifetime -eq 0 ]; then
     esac
 fi
 
-#echo crm_attribute $options
 crm_attribute $options


### PR DESCRIPTION
First revision changes whitespace only.

Second revision uses -eq/-ne instead of =/!= where appropriate.

Third revision is the meat. At some point, crm_attribute's command-line options were updated, e.g. --attr-value became --update. crm_standby's man page and help text were updated accordingly, but not the actual options accepted. This takes care of that and does some minor cleanup (additional comments, separating help text into a variable, etc.).