### PR TITLE
Low: mcp: Add 'start on started local and runlevel' to Upstart job.

### DIFF
--- a/mcp/pacemaker.combined.upstart.in
+++ b/mcp/pacemaker.combined.upstart.in
@@ -2,6 +2,9 @@
 #
 # Starts Corosync cluster engine and Pacemaker cluster manager.
 
+# if you use automatic start, uncomment the line below.
+#start on started local and runlevel [2345]
+
 stop on runlevel [0123456]
 kill timeout 3600
 respawn


### PR DESCRIPTION
We added setting of the automatic start in
upstart.(pacemaker.combined.conf)
It is necessary for the user to exclude comment.

We confirmed movement only in RHEL6.6.
#Possibly a change may be necessary for the different distribution.

Best Regards,
Hideo Yamauchi.