### PR TITLE
Fix init script return status

### DIFF
--- a/mcp/pacemaker.in
+++ b/mcp/pacemaker.in
@@ -59,7 +59,7 @@ notify()
 status()
 {
 	pid=$(pidof $1 2>/dev/null)
-	rtrn=$?
+	local rtrn=$?
 	if [ $rtrn -ne 0 ]; then
 		echo "$1 is stopped"
 	else


### PR DESCRIPTION
[Updated PR #993 to use "local" and rebase against 1.1 branch]

In the original variant, function status() overwrite $rtrn 'in global
scope' which leads to a pretended failing stop() function and
respectively failing initscript when called with action stop.

References: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=686548
Signed-off-by: Christian Schneider <christian.schneider@aoe.com>
Signed-off-by: Christoph Berg <myon@debian.org>