### PR TITLE
Low : fencing : Correction of the log output of the practice node of …

### DIFF
--- a/fencing/remote.c
+++ b/fencing/remote.c
@@ -278,10 +278,12 @@ remote_op_done(remote_fencing_op_t * op, xmlNode * data, int rc, int dup)
         goto remote_op_done_cleanup;
     }
 
-    if (!op->delegate && data) {
+    if (!op->delegate && data && rc != -ENODEV && rc != -EHOSTUNREACH) {
         xmlNode *ndata = get_xpath_object("//@" F_STONITH_DELEGATE, data, LOG_TRACE);
         if(ndata) {
             op->delegate = crm_element_value_copy(ndata, F_STONITH_DELEGATE);
+        } else { 
+            op->delegate = crm_element_value_copy(data, F_ORIG);
         }
     }
 


### PR DESCRIPTION
When there is not stonith device or when a host does not exist, the patch does the log output of the executant in \<anyone\>.


Output.log after revise.
 notice: tengine_stonith_notify: Peer snmp1 was not terminated (reboot) by \<anyone\> for snmp3: No such device (ref=b2615372-109b-41fe-bb70-8ca7640753a4) by client....
 notice: tengine_stonith_notify: Peer snmp1 was not terminated (reboot) by \<anyone\> for snmp3: No route to host (ref=72a44cd4-ba07-444f-9636-819f81f2249e) by client....

There might be an error to the next patch which I contributed to a past.
 * https://github.com/ClusterLabs/pacemaker/pull/584
 * https://github.com/ClusterLabs/pacemaker/commit/272814b6423d4cdc21a0a83cd9007a4d57bd542d

I changed it to control the log output in a right judgment.

Best Regards,
Hideo Yamauchi.