### PR TITLE
Important regression in 1.1.15 Pacemaker Remote handling

### DIFF
--- a/crmd/callbacks.c
+++ b/crmd/callbacks.c
@@ -124,7 +124,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
 
     switch (type) {
         case crm_status_uname:
-            /* If we've never seen the node, then it also wont be in the status section */
+            /* If we've never seen the node, then it also won't be in the status section */
             crm_info("%s is now %s", node->uname, state_text(node->state));
             return;
 

--- a/crmd/callbacks.c
+++ b/crmd/callbacks.c
@@ -268,7 +268,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
         }
 
         /* Update the CIB node state */
-        update = do_update_node_cib(node, flags, NULL, __FUNCTION__);
+        update = create_node_state_update(node, flags, NULL, __FUNCTION__);
         fsa_cib_anon_update(XML_CIB_TAG_STATUS, update,
                             cib_scope_local | cib_quorum_override | cib_can_create);
         free_xml(update);

--- a/crmd/crmd_utils.h
+++ b/crmd/crmd_utils.h
@@ -85,7 +85,8 @@ void fsa_dump_inputs(int log_level, const char *text, long long input_register);
 
 gboolean update_dc(xmlNode * msg);
 void crm_update_peer_join(const char *source, crm_node_t * node, enum crm_join_phase phase);
-xmlNode *do_update_node_cib(crm_node_t * node, int flags, xmlNode * parent, const char *source);
+xmlNode *create_node_state_update(crm_node_t *node, int flags,
+                                  xmlNode *parent, const char *source);
 void populate_cib_nodes(enum node_update_flags flags, const char *source);
 void crm_update_quorum(gboolean quorum, gboolean force_update);
 void erase_status_tag(const char *uname, const char *tag, int options);

--- a/crmd/election.c
+++ b/crmd/election.c
@@ -249,7 +249,8 @@ do_dc_release(long long action,
             crm_node_t *node = crm_get_peer(0, fsa_our_uname);
 
             crm_update_peer_expected(__FUNCTION__, node, CRMD_JOINSTATE_DOWN);
-            update = do_update_node_cib(node, node_update_expected, NULL, __FUNCTION__);
+            update = create_node_state_update(node, node_update_expected, NULL,
+                                              __FUNCTION__);
             fsa_cib_anon_update(XML_CIB_TAG_STATUS, update,
                                 cib_scope_local | cib_quorum_override | cib_can_create);
             free_xml(update);

--- a/crmd/heartbeat.c
+++ b/crmd/heartbeat.c
@@ -403,7 +403,8 @@ crmd_ha_status_callback(const char *node, const char *status, void *private)
     trigger_fsa(fsa_source);
 
     if (AM_I_DC) {
-        update = do_update_node_cib(peer, node_update_cluster, NULL, __FUNCTION__);
+        update = create_node_state_update(peer, node_update_cluster, NULL,
+                                          __FUNCTION__);
         fsa_cib_anon_update(XML_CIB_TAG_STATUS, update,
                             cib_scope_local | cib_quorum_override | cib_can_create);
         free_xml(update);
@@ -456,7 +457,8 @@ crmd_client_status_callback(const char *node, const char *client, const char *st
         xmlNode *update = NULL;
 
         crm_trace("Got client status callback");
-        update = do_update_node_cib(peer, node_update_peer, NULL, __FUNCTION__);
+        update = create_node_state_update(peer, node_update_peer, NULL,
+                                          __FUNCTION__);
         fsa_cib_anon_update(XML_CIB_TAG_STATUS, update,
                             cib_scope_local | cib_quorum_override | cib_can_create);
         free_xml(update);

--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -879,7 +879,8 @@ do_lrm_query_internal(lrm_state_t *lrm_state, int update_flags)
     peer = crm_get_peer_full(0, lrm_state->node_name, CRM_GET_PEER_ANY);
     CRM_CHECK(peer != NULL, return NULL);
 
-    xml_state = do_update_node_cib(peer, update_flags, NULL, __FUNCTION__);
+    xml_state = create_node_state_update(peer, update_flags, NULL,
+                                         __FUNCTION__);
 
     xml_data = create_xml_node(xml_state, XML_CIB_TAG_LRM);
     crm_xml_add(xml_data, XML_ATTR_ID, peer->uuid);
@@ -1932,7 +1933,8 @@ send_direct_ack(const char *to_host, const char *to_sys,
     }
 
     peer = crm_get_peer(0, fsa_our_uname);
-    update = do_update_node_cib(peer, node_update_none, NULL, __FUNCTION__);
+    update = create_node_state_update(peer, node_update_none, NULL,
+                                      __FUNCTION__);
 
     iter = create_xml_node(update, XML_CIB_TAG_LRM);
     crm_xml_add(iter, XML_ATTR_ID, fsa_our_uuid);

--- a/crmd/membership.c
+++ b/crmd/membership.c
@@ -128,8 +128,20 @@ crmd_node_update_complete(xmlNode * msg, int call_id, int rc, xmlNode * output, 
     }
 }
 
+/*!
+ * \internal
+ * \brief Create an XML node state tag with updates
+ *
+ * \param[in/out] node    Node whose state will be used for update
+ * \param[in]     flags   Bitmask of node_update_flags indicating what to update
+ * \param[in/out] parent  XML node to contain update (or NULL)
+ * \param[in]     source  Who requested the update (only used for logging)
+ *
+ * \return Pointer to created node state tag
+ */
 xmlNode *
-do_update_node_cib(crm_node_t * node, int flags, xmlNode * parent, const char *source)
+create_node_state_update(crm_node_t *node, int flags, xmlNode *parent,
+                         const char *source)
 {
     const char *value = NULL;
     xmlNode *node_state;
@@ -370,13 +382,13 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
 
         g_hash_table_iter_init(&iter, crm_peer_cache);
         while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
-            do_update_node_cib(node, flags, node_list, source);
+            create_node_state_update(node, flags, node_list, source);
         }
 
         if (crm_remote_peer_cache) {
             g_hash_table_iter_init(&iter, crm_remote_peer_cache);
             while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
-                do_update_node_cib(node, flags, node_list, source);
+                create_node_state_update(node, flags, node_list, source);
             }
         }
 

--- a/crmd/remote_lrmd_ra.c
+++ b/crmd/remote_lrmd_ra.c
@@ -178,10 +178,9 @@ remote_node_up(const char *node_name)
     CRM_CHECK(node_name != NULL, return);
     crm_info("Announcing pacemaker_remote node %s", node_name);
 
-    /* Clear node's operation history and transient attributes.
-     * This should and normally will be done when the node leaves,
-     * but since remote node state has a number of corner cases,
-     * we additionally clear it on startup to be sure.
+    /* Clear node's operation history. The node's transient attributes should
+     * and normally will be cleared when the node leaves, but since remote node
+     * state has a number of corner cases, clear them here as well, to be sure.
      */
     call_opt = crmd_cib_smart_opt();
     erase_status_tag(node_name, XML_CIB_TAG_LRM, call_opt);
@@ -243,8 +242,7 @@ remote_node_down(const char *node_name)
     /* Purge node from attrd's memory */
     update_attrd_remote_node_removed(node_name, NULL);
 
-    /* Purge node's operation history and transient attributes from CIB */
-    erase_status_tag(node_name, XML_CIB_TAG_LRM, call_opt);
+    /* Purge node's transient attributes */
     erase_status_tag(node_name, XML_TAG_TRANSIENT_NODEATTRS, call_opt);
 
     /* Ensure node is in the remote peer cache with lost state */

--- a/crmd/remote_lrmd_ra.c
+++ b/crmd/remote_lrmd_ra.c
@@ -203,7 +203,8 @@ remote_node_up(const char *node_name)
     send_remote_state_message(node_name, TRUE);
 
     update = create_xml_node(NULL, XML_CIB_TAG_STATUS);
-    state = do_update_node_cib(node, node_update_cluster, update, __FUNCTION__);
+    state = create_node_state_update(node, node_update_cluster, update,
+                                     __FUNCTION__);
 
     /* Clear the XML_NODE_IS_FENCED flag in the node state. If the node ever
      * needs to be fenced, this flag will allow various actions to determine
@@ -255,7 +256,7 @@ remote_node_down(const char *node_name)
 
     /* Update CIB node state */
     update = create_xml_node(NULL, XML_CIB_TAG_STATUS);
-    do_update_node_cib(node, node_update_cluster, update, __FUNCTION__);
+    create_node_state_update(node, node_update_cluster, update, __FUNCTION__);
     fsa_cib_update(XML_CIB_TAG_STATUS, update, call_opt, call_id, NULL);
     if (call_id < 0) {
         crm_perror(LOG_ERR, "%s CIB node state update", node_name);

--- a/crmd/te_actions.c
+++ b/crmd/te_actions.c
@@ -99,7 +99,7 @@ send_stonith_update(crm_action_t * action, const char *target, const char *uuid)
     crmd_peer_down(peer, TRUE);
 
     /* Generate a node state update for the CIB */
-    node_state = do_update_node_cib(peer, flags, NULL, __FUNCTION__);
+    node_state = create_node_state_update(peer, flags, NULL, __FUNCTION__);
 
     /* we have to mark whether or not remote nodes have already been fenced */
     if (peer->flags & crm_remote_node) {

--- a/crmd/te_callbacks.c
+++ b/crmd/te_callbacks.c
@@ -442,15 +442,15 @@ te_update_diff(const char *event, xmlNode * msg)
 
         } else if(strstr(xpath, "/cib/configuration")) {
             abort_transition(INFINITY, tg_restart, "Configuration change", change);
-            break; /* Wont be packaged with any resource operations we may be waiting for */
+            break; /* Won't be packaged with any resource operations we may be waiting for */
 
         } else if(strstr(xpath, "/"XML_CIB_TAG_TICKETS) || safe_str_eq(name, XML_CIB_TAG_TICKETS)) {
             abort_transition(INFINITY, tg_restart, "Ticket attribute change", change);
-            break; /* Wont be packaged with any resource operations we may be waiting for */
+            break; /* Won't be packaged with any resource operations we may be waiting for */
 
         } else if(strstr(xpath, "/"XML_TAG_TRANSIENT_NODEATTRS"[") || safe_str_eq(name, XML_TAG_TRANSIENT_NODEATTRS)) {
             abort_unless_down(xpath, op, change, "Transient attribute change");
-            break; /* Wont be packaged with any resource operations we may be waiting for */
+            break; /* Won't be packaged with any resource operations we may be waiting for */
 
         } else if(strstr(xpath, "/"XML_LRM_TAG_RSC_OP"[") && safe_str_eq(op, "delete")) {
             crm_action_t *cancel = NULL;

--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -2924,7 +2924,7 @@ class RemoteDriver(CTSTest):
             return
 
         # This verifies permanent attributes can be set on a remote-node. It also
-        # verifies the remote-node can edit it's own cib node section remotely.
+        # verifies the remote-node can edit its own cib node section remotely.
         (rc, line) = self.CM.rsh(node, "crm_attribute -l forever -n testattr -v testval -N %s" % (self.remote_node), None)
         if rc != 0:
             self.fail("Failed to set remote-node attribute. rc:%s output:%s" % (rc, line))

--- a/fencing/fence_dummy
+++ b/fencing/fence_dummy
@@ -320,7 +320,7 @@ def main():
     ## Defaults for fence agent
     docs = { }
     docs["shortdesc"] = "Dummy fence agent"
-    docs["longdesc"] = "fence_dummy is a fake fencing agent which reports success based on it's mode (pass|fail|random) without doing anything."
+    docs["longdesc"] = "fence_dummy is a fake fencing agent which reports success based on its mode (pass|fail|random) without doing anything."
 
     atexit.register(atexit_handler)
     options = process_input(device_opt)

--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -406,7 +406,7 @@ enum pe_ordering {
 
     pe_order_asymmetrical          = 0x100000,  /* Indicates asymmetrical one way ordering constraint. */
     pe_order_load                  = 0x200000,  /* Only relevant if... */
-    pe_order_one_or_more           = 0x400000,  /* 'then' is only runnable if one or more of it's dependencies are too */
+    pe_order_one_or_more           = 0x400000,  /* 'then' is runnable only if one or more of its dependencies are too */
     pe_order_anti_colocation       = 0x800000,
 
     pe_order_preserve              = 0x1000000, /* Hack for breaking user ordering constraints with container resources */

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -502,7 +502,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
     if (safe_str_eq(section, XML_CIB_TAG_STATUS)) {
         /* Throttle the amount of costly validation we perform due to status updates
          * a) we don't really care whats in the status section
-         * b) we don't validate any of it's contents at the moment anyway
+         * b) we don't validate any of its contents at the moment anyway
          */
         check_dtd = FALSE;
     }

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -200,14 +200,14 @@ crm_compare_age(struct timeval your_age)
         crm_debug("Win: %ld vs %ld (seconds)", (long)our_age.tv_sec, (long)your_age.tv_sec);
         return 1;
     } else if (our_age.tv_sec < your_age.tv_sec) {
-        crm_debug("Loose: %ld vs %ld (seconds)", (long)our_age.tv_sec, (long)your_age.tv_sec);
+        crm_debug("Lose: %ld vs %ld (seconds)", (long)our_age.tv_sec, (long)your_age.tv_sec);
         return -1;
     } else if (our_age.tv_usec > your_age.tv_usec) {
         crm_debug("Win: %ld.%ld vs %ld.%ld (usec)",
                   (long)our_age.tv_sec, (long)our_age.tv_usec, (long)your_age.tv_sec, (long)your_age.tv_usec);
         return 1;
     } else if (our_age.tv_usec < your_age.tv_usec) {
-        crm_debug("Loose: %ld.%ld vs %ld.%ld (usec)",
+        crm_debug("Lose: %ld.%ld vs %ld.%ld (usec)",
                   (long)our_age.tv_sec, (long)our_age.tv_usec, (long)your_age.tv_sec, (long)your_age.tv_usec);
         return -1;
     }

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -274,7 +274,7 @@ pe_find_node_any(GListPtr nodes, const char *id, const char *uname)
     if (match) {
         return match;
     }
-    crm_trace("Looking up %s via it's uname instead", uname);
+    crm_trace("Looking up %s via its uname instead", uname);
     return pe_find_node(nodes, uname);
 }
 

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1685,7 +1685,7 @@ cli_resource_move(const char *rsc_id, const char *host_name, cib_t * cib, pe_wor
                     " --ban %s--host <name>", rsc_id, scope_master?"promoted":"active", scope_master?"--master ":"");
 
         } else {
-            crm_trace("Not banning %s from it's current location: not active", rsc_id);
+            crm_trace("Not banning %s from its current location: not active", rsc_id);
         }
     }
 


### PR DESCRIPTION
1.1.15 introduced a regression where a remote node's LRM history would be cleared when its connection resource is stopped, rather than only at start. This could interfere with the cluster detecting which stop actions are implied by fencing.