### PR TITLE
Handle CPG and quorum notifications in either order

### DIFF
--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -219,7 +219,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
         crm_trace("Alive=%d, appeared=%d, down=%d",
                   alive, appeared, (down? down->id : -1));
 
-        if (alive && type == crm_status_processes) {
+        if (appeared && (alive > 0)) {
             register_fsa_input_before(C_FSA_INTERNAL, I_NODE_JOIN, NULL);
         }
 

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -77,10 +77,8 @@ void
 peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *data)
 {
     uint32_t old = 0;
-    uint32_t changed = 0;
     bool appeared = FALSE;
     bool is_remote = is_set(node->flags, crm_remote_node);
-    const char *status = NULL;
 
     /* The controller waits to receive some information from the membership
      * layer before declaring itself operational. If this is being called for a
@@ -123,30 +121,33 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
             break;
 
         case crm_status_processes:
-            if (data) {
-                old = *(const uint32_t *)data;
-                changed = node->processes ^ old;
-            }
+            CRM_CHECK(data != NULL, return);
+            old = *(const uint32_t *)data;
+            appeared = is_set(node->processes, crm_get_cluster_proc());
 
-            status = (node->processes & proc_flags) ? ONLINESTATUS : OFFLINESTATUS;
-            crm_info("Client %s/%s now has status [%s] (DC=%s, changed=%6x)",
-                     node->uname, peer2text(proc_flags), status,
-                     AM_I_DC ? "true" : crm_str(fsa_our_dc), changed);
+            crm_info("Node %s is %s a peer " CRM_XS " DC=%s old=0x%07x new=0x%07x",
+                     node->uname, (appeared? "now" : "no longer"),
+                     (AM_I_DC? "true" : (fsa_our_dc? fsa_our_dc : "<none>")),
+                     old, node->processes);
 
-            if ((changed & proc_flags) == 0) {
-                /* Peer process did not change */
-                crm_trace("No change %6x %6x %6x", old, node->processes, proc_flags);
+            if (is_not_set((node->processes ^ old), crm_get_cluster_proc())) {
+                /* Peer status did not change. This should not be possible,
+                 * since we don't track process flags other than peer status.
+                 */
+                crm_trace("Process flag 0x%7x did not change from 0x%7x to 0x%7x",
+                          crm_get_cluster_proc(), old, node->processes);
                 return;
+
             } else if (is_not_set(fsa_input_register, R_CIB_CONNECTED)) {
-                crm_trace("Not connected");
+                crm_trace("Ignoring peer status change because not connected to CIB");
                 return;
+
             } else if (fsa_state == S_STOPPING) {
-                crm_trace("Stopping");
+                crm_trace("Ignoring peer status change because stopping");
                 return;
             }
 
-            appeared = (node->processes & proc_flags) != 0;
-            if (safe_str_eq(node->uname, fsa_our_uname) && (node->processes & proc_flags) == 0) {
+            if (safe_str_eq(node->uname, fsa_our_uname) && !appeared) {
                 /* Did we get evicted? */
                 crm_notice("Our peer connection failed");
                 register_fsa_input(C_CRMD_STATUS_CALLBACK, I_ERROR, NULL);
@@ -169,13 +170,10 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                 }
 
             } else if(AM_I_DC) {
-                if (appeared == FALSE) {
-                    crm_info("Peer %s left us", node->uname);
-                    erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
-                } else {
-                    crm_info("New peer %s we want to sync fence history with",
-                             node->uname);
+                if (appeared) {
                     te_trigger_stonith_history_sync();
+                } else {
+                    erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
                 }
             }
             break;

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -163,7 +163,7 @@ create_node_state_update(crm_node_t *node, int flags, xmlNode *parent,
     if (!is_set(node->flags, crm_remote_node)) {
         if (flags & node_update_peer) {
             value = OFFLINESTATUS;
-            if (node->processes & proc_flags) {
+            if (is_set(node->processes, crm_get_cluster_proc())) {
                 value = ONLINESTATUS;
             }
             crm_xml_add(node_state, XML_NODE_IS_PEER, value);

--- a/daemons/controld/controld_membership.h
+++ b/daemons/controld/controld_membership.h
@@ -17,8 +17,6 @@ void post_cache_update(int instance);
 
 extern gboolean check_join_state(enum crmd_fsa_state cur_state, const char *source);
 
-#define proc_flags (crm_proc_controld | crm_get_cluster_proc())
-
 #ifdef __cplusplus
 }
 #endif

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -367,7 +367,7 @@ te_trigger_stonith_history_sync(void)
     /* as we are finally checking the stonith-connection
      * in do_stonith_history_sync we should be fine
      * leaving stonith_history_sync_time & stonith_history_sync_trigger
-     * arround
+     * around
      */
     if (stonith_history_sync_trigger == NULL) {
         stonith_history_sync_trigger =
@@ -381,6 +381,7 @@ te_trigger_stonith_history_sync(void)
                                FALSE, stonith_history_sync_set_trigger,
                                NULL);
     }
+    crm_info("Fence history will be synchronized cluster-wide within 5 seconds");
     mainloop_timer_start(stonith_history_sync_timer);
 }
 

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -112,21 +112,6 @@ peer2text(enum crm_proc_flag proc)
     return text;
 }
 
-static inline enum crm_proc_flag
-text2proc(const char *proc)
-{
-    /* We only care about these two so far */
-
-    if (proc && strcmp(proc, "pacemaker-based") == 0) {
-        return crm_proc_based;
-
-    } else if (proc && strcmp(proc, "pacemaker-controld") == 0) {
-        return crm_proc_controld;
-    }
-
-    return crm_proc_none;
-}
-
 static inline const char *
 ais_dest(const AIS_Host *host)
 {

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -79,10 +79,6 @@ peer2text(enum crm_proc_flag proc)
 {
     const char *text = "unknown";
 
-    if (proc == (crm_proc_controld | crm_get_cluster_proc())) {
-        return "peer";
-    }
-
     switch (proc) {
         case crm_proc_none:
             text = "none";

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -383,9 +383,7 @@ pcmk_cpg_membership(cpg_handle_t handle,
                 // If it persists for more than a minute, update the state
                 crm_warn("Node %u member of group %s but believed offline",
                          member_list[i].nodeid, groupName->value);
-                if (crm_update_peer_state(__FUNCTION__, peer, CRM_NODE_MEMBER, 0)) {
-                    peer->when_lost = 0;
-                }
+                crm_update_peer_state(__FUNCTION__, peer, CRM_NODE_MEMBER, 0);
             }
         }
 

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -323,6 +323,8 @@ pcmk_message_common_cs(cpg_handle_t handle, uint32_t nodeid, uint32_t pid, void 
     return NULL;
 }
 
+#define PEER_NAME(peer) ((peer)? ((peer)->uname? (peer)->uname : "<unknown>") : "<none>")
+
 void
 pcmk_cpg_membership(cpg_handle_t handle,
                     const struct cpg_name *groupName,
@@ -338,43 +340,49 @@ pcmk_cpg_membership(cpg_handle_t handle,
     for (i = 0; i < left_list_entries; i++) {
         crm_node_t *peer = crm_find_peer(left_list[i].nodeid, NULL);
 
-        crm_info("Node %u left group %s (peer=%s, counter=%d.%d)",
-                 left_list[i].nodeid, groupName->value,
-                 (peer? peer->uname : "<none>"), counter, i);
+        crm_info("Group event %s.%d: node %u (%s) left",
+                 groupName->value, counter, left_list[i].nodeid,
+                 PEER_NAME(peer));
         if (peer) {
             crm_update_peer_proc(__FUNCTION__, peer, crm_proc_cpg, OFFLINESTATUS);
         }
     }
 
     for (i = 0; i < joined_list_entries; i++) {
-        crm_info("Node %u joined group %s (counter=%d.%d)",
-                 joined_list[i].nodeid, groupName->value, counter, i);
+        crm_info("Group event %s.%d: node %u joined",
+                 groupName->value, counter, joined_list[i].nodeid);
     }
 
     for (i = 0; i < member_list_entries; i++) {
         crm_node_t *peer = crm_get_peer(member_list[i].nodeid, NULL);
 
-        crm_info("Node %u still member of group %s (peer=%s, counter=%d.%d)",
-                 member_list[i].nodeid, groupName->value,
-                 (peer? peer->uname : "<none>"), counter, i);
+        crm_info("Group event %s.%d: node %u (%s) is member",
+                 groupName->value, counter, member_list[i].nodeid,
+                 PEER_NAME(peer));
 
-        /* Anyone that is sending us CPG messages must also be a _CPG_ member.
-         * But it's _not_ safe to assume it's in the quorum membership.
-         * We may have just found out it's dead and are processing the last couple of messages it sent
+        /* If the caller left auto-reaping enabled, this will also update the
+         * state to member.
          */
         peer = crm_update_peer_proc(__FUNCTION__, peer, crm_proc_cpg, ONLINESTATUS);
-        if(peer && peer->state && crm_is_peer_active(peer) == FALSE) {
+
+        if (peer && peer->state && strcmp(peer->state, CRM_NODE_MEMBER)) {
+            /* The node is a CPG member, but we currently think it's not a
+             * cluster member. This is possible only if auto-reaping was
+             * disabled. The node may be joining, and we happened to get the CPG
+             * notification before the quorum notification; or the node may have
+             * just died, and we are processing its final messages; or a bug
+             * has affected the peer cache.
+             */
             time_t now = time(NULL);
 
             if (peer->when_lost == 0) {
+                // Track when we first got into this contradictory state
                 peer->when_lost = now;
 
             } else if (now > (peer->when_lost + 60)) {
-                /* On the other hand, if we're still getting messages, at a
-                 * certain point we need to acknowledge our internal cache is
-                 * probably wrong. Use 1 minute.
-                 */
-                crm_err("Node %s[%u] appears to be online even though we think it is dead", peer->uname, peer->id);
+                // If it persists for more than a minute, update the state
+                crm_warn("Node %u member of group %s but believed offline",
+                         member_list[i].nodeid, groupName->value);
                 if (crm_update_peer_state(__FUNCTION__, peer, CRM_NODE_MEMBER, 0)) {
                     peer->when_lost = 0;
                 }

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -895,8 +895,11 @@ crm_update_peer_state_iter(const char *source, crm_node_t * node, const char *st
               return NULL);
 
     is_member = safe_str_eq(state, CRM_NODE_MEMBER);
-    if (membership && is_member) {
-        node->last_seen = membership;
+    if (is_member) {
+        node->when_lost = 0;
+        if (membership) {
+            node->last_seen = membership;
+        }
     }
 
     if (state && safe_str_neq(node->state, state)) {


### PR DESCRIPTION
Previously, the controller implicitly assumed that CPG notifications would always be received after quorum notifications when a node joined. However, that is not guaranteed, and in a test environment with corosync 2.99.3 and pcs 0.10.0, the opposite order happens frequently. The issue was likely possible with corosync 2 as well, possibly dependent on start-up timing.

There was also a related bug that was hidden when the expected order occurred, in the handling of conflicting CPG and quorum states for a node.