### PR TITLE
Doc: Clusters from Scratch: Fix netmask in ClusterIP example.

### DIFF
--- a/doc/Clusters_from_Scratch/en-US/Ap-Configuration.txt
+++ b/doc/Clusters_from_Scratch/en-US/Ap-Configuration.txt
@@ -150,7 +150,7 @@ Daemon Status:
     <clone id="ClusterIP-clone">
       <primitive class="ocf" id="ClusterIP" provider="heartbeat" type="IPaddr2">
         <instance_attributes id="ClusterIP-instance_attributes">
-          <nvpair id="ClusterIP-instance_attributes-cidr_netmask" name="cidr_netmask" value="32"/>
+          <nvpair id="ClusterIP-instance_attributes-cidr_netmask" name="cidr_netmask" value="24"/>
           <nvpair id="ClusterIP-instance_attributes-ip" name="ip" value="192.168.122.120"/>
           <nvpair id="ClusterIP-instance_attributes-clusterip_hash" name="clusterip_hash" value="sourceip"/>
         </instance_attributes>
@@ -304,7 +304,7 @@ both.
  Clone: ClusterIP-clone
   Meta Attrs: clone-max=2 clone-node-max=2 globally-unique=true 
   Resource: ClusterIP (class=ocf provider=heartbeat type=IPaddr2)
-   Attributes: cidr_netmask=32 ip=192.168.122.120 clusterip_hash=sourceip
+   Attributes: cidr_netmask=24 ip=192.168.122.120 clusterip_hash=sourceip
    Meta Attrs: resource-stickiness=0 
    Operations: monitor interval=30s (ClusterIP-monitor-interval-30s)
                start interval=0s timeout=20s (ClusterIP-start-interval-0s)

--- a/doc/Clusters_from_Scratch/en-US/Ch-Active-Passive.txt
+++ b/doc/Clusters_from_Scratch/en-US/Ch-Active-Passive.txt
@@ -126,7 +126,7 @@ Do not reuse an IP address one of the nodes already has configured.
 
 ----
 [root@pcmk-1 ~]# pcs resource create ClusterIP ocf:heartbeat:IPaddr2 \ 
-    ip=192.168.122.120 cidr_netmask=32 op monitor interval=30s
+    ip=192.168.122.120 cidr_netmask=24 op monitor interval=30s
 ----
 
 Another important piece of information here is *ocf:heartbeat:IPaddr2*.

--- a/doc/pcs-crmsh-quick-ref.md
+++ b/doc/pcs-crmsh-quick-ref.md
@@ -123,9 +123,9 @@ You can also use the full class:provider:RA format if multiple RAs with the same
 ## Create a resource
 
     crmsh # crm configure primitive ClusterIP ocf:heartbeat:IPaddr2 \
-            params ip=192.168.122.120 cidr_netmask=32 \
+            params ip=192.168.122.120 cidr_netmask=24 \
             op monitor interval=30s 
-    pcs   # pcs resource create ClusterIP IPaddr2 ip=192.168.0.120 cidr_netmask=32
+    pcs   # pcs resource create ClusterIP IPaddr2 ip=192.168.0.120 cidr_netmask=24
 
 The standard and provider (`ocf:heartbeat`) are determined automatically since `IPaddr2` is unique.
 The monitor operation is automatically created based on the agent's metadata.


### PR DESCRIPTION
Following the documentation, with netmask=32 the cluster IP will
eventually drop, likely after ten or fifteen minutes when you've stopped
paying attention, due to an error from findif.

There are two possible solutions.  First, you can use netmask=32
nic=eth0 (or whatever your network device is).  Second, you can use
netmask=24 by itself.  I've gone with the latter here because it's less
stuff for people to do.

See https://bugs.clusterlabs.org/show_bug.cgi?id=5325.