### PR TITLE
More cleanup before 1.1.18 release

### DIFF
--- a/crmd/crmd_metadata.h
+++ b/crmd/crmd_metadata.h
@@ -14,7 +14,7 @@ enum ra_flags_e {
 };
 
 enum ra_param_flags_e {
-    ra_param_reloadable = 0x01,
+    ra_param_unique     = 0x01,
     ra_param_private    = 0x02,
 };
 
@@ -43,8 +43,8 @@ static inline const char *
 ra_param_flag2text(enum ra_param_flags_e flag)
 {
     switch (flag) {
-        case ra_param_reloadable:
-            return "reloadable";
+        case ra_param_unique:
+            return "unique";
         case ra_param_private:
             return "private";
         default:

--- a/include/crm/pengine/common.h
+++ b/include/crm/pengine/common.h
@@ -88,32 +88,29 @@ enum rsc_role_e {
 
 #  define RSC_ROLE_MAX  RSC_ROLE_MASTER+1
 
-#  define	RSC_ROLE_UNKNOWN_S "Unknown"
-#  define	RSC_ROLE_STOPPED_S "Stopped"
-#  define	RSC_ROLE_STARTED_S "Started"
-#  define	RSC_ROLE_SLAVE_S   "Slave"
-#  define	RSC_ROLE_MASTER_S  "Master"
+#  define RSC_ROLE_UNKNOWN_S "Unknown"
+#  define RSC_ROLE_STOPPED_S "Stopped"
+#  define RSC_ROLE_STARTED_S "Started"
+#  define RSC_ROLE_SLAVE_S   "Slave"
+#  define RSC_ROLE_MASTER_S  "Master"
 
-/* *INDENT-OFF* */
 enum pe_print_options {
-
-	pe_print_log		= 0x0001,
-	pe_print_html		= 0x0002,
-	pe_print_ncurses	= 0x0004,
-	pe_print_printf		= 0x0008,
-	pe_print_dev		= 0x0010,
-	pe_print_details	= 0x0020,
-	pe_print_max_details	= 0x0040,
-	pe_print_rsconly	= 0x0080,
-	pe_print_ops		= 0x0100,
-	pe_print_suppres_nl	= 0x0200,
-	pe_print_xml		= 0x0400,
-	pe_print_brief		= 0x0800,
-	pe_print_pending	= 0x1000,
-        pe_print_clone_details  = 0x2000,
-    pe_print_clone_active   = 0x4000, /* print clone instances only if active */
+    pe_print_log            = 0x0001,
+    pe_print_html           = 0x0002,
+    pe_print_ncurses        = 0x0004,
+    pe_print_printf         = 0x0008,
+    pe_print_dev            = 0x0010,
+    pe_print_details        = 0x0020,
+    pe_print_max_details    = 0x0040,
+    pe_print_rsconly        = 0x0080,
+    pe_print_ops            = 0x0100,
+    pe_print_suppres_nl     = 0x0200,
+    pe_print_xml            = 0x0400,
+    pe_print_brief          = 0x0800,
+    pe_print_pending        = 0x1000,
+    pe_print_clone_details  = 0x2000,
+    pe_print_clone_active   = 0x4000, // Print clone instances only if active
 };
-/* *INDENT-ON* */
 
 const char *task2text(enum action_tasks task);
 enum action_tasks text2task(const char *task);

--- a/include/crm/pengine/common.h
+++ b/include/crm/pengine/common.h
@@ -110,6 +110,7 @@ enum pe_print_options {
     pe_print_pending        = 0x1000,
     pe_print_clone_details  = 0x2000,
     pe_print_clone_active   = 0x4000, // Print clone instances only if active
+    pe_print_implicit       = 0x8000, // Print implicitly created resources
 };
 
 const char *task2text(enum action_tasks task);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -248,6 +248,7 @@ extern resource_t *find_clone_instance(resource_t * rsc, const char *sub_id,
 extern void destroy_ticket(gpointer data);
 extern ticket_t *ticket_new(const char *ticket_id, pe_working_set_t * data_set);
 
+const char *pe_base_name_end(const char *id);
 char *clone_strip(const char *last_rsc_id);
 char *clone_zero(const char *last_rsc_id);
 

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -17,6 +17,7 @@
  */
 #ifndef PE_INTERNAL__H
 #  define PE_INTERNAL__H
+#  include <string.h>
 #  include <crm/pengine/status.h>
 #  include <crm/pengine/remote.h>
 
@@ -248,9 +249,22 @@ extern resource_t *find_clone_instance(resource_t * rsc, const char *sub_id,
 extern void destroy_ticket(gpointer data);
 extern ticket_t *ticket_new(const char *ticket_id, pe_working_set_t * data_set);
 
+// Resources for manipulating resource names
 const char *pe_base_name_end(const char *id);
 char *clone_strip(const char *last_rsc_id);
 char *clone_zero(const char *last_rsc_id);
+
+static inline bool
+pe_base_name_eq(resource_t *rsc, const char *id)
+{
+    if (id && rsc && rsc->id) {
+        // Number of characters in rsc->id before any clone suffix
+        size_t base_len = pe_base_name_end(rsc->id) - rsc->id + 1;
+
+        return (strlen(id) == base_len) && !strncmp(id, rsc->id, base_len);
+    }
+    return FALSE;
+}
 
 int get_target_rc(xmlNode * xml_op);
 

--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -49,11 +49,11 @@ enum pe_restart {
 };
 
 enum pe_find {
-    pe_find_renamed  = 0x001,
-    pe_find_anon     = 0x002,
-    pe_find_clone    = 0x004,
-    pe_find_current  = 0x008,
-    pe_find_inactive = 0x010,
+    pe_find_renamed  = 0x001, // match resource ID or LRM history ID
+    pe_find_anon     = 0x002, // match base name of anonymous clone instances
+    pe_find_clone    = 0x004, // match only clone instances
+    pe_find_current  = 0x008, // match resource active on specified node
+    pe_find_inactive = 0x010, // match resource not running anywhere
 };
 
 #  define pe_flag_have_quorum           0x00000001ULL

--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -54,6 +54,7 @@ enum pe_find {
     pe_find_clone    = 0x004, // match only clone instances
     pe_find_current  = 0x008, // match resource active on specified node
     pe_find_inactive = 0x010, // match resource not running anywhere
+    pe_find_any      = 0x020, // match base name of any clone instance
 };
 
 #  define pe_flag_have_quorum           0x00000001ULL

--- a/lib/pengine/container.c
+++ b/lib/pengine/container.c
@@ -1335,7 +1335,7 @@ container_print(resource_t * rsc, const char *pre_text, long options, void *prin
             status_print("<li>");
         }
 
-        if(is_set(options, pe_print_clone_details)) {
+        if (is_set(options, pe_print_implicit)) {
             child_text = crm_strdup_printf("     %s", pre_text);
             if(g_list_length(container_data->tuples) > 1) {
                 status_print("  %sReplica[%d]\n", pre_text, tuple->offset);

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -158,29 +158,51 @@ native_unpack(resource_t * rsc, pe_working_set_t * data_set)
     return TRUE;
 }
 
+static bool
+rsc_is_on_node(resource_t *rsc, node_t *node, int flags)
+{
+    pe_rsc_trace(rsc, "Checking whether %s is on %s",
+                 rsc->id, node->details->uname);
+
+    if (is_set(flags, pe_find_current) && rsc->running_on) {
+
+        for (GListPtr iter = rsc->running_on; iter; iter = iter->next) {
+            node_t *loc = (node_t *) iter->data;
+
+            if (loc->details == node->details) {
+                return TRUE;
+            }
+        }
+
+    } else if (is_set(flags, pe_find_inactive) && (rsc->running_on == NULL)) {
+        return TRUE;
+
+    } else if (is_not_set(flags, pe_find_current) && rsc->allocated_to
+               && (rsc->allocated_to->details == node->details)) {
+        return TRUE;
+    }
+    return FALSE;
+}
+
 resource_t *
 native_find_rsc(resource_t * rsc, const char *id, node_t * on_node, int flags)
 {
-    gboolean match = FALSE;
+    bool match = FALSE;
     resource_t *result = NULL;
-    GListPtr gIter = rsc->children;
 
-    CRM_ASSERT(id != NULL);
+    CRM_CHECK(id && rsc && rsc->id, return NULL);
 
     if (flags & pe_find_clone) {
         const char *rid = ID(rsc->xml);
 
-        if (rsc->parent == NULL) {
+        if (!pe_rsc_is_clone(uber_parent(rsc))) {
             match = FALSE;
 
-        } else if (safe_str_eq(rsc->id, id)) {
-            match = TRUE;
-
-        } else if (safe_str_eq(rid, id)) {
+        } else if (!strcmp(id, rsc->id) || safe_str_eq(id, rid)) {
             match = TRUE;
         }
 
-    } else if (strcmp(rsc->id, id) == 0) {
+    } else if (!strcmp(id, rsc->id)) {
         match = TRUE;
 
     } else if (is_set(flags, pe_find_renamed)
@@ -192,32 +214,18 @@ native_find_rsc(resource_t * rsc, const char *id, node_t * on_node, int flags)
     }
 
     if (match && on_node) {
-        pe_rsc_trace(rsc, "Now checking %s is on %s", rsc->id, on_node->details->uname);
-        if (is_set(flags, pe_find_current) && rsc->running_on) {
+        bool match_node = rsc_is_on_node(rsc, on_node, flags);
 
-            GListPtr gIter = rsc->running_on;
-
-            for (; gIter != NULL; gIter = gIter->next) {
-                node_t *loc = (node_t *) gIter->data;
-
-                if (loc->details == on_node->details) {
-                    return rsc;
-                }
-            }
-
-        } else if (is_set(flags, pe_find_inactive) && rsc->running_on == NULL) {
-            return rsc;
-
-        } else if (is_not_set(flags, pe_find_current) && rsc->allocated_to
-                   && rsc->allocated_to->details == on_node->details) {
-            return rsc;
+        if (match_node == FALSE) {
+            match = FALSE;
         }
+    }
 
-    } else if (match) {
+    if (match) {
         return rsc;
     }
 
-    for (; gIter != NULL; gIter = gIter->next) {
+    for (GListPtr gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
         resource_t *child = (resource_t *) gIter->data;
 
         result = rsc->fns->find_rsc(child, id, on_node, flags);

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -188,11 +188,7 @@ native_find_rsc(resource_t * rsc, const char *id, node_t * on_node, int flags)
         match = TRUE;
 
     } else if (is_set(flags, pe_find_anon) && is_not_set(rsc->flags, pe_rsc_unique)) {
-        char *tmp = clone_strip(rsc->id);
-        if(strcmp(tmp, id) == 0) {
-            match = TRUE;
-        }
-        free(tmp);
+        match = pe_base_name_eq(rsc, id);
     }
 
     if (match && on_node) {

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -488,7 +488,7 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
 
     if (rsc->meta) {
         const char *is_internal = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_INTERNAL_RSC);
-        if (crm_is_true(is_internal) && is_not_set(options, pe_print_clone_details)) {
+        if (crm_is_true(is_internal) && is_not_set(options, pe_print_implicit)) {
             crm_trace("skipping print of internal resource %s", rsc->id);
             return;
         }

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -209,7 +209,9 @@ native_find_rsc(resource_t * rsc, const char *id, node_t * on_node, int flags)
                && rsc->clone_name && strcmp(rsc->clone_name, id) == 0) {
         match = TRUE;
 
-    } else if (is_set(flags, pe_find_anon) && is_not_set(rsc->flags, pe_rsc_unique)) {
+    } else if (is_set(flags, pe_find_any)
+               || (is_set(flags, pe_find_anon)
+                   && is_not_set(rsc->flags, pe_rsc_unique))) {
         match = pe_base_name_eq(rsc, id);
     }
 

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -248,7 +248,7 @@ set_working_set_defaults(pe_working_set_t * data_set)
 resource_t *
 pe_find_resource(GListPtr rsc_list, const char *id)
 {
-    return pe_find_resource_with_flags(rsc_list, id, pe_find_renamed | pe_find_current);
+    return pe_find_resource_with_flags(rsc_list, id, pe_find_renamed);
 }
 
 resource_t *

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -2015,9 +2015,10 @@ rsc_action_digest_cmp(resource_t * rsc, xmlNode * xml_op, node_t * node,
         data->rc = RSC_DIGEST_UNKNOWN;
 
     } else if (strcmp(digest_all, data->digest_all_calc) != 0) {
-        pe_rsc_info(rsc, "Parameters to %s on %s changed: was %s vs. now %s (reload:%s) %s",
+        pe_rsc_info(rsc, "Parameters to %s on %s changed: was %s vs. now %s (%s:%s) %s",
                  key, node->details->uname,
                  crm_str(digest_all), data->digest_all_calc,
+                 (interval > 0)? "reschedule" : "reload",
                  op_version, crm_element_value(xml_op, XML_ATTR_TRANSITION_MAGIC));
         data->rc = RSC_DIGEST_ALL;
     }

--- a/lrmd/pacemaker_remote.service.in
+++ b/lrmd/pacemaker_remote.service.in
@@ -21,6 +21,10 @@ EnvironmentFile=-@CONFIGDIR@/sbd
 
 ExecStart=@sbindir@/pacemaker_remoted
 
+# Uncomment TasksMax if your systemd version supports it.
+# Only systemd v227 and above support this option.
+#TasksMax=infinity
+
 # Pacemaker Remote can exit only after all managed services have shut down;
 # an HA database could conceivably take even longer than this 
 TimeoutStopSec=30min

--- a/lrmd/test.c
+++ b/lrmd/test.c
@@ -345,20 +345,6 @@ start_test(gpointer user_data)
     return 0;
 }
 
-static resource_t *
-find_rsc_or_clone(const char *rsc, pe_working_set_t * data_set)
-{
-    resource_t *the_rsc = pe_find_resource(data_set->resources, rsc);
-
-    if (the_rsc == NULL) {
-        char *as_clone = crm_concat(rsc, "0", ':');
-
-        the_rsc = pe_find_resource(data_set->resources, as_clone);
-        free(as_clone);
-    }
-    return the_rsc;
-}
-
 static int
 generate_params(void)
 {
@@ -406,7 +392,8 @@ generate_params(void)
 
     cluster_status(&data_set);
     if (options.rsc_id) {
-        rsc = find_rsc_or_clone(options.rsc_id, &data_set);
+        rsc = pe_find_resource_with_flags(data_set.resources, options.rsc_id,
+                                          pe_find_renamed|pe_find_any);
     }
 
     if (!rsc) {

--- a/pengine/constraints.c
+++ b/pengine/constraints.c
@@ -181,9 +181,8 @@ pe_find_constraint_resource(GListPtr rsc_list, const char *id)
 
     for (rIter = rsc_list; id && rIter; rIter = rIter->next) {
         resource_t *parent = rIter->data;
-
-        resource_t *match =
-            parent->fns->find_rsc(parent, id, NULL, pe_find_renamed | pe_find_current);
+        resource_t *match = parent->fns->find_rsc(parent, id, NULL,
+                                                  pe_find_renamed);
 
         if (match != NULL) {
             if(safe_str_neq(match->id, id)) {

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -2218,7 +2218,7 @@ get_resource_display_options(void)
         print_opts |= pe_print_pending;
     }
     if (print_clone_detail) {
-        print_opts |= pe_print_clone_details;
+        print_opts |= pe_print_clone_details|pe_print_implicit;
     }
     if (!inactive_resources) {
         print_opts |= pe_print_clone_active;

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -830,9 +830,10 @@ main(int argc, char **argv)
 
         /* Set rc to -ENXIO if no resource matching rsc_id is found.
          * This does not bail, but is handled later for certain commands.
-         * That handling could be done here instead if all flags above set
-         * require_resource appropriately. */
-        if (require_resource && rsc_id && (find_rsc_or_clone(rsc_id, &data_set) == NULL)) {
+         */
+        if (require_resource && rsc_id
+            && !pe_find_resource_with_flags(data_set.resources, rsc_id,
+                                            pe_find_renamed|pe_find_any)) {
             rc = -ENXIO;
         }
     }

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -880,8 +880,8 @@ main(int argc, char **argv)
     } else if (rsc_cmd == 0 && rsc_long_cmd && safe_str_eq(rsc_long_cmd, "restart")) {
         resource_t *rsc = NULL;
 
-        rsc = pe_find_resource_with_flags(data_set.resources, rsc_id, pe_find_renamed | pe_find_current | pe_find_anon);
-
+        rsc = pe_find_resource_with_flags(data_set.resources, rsc_id,
+                                          pe_find_renamed | pe_find_anon);
         rc = -EINVAL;
         if (rsc == NULL) {
             CMD_ERR("Resource '%s' not restarted: unknown", rsc_id);
@@ -902,7 +902,8 @@ main(int argc, char **argv)
 
     } else if (rsc_cmd == 'A' || rsc_cmd == 'a') {
         GListPtr lpc = NULL;
-        resource_t *rsc = pe_find_resource_with_flags(data_set.resources, rsc_id, pe_find_renamed | pe_find_current | pe_find_anon);
+        resource_t *rsc = pe_find_resource_with_flags(data_set.resources, rsc_id,
+                                                      pe_find_renamed | pe_find_anon);
         xmlNode *cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS, data_set.input);
 
         if (rsc == NULL) {
@@ -1004,7 +1005,8 @@ main(int argc, char **argv)
         rc = cli_resource_move(rsc_id, host_uname, cib_conn, &data_set);
 
     } else if (rsc_cmd == 'B' && host_uname) {
-        resource_t *rsc = pe_find_resource_with_flags(data_set.resources, rsc_id, pe_find_renamed | pe_find_current | pe_find_anon);
+        resource_t *rsc = pe_find_resource_with_flags(data_set.resources, rsc_id,
+                                                      pe_find_renamed | pe_find_anon);
         node_t *dest = pe_find_node(data_set.nodes, host_uname);
 
         rc = -ENXIO;
@@ -1019,7 +1021,8 @@ main(int argc, char **argv)
         rc = cli_resource_ban(rsc_id, dest->details->uname, NULL, cib_conn);
 
     } else if (rsc_cmd == 'B' || rsc_cmd == 'M') {
-        resource_t *rsc = pe_find_resource_with_flags(data_set.resources, rsc_id, pe_find_renamed | pe_find_current | pe_find_anon);
+        resource_t *rsc = pe_find_resource_with_flags(data_set.resources, rsc_id,
+                                                      pe_find_renamed | pe_find_anon);
         rc = -EINVAL;
         if(rsc == NULL) {
             CMD_ERR("Resource '%s' not moved: unknown", rsc_id);
@@ -1124,8 +1127,8 @@ main(int argc, char **argv)
                 continue;
             }
 
-            rsc = pe_find_resource_with_flags(
-                data_set.resources, resource_name, pe_find_renamed | pe_find_current | pe_find_anon);
+            rsc = pe_find_resource_with_flags(data_set.resources, resource_name,
+                                              pe_find_renamed | pe_find_anon);
             if(rsc) {
                 crm_debug("Erasing %s failure for %s (%s detected) on %s",
                           task, rsc->id, resource_name, node);
@@ -1140,7 +1143,8 @@ main(int argc, char **argv)
         }
 
     } else if ((rsc_cmd == 'C') && (rsc_id)) {
-        resource_t *rsc = pe_find_resource_with_flags(data_set.resources, rsc_id, pe_find_renamed | pe_find_current | pe_find_anon);
+        resource_t *rsc = pe_find_resource_with_flags(data_set.resources, rsc_id,
+                                                      pe_find_renamed | pe_find_anon);
         if(do_force == FALSE) {
             rsc = uber_parent(rsc);
         }

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -81,7 +81,9 @@ resource_ipc_callback(const char *buffer, ssize_t length, gpointer userdata)
     crm_log_xml_trace(msg, "[inbound]");
 
     crmd_replies_needed--;
-    if (crmd_replies_needed == 0 && g_main_loop_is_running(mainloop)) {
+    if ((crmd_replies_needed == 0) && mainloop
+        && g_main_loop_is_running(mainloop)) {
+
         fprintf(stderr, " OK\n");
         crm_debug("Got all the replies we expected");
         return crm_exit(pcmk_ok);

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -59,34 +59,46 @@ void cli_resource_print_cts_constraints(pe_working_set_t * data_set);
 void cli_resource_print_location(resource_t * rsc, const char *prefix);
 void cli_resource_print_colocation(resource_t * rsc, bool dependents, bool recursive, int offset);
 
-int cli_resource_print(const char *rsc, pe_working_set_t * data_set, bool expanded);
+int cli_resource_print(resource_t *rsc, pe_working_set_t *data_set,
+                       bool expanded);
 int cli_resource_print_list(pe_working_set_t * data_set, bool raw);
-int cli_resource_print_attribute(const char *rsc, const char *attr, pe_working_set_t * data_set);
-int cli_resource_print_property(const char *rsc, const char *attr, pe_working_set_t * data_set);
+int cli_resource_print_attribute(resource_t *rsc, const char *attr,
+                                 pe_working_set_t *data_set);
+int cli_resource_print_property(resource_t *rsc, const char *attr,
+                                pe_working_set_t *data_set);
 int cli_resource_print_operations(const char *rsc_id, const char *host_uname, bool active, pe_working_set_t * data_set);
 
 /* runtime */
 void cli_resource_check(cib_t * cib, resource_t *rsc);
 int cli_resource_fail(crm_ipc_t * crmd_channel, const char *host_uname, const char *rsc_id, pe_working_set_t * data_set);
-int cli_resource_search(const char *rsc, pe_working_set_t * data_set);
+int cli_resource_search(resource_t *rsc, const char *requested_name,
+                        pe_working_set_t *data_set);
 int cli_resource_delete(crm_ipc_t *crmd_channel, const char *host_uname,
                         resource_t *rsc, const char *operation,
                         const char *interval, pe_working_set_t *data_set);
 int cli_resource_restart(resource_t * rsc, const char *host, int timeout_ms, cib_t * cib);
-int cli_resource_move(const char *rsc_id, const char *host_name, cib_t * cib, pe_working_set_t *data_set);
-int cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *override_hash,
-                         int timeout_ms, cib_t * cib, pe_working_set_t *data_set);
+int cli_resource_move(resource_t *rsc, const char *rsc_id,
+                      const char *host_name, cib_t *cib,
+                      pe_working_set_t *data_set);
+int cli_resource_execute(resource_t *rsc, const char *requested_name,
+                         const char *rsc_action, GHashTable *override_hash,
+                         int timeout_ms, cib_t *cib,
+                         pe_working_set_t *data_set);
 
-int cli_resource_update_attribute(const char *rsc_id, const char *attr_set, const char *attr_id,
-                                  const char *attr_name, const char *attr_value, bool recursive,
-                                  cib_t * cib, pe_working_set_t * data_set);
-int cli_resource_delete_attribute(const char *rsc_id, const char *attr_set, const char *attr_id,
-                                  const char *attr_name, cib_t * cib, pe_working_set_t * data_set);
+int cli_resource_update_attribute(resource_t *rsc, const char *requested_name,
+                                  const char *attr_set, const char *attr_id,
+                                  const char *attr_name, const char *attr_value,
+                                  bool recursive, cib_t *cib,
+                                  pe_working_set_t *data_set);
+int cli_resource_delete_attribute(resource_t *rsc, const char *requested_name,
+                                  const char *attr_set, const char *attr_id,
+                                  const char *attr_name, cib_t *cib,
+                                  pe_working_set_t *data_set);
 
 int update_working_set_xml(pe_working_set_t *data_set, xmlNode **xml);
 int wait_till_stable(int timeout_ms, cib_t * cib);
-void cli_resource_why(cib_t *cib_conn,GListPtr resources,const char* rsc,node_t *node) ;
-
+void cli_resource_why(cib_t *cib_conn, GListPtr resources, resource_t *rsc,
+                      node_t *node);
 
 extern xmlNode *do_calculations(pe_working_set_t * data_set, xmlNode * xml_input, crm_time_t * now);
 extern void cleanup_alloc_calculations(pe_working_set_t * data_set);

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -47,8 +47,6 @@ extern char *move_lifetime;
 
 extern const char *attr_set_type;
 
-resource_t *find_rsc_or_clone(const char *rsc, pe_working_set_t * data_set);
-
 /* ban */
 int cli_resource_prefer(const char *rsc_id, const char *host, cib_t * cib_conn);
 int cli_resource_ban(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn);

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -297,7 +297,8 @@ int
 cli_resource_print(const char *rsc, pe_working_set_t * data_set, bool expanded)
 {
     char *rsc_xml = NULL;
-    resource_t *the_rsc = find_rsc_or_clone(rsc, data_set);
+    resource_t *the_rsc = pe_find_resource_with_flags(data_set->resources, rsc,
+                                                      pe_find_renamed|pe_find_any);
     int opts = pe_print_printf;
 
     if (the_rsc == NULL) {
@@ -332,7 +333,8 @@ cli_resource_print_attribute(const char *rsc, const char *attr, pe_working_set_t
     int rc = -ENXIO;
     node_t *current = NULL;
     GHashTable *params = NULL;
-    resource_t *the_rsc = find_rsc_or_clone(rsc, data_set);
+    resource_t *the_rsc = pe_find_resource_with_flags(data_set->resources, rsc,
+                                                      pe_find_renamed|pe_find_any);
     const char *value = NULL;
 
     if (the_rsc == NULL) {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -97,20 +97,6 @@ cli_resource_search(const char *rsc, pe_working_set_t * data_set)
     return found;
 }
 
-resource_t *
-find_rsc_or_clone(const char *rsc, pe_working_set_t * data_set)
-{
-    resource_t *the_rsc = pe_find_resource(data_set->resources, rsc);
-
-    if (the_rsc == NULL) {
-        char *as_clone = crm_concat(rsc, "0", ':');
-
-        the_rsc = pe_find_resource(data_set->resources, as_clone);
-        free(as_clone);
-    }
-    return the_rsc;
-}
-
 #define XPATH_MAX 1024
 
 static int
@@ -266,7 +252,8 @@ cli_resource_update_attribute(const char *rsc_id, const char *attr_set, const ch
     xmlNode *xml_obj = NULL;
 
     bool use_attributes_tag = FALSE;
-    resource_t *rsc = find_rsc_or_clone(rsc_id, data_set);
+    resource_t *rsc = pe_find_resource_with_flags(data_set->resources, rsc_id,
+                                                  pe_find_renamed|pe_find_any);
 
     if (rsc == NULL) {
         return -ENXIO;
@@ -418,7 +405,8 @@ cli_resource_delete_attribute(const char *rsc_id, const char *attr_set, const ch
     int rc = pcmk_ok;
     char *lookup_id = NULL;
     char *local_attr_id = NULL;
-    resource_t *rsc = find_rsc_or_clone(rsc_id, data_set);
+    resource_t *rsc = pe_find_resource_with_flags(data_set->resources, rsc_id,
+                                                  pe_find_renamed|pe_find_any);
 
     if (rsc == NULL) {
         return -ENXIO;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -56,42 +56,30 @@ do_find_resource(const char *rsc, resource_t * the_rsc, pe_working_set_t * data_
 }
 
 int
-cli_resource_search(const char *rsc, pe_working_set_t * data_set)
+cli_resource_search(resource_t *rsc, const char *requested_name,
+                    pe_working_set_t *data_set)
 {
     int found = 0;
-    resource_t *the_rsc = NULL;
-    resource_t *parent = NULL;
+    resource_t *parent = uber_parent(rsc);
 
-    if (the_rsc == NULL) {
-        the_rsc = pe_find_resource(data_set->resources, rsc);
-    }
-
-    if (the_rsc == NULL) {
-        return -ENXIO;
-    }
-
-    if (pe_rsc_is_clone(the_rsc)) {
-        GListPtr gIter = the_rsc->children;
-
-        for (; gIter != NULL; gIter = gIter->next) {
-            found += do_find_resource(rsc, gIter->data, data_set);
+    if (pe_rsc_is_clone(rsc)) {
+        for (GListPtr iter = rsc->children; iter != NULL; iter = iter->next) {
+            found += do_find_resource(requested_name, iter->data, data_set);
         }
 
     /* The anonymous clone children's common ID is supplied */
-    } else if ((parent = uber_parent(the_rsc)) != NULL
-               && pe_rsc_is_clone(parent)
-               && is_not_set(the_rsc->flags, pe_rsc_unique)
-               && the_rsc->clone_name
-               && safe_str_eq(rsc, the_rsc->clone_name)
-               && safe_str_neq(rsc, the_rsc->id)) {
-        GListPtr gIter = parent->children;
+    } else if (pe_rsc_is_clone(parent)
+               && is_not_set(rsc->flags, pe_rsc_unique)
+               && rsc->clone_name
+               && safe_str_eq(requested_name, rsc->clone_name)
+               && safe_str_neq(requested_name, rsc->id)) {
 
-        for (; gIter != NULL; gIter = gIter->next) {
-            found += do_find_resource(rsc, gIter->data, data_set);
+        for (GListPtr iter = parent->children; iter; iter = iter->next) {
+            found += do_find_resource(requested_name, iter->data, data_set);
         }
 
     } else {
-        found += do_find_resource(rsc, the_rsc, data_set);
+        found += do_find_resource(requested_name, rsc, data_set);
     }
 
     return found;
@@ -237,9 +225,11 @@ find_matching_attr_resource(resource_t * rsc, const char * rsc_id, const char * 
 }
 
 int
-cli_resource_update_attribute(const char *rsc_id, const char *attr_set, const char *attr_id,
-                  const char *attr_name, const char *attr_value, bool recursive,
-                  cib_t * cib, pe_working_set_t * data_set)
+cli_resource_update_attribute(resource_t *rsc, const char *requested_name,
+                              const char *attr_set, const char *attr_id,
+                              const char *attr_name, const char *attr_value,
+                              bool recursive, cib_t *cib,
+                              pe_working_set_t *data_set)
 {
     int rc = pcmk_ok;
     static bool need_init = TRUE;
@@ -252,12 +242,6 @@ cli_resource_update_attribute(const char *rsc_id, const char *attr_set, const ch
     xmlNode *xml_obj = NULL;
 
     bool use_attributes_tag = FALSE;
-    resource_t *rsc = pe_find_resource_with_flags(data_set->resources, rsc_id,
-                                                  pe_find_renamed|pe_find_any);
-
-    if (rsc == NULL) {
-        return -ENXIO;
-    }
 
     if(attr_id == NULL
        && do_force == FALSE
@@ -283,7 +267,8 @@ cli_resource_update_attribute(const char *rsc_id, const char *attr_set, const ch
         }
 
     } else {
-        rsc = find_matching_attr_resource(rsc, rsc_id, attr_set, attr_id, attr_name, cib, "update");
+        rsc = find_matching_attr_resource(rsc, requested_name, attr_set,
+                                          attr_id, attr_name, cib, "update");
     }
 
     lookup_id = clone_strip(rsc->id); /* Could be a cloned group! */
@@ -388,7 +373,9 @@ cli_resource_update_attribute(const char *rsc_id, const char *attr_set, const ch
             if (cons->score > 0 && is_not_set(peer->flags, pe_rsc_allocating)) {
                 /* Don't get into colocation loops */
                 crm_debug("Setting %s=%s for dependent resource %s", attr_name, attr_value, peer->id);
-                cli_resource_update_attribute(peer->id, NULL, NULL, attr_name, attr_value, recursive, cib, data_set);
+                cli_resource_update_attribute(peer, peer->id, NULL, NULL,
+                                              attr_name, attr_value, recursive,
+                                              cib, data_set);
             }
         }
     }
@@ -397,20 +384,16 @@ cli_resource_update_attribute(const char *rsc_id, const char *attr_set, const ch
 }
 
 int
-cli_resource_delete_attribute(const char *rsc_id, const char *attr_set, const char *attr_id,
-                     const char *attr_name, cib_t * cib, pe_working_set_t * data_set)
+cli_resource_delete_attribute(resource_t *rsc, const char *requested_name,
+                              const char *attr_set, const char *attr_id,
+                              const char *attr_name, cib_t *cib,
+                              pe_working_set_t *data_set)
 {
     xmlNode *xml_obj = NULL;
 
     int rc = pcmk_ok;
     char *lookup_id = NULL;
     char *local_attr_id = NULL;
-    resource_t *rsc = pe_find_resource_with_flags(data_set->resources, rsc_id,
-                                                  pe_find_renamed|pe_find_any);
-
-    if (rsc == NULL) {
-        return -ENXIO;
-    }
 
     if(attr_id == NULL
        && do_force == FALSE
@@ -420,7 +403,8 @@ cli_resource_delete_attribute(const char *rsc_id, const char *attr_set, const ch
     }
 
     if(safe_str_eq(attr_set_type, XML_TAG_META_SETS)) {
-        rsc = find_matching_attr_resource(rsc, rsc_id, attr_set, attr_id, attr_name, cib, "delete");
+        rsc = find_matching_attr_resource(rsc, requested_name, attr_set,
+                                          attr_id, attr_name, cib, "delete");
     }
 
     lookup_id = clone_strip(rsc->id);
@@ -1176,7 +1160,9 @@ cli_resource_restart(resource_t * rsc, const char *host, int timeout_ms, cib_t *
         find_resource_attr(cib, XML_NVPAIR_ATTR_VALUE, lookup_id, NULL, NULL,
                            NULL, XML_RSC_ATTR_TARGET_ROLE, &orig_target_role);
         free(lookup_id);
-        rc = cli_resource_update_attribute(rsc_id, NULL, NULL, XML_RSC_ATTR_TARGET_ROLE, RSC_STOPPED, FALSE, cib, &data_set);
+        rc = cli_resource_update_attribute(rsc, rsc_id, NULL, NULL,
+                                           XML_RSC_ATTR_TARGET_ROLE,
+                                           RSC_STOPPED, FALSE, cib, &data_set);
     }
     if(rc != pcmk_ok) {
         fprintf(stderr, "Could not set target-role for %s: %s (%d)\n", rsc_id, pcmk_strerror(rc), rc);
@@ -1248,14 +1234,16 @@ cli_resource_restart(resource_t * rsc, const char *host, int timeout_ms, cib_t *
         rc = cli_resource_clear(rsc_id, host, NULL, cib);
 
     } else if (orig_target_role) {
-        rc = cli_resource_update_attribute(rsc_id, NULL, NULL,
+        rc = cli_resource_update_attribute(rsc, rsc_id, NULL, NULL,
                                            XML_RSC_ATTR_TARGET_ROLE,
                                            orig_target_role, FALSE, cib,
                                            &data_set);
         free(orig_target_role);
         orig_target_role = NULL;
     } else {
-        rc = cli_resource_delete_attribute(rsc_id, NULL, NULL, XML_RSC_ATTR_TARGET_ROLE, cib, &data_set);
+        rc = cli_resource_delete_attribute(rsc, rsc_id, NULL, NULL,
+                                           XML_RSC_ATTR_TARGET_ROLE, cib,
+                                           &data_set);
     }
 
     if(rc != pcmk_ok) {
@@ -1328,12 +1316,13 @@ cli_resource_restart(resource_t * rsc, const char *host, int timeout_ms, cib_t *
     if (stop_via_ban) {
         cli_resource_clear(rsc_id, host, NULL, cib);
     } else if (orig_target_role) {
-        cli_resource_update_attribute(rsc_id, NULL, NULL,
+        cli_resource_update_attribute(rsc, rsc_id, NULL, NULL,
                                       XML_RSC_ATTR_TARGET_ROLE,
                                       orig_target_role, FALSE, cib, &data_set);
         free(orig_target_role);
     } else {
-        cli_resource_delete_attribute(rsc_id, NULL, NULL, XML_RSC_ATTR_TARGET_ROLE, cib, &data_set);
+        cli_resource_delete_attribute(rsc, rsc_id, NULL, NULL,
+                                      XML_RSC_ATTR_TARGET_ROLE, cib, &data_set);
     }
 
 done:
@@ -1467,7 +1456,8 @@ wait_till_stable(int timeout_ms, cib_t * cib)
 }
 
 int
-cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *override_hash,
+cli_resource_execute(resource_t *rsc, const char *requested_name,
+                     const char *rsc_action, GHashTable *override_hash,
                      int timeout_ms, cib_t * cib, pe_working_set_t *data_set)
 {
     int rc = pcmk_ok;
@@ -1478,12 +1468,6 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
     const char *rclass = NULL;
     const char *action = NULL;
     GHashTable *params = NULL;
-    resource_t *rsc = pe_find_resource(data_set->resources, rsc_id);
-
-    if (rsc == NULL) {
-        CMD_ERR("Must supply a resource id with -r");
-        return -ENXIO;
-    }
 
     if (safe_str_eq(rsc_action, "validate")) {
         action = "validate-all";
@@ -1500,9 +1484,10 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
         action = rsc_action+6;
 
         if(pe_rsc_is_clone(rsc)) {
-            rc = cli_resource_search(rsc_id, data_set);
+            rc = cli_resource_search(rsc, requested_name, data_set);
             if(rc > 0 && do_force == FALSE) {
-                CMD_ERR("It is not safe to %s %s here: the cluster claims it is already active", action, rsc_id);
+                CMD_ERR("It is not safe to %s %s here: the cluster claims it is already active",
+                        action, rsc->id);
                 CMD_ERR("Try setting target-role=stopped first or specifying --force");
                 crm_exit(EPERM);
             }
@@ -1540,7 +1525,7 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
     /* add crm_feature_set env needed by some resource agents */
     g_hash_table_insert(params, strdup(XML_ATTR_CRM_VERSION), strdup(CRM_FEATURE_SET));
 
-    rid = pe_rsc_is_anon_clone(rsc->parent) ? rsc_id : rsc->id;
+    rid = pe_rsc_is_anon_clone(rsc->parent)? requested_name : rsc->id;
 
     op = resources_action_create(rid, rclass, rprov, rtype, action, 0,
                                  timeout_ms, params, 0);
@@ -1629,20 +1614,16 @@ cli_resource_execute(const char *rsc_id, const char *rsc_action, GHashTable *ove
 }
 
 int
-cli_resource_move(const char *rsc_id, const char *host_name, cib_t * cib, pe_working_set_t *data_set)
+cli_resource_move(resource_t *rsc, const char *rsc_id, const char *host_name,
+                  cib_t *cib, pe_working_set_t *data_set)
 {
     int rc = -EINVAL;
     int count = 0;
     node_t *current = NULL;
     node_t *dest = pe_find_node(data_set->nodes, host_name);
-    resource_t *rsc = pe_find_resource(data_set->resources, rsc_id);
     bool cur_is_dest = FALSE;
 
-    if (rsc == NULL) {
-        CMD_ERR("Resource '%s' not moved: not found", rsc_id);
-        return -ENXIO;
-
-    } else if (scope_master && rsc->variant != pe_master) {
+    if (scope_master && rsc->variant != pe_master) {
         resource_t *p = uber_parent(rsc);
         if(p->variant == pe_master) {
             CMD_ERR("Using parent '%s' for --move command instead of '%s'.", rsc->id, rsc_id);
@@ -1762,12 +1743,10 @@ cli_resource_why_without_rsc_and_host(cib_t *cib_conn,GListPtr resources)
 }
 
 static void
-cli_resource_why_with_rsc_and_host(cib_t *cib_conn,GListPtr resources,const char* rsc_id,const char* host_uname)
+cli_resource_why_with_rsc_and_host(cib_t *cib_conn, GListPtr resources,
+                                   resource_t *rsc, const char *host_uname)
 {
-    resource_t *rsc = NULL;
-
-    rsc = pe_find_resource(resources, rsc_id);
-    if((resource_is_running_on(rsc,host_uname))) {
+    if (resource_is_running_on(rsc, host_uname)) {
         printf("Resource %s is running on host %s\n",rsc->id,host_uname);
     } else {
         printf("Resource %s is not running on host %s\n", rsc->id, host_uname);
@@ -1803,39 +1782,33 @@ cli_resource_why_without_rsc_with_host(cib_t *cib_conn,GListPtr resources,node_t
 }
 
 static void
-cli_resource_why_with_rsc_without_host(cib_t *cib_conn,GListPtr resources,const char* rsc_id)
+cli_resource_why_with_rsc_without_host(cib_t *cib_conn, GListPtr resources,
+                                       resource_t *rsc)
 {
-    resource_t *rsc = NULL;
     GListPtr hosts = NULL;
 
-    rsc = pe_find_resource(resources, rsc_id);
     rsc->fns->location(rsc, &hosts, TRUE);
-    if ( hosts == NULL ) {
-        printf("Resource %s is not running\n", rsc->id);
-    } else {
-        printf("Resource %s is running\n",rsc->id);
-    }
+    printf("Resource %s is %srunning\n", rsc->id, (hosts? "" : "not "));
     cli_resource_check(cib_conn, rsc);
-
     g_list_free(hosts);
-    hosts = NULL;
 }
 
-void cli_resource_why(cib_t *cib_conn,GListPtr resources,const char* rsc_id,node_t *node)
+void cli_resource_why(cib_t *cib_conn, GListPtr resources, resource_t *rsc,
+                      node_t *node)
 {
     const char *host_uname = (node == NULL)? NULL : node->details->uname;
 
-    if ((rsc_id == NULL) && (host_uname == NULL)) {
+    if ((rsc == NULL) && (host_uname == NULL)) {
         cli_resource_why_without_rsc_and_host(cib_conn, resources);
 
-    } else if ((rsc_id != NULL) && (host_uname != NULL)) {
-        cli_resource_why_with_rsc_and_host(cib_conn, resources, rsc_id,
+    } else if ((rsc != NULL) && (host_uname != NULL)) {
+        cli_resource_why_with_rsc_and_host(cib_conn, resources, rsc,
                                            host_uname);
 
-    } else if ((rsc_id == NULL) && (host_uname != NULL)) {
+    } else if ((rsc == NULL) && (host_uname != NULL)) {
         cli_resource_why_without_rsc_with_host(cib_conn, resources, node);
 
-    } else if ((rsc_id != NULL) && (host_uname == NULL)) {
-        cli_resource_why_with_rsc_without_host(cib_conn, resources, rsc_id);
+    } else if ((rsc != NULL) && (host_uname == NULL)) {
+        cli_resource_why_with_rsc_without_host(cib_conn, resources, rsc);
     }
 }

--- a/tools/regression.sh
+++ b/tools/regression.sh
@@ -764,6 +764,7 @@ for t in $tests; do
         -e 's|^/tmp/[0-9][0-9]*\.||'\
         -e 's/^Entity: line [0-9][0-9]*: //'\
         -e 's/schemas\.c:\([0-9][0-9]*\)/schemas.c:NNN/' \
+        -e 's/constraints\.:\([0-9][0-9]*\)/constraints.:NNN/' \
         -e 's/\(validation ([0-9][0-9]* of \)[0-9][0-9]*\().*\)/\1X\2/' \
 	$test_home/regression.$t.out
 

--- a/tools/regression.validity.exp
+++ b/tools/regression.validity.exp
@@ -416,7 +416,7 @@ bad-1.2.xml:10: element rsc_order: Relax-NG validity error : Element constraints
 error: unpack_resources:	Resource start-up disabled since no STONITH resources have been defined
 error: unpack_resources:	Either configure some or disable STONITH with the stonith-enabled option
 error: unpack_resources:	NOTE: Clusters with shared data need STONITH to ensure data integrity
-(constraints.:430   )   error: unpack_simple_rsc_order:	Cannot invert rsc_order constraint ord_1-2. Please specify the inverse manually.
+(constraints.:NNN   )   error: unpack_simple_rsc_order:	Cannot invert rsc_order constraint ord_1-2. Please specify the inverse manually.
 
 Current cluster status:
 


### PR DESCRIPTION
Most importantly, this fixes a nasty bug introduced by 1.1.17+ffb94ac36 affecting the detection of reloadable and private resource agent parameters.

Among other changes, this also replaces find_rsc_or_clone() with a new pe_find_* flag, and overhauls the way crm_resource searches for resources.