### PR TITLE
Fix invalid error in crm_resource --force-start/stop/check

### DIFF
--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -431,6 +431,7 @@ main(int argc, char **argv)
     bool require_crmd = FALSE;    /* whether command requires connection to CRMd */
 
     int rc = pcmk_ok;
+    int is_ocf_rc = 0;
     int option_index = 0;
     int timeout_ms = 0;
     int argerr = 0;
@@ -871,6 +872,9 @@ main(int argc, char **argv)
 
     } else if (rsc_cmd == 0 && rsc_long_cmd) { /* validate or force-(stop|start|check) */
         rc = cli_resource_execute(rsc_id, rsc_long_cmd, override_params, cib_conn, &data_set);
+        if (rc >= 0) {
+            is_ocf_rc = 1;
+        }
 
     } else if (rsc_cmd == 'A' || rsc_cmd == 'a') {
         GListPtr lpc = NULL;
@@ -1188,7 +1192,7 @@ main(int argc, char **argv)
         CMD_ERR("Error performing operation: %s", pcmk_strerror(rc));
         CMD_ERR("Try using -f");
 
-    } else if (rc != pcmk_ok) {
+    } else if (rc != pcmk_ok && !is_ocf_rc) {
         CMD_ERR("Error performing operation: %s", pcmk_strerror(rc));
     }
 

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1525,6 +1525,7 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
     }
 
 
+    setenv("HA_debug", do_trace ? "1" : "0", 1);
     if(do_trace) {
         setenv("OCF_TRACE_RA", "1", 1);
     }


### PR DESCRIPTION
crm_resource --force-check shows an invalid error message when a RA returns other than OCF_SUCCESS, although it's working perfectly as expected:
```
[root@centos73-1 ~]# crm_resource  --force-stop -r dummy1
Operation stop for dummy1 (ocf:heartbeat:Dummy) returned 0
 >  stderr: DEBUG: dummy1 stop : 0
[root@centos73-1 ~]# crm_resource  --force-check -r dummy1
Operation monitor for dummy1 (ocf:heartbeat:Dummy) returned 7
 >  stderr: DEBUG: dummy1 monitor : 7
Error performing operation: Argument list too long
[root@centos73-1 ~]# 
```
Also, it always shows RA's logs as debug level, which could be a bit noisy for some RAs.

This PR suggests to fix those as:
* do not show an error message when it's returning an OCF return value
* do not show RA's debug logs unless -V option was specified

