### PR TITLE
upstart: Delete unnecessary soft_margin

### DIFF
--- a/mcp/pacemaker.combined.upstart.in
+++ b/mcp/pacemaker.combined.upstart.in
@@ -20,9 +20,6 @@ script
 end script
 
 pre-start script
-    # setup the software watchdog which corosync uses.
-    # rewrite according to environment.
-    [ -c /dev/watchdog ] || modprobe softdog soft_margin=60
     pidof corosync || start corosync
 
     # if you use corosync-notifyd, uncomment the line below.


### PR DESCRIPTION
Since the latest corosync initializes watchdog_timeout at startup, setting soft_margin here is no longer necessary.
I will delete this setting.
The systemd startup script on corosync side has been fixed below.
https://github.com/corosync/corosync/pull/168