### PR TITLE
Update Pacemaker Explained for clarity, consistency and current syntax

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -25,6 +25,9 @@ ascii		= crm_fencing.txt acls.txt
 docbook		= Pacemaker_Explained Clusters_from_Scratch Pacemaker_Remote
 doc_DATA	= README.hb2openais $(ascii) $(generated_docs)
 
+# rsync destination for www targets
+RSYNC_DEST      = root@www.clusterlabs.org:/var/www/html/doc/
+
 publican_docs   =
 generated_docs	=
 generated_mans	=
@@ -127,7 +130,6 @@ docbook_build = $(docbook:%=%.build)
 
 all-local: $(docbook_build) */publican.cfg
 
-#install-data-local: all-local
 install-data-local: all-local
 	for book in $(docbook); do 							\
 	    filelist=`find $$book/publish/* -print`;					\
@@ -154,16 +156,11 @@ brand:  $(BRAND_PNGS) $(wildcard publican-clusterlabs/en-US/*.xml)
 pdf:
 	make DOCBOOK_FORMATS="pdf" ASCIIDOC_CLI_TYPE=$(ASCIIDOC_CLI_TYPE) all-local
 
-# Make sure www-(pcs|crmsh) happen in serial
 www: clean-local $(generated_docs) $(ascii)
 	make www-cli
-	rsync -rtz --progress $(generated_docs) $(ascii) $(asciiman) root@www.clusterlabs.org:/var/www/html/doc/
+	rsync -rtz --progress $(generated_docs) $(ascii) $(asciiman) $(RSYNC_DEST)
 
-www-crmsh:
-	make ASCIIDOC_CLI_TYPE=crmsh clean-local www-cli
-
-www-pcs:
-	make ASCIIDOC_CLI_TYPE=pcs www-cli
+www-pcs: www-cli
 
 www-cli:
 	for book in $(docbook); do 										\
@@ -180,7 +177,7 @@ if BUILD_DOCBOOK
 			mv $$book/publish/$$lang/Pacemaker/$(PACKAGE_SERIES)-$(ASCIIDOC_CLI_TYPE)/epub/$$book/Pacemaker-1.1{-$(ASCIIDOC_CLI_TYPE),}-$$book-$$lang.epub;	\
 			mv $$book/publish/$$lang/Pacemaker/$(PACKAGE_SERIES)-$(ASCIIDOC_CLI_TYPE)/pdf/$$book/Pacemaker-1.1{-$(ASCIIDOC_CLI_TYPE),}-$$book-$$lang.pdf;	\
 		done;											\
-		rsync -rtz --progress $$book/publish/* root@www.clusterlabs.org:/var/www/html/doc/;	\
+		rsync -rtz --progress $$book/publish/* $(RSYNC_DEST);					\
 		sed -i.sed 's@version:.*@version: $(PACKAGE_SERIES)@' $$book/publican.cfg;		\
 	done
 endif

--- a/doc/Pacemaker_Explained/en-US/Ap-LSB.txt
+++ b/doc/Pacemaker_Explained/en-US/Ap-LSB.txt
@@ -18,7 +18,7 @@ LSB-compatible:
 ----
 +
   .. Did the service start?
-  .. Did the command print result: 0 (in addition to the regular output)?
+  .. Did the command print *result: 0* (in addition to its usual output)?
 +
 . Status (running):
 +
@@ -28,7 +28,7 @@ LSB-compatible:
 +
   .. Did the script accept the command?
   .. Did the script indicate the service was running?
-  .. Did the command print result: 0 (in addition to the regular output)?
+  .. Did the command print *result: 0* (in addition to its usual output)?
 +
 . Start (running):
 +
@@ -37,7 +37,7 @@ LSB-compatible:
 ----
 +
   .. Is the service still running?
-  .. Did the command print result: 0 (in addition to the regular output)?
+  .. Did the command print *result: 0* (in addition to its usual output)?
 +
 . Stop (running):
 +
@@ -46,7 +46,7 @@ LSB-compatible:
 ----
 +
   .. Was the service stopped?
-  .. Did the command print result: 0 (in addition to the regular output)?
+  .. Did the command print *result: 0* (in addition to its usual output)?
 +
 . Status (stopped):
 +
@@ -56,7 +56,7 @@ LSB-compatible:
 +
   .. Did the script accept the command?
   .. Did the script indicate the service was not running?
-  .. Did the command print result: 3 (in addition to the regular output)?
+  .. Did the command print *result: 3* (in addition to its usual output)?
 +
 . Stop (stopped):
 +
@@ -65,18 +65,17 @@ LSB-compatible:
 ----
 +
   .. Is the service still stopped?
-  .. Did the command print result: 0 (in addition to the regular output)?
+  .. Did the command print *result: 0* (in addition to its usual output)?
 +
 . Status (failed):
 +
-This step is not readily testable and relies on manual inspection of the script.
+.. This step is not readily testable and relies on manual inspection of the script.
 +
 The script can use one of the error codes (other than 3) listed in the
 LSB spec to indicate that it is active but failed. This tells the
 cluster that before moving the resource to another node, it needs to
 stop it on the existing one first.
 
-
 If the answer to any of the above questions is no, then the script is
-not LSB compliant. Your options are then to either fix the script or
+not LSB-compliant. Your options are then to either fix the script or
 write an OCF agent based on the existing script.

--- a/doc/Pacemaker_Explained/en-US/Ap-OCF.txt
+++ b/doc/Pacemaker_Explained/en-US/Ap-OCF.txt
@@ -66,17 +66,17 @@ NOTE: This is _not_ performed as root.
 
 |validate-all
 |Verify the supplied parameters
-|Exit with 0 if parameters are valid, 2 if not valid, 6 if resource is not configured.
+|Return 0 if parameters are valid, 2 if not valid, and 6 if resource is not configured.
  indexterm:[validate-all,OCF Action]
  indexterm:[OCF,Action,validate-all]
 
 |=========================================================
 
-Additional requirements (not part of the OCF specs) are placed on
-agents that will be used for advanced concepts like
+Additional requirements (not part of the OCF specification) are placed on
+agents that will be used for advanced concepts such as
 <<s-resource-clone,clones>> and <<s-resource-multistate,multi-state>> resources.
 
-.Optional Actions for OCF Agents
+.Optional Actions for OCF Resource Agents
 [width="95%",cols="2m,6,3",options="header",align="center"]
 |=========================================================
 
@@ -85,19 +85,19 @@ agents that will be used for advanced concepts like
 |Instructions
 
 |promote
-|Promote the local instance of a multi-state resource to the master/primary state.
+|Promote the local instance of a multi-state resource to the master (primary) state.
 |Return 0 on success
  indexterm:[promote,OCF Action]
  indexterm:[OCF,Action,promote]
 
 |demote
-|Demote the local instance of a multi-state resource to the slave/secondary state.
+|Demote the local instance of a multi-state resource to the slave (secondary) state.
 |Return 0 on success
  indexterm:[demote,OCF Action]
  indexterm:[OCF,Action,demote]
 
 |notify
-|Used by the cluster to send the agent pre and post notification
+|Used by the cluster to send the agent pre- and post-notification
  events telling the resource what has happened and will happen.
 |Must not fail. Must exit with 0
  indexterm:[notify,OCF Action]
@@ -105,13 +105,15 @@ agents that will be used for advanced concepts like
 
 |=========================================================
 
-One action specified in the OCF specs is not currently used by the cluster:
+One action specified in the OCF specs, +recover+, is not currently used by the
+cluster. It is intended to be a variant of the +start+ action that tries to
+recover a resource locally.
 
-* +recover+ - a variant of the +start+ action, this should try to
-  recover a resource locally.
-
-Remember to use indexterm:[ocf-tester]`ocf-tester` to verify that your
-new agent complies with the OCF standard properly.
+[IMPORTANT]
+====
+If you create a new OCF resource agent, use indexterm:[ocf-tester]`ocf-tester`
+to verify that the agent complies with the OCF standard properly.
+====
 
 === How are OCF Return Codes Interpreted? ===
 
@@ -150,12 +152,14 @@ indexterm:[OCF,error,fatal]
 
 |=========================================================
 
-Assuming an action is considered to have failed, the following table
-outlines the different OCF return codes and the type of recovery the
-cluster will initiate when it is received.
-
 [[s-ocf-return-codes]]
 === OCF Return Codes ===
+
+The following table outlines the different OCF return codes and the type of
+recovery the cluster will initiate when a failure code is received.
+Although counterintuitive, even actions that return 0
+(aka. +OCF_SUCCESS+) can be considered to have failed, if 0 was not
+the expected return value.
 
 .OCF Return Codes and their Recovery Types
 [width="95%",cols="1m,4<m,6<,1m",options="header",align="center"]
@@ -224,35 +228,34 @@ indexterm:[Return Code,7,OCF_NOT_RUNNING]
 
 |8
 |OCF_RUNNING_MASTER
-|The resource is running in +Master+ mode.
+|The resource is running in master mode.
 indexterm:[Return Code,OCF_RUNNING_MASTER]
 indexterm:[Return Code,8,OCF_RUNNING_MASTER]
 |soft
 
 |9
 |OCF_FAILED_MASTER
-|The resource is in +Master+ mode but has failed. The resource will be demoted, stopped and then started (and possibly promoted) again.
+|The resource is in master mode but has failed. The resource will be demoted,
+stopped and then started (and possibly promoted) again.
 indexterm:[Return Code,OCF_FAILED_MASTER]
 indexterm:[Return Code,9,OCF_FAILED_MASTER]
 |soft
 
 |other
-|NA
+|N/A
 |Custom error code.
 indexterm:[Return Code,other]
 |soft
 
 |=========================================================
 
-Although counterintuitive, even actions that return 0
-(aka. +OCF_SUCCESS+) can be considered to have failed.
+Exceptions to the recovery handling described above:
 
-=== Exceptions ===
-
-* Non-recurring monitor actions (probes) that find a resource active
-  (or in Master mode) will not result in recovery action unless it is
-  also found active elsewhere
+* Probes (non-recurring monitor actions) that find a resource active
+  (or in master mode) will not result in recovery action unless it is
+  also found active elsewhere.
 * The recovery action taken when a resource is found active more than
-  once is determined by the _multiple-active_ property of the resource
+  once is determined by the resource's +multiple-active+ property
+  (see <<s-resource-options>>).
 * Recurring actions that return +OCF_ERR_UNIMPLEMENTED+
-  do not cause any type of recovery
+  do not cause any type of recovery.

--- a/doc/Pacemaker_Explained/en-US/Ap-OCF.txt
+++ b/doc/Pacemaker_Explained/en-US/Ap-OCF.txt
@@ -6,22 +6,24 @@
 === Location of Custom Scripts ===
 
 indexterm:[OCF Resource Agents]
-OCF Resource Agents are found in '/usr/lib/ocf/resource.d/+provider+'.
+OCF Resource Agents are found in +/usr/lib/ocf/resource.d/pass:[<replaceable>provider</replaceable>]+
 
 When creating your own agents, you are encouraged to create a new
-directory under _/usr/lib/ocf/resource.d/_ so that they are not
-confused with (or overwritten by) the agents shipped with Heartbeat.
+directory under +/usr/lib/ocf/resource.d/+ so that they are not
+confused with (or overwritten by) the agents shipped by existing providers.
 
-So, for example, if you chose the provider name of bigCorp and wanted
-a new resource named bigApp, you would create a script called
-_/usr/lib/ocf/resource.d/bigCorp/bigApp_ and define a resource:
+So, for example, if you choose the provider name of bigCorp and want
+a new resource named bigApp, you would create a resource agent called
++/usr/lib/ocf/resource.d/bigCorp/bigApp+ and define a resource:
  
 [source,XML]
+----
 <primitive id="custom-app" class="ocf" provider="bigCorp" type="bigApp"/>
+----
 
 === Actions ===
 
-All OCF Resource Agents are required to implement the following actions
+All OCF resource agents are required to implement the following actions.
 
 .Required Actions for OCF Agents
 [width="95%",cols="3m,3,7",options="header",align="center"]
@@ -60,7 +62,7 @@ NOTE: The monitor script should test the state of the resource on the local mach
  indexterm:[meta-data,OCF Action]
  indexterm:[OCF,Action,meta-data]
 
-NOTE: This is *not* performed as root.
+NOTE: This is _not_ performed as root.
 
 |validate-all
 |Verify the supplied parameters
@@ -115,7 +117,7 @@ new agent complies with the OCF standard properly.
 
 The first thing the cluster does is to check the return code against
 the expected result.  If the result does not match the expected value,
-then the operation is considered to have failed and recovery action is
+then the operation is considered to have failed, and recovery action is
 initiated.
 
 There are three types of failure recovery:
@@ -141,7 +143,7 @@ indexterm:[hard,OCF error]
 indexterm:[OCF,error,hard]
 
 |fatal
-|A non-transient error that will be common to all cluster nodes (eg. a bad configuration was specified)
+|A non-transient error that will be common to all cluster nodes (e.g. a bad configuration was specified)
 |Stop the resource and prevent it from being started on any cluster node
 indexterm:[fatal,OCF error]
 indexterm:[OCF,error,fatal]
@@ -156,7 +158,7 @@ cluster will initiate when it is received.
 === OCF Return Codes ===
 
 .OCF Return Codes and their Recovery Types
-[width="95%",cols="2m,5^m,6<,1m",options="header",align="center"]
+[width="95%",cols="1m,4<m,6<,1m",options="header",align="center"]
 |=========================================================
 
 |RC
@@ -180,7 +182,7 @@ indexterm:[Return Code,1,OCF_ERR_GENERIC]
 
 |2
 |OCF_ERR_ARGS
-|The resource's configuration is not valid on this machine. Eg. refers to a location/tool not found on the node. 
+|The resource's configuration is not valid on this machine. E.g. it refers to a location not found on the node. 
 indexterm:[Return Code,OCF_ERR_ARGS]
 indexterm:[Return Code,2,OCF_ERR_ARGS]
 |hard
@@ -208,7 +210,7 @@ indexterm:[Return Code,5,OCF_ERR_INSTALLED]
 
 |6
 |OCF_ERR_CONFIGURED
-|The resource's configuration is invalid. Eg. required parameters are missing.
+|The resource's configuration is invalid. E.g. required parameters are missing.
 indexterm:[Return Code,OCF_ERR_CONFIGURED]
 indexterm:[Return Code,6,OCF_ERR_CONFIGURED]
 |fatal

--- a/doc/Pacemaker_Explained/en-US/Ap-Upgrade-Config.txt
+++ b/doc/Pacemaker_Explained/en-US/Ap-Upgrade-Config.txt
@@ -1,6 +1,10 @@
 [appendix]
 
-== Upgrading the Configuration from 0.6 ==
+== Upgrading the Configuration ==
+
+This process was originally written for the upgrade from 0.6.'x' to 1.'y',
+but the concepts should apply for any upgrade involving a change in
+the XML schema version.
 
 indexterm:[Upgrading the Configuration]
 indexterm:[Configuration,Upgrading]
@@ -15,11 +19,11 @@ Refer to the appendix: <<ap-upgrade>>
 
 As XML is not the friendliest of languages, it is common for cluster
 administrators to have scripted some of their activities. In such
-cases, it is likely that those scripts will not work with the new 1.0
+cases, it is likely that those scripts will not work with the new XML
 syntax.
 
 In order to support such environments, it is actually possible to
-continue using the old 0.6 syntax.
+continue using the old XML syntax.
 
 The downside is, however, that not all the new features will be
 available and there is a performance impact since the cluster must do
@@ -28,9 +32,9 @@ while using the old syntax is possible, it is not advisable to
 continue using it indefinitely.
 
 Even if you wish to continue using the old syntax, it is advisable to
-follow the upgrade procedure to ensure that the cluster is able to use
-your existing configuration (since it will perform much the same task
-internally).
+follow the upgrade procedure (except for the last step) to ensure that the
+cluster is able to use your existing configuration (since it will perform much
+the same task internally).
 
 . Create a shadow copy to work with
 +
@@ -55,7 +59,10 @@ internally).
 The most common reason is ID values being repeated or invalid. Pacemaker 1.0 is much stricter regarding this type of validation.
 ]
 +
-If the result of the transformation is invalid, you may see a number of errors from the validation library. If these are not helpful, visit http://clusterlabs.org/wiki/Validation_FAQ and/or try the procedure described below under <<s-upgrade-config-manual>>
+If the result of the transformation is invalid, you may see a number of errors
+from the validation library. If these are not helpful, visit the
+http://clusterlabs.org/wiki/Validation_FAQ[Validation FAQ wiki page] and/or try
+the procedure described below under <<s-upgrade-config-manual>>
 +        
 . Check the changes
 +
@@ -69,11 +76,10 @@ If at this point there is anything about the upgrade that you wish to fine-tune 
 # crm_shadow --edit
 -----
 +
-This will open the configuration in your favorite editor (whichever is specified by the standard +$EDITOR+ environment variable)
+This will open the configuration in your favorite editor (whichever is
+specified by the standard *$EDITOR* environment variable)
 +
-. Preview how the cluster will react
-+
-Test what the cluster will do when you upload the new configuration
+. Preview how the cluster will react:
 +
 ------
 # crm_simulate --live-check --save-dotfile upgrade06.dot -S
@@ -85,24 +91,25 @@ happy with any that are scheduled.  If the output contains actions you
 do not expect (possibly due to changes to the score calculations), you
 may need to make further manual changes.  See
 <<s-config-testing-changes>> for further details on how to interpret
-the output of `crm_simulate`
+the output of `crm_simulate` and `graphviz`.
 +
 . Upload the changes
 +
 -----
 # crm_shadow --commit upgrade06 --force
 -----
-If this step fails, something really strange has occurred. You should report a bug.
++
+In the unlikely event this step fails, please report a bug.
 
 [[s-upgrade-config-manual]]
 ==== Manually Upgrading the Configuration ====
 
 indexterm:[Configuration,Upgrade manually]
-It is also possible to perform the configuration upgrade steps manually. To do this
+It is also possible to perform the configuration upgrade steps manually:
 
-Locate the 'upgrade06.xsl' conversion script or download the latest
-version from
-https://github.com/ClusterLabs/pacemaker/tree/master/xml/upgrade06.xsl[Git]
+. Locate the +upgrade06.xsl+ conversion script provided with the source code
+  (the https://github.com/ClusterLabs/pacemaker/tree/master/xml/upgrade06.xsl[latest version] is available via
+  git).
           
 . Convert the XML blob: indexterm:[XML,Convert]
 +
@@ -110,7 +117,7 @@ https://github.com/ClusterLabs/pacemaker/tree/master/xml/upgrade06.xsl[Git]
 # xsltproc /path/to/upgrade06.xsl config06.xml > config10.xml
 -----
 +          
-. Locate the 'pacemaker.rng' script.
+. Locate the +pacemaker.rng+ script.
 . Check the XML validity: indexterm:[Validate Configuration]indexterm:[Configuration,Validate XML]
 +
 ----

--- a/doc/Pacemaker_Explained/en-US/Ap-Upgrade.txt
+++ b/doc/Pacemaker_Explained/en-US/Ap-Upgrade.txt
@@ -1,18 +1,14 @@
 [appendix]
 
 [[ap-upgrade]]
-== Upgrading Cluster Software
+== Upgrading Cluster Software ==
 
-=== Version Compatibility ===
+There will always be an upgrade path from any pacemaker 1._x_
+release to any other 1._y_ release.
 
-When releasing newer versions we take care to make sure we are
-backwards compatible with older versions. While you will always be
-able to upgrade from version x to x+1, in order to continue to produce
-high quality software it may occasionally be necessary to drop
-compatibility with older versions.
-
-There will always be an upgrade path from any series-2 release to any
-other series-2 release.
+Consult the documentation for your messaging layer
+(Heartbeat or Corosync) to see whether upgrading them to a
+newer version is also supported.
 
 There are three approaches to upgrading your cluster software:
 
@@ -21,10 +17,10 @@ There are three approaches to upgrading your cluster software:
 * Disconnect and Reattach
 
 Each method has advantages and disadvantages, some of which are listed
-in the table below, and you should chose the one most appropriate to
+in the table below, and you should choose the one most appropriate to
 your needs.
 
-.Summary of Upgrade Methodologies
+.Upgrade Methods
 [width="95%",cols="6*",options="header",align="center"]
 |=========================================================
 
@@ -36,11 +32,7 @@ your needs.
 |Allows change of cluster stack type
 indexterm:[Cluster,Switching between Stacks]
 indexterm:[Changing Cluster Stack]
-footnote:[
-For example, switching from Heartbeat to Corosync.  Consult the
-Heartbeat or Corosync documentation to see if upgrading them to a
-newer version is also supported.
-]
+footnote:[For example, switching from Heartbeat to Corosync.]
 
 |Shutdown
 indexterm:[Upgrade,Shutdown]
@@ -73,53 +65,51 @@ indexterm:[Reattach Upgrade]
 
 === Complete Cluster Shutdown ===
 
-In this scenario one shuts down all cluster nodes and resources and
-upgrades all the nodes before restarting the cluster.
+In this scenario, one shuts down all cluster nodes and resources,
+then upgrades all the nodes before restarting the cluster.
 
-==== Procedure ====
 . On each node:
-.. Shutdown the cluster stack (Heartbeat or Corosync)
-.. Upgrade the Pacemaker software.
-   This may also include upgrading the cluster stack and/or the
-   underlying operating system.
+.. Shutdown the cluster software (pacemaker and the messaging layer).
+.. Upgrade the Pacemaker software. This may also include upgrading the
+   messaging layer and/or the underlying operating system.
 .. Check the configuration manually or with the `crm_verify` tool if available.
 . On each node:
-.. Start the cluster stack.
-   This can be either Corosync or Heartbeat and does not need to be
-   the same as the previous cluster stack.
+.. Start the cluster software.
+   The messaging layer can be either Corosync or Heartbeat and does not need to
+   be the same one before the upgrade.
 
 === Rolling (node by node) ===
 
-In this scenario each node is removed from the cluster, upgraded and then brought back online until all nodes are running the newest version.
+In this scenario, each node is removed from the cluster, upgraded and then
+brought back online until all nodes are running the newest version.
 
-[IMPORTANT]
-===========
-This method is currently broken between Pacemaker 0.6.x and 1.0.x.
-
-Measures have been put into place to ensure rolling upgrades always
-work for versions after 1.0.0.  Please try one of the other upgrade
-strategies.  Detach/Reattach is a particularly good option for most
-people.
-===========
-          
-==== Procedure ====
+Rolling upgrades should always be possible for pacemaker versions
+1.0.0 and later.
 
 On each node:
-. Shutdown the cluster stack (Heartbeat or Corosync)
-. Upgrade the Pacemaker software. This may also include upgrading the
-  cluster stack and/or the underlying operating system.
-.. On the first node, check the configuration manually or with the
-   `crm_verify` tool if available.
-.. Start the cluster stack.
-+
-This must be the same type of cluster stack (Corosync or Heartbeat)
-that the rest of the cluster is using.  Upgrading Corosync/Heartbeat
-may also be possible, please consult the documentation for those
-projects to see if the two versions will be compatible.
-+
-.. Repeat for each node in the cluster.
 
-==== Version Compatibility ====
+. Put the node into standby mode, and wait for any active resources
+  to be moved cleanly to another node.
+. Shutdown the cluster software (pacemaker and the messaging layer) on the node.
+. Upgrade the Pacemaker software. This may also include upgrading the
+  messaging layer and/or the underlying operating system.
+. If this is the first node to be upgraded, check the configuration manually
+  or with the `crm_verify` tool if available.
+. Start the messaging layer.
+  This must be the same messaging layer (Corosync or Heartbeat)
+  that the rest of the cluster is using.  Upgrading the messaging layer
+  may also be possible; consult the documentation for those
+  projects to see whether the two versions will be compatible.
+
+[NOTE]
+====
+Rolling upgrades were not always possible with older heartbeat and
+pacemaker versions. The table below shows which versions were
+compatible during rolling upgrades. Rolling upgrades that cross compatibility
+boundaries must be performed in multiple steps (for example,
+upgrading heartbeat 2.0.6 to heartbeat 2.1.3, and then upgrading again
+to pacemaker 0.6.6). Rolling upgrades from pacemaker 0._x_ to 1._y_ are not
+possible.
 
 .Version Compatibility Table
 [width="95%",cols="2*",options="header",align="center"]
@@ -147,59 +137,45 @@ projects to see if the two versions will be compatible.
 |None. Use an alternate upgrade strategy.
 
 |=========================================================
-
-==== Crossing Compatibility Boundaries ====
-
-Rolling upgrades that cross compatibility boundaries must be preformed
-in multiple steps. For example, to perform a rolling update from
-Heartbeat 2.0.1 to Pacemaker 0.6.6 one must:
-
-. Perform a rolling upgrade from Heartbeat 2.0.1 to Heartbeat 2.0.4 
-. Perform a rolling upgrade from Heartbeat 2.0.4 to Heartbeat 2.1.3
-. Perform a rolling upgrade from Heartbeat 2.1.3 to Pacemaker 0.6.6
+====
 
 === Disconnect and Reattach ===
 
-A variant of a complete cluster shutdown, but the resources are left
-active and get re-detected when the cluster is restarted.
+The reattach method is a variant of a complete cluster shutdown, where the
+resources are left active and get re-detected when the cluster is restarted.
 
-==== Procedure ====
-
-. Tell the cluster to stop managing services.
-+
-This is required to allow the services to remain active after the
-cluster shuts down.
+. Tell the cluster to stop managing services. This is required to allow the
+  services to remain active after the cluster shuts down.
 +
 ----
 # crm_attribute -t crm_config -n is-managed-default -v false
 ----
-+
+
 . For any resource that has a value for +is-managed+, make sure it is
-set to +false+ (so that the cluster will not stop it)
+set to +false+ so that the cluster will not stop it (replacing $rsc_id
+appropriately):
 +
 ----
 # crm_resource -t primitive -r $rsc_id -p is-managed -v false
 ----
-+
+
 . On each node:
-.. Shutdown the cluster stack (Heartbeat or Corosync)
-.. Upgrade the cluster stack program - This may also include upgrading
-the underlying operating system.
+.. Shutdown the cluster software (pacemaker and the messaging layer).
+.. Upgrade the Pacemaker software. This may also include upgrading the
+   messaging layer and/or the underlying operating system.
 . Check the configuration manually or with the `crm_verify` tool if available.
 . On each node:
-.. Start the cluster stack.
-+
-This can be either Corosync or Heartbeat and does not need to be the
-same as the previous cluster stack.
-+
+.. Start the cluster software. The messaging layer can be either Corosync or
+   Heartbeat and does not need to be the same one as before the upgrade.
+
 . Verify that the cluster re-detected all resources correctly.
 . Allow the cluster to resume managing resources again:
 +
 ----
 # crm_attribute -t crm_config -n is-managed-default -v true
 ----
-+
-. For any resource that has a value for +is-managed+ reset it to
+
+. For any resource that has a value for +is-managed+, reset it to
   +true+ (so the cluster can recover the service if it fails) if
   desired:
 +
@@ -207,14 +183,11 @@ same as the previous cluster stack.
 # crm_resource -t primitive -r $rsc_id -p is-managed -v true
 ----
 
-
-==== Notes ====
+[NOTE]
+The oldest version of the CRM to support this upgrade type was in Heartbeat 2.0.4.
 
 [IMPORTANT]
 ===========
 Always check your existing configuration is still compatible with the
 version you are installing before starting the cluster.
 ===========
-
-[NOTE]
-The oldest version of the CRM to support this upgrade type was in Heartbeat 2.0.4

--- a/doc/Pacemaker_Explained/en-US/Book_Info.xml
+++ b/doc/Pacemaker_Explained/en-US/Book_Info.xml
@@ -6,24 +6,19 @@
   <subtitle>An A-Z guide to Pacemaker's Configuration Options</subtitle>
   <productname>Pacemaker</productname>
   <productnumber>1.1</productnumber>
-  <edition>1</edition>
+  <!--
+	EDITION-PUBSNUMBER should match REVNUMBER in Revision_History.xml.
+	Increment EDITION when the syntax of the documented software
+	changes (pacemaker), and PUBSNUMBER for
+	simple textual changes (corrections, translations, etc.).
+  -->
+  <edition>5</edition>
   <pubsnumber>0</pubsnumber>
   <abstract>
     <para>
       The purpose of this document is to definitively explain the concepts used to configure Pacemaker.
-      To achieve this, it will focus exclusively on the XML syntax used to configure the CIB.
-    </para>
-    <para>
-      For those that are allergic to XML, there exist several unified shells
-      and GUIs for Pacemaker. However these tools will not be covered at all
-      in this document<footnote>
-        <para>I hope, however, that the concepts explained here make the functionality of these tools more easily understood.</para>
-      </footnote>, precisely because they hide the XML.
-    </para>
-    <para>
-      Additionally, this document is NOT a step-by-step how-to guide for configuring a specific clustering scenario.
-      Although such guides exist, the purpose of this document is to provide an understanding of the building blocks that can be used to construct any type of Pacemaker cluster.
-      Try the <ulink url="http://www.clusterlabs.org/doc">Clusters from Scratch</ulink> document instead.
+      To achieve this, it will focus exclusively on the XML syntax used to configure Pacemaker's
+      Cluster Information Base (CIB).
     </para>
   </abstract>
   <corpauthor>

--- a/doc/Pacemaker_Explained/en-US/Ch-Advanced-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Advanced-Options.txt
@@ -128,6 +128,8 @@ There are primarily two occasions when you would want to move a
 resource from its current location: when the whole node is under
 maintenance, and when a single resource needs to be moved.
 
+==== Standby Mode ====
+
 Since everything eventually comes down to a score, you could create
 constraints for every resource to prevent them from running on one
 node.  While pacemaker configuration can seem convoluted at times, not even
@@ -237,8 +239,13 @@ which has the same long-term consequences as discussed earlier.
 [[s-failure-migration]]
 === Moving Resources Due to Repeated Failure ===
 
+Normally, if a running resource fails, pacemaker will try to start
+it again on the same node. However if a resource fails repeatedly,
+it is possible that there is an underlying problem on that node, and you
+might desire trying a different node in such a case.
 
-New in 1.0 is the concept of a migration threshold.
+Pacemaker allows you to set your preference via the +migration-threshold+
+resource option.
 footnote:[
 The naming of this option was perhaps unfortunate as it is easily
 confused with live migration, the process of moving a resource from
@@ -296,15 +303,13 @@ The attribute name is customizable, in order to allow multiple ping groups to be
 ]
 
 [NOTE]
-Older versions of Heartbeat required users to add ping nodes to _ha.cf_ - this is no longer required.
-
-[IMPORTANT]
 ===========
-Older versions of Pacemaker used a custom binary called 'pingd' for
-this functionality; this is now deprecated in favor of 'ping'.
+Older versions of Heartbeat required users to add ping nodes to +ha.cf+, but
+this is no longer required.
 
-If your version of Pacemaker does not contain the ping agent, you can
-download the latest version from
+Older versions of Pacemaker used a different agent *ocf:pacemaker:pingd* which
+is now deprecated in favor of *ping*. If your version of Pacemaker does not
+contain the *ping* resource agent, download the latest version from
 https://github.com/ClusterLabs/pacemaker/tree/master/extra/resources/ping
 ===========
 
@@ -470,12 +475,17 @@ three (again assuming that +multiplier+ is set to 1000).
 -------
 =====
 
-=== Resource Migration ===
+=== Migrating Resources ===
 
-Some resources, such as Xen virtual guests, are able to move to
-another location without loss of state.  We call this resource
-migration; this is different from the normal practice of stopping the
-resource on the first machine and starting it elsewhere.
+Normally, when the cluster needs to move a resource, it fully restarts
+the resource (i.e. stops the resource on the current node
+and starts it on the new node).
+
+However, some types of resources, such as Xen virtual guests, are able to move to
+another location without loss of state (often referred to as live migration
+or hot migration). In pacemaker, this is called resource migration.
+Pacemaker can be configured to migrate a resource when moving it,
+rather than restarting it.
 
 Not all resources are able to migrate; see the Migration Checklist
 below, and those that can, won't do so in all situations.
@@ -500,30 +510,34 @@ Conversely for pull, the +migrate_to+ action is practically empty and
 +migrate_from+ does most of the work, extracting the relevant resource
 state from the old location and activating it.
 
-There is no wrong or right way to implement migration for your
-service, as long as it works.
+There is no wrong or right way for a resource agent to implement migration,
+as long as it works.
 
-==== Migration Checklist ====
-
+.Migration Checklist
 * The resource may not be a clone.
 * The resource must use an OCF style agent.
 * The resource must not be in a failed or degraded state.
-* The resource must not, directly or indirectly, depend on any
-  primitive or group resources.
-* The resource must support two new actions: +migrate_to+ and
-  +migrate_from+, and advertise them in its metadata.
+* The resource agent must support +migrate_to+ and
+  +migrate_from+ actions, and advertise them in its metadata.
 * The resource must have the +allow-migrate+ meta-attribute set to
   +true+ (which is not the default).
 
-////
-TODO: how can a KVM with DRBD migrate?
-////
+If an otherwise migratable resource depends on another resource
+via an ordering constraint, there are special situations in which it will be
+restarted rather than migrated.
 
-If the resource depends on a clone, and at the time the resource needs
-to be move, the clone has instances that are stopping and instances
-that are starting, then the resource will be moved in the traditional
-manner.  The Policy Engine is not yet able to model this situation
-correctly and so takes the safe (yet less optimal) path.
+For example, if the resource depends on a clone, and at the time the resource
+needs to be moved, the clone has instances that are stopping and instances
+that are starting, then the resource will be restarted.
+The Policy Engine is not yet able to model this
+situation correctly and so takes the safer (if less optimal) path.
+
+In pacemaker 1.1.11 and earlier, a migratable resource will be restarted
+when moving if it directly or indirectly depends on 'any' primitive or group
+resources.
+
+Even in newer versions, if a migratable resource depends on a non-migratable
+resource, and both need to be moved, the migratable resource will be restarted.
 
 [[s-reusing-config-elements]]
 == Reusing Rules, Options and Sets of Operations ==

--- a/doc/Pacemaker_Explained/en-US/Ch-Advanced-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Advanced-Options.txt
@@ -122,7 +122,7 @@ example, to specify an operation that would run on the first Monday of
 indexterm:[Moving,Resources] 
 indexterm:[Resource,Moving]
 
-=== Manual Intervention ===
+=== Moving Resources Manually ===
 
 There are primarily two occasions when you would want to move a
 resource from its current location: when the whole node is under
@@ -130,13 +130,13 @@ maintenance, and when a single resource needs to be moved.
 
 Since everything eventually comes down to a score, you could create
 constraints for every resource to prevent them from running on one
-node.  While the configuration can seem convoluted at times, not even
+node.  While pacemaker configuration can seem convoluted at times, not even
 we would require this of administrators.
 
 Instead, one can set a special node attribute which tells the cluster
 "don't let anything run here".  There is even a helpful tool to help
 query and set it, called `crm_standby`.  To check the standby status
-of the current machine, simply run:
+of the current machine, run:
 
 ----
 # crm_standby -G
@@ -162,8 +162,8 @@ Again, you can change another host's value by supplying a hostname with `--node`
 
 ==== Moving One Resource ====
 
-When only one resource is required to move, we do this by creating
-location constraints.  However, once again we provide a user friendly
+When only one resource is required to move, we could do this by creating
+location constraints.  However, once again we provide a user-friendly
 shortcut as part of the `crm_resource` command, which creates and
 modifies the extra constraints for you.  If +Email+ were running on
 +sles-1+ and you wanted it moved to a specific location, the command
@@ -235,13 +235,13 @@ positive and negative constraints. E.g.
 which has the same long-term consequences as discussed earlier.
 
 [[s-failure-migration]]
-=== Moving Resources Due to Failure ===
+=== Moving Resources Due to Repeated Failure ===
 
 
 New in 1.0 is the concept of a migration threshold.
 footnote:[
 The naming of this option was perhaps unfortunate as it is easily
-confused with true migration, the process of moving a resource from
+confused with live migration, the process of moving a resource from
 one node to another without stopping it.  Xen virtual guests are the
 most common example of resources that can be migrated in this manner.
 ]
@@ -251,20 +251,21 @@ migrate to a new node after 'N' failures.  There is no threshold defined
 by default.  To determine the resource's current failure status and
 limits, run `crm_mon --failcounts`.
 
-By default, once the threshold has been reached, this node will no
+By default, once the threshold has been reached, the troublesome node will no
 longer be allowed to run the failed resource until the administrator
 manually resets the resource's failcount using `crm_failcount` (after
-hopefully first fixing the failure's cause).  However it is possible
-to expire them by setting the resource's +failure-timeout+ option.
+hopefully first fixing the failure's cause).  Alternatively, it is possible
+to expire them by setting the +failure-timeout+ option for the resource.
 
-So a setting of +migration-threshold=2+ and +failure-timeout=60s+
+For example, a setting of +migration-threshold=2+ and +failure-timeout=60s+
 would cause the resource to move to a new node after 2 failures, and
-allow it to move back (depending on the stickiness and constraint
-scores) after one minute.
+allow it to move back (depending on stickiness and constraint scores) after one
+minute.
 
-There are two exceptions to the migration threshold concept; they
-occur when a resource either fails to start or fails to stop.  Start
-failures cause the failcount to be set to +INFINITY+ and thus always
+There are two exceptions to the migration threshold concept:
+when a resource either fails to start or fails to stop.
+
+Start failures cause the failcount to be set to +INFINITY+ and thus always
 cause the resource to move immediately.
 
 Stop failures are slightly different and crucial.  If a resource fails
@@ -275,23 +276,23 @@ to start the resource elsewhere, but will try to stop it again after
 the failure timeout.
 
 [IMPORTANT]
-Please read <<s-rules-recheck>> before enabling this option.
+Please read <<s-rules-recheck>> to understand how timeouts work
+before configuring a +failure-timeout+.
 
 === Moving Resources Due to Connectivity Changes ===
 
-Setting up the cluster to move resources when external connectivity is
-lost is a two-step process.
+You can configure the cluster to move resources when external connectivity is
+lost in two steps.
 
-==== Tell Pacemaker to monitor connectivity ====
+==== Tell Pacemaker to Monitor Connectivity ====
 
-
-To do this, you need to add a +ping+ resource to the cluster.  The
-+ping+ resource uses the system utility of the same name to a test if
+First, add an *ocf:pacemaker:ping* resource to the cluster.  The
+*ping* resource uses the system utility of the same name to a test whether
 list of machines (specified by DNS hostname or IPv4/IPv6 address) are
-reachable and uses the results to maintain a node attribute normally
-called +pingd+.
+reachable and uses the results to maintain a node attribute called +pingd+
+by default.
 footnote:[
-The attribute name is customizable; that allows multiple ping groups to be defined.
+The attribute name is customizable, in order to allow multiple ping groups to be defined.
 ]
 
 [NOTE]
@@ -307,7 +308,7 @@ download the latest version from
 https://github.com/ClusterLabs/pacemaker/tree/master/extra/resources/ping
 ===========
 
-Normally the resource will run on all cluster nodes, which means that
+Normally, the ping resource should run on all cluster nodes, which means that
 you'll need to create a clone.  A template for this can be found below
 along with a description of the most interesting parameters.
           
@@ -366,24 +367,21 @@ how to deal with the connectivity status that +ocf:pacemaker:ping+ is
 recording.
 ===========
 
-==== Tell Pacemaker how to interpret the connectivity data ====
+==== Tell Pacemaker How to Interpret the Connectivity Data ====
 
-[NOTE]
+[IMPORTANT]
 ======
-Before reading the following, please make sure you have read and
-understood <<ch-rules>> above.
+Before attempting the following, make sure you understand
+<<ch-rules>>.
 ======
 
-There are a number of ways to use the connectivity data provided by
-Heartbeat.  The most common setup is for people to have a single ping
-node, to prevent the cluster from running a resource on any
-unconnected node.
+There are a number of ways to use the connectivity data.
 
-////
-TODO: is the idea that only nodes that can reach eg. the router should have active resources?
-////
+The most common setup is for people to have a single ping
+target (e.g. the service network's default gateway), to prevent the cluster
+from running a resource on any unconnected node.
 
-.Don't run on unconnected nodes
+.Don't run a resource on unconnected nodes
 =====
 [source,XML]
 -------
@@ -395,23 +393,29 @@ TODO: is the idea that only nodes that can reach eg. the router should have acti
 -------
 =====
 
-A more complex setup is to have a number of ping nodes configured.
+A more complex setup is to have a number of ping targets configured.
 You can require the cluster to only run resources on nodes that can
 connect to all (or a minimum subset) of them.
 
-.Run only on nodes connected to three or more ping nodes; this assumes +multiplier+ is set to 1000:
+.Run only on nodes connected to three or more ping targets.
 =====
 [source,XML]
 -------
+<primitive id="ping" provider="pacemaker" class="ocf" type="ping">
+... <!-- omitting some configuration to highlight important parts -->
+      <nvpair id="pingd-multiplier" name="multiplier" value="1000"/>
+...
+</primitive>
+...
 <rsc_location id="WebServer-connectivity" rsc="Webserver">
    <rule id="ping-prefer-rule" score="-INFINITY" >
-    <expression id="ping-prefer" attribute="pingd" operation="lt" value="3000"/>
+      <expression id="ping-prefer" attribute="pingd" operation="lt" value="3000"/>
    </rule>
 </rsc_location>
 -------
 =====
 
-Instead you can tell the cluster only to _prefer_ nodes with the best
+Alternatively, you can tell the cluster only to _prefer_ nodes with the best
 connectivity.  Just be sure to set +multiplier+ to a value higher than
 that of +resource-stickiness+ (and don't set either of them to
 +INFINITY+).
@@ -473,17 +477,17 @@ another location without loss of state.  We call this resource
 migration; this is different from the normal practice of stopping the
 resource on the first machine and starting it elsewhere.
 
-Not all resources are able to migrate, see the Migration Checklist
+Not all resources are able to migrate; see the Migration Checklist
 below, and those that can, won't do so in all situations.
-Conceptually there are two requirements from which the other
+Conceptually, there are two requirements from which the other
 prerequisites follow:
 
-* the resource must be active and healthy at the old location
+* The resource must be active and healthy at the old location; and
 * everything required for the resource to run must be available on
-  both the old and new locations
+  both the old and new locations.
 
-The cluster is able to accommodate both push and pull migration models
-by requiring the resource agent to support two new actions:
+The cluster is able to accommodate both 'push' and 'pull' migration models
+by requiring the resource agent to support two special actions:
 +migrate_to+ (performed on the current location) and +migrate_from+
 (performed on the destination).
 
@@ -593,17 +597,17 @@ The same principle applies for +meta_attributes+ and
 == Reloading Services After a Definition Change ==
 
 The cluster automatically detects changes to the definition of
-services it manages.  However, the normal response is to stop the
+services it manages.  The normal response is to stop the
 service (using the old definition) and start it again (with the new
 definition).  This works well, but some services are smarter and can
 be told to use a new set of options without restarting.
 
-To take advantage of this capability, your resource agent must:
+To take advantage of this capability, the resource agent must:
 
 . Accept the +reload+ operation and perform any required actions.
-  _The steps required here depend completely on your application!_
+  _The actions here depend completely on your application!_
 +
-.The DRBD Agent's Control logic for Supporting the +reload+ Operation
+.The DRBD agent's logic for supporting +reload+
 =====
 [source,Bash]
 -------
@@ -680,9 +684,9 @@ field changes.
       
 [NOTE]
 ======
-The metadata is re-read when the resource is started.  This may mean
-that the resource will be restarted the first time, even though you
-changed a parameter with +unique=0+
+Metadata will not be re-read unless the resource needs to be started. This may
+mean that the resource will be restarted the first time, even though you
+changed a parameter with +unique=0+.
 ======
 
 [NOTE]

--- a/doc/Pacemaker_Explained/en-US/Ch-Advanced-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Advanced-Options.txt
@@ -47,20 +47,20 @@ node.
 
 |=========================================================
 
-So, if +c001n01+ is an active cluster node and is listening on +1234+
-for connections, and +someguy+ is a member of the +hacluster+ group,
-then the following would prompt for +someguy+'s password and return
+So, if *c001n01* is an active cluster node and is listening on port 1234
+for connections, and *someuser* is a member of the *hacluster* group,
+then the following would prompt for *someuser*'s password and return
 the cluster's current configuration:
 
 ----
-# export CIB_port=1234; export CIB_server=c001n01; export CIB_user=someguy;
+# export CIB_port=1234; export CIB_server=c001n01; export CIB_user=someuser;
 # cibadmin -Q
 ----
 
 For security reasons, the cluster does not listen for remote
 connections by default.  If you wish to allow remote access, you need
 to set the +remote-tls-port+ (encrypted) or +remote-clear-port+
-(unencrypted) top-level options (ie., those kept in the cib tag, like
+(unencrypted) CIB properties (i.e., those kept in the +cib+ tag, like
 +num_updates+ and +epoch+).
 
 .Extra top-level CIB properties for remote access
@@ -92,25 +92,25 @@ to set the +remote-tls-port+ (encrypted) or +remote-clear-port+
 By default, recurring actions are scheduled relative to when the
 resource started.  So if your resource was last started at 14:32 and
 you have a backup set to be performed every 24 hours, then the backup
-will always run at in the middle of the business day - hardly
+will always run at in the middle of the business day -- hardly
 desirable.
 
-To specify a date/time that the operation should be relative to, set
+To specify a date and time that the operation should be relative to, set
 the operation's +interval-origin+.  The cluster uses this point to
 calculate the correct +start-delay+ such that the operation will occur
 at _origin + (interval * N)_.
 
-So, if the operation's interval is 24h, it's interval-origin is set to
-+02:00+ and it is currently +14:32+, then the cluster would initiate
+So, if the operation's interval is 24h, its interval-origin is set to
+02:00 and it is currently 14:32, then the cluster would initiate
 the operation with a start delay of 11 hours and 28 minutes.  If the
-resource is moved to another node before 2am, then the operation is of
-course cancelled.
+resource is moved to another node before 2am, then the operation is
+cancelled.
 
-The value specified for interval and +interval-origin+ can be any
+The value specified for +interval+ and +interval-origin+ can be any
 date/time conforming to the
 http://en.wikipedia.org/wiki/ISO_8601[ISO8601 standard].  By way of
 example, to specify an operation that would run on the first Monday of
-2009 and every Monday after that you would add:
+2009 and every Monday after that, you would add:
 
 .Specifying a Base for Recurring Action Intervals
 =====
@@ -133,7 +133,7 @@ constraints for every resource to prevent them from running on one
 node.  While the configuration can seem convoluted at times, not even
 we would require this of administrators.
 
-Instead one can set a special node attribute which tells the cluster
+Instead, one can set a special node attribute which tells the cluster
 "don't let anything run here".  There is even a helpful tool to help
 query and set it, called `crm_standby`.  To check the standby status
 of the current machine, simply run:
@@ -225,8 +225,8 @@ where every other cluster node is no longer available!
 In some cases, such as when +resource-stickiness+ is set to
 +INFINITY+, it is possible that you will end up with the problem
 described in <<node-score-equal>>.  The tool can detect
-some of these cases and deals with them by also creating both a
-positive and negative constraint. Eg.
+some of these cases and deals with them by creating both
+positive and negative constraints. E.g.
 
 +Email+ prefers +sles-1+ with a score of +-INFINITY+
 
@@ -246,10 +246,10 @@ one node to another without stopping it.  Xen virtual guests are the
 most common example of resources that can be migrated in this manner.
 ]
 
-Simply define +migration-threshold=N+ for a resource and it will
-migrate to a new node after N failures.  There is no threshold defined
+Simply define +migration-threshold=pass:[<replaceable>N</replaceable>]+ for a resource and it will
+migrate to a new node after 'N' failures.  There is no threshold defined
 by default.  To determine the resource's current failure status and
-limits, use `crm_mon --failcounts`.
+limits, run `crm_mon --failcounts`.
 
 By default, once the threshold has been reached, this node will no
 longer be allowed to run the failed resource until the administrator
@@ -430,11 +430,11 @@ that of +resource-stickiness+ (and don't set either of them to
 
 It is perhaps easier to think of this in terms of the simple
 constraints that the cluster translates it into.  For example, if
-+sles-1+ is connected to all 5 ping nodes but +sles-2+ is only
-connected to 2, then it would be as if you instead had the following
+*sles-1* is connected to all five ping nodes but *sles-2* is only
+connected to two, then it would be as if you instead had the following
 constraints in your configuration:
 
-.How the cluster translates the pingd constraint
+.How the cluster translates the above location constraint
 =====
 [source,XML]
 -------

--- a/doc/Pacemaker_Explained/en-US/Ch-Advanced-Resources.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Advanced-Resources.txt
@@ -8,10 +8,10 @@ indexterm:[Resources,Groups]
 
 One of the most common elements of a cluster is a set of resources
 that need to be located together, start sequentially, and stop in the
-reverse order.  To simplify this configuration we support the concept
+reverse order.  To simplify this configuration, we support the concept
 of groups.
 
-.An example group
+.A group of two primitive resources
 ======
 [source,XML]
 -------
@@ -81,7 +81,7 @@ mount, an IP address, and an application that uses them.
 |Description
 
 |id
-|Your name for the group
+|A unique name for the group
  indexterm:[id,Group Resource Property]
  indexterm:[Resource,Group Property,id]
 
@@ -89,27 +89,27 @@ mount, an IP address, and an application that uses them.
 
 === Group Options ===
 
-Options inherited from <<s-resource-options,primitive>> resources:
-+priority, target-role, is-managed+
+Groups inherit the +priority+, +target-role+, and +is-managed+ properties
+from primitive resources. See <<s-resource-options>> for information about
+those properties.
 
 === Group Instance Attributes ===
 
-Groups have no instance attributes, however any that are set here will
-be inherited by the group's children.
+Groups have no instance attributes. However, any that are set for the group
+object will be inherited by the group's children.
 
 === Group Contents ===
 
-Groups may only contain a collection of
-<<primitive-resource>> cluster resources.  To refer to
-the child of a group resource, just use the child's id instead of the
-group's.
+Groups may only contain a collection of cluster resources (see
+<<primitive-resource>>).  To refer to a child of a group resource, just use
+the child's +id+ instead of the group's.
 
 === Group Constraints ===
 
-Although it is possible to reference the group's children in
-constraints, it is usually preferable to use the group's name instead.
+Although it is possible to reference a group's children in
+constraints, it is usually preferable to reference the group itself.
 
-.Example constraints involving groups
+.Some constraints involving groups
 ======
 [source,XML]
 -------
@@ -136,32 +136,32 @@ current location with a score of 500.
 indexterm:[Clone Resources]
 indexterm:[Resources,Clones]
 
-Clones were initially conceived as a convenient way to start N
-instances of an IP resource and have them distributed throughout the
+Clones were initially conceived as a convenient way to start multiple
+instances of an IP address resource and have them distributed throughout the
 cluster for load balancing.  They have turned out to quite useful for
-a number of purposes including integrating with Red Hat's DLM, the
-fencing subsystem, and OCFS2.
+a number of purposes including integrating with the Distributed Lock Manager
+(used by many cluster filesystems), the fencing subsystem, and OCFS2.
 
 You can clone any resource, provided the resource agent supports it.
 
 Three types of cloned resources exist:
 
 * Anonymous
-* Globally Unique
+* Globally unique
 * Stateful
 
-Anonymous clones are the simplest type.  These resources behave
+'Anonymous' clones are the simplest.  These behave
 completely identically everywhere they are running.  Because of this,
-there can only be one copy of an anonymous clone active per machine.
+there can be only one copy of an anonymous clone active per machine.
       
-Globally unique clones are distinct entities.  A copy of the clone
+'Globally unique' clones are distinct entities.  A copy of the clone
 running on one machine is not equivalent to another instance on
-another node.  Nor would any two copies on the same node be
+another node, nor would any two copies on the same node be
 equivalent.
 
-Stateful clones are covered later in <<s-resource-multistate>>.
+'Stateful' clones are covered later in <<s-resource-multistate>>.
 
-.An example clone
+.A clone of an LSB resource
 ======
 [source,XML]
 -------
@@ -184,7 +184,7 @@ Stateful clones are covered later in <<s-resource-multistate>>.
 |Description
 
 |id
-|Your name for the clone
+|A unique name for the clone
  indexterm:[id,Clone Property]
  indexterm:[Clone,Property,id]
 
@@ -255,7 +255,7 @@ will be inherited by the clone's children.
 
 === Clone Contents ===
 
-Clones must contain exactly one group or one regular resource.
+Clones must contain exactly one primitive or group resource.
 
 [WARNING]
 You should never reference the name of a clone's child.
@@ -285,7 +285,7 @@ Colocation between clones is also possible.  In such cases, the set of
 allowed locations for the clone is limited to nodes on which the clone
 is (or will be) active.  Allocation is then performed as normally.
 
-.Example constraints involving clones
+.Some constraints involving clones
 ======
 [source,XML]
 -------
@@ -320,22 +320,22 @@ other probes for instances of the clone should result in
 +$\{OCF_NOT_RUNNING}+ (or one of the other OCF error codes if
 they are failed).
 
-Copies of a clone are identified by appending a colon and a numerical
-offset, eg. +apache:2+.
+Individual instances of a clone are identified by appending a colon and a
+numerical offset, e.g. +apache:2+.
 
 Resource agents can find out how many copies there are by examining
 the +OCF_RESKEY_CRM_meta_clone_max+ environment variable and which
 copy it is by examining +OCF_RESKEY_CRM_meta_clone+.
 
-You should not make any assumptions (based on
-+OCF_RESKEY_CRM_meta_clone+) about which copies are active.  In
+The resource agent must not make any assumptions (based on
++OCF_RESKEY_CRM_meta_clone+) about which numerical instances are active.  In
 particular, the list of active copies will not always be an unbroken
 sequence, nor always start at 0.
 
 ==== Clone Notifications ====
 
 Supporting notifications requires the +notify+ action to be
-implemented.  Once supported, the notify action will be passed a
+implemented.  If supported, the notify action will be passed a
 number of extra variables which, when combined with additional
 context, can be used to calculate the current state of the cluster and
 what is about to happen to it.
@@ -458,12 +458,13 @@ OCF_RESKEY_CRM_meta_notify_start_uname="sles-1 sles-3 sles-2"
 indexterm:[Multi-state Resources]
 indexterm:[Resources,Multi-state]
 
-Multi-state resources are a specialization of Clone resources; please
-ensure you understand the section on clones before continuing! They
-allow the instances to be in one of two operating modes; these are
-called +Master+ and +Slave+, but can mean whatever you wish them to
-mean.  The only limitation is that when an instance is started, it
-must come up in the +Slave+ state.
+Multi-state resources are a specialization of clone resources; please
+ensure you understand <<s-resource-clone>> before continuing!
+
+Multi-state resources allow the instances to be in one of two operating modes
+(called 'roles'). The roles are called 'master' and 'slave', but can mean
+whatever you wish them to mean. The only limitation is that when an instance is
+started, it must come up in the slave role.
 
 === Multi-state Properties ===
 
@@ -516,11 +517,11 @@ Options inherited from <<s-resource-clone,clone>> resources:
 === Multi-state Instance Attributes ===
 
 Multi-state resources have no instance attributes; however, any that
-are set here will be inherited by master's children.
+are set here will be inherited by a master's children.
 
 === Multi-state Contents ===
 
-Masters must contain exactly one group or one regular resource.
+Masters must contain exactly one primitive or group resource.
 
 [WARNING]
 You should never reference the name of a master's child.
@@ -653,9 +654,9 @@ Colocation with regular clones and other multi-state resources is also
 possible.  In such cases, the set of allowed locations for the +rsc+
 clone is (after role filtering) limited to nodes on which the
 +with-rsc+ multi-state resource is (or will be) in the specified role.
-Allocation is then performed as-per-normal.
+Placement is then performed as normal.
 
-==== Using Multi-state Resources in Colocation/Ordering Sets ====
+==== Using Multi-state Resources in Colocation Sets ====
 
 .Additional colocation set options relevant to multi-state resources
 [width="95%",cols="1m,1,6<",options="header",align="center"]
@@ -675,7 +676,8 @@ Allocation is then performed as-per-normal.
 |=========================================================
 
 In the following example +B+'s master must be located on the same node as +A+'s master.
-Additionally resources +C+ and +D+ must be located on the same node as +B+'s master.
+Additionally resources +C+ and +D+ must be located on the same node as +A+'s
+and +B+'s masters.
 
 .Colocate C and D with A's and B's master instances
 ======
@@ -736,29 +738,29 @@ Additionally resources +C+ and +D+ must wait until +A+ and +B+ have been promote
 -------
 ======
 
+In the above example, +B+ cannot be promoted to a master role until +A+ has
+been promoted. Additionally, resources +C+ and +D+ must wait until +A+ and +B+
+have been promoted before they can start.
+
 
 === Multi-state Stickiness ===
 
 indexterm:[resource-stickiness,Multi-State]
-To achieve a stable allocation pattern, multi-state resources are
-slightly sticky by default.  If no value for +resource-stickiness+ is
-provided, the multi-state resource will use a value of 1.  Being a
-small value, it causes minimal disturbance to the score calculations
-of other resources but is enough to prevent Pacemaker from needlessly
-moving copies around the cluster.
+As with regular clones, multi-state resources are
+slightly sticky by default. See <<s-clone-stickiness>> for details.
 
 === Which Resource Instance is Promoted ===
 
-During the start operation, most Resource Agent scripts should call
+During the start operation, most resource agents should call
 the `crm_master` utility.  This tool automatically detects both the
 resource and host and should be used to set a preference for being
 promoted.  Based on this, +master-max+, and +master-node-max+, the
 instance(s) with the highest preference will be promoted.
 
-The other alternative is to create a location constraint that
+An alternative is to create a location constraint that
 indicates which nodes are most preferred as masters.
 
-.Manually specifying which node should be promoted
+.Explicitly preferring node1 to be promoted to master
 ======
 [source,XML]
 -------
@@ -770,12 +772,14 @@ indicates which nodes are most preferred as masters.
 -------
 ======
 
-=== Multi-state Resource Agent Requirements ===
+=== Requirements for Multi-state Resource Agents ===
 
 Since multi-state resources are an extension of cloned resources, all
-the requirements of Clones are also requirements of multi-state
-resources.  Additionally, multi-state resources require two extra
-actions: +demote+ and +promote+; these actions are responsible for
+the requirements for resource agents that support clones are also requirements
+for resource agents that support multi-state resources.
+
+Additionally, multi-state resources require two extra
+actions, +demote+ and +promote+, which are responsible for
 changing the state of the resource.  Like +start+ and +stop+, they
 should return +$\{OCF_SUCCESS}+ if they completed successfully or a
 relevant error code if they did not.
@@ -820,12 +824,12 @@ not indicate to the agent what role it currently believes it to be in.
 === Multi-state Notifications ===
 
 Like clones, supporting notifications requires the +notify+ action to
-be implemented.  Once supported the notify action will be passed a
+be implemented.  If supported, the notify action will be passed a
 number of extra variables which, when combined with additional
 context, can be used to calculate the current state of the cluster and
 what is about to happen to it.
           
-.Environment variables supplied with Master notify actions footnote:[Emphasized variables are specific to +Master+ resources and all behave in the same manner as described for Clone resources.]
+.Environment variables supplied with multi-state notify actions footnote:[Emphasized variables are specific to +Master+ resources, and all behave in the same manner as described for Clone resources.]
 [width="95%",cols="5,3<",options="header",align="center"]
 |=========================================================
 

--- a/doc/Pacemaker_Explained/en-US/Ch-Advanced-Resources.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Advanced-Resources.txt
@@ -266,24 +266,8 @@ If you think you need to do this, you probably need to re-evaluate your design.
 In most cases, a clone will have a single copy on each active cluster
 node.  If this is not the case, you can indicate which nodes the
 cluster should preferentially assign copies to with resource location
-constraints.  These constraints are written no differently to those
-for regular resources except that the clone's id is used.
-
-Ordering constraints behave slightly differently for clones.  In the
-example below, +apache-stats+ will wait until all copies of the clone
-that need to be started have done so before being started itself.
-Only if _no_ copies can be started +apache-stats+ will be prevented
-from being active.  Additionally, the clone will wait for
-+apache-stats+ to be stopped before stopping the clone.
-
-Colocation of a regular (or group) resource with a clone means that
-the resource can run on any machine with an active copy of the clone.
-The cluster will choose a copy based on where the clone is running and
-the resource's own location preferences.
-
-Colocation between clones is also possible.  In such cases, the set of
-allowed locations for the clone is limited to nodes on which the clone
-is (or will be) active.  Allocation is then performed as normally.
+constraints.  These constraints are written no differently from those
+for primitive resources except that the clone's +id+ is used.
 
 .Some constraints involving clones
 ======
@@ -297,6 +281,24 @@ is (or will be) active.  Allocation is then performed as normally.
 -------
 ======
 
+Ordering constraints behave slightly differently for clones.  In the
+example above, +apache-stats+ will wait until all copies of +apache-clone+
+that need to be started have done so before being started itself.
+Only if _no_ copies can be started will +apache-stats+ be prevented
+from being active.  Additionally, the clone will wait for
++apache-stats+ to be stopped before stopping itself.
+
+Colocation of a primitive or group resource with a clone means that
+the resource can run on any machine with an active copy of the clone.
+The cluster will choose a copy based on where the clone is running and
+the resource's own location preferences.
+
+Colocation between clones is also possible.  If one clone +A+ is colocated
+with another clone +B+, the set of allowed locations for +A+ is limited to
+nodes on which +B+ is (or will be) active.  Placement is then performed
+normally.
+
+[[s-clone-stickiness]]
 === Clone Stickiness ===
 
 indexterm:[resource-stickiness,Clones]
@@ -306,6 +308,16 @@ default.  If no value for +resource-stickiness+ is provided, the clone
 will use a value of 1.  Being a small value, it causes minimal
 disturbance to the score calculations of other resources but is enough
 to prevent Pacemaker from needlessly moving copies around the cluster.
+
+[NOTE]
+====
+For globally unique clones, this may result in multiple instances of the
+clone staying on a single node, even after another eligible node becomes
+active (for example, after being put into standby mode then made active again).
+If you do not want this behavior, specify a +resource-stickiness+ of 0
+for the clone temporarily and let the cluster adjust, then set it back
+to 1 if you want the default behavior to apply again.
+====
 
 === Clone Resource Agent Requirements ===
 
@@ -529,21 +541,12 @@ If you think you need to do this, you probably need to re-evaluate your design.
 
 === Monitoring Multi-State Resources ===
 
-The normal type of monitor actions are not sufficient to monitor a
-multi-state resource in the +Master+ state.  To detect failures of the
-+Master+ instance, you need to define an additional monitor action
-with +role="Master"+.
+The usual monitor actions are insufficient to monitor a multi-state resource,
+because pacemaker needs to verify not only that the resource is active, but
+also that its actual role matches its intended one.
 
-[IMPORTANT]
-===========
-It is crucial that _every_ monitor operation has a different interval!
-
-This is because Pacemaker currently differentiates between operations
-only by resource and interval; so if eg. a master/slave resource has
-the same monitor interval for both roles, Pacemaker would ignore the
-role when checking the status - which would cause unexpected return
-codes, and therefore unnecessary complications.
-===========
+Define two monitoring actions: the usual one will cover the slave role,
+and an additional one with +role="master"+ will cover the master role.
 
 .Monitoring both states of a multi-state resource
 ======
@@ -560,6 +563,15 @@ codes, and therefore unnecessary complications.
 -------
 ======
 
+[IMPORTANT]
+===========
+It is crucial that _every_ monitor operation has a different interval!
+Pacemaker currently differentiates between operations
+only by resource and interval; so if (for example) a master/slave resource had
+the same monitor interval for both roles, Pacemaker would ignore the
+role when checking the status -- which would cause unexpected return
+codes, and therefore unnecessary complications.
+===========
 
 === Multi-state Constraints ===
 
@@ -619,13 +631,7 @@ ordering constraints) are used.
 
 |=========================================================
 
-In the example below, +myApp+ will wait until one of the database
-copies has been started and promoted to master before being started
-itself.  Only if no copies can be promoted will +apache-stats+ be
-prevented from being active.  Additionally, the database will wait for
-+myApp+ to be stopped before it is demoted.
-
-.Example constraints involving multi-state resources       
+.Constraints involving multi-state resources       
 ======
 [source,XML]
 -------
@@ -642,7 +648,13 @@ prevented from being active.  Additionally, the database will wait for
 -------
 ======
 
-Colocation of a regular (or group) resource with a multi-state
+In the example above, +myApp+ will wait until one of the database
+copies has been started and promoted to master before being started
+itself on the same node.  Only if no copies can be promoted will +myApp+ be
+prevented from being active.  Additionally, the cluster will wait for
++myApp+ to be stopped before demoting the database.
+
+Colocation of a primitive or group resource with a multi-state
 resource means that it can run on any machine with an active copy of
 the multi-state resource that has the specified role (+master+ or
 +slave+).  In the example above, the cluster will choose a location based on
@@ -698,6 +710,8 @@ and +B+'s masters.
 -------
 ======
 
+==== Using Multi-state Resources in Ordering Sets ====
+
 .Additional ordered set options relevant to multi-state resources
 [width="95%",cols="1m,1,3<",options="header",align="center"]
 |=========================================================
@@ -715,9 +729,6 @@ and +B+'s masters.
  indexterm:[Constraints,Ordering,action]
 
 |=========================================================
-
-In the following example +B+ cannot be promoted until +A+'s has been promoted.
-Additionally resources +C+ and +D+ must wait until +A+ and +B+ have been promoted before they can start.
 
 .Start C and D after first promoting A and B
 ======
@@ -821,7 +832,7 @@ not indicate to the agent what role it currently believes it to be in.
 
 |=========================================================
 
-=== Multi-state Notifications ===
+==== Multi-state Notifications ====
 
 Like clones, supporting notifications requires the +notify+ action to
 be implemented.  If supported, the notify action will be passed a
@@ -928,7 +939,7 @@ what is about to happen to it.
 
 |=========================================================
 
-=== Multi-state - Proper Interpretation of Notification Environment Variables ===
+==== Proper Interpretation of Multi-state Notification Environment Variables ====
 
 
 .Pre-notification (demote):

--- a/doc/Pacemaker_Explained/en-US/Ch-Advanced-Resources.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Advanced-Resources.txt
@@ -402,13 +402,13 @@ what is about to happen to it.
 The variables come in pairs, such as
 +OCF_RESKEY_CRM_meta_notify_start_resource+ and
 +OCF_RESKEY_CRM_meta_notify_start_uname+ and should be treated as an
-array of whitespace separated elements.
+array of whitespace-separated elements.
 
 Thus in order to indicate that +clone:0+ will be started on +sles-1+,
 +clone:2+ will be started on +sles-3+, and +clone:3+ will be started
 on +sles-2+, the cluster would set
 
-.Example notification variables
+.Notification variables
 ======
 [source,Bash]
 -------
@@ -565,8 +565,8 @@ codes, and therefore unnecessary complications.
 In most cases, multi-state resources will have a single copy on each
 active cluster node.  If this is not the case, you can indicate which
 nodes the cluster should preferentially assign copies to with resource
-location constraints.  These constraints are written no differently to
-those for regular resources except that the master's id is used.
+location constraints.  These constraints are written no differently from
+those for primitive resources except that the master's +id+ is used.
 
 When considering multi-state resources in constraints, for most
 purposes it is sufficient to treat them as clones.  The exception is
@@ -643,10 +643,10 @@ prevented from being active.  Additionally, the database will wait for
 
 Colocation of a regular (or group) resource with a multi-state
 resource means that it can run on any machine with an active copy of
-the multi-state resource that is in the specified state (+Master+ or
-+Slave+).  In the example, the cluster will choose a location based on
-where database is running as a +Master+, and if there are multiple
-+Master+ instances it will also factor in +myApp+'s own location
+the multi-state resource that has the specified role (+master+ or
++slave+).  In the example above, the cluster will choose a location based on
+where database is running as a +master+, and if there are multiple
++master+ instances it will also factor in +myApp+'s own location
 preferences when deciding which location to choose.
 
 Colocation with regular clones and other multi-state resources is also
@@ -777,20 +777,20 @@ the requirements of Clones are also requirements of multi-state
 resources.  Additionally, multi-state resources require two extra
 actions: +demote+ and +promote+; these actions are responsible for
 changing the state of the resource.  Like +start+ and +stop+, they
-should return +OCF_SUCCESS+ if they completed successfully or a
+should return +$\{OCF_SUCCESS}+ if they completed successfully or a
 relevant error code if they did not.
 
 The states can mean whatever you wish, but when the resource is
-started, it must come up in the mode called +Slave+.  From there the
-cluster will then decide which instances to promote to +Master+.
+started, it must come up in the mode called +slave+.  From there the
+cluster will decide which instances to promote to +master+.
 
-In addition to the Clone requirements for monitor actions, agents must
+In addition to the clone requirements for monitor actions, agents must
 also _accurately_ report which state they are in.  The cluster relies
 on the agent to report its status (including role) accurately and does
 not indicate to the agent what role it currently believes it to be in.
 
 .Role implications of OCF return codes
-[width="95%",cols="5,3<",options="header",align="center"]
+[width="95%",cols="1,1<",options="header",align="center"]
 |=========================================================
 
 |Monitor Return Code

--- a/doc/Pacemaker_Explained/en-US/Ch-Basics.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Basics.txt
@@ -129,11 +129,9 @@ Now that it is clear how NOT to update the configuration, we can begin
 to explain how you should.
 
 The most powerful tool for modifying the configuration is the
-+cibadmin+ command which talks to a running cluster.  With +cibadmin+,
-the user can query, add, remove, update or replace any part of the
-configuration; all changes take effect immediately, so there is no
-need to perform a reload-like operation.
-      
++cibadmin+ command.  With +cibadmin+, you can query, add, remove, update
+or replace any part of the configuration. All changes take effect immediately,
+so there is no need to perform a reload-like operation.
 
 The simplest way of using `cibadmin` is to use it to save the current
 configuration to a temporary file, edit that file with your favorite
@@ -155,10 +153,10 @@ deployed in a location such as +/usr/share/pacemaker+ or
 +/usr/lib/heartbeat+ depending on your operating system and how you
 installed the software.
 
-If you only wanted to modify the resources section, you could instead
-do
+If you want to modify just one section of the configuration, you can
+query and replace just that section to avoid modifying any others.
       
-.Safely using an editor to modify a subsection of the cluster configuration
+.Safely using an editor to modify only the resources section
 ======
 --------
 # cibadmin --query --obj_type resources > tmp.xml
@@ -171,15 +169,13 @@ to avoid modifying any other part of the configuration.
 
 == Quickly Deleting Part of the Configuration ==
 
-Identify the object you wish to delete. Eg. run
+Identify the object you wish to delete by XML tag and id. For example,
+you might search the CIB for all STONITH-related configuration:
       
-.Searching for STONITH related configuration items
+.Searching for STONITH-related configuration items
 ======
---------
+----
 # cibadmin -Q | grep stonith
---------
-[source,XML]
---------
  <nvpair id="cib-bootstrap-options-stonith-action" name="stonith-action" value="reboot"/>
  <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="1"/>
  <primitive id="child_DoFencing" class="stonith" type="external/vmware">
@@ -190,11 +186,11 @@ Identify the object you wish to delete. Eg. run
  <lrm_resource id="child_DoFencing:2" type="external/vmware" class="stonith">
  <lrm_resource id="child_DoFencing:0" type="external/vmware" class="stonith">
  <lrm_resource id="child_DoFencing:3" type="external/vmware" class="stonith">
---------
+----
 ======
 
-Next identify the resource's tag name and id (in this case we'll
-choose +primitive+ and +child_DoFencing+).  Then simply execute:
+If you wanted to delete the +primitive+ tag with id +child_DoFencing+,
+you would run:
 
 ----
 # cibadmin --delete --crm_xml '<primitive id="child_DoFencing"/>'
@@ -202,8 +198,8 @@ choose +primitive+ and +child_DoFencing+).  Then simply execute:
 
 == Updating the Configuration Without Using XML ==
 
-Some common tasks can also be performed with one of the higher level
-tools that avoid the need to read or edit XML.
+Most tasks can be performed with one of the other command-line
+tools provided with pacemaker, avoiding the need to read or edit XML.
 
 To enable STONITH for example, one could run:
 
@@ -242,37 +238,40 @@ have created `crm_shadow` which creates a
 "shadow" copy of the configuration and arranges for all the command
 line tools to use it.
 
-To begin, simply invoke `crm_shadow` and give
-it the name of a configuration to create footnote:[Shadow copies are
-identified with a name, making it possible to have more than one.]  ;
-be sure to follow the simple on-screen instructions.
+To begin, simply invoke `crm_shadow --create` with
+the name of a configuration to create footnote:[Shadow copies are
+identified with a name, making it possible to have more than one.],
+and follow the simple on-screen instructions.
 
-WARNING: Read the above carefully, failure to do so could result in you
-destroying the cluster's active configuration!
+[WARNING]
+====
+Read this section and the on-screen instructions carefully; failure to do so could
+result in destroying the cluster's active configuration!
+====
       
       
 .Creating and displaying the active sandbox
 ======
 ----
- # crm_shadow --create test
- Setting up shadow instance
- Type Ctrl-D to exit the crm_shadow shell
- shadow[test]: 
- shadow[test] # crm_shadow --which
- test
+# crm_shadow --create test
+Setting up shadow instance
+Type Ctrl-D to exit the crm_shadow shell
+shadow[test]: 
+shadow[test] # crm_shadow --which
+test
 ----
 ======
 
 From this point on, all cluster commands will automatically use the
 shadow copy instead of talking to the cluster's active configuration.
-Once you have finished experimenting, you can either commit the
-changes, or discard them as shown below.  Again, be sure to follow the
-on-screen instructions carefully.
+Once you have finished experimenting, you can either make the
+changes active via the `--commit` option, or discard them using the `--delete`
+option.  Again, be sure to follow the on-screen instructions carefully!
       
 For a full list of `crm_shadow` options and
 commands, invoke it with the `--help` option.
 
-.Using a sandbox to make multiple changes atomically
+.Using a sandbox to make multiple changes atomically, discard them and verify the real configuration is untouched
 ======
 ----
  shadow[test] # crm_failcount -G -r rsc_c001n01
@@ -315,19 +314,18 @@ Making changes in a sandbox and verifying the real configuration is untouched
 
 We saw previously how to make a series of changes to a "shadow" copy
 of the configuration.  Before loading the changes back into the
-cluster (eg. `crm_shadow --commit mytest --force`), it is often
-advisable to simulate the effect of the changes with +crm_simulate+,
-eg.
+cluster (e.g. `crm_shadow --commit mytest --force`), it is often
+advisable to simulate the effect of the changes with +crm_simulate+.
+For example:
       
 ----
 # crm_simulate --live-check -VVVVV --save-graph tmp.graph --save-dotfile tmp.dot
 ----
 
-
-The tool uses the same library as the live cluster to show what it
-would have done given the supplied input.  It's output, in addition to
+This tool uses the same library as the live cluster to show what it
+would have done given the supplied input.  Its output, in addition to
 a significant amount of logging, is stored in two files +tmp.graph+
-and +tmp.dot+, both are representations of the same thing -- the
+and +tmp.dot+. Both files are representations of the same thing: the
 cluster's response to your changes.
 
 In the graph file is stored the complete transition, containing a list
@@ -337,7 +335,7 @@ also generates a Graphviz dot-file representing the same information.
 
 == Interpreting the Graphviz output ==
  * Arrows indicate ordering dependencies
- * Dashed-arrows indicate dependencies that are not present in the transition graph
+ * Dashed arrows indicate dependencies that are not present in the transition graph
  * Actions with a dashed border of any color do not form part of the transition graph
  * Actions with a green border form part of the transition graph
  * Actions with a red border are ones the cluster would like to execute but cannot run

--- a/doc/Pacemaker_Explained/en-US/Ch-Basics.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Basics.txt
@@ -2,28 +2,8 @@
 
 == Configuration Layout ==
 
-The cluster is written using XML notation and divided into two main
-sections: configuration and status.
-
-The status section contains the history of each resource on each node
-and based on this data, the cluster can construct the complete current
-state of the cluster.  The authoritative source for the status section
-is the local resource manager (lrmd) process on each cluster node and
-the cluster will occasionally repopulate the entire section.  For this
-reason it is never written to disk and administrators are advised
-against modifying it in any way.
-
-The configuration section contains the more traditional information
-like cluster options, lists of resources and indications of where they
-should be placed.  The configuration section is the primary focus of
-this document.
-      
-The configuration section itself is divided into four parts:
-
- * Configuration options (called +crm_config+)
- * Nodes
- * Resources
- * Resource relationships (called +constraints+)
+The cluster is defined by the Cluster Information Base (CIB),
+which uses XML notation. The simplest CIB, an empty one, looks like this:
 
 .An empty configuration
 ======
@@ -40,6 +20,38 @@ The configuration section itself is divided into four parts:
 </cib>
 -------
 ======
+
+The empty configuration above contains the major sections that make up a CIB:
+
+* +cib+: The entire CIB is enclosed with a +cib+ tag. Certain fundamental settings
+  are defined as attributes of this tag.
+
+  ** +configuration+: This section -- the primary focus of this document --
+     contains traditional configuration information such as what resources the
+     cluster serves and the relationships among them.
+
+    *** +crm_config+: cluster-wide configuration options
+    *** +nodes+: the machines that host the cluster
+    *** +resources+: the services run by the cluster
+    *** +constraints+: indications of how resources should be placed
+
+  ** +status+: This section contains the history of each resource on each node.
+    Based on this data, the cluster can construct the complete current
+    state of the cluster.  The authoritative source for this section
+    is the local resource manager (lrmd process) on each cluster node, and
+    the cluster will occasionally repopulate the entire section.  For this
+    reason, it is never written to disk, and administrators are advised
+    against modifying it in any way.
+
+In this document, configuration settings will be described as 'properties' or 'options'
+based on how they are defined in the CIB:
+
+* Properties are XML attributes of an XML element.
+* Options are name-value pairs expressed as +nvpair+ child elements of an XML element.
+
+Normally you will use command-line tools that abstract the XML, so the
+distinction will be unimportant; both properties and options are
+cluster settings you can tweak.
 
 == The Current State of the Cluster ==
 
@@ -125,8 +137,10 @@ There are three basic rules for updating the cluster configuration:
  * Rule 2 - Read Rule 1 again.
  * Rule 3 - The cluster will notice if you ignored rules 1 &amp; 2 and refuse to use the configuration.
 
-Now that it is clear how NOT to update the configuration, we can begin
-to explain how you should.
+Now that it is clear how 'not' to update the configuration, we can begin
+to explain how you 'should'.
+
+=== Editing the CIB Using XML ===
 
 The most powerful tool for modifying the configuration is the
 +cibadmin+ command.  With +cibadmin+, you can query, add, remove, update
@@ -165,9 +179,7 @@ query and replace just that section to avoid modifying any others.
 --------
 ======
 
-to avoid modifying any other part of the configuration.
-
-== Quickly Deleting Part of the Configuration ==
+=== Quickly Deleting Part of the Configuration ===
 
 Identify the object you wish to delete by XML tag and id. For example,
 you might search the CIB for all STONITH-related configuration:
@@ -196,7 +208,7 @@ you would run:
 # cibadmin --delete --crm_xml '<primitive id="child_DoFencing"/>'
 ----
 
-== Updating the Configuration Without Using XML ==
+=== Updating the Configuration Without Using XML ===
 
 Most tasks can be performed with one of the other command-line
 tools provided with pacemaker, avoiding the need to read or edit XML.
@@ -307,8 +319,6 @@ commands, invoke it with the `--help` option.
 ----
 ======
 
-Making changes in a sandbox and verifying the real configuration is untouched
-
 [[s-config-testing-changes]]
 == Testing Your Configuration Changes ==
 
@@ -328,12 +338,17 @@ a significant amount of logging, is stored in two files +tmp.graph+
 and +tmp.dot+. Both files are representations of the same thing: the
 cluster's response to your changes.
 
-In the graph file is stored the complete transition, containing a list
-of all the actions, their parameters and their pre-requisites.
-Because the transition graph is not terribly easy to read, the tool
-also generates a Graphviz dot-file representing the same information.
+The graph file stores the complete transition from the existing cluster state
+to your desired new state, containing a list of all the actions, their
+parameters and their pre-requisites. Because the transition graph is not
+terribly easy to read, the tool also generates a Graphviz
+footnote:[Graph visualization software. See http://www.graphviz.org/ for details.]
+dot-file representing the same information.
 
-== Interpreting the Graphviz output ==
+For information on the options supported by `crm_simulate`, use
+its `--help` option.
+
+.Interpreting the Graphviz output
  * Arrows indicate ordering dependencies
  * Dashed arrows indicate dependencies that are not present in the transition graph
  * Actions with a dashed border of any color do not form part of the transition graph
@@ -358,9 +373,6 @@ were not active there, it would have liked to stop *rsc1* and *rsc2*
 on *pcmk-1* and move them to *pcmk-2*.  However, there appears to be
 some problem and the cluster cannot or is not permitted to perform the
 stop actions which implies it also cannot perform the start actions.
-
-For information on the options supported by `crm_simulate`, use
-the `--help` option.
 For some reason the cluster does not want to start *rsc3* anywhere.
 
 === Complex Cluster Transition ===

--- a/doc/Pacemaker_Explained/en-US/Ch-Basics.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Basics.txt
@@ -45,13 +45,12 @@ The configuration section itself is divided into four parts:
 
 Before one starts to configure a cluster, it is worth explaining how
 to view the finished product.  For this purpose we have created the
-`crm_mon` utility that will display the
+`crm_mon` utility, which will display the
 current state of an active cluster.  It can show the cluster status by
 node or by resource and can be used in either single-shot or
 dynamically-updating mode.  There are also modes for displaying a list
 of the operations performed (grouped by node and resource) as well as
 information about failures.
-      
 
 Using this tool, you can examine the state of the cluster for
 irregularities and see how it responds when you cause or simulate
@@ -113,7 +112,7 @@ Details on all the available options can be obtained using the
 ======
 
 The DC (Designated Controller) node is where all the decisions are
-made and if the current DC fails a new one is elected from the
+made, and if the current DC fails a new one is elected from the
 remaining cluster nodes.  The choice of DC is of no significance to an
 administrator beyond the fact that its logs will generally be more
 interesting.
@@ -122,7 +121,7 @@ interesting.
 
 There are three basic rules for updating the cluster configuration:
 
- * Rule 1 - Never edit the cib.xml file manually. Ever. I'm not making this up.
+ * Rule 1 - Never edit the +cib.xml+ file manually. Ever. I'm not making this up.
  * Rule 2 - Read Rule 1 again.
  * Rule 3 - The cluster will notice if you ignored rules 1 &amp; 2 and refuse to use the configuration.
 
@@ -136,9 +135,9 @@ configuration; all changes take effect immediately, so there is no
 need to perform a reload-like operation.
       
 
-The simplest way of using cibadmin is to use it to save the current
+The simplest way of using `cibadmin` is to use it to save the current
 configuration to a temporary file, edit that file with your favorite
-text or XML editor and then upload the revised configuration.
+text or XML editor, and then upload the revised configuration.
       
 .Safely using an editor to modify the cluster configuration
 ======
@@ -206,19 +205,19 @@ choose +primitive+ and +child_DoFencing+).  Then simply execute:
 Some common tasks can also be performed with one of the higher level
 tools that avoid the need to read or edit XML.
 
-To enable stonith for example, one could run:
+To enable STONITH for example, one could run:
 
 ----
 # crm_attribute --name stonith-enabled --update 1
 ----
 
-Or, to see if +somenode+ is allowed to run resources, there is:
+Or, to check whether *somenode* is allowed to run resources, there is:
 
 ----
 # crm_standby --get-value --node somenode
 ----
 
-Or, to find the current location of +my-test-rsc+, one can use:
+Or, to find the current location of *my-test-rsc*, one can use:
 
 ----
 # crm_resource --locate --resource my-test-rsc
@@ -353,24 +352,24 @@ also generates a Graphviz dot-file representing the same information.
 
 image::images/Policy-Engine-small.png["An example transition graph as represented by Graphviz",width="16cm",height="6cm",align="center"]      
 
-In the above example, it appears that a new node, +pcmk-2+, has come
-online and that the cluster is checking to make sure +rsc1+, +rsc2+
-and +rsc3+ are not already running there (Indicated by the
-+*_monitor_0+ entries).  Once it did that, and assuming the resources
-were not active there, it would have liked to stop +rsc1+ and +rsc2+
-on +pcmk-1+ and move them to +pcmk-2+.  However, there appears to be
+In the above example, it appears that a new node, *pcmk-2*, has come
+online and that the cluster is checking to make sure *rsc1*, *rsc2*
+and *rsc3* are not already running there (Indicated by the
+*rscN_monitor_0* entries).  Once it did that, and assuming the resources
+were not active there, it would have liked to stop *rsc1* and *rsc2*
+on *pcmk-1* and move them to *pcmk-2*.  However, there appears to be
 some problem and the cluster cannot or is not permitted to perform the
 stop actions which implies it also cannot perform the start actions.
-For some reason the cluster does not want to start +rsc3+ anywhere.
 
 For information on the options supported by `crm_simulate`, use
 the `--help` option.
+For some reason the cluster does not want to start *rsc3* anywhere.
 
 === Complex Cluster Transition ===
 
 image::images/Policy-Engine-big.png["Another, slightly more complex, transition graph that you're not expected to be able to read",width="16cm",height="20cm",align="center"]
 
-== Do I Need to Update the Configuration on all Cluster Nodes? ==
+== Do I Need to Update the Configuration on All Cluster Nodes? ==
 
 No. Any changes are immediately synchronized to the other active
 members of the cluster.

--- a/doc/Pacemaker_Explained/en-US/Ch-Constraints.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Constraints.txt
@@ -16,8 +16,8 @@ node with the highest one.
 
 === Infinity Math ===
 
-+INFINITY+ is currently defined as 1,000,000 and addition/subtraction
-with it follows these three basic rules:
+Pacemaker implements +INFINITY+ internally as a score of 1,000,000.
+Addition/subtraction with it follows these three basic rules:
 
 * Any value + +INFINITY+ = +INFINITY+
 * Any value - +INFINITY+ = +-INFINITY+
@@ -30,7 +30,7 @@ indexterm:[Resource,Constraints,Location]
 There are two alternative strategies for specifying which nodes a
 resources can run on.  One way is to say that by default they can run
 anywhere and then create location constraints for nodes that are not
-allowed.  The other option is to have nodes "opt-in"...  to start with
+allowed.  The other option is to have nodes "opt-in" --  to start with
 nothing able to run anywhere and selectively enable allowed nodes.
 
 === Location Properties ===
@@ -164,7 +164,7 @@ If two nodes have the same score, then the cluster will choose one.
 This choice may seem random and may not be what was intended, however
 the cluster was not given enough information to know any better.
 
-.Example of two resources that prefer two nodes equally 
+.Constraints where a resource prefers two nodes equally
 ======
 [source,XML]
 -------
@@ -186,7 +186,7 @@ evenly across the cluster.  However other factors can also be involved
 in more complex configurations.
 
 [[s-resource-ordering]]
-== Specifying in which Order Resources Should Start/Stop ==
+== Specifying the Order in which Resources Should Start/Stop ==
 
 indexterm:[Resource,Constraints,Ordering]
 indexterm:[Resource,Start Order]
@@ -336,7 +336,7 @@ decide where to put this resource first and then decide where to put +rsc+.
 
 === Mandatory Placement ===
 
-Mandatory placement occurs any time the constraint's score is
+Mandatory placement occurs when the constraint's score is
 ++INFINITY+ or +-INFINITY+.  In such cases, if the constraint can't be
 satisfied, then the +rsc+ resource is not permitted to run.  For
 +score=INFINITY+, this includes cases where the +with-rsc+ resource is
@@ -345,7 +345,8 @@ not active.
 If you need +resource1+ to always run on the same machine as
 +resource2+, you would add the following constraint:
 
-.An example colocation constraint
+.Mandatory colocation constraint for two resources
+====
 [source,XML]
 <rsc_colocation id="colocate" rsc="resource1" with-rsc="resource2" score="INFINITY"/>
 
@@ -370,16 +371,16 @@ only place left to run is where +resource2+ already is, then
 If mandatory placement is about "must" and "must not", then advisory
 placement is the "I'd prefer if" alternative.  For constraints with
 scores greater than +-INFINITY+ and less than +INFINITY+, the cluster
-will try and accommodate your wishes but may ignore them if the
+will try to accommodate your wishes but may ignore them if the
 alternative is to stop some of the cluster resources.
-        
 
-Like in life, where if enough people prefer something it effectively
+As in life, where if enough people prefer something it effectively
 becomes mandatory, advisory colocation constraints can combine with
 other elements of the configuration to behave as if they were
 mandatory.
 
-.An example advisory-only colocation constraint
+.Advisory colocation constraint for two resources
+====
 [source,XML]
 <rsc_colocation id="colocate-maybe" rsc="resource1" with-rsc="resource2" score="500"/>
 
@@ -501,8 +502,8 @@ Those sets can be expressed, +(A and B) then \(C) then (D) then (E and F)+.
 Say for example we want to change the first set, +(A and B)+, to use "OR" logic
 so the sets look like this: +(A or B) then \(C) then (D) then (E and F)+.
 This functionality can be achieved through the use of the +require-all+
-option.  By default this option is 'require-all=true' which is why the
-"AND" logic is used by default.  Changing +require-all=false+ means only one
+option.  This option defaults to TRUE which is why the
+"AND" logic is used by default.  Setting +require-all=false+ means only one
 resource in the set needs to be started before continuing on to the next set.
 
 Note that the +require-all=false+ option only makes sense to use in conjunction

--- a/doc/Pacemaker_Explained/en-US/Ch-Constraints.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Constraints.txt
@@ -33,6 +33,13 @@ anywhere and then create location constraints for nodes that are not
 allowed.  The other option is to have nodes "opt-in" --  to start with
 nothing able to run anywhere and selectively enable allowed nodes.
 
+Whether you should choose opt-in or opt-out depends on your
+personal preference and the make-up of your cluster.  If most of your
+resources can run on most of the nodes, then an opt-out arrangement is
+likely to result in a simpler configuration.  On the other-hand, if
+most resources can only run on a small subset of nodes, an opt-in
+configuration might be simpler.
+
 === Location Properties ===
 
 .Properties for Simple Location Constraints
@@ -150,13 +157,6 @@ of the above opt-in configuration.
 -------
 ======
 
-Whether you should choose opt-in or opt-out depends both on your
-personal preference and the make-up of your cluster.  If most of your
-resources can run on most of the nodes, then an opt-out arrangement is
-likely to result in a simpler configuration.  On the other-hand, if
-most resources can only run on a small subset of nodes an opt-in
-configuration might be simpler.
-
 [[node-score-equal]]
 === What if Two Nodes Have the Same Score ===
 
@@ -194,6 +194,15 @@ indexterm:[Ordering Constraints]
 
 The way to specify the order in which resources should start is by
 creating +rsc_order+ constraints.
+
+[IMPORTANT]
+====
+Ordering constraints affect 'only' the ordering of resources;
+they do not require that the resources be placed on the
+same node. If you want resources to be started on the same node
+'and' in a specific order, you need an ordering constraint 'and'
+a location constraint (see <<s-resource-colocation>>).
+====
 
 === Ordering Properties ===
 
@@ -280,10 +289,11 @@ indexterm:[Resource,Location Relative to other Resources]
 When the location of one resource depends on the location of another
 one, we call this colocation.
 
-There is an important side-effect of creating a colocation constraint
-between two resources: it affects the order in which resources are
-assigned to a node.  If you think about it, it's somewhat obvious.
-You can't place A relative to B unless you know where B is.
+Colocation has an important side-effect: it affects the order in which
+resources are assigned to a node.
+footnote:['Not' the order in which they are started. For that, see
+<<s-resource-ordering>>.]
+Think about it: You can't place A relative to B unless you know where B is.
 footnote:[
 While the human brain is sophisticated enough to read the constraint
 in any order and choose the correct one depending on the situation,
@@ -342,29 +352,36 @@ satisfied, then the +rsc+ resource is not permitted to run.  For
 +score=INFINITY+, this includes cases where the +with-rsc+ resource is
 not active.
 
-If you need +resource1+ to always run on the same machine as
-+resource2+, you would add the following constraint:
+If you need resource +A+ to always run on the same machine as
+resource +B+, you would add the following constraint:
 
 .Mandatory colocation constraint for two resources
 ====
 [source,XML]
-<rsc_colocation id="colocate" rsc="resource1" with-rsc="resource2" score="INFINITY"/>
+<rsc_colocation id="colocate" rsc="A" with-rsc="B" score="INFINITY"/>
+====
 
-Remember, because +INFINITY+ was used, if +resource2+ can't run on any
-of the cluster nodes (for whatever reason) then +resource1+ will not
-be allowed to run.
+Remember, because +INFINITY+ was used, if +B+ can't run on any
+of the cluster nodes (for whatever reason) then +A+ will not
+be allowed to run. Whether +A+ is running or not has no effect on +B+.
 
-Alternatively, you may want the opposite...  that +resource1+ cannot
-run on the same machine as +resource2+.  In this case use
-+score="-INFINITY"+
-        
-.An example anti-colocation constraint
+Alternatively, you may want the opposite -- that +A+ 'cannot'
+run on the same machine as +B+.  In this case, use
++score="-INFINITY"+.
+
+.Mandatory anti-colocation constraint for two resources
+====
 [source,XML]
-<rsc_colocation id="anti-colocate" rsc="resource1" with-rsc="resource2" score="-INFINITY"/>
+<rsc_colocation id="anti-colocate" rsc="A" with-rsc="B" score="-INFINITY"/>
+====
 
-Again, by specifying +-INFINTY+, the constraint is binding.  So if the
-only place left to run is where +resource2+ already is, then
-+resource1+ may not run anywhere.
+Again, by specifying +-INFINITY+, the constraint is binding.  So if the
+only place left to run is where +B+ already is, then
++A+ may not run anywhere.
+
+As with +INFINITY+, +B+ can run even if +A+ is stopped.
+However, in this case +A+ also can run if +B+ is stopped, because it still
+meets the constraint of +A+ and +B+ not running on the same node.
 
 === Advisory Placement ===
 
@@ -382,7 +399,8 @@ mandatory.
 .Advisory colocation constraint for two resources
 ====
 [source,XML]
-<rsc_colocation id="colocate-maybe" rsc="resource1" with-rsc="resource2" score="500"/>
+<rsc_colocation id="colocate-maybe" rsc="A" with-rsc="B" score="500"/>
+====
 
 [[s-resource-sets-ordering]]
 == Ordering Sets of Resources ==
@@ -435,10 +453,10 @@ In some tools +create set A B+ is *NOT* equivalent to +create A then B+.
 
 While the set-based format is not less verbose, it is significantly
 easier to get right and maintain.  It can also be expanded to allow
-ordered sets of (un)ordered resources.  In the example below, +rscA+
-and +rscB+ can both start in parallel, as can +rscC+ and +rscD+,
-however +rscC+ and +rscD+ can only start once _both_ +rscA+ _and_ 
- +rscB+ are active.
+ordered sets of (un)ordered resources.  In the example below, +A+
+and +B+ can both start in parallel, as can +C+ and +D+,
+however +C+ and +D+ can only start once _both_ +A+ _and_
+ +B+ are active.
 
 .Ordered sets of unordered resources
 ======
@@ -591,18 +609,7 @@ Always pay attention to how your tools expose this functionality.
 In some tools +create set A B+ is 'not' equivalent to +create A with B+.
 =========
 
-.A group resource with the equivalent colocation rules
-[source,XML]
--------
-<group id="dummy">
-    <primitive id="A" .../>
-    <primitive id="B" .../>
-    <primitive id="C" .../>
-    <primitive id="D" .../>
-</group>
--------
-
-This notation can also be used in this context to tell the cluster
+This notation can also be used to tell the cluster
 that a set of resources must all be located with a common peer, but
 have no dependencies on each other. In this scenario, unlike the
 previous, +B+ 'would' be allowed to remain active even if +A+ or +C+ (or
@@ -627,15 +634,15 @@ both) were inactive.
 -------
 ======
 
-Of course there is no limit to the number and size of the sets used.
-The only thing that matters is that in order for any member of set N
-to be active, all the members of set N+1 must also be active (and
-naturally on the same node); and if a set has +sequential="true"+,
-then in order for member M to be active, member M+1 must also be
-active.  You can even specify the role in which the members of a set
-must be in using the set's role attribute.
-      
-.A colocation chain where the members of the middle set have no inter-dependencies and the last has master status.
+There is no inherent limit to the number and size of the sets used.
+The only thing that matters is that in order for any member of one set
+in the constraint to be active, all members of sets listed after it must also
+be active (and naturally on the same node); and if a set has +sequential="true"+,
+then in order for one member of that set to be active, all members listed after it
+must also be active. You can even specify the role in which the members of a set
+must be in using the set's +role+ attribute.
+
+.A colocation chain where the members of the middle set have no interdependencies and the last has master status.
 ======
 [source,XML]
 -------

--- a/doc/Pacemaker_Explained/en-US/Ch-Constraints.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Constraints.txt
@@ -1,4 +1,4 @@
-=  Resource Constraints =
+= Resource Constraints =
 
 indexterm:[Resource,Constraints]
 
@@ -9,7 +9,7 @@ Practically everything from moving a resource to deciding which
 resource to stop in a degraded cluster is achieved by manipulating
 scores in some way.
 
-Scores are calculated on a per-resource basis and any node with a
+Scores are calculated on a per-resource basis, and any node with a
 negative score for a resource can't run that resource.  After
 calculating the scores for a resource, the cluster then chooses the
 node with the highest one.
@@ -20,8 +20,8 @@ node with the highest one.
 with it follows these three basic rules:
 
 * Any value + +INFINITY+ = +INFINITY+
-* Any value - +INFINITY+ = -+INFINITY+
-* +INFINITY+ - +INFINITY+ = -+INFINITY+
+* Any value - +INFINITY+ = +-INFINITY+
+* +INFINITY+ - +INFINITY+ = +-INFINITY+
 
 == Deciding Which Nodes a Resource Can Run On ==
 
@@ -107,10 +107,10 @@ running anywhere by default:
 ----
 
 Then start enabling nodes.  The following fragment says that the web
-server prefers +sles-1+, the database prefers +sles-2+ and both can
-fail over to +sles-3+ if their most preferred node fails.
+server prefers *sles-1*, the database prefers *sles-2* and both can
+fail over to *sles-3* if their most preferred node fails.
 
-.Example set of opt-in location constraints 
+.Opt-in location constraints for two resources
 ======
 [source,XML]
 -------
@@ -136,8 +136,8 @@ anywhere by default:
 
 Then start disabling nodes.  The following fragment is the equivalent
 of the above opt-in configuration.
-       
-.Example set of opt-out location constraints 
+
+.Opt-out location constraints for two resources
 ======
 [source,XML]
 -------
@@ -179,9 +179,9 @@ the cluster was not given enough information to know any better.
 ======
 
 In the example above, assuming no other constraints and an inactive
-cluster, Webserver would probably be placed on sles-1 and Database on
-sles-2.  It would likely have placed Webserver based on the node's
-uname and Database based on the desire to spread the resource load
+cluster, +Webserver+ would probably be placed on +sles-1+ and +Database+ on
++sles-2+.  It would likely have placed +Webserver+ based on the node's
+uname and +Database+ based on the desire to spread the resource load
 evenly across the cluster.  However other factors can also be involved
 in more complex configurations.
 
@@ -191,6 +191,7 @@ in more complex configurations.
 indexterm:[Resource,Constraints,Ordering]
 indexterm:[Resource,Start Order]
 indexterm:[Ordering Constraints]
+
 The way to specify the order in which resources should start is by
 creating +rsc_order+ constraints.
 
@@ -290,7 +291,7 @@ the cluster is not quite so smart. Yet.
 ]
 
 So when you are creating colocation constraints, it is important to
-consider whether you should colocate A with B or B with A.
+consider whether you should colocate A with B, or B with A.
 
 Another thing to keep in mind is that, assuming A is colocated with
 B, the cluster will take into account A's preferences when
@@ -402,7 +403,7 @@ ordered resources, such as:
 
 .Visual representation of the four resources' start order for the above constraints
 image::images/resource-set.png["Ordered set",width="16cm",height="2.5cm",align="center"]
-        
+
 === Ordered Set ===
 
 To simplify this situation, there is an alternate format for ordering
@@ -456,7 +457,7 @@ however +rscC+ and +rscD+ can only start once _both_ +rscA+ _and_
   </constraints>
 -------
 ======
-        
+
 .Visual representation of the start order for two ordered sets of unordered resources
 image::images/two-sets.png["Two ordered sets",width="13cm",height="7.5cm",align="center"]
 
@@ -504,12 +505,12 @@ option.  By default this option is 'require-all=true' which is why the
 "AND" logic is used by default.  Changing +require-all=false+ means only one
 resource in the set needs to be started before continuing on to the next set.
 
-Note that the 'require-all=false' option only makes sense to use in conjunction
-with unordered sets, 'sequential=false'.  Think of it like this, 'sequential=false'
+Note that the +require-all=false+ option only makes sense to use in conjunction
+with unordered sets, +sequential=false+.  Think of it like this, +sequential=false+
 modifies the set to be an unordered set that uses "AND" logic by default, by adding
-'require-all=false' the unordered set's "AND" logic is flipped to "OR" logic.
++require-all=false+ the unordered set's "AND" logic is flipped to "OR" logic.
 
-.Resource Set "OR" logic. Three ordered sets, where the first set is internally unordered with "OR" logic.
+.Resource Set "OR" logic: Three ordered sets, where the first set is internally unordered with "OR" logic
 ======
 [source,XML]
 -------
@@ -586,7 +587,7 @@ stopped. Here is an example +resource_set+:
 [WARNING]
 =========
 Always pay attention to how your tools expose this functionality.
-In some tools +create set A B+ is *NOT* equivalent to +create A with B+.
+In some tools +create set A B+ is 'not' equivalent to +create A with B+.
 =========
 
 .A group resource with the equivalent colocation rules
@@ -602,11 +603,11 @@ In some tools +create set A B+ is *NOT* equivalent to +create A with B+.
 
 This notation can also be used in this context to tell the cluster
 that a set of resources must all be located with a common peer, but
-have no dependencies on each other.  In this scenario, unlike the
-previous, +B would+ be allowed to remain active even if +A or+ +C+ (or
+have no dependencies on each other. In this scenario, unlike the
+previous, +B+ 'would' be allowed to remain active even if +A+ or +C+ (or
 both) were inactive.
 
-.Using colocation sets to specify a common peer.    
+.Using colocation sets to specify a common peer
 ======
 [source,XML]
 -------
@@ -656,6 +657,6 @@ must be in using the set's role attribute.
 </constraints>
 -------
 ======
-        
+
 .Visual representation of a colocation chain where the members of the middle set have no inter-dependencies
 image::images/three-sets-complex.png["Colocation chain",width="16cm",height="9cm",align="center"]

--- a/doc/Pacemaker_Explained/en-US/Ch-Multi-site-Clusters.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Multi-site-Clusters.txt
@@ -1,7 +1,5 @@
 = Multi-Site Clusters and Tickets =
 
-[[Multisite]]
-== Abstract ==
 Apart from local clusters, Pacemaker also supports multi-site clusters.
 That means you can have multiple, geographically dispersed sites, each with a
 local cluster. Failover between these clusters can be coordinated
@@ -32,8 +30,8 @@ In the following sections, learn how to meet these challenges.
 
 Multi-site clusters can be considered as “overlay” clusters where
 each cluster site corresponds to a cluster node in a traditional cluster.
-The overlay cluster can be managed by a `CTR (Cluster Ticket Registry)`
-mechanism. It guarantees that the cluster resources will be highly
+The overlay cluster can be managed by a CTR in order to
+guarantee that the cluster resources will be highly
 available across different cluster sites. This is achieved by using
 'tickets' that are treated as failover domain between cluster
 sites, in case a site should be down.
@@ -41,23 +39,19 @@ sites, in case a site should be down.
 The following sections explain the individual components and mechanisms
 that were introduced for multi-site clusters in more detail.
 
+=== Ticket ===
 
-=== Components and Concepts ===
-
-==== Ticket ====
-
-"Tickets" are, essentially, cluster-wide attributes. A ticket grants the
+Tickets are, essentially, cluster-wide attributes. A ticket grants the
 right to run certain resources on a specific cluster site. Resources can
 be bound to a certain ticket by +rsc_ticket+ constraints. Only if the
 ticket is available at a site can the respective resources be started there.
 Vice versa, if the ticket is revoked, the resources depending on that
-ticket need to be stopped.
+ticket must be stopped.
 
-The ticket thus is similar to a 'site quorum'; i.e., the permission to
-manage/own resources associated with that site.
-
-(One can also think of the current `have-quorum` flag as a special, cluster-wide
-ticket that is granted in case of node majority.)
+The ticket thus is similar to a 'site quorum', i.e. the permission to
+manage/own resources associated with that site. (One can also think of the
+current +have-quorum+ flag as a special, cluster-wide ticket that is granted in
+case of node majority.)
 
 Tickets can be granted and revoked either manually by administrators
 (which could be the default for classic enterprise clusters), or via
@@ -73,7 +67,7 @@ for a site: +true+ (the site has the ticket) or +false+ (the site does
 not have the ticket). The absence of a certain ticket (during the initial
 state of the multi-site cluster) is the same as the value +false+.
 
-==== Dead Man Dependency ====
+=== Dead Man Dependency ===
 
 A site can only activate resources safely if it can be sure that the
 other site has deactivated them. However after a ticket is revoked, it can
@@ -81,25 +75,23 @@ take a long time until all resources depending on that ticket are stopped
 "cleanly", especially in case of cascaded resources. To cut that process
 short, the concept of a 'Dead Man Dependency' was introduced.
 
-- If the ticket is revoked from a site, the nodes that are hosting
-dependent resources are fenced. This considerably speeds up the recovery
-process of the cluster and makes sure that resources can be migrated more
-quickly. 
+If a dead man dependency is in force, if a ticket is revoked from a site, the
+nodes that are hosting dependent resources are fenced. This considerably speeds
+up the recovery process of the cluster and makes sure that resources can be
+migrated more quickly.
 
 This can be configured by specifying a +loss-policy="fence"+ in
 +rsc_ticket+ constraints.
 
+=== Cluster Ticket Registry ===
 
-==== CTR (Cluster Ticket Registry) ====
-
-This is for those scenarios where the tickets management is supposed to
-be automatic (instead of the administrator revoking the ticket somewhere,
+A CTR is a network daemon that automatically handles granting, revoking, and
+timing out tickets (instead of the administrator revoking the ticket somewhere,
 waiting for everything to stop, and then granting it on the desired site).
 
-A `CTR` is a network daemon that handles granting,
-revoking, and timing out "tickets". The participating clusters would run
-the daemons that would connect to each other, exchange information on
-their connectivity details, and vote on which site gets which ticket(s).
+Pacemaker does not implement its own CTR, but interoperates with external
+software designed for that purpose (similar to how resource and fencing agents
+are not directly part of pacemaker).
 
 Participating clusters run the CTR daemons, which connect to each other, exchange
 information about their connectivity, and vote on which sites gets which
@@ -115,10 +107,9 @@ resources again.
 This can also be thought of as a "quorum server", except that it is not
 a single quorum ticket, but several.
 
+=== Configuration Replication ===
 
-==== Configuration Replication ====
-
-As usual, the CIB is synchronized within each cluster, but it is not synchronized
+As usual, the CIB is synchronized within each cluster, but it is 'not' synchronized
 across cluster sites of a multi-site cluster. You have to configure the resources
 that will be highly available across the multi-site cluster for every site
 accordingly.
@@ -159,34 +150,38 @@ slave mode), you might want to configure that only master mode
 depends on +ticketA+. With the following configuration, +rsc1+ will be
 demoted to slave mode if +ticketA+ is revoked:
 
+.Constraint that demotes +rsc1+ if +ticketA+ is revoked
+====
 [source,XML]
 -------
 <rsc_ticket id="rsc1-req-ticketA" rsc="rsc1" rsc-role="Master" ticket="ticketA" loss-policy="demote"/>
 -------
+====
 
-You can create more `rsc_ticket` constraints to let multiple resources
-depend on the same ticket.
- 
-`rsc_ticket` also supports resource sets. So one can easily list all the
-resources in one `rsc_ticket` constraint. For example:
+You can create multiple `rsc_ticket` constraints to let multiple resources
+depend on the same ticket. However, `rsc_ticket` also supports resource sets,
+so one can easily list all the resources in one `rsc_ticket` constraint instead.
 
+.Ticket constraint for multiple resources
+====
 [source,XML]
 -------
-      <rsc_ticket id="resources-dep-ticketA" ticket="ticketA" loss-policy="fence">
-        <resource_set id="resources-dep-ticketA-0" role="Started">
-          <resource_ref id="rsc1"/>
-          <resource_ref id="group1"/>
-          <resource_ref id="clone1"/>
-        </resource_set>
-        <resource_set id="resources-dep-ticketA-1" role="Master">
-          <resource_ref id="ms1"/>
-        </resource_set>
-      </rsc_ticket>
+<rsc_ticket id="resources-dep-ticketA" ticket="ticketA" loss-policy="fence">
+  <resource_set id="resources-dep-ticketA-0" role="Started">
+    <resource_ref id="rsc1"/>
+    <resource_ref id="group1"/>
+    <resource_ref id="clone1"/>
+  </resource_set>
+  <resource_set id="resources-dep-ticketA-1" role="Master">
+    <resource_ref id="ms1"/>
+  </resource_set>
+</rsc_ticket>
 -------
+====
 
-In the example, there are two resource sets for listing the resources with
-different `roles` in one `rsc_ticket` constraint. There's no dependency
-between the two resource sets. And there's no dependency among the
+In the example above, there are two resource sets, so we can list resources
+with different roles in a single +rsc_ticket+ constraint. There's no dependency
+between the two resource sets, and there's no dependency among the
 resources within a resource set. Each of the resources just depends on
 +ticketA+.
 
@@ -272,66 +267,18 @@ resources before will be treated according to the `loss-policy` you set
 within the `rsc_ticket` constraint.
 
 Before the booth can manage a certain ticket within the multi-site cluster,
-you initially need to grant it to a site manually via `booth client` command.
-After you have initially granted a ticket to a site, the booth mechanism
+you initially need to grant it to a site manually via the `booth` command-line
+tool. After you have initially granted a ticket to a site, `boothd`
 will take over and manage the ticket automatically.  
 
 [IMPORTANT]
 ====
-The `booth client` command line tool can be used to grant, list, or
-revoke tickets.  The `booth client` commands work on any machine where
-the booth daemon is running. 
-
-If you are managing tickets via `Booth`, only use `booth client` for manual
-intervention instead of `crm_ticket`. That can make sure the same ticket
+The `booth` command-line tool can be used to grant, list, or
+revoke tickets and can be run on any machine where `boothd` is running. 
+If you are managing tickets via Booth, use only `booth` for manual
+intervention, not `crm_ticket`. That ensures the same ticket
 will only be owned by one cluster site at a time.
 ====
-
-Booth includes an implementation of
-http://en.wikipedia.org/wiki/Paxos_algorithm['Paxos'] and 'Paxos Lease'
-algorithm, which guarantees the distributed consensus among different
-cluster sites. 
-
-[NOTE]
-====
-`Arbitrator`
-
-Each site runs one booth instance that is responsible for communicating
-with the other sites. If you have a setup with an even number of sites,
-you need an additional instance to reach consensus about decisions such
-as failover of resources across sites. In this case, add one or more
-arbitrators running at additional sites. Arbitrators are single machines
-that run a booth instance in a special mode. As all booth instances
-communicate with each other, arbitrators help to make more reliable
-decisions about granting or revoking tickets.
-
-An arbitrator is especially important for a two-site scenario: For example,
-if site `A` can no longer communicate with site `B`, there are two possible
-causes for that:
-
-- `A` network failure between `A` and `B`.
-
-- Site `B` is down.
-
-However, if site `C` (the arbitrator) can still communicate with site `B`,
-site `B` must still be up and running. 
-
-====
-
-===== Requirements =====
-
-- All clusters that will be part of the multi-site cluster must be based on Pacemaker.
-
-- Booth must be installed on all cluster nodes and on all arbitrators that will
-be part of the multi-site cluster. 
-
-The most common scenario is probably a multi-site cluster with two sites and a
-single arbitrator on a third site. However, technically, there are no limitations
-with regards to the number of sites and the number of arbitrators involved.
-
-Nodes belonging to the same cluster site should be synchronized via NTP. However,
-time synchronization is not required between the individual cluster sites.
-
 
 === General Management of Tickets ===
 

--- a/doc/Pacemaker_Explained/en-US/Ch-Multi-site-Clusters.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Multi-site-Clusters.txt
@@ -3,31 +3,30 @@
 [[Multisite]]
 == Abstract ==
 Apart from local clusters, Pacemaker also supports multi-site clusters.
-That means you can have multiple, geographically dispersed sites with a
-local cluster each. Failover between these clusters can be coordinated
-by a higher level entity, the so-called `CTR (Cluster Ticket Registry)`.
-
+That means you can have multiple, geographically dispersed sites, each with a
+local cluster. Failover between these clusters can be coordinated
+manually by the administrator, or automatically by a higher-level entity called
+a 'Cluster Ticket Registry (CTR)'.
 
 == Challenges for Multi-Site Clusters ==
 
 Typically, multi-site environments are too far apart to support
-synchronous communication between the sites and synchronous data
-replication. That leads to the following challenges:
+synchronous communication and data replication between the sites.
+That leads to significant challenges:
 
-- How to make sure that a cluster site is up and running?
+- How do we make sure that a cluster site is up and running?
 
-- How to make sure that resources are only started once?
+- How do we make sure that resources are only started once?
 
-- How to make sure that quorum can be reached between the different
-sites and a split brain scenario can be avoided?
+- How do we make sure that quorum can be reached between the different
+sites and a split-brain scenario avoided?
 
-- How to manage failover between the sites?
+- How do we manage failover between sites?
 
-- How to deal with high latency in case of resources that need to be
+- How do we deal with high latency in case of resources that need to be
 stopped? 
 
 In the following sections, learn how to meet these challenges.
-
 
 == Conceptual Overview ==
 
@@ -36,10 +35,10 @@ each cluster site corresponds to a cluster node in a traditional cluster.
 The overlay cluster can be managed by a `CTR (Cluster Ticket Registry)`
 mechanism. It guarantees that the cluster resources will be highly
 available across different cluster sites. This is achieved by using
-so-called `tickets` that are treated as failover domain between cluster
+'tickets' that are treated as failover domain between cluster
 sites, in case a site should be down.
 
-The following list explains the individual components and mechanisms
+The following sections explain the individual components and mechanisms
 that were introduced for multi-site clusters in more detail.
 
 
@@ -49,8 +48,8 @@ that were introduced for multi-site clusters in more detail.
 
 "Tickets" are, essentially, cluster-wide attributes. A ticket grants the
 right to run certain resources on a specific cluster site. Resources can
-be bound to a certain ticket by `rsc_ticket` dependencies. Only if the
-ticket is available at a site, the respective resources are started.
+be bound to a certain ticket by +rsc_ticket+ constraints. Only if the
+ticket is available at a site can the respective resources be started there.
 Vice versa, if the ticket is revoked, the resources depending on that
 ticket need to be stopped.
 
@@ -60,9 +59,9 @@ manage/own resources associated with that site.
 (One can also think of the current `have-quorum` flag as a special, cluster-wide
 ticket that is granted in case of node majority.)
 
-These tickets can be granted/revoked either manually by administrators
-(which could be the default for the classic enterprise clusters), or via
-an automated `CTR` mechanism described further below.
+Tickets can be granted and revoked either manually by administrators
+(which could be the default for classic enterprise clusters), or via
+the automated CTR mechanism described below.
 
 A ticket can only be owned by one site at a time. Initially, none
 of the sites has a ticket. Each ticket must be granted once by the cluster
@@ -102,12 +101,16 @@ revoking, and timing out "tickets". The participating clusters would run
 the daemons that would connect to each other, exchange information on
 their connectivity details, and vote on which site gets which ticket(s).
 
-A ticket would only be granted to a site once they can be sure that it
-has been relinquished by the previous owner, which would need to be
-implemented via a timer in most scenarios. If a site loses connection
-to its peers, its tickets time out and recovery occurs. After the
-connection timeout plus the recovery timeout has passed, the other sites
-are allowed to re-acquire the ticket and start the resources again.
+Participating clusters run the CTR daemons, which connect to each other, exchange
+information about their connectivity, and vote on which sites gets which
+tickets.
+
+A ticket is granted to a site only once the CTR is sure that the ticket
+has been relinquished by the previous owner, implemented via a timer in most
+scenarios. If a site loses connection to its peers, its tickets time out and
+recovery occurs. After the connection timeout plus the recovery timeout has
+passed, the other sites are allowed to re-acquire the ticket and start the
+resources again.
 
 This can also be thought of as a "quorum server", except that it is not
 a single quorum ticket, but several.
@@ -121,6 +124,7 @@ that will be highly available across the multi-site cluster for every site
 accordingly.
 
 
+[[s-ticket-constraints]]
 == Configuring Ticket Dependencies ==
 
 The `rsc_ticket` constraint lets you specify the resources depending on a certain
@@ -138,12 +142,13 @@ The attribute `loss-policy` can have the following values:
 * +demote:+ Demote relevant resources that are running in master mode to slave mode. 
 
 
-An example to configure a `rsc_ticket` constraint:
-
+.Constraint that fences node if +ticketA+ is revoked
+====
 [source,XML]
 -------
 <rsc_ticket id="rsc1-req-ticketA" rsc="rsc1" ticket="ticketA" loss-policy="fence"/>
 -------
+====
 
 The example above creates a constraint with the ID +rsc1-req-ticketA+. It
 defines that the resource +rsc1+ depends on +ticketA+ and that the node running
@@ -197,9 +202,9 @@ constraints as necessary with +rsc_ticket+.
 === Granting and Revoking Tickets Manually ===
 
 You can grant tickets to sites or revoke them from sites manually.
-Though if you want to re-distribute a ticket, you should wait for
-the dependent resources to cleanly stop at the previous site before you
-grant the ticket to another desired site.
+If you want to re-distribute a ticket, you should wait for
+the dependent resources to stop cleanly at the previous site before you
+grant the ticket to the new site.
 
 Use the `crm_ticket` command line tool to grant and revoke tickets. 
 
@@ -215,23 +220,44 @@ To revoke a ticket from this site:
 
 [IMPORTANT]
 ====
-If you are managing tickets manually. Use the `crm_ticket` command with
-great care as they cannot help verify if the same ticket is already
+If you are managing tickets manually, use the `crm_ticket` command with
+great care, because it cannot check whether the same ticket is already
 granted elsewhere. 
-
 ====
 
 
 === Granting and Revoking Tickets via a Cluster Ticket Registry ===
 
-==== Booth ====
-Booth is an implementation of `Cluster Ticket Registry` or so-called
-`Cluster Ticket Manager`.
+We will use https://github.com/ClusterLabs/booth[Booth] here as an example of
+software that can be used with pacemaker as a Cluster Ticket Registry.  Booth
+implements the
+http://en.wikipedia.org/wiki/Paxos_%28computer_science%29['Paxos'] lease
+algorithm to guarantee the distributed consensus among different
+cluster sites, and manages the ticket distribution (and thus the failover
+process between sites).
 
-Booth is the instance managing the ticket distribution and thus,
-the failover process between the sites of a multi-site cluster. Each of
-the participating clusters and arbitrators runs a service, the boothd.
-It connects to the booth daemons running at the other sites and
+Each of the participating clusters and 'arbitrators' runs the Booth daemon
+`boothd`.
+
+An 'arbitrator' is the multi-site equivalent of a quorum-only node in a local
+cluster. If you have a setup with an even number of sites,
+you need an additional instance to reach consensus about decisions such
+as failover of resources across sites. In this case, add one or more
+arbitrators running at additional sites. Arbitrators are single machines
+that run a booth instance in a special mode. An arbitrator is especially
+important for a two-site scenario, otherwise there is no way for one site
+to distinguish between a network failure between it and the other site, and
+a failure of the other site.
+
+The most common multi-site scenario is probably a multi-site cluster with two
+sites and a single arbitrator on a third site. However, technically, there are
+no limitations with regards to the number of sites and the number of
+arbitrators involved.
+
+Nodes belonging to the same cluster site should be synchronized via NTP. However,
+time synchronization is not required between the individual cluster sites.
+
+`Boothd` at each site connects to its peers running at the other sites and
 exchanges connectivity details. Once a ticket is granted to a site, the
 booth mechanism will manage the ticket automatically: If the site which
 holds the ticket is out of service, the booth daemons will vote which

--- a/doc/Pacemaker_Explained/en-US/Ch-Multi-site-Clusters.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Multi-site-Clusters.txt
@@ -70,26 +70,25 @@ administrator.
 
 The presence or absence of tickets for a site is stored in the CIB as a
 cluster status. With regards to a certain ticket, there are only two states
-for a site: `true` (the site has the ticket) or `false` (the site does
+for a site: +true+ (the site has the ticket) or +false+ (the site does
 not have the ticket). The absence of a certain ticket (during the initial
-state of the multi-site cluster) is also reflected by the value `false`.
-
+state of the multi-site cluster) is the same as the value +false+.
 
 ==== Dead Man Dependency ====
 
-A site can only activate the resources safely if it can be sure that the
+A site can only activate resources safely if it can be sure that the
 other site has deactivated them. However after a ticket is revoked, it can
 take a long time until all resources depending on that ticket are stopped
 "cleanly", especially in case of cascaded resources. To cut that process
-short, the concept of a `Dead Man Dependency` was introduced:
+short, the concept of a 'Dead Man Dependency' was introduced.
 
 - If the ticket is revoked from a site, the nodes that are hosting
 dependent resources are fenced. This considerably speeds up the recovery
 process of the cluster and makes sure that resources can be migrated more
 quickly. 
 
-This can be configured by specifying a `loss-policy="fence"` in
-`rsc_ticket` constraints.
+This can be configured by specifying a +loss-policy="fence"+ in
++rsc_ticket+ constraints.
 
 
 ==== CTR (Cluster Ticket Registry) ====
@@ -130,13 +129,13 @@ what should happen to the respective resources if the ticket is revoked.
 
 The attribute `loss-policy` can have the following values:
 
-fence:: Fence the nodes that are running the relevant resources.
+* +fence:+ Fence the nodes that are running the relevant resources.
 
-stop:: Stop the relevant resources.
+* +stop:+ Stop the relevant resources.
 
-freeze:: Do nothing to the relevant resources.
+* +freeze:+ Do nothing to the relevant resources.
 
-demote:: Demote relevant resources that are running in master mode to slave mode. 
+* +demote:+ Demote relevant resources that are running in master mode to slave mode. 
 
 
 An example to configure a `rsc_ticket` constraint:
@@ -146,14 +145,14 @@ An example to configure a `rsc_ticket` constraint:
 <rsc_ticket id="rsc1-req-ticketA" rsc="rsc1" ticket="ticketA" loss-policy="fence"/>
 -------
 
-This creates a constraint with the ID `rsc1-req-ticketA`. It defines that the
-resource `rsc1` depends on `ticketA` and that the node running the resource should
-be fenced in case `ticketA` is revoked.
+The example above creates a constraint with the ID +rsc1-req-ticketA+. It
+defines that the resource +rsc1+ depends on +ticketA+ and that the node running
+the resource should be fenced if +ticketA+ is revoked.
 
-If resource `rsc1` was a multi-state resource that can run in master or
-slave mode, you may want to configure that only `rsc1's` master mode
-depends on `ticketA`. With the following configuration, `rsc1` will be
-demoted to slave mode if `ticketA` is revoked:
+If resource +rsc1+ were a multi-state resource (i.e. it could run in master or
+slave mode), you might want to configure that only master mode
+depends on +ticketA+. With the following configuration, +rsc1+ will be
+demoted to slave mode if +ticketA+ is revoked:
 
 [source,XML]
 -------
@@ -184,13 +183,13 @@ In the example, there are two resource sets for listing the resources with
 different `roles` in one `rsc_ticket` constraint. There's no dependency
 between the two resource sets. And there's no dependency among the
 resources within a resource set. Each of the resources just depends on
-`ticketA`.
++ticketA+.
 
-Referencing resource templates in `rsc_ticket` constraints, and even
+Referencing resource templates in +rsc_ticket+ constraints, and even
 referencing them within resource sets, is also supported. 
 
 If you want other resources to depend on further tickets, create as many
-constraints as necessary with `rsc_ticket`.
+constraints as necessary with +rsc_ticket+.
 
 
 == Managing Multi-Site Clusters ==
@@ -320,24 +319,23 @@ Or you can monitor them with:
 # crm_mon --tickets
 -------
 
-Display the rsc_ticket constraints that apply to a ticket:
+Display the +rsc_ticket+ constraints that apply to a ticket:
 -------
 # crm_ticket --ticket ticketA --constraints
 -------
 
-When you want to do maintenance or manual switch-over of a ticket, the
-ticket could be revoked from the site for any reason, which would
-trigger the loss-policies. If `loss-policy="fence"`, the dependent
-resources could not be gracefully stopped/demoted, and even, other
-unrelated resources could be impacted. 
+When you want to do maintenance or manual switch-over of a ticket,
+revoking the ticket would trigger the loss policies. If
++loss-policy="fence"+, the dependent resources could not be gracefully
+stopped/demoted, and other unrelated resources could even be affected. 
 
-The proper way is making the ticket `standby` first with:
+The proper way is making the ticket 'standby' first with:
 -------
 # crm_ticket --ticket ticketA --standby
 -------
 
 Then the dependent resources will be stopped or demoted gracefully without
-triggering the loss-policies.
+triggering the loss policies.
 
 If you have finished the maintenance and want to activate the ticket again,
 you can run:
@@ -347,8 +345,6 @@ you can run:
 
 == For more information ==
 
-`Multi-site Clusters`
-http://doc.opensuse.org/products/draft/SLE-HA/SLE-ha-guide_sd_draft/cha.ha.geo.html
+* http://doc.opensuse.org/products/draft/SLE-HA/SLE-ha-guide_sd_draft/cha.ha.geo.html[SUSE's Multi-site Clusters guide]
 
-`Booth`
-https://github.com/ClusterLabs/booth
+* https://github.com/ClusterLabs/booth[Booth]

--- a/doc/Pacemaker_Explained/en-US/Ch-Nodes.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Nodes.txt
@@ -45,10 +45,13 @@ available to display the name used by the node with the corosync
 *nodeid* of pass:[<replaceable>number</replaceable>], for example: `crm_node --name-for-id 2`.
 
 [[s-node-attributes]]
-== Describing a Cluster Node ==
+== Node Attributes ==
 
 indexterm:[Node,attribute]
-Beyond the basic definition of a node the administrator can also
+'Node attributes' are a special type of option (name-value pair) that
+applies to a node object.
+
+Beyond the basic definition of a node, the administrator can
 describe the node's attributes, such as how much RAM, disk, what OS or
 kernel version it has, perhaps even its physical location.  This
 information can then be used by the cluster when deciding where to
@@ -89,20 +92,22 @@ rejoins the cluster.  The cluster uses this area to store a record of
 how many times a resource has failed on that node, but administrators
 can also read and write to this section by specifying `--type status`.
 
-== Corosync ==
+== Managing Nodes in a Corosync-Based Cluster ==
 
 === Adding a New Corosync Node ===
 
 indexterm:[Corosync,Add Cluster Node]
 indexterm:[Add Cluster Node,Corosync]
 
-Adding a new node is as simple as installing Corosync and Pacemaker,
-and copying '/etc/corosync/corosync.conf' and '/etc/corosync/authkey' (if
-it exists) from an existing node.  You may need to modify the
-+mcastaddr+ option to match the new node's IP address.
+To add a new node:
 
-If a log message containing "Invalid digest" appears from Corosync,
-the keys are not consistent between the machines.
+. Install Corosync and Pacemaker on the new host.
+. Copy +/etc/corosync/corosync.conf+ and +/etc/corosync/authkey+ (if it exists)
+  from an existing node. You may need to modify the *mcastaddr* option to match
+  the new node's IP address.
+. Start the cluster software on the new host. If a log message containing
+  "Invalid digest" appears from Corosync, the keys are not consistent between
+  the machines.
 
 === Removing a Corosync Node ===
 
@@ -110,23 +115,20 @@ indexterm:[Corosync,Remove Cluster Node]
 indexterm:[Remove Cluster Node,Corosync]
 
 Because the messaging and membership layers are the authoritative
-source for cluster nodes, deleting them from the CIB is not a reliable
-solution.  First one must arrange for corosync to forget about the
-node (_pcmk-1_ in the example below).
+source for cluster nodes, deleting them from the CIB is not a complete
+solution.  First, one must arrange for corosync to forget about the
+node (*pcmk-1* in the example below).
 
-On the host to be removed:
-
-. Stop the cluster: `/etc/init.d/corosync stop`
-
-Next, from one of the remaining active cluster nodes:
-
-. Tell Pacemaker to forget about the removed host:
+. Stop the cluster on the host to be removed. How to do this will vary with
+  your operating system and installed versions of cluster software, for example,
+  `pcs cluster stop` if you are using pcs for cluster management, or
+  `service corosync stop` on a host using corosync 1.x with the pacemaker plugin.
+. From one of the remaining active cluster nodes, tell Pacemaker to forget
+  about the removed host, which will also delete the node from the CIB:
 +
 ----
 # crm_node -R pcmk-1
 ----
-+
-This includes deleting the node from the CIB
 
 [NOTE]
 ======
@@ -138,18 +140,14 @@ This procedure only works for pacemaker 1.1.8 and later.
 indexterm:[Corosync,Replace Cluster Node]
 indexterm:[Replace Cluster Node,Corosync]
 
-The five-step guide to replacing an existing cluster node:
+To replace an existing cluster node:
 
-. Make sure the old node is completely stopped
-. Give the new machine the same hostname and IP address as the old one
-. Install the cluster software :-)
-. Copy '/etc/corosync/corosync.conf' and '/etc/corosync/authkey' (if it exists) to the new node
-. Start the new cluster node
+. Make sure the old node is completely stopped.
+. Give the new machine the same hostname and IP address as the old one.
+. Follow the procedure above for adding a node.
 
-If a log message containing "Invalid digest" appears from Corosync,
-the keys are not consistent between the machines.
-
-== CMAN ==
+////
+== Managing Nodes in a CMAN-based Cluster ==
 
 === Adding a New CMAN Node ===
 
@@ -160,20 +158,25 @@ indexterm:[Add Cluster Node,CMAN]
 
 indexterm:[CMAN,Remove Cluster Node]
 indexterm:[Remove Cluster Node,CMAN]
+////
 
-== Heartbeat ==
+== Managing Nodes in a Heartbeat-based Cluster ==
 
 === Adding a New Heartbeat Node ===
 
 indexterm:[Heartbeat,Add Cluster Node]
 indexterm:[Add Cluster Node,Heartbeat]
 
-Provided you specified +autojoin any+ in 'ha.cf', adding a new node is
-as simple as installing heartbeat and copying 'ha.cf' and 'authkeys'
-from an existing node.
+To add a new node:
 
-If you don't want to use +autojoin+, then after setting up 'ha.cf' and
-'authkeys', you must use `hb_addnode` before starting the new node.
+. Install heartbeat and pacemaker on the new host.
+. Copy +ha.cf+ and +authkeys+ from an existing node.
+. If you do not use *autojoin any* in +ha.cf+, run:
++
+----
+hb_addnode $(uname -n)
+----
+. Start the cluster software on the new node.
 
 === Removing a Heartbeat Node ===
 
@@ -181,45 +184,42 @@ indexterm:[Heartbeat,Remove Cluster Node]
 indexterm:[Remove Cluster Node,Heartbeat]
 
 Because the messaging and membership layers are the authoritative
-source for cluster nodes, deleting them from the CIB is not a reliable
-solution.
-
-First one must arrange for Heartbeat to forget about the node (pcmk-1
+source for cluster nodes, deleting them from the CIB is not a complete
+solution. First, one must arrange for Heartbeat to forget about the node (pcmk-1
 in the example below).
 
-On the host to be removed:
-
-. Stop the cluster: `/etc/init.d/corosync stop`
-
-Next, from one of the remaining active cluster nodes:
-
-. Tell Heartbeat the node should be removed
-
+. On the host to be removed, stop the cluster:
++
 ----
-# hb_delnode pcmk-1
+service heartbeat stop
 ----
-
+. From one of the remaining active cluster nodes, tell Heartbeat the node
+should be removed:
++
+----
+hb_delnode pcmk-1
+----
 . Tell Pacemaker to forget about the removed host:
-
++
 ----
-# crm_node -R pcmk-1
+crm_node -R pcmk-1
 ----
 
 [NOTE]
 ======
-This proceedure only works for versions after 1.1.8
+This procedure only works for pacemaker versions after 1.1.8.
 ======
 
 === Replacing a Heartbeat Node ===
 
 indexterm:[Heartbeat,Replace Cluster Node]
 indexterm:[Replace Cluster Node,Heartbeat]
-The seven-step guide to replacing an existing cluster node:
+To replace an existing cluster node:
 
-. Make sure the old node is completely stopped
-. Give the new machine the same hostname as the old one
-. Go to an active cluster node and look up the UUID for the old node in '/var/lib/heartbeat/hostcache'
-. Install the cluster software
-. Copy 'ha.cf' and 'authkeys' to the new node
-. On the new node, populate it's UUID using `crm_uuid -w` and the UUID from step 2
-. Start the new cluster node
+. Make sure the old node is completely stopped.
+. Give the new machine the same hostname as the old one.
+. Go to an active cluster node and look up the UUID for the old node in +/var/lib/heartbeat/hostcache+.
+. Install the cluster software.
+. Copy +ha.cf+ and +authkeys+ to the new node.
+. On the new node, populate its UUID using `crm_uuid -w` and the UUID obtained earlier.
+. Start the new cluster node.

--- a/doc/Pacemaker_Explained/en-US/Ch-Nodes.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Nodes.txt
@@ -30,8 +30,8 @@ returned by `uname -n`.  This can be problematic for services that
 require the `uname -n` to be a specific value (e.g. for a licence
 file).
 
-Since version 2.0.0 of Pacemaker, this requirement has been relaxed
-for clusters using Corosync 2.0 or later.  The name Pacemaker uses is:
+This requirement has been relaxed for clusters using Corosync 2.0 or later.
+The name Pacemaker uses is:
 
 . The value stored in +corosync.conf+ under *ring0_addr* in the *nodelist*, if it does not contain an IP address; otherwise
 . The value stored in +corosync.conf+ under *name* in the *nodelist*; otherwise
@@ -60,7 +60,7 @@ when the cluster is running, using `crm_attribute`.
 
 Below is what the node's definition would look like if the admin ran the command:
       
-.The result of using crm_attribute to specify which kernel pcmk-1 is running
+.Result of using crm_attribute to specify which kernel pcmk-1 is running
 ======
 -------
 # crm_attribute --type nodes --node pcmk-1 --name kernel --update $(uname -r)
@@ -74,7 +74,8 @@ Below is what the node's definition would look like if the admin ran the command
 </node>
 -------
 ======
-A simpler way to determine the current value of an attribute is to use `crm_attribute` command again:
+Rather than having to read the XML, a simpler way to determine the current
+value of an attribute is to use `crm_attribute` again:
 
 ----
 # crm_attribute --type nodes --node pcmk-1 --name kernel --query
@@ -129,7 +130,7 @@ This includes deleting the node from the CIB
 
 [NOTE]
 ======
-This proceedure only works for versions after 1.1.8
+This procedure only works for pacemaker 1.1.8 and later.
 ======
 
 === Replacing a Corosync Node ===

--- a/doc/Pacemaker_Explained/en-US/Ch-Nodes.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Nodes.txt
@@ -27,22 +27,22 @@ to read an existing UUID or define a value before the cluster starts.
 
 Traditionally, Pacemaker required nodes to be referred to by the value
 returned by `uname -n`.  This can be problematic for services that
-require the `uname -n` to be a specific value (ie. for a licence
+require the `uname -n` to be a specific value (e.g. for a licence
 file).
 
 Since version 2.0.0 of Pacemaker, this requirement has been relaxed
 for clusters using Corosync 2.0 or later.  The name Pacemaker uses is:
 
-. The value stored in 'corosync.conf' under +ring0_addr+ in the +nodelist+, if it does not contain an IP address; otherwise
-. The value stored in 'corosync.conf' under +name+ in the +nodelist+; otherwise
+. The value stored in +corosync.conf+ under *ring0_addr* in the *nodelist*, if it does not contain an IP address; otherwise
+. The value stored in +corosync.conf+ under *name* in the *nodelist*; otherwise
 . The value of `uname -n`
 
 Pacemaker provides the `crm_node -n` command which displays the name
 used by a running cluster.
 
-If a Corosync nodelist is used, `crm_node --name-for-id $number` is also
+If a Corosync *nodelist* is used, `crm_node --name-for-id` pass:[<replaceable>number</replaceable>] is also
 available to display the name used by the node with the corosync
-+nodeid+ of '$number', for example: `crm_node --name-for-id 2`.
+*nodeid* of pass:[<replaceable>number</replaceable>], for example: `crm_node --name-for-id 2`.
 
 [[s-node-attributes]]
 == Describing a Cluster Node ==
@@ -85,7 +85,7 @@ By specifying `--type nodes` the admin tells the cluster that this
 attribute is persistent.  There are also transient attributes which
 are kept in the status section which are "forgotten" whenever the node
 rejoins the cluster.  The cluster uses this area to store a record of
-how many times a resource has failed on that node but administrators
+how many times a resource has failed on that node, but administrators
 can also read and write to this section by specifying `--type status`.
 
 == Corosync ==

--- a/doc/Pacemaker_Explained/en-US/Ch-Notifications.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Notifications.txt
@@ -7,21 +7,21 @@ with that construct for chapter headings
 anchor:ch-notifications[Chapter 7, Receiving Notification for Cluster Events]
 indexterm:[Resource,Notification]
 
-A Pacemaker cluster is an event driven system. In this context, an event is a
-resource failure or configuration change (not exhaustive).
+A Pacemaker cluster is an event-driven system. In this context, an 'event'
+might be a resource failure or a configuration change, among others.
 
-The +ocf:pacemaker:ClusterMon+ resource can monitor the cluster status and
-triggers alerts on each cluster event. This resource runs +crm_mon+ in the
-background at regular intervals (configurable) and uses +crm_mon+ capabilities
-to send emails (SMTP), SNMP traps or to execute an external program via the
-+extra_options+ parameter.
+The *ocf:pacemaker:ClusterMon* resource can monitor the cluster status and
+trigger alerts on each cluster event. This resource runs `crm_mon` in the
+background at regular (configurable) intervals and uses `crm_mon` capabilities
+to trigger emails (SMTP), SNMP traps or external programs (via the
++extra_options+ parameter).
 
 [NOTE]
 =====
 Depending on your system settings and compilation settings, SNMP or email
-alerts might be unavailable. Check +crm_mon --help+ output to see if these
+alerts might be unavailable. Check the output of `crm_mon --help` to see whether these
 options are available to you. In any case, executing an external agent will
-always be available, and you can have this agent to send emails, SNMP traps,
+always be available, and you can use this agent to send emails, SNMP traps
 or whatever action you develop.
 =====
 
@@ -74,8 +74,8 @@ Requires a user to send mail alerts to. "Mail-From", SMTP relay and Subject pref
 == Configuring Notifications via External-Agent ==
 
 Requires a program (external-agent) to run when resource operations take
-place, and an external-recipient (IP address, Email address, URI). When
-triggered, the external-agent is fed with dynamically filled environnement
+place, and an external-recipient (IP address, email address, URI). When
+triggered, the external-agent is fed with dynamically filled environment
 variables describing precisely the cluster event that occurred. By making
 smart usage of these variables in your external-agent code, you can trigger
 any action.

--- a/doc/Pacemaker_Explained/en-US/Ch-Notifications.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Notifications.txt
@@ -29,8 +29,12 @@ or whatever action you develop.
 == Configuring SNMP Notifications ==
 indexterm:[Resource,Notification,SNMP]
 
-Requires an IP to send SNMP traps to, and a SNMP community.
-Pacemaker MIB is found in _/usr/share/snmp/mibs/PCMK-MIB.txt_
+Requires an IP to send SNMP traps to, and an SNMP community string.
+The Pacemaker MIB is provided with the source, and is typically
+installed in +/usr/share/snmp/mibs/PCMK-MIB.txt+.
+
+This example uses +snmphost.example.com+ as the SNMP IP and
++public+ as the community string:
 
 .Configuring ClusterMon to send SNMP traps
 =====
@@ -52,7 +56,9 @@ Pacemaker MIB is found in _/usr/share/snmp/mibs/PCMK-MIB.txt_
 == Configuring Email Notifications ==
 indexterm:[Resource,Notification,SMTP,Email]
 
-Requires a user to send mail alerts to. "Mail-From", SMTP relay and Subject prefix can also be configured.
+Requires the recipient e-mail address. You can also optionally configure
+the sender e-mail address, the hostname of the SMTP relay, and a prefix string
+for the subject line.
 
 .Configuring ClusterMon to send email alerts
 =====

--- a/doc/Pacemaker_Explained/en-US/Ch-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Options.txt
@@ -1,4 +1,4 @@
-= Cluster Options =
+= Cluster-Wide Configuration =
 
 == CIB Properties ==
 
@@ -75,9 +75,10 @@ events. Maintained by the cluster.
 
 Although these fields can be written to by the user, in
 most cases the cluster will overwrite any values specified by the
-admin with the "correct" ones.  To change the +admin_epoch+, for
-example, one would use:
+user with the "correct" ones.
 
+To change the ones that can be specified by the user,
+for example +admin_epoch+, one should use:
 ----
 # cibadmin --modify --crm_xml '<cib admin_epoch="42"/>'
 ----
@@ -335,9 +336,8 @@ indexterm:[Setting,Cluster Option]
 indexterm:[Cluster,Querying Options]
 indexterm:[Cluster,Setting Options]
 
-Cluster options can be queried and modified using the
-`crm_attribute` tool.  To get the current
-value of +cluster-delay+, simply use:
+Cluster options can be queried and modified using the `crm_attribute` tool. To
+get the current value of +cluster-delay+, you can run:
 
 ----
 # crm_attribute --query --name cluster-delay
@@ -356,7 +356,7 @@ If a value is found, you'll see a result like this:
 scope=crm_config name=cluster-delay value=60s
 ----
 
-However, if no value is found, the tool will display an error:
+If no value is found, the tool will display an error:
 
 ----
 # crm_attribute -G -n clusta-deway
@@ -364,13 +364,13 @@ scope=crm_config name=clusta-deway value=(null)
 Error performing operation: No such device or address
 ----
 
-To use a different value, eg. +30+, simply run:
+To use a different value (for example, 30 seconds), simply run:
 
 ----
 # crm_attribute --name cluster-delay --update 30s
 ----
 
-To go back to the cluster's default value you can delete the value, for example with this command:
+To go back to the cluster's default value, you can delete the value, for example:
 
 ----
 # crm_attribute --name cluster-delay --delete

--- a/doc/Pacemaker_Explained/en-US/Ch-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Options.txt
@@ -393,6 +393,6 @@ Please choose from one of the matches above and supply the 'id' with --id
 -------
 =======
 
-In such cases follow the on-screen instructions to perform the
+In such cases, follow the on-screen instructions to perform the
 requested action.  To determine which value is currently being used by
-the cluster, please refer to <<ch-rules>>.
+the cluster, refer to <<ch-rules>>.

--- a/doc/Pacemaker_Explained/en-US/Ch-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Options.txt
@@ -329,7 +329,7 @@ _Deprecated:_ See <<s-operation-defaults>> instead
 
 |=========================================================
 
-== Querying and Setting Cluster Options ==
+=== Querying and Setting Cluster Options ===
 
 indexterm:[Querying,Cluster Option]
 indexterm:[Setting,Cluster Option]
@@ -377,7 +377,7 @@ To go back to the cluster's default value, you can delete the value, for example
 Deleted crm_config option: id=cib-bootstrap-options-cluster-delay name=cluster-delay
 ----
 
-== When Options are Listed More Than Once ==
+=== When Options are Listed More Than Once ===
 
 If you ever see something like the following, it means that the option you're modifying is present more than once.
 

--- a/doc/Pacemaker_Explained/en-US/Ch-Resource-Templates.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Resource-Templates.txt
@@ -5,12 +5,11 @@
 If you want to create lots of resources with similar configurations, defining a 
 resource template simplifies the task. Once defined, it can be referenced in 
 primitives or in certain types of constraints.
-
    
 == Configuring Resources with Templates ==
 
-The primitives referencing the template will inherit all meta 
-attributes, instance attributes, utilization attributes and operations defined 
+The primitives referencing the template will inherit all meta-attributes,
+instance attributes, utilization attributes and operations defined 
 in the template. And you can define specific attributes and operations for any 
 of the primitives. If any of these are defined in both the template and the 
 primitive, the values defined in the primitive will take precedence over the 

--- a/doc/Pacemaker_Explained/en-US/Ch-Resource-Templates.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Resource-Templates.txt
@@ -20,8 +20,10 @@ If any changes are needed, they can be done to the template definition and
 will take effect globally in all resource definitions referencing that
 template.
 
-Resource templates have a similar syntax like primitives. For example:
+Resource templates have a syntax similar to that of primitives.
 
+.Resource template for a migratable Xen virtual machine 
+====
 [source,XML]
 ----
 <template id="vm-template" class="ocf" provider="heartbeat" type="Xen">
@@ -37,9 +39,13 @@ Resource templates have a similar syntax like primitives. For example:
   </operations>
 </template>
 ----
+====
 
-Once you defined the new resource template, you can use it in primitives:
+Once you define a resource template, you can use it in primitives by specifying the
++template+ property.
 
+.Xen primitive resource using a resource template
+====
 [source,XML]
 ----
 <primitive id="vm1" template="vm-template">
@@ -49,10 +55,13 @@ Once you defined the new resource template, you can use it in primitives:
   </instance_attributes>
 </primitive>
 ----
+====
     
-The new primitive `vm1` is going to inherit everything from the `vm-template`. For 
-example, the equivalent of the above two would be:
+In the example above, the new primitive +vm1+ will inherit everything from +vm-template+. For 
+example, the equivalent of the above two examples would be:
 
+.Equivalent Xen primitive resource not using a resource template
+====
 [source,XML]
 ----
 <primitive id="vm1" class="ocf" provider="heartbeat" type="Xen">
@@ -72,14 +81,13 @@ example, the equivalent of the above two would be:
   </instance_attributes>
 </primitive>
 ----
+====
     
 If you want to overwrite some attributes or operations, add them to the 
 particular primitive's definition. 
 
-For instance, the following new primitive `vm2` has special 
-attribute values. Its `monitor` operation has a longer `timeout` and `interval`, and 
-the primitive has an additional `stop` operation.
-
+.Xen resource overriding template values
+====
 [source,XML]
 ----
 <primitive id="vm2" template="vm-template">
@@ -99,14 +107,19 @@ the primitive has an additional `stop` operation.
   </operations>
 </primitive>
 ----
+====
     
-The following command shows the resulting definition of a resource:
+In the example above, the new primitive +vm2+ has special 
+attribute values. Its +monitor+ operation has a longer +timeout+ and +interval+, and 
+the primitive has an additional +stop+ operation.
+
+To see the resulting definition of a resource, run:
     
 ----
 # crm_resource --query-xml --resource vm2
 ----
     
-The following command shows its raw definition in cib:
+To see the raw definition of a resource in the CIB, run:
     
 ----
 # crm_resource --query-xml-raw --resource vm2
@@ -116,9 +129,9 @@ The following command shows its raw definition in cib:
    
 A resource template can be referenced in the following types of constraints:
 
-- `order` constraints
-- `colocation` constraints,
-- `rsc_ticket` constraints (for multi-site clusters).
+- +order+ constraints (see <<s-resource-ordering>>)
+- +colocation+ constraints (see <<s-resource-colocation>>)
+- +rsc_ticket+ constraints (for multi-site clusters as described in <<s-ticket-constraints>>)
 
 Resource templates referenced in constraints stand for all primitives which are 
 derived from that template. This means, the constraint applies to all primitive 
@@ -126,12 +139,12 @@ resources referencing the resource template. Referencing resource templates in
 constraints is an alternative to resource sets and can simplify the cluster 
 configuration considerably.
 
-For example:
+For example, given the example templates earlier in this chapter:
 
 [source,XML]
 <rsc_colocation id="vm-template-colo-base-rsc" rsc="vm-template" rsc-role="Started" with-rsc="base-rsc" score="INFINITY"/>
 
-is the equivalent of the following constraint configuration:
+would colocate all VMs with +base-rsc+ and is the equivalent of the following constraint configuration:
 
 [source,XML]
 ----
@@ -149,7 +162,7 @@ is the equivalent of the following constraint configuration:
 [NOTE]
 ======
 In a colocation constraint, only one template may be referenced from either
-`rsc` or `with-rsc`, and the other reference must be a regular resource.
+`rsc` or `with-rsc`; the other reference must be a regular resource.
 ======
 
 Resource templates can also be referenced in resource sets.

--- a/doc/Pacemaker_Explained/en-US/Ch-Resource-Templates.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Resource-Templates.txt
@@ -1,7 +1,5 @@
 = Resource Templates =
 
-== Abstract ==
-
 If you want to create lots of resources with similar configurations, defining a 
 resource template simplifies the task. Once defined, it can be referenced in 
 primitives or in certain types of constraints.
@@ -165,6 +163,8 @@ In a colocation constraint, only one template may be referenced from either
 `rsc` or `with-rsc`; the other reference must be a regular resource.
 ======
 
+=== Referencing Resource Templates in Sequential Resource Sets ===
+
 Resource templates can also be referenced in resource sets.
 
 For example:
@@ -193,6 +193,8 @@ is the equivalent of the following constraint configuration:
   </resource_set>
 </rsc_order>
 ----
+
+=== Referencing Resource Templates in Parallel Resource Sets ===
 
 If the resources referencing the template can run in parallel:
 

--- a/doc/Pacemaker_Explained/en-US/Ch-Resources.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Resources.txt
@@ -99,15 +99,24 @@ http://refspecs.linux-foundation.org/LSB_3.0.0/LSB-Core-generic/LSB-Core-generic
 for the LSB Spec as it relates to init scripts.
 ]
 
+[WARNING]
+====
 Many distributions claim LSB compliance but ship with broken init
 scripts.  For details on how to check whether your init script is
 LSB-compatible, see <<ap-lsb>>. Common problematic violations of
 the LSB standard include:
 
 * Not implementing the status operation at all
-* Not observing the correct exit status codes for start/stop/status actions
-* Starting a started resource returns an error (this violates the LSB spec)
-* Stopping a stopped resource returns an error (this violates the LSB spec)
+* Not observing the correct exit status codes for `start/stop/status` actions
+* Starting a started resource returns an error
+* Stopping a stopped resource returns an error
+====
+
+[IMPORTANT]
+====
+Remember to make sure the computer is _not_ configured to start any
+services at boot time -- that should be controlled by the cluster.
+====
 
 === Systemd ===
 indexterm:[Resource,Systemd]
@@ -126,11 +135,11 @@ are online guides for converting from init scripts.
 footnote:[For example,
 http://0pointer.de/blog/projects/systemd-for-admins-3.html]
 
-[NOTE]
-======
-Remember to make sure the computer is +not+ configured to start any
-services at boot time that should be controlled by the cluster.
-======
+[IMPORTANT]
+====
+Remember to make sure the computer is _not_ configured to start any
+services at boot time -- that should be controlled by the cluster.
+====
 
 === Upstart ===
 indexterm:[Resource,Upstart]
@@ -146,11 +155,11 @@ Pacemaker is able to manage these services _if they are present_.
 Instead of init scripts, upstart has 'jobs'.  Generally, the
 services (jobs) are provided by the OS distribution.
 
-[NOTE]
-======
-Remember to make sure the computer is +not+ configured to start any
-services at boot time that should be controlled by the cluster.
-======
+[IMPORTANT]
+====
+Remember to make sure the computer is _not_ configured to start any
+services at boot time -- that should be controlled by the cluster.
+====
 
 === System Services ===
 indexterm:[Resource,System Services]
@@ -180,8 +189,12 @@ discussed later in <<ch-stonith>>.
 indexterm:[Resource,Nagios Plugins]
 indexterm:[Nagios Plugins,Resources]
 
-Nagios plugins allow us to monitor services on the remote hosts.
-http://nagiosplugins.org[Nagios Plugins].
+Nagios Plugins
+footnote:[The project has two independent forks, hosted at
+https://www.nagios-plugins.org/ and https://www.monitoring-plugins.org/. Output
+from both projects' plugins is similar, so plugins from either project can be
+used with pacemaker.]
+allow us to monitor services on remote hosts.
 
 Pacemaker is able to do remote monitoring with the plugins _if they are
 present_.
@@ -438,7 +451,7 @@ resources in the configuration (unless of course the individual
 resources were specifically enabled by having their +is-managed+ set to
 +true+).
 
-== Instance Attributes ==
+=== Resource Instance Attributes ===
 
 The resource agents of some resource classes (lsb, systemd and upstart 'not' among them)
 can be given parameters which determine how they behave and which instance
@@ -546,9 +559,10 @@ the cluster reacts to operation timeouts.
 
 indexterm:[Resource,Action]
 
-=== Monitoring Resources for Failure ===
+Operations are actions the cluster can perform on a resource,
+such as start, stop and monitor.
 
-By default, the cluster will not ensure your resources are still
+As an example, by default the cluster will not ensure your resources are still
 healthy.  To instruct the cluster to do this, you need to add a
 +monitor+ operation to the resource's definition.
 
@@ -634,8 +648,10 @@ indexterm:[Action,Property,on-fail]
 [[s-operation-defaults]]
 === Setting Global Defaults for Operations ===
 
-To set a default value for a operation option, simply add it to the
-+op_defaults+ section with `crm_attribute`. Thus,
+You can change the global default values for operation properties
+in a given cluster. These are defined in an +op_defaults+ section 
+of the CIB's +configuration+ section, and can be set with `crm_attribute`.
+For example,
 
 ----
 # crm_attribute --type op_defaults --name timeout --update 20s

--- a/doc/Pacemaker_Explained/en-US/Ch-Resources.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Resources.txt
@@ -87,9 +87,10 @@ indexterm:[Resource,LSB]
 indexterm:[LSB,Resources]
 indexterm:[Linux Standard Base,Resources]
 
-LSB resource agents are those found in '/etc/init.d'.
+LSB resource agents are those found in +/etc/init.d+.
 
-Generally they are provided by the OS/distribution and, in order to be used with the cluster, they must conform to the LSB Spec.
+Generally, they are provided by the OS distribution and, in order to be used
+with the cluster, they must conform to the LSB Spec.
 footnote:[
 See
 http://refspecs.linux-foundation.org/LSB_3.0.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html
@@ -134,7 +135,7 @@ indexterm:[Upstart,Resources]
 Some newer distributions have replaced the old
 http://en.wikipedia.org/wiki/Init#SysV-style[SYS-V] style of
 initialization daemons (and scripts) with an alternative called
-http://upstart.ubuntu.com[Upstart].
+http://upstart.ubuntu.com/[Upstart].
 
 Pacemaker is able to manage these services _if they are present_.
 
@@ -215,7 +216,7 @@ where to find that script and what standards it conforms to.
  indexterm:[Resource,Property,class]
 
 |type
-|The name of the Resource Agent you wish to use. Eg. +IPaddr+ or +Filesystem+
+|The name of the Resource Agent you wish to use. E.g. +IPaddr+ or +Filesystem+
  indexterm:[type,Resource]
  indexterm:[Resource,Property,type]
 
@@ -668,21 +669,21 @@ simply specify a new value.
 === Multiple Monitor Operations ===
 
 Provided no two operations (for a single resource) have the same name
-and interval you can have as many monitor operations as you like.  In
-this way you can do a superficial health check every minute and
+and interval, you can have as many monitor operations as you like.  In
+this way, you can do a superficial health check every minute and
 progressively more intense ones at higher intervals.
 
 To tell the resource agent what kind of check to perform, you need to
 provide each monitor with a different value for a common parameter.
 The OCF standard creates a special parameter called +OCF_CHECK_LEVEL+
-for this purpose and dictates that it is _"made available to the
-resource agent without the normal +OCF_RESKEY+ prefix"_.
+for this purpose and dictates that it is "made available to the
+resource agent without the normal +OCF_RESKEY+ prefix".
 
 Whatever name you choose, you can specify it by adding an
-+instance_attributes+ block to the op tag.  Note that it is up to each
++instance_attributes+ block to the +op+ tag. It is up to each
 resource agent to look for the parameter and decide how to use it.
 
-.An OCF resource with two recurring health checks, performing different levels of checks - specified via +OCF_CHECK_LEVEL+.
+.An OCF resource with two recurring health checks, performing different levels of checks specified via +OCF_CHECK_LEVEL+.
 =====
 [source,XML]
 -------

--- a/doc/Pacemaker_Explained/en-US/Ch-Resources.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Resources.txt
@@ -1,37 +1,42 @@
 = Cluster Resources =
 
-== What is a Cluster Resource ==
+== What is a Cluster Resource? ==
 
 indexterm:[Resource]
 
-The role of a resource agent is to abstract the service it provides
-and present a consistent view to the cluster, which allows the cluster
-to be agnostic about the resources it manages.
+A resource is a service made highly available by a cluster.
+The simplest type of resource, a 'primitive' resource, is described
+in this chapter. More complex forms, such as groups and clones,
+are described in later chapters.
 
+Every primitive resource has a 'resource agent'. A resource agent is an
+external program that abstracts the service it provides and present a
+consistent view to the cluster.
+
+This allows the cluster to be agnostic about the resources it manages.
 The cluster doesn't need to understand how the resource works because
 it relies on the resource agent to do the right thing when given a
-+start+, +stop+ or +monitor+ command.
+`start`, `stop` or `monitor` command. For this reason, it is crucial that
+resource agents are well-tested.
 
-For this reason it is crucial that resource agents are well tested.
-
-Typically resource agents come in the form of shell scripts, however
+Typically, resource agents come in the form of shell scripts. However,
 they can be written using any technology (such as C, Python or Perl)
 that the author is comfortable with.
 
 [[s-resource-supported]]
-== Supported Resource Classes ==
+== Resource Classes ==
 
 indexterm:[Resource,class]
 
-There are six classes of agents supported by Pacemaker:
+Pacemaker supports six classes of agents:
 
 * OCF
-* LSB
-* Upstart
-* Systemd
-* Fencing
 * Service
-* Nagios
+** LSB
+** Upstart
+** Systemd
+* Fencing
+* Nagios Plugins
 
 === Open Cluster Framework ===
 
@@ -40,24 +45,22 @@ indexterm:[OCF,Resources]
 indexterm:[Open Cluster Framework,Resources]
 
 The OCF standard
-footnote:[
-http://www.opencf.org/cgi-bin/viewcvs.cgi/specs/ra/resource-agent-api.txt?rev=HEAD - at least as it relates to resource agents.
-] footnote:[
-The Pacemaker implementation has been somewhat extended from the OCF
-Specs, but none of those changes are incompatible with the original
-OCF specification.
-]
+footnote:[See
+http://www.opencf.org/cgi-bin/viewcvs.cgi/specs/ra/resource-agent-api.txt?rev=HEAD
+ -- at least as it relates to resource agents.  The Pacemaker implementation has
+been somewhat extended from the OCF specs, but none of those changes are
+incompatible with the original OCF specification.]
 is basically an extension of the Linux Standard Base conventions for
 init scripts to:
 
 * support parameters,
-* make them self describing and
-* extensible
+* make them self-describing, and
+* make them extensible
 
 OCF specs have strict definitions of the exit codes that actions must return.
 footnote:[
-Included with the cluster is the ocf-tester script, which can be
-useful in this regard.
+The resource-agents source code includes the `ocf-tester` script, which
+can be useful in this regard.
 ]
 
 The cluster follows these specifications exactly, and giving the wrong
@@ -66,15 +69,14 @@ find puzzling and annoying.  In particular, the cluster needs to
 distinguish a completely stopped resource from one which is in some
 erroneous and indeterminate state.
 
-Parameters are passed to the script as environment variables, with the
+Parameters are passed to the resource agent as environment variables, with the
 special prefix +OCF_RESKEY_+.  So, a parameter which the user thinks
-of as ip it will be passed to the script as +OCF_RESKEY_ip+.  The
-number and purpose of the parameters is completely arbitrary, however
-your script should advertise any that it supports using the
-+meta-data+ command.
+of as +ip+ will be passed to the resource agent as +OCF_RESKEY_ip+.  The
+number and purpose of the parameters is left to the resource agent; however,
+the resource agent should use the `meta-data` command to advertise any that it
+supports.
 
-
-The OCF class is the most preferred one as it is an industry standard,
+The OCF class is the most preferred as it is an industry standard,
 highly flexible (allowing parameters to be passed to agents in a
 non-positional manner) and self-describing.
 
@@ -94,12 +96,13 @@ with the cluster, they must conform to the LSB Spec.
 footnote:[
 See
 http://refspecs.linux-foundation.org/LSB_3.0.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html
-for the LSB Spec (as it relates to init scripts).
+for the LSB Spec as it relates to init scripts.
 ]
 
 Many distributions claim LSB compliance but ship with broken init
-scripts.  For details on how to check if your init script is
-LSB-compatible, see <<ap-lsb>>.  The most common problems are:
+scripts.  For details on how to check whether your init script is
+LSB-compatible, see <<ap-lsb>>. Common problematic violations of
+the LSB standard include:
 
 * Not implementing the status operation at all
 * Not observing the correct exit status codes for start/stop/status actions
@@ -111,16 +114,17 @@ indexterm:[Resource,Systemd]
 indexterm:[Systemd,Resources]
 
 Some newer distributions have replaced the old
-http://en.wikipedia.org/wiki/Init#SysV-style[SYS-V] style of
-initialization daemons (and scripts) with an alternative called
+http://en.wikipedia.org/wiki/Init#SysV-style["SysV"] style of
+initialization daemons and scripts with an alternative called
 http://www.freedesktop.org/wiki/Software/systemd[Systemd].
 
 Pacemaker is able to manage these services _if they are present_.
 
-Instead of +init scripts+, systemd has +unit files+.  Generally the
-services (or unit files) are provided by the OS/distribution but there
-are some instructions for converting from init scripts at:
-http://0pointer.de/blog/projects/systemd-for-admins-3.html
+Instead of init scripts, systemd has 'unit files'.  Generally, the
+services (unit files) are provided by the OS distribution, but there
+are online guides for converting from init scripts.
+footnote:[For example,
+http://0pointer.de/blog/projects/systemd-for-admins-3.html]
 
 [NOTE]
 ======
@@ -133,14 +137,14 @@ indexterm:[Resource,Upstart]
 indexterm:[Upstart,Resources]
 
 Some newer distributions have replaced the old
-http://en.wikipedia.org/wiki/Init#SysV-style[SYS-V] style of
+http://en.wikipedia.org/wiki/Init#SysV-style["SysV"] style of
 initialization daemons (and scripts) with an alternative called
 http://upstart.ubuntu.com/[Upstart].
 
 Pacemaker is able to manage these services _if they are present_.
 
-Instead of +init scripts+, upstart has +jobs+.  Generally the
-services (or jobs) are provided by the OS/distribution.
+Instead of init scripts, upstart has 'jobs'.  Generally, the
+services (jobs) are provided by the OS distribution.
 
 [NOTE]
 ======
@@ -152,8 +156,8 @@ services at boot time that should be controlled by the cluster.
 indexterm:[Resource,System Services]
 indexterm:[System Service,Resources]
 
-Since there are now many "common" types of system services (+systemd+,
-+upstart+, and +lsb+), Pacemaker supports a special alias which
+Since there are various types of system services (+systemd+,
++upstart+, and +lsb+), Pacemaker supports a special +service+ alias which
 intelligently figures out which one applies to a given cluster node.
 
 This is particularly useful when the cluster contains a mix of
@@ -161,7 +165,7 @@ This is particularly useful when the cluster contains a mix of
 
 In order, Pacemaker will try to find the named service as:
 
-. an LSB (SYS-V) init script
+. an LSB init script
 . a Systemd unit file
 . an Upstart job
 
@@ -169,9 +173,8 @@ In order, Pacemaker will try to find the named service as:
 indexterm:[Resource,STONITH]
 indexterm:[STONITH,Resources]
 
-There is also an additional class, STONITH, which is used exclusively
-for fencing related resources.  This is discussed later in
-<<ch-stonith>>.
+The STONITH class is used exclusively for fencing-related resources.  This is
+discussed later in <<ch-stonith>>.
 
 === Nagios Plugins ===
 indexterm:[Resource,Nagios Plugins]
@@ -188,13 +191,13 @@ container (usually a virtual machine), and the container will be restarted
 if any of them has failed. Another use is to configure them as ordinary
 resources to be used for monitoring hosts or services via the network.
 
-The supported parameters are same as the long options of a nagios plugin.
+The supported parameters are same as the long options of the plugin.
 
 [[primitive-resource]]
 == Resource Properties ==
 
-These values tell the cluster which script to use for the resource,
-where to find that script and what standards it conforms to.
+These values tell the cluster which resource agent to use for the resource,
+where to find that resource agent and what standards it conforms to.
 
 .Properties of a Primitive Resource
 [width="95%",cols="1m,6<",options="header",align="center"]
@@ -229,7 +232,8 @@ where to find that script and what standards it conforms to.
 
 |=========================================================
 
-Resource definitions can be queried with the `crm_resource` tool. For example
+The XML definition of a resource can be queried with the `crm_resource` tool.
+For example:
 
 ----
 # crm_resource --resource Email --query-xml
@@ -237,7 +241,7 @@ Resource definitions can be queried with the `crm_resource` tool. For example
 
 might produce:
 
-.An example system resource
+.A system resource definition
 =====
 [source,XML]
 <primitive id="Email" class="service" type="exim"/>
@@ -245,7 +249,7 @@ might produce:
 
 [NOTE]
 =====
-One of the main drawbacks to system services (such as LSB, Systemd and
+One of the main drawbacks to system services (LSB, systemd or
 Upstart) resources is that they do not allow any parameters!
 =====
 
@@ -422,8 +426,8 @@ the resulting resource definition might be:
 [[s-resource-defaults]]
 === Setting Global Defaults for Resource Meta-Attributes ===
 
-To set a default value for a resource option, simply add it to the
-+rsc_defaults+ section with `crm_attribute`. Thus,
+To set a default value for a resource option, add it to the
++rsc_defaults+ section with `crm_attribute`. For example,
 
 ----
 # crm_attribute --type rsc_defaults --name is-managed --update false
@@ -431,17 +435,17 @@ To set a default value for a resource option, simply add it to the
 
 would prevent the cluster from starting or stopping any of the
 resources in the configuration (unless of course the individual
-resources were specifically enabled and had +is-managed+ set to
+resources were specifically enabled by having their +is-managed+ set to
 +true+).
 
 == Instance Attributes ==
 
-The scripts of some resource classes (LSB not being one of them) can
-be given parameters which determine how they behave and which instance
+The resource agents of some resource classes (lsb, systemd and upstart 'not' among them)
+can be given parameters which determine how they behave and which instance
 of a service they control.
 
 If your resource agent supports parameters, you can add them with the
-`crm_resource` command. For instance
+`crm_resource` command. For example,
 
 ----
 # crm_resource --resource Public-IP --set-parameter ip --parameter-value 192.0.2.2
@@ -464,17 +468,17 @@ would create an entry in the resource like this:
 For an OCF resource, the result would be an environment variable
 called +OCF_RESKEY_ip+ with a value of +192.0.2.2+.
 
-The list of instance attributes supported by an OCF script can be
-found by calling the resource script with the `meta-data` command.
+The list of instance attributes supported by an OCF resource agent can be
+found by calling the resource agent with the `meta-data` command.
 The output contains an XML description of all the supported
 attributes, their purpose and default values.
 
 .Displaying the metadata for the Dummy resource agent template
 =====
--------
+----
 # export OCF_ROOT=/usr/lib/ocf
 # $OCF_ROOT/resource.d/pacemaker/Dummy meta-data
--------
+----
 [source,XML]
 -------
 <?xml version="1.0"?>
@@ -639,15 +643,14 @@ To set a default value for a operation option, simply add it to the
 
 would default each operation's +timeout+ to 20 seconds.  If an
 operation's definition also includes a value for +timeout+, then that
-value would be used instead (for that operation only).
+value would be used for that operation instead.
 
 === When Resources Take a Long Time to Start/Stop ===
 
-There are a number of implicit operations that the cluster will always
-perform - +start+, +stop+ and a non-recurring +monitor+ operation
-(used at startup to check the resource isn't already active).  If one
-of these is taking too long, then you can create an entry for them and
-simply specify a new value.
+The cluster will always perform a number of implicit operations: +start+,
++stop+ and a non-recurring +monitor+ operation used at startup to check
+whether the resource is already active.  If one of these is taking too long,
+then you can create an entry for them and specify a longer timeout.
 
 .An OCF resource with custom timeouts for its implicit actions
 =====

--- a/doc/Pacemaker_Explained/en-US/Ch-Rules.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Rules.txt
@@ -252,14 +252,14 @@ indexterm:[Duration]
 indexterm:[Resource,Constraint,Duration]
 
 Durations are used to calculate a value for +end+ when one is not
-supplied to in_range operations.  They contain the same fields as
-+date_spec+ objects but without the limitations (ie. you can have a
-duration of 19 months).  Like +date_specs+, any field not supplied is
+supplied to +in-range+ operations. They contain the same fields as
++date_spec+ objects but without the limitations (e.g. you can have a
+duration of 19 months). As with +date_specs+, any field not supplied is
 ignored.
 
 == Sample Time Based Expressions ==
 
-A small sample of how time based expressions can be used.
+A small sample of how time-based expressions can be used:
 
 ////
 On older versions of asciidoc, the [source] directive makes the title disappear
@@ -289,7 +289,7 @@ On older versions of asciidoc, the [source] directive makes the title disappear
 ----
 ====
 
-.9am-5pm, Mon-Friday
+.9am-5pm Monday-Friday
 ====
 [source,XML]
 -------
@@ -517,9 +517,9 @@ Controlling cluster options is achieved in much the same manner as
 specifying different resource options on different nodes.
 
 The difference is that because they are cluster options, one cannot
-(or should not, because they won't work) use attribute based
+(or should not, because they won't work) use attribute-based
 expressions.  The following example illustrates how to set a different
-+resource-stickiness+ value during and outside of work hours.  This
++resource-stickiness+ value during and outside work hours.  This
 allows resources to automatically move back to their most preferred
 hosts, but at a time that (in theory) does not interfere with business
 activities.

--- a/doc/Pacemaker_Explained/en-US/Ch-Rules.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Rules.txt
@@ -121,13 +121,13 @@ called +#uname+ that can also be used.
 
 |=========================================================
 
-== Time/Date Based Expressions ==
+== Time- and Date-Based Expressions ==
 
 indexterm:[Time Based Expressions]
 indexterm:[Resource,Constraint,Date/Time Expression]
         
 As the name suggests, +date_expressions+ are used to control a
-resource or cluster option based on the current date/time.  They can
+resource or cluster option based on the current date/time.  They may
 contain an optional +date_spec+ and/or +duration+ object depending on
 the context.
       
@@ -181,11 +181,11 @@ Instead of defaulting to zero, any field not supplied is ignored.
 
 For example, +monthdays="1"+ matches the first day of every month and
 +hours="09-17"+ matches the hours between 9am and 5pm (inclusive).
-However, at this time one cannot specify +weekdays="1,2"+ or
-+weekdays="1-2,5-6"+ since they contain multiple ranges.  Depending on
-demand, this may be implemented in a future release.
+At this time, multiple ranges (e.g. +weekdays="1,2"+ or
++weekdays="1-2,5-6"+) are not supported; depending on
+demand, this might be implemented in a future release.
         
-.Properties of a Date Spec
+.Properties of a Date Specification
 [width="95%",cols="2m,5<",options="header",align="center"]
 |=========================================================
 
@@ -193,7 +193,7 @@ demand, this may be implemented in a future release.
 |Description
 
 |id
-|A unique name for the date
+|A unique name for the object
  indexterm:[id,Date Specification]
  indexterm:[Constraint,Date Specification,id]
 
@@ -228,18 +228,19 @@ demand, this may be implemented in a future release.
  indexterm:[Constraint,Date Specification,weeks]
 
 |years
-|Year according the Gregorian calendar
+|Year according to the Gregorian calendar
  indexterm:[years,Date Specification]
  indexterm:[Constraint,Date Specification,years]
 
 |weekyears
-|May differ from Gregorian years; Eg. +2005-001 Ordinal+ is also
- +2005-01-01 Gregorian+ is also +2004-W53-6 Weekly+
+|Year in which the week started; e.g. 1 January 2005
+ can be specified as '2005-001 Ordinal', '2005-01-01 Gregorian' or '2004-W53-6
+ Weekly' and thus would match +years="2005"+ or +weekyears="2004"+
  indexterm:[weekyears,Date Specification]
  indexterm:[Constraint,Date Specification,weekyears]
 
 |moon
-|Allowed values: 0-7 (0 is new, 4 is full moon). Seriously, you can
+|Allowed values are 0-7 (0 is new, 4 is full moon). Seriously, you can
  use this. This was implemented to demonstrate the ease with which new
  comparisons could be added.
  indexterm:[moon,Date Specification]
@@ -257,7 +258,7 @@ supplied to +in-range+ operations. They contain the same fields as
 duration of 19 months). As with +date_specs+, any field not supplied is
 ignored.
 
-== Sample Time Based Expressions ==
+=== Sample Time-Based Expressions ===
 
 A small sample of how time-based expressions can be used:
 
@@ -304,7 +305,7 @@ On older versions of asciidoc, the [source] directive makes the title disappear
 Please note that the +16+ matches up to +16:59:59+, as the numeric
 value (hour) still matches!
 
-.9am-6pm, Mon-Friday, or all day saturday
+.9am-6pm Monday through Friday or anytime Saturday
 ====
 [source,XML]
 -------
@@ -319,7 +320,7 @@ value (hour) still matches!
 -------
 ====
 
-.9am-5pm or 9pm-12pm, Mon-Friday
+.9am-5pm or 9pm-12am Monday through Friday
 ====
 [source,XML]
 -------
@@ -355,9 +356,8 @@ value (hour) still matches!
 
 [NOTE]
 ======
-Because no time is specified, 00:00:00 is implied.
-
-This means that the range includes all of 2005-03-01 but none of 2005-04-01.
+Because no time is specified with the above dates, 00:00:00 is implied. This
+means that the range includes all of 2005-03-01 but none of 2005-04-01.
 You may wish to write +end="2005-03-31T23:59:59"+ to avoid confusion.
 ======
 
@@ -377,10 +377,10 @@ You may wish to write +end="2005-03-31T23:59:59"+ to avoid confusion.
 indexterm:[Rule,Determine Resource Location]
 indexterm:[Resource,Location,Determine by Rules]
 
-If the constraint's outer-most rule evaluates to +false+, the cluster
-treats the constraint as if it was not there.  When the rule evaluates
-to +true+, the node's preference for running the resource is updated
-with the score associated with the rule.
+A location constraint may contain rules. When the constraint's outermost
+rule evaluates to +false+, the cluster treats the constraint as if it were not
+there.  When the rule evaluates to +true+, the node's preference for running
+the resource is updated with the score associated with the rule.
 
 If this sounds familiar, it is because you have been using a simplified
 syntax for location constraint rules already.  Consider the following
@@ -412,12 +412,12 @@ This constraint can be more verbosely written as:
 
 The advantage of using the expanded form is that one can then add
 extra clauses to the rule, such as limiting the rule such that it only
-applies during certain times of the day or days of the week (this is
-discussed in subsequent sections).
+applies during certain times of the day or days of the week.
 
+=== Location Rules Based on Other Node Properties ===
 
-It also allows us to match on node properties other than its name.  If
-we rated each machine's CPU power such that the cluster had the
+The expanded form allows us to match on node properties other than its name.
+If we rated each machine's CPU power such that the cluster had the
 following nodes section:
 
 .A sample nodes section for use with score-attribute 
@@ -439,7 +439,7 @@ following nodes section:
 -------
 =====
 
-then we could prevent resources from running on underpowered machines with the rule
+then we could prevent resources from running on underpowered machines with this rule:
 
 [source,XML]
 -------
@@ -460,9 +460,9 @@ would have its preference increased by +5678+.
 
 == Using Rules to Control Resource Options ==
 
-Often some cluster nodes will be different from their peers; sometimes
-these differences (the location of a binary or the names of network
-interfaces) require resources to be configured differently depending
+Often some cluster nodes will be different from their peers. Sometimes,
+these differences -- e.g. the location of a binary or the names of network
+interfaces -- require resources to be configured differently depending
 on the machine they're hosted on.
 
 By defining multiple +instance_attributes+ objects for the resource
@@ -502,12 +502,21 @@ port 9999 for all other nodes.
 
 The order in which +instance_attributes+ objects are evaluated is
 determined by their score (highest to lowest).  If not supplied, score
-defaults to zero and objects with an equal score are processed in
-listed order.  If the +instance_attributes+ object does not have a
-+rule+ or has a +rule+ that evaluates to +true+, then for any
-parameter the resource does not yet have a value for, the resource
-will use the parameter values defined by the +instance_attributes+
-object.
+defaults to zero, and objects with an equal score are processed in
+listed order.  If the +instance_attributes+ object has no rule
+or a +rule+ that evaluates to +true+, then for any parameter the resource does
+not yet have a value for, the resource will use the parameter values defined by
+the +instance_attributes+.
+
+For example, given the configuration above, if the resource is placed on node1:
+
+. +special-node1+ has the highest score (3) and so is evaluated first;
+  its rule evaluates to +true+, so +interface+ is set to +eth1+.
+. +special-node2+ is evaluated next with score 2, but its rule evaluates to +false+,
+  so it is ignored.
+. +defaults+ is evaluated last with score 1, and has no rule, so its values
+  are examined; +interface+ is already defined, so the value here is not used,
+  but +port+ is not yet defined, so +port+ is set to +9999+.
 
 == Using Rules to Control Cluster Options ==
 indexterm:[Rule,Controlling Cluster Options]
@@ -545,22 +554,20 @@ activities.
 =====
 
 [[s-rules-recheck]]
-== Ensuring Time Based Rules Take Effect ==
+== Ensuring Time-Based Rules Take Effect ==
 
-A Pacemaker cluster is an event driven system.  As such, it won't
-recalculate the best place for resources to run in unless something
+A Pacemaker cluster is an event-driven system.  As such, it won't
+recalculate the best place for resources to run unless something
 (like a resource failure or configuration change) happens.  This can
 mean that a location constraint that only allows resource X to run
 between 9am and 5pm is not enforced.
 
-If you rely on time based rules, it is essential that you set the
-+cluster-recheck-interval+ option.  This tells the cluster to
-periodically recalculate the ideal state of the cluster.  For example,
-if you set +cluster-recheck-interval=5m+, then sometime between 9:00
-and 9:05 the cluster would notice that it needs to start resource X,
-and between 17:00 and 17:05 it would realize that X needed to be
-stopped.
+If you rely on time-based rules, the +cluster-recheck-interval+ cluster option
+(which defaults to 15 minutes) is essential.  This tells the cluster to
+periodically recalculate the ideal state of the cluster.
 
-Note that the timing of the actual start and stop actions depends on
-what else needs to be performed first
-.
+For example, if you set +cluster-recheck-interval="5m"+, then sometime between
+09:00 and 09:05 the cluster would notice that it needs to start resource X,
+and between 17:00 and 17:05 it would realize that X needed to be stopped.
+The timing of the actual start and stop actions depends on what other actions
+the cluster may need to perform first.

--- a/doc/Pacemaker_Explained/en-US/Ch-Status.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Status.txt
@@ -27,29 +27,27 @@ up-to-date representation of each cluster node in the +status+ section.
 
 Users are highly recommended _not_ to modify any part of a node's
 state _directly_.  The cluster will periodically regenerate the entire
-section from authoritative sources.  So any changes should be done
-with the tools for those subsystems.
+section from authoritative sources, so any changes should be done
+with the tools appropriate to those sources.
       
 .Authoritative Sources for State Information
 [width="95%",cols="1m,1<",options="header",align="center"]
 |=========================================================
 
-|Dataset  |Authoritative Source
+| CIB Object | Authoritative Source
 
-|node_state fields |crmd
+|node_state|crmd
 
-|transient_attributes tag |attrd
+|transient_attributes|attrd
 
-|lrm tag |lrmd
+|lrm|lrmd
 
 |=========================================================
 
 The fields used in the +node_state+ objects are named as they are
 largely for historical reasons and are rooted in Pacemaker's origins
-as the Heartbeat resource manager.
-
-They have remained unchanged to preserve compatibility with older
-versions.
+as the Heartbeat resource manager. They have remained unchanged to preserve
+compatibility with older versions.
       
 .Node Status Fields
 [width="95%",cols="1m,4<",options="header",align="center"]
@@ -61,9 +59,8 @@ versions.
 | id |
 indexterm:[id,Node Status]
 indexterm:[Node,Status,id]
-Unique identifier for the node. Corosync based clusters use the uname
-of the machine, Heartbeat clusters use a human-readable (but annoying)
-UUID.
+Unique identifier for the node. Corosync-based clusters use a numeric
+counter, while Heartbeat clusters use a (barely) human-readable UUID.
 
 | uname |
 indexterm:[uname,Node Status]
@@ -73,24 +70,23 @@ The node's machine name (output from `uname -n`).
 | ha | 
 indexterm:[ha,Node Status]
 indexterm:[Node,Status,ha]
-Flag specifying whether the cluster software is active on the
-node. Allowed values: +active+, +dead+.
+Is the cluster software active on this node? Allowed values: +active+, +dead+.
 
 | in_ccm |            
 indexterm:[in_ccm,Node Status]
 indexterm:[Node,Status,in_ccm]
-Flag for cluster membership; allowed values: +true+, +false+.
+Is the node a member of the cluster? Allowed values: +true+, +false+.
 
 | crmd |
 indexterm:[crmd,Node Status]
 indexterm:[Node,Status,crmd]
-Flag: is the crmd process active on the node? One of +online+, +offline+.
+Is the crmd process active on the node? Allowed values: +online+, +offline+.
 
 | join |
 indexterm:[join,Node Status]
 indexterm:[Node,Status,join]
-Flag saying whether the node participates in hosting
-resources. Possible values: +down+, +pending+, +member+, +banned+.
+Does the node participate in hosting resources? Allowed values: +down+,
++pending+, +member+, +banned+.
             
 | expected |
 indexterm:[expected,Node Status]
@@ -100,45 +96,44 @@ Expected value for +join+.
 | crm-debug-origin |
 indexterm:[crm-debug-origin,Node Status]
 indexterm:[Node,Status,crm-debug-origin]
-Diagnostic indicator: the origin of the most recent change(s).
+The origin of the most recent change(s). For diagnostic purposes.
 
 |=========================================================
 
-The cluster uses these fields to determine if, at the node level, the
+The cluster uses these fields to determine whether, at the node level, the
 node is healthy or is in a failed state and needs to be fenced.
 
 == Transient Node Attributes ==
 
 Like regular <<s-node-attributes,node attributes>>, the name/value
-pairs listed here also help to describe the node.  However they are
-forgotten by the cluster when the node goes offline.  This can be
-useful, for instance, when you want a node to be in standby mode (not
-able to run resources) until the next reboot.
+pairs listed in the +transient_attributes+ section help to describe the
+node.  However they are forgotten by the cluster when the node goes offline.
+This can be useful, for instance, when you want a node to be in standby mode
+(not able to run resources) just until the next reboot.
       
 In addition to any values the administrator sets, the cluster will
 also store information about failed resources here.
       
-.Example set of transient node attributes for node "cl-virt-1"
+.A set of transient node attributes for node *cl-virt-1*
 ======
 [source,XML]
 -----
-  <transient_attributes id="cl-virt-1">
-    <instance_attributes id="status-cl-virt-1">
-       <nvpair id="status-cl-virt-1-pingd" name="pingd" value="3"/>
-       <nvpair id="status-cl-virt-1-probe_complete" name="probe_complete" value="true"/>
-       <nvpair id="status-cl-virt-1-fail-count-pingd:0" name="fail-count-pingd:0" value="1"/>
-       <nvpair id="status-cl-virt-1-last-failure-pingd:0" name="last-failure-pingd:0" value="1239009742"/>
-    </instance_attributes>
-  </transient_attributes>
+<transient_attributes id="cl-virt-1">
+  <instance_attributes id="status-cl-virt-1">
+     <nvpair id="status-cl-virt-1-pingd" name="pingd" value="3"/>
+     <nvpair id="status-cl-virt-1-probe_complete" name="probe_complete" value="true"/>
+     <nvpair id="status-cl-virt-1-fail-count-pingd:0" name="fail-count-pingd:0" value="1"/>
+     <nvpair id="status-cl-virt-1-last-failure-pingd:0" name="last-failure-pingd:0" value="1239009742"/>
+  </instance_attributes>
+</transient_attributes>
 -----
 ======
 
 In the above example, we can see that the +pingd:0+ resource has
-failed once, at +Mon Apr 6 11:22:22 2009+.
+failed once, at 09:22:22 UTC 6 April 2009.
 footnote:[
-You can use the standard +date+ command to print a human readable of
-any seconds-since-epoch value:
-            # `date -d @<parameter>number</parameter>`
+You can use the standard `date` command to print a human-readable version of
+any seconds-since-epoch value, for example `date -d @1239009742`.
 ]
 We also see that the node is connected to three *pingd* peers and that
 all known resources have been checked for on this machine (+probe_complete+).
@@ -214,27 +209,30 @@ details on what the values here mean and how they are interpreted.
 indexterm:[last-run,Action Status]
 indexterm:[Action,Status,last-run]
 
-Diagnostic indicator. Machine local date/time, in seconds since epoch,
-at which the job was executed.
+Machine-local date/time, in seconds since epoch,
+at which the job was executed. For diagnostic purposes.
 
 | last-rc-change |
 indexterm:[last-rc-change,Action Status]
 indexterm:[Action,Status,last-rc-change]
 
-Diagnostic indicator. Machine local date/time, in seconds since epoch,
+Machine-local date/time, in seconds since epoch,
 at which the job first returned the current value of +rc-code+.
+For diagnostic purposes.
 
 | exec-time |
 indexterm:[exec-time,Action Status]
 indexterm:[Action,Status,exec-time]
 
-Diagnostic indicator. Time, in milliseconds, that the job was running for.
+Time, in milliseconds, that the job was running for.
+For diagnostic purposes.
 
 | queue-time |
 indexterm:[queue-time,Action Status]
 indexterm:[Action,Status,queue-time]
 
-Diagnostic indicator. Time, in seconds, that the job was queued for in the LRMd.
+Time, in seconds, that the job was queued for in the LRMd.
+For diagnostic purposes.
 
 | crm_feature_set |
 indexterm:[crm_feature_set,Action Status]
@@ -274,11 +272,12 @@ necessary.
 indexterm:[crm-debug-origin,Action Status]
 indexterm:[Action,Status,crm-debug-origin]
 
-Diagnostic indicator. The origin of the current values.
+The origin of the current values.
+For diagnostic purposes.
 
 |=========================================================
 
-=== Simple Example ===
+=== Simple Operation History Example ===
         
 .A monitor operation (determines current state of the +apcstonith+ resource)
 ======
@@ -299,24 +298,22 @@ Diagnostic indicator. The origin of the current values.
 In the above example, the job is a non-recurring monitor operation
 often referred to as a "probe" for the +apcstonith+ resource.
 
-The cluster schedules probes for every configured resource on when a
-new node starts, in order to determine the resource's current state
+The cluster schedules probes for every configured resource on a node when
+the node first starts, in order to determine the resource's current state
 before it takes any further action.
         
 From the +transition-key+, we can see that this was the 22nd action of
 the 2nd graph produced by this instance of the crmd
 (2668bbeb-06d5-40f9-936d-24cb7f87006a).
 
-The third field of the +transition-key+ contains a 7, this indicates
-that the job expects to find the resource inactive.
-
-By looking at the +rc-code+ property, we see that this was the case.
-        
+The third field of the +transition-key+ contains a 7, which indicates
+that the job expects to find the resource inactive. By looking at the +rc-code+
+property, we see that this was the case.
 
 As that is the only job recorded for this node, we can conclude that
 the cluster started the resource elsewhere.
 
-=== Complex Resource History Example ===
+=== Complex Operation History Example ===
         
 .Resource history of a +pingd+ clone with multiple jobs
 ======

--- a/doc/Pacemaker_Explained/en-US/Ch-Status.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Status.txt
@@ -1,4 +1,4 @@
-= Status - Here be dragons =
+= Status -- Here be dragons =
 
 Most users never need to understand the contents of the status section
 and can be happy with the output from `crm_mon`.
@@ -12,9 +12,9 @@ indexterm:[Node,Status]
 indexterm:[Status of a Node]
 
 In addition to the cluster's configuration, the CIB holds an
-up-to-date representation of each cluster node in the status section.
+up-to-date representation of each cluster node in the +status+ section.
       
-.A bare-bones status entry for a healthy node called +cl-virt-1+
+.A bare-bones status entry for a healthy node *cl-virt-1*
 ======
 [source,XML]
 -----
@@ -25,13 +25,13 @@ up-to-date representation of each cluster node in the status section.
 -----
 ======      
 
-Users are highly recommended _not to modify_ any part of a node's
+Users are highly recommended _not_ to modify any part of a node's
 state _directly_.  The cluster will periodically regenerate the entire
 section from authoritative sources.  So any changes should be done
 with the tools for those subsystems.
       
 .Authoritative Sources for State Information
-[width="95%",cols="5m,5<",options="header",align="center"]
+[width="95%",cols="1m,1<",options="header",align="center"]
 |=========================================================
 
 |Dataset  |Authoritative Source
@@ -52,7 +52,7 @@ They have remained unchanged to preserve compatibility with older
 versions.
       
 .Node Status Fields
-[width="95%",cols="2m,5<",options="header",align="center"]
+[width="95%",cols="1m,4<",options="header",align="center"]
 |=========================================================
 
 |Field |Description
@@ -140,7 +140,7 @@ You can use the standard +date+ command to print a human readable of
 any seconds-since-epoch value:
             # `date -d @<parameter>number</parameter>`
 ]
-We also see that the node is connected to three "pingd" peers and that
+We also see that the node is connected to three *pingd* peers and that
 all known resources have been checked for on this machine (+probe_complete+).
       
 == Operation History ==
@@ -149,17 +149,17 @@ indexterm:[Operation History]
 A node's resource history is held in the +lrm_resources+ tag (a child
 of the +lrm+ tag). The information stored here includes enough
 information for the cluster to stop the resource safely if it is
-removed from the +configuration+ section. Specifically the resource's
+removed from the +configuration+ section. Specifically, the resource's
 +id+, +class+, +type+ and +provider+ are stored.
 
-.A record of the apcstonith resource
+.A record of the +apcstonith+ resource
 ======
 [source,XML]
 <lrm_resource id="apcstonith" type="apcmastersnmp" class="stonith"/>
 ======
 
 Additionally, we store the last job for every combination of
-+resource, action+ and +interval+.  The concatenation of the values in
++resource+, +action+ and +interval+.  The concatenation of the values in
 this tuple are used to create the id of the +lrm_rsc_op+ object.
 
 .Contents of an +lrm_rsc_op+ job
@@ -280,7 +280,7 @@ Diagnostic indicator. The origin of the current values.
 
 === Simple Example ===
         
-.A monitor operation (determines current state of the apcstonith resource)
+.A monitor operation (determines current state of the +apcstonith+ resource)
 ======
 [source,XML]
 -----
@@ -313,12 +313,12 @@ that the job expects to find the resource inactive.
 By looking at the +rc-code+ property, we see that this was the case.
         
 
-As that is the only job recorded for this node we can conclude that
+As that is the only job recorded for this node, we can conclude that
 the cluster started the resource elsewhere.
 
 === Complex Resource History Example ===
         
-.Resource history of a pingd clone with multiple jobs
+.Resource history of a +pingd+ clone with multiple jobs
 ======
 [source,XML]
 -----
@@ -364,7 +364,7 @@ Once sorted, the above example can be summarized as:
 
 The cluster processes each job record to build up a picture of the
 resource's state.  After the first and second entries, it is
-considered stopped and after the third it considered active.
+considered stopped, and after the third it considered active.
 
 Based on the last operation, we can tell that the resource is
 currently active.

--- a/doc/Pacemaker_Explained/en-US/Ch-Stonith.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Stonith.txt
@@ -41,30 +41,33 @@ SSH-based "devices" used during testing) are inappropriate.
 
 STONITH resources are somewhat special in Pacemaker.
 
-In previous versions, only "running" resources could be used by
-Pacemaker for fencing.  This requirement has been relaxed to allow
-other parts of the cluster (such as resources like DRBD) to reliably
-initiate fencing. footnote:[Fencing a node while Pacemaker was moving
-stonith resources around would otherwise fail]
+STONITH may be initiated by pacemaker or by other parts of the cluster
+(such as resources like DRBD or DLM). To accommodate this, pacemaker
+does not require the STONITH resource to be in the 'started' state
+in order to be used, thus allowing reliable use of STONITH devices in such a
+case.
 
-Now all nodes have access to their definitions and instantiate them
-on-the-fly when needed, however preference is given to 'verified'
-instances which are the ones the cluster has explicitly started.
+[NOTE]
+====
+In pacemaker versions 1.1.9 and earlier, this feature either did not exist or
+did not work well. Only "running" STONITH resources could be used by Pacemaker
+for fencing, and if another component tried to fence a node while Pacemaker was
+moving STONITH resources, the fencing could fail.
+====
+
+All nodes have access to STONITH devices' definitions and instantiate them
+on-the-fly when needed, but preference is given to 'verified' instances, which
+are the ones that are 'started' according to the cluster's knowledge.
 
 In the case of a cluster split, the partition with a verified instance
 will have a slight advantage, because the STONITH daemon in the other partition
 will have to hear from all its current peers before choosing a node to
 perform the fencing.
 
-[NOTE]
-===========
-To disable a fencing device/resource, 'target-role' can be set as you would for a normal resource.
-===========
+Fencing resources do work the same as regular resources in some respects:
 
-[NOTE]
-===========
-To prevent a specific node from using a fencing device, location constraints will work as expected.
-===========
+* +target-role+ can be used to enable or disable the resource
+* Location constraints can be used to prevent a specific node from using the resource
 
 [IMPORTANT]
 ===========
@@ -558,7 +561,8 @@ Some possible uses of topologies include:
 
 |=========================================================
 
-=== Example use of Fencing Topologies ===
+.Fencing topology with different devices for different nodes
+====
 [source,XML]
 ----
  <cib crm_feature_set="3.0.6" validate-with="pacemaker-1.2" admin_epoch="1" epoch="0" num_updates="0">
@@ -578,6 +582,7 @@ Some possible uses of topologies include:
   <status/>
 </cib>
 ----
+====
 
 === Example Dual-Layer, Dual-Device Fencing Topologies ===
 

--- a/doc/Pacemaker_Explained/en-US/Ch-Stonith.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Stonith.txt
@@ -18,13 +18,12 @@ accessing your data. The only way to be 100% sure that your data is
 safe, is to use STONITH so we can be certain that the node is truly
 offline, before allowing the data to be accessed from another node.
 
-
 STONITH also has a role to play in the event that a clustered service
 cannot be stopped. In this case, the cluster uses STONITH to force the
 whole node offline, thereby making it safe to start the service
 elsewhere.
 
-== What STONITH Device Should You Use ==
+== What STONITH Device Should You Use? ==
 
 It is crucial that the STONITH device can allow the cluster to
 differentiate between a node failure and a network one.
@@ -69,11 +68,9 @@ To prevent a specific node from using a fencing device, location constraints wil
 
 [IMPORTANT]
 ===========
-
 Currently there is a limitation that fencing resources may only have
-one set of meta-attributes and one set of instance-attributes.  This
+one set of meta-attributes and one set of instance attributes.  This
 can be revisited if it becomes a significant limitation for people.
-
 ===========
 
 .Properties of Fencing Resources
@@ -306,33 +303,54 @@ Scratch+ for those details.
 
 ===========
 
-. Find the correct driver: +stonith_admin --list-installed+
+. Find the correct driver:
++
+----
+# stonith_admin --list-installed
+----
 
-. Find the required parameters associated with the device: +stonith_admin --metadata --agent <agent name>+
+. Find the required parameters associated with the device
+  (replacing $AGENT_NAME with the name obtained from the previous step):
++
+----
+# stonith_admin --metadata --agent $AGENT_NAME
+----
 
 . Create a file called +stonith.xml+ containing a primitive resource
-  with a class of 'stonith', a type of <agent name> and a parameter
-  for each of the values returned in step 2.
+  with a class of +stonith+, a type equal to the agent name obtained earlier,
+  and a parameter for each of the values returned in the previous step.
 
 . If the device does not know how to fence nodes based on their uname,
   you may also need to set the special +pcmk_host_map+ parameter.  See
-  +man stonithd+ for details.
+  `man stonithd` for details.
 
-. If the device does not support the list command, you may also need
+. If the device does not support the `list` command, you may also need
   to set the special +pcmk_host_list+ and/or +pcmk_host_check+
-  parameters.  See +man stonithd+ for details.
+  parameters.  See `man stonithd` for details.
 
 . If the device does not expect the victim to be specified with the
-  port parameter, you may also need to set the special
-  +pcmk_host_argument+ parameter. See +man stonithd+ for details.
+  `port` parameter, you may also need to set the special
+  +pcmk_host_argument+ parameter. See `man stonithd` for details.
 
-. Upload it into the CIB using cibadmin: +cibadmin -C -o resources --xml-file stonith.xml+
+. Upload it into the CIB using cibadmin:
++
+----
+# cibadmin -C -o resources --xml-file stonith.xml
+----
 
-. Set stonith-enabled to true. +crm_attribute -t crm_config -n stonith-enabled -v true+
+. Set stonith-enabled to true:
++
+----
+# crm_attribute -t crm_config -n stonith-enabled -v true
+----
 
-. Once the stonith resource is running, you can test it by executing:
-  +stonith_admin --reboot nodename+. Although you might want to stop the
-  cluster on that machine first.
+. Once the stonith resource is running, you can test it by executing the
+  following (although you might want to stop the cluster on that machine
+  first):
++
+----
+# stonith_admin --reboot nodename
+----
 
 === Example ===
 
@@ -490,14 +508,14 @@ And finally, since we disabled it earlier, we need to re-enable STONITH.
 
 Some people consider that having one fencing device is a single point
 of failure footnote:[Not true, since a node or resource must fail
-before fencing even has a chance to], others prefer removing the node
+before fencing even has a chance to]; others prefer removing the node
 from the storage and network instead of turning it off.
 
 Whatever the reason, Pacemaker supports fencing nodes with multiple
-devices through a feature called fencing topologies.
+devices through a feature called 'fencing topologies'.
 
-Simply create the individual devices as you normally would and then
-define one or more fencing levels in the fencing-topology section in
+Simply create the individual devices as you normally would, then
+define one or more +fencing-level+ entries in the +fencing-topology+ section of
 the configuration.
 
 * Each level is attempted in +ascending index+ order
@@ -509,9 +527,9 @@ the configuration.
 
 Some possible uses of topologies include:
 
-* try poison-pill and fail back to power
-* try disk and network, and fall back to power if either fails
-* initiate a kdump and then poweroff the node
+* Try poison-pill and fail back to power
+* Try disk and network, and fall back to power if either fails
+* Initiate a kdump and then poweroff the node
 
 .Properties of Fencing Levels
 [width="95%",cols="1m,6<",options="header",align="center"]

--- a/doc/Pacemaker_Explained/en-US/Ch-Stonith.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Stonith.txt
@@ -1,4 +1,4 @@
-= Configure STONITH =
+= STONITH =
 
 ////
 We prefer [[ch-stonith]], but older versions of asciidoc don't deal well
@@ -7,10 +7,10 @@ with that construct for chapter headings
 anchor:ch-stonith[Chapter 13, STONITH]
 indexterm:[STONITH, Configuration]
 
-== What Is STONITH ==
+== What Is STONITH? ==
 
-STONITH is an acronym for Shoot-The-Other-Node-In-The-Head and it
-protects your data from being corrupted by rogue nodes or concurrent
+STONITH (an acronym for "Shoot The Other Node In The Head"), also called
+'fencing', protects your data from being corrupted by rogue nodes or concurrent
 access.
 
 Just because a node is unresponsive, this doesn't mean it isn't
@@ -37,9 +37,9 @@ from a network fault.
 Likewise, any device that relies on the machine being active (such as
 SSH-based "devices" used during testing) are inappropriate.
 
-== Differences of STONITH Resources ==
+== Special Treatment of STONITH Resources ==
 
-Stonith resources are somewhat special in Pacemaker.
+STONITH resources are somewhat special in Pacemaker.
 
 In previous versions, only "running" resources could be used by
 Pacemaker for fencing.  This requirement has been relaxed to allow
@@ -52,8 +52,8 @@ on-the-fly when needed, however preference is given to 'verified'
 instances which are the ones the cluster has explicitly started.
 
 In the case of a cluster split, the partition with a verified instance
-will have a slight advantage as stonith-ng in the other partition will
-have to hear from all its current peers before choosing a node to
+will have a slight advantage, because the STONITH daemon in the other partition
+will have to hear from all its current peers before choosing a node to
 perform the fencing.
 
 [NOTE]
@@ -294,13 +294,11 @@ to alter the number of times Pacemaker retries before giving up.
 
 [NOTE]
 ===========
-
-Both configuration shells include functionality to simplify the
+Higher-level configuration shells include functionality to simplify the
 process below, particularly the step for deciding which parameters are
 required.  However since this document deals only with core
-components, you should refer to the Stonith chapter of +Clusters from
-Scratch+ for those details.
-
+components, you should refer to the STONITH chapter of the
+http://www.clusterlabs.org/doc/[Clusters from Scratch] guide for those details.
 ===========
 
 . Find the correct driver:
@@ -352,7 +350,7 @@ Scratch+ for those details.
 # stonith_admin --reboot nodename
 ----
 
-=== Example ===
+=== Example STONITH Configuration ===
 
 Assume we have an chassis containing four nodes and an IPMI device
 active on 192.0.2.1. We would choose the `fence_ipmilan` driver,
@@ -477,10 +475,10 @@ and obtain the following list of parameters:
 ----
 ====
 
-from which we would create a STONITH resource fragment that might look
+Based on that, we would create a STONITH resource fragment that might look
 like this:
 
-.Sample STONITH Resource
+.An IPMI-based STONITH Resource
 ====
 [source,XML]
 ----
@@ -498,13 +496,12 @@ like this:
 ----
 ====
 
-And finally, since we disabled it earlier, we need to re-enable STONITH.
-
+Finally, we need to enable STONITH:
 ----
 # crm_attribute -t crm_config -n stonith-enabled -v true
 ----
 
-== Advanced Fencing Configurations ==
+== Advanced STONITH Configurations ==
 
 Some people consider that having one fencing device is a single point
 of failure footnote:[Not true, since a node or resource must fail
@@ -518,12 +515,12 @@ Simply create the individual devices as you normally would, then
 define one or more +fencing-level+ entries in the +fencing-topology+ section of
 the configuration.
 
-* Each level is attempted in +ascending index+ order
-* If a device fails, +processing terminates+ for the current level.
-  No further devices in that level are exercised and the next level is attempted instead.
-* If the operation succeeds for all the listed devices in a level, the level is deemed to have passed
-* The operation is finished +when a level has passed+ (success), or all levels have been attempted (failed)
-* If the operation failed, the next step is determined by the Policy Engine and/or crmd.
+* Each fencing level is attempted in order of ascending +index+.
+* If a device fails, processing terminates for the current level.
+  No further devices in that level are exercised, and the next level is attempted instead.
+* If the operation succeeds for all the listed devices in a level, the level is deemed to have passed.
+* The operation is finished when a level has passed (success), or all levels have been attempted (failed).
+* If the operation failed, the next step is determined by the Policy Engine and/or `crmd`.
 
 Some possible uses of topologies include:
 
@@ -539,7 +536,7 @@ Some possible uses of topologies include:
 |Description
 
 |id
-|Your name for the level
+|A unique name for the level
  indexterm:[id,fencing-level]
  indexterm:[Fencing,fencing-level,id]
 
@@ -550,7 +547,7 @@ Some possible uses of topologies include:
 
 |index
 |The order in which to attempt the levels.
- Levels are attempted in +ascending index+ order +until one succeeds+.
+ Levels are attempted in ascending order 'until one succeeds'.
  indexterm:[index,fencing-level]
  indexterm:[Fencing,fencing-level,index]
 
@@ -582,7 +579,7 @@ Some possible uses of topologies include:
 </cib>
 ----
 
-=== Example use of advanced Fencing Topologies: dual layer and dual devices ===
+=== Example Dual-Layer, Dual-Device Fencing Topologies ===
 
 The following example illustrates an advanced use of +fencing-topology+ in a cluster with the following properties:
 
@@ -596,7 +593,7 @@ The following example illustrates an advanced use of +fencing-topology+ in a clu
 * fencing is only implemented for the active nodes and has location constraints
 * fencing topology is set to try IPMI fencing first then default to a "sure-kill" dual PDU fencing
 
-In a normal failure scenario, STONITH will first select +fence_ipmi+ to try and kill the faulty node.
+In a normal failure scenario, STONITH will first select +fence_ipmi+ to try to kill the faulty node.
 Using a fencing topology, if that first method fails, STONITH will then move on to selecting +fence_apc_snmp+ twice:
 
 * once for the first PDU 
@@ -635,7 +632,8 @@ Each cluster node has it own dedicated IPMI channel that can be called for fenci
 
 .Second fencing method: dual PDU devices
 
-Each cluster node also has two distinct power channels controlled by two distinct PDUs. That means a total of 4 fencing devices configured as follows:
+Each cluster node also has two distinct power channels controlled by two
+distinct PDUs. That means a total of 4 fencing devices configured as follows:
 
 - Node 1, PDU 1, PSU 1 @ port 10
 - Node 1, PDU 2, PSU 2 @ port 10
@@ -689,17 +687,18 @@ The matching fencing agents are configured as follows:
 
 .Location Constraints 
 
-To prevent STONITH from running a fencing agent on the very same node it is supposed to fence, constraints are placed on all the fencing primitives:
+To prevent STONITH from trying to run a fencing agent on the same node it is
+supposed to fence, constraints are placed on all the fencing primitives:
 [source,XML]
 ----
-    <constraints>
-      <rsc_location id="l_fence_prod-mysql1_ipmi" node="prod-mysql1" rsc="fence_prod-mysql1_ipmi" score="-INFINITY"/>
-      <rsc_location id="l_fence_prod-mysql2_ipmi" node="prod-mysql2" rsc="fence_prod-mysql2_ipmi" score="-INFINITY"/>
-      <rsc_location id="l_fence_prod-mysql1_apc2" node="prod-mysql1" rsc="fence_prod-mysql1_apc2" score="-INFINITY"/>
-      <rsc_location id="l_fence_prod-mysql1_apc1" node="prod-mysql1" rsc="fence_prod-mysql1_apc1" score="-INFINITY"/>
-      <rsc_location id="l_fence_prod-mysql2_apc1" node="prod-mysql2" rsc="fence_prod-mysql2_apc1" score="-INFINITY"/>
-      <rsc_location id="l_fence_prod-mysql2_apc2" node="prod-mysql2" rsc="fence_prod-mysql2_apc2" score="-INFINITY"/>
-    </constraints>
+<constraints>
+  <rsc_location id="l_fence_prod-mysql1_ipmi" node="prod-mysql1" rsc="fence_prod-mysql1_ipmi" score="-INFINITY"/>
+  <rsc_location id="l_fence_prod-mysql2_ipmi" node="prod-mysql2" rsc="fence_prod-mysql2_ipmi" score="-INFINITY"/>
+  <rsc_location id="l_fence_prod-mysql1_apc2" node="prod-mysql1" rsc="fence_prod-mysql1_apc2" score="-INFINITY"/>
+  <rsc_location id="l_fence_prod-mysql1_apc1" node="prod-mysql1" rsc="fence_prod-mysql1_apc1" score="-INFINITY"/>
+  <rsc_location id="l_fence_prod-mysql2_apc1" node="prod-mysql2" rsc="fence_prod-mysql2_apc1" score="-INFINITY"/>
+  <rsc_location id="l_fence_prod-mysql2_apc2" node="prod-mysql2" rsc="fence_prod-mysql2_apc2" score="-INFINITY"/>
+</constraints>
 ----
 
 .Fencing topology
@@ -708,14 +707,14 @@ Now that all the fencing resources are defined, it's time to create the right to
 We want to first fence using IPMI and if that does not work, fence both PDUs to effectively and surely kill the node.
 [source,XML]
 ----
-    <fencing-topology>
-      <fencing-level devices="fence_prod-mysql1_ipmi" id="fencing-2" index="1" target="prod-mysql1"/>
-      <fencing-level devices="fence_prod-mysql1_apc1,fence_prod-mysql1_apc2" id="fencing-3" index="2" target="prod-mysql1"/>
-      <fencing-level devices="fence_prod-mysql2_ipmi" id="fencing-0" index="1" target="prod-mysql2"/>
-      <fencing-level devices="fence_prod-mysql2_apc1,fence_prod-mysql2_apc2" id="fencing-1" index="2" target="prod-mysql2"/>
-    </fencing-topology>
+<fencing-topology>
+  <fencing-level devices="fence_prod-mysql1_ipmi" id="fencing-2" index="1" target="prod-mysql1"/>
+  <fencing-level devices="fence_prod-mysql1_apc1,fence_prod-mysql1_apc2" id="fencing-3" index="2" target="prod-mysql1"/>
+  <fencing-level devices="fence_prod-mysql2_ipmi" id="fencing-0" index="1" target="prod-mysql2"/>
+  <fencing-level devices="fence_prod-mysql2_apc1,fence_prod-mysql2_apc2" id="fencing-1" index="2" target="prod-mysql2"/>
+</fencing-topology>
 ----
-Please note, in +fencing-topology+, the lowest +index+ value determines the priority of the first fencing method.
+Please note, in +fencing-topology+, the lowest +index+ value determines the priority of the first fencing method. 
 
 .Final configuration
 

--- a/doc/Pacemaker_Explained/en-US/Ch-Utilization.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Utilization.txt
@@ -194,7 +194,7 @@ service. This means it arrives at a solution much faster than traditional
 linear programming algorithms, but by doing so at the price of leaving some
 services stopped.
 
-In the contrived example above:
+In the contrived example at the start of this chapter:
 
 - +rsc-small+ would be allocated to +node1+
 - +rsc-medium+ would be allocated to +node2+

--- a/doc/Pacemaker_Explained/en-US/Ch-Utilization.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Utilization.txt
@@ -196,17 +196,16 @@ services stopped.
 
 In the contrived example above:
 
-- `rsc-small` would be allocated to `node1`
-- `rsc-medium` would be allocated to `node2`
-- `rsc-large` would remain inactive
+- +rsc-small+ would be allocated to +node1+
+- +rsc-medium+ would be allocated to +node2+
+- +rsc-large+ would remain inactive
 
 Which is not ideal.
 
 
 == Strategies for Dealing with the Limitations ==
 
-- Ensure you have sufficient physical capacity.
-It might sounds obvious, but if the physical capacity of your nodes is (close to)
+It might sound obvious, but if the physical capacity of your nodes is (close to)
 maxed out by the cluster under normal conditions, then failover isn't going to
 go well. Even without the Utilization feature, you'll start hitting timeouts and
 getting secondary failures'.

--- a/doc/Pacemaker_Explained/en-US/Ch-Utilization.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Utilization.txt
@@ -1,39 +1,38 @@
 = Utilization and Placement Strategy =
 
-== Background ==
-
 Pacemaker decides where to place a resource according to the resource
 allocation scores on every node. The resource will be allocated to the
-node where the resource has the highest score. If the resource allocation
-scores on all the nodes are equal, by the `default` placement strategy,
-Pacemaker will choose a node with the least number of allocated resources
-for balancing the load. If the number of resources on each node is equal,
-the first eligible node listed in cib will be chosen to run the resource.
+node where the resource has the highest score.
 
-Though resources are different. They may consume different amounts of the
-capacities of the nodes. Actually, we cannot ideally balance the load just
-according to the number of resources allocated to a node. Besides, if
-resources are placed such that their combined requirements exceed the
-provided capacity, they may fail to start completely or run with degraded
-performance.
+If the resource allocation scores on all the nodes are equal, by the default
+placement strategy, Pacemaker will choose a node with the least number of
+allocated resources for balancing the load. If the number of resources on each
+node is equal, the first eligible node listed in the CIB will be chosen to run
+the resource.
 
-To take these into account, Pacemaker allows you to specify the following
-configurations:
+Often, in real-world situations, different resources use significantly
+different proportions of a node's capacities (memory, I/O, etc.).
+We cannot balance the load ideally just according to the number of resources
+allocated to a node. Besides, if resources are placed such that their combined
+requirements exceed the provided capacity, they may fail to start completely or
+run with degraded performance.
 
-. The `capacity` a certain `node provides`.
-. The `capacity` a certain `resource requires`.
-. An overall `strategy` for placement of resources.
+To take these factors into account, Pacemaker allows you to configure:
 
+. The capacity a certain node provides.
+. The capacity a certain resource requires.
+. An overall strategy for placement of resources.
 
 == Utilization attributes ==
 
-To configure the capacity a node provides and the resource's requirements,
-use `utilization` attributes. You can name the `utilization` attributes
-according to your preferences and define as many `name/value` pairs as your
-configuration needs. However, the attribute's values must be `integers`.
+To configure the capacity that a node provides or a resource requires,
+you can use 'utilization attributes' in +node+ and +resource+ objects.
+You can name utilization attributes according to your preferences and define as
+many name/value pairs as your configuration needs. However, the attributes'
+values must be integers.
 
-First, specify the capacities the nodes provide:
-
+.Specifying CPU and RAM capacities of two nodes
+====
 [source,XML]
 ----
 <node id="node1" type="normal" uname="node1">
@@ -49,9 +48,10 @@ First, specify the capacities the nodes provide:
   </utilization>
 </node>
 ----
+====
 
-Then, specify the capacities the resources require:
-
+.Specifying CPU and RAM consumed by several resources
+====
 [source,XML]
 ----
 <primitive id="rsc-small" class="ocf" provider="pacemaker" type="Dummy">
@@ -73,116 +73,118 @@ Then, specify the capacities the resources require:
   </utilization>
 </primitive>
 ----
+====
 
 A node is considered eligible for a resource if it has sufficient free
 capacity to satisfy the resource's requirements. The nature of the required
-or provided capacities is completely irrelevant for Pacemaker, it just makes
+or provided capacities is completely irrelevant to Pacemaker -- it just makes
 sure that all capacity requirements of a resource are satisfied before placing
 a resource to a node.
-
 
 == Placement Strategy ==
 
 After you have configured the capacities your nodes provide and the
-capacities your resources require, you need to set the `placement-strategy`
+capacities your resources require, you need to set the +placement-strategy+
 in the global cluster options, otherwise the capacity configurations have
-`no effect`.
+'no effect'.
 
-Four values are available for the `placement-strategy`: 
+Four values are available for the +placement-strategy+: 
 
-`default`::
++default+::
 
-Utilization values are not taken into account at all, per default.
+Utilization values are not taken into account at all.
 Resources are allocated according to allocation scores. If scores are equal,
 resources are evenly distributed across nodes.
 
-`utilization`::
++utilization+::
 
-Utilization values are taken into account when deciding whether a node
-is considered eligible if it has sufficient free capacity to satisfy the
-resource's requirements. However, load-balancing is still done based on the
+Utilization values are taken into account 'only' when deciding whether a node
+is considered eligible (i.e. whether it has sufficient free capacity to satisfy
+the resource's requirements). Load-balancing is still done based on the
 number of resources allocated to a node. 
 
-`balanced`::
++balanced+::
 
 Utilization values are taken into account when deciding whether a node
-is eligible to serve a resource; an attempt is made to spread the resources
-evenly, optimizing resource performance.
+is eligible to serve a resource 'and' when load-balancing, so an attempt is
+made to spread the resources in a way that optimizes resource performance.
 
-`minimal`::
++minimal+::
 
-Utilization values are taken into account when deciding whether a node
-is eligible to serve a resource; an attempt is made to concentrate the
-resources on as few nodes as possible, thereby enabling possible power savings
-on the remaining nodes. 
+Utilization values are taken into account 'only' when deciding whether a node
+is eligible to serve a resource. For load-balancing, an attempt is made to
+concentrate the resources on as few nodes as possible, thereby enabling
+possible power savings on the remaining nodes. 
 
 
-Set `placement-strategy` with `crm_attribute`:
+Set +placement-strategy+ with `crm_attribute`:
 ----
-# crm_attribute --attr-name placement-strategy --attr-value balanced
+# crm_attribute --name placement-strategy --update balanced
 ----
 
 Now Pacemaker will ensure the load from your resources will be distributed
-evenly throughout the cluster - without the need for convoluted sets of
+evenly throughout the cluster, without the need for convoluted sets of
 colocation constraints.
-
 
 == Allocation Details ==
 
-=== Which node is preferred to be chosen to get consumed first on allocating resources? ===
+=== Which node is preferred to get consumed first when allocating resources? ===
 
-- The node that is most healthy (which has the highest node weight) gets
-consumed first.
+- The node with the highest weight (cumulative score after taking into account
+  location preferences, constraints, etc.) gets consumed first.
 
-- If their weights are equal:
-  * If `placement-strategy="default|utilization"`,
+- If multiple nodes have the same weight:
+  * If +placement-strategy+ is +default+ or +utilization+,
     the node that has the least number of allocated resources gets consumed first.
     ** If their numbers of allocated resources are equal,
-       the first eligible node listed in cib gets consumed first.
+       the first eligible node listed in the CIB gets consumed first.
 
-  * If `placement-strategy="balanced"`,
-    the node that has more free capacity gets consumed first.
+  * If +placement-strategy+ is +balanced+,
+    the node that has the most free capacity gets consumed first.
     ** If the free capacities of the nodes are equal,
        the node that has the least number of allocated resources gets consumed first.
       *** If their numbers of allocated resources are equal,
-          the first eligible node listed in cib gets consumed first.
+          the first eligible node listed in the CIB gets consumed first.
 
-  * If `placement-strategy="minimal"`,
-    the first eligible node listed in cib gets consumed first.
+  * If +placement-strategy+ is +minimal+,
+    the first eligible node listed in the CIB gets consumed first.
 
+=== Which node has more free capacity? ===
 
-==== Which node has more free capacity? ====
+If only one type of utilization attribute has been defined, free capacity
+is a simple numeric comparison.
 
-This will be quite clear if we only define one type of `capacity`. While if we
-define multiple types of `capacity`, for example:
+If multiple types of utilization attributes have been defined, then
+the node that is numerically highest in the the most attribute types
+has the most free capacity. For example:
 
-- If `nodeA` has more free `cpus`, `nodeB` has more free `memory`,
-  their free capacities are equal.
+- If +nodeA+ has more free +cpus+, and +nodeB+ has more free +memory+,
+  then their free capacities are equal.
 
-- If `nodeA` has more free `cpus`, while `nodeB` has more free `memory` and `storage`,
-  `nodeB` has more free capacity.
+- If +nodeA+ has more free +cpus+, while +nodeB+ has more free +memory+ and +storage+,
+  then +nodeB+ has more free capacity.
 
+=== Which resource is preferred to be assigned first? ===
 
-=== Which resource is preferred to be chosen to get assigned first? ===
+- The resource that has the highest +priority+ (see <<s-resource-options>>) gets allocated first.
 
-- The resource that has the highest priority gets allocated first.
+- If their priorities are equal, check whether they are already running. The
+  resource that has the highest score on the node where it's running gets allocated
+  first, to prevent resource shuffling.
 
-- If their priorities are equal, check if they are already running. The
-resource that has the highest score on the node where it's running gets allocated
-first (to prevent resource shuffling).
-
-- If the scores above are equal or they are not running, the resource has
+- If the scores above are equal or the resources are not running, the resource has
   the highest score on the preferred node gets allocated first.
 
-- If the scores above are equal, the first runnable resource listed in cib gets allocated first.
+- If the scores above are equal, the first runnable resource listed in the CIB
+  gets allocated first.
 
 
-== Limitations ==
+== Limitations and Workarounds ==
 
-This type of problem Pacemaker is dealing with here is known as the
+The type of problem Pacemaker is dealing with here is known as the
 http://en.wikipedia.org/wiki/Knapsack_problem[knapsack problem] and falls into
 the http://en.wikipedia.org/wiki/NP-complete[NP-complete] category of computer
-science problems - which is fancy way of saying "it takes a really long time
+science problems -- a fancy way of saying "it takes a really long time
 to solve".
 
 Clearly in a HA cluster, it's not acceptable to spend minutes, let alone hours
@@ -202,20 +204,24 @@ In the contrived example at the start of this chapter:
 
 Which is not ideal.
 
+There are various approaches to dealing with the limitations of
+pacemaker's placement strategy:
 
-== Strategies for Dealing with the Limitations ==
+Ensure you have sufficient physical capacity.::
 
 It might sound obvious, but if the physical capacity of your nodes is (close to)
 maxed out by the cluster under normal conditions, then failover isn't going to
-go well. Even without the Utilization feature, you'll start hitting timeouts and
-getting secondary failures'.
+go well. Even without the utilization feature, you'll start hitting timeouts and
+getting secondary failures.
 
-- Build some buffer into the capabilities advertised by the nodes.
-Advertise slightly more resources than we physically have on the (usually valid)
-assumption that a resource will not use 100% of the configured number of
-cpu/memory/etc `all` the time. This practice is also known as 'over commit'.
+Build some buffer into the capabilities advertised by the nodes.::
 
-- Specify resource priorities.
+Advertise slightly more resources than we physically have, on the (usually valid)
+assumption that a resource will not use 100% of the configured amount of
+CPU, memory and so forth 'all' the time. This practice is sometimes called 'overcommit'.
+
+Specify resource priorities.::
+
 If the cluster is going to sacrifice services, it should be the ones you care
-(comparatively) about the least. Ensure that resource priorities are properly set
+about (comparatively) the least. Ensure that resource priorities are properly set
 so that your most important resources are scheduled first. 

--- a/doc/Pacemaker_Explained/en-US/NOTES
+++ b/doc/Pacemaker_Explained/en-US/NOTES
@@ -1,69 +1,18 @@
+2.3.1 editing CIB copy via VI: isn't that racy? Are concurrent changes detected?
 
-That's a "+", not a hyphen:
+why sometimes <example> and sometimes <figure>? examples have title at top, figures have title at bottom
 
-Key combinations can be distinguished from keycaps by the hyphen connecting each part of a key
-combination. For example:
-Press Enter to execute the command.
-Press Ctrl+Alt+F2 to switch to the first virtual terminal. Press Ctrl+Alt+F1 to
-return to your X-Windows session.
-
-
-
-
-doesn't apply here:
-
-If source code is discussed, class names, methods, functions, v
- including application names; dialog box text; labeled buttons; check-box and radio button labels; menu titles and sub-menu titles. 
-
-
-1.2 terminal output has page-break
-
-
-2.3 editing via VI
-isn't that racy? Are concurrent changes detected?
-
-
-why sometimes <example> and sometimes <figure>? example 2.2 has title at top, different to the figures
-
-
-2.8 header slightly too long, line broken
-
+Example 2.8 (and others) XML line too long, line broken
 
 some <command> are in <para>, some in <programlisting> ... I'd like the latter more, or perhaps in a <screen>.
 Indentation makes whitespace at start of lines ... remove?
 
-Chapter 3
-=========
-- table 3.3 "Properties maintained by the Cluster" incomplete (crm-feature-set, ...)
-
-
-4.4.2 structure different from 4.4.1 ... numbered lists
-
-
-5.3 Notes have next content overlaid
-
-
-ex 5.6: <resource-agent ... version=0.9><version>1.0</version> ????
-
-
-perhaps use 10.20.30.40 instead of the 1.2.3.4 example IP address?
-
-
-6.5 images/resource-set.png missing, "images/two-sets.png"  too; images/three-sets; "images/three-sets-complex.png" 
-
+tables 3.1 and 3.2 incomplete (crm-feature-set, ...)
 
 Ch 7 missing?
 
-
 Remove Ex9.9?
 
-
-collocate or colocate? Eg. in C.1:
-Multi-dimensional colocation and ordering constraints. See Section 6.5, “Ordering Sets of
-Resources” and Section 6.6, “Collocating Sets of Resources”
-
-
 Ap-Debug.xml not used?
-
 
 <indexterm> alias for primary?

--- a/doc/Pacemaker_Explained/en-US/Pacemaker_Explained.ent
+++ b/doc/Pacemaker_Explained/en-US/Pacemaker_Explained.ent
@@ -1,4 +1,4 @@
 <!ENTITY PRODUCT "Pacemaker">
 <!ENTITY BOOKID "Pacemaker_Explained">
-<!ENTITY YEAR "2011">
+<!ENTITY YEAR "2015">
 <!ENTITY HOLDER "Andrew Beekhof">

--- a/doc/Pacemaker_Explained/en-US/Revision_History.xml
+++ b/doc/Pacemaker_Explained/en-US/Revision_History.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
 ]>
 <appendix>
+  <!-- see comment in Book_Info.xml for revision numbering -->
   <title>Revision History</title>
   <simpara>
     <revhistory>
@@ -38,6 +39,18 @@
 	      Converted to <ulink url="http://www.methods.co.nz/asciidoc">asciidoc</ulink>
 	      (which is converted to docbook for use with 
 	      <ulink url="https://fedorahosted.org/publican/">Publican</ulink>)
+	    </member>
+          </simplelist>
+        </revdescription>
+      </revision>
+      <revision>
+        <revnumber>5-0</revnumber>
+        <date>Mon Feb 23 2015</date>
+        <author><firstname>Ken</firstname><surname>Gaillot</surname><email>kgaillot@redhat.com</email></author>
+        <revdescription>
+          <simplelist>
+            <member>
+	      Update for clarity, stylistic consistency and current command-line syntax
 	    </member>
           </simplelist>
         </revdescription>


### PR DESCRIPTION
Apologies for the egregious size of this update; I had my copy editor hat on when I went though Pacemaker Explained and went to town. No more like this, promise. :-)
* The "stylistic consistency", "minor clarifications" and "minor reorganization" revisions isolate the least significant bits so they can be quickly skimmed. They do not affect the content significantly, just the presentation.
* The Makefile revision adds an RSYNC_DEST variable for where docs are uploaded to, so it is easy to override on the command line.
* Using the above, I generated a full set of branded docs available for comparison at http://people.redhat.com/kgaillot/doc/en-US/ -- for example http://people.redhat.com/kgaillot/doc/en-US/Pacemaker/1.1-pcs/html/Pacemaker_Explained/

I made these changes as I read the document; whenever I was confused and had to re-read a section, I edited it to be more clear. Combined with the habitual grammar/punctuation reflexes I have from my newspaper days, it adds up to a lot of small changes. But hopefully it is worth it in readability and being brought up to current usage.