### PR TITLE
Fix: libservices: restore build without dbus

### DIFF
--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -150,7 +150,6 @@ resources_action_create(const char *name, const char *standard, const char *prov
 
     op = calloc(1, sizeof(svc_action_t));
     op->opaque = calloc(1, sizeof(svc_action_private_t));
-    op->opaque->pending = NULL;
     op->rsc = strdup(name);
     op->action = strdup(action);
     op->interval = interval;
@@ -337,7 +336,6 @@ services_action_create_generic(const char *exec, const char *args[])
 
     op->opaque->exec = strdup(exec);
     op->opaque->args[0] = strdup(exec);
-    op->opaque->pending = NULL;
 
     for (cur_arg = 1; args && args[cur_arg - 1]; cur_arg++) {
         op->opaque->args[cur_arg] = strdup(args[cur_arg - 1]);


### PR DESCRIPTION
2091b55f set dbus-specific structure member to NULL without wrapping in
SUPPORT_DBUS. Fixed by removing the relevant lines b/c they were unnecessary
due to structure being calloc'ed.