### PR TITLE
Fix: crm_simulate: Prevent segfault on arches with 64bit time_t

### DIFF
--- a/fencing/remote.c
+++ b/fencing/remote.c
@@ -938,7 +938,7 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
 
     op = calloc(1, sizeof(remote_fencing_op_t));
 
-    crm_element_value_int(request, F_STONITH_TIMEOUT, (int *)&(op->base_timeout));
+    crm_element_value_int(request, F_STONITH_TIMEOUT, &(op->base_timeout));
 
     if (peer && dev) {
         op->id = crm_element_value_copy(dev, F_STONITH_REMOTE_OP_ID);
@@ -974,7 +974,7 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
     crm_element_value_int(request, F_STONITH_CALLOPTS, &call_options);
     op->call_options = call_options;
 
-    crm_element_value_int(request, F_STONITH_CALLID, (int *)&(op->client_callid));
+    crm_element_value_int(request, F_STONITH_CALLID, &(op->client_callid));
 
     crm_trace("%s new stonith op: %s - %s of %s for %s",
               (peer

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -59,8 +59,11 @@ char *use_date = NULL;
 static void
 get_date(pe_working_set_t * data_set)
 {
+    int value = 0;
     time_t original_date = 0;
-    crm_element_value_int(data_set->input, "execution-date", (int*)&original_date);
+
+    crm_element_value_int(data_set->input, "execution-date", &value);
+    original_date = value;
 
     if (use_date) {
         data_set->now = crm_time_new(use_date);


### PR DESCRIPTION
on an s390x system:

 Program terminated with signal SIGSEGV, Segmentation fault.
 #0  ha_set_tm_time (source=0x0, target=0xb188f960) at iso8601.c:1004
 1004        if (source->tm_year > 0) {
 (gdb) bt
 #0  ha_set_tm_time (source=0x0, target=0xb188f960) at iso8601.c:1004
 #1  crm_time_set_timet (target=0xb188f960, source=source@entry=0x3ffffa670a0) at iso8601.c:1037
 #2  0x0000000080004f26 in get_date (data_set=0x3ffffa67218, data_set=0x3ffffa67218) at crm_simulate.c:72
 #3  0x0000000080003d20 in main (argc=<optimized out>, argv=0x3ffffa67538) at crm_simulate.c:789

This commit fixes the cast in get_date() which would result in incorrect
values for arches with 64bit time_t