### PR TITLE
FOR REVIEW ONLY

### DIFF
--- a/crmd/crmd.h
+++ b/crmd/crmd.h
@@ -24,7 +24,6 @@
 #  define DAEMON_DEBUG DEVEL_DIR"/"SYS_NAME".debug"
 
 extern GMainLoop *crmd_mainloop;
-extern GHashTable *ipc_clients;
 extern bool no_quorum_suicide_escalation;
 
 extern void crmd_metadata(void);

--- a/crmd/lrm_state.c
+++ b/crmd/lrm_state.c
@@ -478,6 +478,13 @@ remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
     CRM_CHECK(op != NULL, return);
     CRM_CHECK(session != NULL, return);
 
+    if (safe_str_eq(op, LRMD_IPC_OP_SHUTDOWN_REQ)) {
+        crm_warn("Graceful proxy shutdown not yet supported");
+        /* TODO: uncomment this, then put node in standby: */
+        /* remote_proxy_ack_shutdown(lrmd); */
+        return;
+    }
+
     crm_element_value_int(msg, F_LRMD_IPC_MSG_ID, &msg_id);
 
     /* This is msg from remote ipc client going to real ipc server */

--- a/crmd/lrm_state.c
+++ b/crmd/lrm_state.c
@@ -481,7 +481,7 @@ remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
     crm_element_value_int(msg, F_LRMD_IPC_MSG_ID, &msg_id);
 
     /* This is msg from remote ipc client going to real ipc server */
-    if (safe_str_eq(op, "new")) {
+    if (safe_str_eq(op, LRMD_IPC_OP_NEW)) {
         const char *channel = crm_element_value(msg, F_LRMD_IPC_IPC_SERVER);
 
         CRM_CHECK(channel != NULL, return);
@@ -490,10 +490,10 @@ remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
             remote_proxy_notify_destroy(lrmd, session);
         }
         crm_trace("new remote proxy client established to %s, session id %s", channel, session);
-    } else if (safe_str_eq(op, "destroy")) {
+    } else if (safe_str_eq(op, LRMD_IPC_OP_DESTROY)) {
         remote_proxy_end_session(session);
 
-    } else if (safe_str_eq(op, "request")) {
+    } else if (safe_str_eq(op, LRMD_IPC_OP_REQUEST)) {
         int flags = 0;
         xmlNode *request = get_message_xml(msg, F_LRMD_IPC_MSG);
         const char *name = crm_element_value(msg, F_LRMD_IPC_CLIENT);

--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -2764,6 +2764,14 @@ class RemoteDriver(CTSTest):
                 self.pcmk_started = 1
                 break
 
+    def kill_pcmk_remote(self, node):
+        """ Simulate a Pacemaker Remote daemon failure. """
+
+        # We kill the process to prevent a graceful stop,
+        # then stop it to prevent the OS from restarting it.
+        self.rsh(node, "killall -9 pacemaker_remoted")
+        self.stop_pcmk_remote(node)
+
     def start_metal(self, node):
         pcmk_started = 0
 
@@ -2855,7 +2863,7 @@ class RemoteDriver(CTSTest):
 
         # force stop the pcmk remote daemon. this will result in fencing
         self.debug("Force stopped active remote node")
-        self.stop_pcmk_remote(node)
+        self.kill_pcmk_remote(node)
 
         self.debug("Waiting for remote node to be fenced.")
         self.set_timer("remoteMetalFence")
@@ -3093,8 +3101,8 @@ class RemoteStonithd(RemoteDriver):
     def errorstoignore(self):
         ignore_pats = [
             r"Unexpected disconnect on remote-node",
-            r"crmd.*: error.*: Operation remote_.*_monitor",
-            r"pengine.*: Recover remote_.*\s*\(.*\)",
+            r"crmd.*:\s+error.*: Operation remote_.*_monitor",
+            r"pengine.*:\s+Recover remote_.*\s*\(.*\)",
             r"Calculated Transition .* /var/lib/pacemaker/pengine/pe-error",
             r"error.*: Resource .*ocf::.* is active on 2 nodes attempting recovery",
         ]

--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -90,6 +90,12 @@ typedef struct lrmd_key_value_s {
 #define LRMD_OP_POKE              "lrmd_rsc_poke"
 #define LRMD_OP_NEW_CLIENT        "lrmd_rsc_new_client"
 
+#define LRMD_IPC_OP_NEW           "new"
+#define LRMD_IPC_OP_DESTROY       "destroy"
+#define LRMD_IPC_OP_EVENT         "event"
+#define LRMD_IPC_OP_REQUEST       "request"
+#define LRMD_IPC_OP_RESPONSE      "response"
+
 #define F_LRMD_IPC_OP           "lrmd_ipc_op"
 #define F_LRMD_IPC_IPC_SERVER   "lrmd_ipc_server"
 #define F_LRMD_IPC_SESSION      "lrmd_ipc_session"

--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -95,6 +95,8 @@ typedef struct lrmd_key_value_s {
 #define LRMD_IPC_OP_EVENT         "event"
 #define LRMD_IPC_OP_REQUEST       "request"
 #define LRMD_IPC_OP_RESPONSE      "response"
+#define LRMD_IPC_OP_SHUTDOWN_REQ  "shutdown_req"
+#define LRMD_IPC_OP_SHUTDOWN_ACK  "shutdown_ack"
 
 #define F_LRMD_IPC_OP           "lrmd_ipc_op"
 #define F_LRMD_IPC_IPC_SERVER   "lrmd_ipc_server"

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -380,6 +380,7 @@ typedef struct remote_proxy_s {
 
 } remote_proxy_t;
 void remote_proxy_notify_destroy(lrmd_t *lrmd, const char *session_id);
+void remote_proxy_ack_shutdown(lrmd_t *lrmd);
 void remote_proxy_relay_event(lrmd_t *lrmd, const char *session_id, xmlNode *msg);
 void remote_proxy_relay_response(lrmd_t *lrmd, const char *session_id, xmlNode *msg, int msg_id);
 void remote_proxy_end_session(const char *session);

--- a/lib/lrmd/proxy_common.c
+++ b/lib/lrmd/proxy_common.c
@@ -39,7 +39,7 @@ remote_proxy_notify_destroy(lrmd_t *lrmd, const char *session_id)
 {
     /* sending to the remote node that an ipc connection has been destroyed */
     xmlNode *msg = create_xml_node(NULL, T_LRMD_IPC_PROXY);
-    crm_xml_add(msg, F_LRMD_IPC_OP, "destroy");
+    crm_xml_add(msg, F_LRMD_IPC_OP, LRMD_IPC_OP_DESTROY);
     crm_xml_add(msg, F_LRMD_IPC_SESSION, session_id);
     lrmd_internal_proxy_send(lrmd, msg);
     free_xml(msg);
@@ -50,7 +50,7 @@ remote_proxy_relay_event(lrmd_t *lrmd, const char *session_id, xmlNode *msg)
 {
     /* sending to the remote node an event msg. */
     xmlNode *event = create_xml_node(NULL, T_LRMD_IPC_PROXY);
-    crm_xml_add(event, F_LRMD_IPC_OP, "event");
+    crm_xml_add(event, F_LRMD_IPC_OP, LRMD_IPC_OP_EVENT);
     crm_xml_add(event, F_LRMD_IPC_SESSION, session_id);
     add_message_xml(event, F_LRMD_IPC_MSG, msg);
     crm_log_xml_explicit(event, "EventForProxy");
@@ -63,7 +63,7 @@ remote_proxy_relay_response(lrmd_t *lrmd, const char *session_id, xmlNode *msg, 
 {
     /* sending to the remote node a response msg. */
     xmlNode *response = create_xml_node(NULL, T_LRMD_IPC_PROXY);
-    crm_xml_add(response, F_LRMD_IPC_OP, "response");
+    crm_xml_add(response, F_LRMD_IPC_OP, LRMD_IPC_OP_RESPONSE);
     crm_xml_add(response, F_LRMD_IPC_SESSION, session_id);
     crm_xml_add_int(response, F_LRMD_IPC_MSG_ID, msg_id);
     add_message_xml(response, F_LRMD_IPC_MSG, msg);

--- a/lib/lrmd/proxy_common.c
+++ b/lib/lrmd/proxy_common.c
@@ -45,6 +45,20 @@ remote_proxy_notify_destroy(lrmd_t *lrmd, const char *session_id)
     free_xml(msg);
 }
 
+/*!
+ * \brief Send an acknowledgment of a remote proxy shutdown request.
+ *
+ * \param[in] lrmd  Connection to proxy
+ */
+void
+remote_proxy_ack_shutdown(lrmd_t *lrmd)
+{
+    xmlNode *msg = create_xml_node(NULL, T_LRMD_IPC_PROXY);
+    crm_xml_add(msg, F_LRMD_IPC_OP, LRMD_IPC_OP_SHUTDOWN_ACK);
+    lrmd_internal_proxy_send(lrmd, msg);
+    free_xml(msg);
+}
+
 void
 remote_proxy_relay_event(lrmd_t *lrmd, const char *session_id, xmlNode *msg)
 {

--- a/lrmd/ipc_proxy.c
+++ b/lrmd/ipc_proxy.c
@@ -259,6 +259,30 @@ ipc_proxy_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
     return 0;
 }
 
+/*!
+ * \internal
+ * \brief Notify a proxy provider that we wish to shut down
+ *
+ * \return 0 on success, -1 on error
+ */
+int
+ipc_proxy_shutdown_req(crm_client_t *ipc_proxy)
+{
+    xmlNode *msg = create_xml_node(NULL, T_LRMD_IPC_PROXY);
+    int rc;
+
+    crm_xml_add(msg, F_LRMD_IPC_OP, LRMD_IPC_OP_SHUTDOWN_REQ);
+
+    /* We don't really have a session, but crmd needs this attribute
+     * to recognize this as proxy communication.
+     */
+    crm_xml_add(msg, F_LRMD_IPC_SESSION, "0");
+
+    rc = (lrmd_server_send_notify(ipc_proxy, msg) < 0)? -1 : 0;
+    free_xml(msg);
+    return rc;
+}
+
 static int32_t
 ipc_proxy_closed(qb_ipcs_connection_t * c)
 {

--- a/lrmd/ipc_proxy.c
+++ b/lrmd/ipc_proxy.c
@@ -101,7 +101,7 @@ ipc_proxy_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid, const char *ipc
     g_hash_table_insert(ipc_clients, client->id, client);
 
     msg = create_xml_node(NULL, T_LRMD_IPC_PROXY);
-    crm_xml_add(msg, F_LRMD_IPC_OP, "new");
+    crm_xml_add(msg, F_LRMD_IPC_OP, LRMD_IPC_OP_NEW);
     crm_xml_add(msg, F_LRMD_IPC_IPC_SERVER, ipc_channel);
     crm_xml_add(msg, F_LRMD_IPC_SESSION, client->id);
     lrmd_server_send_notify(ipc_proxy, msg);
@@ -157,7 +157,7 @@ ipc_proxy_forward_client(crm_client_t *ipc_proxy, xmlNode *xml)
 
     if (ipc_client == NULL) {
         xmlNode *msg = create_xml_node(NULL, T_LRMD_IPC_PROXY);
-        crm_xml_add(msg, F_LRMD_IPC_OP, "destroy");
+        crm_xml_add(msg, F_LRMD_IPC_OP, LRMD_IPC_OP_DESTROY);
         crm_xml_add(msg, F_LRMD_IPC_SESSION, session);
         lrmd_server_send_notify(ipc_proxy, msg);
         free_xml(msg);
@@ -176,11 +176,11 @@ ipc_proxy_forward_client(crm_client_t *ipc_proxy, xmlNode *xml)
      * and forwarding it to connection 1.
      */
 
-    if (safe_str_eq(msg_type, "event")) {
+    if (safe_str_eq(msg_type, LRMD_IPC_OP_EVENT)) {
         crm_trace("Sending event to %s", ipc_client->id);
         rc = crm_ipcs_send(ipc_client, 0, msg, crm_ipc_server_event);
 
-    } else if (safe_str_eq(msg_type, "response")) {
+    } else if (safe_str_eq(msg_type, LRMD_IPC_OP_RESPONSE)) {
         int msg_id = 0;
 
         crm_element_value_int(xml, F_LRMD_IPC_MSG_ID, &msg_id);
@@ -190,7 +190,7 @@ ipc_proxy_forward_client(crm_client_t *ipc_proxy, xmlNode *xml)
         CRM_LOG_ASSERT(msg_id == ipc_client->request_id);
         ipc_client->request_id = 0;
 
-    } else if (safe_str_eq(msg_type, "destroy")) {
+    } else if (safe_str_eq(msg_type, LRMD_IPC_OP_DESTROY)) {
         qb_ipcs_disconnect(ipc_client->ipcs);
 
     } else {
@@ -245,7 +245,7 @@ ipc_proxy_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
     client->request_id = id;
 
     msg = create_xml_node(NULL, T_LRMD_IPC_PROXY);
-    crm_xml_add(msg, F_LRMD_IPC_OP, "request");
+    crm_xml_add(msg, F_LRMD_IPC_OP, LRMD_IPC_OP_REQUEST);
     crm_xml_add(msg, F_LRMD_IPC_SESSION, client->id);
     crm_xml_add(msg, F_LRMD_IPC_CLIENT, crm_client_name(client));
     crm_xml_add(msg, F_LRMD_IPC_USER, client->user);
@@ -275,7 +275,7 @@ ipc_proxy_closed(qb_ipcs_connection_t * c)
 
     if (ipc_proxy) {
         xmlNode *msg = create_xml_node(NULL, T_LRMD_IPC_PROXY);
-        crm_xml_add(msg, F_LRMD_IPC_OP, "destroy");
+        crm_xml_add(msg, F_LRMD_IPC_OP, LRMD_IPC_OP_DESTROY);
         crm_xml_add(msg, F_LRMD_IPC_SESSION, client->id);
         lrmd_server_send_notify(ipc_proxy, msg);
         free_xml(msg);

--- a/lrmd/lrmd_private.h
+++ b/lrmd/lrmd_private.h
@@ -103,6 +103,7 @@ void ipc_proxy_cleanup(void);
 void ipc_proxy_add_provider(crm_client_t *client);
 void ipc_proxy_remove_provider(crm_client_t *client);
 void ipc_proxy_forward_client(crm_client_t *client, xmlNode *xml);
+crm_client_t *ipc_proxy_get_provider(void);
 #endif
 
 #endif

--- a/lrmd/lrmd_private.h
+++ b/lrmd/lrmd_private.h
@@ -104,6 +104,7 @@ void ipc_proxy_add_provider(crm_client_t *client);
 void ipc_proxy_remove_provider(crm_client_t *client);
 void ipc_proxy_forward_client(crm_client_t *client, xmlNode *xml);
 crm_client_t *ipc_proxy_get_provider(void);
+int ipc_proxy_shutdown_req(crm_client_t *ipc_proxy);
 #endif
 
 #endif

--- a/lrmd/lrmd_private.h
+++ b/lrmd/lrmd_private.h
@@ -80,7 +80,9 @@ void process_lrmd_message(crm_client_t * client, uint32_t id, xmlNode * request)
 
 void free_rsc(gpointer data);
 
-void lrmd_shutdown(int nsig);
+void handle_shutdown_ack(void);
+
+void lrmd_client_destroy(crm_client_t *client);
 
 void client_disconnect_cleanup(const char *client_id);
 

--- a/lrmd/main.c
+++ b/lrmd/main.c
@@ -40,6 +40,16 @@ static qb_ipcs_service_t *ipcs = NULL;
 stonith_t *stonith_api = NULL;
 int lrmd_call_id = 0;
 
+#ifdef ENABLE_PCMK_REMOTE
+/* whether shutdown request has been sent */
+static volatile sig_atomic_t shutting_down = FALSE;
+
+/* timer for waiting for acknowledgment of shutdown request */
+static volatile guint shutdown_ack_timer = 0;
+
+static gboolean lrmd_exit(gpointer data);
+#endif
+
 static void
 stonith_connection_destroy_cb(stonith_t * st, stonith_event_t * e)
 {
@@ -151,6 +161,27 @@ lrmd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
     return 0;
 }
 
+/*!
+ * \internal
+ * \brief Free a client connection, and exit if appropriate
+ *
+ * \param[in] client  Client connection to free
+ */
+void
+lrmd_client_destroy(crm_client_t *client)
+{
+    crm_client_destroy(client);
+
+#ifdef ENABLE_PCMK_REMOTE
+    /* If we were waiting to shut down, we can now safely do so
+     * if there are no more proxied IPC providers
+     */
+    if (shutting_down && (ipc_proxy_get_provider() == NULL)) {
+        lrmd_exit(NULL);
+    }
+#endif
+}
+
 static int32_t
 lrmd_ipc_closed(qb_ipcs_connection_t * c)
 {
@@ -165,7 +196,7 @@ lrmd_ipc_closed(qb_ipcs_connection_t * c)
 #ifdef ENABLE_PCMK_REMOTE
     ipc_proxy_remove_provider(client);
 #endif
-    crm_client_destroy(client);
+    lrmd_client_destroy(client);
     return 0;
 }
 
@@ -227,8 +258,17 @@ lrmd_server_send_notify(crm_client_t * client, xmlNode * msg)
     return -1;
 }
 
-void
-lrmd_shutdown(int nsig)
+/*!
+ * \internal
+ * \brief Clean up and exit immediately
+ *
+ * \param[in] data  Ignored
+ *
+ * \return Doesn't return
+ * \note   This can be used as a timer callback.
+ */
+static gboolean
+lrmd_exit(gpointer data)
 {
     crm_info("Terminating with  %d clients", crm_hash_table_size(client_connections));
 
@@ -249,6 +289,81 @@ lrmd_shutdown(int nsig)
     crm_client_cleanup();
     g_hash_table_destroy(rsc_list);
     crm_exit(pcmk_ok);
+    return FALSE;
+}
+
+/*!
+ * \internal
+ * \brief Request cluster shutdown if appropriate, otherwise exit immediately
+ *
+ * \param[in] nsig  Signal that caused invocation (ignored)
+ */
+static void
+lrmd_shutdown(int nsig)
+{
+#ifdef ENABLE_PCMK_REMOTE
+    crm_client_t *ipc_proxy = ipc_proxy_get_provider();
+
+    /* If there are active proxied IPC providers, then we may be running
+     * resources, so notify the cluster that we wish to shut down.
+     */
+    if (ipc_proxy) {
+        if (shutting_down) {
+            crm_trace("Shutdown already in progress");
+            return;
+        }
+
+        crm_info("Sending shutdown request to cluster");
+        if (ipc_proxy_shutdown_req(ipc_proxy) < 0) {
+            crm_crit("Shutdown request failed, exiting immediately");
+
+        } else {
+            /* We requested a shutdown. Now, we need to wait for an
+             * acknowledgement from the proxy host (which ensures the proxy host
+             * supports shutdown requests), then wait for all proxy hosts to
+             * disconnect (which ensures that all resources have been stopped).
+             */
+            shutting_down = TRUE;
+
+            /* Older crmd versions will never acknowledge our request, so set a
+             * fairly short timeout to exit quickly in that case. If we get the
+             * ack, we'll defuse this timer.
+             */
+            shutdown_ack_timer = g_timeout_add_seconds(20, lrmd_exit, NULL);
+
+            /* Currently, we let the OS kill us if the clients don't disconnect
+             * in a reasonable time. We could instead set a long timer here
+             * (shorter than what the OS is likely to use) and exit immediately
+             * if it pops.
+             */
+            return;
+        }
+    }
+#endif
+    lrmd_exit(NULL);
+}
+
+/*!
+ * \internal
+ * \brief Defuse short exit timer if shutting down
+ */
+void handle_shutdown_ack()
+{
+#ifdef ENABLE_PCMK_REMOTE
+    if (shutting_down) {
+        crm_info("Received shutdown ack");
+
+        /* Defuse the short timer, to allow time for stopping resources */
+        if (shutdown_ack_timer > 0) {
+            g_source_remove(shutdown_ack_timer);
+        }
+
+        /* Stop accepting new proxy connections */
+        lrmd_tls_server_destroy();
+        return;
+    }
+#endif
+    crm_debug("Ignoring unexpected shutdown ack");
 }
 
 /* *INDENT-OFF* */
@@ -363,6 +478,6 @@ main(int argc, char **argv)
     g_main_run(mainloop);
 
     /* should never get here */
-    lrmd_shutdown(SIGTERM);
+    lrmd_exit(NULL);
     return pcmk_ok;
 }

--- a/lrmd/pacemaker_remote.service.in
+++ b/lrmd/pacemaker_remote.service.in
@@ -13,7 +13,9 @@ EnvironmentFile=-/etc/sysconfig/pacemaker
 
 ExecStart=@sbindir@/pacemaker_remoted
 
-TimeoutStopSec=30s
+# Pacemaker Remote can exit only after all managed services have shut down;
+# an HA database could conceivably take even longer than this 
+TimeoutStopSec=30min
 TimeoutStartSec=30s
 
 # Restart options include: no, on-success, on-failure, on-abort or always

--- a/lrmd/remote_ctl.c
+++ b/lrmd/remote_ctl.c
@@ -333,7 +333,7 @@ remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
     crm_element_value_int(msg, F_LRMD_IPC_MSG_ID, &msg_id);
 
     /* This is msg from remote ipc client going to real ipc server */
-    if (safe_str_eq(op, "new")) {
+    if (safe_str_eq(op, LRMD_IPC_OP_NEW)) {
         const char *channel = crm_element_value(msg, F_LRMD_IPC_IPC_SERVER);
 
         CRM_CHECK(channel != NULL, return);
@@ -342,10 +342,10 @@ remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
             remote_proxy_notify_destroy(lrmd, session);
         }
         crm_info("new remote proxy client established to %s, session id %s", channel, session);
-    } else if (safe_str_eq(op, "destroy")) {
+    } else if (safe_str_eq(op, LRMD_IPC_OP_DESTROY)) {
         remote_proxy_end_session(session);
 
-    } else if (safe_str_eq(op, "request")) {
+    } else if (safe_str_eq(op, LRMD_IPC_OP_REQUEST)) {
         int flags = 0;
         xmlNode *request = get_message_xml(msg, F_LRMD_IPC_MSG);
         const char *name = crm_element_value(msg, F_LRMD_IPC_CLIENT);

--- a/lrmd/tls_backend.c
+++ b/lrmd/tls_backend.c
@@ -163,8 +163,7 @@ lrmd_remote_client_destroy(gpointer user_data)
         close(csock);
     }
 
-    crm_client_destroy(client);
-
+    lrmd_client_destroy(client);
     return;
 }
 


### PR DESCRIPTION
DO NOT MERGE - for review only

This is the complete pacemaker_remote side of a graceful stop. The cluster side is yet to be implemented.

The process on the pacemaker_remote side is:
1. pacemaker_remote catches SIGTERM (sent by systemctl stop)
2. If there is no IPC proxy provider (remote connection from cluster), exit immediately.
3. Otherwise send a new lrmd IPC op, "shutdown_req", to the proxy provider, set a global flag indicating we're shutting down, stop accepting new connections from proxy providers, and set a short (20-second) timer.
4. If the cluster acknowledges the request, defuse the timer. If the timer pops, exit immediately. (This allows us to handle the case where the cluster host is running an older version that doesn't support this new functionality.)
5. Once all IPC proxy providers have disconnected, exit immediately. If all providers are not disconnected before the systemd stop timeout (which is raised to 30 minutes to match pacemaker's), systemd will kill pacemaker_remote immediately.

I have tested through the crmd receiving the shutdown request. Crmd does not yet acknowledge it, so pacemaker_remote times out and exits.

The plan for the crmd side is to put the remote node into standby mode, and require the user to manually take the node out of standby once they're done doing whatever they're doing.

This will involve another change. Currently, if a cluster node is in standby, it can be stopped/rebooted/whatever and not get fenced. However, a remote node in standby will get fenced if pacemaker_remote is stopped. So the necessary change will be to make remote node standby stop the remote connection, and unstandby start it.

One other minor change is that the pacemaker_remote systemd unit file will need a long stop timeout, probably similar to pacemaker's. (Currently it is 30s.)

An alternative to using standby mode would be to use the "shutdown" transient node attribute that is used for cluster node shutdown. Crmd would set the shutdown attribute, and pengine would stop the remote connection. However this would likely be more complicated, and not as obvious for the user how to clear afterward (standby mode is clearly shown in pcs status, and most users are familiar with unstandby to clear it).