### PR TITLE
build: allow for git -> automatic COPR builds integration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 /.*	export-ignore
 /travisci_build_coverity_scan.sh	export-ignore
 /scratch.c	export-ignore
+/.tito*	export-ignore

--- a/.tito.spec.tmpl
+++ b/.tito.spec.tmpl
@@ -1,0 +1,1 @@
+Name: pacemaker

--- a/.tito/custom.py
+++ b/.tito/custom.py
@@ -1,0 +1,63 @@
+# -*- coding: UTF-8 -*-
+"""Tito ad-hoc module for custom git repo -> spec + archive metamorphosis"""
+
+from __future__ import (print_function, unicode_literals, absolute_import,
+                        division)
+
+__author__ = "Jan Pokorný <jpokorny@redhat.com>"
+__copyright__ = "Copyright 2016 Red Hat, Inc."
+__license__ = "LGPLv2.1+ WITHOUT ANY WARRANTY"
+
+
+from os.path import basename, join
+from shutil import copyfile
+
+from tito.builder.main import BuilderBase
+from tito.builder.fetch import FetchBuilder
+from tito.common import error_out, run_command, get_spec_version_and_release
+
+
+class NativeFetchBuilder(FetchBuilder):
+    """
+    A specialized FetchBuilder to just setup the specfile + archive
+    using package-native scripts, which currently boils down to a sequence
+    that needs to be configured via fetch_prep_command option in builder
+    section (e.g., "./autogen.sh && ./configure && make dist foo.spec").
+
+    Uses code of src/tito/builder/fetch.py from the tito project as a template.
+    """
+    REQUIRED_ARGS = []
+
+    def __init__(self, name=None, tag=None, build_dir=None,
+                 config=None, user_config=None,
+                 args=None, **kwargs):
+
+        BuilderBase.__init__(self, name=name, build_dir=build_dir,
+                             config=config,
+                             user_config=user_config, args=args, **kwargs)
+
+        if tag:
+            error_out("FetchBuilder does not support building specific tags.")
+
+        if not config.has_option('builder', 'fetch_prep_command'):
+            error_out("NativeFetchBuilder requires fetch_prep_command.")
+
+        self.build_tag = '%s-%s' % (
+            self.project_name,
+            get_spec_version_and_release(self.start_dir,
+                                         '%s.spec' % self.project_name)
+        )
+
+    def tgz(self):
+        self.ran_tgz = True
+        self._create_build_dirs()
+
+        print("Fetching sources...")
+        run_command(self.config.get('builder', 'fetch_prep_command'))
+        manual_sources = [run_command("ls -1t *.tar.* | head -n1")]
+        self.spec_file = self.project_name + '.spec'
+        for s in manual_sources:
+            base_name = basename(s)
+            dest_filepath = join(self.rpmbuild_sourcedir, base_name)
+            copyfile(s, dest_filepath)
+            self.sources.append(dest_filepath)

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -1,0 +1,21 @@
+[buildconfig]
+builder = custom.NativeFetchBuilder
+tagger = tito.tagger.VersionTagger
+lib_dir = .tito
+
+[builder]
+fetch_prep_command = $(test $(id -u) -eq 0 && echo "ln -s" || echo :) \
+                        /usr/bin/false /usr/local/bin/rpmbuild \
+                     && git rev-list --count HEAD ^$(git describe \
+                        --tags --abbrev=0) > build.counter \
+                     && export WITH="$(git rev-parse --abbrev-ref --quiet HEAD \
+                                       | grep -vqE '^[1-9].[0-9][0-9]*$' \
+                                       || echo '--with pre_release')" \
+                     && { make srpm-temp || :; } \
+                     && test -z "${WITH}" || { \
+                        echo '%define _with_pre_release --with-pre_release' \
+                           > new.spec \
+                        && cat pacemaker.spec >> new.spec \
+                        && mv new.spec pacemaker.spec; } \
+                     && $(test $(id -u) -eq 0 && echo "rm -f" || echo :) \
+                        /usr/local/bin/rpmbuild

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -95,10 +95,10 @@ rpmbuild-with = \
 	eval set -- "$${WITH}"; \
 	while true; do \
 		case "$$1" in \
-		--with) CMD="$${CMD} --define \"_with_$$2 --with-$$2\""; shift 2; \
-			[ "$$2" != pre_release ] || PREREL=1;; \
-		--without) CMD="$${CMD} --define \"_without_$$2 --without-$$2\""; shift 2; \
-		        [ "$$2" != pre_release ] || PREREL=0;; \
+		--with) CMD="$${CMD} --define \"_with_$$2 --with-$$2\""; \
+			[ "$$2" != pre_release ] || PREREL=1; shift 2;; \
+		--without) CMD="$${CMD} --define \"_without_$$2 --without-$$2\""; \
+		        [ "$$2" != pre_release ] || PREREL=0; shift 2;; \
 		--) shift ; break ;; \
 		*) echo "cannot parse WITH: $$1"; exit 1;; \
 		esac; \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -187,7 +187,6 @@ srpm-%:	export $(PACKAGE)-%.spec
 	fi
 	sed -i 's/global\ specversion.*/global\ specversion\ $(SPECVERSION)/' $(PACKAGE).spec
 	sed -i 's/global\ commit.*/global\ commit\ $(TAG)/' $(PACKAGE).spec
-	@WITH=$$(getopt -o "" -l with:,without: -n '$@' -- $(WITH)) || exit 1; \
 	$(call rpmbuild-with,$(WITH),-bs --define "dist .$*" $(RPM_OPTS),$(PACKAGE).spec)
 
 chroot: mock-$(MOCK_CFG) mock-install-$(MOCK_CFG) mock-sh-$(MOCK_CFG)


### PR DESCRIPTION
New tito-related files makes the repository compatible with tito method
of building in COPR (https://fedorahosted.org/copr/wiki/UserDocs#Tito).