### PR TITLE
Fix: crmd: Remove "shutdown" attribute if the node is down to prevent it from being shut down again

### DIFF
--- a/crmd/callbacks.c
+++ b/crmd/callbacks.c
@@ -178,9 +178,11 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                 /* Did the DC leave us? */
                 crm_notice("Our peer on the DC (%s) is dead", fsa_our_dc);
                 register_fsa_input(C_CRMD_STATUS_CALLBACK, I_ELECTION, NULL);
+                erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
 
             } else if(AM_I_DC && appeared == FALSE) {
                 crm_info("Peer %s left us", node->uname);
+                erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
                 /* crm_update_peer_join(__FUNCTION__, node, crm_join_none); */
             }
             break;

--- a/crmd/messages.c
+++ b/crmd/messages.c
@@ -780,6 +780,18 @@ handle_request(xmlNode * stored_msg, enum crmd_fsa_cause cause)
             crm_warn("Discarding %s op from %s", op, host_from);
         }
 
+    } else if (strcmp(op, CRM_OP_SHUTDOWN_NOTIFY) == 0) {
+        const char *shutdown_target = NULL;
+
+        msg = get_message_xml(stored_msg, F_CRM_DATA);
+        shutdown_target = crm_element_value(msg, XML_LRM_ATTR_TARGET);
+        if (shutdown_target) {
+            crm_node_t *node = crm_get_peer(0, shutdown_target);
+
+            crm_update_peer_expected(__FUNCTION__, node, CRMD_JOINSTATE_DOWN);
+        }
+        return I_NULL;
+
     } else if (strcmp(op, CRM_OP_PING) == 0) {
         /* eventually do some stuff to figure out
          * if we /are/ ok

--- a/crmd/te_actions.c
+++ b/crmd/te_actions.c
@@ -216,7 +216,7 @@ te_crm_command(crm_graph_t * graph, crm_action_t * action)
         te_action_confirmed(action);
         update_graph(graph, action);
         trigger_graph();
-        return TRUE;
+        goto done;
 
     } else if (safe_str_eq(task, CRM_OP_SHUTDOWN)) {
         crm_node_t *peer = crm_get_peer(0, router_node);
@@ -249,6 +249,13 @@ te_crm_command(crm_graph_t * graph, crm_action_t * action)
             action->timeout = graph->network_delay;
         }
         te_start_action_timer(graph, action);
+    }
+
+done:
+    if (rc == TRUE && safe_str_eq(task, CRM_OP_SHUTDOWN)) {
+        cmd = create_request(CRM_OP_SHUTDOWN_NOTIFY, action->xml, NULL, CRM_SYSTEM_CRMD, CRM_SYSTEM_CRMD, NULL);
+        send_cluster_message(NULL, crm_msg_crmd, cmd, TRUE);
+        free(cmd);
     }
 
     return TRUE;

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -111,6 +111,7 @@ extern char *crm_system_name;
 #  define CRM_OP_LOCAL_SHUTDOWN 	"start_shutdown"
 #  define CRM_OP_SHUTDOWN_REQ	"req_shutdown"
 #  define CRM_OP_SHUTDOWN 	"do_shutdown"
+#  define CRM_OP_SHUTDOWN_NOTIFY "notify_shutdown"
 #  define CRM_OP_FENCE	 	"stonith"
 #  define CRM_OP_EVENTCC		"event_cc"
 #  define CRM_OP_TEABORT		"te_abort"


### PR DESCRIPTION
There's race condition that "shutdown" attribute is not reset early
enough when the node comes back, which will cause the node to be
shut down again:

crmd[...]: error: handle_request: We didn't ask to be shut down, yet our DC is telling us too