### PR TITLE
Fix: pengine: disable migration for versioned resources

### DIFF
--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -524,15 +524,19 @@ common_unpack(xmlNode * xml_obj, resource_t ** rsc,
     }
 
     value = g_hash_table_lookup((*rsc)->meta, XML_OP_ATTR_ALLOW_MIGRATE);
-    if (crm_is_true(value)) {
+    if (crm_is_true(value) && xml_has_children((*rsc)->versioned_parameters)) {
+        pe_rsc_trace((*rsc), "Migration is disabled for resources with versioned parameters");
+    } else if (crm_is_true(value)) {
         set_bit((*rsc)->flags, pe_rsc_allow_migrate);
-    } else if (value == NULL && baremetal_remote_node) {
+    } else if (value == NULL && baremetal_remote_node &&
+               !xml_has_children((*rsc)->versioned_parameters)) {
         /* by default, we want baremetal remote-nodes to be able
          * to float around the cluster without having to stop all the
          * resources within the remote-node before moving. Allowing
          * migration support enables this feature. If this ever causes
          * problems, migration support can be explicitly turned off with
-         * allow-migrate=false. */
+         * allow-migrate=false.
+         * We don't support migration for versioned resources, though. */
         set_bit((*rsc)->flags, pe_rsc_allow_migrate);
     }
 

--- a/pengine/regression.sh
+++ b/pengine/regression.sh
@@ -315,6 +315,8 @@ do_test 11-a-then-bm-b-move-a-clone-starting "Advanced migrate logic, A clone th
 do_test a-promote-then-b-migrate "A promote then B start. migrate B"
 do_test a-demote-then-b-migrate "A demote then B stop. migrate B"
 
+do_test migrate-versioned "Disable migration for versioned resources"
+
 #echo ""
 #do_test complex1 "Complex	"
 

--- a/pengine/test10/migrate-versioned.dot
+++ b/pengine/test10/migrate-versioned.dot
@@ -1,0 +1,10 @@
+digraph "g" {
+"A_monitor_0 node2" -> "A_start_0 node2" [ style = bold]
+"A_monitor_0 node2" -> "A_stop_0 node1" [ style = bold]
+"A_monitor_0 node2" [ style=bold color="green" fontcolor="black"]
+"A_start_0 node2" [ style=bold color="green" fontcolor="black"]
+"A_stop_0 node1" -> "A_start_0 node2" [ style = bold]
+"A_stop_0 node1" -> "all_stopped" [ style = bold]
+"A_stop_0 node1" [ style=bold color="green" fontcolor="black"]
+"all_stopped" [ style=bold color="green" fontcolor="orange"]
+}

--- a/pengine/test10/migrate-versioned.exp
+++ b/pengine/test10/migrate-versioned.exp
@@ -1,0 +1,76 @@
+<transition_graph cluster-delay="60s" stonith-timeout="60s" failed-stop-offset="INFINITY" failed-start-offset="INFINITY"  transition_id="0">
+  <synapse id="0">
+    <action_set>
+      <rsc_op id="4" operation="start" operation_key="A_start_0" on_node="node2" on_node_uuid="2">
+        <primitive id="A" class="ocf" provider="pacemaker" type="Dummy"/>
+        <versioned_attributes>
+          <instance_attributes score="1" id="A-instance_attributes">
+            <rule score="INFINITY" id="A-instance_attributes-rule">
+              <expression attribute="#ra-version" operation="eq" value="1.0" id="A-instance_attributes-rule-expression"/>
+            </rule>
+            <nvpair name="fake" value="real" id="A-instance_attributes-fake"/>
+          </instance_attributes>
+        </versioned_attributes>
+        <attributes CRM_meta_timeout="20000" />
+      </rsc_op>
+    </action_set>
+    <inputs>
+      <trigger>
+        <rsc_op id="2" operation="monitor" operation_key="A_monitor_0" on_node="node2" on_node_uuid="2"/>
+      </trigger>
+      <trigger>
+        <rsc_op id="3" operation="stop" operation_key="A_stop_0" on_node="node1" on_node_uuid="1"/>
+      </trigger>
+    </inputs>
+  </synapse>
+  <synapse id="1">
+    <action_set>
+      <rsc_op id="3" operation="stop" operation_key="A_stop_0" on_node="node1" on_node_uuid="1">
+        <primitive id="A" class="ocf" provider="pacemaker" type="Dummy"/>
+        <versioned_attributes>
+          <instance_attributes score="1" id="A-instance_attributes">
+            <rule score="INFINITY" id="A-instance_attributes-rule">
+              <expression attribute="#ra-version" operation="eq" value="1.0" id="A-instance_attributes-rule-expression"/>
+            </rule>
+            <nvpair name="fake" value="real" id="A-instance_attributes-fake"/>
+          </instance_attributes>
+        </versioned_attributes>
+        <attributes CRM_meta_timeout="20000" />
+      </rsc_op>
+    </action_set>
+    <inputs>
+      <trigger>
+        <rsc_op id="2" operation="monitor" operation_key="A_monitor_0" on_node="node2" on_node_uuid="2"/>
+      </trigger>
+    </inputs>
+  </synapse>
+  <synapse id="2">
+    <action_set>
+      <rsc_op id="2" operation="monitor" operation_key="A_monitor_0" on_node="node2" on_node_uuid="2">
+        <primitive id="A" class="ocf" provider="pacemaker" type="Dummy"/>
+        <versioned_attributes>
+          <instance_attributes score="1" id="A-instance_attributes">
+            <rule score="INFINITY" id="A-instance_attributes-rule">
+              <expression attribute="#ra-version" operation="eq" value="1.0" id="A-instance_attributes-rule-expression"/>
+            </rule>
+            <nvpair name="fake" value="real" id="A-instance_attributes-fake"/>
+          </instance_attributes>
+        </versioned_attributes>
+        <attributes CRM_meta_op_target_rc="7" CRM_meta_timeout="20000" />
+      </rsc_op>
+    </action_set>
+    <inputs/>
+  </synapse>
+  <synapse id="3">
+    <action_set>
+      <pseudo_event id="1" operation="all_stopped" operation_key="all_stopped">
+        <attributes />
+      </pseudo_event>
+    </action_set>
+    <inputs>
+      <trigger>
+        <rsc_op id="3" operation="stop" operation_key="A_stop_0" on_node="node1" on_node_uuid="1"/>
+      </trigger>
+    </inputs>
+  </synapse>
+</transition_graph>

--- a/pengine/test10/migrate-versioned.scores
+++ b/pengine/test10/migrate-versioned.scores
@@ -1,0 +1,3 @@
+Allocation scores:
+native_color: A allocation score on node1: 0
+native_color: A allocation score on node2: INFINITY

--- a/pengine/test10/migrate-versioned.summary
+++ b/pengine/test10/migrate-versioned.summary
@@ -1,0 +1,20 @@
+
+Current cluster status:
+Online: [ node1 node2 ]
+
+ A	(ocf::pacemaker:Dummy):	Started node1
+
+Transition Summary:
+ * Move    A	(Started node1 -> node2)
+
+Executing cluster transition:
+ * Resource action: A               monitor on node2
+ * Resource action: A               stop on node1
+ * Pseudo action:   all_stopped
+ * Resource action: A               start on node2
+
+Revised cluster status:
+Online: [ node1 node2 ]
+
+ A	(ocf::pacemaker:Dummy):	Started node2
+

--- a/pengine/test10/migrate-versioned.xml
+++ b/pengine/test10/migrate-versioned.xml
@@ -1,0 +1,45 @@
+<cib crm_feature_set="3.0.11" validate-with="pacemaker-2.6" epoch="53" num_updates="3" admin_epoch="0" cib-last-written="Wed Aug  3 14:20:56 2016" update-origin="node1" update-client="cibadmin" update-user="root" have-quorum="1" dc-uuid="1">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-have-watchdog" name="have-watchdog" value="false"/>
+        <nvpair id="cib-bootstrap-options-dc-version" name="dc-version" value="1.1.15-747e11e"/>
+        <nvpair id="cib-bootstrap-options-cluster-infrastructure" name="cluster-infrastructure" value="corosync"/>
+        <nvpair id="cib-bootstrap-options-cluster-name" name="cluster-name" value="lbcluster"/>
+        <nvpair name="stonith-enabled" value="false" id="cib-bootstrap-options-stonith-enabled"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="1" uname="node1"/>
+      <node id="2" uname="node2"/>
+    </nodes>
+    <resources>
+      <primitive id="A" class="ocf" provider="pacemaker" type="Dummy">
+        <instance_attributes score="1" id="A-instance_attributes">
+          <rule score="INFINITY" id="A-instance_attributes-rule">
+            <expression attribute="#ra-version" operation="eq" value="1.0" id="A-instance_attributes-rule-expression"/>
+          </rule>
+          <nvpair name="fake" value="real" id="A-instance_attributes-fake"/>
+        </instance_attributes>
+        <meta_attributes id="A-meta_attributes">
+          <nvpair name="allow-migrate" value="true" id="A-meta_attributes-allow-migrate"/>
+        </meta_attributes>
+      </primitive>
+    </resources>
+    <constraints>
+      <rsc_location id="A-on-node2" rsc="A" score="INFINITY" node="node2"/>
+    </constraints>
+  </configuration>
+  <status>
+    <node_state id="1" uname="node1" in_ccm="true" crmd="online" crm-debug-origin="do_update_resource" join="member" expected="member">
+      <lrm id="1">
+        <lrm_resources>
+          <lrm_resource id="A" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="A_last_0" operation_key="A_start_0" operation="start" crm-debug-origin="do_update_resource" crm_feature_set="3.0.11" transition-key="4:13:0:b3ff8b54-a60d-4919-86b3-b3f843c041ce" transition-magic="0:0;4:13:0:b3ff8b54-a60d-4919-86b3-b3f843c041ce" on_node="node1" call-id="20" rc-code="0" op-status="0" interval="0" last-run="1470248456" last-rc-change="1470248456" exec-time="27" queue-time="0" op-digest="92c1fcfb8e1608efe499629fe54ebb87" op-force-restart=" state  passwd  op_sleep  envfile " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="92c1fcfb8e1608efe499629fe54ebb87"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state id="2" uname="node2" in_ccm="true" crmd="online" join="member" crm-debug-origin="do_update_resource" expected="member"/>
+  </status>
+</cib>


### PR DESCRIPTION
This is a resolution of the issue discussed in [#1063](https://github.com/ClusterLabs/pacemaker/pull/1063).