### PR TITLE
Maint: cts: refrain from async (await) in Python code for being reserved

### DIFF
--- a/cts/remote.py
+++ b/cts/remote.py
@@ -140,7 +140,6 @@ class RemoteExec(object):
     '''
 
     def __init__(self, rsh, silent=False):
-        self.async = []
         self.rsh = rsh
         self.silent = silent
         self.logger = LogFactory()

--- a/cts/watcher.py
+++ b/cts/watcher.py
@@ -47,8 +47,8 @@ class SearchObj(object):
         self.logger.debug(message)
 
     def harvest(self, delegate=None):
-        async = self.harvest_async(delegate)
-        async.join()
+        async_task = self.harvest_async(delegate)
+        async_task.join()
 
     def harvest_async(self, delegate=None):
         self.log("Not implemented")


### PR DESCRIPTION
... as of Python 3.7:
https://docs.python.org/3/whatsnew/3.7.html#summary-release-highlights

One of the instance attributes turned out to be bogus.

Randomly spotted; unfortunately byte compilation when building package
for Fedora will not consider unability to pregenerate bytecode a fatal
problem.