### PR TITLE
Support user option for IPC client eviction threshold

### DIFF
--- a/cib/callbacks.c
+++ b/cib/callbacks.c
@@ -281,6 +281,19 @@ cib_common_callback(qb_ipcs_connection_t * c, void *data, size_t size, gboolean 
             cib_client->name = crm_itoa(cib_client->pid);
         } else {
             cib_client->name = strdup(value);
+            if (crm_is_daemon_name(value)) {
+                set_bit(cib_client->options, cib_is_daemon);
+            }
+        }
+    }
+
+    /* Allow cluster daemons more leeway before being evicted */
+    if (is_set(cib_client->options, cib_is_daemon)) {
+        const char *qmax = cib_config_lookup("cluster-ipc-limit");
+
+        if (crm_set_client_queue_max(cib_client, qmax)) {
+            crm_trace("IPC threshold for %s[%u] is now %u",
+                      cib_client->name, cib_client->pid, cib_client->queue_max);
         }
     }
 

--- a/cib/callbacks.h
+++ b/cib/callbacks.h
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <glib.h>
 
 #include <crm/crm.h>
 #include <crm/cib.h>
@@ -43,6 +44,9 @@ enum cib_notifications
     cib_notify_replace = 0x0004,
     cib_notify_confirm = 0x0008,
     cib_notify_diff    = 0x0010,
+
+    /* not a notification, but uses the same IPC bitmask */
+    cib_is_daemon      = 0x1000, /* whether client is another cluster daemon */
 };
 /* *INDENT-ON* */
 
@@ -80,3 +84,9 @@ extern void cib_ha_peer_callback(HA_Message * msg, void *private_data);
 extern int cib_ccm_dispatch(gpointer user_data);
 extern void cib_ccm_msg_callback(oc_ed_t event, void *cookie, size_t size, const void *data);
 #endif
+
+static inline const char *
+cib_config_lookup(const char *opt)
+{
+    return g_hash_table_lookup(config_hash, opt);
+}

--- a/cib/remote.c
+++ b/cib/remote.c
@@ -325,12 +325,8 @@ cib_remote_listen(gpointer data)
     num_clients++;
 
     crm_client_init();
-    new_client = calloc(1, sizeof(crm_client_t));
+    new_client = crm_client_alloc(NULL);
     new_client->remote = calloc(1, sizeof(crm_remote_t));
-
-    new_client->id = crm_generate_uuid();
-
-    g_hash_table_insert(client_connections, new_client->id /* Should work */ , new_client);
 
     if (ssock == remote_tls_fd) {
 #ifdef HAVE_GNUTLS_GNUTLS_H

--- a/crmd/te_callbacks.c
+++ b/crmd/te_callbacks.c
@@ -822,6 +822,10 @@ tengine_stonith_callback(stonith_t * stonith, stonith_callback_data_t * data)
             abort_action = tg_stop;
         }
 
+        /* Increment the fail count now, so abort_for_stonith_failure() can
+         * check it. Non-DC nodes will increment it in tengine_stonith_notify().
+         */
+        st_fail_count_increment(target);
         abort_for_stonith_failure(abort_action, target, NULL);
     }
 

--- a/crmd/te_utils.c
+++ b/crmd/te_utils.c
@@ -259,7 +259,11 @@ tengine_stonith_notify(stonith_t * st, stonith_event_t * st_event)
         return;
     }
 
-    if (safe_str_eq(st_event->operation, T_STONITH_NOTIFY_FENCE)) {
+    /* Update the count of stonith failures for this target, in case we become
+     * DC later. The current DC has already updated its fail count in
+     * tengine_stonith_callback().
+     */
+    if (!AM_I_DC && safe_str_eq(st_event->operation, T_STONITH_NOTIFY_FENCE)) {
         if (st_event->result == pcmk_ok) {
             st_fail_count_reset(st_event->target);
         } else {

--- a/doc/Pacemaker_Explained/en-US/Ch-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Options.txt
@@ -267,6 +267,15 @@ take effect, we can optionally poll the cluster's status for changes. A value
 of 0 disables polling. Positive values are an interval (in seconds unless other
 SI units are specified, e.g. 5min).
 
+| cluster-ipc-limit | 500 |
+indexterm:[cluster-ipc-limit,Cluster Option]
+indexterm:[Cluster,Option,cluster-ipc-limit]
+The maximum IPC message backlog before one cluster daemon will disconnect
+another. This is of use in large clusters, for which a good value is the number
+of resources in the cluster multiplied by the number of nodes. The default of
+500 is also the minimum. Raise this if you see "Evicting client" messages for
+cluster daemon PIDs in the logs.
+
 | pe-error-series-max | -1 |
 indexterm:[pe-error-series-max,Cluster Option]
 indexterm:[Cluster,Option,pe-error-series-max]

--- a/doc/Pacemaker_Explained/en-US/Ch-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Options.txt
@@ -149,13 +149,13 @@ What to do when the cluster does not have quorum.  Allowed values:
 * +stop:+ stop all resources in the affected cluster partition
 * +suicide:+ fence all nodes in the affected cluster partition
 
-| batch-limit | 30 |
+| batch-limit | 0 '(30 before version 1.1.11)' |
 indexterm:[batch-limit,Cluster Option]
 indexterm:[Cluster,Option,batch-limit]
-The number of jobs that the Transition Engine (TE) is allowed to execute in
-parallel. The TE is the logic in pacemaker's CRMd that executes the actions
-determined by the Policy Engine (PE). The "correct" value will depend on the
-speed and load of your network and cluster nodes.
+The maximum number of actions that the cluster may execute in parallel across
+all nodes. The "correct" value will depend on the speed and load of your
+network and cluster nodes. If zero, the cluster will impose a dynamically
+calculated limit only when any node has high load.
 
 | migration-limit | -1 |
 indexterm:[migration-limit,Cluster Option]

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -338,7 +338,7 @@ ais_error2text(int error)
             text = "Bad flags";
             break;
         case CS_ERR_TOO_BIG:
-            text = "To big";
+            text = "Too big";
             break;
         case CS_ERR_NO_SECTIONS:
             text = "No sections";

--- a/include/crm/common/ipcs.h
+++ b/include/crm/common/ipcs.h
@@ -19,6 +19,7 @@
 #ifndef CRM_COMMON_IPCS__H
 #  define CRM_COMMON_IPCS__H
 
+#  include <stdbool.h>
 #  include <qb/qbipcs.h>
 #  ifdef HAVE_GNUTLS_GNUTLS_H
 #    undef KEYFILE
@@ -95,6 +96,7 @@ struct crm_client_s {
     struct crm_remote_s *remote;        /* TCP/TLS */
 
     unsigned int queue_backlog; /* IPC queue length after last flush */
+    unsigned int queue_max;     /* Evict client whose queue grows this big */
 };
 
 extern GHashTable *client_connections;
@@ -110,6 +112,7 @@ crm_client_t *crm_client_alloc(void *key);
 crm_client_t *crm_client_new(qb_ipcs_connection_t * c, uid_t uid, gid_t gid);
 void crm_client_destroy(crm_client_t * c);
 void crm_client_disconnect_all(qb_ipcs_service_t *s);
+bool crm_set_client_queue_max(crm_client_t *client, const char *qmax);
 
 void crm_ipcs_send_ack(crm_client_t * c, uint32_t request, uint32_t flags,
                        const char *tag, const char *function, int line);

--- a/include/crm/common/ipcs.h
+++ b/include/crm/common/ipcs.h
@@ -93,7 +93,7 @@ struct crm_client_s {
 
     struct crm_remote_s *remote;        /* TCP/TLS */
 
-    unsigned int backlog_len; /* IPC queue length after last flush */
+    unsigned int queue_backlog; /* IPC queue length after last flush */
 };
 
 extern GHashTable *client_connections;

--- a/include/crm/common/ipcs.h
+++ b/include/crm/common/ipcs.h
@@ -105,6 +105,7 @@ crm_client_t *crm_client_get(qb_ipcs_connection_t * c);
 crm_client_t *crm_client_get_by_id(const char *id);
 const char *crm_client_name(crm_client_t * c);
 
+crm_client_t *crm_client_alloc(void *key);
 crm_client_t *crm_client_new(qb_ipcs_connection_t * c, uid_t uid, gid_t gid);
 void crm_client_destroy(crm_client_t * c);
 void crm_client_disconnect_all(qb_ipcs_service_t *s);

--- a/include/crm/common/ipcs.h
+++ b/include/crm/common/ipcs.h
@@ -60,7 +60,8 @@ struct crm_remote_s {
 
 enum crm_client_flags
 {
-    crm_client_flag_ipc_proxied = 0x00001, /* ipc_proxy code only */
+    crm_client_flag_ipc_proxied    = 0x00001, /* ipc_proxy code only */
+    crm_client_flag_ipc_privileged = 0x00002, /* root or cluster user */
 };
 
 struct crm_client_s {

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -26,6 +26,7 @@
 
 #  include <sys/types.h>
 #  include <stdlib.h>
+#  include <stdbool.h>
 #  include <limits.h>
 #  include <signal.h>
 #  include <sysexits.h>
@@ -127,6 +128,7 @@ gboolean did_rsc_op_fail(lrmd_event_data_t * event, int target_rc);
 char *crm_md5sum(const char *buffer);
 
 char *crm_generate_uuid(void);
+bool crm_is_daemon_name(const char *name);
 
 int crm_user_lookup(const char *name, uid_t * uid, gid_t * gid);
 

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -743,7 +743,7 @@ cib_read_config(GHashTable * options, xmlNode * current_cib)
     config = get_object_root(XML_CIB_TAG_CRMCONFIG, current_cib);
     if (config) {
         unpack_instance_attributes(current_cib, config, XML_CIB_TAG_PROPSET, NULL, options,
-                                   CIB_OPTIONS_FIRST, FALSE, now);
+                                   CIB_OPTIONS_FIRST, TRUE, now);
     }
 
     verify_cib_options(options);

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -794,23 +794,24 @@ cib_apply_patch_event(xmlNode * event, xmlNode * input, xmlNode ** output, int l
     return rc;
 }
 
+/* v2 and v2 patch formats */
+#define XPATH_CONFIG_CHANGE \
+    "//" XML_CIB_TAG_CRMCONFIG " | " \
+    "//" XML_DIFF_CHANGE "[contains(@" XML_DIFF_PATH ",'/" XML_CIB_TAG_CRMCONFIG "/')]"
+
 gboolean
-cib_internal_config_changed(xmlNode * diff)
+cib_internal_config_changed(xmlNode *diff)
 {
     gboolean changed = FALSE;
-    xmlXPathObject *xpathObj = NULL;
 
-    if (diff == NULL) {
-        return FALSE;
+    if (diff) {
+        xmlXPathObject *xpathObj = xpath_search(diff, XPATH_CONFIG_CHANGE);
+
+        if (numXpathResults(xpathObj) > 0) {
+            changed = TRUE;
+        }
+        freeXpathObject(xpathObj);
     }
-
-    xpathObj = xpath_search(diff, "//" XML_CIB_TAG_CRMCONFIG);
-    if (numXpathResults(xpathObj) > 0) {
-        changed = TRUE;
-    }
-
-    freeXpathObject(xpathObj);
-
     return changed;
 }
 

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -699,10 +699,26 @@ cib_native_notify(gpointer data, gpointer user_data)
 }
 
 pe_cluster_option cib_opts[] = {
-    /* name, old-name, validate, default, description */
-    {"enable-acl", NULL, "boolean", NULL, "false", &check_boolean,
-     "Enable CIB ACL", NULL}
-    ,
+    /*
+     * name, legacy name,
+     * type, allowed values, default, validator,
+     * short description,
+     * long description
+     */
+    {
+        "enable-acl", NULL,
+        "boolean", NULL, "false", &check_boolean,
+        "Enable CIB ACL",
+        NULL
+    },
+    {
+        "cluster-ipc-limit", NULL,
+        "integer", NULL, "500", &check_positive_number,
+        "Maximum IPC message backlog before disconnecting a cluster daemon",
+        "Raise this if log has \"Evicting client\" messages for cluster daemon"
+            " PIDs (a good value is the number of resources in the cluster"
+            " multiplied by the number of nodes)"
+    },
 };
 
 void

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -39,7 +39,6 @@
 
 /* Evict clients whose event queue grows this large (by default) */
 #define PCMK_IPC_DEFAULT_QUEUE_MAX 500
-#define PCMK_IPC_DEFAULT_QUEUE_MAX_S "500"
 
 struct crm_ipc_response_header {
     struct qb_ipc_response_header qb;
@@ -422,8 +421,12 @@ bool
 crm_set_client_queue_max(crm_client_t *client, const char *qmax)
 {
     if (is_set(client->flags, crm_client_flag_ipc_privileged)) {
-        client->queue_max = crm_parse_int(qmax, PCMK_IPC_DEFAULT_QUEUE_MAX_S);
-        return TRUE;
+        int qmax_int = crm_int_helper(qmax, NULL);
+
+        if ((errno == 0) && (qmax_int > 0)) {
+            client->queue_max = qmax_int;
+            return TRUE;
+        }
     }
     return FALSE;
 }

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -558,25 +558,25 @@ crm_ipcs_flush_events(crm_client_t * c)
          */
 
         if (queue_len > PCMK_IPC_MAX_QUEUE) {
-            if ((c->backlog_len <= 1) || (queue_len < c->backlog_len)) {
+            if ((c->queue_backlog <= 1) || (queue_len < c->queue_backlog)) {
                 /* Don't evict for a new or shrinking backlog */
                 crm_warn("Client with process ID %u has a backlog of %u messages "
                          CRM_XS " %p", c->pid, queue_len, c->ipcs);
             } else {
                 crm_err("Evicting client with process ID %u due to backlog of %u messages "
                          CRM_XS " %p", c->pid, queue_len, c->ipcs);
-                c->backlog_len = 0;
+                c->queue_backlog = 0;
                 qb_ipcs_disconnect(c->ipcs);
                 return rc;
             }
         }
 
-        c->backlog_len = queue_len;
+        c->queue_backlog = queue_len;
         delay_next_flush(c, queue_len);
 
     } else {
         /* Event queue is empty, there is no backlog */
-        c->backlog_len = 0;
+        c->queue_backlog = 0;
     }
 
     return rc;

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -1959,6 +1959,27 @@ crm_generate_uuid(void)
     return buffer;
 }
 
+/*!
+ * \brief Check whether a string represents a cluster daemon name
+ *
+ * \param[in] name  String to check
+ *
+ * \return TRUE if name is standard client name used by daemons, FALSE otherwise
+ */
+bool
+crm_is_daemon_name(const char *name)
+{
+    return (name &&
+            (!strcmp(name, CRM_SYSTEM_CRMD)
+            || !strcmp(name, CRM_SYSTEM_STONITHD)
+            || !strcmp(name, T_ATTRD)
+            || !strcmp(name, CRM_SYSTEM_CIB)
+            || !strcmp(name, CRM_SYSTEM_MCP)
+            || !strcmp(name, CRM_SYSTEM_DC)
+            || !strcmp(name, CRM_SYSTEM_TENGINE)
+            || !strcmp(name, CRM_SYSTEM_LRMD)));
+}
+
 #include <md5.h>
 
 char *

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1768,7 +1768,7 @@ rsc_action_digest_cmp(resource_t * rsc, xmlNode * xml_op, node_t * node,
 #endif
     data->params_all = create_xml_node(NULL, XML_TAG_PARAMS);
 
-    if(fix_remote_addr(rsc) && node) {
+    if (fix_remote_addr(rsc)) {
         // REMOTE_CONTAINER_HACK: Allow remote nodes that start containers with pacemaker remote inside
         crm_xml_add(data->params_all, "addr", node->details->uname);
         crm_trace("Fixing addr for %s on %s", rsc->id, node->details->uname);

--- a/lrmd/tls_backend.c
+++ b/lrmd/tls_backend.c
@@ -212,11 +212,10 @@ lrmd_remote_listen(gpointer data)
         return TRUE;
     }
 
-    new_client = calloc(1, sizeof(crm_client_t));
+    new_client = crm_client_alloc(NULL);
     new_client->remote = calloc(1, sizeof(crm_remote_t));
     new_client->kind = CRM_CLIENT_TLS;
     new_client->remote->tls_session = session;
-    new_client->id = crm_generate_uuid();
     new_client->remote->auth_timeout =
         g_timeout_add(LRMD_REMOTE_AUTH_TIMEOUT, lrmd_auth_timeout_cb, new_client);
     crm_notice("LRMD client connection established. %p id: %s", new_client, new_client->id);
@@ -224,8 +223,6 @@ lrmd_remote_listen(gpointer data)
     new_client->remote->source =
         mainloop_add_fd("lrmd-remote-client", G_PRIORITY_DEFAULT, csock, new_client,
                         &lrmd_remote_fd_cb);
-    g_hash_table_insert(client_connections, new_client->id, new_client);
-
     return TRUE;
 }
 


### PR DESCRIPTION
Previously, cluster daemons would evict any IPC client if the client's message queue reached 500 messages. Now, the user can set this threshold via a cluster-ipc-limit option. The option only applies to clients that are other cluster daemons (connecting as uid root or hacluster, and identifying as a cluster daemon).

This helps with scalability, as certain cluster operations (such as "cleanup all") generate probes of all resources on all nodes, potentially leading to a flood of probe results from the CIB that instantly cross the 500 limit.

This request also contains a handful of unrelated commits with minor fixes.