### PR TITLE
Fix: systemd: No need to trigger assert if cannot obtain an unit

### DIFF
--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -514,8 +514,6 @@ systemd_unit_exec_with_unit(svc_action_t * op, const char *unit)
     DBusMessage *msg = NULL;
     DBusMessage *reply = NULL;
 
-    CRM_ASSERT(unit);
-
     if (unit == NULL) {
         crm_debug("Could not obtain unit named '%s'", op->agent);
         op->rc = PCMK_OCF_NOT_INSTALLED;


### PR DESCRIPTION
Given that it'll be dealt with in the following logic:

    if (unit == NULL) {
        crm_debug("Could not obtain unit named '%s'", op->agent);
        op->rc = PCMK_OCF_NOT_INSTALLED;
    ...