### PR TITLE
Fix: crmd: Avoid double-removal of glib event source on stopping

### DIFF
--- a/crmd/pengine.c
+++ b/crmd/pengine.c
@@ -123,7 +123,7 @@ pe_ipc_destroy(gpointer user_data)
     }
 
     clear_bit(fsa_input_register, R_PE_CONNECTED);
-    pe_subsystem_free();
+    pe_subsystem = NULL;
     mainloop_set_trigger(fsa_source);
     return;
 }


### PR DESCRIPTION
ed51cc97c introduced an issue that'd cause reentrancy of
mainloop_del_fd() on stopping crmd, which would complain like:

"crit: GLib: Source ID 22 was not found when attempting to remove it"

```
 #0  0xb7f29cc9 in __kernel_vsyscall ()
 #1  0xb7b538e2 in raise () from /lib/libc.so.6
 #2  0xb7b54fd1 in abort () from /lib/libc.so.6
 #3  0xb7e51a1e in crm_abort (file=0xb7e83c9f "logging.c", function=0xb7e85b00 <__FUNCTION__.21612> "crm_glib_handler", line=73, assert_condition=0x63c6a0 "Source ID 22 was not found when attempting to remove it", do_core=1, do_fork=<optimized out>) at utils.c:689
 #4  0xb7e7257f in crm_glib_handler (log_domain=0xb7d93e8e "GLib", flags=G_LOG_LEVEL_CRITICAL, message=0x63c6a0 "Source ID 22 was not found when attempting to remove it", user_data=0x0) at logging.c:73
 #5  0xb7d5055c in g_logv () from /usr/lib/libglib-2.0.so.0
 #6  0xb7d506a5 in g_log () from /usr/lib/libglib-2.0.so.0
 #7  0xb7d484f6 in g_source_remove () from /usr/lib/libglib-2.0.so.0
 #8  0xb7e6f921 in mainloop_del_fd (client=0x61a110) at mainloop.c:862
 #9  0xb7e6f9b8 in mainloop_del_ipc_client (client=0x61a110) at mainloop.c:797
 #10 0x005069a8 in pe_subsystem_free () at pengine.c:43
 #11 pe_ipc_destroy (user_data=0x0) at pengine.c:126
 #12 0xb7e6dab4 in mainloop_gio_destroy (c=0x61a110) at mainloop.c:748
 #13 0xb7d46088 in ?? () from /usr/lib/libglib-2.0.so.0
 #14 0xb7d46b6a in ?? () from /usr/lib/libglib-2.0.so.0
 #15 0xb7d484cd in g_source_remove () from /usr/lib/libglib-2.0.so.0
 #16 0xb7e6f921 in mainloop_del_fd (client=0x61a110) at mainloop.c:862
 #17 0xb7e6f9b8 in mainloop_del_ipc_client (client=0x61a110) at mainloop.c:797
 #18 0x00506cac in pe_subsystem_free () at pengine.c:43
 #19 do_pe_control (action=2251799813685248, cause=C_FSA_INTERNAL, cur_state=S_STOPPING, current_input= I_STOP, msg_data=0x645600) at pengine.c:211
 #20 0x004f0b66 in do_fsa_action (fsa_data=fsa_data@entry=0x645600, an_action=<optimized out>, function= 0x506ac0 <do_pe_control>) at fsa.c:139
 #21 0x004f2c8c in s_crmd_fsa_actions (fsa_data=0x645600) at fsa.c:405
 #22 0x004f43c7 in s_crmd_fsa (cause=C_FSA_INTERNAL) at fsa.c:233
 #23 0x004fea0b in crm_fsa_trigger (user_data=0x0) at callbacks.c:298
 #24 0xb7e6e7ca in crm_trigger_dispatch (source=0x60c4a0, callback=0x4fe9d0 <crm_fsa_trigger>, userdata=0x60c4a0) at mainloop.c:109
 #25 0xb7d49944 in g_main_context_dispatch () from /usr/lib/libglib-2.0.so.0
 #26 0xb7d49d49 in ?? () from /usr/lib/libglib-2.0.so.0
 #27 0xb7d4a0f9 in g_main_loop_run () from /usr/lib/libglib-2.0.so.0
 #28 0x004efc68 in crmd_init () at main.c:162
 #29 0x004ef937 in main (argc=<optimized out>, argv=<optimized out>) at main.c:121
```