### PR TITLE
Make logging more admin-friendly

### DIFF
--- a/crmd/utils.c
+++ b/crmd/utils.c
@@ -1032,8 +1032,10 @@ update_attrd_helper(const char *host, const char *name, const char *value, const
     do {
         if (crm_ipc_connected(attrd_ipc) == FALSE) {
             crm_ipc_close(attrd_ipc);
-            crm_info("Connecting to attrd... %d retries remaining", max);
-            crm_ipc_connect(attrd_ipc);
+            crm_info("Connecting to attribute manager ... %d retries remaining", max);
+            if (crm_ipc_connect(attrd_ipc) == FALSE) {
+                crm_perror(LOG_INFO, "Connection to attribute manager failed");
+            }
         }
 
         rc = attrd_update_delegate(attrd_ipc, command, host, name, value, XML_CIB_TAG_STATUS, NULL,
@@ -1042,7 +1044,7 @@ update_attrd_helper(const char *host, const char *name, const char *value, const
             break;
 
         } else if (rc != -EAGAIN && rc != -EALREADY) {
-            crm_info("Disconnecting from attrd: %s (%d)", pcmk_strerror(rc), rc);
+            crm_info("Disconnecting from attribute manager: %s (%d)", pcmk_strerror(rc), rc);
             crm_ipc_close(attrd_ipc);
         }
 

--- a/cts/CM_lha.py
+++ b/cts/CM_lha.py
@@ -350,16 +350,13 @@ class crm_lha(ClusterManager):
                     "send_ipc_message: IPC Channel to .* is not connected",
                     "unconfirmed_actions: Waiting on .* unconfirmed actions",
                     "cib_native_msgready: Message pending on command channel",
-                    "do_exit: Performing A_EXIT_1 - forcefully exiting the CRMd",
-                    "verify_stopped: Resource .* was active at shutdown.  You may ignore this error if it is unmanaged.",
+                    r": Performing A_EXIT_1 - forcefully exiting the CRMd",
+                    r"Resource .* was active at shutdown.  You may ignore this error if it is unmanaged.",
             ]
 
         stonith_ignore = [
-            "(ERROR|error): stonithd_signon: ",
             "update_failcount: Updating failcount for child_DoFencing",
-            "(ERROR|error): te_connect_stonith: Sign-in failed: triggered a retry",
-            "lrmd.*(ERROR|error): cl_get_value: wrong argument (reply)",
-            "lrmd.*(ERROR|error): is_expected_msg:.* null message",
+            r"(ERROR|error).*: Sign-in failed: triggered a retry",
             "lrmd.*(ERROR|error): stonithd_receive_ops_result failed.",
              ]
 
@@ -377,7 +374,7 @@ class crm_lha(ClusterManager):
                     "crmd.*Action A_RECOVER .* not supported",
                     "crmd.*Input I_TERMINATE from do_recover",
                     "Exiting to recover from CCM connection failure",
-                    "crmd.*do_exit: Could not recover from internal error",
+                    r"crmd.*: Could not recover from internal error",
                     "crmd.*I_ERROR.*(ccm_dispatch|crmd_cib_connection_destroy)",
                     "crmd.*exited with return code 2.",
                     "attrd.*exited with return code 1.",
@@ -401,7 +398,7 @@ class crm_lha(ClusterManager):
                     "Connection to the CIB terminated...",
                     "crmd.*Input I_TERMINATE from do_recover",
                     "crmd.*I_ERROR.*crmd_cib_connection_destroy",
-                    "crmd.*do_exit: Could not recover from internal error",
+                    r"crmd.*: Could not recover from internal error",
                     "crmd.*exited with return code 2.",
                     "attrd.*exited with return code 1.",
                     ], badnews_ignore = common_ignore)
@@ -412,7 +409,7 @@ class crm_lha(ClusterManager):
                     "crmd.*I_ERROR.*lrm_connection_destroy",
                     "State transition S_STARTING -> S_PENDING",
                     "crmd.*Input I_TERMINATE from do_recover",
-                    "crmd.*do_exit: Could not recover from internal error",
+                    r"crmd.*: Could not recover from internal error",
                     "crmd.*exited with return code 2.",
                     ], badnews_ignore = common_ignore)
 
@@ -429,17 +426,16 @@ class crm_lha(ClusterManager):
                     "State transition .* S_RECOVERY",
                     "crmd.*exited with return code 2.",
                     "crmd.*Input I_TERMINATE from do_recover",
-                    "crmd.*do_exit: Could not recover from internal error",
-                    "crmd.*CRIT: pe_connection_destroy: Connection to the Policy Engine failed",
+                    r"crmd.*: Could not recover from internal error",
+                    r"crmd.*CRIT.*: Connection to the Policy Engine failed",
                     "crmd.*I_ERROR.*save_cib_contents",
                     "crmd.*exited with return code 2.",
                     ], badnews_ignore = common_ignore, dc_only=1)
 
         if self.Env["DoFencing"] == 1 :
             complist.append(Process(self, "stoniths", triggersreboot=self.fastfail, dc_pats = [
-                        "crmd.*CRIT: tengine_stonith_connection_destroy: Fencing daemon connection failed",
+                        r"crmd.*CRIT.*: Fencing daemon connection failed",
                         "Attempting connection to fencing daemon",
-                        "te_connect_stonith: Connected",
                     ], badnews_ignore = stonith_ignore))
 
         if self.fastfail == 0:

--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -1438,7 +1438,7 @@ class ComponentFail(CTSTest):
                 if re.search("^Resource", line):
                     r = AuditResource(self.CM, line)
                     if r.rclass == "stonith":
-                        self.okerrpatterns.append(self.templates["LogActions: Recover.*%s"] % r.id)
+                        self.okerrpatterns.append(self.templates["Pat:Fencing_recover"] % r.id)
 
         # supply a copy so self.patterns doesnt end up empty
         tmpPats = []

--- a/cts/patterns.py
+++ b/cts/patterns.py
@@ -53,6 +53,7 @@ class BasePatterns:
 
             "Pat:Fencing_start" : "Initiating remote operation .* for %s",
             "Pat:Fencing_ok"    : r"stonith.*:\s*Operation .* of %s by .* for .*@.*: OK",
+            "Pat:Fencing_recover"    : r"pengine.*: Recover %s",
 
             "Pat:RscOpOK"       : r"crmd.*:\s*Operation %s_%s.*:\s*ok \(.*confirmed=\S+\)",
             "Pat:RscRemoteOpOK" : r"crmd.*:\s*Operation %s_%s.*:\s*ok \(node=%s,.*,\s*confirmed=true\)",
@@ -179,7 +180,7 @@ class crm_cs_v0(BasePatterns):
             r"update_trace_data",
             r"async_notify:.*strange, client not found",
             r"Parse error: Ignoring unknown option .*nodename",
-            r"error: log_operation:.*Operation 'reboot' .* with device 'FencingFail' returned:",
+            r"error.*: Operation 'reboot' .* with device 'FencingFail' returned:",
             r"Child process .* terminated with signal 9",
             r"getinfo response error: 1$",
             "sbd.* error: inquisitor_child: DEBUG MODE IS ACTIVE",
@@ -370,7 +371,7 @@ class crm_cs_v0(BasePatterns):
             r"crmd.*:\s*warn.*:\s*Callback already present",
         ]
         self.components["stonith-ignore"] = [
-            "LogActions: Recover Fencing",
+            r"pengine.*: Recover Fencing",
             "Updating failcount for Fencing",
             r"error:.*Connection to stonith-ng failed",
             r"error:.*Connection to stonith-ng.*closed \(I/O condition=17\)",

--- a/cts/patterns.py
+++ b/cts/patterns.py
@@ -393,7 +393,7 @@ class crm_mcp(crm_cs_v0):
 
         self.commands.update({
             "StartCmd"       : "service corosync start && service pacemaker start",
-            "StopCmd"        : "service pacemaker stop; service pacemaker_remote stop; service corosync stop",
+            "StopCmd"        : "service pacemaker stop; [ ! -e /usr/sbin/pacemaker_remoted ] || service pacemaker_remote stop; service corosync stop",
 
             "EpochCmd"      : "crm_node -e",
             "QuorumCmd"      : "crm_node -q",
@@ -443,7 +443,7 @@ class crm_cman(crm_cs_v0):
 
         self.commands.update({
             "StartCmd"       : "service pacemaker start",
-            "StopCmd"        : "service pacemaker stop; service pacemaker_remote stop",
+            "StopCmd"        : "service pacemaker stop; [ ! -e /usr/sbin/pacemaker_remoted ] || service pacemaker_remote stop",
 
             "EpochCmd"      : "crm_node -e --cman",
             "QuorumCmd"      : "crm_node -q --cman",

--- a/cts/watcher.py
+++ b/cts/watcher.py
@@ -290,10 +290,12 @@ class JournalObj(SearchObj):
         self.hitLimit = False
         (rc, lines) = self.rsh(self.host, "date +'%Y-%m-%d %H:%M:%S'", stdout=None, silent=True)
 
-        for line in lines:
-            self.limit = line.strip()
+        if (rc == 0) and (len(lines) == 1):
+            self.limit = lines[0].strip()
             self.debug("Set limit to: %s" % self.limit)
-
+        else:
+            self.debug("Unable to set limit for %s because date returned %d lines with status %d" % (self.host,
+                len(lines), rc))
 
         return
 

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -215,6 +215,7 @@ cib_native_signon_raw(cib_t * cib, const char *name, enum cib_conn_type type, in
             *async_fd = crm_ipc_get_fd(native->ipc);
 
         } else if (native->ipc) {
+            crm_perror(LOG_ERR, "Connection to cluster information base failed");
             rc = -ENOTCONN;
         }
 

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -785,6 +785,13 @@ crm_ipc_new(const char *name, size_t max_size)
     return client;
 }
 
+/*!
+ * \brief Establish an IPC connection to a Pacemaker component
+ *
+ * \param[in] client  Connection instance obtained from crm_ipc_new()
+ *
+ * \return TRUE on success, FALSE otherwise (in which case errno will be set)
+ */
 bool
 crm_ipc_connect(crm_ipc_t * client)
 {
@@ -792,13 +799,11 @@ crm_ipc_connect(crm_ipc_t * client)
     client->ipc = qb_ipcc_connect(client->name, client->buf_size);
 
     if (client->ipc == NULL) {
-        crm_perror(LOG_INFO, "Could not establish %s connection", client->name);
         return FALSE;
     }
 
     client->pfd.fd = crm_ipc_get_fd(client);
     if (client->pfd.fd < 0) {
-        crm_perror(LOG_INFO, "Could not obtain file descriptor for %s connection", client->name);
         return FALSE;
     }
 

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -204,16 +204,13 @@ set_format_string(int method, const char *daemon)
         }
     }
 
-    if (crm_tracing_enabled() && method >= QB_LOG_STDERR) {
-        offset += snprintf(fmt + offset, FMT_MAX - offset, "(%%-12f:%%5l %%g) %%-7p: %%n: ");
-    } else {
-        offset += snprintf(fmt + offset, FMT_MAX - offset, "%%g %%-7p: %%n: ");
-    }
-
     if (method == QB_LOG_SYSLOG) {
-        offset += snprintf(fmt + offset, FMT_MAX - offset, "%%b");
+        offset += snprintf(fmt + offset, FMT_MAX - offset, "%%g %%-7p: %%b");
+        crm_extended_logging(method, QB_FALSE);
+    } else if (crm_tracing_enabled()) {
+        offset += snprintf(fmt + offset, FMT_MAX - offset, "(%%-12f:%%5l %%g) %%-7p: %%n:\t%%b");
     } else {
-        offset += snprintf(fmt + offset, FMT_MAX - offset, "\t%%b");
+        offset += snprintf(fmt + offset, FMT_MAX - offset, "%%g %%-7p: %%n:\t%%b");
     }
 
     CRM_LOG_ASSERT(offset > 0);

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -1820,6 +1820,8 @@ attrd_update_delegate(crm_ipc_t * ipc, char command, const char *host, const cha
 
         if (connected) {
             rc = crm_ipc_send(ipc, update, flags, 0, NULL);
+        } else {
+            crm_perror(LOG_INFO, "Connection to cluster attribute manager failed");
         }
 
         if (ipc != local_ipc) {

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1589,8 +1589,8 @@ stonith_api_signon(stonith_t * stonith, const char *name, int *stonith_fd)
 
         if (native->ipc && crm_ipc_connect(native->ipc)) {
             *stonith_fd = crm_ipc_get_fd(native->ipc);
-
         } else if (native->ipc) {
+            crm_perror(LOG_ERR, "Connection to STONITH manager failed");
             rc = -ENOTCONN;
         }
 

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -960,6 +960,7 @@ lrmd_ipc_connect(lrmd_t * lrmd, int *fd)
         if (native->ipc && crm_ipc_connect(native->ipc)) {
             *fd = crm_ipc_get_fd(native->ipc);
         } else if (native->ipc) {
+            crm_perror(LOG_ERR, "Connection to local resource manager failed");
             rc = -ENOTCONN;
         }
     } else {

--- a/lrmd/pacemaker_remote.service.in
+++ b/lrmd/pacemaker_remote.service.in
@@ -19,3 +19,7 @@ TimeoutStartSec=30s
 
 # Restart options include: no, on-success, on-failure, on-abort or always
 Restart=on-failure
+
+# crm_perror() writes directly to stderr, so ignore it here
+# to avoid double-logging with the wrong format
+StandardError=null

--- a/mcp/pacemaker.service.in
+++ b/mcp/pacemaker.service.in
@@ -56,6 +56,10 @@ TimeoutStartSec=60s
 
 # Restart options include: no, on-success, on-failure, on-abort or always
 Restart=on-failure
+
+# crm_perror() writes directly to stderr, so ignore it here
+# to avoid double-logging with the wrong format
+StandardError=null
+
 # if you use crm_mon, uncomment the line below.
 # ExecStopPost=/bin/sh -c 'systemctl status crm_mon >/dev/null && systemctl stop crm_mon'
-

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -215,6 +215,7 @@ send_attrd_query(const char *name, const char *host, xmlNode **reply)
     crm_debug("Sending query for value of %s on %s", name, (host? host : "all nodes"));
     ipc = crm_ipc_new(T_ATTRD, 0);
     if (crm_ipc_connect(ipc) == FALSE) {
+        crm_perror(LOG_ERR, "Connection to cluster attribute manager failed");
         rc = -ENOTCONN;
     } else {
         rc = crm_ipc_send(ipc, query, crm_ipc_flags_none|crm_ipc_client_response, 0, reply);

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -145,6 +145,7 @@ int tools_remove_node_cache(const char *node, const char *target)
     }
 
     if (!crm_ipc_connect(conn)) {
+        crm_perror(LOG_ERR, "Connection to %s failed", target);
         crm_ipc_destroy(conn);
         return -ENOTCONN;
     }


### PR DESCRIPTION
In addition to some CTS fixes, this request adds support for split logging, drops the function name from syslog messages, and rephrases some log messages to be more user-friendly. No split logging is actually done yet.