### PR TITLE
Track status of Pacemaker Remote nodes

### DIFF
--- a/crmd/callbacks.c
+++ b/crmd/callbacks.c
@@ -107,13 +107,14 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
     uint32_t old = 0;
     uint32_t changed = 0;
     bool appeared = FALSE;
+    bool is_remote = is_set(node->flags, crm_remote_node);
     const char *status = NULL;
 
     /* Crmd waits to receive some information from the membership layer before
      * declaring itself operational. If this is being called for a cluster node,
      * indicate that we have it.
      */
-    if (!is_set(node->flags, crm_remote_node)) {
+    if (!is_remote) {
         set_bit(fsa_input_register, R_PEER_DATA);
     }
 
@@ -126,21 +127,21 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
             /* If we've never seen the node, then it also wont be in the status section */
             crm_info("%s is now %s", node->uname, state_text(node->state));
             return;
+
         case crm_status_rstate:
-            crm_info("Remote node %s is now %s (was %s)",
-                     node->uname, state_text(node->state), state_text(data));
-            /* Keep going */
         case crm_status_nstate:
-            crm_info("%s is now %s (was %s)",
+            /* This callback should not be called unless the state actually
+             * changed, but here's a failsafe just in case.
+             */
+            CRM_CHECK(safe_str_neq(data, node->state), return);
+
+            crm_info("%s node %s is now %s (was %s)",
+                     (is_remote? "Remote" : "Cluster"),
                      node->uname, state_text(node->state), state_text(data));
 
-            if (safe_str_eq(data, node->state)) {
-                /* State did not change */
-                return;
-
-            } else if(safe_str_eq(CRM_NODE_MEMBER, node->state)) {
+            if (safe_str_eq(CRM_NODE_MEMBER, node->state)) {
                 appeared = TRUE;
-                if (!is_set(node->flags, crm_remote_node)) {
+                if (!is_remote) {
                     remove_stonith_cleanup(node->uname);
                 }
             }
@@ -197,7 +198,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
     if (AM_I_DC) {
         xmlNode *update = NULL;
         int flags = node_update_peer;
-        gboolean alive = crm_is_peer_active(node);
+        gboolean alive = is_remote? appeared : crm_is_peer_active(node);
         crm_action_t *down = match_down_event(0, node->uuid, NULL, appeared);
 
         crm_trace("Alive=%d, appear=%d, down=%p", alive, appeared, down);
@@ -220,30 +221,56 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                 /* down->confirmed = TRUE; Only stonith-ng returning should imply completion */
                 stop_te_timer(down->timer);
 
-                flags |= node_update_join | node_update_expected;
-                crmd_peer_down(node, FALSE);
-                check_join_state(fsa_state, __FUNCTION__);
+                if (!is_remote) {
+                    flags |= node_update_join | node_update_expected;
+                    crmd_peer_down(node, FALSE);
+                    check_join_state(fsa_state, __FUNCTION__);
+                }
 
                 update_graph(transition_graph, down);
                 trigger_graph();
 
             } else {
-                crm_trace("Other %p", down);
+                crm_trace("Node %s came up, was expected %s (op %d)",
+                          node->uname, task, down->id);
             }
 
         } else if (appeared == FALSE) {
+            /* match_down_event() doesn't match resource stop events for
+             * pacemaker_remote nodes, so normal pacemaker_remote node stops
+             * will come here and get ugly log messages, but otherwise be OK.
+             * We can't skip this entirely for pacemaker_remote nodes,
+             * because monitor failures will also end up here.
+             */
             crm_notice("Stonith/shutdown of %s not matched", node->uname);
 
-            crm_update_peer_join(__FUNCTION__, node, crm_join_none);
-            check_join_state(fsa_state, __FUNCTION__);
+            if (!is_remote) {
+                crm_update_peer_join(__FUNCTION__, node, crm_join_none);
+                check_join_state(fsa_state, __FUNCTION__);
+            }
 
             abort_transition(INFINITY, tg_restart, "Node failure", NULL);
             fail_incompletable_actions(transition_graph, node->uuid);
 
         } else {
-            crm_trace("Other %p", down);
+            crm_trace("Node %s came up, was not expected to be down",
+                      node->uname);
         }
 
+        if (is_remote) {
+            /* A pacemaker_remote node won't have its cluster status updated
+             * in the CIB by membership-layer callbacks, so do it here.
+             */
+            flags |= node_update_cluster;
+
+            /* Trigger resource placement on newly integrated nodes */
+            if (appeared) {
+                abort_transition(INFINITY, tg_restart,
+                                 "pacemaker_remote node integrated", NULL);
+            }
+        }
+
+        /* Update the CIB node state */
         update = do_update_node_cib(node, flags, NULL, __FUNCTION__);
         fsa_cib_anon_update(XML_CIB_TAG_STATUS, update,
                             cib_scope_local | cib_quorum_override | cib_can_create);

--- a/crmd/callbacks.c
+++ b/crmd/callbacks.c
@@ -240,7 +240,8 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
              * pacemaker_remote nodes, so normal pacemaker_remote node stops
              * will come here and get ugly log messages, but otherwise be OK.
              * We can't skip this entirely for pacemaker_remote nodes,
-             * because monitor failures will also end up here.
+             * because recurring monitor failures will also end up here
+             * when the cluster recovers the connection resource.
              */
             crm_notice("Stonith/shutdown of %s not matched", node->uname);
 

--- a/crmd/crmd_lrm.h
+++ b/crmd/crmd_lrm.h
@@ -158,5 +158,6 @@ int remote_ra_exec(lrm_state_t * lrm_state, const char *rsc_id, const char *acti
                    int start_delay,     /* ms */
                    lrmd_key_value_t * params);
 void remote_ra_cleanup(lrm_state_t * lrm_state);
+void remote_ra_fail(const char *node_name);
 
 gboolean process_lrm_event(lrm_state_t * lrm_state, lrmd_event_data_t * op, struct recurring_op_s *pending);

--- a/crmd/crmd_lrm.h
+++ b/crmd/crmd_lrm.h
@@ -159,6 +159,4 @@ int remote_ra_exec(lrm_state_t * lrm_state, const char *rsc_id, const char *acti
                    lrmd_key_value_t * params);
 void remote_ra_cleanup(lrm_state_t * lrm_state);
 
-xmlNode *simple_remote_node_status(const char *node_name, xmlNode *parent, const char *source);
-
 gboolean process_lrm_event(lrm_state_t * lrm_state, lrmd_event_data_t * op, struct recurring_op_s *pending);

--- a/crmd/crmd_messages.h
+++ b/crmd/crmd_messages.h
@@ -111,4 +111,6 @@ extern enum crmd_fsa_input handle_message(xmlNode * stored_msg, enum crmd_fsa_ca
 
 extern ha_msg_input_t *copy_ha_msg_input(ha_msg_input_t * orig);
 
+void send_remote_state_message(const char *node_name, gboolean node_up);
+
 #endif

--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -837,20 +837,15 @@ do_lrm_query_internal(lrm_state_t *lrm_state, int update_flags)
     xmlNode *xml_state = NULL;
     xmlNode *xml_data = NULL;
     xmlNode *rsc_list = NULL;
-    const char *uuid = NULL;
+    crm_node_t *peer = NULL;
 
-    if (lrm_state_is_local(lrm_state)) {
-        crm_node_t *peer = crm_get_peer(0, lrm_state->node_name);
-        xml_state = do_update_node_cib(peer, update_flags, NULL, __FUNCTION__);
-        uuid = fsa_our_uuid;
+    peer = crm_get_peer_full(0, lrm_state->node_name, CRM_GET_PEER_ANY);
+    CRM_CHECK(peer != NULL, return NULL);
 
-    } else {
-        xml_state = simple_remote_node_status(lrm_state->node_name, NULL, __FUNCTION__);
-        uuid = lrm_state->node_name;
-    }
+    xml_state = do_update_node_cib(peer, update_flags, NULL, __FUNCTION__);
 
     xml_data = create_xml_node(xml_state, XML_CIB_TAG_LRM);
-    crm_xml_add(xml_data, XML_ATTR_ID, uuid);
+    crm_xml_add(xml_data, XML_ATTR_ID, peer->uuid);
     rsc_list = create_xml_node(xml_data, XML_LRM_TAG_RESOURCES);
 
     /* Build a list of active (not always running) resources */

--- a/crmd/messages.c
+++ b/crmd/messages.c
@@ -674,7 +674,7 @@ handle_remote_state(xmlNode *msg)
     CRM_CHECK(remote_peer, return I_NULL);
 
     crm_update_peer_state(__FUNCTION__, remote_peer,
-                          strcmp(remote_is_up, XML_BOOLEAN_TRUE)?
+                          crm_is_true(remote_is_up)?
                           CRM_NODE_LOST : CRM_NODE_MEMBER, 0);
     return I_NULL;
 }

--- a/crmd/remote_lrmd_ra.c
+++ b/crmd/remote_lrmd_ra.c
@@ -1025,3 +1025,24 @@ remote_ra_exec(lrm_state_t * lrm_state, const char *rsc_id, const char *action, 
     lrmd_key_value_freeall(params);
     return rc;
 }
+
+/*!
+ * \internal
+ * \brief Immediately fail all monitors of a remote node, if proxied here
+ *
+ * \param[in] node_name  Name of pacemaker_remote node
+ */
+void
+remote_ra_fail(const char *node_name)
+{
+    lrm_state_t *lrm_state = lrm_state_find(node_name);
+
+    if (lrm_state && lrm_state_is_connected(lrm_state)) {
+        remote_ra_data_t *ra_data = lrm_state->remote_ra_data;
+
+        crm_info("Failing monitors on pacemaker_remote node %s", node_name);
+        ra_data->recurring_cmds = fail_all_monitor_cmds(ra_data->recurring_cmds);
+        ra_data->cmds = fail_all_monitor_cmds(ra_data->cmds);
+    }
+}
+

--- a/crmd/remote_lrmd_ra.c
+++ b/crmd/remote_lrmd_ra.c
@@ -274,6 +274,13 @@ check_remote_node_state(remote_ra_cmd_t *cmd)
     if (safe_str_eq(cmd->action, "start")) {
         remote_node_up(cmd->rsc_id);
 
+    } else if (safe_str_eq(cmd->action, "migrate_from")) {
+        /* Ensure node is in this host's remote peer cache */
+        crm_node_t *node = crm_remote_peer_get(cmd->rsc_id);
+
+        CRM_CHECK(node != NULL, return);
+        crm_update_peer_state(__FUNCTION__, node, CRM_NODE_MEMBER, 0);
+
     } else if (safe_str_eq(cmd->action, "stop")) {
         lrm_state_t *lrm_state = lrm_state_find(cmd->rsc_id);
         remote_ra_data_t *ra_data = lrm_state? lrm_state->remote_ra_data : NULL;

--- a/crmd/te_events.c
+++ b/crmd/te_events.c
@@ -395,6 +395,11 @@ get_cancel_action(const char *id, const char *node)
  * \return Matching event if found, NULL otherwise
  *
  * \note "Down" events are CRM_OP_FENCE and CRM_OP_SHUTDOWN.
+ * \todo This should detect normal pacemaker_remote node stop events,
+ *       where action->type is action_type_rsc,
+ *       XML_LRM_ATTR_TASK is CRMD_ACTION_STOP,
+ *       and the affected resource creates a remote node that matches target.
+ *       Then, peer_update_callback() could ignore these.
  */
 crm_action_t *
 match_down_event(int id, const char *target, const char *filter, bool quiet)

--- a/crmd/te_events.c
+++ b/crmd/te_events.c
@@ -247,77 +247,6 @@ status_from_rc(crm_action_t * action, int orig_status, int rc, int target_rc)
     return PCMK_LRM_OP_ERROR;
 }
 
-static void
-process_remote_node_action(crm_action_t *action, xmlNode *event)
-{
-    xmlNode *child = NULL;
-
-    /* The whole point of this function is to detect when a remote-node
-     * is integrated into the cluster or has failed, and properly abort
-     * the transition so resources can be placed on the new node or fail
-     * all pending actions on a lost node.
-     */
-
-    if (crm_remote_peer_cache_size() == 0) {
-        return;
-    } else if (action->type != action_type_rsc) {
-        return;
-    } else if (action->confirmed == FALSE) {
-        return;
-    } else if (!action->failed || safe_str_neq(crm_element_value(action->xml, XML_LRM_ATTR_TASK), "start")) {
-        /* we only care about failed remote nodes, or remote nodes that have just come online. */
-        return;
-    }
-
-    for (child = __xml_first_child(action->xml); child != NULL; child = __xml_next(child)) {
-        const char *provider;
-        const char *type;
-        const char *rsc;
-        const char *action_type;
-        crm_node_t *remote_peer;
-
-        if (safe_str_neq(crm_element_name(child), XML_CIB_TAG_RESOURCE)) {
-            continue;
-        }
-
-        provider = crm_element_value(child, XML_AGENT_ATTR_PROVIDER);
-        type = crm_element_value(child, XML_ATTR_TYPE);
-        rsc = ID(child);
-        action_type = crm_element_value(action->xml, XML_LRM_ATTR_TASK);
-
-        if (safe_str_neq(provider, "pacemaker") || safe_str_neq(type, "remote") || rsc == NULL) {
-            break;
-        }
-
-        remote_peer = crm_get_peer_full(0, rsc, CRM_GET_PEER_REMOTE);
-        if (remote_peer == NULL) {
-            break;
-        }
-
-        /* if a remote node connection failed, and this failure is not related to a probe
-         * action, make sure to cancel any in-flight operations occurring on that remote node
-         * since those actions will timeout. we don't want to wait around for the timeouts */
-        if (action->failed &&
-            !(safe_str_eq(action_type, "monitor") && action->interval == 0)) {
-
-            /* the rsc id is actually the remote node id. we want to mark all
-             * in-flight actions on a failed remote node as incompletable */
-            fail_incompletable_actions(transition_graph, rsc);
-
-        } else if (!action->failed &&
-                   safe_str_eq(remote_peer->state, CRM_NODE_LOST) &&
-                   safe_str_eq(action_type, "start")) {
-            /* A remote node will be placed in the "lost" state after
-             * it has been successfully fenced.  After successfully connecting
-             * to a remote-node after being fenced, we need to abort the transition
-             * so resources can be placed on the newly integrated remote-node */
-            abort_transition(INFINITY, tg_restart, "Remote-node re-discovered.", event);
-        }
-
-        return;
-    }
-}
-
 /*!
  * \internal
  * \brief Confirm action and update transition graph, aborting transition on failures
@@ -385,9 +314,6 @@ match_graph_event(crm_action_t *action, xmlNode *event, int op_status,
     target = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
     crm_info("Action %s (%d) confirmed on %s (rc=%d%s)",
              crm_str(this_event), action->id, crm_str(target), op_rc, ignore_s);
-
-    /* determine if this action affects a remote-node's online/offline status */
-    process_remote_node_action(action, event);
 }
 
 crm_action_t *

--- a/crmd/te_utils.c
+++ b/crmd/te_utils.c
@@ -360,6 +360,8 @@ tengine_stonith_notify(stonith_t * st, stonith_event_t * st_event)
 
         /* If the target is a remote node, and we host its connection,
          * immediately fail all monitors so it can be recovered quickly.
+         * The connection won't necessarily drop when a remote node is fenced,
+         * so the failure might not otherwise be detected until the next poke.
          */
         if (is_set(peer->flags, crm_remote_node)) {
             remote_ra_fail(st_event->target);

--- a/crmd/te_utils.c
+++ b/crmd/te_utils.c
@@ -26,6 +26,7 @@
 #include <crm/common/xml.h>
 #include <tengine.h>
 #include <crmd_fsa.h>
+#include <crmd_lrm.h>
 #include <crmd_messages.h>
 #include <throttle.h>
 #include <crm/fencing/internal.h>
@@ -355,6 +356,13 @@ tengine_stonith_notify(stonith_t * st, stonith_event_t * st_event)
                 send_stonith_update(NULL, st_event->target, uuid);
             }
             add_stonith_cleanup(st_event->target);
+        }
+
+        /* If the target is a remote node, and we host its connection,
+         * immediately fail all monitors so it can be recovered quickly.
+         */
+        if (is_set(peer->flags, crm_remote_node)) {
+            remote_ra_fail(st_event->target);
         }
 
         crmd_peer_down(peer, TRUE);

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -63,6 +63,9 @@ enum crm_node_flags
     /* deprecated (not used by cluster) */
     crm_remote_container     = 0x0002,
     crm_remote_baremetal     = 0x0004,
+
+    /* node's cache entry is dirty */
+    crm_node_dirty           = 0x0010,
 };
 /* *INDENT-ON* */
 

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -152,6 +152,7 @@ int crm_remote_peer_cache_size(void);
 /* Initialize and refresh the remote peer cache from a cib config */
 void crm_remote_peer_cache_refresh(xmlNode *cib);
 void crm_remote_peer_cache_add(const char *node_name);
+crm_node_t *crm_remote_peer_get(const char *node_name);
 void crm_remote_peer_cache_remove(const char *node_name);
 
 /* allows filtering of remote and cluster nodes using crm_get_peer_flags */

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -132,6 +132,7 @@ extern char *crm_system_name;
 #  define CRM_OP_NODES_PROBED	"probe_nodes_complete"
 #  define CRM_OP_REPROBE		"probe_again"
 #  define CRM_OP_CLEAR_FAILCOUNT  "clear_failcount"
+#  define CRM_OP_REMOTE_STATE     "remote_state"
 #  define CRM_OP_RELAXED_SET  "one-or-more"
 #  define CRM_OP_RELAXED_CLONE  "clone-one-or-more"
 #  define CRM_OP_RM_NODE_CACHE "rm_node_cache"

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -361,6 +361,16 @@ get_node_name(uint32_t nodeid)
     return name;
 }
 
+/*!
+ * \brief Get the node name corresponding to a node UUID
+ *
+ * \param[in] uuid  UUID of desired node
+ *
+ * \return name of desired node
+ *
+ * \note This relies on the remote peer cache being populated with all
+ *       remote nodes in the cluster, so callers should maintain that cache.
+ */
 const char *
 crm_peer_uname(const char *uuid)
 {
@@ -384,6 +394,7 @@ crm_peer_uname(const char *uuid)
             break;
         }
     }
+    node = NULL;
 
 #if SUPPORT_COROSYNC
     if (is_openais_cluster()) {

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -140,7 +140,9 @@ crm_remote_peer_cache_add(const char *node_name)
 void
 crm_remote_peer_cache_remove(const char *node_name)
 {
-    g_hash_table_remove(crm_remote_peer_cache, node_name);
+    if (g_hash_table_remove(crm_remote_peer_cache, node_name)) {
+        crm_trace("removed %s from remote peer cache", node_name);
+    }
 }
 
 /*!


### PR DESCRIPTION
Track whether Pacemaker Remote nodes are up or down, in the remote peer cache (on the connection host and the DC) and in the CIB. This narrows the difference between cluster nodes and Pacemaker Remote nodes, and allows quicker recovery and resource placement after failures.