### PR TITLE
Low: attrd: If a value of dampen is a negative number, attrd outputs warn log.

### DIFF
--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -171,6 +171,8 @@ create_attribute(xmlNode *xml)
     if(dampen > 0) {
         a->timeout_ms = dampen;
         a->timer = mainloop_timer_add(a->id, a->timeout_ms, FALSE, attribute_timer_cb, a);
+    } else if (dampen < 0) {
+	crm_warn("Ignoring invalid delay %s for attribute %s", value, a->id);
     }
 
     g_hash_table_replace(attributes, a->id, a);


### PR DESCRIPTION
This patch becomes the contents which came out in a discussion of next pullrequest.
 * https://github.com/ClusterLabs/pacemaker/pull/946
