### PR TITLE
Fix XML comment processing

### DIFF
--- a/crmd/election.c
+++ b/crmd/election.c
@@ -88,7 +88,7 @@ do_election_check(long long action,
                   enum crmd_fsa_input current_input, fsa_data_t * msg_data)
 {
     if (fsa_state != S_ELECTION) {
-        crm_debug("Ignore election check: we not in an election");
+        crm_debug("Ignoring election check because we are not in an election");
 
     } else if(election_check(fsa_election)) {
         register_fsa_input(C_FSA_INTERNAL, I_ELECTION_DC, NULL);

--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -1629,7 +1629,6 @@ do_lrm_invoke(long long action,
 
         CRM_CHECK(xml_rsc != NULL, return);
 
-        /* only the first 16 chars are used by the LRM */
         params = find_xml_node(input->xml, XML_TAG_ATTRS, TRUE);
 
         if (safe_str_eq(operation, CRMD_ACTION_DELETE)) {

--- a/crmd/te_callbacks.c
+++ b/crmd/te_callbacks.c
@@ -425,6 +425,10 @@ te_update_diff(const char *event, xmlNode * msg)
         }
 
         if(match) {
+            if (match->type == XML_COMMENT_NODE) {
+                crm_trace("Ignoring %s operation for comment at %s", op, xpath);
+                continue;
+            }
             name = (const char *)match->name;
         }
 

--- a/crmd/te_callbacks.c
+++ b/crmd/te_callbacks.c
@@ -428,12 +428,14 @@ te_update_diff(const char *event, xmlNode * msg)
             name = (const char *)match->name;
         }
 
-        crm_trace("Handling %s operation for %s %p, %s", op, xpath, match, name);
+        crm_trace("Handling %s operation for %s%s%s",
+                  op, (xpath? xpath : "CIB"),
+                  (name? " matched by " : ""), (name? name : ""));
         if(xpath == NULL) {
             /* Version field, ignore */
 
         } else if(strstr(xpath, "/cib/configuration")) {
-            abort_transition(INFINITY, tg_restart, "Non-status change", change);
+            abort_transition(INFINITY, tg_restart, "Configuration change", change);
             break; /* Wont be packaged with any resource operations we may be waiting for */
 
         } else if(strstr(xpath, "/"XML_CIB_TAG_TICKETS) || safe_str_eq(name, XML_CIB_TAG_TICKETS)) {
@@ -502,7 +504,7 @@ te_update_diff(const char *event, xmlNode * msg)
             }
 
             if(config) {
-                abort_transition(INFINITY, tg_restart, "Non-status change", change);
+                abort_transition(INFINITY, tg_restart, "Non-status-only change", change);
             }
 
         } else if(strcmp(name, XML_CIB_TAG_STATUS) == 0) {

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -3488,48 +3488,47 @@ __xml_log_element(int log_level, const char *file, const char *function, int lin
         char *buffer = NULL;
 
         insert_prefix(options, &buffer, &offset, &max, depth);
-        if(data->type == XML_COMMENT_NODE) {
-            buffer_print(buffer, max, offset, "<!--");
-            buffer_print(buffer, max, offset, "%s", data->content);
-            buffer_print(buffer, max, offset, "-->");
+
+        if (data->type == XML_COMMENT_NODE) {
+            buffer_print(buffer, max, offset, "<!--%s-->", data->content);
 
         } else {
             buffer_print(buffer, max, offset, "<%s", name);
-        }
 
-        hidden = crm_element_value(data, "hidden");
-        for (pIter = crm_first_attr(data); pIter != NULL; pIter = pIter->next) {
-            xml_private_t *p = pIter->_private;
-            const char *p_name = (const char *)pIter->name;
-            const char *p_value = crm_attr_value(pIter);
-            char *p_copy = NULL;
+            hidden = crm_element_value(data, "hidden");
+            for (pIter = crm_first_attr(data); pIter != NULL; pIter = pIter->next) {
+                xml_private_t *p = pIter->_private;
+                const char *p_name = (const char *)pIter->name;
+                const char *p_value = crm_attr_value(pIter);
+                char *p_copy = NULL;
 
-            if(is_set(p->flags, xpf_deleted)) {
-                continue;
-            } else if ((is_set(options, xml_log_option_diff_plus)
-                 || is_set(options, xml_log_option_diff_minus))
-                && strcmp(XML_DIFF_MARKER, p_name) == 0) {
-                continue;
+                if(is_set(p->flags, xpf_deleted)) {
+                    continue;
+                } else if ((is_set(options, xml_log_option_diff_plus)
+                     || is_set(options, xml_log_option_diff_minus))
+                    && strcmp(XML_DIFF_MARKER, p_name) == 0) {
+                    continue;
 
-            } else if (hidden != NULL && p_name[0] != 0 && strstr(hidden, p_name) != NULL) {
-                p_copy = strdup("*****");
+                } else if (hidden != NULL && p_name[0] != 0 && strstr(hidden, p_name) != NULL) {
+                    p_copy = strdup("*****");
 
-            } else {
-                p_copy = crm_xml_escape(p_value);
+                } else {
+                    p_copy = crm_xml_escape(p_value);
+                }
+
+                buffer_print(buffer, max, offset, " %s=\"%s\"", p_name, p_copy);
+                free(p_copy);
             }
 
-            buffer_print(buffer, max, offset, " %s=\"%s\"", p_name, p_copy);
-            free(p_copy);
-        }
+            if(xml_has_children(data) == FALSE) {
+                buffer_print(buffer, max, offset, "/>");
 
-        if(xml_has_children(data) == FALSE) {
-            buffer_print(buffer, max, offset, "/>");
+            } else if(is_set(options, xml_log_option_children)) {
+                buffer_print(buffer, max, offset, ">");
 
-        } else if(is_set(options, xml_log_option_children)) {
-            buffer_print(buffer, max, offset, ">");
-
-        } else {
-            buffer_print(buffer, max, offset, "/>");
+            } else {
+                buffer_print(buffer, max, offset, "/>");
+            }
         }
 
         do_crm_log_alias(log_level, file, function, line, "%s %s", prefix, buffer);

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -4329,7 +4329,7 @@ __xml_diff_object(xmlNode * old, xmlNode * new)
             xml_private_t *p = new_child->_private;
 
             if(p_old != p_new) {
-                crm_info("%s.%s moved from %d to %d - %d",
+                crm_info("%s.%s moved from %d to %d",
                          new_child->name, ID(new_child), p_old, p_new);
                 __xml_node_dirty(new);
                 p->flags |= xpf_moved;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -154,7 +154,7 @@ unpack_config(xmlNode * config, pe_working_set_t * data_set)
 
     value = pe_pref(data_set->config_hash, XML_ATTR_HAVE_WATCHDOG);
     if (value && crm_is_true(value)) {
-        crm_notice("Relying on watchdog integration for fencing");
+        crm_notice("Watchdog will be used via SBD if fencing is required");
         set_bit(data_set->flags, pe_flag_have_stonith_resource);
     }
 


### PR DESCRIPTION
A thread on the users@clusterlabs.org mailing list, "DC of the election will be an infinite loop.", uncovered a problem with XML comment processing in v2 patchset diffs.

An infinite DC election loop would occur when there is more than one comment at the same level within a CIB XML element, the partition has only one node, and the partition does not yet have a DC. The behavior was introduced in 1.1.14 with commit 1073786e, which did not have any bugs itself, but exercised the code differently, triggering bugs existing since the introduction of v2 patchsets (specifically commit 212ef6fe).

This request fixes multiple issues:

* An info-level message had an extraneous %d format specifier, which did not appear to cause any serious problems.

* The XML logging functions would log a spurious "/>" at the end of comments (with no other ill effects).

* Comment creation and modification would abort the transition unnecessarily. (Deletes still abort; avoiding that would require parsing the xpath.)

* __xml_diff_object() would not distinguish comments when processing child element changes. This would cause it to always find the first comment (since it was searching by ID -- which is NULL for all comments -- rather than comment content), making it think that later comments had always moved. This would show up as log messages like  "node <comment id=(null)> not found", and "comment.(null) moved from 0 to 1" even when a comment had not moved. I did not confirm, but it is possible that this could also allow ACLs to be circumvented for comment-only changes.