### PR TITLE
Fix: tools: crm_master should always work on node attribute

### DIFF
--- a/tools/crm_master
+++ b/tools/crm_master
@@ -8,6 +8,10 @@ if [ $? != 0 ] ; then echo "crm_master - A convenience wrapper for crm_attribute
 # Note the quotes around `$TEMP': they are essential!
 eval set -- "$TEMP"
 
+# Explicitly set the (usual default) lifetime, so the attribute gets set as a
+# node attribute and not a cluster property.
+options="--lifetime forever"
+
 while true ; do
 	case "$1" in
 	    -N|--node|-U|--uname) options="$options $1 $2"; shift; shift;;


### PR DESCRIPTION
Before ccbdb2a, crm_master would always set --node, thus ensuring crm_attribute
would treat the value as a node attribute. That commit removed that so that
crm_attribute could determine the local node name properly, but that introduced
an issue where the master value would be set as a cluster property instead of a
node attribute if --lifetime (or --node) was not set explicitly.

This fixes it by setting the default value of --lifetime explicitly.