### PR TITLE
Build: configure: fix fouled parameter expansion

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1251,7 +1251,7 @@ if test "x${enable_systemd}" = xyes; then
 	PCMK_FEATURES="$PCMK_FEATURES systemd"
 
 	AC_MSG_CHECKING([for systemd path for system unit files])
-	systemdunitdir="${systemdunitdir:}"
+	systemdunitdir="${systemdunitdir-}"
 	PKG_CHECK_VAR([systemdunitdir], [systemd],
 		      [systemdsystemunitdir], [],[
 	   systemdunitdir=no


### PR DESCRIPTION
Introduced with b38f7c5; spotted by and many thanks to wferi:
https://github.com/ClusterLabs/pacemaker/commit/b38f7c54d81a73cabd13f77ed518c45f58a3c25f#commitcomment-19727928