### PR TITLE
Low: crmd: Change desc of alert of the fencing.

### DIFF
--- a/crmd/notify.c
+++ b/crmd/notify.c
@@ -746,9 +746,9 @@ crmd_notify_fencing_op(stonith_event_t * e)
     }
 
     desc = crm_strdup_printf(
-        "Operation %s requested by %s for peer %s: %s (ref=%s)",
-        e->operation, e->origin, e->target, pcmk_strerror(e->result),
-        e->id);
+        "Operation %s of %s by %s for %s@%s: %s (ref=%s)",
+        e->action, e->target, e->executioner ? e->executioner : "<no-one>",
+        e->client_origin, e->origin, pcmk_strerror(e->result), e->id);
 
     set_alert_key(CRM_notify_node, e->target);
     set_alert_key(CRM_notify_task, e->operation);


### PR DESCRIPTION
Hi All,

I referred to fencing/remote.c.
 * https://github.com/HideoYamauchi/pacemaker/blob/change_alert_desc/fencing/remote.c#L509

I included action and delegate in content of desc of fencing in the same way.


The present trap.
```
May 30 14:26:23 snmp-manager snmptrapd[32068]: 2016-05-30 14:26:23 
pgsr02 [UDP: [192.168.100.177]:57155->[192.168.100.189]:162]:
(snip)
PACEMAKER-MIB::pacemakerNotificationOperation = STRING: "st_notify_fence"       
PACEMAKER-MIB::pacemakerNotificationDescription = STRING: "Operation st_notify_fence requested by pgsr02 for peer pgsr01: OK (ref=3fa43de3-6be4-4789-bf53-da82dd5f6526)"        
PACEMAKER-MIB::pacemakerNotificationReturnCode = INTEGER: 0

```

Trap after the change.
```
Jun 16 14:37:26 snmp-manager snmptrapd[30062]: 2016-06-16 14:37:26 
pgsr02 [UDP: [192.168.100.177]:35176->[192.168.100.189]:162]:
(snip)
PACEMAKER-MIB::pacemakerNotificationOperation = STRING: "st_notify_fence"       
PACEMAKER-MIB::pacemakerNotificationDescription = STRING: "Operation reboot of pgsr01 by pgsr02 for crmd.13237@pgsr02: OK (ref=7ac1451a-69a0-482e-9400-9bcfc3be16b5)" 
PACEMAKER-MIB::pacemakerNotificationReturnCode = INTEGER: 0
```

I think that the output including action and delegate is better to a trap.

Best Regards,
Hideo Yamauchi.
