### PR TITLE
Use sh, not bash, for best-match.sh

### DIFF
--- a/xml/best-match.sh
+++ b/xml/best-match.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 base=$1; shift
 target=$1; shift


### PR DESCRIPTION
So it can be used on FreeBSD