### PR TITLE
Clear transient attributes at attrd start-up rather than crmd first join

### DIFF
--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -363,7 +363,7 @@ attrd_client_refresh(void)
     }
 
     crm_info("Updating all attributes");
-    write_attributes(TRUE, FALSE);
+    write_attributes(TRUE);
 }
 
 /*!
@@ -863,7 +863,7 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
         crm_trace("We know %s's node id now: %s",
                   known_peer->uname, known_peer->uuid);
         if (election_state(writer) == election_won) {
-            write_attributes(FALSE, TRUE);
+            write_attributes(FALSE);
             return;
         }
     }
@@ -900,7 +900,7 @@ attrd_election_cb(gpointer user_data)
     attrd_peer_sync(NULL, NULL);
 
     /* Update the CIB after an election */
-    write_attributes(TRUE, FALSE);
+    write_attributes(TRUE);
     return FALSE;
 }
 
@@ -982,14 +982,14 @@ attrd_cib_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
 }
 
 void
-write_attributes(bool all, bool peer_discovered)
+write_attributes(bool all)
 {
     GHashTableIter iter;
     attribute_t *a = NULL;
 
     g_hash_table_iter_init(&iter, attributes);
     while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & a)) {
-        if (peer_discovered && a->unknown_peer_uuids) {
+        if (!all && a->unknown_peer_uuids) {
             /* a new peer uuid has been discovered, try writing this attribute again. */
             a->changed = TRUE;
         }

--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -891,8 +891,6 @@ write_or_elect_attribute(attribute_t *a)
 gboolean
 attrd_election_cb(gpointer user_data)
 {
-    crm_trace("Election complete");
-
     free(peer_writer);
     peer_writer = strdup(attrd_cluster->uname);
 
@@ -987,10 +985,11 @@ write_attributes(bool all)
     GHashTableIter iter;
     attribute_t *a = NULL;
 
+    crm_debug("Writing out %s attributes", all? "all" : "changed");
     g_hash_table_iter_init(&iter, attributes);
     while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & a)) {
         if (!all && a->unknown_peer_uuids) {
-            /* a new peer uuid has been discovered, try writing this attribute again. */
+            // Try writing this attribute again, in case peer ID was learned
             a->changed = TRUE;
         }
 

--- a/attrd/internal.h
+++ b/attrd/internal.h
@@ -52,7 +52,7 @@ election_t *writer;
 #define attrd_send_ack(client, id, flags) \
     crm_ipcs_send_ack((client), (id), (flags), "ack", __FUNCTION__, __LINE__)
 
-void write_attributes(bool all, bool peer_discovered);
+void write_attributes(bool all);
 void attrd_peer_message(crm_node_t *client, xmlNode *msg);
 void attrd_client_peer_remove(const char *client_name, xmlNode *xml);
 void attrd_client_clear_failure(xmlNode *xml);

--- a/attrd/internal.h
+++ b/attrd/internal.h
@@ -48,7 +48,6 @@ typedef struct attribute_value_s {
 crm_cluster_t *attrd_cluster;
 GHashTable *attributes;
 election_t *writer;
-int attrd_error;
 
 #define attrd_send_ack(client, id, flags) \
     crm_ipcs_send_ack((client), (id), (flags), "ack", __FUNCTION__, __LINE__)

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -328,16 +328,15 @@ main(int argc, char **argv)
     }
     crm_info("Cluster connection active");
 
-    writer = election_init(T_ATTRD, attrd_cluster->uname, 120000, attrd_election_cb);
-    attrd_init_ipc(&ipcs, attrd_ipc_dispatch);
-    crm_info("Accepting attribute updates");
-
     attrd_exit_status = attrd_cib_connect(10);
     if (attrd_exit_status != pcmk_ok) {
         goto done;
     }
     crm_info("CIB connection active");
 
+    writer = election_init(T_ATTRD, attrd_cluster->uname, 120000, attrd_election_cb);
+    attrd_init_ipc(&ipcs, attrd_ipc_dispatch);
+    crm_info("Accepting attribute updates");
 
     attrd_run_mainloop();
 

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -97,7 +97,7 @@ attrd_cib_replaced_cb(const char *event, xmlNode * msg)
 {
     crm_notice("Updating all attributes after %s event", event);
     if(election_state(writer) == election_won) {
-        write_attributes(TRUE, FALSE);
+        write_attributes(TRUE);
     }
 }
 

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -148,7 +148,7 @@ attrd_cib_connect(int max_retry)
         goto cleanup;
     }
 
-    crm_info("Connected to the CIB after %d attempts", attempts);
+    crm_debug("Connected to the CIB after %d attempts", attempts);
 
     rc = connection->cmds->set_connection_dnotify(connection, attrd_cib_destroy_cb);
     if (rc != pcmk_ok) {

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -121,6 +121,48 @@ attrd_cib_destroy_cb(gpointer user_data)
     return;
 }
 
+static void
+attrd_erase_cb(xmlNode *msg, int call_id, int rc, xmlNode *output,
+               void *user_data)
+{
+    do_crm_log_unlikely((rc? LOG_NOTICE : LOG_DEBUG),
+                        "Cleared transient attributes: %s "
+                        CRM_XS " xpath=%s rc=%d",
+                        pcmk_strerror(rc), (char *) user_data, rc);
+}
+
+#define XPATH_TRANSIENT "//node_state[@uname='%s']/" XML_TAG_TRANSIENT_NODEATTRS
+
+/*!
+ * \internal
+ * \brief Wipe all transient attributes for this node from the CIB
+ *
+ * Clear any previous transient node attributes from the CIB. This is
+ * normally done by the DC's crmd when this node leaves the cluster, but
+ * this handles the case where the node restarted so quickly that the
+ * cluster layer didn't notice.
+ *
+ * \todo If attrd respawns after crashing (see PCMK_respawned), ideally we'd
+ *       skip this and sync our attributes from the writer. However, currently
+ *       we reject any values for us that the writer has, in
+ *       attrd_peer_update().
+ */
+static void
+attrd_erase_attrs()
+{
+    int call_id;
+    char *xpath = crm_strdup_printf(XPATH_TRANSIENT, attrd_cluster->uname);
+
+    crm_info("Clearing transient attributes from CIB " CRM_XS " xpath=%s",
+             xpath);
+
+    call_id = the_cib->cmds->delete(the_cib, xpath, NULL,
+                                    cib_quorum_override | cib_xpath);
+    the_cib->cmds->register_callback_full(the_cib, call_id, 120, FALSE, xpath,
+                                          "attrd_erase_cb", attrd_erase_cb,
+                                          free);
+}
+
 static int
 attrd_cib_connect(int max_retry)
 {
@@ -168,6 +210,9 @@ attrd_cib_connect(int max_retry)
         crm_err("Could not set CIB notification callback (update)");
         goto cleanup;
     }
+
+    // We have no attribute values in memory, wipe the CIB to match
+    attrd_erase_attrs();
 
     // Set a trigger for reading the CIB (for the alerts section)
     attrd_config_read = mainloop_add_trigger(G_PRIORITY_HIGH, attrd_read_options, NULL);

--- a/crmd/join_client.c
+++ b/crmd/join_client.c
@@ -286,12 +286,12 @@ do_cl_join_finalize_respond(long long action,
                   join_id, fsa_our_dc);
 
         /*
-         * If this is the node's first join since the crmd started on it, clear
-         * any previous transient node attributes, to handle the case where
-         * the node restarted so quickly that the cluster layer didn't notice.
+         * If this is the node's first join since the crmd started on it,
+         * set its initial state (standby or member) according to the user's
+         * preference.
          *
-         * Do not remove the resources though, they'll be cleaned up in
-         * do_dc_join_ack(). Removing them here creates a race condition if the
+         * We do not clear the LRM history here. Even if the DC failed to do it
+         * when we last left, removing them here creates a race condition if the
          * crmd is being recovered. Instead of a list of active resources from
          * the lrmd, we may end up with a blank status section. If we are _NOT_
          * lucky, we will probe for the "wrong" instance of anonymous clones and
@@ -299,10 +299,6 @@ do_cl_join_finalize_respond(long long action,
          */
         if (first_join && is_not_set(fsa_input_register, R_SHUTDOWN)) {
             first_join = FALSE;
-            erase_status_tag(fsa_our_uname, XML_TAG_TRANSIENT_NODEATTRS, 0);
-            update_attrd(fsa_our_uname, "terminate", NULL, NULL, FALSE);
-            update_attrd(fsa_our_uname, XML_CIB_ATTR_SHUTDOWN, "0", NULL, FALSE);
-
             if (start_state) {
                 set_join_state(start_state);
             }


### PR DESCRIPTION
fe44f400 (getting rid of unnecessary complete attribute write-outs at node join) exposed a different issue.

When a node leaves and re-joins the cluster, attrd will be up and accepting requests before the crmd comes up, so attrd can set transient attributes during this time. These will get recorded by attrd and cib correctly.

However, when the crmd completes its first join, it would erase its own transient attributes from the CIB, to handle the case where the node restarted too quickly for the cluster layer to notice
(and thus no peer loss was noticed by the other nodes). It would not wipe them from attrd, so any values set in that window would be in attrd but not the CIB. Before fe44f400, the write-out after join would put those values back in the CIB, but now, the inconsistent state remains.

The solution here is to move the transient attribute clearing to attrd start-up rather than crmd's first join.

Reproducer:
1. Start cluster.
2. On one node, run 'attrd_updater -n testattr -U testval1', then restart pacemaker and immediately run 'attrd_updater -n testattr -U testval2'.

In all versions, testval1 is correctly set, then correctly erased when the node leaves the cluster. Before fe44f400, testval2 would be set, then wiped from the CIB, then re-written to the CIB. After fe44f400 but before these changes, testval2 would be set, then wiped from the CIB, and remain in that state. After these changes, testval2 is set, and not wiped.