### PR TITLE
Low: stonith_admin: Addition of the list-targets option.

### DIFF
--- a/fencing/admin.c
+++ b/fencing/admin.c
@@ -54,6 +54,7 @@ static struct crm_option long_options[] = {
     {"list",            1, 0, 'l', "List devices that can terminate the specified host"},
     {"list-registered", 0, 0, 'L', "List all registered devices"},
     {"list-installed",  0, 0, 'I', "List all installed devices"},
+    {"list-targets",  1, 0, 's', "List the device's target"},
 
     {"-spacer-",    0, 0, '-', ""},
     {"metadata",    0, 0, 'M', "Check the device's metadata"},
@@ -335,6 +336,7 @@ main(int argc, char **argv)
     char *name = NULL;
     char *value = NULL;
     char *target = NULL;
+    char *lists = NULL;
     const char *agent = NULL;
     const char *device = NULL;
     const char *longname = NULL;
@@ -378,6 +380,7 @@ main(int argc, char **argv)
             case 'Q':
             case 'R':
             case 'D':
+            case 's':
                 action = flag;
                 device = optarg;
                 break;
@@ -520,6 +523,37 @@ main(int argc, char **argv)
             rc = st->cmds->monitor(st, st_opts, device, timeout);
             if (rc < 0) {
                 rc = st->cmds->list(st, st_opts, device, NULL, timeout);
+            }
+            break;
+        case 's':
+            rc = st->cmds->list(st, st_opts, device, &lists, timeout);
+            if (rc == 0) {
+                if (lists) {
+                    char *source = lists, *dest = lists; 
+
+                    while (*dest) {
+                        if ((*dest == '\\') && (*(dest+1) == 'n')) {
+                            *source = '\n';
+                            dest++;
+                            dest++;
+                            source++;
+                        } else if ((*dest == ',') || (*dest == ';')) {
+                            dest++;
+                        } else {
+                            *source = *dest;
+                            dest++;
+                            source++;
+                        }
+
+                        if (!(*dest)) {
+                            *source = 0;
+                        }
+                    }
+                    fprintf(stdout, "%s", lists);
+                    free(lists);
+                }
+            } else {
+                fprintf(stderr, "List command returned error. rc : %d\n", rc);
             }
             break;
         case 'R':


### PR DESCRIPTION
Hi All,

Next pullrequest causes it.
 * https://github.com/ClusterLabs/pacemaker/pull/1194

I add list-targets option to stonith_admin command.

```
[root@rh73-01 fencing]# stonith_admin --help
stonith_admin - Provides access to the stonith-ng API.

Allows the administrator to add/remove/list devices, check device and host status and fence hosts

Usage: stonith_admin mode [options]
(snip)
Commands:
 -l, --list=value       List devices that can terminate the specified host
 -L, --list-registered  List all registered devices
 -I, --list-installed   List all installed devices
 -s, --list-targets=value       List the device's target
(snip)

[root@rh73-01 fencing]# stonith_admin -L
 prmStonith2-1
1 devices found

[root@rh73-01 fencing]# stonith_admin -s prmStonith2-1
rh66-hb3
rh66-hb2
(snip)
rh73-01

```

Best Regards,
Hideo Yamauchi.