### PR TITLE
Colon

### DIFF
--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -109,7 +109,7 @@ crm_int_helper(const char *text, char **end_text)
             crm_err("Conversion of %s was clipped: %lld", text, result);
 
         } else if (errno != 0) {
-            crm_perror(LOG_ERR, "Conversion of %s failed:", text);
+            crm_perror(LOG_ERR, "Conversion of %s failed", text);
         }
 
         if (local_end_text != NULL && local_end_text[0] != '\0') {

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -3026,7 +3026,8 @@ write_xml_stream(xmlNode * xml_node, const char *filename, FILE * stream, gboole
         res = -1;
     }
 
-    if (fsync(fileno(stream)) < 0) {
+    /* Don't report error if the file does not support synchronization */
+    if (fsync(fileno(stream)) < 0 && errno != EROFS  && errno != EINVAL) {
         crm_perror(LOG_ERR, "fsync for %s failed", filename);
         res = -1;
     }

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -3022,12 +3022,12 @@ write_xml_stream(xmlNode * xml_node, const char *filename, FILE * stream, gboole
   bail:
 
     if (fflush(stream) != 0) {
-        crm_perror(LOG_ERR, "fflush for %s failed:", filename);
+        crm_perror(LOG_ERR, "fflush for %s failed", filename);
         res = -1;
     }
 
     if (fsync(fileno(stream)) < 0) {
-        crm_perror(LOG_ERR, "fsync for %s failed:", filename);
+        crm_perror(LOG_ERR, "fsync for %s failed", filename);
         res = -1;
     }
 


### PR DESCRIPTION
Currently, `crm_simulate --quiet --live-check --run --save-graph /dev/stdout` finishes with the ugly
~~~
fsync for /dev/stdout failed:: Invalid argument (22)
~~~
message. To be honest, I don't fully understand why `xml.c` does that `fsync()`, but the (now somewhat misleading) trace message following it suggests that it was intended for CIB writes originally, which may indeed require synchronization.
Please consider including these changes.