### PR TITLE
Fix reported times after systemd operation

### DIFF
--- a/lrmd/lrmd.c
+++ b/lrmd/lrmd.c
@@ -552,6 +552,9 @@ cmd_finalize(lrmd_cmd_t * cmd, lrmd_rsc_t * rsc)
         cmd->rsc_deleted = 1;
     }
 
+    /* reset original timeout so client notification has correct information */
+    cmd->timeout = cmd->timeout_orig;
+
     send_cmd_complete_notify(cmd);
 
     if (cmd->interval && (cmd->lrmd_op_status == PCMK_LRM_OP_CANCELLED)) {
@@ -958,6 +961,8 @@ action_complete(svc_action_t * action)
                 rsc->active = NULL;
             }
             schedule_lrmd_cmd(rsc, cmd);
+
+            /* Don't finalize cmd, we're not done with it yet */
             return;
 
         } else {


### PR DESCRIPTION
I ran a test case using the DummySD systemd agent from the standard CTS configuration. I kill -9'd the python command before it could finish starting up. Before this patch, crm_mon reported exec=2ms under failed actions, and with this patch, it reported >10000ms (which was about the actual time when I killed it).

CTS with 75 random tests ran fine against this.