### PR TITLE
Build: spec: fix broken pre-release by tag detection

### DIFF
--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -39,9 +39,9 @@
 %define tag_release %([ %{commit} != Pacemaker-%{shortcommit} ]; echo $?)
 
 ## Whether this is a release candidate (in case of a tagged release)
-%define pre_release %(s=%{shortcommit}; [ "%{tag_release}" -eq 0 ] || {
-                                        case %{s} in *-rc[[:digit:]]*%{rparen} false;;
-                                        esac; }; echo $?)
+%define pre_release %([ "%{tag_release}" -eq 0 ] || {
+                      case "%{shortcommit}" in *-rc[[:digit:]]*%{rparen} false;;
+                      esac; }; echo $?)
 
 ## Turn off auto-compilation of python files outside site-packages directory,
 ## so that the -libs-devel package is multilib-compliant (no *.py[co] files)


### PR DESCRIPTION
The breakage was introduced in 2d6e6c374 (avoid bashism due to
rpmbuild-popen-/bin/sh chain) which accidentally tried to access RPM
macro level variable ("%{s}") instead of the one in the intended scope
of the nested shell ("${s}"}.  This simple swap can then be further
simplified to refer to the underlying macro level variable right away,
so carry this out as well.