### PR TITLE
Allow unit names ending in .socket.

### DIFF
--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -114,6 +114,9 @@ systemd_service_name(const char *name)
 
     } else if (strstr(name, ".service")) {
         return strdup(name);
+
+    } else if (strstr(name, ".socket")) {
+        return strdup(name);
     }
 
     return crm_strdup_printf("%s.service", name);


### PR DESCRIPTION
I've been trying to manage a `name.socket` unit, but the existing code translates this to `name.socket.service`. This change fixes that.