### PR TITLE
High : fencing_topology is not reflected.

### DIFF
--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -1279,7 +1279,7 @@ stonith_level_remove(xmlNode *msg, char **desc)
     CRM_CHECK(level != NULL, return -EINVAL);
 
     target = stonith_level_key(level, -1);
-    crm_element_value_int(level, XML_ATTR_ID, &id);
+    crm_element_value_int(level, XML_ATTR_STONITH_INDEX, &id);
     if (desc) {
         *desc = crm_strdup_printf("%s[%d]", target, id);
     }


### PR DESCRIPTION
Hi All,

The stonith understands only the last level even if I set fencing_topology.

Only prmStonith1-2 and prmStonith2-2 become effective in the next example.

```
<fencing-topology>
<!--### Fencing Topology ###-->
<fencing-level devices="prmStonith1-1" index="1" target="rh72-01"
id="fencing"/>
<fencing-level devices="prmStonith1-2" index="2" target="rh72-01"
id="fencing-0"/>
<fencing-level devices="prmStonith2-1" index="1" target="rh72-02"
id="fencing-1"/>
<fencing-level devices="prmStonith2-2" index="2" target="rh72-02"
id="fencing-2"/>
</fencing-topology>
```

Please reflect this correction for release of Pacemaker1.1.14.

Best Regards,
Hideo Yamauch.