### PR TITLE
Fix: fencing: Correctly track active stonith actions

### DIFF
--- a/fencing/internal.h
+++ b/fencing/internal.h
@@ -34,7 +34,6 @@ typedef struct stonith_device_s {
     /* whether the cluster should automatically unfence nodes with the device */
     gboolean automatic_unfencing;
     guint priority;
-    GListPtr active_pids;
 
     enum st_device_flags flags;
 


### PR DESCRIPTION
When executing a stonith action, stonith_action_async_done() can
re-invoke internal_stonith_action_execute(). In that case, it will
introduce a new pid for the action, which can not be tracked by the
invoker of stonith_action_execute_async().

This commit fixes it by tracking the (async_command_t *)op.