### PR TITLE
Remove unused Linux-specific header

### DIFF
--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -20,7 +20,6 @@
 #include <crm_internal.h>
 
 #include <sched.h>
-#include <syscall.h>
 #include <sys/ioctl.h>
 #include <sys/reboot.h>
 


### PR DESCRIPTION
Fixes a build warning on FreeBSD