### PR TITLE
Feature: Allow regexp substitutions in location constraints

### DIFF
--- a/include/crm/pengine/rules.h
+++ b/include/crm/pengine/rules.h
@@ -22,6 +22,8 @@
 #  include <crm/common/iso8601.h>
 #  include <crm/pengine/common.h>
 
+#  include <regex.h>
+
 enum expression_type {
     not_expr,
     nested_rule,
@@ -31,17 +33,31 @@ enum expression_type {
     time_expr
 };
 
+typedef struct pe_re_match_data {
+    char *string;
+    int nregs;
+    regmatch_t *pmatch;
+} pe_re_match_data_t;
+
 enum expression_type find_expression_type(xmlNode * expr);
 
 gboolean test_ruleset(xmlNode * ruleset, GHashTable * node_hash, crm_time_t * now);
 
 gboolean test_rule(xmlNode * rule, GHashTable * node_hash, enum rsc_role_e role, crm_time_t * now);
 
+gboolean pe_test_rule_re(xmlNode * rule, GHashTable * node_hash, enum rsc_role_e role, crm_time_t * now,
+                         pe_re_match_data_t * match_data);
+
 gboolean test_expression(xmlNode * expr, GHashTable * node_hash,
                          enum rsc_role_e role, crm_time_t * now);
+
+gboolean pe_test_expression_re(xmlNode * expr, GHashTable * node_hash,
+                         enum rsc_role_e role, crm_time_t * now, pe_re_match_data_t * match_data);
 
 void unpack_instance_attributes(xmlNode * top, xmlNode * xml_obj, const char *set_name,
                                 GHashTable * node_hash, GHashTable * hash,
                                 const char *always_first, gboolean overwrite, crm_time_t * now);
+
+char *pe_expand_re_matches(const char *string, pe_re_match_data_t * match_data);
 
 #endif

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -26,6 +26,10 @@
 #include <crm/pengine/rules.h>
 #include <crm/pengine/internal.h>
 
+#include <sys/types.h>
+#include <regex.h>
+#include <ctype.h>
+
 CRM_TRACE_INIT_DATA(pe_rules);
 
 crm_time_t *parse_xml_duration(crm_time_t * start, xmlNode * duration_spec);
@@ -33,6 +37,7 @@ crm_time_t *parse_xml_duration(crm_time_t * start, xmlNode * duration_spec);
 gboolean test_date_expression(xmlNode * time_expr, crm_time_t * now);
 gboolean cron_range_satisfied(crm_time_t * now, xmlNode * cron_spec);
 gboolean test_attr_expression(xmlNode * expr, GHashTable * hash, crm_time_t * now);
+gboolean pe_test_attr_expression_re(xmlNode * expr, GHashTable * hash, crm_time_t * now, pe_re_match_data_t * match_data);
 gboolean test_role_expression(xmlNode * expr, enum rsc_role_e role, crm_time_t * now);
 
 gboolean
@@ -56,6 +61,12 @@ test_ruleset(xmlNode * ruleset, GHashTable * node_hash, crm_time_t * now)
 gboolean
 test_rule(xmlNode * rule, GHashTable * node_hash, enum rsc_role_e role, crm_time_t * now)
 {
+    return pe_test_rule_re(rule, node_hash, role, now, NULL);
+}
+
+gboolean
+pe_test_rule_re(xmlNode * rule, GHashTable * node_hash, enum rsc_role_e role, crm_time_t * now, pe_re_match_data_t * match_data)
+{
     xmlNode *expr = NULL;
     gboolean test = TRUE;
     gboolean empty = TRUE;
@@ -72,7 +83,7 @@ test_rule(xmlNode * rule, GHashTable * node_hash, enum rsc_role_e role, crm_time
 
     crm_trace("Testing rule %s", ID(rule));
     for (expr = __xml_first_child(rule); expr != NULL; expr = __xml_next_element(expr)) {
-        test = test_expression(expr, node_hash, role, now);
+        test = pe_test_expression_re(expr, node_hash, role, now, match_data);
         empty = FALSE;
 
         if (test && do_and == FALSE) {
@@ -96,12 +107,18 @@ test_rule(xmlNode * rule, GHashTable * node_hash, enum rsc_role_e role, crm_time
 gboolean
 test_expression(xmlNode * expr, GHashTable * node_hash, enum rsc_role_e role, crm_time_t * now)
 {
+    return pe_test_expression_re(expr, node_hash, role, now, NULL);
+}
+
+gboolean
+pe_test_expression_re(xmlNode * expr, GHashTable * node_hash, enum rsc_role_e role, crm_time_t * now, pe_re_match_data_t * match_data)
+{
     gboolean accept = FALSE;
     const char *uname = NULL;
 
     switch (find_expression_type(expr)) {
         case nested_rule:
-            accept = test_rule(expr, node_hash, role, now);
+            accept = pe_test_rule_re(expr, node_hash, role, now, match_data);
             break;
         case attr_expr:
         case loc_expr:
@@ -109,7 +126,7 @@ test_expression(xmlNode * expr, GHashTable * node_hash, enum rsc_role_e role, cr
              * no node to compare with
              */
             if (node_hash != NULL) {
-                accept = test_attr_expression(expr, node_hash, now);
+                accept = pe_test_attr_expression_re(expr, node_hash, now, match_data);
             }
             break;
 
@@ -206,7 +223,14 @@ test_role_expression(xmlNode * expr, enum rsc_role_e role, crm_time_t * now)
 gboolean
 test_attr_expression(xmlNode * expr, GHashTable * hash, crm_time_t * now)
 {
+    return pe_test_attr_expression_re(expr, hash, now, NULL);
+}
+
+gboolean
+pe_test_attr_expression_re(xmlNode * expr, GHashTable * hash, crm_time_t * now, pe_re_match_data_t * match_data)
+{
     gboolean accept = FALSE;
+    gboolean attr_allocated = FALSE;
     int cmp = 0;
     const char *h_val = NULL;
 
@@ -221,13 +245,27 @@ test_attr_expression(xmlNode * expr, GHashTable * hash, crm_time_t * now)
     type = crm_element_value(expr, XML_EXPR_ATTR_TYPE);
 
     if (attr == NULL || op == NULL) {
-        pe_err("Invlaid attribute or operation in expression"
+        pe_err("Invalid attribute or operation in expression"
                " (\'%s\' \'%s\' \'%s\')", crm_str(attr), crm_str(op), crm_str(value));
         return FALSE;
     }
 
+    if (match_data) {
+        char *resolved_attr = pe_expand_re_matches(attr, match_data);
+
+       if (resolved_attr) {
+           attr = (const char *) resolved_attr;
+           attr_allocated = TRUE;
+       }
+    }
+
     if (hash != NULL) {
         h_val = (const char *)g_hash_table_lookup(hash, attr);
+    }
+
+    if (attr_allocated) {
+        free((char *)attr);
+        attr = NULL;
     }
 
     if (value != NULL && h_val != NULL) {
@@ -734,4 +772,61 @@ unpack_instance_attributes(xmlNode * top, xmlNode * xml_obj, const char *set_nam
         g_list_foreach(sorted, unpack_attr_set, &data);
         g_list_free_full(sorted, free);
     }
+}
+
+char *
+pe_expand_re_matches(const char *string, pe_re_match_data_t *match_data)
+{
+    size_t len = 0;
+    int i;
+    const char *p, *last_match_index;
+    char *p_dst, *result = NULL;
+
+    if (!string || string[0] == '\0' || !match_data) {
+        return NULL;
+    }
+
+    p = last_match_index = string;
+
+    while (*p) {
+        if (*p == '%' && *(p + 1) && isdigit(*(p + 1))) {
+            i = *(p + 1) - '0';
+            if (match_data->nregs >= i && match_data->pmatch[i].rm_so != -1 &&
+                match_data->pmatch[i].rm_eo > match_data->pmatch[i].rm_so) {
+                len += p - last_match_index + (match_data->pmatch[i].rm_eo - match_data->pmatch[i].rm_so);
+                last_match_index = p + 2;
+            }
+            p++;
+        }
+        p++;
+    }
+    len += p - last_match_index + 1;
+
+    /* FIXME: Excessive? */
+    if (len - 1 <= 0) {
+        return NULL;
+    }
+
+    p_dst = result = calloc(1, len);
+    p = string;
+
+    while (*p) {
+        if (*p == '%' && *(p + 1) && isdigit(*(p + 1))) {
+            i = *(p + 1) - '0';
+            if (match_data->nregs >= i && match_data->pmatch[i].rm_so != -1 &&
+                match_data->pmatch[i].rm_eo > match_data->pmatch[i].rm_so) {
+                /* rm_eo can be equal to rm_so, but then there is nothing to do */
+                int match_len = match_data->pmatch[i].rm_eo - match_data->pmatch[i].rm_so;
+                memcpy(p_dst, match_data->string + match_data->pmatch[i].rm_so, match_len);
+                p_dst += match_len;
+            }
+            p++;
+        } else {
+            *(p_dst) = *(p);
+            p_dst++;
+        }
+        p++;
+    }
+
+    return result;
 }

--- a/pengine/constraints.c
+++ b/pengine/constraints.c
@@ -53,7 +53,8 @@ enum pe_ordering get_flags(const char *id, enum pe_order_kind kind,
                            const char *action_first, const char *action_then, gboolean invert);
 enum pe_ordering get_asymmetrical_flags(enum pe_order_kind kind);
 static rsc_to_node_t *generate_location_rule(resource_t * rsc, xmlNode * rule_xml,
-                                             const char *discovery, pe_working_set_t * data_set);
+                                             const char *discovery, pe_working_set_t * data_set,
+                                             pe_re_match_data_t * match_data);
 
 gboolean
 unpack_constraints(xmlNode * xml_constraints, pe_working_set_t * data_set)
@@ -645,8 +646,8 @@ tag_to_set(xmlNode * xml_obj, xmlNode ** rsc_set, const char * attr,
     return TRUE;
 }
 
-gboolean unpack_rsc_location(xmlNode * xml_obj, resource_t * rsc_lh, const char * role,
-                             const char * score, pe_working_set_t * data_set);
+static gboolean unpack_rsc_location(xmlNode * xml_obj, resource_t * rsc_lh, const char * role,
+                             const char * score, pe_working_set_t * data_set, pe_re_match_data_t * match_data);
 
 static gboolean
 unpack_simple_location(xmlNode * xml_obj, pe_working_set_t * data_set)
@@ -657,7 +658,7 @@ unpack_simple_location(xmlNode * xml_obj, pe_working_set_t * data_set)
     if(value) {
         resource_t *rsc_lh = pe_find_constraint_resource(data_set->resources, value);
 
-        return unpack_rsc_location(xml_obj, rsc_lh, NULL, NULL, data_set);
+        return unpack_rsc_location(xml_obj, rsc_lh, NULL, NULL, data_set, NULL);
     }
 
     value = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE"-pattern");
@@ -680,19 +681,37 @@ unpack_simple_location(xmlNode * xml_obj, pe_working_set_t * data_set)
 
         for (rIter = data_set->resources; rIter; rIter = rIter->next) {
             resource_t *r = rIter->data;
-            int status = regexec(r_patt, r->id, 0, NULL, 0);
+            int nregs = 0;
+            regmatch_t *pmatch = NULL;
+            int status;
+
+            if(r_patt->re_nsub > 0) {
+                nregs = r_patt->re_nsub + 1;
+            } else {
+                nregs = 1;
+            }
+            pmatch = calloc(nregs, sizeof(regmatch_t));
+
+            status = regexec(r_patt, r->id, nregs, pmatch, 0);
 
             if(invert == FALSE && status == 0) {
+                pe_re_match_data_t match_data = {
+                                                .string = r->id,
+                                                .nregs = nregs,
+                                                .pmatch = pmatch
+                                               };
                 crm_debug("'%s' matched '%s' for %s", r->id, value, id);
-                unpack_rsc_location(xml_obj, r, NULL, NULL, data_set);
+                unpack_rsc_location(xml_obj, r, NULL, NULL, data_set, &match_data);
 
             } if(invert && status != 0) {
                 crm_debug("'%s' is an inverted match of '%s' for %s", r->id, value, id);
-                unpack_rsc_location(xml_obj, r, NULL, NULL, data_set);
+                unpack_rsc_location(xml_obj, r, NULL, NULL, data_set, NULL);
 
             } else {
                 crm_trace("'%s' does not match '%s' for %s", r->id, value, id);
             }
+
+            free(pmatch);
         }
 
         regfree(r_patt);
@@ -702,9 +721,9 @@ unpack_simple_location(xmlNode * xml_obj, pe_working_set_t * data_set)
     return FALSE;
 }
 
-gboolean
+static gboolean
 unpack_rsc_location(xmlNode * xml_obj, resource_t * rsc_lh, const char * role,
-                    const char * score, pe_working_set_t * data_set)
+                    const char * score, pe_working_set_t * data_set, pe_re_match_data_t * match_data)
 {
     gboolean empty = TRUE;
     rsc_to_node_t *location = NULL;
@@ -718,7 +737,7 @@ unpack_rsc_location(xmlNode * xml_obj, resource_t * rsc_lh, const char * role,
         crm_config_warn("No resource (con=%s, rsc=%s)", id, id_lh);
         return FALSE;
     }
-    
+
     if (score == NULL) {
         score = crm_element_value(xml_obj, XML_RULE_ATTR_SCORE);
     }
@@ -740,7 +759,7 @@ unpack_rsc_location(xmlNode * xml_obj, resource_t * rsc_lh, const char * role,
             if (crm_str_eq((const char *)rule_xml->name, XML_TAG_RULE, TRUE)) {
                 empty = FALSE;
                 crm_trace("Unpacking %s/%s", id, ID(rule_xml));
-                generate_location_rule(rsc_lh, rule_xml, discovery, data_set);
+                generate_location_rule(rsc_lh, rule_xml, discovery, data_set, match_data);
             }
         }
 
@@ -881,7 +900,7 @@ unpack_location_set(xmlNode * location, xmlNode * set, pe_working_set_t * data_s
     for (xml_rsc = __xml_first_child(set); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
         if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
             EXPAND_CONSTRAINT_IDREF(set_id, resource, ID(xml_rsc));
-            unpack_rsc_location(location, resource, role, local_score, data_set);
+            unpack_rsc_location(location, resource, role, local_score, data_set, NULL);
         }
     }
 
@@ -971,7 +990,8 @@ get_node_score(const char *rule, const char *score, gboolean raw, node_t * node)
 }
 
 static rsc_to_node_t *
-generate_location_rule(resource_t * rsc, xmlNode * rule_xml, const char *discovery, pe_working_set_t * data_set)
+generate_location_rule(resource_t * rsc, xmlNode * rule_xml, const char *discovery, pe_working_set_t * data_set,
+                       pe_re_match_data_t * match_data)
 {
     const char *rule_id = NULL;
     const char *score = NULL;
@@ -984,6 +1004,7 @@ generate_location_rule(resource_t * rsc, xmlNode * rule_xml, const char *discove
     gboolean do_and = TRUE;
     gboolean accept = TRUE;
     gboolean raw_score = TRUE;
+    gboolean score_allocated = FALSE;
 
     rsc_to_node_t *location_rule = NULL;
 
@@ -1018,6 +1039,18 @@ generate_location_rule(resource_t * rsc, xmlNode * rule_xml, const char *discove
     if (location_rule == NULL) {
         return NULL;
     }
+
+    if (match_data && match_data->nregs > 0 && match_data->pmatch[0].rm_so != -1) {
+        if (raw_score == FALSE) {
+            char *result = pe_expand_re_matches(score, match_data);
+
+            if (result) {
+                score = (const char *) result;
+                score_allocated = TRUE;
+            }
+        }
+    }
+
     if (role != NULL) {
         crm_trace("Setting role filter: %s", role);
         location_rule->role_filter = text2role(role);
@@ -1043,7 +1076,7 @@ generate_location_rule(resource_t * rsc, xmlNode * rule_xml, const char *discove
         int score_f = 0;
         node_t *node = (node_t *) gIter->data;
 
-        accept = test_rule(rule_xml, node->details->attrs, RSC_ROLE_UNKNOWN, data_set->now);
+        accept = pe_test_rule_re(rule_xml, node->details->attrs, RSC_ROLE_UNKNOWN, data_set->now, match_data);
 
         crm_trace("Rule %s %s on %s", ID(rule_xml), accept ? "passed" : "failed",
                   node->details->uname);
@@ -1079,6 +1112,10 @@ generate_location_rule(resource_t * rsc, xmlNode * rule_xml, const char *discove
             }
             free(delete);
         }
+    }
+
+    if (score_allocated == TRUE) {
+        free((char *)score);
     }
 
     location_rule->node_list_rh = match_L;

--- a/xml/constraints-2.6.rng
+++ b/xml/constraints-2.6.rng
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" 
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+      <ref name="element-constraints"/>
+  </start>
+
+  <define name="element-constraints">
+    <element name="constraints">
+      <zeroOrMore>
+        <choice>
+          <ref name="element-location"/>
+          <ref name="element-colocation"/>
+          <ref name="element-order"/>
+          <ref name="element-rsc_ticket"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="element-location">
+    <element name="rsc_location">
+      <attribute name="id"><data type="ID"/></attribute>
+      <choice>
+        <group>
+          <attribute name="rsc"><data type="IDREF"/></attribute>
+          <optional>
+            <attribute name="role">
+              <ref name="attribute-roles"/>
+            </attribute>
+          </optional>
+        </group>
+        <oneOrMore>
+          <ref name="element-resource-set"/>
+        </oneOrMore>
+      </choice>
+      <choice>
+        <group>
+          <externalRef href="score.rng"/>
+          <attribute name="node"><text/></attribute>
+        </group>
+        <oneOrMore>
+          <externalRef href="rule.rng"/>
+        </oneOrMore>
+      </choice>
+      <optional>
+        <ref name="element-lifetime"/>
+      </optional>
+      <optional>
+        <attribute name="resource-discovery">
+          <ref name="attribute-discovery"/>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+
+  <define name="element-resource-set">
+    <element name="resource_set">
+      <choice>
+        <attribute name="id-ref"><data type="IDREF"/></attribute>
+        <group>
+          <attribute name="id"><data type="ID"/></attribute>
+          <optional>
+            <attribute name="sequential"><data type="boolean"/></attribute>
+          </optional>
+          <optional>
+            <attribute name="require-all"><data type="boolean"/></attribute>
+          </optional>
+          <optional>
+            <attribute name="ordering">
+              <choice>
+                <value>group</value>
+                <value>listed</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="action">
+              <ref name="attribute-actions"/>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="role">
+              <ref name="attribute-roles"/>
+            </attribute>
+          </optional>
+          <optional>
+            <externalRef href="score.rng"/>
+          </optional>
+          <oneOrMore>
+            <element name="resource_ref">
+              <attribute name="id"><data type="IDREF"/></attribute>
+            </element>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+
+  <define name="element-colocation">
+    <element name="rsc_colocation">
+      <attribute name="id"><data type="ID"/></attribute>
+      <optional>
+        <choice>
+          <externalRef href="score.rng"/>
+          <attribute name="score-attribute"><text/></attribute>
+          <attribute name="score-attribute-mangle"><text/></attribute>
+        </choice>
+      </optional>
+      <optional>
+        <ref name="element-lifetime"/>
+      </optional>
+      <choice>
+        <oneOrMore>
+          <ref name="element-resource-set"/>
+        </oneOrMore>
+        <group>
+          <attribute name="rsc"><data type="IDREF"/></attribute>
+          <attribute name="with-rsc"><data type="IDREF"/></attribute>
+          <optional>
+            <attribute name="node-attribute"><text/></attribute>
+          </optional>
+          <optional>
+            <attribute name="rsc-role">
+              <ref name="attribute-roles"/>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="with-rsc-role">
+              <ref name="attribute-roles"/>
+            </attribute>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+
+  <define name="element-order">
+    <element name="rsc_order">
+      <attribute name="id"><data type="ID"/></attribute>
+      <optional>
+        <ref name="element-lifetime"/>
+      </optional>
+      <optional>
+        <attribute name="symmetrical"><data type="boolean"/></attribute>
+      </optional>
+      <optional>
+        <attribute name="require-all"><data type="boolean"/></attribute>
+      </optional>
+      <optional>
+        <choice>
+          <externalRef href="score.rng"/>
+          <attribute name="kind">
+            <ref name="order-types"/>
+          </attribute>
+        </choice>
+      </optional>
+      <choice>
+        <oneOrMore>
+          <ref name="element-resource-set"/>
+        </oneOrMore>
+        <group>
+          <attribute name="first"><data type="IDREF"/></attribute>
+          <attribute name="then"><data type="IDREF"/></attribute>
+          <optional>
+            <attribute name="first-action">
+              <ref name="attribute-actions"/>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="then-action">
+              <ref name="attribute-actions"/>
+            </attribute>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+ 
+  <define name="element-rsc_ticket">
+    <element name="rsc_ticket">
+      <attribute name="id"><data type="ID"/></attribute>
+      <choice>
+        <oneOrMore>
+          <ref name="element-resource-set"/>
+        </oneOrMore>
+        <group>
+          <attribute name="rsc"><data type="IDREF"/></attribute>
+          <optional>
+            <attribute name="rsc-role">
+              <ref name="attribute-roles"/>
+            </attribute>
+          </optional>
+        </group>
+      </choice>
+      <attribute name="ticket"><text/></attribute>
+      <optional>
+        <attribute name="loss-policy">
+          <choice>
+            <value>stop</value>
+            <value>demote</value>
+            <value>fence</value>
+            <value>freeze</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+
+  <define name="attribute-discovery">
+    <choice>
+      <value>always</value>
+      <value>never</value>
+      <value>exclusive</value>
+    </choice>
+  </define>
+
+  <define name="attribute-actions">
+    <choice>
+      <value>start</value>
+      <value>promote</value>
+      <value>demote</value>
+      <value>stop</value>
+    </choice>
+  </define>
+      
+  <define name="attribute-roles">
+    <choice>
+      <value>Stopped</value>
+      <value>Started</value>
+      <value>Master</value>
+      <value>Slave</value>
+    </choice>
+  </define>
+
+  <define name="order-types">
+    <choice>
+      <value>Optional</value>
+      <value>Mandatory</value>
+      <value>Serialize</value>
+    </choice>
+  </define>
+
+  <define name="element-lifetime">
+    <element name="lifetime">
+      <oneOrMore>
+        <externalRef href="rule.rng"/>
+      </oneOrMore>
+    </element>
+  </define>
+  
+</grammar>

--- a/xml/constraints-2.6.rng
+++ b/xml/constraints-2.6.rng
@@ -23,7 +23,10 @@
       <attribute name="id"><data type="ID"/></attribute>
       <choice>
         <group>
-          <attribute name="rsc"><data type="IDREF"/></attribute>
+          <choice>
+            <attribute name="rsc"><data type="IDREF"/></attribute>
+            <attribute name="rsc-pattern"><text/></attribute>
+          </choice>
           <optional>
             <attribute name="role">
               <ref name="attribute-roles"/>


### PR DESCRIPTION
It was already possible to use regexp in a resource name location applies to.
Now it is also possible to use sed-like %0 - %9 references in both
score-attribute and rule expression to construct attribute names.
(% is used instead of \ to make crmsh almost happy).

Also, fix rsc_pattern is missing from constraints rng ecept constraints-next.