### PR TITLE
Low: tools: set the correct OCF_RESOURCE_INSTANCE env when crm_resource --force-* executes RA

### DIFF
--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1457,7 +1457,6 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
     const char *rprov = NULL;
     const char *rclass = NULL;
     const char *action = NULL;
-    const char *value = NULL;
     GHashTable *params = NULL;
     resource_t *rsc = pe_find_resource(data_set->resources, rsc_id);
 
@@ -1521,8 +1520,7 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
     /* add crm_feature_set env needed by some resource agents */
     g_hash_table_insert(params, strdup(XML_ATTR_CRM_VERSION), strdup(CRM_FEATURE_SET));
 
-    value = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_UNIQUE);
-    rid = crm_is_true(value) ? rsc->id : rsc_id;
+    rid = pe_rsc_is_anon_clone(rsc->parent) ? rsc_id : rsc->id;
 
     op = resources_action_create(rid, rclass, rprov, rtype, action, 0,
                                  timeout_ms, params, 0);

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1452,10 +1452,12 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
 {
     int rc = pcmk_ok;
     svc_action_t *op = NULL;
+    const char *rid = NULL;
     const char *rtype = NULL;
     const char *rprov = NULL;
     const char *rclass = NULL;
     const char *action = NULL;
+    const char *value = NULL;
     GHashTable *params = NULL;
     resource_t *rsc = pe_find_resource(data_set->resources, rsc_id);
 
@@ -1519,12 +1521,15 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
     /* add crm_feature_set env needed by some resource agents */
     g_hash_table_insert(params, strdup(XML_ATTR_CRM_VERSION), strdup(CRM_FEATURE_SET));
 
-    op = resources_action_create(rsc->id, rclass, rprov, rtype, action, 0,
+    value = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_UNIQUE);
+    rid = crm_is_true(value) ? rsc->id : rsc_id;
+
+    op = resources_action_create(rid, rclass, rprov, rtype, action, 0,
                                  timeout_ms, params, 0);
     if (op == NULL) {
         /* Re-run with stderr enabled so we can display a sane error message */
         crm_enable_stderr(TRUE);
-        op = resources_action_create(rsc->id, rclass, rprov, rtype, action, 0,
+        op = resources_action_create(rid, rclass, rprov, rtype, action, 0,
                                      timeout_ms, params, 0);
 
         /* We know op will be NULL, but this makes static analysis happy */


### PR DESCRIPTION
When resource related to globally-unique such as master/slave is specified by crm_resource --force-*, an instance number is given to the OCF_RESOURCE_INSTANCE environment variable of RA.

 * before executing crm_resource. (when executed from lrmd, no instance number is given.) :
```
[root@rhel73-1 ~]# crm configure show
node 3232261507: rhel73-1
node 3232261509: rhel73-3
primitive prmStateful ocf:pacemaker:Stateful \
        op start interval=0s timeout=10s on-fail=restart \
        op promote interval=0s timeout=10s on-fail=restart trace_ra=on \
        op demote interval=0s timeout=10s on-fail=restart \
        op monitor interval=20s role=Slave timeout=10s on-fail=restart \
        op monitor interval=10s role=Master timeout=10s on-fail=restart \
        op stop interval=0s timeout=10s on-fail=fence
ms msStateful prmStateful \
        meta master-max=1 master-node-max=1 notify=true

[root@rhel73-1 ~]# crm_mon -DA1

Online: [ rhel73-1 rhel73-3 ]

Active resources:

 Master/Slave Set: msStateful [prmStateful]
     Masters: [ rhel73-1 ]
     Slaves: [ rhel73-3 ]

Node Attributes:
* Node rhel73-1:
    + master-prmStateful                : 10
* Node rhel73-3:
    + master-prmStateful                : 5

[root@rhel73-1 ~]# grep OCF_RESOURCE_INSTANCE /var/lib/heartbeat/trace_ra/Stateful/prmStateful.promote.2017-11-02.16\:44\:34
OCF_RESOURCE_INSTANCE=prmStateful

```
 * after executing crm_resource --force-*. (when executed from crm_resource, an instance number is given.) :
```
[root@rhel73-1 ~]# crm_resource -m -p maintenance -v true -r msStateful

[root@rhel73-1 ~]# crm_resource --force-demote -r prmStateful -VV | grep OCF_RESOURCE_INSTANCE
 >  stderr: OCF_RESOURCE_INSTANCE=prmStateful:0

[root@rhel73-1 ~]# crm_resource --force-stop -r prmStateful
Operation stop for prmStateful:0 (ocf:pacemaker:Stateful) returned: 'ok' (0)
[root@rhel73-1 ~]# systemctl stop pacemaker
( Perform maintenance. )
[root@rhel73-1 ~]# systemctl start pacemaker
[root@rhel73-1 ~]# crm_resource --force-start -r prmStateful
Operation start for prmStateful:0 (ocf:pacemaker:Stateful) returned: 'ok' (0)

[root@rhel73-1 ~]# crm_resource --force-promote -r prmStateful -VV | grep OCF_RESOURCE_INSTANCE
 >  stderr: OCF_RESOURCE_INSTANCE=prmStateful:0

[root@rhel73-1 ~]# crm_mon -DA1

Online: [ rhel73-1 rhel73-3 ]

Active resources:

 Master/Slave Set: msStateful [prmStateful] (unmanaged)
     prmStateful        (ocf::pacemaker:Stateful):      Slave rhel73-3 (unmanaged)

Node Attributes:
* Node rhel73-1:
    + master-prmStateful:0              : 10
* Node rhel73-3:
    + master-prmStateful                : 5

[root@rhel73-1 ~]# crm_resource -C -r msStateful
[root@rhel73-1 ~]# crm_resource -m -d maintenance -r msStateful
[root@rhel73-1 ~]# crm_mon -DA1

Online: [ rhel73-1 rhel73-3 ]

Active resources:

 Master/Slave Set: msStateful [prmStateful]
     Masters: [ rhel73-1 ]
     Slaves: [ rhel73-3 ]

Node Attributes:
* Node rhel73-1:
    + master-prmStateful                : 10
    + master-prmStateful:0              : 10
* Node rhel73-3:
    + master-prmStateful                : 5

```
In the case of Stateful RA, master-prmStateful:0 has just been added, but the same operation is performed in pgsql RA with replication mode, an error will occur when maintenance is canceled.
```
Migration Summary:
* Node rhel73-1:
   pgsql: migration-threshold=1 fail-count=1 last-failure='Thu Nov  2 11:55:58 2017'

Failed Actions:
* pgsql_monitor_10000 on rhel73-1 'not running' (7): call=63, status=complete, exitreason='',
    last-rc-change='Thu Nov  2 11:55:58 2017', queued=0ms, exec=124ms
```

Regards,