### PR TITLE
High: fix infloop when "validate-with" schema does not validate

### DIFF
--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -5668,13 +5668,8 @@ update_validation(xmlNode ** xml_blob, int *best, int max, gboolean transform, g
                 crm_trace("Stopping at %s", known_schemas[lpc].name);
                 break;
 
-            } else if (max > 0 && lpc == max) {
+            } else if (max > 0 && (lpc == max || next > max)) {
                 crm_trace("Upgrade limit reached at %s (lpc=%d, next=%d, max=%d)",
-                          known_schemas[lpc].name, lpc, next, max);
-                break;
-
-            } else if (max > 0 && next > max) {
-                crm_debug("Upgrade limit reached at %s (lpc=%d, next=%d, max=%d)",
                           known_schemas[lpc].name, lpc, next, max);
                 break;
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -5752,6 +5752,7 @@ cli_config_update(xmlNode ** xml, int *best_version, gboolean to_logs)
     const char *value = crm_element_value(*xml, XML_ATTR_VALIDATION);
 
     int version = get_schema_version(value);
+    int orig_version = version;
     int min_version = xml_minimum_schema_index();
 
     if (version < min_version) {
@@ -5762,7 +5763,19 @@ cli_config_update(xmlNode ** xml, int *best_version, gboolean to_logs)
 
         value = crm_element_value(converted, XML_ATTR_VALIDATION);
         if (version < min_version) {
-            if (to_logs) {
+            if (version < orig_version) {
+                if (to_logs) {
+                    crm_config_err("Your current configuration could not validate"
+                                   " with any schema in range [%s, %s]\n",
+                                   get_schema_name(orig_version),
+                                   xml_latest_schema());
+                } else {
+                    fprintf(stderr, "Your current configuration could not validate"
+                                    " with any schema in range [%s, %s]\n",
+                                    get_schema_name(orig_version),
+                                    xml_latest_schema());
+                }
+            } else if (to_logs) {
                 crm_config_err("Your current configuration could only be upgraded to %s... "
                                "the minimum requirement is %s.\n", crm_str(value),
                                get_schema_name(min_version));

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -329,7 +329,7 @@ static void __xml_schema_add(
         known_schemas[last].transform = strdup(transform);
     }
     if(after_transform == 0) {
-        after_transform = xml_schema_max;
+        after_transform = xml_schema_max;  /* upgrade is a one-way */
     }
     known_schemas[last].after_transform = after_transform;
 
@@ -5664,7 +5664,7 @@ update_validation(xmlNode ** xml_blob, int *best, int max, gboolean transform, g
             xmlNode *upgrade = NULL;
             int next = known_schemas[lpc].after_transform;
 
-            if (next < 0) {
+            if (next < 0 || next <= lpc) {
                 crm_trace("Stopping at %s", known_schemas[lpc].name);
                 break;
 


### PR DESCRIPTION
Test case:
Change constraints-1.0.rng so as to deny score-attribute
in rsc_colocation; then:

$ make  # so as to generate the schemas
$ PCMK_schema_directory=$(pwd)/xml tools/crm_simulate -x $(pwd)/pengine/test10/use-after-free-merge.xml -S

BEFORE:
Entity: line 56: element rsc_colocation: Relax-NG validity error : Invalid attribute score-attribute for element rsc_colocation
Entity: line 49: element rsc_location: Relax-NG validity error : Element constraints has extra content: rsc_location
[...infloop...]

AFTER:
Entity: line 56: element rsc_colocation: Relax-NG validity error : Invalid attribute score-attribute for element rsc_colocation
Entity: line 49: element rsc_location: Relax-NG validity error : Element constraints has extra content: rsc_location
[several times]
4 of 5 resources DISABLED and 0 BLOCKED from being started due to failures
[...]