### PR TITLE
Mid : Synchronization compulsion of the communication with attrd.

### DIFF
--- a/include/crm/attrd.h
+++ b/include/crm/attrd.h
@@ -23,6 +23,7 @@
 #define attrd_opt_none    0x000
 #define attrd_opt_remote  0x001
 #define attrd_opt_private 0x002
+#define attrd_opt_client_response 0x004
 
 int attrd_update_delegate(crm_ipc_t * ipc, char command, const char *host,
                           const char *name, const char *value, const char *section,

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -1762,6 +1762,10 @@ attrd_update_delegate(crm_ipc_t * ipc, char command, const char *host, const cha
     if (ipc == NULL) {
         ipc = local_ipc;
     }
+  
+    if (is_set(options, attrd_opt_client_response)) {
+        flags |= crm_ipc_client_response;
+    }
 
     /* remap common aliases */
     if (safe_str_eq(section, "reboot")) {


### PR DESCRIPTION
The application using attrd_update_delegate() cannot wait for completion
of the attribute update.
* The detailed movement lists it in the next link.
*
https://github.com/ClusterLabs/pacemaker/pull/867#issuecomment-165681662

This option adds wait of the attribute update.

We want Pacemaker1.1.14 to include this correction if possible.

Best Regards,
Hideo Yamauchi.