### PR TITLE
Low: tools: Support of the start from systemd of crm_mon.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1884,6 +1884,7 @@ tools/Makefile							\
 	tools/crm_report					\
         tools/report.common                                     \
 	tools/cibsecret						\
+	tools/crm_mon.service					\
 	tools/crm_mon.upstart					\
 xml/Makefile							\
 lib/gnu/Makefile						\

--- a/mcp/pacemaker.service.in
+++ b/mcp/pacemaker.service.in
@@ -11,6 +11,8 @@ Requires=dbus.service
 Requires=basic.target
 Requires=network.target
 Requires=corosync.service
+# if you use crm_mon, uncomment the line below.
+# Wants=crm_mon.service
 
 [Install]
 WantedBy=multi-user.target
@@ -55,3 +57,6 @@ TimeoutStartSec=60s
 
 # Restart options include: no, on-success, on-failure, on-abort or always
 Restart=on-failure
+# if you use crm_mon, uncomment the line below.
+# ExecStopPost=/bin/sh -c 'systemctl status crm_mon >/dev/null && systemctl stop crm_mon'
+

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -335,12 +335,15 @@ rm -rf %{buildroot}
 %if %{defined _unitdir}
 
 %post
+%systemd_post crm_mon.service
 %systemd_post pacemaker.service
 
 %preun
 %systemd_preun pacemaker.service
+%systemd_preun crm_mon.service
 
 %postun
+%systemd_postun_with_restart crm_mon.service 
 %systemd_postun_with_restart pacemaker.service 
 
 %post remote
@@ -403,6 +406,7 @@ exit 0
 
 %if %{defined _unitdir}
 %{_unitdir}/pacemaker.service
+%{_unitdir}/crm_mon.service
 %else
 %{_initrddir}/pacemaker
 %endif

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -17,6 +17,10 @@
 #
 include $(top_srcdir)/Makefile.common
 
+if BUILD_SYSTEMD
+systemdunit_DATA = crm_mon.service
+endif
+
 COMMONLIBS	= 							\
 		$(top_builddir)/lib/common/libcrmcommon.la		\
 		$(top_builddir)/lib/cib/libcib.la			\

--- a/tools/crm_mon.service.in
+++ b/tools/crm_mon.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daemon for pacemaker monitor
+
+[Service]
+Type=forking
+EnvironmentFile=-@sysconfdir@/sysconfig/crm_mon
+ExecStart=@sbindir@/crm_mon $OPTIONS
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
It supported systemd in crm_mon.
We wish this correction is included in Pacemaker1.1.13.

Best Regards,
Hideo Yamauchi.
