### PR TITLE
Print with "the_rsc->long_name" instead of "rsc"

### DIFF
--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -34,7 +34,7 @@ do_find_resource(const char *rsc, resource_t * the_rsc, pe_working_set_t * data_
     for (lpc = the_rsc->running_on; lpc != NULL; lpc = lpc->next) {
         node_t *node = (node_t *) lpc->data;
 
-        crm_trace("resource %s is running on: %s", rsc, node->details->uname);
+        crm_trace("resource %s is running on: %s", the_rsc->long_name, node->details->uname);
         if (BE_QUIET) {
             fprintf(stdout, "%s\n", node->details->uname);
         } else {
@@ -43,14 +43,14 @@ do_find_resource(const char *rsc, resource_t * the_rsc, pe_working_set_t * data_
             if (the_rsc->variant < pe_clone && the_rsc->fns->state(the_rsc, TRUE) == RSC_ROLE_MASTER) {
                 state = "Master";
             }
-            fprintf(stdout, "resource %s is running on: %s %s\n", rsc, node->details->uname, state);
+            fprintf(stdout, "resource %s is running on: %s %s\n", the_rsc->long_name, node->details->uname, state);
         }
 
         found++;
     }
 
     if (BE_QUIET == FALSE && found == 0) {
-        fprintf(stderr, "resource %s is NOT running\n", rsc);
+        fprintf(stderr, "resource %s is NOT running\n", the_rsc->long_name);
     }
 
     return found;


### PR DESCRIPTION
This fixes an ambiguity problem seen when you start with:

    Master/Slave Set: resourceName
        Masters: [ node0 ]
        Slaves: [ node1 ]

and then one node is then brought down:

    Master/Slave Set: resourceName
        Masters: [ node0 ]
        Stopped: [ id:1 ]

The fix makes it such that if you run `crm_resource -r resourceName -W` it will output:

    resource resourceName:id:0 is running on: node0 Master
    resource resourceName:id:1 is NOT running

instead of this (ambiguous & confusing):

    resource resourceName is running on: node0 Master
    resource resourceName is NOT running