### PR TITLE
Mid: crmd: Keep a state of LRMD in the DC node latest.

### DIFF
--- a/crmd/join_dc.c
+++ b/crmd/join_dc.c
@@ -523,8 +523,25 @@ do_dc_join_ack(long long action,
      *   be started in due time
      */
     erase_status_tag(join_from, XML_CIB_TAG_LRM, cib_scope_local);
-    fsa_cib_update(XML_CIB_TAG_STATUS, join_ack->xml,
-                   cib_scope_local | cib_quorum_override | cib_can_create, call_id, NULL);
+
+    if (safe_str_eq(join_from, fsa_our_uname)) {
+        xmlNode *now_dc_lrmd_state = do_lrm_query(TRUE, fsa_our_uname);
+        if (now_dc_lrmd_state != NULL) {
+            crm_debug("LRM state is updated from do_lrm_query.(%s)", join_from);
+            fsa_cib_update(XML_CIB_TAG_STATUS, now_dc_lrmd_state,
+                cib_scope_local | cib_quorum_override | cib_can_create, call_id, NULL);
+            free(now_dc_lrmd_state);
+        } else {
+            crm_warn("Could not get our LRM state. LRM state is updated from join_ack->xml.(%s)", join_from);
+            fsa_cib_update(XML_CIB_TAG_STATUS, join_ack->xml,
+                cib_scope_local | cib_quorum_override | cib_can_create, call_id, NULL);
+        }
+    } else {
+        crm_debug("LRM state is updated from join_ack->xml.(%s)", join_from);
+        fsa_cib_update(XML_CIB_TAG_STATUS, join_ack->xml,
+           cib_scope_local | cib_quorum_override | cib_can_create, call_id, NULL);
+    }
+
     fsa_register_cib_callback(call_id, FALSE, NULL, join_update_complete_callback);
     crm_debug("join-%d: Registered callback for LRM update %d", join_id, call_id);
 }


### PR DESCRIPTION
Hi All,

I revised next pullrequest.
 - https://github.com/ClusterLabs/pacemaker/pull/1102

This patch prevents that a state of LRMD of the DC node disappears by the participation of the node during an action.

It is the correspondence patch of the next bug.

 - http://bugs.clusterlabs.org/show_bug.cgi?id=5286

Many thanks,
Hideo Yamauchi.