### PR TITLE
Fix: crmd: correctly dig into cib-query-answer if alerts section is p…

### DIFF
--- a/crmd/control.c
+++ b/crmd/control.c
@@ -1010,7 +1010,7 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     config_hash =
         g_hash_table_new_full(crm_str_hash, g_str_equal, g_hash_destroy_str, g_hash_destroy_str);
 
-    unpack_instance_attributes(output, output, XML_CIB_TAG_PROPSET, NULL, config_hash,
+    unpack_instance_attributes(crmconfig, crmconfig, XML_CIB_TAG_PROPSET, NULL, config_hash,
                                CIB_OPTIONS_FIRST, FALSE, now);
 
     verify_crmd_options(config_hash);

--- a/crmd/notify.c
+++ b/crmd/notify.c
@@ -520,7 +520,8 @@ parse_notifications(xmlNode *notifications)
         entry = (notify_entry_t) {
             .id = (char *) crm_element_value(notify, XML_ATTR_ID),
             .path = (char *) crm_element_value(notify, XML_ALERT_ATTR_PATH),
-            .timeout = CRMD_NOTIFY_DEFAULT_TIMEOUT_MS
+            .timeout = CRMD_NOTIFY_DEFAULT_TIMEOUT_MS,
+            .tstamp_format = (char *) CRMD_NOTIFY_DEFAULT_TSTAMP_FORMAT
         };
 
         entry.envvars =

--- a/crmd/notify.h
+++ b/crmd/notify.h
@@ -25,6 +25,9 @@
 /* Default-Timeout to use before killing a notification script (in milliseconds) */
 #  define CRMD_NOTIFY_DEFAULT_TIMEOUT_MS (300000)
 
+/* Default-Format-String used to pass timestamps to the notification scripts */
+#  define CRMD_NOTIFY_DEFAULT_TSTAMP_FORMAT "%H:%M:%S.%06N"
+
 void crmd_enable_notifications(const char *script, const char *target);
 void crmd_notify_node_event(crm_node_t *node);
 void crmd_notify_fencing_op(stonith_event_t * e);


### PR DESCRIPTION
When there is an alerts-section crm_config-section is ignored and everything
switches to defaults
 Fix: crmd: correctly dig into cib-query-answer if alerts section is present

Make the behaviour as announced on the ClusterLabs-list 
 timestamp-format defaults to "%H:%M:%S.%06N"