### PR TITLE
Refactor: code hygiene: move towards "static" well-behavedness

### DIFF
--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -26,10 +26,8 @@
 
 #include <pacemaker-based.h>
 
-extern gboolean cib_is_master;
-extern const char *cib_root;
 gboolean stand_alone = FALSE;
-extern int cib_status;
+
 extern int cib_perform_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff,
                                gboolean privileged);
 

--- a/daemons/based/based_io.c
+++ b/daemons/based/based_io.c
@@ -31,11 +31,7 @@
 
 #include <pacemaker-based.h>
 
-extern const char *cib_root;
-
 crm_trigger_t *cib_writer = NULL;
-
-extern int cib_status;
 
 int write_cib_contents(gpointer p);
 

--- a/daemons/based/cibmon.c
+++ b/daemons/based/cibmon.c
@@ -46,20 +46,20 @@
 #  include <getopt.h>
 #endif
 
-int max_failures = 30;
+static int max_failures = 30;
 
-gboolean log_diffs = FALSE;
-gboolean log_updates = FALSE;
+static gboolean log_diffs = FALSE;
+static gboolean log_updates = FALSE;
 
-GMainLoop *mainloop = NULL;
+static GMainLoop *mainloop = NULL;
 void usage(const char *cmd, crm_exit_t exit_status);
 void cib_connection_destroy(gpointer user_data);
 
 void cibmon_shutdown(int nsig);
 void cibmon_diff(const char *event, xmlNode * msg);
 
-cib_t *cib = NULL;
-xmlNode *cib_copy = NULL;
+static cib_t *cib = NULL;
+static xmlNode *cib_copy = NULL;
 
 #define OPTARGS	"V?m:du"
 

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -37,7 +37,7 @@ crm_cluster_t crm_cluster;
 GMainLoop *mainloop = NULL;
 const char *cib_root = NULL;
 char *cib_our_uname = NULL;
-gboolean preserve_status = FALSE;
+static gboolean preserve_status = FALSE;
 
 /* volatile because it may be changed in a signal handler */
 volatile gboolean cib_writes_enabled = TRUE;

--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -48,7 +48,7 @@ static struct crm_option long_options[] = {
 };
 /* *INDENT-ON* */
 
-cib_t *cib_conn = NULL;
+static cib_t *cib_conn = NULL;
 static int exec_call_id = 0;
 static int exec_call_opts = 0;
 extern void cleanup_alloc_calculations(pe_working_set_t * data_set);
@@ -75,8 +75,8 @@ static struct {
     lrmd_key_value_t *params;
 } options;
 
-GMainLoop *mainloop = NULL;
-lrmd_t *lrmd_conn = NULL;
+static GMainLoop *mainloop = NULL;
+static lrmd_t *lrmd_conn = NULL;
 
 static char event_buf_v0[1024];
 

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -27,9 +27,9 @@
 #  define ENABLE_PCMK_REMOTE
 #endif
 
-GMainLoop *mainloop = NULL;
+static GMainLoop *mainloop = NULL;
 static qb_ipcs_service_t *ipcs = NULL;
-stonith_t *stonith_api = NULL;
+static stonith_t *stonith_api = NULL;
 int lrmd_call_id = 0;
 
 #ifdef ENABLE_PCMK_REMOTE

--- a/daemons/fenced/cts-fence-helper.c
+++ b/daemons/fenced/cts-fence-helper.c
@@ -41,10 +41,10 @@
 
 #include <crm/common/mainloop.h>
 
-GMainLoop *mainloop = NULL;
-crm_trigger_t *trig = NULL;
-int mainloop_iter = 0;
-int callback_rc = 0;
+static GMainLoop *mainloop = NULL;
+static crm_trigger_t *trig = NULL;
+static int mainloop_iter = 0;
+static int callback_rc = 0;
 typedef void (*mainloop_test_iteration_cb) (int check_event);
 
 #define MAINLOOP_DEFAULT_TIMEOUT 2
@@ -85,11 +85,11 @@ static struct crm_option long_options[] = {
 };
 /* *INDENT-ON* */
 
-stonith_t *st = NULL;
-struct pollfd pollfd;
-int st_opts = st_opt_sync_call;
-int expected_notifications = 0;
-int verbose = 0;
+static stonith_t *st = NULL;
+static struct pollfd pollfd;
+static int st_opts = st_opt_sync_call;
+static int expected_notifications = 0;
+static int verbose = 0;
 
 static void
 dispatch_helper(int timeout)

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -40,14 +40,14 @@ char *stonith_our_uname = NULL;
 char *stonith_our_uuid = NULL;
 long stonith_watchdog_timeout_ms = 0;
 
-GMainLoop *mainloop = NULL;
+static GMainLoop *mainloop = NULL;
 
 gboolean stand_alone = FALSE;
-gboolean no_cib_connect = FALSE;
-gboolean stonith_shutdown_flag = FALSE;
+static gboolean no_cib_connect = FALSE;
+static gboolean stonith_shutdown_flag = FALSE;
 
-qb_ipcs_service_t *ipcs = NULL;
-xmlNode *local_cib = NULL;
+static qb_ipcs_service_t *ipcs = NULL;
+static xmlNode *local_cib = NULL;
 
 GHashTable *known_peer_names = NULL;
 

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -28,16 +28,16 @@
 #include <dirent.h>
 #include <ctype.h>
 
-gboolean pcmk_quorate = FALSE;
-gboolean fatal_error = FALSE;
-GMainLoop *mainloop = NULL;
+static gboolean pcmk_quorate = FALSE;
+static gboolean fatal_error = FALSE;
+static GMainLoop *mainloop = NULL;
 
 #define PCMK_PROCESS_CHECK_INTERVAL 5
 
-const char *local_name = NULL;
-uint32_t local_nodeid = 0;
-crm_trigger_t *shutdown_trigger = NULL;
-const char *pid_file = "/var/run/pacemaker.pid";
+static const char *local_name = NULL;
+static uint32_t local_nodeid = 0;
+static crm_trigger_t *shutdown_trigger = NULL;
+static const char *pid_file = "/var/run/pacemaker.pid";
 
 typedef struct pcmk_child_s {
     int pid;

--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -20,8 +20,6 @@
 #define SIZEOF(a)   (sizeof(a) / sizeof(a[0]))
 #define MAX_RESPAWN		100
 
-extern uint32_t local_nodeid;
-
 gboolean mcp_read_config(void);
 
 gboolean cluster_connect_cfg(uint32_t * nodeid);

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -25,8 +25,8 @@
 
 #define OPTARGS	"hVc"
 
-GMainLoop *mainloop = NULL;
-qb_ipcs_service_t *ipcs = NULL;
+static GMainLoop *mainloop = NULL;
+static qb_ipcs_service_t *ipcs = NULL;
 
 void pengine_shutdown(int nsig);
 

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -13,20 +13,20 @@
 #include <crm/common/ipc.h>
 #include <crm/cib/internal.h>
 
-int message_timeout_ms = 30;
-int command_options = 0;
-int request_id = 0;
-int bump_log_num = 0;
+static int message_timeout_ms = 30;
+static int command_options = 0;
+static int request_id = 0;
+static int bump_log_num = 0;
 
-const char *host = NULL;
-const char *cib_user = NULL;
-const char *cib_action = NULL;
-const char *obj_type = NULL;
+static const char *host = NULL;
+static const char *cib_user = NULL;
+static const char *cib_action = NULL;
+static const char *obj_type = NULL;
 
-cib_t *the_cib = NULL;
-GMainLoop *mainloop = NULL;
-gboolean force_flag = FALSE;
-crm_exit_t exit_code = CRM_EX_OK;
+static cib_t *the_cib = NULL;
+static GMainLoop *mainloop = NULL;
+static gboolean force_flag = FALSE;
+static crm_exit_t exit_code = CRM_EX_OK;
 
 int do_init(void);
 int do_work(xmlNode *input, int command_options, xmlNode **output);

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -75,7 +75,7 @@ static char *get_node_display_name(node_t *node);
                                | mon_show_tickets | mon_show_bans \
                                | mon_show_fence_history)
 
-unsigned int show = mon_show_default;
+static unsigned int show = mon_show_default;
 
 /*
  * Definitions indicating how to output
@@ -91,39 +91,39 @@ enum mon_output_format_e {
     mon_output_cgi
 } output_format = mon_output_console;
 
-char *output_filename = NULL;   /* if sending output to a file, its name */
+static char *output_filename = NULL;   /* if sending output to a file, its name */
 
 /* other globals */
-char *xml_file = NULL;
-char *pid_file = NULL;
+static char *xml_file = NULL;
+static char *pid_file = NULL;
 
-gboolean group_by_node = FALSE;
-gboolean inactive_resources = FALSE;
-int reconnect_msec = 5000;
-gboolean daemonize = FALSE;
-GMainLoop *mainloop = NULL;
-guint timer_id = 0;
-mainloop_timer_t *refresh_timer = NULL;
-GList *attr_list = NULL;
+static gboolean group_by_node = FALSE;
+static gboolean inactive_resources = FALSE;
+static int reconnect_msec = 5000;
+static gboolean daemonize = FALSE;
+static GMainLoop *mainloop = NULL;
+static guint timer_id = 0;
+static mainloop_timer_t *refresh_timer = NULL;
+static GList *attr_list = NULL;
 
-const char *external_agent = NULL;
-const char *external_recipient = NULL;
+static const char *external_agent = NULL;
+static const char *external_recipient = NULL;
 
-cib_t *cib = NULL;
-stonith_t *st = NULL;
-xmlNode *current_cib = NULL;
+static cib_t *cib = NULL;
+static stonith_t *st = NULL;
+static xmlNode *current_cib = NULL;
 
-gboolean one_shot = FALSE;
-gboolean has_warnings = FALSE;
-gboolean print_timing = FALSE;
-gboolean watch_fencing = FALSE;
-gboolean fence_history = FALSE;
-gboolean fence_full_history = FALSE;
-gboolean fence_connect = FALSE;
-int fence_history_level = 0;
-gboolean print_brief = FALSE;
-gboolean print_pending = TRUE;
-gboolean print_clone_detail = FALSE;
+static gboolean one_shot = FALSE;
+static gboolean has_warnings = FALSE;
+static gboolean print_timing = FALSE;
+static gboolean watch_fencing = FALSE;
+static gboolean fence_history = FALSE;
+static gboolean fence_full_history = FALSE;
+static gboolean fence_connect = FALSE;
+static int fence_history_level = 0;
+static gboolean print_brief = FALSE;
+static gboolean print_pending = TRUE;
+static gboolean print_clone_detail = FALSE;
 
 /* FIXME allow, detect, and correctly interpret glob pattern or regex? */
 const char *print_neg_location_prefix = "";

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -25,7 +25,7 @@ bool BE_QUIET = FALSE;
 bool scope_master = FALSE;
 int cib_options = cib_sync_call;
 
-GMainLoop *mainloop = NULL;
+static GMainLoop *mainloop = NULL;
 
 #define message_timeout_ms 60*1000
 

--- a/tools/crmadmin.c
+++ b/tools/crmadmin.c
@@ -26,12 +26,12 @@
 
 #include <crm/cib.h>
 
-int message_timer_id = -1;
-int message_timeout_ms = 30 * 1000;
+static int message_timer_id = -1;
+static int message_timeout_ms = 30 * 1000;
 
-GMainLoop *mainloop = NULL;
-crm_ipc_t *crmd_channel = NULL;
-char *admin_uuid = NULL;
+static GMainLoop *mainloop = NULL;
+static crm_ipc_t *crmd_channel = NULL;
+static char *admin_uuid = NULL;
 
 gboolean do_init(void);
 int do_work(void);
@@ -40,21 +40,21 @@ int admin_msg_callback(const char *buffer, ssize_t length, gpointer userdata);
 int do_find_node_list(xmlNode * xml_node);
 gboolean admin_message_timeout(gpointer data);
 
-gboolean BE_VERBOSE = FALSE;
-int expected_responses = 1;
-gboolean BASH_EXPORT = FALSE;
-gboolean DO_HEALTH = FALSE;
-gboolean DO_RESET = FALSE;
-gboolean DO_RESOURCE = FALSE;
-gboolean DO_ELECT_DC = FALSE;
-gboolean DO_WHOIS_DC = FALSE;
-gboolean DO_NODE_LIST = FALSE;
-gboolean BE_SILENT = FALSE;
-gboolean DO_RESOURCE_LIST = FALSE;
-const char *crmd_operation = NULL;
-char *dest_node = NULL;
-crm_exit_t exit_code = CRM_EX_OK;
-const char *sys_to = NULL;
+static gboolean BE_VERBOSE = FALSE;
+static int expected_responses = 1;
+static gboolean BASH_EXPORT = FALSE;
+static gboolean DO_HEALTH = FALSE;
+static gboolean DO_RESET = FALSE;
+static gboolean DO_RESOURCE = FALSE;
+static gboolean DO_ELECT_DC = FALSE;
+static gboolean DO_WHOIS_DC = FALSE;
+static gboolean DO_NODE_LIST = FALSE;
+static gboolean BE_SILENT = FALSE;
+static gboolean DO_RESOURCE_LIST = FALSE;
+static const char *crmd_operation = NULL;
+static char *dest_node = NULL;
+static crm_exit_t exit_code = CRM_EX_OK;
+static const char *sys_to = NULL;
 
 /* *INDENT-OFF* */
 static struct crm_option long_options[] = {

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -173,9 +173,9 @@ static struct crm_option long_options[] = {
 };
 /* *INDENT-ON* */
 
-int st_opts = st_opt_sync_call | st_opt_allow_suicide;
+static int st_opts = st_opt_sync_call | st_opt_allow_suicide;
 
-GMainLoop *mainloop = NULL;
+static GMainLoop *mainloop = NULL;
 struct {
     stonith_t *st;
     const char *target;


### PR DESCRIPTION
This prevents accidental variable shadowing in the future, helps static
analyzers without cross-file (inter-unit) capabilities, and, for
instance, shall speed up static linking a tiny bit.  Normally,
everything is declared static unless there's a good reason not to...

Also drop some superfluous declarations, redundant with the content of
included headers.

External symbols' stats for a particular configuration of the build[*]:
- before: 3170
- after:  2989

[*] find -executable -type f -cnewer configure \
      -exec nm -g --defined-only {} \; 2>/dev/null | wc -l