### PR TITLE
Mid: alert: Add the alert function of the attribute.

### DIFF
--- a/attrd/Makefile.am
+++ b/attrd/Makefile.am
@@ -27,13 +27,15 @@ attrd_CFLAGS	= $(CFLAGS_HARDENED_EXE)
 attrd_LDFLAGS	= $(LDFLAGS_HARDENED_EXE)
 
 attrd_LDADD	= $(top_builddir)/lib/cluster/libcrmcluster.la	\
+                $(top_builddir)/lib/pengine/libpe_rules.la      \
 		$(top_builddir)/lib/common/libcrmcommon.la	\
 		$(top_builddir)/lib/cib/libcib.la		\
+                $(top_builddir)/lib/lrmd/liblrmd.la             \
 		$(CLUSTERLIBS)
 
 attrd_SOURCES	=
 if BUILD_ATOMIC_ATTRD
-attrd_SOURCES	+= main.c commands.c attrd_common.c
+attrd_SOURCES	+= main.c commands.c attrd_common.c attrd_alerts.c
 else
 attrd_SOURCES	+= legacy.c attrd_common.c
 endif

--- a/attrd/Makefile.am
+++ b/attrd/Makefile.am
@@ -37,7 +37,7 @@ attrd_SOURCES	=
 if BUILD_ATOMIC_ATTRD
 attrd_SOURCES	+= main.c commands.c attrd_common.c attrd_alerts.c
 else
-attrd_SOURCES	+= legacy.c attrd_common.c
+attrd_SOURCES	+= legacy.c attrd_common.c attrd_alerts.c
 endif
 
 clean-generic:

--- a/attrd/attrd_alerts.c
+++ b/attrd/attrd_alerts.c
@@ -1,0 +1,528 @@
+/*
+ * Copyright (C) 2015 Andrew Beekhof <andrew@beekhof.net>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include <crm_internal.h>
+#include <crm/crm.h>
+#include <crm/cib/internal.h>
+#include <crm/msg_xml.h>
+#include <crm/pengine/rules.h>
+#include <crm/cluster/internal.h>
+#include <crm/cluster/election.h>
+#include <internal.h>
+#include "attrd_alerts.h"
+#include <crm/common/alerts_internal.h>
+#include <crm/common/iso8601_internal.h>
+
+static char *notify_script = NULL;
+static char *notify_target = NULL;
+GHashTable *alert_info_cache = NULL;
+
+lrmd_t *
+attrd_lrmd_connect(int max_retry, void callback(lrmd_event_data_t * op))
+{
+    int ret;
+    int fails = 0;
+
+    if (!the_lrmd) {
+        the_lrmd = lrmd_api_new();
+    }
+
+    while(fails < max_retry) {
+        the_lrmd->cmds->set_callback(the_lrmd, callback);
+
+        ret = the_lrmd->cmds->connect(the_lrmd, T_ATTRD, NULL);
+        if (ret != pcmk_ok) {
+            fails++;
+            crm_trace("lrmd_connect RETRY!(%d)", fails);
+        } else {
+            crm_trace("lrmd_connect OK!");
+            break;
+        }
+    }
+    return the_lrmd;
+}
+
+static void
+attrd_parse_alerts(xmlNode *notifications)
+{
+    xmlNode *alert;
+    crm_alert_entry_t entry;
+    guint max_timeout = 0;
+
+    crm_free_alert_list();
+    crm_alert_max_alert_timeout = CRM_ALERT_DEFAULT_TIMEOUT_MS;
+
+    if (notifications) {
+        crm_info("We have an alerts section in the cib");
+
+        if (notify_script) {
+            crm_warn("Cib contains configuration for Legacy Notifications "
+                     "which is overruled by alerts section");
+        }
+    } else {
+        crm_info("No optional alerts section in cib");
+
+        if (notify_script) {
+            entry = (crm_alert_entry_t) {
+                .id = (char *) "legacy_notification",
+                .path = notify_script,
+                .timeout = CRM_ALERT_DEFAULT_TIMEOUT_MS,
+                .recipient = notify_target,
+                .select_kind = NULL,
+                .select_attribute_name = NULL
+            };
+            crm_add_dup_alert_list_entry(&entry);
+            crm_info("Legacy Notifications enabled");
+        }
+
+        return;
+    }
+
+    for (alert = first_named_child(notifications, XML_CIB_TAG_ALERT);
+         alert; alert = __xml_next(alert)) {
+        xmlNode *recipient;
+        int recipients = 0, envvars = 0;
+        GHashTable *config_hash = NULL;
+
+        entry = (crm_alert_entry_t) {
+            .id = (char *) crm_element_value(alert, XML_ATTR_ID),
+            .path = (char *) crm_element_value(alert, XML_ALERT_ATTR_PATH),
+            .timeout = CRM_ALERT_DEFAULT_TIMEOUT_MS,
+            .tstamp_format = (char *) CRM_ALERT_DEFAULT_TSTAMP_FORMAT,
+            .select_kind = NULL,
+            .select_attribute_name = NULL
+        };
+
+        crm_get_envvars_from_cib(alert,
+                                 &entry,
+                                 &envvars);
+
+        config_hash =
+            get_meta_attrs_from_cib(alert, &entry, &max_timeout);
+
+        crm_debug("Found alert: id=%s, path=%s, timeout=%d, "
+                   "tstamp_format=%s, select_kind=%s, select_attribute_name=%s, %d additional environment variables",
+                   entry.id, entry.path, entry.timeout,
+                   entry.tstamp_format, entry.select_kind, entry.select_attribute_name, envvars);
+
+        for (recipient = first_named_child(alert,
+                                           XML_CIB_TAG_ALERT_RECIPIENT);
+             recipient; recipient = __xml_next(recipient)) {
+            int envvars_added = 0;
+
+            entry.recipient = (char *) crm_element_value(recipient,
+                                                XML_ALERT_ATTR_REC_VALUE);
+            recipients++;
+
+            crm_get_envvars_from_cib(recipient,
+                                     &entry,
+                                     &envvars_added);
+
+            {
+                crm_alert_entry_t recipient_entry = entry;
+                GHashTable *config_hash =
+                    get_meta_attrs_from_cib(recipient,
+                                            &recipient_entry,
+                                            &max_timeout);
+
+                crm_add_dup_alert_list_entry(&recipient_entry);
+
+                crm_debug("Alert has recipient: id=%s, value=%s, "
+                          "%d additional environment variables",
+                          crm_element_value(recipient, XML_ATTR_ID),
+                          recipient_entry.recipient, envvars_added);
+
+                g_hash_table_destroy(config_hash);
+            }
+
+            entry.envvars =
+                crm_drop_envvars(&entry, envvars_added);
+        }
+
+        if (recipients == 0) {
+            crm_add_dup_alert_list_entry(&entry);
+        }
+
+        crm_drop_envvars(&entry, -1);
+        g_hash_table_destroy(config_hash);
+    }
+
+    if (max_timeout > 0) {
+        crm_alert_max_alert_timeout = max_timeout;
+    }
+}
+
+
+static void
+config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *user_data)
+{
+#ifdef RHEL7_COMPAT
+    const char *script = NULL;
+#endif
+    GHashTable *config_hash = NULL;
+    crm_time_t *now = crm_time_new(NULL);
+    xmlNode *crmconfig = NULL;
+    xmlNode *alerts = NULL;
+
+    if (rc != pcmk_ok) {
+        crm_err("Local CIB query resulted in an error: %s", pcmk_strerror(rc));
+        if (rc == -EACCES || rc == -pcmk_err_schema_validation) {
+            crm_err("The cluster is mis-configured - shutting down and staying down");
+        }
+        goto bail;
+    }
+
+    crmconfig = output;
+    if ((crmconfig) &&
+        (crm_element_name(crmconfig)) &&
+        (strcmp(crm_element_name(crmconfig), XML_CIB_TAG_CRMCONFIG) != 0)) {
+        crmconfig = first_named_child(crmconfig, XML_CIB_TAG_CRMCONFIG);
+    }
+    if (!crmconfig) {
+        crm_err("Local CIB query for " XML_CIB_TAG_CRMCONFIG " section failed");
+        goto bail;
+    }
+
+    crm_debug("Call %d : Parsing CIB options", call_id);
+    config_hash =
+        g_hash_table_new_full(crm_str_hash, g_str_equal, g_hash_destroy_str, g_hash_destroy_str);
+
+    unpack_instance_attributes(crmconfig, crmconfig, XML_CIB_TAG_PROPSET, NULL, config_hash,
+                               CIB_OPTIONS_FIRST, FALSE, now);
+
+#ifdef RHEL7_COMPAT		
+    script = crmd_pref(config_hash, "notification-agent");		
+    value  = crmd_pref(config_hash, "notification-recipient");		
+    attrd_enable_alerts(script, value);		
+#endif
+    alerts = first_named_child(output, XML_CIB_TAG_ALERTS);
+    attrd_parse_alerts(alerts);
+
+    g_hash_table_destroy(config_hash);
+  bail:
+    crm_time_free(now);
+}
+
+gboolean
+attrd_read_options(gpointer user_data)
+{
+    int call_id;
+    
+    if (the_cib) {
+        call_id = the_cib->cmds->query(the_cib,
+            "//" XML_CIB_TAG_CRMCONFIG " | //" XML_CIB_TAG_ALERTS,
+            NULL, cib_xpath | cib_scope_local);
+
+        the_cib->cmds->register_callback_full(the_cib, call_id, 120, FALSE,
+                                              NULL,
+                                              "config_query_callback",
+                                              config_query_callback, free);
+
+        crm_trace("Querying the CIB... call %d", call_id);
+    } else {
+        crm_err("Querying the CIB...CIB connection not active");
+    }
+    return TRUE;
+}
+
+void
+attrd_cib_updated_cb(const char *event, xmlNode * msg)
+{
+    int rc = -1;
+    int format= 1;
+    xmlNode *patchset = get_message_xml(msg, F_CIB_UPDATE_RESULT);
+    xmlNode *change = NULL;
+    xmlXPathObject *xpathObj = NULL;
+
+    CRM_CHECK(msg != NULL, return);
+
+    crm_element_value_int(msg, F_CIB_RC, &rc);
+    if (rc < pcmk_ok) {
+        crm_trace("Filter rc=%d (%s)", rc, pcmk_strerror(rc));
+        return;
+    }
+
+    crm_element_value_int(patchset, "format", &format);
+    if (format == 1) {
+        if ((xpathObj = xpath_search(
+                 msg,
+                 "//" F_CIB_UPDATE_RESULT "//" XML_TAG_DIFF_ADDED "//" XML_CIB_TAG_CRMCONFIG " | " \
+                 "//" F_CIB_UPDATE_RESULT "//" XML_TAG_DIFF_ADDED "//" XML_CIB_TAG_ALERTS
+                 )) != NULL) {
+            freeXpathObject(xpathObj);
+            mainloop_set_trigger(attrd_config_read);
+        }
+    } else if (format == 2) {
+        for (change = __xml_first_child(patchset); change != NULL; change = __xml_next(change)) {
+            const char *xpath = crm_element_value(change, XML_DIFF_PATH);
+
+            if (xpath == NULL) {
+                continue;
+            }
+
+            /* modifying properties */
+            if (!strstr(xpath, "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_CRMCONFIG "/") &&
+                !strstr(xpath, "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_ALERTS)) {
+                xmlNode *section = NULL;
+                const char *name = NULL;
+
+                /* adding notifications section */
+                if ((strcmp(xpath, "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION) != 0) ||
+                    ((section = __xml_first_child(change)) == NULL) ||
+                    ((name = crm_element_name(section)) == NULL) ||
+                    (strcmp(name, XML_CIB_TAG_ALERTS) != 0)) {
+                    continue;
+                }
+            }
+
+            mainloop_set_trigger(attrd_config_read);
+            break;
+        }
+
+    } else {
+        crm_warn("Unknown patch format: %d", format);
+    }
+
+}
+
+GHashTable *
+get_meta_attrs_from_cib(xmlNode *basenode, crm_alert_entry_t *entry,
+                        guint *max_timeout)
+{
+    GHashTable *config_hash =
+        g_hash_table_new_full(crm_str_hash, g_str_equal,
+                              g_hash_destroy_str, g_hash_destroy_str);
+    crm_time_t *now = crm_time_new(NULL);
+    const char *value = NULL;
+
+    unpack_instance_attributes(basenode, basenode, XML_TAG_META_SETS, NULL,
+                               config_hash, NULL, FALSE, now);
+
+    value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_TIMEOUT);
+    if (value) {
+        entry->timeout = crm_get_msec(value);
+        if (entry->timeout <= 0) {
+            if (entry->timeout == 0) {
+                crm_trace("Setting timeout to default %dmsec",
+                          CRM_ALERT_DEFAULT_TIMEOUT_MS);
+            } else {
+                crm_warn("Invalid timeout value setting to default %dmsec",
+                         CRM_ALERT_DEFAULT_TIMEOUT_MS);
+            }
+            entry->timeout = CRM_ALERT_DEFAULT_TIMEOUT_MS;
+        } else {
+            crm_trace("Found timeout %dmsec", entry->timeout);
+        }
+        if (entry->timeout > *max_timeout) {
+            *max_timeout = entry->timeout;
+        }
+    }
+    value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_TSTAMP_FORMAT);
+    if (value) {
+        /* hard to do any checks here as merely anything can
+         * can be a valid time-format-string
+         */
+        entry->tstamp_format = (char *) value;
+        crm_trace("Found timestamp format string '%s'", value);
+    }
+
+    value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_SELECT_KIND);
+    if (value) {
+        entry->select_kind = (char *) value;
+        crm_trace("Found select_kind string '%s'", entry->select_kind);
+    } 
+
+    value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_SELECT_ATTRIBUTE_NAME);
+    if (value) {
+        entry->select_attribute_name = (char *) value;
+        crm_trace("Found attribute_name string '%s'", entry->select_attribute_name);
+    }
+
+    crm_time_free(now);
+    return config_hash; /* keep hash as long as strings are needed */
+}
+
+void
+attrd_enable_alerts(const char *script, const char *target)
+{
+    free(notify_script);
+    notify_script = ((script) &&
+                     (strcmp(script,"/dev/null")))?strdup(script):NULL;
+
+    free(notify_target);
+    notify_target = (target != NULL)?strdup(target):NULL;
+}
+
+void 
+attrd_alert_fini()
+{
+    if (alert_info_cache) {
+        g_hash_table_destroy(alert_info_cache);
+        alert_info_cache = NULL;
+    }
+}
+
+static int 
+exec_alerts(lrmd_t *lrmd, const char *kind, const char *attribute_name, lrmd_key_value_t * params, GListPtr alert_list, GHashTable *info_cache)
+{
+    int call_id = 0;
+    static int operations = 0;
+    GListPtr l;
+    crm_time_hr_t *now = crm_time_hr_new(NULL);
+    
+    params = crm_set_alert_key_to_lrmd_params(params, CRM_alert_kind, kind);
+    params = crm_set_alert_key_to_lrmd_params(params, CRM_alert_version, VERSION);
+
+    for (l = g_list_first(alert_list); l; l = g_list_next(l)) {
+        lrmd_rsc_info_t *rsc = NULL;
+        crm_alert_entry_t *entry = (crm_alert_entry_t *)(l->data);
+        char *timestamp = crm_time_format_hr(entry->tstamp_format, now);
+        lrmd_key_value_t * copy_params = NULL;
+        lrmd_key_value_t *head, *p;
+
+        if (crm_is_target_alert(entry->select_kind == NULL ? CRM_ALERT_KIND_DEFAULT : entry->select_kind, kind) == FALSE) {
+            crm_debug("Cannot sending '%s' alert to '%s' via '%s'(select_kind=%s)", kind, entry->recipient, entry->path, entry->select_kind == NULL ? CRM_ALERT_KIND_DEFAULT : entry->select_kind);
+            free(timestamp);
+            continue;
+        }
+
+        if (crm_is_target_alert(entry->select_attribute_name, attribute_name) == FALSE) {
+            crm_debug("Cannot sending '%s' alert to '%s' via '%s'(select_attribute_name=%s attribute_name=%s)", kind, entry->recipient, entry->path, entry->select_attribute_name, attribute_name);
+            free(timestamp);
+            continue;
+        }
+
+        crm_info("Sending '%s' alert to '%s' via '%s'", kind, entry->recipient, entry->path);
+
+        rsc = g_hash_table_lookup(alert_info_cache, entry->id);
+        if (rsc == NULL) {
+            rsc = lrmd->cmds->get_rsc_info(lrmd, entry->id, 0);
+            if (!rsc) {
+                lrmd->cmds->register_rsc(lrmd, entry->id, "alert",  "pacemaker", entry->path, lrmd_opt_drop_recurring);
+                rsc = lrmd->cmds->get_rsc_info(lrmd, entry->id, 0);
+                if (!rsc) {
+                    crm_err("Could not add alert %s : %s", entry->id, entry->path);
+                    return -1; 
+                }
+                /* cache the result */
+                g_hash_table_insert(alert_info_cache, entry->id, rsc);
+            }
+        }
+
+        /* Because there is a parameter to turn into every transmission, Copy a parameter. */
+        head = params;
+        while (head) {
+            p = head->next;
+            copy_params = lrmd_key_value_add(copy_params, head->key, head->value);
+            head = p;
+        }
+
+        operations++;
+
+        copy_params = lrmd_key_value_add(copy_params, CRM_ALERT_KEY_PATH, entry->path);
+        copy_params = crm_set_alert_key_to_lrmd_params(copy_params, CRM_alert_recipient, entry->recipient);
+        copy_params = crm_set_alert_key_to_lrmd_params(copy_params, CRM_alert_node_sequence, crm_itoa(operations));
+        copy_params = crm_set_alert_key_to_lrmd_params(copy_params, CRM_alert_timestamp, timestamp);
+
+        crm_set_alert_envvar_to_lrmd_params(entry, copy_params);
+        
+        call_id = lrmd->cmds->exec_alert(lrmd, strdup(entry->id), entry->timeout, lrmd_opt_notify_orig_only, copy_params);
+        if (call_id <= 0) {
+            crm_err("Operation %s on %s failed: %d", "start", rsc->id, call_id);
+        } else {
+            crm_info("Operation %s on %s compete: %d", "start", rsc->id, call_id);
+        }
+
+        free(timestamp);
+    }
+
+    if (now) {
+        free(now);
+    }
+
+    return call_id;
+}
+
+static void
+free_alert_info(gpointer value)
+{
+    lrmd_rsc_info_t *rsc_info = value;
+
+    lrmd_free_rsc_info(rsc_info);
+}
+
+int 
+attrd_send_alerts(lrmd_t *lrmd, const char *node, uint32_t nodeid, const char *attribute_name, const char *attribute_value, GListPtr alert_list)
+{
+    int ret = pcmk_ok;
+    lrmd_key_value_t *params = NULL;
+
+    if (lrmd == NULL) {
+        crm_err("LRMD connection not active");
+        return 0;
+    }
+
+    if (alert_info_cache == NULL) {
+        alert_info_cache = g_hash_table_new_full(crm_str_hash,
+                                                g_str_equal, NULL, free_alert_info);
+    }
+   
+    params = crm_set_alert_key_to_lrmd_params(params, CRM_alert_node, node);
+    params = crm_set_alert_key_to_lrmd_params(params, CRM_alert_nodeid, crm_itoa(nodeid));
+    params = crm_set_alert_key_to_lrmd_params(params, CRM_alert_attribute_name, attribute_name);
+    params = crm_set_alert_key_to_lrmd_params(params, CRM_alert_attribute_value, attribute_value == NULL ? "null" : attribute_value);
+
+    ret = exec_alerts(lrmd, "attribute", attribute_name, params, alert_list, alert_info_cache); 
+    crm_trace("ret : %d, node : %s, nodeid: %s,  name: %s, value : %s", 
+                  ret, node, crm_itoa(nodeid), attribute_name, attribute_value); 
+
+    if (params) {
+        lrmd_key_value_freeall(params);
+    }
+
+    return ret;
+}
+#if HAVE_ATOMIC_ATTRD
+void
+set_alert_attribute_value(GHashTable *t, attribute_value_t *v)
+{    attribute_value_t *a_v = NULL;
+    a_v = calloc(1, sizeof(attribute_value_t));
+    CRM_ASSERT(a_v != NULL);
+    a_v->nodeid = v->nodeid;
+    a_v->nodename = strdup(v->nodename);
+    if (v->current != NULL) {
+        a_v->current = strdup(v->current);
+    }
+    g_hash_table_replace(t, a_v->nodename, a_v);
+}
+
+void
+send_alert_attributes_value(attribute_t *a, GHashTable *t)
+{
+    int call_id = 0;
+    attribute_value_t *at = NULL;
+    GHashTableIter vIter;
+
+    g_hash_table_iter_init(&vIter, t);
+
+    while (g_hash_table_iter_next(&vIter, NULL, (gpointer *) & at)) {
+        call_id = attrd_send_alerts(the_lrmd, at->nodename, at->nodeid, a->id, at->current, crm_alert_list);
+        crm_trace("call_id : %d, nodename : %s, nodeid: %d,  name: %s, value : %s", 
+                  call_id, at->nodename, at->nodeid, a->id, at->current); 
+    }
+}
+#endif

--- a/attrd/attrd_alerts.h
+++ b/attrd/attrd_alerts.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Andrew Beekhof <andrew@beekhof.net>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef ATTRD_ALERT__H
+#  define ATTRD_ALERT__H
+
+#  include <crm/crm.h>
+#  include <crm/cluster.h>
+#  include <crm/common/alerts_internal.h>
+
+extern cib_t *the_cib;
+extern lrmd_t *the_lrmd;
+extern crm_trigger_t *attrd_config_read;
+
+lrmd_t *attrd_lrmd_connect(int max_retry, void callback(lrmd_event_data_t * op));
+gboolean attrd_read_options(gpointer user_data);
+void attrd_cib_updated_cb(const char *event, xmlNode * msg);
+GHashTable *get_meta_attrs_from_cib(xmlNode *basenode, crm_alert_entry_t *entry, guint *max_timeout);
+void attrd_enable_alerts(const char *script, const char *target);
+void attrd_alert_fini(void);
+int attrd_send_alerts(lrmd_t *lrmd, const char *node, uint32_t nodeid, const char *attribute_name, const char *attribute_value, GListPtr alert_list);
+#if HAVE_ATOMIC_ATTRD
+void set_alert_attribute_value(GHashTable *t, attribute_value_t *v);
+void send_alert_attributes_value(attribute_t *a, GHashTable *t);
+#endif
+#endif
+

--- a/attrd/internal.h
+++ b/attrd/internal.h
@@ -18,6 +18,33 @@
 
 #include <attrd_common.h>
 
+typedef struct attribute_s {
+    char *uuid; /* TODO: Remove if at all possible */
+    char *id;
+    char *set;
+    GHashTable *values;
+    int update;
+    int timeout_ms;
+
+    /* TODO: refactor these three as a bitmask */
+    bool changed; /* whether attribute value has changed since last write */
+    bool unknown_peer_uuids; /* whether we know we're missing a peer uuid */
+    gboolean is_private; /* whether to keep this attribute out of the CIB */
+
+    mainloop_timer_t *timer;
+
+    char *user;
+
+} attribute_t;
+
+typedef struct attribute_value_s {
+        uint32_t nodeid;
+        gboolean is_remote;
+        char *nodename;
+        char *current;
+        char *requested;
+} attribute_value_t;
+
 cib_t *the_cib;
 crm_cluster_t *attrd_cluster;
 GHashTable *attributes;

--- a/attrd/legacy.c
+++ b/attrd/legacy.c
@@ -32,15 +32,19 @@
 #include <crm/crm.h>
 #include <crm/cib/internal.h>
 #include <crm/msg_xml.h>
+#include <crm/pengine/rules.h>
 #include <crm/common/ipc.h>
 #include <crm/common/ipcs.h>
 #include <crm/cluster/internal.h>
+#include <crm/common/alerts_internal.h>
 
 #include <crm/common/xml.h>
 
 #include <crm/attrd.h>
 
 #include <attrd_common.h>
+
+#include "attrd_alerts.h"
 
 #define OPTARGS	"hV"
 #if SUPPORT_HEARTBEAT
@@ -49,15 +53,18 @@ ll_cluster_t *attrd_cluster_conn;
 
 char *attrd_uname = NULL;
 char *attrd_uuid = NULL;
+uint32_t attrd_nodeid = 0;
 
 GHashTable *attr_hash = NULL;
-cib_t *cib_conn = NULL;
+cib_t *the_cib = NULL;
+lrmd_t *the_lrmd = NULL;
+crm_trigger_t *attrd_config_read = NULL;
 
 /* Convenience macro for registering a CIB callback.
- * Check cib_conn != NULL before using.
+ * Check the_cib != NULL before using.
  */
 #define register_cib_callback(call_id, data, fn, free_fn) \
-    cib_conn->cmds->register_callback_full(cib_conn, call_id, 120, FALSE, \
+    the_cib->cmds->register_callback_full(the_cib, call_id, 120, FALSE, \
                                            data, #fn, fn, free_fn)
 
 typedef struct attr_hash_entry_s {
@@ -340,7 +347,7 @@ remote_clear_failure(xmlNode *xml)
     int rc = pcmk_ok;
     char *xpath;
 
-    if (cib_conn == NULL) {
+    if (the_cib == NULL) {
         crm_info("Ignoring request to clear %s on %s because not connected to CIB",
                  (rsc? rsc : "all resources"),
                  (host? host: "all remote nodes"));
@@ -388,7 +395,7 @@ remote_clear_failure(xmlNode *xml)
     }
 
     crm_trace("Clearing attributes matching %s", xpath);
-    rc = cib_conn->cmds->delete(cib_conn, xpath, NULL, cib_xpath|cib_multiple);
+    rc = the_cib->cmds->delete(the_cib, xpath, NULL, cib_xpath|cib_multiple);
     register_cib_callback(rc, xpath, remote_clear_callback, free);
 }
 
@@ -599,6 +606,17 @@ cib_connect(void *user_data)
             crm_err("Could not set CIB notification callback");
             was_err = TRUE;
         }
+        if (was_err == FALSE) {
+            if (pcmk_ok != local_conn->cmds->add_notify_callback(local_conn, T_CIB_DIFF_NOTIFY, attrd_cib_updated_cb)) {
+                crm_err("Could not set CIB notification callback (update)");
+                was_err = TRUE;
+            }
+
+        }
+        attrd_config_read = mainloop_add_trigger(G_PRIORITY_HIGH, attrd_read_options, NULL);
+
+        /* Reading of cib(Alert section) after the start */
+        mainloop_set_trigger(attrd_config_read);
     }
 
     if (was_err) {
@@ -606,12 +624,45 @@ cib_connect(void *user_data)
         crm_exit(DAEMON_RESPAWN_STOP);
     }
 
-    cib_conn = local_conn;
+    the_cib = local_conn;
 
     crm_info("Sending full refresh now that we're connected to the cib");
     g_hash_table_foreach(attr_hash, local_update_for_hash_entry, NULL);
 
     return FALSE;
+}
+
+static void
+lrm_op_callback(lrmd_event_data_t * op)
+{
+    const char *nodename = NULL;
+
+    CRM_CHECK(op != NULL, return);
+
+    nodename = op->remote_nodename ? op->remote_nodename : attrd_uname;
+
+    if (op->type == lrmd_event_disconnect && (safe_str_eq(nodename, attrd_uname))) {
+        crm_err("Lost connection to LRMD service!");
+        attrd_shutdown(0);
+        return;
+    } else if (op->type != lrmd_event_exec_complete) {
+        return;
+    }
+
+
+    if (op->params != NULL) {
+        void *value_tmp1, *value_tmp2;
+
+        value_tmp1 = g_hash_table_lookup(op->params, CRM_ALERT_KEY_PATH);
+        if (value_tmp1 != NULL) {
+            value_tmp2 = g_hash_table_lookup(op->params, CRM_ALERT_NODE_SEQUENCE);
+            if(op->rc == 0) {
+                crm_notice("Alert %s (%s) complete", value_tmp2, value_tmp1);
+            } else {
+                crm_notice("Alert %s (%s) failed: %d", value_tmp2, value_tmp1, op->rc);
+            }
+        }
+    }
 }
 
 int
@@ -678,6 +729,7 @@ main(int argc, char **argv)
 
         attrd_uname = cluster.uname;
         attrd_uuid = cluster.uuid;
+        attrd_nodeid = cluster.nodeid;
 #if SUPPORT_HEARTBEAT
         attrd_cluster_conn = cluster.hb_conn;
 #endif
@@ -702,6 +754,13 @@ main(int argc, char **argv)
         crm_err("Aborting startup");
         return 100;
     }
+
+    the_lrmd = attrd_lrmd_connect(10, lrm_op_callback);
+    if (the_lrmd == NULL) {
+        crm_err("Aborting startup.(LRMD connect)");
+        return 100;
+    } 
+    crm_notice("LRMD connection active");
 
     crm_notice("Starting mainloop...");
     attrd_run_mainloop();
@@ -728,9 +787,15 @@ main(int argc, char **argv)
 
     qb_ipcs_destroy(ipcs);
 
-    if (cib_conn) {
-        cib_conn->cmds->signoff(cib_conn);
-        cib_delete(cib_conn);
+    if (the_lrmd) {
+        the_lrmd->cmds->disconnect(the_lrmd);
+        lrmd_api_delete(the_lrmd);
+        the_lrmd = NULL;
+    }
+
+    if (the_cib) {
+        the_cib->cmds->signoff(the_cib);
+        cib_delete(the_cib);
     }
 
     g_hash_table_destroy(attr_hash);
@@ -809,7 +874,7 @@ attrd_perform_update(attr_hash_entry_t * hash_entry)
     if (hash_entry == NULL) {
         return;
 
-    } else if (cib_conn == NULL) {
+    } else if (the_cib == NULL) {
         crm_info("Delaying operation %s=%s: cib not connected", hash_entry->id,
                  crm_str(hash_entry->value));
         return;
@@ -824,7 +889,7 @@ attrd_perform_update(attr_hash_entry_t * hash_entry)
 
     if (hash_entry->value == NULL) {
         /* delete the attr */
-        rc = delete_attr_delegate(cib_conn, cib_none, hash_entry->section, attrd_uuid, NULL,
+        rc = delete_attr_delegate(the_cib, cib_none, hash_entry->section, attrd_uuid, NULL,
                                   hash_entry->set, hash_entry->uuid, hash_entry->id, NULL, FALSE,
                                   user_name);
 
@@ -846,10 +911,11 @@ attrd_perform_update(attr_hash_entry_t * hash_entry)
                       hash_entry->uuid ? hash_entry->uuid : "<n/a>", hash_entry->set,
                       hash_entry->section);
         }
+        attrd_send_alerts(the_lrmd, attrd_uname, attrd_nodeid, hash_entry->id, hash_entry->value, crm_alert_list);
 
     } else {
         /* send update */
-        rc = update_attr_delegate(cib_conn, cib_none, hash_entry->section,
+        rc = update_attr_delegate(the_cib, cib_none, hash_entry->section,
                                   attrd_uuid, NULL, hash_entry->set, hash_entry->uuid,
                                   hash_entry->id, hash_entry->value, FALSE, user_name, NULL);
         if (rc < 0) {
@@ -861,6 +927,7 @@ attrd_perform_update(attr_hash_entry_t * hash_entry)
         } else {
             crm_trace("Sent update %d: %s=%s", rc, hash_entry->id, hash_entry->value);
         }
+        attrd_send_alerts(the_lrmd, attrd_uname, attrd_nodeid, hash_entry->id, hash_entry->value, crm_alert_list);
     }
 
     data = calloc(1, sizeof(struct attrd_callback_s));
@@ -1006,7 +1073,7 @@ update_remote_attr(const char *host, const char *name, const char *value,
 
     if (name == NULL) {
         rc = -EINVAL;
-    } else if (cib_conn == NULL) {
+    } else if (the_cib == NULL) {
         rc = -ENOTCONN;
     }
     if (rc != pcmk_ok) {
@@ -1016,14 +1083,17 @@ update_remote_attr(const char *host, const char *name, const char *value,
     }
 
     if (value == NULL) {
-        rc = delete_attr_delegate(cib_conn, cib_none, section,
+        rc = delete_attr_delegate(the_cib, cib_none, section,
                                   host, NULL, NULL, NULL, name, NULL,
                                   FALSE, user_name);
     } else {
-        rc = update_attr_delegate(cib_conn, cib_none, section,
+        rc = update_attr_delegate(the_cib, cib_none, section,
                                   host, NULL, NULL, NULL, name, value,
                                   FALSE, user_name, "remote");
     }
+
+    attrd_send_alerts(the_lrmd, host, 0, name, value == NULL? "null":value, crm_alert_list);
+
     crm_trace("%s submitted as CIB call %d", desc, rc);
     register_cib_callback(rc, desc, remote_attr_callback, free);
 }

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -31,20 +31,26 @@
 #include <crm/crm.h>
 #include <crm/cib/internal.h>
 #include <crm/msg_xml.h>
+#include <crm/pengine/rules.h>
+#include <crm/common/iso8601.h>
 #include <crm/common/ipc.h>
 #include <crm/common/ipcs.h>
 #include <crm/cluster/internal.h>
 #include <crm/cluster/election.h>
+#include <crm/common/alerts_internal.h>
 
 #include <crm/common/xml.h>
 
 #include <crm/attrd.h>
 #include <internal.h>
+#include "attrd_alerts.h"
 
 cib_t *the_cib = NULL;
+lrmd_t *the_lrmd = NULL;
 crm_cluster_t *attrd_cluster = NULL;
 election_t *writer = NULL;
 int attrd_error = pcmk_ok;
+crm_trigger_t *attrd_config_read = NULL;
 
 static void
 attrd_cpg_dispatch(cpg_handle_t handle,
@@ -86,6 +92,40 @@ attrd_cpg_destroy(gpointer unused)
         crm_crit("Lost connection to Corosync service!");
         attrd_error = ECONNRESET;
         attrd_shutdown(0);
+    }
+}
+
+static void
+lrm_op_callback(lrmd_event_data_t * op)
+{
+    const char *nodename = NULL;
+
+    CRM_CHECK(op != NULL, return);
+
+    nodename = op->remote_nodename ? op->remote_nodename : attrd_cluster->uname;
+
+    if (op->type == lrmd_event_disconnect && (safe_str_eq(nodename, attrd_cluster->uname))) {
+        crm_err("Lost connection to LRMD service!");
+        attrd_error = ECONNRESET;
+        attrd_shutdown(0);
+        return;
+    } else if (op->type != lrmd_event_exec_complete) {
+        return;
+    }
+
+
+    if (op->params != NULL) {
+        void *value_tmp1, *value_tmp2;
+
+        value_tmp1 = g_hash_table_lookup(op->params, CRM_ALERT_KEY_PATH);
+        if (value_tmp1 != NULL) {
+            value_tmp2 = g_hash_table_lookup(op->params, CRM_ALERT_NODE_SEQUENCE);
+            if(op->rc == 0) {
+                crm_info("Alert %s (%s) complete", value_tmp2, value_tmp1);
+            } else {
+                crm_warn("Alert %s (%s) failed: %d", value_tmp2, value_tmp1, op->rc);
+            }
+        }
     }
 }
 
@@ -156,6 +196,12 @@ attrd_cib_connect(int max_retry)
     rc = connection->cmds->add_notify_callback(connection, T_CIB_REPLACE_NOTIFY, attrd_cib_replaced_cb);
     if(rc != pcmk_ok) {
         crm_err("Could not set CIB notification callback");
+        goto cleanup;
+    }
+
+    rc = connection->cmds->add_notify_callback(connection, T_CIB_DIFF_NOTIFY, attrd_cib_updated_cb);
+    if (rc != pcmk_ok) {
+        crm_err("Could not set CIB notification callback (update)");
         goto cleanup;
     }
 
@@ -314,6 +360,20 @@ main(int argc, char **argv)
     }
 
     crm_info("CIB connection active");
+
+    attrd_config_read = mainloop_add_trigger(G_PRIORITY_HIGH, attrd_read_options, NULL);
+
+    the_lrmd = attrd_lrmd_connect(10, lrm_op_callback);
+    if (the_lrmd == NULL) {
+        rc = DAEMON_RESPAWN_STOP;
+        goto done;
+    }
+
+    crm_info("LRMD connection active");
+
+    /* Reading of cib(Alert section) after the start */
+    mainloop_set_trigger(attrd_config_read);
+
     attrd_run_mainloop();
 
   done:
@@ -324,6 +384,14 @@ main(int argc, char **argv)
         crm_client_disconnect_all(ipcs);
         qb_ipcs_destroy(ipcs);
         g_hash_table_destroy(attributes);
+    }
+
+    attrd_alert_fini();
+
+    if (the_lrmd) {
+        the_lrmd->cmds->disconnect(the_lrmd);
+        lrmd_api_delete(the_lrmd);
+        the_lrmd = NULL;
     }
 
     if (the_cib) {

--- a/crmd/crmd_alerts.c
+++ b/crmd/crmd_alerts.c
@@ -75,6 +75,18 @@ get_meta_attrs_from_cib(xmlNode *basenode, crm_alert_entry_t *entry,
         crm_trace("Found timestamp format string '%s'", value);
     }
 
+    value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_SELECT_KIND);
+    if (value) {
+        entry->select_kind = (char *) value;
+        crm_trace("Found select_kind string '%s'", entry->select_kind);
+    }
+
+    value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_SELECT_ATTRIBUTE_NAME);
+    if (value) {
+        entry->select_attribute_name = (char *) value;
+        crm_trace("Found attribute_name string '%s'", entry->select_attribute_name);
+    }
+
     crm_time_free(now);
     return config_hash; /* keep hash as long as strings are needed */
 }
@@ -104,7 +116,9 @@ parse_alerts(xmlNode *alerts)
                 .id = (char *) "legacy_notification",
                 .path = notify_script,
                 .timeout = CRM_ALERT_DEFAULT_TIMEOUT_MS,
-                .recipient = notify_target
+                .recipient = notify_target,
+                .select_kind = NULL,
+                .select_attribute_name = NULL
             };
             crm_add_dup_alert_list_entry(&entry);
             crm_info("Legacy Notifications enabled");
@@ -123,7 +137,9 @@ parse_alerts(xmlNode *alerts)
             .id = (char *) crm_element_value(alert, XML_ATTR_ID),
             .path = (char *) crm_element_value(alert, XML_ALERT_ATTR_PATH),
             .timeout = CRM_ALERT_DEFAULT_TIMEOUT_MS,
-            .tstamp_format = (char *) CRM_ALERT_DEFAULT_TSTAMP_FORMAT
+            .tstamp_format = (char *) CRM_ALERT_DEFAULT_TSTAMP_FORMAT,
+            .select_kind = NULL,
+            .select_attribute_name = NULL
         };
 
         crm_get_envvars_from_cib(alert,
@@ -134,9 +150,9 @@ parse_alerts(xmlNode *alerts)
             get_meta_attrs_from_cib(alert, &entry, &max_timeout);
 
         crm_debug("Found alert: id=%s, path=%s, timeout=%d, "
-                   "tstamp_format=%s, %d additional environment variables",
+                   "tstamp_format=%s, select_kind=%s, select_attribute_name=%s, %d additional environment variables",
                    entry.id, entry.path, entry.timeout,
-                   entry.tstamp_format, envvars);
+                   entry.tstamp_format, entry.select_kind, entry.select_attribute_name, envvars);
 
         for (recipient = first_named_child(alert,
                                            XML_CIB_TAG_ALERT_RECIPIENT);
@@ -225,6 +241,13 @@ send_alerts(const char *kind)
     for (l = g_list_first(crm_alert_list); l; l = g_list_next(l)) {
         crm_alert_entry_t *entry = (crm_alert_entry_t *)(l->data);
         char *timestamp = crm_time_format_hr(entry->tstamp_format, now);
+
+
+        if (crm_is_target_alert(entry->select_kind == NULL ? CRM_ALERT_KIND_DEFAULT : entry->select_kind, kind) == FALSE) {
+            crm_debug("Cannot sending '%s' alert to '%s' via '%s'(select_kind=%s)", kind, entry->recipient, entry->path, entry->select_kind == NULL ? CRM_ALERT_KIND_DEFAULT : entry->select_kind);
+            free(timestamp);
+            continue;
+        }
 
         operations++;
 

--- a/extra/PCMK-MIB.txt
+++ b/extra/PCMK-MIB.txt
@@ -14,12 +14,15 @@ IMPORTS
 ;
 
 pacemaker MODULE-IDENTITY
-    LAST-UPDATED "201601052100Z"
+    LAST-UPDATED "201703242100Z"
     ORGANIZATION "www.clusterlabs.org"
     CONTACT-INFO    
         "name:  Andrew Beekhof
         email:  users@clusterlabs.org"
     DESCRIPTION "MIB objects for the Pacemaker cluster manager implementation"
+
+    REVISION    "201703242100Z"
+    DESCRIPTION "Add pacemakerNotificationAttributeName and pacemakerNotificationAttributeValue"
 
     REVISION    "201601052100Z"
     DESCRIPTION "Add pacemakerTrap and pacemakerNotificationTrap"
@@ -98,6 +101,22 @@ pacemakerNotificationTargetReturnCode OBJECT-TYPE
         "The expected return code of the operation."
 ::= { pacemakerNotification 7 }
 
+pacemakerNotificationAttributeName OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(1..256))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name of the attribute."
+::= { pacemakerNotification 8 }
+
+pacemakerNotificationAttributeValue OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(1..256))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The value of the attribute."
+::= { pacemakerNotification 9 }
+
 --
 --  pacemaker Traps
 --
@@ -110,7 +129,9 @@ pacemakerNotificationTrap NOTIFICATION-TYPE
         pacemakerNotificationDescription,
         pacemakerNotificationStatus,
         pacemakerNotificationReturnCode,
-        pacemakerNotificationTargetReturnCode
+        pacemakerNotificationTargetReturnCode,
+        pacemakerNotificationAttributeName,
+        pacemakerNotificationAttributeValue
     }
     STATUS      current
     DESCRIPTION

--- a/extra/alerts/alert_file.sh.sample
+++ b/extra/alerts/alert_file.sh.sample
@@ -106,6 +106,11 @@ case $CRM_alert_kind in
                 ;;
         esac
         ;;
+    attribute)
+        #
+        echo "${tstamp}Attribute '${CRM_alert_attribute_name}' on node '${CRM_alert_node}' was updated to '${CRM_alert_attribute_value}'" >> "${CRM_alert_recipient}"
+        ;;
+
     *)
         echo "${tstamp}Unhandled $CRM_alert_kind alert" >> "${CRM_alert_recipient}"
         env | grep CRM_alert >> "${CRM_alert_recipient}"

--- a/extra/alerts/alert_smtp.sh.sample
+++ b/extra/alerts/alert_smtp.sh.sample
@@ -83,6 +83,10 @@ else
                     ;;
             esac
             ;;
+        attribute)
+            #
+            email_subject="${CRM_alert_timestamp} ${cluster_name}: The '${CRM_alert_attribute_name}' attribute of the '${CRM_alert_node}' node was updated in '${CRM_alert_attribute_value}'"
+            ;;
         *)
             email_subject="${CRM_alert_timestamp} ${cluster_name}: Unhandled $CRM_alert_kind alert"
             ;;

--- a/extra/alerts/alert_snmp.sh.sample
+++ b/extra/alerts/alert_snmp.sh.sample
@@ -159,6 +159,16 @@ case "$CRM_alert_kind" in
             ;;
         esac
         ;;
+    attribute)
+        output=`"${trap_binary}" -v "${trap_version}" ${trap_options} \
+        -c "${trap_community}" "${CRM_alert_recipient}" "" \
+        PACEMAKER-MIB::pacemakerNotificationTrap \
+        PACEMAKER-MIB::pacemakerNotificationNode s "${CRM_alert_node}" \
+        PACEMAKER-MIB::pacemakerNotificationAttributeName s "${CRM_alert_attribute_name}" \
+        PACEMAKER-MIB::pacemakerNotificationAttributeValue s "${CRM_alert_attribute_value}" \
+        ${hires_timestamp} 2>&1`
+        rc=$?
+        ;;
     *)
         ;;
 esac

--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -30,6 +30,8 @@ typedef struct {
     int timeout;
     char *tstamp_format;
     char *recipient;
+    char *select_kind;
+    char *select_attribute_name;
     GListPtr envvars;
 } crm_alert_entry_t;
 
@@ -47,12 +49,21 @@ enum crm_alert_keys_e {
     CRM_alert_kind,
     CRM_alert_version,
     CRM_alert_node_sequence,
-    CRM_alert_timestamp
+    CRM_alert_timestamp,
+    CRM_alert_attribute_name,
+    CRM_alert_attribute_value,
+    CRM_alert_select_kind,
+    CRM_alert_select_attribute_name
 };
+
+#define CRM_ALERT_INTERNAL_KEY_MAX 18
+#define CRM_ALERT_KEY_PATH "CRM_alert_path"
+#define CRM_ALERT_NODE_SEQUENCE "CRM_alert_node_sequence"
+#define CRM_ALERT_KIND_DEFAULT "node,fencing,resource"
 
 extern GListPtr crm_alert_list;
 extern guint crm_alert_max_alert_timeout;
-extern const char *crm_alert_keys[14][3];
+extern const char *crm_alert_keys[CRM_ALERT_INTERNAL_KEY_MAX][3];
 
 void crm_free_alert_list(void);
 GListPtr crm_drop_envvars(crm_alert_entry_t *entry, int count);
@@ -63,4 +74,8 @@ void crm_set_alert_key_int(enum crm_alert_keys_e name, int value);
 void crm_unset_alert_keys(void);
 void crm_set_envvar_list(crm_alert_entry_t *entry);
 void crm_unset_envvar_list(crm_alert_entry_t *entry);
+lrmd_key_value_t * crm_set_alert_key_to_lrmd_params(lrmd_key_value_t *head, enum crm_alert_keys_e name, const char *value);
+void crm_set_alert_envvar_to_lrmd_params(crm_alert_entry_t *entry, lrmd_key_value_t * params);
+gboolean crm_is_target_alert(const char *list, const char *value);
+
 #endif

--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -91,6 +91,7 @@ typedef struct lrmd_key_value_s {
 #define LRMD_OP_POKE              "lrmd_rsc_poke"
 #define LRMD_OP_NEW_CLIENT        "lrmd_rsc_new_client"
 #define LRMD_OP_CHECK             "lrmd_check"
+#define LRMD_OP_ALERT_EXEC        "lrmd_alert_exec"
 
 #define LRMD_IPC_OP_NEW           "new"
 #define LRMD_IPC_OP_DESTROY       "destroy"
@@ -447,6 +448,25 @@ typedef struct lrmd_api_operations_s {
      * \retval negative error code on failure
      */
     int (*list_standards) (lrmd_t * lrmd, lrmd_list_t ** standards);
+
+    /*!
+     * \brief Issue a command on a alert
+     *
+     * \note Asynchronous, command is queued in daemon on function return, but
+     *       execution of command is not synced.
+     *
+     * \note Operations on individual alerts are guaranteed to occur
+     *       in the order the client api calls them in.
+     *
+     * \note Operations between different alerts are not guaranteed
+     *       to occur in any specific order in relation to one another
+     *       regardless of what order the client api is called in.
+     * \retval call_id to track async event result on success
+     * \retval negative error code on failure
+     */
+    int (*exec_alert) (lrmd_t * lrmd, const char *alert_id,
+                 int timeout,   /* ms */
+                 enum lrmd_call_options options, lrmd_key_value_t * params);    /* ownership of params is given up to api here */
 
 } lrmd_api_operations_t;
 

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -363,6 +363,8 @@
 #  define XML_ALERT_ATTR_TIMEOUT	"timeout"
 #  define XML_ALERT_ATTR_TSTAMP_FORMAT	"timestamp-format"
 #  define XML_ALERT_ATTR_REC_VALUE	"value"
+#  define XML_ALERT_ATTR_SELECT_KIND	"kind"
+#  define XML_ALERT_ATTR_SELECT_ATTRIBUTE_NAME	"attribute_name"
 
 #  define XML_CIB_TAG_GENERATION_TUPPLE	"generation_tuple"
 

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -18,6 +18,7 @@
 
 #include <crm_internal.h>
 #include <crm/crm.h>
+#include <crm/lrmd.h>
 #include <crm/msg_xml.h>
 #include <crm/common/alerts_internal.h>
 
@@ -33,7 +34,7 @@ guint crm_alert_max_alert_timeout = CRM_ALERT_DEFAULT_TIMEOUT_MS;
  * to allow script compatibility we can have more than one		
  * set of environment variables		
  */
-const char *crm_alert_keys[14][3] =		
+const char *crm_alert_keys[CRM_ALERT_INTERNAL_KEY_MAX][3] =		
 {		
     [CRM_alert_recipient]     = {"CRM_notify_recipient",     "CRM_alert_recipient",     NULL},		
     [CRM_alert_node]          = {"CRM_notify_node",          "CRM_alert_node",          NULL},		
@@ -47,8 +48,12 @@ const char *crm_alert_keys[14][3] =
     [CRM_alert_rc]            = {"CRM_notify_rc",            "CRM_alert_rc",            NULL},		
     [CRM_alert_kind]          = {"CRM_notify_kind",          "CRM_alert_kind",          NULL},		
     [CRM_alert_version]       = {"CRM_notify_version",       "CRM_alert_version",       NULL},		
-    [CRM_alert_node_sequence] = {"CRM_notify_node_sequence", "CRM_alert_node_sequence", NULL},		
-    [CRM_alert_timestamp]     = {"CRM_notify_timestamp",     "CRM_alert_timestamp",     NULL}		
+    [CRM_alert_node_sequence] = {"CRM_notify_node_sequence", CRM_ALERT_NODE_SEQUENCE, NULL},		
+    [CRM_alert_timestamp]     = {"CRM_notify_timestamp",     "CRM_alert_timestamp",     NULL},
+    [CRM_alert_attribute_name]     = {"CRM_notify_attribute_name",     "CRM_alert_attribute_name",     NULL},
+    [CRM_alert_attribute_value]     = {"CRM_notify_attribute_value",     "CRM_alert_attribute_value",     NULL},
+    [CRM_alert_select_kind]     = {"CRM_notify_select_kind",     "CRM_alert_select_kind",     NULL},
+    [CRM_alert_select_attribute_name]     = {"CRM_notify_select_attribute_name",     "CRM_alert_select_attribute_name",     NULL}
 };
 
 static void		
@@ -66,6 +71,8 @@ crm_free_alert_list_entry(crm_alert_entry_t *entry)
     free(entry->path);		
     free(entry->tstamp_format);		
     free(entry->recipient);		
+    free(entry->select_kind);		
+    free(entry->select_attribute_name);		
     if (entry->envvars) {		
         g_list_free_full(entry->envvars,		
                          (GDestroyNotify) free_envvar_entry);		
@@ -159,6 +166,8 @@ crm_add_dup_alert_list_entry(crm_alert_entry_t *entry)
         .timeout = entry->timeout,		
         .tstamp_format = entry->tstamp_format?strdup(entry->tstamp_format):NULL,		
         .recipient = entry->recipient?strdup(entry->recipient):NULL,		
+        .select_kind = entry->select_kind?strdup(entry->select_kind):NULL,		
+        .select_attribute_name = entry->select_attribute_name?strdup(entry->select_attribute_name):NULL,		
         .envvars = entry->envvars?		
             copy_envvar_list_remove_dupes(entry)		
             :NULL		
@@ -261,3 +270,80 @@ crm_unset_envvar_list(crm_alert_entry_t *entry)
         unsetenv(env->name);
     }
 }
+
+static lrmd_key_value_t *
+set_alert_key_to_lrmd_params(lrmd_key_value_t * head, const char *key, const char *value)
+{
+    lrmd_key_value_t *p, *end;
+
+    p = calloc(1, sizeof(lrmd_key_value_t));
+    p->key = strdup(key);
+    p->value = strdup(value);
+
+    end = head;
+    while (end && end->next) {
+        end = end->next;
+    }
+
+    if (end) {
+        end->next = p;
+    } else {
+        head = p;
+    }
+
+    return head;
+}
+
+lrmd_key_value_t *
+crm_set_alert_key_to_lrmd_params(lrmd_key_value_t *head, enum crm_alert_keys_e name, const char *value)
+{
+    const char **key;
+
+    for (key = crm_alert_keys[name]; *key; key++) {
+        crm_trace("Setting alert key %s = '%s'", *key, value);
+        head = set_alert_key_to_lrmd_params(head, *key, value);
+    }
+    return head;
+}
+
+void
+crm_set_alert_envvar_to_lrmd_params(crm_alert_entry_t *entry, lrmd_key_value_t *head)
+{
+    GListPtr l;
+
+    for (l = g_list_first(entry->envvars); l; l = g_list_next(l)) {
+        envvar_t *ev = (envvar_t *)(l->data);
+
+        crm_trace("Setting environment variable %s = '%s'", ev->name,
+                  ev->value?ev->value:"");
+        head = set_alert_key_to_lrmd_params(head, ev->name, ev->value);
+    }
+    
+}
+
+gboolean 
+crm_is_target_alert(const char *list, const char *value)
+{
+    int target_list_num = 0;
+    gboolean rc = FALSE;
+    char **target_list;
+
+    if (list == NULL) return TRUE;
+
+    target_list = g_strsplit(list, ",", 0);
+    target_list_num = g_strv_length(target_list);
+
+    for( int cnt = 0; cnt < target_list_num; cnt++ ) {
+        if (strcmp(target_list[cnt], value) == 0) {
+            rc = TRUE;
+            break;
+        }
+    } 
+
+    if (target_list) {
+        g_strfreev(target_list);
+    }
+
+    return rc;
+}
+

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -175,6 +175,24 @@ set_ocf_env_with_prefix(gpointer key, gpointer value, gpointer user_data)
 }
 
 static void
+set_alert_env(gpointer key, gpointer value, gpointer user_data)
+{
+    set_ocf_env((char*)key, value, user_data);
+}
+
+static void
+add_alert_env_vars(svc_action_t * op)
+{
+    if (!op->standard || strcasecmp("event", op->standard) != 0) {
+        return;
+    }
+
+    if (op->params) {
+        g_hash_table_foreach(op->params, set_alert_env, NULL);
+    }
+}
+
+static void
 add_OCF_env_vars(svc_action_t * op)
 {
     if ((op->standard == NULL)
@@ -434,6 +452,9 @@ action_launch_child(svc_action_t *op)
 #endif
     /* Setup environment correctly */
     add_OCF_env_vars(op);
+
+    /* Setup environment correctly for Alert */
+    add_alert_env_vars(op);
 
     /* execute the RA */
     execvp(op->opaque->exec, op->opaque->args);

--- a/lrmd/lrmd.c
+++ b/lrmd/lrmd.c
@@ -27,6 +27,7 @@
 #include <crm/common/mainloop.h>
 #include <crm/common/ipc.h>
 #include <crm/common/ipcs.h>
+#include <crm/common/alerts_internal.h>
 #include <crm/msg_xml.h>
 #include <crm/pengine/rules.h>
 
@@ -1321,7 +1322,25 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
         }
     }
 
-    if (cmd->isolation_wrapper) {
+    if (safe_str_eq(rsc->class, "alert")) {
+        /* In the case of Alert, lrmd always set rsc->type from CRM_alert_path parameter. */
+        void *value_lookup = g_hash_table_lookup(params_copy, CRM_ALERT_KEY_PATH);
+        if (value_lookup != NULL) { 
+            action = services_action_create_generic((char*)value_lookup, NULL);
+            action->rsc = strdup(rsc->rsc_id);
+            action->action = strdup(cmd->action);
+            action->timeout = cmd->timeout;
+            action->standard = strdup("event");
+            action->id = strdup(rsc->rsc_id);
+            action->agent = strdup((char*)value_lookup);
+            action->params = params_copy;
+
+            value_lookup = g_hash_table_lookup(params_copy, CRM_ALERT_NODE_SEQUENCE);        
+            if (value_lookup != NULL) {
+                action->sequence = crm_atoi(value_lookup, "");
+            }
+        } 
+    } else if (cmd->isolation_wrapper) {
         g_hash_table_remove(params_copy, "CRM_meta_isolation_wrapper");
         action = resources_action_create(rsc->rsc_id,
                                          PCMK_RESOURCE_CLASS_OCF,
@@ -1654,6 +1673,37 @@ process_lrmd_rsc_exec(crm_client_t * client, uint32_t id, xmlNode * request)
 }
 
 static int
+process_lrmd_alert_exec(crm_client_t * client, uint32_t id, xmlNode * request)
+{
+    lrmd_rsc_t *alert = NULL;
+    lrmd_cmd_t *cmd = NULL;
+    xmlNode *alert_xml = get_xpath_object("//" F_LRMD_RSC, request, LOG_ERR);
+    const char *alert_id = crm_element_value(alert_xml, F_LRMD_RSC_ID);
+    int call_id;
+
+    if (!alert_id) {
+        return -EINVAL;
+    }
+
+    alert = g_hash_table_lookup(rsc_list, alert_id);
+    if (alert == NULL) {
+        crm_info("Alert '%s' not found (%d active resources)",
+                 alert_id, g_hash_table_size(rsc_list));
+        return -ENODEV;
+    }
+
+    call_id = pcmk_ok;
+    cmd = create_lrmd_cmd(request, client, alert);
+    call_id = cmd->call_id;
+
+    /* Don't reference cmd after handing it off to be scheduled.
+     * The cmd could get merged and freed. */
+    schedule_lrmd_cmd(alert, cmd);
+
+    return call_id;
+}
+
+static int
 cancel_op(const char *rsc_id, const char *action, int interval)
 {
     GListPtr gIter = NULL;
@@ -1811,6 +1861,9 @@ process_lrmd_message(crm_client_t * client, uint32_t id, xmlNode * request)
         const char *timeout = crm_element_value(data, F_LRMD_WATCHDOG);
         CRM_LOG_ASSERT(data != NULL);
         check_sbd_timeout(timeout);
+    } else if (crm_str_eq(op, LRMD_OP_ALERT_EXEC, TRUE)) {
+        rc = process_lrmd_alert_exec(client, id, request);
+        do_reply = 1;
     } else {
         rc = -EOPNOTSUPP;
         do_reply = 1;


### PR DESCRIPTION
-----
This PR is a revision of the next PR.
 - https://github.com/ClusterLabs/pacemaker/pull/1262
-----

Hi All,


I added the alert function of the attribute.
I add two meta attributes to alert setting newly.

 - kind
 - attribute_name

```
(snip)
alert notify_9 /usr/share/pacemaker/alerts/alert_snmp.sh \
        meta \
        kind="resource,attribute" \
        attribute_name="default_ping_set" \
        attributes \
        trap_resource_tasks="start,stop,monitor,promote,demote" \
        trap_add_hires_timestamp_oid="false" \
        to "192.168.xx.xxx"
(snip)
```

The kind appoints alert to handle.
For the compatibility with the former version, the default becomes "node,fencing,resource".
The alert function of the attribute that is new by appointing "attribute" becomes effective for kind.

The attribute_name appoints the attribute that alert does.
The attribute_name divides it with a comma and can appoint a plural number.
When a user does not appoint attribute_name, many attributes require attention because it is done alert.

The script of the sample of the alert function is changed, too.
When a user has already carried out a sample script, it is necessary to replace it with a new script.

When attrd writes in an attribute, alert of the attribute is transmitted.
(An attribute may be performed alert of again.)

For a future change, the alert function of the attribute carries out a script via lrmd.

Best Regards,
Hideo Yamauchi.

