### PR TITLE
new cluster option stonith-max-attempts 

### DIFF
--- a/crmd/control.c
+++ b/crmd/control.c
@@ -952,6 +952,9 @@ pe_cluster_option crmd_opts[] = {
 	{ "stonith-watchdog-timeout", NULL, "time", NULL, NULL, &check_sbd_timeout,
 	  "How long to wait before we can assume nodes are safely down", NULL
         },
+        { "stonith-max-attempts",NULL,"integer",NULL,"10",&check_positive_number,
+          "The maximum number of stonith attempts before giving up."
+        },   
 	{ "no-quorum-policy", "no_quorum_policy", "enum", "stop, freeze, ignore, suicide", "stop", &check_quorum, NULL, NULL },
 
 #if SUPPORT_PLUGIN
@@ -1050,6 +1053,9 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     if (safe_str_eq(value, "suicide") && pcmk_locate_sbd()) {
         no_quorum_suicide_escalation = TRUE;
     }
+    
+    value = crmd_pref(config_hash,"stonith-max-attempts");
+    update_stonith_max_attempts(value);
 
     value = crmd_pref(config_hash, XML_CONFIG_ATTR_FORCE_QUIT);
     shutdown_escalation_timer->period_ms = crm_get_msec(value);

--- a/crmd/control.c
+++ b/crmd/control.c
@@ -953,7 +953,7 @@ pe_cluster_option crmd_opts[] = {
 	  "How long to wait before we can assume nodes are safely down", NULL
         },
         { "stonith-max-attempts",NULL,"integer",NULL,"10",&check_positive_number,
-          "The maximum number of stonith attempts before giving up."
+          "How many times stonith can fail before it will no longer be attempted on a target"
         },   
 	{ "no-quorum-policy", "no_quorum_policy", "enum", "stop, freeze, ignore, suicide", "stop", &check_quorum, NULL, NULL },
 

--- a/crmd/te_callbacks.h
+++ b/crmd/te_callbacks.h
@@ -33,4 +33,6 @@ extern void te_update_diff(const char *event, xmlNode * msg);
 
 extern void tengine_stonith_callback(stonith_t * stonith, stonith_callback_data_t * data);
 
+void update_stonith_max_attempts(const char* value);
+
 #endif

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -126,6 +126,7 @@ gboolean check_time(const char *value);
 gboolean check_timer(const char *value);
 gboolean check_boolean(const char *value);
 gboolean check_number(const char *value);
+gboolean check_positive_number(const char *value);
 gboolean check_quorum(const char *value);
 gboolean check_script(const char *value);
 gboolean check_utilization(const char *value);

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -164,7 +164,7 @@ check_number(const char *value)
 gboolean
 check_positive_number(const char* value)
 {
-    if (check_number(value) && (value[0] != '-') && !(safe_str_eq(value,"0"))) {
+    if (safe_str_eq(value, INFINITY_S) || (crm_int_helper(value, NULL))) {
         return TRUE;
     }
     return FALSE;

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -162,6 +162,15 @@ check_number(const char *value)
 }
 
 gboolean
+check_positive_number(const char* value)
+{
+    if (check_number(value) && (value[0] != '-') && !(safe_str_eq(value,"0"))) {
+        return TRUE;
+    }
+    return FALSE;
+}
+
+gboolean
 check_quorum(const char *value)
 {
     if (safe_str_eq(value, "stop")) {


### PR DESCRIPTION
 The maximum number of retry attempts for fencing to be made by crmd before giving up.Default value of 10 and accepts only positive non-zero values.
Added a new function check_positive_number() which return true if the input number is positive and false otherwise.
