### PR TITLE
Mid: alerts: Change timestamp of Alert of snmp.

### DIFF
--- a/extra/alerts/alert_snmp.sh.sample
+++ b/extra/alerts/alert_snmp.sh.sample
@@ -92,7 +92,18 @@ trap_snmp_persistent_dir_default="/var/lib/pacemaker/snmp"
 : ${trap_snmp_persistent_dir=${trap_snmp_persistent_dir_default}}
 
 if [ "${trap_add_hires_timestamp_oid}" = "true" ]; then
-    hires_timestamp="HOST-RESOURCES-MIB::hrSystemDate s ${CRM_alert_timestamp}"
+# 
+# Then disable the set of hires_timestamp using the next CRM_alert_timestamp_epoch.
+# According to the format of DateAndTime of SNMP, hires_timestamp can be changed by script.
+# The current format is "%Y-%m-%d,%H:%M:%S.%01N".
+#
+    trap_fmt_timestamp=`date --date="@${CRM_alert_timestamp_epoch}" +"%Y-%m-%d,%H:%M:%S."`$(echo ${CRM_alert_timestamp_ns} | cut -b 1)
+    hires_timestamp="HOST-RESOURCES-MIB::hrSystemDate s ${trap_fmt_timestamp}"
+#
+# If you want an old style format specification, please remove the following comment.
+#
+#    hires_timestamp="HOST-RESOURCES-MIB::hrSystemDate s ${CRM_alert_timestamp}"
+# 
 fi
 
 is_in_list() {

--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -70,11 +70,13 @@ enum crm_alert_keys_e {
     CRM_alert_timestamp,
     CRM_alert_attribute_name,
     CRM_alert_attribute_value,
+    CRM_alert_timestamp_epoch,
+    CRM_alert_timestamp_ns,
     CRM_alert_select_kind,
     CRM_alert_select_attribute_name
 };
 
-#define CRM_ALERT_INTERNAL_KEY_MAX 16
+#define CRM_ALERT_INTERNAL_KEY_MAX 18
 #define CRM_ALERT_NODE_SEQUENCE "CRM_alert_node_sequence"
 
 extern const char *crm_alert_keys[CRM_ALERT_INTERNAL_KEY_MAX][3];

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -44,7 +44,9 @@ const char *crm_alert_keys[CRM_ALERT_INTERNAL_KEY_MAX][3] =
     [CRM_alert_node_sequence] = {"CRM_notify_node_sequence", CRM_ALERT_NODE_SEQUENCE, NULL},		
     [CRM_alert_timestamp]     = {"CRM_notify_timestamp",     "CRM_alert_timestamp",     NULL},
     [CRM_alert_attribute_name]     = {"CRM_notify_attribute_name",     "CRM_alert_attribute_name",     NULL},
-    [CRM_alert_attribute_value]     = {"CRM_notify_attribute_value",     "CRM_alert_attribute_value",     NULL}
+    [CRM_alert_attribute_value]     = {"CRM_notify_attribute_value",     "CRM_alert_attribute_value",     NULL},
+    [CRM_alert_timestamp_epoch]     = {"CRM_notify_timestamp_epoch",     "CRM_alert_timestamp_epoch",     NULL},
+    [CRM_alert_timestamp_ns]     = {"CRM_notify_timestamp_ns",     "CRM_alert_timestamp_ns",     NULL}
 };
 
 void

--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -130,6 +130,9 @@ exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum crm_alert_flags kind,
     bool any_success = FALSE, any_failure = FALSE;
     const char *kind_s = crm_alert_flag2text(kind);
     crm_time_hr_t *now = NULL;
+    crm_time_t *dt = crm_time_new(NULL);
+    char *timestamp_epoch = calloc(1, 34);
+    char *timestamp_nanos = calloc(1, 14);
 
     params = alert_key2param(params, CRM_alert_kind, kind_s);
     params = alert_key2param(params, CRM_alert_version, VERSION);
@@ -176,6 +179,12 @@ exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum crm_alert_flags kind,
                                               timestamp);
                 free(timestamp);
             }
+
+            crm_time_set_hr_dt(dt, now);
+            snprintf(timestamp_epoch, 32, "%lld", crm_time_get_seconds_since_epoch(dt));
+            copy_params = alert_key2param(copy_params, CRM_alert_timestamp_epoch, timestamp_epoch);
+            snprintf(timestamp_nanos, 12, "%06d000", now->useconds);
+            copy_params = alert_key2param(copy_params, CRM_alert_timestamp_ns, timestamp_nanos);
         }
 
         copy_params = alert_envvar2params(copy_params, entry);
@@ -193,6 +202,18 @@ exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum crm_alert_flags kind,
 
     if (now) {
         free(now);
+    }
+
+    if (dt) { 
+        free(dt);
+    }
+
+    if (timestamp_epoch) {
+        free(timestamp_epoch);
+    }
+    
+    if (timestamp_nanos) {
+        free(timestamp_nanos);
     }
 
     if (any_failure) {


### PR DESCRIPTION
Hi All,

Specifying timestamp-format for SNMP's Alert script is very difficult. This depends on the format of DateAndTime of SNMP.

Add EPOCH time and nanoseconds to the new Alert variable.
 - CRM_alert_timestamp_epoch
 - CRM_alert_timestamp_ns

Then move the format and generation of hires_timestamp to the script side.
It generates with new EPOCH time and nanosecond data.

With this fix, hires_timestamp of the SNMP Alert script needs to be formatted in the script, but timestamp-format specification is unnecessary.

```
(snip)
alert alert_1 /usr/share/pacemaker/alerts/alert_snmp.sh \
     attributes \
         trap_add_hires_timestamp_oid="true" \
         trap_resource_tasks="start,stop,monitor,promote,demote" \
     to 192.168.40.1
(snip)
```

This PR was previously discussed at the next PR.
 -  https://github.com/ClusterLabs/pacemaker/pull/1437

Best Regards,
Hideo Yamauchi.