### PR TITLE
fencing: Allow semi-colon delimiter for pcmk_host_list

### DIFF
--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -520,7 +520,7 @@ parse_host_line(const char *line, int max, GListPtr * output)
         if (a_space && lpc < max && isspace(line[lpc + 1])) {
             /* fast-forward to the end of the spaces */
 
-        } else if (a_space || line[lpc] == ',' || line[lpc] == 0) {
+        } else if (a_space || line[lpc] == ',' || line[lpc] == ';' || line[lpc] == 0) {
             int rc = 1;
             char *entry = NULL;
 


### PR DESCRIPTION
Lack of support for semi-colon delimiter in pcmk_host_list can lead to confusion, seeing as pcmk_host_map does allow it. Out of habit users may use it for both, leading to a host not being seen as eligible to be fenced by a given device. 