### PR TITLE
Low: hide the unused function when compiling w/o CMAN support

### DIFF
--- a/lib/cluster/legacy.c
+++ b/lib/cluster/legacy.c
@@ -52,6 +52,7 @@ void *ais_ipc_ctx = NULL;
 
 hdb_handle_t ais_ipc_handle = 0;
 
+#if SUPPORT_CMAN
 static bool valid_cman_name(const char *name, uint32_t nodeid) 
 {
     bool rc = TRUE;
@@ -66,6 +67,7 @@ static bool valid_cman_name(const char *name, uint32_t nodeid)
     free(fakename);
     return rc;
 }
+#endif
 
 static gboolean
 plugin_get_details(uint32_t * id, char **uname)


### PR DESCRIPTION
This is so as to fix
http://clusterlabs.org/pipermail/users/2016-May/002902.html