### PR TITLE
Fix: header == NULL when parsing compressed message

### DIFF
--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -383,9 +383,6 @@ crm_remote_parse_buffer(crm_remote_t * remote)
         return NULL;
     }
 
-    /* take ownership of the buffer */
-    remote->buffer_offset = 0;
-
     /* Support compression on the receiving end now, in case we ever want to add it later */
     if (header->payload_compressed) {
         int rc = 0;
@@ -420,6 +417,9 @@ crm_remote_parse_buffer(crm_remote_t * remote)
         remote->buffer = uncompressed;
         header = crm_remote_header(remote);
     }
+
+    /* take ownership of the buffer */
+    remote->buffer_offset = 0;
 
     CRM_LOG_ASSERT(remote->buffer[sizeof(struct crm_remote_header_v0) + header->payload_uncompressed - 1] == 0);
 


### PR DESCRIPTION
(I wanted to report it as an issue, however, it seems to be disabled on Github, so proposing a little fixup.)

When parsing a compressed message, message header is reloaded from the
uncompressed buffer. However, because remote->buffer_offset is zeroed
prior that, it'll consider the buffer already processed and return NULL.
Zeoring remote->buffer_offset after header retrieval should remedy this.

AFAICS, the decompression branch is not used so this perhaps is not an
issue in the real world.