### PR TITLE
fix clustermon.sh sendsnmp function with working variables

### DIFF
--- a/extra/clustermon.sh
+++ b/extra/clustermon.sh
@@ -140,10 +140,10 @@ function ocf_exitcode {
 
 function sendsnmp() {
   [ -f /usr/bin/snmptrap ] && /usr/bin/snmptrap -v 2c -c "$SNMPCOMMUNITY" "$SNMPDEST" "" PACEMAKER-MIB::pacemakerNotification \
-        PACEMAKER-MIB::pacemakerNotificationNode s "${node}" \
-        PACEMAKER-MIB::pacemakerNotificationResource s "${rsc}" \
+        PACEMAKER-MIB::pacemakerNotificationNode s "${CRM_notify_node}" \
+        PACEMAKER-MIB::pacemakerNotificationResource s "${CRM_notify_rsc}" \
         PACEMAKER-MIB::pacemakerNotificationOperation s "${CRM_notify_task}" \
-        PACEMAKER-MIB::pacemakerNotificationDescription s "${desc}" \
+        PACEMAKER-MIB::pacemakerNotificationDescription s "${CRM_notify_desc}" \
         PACEMAKER-MIB::pacemakerNotificationStatus i "${CRM_notify_status}" \
         PACEMAKER-MIB::pacemakerNotificationReturnCode i ${CRM_notify_rc} \
         PACEMAKER-MIB::pacemakerNotificationTargetReturnCode i ${CRM_notify_target_rc}


### PR DESCRIPTION
This is a fix for the clustermon.sh script when using snmptraps.
When using ClusterMon resource or crm_mon with this script as an external agent, snmptraps are never sent. 
Some variables were not defined. After replacing them with the original ones, the script is sending snmptraps correctly.