### PR TITLE
treat systemd service reloading as OK instead of FAILED

### DIFF
--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -552,6 +552,8 @@ systemd_unit_check(const char *name, const char *state, void *userdata)
 
     } else if (g_strcmp0(state, "active") == 0) {
         op->rc = PCMK_OCF_OK;
+    } else if (g_strcmp0(state, "reloading") == 0) {
+        op->rc = PCMK_OCF_OK;
     } else if (g_strcmp0(state, "activating") == 0) {
         op->rc = PCMK_OCF_PENDING;
     } else if (g_strcmp0(state, "deactivating") == 0) {


### PR DESCRIPTION
Previously if pacemaker performed a monitor operation while a service was reloading, pacemaker treated it as if the service were stopped/failed.


Fixes http://bugs.clusterlabs.org/show_bug.cgi?id=5307
*(edit: linked wrong bug)*