### PR TITLE
fix build error of crm_node.c for ISO C90

### DIFF
--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -344,7 +344,7 @@ try_pacemaker(int command, enum cluster_type_e stack)
         case 'p':
             /* Go to pacemakerd */
             {
-                mainloop_io_t *ipc
+                mainloop_io_t *ipc;
                 GMainLoop *amainloop = g_main_loop_new(NULL, FALSE);
                 ipc = mainloop_add_ipc_client(CRM_SYSTEM_MCP, G_PRIORITY_DEFAULT, 0, NULL, &node_callbacks);
                 if (ipc != NULL) {

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -344,9 +344,9 @@ try_pacemaker(int command, enum cluster_type_e stack)
         case 'p':
             /* Go to pacemakerd */
             {
+                mainloop_io_t *ipc
                 GMainLoop *amainloop = g_main_loop_new(NULL, FALSE);
-                mainloop_io_t *ipc =
-                    mainloop_add_ipc_client(CRM_SYSTEM_MCP, G_PRIORITY_DEFAULT, 0, NULL, &node_callbacks);
+                ipc = mainloop_add_ipc_client(CRM_SYSTEM_MCP, G_PRIORITY_DEFAULT, 0, NULL, &node_callbacks);
                 if (ipc != NULL) {
                     /* Sending anything will get us a list of nodes */
                     xmlNode *poke = create_xml_node(NULL, "poke");


### PR DESCRIPTION
Fix the following building error, my OS is CentOS 6.3.
gcc -std=gnu99 -DHAVE_CONFIG_H -I. -I../include  -I../include -I../include -I../libltdl -I../libltdl -I/usr/include/heartbeat -I/usr/include/  -fgnu89-inline -
Wall -Waggregate-return -Wbad-function-cast -Wcast-align -Wdeclaration-after-statement -Wendif-labels -Wfloat-equal -Wformano-strict-aliasing -Wpointer-arith -Wwrite-strings -Wunused-but-set-variable -fstack-protector-all -Werror -MT crm_attribute.o -MD -MP -MF .d
cc1: warnings being treated as errors
crm_node.c: In function 'try_pacemaker':
crm_node.c:348: error: ISO C90 forbids mixed declarations and code