### PR TITLE
Low: mcp: Change of the order to stop of corosync-notifyd in pacemake…

### DIFF
--- a/mcp/pacemaker.combined.upstart.in
+++ b/mcp/pacemaker.combined.upstart.in
@@ -48,6 +48,9 @@ post-stop script
     rm -f "$LOCK_FILE"
     rm -f "@localstatedir@/run/$prog.pid"
 
+    # if you use corosync-notifyd, uncomment the line below.
+    #stop corosync-notifyd || true
+
     # if you use watchdog of corosync, uncomment the line below.
     #pidof corosync || false
 
@@ -61,6 +64,4 @@ post-stop script
     # if you use crm_mon, uncomment the line below.
     #stop crm_mon
 
-    # if you use corosync-notifyd, uncomment the line below.
-    #stop corosync-notifyd || true
 end script


### PR DESCRIPTION
Hi All,

The corosync-notifyd has to stop before corosync, but stops later.

Unnecessary respawn of corosync-notifyd occurs, and the following log is in this way output.

```
Dec 16 08:59:47 rh68-01 notifyd[27359]: [error] Could not dispatch cmap events. Error 2
Dec 16 08:59:47 rh68-01 init: corosync-notifyd main process ended, respawning
Dec 16 08:59:47 rh68-01 notifyd[27389]: [error] Failed to initialize the cmap API. Error 2
Dec 16 08:59:47 rh68-01 init: corosync-notifyd main process (27389) terminated with status 1
Dec 16 08:59:47 rh68-01 init: corosync-notifyd main process ended, respawning
Dec 16 08:59:47 rh68-01 notifyd[27396]: [error] Failed to initialize the cmap API. Error 2
Dec 16 08:59:47 rh68-01 init: corosync-notifyd main process (27396) terminated with status 1
(snip)
Dec 16 08:59:47 rh68-01 init: corosync-notifyd respawning too fast, stopped
```

The patch stops corosync-notifyd before corosync.

Best Regards,
Hideo Yamauchi.