### PR TITLE
low: tools: add version options for cibsecret

### DIFF
--- a/tools/cibsecret.in
+++ b/tools/cibsecret.in
@@ -43,6 +43,7 @@ usage() {
 	echo "cibsecret - A tool for managing cib secrets";
 	echo "";
 	echo "usage: $PROG [-C] <command> <parameters>";
+	echo "--version              Display version information, then exit";
 	echo "";
 	echo "-C: don't read/write the CIB"
 	echo ""
@@ -370,6 +371,9 @@ case "$cmd" in
 	delete) [ $# -ne 3 ] && usage 1;;
 	sync) [ $# -ne 1 ] && usage 1;;
 	--help) usage 0;;
+	--version)
+		crm_attribute --version
+		exit $?;;
 	*) usage 1;
 esac
 


### PR DESCRIPTION
Add "--version" option for cibserect.in to fix compile error.