### PR TITLE
Low: drop legacy SysVStartPriority from service units

### DIFF
--- a/lrmd/pacemaker_remote.service.in
+++ b/lrmd/pacemaker_remote.service.in
@@ -9,7 +9,6 @@ WantedBy=multi-user.target
 Type=simple
 KillMode=process
 NotifyAccess=none
-SysVStartPriority=99
 EnvironmentFile=-/etc/sysconfig/pacemaker
 
 ExecStart=@sbindir@/pacemaker_remoted

--- a/mcp/pacemaker.service.in
+++ b/mcp/pacemaker.service.in
@@ -20,7 +20,6 @@ WantedBy=multi-user.target
 Type=simple
 KillMode=process
 NotifyAccess=main
-SysVStartPriority=99
 EnvironmentFile=-@sysconfdir@/sysconfig/pacemaker
 EnvironmentFile=-@sysconfdir@/sysconfig/sbd
 SuccessExitStatus=100


### PR DESCRIPTION
Since systemd-218[1], systemd will emit following lines in the journal
upon (re)loading its configuration:

Support for option SysVStartPriority= has been removed and it is ignored

As it allegedly had no importance for some time even before, simply
drop it.

[1] http://cgit.freedesktop.org/systemd/systemd/commit/?id=9e37c95

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>