### PR TITLE
Low: rethink sed command complexity vs. compatibility trade-off

### DIFF
--- a/extra/cluster-init
+++ b/extra/cluster-init
@@ -151,7 +151,7 @@ done
 if [ ! -z $cluster ]; then
     host_input="-g $cluster"
     # use the last digit present in the variable (if any)
-    dsh_group=`echo $cluster | sed 's/[^0-9]\+//g;s/.*\([0-9]\)$/\1/'`
+    dsh_group=`echo $cluster | sed 's/[^0-9][^0-9]*//g;s/.*\([0-9]\)$/\1/'`
 fi
 
 if [ -z $dsh_group ]; then

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -30,7 +30,7 @@ RNGdir			= $(dtddir)
 # Sorted list of available numeric RNG versions,
 # extracted from filenames like NAME-MAJOR[.MINOR][.MINOR-MINOR].rng
 RNG_numeric_versions    = $(shell ls -1 *.rng \
-			  | sed -E -n -e 's/^.*-([0-9.]+).rng$$/\1/p' \
+			  | sed -n -e 's/^.*-\([0-9][0-9.]*\).rng$$/\1/p' \
 			  | sort -u -t. -k 1,1n -k 2,2n -k 3,3n)
 
 # The highest numeric version


### PR DESCRIPTION
This change effectively reverts [8ebeb52] and re-does the intended
compatibility enhancement in a less intrusive (and hopefully more
compatible) way + the same is applied at another instance of
'BRE-imposed, ERE-unsupported backslashing of meta-plus'.

Note that there is a counter-proposal by Ken:
<https://github.com/ClusterLabs/pacemaker/pull/938>

It is expected that -E switch will eventually become fully adpoted by
main "sed" implementations, but at this point it seems unwise to drop
backward compatibility (with up to at least ~2008 POSIX)  altogether:
<http://austingroupbugs.net/view.php?id=528>
<https://github.com/ClusterLabs/pacemaker/pull/861#commitcomment-16356114>

[8ebeb52] https://github.com/ClusterLabs/pacemaker/pull/861