### PR TITLE
Mid : attrd: Ignoring delayed updating of attributes when integrating disjointed clusters without stonith.

### DIFF
--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -99,7 +99,7 @@ free_attribute(gpointer data)
 static xmlNode *
 build_attribute_xml(
     xmlNode *parent, const char *name, const char *set, const char *uuid, unsigned int timeout_ms, const char *user,
-    gboolean is_private, const char *peer, uint32_t peerid, const char *value)
+    gboolean is_private, const char *peer, uint32_t peerid, const char *value, gboolean is_force_write)
 {
     xmlNode *xml = create_xml_node(parent, __FUNCTION__);
 
@@ -112,6 +112,7 @@ build_attribute_xml(
     crm_xml_add(xml, F_ATTRD_VALUE, value);
     crm_xml_add_int(xml, F_ATTRD_DAMPEN, timeout_ms/1000);
     crm_xml_add_int(xml, F_ATTRD_IS_PRIVATE, is_private);
+    crm_xml_add_int(xml, F_ATTRD_IS_FORCE_WRITE, is_force_write);
 
     return xml;
 }
@@ -628,7 +629,7 @@ attrd_peer_sync(crm_node_t *peer, xmlNode *xml)
         while (g_hash_table_iter_next(&vIter, NULL, (gpointer *) & v)) {
             crm_debug("Syncing %s[%s] = %s to %s", a->id, v->nodename, v->current, peer?peer->uname:"everyone");
             build_attribute_xml(sync, a->id, a->set, a->uuid, a->timeout_ms, a->user, a->is_private,
-                                v->nodename, v->nodeid, v->current);
+                                v->nodename, v->nodeid, v->current, FALSE);
         }
     }
 
@@ -731,9 +732,18 @@ attrd_current_only_attribute_update(crm_node_t *peer, xmlNode *xml)
                 crm_trace("Syncing %s[%s] = %s to everyone.(from local only attributes)", a->id, v->nodename, v->current);
 
                 build = TRUE;
+                /* Attributes held only by own node with delay are forcibly written. */
                 build_attribute_xml(sync, a->id, a->set, a->uuid, a->timeout_ms, a->user, a->is_private,
-                            v->nodename, v->nodeid, v->current);
+                            v->nodename, v->nodeid, v->current, (a->timeout_ms && a->timer ? TRUE : FALSE));
             } else {
+                if (a->force_write) {
+                    /* After being reflected in Writer, clear forced writing flag and change flag are cleared. */
+
+                    crm_trace("Clear the forced write flag of %s attribute", a->id);     
+                    a->changed = FALSE;
+                    a->force_write = FALSE;
+                }
+
                 crm_trace("Local attribute(%s[%s] = %s) was ignore.(another host) : [%s]", a->id, v->nodename, v->current, attrd_cluster->uname);
                 continue;
             }
@@ -753,10 +763,12 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
     bool update_both = FALSE;
     attribute_t *a;
     attribute_value_t *v = NULL;
+    gboolean is_force_write = FALSE;
 
     const char *op = crm_element_value(xml, F_ATTRD_TASK);
     const char *attr = crm_element_value(xml, F_ATTRD_ATTRIBUTE);
     const char *value = crm_element_value(xml, F_ATTRD_VALUE);
+    crm_element_value_int(xml, F_ATTRD_IS_FORCE_WRITE, &is_force_write);
 
     if (attr == NULL) {
         crm_warn("Could not update attribute: peer did not specify name");
@@ -847,7 +859,7 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
         crm_xml_add(sync, F_ATTRD_TASK, ATTRD_OP_SYNC_RESPONSE);
         v = g_hash_table_lookup(a->values, host);
         build_attribute_xml(sync, attr, a->set, a->uuid, a->timeout_ms, a->user,
-                            a->is_private, v->nodename, v->nodeid, v->current);
+                            a->is_private, v->nodename, v->nodeid, v->current, FALSE);
 
         attrd_xml_add_writer(sync);
 
@@ -871,7 +883,15 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
         }
 
     } else {
-        crm_trace("Unchanged %s[%s] from %s is %s", attr, host, peer->uname, value);
+        if (is_force_write && a->timeout_ms && a->timer) {
+            /* Save forced writing and set change flag. */
+            /* The actual attribute is written by Writer after election. */
+            crm_trace("Unchanged %s[%s] from %s is %s(Set the forced write flag)", attr, host, peer->uname, value);
+            a->changed = TRUE;
+            a->force_write = is_force_write;
+        } else {
+            crm_trace("Unchanged %s[%s] from %s is %s", attr, host, peer->uname, value);
+        }
     }
 
     /* Set the seen flag for attribute processing held only in the own node. */
@@ -1051,7 +1071,8 @@ write_attributes(bool all, bool ignore_delay)
         }
 
         if(all || a->changed) {
-            write_attribute(a, ignore_delay);
+            /* When forced write flag is set, ignore delay. */
+            write_attribute(a, (a->force_write ? TRUE : ignore_delay));
         } else {
             crm_debug("Skipping unchanged attribute %s", a->id);
         }
@@ -1182,6 +1203,9 @@ write_attribute(attribute_t *a, bool ignore_delay)
 
     /* We will check all peers' uuids shortly, so initialize this to false */
     a->unknown_peer_uuids = FALSE;
+
+    /* Attribute will be written shortly, so clear forced write flag */
+    a->force_write = FALSE;
 
     /* Make the table for the attribute trap */
     alert_attribute_value = g_hash_table_new_full(crm_strcase_hash,

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -92,6 +92,8 @@ typedef struct attribute_s {
 
     char *user;
 
+    gboolean force_write; /* Flag for updating attribute by ignoring delay */
+
 } attribute_t;
 
 typedef struct attribute_value_s {

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -197,6 +197,7 @@ pid_t pcmk_locate_sbd(void);
 #  define F_ATTRD_RESOURCE          "attr_resource"
 #  define F_ATTRD_OPERATION         "attr_clear_operation"
 #  define F_ATTRD_INTERVAL          "attr_clear_interval"
+#  define F_ATTRD_IS_FORCE_WRITE "attrd_is_force_write"
 
 /* attrd operations */
 #  define ATTRD_OP_PEER_REMOVE   "peer-remove"


### PR DESCRIPTION
Hi All,

When clusters that do not use STONITH are disconnected, when they are integrated, the updating of attributes with delays is delayed.
For this reason, the following events reported in Bugzilla occur.

 - https://bugs.clusterlabs.org/show_bug.cgi?id=5358

It is a patch that uses attrd's sync-response message to update attributes with ignoring delays.
However, even with this patch, if attrd's election is delayed, the problem can not be improved but it works quite well.

Further improvement may be necessary for attrd 's election delay, but first we will send a patch.

 * Even if this patch is applied, if it seems that election is delayed frequently, I think that setting the transition-delay (crmd-transition-delay) parameter is the only solution at this time.

Best Regards,
Hideo Yamauchi.

