### PR TITLE
Low: tools: set meta_timeout env when crm_resource --force-* executes RA

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -217,6 +217,9 @@ extern action_t *custom_action(resource_t * rsc, char *key, const char *task, no
 		rsc, demoted_key(rsc), CRMD_ACTION_DEMOTED, node,	\
 		optional, TRUE, data_set)
 
+extern int pe_get_configured_timeout(resource_t *rsc, const char *action,
+                                     pe_working_set_t *data_set);
+
 extern action_t *find_first_action(GListPtr input, const char *uuid, const char *task,
                                    node_t * on_node);
 extern enum action_tasks get_complex_task(resource_t * rsc, const char *name,

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -841,6 +841,44 @@ unpack_timeout(const char *value, action_t *action, xmlNode *xml_obj,
     return timeout;
 }
 
+int
+pe_get_configured_timeout(resource_t *rsc, const char *action, pe_working_set_t *data_set)
+{
+    xmlNode *child = NULL;
+    const char *timeout = NULL;
+    int timeout_ms = 0;
+
+    for (child = first_named_child(rsc->ops_xml, XML_ATTR_OP);
+         child != NULL; child = crm_next_same_xml(child)) {
+        if (safe_str_eq(action, crm_element_value(child, XML_NVPAIR_ATTR_NAME))) {
+            timeout = crm_element_value(child, XML_ATTR_TIMEOUT);
+            break;
+        }
+    }
+
+    if (timeout == NULL && data_set->op_defaults) {
+        GHashTable *action_meta = crm_str_table_new();
+        unpack_instance_attributes(data_set->input, data_set->op_defaults, XML_TAG_META_SETS,
+                                   NULL, action_meta, NULL, FALSE, data_set->now);
+        timeout = g_hash_table_lookup(action_meta, XML_ATTR_TIMEOUT);
+    }
+
+    if (timeout == NULL && data_set->config_hash) {
+        timeout = pe_pref(data_set->config_hash, "default-action-timeout");
+    }
+
+    if (timeout == NULL) {
+        timeout = CRM_DEFAULT_OP_TIMEOUT_S;
+    }
+
+    timeout_ms = crm_get_msec(timeout);
+    if (timeout_ms < 0) {
+        timeout_ms = 0;
+    }
+
+    return timeout_ms;
+}
+
 #if ENABLE_VERSIONED_ATTRS
 static void
 unpack_versioned_meta(xmlNode *versioned_meta, xmlNode *xml_obj, unsigned long long interval, crm_time_t *now)

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -356,7 +356,7 @@ static struct crm_option long_options[] = {
     },
     {
         "timeout", required_argument, NULL, 'T',
-        "\t(Advanced) Abort if command does not finish in this time (with --restart, --wait)"
+        "\t(Advanced) Abort if command does not finish in this time (with --restart, --wait, --force-*)"
     },
     {
         "force", no_argument, NULL, 'f',
@@ -871,7 +871,8 @@ main(int argc, char **argv)
         rc = wait_till_stable(timeout_ms, cib_conn);
 
     } else if (rsc_cmd == 0 && rsc_long_cmd) { /* validate or force-(stop|start|check) */
-        rc = cli_resource_execute(rsc_id, rsc_long_cmd, override_params, cib_conn, &data_set);
+        rc = cli_resource_execute(rsc_id, rsc_long_cmd, override_params,
+                                  timeout_ms, cib_conn, &data_set);
         if (rc >= 0) {
             is_ocf_rc = 1;
         }

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -76,7 +76,8 @@ int cli_resource_delete(crm_ipc_t *crmd_channel, const char *host_uname,
                         const char *interval, pe_working_set_t *data_set);
 int cli_resource_restart(resource_t * rsc, const char *host, int timeout_ms, cib_t * cib);
 int cli_resource_move(const char *rsc_id, const char *host_name, cib_t * cib, pe_working_set_t *data_set);
-int cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *override_hash, cib_t * cib, pe_working_set_t *data_set);
+int cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *override_hash,
+                         int timeout_ms, cib_t * cib, pe_working_set_t *data_set);
 
 int cli_resource_update_attribute(const char *rsc_id, const char *attr_set, const char *attr_id,
                                   const char *attr_name, const char *attr_value, bool recursive,


### PR DESCRIPTION
Some RAs(\*1) require the OCF_RESKEY_CRM_meta_timeout environment variable.
However, since it is not set with the crm_resource --force-* command, the RA is terminated halfway.

*1 https://github.com/ClusterLabs/resource-agents/blob/v4.0.1/heartbeat/sfex#L187
   https://github.com/ClusterLabs/resource-agents/blob/v4.0.1/heartbeat/rsyslog#L162-L163

```
[root@x3650c ~]# crm_resource --force-stop -r prmEx
Operation stop for prmEx (ocf:heartbeat:sfex) returned: 'unknown error' (1)
 >  stderr: INFO: sfex_daemon: stopping...
 >  stderr: /usr/lib/ocf/resource.d/heartbeat/sfex: line 187: (/1000)-5: syntax error: operand expected (error token is "/1000)-5")
[root@x3650c ~]# echo $?
1
```

Since pacemaker has a value of timeout, I think that pacemaker should set it.
(I also think RA should make sure that the environment variable is set...)