### PR TITLE
Improve crmd handling of various failures

### DIFF
--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -1924,7 +1924,7 @@ construct_op(lrm_state_t * lrm_state, xmlNode * rsc_op, const char *rsc_id, cons
 
 #if ENABLE_VERSIONED_ATTRS
     // Resolve any versioned parameters
-    if (safe_str_neq(op->op_type, RSC_METADATA)
+    if (lrm_state && safe_str_neq(op->op_type, RSC_METADATA)
         && safe_str_neq(op->op_type, CRMD_ACTION_DELETE)
         && !is_remote_lrmd_ra(NULL, NULL, rsc_id)) {
 
@@ -1981,7 +1981,11 @@ construct_op(lrm_state_t * lrm_state, xmlNode * rsc_op, const char *rsc_id, cons
         op->params = params;
 
     } else {
-        rsc_history_t *entry = g_hash_table_lookup(lrm_state->resource_history, rsc_id);
+        rsc_history_t *entry = NULL;
+
+        if (lrm_state) {
+            entry = g_hash_table_lookup(lrm_state->resource_history, rsc_id);
+        }
 
         /* If we do not have stop parameters cached, use
          * whatever we are given */

--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -1234,49 +1234,77 @@ cancel_op_key(lrm_state_t * lrm_state, lrmd_rsc_info_t * rsc, const char *key, g
     return data.done;
 }
 
-static lrmd_rsc_info_t *
-get_lrm_resource(lrm_state_t * lrm_state, xmlNode * resource, xmlNode * op_msg, gboolean do_create)
+/*!
+ * \internal
+ * \brief Retrieve resource information from LRM
+ *
+ * \param[in]  lrm_state LRM connection to use
+ * \param[in]  rsc_xml   XML containing resource configuration
+ * \param[in]  do_create If true, register resource with LRM if not already
+ * \param[out] rsc_info  Where to store resource information obtained from LRM
+ *
+ * \retval pcmk_ok   Success (and rsc_info holds newly allocated result)
+ * \retval -EINVAL   Required information is missing from arguments
+ * \retval -ENOTCONN No active connection to LRM
+ * \retval -ENODEV   Resource not found
+ * \retval -errno    Error communicating with lrmd when registering resource
+ *
+ * \note Caller is responsible for freeing result on success.
+ */
+static int
+get_lrm_resource(lrm_state_t *lrm_state, xmlNode *rsc_xml, gboolean do_create,
+                 lrmd_rsc_info_t **rsc_info)
 {
-    lrmd_rsc_info_t *rsc = NULL;
-    const char *id = ID(resource);
-    const char *type = crm_element_value(resource, XML_ATTR_TYPE);
-    const char *class = crm_element_value(resource, XML_AGENT_ATTR_CLASS);
-    const char *provider = crm_element_value(resource, XML_AGENT_ATTR_PROVIDER);
-    const char *long_id = crm_element_value(resource, XML_ATTR_ID_LONG);
+    const char *id = ID(rsc_xml);
 
-    crm_trace("Retrieving %s from the LRM.", id);
-    CRM_CHECK(id != NULL, return NULL);
+    CRM_CHECK(lrm_state && rsc_xml && rsc_info, return -EINVAL);
+    CRM_CHECK(id, return -EINVAL);
 
-    rsc = lrm_state_get_rsc_info(lrm_state, id, 0);
-
-    if (!rsc && long_id) {
-        rsc = lrm_state_get_rsc_info(lrm_state, long_id, 0);
+    if (lrm_state_is_connected(lrm_state) == FALSE) {
+        return -ENOTCONN;
     }
 
-    if (!rsc && do_create) {
-        CRM_CHECK(class != NULL, return NULL);
-        CRM_CHECK(type != NULL, return NULL);
+    crm_trace("Retrieving resource information for %s from the LRM", id);
+    *rsc_info = lrm_state_get_rsc_info(lrm_state, id, 0);
 
-        crm_trace("Adding rsc %s before operation", id);
+    // If resource isn't known by ID, try clone name, if provided
+    if (!*rsc_info) {
+        const char *long_id = crm_element_value(rsc_xml, XML_ATTR_ID_LONG);
 
-        lrm_state_register_rsc(lrm_state, id, class, provider, type, lrmd_opt_drop_recurring);
-
-        rsc = lrm_state_get_rsc_info(lrm_state, id, 0);
-
-        if (!rsc) {
-            fsa_data_t *msg_data = NULL;
-
-            crm_err("Could not add resource %s to LRM %s", id, lrm_state->node_name);
-            /* only register this as a internal error if this involves the local
-             * lrmd. Otherwise we're likely dealing with an unresponsive remote-node
-             * which is not a FSA failure. */
-            if (lrm_state_is_local(lrm_state) == TRUE) {
-                register_fsa_error(C_FSA_INTERNAL, I_FAIL, NULL);
-            }
+        if (long_id) {
+            *rsc_info = lrm_state_get_rsc_info(lrm_state, long_id, 0);
         }
     }
 
-    return rsc;
+    if ((*rsc_info == NULL) && do_create) {
+        const char *class = crm_element_value(rsc_xml, XML_AGENT_ATTR_CLASS);
+        const char *provider = crm_element_value(rsc_xml, XML_AGENT_ATTR_PROVIDER);
+        const char *type = crm_element_value(rsc_xml, XML_ATTR_TYPE);
+        int rc;
+
+        crm_trace("Registering resource %s with LRM", id);
+        rc = lrm_state_register_rsc(lrm_state, id, class, provider, type,
+                                    lrmd_opt_drop_recurring);
+        if (rc != pcmk_ok) {
+            fsa_data_t *msg_data = NULL;
+
+            crm_err("Could not register resource %s with LRM on %s: %s "
+                    CRM_XS " rc=%d",
+                    id, lrm_state->node_name, pcmk_strerror(rc), rc);
+
+            /* Register this as an internal error if this involves the local
+             * lrmd. Otherwise, we're likely dealing with an unresponsive remote
+             * node, which is not an FSA failure.
+             */
+            if (lrm_state_is_local(lrm_state) == TRUE) {
+                register_fsa_error(C_FSA_INTERNAL, I_FAIL, NULL);
+            }
+            return rc;
+        }
+
+        *rsc_info = lrm_state_get_rsc_info(lrm_state, id, 0);
+    }
+    return *rsc_info? pcmk_ok : -ENODEV;
 }
 
 static void
@@ -1503,13 +1531,13 @@ fail_lrm_resource(xmlNode *xml, lrm_state_t *lrm_state, const char *user_name,
     }
 #endif
 
-    rsc = get_lrm_resource(lrm_state, xml_rsc, xml, TRUE);
-    if (rsc) {
+    if (get_lrm_resource(lrm_state, xml_rsc, TRUE, &rsc) == pcmk_ok) {
         crm_info("Failing resource %s...", rsc->id);
         process_lrm_event(lrm_state, op, NULL);
         op->op_status = PCMK_LRM_OP_DONE;
         op->rc = PCMK_OCF_OK;
         lrmd_free_rsc_info(rsc);
+
     } else {
         crm_info("Cannot find/create resource in order to fail it...");
         crm_log_xml_warn(xml, "bad input");
@@ -1780,24 +1808,27 @@ do_lrm_invoke(long long action,
         lrmd_rsc_info_t *rsc = NULL;
         xmlNode *xml_rsc = find_xml_node(input->xml, XML_CIB_TAG_RESOURCE, TRUE);
         gboolean create_rsc = safe_str_neq(operation, CRMD_ACTION_DELETE);
+        int rc;
 
-        CRM_CHECK(xml_rsc != NULL, return);
+        // We can't return anything meaningful without a resource ID
+        CRM_CHECK(xml_rsc && ID(xml_rsc), return);
 
-        if (lrm_state_is_connected(lrm_state) == FALSE) {
-            synthesize_lrmd_failure(lrm_state, input->xml, PCMK_OCF_CONNECTION_DIED);
+        rc = get_lrm_resource(lrm_state, xml_rsc, create_rsc, &rsc);
+        if (rc == -ENOTCONN) {
+            synthesize_lrmd_failure(lrm_state, input->xml,
+                                    PCMK_OCF_CONNECTION_DIED);
             return;
-        }
 
-        rsc = get_lrm_resource(lrm_state, xml_rsc, input->xml, create_rsc);
-        if ((rsc == NULL) && create_rsc) {
+        } else if ((rc < 0) && create_rsc) {
             crm_err("Invalid resource definition for %s", ID(xml_rsc));
             crm_log_xml_warn(input->msg, "bad input");
 
             /* if the operation couldn't complete because we can't register
              * the resource, return a generic error */
             synthesize_lrmd_failure(lrm_state, input->xml, PCMK_OCF_NOT_CONFIGURED);
+            return;
 
-        } else if (rsc == NULL) {
+        } else if (rc < 0) {
             crm_notice("Not creating %s resource for a %s event "
                        CRM_XS " transition key %s",
                        ID(xml_rsc), operation, ID(input->xml));
@@ -1806,8 +1837,10 @@ do_lrm_invoke(long long action,
             /* Deleting something that does not exist is a success */
             send_task_ok_ack(lrm_state, input, ID(xml_rsc), NULL, operation,
                              from_host, from_sys);
+            return;
+        }
 
-        } else if (safe_str_eq(operation, CRMD_ACTION_CANCEL)) {
+        if (safe_str_eq(operation, CRMD_ACTION_CANCEL)) {
             if (!do_lrm_cancel(input, lrm_state, rsc, from_host, from_sys)) {
                 crm_log_xml_warn(input->xml, "Bad command");
             }

--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -289,7 +289,6 @@ send_task_ok_ack(lrm_state_t *lrm_state, ha_msg_input_t *input,
 {
     lrmd_event_data_t *op = construct_op(lrm_state, input->xml, rsc_id, task);
 
-    CRM_ASSERT(op != NULL);
     op->rc = PCMK_OCF_OK;
     op->op_status = PCMK_LRM_OP_DONE;
     send_direct_ack(ack_host, ack_sys, rsc, op, rsc_id);
@@ -867,7 +866,6 @@ notify_deleted(lrm_state_t * lrm_state, ha_msg_input_t * input, const char *rsc_
              ((rc == pcmk_ok)? "" : " not"));
 
     op = construct_op(lrm_state, input->xml, rsc_id, CRMD_ACTION_DELETE);
-    CRM_ASSERT(op != NULL);
 
     if (rc == pcmk_ok) {
         op->op_status = PCMK_LRM_OP_DONE;
@@ -1432,7 +1430,6 @@ synthesize_lrmd_failure(lrm_state_t *lrm_state, xmlNode *action, int rc)
     }
 
     op = construct_op(lrm_state, action, ID(xml_rsc), operation);
-    CRM_ASSERT(op != NULL);
 
     op->call_id = get_fake_call_id(lrm_state, op->rsc_id);
     if(safe_str_eq(operation, RSC_NOTIFY)) {
@@ -1511,7 +1508,6 @@ fail_lrm_resource(xmlNode *xml, lrm_state_t *lrm_state, const char *user_name,
      * it came from the lrmd.
      */
     op = construct_op(lrm_state, xml, ID(xml_rsc), "asyncmon");
-    CRM_ASSERT(op != NULL);
 
     free((char*) op->user_data);
     op->user_data = NULL;
@@ -1883,9 +1879,11 @@ construct_op(lrm_state_t * lrm_state, xmlNode * rsc_op, const char *rsc_id, cons
 
     const char *transition = NULL;
 
-    CRM_ASSERT(rsc_id != NULL);
+    CRM_ASSERT(rsc_id && operation);
 
     op = calloc(1, sizeof(lrmd_event_data_t));
+    CRM_ASSERT(op != NULL);
+
     op->type = lrmd_event_exec_complete;
     op->op_type = strdup(operation);
     op->op_status = PCMK_LRM_OP_PENDING;

--- a/crmd/lrm_state.c
+++ b/crmd/lrm_state.c
@@ -684,20 +684,21 @@ lrm_state_register_rsc(lrm_state_t * lrm_state,
                        const char *class,
                        const char *provider, const char *agent, enum lrmd_call_options options)
 {
-    if (!lrm_state->conn) {
+    lrmd_t *conn = (lrmd_t *) lrm_state->conn;
+
+    if (conn == NULL) {
         return -ENOTCONN;
     }
 
-    /* optimize this... this function is a synced round trip from client to daemon.
-     * The crmd/lrm.c code path should be re-factored to allow the register of resources
-     * to be performed async. The lrmd client api needs to make an async version
-     * of register available. */
     if (is_remote_lrmd_ra(agent, provider, NULL)) {
-        return lrm_state_find_or_create(rsc_id) ? pcmk_ok : -1;
+        return lrm_state_find_or_create(rsc_id)? pcmk_ok : -EINVAL;
     }
 
-    return ((lrmd_t *) lrm_state->conn)->cmds->register_rsc(lrm_state->conn, rsc_id, class,
-                                                            provider, agent, options);
+    /* @TODO Implement an asynchronous version of this (currently a blocking
+     * call to the lrmd).
+     */
+    return conn->cmds->register_rsc(lrm_state->conn, rsc_id, class, provider,
+                                    agent, options);
 }
 
 int

--- a/crmd/remote_lrmd_ra.c
+++ b/crmd/remote_lrmd_ra.c
@@ -466,7 +466,8 @@ monitor_timeout_cb(gpointer data)
 
     lrm_state = lrm_state_find(cmd->rsc_id);
 
-    crm_info("Poke async response timed out for node %s (%p)", cmd->rsc_id, lrm_state);
+    crm_info("Timed out waiting for remote poke response from %s%s",
+             cmd->rsc_id, (lrm_state? "" : " (no LRM state)"));
     cmd->monitor_timeout_id = 0;
     cmd->op_status = PCMK_LRM_OP_TIMEOUT;
     cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
@@ -565,11 +566,13 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
         (ra_data->active == TRUE)) {
 
         if (!remote_ra_is_in_maintenance(lrm_state)) {
-            crm_err("Unexpected disconnect on remote-node %s", lrm_state->node_name);
+            crm_err("Lost connection to Pacemaker Remote node %s",
+                    lrm_state->node_name);
             ra_data->recurring_cmds = fail_all_monitor_cmds(ra_data->recurring_cmds);
             ra_data->cmds = fail_all_monitor_cmds(ra_data->cmds);
         } else {
-            crm_notice("Disconnect on unmanaged remote-node %s", lrm_state->node_name);
+            crm_notice("Unmanaged Pacemaker Remote node %s disconnected",
+                       lrm_state->node_name);
             /* Do roughly what a 'stop' on the remote-resource would do */
             handle_remote_ra_stop(lrm_state, NULL);
             remote_node_down(lrm_state->node_name, DOWN_KEEP_LRM);

--- a/crmd/te_callbacks.c
+++ b/crmd/te_callbacks.c
@@ -66,7 +66,7 @@ update_stonith_max_attempts(const char* value)
     }
 }
 static void
-te_legacy_update_diff(const char *event, xmlNode * diff)
+te_update_diff_v1(const char *event, xmlNode *diff)
 {
     int lpc, max;
     xmlXPathObject *xpathObj = NULL;
@@ -144,46 +144,40 @@ te_legacy_update_diff(const char *event, xmlNode * diff)
     freeXpathObject(xpathObj);
 
     /*
-     * Check for and fast-track the processing of LRM refreshes
-     * In large clusters this can result in _huge_ speedups
+     * Updates by, or in response to, TE actions will never contain updates
+     * for more than one resource at a time, so such updates indicate an
+     * LRM refresh.
      *
-     * Unfortunately we can only do so when there are no pending actions
-     * Otherwise we could miss updates we're waiting for and stall
+     * In that case, start a new transition rather than check each result
+     * individually, which can result in _huge_ speedups in large clusters.
      *
+     * Unfortunately, we can only do so when there are no pending actions.
+     * Otherwise, we could mistakenly throw away those results here, and
+     * the cluster will stall waiting for them and time out the operation.
      */
-    xpathObj = NULL;
     if (transition_graph->pending == 0) {
-        xpathObj =
-            xpath_search(diff,
-                         "//" F_CIB_UPDATE_RESULT "//" XML_TAG_DIFF_ADDED "//"
-                         XML_LRM_TAG_RESOURCE);
+        xpathObj = xpath_search(diff,
+                                "//" F_CIB_UPDATE_RESULT
+                                "//" XML_TAG_DIFF_ADDED
+                                "//" XML_LRM_TAG_RESOURCE);
+        max = numXpathResults(xpathObj);
+        if (max > 1) {
+            crm_debug("Ignoring resource operation updates due to LRM refresh of %d resources",
+                      max);
+            crm_log_xml_trace(diff, "lrm-refresh");
+            abort_transition(INFINITY, tg_restart, "LRM Refresh", NULL);
+            goto bail;
+        }
+        freeXpathObject(xpathObj);
     }
-
-    max = numXpathResults(xpathObj);
-    if (max > 1) {
-        /* Updates by, or in response to, TE actions will never contain updates
-         * for more than one resource at a time
-         */
-        crm_debug("Detected LRM refresh - %d resources updated: Skipping all resource events", max);
-        crm_log_xml_trace(diff, "lrm-refresh");
-        abort_transition(INFINITY, tg_restart, "LRM Refresh", NULL);
-        goto bail;
-    }
-    freeXpathObject(xpathObj);
 
     /* Process operation updates */
     xpathObj =
         xpath_search(diff,
                      "//" F_CIB_UPDATE_RESULT "//" XML_TAG_DIFF_ADDED "//" XML_LRM_TAG_RSC_OP);
-    if (numXpathResults(xpathObj)) {
-/*
-    <status>
-       <node_state id="node1" state=CRMD_JOINSTATE_MEMBER exp_state="active">
-          <lrm>
-             <lrm_resources>
-        	<rsc_state id="" rsc_id="rsc4" node_id="node1" rsc_state="stopped"/>
-*/
-        int lpc = 0, max = numXpathResults(xpathObj);
+    max = numXpathResults(xpathObj);
+    if (max > 0) {
+        int lpc = 0;
 
         for (lpc = 0; lpc < max; lpc++) {
             xmlNode *rsc_op = getXpathResult(xpathObj, lpc);
@@ -241,38 +235,50 @@ te_legacy_update_diff(const char *event, xmlNode * diff)
     freeXpathObject(xpathObj);
 }
 
-static void process_resource_updates(
-    const char *node, xmlNode *xml, xmlNode *change, const char *op, const char *xpath) 
+static void
+process_lrm_resource_diff(xmlNode *lrm_resource, const char *node)
+{
+    for (xmlNode *rsc_op = __xml_first_child(lrm_resource); rsc_op != NULL;
+         rsc_op = __xml_next(rsc_op)) {
+        process_graph_event(rsc_op, node);
+    }
+}
+
+static void
+process_resource_updates(const char *node, xmlNode *xml, xmlNode *change,
+                         const char *op, const char *xpath)
 {
     xmlNode *cIter = NULL;
     xmlNode *rsc = NULL;
-    xmlNode *rsc_op = NULL;
     int num_resources = 0;
 
-    if(xml == NULL) {
+    if (xml == NULL) {
         return;
 
-    } else if(strcmp((const char*)xml->name, XML_CIB_TAG_LRM) == 0) {
+    } else if (strcmp((const char*)xml->name, XML_CIB_TAG_LRM) == 0) {
         xml = first_named_child(xml, XML_LRM_TAG_RESOURCES);
         crm_trace("Got %p in %s", xml, XML_CIB_TAG_LRM);
     }
 
     CRM_ASSERT(strcmp((const char*)xml->name, XML_LRM_TAG_RESOURCES) == 0);
 
-    for(cIter = xml->children; cIter; cIter = cIter->next) {
+    for (cIter = xml->children; cIter; cIter = cIter->next) {
         num_resources++;
     }
 
-    if(num_resources > 1) {
+    if (num_resources > 1) {
         /*
-         * Check for and fast-track the processing of LRM refreshes
-         * In large clusters this can result in _huge_ speedups
+         * Updates by, or in response to, TE actions will never contain updates
+         * for more than one resource at a time, so such updates indicate an
+         * LRM refresh.
          *
-         * Unfortunately we can only do so when there are no pending actions
-         * Otherwise we could miss updates we're waiting for and stall
+         * In that case, start a new transition rather than check each result
+         * individually, which can result in _huge_ speedups in large clusters.
          *
+         * Unfortunately, we can only do so when there are no pending actions.
+         * Otherwise, we could mistakenly throw away those results here, and
+         * the cluster will stall waiting for them and time out the operation.
          */
-
         crm_debug("Detected LRM refresh - %d resources updated", num_resources);
         crm_log_xml_trace(change, "lrm-refresh");
         abort_transition(INFINITY, tg_restart, "LRM Refresh", NULL);
@@ -281,10 +287,7 @@ static void process_resource_updates(
 
     for (rsc = __xml_first_child(xml); rsc != NULL; rsc = __xml_next(rsc)) {
         crm_trace("Processing %s", ID(rsc));
-        for (rsc_op = __xml_first_child(rsc); rsc_op != NULL; rsc_op = __xml_next(rsc_op)) {
-            crm_trace("Processing %s", ID(rsc_op));
-            process_graph_event(rsc_op, node);
-        }
+        process_lrm_resource_diff(rsc, node);
     }
 }
 
@@ -361,16 +364,219 @@ abort_unless_down(const char *xpath, const char *op, xmlNode *change,
     free(node_uuid);
 }
 
+static void
+process_op_deletion(const char *xpath, xmlNode *change)
+{
+    char *mutable_key = strdup(xpath);
+    char *key;
+    char *node_uuid;
+    crm_action_t *cancel = NULL;
+
+    // Extract the part of xpath between last pair of single quotes
+    key = strrchr(mutable_key, '\'');
+    if (key != NULL) {
+        *key = '\0';
+        key = strrchr(mutable_key, '\'');
+    }
+    if (key == NULL) {
+        crm_warn("Ignoring malformed CIB update (resource deletion of %s)",
+                 xpath);
+        free(mutable_key);
+        return;
+    }
+    ++key;
+
+    node_uuid = extract_node_uuid(xpath);
+    cancel = get_cancel_action(key, node_uuid);
+    if (cancel) {
+        crm_info("Cancellation of %s on %s confirmed (%d)",
+                 key, node_uuid, cancel->id);
+        stop_te_timer(cancel->timer);
+        te_action_confirmed(cancel);
+        update_graph(transition_graph, cancel);
+        trigger_graph();
+    } else {
+        abort_transition(INFINITY, tg_restart, "Resource operation removal",
+                         change);
+    }
+    free(mutable_key);
+    free(node_uuid);
+}
+
+static void
+process_delete_diff(const char *xpath, const char *op, xmlNode *change)
+{
+    if (strstr(xpath, "/" XML_LRM_TAG_RSC_OP "[")) {
+        process_op_deletion(xpath, change);
+
+    } else if (strstr(xpath, "/" XML_CIB_TAG_LRM "[")) {
+        abort_unless_down(xpath, op, change, "Resource state removal");
+
+    } else if (strstr(xpath, "/" XML_CIB_TAG_STATE "[")) {
+        abort_unless_down(xpath, op, change, "Node state removal");
+
+    } else {
+        crm_trace("Ignoring delete of %s", xpath);
+    }
+}
+
+static void
+process_node_state_diff(xmlNode *state, xmlNode *change, const char *op,
+                        const char *xpath)
+{
+    xmlNode *lrm = first_named_child(state, XML_CIB_TAG_LRM);
+
+    process_resource_updates(ID(state), lrm, change, op, xpath);
+}
+
+static void
+process_status_diff(xmlNode *status, xmlNode *change, const char *op,
+                    const char *xpath)
+{
+    for (xmlNode *state = __xml_first_child(status); state != NULL;
+         state = __xml_next(state)) {
+        process_node_state_diff(state, change, op, xpath);
+    }
+}
+
+static void
+process_cib_diff(xmlNode *cib, xmlNode *change, const char *op,
+                 const char *xpath)
+{
+    xmlNode *status = first_named_child(cib, XML_CIB_TAG_STATUS);
+    xmlNode *config = first_named_child(cib, XML_CIB_TAG_CONFIGURATION);
+
+    if (status) {
+        process_status_diff(status, change, op, xpath);
+    }
+    if (config) {
+        abort_transition(INFINITY, tg_restart,
+                         "Non-status-only change", change);
+    }
+}
+
+static void
+te_update_diff_v2(xmlNode *diff)
+{
+    crm_log_xml_trace(diff, "Patch:Raw");
+
+    for (xmlNode *change = __xml_first_child(diff); change != NULL;
+         change = __xml_next(change)) {
+
+        xmlNode *match = NULL;
+        const char *name = NULL;
+        const char *xpath = crm_element_value(change, XML_DIFF_PATH);
+
+        // Possible ops: create, modify, delete, move
+        const char *op = crm_element_value(change, XML_DIFF_OP);
+
+        // Ignore uninteresting updates
+        if (op == NULL) {
+            continue;
+
+        } else if (xpath == NULL) {
+            crm_trace("Ignoring %s change for version field", op);
+            continue;
+
+        } else if (strcmp(op, "move") == 0) {
+            crm_trace("Ignoring move change at %s", xpath);
+            continue;
+        }
+
+        // Find the result of create/modify ops
+        if (strcmp(op, "create") == 0) {
+            match = change->children;
+
+        } else if (strcmp(op, "modify") == 0) {
+            match = first_named_child(change, XML_DIFF_RESULT);
+            if(match) {
+                match = match->children;
+            }
+
+        } else if (strcmp(op, "delete") != 0) {
+            crm_warn("Ignoring malformed CIB update (%s operation on %s is unrecognized)",
+                     op, xpath);
+            continue;
+        }
+
+        if (match) {
+            if (match->type == XML_COMMENT_NODE) {
+                crm_trace("Ignoring %s operation for comment at %s", op, xpath);
+                continue;
+            }
+            name = (const char *)match->name;
+        }
+
+        crm_trace("Handling %s operation for %s%s%s",
+                  op, (xpath? xpath : "CIB"),
+                  (name? " matched by " : ""), (name? name : ""));
+
+        if (strstr(xpath, "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION)) {
+            abort_transition(INFINITY, tg_restart, "Configuration change",
+                             change);
+            break; // Won't be packaged with operation results we may be waiting for
+
+        } else if (strstr(xpath, "/" XML_CIB_TAG_TICKETS)
+                   || safe_str_eq(name, XML_CIB_TAG_TICKETS)) {
+            abort_transition(INFINITY, tg_restart, "Ticket attribute change", change);
+            break; // Won't be packaged with operation results we may be waiting for
+
+        } else if (strstr(xpath, "/" XML_TAG_TRANSIENT_NODEATTRS "[")
+                   || safe_str_eq(name, XML_TAG_TRANSIENT_NODEATTRS)) {
+            abort_unless_down(xpath, op, change, "Transient attribute change");
+            break; // Won't be packaged with operation results we may be waiting for
+
+        } else if (strcmp(op, "delete") == 0) {
+            process_delete_diff(xpath, op, change);
+
+        } else if (name == NULL) {
+            crm_warn("Ignoring malformed CIB update (%s at %s has no result)",
+                     op, xpath);
+
+        } else if (strcmp(name, XML_TAG_CIB) == 0) {
+            process_cib_diff(match, change, op, xpath);
+
+        } else if (strcmp(name, XML_CIB_TAG_STATUS) == 0) {
+            process_status_diff(match, change, op, xpath);
+
+        } else if (strcmp(name, XML_CIB_TAG_STATE) == 0) {
+            process_node_state_diff(match, change, op, xpath);
+
+        } else if (strcmp(name, XML_CIB_TAG_LRM) == 0) {
+            process_resource_updates(ID(match), match, change, op, xpath);
+
+        } else if (strcmp(name, XML_LRM_TAG_RESOURCES) == 0) {
+            char *local_node = get_node_from_xpath(xpath);
+
+            process_resource_updates(local_node, match, change, op, xpath);
+            free(local_node);
+
+        } else if (strcmp(name, XML_LRM_TAG_RESOURCE) == 0) {
+            char *local_node = get_node_from_xpath(xpath);
+
+            process_lrm_resource_diff(match, local_node);
+            free(local_node);
+
+        } else if (strcmp(name, XML_LRM_TAG_RSC_OP) == 0) {
+            char *local_node = get_node_from_xpath(xpath);
+
+            process_graph_event(match, local_node);
+            free(local_node);
+
+        } else {
+            crm_warn("Ignoring malformed CIB update (%s at %s has unrecognized result %s)",
+                     op, xpath, name);
+        }
+    }
+}
+
 void
 te_update_diff(const char *event, xmlNode * msg)
 {
+    xmlNode *diff = NULL;
+    const char *op = NULL;
     int rc = -EINVAL;
     int format = 1;
-    xmlNode *change = NULL;
-    const char *op = NULL;
-
-    xmlNode *diff = NULL;
-
     int p_add[] = { 0, 0, 0 };
     int p_del[] = { 0, 0, 0 };
 
@@ -385,9 +591,10 @@ te_update_diff(const char *event, xmlNode * msg)
         crm_trace("Filter rc=%d (%s)", rc, pcmk_strerror(rc));
         return;
 
-    } else if (transition_graph->complete == TRUE
+    } else if (transition_graph->complete
                && fsa_state != S_IDLE
-               && fsa_state != S_TRANSITION_ENGINE && fsa_state != S_POLICY_ENGINE) {
+               && fsa_state != S_TRANSITION_ENGINE
+               && fsa_state != S_POLICY_ENGINE) {
         crm_trace("Filter state=%s, complete=%d", fsa_state2string(fsa_state),
                   transition_graph->complete);
         return;
@@ -402,177 +609,18 @@ te_update_diff(const char *event, xmlNode * msg)
               fsa_state2string(fsa_state));
 
     crm_element_value_int(diff, "format", &format);
-    switch(format) {
+    switch (format) {
         case 1:
-            te_legacy_update_diff(event, diff);
-            return;
+            te_update_diff_v1(event, diff);
+            break;
         case 2:
-            /* Cool, we know what to do here */
-            crm_log_xml_trace(diff, "Patch:Raw");
+            te_update_diff_v2(diff);
             break;
         default:
-            crm_warn("Unknown patch format: %d", format);
-            return;
-    }
-
-    for (change = __xml_first_child(diff); change != NULL; change = __xml_next(change)) {
-        const char *name = NULL;
-        const char *op = crm_element_value(change, XML_DIFF_OP);
-        const char *xpath = crm_element_value(change, XML_DIFF_PATH);
-        xmlNode *match = NULL;
-        const char *node = NULL;
-
-        if(op == NULL) {
-            continue;
-
-        } else if(strcmp(op, "create") == 0) {
-            match = change->children;
-
-        } else if(strcmp(op, "move") == 0) {
-            continue;
-
-        } else if(strcmp(op, "modify") == 0) {
-            match = first_named_child(change, XML_DIFF_RESULT);
-            if(match) {
-                match = match->children;
-            }
-        }
-
-        if(match) {
-            if (match->type == XML_COMMENT_NODE) {
-                crm_trace("Ignoring %s operation for comment at %s", op, xpath);
-                continue;
-            }
-            name = (const char *)match->name;
-        }
-
-        crm_trace("Handling %s operation for %s%s%s",
-                  op, (xpath? xpath : "CIB"),
-                  (name? " matched by " : ""), (name? name : ""));
-        if(xpath == NULL) {
-            /* Version field, ignore */
-
-        } else if(strstr(xpath, "/cib/configuration")) {
-            abort_transition(INFINITY, tg_restart, "Configuration change", change);
-            break; /* Won't be packaged with any resource operations we may be waiting for */
-
-        } else if(strstr(xpath, "/"XML_CIB_TAG_TICKETS) || safe_str_eq(name, XML_CIB_TAG_TICKETS)) {
-            abort_transition(INFINITY, tg_restart, "Ticket attribute change", change);
-            break; /* Won't be packaged with any resource operations we may be waiting for */
-
-        } else if(strstr(xpath, "/"XML_TAG_TRANSIENT_NODEATTRS"[") || safe_str_eq(name, XML_TAG_TRANSIENT_NODEATTRS)) {
-            abort_unless_down(xpath, op, change, "Transient attribute change");
-            break; /* Won't be packaged with any resource operations we may be waiting for */
-
-        } else if(strstr(xpath, "/"XML_LRM_TAG_RSC_OP"[") && safe_str_eq(op, "delete")) {
-            crm_action_t *cancel = NULL;
-            char *mutable_key = strdup(xpath);
-            char *key, *node_uuid;
-
-            /* Extract the part of xpath between last pair of single quotes */
-            key = strrchr(mutable_key, '\'');
-            if (key != NULL) {
-                *key = '\0';
-                key = strrchr(mutable_key, '\'');
-            }
-            if (key == NULL) {
-                crm_warn("Ignoring malformed CIB update (resource deletion)");
-                free(mutable_key);
-                continue;
-            }
-            ++key;
-
-            node_uuid = extract_node_uuid(xpath);
-            cancel = get_cancel_action(key, node_uuid);
-            if (cancel == NULL) {
-                abort_transition(INFINITY, tg_restart, "Resource operation removal", change);
-
-            } else {
-                crm_info("Cancellation of %s on %s confirmed (%d)", key, node_uuid, cancel->id);
-                stop_te_timer(cancel->timer);
-                te_action_confirmed(cancel);
-
-                update_graph(transition_graph, cancel);
-                trigger_graph();
-
-            }
-            free(mutable_key);
-            free(node_uuid);
-
-        } else if(strstr(xpath, "/"XML_CIB_TAG_LRM"[") && safe_str_eq(op, "delete")) {
-            abort_unless_down(xpath, op, change, "Resource state removal");
-
-        } else if(strstr(xpath, "/"XML_CIB_TAG_STATE"[") && safe_str_eq(op, "delete")) {
-            abort_unless_down(xpath, op, change, "Node state removal");
-
-        } else if(name == NULL) {
-            crm_debug("No result for %s operation to %s", op, xpath);
-            CRM_ASSERT(strcmp(op, "delete") == 0 || strcmp(op, "move") == 0);
-
-        } else if(strcmp(name, XML_TAG_CIB) == 0) {
-            xmlNode *state = NULL;
-            xmlNode *status = first_named_child(match, XML_CIB_TAG_STATUS);
-            xmlNode *config = first_named_child(match, XML_CIB_TAG_CONFIGURATION);
-
-            for (state = __xml_first_child(status); state != NULL; state = __xml_next(state)) {
-                xmlNode *lrm = first_named_child(state, XML_CIB_TAG_LRM);
-
-                node = ID(state);
-                process_resource_updates(node, lrm, change, op, xpath);
-            }
-
-            if(config) {
-                abort_transition(INFINITY, tg_restart, "Non-status-only change", change);
-            }
-
-        } else if(strcmp(name, XML_CIB_TAG_STATUS) == 0) {
-            xmlNode *state = NULL;
-
-            for (state = __xml_first_child(match); state != NULL; state = __xml_next(state)) {
-                xmlNode *lrm = first_named_child(state, XML_CIB_TAG_LRM);
-
-                node = ID(state);
-                process_resource_updates(node, lrm, change, op, xpath);
-            }
-
-        } else if(strcmp(name, XML_CIB_TAG_STATE) == 0) {
-            xmlNode *lrm = first_named_child(match, XML_CIB_TAG_LRM);
-
-            node = ID(match);
-            process_resource_updates(node, lrm, change, op, xpath);
-
-        } else if(strcmp(name, XML_CIB_TAG_LRM) == 0) {
-            node = ID(match);
-            process_resource_updates(node, match, change, op, xpath);
-
-        } else if(strcmp(name, XML_LRM_TAG_RESOURCES) == 0) {
-            char *local_node = get_node_from_xpath(xpath);
-
-            process_resource_updates(local_node, match, change, op, xpath);
-            free(local_node);
-
-        } else if(strcmp(name, XML_LRM_TAG_RESOURCE) == 0) {
-
-            xmlNode *rsc_op;
-            char *local_node = get_node_from_xpath(xpath);
-
-            for (rsc_op = __xml_first_child(match); rsc_op != NULL; rsc_op = __xml_next(rsc_op)) {
-                process_graph_event(rsc_op, local_node);
-            }
-            free(local_node);
-
-        } else if(strcmp(name, XML_LRM_TAG_RSC_OP) == 0) {
-            char *local_node = get_node_from_xpath(xpath);
-
-            process_graph_event(match, local_node);
-            free(local_node);
-
-        } else {
-            crm_err("Ignoring %s operation for %s %p, %s", op, xpath, match, name);
-        }
+            crm_warn("Ignoring malformed CIB update (unknown patch format %d)",
+                     format);
     }
 }
-
 
 gboolean
 process_te_message(xmlNode * msg, xmlNode * xml_data)

--- a/crmd/te_callbacks.c
+++ b/crmd/te_callbacks.c
@@ -350,7 +350,7 @@ abort_unless_down(const char *xpath, const char *op, xmlNode *change,
     }
 
     down = match_down_event(node_uuid, TRUE);
-    if(down == NULL || down->executed == false) {
+    if (down == NULL) {
         crm_trace("Not expecting %s to be down (%s)", node_uuid, xpath);
         abort_transition(INFINITY, tg_restart, reason, change);
     } else {

--- a/crmd/te_events.c
+++ b/crmd/te_events.c
@@ -437,8 +437,8 @@ match_down_event(const char *target, bool quiet)
     return match;
 }
 
-gboolean
-process_graph_event(xmlNode * event, const char *event_node)
+void
+process_graph_event(xmlNode *event, const char *event_node)
 {
     int rc = -1;
     int status = -1;
@@ -451,7 +451,6 @@ process_graph_event(xmlNode * event, const char *event_node)
     int transition_num = -1;
     char *update_te_uuid = NULL;
 
-    gboolean stop_early = FALSE;
     gboolean ignore_failures = FALSE;
     const char *id = NULL;
     const char *desc = NULL;
@@ -471,14 +470,14 @@ process_graph_event(xmlNode * event, const char *event_node)
     magic = crm_element_value(event, XML_ATTR_TRANSITION_KEY);
     if (magic == NULL) {
         /* non-change */
-        return FALSE;
+        return;
     }
 
     if (decode_transition_key(magic, &update_te_uuid, &transition_num,
                               &action_num, &target_rc) == FALSE) {
         crm_err("Invalid event %s.%d detected: %s", id, callid, magic);
         abort_transition(INFINITY, tg_restart, "Bad event", event);
-        return FALSE;
+        return;
     }
 
     if (status == PCMK_LRM_OP_PENDING) {
@@ -492,12 +491,10 @@ process_graph_event(xmlNode * event, const char *event_node)
     } else if ((action_num < 0) || (crm_str_eq(update_te_uuid, te_uuid, TRUE) == FALSE)) {
         desc = "initiated by a different node";
         abort_transition(INFINITY, tg_restart, "Foreign event", event);
-        stop_early = TRUE;      /* This could be an lrm status refresh */
 
     } else if (transition_graph->id != transition_num) {
         desc = "arrived really late";
         abort_transition(INFINITY, tg_restart, "Old event", event);
-        stop_early = TRUE;      /* This could be an lrm status refresh */
 
     } else if (transition_graph->complete) {
         desc = "arrived late";
@@ -522,8 +519,6 @@ process_graph_event(xmlNode * event, const char *event_node)
     } else {
         if (update_failcount(event, event_node, rc, target_rc,
                              (transition_num == -1), ignore_failures)) {
-            /* Turns out this wasn't an lrm status refresh update afterall */
-            stop_early = FALSE;
             desc = "failed";
         }
         crm_info("Detected action (%d.%d) %s.%d=%s: %s", transition_num,
@@ -532,5 +527,4 @@ process_graph_event(xmlNode * event, const char *event_node)
 
   bail:
     free(update_te_uuid);
-    return stop_early;
 }

--- a/crmd/te_events.c
+++ b/crmd/te_events.c
@@ -414,11 +414,16 @@ match_down_event(const char *target, bool quiet)
              gIter2 = gIter2->next) {
 
             match = (crm_action_t*)gIter2->data;
-            xpath_ret = xpath_search(match->xml, xpath);
-            if (numXpathResults(xpath_ret) < 1) {
+            if (match->executed) {
+                xpath_ret = xpath_search(match->xml, xpath);
+                if (numXpathResults(xpath_ret) < 1) {
+                    match = NULL;
+                }
+                freeXpathObject(xpath_ret);
+            } else {
+                // Only actions that were actually started can match
                 match = NULL;
             }
-            freeXpathObject(xpath_ret);
         }
     }
 

--- a/crmd/tengine.h
+++ b/crmd/tengine.h
@@ -38,7 +38,7 @@ extern crm_action_t *get_cancel_action(const char *id, const char *node);
 
 extern gboolean cib_action_update(crm_action_t * action, int status, int op_rc);
 extern gboolean fail_incompletable_actions(crm_graph_t * graph, const char *down_node);
-extern gboolean process_graph_event(xmlNode * event, const char *event_node);
+void process_graph_event(xmlNode *event, const char *event_node);
 
 /* utils */
 extern crm_action_t *get_action(int id, gboolean confirmed);

--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -3057,7 +3057,8 @@ class RemoteStonithd(RemoteDriver):
 
     def errorstoignore(self):
         ignore_pats = [
-            r"Unexpected disconnect on remote-node",
+            r"Lost connection to Pacemaker Remote node",
+            r"Software caused connection abort",
             r"crmd.*:\s+error.*: Operation remote-.*_monitor",
             r"crmd.*:\s+error.*: Result of monitor operation for remote-.*",
             r"pengine.*:\s+Recover remote-.*\s*\(.*\)",

--- a/include/crm/common/ipcs.h
+++ b/include/crm/common/ipcs.h
@@ -111,6 +111,7 @@ void crm_client_cleanup(void);
 crm_client_t *crm_client_get(qb_ipcs_connection_t * c);
 crm_client_t *crm_client_get_by_id(const char *id);
 const char *crm_client_name(crm_client_t * c);
+const char *crm_client_type_text(enum client_type client_type);
 
 crm_client_t *crm_client_alloc(void *key);
 crm_client_t *crm_client_new(qb_ipcs_connection_t * c, uid_t uid, gid_t gid);

--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -265,6 +265,8 @@ typedef struct lrmd_rsc_info_s {
     char *provider;
 } lrmd_rsc_info_t;
 
+lrmd_rsc_info_t *lrmd_new_rsc_info(const char *rsc_id, const char *standard,
+                                   const char *provider, const char *type);
 lrmd_rsc_info_t *lrmd_copy_rsc_info(lrmd_rsc_info_t * rsc_info);
 void lrmd_free_rsc_info(lrmd_rsc_info_t * rsc_info);
 

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -227,6 +227,23 @@ crm_client_name(crm_client_t * c)
     }
 }
 
+const char *
+crm_client_type_text(enum client_type client_type)
+{
+    switch (client_type) {
+        case CRM_CLIENT_IPC:
+            return "IPC";
+        case CRM_CLIENT_TCP:
+            return "TCP";
+#ifdef HAVE_GNUTLS_GNUTLS_H
+        case CRM_CLIENT_TLS:
+            return "TLS";
+#endif
+        default:
+            return "unknown";
+    }
+}
+
 void
 crm_client_init(void)
 {

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1455,20 +1455,36 @@ lrmd_api_unregister_rsc(lrmd_t * lrmd, const char *rsc_id, enum lrmd_call_option
 }
 
 lrmd_rsc_info_t *
+lrmd_new_rsc_info(const char *rsc_id, const char *standard,
+                  const char *provider, const char *type)
+{
+    lrmd_rsc_info_t *rsc_info = calloc(1, sizeof(lrmd_rsc_info_t));
+
+    CRM_ASSERT(rsc_info);
+    if (rsc_id) {
+        rsc_info->id = strdup(rsc_id);
+        CRM_ASSERT(rsc_info->id);
+    }
+    if (standard) {
+        rsc_info->standard = strdup(standard);
+        CRM_ASSERT(rsc_info->standard);
+    }
+    if (provider) {
+        rsc_info->provider = strdup(provider);
+        CRM_ASSERT(rsc_info->provider);
+    }
+    if (type) {
+        rsc_info->type = strdup(type);
+        CRM_ASSERT(rsc_info->type);
+    }
+    return rsc_info;
+}
+
+lrmd_rsc_info_t *
 lrmd_copy_rsc_info(lrmd_rsc_info_t * rsc_info)
 {
-    lrmd_rsc_info_t *copy = NULL;
-
-    copy = calloc(1, sizeof(lrmd_rsc_info_t));
-
-    copy->id = strdup(rsc_info->id);
-    copy->type = strdup(rsc_info->type);
-    copy->standard = strdup(rsc_info->standard);
-    if (rsc_info->provider) {
-        copy->provider = strdup(rsc_info->provider);
-    }
-
-    return copy;
+    return lrmd_new_rsc_info(rsc_info->id, rsc_info->standard,
+                             rsc_info->provider, rsc_info->type);
 }
 
 void
@@ -1515,14 +1531,7 @@ lrmd_api_get_rsc_info(lrmd_t * lrmd, const char *rsc_id, enum lrmd_call_options 
         return NULL;
     }
 
-    rsc_info = calloc(1, sizeof(lrmd_rsc_info_t));
-    rsc_info->id = strdup(rsc_id);
-    rsc_info->standard = strdup(class);
-    if (provider) {
-        rsc_info->provider = strdup(provider);
-    }
-    rsc_info->type = strdup(type);
-
+    rsc_info = lrmd_new_rsc_info(rsc_id, class, provider, type);
     free_xml(output);
     return rsc_info;
 }

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -341,11 +341,11 @@ lrmd_tls_dispatch(gpointer userdata)
     int disconnected = 0;
 
     if (lrmd_tls_connected(lrmd) == FALSE) {
-        crm_trace("tls dispatch triggered after disconnect");
+        crm_trace("TLS dispatch triggered after disconnect");
         return 0;
     }
 
-    crm_trace("tls_dispatch triggered");
+    crm_trace("TLS dispatch triggered");
 
     /* First check if there are any pending notifies to process that came
      * while we were waiting for replies earlier. */
@@ -382,7 +382,7 @@ lrmd_tls_dispatch(gpointer userdata)
                 int reply_id = 0;
                 crm_element_value_int(xml, F_LRMD_CALLID, &reply_id);
                 /* if this happens, we want to know about it */
-                crm_err("Got outdated reply %d", reply_id);
+                crm_err("Got outdated remote LRM reply %d", reply_id);
             }
         }
         free_xml(xml);
@@ -390,7 +390,8 @@ lrmd_tls_dispatch(gpointer userdata)
     }
 
     if (disconnected) {
-        crm_info("Server disconnected while reading remote server msg.");
+        crm_info("Lost %s LRM connection while reading data",
+                 (native->remote_nodename? native->remote_nodename : "local"));
         lrmd_tls_disconnect(lrmd);
         return 0;
     }
@@ -1389,7 +1390,9 @@ lrmd_api_disconnect(lrmd_t * lrmd)
 {
     lrmd_private_t *native = lrmd->lrmd_private;
 
-    crm_info("Disconnecting from %d lrmd service", native->type);
+    crm_info("Disconnecting %s LRM connection to %s",
+             crm_client_type_text(native->type),
+             (native->remote_nodename? native->remote_nodename : "local"));
     switch (native->type) {
         case CRM_CLIENT_IPC:
             lrmd_ipc_disconnect(lrmd);

--- a/lrmd/lrmd.c
+++ b/lrmd/lrmd.c
@@ -372,7 +372,8 @@ send_reply(crm_client_t * client, int rc, uint32_t id, int call_id)
 
     free_xml(reply);
     if (send_rc < 0) {
-        crm_warn("LRMD reply to %s failed: %d", client->name, send_rc);
+        crm_warn("Reply to client %s failed: %s " CRM_XS " %d",
+                 client->name, pcmk_strerror(send_rc), send_rc);
     }
 }
 

--- a/lrmd/tls_backend.c
+++ b/lrmd/tls_backend.c
@@ -91,7 +91,7 @@ lrmd_remote_client_msg(gpointer data)
         /* no msg to read */
         return 0;
     } else if (rc < 0) {
-        crm_info("Client disconnected during remote client read");
+        crm_info("Client disconnected while polling it");
         return -1;
     }
 
@@ -126,7 +126,7 @@ lrmd_remote_client_msg(gpointer data)
     }
 
     if (disconnected) {
-        crm_info("Client disconnect detected in tls msg dispatcher.");
+        crm_info("Client disconnected while reading from it");
         return -1;
     }
 
@@ -142,6 +142,10 @@ lrmd_remote_client_destroy(gpointer user_data)
         return;
     }
 
+    crm_notice("Cleaning up after remote client %s disconnected "
+               CRM_XS " id=%s",
+               (client->name? client->name : ""), client->id);
+
     ipc_proxy_remove_provider(client);
 
     /* if this is the last remote connection, stop recurring
@@ -149,9 +153,6 @@ lrmd_remote_client_destroy(gpointer user_data)
     if (crm_hash_table_size(client_connections) == 1) {
         client_disconnect_cleanup(NULL);
     }
-
-    crm_notice("LRMD client disconnecting remote client - name: %s id: %s",
-               client->name ? client->name : "<unknown>", client->id);
 
     if (client->remote->tls_session) {
         void *sock_ptr;


### PR DESCRIPTION
This addresses multiple issues, most of them timing-sensitive:

* Detect and log malformed CIB diffs better. (Unlikely to be an issue in practice, but this cleans up the code a bit.)

* Don't abort the transition when getting an LRM refresh via a v2 CIB diff if there are pending actions. This was already done for v1, and the same potential problem applies to v2: if there happen to be pending action results coming in at the same time as the LRM refresh, we could mistakenly discard them without processing.

* Match only executed events when searching for events that could make a node down. Previously, we matched any events, but one of the callers only accepted events that were executed. This would lead to wrong behavior when there were multiple possible matches, but the first one found had not yet been initiated.

* Previously, all lrmd errors when attempting to register a resource were treated as resource configuration issues. Now, those are properly distinguished from network communication issues.

* LRM failures synthesized by the crmd are now always written to the CIB, even if the relevant LRM connection doesn't have the resource information cached. Otherwise, the PE doesn't know about it, and we can get into a transition loop. The most likely scenario for this is when we attempt to recover a resource on a Pacemaker Remote node whose connection has just died.