### PR TITLE
Mid: alert: Add the alert function of the attribute.

### DIFF
--- a/attrd/Makefile.am
+++ b/attrd/Makefile.am
@@ -36,7 +36,7 @@ attrd_SOURCES	=
 if BUILD_ATOMIC_ATTRD
 attrd_SOURCES	+= main.c commands.c attrd_common.c attrd_alerts.c
 else
-attrd_SOURCES	+= legacy.c attrd_common.c
+attrd_SOURCES	+= legacy.c attrd_common.c attrd_alerts.c
 endif
 
 clean-generic:

--- a/attrd/Makefile.am
+++ b/attrd/Makefile.am
@@ -29,11 +29,12 @@ attrd_LDFLAGS	= $(LDFLAGS_HARDENED_EXE)
 attrd_LDADD	= $(top_builddir)/lib/cluster/libcrmcluster.la	\
 		$(top_builddir)/lib/common/libcrmcommon.la	\
 		$(top_builddir)/lib/cib/libcib.la		\
+                $(top_builddir)/lib/lrmd/liblrmd.la             \
 		$(CLUSTERLIBS)
 
 attrd_SOURCES	=
 if BUILD_ATOMIC_ATTRD
-attrd_SOURCES	+= main.c commands.c attrd_common.c
+attrd_SOURCES	+= main.c commands.c attrd_common.c attrd_alerts.c
 else
 attrd_SOURCES	+= legacy.c attrd_common.c
 endif

--- a/attrd/attrd_alerts.c
+++ b/attrd/attrd_alerts.c
@@ -1,0 +1,519 @@
+/*
+ * Copyright (C) 2015 Andrew Beekhof <andrew@beekhof.net>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include <crm_internal.h>
+#include <crm/crm.h>
+#include <crm/cib/internal.h>
+#include <crm/msg_xml.h>
+#include <crm/pengine/rules.h>
+#include "attrd_common.h"
+#include "attrd_alerts.h"
+#include <crm/common/alerts_internal.h>
+#include <crm/common/iso8601_internal.h>
+
+static char *notify_script = NULL;
+static char *notify_target = NULL;
+GHashTable *alert_info_cache = NULL;
+
+lrmd_t *
+attrd_lrmd_connect(int max_retry, void callback(lrmd_event_data_t * op))
+{
+    int ret;
+    int fails = 0;
+
+    if (!the_lrmd) {
+        the_lrmd = lrmd_api_new();
+    }
+
+    while(fails < max_retry) {
+        the_lrmd->cmds->set_callback(the_lrmd, callback);
+
+        ret = the_lrmd->cmds->connect(the_lrmd, T_ATTRD, NULL);
+        if (ret != pcmk_ok) {
+            fails++;
+            crm_trace("lrmd_connect RETRY!(%d)", fails);
+        } else {
+            crm_trace("lrmd_connect OK!");
+            break;
+        }
+    }
+    return the_lrmd;
+}
+
+static void
+attrd_parse_alerts(xmlNode *notifications)
+{
+    xmlNode *alert;
+    crm_alert_entry_t entry;
+    guint max_timeout = 0;
+
+    crm_free_alert_list();
+    crm_alert_max_alert_timeout = CRM_ALERT_DEFAULT_TIMEOUT_MS;
+
+    if (notifications) {
+        crm_info("We have an alerts section in the cib");
+
+        if (notify_script) {
+            crm_warn("Cib contains configuration for Legacy Notifications "
+                     "which is overruled by alerts section");
+        }
+    } else {
+        crm_info("No optional alerts section in cib");
+
+        if (notify_script) {
+            entry = (crm_alert_entry_t) {
+                .id = (char *) "legacy_notification",
+                .path = notify_script,
+                .timeout = CRM_ALERT_DEFAULT_TIMEOUT_MS,
+                .recipient = notify_target,
+                .select_kind = NULL,
+                .select_attribute_name = NULL
+            };
+            crm_add_dup_alert_list_entry(&entry);
+            crm_info("Legacy Notifications enabled");
+        }
+
+        return;
+    }
+
+    for (alert = first_named_child(notifications, XML_CIB_TAG_ALERT);
+         alert; alert = __xml_next(alert)) {
+        xmlNode *recipient;
+        int recipients = 0, envvars = 0;
+        GHashTable *config_hash = NULL;
+
+        entry = (crm_alert_entry_t) {
+            .id = (char *) crm_element_value(alert, XML_ATTR_ID),
+            .path = (char *) crm_element_value(alert, XML_ALERT_ATTR_PATH),
+            .timeout = CRM_ALERT_DEFAULT_TIMEOUT_MS,
+            .tstamp_format = (char *) CRM_ALERT_DEFAULT_TSTAMP_FORMAT,
+            .select_kind = NULL,
+            .select_attribute_name = NULL
+        };
+
+        crm_get_envvars_from_cib(alert,
+                                 &entry,
+                                 &envvars);
+
+        config_hash =
+            get_meta_attrs_from_cib(alert, &entry, &max_timeout);
+
+        crm_debug("Found alert: id=%s, path=%s, timeout=%d, "
+                   "tstamp_format=%s, select_kind=%s, select_attribute_name=%s, %d additional environment variables",
+                   entry.id, entry.path, entry.timeout,
+                   entry.tstamp_format, entry.select_kind, entry.select_attribute_name, envvars);
+
+        for (recipient = first_named_child(alert,
+                                           XML_CIB_TAG_ALERT_RECIPIENT);
+             recipient; recipient = __xml_next(recipient)) {
+            int envvars_added = 0;
+
+            entry.recipient = (char *) crm_element_value(recipient,
+                                                XML_ALERT_ATTR_REC_VALUE);
+            recipients++;
+
+            crm_get_envvars_from_cib(recipient,
+                                     &entry,
+                                     &envvars_added);
+
+            {
+                crm_alert_entry_t recipient_entry = entry;
+                GHashTable *config_hash =
+                    get_meta_attrs_from_cib(recipient,
+                                            &recipient_entry,
+                                            &max_timeout);
+
+                crm_add_dup_alert_list_entry(&recipient_entry);
+
+                crm_debug("Alert has recipient: id=%s, value=%s, "
+                          "%d additional environment variables",
+                          crm_element_value(recipient, XML_ATTR_ID),
+                          recipient_entry.recipient, envvars_added);
+
+                g_hash_table_destroy(config_hash);
+            }
+
+            entry.envvars =
+                crm_drop_envvars(&entry, envvars_added);
+        }
+
+        if (recipients == 0) {
+            crm_add_dup_alert_list_entry(&entry);
+        }
+
+        crm_drop_envvars(&entry, -1);
+        g_hash_table_destroy(config_hash);
+    }
+
+    if (max_timeout > 0) {
+        crm_alert_max_alert_timeout = max_timeout;
+    }
+}
+
+
+static void
+config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *user_data)
+{
+#ifdef RHEL7_COMPAT
+    const char *script = NULL;
+#endif
+    GHashTable *config_hash = NULL;
+    crm_time_t *now = crm_time_new(NULL);
+    xmlNode *crmconfig = NULL;
+    xmlNode *alerts = NULL;
+
+    if (rc != pcmk_ok) {
+        crm_err("Local CIB query resulted in an error: %s", pcmk_strerror(rc));
+        if (rc == -EACCES || rc == -pcmk_err_schema_validation) {
+            crm_err("The cluster is mis-configured - shutting down and staying down");
+        }
+        goto bail;
+    }
+
+    crmconfig = output;
+    if ((crmconfig) &&
+        (crm_element_name(crmconfig)) &&
+        (strcmp(crm_element_name(crmconfig), XML_CIB_TAG_CRMCONFIG) != 0)) {
+        crmconfig = first_named_child(crmconfig, XML_CIB_TAG_CRMCONFIG);
+    }
+    if (!crmconfig) {
+        crm_err("Local CIB query for " XML_CIB_TAG_CRMCONFIG " section failed");
+        goto bail;
+    }
+
+    crm_debug("Call %d : Parsing CIB options", call_id);
+    config_hash =
+        g_hash_table_new_full(crm_str_hash, g_str_equal, g_hash_destroy_str, g_hash_destroy_str);
+
+    unpack_instance_attributes(crmconfig, crmconfig, XML_CIB_TAG_PROPSET, NULL, config_hash,
+                               CIB_OPTIONS_FIRST, FALSE, now);
+
+#ifdef RHEL7_COMPAT		
+    script = crmd_pref(config_hash, "notification-agent");		
+    value  = crmd_pref(config_hash, "notification-recipient");		
+    attrd_enable_alerts(script, value);		
+#endif
+    alerts = first_named_child(output, XML_CIB_TAG_ALERTS);
+    attrd_parse_alerts(alerts);
+
+    g_hash_table_destroy(config_hash);
+  bail:
+    crm_time_free(now);
+}
+
+gboolean
+attrd_read_options(gpointer user_data)
+{
+    int call_id;
+    
+    if (the_cib) {
+        call_id = the_cib->cmds->query(the_cib,
+            "//" XML_CIB_TAG_CRMCONFIG " | //" XML_CIB_TAG_ALERTS,
+            NULL, cib_xpath | cib_scope_local);
+
+        the_cib->cmds->register_callback_full(the_cib, call_id, 120, FALSE,
+                                              NULL,
+                                              "config_query_callback",
+                                              config_query_callback, free);
+
+        crm_trace("Querying the CIB... call %d", call_id);
+    } else {
+        crm_err("Querying the CIB...CIB connection not active");
+    }
+    return TRUE;
+}
+
+void
+attrd_cib_updated_cb(const char *event, xmlNode * msg)
+{
+    int rc = -1;
+    int format= 1;
+    xmlNode *patchset = get_message_xml(msg, F_CIB_UPDATE_RESULT);
+    xmlNode *change = NULL;
+    xmlXPathObject *xpathObj = NULL;
+
+    CRM_CHECK(msg != NULL, return);
+
+    crm_element_value_int(msg, F_CIB_RC, &rc);
+    if (rc < pcmk_ok) {
+        crm_trace("Filter rc=%d (%s)", rc, pcmk_strerror(rc));
+        return;
+    }
+
+    crm_element_value_int(patchset, "format", &format);
+    if (format == 1) {
+        if ((xpathObj = xpath_search(
+                 msg,
+                 "//" F_CIB_UPDATE_RESULT "//" XML_TAG_DIFF_ADDED "//" XML_CIB_TAG_CRMCONFIG " | " \
+                 "//" F_CIB_UPDATE_RESULT "//" XML_TAG_DIFF_ADDED "//" XML_CIB_TAG_ALERTS
+                 )) != NULL) {
+            freeXpathObject(xpathObj);
+            mainloop_set_trigger(attrd_config_read);
+        }
+    } else if (format == 2) {
+        for (change = __xml_first_child(patchset); change != NULL; change = __xml_next(change)) {
+            const char *xpath = crm_element_value(change, XML_DIFF_PATH);
+
+            if (xpath == NULL) {
+                continue;
+            }
+
+            /* modifying properties */
+            if (!strstr(xpath, "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_CRMCONFIG "/") &&
+                !strstr(xpath, "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_ALERTS)) {
+                xmlNode *section = NULL;
+                const char *name = NULL;
+
+                /* adding notifications section */
+                if ((strcmp(xpath, "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION) != 0) ||
+                    ((section = __xml_first_child(change)) == NULL) ||
+                    ((name = crm_element_name(section)) == NULL) ||
+                    (strcmp(name, XML_CIB_TAG_ALERTS) != 0)) {
+                    continue;
+                }
+            }
+
+            mainloop_set_trigger(attrd_config_read);
+            break;
+        }
+
+    } else {
+        crm_warn("Unknown patch format: %d", format);
+    }
+
+}
+
+GHashTable *
+get_meta_attrs_from_cib(xmlNode *basenode, crm_alert_entry_t *entry,
+                        guint *max_timeout)
+{
+    GHashTable *config_hash =
+        g_hash_table_new_full(crm_str_hash, g_str_equal,
+                              g_hash_destroy_str, g_hash_destroy_str);
+    crm_time_t *now = crm_time_new(NULL);
+    const char *value = NULL;
+
+    unpack_instance_attributes(basenode, basenode, XML_TAG_META_SETS, NULL,
+                               config_hash, NULL, FALSE, now);
+
+    value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_TIMEOUT);
+    if (value) {
+        entry->timeout = crm_get_msec(value);
+        if (entry->timeout <= 0) {
+            if (entry->timeout == 0) {
+                crm_trace("Setting timeout to default %dmsec",
+                          CRM_ALERT_DEFAULT_TIMEOUT_MS);
+            } else {
+                crm_warn("Invalid timeout value setting to default %dmsec",
+                         CRM_ALERT_DEFAULT_TIMEOUT_MS);
+            }
+            entry->timeout = CRM_ALERT_DEFAULT_TIMEOUT_MS;
+        } else {
+            crm_trace("Found timeout %dmsec", entry->timeout);
+        }
+        if (entry->timeout > *max_timeout) {
+            *max_timeout = entry->timeout;
+        }
+    }
+    value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_TSTAMP_FORMAT);
+    if (value) {
+        /* hard to do any checks here as merely anything can
+         * can be a valid time-format-string
+         */
+        entry->tstamp_format = (char *) value;
+        crm_trace("Found timestamp format string '%s'", value);
+    }
+
+    value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_SELECT_KIND);
+    if (value) {
+        entry->select_kind = (char *) value;
+        crm_trace("Found select_kind string '%s'", entry->select_kind);
+    }
+
+    value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_SELECT_ATTRIBUTE_NAME);
+    if (value) {
+        entry->select_attribute_name = (char *) value;
+        crm_trace("Found attribute_name string '%s'", entry->select_attribute_name);
+    }
+
+    crm_time_free(now);
+    return config_hash; /* keep hash as long as strings are needed */
+}
+
+void
+attrd_enable_alerts(const char *script, const char *target)
+{
+    free(notify_script);
+    notify_script = ((script) &&
+                     (strcmp(script,"/dev/null")))?strdup(script):NULL;
+
+    free(notify_target);
+    notify_target = (target != NULL)?strdup(target):NULL;
+}
+
+void 
+attrd_alert_fini()
+{
+    if (alert_info_cache) {
+        g_hash_table_destroy(alert_info_cache);
+        alert_info_cache = NULL;
+    }
+}
+
+static int 
+exec_alerts(lrmd_t *lrmd, const char *kind, lrmd_key_value_t * params, GListPtr alert_list, GHashTable *info_cache)
+{
+    int call_id = 0;
+    static int operations = 0;
+    GListPtr l;
+    crm_time_hr_t *now = crm_time_hr_new(NULL);
+    
+    params = crm_set_alert_key_to_lrmd_params(params, CRM_alert_kind, kind);
+    params = crm_set_alert_key_to_lrmd_params(params, CRM_alert_version, VERSION);
+
+    for (l = g_list_first(alert_list); l; l = g_list_next(l)) {
+        lrmd_rsc_info_t *rsc = NULL;
+        crm_alert_entry_t *entry = (crm_alert_entry_t *)(l->data);
+        char *timestamp = crm_time_format_hr(entry->tstamp_format, now);
+        lrmd_key_value_t * copy_params = NULL;
+        lrmd_key_value_t *head, *p;
+
+        crm_info("Sending '%s' alert to '%s' via '%s'", kind, entry->recipient, entry->path);
+
+        rsc = g_hash_table_lookup(alert_info_cache, entry->id);
+        if (rsc == NULL) {
+            rsc = lrmd->cmds->get_rsc_info(lrmd, entry->id, 0);
+            if (!rsc) {
+                lrmd->cmds->register_rsc(lrmd, entry->id, "alert",  "pacemaker", entry->path, lrmd_opt_drop_recurring);
+                rsc = lrmd->cmds->get_rsc_info(lrmd, entry->id, 0);
+                if (!rsc) {
+                    crm_err("Could not add alert %s : %s", entry->id, entry->path);
+                    return -1; 
+                }
+                /* cache the result */
+                g_hash_table_insert(alert_info_cache, entry->id, rsc);
+            }
+        }
+
+        /* Because there is a parameter to turn into every transmission, Copy a parameter. */
+        head = params;
+        while (head) {
+            p = head->next;
+            copy_params = lrmd_key_value_add(copy_params, head->key, head->value);
+            head = p;
+        }
+
+        operations++;
+
+        copy_params = lrmd_key_value_add(copy_params, CRM_ALERT_KEY_PATH, entry->path);
+        copy_params = crm_set_alert_key_to_lrmd_params(copy_params, CRM_alert_recipient, entry->recipient);
+        if (entry->select_kind != NULL) {
+            copy_params = crm_set_alert_key_to_lrmd_params(copy_params, CRM_alert_select_kind, entry->select_kind);
+        }
+        if (entry->select_attribute_name != NULL) {
+            copy_params = crm_set_alert_key_to_lrmd_params(copy_params, CRM_alert_select_attribute_name, entry->select_attribute_name);
+        }
+        copy_params = crm_set_alert_key_to_lrmd_params(copy_params, CRM_alert_node_sequence, crm_itoa(operations));
+        copy_params = crm_set_alert_key_to_lrmd_params(copy_params, CRM_alert_timestamp, timestamp);
+
+        crm_set_alert_envvar_to_lrmd_params(entry, copy_params);
+        
+        call_id = lrmd->cmds->exec_alert(lrmd, strdup(entry->id), entry->timeout, lrmd_opt_notify_orig_only, copy_params);
+        if (call_id <= 0) {
+            crm_err("Operation %s on %s failed: %d", "start", rsc->id, call_id);
+        } else {
+            crm_info("Operation %s on %s compete: %d", "start", rsc->id, call_id);
+        }
+
+        free(timestamp);
+    }
+
+    if (now) {
+        free(now);
+    }
+
+    return call_id;
+}
+
+static void
+free_alert_info(gpointer value)
+{
+    lrmd_rsc_info_t *rsc_info = value;
+
+    lrmd_free_rsc_info(rsc_info);
+}
+
+int 
+attrd_send_alerts(lrmd_t *lrmd, const char *node, uint32_t nodeid, const char *attribute_name, const char *attribute_value, GListPtr alert_list)
+{
+    int ret = pcmk_ok;
+    lrmd_key_value_t *params = NULL;
+
+    if (lrmd == NULL) {
+        crm_err("LRMD connection not active");
+        return 0;
+    }
+
+    if (alert_info_cache == NULL) {
+        alert_info_cache = g_hash_table_new_full(crm_str_hash,
+                                                g_str_equal, NULL, free_alert_info);
+    }
+   
+    params = crm_set_alert_key_to_lrmd_params(params, CRM_alert_node, node);
+    params = crm_set_alert_key_to_lrmd_params(params, CRM_alert_nodeid, crm_itoa(nodeid));
+    params = crm_set_alert_key_to_lrmd_params(params, CRM_alert_attribute_name, attribute_name);
+    params = crm_set_alert_key_to_lrmd_params(params, CRM_alert_attribute_value, attribute_value == NULL ? "null" : attribute_value);
+
+    ret = exec_alerts(lrmd, "attribute", params, alert_list, alert_info_cache); 
+    crm_trace("ret : %d, node : %s, nodeid: %s,  name: %s, value : %s", 
+                  ret, node, crm_itoa(nodeid), attribute_name, attribute_value); 
+
+    if (params) {
+        lrmd_key_value_freeall(params);
+    }
+
+    return ret;
+}
+
+void
+set_alert_attribute_value(GHashTable *t, attribute_value_t *v)
+{    attribute_value_t *a_v = NULL;
+    a_v = calloc(1, sizeof(attribute_value_t));
+    CRM_ASSERT(a_v != NULL);
+    a_v->nodeid = v->nodeid;
+    a_v->nodename = strdup(v->nodename);
+    if (v->current != NULL) {
+        a_v->current = strdup(v->current);
+    }
+    g_hash_table_replace(t, a_v->nodename, a_v);
+}
+
+void
+send_alert_attributes_value(attribute_t *a, GHashTable *t)
+{
+    int call_id = 0;
+    attribute_value_t *at = NULL;
+    GHashTableIter vIter;
+
+    g_hash_table_iter_init(&vIter, t);
+
+    while (g_hash_table_iter_next(&vIter, NULL, (gpointer *) & at)) {
+        call_id = attrd_send_alerts(the_lrmd, at->nodename, at->nodeid, a->id, at->current, crm_alert_list);
+        crm_trace("call_id : %d, nodename : %s, nodeid: %d,  name: %s, value : %s", 
+                  call_id, at->nodename, at->nodeid, a->id, at->current); 
+    }
+}

--- a/attrd/attrd_alerts.h
+++ b/attrd/attrd_alerts.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 Andrew Beekhof <andrew@beekhof.net>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef ATTRD_ALERT__H
+#  define ATTRD_ALERT__H
+
+#  include <crm/crm.h>
+#  include <crm/cluster.h>
+#  include <crm/common/alerts_internal.h>
+
+extern cib_t *the_cib;
+extern lrmd_t *the_lrmd;
+extern crm_trigger_t *attrd_config_read;
+
+lrmd_t *attrd_lrmd_connect(int max_retry, void callback(lrmd_event_data_t * op));
+gboolean attrd_read_options(gpointer user_data);
+void attrd_cib_updated_cb(const char *event, xmlNode * msg);
+GHashTable *get_meta_attrs_from_cib(xmlNode *basenode, crm_alert_entry_t *entry, guint *max_timeout);
+void attrd_enable_alerts(const char *script, const char *target);
+void attrd_alert_fini(void);
+int attrd_send_alerts(lrmd_t *lrmd, const char *node, uint32_t nodeid, const char *attribute_name, const char *attribute_value, GListPtr alert_list);
+void set_alert_attribute_value(GHashTable *t, attribute_value_t *v);
+void send_alert_attributes_value(attribute_t *a, GHashTable *t);
+#endif
+

--- a/attrd/attrd_common.h
+++ b/attrd/attrd_common.h
@@ -10,6 +10,32 @@
 
 #include <regex.h>
 
+typedef struct attribute_s {
+    char *uuid; /* TODO: Remove if at all possible */
+    char *id;
+    char *set;
+    GHashTable *values;
+    int update;
+    int timeout_ms;
+
+    /* TODO: refactor these three as a bitmask */
+    bool changed; /* whether attribute value has changed since last write */
+    bool unknown_peer_uuids; /* whether we know we're missing a peer uuid */
+    gboolean is_private; /* whether to keep this attribute out of the CIB */
+
+    mainloop_timer_t *timer;
+
+    char *user;
+
+} attribute_t;
+typedef struct attribute_value_s {
+        uint32_t nodeid;
+        gboolean is_remote;
+        char *nodename;
+        char *current;
+        char *requested;
+} attribute_value_t;
+
 void attrd_init_mainloop(void);
 void attrd_run_mainloop(void);
 gboolean attrd_mainloop_running(void);

--- a/attrd/legacy.c
+++ b/attrd/legacy.c
@@ -32,15 +32,19 @@
 #include <crm/crm.h>
 #include <crm/cib/internal.h>
 #include <crm/msg_xml.h>
+#include <crm/pengine/rules.h>
 #include <crm/common/ipc.h>
 #include <crm/common/ipcs.h>
 #include <crm/cluster/internal.h>
+#include <crm/common/alerts_internal.h>
 
 #include <crm/common/xml.h>
 
 #include <crm/attrd.h>
 
 #include <attrd_common.h>
+
+#include "attrd_alerts.h"
 
 #define OPTARGS	"hV"
 #if SUPPORT_HEARTBEAT
@@ -51,13 +55,15 @@ char *attrd_uname = NULL;
 char *attrd_uuid = NULL;
 
 GHashTable *attr_hash = NULL;
-cib_t *cib_conn = NULL;
+cib_t *the_cib = NULL;
+lrmd_t *the_lrmd = NULL;
+crm_trigger_t *attrd_config_read = NULL;
 
 /* Convenience macro for registering a CIB callback.
- * Check cib_conn != NULL before using.
+ * Check the_cib != NULL before using.
  */
 #define register_cib_callback(call_id, data, fn, free_fn) \
-    cib_conn->cmds->register_callback_full(cib_conn, call_id, 120, FALSE, \
+    the_cib->cmds->register_callback_full(the_cib, call_id, 120, FALSE, \
                                            data, #fn, fn, free_fn)
 
 typedef struct attr_hash_entry_s {
@@ -340,7 +346,7 @@ remote_clear_failure(xmlNode *xml)
     int rc = pcmk_ok;
     char *xpath;
 
-    if (cib_conn == NULL) {
+    if (the_cib == NULL) {
         crm_info("Ignoring request to clear %s on %s because not connected to CIB",
                  (rsc? rsc : "all resources"),
                  (host? host: "all remote nodes"));
@@ -388,7 +394,7 @@ remote_clear_failure(xmlNode *xml)
     }
 
     crm_trace("Clearing attributes matching %s", xpath);
-    rc = cib_conn->cmds->delete(cib_conn, xpath, NULL, cib_xpath|cib_multiple);
+    rc = the_cib->cmds->delete(the_cib, xpath, NULL, cib_xpath|cib_multiple);
     register_cib_callback(rc, xpath, remote_clear_callback, free);
 }
 
@@ -599,6 +605,17 @@ cib_connect(void *user_data)
             crm_err("Could not set CIB notification callback");
             was_err = TRUE;
         }
+        if (was_err == FALSE) {
+            if (pcmk_ok != local_conn->cmds->add_notify_callback(local_conn, T_CIB_DIFF_NOTIFY, attrd_cib_updated_cb)) {
+                crm_err("Could not set CIB notification callback (update)");
+                was_err = TRUE;
+            }
+
+        }
+        attrd_config_read = mainloop_add_trigger(G_PRIORITY_HIGH, attrd_read_options, NULL);
+
+        /* Reading of cib(Alert section) after the start */
+        mainloop_set_trigger(attrd_config_read);
     }
 
     if (was_err) {
@@ -606,12 +623,45 @@ cib_connect(void *user_data)
         crm_exit(DAEMON_RESPAWN_STOP);
     }
 
-    cib_conn = local_conn;
+    the_cib = local_conn;
 
     crm_info("Sending full refresh now that we're connected to the cib");
     g_hash_table_foreach(attr_hash, local_update_for_hash_entry, NULL);
 
     return FALSE;
+}
+
+static void
+lrm_op_callback(lrmd_event_data_t * op)
+{
+    const char *nodename = NULL;
+
+    CRM_CHECK(op != NULL, return);
+
+    nodename = op->remote_nodename ? op->remote_nodename : attrd_uname;
+
+    if (op->type == lrmd_event_disconnect && (safe_str_eq(nodename, attrd_uname))) {
+        crm_err("Lost connection to LRMD service!");
+        attrd_shutdown(0);
+        return;
+    } else if (op->type != lrmd_event_exec_complete) {
+        return;
+    }
+
+
+    if (op->params != NULL) {
+        void *value_tmp1, *value_tmp2;
+
+        value_tmp1 = g_hash_table_lookup(op->params, "CRM_alert_path");
+        if (value_tmp1 != NULL) {
+            value_tmp2 = g_hash_table_lookup(op->params, "CRM_alert_node_sequence");
+            if(op->rc == 0) {
+                crm_notice("Alert %s (%s) complete", value_tmp2, value_tmp1);
+            } else {
+                crm_notice("Alert %s (%s) failed: %d", value_tmp2, value_tmp1, op->rc);
+            }
+        }
+    }
 }
 
 int
@@ -703,6 +753,13 @@ main(int argc, char **argv)
         return 100;
     }
 
+    the_lrmd = attrd_lrmd_connect(10, lrm_op_callback);
+    if (the_lrmd == NULL) {
+        crm_err("Aborting startup.(LRMD connect)");
+        return 100;
+    } 
+    crm_notice("LRMD connection active");
+
     crm_notice("Starting mainloop...");
     attrd_run_mainloop();
     crm_notice("Exiting...");
@@ -728,9 +785,15 @@ main(int argc, char **argv)
 
     qb_ipcs_destroy(ipcs);
 
-    if (cib_conn) {
-        cib_conn->cmds->signoff(cib_conn);
-        cib_delete(cib_conn);
+    if (the_lrmd) {
+        the_lrmd->cmds->disconnect(the_lrmd);
+        lrmd_api_delete(the_lrmd);
+        the_lrmd = NULL;
+    }
+
+    if (the_cib) {
+        the_cib->cmds->signoff(the_cib);
+        cib_delete(the_cib);
     }
 
     g_hash_table_destroy(attr_hash);
@@ -809,7 +872,7 @@ attrd_perform_update(attr_hash_entry_t * hash_entry)
     if (hash_entry == NULL) {
         return;
 
-    } else if (cib_conn == NULL) {
+    } else if (the_cib == NULL) {
         crm_info("Delaying operation %s=%s: cib not connected", hash_entry->id,
                  crm_str(hash_entry->value));
         return;
@@ -824,7 +887,7 @@ attrd_perform_update(attr_hash_entry_t * hash_entry)
 
     if (hash_entry->value == NULL) {
         /* delete the attr */
-        rc = delete_attr_delegate(cib_conn, cib_none, hash_entry->section, attrd_uuid, NULL,
+        rc = delete_attr_delegate(the_cib, cib_none, hash_entry->section, attrd_uuid, NULL,
                                   hash_entry->set, hash_entry->uuid, hash_entry->id, NULL, FALSE,
                                   user_name);
 
@@ -846,10 +909,11 @@ attrd_perform_update(attr_hash_entry_t * hash_entry)
                       hash_entry->uuid ? hash_entry->uuid : "<n/a>", hash_entry->set,
                       hash_entry->section);
         }
+        attrd_send_alerts(the_lrmd, attrd_uname, attrd_uuid, hash_entry->id, hash_entry->value, crm_alert_list);
 
     } else {
         /* send update */
-        rc = update_attr_delegate(cib_conn, cib_none, hash_entry->section,
+        rc = update_attr_delegate(the_cib, cib_none, hash_entry->section,
                                   attrd_uuid, NULL, hash_entry->set, hash_entry->uuid,
                                   hash_entry->id, hash_entry->value, FALSE, user_name, NULL);
         if (rc < 0) {
@@ -861,6 +925,7 @@ attrd_perform_update(attr_hash_entry_t * hash_entry)
         } else {
             crm_trace("Sent update %d: %s=%s", rc, hash_entry->id, hash_entry->value);
         }
+        attrd_send_alerts(the_lrmd, attrd_uname, attrd_uuid, hash_entry->id, hash_entry->value, crm_alert_list);
     }
 
     data = calloc(1, sizeof(struct attrd_callback_s));
@@ -1006,7 +1071,7 @@ update_remote_attr(const char *host, const char *name, const char *value,
 
     if (name == NULL) {
         rc = -EINVAL;
-    } else if (cib_conn == NULL) {
+    } else if (the_cib == NULL) {
         rc = -ENOTCONN;
     }
     if (rc != pcmk_ok) {
@@ -1016,14 +1081,17 @@ update_remote_attr(const char *host, const char *name, const char *value,
     }
 
     if (value == NULL) {
-        rc = delete_attr_delegate(cib_conn, cib_none, section,
+        rc = delete_attr_delegate(the_cib, cib_none, section,
                                   host, NULL, NULL, NULL, name, NULL,
                                   FALSE, user_name);
     } else {
-        rc = update_attr_delegate(cib_conn, cib_none, section,
+        rc = update_attr_delegate(the_cib, cib_none, section,
                                   host, NULL, NULL, NULL, name, value,
                                   FALSE, user_name, "remote");
     }
+
+    attrd_send_alerts(the_lrmd, host, 0, name, value == NULL? "null":value, crm_alert_list);
+
     crm_trace("%s submitted as CIB call %d", desc, rc);
     register_cib_callback(rc, desc, remote_attr_callback, free);
 }

--- a/attrd/legacy.c
+++ b/attrd/legacy.c
@@ -53,6 +53,7 @@ ll_cluster_t *attrd_cluster_conn;
 
 char *attrd_uname = NULL;
 char *attrd_uuid = NULL;
+uint32_t attrd_nodeid = 0;
 
 GHashTable *attr_hash = NULL;
 cib_t *the_cib = NULL;
@@ -728,6 +729,7 @@ main(int argc, char **argv)
 
         attrd_uname = cluster.uname;
         attrd_uuid = cluster.uuid;
+        attrd_nodeid = cluster.nodeid;
 #if SUPPORT_HEARTBEAT
         attrd_cluster_conn = cluster.hb_conn;
 #endif
@@ -909,7 +911,7 @@ attrd_perform_update(attr_hash_entry_t * hash_entry)
                       hash_entry->uuid ? hash_entry->uuid : "<n/a>", hash_entry->set,
                       hash_entry->section);
         }
-        attrd_send_alerts(the_lrmd, attrd_uname, attrd_uuid, hash_entry->id, hash_entry->value, crm_alert_list);
+        attrd_send_alerts(the_lrmd, attrd_uname, attrd_nodeid, hash_entry->id, hash_entry->value, crm_alert_list);
 
     } else {
         /* send update */
@@ -925,7 +927,7 @@ attrd_perform_update(attr_hash_entry_t * hash_entry)
         } else {
             crm_trace("Sent update %d: %s=%s", rc, hash_entry->id, hash_entry->value);
         }
-        attrd_send_alerts(the_lrmd, attrd_uname, attrd_uuid, hash_entry->id, hash_entry->value, crm_alert_list);
+        attrd_send_alerts(the_lrmd, attrd_uname, attrd_nodeid, hash_entry->id, hash_entry->value, crm_alert_list);
     }
 
     data = calloc(1, sizeof(struct attrd_callback_s));

--- a/extra/PCMK-MIB.txt
+++ b/extra/PCMK-MIB.txt
@@ -14,12 +14,15 @@ IMPORTS
 ;
 
 pacemaker MODULE-IDENTITY
-    LAST-UPDATED "201601052100Z"
+    LAST-UPDATED "201703242100Z"
     ORGANIZATION "www.clusterlabs.org"
     CONTACT-INFO    
         "name:  Andrew Beekhof
         email:  users@clusterlabs.org"
     DESCRIPTION "MIB objects for the Pacemaker cluster manager implementation"
+
+    REVISION    "201703242100Z"
+    DESCRIPTION "Add pacemakerNotificationAttributeName and pacemakerNotificationAttributeValue"
 
     REVISION    "201601052100Z"
     DESCRIPTION "Add pacemakerTrap and pacemakerNotificationTrap"
@@ -98,6 +101,22 @@ pacemakerNotificationTargetReturnCode OBJECT-TYPE
         "The expected return code of the operation."
 ::= { pacemakerNotification 7 }
 
+pacemakerNotificationAttributeName OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(1..256))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name of the attribute."
+::= { pacemakerNotification 8 }
+
+pacemakerNotificationAttributeValue OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(1..256))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name of the attribute."
+::= { pacemakerNotification 9 }
+
 --
 --  pacemaker Traps
 --
@@ -110,7 +129,9 @@ pacemakerNotificationTrap NOTIFICATION-TYPE
         pacemakerNotificationDescription,
         pacemakerNotificationStatus,
         pacemakerNotificationReturnCode,
-        pacemakerNotificationTargetReturnCode
+        pacemakerNotificationTargetReturnCode,
+        pacemakerNotificationAttributeName,
+        pacemakerNotificationAttributeValue
     }
     STATUS      current
     DESCRIPTION

--- a/extra/alerts/alert_file.sh.sample
+++ b/extra/alerts/alert_file.sh.sample
@@ -50,11 +50,16 @@ if [ -z "${CRM_alert_recipient}" ]; then
 fi
 
 debug_exec_order_default="false"
+select_kind_default="node,fencing,resource"
+select_attribute_name_default="all"
 
 # Pacemaker passes instance attributes to alert agents as environment variables.
 # It is completely up to the agent what instance attributes to support.
 # Here, we define an instance attribute "debug_exec_order".
 : ${debug_exec_order=${debug_exec_order_default}}
+
+: ${CRM_alert_select_kind=${select_kind_default}}
+: ${CRM_alert_select_attribute_name=${select_attribute_name_default}}
 
 if [ "${debug_exec_order}" = "true" ]; then
     tstamp=`printf "%04d. " "$CRM_alert_node_sequence"`
@@ -66,6 +71,25 @@ else
         tstamp="$CRM_alert_timestamp: "
     fi
 fi
+
+is_in_list() {
+    item_list=`echo "$1" | tr ',' ' '`
+    if [ "${item_list}" = "all" ]; then
+        return 0
+    else
+        for act in $item_list
+        do
+            if [ -z "$3" ]; then
+                act=`echo "$act" | tr A-Z a-z`
+            fi
+            [ "$act" != "$2" ] && continue
+            return 0
+        done
+    fi
+    return 1
+}
+is_in_list "${CRM_alert_select_kind}" "${CRM_alert_kind}"
+[ $? -ne 0 ] && exit 0
 
 case $CRM_alert_kind in
     node)
@@ -106,6 +130,14 @@ case $CRM_alert_kind in
                 ;;
         esac
         ;;
+    attribute)
+        #
+        is_in_list "${CRM_alert_select_attribute_name}" "${CRM_alert_attribute_name}" "no-list-tr"
+        [ $? -ne 0 ] && exit 0
+        #
+        echo "${tstamp}The '${CRM_alert_attribute_name}' attribute of the '${CRM_alert_node}' node was updated in '${CRM_alert_attribute_value}'" >> "${CRM_alert_recipient}"
+        ;;
+
     *)
         echo "${tstamp}Unhandled $CRM_alert_kind alert" >> "${CRM_alert_recipient}"
         env | grep CRM_alert >> "${CRM_alert_recipient}"

--- a/extra/alerts/alert_smtp.sh.sample
+++ b/extra/alerts/alert_smtp.sh.sample
@@ -36,14 +36,35 @@
 email_client_default="sendmail"
 email_sender_default="hacluster"
 email_recipient_default="root"
+select_kind_default="node,fencing,resource"
+select_attribute_name_default="all"
 
 : ${email_client=${email_client_default}}
 : ${email_sender=${email_sender_default}}
+: ${CRM_alert_select_kind=${select_kind_default}}
+: ${CRM_alert_select_attribute_name=${select_attribute_name_default}}
 email_recipient="${CRM_alert_recipient-${email_recipient_default}}"
 
 node_name=`uname -n`
 cluster_name=`crm_attribute --query -n cluster-name -q`
 email_body=`env | grep CRM_alert_`
+
+is_in_list() {
+    item_list=`echo "$1" | tr ',' ' '`
+    if [ "${item_list}" = "all" ]; then
+        return 0
+    else
+        for act in $item_list
+        do
+            if [ -z "$3" ]; then
+                act=`echo "$act" | tr A-Z a-z`
+            fi
+            [ "$act" != "$2" ] && continue
+            return 0
+        done
+    fi
+    return 1
+}
 
 if [ ! -z "${email_sender##*@*}" ]; then
     email_sender="${email_sender}@${node_name}"
@@ -56,6 +77,9 @@ fi
 if [ -z ${CRM_alert_version} ]; then
     email_subject="Pacemaker version 1.1.15 or later is required for alerts"
 else
+    is_in_list "${CRM_alert_select_kind}" "${CRM_alert_kind}"
+    [ $? -ne 0 ] && exit 0
+
     case ${CRM_alert_kind} in
         node)
             email_subject="${CRM_alert_timestamp} ${cluster_name}: Node '${CRM_alert_node}' is now '${CRM_alert_desc}'"
@@ -82,6 +106,13 @@ else
                     email_subject="${CRM_alert_timestamp} ${cluster_name}: Resource operation '${CRM_alert_task}${CRM_alert_interval}' for '${CRM_alert_rsc}' on '${CRM_alert_node}': ${CRM_alert_desc}${CRM_alert_target_rc}"
                     ;;
             esac
+            ;;
+        attribute)
+            #
+            is_in_list "${CRM_alert_select_attribute_name}" "${CRM_alert_attribute_name}" "no-list-tr"
+            [ $? -ne 0 ] && exit 0
+            #
+            email_subject="${CRM_alert_timestamp} ${cluster_name}: The '${CRM_alert_attribute_name}' attribute of the '${CRM_alert_node}' node was updated in '${CRM_alert_attribute_value}'"
             ;;
         *)
             email_subject="${CRM_alert_timestamp} ${cluster_name}: Unhandled $CRM_alert_kind alert"

--- a/extra/alerts/alert_snmp.sh.sample
+++ b/extra/alerts/alert_snmp.sh.sample
@@ -57,10 +57,12 @@ trap_binary_default="/usr/bin/snmptrap"
 trap_version_default="2c"
 trap_options_default=""
 trap_community_default="public"
+trap_select_kind_default="node,fencing,resource"
 trap_node_states_default="all"
 trap_fencing_tasks_default="all"
 trap_resource_tasks_default="all"
 trap_monitor_success_default="false"
+trap_select_attribute_name_default="all"
 trap_add_hires_timestamp_oid_default="true"
 trap_snmp_persistent_dir_default="/var/lib/pacemaker/snmp"
 
@@ -68,10 +70,12 @@ trap_snmp_persistent_dir_default="/var/lib/pacemaker/snmp"
 : ${trap_version=${trap_version_default}}
 : ${trap_options=${trap_options_default}}
 : ${trap_community=${trap_community_default}}
+: ${CRM_alert_select_kind=${trap_select_kind_default}}
 : ${trap_node_states=${trap_node_states_default}}
 : ${trap_fencing_tasks=${trap_fencing_tasks_default}}
 : ${trap_resource_tasks=${trap_resource_tasks_default}}
 : ${trap_monitor_success=${trap_monitor_success_default}}
+: ${CRM_alert_select_attribute_name=${trap_select_attribute_name_default}}
 : ${trap_add_hires_timestamp_oid=${trap_add_hires_timestamp_oid_default}}
 : ${trap_snmp_persistent_dir=${trap_snmp_persistent_dir_default}}
 
@@ -87,7 +91,9 @@ is_in_list() {
     else
         for act in $item_list
         do
-            act=`echo "$act" | tr A-Z a-z`
+            if [ -z "$3" ]; then
+                act=`echo "$act" | tr A-Z a-z`
+            fi
             [ "$act" != "$2" ] && continue
             return 0
         done
@@ -102,6 +108,9 @@ if [ -z ${SNMP_PERSISTENT_DIR} ]; then
         mkdir -p ${SNMP_PERSISTENT_DIR}
     fi
 fi
+
+is_in_list "${CRM_alert_select_kind}" "${CRM_alert_kind}"
+[ $? -ne 0 ] && exit 0
 
 rc=0
 case "$CRM_alert_kind" in
@@ -158,6 +167,19 @@ case "$CRM_alert_kind" in
             rc=$?
             ;;
         esac
+        ;;
+    attribute)
+        is_in_list "${CRM_alert_select_attribute_name}" "${CRM_alert_attribute_name}" "no-list-tr"
+        [ $? -ne 0 ] && exit 0
+
+        output=`"${trap_binary}" -v "${trap_version}" ${trap_options} \
+        -c "${trap_community}" "${CRM_alert_recipient}" "" \
+        PACEMAKER-MIB::pacemakerNotificationTrap \
+        PACEMAKER-MIB::pacemakerNotificationNode s "${CRM_alert_node}" \
+        PACEMAKER-MIB::pacemakerNotificationAttributeName s "${CRM_alert_attribute_name}" \
+        PACEMAKER-MIB::pacemakerNotificationAttributeValue s "${CRM_alert_attribute_value}" \
+        ${hires_timestamp} 2>&1`
+        rc=$?
         ;;
     *)
         ;;

--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -30,6 +30,8 @@ typedef struct {
     int timeout;
     char *tstamp_format;
     char *recipient;
+    char *select_kind;
+    char *select_attribute_name;
     GListPtr envvars;
 } crm_alert_entry_t;
 
@@ -47,12 +49,19 @@ enum crm_alert_keys_e {
     CRM_alert_kind,
     CRM_alert_version,
     CRM_alert_node_sequence,
-    CRM_alert_timestamp
+    CRM_alert_timestamp,
+    CRM_alert_attribute_name,
+    CRM_alert_attribute_value,
+    CRM_alert_select_kind,
+    CRM_alert_select_attribute_name
 };
+
+#define CRM_ALERT_INTERNAL_KEY_MAX 18
+#define CRM_ALERT_KEY_PATH "CRM_alert_path"
 
 extern GListPtr crm_alert_list;
 extern guint crm_alert_max_alert_timeout;
-extern const char *crm_alert_keys[14][3];
+extern const char *crm_alert_keys[CRM_ALERT_INTERNAL_KEY_MAX][3];
 
 void crm_free_alert_list(void);
 GListPtr crm_drop_envvars(crm_alert_entry_t *entry, int count);
@@ -63,4 +72,7 @@ void crm_set_alert_key_int(enum crm_alert_keys_e name, int value);
 void crm_unset_alert_keys(void);
 void crm_set_envvar_list(crm_alert_entry_t *entry);
 void crm_unset_envvar_list(crm_alert_entry_t *entry);
+lrmd_key_value_t * crm_set_alert_key_to_lrmd_params(lrmd_key_value_t *head, enum crm_alert_keys_e name, const char *value);
+void crm_set_alert_envvar_to_lrmd_params(crm_alert_entry_t *entry, lrmd_key_value_t * params);
+
 #endif

--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -91,6 +91,7 @@ typedef struct lrmd_key_value_s {
 #define LRMD_OP_POKE              "lrmd_rsc_poke"
 #define LRMD_OP_NEW_CLIENT        "lrmd_rsc_new_client"
 #define LRMD_OP_CHECK             "lrmd_check"
+#define LRMD_OP_ALERT_EXEC        "lrmd_alert_exec"
 
 #define LRMD_IPC_OP_NEW           "new"
 #define LRMD_IPC_OP_DESTROY       "destroy"
@@ -374,6 +375,25 @@ typedef struct lrmd_api_operations_s {
                  int interval,  /* ms */
                  int timeout,   /* ms */
                  int start_delay,       /* ms */
+                 enum lrmd_call_options options, lrmd_key_value_t * params);    /* ownership of params is given up to api here */
+
+    /*!
+     * \brief Issue a command on a alert
+     *
+     * \note Asynchronous, command is queued in daemon on function return, but
+     *       execution of command is not synced.
+     *
+     * \note Operations on individual alerts are guaranteed to occur
+     *       in the order the client api calls them in.
+     *
+     * \note Operations between different alerts are not guaranteed
+     *       to occur in any specific order in relation to one another
+     *       regardless of what order the client api is called in.
+     * \retval call_id to track async event result on success
+     * \retval negative error code on failure
+     */
+    int (*exec_alert) (lrmd_t * lrmd, const char *alert_id,
+                 int timeout,   /* ms */
                  enum lrmd_call_options options, lrmd_key_value_t * params);    /* ownership of params is given up to api here */
 
     /*!

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -362,6 +362,8 @@
 #  define XML_ALERT_ATTR_TIMEOUT	"timeout"
 #  define XML_ALERT_ATTR_TSTAMP_FORMAT	"timestamp-format"
 #  define XML_ALERT_ATTR_REC_VALUE	"value"
+#  define XML_ALERT_ATTR_SELECT_KIND	"kind"
+#  define XML_ALERT_ATTR_SELECT_ATTRIBUTE_NAME	"attribute_name"
 
 #  define XML_CIB_TAG_GENERATION_TUPPLE	"generation_tuple"
 

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -2029,6 +2029,32 @@ lrmd_api_exec(lrmd_t * lrmd, const char *rsc_id, const char *action, const char 
 }
 
 static int
+lrmd_api_exec_alert(lrmd_t * lrmd, const char *alert_id,
+              int timeout,      /* ms */
+              enum lrmd_call_options options, lrmd_key_value_t * params)
+{
+    int rc = pcmk_ok;
+    xmlNode *data = create_xml_node(NULL, F_LRMD_RSC);
+    xmlNode *args = create_xml_node(data, XML_TAG_ATTRS);
+    lrmd_key_value_t *tmp = NULL;
+
+    crm_xml_add(data, F_LRMD_ORIGIN, __FUNCTION__);
+    crm_xml_add(data, F_LRMD_RSC_ID, alert_id);
+    crm_xml_add(data, F_LRMD_RSC_ACTION, "start");
+    crm_xml_add_int(data, F_LRMD_TIMEOUT, timeout);
+
+    for (tmp = params; tmp; tmp = tmp->next) {
+        hash2smartfield((gpointer) tmp->key, (gpointer) tmp->value, args);
+    }
+
+    rc = lrmd_send_command(lrmd, LRMD_OP_ALERT_EXEC, data, NULL, timeout, options, TRUE);
+    free_xml(data);
+
+    lrmd_key_value_freeall(params);
+    return rc;
+}
+
+static int
 lrmd_api_cancel(lrmd_t * lrmd, const char *rsc_id, const char *action, int interval)
 {
     int rc = pcmk_ok;
@@ -2187,6 +2213,7 @@ lrmd_api_new(void)
     new_lrmd->cmds->set_callback = lrmd_api_set_callback;
     new_lrmd->cmds->get_metadata = lrmd_api_get_metadata;
     new_lrmd->cmds->exec = lrmd_api_exec;
+    new_lrmd->cmds->exec_alert = lrmd_api_exec_alert;
     new_lrmd->cmds->cancel = lrmd_api_cancel;
     new_lrmd->cmds->list_agents = lrmd_api_list_agents;
     new_lrmd->cmds->list_ocf_providers = lrmd_api_list_ocf_providers;

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -175,6 +175,24 @@ set_ocf_env_with_prefix(gpointer key, gpointer value, gpointer user_data)
 }
 
 static void
+set_alert_env(gpointer key, gpointer value, gpointer user_data)
+{
+    set_ocf_env((char*)key, value, user_data);
+}
+
+static void
+add_alert_env_vars(svc_action_t * op)
+{
+    if (!op->standard || strcasecmp("event", op->standard) != 0) {
+        return;
+    }
+
+    if (op->params) {
+        g_hash_table_foreach(op->params, set_alert_env, NULL);
+    }
+}
+
+static void
 add_OCF_env_vars(svc_action_t * op)
 {
     if ((op->standard == NULL)
@@ -434,6 +452,9 @@ action_launch_child(svc_action_t *op)
 #endif
     /* Setup environment correctly */
     add_OCF_env_vars(op);
+
+    /* Setup environment correctly for Alert */
+    add_alert_env_vars(op);
 
     /* execute the RA */
     execvp(op->opaque->exec, op->opaque->args);


### PR DESCRIPTION
Hi All,

I added the alert function of the attribute.
I add two meta attributes to alert setting newly.

 - kind
 - attribute_name

```
(snip)
alert notify_9 /usr/share/pacemaker/alerts/alert_snmp.sh \
        meta \
        kind="resource,attribute" \
        attribute_name="default_ping_set" \
        attributes \
        trap_resource_tasks="start,stop,monitor,promote,demote" \
        trap_add_hires_timestamp_oid="false" \
        to "192.168.xx.xxx"
(snip)
```

The kind appoints alert to handle.
For the compatibility with the former version, the default becomes "node,fencing,resource".
The alert function of the attribute that is new by appointing "attribute" becomes effective for kind.

The attribute_name appoints the attribute that alert does.
The attribute_name divides it with a comma and can appoint a plural number.
When a user does not appoint attribute_name, many attributes require attention because it is done alert.

The script of the sample of the alert function is changed, too.
When a user has already carried out a sample script, it is necessary to replace it with a new script.

When attrd writes in an attribute, alert of the attribute is transmitted.
Thus, the attribute that has been written may be transmitted many times.

For a future change, the alert function of the attribute carries out a script via lrmd.

Best Regards,
Hideo Yamauchi.