### PR TITLE
Fix: pacemaker-remote: pacemaker_remoted shutdown while unmanaged

### DIFF
--- a/crmd/crmd_lrm.h
+++ b/crmd/crmd_lrm.h
@@ -162,5 +162,7 @@ int remote_ra_exec(lrm_state_t * lrm_state, const char *rsc_id, const char *acti
 void remote_ra_cleanup(lrm_state_t * lrm_state);
 void remote_ra_fail(const char *node_name);
 void remote_ra_process_pseudo(xmlNode *xml);
+gboolean remote_ra_is_in_maintenance(lrm_state_t * lrm_state);
+void remote_ra_process_maintenance_nodes(xmlNode *xml);
 
 gboolean process_lrm_event(lrm_state_t * lrm_state, lrmd_event_data_t * op, struct recurring_op_s *pending);

--- a/crmd/lrm_state.c
+++ b/crmd/lrm_state.c
@@ -572,14 +572,21 @@ remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
         crm_notice("%s requested shutdown of its remote connection",
                    lrm_state->node_name);
 
-        now_s = crm_itoa(now);
-        update_attrd(lrm_state->node_name, XML_CIB_ATTR_SHUTDOWN, now_s, NULL, TRUE);
-        free(now_s);
+        if (!remote_ra_is_in_maintenance(lrm_state)) {
+            now_s = crm_itoa(now);
+            update_attrd(lrm_state->node_name, XML_CIB_ATTR_SHUTDOWN, now_s, NULL, TRUE);
+            free(now_s);
 
-        remote_proxy_ack_shutdown(lrmd);
+            remote_proxy_ack_shutdown(lrmd);
 
-        crm_warn("Reconnection attempts to %s may result in failures that must be cleared",
-                 lrm_state->node_name);
+            crm_warn("Reconnection attempts to %s may result in failures that must be cleared",
+                    lrm_state->node_name);
+        } else {
+            remote_proxy_nack_shutdown(lrmd);
+
+            crm_notice("Remote resource for %s is not managed so no ordered shutdown happening",
+                    lrm_state->node_name);
+        }
         return;
 
     } else if (safe_str_eq(op, LRMD_IPC_OP_NEW)) {
@@ -852,3 +859,4 @@ lrm_state_unregister_rsc(lrm_state_t * lrm_state,
 
     return ((lrmd_t *) lrm_state->conn)->cmds->unregister_rsc(lrm_state->conn, rsc_id, options);
 }
+

--- a/crmd/messages.c
+++ b/crmd/messages.c
@@ -872,6 +872,11 @@ handle_request(xmlNode * stored_msg, enum crmd_fsa_cause cause)
             reap_crm_member(id, name);
         }
 
+    } else if (strcmp(op, CRM_OP_MAINTENANCE_NODES) == 0) {
+        xmlNode *xml = get_message_xml(stored_msg, F_CRM_DATA);
+
+        remote_ra_process_maintenance_nodes(xml);
+
     } else {
         crm_err("Unexpected request (%s) sent to %s", op, AM_I_DC ? "the DC" : "non-DC node");
         crm_log_xml_err(stored_msg, "Unexpected");

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -126,6 +126,7 @@ extern char *crm_system_name;
 #  define CRM_OP_RELAXED_SET  "one-or-more"
 #  define CRM_OP_RELAXED_CLONE  "clone-one-or-more"
 #  define CRM_OP_RM_NODE_CACHE "rm_node_cache"
+#  define CRM_OP_MAINTENANCE_NODES "maintenance_nodes"
 
 /* @COMPAT: These symbols are deprecated and not used by Pacemaker,
  * but they are kept for public API backward compatibility.

--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -99,6 +99,7 @@ typedef struct lrmd_key_value_s {
 #define LRMD_IPC_OP_RESPONSE      "response"
 #define LRMD_IPC_OP_SHUTDOWN_REQ  "shutdown_req"
 #define LRMD_IPC_OP_SHUTDOWN_ACK  "shutdown_ack"
+#define LRMD_IPC_OP_SHUTDOWN_NACK "shutdown_nack"
 
 #define F_LRMD_IPC_OP           "lrmd_ipc_op"
 #define F_LRMD_IPC_IPC_SERVER   "lrmd_ipc_server"

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -255,6 +255,7 @@
 #  define XML_NODE_IS_PEER    	"crmd"
 #  define XML_NODE_IS_REMOTE    	"remote_node"
 #  define XML_NODE_IS_FENCED		"node_fenced"
+#  define XML_NODE_IS_MAINTENANCE   "node_in_maintenance"
 
 #  define XML_CIB_ATTR_SHUTDOWN       	"shutdown"
 #  define XML_CIB_ATTR_STONITH	    	"stonith"
@@ -297,6 +298,7 @@
 #  define XML_GRAPH_TAG_PSEUDO_EVENT	"pseudo_event"
 #  define XML_GRAPH_TAG_CRM_EVENT	"crm_event"
 #  define XML_GRAPH_TAG_DOWNED            "downed"
+#  define XML_GRAPH_TAG_MAINTENANCE       "maintenance"
 
 #  define XML_TAG_RULE			"rule"
 #  define XML_RULE_ATTR_SCORE		"score"

--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -160,6 +160,7 @@ struct node_shared_s {
     gboolean rsc_discovery_enabled;
     gboolean remote_requires_reset;
     gboolean remote_was_fenced;
+    gboolean remote_maintenance; /* what the remote-rsc is thinking */
 };
 
 struct node_s {

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -371,6 +371,7 @@ typedef struct remote_proxy_s {
 } remote_proxy_t;
 void remote_proxy_notify_destroy(lrmd_t *lrmd, const char *session_id);
 void remote_proxy_ack_shutdown(lrmd_t *lrmd);
+void remote_proxy_nack_shutdown(lrmd_t *lrmd);
 void remote_proxy_relay_event(lrmd_t *lrmd, const char *session_id, xmlNode *msg);
 void remote_proxy_relay_response(lrmd_t *lrmd, const char *session_id, xmlNode *msg, int msg_id);
 void remote_proxy_end_session(const char *session);

--- a/lib/lrmd/proxy_common.c
+++ b/lib/lrmd/proxy_common.c
@@ -59,6 +59,21 @@ remote_proxy_ack_shutdown(lrmd_t *lrmd)
     free_xml(msg);
 }
 
+/*!
+ * \brief We're not gonna shutdown as response to
+ *        a remote proxy shutdown request.
+ *
+ * \param[in] lrmd  Connection to proxy
+ */
+void
+remote_proxy_nack_shutdown(lrmd_t *lrmd)
+{
+    xmlNode *msg = create_xml_node(NULL, T_LRMD_IPC_PROXY);
+    crm_xml_add(msg, F_LRMD_IPC_OP, LRMD_IPC_OP_SHUTDOWN_NACK);
+    lrmd_internal_proxy_send(lrmd, msg);
+    free_xml(msg);
+}
+
 void
 remote_proxy_relay_event(lrmd_t *lrmd, const char *session_id, xmlNode *msg)
 {

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -89,16 +89,22 @@ pe_fence_node(pe_working_set_t * data_set, node_t * node, const char *reason)
         set_bit(node->details->remote_rsc->flags, pe_rsc_failed);
 
     } else if (is_baremetal_remote_node(node)) {
-        if(pe_can_fence(data_set, node)) {
-            crm_warn("Node %s will be fenced %s", node->details->uname, reason);
+        resource_t *rsc = node->details->remote_rsc;
+
+        if (rsc && (!is_set(rsc->flags, pe_rsc_managed))) {
+            crm_notice("Not fencing node %s because connection is unmanaged, "
+                       "otherwise would %s", node->details->uname, reason);
         } else {
-            crm_warn("Node %s is unclean %s", node->details->uname, reason);
+            if (pe_can_fence(data_set, node)) {
+                crm_warn("Node %s will be fenced %s", node->details->uname, reason);
+            } else {
+                crm_warn("Node %s is unclean %s", node->details->uname, reason);
+            }
+            node->details->remote_requires_reset = TRUE;
         }
         node->details->unclean = TRUE;
-        node->details->remote_requires_reset = TRUE;
-
     } else if (node->details->unclean == FALSE) {
-        if(pe_can_fence(data_set, node)) {
+        if (pe_can_fence(data_set, node)) {
             crm_warn("Node %s will be fenced %s", node->details->uname, reason);
         } else {
             crm_warn("Node %s is unclean %s", node->details->uname, reason);
@@ -1163,6 +1169,7 @@ unpack_remote_status(xmlNode * status, pe_working_set_t * data_set)
     const char *id = NULL;
     const char *uname = NULL;
     const char *shutdown = NULL;
+    resource_t *rsc = NULL;
 
     GListPtr gIter = NULL;
 
@@ -1202,6 +1209,10 @@ unpack_remote_status(xmlNode * status, pe_working_set_t * data_set)
         }
         crm_trace("Processing remote node id=%s, uname=%s", id, uname);
 
+        this_node->details->remote_maintenance =
+            crm_atoi(crm_element_value(state, XML_NODE_IS_MAINTENANCE), "0");
+
+        rsc = this_node->details->remote_rsc;
         if (this_node->details->remote_requires_reset == FALSE) {
             this_node->details->unclean = FALSE;
             this_node->details->unseen = FALSE;
@@ -1211,11 +1222,11 @@ unpack_remote_status(xmlNode * status, pe_working_set_t * data_set)
 
         shutdown = g_hash_table_lookup(this_node->details->attrs, XML_CIB_ATTR_SHUTDOWN);
         if (shutdown != NULL && safe_str_neq("0", shutdown)) {
-            resource_t *rsc = this_node->details->remote_rsc;
-
             crm_info("Node %s is shutting down", this_node->details->uname);
             this_node->details->shutdown = TRUE;
-            rsc->next_role = RSC_ROLE_STOPPED;
+            if (rsc) {
+                rsc->next_role = RSC_ROLE_STOPPED;
+            }
         }
  
         if (crm_is_true(g_hash_table_lookup(this_node->details->attrs, "standby"))) {
@@ -1223,7 +1234,8 @@ unpack_remote_status(xmlNode * status, pe_working_set_t * data_set)
             this_node->details->standby = TRUE;
         }
 
-        if (crm_is_true(g_hash_table_lookup(this_node->details->attrs, "maintenance"))) {
+        if (crm_is_true(g_hash_table_lookup(this_node->details->attrs, "maintenance")) ||
+            (rsc && !is_set(rsc->flags, pe_rsc_managed))) {
             crm_info("Node %s is in maintenance-mode", this_node->details->uname);
             this_node->details->maintenance = TRUE;
         }
@@ -2825,7 +2837,7 @@ determine_op_status(
                 result = PCMK_LRM_OP_NOTSUPPORTED;
                 break;
 
-            } else if(pe_can_fence(data_set, node) == FALSE
+            } else if (pe_can_fence(data_set, node) == FALSE
                && safe_str_eq(task, CRMD_ACTION_STOP)) {
                 /* If a stop fails and we can't fence, there's nothing else we can do */
                 pe_proc_err("No further recovery can be attempted for %s: %s action failed with '%s' (%d)",

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -824,20 +824,28 @@ unpack_operation(action_t * action, xmlNode * xml_obj, resource_t * container,
      * 2. start - a start failure indicates that an active connection does not already
      * exist. The user can set op on-fail=fence if they really want to fence start
      * failures. */
-    } else if (value == NULL &&
-               is_rsc_baremetal_remote_node(action->rsc, data_set) &&
+    } else if (((value == NULL) || !is_set(action->rsc->flags, pe_rsc_managed)) &&
+                (is_rsc_baremetal_remote_node(action->rsc, data_set) &&
                !(safe_str_eq(action->task, CRMD_ACTION_STATUS) && interval == 0) &&
-                (safe_str_neq(action->task, CRMD_ACTION_START))) {
+                (safe_str_neq(action->task, CRMD_ACTION_START)))) {
 
-        if (is_set(data_set->flags, pe_flag_stonith_enabled)) {
-            value = "fence baremetal remote node (default)";
-        } else {
-            value = "recover baremetal remote node connection (default)";
-        }
-        if (action->rsc->remote_reconnect_interval) {
+        if (!is_set(action->rsc->flags, pe_rsc_managed)) {
+            action->on_fail = action_fail_stop;
             action->fail_role = RSC_ROLE_STOPPED;
+            value = "stop unmanaged baremetal remote node (enforcing default)";
+
+        } else {
+            if (is_set(data_set->flags, pe_flag_stonith_enabled)) {
+                value = "fence baremetal remote node (default)";
+            } else {
+                value = "recover baremetal remote node connection (default)";
+            }
+
+            if (action->rsc->remote_reconnect_interval) {
+                action->fail_role = RSC_ROLE_STOPPED;
+            }
+            action->on_fail = action_fail_reset_remote;
         }
-        action->on_fail = action_fail_reset_remote;
 
     } else if (value == NULL && safe_str_eq(action->task, CRMD_ACTION_STOP)) {
         if (is_set(data_set->flags, pe_flag_stonith_enabled)) {

--- a/lrmd/ipc_proxy.c
+++ b/lrmd/ipc_proxy.c
@@ -164,6 +164,11 @@ ipc_proxy_forward_client(crm_client_t *ipc_proxy, xmlNode *xml)
         return;
     }
 
+    if (safe_str_eq(msg_type, LRMD_IPC_OP_SHUTDOWN_NACK)) {
+        handle_shutdown_nack();
+        return;
+    }
+
     ipc_client = crm_client_get_by_id(session);
     if (ipc_client == NULL) {
         xmlNode *msg = create_xml_node(NULL, T_LRMD_IPC_PROXY);

--- a/lrmd/lrmd_private.h
+++ b/lrmd/lrmd_private.h
@@ -85,6 +85,8 @@ void free_rsc(gpointer data);
 
 void handle_shutdown_ack(void);
 
+void handle_shutdown_nack(void);
+
 void lrmd_client_destroy(crm_client_t *client);
 
 void client_disconnect_cleanup(const char *client_id);

--- a/lrmd/main.c
+++ b/lrmd/main.c
@@ -364,11 +364,35 @@ void handle_shutdown_ack()
         crm_info("Received shutdown ack");
         if (shutdown_ack_timer > 0) {
             g_source_remove(shutdown_ack_timer);
+            shutdown_ack_timer = 0;
         }
         return;
     }
 #endif
     crm_debug("Ignoring unexpected shutdown ack");
+}
+
+/*!
+ * \internal
+ * \brief Make short exit timer fire immediately
+ */
+void handle_shutdown_nack()
+{
+#ifdef ENABLE_PCMK_REMOTE
+    if (shutting_down) {
+        crm_info("Received shutdown nack");
+        if (shutdown_ack_timer > 0) {
+            GSource *timer =
+                g_main_context_find_source_by_id(NULL, shutdown_ack_timer);
+
+            if (timer != NULL) {
+                g_source_set_ready_time(timer, 0);
+            }
+        }
+        return;
+    }
+#endif
+    crm_debug("Ignoring unexpected shutdown nack");
 }
 
 /* *INDENT-OFF* */

--- a/pengine/allocate.c
+++ b/pengine/allocate.c
@@ -2150,6 +2150,9 @@ stage8(pe_working_set_t * data_set)
 
     crm_log_xml_trace(data_set->graph, "created resource-driven action list");
 
+    /* pseudo action to distribute list of nodes with maintenance state update */
+    add_maintenance_update(data_set);
+
     /* catch any non-resource specific actions */
     crm_trace("processing non-resource actions");
 

--- a/pengine/pengine.h
+++ b/pengine/pengine.h
@@ -145,6 +145,7 @@ extern int new_rsc_order(resource_t * lh_rsc, const char *lh_task,
     new_rsc_order(rsc1, CRMD_ACTION_STOP, rsc2, CRMD_ACTION_STOP, type, data_set)
 
 extern void graph_element_from_action(action_t * action, pe_working_set_t * data_set);
+extern void add_maintenance_update(pe_working_set_t *data_set);
 
 extern gboolean show_scores;
 extern int scores_log_level;


### PR DESCRIPTION
Since introduction of the graceful shutdown of pacemaker_remoted
the shutdown is hanging if the remote-resource is unmanaged.
This happens as pacemaker_remoted is waiting for all resources
running on the remote-node to be shut down and pacemaker
on the other hand doesn't touch resources on a remote-node
when the remote-resource is unmanaged.

Fixes rhbz#1388102