### PR TITLE
Re-add Default Start and Stop runlevels

### DIFF
--- a/mcp/pacemaker.in
+++ b/mcp/pacemaker.in
@@ -15,8 +15,8 @@
 # Required-Start:	$network corosync
 # Should-Start:		$syslog
 # Required-Stop:	$network corosync
-# Default-Start:
-# Default-Stop:
+# Default-Start:  2 3 4 5
+# Default-Stop:   0 1 6
 # Short-Description:	Starts and stops Pacemaker Cluster Manager.
 # Description:		Starts and stops Pacemaker Cluster Manager.
 ### END INIT INFO


### PR DESCRIPTION
Debian's update-rc.d relies on specification of Default-Start/Stop
to enable/disable init scripts in runlevels.

Restore previous removed definitions to ensure that this still
works - otherwise its not possible to enable pacemaker to start
on boot using 'update-rc.d pacemaker defaults'.