### PR TITLE
Build: spec: make -libs-devel package dependencies arch-qualified

### DIFF
--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -315,11 +315,12 @@ License:       GPLv2+ and LGPLv2+
 Summary:       Pacemaker development package
 Group:         Development/Libraries
 Requires:      %{name}-cts = %{version}-%{release}
-Requires:      %{name}-libs = %{version}-%{release}
-Requires:      %{name}-cluster-libs = %{version}-%{release}
-Requires:      libtool-ltdl-devel libqb-devel libuuid-devel
-Requires:      libxml2-devel libxslt-devel bzip2-devel glib2-devel
-Requires:      corosynclib-devel
+Requires:      %{name}-libs%{?_isa} = %{version}-%{release}
+Requires:      %{name}-cluster-libs%{?_isa} = %{version}-%{release}
+Requires:      libtool-ltdl-devel%{?_isa} libuuid-devel%{?_isa}
+Requires:      libxml2-devel%{?_isa} libxslt-devel%{?_isa}
+Requires:      bzip2-devel%{?_isa} glib2-devel%{?_isa}
+Requires:      libqb-devel%{?_isa} corosynclib-devel%{?_isa}
 
 %description -n %{name}-libs-devel
 Pacemaker is an advanced, scalable High-Availability cluster resource


### PR DESCRIPTION
Beside the fact that *.so symlinks delivered with that package are
indeed satisfied with and only with arch-preserving -{,cluster-}libs
packages, it's also a matter of being disciplined per what distros
reasonably require:
https://fedoraproject.org/wiki/Packaging:Guidelines#Architecture-specific_Dependencies
(https://fedoraproject.org/wiki/Packaging:Guidelines#Requiring_Base_Package)

The syntactic provision at hand was introduced in rpm 4.6.0
(8+ years ago): http://rpm.org/user_doc/arch_dependencies.html