### PR TITLE
Build: configure: fix overkill format specifier serving uint64_t check

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,48 +1,6 @@
 #!/bin/sh
-#
-#	License: GNU General Public License (GPL)
-#	Copyright 2001 horms <horms@vergenet.net>
-#		(heavily mangled by alanr)
-#
-#	bootstrap: set up the project and get it ready to make
-#
-#	Basically, we run autoconf, automake and libtool in the
-#	right way to get things set up for this environment.
-#
-#	We also look and see if those tools are installed, and
-#	tell you where to get them if they're not.
-#
-#	Our goal is to not require dragging along anything
-#	more than we need.  If this doesn't work on your system,
-#	(i.e., your /bin/sh is broken) send us a patch.
-#
-#	This code loosely based on the corresponding named script in
-#	enlightenment, and also on the sort-of-standard autoconf
-#	bootstrap script.
+# Part of pacemaker project
+# SPDX-License-Identifier: GPL-2.0-or-later
 
-# Run this to generate all the initial makefiles, etc.
-
-# Unset GREP_OPTIONS as any coloring can mess up the AC_CONFIG_AUX_DIR matching patterns
-GREP_OPTIONS= autoreconf -visf || exit $?
-
-if [ -f config.log ]; then
-    echo Now re-running ./configure with the previous arguments
-    last=`grep --color=never "$.*configure" config.log | tail -n 1 | sed s:.*configure:./configure: | sed s:--no-create::`
-    echo "  $last"
-    eval $last
-
-elif [ "x$1" = xinit -a -e "`which rpm 2>/dev/null`" ]; then
-    cmd="./__configure.rpm"
-    rpm --eval %{configure} | grep -v program-prefix | sed 's/\t/    /' > $cmd
-    sh $cmd
-    make
-
-else
-    echo "Now run configure with any arguments (eg. --prefix) specific to your system"
-    if [ -e "`which rpm 2>/dev/null`" ]; then
-	echo "Suggested invocation:"
-	rpm --eval %{configure} | grep -v program-prefix
-    fi
-fi
-
-trap '' 0
+autoreconf -fisv || exit $?
+echo 'Now run ./configure and make'

--- a/configure.ac
+++ b/configure.ac
@@ -903,16 +903,16 @@ if test X"$CURSESLIBS" != X"" && cc_supports_flag -Wcast-qual; then
                          ],
                          [printw((const char *)"Test");]
         )],
-        [ac_cv_compatible_printw=yes],
-        [ac_cv_compatible_printw=no]
+        [pcmk_cv_compatible_printw=yes],
+        [pcmk_cv_compatible_printw=no]
     )
 
     LIBS=$ac_save_LIBS
     cc_restore_flags
 
-    AC_MSG_RESULT([$ac_cv_compatible_printw])
+    AC_MSG_RESULT([$pcmk_cv_compatible_printw])
 
-    if test "$ac_cv_compatible_printw" = no; then
+    if test "$pcmk_cv_compatible_printw" = no; then
         AC_MSG_WARN([The printw() function of your ncurses or curses library is old, we will disable usage of the library. If you want to use this library anyway, please update to newer version of the library, ncurses 5.4 or later is recommended. You can get the library from http://www.gnu.org/software/ncurses/.])
         AC_MSG_NOTICE([Disabling curses])
         AC_DEFINE(HAVE_INCOMPATIBLE_PRINTW, 1, [Do we have incompatible printw() in curses library?])

--- a/configure.ac
+++ b/configure.ac
@@ -459,8 +459,9 @@ AC_CACHE_VAL(
     [pcmk_cv_decl_inttypes],
     [
         AC_CHECK_DECLS(
-            [PRIu64, PRIu32, PRIx32],
-            [pcmk_cv_decl_inttypes="PRIu64 PRIu32 PRIx32"],
+            [PRIu64, PRIu32, PRIx32,
+             SCNu64],
+            [pcmk_cv_decl_inttypes="PRIu64 PRIu32 PRIx32 SCNu64"],
             [
                 # test shall only react on "no" cached result & error out respectively
                 if test "x$ac_cv_have_decl_PRIu64" = xno; then
@@ -469,6 +470,8 @@ AC_CACHE_VAL(
                     AC_MSG_ERROR([lack of inttypes.h based specifier serving uint32_t (PRIu32)])
                 elif test "x$ac_cv_have_decl_PRIx32" = xno; then
                     AC_MSG_ERROR([lack of inttypes.h based hexa specifier serving uint32_t (PRIx32)])
+                elif test "x$ac_cv_have_decl_SCNu64" = xno; then
+                    AC_MSG_ERROR([lack of inttypes.h based specifier gathering uint64_t (SCNu64)])
                 fi
             ],
             [[#include <inttypes.h>]]
@@ -477,9 +480,10 @@ AC_CACHE_VAL(
 )
 (
     set $pcmk_cv_decl_inttypes
-    AC_DEFINE_UNQUOTED([U64T], [$1], [Correct format specifier for U64T])
-    AC_DEFINE_UNQUOTED([U32T], [$2], [Correct format specifier for U32T])
-    AC_DEFINE_UNQUOTED([X32T], [$3], [Correct format specifier for X32T])
+    AC_DEFINE_UNQUOTED([U64T],  [$1], [Correct format specifier for U64T])
+    AC_DEFINE_UNQUOTED([U32T],  [$2], [Correct format specifier for U32T])
+    AC_DEFINE_UNQUOTED([X32T],  [$3], [Correct format specifier for X32T])
+    AC_DEFINE_UNQUOTED([U64TS], [$4], [Correct format specifier for U64TS])
 )
 
 dnl ===============================================

--- a/configure.ac
+++ b/configure.ac
@@ -459,12 +459,16 @@ AC_CACHE_VAL(
     [pcmk_cv_decl_inttypes],
     [
         AC_CHECK_DECLS(
-            [PRIu64],
-            [pcmk_cv_decl_inttypes="PRIu64"],
+            [PRIu64, PRIu32, PRIx32],
+            [pcmk_cv_decl_inttypes="PRIu64 PRIu32 PRIx32"],
             [
                 # test shall only react on "no" cached result & error out respectively
                 if test "x$ac_cv_have_decl_PRIu64" = xno; then
                     AC_MSG_ERROR([lack of inttypes.h based specifier serving uint64_t (PRIu64)])
+                elif test "x$ac_cv_have_decl_PRIu32" = xno; then
+                    AC_MSG_ERROR([lack of inttypes.h based specifier serving uint32_t (PRIu32)])
+                elif test "x$ac_cv_have_decl_PRIx32" = xno; then
+                    AC_MSG_ERROR([lack of inttypes.h based hexa specifier serving uint32_t (PRIx32)])
                 fi
             ],
             [[#include <inttypes.h>]]
@@ -474,6 +478,8 @@ AC_CACHE_VAL(
 (
     set $pcmk_cv_decl_inttypes
     AC_DEFINE_UNQUOTED([U64T], [$1], [Correct format specifier for U64T])
+    AC_DEFINE_UNQUOTED([U32T], [$2], [Correct format specifier for U32T])
+    AC_DEFINE_UNQUOTED([X32T], [$3], [Correct format specifier for X32T])
 )
 
 dnl ===============================================

--- a/configure.ac
+++ b/configure.ac
@@ -450,33 +450,31 @@ case "$host_cpu" in
         ;;
 esac
 
-AC_MSG_CHECKING(which format is needed to print uint64_t)
-
-cc_temp_flags "-Wall $WERROR"
-
-AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM(
-        [
-#include <stdio.h>
-#include <stdint.h>
-#include <stdlib.h>
-        ],
-        [
-int max = 512;
-uint64_t bignum = 42;
-char *buffer = malloc(max);
-const char *random = "random";
-snprintf(buffer, max-1, "<quorum id=%lu quorate=%s/>", bignum, random);
-fprintf(stderr, "Result: %s\n", buffer);
-        ]
-    )],
-    [U64T="%lu"],
-    [U64T="%llu"]
+# C99 doesn't guarantee uint64_t type and related format specifiers, but
+# prerequisites, corosync + libqb, use that widely, so the target platforms
+# are already pre-constrained to those "64bit-clean" (doesn't imply native
+# bit width) and hence we deliberately refrain from artificial surrogates
+# (sans manipulation through cached values).
+AC_CACHE_VAL(
+    [pcmk_cv_decl_inttypes],
+    [
+        AC_CHECK_DECLS(
+            [PRIu64],
+            [pcmk_cv_decl_inttypes="PRIu64"],
+            [
+                # test shall only react on "no" cached result & error out respectively
+                if test "x$ac_cv_have_decl_PRIu64" = xno; then
+                    AC_MSG_ERROR([lack of inttypes.h based specifier serving uint64_t (PRIu64)])
+                fi
+            ],
+            [[#include <inttypes.h>]]
+        )
+    ]
 )
-cc_restore_flags
-
-AC_MSG_RESULT($U64T)
-AC_DEFINE_UNQUOTED(U64T, "$U64T", Correct printf format for logging uint64_t)
+(
+    set $pcmk_cv_decl_inttypes
+    AC_DEFINE_UNQUOTED([U64T], [$1], [Correct format specifier for U64T])
+)
 
 dnl ===============================================
 dnl Program Paths

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>  /* U64T ~ PRIu64 */
 
 #include <crm/crm.h>
 #include <crm/cib.h>
@@ -283,7 +284,7 @@ cib_digester_cb(gpointer data)
         free(ping_digest);
         ping_digest = NULL;
         ping_modified_since = FALSE;
-        snprintf(buffer, 32, U64T, ping_seq);
+        snprintf(buffer, 32, "%" U64T, ping_seq);
         crm_trace("Requesting peer digests (%s)", buffer);
 
         crm_xml_add(ping, F_TYPE, "cib");

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>  /* U32T ~ PRIu32, X32T ~ PRIx32 */
 
 #include <crm/crm.h>
 #include <crm/msg_xml.h>
@@ -123,7 +124,8 @@ st_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
     }
 
     crm_element_value_int(request, F_STONITH_CALLOPTS, &call_options);
-    crm_trace("Flags %u/%u for command %u from %s", flags, call_options, id, crm_client_name(c));
+    crm_trace("Flags %" X32T "/%u for command %" U32T " from %s",
+              flags, call_options, id, crm_client_name(c));
 
     if (is_set(call_options, st_opt_sync_call)) {
         CRM_ASSERT(flags & crm_ipc_client_response);

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -17,11 +17,14 @@
  */
 
 #include <crm_internal.h>
-#include <bzlib.h>
+
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <inttypes.h>  /* U64T ~ PRIu64 */
+
+#include <bzlib.h>
 
 #include <crm/common/ipc.h>
 #include <crm/cluster/internal.h>
@@ -184,16 +187,16 @@ pcmk_quorum_notification(quorum_handle_t handle,
 
     if (quorate != crm_have_quorum) {
         if (quorate) {
-            crm_notice("Quorum acquired " CRM_XS " membership=" U64T " members=%lu",
+            crm_notice("Quorum acquired " CRM_XS " membership=%" U64T " members=%lu",
                        ring_id, (long unsigned int)view_list_entries);
         } else {
-            crm_warn("Quorum lost " CRM_XS " membership=" U64T " members=%lu",
+            crm_warn("Quorum lost " CRM_XS " membership=%" U64T " members=%lu",
                      ring_id, (long unsigned int)view_list_entries);
         }
         crm_have_quorum = quorate;
 
     } else {
-        crm_info("Quorum %s " CRM_XS " membership=" U64T " members=%lu",
+        crm_info("Quorum %s " CRM_XS " membership=%" U64T " members=%lu",
                  (quorate? "retained" : "still lost"), ring_id,
                  (long unsigned int)view_list_entries);
     }

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -19,11 +19,11 @@
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
 #include <netdb.h>
-
 #include <stdlib.h>
 #include <errno.h>
-#include <glib.h>
+#include <inttypes.h>  /* X32T ~ PRIx32 */
 
+#include <glib.h>
 #include <bzlib.h>
 
 #include <crm/common/ipcs.h>
@@ -107,9 +107,8 @@ crm_remote_header(crm_remote_t * remote)
 
         CRM_LOG_ASSERT(endian == ENDIAN_LOCAL);
         if(endian != ENDIAN_LOCAL) {
-            /* XXX preprocessor conditionalizing based on, e.g., sizeof and/or
-                   inttypes.h/stdint.h to get character string literals fit */
-            crm_err("Invalid message detected, endian mismatch: %x is neither %x nor the swab'd %x",
+            crm_err("Invalid message detected, endian mismatch: %" X32T
+                    " is neither %" X32T " nor the swab'd %" X32T,
                     ENDIAN_LOCAL, header->endian, endian);
             return NULL;
         }

--- a/tools/notifyServicelogEvent.c
+++ b/tools/notifyServicelogEvent.c
@@ -18,6 +18,7 @@
 #include <syslog.h>
 #include <unistd.h>
 #include <config.h>
+#include <inttypes.h>  /* U64T ~ PRIu64 */
 
 #include <crm/common/xml.h>
 #include <crm/common/util.h>
@@ -117,7 +118,7 @@ main(int argc, char *argv[])
 
     openlog("notifyServicelogEvent", LOG_NDELAY, LOG_USER);
 
-    if (sscanf(argv[optind], U64T, &event_id) != 1) {
+    if (sscanf(argv[optind], "%" U64T, &event_id) != 1) {
         crm_err("Error: could not read event_id from args!");
 
         rc = 1;
@@ -149,7 +150,7 @@ main(int argc, char *argv[])
         const char *health_component = "#health-ipmi";
         const char *health_status = NULL;
 
-        crm_debug("Event id = " U64T ", Log timestamp = %s, Event timestamp = %s",
+        crm_debug("Event id = %" U64T ", Log timestamp = %s, Event timestamp = %s",
                   event_id, ctime(&(event->time_logged)), ctime(&(event->time_event)));
 
         status = event2status(event);

--- a/tools/notifyServicelogEvent.c
+++ b/tools/notifyServicelogEvent.c
@@ -18,7 +18,7 @@
 #include <syslog.h>
 #include <unistd.h>
 #include <config.h>
-#include <inttypes.h>  /* U64T ~ PRIu64 */
+#include <inttypes.h>  /* U64T ~ PRIu64, U64TS ~ SCNu64 */
 
 #include <crm/common/xml.h>
 #include <crm/common/util.h>
@@ -118,7 +118,7 @@ main(int argc, char *argv[])
 
     openlog("notifyServicelogEvent", LOG_NDELAY, LOG_USER);
 
-    if (sscanf(argv[optind], "%" U64T, &event_id) != 1) {
+    if (sscanf(argv[optind], "%" U64TS, &event_id) != 1) {
         crm_err("Error: could not read event_id from args!");
 
         rc = 1;


### PR DESCRIPTION
This was a chained mess:

* fixed-width integer types from <stdint.h> are usually accompanied with
  respective format specifiers in <inttypes.h>, which should have been
  a first line of the solution

* relying on the compiler erroring out on the incorrect format specifier
  in a compile test is broken (if nothing else, may fail like that for
  unrelated reasons, which also happened in the case referred below),
  especially since it's trivially solvable in a preprocessing test,
  which avoids inteferring with -D_FORTIFY_SOURCE vs. optimization
  switches -- even more so when they are split between CFLAGS and
  CPPFLAGS, see https://bugs.clusterlabs.org/show_bug.cgi?id=5274