### PR TITLE
Low: fix missing qbarray.h include, no longer brought by qbipc[cs].h

### DIFF
--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -33,6 +33,8 @@
 #include <crm/common/mainloop.h>
 #include <crm/common/ipcs.h>
 
+#include <qb/qbarray.h>
+
 struct mainloop_child_s {
     pid_t pid;
     char *desc;


### PR DESCRIPTION
Pacemaker should by no mean rely on fancy (and sometimes improper)
transitive includes present with some versions of libqb, and use
the API properly; here: when you use functionality from qbarray.h,
care to include it.

References:
  http://oss.clusterlabs.org/pipermail/users/2016-October/004411.html
  (initial report, thanks Ferdinando!)
  https://github.com/ClusterLabs/libqb/pull/228/commits/c1c26c94cb38e1b40d063a7e5fa29f2de033ed37
  (commit that introduced the change at the libqb side)