### PR TITLE
Fix: crm_shadow: fix broken --display command

### DIFF
--- a/tools/cib_shadow.c
+++ b/tools/cib_shadow.c
@@ -409,7 +409,7 @@ main(int argc, char **argv)
         rc = 0;
         goto done;
 
-    } else if (command == 'P') {
+    } else if (command == 'p') {
         /* display the current contents */
         char *output_s = NULL;
         xmlNode *output = filename2xml(shadow_file);


### PR DESCRIPTION
The command line flag for crm_shadow --display is 'p', but the command
section looks for 'P', so the crm_shadow --display command never
actually does anything.

This commit fixes the typo.