### PR TITLE
Fix: cib: No need to enforce cib digests for v2 diffs in legacy mode

### DIFF
--- a/cib/callbacks.c
+++ b/cib/callbacks.c
@@ -874,9 +874,12 @@ send_peer_reply(xmlNode * msg, xmlNode * result_diff, const char *originator, gb
         int diff_del_admin_epoch = 0;
 
         const char *digest = NULL;
+        int format = 1;
 
         CRM_LOG_ASSERT(result_diff != NULL);
         digest = crm_element_value(result_diff, XML_ATTR_DIGEST);
+        crm_element_value_int(result_diff, "format", &format);
+
         cib_diff_version_details(result_diff,
                                  &diff_add_admin_epoch, &diff_add_epoch, &diff_add_updates,
                                  &diff_del_admin_epoch, &diff_del_epoch, &diff_del_updates);
@@ -889,7 +892,9 @@ send_peer_reply(xmlNode * msg, xmlNode * result_diff, const char *originator, gb
         crm_xml_add(msg, F_CIB_GLOBAL_UPDATE, XML_BOOLEAN_TRUE);
         crm_xml_add(msg, F_CIB_OPERATION, CIB_OP_APPLY_DIFF);
 
-        CRM_ASSERT(digest != NULL);
+        if (format == 1) {
+            CRM_ASSERT(digest != NULL);
+        }
 
         add_message_xml(msg, F_CIB_UPDATE_DIFF, result_diff);
         crm_log_xml_explicit(msg, "copy");
@@ -1195,10 +1200,6 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     op = crm_element_value(request, F_CIB_OPERATION);
     crm_element_value_int(request, F_CIB_CALLOPTS, &call_options);
     rc = cib_get_operation_id(op, &call_type);
-
-    if (cib_legacy_mode()) {
-        call_options |= cib_force_digest;
-    }
 
     if (rc == pcmk_ok && privileged == FALSE) {
         rc = cib_op_can_run(call_type, call_options, privileged, global_update);

--- a/include/crm/cib.h
+++ b/include/crm/cib.h
@@ -72,8 +72,7 @@ enum cib_call_options {
 	cib_inhibit_notify  = 0x00010000,
  	cib_quorum_override = 0x00100000,
 	cib_inhibit_bcast   = 0x01000000, /* TODO: Remove */
-	cib_force_diff	    = 0x10000000,
-	cib_force_digest    = 0x20000000
+	cib_force_diff	    = 0x10000000
 };
 
 #define cib_default_options = cib_none

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -302,7 +302,6 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
     const char *new_version = NULL;
     static struct qb_log_callsite *diff_cs = NULL;
     const char *user = crm_element_value(req, F_CIB_USER);
-    bool with_digest = FALSE;
 
     crm_trace("Begin %s%s op", is_query ? "read-only " : "", op);
 
@@ -444,21 +443,18 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
     strip_text_nodes(scratch);
     fix_plus_plus_recursive(scratch);
 
-    if (is_set(call_options, cib_force_digest)) {
-        with_digest = TRUE;
-    }
-
     if (is_set(call_options, cib_zero_copy)) {
         /* At this point, current_cib is just the 'cib' tag and its properties,
          *
          * The v1 format would barf on this, but we know the v2 patch
          * format only needs it for the top-level version fields
          */
-        local_diff = xml_create_patchset(2, current_cib, scratch, (bool*)config_changed, manage_counters, with_digest);
+        local_diff = xml_create_patchset(2, current_cib, scratch, (bool*)config_changed, manage_counters, FALSE);
 
     } else {
         static time_t expires = 0;
         time_t tm_now = time(NULL);
+        bool with_digest = FALSE;
 
         if (expires < tm_now) {
             expires = tm_now + 60;  /* Validate clients are correctly applying v2-style diffs at most once a minute */


### PR DESCRIPTION
This basically reverts https://github.com/ClusterLabs/pacemaker/commit/8211f32ca0a50d5627792044a2164c9cb53a36c1, and add a condition for the assert in send_peer_reply().