### PR TITLE
Test: tools: validity tests should not depend on libxml2 version

### DIFF
--- a/tools/regression.sh
+++ b/tools/regression.sh
@@ -753,7 +753,8 @@ for t in $tests; do
         -e 's/.*__xml_acl_post_process/__xml_acl_post_process/g'\
         -e 's/.*error: unpack_resources:/error: unpack_resources:/g'\
         -e 's/ last-rc-change=\"[0-9]*\"//'\
-        -e 's|^/tmp/[0-9][0-9]*\.||' $test_home/regression.$t.out
+        -e 's|^/tmp/[0-9][0-9]*\.||'\
+        -e 's/^Entity: line [0-9][0-9]*: //' $test_home/regression.$t.out
 
     if [ $do_save = 1 ]; then
 	cp $test_home/regression.$t.out $test_home/regression.$t.exp

--- a/tools/regression.validity.exp
+++ b/tools/regression.validity.exp
@@ -23,40 +23,40 @@ Call failed: Update does not conform to the configured schema
 * Passed: cibadmin       - Try to make resulting CIB invalid (enum violation)
 =#=#=#= Begin test: Run crm_simulate with invalid CIB (enum violation) =#=#=#=
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-1.2' validation (4 of 12)
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 (   schemas.c:760   )   trace: update_validation:	pacemaker-1.2 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-1.3' validation (5 of 12)
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 (   schemas.c:760   )   trace: update_validation:	pacemaker-1.3 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.0' validation (6 of 12)
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.0 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.1' validation (7 of 12)
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.1 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.2' validation (8 of 12)
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.2 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.3' validation (9 of 12)
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.3 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.4' validation (10 of 12)
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.4 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.5' validation (11 of 12)
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.5 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.6' validation (12 of 12)
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.6 validation failed
 Your current configuration pacemaker-1.2 could not validate with any schema in range [pacemaker-1.2, pacemaker-2.6], cannot upgrade to pacemaker-2.0.
 =#=#=#= End test: Run crm_simulate with invalid CIB (enum violation) - Required key not available (126) =#=#=#=
@@ -97,37 +97,37 @@ element rsc_order: validity error : No declaration for attribute first-action of
 element rsc_order: validity error : No declaration for attribute then of element rsc_order
 (   schemas.c:760   )   trace: update_validation:	transitional-0.6 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-0.7' validation (2 of 12)
-Entity: line 1: element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:760   )   trace: update_validation:	pacemaker-0.7 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-1.0' validation (3 of 12)
-Entity: line 1: element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:760   )   trace: update_validation:	pacemaker-1.0 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-1.2' validation (4 of 12)
-Entity: line 1: element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:760   )   trace: update_validation:	pacemaker-1.2 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-1.3' validation (5 of 12)
-Entity: line 1: element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:760   )   trace: update_validation:	pacemaker-1.3 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.0' validation (6 of 12)
-Entity: line 1: element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.0 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.1' validation (7 of 12)
-Entity: line 1: element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.1 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.2' validation (8 of 12)
-Entity: line 1: element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.2 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.3' validation (9 of 12)
-Entity: line 1: element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.3 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.4' validation (10 of 12)
-Entity: line 1: element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.4 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.5' validation (11 of 12)
-Entity: line 1: element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.5 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-2.6' validation (12 of 12)
-Entity: line 1: element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:760   )   trace: update_validation:	pacemaker-2.6 validation failed
 Your current configuration pacemaker-9999.0 could not validate with any schema in range [unknown, pacemaker-2.6], cannot upgrade to pacemaker-2.0.
 =#=#=#= End test: Run crm_simulate with invalid CIB (unrecognized validate-with) - Required key not available (126) =#=#=#=
@@ -153,7 +153,7 @@ Call failed: Update does not conform to the configured schema
 * Passed: cibadmin       - Try to make resulting CIB invalid, but possibly recoverable (valid with X.Y+1)
 =#=#=#= Begin test: Run crm_simulate with invalid, but possibly recoverable CIB (valid with X.Y+1) =#=#=#=
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-1.2' validation (4 of 12)
-Entity: line 12: element tags: Relax-NG validity error : Element configuration has extra content: tags
+element tags: Relax-NG validity error : Element configuration has extra content: tags
 (   schemas.c:760   )   trace: update_validation:	pacemaker-1.2 validation failed
 (   schemas.c:751   )   debug: update_validation:	Testing 'pacemaker-1.3' validation (5 of 12)
 (   schemas.c:804   )   debug: update_validation:	Upgrading pacemaker-1.3-style configuration to pacemaker-2.0 with upgrade-1.3.xsl
@@ -276,32 +276,32 @@ element rsc_order: validity error : Element rsc_order does not carry attribute f
 element rsc_order: validity error : No declaration for attribute first of element rsc_order
 element rsc_order: validity error : No declaration for attribute first-action of element rsc_order
 element rsc_order: validity error : No declaration for attribute then of element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
-Entity: line 10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 =#=#=#= Current cib after: Make resulting CIB invalid, and without validate-with attribute =#=#=#=
 <cib epoch="31" num_updates="0" admin_epoch="0" validate-with="none">
   <configuration>


### PR DESCRIPTION
This particular change increases robustness against this particular
change (in error.c) applicable for v2.9.0+:
https://git.gnome.org/browse/libxml2/commit/?id=97fa5b3c8f3fe6ff79123ab43ed6b846fd1dd6dd