### PR TITLE
Build: explicitly allow skipping Publican building docs and sanitize docs building as such

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ doc/Clusters_from_Scratch.txt
 doc/Pacemaker_Explained.txt
 doc/acls.html
 doc/crm_fencing.html
+doc/publican-catalog*
 fencing/stonith-test
 fencing/stonith_admin
 fencing/stonithd
@@ -163,7 +164,6 @@ compat_reports
 .ABI-build
 abi_dumps
 logs
-xsl
 
 *.patch
 *.diff

--- a/configure.ac
+++ b/configure.ac
@@ -312,7 +312,7 @@ AC_ARG_WITH(coverage,
 
 PUBLICAN_BRAND="common"
 AC_ARG_WITH(brand,
-    [  --with-brand=brand  Brand to use for generated documentation [$PUBLICAN_BRAND]],
+    [  --with-brand=brand  Brand to use for generated documentation (set empty for no docs) [$PUBLICAN_BRAND]],
     [ PUBLICAN_BRAND="$withval" ])
 AC_SUBST(PUBLICAN_BRAND)
 
@@ -606,8 +606,13 @@ fi
 AM_CONDITIONAL(BUILD_STONITH_CONFIG, test $SUPPORT_STONITH_CONFIG = 1)
 AC_DEFINE_UNQUOTED(SUPPORT_STONITH_CONFIG, $SUPPORT_STONITH_CONFIG, Support a stand-alone stonith config file in addition to the CIB)
 
-AM_CONDITIONAL(BUILD_DOCBOOK, test x"${PUBLICAN}" != x"" -a x"${INKSCAPE}" != x"")
-if test x"${PUBLICAN}" != x"" -a x"${INKSCAPE}" != x""; then
+AM_CONDITIONAL([BUILD_DOCBOOK],
+               [test x"${PUBLICAN_BRAND}" != x"" \
+                && test x"${PUBLICAN}" != x"" \
+                && test x"${INKSCAPE}" != x""])
+if test x"${PUBLICAN_BRAND}" != x"" \
+   && test x"${PUBLICAN}" != x"" \
+   && test x"${INKSCAPE}" != x""; then
    AC_MSG_NOTICE(Enabling publican)
    PCMK_FEATURES="$PCMK_FEATURES publican-docs"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -606,16 +606,31 @@ fi
 AM_CONDITIONAL(BUILD_STONITH_CONFIG, test $SUPPORT_STONITH_CONFIG = 1)
 AC_DEFINE_UNQUOTED(SUPPORT_STONITH_CONFIG, $SUPPORT_STONITH_CONFIG, Support a stand-alone stonith config file in addition to the CIB)
 
+publican_intree_brand=no
+if test x"${PUBLICAN_BRAND}" != x"" \
+   && test x"${PUBLICAN}" != x"" \
+   && test x"${INKSCAPE}" != x""; then
+   dnl special handling for clusterlabs brand (possibly in-tree version used)
+   test "${PUBLICAN_BRAND}" != "clusterlabs" \
+      || test -d /usr/share/publican/Common_Content/clusterlabs
+   if test $? -ne 0; then
+      dnl Unknown option: brand_dir vs. Option brand_dir requires an argument
+      if ${PUBLICAN} build --brand_dir 2>&1 | grep -Eq 'brand_dir$'; then
+         AC_MSG_WARN([Cannot use in-tree clusterlabs brand, resorting to common])
+         PUBLICAN_BRAND=common
+      else
+         publican_intree_brand=yes
+      fi
+   fi
+   AC_MSG_NOTICE([Enabling Publican-generated documentation using ${PUBLICAN_BRAND} brand])
+   PCMK_FEATURES="$PCMK_FEATURES publican-docs"
+fi
 AM_CONDITIONAL([BUILD_DOCBOOK],
                [test x"${PUBLICAN_BRAND}" != x"" \
                 && test x"${PUBLICAN}" != x"" \
                 && test x"${INKSCAPE}" != x""])
-if test x"${PUBLICAN_BRAND}" != x"" \
-   && test x"${PUBLICAN}" != x"" \
-   && test x"${INKSCAPE}" != x""; then
-   AC_MSG_NOTICE([Enabling Publican-generated documentation using ${PUBLICAN_BRAND} brand])
-   PCMK_FEATURES="$PCMK_FEATURES publican-docs"
-fi
+AM_CONDITIONAL([PUBLICAN_INTREE_BRAND],
+               [test x"${publican_intree_brand}" = x"yes"])
 
 dnl ========================================================================
 dnl checks for library functions to replace them

--- a/configure.ac
+++ b/configure.ac
@@ -613,7 +613,7 @@ AM_CONDITIONAL([BUILD_DOCBOOK],
 if test x"${PUBLICAN_BRAND}" != x"" \
    && test x"${PUBLICAN}" != x"" \
    && test x"${INKSCAPE}" != x""; then
-   AC_MSG_NOTICE(Enabling publican)
+   AC_MSG_NOTICE([Enabling Publican-generated documentation using ${PUBLICAN_BRAND} brand])
    PCMK_FEATURES="$PCMK_FEATURES publican-docs"
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -313,7 +313,7 @@ AC_ARG_WITH(coverage,
 PUBLICAN_BRAND="common"
 AC_ARG_WITH(brand,
     [  --with-brand=brand  Brand to use for generated documentation (set empty for no docs) [$PUBLICAN_BRAND]],
-    [ PUBLICAN_BRAND="$withval" ])
+    [ test x"$withval" = x"no" || PUBLICAN_BRAND="$withval" ])
 AC_SUBST(PUBLICAN_BRAND)
 
 ASCIIDOC_CLI_TYPE="pcs"

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -95,7 +95,7 @@ $(CFS_XML): $(CFS_SHARED_XML)
 Clusters_from_Scratch.build: $(PNGS) $(wildcard Clusters_from_Scratch/en-US/*.xml) $(CFS_XML) $(CFS_SHARED_XML) ../xsl
 	$(PCMK_V) @echo Building $(@:%.build=%) because of $?
 	rm -rf $(@:%.build=%)/publish/*
-	$(AM_V_PUB)cd $(@:%.build=%) && RPM_BUILD_DIR="" $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) $(PCMK_quiet) --brand_dir=../publican-clusterlabs
+	$(AM_V_PUB)cd $(@:%.build=%) && RPM_BUILD_DIR="" $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) --brand_dir=../publican-clusterlabs $(PCMK_quiet)
 	rm -rf $(@:%.build=%)/tmp
 	touch $@
 
@@ -112,7 +112,7 @@ $(PE_XML): $(PE_SHARED_XML)
 Pacemaker_Explained.build: $(PNGS) $(wildcard Pacemaker_Explained/en-US/*.xml) $(PE_XML) $(PE_SHARED_XML) ../xsl
 	$(PCMK_V) @echo Building $(@:%.build=%) because of $?
 	rm -rf $(@:%.build=%)/publish/*
-	$(AM_V_PUB)cd $(@:%.build=%) && RPM_BUILD_DIR="" $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) $(PCMK_quiet) --brand_dir=../publican-clusterlabs
+	$(AM_V_PUB)cd $(@:%.build=%) && RPM_BUILD_DIR="" $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) --brand_dir=../publican-clusterlabs $(PCMK_quiet)
 	rm -rf $(@:%.build=%)/tmp
 	touch $@
 
@@ -125,7 +125,7 @@ PR_XML=$(PR_TXT:%.txt=%.xml)
 Pacemaker_Remote.build: $(PNGS) $(wildcard Pacemaker_Remote/en-US/*.xml) $(PR_XML) ../xsl
 	$(PCMK_V) @echo Building $(@:%.build=%) because of $?
 	rm -rf $(@:%.build=%)/publish/*
-	$(AM_V_PUB)cd $(@:%.build=%) && RPM_BUILD_DIR="" $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) $(PCMK_quiet) --brand_dir=../publican-clusterlabs
+	$(AM_V_PUB)cd $(@:%.build=%) && RPM_BUILD_DIR="" $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) --brand_dir=../publican-clusterlabs $(PCMK_quiet)
 	rm -rf $(@:%.build=%)/tmp
 	touch $@
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -108,15 +108,27 @@ CFS_XML=$(CFS_TXT:%.txt=%.xml)
 
 $(CFS_XML): $(CFS_SHARED_XML)
 
+PUBLICAN_INTREE_DEPS =
+if PUBLICAN_INTREE_BRAND
+PUBLICAN_INTREE_DEPS += publican-catalog
+endif
+
 # We have to hardcode the book name
 # With '%' the test for 'newness' fails
-Clusters_from_Scratch.build: $(PNGS) $(wildcard Clusters_from_Scratch/en-US/*.xml) $(CFS_XML) $(CFS_SHARED_XML) publican-catalog
+Clusters_from_Scratch.build: $(PNGS) $(wildcard Clusters_from_Scratch/en-US/*.xml) $(CFS_XML) $(CFS_SHARED_XML) $(PUBLICAN_INTREE_DEPS)
 	$(PCMK_V) @echo Building $(@:%.build=%) because of $?
 	rm -rf $(@:%.build=%)/publish/*
+if PUBLICAN_INTREE_BRAND
 	$(AM_V_PUB)cd $(@:%.build=%) \
 	&& RPM_BUILD_DIR="" XML_CATALOG_FILES="$(CURDIR)/publican-catalog" \
 	   $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) --brand_dir=../publican-clusterlabs \
 	   $(PCMK_quiet)
+else
+	$(AM_V_PUB)cd $(@:%.build=%) \
+	&& RPM_BUILD_DIR="" \
+	   $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) \
+	   $(PCMK_quiet)
+endif
 	rm -rf $(@:%.build=%)/tmp
 	touch $@
 
@@ -130,13 +142,20 @@ $(PE_XML): $(PE_SHARED_XML)
 
 # We have to hardcode the book name
 # With '%' the test for 'newness' fails
-Pacemaker_Explained.build: $(PNGS) $(wildcard Pacemaker_Explained/en-US/*.xml) $(PE_XML) $(PE_SHARED_XML) publican-catalog
+Pacemaker_Explained.build: $(PNGS) $(wildcard Pacemaker_Explained/en-US/*.xml) $(PE_XML) $(PE_SHARED_XML) $(PUBLICAN_INTREE_DEPS)
 	$(PCMK_V) @echo Building $(@:%.build=%) because of $?
 	rm -rf $(@:%.build=%)/publish/*
+if PUBLICAN_INTREE_BRAND
 	$(AM_V_PUB)cd $(@:%.build=%) \
 	&& RPM_BUILD_DIR="" XML_CATALOG_FILES="$(CURDIR)/publican-catalog" \
 	   $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) --brand_dir=../publican-clusterlabs \
 	   $(PCMK_quiet)
+else
+	$(AM_V_PUB)cd $(@:%.build=%) \
+	&& RPM_BUILD_DIR="" \
+	   $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) \
+	   $(PCMK_quiet)
+endif
 	rm -rf $(@:%.build=%)/tmp
 	touch $@
 
@@ -146,13 +165,20 @@ PR_XML=$(PR_TXT:%.txt=%.xml)
 
 # We have to hardcode the book name
 # With '%' the test for 'newness' fails
-Pacemaker_Remote.build: $(PNGS) $(wildcard Pacemaker_Remote/en-US/*.xml) $(PR_XML) publican-catalog
+Pacemaker_Remote.build: $(PNGS) $(wildcard Pacemaker_Remote/en-US/*.xml) $(PR_XML) $(PUBLICAN_INTREE_DEPS)
 	$(PCMK_V) @echo Building $(@:%.build=%) because of $?
 	rm -rf $(@:%.build=%)/publish/*
+if PUBLICAN_INTREE_BRAND
 	$(AM_V_PUB)cd $(@:%.build=%) \
 	&& RPM_BUILD_DIR="" XML_CATALOG_FILES="$(CURDIR)/publican-catalog" \
 	   $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) --brand_dir=../publican-clusterlabs \
 	   $(PCMK_quiet)
+else
+	$(AM_V_PUB)cd $(@:%.build=%) \
+	&& RPM_BUILD_DIR="" \
+	   $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) \
+	   $(PCMK_quiet)
+endif
 	rm -rf $(@:%.build=%)/tmp
 	touch $@
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -74,10 +74,28 @@ EXTRA_DIST	= $(docbook:%=%.xml)
 %.html: %.txt
 	$(AM_V_ASCII)$(ASCIIDOC) --unsafe --backend=xhtml11 $<
 
-# publican-clusterlabs/xsl/html-single.xsl imports that of Publican
-# through this link during the build
-../xsl:
-	ln -s /usr/share/publican/xsl "$@"
+# publican-clusterlabs/xsl/{html,html-single,pdf}.xsl refer to URIs
+# requiring Internet access, hence we shadow that with a XML catalog-based
+# redirect to local files brought with Publican installation;
+# this is what newer Publican normally does with the system-wide catalog
+# upon its installation, but let's provide a compatibility for older
+# or badly installed instances (via adding the created file into
+# XML_CATALOG_FILES for libxml2 backing Publican as a fallback);
+# note that nextCatalog arrangement needed so as to overcome
+# https://rt.cpan.org/Public/Bug/Display.html?id=113781
+publican-catalog-fallback:
+	@exec >$@-t \
+	&& echo '<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">' \
+	&& echo '<rewriteURI uriStartString="https://fedorahosted.org/released/publican/xsl/docbook4/" rewritePrefix="file:///usr/share/publican/xsl/"/>' \
+	&& echo '</catalog>'
+	$(AM_V_GEN)mv $@-t $@
+publican-catalog: publican-catalog-fallback
+	@exec >$@-t \
+	&& echo '<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">' \
+	&& echo '<nextCatalog catalog="file:///etc/xml/catalog"/>' \
+	&& echo '<nextCatalog catalog="file://$(CURDIR)/$<"/>' \
+	&& echo '</catalog>'
+	$(AM_V_GEN)mv $@-t $@
 
 SHARED_TXT=$(wildcard shared/en-US/*.txt)
 SHARED_XML=$(SHARED_TXT:%.txt=%.xml)
@@ -92,10 +110,13 @@ $(CFS_XML): $(CFS_SHARED_XML)
 
 # We have to hardcode the book name
 # With '%' the test for 'newness' fails
-Clusters_from_Scratch.build: $(PNGS) $(wildcard Clusters_from_Scratch/en-US/*.xml) $(CFS_XML) $(CFS_SHARED_XML) ../xsl
+Clusters_from_Scratch.build: $(PNGS) $(wildcard Clusters_from_Scratch/en-US/*.xml) $(CFS_XML) $(CFS_SHARED_XML) publican-catalog
 	$(PCMK_V) @echo Building $(@:%.build=%) because of $?
 	rm -rf $(@:%.build=%)/publish/*
-	$(AM_V_PUB)cd $(@:%.build=%) && RPM_BUILD_DIR="" $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) --brand_dir=../publican-clusterlabs $(PCMK_quiet)
+	$(AM_V_PUB)cd $(@:%.build=%) \
+	&& RPM_BUILD_DIR="" XML_CATALOG_FILES="$(CURDIR)/publican-catalog" \
+	   $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) --brand_dir=../publican-clusterlabs \
+	   $(PCMK_quiet)
 	rm -rf $(@:%.build=%)/tmp
 	touch $@
 
@@ -109,10 +130,13 @@ $(PE_XML): $(PE_SHARED_XML)
 
 # We have to hardcode the book name
 # With '%' the test for 'newness' fails
-Pacemaker_Explained.build: $(PNGS) $(wildcard Pacemaker_Explained/en-US/*.xml) $(PE_XML) $(PE_SHARED_XML) ../xsl
+Pacemaker_Explained.build: $(PNGS) $(wildcard Pacemaker_Explained/en-US/*.xml) $(PE_XML) $(PE_SHARED_XML) publican-catalog
 	$(PCMK_V) @echo Building $(@:%.build=%) because of $?
 	rm -rf $(@:%.build=%)/publish/*
-	$(AM_V_PUB)cd $(@:%.build=%) && RPM_BUILD_DIR="" $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) --brand_dir=../publican-clusterlabs $(PCMK_quiet)
+	$(AM_V_PUB)cd $(@:%.build=%) \
+	&& RPM_BUILD_DIR="" XML_CATALOG_FILES="$(CURDIR)/publican-catalog" \
+	   $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) --brand_dir=../publican-clusterlabs \
+	   $(PCMK_quiet)
 	rm -rf $(@:%.build=%)/tmp
 	touch $@
 
@@ -122,10 +146,13 @@ PR_XML=$(PR_TXT:%.txt=%.xml)
 
 # We have to hardcode the book name
 # With '%' the test for 'newness' fails
-Pacemaker_Remote.build: $(PNGS) $(wildcard Pacemaker_Remote/en-US/*.xml) $(PR_XML) ../xsl
+Pacemaker_Remote.build: $(PNGS) $(wildcard Pacemaker_Remote/en-US/*.xml) $(PR_XML) publican-catalog
 	$(PCMK_V) @echo Building $(@:%.build=%) because of $?
 	rm -rf $(@:%.build=%)/publish/*
-	$(AM_V_PUB)cd $(@:%.build=%) && RPM_BUILD_DIR="" $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) --brand_dir=../publican-clusterlabs $(PCMK_quiet)
+	$(AM_V_PUB)cd $(@:%.build=%) \
+	&& RPM_BUILD_DIR="" XML_CATALOG_FILES="$(CURDIR)/publican-catalog" \
+	   $(PUBLICAN) build --publish --langs=$(DOCBOOK_LANGS) --formats=$(DOCBOOK_FORMATS) --brand_dir=../publican-clusterlabs \
+	   $(PCMK_quiet)
 	rm -rf $(@:%.build=%)/tmp
 	touch $@
 
@@ -201,6 +228,7 @@ if BUILD_DOCBOOK
 endif
 
 clean-local:
-	-rm -rf $(generated_docs) $(generated_mans) $(docbook_build) ../xsl $(generated_PNGS)
+	-rm -rf $(generated_docs) $(generated_mans) $(docbook_build) $(generated_PNGS)
 	-rm -rf $(SHARED_XML) $(CFS_XML) $(PE_XML) $(PR_XML)
+	-rm -rf  publican-catalog-fallback publican-catalog
 	for book in $(docbook); do rm -rf $$book/tmp $$book/publish; done

--- a/doc/publican-clusterlabs/xsl/html-single.xsl
+++ b/doc/publican-clusterlabs/xsl/html-single.xsl
@@ -19,6 +19,6 @@
 
 <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
 <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/graphics.xsl"/>
-<xsl:import href="../../../xsl/html-single.xsl"/>
+<xsl:import href="https://fedorahosted.org/released/publican/xsl/docbook4/html-single.xsl"/>
 <xsl:import href="common.xsl"/>
 </xsl:stylesheet>

--- a/doc/publican-clusterlabs/xsl/html.xsl
+++ b/doc/publican-clusterlabs/xsl/html.xsl
@@ -19,7 +19,7 @@
 
 <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
 <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/graphics.xsl"/>
-<xsl:import href="../../../xsl/html.xsl"/>
+<xsl:import href="https://fedorahosted.org/released/publican/xsl/docbook4/html.xsl"/>
 <xsl:import href="common.xsl"/>
 
 <xsl:template name="user.head.content">

--- a/doc/publican-clusterlabs/xsl/pdf.xsl
+++ b/doc/publican-clusterlabs/xsl/pdf.xsl
@@ -19,7 +19,7 @@
 
 <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
 <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/graphics.xsl"/>
-<xsl:import href="../../../xsl/pdf.xsl"/>
+<xsl:import href="https://fedorahosted.org/released/publican/xsl/docbook4/pdf.xsl"/>
 <xsl:import href="common.xsl"/>
 <xsl:param name="admon.graphics.extension" select="'.svg'"/>
 

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -298,7 +298,8 @@ docdir=%{pcmk_docdir} %{configure}                 \
         %{?with_profiling:   --with-profiling}     \
         %{?with_coverage:    --with-coverage}      \
         %{!?with_cman:       --without-cman}       \
-        --without-heartbeat			   \
+        --without-heartbeat                        \
+        %{!?with_doc:        --with-brand=}        \
         --with-initdir=%{_initrddir}               \
         --localstatedir=%{_var}                    \
         --with-version=%{version}-%{release}


### PR DESCRIPTION
There are cases one wants to avoid Publican being involved in the build
process at all (for instance, if a local copy is too old to behave
gracefully with what build process requires).

We avoid introducing a new configure option by (sort of) overloading
--with-brand one.

See also rhbz#1326350 (instructing configure using --with-brand=
would then help).