### PR TITLE
Test: travis: refrain from relying on (and bothering) relaxng.org host

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ env:
 
     # -- END Coverity Scan ENV
 
+cache:
+  directories:
+  - xml/.relaxng.org
+
 # sudo add-apt-repository ppa:hotot-team
 before_install:
  - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty main"
@@ -99,7 +103,10 @@ script:
         schemas=; for schema in *.rng; do
           case ${schema} in *cibtr*);; *)schemas="${schemas} ${schema}";; esac;
         done;
-        xmllint --noout --relaxng 'http://relaxng.org/relaxng.rng' ${schemas};
+        test -s .relaxng.org/relaxng.rng 2>/dev/null
+          || curl --create-dirs -Lo .relaxng.org/relaxng.rng
+             'http://relaxng.org/relaxng.rng';
+        xmllint --noout --relaxng .relaxng.org/relaxng.rng ${schemas};
       }
     );
   }


### PR DESCRIPTION
We will cache relaxng.rng file using the respective Travis CI facility.
Note that we really don't need to ship that file with pacemaker itself,
plus it would be one more license to care about if we borrowed that
file from BSD-covered jing-trang project:
https://github.com/relaxng/jing-trang/blob/master/eg/relaxng.rng
So we rather stay sole user of that file than redistributor...