### PR TITLE
Fix: libcrmcommon: handle schema versions properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
  - sudo apt-get update -qq
 
 install:
- - sudo apt-get install -qq automake autoconf chrpath libglib2.0-dev perl net-tools python libtool libxml2-dev bison flex uuid-dev libbz2-dev zlib1g-dev libltdl3-dev libgnutls-dev python-central python-dev libpam0g-dev libncurses5-dev libcorosync-dev libxslt1-dev libdbus-1-dev
+ - sudo apt-get install -qq automake autoconf chrpath libglib2.0-dev perl net-tools python libtool libxml2-dev bison flex uuid-dev libbz2-dev zlib1g-dev libltdl3-dev libgnutls-dev python-dev libpam0g-dev libncurses5-dev libcorosync-dev libxslt1-dev libdbus-1-dev
  - sudo apt-get install -qq cluster-glue-dev heartbeat-dev libheartbeat2-dev 
  - sudo apt-get install -qq libqb-dev
 

--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -84,8 +84,6 @@ crm_alert_envvar_t *crm_dup_alert_envvar(crm_alert_envvar_t *src);
 crm_alert_entry_t *crm_alert_entry_new(const char *id, const char *path);
 void crm_free_alert_entry(crm_alert_entry_t *entry);
 void crm_free_alert_envvar(crm_alert_envvar_t *entry);
-void crm_set_alert_key(enum crm_alert_keys_e name, const char *value);
-void crm_set_alert_key_int(enum crm_alert_keys_e name, int value);
 void crm_insert_alert_key(GHashTable *table, enum crm_alert_keys_e name,
                           const char *value);
 void crm_insert_alert_key_int(GHashTable *table, enum crm_alert_keys_e name,

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -35,7 +35,7 @@ libcrmcommon_la_LDFLAGS	= -version-info 10:0:7
 libcrmcommon_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 libcrmcommon_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)
 
-libcrmcommon_la_LIBADD	= @LIBADD_DL@ $(GNUTLSLIBS) -lm
+libcrmcommon_la_LIBADD	= @LIBADD_DL@ $(GNUTLSLIBS)
 
 libcrmcommon_la_SOURCES	= compat.c digest.c ipc.c io.c procfs.c utils.c xml.c	\
 			  iso8601.c remote.c mainloop.c logging.c watchdog.c	\

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -137,30 +137,6 @@ crm_dup_alert_entry(crm_alert_entry_t *entry)
 }
 
 void
-crm_set_alert_key(enum crm_alert_keys_e name, const char *value)
-{
-    const char **key;
-
-    for (key = crm_alert_keys[name]; *key; key++) {
-        crm_trace("Setting alert key %s = '%s'", *key, value);
-        if (value) {
-            setenv(*key, value, 1);
-        } else {
-            unsetenv(*key);
-        }
-    }
-}
-
-void
-crm_set_alert_key_int(enum crm_alert_keys_e name, int value)
-{
-    char *s = crm_itoa(value);
-
-    crm_set_alert_key(name, s);
-    free(s);
-}
-
-void
 crm_unset_alert_keys()
 {
     const char **key;

--- a/tools/regression.validity.exp
+++ b/tools/regression.validity.exp
@@ -93,7 +93,7 @@ Call failed: Update does not conform to the configured schema
 =#=#=#= End test: Try to make resulting CIB invalid (unrecognized validate-with) - Update does not conform to the configured schema (203) =#=#=#=
 * Passed: cibadmin       - Try to make resulting CIB invalid (unrecognized validate-with)
 =#=#=#= Begin test: Run crm_simulate with invalid CIB (unrecognized validate-with) =#=#=#=
-(   schemas.c:NNN   )   debug: update_validation:	Unknown validation type
+(   schemas.c:NNN   )   debug: update_validation:	Unknown validation schema
 (   schemas.c:NNN   )   debug: update_validation:	Testing 'pacemaker-0.6' validation (0 of X)
 element rsc_order: validity error : Element rsc_order does not carry attribute to
 element rsc_order: validity error : Element rsc_order does not carry attribute from

--- a/xml/Readme.md
+++ b/xml/Readme.md
@@ -42,7 +42,7 @@ Create from the most recent `${base}-${X}.${Y}.rng` if it does not already exist
 ## Stable features ##
 
 The current stable version is determined at runtime when
-__xml_build_schema_list() interrogates the CRM_DTD_DIRECTORY.
+crm_schema_init() scans the CRM_DTD_DIRECTORY.
 
 It will have the form `pacemaker-${X}.${Y}` and the highest
 `${X}.${Y}` wins.
@@ -75,7 +75,7 @@ See `xml/upgrade06.xsl` for an example.
 New features will not be available until the admin
 
 1. Updates all the nodes
-1. Runs the equivalent of `cibadmin --upgrade`
+1. Runs the equivalent of `cibadmin --upgrade --force`
 
 ## Random Notes
 


### PR DESCRIPTION
As a byproduct, this eliminates a dependency on the math library.