### PR TITLE
Suppress unused result warning in signal handler

### DIFF
--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -463,7 +463,7 @@ static int sigchld_pipe[2];
 static void
 sigchld_handler()
 {
-    write(sigchld_pipe[1], "", 1);
+    if (write(sigchld_pipe[1], "", 1) == -1) {}
 }
 #endif
 


### PR DESCRIPTION
Modern compilers will fail with "ignoring return value of ‘write’,
declared with attribute warn_unused_result" otherwise.

(In my tests with gcc 5.3 on GNU Hurd, it wasn't enough to simply cast
the return value to (void) which is often suggested as a way to suppress
this kind of error.)