### PR TITLE
Calculate throttle thresholds better

### DIFF
--- a/crmd/control.c
+++ b/crmd/control.c
@@ -1046,14 +1046,14 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 
     value = crmd_pref(config_hash, "load-threshold");
     if(value) {
-        throttle_load_target = strtof(value, NULL) / 100;
+        throttle_set_load_target(strtof(value, NULL) / 100.0);
     }
 
     value = crmd_pref(config_hash, "no-quorum-policy");
     if (safe_str_eq(value, "suicide") && pcmk_locate_sbd()) {
         no_quorum_suicide_escalation = TRUE;
     }
-    
+
     value = crmd_pref(config_hash,"stonith-max-attempts");
     update_stonith_max_attempts(value);
 

--- a/crmd/throttle.c
+++ b/crmd/throttle.c
@@ -33,8 +33,7 @@
 #include <throttle.h>
 
 
-enum throttle_state_e 
-{
+enum throttle_state_e {
     throttle_extreme = 0x1000,
     throttle_high = 0x0100,
     throttle_med  = 0x0010,
@@ -42,24 +41,24 @@ enum throttle_state_e
     throttle_none = 0x0000,
 };
 
-struct throttle_record_s 
-{
-        int max;
-        enum throttle_state_e mode;
-        char *node;
+struct throttle_record_s {
+    int max;
+    enum throttle_state_e mode;
+    char *node;
 };
 
-int throttle_job_max = 0;
-float throttle_load_target = 0.0;
+static int throttle_job_max = 0;
+static float throttle_load_target = 0.0;
 
 #define THROTTLE_FACTOR_LOW    1.2
 #define THROTTLE_FACTOR_MEDIUM 1.6
 #define THROTTLE_FACTOR_HIGH   2.0
 
-GHashTable *throttle_records = NULL;
-mainloop_timer_t *throttle_timer = NULL;
+static GHashTable *throttle_records = NULL;
+static mainloop_timer_t *throttle_timer = NULL;
 
-int throttle_num_cores(void)
+static int
+throttle_num_cores(void)
 {
     static int cores = 0;
     char buffer[256];
@@ -102,14 +101,16 @@ int throttle_num_cores(void)
  *       This will return NULL if the daemon is being run via valgrind.
  *       This should be called only on Linux systems.
  */
-static char *find_cib_loadfile(void) 
+static char *
+find_cib_loadfile(void)
 {
     int pid = crm_procfs_pid_of("cib");
 
     return pid? crm_strdup_printf("/proc/%d/stat", pid) : NULL;
 }
 
-static bool throttle_cib_load(float *load) 
+static bool
+throttle_cib_load(float *load)
 {
 /*
        /proc/[pid]/stat
@@ -233,7 +234,8 @@ static bool throttle_cib_load(float *load)
     return FALSE;
 }
 
-static bool throttle_load_avg(float *load)
+static bool
+throttle_load_avg(float *load)
 {
     char buffer[256];
     FILE *stream = NULL;
@@ -266,7 +268,8 @@ static bool throttle_load_avg(float *load)
     return FALSE;
 }
 
-static bool throttle_io_load(float *load, unsigned int *blocked)
+static bool
+throttle_io_load(float *load, unsigned int *blocked)
 {
     char buffer[64*1024];
     FILE *stream = NULL;
@@ -514,7 +517,13 @@ throttle_record_free(gpointer p)
 }
 
 void
-throttle_update_job_max(const char *preference) 
+throttle_set_load_target(float target)
+{
+    throttle_load_target = target;
+}
+
+void
+throttle_update_job_max(const char *preference)
 {
     int max = 0;
 
@@ -547,7 +556,6 @@ throttle_update_job_max(const char *preference)
     }
 }
 
-
 void
 throttle_init(void)
 {
@@ -567,7 +575,6 @@ throttle_fini(void)
     mainloop_timer_del(throttle_timer); throttle_timer = NULL;
     g_hash_table_destroy(throttle_records); throttle_records = NULL;
 }
-
 
 int
 throttle_get_total_job_limit(int l)
@@ -673,4 +680,3 @@ throttle_update(xmlNode *xml)
     crm_debug("Host %s supports a maximum of %d jobs and throttle mode %.4x.  New job limit is %d",
               from, max, mode, throttle_get_job_limit(from));
 }
-

--- a/crmd/throttle.c
+++ b/crmd/throttle.c
@@ -268,88 +268,6 @@ throttle_load_avg(float *load)
     return FALSE;
 }
 
-static bool
-throttle_io_load(float *load, unsigned int *blocked)
-{
-    char buffer[64*1024];
-    FILE *stream = NULL;
-    const char *loadfile = "/proc/stat";
-
-    if(load == NULL) {
-        return FALSE;
-    }
-
-    stream = fopen(loadfile, "r");
-    if(stream == NULL) {
-        int rc = errno;
-        crm_warn("Couldn't read %s: %s (%d)", loadfile, pcmk_strerror(rc), rc);
-        return FALSE;
-    }
-
-    if(fgets(buffer, sizeof(buffer), stream)) {
-        /* Borrowed from procps-ng's sysinfo.c */
-
-        char *b = NULL;
-        unsigned long long cpu_use = 0;
-        unsigned long long cpu_nic = 0;
-        unsigned long long cpu_sys = 0;
-        unsigned long long cpu_idl = 0;
-        unsigned long long cpu_iow = 0; /* not separated out until the 2.5.41 kernel */
-        unsigned long long cpu_xxx = 0; /* not separated out until the 2.6.0-test4 kernel */
-        unsigned long long cpu_yyy = 0; /* not separated out until the 2.6.0-test4 kernel */
-        unsigned long long cpu_zzz = 0; /* not separated out until the 2.6.11 kernel */
-
-        long long divo2 = 0;
-        long long duse = 0;
-        long long dsys = 0;
-        long long didl =0;
-        long long diow =0;
-        long long dstl = 0;
-        long long Div = 0;
-
-        b = strstr(buffer, "cpu ");
-        if(b) sscanf(b,  "cpu  %Lu %Lu %Lu %Lu %Lu %Lu %Lu %Lu",
-               &cpu_use, &cpu_nic, &cpu_sys, &cpu_idl, &cpu_iow, &cpu_xxx, &cpu_yyy, &cpu_zzz);
-
-        if(blocked) {
-            b = strstr(buffer, "procs_blocked ");
-            if(b) sscanf(b,  "procs_blocked %u", blocked);
-        }
-
-        duse = cpu_use + cpu_nic;
-        dsys = cpu_sys + cpu_xxx + cpu_yyy;
-        didl = cpu_idl;
-        diow = cpu_iow;
-        dstl = cpu_zzz;
-        Div = duse + dsys + didl + diow + dstl;
-        if (!Div) Div = 1, didl = 1;
-        divo2 = Div / 2UL;
-
-        /* vmstat output:
-         *
-         * procs -----------memory---------- ---swap-- -----io---- -system-- ----cpu---- 
-         * r  b   swpd   free   buff  cache     si   so    bi    bo   in   cs us sy id wa
-         * 1  0 5537800 958592 204180 1737740    1    1    12    15    0    0  2  1 97  0
-         *
-         * The last four columns are calculated as:
-         *
-         * (unsigned)( (100*duse			+ divo2) / Div ),
-         * (unsigned)( (100*dsys			+ divo2) / Div ),
-         * (unsigned)( (100*didl			+ divo2) / Div ),
-         * (unsigned)( (100*diow			+ divo2) / Div )
-         *
-         */
-        *load = (diow + divo2) / Div;
-        crm_debug("Current IO load is %f", *load);
-
-        fclose(stream);
-        return TRUE;
-    }
-
-    fclose(stream);
-    return FALSE;
-}
-
 /*!
  * \internal
  * \brief Check a load value against throttling thresholds
@@ -412,7 +330,6 @@ throttle_mode(void)
     int cores;
     float load;
     float thresholds[4];
-    unsigned int blocked = 0;
     enum throttle_state_e mode = throttle_none;
 
 #if defined(ON_BSD) || defined(ON_SOLARIS)
@@ -457,11 +374,6 @@ throttle_mode(void)
 
     if(throttle_load_avg(&load)) {
         mode |= throttle_handle_load(load, "CPU load", cores);
-    }
-
-    if(throttle_io_load(&load, &blocked)) {
-        mode |= throttle_handle_load(load, "IO load", 0);
-        mode |= throttle_handle_load(blocked, "blocked IO ratio", cores);
     }
 
     if(mode & throttle_extreme) {

--- a/crmd/throttle.h
+++ b/crmd/throttle.h
@@ -17,12 +17,10 @@
  */
 
 
-extern float throttle_load_target;
-
 void throttle_init(void);
 void throttle_fini(void);
 
-int throttle_num_cores(void);
+void throttle_set_load_target(float target);
 void throttle_update(xmlNode *xml);
 void throttle_update_job_max(const char *preference);
 int throttle_get_job_limit(const char *node);

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -54,6 +54,7 @@ int crm_write_sync(int fd, const char *contents);
 
 int crm_procfs_process_info(struct dirent *entry, char *name, int *pid);
 int crm_procfs_pid_of(const char *name);
+unsigned int crm_procfs_num_cores(void);
 
 
 /* internal XML schema functions (from xml.c) */

--- a/lib/common/procfs.c
+++ b/lib/common/procfs.c
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <dirent.h>
+#include <ctype.h>
 
 /*!
  * \internal
@@ -139,4 +140,33 @@ crm_procfs_pid_of(const char *name)
     }
     closedir(dp);
     return pid;
+}
+
+/*!
+ * \internal
+ * \brief Calculate number of logical CPU cores from procfs
+ *
+ * \return Number of cores (or 1 if unable to determine)
+ */
+unsigned int
+crm_procfs_num_cores(void)
+{
+    int cores = 0;
+    FILE *stream = NULL;
+
+    /* Parse /proc/stat instead of /proc/cpuinfo because it's smaller */
+    stream = fopen("/proc/stat", "r");
+    if (stream == NULL) {
+        crm_perror(LOG_INFO, "Could not open /proc/stat");
+    } else {
+        char buffer[2048];
+
+        while (fgets(buffer, sizeof(buffer), stream)) {
+            if (!strncmp(buffer, "cpu", 3) && isdigit(buffer[3])) {
+                ++cores;
+            }
+        }
+        fclose(stream);
+    }
+    return cores? cores : 1;
 }


### PR DESCRIPTION
This fixes multiple issues with crmd's throttle checks, most importantly: changes in CPU count due to hot-plugging are now detected; blocked processes are correctly parsed from /proc/stat; and I/O thresholds are set reasonably.