### PR TITLE
Low: ensure messages from crm_schema_init ("file scan") can be logged

### DIFF
--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -716,8 +716,6 @@ crm_log_preinit(const char *entity, int argc, char **argv)
     if(have_logging == FALSE) {
         have_logging = TRUE;
 
-        crm_xml_init(); /* Sets buffer allocation strategy */
-
         if (crm_trace_nonlog == 0) {
             crm_trace_nonlog = g_quark_from_static_string("Pacemaker non-logging tracepoint");
         }
@@ -845,6 +843,8 @@ crm_log_init(const char *entity, uint8_t level, gboolean daemon, gboolean to_std
     if (quiet == FALSE && crm_is_daemon == FALSE) {
         crm_log_args(argc, argv);
     }
+
+    crm_xml_init();  /* Sets buffer allocation strategy */
 
     if (crm_is_daemon) {
         const char *user = getenv("USER");

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -171,7 +171,6 @@ main(int argc, char **argv)
 
     int option_index = 0;
 
-    crm_xml_init(); /* Sets buffer allocation strategy */
     crm_log_cli_init("cibadmin");
     set_crm_log_level(LOG_CRIT);
     crm_set_options(NULL, "command [options] [data]", long_options,


### PR DESCRIPTION
This fit-all-like initialization resembles more spaghetti than something
maintainable with confidence (see also redundant call in cibadmin.c
that's getting dropped).  But at least make sure that log messages
coming from crm_schema_init (currently called from crm_xml_init)
have a chance of being meaningfully dispatched.  That hasn't been
the case until now.