### PR TITLE
Build: keep "make srpm" working with newer git versions

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -45,13 +45,13 @@ ARCH    ?= $(shell test -e /etc/fedora-release && rpm --eval %{_arch})
 MOCK_CFG ?= $(shell test -e /etc/fedora-release && echo fedora-$(F)-$(ARCH))
 DISTRO  ?= $(shell test -e /etc/SuSE-release && echo suse; echo fedora)
 COMMIT  ?= HEAD
-TAG     ?= $(shell T=$$(git describe --all "$(COMMIT)" | sed -n 's|tags/\(.*\)|\1|p'); \
+TAG     ?= $(shell T=$$(git describe --all '$(COMMIT)' | sed -n 's|tags/\(.*\)|\1|p'); \
 	     test -n "$${T}" && echo "$${T}" \
-	       || git log --pretty="format:%H" -n 1 "$(COMMIT)")
+	       || git log --pretty=format:%H -n 1 '$(COMMIT)')
 lparen = (
 rparen = )
-SHORTTAG ?= $(shell case $(TAG) in Pacemaker-*$(rparen) echo $(TAG) | cut -c11-;; \
-	      *$(rparen) git log --pretty="format:%h" -n 1 "$(TAG)";; esac)
+SHORTTAG ?= $(shell case $(TAG) in Pacemaker-*$(rparen) echo '$(TAG)' | cut -c11-;; \
+	      *$(rparen) git log --pretty=format:%h -n 1 '$(TAG)';; esac)
 WITH    ?= --without doc
 #WITH    ?= --without=doc --with=gcov
 
@@ -192,8 +192,9 @@ srpm-%:	export $(PACKAGE)-%.spec
 	if [ -e $(BUILD_COUNTER) ]; then					\
 		echo $(COUNT) > $(BUILD_COUNTER);				\
 	fi
-	sed -i 's/global\ specversion.*/global\ specversion\ $(SPECVERSION)/' $(PACKAGE).spec
-	sed -i 's/global\ commit.*/global\ commit\ $(TAG)/' $(PACKAGE).spec
+	sed -e 's/global\ specversion.*/global\ specversion\ $(SPECVERSION)/' \
+	    -e 's/global\ commit.*/global\ commit\ $(TAG)/' \
+	    -i $(PACKAGE).spec
 	$(call rpmbuild-with,$(WITH),-bs --define "dist .$*" $(RPM_OPTS),$(PACKAGE).spec)
 
 chroot: mock-$(MOCK_CFG) mock-install-$(MOCK_CFG) mock-sh-$(MOCK_CFG)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -52,6 +52,7 @@ lparen = (
 rparen = )
 SHORTTAG ?= $(shell case $(TAG) in Pacemaker-*$(rparen) echo '$(TAG)' | cut -c11-;; \
 	      *$(rparen) git log --pretty=format:%h -n 1 '$(TAG)';; esac)
+SHORTTAG_ABBREV = $(shell printf %s '$(SHORTTAG)' | wc -c)
 WITH    ?= --without doc
 #WITH    ?= --without=doc --with=gcov
 
@@ -192,8 +193,9 @@ srpm-%:	export $(PACKAGE)-%.spec
 	if [ -e $(BUILD_COUNTER) ]; then					\
 		echo $(COUNT) > $(BUILD_COUNTER);				\
 	fi
-	sed -e 's/global\ specversion.*/global\ specversion\ $(SPECVERSION)/' \
-	    -e 's/global\ commit.*/global\ commit\ $(TAG)/' \
+	sed -e 's/global\ specversion\ .*/global\ specversion\ $(SPECVERSION)/' \
+	    -e 's/global\ commit\ .*/global\ commit\ $(TAG)/' \
+	    -e 's/global\ commit_abbrev\ .*/global\ commit_abbrev\ $(SHORTTAG_ABBREV)/' \
 	    -i $(PACKAGE).spec
 	$(call rpmbuild-with,$(WITH),-bs --define "dist .$*" $(RPM_OPTS),$(PACKAGE).spec)
 

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -19,6 +19,9 @@
 ## Upstream commit (or git tag, such as "Pacemaker-" plus the
 ## {pcmkversion} macro for an official release) to use for this package
 %global commit HEAD
+## Since git v2.11, the extent of abbreviation is autoscaled by default
+## (used to be constant of 7), so we need to convey it for non-tags, too.
+%global commit_abbrev 7
 
 
 # Define globals for convenient use later
@@ -30,7 +33,7 @@
 ## Short version of git commit
 %define shortcommit %(c=%{commit}; case ${c} in
                       Pacemaker-*%{rparen} echo ${c:10};;
-                      *%{rparen} echo ${c:0:7};; esac)
+                      *%{rparen} echo ${c:0:%{commit_abbrev}};; esac)
 
 ## Whether this is a tagged release
 %define tag_release %([ %{commit} != Pacemaker-%{shortcommit} ]; echo $?)


### PR DESCRIPTION
Notably those supporting autoscaling of commit hash abbreviation.