### PR TITLE
Fix: pacemaker-remote: skip remote_config_check for guest-nodes

### DIFF
--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -489,11 +489,15 @@ crmd_remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
         const char *channel = crm_element_value(msg, F_LRMD_IPC_IPC_SERVER);
 
         proxy = crmd_remote_proxy_new(lrmd, lrm_state->node_name, session, channel);
-        if (proxy != NULL) {
-            /* Look up stonith-watchdog-timeout and send to the remote peer for validation */
-            int rc = fsa_cib_conn->cmds->query(fsa_cib_conn, XML_CIB_TAG_CRMCONFIG, NULL, cib_scope_local);
-            fsa_cib_conn->cmds->register_callback_full(fsa_cib_conn, rc, 10, FALSE, lrmd,
-                                                       "remote_config_check", remote_config_check, NULL);
+        if (!remote_ra_controlling_guest(lrm_state)) {
+            if (proxy != NULL) {
+                /* Look up stonith-watchdog-timeout and send to the remote peer for validation */
+                int rc = fsa_cib_conn->cmds->query(fsa_cib_conn, XML_CIB_TAG_CRMCONFIG, NULL, cib_scope_local);
+                fsa_cib_conn->cmds->register_callback_full(fsa_cib_conn, rc, 10, FALSE, lrmd,
+                                                        "remote_config_check", remote_config_check, NULL);
+            }
+        } else {
+            crm_debug("Skipping remote_config_check for guest-nodes");
         }
 
     } else if (safe_str_eq(op, LRMD_IPC_OP_SHUTDOWN_REQ)) {

--- a/daemons/controld/controld_lrm.h
+++ b/daemons/controld/controld_lrm.h
@@ -159,5 +159,6 @@ void remote_ra_fail(const char *node_name);
 void remote_ra_process_pseudo(xmlNode *xml);
 gboolean remote_ra_is_in_maintenance(lrm_state_t * lrm_state);
 void remote_ra_process_maintenance_nodes(xmlNode *xml);
+gboolean remote_ra_controlling_guest(lrm_state_t * lrm_state);
 
 gboolean process_lrm_event(lrm_state_t * lrm_state, lrmd_event_data_t * op, struct recurring_op_s *pending);

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -720,10 +720,10 @@ handle_remote_ra_start(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd, int timeo
     int timeout_used = timeout_ms > MAX_START_TIMEOUT_MS ? MAX_START_TIMEOUT_MS : timeout_ms;
 
     for (tmp = cmd->params; tmp; tmp = tmp->next) {
-        if (safe_str_eq(tmp->key, "addr") || safe_str_eq(tmp->key, "server")) {
+        if (safe_str_eq(tmp->key, XML_RSC_ATTR_REMOTE_RA_ADDR) ||
+            safe_str_eq(tmp->key, XML_RSC_ATTR_REMOTE_RA_SERVER)) {
             server = tmp->value;
-        }
-        if (safe_str_eq(tmp->key, "port")) {
+        } else if (safe_str_eq(tmp->key, XML_RSC_ATTR_REMOTE_RA_PORT)) {
             port = atoi(tmp->value);
         }
     }

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -75,6 +75,14 @@ typedef struct remote_ra_data_s {
      * so we have it signalled back with the transition from the scheduler.
      */
     gboolean is_maintenance;
+
+    /* Similar for if we are controlling a guest or a bare-metal remote.
+     * Fortunately there is a meta-attribute in the transition already and
+     * as the situation doesn't change over time we can use the
+     * resource start for noting down the information for later use when
+     * the attributes aren't at hand.
+     */
+    gboolean controlling_guest;
 } remote_ra_data_t;
 
 static int handle_remote_ra_start(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd, int timeout_ms);
@@ -717,6 +725,7 @@ handle_remote_ra_start(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd, int timeo
     const char *server = NULL;
     lrmd_key_value_t *tmp = NULL;
     int port = 0;
+    remote_ra_data_t *ra_data = lrm_state->remote_ra_data;
     int timeout_used = timeout_ms > MAX_START_TIMEOUT_MS ? MAX_START_TIMEOUT_MS : timeout_ms;
 
     for (tmp = cmd->params; tmp; tmp = tmp->next) {
@@ -725,6 +734,8 @@ handle_remote_ra_start(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd, int timeo
             server = tmp->value;
         } else if (safe_str_eq(tmp->key, XML_RSC_ATTR_REMOTE_RA_PORT)) {
             port = atoi(tmp->value);
+        } else if (safe_str_eq(tmp->key, CRM_META"_"XML_RSC_ATTR_CONTAINER)) {
+            ra_data->controlling_guest = TRUE;
         }
     }
 
@@ -1267,4 +1278,12 @@ remote_ra_is_in_maintenance(lrm_state_t * lrm_state)
     remote_ra_data_t *ra_data = lrm_state->remote_ra_data;
 
     return ra_data->is_maintenance;
+}
+
+gboolean
+remote_ra_controlling_guest(lrm_state_t * lrm_state)
+{
+    remote_ra_data_t *ra_data = lrm_state->remote_ra_data;
+
+    return ra_data->controlling_guest;
 }

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -206,6 +206,9 @@ extern "C" {
 #  define XML_RSC_ATTR_REMOTE_NODE  	"remote-node"
 #  define XML_RSC_ATTR_CLEAR_OP         "clear_failure_op"
 #  define XML_RSC_ATTR_CLEAR_INTERVAL   "clear_failure_interval"
+#  define XML_RSC_ATTR_REMOTE_RA_ADDR   "addr"
+#  define XML_RSC_ATTR_REMOTE_RA_SERVER "server"
+#  define XML_RSC_ATTR_REMOTE_RA_PORT   "port"
 
 #  define XML_REMOTE_ATTR_RECONNECT_INTERVAL "reconnect_interval"
 


### PR DESCRIPTION
This is crucial when watchdog-fencing is enabled as the sbd-check
done by pacemaker-remote would fail on guest-containers & bundles
(eventually tearing down pacemaker-remote inside the container)
and even on system-virtualized-guests the sbd-check doesn't make
sense as these guests would be fenced by stop/start-cycling the
VM.

As a base for discussion for the first ...

Currently skipping the whole remote_config_check for guest-nodes.
As neither a guest-node's pacemaker_remoted knows that it is
running on a guest-node nor this info is easily available when the
remote_config_check is kicked off from inside controld after the
remote-connection is established the info is passed from
schedulerd via a mockup attribute (controlling-guest).
As the decision not the kick off the check is entirely done on
the cluster-node existent containers can be used without having
to exchange pacemaker_remoted inside.

Have to investigate if the approach is enough for bundles.

If the mockup attribute is already coming from the cib I currently have
it overrule the automatized detection. That is handy for debug purposes
but potentially dangerous as sbdy might use that to disable the
watchdog-check on a bare-metal-remote as well of course. So finally
we might decide to have the automatized detection just overwrite
any existing attribute.