### PR TITLE
Low: pacemaker.service: do not mistakenly suggest killing fenced

### DIFF
--- a/mcp/pacemaker.service.in
+++ b/mcp/pacemaker.service.in
@@ -39,7 +39,7 @@ SendSIGKILL=no
 # Although the node will likely end up being fenced as a result so it's
 # not on by default
 #
-# ExecStopPost=/usr/bin/killall -TERM crmd attrd fenced cib pengine lrmd
+# ExecStopPost=/usr/bin/killall -TERM crmd attrd stonithd cib pengine lrmd
 
 # If you want Corosync to stop whenever Pacemaker is stopped,
 # uncomment the next line too:


### PR DESCRIPTION
...when stonithd is the proper daemon in charge of node executions.