### PR TITLE
Fix: RA: Prevent an error message on stopping "Dummy" resource

### DIFF
--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -137,7 +137,7 @@ dummy_stop() {
     if [ $? =  $OCF_SUCCESS ]; then
 	rm ${OCF_RESKEY_state}
     fi
-    rm ${VERIFY_SERIALIZED_FILE}
+    rm -f ${VERIFY_SERIALIZED_FILE}
     return $OCF_SUCCESS
 }
 


### PR DESCRIPTION
Prevent the error message on stopping "Dummy" resource:
stderr [ rm: cannot remove '/var/run/Dummy.*.state.serialized': No such file or directory ]