### PR TITLE
Error quickly if Pacemaker Remote authentication key is not readable

### DIFF
--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -42,6 +42,7 @@ void crm_sync_directory(const char *name);
 
 char *crm_read_contents(const char *filename);
 int crm_write_sync(int fd, const char *contents);
+int crm_set_nonblocking(int fd);
 
 
 /* internal procfs utilities (from procfs.c) */

--- a/lib/common/io.c
+++ b/lib/common/io.c
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
+#include <fcntl.h>
 #include <dirent.h>
 #include <pwd.h>
 #include <grp.h>
@@ -456,4 +457,26 @@ crm_write_sync(int fd, const char *contents)
     }
     fclose(fp);
     return rc;
+}
+
+/*!
+ * \internal
+ * \brief Set a file descriptor to non-blocking
+ *
+ * \param[in] fd  File descriptor to use
+ *
+ * \return pcmk_ok on success, -errno on error
+ */
+int
+crm_set_nonblocking(int fd)
+{
+    int flag = fcntl(fd, F_GETFL);
+
+    if (flag < 0) {
+        return -errno;
+    }
+    if (fcntl(fd, F_SETFL, flag | O_NONBLOCK) < 0) {
+        return -errno;
+    }
+    return pcmk_ok;
 }

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -723,19 +723,18 @@ check_connect_finished(gpointer userdata)
     /* can we read or write to the socket now? */
     if (FD_ISSET(sock, &rset) || FD_ISSET(sock, &wset)) {
         if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &error, &len) < 0) {
+            rc = -errno;
             crm_trace("fd %d: call to getsockopt failed", sock);
-            rc = -1;
             goto dispatch_done;
         }
-
         if (error) {
             crm_trace("fd %d: error returned from getsockopt: %d", sock, error);
-            rc = -1;
+            rc = -error;
             goto dispatch_done;
         }
     } else {
         crm_trace("neither read nor write set after select");
-        rc = -1;
+        rc = -EAGAIN;
         goto dispatch_done;
     }
 

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -697,7 +697,7 @@ check_connect_finished(gpointer userdata)
     rc = select(sock + 1, &rset, &wset, NULL, &ts);
 
     if (rc < 0) {
-        rc = errno;
+        rc = -errno;
         if ((errno == EINPROGRESS) || (errno == EAGAIN)) {
             /* reschedule if there is still time left */
             if ((time(NULL) - cb_data->start) < (cb_data->timeout / 1000)) {

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -914,15 +914,17 @@ internal_stonith_action_execute(stonith_action_t * action)
 
     /* parent */
     action->pid = pid;
-    ret = fcntl(p_read_fd, F_SETFL, fcntl(p_read_fd, F_GETFL, 0) | O_NONBLOCK);
+    ret = crm_set_nonblocking(p_read_fd);
     if (ret < 0) {
-        crm_perror(LOG_NOTICE, "Could not change the output of %s to be non-blocking",
-                   action->agent);
+        crm_notice("Could not set output of %s to be non-blocking: %s "
+                   CRM_XS " rc=%d",
+                   action->agent, pcmk_strerror(rc), rc);
     }
-    ret = fcntl(p_stderr_fd, F_SETFL, fcntl(p_stderr_fd, F_GETFL, 0) | O_NONBLOCK);
+    ret = crm_set_nonblocking(p_stderr_fd);
     if (ret < 0) {
-        crm_perror(LOG_NOTICE, "Could not change the stderr of %s to be non-blocking",
-                   action->agent);
+        crm_notice("Could not set error output of %s to be non-blocking: %s "
+                   CRM_XS " rc=%d",
+                   action->agent, pcmk_strerror(rc), rc);
     }
 
     do {

--- a/lrmd/lrmd_private.h
+++ b/lrmd/lrmd_private.h
@@ -61,7 +61,7 @@ typedef struct lrmd_rsc_s {
 
 #  ifdef HAVE_GNUTLS_GNUTLS_H
 /* in remote_tls.c */
-int lrmd_init_remote_tls_server(int port);
+int lrmd_init_remote_tls_server(void);
 void lrmd_tls_server_destroy(void);
 
 /* Hidden in lrmd client lib */

--- a/lrmd/main.c
+++ b/lrmd/main.c
@@ -618,15 +618,11 @@ main(int argc, char **argv, char **envp)
     }
 
 #ifdef ENABLE_PCMK_REMOTE
-    {
-        int remote_port = crm_default_remote_port();
-
-        if (lrmd_init_remote_tls_server(remote_port) < 0) {
-            crm_err("Failed to create TLS server on port %d: shutting down and inhibiting respawn", remote_port);
-            crm_exit(DAEMON_RESPAWN_STOP);
-        }
-        ipc_proxy_init();
+    if (lrmd_init_remote_tls_server() < 0) {
+        crm_err("Failed to create TLS listener: shutting down and staying down");
+        crm_exit(DAEMON_RESPAWN_STOP);
     }
+    ipc_proxy_init();
 #endif
 
     mainloop_add_signal(SIGTERM, lrmd_shutdown);

--- a/lrmd/tls_backend.c
+++ b/lrmd/tls_backend.c
@@ -291,19 +291,20 @@ bind_and_listen(struct addrinfo *addr)
 }
 
 int
-lrmd_init_remote_tls_server(int port)
+lrmd_init_remote_tls_server()
 {
     int rc;
     int filter;
+    int port = crm_default_remote_port();
     struct addrinfo hints, *res = NULL, *iter;
-    char port_str[16];
+    char port_str[6]; // at most "65535"
 
     static struct mainloop_fd_callbacks remote_listen_fd_callbacks = {
         .dispatch = lrmd_remote_listen,
         .destroy = lrmd_remote_connection_destroy,
     };
 
-    crm_notice("Starting a tls listener on port %d.", port);
+    crm_notice("Starting TLS listener on port %d", port);
     crm_gnutls_global_init();
     gnutls_global_set_log_function(debug_log);
 
@@ -314,7 +315,10 @@ lrmd_init_remote_tls_server(int port)
     gnutls_psk_set_server_dh_params(psk_cred_s, dh_params);
 
     memset(&hints, 0, sizeof(struct addrinfo));
-    hints.ai_flags = AI_PASSIVE; /* Only return socket addresses with wildcard INADDR_ANY or IN6ADDR_ANY_INIT */
+    /* Bind to the wildcard address (INADDR_ANY or IN6ADDR_ANY_INIT).
+     * @TODO allow user to specify a specific address
+     */
+    hints.ai_flags = AI_PASSIVE;
     hints.ai_family = AF_UNSPEC; /* Return IPv6 or IPv4 */
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_protocol = IPPROTO_TCP;
@@ -322,7 +326,8 @@ lrmd_init_remote_tls_server(int port)
     snprintf(port_str, sizeof(port_str), "%d", port);
     rc = getaddrinfo(NULL, port_str, &hints, &res);
     if (rc) {
-        crm_err("getaddrinfo: %s", gai_strerror(rc));
+        crm_err("Unable to get IP address info for local node: %s",
+                gai_strerror(rc));
         return -1;
     }
 


### PR DESCRIPTION
Previously, all Pacemaker Remote connection errors were treated the same: the connection would be repeatedly re-attempted until the start operation timeout, and then normal recovery would be done (by default, repeating the process 1,000,000 times on the same node, before moving to another node). This makes sense for transient errors, but not for permanent errors such as a misconfigured (missing or unreadable) authentication key.

Now, an inability to read the key is treated as a hard error, so the node is immediately banned from hosting the connection. Also, a meaningful exit reason is presented to the user in cluster status, e.g.:

Failed Actions:
* remote-rhel7-2_start_0 on rhel7-1 'invalid parameter' (2): call=8, status=Error,
    exitreason='Authentication key not readable',
    last-rc-change='Thu Oct 26 09:33:42 2017', queued=0ms, exec=0ms

These commits also improve remote connection log messages in general.
