### PR TITLE
Low: mcp: Correction of the difference in access permission setting.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1113,6 +1113,10 @@ CRM_STATE_DIR=${localstatedir}/run/crm
 AC_DEFINE_UNQUOTED(CRM_STATE_DIR,"$CRM_STATE_DIR", Where to keep state files and sockets)
 AC_SUBST(CRM_STATE_DIR)
 
+CRM_PACEMAKER_DIR=${localstatedir}/lib/pacemaker
+AC_DEFINE_UNQUOTED(CRM_PACEMAKER_DIR,"$CRM_PACEMAKER_DIR", Location to store directory produced by Pacemaker daemons)
+AC_SUBST(CRM_PACEMAKER_DIR)
+
 CRM_BLACKBOX_DIR=${localstatedir}/lib/pacemaker/blackbox
 AC_DEFINE_UNQUOTED(CRM_BLACKBOX_DIR,"$CRM_BLACKBOX_DIR", Where to keep blackbox dumps)
 AC_SUBST(CRM_BLACKBOX_DIR)

--- a/mcp/pacemaker.c
+++ b/mcp/pacemaker.c
@@ -1058,20 +1058,24 @@ main(int argc, char **argv)
     mkdir(CRM_STATE_DIR, 0750);
     mcp_chown(CRM_STATE_DIR, pcmk_uid, pcmk_gid);
 
+    /* Used to store core/blackbox/pengine/cib files in */
+    crm_build_path(CRM_PACEMAKER_DIR, 0750);
+    mcp_chown(CRM_PACEMAKER_DIR, pcmk_uid, pcmk_gid);
+
     /* Used to store core files in */
-    crm_build_path(CRM_CORE_DIR, 0775);
+    crm_build_path(CRM_CORE_DIR, 0750);
     mcp_chown(CRM_CORE_DIR, pcmk_uid, pcmk_gid);
 
     /* Used to store blackbox dumps in */
-    crm_build_path(CRM_BLACKBOX_DIR, 0755);
+    crm_build_path(CRM_BLACKBOX_DIR, 0750);
     mcp_chown(CRM_BLACKBOX_DIR, pcmk_uid, pcmk_gid);
 
     /* Used to store policy engine inputs in */
-    crm_build_path(PE_STATE_DIR, 0755);
+    crm_build_path(PE_STATE_DIR, 0750);
     mcp_chown(PE_STATE_DIR, pcmk_uid, pcmk_gid);
 
     /* Used to store the cluster configuration */
-    crm_build_path(CRM_CONFIG_DIR, 0755);
+    crm_build_path(CRM_CONFIG_DIR, 0750);
     mcp_chown(CRM_CONFIG_DIR, pcmk_uid, pcmk_gid);
 
     /* Resource agent paths are constructed by the lrmd */


### PR DESCRIPTION
Hi All,

After a user installed Pacemaker, access permission of the access is as follows.

```
[root@rh73-01-test ~]# ls -lt /var/lib | grep pacemaker ; ls -lt /var/lib/pacemaker
drwxr-x---  6 hacluster      haclient         61 Dec  8 12:40 pacemaker
total 0
drwxr-x--- 2 hacluster haclient  71 Dec  8 12:41 pengine
drwxr-x--- 2 hacluster haclient 132 Dec  8 12:41 cib
drwxr-x--- 2 hacluster haclient   6 Sep  9 10:49 blackbox
drwxr-x--- 2 hacluster haclient   6 Sep  9 10:49 cores

-----pacemaker.spec.in-----
(snip)
%dir %attr (750, %{uname}, %{gname}) %{_var}/lib/pacemaker/cib
%dir %attr (750, %{uname}, %{gname}) %{_var}/lib/pacemaker/pengine
(snip)
%dir %attr (750, %{uname}, %{gname}) %{_var}/lib/pacemaker
%dir %attr (750, %{uname}, %{gname}) %{_var}/lib/pacemaker/blackbox
%dir %attr (750, %{uname}, %{gname}) %{_var}/lib/pacemaker/cores
(snip)

```

When a user deletes the /var/lib/pacemaker directory by mistake, access permission of the made directory is as follows by pacemaker.

```
[root@rh73-01-test ~]# ls -lt /var/lib | grep pacemaker ; ls -lt /var/lib/pacemaker
drwxr-x--x  6 root           root             61 Dec  8 12:43 pacemaker
total 0
drwxr-x--x 2 hacluster haclient 56 Dec  8 12:43 cib
drwxr-x--x 2 hacluster haclient  6 Dec  8 12:43 blackbox
drwxr-x--x 2 hacluster haclient  6 Dec  8 12:43 cores
drwxr-x--x 2 hacluster haclient  6 Dec  8 12:43 pengine

```

The permission of the directory to make of pacemakerd seems to have a mistake somehow or other.

Best Regards,
Hideo Yamauchi.
