### PR TITLE
Fix: stonith-ng: Trigger on constraints added to cib

### DIFF
--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -1179,6 +1179,10 @@ stonith_device_remove(const char *id, gboolean from_cib)
         g_hash_table_remove(device_list, id);
         crm_info("Removed '%s' from the device list (%d active devices)",
                  id, g_hash_table_size(device_list));
+    } else {
+        crm_trace("Not removing '%s' from the device list (%d active devices) "
+                  "- still %s%s_registered", id, g_hash_table_size(device_list),
+                  device->cib_registered?"cib":"", device->api_registered?"api":"");
     }
     return pcmk_ok;
 }

--- a/fencing/main.c
+++ b/fencing/main.c
@@ -787,7 +787,7 @@ update_cib_stonith_devices_v2(const char *event, xmlNode * msg)
             needs_update = TRUE;
             break;
 
-        } else if(strstr(xpath, XML_CONS_TAG_RSC_LOCATION)) {
+        } else if(strstr(xpath, XML_CIB_TAG_CONSTRAINTS)) {
             shortpath = strrchr(xpath, '/'); CRM_ASSERT(shortpath);
             reason = crm_strdup_printf("%s %s", op, shortpath+1);
             needs_update = TRUE;
@@ -798,6 +798,8 @@ update_cib_stonith_devices_v2(const char *event, xmlNode * msg)
     if(needs_update) {
         crm_info("Updating device list from the cib: %s", reason);
         cib_devices_update();
+    } else {
+        crm_trace("No updates for device list found in cib");
     }
     free(reason);
 }


### PR DESCRIPTION
The simple search for 'rsc_location' just triggered on delete.
'constraints' is found both in additions and deletes.
A smarter check might reduce the number of unneeded triggers but
probably isn't worth the effort.
Add some trace-logging to facilitate tracking down similar issues.