### PR TITLE
Enable support for private (non-CIB) attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ ylwrap
 Doxyfile
 coverage.sh
 cts/CTSvars.py
+cts/HBDummy
 cts/LSBDummy
 cts/benchmark/clubench
 cts/lxc_autogen.sh

--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -184,7 +184,7 @@ attrd_client_message(crm_client_t *client, xmlNode *xml)
     static int plus_plus_len = 5;
     const char *op = crm_element_value(xml, F_ATTRD_TASK);
 
-    if(safe_str_eq(op, "peer-remove")) {
+    if (safe_str_eq(op, ATTRD_OP_PEER_REMOVE)) {
         const char *host = crm_element_value(xml, F_ATTRD_HOST);
 
         crm_info("Client %s is requesting all values for %s be removed", client->name, host);
@@ -192,7 +192,7 @@ attrd_client_message(crm_client_t *client, xmlNode *xml)
             broadcast = TRUE;
         }
 
-    } else if(safe_str_eq(op, "update")) {
+    } else if (safe_str_eq(op, ATTRD_OP_UPDATE)) {
         attribute_t *a = NULL;
         attribute_value_t *v = NULL;
         char *key = crm_element_value_copy(xml, F_ATTRD_KEY);
@@ -288,7 +288,7 @@ attrd_client_message(crm_client_t *client, xmlNode *xml)
         free(set);
         free(host);
 
-    } else if(safe_str_eq(op, "refresh")) {
+    } else if (safe_str_eq(op, ATTRD_OP_REFRESH)) {
         GHashTableIter iter;
         attribute_t *a = NULL;
 
@@ -341,13 +341,13 @@ attrd_peer_message(crm_node_t *peer, xmlNode *xml)
 
     } else if(v == NULL) {
         /* From the non-atomic version */
-        if(safe_str_eq(op, "update")) {
+        if (safe_str_eq(op, ATTRD_OP_UPDATE)) {
             const char *name = crm_element_value(xml, F_ATTRD_ATTRIBUTE);
 
             crm_trace("Compatibility update of %s from %s", name, peer->uname);
             attrd_peer_update(peer, xml, host, FALSE);
 
-        } else if(safe_str_eq(op, "flush")) {
+        } else if (safe_str_eq(op, ATTRD_OP_FLUSH)) {
             const char *name = crm_element_value(xml, F_ATTRD_ATTRIBUTE);
             attribute_t *a = g_hash_table_lookup(attributes, name);
 
@@ -356,7 +356,7 @@ attrd_peer_message(crm_node_t *peer, xmlNode *xml)
                 write_or_elect_attribute(a);
             }
 
-        } else if(safe_str_eq(op, "refresh")) {
+        } else if (safe_str_eq(op, ATTRD_OP_REFRESH)) {
             GHashTableIter aIter;
             attribute_t *a = NULL;
 
@@ -387,13 +387,13 @@ attrd_peer_message(crm_node_t *peer, xmlNode *xml)
         }
     }
 
-    if(safe_str_eq(op, "update")) {
+    if (safe_str_eq(op, ATTRD_OP_UPDATE)) {
         attrd_peer_update(peer, xml, host, FALSE);
 
-    } else if(safe_str_eq(op, "sync")) {
+    } else if (safe_str_eq(op, ATTRD_OP_SYNC)) {
         attrd_peer_sync(peer, xml);
 
-    } else if(safe_str_eq(op, "peer-remove")) {
+    } else if (safe_str_eq(op, ATTRD_OP_PEER_REMOVE)) {
         int host_id = 0;
         char *endptr = NULL;
 
@@ -406,7 +406,7 @@ attrd_peer_message(crm_node_t *peer, xmlNode *xml)
         attrd_peer_remove(host_id, host, TRUE, peer->uname);
 
 
-    } else if(safe_str_eq(op, "sync-response")
+    } else if (safe_str_eq(op, ATTRD_OP_SYNC_RESPONSE)
               && safe_str_neq(peer->uname, attrd_cluster->uname)) {
         xmlNode *child = NULL;
 
@@ -428,7 +428,7 @@ attrd_peer_sync(crm_node_t *peer, xmlNode *xml)
     attribute_value_t *v = NULL;
     xmlNode *sync = create_xml_node(NULL, __FUNCTION__);
 
-    crm_xml_add(sync, F_ATTRD_TASK, "sync-response");
+    crm_xml_add(sync, F_ATTRD_TASK, ATTRD_OP_SYNC_RESPONSE);
 
     g_hash_table_iter_init(&aIter, attributes);
     while (g_hash_table_iter_next(&aIter, NULL, (gpointer *) & a)) {
@@ -540,7 +540,7 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
         crm_notice("%s[%s]: local value '%s' takes priority over '%s' from %s",
                    a->id, host, v->current, value, peer->uname);
 
-        crm_xml_add(sync, F_ATTRD_TASK, "sync-response");
+        crm_xml_add(sync, F_ATTRD_TASK, ATTRD_OP_SYNC_RESPONSE);
         v = g_hash_table_lookup(a->values, host);
         build_attribute_xml(sync, a->id, a->set, a->uuid, a->timeout_ms, a->user, a->is_private,
                             v->nodename, v->nodeid, v->current);

--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -177,30 +177,6 @@ create_attribute(xmlNode *xml)
     return a;
 }
 
-static void attrd_client_peer_remove(const char *client_name, xmlNode *xml);
-static void attrd_client_update(xmlNode *xml);
-static void attrd_client_refresh(void);
-
-void
-attrd_client_message(crm_client_t *client, xmlNode *xml)
-{
-    const char *op = crm_element_value(xml, F_ATTRD_TASK);
-
-    if (safe_str_eq(op, ATTRD_OP_PEER_REMOVE)) {
-        attrd_client_peer_remove(client->name, xml);
-
-    } else if (safe_str_eq(op, ATTRD_OP_UPDATE)) {
-        attrd_client_update(xml);
-
-    } else if (safe_str_eq(op, ATTRD_OP_REFRESH)) {
-        attrd_client_refresh();
-
-    } else {
-        crm_info("Ignoring request from client %s with unknown operation %s",
-                 client->name, op);
-    }
-}
-
 /*!
  * \internal
  * \brief Respond to a client peer-remove request (i.e. propagate to all peers)
@@ -210,7 +186,7 @@ attrd_client_message(crm_client_t *client, xmlNode *xml)
  *
  * \return void
  */
-static void
+void
 attrd_client_peer_remove(const char *client_name, xmlNode *xml)
 {
     const char *host = crm_element_value(xml, F_ATTRD_HOST);
@@ -233,7 +209,7 @@ attrd_client_peer_remove(const char *client_name, xmlNode *xml)
  *
  * \return void
  */
-static void
+void
 attrd_client_update(xmlNode *xml)
 {
     attribute_t *a = NULL;
@@ -337,7 +313,7 @@ attrd_client_update(xmlNode *xml)
  *
  * \return void
  */
-static void
+void
 attrd_client_refresh(void)
 {
     GHashTableIter iter;

--- a/attrd/internal.h
+++ b/attrd/internal.h
@@ -24,6 +24,9 @@ GHashTable *attributes;
 election_t *writer;
 int attrd_error;
 
+#define attrd_send_ack(client, id, flags) \
+    crm_ipcs_send_ack((client), (id), (flags), "ack", __FUNCTION__, __LINE__)
+
 void write_attributes(bool all, bool peer_discovered);
 void attrd_peer_message(crm_node_t *client, xmlNode *msg);
 void attrd_client_peer_remove(const char *client_name, xmlNode *xml);

--- a/attrd/internal.h
+++ b/attrd/internal.h
@@ -26,7 +26,10 @@ int attrd_error;
 
 void write_attributes(bool all, bool peer_discovered);
 void attrd_peer_message(crm_node_t *client, xmlNode *msg);
-void attrd_client_message(crm_client_t *client, xmlNode *msg);
+void attrd_client_peer_remove(const char *client_name, xmlNode *xml);
+void attrd_client_update(xmlNode *xml);
+void attrd_client_refresh(void);
+
 void free_attribute(gpointer data);
 
 gboolean attrd_election_cb(gpointer user_data);

--- a/attrd/internal.h
+++ b/attrd/internal.h
@@ -31,7 +31,3 @@ void free_attribute(gpointer data);
 
 gboolean attrd_election_cb(gpointer user_data);
 void attrd_peer_change_cb(enum crm_status_type type, crm_node_t *peer, const void *data);
-
-xmlNode *build_attribute_xml(
-    xmlNode *parent, const char *name, const char *set, const char *uuid, unsigned int timeout, const char *user,
-    const char *peer, uint32_t peerid, const char *value);

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -212,7 +212,6 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
     xmlNode *xml = crm_ipcs_recv(client, data, size, &id, &flags);
     const char *op;
 
-    crm_ipcs_send_ack(client, id, flags, "ack", __FUNCTION__, __LINE__);
     if (xml == NULL) {
         crm_debug("No msg from %d (%p)", crm_ipcs_client_pid(c), c);
         return 0;
@@ -228,12 +227,15 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
     op = crm_element_value(xml, F_ATTRD_TASK);
 
     if (safe_str_eq(op, ATTRD_OP_PEER_REMOVE)) {
+        attrd_send_ack(client, id, flags);
         attrd_client_peer_remove(client->name, xml);
 
     } else if (safe_str_eq(op, ATTRD_OP_UPDATE)) {
+        attrd_send_ack(client, id, flags);
         attrd_client_update(xml);
 
     } else if (safe_str_eq(op, ATTRD_OP_REFRESH)) {
+        attrd_send_ack(client, id, flags);
         attrd_client_refresh();
 
     } else {

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -210,6 +210,7 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
     uint32_t flags = 0;
     crm_client_t *client = crm_client_get(c);
     xmlNode *xml = crm_ipcs_recv(client, data, size, &id, &flags);
+    const char *op;
 
     crm_ipcs_send_ack(client, id, flags, "ack", __FUNCTION__, __LINE__);
     if (xml == NULL) {
@@ -224,7 +225,21 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
     crm_trace("Processing msg from %d (%p)", crm_ipcs_client_pid(c), c);
     crm_log_xml_trace(xml, __FUNCTION__);
 
-    attrd_client_message(client, xml);
+    op = crm_element_value(xml, F_ATTRD_TASK);
+
+    if (safe_str_eq(op, ATTRD_OP_PEER_REMOVE)) {
+        attrd_client_peer_remove(client->name, xml);
+
+    } else if (safe_str_eq(op, ATTRD_OP_UPDATE)) {
+        attrd_client_update(xml);
+
+    } else if (safe_str_eq(op, ATTRD_OP_REFRESH)) {
+        attrd_client_refresh();
+
+    } else {
+        crm_info("Ignoring request from client %s with unknown operation %s",
+                 client->name, op);
+    }
 
     free_xml(xml);
     return 0;

--- a/include/crm/attrd.h
+++ b/include/crm/attrd.h
@@ -19,8 +19,13 @@
 #  define CRM_ATTRD__H
 #  include <crm/common/ipc.h>
 
+/* attribute options for clients to use with attrd_update_delegate() */
+#define attrd_opt_none    0x000
+#define attrd_opt_remote  0x001
+#define attrd_opt_private 0x002
+
 int attrd_update_delegate(crm_ipc_t * ipc, char command, const char *host,
                           const char *name, const char *value, const char *section,
-                          const char *set, const char *dampen, const char *user_name, gboolean is_remote);
+                          const char *set, const char *dampen, const char *user_name, int options);
 
 #endif

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -286,6 +286,15 @@ int crm_read_pidfile(const char *filename);
 #  define F_ATTRD_WRITER	"attr_writer"
 #  define F_ATTRD_VERSION	"attr_version"
 
+/* attrd operations */
+#  define ATTRD_OP_PEER_REMOVE   "peer-remove"
+#  define ATTRD_OP_UPDATE        "update"
+#  define ATTRD_OP_QUERY         "query"
+#  define ATTRD_OP_REFRESH       "refresh"
+#  define ATTRD_OP_FLUSH         "flush"
+#  define ATTRD_OP_SYNC          "sync"
+#  define ATTRD_OP_SYNC_RESPONSE "sync-response"
+
 #  if SUPPORT_COROSYNC
 #    if CS_USES_LIBQB
 #      include <qb/qbipc_common.h>

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -276,6 +276,7 @@ int crm_read_pidfile(const char *filename);
 #  define F_ATTRD_VALUE		"attr_value"
 #  define F_ATTRD_SET		"attr_set"
 #  define F_ATTRD_IS_REMOTE	"attr_is_remote"
+#  define F_ATTRD_IS_PRIVATE     "attr_is_private"
 #  define F_ATTRD_SECTION	"attr_section"
 #  define F_ATTRD_DAMPEN	"attr_dampening"
 #  define F_ATTRD_IGNORE_LOCALLY "attr_ignore_locally"

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -1741,7 +1741,7 @@ stonith_ipc_server_init(qb_ipcs_service_t **ipcs, struct qb_ipcs_service_handler
 int
 attrd_update_delegate(crm_ipc_t * ipc, char command, const char *host, const char *name,
                       const char *value, const char *section, const char *set, const char *dampen,
-                      const char *user_name, gboolean is_remote)
+                      const char *user_name, int options)
 {
     int rc = -ENOTCONN;
     int max = 5;
@@ -1803,7 +1803,8 @@ attrd_update_delegate(crm_ipc_t * ipc, char command, const char *host, const cha
     crm_xml_add(update, F_ATTRD_SECTION, section);
     crm_xml_add(update, F_ATTRD_HOST, host);
     crm_xml_add(update, F_ATTRD_SET, set);
-    crm_xml_add_int(update, F_ATTRD_IS_REMOTE, is_remote);
+    crm_xml_add_int(update, F_ATTRD_IS_REMOTE, is_set(options, attrd_opt_remote));
+    crm_xml_add_int(update, F_ATTRD_IS_PRIVATE, is_set(options, attrd_opt_private));
 #if ENABLE_ACL
     if (user_name) {
         crm_xml_add(update, F_ATTRD_USER, user_name);

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -1778,23 +1778,24 @@ attrd_update_delegate(crm_ipc_t * ipc, char command, const char *host, const cha
 
     switch (command) {
         case 'u':
-            crm_xml_add(update, F_ATTRD_TASK, "update");
+            crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_UPDATE);
             crm_xml_add(update, F_ATTRD_REGEX, name);
             break;
         case 'D':
         case 'U':
         case 'v':
-            crm_xml_add(update, F_ATTRD_TASK, "update");
+            crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_UPDATE);
             crm_xml_add(update, F_ATTRD_ATTRIBUTE, name);
             break;
         case 'R':
-            crm_xml_add(update, F_ATTRD_TASK, "refresh");
+            crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_REFRESH);
             break;
-        case 'q':
-            crm_xml_add(update, F_ATTRD_TASK, "query");
+        case 'Q':
+            crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_QUERY);
+            crm_xml_add(update, F_ATTRD_ATTRIBUTE, name);
             break;
         case 'C':
-            crm_xml_add(update, F_ATTRD_TASK, "peer-remove");
+            crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_PEER_REMOVE);
             break;
     }
 

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -61,6 +61,9 @@ static struct crm_option long_options[] = {
     {"delay",   1, 0, 'd', "The time to wait (dampening) in seconds further changes occur"},
     {"set",     1, 0, 's', "(Advanced) The attribute set in which to place the value"},
     {"node",    1, 0, 'N', "Set the attribute for the named node (instead of the local one)"},
+#ifdef HAVE_ATOMIC_ATTRD
+    {"private", 0, 0, 'p', "\tNever write attribute to CIB (but it can be updated and queried as usual)"},
+#endif
 
     /* Legacy options */
     {"update",  1, 0, 'v', NULL, 1},
@@ -74,6 +77,7 @@ main(int argc, char **argv)
 {
     int index = 0;
     int argerr = 0;
+    int attr_options = attrd_opt_none;
     int flag;
 
     crm_log_cli_init("attrd_updater");
@@ -113,6 +117,11 @@ main(int argc, char **argv)
             case 'N':
                 attr_node = strdup(optarg);
                 break;
+#ifdef HAVE_ATOMIC_ATTRD
+            case 'p':
+                set_bit(attr_options, attrd_opt_private);
+                break;
+#endif
             case 'q':
                 break;
             case 'Q':
@@ -147,7 +156,7 @@ main(int argc, char **argv)
 
     } else {
         int rc = attrd_update_delegate(NULL, command, attr_node, attr_name, attr_value, attr_section,
-                                       attr_set, attr_dampen, NULL, FALSE);
+                                       attr_set, attr_dampen, NULL, attr_options);
         if (rc != pcmk_ok) {
             fprintf(stderr, "Could not update %s=%s: %s (%d)\n", attr_name, attr_value, pcmk_strerror(rc), rc);
         }

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -57,12 +57,15 @@ static struct crm_option long_options[] = {
     {"refresh", 0, 0, 'R', "\t(Advanced) Force the attrd daemon to resend all current values to the CIB\n"},    
     
     {"-spacer-",1, 0, '-', "\nAdditional options:"},
-    {"lifetime",1, 0, 'l', "Lifetime of the node attribute.  Allowed values: forever, reboot"},
-    {"delay",   1, 0, 'd', "The time to wait (dampening) in seconds further changes occur"},
+    {"delay",   1, 0, 'd', "The time to wait (dampening) in seconds for further changes before writing"},
     {"set",     1, 0, 's', "(Advanced) The attribute set in which to place the value"},
     {"node",    1, 0, 'N', "Set the attribute for the named node (instead of the local one)"},
 #ifdef HAVE_ATOMIC_ATTRD
+    /* lifetime could be implemented for atomic attrd if there is sufficient user demand */
+    {"lifetime",1, 0, 'l', "(Deprecated) Lifetime of the node attribute (silently ignored by cluster)"},
     {"private", 0, 0, 'p', "\tNever write attribute to CIB (but it can be updated and queried as usual)"},
+#else
+    {"lifetime",1, 0, 'l', "Lifetime of the node attribute.  Allowed values: forever, reboot"},
 #endif
 
     /* Legacy options */


### PR DESCRIPTION
These commits enable support for private attributes (i.e. ones which will never be written to the CIB) in attrd, libcrmcommon's attrd_update_delegate() function, and the attrd_updater tool.  This request has been amended and rebased to (1) revert whitespace-only changes per beekhof; and (2) get some recently merged commits that were needed for further work. Of particular interest:

* The first three commits were already reviewed by beekhof.

* dcfa267 flags a potential bug in attrd with a comment for later investigation.

* 2a3b375 is unrelated to this project: It adds HBDummy to .gitignore (commit 190e756 introduced cts/HBDummy.in but neglected to do this).

* 77bb239 fixes an attrd bug introduced in 7714443

I ran CTS with 25 random tests against a 3-node RHEL cluster to ensure I didn't break anything, and then I tested using attrd_updater to add public and private attributes with all cluster nodes up, with one cluster node restarted, and with one cluster node down before the changes and brought up afterwards, and everything behaved as expected. I used /var/log/pacemaker.log to confirm that the private attributes were propagated to all nodes; attrd_updater does not yet support querying.