### PR TITLE
Fix: controld: able to manually confirm unseen nodes are down

### DIFF
--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -357,6 +357,7 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 
     // Refresh the remote node cache when the scheduler is invoked
     crm_remote_peer_cache_refresh(output);
+    crm_known_peer_cache_refresh(output);
 
     crm_xml_add(output, XML_ATTR_DC_UUID, fsa_our_uuid);
     crm_xml_add_int(output, XML_ATTR_HAVE_QUORUM, fsa_has_quorum);

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -348,4 +348,7 @@ gboolean node_name_is_valid(const char *key, const char *name);
 crm_node_t * crm_find_peer_full(unsigned int id, const char *uname, int flags);
 crm_node_t * crm_find_peer(unsigned int id, const char *uname);
 
+void crm_known_peer_cache_refresh(xmlNode *cib);
+const char *crm_known_peer_id(const char *peer_name);
+
 #endif


### PR DESCRIPTION
9045bacb4 prevented manual fencing confirmations from creating node
entries for random unknown nodes, but it also disabled the ability to do
manual fencing confirmations for the nodes that are already known in the
CIB but not yet in the membership cache.

This commit fixes it.