### PR TITLE
Fix: crmd: Resolve memory leak in remote_proxy_cb()

### DIFF
--- a/crmd/lrm_state.c
+++ b/crmd/lrm_state.c
@@ -535,7 +535,7 @@ remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
 
         } else if(is_set(flags, crm_ipc_proxied)) {
             const char *type = crm_element_value(request, F_TYPE);
-            int rc;
+            int rc = 0;
 
             if (safe_str_eq(type, T_ATTRD)
                 && crm_element_value(request, F_ATTRD_HOST) == NULL) {

--- a/crmd/lrm_state.c
+++ b/crmd/lrm_state.c
@@ -535,15 +535,12 @@ remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
 
         } else if(is_set(flags, crm_ipc_proxied)) {
             const char *type = crm_element_value(request, F_TYPE);
-            const char *host = NULL;
             int rc;
 
-            if (safe_str_eq(type, T_ATTRD)) {
-                host = crm_element_value_copy(request, F_ATTRD_HOST);
-                if (host == NULL) {
-                    crm_xml_add(request, F_ATTRD_HOST, proxy->node_name);
-                    crm_xml_add_int(request, F_ATTRD_HOST_ID, get_local_nodeid(0));
-                }
+            if (safe_str_eq(type, T_ATTRD)
+                && crm_element_value(request, F_ATTRD_HOST) == NULL) {
+                crm_xml_add(request, F_ATTRD_HOST, proxy->node_name);
+                crm_xml_add_int(request, F_ATTRD_HOST_ID, get_local_nodeid(0));
             }
 
             rc = crm_ipc_send(proxy->ipc, request, flags, 5000, NULL);


### PR DESCRIPTION
Resolve memory leak introduced by 446a100. I don't see the necessity of using crm_element_value_copy() in here. It appears to have introduced memory leak.