### PR TITLE
libtransitioner: explicitly depend on liblrmd

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -39,7 +39,7 @@ clean-local:
 	rm -f *.pc
 
 ## Subdirectories...
-SUBDIRS	= gnu common pengine transition cib fencing services lrmd cluster
+SUBDIRS	= gnu common pengine cib fencing services lrmd cluster transition
 DIST_SUBDIRS =  $(SUBDIRS) ais
 
 if BUILD_CS_PLUGIN

--- a/lib/transition/Makefile.am
+++ b/lib/transition/Makefile.am
@@ -28,7 +28,8 @@ libtransitioner_la_CPPFLAGS	= -I$(top_builddir) $(AM_CPPFLAGS)
 libtransitioner_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 libtransitioner_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)
 
-libtransitioner_la_LIBADD	= $(top_builddir)/lib/common/libcrmcommon.la
+libtransitioner_la_LIBADD	= $(top_builddir)/lib/common/libcrmcommon.la \
+				  $(top_builddir)/lib/lrmd/liblrmd.la
 libtransitioner_la_SOURCES	= unpack.c graph.c utils.c
 
 clean-generic:


### PR DESCRIPTION
lrmd_free_rsc_info comes from liblrmd, so also make sure it gets
built before libtransitioner.

Signed-off-by: Ferenc Wágner <wferi@debian.org>