### PR TITLE
Mid: Alerts: Redirection of the snmptrap command. 

### DIFF
--- a/extra/alerts/alert_snmp.sh.sample
+++ b/extra/alerts/alert_snmp.sh.sample
@@ -93,6 +93,7 @@ is_in_list() {
     return 1
 }
 
+rc=0
 case "$CRM_alert_kind" in
     node)
         is_in_list "${trap_node_states}" "${CRM_alert_desc}"
@@ -103,7 +104,8 @@ case "$CRM_alert_kind" in
         PACEMAKER-MIB::pacemakerNotificationTrap \
         PACEMAKER-MIB::pacemakerNotificationNode s "${CRM_alert_node}" \
         PACEMAKER-MIB::pacemakerNotificationDescription s "${CRM_alert_desc}" \
-        ${hires_timestamp}
+        ${hires_timestamp} > /dev/null 2>&1
+        rc=$?
         ;;
     fencing)
         is_in_list "${trap_fencing_tasks}" "${CRM_alert_task}"
@@ -116,7 +118,8 @@ case "$CRM_alert_kind" in
         PACEMAKER-MIB::pacemakerNotificationOperation s "${CRM_alert_task}" \
         PACEMAKER-MIB::pacemakerNotificationDescription s "${CRM_alert_desc}" \
         PACEMAKER-MIB::pacemakerNotificationReturnCode i ${CRM_alert_rc} \
-        ${hires_timestamp}
+        ${hires_timestamp} > /dev/null 2>&1
+        rc=$?
         ;;
     resource)
         is_in_list "${trap_resource_tasks}" "${CRM_alert_task}"
@@ -141,10 +144,16 @@ case "$CRM_alert_kind" in
             PACEMAKER-MIB::pacemakerNotificationStatus i ${CRM_alert_status} \
             PACEMAKER-MIB::pacemakerNotificationReturnCode i ${CRM_alert_rc} \
             PACEMAKER-MIB::pacemakerNotificationTargetReturnCode i ${CRM_alert_target_rc} \
-            ${hires_timestamp}
+            ${hires_timestamp} > /dev/null 2>&1
+            rc=$?
             ;;
         esac
         ;;
     *)
         ;;
 esac
+
+if [ $rc -ne 0 ]; then
+    echo "${trap_binary} returned error. rc=${rc}"
+fi
+


### PR DESCRIPTION
Hi All,

When SNMP_PERSISTENT_DIR is not set definitely, alert_snmp.sh.sample may output the following errors.
However, this error is not an error of the snmptrap command.

```
crmd[3569]:  notice: notify_9:4265:stderr [ Cannot rename t-snmp/snmpapp.conf to /var/lib/net-snmp/snmpapp.0.conf ]
crmd[3569]:  notice: notify_9:4265:stderr [ Cannot unlink /var/lib/net-snmp/snmpapp.conf ]

```

In addition, the next error may be output when there is not a subdirectory.

```
crmd[6507]:  notice: notify_9:6626:stderr [ Created directory: /xxxx/.snmp_presist/cert_indexes ]
crmd[6507]:  notice: notify_9:6626:stderr [ Created directory: /xxxx/.snmp_presist/mib_indexes ]

```

The snmptrap command transmits a trap and is finished normally.

These errors send a patch to ignore.

Best Regards,
Hideo Yamauchi.
