### PR TITLE
Mid: bundle: Added add-host option.

### DIFF
--- a/lib/pengine/container.c
+++ b/lib/pengine/container.c
@@ -78,6 +78,9 @@ allocate_ip(container_variant_data_t *data, container_grouping_t *tuple, char *b
                     data->prefix, tuple->offset, data->prefix, tuple->offset);
 #else
     if (data->type == PE_CONTAINER_TYPE_DOCKER) {
+        if (!crm_is_true(data->add_host)) {
+            return 0;
+        }
         return snprintf(buffer, max, " --add-host=%s-%d:%s",
                         data->prefix, tuple->offset, tuple->ipaddr);
     } else if (data->type == PE_CONTAINER_TYPE_RKT) {
@@ -904,6 +907,10 @@ container_unpack(resource_t * rsc, pe_working_set_t * data_set)
         container_data->host_netmask = crm_element_value_copy(xml_obj, "host-netmask");
         container_data->host_network = crm_element_value_copy(xml_obj, "host-interface");
         container_data->control_port = crm_element_value_copy(xml_obj, "control-port");
+        container_data->add_host = crm_element_value_copy(xml_obj, "add-host");
+        if (container_data->add_host == NULL) {
+            container_data->add_host = strdup("true");
+        }
 
         for (xmlNode *xml_child = __xml_first_child_element(xml_obj); xml_child != NULL;
              xml_child = __xml_next_element(xml_child)) {
@@ -1417,6 +1424,7 @@ container_free(resource_t * rsc)
     free(container_data->host_network);
     free(container_data->host_netmask);
     free(container_data->ip_range_start);
+    free(container_data->add_host);
     free(container_data->docker_network);
     free(container_data->docker_run_options);
     free(container_data->docker_run_command);

--- a/lib/pengine/variant.h
+++ b/lib/pengine/variant.h
@@ -104,6 +104,7 @@ typedef struct container_variant_data_s {
         char *control_port;
         char *docker_network;
         char *ip_range_start;
+        char *add_host;
         char *docker_host_options;
         char *docker_run_options;
         char *docker_run_command;

--- a/xml/resources-3.0.rng
+++ b/xml/resources-3.0.rng
@@ -137,6 +137,9 @@
             <optional>
               <attribute name="host-netmask"><data type="integer"/></attribute>
             </optional>
+            <optional>
+              <attribute name="add-host"><data type="boolean"/></attribute>
+            </optional>
             <zeroOrMore>
               <element name="port-mapping">
                 <attribute name="id"><data type="ID"/></attribute>


### PR DESCRIPTION
Hi All,

When using a bundle in an environment constructed by combining containers with etcd and docker (overlay network) etc, the add-host option may be unnecessary in some cases.

In the following example, the network parameter "bundle" is the network created by "docker network create -d overlay bundle".
```
(snip)
      <bundle id="httpd-bundle">
        <docker image="pcmktest:http" replicas="2" replicas-per-host="2" network="bundle" options="--log-driver=journald"/>
        <network add-host="false" ip-range-start="192.168.0.200" host-interface="ens3" host-netmask="24">
          <port-mapping id="httpd-port" port="80"/>
        </network>
 (snip)
     </bundle>
(snip)
```

This PR adds the add-host option to the network parameter of bundle and makes it select.

If this option is set to false, restarting unnecessary bundle containers is suppressed even if replicas is changed.

Best Regards,
Hideo Yamauchi.
