### PR TITLE
Mid: attrd: Support of the dampen change by attrd.

### DIFF
--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -527,7 +527,7 @@ attrd_peer_message(crm_node_t *peer, xmlNode *xml)
         }
     }
 
-    if (safe_str_eq(op, ATTRD_OP_UPDATE)) {
+    if (safe_str_eq(op, ATTRD_OP_UPDATE) || safe_str_eq(op, ATTRD_OP_UPDATE_BOTH) || safe_str_eq(op, ATTRD_OP_UPDATE_DELAY)) {
         attrd_peer_update(peer, xml, host, FALSE);
 
     } else if (safe_str_eq(op, ATTRD_OP_SYNC)) {
@@ -671,14 +671,53 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
 {
     bool changed = FALSE;
     attribute_value_t *v = NULL;
+    int dampen = 0;
 
+    const char *op = crm_element_value(xml, F_ATTRD_TASK);
     const char *attr = crm_element_value(xml, F_ATTRD_ATTRIBUTE);
     const char *value = crm_element_value(xml, F_ATTRD_VALUE);
+    const char *dvalue = crm_element_value(xml, F_ATTRD_DAMPEN);
 
     attribute_t *a = g_hash_table_lookup(attributes, attr);
 
     if(a == NULL) {
-        a = create_attribute(xml);
+        if (safe_str_eq(op, ATTRD_OP_UPDATE) || safe_str_eq(op, ATTRD_OP_UPDATE_BOTH)) {
+            a = create_attribute(xml);
+        } else {
+            crm_warn("Update error (attribute %s not found)", attr);
+            return;
+        }
+    } else {
+        if (safe_str_eq(op, ATTRD_OP_UPDATE_BOTH) || safe_str_eq(op, ATTRD_OP_UPDATE_DELAY)) {
+            if (dvalue) {
+                dampen = crm_get_msec(dvalue); 
+                if (dampen >= 0) {
+                    if (a->timeout_ms != dampen) {
+                        mainloop_timer_stop(a->timer);
+                        mainloop_timer_del(a->timer);
+                        a->timeout_ms = dampen;
+                        if (dampen > 0) {
+                            a->timer = mainloop_timer_add(a->id, a->timeout_ms, FALSE, attribute_timer_cb, a);
+                            crm_info("Update attribute %s with delay %dms (%s)", a->id, dampen, dvalue);
+                        } else {
+                            a->timer = NULL;
+                            crm_info("Update attribute %s with not delay", a->id);
+                        }
+                        //if dampen is changed, attrd writes in a current value immediately.
+                        write_or_elect_attribute(a);
+                        if (safe_str_eq(op, ATTRD_OP_UPDATE_DELAY)) {
+                            return;
+                        }
+                    }
+                } else {
+                    crm_warn("Update error (A positive number is necessary for delay parameter. attribute %s : %dms (%s))", a->id, dampen, dvalue);
+                    return;
+                }
+            } else {
+                crm_warn("Update error (delay parameter is necessary for the update of the attribute %s)", a->id);
+                return;
+            }
+        }
     }
 
     if(host == NULL) {
@@ -713,15 +752,18 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
         free_xml(sync);
 
     } else if(safe_str_neq(v->current, value)) {
-        crm_info("Setting %s[%s]: %s -> %s from %s", attr, host, v->current, value, peer->uname);
-        free(v->current);
-        if(value) {
-            v->current = strdup(value);
+        if (safe_str_eq(op, ATTRD_OP_UPDATE) || safe_str_eq(op, ATTRD_OP_UPDATE_BOTH)) {
+            crm_info("Setting %s[%s]: %s -> %s from %s", attr, host, v->current, value, peer->uname);
+            free(v->current);
+            if(value) {
+                v->current = strdup(value);
+            } else {
+                v->current = NULL;
+            }
+            changed = TRUE;
         } else {
-            v->current = NULL;
+             crm_trace("Unchanged %s[%s] from %s.(ATTRD_OP_UPDATE_DELAY)", attr, host, peer->uname);
         }
-        changed = TRUE;
-
     } else {
         crm_trace("Unchanged %s[%s] from %s is %s", attr, host, peer->uname, value);
     }

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -239,6 +239,14 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
         attrd_send_ack(client, id, flags);
         attrd_client_update(xml);
 
+    } else if (safe_str_eq(op, ATTRD_OP_UPDATE_BOTH)) {
+        attrd_send_ack(client, id, flags);
+        attrd_client_update(xml);
+
+    } else if (safe_str_eq(op, ATTRD_OP_UPDATE_DELAY)) {
+        attrd_send_ack(client, id, flags);
+        attrd_client_update(xml);
+  
     } else if (safe_str_eq(op, ATTRD_OP_REFRESH)) {
         attrd_send_ack(client, id, flags);
         attrd_client_refresh();

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -291,6 +291,8 @@ long crm_read_pidfile(const char *filename);
 /* attrd operations */
 #  define ATTRD_OP_PEER_REMOVE   "peer-remove"
 #  define ATTRD_OP_UPDATE        "update"
+#  define ATTRD_OP_UPDATE_BOTH   "update-both"
+#  define ATTRD_OP_UPDATE_DELAY  "update-delay"
 #  define ATTRD_OP_QUERY         "query"
 #  define ATTRD_OP_REFRESH       "refresh"
 #  define ATTRD_OP_FLUSH         "flush"

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -1818,6 +1818,14 @@ attrd_update_delegate(crm_ipc_t * ipc, char command, const char *host, const cha
         case 'R':
             crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_REFRESH);
             break;
+        case 'B':
+            crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_UPDATE_BOTH);
+            crm_xml_add(update, F_ATTRD_ATTRIBUTE, name);
+            break;
+        case 'Y':
+            crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_UPDATE_DELAY);
+            crm_xml_add(update, F_ATTRD_ATTRIBUTE, name);
+            break;
         case 'Q':
             crm_xml_add(update, F_ATTRD_TASK, ATTRD_OP_QUERY);
             crm_xml_add(update, F_ATTRD_ATTRIBUTE, name);

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -45,6 +45,8 @@ static struct crm_option long_options[] = {
     {"-spacer-",1, 0, '-', "\nCommands:"},
     {"update",  1, 0, 'U', "Update the attribute's value in attrd.  If this causes the value to change, it will also be updated in the cluster configuration"},
 #ifdef HAVE_ATOMIC_ATTRD
+    {"update-both", 1, 0, 'B', "Update the attribute's value and time to wait (dampening) in attrd. If this causes the value or dampening to change, the attribute will also be written to the cluster configuration, so be aware that repeatedly changing the dampening reduces its effectiveness."},
+    {"update-delay", 0, 0, 'Y', "Update the attribute's dampening in attrd (requires -d/--delay). If this causes the dampening to change, the attribute will also be written to the cluster configuration, so be aware that repeatedly changing the dampening reduces its effectiveness."},
     {"query",   0, 0, 'Q', "\tQuery the attribute's value from attrd"},
 #endif
     {"delete",  0, 0, 'D', "\tDelete the attribute in attrd.  If a value was previously set, it will also be removed from the cluster configuration"},
@@ -142,6 +144,11 @@ main(int argc, char **argv)
             case 'q':
                 break;
 #ifdef HAVE_ATOMIC_ATTRD
+            case 'Y':
+                command = flag;
+                crm_log_args(argc, argv); /* Too much? */
+                break;
+            case 'B':
             case 'Q':
 #endif
             case 'R':


### PR DESCRIPTION
Hi All,

I added the support of the change of dampen by attrd and attrd_updater.
I added a function to change the value only for dampen and a function to change the combination of dampen and value.

The command-line of attrd_updater is as follows.

1)Change the combination of dampen and value.
attrd_updater -B value -n name -d dampen

2)Change the value only for dampen.
attrd_updater -Y -n name -d dampen

It is necessary to discuss the next matter.
 * https://github.com/ClusterLabs/pacemaker/pull/906
 * https://github.com/ClusterLabs/pacemaker/pull/946

Best Regards,
Hideo Yamacuhi.