### PR TITLE
Test: cts: the remote resource being probed to be already running counts as a success

### DIFF
--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -2814,7 +2814,7 @@ class RemoteDriver(CTSTest):
         watch.setwatch()
         pats.append(self.templates["Pat:RscOpOK"] % ("start", self.remote_node))
         if self.remote_rsc_added == 1:
-            pats.append(self.templates["Pat:RscRemoteOpOK"] % ("start", self.remote_rsc, self.remote_node))
+            pats.append(self.templates["Pat:RscRemoteOpOK"] % ("(start|probe)", self.remote_rsc, self.remote_node))
 
         # start the remote node again watch it integrate back into cluster.
         self.start_pcmk_remote(node)


### PR DESCRIPTION
The state file of the dummy resource running on the remote node will
very likely get stalled in there when the remote node gets fenced. Late
on the probe operation will detect the dummy resource is already
running. This should count as a success as well.