### PR TITLE
Feature: stonith-ng: add pcmk_delay_base as static base-delay

### DIFF
--- a/fencing/main.c
+++ b/fencing/main.c
@@ -1381,7 +1381,18 @@ main(int argc, char **argv)
             ("    <shortdesc lang=\"en\">Enable random delay for stonith actions and specify the maximum of random delay</shortdesc>\n");
         printf
             ("    <longdesc lang=\"en\">This prevents double fencing when using slow devices such as sbd.\n"
-             "Use this to enable random delay for stonith actions and specify the maximum of random delay.</longdesc>\n");
+             "Use this to enable random delay for stonith actions.\n"
+             "The overall delay is derived from a random delay value adding a static delay so that the sum is kept below the maximum delay.</longdesc>\n");
+        printf("    <content type=\"time\" default=\"0s\"/>\n");
+        printf("  </parameter>\n");
+
+        printf("  <parameter name=\"%s\" unique=\"0\">\n", STONITH_ATTR_DELAY_BASE);
+        printf
+            ("    <shortdesc lang=\"en\">Enable base delay for stonith actions and specify base delay value</shortdesc>\n");
+        printf
+            ("    <longdesc lang=\"en\">This prevents double fencing when different delays are configured on the nodes.\n"
+             "Use this to enable static delay for stonith actions.\n"
+             "The overall delay is derived from a random delay value adding a static delay so that the sum is kept below the maximum delay.</longdesc>\n");
         printf("    <content type=\"time\" default=\"0s\"/>\n");
         printf("  </parameter>\n");
 

--- a/fencing/remote.c
+++ b/fencing/remote.c
@@ -67,6 +67,8 @@ typedef struct device_properties_s {
     int custom_action_timeout[st_phase_max];
     /* Action-specific maximum random delay for each phase */
     int delay_max[st_phase_max];
+    /* Action-specific base delay for each phase */
+    int delay_base[st_phase_max];
 } device_properties_t;
 
 typedef struct st_query_result_s {
@@ -1674,6 +1676,13 @@ parse_action_specific(xmlNode *xml, const char *peer, const char *device,
     if (props->delay_max[phase]) {
         crm_trace("Peer %s with device %s returned maximum of random delay %d for %s",
                   peer, device, props->delay_max[phase], action);
+    }
+
+    props->delay_base[phase] = 0;
+    crm_element_value_int(xml, F_STONITH_DELAY_BASE, &props->delay_base[phase]);
+    if (props->delay_base[phase]) {
+        crm_trace("Peer %s with device %s returned base delay %d for %s",
+                  peer, device, props->delay_base[phase], action);
     }
 
     /* Handle devices with automatic unfencing */

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -69,6 +69,8 @@ xmlNode *create_device_registration_xml(const char *id, const char *namespace, c
 #  define F_STONITH_ACTION_DISALLOWED     "st_action_disallowed"
 /*! Maximum of random fencing delay for a device */
 #  define F_STONITH_DELAY_MAX            "st_delay_max"
+/*! Base delay used for a fencing delay */
+#  define F_STONITH_DELAY_BASE           "st_delay_base"
 /*! Has this device been verified using a monitor type
  *  operation (monitor, list, status) */
 #  define F_STONITH_DEVICE_VERIFIED   "st_monitor_verified"
@@ -111,6 +113,7 @@ xmlNode *create_device_registration_xml(const char *id, const char *namespace, c
 #  define STONITH_ATTR_HOSTLIST  "pcmk_host_list"
 #  define STONITH_ATTR_HOSTCHECK "pcmk_host_check"
 #  define STONITH_ATTR_DELAY_MAX "pcmk_delay_max"
+#  define STONITH_ATTR_DELAY_BASE   "pcmk_delay_base"
 #  define STONITH_ATTR_ACTION_LIMIT "pcmk_action_limit"
 
 #  define STONITH_ATTR_ACTION_OP   "action"


### PR DESCRIPTION
Have all the delay stuff done by pacemaker directly instead of a random delay done by pacemaker and relying on the fence-agent having an attribute for an additional static delay ( having some fancy name you have to dig out first)
And you get a single log with a single delay derived from a base-part and the already existing random part that looks the same for all fencing-agents.
Random and base part don't just simply add up so that pcmk_delay_max keeps it's original behavior as the maximum delay that can happen. Meaning the actual delay is gonna be between pcmk_delay_base and pcmk_delay_max.