### PR TITLE
Log: establish correct character string literals also with qb_logt sink

### DIFF
--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -491,7 +491,7 @@ attrd_client_query(crm_client_t *client, uint32_t id, uint32_t flags, xmlNode *q
     /* Send the reply to the client */
     client->request_id = 0;
     if ((rc = crm_ipcs_send(client, id, reply, flags)) < 0) {
-        crm_err("Could not respond to query from %s: %s (%d)",
+        crm_err("Could not respond to query from %s: %s (%zd)",
                 origin, pcmk_strerror(-rc), -rc);
     }
     free_xml(reply);
@@ -1209,7 +1209,7 @@ write_attribute(attribute_t *a)
         if (peer->uuid == NULL) {
             a->unknown_peer_uuids = TRUE;
             crm_notice("Update %s[%s]=%s postponed: unknown peer UUID, will retry if UUID is learned",
-                       a->id, v->nodename, v->current, peer);
+                       a->id, v->nodename, v->current);
             continue;
         }
 

--- a/cib/notify.c
+++ b/cib/notify.c
@@ -151,7 +151,7 @@ cib_notify_send(xmlNode * xml)
         g_hash_table_foreach_remove(client_connections, cib_notify_send_one, &update);
 
     } else {
-        crm_notice("Notification failed: %s (%d)", pcmk_strerror(rc), rc);
+        crm_notice("Notification failed: %s (%zd)", pcmk_strerror(rc), rc);
     }
 
     if (iov) {

--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -2141,7 +2141,8 @@ stop_recurring_actions(gpointer key, gpointer value, gpointer user_data)
     struct recurring_op_s *op = (struct recurring_op_s *)value;
 
     if (op->interval_ms != 0) {
-        crm_info("Cancelling op %d for %s (%s)", op->call_id, op->rsc_id, key);
+        crm_info("Cancelling op %d for %s (%s)", op->call_id, op->rsc_id,
+                 (const char *) key);
         remove = !cancel_op(lrm_state, op->rsc_id, key, op->call_id, FALSE);
     }
 

--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -487,7 +487,7 @@ schedule_stonith_command(async_command_t * cmd, stonith_device_t * device)
         cmd->start_delay =
             ((delay_max != delay_base)?(rand() % (delay_max - delay_base)):0)
             + delay_base;
-        crm_notice("Delaying %s on %s for %lldms (timeout=%ds, base=%dms, "
+        crm_notice("Delaying %s on %s for %dms (timeout=%ds, base=%dms, "
                    "max=%dms)",
                     cmd->action, device->id, cmd->start_delay, cmd->timeout,
                     delay_base, delay_max);

--- a/fencing/remote.c
+++ b/fencing/remote.c
@@ -863,7 +863,7 @@ merge_duplicates(remote_fencing_op_t * op)
             continue;
 
         } else if(other->total_timeout > 0 && now > (other->total_timeout + other->created)) {
-            crm_info("Stonith action %s for node %s originating from %s@%s.%.8s is too old: %d vs. %d + %d",
+            crm_info("Stonith action %s for node %s originating from %s@%s.%.8s is too old: %ld vs. %ld + %d",
                      other->action, other->target, other->client_name, other->originator, other->id,
                      now, other->created, other->total_timeout);
             continue;
@@ -1487,7 +1487,7 @@ call_remote_stonith(remote_fencing_op_t * op, st_query_result_t * peer)
 
         } else {
             timeout_one = TIMEOUT_MULTIPLY_FACTOR * get_peer_timeout(op, peer);
-            crm_info("Requesting that '%s' perform op '%s %s' for %s (%ds, %ds)",
+            crm_info("Requesting that '%s' perform op '%s %s' for %s (%ds, %lds)",
                      peer->host, op->target, op->action, op->client_name, timeout_one, stonith_watchdog_timeout_ms);
             crm_xml_add(remote_op, F_STONITH_MODE, "smart");
 
@@ -1499,7 +1499,7 @@ call_remote_stonith(remote_fencing_op_t * op, st_query_result_t * peer)
         }
 
         if(stonith_watchdog_timeout_ms > 0 && device && safe_str_eq(device, "watchdog")) {
-            crm_notice("Waiting %ds for %s to self-fence (%s) for %s.%.8s (%p)",
+            crm_notice("Waiting %lds for %s to self-fence (%s) for %s.%.8s (%p)",
                        stonith_watchdog_timeout_ms/1000, op->target,
                        op->action, op->client_name, op->id, device);
             op->op_timer_one = g_timeout_add(stonith_watchdog_timeout_ms, remote_op_watchdog_done, op);
@@ -1508,7 +1508,7 @@ call_remote_stonith(remote_fencing_op_t * op, st_query_result_t * peer)
         } else if(stonith_watchdog_timeout_ms > 0
                   && safe_str_eq(peer->host, op->target)
                   && safe_str_neq(op->action, "on")) {
-            crm_notice("Waiting %ds for %s to self-fence (%s) for %s.%.8s (%p)",
+            crm_notice("Waiting %lds for %s to self-fence (%s) for %s.%.8s (%p)",
                        stonith_watchdog_timeout_ms/1000, op->target,
                        op->action, op->client_name, op->id, device);
             op->op_timer_one = g_timeout_add(stonith_watchdog_timeout_ms, remote_op_watchdog_done, op);
@@ -1551,7 +1551,7 @@ call_remote_stonith(remote_fencing_op_t * op, st_query_result_t * peer)
          * are available to execute the fencing operation. */
 
         if(stonith_watchdog_timeout_ms && (device == NULL || safe_str_eq(device, "watchdog"))) {
-            crm_notice("Waiting %ds for %s to self-fence (%s) for %s.%.8s (%p)",
+            crm_notice("Waiting %lds for %s to self-fence (%s) for %s.%.8s (%p)",
                      stonith_watchdog_timeout_ms/1000, op->target,
                      op->action, op->client_name, op->id, device);
 
@@ -1945,7 +1945,7 @@ process_remote_stonith_exec(xmlNode * msg)
     if (op->devices && device && safe_str_neq(op->devices->data, device)) {
         crm_err("Received outdated reply for device %s (instead of %s) to "
                 "fence (%s) %s. Operation already timed out at peer level.",
-                device, op->devices->data, op->action, op->target);
+                device, (const char *) op->devices->data, op->action, op->target);
         return rc;
     }
 

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -734,7 +734,7 @@ crm_ipcs_sendv(crm_client_t * c, struct iovec * iov, enum crm_ipc_flags flags)
 
         rc = qb_ipcs_response_sendv(c->ipcs, iov, 2);
         if (rc < header->qb.size) {
-            crm_notice("Response %d to %p[%d] (%u bytes) failed: %s (%d)",
+            crm_notice("Response %d to %p[%d] (%u bytes) failed: %s (%zd)",
                        header->qb.id, c->ipcs, c->pid, header->qb.size, pcmk_strerror(rc), rc);
 
         } else {
@@ -780,7 +780,7 @@ crm_ipcs_send(crm_client_t * c, uint32_t request, xmlNode * message,
 
     } else {
         free(iov);
-        crm_notice("Message to %p[%d] failed: %s (%d)",
+        crm_notice("Message to %p[%d] failed: %s (%zd)",
                    c->ipcs, c->pid, pcmk_strerror(rc), rc);
     }
 

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -118,7 +118,9 @@ crm_remote_header(crm_remote_t * remote)
 
         CRM_LOG_ASSERT(endian == ENDIAN_LOCAL);
         if(endian != ENDIAN_LOCAL) {
-            crm_err("Invalid message detected, endian mismatch: %lx is neither %lx nor the swab'd %lx",
+            /* XXX preprocessor conditionalizing based on, e.g., sizeof and/or
+                   inttypes.h/stdint.h to get character string literals fit */
+            crm_err("Invalid message detected, endian mismatch: %x is neither %x nor the swab'd %x",
                     ENDIAN_LOCAL, header->endian, endian);
             return NULL;
         }

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -2085,7 +2085,7 @@ xml_apply_patchset_v2(xmlNode *xml, xmlNode *patchset)
             }
 
             if(position != __xml_offset(match)) {
-                crm_err("Moved %s.%d to position %d instead of %d (%p)",
+                crm_err("Moved %s.%s to position %d instead of %d (%p)",
                         match->name, ID(match), __xml_offset(match), position, match->prev);
                 rc = -pcmk_err_diff_failed;
             }
@@ -2802,7 +2802,7 @@ stdin2xml(void)
         size_t next = XML_BUFFER_SIZE + data_length + 1;
 
         if(next <= 0) {
-            crm_err("Buffer size exceeded at: %l + %d", data_length, XML_BUFFER_SIZE);
+            crm_err("Buffer size exceeded at: %zu + %d", data_length, XML_BUFFER_SIZE);
             break;
         }
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -2287,8 +2287,8 @@ void pe_action_set_flag_reason(const char *function, long line,
     } else if(is_set(flags, pe_action_requires_any)) {
         change = "required";
     } else {
-        crm_err("Unknown flag change to %s by %s: 0x%.16x",
-                flags, action->uuid, (reason? reason->uuid : 0));
+        crm_err("Unknown flag change to %x by %s: 0x%s",
+                flags, action->uuid, (reason? reason->uuid : "0"));
     }
 
     if(unset) {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1001,7 +1001,8 @@ subtract_lists(GList *from, GList *items)
     for (item = items; item != NULL; item = item->next) {
         GList *candidate = NULL;
         for (candidate = from; candidate != NULL; candidate = candidate->next) {
-            crm_info("Comparing %s with %s", candidate->data, item->data);
+            crm_info("Comparing %s with %s", (const char *) candidate->data,
+                     (const char *) item->data);
             if(strcmp(candidate->data, item->data) == 0) {
                 result = g_list_remove(result, candidate->data);
                 break;
@@ -1590,7 +1591,7 @@ wait_till_stable(int timeout_ms, cib_t * cib)
         /* Abort if timeout is reached */
         time_diff = expire_time - time(NULL);
         if (time_diff > 0) {
-            crm_info("Waiting up to %d seconds for cluster actions to complete", time_diff);
+            crm_info("Waiting up to %ld seconds for cluster actions to complete", time_diff);
         } else {
             print_pending_actions(data_set.actions);
             cleanup_alloc_calculations(&data_set);


### PR DESCRIPTION
Immediate follow-up for 29618ef63 (observation of that issue provoked
this very catch-all iteration), and thematically for fc87717a9.

Note that as in the latter case, this discovery was also enabled with
a special instrumentation at the libqb's side, but this time around,
it wasn't so straightforward:
https://github.com/ClusterLabs/libqb/pull/306