### PR TITLE
Fix crm_node -i/-n/-N for remote nodes

### DIFF
--- a/crmd/messages.c
+++ b/crmd/messages.c
@@ -684,6 +684,46 @@ handle_remote_state(xmlNode *msg)
     return I_NULL;
 }
 
+/*!
+ * \brief Handle a CRM_OP_PING message
+ *
+ * \param[in] msg  Message XML
+ *
+ * \return Next FSA input
+ */
+static enum crmd_fsa_input
+handle_ping(xmlNode *msg)
+{
+    const char *value = NULL;
+    xmlNode *ping = NULL;
+
+    // Build reply
+
+    ping = create_xml_node(NULL, XML_CRM_TAG_PING);
+    value = crm_element_value(msg, F_CRM_SYS_TO);
+    crm_xml_add(ping, XML_PING_ATTR_SYSFROM, value);
+
+    // Add controller state
+    value = fsa_state2string(fsa_state);
+    crm_xml_add(ping, XML_PING_ATTR_CRMDSTATE, value);
+    crm_notice("Current ping state: %s", value); // CTS needs this
+
+    // Add controller health
+    // @TODO maybe do some checks to determine meaningful status
+    crm_xml_add(ping, XML_PING_ATTR_STATUS, "ok");
+
+    // Send reply
+    msg = create_reply(msg, ping);
+    free_xml(ping);
+    if (msg) {
+        (void) relay_message(msg, TRUE);
+        free_xml(msg);
+    }
+
+    // Nothing further to do
+    return I_NULL;
+}
+
 enum crmd_fsa_input
 handle_request(xmlNode * stored_msg, enum crmd_fsa_cause cause)
 {
@@ -812,26 +852,7 @@ handle_request(xmlNode * stored_msg, enum crmd_fsa_cause cause)
         return I_NULL;
 
     } else if (strcmp(op, CRM_OP_PING) == 0) {
-        /* eventually do some stuff to figure out
-         * if we /are/ ok
-         */
-        const char *sys_to = crm_element_value(stored_msg, F_CRM_SYS_TO);
-        xmlNode *ping = create_xml_node(NULL, XML_CRM_TAG_PING);
-
-        crm_xml_add(ping, XML_PING_ATTR_STATUS, "ok");
-        crm_xml_add(ping, XML_PING_ATTR_SYSFROM, sys_to);
-        crm_xml_add(ping, "crmd_state", fsa_state2string(fsa_state));
-
-        /* Ok, so technically not so interesting, but CTS needs to see this */
-        crm_notice("Current ping state: %s", fsa_state2string(fsa_state));
-
-        msg = create_reply(stored_msg, ping);
-        if (msg) {
-            (void)relay_message(msg, TRUE);
-        }
-
-        free_xml(ping);
-        free_xml(msg);
+        return handle_ping(stored_msg);
 
     } else if (strcmp(op, CRM_OP_RM_NODE_CACHE) == 0) {
         int id = 0;

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -1,20 +1,10 @@
 /*
- * Copyright (C) 2004 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
- *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
+
 #ifndef CRM__H
 #  define CRM__H
 
@@ -116,6 +106,7 @@ extern char *crm_system_name;
 #  define CRM_OP_JOIN_ACKNAK	"join_ack_nack"
 #  define CRM_OP_JOIN_CONFIRM	"join_confirm"
 #  define CRM_OP_PING		"ping"
+#  define CRM_OP_NODE_INFO  "node-info"
 #  define CRM_OP_THROTTLE	"throttle"
 #  define CRM_OP_VOTE		"vote"
 #  define CRM_OP_NOVOTE		"no-vote"

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -140,6 +140,7 @@
 #  define XML_CRM_TAG_PING		"ping_response"
 #  define XML_PING_ATTR_STATUS		"result"
 #  define XML_PING_ATTR_SYSFROM		"crm_subsystem"
+#  define XML_PING_ATTR_CRMDSTATE   "crmd_state"
 
 #  define XML_TAG_FRAGMENT		"cib_fragment"
 #  define XML_ATTR_RESULT		"result"

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -36,14 +36,11 @@
 #include <crm/cib.h>
 #include <crm/attrd.h>
 
-int command = 0;
-int ccm_fd = 0;
-gboolean do_quiet = FALSE;
-
-char *target_uuid = NULL;
-char *target_uname = NULL;
-const char *standby_value = NULL;
-const char *standby_scope = NULL;
+static int command = 0;
+static char *pid_s = NULL;
+static const char *target_uname = NULL;
+static GMainLoop *mainloop = NULL;
+static int exit_code = pcmk_ok;
 
 /* *INDENT-OFF* */
 static struct crm_option long_options[] = {
@@ -80,10 +77,77 @@ static struct crm_option long_options[] = {
 
     {"-spacer-", 1, 0, '-', "\nAdditional Options:"},
     {"force",	 0, 0, 'f'},
+    // @TODO add timeout option for when IPC replies are needed
 
     {0, 0, 0, 0}
 };
 /* *INDENT-ON* */
+
+/*!
+ * \internal
+ * \brief Exit crm_node
+ * Clean up memory, and either quit mainloop (if running) or exit
+ *
+ * \param[in] value  Exit status
+ */
+static void
+crm_node_exit(int value)
+{
+    if (pid_s) {
+        free(pid_s);
+        pid_s = NULL;
+    }
+
+    exit_code = value;
+
+    if (mainloop && g_main_loop_is_running(mainloop)) {
+        g_main_loop_quit(mainloop);
+    } else {
+        crm_exit(exit_code);
+    }
+}
+
+static void
+exit_disconnect(gpointer user_data)
+{
+    fprintf(stderr, "error: Lost connection to cluster\n");
+    crm_node_exit(ENOTCONN);
+}
+
+typedef int (*ipc_dispatch_fn) (const char *buffer, ssize_t length,
+                                gpointer userdata);
+
+static crm_ipc_t *
+new_mainloop_for_ipc(const char *system, ipc_dispatch_fn dispatch)
+{
+    mainloop_io_t *source = NULL;
+    crm_ipc_t *ipc = NULL;
+
+    struct ipc_client_callbacks ipc_callbacks = {
+        .dispatch = dispatch,
+        .destroy = exit_disconnect
+    };
+
+    mainloop = g_main_loop_new(NULL, FALSE);
+    source = mainloop_add_ipc_client(system, G_PRIORITY_DEFAULT, 0,
+                                     NULL, &ipc_callbacks);
+    ipc = mainloop_get_ipc_client(source);
+    if (ipc == NULL) {
+        fprintf(stderr,
+                "error: Could not connect to cluster (is it running?)\n");
+        crm_node_exit(ENOTCONN);
+    }
+    return ipc;
+}
+
+static void
+run_mainloop_and_exit()
+{
+    g_main_loop_run(mainloop);
+    g_main_loop_unref(mainloop);
+    mainloop = NULL;
+    crm_node_exit(exit_code);
+}
 
 static int
 cib_remove_node(uint32_t id, const char *name)
@@ -126,9 +190,8 @@ cib_remove_node(uint32_t id, const char *name)
     return rc;
 }
 
-int tools_remove_node_cache(const char *node, const char *target);
-
-int tools_remove_node_cache(const char *node, const char *target)
+static int
+tools_remove_node_cache(const char *node, const char *target)
 {
     int n = 0;
     int rc = -1;
@@ -239,10 +302,10 @@ node_mcp_dispatch(const char *buffer, ssize_t length, gpointer userdata)
         crm_log_xml_trace(msg, "message");
         if (command == 'q' && quorate != NULL) {
             fprintf(stdout, "%s\n", quorate);
-            crm_exit(pcmk_ok);
+            crm_node_exit(pcmk_ok);
 
         } else if(command == 'q') {
-            crm_exit(1);
+            crm_node_exit(1);
         }
 
         for (node = __xml_first_child(msg); node != NULL; node = __xml_next(node)) {
@@ -257,7 +320,8 @@ node_mcp_dispatch(const char *buffer, ssize_t length, gpointer userdata)
         for(iter = nodes; iter; iter = iter->next) {
             crm_node_t *peer = iter->data;
             if (command == 'l') {
-                fprintf(stdout, "%u %s %s\n", peer->id, peer->uname, peer->state?peer->state:"");
+                fprintf(stdout, "%u %s %s\n",
+                        peer->id, peer->uname, (peer->state? peer->state : ""));
 
             } else if (command == 'p') {
                 if(safe_str_eq(peer->state, CRM_NODE_MEMBER)) {
@@ -278,36 +342,26 @@ node_mcp_dispatch(const char *buffer, ssize_t length, gpointer userdata)
             fprintf(stdout, "\n");
         }
 
-        crm_exit(pcmk_ok);
+        crm_node_exit(pcmk_ok);
     }
 
     return 0;
 }
 
 static void
-node_mcp_destroy(gpointer user_data)
-{
-    crm_exit(ENOTCONN);
-}
-
-static gboolean
 try_pacemaker(int command, enum cluster_type_e stack)
 {
-    struct ipc_client_callbacks node_callbacks = {
-        .dispatch = node_mcp_dispatch,
-        .destroy = node_mcp_destroy
-    };
-
     if (stack == pcmk_cluster_heartbeat) {
         /* Nothing to do for them */
-        return FALSE;
+        return;
     }
 
     switch (command) {
         case 'e':
             /* Age only applies to heartbeat clusters */
             fprintf(stdout, "1\n");
-            crm_exit(pcmk_ok);
+            crm_node_exit(pcmk_ok);
+            break;
 
         case 'R':
             {
@@ -322,10 +376,10 @@ try_pacemaker(int command, enum cluster_type_e stack)
                 for(lpc = 0; lpc < DIMOF(daemons); lpc++) {
                     if (tools_remove_node_cache(target_uname, daemons[lpc])) {
                         crm_err("Failed to connect to %s to remove node '%s'", daemons[lpc], target_uname);
-                        crm_exit(pcmk_err_generic);
+                        crm_node_exit(pcmk_err_generic);
                     }
                 }
-                crm_exit(pcmk_ok);
+                crm_node_exit(pcmk_ok);
             }
             break;
 
@@ -335,21 +389,21 @@ try_pacemaker(int command, enum cluster_type_e stack)
         case 'p':
             /* Go to pacemakerd */
             {
-                GMainLoop *amainloop = g_main_loop_new(NULL, FALSE);
-                mainloop_io_t *ipc =
-                    mainloop_add_ipc_client(CRM_SYSTEM_MCP, G_PRIORITY_DEFAULT, 0, NULL, &node_callbacks);
-                if (ipc != NULL) {
-                    /* Sending anything will get us a list of nodes */
-                    xmlNode *poke = create_xml_node(NULL, "poke");
+                crm_ipc_t *ipc = NULL;
+                xmlNode *poke = NULL;
 
-                    crm_ipc_send(mainloop_get_ipc_client(ipc), poke, 0, 0, NULL);
-                    free_xml(poke);
-                    g_main_run(amainloop);
-                }
+                ipc = new_mainloop_for_ipc(CRM_SYSTEM_MCP, node_mcp_dispatch);
+
+                // Sending anything will get us a list of nodes
+                poke = create_xml_node(NULL, "poke");
+                crm_ipc_send(ipc, poke, 0, 0, NULL);
+                free_xml(poke);
+
+                // Handle reply via node_mcp_dispatch()
+                run_mainloop_and_exit();
             }
             break;
     }
-    return FALSE;
 }
 
 #if SUPPORT_HEARTBEAT
@@ -359,6 +413,7 @@ try_pacemaker(int command, enum cluster_type_e stack)
 
 #  define UUID_LEN 16
 
+static int ccm_fd = 0;
 oc_ev_t *ccm_token = NULL;
 static void *ccm_library = NULL;
 void oc_ev_special(const oc_ev_t *, oc_ev_class_t, int);
@@ -753,7 +808,7 @@ ais_membership_dispatch(cpg_handle_t handle,
 #  include <corosync/quorum.h>
 #  include <corosync/cpg.h>
 
-static gboolean
+static void
 try_corosync(int command, enum cluster_type_e stack)
 {
     int rc = 0;
@@ -769,46 +824,40 @@ try_corosync(int command, enum cluster_type_e stack)
             rc = quorum_initialize(&q_handle, NULL, &quorum_type);
             if (rc != CS_OK) {
                 crm_err("Could not connect to the Quorum API: %d", rc);
-                return FALSE;
+                return;
             }
 
             rc = quorum_getquorate(q_handle, &quorate);
             if (rc != CS_OK) {
                 crm_err("Could not obtain the current Quorum API state: %d", rc);
-                return FALSE;
+                return;
             }
 
-            if (quorate) {
-                fprintf(stdout, "1\n");
-            } else {
-                fprintf(stdout, "0\n");
-            }
+            printf("%d\n", quorate);
             quorum_finalize(q_handle);
-            crm_exit(pcmk_ok);
+            crm_node_exit(pcmk_ok);
 
         case 'i':
             /* Go direct to the CPG API */
             rc = cpg_initialize(&c_handle, NULL);
             if (rc != CS_OK) {
                 crm_err("Could not connect to the Cluster Process Group API: %d", rc);
-                return FALSE;
+                return;
             }
 
             rc = cpg_local_get(c_handle, &nodeid);
             if (rc != CS_OK) {
                 crm_err("Could not get local node id from the CPG API");
-                return FALSE;
+                return;
             }
 
-            fprintf(stdout, "%u\n", nodeid);
+            printf("%u\n", nodeid);
             cpg_finalize(c_handle);
-            crm_exit(pcmk_ok);
+            crm_node_exit(pcmk_ok);
 
         default:
-            try_pacemaker(command, stack);
             break;
     }
-    return FALSE;
 }
 #endif
 
@@ -894,7 +943,7 @@ main(int argc, char **argv)
                 crm_help(flag, EX_OK);
                 break;
             case 'Q':
-                do_quiet = TRUE;
+                // currently unused
                 break;
             case 'H':
                 set_cluster_type(pcmk_cluster_heartbeat);
@@ -942,25 +991,24 @@ main(int argc, char **argv)
         crm_help('?', EX_USAGE);
     }
 
+    if (dangerous_cmd && force_flag == FALSE) {
+        fprintf(stderr, "The supplied command is considered dangerous."
+                "  To prevent accidental destruction of the cluster,"
+                " the --force flag is required in order to proceed.\n");
+        crm_node_exit(EINVAL);
+    }
+
     if (command == 'n') {
         const char *name = getenv("OCF_RESKEY_" CRM_META "_" XML_LRM_ATTR_TARGET);
         if(name == NULL) {
             name = get_local_node_name();
         }
         fprintf(stdout, "%s\n", name);
-        crm_exit(pcmk_ok);
+        crm_node_exit(pcmk_ok);
 
     } else if (command == 'N') {
         fprintf(stdout, "%s\n", get_node_name(nodeid));
-        crm_exit(pcmk_ok);
-    }
-
-    if (dangerous_cmd && force_flag == FALSE) {
-        fprintf(stderr, "The supplied command is considered dangerous."
-                "  To prevent accidental destruction of the cluster,"
-                " the --force flag is required in order to proceed.\n");
-        fflush(stderr);
-        crm_exit(EINVAL);
+        crm_node_exit(pcmk_ok);
     }
 
     try_stack = get_cluster_type();
@@ -994,5 +1042,6 @@ main(int argc, char **argv)
 
     try_pacemaker(command, try_stack);
 
-    return (1);
+    // We only get here if command hasn't been handled
+    crm_node_exit(1);
 }

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -163,6 +163,117 @@ send_controller_hello(crm_ipc_t *controller)
 }
 
 static int
+send_node_info_request(crm_ipc_t *controller)
+{
+    xmlNode *ping = NULL;
+    int rc;
+
+    ping = create_request(CRM_OP_NODE_INFO, NULL, NULL, CRM_SYSTEM_CRMD,
+                          crm_system_name, pid_s);
+    rc = crm_ipc_send(controller, ping, 0, 0, NULL);
+    free_xml(ping);
+    return (rc < 0)? rc : 0;
+}
+
+static int
+dispatch_controller(const char *buffer, ssize_t length, gpointer userdata)
+{
+    xmlNode *message = string2xml(buffer);
+    xmlNode *data = NULL;
+    const char *value = NULL;
+
+    if (message == NULL) {
+        fprintf(stderr, "error: Could not understand reply from controller\n");
+        crm_node_exit(1);
+        return 0;
+    }
+    crm_log_xml_trace(message, "controller reply");
+
+    exit_code = 1;
+
+    // Validate reply
+    value = crm_element_value(message, F_CRM_MSG_TYPE);
+    if (safe_str_neq(value, XML_ATTR_RESPONSE)) {
+        fprintf(stderr, "error: Message from controller was not a reply\n");
+        goto done;
+    }
+    value = crm_element_value(message, XML_ATTR_REFERENCE);
+    if (value == NULL) {
+        fprintf(stderr, "error: Controller reply did not specify original message\n");
+        goto done;
+    }
+    data = get_message_xml(message, F_CRM_DATA);
+    if (data == NULL) {
+        fprintf(stderr, "error: Controller reply did not contain any data\n");
+        goto done;
+    }
+
+    switch (command) {
+        case 'n':
+            value = crm_element_value(data, XML_ATTR_UNAME);
+            if (value == NULL) {
+                fprintf(stderr, "Node is not known to cluster\n");
+                exit_code = 1;
+            } else {
+                printf("%s\n", value);
+                exit_code = pcmk_ok;
+            }
+            break;
+        default:
+            fprintf(stderr, "internal error: Controller reply not expected\n");
+            exit_code = 1;
+            break;
+    }
+
+done:
+    free_xml(message);
+    crm_node_exit(exit_code);
+    return 0;
+}
+
+static void
+run_controller_mainloop()
+{
+    crm_ipc_t *controller = NULL;
+    int rc;
+
+    controller = new_mainloop_for_ipc(CRM_SYSTEM_CRMD, dispatch_controller);
+
+    rc = send_controller_hello(controller);
+    if (rc < 0) {
+        fprintf(stderr, "error: Could not register with controller: %s\n",
+                pcmk_strerror(rc));
+        crm_node_exit(1);
+    }
+
+    rc = send_node_info_request(controller);
+    if (rc < 0) {
+        fprintf(stderr, "error: Could not ping controller: %s\n",
+                pcmk_strerror(rc));
+        crm_node_exit(1);
+    }
+
+    // Run main loop to get controller reply via dispatch_controller()
+    run_mainloop_and_exit();
+}
+
+static void
+print_node_name()
+{
+    // Check environment first (i.e. when called by resource agent)
+    const char *name = getenv("OCF_RESKEY_" CRM_META "_" XML_LRM_ATTR_TARGET);
+
+    if (name != NULL) {
+        printf("%s\n", name);
+        crm_node_exit(pcmk_ok);
+
+    } else {
+        // Otherwise ask the controller
+        run_controller_mainloop();
+    }
+}
+
+static int
 cib_remove_node(uint32_t id, const char *name)
 {
     int rc;
@@ -1005,12 +1116,7 @@ main(int argc, char **argv)
     }
 
     if (command == 'n') {
-        const char *name = getenv("OCF_RESKEY_" CRM_META "_" XML_LRM_ATTR_TARGET);
-        if(name == NULL) {
-            name = get_local_node_name();
-        }
-        fprintf(stdout, "%s\n", name);
-        crm_node_exit(pcmk_ok);
+        print_node_name();
 
     } else if (command == 'N') {
         fprintf(stdout, "%s\n", get_node_name(nodeid));

--- a/tools/crmadmin.c
+++ b/tools/crmadmin.c
@@ -473,7 +473,7 @@ admin_msg_callback(const char *buffer, ssize_t length, gpointer userdata)
 
     } else if (DO_HEALTH) {
         xmlNode *data = get_message_xml(xml, F_CRM_DATA);
-        const char *state = crm_element_value(data, "crmd_state");
+        const char *state = crm_element_value(data, XML_PING_ATTR_CRMDSTATE);
 
         printf("Status of %s@%s: %s (%s)\n",
                crm_element_value(data, XML_PING_ATTR_SYSFROM),


### PR DESCRIPTION
This is a partial backport of a fix from the 2.0 branch. Due to the need to support legacy cluster stacks, the entire fix will not be backported, so only the -n/-N options are handled like 2.0 for all stacks, and the -i option is handled like 2.0 only for the corosync 2+ stack. crm_node does not change packages.