### PR TITLE
Build: configure: run initctl as an upstart detection fallback

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1232,10 +1232,11 @@ if test "x${enable_upstart}" != xno; then
 		# ret is intentionally unenquoted so as to normalize whitespace
 		ret=$(echo ${ret} | cut -d' ' -f2-)
 		AC_MSG_RESULT([${ret}])
-		if test "x${ret}" = xborked; then
-			enable_upstart=no
-		else
+		if test "x${ret}" != xborked \
+		   || initctl --version 2>/dev/null | grep -q upstart; then
 			enable_upstart=yes
+		else
+			enable_upstart=no
 		fi
 	fi
 fi


### PR DESCRIPTION
Understandably, chroot-based buildsystems do not reliably expose system
message bus, so additional fallback to handle this corner case is added.
The DBus method is kept primary, also to have possible DBus API changes
checked, should the version of the Upstart interface at the target system
differ from what pacemaker uses.