### PR TITLE
Fix: Set the attribute from remote node.

### DIFF
--- a/crmd/lrm_state.c
+++ b/crmd/lrm_state.c
@@ -536,7 +536,6 @@ remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
         } else if(is_set(flags, crm_ipc_proxied)) {
             const char *type = crm_element_value(request, F_TYPE);
             const char *host = NULL;
-            remote_proxy_t *proxy = g_hash_table_lookup(proxy_table, session);
             int rc;
 
             if (safe_str_eq(type, T_ATTRD)) {

--- a/crmd/lrm_state.c
+++ b/crmd/lrm_state.c
@@ -534,7 +534,20 @@ remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
             }
 
         } else if(is_set(flags, crm_ipc_proxied)) {
-            int rc = crm_ipc_send(proxy->ipc, request, flags, 5000, NULL);
+            const char *type = crm_element_value(request, F_TYPE);
+            const char *host = NULL;
+            remote_proxy_t *proxy = g_hash_table_lookup(proxy_table, session);
+            int rc;
+
+            if (safe_str_eq(type, T_ATTRD)) {
+                host = crm_element_value_copy(request, F_ATTRD_HOST);
+                if (host == NULL) {
+                    crm_xml_add(request, F_ATTRD_HOST, proxy->node_name);
+                    crm_xml_add_int(request, F_ATTRD_HOST_ID, get_local_nodeid(0));
+                }
+            }
+
+            rc = crm_ipc_send(proxy->ipc, request, flags, 5000, NULL);
 
             if(rc < 0) {
                 xmlNode *op_reply = create_xml_node(NULL, "nack");


### PR DESCRIPTION
Fix: Set the attribute from remote node.

* The characteristic by attrd_updater carried out in the node that is remote by way of proxy is not surely set.

```
[root@sl7-01 ~]# crm_mon -1 -Af
Last updated: Thu Jul 30 10:41:10 2015          Last change: Thu Jul 30 10:41:07 2015 by root via cibadmin on sl7-01
Stack: corosync
Current DC: sl7-01 (version 1.1.13-b2b4950) - partition WITHOUT quorum
3 nodes and 4 resources configured

Online: [ sl7-01 ]
RemoteOnline: [ snmp1 snmp2 ]

(snip)
Node Attributes:
* Node sl7-01:
* Node snmp1:
* Node snmp2:

Migration Summary:
* Node sl7-01:
* Node snmp1:
* Node snmp2:

[root@snmp1 ~]# attrd_updater -n test -v 100

[root@sl7-01 ~]# crm_mon -1 -Af
Last updated: Thu Jul 30 10:41:32 2015          Last change: Thu Jul 30 10:41:07 2015 by root via cibadmin on sl7-01
Stack: corosync
Current DC: sl7-01 (version 1.1.13-b2b4950) - partition WITHOUT quorum
3 nodes and 4 resources configured

Online: [ sl7-01 ]
RemoteOnline: [ snmp1 snmp2 ]

(snip)
Node Attributes:
* Node sl7-01:
    + test                              : 100       
* Node snmp1:
* Node snmp2:

Migration Summary:
* Node sl7-01:
* Node snmp1:
* Node snmp2:
```
* This patch sets the attribute from remote node definitely.

```
[root@sl7-01 ~]# crm_mon -1 -Af
Last updated: Thu Jul 30 10:36:37 2015          Last change: Thu Jul 30 10:36:34 2015 by root via cibadmin on sl7-01
Stack: corosync
Current DC: sl7-01 (version 1.1.13-b2b4950) - partition WITHOUT quorum
3 nodes and 4 resources configured

Online: [ sl7-01 ]
RemoteOnline: [ snmp1 snmp2 ]

(snip)
Node Attributes:
* Node sl7-01:
* Node snmp1:
* Node snmp2:

Migration Summary:
* Node sl7-01:
* Node snmp1:
* Node snmp2:

[root@snmp1 ~]# attrd_updater -n test -v 100

[root@sl7-01 ~]# crm_mon -1 -Af
Last updated: Thu Jul 30 10:37:15 2015          Last change: Thu Jul 30 10:36:34 2015 by root via cibadmin on sl7-01
Stack: corosync
Current DC: sl7-01 (version 1.1.13-b2b4950) - partition WITHOUT quorum
3 nodes and 4 resources configured

Online: [ sl7-01 ]
RemoteOnline: [ snmp1 snmp2 ]
(snip)
Node Attributes:
* Node sl7-01:
* Node snmp1:
    + test                              : 100       
* Node snmp2:

Migration Summary:
* Node sl7-01:
* Node snmp1:
* Node snmp2:
```
