### PR TITLE
Log: crm_mon: Avoid logging errors for any CIB changes that we don't care about

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -3922,16 +3922,8 @@ static void crm_diff_update_v2(const char *event, xmlNode * msg)
             handle_rsc_op(match, local_node);
             free(local_node);
 
-        } else if(strcmp(name, XML_TAG_TRANSIENT_NODEATTRS) == 0
-                  || strcmp(name, XML_TAG_ATTR_SETS) == 0
-                  || strcmp(name, XML_CIB_TAG_NVPAIR) == 0
-                  || strcmp(name, XML_CIB_TAG_TICKETS) == 0
-                  || strcmp(name, XML_CIB_TAG_TICKET_STATE) == 0) {
-            crm_trace("Ignoring %s operation for %s %p, %s", op, xpath, match, name);
-
         } else {
-            crm_err("Unable to process unrecognized CIB change: %s operation for %s %p, %s",
-                    op, xpath, match, name);
+            crm_trace("Ignoring %s operation for %s %p, %s", op, xpath, match, name);
         }
     }
 }


### PR DESCRIPTION
3844f09 considered the changes in cib status that should be ignored.
But actually it still reported errors for any changes of cib
configuration.

Given that we only care about the xml objects that may contain
lrm_rsc_op anyway, downgrade the message to trace for all the other
cases.