### PR TITLE
Use fencing level tag consistently in internal XML

### DIFF
--- a/fencing/main.c
+++ b/fencing/main.c
@@ -398,7 +398,7 @@ topology_remove_helper(const char *node, int level)
 {
     int rc;
     char *desc = NULL;
-    xmlNode *data = create_xml_node(NULL, F_STONITH_LEVEL);
+    xmlNode *data = create_xml_node(NULL, XML_TAG_FENCING_LEVEL);
     xmlNode *notify_data = create_xml_node(NULL, STONITH_OP_LEVEL_DEL);
 
     crm_xml_add(data, F_STONITH_ORIGIN, __FUNCTION__);

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -89,7 +89,6 @@ xmlNode *create_device_registration_xml(const char *id, const char *namespace, c
 #  define F_STONITH_HISTORY_LIST  "st_history"
 #  define F_STONITH_DATE          "st_date"
 #  define F_STONITH_STATE         "st_state"
-#  define F_STONITH_LEVEL         "st_level"
 #  define F_STONITH_ACTIVE        "st_active"
 
 #  define F_STONITH_DEVICE        "st_device_id"

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -243,7 +243,7 @@ stonith_api_remove_level(stonith_t * st, int options, const char *node, int leve
     int rc = 0;
     xmlNode *data = NULL;
 
-    data = create_xml_node(NULL, F_STONITH_LEVEL);
+    data = create_xml_node(NULL, XML_TAG_FENCING_LEVEL);
     crm_xml_add(data, F_STONITH_ORIGIN, __FUNCTION__);
 
     /* Current versions use XML_ATTR_STONITH_TARGET, older F_STONITH_TARGET */
@@ -262,7 +262,7 @@ create_level_registration_xml(const char *node, int level, stonith_key_value_t *
 {
     int len = 0;
     char *list = NULL;
-    xmlNode *data = create_xml_node(NULL, F_STONITH_LEVEL);
+    xmlNode *data = create_xml_node(NULL, XML_TAG_FENCING_LEVEL);
 
     crm_xml_add_int(data, XML_ATTR_ID, level);
     crm_xml_add_int(data, XML_ATTR_STONITH_INDEX, level);


### PR DESCRIPTION
12ca8bb broke the stonith regression tests, and a4f67f5 fixed the regression tests but broke normal stonith operation. This reconciles the two.