### PR TITLE
Add OCF_RESKEY_CRM_meta_restart_remaining

### DIFF
--- a/doc/Pacemaker_Explained/en-US/Ch-Resources.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Resources.txt
@@ -357,8 +357,10 @@ indexterm:[Resource,Option,requires]
 |migration-threshold
 |INFINITY
 |How many failures may occur for this resource on a node, before this
- node is marked ineligible to host this resource. A value of INFINITY
- indicates that this feature is disabled.
+ node is marked ineligible to host this resource. A value of 0 indicates that
+ this feature is disabled (the node will never be marked ineligible); by
+ constrast, the cluster treats INFINITY (the default) as a very large but
+ finite number.
  indexterm:[migration-threshold,Resource Option]
  indexterm:[Resource,Option,migration-threshold]
 

--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -101,6 +101,14 @@ running). This can be used to test on-fail=ignore.
 <content type="string" default="" />
 </parameter>
 
+<parameter name="envfile" unique="1">
+<longdesc lang="en">
+If this is set, the environment will be dumped to this file for every call.
+</longdesc>
+<shortdesc lang="en">Environment dump file</shortdesc>
+<content type="string" default="" />
+</parameter>
+
 </parameters>
 
 <actions>
@@ -132,6 +140,14 @@ usage: $0 {start|stop|monitor|migrate_to|migrate_from|validate-all|meta-data}
 
 Expects to have a fully populated OCF RA-compliant environment set.
 END
+}
+
+dump_env() {
+    if [ "${OCF_RESKEY_envfile}" != "" ]; then
+            echo "### $(date) ###
+$(env)
+###" >> "${OCF_RESKEY_envfile}"
+    fi
 }
 
 dummy_start() {
@@ -215,6 +231,8 @@ if [ -z "$OCF_RESKEY_state" ]; then
     fi
 fi
 VERIFY_SERIALIZED_FILE="${OCF_RESKEY_state}.serialized"
+
+dump_env
 
 case $__OCF_ACTION in
 meta-data)	meta_data

--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -91,6 +91,16 @@ the cluster reacts to operation timeouts.
 <content type="string" default="0" />
 </parameter>
 
+<parameter name="fail_start_on" unique="0">
+<longdesc lang="en">
+Start actions will return failure if running on the host specified here, but
+the resource will start successfully anyway (future monitor calls will find it
+running). This can be used to test on-fail=ignore.
+</longdesc>
+<shortdesc lang="en">Fail to start on specified host</shortdesc>
+<content type="string" default="" />
+</parameter>
+
 </parameters>
 
 <actions>
@@ -125,11 +135,24 @@ END
 }
 
 dummy_start() {
+    local RETVAL
+
     dummy_monitor
-    if [ $? -eq $OCF_SUCCESS ]; then
-	return $OCF_SUCCESS
+
+    RETVAL=$?
+    if [ $RETVAL -eq $OCF_SUCCESS ]; then
+        if [ "$(hostname)" = "${OCF_RESKEY_fail_start_on}" ]; then
+            RETVAL=$OCF_ERR_GENERIC
+        fi
+        return $RETVAL
     fi
+
     touch "${OCF_RESKEY_state}"
+    RETVAL=$?
+    if [ "$(hostname)" = "${OCF_RESKEY_fail_start_on}" ]; then
+        RETVAL=$OCF_ERR_GENERIC
+    fi
+    return $RETVAL
 }
 
 dummy_stop() {

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -217,6 +217,7 @@
 #  define XML_RSC_ATTR_INTERNAL_RSC	"internal_rsc"
 #  define XML_RSC_ATTR_MAINTENANCE	"maintenance"
 #  define XML_RSC_ATTR_REMOTE_NODE  	"remote-node"
+#  define XML_RSC_ATTR_RECOVERY         "restart-remaining"
 
 #  define XML_REMOTE_ATTR_RECONNECT_INTERVAL "reconnect_interval"
 

--- a/pengine/allocate.c
+++ b/pengine/allocate.c
@@ -608,12 +608,68 @@ failcount_clear_action_exists(node_t * node, resource_t * rsc)
     return rc;
 }
 
+/*!
+ * \internal
+ * \brief Force resource away if failures hit migration threshold
+ *
+ * \param[in,out] rsc       Resource to check for failures
+ * \param[in,out] node      Node to check for failures
+ * \param[in,out] data_set  Cluster working set to update
+ */
+static void
+check_migration_threshold(resource_t *rsc, node_t *node,
+                          pe_working_set_t *data_set)
+{
+    int fail_count, countdown;
+    resource_t *failed;
+
+    /* Migration threshold of 0 means never force away */
+    if (rsc->migration_threshold == 0) {
+        return;
+    }
+
+    /* If there are no failures, there's no need to force away */
+    fail_count = get_failcount_all(node, rsc, NULL, data_set);
+    if (fail_count <= 0) {
+        return;
+    }
+
+    /* How many more times recovery will be tried on this node */
+    countdown = QB_MAX(rsc->migration_threshold - fail_count, 0);
+
+    /* If failed resource has a parent, we'll force the parent away */
+    failed = rsc;
+    if (is_not_set(rsc->flags, pe_rsc_unique)) {
+        failed = uber_parent(rsc);
+    }
+
+    if (countdown == 0) {
+        resource_location(failed, node, -INFINITY, "__fail_limit__", data_set);
+        crm_warn("Forcing %s away from %s after %d failures (max=%d)",
+                 failed->id, node->details->uname, fail_count,
+                 rsc->migration_threshold);
+    } else {
+        crm_info("%s can fail %d more times on %s before being forced off",
+                 failed->id, countdown, node->details->uname);
+    }
+
+    /* An OCF resource agent might want to know whether this is the last
+     * recovery attempt on this node, so add a meta-attribute to any
+     * scheduled stop action, with the number of remaining recovery attempts.
+     */
+    if (rsc->variant == pe_native) {
+        action_t *stop = find_first_action(rsc->actions, NULL, RSC_STOP, node);
+
+        if (stop) {
+            add_hash_param(stop->meta, XML_RSC_ATTR_RECOVERY,
+                           crm_itoa(countdown));
+        }
+    }
+}
+
 static void
 common_apply_stickiness(resource_t * rsc, node_t * node, pe_working_set_t * data_set)
 {
-    int fail_count = 0;
-    resource_t *failed = rsc;
-
     if (rsc->children) {
         GListPtr gIter = rsc->children;
 
@@ -652,26 +708,12 @@ common_apply_stickiness(resource_t * rsc, node_t * node, pe_working_set_t * data
         }
     }
 
-    /* only check failcount here if a failcount clear action
+    /* Check the migration threshold only if a failcount clear action
      * has not already been placed for this resource on the node.
-     * There is no sense in potentially forcing the rsc from this
+     * There is no sense in potentially forcing the resource from this
      * node if the failcount is being reset anyway. */
     if (failcount_clear_action_exists(node, rsc) == FALSE) {
-        fail_count = get_failcount_all(node, rsc, NULL, data_set);
-    }
-
-    if (fail_count > 0 && rsc->migration_threshold != 0) {
-        if (is_not_set(rsc->flags, pe_rsc_unique)) {
-            failed = uber_parent(rsc);
-        }
-        if (rsc->migration_threshold <= fail_count) {
-            resource_location(failed, node, -INFINITY, "__fail_limit__", data_set);
-            crm_warn("Forcing %s away from %s after %d failures (max=%d)",
-                     failed->id, node->details->uname, fail_count, rsc->migration_threshold);
-        } else {
-            crm_info("%s can fail %d more times on %s before being forced off",
-                     failed->id, rsc->migration_threshold - fail_count, node->details->uname);
-        }
+        check_migration_threshold(rsc, node, data_set);
     }
 }
 

--- a/pengine/test10/bug-cl-5247.exp
+++ b/pengine/test10/bug-cl-5247.exp
@@ -3,7 +3,7 @@
     <action_set>
       <rsc_op id="4" operation="stop" operation_key="prmDB2_stop_0" on_node="bl460g8n4" on_node_uuid="3232261400">
         <primitive id="prmDB2" class="ocf" provider="heartbeat" type="VirtualDomain"/>
-        <attributes CRM_meta_name="stop" CRM_meta_on_fail="fence" CRM_meta_remote_node="pgsr02" CRM_meta_timeout="120000" config="/etc/libvirt/qemu/pgsr02.xml"  hypervisor="qemu:///system" migration_transport="ssh"/>
+        <attributes CRM_meta_name="stop" CRM_meta_on_fail="fence" CRM_meta_remote_node="pgsr02" CRM_meta_restart_remaining="0" CRM_meta_timeout="120000" config="/etc/libvirt/qemu/pgsr02.xml"  hypervisor="qemu:///system" migration_transport="ssh"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/bug-lf-2613.exp
+++ b/pengine/test10/bug-lf-2613.exp
@@ -355,7 +355,7 @@
     <action_set>
       <rsc_op id="2" operation="stop" operation_key="prmApPostgreSQLDB1_stop_0" on_node="act1" on_node_uuid="act1">
         <primitive id="prmApPostgreSQLDB1" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_name="stop" CRM_meta_on_fail="block" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_name="stop" CRM_meta_on_fail="block" CRM_meta_restart_remaining="0" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/bug-lf-2619.exp
+++ b/pengine/test10/bug-lf-2619.exp
@@ -368,7 +368,7 @@
     <action_set>
       <rsc_op id="7" operation="stop" operation_key="prmPingd:0_stop_0" on_node="act1" on_node_uuid="act1">
         <primitive id="prmPingd" long-id="prmPingd:0" class="ocf" provider="pacemaker" type="ping"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="5" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="stop" CRM_meta_notify="false" CRM_meta_on_fail="ignore" CRM_meta_timeout="100000"  dampen="0" host_list="192.168.201.254" multiplier="100" name="default_ping_set"/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="5" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="stop" CRM_meta_notify="false" CRM_meta_on_fail="ignore" CRM_meta_restart_remaining="0" CRM_meta_timeout="100000"  dampen="0" host_list="192.168.201.254" multiplier="100" name="default_ping_set"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/bug-n-385265.exp
+++ b/pengine/test10/bug-n-385265.exp
@@ -26,7 +26,7 @@
      <action_set>
        <rsc_op id="2" operation="stop" operation_key="resource_idvscommon_stop_0" on_node="ih02" on_node_uuid="57226bfc-310f-409b-8b3d-49d93498e4b5">
         <primitive id="resource_idvscommon" class="ocf" provider="dfs" type="idvs"/>
-        <attributes CRM_meta_timeout="20000"  site="common"/>
+        <attributes CRM_meta_restart_remaining="0" CRM_meta_timeout="20000"  site="common"/>
        </rsc_op>
      </action_set>
      <inputs>

--- a/pengine/test10/clone-anon-failcount.exp
+++ b/pengine/test10/clone-anon-failcount.exp
@@ -326,7 +326,7 @@
     <action_set>
       <rsc_op id="15" operation="stop" operation_key="clnUMdummy01:1_stop_0" internal_operation_key="clnUMdummy01:0_stop_0" on_node="srv04" on_node_uuid="srv04">
         <primitive id="clnUMdummy01" long-id="clnUMdummy01:1" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="stop" CRM_meta_notify="false" CRM_meta_on_fail="block" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="stop" CRM_meta_notify="false" CRM_meta_on_fail="block" CRM_meta_restart_remaining="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/container-2.exp
+++ b/pengine/test10/container-2.exp
@@ -16,7 +16,7 @@
     <action_set>
       <rsc_op id="3" operation="stop" operation_key="container1_stop_0" on_node="node1" on_node_uuid="node1">
         <primitive id="container1" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_timeout="20000" />
+        <attributes CRM_meta_restart_remaining="5" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/container-3.exp
+++ b/pengine/test10/container-3.exp
@@ -16,7 +16,7 @@
     <action_set>
       <rsc_op id="2" operation="stop" operation_key="container1_stop_0" on_node="node1" on_node_uuid="node1">
         <primitive id="container1" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_timeout="20000" />
+        <attributes CRM_meta_restart_remaining="4" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/container-4.exp
+++ b/pengine/test10/container-4.exp
@@ -29,7 +29,7 @@
     <action_set>
       <rsc_op id="3" operation="stop" operation_key="container1_stop_0" on_node="node1" on_node_uuid="node1">
         <primitive id="container1" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_timeout="20000" />
+        <attributes CRM_meta_restart_remaining="0" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/container-group-2.exp
+++ b/pengine/test10/container-group-2.exp
@@ -81,7 +81,7 @@
     <action_set>
       <rsc_op id="3" operation="stop" operation_key="container1_stop_0" on_node="node1" on_node_uuid="node1">
         <primitive id="container1" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_timeout="20000" />
+        <attributes CRM_meta_restart_remaining="5" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/container-group-3.exp
+++ b/pengine/test10/container-group-3.exp
@@ -75,7 +75,7 @@
     <action_set>
       <rsc_op id="2" operation="stop" operation_key="container1_stop_0" on_node="node1" on_node_uuid="node1">
         <primitive id="container1" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_timeout="20000" />
+        <attributes CRM_meta_restart_remaining="4" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/container-group-4.exp
+++ b/pengine/test10/container-group-4.exp
@@ -94,7 +94,7 @@
     <action_set>
       <rsc_op id="3" operation="stop" operation_key="container1_stop_0" on_node="node1" on_node_uuid="node1">
         <primitive id="container1" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_timeout="20000" />
+        <attributes CRM_meta_restart_remaining="0" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/master-demote-2.exp
+++ b/pengine/test10/master-demote-2.exp
@@ -175,7 +175,7 @@
     <action_set>
       <rsc_op id="1" operation="stop" operation_key="stateful-1:1_stop_0" internal_operation_key="stateful-1:0_stop_0" on_node="pcmk-1" on_node_uuid="pcmk-1">
         <primitive id="stateful-1" long-id="stateful-1:1" class="ocf" provider="pacemaker" type="Stateful"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_master_max="1" CRM_meta_master_node_max="1" CRM_meta_notify="false" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_master_max="1" CRM_meta_master_node_max="1" CRM_meta_notify="false" CRM_meta_restart_remaining="999999" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/master-move.exp
+++ b/pengine/test10/master-move.exp
@@ -94,7 +94,7 @@
     <action_set>
       <rsc_op id="2" operation="stop" operation_key="dummy01_stop_0" on_node="bl460g1n13" on_node_uuid="11111111-1111-1111-1111-111111111111">
         <primitive id="dummy01" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_name="stop" CRM_meta_on_fail="block" CRM_meta_timeout="120000" />
+        <attributes CRM_meta_name="stop" CRM_meta_on_fail="block" CRM_meta_restart_remaining="0" CRM_meta_timeout="120000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/monitor-onfail-restart.exp
+++ b/pengine/test10/monitor-onfail-restart.exp
@@ -16,7 +16,7 @@
     <action_set>
       <rsc_op id="2" operation="stop" operation_key="A_stop_0" on_node="fc16-builder" on_node_uuid="fc16-builder">
         <primitive id="A" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_name="stop" CRM_meta_on_fail="block" CRM_meta_timeout="30000" />
+        <attributes CRM_meta_name="stop" CRM_meta_on_fail="block" CRM_meta_restart_remaining="999999" CRM_meta_timeout="30000" />
       </rsc_op>
     </action_set>
     <inputs/>

--- a/pengine/test10/multiple-monitor-one-failed.exp
+++ b/pengine/test10/multiple-monitor-one-failed.exp
@@ -16,7 +16,7 @@
     <action_set>
       <rsc_op id="3" operation="stop" operation_key="Dummy-test2_stop_0" on_node="dhcp180" on_node_uuid="dhcp180">
         <primitive id="Dummy-test2" class="ocf" provider="test" type="Dummy"/>
-        <attributes CRM_meta_timeout="20000"  state="/tmp/dummy-state" state2="/tmp/dummy-state-2"/>
+        <attributes CRM_meta_restart_remaining="999999" CRM_meta_timeout="20000"  state="/tmp/dummy-state" state2="/tmp/dummy-state-2"/>
       </rsc_op>
     </action_set>
     <inputs/>

--- a/pengine/test10/remote-fence-unclean.exp
+++ b/pengine/test10/remote-fence-unclean.exp
@@ -19,7 +19,7 @@
     <action_set>
       <rsc_op id="5" operation="stop" operation_key="remote1_stop_0" on_node="18node1" on_node_uuid="1">
         <primitive id="remote1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_timeout="20000" />
+        <attributes CRM_meta_restart_remaining="999999" CRM_meta_timeout="20000" />
         <downed>
           <node id="remote1"/>
         </downed>

--- a/pengine/test10/remote-start-fail.exp
+++ b/pengine/test10/remote-start-fail.exp
@@ -29,7 +29,7 @@
     <action_set>
       <rsc_op id="2" operation="stop" operation_key="rhel7-auto4_stop_0" on_node="rhel7-auto2" on_node_uuid="2">
         <primitive id="rhel7-auto4" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_name="stop" CRM_meta_restart_remaining="0" CRM_meta_timeout="60000" />
         <downed>
           <node id="rhel7-auto4"/>
         </downed>

--- a/pengine/test10/remote-unclean2.exp
+++ b/pengine/test10/remote-unclean2.exp
@@ -19,7 +19,7 @@
     <action_set>
       <rsc_op id="2" operation="stop" operation_key="rhel7-auto4_stop_0" on_node="rhel7-auto1" on_node_uuid="1">
         <primitive id="rhel7-auto4" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_name="stop" CRM_meta_restart_remaining="999999" CRM_meta_timeout="60000" />
         <downed>
           <node id="rhel7-auto4"/>
         </downed>

--- a/pengine/test10/whitebox-fail1.exp
+++ b/pengine/test10/whitebox-fail1.exp
@@ -16,7 +16,7 @@
     <action_set>
       <rsc_op id="5" operation="stop" operation_key="container1_stop_0" on_node="18node2" on_node_uuid="2">
         <primitive id="container1" class="ocf" provider="heartbeat" type="VirtualDomain"/>
-        <attributes CRM_meta_remote_node="lxc1" CRM_meta_timeout="20000" config="/home/dvossel/virtual_machines/lxc/lxc1.xml"  force_stop="true" hypervisor="lxc:///"/>
+        <attributes CRM_meta_remote_node="lxc1" CRM_meta_restart_remaining="999999" CRM_meta_timeout="20000" config="/home/dvossel/virtual_machines/lxc/lxc1.xml"  force_stop="true" hypervisor="lxc:///"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/whitebox-fail2.exp
+++ b/pengine/test10/whitebox-fail2.exp
@@ -16,7 +16,7 @@
     <action_set>
       <rsc_op id="5" operation="stop" operation_key="container1_stop_0" on_node="18node2" on_node_uuid="2">
         <primitive id="container1" class="ocf" provider="heartbeat" type="VirtualDomain"/>
-        <attributes CRM_meta_remote_node="lxc1" CRM_meta_timeout="20000" config="/home/dvossel/virtual_machines/lxc/lxc1.xml"  force_stop="true" hypervisor="lxc:///"/>
+        <attributes CRM_meta_remote_node="lxc1" CRM_meta_restart_remaining="999998" CRM_meta_timeout="20000" config="/home/dvossel/virtual_machines/lxc/lxc1.xml"  force_stop="true" hypervisor="lxc:///"/>
       </rsc_op>
     </action_set>
     <inputs>


### PR DESCRIPTION
When recovering a resource, add a new meta-attribute to stop actions with the number of recovery attempts remaining on the current node before forcing away to another node due to migration-threshold.