### PR TITLE
Fix: st_client, stonith_admin: cleanup memory of stonith-history

### DIFF
--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -419,6 +419,8 @@ stonith_key_value_t *stonith_key_value_add(stonith_key_value_t * kvp, const char
                                            const char *value);
 void stonith_key_value_freeall(stonith_key_value_t * kvp, int keys, int values);
 
+void stonith_history_free(stonith_history_t *history);
+
 /* Basic helpers that allows nodes to be fenced and the history to be
  * queried without mainloop or the caller understanding the full API
  *

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1336,6 +1336,19 @@ stonith_api_history(stonith_t * stonith, int call_options, const char *node,
     return rc;
 }
 
+void stonith_history_free(stonith_history_t *history)
+{
+    stonith_history_t *hp, *hp_old;
+
+    for (hp = history; hp; hp_old = hp, hp = hp->next, free(hp_old)) {
+        free(hp->target);
+        free(hp->action);
+        free(hp->origin);
+        free(hp->delegate);
+        free(hp->client);
+    }
+}
+
 /*!
  * \brief Deprecated (use stonith_get_namespace() instead)
  */
@@ -2389,7 +2402,7 @@ stonith_api_time(uint32_t nodeid, const char *uname, bool in_progress)
 
     time_t when = 0;
     stonith_t *st = NULL;
-    stonith_history_t *history, *hp = NULL;
+    stonith_history_t *history = NULL, *hp = NULL;
     enum stonith_call_options opts = st_opt_sync_call;
 
     st = stonith_api_new();
@@ -2430,6 +2443,8 @@ stonith_api_time(uint32_t nodeid, const char *uname, bool in_progress)
                 }
             }
         }
+
+        stonith_history_free(history);
 
         if(rc == pcmk_ok) {
             api_log(LOG_INFO, "Found %d entries for %u/%s: %d in progress, %d completed", entries, nodeid, uname, progress, completed);

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -347,7 +347,7 @@ static int
 show_history(stonith_t *st, const char *target, int timeout, int quiet,
              int verbose)
 {
-    stonith_history_t *history, *hp, *latest = NULL;
+    stonith_history_t *history = NULL, *hp, *latest = NULL;
     int rc = 0;
 
     rc = st->cmds->history(st, st_opts,
@@ -395,6 +395,8 @@ show_history(stonith_t *st, const char *target, int timeout, int quiet,
             print_fence_event(latest);
         }
     }
+
+    stonith_history_free(history);
     return rc;
 }
 


### PR DESCRIPTION
For now just a minor issue I found where obviously memory allocated for stonith-history isn't freed.
The history-API-call being used in stonith_admin is probably a minor issue as stonith_admin never daemonizes and thus the leak can't accumulate.
In the library it is probably more ugly as you never know who is using it - might be a daemon where the leak can accumulate.
Intending to bring stonith-history to crm_mon where the history won't be used when it daemonizes for gathering events but in interactive mode the leak would accumulate over time.
