### PR TITLE
Fix: crm_mon: protect against non-standard or failing asctime

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -954,10 +954,10 @@ print_nvpair(FILE *stream, const char *name, const char *value,
 
     /* Otherwise print user-friendly time string */
     } else {
-        char *date_str, *c;
+        static char empty_str[] = "";
+        char *c, *date_str = asctime(localtime(&epoch_time));
 
-        date_str = asctime(localtime(&epoch_time));
-        for (c = date_str; c != '\0'; ++c) {
+        for (c = (date_str != NULL) ? date_str : empty_str; *c != '\0'; ++c) {
             if (*c == '\n') {
                 *c = '\0';
                 break;


### PR DESCRIPTION
So far, we have been likely covered by standards requiring asctime to
produce an output ending with \n\0 bytes, because otherwise, we would
overrun the buffer, reading unspecified content, possibly segfaulting.
This was actually discovered with a brand new GCC7 warning
( [-Werror=pointer-compare]).

Another latent issue was that the code was not ready for the case
of failing asctime call (returning NULL).  This is now fixed as well.