### PR TITLE
Fix: xml: Fix upgrade-1.3.xsl to correctly transform ACL rules with "attribute"

### DIFF
--- a/xml/upgrade-1.3.xsl
+++ b/xml/upgrade-1.3.xsl
@@ -19,13 +19,13 @@
 
     <xsl:if test="@ref">
       <xsl:attribute name="reference"><xsl:value-of select="@ref"/></xsl:attribute>
-      <xsl:if test="@attribute">
-	<xsl:attribute name="attribute"><xsl:value-of select="@attribute"/></xsl:attribute>
-      </xsl:if>
     </xsl:if>
     <xsl:if test="not(@ref)">
       <xsl:if test="@tag">
 	<xsl:attribute name="object-type"><xsl:value-of select="@tag"/></xsl:attribute>
+	<xsl:if test="@attribute">
+	  <xsl:attribute name="attribute"><xsl:value-of select="@attribute"/></xsl:attribute>
+	</xsl:if>
       </xsl:if>
     </xsl:if>
 


### PR DESCRIPTION
Any old ACLs rule configured with both "ref" and "attribute" could not be transformed into a new rule that validates against acls-2.0.rng.

And although the new "attribute" actually has the  different semantic, I think it's safer to preserve it when transforming "tag" to "object-type".