### PR TITLE
Mid : Addition of the reconnection option for Attrd clients.

### DIFF
--- a/include/crm/attrd.h
+++ b/include/crm/attrd.h
@@ -23,6 +23,7 @@
 #define attrd_opt_none    0x000
 #define attrd_opt_remote  0x001
 #define attrd_opt_private 0x002
+#define attrd_opt_client_reconnect 0x004
 
 int attrd_update_delegate(crm_ipc_t * ipc, char command, const char *host,
                           const char *name, const char *value, const char *section,

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -1753,6 +1753,15 @@ attrd_update_delegate(crm_ipc_t * ipc, char command, const char *host, const cha
     static gboolean connected = TRUE;
     static crm_ipc_t *local_ipc = NULL;
 
+    /* Cut connection to let the update of the attribute from a client complete and connect it again. */
+    /* The attrd_opt_client_reconnect is an option to a client using attrd_update_delegate. */
+    if (ipc == NULL && is_set(options, attrd_opt_client_reconnect)) {
+        if (local_ipc != NULL) {
+            crm_ipc_close(local_ipc);
+            local_ipc = NULL;
+        }
+    }
+
     if (ipc == NULL && local_ipc == NULL) {
         local_ipc = crm_ipc_new(T_ATTRD, 0);
         flags |= crm_ipc_client_response;


### PR DESCRIPTION
When a client stops, the use and the client may fail in the update of
the attribute by attrd_update_delegate function.

This is because IPC connection is recycled in attrd_update_delegate
function.
This correction adds an option and evades a problem.

We use attrd_update_delegate function from tools of the Japanese
community, but do not work by this problem well now.
* https://github.com/linux-ha-japan/pm_extras

Best Regards,
Hideo Yamauchi.