### PR TITLE
Don't override any libdir containing $prefix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -378,7 +378,7 @@ AC_SUBST(INITDIR)
 AC_MSG_NOTICE(Sanitizing libdir: ${libdir})
 case $libdir in
   dnl For consistency with Heartbeat, map NONE->$prefix
-  *prefix*|NONE)
+  prefix|NONE)
     AC_MSG_CHECKING(which lib directory to use)
     for aDir in lib64 lib
     do


### PR DESCRIPTION
I have no idea what this whole "sanitizing" business is supposed to do in `configure.ac`, but it complicates the packaging of Pacemaker in Debian, so I decided to start a discussion here. The current best packaging practice recommends adhering to the [multiarch specification](https://wiki.ubuntu.com/MultiarchSpec), and this is backed by very good tool support. Straightforward packaging thus results in `configure` calls like
```
./configure --build=x86_64-linux-gnu --prefix=/usr --includedir=\${prefix}/include --mandir=\${prefix}/share/man --infodir=\${prefix}/share/info --sysconfdir=/etc --localstatedir=/var --disable-silent-rules --libdir=\${prefix}/lib/x86_64-linux-gnu --libexecdir=\${prefix}/lib/x86_64-linux-gnu --disable-maintainer-mode --disable-dependency-tracking --disable-static
```
Unfortunately, `configure` then "sanitizes" libdir to `/usr/lib` (leaving the other settings alone), necessitating an architecture specific manual override. I've been doing this for a couple of releases, but also wondered from the start if it serves a useful purpose in some cases or it is rather a bug. After all, this is the only "sanitizing" operation matching on `*prefix*`, all others are triggered by plain `prefix` (besides `NONE`). My patch uniformizes this, simply because it practically deactivates this operation as well, not because I understand why it should be like so (actually, I don't). So don't take it too seriously, but please enlighten me about this issue. so that I can suggest something for real. Thanks.