### PR TITLE
XML: logging related enablement (in RNG/XSLT context)

### DIFF
--- a/include/crm/cib.h
+++ b/include/crm/cib.h
@@ -60,7 +60,7 @@ enum cib_conn_type {
 /* *INDENT-OFF* */
 enum cib_call_options {
 	cib_none            = 0x00000000,
-	cib_verbose         = 0x00000001,
+	cib_verbose         = 0x00000001,  /* prefer stderr to logs */
 	cib_xpath           = 0x00000002,
 	cib_multiple        = 0x00000004,
 	cib_can_create      = 0x00000008,

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -108,7 +108,8 @@ cib_process_upgrade(const char *op, int options, const char *section, xmlNode * 
         max_version = get_schema_version(max);
     }
 
-    rc = update_validation(result_cib, &new_version, max_version, TRUE, TRUE);
+    rc = update_validation(result_cib, &new_version, max_version, TRUE,
+                           !(options & cib_verbose));
     if (new_version > current_version) {
         cib_update_counter(*result_cib, XML_ATTR_GENERATION_ADMIN, FALSE);
         cib_update_counter(*result_cib, XML_ATTR_GENERATION, TRUE);


### PR DESCRIPTION
The change also means that `cibadmin` invocations will output
RNG/XSLT related messages sanely.