### PR TITLE
Fix: crm_report: search for logs via syslog when being called by sosreport (CLBZ#5365)

### DIFF
--- a/tools/crm_report.in
+++ b/tools/crm_report.in
@@ -21,6 +21,7 @@ compress=1
 cluster="any"
 ssh_user="root"
 search_logs=1
+sos_mode=0
 report_data=`dirname $0`
 maxdepth=5
 
@@ -120,7 +121,7 @@ while true; do
 	-u|--user)      ssh_user="$2"; shift; shift;;
         -D|--max-depth)     maxdepth="$2"; shift; shift;;
 	-M) search_logs=0; shift;;
-        --sos-mode) search_logs=0; nodes="$host"; shift;;
+        --sos-mode) sos_mode=1; nodes="$host"; shift;;
 	--dest) DESTDIR=$2; shift; shift;;
 	--) if [ ! -z $2 ]; then DESTDIR=$2; fi; break;;
 	-h|--help) usage; exit 0;;
@@ -175,6 +176,7 @@ CLUSTER=$cluster
 LOG_PATTERNS="$log_patterns"
 EXTRA_LOGS="$extra_logs"
 SEARCH_LOGS=$search_logs
+SOS_MODE=$sos_mode
 verbose=$verbose
 maxdepth=$maxdepth
 EOF

--- a/tools/report.collector.in
+++ b/tools/report.collector.in
@@ -561,34 +561,41 @@ find_syslog() {
     findmsg 1 "$msg"
 }
 
+get_logfiles_cs() {
+    if [ ! -f "$cf_file" ]; then
+        return
+    fi
+
+    debug "Reading $cf_type log settings from $cf_file"
+
+    # The default value of to_syslog is yes.
+    if ! iscfvarfalse $cf_type to_syslog "$cf_file"; then
+        facility_cs=$(getcfvar $cf_type syslog_facility "$cf_file")
+        if [ -z "$facility_cs" ]; then
+            facility_cs="daemon"
+        fi
+
+        find_syslog "$facility_cs.info"
+    fi
+    if [ "$SOS_MODE" = "1" ]; then
+        return
+    fi
+
+    if iscfvartrue $cf_type to_logfile "$cf_file"; then
+        logfile=$(getcfvar $cf_type logfile "$cf_file")
+        if [ -f "$logfile" ]; then
+            debug "Log settings found for cluster type $cf_type: $logfile"
+            echo "$logfile"
+        fi
+    fi
+}
+
 get_logfiles() {
     cf_type=$1
     cf_file="$2"
 
     case $cf_type in
-        corosync)
-            if [ -f "$cf_file" ]; then
-                debug "Reading $cf_type log settings from $cf_file"
-
-                # The default value of to_syslog is yes.
-                if ! iscfvarfalse $cf_type to_syslog "$cf_file"; then
-                    facility_cs=$(getcfvar $cf_type syslog_facility "$cf_file")
-                    if [ -z "$facility_cs" ]; then
-                        facility_cs="daemon"
-                    fi
-
-                    find_syslog "$facility_cs.info"
-                fi
-
-                if iscfvartrue $cf_type to_logfile "$cf_file"; then
-                    logfile=$(getcfvar $cf_type logfile "$cf_file")
-                    if [ -f "$logfile" ]; then
-                        debug "Log settings found for cluster type $cf_type: $logfile"
-                        echo "$logfile"
-                    fi
-                fi
-            fi
-            ;;
+        corosync) get_logfiles_cs;;
     esac
 
     . @CONFIGDIR@/pacemaker
@@ -599,6 +606,9 @@ get_logfiles() {
     fi
     if [ "$facility" != "$facility_cs" ]&&[ "$facility" != none ]; then
         find_syslog "$facility.notice"
+    fi
+    if [ "$SOS_MODE" = "1" ]; then
+        return
     fi
 
     logfile="$PCMK_logfile"


### PR DESCRIPTION
Since RHEL 7.3 and later sosreport executes crm_report with --sos-mode,
the logs specified in ```PCMK_logfacility``` (/etc/sysconfig/pacemaker)
and ```syslog_facility``` (/etc/corosync/corosync.conf) are not collected.

This fixes https://bugs.clusterlabs.org/show_bug.cgi?id=5365