### PR TITLE
Fix: dbus: Use operation timeout for dbus reply timeout

### DIFF
--- a/lib/services/pcmk-dbus.h
+++ b/lib/services/pcmk-dbus.h
@@ -3,13 +3,13 @@ void pcmk_dbus_connection_setup_with_select(DBusConnection *c);
 void pcmk_dbus_disconnect(DBusConnection *connection);
 
 DBusPendingCall *pcmk_dbus_send(DBusMessage *msg, DBusConnection *connection,
-                    void(*done)(DBusPendingCall *pending, void *user_data), void *user_data);
-DBusMessage *pcmk_dbus_send_recv(DBusMessage *msg, DBusConnection *connection, DBusError *error);
+                    void(*done)(DBusPendingCall *pending, void *user_data), void *user_data, int timeout);
+DBusMessage *pcmk_dbus_send_recv(DBusMessage *msg, DBusConnection *connection, DBusError *error, int timeout);
 bool pcmk_dbus_type_check(DBusMessage *msg, DBusMessageIter *field, int expected, const char *function, int line);
 char *pcmk_dbus_get_property(
     DBusConnection *connection, const char *target, const char *obj, const gchar * iface, const char *name,
     void (*callback)(const char *name, const char *value, void *userdata), void *userdata,
-    DBusPendingCall **pending);
+    DBusPendingCall **pending, int timeout);
 
 bool pcmk_dbus_find_error(const char *method, DBusPendingCall* pending, DBusMessage *reply, DBusError *error);
 

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -138,7 +138,7 @@ systemd_daemon_reload_complete(DBusPendingCall *pending, void *user_data)
 }
 
 static bool
-systemd_daemon_reload(void)
+systemd_daemon_reload(int timeout)
 {
     static unsigned int reload_count = 0;
     const char *method = "Reload";
@@ -149,7 +149,7 @@ systemd_daemon_reload(void)
         DBusMessage *msg = systemd_new_method(BUS_NAME".Manager", method);
 
         CRM_ASSERT(msg != NULL);
-        pcmk_dbus_send(msg, systemd_proxy, systemd_daemon_reload_complete, GUINT_TO_POINTER(reload_count));
+        pcmk_dbus_send(msg, systemd_proxy, systemd_daemon_reload_complete, GUINT_TO_POINTER(reload_count), timeout);
         dbus_message_unref(msg);
     }
     return TRUE;
@@ -236,7 +236,7 @@ systemd_unit_by_name(const gchar * arg_name, svc_action_t *op)
         DBusError error;
 
         dbus_error_init(&error);
-        reply = pcmk_dbus_send_recv(msg, systemd_proxy, &error);
+        reply = pcmk_dbus_send_recv(msg, systemd_proxy, &error, op? op->timeout : DBUS_TIMEOUT_USE_DEFAULT);
         dbus_message_unref(msg);
 
         unit = systemd_loadunit_result(reply, op);
@@ -249,7 +249,7 @@ systemd_unit_by_name(const gchar * arg_name, svc_action_t *op)
         return munit;
     }
 
-    pcmk_dbus_send(msg, systemd_proxy, systemd_loadunit_cb, op);
+    pcmk_dbus_send(msg, systemd_proxy, systemd_loadunit_cb, op, op? op->timeout : DBUS_TIMEOUT_USE_DEFAULT);
     dbus_message_unref(msg);
     return NULL;
 }
@@ -281,7 +281,7 @@ systemd_unit_listall(void)
     msg = systemd_new_method(BUS_NAME".Manager", method);
     CRM_ASSERT(msg != NULL);
 
-    reply = pcmk_dbus_send_recv(msg, systemd_proxy, &error);
+    reply = pcmk_dbus_send_recv(msg, systemd_proxy, &error, DBUS_TIMEOUT_USE_DEFAULT);
     dbus_message_unref(msg);
 
     if(error.name) {
@@ -355,7 +355,7 @@ systemd_unit_exists(const char *name)
 }
 
 static char *
-systemd_unit_metadata(const char *name)
+systemd_unit_metadata(const char *name, int timeout)
 {
     char *meta = NULL;
     char *desc = NULL;
@@ -363,7 +363,7 @@ systemd_unit_metadata(const char *name)
 
     if (path) {
         /* TODO: Worth a making blocking call for? Probably not. Possibly if cached. */
-        desc = pcmk_dbus_get_property(systemd_proxy, BUS_NAME, path, BUS_NAME ".Unit", "Description", NULL, NULL, NULL);
+        desc = pcmk_dbus_get_property(systemd_proxy, BUS_NAME, path, BUS_NAME ".Unit", "Description", NULL, NULL, NULL, timeout);
     } else {
         desc = crm_strdup_printf("Systemd unit file for %s", name);
     }
@@ -530,7 +530,7 @@ systemd_unit_exec_with_unit(svc_action_t * op, const char *unit)
         state = pcmk_dbus_get_property(systemd_proxy, BUS_NAME, unit,
                                        BUS_NAME ".Unit", "ActiveState",
                                        op->synchronous?NULL:systemd_unit_check,
-                                       op, op->synchronous?NULL:&pending);
+                                       op, op->synchronous?NULL:&pending, op->timeout);
         if (op->synchronous) {
             systemd_unit_check("ActiveState", state, op);
             free(state);
@@ -578,7 +578,7 @@ systemd_unit_exec_with_unit(svc_action_t * op, const char *unit)
             fflush(file_strm);
             fclose(file_strm);
         }
-        systemd_daemon_reload();
+        systemd_daemon_reload(op->timeout);
         free(override_file);
         free(override_dir);
 
@@ -588,7 +588,7 @@ systemd_unit_exec_with_unit(svc_action_t * op, const char *unit)
         method = "StopUnit";
         unlink(override_file);
         free(override_file);
-        systemd_daemon_reload();
+        systemd_daemon_reload(op->timeout);
 
     } else if (g_strcmp0(method, "restart") == 0) {
         method = "RestartUnit";
@@ -615,7 +615,7 @@ systemd_unit_exec_with_unit(svc_action_t * op, const char *unit)
     }
 
     if (op->synchronous == FALSE) {
-        DBusPendingCall* pending = pcmk_dbus_send(msg, systemd_proxy, systemd_async_dispatch, op);
+        DBusPendingCall* pending = pcmk_dbus_send(msg, systemd_proxy, systemd_async_dispatch, op, op->timeout);
 
         dbus_message_unref(msg);
         if(pending) {
@@ -628,7 +628,7 @@ systemd_unit_exec_with_unit(svc_action_t * op, const char *unit)
     } else {
         DBusError error;
 
-        reply = pcmk_dbus_send_recv(msg, systemd_proxy, &error);
+        reply = pcmk_dbus_send_recv(msg, systemd_proxy, &error, op->timeout);
         dbus_message_unref(msg);
         systemd_exec_result(reply, op);
 
@@ -672,7 +672,7 @@ systemd_unit_exec(svc_action_t * op)
 
     if (safe_str_eq(op->action, "meta-data")) {
         /* TODO: See if we can teach the lrmd not to make these calls synchronously */
-        op->stdout_data = systemd_unit_metadata(op->agent);
+        op->stdout_data = systemd_unit_metadata(op->agent, op->timeout);
         op->rc = PCMK_OCF_OK;
 
         if (op->synchronous == FALSE) {

--- a/lib/services/upstart.c
+++ b/lib/services/upstart.c
@@ -77,7 +77,7 @@ upstart_cleanup(void)
 }
 
 static gboolean
-upstart_job_by_name(const gchar * arg_name, gchar ** out_unit)
+upstart_job_by_name(const gchar * arg_name, gchar ** out_unit, int timeout)
 {
 /*
   com.ubuntu.Upstart0_6.GetJobByName (in String name, out ObjectPath job)
@@ -97,7 +97,7 @@ upstart_job_by_name(const gchar * arg_name, gchar ** out_unit)
 
     dbus_error_init(&error);
     CRM_LOG_ASSERT(dbus_message_append_args(msg, DBUS_TYPE_STRING, &arg_name, DBUS_TYPE_INVALID));
-    reply = pcmk_dbus_send_recv(msg, upstart_proxy, &error);
+    reply = pcmk_dbus_send_recv(msg, upstart_proxy, &error, timeout);
     dbus_message_unref(msg);
 
     if(error.name) {
@@ -190,7 +190,7 @@ upstart_job_listall(void)
                                        method); // method name
     CRM_ASSERT(msg != NULL);
 
-    reply = pcmk_dbus_send_recv(msg, upstart_proxy, &error);
+    reply = pcmk_dbus_send_recv(msg, upstart_proxy, &error, DBUS_TIMEOUT_USE_DEFAULT);
     dbus_message_unref(msg);
 
     if(error.name) {
@@ -246,11 +246,11 @@ upstart_job_listall(void)
 gboolean
 upstart_job_exists(const char *name)
 {
-    return upstart_job_by_name(name, NULL);
+    return upstart_job_by_name(name, NULL, DBUS_TIMEOUT_USE_DEFAULT);
 }
 
 static char *
-get_first_instance(const gchar * job)
+get_first_instance(const gchar * job, int timeout)
 {
     char *instance = NULL;
     const char *method = "GetAllInstances";
@@ -268,7 +268,7 @@ get_first_instance(const gchar * job)
     CRM_ASSERT(msg != NULL);
 
     dbus_message_append_args(msg, DBUS_TYPE_INVALID);
-    reply = pcmk_dbus_send_recv(msg, upstart_proxy, &error);
+    reply = pcmk_dbus_send_recv(msg, upstart_proxy, &error, timeout);
     dbus_message_unref(msg);
 
     if(error.name) {
@@ -451,7 +451,7 @@ upstart_job_exec(svc_action_t * op, gboolean synchronous)
         goto cleanup;
     }
 
-    if(!upstart_job_by_name(op->agent, &job)) {
+    if(!upstart_job_by_name(op->agent, &job, op->timeout)) {
         crm_debug("Could not obtain job named '%s' to %s", op->agent, action);
         if (!g_strcmp0(action, "stop")) {
             op->rc = PCMK_OCF_OK;
@@ -465,7 +465,7 @@ upstart_job_exec(svc_action_t * op, gboolean synchronous)
 
     if (safe_str_eq(op->action, "monitor") || safe_str_eq(action, "status")) {
 
-        char *path = get_first_instance(job);
+        char *path = get_first_instance(job, op->timeout);
 
         op->rc = PCMK_OCF_NOT_RUNNING;
         if(path) {
@@ -473,7 +473,7 @@ upstart_job_exec(svc_action_t * op, gboolean synchronous)
             char *state = pcmk_dbus_get_property(
                 upstart_proxy, BUS_NAME, path, UPSTART_06_API ".Instance", "state",
                 op->synchronous?NULL:upstart_job_check, op,
-                op->synchronous?NULL:&pending);
+                op->synchronous?NULL:&pending, op->timeout);
 
             free(job);
             free(path);
@@ -523,7 +523,7 @@ upstart_job_exec(svc_action_t * op, gboolean synchronous)
     CRM_LOG_ASSERT(dbus_message_append_args(msg, DBUS_TYPE_BOOLEAN, &arg_wait, DBUS_TYPE_INVALID));
 
     if (op->synchronous == FALSE) {
-        DBusPendingCall* pending = pcmk_dbus_send(msg, upstart_proxy, upstart_async_dispatch, op);
+        DBusPendingCall* pending = pcmk_dbus_send(msg, upstart_proxy, upstart_async_dispatch, op, op->timeout);
         free(job);
 
         if(pending) {
@@ -535,7 +535,7 @@ upstart_job_exec(svc_action_t * op, gboolean synchronous)
     }
 
     dbus_error_init(&error);
-    reply = pcmk_dbus_send_recv(msg, upstart_proxy, &error);
+    reply = pcmk_dbus_send_recv(msg, upstart_proxy, &error, op->timeout);
 
     if(error.name) {
         if(!upstart_mask_error(op, error.name)) {


### PR DESCRIPTION
The reply timeout of dbus defaults to 25 seconds. That's not sufficient
in case the system is under high load. This commit uses operation timeout
for dbus reply timeout instead.

Does it make sense?