### PR TITLE
Build: spec + configure: superfluous dependency of -libs-devel on -cts + deprecated macro swap

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ dnl   - Manually edit include/crm_config.h.in to have configure include
 dnl     new defines
 dnl   - Should not include HAVE_* defines
 dnl   - Safe to include anywhere
-AM_CONFIG_HEADER(include/config.h include/crm_config.h)
+AC_CONFIG_HEADERS([include/config.h include/crm_config.h])
 
 AC_ARG_WITH(version,
     [  --with-version=version   Override package version (if you are a packager needing to pretend) ],

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -336,7 +336,6 @@ nodes not running the full corosync/cluster stack.
 License:       GPLv2+ and LGPLv2+
 Summary:       Pacemaker development package
 Group:         Development/Libraries
-Requires:      %{name}-cts = %{version}-%{release}
 Requires:      %{name}-libs%{?_isa} = %{version}-%{release}
 Requires:      %{name}-cluster-libs%{?_isa} = %{version}-%{release}
 Requires:      libuuid-devel%{?_isa} libtool-ltdl-devel%{?_isa}


### PR DESCRIPTION
It's not entirely clear why 7fb768bbd introduced it.