### PR TITLE
Fix: ipc: Correctly compare values for the size of ipc buffer and prevent suggesting a negative value when it's insufficient

### DIFF
--- a/include/crm/common/ipc.h
+++ b/include/crm/common/ipc.h
@@ -75,7 +75,7 @@ long crm_ipc_read(crm_ipc_t * client);
 const char *crm_ipc_buffer(crm_ipc_t * client);
 uint32_t crm_ipc_buffer_flags(crm_ipc_t * client);
 const char *crm_ipc_name(crm_ipc_t * client);
-int crm_ipc_default_buffer_size(void);
+unsigned int crm_ipc_default_buffer_size(void);
 
 /* Utils */
 xmlNode *create_hello_message(const char *uuid, const char *client_name,

--- a/include/crm/common/ipcs.h
+++ b/include/crm/common/ipcs.h
@@ -110,7 +110,7 @@ void crm_ipcs_send_ack(crm_client_t * c, uint32_t request, uint32_t flags,
                        const char *tag, const char *function, int line);
 
 /* when max_send_size is 0, default ipc buffer size is used */
-ssize_t crm_ipc_prepare(uint32_t request, xmlNode * message, struct iovec **result, int32_t max_send_size);
+ssize_t crm_ipc_prepare(uint32_t request, xmlNode * message, struct iovec ** result, uint32_t max_send_size);
 ssize_t crm_ipcs_send(crm_client_t * c, uint32_t request, xmlNode * message, enum crm_ipc_flags flags);
 ssize_t crm_ipcs_sendv(crm_client_t * c, struct iovec *iov, enum crm_ipc_flags flags);
 xmlNode *crm_ipcs_recv(crm_client_t * c, void *data, size_t size, uint32_t * id, uint32_t * flags);

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -91,7 +91,7 @@ generateReference(const char *custom1, const char *custom2)
     since_epoch = calloc(1, reference_len);
 
     if (since_epoch != NULL) {
-        sprintf(since_epoch, "%s-%s-%ld-%u",
+        sprintf(since_epoch, "%s-%s-%lu-%u",
                 local_cust1, local_cust2, (unsigned long)time(NULL), ref_counter++);
     }
 
@@ -656,7 +656,7 @@ crm_ipcs_sendv(crm_client_t * c, struct iovec * iov, enum crm_ipc_flags flags)
 
         rc = qb_ipcs_response_sendv(c->ipcs, iov, 2);
         if (rc < header->qb.size) {
-            crm_notice("Response %d to %p[%d] (%d bytes) failed: %s (%d)",
+            crm_notice("Response %d to %p[%d] (%u bytes) failed: %s (%d)",
                        header->qb.id, c->ipcs, c->pid, header->qb.size, pcmk_strerror(rc), rc);
 
         } else {
@@ -986,7 +986,7 @@ crm_ipc_read(crm_ipc_t * client)
             return -EBADMSG;
         }
 
-        crm_trace("Received %s event %d, size=%d, rc=%d, text: %.100s",
+        crm_trace("Received %s event %d, size=%u, rc=%d, text: %.100s",
                   client->name, header->qb.id, header->qb.size, client->msg_size,
                   client->buffer + hdr_offset);
 
@@ -1211,7 +1211,7 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
     if (rc > 0) {
         struct crm_ipc_response_header *hdr = (struct crm_ipc_response_header *)(void*)client->buffer;
 
-        crm_trace("Received response %d, size=%d, rc=%ld, text: %.200s", hdr->qb.id, hdr->qb.size,
+        crm_trace("Received response %d, size=%u, rc=%ld, text: %.200s", hdr->qb.id, hdr->qb.size,
                   rc, crm_ipc_buffer(client));
 
         if (reply) {

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -46,8 +46,8 @@ struct crm_ipc_response_header {
 };
 
 static int hdr_offset = 0;
-static int ipc_buffer_max = 0;
-static unsigned int pick_ipc_buffer(int max);
+static unsigned int ipc_buffer_max = 0;
+static unsigned int pick_ipc_buffer(unsigned int max);
 
 static inline void
 crm_ipc_init(void)
@@ -60,7 +60,7 @@ crm_ipc_init(void)
     }
 }
 
-int
+unsigned int
 crm_ipc_default_buffer_size(void)
 {
     return pick_ipc_buffer(0);
@@ -431,7 +431,7 @@ crm_ipcs_recv(crm_client_t * c, void *data, size_t size, uint32_t * id, uint32_t
         unsigned int size_u = 1 + header->size_uncompressed;
         uncompressed = calloc(1, size_u);
 
-        crm_trace("Decompressing message data %d bytes into %d bytes",
+        crm_trace("Decompressing message data %u bytes into %u bytes",
                   header->size_compressed, size_u);
 
         rc = BZ2_bzBuffToBuffDecompress(uncompressed, &size_u, text, header->size_compressed, 1, 0);
@@ -531,9 +531,9 @@ crm_ipcs_flush_events(crm_client_t * c)
 }
 
 ssize_t
-crm_ipc_prepare(uint32_t request, xmlNode * message, struct iovec ** result, int32_t max_send_size)
+crm_ipc_prepare(uint32_t request, xmlNode * message, struct iovec ** result, uint32_t max_send_size)
 {
-    static int biggest = 0;
+    static unsigned int biggest = 0;
     struct iovec *iov;
     unsigned int total = 0;
     char *compressed = NULL;
@@ -590,8 +590,8 @@ crm_ipc_prepare(uint32_t request, xmlNode * message, struct iovec ** result, int
             biggest = 2 * QB_MAX(header->size_uncompressed, biggest);
 
             crm_err
-                ("Could not compress the message into less than the configured ipc limit (%d bytes)."
-                 "Set PCMK_ipc_buffer to a higher value (%d bytes suggested)", max_send_size,
+                ("Could not compress the message into less than the configured ipc limit (%u bytes)."
+                 "Set PCMK_ipc_buffer to a higher value (%u bytes suggested)", max_send_size,
                  biggest);
 
             free(compressed);
@@ -747,9 +747,9 @@ struct crm_ipc_s {
 };
 
 static unsigned int
-pick_ipc_buffer(int max)
+pick_ipc_buffer(unsigned int max)
 {
-    static int global_max = 0;
+    static unsigned int global_max = 0;
 
     if(global_max == 0) {
         const char *env = getenv("PCMK_ipc_buffer");
@@ -925,7 +925,7 @@ crm_ipc_decompress(crm_ipc_t * client)
         unsigned int new_buf_size = QB_MAX((hdr_offset + size_u), client->max_buf_size);
         char *uncompressed = calloc(1, new_buf_size);
 
-        crm_trace("Decompressing message data %d bytes into %d bytes",
+        crm_trace("Decompressing message data %u bytes into %u bytes",
                  header->size_compressed, size_u);
 
         rc = BZ2_bzBuffToBuffDecompress(uncompressed + hdr_offset, &size_u,
@@ -1166,9 +1166,9 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
 
     if(header->size_compressed) {
         if(factor < 10 && (client->max_buf_size / 10) < (rc / factor)) {
-            crm_notice("Compressed message exceeds %d0%% of the configured ipc limit (%d bytes), "
-                       "consider setting PCMK_ipc_buffer to %d or higher",
-                       factor, client->max_buf_size, 2*client->max_buf_size);
+            crm_notice("Compressed message exceeds %d0%% of the configured ipc limit (%u bytes), "
+                       "consider setting PCMK_ipc_buffer to %u or higher",
+                       factor, client->max_buf_size, 2 * client->max_buf_size);
             factor++;
         }
     }


### PR DESCRIPTION
Previously, pick_ipc_buffer() compared two integers, which made the following true:
    0 > 0x80000000

That would trigger assert in crm_ipc_prepare():
    CRM_ASSERT(result != NULL);

Besides, crm_ipc_prepare() and pick_ipc_buffer() could suggest negative
values for PCMK_ipc_buffer.

This commit fixes these by using "unsigned int".