### PR TITLE
Stonith-Max-Attempts Doc Updation

### DIFF
--- a/doc/Pacemaker_Explained/en-US/Ch-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Options.txt
@@ -227,6 +227,12 @@ indexterm:[stonith-timeout,Cluster Option]
 indexterm:[Cluster,Option,stonith-timeout]
 How long to wait for STONITH actions (reboot, on, off) to complete
 
+| stonith-max-attempts | 10 |
+indexterm:[stonith-max-attempts,Cluster Option]
+indexterm:[Cluster,Option,stonith-max-attempts]
+How many times stonith can fail before it will no longer be attempted on a target.
+Positive non-zero values are allowed.
+
 | concurrent-fencing | FALSE |
 indexterm:[concurrent-fencing,Cluster Option]
 indexterm:[Cluster,Option,concurrent-fencing]


### PR DESCRIPTION
#1245 Updated Cluster Options Section with stonith-max-attempts under Pacemaker-Explained Document.
Attached the generated output.
<img width="1280" alt="stonith-max-attemps" src="https://cloud.githubusercontent.com/assets/8017518/24054327/d8c6eaca-0b61-11e7-9779-59182713c11c.png">
