### PR TITLE
Low: Change the log of the noise to the trace log.

### DIFF
--- a/crmd/lrm_state.c
+++ b/crmd/lrm_state.c
@@ -490,7 +490,7 @@ remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
         if (remote_proxy_new(lrm_state->node_name, session, channel) == NULL) {
             remote_proxy_notify_destroy(lrmd, session);
         }
-        crm_info("new remote proxy client established to %s, session id %s", channel, session);
+        crm_trace("new remote proxy client established to %s, session id %s", channel, session);
     } else if (safe_str_eq(op, "destroy")) {
         remote_proxy_end_session(session);
 

--- a/lrmd/ipc_proxy.c
+++ b/lrmd/ipc_proxy.c
@@ -165,14 +165,14 @@ ipc_proxy_forward_client(crm_client_t *ipc_proxy, xmlNode *xml)
      */
 
     if (safe_str_eq(msg_type, "event")) {
-        crm_info("Sending event to %s", ipc_client->id);
+        crm_trace("Sending event to %s", ipc_client->id);
         rc = crm_ipcs_send(ipc_client, 0, msg, crm_ipc_server_event);
 
     } else if (safe_str_eq(msg_type, "response")) {
         int msg_id = 0;
 
         crm_element_value_int(xml, F_LRMD_IPC_MSG_ID, &msg_id);
-        crm_info("Sending response to %d - %s", ipc_client->request_id, ipc_client->id);
+        crm_trace("Sending response to %d - %s", ipc_client->request_id, ipc_client->id);
         rc = crm_ipcs_send(ipc_client, msg_id, msg, FALSE);
 
         CRM_LOG_ASSERT(msg_id == ipc_client->request_id);


### PR DESCRIPTION
Every time a user carries out crm_mon and cibadmin in remote node via
proxy, log outputs it.
In addition, log outputs it every time a resource executes a command
with monitors in remote node.

```
Jun 24 16:11:26 bl460g8n1 crmd[58595]: info: new remote proxy client established to cib_ro, session id 25f2ce7e-44bd-450a-8311-b9969a70fbc6
Jun 24 16:11:26 bl460g8n1 crmd[58595]: info: new remote proxy client established to cib_rw, session id 04b53915-1912-4dcd-b878-1eee549485fc
Jun 24 16:11:26 bl460g8n1 crmd[58595]: info: new remote proxy client established to cib_ro, session id 8984746d-ecdd-4bdd-8ee4-c5c0b5952d33
Jun 24 16:11:26 bl460g8n1 crmd[58595]: info: new remote proxy client established to cib_rw, session id fa36c226-92c8-403e-ba2d-a56cfe441162
Jun 24 16:11:27 bl460g8n1 crmd[58595]: info: new remote proxy client established to cib_ro, session id 5ecf7bb0-c62f-47ec-91ac-8ad1508653e1
Jun 24 16:11:27 bl460g8n1 crmd[58595]: info: new remote proxy client established to cib_rw, session id c3d87e91-6877-4175-b8c5-ba3841264e1f
Jun 24 16:11:27 bl460g8n1 crmd[58595]: info: new remote proxy client established to cib_ro, session id 49a8c16a-5dc3-4d2f-b5c2-aeb7930b2b7b
Jun 24 16:11:27 bl460g8n1 crmd[58595]: info: new remote proxy client established to cib_rw, session id 557b0083-64cc-4b26-8c4b-fcd670d63c73
Jun 24 16:11:27 bl460g8n1 crmd[58595]: info: new remote proxy client established to cib_ro, session id 79ba1448-f5

Jun 24 16:15:41 bl460g8n3 pacemaker_remoted[14465]: info: Sending response to 1 - 037f84ec-c4d2-4a57-ae8d-1deac2aedffb
Jun 24 16:15:41 bl460g8n3 pacemaker_remoted[14465]: info: Sending response to 2 - 037f84ec-c4d2-4a57-ae8d-1deac2aedffb
Jun 24 16:15:41 bl460g8n3 pacemaker_remoted[14465]: info: Sending response to 1 - 05dd3f25-cd62-4ed9-902b-c5e9a549b10c
Jun 24 16:15:41 bl460g8n3 pacemaker_remoted[14465]: info: Sending response to 2 - 05dd3f25-cd62-4ed9-902b-c5e9a549b10c
Jun 24 16:16:11 bl460g8n3 pacemaker_remoted[14465]: info: Sending response to 1 - 0cc6d1ab-df54-471b-a52f-cb9a5c0c8c34
Jun 24 16:16:12 bl460g8n3 pacemaker_remoted[14465]: info: Sending response to 2 - 0cc6d1ab-df54-471b-a52f-cb9a5c0c8c34
Jun 24 16:16:12 bl460g8n3 pacemaker_remoted[14465]: info: Sending response to 1 - b0e09396-8f48-4dc4-a314-c66f0f33e411
Jun 24 16:16:12 bl460g8n3 pacemaker_remoted[14465]: info: Sending response to 2 - b0e09396-8f48-4dc4-a314-c66f0f33e411
```
Please change the log to the trace.