### PR TITLE
Take pkg-config result into account when checking for libqb

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1039,7 +1039,7 @@ if test x${enable_no_stack} = xyes; then
     SUPPORT_CS=no
 fi
 
-PKG_CHECK_MODULES(libqb, libqb >= 0.13, HAVE_libqb=1, HAVE_libqb=0)
+PKG_CHECK_MODULES(libqb, libqb >= 0.13, HAVE_libqb=1)
 AC_CHECK_HEADERS(qb/qbipc_common.h)
 AC_CHECK_LIB(qb, qb_ipcs_connection_auth_set)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1040,6 +1040,8 @@ if test x${enable_no_stack} = xyes; then
 fi
 
 PKG_CHECK_MODULES(libqb, libqb >= 0.13, HAVE_libqb=1)
+CPPFLAGS="$libqb_CFLAGS $CPPFLAGS"
+LIBS="$libqb_LIBS $LIBS"
 AC_CHECK_HEADERS(qb/qbipc_common.h)
 AC_CHECK_LIB(qb, qb_ipcs_connection_auth_set)
 
@@ -1048,7 +1050,6 @@ PCMK_FEATURES="$PCMK_FEATURES libqb-logging libqb-ipc"
 
 AC_CHECK_FUNCS(qb_ipcs_connection_get_buffer_size, AC_DEFINE(HAVE_IPCS_GET_BUFFER_SIZE,  1, [Have qb_ipcc_get_buffer_size function]))
 
-LIBS="$LIBS $libqb_LIBS"
 
 AC_CHECK_HEADERS(heartbeat/hb_config.h)
 AC_CHECK_HEADERS(heartbeat/glue_config.h)

--- a/configure.ac
+++ b/configure.ac
@@ -1045,7 +1045,6 @@ LIBS="$libqb_LIBS $LIBS"
 AC_CHECK_HEADERS(qb/qbipc_common.h)
 AC_CHECK_LIB(qb, qb_ipcs_connection_auth_set)
 
-LIBQB_LOG=1
 PCMK_FEATURES="$PCMK_FEATURES libqb-logging libqb-ipc"
 
 AC_CHECK_FUNCS(qb_ipcs_connection_get_buffer_size, AC_DEFINE(HAVE_IPCS_GET_BUFFER_SIZE,  1, [Have qb_ipcc_get_buffer_size function]))


### PR DESCRIPTION
This fixes detecting libqb when it is outside the default library search path, in /opt/lib for example.

I found out the hard way that we assume -lqb is in $LIBS in too many places. Ideally we should explicitly link with $libqb_LIBS, but that can come later.