### PR TITLE
Fix rhbz#1200849

### DIFF
--- a/crmd/fsa_defines.h
+++ b/crmd/fsa_defines.h
@@ -467,6 +467,12 @@ enum crmd_fsa_input {
 
 #  define R_IN_RECOVERY	0x80000000ULL
 
+/*
+ * Magic RC used within CRMd to indicate direct nacks
+ * (operation is invalid in current state)
+ */
+#define CRM_DIRECT_NACK_RC (99)
+
 enum crmd_fsa_cause {
     C_UNKNOWN = 0,
     C_STARTUP,

--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -1862,7 +1862,7 @@ do_lrm_rsc_op(lrm_state_t * lrm_state, lrmd_rsc_info_t * rsc, const char *operat
             && safe_str_neq(operation, CRMD_ACTION_STOP)) {
             crm_info("Discarding attempt to perform action %s on %s in state %s",
                      operation, rsc->id, fsa_state2string(fsa_state));
-            op->rc = 99;
+            op->rc = CRM_DIRECT_NACK_RC;
             op->op_status = PCMK_LRM_OP_ERROR;
             send_direct_ack(NULL, NULL, rsc, op, rsc->id);
             lrmd_free_event(op);

--- a/crmd/te_callbacks.c
+++ b/crmd/te_callbacks.c
@@ -688,15 +688,11 @@ tengine_stonith_callback(stonith_t * stonith, stonith_callback_data_t * data)
 
     } else {
         const char *target = crm_element_value_const(action->xml, XML_LRM_ATTR_TARGET);
-        const char *allow_fail = crm_meta_value(action->params, XML_ATTR_TE_ALLOWFAIL);
 
         action->failed = TRUE;
-        if (crm_is_true(allow_fail) == FALSE) {
-            crm_notice("Stonith operation %d for %s failed (%s): aborting transition.", call_id,
-                       target, pcmk_strerror(rc));
-            abort_transition(INFINITY, tg_restart, "Stonith failed", NULL);
-        }
-
+        crm_notice("Stonith operation %d for %s failed (%s): aborting transition.",
+                   call_id, target, pcmk_strerror(rc));
+        abort_transition(INFINITY, tg_restart, "Stonith failed", NULL);
         st_fail_count_increment(target, rc);
     }
 

--- a/crmd/te_events.c
+++ b/crmd/te_events.c
@@ -522,7 +522,7 @@ process_graph_event(xmlNode * event, const char *event_node)
     int status = -1;
     int callid = -1;
 
-    int action = -1;
+    int action_num = -1;
     int target_rc = -1;
     int transition_num = -1;
     char *update_te_uuid = NULL;
@@ -550,8 +550,8 @@ process_graph_event(xmlNode * event, const char *event_node)
         return FALSE;
     }
 
-    if (decode_transition_key(magic, &update_te_uuid, &transition_num, &action, &target_rc) ==
-        FALSE) {
+    if (decode_transition_key(magic, &update_te_uuid, &transition_num,
+                              &action_num, &target_rc) == FALSE) {
         crm_err("Invalid event %s.%d detected: %s", id, callid, magic);
         abort_transition(INFINITY, tg_restart, "Bad event", event);
         return FALSE;
@@ -565,7 +565,7 @@ process_graph_event(xmlNode * event, const char *event_node)
         desc = "initiated outside of the cluster";
         abort_transition(INFINITY, tg_restart, "Unexpected event", event);
 
-    } else if (action < 0 || crm_str_eq(update_te_uuid, te_uuid, TRUE) == FALSE) {
+    } else if ((action_num < 0) || (crm_str_eq(update_te_uuid, te_uuid, TRUE) == FALSE)) {
         desc = "initiated by a different node";
         abort_transition(INFINITY, tg_restart, "Foreign event", event);
         stop_early = TRUE;      /* This could be an lrm status refresh */
@@ -579,7 +579,7 @@ process_graph_event(xmlNode * event, const char *event_node)
         desc = "arrived late";
         abort_transition(INFINITY, tg_restart, "Inactive graph", event);
 
-    } else if (match_graph_event(action, event, status, rc, target_rc) < 0) {
+    } else if (match_graph_event(action_num, event, status, rc, target_rc) < 0) {
         desc = "unknown";
         abort_transition(INFINITY, tg_restart, "Unknown event", event);
 
@@ -594,8 +594,8 @@ process_graph_event(xmlNode * event, const char *event_node)
             stop_early = FALSE;
             desc = "failed";
         }
-        crm_info("Detected action (%d.%d) %s.%d=%s: %s", transition_num, action, id, callid,
-                 services_ocf_exitcode_str(rc), desc);
+        crm_info("Detected action (%d.%d) %s.%d=%s: %s", transition_num,
+                 action_num, id, callid, services_ocf_exitcode_str(rc), desc);
     }
 
   bail:

--- a/crmd/te_events.c
+++ b/crmd/te_events.c
@@ -305,9 +305,6 @@ match_graph_event(int action_id, xmlNode * event, const char *event_node,
     }
 
     op_status = status_from_rc(action, op_status, op_rc, target_rc);
-    if (op_status != PCMK_LRM_OP_DONE) {
-        update_failcount(event, event_node, op_rc, target_rc, FALSE);
-    }
 
     /* Process OP status */
     switch (op_status) {

--- a/crmd/te_events.c
+++ b/crmd/te_events.c
@@ -352,7 +352,7 @@ match_graph_event(int action_id, xmlNode * event, const char *event_node,
     this_event = crm_element_value(event, XML_LRM_ATTR_TASK_KEY);
     target = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
     crm_info("Action %s (%d) confirmed on %s (rc=%d)",
-             crm_str(this_event), action->id, crm_str(target), op_status);
+             crm_str(this_event), action->id, crm_str(target), op_rc);
 
     /* determine if this action affects a remote-node's online/offline status */
     process_remote_node_action(action, event);

--- a/crmd/te_events.c
+++ b/crmd/te_events.c
@@ -121,7 +121,7 @@ update_failcount(xmlNode * event, const char *event_node_uuid, int rc, int targe
     const char *on_uname = crm_peer_uname(event_node_uuid);
     const char *origin = crm_element_value(event, XML_ATTR_ORIGIN);
 
-    if (rc == 99) {
+    if (rc == CRM_DIRECT_NACK_RC) {
         /* this is an internal code for "we're busy, try again" */
         return FALSE;
 
@@ -216,8 +216,7 @@ status_from_rc(crm_action_t * action, int orig_status, int rc, int target_rc)
         status = PCMK_LRM_OP_ERROR;
     }
 
-    /* 99 is the code we use for direct nack's */
-    if (rc != 99 && status != PCMK_LRM_OP_DONE) {
+    if ((rc != CRM_DIRECT_NACK_RC) && (status != PCMK_LRM_OP_DONE)) {
         const char *task, *uname;
 
         task = crm_element_value(action->xml, XML_LRM_ATTR_TASK_KEY);

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -770,6 +770,7 @@ unpack_operation(action_t * action, xmlNode * xml_obj, resource_t * container,
     } else if (safe_str_eq(value, "ignore")
                || safe_str_eq(value, "nothing")) {
         action->on_fail = action_fail_ignore;
+        pe_clear_action_bit(action, pe_action_failure_is_fatal);
         value = "ignore";
 
     } else if (safe_str_eq(value, "migrate")) {


### PR DESCRIPTION
The cluster now handles on-fail=ignore properly. Previously, the fail count would still get updated, potentially leading to a migration. The most obvious situation was a start failure with start-failure-is-fatal=true (the default), which would cause the fail count to be set to INFINITY resulting in an immediate migration.