### PR TITLE
Fix: tools: Make crm_report correctly find the system log

### DIFF
--- a/tools/report.collector.in
+++ b/tools/report.collector.in
@@ -588,7 +588,7 @@ get_logfiles() {
     pattern="Starting Pacemaker"
 
     # - make sure we get something from the scheduler
-    pattern="$pattern\\|Calculated Transition"
+    pattern="$pattern\\|Calculated transition"
 
     # - cib and pacemaker-execd updates
     # (helpful on non-DC nodes and when cluster has been up for a long time)

--- a/tools/report.collector.in
+++ b/tools/report.collector.in
@@ -540,47 +540,79 @@ iscfvarset() {
 }
 
 iscfvartrue() {
-    getcfvar $1 $2 $3 | egrep -qsi "^(true|y|yes|on|1)"
+    getcfvar $1 $2 $3 | grep -E -qsi "^(true|y|yes|on|1)"
+}
+
+iscfvarfalse() {
+    getcfvar $1 $2 $3 | grep -E -qsi "^(false|n|no|off|0)"
+}
+
+find_syslog() {
+    priority="$1"
+
+    # Always include system logs (if we can find them)
+    msg="Mark:pcmk:`perl -e 'print time()'`"
+    logger -p "$priority" "$msg" >/dev/null 2>&1
+    sleep 2 # Give syslog time to catch up in case it's busy
+    findmsg 1 "$msg"
 }
 
 get_logfiles() {
     cf_type=$1
     cf_file="$2"
-    facility_var="logfacility"
 
     case $cf_type in
-	corosync)
+        corosync)
             if [ -f "$cf_file" ]; then
                 debug "Reading $cf_type log settings from $cf_file"
-                if iscfvartrue $cf_type to_syslog "$cf_file"; then
-                    facility_var=syslog_facility
+
+                # The default value of to_syslog is yes.
+                if ! iscfvarfalse $cf_type to_syslog "$cf_file"; then
+                    facility_cs=$(getcfvar $cf_type syslog_facility "$cf_file")
+                    if [ -z "$facility_cs" ]; then
+                        facility_cs="daemon"
+                    fi
+
+                    find_syslog "$facility_cs.info"
                 fi
+
                 if iscfvartrue $cf_type to_logfile "$cf_file"; then
                     logfile=$(getcfvar $cf_type logfile "$cf_file")
+                    if [ -f "$logfile" ]; then
+                        debug "Log settings found for cluster type $cf_type: $logfile"
+                        echo "$logfile"
+                    fi
                 fi
             fi
-	    ;;
+            ;;
     esac
 
-    if [ -z "$logfile" ]; then
-        # @TODO Use PCMK_logfile if set
-        logfile="@CRM_LOG_DIR@/pacemaker.log"
-        debug "Log settings not found for cluster type $cf_type, assuming $logfile"
+    . @CONFIGDIR@/pacemaker
+
+    facility="$PCMK_logfacility"
+    if [ -z "$facility" ]; then
+        facility="daemon"
     fi
-    if [ -f "$logfile" ]; then
-	echo $logfile
+    if [ "$facility" != "$facility_cs" ]&&[ "$facility" != none ]; then
+        find_syslog "$facility.notice"
     fi
 
-    if [ "x$facility" = x ]; then
-	facility=`getcfvar $cf_type $facility_var $cf_file`
-	[ "" = "$facility" ] && facility="daemon"
-    fi
+    logfile="$PCMK_logfile"
+    if [ "$logfile" != none ]; then
+        if [ -z "$logfile" ]; then
+            for logfile in "@CRM_LOG_DIR@/pacemaker.log" "/var/log/pacemaker.log"; do
+                if [ -f "$logfile" ]; then
+                    debug "Log settings not found for Pacemaker, assuming $logfile"
+                    echo "$logfile"
+                    break
+                fi
+            done
 
-    # Always include system logs (if we can find them)
-    msg="Mark:pcmk:`perl -e 'print time()'`"
-    logger -p $facility.info $msg >/dev/null 2>&1
-    sleep 2 # Give syslog time to catch up in case it's busy
-    findmsg 1 "$msg"
+        elif [ -f "$logfile" ]; then
+            debug "Log settings found for Pacemaker: $logfile"
+            echo "$logfile"
+        fi
+    fi
 
     # Look for detail logs:
 

--- a/tools/report.collector.in
+++ b/tools/report.collector.in
@@ -553,6 +553,10 @@ find_syslog() {
     # Always include system logs (if we can find them)
     msg="Mark:pcmk:`perl -e 'print time()'`"
     logger -p "$priority" "$msg" >/dev/null 2>&1
+
+    # Force buffer flush
+    killall -HUP rsyslogd >/dev/null 2>&1
+
     sleep 2 # Give syslog time to catch up in case it's busy
     findmsg 1 "$msg"
 }

--- a/tools/report.common.in
+++ b/tools/report.common.in
@@ -451,16 +451,17 @@ $f"
             # If we have enough hits, print them and return.
             found=$(($found+1))
             if [ $found -ge $max ]; then
-                debug "Pattern \'$pattern\' found in: [ $logfiles ]"
-                IFS=$SAVE_IFS
-                echo "$logfiles"
-                return
+                break
             fi
         fi
     done 2>/dev/null
     IFS=$SAVE_IFS
-
-    debug "Pattern \'$pattern\' not found in any system logs"
+    if [ -z "$logfiles" ]; then
+        debug "Pattern \'$pattern\' not found in any system logs"
+    else
+        debug "Pattern \'$pattern\' found in: [ $logfiles ]"
+        echo "$logfiles"
+    fi
 }
 
 node_events() {


### PR DESCRIPTION
This request has two commits.
1. https://github.com/inouekazu/pacemaker/commit/f4c4568b007387788b4a750842c2019787954371
   ```
   +    pattern="$pattern\\|Calculated transition"
   ```
   It corresponds to [66364b5](https://github.com/ClusterLabs/pacemaker/commit/66364b5caa2db55d0dd437e6e1ce8237e2cb86aa#diff-9eabe1ed584de205bd89ecbf6c5ac527).

   ---
   ```
        pattern="$pattern\\|cib_perform_op\\|process_lrm_event"
   +    pattern="$pattern\\|Diff: +++ \\|Result of .* for .* on"
   ```
   The messages logged via syslog does not contain a function name, so I added a <pattern> that is output within that function.
   ```
   # egrep "cib_perform_op|process_lrm_event" /var/log/pacemaker/pacemaker.log
   Aug 16 14:16:50 r75a pacemaker-based     [13647] (cib_perform_op)       info: Diff: --- 0.15.0 2
   Aug 16 14:16:50 r75a pacemaker-based     [13647] (cib_perform_op)       info: Diff: +++ 0.15.1 (null)
   Aug 16 14:16:50 r75a pacemaker-based     [13647] (cib_perform_op)       info: +  /cib:  @num_updates=1
   (snip)
   Aug 16 14:17:11 r75a pacemaker-controld  [13652] (process_lrm_event)    notice: Result of probe operation for prmDummy on r75a: 7 (not running) | call=5 key=prmDummy_monitor_0 confirmed=true cib-updat

   # cat /etc/sysconfig/pacemaker
   PCMK_logfacility=local1
   PCMK_logpriority=info

   # cat /var/log/ha-log
   Aug 16 14:16:50 r75a pacemaker-based[13647]: info: Diff: --- 0.15.0 2
   Aug 16 14:16:50 r75a pacemaker-based[13647]: info: Diff: +++ 0.15.1 (null)
   Aug 16 14:16:50 r75a pacemaker-based[13647]: info: +  /cib:  @num_updates=1
   (snip)
   Aug 16 14:17:11 r75a pacemaker-controld[13652]: notice: Result of probe operation for prmDummy on r75a: 7 (not running)
   ```
2. https://github.com/inouekazu/pacemaker/commit/13dcd55d84664f41aeda177537707c28c033029f
   I reverted to previous specs[1] .
   Because in the current implementation, it will not be outputs unless **three or more** files are found..

   [1] [5530088](https://github.com/ClusterLabs/pacemaker/commit/5530088f427d9b51927b06245739a2999af4eb00#diff-1c9d3e1e7337d87e931ff20c46c50bf9L339) findmsg() outputs if it finds **one or more** files. Up to 3 at maximum.