### PR TITLE
The default IPC buffer size is 128k since 1.1.10 (8196f23a)

### DIFF
--- a/mcp/pacemaker.sysconfig
+++ b/mcp/pacemaker.sysconfig
@@ -80,8 +80,8 @@
 # PCMK_ipc_type=shared-mem|socket|posix|sysv
 
 # Specify an IPC buffer size in bytes
-# Useful when connecting to really big clusters that exceed the default 20k buffer
-# PCMK_ipc_buffer=20480
+# Useful when connecting to really big clusters that exceed the default 128k buffer
+# PCMK_ipc_buffer=131072
 
 #==#==# Profiling and memory leak testing
 


### PR DESCRIPTION
Signed-off-by: Ferenc Wágner <wferi@niif.hu>