### PR TITLE
Build: spec: %define back to %global to prevent recursive declaration

### DIFF
--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -42,7 +42,8 @@
 
 ## Turn off auto-compilation of python files outside site-packages directory,
 ## so that the -libs-devel package is multilib-compliant (no *.py[co] files)
-%define __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
+%global __os_install_post %(echo '%{__os_install_post}' | {
+                            sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g'; })
 
 ## Heuristic used to infer bleeding-edge deployments that are
 ## less likely to have working versions of the documentation tools


### PR DESCRIPTION
Commit 625d427 was too coarse and disregarded self-inflicted recursive
redefinition of an internal macro, owing to how %define is treated.
Unfortunately, rpmbuild won't currently abort the build in that case
even if it is aware of the recursive expansion [*], masking the problem.

The breakthrough emerged only thanks to materialized changes in the
resulting RPMs, specifically because __os_install_post macro definition
got suddently empty, disregarding common actions such as compressing
the man pages (beside various debug symbols stripping), which in turn
led to the discovery (good catch, Ken).

So simply revert back to using %global in this instance, which will
make it harmless one-off definition once again.  (And reformat to
spare overly long line.)

[*] https://github.com/rpm-software-management/rpm/issues/145