### PR TITLE
Low: stonith_admin: Display a query result with Q option.

### DIFF
--- a/fencing/admin.c
+++ b/fencing/admin.c
@@ -335,6 +335,7 @@ main(int argc, char **argv)
     char *name = NULL;
     char *value = NULL;
     char *target = NULL;
+    char *lists = NULL;
     const char *agent = NULL;
     const char *device = NULL;
     const char *longname = NULL;
@@ -518,8 +519,11 @@ main(int argc, char **argv)
             break;
         case 'Q':
             rc = st->cmds->monitor(st, st_opts, device, timeout);
-            if (rc < 0) {
-                rc = st->cmds->list(st, st_opts, device, NULL, timeout);
+            if (rc == 0) {
+                rc = st->cmds->list(st, st_opts, device, &lists, timeout);
+                if (rc == 0) {
+                    fprintf(stdout, "%s\n", lists ? lists : "<none>");
+                }
             }
             break;
         case 'R':


### PR DESCRIPTION
Hi All,

The Q option of stonith_admin is ignored now.

The result displays the XML character string of the QUERY reply of stonithd.

User can process the unnecessary character string of the result in sed.

```
[root@rh73-01 fencing]# stonith_admin -L
 prmStonith2-1
1 devices found

[root@rh73-01 fencing]# stonith_admin -Q prmStonith2-1
rh66-hb3,\nrh66-hb2,\nrh66-hb1,\nrh68-02,\nrh72-03,\nrh68-01,\ncent7-go,\nrh72-01-pcsd,\nrh72-02,\nsnmp-server-2,\nrh72-01,\ncent7-pcsd1,\nrh73-02,\nsnmp-server,\ncent7-docker,\nrh73-01,\n

[root@rh73-01 fencing]# stonith_admin -Q prmStonith2-1 | sed -e "s/\\\n//g"
rh66-hb3,rh66-hb2,rh66-hb1,rh68-02,rh72-03,rh68-01,cent7-go,rh72-01-pcsd,rh72-02,snmp-server-2,rh72-01,cent7-pcsd1,rh73-02,snmp-server,cent7-docker,rh73-01,

```

Best Regards,
Hideo Yamauchi.

