### PR TITLE
Fix: pengine: The failed action of the resource that occurred in shutdown is not displayed.

### DIFF
--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2536,9 +2536,7 @@ record_failed_op(xmlNode *op, node_t* node, pe_working_set_t * data_set)
     xmlNode *xIter = NULL;
     const char *op_key = crm_element_value(op, XML_LRM_ATTR_TASK_KEY);
 
-    if (node->details->shutdown) {
-        return;
-    } else if(node->details->online == FALSE) {
+    if ((node->details->shutdown) && (node->details->online == FALSE)) {
         return;
     }
 


### PR DESCRIPTION
It is like the problem that entered when you summarized an old judgment
in function (record_failed_op) by the next correction.

*https://github.com/ClusterLabs/pacemaker/commit/9cd666ac15a2998f4543e1dac33edea36bbcf930#diff-7dae505817fa61e544018e581ee45933