### PR TITLE
 crm_resource --show-metadata drops documentation strings for fencing agents

### DIFF
--- a/include/crm/common/logging.h
+++ b/include/crm/common/logging.h
@@ -61,6 +61,7 @@ enum xml_log_options
 {
     xml_log_option_filtered   = 0x0001,
     xml_log_option_formatted  = 0x0002,
+    xml_log_option_text       = 0x0004, /* add this option to dump text into xml */
     xml_log_option_diff_plus  = 0x0010,
     xml_log_option_diff_minus = 0x0020,
     xml_log_option_diff_short = 0x0040,

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -140,6 +140,8 @@ int write_xml_fd(xmlNode * xml_node, const char *filename, int fd, gboolean comp
 int write_xml_file(xmlNode * xml_node, const char *filename, gboolean compress);
 
 char *dump_xml_formatted(xmlNode * msg);
+/* Also dump the text node with xml_log_option_text enabled */ 
+char *dump_xml_formatted_with_text(xmlNode * msg);
 
 char *dump_xml_unformatted(xmlNode * msg);
 

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1169,7 +1169,7 @@ stonith_api_device_metadata(stonith_t * stonith, int call_options, const char *a
 
         freeXpathObject(xpathObj);
         free(buffer);
-        buffer = dump_xml_formatted(xml);
+        buffer = dump_xml_formatted_with_text(xml);
         free_xml(xml);
         if (!buffer) {
             return -EINVAL;


### PR DESCRIPTION
crm_resource --show-metadata drops documentation strings for fencing agents

crm_resource --show-metadata works fine for normal OCF agents and STONITH plugins, but when run on fencing agents, e.g.:

  crm_resource --show-metadata=stonith:fence_drac

then all the parameters have empty <shortdesc> elements.  This prevents "crm ra info" from showing anything particularly useful for fencing agents.