### PR TITLE
Maint: scratch.c is only useful when developing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 /configure.ac	export-subst
 /.*	export-ignore
 /travisci_build_coverity_scan.sh	export-ignore
+/scratch.c	export-ignore

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,8 +39,11 @@ test_SCRIPTS		= coverage.sh BasicSanity.sh
 test_DATA		= valgrind-pcmk.suppressions
 
 # Scratch file for ad-hoc testing
-scratch_SOURCES	= scratch.c
+nodist_scratch_SOURCES	= scratch.c
 scratch_LDADD	= $(top_builddir)/lib/common/libcrmcommon.la -lm
+
+scratch.c:
+	echo 'int main(void){}' >$@
 
 core:
 	@echo "Building only core components: $(CORE)"


### PR DESCRIPTION
Hence drop it from autotools-produced distribution files and git
archives, and make the Makefile deal with that file missing.
Alternative would be to make configure.ac figure out if that file
missing, but it sounds like too much complexity for no gain.