### PR TITLE
Low: crmd: Move Alert function to common. (again)

### DIFF
--- a/crmd/Makefile.am
+++ b/crmd/Makefile.am
@@ -41,7 +41,7 @@ crmd_LDADD	= $(top_builddir)/lib/fencing/libstonithd.la		\
 		$(top_builddir)/lib/lrmd/liblrmd.la			\
 		$(CLUSTERLIBS)
 
-crmd_SOURCES	= main.c crmd.c corosync.c notify.c				\
+crmd_SOURCES	= main.c crmd.c corosync.c crmd_alerts.c				\
 		fsa.c control.c messages.c membership.c callbacks.c attrd.c	\
 		election.c join_client.c join_dc.c subsystems.c throttle.c	\
 		cib.c pengine.c tengine.c lrm.c lrm_state.c remote_lrmd_ra.c	\

--- a/crmd/callbacks.c
+++ b/crmd/callbacks.c
@@ -146,7 +146,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                 }
             }
 
-            crmd_notify_node_event(node);
+            crmd_alert_node_event(node);
             break;
 
         case crm_status_processes:

--- a/crmd/control.c
+++ b/crmd/control.c
@@ -1035,7 +1035,7 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 #ifdef RHEL7_COMPAT
     script = crmd_pref(config_hash, "notification-agent");
     value  = crmd_pref(config_hash, "notification-recipient");
-    crmd_enable_notifications(script, value);
+    crmd_enable_alerts(script, value);
 #endif
 
     value = crmd_pref(config_hash, XML_CONFIG_ATTR_DC_DEADTIME);
@@ -1095,7 +1095,7 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     }
 
     alerts = first_named_child(output, XML_CIB_TAG_ALERTS);
-    parse_notifications(alerts);
+    parse_alerts(alerts);
 
     set_bit(fsa_input_register, R_READ_CONFIG);
     crm_trace("Triggering FSA: %s", __FUNCTION__);

--- a/crmd/crmd_alerts.c
+++ b/crmd/crmd_alerts.c
@@ -126,9 +126,8 @@ parse_notifications(xmlNode *notifications)
             .tstamp_format = (char *) CRM_ALERT_DEFAULT_TSTAMP_FORMAT
         };
 
-        entry.envvars =
-            crm_get_envvars_from_cib(notify,
-                                 entry.envvars,
+        crm_get_envvars_from_cib(notify,
+                                 &entry,
                                  &envvars);
 
         config_hash =
@@ -148,9 +147,8 @@ parse_notifications(xmlNode *notifications)
                                                 XML_ALERT_ATTR_REC_VALUE);
             recipients++;
 
-            entry.envvars =
-                crm_get_envvars_from_cib(recipient,
-                                     entry.envvars,
+            crm_get_envvars_from_cib(recipient,
+                                     &entry,
                                      &envvars_added);
 
             {
@@ -170,15 +168,14 @@ parse_notifications(xmlNode *notifications)
                 g_hash_table_destroy(config_hash);
             }
 
-            entry.envvars =
-                crm_drop_envvars(entry.envvars, envvars_added);
+            crm_drop_envvars(&entry, envvars_added);
         }
 
         if (recipients == 0) {
             crm_add_dup_notify_list_entry(&entry);
         }
 
-        crm_drop_envvars(entry.envvars, -1);
+        crm_drop_envvars(&entry, -1);
         g_hash_table_destroy(config_hash);
     }
 
@@ -246,7 +243,7 @@ send_notifications(const char *kind)
             notify->agent = strdup(entry->path);
             notify->sequence = operations;
 
-            crm_set_envvar_list(entry->envvars);
+            crm_set_envvar_list(entry);
 
             alerts_inflight++;
             if(services_action_async(notify, &crmd_notify_complete) == FALSE) {
@@ -254,7 +251,7 @@ send_notifications(const char *kind)
                 alerts_inflight--;
             }
 
-            crm_unset_envvar_list(entry->envvars);
+            crm_unset_envvar_list(entry);
         } else {
             crm_warn("Ignoring '%s' alert to '%s' via '%s' received "
                      "while shutting down",

--- a/crmd/crmd_alerts.c
+++ b/crmd/crmd_alerts.c
@@ -20,7 +20,7 @@
 #include <crm/crm.h>
 #include <crm/msg_xml.h>
 #include <crm/pengine/rules.h>
-#include "notify.h"
+#include "crmd_alerts.h"
 #include "crmd_messages.h"
 #include <crm/common/alerts_internal.h>
 #include <crm/common/iso8601_internal.h>

--- a/crmd/crmd_alerts.h
+++ b/crmd/crmd_alerts.h
@@ -15,8 +15,8 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
-#ifndef CRMD_NOTIFY__H
-#  define CRMD_NOTIFY__H
+#ifndef CRMD_ALERT__H
+#  define CRMD_ALERT__H
 
 #  include <crm/crm.h>
 #  include <crm/cluster.h>

--- a/crmd/crmd_alerts.h
+++ b/crmd/crmd_alerts.h
@@ -22,11 +22,11 @@
 #  include <crm/cluster.h>
 #  include <crm/stonith-ng.h>
 
-void crmd_enable_notifications(const char *script, const char *target);
-void crmd_notify_node_event(crm_node_t *node);
-void crmd_notify_fencing_op(stonith_event_t *e);
-void crmd_notify_resource_op(const char *node, lrmd_event_data_t *op);
+void crmd_enable_alerts(const char *script, const char *target);
+void crmd_alert_node_event(crm_node_t *node);
+void crmd_alert_fencing_op(stonith_event_t *e);
+void crmd_alert_resource_op(const char *node, lrmd_event_data_t *op);
 void crmd_drain_alerts(GMainContext *ctx);
-void parse_notifications(xmlNode *notifications);
+void parse_alerts(xmlNode *alerts);
 
 #endif

--- a/crmd/crmd_utils.h
+++ b/crmd/crmd_utils.h
@@ -21,7 +21,7 @@
 #  include <crm/crm.h>
 #  include <crm/common/xml.h>
 #  include <crm/cib/internal.h> /* For CIB_OP_MODIFY */
-#  include "notify.h"
+#  include "crmd_alerts.h"
 
 #  define CLIENT_EXIT_WAIT 30
 #  define FAKE_TE_ID	"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -2561,7 +2561,7 @@ process_lrm_event(lrm_state_t * lrm_state, lrmd_event_data_t * op, struct recurr
         free(prefix);
     }
 
-    crmd_notify_resource_op(lrm_state->node_name, op);
+    crmd_alert_resource_op(lrm_state->node_name, op);
 
     if (op->rsc_deleted) {
         crm_info("Deletion of resource '%s' complete after %s", op->rsc_id, op_key);

--- a/crmd/notify.h
+++ b/crmd/notify.h
@@ -22,12 +22,6 @@
 #  include <crm/cluster.h>
 #  include <crm/stonith-ng.h>
 
-/* Default-Timeout to use before killing a notification script (in milliseconds) */
-#  define CRMD_NOTIFY_DEFAULT_TIMEOUT_MS (30000)
-
-/* Default-Format-String used to pass timestamps to the notification scripts */
-#  define CRMD_NOTIFY_DEFAULT_TSTAMP_FORMAT "%H:%M:%S.%06N"
-
 void crmd_enable_notifications(const char *script, const char *target);
 void crmd_notify_node_event(crm_node_t *node);
 void crmd_notify_fencing_op(stonith_event_t *e);

--- a/crmd/te_utils.c
+++ b/crmd/te_utils.c
@@ -214,7 +214,7 @@ tengine_stonith_notify(stonith_t * st, stonith_event_t * st_event)
         return;
     }
 
-    crmd_notify_fencing_op(st_event);
+    crmd_alert_fencing_op(st_event);
 
     if (st_event->result == pcmk_ok && safe_str_eq("on", st_event->action)) {
         crm_notice("%s was successfully unfenced by %s (at the request of %s)",

--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -55,12 +55,12 @@ extern guint crm_alert_max_alert_timeout;
 extern const char *crm_alert_keys[14][3];
 
 void crm_free_notify_list(void);
-GListPtr crm_drop_envvars(GListPtr envvar_list, int count);
+GListPtr crm_drop_envvars(crm_alert_entry_t *entry, int count);
 void crm_add_dup_notify_list_entry(crm_alert_entry_t *entry);
-GListPtr crm_get_envvars_from_cib(xmlNode *basenode, GListPtr list, int *count);
+GListPtr crm_get_envvars_from_cib(xmlNode *basenode, crm_alert_entry_t *entry, int *count);
 void crm_set_alert_key(enum crm_alert_keys_e name, const char *value);
 void crm_set_alert_key_int(enum crm_alert_keys_e name, int value);
 void crm_unset_alert_keys(void);
-void crm_set_envvar_list(GListPtr envvars);
-void crm_unset_envvar_list(GListPtr envvars);
+void crm_set_envvar_list(crm_alert_entry_t *entry);
+void crm_unset_envvar_list(crm_alert_entry_t *entry);
 #endif

--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -18,10 +18,10 @@
 
 #ifndef ALERT_INTERNAL_H
 #define ALERT_INTERNAL_H
-/* Default-Timeout to use before killing a notification script (in milliseconds) */
+/* Default-Timeout to use before killing a alerts script (in milliseconds) */
 #  define CRM_ALERT_DEFAULT_TIMEOUT_MS (30000)
 
-/* Default-Format-String used to pass timestamps to the notification scripts */
+/* Default-Format-String used to pass timestamps to the alerts scripts */
 #  define CRM_ALERT_DEFAULT_TSTAMP_FORMAT "%H:%M:%S.%06N"
 
 typedef struct {
@@ -54,9 +54,9 @@ extern GListPtr crm_alert_list;
 extern guint crm_alert_max_alert_timeout;
 extern const char *crm_alert_keys[14][3];
 
-void crm_free_notify_list(void);
+void crm_free_alert_list(void);
 GListPtr crm_drop_envvars(crm_alert_entry_t *entry, int count);
-void crm_add_dup_notify_list_entry(crm_alert_entry_t *entry);
+void crm_add_dup_alert_list_entry(crm_alert_entry_t *entry);
 GListPtr crm_get_envvars_from_cib(xmlNode *basenode, crm_alert_entry_t *entry, int *count);
 void crm_set_alert_key(enum crm_alert_keys_e name, const char *value);
 void crm_set_alert_key_int(enum crm_alert_keys_e name, int value);

--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015 Andrew Beekhof <andrew@beekhof.net>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef ALERT_INTERNAL_H
+#define ALERT_INTERNAL_H
+/* Default-Timeout to use before killing a notification script (in milliseconds) */
+#  define CRM_ALERT_DEFAULT_TIMEOUT_MS (30000)
+
+/* Default-Format-String used to pass timestamps to the notification scripts */
+#  define CRM_ALERT_DEFAULT_TSTAMP_FORMAT "%H:%M:%S.%06N"
+
+typedef struct {
+    char *id;
+    char *path;
+    int timeout;
+    char *tstamp_format;
+    char *recipient;
+    GListPtr envvars;
+} crm_alert_entry_t;
+
+enum crm_alert_keys_e {
+    CRM_alert_recipient = 0,
+    CRM_alert_node,
+    CRM_alert_nodeid,
+    CRM_alert_rsc,
+    CRM_alert_task,
+    CRM_alert_interval,
+    CRM_alert_desc,
+    CRM_alert_status,
+    CRM_alert_target_rc,
+    CRM_alert_rc,
+    CRM_alert_kind,
+    CRM_alert_version,
+    CRM_alert_node_sequence,
+    CRM_alert_timestamp
+};
+
+extern GListPtr crm_alert_list;
+extern guint crm_alert_max_alert_timeout;
+extern const char *crm_alert_keys[14][3];
+
+void crm_free_notify_list(void);
+GListPtr crm_drop_envvars(GListPtr envvar_list, int count);
+void crm_add_dup_notify_list_entry(crm_alert_entry_t *entry);
+GListPtr crm_get_envvars_from_cib(xmlNode *basenode, GListPtr list, int *count);
+void crm_set_alert_key(enum crm_alert_keys_e name, const char *value);
+void crm_set_alert_key_int(enum crm_alert_keys_e name, int value);
+void crm_unset_alert_keys(void);
+void crm_set_envvar_list(GListPtr envvars);
+void crm_unset_envvar_list(GListPtr envvars);
+#endif

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -39,7 +39,7 @@ libcrmcommon_la_LIBADD	= @LIBADD_DL@ $(GNUTLSLIBS) -lm
 
 libcrmcommon_la_SOURCES	= compat.c digest.c ipc.c io.c procfs.c utils.c xml.c \
 			  iso8601.c remote.c mainloop.c logging.c watchdog.c \
-			  schemas.c strings.c xpath.c attrd_client.c
+			  schemas.c strings.c xpath.c attrd_client.c alerts.c
 if BUILD_CIBSECRETS
 libcrmcommon_la_SOURCES	+= cib_secrets.c
 endif

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2015 Andrew Beekhof <andrew@beekhof.net>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <crm_internal.h>
+#include <crm/crm.h>
+#include <crm/msg_xml.h>
+#include <crm/common/alerts_internal.h>
+
+typedef struct {
+    char *name;
+    char *value;
+} envvar_t;
+
+GListPtr crm_alert_list = NULL;
+guint crm_alert_max_alert_timeout = CRM_ALERT_DEFAULT_TIMEOUT_MS;
+
+/*		
+ * to allow script compatibility we can have more than one		
+ * set of environment variables		
+ */
+const char *crm_alert_keys[14][3] =		
+{		
+    [CRM_alert_recipient]     = {"CRM_notify_recipient",     "CRM_alert_recipient",     NULL},		
+    [CRM_alert_node]          = {"CRM_notify_node",          "CRM_alert_node",          NULL},		
+    [CRM_alert_nodeid]        = {"CRM_notify_nodeid",        "CRM_alert_nodeid",        NULL},		
+    [CRM_alert_rsc]           = {"CRM_notify_rsc",           "CRM_alert_rsc",           NULL},		
+    [CRM_alert_task]          = {"CRM_notify_task",          "CRM_alert_task",          NULL},		
+    [CRM_alert_interval]      = {"CRM_notify_interval",      "CRM_alert_interval",      NULL},		
+    [CRM_alert_desc]          = {"CRM_notify_desc",          "CRM_alert_desc",          NULL},		
+    [CRM_alert_status]        = {"CRM_notify_status",        "CRM_alert_status",        NULL},		
+    [CRM_alert_target_rc]     = {"CRM_notify_target_rc",     "CRM_alert_target_rc",     NULL},		
+    [CRM_alert_rc]            = {"CRM_notify_rc",            "CRM_alert_rc",            NULL},		
+    [CRM_alert_kind]          = {"CRM_notify_kind",          "CRM_alert_kind",          NULL},		
+    [CRM_alert_version]       = {"CRM_notify_version",       "CRM_alert_version",       NULL},		
+    [CRM_alert_node_sequence] = {"CRM_notify_node_sequence", "CRM_alert_node_sequence", NULL},		
+    [CRM_alert_timestamp]     = {"CRM_notify_timestamp",     "CRM_alert_timestamp",     NULL}		
+};
+
+static void		
+free_envvar_entry(envvar_t *entry)		
+{		
+    free(entry->name);		
+    free(entry->value);		
+    free(entry);		
+}		
+
+static void		
+crm_free_notify_list_entry(crm_alert_entry_t *entry)		
+{		
+    free(entry->id);		
+    free(entry->path);		
+    free(entry->tstamp_format);		
+    free(entry->recipient);		
+    if (entry->envvars) {		
+        g_list_free_full(entry->envvars,		
+                         (GDestroyNotify) free_envvar_entry);		
+    }		
+    free(entry);		
+}		
+
+void		
+crm_free_notify_list()		
+{		
+    if (crm_alert_list) {		
+        g_list_free_full(crm_alert_list, (GDestroyNotify) crm_free_notify_list_entry);		
+        crm_alert_list = NULL;		
+    }		
+}		
+
+static gpointer		
+copy_envvar_entry(envvar_t * src,		
+                  gpointer data)		
+{		
+    envvar_t *dst = calloc(1, sizeof(envvar_t));		
+
+    CRM_ASSERT(dst);		
+    dst->name = strdup(src->name);		
+    dst->value = src->value?strdup(src->value):NULL;		
+    return (gpointer) dst;		
+}		
+
+static GListPtr		
+add_dup_envvar(GListPtr envvar_list,		
+               envvar_t *entry)		
+{		
+    return g_list_prepend(envvar_list, copy_envvar_entry(entry, NULL));		
+}		
+
+GListPtr		
+crm_drop_envvars(GListPtr envvar_list, int count)		
+{		
+    int i;		
+		
+    for (i = 0;		
+         (envvar_list) && ((count < 0) || (i < count));		
+         i++) {		
+        free_envvar_entry((envvar_t *) g_list_first(envvar_list)->data);		
+        envvar_list = g_list_delete_link(envvar_list,		
+                                         g_list_first(envvar_list));		
+    }		
+    return envvar_list;		
+}		
+
+static GListPtr		
+copy_envvar_list_remove_dupes(GListPtr src)		
+{		
+    GListPtr dst = NULL, ls, ld;		
+
+    /* we are adding to the front so variable dupes coming via		
+     * recipient-section have got precedence over those in the		
+     * global section - we don't expect that many variables here		
+     * that it pays off to go for a hash-table to make dupe elimination		
+     * more efficient - maybe later when we might decide to do more		
+     * with the variables than cycling through them		
+     */		
+
+    for (ls = g_list_first(src); ls; ls = g_list_next(ls)) {		
+        for (ld = g_list_first(dst); ld; ld = g_list_next(ld)) {		
+            if (!strcmp(((envvar_t *)(ls->data))->name,		
+                        ((envvar_t *)(ld->data))->name)) {		
+                break;		
+            }		
+        }		
+        if (!ld) {		
+            dst = g_list_prepend(dst,		
+                    copy_envvar_entry((envvar_t *)(ls->data), NULL));		
+        }		
+    }		
+
+    return dst;		
+}		
+
+void		
+crm_add_dup_notify_list_entry(crm_alert_entry_t *entry)		
+{		
+    crm_alert_entry_t *new_entry =		
+        (crm_alert_entry_t *) calloc(1, sizeof(crm_alert_entry_t));		
+
+    CRM_ASSERT(new_entry);		
+    *new_entry = (crm_alert_entry_t) {		
+        .id = strdup(entry->id),		
+        .path = strdup(entry->path),		
+        .timeout = entry->timeout,		
+        .tstamp_format = entry->tstamp_format?strdup(entry->tstamp_format):NULL,		
+        .recipient = entry->recipient?strdup(entry->recipient):NULL,		
+        .envvars = entry->envvars?		
+            copy_envvar_list_remove_dupes(entry->envvars)		
+            :NULL		
+    };		
+    crm_alert_list = g_list_prepend(crm_alert_list, new_entry);		
+}		
+
+GListPtr		
+crm_get_envvars_from_cib(xmlNode *basenode, GListPtr list, int *count)		
+{		
+    xmlNode *envvar;		
+    xmlNode *pair;		
+
+    if ((!basenode) ||		
+        (!(envvar = first_named_child(basenode, XML_TAG_ATTR_SETS)))) {		
+        return list;		
+    }		
+
+    for (pair = first_named_child(envvar, XML_CIB_TAG_NVPAIR);		
+         pair; pair = __xml_next(pair)) {		
+
+        envvar_t envvar_entry = (envvar_t) {		
+            .name = (char *) crm_element_value(pair, XML_NVPAIR_ATTR_NAME),		
+            .value = (char *) crm_element_value(pair, XML_NVPAIR_ATTR_VALUE)		
+        };		
+        crm_trace("Found environment variable %s = '%s'", envvar_entry.name,		
+                  envvar_entry.value?envvar_entry.value:"");		
+        (*count)++;		
+        list = add_dup_envvar(list, &envvar_entry);		
+    }		
+
+    return list;		
+}
+
+void
+crm_set_alert_key(enum crm_alert_keys_e name, const char *value)
+{
+    const char **key;
+
+    for (key = crm_alert_keys[name]; *key; key++) {
+        crm_trace("Setting alert key %s = '%s'", *key, value);
+        if (value) {
+            setenv(*key, value, 1);
+        } else {
+            unsetenv(*key);
+        }
+    }
+}
+
+void
+crm_set_alert_key_int(enum crm_alert_keys_e name, int value)
+{
+    char *s = crm_itoa(value);
+
+    crm_set_alert_key(name, s);
+    free(s);
+}
+
+void
+crm_unset_alert_keys()
+{
+    const char **key;
+    enum crm_alert_keys_e name;
+
+    for(name = 0; name < DIMOF(crm_alert_keys); name++) {
+        for(key = crm_alert_keys[name]; *key; key++) {
+            crm_trace("Unsetting alert key %s", *key);
+            unsetenv(*key);
+        }
+    }
+}
+
+void
+crm_set_envvar_list(GListPtr envvars)
+{
+    GListPtr l;
+
+    for (l = g_list_first(envvars); l; l = g_list_next(l)) {
+        envvar_t *entry = (envvar_t *)(l->data);
+
+        crm_trace("Setting environment variable %s = '%s'", entry->name,
+                  entry->value?entry->value:"");
+        if (entry->value) {
+            setenv(entry->name, entry->value, 1);
+        } else {
+            unsetenv(entry->name);
+        }
+    }
+}
+
+void
+crm_unset_envvar_list(GListPtr envvars)
+{
+    GListPtr l;
+
+    for (l = g_list_first(envvars); l; l = g_list_next(l)) {
+        envvar_t *entry = (envvar_t *)(l->data);
+
+        crm_trace("Unsetting environment variable %s", entry->name);
+        unsetenv(entry->name);
+    }
+}

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -60,7 +60,7 @@ free_envvar_entry(envvar_t *entry)
 }		
 
 static void		
-crm_free_notify_list_entry(crm_alert_entry_t *entry)		
+crm_free_alert_list_entry(crm_alert_entry_t *entry)		
 {		
     free(entry->id);		
     free(entry->path);		
@@ -74,10 +74,10 @@ crm_free_notify_list_entry(crm_alert_entry_t *entry)
 }		
 
 void		
-crm_free_notify_list()		
+crm_free_alert_list()		
 {		
     if (crm_alert_list) {		
-        g_list_free_full(crm_alert_list, (GDestroyNotify) crm_free_notify_list_entry);		
+        g_list_free_full(crm_alert_list, (GDestroyNotify) crm_free_alert_list_entry);		
         crm_alert_list = NULL;		
     }		
 }		
@@ -147,7 +147,7 @@ copy_envvar_list_remove_dupes(crm_alert_entry_t *entry)
 }		
 
 void		
-crm_add_dup_notify_list_entry(crm_alert_entry_t *entry)		
+crm_add_dup_alert_list_entry(crm_alert_entry_t *entry)		
 {		
     crm_alert_entry_t *new_entry =		
         (crm_alert_entry_t *) calloc(1, sizeof(crm_alert_entry_t));		


### PR DESCRIPTION
Hi All,

This is modified PR discussed by the next PR.
 - https://github.com/ClusterLabs/pacemaker/pull/1251

I perform the following changes for an attribute trap function.

- Move a movable Alert-related function to a common function.
- Change of file names from notify.c to crmd_alerts.c and crmd_alerts.h.
- Changed the parameter of the function,
- Changed the description to "alert".

Some functions have not yet moved.

Best Regards,
Hideo Yamauchi.
