### PR TITLE
pacemaker_remote: set LSB Provides header to the service name

### DIFF
--- a/lrmd/pacemaker_remote.in
+++ b/lrmd/pacemaker_remote.in
@@ -10,7 +10,7 @@
 # processname: pacemaker_remoted
 #
 ### BEGIN INIT INFO
-# Provides:		pacemaker_remoted
+# Provides:		pacemaker_remote
 # Required-Start:	$network $remote_fs
 # Should-Start:		$syslog
 # Required-Stop:	$network $remote_fs


### PR DESCRIPTION
Originally it was set to the daemon name (pacemaker_remoted), but that's
out of line with the script name, the systemd service name and the general
trend, which the main Pacemaker daemon follows as well.

Differing names also break the automatic synchronization of SysV init and
systemd service statuses (as done in Debian at least).

Signed-off-by: Ferenc Wágner <wferi@niif.hu>