### PR TITLE
Med: schemas.c: cleanup XSLT extension modules' data and whatnot

### DIFF
--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -471,6 +471,11 @@ crm_schema_cleanup(void)
     }
     free(known_schemas);
     known_schemas = NULL;
+
+    xsltCleanupGlobals();  /* XXX proper, explicit reshaking regarding
+                                  init/fini routines is pending (pair
+                                  of facade functions to express the
+                                  intentions in a clean way) */
 }
 
 static gboolean


### PR DESCRIPTION
There's a note left in the code so that it's picked in the future
overhaul regarding initialization and cleanup.

Makes valgrind output actually useful.