### PR TITLE
Low: tools: Add lsblk to sysstats output in crm_reports

### DIFF
--- a/tools/report.collector.in
+++ b/tools/report.collector.in
@@ -469,6 +469,7 @@ sys_stats() {
     }
     lsscsi
     lspci
+    lsblk
     mount
     df
     set +x


### PR DESCRIPTION
lsblk ships with util-linux. If we assume that the system has 'mount' installed, I believe we can safely assume it will have 'lsblk' as well. 

I would find it useful in the crm_reports to quickly get an understanding of the storage on the node.