### PR TITLE
Refactor: drop qb_to_cs_error emulation when !defined(CS_USES_LIBQB)

### DIFF
--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -293,12 +293,6 @@ typedef struct qb_ipc_response_header cs_ipc_header_response_t;
 #      include <corosync/corodefs.h>
 #      include <corosync/coroipcc.h>
 #      include <corosync/coroipc_types.h>
-static inline int
-qb_to_cs_error(int a)
-{
-    return a;
-}
-
 typedef coroipc_request_header_t cs_ipc_header_request_t;
 typedef coroipc_response_header_t cs_ipc_header_response_t;
 #    endif


### PR DESCRIPTION
It's not in use as of 18e78014a3973eebdc323ba92d7ffd22f33e04c1.

Sidenote: at least with corosync v2, this symbol is normally defined
in libcorosync_common.so.