### PR TITLE
Build: travis: avoid implicit cast of 1.1 branch to float

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,4 +70,4 @@ notifications:
 branches:
   only:
     - master
-    - 1.1
+    - "1.1"


### PR DESCRIPTION
This prevented Travis CI to catching on the commits for/at this branch
completely.

Reference:
https://en.wikipedia.org/wiki/YAML#Casting_data_types