### PR TITLE
Build: Include libxml/tree.h in crm/common/util.h

### DIFF
--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -32,6 +32,8 @@
 #  include <sysexits.h>
 #  include <glib.h>
 
+#  include <libxml/tree.h>
+
 #  include <crm/lrmd.h>
 
 #  if SUPPORT_HEARTBEAT


### PR DESCRIPTION
Sbd failed to build against 67795f1a0:
```
In file included from sbd-inquisitor.c:19:0:
/usr/include/pacemaker/crm/common/util.h:130:1: error: unknown type name ‘xmlNode’
 xmlNode *crm_create_op_xml(xmlNode *parent, const char *prefix,
 ^
/usr/include/pacemaker/crm/common/util.h:130:28: error: unknown type name ‘xmlNode’
 xmlNode *crm_create_op_xml(xmlNode *parent, const char *prefix,
                            ^
```