### PR TITLE
Finish crm_resource --cleanup fix

### DIFF
--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -970,39 +970,10 @@ unpack_operation(action_t * action, xmlNode * xml_obj, resource_t * container,
         }
     }
 
-    /* @COMPAT data sets < 1.1.10 ("requires" on start action not resource) */
-    value = g_hash_table_lookup(action->meta, "requires");
-    if (value) {
-        pe_warn_once(pe_wo_requires, "Support for 'requires' operation meta-attribute"
-                                     " is deprecated and will be removed in a future version"
-                                     " (use 'requires' resource meta-attribute instead)");
-    }
-
     if (safe_str_neq(action->task, RSC_START)
         && safe_str_neq(action->task, RSC_PROMOTE)) {
         action->needs = rsc_req_nothing;
         value = "nothing (not start/promote)";
-
-    } else if (safe_str_eq(value, "nothing")) {
-        action->needs = rsc_req_nothing;
-
-    } else if (safe_str_eq(value, "quorum")) {
-        action->needs = rsc_req_quorum;
-
-    } else if (safe_str_eq(value, "unfencing")) {
-        action->needs = rsc_req_stonith;
-        set_bit(action->rsc->flags, pe_rsc_needs_unfencing);
-        if (is_not_set(data_set->flags, pe_flag_stonith_enabled)) {
-            crm_notice("%s requires unfencing but fencing is disabled", action->rsc->id);
-        }
-
-    } else if (is_set(data_set->flags, pe_flag_stonith_enabled)
-               && safe_str_eq(value, "fencing")) {
-        action->needs = rsc_req_stonith;
-        if (is_not_set(data_set->flags, pe_flag_stonith_enabled)) {
-            crm_notice("%s requires fencing but fencing is disabled", action->rsc->id);
-        }
-        /* @COMPAT end compatibility code */
 
     } else if (is_set(action->rsc->flags, pe_rsc_needs_fencing)) {
         action->needs = rsc_req_stonith;

--- a/pengine/test10/726.exp
+++ b/pengine/test10/726.exp
@@ -288,7 +288,7 @@
      <action_set>
       <rsc_op id="47" operation="monitor" operation_key="child_DoFencing:0_monitor_5000" on_node="test02" on_node_uuid="f75e684a-be1e-4036-89e5-a14f8dcdc947">
         <primitive id="child_DoFencing:0" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="test02" CRM_meta_on_node_uuid="f75e684a-be1e-4036-89e5-a14f8dcdc947" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="test02" CRM_meta_on_node_uuid="f75e684a-be1e-4036-89e5-a14f8dcdc947" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
        </rsc_op>
      </action_set>
     <inputs>
@@ -301,7 +301,7 @@
      <action_set>
       <rsc_op id="45" operation="start" operation_key="child_DoFencing:0_start_0" on_node="test02" on_node_uuid="f75e684a-be1e-4036-89e5-a14f8dcdc947">
         <primitive id="child_DoFencing:0" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="test02" CRM_meta_on_node_uuid="f75e684a-be1e-4036-89e5-a14f8dcdc947" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="test02" CRM_meta_on_node_uuid="f75e684a-be1e-4036-89e5-a14f8dcdc947" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -332,7 +332,7 @@
     <action_set>
       <rsc_op id="50" operation="monitor" operation_key="child_DoFencing:1_monitor_5000" on_node="test03" on_node_uuid="f9c593eb-ca0d-4ab3-ba88-fde12c02334a">
         <primitive id="child_DoFencing:1" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="test03" CRM_meta_on_node_uuid="f9c593eb-ca0d-4ab3-ba88-fde12c02334a" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="test03" CRM_meta_on_node_uuid="f9c593eb-ca0d-4ab3-ba88-fde12c02334a" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -345,7 +345,7 @@
      <action_set>
       <rsc_op id="48" operation="start" operation_key="child_DoFencing:1_start_0" on_node="test03" on_node_uuid="f9c593eb-ca0d-4ab3-ba88-fde12c02334a">
         <primitive id="child_DoFencing:1" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="test03" CRM_meta_on_node_uuid="f9c593eb-ca0d-4ab3-ba88-fde12c02334a" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="test03" CRM_meta_on_node_uuid="f9c593eb-ca0d-4ab3-ba88-fde12c02334a" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -385,7 +385,7 @@
      <action_set>
       <rsc_op id="52" operation="monitor" operation_key="child_DoFencing:2_monitor_5000" on_node="ibm1" on_node_uuid="d0d76dd9-7a01-4c12-bbec-98aa2a669638">
         <primitive id="child_DoFencing:2" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="2" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="ibm1" CRM_meta_on_node_uuid="d0d76dd9-7a01-4c12-bbec-98aa2a669638" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
+        <attributes CRM_meta_clone="2" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="ibm1" CRM_meta_on_node_uuid="d0d76dd9-7a01-4c12-bbec-98aa2a669638" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -398,7 +398,7 @@
      <action_set>
       <rsc_op id="51" operation="start" operation_key="child_DoFencing:2_start_0" on_node="ibm1" on_node_uuid="d0d76dd9-7a01-4c12-bbec-98aa2a669638">
         <primitive id="child_DoFencing:2" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="2" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="ibm1" CRM_meta_on_node_uuid="d0d76dd9-7a01-4c12-bbec-98aa2a669638" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
+        <attributes CRM_meta_clone="2" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="ibm1" CRM_meta_on_node_uuid="d0d76dd9-7a01-4c12-bbec-98aa2a669638" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -447,7 +447,7 @@
      <action_set>
       <rsc_op id="54" operation="monitor" operation_key="child_DoFencing:3_monitor_5000" on_node="sgi2" on_node_uuid="619e8a37-147a-4782-ac11-46afad7c32b8">
         <primitive id="child_DoFencing:3" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="3" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="sgi2" CRM_meta_on_node_uuid="619e8a37-147a-4782-ac11-46afad7c32b8" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
+        <attributes CRM_meta_clone="3" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="sgi2" CRM_meta_on_node_uuid="619e8a37-147a-4782-ac11-46afad7c32b8" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -460,7 +460,7 @@
      <action_set>
       <rsc_op id="53" operation="start" operation_key="child_DoFencing:3_start_0" on_node="sgi2" on_node_uuid="619e8a37-147a-4782-ac11-46afad7c32b8">
         <primitive id="child_DoFencing:3" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="3" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="sgi2" CRM_meta_on_node_uuid="619e8a37-147a-4782-ac11-46afad7c32b8" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
+        <attributes CRM_meta_clone="3" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="sgi2" CRM_meta_on_node_uuid="619e8a37-147a-4782-ac11-46afad7c32b8" CRM_meta_timeout="20000"  hostlist="sgi2 ibm1 test02 test03 "/>
        </rsc_op>
      </action_set>
      <inputs>

--- a/pengine/test10/726.xml
+++ b/pengine/test10/726.xml
@@ -73,13 +73,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="5s" id="op.auto-6" timeout="20s" requires="nothing"/>
-            <op name="start" interval="0" id="op.auto-7" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="op.auto-6" timeout="20s"/>
+            <op name="start" interval="0" id="op.auto-7" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22207">
             <nvpair id="nvpair.id22214" name="hostlist" value="sgi2 ibm1 test02 test03 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-121" name="resource-stickiness" value="1"/>

--- a/pengine/test10/735.exp
+++ b/pengine/test10/735.exp
@@ -78,7 +78,7 @@
      <action_set>
       <rsc_op id="18" operation="monitor" operation_key="child_DoFencing:0_monitor_5000" on_node="hadev2" on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3">
         <primitive id="child_DoFencing:0" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="3" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="hadev2" CRM_meta_on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="3" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="hadev2" CRM_meta_on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
        </rsc_op>
      </action_set>
     <inputs>
@@ -91,7 +91,7 @@
      <action_set>
       <rsc_op id="17" operation="start" operation_key="child_DoFencing:0_start_0" on_node="hadev2" on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3">
         <primitive id="child_DoFencing:0" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="3" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="hadev2" CRM_meta_on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="3" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="hadev2" CRM_meta_on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -113,7 +113,7 @@
      <action_set>
       <rsc_op id="20" operation="monitor" operation_key="child_DoFencing:1_monitor_5000" on_node="hadev3" on_node_uuid="879e65f8-4b38-4c56-9552-4752ad436669">
         <primitive id="child_DoFencing:1" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="3" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="hadev3" CRM_meta_on_node_uuid="879e65f8-4b38-4c56-9552-4752ad436669" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="3" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="hadev3" CRM_meta_on_node_uuid="879e65f8-4b38-4c56-9552-4752ad436669" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -126,7 +126,7 @@
      <action_set>
       <rsc_op id="19" operation="start" operation_key="child_DoFencing:1_start_0" on_node="hadev3" on_node_uuid="879e65f8-4b38-4c56-9552-4752ad436669">
         <primitive id="child_DoFencing:1" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="3" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="hadev3" CRM_meta_on_node_uuid="879e65f8-4b38-4c56-9552-4752ad436669" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="3" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="hadev3" CRM_meta_on_node_uuid="879e65f8-4b38-4c56-9552-4752ad436669" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
        </rsc_op>
      </action_set>
      <inputs>

--- a/pengine/test10/735.xml
+++ b/pengine/test10/735.xml
@@ -66,13 +66,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="5s" id="op.auto-5" timeout="20s" requires="nothing"/>
-            <op name="start" interval="0" id="op.auto-6" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="op.auto-5" timeout="20s"/>
+            <op name="start" interval="0" id="op.auto-6" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22174">
             <nvpair id="nvpair.id22180" name="hostlist" value="hadev1 hadev2 hadev3 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-110" name="clone-max" value="3"/>

--- a/pengine/test10/764.exp
+++ b/pengine/test10/764.exp
@@ -93,7 +93,7 @@
      <action_set>
       <rsc_op id="27" operation="monitor" operation_key="child_DoFencing:0_monitor_5000" on_node="posic043" on_node_uuid="3daa25e7-8713-4c6f-8790-7f41599a1596">
         <primitive id="child_DoFencing:0" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="posic043" CRM_meta_on_node_uuid="3daa25e7-8713-4c6f-8790-7f41599a1596" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="posic041 posic042 posic043 posic044 "/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="posic043" CRM_meta_on_node_uuid="3daa25e7-8713-4c6f-8790-7f41599a1596" CRM_meta_timeout="20000"  hostlist="posic041 posic042 posic043 posic044 "/>
        </rsc_op>
      </action_set>
      <inputs/>
@@ -102,7 +102,7 @@
      <action_set>
       <rsc_op id="30" operation="monitor" operation_key="child_DoFencing:1_monitor_5000" on_node="posic041" on_node_uuid="c5d5ed56-7340-4d81-afd6-40b5ee6803ad">
         <primitive id="child_DoFencing:1" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="posic041" CRM_meta_on_node_uuid="c5d5ed56-7340-4d81-afd6-40b5ee6803ad" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="posic041 posic042 posic043 posic044 "/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="posic041" CRM_meta_on_node_uuid="c5d5ed56-7340-4d81-afd6-40b5ee6803ad" CRM_meta_timeout="20000"  hostlist="posic041 posic042 posic043 posic044 "/>
        </rsc_op>
      </action_set>
      <inputs/>

--- a/pengine/test10/764.xml
+++ b/pengine/test10/764.xml
@@ -73,13 +73,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="5s" id="op.auto-6" timeout="20s" requires="nothing"/>
-            <op name="start" interval="0" id="op.auto-7" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="op.auto-6" timeout="20s"/>
+            <op name="start" interval="0" id="op.auto-7" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22199">
             <nvpair id="nvpair.id22206" name="hostlist" value="posic041 posic042 posic043 posic044 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-117" name="clone-max" value="4"/>

--- a/pengine/test10/797.exp
+++ b/pengine/test10/797.exp
@@ -142,7 +142,7 @@
      <action_set>
       <rsc_op id="39" operation="start" operation_key="child_DoFencing:0_start_0" on_node="c001n01" on_node_uuid="de937e3d-0309-4b5d-b85c-f96edc1ed8e3">
         <primitive id="child_DoFencing:0" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="c001n01" CRM_meta_on_node_uuid="de937e3d-0309-4b5d-b85c-f96edc1ed8e3" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="c001n01" CRM_meta_on_node_uuid="de937e3d-0309-4b5d-b85c-f96edc1ed8e3" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -187,7 +187,7 @@
      <action_set>
       <rsc_op id="6" operation="monitor" operation_key="child_DoFencing:0_monitor_5000" on_node="c001n01" on_node_uuid="de937e3d-0309-4b5d-b85c-f96edc1ed8e3">
         <primitive id="child_DoFencing:0" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n01" CRM_meta_on_node_uuid="de937e3d-0309-4b5d-b85c-f96edc1ed8e3" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n01" CRM_meta_on_node_uuid="de937e3d-0309-4b5d-b85c-f96edc1ed8e3" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
        </rsc_op>
      </action_set>
      <inputs>

--- a/pengine/test10/797.xml
+++ b/pengine/test10/797.xml
@@ -73,13 +73,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="5s" id="op.auto-6" timeout="20s" requires="nothing"/>
-            <op name="start" interval="0" id="op.auto-7" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="op.auto-6" timeout="20s"/>
+            <op name="start" interval="0" id="op.auto-7" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22208">
             <nvpair id="nvpair.id22214" name="hostlist" value="c001n08 c001n02 c001n03 c001n01 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-121" name="resource-stickiness" value="1"/>

--- a/pengine/test10/829.xml
+++ b/pengine/test10/829.xml
@@ -74,13 +74,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="5s" id="op.auto-6" timeout="20s" requires="nothing"/>
-            <op name="start" interval="0" id="op.auto-7" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="op.auto-6" timeout="20s"/>
+            <op name="start" interval="0" id="op.auto-7" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22214">
             <nvpair id="nvpair.id22220" name="hostlist" value="c001n08 c001n02 c001n03 c001n01 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-123" name="resource-stickiness" value="1"/>

--- a/pengine/test10/bug-lf-2106.xml
+++ b/pengine/test10/bug-lf-2106.xml
@@ -20,9 +20,12 @@
           <nvpair id="apcstonith-instance_attributes-port" name="port" value="161"/>
           <nvpair id="apcstonith-instance_attributes-ipaddr" name="ipaddr" value="10.2.50.154"/>
         </instance_attributes>
+        <meta_attributes id="meta_attributes-requires">
+          <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+        </meta_attributes>
         <operations>
           <op id="apcstonith-monitor-60" interval="60" name="monitor" timeout="120"/>
-          <op id="apcstonith-start-0" interval="0" name="start" requires="nothing"/>
+          <op id="apcstonith-start-0" interval="0" name="start"/>
         </operations>
       </primitive>
       <clone id="pingdclone">

--- a/pengine/test10/bug-lf-2508.exp
+++ b/pengine/test10/bug-lf-2508.exp
@@ -39,7 +39,7 @@
     <action_set>
       <rsc_op id="20" operation="start" operation_key="Dummy01_start_0" on_node="srv01" on_node_uuid="e2bc05d5-2a0f-4e2e-8566-bd1000f1cfeb">
         <primitive id="Dummy01" class="ocf" provider="heartbeat" type="Dummy"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_fail="restart" CRM_meta_on_node="srv01" CRM_meta_on_node_uuid="e2bc05d5-2a0f-4e2e-8566-bd1000f1cfeb" CRM_meta_requires="fencing" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_name="start" CRM_meta_on_fail="restart" CRM_meta_on_node="srv01" CRM_meta_on_node_uuid="e2bc05d5-2a0f-4e2e-8566-bd1000f1cfeb" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -122,7 +122,7 @@
     <action_set>
       <rsc_op id="27" operation="start" operation_key="Dummy02_start_0" on_node="srv04" on_node_uuid="82d8b53b-a29d-40f5-9a1d-156bf3b7af62">
         <primitive id="Dummy02" class="ocf" provider="heartbeat" type="Dummy"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_fail="restart" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="82d8b53b-a29d-40f5-9a1d-156bf3b7af62" CRM_meta_requires="fencing" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_name="start" CRM_meta_on_fail="restart" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="82d8b53b-a29d-40f5-9a1d-156bf3b7af62" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/bug-lf-2508.xml
+++ b/pengine/test10/bug-lf-2508.xml
@@ -22,7 +22,7 @@
       <group id="Group01">
         <primitive class="ocf" type="Dummy" provider="heartbeat" id="Dummy01">
           <operations>
-            <op id="op-dummy01-start" interval="0" name="start" timeout="60s" on-fail="restart" requires="fencing"/>
+            <op id="op-dummy01-start" interval="0" name="start" timeout="60s" on-fail="restart"/>
             <op id="op-dummy01-monitor" interval="10" name="monitor" timeout="60s" on-fail="restart"/>
             <op id="op-dummy01-stop" interval="0" name="stop" timeout="60s" on-fail="fence"/>
           </operations>
@@ -31,7 +31,7 @@
       <group id="Group02">
         <primitive class="ocf" type="Dummy" provider="heartbeat" id="Dummy02">
           <operations>
-            <op id="op-dummy02-start" interval="0" name="start" timeout="60s" on-fail="restart" requires="fencing"/>
+            <op id="op-dummy02-start" interval="0" name="start" timeout="60s" on-fail="restart"/>
             <op id="op-dummy02-monitor" interval="10" name="monitor" timeout="60s" on-fail="restart"/>
             <op id="op-dummy02-stop" interval="0" name="stop" timeout="60s" on-fail="fence"/>
           </operations>
@@ -40,7 +40,7 @@
       <group id="Group03">
         <primitive class="ocf" type="Dummy" provider="heartbeat" id="Dummy03">
           <operations>
-            <op id="op-dummy03-start" interval="0" name="start" timeout="60s" on-fail="restart" requires="fencing"/>
+            <op id="op-dummy03-start" interval="0" name="start" timeout="60s" on-fail="restart"/>
             <op id="op-dummy03-monitor" interval="10" name="monitor" timeout="60s" on-fail="restart"/>
             <op id="op-dummy03-stop" interval="0" name="stop" timeout="60s" on-fail="fence"/>
           </operations>

--- a/pengine/test10/bug-lf-2581.exp
+++ b/pengine/test10/bug-lf-2581.exp
@@ -46,7 +46,7 @@
     <action_set>
       <rsc_op id="28" operation="start" operation_key="A:1_start_0" on_node="queen" on_node_uuid="queen">
         <primitive id="A" long-id="A:1" class="ocf" provider="rgk" type="typeA"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_fail="restart" CRM_meta_on_node="queen" CRM_meta_on_node_uuid="queen" CRM_meta_requires="fencing" CRM_meta_timeout="30000" />
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_fail="restart" CRM_meta_on_node="queen" CRM_meta_on_node_uuid="queen" CRM_meta_timeout="30000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -81,7 +81,7 @@
     <action_set>
       <rsc_op id="30" operation="start" operation_key="Z:1_start_0" on_node="queen" on_node_uuid="queen">
         <primitive id="Z" long-id="Z:1" class="ocf" provider="rgk" type="typeZ"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_fail="restart" CRM_meta_on_node="queen" CRM_meta_on_node_uuid="queen" CRM_meta_requires="fencing" CRM_meta_timeout="30000" />
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_fail="restart" CRM_meta_on_node="queen" CRM_meta_on_node_uuid="queen" CRM_meta_timeout="30000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/bug-lf-2581.xml
+++ b/pengine/test10/bug-lf-2581.xml
@@ -24,7 +24,7 @@
             <operations id="A-operations">
               <op id="A-op-monitor-120s" interval="120s" name="monitor" on-fail="restart" timeout="30s"/>
               <op id="A-op-monitor-0" interval="0" name="monitor" timeout="30s"/>
-              <op id="A-op-start-0" interval="0" name="start" on-fail="restart" requires="fencing" timeout="30s"/>
+              <op id="A-op-start-0" interval="0" name="start" on-fail="restart" timeout="30s"/>
               <op id="A-op-stop-0" interval="0" name="stop" on-fail="fence" timeout="30s"/>
             </operations>
           </primitive>
@@ -32,7 +32,7 @@
             <operations id="Z-operations">
               <op id="Z-op-monitor-120s" interval="120s" name="monitor" on-fail="restart" timeout="30s"/>
               <op id="Z-op-monitor-0" interval="0" name="monitor" timeout="30s"/>
-              <op id="Z-op-start-0" interval="0" name="start" on-fail="restart" requires="fencing" timeout="30s"/>
+              <op id="Z-op-start-0" interval="0" name="start" on-fail="restart" timeout="30s"/>
               <op id="Z-op-stop-0" interval="0" name="stop" on-fail="fence" timeout="30s"/>
             </operations>
           </primitive>
@@ -50,7 +50,7 @@
           <operations id="B-1-operations">
             <op id="B-1-op-monitor-120s" interval="120s" name="monitor" on-fail="restart" timeout="30s"/>
             <op id="B-1-op-monitor-0" interval="30s" name="monitor" timeout="30s"/>
-            <op id="B-1-op-start-0" interval="0" name="start" on-fail="restart" requires="fencing" timeout="30s"/>
+            <op id="B-1-op-start-0" interval="0" name="start" on-fail="restart" timeout="30s"/>
             <op id="B-1-op-stop-0" interval="0" name="stop" on-fail="fence" timeout="30s"/>
           </operations>
           <instance_attributes id="B-1-instance_attributes">
@@ -65,7 +65,7 @@
           <operations id="C-1-operations">
             <op id="C-1-op-monitor-120s" interval="120s" name="monitor" on-fail="restart" timeout="30s"/>
             <op id="C-1-op-monitor-0" interval="30s" name="monitor" timeout="30s"/>
-            <op id="C-1-op-start-0" interval="0" name="start" on-fail="restart" requires="fencing" timeout="30s"/>
+            <op id="C-1-op-start-0" interval="0" name="start" on-fail="restart" timeout="30s"/>
             <op id="C-1-op-stop-0" interval="0" name="stop" on-fail="fence" timeout="30s"/>
           </operations>
           <instance_attributes id="C-1-instance_attributes">
@@ -85,7 +85,7 @@
           <operations id="B-2-operations">
             <op id="B-2-op-monitor-120s" interval="120s" name="monitor" on-fail="restart" timeout="30s"/>
             <op id="B-2-op-monitor-0" interval="30s" name="monitor" timeout="30s"/>
-            <op id="B-2-op-start-0" interval="0" name="start" on-fail="restart" requires="fencing" timeout="30s"/>
+            <op id="B-2-op-start-0" interval="0" name="start" on-fail="restart" timeout="30s"/>
             <op id="B-2-op-stop-0" interval="0" name="stop" on-fail="fence" timeout="30s"/>
           </operations>
           <instance_attributes id="B-2-instance_attributes">
@@ -100,7 +100,7 @@
           <operations id="C-2-operations">
             <op id="C-2-op-monitor-120s" interval="120s" name="monitor" on-fail="restart" timeout="30s"/>
             <op id="C-2-op-monitor-0" interval="30s" name="monitor" timeout="30s"/>
-            <op id="C-2-op-start-0" interval="0" name="start" on-fail="restart" requires="fencing" timeout="30s"/>
+            <op id="C-2-op-start-0" interval="0" name="start" on-fail="restart" timeout="30s"/>
             <op id="C-2-op-stop-0" interval="0" name="stop" on-fail="fence" timeout="30s"/>
           </operations>
           <instance_attributes id="C-2-instance_attributes">

--- a/pengine/test10/clone-anon-failcount.exp
+++ b/pengine/test10/clone-anon-failcount.exp
@@ -119,7 +119,7 @@
     <action_set>
       <rsc_op id="36" operation="start" operation_key="UmIPaddr_start_0" on_node="srv04" on_node_uuid="srv04">
         <primitive id="UmIPaddr" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_fail="restart" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="srv04" CRM_meta_requires="fencing" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_name="start" CRM_meta_on_fail="restart" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="srv04" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -167,7 +167,7 @@
     <action_set>
       <rsc_op id="39" operation="start" operation_key="UmDummy01_start_0" on_node="srv04" on_node_uuid="srv04">
         <primitive id="UmDummy01" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_fail="restart" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="srv04" CRM_meta_requires="fencing" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_name="start" CRM_meta_on_fail="restart" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="srv04" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -215,7 +215,7 @@
     <action_set>
       <rsc_op id="42" operation="start" operation_key="UmDummy02_start_0" on_node="srv04" on_node_uuid="srv04">
         <primitive id="UmDummy02" class="ocf" provider="pacemaker" type="Dummy"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_fail="standby" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="srv04" CRM_meta_requires="fencing" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_name="start" CRM_meta_on_fail="standby" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="srv04" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/clone-anon-failcount.xml
+++ b/pengine/test10/clone-anon-failcount.xml
@@ -27,21 +27,21 @@
         </primitive>
         <primitive class="ocf" type="Dummy" provider="pacemaker" id="UmIPaddr">
           <operations>
-            <op id="op-umIPaddr-start" interval="0" name="start" timeout="60s" on-fail="restart" requires="fencing"/>
+            <op id="op-umIPaddr-start" interval="0" name="start" timeout="60s" on-fail="restart"/>
             <op id="op-umIPaddr-monitor" interval="10" name="monitor" timeout="60s" on-fail="restart"/>
             <op id="op-umIPaddr-stop" interval="0" name="stop" timeout="60s" on-fail="block"/>
           </operations>
         </primitive>
         <primitive class="ocf" type="Dummy" provider="pacemaker" id="UmDummy01">
           <operations>
-            <op id="op-umdummy01-start" interval="0" name="start" timeout="60s" on-fail="restart" requires="fencing"/>
+            <op id="op-umdummy01-start" interval="0" name="start" timeout="60s" on-fail="restart"/>
             <op id="op-umdummy01-monitor" interval="10" name="monitor" timeout="60s" on-fail="ignore"/>
             <op id="op-umdummy01-stop" interval="0" name="stop" timeout="60s" on-fail="stop"/>
           </operations>
         </primitive>
         <primitive class="ocf" type="Dummy" provider="pacemaker" id="UmDummy02">
           <operations>
-            <op id="op-umdummy02-start" interval="0" name="start" timeout="60s" on-fail="standby" requires="fencing"/>
+            <op id="op-umdummy02-start" interval="0" name="start" timeout="60s" on-fail="standby"/>
             <op id="op-umdummy02-monitor" interval="10" name="monitor" timeout="60s" on-fail="standby"/>
             <op id="op-umdummy02-stop" interval="0" name="stop" timeout="60s" on-fail="block"/>
           </operations>

--- a/pengine/test10/coloc-slave-anti.xml
+++ b/pengine/test10/coloc-slave-anti.xml
@@ -46,10 +46,12 @@
             <nvpair id="nvpair.id22109" name="multiplier" value="100"/>
           </instance_attributes>
           <operations>
-            <op name="monitor" interval="10s" id="pingd-1-monitor" timeout="5s" requires="nothing"/>
-            <op name="start" interval="0" id="pingd-1-start" timeout="10s" requires="nothing"/>
+            <op name="monitor" interval="10s" id="pingd-1-monitor" timeout="5s"/>
+            <op name="start" interval="0" id="pingd-1-start" timeout="10s"/>
           </operations>
-          <meta_attributes id="primitive-pingd-1.meta"/>
+          <meta_attributes id="pingd-1-meta_attributes-requires">
+            <nvpair id="pingd-1-nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-pingd-clone.meta"/>
       </clone>
@@ -134,12 +136,13 @@
           <nvpair id="nvpair.id22637" name="passwd" value="qwe123"/>
         </instance_attributes>
         <operations>
-          <op name="monitor" interval="60s" id="pollux-fencing-monitor" timeout="10s" requires="nothing"/>
-          <op name="start" interval="0" id="pollux-fencing-start" timeout="10s" requires="nothing"/>
-          <op name="stop" interval="0" id="pollux-fencing-stop" timeout="10s" requires="nothing"/>
+          <op name="monitor" interval="60s" id="pollux-fencing-monitor" timeout="10s"/>
+          <op name="start" interval="0" id="pollux-fencing-start" timeout="10s"/>
+          <op name="stop" interval="0" id="pollux-fencing-stop" timeout="10s"/>
         </operations>
         <meta_attributes id="primitive-pollux-fencing.meta">
           <nvpair id="resource_stickiness.meta.auto-226" name="resource-stickiness" value="INFINITY"/>
+          <nvpair id="pollux-fencing-nvpair-requires" name="requires" value="nothing"/>
         </meta_attributes>
       </primitive>
       <primitive id="sirius-fencing" class="stonith" type="external/ipmi-soft">
@@ -150,12 +153,13 @@
           <nvpair id="nvpair.id22732" name="passwd" value="qwe123"/>
         </instance_attributes>
         <operations>
-          <op name="monitor" interval="60s" id="sirius-fencing-monitor" timeout="10s" requires="nothing"/>
-          <op name="start" interval="0" id="sirius-fencing-start" timeout="10s" requires="nothing"/>
-          <op name="stop" interval="0" id="sirius-fencing-stop" timeout="10s" requires="nothing"/>
+          <op name="monitor" interval="60s" id="sirius-fencing-monitor" timeout="10s"/>
+          <op name="start" interval="0" id="sirius-fencing-start" timeout="10s"/>
+          <op name="stop" interval="0" id="sirius-fencing-stop" timeout="10s"/>
         </operations>
         <meta_attributes id="primitive-sirius-fencing.meta">
           <nvpair id="resource_stickiness.meta.auto-252" name="resource-stickiness" value="INFINITY"/>
+          <nvpair id="sirius-fencing-nvpair-requires" name="requires" value="nothing"/>
         </meta_attributes>
       </primitive>
     </resources>

--- a/pengine/test10/colocate-primitive-with-clone.exp
+++ b/pengine/test10/colocate-primitive-with-clone.exp
@@ -61,7 +61,7 @@
     <action_set>
       <rsc_op id="39" operation="start" operation_key="UmIPaddr_start_0" on_node="srv04" on_node_uuid="srv04">
         <primitive id="UmIPaddr" class="ocf" provider="heartbeat" type="Dummy"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_fail="restart" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="srv04" CRM_meta_requires="fencing" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_name="start" CRM_meta_on_fail="restart" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="srv04" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -90,7 +90,7 @@
     <action_set>
       <rsc_op id="41" operation="start" operation_key="UmDummy01_start_0" on_node="srv04" on_node_uuid="srv04">
         <primitive id="UmDummy01" class="ocf" provider="heartbeat" type="Dummy"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_fail="restart" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="srv04" CRM_meta_requires="fencing" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_name="start" CRM_meta_on_fail="restart" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="srv04" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -119,7 +119,7 @@
     <action_set>
       <rsc_op id="43" operation="start" operation_key="UmDummy02_start_0" on_node="srv04" on_node_uuid="srv04">
         <primitive id="UmDummy02" class="ocf" provider="heartbeat" type="Dummy"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_fail="standby" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="srv04" CRM_meta_requires="fencing" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_name="start" CRM_meta_on_fail="standby" CRM_meta_on_node="srv04" CRM_meta_on_node_uuid="srv04" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/colocate-primitive-with-clone.xml
+++ b/pengine/test10/colocate-primitive-with-clone.xml
@@ -33,21 +33,21 @@
         </primitive>
         <primitive class="ocf" type="Dummy" provider="heartbeat" id="UmIPaddr">
           <operations>
-            <op id="op-umIPaddr-start" interval="0" name="start" timeout="60s" on-fail="restart" requires="fencing"/>
+            <op id="op-umIPaddr-start" interval="0" name="start" timeout="60s" on-fail="restart"/>
             <op id="op-umIPaddr-monitor" interval="10" name="monitor" timeout="60s" on-fail="restart"/>
             <op id="op-umIPaddr-stop" interval="0" name="stop" timeout="60s" on-fail="block"/>
           </operations>
         </primitive>
         <primitive class="ocf" type="Dummy" provider="heartbeat" id="UmDummy01">
           <operations>
-            <op id="op-umdummy01-start" interval="0" name="start" timeout="60s" on-fail="restart" requires="fencing"/>
+            <op id="op-umdummy01-start" interval="0" name="start" timeout="60s" on-fail="restart"/>
             <op id="op-umdummy01-monitor" interval="10" name="monitor" timeout="60s" on-fail="ignore"/>
             <op id="op-umdummy01-stop" interval="0" name="stop" timeout="60s" on-fail="stop"/>
           </operations>
         </primitive>
         <primitive class="ocf" type="Dummy" provider="heartbeat" id="UmDummy02">
           <operations>
-            <op id="op-umdummy02-start" interval="0" name="start" timeout="60s" on-fail="standby" requires="fencing"/>
+            <op id="op-umdummy02-start" interval="0" name="start" timeout="60s" on-fail="standby"/>
             <op id="op-umdummy02-monitor" interval="10" name="monitor" timeout="60s" on-fail="standby"/>
             <op id="op-umdummy02-stop" interval="0" name="stop" timeout="60s" on-fail="block"/>
           </operations>

--- a/pengine/test10/group10.xml
+++ b/pengine/test10/group10.xml
@@ -109,13 +109,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s" requires="nothing"/>
-            <op name="start" interval="0" id="DoFencing-2" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s"/>
+            <op name="start" interval="0" id="DoFencing-2" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22394">
             <nvpair id="nvpair.id22400" name="hostlist" value="c001n08 c001n02 c001n03 c001n01 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-184" name="resource-stickiness" value="1"/>

--- a/pengine/test10/group14.exp
+++ b/pengine/test10/group14.exp
@@ -51,7 +51,7 @@
      <action_set>
       <rsc_op id="33" operation="monitor" operation_key="child_DoFencing:0_monitor_20000" on_node="c001n06" on_node_uuid="169e4673-93fb-4c0a-8082-d3408bae9431">
         <primitive id="child_DoFencing" long-id="child_DoFencing:0" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="6" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n06" CRM_meta_on_node_uuid="169e4673-93fb-4c0a-8082-d3408bae9431" CRM_meta_requires="nothing" CRM_meta_timeout="10000"  hostlist="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 "/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="6" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n06" CRM_meta_on_node_uuid="169e4673-93fb-4c0a-8082-d3408bae9431" CRM_meta_timeout="10000"  hostlist="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 "/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -64,7 +64,7 @@
      <action_set>
       <rsc_op id="32" operation="start" operation_key="child_DoFencing:0_start_0" on_node="c001n06" on_node_uuid="169e4673-93fb-4c0a-8082-d3408bae9431">
         <primitive id="child_DoFencing" long-id="child_DoFencing:0" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="6" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="c001n06" CRM_meta_on_node_uuid="169e4673-93fb-4c0a-8082-d3408bae9431" CRM_meta_requires="nothing" CRM_meta_timeout="10000"  hostlist="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 "/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="6" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="c001n06" CRM_meta_on_node_uuid="169e4673-93fb-4c0a-8082-d3408bae9431" CRM_meta_timeout="10000"  hostlist="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 "/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -77,7 +77,7 @@
      <action_set>
       <rsc_op id="35" operation="monitor" operation_key="child_DoFencing:1_monitor_20000" on_node="c001n07" on_node_uuid="6637ebb5-ab11-4728-b69e-b61222af9a0c">
         <primitive id="child_DoFencing" long-id="child_DoFencing:1" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="6" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n07" CRM_meta_on_node_uuid="6637ebb5-ab11-4728-b69e-b61222af9a0c" CRM_meta_requires="nothing" CRM_meta_timeout="10000"  hostlist="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 "/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="6" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n07" CRM_meta_on_node_uuid="6637ebb5-ab11-4728-b69e-b61222af9a0c" CRM_meta_timeout="10000"  hostlist="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 "/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -90,7 +90,7 @@
      <action_set>
       <rsc_op id="34" operation="start" operation_key="child_DoFencing:1_start_0" on_node="c001n07" on_node_uuid="6637ebb5-ab11-4728-b69e-b61222af9a0c">
         <primitive id="child_DoFencing" long-id="child_DoFencing:1" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="6" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="c001n07" CRM_meta_on_node_uuid="6637ebb5-ab11-4728-b69e-b61222af9a0c" CRM_meta_requires="nothing" CRM_meta_timeout="10000"  hostlist="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 "/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="6" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="c001n07" CRM_meta_on_node_uuid="6637ebb5-ab11-4728-b69e-b61222af9a0c" CRM_meta_timeout="10000"  hostlist="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 "/>
        </rsc_op>
      </action_set>
      <inputs>

--- a/pengine/test10/group14.xml
+++ b/pengine/test10/group14.xml
@@ -152,13 +152,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="20s" id="DoFencing-1" requires="nothing"/>
-            <op name="start" interval="0" id="DoFencing-2" requires="nothing"/>
+            <op name="monitor" interval="20s" id="DoFencing-1"/>
+            <op name="start" interval="0" id="DoFencing-2"/>
           </operations>
           <instance_attributes id="instance_attributes.id22637">
             <nvpair id="nvpair.id22643" name="hostlist" value="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="globally_unique.meta.auto-270" name="globally-unique" value="false"/>

--- a/pengine/test10/inc10.xml
+++ b/pengine/test10/inc10.xml
@@ -35,13 +35,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="null">
           <operations>
-            <op name="monitor" interval="5s" id="op-01" timeout="20s" requires="nothing"/>
-            <op name="start" interval="0" id="op-02" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="op-01" timeout="20s"/>
+            <op name="start" interval="0" id="op-02" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22093">
             <nvpair id="nvpair.id22100" name="hostlist" value="xen-1,xen-2,xen-3,xen-4"/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="globally_unique.meta.auto-67" name="globally-unique" value="false"/>

--- a/pengine/test10/inc12.xml
+++ b/pengine/test10/inc12.xml
@@ -154,13 +154,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="20s" id="DoFencing-1" requires="nothing"/>
-            <op name="start" interval="0" id="DoFencing-2" requires="nothing"/>
+            <op name="monitor" interval="20s" id="DoFencing-1"/>
+            <op name="start" interval="0" id="DoFencing-2"/>
           </operations>
           <instance_attributes id="instance_attributes.id22618">
             <nvpair id="nvpair.id22625" name="hostlist" value="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="globally_unique.meta.auto-250" name="globally-unique" value="false"/>

--- a/pengine/test10/master-4.xml
+++ b/pengine/test10/master-4.xml
@@ -113,13 +113,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s" requires="nothing"/>
-            <op name="start" interval="0" id="DoFencing-2" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s"/>
+            <op name="start" interval="0" id="DoFencing-2" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22439">
             <nvpair id="nvpair.id22445" name="hostlist" value="c001n08 c001n02 c001n03 c001n01 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-195" name="resource-stickiness" value="1"/>

--- a/pengine/test10/master-5.xml
+++ b/pengine/test10/master-5.xml
@@ -113,13 +113,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s" requires="nothing"/>
-            <op name="start" interval="0" id="DoFencing-2" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s"/>
+            <op name="start" interval="0" id="DoFencing-2" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22439">
             <nvpair id="nvpair.id22445" name="hostlist" value="c001n08 c001n02 c001n03 c001n01 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-195" name="resource-stickiness" value="1"/>

--- a/pengine/test10/master-6.xml
+++ b/pengine/test10/master-6.xml
@@ -122,13 +122,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s" requires="nothing"/>
-            <op name="start" interval="0" id="DoFencing-2" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s"/>
+            <op name="start" interval="0" id="DoFencing-2" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22482">
             <nvpair id="nvpair.id22488" name="hostlist" value="c001n08 c001n02 c001n03 c001n01 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-211" name="resource-stickiness" value="1"/>

--- a/pengine/test10/master-7.xml
+++ b/pengine/test10/master-7.xml
@@ -129,13 +129,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s" requires="nothing"/>
-            <op name="start" interval="0" id="DoFencing-2" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s"/>
+            <op name="start" interval="0" id="DoFencing-2" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22536">
             <nvpair id="nvpair.id22542" name="hostlist" value="c001n01 c001n08 c001n02 c001n03 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-230" name="resource-stickiness" value="1"/>

--- a/pengine/test10/master-8.xml
+++ b/pengine/test10/master-8.xml
@@ -129,13 +129,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s" requires="nothing"/>
-            <op name="start" interval="0" id="DoFencing-2" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s"/>
+            <op name="start" interval="0" id="DoFencing-2" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22536">
             <nvpair id="nvpair.id22542" name="hostlist" value="c001n01 c001n08 c001n02 c001n03 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-230" name="resource-stickiness" value="1"/>

--- a/pengine/test10/master-9.xml
+++ b/pengine/test10/master-9.xml
@@ -129,13 +129,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s" requires="nothing"/>
-            <op name="start" interval="0" id="DoFencing-2" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s"/>
+            <op name="start" interval="0" id="DoFencing-2" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22536">
             <nvpair id="nvpair.id22542" name="hostlist" value="sgi2 ibm1 va1 test02 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-230" name="resource-stickiness" value="1"/>

--- a/pengine/test10/master-demote.xml
+++ b/pengine/test10/master-demote.xml
@@ -123,7 +123,7 @@
       <clone id="pingd_clone">
         <primitive id="pingd_node" provider="heartbeat" class="ocf" type="pingd">
           <operations>
-            <op name="monitor" interval="20s" id="pingd_node_monitor" timeout="40s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="pingd_node_monitor" timeout="40s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22546">
             <nvpair id="nvpair.id22552" name="pidfile" value="/var/run/pingd.pid"/>

--- a/pengine/test10/master-depend.xml
+++ b/pengine/test10/master-depend.xml
@@ -77,7 +77,7 @@
       </clone>
       <primitive id="vmnci36" class="ocf" provider="heartbeat" type="vm">
         <operations>
-          <op name="monitor" interval="10s" id="vmnci36_op_1" timeout="60s" requires="nothing"/>
+          <op name="monitor" interval="10s" id="vmnci36_op_1" timeout="60s"/>
           <op name="start" interval="0" id="vmnci36_op_2" timeout="60s" start-delay="0"/>
           <op name="stop" interval="0" id="vmnci36_op_3" timeout="300s"/>
         </operations>
@@ -91,7 +91,7 @@
       </primitive>
       <primitive id="vmnci37" class="ocf" provider="heartbeat" type="vm">
         <operations>
-          <op name="monitor" interval="10s" id="vmnci37_op_1" timeout="60s" requires="nothing"/>
+          <op name="monitor" interval="10s" id="vmnci37_op_1" timeout="60s"/>
           <op name="start" interval="0" id="vmnci37_op_2" timeout="60s" start-delay="0"/>
           <op name="stop" interval="0" id="vmnci37_op_3" timeout="300s"/>
         </operations>
@@ -105,7 +105,7 @@
       </primitive>
       <primitive id="vmnci38" class="ocf" provider="heartbeat" type="vm">
         <operations>
-          <op name="monitor" interval="10s" id="vmnci38_op_1" timeout="60s" requires="nothing"/>
+          <op name="monitor" interval="10s" id="vmnci38_op_1" timeout="60s"/>
           <op name="start" interval="0" id="vmnci38_op_2" timeout="60s" start-delay="0"/>
           <op name="stop" interval="0" id="vmnci38_op_3" timeout="300s"/>
         </operations>
@@ -119,7 +119,7 @@
       </primitive>
       <primitive id="vmnci55" class="ocf" provider="heartbeat" type="vm">
         <operations>
-          <op name="monitor" interval="10s" id="vmnci55_op_1" timeout="60s" requires="nothing"/>
+          <op name="monitor" interval="10s" id="vmnci55_op_1" timeout="60s"/>
           <op name="start" interval="0" id="vmnci55_op_2" timeout="60s" start-delay="0"/>
           <op name="stop" interval="0" id="vmnci55_op_3" timeout="300s"/>
         </operations>

--- a/pengine/test10/novell-251689.xml
+++ b/pengine/test10/novell-251689.xml
@@ -19,13 +19,15 @@
       <clone id="stonithcloneset">
         <primitive id="stonithclone" class="stonith" type="external/ssh">
           <operations>
-            <op name="monitor" interval="5s" id="stonithclone-op-01" timeout="20s" requires="nothing"/>
-            <op name="start" interval="0" id="stonithclone-op-02" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="stonithclone-op-01" timeout="20s"/>
+            <op name="start" interval="0" id="stonithclone-op-02" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22007">
             <nvpair id="nvpair.id22014" name="hostlist" value="node1,node2"/>
           </instance_attributes>
-          <meta_attributes id="primitive-stonithclone.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-stonithcloneset.meta">
           <nvpair id="globally_unique.meta.auto-39" name="globally-unique" value="false"/>
@@ -35,7 +37,7 @@
       <clone id="evmsdcloneset">
         <primitive id="evmsdclone" class="ocf" type="Evmsd" provider="heartbeat">
           <operations>
-            <op name="monitor" interval="5s" id="evmsdclone-op-01" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="evmsdclone-op-01" timeout="20s"/>
           </operations>
           <meta_attributes id="primitive-evmsdclone.meta"/>
         </primitive>
@@ -58,7 +60,7 @@
       <clone id="imagestorecloneset">
         <primitive id="imagestoreclone" class="ocf" type="Filesystem" provider="heartbeat">
           <operations>
-            <op name="monitor" interval="20s" id="imagestoreclone-op-01" timeout="60s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="imagestoreclone-op-01" timeout="60s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22179">
             <nvpair id="nvpair.id22185" name="device" value="/dev/evms/vmsharedclustercontainer/imagestore"/>
@@ -77,7 +79,7 @@
       <clone id="configstorecloneset">
         <primitive id="configstoreclone" class="ocf" type="Filesystem" provider="heartbeat">
           <operations>
-            <op name="monitor" interval="20s" id="configstoreclone-op-01" timeout="60s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="configstoreclone-op-01" timeout="60s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22278">
             <nvpair id="nvpair.id22285" name="device" value="/dev/evms/vmsharedclustercontainer/configstore"/>
@@ -95,7 +97,7 @@
       </clone>
       <primitive id="sles10" class="ocf" type="Xen" provider="heartbeat">
         <operations>
-          <op name="monitor" interval="10s" id="xen-op-01" timeout="60s" requires="nothing"/>
+          <op name="monitor" interval="10s" id="xen-op-01" timeout="60s"/>
           <op name="stop" interval="0" id="xen-op-02" timeout="60s"/>
         </operations>
         <instance_attributes id="instance_attributes.id22350">

--- a/pengine/test10/novell-252693-2.exp
+++ b/pengine/test10/novell-252693-2.exp
@@ -3,7 +3,7 @@
      <action_set>
       <rsc_op id="16" operation="monitor" operation_key="stonithclone:1_monitor_5000" on_node="node1" on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a">
         <primitive id="stonithclone" long-id="stonithclone:1" class="stonith" type="external/ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="node1,node2"/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_timeout="20000"  hostlist="node1,node2"/>
        </rsc_op>
      </action_set>
     <inputs>
@@ -16,7 +16,7 @@
      <action_set>
       <rsc_op id="15" operation="start" operation_key="stonithclone:1_start_0" on_node="node1" on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a">
         <primitive id="stonithclone" long-id="stonithclone:1" class="stonith" type="external/ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="node1,node2"/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_timeout="20000"  hostlist="node1,node2"/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -65,7 +65,7 @@
      <action_set>
       <rsc_op id="24" operation="monitor" operation_key="evmsdclone:1_monitor_5000" on_node="node1" on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a">
         <primitive id="evmsdclone" long-id="evmsdclone:1" class="ocf" provider="heartbeat" type="Evmsd"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_requires="nothing" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_timeout="20000" />
        </rsc_op>
      </action_set>
     <inputs>
@@ -316,7 +316,7 @@
      <action_set>
       <rsc_op id="47" operation="monitor" operation_key="imagestoreclone:1_monitor_20000" on_node="node1" on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a">
         <primitive id="imagestoreclone" long-id="imagestoreclone:1" class="ocf" provider="heartbeat" type="Filesystem"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="true" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_requires="nothing" CRM_meta_timeout="60000"  device="/dev/evms/vmsharedclustercontainer/imagestore" directory="/var/lib/xen/images" fstype="ocfs2"/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="true" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_timeout="60000"  device="/dev/evms/vmsharedclustercontainer/imagestore" directory="/var/lib/xen/images" fstype="ocfs2"/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -482,7 +482,7 @@
      <action_set>
       <rsc_op id="63" operation="monitor" operation_key="configstoreclone:1_monitor_20000" on_node="node1" on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a">
         <primitive id="configstoreclone" long-id="configstoreclone:1" class="ocf" provider="heartbeat" type="Filesystem"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="true" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_requires="nothing" CRM_meta_timeout="60000"  device="/dev/evms/vmsharedclustercontainer/configstore" directory="/etc/xen/vm" fstype="ocfs2"/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="true" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_timeout="60000"  device="/dev/evms/vmsharedclustercontainer/configstore" directory="/etc/xen/vm" fstype="ocfs2"/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -641,7 +641,7 @@
      <action_set>
       <rsc_op id="78" operation="monitor" operation_key="sles10_monitor_10000" on_node="node1" on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a">
         <primitive id="sles10" class="ocf" provider="heartbeat" type="Xen"/>
-        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_requires="nothing" CRM_meta_timeout="60000"  xmfile="/etc/xen/vm/sles10"/>
+        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_timeout="60000"  xmfile="/etc/xen/vm/sles10"/>
        </rsc_op>
      </action_set>
      <inputs>

--- a/pengine/test10/novell-252693-2.xml
+++ b/pengine/test10/novell-252693-2.xml
@@ -19,8 +19,8 @@
       <clone id="stonithcloneset">
         <primitive id="stonithclone" class="stonith" type="external/ssh">
           <operations>
-            <op name="monitor" interval="5s" id="stonithclone-op-01" timeout="20s" requires="nothing"/>
-            <op name="start" interval="0" id="stonithclone-op-02" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="stonithclone-op-01" timeout="20s"/>
+            <op name="start" interval="0" id="stonithclone-op-02" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22008">
             <nvpair id="nvpair.id22014" name="hostlist" value="node1,node2"/>
@@ -30,12 +30,13 @@
         <meta_attributes id="clone-stonithcloneset.meta">
           <nvpair id="globally_unique.meta.auto-39" name="globally-unique" value="false"/>
           <nvpair id="nvpair.meta.auto-45" name="clone-node-max" value="1"/>
+          <nvpair id="nvpair-requires" name="requires" value="nothing"/>
         </meta_attributes>
       </clone>
       <clone id="evmsdcloneset">
         <primitive id="evmsdclone" class="ocf" type="Evmsd" provider="heartbeat">
           <operations>
-            <op name="monitor" interval="5s" id="evmsdclone-op-01" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="evmsdclone-op-01" timeout="20s"/>
           </operations>
           <meta_attributes id="primitive-evmsdclone.meta"/>
         </primitive>
@@ -58,7 +59,7 @@
       <clone id="imagestorecloneset">
         <primitive id="imagestoreclone" class="ocf" type="Filesystem" provider="heartbeat">
           <operations>
-            <op name="monitor" interval="20s" id="imagestoreclone-op-01" timeout="60s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="imagestoreclone-op-01" timeout="60s"/>
             <op name="stop" interval="0" id="imagestoreclone-op-02" timeout="600s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22188">
@@ -78,7 +79,7 @@
       <clone id="configstorecloneset">
         <primitive id="configstoreclone" class="ocf" type="Filesystem" provider="heartbeat">
           <operations>
-            <op name="monitor" interval="20s" id="configstoreclone-op-01" timeout="60s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="configstoreclone-op-01" timeout="60s"/>
             <op name="stop" interval="0" id="configstoreclone-op-02" timeout="60s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22296">
@@ -97,7 +98,7 @@
       </clone>
       <primitive id="sles10" class="ocf" type="Xen" provider="heartbeat">
         <operations>
-          <op name="monitor" interval="10s" id="xen-op-01" timeout="60s" requires="nothing"/>
+          <op name="monitor" interval="10s" id="xen-op-01" timeout="60s"/>
           <op name="stop" interval="0" id="xen-op-02" timeout="60s"/>
         </operations>
         <instance_attributes id="instance_attributes.id22368">

--- a/pengine/test10/novell-252693-3.exp
+++ b/pengine/test10/novell-252693-3.exp
@@ -3,7 +3,7 @@
      <action_set>
       <rsc_op id="17" operation="monitor" operation_key="stonithclone:1_monitor_5000" on_node="node1" on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a">
         <primitive id="stonithclone" long-id="stonithclone:1" class="stonith" type="external/ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="node1,node2"/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_timeout="20000"  hostlist="node1,node2"/>
        </rsc_op>
      </action_set>
     <inputs>
@@ -16,7 +16,7 @@
      <action_set>
       <rsc_op id="16" operation="start" operation_key="stonithclone:1_start_0" on_node="node1" on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a">
         <primitive id="stonithclone" long-id="stonithclone:1" class="stonith" type="external/ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="node1,node2"/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_timeout="20000"  hostlist="node1,node2"/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -65,7 +65,7 @@
      <action_set>
       <rsc_op id="25" operation="monitor" operation_key="evmsdclone:1_monitor_5000" on_node="node1" on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a">
         <primitive id="evmsdclone" long-id="evmsdclone:1" class="ocf" provider="heartbeat" type="Evmsd"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_requires="nothing" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_timeout="20000" />
        </rsc_op>
      </action_set>
     <inputs>
@@ -303,7 +303,7 @@
      <action_set>
       <rsc_op id="46" operation="monitor" operation_key="imagestoreclone:0_monitor_20000" on_node="node1" on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a">
         <primitive id="imagestoreclone" long-id="imagestoreclone:0" class="ocf" provider="heartbeat" type="Filesystem"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="true" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_requires="nothing" CRM_meta_timeout="60000"  device="/dev/evms/vmsharedclustercontainer/imagestore" directory="/var/lib/xen/images" fstype="ocfs2"/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="true" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_timeout="60000"  device="/dev/evms/vmsharedclustercontainer/imagestore" directory="/var/lib/xen/images" fstype="ocfs2"/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -370,7 +370,7 @@
      <action_set>
       <rsc_op id="48" operation="monitor" operation_key="imagestoreclone:1_monitor_20000" on_node="node2" on_node_uuid="2c826922-d092-4862-bedc-de9ae2312117">
         <primitive id="imagestoreclone" long-id="imagestoreclone:1" class="ocf" provider="heartbeat" type="Filesystem"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="true" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="2c826922-d092-4862-bedc-de9ae2312117" CRM_meta_requires="nothing" CRM_meta_timeout="60000"  device="/dev/evms/vmsharedclustercontainer/imagestore" directory="/var/lib/xen/images" fstype="ocfs2"/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="true" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="2c826922-d092-4862-bedc-de9ae2312117" CRM_meta_timeout="60000"  device="/dev/evms/vmsharedclustercontainer/imagestore" directory="/var/lib/xen/images" fstype="ocfs2"/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -611,7 +611,7 @@
      <action_set>
       <rsc_op id="64" operation="monitor" operation_key="configstoreclone:1_monitor_20000" on_node="node1" on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a">
         <primitive id="configstoreclone" long-id="configstoreclone:1" class="ocf" provider="heartbeat" type="Filesystem"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="true" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_requires="nothing" CRM_meta_timeout="60000"  device="/dev/evms/vmsharedclustercontainer/configstore" directory="/etc/xen/vm" fstype="ocfs2"/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="true" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_timeout="60000"  device="/dev/evms/vmsharedclustercontainer/configstore" directory="/etc/xen/vm" fstype="ocfs2"/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -770,7 +770,7 @@
     <action_set>
       <rsc_op id="79" operation="monitor" operation_key="sles10_monitor_10000" on_node="node1" on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a">
         <primitive id="sles10" class="ocf" provider="heartbeat" type="Xen"/>
-        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_requires="nothing" CRM_meta_timeout="60000"  xmfile="/etc/xen/vm/sles10"/>
+        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="85d23ecf-8b5b-4cd3-9344-e1ff5d869d6a" CRM_meta_timeout="60000"  xmfile="/etc/xen/vm/sles10"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/novell-252693-3.xml
+++ b/pengine/test10/novell-252693-3.xml
@@ -19,8 +19,8 @@
       <clone id="stonithcloneset">
         <primitive id="stonithclone" class="stonith" type="external/ssh">
           <operations>
-            <op name="monitor" interval="5s" id="stonithclone-op-01" timeout="20s" requires="nothing"/>
-            <op name="start" interval="0" id="stonithclone-op-02" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="stonithclone-op-01" timeout="20s"/>
+            <op name="start" interval="0" id="stonithclone-op-02" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22008">
             <nvpair id="nvpair.id22014" name="hostlist" value="node1,node2"/>
@@ -30,12 +30,13 @@
         <meta_attributes id="clone-stonithcloneset.meta">
           <nvpair id="globally_unique.meta.auto-39" name="globally-unique" value="false"/>
           <nvpair id="nvpair.meta.auto-45" name="clone-node-max" value="1"/>
+          <nvpair id="nvpair-requires" name="requires" value="nothing"/>
         </meta_attributes>
       </clone>
       <clone id="evmsdcloneset">
         <primitive id="evmsdclone" class="ocf" type="Evmsd" provider="heartbeat">
           <operations>
-            <op name="monitor" interval="5s" id="evmsdclone-op-01" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="evmsdclone-op-01" timeout="20s"/>
           </operations>
           <meta_attributes id="primitive-evmsdclone.meta"/>
         </primitive>
@@ -58,7 +59,7 @@
       <clone id="imagestorecloneset">
         <primitive id="imagestoreclone" class="ocf" type="Filesystem" provider="heartbeat">
           <operations>
-            <op name="monitor" interval="20s" id="imagestoreclone-op-01" timeout="60s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="imagestoreclone-op-01" timeout="60s"/>
             <op name="stop" interval="0" id="imagestoreclone-op-02" timeout="600s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22197">
@@ -79,7 +80,7 @@
       <clone id="configstorecloneset">
         <primitive id="configstoreclone" class="ocf" type="Filesystem" provider="heartbeat">
           <operations>
-            <op name="monitor" interval="20s" id="configstoreclone-op-01" timeout="60s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="configstoreclone-op-01" timeout="60s"/>
             <op name="stop" interval="0" id="configstoreclone-op-02" timeout="60s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22305">
@@ -98,7 +99,7 @@
       </clone>
       <primitive id="sles10" class="ocf" type="Xen" provider="heartbeat">
         <operations>
-          <op name="monitor" interval="10s" id="xen-op-01" timeout="60s" requires="nothing"/>
+          <op name="monitor" interval="10s" id="xen-op-01" timeout="60s"/>
           <op name="stop" interval="0" id="xen-op-02" timeout="60s"/>
         </operations>
         <instance_attributes id="instance_attributes.id22377">

--- a/pengine/test10/novell-252693.exp
+++ b/pengine/test10/novell-252693.exp
@@ -512,7 +512,7 @@
      <action_set>
       <rsc_op id="72" operation="monitor" operation_key="sles10_monitor_10000" on_node="node2" on_node_uuid="997c3f45-7e3f-4c70-8d9a-623ba1678a6e">
         <primitive id="sles10" class="ocf" provider="heartbeat" type="Xen"/>
-        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="997c3f45-7e3f-4c70-8d9a-623ba1678a6e" CRM_meta_requires="nothing" CRM_meta_timeout="60000"  xmfile="/etc/xen/vm/sles10"/>
+        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="997c3f45-7e3f-4c70-8d9a-623ba1678a6e" CRM_meta_timeout="60000"  xmfile="/etc/xen/vm/sles10"/>
        </rsc_op>
      </action_set>
      <inputs>

--- a/pengine/test10/novell-252693.xml
+++ b/pengine/test10/novell-252693.xml
@@ -19,8 +19,8 @@
       <clone id="stonithcloneset">
         <primitive id="stonithclone" class="stonith" type="external/ssh">
           <operations>
-            <op name="monitor" interval="5s" id="stonithclone-op-01" timeout="20s" requires="nothing"/>
-            <op name="start" interval="0" id="stonithclone-op-02" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="stonithclone-op-01" timeout="20s"/>
+            <op name="start" interval="0" id="stonithclone-op-02" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22007">
             <nvpair id="nvpair.id22014" name="hostlist" value="node1,node2"/>
@@ -30,12 +30,13 @@
         <meta_attributes id="clone-stonithcloneset.meta">
           <nvpair id="globally_unique.meta.auto-39" name="globally-unique" value="false"/>
           <nvpair id="nvpair.meta.auto-45" name="clone-node-max" value="1"/>
+          <nvpair id="nvpair-requires" name="requires" value="nothing"/>
         </meta_attributes>
       </clone>
       <clone id="evmsdcloneset">
         <primitive id="evmsdclone" class="ocf" type="Evmsd" provider="heartbeat">
           <operations>
-            <op name="monitor" interval="5s" id="evmsdclone-op-01" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="evmsdclone-op-01" timeout="20s"/>
           </operations>
           <meta_attributes id="primitive-evmsdclone.meta"/>
         </primitive>
@@ -58,7 +59,7 @@
       <clone id="imagestorecloneset">
         <primitive id="imagestoreclone" class="ocf" type="Filesystem" provider="heartbeat">
           <operations>
-            <op name="monitor" interval="20s" id="imagestoreclone-op-01" timeout="60s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="imagestoreclone-op-01" timeout="60s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22179">
             <nvpair id="nvpair.id22185" name="device" value="/dev/evms/vmsharedclustercontainer/imagestore"/>
@@ -77,7 +78,7 @@
       <clone id="configstorecloneset">
         <primitive id="configstoreclone" class="ocf" type="Filesystem" provider="heartbeat">
           <operations>
-            <op name="monitor" interval="20s" id="configstoreclone-op-01" timeout="60s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="configstoreclone-op-01" timeout="60s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22278">
             <nvpair id="nvpair.id22285" name="device" value="/dev/evms/vmsharedclustercontainer/configstore"/>
@@ -95,7 +96,7 @@
       </clone>
       <primitive id="sles10" class="ocf" type="Xen" provider="heartbeat">
         <operations>
-          <op name="monitor" interval="10s" id="xen-op-01" timeout="60s" requires="nothing"/>
+          <op name="monitor" interval="10s" id="xen-op-01" timeout="60s"/>
           <op name="stop" interval="0" id="xen-op-02" timeout="60s"/>
           <op name="migrate" interval="0" id="xen-op-03" timeout="120s"/>
         </operations>

--- a/pengine/test10/order-sets.exp
+++ b/pengine/test10/order-sets.exp
@@ -3,7 +3,7 @@
     <action_set>
       <rsc_op id="8" operation="monitor" operation_key="world1_monitor_10000" on_node="ubuntu_1" on_node_uuid="ubuntu_1">
         <primitive id="world1" class="ocf" provider="bbnd" type="world1test"/>
-        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_fail="restart" CRM_meta_on_node="ubuntu_1" CRM_meta_on_node_uuid="ubuntu_1" CRM_meta_requires="nothing" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_fail="restart" CRM_meta_on_node="ubuntu_1" CRM_meta_on_node_uuid="ubuntu_1" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -42,7 +42,7 @@
     <action_set>
       <rsc_op id="11" operation="monitor" operation_key="world2_monitor_10000" on_node="ubuntu_1" on_node_uuid="ubuntu_1">
         <primitive id="world2" class="ocf" provider="bbnd" type="world2test"/>
-        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_fail="restart" CRM_meta_on_node="ubuntu_1" CRM_meta_on_node_uuid="ubuntu_1" CRM_meta_requires="nothing" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_fail="restart" CRM_meta_on_node="ubuntu_1" CRM_meta_on_node_uuid="ubuntu_1" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -84,7 +84,7 @@
     <action_set>
       <rsc_op id="14" operation="monitor" operation_key="world3_monitor_10000" on_node="ubuntu_1" on_node_uuid="ubuntu_1">
         <primitive id="world3" class="ocf" provider="bbnd" type="world3test"/>
-        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_fail="restart" CRM_meta_on_node="ubuntu_1" CRM_meta_on_node_uuid="ubuntu_1" CRM_meta_requires="nothing" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_fail="restart" CRM_meta_on_node="ubuntu_1" CRM_meta_on_node_uuid="ubuntu_1" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -126,7 +126,7 @@
     <action_set>
       <rsc_op id="17" operation="monitor" operation_key="world4_monitor_10000" on_node="ubuntu_1" on_node_uuid="ubuntu_1">
         <primitive id="world4" class="ocf" provider="bbnd" type="world4test"/>
-        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_fail="restart" CRM_meta_on_node="ubuntu_1" CRM_meta_on_node_uuid="ubuntu_1" CRM_meta_requires="nothing" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_fail="restart" CRM_meta_on_node="ubuntu_1" CRM_meta_on_node_uuid="ubuntu_1" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/order-sets.xml
+++ b/pengine/test10/order-sets.xml
@@ -28,22 +28,22 @@
     <resources>
       <primitive id="world1" class="ocf" type="world1test" provider="bbnd">
         <operations>
-          <op id="world1check" name="monitor" interval="10s" requires="nothing" on-fail="restart"/>
+          <op id="world1check" name="monitor" interval="10s" on-fail="restart"/>
         </operations>
       </primitive>
       <primitive id="world2" class="ocf" type="world2test" provider="bbnd">
         <operations>
-          <op id="world2check" name="monitor" interval="10s" requires="nothing" on-fail="restart"/>
+          <op id="world2check" name="monitor" interval="10s" on-fail="restart"/>
         </operations>
       </primitive>
       <primitive id="world3" class="ocf" type="world3test" provider="bbnd">
         <operations>
-          <op id="world3check" name="monitor" interval="10s" requires="nothing" on-fail="restart"/>
+          <op id="world3check" name="monitor" interval="10s" on-fail="restart"/>
         </operations>
       </primitive>
       <primitive id="world4" class="ocf" type="world4test" provider="bbnd">
         <operations>
-          <op id="world4check" name="monitor" interval="10s" requires="nothing" on-fail="restart"/>
+          <op id="world4check" name="monitor" interval="10s" on-fail="restart"/>
         </operations>
       </primitive>
     </resources>

--- a/pengine/test10/probe-0.xml
+++ b/pengine/test10/probe-0.xml
@@ -24,8 +24,8 @@
       <clone id="stonithcloneset">
         <primitive id="stonithclone" class="stonith" type="null">
           <operations>
-            <op name="monitor" interval="5s" id="stonithclone-op-01" timeout="20s" requires="nothing"/>
-            <op name="start" interval="0" id="stonithclone-op-02" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="stonithclone-op-01" timeout="20s"/>
+            <op name="start" interval="0" id="stonithclone-op-02" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22022">
             <nvpair id="nvpair.id22029" name="hostlist" value="32c47,32c48"/>
@@ -35,6 +35,7 @@
         <meta_attributes id="clone-stonithcloneset.meta">
           <nvpair id="globally_unique.meta.auto-43" name="globally-unique" value="false"/>
           <nvpair id="nvpair.meta.auto-49" name="clone-node-max" value="1"/>
+          <nvpair id="nvpair-requires" name="requires" value="nothing"/>
         </meta_attributes>
       </clone>
       <clone id="imagestorecloneset">

--- a/pengine/test10/probe-2.exp
+++ b/pengine/test10/probe-2.exp
@@ -1018,7 +1018,7 @@
     <action_set>
       <rsc_op id="169" operation="monitor" operation_key="stonith_rackpdu:0_monitor_5000" on_node="wc01" on_node_uuid="31de4ab3-2d05-476e-8f9a-627ad6cd94ca">
         <primitive id="stonith_rackpdu:0" class="stonith" type="external/rackpdu"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="wc01" CRM_meta_on_node_uuid="31de4ab3-2d05-476e-8f9a-627ad6cd94ca" CRM_meta_requires="nothing" CRM_meta_timeout="20000" community="wc"  hostlist="wc01 wc02" pduip="pdu02.r02.ipax.at"/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="2" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="wc01" CRM_meta_on_node_uuid="31de4ab3-2d05-476e-8f9a-627ad6cd94ca" CRM_meta_timeout="20000" community="wc"  hostlist="wc01 wc02" pduip="pdu02.r02.ipax.at"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/probe-2.summary
+++ b/pengine/test10/probe-2.summary
@@ -41,7 +41,7 @@ Transition Summary:
  * Stop    mysql-proxy:1	(wc02)  	due to node availability
  * Stop    fs_www:1	(wc02)  	due to node availability
  * Stop    apache2:1	(wc02)  	due to node availability
- * Restart    stonith_rackpdu:0     (                 wc01 )   due to resource definition change
+ * Restart    stonith_rackpdu:0     (                 wc01 )  
  * Stop    stonith_rackpdu:1	(wc02)  	due to node availability
 
 Executing cluster transition:

--- a/pengine/test10/probe-2.xml
+++ b/pengine/test10/probe-2.xml
@@ -249,9 +249,12 @@
         </meta_attributes>
         <primitive id="stonith_rackpdu" class="stonith" type="external/rackpdu">
           <operations>
-            <op id="stonith_rackpdu_monitor" name="monitor" interval="5s" timeout="20s" requires="nothing"/>
-            <op id="sontith_rackpdu_start" name="start" interval="20s" requires="nothing"/>
+            <op id="stonith_rackpdu_monitor" name="monitor" interval="5s" timeout="20s"/>
+            <op id="sontith_rackpdu_start" name="start" interval="20s"/>
           </operations>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
           <instance_attributes id="stonith_rackpdu_ia">
             <nvpair id="stonith_rackpdu_ia_hostlist" name="hostlist" value="wc01 wc02"/>
             <nvpair id="stonith_rackpdu_ia_pduip" name="pduip" value="pdu02.r02.ipax.at"/>

--- a/pengine/test10/quorum-4.exp
+++ b/pengine/test10/quorum-4.exp
@@ -16,7 +16,7 @@
      <action_set>
       <rsc_op id="3" operation="start" operation_key="child_DoFencing_start_0" on_node="hadev2" on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3">
         <primitive id="child_DoFencing" class="stonith" type="ssh"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="hadev2" CRM_meta_on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
+        <attributes CRM_meta_name="start" CRM_meta_on_node="hadev2" CRM_meta_on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
        </rsc_op>
      </action_set>
      <inputs>

--- a/pengine/test10/quorum-4.xml
+++ b/pengine/test10/quorum-4.xml
@@ -18,12 +18,14 @@
       <primitive id="child_DoFencing" class="stonith" type="ssh">
         <operations>
           <op name="monitor" interval="5s" id="op.auto-1" timeout="20s"/>
-          <op name="start" interval="0" id="op.auto-2" requires="nothing" timeout="20s"/>
+          <op name="start" interval="0" id="op.auto-2" timeout="20s"/>
         </operations>
         <instance_attributes id="instance_attributes.id21956">
           <nvpair id="nvpair.id21962" name="hostlist" value="hadev1 hadev2 hadev3 "/>
         </instance_attributes>
-        <meta_attributes id="primitive-child_DoFencing.meta"/>
+        <meta_attributes id="meta_attributes-requires">
+          <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+        </meta_attributes>
       </primitive>
     </resources>
     <constraints/>

--- a/pengine/test10/quorum-5.exp
+++ b/pengine/test10/quorum-5.exp
@@ -42,7 +42,7 @@
      <action_set>
       <rsc_op id="4" operation="start" operation_key="child_DoFencing_1_start_0" on_node="hadev2" on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3">
         <primitive id="child_DoFencing_1" class="stonith" type="ssh"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="hadev2" CRM_meta_on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
+        <attributes CRM_meta_name="start" CRM_meta_on_node="hadev2" CRM_meta_on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
        </rsc_op>
      </action_set>
      <inputs>
@@ -80,7 +80,7 @@
      <action_set>
       <rsc_op id="6" operation="start" operation_key="child_DoFencing_2_start_0" on_node="hadev2" on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3">
         <primitive id="child_DoFencing_2" class="stonith" type="ssh"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="hadev2" CRM_meta_on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
+        <attributes CRM_meta_name="start" CRM_meta_on_node="hadev2" CRM_meta_on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
        </rsc_op>
      </action_set>
      <inputs>

--- a/pengine/test10/quorum-5.xml
+++ b/pengine/test10/quorum-5.xml
@@ -18,23 +18,27 @@
       <group id="group1">
         <primitive id="child_DoFencing_1" class="stonith" type="ssh">
           <operations>
-            <op name="start" interval="0" id="op.auto-1" requires="nothing"/>
+            <op name="start" interval="0" id="op.auto-1"/>
             <op name="monitor" interval="5s" id="op.auto-2" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id21958">
             <nvpair id="nvpair.id21965" name="hostlist" value="hadev1 hadev2 hadev3 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing_1.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <primitive id="child_DoFencing_2" class="stonith" type="ssh">
           <operations>
-            <op name="start" interval="0" id="op.auto-4" requires="nothing"/>
+            <op name="start" interval="0" id="op.auto-4"/>
             <op name="monitor" interval="5s" id="op.auto-3" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id21997">
             <nvpair id="nvpair.id22003" name="hostlist" value="hadev1 hadev2 hadev3 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing_2.meta"/>
+          <meta_attributes id="meta_attributes2-requires">
+            <nvpair id="nvpair2-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="group-group1.meta"/>
       </group>

--- a/pengine/test10/quorum-6.exp
+++ b/pengine/test10/quorum-6.exp
@@ -16,7 +16,7 @@
      <action_set>
       <rsc_op id="10" operation="start" operation_key="child_DoFencing:0_start_0" on_node="hadev2" on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3">
         <primitive id="child_DoFencing:0" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="8" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="hadev2" CRM_meta_on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="8" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="hadev2" CRM_meta_on_node_uuid="190b75b6-5585-42d9-8cde-eb6041843ae3" CRM_meta_timeout="20000"  hostlist="hadev1 hadev2 hadev3 "/>
        </rsc_op>
      </action_set>
      <inputs>

--- a/pengine/test10/quorum-6.xml
+++ b/pengine/test10/quorum-6.xml
@@ -19,12 +19,14 @@
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
             <op name="monitor" interval="5s" id="op.auto-1" timeout="20s"/>
-            <op name="start" interval="0" id="op.auto-2" requires="nothing" timeout="20s"/>
+            <op name="start" interval="0" id="op.auto-2" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id21983">
             <nvpair id="nvpair.id21989" name="hostlist" value="hadev1 hadev2 hadev3 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-37" name="clone-max" value="8"/>

--- a/pengine/test10/rec-node-12.exp
+++ b/pengine/test10/rec-node-12.exp
@@ -313,7 +313,7 @@
     <action_set>
       <rsc_op id="40" operation="monitor" operation_key="child_DoFencing:0_monitor_5000" on_node="c001n03" on_node_uuid="5d9a8c11-8684-43ea-91.0.6e221530c193">
         <primitive id="child_DoFencing:0" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n03" CRM_meta_on_node_uuid="5d9a8c11-8684-43ea-91.0.6e221530c193" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n03" CRM_meta_on_node_uuid="5d9a8c11-8684-43ea-91.0.6e221530c193" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -326,7 +326,7 @@
     <action_set>
       <rsc_op id="39" operation="start" operation_key="child_DoFencing:0_start_0" on_node="c001n03" on_node_uuid="5d9a8c11-8684-43ea-91.0.6e221530c193">
         <primitive id="child_DoFencing:0" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="c001n03" CRM_meta_on_node_uuid="5d9a8c11-8684-43ea-91.0.6e221530c193" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
+        <attributes CRM_meta_clone="0" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="c001n03" CRM_meta_on_node_uuid="5d9a8c11-8684-43ea-91.0.6e221530c193" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -366,7 +366,7 @@
     <action_set>
       <rsc_op id="42" operation="monitor" operation_key="child_DoFencing:1_monitor_5000" on_node="c001n01" on_node_uuid="de937e3d-0309-4b5d-b85c-f96edc1ed8e3">
         <primitive id="child_DoFencing:1" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n01" CRM_meta_on_node_uuid="de937e3d-0309-4b5d-b85c-f96edc1ed8e3" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n01" CRM_meta_on_node_uuid="de937e3d-0309-4b5d-b85c-f96edc1ed8e3" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -379,7 +379,7 @@
     <action_set>
       <rsc_op id="41" operation="start" operation_key="child_DoFencing:1_start_0" on_node="c001n01" on_node_uuid="de937e3d-0309-4b5d-b85c-f96edc1ed8e3">
         <primitive id="child_DoFencing:1" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="1" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="c001n01" CRM_meta_on_node_uuid="de937e3d-0309-4b5d-b85c-f96edc1ed8e3" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
+        <attributes CRM_meta_clone="1" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="c001n01" CRM_meta_on_node_uuid="de937e3d-0309-4b5d-b85c-f96edc1ed8e3" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -419,7 +419,7 @@
     <action_set>
       <rsc_op id="44" operation="monitor" operation_key="child_DoFencing:2_monitor_5000" on_node="c001n08" on_node_uuid="6427cb5a-c7a5-4bdf-9892-a04ce56f4e6b">
         <primitive id="child_DoFencing:2" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="2" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n08" CRM_meta_on_node_uuid="6427cb5a-c7a5-4bdf-9892-a04ce56f4e6b" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
+        <attributes CRM_meta_clone="2" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_interval="5000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n08" CRM_meta_on_node_uuid="6427cb5a-c7a5-4bdf-9892-a04ce56f4e6b" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -432,7 +432,7 @@
     <action_set>
       <rsc_op id="43" operation="start" operation_key="child_DoFencing:2_start_0" on_node="c001n08" on_node_uuid="6427cb5a-c7a5-4bdf-9892-a04ce56f4e6b">
         <primitive id="child_DoFencing:2" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="2" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="c001n08" CRM_meta_on_node_uuid="6427cb5a-c7a5-4bdf-9892-a04ce56f4e6b" CRM_meta_requires="nothing" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
+        <attributes CRM_meta_clone="2" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="true" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="c001n08" CRM_meta_on_node_uuid="6427cb5a-c7a5-4bdf-9892-a04ce56f4e6b" CRM_meta_timeout="20000"  hostlist="c001n08 c001n02 c001n03 c001n01 "/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/rec-node-12.xml
+++ b/pengine/test10/rec-node-12.xml
@@ -74,13 +74,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="5s" id="op.auto-6" timeout="20s" requires="nothing"/>
-            <op name="start" interval="0" id="op.auto-7" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="5s" id="op.auto-6" timeout="20s"/>
+            <op name="start" interval="0" id="op.auto-7" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22208">
             <nvpair id="nvpair.id22214" name="hostlist" value="c001n08 c001n02 c001n03 c001n01 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-119" name="clone-max" value="4"/>

--- a/pengine/test10/rec-node-13.xml
+++ b/pengine/test10/rec-node-13.xml
@@ -34,13 +34,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s" requires="nothing"/>
-            <op name="start" interval="0" id="DoFencing-2" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s"/>
+            <op name="start" interval="0" id="DoFencing-2" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22137">
             <nvpair id="nvpair.id22144" name="hostlist" value="c001n05 c001n03 c001n04 c001n02 c001n07 c001n06 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="globally_unique.meta.auto-73" name="globally-unique" value="false"/>

--- a/pengine/test10/rec-node-2.exp
+++ b/pengine/test10/rec-node-2.exp
@@ -28,7 +28,7 @@
     <action_set>
       <rsc_op id="10" operation="start" operation_key="rsc1_start_0" on_node="node2" on_node_uuid="uuid2">
         <primitive id="rsc1" class="ocf" provider="heartbeat" type="apache"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="uuid2" CRM_meta_requires="quorum" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_name="start" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="uuid2" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -53,7 +53,7 @@
     <action_set>
       <rsc_op id="11" operation="start" operation_key="rsc2_start_0" on_node="node2" on_node_uuid="uuid2">
         <primitive id="rsc2" class="ocf" provider="heartbeat" type="apache"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="uuid2" CRM_meta_requires="fencing" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_name="start" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="uuid2" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -104,7 +104,7 @@
     <action_set>
       <rsc_op id="12" operation="start" operation_key="rsc3_start_0" on_node="node2" on_node_uuid="uuid2">
         <primitive id="rsc3" class="ocf" provider="heartbeat" type="apache"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="uuid2" CRM_meta_requires="quorum" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_name="start" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="uuid2" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -189,7 +189,7 @@
     <action_set>
       <rsc_op id="18" operation="start" operation_key="rsc5_start_0" on_node="node2" on_node_uuid="uuid2">
         <primitive id="rsc5" class="ocf" provider="heartbeat" type="apache"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="uuid2" CRM_meta_requires="fencing" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_name="start" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="uuid2" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/rec-node-2.xml
+++ b/pengine/test10/rec-node-2.xml
@@ -15,23 +15,27 @@
       <primitive id="rsc1" class="ocf" provider="heartbeat" type="apache">
         <operations>
           <op name="stop" interval="0" id="stop-1" on-fail="block"/>
-          <op name="start" interval="0" id="start-1" requires="quorum"/>
+          <op name="start" interval="0" id="start-1"/>
         </operations>
-        <meta_attributes id="primitive-rsc1.meta"/>
+        <meta_attributes id="meta_attributes1-requires">
+          <nvpair id="nvpair1-requires" name="requires" value="quorum"/>
+        </meta_attributes>
       </primitive>
       <primitive id="rsc2" class="ocf" provider="heartbeat" type="apache">
         <operations>
           <op name="stop" interval="0" id="stop-2" on-fail="block"/>
-          <op name="start" interval="0" id="start-2" requires="fencing"/>
+          <op name="start" interval="0" id="start-2"/>
         </operations>
         <meta_attributes id="primitive-rsc2.meta"/>
       </primitive>
       <group id="group1">
         <primitive id="rsc3" class="ocf" provider="heartbeat" type="apache">
           <operations>
-            <op name="start" interval="0" id="op.auto-5" requires="quorum"/>
+            <op name="start" interval="0" id="op.auto-5"/>
           </operations>
-          <meta_attributes id="primitive-rsc3.meta"/>
+          <meta_attributes id="meta_attributes2-requires">
+            <nvpair id="nvpair2-requires" name="requires" value="quorum"/>
+          </meta_attributes>
         </primitive>
         <primitive id="rsc4" class="ocf" provider="heartbeat" type="apache">
           <meta_attributes id="primitive-rsc4.meta"/>
@@ -41,7 +45,7 @@
       <group id="group2">
         <primitive id="rsc5" class="ocf" provider="heartbeat" type="apache">
           <operations>
-            <op name="start" interval="0" id="op.auto-6" requires="fencing"/>
+            <op name="start" interval="0" id="op.auto-6"/>
           </operations>
           <meta_attributes id="primitive-rsc5.meta"/>
         </primitive>

--- a/pengine/test10/stonith-0.exp
+++ b/pengine/test10/stonith-0.exp
@@ -361,7 +361,7 @@
     <action_set>
       <rsc_op id="70" operation="monitor" operation_key="child_DoFencing:4_monitor_20000" on_node="c001n08" on_node_uuid="f3dcc75c-12da-4949-b01c-1988f7df5238">
         <primitive id="child_DoFencing" long-id="child_DoFencing:4" class="stonith" type="ssh"/>
-        <attributes CRM_meta_clone="4" CRM_meta_clone_max="7" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n08" CRM_meta_on_node_uuid="f3dcc75c-12da-4949-b01c-1988f7df5238" CRM_meta_requires="nothing" CRM_meta_timeout="40000"  hostlist="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 c001n08 "/>
+        <attributes CRM_meta_clone="4" CRM_meta_clone_max="7" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="20000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="c001n08" CRM_meta_on_node_uuid="f3dcc75c-12da-4949-b01c-1988f7df5238" CRM_meta_timeout="40000"  hostlist="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 c001n08 "/>
       </rsc_op>
     </action_set>
     <inputs/>

--- a/pengine/test10/stonith-0.xml
+++ b/pengine/test10/stonith-0.xml
@@ -167,13 +167,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s" requires="nothing"/>
-            <op name="start" interval="0" id="DoFencing-2" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s"/>
+            <op name="start" interval="0" id="DoFencing-2" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22719">
             <nvpair id="nvpair.id22725" name="hostlist" value="c001n03 c001n02 c001n04 c001n05 c001n06 c001n07 c001n08 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="globally_unique.meta.auto-278" name="globally-unique" value="false"/>

--- a/pengine/test10/stonith-1.exp
+++ b/pengine/test10/stonith-1.exp
@@ -175,7 +175,7 @@
     <action_set>
       <rsc_op id="41" operation="monitor" operation_key="child_DoFencing:2_monitor_60000" on_node="sles-4" on_node_uuid="ea7d39f4-3b94-4cfa-ba7a-952956daabee">
         <primitive id="child_DoFencing" long-id="child_DoFencing:2" class="stonith" type="external/vmware"/>
-        <attributes CRM_meta_clone="2" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="60000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="sles-4" CRM_meta_on_node_uuid="ea7d39f4-3b94-4cfa-ba7a-952956daabee" CRM_meta_requires="nothing" CRM_meta_timeout="300000"  device_host="vmhost"/>
+        <attributes CRM_meta_clone="2" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_interval="60000" CRM_meta_name="monitor" CRM_meta_notify="false" CRM_meta_on_node="sles-4" CRM_meta_on_node_uuid="ea7d39f4-3b94-4cfa-ba7a-952956daabee" CRM_meta_timeout="300000"  device_host="vmhost"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -188,7 +188,7 @@
     <action_set>
       <rsc_op id="40" operation="start" operation_key="child_DoFencing:2_start_0" on_node="sles-4" on_node_uuid="ea7d39f4-3b94-4cfa-ba7a-952956daabee">
         <primitive id="child_DoFencing" long-id="child_DoFencing:2" class="stonith" type="external/vmware"/>
-        <attributes CRM_meta_clone="2" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="sles-4" CRM_meta_on_node_uuid="ea7d39f4-3b94-4cfa-ba7a-952956daabee" CRM_meta_requires="nothing" CRM_meta_timeout="180000"  device_host="vmhost"/>
+        <attributes CRM_meta_clone="2" CRM_meta_clone_max="4" CRM_meta_clone_node_max="1" CRM_meta_globally_unique="false" CRM_meta_name="start" CRM_meta_notify="false" CRM_meta_on_node="sles-4" CRM_meta_on_node_uuid="ea7d39f4-3b94-4cfa-ba7a-952956daabee" CRM_meta_timeout="180000"  device_host="vmhost"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/pengine/test10/stonith-1.xml
+++ b/pengine/test10/stonith-1.xml
@@ -123,14 +123,16 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="external/vmware">
           <operations>
-            <op name="monitor" interval="60s" id="DoFencing-1" requires="nothing" timeout="300s"/>
-            <op name="start" interval="0" id="DoFencing-2" requires="nothing" timeout="180s"/>
+            <op name="monitor" interval="60s" id="DoFencing-1" timeout="300s"/>
+            <op name="start" interval="0" id="DoFencing-2" timeout="180s"/>
             <op name="stop" interval="0" id="DoFencing-3" timeout="180s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22505">
             <nvpair id="nvpair.id22511" name="device_host" value="vmhost"/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="globally_unique.meta.auto-218" name="globally-unique" value="false"/>

--- a/pengine/test10/stonith-2.xml
+++ b/pengine/test10/stonith-2.xml
@@ -147,14 +147,16 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="external/vmware">
           <operations>
-            <op name="monitor" interval="120s" id="DoFencing-1" requires="nothing" timeout="300s"/>
-            <op name="start" interval="0" id="DoFencing-2" requires="nothing" timeout="180s"/>
+            <op name="monitor" interval="120s" id="DoFencing-1" timeout="300s"/>
+            <op name="start" interval="0" id="DoFencing-2" timeout="180s"/>
             <op name="stop" interval="0" id="DoFencing-3" timeout="180s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22574">
             <nvpair id="nvpair.id22581" name="device_host" value="vmhost"/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="globally_unique.meta.auto-268" name="globally-unique" value="false"/>

--- a/pengine/test10/unrunnable-1.xml
+++ b/pengine/test10/unrunnable-1.xml
@@ -108,13 +108,15 @@
       <clone id="DoFencing">
         <primitive id="child_DoFencing" class="stonith" type="ssh">
           <operations>
-            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s" requires="nothing"/>
-            <op name="start" interval="0" id="DoFencing-2" timeout="20s" requires="nothing"/>
+            <op name="monitor" interval="20s" id="DoFencing-1" timeout="40s"/>
+            <op name="start" interval="0" id="DoFencing-2" timeout="20s"/>
           </operations>
           <instance_attributes id="instance_attributes.id22375">
             <nvpair id="nvpair.id22381" name="hostlist" value="c001n08 c001n02 c001n03 c001n01 "/>
           </instance_attributes>
-          <meta_attributes id="primitive-child_DoFencing.meta"/>
+          <meta_attributes id="meta_attributes-requires">
+            <nvpair id="nvpair-requires" name="requires" value="nothing"/>
+          </meta_attributes>
         </primitive>
         <meta_attributes id="clone-DoFencing.meta">
           <nvpair id="nvpair.meta.auto-178" name="clone-max" value="4"/>

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -569,6 +569,7 @@ clear_rsc_failures(crm_ipc_t *crmd_channel, const char *node_name,
 {
     int rc = pcmk_ok;
     const char *failed_value = NULL;
+    const char *failed_id = NULL;
     const char *interval_ms_str = NULL;
     GHashTable *rscs = NULL;
     GHashTableIter iter;
@@ -587,11 +588,14 @@ clear_rsc_failures(crm_ipc_t *crmd_channel, const char *node_name,
     for (xmlNode *xml_op = __xml_first_child(data_set->failed); xml_op != NULL;
          xml_op = __xml_next(xml_op)) {
 
+        failed_id = crm_element_value(xml_op, XML_LRM_ATTR_RSCID);
+        if (failed_id == NULL) {
+            // Malformed history entry, should never happen
+            continue;
+        }
+
         // No resource specified means all resources match
-        failed_value = crm_element_value(xml_op, XML_LRM_ATTR_RSCID);
-        if (rsc_id == NULL) {
-            rsc_id = failed_value;
-        } else if (safe_str_neq(rsc_id, failed_value)) {
+        if (rsc_id && safe_str_neq(rsc_id, failed_id)) {
             continue;
         }
 
@@ -615,13 +619,13 @@ clear_rsc_failures(crm_ipc_t *crmd_channel, const char *node_name,
             }
         }
 
-        g_hash_table_add(rscs, (gpointer) rsc_id);
+        g_hash_table_add(rscs, (gpointer) failed_id);
     }
 
     g_hash_table_iter_init(&iter, rscs);
-    while (g_hash_table_iter_next(&iter, (gpointer *) &rsc_id, NULL)) {
-        crm_debug("Erasing failures of %s on %s", rsc_id, node_name);
-        rc = clear_rsc_history(crmd_channel, node_name, rsc_id, data_set);
+    while (g_hash_table_iter_next(&iter, (gpointer *) &failed_id, NULL)) {
+        crm_debug("Erasing failures of %s on %s", failed_id, node_name);
+        rc = clear_rsc_history(crmd_channel, node_name, failed_id, data_set);
         if (rc != pcmk_ok) {
             return rc;
         }

--- a/tools/regression.validity.exp
+++ b/tools/regression.validity.exp
@@ -74,7 +74,11 @@ element rsc_order: Relax-NG validity error : Element constraints has extra conte
 element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
 element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 (   schemas.c:NNN   )   trace: update_validation:	pacemaker-2.10 validation failed
-Your current configuration pacemaker-1.2 could not validate with any schema in range [pacemaker-1.2, pacemaker-2.10], cannot upgrade to pacemaker-2.0.
+(   schemas.c:NNN   )   debug: update_validation:	Testing 'pacemaker-3.0' validation (14 of X)
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+(   schemas.c:NNN   )   trace: update_validation:	pacemaker-3.0 validation failed
+Your current configuration pacemaker-1.2 could not validate with any schema in range [pacemaker-1.2, pacemaker-3.0], cannot upgrade to pacemaker-3.0.
 =#=#=#= End test: Run crm_simulate with invalid CIB (enum violation) - Required key not available (126) =#=#=#=
 * Passed: crm_simulate   - Run crm_simulate with invalid CIB (enum violation)
 =#=#=#= Begin test: Try to make resulting CIB invalid (unrecognized validate-with) =#=#=#=
@@ -140,7 +144,10 @@ element cib: Relax-NG validity error : Invalid attribute validate-with for eleme
 (   schemas.c:NNN   )   debug: update_validation:	Testing 'pacemaker-2.10' validation (13 of X)
 element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 (   schemas.c:NNN   )   trace: update_validation:	pacemaker-2.10 validation failed
-Your current configuration pacemaker-9999.0 could not validate with any schema in range [unknown, pacemaker-2.10], cannot upgrade to pacemaker-2.0.
+(   schemas.c:NNN   )   debug: update_validation:	Testing 'pacemaker-3.0' validation (14 of X)
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+(   schemas.c:NNN   )   trace: update_validation:	pacemaker-3.0 validation failed
+Your current configuration pacemaker-9999.0 could not validate with any schema in range [unknown, pacemaker-3.0], cannot upgrade to pacemaker-3.0.
 =#=#=#= End test: Run crm_simulate with invalid CIB (unrecognized validate-with) - Required key not available (126) =#=#=#=
 * Passed: crm_simulate   - Run crm_simulate with invalid CIB (unrecognized validate-with)
 =#=#=#= Begin test: Try to make resulting CIB invalid, but possibly recoverable (valid with X.Y+1) =#=#=#=
@@ -200,8 +207,11 @@ element tags: Relax-NG validity error : Element configuration has extra content:
 (   schemas.c:NNN   )   debug: update_validation:	pacemaker-2.9-style configuration is also valid for pacemaker-2.10
 (   schemas.c:NNN   )   debug: update_validation:	Testing 'pacemaker-2.10' validation (13 of X)
 (   schemas.c:NNN   )   debug: update_validation:	Configuration valid for schema: pacemaker-2.10
-(   schemas.c:NNN   )   trace: update_validation:	Stopping at pacemaker-2.10
-(   schemas.c:NNN   )    info: update_validation:	Transformed the configuration from pacemaker-1.2 to pacemaker-2.10
+(   schemas.c:NNN   )   debug: update_validation:	Upgrading pacemaker-2.10-style configuration to pacemaker-3.0 with upgrade-2.10.xsl
+(   schemas.c:NNN   )    info: update_validation:	Transformation upgrade-2.10.xsl successful
+(   schemas.c:NNN   )   debug: update_validation:	Testing 'pacemaker-3.0' validation (14 of X)
+(   schemas.c:NNN   )   trace: update_validation:	Stopping at pacemaker-3.0
+(   schemas.c:NNN   )    info: update_validation:	Transformed the configuration from pacemaker-1.2 to pacemaker-3.0
 error: unpack_resources:	Resource start-up disabled since no STONITH resources have been defined
 error: unpack_resources:	Either configure some or disable STONITH with the stonith-enabled option
 error: unpack_resources:	NOTE: Clusters with shared data need STONITH to ensure data integrity
@@ -299,6 +309,8 @@ element rsc_order: Relax-NG validity error : Invalid attribute first-action for 
 element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
 element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 =#=#=#= Current cib after: Make resulting CIB invalid, and without validate-with attribute =#=#=#=
 <cib epoch="31" num_updates="0" admin_epoch="0" validate-with="none">
   <configuration>
@@ -318,6 +330,8 @@ element rsc_order: Relax-NG validity error : Element constraints has extra conte
 * Passed: cibadmin       - Make resulting CIB invalid, and without validate-with attribute
 =#=#=#= Begin test: Run crm_simulate with invalid CIB, also without validate-with attribute =#=#=#=
 Configuration validation is currently disabled. It is highly encouraged and prevents many common cluster issues.
+bad-1.2.xml:10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+bad-1.2.xml:10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 bad-1.2.xml:10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
 bad-1.2.xml:10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 bad-1.2.xml:10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order

--- a/xml/resources-3.0.rng
+++ b/xml/resources-3.0.rng
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+      <ref name="element-resources"/>
+  </start>
+
+  <define name="element-resources">
+    <element name="resources">
+      <zeroOrMore>
+        <choice>
+          <ref name="element-primitive"/>
+          <ref name="element-template"/>
+          <ref name="element-group"/>
+          <ref name="element-clone"/>
+          <ref name="element-master"/>
+          <ref name="element-bundle"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="element-primitive">
+    <element name="primitive">
+      <interleave>
+        <attribute name="id"><data type="ID"/></attribute>
+        <choice>
+          <group>
+            <ref name="element-resource-class"/>
+            <attribute name="type"><text/></attribute>
+          </group>
+          <attribute name="template"><data type="IDREF"/></attribute>
+        </choice>
+        <optional>
+          <attribute name="description"><text/></attribute>
+        </optional>
+        <ref name="element-resource-extra"/>
+        <ref name="element-operations"/>
+        <zeroOrMore>
+          <element name="utilization">
+            <externalRef href="nvset-2.9.rng"/>
+          </element>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+
+  <define name="element-template">
+    <element name="template">
+      <interleave>
+        <attribute name="id"><data type="ID"/></attribute>
+        <ref name="element-resource-class"/>
+        <attribute name="type"><text/></attribute>
+        <optional>
+          <attribute name="description"><text/></attribute>
+        </optional>
+        <ref name="element-resource-extra"/>
+        <ref name="element-operations"/>
+        <zeroOrMore>
+          <element name="utilization">
+            <externalRef href="nvset-2.9.rng"/>
+          </element>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+
+  <define name="element-bundle">
+    <element name="bundle">
+      <interleave>
+        <attribute name="id"><data type="ID"/></attribute>
+        <optional>
+          <attribute name="description"><text/></attribute>
+        </optional>
+        <ref name="element-resource-extra"/>
+        <choice>
+          <element name="docker">
+            <attribute name="image"><text/></attribute>
+            <optional>
+              <attribute name="replicas"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="replicas-per-host"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="masters"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="run-command"> <text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="network"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="options"><text/></attribute>
+            </optional>
+          </element>
+          <element name="rkt">
+            <attribute name="image"><text/></attribute>
+            <optional>
+              <attribute name="replicas"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="replicas-per-host"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="masters"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="run-command"> <text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="network"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="options"><text/></attribute>
+            </optional>
+          </element>
+        </choice>
+        <optional>
+          <element name="network">
+            <optional>
+              <attribute name="ip-range-start"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="control-port"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="host-interface"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="host-netmask"><data type="integer"/></attribute>
+            </optional>
+            <zeroOrMore>
+              <element name="port-mapping">
+                <attribute name="id"><data type="ID"/></attribute>
+                <choice>
+                  <group>
+                    <attribute name="port"><data type="integer"/></attribute>
+                    <optional>
+                      <attribute name="internal-port"><data type="integer"/></attribute>
+                    </optional>
+                  </group>
+                  <attribute name="range">
+                    <data type="string">
+                      <param name="pattern">([0-9\-]+)</param>
+                    </data>
+                  </attribute>
+                </choice>
+              </element>
+            </zeroOrMore>
+          </element>
+        </optional>
+        <optional>
+          <element name="storage">
+            <zeroOrMore>
+              <element name="storage-mapping">
+                <attribute name="id"><data type="ID"/></attribute>
+                <choice>
+                  <attribute name="source-dir"><text/></attribute>
+                  <attribute name="source-dir-root"><text/></attribute>
+                </choice>
+                <attribute name="target-dir"><text/></attribute>
+                <optional>
+                  <attribute name="options"><text/></attribute>
+                </optional>
+              </element>
+            </zeroOrMore>
+          </element>
+        </optional>
+        <optional>
+          <ref name="element-primitive"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+
+  <define name="element-group">
+    <element name="group">
+      <attribute name="id"><data type="ID"/></attribute>
+      <optional>
+        <attribute name="description"><text/></attribute>
+      </optional>
+      <interleave>
+        <ref name="element-resource-extra"/>
+        <oneOrMore>
+          <ref name="element-primitive"/>
+        </oneOrMore>
+      </interleave>
+    </element>
+  </define>
+
+  <define name="element-clone">
+    <element name="clone">
+      <attribute name="id"><data type="ID"/></attribute>
+      <optional>
+        <attribute name="description"><text/></attribute>
+      </optional>
+      <interleave>
+        <ref name="element-resource-extra"/>
+        <choice>
+          <ref name="element-primitive"/>
+          <ref name="element-group"/>
+        </choice>
+      </interleave>
+    </element>
+  </define>
+
+  <define name="element-master">
+    <element name="master">
+      <attribute name="id"><data type="ID"/></attribute>
+      <optional>
+        <attribute name="description"><text/></attribute>
+      </optional>
+      <interleave>
+        <ref name="element-resource-extra"/>
+        <choice>
+          <ref name="element-primitive"/>
+          <ref name="element-group"/>
+        </choice>
+      </interleave>
+    </element>
+  </define>
+
+  <define name="element-resource-extra">
+      <zeroOrMore>
+        <choice>
+          <element name="meta_attributes">
+            <externalRef href="nvset-2.9.rng"/>
+          </element>
+          <element name="instance_attributes">
+            <externalRef href="nvset-2.9.rng"/>
+          </element>
+        </choice>
+      </zeroOrMore>
+  </define>
+
+  <define name="element-operations">
+    <optional>
+      <element name="operations">
+        <optional>
+          <attribute name="id"><data type="ID"/></attribute>
+        </optional>
+        <optional>
+          <attribute name="id-ref"><data type="IDREF"/></attribute>
+        </optional>
+        <zeroOrMore>
+          <element name="op">
+            <attribute name="id"><data type="ID"/></attribute>
+            <attribute name="name"><text/></attribute>
+            <attribute name="interval"><text/></attribute>
+            <optional>
+              <attribute name="description"><text/></attribute>
+            </optional>
+            <optional>
+              <choice>
+                <attribute name="start-delay"><text/></attribute>
+                <attribute name="interval-origin"><text/></attribute>
+              </choice>
+            </optional>
+            <optional>
+              <attribute name="timeout"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="enabled"><data type="boolean"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="record-pending"><data type="boolean"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="role">
+                <choice>
+                  <value>Stopped</value>
+                  <value>Started</value>
+                  <value>Slave</value>
+                  <value>Master</value>
+                </choice>
+              </attribute>
+            </optional>
+            <optional>
+              <attribute name="requires">
+                <choice>
+                  <value>nothing</value>
+                  <value>quorum</value>
+                  <value>fencing</value>
+                  <value>unfencing</value>
+                </choice>
+              </attribute>
+            </optional>
+            <optional>
+              <attribute name="on-fail">
+                <choice>
+                  <value>ignore</value>
+                  <value>block</value>
+                  <value>stop</value>
+                  <value>restart</value>
+                  <value>standby</value>
+                  <value>fence</value>
+                  <value>restart-container</value>
+                </choice>
+              </attribute>
+            </optional>
+            <ref name="element-resource-extra"/>
+          </element>
+        </zeroOrMore>
+      </element>
+    </optional>
+  </define>
+
+  <define name="element-resource-class">
+    <choice>
+      <group>
+        <attribute name="class"><value>ocf</value></attribute>
+        <attribute name="provider"><text/></attribute>
+      </group>
+      <attribute name="class">
+        <choice>
+          <value>lsb</value>
+          <value>heartbeat</value>
+          <value>stonith</value>
+          <value>upstart</value>
+          <value>service</value>
+          <value>systemd</value>
+          <value>nagios</value>
+        </choice>
+      </attribute>
+    </choice>
+  </define>
+</grammar>

--- a/xml/resources-3.0.rng
+++ b/xml/resources-3.0.rng
@@ -278,16 +278,6 @@
               </attribute>
             </optional>
             <optional>
-              <attribute name="requires">
-                <choice>
-                  <value>nothing</value>
-                  <value>quorum</value>
-                  <value>fencing</value>
-                  <value>unfencing</value>
-                </choice>
-              </attribute>
-            </optional>
-            <optional>
               <attribute name="on-fail">
                 <choice>
                   <value>ignore</value>

--- a/xml/upgrade-2.10.xsl
+++ b/xml/upgrade-2.10.xsl
@@ -1,0 +1,10 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+
+<xsl:template match="@*|*">
+  <xsl:copy>
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:copy>
+</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
with another legacy syntax removal. Note that this removal requires an XSL transform, which is currently a no-op. Clusters using the legacy syntax will not be valid until the XSL is updated later.