### PR TITLE
Fix: systemd: Return PCMK_OCF_UNKNOWN_ERROR instead of PCMK_OCF_NOT_INSTALLED for uncertain errors on LoadUnit

### DIFF
--- a/lib/services/dbus.c
+++ b/lib/services/dbus.c
@@ -100,8 +100,10 @@ pcmk_dbus_find_error(const char *method, DBusPendingCall* pending, DBusMessage *
         }
     }
 
-    if(ret && (error.name || error.message)) {
-        *ret = error;
+    if(error.name || error.message) {
+        if (ret) {
+            *ret = error;
+        }
         return TRUE;
     }
 

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -406,13 +406,14 @@ systemd_mask_error(svc_action_t *op, const char *error)
         if (safe_str_eq(op->action, "stop")) {
             crm_trace("Masking %s failure for %s: unknown services are stopped", op->action, op->rsc);
             op->rc = PCMK_OCF_OK;
+            return TRUE;
 
         } else {
             crm_trace("Mapping %s failure for %s: unknown services are not installed", op->action, op->rsc);
             op->rc = PCMK_OCF_NOT_INSTALLED;
             op->status = PCMK_LRM_OP_NOT_INSTALLED;
+            return FALSE;
         }
-        return TRUE;
     }
 
     return FALSE;

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -155,14 +155,40 @@ systemd_daemon_reload(int timeout)
     return TRUE;
 }
 
+static bool
+systemd_mask_error(svc_action_t *op, const char *error)
+{
+    crm_trace("Could not issue %s for %s: %s", op->action, op->rsc, error);
+    if(strstr(error, "org.freedesktop.systemd1.InvalidName")
+       || strstr(error, "org.freedesktop.systemd1.LoadFailed")
+       || strstr(error, "org.freedesktop.systemd1.NoSuchUnit")) {
+
+        if (safe_str_eq(op->action, "stop")) {
+            crm_trace("Masking %s failure for %s: unknown services are stopped", op->action, op->rsc);
+            op->rc = PCMK_OCF_OK;
+            return TRUE;
+
+        } else {
+            crm_trace("Mapping %s failure for %s: unknown services are not installed", op->action, op->rsc);
+            op->rc = PCMK_OCF_NOT_INSTALLED;
+            op->status = PCMK_LRM_OP_NOT_INSTALLED;
+            return FALSE;
+        }
+    }
+
+    return FALSE;
+}
+
 static const char *
 systemd_loadunit_result(DBusMessage *reply, svc_action_t * op)
 {
     const char *path = NULL;
+    DBusError error;
 
-    if(pcmk_dbus_find_error("LoadUnit", (void*)&path, reply, NULL)) {
-        if(op) {
-            crm_warn("No unit found for %s", op->rsc);
+    if(pcmk_dbus_find_error("LoadUnit", (void*)&path, reply, &error)) {
+        if(op && !systemd_mask_error(op, error.name)) {
+            crm_err("Could not find unit %s for %s: LoadUnit error '%s'",
+                    op->agent, op->id, error.name);
         }
 
     } else if(pcmk_dbus_type_check(reply, NULL, DBUS_TYPE_OBJECT_PATH, __FUNCTION__, __LINE__)) {
@@ -172,7 +198,12 @@ systemd_loadunit_result(DBusMessage *reply, svc_action_t * op)
     }
 
     if(op) {
-        systemd_unit_exec_with_unit(op, path);
+        if (path) {
+            systemd_unit_exec_with_unit(op, path);
+
+        } else if (op->synchronous == FALSE) {
+            operation_finalize(op);
+        }
     }
 
     return path;
@@ -395,30 +426,6 @@ systemd_unit_metadata(const char *name, int timeout)
     return meta;
 }
 
-static bool
-systemd_mask_error(svc_action_t *op, const char *error)
-{
-    crm_trace("Could not issue %s for %s: %s", op->action, op->rsc, error);
-    if(strstr(error, "org.freedesktop.systemd1.InvalidName")
-       || strstr(error, "org.freedesktop.systemd1.LoadFailed")
-       || strstr(error, "org.freedesktop.systemd1.NoSuchUnit")) {
-
-        if (safe_str_eq(op->action, "stop")) {
-            crm_trace("Masking %s failure for %s: unknown services are stopped", op->action, op->rsc);
-            op->rc = PCMK_OCF_OK;
-            return TRUE;
-
-        } else {
-            crm_trace("Mapping %s failure for %s: unknown services are not installed", op->action, op->rsc);
-            op->rc = PCMK_OCF_NOT_INSTALLED;
-            op->status = PCMK_LRM_OP_NOT_INSTALLED;
-            return FALSE;
-        }
-    }
-
-    return FALSE;
-}
-
 static void
 systemd_exec_result(DBusMessage *reply, svc_action_t *op)
 {
@@ -508,12 +515,7 @@ systemd_unit_exec_with_unit(svc_action_t * op, const char *unit)
     DBusMessage *msg = NULL;
     DBusMessage *reply = NULL;
 
-    if (unit == NULL) {
-        crm_debug("Could not obtain unit named '%s'", op->agent);
-        op->rc = PCMK_OCF_NOT_INSTALLED;
-        op->status = PCMK_LRM_OP_NOT_INSTALLED;
-        goto cleanup;
-    }
+    CRM_ASSERT(unit);
 
     if (safe_str_eq(op->action, "monitor") || safe_str_eq(method, "status")) {
         DBusPendingCall *pending = NULL;
@@ -630,8 +632,7 @@ systemd_unit_exec_with_unit(svc_action_t * op, const char *unit)
 
   cleanup:
     if (op->synchronous == FALSE) {
-        operation_finalize(op);
-        return TRUE;
+        return operation_finalize(op);
     }
 
     return op->rc == PCMK_OCF_OK;


### PR DESCRIPTION
Previously, as long as we could not get the path of the unit via
LoadUnit, it would return PCMK_OCF_NOT_INSTALLED, which is a hard error.

It should not return PCMK_OCF_NOT_INSTALLED unless it's sure about that.
For uncertain errors such as "org.freedesktop.DBus.Error.NoReply", it
should return PCMK_OCF_UNKNOWN_ERROR instead.