### PR TITLE
Add missing library dependencies

### DIFF
--- a/attrd/Makefile.am
+++ b/attrd/Makefile.am
@@ -29,6 +29,8 @@ attrd_LDFLAGS	= $(LDFLAGS_HARDENED_EXE)
 attrd_LDADD	= $(top_builddir)/lib/cluster/libcrmcluster.la	\
                 $(top_builddir)/lib/pengine/libpe_rules.la      \
 		$(top_builddir)/lib/common/libcrmcommon.la	\
+		$(top_builddir)/lib/services/libcrmservice.la	\
+		$(top_builddir)/lib/fencing/libstonithd.la	\
 		$(top_builddir)/lib/cib/libcib.la		\
                 $(top_builddir)/lib/lrmd/liblrmd.la             \
 		$(CLUSTERLIBS)

--- a/cib/Makefile.am
+++ b/cib/Makefile.am
@@ -24,6 +24,7 @@ halibdir	= $(CRM_DAEMON_DIR)
 commmoddir	= $(halibdir)/modules/comm
 
 COMMONLIBS	= $(top_builddir)/lib/common/libcrmcommon.la \
+		$(top_builddir)/lib/pengine/libpe_rules.la \
 		$(top_builddir)/lib/cib/libcib.la
 
 ## binary progs
@@ -36,6 +37,7 @@ cib_CFLAGS	= $(CFLAGS_HARDENED_EXE)
 cib_LDFLAGS	= $(LDFLAGS_HARDENED_EXE)
 
 cib_LDADD	= $(top_builddir)/lib/cluster/libcrmcluster.la \
+		$(top_builddir)/lib/fencing/libstonithd.la \
 		$(COMMONLIBS) $(CRYPTOLIB) $(CLUSTERLIBS)
 
 cib_SOURCES	= io.c messages.c notify.c \

--- a/fencing/Makefile.am
+++ b/fencing/Makefile.am
@@ -56,6 +56,7 @@ stonithd_CFLAGS		= $(CFLAGS_HARDENED_EXE)
 stonithd_LDFLAGS	= $(LDFLAGS_HARDENED_EXE)
 
 stonithd_LDADD		= $(top_builddir)/lib/common/libcrmcommon.la	\
+			$(top_builddir)/lib/cib/libcib.la		\
 			$(top_builddir)/lib/cluster/libcrmcluster.la	\
 			$(top_builddir)/lib/fencing/libstonithd.la	\
 			$(top_builddir)/lib/pengine/libpe_status.la	\

--- a/lrmd/Makefile.am
+++ b/lrmd/Makefile.am
@@ -52,17 +52,21 @@ pacemaker_remoted_SOURCES	= $(lrmd_SOURCES) tls_backend.c ipc_proxy.c
 
 lrmd_internal_ctl_LDADD		= $(top_builddir)/lib/common/libcrmcommon.la	\
 				$(top_builddir)/lib/lrmd/liblrmd.la		\
+				$(top_builddir)/lib/fencing/libstonithd.la	\
 				$(top_builddir)/lib/cib/libcib.la		\
 				$(top_builddir)/lib/services/libcrmservice.la	\
 				$(top_builddir)/lib/pengine/libpe_status.la	\
+				$(top_builddir)/lib/pengine/libpe_rules.la	\
 				$(top_builddir)/pengine/libpengine.la
 lrmd_internal_ctl_SOURCES	= remote_ctl.c
 
 lrmd_test_LDADD		= $(top_builddir)/lib/common/libcrmcommon.la	\
 			$(top_builddir)/lib/lrmd/liblrmd.la		\
+			$(top_builddir)/lib/fencing/libstonithd.la	\
 			$(top_builddir)/lib/cib/libcib.la		\
 			$(top_builddir)/lib/services/libcrmservice.la	\
 			$(top_builddir)/lib/pengine/libpe_status.la	\
+			$(top_builddir)/lib/pengine/libpe_rules.la	\
 			$(top_builddir)/pengine/libpengine.la
 lrmd_test_SOURCES	= test.c
 

--- a/mcp/Makefile.am
+++ b/mcp/Makefile.am
@@ -34,7 +34,10 @@ noinst_HEADERS		= pacemaker.h
 pacemakerd_CFLAGS	= $(CFLAGS_HARDENED_EXE)
 pacemakerd_LDFLAGS	= $(LDFLAGS_HARDENED_EXE)
 
-pacemakerd_LDADD	= $(top_builddir)/lib/cluster/libcrmcluster.la $(top_builddir)/lib/common/libcrmcommon.la
+pacemakerd_LDADD	= $(top_builddir)/lib/cluster/libcrmcluster.la	\
+			$(top_builddir)/lib/common/libcrmcommon.la	\
+			$(top_builddir)/lib/fencing/libstonithd.la
+
 pacemakerd_LDADD	+= $(CLUSTERLIBS)
 pacemakerd_SOURCES	= pacemaker.c corosync.c
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -24,6 +24,8 @@ endif
 COMMONLIBS	= 							\
 		$(top_builddir)/lib/common/libcrmcommon.la		\
 		$(top_builddir)/lib/cib/libcib.la			\
+		$(top_builddir)/lib/pengine/libpe_rules.la		\
+		$(top_builddir)/lib/fencing/libstonithd.la		\
 		$(CURSESLIBS) $(CLUSTERLIBS)
 
 noinst_HEADERS		= crm_resource.h fake_transition.h
@@ -83,9 +85,9 @@ crm_simulate_SOURCES	= crm_simulate.c fake_transition.c
 crm_simulate_CFLAGS	= -I$(top_srcdir)/pengine
 
 crm_simulate_LDADD	= $(top_builddir)/lib/pengine/libpe_status.la		\
-			$(top_builddir)/pengine/libpengine.la 			\
-			$(top_builddir)/lib/cib/libcib.la			\
+			$(top_builddir)/pengine/libpengine.la			\
 			$(top_builddir)/lib/lrmd/liblrmd.la			\
+			$(top_builddir)/lib/services/libcrmservice.la		\
 			$(top_builddir)/lib/transition/libtransitioner.la	\
 			$(COMMONLIBS)
 
@@ -94,7 +96,6 @@ crm_diff_LDADD		= $(COMMONLIBS)
 
 crm_mon_SOURCES		= crm_mon.c
 crm_mon_LDADD		= $(top_builddir)/lib/pengine/libpe_status.la		\
-			  $(top_builddir)/lib/fencing/libstonithd.la		\
 			  $(top_builddir)/pengine/libpengine.la \
 			  $(COMMONLIBS) $(SNMPLIBS) $(ESMTPLIBS)
 
@@ -109,11 +110,10 @@ crm_attribute_LDADD	= $(top_builddir)/lib/cluster/libcrmcluster.la $(COMMONLIBS)
 
 crm_resource_SOURCES	= crm_resource.c crm_resource_ban.c crm_resource_runtime.c crm_resource_print.c fake_transition.c
 crm_resource_CFLAGS	= -I$(top_srcdir)/pengine
-crm_resource_LDADD	= $(top_builddir)/lib/pengine/libpe_rules.la  		\
-			$(top_builddir)/lib/lrmd/liblrmd.la 			\
-			$(top_builddir)/lib/services/libcrmservice.la 		\
-			$(top_builddir)/lib/pengine/libpe_status.la 		\
-			$(top_builddir)/pengine/libpengine.la 			\
+crm_resource_LDADD	= $(top_builddir)/lib/lrmd/liblrmd.la			\
+			$(top_builddir)/lib/services/libcrmservice.la		\
+			$(top_builddir)/lib/pengine/libpe_status.la		\
+			$(top_builddir)/pengine/libpengine.la			\
 			$(top_builddir)/lib/transition/libtransitioner.la	\
 			$(COMMONLIBS)
 
@@ -124,8 +124,7 @@ attrd_updater_SOURCES	= attrd_updater.c
 attrd_updater_LDADD	= $(COMMONLIBS)
 
 crm_ticket_SOURCES	= crm_ticket.c
-crm_ticket_LDADD	= $(top_builddir)/lib/pengine/libpe_rules.la  \
-			$(top_builddir)/lib/pengine/libpe_status.la \
+crm_ticket_LDADD	= $(top_builddir)/lib/pengine/libpe_status.la \
 			$(top_builddir)/pengine/libpengine.la \
 			$(COMMONLIBS)
 


### PR DESCRIPTION
Libtool is totally broken when crosscompiling, so we need to explictly itemize
every library dependency. In theory, we could add each of the .lib directories
via -rpath or -rpath-link, but that would be very ugly.