### PR TITLE
Fix: iso8601: strftime needs fully populated struct tm

### DIFF
--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1288,15 +1288,17 @@ ha_get_tm_time( struct tm *target, crm_time_t *source)
 {
     *target = (struct tm) {
         .tm_year = source->years - 1900,
-        .tm_yday = source->days - 1,
+        .tm_mday = source->days,
         .tm_sec = source->seconds % 60,
         .tm_min = ( source->seconds / 60 ) % 60,
         .tm_hour = source->seconds / 60 / 60,
+        .tm_isdst = -1, /* don't adjust */
 
 #if defined(HAVE_STRUCT_TM_TM_GMTOFF)
         .tm_gmtoff = source->offset
 #endif
     };
+    mktime(target);
 }
 
 crm_time_hr_t *


### PR DESCRIPTION
Fixes rhbz#1462253

using mktime to normalize and fully populate 'struct tm' so that strftime (used for time-format-strings in alerts-feature) is satisfied.
Jannuary 181st 2017 -> June 30th 2017

'.tm_isdst = -1' seems to keep mktime away from daylight-saving adaptions to the already local time