### PR TITLE
Refactor: pengine: Reschedule specific monitors when resource definitions have changed

### DIFF
--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -183,7 +183,6 @@ struct node_s {
 
 #  define pe_rsc_try_reload     0x00001000ULL
 #  define pe_rsc_reload         0x00002000ULL
-#  define pe_rsc_reschedule_monitor 0x00004000ULL
 
 #  define pe_rsc_failed		0x00010000ULL
 #  define pe_rsc_shutdown	0x00020000ULL
@@ -231,6 +230,7 @@ enum pe_action_flags {
     pe_action_requires_any = 0x01000, /* This action requires one or mre of its dependancies to be runnable
                                        * We use this to clear the runnable flag before checking dependancies
                                        */
+    pe_action_reschedule = 0x02000,
 };
 /* *INDENT-ON* */
 

--- a/pengine/allocate.c
+++ b/pengine/allocate.c
@@ -274,16 +274,16 @@ check_action_definition(resource_t * rsc, node_t * active_node, xmlNode * xml_op
                  crm_element_value(xml_op, XML_ATTR_TRANSITION_MAGIC));
 
         if (interval > 0) {
-#if 0
             action_t *op = NULL;
 
+#if 0
             /* Always reload/restart the entire resource */
             op = custom_action(rsc, start_key(rsc), RSC_START, NULL, FALSE, TRUE, data_set);
             update_action_flags(op, pe_action_allow_reload_conversion);
 #else
             /* Re-sending the recurring op is sufficient - the old one will be cancelled automatically */
-            set_bit(rsc->flags, pe_rsc_reschedule_monitor);
-            free(key);
+            op = custom_action(rsc, key, task, active_node, TRUE, TRUE, data_set);
+            set_bit(op->flags, pe_action_reschedule);
 #endif
 
         } else if (digest_restart) {

--- a/pengine/allocate.c
+++ b/pengine/allocate.c
@@ -283,6 +283,7 @@ check_action_definition(resource_t * rsc, node_t * active_node, xmlNode * xml_op
 #else
             /* Re-sending the recurring op is sufficient - the old one will be cancelled automatically */
             set_bit(rsc->flags, pe_rsc_reschedule_monitor);
+            free(key);
 #endif
 
         } else if (digest_restart) {

--- a/pengine/native.c
+++ b/pengine/native.c
@@ -727,8 +727,15 @@ RecurringOp(resource_t * rsc, action_t * start, node_t * node,
         pe_rsc_trace(rsc, "Marking %s manditory: not active", key);
 
     } else {
-        if (is_set(rsc->flags, pe_rsc_reschedule_monitor)) {
-            is_optional = FALSE;
+        GListPtr gIter = NULL;
+
+        for (gIter = possible_matches; gIter != NULL; gIter = gIter->next) {
+            action_t *op = (action_t *) gIter->data;
+
+            if (is_set(op->flags, pe_action_reschedule)) {
+                is_optional = FALSE;
+                break;
+            }
         }
         g_list_free(possible_matches);
     }

--- a/pengine/native.c
+++ b/pengine/native.c
@@ -726,10 +726,10 @@ RecurringOp(resource_t * rsc, action_t * start, node_t * node,
         is_optional = FALSE;
         pe_rsc_trace(rsc, "Marking %s manditory: not active", key);
 
-    } else if (is_set(rsc->flags, pe_rsc_reschedule_monitor)) {
-        is_optional = FALSE;
-
     } else {
+        if (is_set(rsc->flags, pe_rsc_reschedule_monitor)) {
+            is_optional = FALSE;
+        }
         g_list_free(possible_matches);
     }
 


### PR DESCRIPTION
Resolved memory leaks. Well, and refactored --  I think it's more precise to reschedule specific monitors ;-)