### PR TITLE
crm_mon: consistently print ms resource state

### DIFF
--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -528,7 +528,7 @@ clone_print(resource_t * rsc, const char *pre_text, long options, void *print_da
     if(rsc->variant == pe_master) {
         enum rsc_role_e role = configured_role(rsc);
 
-        if(role > RSC_ROLE_STOPPED && role < RSC_ROLE_MASTER) {
+        if(role == RSC_ROLE_SLAVE) {
             short_print(list_text, child_text, "Slaves (target-role)", NULL, options, print_data);
         } else {
             short_print(list_text, child_text, "Slaves", NULL, options, print_data);

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -440,6 +440,7 @@ native_print(resource_t * rsc, const char *pre_text, long options, void *print_d
     const char *class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
     const char *kind = crm_element_value(rsc->xml, XML_ATTR_TYPE);
     const char *target_role = NULL;
+    enum rsc_role_e role = rsc->role;
 
     int offset = 0;
     int flagOffset = 0;
@@ -456,6 +457,10 @@ native_print(resource_t * rsc, const char *pre_text, long options, void *print_d
             return;
         }
         target_role = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_TARGET_ROLE);
+    }
+
+    if(role == RSC_ROLE_STARTED && uber_parent(rsc)->variant == pe_master) {
+        role = RSC_ROLE_SLAVE;
     }
 
     if (pre_text == NULL && (options & pe_print_printf)) {
@@ -508,18 +513,17 @@ native_print(resource_t * rsc, const char *pre_text, long options, void *print_d
     if(is_set(rsc->flags, pe_rsc_orphan)) {
         offset += snprintf(buffer + offset, LINE_MAX - offset, " ORPHANED ");
     }
-    if(rsc->role > RSC_ROLE_SLAVE && is_set(rsc->flags, pe_rsc_failed)) {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, "FAILED %s", role2text(rsc->role));
+    if(role > RSC_ROLE_SLAVE && is_set(rsc->flags, pe_rsc_failed)) {
+        offset += snprintf(buffer + offset, LINE_MAX - offset, "FAILED %s", role2text(role));
     } else if(is_set(rsc->flags, pe_rsc_failed)) {
         offset += snprintf(buffer + offset, LINE_MAX - offset, "FAILED");
     } else {
         const char *rsc_state = NULL;
-
         if (options & pe_print_pending) {
             rsc_state = native_pending_state(rsc);
         }
         if (rsc_state == NULL) {
-            rsc_state = role2text(rsc->role);
+            rsc_state = role2text(role);
         }
         offset += snprintf(buffer + offset, LINE_MAX - offset, "%s", rsc_state);
     }
@@ -545,16 +549,13 @@ native_print(resource_t * rsc, const char *pre_text, long options, void *print_d
 
         /* Ignore target role Started, as it is the default anyways
          * (and would also allow a Master to be Master).
-         * Show if current role differs from target role,
-         * or if target role limits our abilities. */
+         * Show if target role limits our abilities. */
         if (target_role_e == RSC_ROLE_STOPPED) {
             flagOffset += snprintf(flagBuffer + flagOffset, LINE_MAX - flagOffset, "%sdisabled", flagOffset?", ":"");
             rsc->cluster->disabled_resources++;
 
         } else if (uber_parent(rsc)->variant == pe_master
-                   && target_role_e > RSC_ROLE_STOPPED
-                   && target_role_e < RSC_ROLE_MASTER
-                   && safe_str_neq(target_role, role2text(rsc->role))) {
+                   && target_role_e == RSC_ROLE_SLAVE) {
             flagOffset += snprintf(flagBuffer + flagOffset, LINE_MAX - flagOffset, "%starget-role:%s", flagOffset?", ":"", target_role);
             rsc->cluster->disabled_resources++;
         }

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -707,7 +707,7 @@ cli_resource_check(cib_t * cib_conn, resource_t *rsc)
             printf("\n  * The configuration specifies that '%s' should remain stopped\n", parent->id);
             need_nl++;
 
-        } else if(parent->variant > pe_clone && role != RSC_ROLE_MASTER) {
+        } else if(parent->variant > pe_clone && role == RSC_ROLE_SLAVE) {
             printf("\n  * The configuration specifies that '%s' should not be promoted\n", parent->id);
             need_nl++;
         }


### PR DESCRIPTION
 * consistently use 'Slave', not sometimes 'Slave', sometimes 'Started'
 * only report target role, if it is the limitation (target-role:Slave)
   Both target-role Master and target-role Started
   do not limit us in any way.