### PR TITLE
Refactor: crmd/pengine: implement on-fail=ignore without allow-fail

### DIFF
--- a/crmd/te_events.c
+++ b/crmd/te_events.c
@@ -589,10 +589,8 @@ process_graph_event(xmlNode * event, const char *event_node)
             abort_transition(INFINITY, tg_restart, "Unknown event", event);
 
         } else {
-            /* XML_ATTR_TE_ALLOWFAIL will be true if on-fail=ignore for the operation */
-            ignore_failures = crm_is_true(crm_meta_value(action->params,
-                                                         XML_ATTR_TE_ALLOWFAIL));
-
+            ignore_failures = safe_str_eq(
+                crm_meta_value(action->params, XML_OP_ATTR_ON_FAIL), "ignore");
             match_graph_event(action, event, status, rc, target_rc, ignore_failures);
         }
     }

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -342,7 +342,6 @@
 
 #  define XML_ATTR_TE_NOWAIT		"op_no_wait"
 #  define XML_ATTR_TE_TARGET_RC		"op_target_rc"
-#  define XML_ATTR_TE_ALLOWFAIL		"op_allow_fail"
 #  define XML_ATTR_LRM_PROBE		"lrm-is-probe"
 #  define XML_TAG_TRANSIENT_NODEATTRS	"transient_attributes"
 
@@ -391,6 +390,9 @@
 #  define XML_DIFF_OP                   "operation"
 #  define XML_DIFF_PATH                 "path"
 #  define XML_DIFF_POSITION             "position"
+
+/* Defined for backward API compatibility but no longer used by Pacemaker */
+#  define XML_ATTR_TE_ALLOWFAIL         "op_allow_fail"
 
 #  include <crm/common/xml.h>
 

--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -218,7 +218,7 @@ enum pe_action_flags {
     pe_action_print_always = 0x00008,
 
     pe_action_have_node_attrs = 0x00010,
-    pe_action_failure_is_fatal = 0x00020,
+    pe_action_failure_is_fatal = 0x00020, /* no longer used, here for API compatibility */
     pe_action_implied_by_stonith = 0x00040,
     pe_action_migrate_runnable =   0x00080,
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -416,7 +416,6 @@ custom_action(resource_t * rsc, char *key, const char *task,
         }
         action->uuid = strdup(key);
 
-        pe_set_action_bit(action, pe_action_failure_is_fatal);
         pe_set_action_bit(action, pe_action_runnable);
         if (optional) {
             pe_rsc_trace(rsc, "Set optional on %s", action->uuid);
@@ -770,7 +769,6 @@ unpack_operation(action_t * action, xmlNode * xml_obj, resource_t * container,
     } else if (safe_str_eq(value, "ignore")
                || safe_str_eq(value, "nothing")) {
         action->on_fail = action_fail_ignore;
-        pe_clear_action_bit(action, pe_action_failure_is_fatal);
         value = "ignore";
 
     } else if (safe_str_eq(value, "migrate")) {

--- a/pengine/graph.c
+++ b/pengine/graph.c
@@ -823,10 +823,6 @@ action2xml(action_t * action, gboolean as_input, pe_working_set_t *data_set)
         }
     }
 
-    if (is_set(action->flags, pe_action_failure_is_fatal) == FALSE) {
-        add_hash_param(action->meta, XML_ATTR_TE_ALLOWFAIL, XML_BOOLEAN_TRUE);
-    }
-
     if (as_input) {
         return action_xml;
     }


### PR DESCRIPTION
This reimplementation avoids the need to change any pengine regression tests,
and deprecates the XML_ATTR_TE_ALLOWFAIL operation attribute and the
corresponding pe_action_failure_is_fatal value of pe_action_flags
(retaining them for backward API compatibility).