### PR TITLE
[WIP][part 6] Prepare XSL template for 2-to-3 schema upgrade

### DIFF
--- a/xml/Readme.md
+++ b/xml/Readme.md
@@ -78,6 +78,16 @@ one and must be named `upgrade-${Xold}.${Yold}.xsl`.
 
 See `xml/upgrade-1.3.xsl` for an example.
 
+Since `xml/upgrade-2.10.xsl`, rather self-descriptive approach is taken,
+separating metadata of the replacements and other modifications to
+perform from the actual executive parts, which is leveraged, e.g., with
+the on-the-fly overview as obtained with `./regression.sh -X test2to3`.
+Also this was the first time particular key names of `nvpair`s,
+i.e. below the granularity of the schemas so far, received attention,
+and consequently, no longer expected names became systemically banned
+in the after-upgrade schemas, using `<except>` construct in the
+data type specification pertaining the affected XML path.
+
 ### General Procedure
 
 1. Copy the most recent version of `${base}-*.rng` to `${base}-${X}.${Y}.rng` 
@@ -93,6 +103,8 @@ See `xml/upgrade-1.3.xsl` for an example.
    `diff tools/regression.validity.{out,exp}` to ensure the changes look correct,
    `cp tools/regression.validity.{out,exp}` to update the expected output,
    then commit the change.
+1. Similarly, with the new major version `${X}`, it's advisable to refresh
+   scheduler tests at some point, see the instructions in `cts/README.md`.
 
 ## Using a New Schema
 

--- a/xml/regression.sh
+++ b/xml/regression.sh
@@ -25,7 +25,6 @@ _saxon_wrapper() {
 	{ saxon "-xsl:$1" "-s:$2" -versionmsg:off 2>&1 >&3 \
 	  | sed -e '/^Cannot find CatalogManager.properties$/d'; } 3>&- 3>&1 >&2
 }
-#_xalan_wrapper() { Xalan $2 $1; }
 XSLTPROCESSOR=${XSLTPROCESSOR:-xsltproc}
 test "${XSLTPROCESSOR}" != Xalan || XSLTPROCESSOR=_xalan_wrapper
 test "${XSLTPROCESSOR}" != saxon || XSLTPROCESSOR=_saxon_wrapper

--- a/xml/resources-3.0.rng
+++ b/xml/resources-3.0.rng
@@ -327,7 +327,8 @@
   </define>
 
   <!--
-   see above
+   see above and upgrade-2.10.xsl
+   - cibtr:table for="resources-operation-instance-attributes"
    NOTE: this is rather a grey area, but setting special parameters
          just for the particular operation is currently not customary,
          and unsupported by higher level tools, e.g. pcs:
@@ -339,6 +340,15 @@
       <data type="string">
         <except>
           <choice>
+            <value>interval-origin</value>
+            <value>start-delay</value>
+
+            <value>enabled</value>
+            <value>on-fail</value>
+            <value>record-pending</value>
+            <value>role</value>
+            <value>timeout</value>
+
             <value>requires</value>
           </choice>
         </except>

--- a/xml/resources-3.0.rng
+++ b/xml/resources-3.0.rng
@@ -326,6 +326,26 @@
     </attribute>
   </define>
 
+  <!--
+   see above
+   NOTE: this is rather a grey area, but setting special parameters
+         just for the particular operation is currently not customary,
+         and unsupported by higher level tools, e.g. pcs:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1469801
+         so take the liberty to exclude them for now
+   -->
+  <define name="op.instance_attributes.nvpair.name-unsupported">
+    <attribute name="name">
+      <data type="string">
+        <except>
+          <choice>
+            <value>requires</value>
+          </choice>
+        </except>
+      </data>
+    </attribute>
+  </define>
+
   <define name="element-resource-extra.op">
     <zeroOrMore>
       <choice>
@@ -339,7 +359,13 @@
           </grammar>
         </element>
         <element name="instance_attributes">
-          <externalRef href="nvset-3.0.rng"/>
+          <grammar>
+            <include href="nvset-3.0.rng">
+              <define name="element-nvset.name">
+                <parentRef name="op.instance_attributes.nvpair.name-unsupported"/>
+              </define>
+            </include>
+          </grammar>
         </element>
       </choice>
     </zeroOrMore>

--- a/xml/resources-3.0.rng
+++ b/xml/resources-3.0.rng
@@ -22,6 +22,25 @@
 
   <!--
    see upgrade-2.10.xsl
+   - cibtr:table for="resource-meta-attributes"
+   -->
+  <define name="primitive-template.meta_attributes.nvpair.name-unsupported">
+    <attribute name="name">
+      <data type="string">
+        <except>
+          <choice>
+            <value>isolation</value>
+            <value>isolation-host</value>
+            <value>isolation-instance</value>
+            <value>isolation-wrapper</value>
+          </choice>
+        </except>
+      </data>
+    </attribute>
+  </define>
+
+  <!--
+   see upgrade-2.10.xsl
    - cibtr:table for="resource-instance-attributes"
    -->
   <define name="primitive-template.instance_attributes.nvpair.name-unsupported">
@@ -46,7 +65,13 @@
     <zeroOrMore>
       <choice>
         <element name="meta_attributes">
-          <externalRef href="nvset-3.0.rng"/>
+          <grammar>
+            <include href="nvset-3.0.rng">
+              <define name="element-nvset.name">
+                <parentRef name="primitive-template.meta_attributes.nvpair.name-unsupported"/>
+              </define>
+            </include>
+          </grammar>
         </element>
         <element name="instance_attributes">
           <grammar>

--- a/xml/test-2/020-rsc-requires-inline.ref
+++ b/xml/test-2/020-rsc-requires-inline.ref
@@ -20,7 +20,9 @@
         <instance_attributes id="myAddr-params">
           <nvpair id="myAddr-ip" name="ip" value="192.0.2.10"/>
         </instance_attributes>
-      <meta_attributes id="_2TO3_myAddr-meta"><nvpair id="_2TO3_myAddr-start-meta-requires" name="requires" value="nothing"/></meta_attributes></primitive>
+      <meta_attributes id="_2TO3_myAddr-meta"><nvpair id="_2TO3_myAddr-start-meta-requires" name="requires" value="nothing"/>
+      </meta_attributes>
+      </primitive>
 
       <primitive id="myHttpd" class="ocf" provider="heartbeat" type="apache">
         <operations>

--- a/xml/test-2/021-rsc-requires-nvpair.ref
+++ b/xml/test-2/021-rsc-requires-nvpair.ref
@@ -23,7 +23,8 @@
                    transitively (unfencing/fencing/quorum)? -->
               
             <nvpair id="myAddr-start-requires" name="requires" value="nothing"/>
-            </meta_attributes></primitive>
+            </meta_attributes>
+            </primitive>
 
       <primitive id="myHttpd" class="ocf" provider="heartbeat" type="apache">
         <operations>

--- a/xml/test-2/024-rsc-requires-no-selfclash.ref
+++ b/xml/test-2/024-rsc-requires-no-selfclash.ref
@@ -48,7 +48,9 @@
         <instance_attributes id="myAddr2-params">
           <nvpair id="myAddr2-ip" name="ip" value="192.0.2.10"/>
         </instance_attributes>
-      <meta_attributes id="_2TO3_myAddr2-meta"><nvpair id="_2TO3_myAddr2-start-meta-requires" name="requires" value="nothing"/></meta_attributes></primitive>
+      <meta_attributes id="_2TO3_myAddr2-meta"><nvpair id="_2TO3_myAddr2-start-meta-requires" name="requires" value="nothing"/>
+      </meta_attributes>
+      </primitive>
 
       <!-- potential clash between multiple op[@name = 'start'
                                                or
@@ -72,7 +74,9 @@
             <!-- demote != promote -->
             <op id="stateful1-demote" interval="0" name="demote" timeout="40s"/>
           </operations>
-        <meta_attributes id="_2TO3_stateful1-meta"><nvpair id="_2TO3_stateful1-start-meta-requires" name="requires" value="fencing"/></meta_attributes></primitive>
+        <meta_attributes id="_2TO3_stateful1-meta"><nvpair id="_2TO3_stateful1-start-meta-requires" name="requires" value="fencing"/>
+        </meta_attributes>
+        </primitive>
       </clone>
 
       <!-- potential clash between multiple
@@ -101,7 +105,8 @@
         <meta_attributes id="_2TO3_stateful2-promote-meta3">
                 
               <nvpair id="stateful2-promote-requires3-1" name="requires" value="fencing"/>
-              </meta_attributes></primitive>
+              </meta_attributes>
+              </primitive>
       </clone>
 
     </resources>

--- a/xml/test-2/024-rsc-requires-no-selfclash.ref.err
+++ b/xml/test-2/024-rsc-requires-no-selfclash.ref.err
@@ -2,10 +2,10 @@ Resources-operation: myAddr1-start (rsc=myAddr1, meta=myAddr1-start-meta): movin
 Resources-operation: myAddr1-start (rsc=myAddr1): moving requires under meta_attributes as requires unless already defined there for matching start|promote
 Resources-operation: myAddr2-start (rsc=myAddr2, meta=myAddr2-start-meta): moving requires under meta_attributes as requires unless already defined there for matching start|promote
 Resources-operation: myAddr2-start (rsc=myAddr2): moving requires under meta_attributes as requires unless already defined there for matching start|promote
-Resources-operation: stateful1-promote (rsc=stateful1): moving requires under meta_attributes as requires unless already defined there for matching start|promote
-Resources-operation: stateful1-start (rsc=stateful1): moving requires under meta_attributes as requires unless already defined there for matching start|promote
 Resources-operation: stateful1-demote (rsc=stateful1, meta=stateful1-demote-meta): dropping requires
 Resources-operation: ... only start/promote operation taken into account
+Resources-operation: stateful1-promote (rsc=stateful1): moving requires under meta_attributes as requires unless already defined there for matching start|promote
+Resources-operation: stateful1-start (rsc=stateful1): moving requires under meta_attributes as requires unless already defined there for matching start|promote
 Resources-operation: stateful2-promote (rsc=stateful2, meta=stateful2-promote-meta1): moving requires under meta_attributes as requires unless already defined there for matching start|promote
 Resources-operation: stateful2-promote (rsc=stateful2, meta=stateful2-promote-meta1): moving requires under meta_attributes as requires unless already defined there for matching start|promote
 Resources-operation: stateful2-promote (rsc=stateful2, meta=stateful2-promote-meta2): moving requires under meta_attributes as requires unless already defined there for matching start|promote

--- a/xml/test-2/061-rsc-attrs-meta-exchange.ref
+++ b/xml/test-2/061-rsc-attrs-meta-exchange.ref
@@ -1,0 +1,27 @@
+<cib validate-with="pacemaker-3.0" admin_epoch="0" epoch="0" num_updates="0">
+  <configuration>
+    <crm_config/>
+    <nodes/>
+    <resources>
+
+      <primitive class="ocf" id="res1" provider="heartbeat" type="Dummy">
+        <operations>
+          <op id="res1-monitor-interval-60s" interval="60s" name="monitor"/>
+        </operations>
+        <meta_attributes id="res1-meta_attributes">
+          <nvpair id="res1-resource-failure-stickiness" name="migration-threshold" value="1"/>
+        </meta_attributes>
+      </primitive>
+
+      <primitive class="ocf" id="res2" provider="heartbeat" type="Dummy">
+        <operations>
+          <op id="res2-monitor-interval-60s" interval="60s" name="monitor"/>
+        </operations>
+        
+      </primitive>
+
+    </resources>
+    <constraints/>
+  </configuration>
+  <status/>
+</cib>

--- a/xml/test-2/061-rsc-attrs-meta-exchange.ref.err
+++ b/xml/test-2/061-rsc-attrs-meta-exchange.ref.err
@@ -1,0 +1,3 @@
+Resource meta_attributes: res1 (meta=res1-meta_attributes): renaming resource-failure-stickiness as migration-threshold, redefined as 1, for matching -INFINITY
+Resource meta_attributes: res2 (meta=res2-meta_attributes): dropping resource-failure-stickiness
+Resource meta_attributes: ... migration-threshold can be configured instead

--- a/xml/test-2/061-rsc-attrs-meta-exchange.xml
+++ b/xml/test-2/061-rsc-attrs-meta-exchange.xml
@@ -1,0 +1,29 @@
+<cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
+  <configuration>
+    <crm_config/>
+    <nodes/>
+    <resources>
+
+      <primitive class="ocf" id="res1" provider="heartbeat" type="Dummy">
+        <operations>
+          <op id="res1-monitor-interval-60s" interval="60s" name="monitor"/>
+        </operations>
+        <meta_attributes id="res1-meta_attributes">
+          <nvpair id="res1-resource-failure-stickiness" name="resource-failure-stickiness" value="-INFINITY"/>
+        </meta_attributes>
+      </primitive>
+
+      <primitive class="ocf" id="res2" provider="heartbeat" type="Dummy">
+        <operations>
+          <op id="res2-monitor-interval-60s" interval="60s" name="monitor"/>
+        </operations>
+        <meta_attributes id="res2-meta_attributes">
+          <nvpair id="res2-resource-failure-stickiness" name="resource-failure-stickiness" value="0"/>
+        </meta_attributes>
+      </primitive>
+
+    </resources>
+    <constraints/>
+  </configuration>
+  <status/>
+</cib>

--- a/xml/test-2/070-rsc-op-attrs-inst-requires-start.ref
+++ b/xml/test-2/070-rsc-op-attrs-inst-requires-start.ref
@@ -1,0 +1,48 @@
+<cib validate-with="pacemaker-3.0" admin_epoch="0" epoch="0" num_updates="0">
+  <configuration>
+    <crm_config/>
+    <nodes>
+
+      <node id="virt-063" uname="virt-063"/>
+      <node id="virt-064" uname="virt-064"/>
+      <node id="virt-069" uname="virt-069"/>
+
+    </nodes>
+    <resources>
+
+      <!-- borrowed from 021-rsc-requires-nvpair -->
+      <primitive id="myAddr" class="ocf" provider="heartbeat" type="IPaddr2">
+        <operations>
+          <op id="myAddr-monitor" name="monitor" interval="30s"/>
+          <op id="myAddr-start" name="start" interval="0" timeout="40s"/>
+        </operations>
+        <instance_attributes id="myAddr-params">
+          <nvpair id="myAddr-ip" name="ip" value="192.0.2.10"/>
+        </instance_attributes>
+      <meta_attributes id="_2TO3_myAddr-start-instanceparams">
+              <!-- relying on order (+ colocation) to guarantee "requires"
+                   transitively (unfencing/fencing/quorum)? -->
+              
+            <nvpair id="myAddr-start-requires" name="requires" value="nothing"/>
+            </meta_attributes>
+            </primitive>
+
+      <primitive id="myHttpd" class="ocf" provider="heartbeat" type="apache">
+        <operations>
+          <op id="myHttpd-monitor" name="monitor" interval="30s"/>
+        </operations>
+        <instance_attributes id="myHttpd-params">
+          <nvpair id="myHttpd-configfile" name="configfile" value="/etc/httpd/conf/httpd.conf"/>
+        </instance_attributes>
+      </primitive>
+
+    </resources>
+    <constraints>
+
+      <rsc_order id="order-addr-httpd" first="myAddr" then="myHttpd"/>
+      <rsc_colocation id="colocation-addr-httpd" rsc="myHttpd" with-rsc="myAddr" score="INFINITY"/>
+
+    </constraints>
+  </configuration>
+  <status/>
+</cib>

--- a/xml/test-2/070-rsc-op-attrs-inst-requires-start.ref.err
+++ b/xml/test-2/070-rsc-op-attrs-inst-requires-start.ref.err
@@ -1,0 +1,1 @@
+Resources-operation instance_attributes: myAddr-start (rsc=myAddr, meta=myAddr-start-instanceparams): moving requires under per-resource-meta_attributes as requires unless already defined there for matching start|promote

--- a/xml/test-2/070-rsc-op-attrs-inst-requires-start.xml
+++ b/xml/test-2/070-rsc-op-attrs-inst-requires-start.xml
@@ -1,0 +1,48 @@
+<cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
+  <configuration>
+    <crm_config/>
+    <nodes>
+
+      <node id="virt-063" uname="virt-063"/>
+      <node id="virt-064" uname="virt-064"/>
+      <node id="virt-069" uname="virt-069"/>
+
+    </nodes>
+    <resources>
+
+      <!-- borrowed from 021-rsc-requires-nvpair -->
+      <primitive id="myAddr" class="ocf" provider="heartbeat" type="IPaddr2">
+        <operations>
+          <op id="myAddr-monitor" name="monitor" interval="30s"/>
+          <op id="myAddr-start" name="start" interval="0" timeout="40s">
+            <instance_attributes id="myAddr-start-instanceparams">
+              <!-- relying on order (+ colocation) to guarantee "requires"
+                   transitively (unfencing/fencing/quorum)? -->
+              <nvpair id="myAddr-start-requires" name="requires" value="nothing"/>
+            </instance_attributes>
+          </op>
+        </operations>
+        <instance_attributes id="myAddr-params">
+          <nvpair id="myAddr-ip" name="ip" value="192.0.2.10"/>
+        </instance_attributes>
+      </primitive>
+
+      <primitive id="myHttpd" class="ocf" provider="heartbeat" type="apache">
+        <operations>
+          <op id="myHttpd-monitor" name="monitor" interval="30s"/>
+        </operations>
+        <instance_attributes id="myHttpd-params">
+          <nvpair id="myHttpd-configfile" name="configfile" value="/etc/httpd/conf/httpd.conf"/>
+        </instance_attributes>
+      </primitive>
+
+    </resources>
+    <constraints>
+
+      <rsc_order id="order-addr-httpd" first="myAddr" then="myHttpd"/>
+      <rsc_colocation id="colocation-addr-httpd" rsc="myHttpd" with-rsc="myAddr" score="INFINITY"/>
+
+    </constraints>
+  </configuration>
+  <status/>
+</cib>

--- a/xml/test-2/071-rsc-op-attrs-inst-requires-nonstart.ref
+++ b/xml/test-2/071-rsc-op-attrs-inst-requires-nonstart.ref
@@ -1,0 +1,42 @@
+<cib validate-with="pacemaker-3.0" admin_epoch="0" epoch="0" num_updates="0">
+  <configuration>
+    <crm_config/>
+    <nodes>
+
+      <node id="virt-063" uname="virt-063"/>
+      <node id="virt-064" uname="virt-064"/>
+      <node id="virt-069" uname="virt-069"/>
+
+    </nodes>
+    <resources>
+
+      <!-- borrowed from 021-rsc-requires-nvpair -->
+      <primitive id="myAddr" class="ocf" provider="heartbeat" type="IPaddr2">
+        <operations>
+          <op id="myAddr-monitor" name="monitor" interval="30s"/>
+          <op id="myAddr-stop" name="stop" interval="0" timeout="40s"/>
+        </operations>
+        <instance_attributes id="myAddr-params">
+          <nvpair id="myAddr-ip" name="ip" value="192.0.2.10"/>
+        </instance_attributes>
+      </primitive>
+
+      <primitive id="myHttpd" class="ocf" provider="heartbeat" type="apache">
+        <operations>
+          <op id="myHttpd-monitor" name="monitor" interval="30s"/>
+        </operations>
+        <instance_attributes id="myHttpd-params">
+          <nvpair id="myHttpd-configfile" name="configfile" value="/etc/httpd/conf/httpd.conf"/>
+        </instance_attributes>
+      </primitive>
+
+    </resources>
+    <constraints>
+
+      <rsc_order id="order-addr-httpd" first="myAddr" then="myHttpd"/>
+      <rsc_colocation id="colocation-addr-httpd" rsc="myHttpd" with-rsc="myAddr" score="INFINITY"/>
+
+    </constraints>
+  </configuration>
+  <status/>
+</cib>

--- a/xml/test-2/071-rsc-op-attrs-inst-requires-nonstart.ref.err
+++ b/xml/test-2/071-rsc-op-attrs-inst-requires-nonstart.ref.err
@@ -1,0 +1,2 @@
+Resources-operation instance_attributes: myAddr-stop (rsc=myAddr, meta=myAddr-stop-instanceparams): dropping requires
+Resources-operation instance_attributes: ... only start/promote operation taken into account

--- a/xml/test-2/071-rsc-op-attrs-inst-requires-nonstart.xml
+++ b/xml/test-2/071-rsc-op-attrs-inst-requires-nonstart.xml
@@ -1,0 +1,48 @@
+<cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
+  <configuration>
+    <crm_config/>
+    <nodes>
+
+      <node id="virt-063" uname="virt-063"/>
+      <node id="virt-064" uname="virt-064"/>
+      <node id="virt-069" uname="virt-069"/>
+
+    </nodes>
+    <resources>
+
+      <!-- borrowed from 021-rsc-requires-nvpair -->
+      <primitive id="myAddr" class="ocf" provider="heartbeat" type="IPaddr2">
+        <operations>
+          <op id="myAddr-monitor" name="monitor" interval="30s"/>
+          <op id="myAddr-stop" name="stop" interval="0" timeout="40s">
+            <instance_attributes id="myAddr-stop-instanceparams">
+              <!-- relying on order (+ colocation) to guarantee "requires"
+                   transitively (unfencing/fencing/quorum)? -->
+              <nvpair id="myAddr-stop-requires" name="requires" value="nothing"/>
+            </instance_attributes>
+          </op>
+        </operations>
+        <instance_attributes id="myAddr-params">
+          <nvpair id="myAddr-ip" name="ip" value="192.0.2.10"/>
+        </instance_attributes>
+      </primitive>
+
+      <primitive id="myHttpd" class="ocf" provider="heartbeat" type="apache">
+        <operations>
+          <op id="myHttpd-monitor" name="monitor" interval="30s"/>
+        </operations>
+        <instance_attributes id="myHttpd-params">
+          <nvpair id="myHttpd-configfile" name="configfile" value="/etc/httpd/conf/httpd.conf"/>
+        </instance_attributes>
+      </primitive>
+
+    </resources>
+    <constraints>
+
+      <rsc_order id="order-addr-httpd" first="myAddr" then="myHttpd"/>
+      <rsc_colocation id="colocation-addr-httpd" rsc="myHttpd" with-rsc="myAddr" score="INFINITY"/>
+
+    </constraints>
+  </configuration>
+  <status/>
+</cib>

--- a/xml/test-2/072-rsc-op-attrs-inst-requires-no-override.ref
+++ b/xml/test-2/072-rsc-op-attrs-inst-requires-no-override.ref
@@ -1,0 +1,54 @@
+<cib validate-with="pacemaker-3.0" admin_epoch="0" epoch="0" num_updates="0">
+  <configuration>
+    <crm_config/>
+    <nodes>
+
+      <node id="virt-063" uname="virt-063"/>
+      <node id="virt-064" uname="virt-064"/>
+      <node id="virt-069" uname="virt-069"/>
+
+    </nodes>
+    <resources>
+
+      <!-- possible override from op's instance attribute over
+           op attribute -->
+      <primitive id="myAddr" class="ocf" provider="heartbeat" type="IPaddr2">
+        <operations>
+          <op id="myAddr-monitor" name="monitor" interval="30s"/>
+          <op id="myAddr-start" name="start" interval="0" timeout="40s"/>
+        </operations>
+        <instance_attributes id="myAddr-params">
+          <nvpair id="myAddr-ip" name="ip" value="192.0.2.10"/>
+        </instance_attributes>
+      <meta_attributes id="_2TO3_myAddr-meta"><nvpair id="_2TO3_myAddr-start-meta-requires" name="requires" value="nothing"/>
+      </meta_attributes>
+      </primitive>
+
+      <!-- possible override from op's instance attribute over
+           op's meta-attribute -->
+      <clone id="master">
+        <meta_attributes id="master-meta">
+          <nvpair id="master-promotable" name="promotable" value="true"/>
+          <nvpair id="master-promoted-node-max" name="promoted-node-max" value="1"/>
+          <nvpair id="master-clone-max" name="clone-max" value="3"/>
+          <nvpair id="master-promoted-max" name="promoted-max" value="1"/>
+          <nvpair id="master-clone-node-max" name="clone-node-max" value="1"/>
+        </meta_attributes>
+        <primitive id="stateful" class="ocf" type="Stateful" provider="pacemaker">
+          <operations>
+            <op id="stateful-monitor-15s" interval="15s" name="monitor" timeout="60s"/>
+            <op id="stateful-monitor-16s" interval="16s" name="monitor" timeout="60s" role="Master"/>
+            <op id="stateful-promote" interval="0" name="promote" timeout="40s"/>
+          </operations>
+        <meta_attributes id="_2TO3_stateful-promote-meta">
+                
+              <nvpair id="stateful-promote-meta-requires" name="requires" value="nothing"/>
+              </meta_attributes>
+              </primitive>
+      </clone>
+
+    </resources>
+    <constraints/>
+  </configuration>
+  <status/>
+</cib>

--- a/xml/test-2/072-rsc-op-attrs-inst-requires-no-override.ref.err
+++ b/xml/test-2/072-rsc-op-attrs-inst-requires-no-override.ref.err
@@ -1,0 +1,4 @@
+Resources-operation instance_attributes: myAddr-start (rsc=myAddr, meta=myAddr-start-instance): moving requires under per-resource-meta_attributes as requires unless already defined there for matching start|promote
+Resources-operation: myAddr-start (rsc=myAddr): moving requires under meta_attributes as requires unless already defined there for matching start|promote
+Resources-operation: stateful-promote (rsc=stateful, meta=stateful-promote-meta): moving requires under meta_attributes as requires unless already defined there for matching start|promote
+Resources-operation instance_attributes: stateful-promote (rsc=stateful, meta=stateful-promote-instance): moving requires under per-resource-meta_attributes as requires unless already defined there for matching start|promote

--- a/xml/test-2/072-rsc-op-attrs-inst-requires-no-override.ref.err
+++ b/xml/test-2/072-rsc-op-attrs-inst-requires-no-override.ref.err
@@ -1,4 +1,4 @@
 Resources-operation instance_attributes: myAddr-start (rsc=myAddr, meta=myAddr-start-instance): moving requires under per-resource-meta_attributes as requires unless already defined there for matching start|promote
 Resources-operation: myAddr-start (rsc=myAddr): moving requires under meta_attributes as requires unless already defined there for matching start|promote
-Resources-operation: stateful-promote (rsc=stateful, meta=stateful-promote-meta): moving requires under meta_attributes as requires unless already defined there for matching start|promote
 Resources-operation instance_attributes: stateful-promote (rsc=stateful, meta=stateful-promote-instance): moving requires under per-resource-meta_attributes as requires unless already defined there for matching start|promote
+Resources-operation: stateful-promote (rsc=stateful, meta=stateful-promote-meta): moving requires under meta_attributes as requires unless already defined there for matching start|promote

--- a/xml/test-2/072-rsc-op-attrs-inst-requires-no-override.xml
+++ b/xml/test-2/072-rsc-op-attrs-inst-requires-no-override.xml
@@ -1,0 +1,60 @@
+<cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
+  <configuration>
+    <crm_config/>
+    <nodes>
+
+      <node id="virt-063" uname="virt-063"/>
+      <node id="virt-064" uname="virt-064"/>
+      <node id="virt-069" uname="virt-069"/>
+
+    </nodes>
+    <resources>
+
+      <!-- possible override from op's instance attribute over
+           op attribute -->
+      <primitive id="myAddr" class="ocf" provider="heartbeat" type="IPaddr2">
+        <operations>
+          <op id="myAddr-monitor" name="monitor" interval="30s"/>
+          <op id="myAddr-start" name="start" interval="0" timeout="40s"
+              requires="nothing">
+            <instance_attributes id="myAddr-start-instance">
+              <nvpair id="myAddr-start-instance-requires" name="requires" value="quorum"/>
+            </instance_attributes>
+          </op>
+        </operations>
+        <instance_attributes id="myAddr-params">
+          <nvpair id="myAddr-ip" name="ip" value="192.0.2.10"/>
+        </instance_attributes>
+      </primitive>
+
+      <!-- possible override from op's instance attribute over
+           op's meta-attribute -->
+      <clone id="master">
+        <meta_attributes id="master-meta">
+          <nvpair id="master-promotable" name="promotable" value="true"/>
+          <nvpair id="master-promoted-node-max" name="promoted-node-max" value="1"/>
+          <nvpair id="master-clone-max" name="clone-max" value="3"/>
+          <nvpair id="master-promoted-max" name="promoted-max" value="1"/>
+          <nvpair id="master-clone-node-max" name="clone-node-max" value="1"/>
+        </meta_attributes>
+        <primitive id="stateful" class="ocf" type="Stateful" provider="pacemaker">
+          <operations>
+            <op id="stateful-monitor-15s" interval="15s" name="monitor" timeout="60s"/>
+            <op id="stateful-monitor-16s" interval="16s" name="monitor" timeout="60s" role="Master"/>
+            <op id="stateful-promote" interval="0" name="promote" timeout="40s">
+              <meta_attributes id="stateful-promote-meta">
+                <nvpair id="stateful-promote-meta-requires" name="requires" value="nothing"/>
+              </meta_attributes>
+              <instance_attributes id="stateful-promote-instance">
+                <nvpair id="stateful-promote-instance-requires" name="requires" value="quorum"/>
+              </instance_attributes>
+            </op>
+          </operations>
+        </primitive>
+      </clone>
+
+    </resources>
+    <constraints/>
+  </configuration>
+  <status/>
+</cib>

--- a/xml/test-2/073-rsc-op-attrs-inst-meta-meaning.ref
+++ b/xml/test-2/073-rsc-op-attrs-inst-meta-meaning.ref
@@ -1,0 +1,51 @@
+<cib validate-with="pacemaker-3.0" admin_epoch="0" epoch="0" num_updates="0">
+  <configuration>
+    <crm_config/>
+    <nodes>
+
+      <node id="virt-063" uname="virt-063"/>
+      <node id="virt-064" uname="virt-064"/>
+      <node id="virt-069" uname="virt-069"/>
+
+    </nodes>
+    <resources>
+
+      <primitive id="myAddr" class="ocf" provider="heartbeat" type="IPaddr2">
+        <operations>
+          <op id="myAddr-monitor" name="monitor" interval="30s"/>
+          <op id="myAddr-start" name="start" interval="0" timeout="40s">
+            
+          <meta_attributes id="_2TO3_myAddr-start-meta">
+              <nvpair id="myAddr-start-instance-on-fail" name="on-fail" value="standby"/>
+              <nvpair id="myAddr-start-instance-record-pending" name="record-pending" value="true"/>
+          </meta_attributes>
+          </op>
+        </operations>
+        <instance_attributes id="myAddr-params">
+          <nvpair id="myAddr-ip" name="ip" value="192.0.2.10"/>
+        </instance_attributes>
+      </primitive>
+
+      <primitive id="myHttpd" class="ocf" provider="heartbeat" type="apache">
+        <operations>
+          <op id="myHttpd-monitor" name="monitor" interval="30s">
+            <instance_attributes id="myHttpd-monitor-instance">
+              <nvpair id="myHttpd-monitor-instance-statusurl" name="statusurl" value="http://localhost/server-status"/>
+            </instance_attributes>
+            
+          <meta_attributes id="_2TO3_myHttpd-monitor-meta">
+            
+              <nvpair id="myHttpd-monitor-instance2-timeout" name="timeout" value="30"/>
+          </meta_attributes>
+          </op>
+        </operations>
+        <instance_attributes id="myHttpd-params">
+          <nvpair id="myHttpd-configfile" name="configfile" value="/etc/httpd/conf/httpd.conf"/>
+        </instance_attributes>
+      </primitive>
+
+    </resources>
+    <constraints/>
+  </configuration>
+  <status/>
+</cib>

--- a/xml/test-2/073-rsc-op-attrs-inst-meta-meaning.ref.err
+++ b/xml/test-2/073-rsc-op-attrs-inst-meta-meaning.ref.err
@@ -1,0 +1,4 @@
+Resources-operation instance_attributes: myAddr-start (rsc=myAddr, meta=myAddr-start-instance): moving on-fail under meta_attributes as on-fail unless already defined there
+Resources-operation instance_attributes: myAddr-start (rsc=myAddr, meta=myAddr-start-instance): moving record-pending under meta_attributes as record-pending unless already defined there
+Resources-operation instance_attributes: myHttpd-monitor (rsc=myHttpd, meta=myHttpd-monitor-instance): moving timeout under meta_attributes as timeout unless already defined there
+Resources-operation instance_attributes: myHttpd-monitor (rsc=myHttpd, meta=myHttpd-monitor-instance2): moving timeout under meta_attributes as timeout unless already defined there

--- a/xml/test-2/073-rsc-op-attrs-inst-meta-meaning.xml
+++ b/xml/test-2/073-rsc-op-attrs-inst-meta-meaning.xml
@@ -1,0 +1,49 @@
+<cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
+  <configuration>
+    <crm_config/>
+    <nodes>
+
+      <node id="virt-063" uname="virt-063"/>
+      <node id="virt-064" uname="virt-064"/>
+      <node id="virt-069" uname="virt-069"/>
+
+    </nodes>
+    <resources>
+
+      <primitive id="myAddr" class="ocf" provider="heartbeat" type="IPaddr2">
+        <operations>
+          <op id="myAddr-monitor" name="monitor" interval="30s"/>
+          <op id="myAddr-start" name="start" interval="0" timeout="40s">
+            <instance_attributes id="myAddr-start-instance">
+              <nvpair id="myAddr-start-instance-on-fail" name="on-fail" value="standby"/>
+              <nvpair id="myAddr-start-instance-record-pending" name="record-pending" value="true"/>
+            </instance_attributes>
+          </op>
+        </operations>
+        <instance_attributes id="myAddr-params">
+          <nvpair id="myAddr-ip" name="ip" value="192.0.2.10"/>
+        </instance_attributes>
+      </primitive>
+
+      <primitive id="myHttpd" class="ocf" provider="heartbeat" type="apache">
+        <operations>
+          <op id="myHttpd-monitor" name="monitor" interval="30s">
+            <instance_attributes id="myHttpd-monitor-instance">
+              <nvpair id="myHttpd-monitor-instance-timeout" name="timeout" value="20"/>
+              <nvpair id="myHttpd-monitor-instance-statusurl" name="statusurl" value="http://localhost/server-status"/>
+            </instance_attributes>
+            <instance_attributes id="myHttpd-monitor-instance2">
+              <nvpair id="myHttpd-monitor-instance2-timeout" name="timeout" value="30"/>
+            </instance_attributes>
+          </op>
+        </operations>
+        <instance_attributes id="myHttpd-params">
+          <nvpair id="myHttpd-configfile" name="configfile" value="/etc/httpd/conf/httpd.conf"/>
+        </instance_attributes>
+      </primitive>
+
+    </resources>
+    <constraints/>
+  </configuration>
+  <status/>
+</cib>

--- a/xml/upgrade-2.10.xsl
+++ b/xml/upgrade-2.10.xsl
@@ -500,6 +500,15 @@
     no-denormalized-space is an internal criterium for the template)
     or, conventionally, the result tree fragment representing the
     output of the template at hand called with a simulation flag
+    * established signaling strings accompanying InnerSimulation=true:
+      - TRIGGER-MSG ... make the template execution emit messages
+                        describing changes being performed
+      - TRIGGER-RECURSION
+                    ... currently used in the oracle-like evaluation
+                        of what's the situation with the sibling
+                        elements as a recursion guard so that such
+                        nested runs won't revisit the new set of
+                        siblings per the respective nested context
 
  -->
 
@@ -579,9 +588,7 @@
                                   )
                                 )
                               ]"/>
-        <xsl:if test="$InverseMode = false()
-                      and
-                      $InnerSimulation">
+        <xsl:if test="$InnerPass = 'TRIGGER-MSG'">
           <xsl:call-template name="MapMsg">
             <xsl:with-param name="Context" select="@id"/>
             <xsl:with-param name="Replacement" select="$Replacement"/>
@@ -797,7 +804,7 @@
                                   )
                                 )
                               ]"/>
-        <xsl:if test="not($InnerSimulation)">
+        <xsl:if test="$InnerPass = 'TRIGGER-MSG'">
           <xsl:call-template name="MapMsg">
             <xsl:with-param name="Context" select="@id"/>
             <xsl:with-param name="Replacement" select="$Replacement"/>
@@ -939,7 +946,7 @@
                                   )
                                 )
                               ]"/>
-        <xsl:if test="not($InnerSimulation)">
+        <xsl:if test="$InnerPass = 'TRIGGER-MSG'">
           <xsl:call-template name="MapMsg">
             <xsl:with-param name="Context"
                             select="concat(../../@id,
@@ -1110,9 +1117,7 @@
                                   )
                                 )
                               ]"/>
-        <xsl:if test="not($InverseMode or $InnerSimulation)
-                      or
-                      $InnerPass = 'TRIGGER-MSG'">
+        <xsl:if test="$InnerPass = 'TRIGGER-MSG'">
           <xsl:call-template name="MapMsg">
             <xsl:with-param name="Context"
                             select="concat(../../@id,
@@ -1316,7 +1321,7 @@
                                 )
                               )
                             ]"/>
-      <xsl:if test="not($InverseMode or $InnerSimulation)">
+      <xsl:if test="$InnerPass = 'TRIGGER-MSG'">
         <xsl:call-template name="MapMsg">
           <xsl:with-param name="Context"
                                 select="concat(../@id,
@@ -1564,6 +1569,7 @@
         <xsl:with-param name="Source" select="$Source"/>
         <xsl:with-param name="InverseMode" select="$Variant"/>
         <xsl:with-param name="InnerSimulation" select="true()"/>
+        <xsl:with-param name="InnerPass" select="'TRIGGER-MSG'"/>
       </xsl:call-template>
     </xsl:variable>
     <xsl:if test="normalize-space($ProcessedPartial)
@@ -1600,6 +1606,7 @@
     <xsl:call-template name="ProcessClusterProperties">
       <xsl:with-param name="Source" select="."/>
       <xsl:with-param name="InnerSimulation" select="true()"/>
+      <xsl:with-param name="InnerPass" select="'TRIGGER-MSG'"/>
     </xsl:call-template>
   </xsl:variable>
   <xsl:if test="normalize-space($ProcessedClusterProperties)
@@ -1763,6 +1770,7 @@
             <xsl:call-template name="ProcessRscInstanceAttributes">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InnerSimulation" select="true()"/>
+              <xsl:with-param name="InnerPass" select="'TRIGGER-MSG'"/>
             </xsl:call-template>
           </xsl:variable>
           <!-- cf. trick A. -->
@@ -1783,6 +1791,7 @@
             <xsl:call-template name="ProcessRscMetaAttributes">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InnerSimulation" select="true()"/>
+              <xsl:with-param name="InnerPass" select="'TRIGGER-MSG'"/>
             </xsl:call-template>
           </xsl:variable>
           <!-- cf. trick A. -->
@@ -1814,6 +1823,7 @@
           <xsl:with-param name="Source" select="."/>
           <xsl:with-param name="InverseMode" select="true()"/>
           <xsl:with-param name="InnerSimulation" select="true()"/>
+          <xsl:with-param name="InnerPass" select="'TRIGGER-MSG'"/>
         </xsl:call-template>
       </xsl:for-each>
     </xsl:variable>

--- a/xml/upgrade-2.10.xsl
+++ b/xml/upgrade-2.10.xsl
@@ -183,6 +183,8 @@
    Selector ctxt:  N/A
    Move ctxt:      N/A
    Related commit: c713bbe39
+                   +
+                   6052ad6da
    -->
   <cibtr:table for="resource-meta-attributes" msg-prefix="Resource meta_attributes">
     <cibtr:replace what="isolation"
@@ -201,6 +203,21 @@
                    with="target-role"
                    redefined-as="Stopped"
                    msg-extra="i.e. resource at hand disabled; isolation wrappers obsoleted with bundle resources"/>
+
+    <cibtr:replace what="resource-failure-stickiness"
+                   with="migration-threshold"
+                   in-case-of="-INFINITY"
+                   redefined-as="1"/>
+    <cibtr:replace what="resource-failure-stickiness"
+                   with=""
+                   msg-extra="migration-threshold can be configured instead"/>
+    <cibtr:replace what="resource_failure_stickiness"
+                   with="migration-threshold"
+                   in-case-of="-INFINITY"
+                   redefined-as="1"/>
+    <cibtr:replace what="resource_failure_stickiness"
+                   with=""
+                   msg-extra="migration-threshold can be configured instead"/>
   </cibtr:table>
 
   <!--

--- a/xml/upgrade-2.10.xsl
+++ b/xml/upgrade-2.10.xsl
@@ -1377,9 +1377,6 @@
           </xsl:message>
         </xsl:when>
         <xsl:otherwise>
-          <!--xsl:attribute name="{name()}">
-            <xsl:value-of select="."/>
-          </xsl:attribute-->
           <xsl:copy/>
         </xsl:otherwise>
       </xsl:choose>
@@ -1389,9 +1386,7 @@
       <!-- B: special-casing meta_attributes -->
       <xsl:for-each select="$Source/node()">
         <xsl:choose>
-          <xsl:when test="self::text()
-                          and
-                          not($InverseMode)">
+          <xsl:when test="self::text()">
             <!-- cf. trick A. (consideration 1.) -->
             <xsl:choose>
               <xsl:when test="normalize-space($InnerPass)

--- a/xml/upgrade-2.10.xsl
+++ b/xml/upgrade-2.10.xsl
@@ -1815,7 +1815,9 @@
             <xsl:with-param name="InverseMode" select="true()"/>
           </xsl:call-template>
         </xsl:for-each>
+        <xsl:apply-templates select="text()[position() = last()]"/>
       </meta_attributes>
+      <xsl:apply-templates select="text()[position() = last()]"/>
     </xsl:if>
 
     <!-- ...directly by picking existing nvpairs of meta_attributes -->
@@ -1848,6 +1850,7 @@
           </xsl:call-template>
           <xsl:apply-templates select="text()[position() = last()]"/>
         </xsl:copy>
+        <xsl:apply-templates select="text()[position() = last()]"/>
       </xsl:if>
     </xsl:for-each>
   </xsl:copy>

--- a/xml/upgrade-2.10.xsl
+++ b/xml/upgrade-2.10.xsl
@@ -25,6 +25,16 @@
    Selector ctxt:  ./nvpair/@value
    Move ctxt:      op_defaults ~ /cib/configuration/op_defaults
                    rsc_defaults ~ /cib/configuration/rsc_defaults
+   Related commit: c1c66fe13
+                   +
+                   7a9891f29
+                   7d0d1b0eb
+                   1f643d610
+                   73a5d63a8
+                   +
+                   642a09b22
+                   0c03e366d
+                   a28a558f9
    -->
   <cibtr:table for="cluster-properties" msg-prefix="Cluster properties"
                where-cases="op_defaults|rsc_defaults">
@@ -123,6 +133,7 @@
    Object:         ./@*
    Selector ctxt:  ./@*
    Move ctxt:      N/A
+   Related commit: 55ab749bf
    -->
   <cibtr:table for="cluster-node" msg-prefix="Cluster node">
     <cibtr:replace what="type"
@@ -137,6 +148,9 @@
    Object:         ./instance_attributes/nvpair/@name
    Selector ctxt:  N/A
    Move ctxt:      N/A
+   Related commit: 06d4559cb
+                   +
+                   6c8e0be20
    -->
   <cibtr:table for="resource-instance-attributes" msg-prefix="Resource instance_attributes">
     <cibtr:replace what="pcmk_arg_map"
@@ -168,6 +182,7 @@
    Object:         ./meta_attributes/nvpair/@name
    Selector ctxt:  N/A
    Move ctxt:      N/A
+   Related commit: c713bbe39
    -->
   <cibtr:table for="resource-meta-attributes" msg-prefix="Resource meta_attributes">
     <cibtr:replace what="isolation"
@@ -195,6 +210,7 @@
                    ./operations/op/meta_attributes/nvpair/@name
    Selector ctxt:  ./operations/op/@name
    Move ctxt:      meta_attributes ~ ./meta_attributes/nvpair
+   Related commit: 014a543d5
    -->
   <cibtr:table for="resources-operation" msg-prefix="Resources-operation"
                where-cases="meta_attributes">
@@ -212,6 +228,7 @@
    Object:         ./@*
    Selector ctxt:  N/A
    Move ctxt:      N/A
+   Related commit: 96d7ffedf
    -->
   <cibtr:table for="constraints-colocation" msg-prefix="Constraints-colocation">
     <cibtr:replace what="score-attribute"


### PR DESCRIPTION
Pending:
- [x] dealing with operation meta_attributes that are misplaced as
  its instance_attributes
- [ ] check that we are not pruning some attributes' element in a way
  the referential integrity would break (currently may happen)
- [ ] possibly reconsider format of diagnostics
- [ ] create new `resources-3.1.rng` so as to introduced new, more relaxed
  version of the schema as a basis for 2.0 final release (details covered
  in `XML: upgrade-2.10.xsl: rsc op instance_attrs [1/2]: meta-like requires`
  commit
- [ ] ?