### PR TITLE
Peer cache fix

### DIFF
--- a/cib/callbacks.c
+++ b/cib/callbacks.c
@@ -1570,7 +1570,7 @@ static gboolean
 cib_force_exit(gpointer data)
 {
     crm_notice("Forcing exit!");
-    terminate_cib(__FUNCTION__, TRUE);
+    terminate_cib(__FUNCTION__, -1);
     return FALSE;
 }
 
@@ -1656,7 +1656,7 @@ initiate_exit(void)
 
     active = crm_active_peers();
     if (active < 2) {
-        terminate_cib(__FUNCTION__, FALSE);
+        terminate_cib(__FUNCTION__, 0);
         return;
     }
 
@@ -1675,9 +1675,19 @@ initiate_exit(void)
 extern int remote_fd;
 extern int remote_tls_fd;
 
+/*
+ * \internal
+ * \brief Close remote sockets, free the global CIB and quit
+ *
+ * \param[in] caller           Name of calling function (for log message)
+ * \param[in] fast             If 1, skip disconnect; if -1, also exit error
+ */
 void
-terminate_cib(const char *caller, gboolean fast)
+terminate_cib(const char *caller, int fast)
 {
+    crm_info("%s: Exiting%s...", caller,
+             (fast < 0)? " fast" : mainloop ? " from mainloop" : "");
+
     if (remote_fd > 0) {
         close(remote_fd);
         remote_fd = 0;
@@ -1687,27 +1697,29 @@ terminate_cib(const char *caller, gboolean fast)
         remote_tls_fd = 0;
     }
 
-    if (!fast) {
-        crm_info("%s: Disconnecting from cluster infrastructure", caller);
-        crm_cluster_disconnect(&crm_cluster);
-    }
-
     uninitializeCib();
 
-    crm_info("%s: Exiting%s...", caller, fast ? " fast" : mainloop ? " from mainloop" : "");
+    if (fast < 0) {
+        /* Quit fast on error */
+        cib_ipc_servers_destroy(ipcs_ro, ipcs_rw, ipcs_shm);
+        crm_exit(EINVAL);
 
-    if (fast == FALSE && mainloop != NULL && g_main_is_running(mainloop)) {
+    } else if ((mainloop != NULL) && g_main_is_running(mainloop)) {
+        /* Quit via returning from the main loop. If fast == 1, we skip the
+         * disconnect here, and it will be done when the main loop returns
+         * (this allows the peer status callback to avoid messing with the
+         * peer caches).
+         */
+        if (fast == 0) {
+            crm_cluster_disconnect(&crm_cluster);
+        }
         g_main_quit(mainloop);
 
     } else {
-        qb_ipcs_destroy(ipcs_ro);
-        qb_ipcs_destroy(ipcs_rw);
-        qb_ipcs_destroy(ipcs_shm);
-
-        if (fast) {
-            crm_exit(EINVAL);
-        } else {
-            crm_exit(pcmk_ok);
-        }
+        /* Quit via clean exit. Even the peer status callback can disconnect
+         * here, because we're not returning control to the caller. */
+        crm_cluster_disconnect(&crm_cluster);
+        cib_ipc_servers_destroy(ipcs_ro, ipcs_rw, ipcs_shm);
+        crm_exit(pcmk_ok);
     }
 }

--- a/cib/callbacks.h
+++ b/cib/callbacks.h
@@ -71,7 +71,7 @@ extern void cib_common_callback_worker(uint32_t id, uint32_t flags, xmlNode * op
 
 void cib_shutdown(int nsig);
 void initiate_exit(void);
-void terminate_cib(const char *caller, gboolean fast);
+void terminate_cib(const char *caller, int fast);
 
 extern gboolean cib_legacy_mode(void);
 

--- a/cib/messages.c
+++ b/cib/messages.c
@@ -87,7 +87,7 @@ cib_process_shutdown_req(const char *op, int options, const char *section, xmlNo
 
     } else if (cib_shutdown_flag) {
         crm_info("Shutdown ACK from %s", host);
-        terminate_cib(__FUNCTION__, FALSE);
+        terminate_cib(__FUNCTION__, 0);
         return pcmk_ok;
 
     } else {

--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -1105,7 +1105,7 @@ class MaintenanceMode(CTSTest):
         # fail the resource right after turning Maintenance mode on
         # verify it is not recovered until maintenance mode is turned off
         if action == "On":
-            pats.append("pengine.*: warning:.* Processing failed op %s for %s on" % (self.action, self.rid))
+            pats.append(r"pengine.*:\s+warning:.*Processing failed op %s for %s on" % (self.action, self.rid))
         else:
             pats.append(self.templates["Pat:RscOpOK"] % (self.rid, "stop_0"))
             pats.append(self.templates["Pat:RscOpOK"] % (self.rid, "start_0"))
@@ -1314,7 +1314,7 @@ class ResourceRecover(CTSTest):
         self.debug("Shooting %s aka. %s" % (rsc.clone_id, rsc.id))
 
         pats = []
-        pats.append(r"pengine.*: warning:.* Processing failed op %s for (%s|%s) on" % (self.action,
+        pats.append(r"pengine.*:\s+warning:.*Processing failed op %s for (%s|%s) on" % (self.action,
             rsc.id, rsc.clone_id))
 
         if rsc.managed():

--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -1224,7 +1224,6 @@ stonith_device_action(xmlNode * msg, char **output)
     } else if (device) {
         cmd = create_async_command(msg);
         if (cmd == NULL) {
-            free_device(device);
             return -EPROTO;
         }
 

--- a/lib/services/upstart.c
+++ b/lib/services/upstart.c
@@ -417,6 +417,7 @@ upstart_async_dispatch(DBusPendingCall *pending, void *user_data)
         }
     }
 
+    CRM_LOG_ASSERT(pending == op->opaque->pending);
     services_set_op_pending(op, NULL);
     operation_finalize(op);
 
@@ -479,6 +480,7 @@ upstart_job_exec(svc_action_t * op, gboolean synchronous)
                 free(state);
                 return op->rc == PCMK_OCF_OK;
             } else if (pending) {
+                dbus_pending_call_ref(pending);
                 services_set_op_pending(op, pending);
                 return TRUE;
             }


### PR DESCRIPTION
Previously, a workaround was added to the peer cache handling because the CIB peer status callback could destroy the peer cache tables. This is an actual fix, so that the CIB no longer does that.

Two unrelated minor commits fix a CTS pattern issue and a potential memory issue.