### PR TITLE
Fix state file metadata in Dummy, Stateful and HealthCPU resource agents

### DIFF
--- a/doc/Pacemaker_Explained/en-US/Ch-Resources.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Resources.txt
@@ -519,7 +519,7 @@ but moderate. The minimum timeouts should never be below 10 seconds.
 Location to store the resource state in.
 </longdesc>
 <shortdesc lang="en">State file</shortdesc>
-<content type="string" default="/var/run//Dummy-{OCF_RESOURCE_INSTANCE}.state" />
+<content type="string" default="/var/run//Dummy-default.state" />
 </parameter>
 
 <parameter name="fake" unique="0">

--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -63,7 +63,7 @@ but moderate. The minimum timeouts should never be below 10 seconds.
 Location to store the resource state in.
 </longdesc>
 <shortdesc lang="en">State file</shortdesc>
-<content type="string" default="${HA_VARRUN}/Dummy-{OCF_RESOURCE_INSTANCE}.state" />
+<content type="string" default="${HA_VARRUN}/Dummy-${OCF_RESOURCE_INSTANCE}.state" />
 </parameter>
 
 <parameter name="passwd" unique="1">

--- a/extra/resources/HealthCPU
+++ b/extra/resources/HealthCPU
@@ -62,7 +62,7 @@ Systhem health agent that measures the CPU idling and updates the #health-cpu at
 Location to store the resource state in.
 </longdesc>
 <shortdesc lang="en">State file</shortdesc>
-<content type="string" default="${HA_VARRUN}/health-cpu-{OCF_RESOURCE_INSTANCE}.state" />
+<content type="string" default="${HA_VARRUN}/health-cpu-${OCF_RESOURCE_INSTANCE}.state" />
 </parameter>
 
 <parameter name="yellow_limit" unique="1">

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -54,7 +54,7 @@ This is an example resource agent that impliments two states
 Location to store the resource state in
 </longdesc>
 <shortdesc lang="en">State file</shortdesc>
-<content type="string" default="${HA_VARRUN}/Stateful-{OCF_RESOURCE_INSTANCE}.state" />
+<content type="string" default="${HA_VARRUN}/Stateful-${OCF_RESOURCE_INSTANCE}.state" />
 </parameter>
 
 </parameters>


### PR DESCRIPTION
This fixes a simple typo, which spread out. Beyond that, the `HA_VARRUN` variable is undocumented. Its usage seems to stem from [[Linux-ha-dev] Pseudo RAs do not work properly on Corosync stack](http://lists.linux-ha.org/pipermail/linux-ha-dev/2010-March/017258.html) (commit baef7d98), but I wonder if the original reason still applies and warrants polluting the `/var/run` directory with state files. Isn't `HA_RSCTMP_OLD=/var/run/heartbeat/rsctmp` the directory Heartbeat removes on start? `HA_RSCTMP=/var/run/resource-agents` was invented in the above thread, if I read it correctly.