### PR TITLE
Fix: crmd: cl#5185 - Record pending operations in the CIB before they are performed

### DIFF
--- a/crmd/te_actions.c
+++ b/crmd/te_actions.c
@@ -491,15 +491,6 @@ te_rsc_command(crm_graph_t * graph, crm_action_t * action)
         te_start_action_timer(graph, action);
     }
 
-    value = crm_meta_value(action->params, XML_OP_ATTR_PENDING);
-    if (crm_is_true(value)
-        && safe_str_neq(task, CRMD_ACTION_CANCEL)
-        && safe_str_neq(task, CRMD_ACTION_DELETE)) {
-        /* write a "pending" entry to the CIB, inhibit notification */
-        crm_debug("Recording pending op %s in the CIB", task_uuid);
-        cib_action_update(action, PCMK_LRM_OP_PENDING, PCMK_OCF_UNKNOWN);
-    }
-
     return TRUE;
 }
 


### PR DESCRIPTION
Although we had the assurance of CPG, there was the race condition that
the peer received the lrm_invoke request from the DC, got the operation
performed, returned and updated into the CIB very fast, even before
the pending operation was injected into the CIB. The late pending
operation would override the real result of the operation and get
stalled in the CIB, which would basically tell the wrong state of the
resource.

The idea of this fix is to record the pending operation from the node
where the operation will be performed rather than from the DC, and right
before it's performed, to avoid the race condition.