### PR TITLE
[intermezzo] Prepare XSL template for 2-to-3 schema upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ lib/gnu/stdalign.h
 /cts/test-suite.log
 /xml/test-2/*.up
 /xml/test-2/*.up.err
+/xml/assets/diffview.js
 
 # Formerly built files (helps when jumping back and forth in checkout)
 /attrd

--- a/xml/assets/upgrade-2.10-htmldiff.xsl
+++ b/xml/assets/upgrade-2.10-htmldiff.xsl
@@ -1,0 +1,351 @@
+<!--
+ Copyright 2018 Red Hat, Inc.
+ Author: Jan Pokorny <jpokorny@redhat.com>
+ Part of pacemaker project
+ SPDX-License-Identifier: GPL-2.0-or-later
+ -->
+<xsl:stylesheet version="1.0"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:cibtr="http://clusterlabs.org/ns/pacemaker/cibtr-2"
+                xmlns:exsl="http://exslt.org/common">
+<!-- NOTE: this is an exception from rule forbidding EXSLT's usage -->
+
+<xsl:include href="../upgrade-2.10.xsl"/>
+
+<!--
+ we are embedding files from 3rd party project so as to reproduce the content
+ of XML into HTML-formatted presentation form; alternatively:
+ * from mozilla/firefox:
+   - view-source.xsl by Keith Visco (example transformation for transformiix)
+     https://dxr.mozilla.org/mozilla/source/extensions/transformiix/source/examples
+   - XMLPrettyPrint.xsl by Jonas Sicking
+     https://dxr.mozilla.org/mozilla-central/source/dom/xml/resources
+     https://hg.mozilla.org/mozilla-central/file/9b2a99adc05e/content/xml/document/resources/XMLPrettyPrint.xsl
+     or possibly its readily sanitized version from rdf-viewer project
+     https://github.com/marianafranco/rdf-viewer
+ * custom stylesheet to be written
+ -->
+<xsl:param name="highlight-namespace" select="''"/>
+<!--
+<xsl:include href="https://raw.githubusercontent.com/Boldewyn/view-source/master/library.xsl"/>
+<xsl:include href="https://raw.githubusercontent.com/Boldewyn/view-source/master/original.xsl"/>
+ -->
+<xsl:include href="view-source-library.xsl"/>
+<xsl:include href="view-source-original.xsl"/>
+
+<xsl:output method="xml" encoding="UTF-8"
+            omit-xml-declaration="yes"
+            doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"
+            doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"/>
+
+<!-- B: identity mode -->
+<xsl:template match="@*|node()" mode="identity">
+  <xsl:copy>
+    <xsl:apply-templates select="@*|node()" mode="identity"/>
+  </xsl:copy>
+</xsl:template>
+
+<!-- used in test files to allow in-browser on-the-fly checking -->
+<xsl:template match="processing-instruction()[
+                       name() = 'xml-stylesheet'
+                       and
+                       count(..|/) = 1
+                     ]"
+              mode="identity"/>
+<!-- E: identity mode -->
+
+<xsl:template match="/">
+  <xsl:variable name="before-upgrade">
+    <xsl:apply-templates mode="identity"/>
+  </xsl:variable>
+
+  <xsl:variable name="after-upgrade">
+    <xsl:apply-templates mode="cibtr:main"/>
+  </xsl:variable>
+
+  <html>
+    <head>
+      <title>
+        <xsl:text>upgrade-2.10 on-the-fly in-browser transformation</xsl:text>
+      </title>
+      <style>
+        ol.count,.possibly-revealed { display: none; }
+        li.delete { color: red; }
+        li.delete em { background-color: #FFE4E1; }
+        li.insert { color: green; }
+        li.insert em { background-color: #FAFAD2; }
+        .count,.data { font-family: monospace;
+                       background-color: #F8F8FF;
+                       border: 1px solid #DCDCDC; }
+      </style>
+      <script type="text/javascript">
+        var global = { prettydiff: {} },  /* for diffview.js */
+            diffview_source = new String("../assets/diffview.js");
+
+        /* add location-based file detail to the title */
+        var split_url = document.URL.split('/'),
+            basename = new String(split_url[split_url.length - 1]),
+            /* see whether there's 'test-\d+' in URL as a discriminator */
+            is_test = split_url.some(function(item, index, array) {
+              if (index &lt; array.length - 1 &amp;&amp; item.match(/test-\d+/))
+                return true;
+              return false;
+            });
+
+        window.addEventListener("DOMContentLoaded", function(event) {
+          /* update title + headline */
+          var basename_title = new String(basename + " upgrade");
+          document.getElementById("headline").innerText = basename_title;
+          document.title = basename_title + " [" + document.title + "]";
+
+          /* add location-based file detail to the acknowledgement's text */
+          document.getElementById("acknowledgement")
+            .innerHTML = document.getElementById("acknowledgement").innerHTML
+                         .replace("@basename@", basename);
+
+          /* make expand/collapse buttons udner debugging section work */
+          document.querySelectorAll("#original, #transformed").forEach(
+            function(item) {
+              item.querySelector(".expand").addEventListener("click",
+                                                             function(event) {
+                item.querySelectorAll(".possibly-revealed").forEach(
+                  function(item) {
+                    item.classList.replace("possibly-revealed", "revealed");
+                  }
+                );
+                this.classList.add("possibly-revealed");
+                event.preventDefault();
+              });
+              item.querySelector(".collapse").addEventListener("click",
+                                                               function(event) {
+                item.querySelectorAll(".revealed").forEach(
+                  function(item) {
+                    item.classList.replace("revealed", "possibly-revealed");
+                  }
+                );
+                item.querySelector(".expand").classList.remove("possibly-revealed");
+                event.preventDefault();
+              });
+            }
+          );
+
+          if (is_test) {
+            var xhr1 = new XMLHttpRequest(),
+                xhr2 = new XMLHttpRequest(),
+                basename_split = basename.split('.');
+
+            /* fetch expected out-of-band messages */
+            xhr1.onload = function() {
+              document.getElementById("expected-messages").innerText = this.responseText;
+              document.querySelectorAll(["#expected-messages",
+                                         "#expected-messages-ext",
+                                         "#navigation"]).forEach(
+                function(item) {
+                  item.classList.remove("possibly-revealed");
+                }
+              );
+            };
+            xhr1.open("GET", basename_split.splice(0, basename_split.length - 1)
+                                           .join('.') + ".ref.err");
+            xhr1.responseType = "text";
+            xhr1.send();
+
+            /* fetch previous/next pointers */
+            xhr2.onload = function() {
+              var prev_link, next_link,
+                  found = false;
+              Array.prototype.every.call(
+                this.responseXML.getElementsByTagName("a"),
+                function(item) {
+                  if (item.href.endsWith(basename_split[basename_split.length - 1])) {
+                    if (item.href.endsWith(basename))
+                      found = true;
+                    else if (!found)
+                      prev_link = item;
+                    else if (next_link !== undefined)
+                      return false;
+                    else
+                      next_link = item;
+                  }
+                  return true;
+                }
+              );
+              if (prev_link !== undefined)
+                document.getElementById("navigation-prev").href = prev_link.href;
+              if (next_link !== undefined)
+              document.getElementById("navigation-next").href = next_link.href;
+            };
+            xhr2.open("GET", ".");
+            xhr2.responseType = "document";
+            xhr2.send();
+          }
+        });
+
+        window.addEventListener("load", function(event) {
+          /* trigger diff'ing */
+          document
+            .getElementById("output")
+            .innerHTML = global.prettydiff.diffview({
+              source: document.getElementById("original-placeholder").innerText,
+              sourcelabel: "Differences: original",
+              diff: document.getElementById("transformed-placeholder").innerText,
+              difflabel: "transformed (some whitespace stripped)",
+              diffview: "inline",
+              lang: "text"
+            })[0];
+
+          /* add proper location of diffview.js */
+          var diffview_link = document.getElementById("diffview-link");
+          if (diffview_link.host != document.location.host) {
+            diffview_link.href = diffview_source;
+            diffview_link.parentElement.querySelector(".possibly-revealed")
+              .classList.remove("possibly-revealed");
+            diffview_link.parentElement.querySelector(".revealed")
+              .classList.replace("revealed", "possibly-revealed");
+          }
+        });
+
+        /* bind left/right arrows */
+        window.addEventListener("keydown", function(event) {
+          switch (event.keyCode) {
+          case 37:
+            document.location = document.getElementById("navigation-prev").href;
+            break;
+          case 39:
+            document.location = document.getElementById("navigation-next").href;
+            break;
+          }
+        });
+      </script>
+      <script type="text/javascript" src="../assets/diffview.js"/>
+      <!-- fallback to externally fetched js, without any guarantees,
+           safety ones or otherwise -->
+      <script type="text/javascript">
+        if (typeof global.prettydiff.diffview == "undefined") {
+          diffview_source = new String("https://raw.githubusercontent.com/prettydiff/prettydiff/2.2.8/lib/diffview.js");
+          document.write(unescape('%3Cscript type="text/javascript" src=' + diffview_source + '/%3E'));
+        }
+      </script>
+    </head>
+    <body>
+      <h1 id="headline">test</h1>
+      <p>
+        <strong>Using <a href="../upgrade-2.10.xsl">upgrade-2.10</a> on-the-fly in-browser transformation</strong>
+        <span id="navigation" class="possibly-revealed">
+          [
+          <a id="navigation-prev" href="#">previous</a>
+          and
+          <a id="navigation-next" href="#">next</a>, or use arrows
+          ]
+        </span>
+      </p>
+      <p id="output">
+        Differences highlight view to be loaded here.
+      </p>
+      <h3>Diagnostics</h3>
+      <p>
+        Open <a href="https://webmasters.stackexchange.com/a/77337">JS console</a>
+        (e.g. <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>J</kbd>, focusing JS + log combo)
+        <span id="expected-messages-ext" class="possibly-revealed">
+          to check the actual messages from the in-browser transformation match the baseline:
+        </span>
+      </p>
+      <pre id="expected-messages" class="data possibly-revealed">
+        Expected diagnostic messages to be loaded here.
+      </pre>
+      <h3>Debugging</h3>
+      <p>
+        These are raw data (beware, already chewed with the
+        <a href="../assets/view-source-original.xsl">view-source</a>
+        transformation, hence not very suitable for copying) entering
+        the differential generating processs:
+      </p>
+      <p id="original">
+        <span>
+          <a class="expand" href="">original+</a>
+          <a class="collapse possibly-revealed" href="">original-</a>
+        </span>
+        <br/>
+        <pre id="original-placeholder" class="data possibly-revealed">
+          <xsl:apply-templates select="exsl:node-set($before-upgrade)/node()" mode="original"/>
+        </pre>
+      </p>
+      <p id="transformed">
+        <span>
+          <a class="expand" href="">transformed+</a>
+          <a class="collapse possibly-revealed" href="">transformed-</a>
+        </span>
+        <br/>
+        <pre id="transformed-placeholder" class="data possibly-revealed">
+          <xsl:apply-templates select="exsl:node-set($after-upgrade)/node()" mode="original"/>
+        </pre>
+      </p>
+      <hr/>
+      <p id="acknowledgement">
+        This generated page is based on the externally provided pacemaker XML
+        configuration file (CIB), <span class="data">@basename@</span>, which is
+        the primary object of interest here.
+        But the rendered page wouldn't be possible without the actual
+        transformations and other auxiliary files that come with these notices:
+        <br/>
+        <ul>
+          <li id="ack-diffview">
+            <a href="../assets/diffview.js" id="diffview-link">diffview.js</a>
+            <p class="data revealed">
+              This file was obtained from <a href="https://github.com/prettydiff/prettydiff">prettydiff/prettydiff</a> project:<br/>
+              <a href="https://raw.githubusercontent.com/prettydiff/prettydiff/2.2.8/lib/diffview.js">diffview.js</a><br/>
+              <br/>
+              Licensing governed with:<br/>
+              <a href="https://github.com/prettydiff/prettydiff/blob/2.2.8/license.txt">license.txt</a><br/>
+              <br/>
+              > Rights holder Austin Cheney and Pretty Diff<br/>
+              > <br/>
+              > Pretty Diff project, as of version 2.1.17 and all following versions<br/>
+              > unless otherwise changed, is licensed with a Creative Commons 1.0<br/>
+              > Universal license (CC0).
+            </p>
+            <p class="data possibly-revealed">
+              This file is being served directly from <a href="https://raw.githubusercontent.com/prettydiff/prettydiff/2.2.8/lib/diffview.js">
+              GitHub hosted location</a>, hence refer to <a href="https://raw.githubusercontent.com/prettydiff/prettydiff/2.2.8">
+              respective repo tree</a>
+            </p>
+          </li>
+          <li id="ack-view-source">
+            <a href="../assets/view-source-library.xsl">library.xsl</a>
+            and
+            <a href="../assets/view-source-original.xsl">original.xsl</a>
+            <p class="data">
+              This file was obtained from <a href="https://github.com/Boldewyn/view-source">Boldewyn/view-source</a> project:<br/>
+              <a href="https://raw.githubusercontent.com/Boldewyn/view-source/f425605366b9f5a52e6a71632785d6e4543c705e/library.xsl">library.xsl</a><br/>
+              <a href="https://raw.githubusercontent.com/Boldewyn/view-source/f425605366b9f5a52e6a71632785d6e4543c705e/original.xsl">original.xsl</a><br/>
+              <br/>
+              Licensing governed with:<br/>
+              <a href="https://github.com/Boldewyn/view-source/blob/f425605366b9f5a52e6a71632785d6e4543c705e/README">README</a><br/>
+              <br/>
+              > The stylesheet is published under an MIT-style license and the GPL v2.<br/>
+              > Choose at your liking.
+            </p>
+          </li>
+          <li id="ack-upgrade">
+            <a href="../assets/upgrade-2.10-htmldiff.xsl">upgrade-2.10-htmldiff.xsl</a>
+            (master template for this report) and
+            <a href="../upgrade-2.10.xsl">upgrade-2.10.xsl</a>
+            (actual upgrade engine)
+            <p class="data">
+              Copyright 2018 <a href="https://redhat.com">Red Hat, Inc.</a><br/>
+              Author: <a href="https://wiki.clusterlabs.org/wiki/User:Jpokorny">Jan Pokorny</a>
+              &lt;<a href="mailto:jpokorny@redhat.com">jpokorny@redhat.com</a>&gt;<br/>
+              <a href="https://github.com/ClusterLabs/pacemaker/tree/master/xml">Part</a> of
+              <a href="https://wiki.clusterlabs.org/wiki/Pacemaker">pacemaker</a> project<br/>
+              <a href="https://spdx.org/sites/cpstandard/files/pages/files/using_spdx_license_list_short_identifiers.pdf#page=5">SPDX-License-Identifier</a>:
+              <a href="https://spdx.org/licenses/GPL-2.0-or-later.html">GPL-2.0-or-later</a>
+            </p>
+          </li>
+        </ul>
+      </p>
+    </body>
+  </html>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xml/assets/view-source-library.xsl
+++ b/xml/assets/view-source-library.xsl
@@ -1,0 +1,222 @@
+<?xml version="1.0" ?>
+<!--
+ This file was obtained from https://github.com/Boldewyn/view-source project:
+ https://raw.githubusercontent.com/Boldewyn/view-source/f425605366b9f5a52e6a71632785d6e4543c705e/library.xsl
+
+ Licensing governed with:
+ https://github.com/Boldewyn/view-source/blob/f425605366b9f5a52e6a71632785d6e4543c705e/README
+
+ > The stylesheet is published under an MIT-style license and the GPL v2.
+ > Choose at your liking.
+
+ -->
+<t:stylesheet version="1.0"
+  xmlns:t="http://www.w3.org/1999/XSL/Transform"
+  xmlns="http://www.w3.org/1999/xhtml">
+
+  <t:variable name="ns" xmlns="">
+    <empty></empty>
+    <xml>http://www.w3.org/XML/1998/namespace</xml>
+    <xmlns>http://www.w3.org/2000/xmlns/</xmlns>
+    <xhtml>http://www.w3.org/1999/xhtml</xhtml>
+    <svg>http://www.w3.org/2000/svg</svg>
+    <mathml>http://www.w3.org/1998/Math/MathML</mathml>
+    <xslt>http://www.w3.org/1999/XSL/Transform</xslt>
+    <fo>http://www.w3.org/1999/XSL/Format</fo>
+    <smil>http://www.w3.org/2005/SMIL21/Language</smil>
+    <xlink>http://www.w3.org/1999/xlink</xlink>
+    <xsd>http://www.w3.org/2001/XMLSchema</xsd>
+    <xsd-inst>http://www.w3.org/2001/XMLSchema-instance</xsd-inst>
+    <xforms>http://www.w3.org/2001/xforms</xforms>
+    <xinclude>http://www.w3.org/2001/XInclude</xinclude>
+    <xul>http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul</xul>
+    <rdf>http://www.w3.org/1999/02/22-rdf-syntax-ns#</rdf>
+  </t:variable>
+
+  <!--
+    format text, so that newlines get indented correctly
+  -->
+  <t:template name="format-text">
+    <t:param name="text" select="." />
+    <t:param name="indent" />
+    <t:choose>
+      <t:when test="contains($text, '&#xA;')">
+        <t:value-of select="normalize-space(substring-before($text, '&#xA;'))" />
+        <t:text>&#xA;</t:text>
+        <t:value-of select="$indent" />
+        <t:call-template name="format-text">
+          <t:with-param name="text" select="substring-after($text, '&#xA;')" />
+          <t:with-param name="indent" select="$indent " />
+        </t:call-template>
+      </t:when>
+      <t:otherwise>
+        <t:value-of select="normalize-space($text)" />
+      </t:otherwise>
+    </t:choose>
+  </t:template>
+
+  <!--
+    HTML entity quote stuff
+  -->
+  <t:template name="quote">
+    <t:param name="text" />
+    <t:call-template name="replace">
+      <t:with-param name="text">
+        <t:call-template name="replace">
+          <t:with-param name="text">
+            <t:call-template name="replace">
+              <t:with-param name="text">
+                <t:call-template name="replace">
+                  <t:with-param name="text">
+                    <t:call-template name="replace">
+                      <t:with-param name="text">
+                        <t:value-of select="$text" />
+                      </t:with-param>
+                      <t:with-param name="from" select="'&amp;'" />
+                      <t:with-param name="to" select="'&amp;amp;'" />
+                    </t:call-template>
+                  </t:with-param>
+                  <t:with-param name="from" select='"&apos;"' />
+                  <t:with-param name="to" select="'&amp;apos;'" />
+                </t:call-template>
+              </t:with-param>
+              <t:with-param name="from" select="'&quot;'" />
+              <t:with-param name="to" select="'&amp;quot;'" />
+            </t:call-template>
+          </t:with-param>
+          <t:with-param name="from" select="'&gt;'" />
+          <t:with-param name="to" select="'&amp;gt;'" />
+        </t:call-template>
+      </t:with-param>
+      <t:with-param name="from" select="'&lt;'" />
+      <t:with-param name="to" select="'&amp;lt;'" />
+    </t:call-template>
+  </t:template>
+
+  <!--
+    replace a string with another
+  -->
+  <t:template name="replace">
+    <t:param name="text" />
+    <t:param name="from" />
+    <t:param name="to" />
+    <t:choose>
+      <t:when test="not($from)">
+        <t:value-of select="$text" />
+      </t:when>
+      <t:when test="contains($text, $from)">
+        <t:value-of select="substring-before($text, $from)" />
+        <t:value-of select="$to" />
+        <t:call-template name="replace">
+          <t:with-param name="text" select="substring-after($text, $from)" />
+          <t:with-param name="from" select="$from" />
+          <t:with-param name="to" select="$to" />
+        </t:call-template>
+      </t:when>
+      <t:otherwise>
+        <t:value-of select="$text" />
+      </t:otherwise>
+    </t:choose>
+  </t:template>
+
+  <!--
+    parse the value of an attribute (find links and make them clickable)
+  -->
+  <t:template name="parse-attval">
+    <t:param name="att" select="." />
+    <t:choose>
+      <!-- FIXME: element{xhtml} / @attr{obscure-ns} 'href' gets linkified -->
+      <t:when test="(namespace-uri($att/..) = document('')//t:variable[@name = 'ns']/xml/text()   and ( local-name($att) = 'base' )) or
+                    (namespace-uri($att/..) = document('')//t:variable[@name = 'ns']/xhtml/text() and ( local-name($att) = 'src' or local-name($att) = 'href' )) or
+                    (namespace-uri($att/..) = document('')//t:variable[@name = 'ns']/svg/text()   and ( local-name($att) = 'src' )) or
+                    (namespace-uri($att/..) = document('')//t:variable[@name = 'ns']/xslt/text()  and ( local-name($att) = 'href' )) or
+                    (namespace-uri($att/..) = document('')//t:variable[@name = 'ns']/smil/text()  and ( local-name($att) = 'src' or local-name($att) = 'href' )) or
+                    (namespace-uri($att)    = document('')//t:variable[@name = 'ns']/xlink/text() and ( local-name($att) = 'href' or local-name($att) = 'role' )) or
+                    contains(substring($att, 1, 7), 'http://') or
+                    contains(substring($att, 1, 8), 'https://') or
+                    contains(substring($att, 1, 7), 'file://') or
+                    contains(substring($att, 1, 7), 'mailto:') or
+                    contains(substring($att, 1, 6), 'ftp://') or
+                    contains(substring($att, 1, 7), 'ftps://') or
+                    contains(substring($att, 1, 5), 'news:') or
+                    contains(substring($att, 1, 4), 'urn:') or
+                    contains(substring($att, 1, 5), 'ldap:') or
+                    contains(substring($att, 1, 5), 'data:')">
+        <a>
+          <t:attribute name="href">
+            <t:value-of select="$att" />
+          </t:attribute>
+          <t:call-template name="quote">
+            <t:with-param name="text" select="$att" />
+          </t:call-template>
+        </a>
+      </t:when>
+      <t:otherwise>
+        <t:call-template name="quote">
+          <t:with-param name="text" select="$att" />
+        </t:call-template>
+      </t:otherwise>
+    </t:choose>
+  </t:template>
+
+  <!--
+    print the name of a node plus the namespace URI in a title attribute
+  -->
+  <t:template name="print-name">
+    <t:param name="node" select="." />
+    <span class="label">
+      <t:if test="namespace-uri($node)">
+        <t:attribute name="title">
+          <t:value-of select="namespace-uri($node)" />
+        </t:attribute>
+      </t:if>
+      <t:choose>
+        <t:when test="name($node) != local-name($node)">
+          <span class="nsprefix">
+            <t:value-of select="substring-before(name($node), ':')" />
+          </span>
+          <span class="nscolon syntax">
+            <t:text>:</t:text>
+          </span>
+          <span class="local-name">
+            <t:value-of select="local-name($node)" />
+          </span>
+        </t:when>
+        <t:otherwise>
+          <t:value-of select="name($node)" />
+        </t:otherwise>
+      </t:choose>
+    </span>
+  </t:template>
+
+  <!--
+    check the used language against a list of known ones
+  -->
+  <t:template name="detect-lang">
+    <t:param name="node" select="." />
+    <t:if test="namespace-uri($node) = $highlight-namespace">
+      <t:text>highlight </t:text>
+    </t:if>
+    <t:value-of select="local-name(document('')//t:variable[@name = 'ns']/*[text() = namespace-uri($node)])" />
+  </t:template>
+
+  <t:key name="kElemByNSURI"
+       match="*[namespace::*[not(. = ../../namespace::*)]]"
+       use="namespace::*[not(. = ../../namespace::*)]" />
+
+  <!--
+    get a list of all namespaces used in the document
+  -->
+  <t:template name="get-namespace-nodes">
+    <script type="text/javascript">
+      var namespaces = [
+      <t:for-each select="//namespace::*[not(. = ../../namespace::*)]
+                        [count(..|key('kElemByNSURI',.)[1])=1]">
+        <t:value-of select="concat('&quot;',.,'&quot;,')"/>
+      </t:for-each>
+      'DUMMY'
+      ];
+    </script>
+  </t:template>
+
+</t:stylesheet>

--- a/xml/assets/view-source-original.xsl
+++ b/xml/assets/view-source-original.xsl
@@ -1,0 +1,103 @@
+<?xml version="1.0" ?>
+<!--
+ This file was obtained from https://github.com/Boldewyn/view-source project:
+ https://raw.githubusercontent.com/Boldewyn/view-source/f425605366b9f5a52e6a71632785d6e4543c705e/original.xsl
+
+ Licensing governed with:
+ https://github.com/Boldewyn/view-source/blob/f425605366b9f5a52e6a71632785d6e4543c705e/README
+
+ > The stylesheet is published under an MIT-style license and the GPL v2.
+ > Choose at your liking.
+
+ -->
+<t:stylesheet version="1.0"
+  xmlns:t="http://www.w3.org/1999/XSL/Transform"
+  xmlns="http://www.w3.org/1999/xhtml">
+
+  <!-- Elements (original) -->
+  <t:template match="*" mode="original">
+    <t:variable name="lang">
+      <t:call-template name="detect-lang" />
+    </t:variable>
+    <t:choose>
+      <t:when test="node()">
+        <span class="{$lang} element">
+          <span class="tag start">
+            <t:text>&lt;</t:text>
+            <t:call-template name="print-name" />
+            <t:for-each select="@*">
+              <t:apply-templates select="." mode="original" />
+            </t:for-each>
+            <t:text>&gt;</t:text>
+          </span>
+          <t:apply-templates mode="original" />
+          <span class="tag end">
+            <t:text>&lt;/</t:text>
+            <t:value-of select="name(.)"/>
+            <t:text>&gt;</t:text>
+          </span>
+        </span>
+      </t:when>
+      <t:otherwise>
+        <span class="{$lang} element empty">
+          <span class="tag empty">
+            <t:text>&lt;</t:text>
+            <t:call-template name="print-name" />
+            <t:for-each select="@*">
+              <t:apply-templates select="." mode="original" />
+            </t:for-each>
+            <t:text> /&gt;</t:text>
+          </span>
+        </span>
+      </t:otherwise>
+    </t:choose>
+  </t:template>
+
+  <!-- Attributes (original) -->
+  <t:template match="@*" mode="original">
+    <t:variable name="lang">
+      <t:call-template name="detect-lang" />
+    </t:variable>
+    <t:text> </t:text>
+    <span class="{$lang} attribute">
+      <t:call-template name="print-name" />
+      <t:text>="</t:text>
+      <span class="attribute-value">
+        <t:call-template name="parse-attval" />
+      </span>
+      <t:text>"</t:text>
+    </span>
+  </t:template>
+
+  <!-- Processing Instructions (original) -->
+  <t:template match="processing-instruction()" mode="original">
+    <span class="processing-instruction">
+      <t:text>&lt;?</t:text>
+      <t:value-of select="name(.)" />
+      <t:text> </t:text>
+      <t:value-of select="." />
+      <t:text>?&gt;</t:text>
+    </span>
+  </t:template>
+
+  <!-- Comments (original) -->
+  <t:template match="comment()" mode="original">
+    <span class="comment">
+      <t:text>&lt;!--</t:text>
+      <t:call-template name="quote">
+        <t:with-param name="text" select="." />
+      </t:call-template>
+      <t:text>--></t:text>
+    </span>
+  </t:template>
+
+  <!-- Text (original) -->
+  <t:template match="text()" mode="original">
+    <span class="text">
+      <t:call-template name="quote">
+        <t:with-param name="text" select="." />
+      </t:call-template>
+    </span>
+  </t:template>
+
+</t:stylesheet>

--- a/xml/regression.sh
+++ b/xml/regression.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 set -eu
+test -d assets && test -d test-2 \
+  || { echo 'Run me from source-tree-like location'; exit 1; }
 # $1=reference (can be '-' for stdin), $2=investigated
 # alt.: wdiff, colordiff, ...
 DIFF=${DIFF:-diff}

--- a/xml/regression.sh
+++ b/xml/regression.sh
@@ -113,6 +113,7 @@ test_cleaner() {
 }
 
 test_selfcheck() {
+	_tsc_ret=0
 	_tsc_template=
 	_tsc_validator=
 
@@ -127,9 +128,15 @@ test_selfcheck() {
 	_tsc_template="upgrade-${_tsc_template}.xsl"
 
 	# check schema (sub-grammar) for custom transformation mapping alone
-	${RNGVALIDATOR} 'http://relaxng.org/relaxng.rng' "${_tsc_validator}"
+	if ! ${RNGVALIDATOR} 'http://relaxng.org/relaxng.rng' "${_tsc_validator}"; then
+		_tsc_ret=$((_tsc_ret + 1))
+	fi
 	# check the overall XSLT per the main grammar + said sub-grammar
-	${RNGVALIDATOR} "xslt_${_tsc_validator}" "${_tsc_template}"
+	if ! ${RNGVALIDATOR} "xslt_${_tsc_validator}" "${_tsc_template}"; then
+		_tsc_ret=$((_tsc_ret + 1))
+	fi
+
+	log2_or_0_return ${_tsc_ret}
 }
 
 test_explanation() {

--- a/xml/regression.sh
+++ b/xml/regression.sh
@@ -122,14 +122,16 @@ test_browser() {
 	  || curl -Lo assets/diffview.js \
 	     'https://raw.githubusercontent.com/prettydiff/prettydiff/2.2.8/lib/diffview.js'
 
-	which python3 >/dev/null 2>/dev/null \
+	{ which python3 >/dev/null 2>/dev/null \
 	  && { python3 -m http.server "${HTTPPORT}" -b 127.0.0.1 \
-	       || emit_error "Python3 HTTP server shutdown/fail"; } \
-	  || { printf '%s %s\n' \
-	         'Python 2 backed HTTP server cannot listen at particular' \
-		 'address, discretion regarding firewall rules recommended!'
-	       python2 -m SimpleHTTPServer "${HTTPPORT}" \
-	       || emit_error "Python2 HTTP server shutdown/fail"; } &
+	       || emit_error "Python3 HTTP server fail"; return; } \
+	  || which python2 >/dev/null 2>/dev/null \
+	       && { printf '%s %s\n' \
+	            'Python 2 backed HTTP server cannot listen at particular' \
+	            'address, discretion regarding firewall rules recommended!'
+	            python2 -m SimpleHTTPServer "${HTTPPORT}" \
+	            || emit_error 'Python2 HTTP server fail'; return; } \
+	       || emit_error 'Cannot run Python based HTTP server' ; } &
 	_tb_serverpid=$!
 	${WEBBROWSER} "http://localhost:${HTTPPORT}/${_tb_first}" &
 	printf "When finished, just press Ctrl+C or kill %d, please\n" \
@@ -588,7 +590,7 @@ test_suite() {
 #       small ones for generic/global behaviour
 usage() {
 	printf \
-	  '%s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n' \
+	  '%s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n' \
 	  "usage: $0 [-{B,C,D,G,S,X}]* [-|{${tests## }}*]" \
 	  "- when no suites (arguments) provided, \"test*\" ones get used" \
 	  "- with '-' suite specification the actual ones grabbed on stdin" \
@@ -597,16 +599,19 @@ usage() {
 	  "- use '-D' to review originals vs. \"referential\" outcomes" \
 	  "- use '-G' to generate \"referential\" outcomes" \
 	  "- use '-S' for template self-check (requires net access)" \
+	  "- use '-W' to run browser-based, on-the-fly diff'ing test drive" \
 	  "- use '-X' to show explanatory details about the upgrade" \
 	  "- test specification can be granular, e.g. 'test2to3/022'"
 	printf \
-	  '\n%s\n  %s\n  %s\n  %s\n  %s\n  %s\n' \
+	  '\n%s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n' \
 	  'environment variables affecting the run + default/current values:' \
 	  "- DIFF (${DIFF}): tool to compute and show differences of 2 files" \
 	  "- DIFFOPTS (${DIFFOPTS}): options to the above tool" \
 	  "- DIFFPAGER (${DIFFPAGER}): possibly accompanying the above tool" \
 	  "- RNGVALIDATOR (${RNGVALIDATOR}): RelaxNG validator" \
-	  "- XSLTPROCESSOR (${_XSLTPROCESSOR}): XSLT 1.0 capable processor"
+	  "- XSLTPROCESSOR (${_XSLTPROCESSOR}): XSLT 1.0 capable processor" \
+	  "- HTTPPORT (${HTTPPORT}): port used by test drive HTTP server run" \
+	  "- WEBBROWSER (${WEBBROWSER}): used for in-browser test drive"
 }
 
 main() {

--- a/xml/regression.sh
+++ b/xml/regression.sh
@@ -18,18 +18,21 @@ RNGVALIDATOR=${RNGVALIDATOR:-xmllint --noout --relaxng}
 # $1=stylesheet, $2=source
 # alt.: Xalan, saxon (note: only validates reliably with -B)
 _xalan_wrapper() {
-	{ Xalan "$2" "$1" 2>&1 >&3 \
+	{ ${_XSLTPROCESSOR} "$2" "$1" 2>&1 >&3 \
 	  | sed -e '/^Source tree node.*$/d' \
 	        -e 's|^XSLT message: \(.*\) (Occurred.*)|\1|'; } 3>&- 3>&1 >&2
 }
 # filtered out message: https://bugzilla.redhat.com/show_bug.cgi?id=1577367
 _saxon_wrapper() {
-	{ saxon "-xsl:$1" "-s:$2" -versionmsg:off 2>&1 >&3 \
+	{ ${_XSLTPROCESSOR} "-xsl:$1" "-s:$2" -versionmsg:off 2>&1 >&3 \
 	  | sed -e '/^Cannot find CatalogManager.properties$/d'; } 3>&- 3>&1 >&2
 }
-XSLTPROCESSOR=${XSLTPROCESSOR:-xsltproc}
-test "${XSLTPROCESSOR}" != Xalan || XSLTPROCESSOR=_xalan_wrapper
-test "${XSLTPROCESSOR}" != saxon || XSLTPROCESSOR=_saxon_wrapper
+XSLTPROCESSOR=${XSLTPROCESSOR:-xsltproc --nonet}
+_XSLTPROCESSOR=${XSLTPROCESSOR}
+case "${XSLTPROCESSOR}" in
+[Xx]alan*|*/[Xx]alan*) XSLTPROCESSOR=_xalan_wrapper;;
+saxon*|*/saxon*)       XSLTPROCESSOR=_saxon_wrapper;;
+esac
 
 tests=  # test* names (should go first) here will become preselected default
 

--- a/xml/regression.sh
+++ b/xml/regression.sh
@@ -321,7 +321,7 @@ test_runner_validate() {
 # -t= ... which conventional version to deem as the transform target
 # -B
 # -D
-# -G  ... see usage
+# -G ... see usage
 # stdin: input file per line
 test_runner() {
 	_tr_mode=0
@@ -407,7 +407,7 @@ tests="${tests} test2to3"
 
 # -B
 # -D
-# -G  ... see usage
+# -G ... see usage
 cts_scheduler() {
 	_tcp_mode=0
 	_tcp_ret=0

--- a/xml/test-2/010-rsc_colocation-dropped-for-noop-sa.xml
+++ b/xml/test-2/010-rsc_colocation-dropped-for-noop-sa.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <!--
  Contrieved example of how rsc_colocation/@score-attribute might have been used
 

--- a/xml/test-2/020-rsc-requires-inline.xml
+++ b/xml/test-2/020-rsc-requires-inline.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/021-rsc-requires-nvpair.xml
+++ b/xml/test-2/021-rsc-requires-nvpair.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/022-rsc-requires-counterexamples.xml
+++ b/xml/test-2/022-rsc-requires-counterexamples.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/023-rsc-requires-no-override.xml
+++ b/xml/test-2/023-rsc-requires-no-override.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/024-rsc-requires-no-selfclash.xml
+++ b/xml/test-2/024-rsc-requires-no-selfclash.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/030-clu-props-plain-rename.xml
+++ b/xml/test-2/030-clu-props-plain-rename.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config>

--- a/xml/test-2/031-clu-props-drop.xml
+++ b/xml/test-2/031-clu-props-drop.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config>

--- a/xml/test-2/032-clu-props-move.xml
+++ b/xml/test-2/032-clu-props-move.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config>

--- a/xml/test-2/033-clu-props-move-merge.xml
+++ b/xml/test-2/033-clu-props-move-merge.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config>

--- a/xml/test-2/034-clu-props-move-redef.xml
+++ b/xml/test-2/034-clu-props-move-redef.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config>

--- a/xml/test-2/040-nodes-rename-type.xml
+++ b/xml/test-2/040-nodes-rename-type.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/050-rsc-attrs-instance-plain-rename.xml
+++ b/xml/test-2/050-rsc-attrs-instance-plain-rename.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/051-rsc-attrs-instance-pcmk_arg_map.xml
+++ b/xml/test-2/051-rsc-attrs-instance-pcmk_arg_map.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/060-rsc-attrs-meta-isolation.xml
+++ b/xml/test-2/060-rsc-attrs-meta-isolation.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/061-rsc-attrs-meta-exchange.xml
+++ b/xml/test-2/061-rsc-attrs-meta-exchange.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/070-rsc-op-attrs-inst-requires-start.xml
+++ b/xml/test-2/070-rsc-op-attrs-inst-requires-start.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/071-rsc-op-attrs-inst-requires-nonstart.xml
+++ b/xml/test-2/071-rsc-op-attrs-inst-requires-nonstart.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/072-rsc-op-attrs-inst-requires-no-override.xml
+++ b/xml/test-2/072-rsc-op-attrs-inst-requires-no-override.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/test-2/073-rsc-op-attrs-inst-meta-meaning.xml
+++ b/xml/test-2/073-rsc-op-attrs-inst-meta-meaning.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet href="../assets/upgrade-2.10-htmldiff.xsl" type="text/xsl"?>
 <cib validate-with="pacemaker-2.0" admin_epoch="0" epoch="0" num_updates="0">
   <configuration>
     <crm_config/>

--- a/xml/upgrade-2.10.xsl
+++ b/xml/upgrade-2.10.xsl
@@ -9,7 +9,7 @@
                 exclude-result-prefixes="cibtr">
 <xsl:output method="xml" encoding="UTF-8" indent="yes" omit-xml-declaration="yes"/>
 
-<xsl:param name="cib-min-ver" select="'3.0'"/>
+<xsl:param name="cibtr:cib-min-ver" select="'3.0'"/>
 
 <!--
 
@@ -325,43 +325,43 @@
 
 </cibtr:map>
 
-<xsl:variable name="MapClusterProperties"
+<xsl:variable name="cibtr:MapClusterProperties"
               select="document('')/xsl:stylesheet
                         /cibtr:map/cibtr:table[
                           @for = 'cluster-properties'
                         ]"/>
 
-<xsl:variable name="MapClusterNode"
+<xsl:variable name="cibtr:MapClusterNode"
               select="document('')/xsl:stylesheet
                         /cibtr:map/cibtr:table[
                           @for = 'cluster-node'
                         ]"/>
 
-<xsl:variable name="MapResourceInstanceAttributes"
+<xsl:variable name="cibtr:MapResourceInstanceAttributes"
               select="document('')/xsl:stylesheet
                         /cibtr:map/cibtr:table[
                           @for = 'resource-instance-attributes'
                         ]"/>
 
-<xsl:variable name="MapResourceMetaAttributes"
+<xsl:variable name="cibtr:MapResourceMetaAttributes"
               select="document('')/xsl:stylesheet
                         /cibtr:map/cibtr:table[
                           @for = 'resource-meta-attributes'
                         ]"/>
 
-<xsl:variable name="MapResourcesOperation"
+<xsl:variable name="cibtr:MapResourcesOperation"
               select="document('')/xsl:stylesheet
                         /cibtr:map/cibtr:table[
                           @for = 'resources-operation'
                         ]"/>
 
-<xsl:variable name="MapResourcesOperationInstanceAttributes"
+<xsl:variable name="cibtr:MapResourcesOperationInstanceAttributes"
               select="document('')/xsl:stylesheet
                         /cibtr:map/cibtr:table[
                           @for = 'resource-operation-instance-attributes'
                         ]"/>
 
-<xsl:variable name="MapConstraintsColocation"
+<xsl:variable name="cibtr:MapConstraintsColocation"
               select="document('')/xsl:stylesheet
                         /cibtr:map/cibtr:table[
                           @for = 'constraints-colocation'
@@ -378,9 +378,10 @@
 
  Merely implicit-context-driven, no arguments.
  -->
-<xsl:template name="HelperIdentity">
+<xsl:template name="cibtr:HelperIdentity">
   <xsl:copy>
-    <xsl:apply-templates select="@*|node()"/>
+    <xsl:apply-templates select="@*|node()"
+                         mode="cibtr:main"/>
   </xsl:copy>
 </xsl:template>
 
@@ -392,7 +393,7 @@
  - Replacement: selected subset of cibtr:map's leaves
                 (it's considered a hard error if consists of more than 1 item)
  -->
-<xsl:template name="MapMsg">
+<xsl:template name="cibtr:MapMsg">
   <xsl:param name="Context" select="''"/>
   <xsl:param name="Replacement"/>
   <xsl:choose>
@@ -495,7 +496,7 @@
  - Source: input selection or result tree fragment to evaluate
  - ResultTreeFragment: optional self-explanatory flag related to Source
  -->
-<xsl:template name="HelperDenormalizedSpace">
+<xsl:template name="cibtr:HelperDenormalizedSpace">
   <xsl:param name="Source"/>
   <xsl:param name="ResultTreeFragment" select="false()"/>
   <xsl:param name="InnerSimulation" select="false()"/>
@@ -609,7 +610,7 @@
                  [cluster_property_set -> meta_attributes]
  Dependencies:   N/A
  -->
-<xsl:template name="ProcessClusterProperties">
+<xsl:template name="cibtr:ProcessClusterProperties">
   <xsl:param name="Source"/>
   <xsl:param name="InverseMode" select="false()"/>
   <xsl:param name="InnerSimulation" select="false()"/>
@@ -619,7 +620,7 @@
         <xsl:value-of select="''"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="ProcessClusterProperties">
+        <xsl:call-template name="cibtr:ProcessClusterProperties">
           <xsl:with-param name="Source" select="$Source"/>
           <xsl:with-param name="InverseMode" select="$InverseMode"/>
           <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -651,7 +652,7 @@
       </xsl:when>
       <xsl:when test="self::nvpair">
         <xsl:variable name="Replacement"
-                      select="$MapClusterProperties/cibtr:replace[
+                      select="$cibtr:MapClusterProperties/cibtr:replace[
                                 @what = current()/@name
                                 and
                                 (
@@ -666,7 +667,7 @@
                                     not(@in-case-of)
                                     and
                                     not(
-                                      $MapClusterProperties/cibtr:replace[
+                                      $cibtr:MapClusterProperties/cibtr:replace[
                                         @what = current()/@name
                                         and
                                         @in-case-of
@@ -679,7 +680,7 @@
                                 )
                               ]"/>
         <xsl:if test="$InnerPass = 'TRIGGER-MSG'">
-          <xsl:call-template name="MapMsg">
+          <xsl:call-template name="cibtr:MapMsg">
             <xsl:with-param name="Context" select="@id"/>
             <xsl:with-param name="Replacement" select="$Replacement"/>
           </xsl:call-template>
@@ -716,7 +717,7 @@
                               $Replacement/@where = name($InverseMode/..)
                             )
                           )">
-              <xsl:call-template name="HelperDenormalizedSpace">
+              <xsl:call-template name="cibtr:HelperDenormalizedSpace">
                 <xsl:with-param name="Source" select="."/>
                 <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
               </xsl:call-template>
@@ -745,7 +746,7 @@
           </xsl:when>
           <xsl:when test="$InverseMode"/>
           <xsl:when test="$Replacement">
-            <xsl:call-template name="HelperDenormalizedSpace">
+            <xsl:call-template name="cibtr:HelperDenormalizedSpace">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
             </xsl:call-template>
@@ -772,11 +773,11 @@
             </xsl:copy>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:call-template name="HelperDenormalizedSpace">
+            <xsl:call-template name="cibtr:HelperDenormalizedSpace">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
             </xsl:call-template>
-            <xsl:call-template name="HelperIdentity"/>
+            <xsl:call-template name="cibtr:HelperIdentity"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:when>
@@ -786,7 +787,7 @@
         <!-- drop -->
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="HelperIdentity"/>
+        <xsl:call-template name="cibtr:HelperIdentity"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:for-each>
@@ -798,7 +799,7 @@
  Target-inv ctxt:N/A
  Dependencies:   N/A
  -->
-<xsl:template name="ProcessRscInstanceAttributes">
+<xsl:template name="cibtr:ProcessRscInstanceAttributes">
   <xsl:param name="Source"/>
   <xsl:param name="InnerSimulation" select="false()"/>
   <xsl:param name="InnerPass">
@@ -807,7 +808,7 @@
         <xsl:value-of select="''"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="ProcessRscInstanceAttributes">
+        <xsl:call-template name="cibtr:ProcessRscInstanceAttributes">
           <xsl:with-param name="Source" select="$Source"/>
           <xsl:with-param name="InnerSimulation" select="true()"/>
         </xsl:call-template>
@@ -839,7 +840,7 @@
       </xsl:when>
       <xsl:when test="self::nvpair">
         <xsl:variable name="Replacement"
-                      select="$MapResourceInstanceAttributes/cibtr:replace[
+                      select="$cibtr:MapResourceInstanceAttributes/cibtr:replace[
                                 @what = current()/@name
                                 and
                                 (
@@ -867,7 +868,7 @@
                                     not(@in-case-of-droppable-prefix)
                                     and
                                     not(
-                                      $MapResourceInstanceAttributes/cibtr:replace[
+                                      $cibtr:MapResourceInstanceAttributes/cibtr:replace[
                                         @what = current()/@name
                                         and
                                         (
@@ -895,7 +896,7 @@
                                 )
                               ]"/>
         <xsl:if test="$InnerPass = 'TRIGGER-MSG'">
-          <xsl:call-template name="MapMsg">
+          <xsl:call-template name="cibtr:MapMsg">
             <xsl:with-param name="Context" select="@id"/>
             <xsl:with-param name="Replacement" select="$Replacement"/>
           </xsl:call-template>
@@ -908,7 +909,7 @@
           </xsl:when>
           <xsl:when test="$Replacement">
             <!-- plain rename -->
-            <xsl:call-template name="HelperDenormalizedSpace">
+            <xsl:call-template name="cibtr:HelperDenormalizedSpace">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
             </xsl:call-template>
@@ -944,16 +945,16 @@
             </xsl:copy>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:call-template name="HelperDenormalizedSpace">
+            <xsl:call-template name="cibtr:HelperDenormalizedSpace">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
             </xsl:call-template>
-            <xsl:call-template name="HelperIdentity"/>
+            <xsl:call-template name="cibtr:HelperIdentity"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="HelperIdentity"/>
+        <xsl:call-template name="cibtr:HelperIdentity"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:for-each>
@@ -966,7 +967,7 @@
  Target-inv ctxt:N/A
  Dependencies:   N/A
  -->
-<xsl:template name="ProcessRscMetaAttributes">
+<xsl:template name="cibtr:ProcessRscMetaAttributes">
   <xsl:param name="Source"/>
   <xsl:param name="InnerSimulation" select="false()"/>
   <xsl:param name="InnerPass">
@@ -975,7 +976,7 @@
         <xsl:value-of select="''"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="ProcessRscMetaAttributes">
+        <xsl:call-template name="cibtr:ProcessRscMetaAttributes">
           <xsl:with-param name="Source" select="$Source"/>
           <xsl:with-param name="InnerSimulation" select="true()"/>
         </xsl:call-template>
@@ -1007,7 +1008,7 @@
       </xsl:when>
       <xsl:when test="self::nvpair">
         <xsl:variable name="Replacement"
-                      select="$MapResourceMetaAttributes/cibtr:replace[
+                      select="$cibtr:MapResourceMetaAttributes/cibtr:replace[
                                 @what = current()/@name
                                 and
                                 (
@@ -1022,7 +1023,7 @@
                                     not(@in-case-of)
                                     and
                                     not(
-                                      $MapResourceMetaAttributes/cibtr:replace[
+                                      $cibtr:MapResourceMetaAttributes/cibtr:replace[
                                         @what = current()/@name
                                         and
                                         (
@@ -1037,7 +1038,7 @@
                                 )
                               ]"/>
         <xsl:if test="$InnerPass = 'TRIGGER-MSG'">
-          <xsl:call-template name="MapMsg">
+          <xsl:call-template name="cibtr:MapMsg">
             <xsl:with-param name="Context"
                             select="concat(../../@id,
                                            ' (meta=', ../@id,
@@ -1059,7 +1060,7 @@
                                       not(rule)
                                     ]">
                 <xsl:if test="$InnerPass != 'TRIGGER-RECURSION'">
-                  <xsl:call-template name="ProcessRscMetaAttributes">
+                  <xsl:call-template name="cibtr:ProcessRscMetaAttributes">
                     <xsl:with-param name="Source" select="."/>
                     <xsl:with-param name="InnerSimulation" select="true()"/>
                     <xsl:with-param name="InnerPass" select="'TRIGGER-RECURSION'"/>
@@ -1082,7 +1083,7 @@
                               =
                               substring-before($SimulateFollowingSiblings,
                                                concat('@', $Replacement/@with))">
-                  <xsl:call-template name="HelperDenormalizedSpace">
+                  <xsl:call-template name="cibtr:HelperDenormalizedSpace">
                     <xsl:with-param name="Source" select="."/>
                     <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
                   </xsl:call-template>
@@ -1112,16 +1113,16 @@
             </xsl:choose>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:call-template name="HelperDenormalizedSpace">
+            <xsl:call-template name="cibtr:HelperDenormalizedSpace">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
             </xsl:call-template>
-            <xsl:call-template name="HelperIdentity"/>
+            <xsl:call-template name="cibtr:HelperIdentity"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="HelperIdentity"/>
+        <xsl:call-template name="cibtr:HelperIdentity"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:for-each>
@@ -1134,7 +1135,7 @@
  Target-inv ctxt:(primitive|template)/operations/op/meta_attributes
  Dependencies:   ProcessNonattrOpMetaAttributes [inverse only]
  -->
-<xsl:template name="ProcessOpInstanceAttributes">
+<xsl:template name="cibtr:ProcessOpInstanceAttributes">
   <xsl:param name="Source"/>
   <xsl:param name="InverseMode" select="false()"/>
   <xsl:param name="InnerSimulation" select="false()"/>
@@ -1144,7 +1145,7 @@
         <xsl:value-of select="''"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="ProcessOpInstanceAttributes">
+        <xsl:call-template name="cibtr:ProcessOpInstanceAttributes">
           <xsl:with-param name="Source" select="$Source"/>
           <xsl:with-param name="InnerSimulation" select="true()"/>
         </xsl:call-template>
@@ -1178,7 +1179,7 @@
       </xsl:when>
       <xsl:when test="self::nvpair">
         <xsl:variable name="Replacement"
-                      select="$MapResourcesOperationInstanceAttributes/cibtr:replace[
+                      select="$cibtr:MapResourcesOperationInstanceAttributes/cibtr:replace[
                                 @what = current()/@name
                                 and
                                 (
@@ -1193,7 +1194,7 @@
                                     not(@in-case-of)
                                     and
                                     not(
-                                      $MapResourcesOperationInstanceAttributes/cibtr:replace[
+                                      $cibtr:MapResourcesOperationInstanceAttributes/cibtr:replace[
                                         @what = current()/@name
                                         and
                                         @in-case-of
@@ -1206,7 +1207,7 @@
                                 )
                               ]"/>
         <xsl:if test="$InnerPass = 'TRIGGER-MSG'">
-          <xsl:call-template name="MapMsg">
+          <xsl:call-template name="cibtr:MapMsg">
             <xsl:with-param name="Context"
                             select="concat(../../@id,
                                            ' (rsc=', $EnclosingTag/@id,
@@ -1226,7 +1227,7 @@
             <!-- drop (possibly just move over) -->
             <xsl:variable name="SimulateAttrOverrides">
               <xsl:for-each select="../../../op">
-                <xsl:call-template name="ProcessAttrOpMetaAttributes">
+                <xsl:call-template name="cibtr:ProcessAttrOpMetaAttributes">
                   <xsl:with-param name="Source" select="."/>
                   <xsl:with-param name="InverseMode" select="true()"/>
                   <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -1250,7 +1251,7 @@
                                        |../../following-sibling::op/meta_attributes)[
                                         not(rule)
                                       ]">
-                  <xsl:call-template name="ProcessNonattrOpMetaAttributes">
+                  <xsl:call-template name="cibtr:ProcessNonattrOpMetaAttributes">
                     <xsl:with-param name="Source" select="."/>
                     <xsl:with-param name="InverseMode" select="true()"/>
                     <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -1261,7 +1262,7 @@
                 <xsl:for-each select="../following-sibling::instance_attributes[
                                         not(rule)
                                       ]">
-                  <xsl:call-template name="ProcessOpInstanceAttributes">
+                  <xsl:call-template name="cibtr:ProcessOpInstanceAttributes">
                     <xsl:with-param name="Source" select="."/>
                     <xsl:with-param name="InverseMode" select="true()"/>
                     <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -1289,12 +1290,13 @@
                     <xsl:value-of select="concat(@name, ' ')"/>
                   </xsl:when>
                   <xsl:otherwise>
-                    <xsl:call-template name="HelperDenormalizedSpace">
+                    <xsl:call-template name="cibtr:HelperDenormalizedSpace">
                       <xsl:with-param name="Source" select="."/>
                       <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
                     </xsl:call-template>
                     <xsl:copy>
-                      <xsl:apply-templates select="@*"/>
+                      <xsl:apply-templates select="@*"
+                                           mode="cibtr:main"/>
                     </xsl:copy>
                   </xsl:otherwise>
                 </xsl:choose>
@@ -1312,11 +1314,11 @@
           </xsl:when>
           <xsl:when test="$InverseMode"/>
           <xsl:otherwise>
-            <xsl:call-template name="HelperDenormalizedSpace">
+            <xsl:call-template name="cibtr:HelperDenormalizedSpace">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
             </xsl:call-template>
-            <xsl:call-template name="HelperIdentity"/>
+            <xsl:call-template name="cibtr:HelperIdentity"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:when>
@@ -1326,7 +1328,7 @@
         <!-- drop -->
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="HelperIdentity"/>
+        <xsl:call-template name="cibtr:HelperIdentity"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:for-each>
@@ -1341,7 +1343,7 @@
  Dependencies:   ProcessAttrOpMetaAttributes
                  ProcessNonattrOpMetaAttributes
  -->
-<xsl:template name="ProcessNonattrOpMetaAttributes">
+<xsl:template name="cibtr:ProcessNonattrOpMetaAttributes">
   <xsl:param name="Source"/>
   <xsl:param name="InverseMode" select="false()"/>
   <xsl:param name="InnerSimulation" select="false()"/>
@@ -1351,7 +1353,7 @@
         <xsl:value-of select="''"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="ProcessNonattrOpMetaAttributes">
+        <xsl:call-template name="cibtr:ProcessNonattrOpMetaAttributes">
           <xsl:with-param name="Source" select="$Source"/>
           <xsl:with-param name="InnerSimulation" select="true()"/>
         </xsl:call-template>
@@ -1386,7 +1388,7 @@
       </xsl:when>
       <xsl:when test="self::nvpair">
         <xsl:variable name="Replacement"
-                      select="$MapResourcesOperation/cibtr:replace[
+                      select="$cibtr:MapResourcesOperation/cibtr:replace[
                                 @what = current()/@name
                                 and
                                 (
@@ -1401,7 +1403,7 @@
                                     not(@in-case-of)
                                     and
                                     not(
-                                      $MapResourcesOperation/cibtr:replace[
+                                      $cibtr:MapResourcesOperation/cibtr:replace[
                                         @what = current()/@name
                                         and
                                         @in-case-of
@@ -1414,7 +1416,7 @@
                                 )
                               ]"/>
         <xsl:if test="$InnerPass = 'TRIGGER-MSG'">
-          <xsl:call-template name="MapMsg">
+          <xsl:call-template name="cibtr:MapMsg">
             <xsl:with-param name="Context"
                             select="concat(../../@id,
                                            ' (rsc=', $EnclosingTag/@id,
@@ -1435,7 +1437,7 @@
             <xsl:if test="$InverseMode">
               <xsl:variable name="SimulateAttrOverrides">
                 <xsl:for-each select="../../../op">
-                  <xsl:call-template name="ProcessAttrOpMetaAttributes">
+                  <xsl:call-template name="cibtr:ProcessAttrOpMetaAttributes">
                     <xsl:with-param name="Source" select="."/>
                     <xsl:with-param name="InverseMode" select="true()"/>
                     <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -1460,7 +1462,7 @@
                                            |../../following-sibling::op/meta_attributes)[
                                             not(rule)
                                           ]">
-                      <xsl:call-template name="ProcessNonattrOpMetaAttributes">
+                      <xsl:call-template name="cibtr:ProcessNonattrOpMetaAttributes">
                         <xsl:with-param name="Source" select="."/>
                         <xsl:with-param name="InverseMode" select="true()"/>
                         <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -1474,7 +1476,7 @@
                                            |../../../op/meta_attributes)[
                                             not(rule)
                                           ]">
-                      <xsl:call-template name="ProcessNonattrOpMetaAttributes">
+                      <xsl:call-template name="cibtr:ProcessNonattrOpMetaAttributes">
                         <xsl:with-param name="Source" select="."/>
                         <xsl:with-param name="InverseMode" select="true()"/>
                         <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -1504,7 +1506,8 @@
                     </xsl:when>
                     <xsl:otherwise>
                       <xsl:copy>
-                        <xsl:apply-templates select="@*"/>
+                        <xsl:apply-templates select="@*"
+                                             mode="cibtr:main"/>
                       </xsl:copy>
                     </xsl:otherwise>
                   </xsl:choose>
@@ -1523,11 +1526,11 @@
           </xsl:when>
           <xsl:when test="$InverseMode"/>
           <xsl:otherwise>
-            <xsl:call-template name="HelperDenormalizedSpace">
+            <xsl:call-template name="cibtr:HelperDenormalizedSpace">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
             </xsl:call-template>
-            <xsl:call-template name="HelperIdentity"/>
+            <xsl:call-template name="cibtr:HelperIdentity"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:when>
@@ -1537,7 +1540,7 @@
         <!-- drop -->
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="HelperIdentity"/>
+        <xsl:call-template name="cibtr:HelperIdentity"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:for-each>
@@ -1550,7 +1553,7 @@
  Dependencies:   ProcessNonattrOpMetaAttributes [non-inverse only]
                  ProcessOpInstanceAttributes [non-inverse only]
  -->
-<xsl:template name="ProcessAttrOpMetaAttributes">
+<xsl:template name="cibtr:ProcessAttrOpMetaAttributes">
   <xsl:param name="Source"/>
   <xsl:param name="InverseMode" select="false()"/>
   <xsl:param name="InnerSimulation" select="false()"/>
@@ -1560,7 +1563,7 @@
         <xsl:value-of select="''"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="ProcessAttrOpMetaAttributes">
+        <xsl:call-template name="cibtr:ProcessAttrOpMetaAttributes">
           <xsl:with-param name="Source" select="$Source"/>
           <xsl:with-param name="InverseMode" select="$InverseMode"/>
           <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -1586,7 +1589,7 @@
     <xsl:if test="$InverseMode
                   and
                   $InnerSimulation">
-      <xsl:call-template name="HelperDenormalizedSpace">
+      <xsl:call-template name="cibtr:HelperDenormalizedSpace">
         <xsl:with-param name="Source" select="$InnerPass"/>
         <xsl:with-param name="ResultTreeFragment" select="true()"/>
       </xsl:call-template>
@@ -1609,7 +1612,7 @@
     <!-- B: special-casing @* -->
     <xsl:for-each select="@*">
       <xsl:variable name="Replacement"
-                    select="$MapResourcesOperation/cibtr:replace[
+                    select="$cibtr:MapResourcesOperation/cibtr:replace[
                               @what = name(current())
                               and
                               (
@@ -1624,7 +1627,7 @@
                                   not(@in-case-of)
                                   and
                                   not(
-                                    $MapResourcesOperation/cibtr:replace[
+                                    $cibtr:MapResourcesOperation/cibtr:replace[
                                       @what = name(current())
                                       and
                                       @in-case-of
@@ -1637,7 +1640,7 @@
                               )
                             ]"/>
       <xsl:if test="$InnerPass = 'TRIGGER-MSG'">
-        <xsl:call-template name="MapMsg">
+        <xsl:call-template name="cibtr:MapMsg">
           <xsl:with-param name="Context"
                                 select="concat(../@id,
                                                ' (rsc=', $EnclosingTag/@id,
@@ -1664,7 +1667,7 @@
                - successors sourced like this (see below) -->
           <xsl:variable name="SimulateFollowingSiblings">
             <xsl:for-each select="../following-sibling::op">
-              <xsl:call-template name="ProcessAttrOpMetaAttributes">
+              <xsl:call-template name="cibtr:ProcessAttrOpMetaAttributes">
                 <xsl:with-param name="Source" select="."/>
                 <xsl:with-param name="InverseMode" select="true()"/>
                 <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -1725,7 +1728,7 @@
            be propagated next door, into existing/new meta_attributes -->
       <xsl:variable name="ProcessedInverseNonruleOpInstanceAttributes">
         <xsl:for-each select="instance_attributes[not(rule)]">
-          <xsl:call-template name="ProcessOpInstanceAttributes">
+          <xsl:call-template name="cibtr:ProcessOpInstanceAttributes">
             <xsl:with-param name="Source" select="."/>
             <xsl:with-param name="InnerSimulation" select="true()"/>
             <xsl:with-param name="InverseMode" select="true()"/>
@@ -1764,7 +1767,7 @@
           </xsl:when>
           <xsl:when test="self::instance_attributes">
             <xsl:variable name="ProcessedOpInstanceAttributes">
-              <xsl:call-template name="ProcessOpInstanceAttributes">
+              <xsl:call-template name="cibtr:ProcessOpInstanceAttributes">
                 <xsl:with-param name="Source" select="."/>
                 <xsl:with-param name="InnerSimulation" select="true()"/>
               </xsl:call-template>
@@ -1773,8 +1776,9 @@
             <xsl:if test="normalize-space($ProcessedOpInstanceAttributes)
                           != $ProcessedOpInstanceAttributes">
               <xsl:copy>
-                <xsl:apply-templates select="@*"/>
-                <xsl:call-template name="ProcessOpInstanceAttributes">
+                <xsl:apply-templates select="@*"
+                                     mode="cibtr:main"/>
+                <xsl:call-template name="cibtr:ProcessOpInstanceAttributes">
                   <xsl:with-param name="Source" select="."/>
                   <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
                   <!-- cf. trick E. -->
@@ -1785,7 +1789,7 @@
           </xsl:when>
           <xsl:when test="self::meta_attributes">
             <xsl:variable name="ProcessedOpMetaAttributes">
-              <xsl:call-template name="ProcessNonattrOpMetaAttributes">
+              <xsl:call-template name="cibtr:ProcessNonattrOpMetaAttributes">
                 <xsl:with-param name="Source" select="."/>
                 <xsl:with-param name="InnerSimulation" select="true()"/>
                 <xsl:with-param name="InnerPass"
@@ -1814,10 +1818,11 @@
                             != $ProcessedInverseNonruleOpInstanceAttributes
                           )">
               <xsl:copy>
-                <xsl:apply-templates select="@*"/>
+                <xsl:apply-templates select="@*"
+                                     mode="cibtr:main"/>
                 <xsl:if test="normalize-space($ProcessedOpMetaAttributes)
                               != $ProcessedOpMetaAttributes">
-                  <xsl:call-template name="ProcessNonattrOpMetaAttributes">
+                  <xsl:call-template name="cibtr:ProcessNonattrOpMetaAttributes">
                     <xsl:with-param name="Source" select="."/>
                     <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
                     <!-- cf. trick E. -->
@@ -1831,7 +1836,7 @@
                               normalize-space($ProcessedInverseNonruleOpInstanceAttributes)
                               != $ProcessedInverseNonruleOpInstanceAttributes">
                   <xsl:for-each select="../instance_attributes[not(rule)]">
-                    <xsl:call-template name="ProcessOpInstanceAttributes">
+                    <xsl:call-template name="cibtr:ProcessOpInstanceAttributes">
                       <xsl:with-param name="Source" select="."/>
                       <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
                       <xsl:with-param name="InverseMode" select="true()"/>
@@ -1842,7 +1847,7 @@
             </xsl:if>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:call-template name="HelperIdentity"/>
+            <xsl:call-template name="cibtr:HelperIdentity"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:for-each>
@@ -1856,21 +1861,23 @@
                     != $ProcessedInverseNonruleOpInstanceAttributes">
         <meta_attributes id="{concat('_2TO3_', @id, '-meta')}">
           <xsl:for-each select="instance_attributes[not(rule)]">
-            <xsl:call-template name="ProcessOpInstanceAttributes">
+            <xsl:call-template name="cibtr:ProcessOpInstanceAttributes">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InnerSimulation" select="$InnerSimulation"/>
               <xsl:with-param name="InverseMode" select="true()"/>
             </xsl:call-template>
           </xsl:for-each>
-          <xsl:apply-templates select="text()[position() = last()]"/>
+          <xsl:apply-templates select="text()[position() = last()]"
+                               mode="cibtr:main"/>
         </meta_attributes>
-        <xsl:apply-templates select="text()[position() = last()]"/>
+        <xsl:apply-templates select="text()[position() = last()]"
+                             mode="cibtr:main"/>
       </xsl:if>
 
       <!-- ...then individually for rules-driven ones -->
       <xsl:for-each select="instance_attributes[rule]">
         <xsl:variable name="ProcessedInverseRuleOpInstanceAttributes">
-          <xsl:call-template name="ProcessOpInstanceAttributes">
+          <xsl:call-template name="cibtr:ProcessOpInstanceAttributes">
             <xsl:with-param name="Source" select="."/>
             <xsl:with-param name="InnerSimulation" select="true()"/>
             <xsl:with-param name="InverseMode" select="true()"/>
@@ -1890,20 +1897,23 @@
           <meta_attributes>
             <xsl:apply-templates select="@*[
                                            name() != 'id'
-                                         ]"/>
+                                         ]"
+                                 mode="cibtr:main"/>
             <xsl:attribute name='id'>
               <xsl:value-of select="concat('_2TO3_', @id)"/>
             </xsl:attribute>
             <xsl:apply-templates select="node()[
                                            name() != 'nvpair'
-                                         ]"/>
-            <xsl:call-template name="ProcessOpInstanceAttributes">
+                                         ]"
+                                 mode="cibtr:main"/>
+            <xsl:call-template name="cibtr:ProcessOpInstanceAttributes">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InverseMode" select="true()"/>
               <!-- cf. trick E. -->
               <xsl:with-param name="InnerPass" select="$ProcessedInverseRuleOpInstanceAttributes"/>
             </xsl:call-template>
-            <xsl:apply-templates select="text()[position() = last()]"/>
+            <xsl:apply-templates select="text()[position() = last()]"
+                                 mode="cibtr:main"/>
           </meta_attributes>
         </xsl:if>
       </xsl:for-each>
@@ -1920,7 +1930,7 @@
 
  Variant:        'op_defaults' | 'rsc_defaults'
  -->
-<xsl:template name="ProcessDefaultsNonruleClusterProperties">
+<xsl:template name="cibtr:ProcessDefaultsNonruleClusterProperties">
   <xsl:param name="Source"/>
   <xsl:param name="Variant"/>
   <xsl:param name="InnerSimulation" select="false()"/>
@@ -1930,7 +1940,7 @@
         <xsl:value-of select="''"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="ProcessDefaultsNonruleClusterProperties">
+        <xsl:call-template name="cibtr:ProcessDefaultsNonruleClusterProperties">
           <xsl:with-param name="Source" select="$Source"/>
           <xsl:with-param name="Variant" select="$Variant"/>
           <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -1945,7 +1955,7 @@
                       and
                       not(rule)
                     ]">
-      <xsl:call-template name="ProcessClusterProperties">
+      <xsl:call-template name="cibtr:ProcessClusterProperties">
         <xsl:with-param name="Source"
                         select="$Source/crm_config/cluster_property_set[
                                   not(@id-ref)
@@ -1962,7 +1972,7 @@
       </xsl:call-template>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:call-template name="ProcessClusterProperties">
+      <xsl:call-template name="cibtr:ProcessClusterProperties">
         <xsl:with-param name="Source"
                       select="$Source/crm_config/cluster_property_set[
                                   not(@id-ref)
@@ -1985,7 +1995,7 @@
 
  Variant:        'op_defaults' | 'rsc_defaults'
  -->
-<xsl:template name="ProcessDefaultsRuleClusterProperties">
+<xsl:template name="cibtr:ProcessDefaultsRuleClusterProperties">
   <xsl:param name="Source"/>
   <xsl:param name="Variant"/>
   <xsl:param name="InnerSimulation" select="false()"/>
@@ -1995,7 +2005,7 @@
         <xsl:value-of select="''"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="ProcessDefaultsRuleClusterProperties">
+        <xsl:call-template name="cibtr:ProcessDefaultsRuleClusterProperties">
           <xsl:with-param name="Source" select="$Source"/>
           <xsl:with-param name="Variant" select="$Variant"/>
           <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -2010,7 +2020,7 @@
                           rule
                         ]">
     <xsl:variable name="ProcessedPartial">
-      <xsl:call-template name="ProcessClusterProperties">
+      <xsl:call-template name="cibtr:ProcessClusterProperties">
         <xsl:with-param name="Source" select="$Source"/>
         <xsl:with-param name="InverseMode" select="$Variant"/>
         <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -2021,7 +2031,7 @@
                   != $ProcessedPartial">
       <meta_attributes id="{concat('_2TO3_', @id)}">
         <xsl-copy-of select="rule"/>
-        <xsl:call-template name="ProcessClusterProperties">
+        <xsl:call-template name="cibtr:ProcessClusterProperties">
           <xsl:with-param name="Source" select="$Source"/>
           <xsl:with-param name="InverseMode" select="$Variant"/>
         </xsl:call-template>
@@ -2036,19 +2046,21 @@
 
  -->
 
-<xsl:template match="cib">
+<xsl:template match="cib" mode="cibtr:main">
   <xsl:copy>
-    <xsl:apply-templates select="@*"/>
+    <xsl:apply-templates select="@*"
+                         mode="cibtr:main"/>
     <xsl:attribute name="validate-with">
-      <xsl:value-of select="concat('pacemaker-', $cib-min-ver)"/>
+      <xsl:value-of select="concat('pacemaker-', $cibtr:cib-min-ver)"/>
     </xsl:attribute>
-    <xsl:apply-templates select="node()"/>
+    <xsl:apply-templates select="node()"
+                         mode="cibtr:main"/>
   </xsl:copy>
 </xsl:template>
 
-<xsl:template match="cluster_property_set">
+<xsl:template match="cluster_property_set" mode="cibtr:main">
   <xsl:variable name="ProcessedClusterProperties">
-    <xsl:call-template name="ProcessClusterProperties">
+    <xsl:call-template name="cibtr:ProcessClusterProperties">
       <xsl:with-param name="Source" select="."/>
       <xsl:with-param name="InnerSimulation" select="true()"/>
       <xsl:with-param name="InnerPass" select="'TRIGGER-MSG'"/>
@@ -2057,8 +2069,9 @@
   <xsl:if test="normalize-space($ProcessedClusterProperties)
                 != $ProcessedClusterProperties">
     <xsl:copy>
-      <xsl:apply-templates select="@*"/>
-      <xsl:call-template name="ProcessClusterProperties">
+      <xsl:apply-templates select="@*"
+                           mode="cibtr:main"/>
+      <xsl:call-template name="cibtr:ProcessClusterProperties">
         <xsl:with-param name="Source" select="."/>
         <!-- cf. trick E. -->
         <xsl:with-param name="InnerPass" select="$ProcessedClusterProperties"/>
@@ -2067,14 +2080,14 @@
   </xsl:if>
 </xsl:template>
 
-<xsl:template match="rsc_colocation">
+<xsl:template match="rsc_colocation" mode="cibtr:main">
   <xsl:copy>
     <xsl:for-each select="@*">
       <xsl:variable name="Replacement"
-                    select="$MapConstraintsColocation/cibtr:replace[
+                    select="$cibtr:MapConstraintsColocation/cibtr:replace[
                               @what = name(current())
                             ]"/>
-      <xsl:call-template name="MapMsg">
+      <xsl:call-template name="cibtr:MapMsg">
         <xsl:with-param name="Context" select="../@id"/>
         <xsl:with-param name="Replacement" select="$Replacement"/>
       </xsl:call-template>
@@ -2095,15 +2108,16 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:for-each>
-    <xsl:apply-templates select="node()"/>
+    <xsl:apply-templates select="node()"
+                         mode="cibtr:main"/>
   </xsl:copy>
 </xsl:template>
 
-<xsl:template match="node">
+<xsl:template match="node" mode="cibtr:main">
   <xsl:copy>
     <xsl:for-each select="@*">
       <xsl:variable name="Replacement"
-                    select="$MapClusterNode/cibtr:replace[
+                    select="$cibtr:MapClusterNode/cibtr:replace[
                               @what = name(current())
                               and
                               (
@@ -2118,7 +2132,7 @@
                                   not(@in-case-of)
                                   and
                                   not(
-                                    $MapClusterNode/cibtr:replace[
+                                    $cibtr:MapClusterNode/cibtr:replace[
                                       @what = name(current())
                                       and
                                       @in-case-of
@@ -2130,7 +2144,7 @@
                                 )
                               )
                             ]"/>
-      <xsl:call-template name="MapMsg">
+      <xsl:call-template name="cibtr:MapMsg">
         <xsl:with-param name="Context" select="concat(../@uname, ' (id=', ../@id, ')')"/>
         <xsl:with-param name="Replacement" select="$Replacement"/>
       </xsl:call-template>
@@ -2158,7 +2172,8 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:for-each>
-    <xsl:apply-templates select="node()"/>
+    <xsl:apply-templates select="node()"
+                         mode="cibtr:main"/>
   </xsl:copy>
 </xsl:template>
 
@@ -2183,27 +2198,29 @@
  Not compatible with meta_attributes referenced via id-ref
  (would need external preprocessing).
  -->
-<xsl:template match="primitive|template">
+<xsl:template match="primitive|template" mode="cibtr:main">
   <xsl:copy>
-    <xsl:apply-templates select="@*"/>
+    <xsl:apply-templates select="@*"
+                         mode="cibtr:main"/>
     <!-- B: special-casing operations|instance_attributes|meta_attributes -->
     <xsl:for-each select="node()">
       <xsl:choose>
         <xsl:when test="self::operations">
           <xsl:copy>
-            <xsl:apply-templates select="@*"/>
+            <xsl:apply-templates select="@*"
+                                 mode="cibtr:main"/>
             <!-- B: special-casing op -->
             <xsl:for-each select="node()">
               <xsl:choose>
                 <xsl:when test="self::op">
                   <!-- process @*|meta_attributes/nvpair
                        (keep/drop/move elsewhere) -->
-                  <xsl:call-template name="ProcessAttrOpMetaAttributes">
+                  <xsl:call-template name="cibtr:ProcessAttrOpMetaAttributes">
                     <xsl:with-param name="Source" select="."/>
                   </xsl:call-template>
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:call-template name="HelperIdentity"/>
+                  <xsl:call-template name="cibtr:HelperIdentity"/>
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:for-each>
@@ -2212,7 +2229,7 @@
         </xsl:when>
         <xsl:when test="self::instance_attributes">
           <xsl:variable name="ProcessedRscInstanceAttributes">
-            <xsl:call-template name="ProcessRscInstanceAttributes">
+            <xsl:call-template name="cibtr:ProcessRscInstanceAttributes">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InnerSimulation" select="true()"/>
               <xsl:with-param name="InnerPass" select="'TRIGGER-MSG'"/>
@@ -2222,8 +2239,9 @@
           <xsl:if test="normalize-space($ProcessedRscInstanceAttributes)
                         != $ProcessedRscInstanceAttributes">
             <xsl:copy>
-              <xsl:apply-templates select="@*"/>
-              <xsl:call-template name="ProcessRscInstanceAttributes">
+              <xsl:apply-templates select="@*"
+                                   mode="cibtr:main"/>
+              <xsl:call-template name="cibtr:ProcessRscInstanceAttributes">
                 <xsl:with-param name="Source" select="."/>
                 <!-- cf. trick E. -->
                 <xsl:with-param name="InnerPass" select="$ProcessedRscInstanceAttributes"/>
@@ -2233,7 +2251,7 @@
         </xsl:when>
         <xsl:when test="self::meta_attributes">
           <xsl:variable name="ProcessedRscMetaAttributes">
-            <xsl:call-template name="ProcessRscMetaAttributes">
+            <xsl:call-template name="cibtr:ProcessRscMetaAttributes">
               <xsl:with-param name="Source" select="."/>
               <xsl:with-param name="InnerSimulation" select="true()"/>
               <xsl:with-param name="InnerPass" select="'TRIGGER-MSG'"/>
@@ -2243,8 +2261,9 @@
           <xsl:if test="normalize-space($ProcessedRscMetaAttributes)
                         != $ProcessedRscMetaAttributes">
             <xsl:copy>
-              <xsl:apply-templates select="@*"/>
-              <xsl:call-template name="ProcessRscMetaAttributes">
+              <xsl:apply-templates select="@*"
+                                   mode="cibtr:main"/>
+              <xsl:call-template name="cibtr:ProcessRscMetaAttributes">
                 <xsl:with-param name="Source" select="."/>
                 <!-- cf. trick E. -->
                 <xsl:with-param name="InnerPass" select="$ProcessedRscMetaAttributes"/>
@@ -2253,7 +2272,7 @@
           </xsl:if>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:call-template name="HelperIdentity"/>
+          <xsl:call-template name="cibtr:HelperIdentity"/>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:for-each>
@@ -2264,7 +2283,7 @@
     <!-- ...indirectly from op attributes -->
     <xsl:variable name="ToPropagateFromOp">
       <xsl:for-each select="operations/op">
-        <xsl:call-template name="ProcessAttrOpMetaAttributes">
+        <xsl:call-template name="cibtr:ProcessAttrOpMetaAttributes">
           <xsl:with-param name="Source" select="."/>
           <xsl:with-param name="InverseMode" select="true()"/>
           <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -2277,14 +2296,16 @@
                   != $ToPropagateFromOp">
       <meta_attributes id="{concat('_2TO3_', @id, '-meta')}">
         <xsl:for-each select="operations/op">
-          <xsl:call-template name="ProcessAttrOpMetaAttributes">
+          <xsl:call-template name="cibtr:ProcessAttrOpMetaAttributes">
             <xsl:with-param name="Source" select="."/>
             <xsl:with-param name="InverseMode" select="true()"/>
           </xsl:call-template>
         </xsl:for-each>
-        <xsl:apply-templates select="text()[position() = last()]"/>
+        <xsl:apply-templates select="text()[position() = last()]"
+                             mode="cibtr:main"/>
       </meta_attributes>
-      <xsl:apply-templates select="text()[position() = last()]"/>
+      <xsl:apply-templates select="text()[position() = last()]"
+                           mode="cibtr:main"/>
     </xsl:if>
 
     <!-- ...directly by picking existing nvpairs of
@@ -2292,7 +2313,7 @@
     <xsl:for-each select="operations/op/meta_attributes
                           |operations/op/instance_attributes">
       <xsl:variable name="ProcessedOpMetaAttributes">
-        <xsl:call-template name="ProcessNonattrOpMetaAttributes">
+        <xsl:call-template name="cibtr:ProcessNonattrOpMetaAttributes">
           <xsl:with-param name="Source" select="."/>
           <xsl:with-param name="InverseMode" select="true()"/>
           <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -2305,52 +2326,56 @@
         <meta_attributes>
           <xsl:apply-templates select="@*[
                                          name() != 'id'
-                                       ]"/>
+                                       ]"
+                               mode="cibtr:main"/>
           <xsl:attribute name='id'>
             <xsl:value-of select="concat('_2TO3_', @id)"/>
           </xsl:attribute>
           <xsl:apply-templates select="node()[
                                          name() != 'nvpair'
-                                       ]"/>
-          <xsl:call-template name="ProcessNonattrOpMetaAttributes">
+                                       ]"
+                               mode="cibtr:main"/>
+          <xsl:call-template name="cibtr:ProcessNonattrOpMetaAttributes">
             <xsl:with-param name="Source" select="."/>
             <xsl:with-param name="InverseMode" select="true()"/>
             <!-- cf. trick E. -->
             <xsl:with-param name="InnerPass" select="$ProcessedOpMetaAttributes"/>
           </xsl:call-template>
-          <xsl:apply-templates select="text()[position() = last()]"/>
+          <xsl:apply-templates select="text()[position() = last()]"
+                               mode="cibtr:main"/>
         </meta_attributes>
-        <xsl:apply-templates select="text()[position() = last()]"/>
+        <xsl:apply-templates select="text()[position() = last()]"
+                             mode="cibtr:main"/>
       </xsl:if>
     </xsl:for-each>
   </xsl:copy>
 </xsl:template>
 
-<xsl:template match="configuration">
+<xsl:template match="configuration" mode="cibtr:main">
   <xsl:variable name="Configuration" select="."/>
   <xsl:variable name="ProcessedOpDefaultsNonruleClusterProperties">
-    <xsl:call-template name="ProcessDefaultsNonruleClusterProperties">
+    <xsl:call-template name="cibtr:ProcessDefaultsNonruleClusterProperties">
       <xsl:with-param name="Source" select="$Configuration"/>
       <xsl:with-param name="Variant" select="'op_defaults'"/>
       <xsl:with-param name="InnerSimulation" select="true()"/>
     </xsl:call-template>
   </xsl:variable>
   <xsl:variable name="ProcessedRscDefaultsNonruleClusterProperties">
-    <xsl:call-template name="ProcessDefaultsNonruleClusterProperties">
+    <xsl:call-template name="cibtr:ProcessDefaultsNonruleClusterProperties">
       <xsl:with-param name="Source" select="$Configuration"/>
       <xsl:with-param name="Variant" select="'rsc_defaults'"/>
       <xsl:with-param name="InnerSimulation" select="true()"/>
     </xsl:call-template>
   </xsl:variable>
   <xsl:variable name="ProcessedOpDefaultsRuleClusterProperties">
-    <xsl:call-template name="ProcessDefaultsNonruleClusterProperties">
+    <xsl:call-template name="cibtr:ProcessDefaultsNonruleClusterProperties">
       <xsl:with-param name="Source" select="$Configuration"/>
       <xsl:with-param name="Variant" select="'op_defaults'"/>
       <xsl:with-param name="InnerSimulation" select="true()"/>
     </xsl:call-template>
   </xsl:variable>
   <xsl:variable name="ProcessedRscDefaultsRuleClusterProperties">
-    <xsl:call-template name="ProcessDefaultsNonruleClusterProperties">
+    <xsl:call-template name="cibtr:ProcessDefaultsNonruleClusterProperties">
       <xsl:with-param name="Source" select="$Configuration"/>
       <xsl:with-param name="Variant" select="'rsc_defaults'"/>
       <xsl:with-param name="InnerSimulation" select="true()"/>
@@ -2358,14 +2383,16 @@
   </xsl:variable>
 
   <xsl:copy>
-    <xsl:apply-templates select="@*"/>
+    <xsl:apply-templates select="@*"
+                         mode="cibtr:main"/>
     <!-- B: special-casing {op,rsc}_defaults -->
     <xsl:for-each select="node()">
       <xsl:choose>
         <xsl:when test="self::op_defaults|self::rsc_defaults">
           <xsl:variable name="WhichDefaults" select="name()"/>
           <xsl:copy>
-            <xsl:apply-templates select="@*"/>
+            <xsl:apply-templates select="@*"
+                                 mode="cibtr:main"/>
             <!-- B: special-casing meta_attributes -->
             <xsl:for-each select="node()">
               <xsl:copy>
@@ -2383,18 +2410,20 @@
                                       ]
                                     )
                                   ]">
-                    <xsl:apply-templates select="@*|node()"/>
+                  <xsl:apply-templates select="@*|node()"
+                                       mode="cibtr:main"/>
                     <xsl:if test="$WhichDefaults = 'op_defaults'
                                   or
                                   $WhichDefaults = 'rsc_defaults'">
-                      <xsl:call-template name="ProcessDefaultsNonruleClusterProperties">
+                      <xsl:call-template name="cibtr:ProcessDefaultsNonruleClusterProperties">
                         <xsl:with-param name="Source" select="$Configuration"/>
                         <xsl:with-param name="Variant" select="$WhichDefaults"/>
                       </xsl:call-template>
                     </xsl:if>
                   </xsl:when>
                   <xsl:otherwise>
-                    <xsl:apply-templates select="@*|node()"/>
+                    <xsl:apply-templates select="@*|node()"
+                                         mode="cibtr:main"/>
                   </xsl:otherwise>
                 </xsl:choose>
                 <xsl:if test="(
@@ -2410,7 +2439,7 @@
                                 normalize-space($ProcessedRscDefaultsRuleClusterProperties)
                                 != $ProcessedRscDefaultsRuleClusterProperties
                               )">
-                  <xsl:call-template name="ProcessDefaultsRuleClusterProperties">
+                  <xsl:call-template name="cibtr:ProcessDefaultsRuleClusterProperties">
                     <xsl:with-param name="Source" select="$Configuration"/>
                     <xsl:with-param name="Variant" select="$WhichDefaults"/>
                   </xsl:call-template>
@@ -2421,7 +2450,7 @@
           </xsl:copy>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:call-template name="HelperIdentity"/>
+          <xsl:call-template name="cibtr:HelperIdentity"/>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:for-each>
@@ -2439,17 +2468,18 @@
         <xsl:if test="normalize-space($ProcessedOpDefaultsNonruleClusterProperties)
                       != $ProcessedOpDefaultsNonruleClusterProperties">
           <meta_attributes id="{concat('_2TO3_', '-op-defaults')}">
-            <xsl:call-template name="ProcessDefaultsNonruleClusterProperties">
+            <xsl:call-template name="cibtr:ProcessDefaultsNonruleClusterProperties">
               <xsl:with-param name="Source" select="$Configuration"/>
               <xsl:with-param name="Variant" select="'op_defaults'"/>
             </xsl:call-template>
           </meta_attributes>
         </xsl:if>
-        <xsl:call-template name="ProcessDefaultsRuleClusterProperties">
+        <xsl:call-template name="cibtr:ProcessDefaultsRuleClusterProperties">
           <xsl:with-param name="Source" select="$Configuration"/>
           <xsl:with-param name="Variant" select="'op_defaults'"/>
         </xsl:call-template>
-        <xsl:apply-templates select="text()[position() = last()]"/>
+        <xsl:apply-templates select="text()[position() = last()]"
+                             mode="cibtr:main"/>
       </op_defaults>
     </xsl:if>
     <xsl:if test="not(rsc_defaults)
@@ -2465,24 +2495,30 @@
         <xsl:if test="normalize-space($ProcessedRscDefaultsNonruleClusterProperties)
                       != $ProcessedRscDefaultsNonruleClusterProperties">
           <meta_attributes id="{concat('_2TO3_', '-rsc-defaults')}">
-            <xsl:call-template name="ProcessDefaultsNonruleClusterProperties">
+            <xsl:call-template name="cibtr:ProcessDefaultsNonruleClusterProperties">
               <xsl:with-param name="Source" select="$Configuration"/>
               <xsl:with-param name="Variant" select="'rsc_defaults'"/>
             </xsl:call-template>
           </meta_attributes>
         </xsl:if>
-        <xsl:call-template name="ProcessDefaultsRuleClusterProperties">
+        <xsl:call-template name="cibtr:ProcessDefaultsRuleClusterProperties">
           <xsl:with-param name="Source" select="$Configuration"/>
           <xsl:with-param name="Variant" select="'rsc_defaults'"/>
         </xsl:call-template>
-        <xsl:apply-templates select="text()[position() = last()]"/>
+        <xsl:apply-templates select="text()[position() = last()]"
+                             mode="cibtr:main"/>
       </rsc_defaults>
     </xsl:if>
   </xsl:copy>
 </xsl:template>
 
-<xsl:template match="@*|node()">
-  <xsl:call-template name="HelperIdentity"/>
+<xsl:template match="@*|node()" mode="cibtr:main">
+  <xsl:call-template name="cibtr:HelperIdentity"/>
+</xsl:template>
+
+<!-- mode-less, easy to override kick-off -->
+<xsl:template match="/">
+  <xsl:call-template name="cibtr:HelperIdentity"/>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/xml/upgrade-2.10.xsl
+++ b/xml/upgrade-2.10.xsl
@@ -2512,6 +2512,14 @@
   </xsl:copy>
 </xsl:template>
 
+<!-- used in test files to allow in-browser on-the-fly upgrade reports -->
+<xsl:template match="processing-instruction()[
+                       name() = 'xml-stylesheet'
+                       and
+                       count(..|/) = 1
+                     ]"
+              mode="cibtr:main"/>
+
 <xsl:template match="@*|node()" mode="cibtr:main">
   <xsl:call-template name="cibtr:HelperIdentity"/>
 </xsl:template>

--- a/xml/upgrade-detail.xsl
+++ b/xml/upgrade-detail.xsl
@@ -71,7 +71,7 @@
             <xsl:value-of select="','"/>
           </xsl:if>
         </xsl:if>
-	<xsl:choose>
+        <xsl:choose>
           <xsl:when test="string($Replacement/@in-case-of)">
             <xsl:value-of select="concat(' for matching ',
                                          $Replacement/@in-case-of)"/>
@@ -85,7 +85,7 @@
                                     ' prefix that will, meanwhile, get dropped'
                                   )"/>
           </xsl:when>
-	</xsl:choose>
+        </xsl:choose>
       </cibtr-2:noop>
       <xsl:if test="$Replacement/@msg-extra">
         <cibtr-2:noop>


### PR DESCRIPTION
This exercises some maintenance and allows one to perform the upgrade
on-the-fly, directly in the web browser + immediately observe the impact
in the form of a diff.

There's a possibility to spin-off this merely test maintenance helper to
full-fledged script that would present something similar to the user
based on arbitrary input CIB.  Such informative page itself can be
prerendered with `xsltproc` (which would be unnecessary overhead
in the context of its original use). 