### PR TITLE
ispeed resource agent improvement.

### DIFF
--- a/extra/resources/ifspeed
+++ b/extra/resources/ifspeed
@@ -204,6 +204,8 @@ iface_get_speed() {
             bond_get_speed ${iface}
         elif iface_is_vlan ${iface} ; then
             iface_get_speed $( vlan_get_phy ${iface} )
+        elif iface_is_hfi1 "${iface}" ; then
+            hfi1_get_speed "${iface}"
         else
             read speed < "/sys/class/net/${iface}/speed"
             echo ${speed}
@@ -224,6 +226,19 @@ iface_is_bridge() {
 iface_is_bond() {
     local iface=$1
     [ -e "/sys/class/net/${iface}/bonding" ] && return 0 || return 1
+}
+
+iface_is_infiniband() {
+    local iface=$1
+    local type
+    read type < /sys/class/net/${iface}/type
+    [ ${type} -eq 32 ] && return 0 || return 1
+}
+
+iface_is_hfi1() {
+    local iface=$1
+    driver=$(readlink /sys/class/net/${iface}/device/driver)
+    [[ $(basename ${driver}) =~ "hfi1" ]] && return 0 || return 1
 }
 
 vlan_get_phy() {
@@ -323,6 +338,24 @@ bridge_get_speed() {
     else # Expect sub-shell
         echo ${aggregate_speed}
     fi
+}
+
+hfi1_get_speed() {
+    local iface=$1
+    local hfi1_speed
+    local hfi1_speed
+    local hfi1_value
+    local hfi1_desc
+
+    # Currently (9/14/2017 Intel Omni Path v10.5.0.0.155) Intel doesn't have Dual/Multiple ports Host Channel Adapters
+    # and it's save to use such method to get a speed.
+    # Example of output:
+    # [root@es-host0 ~]# cat /sys/class/net/ib0/device/infiniband/*/ports/*/rate
+    # 100 Gb/sec (4X EDR)
+    read hfi1_speed hfi1_value hfi1_desc < /sys/class/net/${iface}/device/infiniband/*/ports/*/rate
+    
+    # hfi1_value always in Gb/sec, so we need to convert hfi1_speed in Mb/sec
+    echo $(expr $hfi1_speed \* 1000)
 }
 
 bond_get_slaves() {


### PR DESCRIPTION
Added support of Intel Omni Path nics.

Since Intel HFI's don't support /sys/class/net/<iface>/speed ifspeed resource agent will always show OCF_RESKEY_default_speed_default. This improvement allows to get a speed param from <rate> which is located in /sys/class/net/<iface>/device/infiniband/<hfi1_adapter>/ports/*/rate .