### PR TITLE
Add $remote_fs dependencies to the init scripts

### DIFF
--- a/lrmd/pacemaker_remote.in
+++ b/lrmd/pacemaker_remote.in
@@ -11,9 +11,9 @@
 #
 ### BEGIN INIT INFO
 # Provides:		pacemaker_remoted
-# Required-Start:	$network
+# Required-Start:	$network $remote_fs
 # Should-Start:		$syslog
-# Required-Stop:	$network
+# Required-Stop:	$network $remote_fs
 # Default-Start:
 # Default-Stop:
 # Short-Description:	Starts and stops the Pacemaker remote agent for non-cluster nodes

--- a/mcp/pacemaker.in
+++ b/mcp/pacemaker.in
@@ -12,9 +12,9 @@
 #
 ### BEGIN INIT INFO
 # Provides:		pacemaker
-# Required-Start:	$network corosync
+# Required-Start:	$network $remote_fs corosync
 # Should-Start:		$syslog
-# Required-Stop:	$network corosync
+# Required-Stop:	$network $remote_fs corosync
 # Default-Start:
 # Default-Stop:
 # Short-Description:	Starts and stops Pacemaker Cluster Manager.


### PR DESCRIPTION
Because pacemaker and pacemaker-remote both need /usr.

Signed-off-by: Ferenc Wágner <wferi@niif.hu>