### PR TITLE
Fix time formatting on x32

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -3302,7 +3302,7 @@ send_snmp_trap(const char *node, const char *rsc, const char *task, int target_r
         char csysuptime[20];
         time_t now = time(NULL);
 
-        sprintf(csysuptime, "%ld", now);
+        sprintf(csysuptime, "%lld", (long long) now);
         snmp_add_var(trap_pdu, sysuptime_oid, sizeof(sysuptime_oid) / sizeof(oid), 't', csysuptime);
     }
 


### PR DESCRIPTION
On x32, time_t is long long, but long is only 32bits, so sprintf("%ld", time_t)
will error out. Fix by always casting to long long which is long enough on any
platform.