### PR TITLE
Fix: libcrmcommon: warn instead of shutdown if stonith-watchdog-timeout is too short

### DIFF
--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -298,9 +298,8 @@ check_sbd_timeout(const char *value)
 
         if (st_timeout < sbd_timeout) {
             do_crm_log_always(LOG_EMERG,
-                              "Shutting down: stonith-watchdog-timeout (%s) too short (must be >%ldms)",
+                              "FIX CONFIGURATION: stonith-watchdog-timeout (%s) too short (must be >%ldms)",
                               value, sbd_timeout);
-            crm_exit(CRM_EX_FATAL);
             return FALSE;
         }
         crm_info("Watchdog configured with stonith-watchdog-timeout %s and SBD timeout %ldms",


### PR DESCRIPTION
It was probably too strict that it would shutdown cluster service if
stonith-watchdog-timeout was misconfigured to be too short. We should
give users the opportunity to correct their configuration.