### PR TITLE
low: attrd: simplify function attrd_ipc_dispatch in attrd/main.c

### DIFF
--- a/attrd/main.c
+++ b/attrd/main.c
@@ -199,18 +199,12 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
         attrd_send_ack(client, id, flags);
         attrd_client_peer_remove(client->name, xml);
 
-    } else if (safe_str_eq(op, ATTRD_OP_UPDATE)) {
+    } else if ((safe_str_eq(op, ATTRD_OP_UPDATE))||
+               (safe_str_eq(op, ATTRD_OP_UPDATE_BOTH))||
+               (safe_str_eq(op, ATTRD_OP_UPDATE_DELAY))){
         attrd_send_ack(client, id, flags);
         attrd_client_update(xml);
 
-    } else if (safe_str_eq(op, ATTRD_OP_UPDATE_BOTH)) {
-        attrd_send_ack(client, id, flags);
-        attrd_client_update(xml);
-
-    } else if (safe_str_eq(op, ATTRD_OP_UPDATE_DELAY)) {
-        attrd_send_ack(client, id, flags);
-        attrd_client_update(xml);
-  
     } else if (safe_str_eq(op, ATTRD_OP_REFRESH)) {
         attrd_send_ack(client, id, flags);
         attrd_client_refresh();
@@ -254,7 +248,7 @@ main(int argc, char **argv)
 
     mainloop_add_signal(SIGTERM, attrd_shutdown);
 
-     while (1) {
+    while (1) {
         flag = crm_get_option(argc, argv, &index);
         if (flag == -1)
             break;


### PR DESCRIPTION
in attrd_ipc_dispatch, there 3 times calls as following:

attrd_send_ack(client, id, flags);
attrd_client_update(xml);

for op ATTRD_OP_UPDATE, ATTRD_OP_UPDATE_BOTH
and  ATTRD_OP_UPDATE_DELAY, the callings are the same, 
so merge them into one judgment to simplify the code.