### PR TITLE
High : Mistake of the parameter order.

### DIFF
--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -1314,7 +1314,7 @@ crm_pidfile_inuse(const char *filename, long mypid, const char *daemon)
 }
 
 static int
-crm_lock_pidfile(const char *name, const char *filename)
+crm_lock_pidfile(const char *filename, const char *name)
 {
     long mypid = 0;
     int fd = 0, rc = 0;


### PR DESCRIPTION
crm_make_daemon() cannot make Pid file.

Please reflect it to master.