### PR TITLE
xml: score-attribute{,-mangled} in RNG schemas

### DIFF
--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -297,6 +297,7 @@
 #  define XML_TAG_RULE			"rule"
 #  define XML_RULE_ATTR_SCORE		"score"
 #  define XML_RULE_ATTR_SCORE_ATTRIBUTE	"score-attribute"
+/* following has no use (hardly ever meaningful); kept for compatibility */
 #  define XML_RULE_ATTR_SCORE_MANGLED	"score-attribute-mangled"
 #  define XML_RULE_ATTR_ROLE		"role"
 #  define XML_RULE_ATTR_RESULT		"result"

--- a/pengine/constraints.c
+++ b/pengine/constraints.c
@@ -1013,9 +1013,6 @@ generate_location_rule(resource_t * rsc, xmlNode * rule_xml, const char *discove
     score = crm_element_value(rule_xml, XML_RULE_ATTR_SCORE);
     if (score == NULL) {
         score = crm_element_value(rule_xml, XML_RULE_ATTR_SCORE_ATTRIBUTE);
-        if (score == NULL) {
-            score = crm_element_value(rule_xml, XML_RULE_ATTR_SCORE_MANGLED);
-        }
         if (score != NULL) {
             raw_score = FALSE;
         }

--- a/pengine/test10/use-after-free-merge.xml
+++ b/pengine/test10/use-after-free-merge.xml
@@ -52,8 +52,7 @@
         </rule>
       </rsc_location>
       <rsc_order first="g0" id="promote-after-g0" score="INFINITY" then="ms0" then-action="promote"/>
-      <!--rsc_colocation id="master-with-g0" rsc="ms0" rsc-role="Master" score-attribute="info" with-rsc="g0"/-->
-      <rsc_colocation id="master-with-g0" rsc="ms0" rsc-role="Master" score-attribute="info" with-rsc="g0"/>
+      <rsc_colocation id="master-with-g0" rsc="ms0" rsc-role="Master" score="INFINITY" with-rsc="g0"/>
     </constraints>
     <rsc_defaults/>
     <op_defaults/>

--- a/xml/constraints-1.0.rng
+++ b/xml/constraints-1.0.rng
@@ -72,11 +72,7 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <choice>
-          <externalRef href="score.rng"/>
-          <attribute name="score-attribute"><text/></attribute>
-          <attribute name="score-attribute-mangle"><text/></attribute>
-        </choice>
+        <externalRef href="score.rng"/>
       </optional>
       <optional>
         <ref name="element-lifetime"/>

--- a/xml/constraints-1.2.rng
+++ b/xml/constraints-1.2.rng
@@ -88,11 +88,7 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <choice>
-          <externalRef href="score.rng"/>
-          <attribute name="score-attribute"><text/></attribute>
-          <attribute name="score-attribute-mangle"><text/></attribute>
-        </choice>
+        <externalRef href="score.rng"/>
       </optional>
       <optional>
         <ref name="element-lifetime"/>

--- a/xml/constraints-2.1.rng
+++ b/xml/constraints-2.1.rng
@@ -96,11 +96,7 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <choice>
-          <externalRef href="score.rng"/>
-          <attribute name="score-attribute"><text/></attribute>
-          <attribute name="score-attribute-mangle"><text/></attribute>
-        </choice>
+        <externalRef href="score.rng"/>
       </optional>
       <optional>
         <ref name="element-lifetime"/>

--- a/xml/constraints-2.2.rng
+++ b/xml/constraints-2.2.rng
@@ -101,11 +101,7 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <choice>
-          <externalRef href="score.rng"/>
-          <attribute name="score-attribute"><text/></attribute>
-          <attribute name="score-attribute-mangle"><text/></attribute>
-        </choice>
+        <externalRef href="score.rng"/>
       </optional>
       <optional>
         <ref name="element-lifetime"/>

--- a/xml/constraints-2.3.rng
+++ b/xml/constraints-2.3.rng
@@ -101,11 +101,7 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <choice>
-          <externalRef href="score.rng"/>
-          <attribute name="score-attribute"><text/></attribute>
-          <attribute name="score-attribute-mangle"><text/></attribute>
-        </choice>
+        <externalRef href="score.rng"/>
       </optional>
       <optional>
         <ref name="element-lifetime"/>

--- a/xml/constraints-2.6.rng
+++ b/xml/constraints-2.6.rng
@@ -104,11 +104,7 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <choice>
-          <externalRef href="score.rng"/>
-          <attribute name="score-attribute"><text/></attribute>
-          <attribute name="score-attribute-mangle"><text/></attribute>
-        </choice>
+        <externalRef href="score.rng"/>
       </optional>
       <optional>
         <ref name="element-lifetime"/>

--- a/xml/constraints-next.rng
+++ b/xml/constraints-next.rng
@@ -104,11 +104,7 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <choice>
-          <externalRef href="score.rng"/>
-          <attribute name="score-attribute"><text/></attribute>
-          <attribute name="score-attribute-mangle"><text/></attribute>
-        </choice>
+        <externalRef href="score.rng"/>
       </optional>
       <optional>
         <ref name="element-lifetime"/>


### PR DESCRIPTION
Unlike the first (and second) commit, the third may be controversial and I'll happily drop it if you think there's no need to blindly follow ancient predestined path, which pacemaker users could live without for so many years.