### PR TITLE
Feature: fencing: cl#5134 - Support random fencing delay to avoid double fencing

### DIFF
--- a/fencing/main.c
+++ b/fencing/main.c
@@ -1294,6 +1294,15 @@ main(int argc, char **argv)
         printf("    <content type=\"string\" default=\"dynamic-list\"/>\n");
         printf("  </parameter>\n");
 
+        printf("  <parameter name=\"%s\" unique=\"0\">\n", STONITH_ATTR_DELAY_MAX);
+        printf
+            ("    <shortdesc lang=\"en\">Enable random delay for stonith actions and specify the maximum of random delay</shortdesc>\n");
+        printf
+            ("    <longdesc lang=\"en\">This prevents double fencing when using slow devices such as sbd.\n"
+             "Use this to enable random delay for stonith actions and specify the maximum of random delay.</longdesc>\n");
+        printf("    <content type=\"time\" default=\"0s\"/>\n");
+        printf("  </parameter>\n");
+
         for (lpc = 0; lpc < DIMOF(actions); lpc++) {
             printf("  <parameter name=\"pcmk_%s_action\" unique=\"0\">\n", actions[lpc]);
             printf

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -63,6 +63,8 @@ xmlNode *create_device_registration_xml(const char *id, const char *namespace, c
 #  define F_STONITH_TOLERANCE     "st_tolerance"
 /*! Action specific timeout period returned in query of fencing devices. */
 #  define F_STONITH_ACTION_TIMEOUT       "st_action_timeout"
+/*! Maximum of random fencing delay for a device */
+#  define F_STONITH_DELAY_MAX            "st_delay_max"
 /*! Has this device been verified using a monitor type
  *  operation (monitor, list, status) */
 #  define F_STONITH_DEVICE_VERIFIED   "st_monitor_verified"
@@ -103,6 +105,7 @@ xmlNode *create_device_registration_xml(const char *id, const char *namespace, c
 #  define STONITH_ATTR_HOSTMAP   "pcmk_host_map"
 #  define STONITH_ATTR_HOSTLIST  "pcmk_host_list"
 #  define STONITH_ATTR_HOSTCHECK "pcmk_host_check"
+#  define STONITH_ATTR_DELAY_MAX "pcmk_delay_max"
 
 #  define STONITH_ATTR_ACTION_OP   "action"
 


### PR DESCRIPTION
This prevents double fencing when using slow fencing devices such as sbd.
A "pcmk_delay_max" parameter can be configured for a fencing resource to
enable random delay for stonith actions and specify the maximum of
random delay.