### PR TITLE
crm_resource --list-agents: don't print uninitialized memory

### DIFF
--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -375,18 +375,16 @@ main(int argc, char **argv)
                 } else if (safe_str_eq("list-agents", longname)) {
                     lrmd_list_t *list = NULL;
                     lrmd_list_t *iter = NULL;
-                    char standard[512];
-                    char provider[512];
+                    char *provider = strchr (optarg, ':');
                     lrmd_t *lrmd_conn = lrmd_api_new();
 
-                    rc = sscanf(optarg, "%[^:]:%s", standard, provider);
-                    if (rc == 1) {
+                    if (!provider) {
                         rc = lrmd_conn->cmds->list_agents(lrmd_conn, &list, optarg, NULL);
-                        provider[0] = '*';
-                        provider[1] = 0;
+                        provider = "*";
 
-                    } else if (rc == 2) {
-                        rc = lrmd_conn->cmds->list_agents(lrmd_conn, &list, standard, provider);
+                    } else {
+                        *provider++ = 0;
+                        rc = lrmd_conn->cmds->list_agents(lrmd_conn, &list, optarg, provider);
                     }
 
                     if (rc > 0) {
@@ -398,7 +396,7 @@ main(int argc, char **argv)
                         lrmd_list_freeall(list);
                         rc = 0;
                     } else {
-                        fprintf(stderr, "No agents found for standard=%s, provider=%s\n", standard,
+                        fprintf(stderr, "No agents found for standard=%s, provider=%s\n", optarg,
                                 provider);
                         rc = -1;
                     }


### PR DESCRIPTION
When the first character of the argument is a colon, the original code
printed uninitialized memory, because sscanf returned 0.  For example:

$ /usr/sbin/crm_resource --list-agents=:
No agents found for standard=øDÀ, provider=

This patch avoids using arbitrarily sized buffers, and separates
standard and provider by changing argv through the optarg pointer.