### PR TITLE
Low: libcommon: Ignore CDATA of metadata of the resource.

### DIFF
--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -587,6 +587,7 @@ pcmkRegisterNode(xmlNodePtr node)
             break;
         case XML_TEXT_NODE:
         case XML_DTD_NODE:
+        case XML_CDATA_SECTION_NODE:
             break;
         default:
             /* Ignore */


### PR DESCRIPTION
When CDATA is included in metada of the resource, an error occurs.

Oct  9 09:35:57 rh66-tomcat1 crmd[11182]:    error: crm_abort: pcmkRegisterNode: Triggered assert at xml.c:595 : node->type == XML_ELEMENT_NODE

The present conditions are only resources of tomcat, but, in
consideration of the future, should ignore CDATA.

/usr/lib/ocf/resource.d/heartbeat/tomcat
(snip)
<parameter name="tomcat_name" unique="1" >
<longdesc lang="en"><![CDATA[
The name of the resource, added as a Java parameter in JAVA_OPTS:
-Dname=<tomcat_name> to Tomcat process on start. Used to ensure
process is still running and must be unique.
]]></longdesc>
<shortdesc>The name of the resource</shortdesc>
<content type="string" default="" />
</parameter>
(snip)

Best Regards,
Hideo Yamauchi.