### PR TITLE
Fix: cib: Broadcasts of cib changes should always pass ACLs check

### DIFF
--- a/cib/callbacks.c
+++ b/cib/callbacks.c
@@ -893,6 +893,7 @@ send_peer_reply(xmlNode * msg, xmlNode * result_diff, const char *originator, gb
         crm_xml_add(msg, F_CIB_ISREPLY, originator);
         crm_xml_add(msg, F_CIB_GLOBAL_UPDATE, XML_BOOLEAN_TRUE);
         crm_xml_add(msg, F_CIB_OPERATION, CIB_OP_APPLY_DIFF);
+        crm_xml_add(msg, F_CIB_USER, CRM_DAEMON_USER);
 
         if (format == 1) {
             CRM_ASSERT(digest != NULL);


### PR DESCRIPTION
Previously in cib legacy mode, if a cib change was requested by an
unprivileged user that had limited permissions to the cib, after it got
accepted by the master cib daemon, the broadcast of the cib change would
get denied by the ACLs check of the slave cib daemons since the user
didn't have the permission to write the additional bits from the
broadcast such as the cib properties like "epoch", "num_updates" and so
on.

Technically, the broadcast of a cib change is issued by the master cib
daemon as CRM_DAEMON_USER instead of the user that originally requested
the change. The broadcast should always pass the ACLs check when it's
processed by the slave cib daemons.

This commit fixes the issue by overwriting any existing F_CIB_USER field
in a broadcast with the privileged user CRM_DAEMON_USER.