### PR TITLE
High: CIB: no schema violating oversimplified patching with @id-ref

### DIFF
--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -4599,8 +4599,9 @@ static int
 add_xml_object(xmlNode * parent, xmlNode * target, xmlNode * update, gboolean as_diff)
 {
     xmlNode *a_child = NULL;
-    const char *object_id = NULL;
-    const char *object_name = NULL;
+    const char *object_name = NULL,
+               *object_href = NULL,
+               *object_href_val = NULL;
 
 #if XML_PARSE_DEBUG
     crm_log_xml_trace("update:", update);
@@ -4614,25 +4615,38 @@ add_xml_object(xmlNode * parent, xmlNode * target, xmlNode * update, gboolean as
     }
 
     object_name = crm_element_name(update);
-    object_id = ID(update);
+    object_href_val = ID(update);
+    if (object_href_val != NULL) {
+        object_href = XML_ATTR_ID;
+    } else {
+        object_href_val = crm_element_value(update, XML_ATTR_IDREF);
+        object_href = (object_href_val == NULL) ? NULL : XML_ATTR_IDREF;
+    }
 
     CRM_CHECK(object_name != NULL, return 0);
     CRM_CHECK(target != NULL || parent != NULL, return 0);
 
     if (target == NULL) {
-        target = find_entity(parent, object_name, object_id);
+        target = find_entity_by_attr_or_just_name(parent, object_name,
+                                                  object_href, object_href_val);
     }
 
     if (target == NULL) {
         target = create_xml_node(parent, object_name);
         CRM_CHECK(target != NULL, return 0);
 #if XML_PARSER_DEBUG
-        crm_trace("Added  <%s%s%s/>", crm_str(object_name),
-                  object_id ? " id=" : "", object_id ? object_id : "");
+        crm_trace("Added  <%s%s%s%s%s/>", crm_str(object_name),
+                  object_href ? " " : "",
+                  object_href ? object_href : "",
+                  object_href ? "=" : "",
+                  object_href ? object_href_val : "");
 
     } else {
-        crm_trace("Found node <%s%s%s/> to update",
-                  crm_str(object_name), object_id ? " id=" : "", object_id ? object_id : "");
+        crm_trace("Found node <%s%s%s%s%s/> to update", crm_str(object_name),
+                  object_href ? " " : "",
+                  object_href ? object_href : "",
+                  object_href ? "=" : "",
+                  object_href ? object_href_val : "");
 #endif
     }
 
@@ -4658,13 +4672,21 @@ add_xml_object(xmlNode * parent, xmlNode * target, xmlNode * update, gboolean as
 
     for (a_child = __xml_first_child(update); a_child != NULL; a_child = __xml_next(a_child)) {
 #if XML_PARSER_DEBUG
-        crm_trace("Updating child <%s id=%s>", crm_element_name(a_child), ID(a_child));
+        crm_trace("Updating child <%s%s%s%s%s/>", crm_str(object_name),
+                  object_href ? " " : "",
+                  object_href ? object_href : "",
+                  object_href ? "=" : "",
+                  object_href ? object_href_val : "");
 #endif
         add_xml_object(target, NULL, a_child, as_diff);
     }
 
 #if XML_PARSER_DEBUG
-    crm_trace("Finished with <%s id=%s>", crm_str(object_name), crm_str(object_id));
+    crm_trace("Finished with <%s%s%s%s%s/>", crm_str(object_name),
+              object_href ? " " : "",
+              object_href ? object_href : "",
+              object_href ? "=" : "",
+              object_href ? object_href_val : "");
 #endif
     return 0;
 }

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -245,10 +245,7 @@ int get_attr_name(const char *input, size_t offset, size_t max);
 int get_attr_value(const char *input, size_t offset, size_t max);
 gboolean can_prune_leaf(xmlNode * xml_node);
 
-void diff_filter_context(int context, int upper_bound, int lower_bound,
-                         xmlNode * xml_node, xmlNode * parent);
-int in_upper_context(int depth, int context, xmlNode * xml_node);
-int add_xml_object(xmlNode * parent, xmlNode * target, xmlNode * update, gboolean as_diff);
+static int add_xml_object(xmlNode * parent, xmlNode * target, xmlNode * update, gboolean as_diff);
 
 static inline const char *
 crm_attr_value(const xmlAttr *attr)
@@ -4312,69 +4309,6 @@ can_prune_leaf(xmlNode * xml_node)
     return can_prune;
 }
 
-void
-diff_filter_context(int context, int upper_bound, int lower_bound,
-                    xmlNode * xml_node, xmlNode * parent)
-{
-    xmlNode *us = NULL;
-    xmlNode *child = NULL;
-    xmlAttrPtr pIter = NULL;
-    xmlNode *new_parent = parent;
-    const char *name = crm_element_name(xml_node);
-
-    CRM_CHECK(xml_node != NULL && name != NULL, return);
-
-    us = create_xml_node(parent, name);
-    for (pIter = crm_first_attr(xml_node); pIter != NULL; pIter = pIter->next) {
-        const char *p_name = (const char *)pIter->name;
-        const char *p_value = crm_attr_value(pIter);
-
-        lower_bound = context;
-        crm_xml_add(us, p_name, p_value);
-    }
-
-    if (lower_bound >= 0 || upper_bound >= 0) {
-        crm_xml_add(us, XML_ATTR_ID, ID(xml_node));
-        new_parent = us;
-
-    } else {
-        upper_bound = in_upper_context(0, context, xml_node);
-        if (upper_bound >= 0) {
-            crm_xml_add(us, XML_ATTR_ID, ID(xml_node));
-            new_parent = us;
-        } else {
-            free_xml(us);
-            us = NULL;
-        }
-    }
-
-    for (child = __xml_first_child(us); child != NULL; child = __xml_next(child)) {
-        diff_filter_context(context, upper_bound - 1, lower_bound - 1, child, new_parent);
-    }
-}
-
-int
-in_upper_context(int depth, int context, xmlNode * xml_node)
-{
-    if (context == 0) {
-        return 0;
-    }
-
-    if (xml_node->properties) {
-        return depth;
-
-    } else if (depth < context) {
-        xmlNode *child = NULL;
-
-        for (child = __xml_first_child(xml_node); child != NULL; child = __xml_next(child)) {
-            if (in_upper_context(depth + 1, context, child)) {
-                return depth;
-            }
-        }
-    }
-    return 0;
-}
-
 static xmlNode *
 find_xml_comment(xmlNode * root, xmlNode * search_comment, gboolean exact)
 {
@@ -4641,7 +4575,7 @@ add_xml_comment(xmlNode * parent, xmlNode * target, xmlNode * update)
     return 0;
 }
 
-int
+static int
 add_xml_object(xmlNode * parent, xmlNode * target, xmlNode * update, gboolean as_diff)
 {
     xmlNode *a_child = NULL;

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -4597,12 +4597,9 @@ add_xml_object(xmlNode * parent, xmlNode * target, xmlNode * update, gboolean as
     object_id = ID(update);
 
     CRM_CHECK(object_name != NULL, return 0);
+    CRM_CHECK(target != NULL || parent != NULL, return 0);
 
-    if (target == NULL && object_id == NULL) {
-        /*  placeholder object */
-        target = find_xml_node(parent, object_name, FALSE);
-
-    } else if (target == NULL) {
+    if (target == NULL) {
         target = find_entity(parent, object_name, object_id);
     }
 


### PR DESCRIPTION
Previously, this input to modification of CIB:

> <primitive ...>
>   <operations>
>     <op id="mySmartFuse-monitor-outputpower" name="monitor" interval="2s">
>       <instance_attributes id="mySmartFuse-outputpower-instanceparams">
>         <nvpair id="mySmartFuse-outputpower-req" name="req" value="outputpower"/>
>       </instance_attributes>
>     </op>
>   </operations>
>   <instance_attributes id="mySmartFuse-params">
>     <nvpair id="mySmartFuse-params-ip" name="ip" value="192.0.2.10"/>
>   </instance_attributes>
>   <instance_attributes id-ref="mySmartFuse-outputpower-instanceparams"/>
> </primitive>

would degenerate into this:

> <primitive ...>
>   <operations>
>     <op id="mySmartFuse-monitor-outputpower" name="monitor" interval="2s">
>       <instance_attributes id="mySmartFuse-outputpower-instanceparams">
>         <nvpair id="mySmartFuse-outputpower-req" name="req" value="outputpower"/>
>       </instance_attributes>
>     </op>
>   </operations>
>   <instance_attributes id="mySmartFuse-params" id-ref="mySmartFuse-outputpower-instanceparams>
>     <nvpair id="mySmartFuse-params-ip" name="ip" value="192.0.2.10"/>
>   </instance_attributes>
> </primitive>

apparently resulting in an invalid configuration instance
(cannot mix @id-ref with anything else incl. @id).

Now, we are more careful about @id-ref so this won't happen.
As mentioned in the in-code comment, it's not the best qualitative
arrangement, but there's no time complexity penalty, either.