### PR TITLE
Fix: lrmd: cancel currently pending STONITH op if stonithd connection is lost

### DIFF
--- a/lrmd/lrmd.c
+++ b/lrmd/lrmd.c
@@ -1061,6 +1061,9 @@ stonith_connection_failed(void)
     g_hash_table_iter_init(&iter, rsc_list);
     while (g_hash_table_iter_next(&iter, (gpointer *) & key, (gpointer *) & rsc)) {
         if (safe_str_eq(rsc->class, "stonith")) {
+            if (rsc->active) {
+                cmd_list = g_list_append(cmd_list, rsc->active);
+            }
             if (rsc->recurring_ops) {
                 cmd_list = g_list_concat(cmd_list, rsc->recurring_ops);
             }


### PR DESCRIPTION
This avoids things like nodes getting killed due to hanging stop operations if a start operation caused stonithd to crash.

I saw and debugged this issue on pacemaker 1.1.10+git20130802-1ubuntu2.3 (Ubuntu Trusty). Although the issue manifests itself there due to another bug that is already fixed, it's a bug in its own right, hence this PR. I don't know of any way to trigger this behavior on the current version of pacemaker short of manually killing stonithd in the middle of an op, but it could theoretically happen if stonithd dies for whatever reason.

This is the sequence of events that triggers the bug, conditional on the (long fixed) bug mentioned in PR #334:
1. lrmd gets a start action, and it becomes rsc->active
2. stonithd times out on the action (e.g. stonith device is broken/hanging)
3. stonithd gets SIGTERMed due to the aforementioned bug
4. lrmd notices and attemps to clean up the pending ops, but misses rsc->active, thus the start op never completes
5. start times out in crmd, it attempts to recover the resource
6. lrmd gets a stop action, and it gets put into rsc->pending_ops
7. lrmd never runs the action since rsc->active is still non-NULL
8. stop times out in crmd and the host gets STONITHed due to a failed stop
   (even though a stonith resource stop is basically a no-op!)