### PR TITLE
Use new-style classes in python regression tests

### DIFF
--- a/cts/__init__.py
+++ b/cts/__init__.py
@@ -1,2 +1,19 @@
-# This file is required for python packages.
-# It is intentionally empty.
+"""Python modules for Pacemaker's Cluster Test Suite (CTS)
+
+This package provides the following modules:
+
+CIB
+cib_xml
+CM_ais
+CM_lha
+CTSaudits
+CTS
+CTSscenarios
+CTStests
+CTSvars
+environment
+logging
+patterns
+remote
+watcher
+"""

--- a/cts/logging.py
+++ b/cts/logging.py
@@ -1,112 +1,159 @@
-'''
-Classes related to producing logs
-'''
+""" Logging classes for Pacemaker's Cluster Test Suite (CTS)
+"""
 
-__copyright__='''
-Copyright (C) 2014 Andrew Beekhof <andrew@beekhof.net>
-Licensed under the GNU GPL.
-'''
+# Pacemaker targets compatibility with Python 2.6+ and 3.2+
+from __future__ import print_function, unicode_literals, absolute_import, division
 
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA.
+__copyright__ = "Copyright (C) 2014-2016 Andrew Beekhof <andrew@beekhof.net>"
+__license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
-import string, sys, time, os
+import io
+import os
+import sys
+import time
 
-class Logger:
+
+# Wrapper to detect a string under Python 2 or 3
+try:
+    _StringType = basestring
+except NameError:
+    _StringType = str
+
+def _is_string(obj):
+    """ Return True if obj is a simple string. """
+
+    return isinstance(obj, _StringType)
+
+
+def _strip(line):
+    """ Wrapper for strip() that works regardless of Python version """
+
+    if sys.version_info < (3,):
+        return line.decode('utf-8').strip()
+    else:
+        return line.strip()
+
+
+def _rstrip(line):
+    """ Wrapper for rstrip() that works regardless of Python version """
+
+    if sys.version_info < (3,):
+        return line.decode('utf-8').rstrip()
+    else:
+        return line.rstrip()
+
+
+class Logger(object):
+    """ Abstract class to use as parent for CTS logging classes """
+
     TimeFormat = "%b %d %H:%M:%S\t"
 
+    def __init__(self):
+        # Whether this logger should print debug messages
+        self.debug_target = True
+
     def __call__(self, lines):
+        """ Log specified messages """
+
         raise ValueError("Abstract class member (__call__)")
+
     def write(self, line):
-        return self(line.rstrip())
+        """ Log a single line excluding trailing whitespace """
+
+        return self(_rstrip(line))
+
     def writelines(self, lines):
-        for s in lines:
-            self.write(s)
+        """ Log a series of lines excluding trailing whitespace """
+
+        for line in lines:
+            self.write(line)
         return 1
-    def flush(self):
-        return 1
-    def isatty(self):
-        return None
+
+    def is_debug_target(self):
+        """ Return True if this logger should receive debug messages """
+
+        return self.debug_target
+
 
 class StdErrLog(Logger):
+    """ Class to log to standard error """
 
     def __init__(self, filename, tag):
-        pass
+        Logger.__init__(self)
+        self.debug_target = False
 
     def __call__(self, lines):
-        t = time.strftime(Logger.TimeFormat, time.localtime(time.time()))
-        if isinstance(lines, basestring):
-            sys.__stderr__.writelines([t, lines, "\n"])
-        else:
-            for line in lines:
-                sys.__stderr__.writelines([t, line, "\n"])
+        """ Log specified lines to stderr """
+
+        timestamp = time.strftime(Logger.TimeFormat,
+                                  time.localtime(time.time()))
+        if _is_string(lines):
+            lines = [lines]
+        for line in lines:
+            print("%s%s" % (timestamp, line), file=sys.__stderr__)
         sys.__stderr__.flush()
 
-    def name(self):
-        return "StdErrLog"
 
 class FileLog(Logger):
-    def __init__(self, filename, tag):
-        self.logfile=filename
-        self.hostname = os.uname()[1]+" "
+    """ Class to log to a file """
 
-        self.source = ""
+    def __init__(self, filename, tag):
+        Logger.__init__(self)
+        self.logfile = filename
+        self.hostname = os.uname()[1]
         if tag:
-            self.source = tag+": "
+            self.source = tag + ": "
+        else:
+            self.source = ""
 
     def __call__(self, lines):
+        """ Log specified lines to the file """
 
-        fd = open(self.logfile, "a")
-        t = time.strftime(Logger.TimeFormat, time.localtime(time.time()))
+        logf = io.open(self.logfile, "at")
+        timestamp = time.strftime(Logger.TimeFormat,
+                                  time.localtime(time.time()))
+        if _is_string(lines):
+            lines = [lines]
+        for line in lines:
+            print("%s%s %s%s" % (timestamp, self.hostname, self.source, line),
+                  file=logf)
+        logf.close()
 
-        if isinstance(lines, basestring):
-            fd.writelines([t, self.hostname, self.source, lines, "\n"])
-        else:
-            for line in lines:
-                fd.writelines([t, self.hostname, self.source, line, "\n"])
-        fd.close()
 
-    def name(self):
-        return "FileLog"
+class LogFactory(object):
+    """ Singleton to log messages to various destinations """
 
-class LogFactory:
-
-    log_methods=[]
+    log_methods = []
     have_stderr = False
 
-    def __init__(self):
-        pass
-
     def add_file(self, filename, tag=None):
+        """ When logging messages, log them to specified file """
+
         if filename:
             LogFactory.log_methods.append(FileLog(filename, tag))
 
     def add_stderr(self):
+        """ When logging messages, log them to standard error """
+
         if not LogFactory.have_stderr:
             LogFactory.have_stderr = True
             LogFactory.log_methods.append(StdErrLog(None, None))
 
     def log(self, args):
+        """ Log a message (to all configured log destinations) """
+
         for logfn in LogFactory.log_methods:
-            logfn(string.strip(args))
+            logfn(_strip(args))
 
     def debug(self, args):
+        """ Log a debug message (to all configured log destinations) """
+
         for logfn in LogFactory.log_methods:
-            if logfn.name() != "StdErrLog":
-                logfn("debug: %s" % string.strip(args))
+            if logfn.is_debug_target():
+                logfn("debug: %s" % _strip(args))
 
     def traceback(self, traceback):
+        """ Log a stack trace (to all configured log destinations) """
+
         for logfn in LogFactory.log_methods:
             traceback.print_exc(50, logfn)

--- a/doc/Pacemaker_Development/en-US/Ch-Python.txt
+++ b/doc/Pacemaker_Development/en-US/Ch-Python.txt
@@ -85,6 +85,8 @@ The future imports used in <<s-python-boilerplate>> mean:
 * Always use the I/O functions from the +io+ module rather than the native
   I/O functions (e.g. +io.open()+ rather than +open()+).
 * When opening a file, always use the +t+ (text) or +b+ (binary) mode flag.
+* When creating classes, always specify a parent class to ensure that it is a
+  "new-style" class (e.g. +class Foo(object):+ rather than +class Foo:+)
 * Be aware of the bytes type added in Python 3. Many places where strings are
   used in Python 2 use bytes or bytearrays in Python 3 (for example, the pipes
   used with +subprocess.Popen()+). Code should handle both possibilities.
@@ -133,3 +135,7 @@ indexterm:[Python,formatting]
   definitely keep it under 120 characters.
 * Where not conflicting with this style guide, it is recommended (but not
   required) to follow https://www.python.org/dev/peps/pep-0008/:[PEP 8].
+* It is recommended (but not required) to format Python code such that
+  `pylint --disable=line-too-long,too-many-lines,too-many-instance-attributes,too-many-arguments,too-many-statements`
+  produces minimal complaints (even better if you don't need to disable all
+  those checks).

--- a/doc/Pacemaker_Development/en-US/Revision_History.xml
+++ b/doc/Pacemaker_Development/en-US/Revision_History.xml
@@ -24,7 +24,7 @@
 
       <revision>
         <revnumber>1-1</revnumber>
-        <date>Wed Aug 17 2016</date>
+        <date>Mon Aug 29 2016</date>
         <author>
           <firstname>Ken</firstname><surname>Gaillot</surname>
           <email>kgaillot@redhat.com</email>

--- a/fencing/fence_dummy
+++ b/fencing/fence_dummy
@@ -24,39 +24,44 @@ LONG_DESC = """fence_dummy is a fake fencing agent which reports success
 based on its mode (pass|fail|random) without doing anything."""
 
 # Short options used: ifhmnoqsvBDHMRUV
-all_opt = {
+ALL_OPT = {
     "quiet"   : {
         "getopt" : "q",
         "help" : "",
-        "order" : 50 },
+        "order" : 50
+        },
     "verbose" : {
         "getopt" : "v",
         "longopt" : "verbose",
         "help" : "-v, --verbose                  Verbose mode",
         "required" : "0",
         "shortdesc" : "Verbose mode",
-        "order" : 51 },
+        "order" : 51
+        },
     "debug" : {
         "getopt" : "D:",
-        "longopt" : "debug-file", 
+        "longopt" : "debug-file",
         "help" : "-D, --debug-file=[debugfile]   Debugging to output file",
         "required" : "0",
         "shortdesc" : "Write debug information to given file",
-        "order" : 52 },
-    "version" : { 
+        "order" : 52
+        },
+    "version" : {
         "getopt" : "V",
         "longopt" : "version",
         "help" : "-V, --version                  Display version information and exit",
         "required" : "0",
         "shortdesc" : "Display version information and exit",
-        "order" : 53 },
+        "order" : 53
+        },
     "help"    : {
         "getopt" : "h",
         "longopt" : "help",
         "help" : "-h, --help                     Display this help and exit",
         "required" : "0",
         "shortdesc" : "Display help and exit",
-        "order" : 54 },
+        "order" : 54
+        },
     "action" : {
         "getopt" : "o:",
         "longopt" : "action",
@@ -64,42 +69,48 @@ all_opt = {
         "required" : "1",
         "shortdesc" : "Fencing Action",
         "default" : "reboot",
-        "order" : 1 },
+        "order" : 1
+        },
     "nodename" : {
         "getopt" : "N:",
         "longopt" : "nodename",
         "help" : "-N, --nodename                 Node name of fence victim (ignored)",
         "required" : "0",
         "shortdesc" : "The node name of fence victim (ignored)",
-        "order" : 2 },
+        "order" : 2
+        },
     "mode": {
         "getopt" : "M:",
         "longopt" : "mode",
         "required" : "0",
         "help" : "-M, --mode=(pass|fail|random)  Exit status to return for non-monitor operations",
         "shortdesc" : "Whether fence operations should always pass, always fail, or fail at random",
-        "order" : 3 },
+        "order" : 3
+        },
     "monitor_mode" : {
         "getopt" : "m:",
         "longopt" : "monitor_mode",
         "help" : "-m, --monitor_mode=(pass|fail|random) Exit status to return for monitor operations",
         "required" : "0",
         "shortdesc" : "Whether monitor operations should always pass, always fail, or fail at random",
-        "order" : 3 },
+        "order" : 3
+        },
     "random_sleep_range": {
         "getopt" : "R:",
         "required" : "0",
         "longopt" : "random_sleep_range",
         "help" : "-R, --random_sleep_range=[seconds] Sleep between 1 and [seconds] before returning",
         "shortdesc" : "Wait randomly between 1 and [seconds]",
-        "order" : 3 },
+        "order" : 3
+        },
     "mock_dynamic_hosts" : {
         "getopt" : "H:",
         "longopt" : "mock_dynamic_hosts",
         "help" : "-H, --mock_dynamic_hosts=[list] What to return when dynamically queried for possible targets",
         "required" : "0",
         "shortdesc" : "A list of hosts we can fence",
-        "order" : 3 },
+        "order" : 3
+        },
     "delay" : {
         "getopt" : "f:",
         "longopt" : "delay",
@@ -107,41 +118,53 @@ all_opt = {
         "required" : "0",
         "shortdesc" : "Wait X seconds before fencing is started",
         "default" : "0",
-        "order" : 3 },
+        "order" : 3
+        },
     "port" : {
         "getopt" : "n:",
         "longopt" : "plug",
         "help" : "-n, --plug=[id]                Physical plug number on device (ignored)",
         "required" : "1",
         "shortdesc" : "Ignored",
-        "order" : 4 },
+        "order" : 4
+        },
     "switch" : {
         "getopt" : "s:",
         "longopt" : "switch",
         "help" : "-s, --switch=[id]              Physical switch number on device (ignored)",
         "required" : "0",
         "shortdesc" : "Ignored",
-        "order" : 4 },
+        "order" : 4
+        },
     "nodeid" : {
         "getopt" : "i:",
         "longopt" : "nodeid",
         "help" : "-i, --nodeid                   Corosync id of fence victim (ignored)",
         "required" : "0",
         "shortdesc" : "Ignored",
-        "order" : 4 },
+        "order" : 4
+        },
     "uuid" : {
         "getopt" : "U:",
         "longopt" : "uuid",
         "help" : "-U, --uuid                     UUID of the VM to fence (ignored)",
         "required" : "0",
         "shortdesc" : "Ignored",
-        "order" : 4 }
+        "order" : 4
+        }
 }
 
 
+def agent():
+    """ Return name this file was run as. """
+
+    return os.path.basename(sys.argv[0])
+
+
 def fail_usage(message):
-    sys.stderr.write("%s\nPlease use '-h' for usage\n" % message)
-    sys.exit(1)
+    """ Print a usage message and exit. """
+
+    sys.exit("%s\nPlease use '-h' for usage" % message)
 
 
 def show_docs(options):
@@ -149,7 +172,7 @@ def show_docs(options):
 
     device_opt = options["device_opt"]
 
-    if "-h" in options: 
+    if "-h" in options:
         usage(device_opt)
         sys.exit(0)
 
@@ -162,69 +185,73 @@ def show_docs(options):
         sys.exit(0)
 
 
+def sorted_options(avail_opt):
+    """ Return a list of all options, in their internally specified order. """
+
+    sorted_list = [(key, ALL_OPT[key]) for key in avail_opt]
+    sorted_list.sort(key=lambda x: x[1]["order"])
+    return sorted_list
+
+
 def usage(avail_opt):
-    global all_opt
+    """ Print a usage message. """
 
     print("Usage:")
-    print("\t" + os.path.basename(sys.argv[0]) + " [options]")
+    print("\t" + agent() + " [options]")
     print("Options:")
 
-    sorted_list = [ (key, all_opt[key]) for key in avail_opt ]
-    sorted_list.sort(key=lambda x: x[1]["order"])
-
-    for key, value in sorted_list:
+    for dummy, value in sorted_options(avail_opt):
         if len(value["help"]) != 0:
             print("   " + value["help"])
 
 
 def metadata(avail_opt, options):
-    global all_opt
+    """ Print agent metadata. """
 
     # This log is just for testing handling of stderr output
-    sys.stderr.write("asked for fence_dummy metadata\n")
-
-    sorted_list = [ (key, all_opt[key]) for key in avail_opt ]
-    sorted_list.sort(key=lambda x: x[1]["order"])
+    print("asked for fence_dummy metadata", file=sys.stderr)
 
     print("""<?xml version="1.0" ?>
 <resource-agent name="%s" shortdesc="%s" version="%s">
 <version>%s</version>
 <longdesc>%s</longdesc>
-<parameters>""" % (os.path.basename(sys.argv[0]), SHORT_DESC,
-                  AGENT_VERSION, OCF_VERSION, LONG_DESC))
+<parameters>""" % (agent(), SHORT_DESC, AGENT_VERSION, OCF_VERSION, LONG_DESC))
 
-    for option, value in sorted_list:
-        if "shortdesc" in all_opt[option]:
-            print("\t<parameter name=\"" + option + "\" unique=\"0\" required=\"" + all_opt[option]["required"] + "\">")
+    for option, dummy in sorted_options(avail_opt):
+        if "shortdesc" in ALL_OPT[option]:
+            print("\t<parameter name=\"" + option + "\" unique=\"0\" required=\"" + ALL_OPT[option]["required"] + "\">")
 
             default = ""
-            if "default" in all_opt[option]:
-                default = "default=\""+str(all_opt[option]["default"])+"\""
-            elif ("-" + all_opt[option]["getopt"][:-1]) in options:
-                if options["-" + all_opt[option]["getopt"][:-1]]:
+            default_name_arg = "-" + ALL_OPT[option]["getopt"][:-1]
+            default_name_no_arg = "-" + ALL_OPT[option]["getopt"]
+
+            if "default" in ALL_OPT[option]:
+                default = 'default="%s"' % str(ALL_OPT[option]["default"])
+            elif default_name_arg in options:
+                if options[default_name_arg]:
                     try:
-                        default = "default=\"" + options["-" + all_opt[option]["getopt"][:-1]] + "\""
+                        default = 'default="%s"' % options[default_name_arg]
                     except TypeError:
                         ## @todo/@note: Currently there is no clean way how to handle lists
                         ## we can create a string from it but we can't set it on command line
-                        default = "default=\"" + str(options["-" + all_opt[option]["getopt"][:-1]]) +"\""
-            elif ("-" + all_opt[option]["getopt"]) in options:
-                default = "default=\"true\" "
+                        default = 'default="%s"' % str(options[default_name_arg])
+            elif default_name_no_arg in options:
+                default = 'default="true"'
 
-            mixed = all_opt[option]["help"]
+            mixed = ALL_OPT[option]["help"]
             ## split it between option and help text
-            res = re.compile("^(.*--\S+)\s+", re.IGNORECASE | re.S).search(mixed)
-            if (None != res):
+            res = re.compile(r"^(.*--\S+)\s+", re.IGNORECASE | re.S).search(mixed)
+            if None != res:
                 mixed = res.group(1)
             mixed = mixed.replace("<", "&lt;").replace(">", "&gt;")
             print("\t\t<getopt mixed=\"" + mixed + "\" />")
 
-            if all_opt[option]["getopt"].count(":") > 0:
+            if ALL_OPT[option]["getopt"].count(":") > 0:
                 print("\t\t<content type=\"string\" "+default+" />")
             else:
                 print("\t\t<content type=\"boolean\" "+default+" />")
-                
-            print("\t\t<shortdesc lang=\"en\">" + all_opt[option]["shortdesc"] + "</shortdesc>")
+
+            print("\t\t<shortdesc lang=\"en\">" + ALL_OPT[option]["shortdesc"] + "</shortdesc>")
             print("\t</parameter>")
 
     print("""</parameters>
@@ -240,100 +267,109 @@ def metadata(avail_opt, options):
 </resource-agent>""")
 
 
-def process_input(avail_opt):
-    global all_opt
+def option_longopt(option):
+    """ Return the getopt-compatible long-option name of the given option. """
 
-    ##
-    ## Set standard environment
-    #####
-    os.putenv("LANG", "C")
-    os.putenv("LC_ALL", "C")
+    if ALL_OPT[option]["getopt"].endswith(":"):
+        return ALL_OPT[option]["longopt"] + "="
+    else:
+        return ALL_OPT[option]["longopt"]
 
-    ##
-    ## Prepare list of options for getopt
-    #####
+
+def opts_from_command_line(argv, avail_opt):
+    """ Read options from command-line arguments. """
+
+    # Prepare list of options for getopt
     getopt_string = ""
-    longopt_list = [ ]
+    longopt_list = []
     for k in avail_opt:
-        if k in all_opt:
-            getopt_string += all_opt[k]["getopt"]
+        if k in ALL_OPT:
+            getopt_string += ALL_OPT[k]["getopt"]
         else:
             fail_usage("Parse error: unknown option '"+k+"'")
 
-        if k in all_opt and "longopt" in all_opt[k]:
-            if all_opt[k]["getopt"].endswith(":"):
-                longopt_list.append(all_opt[k]["longopt"] + "=")
-            else:
-                longopt_list.append(all_opt[k]["longopt"])
+        if k in ALL_OPT and "longopt" in ALL_OPT[k]:
+            longopt_list.append(option_longopt(k))
 
-    ##
-    ## Read options from command line or standard input
-    #####
-    if len(sys.argv) > 1:
-        try:
-            opt, args = getopt.gnu_getopt(sys.argv[1:], getopt_string, longopt_list)
-        except getopt.GetoptError as error:
-            fail_usage("Parse error: " + error.msg)
+    try:
+        opt, dummy = getopt.gnu_getopt(argv, getopt_string, longopt_list)
+    except getopt.GetoptError as error:
+        fail_usage("Parse error: " + error.msg)
 
-        ## Transform longopt to short one which are used in fencing agents
-        #####
-        old_opt = opt
-        opt = { }
-        for o in dict(old_opt).keys():
-            if o.startswith("--"):
-                for x in all_opt.keys():
-                    if "longopt" in all_opt[x] and "--" + all_opt[x]["longopt"] == o:
-                        opt["-" + all_opt[x]["getopt"].rstrip(":")] = dict(old_opt)[o]
-            else:
-                opt[o] = dict(old_opt)[o]
+    # Transform longopt to short one which are used in fencing agents
+    old_opt = opt
+    opt = {}
+    for old_option in dict(old_opt).keys():
+        if old_option.startswith("--"):
+            for option in ALL_OPT.keys():
+                if "longopt" in ALL_OPT[option] and "--" + ALL_OPT[option]["longopt"] == old_option:
+                    opt["-" + ALL_OPT[option]["getopt"].rstrip(":")] = dict(old_opt)[old_option]
+        else:
+            opt[old_option] = dict(old_opt)[old_option]
 
-        ## Compatibility Layer
-        #####
-        z = dict(opt)
-        if "-T" in z:
-            z["-o"] = "status"
-        if "-n" in z:
-            z["-m"] = z["-n"]
+    # Compatibility Layer (with what? probably not needed for fence_dummy)
+    new_opt = dict(opt)
+    if "-T" in new_opt:
+        new_opt["-o"] = "status"
+    if "-n" in new_opt:
+        new_opt["-m"] = new_opt["-n"]
+    opt = new_opt
 
-        opt = z
-        ##
-        #####
-    else:
-        opt = { }
-        name = ""
-        for line in sys.stdin.readlines():
-            line = line.strip()
-            if ((line.startswith("#")) or (len(line) == 0)):
-                continue
-
-            (name, value) = (line + "=").split("=", 1)
-            value = value[:-1]
-
-            ## Compatibility Layer
-            ######
-            if name == "option":
-                name = "action"
-
-            ##
-            ######
-            if name not in avail_opt:
-                sys.stderr.write("Parse error: Ignoring unknown option '"+line+"'\n")
-                continue
-
-            if all_opt[name]["getopt"].endswith(":"):
-                opt["-"+all_opt[name]["getopt"].rstrip(":")] = value
-            elif ((value == "1") or (value.lower() == "yes") or (value.lower() == "on") or (value.lower() == "true")):
-                opt["-"+all_opt[name]["getopt"]] = "1"
     return opt
 
 
+def opts_from_stdin(avail_opt):
+    """ Read options from standard input. """
+
+    opt = {}
+    name = ""
+    for line in sys.stdin.readlines():
+        line = line.strip()
+        if line.startswith("#") or (len(line) == 0):
+            continue
+
+        (name, value) = (line + "=").split("=", 1)
+        value = value[:-1]
+
+        # Compatibility Layer (with what? probably not needed for fence_dummy)
+        if name == "option":
+            name = "action"
+
+        if name not in avail_opt:
+            print("Parse error: Ignoring unknown option '%s'" % line,
+                  file=sys.stderr)
+            continue
+
+        if ALL_OPT[name]["getopt"].endswith(":"):
+            opt["-"+ALL_OPT[name]["getopt"].rstrip(":")] = value
+        elif value.lower() in ["1", "yes", "on", "true"]:
+            opt["-"+ALL_OPT[name]["getopt"]] = "1"
+
+    return opt
+
+
+def process_input(avail_opt):
+    """ Set standard environment variables, and parse all options. """
+
+    # Set standard environment
+    os.putenv("LANG", "C")
+    os.putenv("LC_ALL", "C")
+
+    # Read options from command line or standard input
+    if len(sys.argv) > 1:
+        return opts_from_command_line(sys.argv[1:], avail_opt)
+    else:
+        return opts_from_stdin(avail_opt)
+
+
 def atexit_handler():
+    """ Close stdout on exit. """
+
     try:
         sys.stdout.close()
         os.close(1)
     except IOError:
-        sys.stderr.write("%s failed to close standard output\n"%(sys.argv[0]))
-        sys.exit(1)
+        sys.exit("%s failed to close standard output" % agent())
 
 
 def success_mode(options, option, default_value):
@@ -354,9 +390,24 @@ def success_mode(options, option, default_value):
     return exitcode
 
 
+def write_options(options):
+    """ Write out all options to debug file. """
+
+    try:
+        debugfile = io.open(options["-D"], 'at')
+        debugfile.write("### %s ###\n" % (time.strftime("%Y-%m-%d %H:%M:%S")))
+        for option in sorted(options):
+            debugfile.write("%s=%s\n" % (option, options[option]))
+        debugfile.write("###\n")
+        debugfile.close()
+    except IOError:
+        pass
+
+
 def main():
-    global all_opt
-    device_opt = all_opt.keys()
+    """ Make it so! """
+
+    device_opt = ALL_OPT.keys()
 
     ## Defaults for fence agent
     atexit.register(atexit_handler)
@@ -366,26 +417,18 @@ def main():
 
     # dump input to file
     if "-D" in options:
-        try:
-           f = io.open(options["-D"], 'at')
-           f.write("### %s ###\n" % (time.strftime("%Y-%m-%d %H:%M:%S")))
-           for v in sorted(options):
-               f.write("%s=%s\n" % (v, options[v]))
-           f.write("###\n")
-           f.close()
-        except IOError:
-           pass
+        write_options(options)
 
     if "-f" in options:
         val = int(options["-f"])
-        sys.stderr.write("delay sleep for %d seconds\n" % val)
+        print("delay sleep for %d seconds" % val, file=sys.stderr)
         time.sleep(val)
 
     # random sleep for testing
     if "-R" in options:
         val = int(options["-R"])
         ran = random.randint(1, val)
-        sys.stderr.write("random sleep for %d seconds\n" % ran)
+        print("random sleep for %d seconds" % ran, file=sys.stderr)
         time.sleep(ran)
 
     if "-o" in options:
@@ -397,12 +440,13 @@ def main():
         exitcode = success_mode(options, "-m", "pass")
 
     elif action == "list":
-        sys.stderr.write("fence_dummy action (list) called\n")
+        print("fence_dummy action (list) called", file=sys.stderr)
         if "-H" in options:
             print(options["-H"])
             exitcode = 0
         else:
-            sys.stderr.write("were asked for hostlist but attribute mock_dynamic_hosts wasn't set\n")
+            print("dynamic hostlist requires mock_dynamic_hosts to be set",
+                  file=sys.stderr)
             exitcode = 1
 
     else:
@@ -410,7 +454,7 @@ def main():
 
     # Ensure we generate some error output on failure exit.
     if exitcode == 1:
-        sys.stderr.write("simulated %s failure\n" % action)
+        print("simulated %s failure" % action, file=sys.stderr)
 
     sys.exit(exitcode)
 

--- a/fencing/regression.py.in
+++ b/fencing/regression.py.in
@@ -21,7 +21,7 @@ FENCE_DUMMY = "@datadir@/@PACKAGE@/tests/cts/fence_dummy"
 def shlex_split(command):
     """ Wrapper for shlex.split() that works around Python 2.6 bug """
 
-    if sys.version_info < (2,7,):
+    if sys.version_info < (2, 7,):
         return shlex.split(command.encode('ascii'))
     else:
         return shlex.split(command)
@@ -46,16 +46,15 @@ def pipe_output(pipes, stdout=True, stderr=False):
 
 
 def output_from_command(command):
-    test = subprocess.Popen(shlex_split(command),
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-    test.wait()
+    """ Execute command and return its standard output """
 
+    test = subprocess.Popen(shlex_split(command), stdout=subprocess.PIPE)
+    test.wait()
     return pipe_output(test).split("\n")
 
 
 def localname():
-    """ Return the uname of the local host. """
+    """ Return the uname of the local host """
 
     our_uname = output_from_command("uname -n")
     if our_uname:
@@ -65,8 +64,18 @@ def localname():
     return our_uname
 
 
-class Test:
-    def __init__(self, name, description, verbose = 0, with_cpg = 0):
+def killall(process):
+    """ Kill all instances of a process """
+
+    cmd = shlex_split("killall -9 -q %s" % process)
+    test = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    test.wait()
+
+
+class Test(object):
+    """ Executor for a single test """
+
+    def __init__(self, name, description, verbose=0, with_cpg=0):
         self.name = name
         self.description = description
         self.cmds = []
@@ -74,14 +83,14 @@ class Test:
 
         self.result_txt = ""
         self.cmd_tool_output = ""
-        self.result_exitcode = 0;
-
-        self.stonith_options = "-s"
-        self.enable_corosync = 0
+        self.result_exitcode = 0
 
         if with_cpg:
             self.stonith_options = "-c"
             self.enable_corosync = 1
+        else:
+            self.stonith_options = "-s"
+            self.enable_corosync = 0
 
         self.stonith_process = None
         self.stonith_output = ""
@@ -90,7 +99,9 @@ class Test:
 
         self.executed = 0
 
-    def __new_cmd(self, cmd, args, exitcode, stdout_match = "", no_wait = 0, stdout_negative_match = "", kill=None):
+    def __new_cmd(self, cmd, args, exitcode, stdout_match="", no_wait=0, stdout_negative_match="", kill=None):
+        """ Add a command to be executed as part of this test """
+
         self.cmds.append(
             {
                 "cmd" : cmd,
@@ -103,18 +114,12 @@ class Test:
             }
         )
 
-    def stop_pacemaker(self):
-        cmd = shlex_split("killall -9 -q pacemakerd")
-        test = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        test.wait()
-
     def start_environment(self):
-        ### make sure we are in full control here ###
-        self.stop_pacemaker()
+        """ Prepare the host for executing a test """
 
-        cmd = shlex_split("killall -9 -q stonithd")
-        test = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        test.wait()
+        # Make sure we are in full control
+        killall("pacemakerd")
+        killall("stonithd")
 
         if self.verbose:
             self.stonith_options = self.stonith_options + " -V"
@@ -129,6 +134,8 @@ class Test:
         time.sleep(1)
 
     def clean_environment(self):
+        """ Clean up the host after executing a test """
+
         if self.stonith_process:
             self.stonith_process.terminate()
             self.stonith_process.wait()
@@ -136,8 +143,8 @@ class Test:
         self.stonith_output = ""
         self.stonith_process = None
 
-        f = io.open('/tmp/stonith-regression.log', 'rt')
-        for line in f.readlines():
+        logfile = io.open('/tmp/stonith-regression.log', 'rt')
+        for line in logfile.readlines():
             self.stonith_output = self.stonith_output + line
 
         if self.verbose:
@@ -147,30 +154,48 @@ class Test:
         os.remove('/tmp/stonith-regression.log')
 
     def add_stonith_log_pattern(self, pattern):
+        """ Add a log pattern to expect from this test """
+
         self.stonith_patterns.append(pattern)
 
-    def add_stonith_negative_log_pattern(self, pattern):
+    def add_stonith_neg_log_pattern(self, pattern):
+        """ Add a log pattern that should not occur with this test """
+
         self.negative_stonith_patterns.append(pattern)
 
     def add_cmd(self, cmd, args):
+        """ Add a simple command to be executed as part of this test """
+
         self.__new_cmd(cmd, args, 0, "")
 
     def add_cmd_no_wait(self, cmd, args):
+        """ Add a simple command to be executed (without waiting) as part of this test """
+
         self.__new_cmd(cmd, args, 0, "", 1)
 
-    def add_cmd_check_stdout(self, cmd, args, match, no_match = ""):
+    def add_cmd_check_stdout(self, cmd, args, match, no_match=""):
+        """ Add a simple command with expected output to be executed as part of this test """
+
         self.__new_cmd(cmd, args, 0, match, 0, no_match)
 
-    def add_expected_fail_cmd(self, cmd, args, exitcode = 255):
+    def add_expected_fail_cmd(self, cmd, args, exitcode=255):
+        """ Add a command to be executed as part of this test and expected to fail """
+
         self.__new_cmd(cmd, args, exitcode, "")
 
     def get_exitcode(self):
+        """ Return the exit status of the last test execution """
+
         return self.result_exitcode
 
     def print_result(self, filler):
+        """ Print the result of the last test execution """
+
         print("%s%s" % (filler, self.result_txt))
 
     def run_cmd(self, args):
+        """ Execute a command as part of this test """
+
         cmd = shlex_split(args['args'])
         cmd.insert(0, args['cmd'])
 
@@ -200,10 +225,12 @@ class Test:
             test.returncode = -2
             print("STDOUT string '%s' was found in cmd output: %s" % (args['stdout_negative_match'], output))
 
-        return test.returncode;
+        return test.returncode
 
 
     def count_negative_matches(self, outline):
+        """ Return 1 if a line matches patterns that shouldn't have occurred """
+
         count = 0
         for line in self.negative_stonith_patterns:
             if outline.count(line):
@@ -213,12 +240,14 @@ class Test:
         return count
 
     def match_stonith_patterns(self):
+        """ Check test output for expected patterns """
+
         negative_matches = 0
         cur = 0
         pats = self.stonith_patterns
         total_patterns = len(self.stonith_patterns)
 
-        if len(self.stonith_patterns) == 0:
+        if len(self.stonith_patterns) == 0 and len(self.negative_stonith_patterns) == 0:
             return
 
         for line in self.stonith_output.split("\n"):
@@ -226,7 +255,7 @@ class Test:
             if len(pats) == 0:
                 continue
             cur = -1
-            for p in pats:
+            for pat in pats:
                 cur = cur + 1
                 if line.count(pats[cur]):
                     del pats[cur]
@@ -234,13 +263,16 @@ class Test:
 
         if len(pats) > 0 or negative_matches:
             if self.verbose:
-                for p in pats:
-                    print("Pattern Not Matched = '%s'" % p)
+                for pat in pats:
+                    print("Pattern Not Matched = '%s'" % pat)
 
-            self.result_txt = "FAILURE - '%s' failed. %d patterns out of %d not matched. %d negative matches." % (self.name, len(pats), total_patterns, negative_matches)
+            msg = "FAILURE - '%s' failed. %d patterns out of %d not matched. %d negative matches."
+            self.result_txt = msg % (self.name, len(pats), total_patterns, negative_matches)
             self.result_exitcode = -1
 
     def run(self):
+        """ Execute this test. """
+
         res = 0
         i = 1
         self.start_environment()
@@ -254,7 +286,8 @@ class Test:
             res = self.run_cmd(cmd)
             if res != cmd['expected_exitcode']:
                 print("Step %d FAILED - command returned %d, expected %d" % (i, res, cmd['expected_exitcode']))
-                self.result_txt = "FAILURE - '%s' failed at step %d. Command: %s %s" % (self.name, i, cmd['cmd'], cmd['args'])
+                msg = "FAILURE - '%s' failed at step %d. Command: %s %s"
+                self.result_txt = msg % (self.name, i, cmd['cmd'], cmd['args'])
                 self.result_exitcode = -1
                 break
             else:
@@ -273,20 +306,26 @@ class Test:
         self.executed = 1
         return res
 
-class Tests:
-    def __init__(self, verbose = 0):
+class Tests(object):
+    """ Collection of all fencing regression tests """
+
+    def __init__(self, verbose=0):
         self.tests = []
         self.verbose = verbose
         self.autogen_corosync_cfg = 0
         if not os.path.exists("/etc/corosync/corosync.conf"):
             self.autogen_corosync_cfg = 1
 
-    def new_test(self, name, description, with_cpg = 0):
+    def new_test(self, name, description, with_cpg=0):
+        """ Create a named test """
+
         test = Test(name, description, self.verbose, with_cpg)
         self.tests.append(test)
         return test
 
     def print_list(self):
+        """ List all registered tests """
+
         print("\n==== %d TESTS FOUND ====" % (len(self.tests)))
         print("%35s - %s" % ("TEST NAME", "TEST DESCRIPTION"))
         print("%35s - %s" % ("--------------------", "--------------------"))
@@ -295,6 +334,8 @@ class Tests:
         print("==== END OF LIST ====\n")
 
     def start_corosync(self):
+        """ Start the corosync process """
+
         if self.verbose:
             print("Starting corosync")
 
@@ -302,37 +343,44 @@ class Tests:
         test.wait()
         time.sleep(10)
 
-    def stop_corosync(self):
-        cmd = shlex_split("killall -9 -q corosync")
-        test = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        test.wait()
-
     def run_single(self, name):
+        """ Run a single named test """
+
         for test in self.tests:
             if test.name == name:
                 test.run()
-                break;
+                break
 
     def run_tests_matching(self, pattern):
+        """ Run all tests whose name matches a pattern """
+
         for test in self.tests:
             if test.name.count(pattern) != 0:
                 test.run()
 
     def run_cpg_only(self):
+        """ Run all corosync-enabled tests """
+
         for test in self.tests:
             if test.enable_corosync:
                 test.run()
 
     def run_no_cpg(self):
+        """ Run all standalone tests """
+
         for test in self.tests:
             if not test.enable_corosync:
                 test.run()
 
     def run_tests(self):
+        """ Run all tests """
+
         for test in self.tests:
             test.run()
 
     def exit(self):
+        """ Exit (with error status code if any test failed) """
+
         for test in self.tests:
             if test.executed == 0:
                 continue
@@ -343,8 +391,10 @@ class Tests:
         sys.exit(0)
 
     def print_results(self):
-        failures = 0;
-        success = 0;
+        """ Print summary of results of executed tests """
+
+        failures = 0
+        success = 0
         print("\n\n======= FINAL RESULTS ==========")
         print("\n--- FAILURE RESULTS:")
         for test in self.tests:
@@ -363,6 +413,8 @@ class Tests:
         print("\n--- TOTALS\n    Pass:%d\n    Fail:%d\n" % (success, failures))
 
     def build_api_sanity_tests(self):
+        """ Register tests to verify basic API usage """
+
         verbose_arg = ""
         if self.verbose:
             verbose_arg = "-V"
@@ -374,22 +426,30 @@ class Tests:
         test.add_cmd("@CRM_DAEMON_DIR@/stonith-test", "-m %s" % (verbose_arg))
 
     def build_custom_timeout_tests(self):
+        """ Register tests to verify custom timeout usage """
+
         # custom timeout without topology
         test = self.new_test("cpg_custom_timeout_1",
-                "Verify per device timeouts work as expected without using topology.", 1)
-        test.add_cmd("stonith_admin", "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
-        test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3\" -o \"pcmk_off_timeout=1\"")
-        test.add_cmd("stonith_admin", "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node3\" -o \"pcmk_off_timeout=4\"")
+                             "Verify per device timeouts work as expected without using topology.", 1)
+        test.add_cmd('stonith_admin',
+                     '-R false1 -a fence_dummy -o "mode=fail" -o "pcmk_host_list=node1 node2 node3"')
+        test.add_cmd('stonith_admin',
+                     '-R true1  -a fence_dummy -o "mode=pass" -o "pcmk_host_list=node3" -o "pcmk_off_timeout=1"')
+        test.add_cmd('stonith_admin',
+                     '-R false2 -a fence_dummy -o "mode=fail" -o "pcmk_host_list=node3" -o "pcmk_off_timeout=4"')
         test.add_cmd("stonith_admin", "-F node3 -t 2")
         # timeout is 2+1+4 = 7
         test.add_stonith_log_pattern("Total timeout set to 7")
 
         # custom timeout _WITH_ topology
         test = self.new_test("cpg_custom_timeout_2",
-                "Verify per device timeouts work as expected _WITH_ topology.", 1)
-        test.add_cmd("stonith_admin", "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
-        test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3\" -o \"pcmk_off_timeout=1\"")
-        test.add_cmd("stonith_admin", "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node3\" -o \"pcmk_off_timeout=4000\"")
+                             "Verify per device timeouts work as expected _WITH_ topology.", 1)
+        test.add_cmd('stonith_admin',
+                     '-R false1 -a fence_dummy -o "mode=fail" -o "pcmk_host_list=node1 node2 node3"')
+        test.add_cmd('stonith_admin',
+                     '-R true1  -a fence_dummy -o "mode=pass" -o "pcmk_host_list=node3" -o "pcmk_off_timeout=1"')
+        test.add_cmd('stonith_admin',
+                     '-R false2 -a fence_dummy -o "mode=fail" -o "pcmk_host_list=node3" -o "pcmk_off_timeout=4000"')
         test.add_cmd("stonith_admin", "-r node3 -i 1 -v false1")
         test.add_cmd("stonith_admin", "-r node3 -i 2 -v true1")
         test.add_cmd("stonith_admin", "-r node3 -i 3 -v false2")
@@ -398,10 +458,11 @@ class Tests:
         test.add_stonith_log_pattern("Total timeout set to 4003")
 
     def build_fence_merge_tests(self):
+        """ Register tests to verify when fence operations should be merged """
 
         ### Simple test that overlapping fencing operations get merged
         test = self.new_test("cpg_custom_merge_single",
-                "Verify overlapping identical fencing operations are merged, no fencing levels used.", 1)
+                             "Verify overlapping identical fencing operations are merged, no fencing levels used.", 1)
         test.add_cmd("stonith_admin", "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node3\"")
         test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3\" ")
         test.add_cmd("stonith_admin", "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node3\"")
@@ -415,9 +476,10 @@ class Tests:
 
         ### Test that multiple mergers occur
         test = self.new_test("cpg_custom_merge_multiple",
-                "Verify multiple overlapping identical fencing operations are merged", 1)
+                             "Verify multiple overlapping identical fencing operations are merged", 1)
         test.add_cmd("stonith_admin", "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node3\"")
-        test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"delay=2\" -o \"pcmk_host_list=node3\" ")
+        test.add_cmd("stonith_admin",
+                     "-R true1  -a fence_dummy -o \"mode=pass\" -o \"delay=2\" -o \"pcmk_host_list=node3\" ")
         test.add_cmd("stonith_admin", "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node3\"")
         test.add_cmd_no_wait("stonith_admin", "-F node3 -t 10")
         test.add_cmd_no_wait("stonith_admin", "-F node3 -t 10")
@@ -438,7 +500,8 @@ class Tests:
 
         ### Test that multiple mergers occur with topologies used
         test = self.new_test("cpg_custom_merge_with_topology",
-                "Verify multiple overlapping identical fencing operations are merged with fencing levels.", 1)
+                             "Verify multiple overlapping identical fencing operations are merged with fencing levels.",
+                             1)
         test.add_cmd("stonith_admin", "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node3\"")
         test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3\" ")
         test.add_cmd("stonith_admin", "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node3\"")
@@ -462,9 +525,11 @@ class Tests:
         test.add_stonith_log_pattern("Operation off of node3 by")
         test.add_stonith_log_pattern("Operation off of node3 by")
 
+    def build_fence_no_merge_tests(self):
+        """ Register tests to verify when fence operations should not be merged """
 
         test = self.new_test("cpg_custom_no_merge",
-                "Verify differing fencing operations are not merged", 1)
+                             "Verify differing fencing operations are not merged", 1)
         test.add_cmd("stonith_admin", "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node3 node2\"")
         test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3 node2\" ")
         test.add_cmd("stonith_admin", "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node3 node2\"")
@@ -473,16 +538,18 @@ class Tests:
         test.add_cmd("stonith_admin", "-r node3 -i 2 -v true1")
         test.add_cmd_no_wait("stonith_admin", "-F node2 -t 10")
         test.add_cmd("stonith_admin", "-F node3 -t 10")
-        test.add_stonith_negative_log_pattern("Merging stonith action off for node node3 originating from client")
+        test.add_stonith_neg_log_pattern("Merging stonith action off for node node3 originating from client")
 
     def build_standalone_tests(self):
+        """ Register a grab bag of tests that can be executed in standalone or corosync mode """
+
         test_types = [
             {
-                "prefix" : "standalone" ,
+                "prefix" : "standalone",
                 "use_cpg" : 0,
             },
             {
-                "prefix" : "cpg" ,
+                "prefix" : "cpg",
                 "use_cpg" : 1,
             },
         ]
@@ -490,10 +557,14 @@ class Tests:
         # test what happens when all devices timeout
         for test_type in test_types:
             test = self.new_test("%s_fence_multi_device_failure" % test_type["prefix"],
-                    "Verify that all devices timeout, a fencing failure is returned.", test_type["use_cpg"])
-            test.add_cmd("stonith_admin", "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R false2  -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R false3 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
+                                 "Verify that all devices timeout, a fencing failure is returned.",
+                                 test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R false2  -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R false3 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
             if test_type["use_cpg"] == 1:
                 # 194 = (unsigned char)-62 (-ETIME)
                 test.add_expected_fail_cmd("stonith_admin", "-F node3 -t 2", 194)
@@ -509,10 +580,14 @@ class Tests:
         # test what happens when multiple devices can fence a node, but the first device fails.
         for test_type in test_types:
             test = self.new_test("%s_fence_device_failure_rollover" % test_type["prefix"],
-                    "Verify that when one fence device fails for a node, the others are tried.", test_type["use_cpg"])
-            test.add_cmd("stonith_admin", "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
+                                 "Verify that when one fence device fails for a node, the others are tried.",
+                                 test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
             test.add_cmd("stonith_admin", "-F node3 -t 2")
 
             if test_type["use_cpg"] == 1:
@@ -524,9 +599,9 @@ class Tests:
                 continue
 
             test = self.new_test("%s_topology_simple" % test_type["prefix"],
-                    "Verify all fencing devices at a level are used.", test_type["use_cpg"])
-            test.add_cmd("stonith_admin", "-R true  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-
+                                 "Verify all fencing devices at a level are used.", test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         "-R true  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
             test.add_cmd("stonith_admin", "-r node3 -i 1 -v true")
             test.add_cmd("stonith_admin", "-F node3 -t 2")
 
@@ -540,9 +615,10 @@ class Tests:
                 continue
 
             test = self.new_test("%s_topology_add_remove" % test_type["prefix"],
-                    "Verify fencing occurrs after all topology levels are removed", test_type["use_cpg"])
-            test.add_cmd("stonith_admin", "-R true  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-
+                                 "Verify fencing occurrs after all topology levels are removed",
+                                 test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         "-R true  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
             test.add_cmd("stonith_admin", "-r node3 -i 1 -v true")
             test.add_cmd("stonith_admin", "-d node3 -i 1")
             test.add_cmd("stonith_admin", "-F node3 -t 2")
@@ -556,10 +632,12 @@ class Tests:
                 continue
 
             test = self.new_test("%s_topology_device_fails" % test_type["prefix"],
-                    "Verify if one device in a level fails, the other is tried.", test_type["use_cpg"])
-            test.add_cmd("stonith_admin", "-R false  -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R true  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-
+                                 "Verify if one device in a level fails, the other is tried.",
+                                 test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         "-R false  -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
             test.add_cmd("stonith_admin", "-r node3 -i 1 -v false")
             test.add_cmd("stonith_admin", "-r node3 -i 2 -v true")
             test.add_cmd("stonith_admin", "-F node3 -t 20")
@@ -574,13 +652,20 @@ class Tests:
                 continue
 
             test = self.new_test("%s_topology_multi_level_fails" % test_type["prefix"],
-                    "Verify if one level fails, the next leve is tried.", test_type["use_cpg"])
-            test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R true2  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R true3  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R true4  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
+                                 "Verify if one level fails, the next leve is tried.",
+                                 test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true2  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true3  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true4  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
 
             test.add_cmd("stonith_admin", "-r node3 -i 1 -v false1")
             test.add_cmd("stonith_admin", "-r node3 -i 1 -v true1")
@@ -604,11 +689,16 @@ class Tests:
                 continue
 
             test = self.new_test("%s_topology_missing_devices" % test_type["prefix"],
-                    "Verify topology can continue with missing devices.", test_type["use_cpg"])
-            test.add_cmd("stonith_admin", "-R true2  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R true3  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R true4  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
+                                 "Verify topology can continue with missing devices.",
+                                 test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         "-R true2  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true3  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true4  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
 
             test.add_cmd("stonith_admin", "-r node3 -i 1 -v false1")
             test.add_cmd("stonith_admin", "-r node3 -i 1 -v true1")
@@ -625,13 +715,19 @@ class Tests:
                 continue
 
             test = self.new_test("%s_topology_level_removal" % test_type["prefix"],
-                    "Verify level removal works.", test_type["use_cpg"])
-            test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R true2  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R true3  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R true4  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
+                                 "Verify level removal works.", test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true2  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true3  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true4  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
 
             test.add_cmd("stonith_admin", "-r node3 -i 1 -v false1")
             test.add_cmd("stonith_admin", "-r node3 -i 1 -v true1")
@@ -649,7 +745,7 @@ class Tests:
 
             test.add_stonith_log_pattern("Total timeout set to 8")
             test.add_stonith_log_pattern("for host 'node3' with device 'false1' returned: -201")
-            test.add_stonith_negative_log_pattern("for host 'node3' with device 'false2' returned: ")
+            test.add_stonith_neg_log_pattern("for host 'node3' with device 'false2' returned: ")
             test.add_stonith_log_pattern("for host 'node3' with device 'true3' returned: 0")
             test.add_stonith_log_pattern("for host 'node3' with device 'true4' returned: 0")
 
@@ -659,7 +755,8 @@ class Tests:
                 continue
 
             test = self.new_test("%s_topology_level_pattern" % test_type["prefix"],
-                    "Verify targeting topology by node name pattern works.", test_type["use_cpg"])
+                                 "Verify targeting topology by node name pattern works.",
+                                 test_type["use_cpg"])
             test.add_cmd("stonith_admin",
                          """-R true -a fence_dummy -o "mode=pass" -o "pcmk_host_list=node1 node2 node3" """)
             test.add_cmd("stonith_admin", """-r '@node.*' -i 1 -v true""")
@@ -683,18 +780,21 @@ class Tests:
         # test the stonith builds the correct list of devices that can fence a node.
         for test_type in test_types:
             test = self.new_test("%s_list_devices" % test_type["prefix"],
-                    "Verify list of devices that can fence a node is correct", test_type["use_cpg"])
-            test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3\"")
-            test.add_cmd("stonith_admin", "-R true2 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-R true3 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-
+                                 "Verify list of devices that can fence a node is correct",
+                                 test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true2 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true3 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
             test.add_cmd_check_stdout("stonith_admin", "-l node1 -V", "true2", "true1")
             test.add_cmd_check_stdout("stonith_admin", "-l node1 -V", "true3", "true1")
 
         # simple test of device monitor
         for test_type in test_types:
             test = self.new_test("%s_monitor" % test_type["prefix"],
-                    "Verify device is reachable", test_type["use_cpg"])
+                                 "Verify device is reachable", test_type["use_cpg"])
             test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3\"")
             test.add_cmd("stonith_admin", "-R false1  -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node3\"")
 
@@ -727,7 +827,8 @@ class Tests:
         # simple register test
         for test_type in test_types:
             test = self.new_test("%s_register" % test_type["prefix"],
-                    "Verify devices can be registered and un-registered", test_type["use_cpg"])
+                                 "Verify devices can be registered and un-registered",
+                                 test_type["use_cpg"])
             test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3\"")
 
             test.add_cmd("stonith_admin", "-Q true1")
@@ -739,7 +840,8 @@ class Tests:
         # simple reboot test
         for test_type in test_types:
             test = self.new_test("%s_reboot" % test_type["prefix"],
-                    "Verify devices can be rebooted", test_type["use_cpg"])
+                                 "Verify devices can be rebooted",
+                                 test_type["use_cpg"])
             test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3\"")
 
             test.add_cmd("stonith_admin", "-B node3 -t 2")
@@ -753,7 +855,8 @@ class Tests:
             if test_type["use_cpg"] == 0:
                 continue
             test = self.new_test("%s_fence_history" % test_type["prefix"],
-                    "Verify last fencing operation is returned.", test_type["use_cpg"])
+                                 "Verify last fencing operation is returned.",
+                                 test_type["use_cpg"])
             test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3\"")
 
             test.add_cmd("stonith_admin", "-F node3 -t 2 -V")
@@ -763,7 +866,8 @@ class Tests:
         # simple test of dynamic list query
         for test_type in test_types:
             test = self.new_test("%s_dynamic_list_query" % test_type["prefix"],
-                    "Verify dynamic list of fencing devices can be retrieved.", test_type["use_cpg"])
+                                 "Verify dynamic list of fencing devices can be retrieved.",
+                                 test_type["use_cpg"])
             test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o mock_dynamic_hosts=fake_port_1")
             test.add_cmd("stonith_admin", "-R true2  -a fence_dummy -o mock_dynamic_hosts=fake_port_1")
             test.add_cmd("stonith_admin", "-R true3  -a fence_dummy -o mock_dynamic_hosts=fake_port_1")
@@ -774,17 +878,19 @@ class Tests:
         # fence using dynamic list query
         for test_type in test_types:
             test = self.new_test("%s_fence_dynamic_list_query" % test_type["prefix"],
-                    "Verify dynamic list of fencing devices can be retrieved.", test_type["use_cpg"])
+                                 "Verify dynamic list of fencing devices can be retrieved.",
+                                 test_type["use_cpg"])
             test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o mock_dynamic_hosts=fake_port_1")
             test.add_cmd("stonith_admin", "-R true2  -a fence_dummy -o mock_dynamic_hosts=fake_port_1")
             test.add_cmd("stonith_admin", "-R true3  -a fence_dummy -o mock_dynamic_hosts=fake_port_1")
 
-            test.add_cmd("stonith_admin", "-F fake_port_1 -t 5 -V");
+            test.add_cmd("stonith_admin", "-F fake_port_1 -t 5 -V")
 
         # simple test of  query using status action
         for test_type in test_types:
             test = self.new_test("%s_status_query" % test_type["prefix"],
-                    "Verify dynamic list of fencing devices can be retrieved.", test_type["use_cpg"])
+                                 "Verify dynamic list of fencing devices can be retrieved.",
+                                 test_type["use_cpg"])
             test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_check=status\"")
             test.add_cmd("stonith_admin", "-R true2  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_check=status\"")
             test.add_cmd("stonith_admin", "-R true3  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_check=status\"")
@@ -794,92 +900,121 @@ class Tests:
         # test what happens when no reboot action is advertised
         for test_type in test_types:
             test = self.new_test("%s_no_reboot_support" % test_type["prefix"],
-                    "Verify reboot action defaults to off when no reboot action is advertised by agent.", test_type["use_cpg"])
-            test.add_cmd("stonith_admin", "-R true1 -a fence_dummy_no_reboot -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-B node1 -t 5 -V");
+                                 "Verify reboot action defaults to off when no reboot action is advertised by agent.",
+                                 test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         "-R true1 -a fence_dummy_no_reboot -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin", "-B node1 -t 5 -V")
             test.add_stonith_log_pattern("does not advertise support for 'reboot', performing 'off'")
-            test.add_stonith_log_pattern("with device 'true1' returned: 0 (OK)");
+            test.add_stonith_log_pattern("with device 'true1' returned: 0 (OK)")
 
         # make sure reboot is used when reboot action is advertised
         for test_type in test_types:
             test = self.new_test("%s_with_reboot_support" % test_type["prefix"],
-                    "Verify reboot action can be used when metadata advertises it.", test_type["use_cpg"])
-            test.add_cmd("stonith_admin", "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-B node1 -t 5 -V");
-            test.add_stonith_negative_log_pattern("does not advertise support for 'reboot', performing 'off'")
-            test.add_stonith_log_pattern("with device 'true1' returned: 0 (OK)");
+                                 "Verify reboot action can be used when metadata advertises it.",
+                                 test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+            test.add_cmd("stonith_admin", "-B node1 -t 5 -V")
+            test.add_stonith_neg_log_pattern("does not advertise support for 'reboot', performing 'off'")
+            test.add_stonith_log_pattern("with device 'true1' returned: 0 (OK)")
 
     def build_nodeid_tests(self):
+        """ Register tests that use a corosync node id """
+
         our_uname = localname()
 
         ### verify nodeid is supplied when nodeid is in the metadata parameters
         test = self.new_test("cpg_supply_nodeid",
-                "Verify nodeid is given when fence agent has nodeid as parameter", 1)
+                             "Verify nodeid is given when fence agent has nodeid as parameter", 1)
 
-        test.add_cmd("stonith_admin", "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s\"" % (our_uname))
+        test.add_cmd("stonith_admin",
+                     "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s\"" % (our_uname))
         test.add_cmd("stonith_admin", "-F %s -t 3" % (our_uname))
         test.add_stonith_log_pattern("For stonith action (off) for victim %s, adding nodeid" % (our_uname))
 
         ### verify nodeid is _NOT_ supplied when nodeid is not in the metadata parameters
         test = self.new_test("cpg_do_not_supply_nodeid",
-                "Verify nodeid is _NOT_ given when fence agent does not have nodeid as parameter", 1)
+                             "Verify nodeid is _NOT_ given when fence agent does not have nodeid as parameter",
+                             1)
 
-        test.add_cmd("stonith_admin", "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s\"" % (our_uname))
+        test.add_cmd("stonith_admin",
+                     "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s\"" % (our_uname))
         test.add_cmd("stonith_admin", "-F %s -t 3" % (our_uname))
-        test.add_stonith_negative_log_pattern("For stonith action (off) for victim %s, adding nodeid" % (our_uname))
+        test.add_stonith_neg_log_pattern("For stonith action (off) for victim %s, adding nodeid" % (our_uname))
 
         ### verify nodeid use doesn't explode standalone mode
         test = self.new_test("standalone_do_not_supply_nodeid",
-                "Verify nodeid in metadata parameter list doesn't kill standalone mode", 0)
+                             "Verify nodeid in metadata parameter list doesn't kill standalone mode",
+                             0)
 
-        test.add_cmd("stonith_admin", "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s\"" % (our_uname))
+        test.add_cmd("stonith_admin",
+                     "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s\"" % (our_uname))
         test.add_cmd("stonith_admin", "-F %s -t 3" % (our_uname))
-        test.add_stonith_negative_log_pattern("For stonith action (off) for victim %s, adding nodeid" % (our_uname))
+        test.add_stonith_neg_log_pattern("For stonith action (off) for victim %s, adding nodeid" % (our_uname))
 
     def build_unfence_tests(self):
+        """ Register tests that verify unfencing """
+
         our_uname = localname()
 
         ### verify unfencing using automatic unfencing
         test = self.new_test("cpg_unfence_required_1",
-                "Verify require unfencing on all devices when automatic=true in agent's metadata", 1)
-        test.add_cmd("stonith_admin", "-R true1 -a fence_dummy_automatic_unfence -o \"mode=pass\" -o \"pcmk_host_list=%s\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-R true2 -a fence_dummy_automatic_unfence -o \"mode=pass\" -o \"pcmk_host_list=%s\"" % (our_uname))
+                             "Verify require unfencing on all devices when automatic=true in agent's metadata",
+                             1)
+        test.add_cmd('stonith_admin',
+                     '-R true1 -a fence_dummy_auto_unfence -o "mode=pass" -o "pcmk_host_list=%s"' % (our_uname))
+        test.add_cmd('stonith_admin',
+                     '-R true2 -a fence_dummy_auto_unfence -o "mode=pass" -o "pcmk_host_list=%s"' % (our_uname))
         test.add_cmd("stonith_admin", "-U %s -t 3" % (our_uname))
         # both devices should be executed
-        test.add_stonith_log_pattern("with device 'true1' returned: 0 (OK)");
-        test.add_stonith_log_pattern("with device 'true2' returned: 0 (OK)");
-
+        test.add_stonith_log_pattern("with device 'true1' returned: 0 (OK)")
+        test.add_stonith_log_pattern("with device 'true2' returned: 0 (OK)")
 
         ### verify unfencing using automatic unfencing fails if any of the required agents fail
         test = self.new_test("cpg_unfence_required_2",
-                "Verify require unfencing on all devices when automatic=true in agent's metadata", 1)
-        test.add_cmd("stonith_admin", "-R true1 -a fence_dummy_automatic_unfence -o \"mode=pass\" -o \"pcmk_host_list=%s\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-R true2 -a fence_dummy_automatic_unfence -o \"mode=fail\" -o \"pcmk_host_list=%s\"" % (our_uname))
+                             "Verify require unfencing on all devices when automatic=true in agent's metadata",
+                             1)
+        test.add_cmd('stonith_admin',
+                     '-R true1 -a fence_dummy_auto_unfence -o "mode=pass" -o "pcmk_host_list=%s"' % (our_uname))
+        test.add_cmd('stonith_admin',
+                     '-R true2 -a fence_dummy_auto_unfence -o "mode=fail" -o "pcmk_host_list=%s"' % (our_uname))
         test.add_expected_fail_cmd("stonith_admin", "-U %s -t 6" % (our_uname), 143)
 
         ### verify unfencing using automatic devices with topology
         test = self.new_test("cpg_unfence_required_3",
-                "Verify require unfencing on all devices even when required devices are at different topology levels", 1)
-        test.add_cmd("stonith_admin", "-R true1 -a fence_dummy_automatic_unfence -o \"mode=pass\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-R true2 -a fence_dummy_automatic_unfence -o \"mode=pass\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
+                             "Verify require unfencing on all devices even when at different topology levels",
+                             1)
+        test.add_cmd('stonith_admin',
+                     '-R true1 -a fence_dummy_auto_unfence -o "mode=pass" -o "pcmk_host_list=%s node3"' % (our_uname))
+        test.add_cmd('stonith_admin',
+                     '-R true2 -a fence_dummy_auto_unfence -o "mode=pass" -o "pcmk_host_list=%s node3"' % (our_uname))
         test.add_cmd("stonith_admin", "-r %s -i 1 -v true1" % (our_uname))
         test.add_cmd("stonith_admin", "-r %s -i 2 -v true2" % (our_uname))
         test.add_cmd("stonith_admin", "-U %s -t 3" % (our_uname))
-        test.add_stonith_log_pattern("with device 'true1' returned: 0 (OK)");
-        test.add_stonith_log_pattern("with device 'true2' returned: 0 (OK)");
-
+        test.add_stonith_log_pattern("with device 'true1' returned: 0 (OK)")
+        test.add_stonith_log_pattern("with device 'true2' returned: 0 (OK)")
 
         ### verify unfencing using automatic devices with topology
         test = self.new_test("cpg_unfence_required_4",
-                "Verify all required devices are executed even with topology levels fail.", 1)
-        test.add_cmd("stonith_admin", "-R true1 -a fence_dummy_automatic_unfence -o \"mode=pass\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-R true2 -a fence_dummy_automatic_unfence -o \"mode=pass\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-R true3 -a fence_dummy_automatic_unfence -o \"mode=pass\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-R true4 -a fence_dummy_automatic_unfence -o \"mode=pass\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-R false3 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-R false4 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
+                             "Verify all required devices are executed even with topology levels fail.",
+                             1)
+        test.add_cmd('stonith_admin',
+                     '-R true1 -a fence_dummy_auto_unfence -o "mode=pass" -o "pcmk_host_list=%s node3"' % (our_uname))
+        test.add_cmd('stonith_admin',
+                     '-R true2 -a fence_dummy_auto_unfence -o "mode=pass" -o "pcmk_host_list=%s node3"' % (our_uname))
+        test.add_cmd('stonith_admin',
+                     '-R true3 -a fence_dummy_auto_unfence -o "mode=pass" -o "pcmk_host_list=%s node3"' % (our_uname))
+        test.add_cmd('stonith_admin',
+                     '-R true4 -a fence_dummy_auto_unfence -o "mode=pass" -o "pcmk_host_list=%s node3"' % (our_uname))
+        test.add_cmd('stonith_admin',
+                     '-R false1 -a fence_dummy -o "mode=fail" -o "pcmk_host_list=%s node3"' % (our_uname))
+        test.add_cmd('stonith_admin',
+                     '-R false2 -a fence_dummy -o "mode=fail" -o "pcmk_host_list=%s node3"' % (our_uname))
+        test.add_cmd('stonith_admin',
+                     '-R false3 -a fence_dummy -o "mode=fail" -o "pcmk_host_list=%s node3"' % (our_uname))
+        test.add_cmd('stonith_admin',
+                     '-R false4 -a fence_dummy -o "mode=fail" -o "pcmk_host_list=%s node3"' % (our_uname))
         test.add_cmd("stonith_admin", "-r %s -i 1 -v true1" % (our_uname))
         test.add_cmd("stonith_admin", "-r %s -i 1 -v false1" % (our_uname))
         test.add_cmd("stonith_admin", "-r %s -i 2 -v false2" % (our_uname))
@@ -889,33 +1024,42 @@ class Tests:
         test.add_cmd("stonith_admin", "-r %s -i 3 -v false4" % (our_uname))
         test.add_cmd("stonith_admin", "-r %s -i 4 -v true4" % (our_uname))
         test.add_cmd("stonith_admin", "-U %s -t 3" % (our_uname))
-        test.add_stonith_log_pattern("with device 'true1' returned: 0 (OK)");
-        test.add_stonith_log_pattern("with device 'true2' returned: 0 (OK)");
-        test.add_stonith_log_pattern("with device 'true3' returned: 0 (OK)");
-        test.add_stonith_log_pattern("with device 'true4' returned: 0 (OK)");
+        test.add_stonith_log_pattern("with device 'true1' returned: 0 (OK)")
+        test.add_stonith_log_pattern("with device 'true2' returned: 0 (OK)")
+        test.add_stonith_log_pattern("with device 'true3' returned: 0 (OK)")
+        test.add_stonith_log_pattern("with device 'true4' returned: 0 (OK)")
+
+    def build_unfence_on_target_tests(self):
+        """ Register tests that verify unfencing that runs on the target """
+
+        our_uname = localname()
 
         ### verify unfencing using on_target device
         test = self.new_test("cpg_unfence_on_target_1",
-                "Verify unfencing with on_target = true", 1)
-        test.add_cmd("stonith_admin", "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s\"" % (our_uname))
+                             "Verify unfencing with on_target = true", 1)
+        test.add_cmd("stonith_admin",
+                     "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s\"" % (our_uname))
         test.add_cmd("stonith_admin", "-U %s -t 3" % (our_uname))
         test.add_stonith_log_pattern("(on) to be executed on the target node")
 
-
         ### verify failure of unfencing using on_target device
         test = self.new_test("cpg_unfence_on_target_2",
-                "Verify failure unfencing with on_target = true", 1)
-        test.add_cmd("stonith_admin", "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s node_fake_1234\"" % (our_uname))
+                             "Verify failure unfencing with on_target = true",
+                             1)
+        test.add_cmd("stonith_admin",
+                     "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s node_fake_1234\"" % (our_uname))
         test.add_expected_fail_cmd("stonith_admin", "-U node_fake_1234 -t 3", 237)
         test.add_stonith_log_pattern("(on) to be executed on the target node")
 
-
         ### verify unfencing using on_target device with topology
         test = self.new_test("cpg_unfence_on_target_3",
-                "Verify unfencing with on_target = true using topology", 1)
+                             "Verify unfencing with on_target = true using topology",
+                             1)
 
-        test.add_cmd("stonith_admin", "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-R true2 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
+        test.add_cmd("stonith_admin",
+                     "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
+        test.add_cmd("stonith_admin",
+                     "-R true2 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s node3\"" % (our_uname))
 
         test.add_cmd("stonith_admin", "-r %s -i 1 -v true1" % (our_uname))
         test.add_cmd("stonith_admin", "-r %s -i 2 -v true2" % (our_uname))
@@ -925,10 +1069,13 @@ class Tests:
 
         ### verify unfencing using on_target device with topology fails when victim node doesn't exist
         test = self.new_test("cpg_unfence_on_target_4",
-                "Verify unfencing failure with on_target = true using topology", 1)
+                             "Verify unfencing failure with on_target = true using topology",
+                             1)
 
-        test.add_cmd("stonith_admin", "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s node_fake\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-R true2 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s node_fake\"" % (our_uname))
+        test.add_cmd("stonith_admin",
+                     "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s node_fake\"" % (our_uname))
+        test.add_cmd("stonith_admin",
+                     "-R true2 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s node_fake\"" % (our_uname))
 
         test.add_cmd("stonith_admin", "-r node_fake -i 1 -v true1")
         test.add_cmd("stonith_admin", "-r node_fake -i 2 -v true2")
@@ -937,6 +1084,8 @@ class Tests:
         test.add_stonith_log_pattern("(on) to be executed on the target node")
 
     def build_remap_tests(self):
+        """ Register tests that verify remapping of reboots to off-on """
+
         test = self.new_test("cpg_remap_simple",
                              "Verify sequential topology reboot is remapped to all-off-then-all-on", 1)
         test.add_cmd("stonith_admin",
@@ -961,10 +1110,10 @@ class Tests:
         test = self.new_test("cpg_remap_automatic",
                              "Verify remapped topology reboot skips automatic 'on'", 1)
         test.add_cmd("stonith_admin",
-                     """-R true1 -a fence_dummy_automatic_unfence """
+                     """-R true1 -a fence_dummy_auto_unfence """
                      """-o "mode=pass" -o "pcmk_host_list=node_fake" """)
         test.add_cmd("stonith_admin",
-                     """-R true2 -a fence_dummy_automatic_unfence """
+                     """-R true2 -a fence_dummy_auto_unfence """
                      """-o "mode=pass" -o "pcmk_host_list=node_fake" """)
         test.add_cmd("stonith_admin", "-r node_fake -i 1 -v true1 -v true2")
         test.add_cmd("stonith_admin", "-B node_fake -t 5")
@@ -973,11 +1122,12 @@ class Tests:
         test.add_stonith_log_pattern("perform op 'node_fake off' with 'true2'")
         test.add_stonith_log_pattern("Remapped off of node_fake complete, remapping to on")
         test.add_stonith_log_pattern("Undoing remap of reboot of node_fake")
-        test.add_stonith_negative_log_pattern("perform op 'node_fake on' with")
-        test.add_stonith_negative_log_pattern("'on' failure")
+        test.add_stonith_neg_log_pattern("perform op 'node_fake on' with")
+        test.add_stonith_neg_log_pattern("'on' failure")
 
         test = self.new_test("cpg_remap_complex_1",
-                "Verify remapped topology reboot in second level works if non-remapped first level fails", 1)
+                             "Verify remapped topology reboot in second level works if non-remapped first level fails",
+                             1)
         test.add_cmd("stonith_admin", """-R false1 -a fence_dummy -o "mode=fail" -o "pcmk_host_list=node_fake" """)
         test.add_cmd("stonith_admin", """-R true1 -a fence_dummy -o "mode=pass" -o "pcmk_host_list=node_fake" """)
         test.add_cmd("stonith_admin", """-R true2 -a fence_dummy -o "mode=pass" -o "pcmk_host_list=node_fake" """)
@@ -994,7 +1144,8 @@ class Tests:
         test.add_stonith_log_pattern("Undoing remap of reboot of node_fake")
 
         test = self.new_test("cpg_remap_complex_2",
-                "Verify remapped topology reboot failure in second level proceeds to third level", 1)
+                             "Verify remapped topology reboot failure in second level proceeds to third level",
+                             1)
         test.add_cmd("stonith_admin", """-R false1 -a fence_dummy -o "mode=fail" -o "pcmk_host_list=node_fake" """)
         test.add_cmd("stonith_admin", """-R false2 -a fence_dummy -o "mode=fail" -o "pcmk_host_list=node_fake" """)
         test.add_cmd("stonith_admin", """-R true1 -a fence_dummy -o "mode=pass" -o "pcmk_host_list=node_fake" """)
@@ -1011,9 +1162,11 @@ class Tests:
         test.add_stonith_log_pattern("Attempted to execute agent fence_dummy (off) the maximum number of times")
         test.add_stonith_log_pattern("Undoing remap of reboot of node_fake")
         test.add_stonith_log_pattern("perform op 'node_fake reboot' with 'true2'")
-        test.add_stonith_negative_log_pattern("node_fake with true3")
+        test.add_stonith_neg_log_pattern("node_fake with true3")
 
     def setup_environment(self, use_corosync):
+        """ Prepare the host before executing any tests """
+
         if self.autogen_corosync_cfg and use_corosync:
             corosync_conf = ("""
 totem {
@@ -1050,27 +1203,29 @@ logging {
 
         if use_corosync:
             ### make sure we are in control ###
-            self.stop_corosync()
+            killall("corosync")
             self.start_corosync()
 
         os.system("cp %s /usr/sbin/fence_dummy" % FENCE_DUMMY)
 
         # modifies dummy agent to do require unfencing
-        os.system("sed 's/on_target=/automatic=/g' %s > /usr/sbin/fence_dummy_automatic_unfence" % FENCE_DUMMY);
-        os.system("chmod 711 /usr/sbin/fence_dummy_automatic_unfence")
+        os.system("sed 's/on_target=/automatic=/g' %s > /usr/sbin/fence_dummy_auto_unfence" % FENCE_DUMMY)
+        os.system("chmod 711 /usr/sbin/fence_dummy_auto_unfence")
 
         # modifies dummy agent to not advertise reboot
-        os.system("sed 's/^.*<action.*name.*reboot.*>.*//g' %s > /usr/sbin/fence_dummy_no_reboot" % FENCE_DUMMY);
+        os.system("sed 's/^.*<action.*name.*reboot.*>.*//g' %s > /usr/sbin/fence_dummy_no_reboot" % FENCE_DUMMY)
         os.system("chmod 711 /usr/sbin/fence_dummy_no_reboot")
 
     def cleanup_environment(self, use_corosync):
+        """ Clean up the host after executing desired tests """
+
         if use_corosync:
-            self.stop_corosync()
+            killall("corosync")
 
             if self.verbose and os.path.exists('/var/log/corosync.log'):
                 print("Corosync output")
-                f = io.open('/var/log/corosync.log', 'rt')
-                for line in f.readlines():
+                logfile = io.open('/var/log/corosync.log', 'rt')
+                for line in logfile.readlines():
                     print(line.strip())
                 os.remove('/var/log/corosync.log')
 
@@ -1078,10 +1233,12 @@ logging {
             os.system("rm -f /etc/corosync/corosync.conf")
 
         os.system("rm -f /usr/sbin/fence_dummy")
-        os.system("rm -f /usr/sbin/fence_dummy_automatic_unfence")
+        os.system("rm -f /usr/sbin/fence_dummy_auto_unfence")
         os.system("rm -f /usr/sbin/fence_dummy_no_reboot")
 
-class TestOptions:
+class TestOptions(object):
+    """ Option handler """
+
     def __init__(self):
         self.options = {}
         self.options['list-tests'] = 0
@@ -1095,6 +1252,8 @@ class TestOptions:
         self.options['show-usage'] = 0
 
     def build_options(self, argv):
+        """ Set options based on command-line arguments """
+
         args = argv[1:]
         skip = 0
         for i in range(0, len(args)):
@@ -1119,6 +1278,8 @@ class TestOptions:
                 skip = 1
 
     def show_usage(self):
+        """ Show command usage """
+
         print("usage: " + sys.argv[0] + " [options]")
         print("If no options are provided, all tests will run")
         print("Options:")
@@ -1136,44 +1297,48 @@ class TestOptions:
 
 
 def main(argv):
-    o = TestOptions()
-    o.build_options(argv)
+    """ Run fencing regression tests as specified by arguments """
+
+    opts = TestOptions()
+    opts.build_options(argv)
 
     use_corosync = 1
 
-    tests = Tests(o.options['verbose'])
+    tests = Tests(opts.options['verbose'])
     tests.build_standalone_tests()
     tests.build_custom_timeout_tests()
     tests.build_api_sanity_tests()
     tests.build_fence_merge_tests()
+    tests.build_fence_no_merge_tests()
     tests.build_unfence_tests()
+    tests.build_unfence_on_target_tests()
     tests.build_nodeid_tests()
     tests.build_remap_tests()
 
-    if o.options['list-tests']:
+    if opts.options['list-tests']:
         tests.print_list()
         sys.exit(0)
-    elif o.options['show-usage']:
-        o.show_usage()
+    elif opts.options['show-usage']:
+        opts.show_usage()
         sys.exit(0)
 
     print("Starting ...")
 
-    if o.options['no-cpg']:
+    if opts.options['no-cpg']:
         use_corosync = 0
 
     tests.setup_environment(use_corosync)
 
-    if o.options['run-only-pattern'] != "":
-        tests.run_tests_matching(o.options['run-only-pattern'])
+    if opts.options['run-only-pattern'] != "":
+        tests.run_tests_matching(opts.options['run-only-pattern'])
         tests.print_results()
-    elif o.options['run-only'] != "":
-        tests.run_single(o.options['run-only'])
+    elif opts.options['run-only'] != "":
+        tests.run_single(opts.options['run-only'])
         tests.print_results()
-    elif o.options['no-cpg']:
+    elif opts.options['no-cpg']:
         tests.run_no_cpg()
         tests.print_results()
-    elif o.options['cpg-only']:
+    elif opts.options['cpg-only']:
         tests.run_cpg_only()
         tests.print_results()
     else:
@@ -1184,5 +1349,5 @@ def main(argv):
     tests.exit()
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     main(sys.argv)

--- a/fencing/regression.py.in
+++ b/fencing/regression.py.in
@@ -938,10 +938,11 @@ class Tests(object):
                              "Verify nodeid is _NOT_ given when fence agent does not have nodeid as parameter",
                              1)
 
+        # use a host name that won't be in corosync.conf
         test.add_cmd("stonith_admin",
-                     "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=%s\"" % (our_uname))
-        test.add_cmd("stonith_admin", "-F %s -t 3" % (our_uname))
-        test.add_stonith_neg_log_pattern("For stonith action (off) for victim %s, adding nodeid" % (our_uname))
+                     "-R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=regr-test\"")
+        test.add_cmd("stonith_admin", "-F regr-test -t 3")
+        test.add_stonith_neg_log_pattern("For stonith action (off) for victim regr-test, adding nodeid")
 
         ### verify nodeid use doesn't explode standalone mode
         test = self.new_test("standalone_do_not_supply_nodeid",

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -558,7 +558,7 @@ make_args(const char *agent, const char *action, const char *victim, uint32_t vi
         if (victim_nodeid) {
             char nodeid_str[33] = { 0, };
             if (snprintf(nodeid_str, 33, "%u", (unsigned int)victim_nodeid)) {
-                crm_info("For stonith action (%s) for victim %s, adding nodeid (%d) to parameters",
+                crm_info("For stonith action (%s) for victim %s, adding nodeid (%s) to parameters",
                          action, victim, nodeid_str);
                 append_const_arg("nodeid", nodeid_str, &arg_list);
             }

--- a/lrmd/pacemaker_remote.in
+++ b/lrmd/pacemaker_remote.in
@@ -115,7 +115,7 @@ start()
 	fi
 	echo
 
-	[ "x$SBD_SERVICE" != x ] && service $SBD_SERVICE start
+	[ "x$SBD_SERVICE" = "x" ] || service $SBD_SERVICE start
 }
 
 stop()
@@ -131,6 +131,8 @@ stop()
 		sleep 1
 		echo -n "."
 	    done
+	else
+		echo -n "$desc is already stopped"
 	fi
 
 	rm -f "$LOCK_FILE"
@@ -138,7 +140,7 @@ stop()
 	success
 	echo
 
-	[ "x$SBD_SERVICE" != x ] && service $SBD_SERVICE stop
+	[ "x$SBD_SERVICE" = "x" ] || service $SBD_SERVICE stop
 }
 
 rtrn=0

--- a/lrmd/regression.py.in
+++ b/lrmd/regression.py.in
@@ -17,28 +17,31 @@ import time
 
 # Where to find test binaries
 # Prefer the source tree if available
-build_dir="@abs_top_builddir@"
-test_dir=sys.path[0]
+BUILD_DIR = "@abs_top_builddir@"
+TEST_DIR = sys.path[0]
 
-new_path=os.environ['PATH']
-if os.path.exists("%s/regression.py.in" % test_dir):
-    print("Running tests from the source tree: %s (%s)" % (build_dir, test_dir))
-    new_path = "%s/lrmd:%s" % (build_dir, new_path)    # For lrmd, lrmd_test and pacemaker_remoted
-    new_path = "%s/tools:%s" % (build_dir, new_path)   # For crm_resource
-    new_path = "%s/fencing:%s" % (build_dir, new_path) # For stonithd
+def update_path():
+    """ Set the PATH environment variable appropriately for the tests """
 
-else:
-    print("Running tests from the install tree: @CRM_DAEMON_DIR@ (not %s)" % test_dir)
-    new_path = "@CRM_DAEMON_DIR@:%s" % (new_path) # For stonithd, lrmd, lrmd_test and pacemaker_remoted
+    new_path = os.environ['PATH']
+    if os.path.exists("%s/regression.py.in" % TEST_DIR):
+        print("Running tests from the source tree: %s (%s)" % (BUILD_DIR, TEST_DIR))
+        new_path = "%s/lrmd:%s" % (BUILD_DIR, new_path)    # For lrmd, lrmd_test and pacemaker_remoted
+        new_path = "%s/tools:%s" % (BUILD_DIR, new_path)   # For crm_resource
+        new_path = "%s/fencing:%s" % (BUILD_DIR, new_path) # For stonithd
 
-print(new_path)
-os.environ['PATH']=new_path
+    else:
+        print("Running tests from the install tree: @CRM_DAEMON_DIR@ (not %s)" % TEST_DIR)
+        new_path = "@CRM_DAEMON_DIR@:%s" % (new_path) # For stonithd, lrmd, lrmd_test and pacemaker_remoted
+
+    print(new_path)
+    os.environ['PATH'] = new_path
 
 
 def shlex_split(command):
     """ Wrapper for shlex.split() that works around Python 2.6 bug """
 
-    if sys.version_info < (2,7,):
+    if sys.version_info < (2, 7,):
         return shlex.split(command.encode('ascii'))
     else:
         return shlex.split(command)
@@ -63,13 +66,17 @@ def pipe_output(pipes, stdout=True, stderr=False):
 
 
 def output_from_command(command):
+    """ Run a command, and return its standard output. """
+
     test = subprocess.Popen(shlex_split(command), stdout=subprocess.PIPE)
     test.wait()
     return pipe_output(test).split("\n")
 
 
-class Test:
-    def __init__(self, name, description, verbose = 0, tls = 0):
+class Test(object):
+    """ Executor for a single lrmd regression test """
+
+    def __init__(self, name, description, verbose=0, tls=0):
         self.name = name
         self.description = description
         self.cmds = []
@@ -85,14 +92,16 @@ class Test:
 
         self.result_txt = ""
         self.cmd_tool_output = ""
-        self.result_exitcode = 0;
+        self.result_exitcode = 0
 
         self.lrmd_process = None
         self.stonith_process = None
 
         self.executed = 0
 
-    def __new_cmd(self, cmd, args, exitcode, stdout_match = "", no_wait = 0, stdout_negative_match = "", kill=None):
+    def __new_cmd(self, cmd, args, exitcode, stdout_match="", no_wait=0, stdout_negative_match="", kill=None):
+        """ Add a command to be executed as part of this test """
+
         if self.verbose and cmd == self.test_tool_location:
             args = args + " -V "
 
@@ -113,6 +122,8 @@ class Test:
         )
 
     def start_environment(self):
+        """ Prepare the host for running a test """
+
         ### make sure we are in full control here ###
         cmd = shlex_split("killall -q -9 stonithd lt-stonithd lrmd lt-lrmd lrmd_test lt-lrmd_test pacemaker_remoted")
         test = subprocess.Popen(cmd, stdout=subprocess.PIPE)
@@ -126,19 +137,22 @@ class Test:
         if self.verbose:
             additional_args = additional_args + " -V"
 
-        self.lrmd_process = subprocess.Popen(shlex_split("%s %s -l /tmp/lrmd-regression.log" % (self.daemon_location, additional_args)))
+        self.lrmd_process = subprocess.Popen(shlex_split("%s %s -l /tmp/lrmd-regression.log"
+                                                         % (self.daemon_location, additional_args)))
 
         time.sleep(1)
 
     def clean_environment(self):
+        """ Clean up the host after running a test """
+
         if self.lrmd_process:
             self.lrmd_process.terminate()
             self.lrmd_process.wait()
 
             if self.verbose:
                 print("Daemon output")
-                f = io.open('/tmp/lrmd-regression.log', 'rt')
-                for line in f.readlines():
+                logfile = io.open('/tmp/lrmd-regression.log', 'rt')
+                for line in logfile.readlines():
                     print(line.strip())
             os.remove('/tmp/lrmd-regression.log')
 
@@ -150,33 +164,53 @@ class Test:
         self.stonith_process = None
 
     def add_sys_cmd(self, cmd, args):
+        """ Add a simple command to be executed as part of this test """
+
         self.__new_cmd(cmd, args, 0, "")
 
     def add_sys_cmd_no_wait(self, cmd, args):
+        """ Add a simple command to be executed (without waiting) as part of this test """
+
         self.__new_cmd(cmd, args, 0, "", 1)
 
     def add_expected_fail_sys_cmd(self, cmd, args, exitcode):
+        """ Add a command to be executed as part of this test and expected to fail """
+
         self.__new_cmd(cmd, args, exitcode)
 
-    def add_cmd_check_stdout(self, args, match, no_match = ""):
+    def add_cmd_check_stdout(self, args, match, no_match=""):
+        """ Add a command with expected output to be executed as part of this test """
+
         self.__new_cmd(self.test_tool_location, args, 0, match, 0, no_match)
 
     def add_cmd(self, args):
+        """ Add an lrmd_test command to be executed as part of this test """
+
         self.__new_cmd(self.test_tool_location, args, 0, "")
 
-    def add_cmd_and_kill(self, killProc, args):
-        self.__new_cmd(self.test_tool_location, args, 0, "", kill=killProc)
+    def add_cmd_and_kill(self, kill_proc, args):
+        """ Add an lrmd_test command and system command to be executed as part of this test """
+
+        self.__new_cmd(self.test_tool_location, args, 0, "", kill=kill_proc)
 
     def add_expected_fail_cmd(self, args):
+        """ Add an lrmd_test command to be executed as part of this test and expected to fail """
+
         self.__new_cmd(self.test_tool_location, args, 1, "")
 
     def get_exitcode(self):
+        """ Return the exit status of the last test execution """
+
         return self.result_exitcode
 
     def print_result(self, filler):
+        """ Print the result of the last test execution """
+
         print("%s%s" % (filler, self.result_txt))
 
     def run_cmd(self, args):
+        """ Execute a command as part of this test """
+
         cmd = shlex_split(args['args'])
         cmd.insert(0, args['cmd'])
         if self.verbose:
@@ -210,9 +244,11 @@ class Test:
 
         args['cmd_output'] = output
 
-        return test.returncode;
+        return test.returncode
 
     def run(self):
+        """ Execute this test. """
+
         res = 0
         i = 1
 
@@ -233,7 +269,8 @@ class Test:
             if res != cmd['expected_exitcode']:
                 print(cmd['cmd_output'])
                 print("Step %d FAILED - command returned %d, expected %d" % (i, res, cmd['expected_exitcode']))
-                self.result_txt = "FAILURE - '%s' failed at step %d. Command: lrmd_test %s" % (self.name, i, cmd['args'])
+                msg = "FAILURE - '%s' failed at step %d. Command: lrmd_test %s"
+                self.result_txt = msg % (self.name, i, cmd['args'])
                 self.result_exitcode = -1
                 break
             else:
@@ -250,11 +287,13 @@ class Test:
         self.executed = 1
         return res
 
-class Tests:
-    def __init__(self, verbose = 0, tls = 0):
+class Tests(object):
+    """ Collection of all lrmd regression tests """
+
+    def __init__(self, verbose=0, tls=0):
         self.tests = []
         self.verbose = verbose
-        self.tls = tls;
+        self.tls = tls
         self.rsc_classes = output_from_command("crm_resource --list-standards")
         self.rsc_classes = self.rsc_classes[:-1] # Strip trailing empty line
         self.need_authkey = 0
@@ -262,12 +301,15 @@ class Tests:
         if self.tls:
             self.rsc_classes.remove("stonith")
         if "systemd" in self.rsc_classes:
-            # the lrmd_dummy_daemon requires this, we are importing it
-            # here just to guarantee it is installed before allowing this
-            # script to run. Otherwise, running without this import being
-            # available will make all the systemd tests look like they fail,
-            # which is really scary looking. I'd rather see the import fail.
-            import systemd.daemon
+            try:
+                # This code doesn't need this import, but lrmd_dummy_daemon does,
+                # so ensure the dependency is available rather than cause all
+                # systemd tests to fail.
+                import systemd.daemon
+            except ImportError:
+                print("Fatal error: python systemd bindings not found. Is package installed?",
+                      file=sys.stderr)
+                sys.exit(1)
 
         print("Testing "+repr(self.rsc_classes))
 
@@ -365,11 +407,15 @@ class Tests:
         }
 
     def new_test(self, name, description):
+        """ Create a named test """
+
         test = Test(name, description, self.verbose, self.tls)
         self.tests.append(test)
         return test
 
     def setup_test_environment(self):
+        """ Prepare the host before executing any tests """
+
         os.system("service pacemaker_remote stop")
         self.cleanup_test_environment()
 
@@ -458,17 +504,17 @@ if __name__ == "__main__":
         os.system("cat <<-END >>/usr/sbin/fence_dummy_monitor\n%s\nEND" % (dummy_fence_agent))
         os.system("chmod 711 /usr/sbin/fence_dummy_monitor")
 
-        if os.path.exists("%s/cts/LSBDummy" % build_dir):
-            print("Using %s/cts/LSBDummy" % build_dir)
-            os.system("cp %s/cts/LSBDummy /etc/init.d/LSBDummy" % build_dir)
+        if os.path.exists("%s/cts/LSBDummy" % BUILD_DIR):
+            print("Using %s/cts/LSBDummy" % BUILD_DIR)
+            os.system("cp %s/cts/LSBDummy /etc/init.d/LSBDummy" % BUILD_DIR)
 
             if not os.path.exists("@OCF_RA_DIR@/pacemaker"):
                 os.system("mkdir -p @OCF_RA_DIR@/pacemaker/")
 
             # Install helper OCF agents
-            for ra in [ "Dummy", "Stateful", "ping" ]:
-                os.system("cp %s/extra/resources/%s @OCF_RA_DIR@/pacemaker/%s" % (build_dir, ra, ra))
-                os.system("chmod a+x @OCF_RA_DIR@/pacemaker/%s" % (ra))
+            for agent in ["Dummy", "Stateful", "ping"]:
+                os.system("cp %s/extra/resources/%s @OCF_RA_DIR@/pacemaker/%s" % (BUILD_DIR, agent, agent))
+                os.system("chmod a+x @OCF_RA_DIR@/pacemaker/%s" % (agent))
 
         else:
             # Assume it's installed
@@ -480,9 +526,9 @@ if __name__ == "__main__":
         os.system("mkdir -p @CRM_CORE_DIR@/root")
 
         os.system("mkdir -p /etc/ha.d/resource.d")
-        if os.path.exists("%s/cts/HBDummy" % build_dir):
-            print("Using %s/cts/HBDummy" % build_dir)
-            os.system("cp %s/cts/HBDummy /etc/ha.d/resource.d/HBDummy" % build_dir)
+        if os.path.exists("%s/cts/HBDummy" % BUILD_DIR):
+            print("Using %s/cts/HBDummy" % BUILD_DIR)
+            os.system("cp %s/cts/HBDummy /etc/ha.d/resource.d/HBDummy" % BUILD_DIR)
         else:
             # Assume it's installed
             print("Using @datadir@/@PACKAGE@/tests/cts/HBDummy")
@@ -495,6 +541,8 @@ if __name__ == "__main__":
             os.system("systemctl daemon-reload")
 
     def cleanup_test_environment(self):
+        """ Clean up the host after executing desired tests """
+
         if self.need_authkey:
             os.system("rm -f /etc/pacemaker/authkey")
 
@@ -507,13 +555,15 @@ if __name__ == "__main__":
         if os.path.exists("/bin/systemctl"):
             os.system("systemctl daemon-reload")
 
-    ### These are tests that should apply to all resource classes ###
     def build_generic_tests(self):
+        """ Register tests that apply to all resource classes """
+
         common_cmds = self.common_cmds
 
         ### register/unregister tests ###
         for rsc in self.rsc_classes:
-            test = self.new_test("generic_registration_%s" % (rsc), "Simple resource registration test for %s standard" % (rsc))
+            test = self.new_test("generic_registration_%s" % (rsc),
+                                 "Simple resource registration test for %s standard" % (rsc))
             test.add_cmd(common_cmds["%s_reg_line" % (rsc)] + " " + common_cmds["%s_reg_event" % (rsc)])
             test.add_cmd(common_cmds["%s_unreg_line" % (rsc)] + " " + common_cmds["%s_unreg_event" % (rsc)])
 
@@ -527,26 +577,34 @@ if __name__ == "__main__":
 
         ### monitor cancel test ###
         for rsc in self.rsc_classes:
-            test = self.new_test("generic_monitor_cancel_%s" % (rsc), "Simple monitor cancel test for %s standard" % (rsc))
+            test = self.new_test("generic_monitor_cancel_%s" % (rsc),
+                                 "Simple monitor cancel test for %s standard" % (rsc))
             test.add_cmd(common_cmds["%s_reg_line" % (rsc)]   + " " + common_cmds["%s_reg_event" % (rsc)])
             test.add_cmd(common_cmds["%s_start_line" % (rsc)] + " " + common_cmds["%s_start_event" % (rsc)])
             test.add_cmd(common_cmds["%s_monitor_line" % (rsc)] + " " + common_cmds["%s_monitor_event" % (rsc)])
-            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this fails, that means the monitor may not be getting rescheduled ####
-            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this fails, that means the monitor may not be getting rescheduled ####
+            ### If this fails, that means the monitor may not be getting rescheduled ####
+            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)])
+            ### If this fails, that means the monitor may not be getting rescheduled ####
+            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)])
             test.add_cmd(common_cmds["%s_cancel_line" % (rsc)] + " " + common_cmds["%s_cancel_event" % (rsc)])
-            test.add_expected_fail_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this happens the monitor did not actually cancel correctly. ###
-            test.add_expected_fail_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this happens the monitor did not actually cancel correctly. ###
+            ### If this happens the monitor did not actually cancel correctly. ###
+            test.add_expected_fail_cmd(common_cmds["%s_monitor_event" % (rsc)])
+            ### If this happens the monitor did not actually cancel correctly. ###
+            test.add_expected_fail_cmd(common_cmds["%s_monitor_event" % (rsc)])
             test.add_cmd(common_cmds["%s_stop_line" % (rsc)]  + " " + common_cmds["%s_stop_event" % (rsc)])
             test.add_cmd(common_cmds["%s_unreg_line" % (rsc)] + " " + common_cmds["%s_unreg_event" % (rsc)])
 
         ### monitor duplicate test ###
         for rsc in self.rsc_classes:
-            test = self.new_test("generic_monitor_duplicate_%s" % (rsc), "Test creation and canceling of duplicate monitors for %s standard" % (rsc))
+            test = self.new_test("generic_monitor_duplicate_%s" % (rsc),
+                                 "Test creation and canceling of duplicate monitors for %s standard" % (rsc))
             test.add_cmd(common_cmds["%s_reg_line" % (rsc)]   + " " + common_cmds["%s_reg_event" % (rsc)])
             test.add_cmd(common_cmds["%s_start_line" % (rsc)] + " " + common_cmds["%s_start_event" % (rsc)])
             test.add_cmd(common_cmds["%s_monitor_line" % (rsc)] + " " + common_cmds["%s_monitor_event" % (rsc)])
-            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this fails, that means the monitor may not be getting rescheduled ####
-            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this fails, that means the monitor may not be getting rescheduled ####
+            ### If this fails, that means the monitor may not be getting rescheduled ####
+            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)])
+            ### If this fails, that means the monitor may not be getting rescheduled ####
+            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)])
 
             # Add the duplicate monitors
             test.add_cmd(common_cmds["%s_monitor_line" % (rsc)] + " " + common_cmds["%s_monitor_event" % (rsc)])
@@ -554,36 +612,46 @@ if __name__ == "__main__":
             test.add_cmd(common_cmds["%s_monitor_line" % (rsc)] + " " + common_cmds["%s_monitor_event" % (rsc)])
             test.add_cmd(common_cmds["%s_monitor_line" % (rsc)] + " " + common_cmds["%s_monitor_event" % (rsc)])
             # verify we still get update events
-            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this fails, that means the monitor may not be getting rescheduled ####
+            ### If this fails, that means the monitor may not be getting rescheduled ####
+            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)])
 
             # cancel the monitor, if the duplicate merged with the original, we should no longer see monitor updates
             test.add_cmd(common_cmds["%s_cancel_line" % (rsc)] + " " + common_cmds["%s_cancel_event" % (rsc)])
-            test.add_expected_fail_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this happens the monitor did not actually cancel correctly. ###
-            test.add_expected_fail_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this happens the monitor did not actually cancel correctly. ###
+            ### If this happens the monitor did not actually cancel correctly. ###
+            test.add_expected_fail_cmd(common_cmds["%s_monitor_event" % (rsc)])
+            ### If this happens the monitor did not actually cancel correctly. ###
+            test.add_expected_fail_cmd(common_cmds["%s_monitor_event" % (rsc)])
             test.add_cmd(common_cmds["%s_stop_line" % (rsc)]  + " " + common_cmds["%s_stop_event" % (rsc)])
             test.add_cmd(common_cmds["%s_unreg_line" % (rsc)] + " " + common_cmds["%s_unreg_event" % (rsc)])
 
         ### stop implies cancel test ###
         for rsc in self.rsc_classes:
-            test = self.new_test("generic_stop_implies_cancel_%s" % (rsc), "Verify stopping a resource implies cancel of recurring ops for %s standard" % (rsc))
+            test = self.new_test("generic_stop_implies_cancel_%s" % (rsc),
+                                 "Verify stopping a resource implies cancel of recurring ops for %s standard" % (rsc))
             test.add_cmd(common_cmds["%s_reg_line" % (rsc)]   + " " + common_cmds["%s_reg_event" % (rsc)])
             test.add_cmd(common_cmds["%s_start_line" % (rsc)] + " " + common_cmds["%s_start_event" % (rsc)])
             test.add_cmd(common_cmds["%s_monitor_line" % (rsc)] + " " + common_cmds["%s_monitor_event" % (rsc)])
-            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this fails, that means the monitor may not be getting rescheduled ####
-            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this fails, that means the monitor may not be getting rescheduled ####
+            ### If this fails, that means the monitor may not be getting rescheduled ####
+            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)])
+            ### If this fails, that means the monitor may not be getting rescheduled ####
+            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)])
             test.add_cmd(common_cmds["%s_stop_line" % (rsc)]  + " " + common_cmds["%s_stop_event" % (rsc)])
-            test.add_expected_fail_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this happens the monitor did not actually cancel correctly. ###
-            test.add_expected_fail_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this happens the monitor did not actually cancel correctly. ###
+            ### If this happens the monitor did not actually cancel correctly. ###
+            test.add_expected_fail_cmd(common_cmds["%s_monitor_event" % (rsc)])
+            ### If this happens the monitor did not actually cancel correctly. ###
+            test.add_expected_fail_cmd(common_cmds["%s_monitor_event" % (rsc)])
             test.add_cmd(common_cmds["%s_unreg_line" % (rsc)] + " " + common_cmds["%s_unreg_event" % (rsc)])
 
 
-    ### These are complex tests that involve managing multiple resouces of different types ###
     def build_multi_rsc_tests(self):
+        """ Register complex tests that involve managing multiple resouces of different types """
+
         common_cmds = self.common_cmds
         # do not use service and systemd at the same time, it is the same resource.
 
         ### register start monitor stop unregister resources of each type at the same time. ###
-        test = self.new_test("multi_rsc_start_stop_all", "Start, monitor, and stop resources of multiple types and classes")
+        test = self.new_test("multi_rsc_start_stop_all",
+                             "Start, monitor, and stop resources of multiple types and classes")
         for rsc in self.rsc_classes:
             test.add_cmd(common_cmds["%s_reg_line" % (rsc)]   + " " + common_cmds["%s_reg_event" % (rsc)])
         for rsc in self.rsc_classes:
@@ -591,7 +659,8 @@ if __name__ == "__main__":
         for rsc in self.rsc_classes:
             test.add_cmd(common_cmds["%s_monitor_line" % (rsc)] + " " + common_cmds["%s_monitor_event" % (rsc)])
         for rsc in self.rsc_classes:
-            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)]) ### If this fails, that means the monitor is not being rescheduled ####
+            ### If this fails, that means the monitor is not being rescheduled ####
+            test.add_cmd(common_cmds["%s_monitor_event" % (rsc)])
         for rsc in self.rsc_classes:
             test.add_cmd(common_cmds["%s_cancel_line" % (rsc)] + " " + common_cmds["%s_cancel_event" % (rsc)])
         for rsc in self.rsc_classes:
@@ -599,33 +668,35 @@ if __name__ == "__main__":
         for rsc in self.rsc_classes:
             test.add_cmd(common_cmds["%s_unreg_line" % (rsc)] + " " + common_cmds["%s_unreg_event" % (rsc)])
 
-    ### These are tests related to how the lrmd handles failures.  ###
     def build_negative_tests(self):
+        """ Register tests related to how the lrmd handles failures """
 
         ### ocf start timeout test  ###
         test = self.new_test("ocf_start_timeout", "Force start timeout to occur, verify start failure.")
-        test.add_cmd("-c register_rsc -r \"test_rsc\" -C \"ocf\" -P \"pacemaker\" -T \"Dummy\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
-        test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" -k \"op_sleep\" -v \"5\" -t 1000 -w")  # -t must be less than self.action_timeout
-        test.add_cmd("-l "
-            "\"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:unknown error op_status:Timed Out\" "+self.action_timeout)
-        test.add_cmd("-c exec -r test_rsc -a stop "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:stop rc:ok op_status:complete\" ")
-        test.add_cmd("-c unregister_rsc -r test_rsc "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
-
+        test.add_cmd("-c register_rsc -r \"test_rsc\" -C \"ocf\" -P \"pacemaker\" -T \"Dummy\" "
+                     + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+        # -t must be less than self.action_timeout
+        test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" -k \"op_sleep\" -v \"5\" -t 1000 -w")
+        test.add_cmd('-l "NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:unknown error op_status:Timed Out" '
+                     + self.action_timeout)
+        test.add_cmd("-c exec -r test_rsc -a stop " + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:stop rc:ok op_status:complete\" ")
+        test.add_cmd("-c unregister_rsc -r test_rsc " + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### stonith start timeout test  ###
         test = self.new_test("stonith_start_timeout", "Force start timeout to occur, verify start failure.")
-        test.add_cmd("-c register_rsc -r \"test_rsc\" -C \"stonith\" -P \"pacemaker\" -T \"fence_dummy_sleep\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+        test.add_cmd("-c register_rsc -r \"test_rsc\" -C \"stonith\" -P \"pacemaker\" -T \"fence_dummy_sleep\" "
+                     + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
         test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" -t 1000 -w") # -t must be less than self.action_timeout
-        test.add_cmd("-l "
-            "\"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:unknown error op_status:Timed Out\" "+self.action_timeout)
-        test.add_cmd("-c exec -r test_rsc -a stop "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:stop rc:ok op_status:complete\" ")
-        test.add_cmd("-c unregister_rsc -r test_rsc "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+        test.add_cmd('-l "NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:unknown error op_status:Timed Out" '
+                     + self.action_timeout)
+        test.add_cmd("-c exec -r test_rsc -a stop " + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:stop rc:ok op_status:complete\" ")
+        test.add_cmd("-c unregister_rsc -r test_rsc " + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### stonith component fail ###
         common_cmds = self.common_cmds
@@ -633,171 +704,182 @@ if __name__ == "__main__":
         test.add_cmd(common_cmds["stonith_reg_line"]   + " " + common_cmds["stonith_reg_event"])
         test.add_cmd(common_cmds["stonith_start_line"] + " " + common_cmds["stonith_start_event"])
 
-        test.add_cmd("-c exec -r \"stonith_test_rsc\" -a \"monitor\" -i \"600000\" "
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:stonith_test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
+        test.add_cmd('-c exec -r "stonith_test_rsc" -a "monitor" -i "600000" -l "NEW_EVENT event_type:exec_complete rsc_id:stonith_test_rsc action:monitor rc:ok op_status:complete" '
+                     + self.action_timeout)
 
-        test.add_cmd_and_kill("killall -9 -q stonithd lt-stonithd" ,"-l \"NEW_EVENT event_type:exec_complete rsc_id:stonith_test_rsc action:monitor rc:unknown error op_status:error\" -t 15000")
+        test.add_cmd_and_kill("killall -9 -q stonithd lt-stonithd",
+                              '-l "NEW_EVENT event_type:exec_complete rsc_id:stonith_test_rsc action:monitor rc:unknown error op_status:error" -t 15000')
         test.add_cmd(common_cmds["stonith_unreg_line"] + " " + common_cmds["stonith_unreg_event"])
 
 
         ### monitor fail for ocf resources ###
         test = self.new_test("monitor_fail_ocf", "Force ocf monitor to fail, verify failure is reported.")
-        test.add_cmd("-c register_rsc -r \"test_rsc\" -C \"ocf\" -P \"pacemaker\" -T \"Dummy\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
-        test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
-        test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
-        test.add_cmd("-c exec -r \"test_rsc\" -a \"monitor\" -i \"100\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" ")
-        test.add_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
-        test.add_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
-        test.add_cmd_and_kill("rm -f @localstatedir@/run/Dummy-test_rsc.state", "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:complete\" -t 6000")
+        test.add_cmd("-c register_rsc -r \"test_rsc\" -C \"ocf\" -P \"pacemaker\" -T \"Dummy\" "
+                     + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+        test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" " + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
+        test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" " + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
+        test.add_cmd('-c exec -r "test_rsc" -a "monitor" -i "100" '
+                     + self.action_timeout +
+                     '-l "NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete"')
+        test.add_cmd('-l "NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete"'
+                     + self.action_timeout)
+        test.add_cmd('-l "NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete"'
+                     + self.action_timeout)
+        test.add_cmd_and_kill("rm -f @localstatedir@/run/Dummy-test_rsc.state",
+                              '-l "NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:complete" -t 6000')
         test.add_cmd("-c cancel -r \"test_rsc\" -a \"monitor\" -i \"100\" -t \"6000\" "
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:Cancelled\" ")
-        test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:complete\" "+self.action_timeout)
-        test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
-        test.add_cmd("-c unregister_rsc -r \"test_rsc\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:Cancelled\" ")
+        test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:complete\" "
+                                   + self.action_timeout)
+        test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "
+                                   + self.action_timeout)
+        test.add_cmd("-c unregister_rsc -r \"test_rsc\" "
+                     + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### verify notify changes only for monitor operation.  ###
         test = self.new_test("monitor_changes_only", "Verify when flag is set, only monitor changes are notified.")
         test.add_cmd("-c register_rsc -r \"test_rsc\" -C \"ocf\" -P \"pacemaker\" -T \"Dummy\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
         test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+" -o "
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
-        test.add_cmd("-c exec -r \"test_rsc\" -a \"monitor\" -i \"100\" "+self.action_timeout+" -o "
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
+        test.add_cmd('-c exec -r "test_rsc" -a "monitor" -i "100" '
+                     + self.action_timeout +
+                     ' -o -l "NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete" ')
         test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
         test.add_cmd_and_kill("rm -f @localstatedir@/run/Dummy-test_rsc.state", "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:complete\" -t 6000")
         test.add_cmd("-c cancel -r \"test_rsc\" -a \"monitor\" -i \"100\" -t \"6000\" "
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:Cancelled\" ")
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:Cancelled\" ")
         test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:complete\" "+self.action_timeout)
         test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
-        test.add_cmd("-c unregister_rsc -r \"test_rsc\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+        test.add_cmd('-c unregister_rsc -r "test_rsc" ' + self.action_timeout +
+                     '-l "NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete"')
 
         ### monitor fail for systemd resource ###
         if "systemd" in self.rsc_classes:
             test = self.new_test("monitor_fail_systemd", "Force systemd monitor to fail, verify failure is reported..")
             test.add_cmd("-c register_rsc -r \"test_rsc\" -C systemd -T lrmd_dummy_daemon "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
             test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
             test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
             test.add_cmd("-c exec -r \"test_rsc\" -a \"monitor\" -i \"100\" "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" ")
             test.add_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
             test.add_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
             test.add_cmd_and_kill("killall -9 -q lrmd_dummy_daemon", "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:complete\" -t 8000")
             test.add_cmd("-c cancel -r \"test_rsc\" -a \"monitor\" -i \"100\" -t \"6000\" "
-                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:Cancelled\" ")
+                         "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:Cancelled\" ")
             test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:complete\" "+self.action_timeout)
             test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
             test.add_cmd("-c unregister_rsc -r \"test_rsc\" "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### monitor fail for upstart resource ###
         if "upstart" in self.rsc_classes:
             test = self.new_test("monitor_fail_upstart", "Force upstart monitor to fail, verify failure is reported..")
             test.add_cmd("-c register_rsc -r \"test_rsc\" -C upstart -T lrmd_dummy_daemon "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
             test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
             test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
             test.add_cmd("-c exec -r \"test_rsc\" -a \"monitor\" -i \"100\" "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" ")
             test.add_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
             test.add_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
             test.add_cmd_and_kill("killall -9 -q dd", "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:complete\" -t 8000")
             test.add_cmd("-c cancel -r \"test_rsc\" -a \"monitor\" -i \"100\" -t \"6000\" "
-                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:Cancelled\" ")
+                         "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:Cancelled\" ")
             test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:complete\" "+self.action_timeout)
             test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
             test.add_cmd("-c unregister_rsc -r \"test_rsc\" "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### Cancel non-existent operation on a resource ###
         test = self.new_test("cancel_non_existent_op", "Attempt to cancel the wrong monitor operation, verify expected failure")
         test.add_cmd("-c register_rsc -r \"test_rsc\" -C \"ocf\" -P \"pacemaker\" -T \"Dummy\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
         test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
         test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
         test.add_cmd("-c exec -r \"test_rsc\" -a \"monitor\" -i \"100\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" ")
         test.add_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
         test.add_expected_fail_cmd("-c cancel -r test_rsc -a \"monitor\" -i 1234 -t \"6000\" " ### interval is wrong, should fail
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:Cancelled\" ")
+                                   "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:Cancelled\" ")
         test.add_expected_fail_cmd("-c cancel -r test_rsc -a stop -i 100 -t \"6000\" " ### action name is wrong, should fail
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:Cancelled\" ")
-        test.add_cmd("-c unregister_rsc -r \"test_rsc\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                                   "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:not running op_status:Cancelled\" ")
+        test.add_cmd("-c unregister_rsc -r \"test_rsc\" " + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### Attempt to invoke non-existent rsc id ###
         test = self.new_test("invoke_non_existent_rsc", "Attempt to perform operations on a non-existent rsc id.")
         test.add_expected_fail_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:unknown error op_status:complete\" ")
+                                   "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:unknown error op_status:complete\" ")
         test.add_expected_fail_cmd("-c exec -r test_rsc -a stop "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:stop rc:ok op_status:complete\" ")
+                                   "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:stop rc:ok op_status:complete\" ")
         test.add_expected_fail_cmd("-c exec -r test_rsc -a monitor -i 6000 "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" ")
+                                   "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" ")
         test.add_expected_fail_cmd("-c cancel -r test_rsc -a start "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:Cancelled\" ")
+                                   "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:Cancelled\" ")
         test.add_cmd("-c unregister_rsc -r \"test_rsc\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### Register and start a resource that doesn't exist, systemd  ###
         if "systemd" in self.rsc_classes:
             test = self.new_test("start_uninstalled_systemd", "Register uninstalled systemd agent, try to start, verify expected failure")
             test.add_cmd("-c register_rsc -r \"test_rsc\" -C systemd -T this_is_fake1234 "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
             test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:not installed op_status:Not installed\" ")
+                         "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:not installed op_status:Not installed\" ")
             test.add_cmd("-c unregister_rsc -r \"test_rsc\" "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         if "upstart" in self.rsc_classes:
             test = self.new_test("start_uninstalled_upstart", "Register uninstalled upstart agent, try to start, verify expected failure")
             test.add_cmd("-c register_rsc -r \"test_rsc\" -C upstart -T this_is_fake1234 "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
             test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:not installed op_status:Not installed\" ")
+                         "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:not installed op_status:Not installed\" ")
             test.add_cmd("-c unregister_rsc -r \"test_rsc\" "+self.action_timeout+
-                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                         "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### Register and start a resource that doesn't exist, ocf ###
         test = self.new_test("start_uninstalled_ocf", "Register uninstalled ocf agent, try to start, verify expected failure.")
         test.add_cmd("-c register_rsc -r \"test_rsc\" -C ocf -P pacemaker -T this_is_fake1234 "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
         test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:not installed op_status:Not installed\" ")
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:not installed op_status:Not installed\" ")
         test.add_cmd("-c unregister_rsc -r \"test_rsc\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### Register ocf with non-existent provider  ###
         test = self.new_test("start_ocf_bad_provider", "Register ocf agent with a non-existent provider, verify expected failure.")
         test.add_cmd("-c register_rsc -r \"test_rsc\" -C ocf -P pancakes -T Dummy "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
         test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:not installed op_status:Not installed\" ")
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:not installed op_status:Not installed\" ")
         test.add_cmd("-c unregister_rsc -r \"test_rsc\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### Register ocf with empty provider field  ###
         test = self.new_test("start_ocf_no_provider", "Register ocf agent with a no provider, verify expected failure.")
         test.add_expected_fail_cmd("-c register_rsc -r \"test_rsc\" -C ocf -T Dummy "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                                   "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
         test.add_expected_fail_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:Error\" ")
+                                   "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:Error\" ")
         test.add_cmd("-c unregister_rsc -r \"test_rsc\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
-    ### stress tests ###
     def build_stress_tests(self):
+        """ Register stress tests """
+
         timeout = "-t 20000"
 
         iterations = 25
@@ -827,7 +909,7 @@ if __name__ == "__main__":
         ### Verify recurring op in-flight collision is handled in series properly
         test = self.new_test("rsc_inflight_collision", "Verify recurring ops do not collide with other operations for the same rsc.")
         test.add_cmd("-c register_rsc -r test_rsc -P pacemaker -C ocf -T Dummy "
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" "+self.action_timeout)
+                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" "+self.action_timeout)
         test.add_cmd("-c exec -r test_rsc -a start %s -k op_sleep -v 1 -l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\"" % (timeout))
         for i in range(iterations):
             test.add_cmd("-c exec -r test_rsc -a monitor %s -i 100%d -k op_sleep -v 2 -l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\"" % (timeout, i))
@@ -836,47 +918,43 @@ if __name__ == "__main__":
         test.add_cmd("-c exec -r test_rsc -a stop %s -l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:stop rc:ok op_status:complete\"" % (timeout))
         test.add_cmd("-c unregister_rsc -r test_rsc %s -l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\"" % (timeout))
 
-    ### These are tests that target specific cases ###
     def build_custom_tests(self):
-
+        """ Register tests that target specific cases """
 
         ### verify resource temporary folder is created and used by heartbeat agents.  ###
         test = self.new_test("rsc_tmp_dir", "Verify creation and use of rsc temporary state directory")
         test.add_sys_cmd("ls", "-al @CRM_RSCTMP_DIR@")
         test.add_cmd("-c register_rsc -r test_rsc -P heartbeat -C ocf -T Dummy "
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" "+self.action_timeout)
+                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" "+self.action_timeout)
         test.add_cmd("-c exec -r test_rsc -a start -t 4000")
         test.add_sys_cmd("ls", "-al @CRM_RSCTMP_DIR@")
         test.add_sys_cmd("ls", "@CRM_RSCTMP_DIR@/Dummy-test_rsc.state")
         test.add_cmd("-c exec -r test_rsc -a stop -t 4000")
         test.add_cmd("-c unregister_rsc -r test_rsc "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### start delay then stop test ###
         test = self.new_test("start_delay", "Verify start delay works as expected.")
         test.add_cmd("-c register_rsc -r test_rsc -P pacemaker -C ocf -T Dummy "
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" "+self.action_timeout)
+                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" "+self.action_timeout)
         test.add_cmd("-c exec -r test_rsc -s 6000 -a start -w -t 6000")
-        test.add_expected_fail_cmd("-l "
-            "\"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" -t 2000")
-        test.add_cmd("-l "
-            "\"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" -t 6000")
-        test.add_cmd("-c exec -r test_rsc -a stop "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:stop rc:ok op_status:complete\" ")
-        test.add_cmd("-c unregister_rsc -r test_rsc "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+        test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" -t 2000")
+        test.add_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" -t 6000")
+        test.add_cmd("-c exec -r test_rsc -a stop " + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:stop rc:ok op_status:complete\" ")
+        test.add_cmd("-c unregister_rsc -r test_rsc " + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### start delay, but cancel before it gets a chance to start.  ###
         test = self.new_test("start_delay_cancel", "Using start_delay, start a rsc, but cancel the start op before execution.")
         test.add_cmd("-c register_rsc -r test_rsc -P pacemaker -C ocf -T Dummy "
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" "+self.action_timeout)
+                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" "+self.action_timeout)
         test.add_cmd("-c exec -r test_rsc -s 5000 -a start -w -t 4000")
-        test.add_cmd("-c cancel -r test_rsc -a start "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:Cancelled\" ")
-        test.add_expected_fail_cmd("-l "
-            "\"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" -t 5000")
-        test.add_cmd("-c unregister_rsc -r test_rsc "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+        test.add_cmd("-c cancel -r test_rsc -a start " + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:Cancelled\" ")
+        test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" -t 5000")
+        test.add_cmd("-c unregister_rsc -r test_rsc " + self.action_timeout +
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### Register a bunch of resources, verify we can get info on them ###
         test = self.new_test("verify_get_rsc_info", "Register multiple resources, verify retrieval of rsc info.")
@@ -911,16 +989,16 @@ if __name__ == "__main__":
         ### verify the option to only send notification to the original client. ###
         test = self.new_test("notify_orig_client_only", "Verify option to only send notifications to the client originating the action.")
         test.add_cmd("-c register_rsc -r \"test_rsc\" -C \"ocf\" -P \"pacemaker\" -T \"Dummy\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
         test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:ok op_status:complete\" ")
         test.add_cmd("-c exec -r \"test_rsc\" -a \"monitor\" -i \"100\" "+self.action_timeout+" -n "
-            "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" ")
         # this will fail because the monitor notifications should only go to the original caller, which no longer exists.
         test.add_expected_fail_cmd("-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:monitor rc:ok op_status:complete\" "+self.action_timeout)
         test.add_cmd("-c cancel -r \"test_rsc\" -a \"monitor\" -i \"100\" -t \"6000\" ")
         test.add_cmd("-c unregister_rsc -r \"test_rsc\" "+self.action_timeout+
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
         ### Verify that versioned resource parameters are chosen properly
 
@@ -952,8 +1030,8 @@ if __name__ == "__main__":
 
         # Register and start the resource.
         test.add_cmd("-c register_rsc -r test_rsc -P heartbeat -C ocf -T Dummy "
-            "-l 'NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete' "
-            "%s" % (self.action_timeout))
+                     "-l 'NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete' "
+                     "%s" % (self.action_timeout))
         test.add_cmd("-c exec -r test_rsc -a start -t 6000 %s" % cmd_params)
 
         # Check the created state file.
@@ -963,46 +1041,47 @@ if __name__ == "__main__":
         # Stop and unregister the resource.
         test.add_cmd("-c exec -r test_rsc -a stop -t 4000 %s" % cmd_params)
         test.add_cmd("-c unregister_rsc -r test_rsc " + self.action_timeout +
-            "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
+                     "-l \"NEW_EVENT event_type:unregister rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
 
 
         ### get metadata ###
         test = self.new_test("get_ocf_metadata", "Retrieve metadata for a resource")
-        test.add_cmd_check_stdout("-c metadata -C \"ocf\" -P \"pacemaker\" -T \"Dummy\""
-            ,"resource-agent name=\"Dummy\"")
+        test.add_cmd_check_stdout("-c metadata -C \"ocf\" -P \"pacemaker\" -T \"Dummy\"",
+                                  "resource-agent name=\"Dummy\"")
         test.add_cmd("-c metadata -C \"ocf\" -P \"pacemaker\" -T \"Stateful\"")
         test.add_expected_fail_cmd("-c metadata -P \"pacemaker\" -T \"Stateful\"")
         test.add_expected_fail_cmd("-c metadata -C \"ocf\" -P \"pacemaker\" -T \"fake_agent\"")
 
         ### get metadata ###
         test = self.new_test("get_lsb_metadata", "Retrieve metadata for a resource")
-        test.add_cmd_check_stdout("-c metadata -C \"lsb\" -T \"LSBDummy\""
-            ,"resource-agent name='LSBDummy'")
+        test.add_cmd_check_stdout("-c metadata -C \"lsb\" -T \"LSBDummy\"",
+                                  "resource-agent name='LSBDummy'")
 
         ### get stonith metadata ###
         test = self.new_test("get_stonith_metadata", "Retrieve stonith metadata for a resource")
         test.add_cmd_check_stdout("-c metadata -C \"stonith\" -P \"pacemaker\" -T \"fence_dummy_monitor\"",
-            "resource-agent name=\"fence_dummy_monitor\"")
+                                  "resource-agent name=\"fence_dummy_monitor\"")
 
         ### get metadata ###
         if "systemd" in self.rsc_classes:
             test = self.new_test("get_systemd_metadata", "Retrieve metadata for a resource")
-            test.add_cmd_check_stdout("-c metadata -C \"systemd\" -T \"lrmd_dummy_daemon\""
-                ,"resource-agent name=\"lrmd_dummy_daemon\"")
+            test.add_cmd_check_stdout("-c metadata -C \"systemd\" -T \"lrmd_dummy_daemon\"",
+                                      "resource-agent name=\"lrmd_dummy_daemon\"")
 
         ### get metadata ###
         if "upstart" in self.rsc_classes:
             test = self.new_test("get_upstart_metadata", "Retrieve metadata for a resource")
-            test.add_cmd_check_stdout("-c metadata -C \"upstart\" -T \"lrmd_dummy_daemon\""
-                ,"resource-agent name=\"lrmd_dummy_daemon\"")
+            test.add_cmd_check_stdout("-c metadata -C \"upstart\" -T \"lrmd_dummy_daemon\"",
+                                      "resource-agent name=\"lrmd_dummy_daemon\"")
 
         if "heartbeat" in self.rsc_classes:
             test = self.new_test("get_heartbeat_metadata", "Retrieve metadata for a resource")
-            test.add_cmd_check_stdout("-c metadata -C \"heartbeat\" -T \"HBDummy\""
-                ,"resource-agent name='HBDummy'")
+            test.add_cmd_check_stdout("-c metadata -C \"heartbeat\" -T \"HBDummy\"",
+                                      "resource-agent name='HBDummy'")
 
         ### get ocf providers  ###
-        test = self.new_test("list_ocf_providers", "Retrieve list of available resource providers, verifies pacemaker is a provider.")
+        test = self.new_test("list_ocf_providers",
+                             "Retrieve list of available resource providers, verifies pacemaker is a provider.")
         test.add_cmd_check_stdout("-c list_ocf_providers ", "pacemaker")
         test.add_cmd_check_stdout("-c list_ocf_providers -T ping", "pacemaker")
 
@@ -1048,6 +1127,8 @@ if __name__ == "__main__":
             test.add_cmd_check_stdout("-c list_agents -C service", "", "HBDummy")            ### should not exist
 
     def print_list(self):
+        """ List all registered tests """
+
         print("\n==== %d TESTS FOUND ====" % (len(self.tests)))
         print("%35s - %s" % ("TEST NAME", "TEST DESCRIPTION"))
         print("%35s - %s" % ("--------------------", "--------------------"))
@@ -1056,21 +1137,29 @@ if __name__ == "__main__":
         print("==== END OF LIST ====\n")
 
     def run_single(self, name):
+        """ Run a single named test """
+
         for test in self.tests:
             if test.name == name:
                 test.run()
-                break;
+                break
 
     def run_tests_matching(self, pattern):
+        """ Run all tests whose name matches a pattern """
+
         for test in self.tests:
             if test.name.count(pattern) != 0:
                 test.run()
 
     def run_tests(self):
+        """ Run all tests """
+
         for test in self.tests:
             test.run()
 
     def exit(self):
+        """ Exit (with error status code if any test failed) """
+
         for test in self.tests:
             if test.executed == 0:
                 continue
@@ -1078,11 +1167,13 @@ if __name__ == "__main__":
             if test.get_exitcode() != 0:
                 sys.exit(-1)
 
-        sys.exit(0);
+        sys.exit(0)
 
     def print_results(self):
-        failures = 0;
-        success = 0;
+        """ Print summary of results of executed tests """
+
+        failures = 0
+        success = 0
         print("\n\n======= FINAL RESULTS ==========")
         print("\n--- FAILURE RESULTS:")
         for test in self.tests:
@@ -1100,7 +1191,10 @@ if __name__ == "__main__":
 
         print("\n--- TOTALS\n    Pass:%d\n    Fail:%d\n" % (success, failures))
 
-class TestOptions:
+
+class TestOptions(object):
+    """ Option handler """
+
     def __init__(self):
         self.options = {}
         self.options['list-tests'] = 0
@@ -1113,6 +1207,8 @@ class TestOptions:
         self.options['pacemaker-remote'] = 0
 
     def build_options(self, argv):
+        """ Set options based on command-line arguments """
+
         args = argv[1:]
         skip = 0
         for i in range(0, len(args)):
@@ -1135,6 +1231,8 @@ class TestOptions:
                 skip = 1
 
     def show_usage(self):
+        """ Show command usage """
+
         print("usage: " + sys.argv[0] + " [options]")
         print("If no options are provided, all tests will run")
         print("Options:")
@@ -1151,10 +1249,14 @@ class TestOptions:
 
 
 def main(argv):
-    o = TestOptions()
-    o.build_options(argv)
+    """ Run lrmd regression tests as specified by arguments """
 
-    tests = Tests(o.options['verbose'], o.options['pacemaker-remote'])
+    update_path()
+
+    opts = TestOptions()
+    opts.build_options(argv)
+
+    tests = Tests(opts.options['verbose'], opts.options['pacemaker-remote'])
 
     tests.build_generic_tests()
     tests.build_multi_rsc_tests()
@@ -1166,15 +1268,15 @@ def main(argv):
 
     print("Starting ...")
 
-    if o.options['list-tests']:
+    if opts.options['list-tests']:
         tests.print_list()
-    elif o.options['show-usage']:
-        o.show_usage()
-    elif o.options['run-only-pattern'] != "":
-        tests.run_tests_matching(o.options['run-only-pattern'])
+    elif opts.options['show-usage']:
+        opts.show_usage()
+    elif opts.options['run-only-pattern'] != "":
+        tests.run_tests_matching(opts.options['run-only-pattern'])
         tests.print_results()
-    elif o.options['run-only'] != "":
-        tests.run_single(o.options['run-only'])
+    elif opts.options['run-only'] != "":
+        tests.run_single(opts.options['run-only'])
         tests.print_results()
     else:
         tests.run_tests()
@@ -1182,6 +1284,7 @@ def main(argv):
 
     tests.cleanup_test_environment()
     tests.exit()
+
 
 if __name__ == "__main__":
     main(sys.argv)


### PR DESCRIPTION
pylint turned up that we weren't using new-style classes in our python code. As all classes are new-style in Python 3, we should be using them, for our goal of 2.6+/3.2+ compatibility. So, this edits the fencing and lrmd regression tests to use new-style classes, and adds that to our python coding guidelines.

Additionally, this reformats and restructures the code to run more cleanly under pylint, and recommends that in the style guidelines.

This also updates a small bit of CTS code to be 2.6+/3.2+ compatible, and fixes some minor issues found in the course of all this.