### PR TITLE
Mid : pengine : Correction of the record judgment of the failed information.

### DIFF
--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2543,7 +2543,7 @@ record_failed_op(xmlNode *op, node_t* node, pe_working_set_t * data_set)
     xmlNode *xIter = NULL;
     const char *op_key = crm_element_value(op, XML_LRM_ATTR_TASK_KEY);
 
-    if ((node->details->shutdown) && (node->details->online == FALSE)) {
+    if (node->details->online == FALSE) {
         return;
     }
 


### PR DESCRIPTION
Hi All,

I made the next modifications before.
 * https://github.com/ClusterLabs/pacemaker/pull/782

This correction was to revise that the trouble information at the time of the stop disappeared.
For example, trouble occurred in Dummy resource at the time of a node stop, and the trouble information was not displayed when stonith failed.

However, my correction of the past had a problem.
After a resource broke down in a node having stonith, the trouble information is displayed in crm_mon even if I stop the node.

```
Online: [ pm02 ]
OFFLINE: [ vm01 ]

Full list of resources:

 prmDummy1      (ocf::heartbeat:Dummy): Started pm02
 Resource Group: grpStonith1
     prmStonith1-1      (stonith:external/xxxxx1):      Stopped
     prmStonith1-2      (stonith:external/xxxxx2):        Stopped
 Resource Group: grpStonith2
     prmStonith2-1      (stonith:external/xxxxx1):      Started pm02
     prmStonith2-2      (stonith:external/xxxxx2):        Started pm02

Node Attributes:
* Node pm02:

Migration Summary:
* Node pm02:

Failed Actions:
* prmDummy1_monitor_10000 on vm01 'not running' (7): call=27, status=complete, exitreason='No process state file found',
    last-rc-change='Tue Jun  7 09:21:28 2016', queued=0ms, exec=0ms

```

I reviewed a judgment again.
The right judgment should have been the next judgment.

```
static void
record_failed_op(xmlNode *op, node_t* node, pe_working_set_t * data_set)
{
(snip)
  if ((node->details->shutdown == TRUE) && (node->details->online == TRUE)) {
     ;  // For the state at the time of the stop, it is necessary to handle this.
  } else if (node->details->shutdown) {
        return;
  } else if(node->details->online == FALSE) {
        return;
  }
(snip)
```

I reviewed this judgment and changed the judgment to "node-details-online==FALSE".

Best Regards,
Hideo Yamauchi.