### PR TITLE
Fix: crm_mon: error-exit child if execl should return

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -3625,6 +3625,7 @@ send_custom_trap(const char *node, const char *rsc, const char *task, int target
     if (pid == 0) {
         /* crm_debug("notification: I am the child. Executing the nofitication program."); */
         execl(external_agent, external_agent, NULL);
+        exit(EXIT_FAILURE);
     }
 
     crm_trace("Finished running custom notification program '%s'.", external_agent);


### PR DESCRIPTION
Fixes rhbz#1500509