### PR TITLE
Сhange starting process with PCMK_node_start_state

### DIFF
--- a/crmd/crmd_utils.h
+++ b/crmd/crmd_utils.h
@@ -90,7 +90,6 @@ xmlNode *create_node_state_update(crm_node_t *node, int flags,
 void populate_cib_nodes(enum node_update_flags flags, const char *source);
 void crm_update_quorum(gboolean quorum, gboolean force_update);
 void erase_status_tag(const char *uname, const char *tag, int options);
-void init_transient_attrs(const char *uname, const char *start_state, int options);
 void update_attrd(const char *host, const char *name, const char *value, const char *user_name, gboolean is_remote_node);
 void update_attrd_remote_node_removed(const char *host, const char *user_name);
 void update_attrd_clear_failures(const char *host, const char *rsc,

--- a/crmd/join_client.c
+++ b/crmd/join_client.c
@@ -258,21 +258,24 @@ do_cl_join_finalize_respond(long long action,
             if (start_state) {
                 if (safe_str_eq(start_state, "standby")) {
                     char *attr_id = crm_strdup_printf("nodes-%.256s-standby", fsa_our_uuid);
-                    crm_notice("Forcing node %s to join in %s state per configured environment", fsa_our_uname, start_state);
-                    update_attr_delegate(fsa_cib_conn, cib_sync_call, XML_CIB_TAG_NODES, fsa_our_uuid, NULL, NULL, 
-                                         attr_id, "standby", "on", TRUE, NULL, NULL);
+                    crm_notice("Forcing node %s to join in %s state per configured environment",
+                               fsa_our_uname, start_state);
+                    update_attr_delegate(fsa_cib_conn, cib_sync_call, XML_CIB_TAG_NODES, fsa_our_uuid,
+                                         NULL, NULL, attr_id, "standby", "on", TRUE, NULL, NULL);
 
                 } else if (safe_str_eq(start_state, "online")) {
                     char *attr_id = crm_strdup_printf("nodes-%.256s-standby", fsa_our_uuid);
-                    crm_notice("Forcing node %s to join in %s state per configured environment", fsa_our_uname, start_state);
-                    update_attr_delegate(fsa_cib_conn, cib_sync_call, XML_CIB_TAG_NODES, fsa_our_uuid, NULL, NULL, 
-                                         attr_id, "standby", "off", TRUE, NULL, NULL);
+                    crm_notice("Forcing node %s to join in %s state per configured environment",
+                               fsa_our_uname, start_state);
+                    update_attr_delegate(fsa_cib_conn, cib_sync_call, XML_CIB_TAG_NODES, fsa_our_uuid,
+                               NULL, NULL, attr_id, "standby", "off", TRUE, NULL, NULL);
 
                 } else if (safe_str_eq(start_state, "default")) {
                     crm_debug("Not forcing a starting state on node %s", fsa_our_uname);
 
                 } else {
-                    crm_warn("Unrecognized start state '%s', using 'default' (%s)", start_state, fsa_our_uname);
+                    crm_warn("Unrecognized start state '%s', using 'default' (%s)",
+                             start_state, fsa_our_uname);
                 }
             }
         }

--- a/crmd/join_client.c
+++ b/crmd/join_client.c
@@ -257,12 +257,16 @@ do_cl_join_finalize_respond(long long action,
 
             if (start_state) {
                 if (safe_str_eq(start_state, "standby")) {
+                    char *attr_id = crm_strdup_printf("nodes-%.256s-standby", fsa_our_uuid);
                     crm_notice("Forcing node %s to join in %s state per configured environment", fsa_our_uname, start_state);
-                    set_standby(fsa_cib_conn, fsa_our_uuid, NULL, "on");
+                    update_attr_delegate(fsa_cib_conn, cib_sync_call, XML_CIB_TAG_NODES, fsa_our_uuid, NULL, NULL, 
+                                         attr_id, "standby", "on", TRUE, NULL, NULL);
 
                 } else if (safe_str_eq(start_state, "online")) {
+                    char *attr_id = crm_strdup_printf("nodes-%.256s-standby", fsa_our_uuid);
                     crm_notice("Forcing node %s to join in %s state per configured environment", fsa_our_uname, start_state);
-                    set_standby(fsa_cib_conn, fsa_our_uuid, NULL, "off");
+                    update_attr_delegate(fsa_cib_conn, cib_sync_call, XML_CIB_TAG_NODES, fsa_our_uuid, NULL, NULL, 
+                                         attr_id, "standby", "off", TRUE, NULL, NULL);
 
                 } else if (safe_str_eq(start_state, "default")) {
                     crm_debug("Not forcing a starting state on node %s", fsa_our_uname);

--- a/crmd/join_client.c
+++ b/crmd/join_client.c
@@ -181,18 +181,16 @@ static void
 set_join_state(const char * start_state)
 {
     if (safe_str_eq(start_state, "standby")) {
-        char *attr_id = crm_strdup_printf("nodes-%.256s-standby", fsa_our_uuid);
         crm_notice("Forcing node %s to join in %s state per configured environment",
                    fsa_our_uname, start_state);
         update_attr_delegate(fsa_cib_conn, cib_sync_call, XML_CIB_TAG_NODES, fsa_our_uuid,
-                             NULL, NULL, attr_id, "standby", "on", TRUE, NULL, NULL);
+                             NULL, NULL, NULL, "standby", "on", TRUE, NULL, NULL);
 
     } else if (safe_str_eq(start_state, "online")) {
-        char *attr_id = crm_strdup_printf("nodes-%.256s-standby", fsa_our_uuid);
         crm_notice("Forcing node %s to join in %s state per configured environment",
                    fsa_our_uname, start_state);
         update_attr_delegate(fsa_cib_conn, cib_sync_call, XML_CIB_TAG_NODES, fsa_our_uuid,
-                             NULL, NULL, attr_id, "standby", "off", TRUE, NULL, NULL);
+                             NULL, NULL, NULL, "standby", "off", TRUE, NULL, NULL);
 
     } else if (safe_str_eq(start_state, "default")) {
         crm_debug("Not forcing a starting state on node %s", fsa_our_uname);

--- a/crmd/te_actions.c
+++ b/crmd/te_actions.c
@@ -103,8 +103,6 @@ send_stonith_update(crm_action_t * action, const char *target, const char *uuid)
     /* zero out the node-status & remove all LRM status info */
     xmlNode *node_state = NULL;
 
-    const char *start_state = daemon_option("node_start_state");
-
     CRM_CHECK(target != NULL, return);
     CRM_CHECK(uuid != NULL, return);
 
@@ -153,11 +151,7 @@ send_stonith_update(crm_action_t * action, const char *target, const char *uuid)
     /* fsa_cib_conn->cmds->bump_epoch(fsa_cib_conn, cib_quorum_override|cib_scope_local);    */
 
     erase_status_tag(peer->uname, XML_CIB_TAG_LRM, cib_scope_local);
-    if (start_state) {
-        init_transient_attrs(peer->uname, start_state, cib_scope_local);
-    } else {
-        erase_status_tag(peer->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
-    }
+    erase_status_tag(peer->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
 
     free_xml(node_state);
     return;

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -591,7 +591,8 @@ set_standby(cib_t * the_cib, const char *uuid, const char *scope, const char *st
 
     } else {
         scope = XML_CIB_TAG_NODES;
-        attr_id = crm_strdup_printf("nodes-%.256s-standby", uuid);
+        attr_id = crm_strdup_printf("standby-%.256s", uuid);
+        // attr_id = crm_strdup_printf("nodes-%.256s-standby", uuid);
     }
 
     rc = update_attr_delegate(the_cib, cib_sync_call, scope, uuid, NULL, NULL,

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -591,7 +591,7 @@ set_standby(cib_t * the_cib, const char *uuid, const char *scope, const char *st
 
     } else {
         scope = XML_CIB_TAG_NODES;
-        attr_id = crm_strdup_printf("standby-%.256s", uuid);
+        attr_id = crm_strdup_printf("nodes-%.256s-standby", uuid);
     }
 
     rc = update_attr_delegate(the_cib, cib_sync_call, scope, uuid, NULL, NULL,

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -592,7 +592,6 @@ set_standby(cib_t * the_cib, const char *uuid, const char *scope, const char *st
     } else {
         scope = XML_CIB_TAG_NODES;
         attr_id = crm_strdup_printf("standby-%.256s", uuid);
-        // attr_id = crm_strdup_printf("nodes-%.256s-standby", uuid);
     }
 
     rc = update_attr_delegate(the_cib, cib_sync_call, scope, uuid, NULL, NULL,


### PR DESCRIPTION
Now we can start node with `PCMK_node_start_state` the same way. But it will be the permanent state instead of the transient. 
The behavior is:
`PCMK_node_start_state=standby` -> set standby on, 
`PCMK_node_start_state=online` -> set standby off, 
`PCMK_node_start_state=default` -> leave standby alone.
Also we can use commandline option `-s` to to start node in standby state.
E.g. `ExecStart=/path/to/pacemakerd -s` for `pacemaker.service` file.

During the testing there was no race condition. But we noticed one thing: `set_standby(...)` uses `cib_sync_call` option inside the `update_attr_delegate(...)`. We tested without this option and there was no race too.