### PR TITLE
Fix detection of heartbeat headers on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -463,7 +463,7 @@ esac
 
 dnl Eventually remove this
 if test "$cross_compiling" != "yes"; then
-   CFLAGS="$CFLAGS -I${prefix}/include/heartbeat"
+   CPPFLAGS="$CPPFLAGS -I${prefix}/include/heartbeat"
 fi
 
 AC_SUBST(INIT_EXT)


### PR DESCRIPTION
Header checks use the preprocessor so don't look at CFLAGS.