### PR TITLE
Build: spec: add a simple retention of pre-existing log move targets

### DIFF
--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -477,7 +477,7 @@ done
 %systemd_preun pacemaker.service
 %else
 /sbin/service pacemaker stop >/dev/null 2>&1 || :
-if [ $1 -eq 0 ]; then
+if [ "$1" -eq 0 ]; then
     # Package removal, not upgrade
     /sbin/chkconfig --del pacemaker || :
 fi
@@ -515,7 +515,7 @@ fi
 %systemd_preun pacemaker_remote.service
 %else
 /sbin/service pacemaker_remote stop >/dev/null 2>&1 || :
-if [ $1 -eq 0 ]; then
+if [ "$1" -eq 0 ]; then
     # Package removal, not upgrade
     /sbin/chkconfig --del pacemaker_remote || :
 fi
@@ -528,7 +528,7 @@ fi
 # in the future if desired
 %systemd_postun_with_restart pacemaker_remote.service
 # Explicitly take care of removing the flag-file(s) upon final removal
-if [ $1 -eq 0 ] ; then
+if [ "$1" -eq 0 ] ; then
     rm -f %{_localstatedir}/lib/rpm-state/%{name}/restart_pacemaker_remote
 fi
 %endif
@@ -545,7 +545,7 @@ fi
 %if %{defined _unitdir}
 %systemd_post crm_mon.service
 %endif
-if [ "$1" = "2" ]; then
+if [ "$1" -eq 2 ]; then
     # Package upgrade, not initial install:
     # Move any pre-2.0 logs to new location to ensure they get rotated
     { mv -fbS.rpmsave %{_var}/log/pacemaker.log* %{_var}/log/pacemaker \

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -260,6 +260,7 @@ Summary:       Command line tools for controlling Pacemaker clusters
 Group:         System Environment/Daemons
 Requires:      %{name}-libs = %{version}-%{release}
 Requires:      perl-TimeDate
+Requires(post):coreutils
 
 %description cli
 Pacemaker is an advanced, scalable High-Availability cluster resource
@@ -547,7 +548,9 @@ fi
 if [ "$1" = "2" ]; then
     # Package upgrade, not initial install:
     # Move any pre-2.0 logs to new location to ensure they get rotated
-    mv -f %{_var}/log/pacemaker.log* %{_var}/log/pacemaker >/dev/null 2>/dev/null || :
+    { mv -fbS.rpmsave %{_var}/log/pacemaker.log* %{_var}/log/pacemaker \
+      || mv -f %{_var}/log/pacemaker.log* %{_var}/log/pacemaker
+    } >/dev/null 2>/dev/null || :
 fi
 
 %preun cli


### PR DESCRIPTION
Arranged using coreutils-compatible "mv" implementation, with a fallback
to unconditional clobbering of the pre-existing move targets (as it used
to be).  Presence of the pre-2.0 log files clashing with 2.0 defaults
is unlikely, but better to be safe (consider also 2.0 release candidates
up to and including -rc3).