### PR TITLE
Refactor: cib: Calculate and add digest for a patchset after accepting changes for the target xml

### DIFF
--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -267,8 +267,10 @@ void xml_log_patchset(uint8_t level, const char *function, xmlNode *xml);
 bool xml_patch_versions(xmlNode *patchset, int add[3], int del[3]);
 
 xmlNode *xml_create_patchset(
-    int format, xmlNode *source, xmlNode *target, bool *config, bool manage_version, bool with_digest);
+    int format, xmlNode *source, xmlNode *target, bool *config, bool manage_version);
 int xml_apply_patchset(xmlNode *xml, xmlNode *patchset, bool check_version);
+
+void patchset_process_digest(xmlNode *patch, xmlNode *source, xmlNode *target, bool with_digest);
 
 void save_xml_to_file(xmlNode * xml, const char *desc, const char *filename);
 char *xml_get_path(xmlNode *xml);

--- a/tools/cib_shadow.c
+++ b/tools/cib_shadow.c
@@ -433,7 +433,7 @@ main(int argc, char **argv)
             goto done;
         }
 
-        diff = xml_create_patchset(0, old_config, new_config, NULL, FALSE, FALSE);
+        diff = xml_create_patchset(0, old_config, new_config, NULL, FALSE);
         if (diff != NULL) {
             xml_log_patchset(0, "  ", diff);
             rc = 1;

--- a/tools/cib_shadow.c
+++ b/tools/cib_shadow.c
@@ -433,7 +433,14 @@ main(int argc, char **argv)
             goto done;
         }
 
+        xml_track_changes(new_config, NULL, new_config, FALSE);
+        xml_calculate_changes(old_config, new_config);
+
         diff = xml_create_patchset(0, old_config, new_config, NULL, FALSE);
+
+        xml_log_changes(LOG_INFO, __FUNCTION__, new_config);
+        xml_accept_changes(new_config);
+
         if (diff != NULL) {
             xml_log_patchset(0, "  ", diff);
             rc = 1;

--- a/tools/xml_diff.c
+++ b/tools/xml_diff.c
@@ -203,7 +203,14 @@ main(int argc, char **argv)
         xml_calculate_changes(object_1, object_2);
         crm_log_xml_debug(object_2, xml_file_2?xml_file_2:"target");
 
-        output = xml_create_patchset(0, object_1, object_2, NULL, FALSE, as_cib);
+        output = xml_create_patchset(0, object_1, object_2, NULL, FALSE);
+
+        xml_log_changes(LOG_INFO, __FUNCTION__, object_2);
+        xml_accept_changes(object_2);
+
+        if (output) {
+            patchset_process_digest(output, object_1, object_2, as_cib);
+        }
 
         if(as_cib && output) {
             int add[] = { 0, 0, 0 };
@@ -267,7 +274,6 @@ main(int argc, char **argv)
                 }
             }
         }
-        xml_log_changes(LOG_INFO, __FUNCTION__, object_2);
         xml_log_patchset(LOG_NOTICE, __FUNCTION__, output);
     }
 


### PR DESCRIPTION
Although https://github.com/ClusterLabs/pacemaker/commit/caac728b227bb14b541d32274ea80083e16d21ab fixes the issue of calculating digest with an on-tracking xml. But we'd better not do that with an on-tracking xml at all. This would be very important in case some day we want to switch back to libxml2 xmlNodeDump() function to dump xml string. 

With this refactoring, it  calculates and adds digest for a patchset after doing xml_accept_changes() to the target xml.