### PR TITLE
Stonith fixes

### DIFF
--- a/fencing/remote.c
+++ b/fencing/remote.c
@@ -498,6 +498,7 @@ find_topology_for_host(const char *host)
                 break;
             }
             crm_trace("No match for %s with %s", host, tp->node);
+            tp = NULL;
         }
     }
 

--- a/fencing/standalone_config.c
+++ b/fencing/standalone_config.c
@@ -313,7 +313,7 @@ cfg_register_device(struct device *dev)
     dump = dump_xml_formatted(data);
     crm_info("Standalone device being added:\n%s", dump);
 
-    res = stonith_device_register(data, NULL);
+    res = stonith_device_register(data, NULL, FALSE);
 
     free(dump);
     free_xml(data);


### PR DESCRIPTION
A couple of one-line fixes for stonith issues

e841639 fixes a bug introduced in 5fcdb10 resulting in an incorrect fencing topology level being chosen for some nodes.