### PR TITLE
Peer cache overhaul

### DIFF
--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -773,10 +773,6 @@ attrd_peer_change_cb(enum crm_status_type kind, crm_node_t *peer, const void *da
                 crm_notice("Lost attribute writer %s", peer->uname);
             }
         }
-    } else if (kind == crm_status_processes) {
-        crm_update_peer_state(__FUNCTION__, peer,
-                              is_set(peer->processes, crm_proc_cpg)?
-                              CRM_NODE_MEMBER : CRM_NODE_LOST, 0);
     }
 }
 

--- a/attrd/legacy.c
+++ b/attrd/legacy.c
@@ -769,7 +769,7 @@ attrd_local_callback(xmlNode * msg)
         crm_notice("Sending full refresh (origin=%s)", from);
         g_hash_table_foreach(attr_hash, update_for_hash_entry, NULL);
         return;
-    } else if(safe_str_eq(op, "peer-remove")) {
+    } else if (safe_str_eq(op, ATTRD_OP_PEER_REMOVE)) {
         /* The legacy code didn't understand this command - swallow silently */
         return;
     }

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -342,7 +342,7 @@ main(int argc, char **argv)
     attrd_cluster->cpg.cpg_deliver_fn = attrd_cpg_dispatch;
     attrd_cluster->cpg.cpg_confchg_fn = pcmk_cpg_membership;
 
-    crm_set_status_callback(attrd_peer_change_cb);
+    crm_set_status_callback(&attrd_peer_change_cb);
 
     if (crm_cluster_connect(attrd_cluster) == FALSE) {
         crm_err("Cluster connection failed");

--- a/cib/main.c
+++ b/cib/main.c
@@ -426,7 +426,8 @@ cib_peer_update_callback(enum crm_status_type type, crm_node_t * node, const voi
         crm_update_peer_state(__FUNCTION__, node, is_set(node->processes, crm_proc_cpg)?CRM_NODE_MEMBER:CRM_NODE_LOST, 0);
     }
 
-    if (type == crm_status_processes && legacy_mode && is_not_set(node->processes, crm_proc_cpg)) {
+    if ((type == crm_status_processes) && legacy_mode
+        && is_not_set(node->processes, crm_get_cluster_proc())) {
         uint32_t old = 0;
 
         if (data) {

--- a/cib/main.c
+++ b/cib/main.c
@@ -422,10 +422,6 @@ cib_cs_destroy(gpointer user_data)
 static void
 cib_peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *data)
 {
-    if (type == crm_status_processes) {
-        crm_update_peer_state(__FUNCTION__, node, is_set(node->processes, crm_proc_cpg)?CRM_NODE_MEMBER:CRM_NODE_LOST, 0);
-    }
-
     if ((type == crm_status_processes) && legacy_mode
         && is_not_set(node->processes, crm_get_cluster_proc())) {
         uint32_t old = 0;
@@ -443,11 +439,6 @@ cib_peer_update_callback(enum crm_status_type type, crm_node_t * node, const voi
     if (cib_shutdown_flag && crm_active_peers() < 2 && crm_hash_table_size(client_connections) == 0) {
         crm_info("No more peers");
         terminate_cib(__FUNCTION__, FALSE);
-    }
-
-    if(type == crm_status_nstate && node->id && safe_str_eq(node->state, CRM_NODE_LOST)) {
-        /* Avoid conflicts, keep the membership list to active members */
-        reap_crm_member(node->id, NULL);
     }
 }
 

--- a/crmd/callbacks.c
+++ b/crmd/callbacks.c
@@ -99,6 +99,8 @@ crmd_ha_msg_filter(xmlNode * msg)
     trigger_fsa(fsa_source);
 }
 
+#define state_text(state) ((state)? (const char *)(state) : "in unknown state")
+
 void
 peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *data)
 {
@@ -115,13 +117,15 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
     switch (type) {
         case crm_status_uname:
             /* If we've never seen the node, then it also wont be in the status section */
-            crm_info("%s is now %s", node->uname, node->state);
+            crm_info("%s is now %s", node->uname, state_text(node->state));
             return;
         case crm_status_rstate:
-            crm_info("Remote node %s is now %s (was %s)", node->uname, node->state, (const char *)data);
+            crm_info("Remote node %s is now %s (was %s)",
+                     node->uname, state_text(node->state), state_text(data));
             /* Keep going */
         case crm_status_nstate:
-            crm_info("%s is now %s (was %s)", node->uname, node->state, (const char *)data);
+            crm_info("%s is now %s (was %s)",
+                     node->uname, state_text(node->state), state_text(data));
             if (safe_str_eq(data, node->state)) {
                 /* State did not change */
                 return;

--- a/crmd/control.c
+++ b/crmd/control.c
@@ -86,6 +86,7 @@ do_ha_control(long long action,
 
     if (action & A_HA_CONNECT) {
         crm_set_status_callback(&peer_update_callback);
+        crm_set_autoreap(FALSE);
 
         if (is_openais_cluster()) {
 #if SUPPORT_COROSYNC

--- a/crmd/membership.h
+++ b/crmd/membership.h
@@ -1,7 +1,8 @@
+#include <crm/cluster/internal.h>
 
 void reap_dead_ccm_nodes(gpointer key, gpointer value, gpointer user_data);
 void post_cache_update(int instance);
 
 extern gboolean check_join_state(enum crmd_fsa_state cur_state, const char *source);
 
-#define proc_flags (crm_proc_crmd | crm_proc_cpg)
+#define proc_flags (crm_proc_crmd | crm_get_cluster_proc())

--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -1918,7 +1918,7 @@ bool fencing_peer_active(crm_node_t *peer)
         return FALSE;
     } else if (peer->uname == NULL) {
         return FALSE;
-    } else if(peer->processes & (crm_proc_plugin | crm_proc_heartbeat | crm_proc_cpg)) {
+    } else if (is_set(peer->processes, crm_get_cluster_proc())) {
         return TRUE;
     }
     return FALSE;

--- a/fencing/main.c
+++ b/fencing/main.c
@@ -1195,30 +1195,33 @@ struct qb_ipcs_service_handlers ipc_callbacks = {
     .connection_destroyed = st_ipc_destroy
 };
 
+/*!
+ * \internal
+ * \brief Callback for peer status changes
+ *
+ * \param[in] type  What changed
+ * \param[in] node  What peer had the change
+ * \param[in] data  Previous value of what changed
+ */
 static void
 st_peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *data)
 {
-    xmlNode *query = NULL;
+    if (type == crm_status_uname) {
+        /*
+         * This is a hack until we can send to a nodeid and/or we fix node name lookups
+         * These messages are ignored in stonith_peer_callback()
+         */
+        xmlNode *query = query = create_xml_node(NULL, "stonith_command");
 
-    if (type == crm_status_processes) {
-        crm_update_peer_state(__FUNCTION__, node, is_set(node->processes, crm_proc_cpg)?CRM_NODE_MEMBER:CRM_NODE_LOST, 0);
-        return;
+        crm_xml_add(query, F_XML_TAGNAME, "stonith_command");
+        crm_xml_add(query, F_TYPE, T_STONITH_NG);
+        crm_xml_add(query, F_STONITH_OPERATION, "poke");
+
+        crm_debug("Broadcasting our uname because of node %u", node->id);
+        send_cluster_message(NULL, crm_msg_stonith_ng, query, FALSE);
+
+        free_xml(query);
     }
-
-    /*
-     * This is a hack until we can send to a nodeid and/or we fix node name lookups
-     * These messages are ignored in stonith_peer_callback()
-     */
-    query = create_xml_node(NULL, "stonith_command");
-
-    crm_xml_add(query, F_XML_TAGNAME, "stonith_command");
-    crm_xml_add(query, F_TYPE, T_STONITH_NG);
-    crm_xml_add(query, F_STONITH_OPERATION, "poke");
-
-    crm_debug("Broadcasting our uname because of node %u", node->id);
-    send_cluster_message(NULL, crm_msg_stonith_ng, query, FALSE);
-
-    free_xml(query);
 }
 
 int

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -199,6 +199,7 @@ enum crm_status_type {
 
 enum crm_ais_msg_types text2msg_type(const char *text);
 void crm_set_status_callback(void (*dispatch) (enum crm_status_type, crm_node_t *, const void *));
+void crm_set_autoreap(gboolean autoreap);
 
 /* *INDENT-OFF* */
 enum cluster_type_e

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -448,17 +448,17 @@ int get_corosync_id(int id, const char *uuid);
 char *get_corosync_uuid(crm_node_t *peer);
 enum crm_quorum_source get_quorum_source(void);
 
-void crm_update_peer_proc(const char *source, crm_node_t * peer, uint32_t flag, const char *status);
-
-crm_node_t *crm_update_peer(const char *source, unsigned int id, uint64_t born, uint64_t seen,
-                            int32_t votes, uint32_t children, const char *uuid, const char *uname,
+crm_node_t *crm_update_peer(const char *source, unsigned int id, uint64_t born,
+                            uint64_t seen, int32_t votes, uint32_t children,
+                            const char *uuid, const char *uname,
                             const char *addr, const char *state);
+crm_node_t *crm_update_peer_proc(const char *source, crm_node_t * peer,
+                                 uint32_t flag, const char *status);
+crm_node_t *crm_update_peer_state(const char *source, crm_node_t * node,
+                                  const char *state, int membership);
 
 void crm_update_peer_expected(const char *source, crm_node_t * node, const char *expected);
-void crm_update_peer_state(const char *source, crm_node_t * node, const char *state,
-                           int membership);
 void crm_reap_unseen_nodes(uint64_t ring_id);
-
 
 gboolean init_cman_connection(gboolean(*dispatch) (unsigned long long, gboolean),
                               void (*destroy) (gpointer));

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -102,13 +102,38 @@ enum crm_proc_flag {
 };
 /* *INDENT-ON* */
 
+/*!
+ * \internal
+ * \brief Return the process bit corresponding to the current cluster stack
+ *
+ * \return Process flag if detectable, otherwise 0
+ */
+static inline uint32_t
+crm_get_cluster_proc()
+{
+    switch (get_cluster_type()) {
+        case pcmk_cluster_corosync:
+        case pcmk_cluster_cman:
+            return crm_proc_cpg;
+
+        case pcmk_cluster_heartbeat:
+            return crm_proc_heartbeat;
+
+        case pcmk_cluster_classic_ais:
+            return crm_proc_plugin;
+
+        default:
+            break;
+    }
+    return crm_proc_none;
+}
+
 static inline const char *
 peer2text(enum crm_proc_flag proc)
 {
     const char *text = "unknown";
 
-    if (proc == (crm_proc_cpg | crm_proc_crmd)
-    ||  proc == (crm_proc_heartbeat | crm_proc_crmd)) {
+    if (proc == (crm_proc_crmd | crm_get_cluster_proc())) {
         return "peer";
     }
 

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -457,6 +457,8 @@ crm_node_t *crm_update_peer(const char *source, unsigned int id, uint64_t born, 
 void crm_update_peer_expected(const char *source, crm_node_t * node, const char *expected);
 void crm_update_peer_state(const char *source, crm_node_t * node, const char *state,
                            int membership);
+void crm_reap_unseen_nodes(uint64_t ring_id);
+
 
 gboolean init_cman_connection(gboolean(*dispatch) (unsigned long long, gboolean),
                               void (*destroy) (gpointer));

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -395,7 +395,7 @@ pcmk_cpg_membership(cpg_handle_t handle,
          * But its _not_ safe to assume its in the quorum membership.
          * We may have just found out its dead and are processing the last couple of messages it sent
          */
-        crm_update_peer_proc(__FUNCTION__, peer, crm_proc_cpg, ONLINESTATUS);
+        peer = crm_update_peer_proc(__FUNCTION__, peer, crm_proc_cpg, ONLINESTATUS);
         if(peer && peer->state && crm_is_peer_active(peer) == FALSE) {
             time_t now = time(NULL);
 
@@ -410,8 +410,9 @@ pcmk_cpg_membership(cpg_handle_t handle,
                  * Set the threshold to 1 minute
                  */
                 crm_err("Node %s[%u] appears to be online even though we think it is dead", peer->uname, peer->id);
-                crm_update_peer_state(__FUNCTION__, peer, CRM_NODE_MEMBER, 0);
-                peer->votes = 0;
+                if (crm_update_peer_state(__FUNCTION__, peer, CRM_NODE_MEMBER, 0)) {
+                    peer->votes = 0;
+                }
             }
         }
 

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -369,20 +369,27 @@ pcmk_cpg_membership(cpg_handle_t handle,
     uint32_t local_nodeid = get_local_nodeid(handle);
 
     for (i = 0; i < left_list_entries; i++) {
-        crm_node_t *peer = crm_get_peer(left_list[i].nodeid, NULL);
+        crm_node_t *peer = crm_find_peer(left_list[i].nodeid, NULL);
 
-        crm_info("Left[%d.%d] %s.%u ", counter, i, groupName->value, left_list[i].nodeid);
-        crm_update_peer_proc(__FUNCTION__, peer, crm_proc_cpg, OFFLINESTATUS);
+        crm_info("Node %u left group %s (peer=%s, counter=%d.%d)",
+                 left_list[i].nodeid, groupName->value,
+                 (peer? peer->uname : "<none>"), counter, i);
+        if (peer) {
+            crm_update_peer_proc(__FUNCTION__, peer, crm_proc_cpg, OFFLINESTATUS);
+        }
     }
 
     for (i = 0; i < joined_list_entries; i++) {
-        crm_info("Joined[%d.%d] %s.%u ", counter, i, groupName->value, joined_list[i].nodeid);
+        crm_info("Node %u joined group %s (counter=%d.%d)",
+                 joined_list[i].nodeid, groupName->value, counter, i);
     }
 
     for (i = 0; i < member_list_entries; i++) {
         crm_node_t *peer = crm_get_peer(member_list[i].nodeid, NULL);
 
-        crm_info("Member[%d.%d] %s.%u ", counter, i, groupName->value, member_list[i].nodeid);
+        crm_info("Node %u still member of group %s (peer=%s, counter=%d.%d)",
+                 member_list[i].nodeid, groupName->value,
+                 (peer? peer->uname : "<none>"), counter, i);
 
         /* Anyone that is sending us CPG messages must also be a _CPG_ member.
          * But its _not_ safe to assume its in the quorum membership.

--- a/lib/cluster/heartbeat.c
+++ b/lib/cluster/heartbeat.c
@@ -373,9 +373,12 @@ crm_update_ccm_node(const oc_ev_membership_t * oc, int offset, const char *state
     peer = crm_get_peer(0, oc->m_array[offset].node_uname);
     uuid = crm_peer_uuid(peer);
 
-    crm_update_peer(__FUNCTION__, oc->m_array[offset].node_id,
+    peer = crm_update_peer(__FUNCTION__, oc->m_array[offset].node_id,
                            oc->m_array[offset].node_born_on, seq, -1, 0,
                            uuid, oc->m_array[offset].node_uname, NULL, state);
+    if (peer == NULL) {
+        return NULL;
+    }
 
     if (safe_str_eq(CRM_NODE_MEMBER, state)) {
         /* Heartbeat doesn't send status notifications for nodes that were already part of the cluster.
@@ -389,11 +392,11 @@ crm_update_ccm_node(const oc_ev_membership_t * oc, int offset, const char *state
         if (safe_str_eq(const_uname, peer->uname)) {
             flags |= this_proc;
         }
-        crm_update_peer_proc(__FUNCTION__, peer, flags, ONLINESTATUS);
+        peer = crm_update_peer_proc(__FUNCTION__, peer, flags, ONLINESTATUS);
     } else {
         /* crm_update_peer_proc(__FUNCTION__, peer, crm_proc_heartbeat, OFFLINESTATUS); */
         /* heartbeat may well be still alive. peer client process apparently vanished, though ... */
-        crm_update_peer_proc(__FUNCTION__, peer, this_proc, OFFLINESTATUS);
+        peer = crm_update_peer_proc(__FUNCTION__, peer, this_proc, OFFLINESTATUS);
     }
     return peer;
 }

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -482,8 +482,8 @@ crm_get_peer(unsigned int id, const char *uname)
     }
 
     if (uname_lookup) {
-        crm_trace("Inferred a name of '%s' for node %u", uname, id);
         uname = uname_lookup;
+        crm_trace("Inferred a name of '%s' for node %u", uname, id);
 
         /* try to turn up the node one more time now that we know the uname. */
         if (node == NULL) {

--- a/mcp/pacemaker.c
+++ b/mcp/pacemaker.c
@@ -551,14 +551,18 @@ struct qb_ipcs_service_handlers mcp_ipc_callbacks = {
     .connection_destroyed = pcmk_ipc_destroy
 };
 
+/*!
+ * \internal
+ * \brief Send an XML message with process list of all known peers to client(s)
+ *
+ * \param[in] client  Send message to this client, or all clients if NULL
+ */
 void
 update_process_clients(crm_client_t *client)
 {
     GHashTableIter iter;
     crm_node_t *node = NULL;
     xmlNode *update = create_xml_node(NULL, "nodes");
-
-    crm_trace("Sending process list to %d children", crm_hash_table_size(client_connections));
 
     g_hash_table_iter_init(&iter, crm_peer_cache);
     while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & node)) {
@@ -571,9 +575,11 @@ update_process_clients(crm_client_t *client)
     }
 
     if(client) {
+        crm_trace("Sending process list to client %s", client->id);
         crm_ipcs_send(client, 0, update, crm_ipc_server_event);
 
     } else {
+        crm_trace("Sending process list to %d clients", crm_hash_table_size(client_connections));
         g_hash_table_iter_init(&iter, client_connections);
         while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & client)) {
             crm_ipcs_send(client, 0, update, crm_ipc_server_event);
@@ -583,6 +589,10 @@ update_process_clients(crm_client_t *client)
     free_xml(update);
 }
 
+/*!
+ * \internal
+ * \brief Send a CPG message with local node's process list to all peers
+ */
 void
 update_process_peers(void)
 {
@@ -608,6 +618,16 @@ update_process_peers(void)
     send_cpg_iov(iov);
 }
 
+/*!
+ * \internal
+ * \brief Update a node's process list, notifying clients and peers if needed
+ *
+ * \param[in] id     Node ID of affected node
+ * \param[in] uname  Uname of affected node
+ * \param[in] procs  Affected node's process list mask
+ *
+ * \return TRUE if the process list changed, FALSE otherwise
+ */
 gboolean
 update_node_processes(uint32_t id, const char *uname, uint32_t procs)
 {
@@ -621,14 +641,15 @@ update_node_processes(uint32_t id, const char *uname, uint32_t procs)
             node->processes = procs;
             changed = TRUE;
 
+            /* If local node's processes have changed, notify clients/peers */
+            if (id == local_nodeid) {
+                update_process_clients(NULL);
+                update_process_peers();
+            }
+
         } else {
             crm_trace("Node %s still has process list: %.32x", node->uname, procs);
         }
-    }
-
-    if (changed && id == local_nodeid) {
-        update_process_clients(NULL);
-        update_process_peers();
     }
     return changed;
 }
@@ -810,6 +831,17 @@ mcp_cpg_destroy(gpointer user_data)
     crm_exit(ENOTCONN);
 }
 
+/*!
+ * \internal
+ * \brief Process a CPG message (process list or manual peer cache removal)
+ *
+ * \param[in] handle     CPG connection (ignored)
+ * \param[in] groupName  CPG group name (ignored)
+ * \param[in] nodeid     ID of affected node
+ * \param[in] pid        Process ID (ignored)
+ * \param[in] msg        CPG XML message
+ * \param[in] msg_len    Length of msg in bytes (ignored)
+ */
 static void
 mcp_cpg_deliver(cpg_handle_t handle,
                  const struct cpg_name *groupName,
@@ -818,15 +850,20 @@ mcp_cpg_deliver(cpg_handle_t handle,
     xmlNode *xml = string2xml(msg);
     const char *task = crm_element_value(xml, F_CRM_TASK);
 
-    crm_trace("Received %s %.200s", task, msg);
-    if (task == NULL && nodeid != local_nodeid) {
-        uint32_t procs = 0;
-        const char *uname = crm_element_value(xml, "uname");
+    crm_trace("Received CPG message (%s): %.200s",
+              (task? task : "process list"), msg);
 
-        crm_element_value_int(xml, "proclist", (int *)&procs);
-        /* crm_debug("Got proclist %.32x from %s", procs, uname); */
-        if (update_node_processes(nodeid, uname, procs)) {
-            update_process_clients(NULL);
+    if (task == NULL) {
+        if (nodeid == local_nodeid) {
+            crm_info("Ignoring process list sent by peer for local node");
+        } else {
+            uint32_t procs = 0;
+            const char *uname = crm_element_value(xml, "uname");
+
+            crm_element_value_int(xml, "proclist", (int *)&procs);
+            if (update_node_processes(nodeid, uname, procs)) {
+                update_process_clients(NULL);
+            }
         }
 
     } else if (crm_str_eq(task, CRM_OP_RM_NODE_CACHE, TRUE)) {

--- a/mcp/pacemaker.c
+++ b/mcp/pacemaker.c
@@ -883,7 +883,12 @@ mcp_cpg_membership(cpg_handle_t handle,
                     const struct cpg_address *left_list, size_t left_list_entries,
                     const struct cpg_address *joined_list, size_t joined_list_entries)
 {
-    /* Don't care about CPG membership, but we do want to broadcast our own presence */
+    /* Update peer cache if needed */
+    pcmk_cpg_membership(handle, groupName, member_list, member_list_entries,
+                        left_list, left_list_entries,
+                        joined_list, joined_list_entries);
+
+    /* Always broadcast our own presence after any membership change */
     update_process_peers();
 }
 

--- a/mcp/pacemaker.c
+++ b/mcp/pacemaker.c
@@ -105,11 +105,7 @@ static uint32_t
 get_process_list(void)
 {
     int lpc = 0;
-    uint32_t procs = 0;
-
-    if(is_classic_ais_cluster()) {
-        procs |= crm_proc_plugin;
-    }
+    uint32_t procs = crm_get_cluster_proc();
 
     for (lpc = 0; lpc < SIZEOF(pcmk_children); lpc++) {
         if (pcmk_children[lpc].pid != 0) {

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -183,7 +183,7 @@ int tools_remove_node_cache(const char *node, const char *target)
         crm_xml_add(cmd, F_TYPE, T_ATTRD);
         crm_xml_add(cmd, F_ORIG, crm_system_name);
 
-        crm_xml_add(cmd, F_ATTRD_TASK, "peer-remove");
+        crm_xml_add(cmd, F_ATTRD_TASK, ATTRD_OP_PEER_REMOVE);
         crm_xml_add(cmd, F_ATTRD_HOST, name);
 
         if (n) {


### PR DESCRIPTION
These revisions fix RHBZ#1193499 (the "member weirdness" issue) by overhauling peer cache management. Rather than being managed by each daemon's callback, the caches are managed by libcluster automatically, ensuring that exiting nodes are removed from the cache. This incidentally fixes a number of other minor issues, including potential use-after-free bugs, a potential iterator invalidation bug, and incorrect log messages.