### PR TITLE
Low: tools: ensure crm_resource --force-* commands get stderr messages

### DIFF
--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1757,6 +1757,12 @@ cli_resource_execute(resource_t *rsc, const char *requested_name,
         setenv("OCF_TRACE_RA", "1", 1);
     }
 
+    /* A resource agent using the standard ocf-shellfuncs library will not print
+     * messages to stderr if it doesn't have a controlling terminal (e.g. if
+     * crm_resource is called via script or ssh). This forces it to do so.
+     */
+    setenv("OCF_TRACE_FILE", "/dev/stderr", 0);
+
     if (override_hash) {
         GHashTableIter iter;
         char *name = NULL;


### PR DESCRIPTION
The resource-agents package's ocf-shellfuncs library uses whether it has a controlling terminal to decide whether to send messages to stderr. This means that crm_resource --force-* commands run via e.g. ssh (without the -t option) would not get stderr output as expected with the -V option.

This makes crm_resource set the OCF_TRACE_FILE environment variable to /dev/stderr to force the agent to write messages to stderr (when verbose is set).