### PR TITLE
Fix: ipc: Respect the parameter of pick_ipc_buffer() but don't let it affect the global value

### DIFF
--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -747,22 +747,22 @@ struct crm_ipc_s {
 static unsigned int
 pick_ipc_buffer(unsigned int max)
 {
-    const char *env;
     static unsigned int global_max = 0;
 
-    if (global_max != 0)
-        return global_max;
+    if (global_max == 0) {
+        const char *env = getenv("PCMK_ipc_buffer");
 
-    env = getenv("PCMK_ipc_buffer");
-    if (env) {
-        int env_max = crm_parse_int(env, "0");
+        if (env) {
+            int env_max = crm_parse_int(env, "0");
 
-        global_max = QB_MAX(MIN_MSG_SIZE, env_max);
-    } else {
-        global_max = QB_MAX(MAX_MSG_SIZE, max);
+            global_max = (env_max > 0)? QB_MAX(MIN_MSG_SIZE, env_max) : MAX_MSG_SIZE;
+
+        } else {
+            global_max = MAX_MSG_SIZE;
+        }
     }
 
-    return global_max;
+    return QB_MAX(max, global_max);
 }
 
 crm_ipc_t *


### PR DESCRIPTION
e5964d5 changed the logic in pick_ipc_buffer(). It doesn't look right
to let the parameter "max" affect "global_max". And any following
invocations would basically ignore "max" and directly return "global_max".