### PR TITLE
Low: alerts: Add default format to SNMP Alert timestamp.

### DIFF
--- a/extra/alerts/alert_snmp.sh.sample
+++ b/extra/alerts/alert_snmp.sh.sample
@@ -92,7 +92,7 @@ trap_snmp_persistent_dir_default="/var/lib/pacemaker/snmp"
 : ${trap_snmp_persistent_dir=${trap_snmp_persistent_dir_default}}
 
 if [ "${trap_add_hires_timestamp_oid}" = "true" ]; then
-    hires_timestamp="HOST-RESOURCES-MIB::hrSystemDate s ${CRM_alert_timestamp}"
+    hires_timestamp="HOST-RESOURCES-MIB::hrSystemDate s ${CRM_alert_timestamp_snmp}"
 fi
 
 is_in_list() {

--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -27,6 +27,8 @@
 
 /* Default-Format-String used to pass timestamps to the alerts scripts */
 #  define CRM_ALERT_DEFAULT_TSTAMP_FORMAT "%H:%M:%S.%06N"
+/* Default-Format-String used to pass timestamps to the alerts scripts.(snmp) */
+#  define CRM_ALERT_DEFAULT_TSTAMP_FORMAT_SNMP "%Y-%m-%d,%H:%M:%S.%01N"
 
 typedef struct {
     char *name;
@@ -70,11 +72,12 @@ enum crm_alert_keys_e {
     CRM_alert_timestamp,
     CRM_alert_attribute_name,
     CRM_alert_attribute_value,
+    CRM_alert_timestamp_snmp,
     CRM_alert_select_kind,
     CRM_alert_select_attribute_name
 };
 
-#define CRM_ALERT_INTERNAL_KEY_MAX 16
+#define CRM_ALERT_INTERNAL_KEY_MAX 17
 #define CRM_ALERT_NODE_SEQUENCE "CRM_alert_node_sequence"
 
 extern const char *crm_alert_keys[CRM_ALERT_INTERNAL_KEY_MAX][3];

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -44,7 +44,8 @@ const char *crm_alert_keys[CRM_ALERT_INTERNAL_KEY_MAX][3] =
     [CRM_alert_node_sequence] = {"CRM_notify_node_sequence", CRM_ALERT_NODE_SEQUENCE, NULL},		
     [CRM_alert_timestamp]     = {"CRM_notify_timestamp",     "CRM_alert_timestamp",     NULL},
     [CRM_alert_attribute_name]     = {"CRM_notify_attribute_name",     "CRM_alert_attribute_name",     NULL},
-    [CRM_alert_attribute_value]     = {"CRM_notify_attribute_value",     "CRM_alert_attribute_value",     NULL}
+    [CRM_alert_attribute_value]     = {"CRM_notify_attribute_value",     "CRM_alert_attribute_value",     NULL},
+    [CRM_alert_timestamp_snmp]     = {"CRM_notify_timestamp_snmp",     "CRM_alert_timestamp_snmp",     NULL}
 };
 
 void

--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -169,12 +169,25 @@ exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum crm_alert_flags kind,
                                       entry->recipient);
 
         if (now) {
-            char *timestamp = crm_time_format_hr(entry->tstamp_format, now);
+            char *timestamp = crm_time_format_hr(entry->tstamp_format == NULL ? CRM_ALERT_DEFAULT_TSTAMP_FORMAT : entry->tstamp_format, now);
+            char *timestamp_snmp = NULL;
+
+            if (entry->tstamp_format == NULL) {
+                timestamp_snmp = crm_time_format_hr(CRM_ALERT_DEFAULT_TSTAMP_FORMAT_SNMP, now); 
+            } else if (timestamp != NULL) {
+                timestamp_snmp = strdup(timestamp);
+            }
 
             if (timestamp) {
                 copy_params = alert_key2param(copy_params, CRM_alert_timestamp,
                                               timestamp);
                 free(timestamp);
+            }
+
+            if (timestamp_snmp) {
+                copy_params = alert_key2param(copy_params, CRM_alert_timestamp_snmp,
+                                              timestamp_snmp);
+                free(timestamp_snmp);
             }
         }
 

--- a/lib/pengine/rules_alerts.c
+++ b/lib/pengine/rules_alerts.c
@@ -201,10 +201,6 @@ pe_unpack_alerts(xmlNode *alerts)
 
         unpack_alert(alert, entry, &max_timeout);
 
-        if (entry->tstamp_format == NULL) {
-            entry->tstamp_format = strdup(CRM_ALERT_DEFAULT_TSTAMP_FORMAT);
-        }
-
         crm_debug("Alert %s: path=%s timeout=%dms tstamp-format='%s' %u vars",
                   entry->id, entry->path, entry->timeout, entry->tstamp_format,
                   (entry->envvars? g_hash_table_size(entry->envvars) : 0));


### PR DESCRIPTION
Hi All,

It is very difficult to specify the date and time format when the user uses snmp Alert.
I added a default format, and date and time variable for snmp's Alert.

Users no longer need to specify timestamp-format.
```
alert alert_1 /usr/share/pacemaker/alerts/alert_snmp_xxxx.sh \
     attributes \
         trap_add_hires_timestamp_oid="true" \                                                                                                                                                                     
         trap_resource_tasks="start,stop,monitor,promote,demote" \
     to 192.168.xxx.xxx
```

Of course, the user can specify timestamp-format according to the SNMP Date-and-Time format.
In order to use this new change, it is necessary to replace the snmp sample script.

This change has no effect when using other Alerts.

Best Regards,
Hideo Yamauchi.