### PR TITLE
Present exec_time in event environment

### DIFF
--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -72,11 +72,12 @@ enum crm_alert_keys_e {
     CRM_alert_attribute_value,
     CRM_alert_timestamp_epoch,
     CRM_alert_timestamp_usec,
+    CRM_alert_exec_time,
     CRM_alert_select_kind,
     CRM_alert_select_attribute_name
 };
 
-#define CRM_ALERT_INTERNAL_KEY_MAX 18
+#define CRM_ALERT_INTERNAL_KEY_MAX 19
 #define CRM_ALERT_NODE_SEQUENCE "CRM_alert_node_sequence"
 
 extern const char *crm_alert_keys[CRM_ALERT_INTERNAL_KEY_MAX][3];

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -35,7 +35,8 @@ const char *crm_alert_keys[CRM_ALERT_INTERNAL_KEY_MAX][3] =
     [CRM_alert_attribute_name]     = {"CRM_notify_attribute_name",     "CRM_alert_attribute_name",     NULL},
     [CRM_alert_attribute_value]     = {"CRM_notify_attribute_value",     "CRM_alert_attribute_value",     NULL},
     [CRM_alert_timestamp_epoch]     = {"CRM_notify_timestamp_epoch",     "CRM_alert_timestamp_epoch",     NULL},
-    [CRM_alert_timestamp_usec]     = {"CRM_notify_timestamp_usec",     "CRM_alert_timestamp_usec",     NULL}
+    [CRM_alert_timestamp_usec]     = {"CRM_notify_timestamp_usec",     "CRM_alert_timestamp_usec",     NULL},
+    [CRM_alert_exec_time]     = {"CRM_notify_exec_time",     "CRM_alert_exec_time",     NULL}
 };
 
 void

--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -365,6 +365,12 @@ lrmd_send_resource_alert(lrmd_t *lrmd, GList *alert_list,
     params = alert_key2param_int(params, CRM_alert_status, op->op_status);
     params = alert_key2param_int(params, CRM_alert_rc, op->rc);
 
+    if(op->op_status == PCMK_LRM_OP_TIMEOUT) {
+        params = alert_key2param_int(params, CRM_alert_exec_time, op->timeout);
+    } else {
+        params = alert_key2param_int(params, CRM_alert_exec_time, op->exec_time);
+    }
+
     if (op->op_status == PCMK_LRM_OP_DONE) {
         params = alert_key2param(params, CRM_alert_desc, services_ocf_exitcode_str(op->rc));
     } else {


### PR DESCRIPTION
The interesting event stuff is great, thanks very much for that.  Among other things, I'd like to be able to use the events to compile statistics on how long operations take in order to tune timeouts, so I'm wondering if I could get exec_time presented to the IE environment, as in this pull request.

In order to compile statistics from reoccurring actions, I'd also like to have an option to notify on all events, not just change events, but that'll come later...

Thanks,
Chris