### PR TITLE
Build: let "make [s]rpm" use pre-/post-release logic from spec proper

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -64,6 +64,48 @@ COUNT           = $(shell expr 1 + $(LAST_COUNT))
 
 SPECVERSION	?= $(COUNT)
 
+# rpmbuild wrapper that translates "--with[out] FEATURE" into RPM macros
+#
+# Unfortunately, at least recent versions of rpm do no support mentioned
+# switch.  To work this around, we can emulate mechanism that rpm uses
+# internally: unfold the flags into respective macro definitions:
+#
+#    --with[out] FOO  ->  --define "_with[out]_FOO --with[out]-FOO"
+#
+# $(1) ... WITH string (e.g., --with pre_release --without cman)
+# $(2) ... options following the initial "rpmbuild" in the command
+# $(3) ... final arguments determined with $2 (e.g., pacemaker.spec)
+#
+# Note that if $(3) is a specfile, extra case is taken so as to reflect
+# pcmkversion correctly (using in-place modification).
+#
+# Also note that both ways to specify long option with an argument
+# (i.e., what getopt and, importantly, rpm itself support) can be used:
+#
+#    --with FOO
+#    --with=FOO
+rpmbuild-with = \
+	WITH=$$(getopt -o "" -l with:,without: -- $(1)) || exit 1; \
+	CMD='rpmbuild $(2)'; PREREL=0; \
+	eval set -- "$${WITH}"; \
+	while true; do \
+		case "$$1" in \
+		--with) CMD="$${CMD} --define \"_with_$$2 --with-$$2\""; shift 2; \
+			[ "$$2" != pre_release ] || PREREL=1;; \
+		--without) CMD="$${CMD} --define \"_without_$$2 --without-$$2\""; shift 2; \
+		        [ "$$2" != pre_release ] || PREREL=0;; \
+		--) shift ; break ;; \
+		*) echo "cannot parse WITH: $$1"; exit 1;; \
+		esac; \
+	done; \
+	case "$(3)" in \
+	*.spec) [ $${PREREL} -eq 0 ] \
+		&& sed -i 's/^\(%global pcmkversion \).*/\1$(shell git describe --tags $(TAG) | sed -e s:Pacemaker-:: -e s:-.*::)/' $(3) \
+		|| sed -i 's/^\(%global pcmkversion \).*/\1$(shell echo $(NEXT_RELEASE) | sed -e s:Pacemaker-:: -e s:-.*::)/' $(3);; \
+	esac; \
+	CMD="$${CMD} $(3)"; \
+	eval "$${CMD}"
+
 init:
 	./autogen.sh init
 
@@ -144,8 +186,6 @@ $(PACKAGE)-%.spec: $(PACKAGE).spec.in
 	    echo "Rebuilt $@ from $(TAG)";					\
 	fi
 
-# rpmbuild apparently temporarily lost the ability to use --with arguments at some point
-# Compensate by tweaking the format for pcmk_release here
 srpm-%:	export $(PACKAGE)-%.spec
 	rm -f *.src.rpm
 	cp $(PACKAGE)-$*.spec $(PACKAGE).spec
@@ -156,16 +196,8 @@ srpm-%:	export $(PACKAGE)-%.spec
 	fi
 	sed -i 's/global\ specversion.*/global\ specversion\ $(SPECVERSION)/' $(PACKAGE).spec
 	sed -i 's/global\ commit.*/global\ commit\ $(TAG)/' $(PACKAGE).spec
-	case "$(WITH)" in 	\
-	  *pre_release*)	\
-	    sed -i 's/^\(%global pcmk_release \).*/\10.%{specversion}.%{shortcommit}.git/' $(PACKAGE).spec;	\
-	    sed -i 's/^\(%global pcmkversion \).*/\1$(shell echo $(NEXT_RELEASE) | sed -e s:Pacemaker-:: -e s:-.*::)/' $(PACKAGE).spec;;	\
-	  *)			\
-	    [ "$(TAG)" = "Pacemaker-$(SHORTTAG)" ] \
-	      || sed -i 's/^\(%global pcmk_release \).*/\1%{specversion}.%{shortcommit}.git/' $(PACKAGE).spec; \
-	    sed -i 's/^\(%global pcmkversion \).*/\1$(shell git describe --tags $(TAG) | sed -e s:Pacemaker-:: -e s:-.*::)/' $(PACKAGE).spec;;\
-	esac
-	rpmbuild -bs --define "dist .$*" $(RPM_OPTS) $(PACKAGE).spec
+	@WITH=$$(getopt -o "" -l with:,without: -n '$@' -- $(WITH)) || exit 1; \
+	$(call rpmbuild-with,$(WITH),-bs --define "dist .$*" $(RPM_OPTS),$(PACKAGE).spec)
 
 chroot: mock-$(MOCK_CFG) mock-install-$(MOCK_CFG) mock-sh-$(MOCK_CFG)
 	echo "Done"
@@ -220,7 +252,7 @@ rpm-dep: $(PACKAGE)-$(DISTRO).spec
 
 rpm:	srpm
 	@echo To create custom builds, edit the flags and options in $(PACKAGE).spec first
-	rpmbuild $(RPM_OPTS) $(WITH) --rebuild $(RPM_ROOT)/*.src.rpm
+	$(call rpmbuild-with,$(WITH),$(RPM_OPTS),--rebuild $(RPM_ROOT)/*.src.rpm)
 
 release:
 	make TAG=$(LAST_RELEASE) rpm


### PR DESCRIPTION
This is just a parallel to commit 5401f3b that covered just spec proper
(without GNUmakefile-predestined preprocessing, it actually works just
fine for pre-releases... it might be a good idea to eliminate the
accumulated redundancy there, eventually, perhaps as a partial revert
of c071e92 that wasn't necessarily correct as one should be still able
to pass "--define '_with_FOO 1'" to rpmbuild as an alternative).