### PR TITLE
Fix: cib: Correctly add "update-origin", "update-client" and "update-user" attributes for cib

### DIFF
--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -531,7 +531,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
             int current_schema = get_schema_version(schema);
 
             if (minimum_schema == 0) {
-                minimum_schema = get_schema_version("pacemaker-1.1");
+                minimum_schema = get_schema_version("pacemaker-1.2");
             }
 
             /* Does the CIB support the "update-*" attributes... */


### PR DESCRIPTION
Schema "pacemaker-1.1" has a larger index number than the regular
schemas now.