### PR TITLE
cts: fix syntax error with python3+

### DIFF
--- a/cts/CTS.py
+++ b/cts/CTS.py
@@ -246,7 +246,7 @@ class NodeStatus:
         else:
             try:
                 answer = raw_input('Continue? [nY]')
-            except EOFError, e:
+            except EOFError as e:
                 answer = "n"
         if answer and answer == "n":
             raise ValueError("%s did not come up within %d tries" % (node, Timeout))

--- a/cts/CTSaudits.py
+++ b/cts/CTSaudits.py
@@ -185,7 +185,7 @@ class DiskAudit(ClusterAudit):
                         else:
                             try:
                                 answer = raw_input('Continue? [nY]')
-                            except EOFError, e:
+                            except EOFError as e:
                                 answer = "n"
 
                         if answer and answer == "n":

--- a/cts/CTSscenarios.py
+++ b/cts/CTSscenarios.py
@@ -171,7 +171,7 @@ A partially set up scenario is torn down if it fails during setup.
             else:
                 try:
                     answer = raw_input('Continue? [nY]')
-                except EOFError, e:
+                except EOFError as e:
                     answer = "n"
             if answer and answer == "n":
                 raise ValueError("Teardown of %s on %s failed" % (test.name, nodechoice))
@@ -266,7 +266,7 @@ A partially set up scenario is torn down if it fails during setup.
             else:
                 try:
                     answer = raw_input('Big problems. Continue? [nY]')
-                except EOFError, e:
+                except EOFError as e:
                     answer = "n"
             if answer and answer == "n":
                 self.ClusterManager.log("Shutting down.")

--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -1659,7 +1659,7 @@ class SplitBrainTest(CTSTest):
             else:
                 try:
                     answer = raw_input('Continue? [nY]')
-                except EOFError, e:
+                except EOFError as e:
                     answer = "n" 
             if answer and answer == "n":
                 raise ValueError("Reformed cluster not stable")


### PR DESCRIPTION
The , format is not supported for exception-handling in Python3.0+.

https://docs.python.org/release/3.0.1/whatsnew/2.6.html#pep-3110

Signed-off-by: Nishanth Aravamudan <nish.aravamudan@canonical.com>