### PR TITLE
Feature: fencing: make watchdog-fencing configurable

### DIFF
--- a/crmd/control.c
+++ b/crmd/control.c
@@ -894,6 +894,17 @@ do_recover(long long action,
     register_fsa_input(C_FSA_INTERNAL, I_TERMINATE, NULL);
 }
 
+static gboolean
+verify_stonith_watchdog_timeout(const char *value)
+{
+    gboolean rv = TRUE;
+
+    if (watchdog_fencing_enabled_for_node(fsa_our_uname)) {
+        rv = check_sbd_timeout(value);
+    }
+    return rv;
+}
+
 /* *INDENT-OFF* */
 pe_cluster_option crmd_opts[] = {
 	/* name, old-name, validate, values, default, short description, long description */
@@ -957,7 +968,7 @@ pe_cluster_option crmd_opts[] = {
           "Delay cluster recovery for the configured interval to allow for additional/related events to occur.\n"
           "Useful if your configuration is sensitive to the order in which ping updates arrive."
         },
-	{ "stonith-watchdog-timeout", NULL, "time", NULL, NULL, &check_sbd_timeout,
+	{ "stonith-watchdog-timeout", NULL, "time", NULL, NULL, &verify_stonith_watchdog_timeout,
 	  "How long to wait before we can assume nodes are safely down", NULL
         },
         { "stonith-max-attempts",NULL,"integer",NULL,"10",&check_positive_number,

--- a/fencing/Makefile.am
+++ b/fencing/Makefile.am
@@ -25,7 +25,7 @@ halibdir	= $(CRM_DAEMON_DIR)
 halib_PROGRAMS	= stonithd stonith-test
 
 sbin_PROGRAMS	= stonith_admin
-sbin_SCRIPTS	= fence_legacy fence_pcmk
+sbin_SCRIPTS	= fence_legacy fence_pcmk fence_watchdog
 
 noinst_HEADERS	= internal.h standalone_config.h
 

--- a/fencing/fence_watchdog
+++ b/fencing/fence_watchdog
@@ -1,0 +1,278 @@
+#!/usr/bin/python
+"""Dummy watchdog fence agent for providing meta-data for the pacemaker internal agent
+"""
+
+# Pacemaker targets compatibility with Python 2.6+ and 3.2+
+from __future__ import print_function, unicode_literals, absolute_import, division
+
+__copyright__ = "Copyright (C) 2012-2016 Andrew Beekhof <andrew@beekhof.net>"
+__license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
+
+import io
+import os
+import re
+import sys
+import atexit
+import getopt
+
+AGENT_VERSION = "1.0.0"
+OCF_VERSION = "1.0"
+SHORT_DESC = "Dummy watchdog fence agent"
+LONG_DESC = """fence_watchdog is a fake fence-agent which provides
+meta-data for the pacemaker internal watchdog agent."""
+
+ALL_OPT = {
+    "version" : {
+        "getopt" : "V",
+        "longopt" : "version",
+        "help" : "-V, --version                  Display version information and exit",
+        "required" : "0",
+        "shortdesc" : "Display version information and exit",
+        "order" : 53
+        },
+    "help"    : {
+        "getopt" : "h",
+        "longopt" : "help",
+        "help" : "-h, --help                     Display this help and exit",
+        "required" : "0",
+        "shortdesc" : "Display help and exit",
+        "order" : 54
+        },
+    "action" : {
+        "getopt" : "o:",
+        "longopt" : "action",
+        "help" : "-o, --action=[action]          Action: metadata",
+        "required" : "1",
+        "shortdesc" : "Fencing Action",
+        "default" : "metadata",
+        "order" : 1
+        }
+}
+
+
+def agent():
+    """ Return name this file was run as. """
+
+    return os.path.basename(sys.argv[0])
+
+
+def fail_usage(message):
+    """ Print a usage message and exit. """
+
+    sys.exit("%s\nPlease use '-h' for usage" % message)
+
+
+def show_docs(options):
+    """ Handle informational options (display info and exit). """
+
+    device_opt = options["device_opt"]
+
+    if "-h" in options:
+        usage(device_opt)
+        sys.exit(0)
+
+    if "-o" in options and options["-o"].lower() == "metadata":
+        metadata(device_opt, options)
+        sys.exit(0)
+
+    if "-V" in options:
+        print(AGENT_VERSION)
+        sys.exit(0)
+
+
+def sorted_options(avail_opt):
+    """ Return a list of all options, in their internally specified order. """
+
+    sorted_list = [(key, ALL_OPT[key]) for key in avail_opt]
+    sorted_list.sort(key=lambda x: x[1]["order"])
+    return sorted_list
+
+
+def usage(avail_opt):
+    """ Print a usage message. """
+    print(LONG_DESC)
+    print()
+    print("Usage:")
+    print("\t" + agent() + " [options]")
+    print("Options:")
+
+    for dummy, value in sorted_options(avail_opt):
+        if len(value["help"]) != 0:
+            print("   " + value["help"])
+
+
+def metadata(avail_opt, options):
+    """ Print agent metadata. """
+
+    print("""<?xml version="1.0" ?>
+<resource-agent name="%s" shortdesc="%s" version="%s">
+<version>%s</version>
+<longdesc>%s</longdesc>
+<parameters>""" % (agent(), SHORT_DESC, AGENT_VERSION, OCF_VERSION, LONG_DESC))
+
+    for option, dummy in sorted_options(avail_opt):
+        if "shortdesc" in ALL_OPT[option]:
+            print("\t<parameter name=\"" + option + "\" unique=\"0\" required=\"" + ALL_OPT[option]["required"] + "\">")
+
+            default = ""
+            default_name_arg = "-" + ALL_OPT[option]["getopt"][:-1]
+            default_name_no_arg = "-" + ALL_OPT[option]["getopt"]
+
+            if "default" in ALL_OPT[option]:
+                default = 'default="%s"' % str(ALL_OPT[option]["default"])
+            elif default_name_arg in options:
+                if options[default_name_arg]:
+                    try:
+                        default = 'default="%s"' % options[default_name_arg]
+                    except TypeError:
+                        ## @todo/@note: Currently there is no clean way how to handle lists
+                        ## we can create a string from it but we can't set it on command line
+                        default = 'default="%s"' % str(options[default_name_arg])
+            elif default_name_no_arg in options:
+                default = 'default="true"'
+
+            mixed = ALL_OPT[option]["help"]
+            ## split it between option and help text
+            res = re.compile(r"^(.*--\S+)\s+", re.IGNORECASE | re.S).search(mixed)
+            if None != res:
+                mixed = res.group(1)
+            mixed = mixed.replace("<", "&lt;").replace(">", "&gt;")
+            print("\t\t<getopt mixed=\"" + mixed + "\" />")
+
+            if ALL_OPT[option]["getopt"].count(":") > 0:
+                print("\t\t<content type=\"string\" "+default+" />")
+            else:
+                print("\t\t<content type=\"boolean\" "+default+" />")
+
+            print("\t\t<shortdesc lang=\"en\">" + ALL_OPT[option]["shortdesc"] + "</shortdesc>")
+            print("\t</parameter>")
+
+    print("""</parameters>
+<actions>
+\t<action name="on" on_target="1" />
+\t<action name="off" />
+\t<action name="reboot" />
+\t<action name="status" />
+\t<action name="monitor" />
+\t<action name="metadata" />
+\t<action name="list" />
+</actions>
+</resource-agent>""")
+
+
+def option_longopt(option):
+    """ Return the getopt-compatible long-option name of the given option. """
+
+    if ALL_OPT[option]["getopt"].endswith(":"):
+        return ALL_OPT[option]["longopt"] + "="
+    else:
+        return ALL_OPT[option]["longopt"]
+
+
+def opts_from_command_line(argv, avail_opt):
+    """ Read options from command-line arguments. """
+
+    # Prepare list of options for getopt
+    getopt_string = ""
+    longopt_list = []
+    for k in avail_opt:
+        if k in ALL_OPT:
+            getopt_string += ALL_OPT[k]["getopt"]
+        else:
+            fail_usage("Parse error: unknown option '"+k+"'")
+
+        if k in ALL_OPT and "longopt" in ALL_OPT[k]:
+            longopt_list.append(option_longopt(k))
+
+    try:
+        opt, dummy = getopt.gnu_getopt(argv, getopt_string, longopt_list)
+    except getopt.GetoptError as error:
+        fail_usage("Parse error: " + error.msg)
+
+    # Transform longopt to short one which are used in fencing agents
+    old_opt = opt
+    opt = {}
+    for old_option in dict(old_opt).keys():
+        if old_option.startswith("--"):
+            for option in ALL_OPT.keys():
+                if "longopt" in ALL_OPT[option] and "--" + ALL_OPT[option]["longopt"] == old_option:
+                    opt["-" + ALL_OPT[option]["getopt"].rstrip(":")] = dict(old_opt)[old_option]
+        else:
+            opt[old_option] = dict(old_opt)[old_option]
+
+    return opt
+
+
+def opts_from_stdin(avail_opt):
+    """ Read options from standard input. """
+
+    opt = {}
+    name = ""
+    for line in sys.stdin.readlines():
+        line = line.strip()
+        if line.startswith("#") or (len(line) == 0):
+            continue
+
+        (name, value) = (line + "=").split("=", 1)
+        value = value[:-1]
+
+        # Compatibility Layer (with what? probably not needed for fence_dummy)
+        if name == "option":
+            name = "action"
+
+        if name not in avail_opt:
+            print("Parse error: Ignoring unknown option '%s'" % line,
+                  file=sys.stderr)
+            continue
+
+        if ALL_OPT[name]["getopt"].endswith(":"):
+            opt["-"+ALL_OPT[name]["getopt"].rstrip(":")] = value
+        elif value.lower() in ["1", "yes", "on", "true"]:
+            opt["-"+ALL_OPT[name]["getopt"]] = "1"
+
+    return opt
+
+
+def process_input(avail_opt):
+    """ Set standard environment variables, and parse all options. """
+
+    # Set standard environment
+    os.putenv("LANG", "C")
+    os.putenv("LC_ALL", "C")
+
+    # Read options from command line or standard input
+    if len(sys.argv) > 1:
+        return opts_from_command_line(sys.argv[1:], avail_opt)
+    else:
+        return opts_from_stdin(avail_opt)
+
+
+def atexit_handler():
+    """ Close stdout on exit. """
+
+    try:
+        sys.stdout.close()
+        os.close(1)
+    except IOError:
+        sys.exit("%s failed to close standard output" % agent())
+
+
+def main():
+    """ Make it so! """
+
+    device_opt = ALL_OPT.keys()
+
+    ## Defaults for fence agent
+    atexit.register(atexit_handler)
+    options = process_input(device_opt)
+    options["device_opt"] = device_opt
+    show_docs(options)
+
+    print("This is just a dummy - no actual fencing via this agent",
+          file=sys.stderr)
+
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/fencing/internal.h
+++ b/fencing/internal.h
@@ -221,7 +221,7 @@ int stonith_manual_ack(xmlNode * msg, remote_fencing_op_t * op);
 
 void unfence_cb(GPid pid, int rc, const char *output, gpointer user_data);
 
-gboolean string_in_list(GListPtr list, const char *item);
+char *list_to_string(GListPtr list, const char *delim, gboolean terminate_with_delim);
 
 gboolean node_has_attr(const char *node, const char *name, const char *value);
 
@@ -242,5 +242,6 @@ extern gboolean stand_alone;
 extern GHashTable *device_list;
 extern GHashTable *topology;
 extern long stonith_watchdog_timeout_ms;
+extern GListPtr stonith_watchdog_targets;
 
 extern GHashTable *known_peer_names;

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -50,6 +50,10 @@ xmlNode *create_level_registration_xml(const char *node, const char *pattern,
 xmlNode *create_device_registration_xml(const char *id, const char *namespace, const char *agent,
                                         stonith_key_value_t * params, const char *rsc_provides);
 
+gboolean string_in_list(GListPtr list, const char *item);
+
+GListPtr parse_host_list(const char *hosts);
+
 #  define ST_LEVEL_MAX 10
 
 #  define F_STONITH_CLIENTID      "st_clientid"
@@ -134,6 +138,7 @@ xmlNode *create_device_registration_xml(const char *id, const char *namespace, c
 #  define stonith_channel            "st_command"
 #  define stonith_channel_callback   "st_callback"
 
-#  define STONITH_WATCHDOG_AGENT  "#watchdog"
+#  define STONITH_WATCHDOG_AGENT  "fence_watchdog"
+#  define STONITH_WATCHDOG_ID     "watchdog"
 
 #endif

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -59,6 +59,7 @@ enum stonith_call_options {
     st_opt_timeout_updates = 0x00002000,
     /*! Only report back if operation is a success in callback */
     st_opt_report_only_success = 0x00004000,
+    st_opt_check_watchdog  = 0x00008000,
 };
 
 /*! Order matters here, do not change values */

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -388,4 +388,6 @@ void remote_proxy_free(gpointer data);
 void remote_proxy_relay_event(remote_proxy_t *proxy, xmlNode *msg);
 void remote_proxy_relay_response(remote_proxy_t *proxy, xmlNode *msg, int msg_id);
 
+gboolean watchdog_fencing_enabled_for_node(const char *node);
+
 #endif                          /* CRM_INTERNAL__H */

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -883,7 +883,9 @@ remote_proxy_check(lrmd_t * lrmd, GHashTable *hash)
     crm_xml_add(data, F_LRMD_ORIGIN, __FUNCTION__);
 
     value = g_hash_table_lookup(hash, "stonith-watchdog-timeout");
-    crm_xml_add(data, F_LRMD_WATCHDOG, value);
+    if ((value) && (watchdog_fencing_enabled_for_node(native->remote_nodename))) {
+        crm_xml_add(data, F_LRMD_WATCHDOG, value);
+    }
 
     rc = lrmd_send_command(lrmd, LRMD_OP_CHECK, data, NULL, 0, 0, native->type == CRM_CLIENT_IPC ? TRUE : FALSE);
     free_xml(data);

--- a/lrmd/lrmd.c
+++ b/lrmd/lrmd.c
@@ -1686,6 +1686,7 @@ process_lrmd_message(crm_client_t * client, uint32_t id, xmlNode * request)
         xmlNode *data = get_message_xml(request, F_LRMD_CALLDATA); 
         const char *timeout = crm_element_value(data, F_LRMD_WATCHDOG);
         CRM_LOG_ASSERT(data != NULL);
+        crm_trace("Checking sbd-timeout %s.", timeout);
         check_sbd_timeout(timeout);
     } else if (crm_str_eq(op, LRMD_OP_ALERT_EXEC, TRUE)) {
         rc = process_lrmd_alert_exec(client, id, request);

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -614,6 +614,7 @@ exit 0
 %if %{with cman}
 %{_sbindir}/fence_pcmk
 %endif
+%{_sbindir}/fence_watchdog
 %{_sbindir}/stonith_admin
 
 %doc %{_mandir}/man7/crmd.*
@@ -631,6 +632,7 @@ exit 0
 %doc %{_mandir}/man8/fence_pcmk.*
 %endif
 %doc %{_mandir}/man8/fence_legacy.*
+%doc %{_mandir}/man8/fence_watchdog.*
 %doc %{_mandir}/man8/pacemakerd.*
 %doc %{_mandir}/man8/stonith_admin.*
 
@@ -715,6 +717,7 @@ exit 0
 %exclude %{_mandir}/man8/crm_master.*
 %exclude %{_mandir}/man8/fence_pcmk.*
 %exclude %{_mandir}/man8/fence_legacy.*
+%exclude %{_mandir}/man8/fence_watchdog.*
 %exclude %{_mandir}/man8/pacemakerd.*
 %exclude %{_mandir}/man8/pacemaker_remoted.*
 %exclude %{_mandir}/man8/stonith_admin.*


### PR DESCRIPTION
Still needs some cleanup:
- checking in how far it would fit 2.0
- verify moving of utility functions to libraries
- simplify/cleanup /usr/sbin/fence_watchdog to better serve its purpose
  as just a dummy to satisfy pcs and a generator for a man-page
- check if extra conditions for watchdog-fall-through removed made
  sense in scenarios with levels or if they are some form of bug/regression
  (scenario with disabled fencing-devices on levels definitely leads to
  watchdog-fall-through not working)
- I've discovered racy behavior when cib is altered and stonithd reconstructs
  it's device-list and at the same time a query for the watchdog-list comes in.
  That has to be checked - might be an issue with other operations as well.
   And atm the sbd-timeout-check upon crmd comming up is racy probably
   as well.
   Guess a solution for both issues would be to queue API-calls until the
   device-list has reached a stable state.

Nowadays watchdog-fencing is enabled by setting stonith-watchdog-timeout.
Unfortunately that enables watchdog-fencing for all nodes at once.
This might be undesirable in a variety of scenarios:

- for certain nodes there are other fencing-devices and we don't want
  them to fall-through to watchdog-fencing when they fail but we'd rather 
  have a retry
- certain nodes just don't have a proper watchdog-device which disqualifies
  them for watchdog fencing
- on remote-nodes watchdog-fencing has some issues so it might be
  desirable to fence them diffently

Basic idea:

- without additional configuration but just stonith-watchdog-timeout set we
  want unchanged behavior
- when a watchdog-device is explicitly configured pcmk_host_list should
  be usable as a way to configure which nodes should be fencable via
  watchdog-fencing
  e.g.: pcs stonith create watchdog fence_watchdog pcmk_host_list="node2 node3"

As the watchdog device locally registered with stonithd is just does
self-fencing this isn't as straight-forward as it seems in the first place.
Even with a host-list watchdog-fence-devices are still registered solely
for self-fencing with stonithd. The list of fencable nodes is kept in
a global list within stonithd. When needed from other pacemaker-daemons
(namely crmd when it checks stonith-watchdog-timeout against sbd-settings
or sends the watchdog-config to remote-nodes for them
to verify if sbd is setup properly) it can be queried using the existent
stonith-API query-function. This has the nice side-effect that issuing
a 'stonith_admin -s watchdog' gives the list of fencable devices. 