### PR TITLE
Feature: add versioned parameters support

### DIFF
--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -628,9 +628,18 @@ build_parameter_list(lrmd_event_data_t *op, xmlNode *metadata, xmlNode *result,
 
             if(result && accept) {
                 value = g_hash_table_lookup(op->params, name);
+
                 if(value != NULL) {
-                    crm_trace("Adding attr %s=%s to the xml result", name, value);
-                    crm_xml_add(result, name, value);
+                    char *summary = crm_versioned_param_summary(op->versioned_params, name);
+
+                    if (summary) {
+                        crm_trace("Adding attr %s=%s to the xml result", name, summary);
+                        crm_xml_add(result, name, summary);
+                        free(summary);
+                    } else {
+                        crm_trace("Adding attr %s=%s to the xml result", name, value);
+                        crm_xml_add(result, name, value);
+                    }
                 }
             }
         }
@@ -1789,6 +1798,7 @@ construct_op(lrm_state_t * lrm_state, xmlNode * rsc_op, const char *rsc_id, cons
     const char *op_timeout = NULL;
     const char *op_interval = NULL;
     GHashTable *params = NULL;
+    xmlNode *versioned_params = NULL;
 
     const char *transition = NULL;
 
@@ -1823,6 +1833,14 @@ construct_op(lrm_state_t * lrm_state, xmlNode * rsc_op, const char *rsc_id, cons
 
     params = xml2list(rsc_op);
     g_hash_table_remove(params, CRM_META "_op_target_rc");
+    
+    if (!is_remote_lrmd_ra(NULL, NULL, rsc_id)) {
+        xmlNode *ptr = first_named_child(rsc_op, XML_TAG_VER_ATTRS);
+        
+        if (ptr) {
+            versioned_params = copy_xml(ptr);
+        }
+    }
 
     op_delay = crm_meta_value(params, XML_OP_ATTR_START_DELAY);
     op_timeout = crm_meta_value(params, XML_ATTR_TIMEOUT);
@@ -1834,6 +1852,7 @@ construct_op(lrm_state_t * lrm_state, xmlNode * rsc_op, const char *rsc_id, cons
 
     if (safe_str_neq(operation, RSC_STOP)) {
         op->params = params;
+        op->versioned_params = versioned_params;
 
     } else {
         rsc_history_t *entry = g_hash_table_lookup(lrm_state->resource_history, rsc_id);
@@ -1842,6 +1861,7 @@ construct_op(lrm_state_t * lrm_state, xmlNode * rsc_op, const char *rsc_id, cons
          * whatever we are given */
         if (!entry || !entry->stop_params) {
             op->params = params;
+            op->versioned_params = versioned_params;
         } else {
             /* Copy the cached parameter list so that we stop the resource
              * with the old attributes, not the new ones */
@@ -1852,6 +1872,17 @@ construct_op(lrm_state_t * lrm_state, xmlNode * rsc_op, const char *rsc_id, cons
             g_hash_table_foreach(entry->stop_params, copy_instance_keys, op->params);
             g_hash_table_destroy(params);
             params = NULL;
+            
+            op->versioned_params = NULL;
+            free_xml(versioned_params);
+        }
+    }
+
+    if (op->versioned_params) {
+        char *versioned_params_text = dump_xml_unformatted(op->versioned_params);
+
+        if (versioned_params_text) {
+            g_hash_table_insert(op->params, strdup("#" XML_TAG_VER_ATTRS), versioned_params_text);
         }
     }
 

--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -237,6 +237,10 @@ typedef struct lrmd_event_data_s {
     /*! exit failure reason string from resource agent operation */
     const char *exit_reason;
 
+    /* This is an xmlNode containing the versioned parameters
+     * that should be evaluated */
+    xmlNode *versioned_params;
+
 } lrmd_event_data_t;
 
 lrmd_event_data_t *lrmd_copy_event(lrmd_event_data_t * event);

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -176,6 +176,7 @@
 #  define XML_TAG_ATTR_SETS	   	"instance_attributes"
 #  define XML_TAG_META_SETS	   	"meta_attributes"
 #  define XML_TAG_ATTRS			"attributes"
+#  define XML_TAG_VER_ATTRS		"versioned_attributes"
 #  define XML_TAG_PARAMS		"parameters"
 #  define XML_TAG_PARAM			"param"
 #  define XML_TAG_UTILIZATION		"utilization"

--- a/include/crm/pengine/complex.h
+++ b/include/crm/pengine/complex.h
@@ -56,6 +56,9 @@ void get_meta_attributes(GHashTable * meta_hash, resource_t * rsc, node_t * node
 void get_rsc_attributes(GHashTable * meta_hash, resource_t * rsc, node_t * node,
                         pe_working_set_t * data_set);
 
+void pe_get_versioned_attributes(xmlNode * meta_hash, resource_t * rsc, node_t * node,
+                                 pe_working_set_t * data_set);
+
 typedef struct resource_alloc_functions_s resource_alloc_functions_t;
 
 gboolean is_parent(resource_t *child, resource_t *rsc);

--- a/include/crm/pengine/rules.h
+++ b/include/crm/pengine/rules.h
@@ -30,7 +30,8 @@ enum expression_type {
     attr_expr,
     loc_expr,
     role_expr,
-    time_expr
+    time_expr,
+    version_expr
 };
 
 typedef struct pe_re_match_data {
@@ -57,6 +58,9 @@ gboolean pe_test_expression_re(xmlNode * expr, GHashTable * node_hash,
 void unpack_instance_attributes(xmlNode * top, xmlNode * xml_obj, const char *set_name,
                                 GHashTable * node_hash, GHashTable * hash,
                                 const char *always_first, gboolean overwrite, crm_time_t * now);
+
+void pe_unpack_versioned_attributes(xmlNode * top, xmlNode * xml_obj, const char *set_name,
+                                    GHashTable * node_hash, xmlNode * hash, crm_time_t * now);
 
 char *pe_expand_re_matches(const char *string, pe_re_match_data_t * match_data);
 

--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -301,6 +301,8 @@ struct resource_s {
     int remote_reconnect_interval;
 
     pe_working_set_t *cluster;
+    
+    xmlNode *versioned_parameters;
 };
 
 struct pe_action_s {

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -375,4 +375,6 @@ void remote_proxy_end_session(const char *session);
 void remote_proxy_free(gpointer data);
 int  remote_proxy_check(lrmd_t * lrmd, GHashTable *hash);
 
+char* crm_versioned_param_summary(xmlNode *versioned_params, const char *name);
+void crm_summarize_versioned_params(xmlNode *param_set, xmlNode *versioned_params);
 #endif                          /* CRM_INTERNAL__H */

--- a/lib/common/digest.c
+++ b/lib/common/digest.c
@@ -240,3 +240,69 @@ crm_digest_verify(xmlNode *input, const char *expected)
     free(calculated);
     return passed;
 }
+
+char*
+crm_versioned_param_summary(xmlNode *versioned_params, const char *name)
+{
+    xmlNode *attrs = NULL;
+    xmlNode *attr = NULL;
+    char *summary = NULL;
+    gboolean found = FALSE;
+
+    if (!name) {
+        return NULL;
+    }
+
+    for (attrs = __xml_first_child(versioned_params); attrs != NULL; attrs = __xml_next_element(attrs)) {
+        for (attr = __xml_first_child(attrs); attr != NULL; attr = __xml_next_element(attr)) {
+            if (safe_str_eq((const char*) attr->name, XML_TAG_RULE)) {
+                const char *boolean_op = crm_element_value(attr, XML_RULE_ATTR_BOOLEAN_OP);
+                xmlNode *expr = NULL;
+
+                if (boolean_op == NULL) {
+                    boolean_op = "and";
+                }
+                summary = add_list_element(summary, boolean_op);
+
+                for (expr = __xml_first_child(attr); expr != NULL; expr = __xml_next_element(expr)) {
+                    summary = add_list_element(summary, crm_element_value(expr, XML_EXPR_ATTR_OPERATION));
+                    summary = add_list_element(summary, crm_element_value(expr, XML_EXPR_ATTR_VALUE));
+                }
+            } else if (safe_str_eq(crm_element_value(attr, XML_NVPAIR_ATTR_NAME), name)) {
+                found = TRUE;
+                summary = add_list_element(summary, crm_element_value(attr, XML_NVPAIR_ATTR_VALUE));
+                break;
+            }
+        }
+    }
+
+    if (!found) {
+        free(summary);
+        return NULL;
+    }
+
+    return summary;
+}
+
+void
+crm_summarize_versioned_params(xmlNode *param_set, xmlNode *versioned_params)
+{
+    xmlNode *attrs = NULL;
+    xmlNode *attr = NULL;
+
+    if (!param_set) {
+        return;
+    }
+
+    for (attrs = __xml_first_child(versioned_params); attrs != NULL; attrs = __xml_next_element(attrs)) {
+        for (attr = __xml_first_child(attrs); attr != NULL; attr = __xml_next_element(attr)) {
+            const char *attr_name = crm_element_value(attr, XML_NVPAIR_ATTR_NAME);
+
+            if (attr_name) {
+                char *summary = crm_versioned_param_summary(versioned_params, attr_name);
+                crm_xml_replace(param_set, attr_name, summary);
+                free(summary);
+            }
+        }
+    }
+}

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -1715,6 +1715,7 @@ append_digest(lrmd_event_data_t * op, xmlNode * update, const char *version, con
     args_xml = create_xml_node(NULL, XML_TAG_PARAMS);
     g_hash_table_foreach(op->params, hash2field, args_xml);
     filter_action_parameters(args_xml, version);
+    crm_summarize_versioned_params(args_xml, op->versioned_params);
     digest = calculate_operation_digest(args_xml, version);
 
 #if 0

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -220,6 +220,10 @@ lrmd_copy_event(lrmd_event_data_t * event)
         }
     }
 
+    if (event->versioned_params) {
+        copy->versioned_params = copy_xml(event->versioned_params);
+    }
+
     return copy;
 }
 
@@ -239,6 +243,9 @@ lrmd_free_event(lrmd_event_data_t * event)
     free((char *)event->remote_nodename);
     if (event->params) {
         g_hash_table_destroy(event->params);
+    }
+    if (event->versioned_params) {
+        free_xml(event->versioned_params);
     }
     free(event);
 }
@@ -290,6 +297,7 @@ lrmd_dispatch_internal(lrmd_t * lrmd, xmlNode * msg)
         event.type = lrmd_event_exec_complete;
 
         event.params = xml2list(msg);
+        event.versioned_params = first_named_child(msg, XML_TAG_VER_ATTRS); 
     } else if (crm_str_eq(type, LRMD_OP_NEW_CLIENT, TRUE)) {
         event.type = lrmd_event_new_client;
     } else if (crm_str_eq(type, LRMD_OP_POKE, TRUE)) {
@@ -1991,6 +1999,7 @@ lrmd_api_exec(lrmd_t * lrmd, const char *rsc_id, const char *action, const char 
     xmlNode *data = create_xml_node(NULL, F_LRMD_RSC);
     xmlNode *args = create_xml_node(data, XML_TAG_ATTRS);
     lrmd_key_value_t *tmp = NULL;
+    const char *versioned_args_key = "#" XML_TAG_VER_ATTRS;
 
     crm_xml_add(data, F_LRMD_ORIGIN, __FUNCTION__);
     crm_xml_add(data, F_LRMD_RSC_ID, rsc_id);
@@ -2001,7 +2010,15 @@ lrmd_api_exec(lrmd_t * lrmd, const char *rsc_id, const char *action, const char 
     crm_xml_add_int(data, F_LRMD_RSC_START_DELAY, start_delay);
 
     for (tmp = params; tmp; tmp = tmp->next) {
-        hash2smartfield((gpointer) tmp->key, (gpointer) tmp->value, args);
+        if (safe_str_eq(tmp->key, versioned_args_key)) {
+            xmlNode *versioned_args = string2xml(tmp->value);
+
+            if (versioned_args) {
+                add_node_nocopy(data, NULL, versioned_args);
+            }
+        } else {
+            hash2smartfield((gpointer) tmp->key, (gpointer) tmp->value, args);
+        }
     }
 
     rc = lrmd_send_command(lrmd, LRMD_OP_RSC_EXEC, data, NULL, timeout, options, TRUE);

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -173,6 +173,30 @@ get_rsc_attributes(GHashTable * meta_hash, resource_t * rsc,
     }
 }
 
+void
+pe_get_versioned_attributes(xmlNode * meta_hash, resource_t * rsc,
+                            node_t * node, pe_working_set_t * data_set)
+{
+    GHashTable *node_hash = NULL;
+
+    if (node) {
+        node_hash = node->details->attrs;
+    }
+
+    pe_unpack_versioned_attributes(data_set->input, rsc->xml, XML_TAG_ATTR_SETS, node_hash,
+                                   meta_hash, data_set->now);
+
+    /* set anything else based on the parent */
+    if (rsc->parent != NULL) {
+        pe_get_versioned_attributes(meta_hash, rsc->parent, node, data_set);
+
+    } else {
+        /* and finally check the defaults */
+        pe_unpack_versioned_attributes(data_set->input, data_set->rsc_defaults, XML_TAG_ATTR_SETS,
+                                       node_hash, meta_hash, data_set->now);
+    }
+}
+
 static char *
 template_op_key(xmlNode * op)
 {
@@ -437,6 +461,8 @@ common_unpack(xmlNode * xml_obj, resource_t ** rsc,
     (*rsc)->parameters =
         g_hash_table_new_full(crm_str_hash, g_str_equal, g_hash_destroy_str, g_hash_destroy_str);
 
+    (*rsc)->versioned_parameters = create_xml_node(NULL, XML_TAG_VER_ATTRS);
+
     (*rsc)->meta =
         g_hash_table_new_full(crm_str_hash, g_str_equal, g_hash_destroy_str, g_hash_destroy_str);
 
@@ -459,6 +485,7 @@ common_unpack(xmlNode * xml_obj, resource_t ** rsc,
 
     get_meta_attributes((*rsc)->meta, *rsc, NULL, data_set);
     get_rsc_attributes((*rsc)->parameters, *rsc, NULL, data_set);
+    pe_get_versioned_attributes((*rsc)->versioned_parameters, *rsc, NULL, data_set);
 
     (*rsc)->flags = 0;
     set_bit((*rsc)->flags, pe_rsc_runnable);
@@ -807,6 +834,9 @@ common_free(resource_t * rsc)
 
     if (rsc->parameters != NULL) {
         g_hash_table_destroy(rsc->parameters);
+    }
+    if (rsc->versioned_parameters != NULL) {
+        free_xml(rsc->versioned_parameters);
     }
     if (rsc->meta != NULL) {
         g_hash_table_destroy(rsc->meta);

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1926,6 +1926,7 @@ rsc_action_digest_cmp(resource_t * rsc, xmlNode * xml_op, node_t * node,
     op_digest_cache_t *data = NULL;
 
     GHashTable *local_rsc_params = NULL;
+    xmlNode *local_versioned_params = NULL;
 
     action_t *action = NULL;
     char *key = NULL;
@@ -1964,12 +1965,16 @@ rsc_action_digest_cmp(resource_t * rsc, xmlNode * xml_op, node_t * node,
     local_rsc_params = g_hash_table_new_full(crm_str_hash, g_str_equal,
                                              g_hash_destroy_str, g_hash_destroy_str);
     get_rsc_attributes(local_rsc_params, rsc, node, data_set);
+    local_versioned_params = create_xml_node(NULL, XML_TAG_VER_ATTRS);
+    pe_get_versioned_attributes(local_versioned_params, rsc, node, data_set);
     data->params_all = create_xml_node(NULL, XML_TAG_PARAMS);
     g_hash_table_foreach(local_rsc_params, hash2field, data->params_all);
     g_hash_table_foreach(action->extra, hash2field, data->params_all);
     g_hash_table_foreach(rsc->parameters, hash2field, data->params_all);
     g_hash_table_foreach(action->meta, hash2metafield, data->params_all);
     filter_action_parameters(data->params_all, op_version);
+    crm_summarize_versioned_params(data->params_all, rsc->versioned_parameters);
+    crm_summarize_versioned_params(data->params_all, local_versioned_params);
 
     data->digest_all_calc = calculate_operation_digest(data->params_all, op_version);
 
@@ -2005,6 +2010,7 @@ rsc_action_digest_cmp(resource_t * rsc, xmlNode * xml_op, node_t * node,
 
     g_hash_table_insert(node->details->digest_cache, strdup(op_id), data);
     g_hash_table_destroy(local_rsc_params);
+    free_xml(local_versioned_params);
     pe_free_action(action);
 
     return data;

--- a/lrmd/Makefile.am
+++ b/lrmd/Makefile.am
@@ -35,7 +35,9 @@ lrmd_LDFLAGS		= $(LDFLAGS_HARDENED_EXE)
 
 lrmd_LDADD		= $(top_builddir)/lib/common/libcrmcommon.la	\
 			$(top_builddir)/lib/services/libcrmservice.la	\
-			$(top_builddir)/lib/fencing/libstonithd.la ${COMPAT_LIBS}
+			$(top_builddir)/lib/lrmd/liblrmd.la		\
+			$(top_builddir)/lib/fencing/libstonithd.la	\
+			$(top_builddir)/lib/pengine/libpe_rules.la ${COMPAT_LIBS}
 lrmd_SOURCES		= main.c lrmd.c
 
 pacemaker_remoted_CPPFLAGS	= -DSUPPORT_REMOTE $(AM_CPPFLAGS)

--- a/lrmd/lrmd.c
+++ b/lrmd/lrmd.c
@@ -28,6 +28,7 @@
 #include <crm/common/ipc.h>
 #include <crm/common/ipcs.h>
 #include <crm/msg_xml.h>
+#include <crm/pengine/rules.h>
 
 #include <lrmd_private.h>
 
@@ -38,6 +39,8 @@
 #define EXIT_REASON_MAX_LEN 128
 
 GHashTable *rsc_list = NULL;
+regex_t *version_format_regex = NULL;
+GHashTable *ra_version_hash = NULL;
 
 typedef struct lrmd_cmd_s {
     int timeout;
@@ -87,6 +90,7 @@ typedef struct lrmd_cmd_s {
     int last_pid;
 
     GHashTable *params;
+    xmlNode *versioned_attrs;
 } lrmd_cmd_t;
 
 static void cmd_finalize(lrmd_cmd_t * cmd, lrmd_rsc_t * rsc);
@@ -160,6 +164,97 @@ build_rsc_from_xml(xmlNode * msg)
     return rsc;
 }
 
+static void
+dup_attr(gpointer key, gpointer value, gpointer user_data)
+{
+    g_hash_table_replace(user_data, strdup(key), strdup(value));
+}
+
+static gboolean
+valid_version_format(const char *version)
+{
+    if (version == NULL) {
+        return FALSE;
+    }
+
+    if (version_format_regex == NULL) {
+        const char *regex_string = "^[[:digit:]]+([.][[:digit:]]+)*$";
+        version_format_regex = calloc(1, sizeof(regex_t));
+        regcomp(version_format_regex, regex_string, REG_EXTENDED);
+    }
+
+    return regexec(version_format_regex, version, 0, NULL, 0) == 0;
+}
+
+static const char*
+get_ra_version(const char *class, const char *provider, const char *type, gboolean update_hash)
+{
+    int len = 0;
+    char *key = NULL;
+    static const char *default_version = "0.1";
+    const char *version = NULL;
+
+    CRM_CHECK(type != NULL, return default_version);
+    CRM_CHECK(class != NULL, return default_version);
+
+    if (!provider) {
+        provider = "heartbeat";
+    }
+    
+    len = strlen(class) + strlen(provider) + strlen(type) + 3;
+    key = calloc(len, sizeof(char));
+
+    if (!key) {
+        return default_version;
+    }
+    
+    if (!ra_version_hash) {
+        ra_version_hash = g_hash_table_new_full(crm_str_hash, g_str_equal, g_hash_destroy_str, g_hash_destroy_str);
+    }
+
+    snprintf(key, len, "%s:%s:%s", class, provider, type);
+
+    version = g_hash_table_lookup(ra_version_hash, key);
+
+    if (!version || update_hash) {
+        char *metadata = NULL;
+        lrmd_t *lrmd = lrmd_api_new();
+
+        lrmd->cmds->get_metadata(lrmd, class, provider, type, &metadata, 0);
+        lrmd_api_delete(lrmd);
+
+        if (metadata) {
+            xmlNode *metadata_xml = string2xml(metadata);
+            xmlNode *version_xml = get_xpath_object("//resource-agent/@version", metadata_xml, LOG_TRACE);
+
+            if (version_xml) {
+                version = crm_element_value(version_xml, XML_ATTR_VERSION);
+
+                if (valid_version_format(version)) {
+                    crm_info("Resource agent version for %s:%s:%s is %s", class, provider, type, version);
+                    version = strdup(version);
+                    g_hash_table_replace(ra_version_hash, strdup(key), (gpointer) version);
+                } else {
+                    crm_notice("Resource agent version for %s:%s:%s has unrecognized format: %s", class, provider, type, version);
+                    version = default_version;
+                }
+            } else {
+                crm_trace("Resource agent version for %s:%s:%s does not specified", class, provider, type);
+                version = default_version;
+            }
+
+            free_xml(metadata_xml);
+            free(metadata);
+        } else {
+            version = default_version;
+        }
+    }
+
+    free(key);
+
+    return version;
+}
+
 static lrmd_cmd_t *
 create_lrmd_cmd(xmlNode * msg, crm_client_t * client, lrmd_rsc_t *rsc)
 {
@@ -185,6 +280,23 @@ create_lrmd_cmd(xmlNode * msg, crm_client_t * client, lrmd_rsc_t *rsc)
     cmd->rsc_id = crm_element_value_copy(rsc_xml, F_LRMD_RSC_ID);
 
     cmd->params = xml2list(rsc_xml);
+
+    cmd->versioned_attrs = first_named_child(rsc_xml, XML_TAG_VER_ATTRS);
+
+    if (cmd->versioned_attrs) {
+        const char *ra_version = get_ra_version(rsc->class, rsc->provider, rsc->type, safe_str_eq(cmd->action, "start"));
+        GHashTable *node_hash = g_hash_table_new_full(crm_str_hash, g_str_equal, g_hash_destroy_str, g_hash_destroy_str);
+        GHashTable *hash = g_hash_table_new_full(crm_str_hash, g_str_equal, g_hash_destroy_str, g_hash_destroy_str);
+
+        cmd->versioned_attrs = copy_xml(cmd->versioned_attrs);
+        g_hash_table_insert(node_hash, strdup("#ra-version"), strdup(ra_version));
+        unpack_instance_attributes(NULL, cmd->versioned_attrs, XML_TAG_ATTR_SETS, node_hash, hash, NULL, FALSE, NULL);
+        g_hash_table_foreach(hash, dup_attr, cmd->params);
+
+        g_hash_table_destroy(node_hash);
+        g_hash_table_destroy(hash);
+    }
+
     cmd->isolation_wrapper = g_hash_table_lookup(cmd->params, "CRM_meta_isolation_wrapper");
 
     if (cmd->isolation_wrapper) {
@@ -216,6 +328,9 @@ free_lrmd_cmd(lrmd_cmd_t * cmd)
     }
     if (cmd->params) {
         g_hash_table_destroy(cmd->params);
+    }
+    if (cmd->versioned_attrs) {
+        free_xml(cmd->versioned_attrs);
     }
     free(cmd->origin);
     free(cmd->action);
@@ -534,7 +649,11 @@ send_cmd_complete_notify(lrmd_cmd_t * cmd)
             hash2smartfield((gpointer) key, (gpointer) value, args);
         }
     }
-
+    
+    if (cmd->versioned_attrs) {
+        add_node_copy(notify, cmd->versioned_attrs);
+    }
+    
     if (cmd->client_id && (cmd->call_opts & lrmd_opt_notify_orig_only)) {
         crm_client_t *client = crm_client_get_by_id(cmd->client_id);
 
@@ -1165,12 +1284,6 @@ lrmd_rsc_execute_stonith(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
   cleanup_stonith_exec:
     stonith_action_complete(cmd, rc);
     return rc;
-}
-
-static void
-dup_attr(gpointer key, gpointer value, gpointer user_data)
-{
-    g_hash_table_replace(user_data, strdup(key), strdup(value));
 }
 
 static int

--- a/lrmd/lrmd_private.h
+++ b/lrmd/lrmd_private.h
@@ -21,6 +21,7 @@
 #  define LRMD_PVT__H
 
 #  include <glib.h>
+#  include <regex.h>
 #  include <crm/common/ipcs.h>
 #  include <crm/lrmd.h>
 #  include <crm/stonith-ng.h>
@@ -33,6 +34,8 @@
 #define LRMD_ISOLATION_PROVIDER ".isolation"
 
 GHashTable *rsc_list;
+extern regex_t *version_format_regex;
+extern GHashTable *ra_version_hash;
 
 typedef struct lrmd_rsc_s {
     char *rsc_id;

--- a/lrmd/main.c
+++ b/lrmd/main.c
@@ -280,6 +280,13 @@ lrmd_exit(gpointer data)
     if (ipcs) {
         mainloop_del_ipc_server(ipcs);
     }
+    if (version_format_regex) {
+        regfree(version_format_regex);
+        free(version_format_regex);
+    }
+    if (ra_version_hash) {
+        g_hash_table_destroy(ra_version_hash);
+    }
 
 #ifdef ENABLE_PCMK_REMOTE
     lrmd_tls_server_destroy();

--- a/pengine/graph.c
+++ b/pengine/graph.c
@@ -1019,13 +1019,24 @@ action2xml(action_t * action, gboolean as_input, pe_working_set_t *data_set)
     g_hash_table_foreach(action->extra, hash2field, args_xml);
     if (action->rsc != NULL && action->node) {
         GHashTable *p = g_hash_table_new_full(crm_str_hash, g_str_equal, g_hash_destroy_str, g_hash_destroy_str);
+        xmlNode *versioned_parameters = create_xml_node(NULL, XML_TAG_VER_ATTRS);
 
         get_rsc_attributes(p, action->rsc, action->node, data_set);
         g_hash_table_foreach(p, hash2smartfield, args_xml);
 
+        pe_get_versioned_attributes(versioned_parameters, action->rsc, action->node, data_set);
+        if (xml_has_children(versioned_parameters)) {
+            add_node_copy(action_xml, versioned_parameters);
+        }
+
         g_hash_table_destroy(p);
+        free_xml(versioned_parameters);
     } else if(action->rsc && action->rsc->variant <= pe_native) {
         g_hash_table_foreach(action->rsc->parameters, hash2smartfield, args_xml);
+        
+        if (xml_has_children(action->rsc->versioned_parameters)) {
+            add_node_copy(action_xml, action->rsc->versioned_parameters);
+        }
     }
 
     g_hash_table_foreach(action->meta, hash2metafield, args_xml);


### PR DESCRIPTION
Here is the implementation of the feature we have discussed in [#1001](https://github.com/ClusterLabs/pacemaker/pull/1001).

Similar to lib/pengine/rules.c:unpack_instance_attributes() I've created unpack_versioned_attributes() which evaluates non-versioned expressions in rules and does not touch versioned ones. It ends up with XML which is included in the message to LRMd.

So, following your example
```
<primitive id="A" class="ocf" type="myRA" provider="me">
    <instance_attributes id="ia01" score="3">
        <rule id="ia01-r01" score="INFINITY" >
             <expression id="ia01-r01-e01" type=version attribute="#ra-version"
                 operation="gt" value="1.0"/>
        </rule>
        <nvpair id="ia01-nv02" name="super-new-param" value="10"/>
    </instance_attributes>
    <instance_attributes id="ia02" score="2">
        <rule id="ia02-r01" score="INFINITY" >
             <expression id="ia02-r01-e01" type=version attribute="#ra-version"
                 operation="lte" value="1.0"/>
        </rule>
        <nvpair id="ia02-nv02" name="really-old-param" value="5"/>
    </instance_attributes>
    <instance_attributes id="ia03" score="1">
        <nvpair id="ia02-nv01" name="widget" value="1"/>
    </instance_attributes>
</primitive>
```
LRMd will receive such XML:

```
<versioned_attributes>
	<instance_attributes id="ia01" score="3">
        <rule id="ia01-r01" score="INFINITY" >
             <expression id="ia01-r01-e01" type=version attribute="#ra-version"
                 operation="gt" value="1.0"/>
        </rule>
        <nvpair id="ia01-nv02" name="super-new-param" value="10"/>
    </instance_attributes>
    <instance_attributes id="ia02" score="2">
        <rule id="ia02-r01" score="INFINITY" >
             <expression id="ia02-r01-e01" type=version attribute="#ra-version"
                 operation="lte" value="1.0"/>
        </rule>
        <nvpair id="ia02-nv02" name="really-old-param" value="5"/>
    </instance_attributes>
</versioned_attributes>
```
I've decided not to change representation of the attributes to be able to reuse unpack_instance_attributes() function in LRMd  when ra-version is known.

When unpack_instance_attributes() is called and resource contains versioned params, PE only evaluates them if node_hash with ra-version is available, otherwise they are never added to the hash.

When unpack_versioned_attributes() is called PE pretends that all versioned expressions have passed the test in order to evaluate other expressions in the rule and not to add improper rules to the versioned_attributes XML.

