### PR TITLE
Prune: crm_mon: crm_system_name no longer influenced with argv

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -555,11 +555,6 @@ main(int argc, char **argv)
     signal(SIGCLD, SIG_IGN);
 #endif
 
-    if (strcmp(crm_system_name, "crm_mon.cgi") == 0) {
-        output_format = mon_output_cgi;
-        one_shot = TRUE;
-    }
-
     while (1) {
         flag = crm_get_option(argc, argv, &option_index);
         if (flag == -1)


### PR DESCRIPTION
This drops a chunk of code added with 789936866, which introduced
a generic support for running crm_mon in the role of CGI handler
-- specifically the chunk responsible for switching into this mode
automatically if run as "crm_mon.cgi".  That, however, only worked
until fc1fbd03a that hardcoded what is to become value of
crm_system_name variable, no longer taking argv into account.

Hence the lines in question are effectively just a dead code
eligible for removal.  Alternative would be to revert to using
"crm_log_init*(NULL, ..., argc, argv, ...)" again.