### PR TITLE
Various portability fixes and a typo fix

### DIFF
--- a/extra/resources/ifspeed
+++ b/extra/resources/ifspeed
@@ -68,7 +68,7 @@ Examples:
 
 For STP-enabled bridges this RA tries to some-how guess network topology and by
 default looks only on ports which are connected to upstream switch. This can be
-overriden by 'bridge_ports' parameter. Active interfaces in this case are those
+overridden by 'bridge_ports' parameter. Active interfaces in this case are those
 in "forwarding" state.
 
 For balancing bonds this RA summs speeds of underlying "up" slave interfaces

--- a/include/portability.h
+++ b/include/portability.h
@@ -265,6 +265,10 @@ typedef union
 #    define ENOSTR    199
 #  endif
 
+#  ifndef EKEYREJECTED
+#    define EKEYREJECTED 200
+#  endif
+
 /*
  * Some compilers (eg. Sun studio) do not define __FUNCTION__
  */

--- a/include/portability.h
+++ b/include/portability.h
@@ -223,6 +223,8 @@ typedef union
 #  endif
 
 /* Replacement error codes for non-linux */
+#  include <errno.h>
+
 #  ifndef ENOTUNIQ
 #    define ENOTUNIQ  190
 #  endif

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -444,10 +444,10 @@ crm_compress_string(const char *data, int length, int max, char **result, unsign
 #ifdef CLOCK_MONOTONIC
     clock_gettime(CLOCK_MONOTONIC, &after_t);
 
-    crm_trace("Compressed %d bytes into %d (ratio %d:1) in %ldms",
+    crm_trace("Compressed %d bytes into %d (ratio %d:1) in %.0fms",
              length, *result_len, length / (*result_len),
-             (after_t.tv_sec - before_t.tv_sec) * 1000 + (after_t.tv_nsec -
-                                                          before_t.tv_nsec) / 1000000);
+             difftime (after_t.tv_sec, before_t.tv_sec) * 1000 +
+             (after_t.tv_nsec - before_t.tv_nsec) / 1e6);
 #else
     crm_trace("Compressed %d bytes into %d (ratio %d:1)",
              length, *result_len, length / (*result_len));

--- a/lrmd/main.c
+++ b/lrmd/main.c
@@ -25,7 +25,6 @@
 
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <sys/prctl.h>
 
 #include <crm/crm.h>
 #include <crm/msg_xml.h>


### PR DESCRIPTION
There are more latent problems around `time_t` conversions. Explicit casts to `long` may fail when it's a 32-bit type, and there's even a conversion to `int` in

    crm_xml_add_int(vote, F_CRM_ELECTION_AGE_S, age.tv_sec);

at https://github.com/ClusterLabs/pacemaker/blob/1.1/lib/cluster/election.c#L233. These will probably require further work.