### PR TITLE
Low: ping resource: avoid undefined func w/ OCF_FUNCTIONS=/dev/null

### DIFF
--- a/extra/resources/ping
+++ b/extra/resources/ping
@@ -353,20 +353,20 @@ else
     : ${OCF_RESKEY_pidfile:="${HA_VARRUN%%/}/ping-${OCF_RESOURCE_INSTANCE}"}
 fi
 
+# Check the debug option
+case "${OCF_RESKEY_debug}" in
+    true|True|TRUE|1)    OCF_RESKEY_debug=true;;
+    false|False|FALSE|0) OCF_RESKEY_debug=false;;
+    *)
+        ocf_log warn "Value for 'debug' is incorrect. Please specify 'true' or 'false' not: ${OCF_RESKEY_debug}"
+        OCF_RESKEY_debug=false
+        ;;
+esac
+
 attrd_options='-q'
-if ocf_is_true ${OCF_RESKEY_debug} ; then
+if [ ${OCF_RESKEY_debug} = "true" ]; then
     attrd_options=''
 fi
-
-# Check the debug option    
-    case "${OCF_RESKEY_debug}" in
-	true|True|TRUE|1)    OCF_RESKEY_debug=true;;
-	false|False|FALSE|0) OCF_RESKEY_debug=false;;
-	*)
-            ocf_log warn "Value for 'debug' is incorrect. Please specify 'true' or 'false' not: ${OCF_RESKEY_debug}"
-	    OCF_RESKEY_debug=false
-	    ;;
-    esac
 
 case $__OCF_ACTION in
 meta-data)	meta_data


### PR DESCRIPTION
When generating man pages for the agents:
pacemaker/extra/resources/ping: line 357: ocf_is_true: command not found

Note that neither set of "true" indicators (those in ocf_is_true
function of ocf-shellfuncs[*] file vs. those recognized as values
of "debug" OCF parameter in the very script) is a subset of the other,
but acknowledge that latter is a master on its own domain
(at least for now, also to avoid regression when "True" is used).

[*] as an aside, there's also an almost anecdotical "ja" Germanism