### PR TITLE
fix: stonith-ng: avoid double-free of pending-ops in free_device

### DIFF
--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -509,7 +509,6 @@ free_device(gpointer data)
 
         crm_warn("Removal of device '%s' purged operation %s", device->id, cmd->action);
         cmd->done_cb(0, -ENODEV, NULL, cmd);
-        free_async_command(cmd);
     }
     g_list_free(device->pending_ops);
 


### PR DESCRIPTION
st_child_done does already call free_async_command ...
didn't see cases where we don't have st_child_done as done_cb.