### PR TITLE
Low: lib: logging: use crm_info instead of fprintf

### DIFF
--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -311,7 +311,7 @@ crm_add_logfile(const char *filename)
                 crm_warn("Cannot change the mode of %s to rw-rw----", filename);
             }
 
-            fprintf(logfile, "Set r/w permissions for uid=%d, gid=%d on %s\n",
+            crm_info("Set r/w permissions for uid=%d, gid=%d on %s\n",
                     pcmk_uid, pcmk_gid, filename);
             if (fflush(logfile) < 0 || fsync(logfd) < 0) {
                 crm_err("Couldn't write out logfile: %s", filename);


### PR DESCRIPTION
Hi:
When I'm doing some work as parse log time in crmsh(hb_report), 
my program will crash because this line not follow the logging format rules.
So I think it's better to use crm_info instead of fprintf

Regards,
xin