### PR TITLE
Cross compilation fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -453,7 +453,6 @@ case "$host_os" in
 		;;
 *linux*)
 		AC_DEFINE_UNQUOTED(ON_LINUX, 1, Compiling for Linux platform)
-  		CFLAGS="$CFLAGS -I${prefix}/include"
  		;;
 darwin*)
 		AC_DEFINE_UNQUOTED(ON_DARWIN, 1, Compiling for Darwin platform)

--- a/configure.ac
+++ b/configure.ac
@@ -462,7 +462,9 @@ darwin*)
 esac
 
 dnl Eventually remove this
-CFLAGS="$CFLAGS -I${prefix}/include/heartbeat"
+if test "$cross_compiling" != "yes"; then
+   CFLAGS="$CFLAGS -I${prefix}/include/heartbeat"
+fi
 
 AC_SUBST(INIT_EXT)
 AC_MSG_NOTICE(Host CPU: $host_cpu)


### PR DESCRIPTION
These two patches fix errors that happen only when Pacemaker is cross-compiled.
I experienced these errors when trying to cross-compile Pacemaker with Buildroot. In particular, passing -I/usr/include to a cross-compiler leads to mix host headers with target headers and causes compilation errors.