### PR TITLE
wd: Fix to not compare NULL when environment variable is not set

### DIFF
--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -129,7 +129,7 @@ pcmk_panic_local(void)
 
     /* We're either pacemakerd, or a pacemaker daemon running as root */
 
-    if (strcmp("crash", getenv("PCMK_panic_action")) == 0) {
+    if (safe_str_eq("crash", getenv("PCMK_panic_action"))) {
         sysrq_trigger('c');
     } else {
         sysrq_trigger('b');


### PR DESCRIPTION
Fixed the problem which caused SEGV by comparing NULL when the PCMK_panic_action environment variable is not set.