### PR TITLE
Move some reusable CIB daemon code into libraries

### DIFF
--- a/cib/io.c
+++ b/cib/io.c
@@ -85,7 +85,6 @@ static gboolean
 validate_cib_digest(xmlNode * local_cib, const char *sigfile)
 {
     gboolean passed = FALSE;
-    char *digest = NULL;
     char *expected = crm_read_contents(sigfile);
 
     if (expected == NULL) {
@@ -101,25 +100,7 @@ validate_cib_digest(xmlNode * local_cib, const char *sigfile)
                 return FALSE;
         }
     }
-
-    if (local_cib != NULL) {
-        digest = calculate_on_disk_digest(local_cib);
-        if (digest == NULL) {
-            crm_perror(LOG_ERR, "Could not calculate digest for comparison");
-            free(expected);
-            return FALSE;
-        }
-    }
-
-    if (safe_str_eq(expected, digest)) {
-        crm_trace("Digest comparision passed: %s", digest);
-        passed = TRUE;
-    } else {
-        crm_err("Digest comparision failed: expected %s (%s), calculated %s",
-                expected, sigfile, digest);
-    }
-
-    free(digest);
+    passed = crm_digest_verify(local_cib, expected);
     free(expected);
     return passed;
 }

--- a/include/crm/common/Makefile.am
+++ b/include/crm/common/Makefile.am
@@ -21,7 +21,7 @@ MAINTAINERCLEANFILES = Makefile.in
 headerdir=$(pkgincludedir)/crm/common
 
 header_HEADERS = xml.h ipc.h util.h iso8601.h mainloop.h logging.h
-noinst_HEADERS = ipcs.h
+noinst_HEADERS = io.h ipcs.h
 if BUILD_CIBSECRETS
 noinst_HEADERS += cib_secrets.h
 endif

--- a/include/crm/common/io.h
+++ b/include/crm/common/io.h
@@ -41,5 +41,6 @@ gboolean crm_is_writable(const char *dir, const char *file, const char *user, co
 void crm_sync_directory(const char *name);
 
 char *crm_read_contents(const char *filename);
+int crm_write_sync(int fd, const char *contents);
 
 #endif /* CRM_COMMON_IO__H */

--- a/include/crm/common/io.h
+++ b/include/crm/common/io.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015
+ *     Andrew Beekhof <andrew@beekhof.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * \file
+ * \brief internal I/O utilities
+ * \ingroup core
+ */
+
+/* public APIs from io.c are declared in util.h */
+
+#ifndef CRM_COMMON_IO__H
+#define CRM_COMMON_IO__H
+
+#include <glib.h> /* for gboolean */
+
+char *generate_series_filename(const char *directory, const char *series, int sequence,
+                               gboolean bzip);
+int get_last_sequence(const char *directory, const char *series);
+void write_last_sequence(const char *directory, const char *series, int sequence, int max);
+
+gboolean crm_is_writable(const char *dir, const char *file, const char *user, const char *group,
+                         gboolean need_both);
+
+#endif /* CRM_COMMON_IO__H */

--- a/include/crm/common/io.h
+++ b/include/crm/common/io.h
@@ -38,4 +38,6 @@ void write_last_sequence(const char *directory, const char *series, int sequence
 gboolean crm_is_writable(const char *dir, const char *file, const char *user, const char *group,
                          gboolean need_both);
 
+void crm_sync_directory(const char *name);
+
 #endif /* CRM_COMMON_IO__H */

--- a/include/crm/common/io.h
+++ b/include/crm/common/io.h
@@ -40,4 +40,6 @@ gboolean crm_is_writable(const char *dir, const char *file, const char *user, co
 
 void crm_sync_directory(const char *name);
 
+char *crm_read_contents(const char *filename);
+
 #endif /* CRM_COMMON_IO__H */

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -347,5 +347,7 @@ static inline void *realloc_safe(void *ptr, size_t size)
     return ret;
 }
 
+void crm_xml_dump(xmlNode * data, int options, char **buffer, int *offset, int *max, int depth);
+void crm_buffer_add_char(char **buffer, int *offset, int *max, char c);
 
 #endif                          /* CRM_INTERNAL__H */

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -350,4 +350,6 @@ static inline void *realloc_safe(void *ptr, size_t size)
 void crm_xml_dump(xmlNode * data, int options, char **buffer, int *offset, int *max, int depth);
 void crm_buffer_add_char(char **buffer, int *offset, int *max, char c);
 
+gboolean crm_digest_verify(xmlNode *input, const char *expected);
+
 #endif                          /* CRM_INTERNAL__H */

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -31,6 +31,7 @@
 
 #  include <crm/lrmd.h>
 #  include <crm/common/logging.h>
+#  include <crm/common/io.h>
 #  include <crm/common/ipcs.h>
 
 /* Dynamic loading of libraries */
@@ -151,15 +152,9 @@ crm_strlen_zero(const char *s)
 }
 
 char *add_list_element(char *list, const char *value);
-char *generate_series_filename(const char *directory, const char *series, int sequence,
-                               gboolean bzip);
-int get_last_sequence(const char *directory, const char *series);
-void write_last_sequence(const char *directory, const char *series, int sequence, int max);
 
 int crm_pid_active(long pid);
 void crm_make_daemon(const char *name, gboolean daemonize, const char *pidfile);
-gboolean crm_is_writable(const char *dir, const char *file, const char *user, const char *group,
-                         gboolean need_both);
 
 char *generate_op_key(const char *rsc_id, const char *op_type, int interval);
 char *generate_notify_key(const char *rsc_id, const char *notify_type, const char *op_type);

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -32,7 +32,7 @@ lib_LTLIBRARIES	= libcrmcommon.la
 
 CFLAGS		= $(CFLAGS_COPY:-Wcast-qual=) -fPIC
 
-libcrmcommon_la_SOURCES	= ipc.c utils.c xml.c iso8601.c remote.c mainloop.c logging.c watchdog.c
+libcrmcommon_la_SOURCES	= ipc.c io.c utils.c xml.c iso8601.c remote.c mainloop.c logging.c watchdog.c
 if BUILD_CIBSECRETS
 libcrmcommon_la_SOURCES	+= cib_secrets.c
 endif

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -32,7 +32,7 @@ lib_LTLIBRARIES	= libcrmcommon.la
 
 CFLAGS		= $(CFLAGS_COPY:-Wcast-qual=) -fPIC
 
-libcrmcommon_la_SOURCES	= ipc.c io.c utils.c xml.c iso8601.c remote.c mainloop.c logging.c watchdog.c
+libcrmcommon_la_SOURCES	= digest.c ipc.c io.c utils.c xml.c iso8601.c remote.c mainloop.c logging.c watchdog.c
 if BUILD_CIBSECRETS
 libcrmcommon_la_SOURCES	+= cib_secrets.c
 endif

--- a/lib/common/digest.c
+++ b/lib/common/digest.c
@@ -159,3 +159,27 @@ calculate_xml_versioned_digest(xmlNode * input, gboolean sort, gboolean do_filte
     crm_trace("Using v2 digest algorithm for %s", crm_str(version));
     return calculate_xml_digest_v2(input, do_filter);
 }
+
+gboolean
+crm_digest_verify(xmlNode *input, const char *expected)
+{
+    char *calculated = NULL;
+    gboolean passed;
+
+    if (input != NULL) {
+        calculated = calculate_on_disk_digest(input);
+        if (calculated == NULL) {
+            crm_perror(LOG_ERR, "Could not calculate digest for comparison");
+            return FALSE;
+        }
+    }
+    passed = safe_str_eq(expected, calculated);
+    if (passed) {
+        crm_trace("Digest comparison passed: %s", calculated);
+    } else {
+        crm_err("Digest comparison failed: expected %s, calculated %s",
+                expected, calculated);
+    }
+    free(calculated);
+    return passed;
+}

--- a/lib/common/digest.c
+++ b/lib/common/digest.c
@@ -29,6 +29,13 @@
 
 #define BEST_EFFORT_STATUS 0
 
+/*!
+ * \brief Dump XML in a format used with v1 digests
+ *
+ * \param[in] an_xml_node Root of XML to dump
+ *
+ * \return Newly allocated buffer containing dumped XML
+ */
 static char *
 dump_xml_for_digest(xmlNode * an_xml_node)
 {
@@ -43,7 +50,16 @@ dump_xml_for_digest(xmlNode * an_xml_node)
     return buffer;
 }
 
-/* "c048eae664dba840e1d2060f00299e9d" */
+/*!
+ * \brief Calculate and return v1 digest of XML tree
+ *
+ * \param[in] input Root of XML to digest
+ * \param[in] sort Whether to sort the XML before calculating digest
+ * \param[in] ignored Not used
+ *
+ * \return Newly allocated string containing digest
+ * \note Example return value: "c048eae664dba840e1d2060f00299e9d"
+ */
 static char *
 calculate_xml_digest_v1(xmlNode * input, gboolean sort, gboolean ignored)
 {
@@ -71,6 +87,14 @@ calculate_xml_digest_v1(xmlNode * input, gboolean sort, gboolean ignored)
     return digest;
 }
 
+/*!
+ * \brief Calculate and return v2 digest of XML tree
+ *
+ * \param[in] source Root of XML to digest
+ * \param[in] do_filter Whether to filter certain XML attributes
+ *
+ * \return Newly allocated string containing digest
+ */
 static char *
 calculate_xml_digest_v2(xmlNode * source, gboolean do_filter)
 {
@@ -121,6 +145,13 @@ calculate_xml_digest_v2(xmlNode * source, gboolean do_filter)
     return digest;
 }
 
+/*!
+ * \brief Calculate and return digest of XML tree, suitable for storing on disk
+ *
+ * \param[in] input Root of XML to digest
+ *
+ * \return Newly allocated string containing digest
+ */
 char *
 calculate_on_disk_digest(xmlNode * input)
 {
@@ -132,13 +163,31 @@ calculate_on_disk_digest(xmlNode * input)
     return calculate_xml_digest_v1(input, FALSE, FALSE);
 }
 
+/*!
+ * \brief Calculate and return digest of XML operation
+ *
+ * \param[in] input Root of XML to digest
+ * \param[in] version Not used
+ *
+ * \return Newly allocated string containing digest
+ */
 char *
-calculate_operation_digest(xmlNode * input, const char *version)
+calculate_operation_digest(xmlNode *input, const char *version)
 {
-    /* We still need the sorting for parameter digests */
+    /* We still need the sorting for operation digests */
     return calculate_xml_digest_v1(input, TRUE, FALSE);
 }
 
+/*!
+ * \brief Calculate and return digest of XML tree
+ *
+ * \param[in] input Root of XML to digest
+ * \param[in] sort Whether to sort XML before calculating digest
+ * \param[in] do_filter Whether to filter certain XML attributes
+ * \param[in] version CRM feature set version (used to select v1/v2 digest)
+ *
+ * \return Newly allocated string containing digest
+ */
 char *
 calculate_xml_versioned_digest(xmlNode * input, gboolean sort, gboolean do_filter,
                                const char *version)
@@ -160,6 +209,14 @@ calculate_xml_versioned_digest(xmlNode * input, gboolean sort, gboolean do_filte
     return calculate_xml_digest_v2(input, do_filter);
 }
 
+/*!
+ * \brief Return whether calculated digest of XML tree matches expected digest
+ *
+ * \param[in] input Root of XML to digest
+ * \param[in] expected Expected digest in on-disk format
+ *
+ * \return TRUE if digests match, FALSE otherwise or on error
+ */
 gboolean
 crm_digest_verify(xmlNode *input, const char *expected)
 {

--- a/lib/common/digest.c
+++ b/lib/common/digest.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2015 Andrew Beekhof <andrew@beekhof.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <crm_internal.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <crm/crm.h>
+#include <crm/msg_xml.h>
+#include <crm/common/xml.h>
+
+#define BEST_EFFORT_STATUS 0
+
+static char *
+dump_xml_for_digest(xmlNode * an_xml_node)
+{
+    char *buffer = NULL;
+    int offset = 0, max = 0;
+
+    /* for compatability with the old result which is used for v1 digests */
+    crm_buffer_add_char(&buffer, &offset, &max, ' ');
+    crm_xml_dump(an_xml_node, 0, &buffer, &offset, &max, 0);
+    crm_buffer_add_char(&buffer, &offset, &max, '\n');
+
+    return buffer;
+}
+
+/* "c048eae664dba840e1d2060f00299e9d" */
+static char *
+calculate_xml_digest_v1(xmlNode * input, gboolean sort, gboolean ignored)
+{
+    char *digest = NULL;
+    char *buffer = NULL;
+    xmlNode *copy = NULL;
+
+    if (sort) {
+        crm_trace("Sorting xml...");
+        copy = sorted_xml(input, NULL, TRUE);
+        crm_trace("Done");
+        input = copy;
+    }
+
+    buffer = dump_xml_for_digest(input);
+    CRM_CHECK(buffer != NULL && strlen(buffer) > 0, free_xml(copy);
+              free(buffer);
+              return NULL);
+
+    digest = crm_md5sum(buffer);
+    crm_log_xml_trace(input, "digest:source");
+
+    free(buffer);
+    free_xml(copy);
+    return digest;
+}
+
+static char *
+calculate_xml_digest_v2(xmlNode * source, gboolean do_filter)
+{
+    char *digest = NULL;
+    char *buffer = NULL;
+    int offset, max;
+
+    static struct qb_log_callsite *digest_cs = NULL;
+
+    crm_trace("Begin digest %s", do_filter?"filtered":"");
+    if (do_filter && BEST_EFFORT_STATUS) {
+        /* Exclude the status calculation from the digest
+         *
+         * This doesn't mean it wont be sync'd, we just wont be paranoid
+         * about it being an _exact_ copy
+         *
+         * We don't need it to be exact, since we throw it away and regenerate
+         * from our peers whenever a new DC is elected anyway
+         *
+         * Importantly, this reduces the amount of XML to copy+export as
+         * well as the amount of data for MD5 needs to operate on
+         */
+
+    } else {
+        crm_xml_dump(source, do_filter ? xml_log_option_filtered : 0, &buffer, &offset, &max, 0);
+    }
+
+    CRM_ASSERT(buffer != NULL);
+    digest = crm_md5sum(buffer);
+
+    if (digest_cs == NULL) {
+        digest_cs = qb_log_callsite_get(__func__, __FILE__, "cib-digest", LOG_TRACE, __LINE__,
+                                        crm_trace_nonlog);
+    }
+    if (digest_cs && digest_cs->targets) {
+        char *trace_file = crm_concat("/tmp/digest", digest, '-');
+
+        crm_trace("Saving %s.%s.%s to %s",
+                  crm_element_value(source, XML_ATTR_GENERATION_ADMIN),
+                  crm_element_value(source, XML_ATTR_GENERATION),
+                  crm_element_value(source, XML_ATTR_NUMUPDATES), trace_file);
+        save_xml_to_file(source, "digest input", trace_file);
+        free(trace_file);
+    }
+
+    free(buffer);
+    crm_trace("End digest");
+    return digest;
+}
+
+char *
+calculate_on_disk_digest(xmlNode * input)
+{
+    /* Always use the v1 format for on-disk digests
+     * a) its a compatability nightmare
+     * b) we only use this once at startup, all other
+     *    invocations are in a separate child process
+     */
+    return calculate_xml_digest_v1(input, FALSE, FALSE);
+}
+
+char *
+calculate_operation_digest(xmlNode * input, const char *version)
+{
+    /* We still need the sorting for parameter digests */
+    return calculate_xml_digest_v1(input, TRUE, FALSE);
+}
+
+char *
+calculate_xml_versioned_digest(xmlNode * input, gboolean sort, gboolean do_filter,
+                               const char *version)
+{
+    /*
+     * The sorting associated with v1 digest creation accounted for 23% of
+     * the CIB's CPU usage on the server. v2 drops this.
+     *
+     * The filtering accounts for an additional 2.5% and we may want to
+     * remove it in future.
+     *
+     * v2 also uses the xmlBuffer contents directly to avoid additional copying
+     */
+    if (version == NULL || compare_version("3.0.5", version) > 0) {
+        crm_trace("Using v1 digest algorithm for %s", crm_str(version));
+        return calculate_xml_digest_v1(input, sort, do_filter);
+    }
+    crm_trace("Using v2 digest algorithm for %s", crm_str(version));
+    return calculate_xml_digest_v2(input, do_filter);
+}

--- a/lib/common/io.c
+++ b/lib/common/io.c
@@ -329,3 +329,25 @@ crm_read_contents(const char *filename)
     fclose(fp);
     return contents;
 }
+
+int
+crm_write_sync(int fd, const char *contents)
+{
+    int rc = 0;
+    FILE *fp = fdopen(fd, "w");
+
+    if (fp == NULL) {
+        return -1;
+    }
+    if ((contents != NULL) && (fprintf(fp, "%s", contents) < 0)) {
+        rc = -1;
+    }
+    if (fflush(fp) != 0) {
+        rc = -1;
+    }
+    if (fsync(fileno(fp)) < 0) {
+        rc = -1;
+    }
+    fclose(fp);
+    return rc;
+}

--- a/lib/common/io.c
+++ b/lib/common/io.c
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2004 Andrew Beekhof <andrew@beekhof.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <crm_internal.h>
+
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <pwd.h>
+#include <grp.h>
+
+#include <crm/crm.h>
+#include <crm/common/util.h>
+
+void
+crm_build_path(const char *path_c, mode_t mode)
+{
+    int offset = 1, len = 0;
+    char *path = strdup(path_c);
+
+    CRM_CHECK(path != NULL, return);
+    for (len = strlen(path); offset < len; offset++) {
+        if (path[offset] == '/') {
+            path[offset] = 0;
+            if (mkdir(path, mode) < 0 && errno != EEXIST) {
+                crm_perror(LOG_ERR, "Could not create directory '%s'", path);
+                break;
+            }
+            path[offset] = '/';
+        }
+    }
+    if (mkdir(path, mode) < 0 && errno != EEXIST) {
+        crm_perror(LOG_ERR, "Could not create directory '%s'", path);
+    }
+
+    free(path);
+}
+
+char *
+generate_series_filename(const char *directory, const char *series, int sequence, gboolean bzip)
+{
+    int len = 40;
+    char *filename = NULL;
+    const char *ext = "raw";
+
+    CRM_CHECK(directory != NULL, return NULL);
+    CRM_CHECK(series != NULL, return NULL);
+
+#if !HAVE_BZLIB_H
+    bzip = FALSE;
+#endif
+
+    len += strlen(directory);
+    len += strlen(series);
+    filename = malloc(len);
+    CRM_CHECK(filename != NULL, return NULL);
+
+    if (bzip) {
+        ext = "bz2";
+    }
+    sprintf(filename, "%s/%s-%d.%s", directory, series, sequence, ext);
+
+    return filename;
+}
+
+int
+get_last_sequence(const char *directory, const char *series)
+{
+    FILE *file_strm = NULL;
+    int start = 0, length = 0, read_len = 0;
+    char *series_file = NULL;
+    char *buffer = NULL;
+    int seq = 0;
+    int len = 36;
+
+    CRM_CHECK(directory != NULL, return 0);
+    CRM_CHECK(series != NULL, return 0);
+
+    len += strlen(directory);
+    len += strlen(series);
+    series_file = malloc(len);
+    CRM_CHECK(series_file != NULL, return 0);
+    sprintf(series_file, "%s/%s.last", directory, series);
+
+    file_strm = fopen(series_file, "r");
+    if (file_strm == NULL) {
+        crm_debug("Series file %s does not exist", series_file);
+        free(series_file);
+        return 0;
+    }
+
+    /* see how big the file is */
+    start = ftell(file_strm);
+    fseek(file_strm, 0L, SEEK_END);
+    length = ftell(file_strm);
+    fseek(file_strm, 0L, start);
+
+    CRM_ASSERT(length >= 0);
+    CRM_ASSERT(start == ftell(file_strm));
+
+    if (length <= 0) {
+        crm_info("%s was not valid", series_file);
+        free(buffer);
+        buffer = NULL;
+
+    } else {
+        crm_trace("Reading %d bytes from file", length);
+        buffer = calloc(1, (length + 1));
+        read_len = fread(buffer, 1, length, file_strm);
+        if (read_len != length) {
+            crm_err("Calculated and read bytes differ: %d vs. %d", length, read_len);
+            free(buffer);
+            buffer = NULL;
+        }
+    }
+
+    seq = crm_parse_int(buffer, "0");
+    fclose(file_strm);
+
+    crm_trace("Found %d in %s", seq, series_file);
+
+    free(series_file);
+    free(buffer);
+    return seq;
+}
+
+void
+write_last_sequence(const char *directory, const char *series, int sequence, int max)
+{
+    int rc = 0;
+    int len = 36;
+    FILE *file_strm = NULL;
+    char *series_file = NULL;
+
+    CRM_CHECK(directory != NULL, return);
+    CRM_CHECK(series != NULL, return);
+
+    if (max == 0) {
+        return;
+    }
+    if (max > 0 && sequence >= max) {
+        sequence = 0;
+    }
+
+    len += strlen(directory);
+    len += strlen(series);
+    series_file = malloc(len);
+
+    if(series_file) {
+        sprintf(series_file, "%s/%s.last", directory, series);
+        file_strm = fopen(series_file, "w");
+    }
+
+    if (file_strm != NULL) {
+        rc = fprintf(file_strm, "%d", sequence);
+        if (rc < 0) {
+            crm_perror(LOG_ERR, "Cannot write to series file %s", series_file);
+        }
+
+    } else {
+        crm_err("Cannot open series file %s for writing", series_file);
+    }
+
+    if (file_strm != NULL) {
+        fflush(file_strm);
+        fclose(file_strm);
+    }
+
+    crm_trace("Wrote %d to %s", sequence, series_file);
+    free(series_file);
+}
+
+gboolean
+crm_is_writable(const char *dir, const char *file,
+                const char *user, const char *group, gboolean need_both)
+{
+    int s_res = -1;
+    struct stat buf;
+    char *full_file = NULL;
+    const char *target = NULL;
+
+    gboolean pass = TRUE;
+    gboolean readwritable = FALSE;
+
+    CRM_ASSERT(dir != NULL);
+    if (file != NULL) {
+        full_file = crm_concat(dir, file, '/');
+        target = full_file;
+        s_res = stat(full_file, &buf);
+        if (s_res == 0 && S_ISREG(buf.st_mode) == FALSE) {
+            crm_err("%s must be a regular file", target);
+            pass = FALSE;
+            goto out;
+        }
+    }
+
+    if (s_res != 0) {
+        target = dir;
+        s_res = stat(dir, &buf);
+        if (s_res != 0) {
+            crm_err("%s must exist and be a directory", dir);
+            pass = FALSE;
+            goto out;
+
+        } else if (S_ISDIR(buf.st_mode) == FALSE) {
+            crm_err("%s must be a directory", dir);
+            pass = FALSE;
+        }
+    }
+
+    if (user) {
+        struct passwd *sys_user = NULL;
+
+        sys_user = getpwnam(user);
+        readwritable = (sys_user != NULL
+                        && buf.st_uid == sys_user->pw_uid && (buf.st_mode & (S_IRUSR | S_IWUSR)));
+        if (readwritable == FALSE) {
+            crm_err("%s must be owned and r/w by user %s", target, user);
+            if (need_both) {
+                pass = FALSE;
+            }
+        }
+    }
+
+    if (group) {
+        struct group *sys_grp = getgrnam(group);
+
+        readwritable = (sys_grp != NULL
+                        && buf.st_gid == sys_grp->gr_gid && (buf.st_mode & (S_IRGRP | S_IWGRP)));
+        if (readwritable == FALSE) {
+            if (need_both || user == NULL) {
+                pass = FALSE;
+                crm_err("%s must be owned and r/w by group %s", target, group);
+            } else {
+                crm_warn("%s should be owned and r/w by group %s", target, group);
+            }
+        }
+    }
+
+  out:
+    free(full_file);
+    return pass;
+}

--- a/lib/common/io.c
+++ b/lib/common/io.c
@@ -37,6 +37,14 @@
 #include <crm/crm.h>
 #include <crm/common/util.h>
 
+/*!
+ * \brief Create a directory, including any parent directories needed
+ *
+ * \param[in] path_c Pathname of the directory to create
+ * \param[in] mode Permissions to be used (with current umask) when creating
+ *
+ * \note This logs errors but does not return them to the caller.
+ */
 void
 crm_build_path(const char *path_c, mode_t mode)
 {
@@ -61,6 +69,18 @@ crm_build_path(const char *path_c, mode_t mode)
     free(path);
 }
 
+/*!
+ * \internal
+ * \brief Allocate and create a file path using a sequence number
+ *
+ * \param[in] directory Directory that contains the file series
+ * \param[in] series Start of file name
+ * \param[in] sequence Sequence number (MUST be less than 33 digits)
+ * \param[in] bzip Whether to use ".bz2" instead of ".raw" as extension
+ *
+ * \return Newly allocated file path, or NULL on error
+ * \note Caller is responsible for freeing the returned memory
+ */
 char *
 generate_series_filename(const char *directory, const char *series, int sequence, gboolean bzip)
 {
@@ -88,6 +108,15 @@ generate_series_filename(const char *directory, const char *series, int sequence
     return filename;
 }
 
+/*!
+ * \internal
+ * \brief Read and return sequence number stored in a file series' .last file
+ *
+ * \param[in] directory Directory that contains the file series
+ * \param[in] series Start of file name
+ *
+ * \return The last sequence number, or 0 on error
+ */
 int
 get_last_sequence(const char *directory, const char *series)
 {
@@ -149,6 +178,17 @@ get_last_sequence(const char *directory, const char *series)
     return seq;
 }
 
+/*!
+ * \internal
+ * \brief Write sequence number to a file series' .last file
+ *
+ * \param[in] directory Directory that contains the file series
+ * \param[in] series Start of file name
+ * \param[in] sequence Sequence number to write
+ * \param[in] max Maximum sequence value, after which sequence is reset to 0
+ *
+ * \note This function logs some errors but does not return any to the caller
+ */
 void
 write_last_sequence(const char *directory, const char *series, int sequence, int max)
 {
@@ -171,7 +211,7 @@ write_last_sequence(const char *directory, const char *series, int sequence, int
     len += strlen(series);
     series_file = malloc(len);
 
-    if(series_file) {
+    if (series_file) {
         sprintf(series_file, "%s/%s.last", directory, series);
         file_strm = fopen(series_file, "w");
     }
@@ -195,6 +235,18 @@ write_last_sequence(const char *directory, const char *series, int sequence, int
     free(series_file);
 }
 
+/*!
+ * \internal
+ * \brief Return whether a directory or file is writable by a user/group
+ *
+ * \param[in] dir Directory to check or that contains file
+ * \param[in] file File name to check (or NULL to check directory)
+ * \param[in] user Name of user that should have write permission
+ * \param[in] group Name of group that should have write permission
+ * \param[in] need_both Whether both user and group must be able to write
+ *
+ * \return TRUE if permissions match, FALSE if they don't or on error
+ */
 gboolean
 crm_is_writable(const char *dir, const char *file,
                 const char *user, const char *group, gboolean need_both)
@@ -267,6 +319,13 @@ crm_is_writable(const char *dir, const char *file,
     return pass;
 }
 
+/*!
+ * \internal
+ * \brief Flush and sync a directory to disk
+ *
+ * \param[in] name Directory to flush and sync
+ * \note This function logs errors but does not return them to the caller
+ */
 void
 crm_sync_directory(const char *name)
 {
@@ -293,6 +352,17 @@ crm_sync_directory(const char *name)
     }
 }
 
+/*!
+ * \internal
+ * \brief Allocate, read and return the contents of a file
+ *
+ * \param[in] filename Name of file to read
+ *
+ * \return Newly allocated memory with contents of file, or NULL on error
+ * \note On success, the caller is responsible for freeing the returned memory;
+ *       on error, errno will be 0 (indicating file was nonexistent or empty)
+ *       or one of the errno values set by fopen, ftell, or calloc
+ */
 char *
 crm_read_contents(const char *filename)
 {
@@ -330,6 +400,15 @@ crm_read_contents(const char *filename)
     return contents;
 }
 
+/*!
+ * \internal
+ * \brief Write text to a file, flush and sync it to disk, then close the file
+ *
+ * \param[in] fd File descriptor opened for writing
+ * \param[in] contents String to write to file
+ *
+ * \return 0 on success, -1 on error (in which case errno will be set)
+ */
 int
 crm_write_sync(int fd, const char *contents)
 {

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -36,7 +36,6 @@
 #include <limits.h>
 #include <ctype.h>
 #include <pwd.h>
-#include <grp.h>
 #include <time.h>
 #include <libgen.h>
 #include <signal.h>
@@ -423,30 +422,6 @@ crm_itoa(int an_int)
     }
 
     return buffer;
-}
-
-void
-crm_build_path(const char *path_c, mode_t mode)
-{
-    int offset = 1, len = 0;
-    char *path = strdup(path_c);
-
-    CRM_CHECK(path != NULL, return);
-    for (len = strlen(path); offset < len; offset++) {
-        if (path[offset] == '/') {
-            path[offset] = 0;
-            if (mkdir(path, mode) < 0 && errno != EEXIST) {
-                crm_perror(LOG_ERR, "Could not create directory '%s'", path);
-                break;
-            }
-            path[offset] = '/';
-        }
-    }
-    if (mkdir(path, mode) < 0 && errno != EEXIST) {
-        crm_perror(LOG_ERR, "Could not create directory '%s'", path);
-    }
-
-    free(path);
 }
 
 int
@@ -1219,140 +1194,6 @@ crm_abort(const char *file, const char *function, int line,
     crm_perror(LOG_ERR, "Cannot wait on forked child %d", pid);
 }
 
-char *
-generate_series_filename(const char *directory, const char *series, int sequence, gboolean bzip)
-{
-    int len = 40;
-    char *filename = NULL;
-    const char *ext = "raw";
-
-    CRM_CHECK(directory != NULL, return NULL);
-    CRM_CHECK(series != NULL, return NULL);
-
-#if !HAVE_BZLIB_H
-    bzip = FALSE;
-#endif
-
-    len += strlen(directory);
-    len += strlen(series);
-    filename = malloc(len);
-    CRM_CHECK(filename != NULL, return NULL);
-
-    if (bzip) {
-        ext = "bz2";
-    }
-    sprintf(filename, "%s/%s-%d.%s", directory, series, sequence, ext);
-
-    return filename;
-}
-
-int
-get_last_sequence(const char *directory, const char *series)
-{
-    FILE *file_strm = NULL;
-    int start = 0, length = 0, read_len = 0;
-    char *series_file = NULL;
-    char *buffer = NULL;
-    int seq = 0;
-    int len = 36;
-
-    CRM_CHECK(directory != NULL, return 0);
-    CRM_CHECK(series != NULL, return 0);
-
-    len += strlen(directory);
-    len += strlen(series);
-    series_file = malloc(len);
-    CRM_CHECK(series_file != NULL, return 0);
-    sprintf(series_file, "%s/%s.last", directory, series);
-
-    file_strm = fopen(series_file, "r");
-    if (file_strm == NULL) {
-        crm_debug("Series file %s does not exist", series_file);
-        free(series_file);
-        return 0;
-    }
-
-    /* see how big the file is */
-    start = ftell(file_strm);
-    fseek(file_strm, 0L, SEEK_END);
-    length = ftell(file_strm);
-    fseek(file_strm, 0L, start);
-
-    CRM_ASSERT(length >= 0);
-    CRM_ASSERT(start == ftell(file_strm));
-
-    if (length <= 0) {
-        crm_info("%s was not valid", series_file);
-        free(buffer);
-        buffer = NULL;
-
-    } else {
-        crm_trace("Reading %d bytes from file", length);
-        buffer = calloc(1, (length + 1));
-        read_len = fread(buffer, 1, length, file_strm);
-        if (read_len != length) {
-            crm_err("Calculated and read bytes differ: %d vs. %d", length, read_len);
-            free(buffer);
-            buffer = NULL;
-        }
-    }
-
-    seq = crm_parse_int(buffer, "0");
-    fclose(file_strm);
-
-    crm_trace("Found %d in %s", seq, series_file);
-
-    free(series_file);
-    free(buffer);
-    return seq;
-}
-
-void
-write_last_sequence(const char *directory, const char *series, int sequence, int max)
-{
-    int rc = 0;
-    int len = 36;
-    FILE *file_strm = NULL;
-    char *series_file = NULL;
-
-    CRM_CHECK(directory != NULL, return);
-    CRM_CHECK(series != NULL, return);
-
-    if (max == 0) {
-        return;
-    }
-    if (max > 0 && sequence >= max) {
-        sequence = 0;
-    }
-
-    len += strlen(directory);
-    len += strlen(series);
-    series_file = malloc(len);
-
-    if(series_file) {
-        sprintf(series_file, "%s/%s.last", directory, series);
-        file_strm = fopen(series_file, "w");
-    }
-
-    if (file_strm != NULL) {
-        rc = fprintf(file_strm, "%d", sequence);
-        if (rc < 0) {
-            crm_perror(LOG_ERR, "Cannot write to series file %s", series_file);
-        }
-
-    } else {
-        crm_err("Cannot open series file %s for writing", series_file);
-    }
-
-    if (file_strm != NULL) {
-        fflush(file_strm);
-        fclose(file_strm);
-    }
-
-    crm_trace("Wrote %d to %s", sequence, series_file);
-    free(series_file);
-}
-
 #define	LOCKSTRLEN	11
 
 int
@@ -1550,78 +1391,6 @@ crm_make_daemon(const char *name, gboolean daemonize, const char *pidfile)
     (void)open(devnull, O_WRONLY);      /* Stdout: fd 1 */
     close(STDERR_FILENO);
     (void)open(devnull, O_WRONLY);      /* Stderr: fd 2 */
-}
-
-gboolean
-crm_is_writable(const char *dir, const char *file,
-                const char *user, const char *group, gboolean need_both)
-{
-    int s_res = -1;
-    struct stat buf;
-    char *full_file = NULL;
-    const char *target = NULL;
-
-    gboolean pass = TRUE;
-    gboolean readwritable = FALSE;
-
-    CRM_ASSERT(dir != NULL);
-    if (file != NULL) {
-        full_file = crm_concat(dir, file, '/');
-        target = full_file;
-        s_res = stat(full_file, &buf);
-        if (s_res == 0 && S_ISREG(buf.st_mode) == FALSE) {
-            crm_err("%s must be a regular file", target);
-            pass = FALSE;
-            goto out;
-        }
-    }
-
-    if (s_res != 0) {
-        target = dir;
-        s_res = stat(dir, &buf);
-        if (s_res != 0) {
-            crm_err("%s must exist and be a directory", dir);
-            pass = FALSE;
-            goto out;
-
-        } else if (S_ISDIR(buf.st_mode) == FALSE) {
-            crm_err("%s must be a directory", dir);
-            pass = FALSE;
-        }
-    }
-
-    if (user) {
-        struct passwd *sys_user = NULL;
-
-        sys_user = getpwnam(user);
-        readwritable = (sys_user != NULL
-                        && buf.st_uid == sys_user->pw_uid && (buf.st_mode & (S_IRUSR | S_IWUSR)));
-        if (readwritable == FALSE) {
-            crm_err("%s must be owned and r/w by user %s", target, user);
-            if (need_both) {
-                pass = FALSE;
-            }
-        }
-    }
-
-    if (group) {
-        struct group *sys_grp = getgrnam(group);
-
-        readwritable = (sys_grp != NULL
-                        && buf.st_gid == sys_grp->gr_gid && (buf.st_mode & (S_IRGRP | S_IWGRP)));
-        if (readwritable == FALSE) {
-            if (need_both || user == NULL) {
-                pass = FALSE;
-                crm_err("%s must be owned and r/w by group %s", target, group);
-            } else {
-                crm_warn("%s should be owned and r/w by group %s", target, group);
-            }
-        }
-    }
-
-  out:
-    free(full_file);
-    return pass;
 }
 
 char *


### PR DESCRIPTION
These commits lay the groundwork for enabling CIB_file to operate on the real CIB. They are not entirely necessary for that goal but helped me get familiar with the affected pieces. The I/O-related functions in lib/common/utils.c were separated into a new file io.c, and some reusable I/O bits of the CIB daemon were moved there. Similarly, the digest-related functions in lib/common/xml.c were separated into digest.c, and a bit of daemon code moved there.