### PR TITLE
Snprintf and more

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,11 @@ AC_ARG_WITH(pkg-name,
 
 dnl Older distros may need: AM_INIT_AUTOMAKE($PACKAGE_NAME, $PACKAGE_VERSION)
 AM_INIT_AUTOMAKE
+dnl older automake's default of ARFLAGS=cru is noisy on newer binutils;
+dnl we don't really need the 'u' even in older toolchains.  Then there is
+dnl older libtool, which spelled it AR_FLAGS
+m4_divert_text([DEFAULTS], [: "${ARFLAGS=cr} ${AR_FLAGS=cr}"])
+
 AC_DEFINE_UNQUOTED(PACEMAKER_VERSION, "$PACKAGE_VERSION", Current pacemaker version)
 
 PACKAGE_SERIES=`echo $PACKAGE_VERSION | awk -F. '{ print $1"."$2 }'`

--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -673,9 +673,10 @@ add_action(char *actions, const char *action)
     }
 
     if (offset > 0) {
-        offset += snprintf(actions+offset, len-offset, " ");
+        offset += crm_snprintf_offset(actions, offset, len, " ");
     }
-    offset += snprintf(actions+offset, len-offset, "%s", action);
+    offset += crm_snprintf_offset(actions, offset, len, "%s", action);
+    CRM_LOG_ASSERT(offset >= 0 && offset < len);  /* offset == 0 possible */
 
     return actions;
 }

--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -663,7 +663,7 @@ is_nodeid_required(xmlNode * xml)
 static char *
 add_action(char *actions, const char *action)
 {
-    static size_t len = 256;
+    static const size_t len = 256;
     int offset = 0;
 
     if (actions == NULL) {

--- a/lib/ais/utils.c
+++ b/lib/ais/utils.c
@@ -411,22 +411,23 @@ append_member(char *data, crm_node_t * node)
     }
     data = realloc_safe(data, size);
 
-    offset += snprintf(data + offset, size - offset, "<node id=\"%u\" ", node->id);
+    offset += crm_snprintf_offset(data, offset, size, "<node id=\"%u\" ", node->id);
     if (node->uname) {
-        offset += snprintf(data + offset, size - offset, "uname=\"%s\" ", node->uname);
+        offset += crm_snprintf_offset(data, offset, size, "uname=\"%s\" ", node->uname);
     }
-    offset += snprintf(data + offset, size - offset, "state=\"%s\" ", node->state);
-    offset += snprintf(data + offset, size - offset, "born=\"" U64T "\" ", node->born);
-    offset += snprintf(data + offset, size - offset, "seen=\"" U64T "\" ", node->last_seen);
-    offset += snprintf(data + offset, size - offset, "votes=\"%d\" ", node->votes);
-    offset += snprintf(data + offset, size - offset, "processes=\"%u\" ", node->processes);
+    offset += crm_snprintf_offset(data, offset, size, "state=\"%s\" ", node->state);
+    offset += crm_snprintf_offset(data, offset, size, "born=\"" U64T "\" ", node->born);
+    offset += crm_snprintf_offset(data, offset, size, "seen=\"" U64T "\" ", node->last_seen);
+    offset += crm_snprintf_offset(data, offset, size, "votes=\"%d\" ", node->votes);
+    offset += crm_snprintf_offset(data, offset, size, "processes=\"%u\" ", node->processes);
     if (node->addr) {
-        offset += snprintf(data + offset, size - offset, "addr=\"%s\" ", node->addr);
+        offset += crm_snprintf_offset(data, offset, size, "addr=\"%s\" ", node->addr);
     }
     if (node->version) {
-        offset += snprintf(data + offset, size - offset, "version=\"%s\" ", node->version);
+        offset += crm_snprintf_offset(data, offset, size, "version=\"%s\" ", node->version);
     }
-    offset += snprintf(data + offset, size - offset, "/>");
+    offset += crm_snprintf_offset(data, offset, size, "/>");
+    CRM_LOG_ASSERT(offset > 0 && offset < len);
 
     return data;
 }

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -57,7 +57,7 @@ find_nvpair_attr_delegate(cib_t * the_cib, const char *attr, const char *section
                           char **value, const char *user_name)
 {
     int offset = 0;
-    static int xpath_max = 1024;
+    static const int xpath_max = 1024;
     int rc = pcmk_ok;
 
     char *xpath_string = NULL;

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -43,13 +43,6 @@
 	}					\
     } while(0)
 
-/* could also check for possible truncation */
-#define attr_snprintf(_str, _offset, _limit, ...) do {              \
-    _offset += snprintf(_str + _offset,                             \
-                        (_limit > _offset) ? _limit - _offset : 0,  \
-                        __VA_ARGS__);                               \
-    } while(0)
-
 extern int
 find_nvpair_attr_delegate(cib_t * the_cib, const char *attr, const char *section,
                           const char *node_uuid, const char *attr_set_type, const char *set_name,
@@ -95,10 +88,12 @@ find_nvpair_attr_delegate(cib_t * the_cib, const char *attr, const char *section
     xpath_string = calloc(1, xpath_max);
     CRM_CHECK(xpath_string != NULL, return -ENOMEM);
 
-    attr_snprintf(xpath_string, offset, xpath_max, "%.128s", get_object_path(section));
+    offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                  "%s", get_object_path(section));
 
     if (safe_str_eq(node_type, XML_CIB_TAG_TICKETS)) {
-        attr_snprintf(xpath_string, offset, xpath_max, "//%s", node_type);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                      "//%s", node_type);
 
     } else if (node_uuid) {
         const char *node_type = XML_CIB_TAG_NODE;
@@ -107,30 +102,33 @@ find_nvpair_attr_delegate(cib_t * the_cib, const char *attr, const char *section
             node_type = XML_CIB_TAG_STATE;
             set_type = XML_TAG_TRANSIENT_NODEATTRS;
         }
-        attr_snprintf(xpath_string, offset, xpath_max, "//%s[@id='%s']", node_type,
-                      node_uuid);
+        offset +=
+            crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                "//%s[@id='%s']", node_type, node_uuid);
     }
 
     if (set_name) {
-        attr_snprintf(xpath_string, offset, xpath_max, "//%s[@id='%.128s']", set_type,
-                      set_name);
+        offset +=
+            crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                "//%s[@id='%s']", set_type, set_name);
     } else {
-        attr_snprintf(xpath_string, offset, xpath_max, "//%s", set_type);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "//%s", set_type);
     }
 
-    attr_snprintf(xpath_string, offset, xpath_max, "//nvpair[");
+    offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "//nvpair[");
     if (attr_id) {
-        attr_snprintf(xpath_string, offset, xpath_max, "@id='%s'", attr_id);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "@id='%s'", attr_id);
     }
 
     if (attr_name) {
         if (attr_id) {
-            attr_snprintf(xpath_string, offset, xpath_max, " and ");
+            offset += crm_snprintf_offset(xpath_string, offset, xpath_max, " and ");
         }
-        attr_snprintf(xpath_string, offset, xpath_max, "@name='%.128s'", attr_name);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                      "@name='%s'", attr_name);
     }
-    attr_snprintf(xpath_string, offset, xpath_max, "]");
-    CRM_LOG_ASSERT(offset > 0);
+    offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "]");
+    CRM_LOG_ASSERT(offset > 0 && offset < xpath_max);
 
     rc = cib_internal_op(the_cib, CIB_OP_QUERY, NULL, xpath_string, NULL, &xml_search,
                          cib_sync_call | cib_scope_local | cib_xpath, user_name);

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -428,7 +428,7 @@ crm_time_as_string(crm_time_t * date_time, int flags)
         int offset = 0;
         static const int max = 128;
 
-        date_s = calloc(1, max+1);
+        date_s = calloc(1, max);
         crm_time_get_sec(dt->seconds, &h, &m, &s);
 
         if (date_s == NULL) {
@@ -468,13 +468,13 @@ crm_time_as_string(crm_time_t * date_time, int flags)
         } else if (flags & crm_time_seconds) {
             unsigned long long s = crm_time_get_seconds(date_time);
 
-            snprintf(date_s, 31, "%lld", s); /* Durations may not be +ve */
+            snprintf(date_s, 32, "%lld", s); /* Durations may not be +ve */
             goto done;
 
         } else if (flags & crm_time_epoch) {
             unsigned long long s = crm_time_get_seconds_since_epoch(date_time);
 
-            snprintf(date_s, 31, "%lld", s); /* Durations may not be +ve */
+            snprintf(date_s, 32, "%lld", s); /* Durations may not be +ve */
             goto done;
 
         } else if (flags & crm_time_weeks) {
@@ -482,7 +482,7 @@ crm_time_as_string(crm_time_t * date_time, int flags)
             uint y, w, d;
 
             if (crm_time_get_isoweek(dt, &y, &w, &d)) {
-                snprintf(date_s, 31, "%d-W%.2d-%d", y, w, d);
+                snprintf(date_s, 32, "%d-W%.2d-%d", y, w, d);
             }
 
         } else if (flags & crm_time_ordinal) {
@@ -490,7 +490,7 @@ crm_time_as_string(crm_time_t * date_time, int flags)
             uint y, d;
 
             if (crm_time_get_ordinal(dt, &y, &d)) {
-                snprintf(date_s, 31, "%d-%.3d", y, d);
+                snprintf(date_s, 32, "%d-%.3d", y, d);
             }
 
         } else {
@@ -498,7 +498,7 @@ crm_time_as_string(crm_time_t * date_time, int flags)
             uint y, m, d;
 
             if (crm_time_get_gregorian(dt, &y, &m, &d)) {
-                snprintf(date_s, 31, "%.4d-%.2d-%.2d", y, m, d);
+                snprintf(date_s, 32, "%.4d-%.2d-%.2d", y, m, d);
             }
         }
     }
@@ -512,7 +512,7 @@ crm_time_as_string(crm_time_t * date_time, int flags)
         }
 
         if (crm_time_get_timeofday(dt, &h, &m, &s)) {
-            snprintf(time_s, 31, "%.2d:%.2d:%.2d", h, m, s);
+            snprintf(time_s, 32, "%.2d:%.2d:%.2d", h, m, s);
         }
 
         if (dt->offset != 0) {
@@ -522,10 +522,10 @@ crm_time_as_string(crm_time_t * date_time, int flags)
         offset_s = calloc(1, 32);
         if ((flags & crm_time_log_with_timezone) == 0 || dt->offset == 0) {
             crm_trace("flags %6x %6x", flags, crm_time_log_with_timezone);
-            snprintf(offset_s, 31, "Z");
+            snprintf(offset_s, 32, "Z");
 
         } else {
-            snprintf(offset_s, 31, " %c%.2d:%.2d", dt->offset < 0 ? '-' : '+', h, m);
+            snprintf(offset_s, 32, " %c%.2d:%.2d", dt->offset < 0 ? '-' : '+', h, m);
         }
     }
 

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -436,27 +436,35 @@ crm_time_as_string(crm_time_t * date_time, int flags)
         }
 
         if(dt->years) {
-            offset += snprintf(date_s+offset, max-offset, "%4d year%s ", dt->years, dt->years>1?"s":"");
+            offset += crm_snprintf_offset(date_s, offset, max,
+                                          "%4d year%s ", dt->years, dt->years>1?"s":"");
         }
         if(dt->months) {
-            offset += snprintf(date_s+offset, max-offset, "%2d month%s ", dt->months, dt->months>1?"s":"");
+            offset += crm_snprintf_offset(date_s, offset, max,
+                                          "%2d month%s ", dt->months, dt->months>1?"s":"");
         }
         if(dt->days) {
-            offset += snprintf(date_s+offset, max-offset, "%2d day%s ", dt->days, dt->days>1?"s":"");
+            offset += crm_snprintf_offset(date_s, offset, max,
+                                          "%2d day%s ", dt->days, dt->days>1?"s":"");
         }
         if(dt->seconds) {
-            offset += snprintf(date_s+offset, max-offset, "%d seconds ( ", dt->seconds);
+            offset += crm_snprintf_offset(date_s, offset, max,
+                                          "%d seconds ( ", dt->seconds);
             if(h) {
-                offset += snprintf(date_s+offset, max-offset, "%d hour%s ", h, h>1?"s":"");
+                offset += crm_snprintf_offset(date_s, offset, max,
+                                              "%d hour%s ", h, h>1?"s":"");
             }
             if(m) {
-                offset += snprintf(date_s+offset, max-offset, "%d minute%s ", m, m>1?"s":"");
+                offset += crm_snprintf_offset(date_s, offset, max,
+                                              "%d minute%s ", m, m>1?"s":"");
             }
             if(s) {
-                offset += snprintf(date_s+offset, max-offset, "%d second%s ", s, s>1?"s":"");
+                offset += crm_snprintf_offset(date_s, offset, max,
+                                              "%d second%s ", s, s>1?"s":"");
             }
-            offset += snprintf(date_s+offset, max-offset, ")");
+            offset += crm_snprintf_offset(date_s, offset, max, ")");
         }
+        CRM_LOG_ASSERT(offset > 0 && offset < max);  /* offset == 0 possible */
         goto done;
     }
 

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -425,7 +425,8 @@ crm_time_as_string(crm_time_t * date_time, int flags)
     CRM_CHECK(dt != NULL, return NULL);
     if (flags & crm_time_log_duration) {
         uint h = 0, m = 0, s = 0;
-        int offset = 0, max = 128;
+        int offset = 0;
+        static const int max = 128;
 
         date_s = calloc(1, max+1);
         crm_time_get_sec(dt->seconds, &h, &m, &s);

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -197,23 +197,26 @@ set_format_string(int method, const char *daemon)
 
         if (uname(&res) == 0) {
             offset +=
-                snprintf(fmt + offset, FMT_MAX - offset, "%%t [%d] %s %10s: ", getpid(),
-                         res.nodename, daemon);
+                crm_snprintf_offset(fmt, offset, FMT_MAX,
+                                    "%%t [%d] %s %10s: ", getpid(), res.nodename, daemon);
         } else {
-            offset += snprintf(fmt + offset, FMT_MAX - offset, "%%t [%d] %10s: ", getpid(), daemon);
+            offset += crm_snprintf_offset(fmt, offset, FMT_MAX,
+                                          "%%t [%d] %10s: ", getpid(), daemon);
         }
     }
 
     if (method == QB_LOG_SYSLOG) {
-        offset += snprintf(fmt + offset, FMT_MAX - offset, "%%g %%-7p: %%b");
+        offset += crm_snprintf_offset(fmt, offset, FMT_MAX, "%%g %%-7p: %%b");
         crm_extended_logging(method, QB_FALSE);
     } else if (crm_tracing_enabled()) {
-        offset += snprintf(fmt + offset, FMT_MAX - offset, "(%%-12f:%%5l %%g) %%-7p: %%n:\t%%b");
+        offset += crm_snprintf_offset(fmt, offset, FMT_MAX,
+                                      "(%%-12f:%%5l %%g) %%-7p: %%n:\t%%b");
     } else {
-        offset += snprintf(fmt + offset, FMT_MAX - offset, "%%g %%-7p: %%n:\t%%b");
+        offset += crm_snprintf_offset(fmt, offset, FMT_MAX,
+                                      "%%g %%-7p: %%n:\t%%b");
     }
 
-    CRM_LOG_ASSERT(offset > 0);
+    CRM_LOG_ASSERT(offset > 0 && offset < FMT_MAX);
     qb_log_format_set(method, fmt);
 }
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -5917,7 +5917,8 @@ expand_idref(xmlNode * input, xmlNode * top)
     ref = crm_element_value(result, XML_ATTR_IDREF);
 
     if (ref != NULL) {
-        int xpath_max = 512, offset = 0;
+        static const int xpath_max = 512;
+        int offset = 0;
 
         xpath_string = calloc(1, xpath_max);
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -204,7 +204,7 @@ static inline bool TRACKING_CHANGES(xmlNode *xml)
         } else if(rc >= ((max) - (offset))) {                           \
             char *tmp = NULL;                                           \
             (max) = QB_MAX(CHUNK_SIZE, (max) * 2);                      \
-            tmp = realloc_safe((buffer), (max) + 1);                         \
+            tmp = realloc_safe((buffer), (max));                        \
             CRM_ASSERT(tmp);                                            \
             (buffer) = tmp;                                             \
         } else {                                                        \
@@ -221,7 +221,7 @@ insert_prefix(int options, char **buffer, int *offset, int *max, int depth)
 
         if ((*buffer) == NULL || spaces >= ((*max) - (*offset))) {
             (*max) = QB_MAX(CHUNK_SIZE, (*max) * 2);
-            (*buffer) = realloc_safe((*buffer), (*max) + 1);
+            (*buffer) = realloc_safe((*buffer), (*max));
         }
         memset((*buffer) + (*offset), ' ', spaces);
         (*offset) += spaces;

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -201,6 +201,7 @@ static inline bool TRACKING_CHANGES(xmlNode *xml)
         if(buffer && rc < 0) {                                          \
             crm_perror(LOG_ERR, "snprintf failed at offset %d", offset); \
             (buffer)[(offset)] = 0;                                     \
+            break;                                                      \
         } else if(rc >= ((max) - (offset))) {                           \
             char *tmp = NULL;                                           \
             (max) = QB_MAX(CHUNK_SIZE, (max) * 2);                      \

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1651,7 +1651,7 @@ lsb_get_metadata(const char *type, char **output)
     char *s_dscrpt = NULL;
     char *xml_l_dscrpt = NULL;
     int offset = 0;
-    int max = 2048;
+    static const int max = 2048;
     char description[max];
 
     if(type[0] == '/') {

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1704,8 +1704,7 @@ lsb_get_metadata(const char *type, char **output)
             while (fgets(buffer, sizeof(buffer), fp)) {
                 if (!strncmp(buffer, "#  ", 3) || !strncmp(buffer, "#\t", 2)) {
                     buffer[0] = ' ';
-                    offset += snprintf(description+offset, max-offset, "%s", buffer);
-
+                    offset += crm_snprintf_offset(description, offset, max, "%s", buffer);
                 } else {
                     fputs(buffer, fp);
                     break;      /* Long description ends */

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -478,22 +478,22 @@ native_print(resource_t * rsc, const char *pre_text, long options, void *print_d
     }
 
     if(pre_text) {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, "%s", pre_text);
+        offset += crm_snprintf_offset(buffer, offset, LINE_MAX, "%s", pre_text);
     }
-    offset += snprintf(buffer + offset, LINE_MAX - offset, "%s", rsc_printable_id(rsc));
-    offset += snprintf(buffer + offset, LINE_MAX - offset, "\t(%s", class);
+    offset += crm_snprintf_offset(buffer, offset, LINE_MAX, "%s", rsc_printable_id(rsc));
+    offset += crm_snprintf_offset(buffer, offset, LINE_MAX, "\t(%s", class);
     if (safe_str_eq(class, "ocf")) {
         const char *prov = crm_element_value(rsc->xml, XML_AGENT_ATTR_PROVIDER);
-        offset += snprintf(buffer + offset, LINE_MAX - offset, "::%s", prov);
+        offset += crm_snprintf_offset(buffer, offset, LINE_MAX, "::%s", prov);
     }
-    offset += snprintf(buffer + offset, LINE_MAX - offset, ":%s):\t", kind);
+    offset += crm_snprintf_offset(buffer, offset, LINE_MAX, ":%s):\t", kind);
     if(is_set(rsc->flags, pe_rsc_orphan)) {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, " ORPHANED ");
+        offset += crm_snprintf_offset(buffer, offset, LINE_MAX, " ORPHANED ");
     }
     if(rsc->role > RSC_ROLE_SLAVE && is_set(rsc->flags, pe_rsc_failed)) {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, "FAILED %s", role2text(rsc->role));
+        offset += crm_snprintf_offset(buffer, offset, LINE_MAX, "FAILED %s", role2text(rsc->role));
     } else if(is_set(rsc->flags, pe_rsc_failed)) {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, "FAILED");
+        offset += crm_snprintf_offset(buffer, offset, LINE_MAX, "FAILED");
     } else {
         const char *rsc_state = NULL;
 
@@ -515,17 +515,18 @@ native_print(resource_t * rsc, const char *pre_text, long options, void *print_d
 		target_role_e == RSC_ROLE_STOPPED ||
                 safe_str_neq(target_role, rsc_state)))
             {
-                offset += snprintf(buffer + offset, LINE_MAX - offset, "(target-role:%s) ", target_role);
+                offset += crm_snprintf_offset(buffer, offset, LINE_MAX,
+                                              "(target-role:%s) ", target_role);
             }
         }
-        offset += snprintf(buffer + offset, LINE_MAX - offset, "%s", rsc_state);
+        offset += crm_snprintf_offset(buffer, offset, LINE_MAX, "%s", rsc_state);
     }
 
     if(node) {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, " %s", node->details->uname);
+        offset += crm_snprintf_offset(buffer, offset, LINE_MAX, " %s", node->details->uname);
 
         if (node->details->online == FALSE && node->details->unclean) {
-            offset += snprintf(buffer + offset, LINE_MAX - offset, " (UNCLEAN)");
+            offset += crm_snprintf_offset(buffer, offset, LINE_MAX, " (UNCLEAN)");
         }
     }
 
@@ -533,25 +534,25 @@ native_print(resource_t * rsc, const char *pre_text, long options, void *print_d
         const char *pending_task = native_pending_task(rsc);
 
         if (pending_task) {
-            offset += snprintf(buffer + offset, LINE_MAX - offset, " (%s)", pending_task);
+            offset += crm_snprintf_offset(buffer, offset, LINE_MAX, " (%s)", pending_task);
         }
     }
 
     if(is_not_set(rsc->flags, pe_rsc_managed)) {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, " (unmanaged)");
+        offset += crm_snprintf_offset(buffer, offset, LINE_MAX, " (unmanaged)");
     }
     if(is_set(rsc->flags, pe_rsc_failure_ignored)) {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, " (failure ignored)");
+        offset += crm_snprintf_offset(buffer, offset, LINE_MAX, " (failure ignored)");
     }
 
     if ((options & pe_print_rsconly) || g_list_length(rsc->running_on) > 1) {
         const char *desc = crm_element_value(rsc->xml, XML_ATTR_DESC);
         if(desc) {
-            offset += snprintf(buffer + offset, LINE_MAX - offset, " %s", desc);
+            offset += crm_snprintf_offset(buffer, offset, LINE_MAX, " %s", desc);
         }
     }
 
-    CRM_LOG_ASSERT(offset > 0);
+    CRM_LOG_ASSERT(offset > 0 && offset < LINE_MAX);
     status_print("%s", buffer);
 
 #if CURSES_ENABLED
@@ -738,13 +739,13 @@ get_rscs_brief(GListPtr rsc_list, GHashTable * rsc_table, GHashTable * active_ta
             continue;
         }
 
-        offset += snprintf(buffer + offset, LINE_MAX - offset, "%s", class);
+        offset += crm_snprintf_offset(buffer, offset, LINE_MAX, "%s", class);
         if (safe_str_eq(class, "ocf")) {
             const char *prov = crm_element_value(rsc->xml, XML_AGENT_ATTR_PROVIDER);
-            offset += snprintf(buffer + offset, LINE_MAX - offset, "::%s", prov);
+            offset += crm_snprintf_offset(buffer, offset, LINE_MAX, "::%s", prov);
         }
-        offset += snprintf(buffer + offset, LINE_MAX - offset, ":%s", kind);
-        CRM_LOG_ASSERT(offset > 0);
+        offset += crm_snprintf_offset(buffer, offset, LINE_MAX, ":%s", kind);
+        CRM_LOG_ASSERT(offset > 0 && offset < LINE_MAX);
 
         if (rsc_table) {
             rsc_counter = g_hash_table_lookup(rsc_table, buffer);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2323,29 +2323,30 @@ find_lrm_op(const char *resource, const char *op, const char *node, const char *
     int offset = 0;
     char xpath[STATUS_PATH_MAX];
 
-    offset += snprintf(xpath + offset, STATUS_PATH_MAX - offset, "//node_state[@uname='%s']", node);
+    offset += crm_snprintf_offset(xpath, offset, STATUS_PATH_MAX,
+                                  "//node_state[@uname='%s']", node);
     offset +=
-        snprintf(xpath + offset, STATUS_PATH_MAX - offset, "//" XML_LRM_TAG_RESOURCE "[@id='%s']",
-                 resource);
+        crm_snprintf_offset(xpath, offset, STATUS_PATH_MAX,
+                            "//" XML_LRM_TAG_RESOURCE "[@id='%s']", resource);
 
     /* Need to check against transition_magic too? */
     if (source && safe_str_eq(op, CRMD_ACTION_MIGRATE)) {
         offset +=
-            snprintf(xpath + offset, STATUS_PATH_MAX - offset,
-                     "/" XML_LRM_TAG_RSC_OP "[@operation='%s' and @migrate_target='%s']", op,
-                     source);
+            crm_snprintf_offset(xpath, offset, STATUS_PATH_MAX,
+                                "/" XML_LRM_TAG_RSC_OP "[@operation='%s' and @migrate_target='%s']",
+                                op, source);
     } else if (source && safe_str_eq(op, CRMD_ACTION_MIGRATED)) {
         offset +=
-            snprintf(xpath + offset, STATUS_PATH_MAX - offset,
-                     "/" XML_LRM_TAG_RSC_OP "[@operation='%s' and @migrate_source='%s']", op,
-                     source);
+            crm_snprintf_offset(xpath, offset, STATUS_PATH_MAX,
+                                "/" XML_LRM_TAG_RSC_OP "[@operation='%s' and @migrate_source='%s']",
+                                op, source);
     } else {
         offset +=
-            snprintf(xpath + offset, STATUS_PATH_MAX - offset,
-                     "/" XML_LRM_TAG_RSC_OP "[@operation='%s']", op);
+            crm_snprintf_offset(xpath, offset, STATUS_PATH_MAX,
+                                "/" XML_LRM_TAG_RSC_OP "[@operation='%s']", op);
     }
 
-    CRM_LOG_ASSERT(offset > 0);
+    CRM_LOG_ASSERT(offset > 0 && offset < STATUS_PATH_MAX);
     return get_xpath_object(xpath, data_set->input, LOG_DEBUG);
 }
 

--- a/pengine/allocate.c
+++ b/pengine/allocate.c
@@ -2034,14 +2034,15 @@ expand_node_list(GListPtr list)
 
         if (node->details->uname) {
             int existing_len = 0;
-            int len = 2 + strlen(node->details->uname);
+            int len = 2 + strlen(node->details->uname);  /* space + null byte */
 
             if(node_list) {
                 existing_len = strlen(node_list);
             }
             crm_trace("Adding %s (%dc) at offset %d", node->details->uname, len - 2, existing_len);
             node_list = realloc_safe(node_list, len + existing_len);
-            sprintf(node_list + existing_len, "%s%s", existing_len == 0 ? "":" ", node->details->uname);
+            snprintf(node_list + existing_len, len,
+                     "%s%s", existing_len == 0 ? "":" ", node->details->uname);
         }
     }
 

--- a/pengine/regression.core.sh.in
+++ b/pengine/regression.core.sh.in
@@ -60,7 +60,7 @@ while true ; do
 	-V|--verbose) verbose=1; shift;;
 	-v|--valgrind)
 	    export G_SLICE=always-malloc
-	    VALGRIND_CMD="valgrind -q --gen-suppressions=all --log-file=%q{valgrind_output} --show-reachable=no --leak-check=full --trace-children=no --time-stamp=yes --num-callers=20 --suppressions=@datadir@/@PACKAGE@/tests/valgrind-pcmk.suppressions"
+	    VALGRIND_CMD="valgrind -q --gen-suppressions=all --log-file=%q{valgrind_output} --show-reachable=no --leak-check=full --trace-children=no --time-stamp=yes --num-callers=20 --partial-loads-ok=yes --suppressions=@datadir@/@PACKAGE@/tests/valgrind-pcmk.suppressions"
 	    test_binary=
 	    shift;;
 	--valgrind-dhat)

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -3529,26 +3529,32 @@ send_smtp_trap(const char *node, const char *rsc, const char *task, int target_r
              rsc, node, desc);
 
     len = 0;
-    len += snprintf(crm_mail_body + len, BODY_MAX - len, "\r\n%s\r\n", crm_mail_prefix);
-    len += snprintf(crm_mail_body + len, BODY_MAX - len, "====\r\n\r\n");
+    len += crm_snprintf_offset(crm_mail_body, len, BODY_MAX, "\r\n%s\r\n", crm_mail_prefix);
+    len += crm_snprintf_offset(crm_mail_body, len, BODY_MAX, "====\r\n\r\n");
     if (rc == target_rc) {
-        len += snprintf(crm_mail_body + len, BODY_MAX - len,
-                        "Completed operation %s for resource %s on %s\r\n", task, rsc, node);
+        len += crm_snprintf_offset(crm_mail_body, len, BODY_MAX,
+                                   "Completed operation %s for resource %s on %s\r\n",
+                                   task, rsc, node);
     } else {
-        len += snprintf(crm_mail_body + len, BODY_MAX - len,
-                        "Operation %s for resource %s on %s failed: %s\r\n", task, rsc, node, desc);
+        len += crm_snprintf_offset(crm_mail_body, len, BODY_MAX,
+                                   "Operation %s for resource %s on %s failed: %s\r\n",
+                                   task, rsc, node, desc);
     }
 
-    len += snprintf(crm_mail_body + len, BODY_MAX - len, "\r\nDetails:\r\n");
-    len += snprintf(crm_mail_body + len, BODY_MAX - len,
-                    "\toperation status: (%d) %s\r\n", status, services_lrm_status_str(status));
+    len += crm_snprintf_offset(crm_mail_body, len, BODY_MAX, "\r\nDetails:\r\n");
+    len += crm_snprintf_offset(crm_mail_body, len, BODY_MAX,
+                               "\toperation status: (%d) %s\r\n", status,
+                               services_lrm_status_str(status));
     if (status == PCMK_LRM_OP_DONE) {
-        len += snprintf(crm_mail_body + len, BODY_MAX - len,
-                        "\tscript returned: (%d) %s\r\n", rc, services_ocf_exitcode_str(rc));
-        len += snprintf(crm_mail_body + len, BODY_MAX - len,
-                        "\texpected return value: (%d) %s\r\n", target_rc,
-                        services_ocf_exitcode_str(target_rc));
+        len += crm_snprintf_offset(crm_mail_body, len, BODY_MAX,
+                                   "\tscript returned: (%d) %s\r\n", rc,
+                                   services_ocf_exitcode_str(rc));
+        len += crm_snprintf_offset(crm_mail_body, len, BODY_MAX,
+                                   "\texpected return value: (%d) %s\r\n",
+                                   target_rc,
+                                   services_ocf_exitcode_str(target_rc));
     }
+    CRM_LOG_ASSERT(len > 0 && len < BODY_MAX);
 
     auth_client_init();
     session = smtp_create_session();

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -589,7 +589,7 @@ main(int argc, char **argv)
     rc = cib_conn->cmds->signon(cib_conn, crm_system_name, cib_command);
     if (rc != pcmk_ok) {
         CMD_ERR("Error signing on to the CIB service: %s", pcmk_strerror(rc));
-        return crm_exit(rc);
+        goto bail;
     }
 
     /* Populate working set from XML file if specified or CIB query otherwise */
@@ -959,7 +959,8 @@ main(int argc, char **argv)
             if (node && is_remote_node(node)) {
                 if (node->details->remote_rsc == NULL || node->details->remote_rsc->running_on == NULL) {
                     CMD_ERR("No lrmd connection detected to remote node %s", host_uname);
-                    return -ENXIO;
+                    rc = -ENXIO;
+                    goto bail;
                 }
                 node = node->details->remote_rsc->running_on->data;
                 router_node = node->details->uname;
@@ -1029,6 +1030,8 @@ main(int argc, char **argv)
     }
 
   bail:
+
+    free(our_pid);
 
     if (data_set.input != NULL) {
         cleanup_alloc_calculations(&data_set);

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -18,6 +18,7 @@
  */
 
 #include <crm_resource.h>
+#include <crm_internal.h>  /* crm_snprintf_offset */
 
 bool do_trace = FALSE;
 bool do_force = FALSE;
@@ -132,30 +133,34 @@ find_resource_attr(cib_t * the_cib, const char *attr, const char *rsc, const cha
 
     xpath_string = calloc(1, xpath_max);
     offset +=
-        snprintf(xpath_string + offset, xpath_max - offset, "%s", get_object_path("resources"));
+        crm_snprintf_offset(xpath_string, offset, xpath_max,
+                            "%s", get_object_path("resources"));
 
-    offset += snprintf(xpath_string + offset, xpath_max - offset, "//*[@id=\"%s\"]", rsc);
+    offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "//*[@id=\"%s\"]", rsc);
 
     if (set_type) {
-        offset += snprintf(xpath_string + offset, xpath_max - offset, "/%s", set_type);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "/%s", set_type);
         if (set_name) {
-            offset += snprintf(xpath_string + offset, xpath_max - offset, "[@id=\"%s\"]", set_name);
+            offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                          "[@id=\"%s\"]", set_name);
         }
     }
 
-    offset += snprintf(xpath_string + offset, xpath_max - offset, "//nvpair[");
+    offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "//nvpair[");
     if (attr_id) {
-        offset += snprintf(xpath_string + offset, xpath_max - offset, "@id=\"%s\"", attr_id);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                      "@id=\"%s\"", attr_id);
     }
 
     if (attr_name) {
         if (attr_id) {
-            offset += snprintf(xpath_string + offset, xpath_max - offset, " and ");
+            offset += crm_snprintf_offset(xpath_string, offset, xpath_max, " and ");
         }
-        offset += snprintf(xpath_string + offset, xpath_max - offset, "@name=\"%s\"", attr_name);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                      "@name=\"%s\"", attr_name);
     }
-    offset += snprintf(xpath_string + offset, xpath_max - offset, "]");
-    CRM_LOG_ASSERT(offset > 0);
+    offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "]");
+    CRM_LOG_ASSERT(offset > 0 && offset < xpath_max);
 
     rc = the_cib->cmds->query(the_cib, xpath_string, &xml_search,
                               cib_sync_call | cib_scope_local | cib_xpath);

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -118,7 +118,7 @@ find_resource_attr(cib_t * the_cib, const char *attr, const char *rsc, const cha
                    const char *set_name, const char *attr_id, const char *attr_name, char **value)
 {
     int offset = 0;
-    static int xpath_max = 1024;
+    static const int xpath_max = 1024;
     int rc = pcmk_ok;
     xmlNode *xml_search = NULL;
     char *xpath_string = NULL;

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -164,14 +164,14 @@ find_ticket_state(cib_t * the_cib, const char *ticket_id, xmlNode ** ticket_stat
     *ticket_state_xml = NULL;
 
     xpath_string = calloc(1, xpath_max);
-    offset += snprintf(xpath_string + offset, xpath_max - offset, "%s", "/cib/status/tickets");
+    offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "%s", "/cib/status/tickets");
 
     if (ticket_id) {
-        offset += snprintf(xpath_string + offset, xpath_max - offset, "/%s[@id=\"%s\"]",
-                           XML_CIB_TAG_TICKET_STATE, ticket_id);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                      "/%s[@id=\"%s\"]", XML_CIB_TAG_TICKET_STATE, ticket_id);
     }
 
-    CRM_LOG_ASSERT(offset > 0);
+    CRM_LOG_ASSERT(offset > 0 && offset < xpath_max);
     rc = the_cib->cmds->query(the_cib, xpath_string, &xml_search,
                               cib_sync_call | cib_scope_local | cib_xpath);
 
@@ -209,15 +209,16 @@ find_ticket_constraints(cib_t * the_cib, const char *ticket_id, xmlNode ** ticke
 
     xpath_string = calloc(1, xpath_max);
     offset +=
-        snprintf(xpath_string + offset, xpath_max - offset, "%s/%s",
-                 get_object_path(XML_CIB_TAG_CONSTRAINTS), XML_CONS_TAG_RSC_TICKET);
+        crm_snprintf_offset(xpath_string, offset, xpath_max, "%s/%s",
+                            get_object_path(XML_CIB_TAG_CONSTRAINTS),
+                            XML_CONS_TAG_RSC_TICKET);
 
     if (ticket_id) {
-        offset += snprintf(xpath_string + offset, xpath_max - offset, "[@ticket=\"%s\"]",
-                           ticket_id);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                      "[@ticket=\"%s\"]", ticket_id);
     }
 
-    CRM_LOG_ASSERT(offset > 0);
+    CRM_LOG_ASSERT(offset > 0 && offset < xpath_max);
     rc = the_cib->cmds->query(the_cib, xpath_string, &xml_search,
                               cib_sync_call | cib_scope_local | cib_xpath);
 
@@ -295,18 +296,21 @@ find_ticket_state_attr_legacy(cib_t * the_cib, const char *attr, const char *tic
     *value = NULL;
 
     xpath_string = calloc(1, xpath_max);
-    offset += snprintf(xpath_string + offset, xpath_max - offset, "%s", "/cib/status/tickets");
+    offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                  "%s", "/cib/status/tickets");
 
     if (set_type) {
-        offset += snprintf(xpath_string + offset, xpath_max - offset, "/%s", set_type);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "/%s", set_type);
         if (set_name) {
-            offset += snprintf(xpath_string + offset, xpath_max - offset, "[@id=\"%s\"]", set_name);
+            offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                          "[@id=\"%s\"]", set_name);
         }
     }
 
-    offset += snprintf(xpath_string + offset, xpath_max - offset, "//nvpair[");
+    offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "//nvpair[");
     if (attr_id) {
-        offset += snprintf(xpath_string + offset, xpath_max - offset, "@id=\"%s\"", attr_id);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                      "@id=\"%s\"", attr_id);
     }
 
     if (attr_name) {
@@ -321,14 +325,15 @@ find_ticket_state_attr_legacy(cib_t * the_cib, const char *attr, const char *tic
         long_key = crm_concat(attr_prefix, ticket_id, '-');
 
         if (attr_id) {
-            offset += snprintf(xpath_string + offset, xpath_max - offset, " and ");
+            offset += crm_snprintf_offset(xpath_string, offset, xpath_max, " and ");
         }
-        offset += snprintf(xpath_string + offset, xpath_max - offset, "@name=\"%s\"", long_key);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                      "@name=\"%s\"", long_key);
 
         free(long_key);
     }
-    offset += snprintf(xpath_string + offset, xpath_max - offset, "]");
-    CRM_LOG_ASSERT(offset > 0);
+    offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "]");
+    CRM_LOG_ASSERT(offset > 0 && offset < xpath_max);
 
     rc = the_cib->cmds->query(the_cib, xpath_string, &xml_search,
                               cib_sync_call | cib_scope_local | cib_xpath);
@@ -439,34 +444,34 @@ ticket_warning(const char *ticket_id, const char *action)
 
     warning = calloc(1, text_max);
     if (safe_str_eq(action, "grant")) {
-        offset += snprintf(warning + offset, text_max - offset,
-                           "This command cannot help you verify whether '%s' has been already granted elsewhere.\n",
-                           ticket_id);
+        offset += crm_snprintf_offset(warning, offset, text_max,
+                                      "This command cannot help you verify whether '%s' has been already granted elsewhere.\n",
+                                      ticket_id);
         word = "to";
 
     } else {
-        offset += snprintf(warning + offset, text_max - offset,
-                           "Revoking '%s' can trigger the specified 'loss-policy'(s) relating to '%s'.\n\n",
-                           ticket_id, ticket_id);
+        offset += crm_snprintf_offset(warning, offset, text_max,
+                                      "Revoking '%s' can trigger the specified 'loss-policy'(s) relating to '%s'.\n\n",
+                                      ticket_id, ticket_id);
 
-        offset += snprintf(warning + offset, text_max - offset,
-                           "You can check that with:\ncrm_ticket --ticket %s --constraints\n\n",
-                           ticket_id);
+        offset += crm_snprintf_offset(warning, offset, text_max,
+                                      "You can check that with:\ncrm_ticket --ticket %s --constraints\n\n",
+                                      ticket_id);
 
-        offset += snprintf(warning + offset, text_max - offset,
-                           "Otherwise before revoking '%s', you may want to make '%s' standby with:\ncrm_ticket --ticket %s --standby\n\n",
-                           ticket_id, ticket_id, ticket_id);
+        offset += crm_snprintf_offset(warning, offset, text_max,
+                                      "Otherwise before revoking '%s', you may want to make '%s' standby with:\ncrm_ticket --ticket %s --standby\n\n",
+                                      ticket_id, ticket_id, ticket_id);
         word = "from";
     }
 
-    offset += snprintf(warning + offset, text_max - offset,
-                       "If you really want to %s '%s' %s this site now, and you know what you are doing,\n",
-                       action, ticket_id, word);
+    offset += crm_snprintf_offset(warning, offset, text_max,
+                                  "If you really want to %s '%s' %s this site now, and you know what you are doing,\n",
+                                  action, ticket_id, word);
 
-    offset += snprintf(warning + offset, text_max - offset, 
-                       "please specify --force.");
+    offset += crm_snprintf_offset(warning, offset, text_max,
+                                  "please specify --force.");
 
-    CRM_LOG_ASSERT(offset > 0);
+    CRM_LOG_ASSERT(offset > 0 && offset < text_max);
     fprintf(stdout, "%s\n", warning);
 
     free(warning);

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -154,7 +154,7 @@ static int
 find_ticket_state(cib_t * the_cib, const char *ticket_id, xmlNode ** ticket_state_xml)
 {
     int offset = 0;
-    static int xpath_max = 1024;
+    static const int xpath_max = 1024;
     int rc = pcmk_ok;
     xmlNode *xml_search = NULL;
 
@@ -198,7 +198,7 @@ static int
 find_ticket_constraints(cib_t * the_cib, const char *ticket_id, xmlNode ** ticket_cons_xml)
 {
     int offset = 0;
-    static int xpath_max = 1024;
+    static const int xpath_max = 1024;
     int rc = pcmk_ok;
     xmlNode *xml_search = NULL;
 
@@ -285,7 +285,7 @@ find_ticket_state_attr_legacy(cib_t * the_cib, const char *attr, const char *tic
                               const char *attr_name, char **value)
 {
     int offset = 0;
-    static int xpath_max = 1024;
+    static const int xpath_max = 1024;
     int rc = pcmk_ok;
     xmlNode *xml_search = NULL;
 
@@ -432,7 +432,7 @@ ticket_warning(const char *ticket_id, const char *action)
 {
     gboolean rc = FALSE;
     int offset = 0;
-    static int text_max = 1024;
+    static const int text_max = 1024;
 
     char *warning = NULL;
     const char *word = NULL;

--- a/tools/fake_transition.c
+++ b/tools/fake_transition.c
@@ -354,13 +354,13 @@ find_ticket_state(cib_t * the_cib, const char *ticket_id, xmlNode ** ticket_stat
     *ticket_state_xml = NULL;
 
     xpath_string = calloc(1, xpath_max);
-    offset += snprintf(xpath_string + offset, xpath_max - offset, "%s", "/cib/status/tickets");
+    offset += crm_snprintf_offset(xpath_string, offset, xpath_max, "%s", "/cib/status/tickets");
 
     if (ticket_id) {
-        offset += snprintf(xpath_string + offset, xpath_max - offset, "/%s[@id=\"%s\"]",
-                           XML_CIB_TAG_TICKET_STATE, ticket_id);
+        offset += crm_snprintf_offset(xpath_string, offset, xpath_max,
+                                      "/%s[@id=\"%s\"]", XML_CIB_TAG_TICKET_STATE, ticket_id);
     }
-    CRM_LOG_ASSERT(offset > 0);
+    CRM_LOG_ASSERT(offset > 0 && offset < xpath_max);
     rc = the_cib->cmds->query(the_cib, xpath_string, &xml_search,
                               cib_sync_call | cib_scope_local | cib_xpath);
 

--- a/tools/fake_transition.c
+++ b/tools/fake_transition.c
@@ -344,7 +344,7 @@ static int
 find_ticket_state(cib_t * the_cib, const char *ticket_id, xmlNode ** ticket_state_xml)
 {
     int offset = 0;
-    static int xpath_max = 1024;
+    static const int xpath_max = 1024;
     int rc = pcmk_ok;
     xmlNode *xml_search = NULL;
 

--- a/tools/regression.sh
+++ b/tools/regression.sh
@@ -52,7 +52,7 @@ while test "$done" = "0"; do
 	-V|--verbose) verbose=1; shift;;
 	-v|--valgrind)
 	    export G_SLICE=always-malloc
-	    VALGRIND_CMD="valgrind -q --gen-suppressions=all --show-reachable=no --leak-check=full --trace-children=no --time-stamp=yes --num-callers=20 --suppressions=/usr/share/pacemaker/tests/valgrind-pcmk.suppressions"
+	    VALGRIND_CMD="valgrind -q --gen-suppressions=all --show-reachable=no --leak-check=full --trace-children=no --time-stamp=yes --num-callers=20 --partial-loads-ok=yes --suppressions=/usr/share/pacemaker/tests/valgrind-pcmk.suppressions"
 	    shift;;
 	-x) set -x; shift;;
 	-s) do_save=1; shift;;


### PR DESCRIPTION
- global `snprintf` rewrite as discussed (https://github.com/ClusterLabs/pacemaker/pull/792#discussion_r39453677); note that `crm_snprintf_offset` name for the macro was chosen to better reflect its idiomatic `offset += crm_snprintf_offset()` use
- `crm_resource` memleak was fixed (discovered by `./BasicSanity.sh -v cli`)
- `valgrind` now uses `--partial-loads-ok=yes` to avoid known false positives
- some more fixing (possible buffer overrun, off-by-one greedy allocations) and silencing (recent `ar` tool)
