### PR TITLE
Fix: crmd,tools: Set attributes for remote nodes directly into cib if it's legacy attrd

### DIFF
--- a/crmd/utils.c
+++ b/crmd/utils.c
@@ -1018,11 +1018,53 @@ erase_status_tag(const char *uname, const char *tag, int options)
 
 crm_ipc_t *attrd_ipc = NULL;
 
+#if !HAVE_ATOMIC_ATTRD
+static int
+update_without_attrd(const char * host_uuid, const char * name, const char * value,
+                     const char * user_name, gboolean is_remote_node, char command)
+{
+    int call_opt = cib_none;
+
+    if (fsa_cib_conn == NULL) {
+        return -1;
+    }
+
+    call_opt = crmd_cib_smart_opt();
+
+    if (command == 'C') {
+        erase_status_tag(host_uuid, XML_TAG_TRANSIENT_NODEATTRS, call_opt);
+        return pcmk_ok;
+    }
+
+    crm_trace("updating status for host_uuid %s, %s=%s", host_uuid, name ? name : "<null>", value ? value : "<null>");
+    if (value) {
+        return update_attr_delegate(fsa_cib_conn, call_opt, XML_CIB_TAG_STATUS, host_uuid, NULL, NULL,
+                                    NULL, name, value, FALSE, user_name, is_remote_node ? "remote" : NULL);
+    } else {
+        return delete_attr_delegate(fsa_cib_conn, call_opt, XML_CIB_TAG_STATUS, host_uuid, NULL, NULL,
+                                    NULL, name, NULL, FALSE, user_name);
+    }
+}
+#endif
+
 static void
 update_attrd_helper(const char *host, const char *name, const char *value, const char *user_name, gboolean is_remote_node, char command)
 {
     gboolean rc;
     int max = 5;
+
+#if !HAVE_ATOMIC_ATTRD
+    /* Talk directly to cib for remote nodes if it's legacy attrd */
+    if (is_remote_node) {
+        /* host is required for updating a remote node */
+        CRM_CHECK(host != NULL, return;);
+        /* remote node uname and uuid are equal */
+        if (update_without_attrd(host, name, value, user_name, is_remote_node, command) < pcmk_ok) {
+            crm_err("Could not update attribute %s for remote-node %s", name, host);
+        }
+        return;
+    }
+#endif
 
     if (attrd_ipc == NULL) {
         attrd_ipc = crm_ipc_new(T_ATTRD, 0);

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -260,6 +260,10 @@ main(int argc, char **argv)
     }
 
     if ((command == 'v' || command == 'D')
+#if !HAVE_ATOMIC_ATTRD
+        /* Always send remote node attr directly to cib if it's legacy attrd */
+        && is_remote_node == FALSE
+#endif
         && safe_str_eq(type, XML_CIB_TAG_STATUS)
         && pcmk_ok == attrd_update_delegate(NULL, command, dest_uname, attr_name, attr_value, type, set_name,
                                  NULL, NULL, is_remote_node)) {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -584,6 +584,28 @@ send_lrm_rsc_op(crm_ipc_t * crmd_channel, const char *op,
     return rc;
 }
 
+static int
+cli_delete_attr(cib_t * cib_conn, const char * host_uname, const char * attr_name,
+                pe_working_set_t * data_set)
+{
+    node_t *node = pe_find_node(data_set->nodes, host_uname);
+
+    if (node == NULL) {
+        CMD_ERR("Error deleting attribute '%s': node '%s' is unknown", attr_name, host_uname);
+        return -ENXIO;
+    }
+
+#if !HAVE_ATOMIC_ATTRD
+    if (is_remote_node(node)) {
+        /* Talk directly to cib for remote nodes if it's legacy attrd */
+        return delete_attr_delegate(cib_conn, cib_sync_call, XML_CIB_TAG_STATUS, node->details->id, NULL, NULL,
+                                    NULL, attr_name, NULL, FALSE, NULL);
+    }
+#endif
+    return attrd_update_delegate(NULL, 'D', node->details->uname, attr_name, NULL, XML_CIB_TAG_STATUS, NULL,
+                                 NULL, NULL, node ? is_remote_node(node) : FALSE);
+}
+
 int
 cli_resource_delete(cib_t *cib_conn, crm_ipc_t * crmd_channel, const char *host_uname,
                resource_t * rsc, pe_working_set_t * data_set)
@@ -652,8 +674,7 @@ cli_resource_delete(cib_t *cib_conn, crm_ipc_t * crmd_channel, const char *host_
         }
 
         printf(", removing %s\n", attr_name);
-        rc = attrd_update_delegate(NULL, 'D', host_uname, attr_name, NULL, XML_CIB_TAG_STATUS, NULL,
-                              NULL, NULL, node ? is_remote_node(node) : FALSE);
+        rc = cli_delete_attr(cib_conn, host_uname, attr_name, data_set);
         free(attr_name);
 
     } else if(rc != -EOPNOTSUPP) {


### PR DESCRIPTION
Legacy attrd cannot handle attributes for remote nodes. Fix it by
conditionally reverting part of 488d82f.