### PR TITLE
Fix: crmd: Don't update cluster/peer CIB fields when processing stoni…

### DIFF
--- a/crmd/callbacks.c
+++ b/crmd/callbacks.c
@@ -209,19 +209,11 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
         if (down) {
             const char *task = crm_element_value(down->xml, XML_LRM_ATTR_TASK);
 
-            if (alive && safe_str_eq(task, CRM_OP_FENCE)) {
-                crm_info("Node return implies stonith of %s (action %d) completed", node->uname,
-                         down->id);
+            if (safe_str_eq(task, CRM_OP_FENCE)) {
 
-                st_fail_count_reset(node->uname);
-
-                erase_status_tag(node->uname, XML_CIB_TAG_LRM, cib_scope_local);
-                erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
-                /* down->confirmed = TRUE; Only stonith-ng returning should imply completion */
-                down->sent_update = TRUE;       /* Prevent tengine_stonith_callback() from calling send_stonith_update() */
-
-            } else if (safe_str_eq(task, CRM_OP_FENCE)) {
-                crm_trace("Waiting for stonithd to report the fencing of %s is complete", node->uname); /* via tengine_stonith_callback() */
+                /* tengine_stonith_callback() confirms fence actions */
+                crm_trace("Updating CIB %s stonithd reported fencing of %s complete",
+                          (down->confirmed? "after" : "before"), node->uname);
 
             } else if (alive == FALSE) {
                 crm_notice("%s of %s (op %d) is complete", task, node->uname, down->id);

--- a/crmd/te_actions.c
+++ b/crmd/te_actions.c
@@ -82,7 +82,14 @@ send_stonith_update(crm_action_t * action, const char *target, const char *uuid)
     }
 
     crmd_peer_down(peer, TRUE);
-    node_state = do_update_node_cib(peer, node_update_all, NULL, __FUNCTION__);
+
+    /* Generate a node state update for the CIB.
+     * We rely on the membership layer to do node_update_cluster,
+     * and the peer status callback to do node_update_peer,
+     * because the node might rejoin before we get the stonith result.
+     */
+    node_state = do_update_node_cib(peer, node_update_join|node_update_expected,
+                                    NULL, __FUNCTION__);
 
     /* we have to mark whether or not remote nodes have already been fenced */
     if (peer->flags & crm_remote_node) {

--- a/crmd/te_callbacks.c
+++ b/crmd/te_callbacks.c
@@ -734,6 +734,7 @@ tengine_stonith_callback(stonith_t * stonith, stonith_callback_data_t * data)
             te_action_confirmed(action);
             if (action->sent_update == FALSE && safe_str_neq("on", op)) {
                 send_stonith_update(action, target, uuid);
+                action->sent_update = TRUE;
             }
         }
         st_fail_count_reset(target);


### PR DESCRIPTION
…th results

Previously, to avoid tengine_stonith_callback() overwriting the CIB update
made by peer_update_callback() when a fenced node rejoins the cluster before
stonithd reports completion, the callback would set the sent_update flag.
However, tengine_stonith_notify() does not have access to this flag and
would update the CIB anyway.

Now, stonith_send_update() (used by both tengine_stonith_callback() and
tengine_stonith_notify()) doesn't set the cluster and peer fields in the
CIB at all (relying on membership layer and peer status callbacks to do so).

This way, the peer_status_callback()'s CIB update really doesn't get
overwritten, and peer_status_callback() doesn't have to try to do some
of the stonith callback's work (which would be erroneous if the node
was flapping and happened to rejoin before fencing actually occurred).