### PR TITLE
Maint: mark files not appropriate for automatic archive files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 configure.ac	export-subst
+.gitattributes	export-ignore
+.gitignore	export-ignore
+.travis.yml	export-ignore
+travisci_build_coverity_scan.sh	export-ignore


### PR DESCRIPTION
- git management files themselves
- Travis CI related files