### PR TITLE
Fix: PE: Have bundles log to stderr so that 'journalctl -M' works (rkt)

### DIFF
--- a/lib/pengine/container.c
+++ b/lib/pengine/container.c
@@ -374,6 +374,8 @@ create_rkt_resource(
                                data->prefix, tuple->offset);
         }
 
+        offset += snprintf(buffer+offset, max-offset, " --environment=PCMK_stderr=1");
+
         if(data->docker_network) {
 //        offset += snprintf(buffer+offset, max-offset, " --link-local-ip=%s", tuple->ipaddr);
             offset += snprintf(buffer+offset, max-offset, " --net=%s", data->docker_network);


### PR DESCRIPTION
Logs can be read using container ID from machinectl:

  journalctl -M rkt-bc3c1451-2e81-45c6-aeb0-807db44e31b4