### PR TITLE
Fix: pengine: Make sure calculated resource scores are consistent on different architectures

### DIFF
--- a/pengine/native.c
+++ b/pengine/native.c
@@ -235,11 +235,20 @@ node_hash_update(GHashTable * list1, GHashTable * list2, const char *attr, float
 
     g_hash_table_iter_init(&iter, list1);
     while (g_hash_table_iter_next(&iter, NULL, (void **)&node)) {
+        float weight_f = 0;
+        int weight = 0;
+
         CRM_LOG_ASSERT(node != NULL);
         if(node == NULL) { continue; };
 
         score = node_list_attr_score(list2, attr, g_hash_table_lookup(node->details->attrs, attr));
-        new_score = merge_weights(factor * score, node->weight);
+
+        weight_f = factor * score;
+        /* Round the number */
+        /* http://c-faq.com/fp/round.html */
+        weight = (int)(weight_f < 0 ? weight_f - 0.5 : weight_f + 0.5);
+
+        new_score = merge_weights(weight, node->weight);
 
         if (factor < 0 && score < 0) {
             /* Negative preference for a node with a negative score


### PR DESCRIPTION
Previously, pengine test "bundle-nested-colocation" failed on x86
architecture:

```
@@ -334,8 +334,8 @@
 native_color: rabbitmq-bundle-docker-0 allocation score on overcloud-galera-1: -INFINITY
 native_color: rabbitmq-bundle-docker-0 allocation score on overcloud-galera-2: -INFINITY
 native_color: rabbitmq-bundle-docker-0 allocation score on overcloud-rabbit-0: INFINITY
-native_color: rabbitmq-bundle-docker-0 allocation score on overcloud-rabbit-1: -9999
-native_color: rabbitmq-bundle-docker-0 allocation score on overcloud-rabbit-2: -9999
+native_color: rabbitmq-bundle-docker-0 allocation score on overcloud-rabbit-1: -9998
+native_color: rabbitmq-bundle-docker-0 allocation score on overcloud-rabbit-2: -9998
 native_color: rabbitmq-bundle-docker-0 allocation score on rabbitmq-bundle-0: -INFINITY
 native_color: rabbitmq-bundle-docker-0 allocation score on rabbitmq-bundle-1: -INFINITY
 native_color: rabbitmq-bundle-docker-0 allocation score on rabbitmq-bundle-2: -INFINITY
@@ -347,7 +347,7 @@
 native_color: rabbitmq-bundle-docker-1 allocation score on overcloud-galera-2: -INFINITY
 native_color: rabbitmq-bundle-docker-1 allocation score on overcloud-rabbit-0: -INFINITY
 native_color: rabbitmq-bundle-docker-1 allocation score on overcloud-rabbit-1: INFINITY
-native_color: rabbitmq-bundle-docker-1 allocation score on overcloud-rabbit-2: -9999
+native_color: rabbitmq-bundle-docker-1 allocation score on overcloud-rabbit-2: -9998
 native_color: rabbitmq-bundle-docker-1 allocation score on rabbitmq-bundle-0: -INFINITY
 native_color: rabbitmq-bundle-docker-1 allocation score on rabbitmq-bundle-1: -INFINITY
 native_color: rabbitmq-bundle-docker-1 allocation score on rabbitmq-bundle-2: -INFINITY
```

In this case, given:

float factor = 10000.0 / 1000000;
int score = -1000000;
int weight = factor * score;

, the "weight" would be -10000 on x86_64, but -9999 on x86.

This commit fixes it by rounding the number according to the description
in http://c-faq.com/fp/round.html:

"Note that because truncation is otherwise the default, it's usually a
good idea to use an explicit rounding step when converting
floating-point numbers to integers. Unless you're careful, it's quite
possible for a number which you thought was 8.0 to be represented
internally as 7.999999 and to be truncated to 7."