### PR TITLE
Build: Makefile.common: Remove extra output when making man pages

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -38,8 +38,6 @@ endif
 
 %.8:	% $(MAN8DEPS)
 	chmod a+x $(abs_builddir)/$<
-	$(PCMK_V)  PATH=$(abs_builddir):$$PATH $(abs_builddir)/$< --help
-	$(PCMK_V)  PATH=$(abs_builddir):$$PATH $(abs_builddir)/$< --version
 	$(AM_V_MAN)PATH=$(abs_builddir):$$PATH $(HELP2MAN) --output $@ --no-info --section 8 --name "Part of the Pacemaker cluster resource manager" $(abs_builddir)/$<
 
 %.xml:  %


### PR DESCRIPTION
The --help and --version calls are tripping up building on openbsd, and
do not currently appear to be adding anything that we can't figure out
elsewhere.

See https://bugs.clusterlabs.org/show_bug.cgi?id=5341.