### PR TITLE
Fix: cib: Prevent use-after-free issues when deleting xml nodes with xpath

### DIFF
--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -241,6 +241,7 @@ xmlNode *expand_idref(xmlNode * input, xmlNode * top);
 
 void freeXpathObject(xmlXPathObjectPtr xpathObj);
 xmlNode *getXpathResult(xmlXPathObjectPtr xpathObj, int index);
+void dedupXpathResults(xmlXPathObjectPtr xpathObj);
 
 static inline int numXpathResults(xmlXPathObjectPtr xpathObj)
 {

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -719,6 +719,13 @@ cib_process_xpath(const char *op, int options, const char *section, xmlNode * re
         free(path);
 
         if (safe_str_eq(op, CIB_OP_DELETE)) {
+            if (match == *result_cib) {
+                /* Attempting to delete the whole "/cib" */
+                crm_warn("Cannot perform %s for %s: The xpath is addressing the whole /cib", op, section);
+                rc = -EINVAL;
+                break;
+            }
+
             free_xml(match);
             if ((options & cib_multiple) == 0) {
                 break;

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -702,6 +702,10 @@ cib_process_xpath(const char *op, int options, const char *section, xmlNode * re
         }
     }
 
+    if (safe_str_eq(op, CIB_OP_DELETE) && (options & cib_multiple)) {
+        dedupXpathResults(xpathObj);
+    }
+
     for (lpc = 0; lpc < max; lpc++) {
         xmlChar *path = NULL;
         xmlNode *match = getXpathResult(xpathObj, lpc);

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -5743,6 +5743,43 @@ getXpathResult(xmlXPathObjectPtr xpathObj, int index)
     return match;
 }
 
+void
+dedupXpathResults(xmlXPathObjectPtr xpathObj)
+{
+    int lpc, max = numXpathResults(xpathObj);
+
+    if (xpathObj == NULL) {
+        return;
+    }
+
+    for (lpc = 0; lpc < max; lpc++) {
+        xmlNode *xml = NULL;
+        gboolean dedup = FALSE;
+
+        if (xpathObj->nodesetval->nodeTab[lpc] == NULL) {
+            continue;
+        }
+
+        xml = xpathObj->nodesetval->nodeTab[lpc]->parent;
+
+        for (; xml; xml = xml->parent) {
+            int lpc2 = 0;
+
+            for (lpc2 = 0; lpc2 < max; lpc2++) {
+                if (xpathObj->nodesetval->nodeTab[lpc2] == xml) {
+                    xpathObj->nodesetval->nodeTab[lpc] = NULL;
+                    dedup = TRUE;
+                    break;
+                }
+            }
+
+            if (dedup) {
+                break;
+            }
+        }
+    }
+}
+
 /* the caller needs to check if the result contains a xmlDocPtr or xmlNodePtr */
 xmlXPathObjectPtr
 xpath_search(xmlNode * xml_top, const char *path)


### PR DESCRIPTION
An xpath like "//*[contains(@id,'rsc1')]" or a bad xpath can match xml
nodes that have parent-child relationships among them. That would cause
use-after-free when invoking "cibadmin --delete-all --xpath" with it.

This commit deduplicates xml nodes from xpathObj->nodesetval->nodeTab
as long as any of their parents are also in there.