### PR TITLE
Fix: crm_mon: Do not call setenv with null value

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -3583,7 +3583,9 @@ send_custom_trap(const char *node, const char *rsc, const char *task, int target
     if(rsc) {
         setenv("CRM_notify_rsc", rsc, 1);
     }
-    setenv("CRM_notify_recipient", external_recipient, 1);
+    if (external_recipient) {
+        setenv("CRM_notify_recipient", external_recipient, 1);
+    }
     setenv("CRM_notify_node", node, 1);
     setenv("CRM_notify_task", task, 1);
     setenv("CRM_notify_desc", desc, 1);


### PR DESCRIPTION
setenv can cause a segfault if the value passed to it is NULL. Only set CRM_notify_recipient if
external_recipient is not NULL.

This could be  a change glibc between 2.21 and 2.23.1, because the issue did not seem to occur in prior versions. This can be tested by invoking crm_mon with --external-agent but not --external-recipient on fedora24.