### PR TITLE
Fix: remote: cl#5269 - Notify other clients of a new connection only if the handshake has completed (bsc#967388)

### DIFF
--- a/lrmd/tls_backend.c
+++ b/lrmd/tls_backend.c
@@ -79,6 +79,9 @@ lrmd_remote_client_msg(gpointer data)
                 g_source_remove(client->remote->auth_timeout);
             }
             client->remote->auth_timeout = 0;
+
+            /* Alert other clients of the new connection */
+            notify_of_new_client(client);
         }
         return 0;
     }
@@ -289,8 +292,6 @@ lrmd_remote_listen(gpointer data)
                         &lrmd_remote_fd_cb);
     g_hash_table_insert(client_connections, new_client->id, new_client);
 
-    /* Alert other clients of the new connection */
-    notify_of_new_client(new_client);
     return TRUE;
 }
 


### PR DESCRIPTION
This fixes http://bugs.clusterlabs.org/show_bug.cgi?id=5269