### PR TITLE
Automatically update .sig files in file backends when clients update live CIB

### DIFF
--- a/include/crm/common/io.h
+++ b/include/crm/common/io.h
@@ -34,6 +34,7 @@ char *generate_series_filename(const char *directory, const char *series, int se
                                gboolean bzip);
 int get_last_sequence(const char *directory, const char *series);
 void write_last_sequence(const char *directory, const char *series, int sequence, int max);
+int crm_chown_last_sequence(const char *directory, const char *series, uid_t uid, gid_t gid);
 
 gboolean crm_is_writable(const char *dir, const char *file, const char *user, const char *group,
                          gboolean need_both);

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -353,4 +353,7 @@ void crm_buffer_add_char(char **buffer, int *offset, int *max, char c);
 
 gboolean crm_digest_verify(xmlNode *input, const char *expected);
 
+/* cross-platform compatibility functions */
+char *crm_compat_realpath(const char *path);
+
 #endif                          /* CRM_INTERNAL__H */

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -23,8 +23,10 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
+#include <pwd.h>
 
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <glib.h>
 
 #include <crm/crm.h>
@@ -218,6 +220,14 @@ cib_file_is_live(const char *filename)
     return FALSE;
 }
 
+/* cib_file_backup() and cib_file_write_with_digest() need to chown the
+ * written files only in limited circumstances, so these variables allow
+ * that to be indicated without affecting external callers
+ */
+static uid_t cib_file_owner = 0;
+static uid_t cib_file_group = 0;
+static gboolean cib_do_chown = FALSE;
+
 /*!
  * \internal
  * \brief Back up a CIB
@@ -249,17 +259,38 @@ cib_file_backup(const char *cib_dirname, const char *cib_filename)
 
     /* Back up the CIB, by hard-linking it to the backup name */
     if ((link(cib_path, backup_path) < 0) && (errno != ENOENT)) {
-        crm_perror(LOG_ERR, "Could not archive %s by linking to %s", cib_path, backup_path);
+        crm_perror(LOG_ERR, "Could not archive %s by linking to %s",
+                   cib_path, backup_path);
         rc = -1;
 
     /* Back up the CIB signature similarly */
     } else if ((link(cib_digest, backup_digest) < 0) && (errno != ENOENT)) {
-        crm_perror(LOG_ERR, "Could not archive %s by linking to %s", cib_digest, backup_digest);
+        crm_perror(LOG_ERR, "Could not archive %s by linking to %s",
+                   cib_digest, backup_digest);
         rc = -1;
 
     /* Update the last counter and ensure everything is sync'd to media */
     } else {
         write_last_sequence(cib_dirname, CIB_SERIES, seq + 1, CIB_SERIES_MAX);
+        if (cib_do_chown) {
+            if ((chown(backup_path, cib_file_owner, cib_file_group) < 0)
+                    && (errno != ENOENT)) {
+                crm_perror(LOG_ERR, "Could not set owner of %s", backup_path);
+                rc = -1;
+            }
+            if ((chown(backup_digest, cib_file_owner, cib_file_group) < 0)
+                    && (errno != ENOENT)) {
+                crm_perror(LOG_ERR, "Could not set owner of %s", backup_digest);
+                rc = -1;
+            }
+            if (crm_chown_last_sequence(cib_dirname, CIB_SERIES, cib_file_owner,
+                                        cib_file_group) < 0) {
+                crm_perror(LOG_ERR,
+                           "Could not set owner of %s last sequence file",
+                           cib_dirname);
+                rc = -1;
+            }
+        }
         crm_sync_directory(cib_dirname);
         crm_info("Archived previous version as %s", backup_path);
     }
@@ -364,7 +395,22 @@ cib_file_write_with_digest(xmlNode *cib_root, const char *cib_dirname,
         exit_rc = pcmk_err_cib_save;
         goto cleanup;
     }
-    fchmod(fd, S_IRUSR | S_IWUSR); /* establish the correct permissions */
+
+    /* Protect the temporary file */
+    if (fchmod(fd, S_IRUSR | S_IWUSR) < 0) {
+        crm_perror(LOG_ERR, "Couldn't protect temporary file %s for writing CIB",
+                   tmp_cib);
+        exit_rc = pcmk_err_cib_save;
+        goto cleanup;
+    }
+    if (cib_do_chown && (fchown(fd, cib_file_owner, cib_file_group) < 0)) {
+        crm_perror(LOG_ERR, "Couldn't protect temporary file %s for writing CIB",
+                   tmp_cib);
+        exit_rc = pcmk_err_cib_save;
+        goto cleanup;
+    }
+
+    /* Write out the CIB */
     if (write_xml_fd(cib_root, tmp_cib, fd, FALSE) <= 0) {
         crm_err("Changes couldn't be written to %s", tmp_cib);
         exit_rc = pcmk_err_cib_save;
@@ -379,6 +425,12 @@ cib_file_write_with_digest(xmlNode *cib_root, const char *cib_dirname,
 
     /* Write the CIB digest to a temporary file */
     fd = mkstemp(tmp_digest);
+    if (cib_do_chown && (fchown(fd, cib_file_owner, cib_file_group) < 0)) {
+        crm_perror(LOG_ERR, "Couldn't protect temporary file %s for writing CIB",
+                   tmp_cib);
+        exit_rc = pcmk_err_cib_save;
+        goto cleanup;
+    }
     if ((fd < 0) || (crm_write_sync(fd, digest) < 0)) {
         crm_perror(LOG_ERR, "Could not write digest to file %s", tmp_digest);
         exit_rc = pcmk_err_cib_save;
@@ -430,6 +482,7 @@ cib_file_new(const char *cib_location)
     private->flags = 0;
     if (cib_file_is_live(cib_location)) {
         set_bit(private->flags, cib_flag_live);
+        crm_trace("File %s detected as live CIB", cib_location);
     }
     private->filename = strdup(cib_location);
 
@@ -447,49 +500,55 @@ cib_file_new(const char *cib_location)
 }
 
 static xmlNode *in_mem_cib = NULL;
+
+/*!
+ * \internal
+ * \brief Read CIB from disk and validate it against XML DTD
+ *
+ * \param[in] filename Name of file to read CIB from
+ *
+ * \return pcmk_ok on success,
+ *         -ENXIO if file does not exist (or stat() otherwise fails), or
+ *         -pcmk_err_schema_validation if XML doesn't parse or validate
+ * \note If filename is the live CIB, this will *not* verify its digest,
+ *       though that functionality would be trivial to add here.
+ *       Also, this will *not* verify that the file is writeable,
+ *       because some callers might not need to write.
+ */
 static int
 load_file_cib(const char *filename)
 {
-    int rc = pcmk_ok;
     struct stat buf;
     xmlNode *root = NULL;
-    gboolean dtd_ok = TRUE;
     const char *ignore_dtd = NULL;
-    xmlNode *status = NULL;
 
-    rc = stat(filename, &buf);
-    if (rc == 0) {
-        root = filename2xml(filename);
-        if (root == NULL) {
-            return -pcmk_err_schema_validation;
-        }
-
-    } else {
+    /* Ensure file is readable */
+    if (stat(filename, &buf) < 0) {
         return -ENXIO;
     }
 
-    rc = 0;
+    /* Parse XML from file */
+    root = filename2xml(filename);
+    if (root == NULL) {
+        return -pcmk_err_schema_validation;
+    }
 
-    status = find_xml_node(root, XML_CIB_TAG_STATUS, FALSE);
-    if (status == NULL) {
+    /* Add a status section if not already present */
+    if (find_xml_node(root, XML_CIB_TAG_STATUS, FALSE) == NULL) {
         create_xml_node(root, XML_CIB_TAG_STATUS);
     }
 
+    /* Validate XML against its specified DTD */
     ignore_dtd = crm_element_value(root, XML_ATTR_VALIDATION);
-    dtd_ok = validate_xml(root, NULL, TRUE);
-    if (dtd_ok == FALSE) {
+    if (validate_xml(root, NULL, TRUE) == FALSE) {
         crm_err("CIB does not validate against %s", ignore_dtd);
-        rc = -pcmk_err_schema_validation;
-        goto bail;
+        free_xml(root);
+        return -pcmk_err_schema_validation;
     }
 
+    /* Remember the parsed XML for later use */
     in_mem_cib = root;
-    return rc;
-
-  bail:
-    free_xml(root);
-    root = NULL;
-    return rc;
+    return pcmk_ok;
 }
 
 int
@@ -498,7 +557,7 @@ cib_file_signon(cib_t * cib, const char *name, enum cib_conn_type type)
     int rc = pcmk_ok;
     cib_file_opaque_t *private = cib->variant_opaque;
 
-    if (private->filename == FALSE) {
+    if (private->filename == NULL) {
         rc = -EINVAL;
     } else {
         rc = load_file_cib(private->filename);
@@ -517,6 +576,96 @@ cib_file_signon(cib_t * cib, const char *name, enum cib_conn_type type)
     return rc;
 }
 
+/*!
+ * \internal
+ * \brief Write out the in-memory CIB to a live CIB file
+ *
+ * param[in] path Full path to file to write
+ *
+ * \return 0 on success, -1 on failure
+ */
+static int
+cib_file_write_live(char *path)
+{
+    uid_t uid = geteuid();
+    struct passwd *daemon_pwent;
+    char *sep = strrchr(path, '/');
+    const char *cib_dirname, *cib_filename;
+    int rc = 0;
+
+    /* Get the desired uid/gid */
+    errno = 0;
+    daemon_pwent = getpwnam(CRM_DAEMON_USER);
+    if (daemon_pwent == NULL) {
+        crm_perror(LOG_ERR, "Could not find %s user", CRM_DAEMON_USER);
+        return -1;
+    }
+
+    /* If we're root, we can change the ownership;
+     * if we're daemon, anything we create will be OK;
+     * otherwise, block access so we don't create wrong owner
+     */
+    if ((uid != 0) && (uid == daemon_pwent->pw_uid)) {
+        crm_perror(LOG_ERR, "Must be root or %s to modify live CIB",
+                   CRM_DAEMON_USER);
+        return 0;
+    }
+
+    /* fancy footwork to separate dirname from filename
+     * (we know the canonical name maps to the live CIB,
+     * but the given name might be relative, or symlinked)
+     */
+    if (sep == NULL) { /* no directory component specified */
+        cib_dirname = "./";
+        cib_filename = path;
+    } else if (sep == path) { /* given name is in / */
+        cib_dirname = "/";
+        cib_filename = path + 1;
+    } else { /* typical case; split given name into parts */
+        *sep = '\0';
+        cib_dirname = path;
+        cib_filename = sep + 1;
+    }
+
+    /* if we're root, we want to update the file ownership */
+    if (uid == 0) {
+        cib_file_owner = daemon_pwent->pw_uid;
+        cib_file_group = daemon_pwent->pw_gid;
+        cib_do_chown = TRUE;
+    }
+
+    /* write the file */
+    if (cib_file_write_with_digest(in_mem_cib, cib_dirname,
+                                   cib_filename) != pcmk_ok) {
+        rc = -1;
+    }
+
+    /* turn off file ownership changes, for other callers */
+    if (uid == 0) {
+        cib_do_chown = FALSE;
+    }
+
+    /* undo fancy stuff */
+    if ((sep != NULL) && (*sep = '\0')) {
+        *sep = '/';
+    }
+
+    return rc;
+}
+
+/*!
+ * \internal
+ * \brief Sign-off method for CIB file variants
+ *
+ * This will write the file to disk if needed, and free the in-memory CIB. If
+ * the file is the live CIB, it will compute and write a signature as well.
+ *
+ * \param[in] cib CIB object to sign off
+ *
+ * \return pcmk_ok on success, pcmk_err_generic on failure
+ * \todo This method should refuse to write the live CIB if the CIB daemon is
+ *       running.
+ */
 int
 cib_file_signoff(cib_t * cib)
 {
@@ -524,32 +673,38 @@ cib_file_signoff(cib_t * cib)
     cib_file_opaque_t *private = cib->variant_opaque;
 
     crm_debug("Signing out of the CIB Service");
-
     cib->state = cib_disconnected;
     cib->type = cib_no_connection;
 
-    if (is_not_set(private->flags, cib_flag_dirty)) {
-        /* No changes to write out */
-        free_xml(in_mem_cib);
-        return pcmk_ok;
+    /* If the in-memory CIB has been changed, write it to disk */
+    if (is_set(private->flags, cib_flag_dirty)) {
 
-    } else if (strstr(private->filename, ".bz2") != NULL) {
-        rc = write_xml_file(in_mem_cib, private->filename, TRUE);
+        /* If this is the live CIB, write it out with a digest */
+        if (is_set(private->flags, cib_flag_live)) {
+            if (cib_file_write_live(private->filename) < 0) {
+                rc = pcmk_err_generic;
+            }
 
-    } else {
-        rc = write_xml_file(in_mem_cib, private->filename, FALSE);
+        /* Otherwise, it's a simple write */
+        } else {
+            gboolean do_bzip = (strstr(private->filename, ".bz2") != NULL);
+
+            if (write_xml_file(in_mem_cib, private->filename, do_bzip) <= 0) {
+                rc = pcmk_err_generic;
+            }
+        }
+
+        if (rc == pcmk_ok) {
+            crm_info("Wrote CIB to %s", private->filename);
+            clear_bit(private->flags, cib_flag_dirty);
+        } else {
+            crm_err("Could not write CIB to %s", private->filename);
+        }
     }
 
-    if (rc > 0) {
-        crm_info("Wrote CIB to %s", private->filename);
-        clear_bit(private->flags, cib_flag_dirty);
-        rc = pcmk_ok;
-
-    } else {
-        crm_err("Could not write CIB to %s: %s (%d)", private->filename, pcmk_strerror(rc), rc);
-    }
+    /* Free the in-memory CIB */
     free_xml(in_mem_cib);
-
+    in_mem_cib = NULL;
     return rc;
 }
 

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -605,7 +605,7 @@ cib_file_write_live(char *path)
      * if we're daemon, anything we create will be OK;
      * otherwise, block access so we don't create wrong owner
      */
-    if ((uid != 0) && (uid == daemon_pwent->pw_uid)) {
+    if ((uid != 0) && (uid != daemon_pwent->pw_uid)) {
         crm_perror(LOG_ERR, "Must be root or %s to modify live CIB",
                    CRM_DAEMON_USER);
         return 0;

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -32,7 +32,7 @@ lib_LTLIBRARIES	= libcrmcommon.la
 
 CFLAGS		= $(CFLAGS_COPY:-Wcast-qual=) -fPIC
 
-libcrmcommon_la_SOURCES	= digest.c ipc.c io.c utils.c xml.c iso8601.c remote.c mainloop.c logging.c watchdog.c
+libcrmcommon_la_SOURCES	= compat.c digest.c ipc.c io.c utils.c xml.c iso8601.c remote.c mainloop.c logging.c watchdog.c
 if BUILD_CIBSECRETS
 libcrmcommon_la_SOURCES	+= cib_secrets.c
 endif

--- a/lib/common/compat.c
+++ b/lib/common/compat.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015 Andrew Beekhof <andrew@beekhof.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+
+#include <crm_internal.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <errno.h>
+
+/*!
+ * \internal
+ * \brief Return canonicalized form of a path name, like realpath(path, NULL)
+ *
+ * \param[in] path Pathname to canonicalize
+ *
+ * \return Canonicalized pathname
+ * \note The caller is responsible for freeing the result of this funtion.
+ */
+char *
+crm_compat_realpath(const char *path)
+{
+#if _POSIX_VERSION >= 200809L
+    /* Recent C libraries can dynamically allocate memory as needed */
+    return realpath(path, NULL);
+
+#elif defined(PATH_MAX)
+    /* Older implementations require pre-allocated memory */
+    /* (this is less desirable because PATH_MAX may be huge or not defined) */
+    char *canonicalized = malloc(PATH_MAX);
+    if ((canonicalized == NULL) || (realpath(path, canonicalized) == NULL)) {
+        return NULL;
+    }
+    return canonicalized;
+#else
+    errno = ENOTSUP;
+    return NULL;
+#endif
+}

--- a/lib/common/io.c
+++ b/lib/common/io.c
@@ -237,6 +237,33 @@ write_last_sequence(const char *directory, const char *series, int sequence, int
 
 /*!
  * \internal
+ * \brief Change the owner and group of a file series' .last file
+ *
+ * \param[in] dir Directory that contains series
+ * \param[in] uid Uid of desired file owner
+ * \param[in] gid Gid of desired file group
+ *
+ * \return 0 on success, -1 on error (in which case errno will be set)
+ * \note The caller must have the appropriate privileges.
+ */
+int
+crm_chown_last_sequence(const char *directory, const char *series, uid_t uid, gid_t gid)
+{
+    char *series_file = NULL;
+    int rc;
+
+    CRM_CHECK((directory != NULL) && (series != NULL), errno = EINVAL; return -1);
+
+    series_file = g_strdup_printf("%s/%s.last", directory, series);
+    CRM_CHECK(series_file != NULL, return -1);
+
+    rc = chown(series_file, uid, gid);
+    free(series_file);
+    return rc;
+}
+
+/*!
+ * \internal
  * \brief Return whether a directory or file is writable by a user/group
  *
  * \param[in] dir Directory to check or that contains file


### PR DESCRIPTION
These commits allow the CIB library to detect when CIB_file points to the live CIB, and if so, it creates a signature file when writing. It will also back up the existing CIB in the backup series, and update the ownerships of all written files appropriately.

If you saw my earlier commits that did not get a pull request, the first three commits here are identical, but the tip is different. The earlier version dropped privileges to daemon before writing out the file; it turns out that is insufficient, as the file may already exist under a different ownership. This version changes the ownership after writing the file.

CTS with 25 random tests against a 3-node RHEL7 cluster completed with no errors. The actual functionality of running various tools with CIB_file pointing to the live CIB will need further testing when time permits, but CTS does exercise the functionality when it creates the initial test configuration using cibadmin, so it looks good at this point.