### PR TITLE
Low: alerts: Changing the default format.

### DIFF
--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -26,7 +26,7 @@
 #  define CRM_ALERT_DEFAULT_TIMEOUT_MS (30000)
 
 /* Default-Format-String used to pass timestamps to the alerts scripts */
-#  define CRM_ALERT_DEFAULT_TSTAMP_FORMAT "%H:%M:%S.%06N"
+#  define CRM_ALERT_DEFAULT_TSTAMP_FORMAT "%Y-%m-%d,%H:%M:%S.%01N"
 
 typedef struct {
     char *name;


### PR DESCRIPTION
Hi All,

When using the snmp trap script with the Alert function, it is very difficult for the user to specify the timestamp-format freely.

This is a limitation of the "DateAndTime" format of net-snmp.
 - http://www.net-snmp.org/docs/mibs/host.html#DateAndTime


Most users get confused with format specifications.

If possible, I would like to change the default format created by Pacemaker to SNMP trap side.

```
@include/crm/common/alert_internal.h
(snip)
/* Default-Format-String used to pass timestamps to the alerts scripts */
#  define CRM_ALERT_DEFAULT_TSTAMP_FORMAT "%H:%M:%S.%06N"
(snip)
```

Of course, I understand that it affects users already using the Alert function.

How about this change?

If it seems difficult to accept this change, we will consider other ways.

Best Regards,
Hideo Yamauchi.