### PR TITLE
Improvement of the log

### DIFF
--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -2368,25 +2368,28 @@ process_lrm_event(lrm_state_t * lrm_state, lrmd_event_data_t * op, struct recurr
         case PCMK_LRM_OP_CANCELLED:
             crm_info("Result of %s operation for %s on %s: %s "
                      CRM_XS " call=%d key=%s confirmed=%s",
-                     op->op_type, op->rsc_id, lrm_state->node_name,
+                     crm_action_str(op->op_type, op->interval),
+                     op->rsc_id, lrm_state->node_name,
                      services_lrm_status_str(op->op_status),
                      op->call_id, op_key, (removed? "true" : "false"));
             break;
 
         case PCMK_LRM_OP_DONE:
             do_crm_log(op->interval?LOG_INFO:LOG_NOTICE,
-                       "Result of %s operation for %s on %s: %s "
-                       CRM_XS " call=%d key=%s confirmed=%s rc=%d cib-update=%d",
-                       op->op_type, op->rsc_id, lrm_state->node_name,
-                       services_ocf_exitcode_str(op->rc),
+                       "Result of %s operation for %s on %s: %d (%s) "
+                       CRM_XS " call=%d key=%s confirmed=%s cib-update=%d",
+                       crm_action_str(op->op_type, op->interval),
+                       op->rsc_id, lrm_state->node_name,
+                       op->rc, services_ocf_exitcode_str(op->rc),
                        op->call_id, op_key, (removed? "true" : "false"),
-                       op->rc, update_id);
+                       update_id);
             break;
 
         case PCMK_LRM_OP_TIMEOUT:
             crm_err("Result of %s operation for %s on %s: %s "
                     CRM_XS " call=%d key=%s timeout=%dms",
-                    op->op_type, op->rsc_id, lrm_state->node_name,
+                    crm_action_str(op->op_type, op->interval),
+                    op->rsc_id, lrm_state->node_name,
                     services_lrm_status_str(op->op_status),
                     op->call_id, op_key, op->timeout);
             break;
@@ -2394,7 +2397,8 @@ process_lrm_event(lrm_state_t * lrm_state, lrmd_event_data_t * op, struct recurr
         default:
             crm_err("Result of %s operation for %s on %s: %s "
                     CRM_XS " call=%d key=%s confirmed=%s status=%d cib-update=%d",
-                    op->op_type, op->rsc_id, lrm_state->node_name,
+                    crm_action_str(op->op_type, op->interval),
+                    op->rsc_id, lrm_state->node_name,
                     services_lrm_status_str(op->op_status), op->call_id, op_key,
                     (removed? "true" : "false"), op->op_status, update_id);
     }

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -200,4 +200,11 @@ typedef GList *GListPtr;
 guint crm_strcase_hash(gconstpointer v);
 guint g_str_hash_traditional(gconstpointer v);
 
+static inline const char *crm_action_str(const char *task, int interval) {
+    if(safe_str_eq(task, RSC_STATUS) && !interval) {
+        return "probe";
+    }
+    return task;
+}
+
 #endif


### PR DESCRIPTION
I will demand an improvement in the log of the next two points.
The monitor is I want to know whether or not it so? Probe.
In previous log is monitor_0, interval 0 So it was found.
I want to now change it to a more easy-to-understand display

Please display the return code.
It is important in order for the user to analyze whether the finished from the return code that appeared in the log at any exit code resource agent.