### PR TITLE
pengine: Allow use of resource meta params in location rules

### DIFF
--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -316,6 +316,7 @@
 #  define XML_EXPR_ATTR_OPERATION	"operation"
 #  define XML_EXPR_ATTR_VALUE		"value"
 #  define XML_EXPR_ATTR_TYPE		"type"
+#  define XML_EXPR_ATTR_VALUE_SOURCE	"value-source"
 
 #  define XML_CONS_TAG_RSC_DEPEND	"rsc_colocation"
 #  define XML_CONS_TAG_RSC_ORDER	"rsc_order"

--- a/include/crm/pengine/rules.h
+++ b/include/crm/pengine/rules.h
@@ -21,6 +21,7 @@
 #  include <crm/crm.h>
 #  include <crm/common/iso8601.h>
 #  include <crm/pengine/common.h>
+#  include <crm/pengine/status.h>
 
 #  include <regex.h>
 
@@ -40,6 +41,12 @@ typedef struct pe_re_match_data {
     regmatch_t *pmatch;
 } pe_re_match_data_t;
 
+typedef struct pe_match_data {
+    pe_re_match_data_t *re;
+    GHashTable *params;
+    GHashTable *meta;
+} pe_match_data_t;
+
 enum expression_type find_expression_type(xmlNode * expr);
 
 gboolean test_ruleset(xmlNode * ruleset, GHashTable * node_hash, crm_time_t * now);
@@ -47,13 +54,19 @@ gboolean test_ruleset(xmlNode * ruleset, GHashTable * node_hash, crm_time_t * no
 gboolean test_rule(xmlNode * rule, GHashTable * node_hash, enum rsc_role_e role, crm_time_t * now);
 
 gboolean pe_test_rule_re(xmlNode * rule, GHashTable * node_hash, enum rsc_role_e role, crm_time_t * now,
-                         pe_re_match_data_t * match_data);
+                         pe_re_match_data_t * re_match_data);
+
+gboolean pe_test_rule_full(xmlNode * rule, GHashTable * node_hash, enum rsc_role_e role, crm_time_t * now,
+                         pe_match_data_t * match_data);
 
 gboolean test_expression(xmlNode * expr, GHashTable * node_hash,
                          enum rsc_role_e role, crm_time_t * now);
 
 gboolean pe_test_expression_re(xmlNode * expr, GHashTable * node_hash,
-                         enum rsc_role_e role, crm_time_t * now, pe_re_match_data_t * match_data);
+                         enum rsc_role_e role, crm_time_t * now, pe_re_match_data_t * re_match_data);
+
+gboolean pe_test_expression_full(xmlNode * expr, GHashTable * node_hash,
+                         enum rsc_role_e role, crm_time_t * now, pe_match_data_t * match_data);
 
 void unpack_instance_attributes(xmlNode * top, xmlNode * xml_obj, const char *set_name,
                                 GHashTable * node_hash, GHashTable * hash,

--- a/xml/alerts-2.8.rng
+++ b/xml/alerts-2.8.rng
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" 
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+      <ref name="element-alerts"/>
+  </start>
+
+  <define name="element-alerts">
+    <optional>
+    <element name="alerts">
+      <zeroOrMore>
+        <element name="alert">
+          <attribute name="id"><data type="ID"/></attribute>
+          <optional>
+            <attribute name="description"><text/></attribute>
+          </optional>
+          <!-- path to the script called for alert -->
+          <attribute name="path"><text/></attribute>
+          <ref name="element-alert-extra"/>
+          <zeroOrMore>
+            <element name="recipient">
+              <attribute name="id"><data type="ID"/></attribute>
+              <optional>
+                <attribute name="description"><text/></attribute>
+              </optional>
+              <attribute name="value"><text/></attribute>
+              <ref name="element-alert-extra"/>
+            </element>
+          </zeroOrMore>
+        </element>
+      </zeroOrMore>
+    </element>
+    </optional>
+  </define>
+
+  <define name="element-alert-extra">
+      <zeroOrMore>
+        <choice>
+          <element name="meta_attributes">
+            <externalRef href="nvset-2.8.rng"/>
+          </element>
+          <element name="instance_attributes">
+            <externalRef href="nvset-2.8.rng"/>
+          </element>
+        </choice>
+      </zeroOrMore>
+  </define>
+
+</grammar>

--- a/xml/constraints-2.8.rng
+++ b/xml/constraints-2.8.rng
@@ -104,7 +104,11 @@
     <element name="rsc_colocation">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <externalRef href="score.rng"/>
+        <choice>
+          <externalRef href="score.rng"/>
+          <attribute name="score-attribute"><text/></attribute>
+          <attribute name="score-attribute-mangle"><text/></attribute>
+        </choice>
       </optional>
       <optional>
         <ref name="element-lifetime"/>
@@ -128,12 +132,6 @@
             <attribute name="with-rsc-role">
               <ref name="attribute-roles"/>
             </attribute>
-          </optional>
-          <optional>
-            <attribute name="rsc-instance"><data type="integer"/></attribute>
-          </optional>
-          <optional>
-            <attribute name="with-rsc-instance"><data type="integer"/></attribute>
           </optional>
         </group>
       </choice>
@@ -176,12 +174,6 @@
             <attribute name="then-action">
               <ref name="attribute-actions"/>
             </attribute>
-          </optional>
-          <optional>
-            <attribute name="first-instance"><data type="integer"/></attribute>
-          </optional>
-          <optional>
-            <attribute name="then-instance"><data type="integer"/></attribute>
           </optional>
         </group>
       </choice>

--- a/xml/nodes-2.8.rng
+++ b/xml/nodes-2.8.rng
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" 
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+      <ref name="element-nodes"/>
+  </start>
+
+  <define name="element-nodes">
+    <element name="nodes">
+      <zeroOrMore>
+        <element name="node">
+          <attribute name="id"><text/></attribute>
+          <attribute name="uname"><text/></attribute>
+          <optional>
+            <attribute name="type">
+              <choice>
+                <value>normal</value>
+                <value>member</value>
+                <value>ping</value>
+                <value>remote</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="description"><text/></attribute>
+          </optional>
+          <optional>
+            <externalRef href="score.rng"/>
+          </optional>
+          <zeroOrMore>
+            <choice>
+              <element name="instance_attributes">
+                <externalRef href="nvset-2.8.rng"/>
+              </element>
+              <element name="utilization">
+                <externalRef href="nvset-2.8.rng"/>
+              </element>
+            </choice>
+          </zeroOrMore>
+        </element>
+      </zeroOrMore>
+    </element>
+  </define>
+
+</grammar>

--- a/xml/nvset-2.8.rng
+++ b/xml/nvset-2.8.rng
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- types: http://www.w3.org/TR/xmlschema-2/#dateTime -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" 
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <ref name="element-nvset"/>
+  </start>
+
+  <define name="element-nvset">
+   <choice>
+   <attribute name="id-ref"><data type="IDREF"/></attribute>
+   <group>
+    <attribute name="id"><data type="ID"/></attribute>
+    <interleave>
+      <optional>
+        <externalRef href="rule-2.8.rng"/>
+      </optional>
+        <zeroOrMore>
+          <element name="nvpair">
+            <choice>
+              <group>
+                <attribute name="id-ref"><data type="IDREF"/></attribute>
+                <optional>
+                  <attribute name="name"><text/></attribute>
+                </optional>
+              </group>
+              <group>
+                <attribute name="id"><data type="ID"/></attribute>
+                <attribute name="name"><text/></attribute>
+                <optional>
+                  <attribute name="value"><text/></attribute>
+                </optional>
+              </group>
+            </choice>
+          </element>
+        </zeroOrMore>
+      <optional>
+        <externalRef href="score.rng"/>
+      </optional>
+    </interleave>
+   </group>
+   </choice>
+  </define>
+
+</grammar>

--- a/xml/resources-2.8.rng
+++ b/xml/resources-2.8.rng
@@ -38,7 +38,7 @@
         <ref name="element-operations"/>
         <zeroOrMore>
           <element name="utilization">
-            <externalRef href="nvset-1.3.rng"/>
+            <externalRef href="nvset-2.8.rng"/>
           </element>
         </zeroOrMore>
       </interleave>
@@ -58,7 +58,7 @@
         <ref name="element-operations"/>
         <zeroOrMore>
           <element name="utilization">
-            <externalRef href="nvset-1.3.rng"/>
+            <externalRef href="nvset-2.8.rng"/>
           </element>
         </zeroOrMore>
       </interleave>
@@ -203,10 +203,10 @@
       <zeroOrMore>
         <choice>
           <element name="meta_attributes">
-            <externalRef href="nvset-1.3.rng"/>
+            <externalRef href="nvset-2.8.rng"/>
           </element>
           <element name="instance_attributes">
-            <externalRef href="nvset-1.3.rng"/>
+            <externalRef href="nvset-2.8.rng"/>
           </element>
         </choice>
       </zeroOrMore>

--- a/xml/rule-2.8.rng
+++ b/xml/rule-2.8.rng
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" 
+         xmlns:ann="http://relaxng.org/ns/compatibility/annotations/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+      <ref name="element-rule"/>
+  </start>
+
+  <define name="element-rule">
+    <element name="rule">
+     <choice>
+     <attribute name="id-ref"><data type="IDREF"/></attribute>
+     <group>
+      <attribute name="id"><data type="ID"/></attribute>
+      <choice>
+        <externalRef href="score.rng"/>
+        <attribute name="score-attribute"><text/></attribute>
+      </choice>
+      <optional>
+        <attribute name="boolean-op">
+          <choice>
+            <value>or</value>
+            <value>and</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="role"><text/></attribute>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <element name="expression">
+            <attribute name="id"><data type="ID"/></attribute>
+            <attribute name="attribute"><text/></attribute>
+            <attribute name="operation">
+              <choice>
+                <value>lt</value>
+                <value>gt</value>
+                <value>lte</value>
+                <value>gte</value>
+                <value>eq</value>
+                <value>ne</value>
+                <value>defined</value>
+                <value>not_defined</value>
+              </choice>
+            </attribute>
+            <optional>
+              <attribute name="value"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="type" ann:defaultValue="string">
+                <choice>
+                  <value>string</value>
+                  <value>number</value>
+                  <value>version</value>
+                </choice>
+              </attribute>
+            </optional>
+            <optional>
+              <attribute name="value-source" ann:defaultValue="literal">
+                <choice>
+                  <value>literal</value>
+                  <value>param</value>
+                  <value>meta</value>
+                </choice>
+              </attribute>
+            </optional>
+          </element>
+          <element name="date_expression">
+            <attribute name="id"><data type="ID"/></attribute>
+            <choice>
+              <group>
+                <attribute name="operation"><value>in_range</value></attribute>
+                <choice>
+                  <group>
+                    <optional>
+                      <attribute name="start"><text/></attribute>
+                    </optional>
+                    <attribute name="end"><text/></attribute>
+                  </group>
+                  <group>
+                    <attribute name="start"><text/></attribute>
+                    <element name="duration">
+                      <ref name="date-common"/>
+                    </element>
+                  </group>
+                </choice>
+              </group>
+              <group>
+                <attribute name="operation"><value>gt</value></attribute>
+                <attribute name="start"><text/></attribute>
+              </group>
+              <group>
+                <attribute name="operation"><value>lt</value></attribute>
+                <choice>
+                  <attribute name="end"><text/></attribute>
+                </choice>
+              </group>
+              <group>
+                <attribute name="operation"><value>date_spec</value></attribute>
+                <element name="date_spec">
+                  <ref name="date-common"/>
+                </element> 
+              </group>
+            </choice>
+          </element> 
+          <ref name="element-rule"/>
+        </choice>
+      </oneOrMore>
+     </group>
+     </choice>
+    </element>
+  </define>
+
+  <define name="date-common">
+    <attribute name="id"><data type="ID"/></attribute>
+    <optional>
+      <attribute name="hours"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="monthdays"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="weekdays"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="yearsdays"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="months"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="weeks"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="years"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="weekyears"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="moon"><text/></attribute>
+    </optional>
+  </define>
+
+</grammar>


### PR DESCRIPTION
This would allow following syntax (in crmsh terms):

location resource-require-home-zone /resource-.+/ \
    rule -inf: not_defined zone or zone ne meta{zone}