### PR TITLE
Fix: controld: able to manually confirm unseen nodes are down

### DIFF
--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -355,8 +355,9 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 
     CRM_LOG_ASSERT(output != NULL);
 
-    // Refresh the remote node cache when the scheduler is invoked
-    crm_remote_peer_cache_refresh(output);
+    /* Refresh the remote node cache and the known node cache when the
+     * scheduler is invoked */
+    crm_peer_caches_refresh(output);
 
     crm_xml_add(output, XML_ATTR_DC_UUID, fsa_our_uuid);
     crm_xml_add_int(output, XML_ATTR_HAVE_QUORUM, fsa_has_quorum);

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -269,7 +269,7 @@ tengine_stonith_notify(stonith_t * st, stonith_event_t * st_event)
                st_event->origin, st_event->id);
 
     if (st_event->result == pcmk_ok) {
-        crm_node_t *peer = crm_find_peer_full(0, st_event->target, CRM_GET_PEER_ANY);
+        crm_node_t *peer = crm_find_known_peer_full(0, st_event->target, CRM_GET_PEER_ANY);
         const char *uuid = NULL;
         gboolean we_are_executioner = safe_str_eq(st_event->executioner, fsa_our_uname);
 

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2298,22 +2298,19 @@ stonith_fence(xmlNode * msg)
 
     } else {
         const char *host = crm_element_value(dev, F_STONITH_TARGET);
-        char *nodename = NULL;
 
         if (cmd->options & st_opt_cs_nodeid) {
             int nodeid = crm_atoi(host, NULL);
+            crm_node_t *node = crm_find_known_peer_full(nodeid, NULL, CRM_GET_PEER_ANY);
 
-            nodename = stonith_get_peer_name(nodeid);
-            if (nodename) {
-                host = nodename;
+            if (node) {
+                host = node->uname;
             }
         }
 
         /* If we get to here, then self-fencing is implicitly allowed */
         get_capable_devices(host, cmd->action, cmd->default_timeout,
                             TRUE, cmd, stonith_fence_get_devices_cb);
-
-        free(nodename);
     }
 
     return -EINPROGRESS;

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -384,17 +384,16 @@ stonith_fence_history(xmlNode *msg, xmlNode **output,
     int rc = 0;
     const char *target = NULL;
     xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, msg, LOG_TRACE);
-    char *nodename = NULL;
     xmlNode *out_history = NULL;
 
     if (dev) {
         target = crm_element_value(dev, F_STONITH_TARGET);
         if (target && (options & st_opt_cs_nodeid)) {
             int nodeid = crm_atoi(target, NULL);
+            crm_node_t *node = crm_find_known_peer_full(nodeid, NULL, CRM_GET_PEER_ANY);
 
-            nodename = stonith_get_peer_name(nodeid);
-            if (nodename) {
-                target = nodename;
+            if (node) {
+                target = node->uname;
             }
         }
     }
@@ -463,7 +462,6 @@ stonith_fence_history(xmlNode *msg, xmlNode **output,
                   stonith_remote_op_list);
         *output = stonith_local_history_diff(NULL, FALSE, target);
     }
-    free(nodename);
     free_xml(out_history);
     return rc;
 }

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -255,14 +255,10 @@ schedule_internal_command(const char *origin,
                           void (*done_cb) (GPid pid, int rc, const char *output,
                                            gpointer user_data));
 
-char *stonith_get_peer_name(unsigned int nodeid);
-
 extern char *stonith_our_uname;
 extern gboolean stand_alone;
 extern GHashTable *device_list;
 extern GHashTable *topology;
 extern long stonith_watchdog_timeout_ms;
-
-extern GHashTable *known_peer_names;
 
 extern GHashTable *stonith_remote_op_list;

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -329,4 +329,7 @@ gboolean node_name_is_valid(const char *key, const char *name);
 crm_node_t * crm_find_peer_full(unsigned int id, const char *uname, int flags);
 crm_node_t * crm_find_peer(unsigned int id, const char *uname);
 
+void crm_peer_caches_refresh(xmlNode *cib);
+crm_node_t *crm_find_known_peer_full(unsigned int id, const char *uname, int flags);
+
 #endif

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -50,6 +50,8 @@ GHashTable *crm_peer_cache = NULL;
  */
 GHashTable *crm_remote_peer_cache = NULL;
 
+GHashTable *crm_known_peer_cache = NULL;
+
 unsigned long long crm_peer_seq = 0;
 gboolean crm_have_quorum = FALSE;
 static gboolean crm_autoreap  = TRUE;
@@ -394,6 +396,10 @@ crm_peer_init(void)
     if (crm_remote_peer_cache == NULL) {
         crm_remote_peer_cache = g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal, NULL, destroy_crm_node);
     }
+
+    if (crm_known_peer_cache == NULL) {
+        crm_known_peer_cache = g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal, free, destroy_crm_node);
+    }
 }
 
 void
@@ -410,6 +416,13 @@ crm_peer_destroy(void)
         g_hash_table_destroy(crm_remote_peer_cache);
         crm_remote_peer_cache = NULL;
     }
+
+    if (crm_known_peer_cache != NULL) {
+        crm_trace("Destroying known peer cache with %d members", g_hash_table_size(crm_known_peer_cache));
+        g_hash_table_destroy(crm_known_peer_cache);
+        crm_known_peer_cache = NULL;
+    }
+
 }
 
 void (*crm_status_callback) (enum crm_status_type, crm_node_t *, const void *) = NULL;
@@ -1000,4 +1013,168 @@ int
 crm_terminate_member_no_mainloop(int nodeid, const char *uname, int *connection)
 {
     return stonith_api_kick(nodeid, uname, 120, TRUE);
+}
+
+static crm_node_t *
+crm_find_known_peer(const char *id, const char *uname)
+{
+    GHashTableIter iter;
+    crm_node_t *node = NULL;
+    crm_node_t *by_id = NULL;
+    crm_node_t *by_name = NULL;
+
+    if (uname) {
+        g_hash_table_iter_init(&iter, crm_known_peer_cache);
+        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+            if (node->uname && strcasecmp(node->uname, uname) == 0) {
+                crm_trace("Name match: %s = %p", node->uname, node);
+                by_name = node;
+                break;
+            }
+        }
+    }
+
+    if (id) {
+        g_hash_table_iter_init(&iter, crm_known_peer_cache);
+        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+            if(strcasecmp(node->uuid, id) == 0) {
+                crm_trace("ID match: %s= %p", id, node);
+                by_id = node;
+                break;
+            }
+        }
+    }
+
+    node = by_id; /* Good default */
+    if (by_id == by_name) {
+        /* Nothing to do if they match (both NULL counts) */
+        crm_trace("Consistent: %p for %s/%s", by_id, id, uname);
+
+    } else if (by_id == NULL && by_name) {
+        crm_trace("Only one: %p for %s/%s", by_name, id, uname);
+
+        if (id) {
+            node = NULL;
+
+        } else {
+            node = by_name;
+        }
+
+    } else if (by_name == NULL && by_id) {
+        crm_trace("Only one: %p for %s/%s", by_id, id, uname);
+
+        if (uname) {
+            node = NULL;
+        }
+
+    } else if (uname && by_id->uname
+               && safe_str_eq(uname, by_id->uname)) {
+        /* Multiple nodes have the same uname in the CIB.
+         * Return by_id. */
+
+    } else if (id && by_name->uuid
+               && safe_str_eq(id, by_name->uuid)) {
+        /* Multiple nodes have the same id in the CIB.
+         * Return by_name. */
+        node = by_name;
+
+    } else {
+        node = NULL;
+    }
+
+    if (node == NULL) {
+        crm_debug("Couldn't find node%s%s%s%s",
+                   id? " " : "",
+                   id? id : "",
+                   uname? " with name " : "",
+                   uname? uname : "");
+    }
+
+    return node;
+}
+
+static void
+known_peer_cache_refresh_helper(xmlNode *xml_node, void *user_data)
+{
+    const char *id = crm_element_value(xml_node, XML_ATTR_ID);
+    const char *uname = crm_element_value(xml_node, XML_ATTR_UNAME);
+    crm_node_t * node =  NULL;
+
+    CRM_CHECK(id != NULL && uname !=NULL, return);
+    node = crm_find_known_peer(id, uname);
+
+    if (node == NULL) {
+        char *uniqueid = crm_generate_uuid();
+
+        node = calloc(1, sizeof(crm_node_t));
+        CRM_ASSERT(node != NULL);
+
+        node->uname = strdup(uname);
+        CRM_ASSERT(node->uname != NULL);
+
+        node->uuid = strdup(id);
+        CRM_ASSERT(node->uuid != NULL);
+
+        g_hash_table_replace(crm_known_peer_cache, uniqueid, node);
+
+    } else if (is_set(node->flags, crm_node_dirty)) {
+        if (safe_str_neq(uname, node->uname)) {
+            free(node->uname);
+            node->uname = strdup(uname);
+            CRM_ASSERT(node->uname != NULL);
+        }
+
+        /* Node is in cache and hasn't been updated already, so mark it clean */
+        clear_bit(node->flags, crm_node_dirty);
+    }
+
+}
+
+#define XPATH_MEMBER_NODE_CONFIG \
+    "//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_NODES \
+    "/" XML_CIB_TAG_NODE "[not(@type) or @type='member']"
+
+static void
+crm_known_peer_cache_refresh(xmlNode *cib)
+{
+    crm_peer_init();
+
+    g_hash_table_foreach(crm_known_peer_cache, mark_dirty, NULL);
+
+    crm_foreach_xpath_result(cib, XPATH_MEMBER_NODE_CONFIG,
+                             known_peer_cache_refresh_helper, NULL);
+
+    /* Remove all old cache entries that weren't seen in the CIB */
+    g_hash_table_foreach_remove(crm_known_peer_cache, is_dirty, NULL);
+}
+
+void
+crm_peer_caches_refresh(xmlNode *cib)
+{
+    crm_remote_peer_cache_refresh(cib);
+    crm_known_peer_cache_refresh(cib);
+}
+
+crm_node_t *
+crm_find_known_peer_full(unsigned int id, const char *uname, int flags)
+{
+    crm_node_t *node = NULL;
+    char *id_str = NULL;
+
+    CRM_ASSERT(id > 0 || uname != NULL);
+
+    node = crm_find_peer_full(id, uname, flags);
+
+    if (node || !(flags & CRM_GET_PEER_CLUSTER)) {
+        return node;
+    }
+
+    if (id > 0) {
+        id_str = crm_strdup_printf("%u", id);
+    }
+
+    node = crm_find_known_peer(id_str, uname);
+
+    free(id_str);
+    return node;
 }


### PR DESCRIPTION
9045bac prevented manual fencing confirmations from creating node
entries for random unknown nodes, but it also disabled the ability to do
manual fencing confirmations for the nodes that are already known in the
CIB but not yet in the membership cache.

This commit fixes it by maintaining and utilizing an additional
membership cache of known nodes based on the CIB.

This follows up the discussions from https://github.com/ClusterLabs/pacemaker/pull/1503