### PR TITLE
Add command `validate` to crm_resource

### DIFF
--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -128,6 +128,7 @@ static struct crm_option long_options[] = {
     {"constraints",0, 0, 'a', "\tDisplay the (co)location constraints that apply to a resource"},
 
     {"-spacer-",	1, 0, '-', "\nCommands:"},
+    {"validate",   0, 0, 0, "\t\tCall the validate-all action of the local given resource"},
     {"cleanup",         0, 0, 'C',
         "\t\tDelete resource's history and re-check its current state. "
         "Optional: --resource (if not specified, all resources), "
@@ -303,7 +304,8 @@ main(int argc, char **argv)
                     require_dataset = FALSE;
 
                 } else if (
-                    safe_str_eq("restart", longname)
+                    safe_str_eq("validate", longname)
+                    || safe_str_eq("restart", longname)
                     || safe_str_eq("force-demote",  longname)
                     || safe_str_eq("force-stop",    longname)
                     || safe_str_eq("force-start",   longname)
@@ -687,7 +689,7 @@ main(int argc, char **argv)
     } else if (rsc_cmd == 0 && rsc_long_cmd && safe_str_eq(rsc_long_cmd, "wait")) {
         rc = wait_till_stable(timeout_ms, cib_conn);
 
-    } else if (rsc_cmd == 0 && rsc_long_cmd) { /* force-(stop|start|check) */
+    } else if (rsc_cmd == 0 && rsc_long_cmd) { /* validate or force-(stop|start|check) */
         rc = cli_resource_execute(rsc_id, rsc_long_cmd, override_params, cib_conn, &data_set);
 
     } else if (rsc_cmd == 'A' || rsc_cmd == 'a') {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1508,6 +1508,10 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
     }
 
     params = generate_resource_params(rsc, data_set);
+
+    /* add crm_feature_set env needed by some resource agents */
+    g_hash_table_insert(params, strdup(XML_ATTR_CRM_VERSION), strdup(CRM_FEATURE_SET));
+
     op = resources_action_create(rsc->id, rclass, rprov, rtype, action, 0, -1, params, 0);
 
     if(do_trace) {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1552,6 +1552,10 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
                    action, rsc->id, rclass, rprov ? rprov : "", rtype, op->status);
         }
 
+        /* hide output for validate-all if not in verbose */
+        if (!do_trace && safe_str_eq(action, "validate-all"))
+            goto done;
+
         if (op->stdout_data) {
             local_copy = strdup(op->stdout_data);
             more = strlen(local_copy);
@@ -1581,6 +1585,7 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
             free(local_copy);
         }
     }
+  done:
     rc = op->rc;
     services_action_free(op);
     return rc;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1467,7 +1467,10 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
         return -ENXIO;
     }
 
-    if (safe_str_eq(rsc_action, "force-check")) {
+    if (safe_str_eq(rsc_action, "validate")) {
+        action = "validate-all";
+
+    } else if (safe_str_eq(rsc_action, "force-check")) {
         action = "monitor";
 
     } else if (safe_str_eq(rsc_action, "force-stop")) {


### PR DESCRIPTION
Hi,

Based on the feedback from users deploying the PAF resource agent, it is quite easy to forget a step in the resource setup often leading to resource failure or node fencing.

As the `validate-all` function of resource agent is intended to be used by UIs, it seems useful to add command to call it from a cli tool.

I have been able to check it with a simple scenario like:

~~~console
# crm_shadow --create test_validate

# [...cluster setup...]

# crm_resource -r pgsql-ha --validate --verbose
Operation validate-all for pgsqld:0 (ocf:heartbeat:pgsqlms) returned 2
 >  stderr: ocf-exit-reason:Recovery template file must contain in primary_conninfo parameter "application_name=srv1"
~~~

The next step would be to be able to run this command on remote nodes as well, but I am not sure yet how to achieve this. Is it possible to export/import the cib in the crm_shadow environment?

Regards,