### PR TITLE
Add documentation URIs to the service files

### DIFF
--- a/lrmd/pacemaker_remote.service.in
+++ b/lrmd/pacemaker_remote.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Pacemaker Remote Service
+Documentation=man:pacemaker_remoted http://clusterlabs.org/doc/en-US/Pacemaker/1.1-pcs/html/Pacemaker_Remote/index.html
 After=network.target
 
 [Install]

--- a/mcp/pacemaker.service.in
+++ b/mcp/pacemaker.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Pacemaker High Availability Cluster Manager
+Documentation=man:pacemakerd http://clusterlabs.org/doc/en-US/Pacemaker/1.1-pcs/html/Pacemaker_Explained/index.html
 
 After=dbus.service
 After=basic.target

--- a/tools/crm_mon.service.in
+++ b/tools/crm_mon.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Daemon for pacemaker monitor
+Documentation=man:crm_mon
 
 [Service]
 Type=forking


### PR DESCRIPTION
This way systemctl help can show the respective man pages.

Signed-off-by: Ferenc Wágner <wferi@niif.hu>