### PR TITLE
Low: alerts: Delete redundant code.

### DIFF
--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -169,7 +169,6 @@ exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum crm_alert_flags kind,
         }
 
         if (now == NULL) {
-            now = crm_time_hr_new(NULL);
             if (gettimeofday(&tv_now, NULL) == 0) {
                 now = crm_time_timeval_hr_convert(NULL, &tv_now);
             }


### PR DESCRIPTION
Hi All,

I forgot to delete crm_time_hr_new () discussed in the next PR.
For redundant code, I will send PR of deletion.

 - https://github.com/ClusterLabs/pacemaker/pull/1442

```
(snip)
        if (now == NULL) {
// ----> In order not to take different time, replace crm_time_hr_new ().
            if (gettimeofday(&tv_now, NULL) == 0){
                now = crm_time_timeval_hr_convert(NULL, &tv_now);
            }
        }
(snip)

```

Best Regards,
Hideo Yamauchi.