### PR TITLE
Fix minor bug when matching down events

### DIFF
--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -962,7 +962,7 @@ write_attribute(attribute_t *a)
     /* Iterate over each peer value of this attribute */
     g_hash_table_iter_init(&iter, a->values);
     while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & v)) {
-        crm_node_t *peer = crm_get_peer_full(v->nodeid, v->nodename, CRM_GET_PEER_REMOTE|CRM_GET_PEER_CLUSTER);
+        crm_node_t *peer = crm_get_peer_full(v->nodeid, v->nodename, CRM_GET_PEER_ANY);
 
         /* If the value's peer info does not correspond to a peer, ignore it */
         if (peer == NULL) {

--- a/crmd/cib.c
+++ b/crmd/cib.c
@@ -239,3 +239,20 @@ do_cib_control(long long action,
         }
     }
 }
+
+/*!
+ * \internal
+ * \brief Get CIB call options to use local scope if master unavailable
+ *
+ * \return CIB call options
+ */
+int crmd_cib_smart_opt()
+{
+    int call_opt = cib_quorum_override;
+
+    if (fsa_state == S_ELECTION || fsa_state == S_PENDING) {
+        crm_info("Sending update to local CIB in state: %s", fsa_state2string(fsa_state));
+        call_opt |= cib_scope_local;
+    }
+    return call_opt;
+}

--- a/crmd/crmd_fsa.h
+++ b/crmd/crmd_fsa.h
@@ -116,6 +116,7 @@ extern struct crm_subsystem_s *pe_subsystem;
 
 /* these two should be moved elsewhere... */
 extern void do_update_cib_nodes(gboolean overwrite, const char *caller);
+int crmd_cib_smart_opt(void);
 
 #  define AM_I_DC is_set(fsa_input_register, R_THE_DC)
 #  define AM_I_OPERATIONAL (is_set(fsa_input_register, R_STARTING)==FALSE)

--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -2194,15 +2194,10 @@ do_update_resource(const char *node_name, lrmd_rsc_info_t * rsc, lrmd_event_data
 */
     int rc = pcmk_ok;
     xmlNode *update, *iter = NULL;
-    int call_opt = cib_quorum_override;
+    int call_opt = crmd_cib_smart_opt();
     const char *uuid = NULL;
 
     CRM_CHECK(op != NULL, return 0);
-
-    if (fsa_state == S_ELECTION || fsa_state == S_PENDING) {
-        crm_info("Sending update to local CIB in state: %s", fsa_state2string(fsa_state));
-        call_opt |= cib_scope_local;
-    }
 
     iter = create_xml_node(iter, XML_CIB_TAG_STATUS);
     update = iter;

--- a/crmd/te_actions.c
+++ b/crmd/te_actions.c
@@ -72,7 +72,7 @@ send_stonith_update(crm_action_t * action, const char *target, const char *uuid)
     CRM_CHECK(uuid != NULL, return);
 
     /* Make sure the membership and join caches are accurate */
-    peer = crm_get_peer_full(0, target, CRM_GET_PEER_CLUSTER | CRM_GET_PEER_REMOTE);
+    peer = crm_get_peer_full(0, target, CRM_GET_PEER_ANY);
 
     CRM_CHECK(peer != NULL, return);
 

--- a/crmd/te_callbacks.c
+++ b/crmd/te_callbacks.c
@@ -716,7 +716,6 @@ tengine_stonith_callback(stonith_t * stonith, stonith_callback_data_t * data)
         goto bail;
     }
 
-    /* this will mark the event complete if a match is found */
     action = get_action(stonith_id, FALSE);
     if (action == NULL) {
         crm_err("Stonith action not matched");

--- a/crmd/te_events.c
+++ b/crmd/te_events.c
@@ -511,13 +511,11 @@ match_down_event(int id, const char *target, const char *filter, bool quiet)
         }
 
         if (match != NULL) {
-            /* stop this event's timer if it had one */
             break;
         }
     }
 
     if (match != NULL) {
-        /* stop this event's timer if it had one */
         crm_debug("Match found for action %d: %s on %s", id,
                   crm_element_value(match->xml, XML_LRM_ATTR_TASK_KEY), target);
 

--- a/crmd/te_events.c
+++ b/crmd/te_events.c
@@ -458,6 +458,18 @@ get_cancel_action(const char *id, const char *node)
     return NULL;
 }
 
+/*!
+ * \brief Find a transition event that would have made a specified node down
+ *
+ * \param[in] id      If nonzero, also consider this action ID a match
+ * \param[in] target  UUID of node to match
+ * \param[in] filter  If not NULL, only match CRM actions of this type
+ * \param[in] quiet   If FALSE, log a warning if no match found
+ *
+ * \return Matching event if found, NULL otherwise
+ *
+ * \note "Down" events are CRM_OP_FENCE and CRM_OP_SHUTDOWN.
+ */
 crm_action_t *
 match_down_event(int id, const char *target, const char *filter, bool quiet)
 {
@@ -487,10 +499,11 @@ match_down_event(int id, const char *target, const char *filter, bool quiet)
             if (action->type != action_type_crm) {
                 continue;
 
-            } else if (safe_str_eq(this_action, CRM_OP_LRM_REFRESH)) {
+            } else if (filter != NULL && safe_str_neq(this_action, filter)) {
                 continue;
 
-            } else if (filter != NULL && safe_str_neq(this_action, filter)) {
+            } else if (safe_str_neq(this_action, CRM_OP_FENCE)
+                       && safe_str_neq(this_action, CRM_OP_SHUTDOWN)) {
                 continue;
             }
 
@@ -501,7 +514,8 @@ match_down_event(int id, const char *target, const char *filter, bool quiet)
             }
 
             if (safe_str_neq(this_node, target)) {
-                crm_debug("Action %d : Node mismatch: %s", action->id, this_node);
+                crm_trace("Action %d node %s is not a match for %s",
+                          action->id, this_node, target);
                 continue;
             }
 

--- a/crmd/te_utils.c
+++ b/crmd/te_utils.c
@@ -315,7 +315,7 @@ tengine_stonith_notify(stonith_t * st, stonith_event_t * st_event)
 #endif
 
     if (st_event->result == pcmk_ok) {
-        crm_node_t *peer = crm_find_peer_full(0, st_event->target, CRM_GET_PEER_REMOTE | CRM_GET_PEER_CLUSTER);
+        crm_node_t *peer = crm_find_peer_full(0, st_event->target, CRM_GET_PEER_ANY);
         const char *uuid = NULL;
         gboolean we_are_executioner = safe_str_eq(st_event->executioner, fsa_our_uname);
 

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -139,6 +139,7 @@ enum crm_ais_msg_types {
 enum crm_get_peer_flags {
     CRM_GET_PEER_CLUSTER   = 0x0001,
     CRM_GET_PEER_REMOTE    = 0x0002,
+    CRM_GET_PEER_ANY       = CRM_GET_PEER_CLUSTER|CRM_GET_PEER_REMOTE,
 };
 /* *INDENT-ON* */
 

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -457,6 +457,7 @@ crm_node_t *crm_update_peer_proc(const char *source, crm_node_t * peer,
 crm_node_t *crm_update_peer_state(const char *source, crm_node_t * node,
                                   const char *state, int membership);
 
+void crm_update_peer_uname(crm_node_t *node, const char *uname);
 void crm_update_peer_expected(const char *source, crm_node_t * node, const char *expected);
 void crm_reap_unseen_nodes(uint64_t ring_id);
 

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -101,6 +101,24 @@ const char *crm_xml_replace(xmlNode * node, const char *name, const char *value)
 
 const char *crm_xml_add_int(xmlNode * node, const char *name, int value);
 
+/*!
+ * \brief Add a boolean attribute to an XML object
+ *
+ * Add an attribute with the value XML_BOOLEAN_TRUE or XML_BOOLEAN_FALSE
+ * as appropriate to an XML object.
+ *
+ * \param[in/out] node   XML object to add attribute to
+ * \param[in]     name   Name of attribute to add
+ * \param[in]     value  Boolean whose value will be tested
+ *
+ * \return Pointer to newly created XML attribute's content, or NULL on error
+ */
+static inline const char *
+crm_xml_add_boolean(xmlNode *node, const char *name, gboolean value)
+{
+    return crm_xml_add(node, name, (value? "true" : "false"));
+}
+
 /*
  * Unlink the node and set its doc pointer to NULL so free_xml()
  * will act appropriately


### PR DESCRIPTION
The most significant commit in this request modifies match_down_event() to match only fence and shutdown events (previously it would sometimes mistakenly match clear-failcount).

The other commits are some simple refactors that will come in handy when we start tracking pacemaker_remote node member/lost state.