### PR TITLE
Feature: crm_mon: default to showing pending fence actions

### DIFF
--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1309,7 +1309,7 @@ stonith_api_history(stonith_t * stonith, int call_options, const char *node,
 
     if (rc == 0) {
         xmlNode *op = NULL;
-        xmlNode *reply = get_xpath_object("//" F_STONITH_HISTORY_LIST, output, LOG_ERR);
+        xmlNode *reply = get_xpath_object("//" F_STONITH_HISTORY_LIST, output, LOG_TRACE);
 
         for (op = __xml_first_child(reply); op != NULL; op = __xml_next(op)) {
             stonith_history_t *kvp;

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -380,7 +380,8 @@ static struct crm_option long_options[] = {
     {"tickets",        0, 0, 'c', "\t\tDisplay cluster tickets"},
     {"watch-fencing",  0, 0, 'W', "\tListen for fencing events. For use with --external-agent"},
     {"fence-history",  2, 0, 'm', "Show fence history\n"
-                                  "\t\t\t\t\t0=off, 1=failures, 2=add successes and pending (default without value),\n"
+                                  "\t\t\t\t\t0=off, 1=failures and pending (default without option),\n"
+                                  "\t\t\t\t\t2=add successes (default without value for option),\n"
                                   "\t\t\t\t\t3=show full history without reduction to most recent of each flavor"},
     {"neg-locations",  2, 0, 'L', "Display negative location constraints [optionally filtered by id prefix]"},
     {"show-node-attributes", 0, 0, 'A', "Display node attributes" },
@@ -3250,6 +3251,61 @@ print_failed_stonith_actions(FILE *stream, stonith_history_t *history)
 
 /*!
  * \internal
+ * \brief Print pending stonith actions
+ *
+ * \param[in] stream     File stream to display output to
+ * \param[in] history    List of stonith actions
+ *
+ */
+static void
+print_stonith_pending(FILE *stream, stonith_history_t *history)
+{
+    /* xml-output always shows the full history
+     * so we'll never have to show pending-actions
+     * separately
+     */
+    if (history && (history->state != st_failed) &&
+        (history->state != st_done)) {
+        stonith_history_t *hp;
+
+        /* Print section heading */
+        switch (output_format) {
+            case mon_output_plain:
+            case mon_output_console:
+                print_as("\nPending Fencing Actions:\n");
+                break;
+
+            case mon_output_html:
+            case mon_output_cgi:
+                fprintf(stream, " <hr />\n <h2>Pending Fencing Actions</h2>\n <ul>\n");
+                break;
+
+            default:
+                break;
+        }
+
+        for (hp = history; hp; hp = hp->next) {
+            if ((hp->state == st_failed) || (hp->state == st_done)) {
+                break;
+            }
+            print_stonith_action(stream, hp);
+        }
+
+        /* End section */
+        switch (output_format) {
+            case mon_output_html:
+            case mon_output_cgi:
+                fprintf(stream, " </ul>\n");
+                break;
+
+        default:
+            break;
+        }
+    }
+}
+
+/*!
+ * \internal
  * \brief Print a section for stonith-history
  *
  * \param[in] stream     File stream to display output to
@@ -3486,8 +3542,12 @@ print_status(pe_working_set_t * data_set,
     }
 
     /* Print stonith history */
-    if (fence_history && (show & mon_show_fence_history)) {
-        print_stonith_history(stdout, stonith_history);
+    if (fence_history) {
+        if (show & mon_show_fence_history) {
+            print_stonith_history(stdout, stonith_history);
+        } else {
+            print_stonith_pending(stdout, stonith_history);
+        }
     }
 
 #if CURSES_ENABLED
@@ -3725,8 +3785,12 @@ print_html_status(pe_working_set_t * data_set,
     }
 
     /* Print stonith history */
-    if (fence_history && (show & mon_show_fence_history)) {
-        print_stonith_history(stream, stonith_history);
+    if (fence_history) {
+        if (show & mon_show_fence_history) {
+            print_stonith_history(stream, stonith_history);
+        } else {
+            print_stonith_pending(stdout, stonith_history);
+        }
     }
 
     /* Print tickets if requested */

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -50,7 +50,7 @@ static struct crm_option long_options[] = {
         "\tCleanup wherever appropriate."
     },
     {   "broadcast", no_argument, NULL, 'b',
-        "\tBroadcast wherever appropriate."
+        "Broadcast wherever appropriate."
     },
     {   "-spacer-", no_argument, NULL, '-', "\nDevice definition commands:" },
 

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -605,6 +605,10 @@ main(int argc, char **argv)
         ++argerr;
     }
 
+    if (action == 0) {
+        ++argerr;
+    }
+
     if (argerr) {
         crm_help('?', CRM_EX_USAGE);
     }


### PR DESCRIPTION
Pending fence-actions as well as failed fence-actions should be empty on a healthy cluster
and especially pending fence-actions aren't prone to clutter the display as they disappear anyway.
so this - in case fence-history isn't shown - this adds an additional section for pending actions that pops up of there is anything pending (just as with failed actions).
in addition the - anyway to adapt - help now tries to clarify the unclear situation the the default with the '-m' option given but without value is different from the default if -m isn't given at all.
the distinction makes sense in a way that '-m' is also called --fence-history which would mean for my intuition that it should turn on the history-section when issued without additional value.
```
 -m, --fence-history[=value]	Show fence history
					0=off, 1=failures and pending (default without option),
					2=add successes (default without value for option),
					3=show full history without reduction to most recent of each flavor
```