### PR TITLE
fix: stonith-ng: advertise pcmk_on_action via metadata

### DIFF
--- a/fencing/main.c
+++ b/fencing/main.c
@@ -1289,7 +1289,7 @@ main(int argc, char **argv)
     int argerr = 0;
     int option_index = 0;
     crm_cluster_t cluster;
-    const char *actions[] = { "reboot", "off", "list", "monitor", "status" };
+    const char *actions[] = { "reboot", "off", "on", "list", "monitor", "status" };
 
     crm_log_preinit("stonith-ng", argc, argv);
     crm_set_options(NULL, "mode [options]", long_options,


### PR DESCRIPTION
The metadata being used by high-level-tooling to determine which
attributes can be set for fencing-resources this is needed to
be able to replace the on-action by an alternate command.

Assuming there is no intention behind not having 'on' in the list of actions ...