### PR TITLE
Alert cleanup

### DIFF
--- a/crmd/cib.c
+++ b/crmd/cib.c
@@ -72,7 +72,7 @@ do_cib_updated(const char *event, xmlNode * msg)
         if ((xpathObj = xpath_search(
                  msg,
                  "//" F_CIB_UPDATE_RESULT "//" XML_TAG_DIFF_ADDED "//" XML_CIB_TAG_CRMCONFIG " | " \
-                 "//" F_CIB_UPDATE_RESULT "//" XML_TAG_DIFF_ADDED "//" XML_CIB_TAG_NOTIFICATIONS
+                 "//" F_CIB_UPDATE_RESULT "//" XML_TAG_DIFF_ADDED "//" XML_CIB_TAG_ALERTS
                  )) != NULL) {
             freeXpathObject(xpathObj);
             mainloop_set_trigger(config_read);
@@ -87,7 +87,7 @@ do_cib_updated(const char *event, xmlNode * msg)
 
             /* modifying properties */
             if (!strstr(xpath, "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_CRMCONFIG "/") &&
-                !strstr(xpath, "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_NOTIFICATIONS)) {
+                !strstr(xpath, "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_ALERTS)) {
                 xmlNode *section = NULL;
                 const char *name = NULL;
 
@@ -95,7 +95,7 @@ do_cib_updated(const char *event, xmlNode * msg)
                 if ((strcmp(xpath, "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION) != 0) ||
                     ((section = __xml_first_child(change)) == NULL) ||
                     ((name = crm_element_name(section)) == NULL) ||
-                    (strcmp(name, XML_CIB_TAG_NOTIFICATIONS) != 0)) {
+                    (strcmp(name, XML_CIB_TAG_ALERTS) != 0)) {
                     continue;
                 }
             } 

--- a/crmd/control.c
+++ b/crmd/control.c
@@ -976,6 +976,8 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     const char *value = NULL;
     GHashTable *config_hash = NULL;
     crm_time_t *now = crm_time_new(NULL);
+    xmlNode *crmconfig = NULL;
+    xmlNode *alerts = NULL;
 
     if (rc != pcmk_ok) {
         fsa_data_t *msg_data = NULL;
@@ -987,6 +989,20 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
             crm_err("The cluster is mis-configured - shutting down and staying down");
             set_bit(fsa_input_register, R_STAYDOWN);
         }
+        goto bail;
+    }
+
+    crmconfig = output;
+    if ((crmconfig) &&
+        (crm_element_name(crmconfig)) &&
+        (strcmp(crm_element_name(crmconfig), XML_CIB_TAG_CRMCONFIG) != 0)) {
+        crmconfig = first_named_child(crmconfig, XML_CIB_TAG_CRMCONFIG);
+    }
+    if (!crmconfig) {
+        fsa_data_t *msg_data = NULL;
+
+        crm_err("Local CIB query for " XML_CIB_TAG_CRMCONFIG " section failed");
+        register_fsa_error(C_FSA_INTERNAL, I_ERROR, NULL);
         goto bail;
     }
 
@@ -1058,34 +1074,8 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
         fsa_cluster_name = strdup(value);
     }
 
-#if 0
-    {
-        int sub_call_id;
-
-        sub_call_id = fsa_cib_conn->cmds->query(fsa_cib_conn, 
-            "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION
-            "/" XML_CIB_TAG_NOTIFICATIONS "/" XML_CIB_TAG_NOTIFY, NULL,
-            cib_scope_local | cib_xpath);
-
-        fsa_register_cib_callback(sub_call_id, FALSE, NULL,
-                                  notifications_query_callback);
-
-        crm_trace("Querying the CIB for notifications ... call %d", sub_call_id);
-    }
-#endif
-
-    {
-        xmlNode *cib_object = NULL;
-        int rc;
-
-        rc = fsa_cib_conn->cmds->query(fsa_cib_conn, 
-            "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION
-            "/" XML_CIB_TAG_NOTIFICATIONS "/" XML_CIB_TAG_NOTIFY, &cib_object,
-            cib_scope_local | cib_xpath | cib_sync_call);
-
-        notifications_query_callback(msg, call_id, rc, cib_object, user_data);
-        free_xml(cib_object);
-    }
+    alerts = output?first_named_child(output, XML_CIB_TAG_ALERTS):NULL;
+    parse_notifications(alerts);
 
     set_bit(fsa_input_register, R_READ_CONFIG);
     crm_trace("Triggering FSA: %s", __FUNCTION__);
@@ -1100,7 +1090,9 @@ gboolean
 crm_read_options(gpointer user_data)
 {
     int call_id =
-        fsa_cib_conn->cmds->query(fsa_cib_conn, XML_CIB_TAG_CRMCONFIG, NULL, cib_scope_local);
+        fsa_cib_conn->cmds->query(fsa_cib_conn,
+            "//" XML_CIB_TAG_CRMCONFIG " | //" XML_CIB_TAG_ALERTS,
+            NULL, cib_xpath | cib_scope_local);
 
     fsa_register_cib_callback(call_id, FALSE, NULL, config_query_callback);
     crm_trace("Querying the CIB... call %d", call_id);

--- a/crmd/notify.c
+++ b/crmd/notify.c
@@ -221,7 +221,7 @@ crm_time_format_hr(const char *format, crm_time_hr_t * hr_dt)
 {
     const char *mark_s;
     int max = 128, scanned_pos = 0, printed_pos = 0, fmt_pos = 0,
-        date_len = 0, nano_digits, fmt_len;
+        date_len = 0, nano_digits = 0, fmt_len;
     char nano_s[10], date_s[max+1], nanofmt_s[5] = "%", *tmp_fmt_s;
     struct tm tm;
     crm_time_t dt;

--- a/crmd/notify.c
+++ b/crmd/notify.c
@@ -450,13 +450,27 @@ get_meta_attrs_from_cib(xmlNode *basenode, notify_entry_t *entry)
     unpack_instance_attributes(basenode, basenode, XML_TAG_META_SETS, NULL,
                                config_hash, NULL, FALSE, now);
 
-    value = g_hash_table_lookup(config_hash, XML_NOTIFY_ATTR_TIMEOUT);
+    value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_TIMEOUT);
     if (value) {
         entry->timeout = crm_get_msec(value);
-        crm_trace("Found timeout %dmsec", entry->timeout);
+        if (entry->timeout <= 0) {
+            if (entry->timeout == 0) {
+                crm_trace("Setting timeout to default %dmsec",
+                          CRMD_NOTIFY_DEFAULT_TIMEOUT_MS);
+            } else {
+                crm_warn("Invalid timeout value setting to default %dmsec",
+                         CRMD_NOTIFY_DEFAULT_TIMEOUT_MS);
+            }
+            entry->timeout = CRMD_NOTIFY_DEFAULT_TIMEOUT_MS;
+        } else {
+            crm_trace("Found timeout %dmsec", entry->timeout);
+        }
     }
-    value = g_hash_table_lookup(config_hash, XML_NOTIFY_ATTR_TSTAMP_FORMAT);
+    value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_TSTAMP_FORMAT);
     if (value) {
+        /* hard to do any checks here as merely anything can
+         * can be a valid time-format-string
+         */
         entry->tstamp_format = (char *) value;
         crm_trace("Found timestamp format string '%s'", value);
     }
@@ -466,15 +480,21 @@ get_meta_attrs_from_cib(xmlNode *basenode, notify_entry_t *entry)
 }
 
 void
-notifications_query_callback(xmlNode * msg, int call_id, int rc,
-                             xmlNode * output, void *user_data)
+parse_notifications(xmlNode *notifications)
 {
-    xmlNode *notify = output;
+    xmlNode *notify;
     notify_entry_t entry;
 
     free_notify_list();
 
-    if (rc != pcmk_ok) {
+    if (notifications) {
+        crm_info("We have an alerts section in the cib");
+
+        if (notify_script) {
+            crm_warn("Cib contains configuration for Legacy Notifications "
+                     "which is overruled by alerts section");
+        }
+    } else {
         crm_info("No optional alerts section in cib");
 
         if (notify_script) {
@@ -489,29 +509,17 @@ notifications_query_callback(xmlNode * msg, int call_id, int rc,
         }
 
         return;
-    } else {
-        crm_info("We have an alerts section in the cib");
-
-        if (notify_script) {
-            crm_warn("Cib contains configuration for Legacy Notifications "
-                     "which is overruled by alerts section");
-        }
     }
 
-    if ((notify) &&
-        (crm_element_name(notify)) &&
-        (strcmp(crm_element_name(notify), XML_CIB_TAG_NOTIFY) != 0)) {
-        notify = first_named_child(notify, XML_CIB_TAG_NOTIFY);
-    }
-
-    for (; notify; notify = __xml_next(notify)) {
+    for (notify = first_named_child(notifications, XML_CIB_TAG_ALERT);
+         notify; notify = __xml_next(notify)) {
         xmlNode *recipient;
         int recipients = 0, envvars = 0;
         GHashTable *config_hash = NULL;
 
         entry = (notify_entry_t) {
             .id = (char *) crm_element_value(notify, XML_ATTR_ID),
-            .path = (char *) crm_element_value(notify, XML_NOTIFY_ATTR_PATH),
+            .path = (char *) crm_element_value(notify, XML_ALERT_ATTR_PATH),
             .timeout = CRMD_NOTIFY_DEFAULT_TIMEOUT_MS
         };
 
@@ -529,12 +537,12 @@ notifications_query_callback(xmlNode * msg, int call_id, int rc,
                    entry.tstamp_format, envvars);
 
         for (recipient = first_named_child(notify,
-                                           XML_CIB_TAG_NOTIFY_RECIPIENT);
+                                           XML_CIB_TAG_ALERT_RECIPIENT);
              recipient; recipient = __xml_next(recipient)) {
             int envvars_added = 0;
 
             entry.recipient = (char *) crm_element_value(recipient,
-                                                XML_NOTIFY_ATTR_REC_VALUE);
+                                                XML_ALERT_ATTR_REC_VALUE);
             recipients++;
 
             entry.envvars =

--- a/crmd/notify.h
+++ b/crmd/notify.h
@@ -29,6 +29,6 @@ void crmd_enable_notifications(const char *script, const char *target);
 void crmd_notify_node_event(crm_node_t *node);
 void crmd_notify_fencing_op(stonith_event_t * e);
 void crmd_notify_resource_op(const char *node, lrmd_event_data_t * op);
-void notifications_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *user_data);
+void parse_notifications(xmlNode *notifications);
 
 #endif

--- a/extra/alerts/pcmk_alert_sample.sh
+++ b/extra/alerts/pcmk_alert_sample.sh
@@ -16,58 +16,58 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-if [ -z $CRM_notify_version ]; then
-    echo "Pacemaker version 1.1.14 is required" >> ${CRM_notify_recipient}
+if [ -z $CRM_alert_version ]; then
+    echo "Pacemaker version 1.1.15 is required" >> ${CRM_alert_recipient}
     exit 0
 fi
 
-tstamp=`printf "%04d. " "$CRM_notify_node_sequence"`
-if [ ! -z $CRM_notify_timestamp ]; then
-    tstamp="${tstamp} $CRM_notify_timestamp (`date "+%H:%M:%S.%06N"`): " 
+tstamp=`printf "%04d. " "$CRM_alert_node_sequence"`
+if [ ! -z $CRM_alert_timestamp ]; then
+    tstamp="${tstamp} $CRM_alert_timestamp (`date "+%H:%M:%S.%06N"`): "
 fi
 
-case $CRM_notify_kind in
+case $CRM_alert_kind in
     node)
-	echo "${tstamp}Node '${CRM_notify_node}' is now '${CRM_notify_desc}'" >> ${CRM_notify_recipient}
+	echo "${tstamp}Node '${CRM_alert_node}' is now '${CRM_alert_desc}'" >> ${CRM_alert_recipient}
 	;;
     fencing)
 	# Other keys:
 	# 
-	# CRM_notify_node
-	# CRM_notify_task
-	# CRM_notify_rc
+	# CRM_alert_node
+	# CRM_alert_task
+	# CRM_alert_rc
 	#
-	echo "${tstamp}Fencing ${CRM_notify_desc}" >> ${CRM_notify_recipient}
+	echo "${tstamp}Fencing ${CRM_alert_desc}" >> ${CRM_alert_recipient}
 	;;
     resource)
 	# Other keys:
 	# 
-	# CRM_notify_target_rc
-	# CRM_notify_status
-	# CRM_notify_rc
+	# CRM_alert_target_rc
+	# CRM_alert_status
+	# CRM_alert_rc
 	#
-	if [ ${CRM_notify_interval} = "0" ]; then
-	    CRM_notify_interval=""
+	if [ ${CRM_alert_interval} = "0" ]; then
+	    CRM_alert_interval=""
 	else
-	    CRM_notify_interval=" (${CRM_notify_interval})"
+	    CRM_alert_interval=" (${CRM_alert_interval})"
 	fi
 
-	if [ ${CRM_notify_target_rc} = "0" ]; then
-	    CRM_notify_target_rc=""
+	if [ ${CRM_alert_target_rc} = "0" ]; then
+	    CRM_alert_target_rc=""
 	else
-	    CRM_notify_target_rc=" (target: ${CRM_notify_target_rc})"
+	    CRM_alert_target_rc=" (target: ${CRM_alert_target_rc})"
 	fi
 	
-	case ${CRM_notify_desc} in
+	case ${CRM_alert_desc} in
 	    Cancelled) ;;
 	    *)
-		echo "${tstamp}Resource operation '${CRM_notify_task}${CRM_notify_interval}' for '${CRM_notify_rsc}' on '${CRM_notify_node}': ${CRM_notify_desc}${CRM_notify_target_rc}" >> ${CRM_notify_recipient}
+		echo "${tstamp}Resource operation '${CRM_alert_task}${CRM_alert_interval}' for '${CRM_alert_rsc}' on '${CRM_alert_node}': ${CRM_alert_desc}${CRM_alert_target_rc}" >> ${CRM_alert_recipient}
 		;;
 	esac
 	;;
     *)
-        echo "${tstamp}Unhandled $CRM_notify_kind notification" >> ${CRM_notify_recipient}
-	env | grep CRM_notify >> ${CRM_notify_recipient}
+        echo "${tstamp}Unhandled $CRM_alert_kind alert" >> ${CRM_alert_recipient}
+	env | grep CRM_alert >> ${CRM_alert_recipient}
         ;;
 
 esac

--- a/extra/alerts/pcmk_snmp_helper.sh
+++ b/extra/alerts/pcmk_snmp_helper.sh
@@ -18,34 +18,39 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 # Resources:
-#  crm ra meta ocf:pacemaker:ClusterMon
-#  man 8 crm_mon
+#  Pacemaker Explained - to come
+#  man 8 pcs - to come
+#  pcs alert help - to come
+#  https://github.com/ClusterLabs/pacemaker/pull/950 - to go away
 
-# Sample configuration
+# Sample configuration (cib fragment in xml notation)
 # ================================
-# primitive ClusterMon ocf:pacemaker:ClusterMon \
-#        params user="root" update="30" extra_options="-E /path/to/pcmk_snmp_helper.sh -e 192.168.1.2" \
-#        op monitor on-fail="restart" interval="10"
+# <configuration>
+#   <alerts>
+#     <alert id="snmp_alert" path="/path/to/pcmk_snmp_helper.sh">
+#       <recipient id="snmp_destination" value="192.168.1.2"/>
+#     </alert>
+#   </alerts>
+# </configuration>
 # ================================
 
 # The external agent is fed with environment variables allowing us to know
-# what transition happened and to react accordingly:
-#  http://clusterlabs.org/doc/en-US/Pacemaker/1.1-crmsh/html/Pacemaker_Explained/s-notification-external.html
+# what transition happened and to react accordingly.
 
 # Generates SNMP alerts for any failing monitor operation
 #  OR
 # for any operations (even successful) that are not a monitor
-if [[ ${CRM_notify_rc} != 0 && ${CRM_notify_task} == "monitor" ]] || [[ ${CRM_notify_task} != "monitor" ]] ; then
+if [[ ${CRM_alert_rc} != 0 && ${CRM_alert_task} == "monitor" ]] || [[ ${CRM_alert_task} != "monitor" ]] ; then
     # This trap is compliant with PACEMAKER MIB
     #  https://github.com/ClusterLabs/pacemaker/blob/master/extra/PCMK-MIB.txt
-    /usr/bin/snmptrap -v 2c -c public ${CRM_notify_recipient} "" PACEMAKER-MIB::pacemakerNotificationTrap \
-	PACEMAKER-MIB::pacemakerNotificationNode s "${CRM_notify_node}" \
-	PACEMAKER-MIB::pacemakerNotificationResource s "${CRM_notify_rsc}" \
-	PACEMAKER-MIB::pacemakerNotificationOperation s "${CRM_notify_task}" \
-	PACEMAKER-MIB::pacemakerNotificationDescription s "${CRM_notify_desc}" \
-	PACEMAKER-MIB::pacemakerNotificationStatus i "${CRM_notify_status}" \
-	PACEMAKER-MIB::pacemakerNotificationReturnCode i ${CRM_notify_rc} \
-	PACEMAKER-MIB::pacemakerNotificationTargetReturnCode i ${CRM_notify_target_rc} && exit 0 || exit 1
+    /usr/bin/snmptrap -v 2c -c public ${CRM_alert_recipient} "" PACEMAKER-MIB::pacemakerNotificationTrap \
+	PACEMAKER-MIB::pacemakerNotificationNode s "${CRM_alert_node}" \
+	PACEMAKER-MIB::pacemakerNotificationResource s "${CRM_alert_rsc}" \
+	PACEMAKER-MIB::pacemakerNotificationOperation s "${CRM_alert_task}" \
+	PACEMAKER-MIB::pacemakerNotificationDescription s "${CRM_alert_desc}" \
+	PACEMAKER-MIB::pacemakerNotificationStatus i "${CRM_alert_status}" \
+	PACEMAKER-MIB::pacemakerNotificationReturnCode i ${CRM_alert_rc} \
+	PACEMAKER-MIB::pacemakerNotificationTargetReturnCode i ${CRM_alert_target_rc} && exit 0 || exit 1
 fi
 
 exit 0

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -162,9 +162,9 @@
 #  define XML_CIB_TAG_OPCONFIG		"op_defaults"
 #  define XML_CIB_TAG_RSCCONFIG   	"rsc_defaults"
 #  define XML_CIB_TAG_ACLS   		"acls"
-#  define XML_CIB_TAG_NOTIFICATIONS     "alerts"
-#  define XML_CIB_TAG_NOTIFY            "alert"
-#  define XML_CIB_TAG_NOTIFY_RECIPIENT  "recipient"
+#  define XML_CIB_TAG_ALERTS    	"alerts"
+#  define XML_CIB_TAG_ALERT   		"alert"
+#  define XML_CIB_TAG_ALERT_RECIPIENT	"recipient"
 
 #  define XML_CIB_TAG_STATE         	"node_state"
 #  define XML_CIB_TAG_NODE          	"node"
@@ -347,10 +347,10 @@
 #  define XML_CONFIG_ATTR_FORCE_QUIT	"shutdown-escalation"
 #  define XML_CONFIG_ATTR_RECHECK	"cluster-recheck-interval"
 
-#  define XML_NOTIFY_ATTR_PATH          "path"
-#  define XML_NOTIFY_ATTR_TIMEOUT       "timeout"
-#  define XML_NOTIFY_ATTR_TSTAMP_FORMAT "tstamp_format"
-#  define XML_NOTIFY_ATTR_REC_VALUE     "value"
+#  define XML_ALERT_ATTR_PATH		"path"
+#  define XML_ALERT_ATTR_TIMEOUT	"timeout"
+#  define XML_ALERT_ATTR_TSTAMP_FORMAT	"timestamp-format"
+#  define XML_ALERT_ATTR_REC_VALUE	"value"
 
 #  define XML_CIB_TAG_GENERATION_TUPPLE	"generation_tuple"
 


### PR DESCRIPTION
some more renaming notify -> alert in the publicly exposed headers and sample-scripts
add attribute sanity checking
spare additional cib query for alerts
rename tstamp_format to more consistent timestamp-format

left out updated "Pacemaker Explained" so far in favour of not committing anything inconsistent
