### PR TITLE
remove a dup line from function fail_pending_op

### DIFF
--- a/crmd/lrm_state.c
+++ b/crmd/lrm_state.c
@@ -85,7 +85,6 @@ fail_pending_op(gpointer key, gpointer value, gpointer user_data)
     event.op_status = PCMK_LRM_OP_ERROR;
     event.t_run = op->start_time;
     event.t_rcchange = op->start_time;
-    event.t_rcchange = op->start_time;
 
     event.call_id = op->call_id;
     event.remote_nodename = lrm_state->node_name;


### PR DESCRIPTION
there is a duplicate line in function fail_pending_op(crmd/lrm_state.c)