### PR TITLE
Build: simplify and update deprecated libtool/ltdl integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ configure
 depcomp
 install-sh
 include/stamp-*
-libltdl.tar
 libtool
 libtool.m4
 ltdl.m4

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -363,7 +363,7 @@ check: clang cppcheck
 
 # Extra cppcheck options:  --enable=all --inconclusive --std=posix
 cppcheck:
-	for d in $(LIBLTDL_DIR) replace lib mcp attrd pengine cib crmd fencing lrmd tools; do cppcheck -q $$d; done
+	for d in replace lib mcp attrd pengine cib crmd fencing lrmd tools; do cppcheck -q $$d; done
 
 clang:
 	test -e $(CLANG_analyzer)

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,12 +18,12 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #
 
-EXTRA_DIST              = autogen.sh ConfigureMe README.in libltdl.tar m4/gnulib-cache.m4
+EXTRA_DIST              = autogen.sh ConfigureMe README.in m4/gnulib-cache.m4
 
 MAINTAINERCLEANFILES    = Makefile.in aclocal.m4 configure DRF/config-h.in \
-                        DRF/stamp-h.in libtool.m4 ltdl.m4 libltdl.tar
+                        DRF/stamp-h.in libtool.m4 ltdl.m4
 
-CORE	= $(LIBLTDL_DIR) replace include lib mcp attrd pengine cib crmd fencing lrmd tools xml
+CORE	= replace include lib mcp attrd pengine cib crmd fencing lrmd tools xml
 SUBDIRS	= $(CORE) extra doc
 
 doc_DATA = README.markdown COPYING
@@ -79,6 +79,3 @@ clean-generic:
 
 dist-clean-local:
 	rm -f autoconf automake autoheader
-
-maintainer-clean-local:
-	rm -f libltdl.tar

--- a/configure.ac
+++ b/configure.ac
@@ -92,9 +92,8 @@ AC_PROG_CC_STDC
 gl_EARLY
 gl_INIT
 
-AC_LIBTOOL_DLOPEN               dnl Enable dlopen support...
-AC_LIBLTDL_CONVENIENCE          dnl make libltdl a convenience lib
-AC_PROG_LIBTOOL
+LT_INIT([dlopen])
+LTDL_INIT([convenience])
 
 AC_PROG_YACC
 AM_PROG_LEX
@@ -179,10 +178,6 @@ AC_ARG_ENABLE([quiet],
 [  --enable-quiet
      Supress make output unless there is an error
      [default=no]])
-
-AC_ARG_ENABLE([bundled-ltdl],
-[  --enable-bundled-ltdl  Configure, build and install the standalone ltdl library bundled with ${PACKAGE} [default=no]])
-LTDL_LIBS=""
 
 AC_ARG_ENABLE([no-stack],
     [  --enable-no-stack
@@ -845,38 +840,6 @@ dnl ========================================================================
 AC_CHECK_FUNCS(g_log_set_default_handler)
 AC_CHECK_FUNCS(getopt, AC_DEFINE(HAVE_DECL_GETOPT,  1, [Have getopt function]))
 AC_CHECK_FUNCS(nanosleep, AC_DEFINE(HAVE_DECL_NANOSLEEP,  1, [Have nanosleep function]))
-
-dnl ========================================================================
-dnl   ltdl
-dnl ========================================================================
-
-AC_CHECK_LIB(ltdl, lt_dlopen, [LTDL_foo=1])
-if test "x${enable_bundled_ltdl}" = "xyes"; then
-   if test $ac_cv_lib_ltdl_lt_dlopen = yes; then
-      AC_MSG_NOTICE([Disabling usage of installed ltdl])
-   fi
-   ac_cv_lib_ltdl_lt_dlopen=no
-fi
-
-LIBLTDL_DIR=""
-if test $ac_cv_lib_ltdl_lt_dlopen != yes ; then
-   AC_MSG_NOTICE([Installing local ltdl])
-   LIBLTDL_DIR=libltdl
-   ( cd $srcdir ; $TAR -xvf libltdl.tar )
-   if test "$?" -ne 0; then
-     AC_MSG_ERROR([$TAR of libltdl.tar in $srcdir failed])
-   fi
-   AC_CONFIG_SUBDIRS(libltdl)
-else
-   LIBS="$LIBS -lltdl"
-   AC_MSG_NOTICE([Using installed ltdl])
-   INCLTDL=""
-   LIBLTDL=""
-fi
-
-AC_SUBST(INCLTDL)
-AC_SUBST(LIBLTDL)
-AC_SUBST(LIBLTDL_DIR)
 
 dnl ========================================================================
 dnl   bzip2
@@ -2168,8 +2131,6 @@ AC_MSG_RESULT([  System configuration     = ${sysconfdir}])
 if test $SUPPORT_PLUGIN = 1; then
 AC_MSG_RESULT([  Corosync Plugins         = ${LCRSODIR}])
 fi
-AC_MSG_RESULT([])
-AC_MSG_RESULT([  Use system LTDL          = ${ac_cv_lib_ltdl_lt_dlopen}])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([  HA group name            = ${CRM_DAEMON_GROUP}])
 AC_MSG_RESULT([  HA user name             = ${CRM_DAEMON_USER}])


### PR DESCRIPTION
To name a few pain points in the former version:
- pacemaker is not distributed with "libltdl.tar" for the past few
  years and it's unclear if it ever was or if it's just the heartbeat
  legacy; definitely no recipe to prepare such a file was found
- custom mechanism to use bundled libltdl is redundant (and inferior
  in parameterization) compared to options automatically available
  to configure script thanks to newly introduced LTDL_INIT macro
  (--with-ltdl-lib DIR, --with-included-ltdl)
- "INCLTDL" was likely a typo for "LTDLINCL"