### PR TITLE
Fix: crm_shadow: Do not invoke shells with --noprofile option other than bash

### DIFF
--- a/tools/cib_shadow.c
+++ b/tools/cib_shadow.c
@@ -78,7 +78,7 @@ shadow_setup(char *name, gboolean do_switch)
         if (strstr(shell, "bash")) {
             execl(shell, shell, "--norc", "--noprofile", NULL);
         } else {
-            execl(shell, shell, "--noprofile", NULL);
+            execl(shell, shell, NULL);
         }
 
     } else if (do_switch) {


### PR DESCRIPTION
Previously, shells that don't support --noprofile option failed to be
invoked. So far as I've seen, only bash supports --noprofile option.