### PR TITLE
Low: attrd: Adding the ignore_delay parameter to reduce the number of scans of the attribute hash table.

### DIFF
--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -44,7 +44,7 @@ int last_cib_op_done = 0;
 char *peer_writer = NULL;
 GHashTable *attributes = NULL;
 
-void write_attribute(attribute_t *a);
+void write_attribute(attribute_t *a, bool ignore_delay);
 void write_or_elect_attribute(attribute_t *a);
 void attrd_current_only_attribute_update(crm_node_t *peer, xmlNode *xml);
 void attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter);
@@ -382,19 +382,8 @@ attrd_client_clear_failure(xmlNode *xml)
 void
 attrd_client_refresh(void)
 {
-    GHashTableIter iter;
-    attribute_t *a = NULL;
-
-    /* 'refresh' forces a write of the current value of all attributes
-     * Cancel any existing timers, we're writing it NOW
-     */
-    g_hash_table_iter_init(&iter, attributes);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & a)) {
-        mainloop_timer_stop(a->timer);
-    }
-
     crm_info("Updating all attributes");
-    write_attributes(TRUE);
+    write_attributes(TRUE, TRUE);
 }
 
 /*!
@@ -936,7 +925,7 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
         crm_trace("Learned %s has node id %s",
                   known_peer->uname, known_peer->uuid);
         if (election_state(writer) == election_won) {
-            write_attributes(FALSE);
+            write_attributes(FALSE, FALSE);
         }
     }
 }
@@ -946,7 +935,7 @@ write_or_elect_attribute(attribute_t *a)
 {
     enum election_result rc = election_state(writer);
     if(rc == election_won) {
-        write_attribute(a);
+        write_attribute(a, FALSE);
 
     } else if(rc == election_in_progress) {
         crm_trace("Election in progress to determine who will write out %s", a->id);
@@ -970,7 +959,7 @@ attrd_election_cb(gpointer user_data)
     attrd_peer_sync(NULL, NULL);
 
     /* Update the CIB after an election */
-    write_attributes(TRUE);
+    write_attributes(TRUE, FALSE);
     return FALSE;
 }
 
@@ -1083,7 +1072,7 @@ attrd_cib_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
 }
 
 void
-write_attributes(bool all)
+write_attributes(bool all, bool ignore_delay)
 {
     GHashTableIter iter;
     attribute_t *a = NULL;
@@ -1097,7 +1086,7 @@ write_attributes(bool all)
         }
 
         if(all || a->changed) {
-            write_attribute(a);
+            write_attribute(a, ignore_delay);
         } else {
             crm_debug("Skipping unchanged attribute %s", a->id);
         }
@@ -1178,7 +1167,7 @@ send_alert_attributes_value(attribute_t *a, GHashTable *t)
 #define s_if_plural(i) (((i) == 1)? "" : "s")
 
 void
-write_attribute(attribute_t *a)
+write_attribute(attribute_t *a, bool ignore_delay)
 {
     int private_updates = 0, cib_updates = 0;
     xmlNode *xml_top = NULL;
@@ -1207,8 +1196,16 @@ write_attribute(attribute_t *a)
             return;
 
         } else if (mainloop_timer_running(a->timer)) {
-            crm_info("Write out of '%s' delayed: timer is running", a->id);
-            return;
+            if (ignore_delay) {
+                /* 'refresh' forces a write of the current value of all attributes
+                 * Cancel any existing timers, we're writing it NOW
+                 */
+                mainloop_timer_stop(a->timer);
+                crm_debug("Write out of '%s': timer is running but ignore delay", a->id);
+            } else {
+                crm_info("Write out of '%s' delayed: timer is running", a->id);
+                return;
+            }
         }
 
         /* Initialize the status update XML */

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -86,7 +86,7 @@ attrd_cib_replaced_cb(const char *event, xmlNode * msg)
 {
     crm_notice("Updating all attributes after %s event", event);
     if(election_state(writer) == election_won) {
-        write_attributes(TRUE);
+        write_attributes(TRUE, FALSE);
     }
 }
 

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -99,7 +99,7 @@ election_t *writer;
 #define attrd_send_ack(client, id, flags) \
     crm_ipcs_send_ack((client), (id), (flags), "ack", __FUNCTION__, __LINE__)
 
-void write_attributes(bool all);
+void write_attributes(bool all, bool ignore_delay);
 void attrd_broadcast_protocol(void);
 void attrd_peer_message(crm_node_t *client, xmlNode *msg);
 void attrd_client_peer_remove(const char *client_name, xmlNode *xml);


### PR DESCRIPTION
Hi All,

This correction is based on the idea from Mr. Ken.
It adds the ignore_delay parameter to reduce the number of times of scanning the attribute hash table.
In the current processing, scanning of the attribute hash table is executed twice, but this patch makes it once.

Best Regards,
Hideo Yamauchi.
