### PR TITLE
Feature: fence-history: add cleanup & sync & history-notify

### DIFF
--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -168,9 +168,15 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                     erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
                 }
 
-            } else if(AM_I_DC && appeared == FALSE) {
-                crm_info("Peer %s left us", node->uname);
-                erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
+            } else if(AM_I_DC) {
+                if (appeared == FALSE) {
+                    crm_info("Peer %s left us", node->uname);
+                    erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
+                } else {
+                    crm_info("New peer %s we want to sync fence history with",
+                             node->uname);
+                    te_trigger_stonith_history_sync();
+                }
             }
             break;
     }

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -21,6 +21,8 @@
 #include <crm/fencing/internal.h>
 
 crm_trigger_t *stonith_reconnect = NULL;
+static crm_trigger_t *stonith_history_sync_trigger = NULL;
+static mainloop_timer_t *stonith_history_sync_timer = NULL;
 
 /*
  * stonith cleanup list
@@ -328,6 +330,58 @@ tengine_stonith_notify(stonith_t * st, stonith_event_t * st_event)
 
         crmd_peer_down(peer, TRUE);
      }
+}
+
+static gboolean
+do_stonith_history_sync(gpointer user_data)
+{
+    if (stonith_api && (stonith_api->state != stonith_disconnected)) {
+        stonith_history_t *history = NULL;
+
+        stonith_api->cmds->history(stonith_api,
+                                   st_opt_sync_call | st_opt_broadcast,
+                                   NULL, &history, 5);
+        stonith_history_free(history);
+        return TRUE;
+    } else {
+        crm_info("Skip triggering stonith history-sync as stonith is disconnected");
+        return FALSE;
+    }
+}
+
+static gboolean
+stonith_history_sync_set_trigger(gpointer user_data)
+{
+    mainloop_set_trigger(stonith_history_sync_trigger);
+    return FALSE;
+}
+
+void
+te_trigger_stonith_history_sync(void)
+{
+    /* trigger a sync in 5s to give more nodes the
+     * chance to show up so that we don't create
+     * unnecessary stonith-history-sync traffic
+     */
+
+    /* as we are finally checking the stonith-connection
+     * in do_stonith_history_sync we should be fine
+     * leaving stonith_history_sync_time & stonith_history_sync_trigger
+     * arround
+     */
+    if (stonith_history_sync_trigger == NULL) {
+        stonith_history_sync_trigger =
+            mainloop_add_trigger(G_PRIORITY_LOW,
+                                 do_stonith_history_sync, NULL);
+    }
+
+    if(stonith_history_sync_timer == NULL) {
+        stonith_history_sync_timer =
+            mainloop_timer_add("history_sync", 5000,
+                               FALSE, stonith_history_sync_set_trigger,
+                               NULL);
+    }
+    mainloop_timer_start(stonith_history_sync_timer);
 }
 
 gboolean

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -69,6 +69,8 @@ extern void abort_transition_graph(int abort_priority, enum transition_action ab
 
 extern gboolean te_connect_stonith(gpointer user_data);
 
+extern void te_trigger_stonith_history_sync(void);
+
 extern crm_trigger_t *transition_trigger;
 extern crm_trigger_t *stonith_reconnect;
 

--- a/daemons/fenced/Makefile.am
+++ b/daemons/fenced/Makefile.am
@@ -36,7 +36,8 @@ pacemaker_fenced_LDADD		= $(top_builddir)/lib/common/libcrmcommon.la		\
 				  $(CLUSTERLIBS)
 pacemaker_fenced_SOURCES	= pacemaker-fenced.c \
 				  fenced_commands.c \
-				  fenced_remote.c
+				  fenced_remote.c \
+				  fenced_history.c
 
 CLEANFILES = $(man7_MANS) $(man8_MANS)
 

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2009-2018 Andrew Beekhof <andrew@beekhof.net>
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#include <crm/crm.h>
+#include <crm/msg_xml.h>
+#include <crm/common/ipc.h>
+#include <crm/common/ipcs.h>
+#include <crm/cluster/internal.h>
+
+#include <crm/stonith-ng.h>
+#include <crm/fencing/internal.h>
+#include <crm/common/xml.h>
+
+#include <pacemaker-fenced.h>
+
+/*!
+ * \internal
+ * \brief Send a broadcast to all nodes to trigger cleanup or
+ *        history synchronisation
+ *
+ * \param[in] history   Optional history to be attached
+ * \param[in] callopts  We control cleanup via a flag in the callopts
+ * \param[in] target    Cleanup can be limited to certain fence-targets
+ */
+static void
+stonith_send_broadcast_history(xmlNode *history,
+                               int callopts,
+                               const char *target)
+{
+    xmlNode *bcast = create_xml_node(NULL, "stonith_command");
+    xmlNode *data = create_xml_node(NULL, __FUNCTION__);
+
+    if (target) {
+        crm_xml_add(data, F_STONITH_TARGET, target);
+    }
+    crm_xml_add(bcast, F_TYPE, T_STONITH_NG);
+    crm_xml_add(bcast, F_SUBTYPE, "broadcast");
+    crm_xml_add(bcast, F_STONITH_OPERATION, STONITH_OP_FENCE_HISTORY);
+    crm_xml_add_int(bcast, F_STONITH_CALLOPTS, callopts);
+    if (history) {
+        add_node_copy(data, history);
+    }
+    add_message_xml(bcast, F_STONITH_CALLDATA, data);
+    send_cluster_message(NULL, crm_msg_stonith_ng, bcast, FALSE);
+
+    free_xml(data);
+    free_xml(bcast);
+}
+
+static gboolean
+stonith_remove_history_entry (gpointer key,
+                              gpointer value,
+                              gpointer user_data)
+{
+    remote_fencing_op_t *op = value;
+    const char *target = (const char *) user_data;
+
+    if ((op->state == st_failed) || (op->state == st_done)) {
+        if ((target) && (strcmp(op->target, target) != 0)) {
+            return FALSE;
+        }
+        return TRUE;
+    }
+
+    return FALSE; /* don't clean pending operations */
+}
+
+/*!
+ * \internal
+ * \brief Send out a cleanup broadcast and do a local history-cleanup
+ *
+ * \param[in] request   The request message that triggered cleanup
+ * \param[in] target    Cleanup can be limited to certain fence-targets
+ */
+static void
+stonith_fence_history_cleanup(xmlNode *request, const char *target)
+{
+    if (crm_element_value(request, F_STONITH_CALLID)) {
+        stonith_send_broadcast_history(NULL,
+                                       st_opt_cleanup | st_opt_discard_reply,
+                                       target);
+        /* we'll do the local clean when we receive back our own broadcast */
+    } else if (stonith_remote_op_list) {
+        g_hash_table_foreach_remove(stonith_remote_op_list,
+                             stonith_remove_history_entry,
+                             (gpointer) target);
+        do_stonith_notify(0, T_STONITH_NOTIFY_HISTORY, 0, NULL);
+    }
+}
+
+/*!
+ * \internal
+ * \brief Convert xml fence-history to a hash-table like stonith_remote_op_list
+ *
+ * \param[in] history   Fence-history in xml
+ *
+ * \return Fence-history as hash-table
+ */
+static GHashTable *
+stonith_xml_history_to_list(xmlNode *history)
+{
+    xmlNode *xml_op = NULL;
+    GHashTable *rv = NULL;
+
+    init_stonith_remote_op_hash_table(&rv);
+
+    CRM_LOG_ASSERT(rv != NULL);
+
+    for (xml_op = __xml_first_child(history); xml_op != NULL;
+         xml_op = __xml_next(xml_op)) {
+        remote_fencing_op_t *op = NULL;
+        char *id = crm_element_value_copy(xml_op, F_STONITH_REMOTE_OP_ID);
+        int completed, state;
+
+        if (!id) {
+            crm_warn("History to convert to hashtable has no id in entry");
+            continue;
+        }
+
+        crm_trace("Attaching op %s to hashtable", id);
+
+        op = calloc(1, sizeof(remote_fencing_op_t));
+
+        op->id = id;
+        op->target = crm_element_value_copy(xml_op, F_STONITH_TARGET);
+        op->action = crm_element_value_copy(xml_op, F_STONITH_ACTION);
+        op->originator = crm_element_value_copy(xml_op, F_STONITH_ORIGIN);
+        op->delegate = crm_element_value_copy(xml_op, F_STONITH_DELEGATE);
+        op->client_name = crm_element_value_copy(xml_op, F_STONITH_CLIENTNAME);
+        crm_element_value_int(xml_op, F_STONITH_DATE, &completed);
+        op->completed = (time_t) completed;
+        crm_element_value_int(xml_op, F_STONITH_STATE, &state);
+        op->state = (enum op_state) state;
+
+        g_hash_table_replace(rv, id, op);
+        CRM_LOG_ASSERT(g_hash_table_lookup(rv, id) != NULL);
+    }
+
+    return rv;
+}
+
+/*!
+ * \internal
+ * \brief Craft xml difference between local fence-history and a history
+ *        coming from remote
+ *
+ * \param[in] remote_history    Fence-history as hash-table (may be NULL)
+ * \param[in] add_id            If crafting the answer for an API
+ *                              history-request there is no need for the id
+ * \param[in] target            Optionally limit to certain fence-target
+ *
+ * \return The fence-history as xml
+ */
+static xmlNode *
+stonith_local_history_diff(GHashTable *remote_history,
+                           gboolean add_id,
+                           const char *target)
+{
+    xmlNode *history = NULL;
+    int cnt = 0;
+
+    if (stonith_remote_op_list) {
+            GHashTableIter iter;
+            remote_fencing_op_t *op = NULL;
+
+            history = create_xml_node(NULL, F_STONITH_HISTORY_LIST);
+
+            g_hash_table_iter_init(&iter, stonith_remote_op_list);
+            while (g_hash_table_iter_next(&iter, NULL, (void **)&op)) {
+                xmlNode *entry = NULL;
+
+                if (remote_history &&
+                    g_hash_table_lookup(remote_history, op->id)) {
+                    continue; /* skip entries broadcasted already */
+                }
+
+                if (target && strcmp(op->target, target) != 0) {
+                    continue;
+                }
+
+                cnt++;
+                crm_trace("Attaching op %s", op->id);
+                entry = create_xml_node(history, STONITH_OP_EXEC);
+                if (add_id) {
+                    crm_xml_add(entry, F_STONITH_REMOTE_OP_ID, op->id);
+                }
+                crm_xml_add(entry, F_STONITH_TARGET, op->target);
+                crm_xml_add(entry, F_STONITH_ACTION, op->action);
+                crm_xml_add(entry, F_STONITH_ORIGIN, op->originator);
+                crm_xml_add(entry, F_STONITH_DELEGATE, op->delegate);
+                crm_xml_add(entry, F_STONITH_CLIENTNAME, op->client_name);
+                crm_xml_add_int(entry, F_STONITH_DATE, op->completed);
+                crm_xml_add_int(entry, F_STONITH_STATE, op->state);
+            }
+    }
+
+    if (cnt == 0) {
+        free_xml(history);
+        return NULL;
+    } else {
+        return history;
+    }
+}
+
+/*!
+ * \internal
+ * \brief Merge fence-history coming from remote into local history
+ *
+ * \param[in] history   Hash-table holding remote history to be merged in
+ */
+static void
+stonith_merge_in_history_list(GHashTable *history)
+{
+    GHashTableIter iter;
+    remote_fencing_op_t *op = NULL;
+    gboolean updated = FALSE;
+
+    if (!history) {
+        return;
+    }
+
+    init_stonith_remote_op_hash_table(&stonith_remote_op_list);
+
+    g_hash_table_iter_init(&iter, history);
+    while (g_hash_table_iter_next(&iter, NULL, (void **)&op)) {
+        remote_fencing_op_t *stored_op =
+            g_hash_table_lookup(stonith_remote_op_list, op->id);
+
+        if (stored_op) {
+            continue; /* skip over existant - state-merging migh be desirable */
+        }
+
+        updated = TRUE;
+        g_hash_table_iter_steal(&iter);
+        CRM_LOG_ASSERT(g_hash_table_insert(stonith_remote_op_list, op->id, op));
+    }
+    if (updated) {
+        do_stonith_notify(0, T_STONITH_NOTIFY_HISTORY, 0, NULL);
+    }
+    g_hash_table_destroy(history); /* remove what is left */
+}
+
+/*!
+ * \internal
+ * \brief Handle fence-history messages (either from API or coming in as
+ *        broadcasts
+ *
+ * \param[in] msg       Request message
+ * \param[in] output    In case of a request from the API used to craft
+ *                      a reply from
+ * \param[in] remote_peer
+ * \param[in] options   call-options from the request
+ *
+ * \return always success as there is actully nothing that can go really wrong
+ */
+int
+stonith_fence_history(xmlNode *msg, xmlNode **output,
+                      const char *remote_peer, int options)
+{
+    int rc = 0;
+    const char *target = NULL;
+    xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, msg, LOG_TRACE);
+    char *nodename = NULL;
+    xmlNode *out_history = NULL;
+
+    if (dev) {
+        target = crm_element_value(dev, F_STONITH_TARGET);
+        if (target && (options & st_opt_cs_nodeid)) {
+            int nodeid = crm_atoi(target, NULL);
+
+            nodename = stonith_get_peer_name(nodeid);
+            if (nodename) {
+                target = nodename;
+            }
+        }
+    }
+
+    if (options & st_opt_cleanup) {
+        crm_trace("Cleaning up operations on %s in %p", target,
+                  stonith_remote_op_list);
+
+        stonith_fence_history_cleanup(msg, target);
+    } else if (options & st_opt_broadcast) {
+        if (crm_element_value(msg, F_STONITH_CALLID)) {
+            /* this is coming from the stonith-API
+            *
+            * craft a broadcast with node's history
+            * so that every node can merge and broadcast
+            * what it has on top
+            */
+            out_history = stonith_local_history_diff(NULL, TRUE, NULL);
+            crm_trace("Broadcasting history to peers");
+            stonith_send_broadcast_history(out_history,
+                                        st_opt_broadcast | st_opt_discard_reply,
+                                        NULL);
+        } else if (remote_peer &&
+                   !safe_str_eq(remote_peer, stonith_our_uname)) {
+            xmlNode *history =
+                get_xpath_object("//" F_STONITH_HISTORY_LIST, msg, LOG_TRACE);
+            GHashTable *received_history =
+                history?stonith_xml_history_to_list(history):NULL;
+
+            /* either a broadcast created directly upon stonith-API request
+            * or a diff as response to such a thing
+            *
+            * in both cases it may have a history or not
+            * if we have differential data
+            * merge in what we've received and stop
+            * otherwise broadcast what we have on top
+            * marking as differential and merge in afterwards
+            */
+            if (!history ||
+                !crm_is_true(crm_element_value(history,
+                                               F_STONITH_DIFFERENTIAL))) {
+                out_history =
+                    stonith_local_history_diff(received_history, TRUE, NULL);
+                if (out_history) {
+                    crm_trace("Broadcasting history-diff to peers");
+                    crm_xml_add(out_history, F_STONITH_DIFFERENTIAL,
+                                XML_BOOLEAN_TRUE);
+                    stonith_send_broadcast_history(out_history,
+                        st_opt_broadcast | st_opt_discard_reply,
+                        NULL);
+                } else {
+                    crm_trace("History-diff is empty - skip broadcast");
+                }
+            }
+            stonith_merge_in_history_list(received_history);
+        } else {
+            crm_trace("Skipping history-query-broadcast (%s%s)"
+                      " we sent ourselves",
+                      remote_peer?"remote-peer=":"local-ipc",
+                      remote_peer?remote_peer:"");
+        }
+    } else {
+        /* plain history request */
+        crm_trace("Looking for operations on %s in %p", target,
+                  stonith_remote_op_list);
+        *output = stonith_local_history_diff(NULL, FALSE, target);
+    }
+    free(nodename);
+    free_xml(out_history);
+    return rc;
+}

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -71,7 +71,7 @@ typedef struct st_query_result_s {
     GHashTable *devices;
 } st_query_result_t;
 
-static GHashTable *remote_op_list = NULL;
+GHashTable *stonith_remote_op_list = NULL;
 
 void call_remote_stonith(remote_fencing_op_t * op, st_query_result_t * peer);
 static void remote_op_done(remote_fencing_op_t * op, xmlNode * data, int rc, int dup);
@@ -102,11 +102,11 @@ free_remote_query(gpointer data)
 }
 
 void
-free_remote_op_list()
+free_stonith_remote_op_list()
 {
-    if (remote_op_list != NULL) {
-        g_hash_table_destroy(remote_op_list);
-        remote_op_list = NULL;
+    if (stonith_remote_op_list != NULL) {
+        g_hash_table_destroy(stonith_remote_op_list);
+        stonith_remote_op_list = NULL;
     }
 }
 
@@ -259,6 +259,14 @@ free_remote_op(gpointer data)
     free(op);
 }
 
+void
+init_stonith_remote_op_hash_table(GHashTable **table)
+{
+    if (*table == NULL) {
+        *table = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free_remote_op);
+    }
+}
+
 /*!
  * \internal
  * \brief Return an operation's originally requested action (before any remap)
@@ -407,6 +415,7 @@ handle_local_reply_and_notify(remote_fencing_op_t * op, xmlNode * data, int rc)
 
     /* bcast to all local clients that the fencing operation happend */
     do_stonith_notify(0, T_STONITH_NOTIFY_FENCE, rc, notify_data);
+    do_stonith_notify(0, T_STONITH_NOTIFY_HISTORY, 0, NULL);
 
     /* mark this op as having notify's already sent */
     op->notify_sent = TRUE;
@@ -834,7 +843,7 @@ merge_duplicates(remote_fencing_op_t * op)
 
     time_t now = time(NULL);
 
-    g_hash_table_iter_init(&iter, remote_op_list);
+    g_hash_table_iter_init(&iter, stonith_remote_op_list);
     while (g_hash_table_iter_next(&iter, NULL, (void **)&other)) {
         crm_node_t *peer = NULL;
         const char *other_action = op_requested_action(other);
@@ -964,9 +973,7 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
     xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, request, LOG_TRACE);
     int call_options = 0;
 
-    if (remote_op_list == NULL) {
-        remote_op_list = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free_remote_op);
-    }
+    init_stonith_remote_op_hash_table(&stonith_remote_op_list);
 
     /* If this operation is owned by another node, check to make
      * sure we haven't already created this operation. */
@@ -975,7 +982,7 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
 
         CRM_CHECK(op_id != NULL, return NULL);
 
-        op = g_hash_table_lookup(remote_op_list, op_id);
+        op = g_hash_table_lookup(stonith_remote_op_list, op_id);
         if (op) {
             crm_debug("%s already exists", op_id);
             return op;
@@ -992,8 +999,8 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
         op->id = crm_generate_uuid();
     }
 
-    g_hash_table_replace(remote_op_list, op->id, op);
-    CRM_LOG_ASSERT(g_hash_table_lookup(remote_op_list, op->id) != NULL);
+    g_hash_table_replace(stonith_remote_op_list, op->id, op);
+    CRM_LOG_ASSERT(g_hash_table_lookup(stonith_remote_op_list, op->id) != NULL);
     crm_trace("Created %s", op->id);
 
     op->state = st_query;
@@ -1044,6 +1051,11 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
 
     /* check to see if this is a duplicate operation of another in-flight operation */
     merge_duplicates(op);
+
+    if (op->state != st_duplicate) {
+        /* kick history readers */
+        do_stonith_notify(0, T_STONITH_NOTIFY_HISTORY, 0, NULL);
+    }
 
     return op;
 }
@@ -1831,7 +1843,7 @@ process_remote_stonith_query(xmlNode * msg)
     CRM_CHECK(dev != NULL, return -EPROTO);
     crm_element_value_int(dev, F_STONITH_AVAILABLE_DEVICES, &ndevices);
 
-    op = g_hash_table_lookup(remote_op_list, id);
+    op = g_hash_table_lookup(stonith_remote_op_list, id);
     if (op == NULL) {
         crm_debug("Received query reply for unknown or expired operation %s",
                   id);
@@ -1926,8 +1938,8 @@ process_remote_stonith_exec(xmlNode * msg)
 
     device = crm_element_value(dev, F_STONITH_DEVICE);
 
-    if (remote_op_list) {
-        op = g_hash_table_lookup(remote_op_list, id);
+    if (stonith_remote_op_list) {
+        op = g_hash_table_lookup(stonith_remote_op_list, id);
     }
 
     if (op == NULL && rc == pcmk_ok) {
@@ -2030,61 +2042,6 @@ process_remote_stonith_exec(xmlNode * msg)
     return rc;
 }
 
-int
-stonith_fence_history(xmlNode * msg, xmlNode ** output)
-{
-    int rc = 0;
-    const char *target = NULL;
-    xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, msg, LOG_TRACE);
-    char *nodename = NULL;
-
-    if (dev) {
-        int options = 0;
-
-        target = crm_element_value(dev, F_STONITH_TARGET);
-        crm_element_value_int(msg, F_STONITH_CALLOPTS, &options);
-        if (target && (options & st_opt_cs_nodeid)) {
-            int nodeid = crm_atoi(target, NULL);
-
-            nodename = stonith_get_peer_name(nodeid);
-            if (nodename) {
-                target = nodename;
-            }
-        }
-    }
-
-    crm_trace("Looking for operations on %s in %p", target, remote_op_list);
-
-    *output = create_xml_node(NULL, F_STONITH_HISTORY_LIST);
-    if (remote_op_list) {
-        GHashTableIter iter;
-        remote_fencing_op_t *op = NULL;
-
-        g_hash_table_iter_init(&iter, remote_op_list);
-        while (g_hash_table_iter_next(&iter, NULL, (void **)&op)) {
-            xmlNode *entry = NULL;
-
-            if (target && strcmp(op->target, target) != 0) {
-                continue;
-            }
-
-            rc = 0;
-            crm_trace("Attaching op %s", op->id);
-            entry = create_xml_node(*output, STONITH_OP_EXEC);
-            crm_xml_add(entry, F_STONITH_TARGET, op->target);
-            crm_xml_add(entry, F_STONITH_ACTION, op->action);
-            crm_xml_add(entry, F_STONITH_ORIGIN, op->originator);
-            crm_xml_add(entry, F_STONITH_DELEGATE, op->delegate);
-            crm_xml_add(entry, F_STONITH_CLIENTNAME, op->client_name);
-            crm_xml_add_int(entry, F_STONITH_DATE, (int) op->completed);
-            crm_xml_add_int(entry, F_STONITH_STATE, op->state);
-        }
-    }
-
-    free(nodename);
-    return rc;
-}
-
 gboolean
 stonith_check_fence_tolerance(int tolerance, const char *target, const char *action)
 {
@@ -2092,13 +2049,15 @@ stonith_check_fence_tolerance(int tolerance, const char *target, const char *act
     time_t now = time(NULL);
     remote_fencing_op_t *rop = NULL;
 
-    crm_trace("tolerance=%d, remote_op_list=%p", tolerance, remote_op_list);
+    crm_trace("tolerance=%d, stonith_remote_op_list=%p", tolerance,
+              stonith_remote_op_list);
 
-    if (tolerance <= 0 || !remote_op_list || target == NULL || action == NULL) {
+    if (tolerance <= 0 || !stonith_remote_op_list || target == NULL ||
+        action == NULL) {
         return FALSE;
     }
 
-    g_hash_table_iter_init(&iter, remote_op_list);
+    g_hash_table_iter_init(&iter, stonith_remote_op_list);
     while (g_hash_table_iter_next(&iter, NULL, (void **)&rop)) {
         if (strcmp(rop->target, target) != 0) {
             continue;

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -265,15 +265,19 @@ long long
 get_stonith_flag(const char *name)
 {
     if (safe_str_eq(name, T_STONITH_NOTIFY_FENCE)) {
-        return 0x01;
+        return st_callback_notify_fence;
 
     } else if (safe_str_eq(name, STONITH_OP_DEVICE_ADD)) {
-        return 0x04;
+        return st_callback_device_add;
 
     } else if (safe_str_eq(name, STONITH_OP_DEVICE_DEL)) {
-        return 0x10;
+        return st_callback_device_del;
+
+    } else if (safe_str_eq(name, T_STONITH_NOTIFY_HISTORY)) {
+        return st_callback_notify_history;
+
     }
-    return 0;
+    return st_callback_unknown;
 }
 
 static void
@@ -1148,7 +1152,7 @@ stonith_cleanup(void)
 
     crm_peer_destroy();
     crm_client_cleanup();
-    free_remote_op_list();
+    free_stonith_remote_op_list();
     free_topology_list();
     free_device_list();
     free_metadata_cache();

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -149,6 +149,14 @@ typedef struct remote_fencing_op_s {
 
 } remote_fencing_op_t;
 
+enum st_callback_flags {
+    st_callback_unknown        = 0x0000,
+    st_callback_notify_fence   = 0x0001,
+    st_callback_device_add     = 0x0004,
+    st_callback_device_del     = 0x0010,
+    st_callback_notify_history = 0x0020
+};
+
 /*
  * Complex fencing requirements are specified via fencing topologies.
  * A topology consists of levels; each level is a list of fencing devices.
@@ -181,7 +189,8 @@ void init_device_list(void);
 void free_device_list(void);
 void init_topology_list(void);
 void free_topology_list(void);
-void free_remote_op_list(void);
+void free_stonith_remote_op_list(void);
+void init_stonith_remote_op_hash_table(GHashTable **table);
 void free_metadata_cache(void);
 
 long long get_stonith_flag(const char *name);
@@ -223,7 +232,8 @@ int process_remote_stonith_query(xmlNode * msg);
 
 void *create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer);
 
-int stonith_fence_history(xmlNode * msg, xmlNode ** output);
+int stonith_fence_history(xmlNode *msg, xmlNode **output,
+                          const char *remote_peer, int options);
 
 bool fencing_peer_active(crm_node_t *peer);
 
@@ -252,3 +262,5 @@ extern GHashTable *topology;
 extern long stonith_watchdog_timeout_ms;
 
 extern GHashTable *known_peer_names;
+
+extern GHashTable *stonith_remote_op_list;

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -86,6 +86,7 @@ xmlNode *create_device_registration_xml(const char *id,
 #  define F_STONITH_DATE          "st_date"
 #  define F_STONITH_STATE         "st_state"
 #  define F_STONITH_ACTIVE        "st_active"
+#  define F_STONITH_DIFFERENTIAL  "st_differential"
 
 #  define F_STONITH_DEVICE        "st_device_id"
 #  define F_STONITH_ACTION        "st_device_action"

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -27,6 +27,7 @@ extern "C" {
 
 #  define T_STONITH_NOTIFY_DISCONNECT     "st_notify_disconnect"
 #  define T_STONITH_NOTIFY_FENCE          "st_notify_fence"
+#  define T_STONITH_NOTIFY_HISTORY        "st_notify_history"
 
 /* *INDENT-OFF* */
 enum stonith_state {
@@ -52,6 +53,10 @@ enum stonith_call_options {
     st_opt_timeout_updates = 0x00002000,
     /*! Only report back if operation is a success in callback */
     st_opt_report_only_success = 0x00004000,
+    /* used where ever apropriate - e.g. cleanup of history */
+    st_opt_cleanup         = 0x000080000,
+    /* used where ever apropriate - e.g. send out a history query to all nodes */
+    st_opt_broadcast       = 0x000100000,
 };
 
 /*! Order matters here, do not change values */

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -120,7 +120,7 @@ static gboolean watch_fencing = FALSE;
 static gboolean fence_history = FALSE;
 static gboolean fence_full_history = FALSE;
 static gboolean fence_connect = FALSE;
-static int fence_history_level = 0;
+static int fence_history_level = 1;
 static gboolean print_brief = FALSE;
 static gboolean print_pending = TRUE;
 static gboolean print_clone_detail = FALSE;
@@ -718,6 +718,11 @@ main(int argc, char **argv)
                 ++argerr;
                 break;
         }
+    }
+
+    if (watch_fencing) {
+        /* don't moan as fence_history_level == 1 is default */
+        fence_history_level = 0;
     }
 
     switch (fence_history_level) {


### PR DESCRIPTION
This is the followup of #1521 

At the moment it is one big commit to discuss the basic approach:

```
- refactor init of remote_op_list
- add fence-history notifications
- add possibility to cleanup fence-history via API
- add possibility to cluster-sync fence-history via API
- refactor stonith-flags to enum
- make crm_mon use new fence-history notifications instead of polling
- add possibility to trigger new fence-history cleanup & broadcast to stonith_admin
```

Cleanup is triggered:
```
stonith_admin -H "*" --cleanup
```
The stonith-API-call creates a broadcast to all nodes in the cluster to purge their fence-history.
There are no replies expected.

Syncing the fence-history is triggered:
```
stonith_admin -H "*" --broadcast
```
The stonith-API-call creates a broadcast sending the local fence-history to all nodes.
If a node receives this broadcast it checks if it would have additional history-entries to that, and if it has, it sends out a diff-broadcast. (empty diff-broadcasts are suppressed).
Content of received history-broadcasts and diff-history-broadcasts are merged into the local history.
```
...
 -Q, --query=value	Check the named device's status. Optional: --timeout.
 -H, --history=value	Show last successful fencing operation for named node
			(or '*' for all nodes). Optional: --timeout, --cleanup,
			--quiet (show only the operation's epoch timestamp),
			--verbose (show all recorded and pending operations),
			--broadcast (update history from all nodes available).
 -h, --last=value	Indicate when the named node was last fenced.
			Optional: --as-node-id.
...
```

The last 2 commits trigger an automated history-sync upon nodes joining a DC abd
make crm_mon default to showing the history of fence-failures.
The actual sync is delayed by 5 seconds after the last join in a row so that
we don't create unnecessary traffic when cluster-nodes are finding each other.
