### PR TITLE
Fix: crmd: Prevent the old version of DC from being fenced when it shuts down for rolling-upgrade

### DIFF
--- a/crmd/callbacks.c
+++ b/crmd/callbacks.c
@@ -178,7 +178,10 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                 /* Did the DC leave us? */
                 crm_notice("Our peer on the DC (%s) is dead", fsa_our_dc);
                 register_fsa_input(C_CRMD_STATUS_CALLBACK, I_ELECTION, NULL);
-                erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
+
+                if (compare_version(fsa_our_dc_version, "3.0.9") > 0) {
+                    erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
+                }
 
             } else if(AM_I_DC && appeared == FALSE) {
                 crm_info("Peer %s left us", node->uname);

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -35,7 +35,7 @@
 
 #  include <libxml/tree.h>
 
-#  define CRM_FEATURE_SET		"3.0.9"
+#  define CRM_FEATURE_SET		"3.0.10"
 
 #  define EOS		'\0'
 #  define DIMOF(a)	((int) (sizeof(a)/sizeof(a[0])) )


### PR DESCRIPTION
This issue is related to https://github.com/ClusterLabs/pacemaker/commit/5cb541fb0d34b1d224debb222ade51178a9eb5ba and https://github.com/ClusterLabs/pacemaker/commit/23b5f07fc15fd8436ff70883770349390771f8eb

In a mixed cluster, if the node that is shutting down is an old version
of DC, it won't send the CRM_OP_SHUTDOWN_REQ to the other newly upgraded
nodes. So the other nodes won't get a chance to update this node's
"expected" field to "down" from their membership caches, while they'll
still erase this node's transient attributes. Any node that is later
elected to be the new DC will decide to fence this node that has just
shut down.

The idea of this fix is not to erase this node's transient attributes
in this case to prevent the fencing. Although when this node first
rejoins, there could be the potential race condition. That's still
better than being fenced I think.

Do you think it makes sense? Or probably you have a better idea?