### PR TITLE
Finalize support for targeting fencing by node attribute

### DIFF
--- a/crmd/notify.c
+++ b/crmd/notify.c
@@ -108,7 +108,7 @@ send_notification(const char *kind)
 
     notify = services_action_create_generic(notify_script, NULL);
 
-    notify->timeout = 300;
+    notify->timeout = CRMD_NOTIFY_TIMEOUT_MS;
     notify->standard = strdup("event");
     notify->id = strdup(notify_script);
     notify->agent = strdup(notify_script);

--- a/crmd/notify.h
+++ b/crmd/notify.h
@@ -22,6 +22,9 @@
 #  include <crm/cluster.h>
 #  include <crm/stonith-ng.h>
 
+/* Timeout to use before killing a notification script (in milliseconds) */
+#  define CRMD_NOTIFY_TIMEOUT_MS (300000)
+
 void crmd_enable_notifications(const char *script, const char *target);
 void crmd_notify_node_event(crm_node_t *node);
 void crmd_notify_fencing_op(stonith_event_t * e);

--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -2428,53 +2428,29 @@ handle_request(crm_client_t * client, uint32_t id, uint32_t flags, xmlNode * req
 
     } else if (crm_str_eq(op, STONITH_OP_DEVICE_ADD, TRUE)) {
         const char *id = NULL;
-        xmlNode *notify_data = create_xml_node(NULL, op);
 
         rc = stonith_device_register(request, &id, FALSE);
-
-        crm_xml_add(notify_data, F_STONITH_DEVICE, id);
-        crm_xml_add_int(notify_data, F_STONITH_ACTIVE, g_hash_table_size(device_list));
-
-        do_stonith_notify(call_options, op, rc, notify_data);
-        free_xml(notify_data);
+        do_stonith_notify_device(call_options, op, rc, id);
 
     } else if (crm_str_eq(op, STONITH_OP_DEVICE_DEL, TRUE)) {
         xmlNode *dev = get_xpath_object("//" F_STONITH_DEVICE, request, LOG_ERR);
         const char *id = crm_element_value(dev, XML_ATTR_ID);
-        xmlNode *notify_data = create_xml_node(NULL, op);
 
         rc = stonith_device_remove(id, FALSE);
-
-        crm_xml_add(notify_data, F_STONITH_DEVICE, id);
-        crm_xml_add_int(notify_data, F_STONITH_ACTIVE, g_hash_table_size(device_list));
-
-        do_stonith_notify(call_options, op, rc, notify_data);
-        free_xml(notify_data);
+        do_stonith_notify_device(call_options, op, rc, id);
 
     } else if (crm_str_eq(op, STONITH_OP_LEVEL_ADD, TRUE)) {
         char *id = NULL;
-        xmlNode *notify_data = create_xml_node(NULL, op);
 
         rc = stonith_level_register(request, &id);
-
-        crm_xml_add(notify_data, F_STONITH_DEVICE, id);
-        crm_xml_add_int(notify_data, F_STONITH_ACTIVE, g_hash_table_size(topology));
-
-        do_stonith_notify(call_options, op, rc, notify_data);
-        free_xml(notify_data);
+        do_stonith_notify_level(call_options, op, rc, id);
         free(id);
 
     } else if (crm_str_eq(op, STONITH_OP_LEVEL_DEL, TRUE)) {
         char *id = NULL;
-        xmlNode *notify_data = create_xml_node(NULL, op);
 
         rc = stonith_level_remove(request, &id);
-
-        crm_xml_add(notify_data, F_STONITH_DEVICE, id);
-        crm_xml_add_int(notify_data, F_STONITH_ACTIVE, g_hash_table_size(topology));
-
-        do_stonith_notify(call_options, op, rc, notify_data);
-        free_xml(notify_data);
+        do_stonith_notify_level(call_options, op, rc, id);
 
     } else if (crm_str_eq(op, STONITH_OP_CONFIRM, TRUE)) {
         async_command_t *cmd = create_async_command(request);

--- a/fencing/internal.h
+++ b/fencing/internal.h
@@ -198,6 +198,8 @@ void
  do_stonith_async_timeout_update(const char *client, const char *call_id, int timeout);
 
 void do_stonith_notify(int options, const char *type, int result, xmlNode * data);
+void do_stonith_notify_device(int options, const char *op, int rc, const char *desc);
+void do_stonith_notify_level(int options, const char *op, int rc, const char *desc);
 
 remote_fencing_op_t *initiate_remote_stonith_op(crm_client_t * client, xmlNode * request,
                                                        gboolean manual_ack);

--- a/fencing/regression.py.in
+++ b/fencing/regression.py.in
@@ -631,6 +631,20 @@ class Tests:
             test.add_cmd("stonith_admin", "-F node3 -t 2")
             test.add_stonith_log_pattern("for host 'node3' with device 'true' returned: 0")
 
+        # test allowing commas and semicolons as delimiters in pcmk_host_list
+        for test_type in test_types:
+            test = self.new_test("%s_host_list_delimiters" % test_type["prefix"],
+                                 "Verify commas and semicolons can be used as pcmk_host_list delimiters",
+                                 test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         """-R true1 -a fence_dummy -o "mode=pass" -o "pcmk_host_list=node1,node2,node3" """)
+            test.add_cmd("stonith_admin",
+                         """-R true2 -a fence_dummy -o "mode=pass" -o "pcmk_host_list=pcmk1;pcmk2;pcmk3" """)
+            test.add_cmd("stonith_admin", "stonith_admin -F node2 -t 2")
+            test.add_cmd("stonith_admin", "stonith_admin -F pcmk3 -t 2")
+            test.add_stonith_log_pattern("for host 'node2' with device 'true1' returned: 0")
+            test.add_stonith_log_pattern("for host 'pcmk3' with device 'true2' returned: 0")
+
         # test the stonith builds the correct list of devices that can fence a node.
         for test_type in test_types:
             test = self.new_test("%s_list_devices" % test_type["prefix"],

--- a/fencing/regression.py.in
+++ b/fencing/regression.py.in
@@ -618,6 +618,19 @@ class Tests:
             test.add_stonith_log_pattern("for host 'node3' with device 'true3' returned: 0")
             test.add_stonith_log_pattern("for host 'node3' with device 'true4' returned: 0")
 
+        # Test targeting a topology level by node name pattern.
+        for test_type in test_types:
+            if test_type["use_cpg"] == 0:
+                continue
+
+            test = self.new_test("%s_topology_level_pattern" % test_type["prefix"],
+                    "Verify targeting topology by node name pattern works.", test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         """-R true -a fence_dummy -o "mode=pass" -o "pcmk_host_list=node1 node2 node3" """)
+            test.add_cmd("stonith_admin", """-r '@node.*' -i 1 -v true""")
+            test.add_cmd("stonith_admin", "-F node3 -t 2")
+            test.add_stonith_log_pattern("for host 'node3' with device 'true' returned: 0")
+
         # test the stonith builds the correct list of devices that can fence a node.
         for test_type in test_types:
             test = self.new_test("%s_list_devices" % test_type["prefix"],

--- a/fencing/standalone_config.c
+++ b/fencing/standalone_config.c
@@ -272,7 +272,7 @@ cfg_register_topology(struct topology *topo)
     for (i = 0; i < topo->priority_levels_count; i++) {
         devices = stonith_key_value_add(devices, NULL, topo->priority_levels[i].device_name);
 
-        data = create_level_registration_xml(topo->node_name,
+        data = create_level_registration_xml(topo->node_name, NULL, NULL, NULL,
                                              topo->priority_levels[i].level, devices);
 
         dump = dump_xml_formatted(data);

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -42,8 +42,10 @@ int
 
 gboolean is_redhat_agent(const char *agent);
 
-xmlNode *create_level_registration_xml(const char *node, int level,
-                                       stonith_key_value_t * device_list);
+xmlNode *create_level_registration_xml(const char *node, const char *pattern,
+                                       const char *attr, const char *value,
+                                       int level,
+                                       stonith_key_value_t *device_list);
 
 xmlNode *create_device_registration_xml(const char *id, const char *namespace, const char *agent,
                                         stonith_key_value_t * params, const char *rsc_provides);

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -314,6 +314,48 @@ typedef struct stonith_api_operations_s
      */
     int (*remove_callback)(stonith_t *st, int call_id, bool all_callbacks);
 
+    /*!
+     * \brief Remove fencing level for specific node, node regex or attribute
+     *
+     * \param[in] st      Stonithd connection to use
+     * \param[in] options Bitmask of stonith_call_options to pass to stonithd
+     * \param[in] node    If not NULL, target level by this node name
+     * \param[in] pattern If not NULL, target by node name using this regex
+     * \param[in] attr    If not NULL, target by this node attribute
+     * \param[in] value   If not NULL, target by this node attribute value
+     * \param[in] level   Index number of level to remove
+     *
+     * \return 0 on success, negative error code otherwise
+     *
+     * \note This feature is not available when stonith is in standalone mode.
+     *       The caller should set only one of node, pattern or attr/value.
+     */
+    int (*remove_level_full)(stonith_t *st, int options,
+                             const char *node, const char *pattern,
+                             const char *attr, const char *value, int level);
+
+    /*!
+     * \brief Register fencing level for specific node, node regex or attribute
+     *
+     * \param[in] st          Stonithd connection to use
+     * \param[in] options     Bitmask of stonith_call_options to pass to stonithd
+     * \param[in] node        If not NULL, target level by this node name
+     * \param[in] pattern     If not NULL, target by node name using this regex
+     * \param[in] attr        If not NULL, target by this node attribute
+     * \param[in] value       If not NULL, target by this node attribute value
+     * \param[in] level       Index number of level to add
+     * \param[in] device_list Devices to use in level
+     *
+     * \return 0 on success, negative error code otherwise
+     *
+     * \note This feature is not available when stonith is in standalone mode.
+     *       The caller should set only one of node, pattern or attr/value.
+     */
+    int (*register_level_full)(stonith_t *st, int options,
+                               const char *node, const char *pattern,
+                               const char *attr, const char *value,
+                               int level, stonith_key_value_t *device_list);
+
 } stonith_api_operations_t;
 
 struct stonith_s


### PR DESCRIPTION
This adds support for target-by-attribute to the libfencing API, stonith_admin and regression tests.

It also includes two unrelated commits for fixing some issues with timeout handling.