### PR TITLE
Build: spec: better revision and version schema

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -24,7 +24,7 @@ PACKAGE		?= pacemaker
 
 # Force 'make dist' to be consistent with 'make export'
 distdir			= $(PACKAGE)-$(TAG)
-TARFILE			= $(distdir).tar.gz
+TARFILE			= $(PACKAGE)-$(SHORTTAG).tar.gz
 DIST_ARCHIVES		= $(TARFILE)
 
 RPM_ROOT	= $(shell pwd)
@@ -44,6 +44,9 @@ ARCH    ?= $(shell test -e /etc/fedora-release && rpm --eval %{_arch})
 MOCK_CFG ?= $(shell test -e /etc/fedora-release && echo fedora-$(F)-$(ARCH))
 DISTRO  ?= $(shell test -e /etc/SuSE-release && echo suse; echo fedora)
 TAG     ?= $(shell git log --pretty="format:%H" -n 1)
+lparen = (
+rparen = )
+SHORTTAG ?= $(shell case $(TAG) in Pacemaker-*$(rparen) echo $(TAG);; *$(rparen) git log --pretty="format:%h" -n 1;; esac)
 WITH    ?= --without doc
 #WITH    ?= --without=doc --with=gcov
 
@@ -151,10 +154,10 @@ srpm-%:	export $(PACKAGE)-%.spec
 	sed -i 's/global\ commit.*/global\ commit\ $(TAG)/' $(PACKAGE).spec
 	case "$(WITH)" in 	\
 	  *pre_release*)	\
-	    sed -i 's/global\ pcmk_release.*/global\ pcmk_release\ 0.%{specversion}.%{shortcommit}.git/' $(PACKAGE).spec;	\
-	    sed -i 's/Version:.*/Version:\ $(shell echo $(NEXT_RELEASE) | sed -e s:Pacemaker-:: -e s:-.*::)/' $(PACKAGE).spec;;	\
+	    sed -i 's/^\(%global pcmk_release \).*/\10.%{specversion}.%{shortcommit}.git/' $(PACKAGE).spec;	\
+	    sed -i 's/^\(%global pcmkversion \).*/\1$(shell echo $(NEXT_RELEASE) | sed -e s:Pacemaker-:: -e s:-.*::)/' $(PACKAGE).spec;;	\
 	  *)			\
-	    sed -i 's/Version:.*/Version:\ $(shell git describe --tags $(TAG) | sed -e s:Pacemaker-:: -e s:-.*::)/' $(PACKAGE).spec;;\
+	    sed -i 's/^\(%global pcmkversion \).*/\1$(shell git describe --tags $(TAG) | sed -e s:Pacemaker-:: -e s:-.*::)/' $(PACKAGE).spec;;\
 	esac
 	rpmbuild -bs --define "dist .$*" $(RPM_OPTS) $(PACKAGE).spec
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -157,6 +157,7 @@ srpm-%:	export $(PACKAGE)-%.spec
 	    sed -i 's/^\(%global pcmk_release \).*/\10.%{specversion}.%{shortcommit}.git/' $(PACKAGE).spec;	\
 	    sed -i 's/^\(%global pcmkversion \).*/\1$(shell echo $(NEXT_RELEASE) | sed -e s:Pacemaker-:: -e s:-.*::)/' $(PACKAGE).spec;;	\
 	  *)			\
+	    [ "$(TAG)" = "$(SHORTTAG)" ] || sed -i 's/^\(%global pcmk_release \).*/\1%{specversion}.%{shortcommit}.git/' $(PACKAGE).spec;	\
 	    sed -i 's/^\(%global pcmkversion \).*/\1$(shell git describe --tags $(TAG) | sed -e s:Pacemaker-:: -e s:-.*::)/' $(PACKAGE).spec;;\
 	esac
 	rpmbuild -bs --define "dist .$*" $(RPM_OPTS) $(PACKAGE).spec

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -8,6 +8,7 @@
 # "pcmkversion" macro to "Pacemaker-" (will yield a tag per the convention)
 %global commit HEAD
 %global shortcommit %(c=%{commit}; [ ${c} = Pacemaker-%{pcmkversion} ] && echo %{pcmkversion} || echo ${c:0:7})
+%global post_release %([ %{commit} = Pacemaker-%{pcmkversion} ]; echo $?)
 %global github_owner ClusterLabs
 
 # Turn off the auto compilation of python files not in the site-packages directory
@@ -56,7 +57,11 @@
 %if %{with pre_release}
 %global pcmk_release 0.%{specversion}.%{shortcommit}.git
 %else
+%if 0%{post_release}
+%global pcmk_release %{specversion}.%{shortcommit}.git
+%else
 %global pcmk_release %{specversion}
+%endif
 %endif
 
 Name:          pacemaker

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -3,8 +3,11 @@
 %global pcmk_docdir %{_docdir}/%{name}
 
 %global specversion 1
+%global pcmkversion 1.1.14
+# set following to the actual commit or, for final release, concatenate
+# "pcmkversion" macro to "Pacemaker-" (will yield a tag per the convention)
 %global commit HEAD
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global shortcommit %(c=%{commit}; [ ${c} = Pacemaker-%{pcmkversion} ] && echo %{pcmkversion} || echo ${c:0:7})
 %global github_owner ClusterLabs
 
 # Turn off the auto compilation of python files not in the site-packages directory
@@ -58,7 +61,7 @@
 
 Name:          pacemaker
 Summary:       Scalable High-Availability cluster resource manager
-Version:       1.1.14
+Version:       %{pcmkversion}
 Release:       %{pcmk_release}%{?dist}
 %if %{defined _unitdir}
 License:       GPLv2+ and LGPLv2+
@@ -69,7 +72,7 @@ License:       GPLv2+ and LGPLv2+ and BSD
 Url:           http://www.clusterlabs.org
 Group:         System Environment/Daemons
 
-Source0:       https://github.com/%{github_owner}/%{name}/archive/%{commit}/%{name}-%{commit}.tar.gz
+Source0:       https://github.com/%{github_owner}/%{name}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
 BuildRoot:     %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 AutoReqProv:   on
 Requires:      python


### PR DESCRIPTION
Make natively generated spec and archive versioning cope better with post-releases (snapshots) and avoid full hashes in the source tarballs.