### PR TITLE
Fix: liblrmd: Make sure the operation of a remote resource returns if setup of the key fails

### DIFF
--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1154,8 +1154,12 @@ lrmd_tcp_connect_cb(void *userdata, int sock)
      * to avoid all blocking code in the client. */
     native->sock = sock;
 
-    if (lrmd_tls_set_key(&psk_key) != 0) {
+    rc = lrmd_tls_set_key(&psk_key);
+    if (rc != 0) {
+        crm_warn("Setup of the key failed (rc=%d) for remote node %s:%d",
+                 rc, native->server, native->port);
         lrmd_tls_connection_destroy(lrmd);
+        report_async_connection_result(lrmd, rc);
         return;
     }
 


### PR DESCRIPTION
Previously, if the operation of a remote resource failed on setting up
the key, it'd become forever in-flight operation and never return.