### PR TITLE
serialize rsc execution within service library

### DIFF
--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -129,6 +129,7 @@ dummy_stop() {
     if [ $? =  $OCF_SUCCESS ]; then
 	rm ${OCF_RESKEY_state}
     fi
+    rm ${VERIFY_SERIALIZED_FILE}
     return $OCF_SUCCESS
 }
 
@@ -137,10 +138,21 @@ dummy_monitor() {
 	# (SUCCESS), failed (ERROR) or _cleanly_ stopped (NOT RUNNING).
 	# That is THREE states, not just yes/no.
 
-	sleep ${OCF_RESKEY_op_sleep}
+	if [ "$OCF_RESKEY_op_sleep" -ne "0" ]; then
+		if [ -f ${VERIFY_SERIALIZED_FILE} ]; then
+			# two monitor ops have occurred at the same time.
+			# this is to verify a condition in the lrmd regression tests.
+			ocf_log err "$VERIFY_SERIALIZED_FILE exists already"
+			return $OCF_ERR_GENERIC
+		fi
+
+		touch ${VERIFY_SERIALIZED_FILE}
+		sleep ${OCF_RESKEY_op_sleep}
+		rm ${VERIFY_SERIALIZED_FILE}
+	fi
 	
 	if [ -f ${OCF_RESKEY_state} ]; then
-	    return $OCF_SUCCESS
+		return $OCF_SUCCESS
 	fi
 	if false ; then
 		return $OCF_ERR_GENERIC
@@ -176,6 +188,7 @@ if [ "x$OCF_RESKEY_state" = "x" ]; then
 	OCF_RESKEY_state="${HA_VARRUN}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
     fi
 fi
+VERIFY_SERIALIZED_FILE="${OCF_RESKEY_state}.serialized"
 
 case $__OCF_ACTION in
 meta-data)	meta_data

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -47,6 +47,9 @@
 #  include "crm/common/cib_secrets.h"
 #endif
 
+/* ops currently active (in-flight) */
+extern GList *inflight_ops;
+
 static inline void
 set_fd_opts(int fd, int opts)
 {
@@ -255,6 +258,10 @@ operation_finalize(svc_action_t * op)
     }
 
     op->pid = 0;
+
+    inflight_ops = g_list_remove(inflight_ops, op);
+
+    handle_blocked_ops();
 
     if (!recurring && op->synchronous == FALSE) {
         /*

--- a/lib/services/services_private.h
+++ b/lib/services/services_private.h
@@ -59,4 +59,8 @@ gboolean cancel_recurring_action(svc_action_t * op);
 gboolean recurring_action_timer(gpointer data);
 gboolean operation_finalize(svc_action_t * op);
 
+void handle_blocked_ops(void);
+
+gboolean is_op_blocked(const char *rsc);
+
 #endif                          /* __MH_SERVICES_PRIVATE_H__ */

--- a/lrmd/regression.py.in
+++ b/lrmd/regression.py.in
@@ -777,8 +777,8 @@ if __name__ == "__main__":
 	### stress tests ###
 	def build_stress_tests(self):
 		timeout = "-t 20000"
-		iterations = 25
 
+		iterations = 25
 		test = self.new_test("ocf_stress", "Verify systemd dbus connection works under load")
 		for i in range(iterations):
 			test.add_cmd("-c register_rsc -r rsc_%s %s -C ocf -P heartbeat -T Dummy -l \"NEW_EVENT event_type:register rsc_id:rsc_%s action:none rc:ok op_status:complete\"" % (i, timeout, i))
@@ -800,9 +800,23 @@ if __name__ == "__main__":
 				test.add_cmd("-c exec -r rsc_%s -a stop %s -l \"NEW_EVENT event_type:exec_complete rsc_id:rsc_%s action:stop rc:ok op_status:complete\"" % (i, timeout, i))
 				test.add_cmd("-c unregister_rsc -r rsc_%s %s -l \"NEW_EVENT event_type:unregister rsc_id:rsc_%s action:none rc:ok op_status:complete\"" % (i, timeout, i))
 
+		iterations = 9
+		timeout = "-t 30000"
+		### Verify recurring op in-flight collision is handled in series properly
+		test = self.new_test("rsc_inflight_collision", "Verify recurring ops do not collide with other operations for the same rsc.")
+		test.add_cmd("-c register_rsc -r test_rsc -P pacemaker -C ocf -T Dummy "
+			"-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" "+self.action_timeout)
+		test.add_cmd("-c exec -r test_rsc -a start %s -k op_sleep -v 1 -l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\"" % (timeout))
+		for i in range(iterations):
+			test.add_cmd("-c exec -r test_rsc -a monitor %s -i 100%d -k op_sleep -v 2 -l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\"" % (timeout, i))
+#			test.add_sys_cmd("sleep", "-al @CRM_RSCTMP_DIR@")
+
+		test.add_cmd("-c exec -r test_rsc -a stop %s -l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:stop rc:ok op_status:complete\"" % (timeout))
+		test.add_cmd("-c unregister_rsc -r test_rsc %s -l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\"" % (timeout))
 
 	### These are tests that target specific cases ###
 	def build_custom_tests(self):
+
 
 		### verify resource temporary folder is created and used by heartbeat agents.  ###
 		test = self.new_test("rsc_tmp_dir", "Verify creation and use of rsc temporary state directory")


### PR DESCRIPTION
Resource execution is already serialized in the lrmd, but we've seen that once recurring operations are handed off to the service library that monitor and notify actions can collide.

This patch enforces serialized execution of actions within the service library. If actions are being executed for a resource that already has a pending in-flight action in progress, those actions are put into the 'blocking_ops' list. That list is checked every time an operation is finalized allowing blocked ops to be executed immediately once the in flight operation has completed.

I've included a lrmd regression test that exercises this behavior.