### PR TITLE
Low: crmd: Change of the log level(again).

### DIFF
--- a/crmd/join_dc.c
+++ b/crmd/join_dc.c
@@ -132,7 +132,7 @@ join_make_offer(gpointer key, gpointer value, gpointer user_data)
     }
 
     if (member->uname == NULL) {
-        crm_warn("No recipient for welcome message.(Node uuid:%s)", member->uuid);
+        crm_info("No recipient for welcome message.(Node uuid:%s)", member->uuid);
         return;
     }
 


### PR DESCRIPTION
Hi All,

The log level was changed by the next PR.
 - https://github.com/ClusterLabs/pacemaker/pull/1239

We argued about this log again.
The frequency that this log appears is unexpectedly high.
However, the node is incorporated in a cluster even if log is output.

Because we do not confuse an operator, we want to switch to info level more.

Best Regards,
Hideo Yamauchi.