### PR TITLE
Mid: attrd: Support of the dampen change by attrd.

### DIFF
--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -525,7 +525,7 @@ attrd_peer_message(crm_node_t *peer, xmlNode *xml)
         }
     }
 
-    if (safe_str_eq(op, ATTRD_OP_UPDATE)) {
+    if (safe_str_eq(op, ATTRD_OP_UPDATE) || safe_str_eq(op, ATTRD_OP_UPDATE_VALUE_AND_DAMPEN) || safe_str_eq(op, ATTRD_OP_UPDATE_ONLY_DAMPEN)) {
         attrd_peer_update(peer, xml, host, FALSE);
 
     } else if (safe_str_eq(op, ATTRD_OP_SYNC)) {
@@ -669,14 +669,41 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
 {
     bool changed = FALSE;
     attribute_value_t *v = NULL;
+    int dampen = 0;
 
+    const char *op = crm_element_value(xml, F_ATTRD_TASK);
     const char *attr = crm_element_value(xml, F_ATTRD_ATTRIBUTE);
     const char *value = crm_element_value(xml, F_ATTRD_VALUE);
+    const char *dvalue = crm_element_value(xml, F_ATTRD_DAMPEN);
 
     attribute_t *a = g_hash_table_lookup(attributes, attr);
 
     if(a == NULL) {
-        a = create_attribute(xml);
+        if (safe_str_eq(op, ATTRD_OP_UPDATE) || safe_str_eq(op, ATTRD_OP_UPDATE_VALUE_AND_DAMPEN)) {
+            a = create_attribute(xml);
+        }
+    } else {
+        if (safe_str_eq(op, ATTRD_OP_UPDATE_VALUE_AND_DAMPEN) || safe_str_eq(op, ATTRD_OP_UPDATE_ONLY_DAMPEN)) {
+            if (dvalue) {
+                dampen = crm_get_msec(dvalue); 
+                if (dampen >= 0) {
+                    if (a->timeout_ms != dampen) {
+                        mainloop_timer_stop(a->timer);
+                        mainloop_timer_del(a->timer);
+                        a->timeout_ms = dampen;
+                        if (dampen > 0) {
+                            a->timer = mainloop_timer_add(a->id, a->timeout_ms, FALSE, attribute_timer_cb, a);
+                            crm_info("Update attribute %s with delay %dms (%s)", a->id, dampen, dvalue);
+                        } else {
+                            a->timer = NULL;
+                            crm_info("Update attribute %s with not delay", a->id);
+                        }
+                        //if dampen is changed, attrd writes in a current value immediately.
+                        write_or_elect_attribute(a);
+                    }
+                } 
+            }
+        }
     }
 
     if(host == NULL) {
@@ -711,14 +738,18 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
         free_xml(sync);
 
     } else if(safe_str_neq(v->current, value)) {
-        crm_info("Setting %s[%s]: %s -> %s from %s", attr, host, v->current, value, peer->uname);
-        free(v->current);
-        if(value) {
-            v->current = strdup(value);
+        if (safe_str_eq(op, ATTRD_OP_UPDATE) || safe_str_eq(op, ATTRD_OP_UPDATE_VALUE_AND_DAMPEN)) {
+            crm_info("Setting %s[%s]: %s -> %s from %s", attr, host, v->current, value, peer->uname);
+            free(v->current);
+            if(value) {
+                v->current = strdup(value);
+            } else {
+                v->current = NULL;
+            }
+            changed = TRUE;
         } else {
-            v->current = NULL;
+            crm_trace("Unchanged %s[%s] from %s.(ATTRD_OP_UPDATE_ONLY_DAMPEN)", attr, host, peer->uname);
         }
-        changed = TRUE;
 
     } else {
         crm_trace("Unchanged %s[%s] from %s is %s", attr, host, peer->uname, value);

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -239,6 +239,14 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
         attrd_send_ack(client, id, flags);
         attrd_client_update(xml);
 
+    } else if (safe_str_eq(op, ATTRD_OP_UPDATE_VALUE_AND_DAMPEN)) {
+        attrd_send_ack(client, id, flags);
+        attrd_client_update(xml);
+
+    } else if (safe_str_eq(op, ATTRD_OP_UPDATE_ONLY_DAMPEN)) {
+        attrd_send_ack(client, id, flags);
+        attrd_client_update(xml);
+  
     } else if (safe_str_eq(op, ATTRD_OP_REFRESH)) {
         attrd_send_ack(client, id, flags);
         attrd_client_refresh();

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -291,6 +291,8 @@ long crm_read_pidfile(const char *filename);
 /* attrd operations */
 #  define ATTRD_OP_PEER_REMOVE   "peer-remove"
 #  define ATTRD_OP_UPDATE        "update"
+#  define ATTRD_OP_UPDATE_VALUE_AND_DAMPEN         "update-value-and-dampen"
+#  define ATTRD_OP_UPDATE_ONLY_DAMPEN         "update-only-dampen"
 #  define ATTRD_OP_QUERY         "query"
 #  define ATTRD_OP_REFRESH       "refresh"
 #  define ATTRD_OP_FLUSH         "flush"

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -1818,6 +1818,14 @@ attrd_update_delegate(crm_ipc_t * ipc, char command, const char *host, const cha
         case 'R':
             crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_REFRESH);
             break;
+        case 'E':
+            crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_UPDATE_VALUE_AND_DAMPEN);
+            crm_xml_add(update, F_ATTRD_ATTRIBUTE, name);
+            break;
+        case 'F':
+            crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_UPDATE_ONLY_DAMPEN);
+            crm_xml_add(update, F_ATTRD_ATTRIBUTE, name);
+            break;
         case 'Q':
             crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_QUERY);
             crm_xml_add(update, F_ATTRD_ATTRIBUTE, name);

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -45,6 +45,8 @@ static struct crm_option long_options[] = {
     {"-spacer-",1, 0, '-', "\nCommands:"},
     {"update",  1, 0, 'U', "Update the attribute's value in attrd.  If this causes the value to change, it will also be updated in the cluster configuration"},
 #ifdef HAVE_ATOMIC_ATTRD
+    {"update-all",   1, 0, 'E', "Update the attribute's value, and the time to wait (dampening) in attrd.  If this causes the value to change, it will also be updated in the cluster configuration"},
+    {"update-dampen",   0, 0, 'F', "Update the time to wait (dampening) in attrd. If this causes the value to change, it will also be updated in the cluster configuration"},
     {"query",   0, 0, 'Q', "\tQuery the attribute's value from attrd"},
 #endif
     {"delete",  0, 0, 'D', "\tDelete the attribute in attrd.  If a value was previously set, it will also be removed from the cluster configuration"},
@@ -142,6 +144,11 @@ main(int argc, char **argv)
             case 'q':
                 break;
 #ifdef HAVE_ATOMIC_ATTRD
+            case 'F':
+                command = flag;
+                crm_log_args(argc, argv); /* Too much? */
+                break;
+            case 'E':
             case 'Q':
 #endif
             case 'R':


### PR DESCRIPTION
Hi All,

I added the support of the change of dampen by attrd and attrd_updater.
I added a function to change the value only for dampen and a function to change the combination of dampen and value.

The command-line of attrd_updater is as follows.

1)Change the combination of dampen and value.
  attrd_updater -E value -n name -d dampen

2)Change the value only for dampen.
  attrd_updater -F -n name -d dampen

It is necessary to discuss the next matter.
 * Option of the attrd_updater command.
  * The current patch uses E and F by tentativeness.
 * Help of attrd_updater.
  * Because I am weak in English, I do not understand the expression of the right help.
 * Lack of the processing may be to the patch.

I make this patch from former next pullrequest.
 * https://github.com/ClusterLabs/pacemaker/pull/906

Best Regards,
Hideo Yamauchi.
