### PR TITLE
Fix memory leaks in CIB callbacks

### DIFF
--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -832,7 +832,6 @@ attrd_cib_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
         }
     }
   done:
-    free(name);
     if(a && a->changed && election_state(writer) == election_won) {
         write_attribute(a);
     }
@@ -1019,8 +1018,10 @@ write_attribute(attribute_t *a)
         crm_info("Sent update %d with %d changes for %s, id=%s, set=%s",
                  a->update, cib_updates, a->id, (a->uuid? a->uuid : "<n/a>"), a->set);
 
-        the_cib->cmds->register_callback(
-            the_cib, a->update, 120, FALSE, strdup(a->id), "attrd_cib_callback", attrd_cib_callback);
+        the_cib->cmds->register_callback_full(the_cib, a->update, 120, FALSE,
+                                              strdup(a->id),
+                                              "attrd_cib_callback",
+                                              attrd_cib_callback, free);
     }
     free_xml(xml_top);
 }

--- a/attrd/legacy.c
+++ b/attrd/legacy.c
@@ -635,6 +635,20 @@ struct attrd_callback_s {
     char *value;
 };
 
+/*
+ * \internal
+ * \brief Free an attrd callback structure
+ */
+static void
+free_attrd_callback(void *user_data)
+{
+    struct attrd_callback_s *data = user_data;
+
+    free(data->attr);
+    free(data->value);
+    free(data);
+}
+
 static void
 attrd_cib_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *user_data)
 {
@@ -646,7 +660,7 @@ attrd_cib_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
 
     } else if (call_id < 0) {
         crm_warn("Update %s=%s failed: %s", data->attr, data->value, pcmk_strerror(call_id));
-        goto cleanup;
+        return;
     }
 
     switch (rc) {
@@ -674,10 +688,6 @@ attrd_cib_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
             crm_err("Update %d for %s=%s failed: %s",
                     call_id, data->attr, data->value, pcmk_strerror(rc));
     }
-  cleanup:
-    free(data->value);
-    free(data->attr);
-    free(data);
 }
 
 void
@@ -749,8 +759,10 @@ attrd_perform_update(attr_hash_entry_t * hash_entry)
     if (hash_entry->value != NULL) {
         data->value = strdup(hash_entry->value);
     }
-    cib_conn->cmds->register_callback(cib_conn, rc, 120, FALSE, data, "attrd_cib_callback",
-                                      attrd_cib_callback);
+    cib_conn->cmds->register_callback_full(cib_conn, rc, 120, FALSE, data,
+                                           "attrd_cib_callback",
+                                           attrd_cib_callback,
+                                           free_attrd_callback);
     return;
 }
 

--- a/crmd/crmd_utils.h
+++ b/crmd/crmd_utils.h
@@ -102,11 +102,14 @@ gboolean too_many_st_failures(void);
 void st_fail_count_reset(const char * target);
 void crmd_peer_down(crm_node_t *peer, bool full);
 
+/* Convenience macro for registering a CIB callback
+ * (assumes that data can be freed with free())
+ */
 #  define fsa_register_cib_callback(id, flag, data, fn) do {            \
     CRM_ASSERT(fsa_cib_conn);                                           \
-    fsa_cib_conn->cmds->register_callback(                              \
+    fsa_cib_conn->cmds->register_callback_full(                         \
             fsa_cib_conn, id, 10 * (1 + crm_active_peers()),            \
-            flag, data, #fn, fn);                                       \
+            flag, data, #fn, fn, free);                                 \
     } while(0)
 
 #  define start_transition(state) do {					\

--- a/crmd/join_client.c
+++ b/crmd/join_client.c
@@ -116,8 +116,8 @@ do_cl_join_offer_respond(long long action,
 
     /* we only ever want the last one */
     if (query_call_id > 0) {
-        /* Calling remove_cib_op_callback() would result in a memory leak of the data field */
         crm_trace("Cancelling previous join query: %d", query_call_id);
+        remove_cib_op_callback(query_call_id, FALSE);
         query_call_id = 0;
     }
 
@@ -173,7 +173,6 @@ join_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *
 
   done:
     free_xml(generation);
-    free(join_id);
 }
 
 /*	A_CL_JOIN_RESULT	*/

--- a/crmd/join_dc.c
+++ b/crmd/join_dc.c
@@ -452,8 +452,6 @@ finalize_sync_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, voi
         crm_debug("No longer the DC in S_FINALIZE_JOIN: %s/%s",
                   AM_I_DC ? "DC" : "CRMd", fsa_state2string(fsa_state));
     }
-
-    free(user_data);
 }
 
 static void

--- a/crmd/membership.c
+++ b/crmd/membership.c
@@ -200,7 +200,6 @@ remove_conflicting_node_callback(xmlNode * msg, int call_id, int rc,
     do_crm_log_unlikely(rc == 0 ? LOG_DEBUG : LOG_NOTICE,
                         "Deletion of the unknown conflicting node \"%s\": %s (rc=%d)",
                         node_uuid, pcmk_strerror(rc), rc);
-    free(node_uuid);
 }
 
 static void
@@ -215,11 +214,9 @@ search_conflicting_node_callback(xmlNode * msg, int call_id, int rc,
             crm_notice("Searching conflicting nodes for %s failed: %s (%d)",
                        new_node_uuid, pcmk_strerror(rc), rc);
         }
-        free(new_node_uuid);
         return;
 
     } else if (output == NULL) {
-        free(new_node_uuid);
         return;
     }
 
@@ -283,8 +280,6 @@ search_conflicting_node_callback(xmlNode * msg, int call_id, int rc,
             free_xml(node_state_xml);
         }
     }
-
-    free(new_node_uuid);
 }
 
 static void

--- a/crmd/pengine.c
+++ b/crmd/pengine.c
@@ -320,9 +320,10 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
         crm_debug("Discarding PE request in state: %s", fsa_state2string(fsa_state));
         return;
 
-    } else if (num_cib_op_callbacks() != 0) {
-        crm_debug("Re-asking for the CIB: %d peer updates still pending", num_cib_op_callbacks());
-
+    /* this callback counts as 1 */
+    } else if (num_cib_op_callbacks() > 1) {
+        crm_debug("Re-asking for the CIB: %d other peer updates still pending",
+                  (num_cib_op_callbacks() - 1));
         sleep(1);
         register_fsa_action(A_PE_INVOKE);
         return;

--- a/crmd/pengine.c
+++ b/crmd/pengine.c
@@ -77,8 +77,6 @@ save_cib_contents(xmlNode * msg, int call_id, int rc, xmlNode * output, void *us
 
         free(filename);
     }
-
-    free(id);
 }
 
 static void

--- a/crmd/te_callbacks.c
+++ b/crmd/te_callbacks.c
@@ -717,7 +717,6 @@ cib_fencing_updated(xmlNode * msg, int call_id, int rc, xmlNode * output, void *
     } else {
         crm_info("Fencing update %d for %s: complete", call_id, (char *)user_data);
     }
-    free(user_data);
 }
 
 void

--- a/crmd/utils.c
+++ b/crmd/utils.c
@@ -999,7 +999,6 @@ erase_xpath_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void 
 
     do_crm_log_unlikely(rc == 0 ? LOG_DEBUG : LOG_NOTICE,
                         "Deletion of \"%s\": %s (rc=%d)", xpath, pcmk_strerror(rc), rc);
-    free(xpath);
 }
 
 void

--- a/include/crm/cib.h
+++ b/include/crm/cib.h
@@ -136,6 +136,13 @@ typedef struct cib_api_operations_s {
                                    void *user_data, const char *callback_name,
                                    void (*callback) (xmlNode *, int, int, xmlNode *, void *));
 
+    gboolean (*register_callback_full)(cib_t *cib, int call_id, int timeout,
+                                       gboolean only_success, void *user_data,
+                                       const char *callback_name,
+                                       void (*callback)(xmlNode *, int, int,
+                                                        xmlNode *, void *),
+                                       void (*free_func)(void *));
+
 } cib_api_operations_t;
 
 struct cib_s {

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -106,7 +106,7 @@ typedef struct cib_callback_client_s {
     void *user_data;
     gboolean only_success;
     struct timer_rec_s *timer;
-
+    void (*free_func)(void *);
 } cib_callback_client_t;
 
 struct timer_rec_s {
@@ -137,6 +137,13 @@ int cib_native_register_notification(cib_t * cib, const char *callback, int enab
 gboolean cib_client_register_callback(cib_t * cib, int call_id, int timeout, gboolean only_success,
                                       void *user_data, const char *callback_name,
                                       void (*callback) (xmlNode *, int, int, xmlNode *, void *));
+gboolean cib_client_register_callback_full(cib_t *cib, int call_id,
+                                           int timeout, gboolean only_success,
+                                           void *user_data,
+                                           const char *callback_name,
+                                           void (*callback)(xmlNode *, int, int,
+                                                            xmlNode *, void *),
+                                           void (*free_func)(void *));
 
 int cib_process_query(const char *op, int options, const char *section, xmlNode * req,
                       xmlNode * input, xmlNode * existing_cib, xmlNode ** result_cib,


### PR DESCRIPTION
Previously, freeing of CIB callback user data was left to the calling application (in the pacemaker code base, it was done in the callbacks themselves). That resulted in leaks when libcib removed callbacks without calling them first (e.g. when a callback for an existing call ID was replaced, or when the entire table was dropped). Now, callers can register a free function with the callback, and libcib will manage the memory.

This involves public API additions but no changes or removals. However there are two changes in behavior: (1) if num_cib_op_callbacks() is called from a callback, its return value will now include the currently executing callback (i.e. it will be 1 more than before); and (2) applications that use CIB callbacks must not free the callback user data (which would cause a double free).