### PR TITLE
Build: spec: support for --without snmp and --without esmtp

### DIFF
--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -120,6 +120,10 @@
 ## Add option to turn off CMAN support on CMAN-native platforms
 %bcond_without cman
 
+## Add option to turn off SNMP / ESMTP support
+%bcond_without snmp
+%bcond_without esmtp
+
 ## Add option to turn off hardening of libraries and daemon executables
 %bcond_without hardening
 
@@ -395,6 +399,8 @@ export LDFLAGS_HARDENED_LIB="%{?_hardening_ldflags}"
         %{?with_profiling:   --with-profiling}     \
         %{?with_coverage:    --with-coverage}      \
         %{!?with_cman:       --without-cman}       \
+        %{!?with_snmp:       --without-snmp}       \
+        %{!?with_esmtp:      --without-esmtp}      \
         --without-heartbeat                        \
         %{!?with_doc:        --with-brand=}        \
         %{!?with_hardening:  --disable-hardening}  \


### PR DESCRIPTION
"make rpm" of Pacemaker-1.1.18 in an environment where net-snmp-devel or libesmtp-devel is installed will create crmd outputting the following warning.
* https://github.com/ClusterLabs/pacemaker/blob/Pacemaker-1.1.18-rc3/crmd/main.c#L136-L147

So, I want to be able to disable the features of SNMP and ESMTP even in "make rpm".

"WITH='--without snmp --without esmtp' make rpm" before adding commit :
```
# LANG=C DISTRO=el7 WITH='--without cman --without snmp --without esmtp --with pre_release' make rpm
(snip)
# grep Features /root/rpmbuild/BUILD/pacemaker-Pacemaker-1.1.18-rc3/config.log
configure:25512: result:   Features                 = (snip) atomic-attrd snmp libesmtp acls
```
after adding commit :
```
# LANG=C DISTRO=el7 WITH='--without cman --without snmp --without esmtp --with pre_release' make rpm
(snip)
# grep Features /root/rpmbuild/BUILD/pacemaker-Pacemaker-1.1.18-rc3/config.log
configure:25512: result:   Features                 = (snip) atomic-attrd acls
```