### PR TITLE
Build: spec: Make sure shadow package is installed before adding user and group

### DIFF
--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -273,7 +273,7 @@ be part of the cluster.
 License:       GPLv2+ and LGPLv2+
 Summary:       Core Pacemaker libraries
 Group:         System Environment/Daemons
-Requires:      shadow-utils
+Requires(pre): shadow-utils
 
 %description -n %{name}-libs
 Pacemaker is an advanced, scalable High-Availability cluster resource


### PR DESCRIPTION
Only a PreReq can be guaranteed to be installed before the dependent package.