### PR TITLE
Fix cib legacy mode

### DIFF
--- a/cib/callbacks.c
+++ b/cib/callbacks.c
@@ -48,7 +48,13 @@ typedef struct cib_local_notify_s {
 } cib_local_notify_t;
 
 int next_client_id = 0;
+
+#if SUPPORT_PLUGIN
+gboolean legacy_mode = TRUE;
+#else
 gboolean legacy_mode = FALSE;
+#endif
+
 qb_ipcs_service_t *ipcs_ro = NULL;
 qb_ipcs_service_t *ipcs_rw = NULL;
 qb_ipcs_service_t *ipcs_shm = NULL;
@@ -84,6 +90,10 @@ static gboolean cib_read_legacy_mode(void)
 
 static gboolean cib_legacy_mode(void)
 {
+#if SUPPORT_PLUGIN
+    return TRUE;
+#endif
+
     if(cib_read_legacy_mode()) {
         return TRUE;
     }

--- a/cib/callbacks.c
+++ b/cib/callbacks.c
@@ -90,7 +90,7 @@ static gboolean cib_read_legacy_mode(void)
     return legacy;
 }
 
-static gboolean cib_legacy_mode(void)
+gboolean cib_legacy_mode(void)
 {
 #if SUPPORT_PLUGIN
     return TRUE;

--- a/cib/callbacks.c
+++ b/cib/callbacks.c
@@ -1196,6 +1196,10 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     crm_element_value_int(request, F_CIB_CALLOPTS, &call_options);
     rc = cib_get_operation_id(op, &call_type);
 
+    if (cib_legacy_mode()) {
+        call_options |= cib_force_digest;
+    }
+
     if (rc == pcmk_ok && privileged == FALSE) {
         rc = cib_op_can_run(call_type, call_options, privileged, global_update);
     }

--- a/cib/callbacks.h
+++ b/cib/callbacks.h
@@ -73,6 +73,8 @@ void cib_shutdown(int nsig);
 void initiate_exit(void);
 void terminate_cib(const char *caller, gboolean fast);
 
+extern gboolean cib_legacy_mode(void);
+
 #if SUPPORT_HEARTBEAT
 extern void cib_ha_peer_callback(HA_Message * msg, void *private_data);
 extern int cib_ccm_dispatch(gpointer user_data);

--- a/cib/messages.c
+++ b/cib/messages.c
@@ -297,7 +297,14 @@ cib_process_upgrade_server(const char *op, int options, const char *section, xml
             crm_xml_add(up, F_CIB_CALLOPTS, crm_element_value(req, F_CIB_CALLOPTS));
             crm_xml_add(up, F_CIB_CALLID, crm_element_value(req, F_CIB_CALLID));
 
-            send_cluster_message(NULL, crm_msg_cib, up, FALSE);
+            if (cib_legacy_mode() && cib_is_master) {
+                rc = cib_process_upgrade(
+                    op, options, section, up, input, existing_cib, result_cib, answer);
+
+            } else {
+                send_cluster_message(NULL, crm_msg_cib, up, FALSE);
+            }
+
             free_xml(up);
 
         } else if(rc == pcmk_ok) {

--- a/include/crm/cib.h
+++ b/include/crm/cib.h
@@ -72,7 +72,8 @@ enum cib_call_options {
 	cib_inhibit_notify  = 0x00010000,
  	cib_quorum_override = 0x00100000,
 	cib_inhibit_bcast   = 0x01000000, /* TODO: Remove */
-	cib_force_diff	    = 0x10000000
+	cib_force_diff	    = 0x10000000,
+	cib_force_digest    = 0x20000000
 };
 
 #define cib_default_options = cib_none

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -3408,9 +3408,15 @@ dump_xml_attr(xmlAttrPtr attr, int options, char **buffer, int *offset, int *max
 {
     char *p_value = NULL;
     const char *p_name = NULL;
+    xml_private_t *p = NULL;
 
     CRM_ASSERT(buffer != NULL);
     if (attr == NULL || attr->children == NULL) {
+        return;
+    }
+
+    p = attr->_private;
+    if (is_set(p->flags, xpf_deleted)) {
         return;
     }
 


### PR DESCRIPTION
Well, if all the nodes are running the latest code in legacy mode, CIB doesn't get updated/synchronized correctly.  AFAICS, the legacy mode still requires https://github.com/ClusterLabs/pacemaker/commit/d153b86382516dd2716ff07145ef6a8c499e8d7f to work, right?

I'm still testing the code. I'm pushing them to show the idea. Please help take a look if they make sense.

-  Force plugin-based cluster to be in legacy mode through modifying cib/callbacks.c:cib_legacy_mode().  So multi-master is disabled.

- Keep  lib/common/xml.c: patch_legacy_mode() as it is,  so that it can also benefit from v2 diff format unless  "export legacy=cib" is explicitly set in /etc/sysconfig/pacemaker.

- Recover broadcast by reverting https://github.com/ClusterLabs/pacemaker/commit/d153b86382516dd2716ff07145ef6a8c499e8d7f

- Always generate digests for cib diffs in legacy mode, even if they are in v2 format -- Too strict?

Any thoughts or suggestions are appreciated.