### PR TITLE
Low: action_launch_child is effectively noreturn

### DIFF
--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -728,6 +728,7 @@ services_os_action_execute(svc_action_t * op, gboolean synchronous)
             }
 
             action_launch_child(op);
+            CRM_ASSERT(0);  /* action_launch_child is effectively noreturn */
     }
 
     /* Only the parent reaches here */


### PR DESCRIPTION
Explicit commented assert will ease the code comprehension.