### PR TITLE
wd: Correction to do to change action of the system reboot by fail_fast

### DIFF
--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -140,7 +140,11 @@ pcmk_panic_local(void)
 
     /* We're either pacemakerd, or a pacemaker daemon running as root */
 
-    sysrq_trigger('b');
+    if (strcmp("crash", getenv("PCMK_panic_action")) == 0) {
+        sysrq_trigger('c');
+    } else {
+        sysrq_trigger('b');
+    }
     /* reboot(RB_HALT_SYSTEM); rc = errno; */
     reboot(RB_AUTOBOOT);
     rc = errno;

--- a/mcp/pacemaker.sysconfig
+++ b/mcp/pacemaker.sysconfig
@@ -67,6 +67,12 @@
 # Enable this for rebooting this machine at the time of process (subsystem) failure
 # PCMK_fail_fast=no
 
+# Set action at the time of the system reboot by fail_fast
+# When set 'crash' , the kernel does panic
+# When you want to get kdump , please set 'crash'
+# The default action is 'reboot'
+# PCMK_panic_action=crash
+
 #==#==# Pacemaker Remote
 # Use a custom directory for finding the authkey.
 # PCMK_authkey_location=/etc/pacemaker/authkey


### PR DESCRIPTION
Hi All,

We want to allow us to change action when we reboot in fail_fast and sbd so that panic rises.
Because I want to acquire information at the time of these actions using kdump.

I want you to merge it because we want to use this feature from Pacemaker-1.1.14.