### PR TITLE
Fix: systemd: Reconnect to System DBus if the connection is closed

### DIFF
--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -78,6 +78,14 @@ systemd_init(void)
     static int need_init = 1;
     /* http://dbus.freedesktop.org/doc/api/html/group__DBusConnection.html */
 
+    if (systemd_proxy
+        && dbus_connection_get_is_connected(systemd_proxy) == FALSE) {
+        crm_warn("Connection to System DBus is closed. Reconnecting...");
+        pcmk_dbus_disconnect(systemd_proxy);
+        systemd_proxy = NULL;
+        need_init = 1;
+    }
+
     if (need_init) {
         need_init = 0;
         systemd_proxy = pcmk_dbus_connect();


### PR DESCRIPTION
An user's system encounters high load, which leads to monitor timeout of systemd resources. Then the connection to system dbus is found to be closed.

I think in that case we should try to reconnect. Please check if I've missed anything.