### PR TITLE
build: spec: rationalize pre-release vs. tags logic

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -111,7 +111,7 @@ rpmbuild-with = \
 		esac; \
 	done; \
 	case "$(3)" in \
-	*.spec) [ $${PREREL} -eq 0 ] \
+	*.spec) { [ $${PREREL} -eq 0 ] || [ $(LAST_RELEASE) = $(TAG) ]; } \
 		&& sed -i "s/^\(%global pcmkversion \).*/\1$$(echo $(LAST_RELEASE) | sed -e s:Pacemaker-:: -e s:-.*::)/" $(3) \
 		|| sed -i "s/^\(%global pcmkversion \).*/\1$$(echo $(NEXT_RELEASE) | sed -e s:Pacemaker-:: -e s:-.*::)/" $(3);; \
 	esac; \

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -32,11 +32,11 @@
                       Pacemaker-*%{rparen} echo ${c:10};;
                       *%{rparen} echo ${c:0:7};; esac)
 
-## Whether this is a release candidate
-%define pre_release %(s=%{shortcommit}; [ ${s: -4:3} != -rc ]; echo $?)
+## Whether this is a tagged release
+%define tag_release %([ %{commit} != Pacemaker-%{shortcommit} ]; echo $?)
 
-## Whether this is a development branch
-%define post_release %([ %{commit} = Pacemaker-%{shortcommit} ]; echo $?)
+## Whether this is a release candidate (in case of a tagged release)
+%define pre_release %(s=%{shortcommit};  [ "%{tag_release}" -ne 0 ] && [ ${s: -4:3} != -rc ]; echo $?)
 
 ## Turn off auto-compilation of python files outside site-packages directory,
 ## so that the -devel package is multilib-compliant
@@ -128,17 +128,19 @@
 
 
 # Define the release version
-%if %{with pre_release} || 0%{pre_release}
+# (do not look at externally enforced pre-release flag for tagged releases
+# as only -rc tags, captured with the second condition, implies that then)
+%if (!%{tag_release} && %{with pre_release}) || 0%{pre_release}
 %if 0%{pre_release}
 %define pcmk_release 0.%{specversion}.%(s=%{shortcommit}; echo ${s: -3})
 %else
 %define pcmk_release 0.%{specversion}.%{shortcommit}.git
 %endif
 %else
-%if 0%{post_release}
-%define pcmk_release %{specversion}.%{shortcommit}.git
-%else
+%if 0%{tag_release}
 %define pcmk_release %{specversion}
+%else
+%define pcmk_release %{specversion}.%{shortcommit}.git
 %endif
 %endif
 


### PR DESCRIPTION
- spec file should silently ignore "--with pre_release" condition
  when commit variable carries the tag alias instead of the hash;
  note that if the tag itself implies pre-release with -rcX suffix,
  pre-release logic is selected regardless

- similarly, GNUMakefile should not push the version to be substituted
  in the spec file up when the current checkout happens to be tagged

Disclaimer: this is to solve rough edges in COPR integration, because
currently a build from 1.1 branch (i.e. enforcing "--with pre_release"),
HEAD resolving to Pacemaker-1.1.16 tag, the generated version would be
"1.1.17-0.1.1.1.16.git" instead of expected "1.1.16-1".

To some extent, the whole arrangement relies on established release
procedures, e.g., in terms of restoring work on release ("decimal dot
decimal") branch at the same time updated version.m4 is pushed there.