### PR TITLE
Build: lrmd: Include libxml/tree.h in lrmd.h

### DIFF
--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -23,6 +23,7 @@
  * \ingroup lrmd
  */
 #include <stdbool.h>
+#include <libxml/tree.h>
 #include <crm/services.h>
 
 #ifndef LRMD__H


### PR DESCRIPTION
65d0b80 introduced "xmlNode *versioned_params" in lrmd_event_data_t but
without including libxml/tree.h in lrmd.h.

Sbd failed to build against it:

In file included from /usr/include/pacemaker/crm/common/util.h:33:0,
                 from sbd-inquisitor.c:19:
/usr/include/pacemaker/crm/lrmd.h:241:5: error: unknown type name ‘xmlNode’
     xmlNode *versioned_params;
     ^