### PR TITLE
Simplify automatic unfencing

### DIFF
--- a/fencing/internal.h
+++ b/fencing/internal.h
@@ -130,15 +130,9 @@ typedef struct remote_fencing_op_s {
     /*! The current operation phase being executed */
     enum st_remap_phase phase;
 
-    /* For phase 0 or 1 (requested action or a remapped "off"), required devices
-     * will be executed regardless of what topology level is being executed
-     * currently. For phase 1 (remapped "on"), required devices will not be
-     * attempted, because the cluster will execute them automatically when the
-     * node next joins the cluster.
-     */
-    /*! Lists of devices marked as required for each phase */
-    GListPtr required_list[st_phase_max];
-    /*! The device list of all the devices at the current executing topology level. */
+    /*! Devices with automatic unfencing (always run if "on" requested, never if remapped) */
+    GListPtr automatic_list;
+    /*! List of all devices at the currently executing topology level */
     GListPtr devices_list;
     /*! Current entry in the topology device list */
     GListPtr devices;

--- a/fencing/internal.h
+++ b/fencing/internal.h
@@ -59,7 +59,8 @@ typedef struct stonith_device_s {
 enum st_remap_phase {
     st_phase_requested = 0,
     st_phase_off = 1,
-    st_phase_on = 2
+    st_phase_on = 2,
+    st_phase_max = 3
 };
 
 typedef struct remote_fencing_op_s {
@@ -135,7 +136,7 @@ typedef struct remote_fencing_op_s {
      * node next joins the cluster.
      */
     /*! Lists of devices marked as required for each phase */
-    GListPtr required_list[3];
+    GListPtr required_list[st_phase_max];
     /*! The device list of all the devices at the current executing topology level. */
     GListPtr devices_list;
     /*! Current entry in the topology device list */

--- a/fencing/internal.h
+++ b/fencing/internal.h
@@ -26,12 +26,13 @@ typedef struct stonith_device_s {
 
     /*! list of actions that must execute on the target node. Used for unfencing */
     char *on_target_actions;
-    char *required_actions;
     GListPtr targets;
     time_t targets_age;
     gboolean has_attr_map;
     /* should nodeid parameter for victim be included in agent arguments */
     gboolean include_nodeid;
+    /* whether the cluster should automatically unfence nodes with the device */
+    gboolean automatic_unfencing;
     guint priority;
     guint active_pid;
 

--- a/fencing/main.c
+++ b/fencing/main.c
@@ -553,7 +553,7 @@ remove_fencing_topology(xmlXPathObjectPtr xpathObj)
 }
 
 static void
-register_fencing_topology(xmlXPathObjectPtr xpathObj, gboolean force)
+register_fencing_topology(xmlXPathObjectPtr xpathObj)
 {
     int max = numXpathResults(xpathObj), lpc = 0;
 
@@ -584,7 +584,7 @@ register_fencing_topology(xmlXPathObjectPtr xpathObj, gboolean force)
 */
 
 static void
-fencing_topology_init(xmlNode * msg)
+fencing_topology_init()
 {
     xmlXPathObjectPtr xpathObj = NULL;
     const char *xpath = "//" XML_TAG_FENCING_LEVEL;
@@ -598,7 +598,7 @@ fencing_topology_init(xmlNode * msg)
 
     /* Grab everything */
     xpathObj = xpath_search(local_cib, xpath);
-    register_fencing_topology(xpathObj, TRUE);
+    register_fencing_topology(xpathObj);
 
     freeXpathObject(xpathObj);
 }
@@ -931,7 +931,7 @@ update_fencing_topology(const char *event, xmlNode * msg)
         xpath = "//" F_CIB_UPDATE_RESULT "//" XML_TAG_DIFF_ADDED "//" XML_TAG_FENCING_LEVEL;
         xpathObj = xpath_search(msg, xpath);
 
-        register_fencing_topology(xpathObj, FALSE);
+        register_fencing_topology(xpathObj);
         freeXpathObject(xpathObj);
 
     } else if(format == 2) {
@@ -969,7 +969,7 @@ update_fencing_topology(const char *event, xmlNode * msg)
                     /* Nuclear option, all we have is the path and an id... not enough to remove a specific entry */
                     crm_info("Re-initializing fencing topology after %s operation %d.%d.%d for %s",
                              op, add[0], add[1], add[2], xpath);
-                    fencing_topology_init(NULL);
+                    fencing_topology_init();
                     return;
                 }
 
@@ -977,7 +977,7 @@ update_fencing_topology(const char *event, xmlNode * msg)
                 /* Change to the topology in general */
                 crm_info("Re-initializing fencing topology after top-level %s operation  %d.%d.%d for %s",
                          op, add[0], add[1], add[2], xpath);
-                fencing_topology_init(NULL);
+                fencing_topology_init();
                 return;
 
             } else if (strstr(xpath, "/" XML_CIB_TAG_CONFIGURATION)) {
@@ -989,7 +989,7 @@ update_fencing_topology(const char *event, xmlNode * msg)
                 } else if(strcmp(op, "delete") == 0 || strcmp(op, "create") == 0) {
                     crm_info("Re-initializing fencing topology after top-level %s operation %d.%d.%d for %s.",
                              op, add[0], add[1], add[2], xpath);
-                    fencing_topology_init(NULL);
+                    fencing_topology_init();
                     return;
                 }
 
@@ -1098,7 +1098,7 @@ update_cib_cache_cb(const char *event, xmlNode * msg)
     } else if (stonith_enabled_saved == FALSE) {
         crm_info("Updating stonith device and topology lists now that stonith is enabled");
         stonith_enabled_saved = TRUE;
-        fencing_topology_init(NULL);
+        fencing_topology_init();
         cib_devices_update();
 
     } else {
@@ -1114,7 +1114,7 @@ init_cib_cache_cb(xmlNode * msg, int call_id, int rc, xmlNode * output, void *us
     have_cib_devices = TRUE;
     local_cib = copy_xml(output);
 
-    fencing_topology_init(msg);
+    fencing_topology_init();
     cib_devices_update();
 }
 

--- a/fencing/remote.c
+++ b/fencing/remote.c
@@ -207,22 +207,6 @@ grab_peer_device(const remote_fencing_op_t *op, st_query_result_t *peer,
     return TRUE;
 }
 
-/*
- * \internal
- * \brief Free the list of required devices for a particular phase
- *
- * \param[in,out] op     Operation to modify
- * \param[in]     phase  Phase to modify
- */
-static void
-free_required_list(remote_fencing_op_t *op, enum st_remap_phase phase)
-{
-    if (op->required_list[phase]) {
-        g_list_free_full(op->required_list[phase], free);
-        op->required_list[phase] = NULL;
-    }
-}
-
 static void
 clear_remote_op_timers(remote_fencing_op_t * op)
 {
@@ -268,9 +252,7 @@ free_remote_op(gpointer data)
         g_list_free_full(op->devices_list, free);
         op->devices_list = NULL;
     }
-    free_required_list(op, st_phase_requested);
-    free_required_list(op, st_phase_off);
-    free_required_list(op, st_phase_on);
+    g_list_free_full(op->automatic_list, free);
     free(op);
 }
 
@@ -323,10 +305,10 @@ op_phase_on(remote_fencing_op_t *op)
     op->phase = st_phase_on;
     strcpy(op->action, "on");
 
-    /* Any devices that are required for "on" will be automatically executed by
-     * the cluster when the node next joins, so we skip them here.
+    /* Skip devices with automatic unfencing, because the cluster will handle it
+     * when the node rejoins.
      */
-    for (iter = op->required_list[op->phase]; iter != NULL; iter = iter->next) {
+    for (iter = op->automatic_list; iter != NULL; iter = iter->next) {
         GListPtr match = g_list_find_custom(op->devices_list, iter->data,
                                             sort_strings);
 
@@ -334,12 +316,8 @@ op_phase_on(remote_fencing_op_t *op)
             op->devices_list = g_list_remove(op->devices_list, match->data);
         }
     }
-
-    /* We know this level will succeed, because phase 1 completed successfully
-     * and we ignore any errors from phase 2. So we can free the required list,
-     * which will keep them from being executed after the device list is done.
-     */
-    free_required_list(op, op->phase);
+    g_list_free_full(op->automatic_list, free);
+    op->automatic_list = NULL;
 
     /* Rewind device list pointer */
     op->devices = op->devices_list;
@@ -659,28 +637,25 @@ topology_is_empty(stonith_topology_t *tp)
 
 /*
  * \internal
- * \brief Add a device to the required list for a particular phase
+ * \brief Add a device to an operation's automatic unfencing list
  *
  * \param[in,out] op      Operation to modify
- * \param[in]     phase   Phase to modify
  * \param[in]     device  Device ID to add
  */
 static void
-add_required_device(remote_fencing_op_t *op, enum st_remap_phase phase,
-                    const char *device)
+add_required_device(remote_fencing_op_t *op, const char *device)
 {
-    GListPtr match  = g_list_find_custom(op->required_list[phase], device,
+    GListPtr match  = g_list_find_custom(op->automatic_list, device,
                                          sort_strings);
 
     if (!match) {
-        op->required_list[phase] = g_list_prepend(op->required_list[phase],
-                                                  strdup(device));
+        op->automatic_list = g_list_prepend(op->automatic_list, strdup(device));
     }
 }
 
 /*
  * \internal
- * \brief Remove a device from the required list for the current phase
+ * \brief Remove a device from the automatic unfencing list
  *
  * \param[in,out] op      Operation to modify
  * \param[in]     device  Device ID to remove
@@ -688,12 +663,11 @@ add_required_device(remote_fencing_op_t *op, enum st_remap_phase phase,
 static void
 remove_required_device(remote_fencing_op_t *op, const char *device)
 {
-    GListPtr match = g_list_find_custom(op->required_list[op->phase], device,
+    GListPtr match = g_list_find_custom(op->automatic_list, device,
                                         sort_strings);
 
     if (match) {
-        op->required_list[op->phase] = g_list_remove(op->required_list[op->phase],
-                                                     match->data);
+        op->automatic_list = g_list_remove(op->automatic_list, match->data);
     }
 }
 
@@ -1352,14 +1326,17 @@ advance_op_topology(remote_fencing_op_t *op, const char *device, xmlNode *msg,
         op->devices = op->devices->next;
     }
 
-    /* If this device was required, it's not anymore */
-    remove_required_device(op, device);
+    /* Handle automatic unfencing if an "on" action was requested */
+    if ((op->phase == st_phase_requested) && safe_str_eq(op->action, "on")) {
+        /* If the device we just executed was required, it's not anymore */
+        remove_required_device(op, device);
 
-    /* If there are no more devices at this topology level,
-     * run through any required devices not already executed
-     */
-    if (op->devices == NULL) {
-        op->devices = op->required_list[op->phase];
+        /* If there are no more devices at this topology level, run through any
+         * remaining devices with automatic unfencing
+         */
+        if (op->devices == NULL) {
+            op->devices = op->automatic_list;
+        }
     }
 
     if ((op->devices == NULL) && (op->phase == st_phase_off)) {
@@ -1613,8 +1590,6 @@ parse_action_specific(xmlNode *xml, const char *peer, const char *device,
                       const char *action, remote_fencing_op_t *op,
                       enum st_remap_phase phase, device_properties_t *props)
 {
-    int required;
-
     props->custom_action_timeout[phase] = 0;
     crm_element_value_int(xml, F_STONITH_ACTION_TIMEOUT,
                           &props->custom_action_timeout[phase]);
@@ -1630,20 +1605,16 @@ parse_action_specific(xmlNode *xml, const char *peer, const char *device,
                   peer, device, props->delay_max[phase], action);
     }
 
-    required = 0;
-    crm_element_value_int(xml, F_STONITH_DEVICE_REQUIRED, &required);
-    if (required) {
-        /* If the action is marked as required, add the device to the
-         * operation's list of required devices for this phase. We use this
-         * for unfencing when executing a topology. In phase 0 (requested
-         * action) or phase 1 (remapped "off"), required devices get executed
-         * regardless of their topology level; in phase 2 (remapped "on"),
-         * required devices are not attempted, because the cluster will
-         * execute them automatically later.
-         */
-        crm_trace("Peer %s requires device %s to execute for action %s",
-                  peer, device, action);
-        add_required_device(op, phase, device);
+    /* Handle devices with automatic unfencing */
+    if (safe_str_eq(action, "on")) {
+        int required = 0;
+
+        crm_element_value_int(xml, F_STONITH_DEVICE_REQUIRED, &required);
+        if (required) {
+            crm_trace("Peer %s requires device %s to execute for action %s",
+                      peer, device, action);
+            add_required_device(op, device);
+        }
     }
 
     /* If a reboot is remapped to off+on, it's possible that a node is allowed

--- a/fencing/remote.c
+++ b/fencing/remote.c
@@ -60,13 +60,13 @@ typedef struct device_properties_s {
     /* The remaining members are indexed by the operation's "phase" */
 
     /* Whether this device has been executed in each phase */
-    gboolean executed[3];
+    gboolean executed[st_phase_max];
     /* Whether this device is disallowed from executing in each phase */
-    gboolean disallowed[3];
+    gboolean disallowed[st_phase_max];
     /* Action-specific timeout for each phase */
-    int custom_action_timeout[3];
+    int custom_action_timeout[st_phase_max];
     /* Action-specific maximum random delay for each phase */
-    int delay_max[3];
+    int delay_max[st_phase_max];
 } device_properties_t;
 
 typedef struct st_query_result_s {


### PR DESCRIPTION
This brings handling of automatic unfencing in line with the currently intended behavior, i.e. "automatic" and (legacy) "required" fence agent action parameters apply only to "on" actions.