### PR TITLE
Feature: crm_mon: rhbz#1461964 - add fence history features

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -44,29 +44,36 @@ static void clean_up(crm_exit_t exit_code);
 void crm_diff_update(const char *event, xmlNode * msg);
 gboolean mon_refresh_display(gpointer user_data);
 int cib_connect(gboolean full);
-void mon_st_callback(stonith_t * st, stonith_event_t * e);
+void mon_st_callback_event(stonith_t * st, stonith_event_t * e);
+void mon_st_callback_display(stonith_t * st, stonith_event_t * e);
+void kick_refresh(gboolean data_updated);
 static char *get_node_display_name(node_t *node);
 
 /*
  * Definitions indicating which items to print
  */
 
-#define mon_show_times      (0x0001U)
-#define mon_show_stack      (0x0002U)
-#define mon_show_dc         (0x0004U)
-#define mon_show_count      (0x0008U)
-#define mon_show_nodes      (0x0010U)
-#define mon_show_resources  (0x0020U)
-#define mon_show_attributes (0x0040U)
-#define mon_show_failcounts (0x0080U)
-#define mon_show_operations (0x0100U)
-#define mon_show_tickets    (0x0200U)
-#define mon_show_bans       (0x0400U)
+#define mon_show_times         (0x0001U)
+#define mon_show_stack         (0x0002U)
+#define mon_show_dc            (0x0004U)
+#define mon_show_count         (0x0008U)
+#define mon_show_nodes         (0x0010U)
+#define mon_show_resources     (0x0020U)
+#define mon_show_attributes    (0x0040U)
+#define mon_show_failcounts    (0x0080U)
+#define mon_show_operations    (0x0100U)
+#define mon_show_tickets       (0x0200U)
+#define mon_show_bans          (0x0400U)
+#define mon_show_fence_history (0x0800U)
 
-#define mon_show_headers    (mon_show_times | mon_show_stack | mon_show_dc | mon_show_count)
-#define mon_show_default    (mon_show_headers | mon_show_nodes | mon_show_resources)
-#define mon_show_all        (mon_show_default | mon_show_attributes | mon_show_failcounts \
-                     | mon_show_operations | mon_show_tickets | mon_show_bans)
+#define mon_show_headers       (mon_show_times | mon_show_stack | mon_show_dc \
+                               | mon_show_count)
+#define mon_show_default       (mon_show_headers | mon_show_nodes \
+                               | mon_show_resources)
+#define mon_show_all           (mon_show_default | mon_show_attributes \
+                               | mon_show_failcounts | mon_show_operations \
+                               | mon_show_tickets | mon_show_bans \
+                               | mon_show_fence_history)
 
 unsigned int show = mon_show_default;
 
@@ -96,6 +103,7 @@ int reconnect_msec = 5000;
 gboolean daemonize = FALSE;
 GMainLoop *mainloop = NULL;
 guint timer_id = 0;
+mainloop_timer_t *refresh_timer = NULL;
 GList *attr_list = NULL;
 
 const char *external_agent = NULL;
@@ -109,6 +117,10 @@ gboolean one_shot = FALSE;
 gboolean has_warnings = FALSE;
 gboolean print_timing = FALSE;
 gboolean watch_fencing = FALSE;
+gboolean fence_history = FALSE;
+gboolean fence_full_history = FALSE;
+gboolean fence_connect = FALSE;
+int fence_history_level = 0;
 gboolean print_brief = FALSE;
 gboolean print_pending = TRUE;
 gboolean print_clone_detail = FALSE;
@@ -183,6 +195,7 @@ mon_timer_popped(gpointer data)
 
     if (timer_id > 0) {
         g_source_remove(timer_id);
+        timer_id = 0;
     }
 
     print_as("Reconnecting...\n");
@@ -197,7 +210,26 @@ mon_timer_popped(gpointer data)
 static void
 mon_cib_connection_destroy(gpointer user_data)
 {
-    print_as("Connection to the CIB manager terminated\n");
+    print_as("Connection to the cluster-daemons terminated\n");
+    if (refresh_timer != NULL) {
+        /* we'll trigger a refresh after reconnect */
+        mainloop_timer_stop(refresh_timer);
+    }
+    if (timer_id) {
+        /* we'll trigger a new reconnect-timeout at the end */
+        g_source_remove(timer_id);
+        timer_id = 0;
+    }
+    if (st) {
+        /* the client API won't properly reconnect notifications
+         * if they are still in the table - so remove them
+         */
+        st->cmds->remove_notification(st, T_STONITH_NOTIFY_DISCONNECT);
+        st->cmds->remove_notification(st, T_STONITH_NOTIFY_FENCE);
+        if (st->state != stonith_disconnected) {
+            st->cmds->disconnect(st);
+        }
+    }
     if (cib) {
         cib->cmds->signoff(cib);
         timer_id = g_timeout_add(reconnect_msec, mon_timer_popped, NULL);
@@ -255,16 +287,24 @@ cib_connect(gboolean full)
         need_pass = FALSE;
     }
 
-    if (watch_fencing && st == NULL) {
+    if ((fence_connect) && (st == NULL)) {
         st = stonith_api_new();
     }
 
-    if (watch_fencing && st->state == stonith_disconnected) {
+    if ((fence_connect) && (st->state == stonith_disconnected)) {
         crm_trace("Connecting to stonith");
         rc = st->cmds->connect(st, crm_system_name, NULL);
         if (rc == pcmk_ok) {
             crm_trace("Setting up stonith callbacks");
-            st->cmds->register_notification(st, T_STONITH_NOTIFY_FENCE, mon_st_callback);
+            if (watch_fencing) {
+                st->cmds->register_notification(st, T_STONITH_NOTIFY_DISCONNECT,
+                                                mon_st_callback_event);
+                st->cmds->register_notification(st, T_STONITH_NOTIFY_FENCE, mon_st_callback_event);
+            } else {
+                st->cmds->register_notification(st, T_STONITH_NOTIFY_DISCONNECT,
+                                                mon_st_callback_display);
+                st->cmds->register_notification(st, T_STONITH_NOTIFY_FENCE, mon_st_callback_display);
+            }
         }
     }
 
@@ -338,6 +378,9 @@ static struct crm_option long_options[] = {
     {"timing-details", 0, 0, 't', "\tDisplay resource operation history with timing details" },
     {"tickets",        0, 0, 'c', "\t\tDisplay cluster tickets"},
     {"watch-fencing",  0, 0, 'W', "\tListen for fencing events. For use with --external-agent"},
+    {"fence-history",  2, 0, 'm', "Show fence history\n"
+                                  "\t\t\t\t\t0=off, 1=failures, 2=add successes and pending (default without value),\n"
+                                  "\t\t\t\t\t3=show full history without reduction to most recent of each flavor"},
     {"neg-locations",  2, 0, 'L', "Display negative location constraints [optionally filtered by id prefix]"},
     {"show-node-attributes", 0, 0, 'A', "Display node attributes" },
     {"hide-headers",   0, 0, 'D', "\tHide all headers" },
@@ -385,9 +428,26 @@ get_option_desc(char c)
             continue;
 
         if (long_options[lpc].val == c) {
-            const char * tab = NULL;
-            tab = strrchr(long_options[lpc].desc, '\t');
-            return tab ? ++tab : long_options[lpc].desc;
+            static char *buf = NULL;
+            const char *rv;
+            char *nl;
+
+            /* chop off tabs and cut at newline */
+            free(buf); /* free string from last usage */
+            buf = strdup(long_options[lpc].desc);
+            rv = buf; /* make a copy to keep buf pointer unaltered
+                         for freeing when we come by next time.
+                         Like this the result stays valid until
+                         the next call.
+                       */
+            while(isspace(rv[0])) {
+                rv++;
+            }
+            nl = strchr(rv, '\n');
+            if (nl) {
+                *nl = '\0';
+            }
+            return rv;
         }
     }
 
@@ -409,6 +469,16 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer unused)
         c = getchar();
 
         switch (c) {
+            case 'm':
+                if (!fence_history_level) {
+                    fence_history = TRUE;
+                    fence_connect = TRUE;
+                    if (st == NULL) {
+                        mon_cib_connection_destroy(NULL);
+                    }
+                }
+                show ^= mon_show_fence_history;
+                break;
             case 'c':
                 show ^= mon_show_tickets;
                 break;
@@ -482,6 +552,7 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer unused)
         print_option_help('R', print_clone_detail);
         print_option_help('b', print_brief);
         print_option_help('j', print_pending);
+        print_option_help('m', (show & mon_show_fence_history));
         print_as("\n");
         print_as("Toggle fields via field letter, type any other key to return");
     }
@@ -515,6 +586,12 @@ main(int argc, char **argv)
         one_shot = TRUE;
     }
 
+    /* to enable stonith-connection when called via some application like pcs
+     * set environment-variable FENCE_HISTORY to desired level
+     * so you don't have to modify this application
+     */
+    /* fence_history_level = crm_atoi(getenv("FENCE_HISTORY"), "0"); */
+
     while (1) {
         flag = crm_get_option(argc, argv, &option_index);
         if (flag == -1)
@@ -538,6 +615,10 @@ main(int argc, char **argv)
                 break;
             case 'W':
                 watch_fencing = TRUE;
+                fence_connect = TRUE;
+                break;
+            case 'm':
+                fence_history_level = crm_atoi(optarg, "2");
                 break;
             case 'd':
                 daemonize = TRUE;
@@ -636,6 +717,21 @@ main(int argc, char **argv)
                 ++argerr;
                 break;
         }
+    }
+
+    switch (fence_history_level) {
+        case 3:
+            fence_full_history = TRUE;
+            /* fall through to next lower level */
+        case 2:
+            show |= mon_show_fence_history;
+            /* fall through to next lower level */
+        case 1:
+            fence_history = TRUE;
+            fence_connect = TRUE;
+            break;
+        default:
+            break;
     }
 
     /* Extra sanity checks when in CGI mode */
@@ -812,12 +908,14 @@ count_resources(pe_working_set_t * data_set, resource_t * rsc)
  * \brief Print one-line status suitable for use with monitoring software
  *
  * \param[in] data_set  Working set of CIB state
+ * \param[in] history   List of stonith actions
  *
  * \note This function's output (and the return code when the program exits)
  *       should conform to https://www.monitoring-plugins.org/doc/guidelines.html
  */
 static void
-print_simple_status(pe_working_set_t * data_set)
+print_simple_status(pe_working_set_t * data_set,
+                    stonith_history_t *history)
 {
     GListPtr gIter = NULL;
     int nodes_online = 0;
@@ -2783,12 +2881,13 @@ print_failed_actions(FILE *stream, pe_working_set_t *data_set)
     switch (output_format) {
         case mon_output_plain:
         case mon_output_console:
-            print_as("\nFailed Actions:\n");
+            print_as("\nFailed Resource Actions:\n");
             break;
 
         case mon_output_html:
         case mon_output_cgi:
-            fprintf(stream, " <hr />\n <h2>Failed Actions</h2>\n <ul>\n");
+            fprintf(stream,
+                    " <hr />\n <h2>Failed Resource Actions</h2>\n <ul>\n");
             break;
 
         case mon_output_xml:
@@ -2807,11 +2906,6 @@ print_failed_actions(FILE *stream, pe_working_set_t *data_set)
 
     /* End section */
     switch (output_format) {
-        case mon_output_plain:
-        case mon_output_console:
-            print_as("\n");
-            break;
-
         case mon_output_html:
         case mon_output_cgi:
             fprintf(stream, " </ul>\n");
@@ -2828,15 +2922,394 @@ print_failed_actions(FILE *stream, pe_working_set_t *data_set)
 
 /*!
  * \internal
+ * \brief Reduce the stonith-history
+ *        for successful actions we keep the last of every action-type & target
+ *        for failed actions we record as well who had failed
+ *        for actions in progress we keep full track
+ *
+ * \param[in] history    List of stonith actions
+ *
+ */
+static stonith_history_t *
+reduce_stonith_history(stonith_history_t *history)
+{
+    stonith_history_t *new = NULL, *hp, *np, *tmp;
+
+    for (hp = history; hp; ) {
+        for (np = new; np; np = np->next) {
+            if ((hp->state == st_done) || (hp->state == st_failed)) {
+                /* action not in progress */
+                if (safe_str_eq(hp->target, np->target) &&
+                    safe_str_eq(hp->action, np->action) &&
+                    (hp->state == np->state)) {
+                    if ((hp->state == st_done) ||
+                        safe_str_eq(hp->delegate, np->delegate)) {
+                        /* replace or purge */
+                        if (hp->completed < np->completed) {
+                            /* purge older hp */
+                            tmp = hp->next;
+                            hp->next = NULL;
+                            stonith_history_free(hp);
+                            hp = tmp;
+                            break;
+                        }
+                        /* damn single linked list */
+                        free(hp->target);
+                        free(hp->action);
+                        free(np->origin);
+                        np->origin = hp->origin;
+                        free(np->delegate);
+                        np->delegate = hp->delegate;
+                        free(np->client);
+                        np->client = hp->client;
+                        np->completed = hp->completed;
+                        tmp = hp;
+                        hp = hp->next;
+                        free(tmp);
+                        break;
+                    }
+                }
+                if (np->next) {
+                    continue;
+                }
+            }
+            np = 0; /* let outer loop progress hp */
+            break;
+        }
+        /* simply move hp from history to new */
+        if (np == NULL) {
+            tmp = hp->next;
+            hp->next = new;
+            new = hp;
+            hp = tmp;
+        }
+    }
+    return new;
+}
+
+/*!
+ * \internal
+ * \brief Sort the stonith-history
+ *        sort by competed most current on the top
+ *        pending actions lacking a completed-stamp are gathered at the top
+ *
+ * \param[in] history    List of stonith actions
+ *
+ */
+static stonith_history_t *
+sort_stonith_history(stonith_history_t *history)
+{
+    stonith_history_t *new = NULL, *pending = NULL, *hp, *np, *tmp;
+
+    for (hp = history; hp; ) {
+        tmp = hp->next;
+        if ((hp->state == st_done) || (hp->state == st_failed)) {
+            /* sort into new */
+            if ((!new) || (hp->completed > new->completed)) {
+                hp->next = new;
+                new = hp;
+            } else {
+                np = new;
+                do {
+                    if ((!np->next) || (hp->completed > np->next->completed)) {
+                        hp->next = np->next;
+                        np->next = hp;
+                        break;
+                    }
+                    np = np->next;
+                } while (1);
+            }
+        } else {
+            /* put into pending */
+            hp->next = pending;
+            pending = hp;
+        }
+        hp = tmp;
+    }
+
+    /* pending actions don't have a completed-stamp so make them go front */
+    if (pending) {
+        stonith_history_t *last_pending = pending;
+
+        while (last_pending->next) {
+            last_pending = last_pending->next;
+        }
+
+        last_pending->next = new;
+        new = pending;
+    }
+    return new;
+}
+
+/*!
+ * \internal
+ * \brief Turn stonith action into a better readable string
+ *
+ * \param[in] action     Stonith action
+ */
+static char *
+fence_action_str(const char *action)
+{
+    char *str = NULL;
+
+    if (action == NULL) {
+        str = strdup("fencing");
+    } else if (!strcmp(action, "on")) {
+        str = strdup("unfencing");
+    } else if (!strcmp(action, "off")) {
+        str = strdup("turning off");
+    } else {
+        str = strdup(action);
+    }
+    return str;
+}
+
+/*!
+ * \internal
+ * \brief Print a stonith action
+ *
+ * \param[in] stream     File stream to display output to
+ * \param[in] event      stonith event
+ */
+static void
+print_stonith_action(FILE *stream, stonith_history_t *event)
+{
+    char *action_s = fence_action_str(event->action);
+    char *run_at_s = ctime(&event->completed);
+
+    if ((run_at_s) && (run_at_s[0] != 0)) {
+        run_at_s[strlen(run_at_s)-1] = 0; /* Overwrite the newline */
+    }
+
+    switch(output_format) {
+        case mon_output_xml:
+            fprintf(stream, "        <fence_event target=\"%s\" action=\"%s\"",
+                    event->target, event->action);
+            switch(event->state) {
+                case st_done:
+                    fprintf(stream, " state=\"success\"");
+                    break;
+                case st_failed:
+                    fprintf(stream, " state=\"failed\"");
+                    break;
+                default:
+                    fprintf(stream, " state=\"pending\"");
+            }
+            fprintf(stream, " origin=\"%s\" client=\"%s\"",
+                    event->origin, event->client);
+            if (event->delegate) {
+                fprintf(stream, " delegate=\"%s\"", event->delegate);
+            }
+            switch(event->state) {
+                case st_done:
+                case st_failed:
+                    fprintf(stream, " completed=\"%s\"", run_at_s?run_at_s:"");
+                    break;
+                default:
+                    fprintf(stream, " state=\"pending\"");
+            }
+            fprintf(stream, " />\n");
+            break;
+
+        case mon_output_plain:
+        case mon_output_console:
+            switch(event->state) {
+                case st_done:
+                    print_as("* %s of %s successful: delegate=%s, client=%s, origin=%s,\n"
+                             "    %s='%s'\n",
+                             action_s, event->target,
+                             event->delegate ? event->delegate : "",
+                             event->client, event->origin,
+                             ((!fence_full_history) && (output_format != mon_output_xml))?
+                             "last-successful":"completed",
+                             run_at_s?run_at_s:"");
+                    break;
+                case st_failed:
+                    print_as("* %s of %s failed: delegate=%s, client=%s, origin=%s,\n"
+                             "    %s='%s'\n",
+                             action_s, event->target,
+                             event->delegate ? event->delegate : "",
+                             event->client, event->origin,
+                             ((!fence_full_history) && (output_format != mon_output_xml))?
+                             "last-failed":"completed",
+                             run_at_s?run_at_s:"");
+                    break;
+                default:
+                    print_as("* %s of %s pending: client=%s, origin=%s\n",
+                             action_s, event->target,
+                             event->client, event->origin);
+            }
+            break;
+
+        case mon_output_html:
+        case mon_output_cgi:
+            switch(event->state) {
+                case st_done:
+                    fprintf(stream, "  <li>%s of %s successful: delegate=%s, "
+                                    "client=%s, origin=%s, %s='%s'</li>\n",
+                                    action_s, event->target,
+                                    event->delegate ? event->delegate : "",
+                                    event->client, event->origin,
+                                    ((!fence_full_history) &&
+                                     (output_format != mon_output_xml))?
+                                    "last-successful":"completed",
+                                    run_at_s?run_at_s:"");
+                    break;
+                case st_failed:
+                    fprintf(stream, "  <li>%s of %s failed: delegate=%s, "
+                                    "client=%s, origin=%s, %s='%s'</li>\n",
+                                    action_s, event->target,
+                                    event->delegate ? event->delegate : "",
+                                    event->client, event->origin,
+                                    ((!fence_full_history) &&
+                                     (output_format != mon_output_xml))?
+                                    "last-failed":"completed",
+                                    run_at_s?run_at_s:"");
+                    break;
+                default:
+                    fprintf(stream, "  <li>%s of %s pending: client=%s, "
+                                    "origin=%s</li>\n",
+                                    action_s, event->target,
+                                    event->client, event->origin);
+            }
+            break;
+
+        default:
+            /* no support for fence history for other formats so far */
+            break;
+    }
+
+    free(action_s);
+}
+
+/*!
+ * \internal
+ * \brief Print a section for failed stonith actions
+ *
+ * \param[in] stream     File stream to display output to
+ * \param[in] history    List of stonith actions
+ *
+ */
+static void
+print_failed_stonith_actions(FILE *stream, stonith_history_t *history)
+{
+    stonith_history_t *hp;
+
+    for (hp = history; hp; hp = hp->next) {
+        if (hp->state == st_failed) {
+            break;
+        }
+    }
+    if (!hp) {
+        return;
+    }
+
+    /* Print section heading */
+    switch (output_format) {
+        /* no need to take care of xml in here as xml gets full
+         * history anyway
+         */
+        case mon_output_plain:
+        case mon_output_console:
+            print_as("\nFailed Fencing Actions:\n");
+            break;
+
+        case mon_output_html:
+        case mon_output_cgi:
+            fprintf(stream, " <hr />\n <h2>Failed Fencing Actions</h2>\n <ul>\n");
+            break;
+
+        default:
+            break;
+    }
+
+    /* Print each failed stonith action */
+    for (hp = history; hp; hp = hp->next) {
+        if (hp->state == st_failed) {
+            print_stonith_action(stream, hp);
+        }
+    }
+
+    /* End section */
+    switch (output_format) {
+        case mon_output_html:
+        case mon_output_cgi:
+            fprintf(stream, " </ul>\n");
+            break;
+
+        default:
+            break;
+    }
+}
+
+/*!
+ * \internal
+ * \brief Print a section for stonith-history
+ *
+ * \param[in] stream     File stream to display output to
+ * \param[in] history    List of stonith actions
+ *
+ */
+static void
+print_stonith_history(FILE *stream, stonith_history_t *history)
+{
+    stonith_history_t *hp;
+
+    /* Print section heading */
+    switch (output_format) {
+        case mon_output_plain:
+        case mon_output_console:
+            print_as("\nFencing History:\n");
+            break;
+
+        case mon_output_html:
+        case mon_output_cgi:
+            fprintf(stream, " <hr />\n <h2>Fencing History</h2>\n <ul>\n");
+            break;
+
+        case mon_output_xml:
+            fprintf(stream, "    <fence_history>\n");
+            break;
+
+        default:
+            break;
+    }
+
+    for (hp = history; hp; hp = hp->next) {
+        if ((hp->state != st_failed) || (output_format == mon_output_xml)) {
+            print_stonith_action(stream, hp);
+        }
+    }
+
+    /* End section */
+    switch (output_format) {
+        case mon_output_html:
+        case mon_output_cgi:
+            fprintf(stream, " </ul>\n");
+            break;
+
+        case mon_output_xml:
+            fprintf(stream, "    </fence_history>\n");
+            break;
+
+        default:
+            break;
+    }
+}
+
+/*!
+ * \internal
  * \brief Print cluster status to screen
  *
  * This uses the global display preferences set by command-line options
  * to display cluster status in a human-friendly way.
  *
- * \param[in] data_set   Working set of CIB state
+ * \param[in] data_set          Working set of CIB state
+ * \param[in] stonith_history   List of stonith actions
  */
 static void
-print_status(pe_working_set_t * data_set)
+print_status(pe_working_set_t * data_set,
+             stonith_history_t *stonith_history)
 {
     GListPtr gIter = NULL;
     int print_opts = get_resource_display_options();
@@ -2991,6 +3464,11 @@ print_status(pe_working_set_t * data_set)
         print_failed_actions(stdout, data_set);
     }
 
+    /* Print failed stonith actions */
+    if (fence_history) {
+        print_failed_stonith_actions(stdout, stonith_history);
+    }
+
     /* Print tickets if requested */
     if (show & mon_show_tickets) {
         print_cluster_tickets(stdout, data_set);
@@ -2999,6 +3477,11 @@ print_status(pe_working_set_t * data_set)
     /* Print negative location constraints if requested */
     if (show & mon_show_bans) {
         print_neg_locations(stdout, data_set);
+    }
+
+    /* Print stonith history */
+    if (fence_history && (show & mon_show_fence_history)) {
+        print_stonith_history(stdout, stonith_history);
     }
 
 #if CURSES_ENABLED
@@ -3015,7 +3498,8 @@ print_status(pe_working_set_t * data_set)
  * \param[in] data_set   Working set of CIB state
  */
 static void
-print_xml_status(pe_working_set_t * data_set)
+print_xml_status(pe_working_set_t * data_set,
+                 stonith_history_t *stonith_history)
 {
     FILE *stream = stdout;
     GListPtr gIter = NULL;
@@ -3098,6 +3582,11 @@ print_xml_status(pe_working_set_t * data_set)
         print_failed_actions(stream, data_set);
     }
 
+    /* Print stonith history */
+    if (fence_history) {
+        print_stonith_history(stdout, stonith_history);
+    }
+
     /* Print tickets if requested */
     if (show & mon_show_tickets) {
         print_cluster_tickets(stream, data_set);
@@ -3123,7 +3612,9 @@ print_xml_status(pe_working_set_t * data_set)
  * \return 0 on success, -1 on error
  */
 static int
-print_html_status(pe_working_set_t * data_set, const char *filename)
+print_html_status(pe_working_set_t * data_set,
+                  const char *filename,
+                  stonith_history_t *stonith_history)
 {
     FILE *stream;
     GListPtr gIter = NULL;
@@ -3220,6 +3711,16 @@ print_html_status(pe_working_set_t * data_set, const char *filename)
     /* If there were any failed actions, print them */
     if (xml_has_children(data_set->failed)) {
         print_failed_actions(stream, data_set);
+    }
+
+    /* Print failed stonith actions */
+    if (fence_history) {
+        print_failed_stonith_actions(stream, stonith_history);
+    }
+
+    /* Print stonith history */
+    if (fence_history && (show & mon_show_fence_history)) {
+        print_stonith_history(stream, stonith_history);
     }
 
     /* Print tickets if requested */
@@ -3538,17 +4039,11 @@ void
 crm_diff_update(const char *event, xmlNode * msg)
 {
     int rc = -1;
-    long now = time(NULL);
     static bool stale = FALSE;
-    static int updates = 0;
-    static mainloop_timer_t *refresh_timer = NULL;
+    gboolean cib_updated = FALSE;
     xmlNode *diff = get_message_xml(msg, F_CIB_UPDATE_RESULT);
 
     print_dot();
-
-    if(refresh_timer == NULL) {
-        refresh_timer = mainloop_timer_add("refresh", 2000, FALSE, mon_trigger_refresh, NULL);
-    }
 
     if (current_cib != NULL) {
         rc = xml_apply_patchset(current_cib, diff, TRUE);
@@ -3560,7 +4055,7 @@ crm_diff_update(const char *event, xmlNode * msg)
                 free_xml(current_cib); current_cib = NULL;
                 break;
             case pcmk_ok:
-                updates++;
+                cib_updated = TRUE;
                 break;
             default:
                 crm_notice("[%s] ABORTED: %s (%d)", event, pcmk_strerror(rc), rc);
@@ -3597,24 +4092,7 @@ crm_diff_update(const char *event, xmlNode * msg)
     }
 
     stale = FALSE;
-    /* Refresh
-     * - immediately if the last update was more than 5s ago
-     * - every 10 updates
-     * - at most 2s after the last update
-     */
-    if ((now - last_refresh) > (reconnect_msec / 1000)) {
-        mainloop_set_trigger(refresh_trigger);
-        mainloop_timer_stop(refresh_timer);
-        updates = 0;
-
-    } else if(updates > 10) {
-        mainloop_set_trigger(refresh_trigger);
-        mainloop_timer_stop(refresh_timer);
-        updates = 0;
-
-    } else {
-        mainloop_timer_start(refresh_timer);
-    }
+    kick_refresh(cib_updated);
 }
 
 gboolean
@@ -3622,6 +4100,7 @@ mon_refresh_display(gpointer user_data)
 {
     xmlNode *cib_copy = copy_xml(current_cib);
     pe_working_set_t data_set;
+    stonith_history_t *stonith_history = NULL;
 
     last_refresh = time(NULL);
 
@@ -3634,6 +4113,31 @@ mon_refresh_display(gpointer user_data)
             sleep(2);
         }
         clean_up(CRM_EX_CONFIG);
+        return FALSE;
+    }
+
+    /* get the stonith-history if there is evidence we need it
+     */
+    while (fence_history) {
+        if (st != NULL) {
+            if (st->cmds->history(st, st_opt_sync_call, NULL, &stonith_history, 120)) {
+                fprintf(stderr, "Critical: Unable to get stonith-history\n");
+                mon_cib_connection_destroy(NULL);
+            } else {
+                if ((!fence_full_history) && (output_format != mon_output_xml)) {
+                    stonith_history = reduce_stonith_history(stonith_history);
+                }
+                stonith_history = sort_stonith_history(stonith_history);
+                break; /* all other cases are errors */
+            }
+        } else {
+            fprintf(stderr, "Critical: No stonith-API\n");
+        }
+        free_xml(cib_copy);
+        print_as("Reading stonith-history failed");
+        if (output_format == mon_output_console) {
+            sleep(2);
+        }
         return FALSE;
     }
 
@@ -3652,18 +4156,18 @@ mon_refresh_display(gpointer user_data)
     switch (output_format) {
         case mon_output_html:
         case mon_output_cgi:
-            if (print_html_status(&data_set, output_filename) != 0) {
+            if (print_html_status(&data_set, output_filename, stonith_history) != 0) {
                 fprintf(stderr, "Critical: Unable to output html file\n");
                 clean_up(CRM_EX_CANTCREAT);
             }
             break;
 
         case mon_output_xml:
-            print_xml_status(&data_set);
+            print_xml_status(&data_set, stonith_history);
             break;
 
         case mon_output_monitor:
-            print_simple_status(&data_set);
+            print_simple_status(&data_set, stonith_history);
             if (has_warnings) {
                 clean_up(MON_STATUS_WARN);
             }
@@ -3671,28 +4175,87 @@ mon_refresh_display(gpointer user_data)
 
         case mon_output_plain:
         case mon_output_console:
-            print_status(&data_set);
+            print_status(&data_set, stonith_history);
             break;
 
         case mon_output_none:
             break;
     }
 
+    stonith_history_free(stonith_history);
+    stonith_history = NULL;
     cleanup_alloc_calculations(&data_set);
+
+    /* poll for pending fence-actions as we don't get notifications so far */
+    if ((!one_shot) && (show & mon_show_fence_history)) {
+        kick_refresh(FALSE);
+    }
     return TRUE;
 }
 
 void
-mon_st_callback(stonith_t * st, stonith_event_t * e)
+mon_st_callback_event(stonith_t * st, stonith_event_t * e)
 {
-    char *desc = crm_strdup_printf("Operation %s requested by %s for peer %s: %s (ref=%s)",
-                                 e->operation, e->origin, e->target, pcmk_strerror(e->result),
-                                 e->id);
-
-    if (external_agent) {
+    if (st->state == stonith_disconnected) {
+        /* disconnect cib as well and have everything reconnect */
+        mon_cib_connection_destroy(NULL);
+    } else if (external_agent) {
+        char *desc = crm_strdup_printf("Operation %s requested by %s for peer %s: %s (ref=%s)",
+                                    e->operation, e->origin, e->target, pcmk_strerror(e->result),
+                                    e->id);
         send_custom_trap(e->target, NULL, e->operation, pcmk_ok, e->result, 0, desc);
+        free(desc);
     }
-    free(desc);
+}
+
+void kick_refresh(gboolean data_updated)
+{
+    static int updates = 0;
+    long now = time(NULL);
+
+    if (data_updated) {
+        updates++;
+    }
+
+    if(refresh_timer == NULL) {
+        refresh_timer = mainloop_timer_add("refresh", 2000, FALSE, mon_trigger_refresh, NULL);
+    }
+
+    /* Refresh
+     * - immediately if the last update was more than 5s ago
+     * - every 10 cib-updates
+     * - at most 2s after the last update
+     */
+    if ((now - last_refresh) > (reconnect_msec / 1000)) {
+        mainloop_set_trigger(refresh_trigger);
+        mainloop_timer_stop(refresh_timer);
+        updates = 0;
+
+    } else if(updates >= 10) {
+        mainloop_set_trigger(refresh_trigger);
+        mainloop_timer_stop(refresh_timer);
+        updates = 0;
+
+    } else {
+        /* if nothing has been updated (e.g. fence-history polling for changes
+         * in pending actions since atm that doesn't generate notifications or
+         * cib update has gone wrong) it is enough to update at reconnect-rate
+         */
+        mainloop_timer_set_period(refresh_timer, data_updated?2000:reconnect_msec);
+        mainloop_timer_start(refresh_timer);
+    }
+}
+
+void
+mon_st_callback_display(stonith_t * st, stonith_event_t * e)
+{
+    if (st->state == stonith_disconnected) {
+        /* disconnect cib as well and have everything reconnect */
+        mon_cib_connection_destroy(NULL);
+    } else {
+        print_dot();
+        kick_refresh(TRUE);
+    }
 }
 
 /*
@@ -3714,6 +4277,15 @@ clean_up(crm_exit_t exit_code)
         cib->cmds->signoff(cib);
         cib_delete(cib);
         cib = NULL;
+    }
+
+    if (st != NULL) {
+        if (st->state != stonith_disconnected) {
+            st->cmds->remove_notification(st, T_STONITH_NOTIFY_DISCONNECT);
+            st->cmds->disconnect(st);
+        }
+        stonith_api_delete(st);
+        st = NULL;
     }
 
     free(output_filename);

--- a/xml/crm_mon.rng
+++ b/xml/crm_mon.rng
@@ -203,6 +203,56 @@
                 </element>
             </optional>
             <optional>
+                <element name="fence_history">
+                    <zeroOrMore>
+                        <element name="fence_event">
+                            <!-- node to be fenced -->
+                            <attribute name="target"> <text/> </attribute>
+                            <!-- reboot, on, off -->
+                            <attribute name="action"> <text/> </attribute>
+                            <!-- failed, success, pending -->
+                            <attribute name="state"> <text/> </attribute>
+                            <optional>
+                                <!-- node from where action was triggered -->
+                                <attribute name="origin"> <text/> </attribute>
+                            </optional>
+                            <optional>
+                                <!-- originating entity on triggering node -->
+                                <attribute name="client"> <text/> </attribute>
+                            </optional>
+                            <optional>
+                                <!-- node the action is executed on -->
+                                <attribute name="delegate"> <text/> </attribute>
+                            </optional>
+                            <optional>
+                                <!-- stamp when action was declared failed or success -->
+                                <attribute name="completed"> <text/> </attribute>
+                            </optional>
+                            <optional>
+                                <!-- especially interesting in the pending case -->
+                                <attribute name="started"> <text/> </attribute>
+                            </optional>
+                            <optional>
+                                <!-- in case output is reduced to most recent -->
+                                <attribute name="last-failed"> <text/> </attribute>
+                            </optional>
+                            <optional>
+                                <!-- in case output is reduced to most recent -->
+                                <attribute name="last-successful"> <text/> </attribute>
+                            </optional>
+                            <optional>
+                                <!-- why was the fencing action triggered -->
+                                <attribute name="exec-reason"> <text/> </attribute>
+                            </optional>
+                            <optional>
+                                <!-- details on the execution like failure reason -->
+                                <attribute name="exec-details"> <text/> </attribute>
+                            </optional>
+                        </element>
+                    </zeroOrMore>
+                </element>
+            </optional>
+            <optional>
                 <element name="tickets">
                     <zeroOrMore>
                         <element name="ticket">


### PR DESCRIPTION
Enable crm_mon to show fence-history grabbed from stonith
 
```
     r192.168.123.104   (ocf::heartbeat:IPaddr2):	Started node2
     petulant   (service:pacemaker-cts-dummyd@10):	Started node2
     r192.168.123.105   (ocf::heartbeat:IPaddr2):	Started node2
lsb-dummy	(lsb:/usr/share/pacemaker/tests/cts/LSBDummy):  Started node2

Failed Resource Actions:
* Fencing_start_0 on node2 'unknown error' (1): call=77, status=Timed Out, exitreason='',
    last-rc-change='Fri Jun 22 17:01:42 2018', queued=0ms, exec=60097ms
* Fencing_start_0 on node3 'unknown error' (1): call=68, status=Timed Out, exitreason='',
    last-rc-change='Thu Jun 21 14:39:14 2018', queued=0ms, exec=60084ms

Failed Fencing Actions:
* reboot of node4 failed: delegate=node2, client=pacemaker-controld.7817, origin=node3,
    last-failed='Fri Jun 22 16:59:39 2018'

Fencing History:
* reboot of node4 pending: client=pacemaker-controld.7817, origin=node3
* reboot of node4 successful: delegate=node3, client=pacemaker-controld.7817, origin=node3,
    last-successful='Mon Jun 25 14:13:28 2018'
```

configurable via console:
```
  R:    Show more details (node IDs, individual clone instances)
  b:    Brief output
* j:    Display pending state if 'record-pending' is enabled
* m:    Show fence history
```
schema adapted and switchable via cmdline-option
just connecting to stonith if specified via cmdline-option or enabled via console
```
[root@node2 ~]# crm_mon --help
...
 -W, --watch-fencing		Listen for fencing events. For use with --external-agent
 -m, --fence-history[=value]	Show fence history
					0=off, 1=failures, 2=add successes and pending (default without value),
					3=show full history without reduction to most recent of each flavor
 -L, --neg-locations[=value]	Display negative location constraints [optionally filtered by id prefix]
...
```

xml-output available (always full history atm) to be processed by e.g. pcs
``` xml
<tickets>
    </tickets>
    <fence_history>
        <fence_event target="node4" action="reboot" state="failed" origin="node3" client="pacemaker-controld.7817" delegate="node2" completed="Fri Jun 22 17:35:36 2018" />
        <fence_event target="node4" action="reboot" state="failed" origin="node3" client="pacemaker-controld.7817" delegate="node2" completed="Fri Jun 22 16:59:39 2018" />
        <fence_event target="node4" action="reboot" state="failed" origin="node3" client="pacemaker-controld.7817" delegate="node2" completed="Fri Jun 22 16:57:38 2018" />
    </fence_history>
    <bans>
```

following optional elements aren't filled yet but they are in the schema for highlevel-tooling to be prepared
``` xml
<optional>
  <!-- especially interesting in the pending case -->
  <attribute name="started"> <text/> </attribute>
</optional>
<optional>
  <!-- in case output is reduced to most recent -->
  <attribute name="last-failed"> <text/> </attribute>
</optional>
<optional>
  <!-- in case output is reduced to most recent -->
  <attribute name="last-successful"> <text/> </attribute>
</optional>
<optional>
  <!-- why was the fencing action triggered -->
  <attribute name="exec-reason"> <text/> </attribute>
</optional>
<optional>
  <!-- details on the execution like failure reason -->
  <attribute name="exec-details"> <text/> </attribute>
</optional> 