### PR TITLE
Fix: fencing: Correctly make args for fencing agents

### DIFF
--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -456,7 +456,7 @@ make_args(const char *agent, const char *action, const char *victim, uint32_t vi
         }
 
         /* Check if we need to supply the victim in any other form */
-        if(safe_str_neq(agent, "fence_legacy")) {
+        if(safe_str_eq(agent, "fence_legacy")) {
             value = agent;
 
         } else if (param == NULL) {


### PR DESCRIPTION
Some heartbeat stonith plugins support "port" themselves. We should not
use it for passing the victim to fence_legacy