### PR TITLE
Fix: cib: Check if the configuration changes with cib_config_changed() only for v1 diffs

### DIFF
--- a/cib/callbacks.c
+++ b/cib/callbacks.c
@@ -1256,10 +1256,17 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
                             current_cib, &result_cib, cib_diff, &output);
 
         if (manage_counters == FALSE) {
+            int format = 1;
             /* Legacy code
              * If the diff is NULL at this point, its because nothing changed
              */
-            config_changed = cib_config_changed(NULL, NULL, cib_diff);
+            if (*cib_diff) {
+                crm_element_value_int(*cib_diff, "format", &format);
+            }
+
+            if (format == 1) {
+                config_changed = cib_config_changed(NULL, NULL, cib_diff);
+            }
         }
 
         /* Always write to disk for replace ops,

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -610,6 +610,7 @@ cib_config_changed(xmlNode * last, xmlNode * next, xmlNode ** diff)
     int lpc = 0, max = 0;
     gboolean config_changes = FALSE;
     xmlXPathObject *xpathObj = NULL;
+    int format = 1;
 
     CRM_ASSERT(diff != NULL);
 
@@ -620,6 +621,10 @@ cib_config_changed(xmlNode * last, xmlNode * next, xmlNode ** diff)
     if (*diff == NULL) {
         goto done;
     }
+
+    crm_element_value_int(*diff, "format", &format);
+    /* This function only applies to v1 diffs. */
+    CRM_LOG_ASSERT(format == 1);
 
     xpathObj = xpath_search(*diff, "//" XML_CIB_TAG_CONFIGURATION);
     if (numXpathResults(xpathObj) > 0) {


### PR DESCRIPTION
The cib_config_change() function only applies to v1 diffs. Previously,
if cib was running in legacy mode while using v2 diff format, it would
get incorrect result from the function and refuse to write back on-disk
cib on the slave node.