### PR TITLE
autotools: suppress portability warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,6 @@ SUBDIRS	= $(CORE) cts extra doc
 doc_DATA = AUTHORS COPYING COPYING.LIB
 noinst_PROGRAMS = scratch
 
-AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS  = -I m4
 
 testdir			= $(datadir)/$(PACKAGE)/tests/

--- a/autogen.sh
+++ b/autogen.sh
@@ -23,7 +23,7 @@
 # Run this to generate all the initial makefiles, etc.
 
 # Unset GREP_OPTIONS as any coloring can mess up the AC_CONFIG_AUX_DIR matching patterns
-GREP_OPTIONS= autoreconf -visf  -Wno-portability
+GREP_OPTIONS= autoreconf -visf
 
 if [ -f config.log ]; then
     echo Now re-running ./configure with the previous arguments

--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,7 @@ AC_ARG_WITH(pkg-name,
     [ PACKAGE_NAME="$withval" ])
 
 dnl Older distros may need: AM_INIT_AUTOMAKE($PACKAGE_NAME, $PACKAGE_VERSION)
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 AC_DEFINE_UNQUOTED(PACEMAKER_VERSION, "$PACKAGE_VERSION", Current pacemaker version)
 
 PACKAGE_SERIES=`echo $PACKAGE_VERSION | awk -F. '{ print $1"."$2 }'`


### PR DESCRIPTION
These are to be expected since we use GNU make extensions