### PR TITLE
Consolidate dummy fence agents

### DIFF
--- a/cts/CIB.py
+++ b/cts/CIB.py
@@ -264,7 +264,6 @@ class CIB12(ConfigBase):
 
                 # Create a Dummy agent that always passes for levels-and
                 if len(stt_nodes):
-                    self.CM.install_helper("fence_dummy", destdir="/usr/sbin", sourcedir=CTSvars.Fencing_home)
                     stt = Resource(self.Factory, "FencingPass", "fence_dummy", "stonith")
                     stt["pcmk_host_list"] = " ".join(stt_nodes)
                     # Wait this many seconds before doing anything, handy for letting disks get flushed too
@@ -274,7 +273,6 @@ class CIB12(ConfigBase):
 
                 # Create a Dummy agent that always fails for levels-or
                 if len(stf_nodes):
-                    self.CM.install_helper("fence_dummy", destdir="/usr/sbin", sourcedir=CTSvars.Fencing_home)
                     stf = Resource(self.Factory, "FencingFail", "fence_dummy", "stonith")
                     stf["pcmk_host_list"] = " ".join(stf_nodes)
                     # Wait this many seconds before doing anything, handy for letting disks get flushed too

--- a/cts/CTS.py.in
+++ b/cts/CTS.py.in
@@ -347,22 +347,6 @@ class ClusterManager(UserDict):
             count = count + 1
         return count
 
-    def install_helper(self, filename, destdir=None, nodes=None, sourcedir=None):
-        if sourcedir == None:
-            sourcedir = CTSvars.CTS_home
-        file_with_path = "%s/%s" % (sourcedir, filename)
-        if not nodes:
-            nodes = self.Env["nodes"]
-
-        if not destdir:
-            destdir = CTSvars.CTS_home
-
-        self.debug("Installing %s to %s on %s" % (filename, destdir, repr(self.Env["nodes"])))
-        for node in nodes:
-            self.rsh(node, "mkdir -p %s" % destdir)
-            self.rsh.cp(file_with_path, "root@%s:%s/%s" % (node, destdir, filename))
-        return file_with_path
-
     def install_support(self, command="install"):
         for node in self.Env["nodes"]:
             self.rsh(node, CTSvars.CRM_DAEMON_DIR + "/cts-support " + command)

--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -506,21 +506,6 @@ class Tests(object):
             os.system("dd if=/dev/urandom of=/etc/pacemaker/authkey bs=4096 count=1")
             self.installed_files.append("/etc/pacemaker/authkey")
 
-        dummy_fence_sleep_agent = ("""#!@PYTHON@
-import sys
-import time
-def main():
-    for line in sys.stdin:
-        if line.count("monitor") > 0:
-            time.sleep(30000)
-            sys.exit(0)
-    sys.exit(1)
-if __name__ == "__main__":
-    main()
-""")
-
-        write_file(SBIN_DIR + "/fence_dummy_sleep", dummy_fence_sleep_agent, executable=True);
-
         # If we're in build directory, install agents if not already installed
         if os.path.exists("%s/cts/cts-exec.in" % BUILD_DIR):
 
@@ -541,8 +526,6 @@ if __name__ == "__main__":
 
     def cleanup_test_environment(self):
         """ Clean up the host after executing desired tests """
-
-        os.system("rm -f " + SBIN_DIR + "/fence_dummy_sleep")
 
         for installed_file in self.installed_files:
             print("Removing %s ..." % (installed_file))
@@ -682,10 +665,12 @@ if __name__ == "__main__":
 
         ### stonith start timeout test  ###
         test = self.new_test("stonith_start_timeout", "Force start timeout to occur, verify start failure.")
-        test.add_cmd("-c register_rsc -r \"test_rsc\" -C \"stonith\" -P \"pacemaker\" -T \"fence_dummy_sleep\" "
-                     + self.action_timeout +
-                     "-l \"NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete\" ")
-        test.add_cmd("-c exec -r \"test_rsc\" -a \"start\" -t 1000 -w") # -t must be less than self.action_timeout
+        test.add_cmd('-c register_rsc -r test_rsc ' +
+                     '-C stonith -P pacemaker -T fence_dummy ' +
+                     self.action_timeout +
+                     '-l "NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete"')
+        test.add_cmd('-c exec -r test_rsc -a start -k monitor_delay -v 30 ' +
+                     '-t 1000 -w') # -t must be less than self.action_timeout
         test.add_cmd('-l "NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:unknown error op_status:Timed Out" '
                      + self.action_timeout)
         test.add_cmd("-c exec -r test_rsc -a stop " + self.action_timeout +

--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -472,7 +472,8 @@ class Tests(object):
             "lsb_cancel_line"   : '-c cancel -r lsb_test_rsc -a status -i 2s ' + self.action_timeout,
             "lsb_cancel_event"  : "-l \"NEW_EVENT event_type:exec_complete rsc_id:lsb_test_rsc action:status rc:ok op_status:Cancelled\" ",
 
-            "stonith_reg_line"      : "-c register_rsc -r stonith_test_rsc "+self.action_timeout+" -C stonith -P pacemaker -T fence_dummy_monitor",
+            "stonith_reg_line"      : "-c register_rsc -r stonith_test_rsc " + self.action_timeout +
+				      " -C stonith -P pacemaker -T fence_dummy",
             "stonith_reg_event"     : "-l \"NEW_EVENT event_type:register rsc_id:stonith_test_rsc action:none rc:ok op_status:complete\" ",
             "stonith_unreg_line"    : "-c unregister_rsc -r \"stonith_test_rsc\" "+self.action_timeout,
             "stonith_unreg_event"   : "-l \"NEW_EVENT event_type:unregister rsc_id:stonith_test_rsc action:none rc:ok op_status:complete\"",
@@ -517,41 +518,8 @@ def main():
 if __name__ == "__main__":
     main()
 """)
-        dummy_fence_agent = ("""#!/bin/sh
-while read line; do
-    case ${line} in
-    *monitor*) exit 0;;
-    *metadata*)
-        echo '<resource-agent name="fence_dummy_monitor" shortdesc="Dummy Fence agent for testing">'
-        echo '  <longdesc>dummy description.</longdesc>'
-        echo '  <vendor-url>http://www.example.com</vendor-url>'
-        echo '  <parameters>'
-        echo '    <parameter name="action" unique="0" required="1">'
-        echo '      <getopt mixed="-o, --action=[action]"/>'
-        echo '      <content type="string" default="reboot"/>'
-        echo '      <shortdesc lang="en">Fencing Action</shortdesc>'
-        echo '    </parameter>'
-        echo '    <parameter name="port" unique="0" required="0">'
-        echo '      <getopt mixed="-n, --plug=[id]"/>'
-        echo '      <content type="string"/>'
-        echo '      <shortdesc lang="en">Physical plug number or name of virtual machine</shortdesc>'
-        echo '    </parameter>'
-        echo '  </parameters>'
-        echo '  <actions>'
-        echo '    <action name="on"/>'
-        echo '    <action name="off"/>'
-        echo '    <action name="monitor"/>'
-        echo '    <action name="metadata"/>'
-        echo '  </actions>'
-        echo '</resource-agent>'
-        exit 0;;
-    esac
-    exit 1
-done
-""")
 
         write_file(SBIN_DIR + "/fence_dummy_sleep", dummy_fence_sleep_agent, executable=True);
-        write_file(SBIN_DIR + "/fence_dummy_monitor", dummy_fence_agent, executable=True);
 
         # If we're in build directory, install agents if not already installed
         if os.path.exists("%s/cts/cts-exec.in" % BUILD_DIR):
@@ -574,7 +542,6 @@ done
     def cleanup_test_environment(self):
         """ Clean up the host after executing desired tests """
 
-        os.system("rm -f " + SBIN_DIR + "/fence_dummy_monitor")
         os.system("rm -f " + SBIN_DIR + "/fence_dummy_sleep")
 
         for installed_file in self.installed_files:
@@ -1057,8 +1024,8 @@ done
 
         ### get stonith metadata ###
         test = self.new_test("get_stonith_metadata", "Retrieve stonith metadata for a resource")
-        test.add_cmd_check_stdout("-c metadata -C \"stonith\" -P \"pacemaker\" -T \"fence_dummy_monitor\"",
-                                  "resource-agent name=\"fence_dummy_monitor\"")
+        test.add_cmd_check_stdout("-c metadata -C \"stonith\" -P \"pacemaker\" -T \"fence_dummy\"",
+                                  "resource-agent name=\"fence_dummy\"")
 
         ### get metadata ###
         if "systemd" in self.rsc_classes:
@@ -1090,29 +1057,29 @@ done
         test.add_cmd_check_stdout("-c list_agents -C ocf", "", "pacemaker-cts-dummyd@")           ### should not exist
 
         test.add_cmd_check_stdout("-c list_agents -C ocf", "", "pacemaker-cts-dummyd@")           ### should not exist
-        test.add_cmd_check_stdout("-c list_agents -C lsb", "", "fence_dummy_monitor")             ### should not exist
-        test.add_cmd_check_stdout("-c list_agents -C service", "", "fence_dummy_monitor")         ### should not exist
-        test.add_cmd_check_stdout("-c list_agents -C ocf", "", "fence_dummy_monitor")             ### should not exist
+        test.add_cmd_check_stdout("-c list_agents -C lsb", "", "fence_dummy")                     ### should not exist
+        test.add_cmd_check_stdout("-c list_agents -C service", "", "fence_dummy")                 ### should not exist
+        test.add_cmd_check_stdout("-c list_agents -C ocf", "", "fence_dummy")                     ### should not exist
 
         if "systemd" in self.rsc_classes:
             test.add_cmd_check_stdout("-c list_agents ", "pacemaker-cts-dummyd@")             ### systemd ###
             test.add_cmd_check_stdout("-c list_agents -C service", "LSBDummy")
             test.add_cmd_check_stdout("-c list_agents -C systemd", "", "Stateful")            ### should not exist
             test.add_cmd_check_stdout("-c list_agents -C systemd", "pacemaker-cts-dummyd@")
-            test.add_cmd_check_stdout("-c list_agents -C systemd", "", "fence_dummy_monitor") ### should not exist
+            test.add_cmd_check_stdout("-c list_agents -C systemd", "", "fence_dummy")         ### should not exist
 
         if "upstart" in self.rsc_classes:
             test.add_cmd_check_stdout("-c list_agents ", "pacemaker-cts-dummyd")              ### upstart ###
             test.add_cmd_check_stdout("-c list_agents -C service", "LSBDummy")
             test.add_cmd_check_stdout("-c list_agents -C upstart", "", "Stateful")            ### should not exist
             test.add_cmd_check_stdout("-c list_agents -C upstart", "pacemaker-cts-dummyd")
-            test.add_cmd_check_stdout("-c list_agents -C upstart", "", "fence_dummy_monitor") ### should not exist
+            test.add_cmd_check_stdout("-c list_agents -C upstart", "", "fence_dummy")         ### should not exist
 
         if "stonith" in self.rsc_classes:
-            test.add_cmd_check_stdout("-c list_agents -C stonith", "fence_dummy_monitor")     ### stonith ###
+            test.add_cmd_check_stdout("-c list_agents -C stonith", "fence_dummy")             ### stonith ###
             test.add_cmd_check_stdout("-c list_agents -C stonith", "", "pacemaker-cts-dummyd@") ### should not exist
             test.add_cmd_check_stdout("-c list_agents -C stonith", "", "Stateful")            ### should not exist
-            test.add_cmd_check_stdout("-c list_agents ", "fence_dummy_monitor")
+            test.add_cmd_check_stdout("-c list_agents ", "fence_dummy")
 
     def print_list(self):
         """ List all registered tests """

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -1309,7 +1309,7 @@ logging {
             killall("corosync")
             self.start_corosync()
 
-        os.system("cp %s @sbindir@/fence_dummy" % FENCE_DUMMY)
+        subprocess.call(["cts-support", "install"])
 
         # modifies dummy agent to do require unfencing
         os.system("sed 's/on_target=/automatic=/g' %s > @sbindir@/fence_dummy_auto_unfence" % FENCE_DUMMY)
@@ -1335,7 +1335,7 @@ logging {
         if self.autogen_corosync_cfg:
             os.system("rm -f /etc/corosync/corosync.conf")
 
-        os.system("rm -f @sbindir@/fence_dummy")
+        subprocess.call(["cts-support", "uninstall"])
         os.system("rm -f @sbindir@/fence_dummy_auto_unfence")
         os.system("rm -f @sbindir@/fence_dummy_no_reboot")
 

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -15,7 +15,12 @@ import subprocess
 import shlex
 import time
 
-FENCE_DUMMY = "@datadir@/@PACKAGE@/tests/cts/fence_dummy"
+# Where to find test binaries
+# Prefer the source tree if available
+BUILD_DIR = "@abs_top_builddir@"
+TEST_DIR = sys.path[0]
+
+FENCE_DUMMY = ""
 
 # These values must be kept in sync with include/crm/crm.h
 class CrmExit:
@@ -55,6 +60,30 @@ class CrmExit:
     OLD                  = 110
     TIMEOUT              = 124
     MAX                  = 255
+
+
+def update_path():
+    """ Set the PATH environment variable appropriately for the tests """
+
+    global FENCE_DUMMY
+
+    new_path = os.environ['PATH']
+    if os.path.exists("%s/cts-fencing.in" % TEST_DIR):
+        print("Running tests from the source tree: %s (%s)" % (BUILD_DIR, TEST_DIR))
+        # For pacemaker-fenced and cts-fence-helper
+        new_path = "%s/daemons/fenced:%s" % (BUILD_DIR, new_path)
+        new_path = "%s/tools:%s" % (BUILD_DIR, new_path) # For stonith_admin
+        new_path = "%s/cts:%s" % (BUILD_DIR, new_path)   # For cts-support
+        FENCE_DUMMY = "%s/cts/fence_dummy" % (BUILD_DIR)
+
+    else:
+        print("Running tests from the install tree: @CRM_DAEMON_DIR@ (not %s)" % TEST_DIR)
+        # For pacemaker-fenced, cts-fence-helper, and cts-support
+        new_path = "@CRM_DAEMON_DIR@:%s" % (new_path)
+        FENCE_DUMMY = "@datadir@/@PACKAGE@/tests/cts/fence_dummy"
+
+    print('Using PATH="{}"'.format(new_path))
+    os.environ['PATH'] = new_path
 
 
 def pipe_output(pipes, stdout=True, stderr=False):
@@ -193,7 +222,7 @@ class Test(object):
         if os.path.exists("/tmp/stonith-regression.log"):
             os.remove('/tmp/stonith-regression.log')
 
-        cmd = "@CRM_DAEMON_DIR@/pacemaker-fenced %s -l /tmp/stonith-regression.log" % self.stonith_options
+        cmd = "pacemaker-fenced %s -l /tmp/stonith-regression.log" % self.stonith_options
         self.stonith_process = subprocess.Popen(shlex.split(cmd))
 
         time.sleep(1)
@@ -497,10 +526,10 @@ class Tests(object):
             verbose_arg = "-V"
 
         test = self.new_test("standalone_low_level_api_test", "Sanity test client api in standalone mode.")
-        test.add_cmd("@CRM_DAEMON_DIR@/cts-fence-helper", "-t %s" % (verbose_arg))
+        test.add_cmd("cts-fence-helper", "-t %s" % (verbose_arg))
 
         test = self.new_test("cpg_low_level_api_test", "Sanity test client api using mainloop and cpg.", 1)
-        test.add_cmd("@CRM_DAEMON_DIR@/cts-fence-helper", "-m %s" % (verbose_arg))
+        test.add_cmd("cts-fence-helper", "-m %s" % (verbose_arg))
 
     def build_custom_timeout_tests(self):
         """ Register tests to verify custom timeout usage """
@@ -1372,6 +1401,8 @@ class TestOptions(object):
 
 def main(argv):
     """ Run fencing regression tests as specified by arguments """
+
+    update_path()
 
     opts = TestOptions()
     opts.build_options(argv)

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -20,8 +20,6 @@ import time
 BUILD_DIR = "@abs_top_builddir@"
 TEST_DIR = sys.path[0]
 
-FENCE_DUMMY = ""
-
 # These values must be kept in sync with include/crm/crm.h
 class CrmExit:
     OK                   =   0
@@ -65,8 +63,6 @@ class CrmExit:
 def update_path():
     """ Set the PATH environment variable appropriately for the tests """
 
-    global FENCE_DUMMY
-
     new_path = os.environ['PATH']
     if os.path.exists("%s/cts-fencing.in" % TEST_DIR):
         print("Running tests from the source tree: %s (%s)" % (BUILD_DIR, TEST_DIR))
@@ -74,13 +70,11 @@ def update_path():
         new_path = "%s/daemons/fenced:%s" % (BUILD_DIR, new_path)
         new_path = "%s/tools:%s" % (BUILD_DIR, new_path) # For stonith_admin
         new_path = "%s/cts:%s" % (BUILD_DIR, new_path)   # For cts-support
-        FENCE_DUMMY = "%s/cts/fence_dummy" % (BUILD_DIR)
 
     else:
         print("Running tests from the install tree: @CRM_DAEMON_DIR@ (not %s)" % TEST_DIR)
         # For pacemaker-fenced, cts-fence-helper, and cts-support
         new_path = "@CRM_DAEMON_DIR@:%s" % (new_path)
-        FENCE_DUMMY = "@datadir@/@PACKAGE@/tests/cts/fence_dummy"
 
     print('Using PATH="{}"'.format(new_path))
     os.environ['PATH'] = new_path
@@ -1311,14 +1305,6 @@ logging {
 
         subprocess.call(["cts-support", "install"])
 
-        # modifies dummy agent to do require unfencing
-        os.system("sed 's/on_target=/automatic=/g' %s > @sbindir@/fence_dummy_auto_unfence" % FENCE_DUMMY)
-        os.system("chmod 711 @sbindir@/fence_dummy_auto_unfence")
-
-        # modifies dummy agent to not advertise reboot
-        os.system("sed 's/^.*<action.*name.*reboot.*>.*//g' %s > @sbindir@/fence_dummy_no_reboot" % FENCE_DUMMY)
-        os.system("chmod 711 @sbindir@/fence_dummy_no_reboot")
-
     def cleanup_environment(self, use_corosync):
         """ Clean up the host after executing desired tests """
 
@@ -1336,8 +1322,6 @@ logging {
             os.system("rm -f /etc/corosync/corosync.conf")
 
         subprocess.call(["cts-support", "uninstall"])
-        os.system("rm -f @sbindir@/fence_dummy_auto_unfence")
-        os.system("rm -f @sbindir@/fence_dummy_no_reboot")
 
 class TestOptions(object):
     """ Option handler """

--- a/cts/cts-support.in
+++ b/cts/cts-support.in
@@ -23,6 +23,7 @@ CRM_EX_USAGE=64
 UNIT_DIR="@systemdunitdir@"
 LIBEXEC_DIR="@libexecdir@/pacemaker"
 INIT_DIR="@INITDIR@"
+SBIN_DIR="@sbindir@"
 DATA_DIR="@datadir@/pacemaker/tests/cts"
 UPSTART_DIR="/etc/init"
 
@@ -31,6 +32,7 @@ DUMMY_DAEMON_UNIT="pacemaker-cts-dummyd@.service"
 
 LSB_DUMMY="LSBDummy"
 UPSTART_DUMMY="pacemaker-cts-dummyd.conf"
+FENCE_DUMMY="fence_dummy"
 
 # If the install directory doesn't exist, assume we're in a build directory.
 if [ ! -d "$DATA_DIR" ]; then
@@ -69,6 +71,7 @@ support_uninstall() {
     for FILE in \
         "$LIBEXEC_DIR/$DUMMY_DAEMON" \
         "$UPSTART_DIR/$UPSTART_DUMMY" \
+        "$SBIN_DIR/$FENCE_DUMMY" \
         "$INIT_DIR/$LSB_DUMMY"
     do
         if [ -e "$FILE" ]; then
@@ -93,6 +96,10 @@ support_install() {
         install -m 0644 "$DUMMY_DAEMON_UNIT" "$UNIT_DIR" || return $CRM_EX_ERROR
         systemctl daemon-reload # Ignore failure
     fi
+
+    echo "Installing $FENCE_DUMMY to $SBIN_DIR ..."
+    mkdir -p "$SBIN_DIR"
+    install -m 0755 "$FENCE_DUMMY" "$SBIN_DIR" || return $CRM_EX_ERROR
 
     echo "Installing $LSB_DUMMY to $INIT_DIR ..."
     mkdir -p "$INIT_DIR"

--- a/cts/cts-support.in
+++ b/cts/cts-support.in
@@ -33,6 +33,7 @@ DUMMY_DAEMON_UNIT="pacemaker-cts-dummyd@.service"
 LSB_DUMMY="LSBDummy"
 UPSTART_DUMMY="pacemaker-cts-dummyd.conf"
 FENCE_DUMMY="fence_dummy"
+FENCE_DUMMY_ALIASES="fence_dummy_auto_unfence fence_dummy_no_reboot"
 
 # If the install directory doesn't exist, assume we're in a build directory.
 if [ ! -d "$DATA_DIR" ]; then
@@ -79,6 +80,13 @@ support_uninstall() {
             rm -f "$FILE"
         fi
     done
+    for ALIAS in $FENCE_DUMMY_ALIASES; do \
+        FILE="$SBIN_DIR/$ALIAS" 
+        if [ -L "$FILE" ] || [ -e "$FILE" ]; then
+            echo "Removing $FILE ..."
+            rm -f "$FILE"
+        fi
+    done
 
     return $CRM_EX_OK
 }
@@ -100,6 +108,10 @@ support_install() {
     echo "Installing $FENCE_DUMMY to $SBIN_DIR ..."
     mkdir -p "$SBIN_DIR"
     install -m 0755 "$FENCE_DUMMY" "$SBIN_DIR" || return $CRM_EX_ERROR
+    for alias in $FENCE_DUMMY_ALIASES; do \
+        echo "Installing $alias to $SBIN_DIR ..."
+        ln -s "$FENCE_DUMMY" "$SBIN_DIR/$alias" || return $CRM_EX_ERROR
+    done
 
     echo "Installing $LSB_DUMMY to $INIT_DIR ..."
     mkdir -p "$INIT_DIR"

--- a/cts/fence_dummy.in
+++ b/cts/fence_dummy.in
@@ -17,13 +17,13 @@ import random
 import atexit
 import getopt
 
-AGENT_VERSION = "4.0.0"
+AGENT_VERSION = "4.0.1"
 OCF_VERSION = "1.0"
 SHORT_DESC = "Dummy fence agent"
 LONG_DESC = """fence_dummy is a fake fencing agent which reports success
 based on its mode (pass|fail|random) without doing anything."""
 
-# Short options used: ifhmnoqsvBDHMRUV
+# Short options used: difhmnoqsvBDHMRUV
 ALL_OPT = {
     "quiet"   : {
         "getopt" : "q",
@@ -117,6 +117,15 @@ ALL_OPT = {
         "help" : "-f, --delay [seconds]          Wait X seconds before fencing is started",
         "required" : "0",
         "shortdesc" : "Wait X seconds before fencing is started",
+        "default" : "0",
+        "order" : 3
+        },
+    "monitor_delay" : {
+        "getopt" : "d:",
+        "longopt" : "monitor_delay",
+        "help" : "-d, --monitor_delay [seconds]  Wait X seconds before monitor completes",
+        "required" : "0",
+        "shortdesc" : "Wait X seconds before monitor completes",
         "default" : "0",
         "order" : 3
         },
@@ -437,6 +446,8 @@ def main():
         action = "action"
 
     if action == "monitor":
+        if "-d" in options:
+            time.sleep(int(options["-d"]))
         exitcode = success_mode(options, "-m", "pass")
 
     elif action == "list":

--- a/cts/fence_dummy.in
+++ b/cts/fence_dummy.in
@@ -163,6 +163,8 @@ ALL_OPT = {
         }
 }
 
+auto_unfence = False
+no_reboot = False
 
 def agent():
     """ Return name this file was run as. """
@@ -222,13 +224,14 @@ def metadata(avail_opt, options):
 
     print("""<?xml version="1.0" ?>
 <resource-agent name="%s" shortdesc="%s" version="%s">
-<version>%s</version>
-<longdesc>%s</longdesc>
-<parameters>""" % (agent(), SHORT_DESC, AGENT_VERSION, OCF_VERSION, LONG_DESC))
+  <version>%s</version>
+  <longdesc>%s</longdesc>
+  <parameters>""" % (agent(), SHORT_DESC, AGENT_VERSION, OCF_VERSION, LONG_DESC))
 
     for option, dummy in sorted_options(avail_opt):
         if "shortdesc" in ALL_OPT[option]:
-            print("\t<parameter name=\"" + option + "\" unique=\"0\" required=\"" + ALL_OPT[option]["required"] + "\">")
+            print('    <parameter name="' + option + '" unique="0" ' +
+                  'required="' + ALL_OPT[option]["required"] + '">')
 
             default = ""
             default_name_arg = "-" + ALL_OPT[option]["getopt"][:-1]
@@ -253,27 +256,31 @@ def metadata(avail_opt, options):
             if None != res:
                 mixed = res.group(1)
             mixed = mixed.replace("<", "&lt;").replace(">", "&gt;")
-            print("\t\t<getopt mixed=\"" + mixed + "\" />")
+            print('      <getopt mixed="' + mixed + '" />')
 
             if ALL_OPT[option]["getopt"].count(":") > 0:
-                print("\t\t<content type=\"string\" "+default+" />")
+                print('      <content type="string" ' + default + ' />')
             else:
-                print("\t\t<content type=\"boolean\" "+default+" />")
+                print('      <content type="boolean" ' + default + ' />')
 
-            print("\t\t<shortdesc lang=\"en\">" + ALL_OPT[option]["shortdesc"] + "</shortdesc>")
-            print("\t</parameter>")
+            print('      <shortdesc lang="en">' + ALL_OPT[option]["shortdesc"] + '</shortdesc>')
+            print('    </parameter>')
 
-    print("""</parameters>
-<actions>
-\t<action name="on" on_target="1" />
-\t<action name="off" />
-\t<action name="reboot" />
-\t<action name="status" />
-\t<action name="monitor" />
-\t<action name="metadata" />
-\t<action name="list" />
-</actions>
-</resource-agent>""")
+    print('  </parameters>\n  <actions>')
+    if auto_unfence:
+        attr_name = 'automatic'
+    else:
+        attr_name = 'on_target'
+    print('    <action name="on" ' + attr_name + '="1" />')
+    print('    <action name="off" />')
+    if not no_reboot:
+        print('    <action name="reboot" />')
+    print('    <action name="status" />')
+    print('    <action name="monitor" />')
+    print('    <action name="metadata" />')
+    print('    <action name="list" />')
+    print('  </actions>')
+    print('</resource-agent>')
 
 
 def option_longopt(option):
@@ -415,6 +422,16 @@ def write_options(options):
 
 def main():
     """ Make it so! """
+
+    global auto_unfence
+    global no_reboot
+
+    # Meta-data can't take parameters, so we simulate different meta-data
+    # behavior based on the executable name (which can be a symbolic link).
+    if (sys.argv[0].endswith("_auto_unfence")):
+        auto_unfence = True
+    elif (sys.argv[0].endswith("_no_reboot")):
+        no_reboot = True
 
     device_opt = ALL_OPT.keys()
 

--- a/daemons/fenced/cts-fence-helper.c
+++ b/daemons/fenced/cts-fence-helper.c
@@ -1,19 +1,8 @@
-/* 
- * Copyright (C) 2009 Andrew Beekhof <andrew@beekhof.net>
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
- * 
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+/*
+ * Copyright 2009-2018 Andrew Beekhof <andrew@beekhof.net>
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
  */
 
 #include <crm_internal.h>
@@ -601,6 +590,7 @@ main(int argc, char **argv)
 
     enum test_modes mode = test_standard;
 
+    crm_log_cli_init("cts-fence-helper");
     crm_set_options(NULL, "mode [options]", long_options,
                     "Provides a summary of cluster's current state."
                     "\n\nOutputs varying levels of detail in a number of different formats.\n");


### PR DESCRIPTION
Previously, CTS and cts-fencing individually copied fence_dummy to /usr/sbin (cts-fencing removed it after completing, CTS did not); cts-fencing also used sed on fence_dummy to create two variants; and cts-exec used its own internally defined versions of two dummy fence agents.

Now, fence_dummy can handle all of the desired variations, and cts-support handles installing and uninstalling it for all tests.

Besides making things more consistent, this will help CI run more regression tests.