### PR TITLE
Really redefine INFINITY

### DIFF
--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -29,6 +29,7 @@
 #  include <glib.h>
 #  include <stdbool.h>
 
+#  undef INFINITY
 #  undef MIN
 #  undef MAX
 #  include <string.h>

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include <math.h>
 #include <crm_internal.h>
 #include <sys/param.h>
 #include <stdio.h>
@@ -30,7 +31,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <ctype.h>
-#include <math.h>
 
 #include <crm/crm.h>
 #include <crm/msg_xml.h>


### PR DESCRIPTION
<math.h> defines INFINITY, but so does crm.h
Make sure we use the definition from the latter.

Fixes the following build warning on FreeBSD:

xml.c:2578:26: warning: cast from function call of type 'float' to non-matching type 'int' [-Wbad-function-cast]
        int_value = (int)INFINITY;
                         ^~~~~~~~
/usr/include/math.h:58:18: note: expanded from macro 'INFINITY'
                        ^~~~~~~~~~~~~~~~
#define INFINITY        __builtin_inff()
1 warning generated.