### PR TITLE
Fix: pacemaker_remote: set timeout for remote connection to sbd_timeo…

### DIFF
--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -203,6 +203,7 @@ xmlNode *crm_remote_parse_buffer(crm_remote_t * remote);
 int crm_remote_tcp_connect(const char *host, int port);
 int crm_remote_tcp_connect_async(const char *host, int port, int timeout,       /*ms */
                                  int *timer_id, void *userdata, void (*callback) (void *userdata, int sock));
+int crm_remote_accept(int ssock);
 
 #  ifdef HAVE_GNUTLS_GNUTLS_H
 /*!

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -129,6 +129,7 @@ gboolean check_number(const char *value);
 gboolean check_quorum(const char *value);
 gboolean check_script(const char *value);
 gboolean check_utilization(const char *value);
+long crm_get_sbd_timeout(void);
 gboolean check_sbd_timeout(const char *value);
 
 /* Shared PE/crmd functionality */

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -28,6 +28,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
+#include <netinet/tcp.h>
 #include <netdb.h>
 
 #include <stdlib.h>
@@ -927,4 +928,84 @@ int
 crm_remote_tcp_connect(const char *host, int port)
 {
     return crm_remote_tcp_connect_async(host, port, -1, NULL, NULL, NULL);
+}
+
+
+/* Convert a struct sockaddr address to a string, IPv4 and IPv6: */
+
+static char *
+get_ip_str(const struct sockaddr_storage * sa, char * s, size_t maxlen)
+{
+    switch(((struct sockaddr *)sa)->sa_family) {
+        case AF_INET:
+            inet_ntop(AF_INET, &(((struct sockaddr_in *)sa)->sin_addr),
+                      s, maxlen);
+            break;
+
+        case AF_INET6:
+            inet_ntop(AF_INET6, &(((struct sockaddr_in6 *)sa)->sin6_addr),
+                      s, maxlen);
+            break;
+
+        default:
+            strncpy(s, "Unknown AF", maxlen);
+            return NULL;
+    }
+
+    return s;
+}
+
+int
+crm_remote_accept(int ssock)
+{
+    int csock = 0;
+    int rc = 0;
+    int flag = 0;
+    unsigned laddr = 0;
+    struct sockaddr_storage addr;
+    char addr_str[INET6_ADDRSTRLEN];
+#ifdef TCP_USER_TIMEOUT
+    int optval;
+    long sbd_timeout = crm_get_sbd_timeout();
+#endif
+
+    /* accept the connection */
+    laddr = sizeof(addr);
+    memset(&addr, 0, sizeof(addr));
+    csock = accept(ssock, (struct sockaddr *)&addr, &laddr);
+    get_ip_str(&addr, addr_str, INET6_ADDRSTRLEN);
+    crm_info("New remote connection from %s", addr_str);
+
+    if (csock == -1) {
+        crm_err("accept socket failed");
+        return -1;
+    }
+
+    if ((flag = fcntl(csock, F_GETFL)) >= 0) {
+        if ((rc = fcntl(csock, F_SETFL, flag | O_NONBLOCK)) < 0) {
+            crm_err("fcntl() write failed");
+            close(csock);
+            return rc;
+        }
+    } else {
+        crm_err("fcntl() read failed");
+        close(csock);
+        return flag;
+    }
+
+#ifdef TCP_USER_TIMEOUT
+    if (sbd_timeout > 0) {
+        optval = sbd_timeout / 2; /* time to fail and retry before watchdog */
+        rc = setsockopt(csock, SOL_TCP, TCP_USER_TIMEOUT,
+                        &optval, sizeof(optval));
+        if (rc < 0) {
+            crm_err("setting TCP_USER_TIMEOUT (%d) on client socket failed",
+                    optval);
+            close(csock);
+            return rc;
+        }
+    }
+#endif
+
+    return csock;
 }

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -130,34 +130,6 @@ check_timer(const char *value)
 }
 
 gboolean
-check_sbd_timeout(const char *value)
-{
-    const char *env_value = getenv("SBD_WATCHDOG_TIMEOUT");
-
-    long sbd_timeout = crm_get_msec(env_value);
-    long st_timeout = crm_get_msec(value);
-
-    if(value == NULL || st_timeout <= 0) {
-        crm_notice("Watchdog may be enabled but stonith-watchdog-timeout is disabled: %s", value);
-
-    } else if(pcmk_locate_sbd() == 0) {
-        do_crm_log_always(LOG_EMERG, "Shutting down: stonith-watchdog-timeout is configured (%ldms) but SBD is not active", st_timeout);
-        crm_exit(DAEMON_RESPAWN_STOP);
-        return FALSE;
-
-    } else if(st_timeout < sbd_timeout) {
-        do_crm_log_always(LOG_EMERG, "Shutting down: stonith-watchdog-timeout (%ldms) is too short (must be greater than %ldms)",
-                          st_timeout, sbd_timeout);
-        crm_exit(DAEMON_RESPAWN_STOP);
-        return FALSE;
-    }
-
-    crm_info("Watchdog functionality is consistent: %s delay exceeds timeout of %s", value, env_value);
-    return TRUE;
-}
-
-
-gboolean
 check_boolean(const char *value)
 {
     int tmp = FALSE;


### PR DESCRIPTION
…ut/2 - needed to switch sbd_remote from one control-node to another without rebooting

sbd_remote - when pacemaker-watcher is enabled - connects to the cib via proxy.
having a timeout on the tcp-connection gives clients in general the possibility to
easily fail and possibly recover - in case of sbd_remote without running into a
watchdog-timeout.
Unfortunately TCP_USER_TIMEOUT is one of the more recent socket-options.
So code is guarded by a macro accordingly.
As pacemaker already knows the timeout sbd is setting on the watchdog, for now
half of that is used for the socket-option to still have the other half for recovery.
If this turns out to be of generic interest for other clients on remote-nodes a cluster-property
might be added to set the timeout directly - overruling, if set, what comes from the
sbd-timeout-value.
This fix alone already fixes the watchdog-reboot occurring when the control-resource
for a remote-node switches from one cluster-node to another.
Combined with some tweaking in sbd other unnecessary watchdog-reboots can
be prevented as well (Link to corresponding pull request is coming...). 