### PR TITLE
Low: stonith_admin: Addition of the list-targets option.

### DIFF
--- a/fencing/admin.c
+++ b/fencing/admin.c
@@ -54,6 +54,7 @@ static struct crm_option long_options[] = {
     {"list",            1, 0, 'l', "List devices that can terminate the specified host"},
     {"list-registered", 0, 0, 'L', "List all registered devices"},
     {"list-installed",  0, 0, 'I', "List all installed devices"},
+    {"list-targets",  1, 0, 's', "List the device's target"},
 
     {"-spacer-",    0, 0, '-', ""},
     {"metadata",    0, 0, 'M', "Check the device's metadata"},
@@ -335,6 +336,7 @@ main(int argc, char **argv)
     char *name = NULL;
     char *value = NULL;
     char *target = NULL;
+    char *lists = NULL;
     const char *agent = NULL;
     const char *device = NULL;
     const char *longname = NULL;
@@ -378,6 +380,7 @@ main(int argc, char **argv)
             case 'Q':
             case 'R':
             case 'D':
+            case 's':
                 action = flag;
                 device = optarg;
                 break;
@@ -520,6 +523,12 @@ main(int argc, char **argv)
             rc = st->cmds->monitor(st, st_opts, device, timeout);
             if (rc < 0) {
                 rc = st->cmds->list(st, st_opts, device, NULL, timeout);
+            }
+            break;
+        case 's':
+            rc = st->cmds->list(st, st_opts, device, &lists, timeout);
+            if (rc == 0) {
+                fprintf(stdout, "%s\n", lists ? lists : "<none>");
             }
             break;
         case 'R':


### PR DESCRIPTION
Hi All,

Next pullrequest causes it.
 * https://github.com/ClusterLabs/pacemaker/pull/1186

I add list-targets option to stonith_admin command.

```
[root@rh73-01 fencing]# stonith_admin -L
 prmStonith2-1
1 devices found

[root@rh73-01 fencing]# stonith_admin -s prmStonith2-1
rh66-hb3,\nrh66-hb2,\nrh66-hb1,\nrh68-02,\nrh72-02,\nrh72-03,\nsnmp-server,\ncent7-go,\nrh72-01-pcsd,\nrh68-01,\nsnmp-server-2,\nrh73-01-test,\nrh72-01,\ncent7-pcsd1,\nrh73-02,\ncent7-docker,\nrh73-01,\n

[root@rh73-01 fencing]# stonith_admin --list-targets prmStonith2-1
rh66-hb3,\nrh66-hb2,\nrh66-hb1,\nrh68-02,\nrh72-02,\nrh72-03,\nsnmp-server,\ncent7-go,\nrh72-01-pcsd,\nrh68-01,\nsnmp-server-2,\nrh73-01-test,\nrh72-01,\ncent7-pcsd1,\nrh73-02,\ncent7-docker,\nrh73-01,\n


[root@rh73-01 fencing]# stonith_admin -s prmStonith2-2
Command failed: No such device
```

User can process the unnecessary character string of the result in sed.

```
[root@rh73-01 fencing]# stonith_admin -s prmStonith2-1 | sed -e "s/\\\n//g"
rh66-hb3,rh66-hb2,rh66-hb1,rh68-02,rh72-02,rh72-03,snmp-server,cent7-go,rh72-01-pcsd,rh68-01,snmp-server-2,rh73-01-test,rh72-01,cent7-pcsd1,rh73-02,cent7-docker,rh73-01,
```

Best Regards,
Hideo Yamauchi.
