### PR TITLE
Move reusable CIB daemon code to the CIB library

### DIFF
--- a/cib/cibio.h
+++ b/cib/cibio.h
@@ -1,16 +1,16 @@
-/* 
+/*
  * Copyright (C) 2004 Andrew Beekhof <andrew@beekhof.net>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public
  * License as published by the Free Software Foundation; either
  * version 2 of the License, or (at your option) any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -32,10 +32,6 @@
 
 extern gboolean initialized;
 extern xmlNode *the_cib;
-extern xmlNode *node_search;
-extern xmlNode *resource_search;
-extern xmlNode *constraint_search;
-extern xmlNode *status_search;
 
 extern xmlNode *get_the_CIB(void);
 

--- a/cib/io.c
+++ b/cib/io.c
@@ -653,13 +653,21 @@ write_cib_contents(gpointer p)
     umask(S_IWGRP | S_IWOTH | S_IROTH);
 
     tmp_cib_fd = mkstemp(tmp_cib);
-    if (tmp_cib_fd < 0 || write_xml_fd(cib_local, tmp_cib, tmp_cib_fd, FALSE) <= 0) {
+    if (tmp_cib_fd < 0) {
+        crm_perror(LOG_ERR, "Couldn't open temporary file %s for writing CIB", tmp_cib);
+        exit_rc = pcmk_err_cib_save;
+        goto cleanup;
+    }
+
+    fchmod(tmp_cib_fd, S_IRUSR | S_IWUSR); /* establish the correct permissions */
+    crm_xml_add_last_written(cib_local);
+    if (write_xml_fd(cib_local, tmp_cib, tmp_cib_fd, FALSE) <= 0) {
         crm_err("Changes couldn't be written to %s", tmp_cib);
         exit_rc = pcmk_err_cib_save;
         goto cleanup;
     }
 
-    /* Must calculate the digest after writing as write_xml_file() updates the last-written field */
+    /* Calculate the digest after writing, because we updated the last-written field */
     digest = calculate_on_disk_digest(cib_local);
     CRM_ASSERT(digest != NULL);
     crm_info("Wrote version %s.%s.0 of the CIB to disk (digest: %s)",

--- a/cib/io.c
+++ b/cib/io.c
@@ -50,39 +50,15 @@
 
 extern const char *cib_root;
 
-#define CIB_WRITE_PARANOIA	0
-
-const char *local_resource_path[] = {
-    XML_CIB_TAG_STATUS,
-};
-
-const char *resource_path[] = {
-    XML_CIB_TAG_RESOURCES,
-};
-
-const char *node_path[] = {
-    XML_CIB_TAG_NODES,
-};
-
-const char *constraint_path[] = {
-    XML_CIB_TAG_CONSTRAINTS,
-};
-
 crm_trigger_t *cib_writer = NULL;
 gboolean initialized = FALSE;
-xmlNode *node_search = NULL;
-xmlNode *resource_search = NULL;
-xmlNode *constraint_search = NULL;
-xmlNode *status_search = NULL;
 
 extern int cib_status;
 
-int set_connected_peers(xmlNode * xml_obj);
 int write_cib_contents(gpointer p);
-extern void cib_cleanup(void);
 
 static gboolean
-validate_cib_digest(xmlNode * local_cib, const char *sigfile)
+validate_cib_digest(xmlNode *local_cib, const char *sigfile)
 {
     gboolean passed = FALSE;
     char *expected = crm_read_contents(sigfile);
@@ -478,10 +454,6 @@ uninitializeCib(void)
 
     initialized = FALSE;
     the_cib = NULL;
-    node_search = NULL;
-    resource_search = NULL;
-    constraint_search = NULL;
-    status_search = NULL;
 
     crm_debug("Deallocating the CIB.");
 

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -187,6 +187,9 @@ int cib_internal_op(cib_t * cib, const char *op, const char *host,
                     xmlNode ** output_data, int call_options, const char *user_name);
 
 
-int cib_file_read_and_verify(const char *filename, const char *sigfile, xmlNode **root);
+int cib_file_read_and_verify(const char *filename, const char *sigfile,
+                             xmlNode **root);
+int cib_file_write_with_digest(xmlNode *cib_root, const char *cib_dirname,
+                               const char *cib_filename);
 
 #endif

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -1,16 +1,16 @@
-/* 
+/*
  * Copyright (C) 2004 Andrew Beekhof <andrew@beekhof.net>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public
  * License as published by the Free Software Foundation; either
  * version 2 of the License, or (at your option) any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -186,5 +186,7 @@ int cib_internal_op(cib_t * cib, const char *op, const char *host,
                     const char *section, xmlNode * data,
                     xmlNode ** output_data, int call_options, const char *user_name);
 
+
+int cib_file_read_and_verify(const char *filename, const char *sigfile, xmlNode **root);
 
 #endif

--- a/include/crm/error.h
+++ b/include/crm/error.h
@@ -53,6 +53,7 @@
 #  define pcmk_err_cib_backup           209
 #  define pcmk_err_cib_save             210
 #  define pcmk_err_schema_unchanged     211
+#  define pcmk_err_cib_corrupt          212
 #  define pcmk_err_panic                255
 
 const char *pcmk_strerror(int rc);

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -347,6 +347,7 @@ static inline void *realloc_safe(void *ptr, size_t size)
     return ret;
 }
 
+const char *crm_xml_add_last_written(xmlNode *xml_node);
 void crm_xml_dump(xmlNode * data, int options, char **buffer, int *offset, int *max, int depth);
 void crm_buffer_add_char(char **buffer, int *offset, int *max, char c);
 

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -170,6 +170,173 @@ cib_file_read_and_verify(const char *filename, const char *sigfile, xmlNode **ro
     return pcmk_ok;
 }
 
+#define CIB_SERIES "cib"
+#define CIB_SERIES_MAX 100
+#define CIB_SERIES_BZIP FALSE /* Must be false because archived copies are
+                                 created with hard links
+                               */
+
+static int
+cib_file_backup(const char *cib_dirname, const char *cib_filename)
+{
+    int rc = 0;
+    char *cib_path = crm_concat(cib_dirname, cib_filename, '/');
+    char *cib_digest = crm_concat(cib_path, "sig", '.');
+
+    /* Figure out what backup file sequence number to use */
+    int seq = get_last_sequence(cib_dirname, CIB_SERIES);
+    char *backup_path = generate_series_filename(cib_dirname, CIB_SERIES, seq,
+                                                 CIB_SERIES_BZIP);
+    char *backup_digest = crm_concat(backup_path, "sig", '.');
+
+    CRM_ASSERT((cib_path != NULL) && (cib_digest != NULL)
+               && (backup_path != NULL) && (backup_digest != NULL));
+
+    /* Remove the old backups if they exist */
+    unlink(backup_path);
+    unlink(backup_digest);
+
+    /* Back up the CIB, by hard-linking it to the backup name */
+    if ((link(cib_path, backup_path) < 0) && (errno != ENOENT)) {
+        crm_perror(LOG_ERR, "Could not archive %s by linking to %s", cib_path, backup_path);
+        rc = -1;
+
+    /* Back up the CIB signature similarly */
+    } else if ((link(cib_digest, backup_digest) < 0) && (errno != ENOENT)) {
+        crm_perror(LOG_ERR, "Could not archive %s by linking to %s", cib_digest, backup_digest);
+        rc = -1;
+
+    /* Update the last counter and ensure everything is sync'd to media */
+    } else {
+        write_last_sequence(cib_dirname, CIB_SERIES, seq + 1, CIB_SERIES_MAX);
+        crm_sync_directory(cib_dirname);
+        crm_info("Archived previous version as %s", backup_path);
+    }
+
+    free(cib_path);
+    free(cib_digest);
+    free(backup_path);
+    free(backup_digest);
+    return rc;
+}
+
+static void
+cib_file_prepare_xml(xmlNode *root)
+{
+    xmlNode *cib_status_root = NULL;
+
+    /* Always write out with num_updates=0 and current last-written timestamp */
+    crm_xml_add(root, XML_ATTR_NUMUPDATES, "0");
+    crm_xml_add_last_written(root);
+
+    /* Delete status section before writing to file, because
+     * we discard it on startup anyway, and users get confused by it */
+    cib_status_root = find_xml_node(root, XML_CIB_TAG_STATUS, TRUE);
+    CRM_LOG_ASSERT(cib_status_root != NULL);
+    if (cib_status_root != NULL) {
+        free_xml(cib_status_root);
+    }
+}
+
+int
+cib_file_write_with_digest(xmlNode *cib_root, const char *cib_dirname,
+                           const char *cib_filename)
+{
+    int exit_rc = pcmk_ok;
+    int rc, fd;
+    char *digest = NULL;
+
+    /* Detect CIB version for diagnostic purposes */
+    const char *epoch = crm_element_value(cib_root, XML_ATTR_GENERATION);
+    const char *admin_epoch = crm_element_value(cib_root,
+                                                XML_ATTR_GENERATION_ADMIN);
+
+    /* Determine full CIB and signature pathnames */
+    char *cib_path = crm_concat(cib_dirname, cib_filename, '/');
+    char *digest_path = crm_concat(cib_path, "sig", '.');
+
+    /* Create temporary file name patterns for writing out CIB and signature */
+    char *tmp_cib = g_strdup_printf("%s/cib.XXXXXX", cib_dirname);
+    char *tmp_digest = g_strdup_printf("%s/cib.XXXXXX", cib_dirname);
+
+    CRM_ASSERT((cib_path != NULL) && (digest_path != NULL)
+               && (tmp_cib != NULL) && (tmp_digest != NULL));
+
+    /* Ensure the admin didn't modify the existing CIB underneath us */
+    rc = cib_file_read_and_verify(cib_path, NULL, NULL);
+    if ((rc != pcmk_ok) && (rc != -ENOENT)) {
+        crm_err("%s was manually modified while the cluster was active!",
+                cib_path);
+        exit_rc = pcmk_err_cib_modified;
+        goto cleanup;
+    }
+
+    /* Back up the existing CIB */
+    if (cib_file_backup(cib_dirname, cib_filename) < 0) {
+        exit_rc = pcmk_err_cib_backup;
+        goto cleanup;
+    }
+
+    crm_debug("Writing CIB to disk");
+    umask(S_IWGRP | S_IWOTH | S_IROTH);
+    cib_file_prepare_xml(cib_root);
+
+    /* Write the CIB to a temporary file, so we can deploy (near) atomically */
+    fd = mkstemp(tmp_cib);
+    if (fd < 0) {
+        crm_perror(LOG_ERR, "Couldn't open temporary file %s for writing CIB",
+                   tmp_cib);
+        exit_rc = pcmk_err_cib_save;
+        goto cleanup;
+    }
+    fchmod(fd, S_IRUSR | S_IWUSR); /* establish the correct permissions */
+    if (write_xml_fd(cib_root, tmp_cib, fd, FALSE) <= 0) {
+        crm_err("Changes couldn't be written to %s", tmp_cib);
+        exit_rc = pcmk_err_cib_save;
+        goto cleanup;
+    }
+
+    /* Calculate CIB digest */
+    digest = calculate_on_disk_digest(cib_root);
+    CRM_ASSERT(digest != NULL);
+    crm_info("Wrote version %s.%s.0 of the CIB to disk (digest: %s)",
+             (admin_epoch ? admin_epoch : "0"), (epoch ? epoch : "0"), digest);
+
+    /* Write the CIB digest to a temporary file */
+    fd = mkstemp(tmp_digest);
+    if ((fd < 0) || (crm_write_sync(fd, digest) < 0)) {
+        crm_perror(LOG_ERR, "Could not write digest to file %s", tmp_digest);
+        exit_rc = pcmk_err_cib_save;
+        goto cleanup;
+    }
+    crm_debug("Wrote digest %s to disk", digest);
+
+    /* Verify that what we wrote is sane */
+    rc = cib_file_read_and_verify(tmp_cib, tmp_digest, NULL);
+    CRM_ASSERT(rc == 0);
+
+    /* Rename temporary files to live, and sync directory changes to media */
+    crm_debug("Activating %s", tmp_cib);
+    if (rename(tmp_cib, cib_path) < 0) {
+        crm_perror(LOG_ERR, "Couldn't rename %s as %s", tmp_cib, cib_path);
+        exit_rc = pcmk_err_cib_save;
+    }
+    if (rename(tmp_digest, digest_path) < 0) {
+        crm_perror(LOG_ERR, "Couldn't rename %s as %s", tmp_digest,
+                   digest_path);
+        exit_rc = pcmk_err_cib_save;
+    }
+    crm_sync_directory(cib_dirname);
+
+  cleanup:
+    free(cib_path);
+    free(digest_path);
+    free(digest);
+    free(tmp_digest);
+    free(tmp_cib);
+    return exit_rc;
+}
+
 cib_t *
 cib_file_new(const char *cib_location)
 {

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -1114,6 +1114,7 @@ pcmk_errorname(int rc)
         case pcmk_err_cib_modified: return "pcmk_err_cib_modified";
         case pcmk_err_cib_backup: return "pcmk_err_cib_backup";
         case pcmk_err_cib_save: return "pcmk_err_cib_save";
+        case pcmk_err_cib_corrupt: return "pcmk_err_cib_corrupt";
     }
     return "Unknown";
 }
@@ -1151,6 +1152,8 @@ pcmk_strerror(int rc)
             return "Could not archive the previous configuration";
         case pcmk_err_cib_save:
             return "Could not save the new configuration to disk";
+        case pcmk_err_cib_corrupt:
+            return "Could not parse on-disk configuration";
 
         case pcmk_err_schema_unchanged:
             return "Schema is already the latest available";


### PR DESCRIPTION
These refactoring commits are the final prep work for enabling CIB_file to operate on the real CIB. The effect is to segregate daemon-specific CIB code (mainloop stuff, global variables) from generic CIB code and move the latter to the CIB library. I tried as far as possible to avoid any behavioral changes; the only such changes should be improved error handling.

CTS with 25 random tests against a 3-node RHEL7 cluster completed without errors.

For "remove dead code", I grepped the entire code base to make sure the variables weren't used.

For all revisions, I checked cts/patterns.py to make sure no changed messages were used by CTS.