### PR TITLE
Fix RHBZ#1165423: Do an ordered shutdown of systemd resources

### DIFF
--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -150,16 +150,13 @@ systemd_daemon_reload(int timeout)
 {
     static unsigned int reload_count = 0;
     const char *method = "Reload";
-
+    DBusMessage *msg = systemd_new_method(BUS_NAME".Manager", method);
 
     reload_count++;
-    if(reload_count % 10 == 0) {
-        DBusMessage *msg = systemd_new_method(BUS_NAME".Manager", method);
+    CRM_ASSERT(msg != NULL);
+    pcmk_dbus_send(msg, systemd_proxy, systemd_daemon_reload_complete, GUINT_TO_POINTER(reload_count), timeout);
+    dbus_message_unref(msg);
 
-        CRM_ASSERT(msg != NULL);
-        pcmk_dbus_send(msg, systemd_proxy, systemd_daemon_reload_complete, GUINT_TO_POINTER(reload_count), timeout);
-        dbus_message_unref(msg);
-    }
     return TRUE;
 }
 

--- a/lrmd/lrmd.c
+++ b/lrmd/lrmd.c
@@ -900,6 +900,8 @@ action_complete(svc_action_t * action)
             /* Ok, so this is the follow up monitor action to check if start actually completed */
             if(cmd->lrmd_op_status == PCMK_LRM_OP_DONE && cmd->exec_rc == PCMK_OCF_PENDING) {
                 goagain = true;
+            } else if(cmd->exec_rc == PCMK_OCF_OK && safe_str_eq(cmd->real_action, "stop")) {
+                goagain = true;
 
             } else {
 #ifdef HAVE_SYS_TIMEB_H


### PR DESCRIPTION
    have lrmd wait till systemd actually starts bringing down systemd resources
    instead of being confused if service is still active on first status
    send a reload to systemd whenever a unitfile is changed instead of doing
    this just with every 10th change