### PR TITLE
Change XML syntax used to filter alert events

### DIFF
--- a/doc/Pacemaker_Explained/en-US/Ch-Alerts.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Alerts.txt
@@ -164,6 +164,65 @@ instance attributes are completely up to the particular agent.
 =====
 
 
+== Alert Filters ==
+
+'Coming in 1.1.18'
+
+By default, an alert agent will be called for node events, fencing events, and
+resource events. An agent may choose to ignore certain types of events, but
+there is still the overhead of calling it for those events. To eliminate that
+overhead, you may select which types of events the agent should receive.
+
+.Alert configuration to receive only node events and fencing events
+=====
+[source,XML]
+-----
+<configuration>
+    <alerts>
+        <alert id="my-alert" path="/path/to/my-script.sh">
+            <select>
+              <select_nodes />
+              <select_fencing />
+            </select>
+            <recipient id="my-alert-recipient1" value="someuser@example.com"/>
+        </alert>
+    </alerts>
+</configuration>
+-----
+=====
+
+The possible options within +<select>+ are +<select_nodes>+,
++<select_fencing>+, +<select_resources>+, and +<select_attributes>+.
+
+With +<select_attributes>+ (the only event type not enabled by default), the
+agent will receive alerts when a node attribute changes. If you wish the agent
+to be called only when certain attributes change, you can configure that as well.
+
+.Alert configuration to be called when certain node attributes change
+=====
+[source,XML]
+-----
+<configuration>
+    <alerts>
+        <alert id="my-alert" path="/path/to/my-script.sh">
+            <select>
+              <select_attributes>
+                <attribute id="alert-standby" name="standby" />
+                <attribute id="alert-shutdown" name="shutdown" />
+              </select_attributes>
+            </select>
+            <recipient id="my-alert-recipient1" value="someuser@example.com"/>
+        </alert>
+    </alerts>
+</configuration>
+-----
+=====
+
+Node attribute alerts are currently considered experimental. Alerts may be
+limited to attributes set via attrd_updater, and agents may be called multiple
+times with the same attribute value.
+
+
 == Using the Sample Alert Agents ==
 
 Pacemaker provides several sample alert agents, installed in
@@ -212,8 +271,8 @@ See their source code for the full set of instance attributes they support.
 -----
 =====
 
-== Writing an Alert Agent ==
 
+== Writing an Alert Agent ==
 
 .Environment variables passed to alert agents
 
@@ -224,7 +283,7 @@ See their source code for the full set of instance attributes they support.
 |Description
 
 |CRM_alert_kind
-|The type of alert (+node+, +fencing+, or +resource+)
+|The type of alert (+node+, +fencing+, +resource+, or +attribute+)
  indexterm:[Environment Variable,CRM_alert_,kind]
 
 |CRM_alert_version
@@ -293,6 +352,14 @@ See their source code for the full set of instance attributes they support.
 |A numerical code used by Pacemaker to represent the operation result
  (+resource+ alerts only)
  indexterm:[Environment Variable,CRM_alert_,status]
+
+|CRM_alert_attribute_name
+|The name of the node attribute that changed (+attribute+ alerts only)
+ indexterm:[Environment Variable,CRM_alert_,attribute_name]
+
+|CRM_alert_attribute_value
+|The new value of the node attribute that changed (+attribute+ alerts only)
+ indexterm:[Environment Variable,CRM_alert_,attribute_value]
 
 |=========================================================
 

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -167,6 +167,12 @@
 #  define XML_CIB_TAG_ALERTS    	"alerts"
 #  define XML_CIB_TAG_ALERT   		"alert"
 #  define XML_CIB_TAG_ALERT_RECIPIENT	"recipient"
+#  define XML_CIB_TAG_ALERT_SELECT      "select"
+#  define XML_CIB_TAG_ALERT_ATTRIBUTES  "select_attributes"
+#  define XML_CIB_TAG_ALERT_FENCING     "select_fencing"
+#  define XML_CIB_TAG_ALERT_NODES       "select_nodes"
+#  define XML_CIB_TAG_ALERT_RESOURCES   "select_resources"
+#  define XML_CIB_TAG_ALERT_ATTR        "attribute"
 
 #  define XML_CIB_TAG_STATE         	"node_state"
 #  define XML_CIB_TAG_NODE          	"node"
@@ -371,8 +377,6 @@
 #  define XML_ALERT_ATTR_TIMEOUT	"timeout"
 #  define XML_ALERT_ATTR_TSTAMP_FORMAT	"timestamp-format"
 #  define XML_ALERT_ATTR_REC_VALUE	"value"
-#  define XML_ALERT_ATTR_SELECT_KIND	"kind"
-#  define XML_ALERT_ATTR_SELECT_ATTRIBUTE_NAME	"attribute_name"
 
 #  define XML_CIB_TAG_GENERATION_TUPPLE	"generation_tuple"
 

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -82,19 +82,18 @@ crm_alert_entry_new(const char *id, const char *path)
 void
 crm_free_alert_entry(crm_alert_entry_t *entry)
 {		
-    free(entry->id);		
-    free(entry->path);		
-    free(entry->tstamp_format);		
-    free(entry->recipient);		
+    if (entry) {
+        free(entry->id);
+        free(entry->path);
+        free(entry->tstamp_format);
+        free(entry->recipient);
 
-    if(entry->select_attribute_name) {
         g_strfreev(entry->select_attribute_name);
+        if (entry->envvars) {
+            g_hash_table_destroy(entry->envvars);
+        }
+        free(entry);
     }
-
-    if (entry->envvars) {		
-        g_hash_table_destroy(entry->envvars);
-    }		
-    free(entry);		
 }		
 
 crm_alert_envvar_t *

--- a/tools/regression.validity.exp
+++ b/tools/regression.validity.exp
@@ -70,7 +70,11 @@ element rsc_order: Relax-NG validity error : Element constraints has extra conte
 element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
 element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 (   schemas.c:NNN   )   trace: update_validation:	pacemaker-2.9 validation failed
-Your current configuration pacemaker-1.2 could not validate with any schema in range [pacemaker-1.2, pacemaker-2.9], cannot upgrade to pacemaker-2.0.
+(   schemas.c:NNN   )   debug: update_validation:	Testing 'pacemaker-2.10' validation (16 of X)
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+(   schemas.c:NNN   )   trace: update_validation:	pacemaker-2.10 validation failed
+Your current configuration pacemaker-1.2 could not validate with any schema in range [pacemaker-1.2, pacemaker-2.10], cannot upgrade to pacemaker-2.0.
 =#=#=#= End test: Run crm_simulate with invalid CIB (enum violation) - Required key not available (126) =#=#=#=
 * Passed: crm_simulate   - Run crm_simulate with invalid CIB (enum violation)
 =#=#=#= Begin test: Try to make resulting CIB invalid (unrecognized validate-with) =#=#=#=
@@ -150,7 +154,10 @@ element cib: Relax-NG validity error : Invalid attribute validate-with for eleme
 (   schemas.c:NNN   )   debug: update_validation:	Testing 'pacemaker-2.9' validation (15 of X)
 element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:NNN   )   trace: update_validation:	pacemaker-2.9 validation failed
-Your current configuration pacemaker-9999.0 could not validate with any schema in range [unknown, pacemaker-2.9], cannot upgrade to pacemaker-2.0.
+(   schemas.c:NNN   )   debug: update_validation:	Testing 'pacemaker-2.10' validation (16 of X)
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+(   schemas.c:NNN   )   trace: update_validation:	pacemaker-2.10 validation failed
+Your current configuration pacemaker-9999.0 could not validate with any schema in range [unknown, pacemaker-2.10], cannot upgrade to pacemaker-2.0.
 =#=#=#= End test: Run crm_simulate with invalid CIB (unrecognized validate-with) - Required key not available (126) =#=#=#=
 * Passed: crm_simulate   - Run crm_simulate with invalid CIB (unrecognized validate-with)
 =#=#=#= Begin test: Try to make resulting CIB invalid, but possibly recoverable (valid with X.Y+1) =#=#=#=
@@ -207,8 +214,11 @@ element tags: Relax-NG validity error : Element configuration has extra content:
 (   schemas.c:NNN   )   debug: update_validation:	pacemaker-2.8-style configuration is also valid for pacemaker-2.9
 (   schemas.c:NNN   )   debug: update_validation:	Testing 'pacemaker-2.9' validation (15 of X)
 (   schemas.c:NNN   )   debug: update_validation:	Configuration valid for schema: pacemaker-2.9
-(   schemas.c:NNN   )   trace: update_validation:	Stopping at pacemaker-2.9
-(   schemas.c:NNN   )    info: update_validation:	Transformed the configuration from pacemaker-1.2 to pacemaker-2.9
+(   schemas.c:NNN   )   debug: update_validation:	pacemaker-2.9-style configuration is also valid for pacemaker-2.10
+(   schemas.c:NNN   )   debug: update_validation:	Testing 'pacemaker-2.10' validation (16 of X)
+(   schemas.c:NNN   )   debug: update_validation:	Configuration valid for schema: pacemaker-2.10
+(   schemas.c:NNN   )   trace: update_validation:	Stopping at pacemaker-2.10
+(   schemas.c:NNN   )    info: update_validation:	Transformed the configuration from pacemaker-1.2 to pacemaker-2.10
 error: unpack_resources:	Resource start-up disabled since no STONITH resources have been defined
 error: unpack_resources:	Either configure some or disable STONITH with the stonith-enabled option
 error: unpack_resources:	NOTE: Clusters with shared data need STONITH to ensure data integrity
@@ -338,6 +348,8 @@ element rsc_order: Relax-NG validity error : Invalid attribute first-action for 
 element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
 element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 =#=#=#= Current cib after: Make resulting CIB invalid, and without validate-with attribute =#=#=#=
 <cib epoch="31" num_updates="0" admin_epoch="0" validate-with="none">
   <configuration>
@@ -367,6 +379,8 @@ bad-1.2.xml:10: element rsc_order: validity error : Element rsc_order does not c
 bad-1.2.xml:10: element rsc_order: validity error : No declaration for attribute first of element rsc_order
 bad-1.2.xml:10: element rsc_order: validity error : No declaration for attribute first-action of element rsc_order
 bad-1.2.xml:10: element rsc_order: validity error : No declaration for attribute then of element rsc_order
+bad-1.2.xml:10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+bad-1.2.xml:10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 bad-1.2.xml:10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
 bad-1.2.xml:10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 bad-1.2.xml:10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order

--- a/xml/Readme.md
+++ b/xml/Readme.md
@@ -1,11 +1,11 @@
 # Schema Reference
 
-Besides the version of Pacemaker itself, the XML schema of the Pacemaker
-configuration has its own version.
+Pacemaker's XML schema has a version of its own, independent of the version of
+Pacemaker itself.
 
 ## Versioned Schema Evolution
 
-A versioned schema offers transparent backward/forward compatibility.
+A versioned schema offers transparent backward and forward compatibility.
 
 - It reflects the timeline of schema-backed features (introduction,
   changes to the syntax, possibly deprecation) through the versioned
@@ -31,13 +31,27 @@ A versioned schema offers transparent backward/forward compatibility.
 | `1.1.12`  | `2.0`         | `nodes`, `nvset`, `resources`, `tags` + `acls`
 | `1.1.8`+  | `1.2`         |
 
+## Schema generation
+
+Each logical portion of the schema goes into its own RNG file, named like
+`${base}-${X}.${Y}.rng`. `${base}` identifies the portion of the schema
+(e.g. constraints, resources); ${X}.${Y} is the latest schema version that
+contained changes in this portion of the schema.
+
+The complete, overall schema, `pacemaker-${X}.${Y}.rng`, is automatically
+generated from the other files via the Makefile.
+
 # Updating schema files #
 
 ## Experimental features ##
 
-Experimental features go into `${base}-next.rng`
+Experimental features go into `${base}-next.rng` where `${base}` is the
+affected portion of the schema. If such a file does not already exist,
+create it by copying the most recent `${base}-${X}.${Y}.rng`.
 
-Create from the most recent `${base}-${X}.${Y}.rng` if it does not already exist
+Pacemaker will not use the experimental schema by default; the cluster
+administrator must explicitly set the `validate-with` property appropriately to
+use it.
 
 ## Stable features ##
 
@@ -50,29 +64,37 @@ It will have the form `pacemaker-${X}.${Y}` and the highest
 ### Simple Additions
 
 When the new syntax is a simple addition to the previous one, create a
-new entry with `${Y} = ${Yold} + 1`
+new entry, incrementing `${Y}`.
 
 ### Feature Removal or otherwise Incompatible Changes
 
 When the new syntax is not a simple addition to the previous one,
-create a new entry with `${X} = ${Xold} + 1` and `${Y} = 0`.
+create a new entry, incrementing `${X}` and setting `${Y} = 0`.
 
 An XSLT file is also required that converts an old syntax to the new
 one and must be named `upgrade-${Xold}.${Yold}.xsl`.
 
-See `xml/upgrade06.xsl` for an example.
+See `xml/upgrade-1.3.xsl` for an example.
 
 ### General Procedure
 
 1. Copy the most recent version of `${base}-*.rng` to `${base}-${X}.${Y}.rng` 
-1. Commit the copy, eg. `"Clone the latest ${base} schema in preparation for changes"`.  
-   This way the actual change will be obvious in the commit history.
-1. Modify `${base}-${X}.${Y}.rng` as required
-1. Add an XSLT file if required and update `xslt_SCRIPTS` in `xml/Makefile.am` 
+1. Commit the copy, e.g. `"Low: xml: clone ${base} schema in preparation for
+   changes"`. This way, the actual change will be obvious in the commit history.
+1. Modify `${base}-${X}.${Y}.rng` as required.
+1. If required, add an XSLT file, and update `xslt_SCRIPTS` in `xml/Makefile.am`.
 1. Commit
+1. `make -C xml clean; make -C xml all` to rebuild the schemas in the local
+   source directory.
+1. The CIB validity regression tests will break after the schema is updated.
+   Run `tools/regression.sh` to get the new output,
+   `diff tools/regression.validity.{out,exp}` to ensure the changes look correct,
+   `cp tools/regression.validity.{out,exp}` to update the expected output,
+   then commit the change.
 
-## Admin Tasks
-New features will not be available until the admin
+## Using a New Schema
+
+New features will not be available until the cluster administrator:
 
 1. Updates all the nodes
 1. Runs the equivalent of `cibadmin --upgrade --force`

--- a/xml/alerts-2.10.rng
+++ b/xml/alerts-2.10.rng
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" 
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+      <ref name="element-alerts"/>
+  </start>
+
+  <define name="element-alerts">
+    <optional>
+    <element name="alerts">
+      <zeroOrMore>
+        <element name="alert">
+          <attribute name="id"><data type="ID"/></attribute>
+          <optional>
+            <attribute name="description"><text/></attribute>
+          </optional>
+          <!-- path to the script called for alert -->
+          <attribute name="path"><text/></attribute>
+          <ref name="element-alert-extra"/>
+          <zeroOrMore>
+            <element name="recipient">
+              <attribute name="id"><data type="ID"/></attribute>
+              <optional>
+                <attribute name="description"><text/></attribute>
+              </optional>
+              <attribute name="value"><text/></attribute>
+              <ref name="element-alert-extra"/>
+            </element>
+          </zeroOrMore>
+        </element>
+      </zeroOrMore>
+    </element>
+    </optional>
+  </define>
+
+  <define name="element-alert-extra">
+      <zeroOrMore>
+        <choice>
+          <element name="meta_attributes">
+            <externalRef href="nvset-2.9.rng"/>
+          </element>
+          <element name="instance_attributes">
+            <externalRef href="nvset-2.9.rng"/>
+          </element>
+        </choice>
+      </zeroOrMore>
+  </define>
+
+</grammar>

--- a/xml/alerts-2.10.rng
+++ b/xml/alerts-2.10.rng
@@ -16,17 +16,50 @@
           </optional>
           <!-- path to the script called for alert -->
           <attribute name="path"><text/></attribute>
-          <ref name="element-alert-extra"/>
-          <zeroOrMore>
-            <element name="recipient">
-              <attribute name="id"><data type="ID"/></attribute>
-              <optional>
-                <attribute name="description"><text/></attribute>
-              </optional>
-              <attribute name="value"><text/></attribute>
-              <ref name="element-alert-extra"/>
-            </element>
-          </zeroOrMore>
+          <interleave>
+            <ref name="element-alert-extra"/>
+            <optional>
+              <element name="select">
+                <interleave>
+                  <optional>
+                    <element name="select_attributes">
+                      <zeroOrMore>
+                        <element name="attribute">
+                          <attribute name="id"><data type="ID"/></attribute>
+                          <attribute name="name"><text/></attribute>
+                        </element>
+                      </zeroOrMore>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name="select_fencing">
+                      <empty/>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name="select_nodes">
+                      <empty/>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name="select_resources">
+                      <empty/>
+                    </element>
+                  </optional>
+                </interleave>
+              </element>
+            </optional>
+            <zeroOrMore>
+              <element name="recipient">
+                <attribute name="id"><data type="ID"/></attribute>
+                <optional>
+                  <attribute name="description"><text/></attribute>
+                </optional>
+                <attribute name="value"><text/></attribute>
+                <ref name="element-alert-extra"/>
+              </element>
+            </zeroOrMore>
+          </interleave>
         </element>
       </zeroOrMore>
     </element>


### PR DESCRIPTION
Structured XML is now used to filter alert events, instead of comma-separated lists in the "kind" and "attribute_name" meta-attributes, so that more errors can be caught when the schema is validated. Example of new syntax:

       <alert id="my-alert" path="/path/to/my-script.sh">
         <select>
            <select_attributes>
              <attribute name="myattr" />
            </select_attributes>
            <select_resources />
         </select>
       ...
