### PR TITLE
xml: rng: Keep score-attribute{,-mangle} in the existing RelaxNG schema files for graceful upgrades

### DIFF
--- a/xml/constraints-1.0.rng
+++ b/xml/constraints-1.0.rng
@@ -72,7 +72,11 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <externalRef href="score.rng"/>
+        <choice>
+          <externalRef href="score.rng"/>
+          <attribute name="score-attribute"><text/></attribute>
+          <attribute name="score-attribute-mangle"><text/></attribute>
+        </choice>
       </optional>
       <optional>
         <ref name="element-lifetime"/>

--- a/xml/constraints-1.2.rng
+++ b/xml/constraints-1.2.rng
@@ -88,7 +88,11 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <externalRef href="score.rng"/>
+        <choice>
+          <externalRef href="score.rng"/>
+          <attribute name="score-attribute"><text/></attribute>
+          <attribute name="score-attribute-mangle"><text/></attribute>
+        </choice>
       </optional>
       <optional>
         <ref name="element-lifetime"/>

--- a/xml/constraints-2.1.rng
+++ b/xml/constraints-2.1.rng
@@ -96,7 +96,11 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <externalRef href="score.rng"/>
+        <choice>
+          <externalRef href="score.rng"/>
+          <attribute name="score-attribute"><text/></attribute>
+          <attribute name="score-attribute-mangle"><text/></attribute>
+        </choice>
       </optional>
       <optional>
         <ref name="element-lifetime"/>

--- a/xml/constraints-2.2.rng
+++ b/xml/constraints-2.2.rng
@@ -101,7 +101,11 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <externalRef href="score.rng"/>
+        <choice>
+          <externalRef href="score.rng"/>
+          <attribute name="score-attribute"><text/></attribute>
+          <attribute name="score-attribute-mangle"><text/></attribute>
+        </choice>
       </optional>
       <optional>
         <ref name="element-lifetime"/>

--- a/xml/constraints-2.3.rng
+++ b/xml/constraints-2.3.rng
@@ -101,7 +101,11 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <externalRef href="score.rng"/>
+        <choice>
+          <externalRef href="score.rng"/>
+          <attribute name="score-attribute"><text/></attribute>
+          <attribute name="score-attribute-mangle"><text/></attribute>
+        </choice>
       </optional>
       <optional>
         <ref name="element-lifetime"/>

--- a/xml/constraints-2.6.rng
+++ b/xml/constraints-2.6.rng
@@ -104,7 +104,11 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <externalRef href="score.rng"/>
+        <choice>
+          <externalRef href="score.rng"/>
+          <attribute name="score-attribute"><text/></attribute>
+          <attribute name="score-attribute-mangle"><text/></attribute>
+        </choice>
       </optional>
       <optional>
         <ref name="element-lifetime"/>


### PR DESCRIPTION
This commit partially reverts commit
30383cc5d70d542a95860a043f4d044f9fa5af5e to prevent either rolling
upgrade or offline upgrade from being possibly broken.

So that the removal of the attributes score-attribute and
score-attribute-mangle only remains for constraints-next.rng as a
reminder. We'll remove the attributes in the next bumped RNG version and
create a XSL file for doing transformation.