### PR TITLE
restore CIB read-and-verify logging to 1.1.12 verbosity

### DIFF
--- a/cib/io.c
+++ b/cib/io.c
@@ -78,6 +78,8 @@ retrieveCib(const char *filename, const char *sigfile)
 {
     xmlNode *root = NULL;
 
+    crm_info("Reading cluster configuration file %s (digest: %s)",
+             filename, sigfile);
     switch (cib_file_read_and_verify(filename, sigfile, &root)) {
         case -pcmk_err_cib_corrupt:
             crm_warn("Continuing but %s will NOT be used.", filename);
@@ -230,6 +232,8 @@ readCibXmlFile(const char *dir, const char *file, gboolean discard_status)
         filename = crm_strdup_printf("%s/%s", cib_root, namelist[lpc]->d_name);
         sigfile = crm_concat(filename, "sig", '.');
 
+        crm_info("Reading cluster configuration file %s (digest: %s)",
+                 filename, sigfile);
         if (cib_file_read_and_verify(filename, sigfile, &root) < 0) {
             crm_warn("Continuing but %s will NOT be used.", filename);
         } else {

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -145,7 +145,6 @@ cib_file_read_and_verify(const char *filename, const char *sigfile, xmlNode **ro
     }
 
     /* Parse XML */
-    crm_info("Reading cluster configuration file %s", filename);
     local_root = filename2xml(filename);
     if (local_root == NULL) {
         crm_warn("Cluster configuration file %s is corrupt (unparseable as XML)", filename);
@@ -158,7 +157,6 @@ cib_file_read_and_verify(const char *filename, const char *sigfile, xmlNode **ro
     }
 
     /* Verify that digests match */
-    crm_debug("Verifying cluster configuration signature from %s", sigfile);
     if (cib_file_verify_digest(local_root, sigfile) == FALSE) {
         free(local_sigfile);
         free_xml(local_root);
@@ -369,6 +367,7 @@ cib_file_write_with_digest(xmlNode *cib_root, const char *cib_dirname,
                && (tmp_cib != NULL) && (tmp_digest != NULL));
 
     /* Ensure the admin didn't modify the existing CIB underneath us */
+    crm_trace("Reading cluster configuration file %s", cib_path);
     rc = cib_file_read_and_verify(cib_path, NULL, NULL);
     if ((rc != pcmk_ok) && (rc != -ENOENT)) {
         crm_err("%s was manually modified while the cluster was active!",
@@ -439,6 +438,8 @@ cib_file_write_with_digest(xmlNode *cib_root, const char *cib_dirname,
     crm_debug("Wrote digest %s to disk", digest);
 
     /* Verify that what we wrote is sane */
+    crm_info("Reading cluster configuration file %s (digest: %s)",
+             tmp_cib, tmp_digest);
     rc = cib_file_read_and_verify(tmp_cib, tmp_digest, NULL);
     CRM_ASSERT(rc == 0);
 


### PR DESCRIPTION
This restores the log messages to exactly what they were before 9f83b41. I'd recommend reducing them even further; if you agree, I'll amend this:

* Remove the second crm_info() added here in cib/io.c. That's if the main CIB file is bad, and we need to read from one of the backups; in such a case there will already be a warning just beforehand and a warning (if unsuccessful) or notice (if successful) with the backup filename just afterward.

* Maybe get rid of the crm_trace() added here in lib/cib/cib_file.c. That's when we're verifying the existing CIB before writing a new one. There won't be any logs beforehand, but we'll log an error immediately if it fails, and log a debug message "Writing CIB to disk" a couple steps later, so I think that's adequate to investigate any issues.

* Get rid of the crm_info() added here in lib/cib/cib_file.c (when we're verifying a CIB that was just written -- all we're learning is the temporary CIB/digest file names) and instead add the temporary file names to the "Writing CIB to disk" debug message a little earlier.