### PR TITLE
Refactor: avoid warning triggering construct with GCC8

### DIFF
--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -2384,7 +2384,8 @@ unescape_newlines(const char *string)
     ret = strdup(string);
     pch = strstr(ret, escaped_newline);
     while (pch != NULL) {
-        strncpy(pch, "\n ", 2);
+        /* 2 chars for 2 chars, null-termination irrelevant */
+        memcpy(pch, "\n ", 2 * sizeof(char));
         pch = strstr(pch, escaped_newline);
     }
 


### PR DESCRIPTION
lrm.c: In function ‘unescape_newlines’:
lrm.c:2387:9: error: ‘strncpy’ output truncated before terminating
                     nul copying 2 bytes from a string of the same
                     length [-Werror=stringop-truncation]
         strncpy(pch, "\n ", 2);
         ^~~~~~~~~~~~~~~~~~~~~~

It was actually purposeful here, so switch to less worrying memcpy
instead (deemed better alternative to stepwise indexed assignments).

Possibly relevant:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81117#c9