### PR TITLE
Doc: pacemaker.service: Recommend not to limit tasks

### DIFF
--- a/mcp/pacemaker.service.in
+++ b/mcp/pacemaker.service.in
@@ -41,6 +41,10 @@ SuccessExitStatus=100
 
 ExecStart=@sbindir@/pacemakerd -f
 
+# Uncomment TasksMax if your systemd version supports it.
+# Only systemd v227 and above support this option.
+#TasksMax=infinity
+
 # If pacemakerd doesn't stop, it's probably waiting on a cluster
 # resource.  Sending -KILL will just get the node fenced
 SendSIGKILL=no


### PR DESCRIPTION
Systemd v227 introduced the "pids" cgroup controller:
https://github.com/systemd/systemd/commit/03a7b521e

From systemd v228, it's enabled for all services by default, and the
global default of TasksMax was 512:
https://github.com/systemd/systemd/commit/9ded9cd14

The limit could be be easily hit since any processes/threads spawned
from the unit count, such as the "ocf" type of resources.

In systemd v235, the default TasksMax= has been effectively changed to
4915:
https://github.com/systemd/systemd/commit/79baeeb96

But it still could be a potential issue for cluster with heavy workload.

Generally it probably doesn't make much sense to set such a limit for a
resource manager like pacemaker.

This commit recommends the same as the docker project does:
https://github.com/moby/moby/commit/33a8ab29ed