### PR TITLE
Build: configure/spec surpriseless/overridable --with{,out}-gnutls-priorities handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -215,11 +215,10 @@ AC_ARG_WITH(cibsecrets,
     [ SUPPORT_CIBSECRETS=no ],
 )
 
+PCMK_GNUTLS_PRIORITIES="NORMAL"
 AC_ARG_WITH(gnutls-priorities,
     [  --with-gnutls-priorities  GnuTLS cipher priorities @<:@NORMAL@:>@ ],
-    [ PCMK_GNUTLS_PRIORITIES="$withval" ],
-    [ PCMK_GNUTLS_PRIORITIES="NORMAL" ],
-)
+    [ test x"$withval" = x"no" || PCMK_GNUTLS_PRIORITIES="$withval" ])
 
 INITDIR=""
 AC_ARG_WITH(initdir,
@@ -388,8 +387,12 @@ fi
 AC_DEFINE_UNQUOTED(CRM_BUNDLE_DIR,"$CRM_BUNDLE_DIR", Location for Pacemaker bundle logs)
 AC_SUBST(CRM_BUNDLE_DIR)
 
+
+if test x"${PCMK_GNUTLS_PRIORITIES}" = x""; then
+    AC_MSG_ERROR([Empty string not applicable with --with-gnutls-priorities])
+fi
 AC_DEFINE_UNQUOTED([PCMK_GNUTLS_PRIORITIES], ["$PCMK_GNUTLS_PRIORITIES"],
-		   [GnuTLS cipher priorities])
+                   [GnuTLS cipher priorities])
 
 for j in prefix exec_prefix bindir sbindir libexecdir datadir sysconfdir \
     sharedstatedir localstatedir libdir includedir oldincludedir infodir \

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -67,7 +67,9 @@
   } || %(test -f /usr/lib/os-release; test $? -ne 0; echo $?))
 
 %if 0%{?fedora} > 20 || 0%{?rhel} > 7
-%global gnutls_priorities @SYSTEM
+## Base GnuTLS cipher priorities (presumably only the initial, required keyword)
+## overridable with "rpmbuild --define 'pcmk_gnutls_priorities PRIORITY-SPEC'"
+%define gnutls_priorities %{?pcmk_gnutls_priorities}%{!?pcmk_gnutls_priorities:@SYSTEM}
 %endif
 
 # Python-related definitions


### PR DESCRIPTION
Avoiding evaluating underlying definition as "no" (will just fall
back to the designated default, instead), sticking with --without-brand
as a precedence.

Also an empty string propagated from there (--with-gnutls-priorities="")
would result in a run-time error:

  $ gnutls-cli -l --priority=":+DHE-PSK:+PSK"
  > Cipher suites for :+DHE-PSK:+PSK
  > Syntax error at: :+DHE-PSK:+PSK