### PR TITLE
Fixes for the execution functions of services

### DIFF
--- a/lib/services/dbus.c
+++ b/lib/services/dbus.c
@@ -176,7 +176,7 @@ DBusPendingCall* pcmk_dbus_send(DBusMessage *msg, DBusConnection *connection,
         return NULL;
 
     } else if (pending == NULL) {
-        crm_err("No pending call found for %s", method);
+        crm_err("No pending call found for %s: Connection to System DBus may be closed", method);
         return NULL;
     }
 

--- a/lib/services/services_private.h
+++ b/lib/services/services_private.h
@@ -44,7 +44,7 @@ struct svc_action_private_s {
 
 GList *services_os_get_directory_list(const char *root, gboolean files, gboolean executable);
 
-gboolean services_os_action_execute(svc_action_t * op, gboolean synchronous);
+gboolean services_os_action_execute(svc_action_t * op, gboolean synchronous, gboolean * inflight);
 
 GList *resources_os_list_lsb_agents(void);
 

--- a/lib/services/systemd.h
+++ b/lib/services/systemd.h
@@ -17,7 +17,7 @@
  */
 
 G_GNUC_INTERNAL GList *systemd_unit_listall(void);
-G_GNUC_INTERNAL int systemd_unit_exec(svc_action_t * op);
+G_GNUC_INTERNAL int systemd_unit_exec(svc_action_t * op, gboolean * inflight);
 G_GNUC_INTERNAL gboolean systemd_unit_exists(const gchar * name);
 G_GNUC_INTERNAL gboolean systemd_unit_running(const gchar * name);
 G_GNUC_INTERNAL void systemd_cleanup(void);

--- a/lib/services/upstart.h
+++ b/lib/services/upstart.h
@@ -24,7 +24,7 @@
 #  include "crm/services.h"
 
 G_GNUC_INTERNAL GList *upstart_job_listall(void);
-G_GNUC_INTERNAL int upstart_job_exec(svc_action_t * op, gboolean synchronous);
+G_GNUC_INTERNAL int upstart_job_exec(svc_action_t * op, gboolean synchronous, gboolean * inflight);
 G_GNUC_INTERNAL gboolean upstart_job_exists(const gchar * name);
 G_GNUC_INTERNAL gboolean upstart_job_running(const gchar * name);
 G_GNUC_INTERNAL void upstart_cleanup(void);


### PR DESCRIPTION
Fix: services: Correctly determine if operations are in-flight

Previously, we kind of abused the return codes of upstart_job_exec(),
systemd_unit_exec() and services_os_action_execute(). For an
asynchronous operation, the return code is supposed to tell whether the
'op' should be freed by the caller. It doesn't exactly indicate whether
the 'op' is in-flight.

For instance, in services_os_action_execute(), if stat() or fork() fail,
operation_finalize() will be called for an asynchronous operation, which
will free the operation and return TRUE if the operation is
non-recurring. But in action_async_helper(), the freed operation
would be considered in-flight and added into inflight_ops list.