### PR TITLE
st_client: print the full unexpected status value from waitpid()

### DIFF
--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1035,8 +1035,8 @@ internal_stonith_action_execute(stonith_action_t * action)
                     WTERMSIG(status));
 
         } else {
-            crm_err("call %s for %s exited abnormally. stopped=%d, continued=%d",
-                    action->action, action->agent, WIFSTOPPED(status), WIFCONTINUED(status));
+            crm_err("call %s for %s returned unexpected status %#x",
+                    action->action, action->agent, status);
         }
     }
 


### PR DESCRIPTION
Neither WIFSTOPPED nor WIFCONTINUED could evaluate to true here, because
the waitpid() calls above lack the WUNTRACED and WCONTINUED flags.  Since
we don't use ptrace() this is an "impossible" branch, but it's best to
have the raw status value around to enable post-mortem manual decoding.

This patch also enhances portability, because WIFCONTINUED is not defined
on Hurd (at least).

Signed-off-by: Ferenc Wágner <wferi@niif.hu>