### PR TITLE
Fix: pengine: "symmetrical" defaults to "false" for serialize orders

### DIFF
--- a/doc/Pacemaker_Explained/en-US/Ch-Constraints.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Constraints.txt
@@ -308,9 +308,10 @@ indexterm:[kind,Ordering Constraints]
 indexterm:[Constraints,Ordering,kind]
 
 |symmetrical
-|TRUE
+|TRUE for +Mandatory+ and +Optional+ kinds. FALSE for +Serialize+ kind.
 |If true, the reverse of the constraint applies for the opposite action (for
  example, if B starts after A starts, then B stops before A stops).
+ +Serialize+ orders cannot be symmetrical.
 indexterm:[symmetrical,Ordering Constraints]
 indexterm:[Ordering Constraints,symmetrical]
 

--- a/pengine/constraints.c
+++ b/pengine/constraints.c
@@ -269,19 +269,22 @@ unpack_simple_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
     const char *instance_then = NULL;
     const char *instance_first = NULL;
 
-    const char *id = crm_element_value(xml_obj, XML_ATTR_ID);
-    const char *invert = crm_element_value(xml_obj, XML_CONS_ATTR_SYMMETRICAL);
-
-    crm_str_to_boolean(invert, &invert_bool);
+    const char *id = NULL;
+    const char *invert = NULL;
 
     if (xml_obj == NULL) {
         crm_config_err("No constraint object to process.");
         return FALSE;
+    }
 
-    } else if (id == NULL) {
+    id = crm_element_value(xml_obj, XML_ATTR_ID);
+    if (id == NULL) {
         crm_config_err("%s constraint must have an id", crm_element_name(xml_obj));
         return FALSE;
     }
+
+    invert = crm_element_value(xml_obj, XML_CONS_ATTR_SYMMETRICAL);
+    crm_str_to_boolean(invert, &invert_bool);
 
     id_then = crm_element_value(xml_obj, XML_ORDER_ATTR_THEN);
     id_first = crm_element_value(xml_obj, XML_ORDER_ATTR_FIRST);

--- a/xml/constraints-3.0.rng
+++ b/xml/constraints-3.0.rng
@@ -88,7 +88,12 @@
             </attribute>
           </optional>
           <optional>
-            <externalRef href="score.rng"/>
+            <choice>
+              <externalRef href="score.rng"/>
+              <attribute name="kind">
+                <ref name="order-types"/>
+              </attribute>
+             </choice>
           </optional>
           <oneOrMore>
             <element name="resource_ref">


### PR DESCRIPTION
Practically it has already been the case. But previously it would
complain if "symmetrical" was not explicitly configured for serialize
orders with resource sets:
```
Cannot invert serialized constraint set ...
```

This commit officially makes "symmetrical" default to "false" for
serialize orders and documents it.

Other fixes:

- A resource_set can have a "score" but no "kind".
- Potential use-of-NULL in unpack_simple_rsc_order().