### PR TITLE
CI: kick off .gitlab-ci.yml for integration with GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,270 @@
+# Copyright 2018 Red Hat, Inc.
+# Author: Jan Pokorny <jpokorny@redhat.com>
+# Part of pacemaker project
+# SPDX-License-Identifier: FSFAP
+
+# Conventions:
+# 0/ subject to change: compatibility with GitLab (CE) as old as 10.8
+# 1/ heavy reuse (compatible map merges for now, see fedora-rawhide example)
+# 2/ consolidated prefixes for custom variable names: GLOBAL_* and LOCAL_*
+
+variables:
+  GIT_DEPTH: "16"  # nice-to-have automatic "bisect" for even more convenience
+
+stages:
+  - buildenv
+  - build
+  - test
+
+# currently, 1:1 with the eponymous stage
+.buildenv: &buildenv-anchor
+  stage: buildenv
+
+# currently, subset of all jobs pertaining "build" stage
+.compilation: &compilation-anchor
+  variables:
+    GLOBAL_COMPILATION: "1"  # bogus content so that this anchor is not empty
+  # only since GitLab 11.4
+  #  changes:
+  #    - "configure.ac"
+  #    - "**/*.[ch]"
+  #    - "**/*.xml"
+  #    - "**/*.xsl"
+  #    - "**/Makefile.am"
+  #    - ".gitlab-ci.yml"
+
+
+#
+# Fedora Rawhide
+#
+#
+.fedora-rawhide: &fedora-rawhide-anchor
+  tags:
+    - docker
+  image: fedora:rawhide
+
+.fedora-rawhide-variables-rpm: &fedora-rawhide-variables-rpm-anchor
+  # below are captured major sets of packages that need to be installed on top
+  # of what the base image contains; some packages named individually later;
+  # transitive dependencies preferably kept at minimum, i.e., w/o proliferation
+  GLOBAL_RPM_BR_BASIC:          autoconf
+                                automake
+                                pkgconf-pkg-config
+                                libtool
+                                libtool-ltdl-devel
+                                make
+  # with these two, first word denotes also the derived value of CC variable
+  GLOBAL_RPM_BR_GCC:            gcc
+  GLOBAL_RPM_BR_CLANG:          clang  # compiler-rt  # for when with coverage
+  GLOBAL_RPM_BR_LIBS_PLAIN:     libuuid-devel
+                                libxslt-devel
+                                bzip2-devel
+  # note a special trick using \v escaped character, since it's not in IFS
+  # (word separators) in Bash, while fulfilling the requirements in libdnf
+  # (cf. https://github.com/rpm-software-management/libdnf/pull/476)
+  GLOBAL_RPM_BR_LIBS_PKGCONFIG: "pkgconfig(glib-2.0)\v>=2.16.0
+                                pkgconfig(libxml-2.0)
+                                pkgconfig(libqb)\v>=0.13
+                                pkgconfig(libcpg)"
+  GLOBAL_RPM_REQ_LIBS:          bzip2-libs glib2  # not dragged transitively
+
+.fedora-rawhide-gcc: &fedora-rawhide-gcc-anchor
+  <<: *fedora-rawhide-anchor  #extends: .fedora-rawhide
+  variables:
+    <<: *fedora-rawhide-variables-rpm-anchor
+    LOCAL_RPM_COMPILER:  $GLOBAL_RPM_BR_GCC
+    LOCAL_WITH_COVERAGE: --with-coverage
+
+.fedora-rawhide-clang: &fedora-rawhide-clang-anchor
+  <<: *fedora-rawhide-anchor  #extends: .fedora-rawhide
+  variables:
+    <<: *fedora-rawhide-variables-rpm-anchor
+    LOCAL_RPM_COMPILER:  $GLOBAL_RPM_BR_CLANG
+    LOCAL_WITH_COVERAGE: ""  # override from enabling in GCC case for now
+
+# buildenv
+
+buildenv:fedora-rawhide:info:
+  # to gather some info about the image itself/container settings
+  <<: *buildenv-anchor  #extends: .buildenv
+  <<: *fedora-rawhide-anchor  #extends: .fedora-rawhide
+  variables:
+    GIT_STRATEGY: "none"  # invariant stage, not project dependence at all
+  script:
+   - cat /proc/meminfo | grep Free
+   - df -H
+   - lsblk
+   - nproc
+   - ulimit -a
+   - uname -r
+   - dnf --version
+
+buildenv:fedora-rawhide:rpms:
+  # primarily to download RPMs, but alas, "download" plugin not baked into image
+  <<: *buildenv-anchor  #extends: .buildenv
+  <<: *fedora-rawhide-anchor  #extends: .fedora-rawhide
+  variables:
+    <<: *fedora-rawhide-variables-rpm-anchor
+    GIT_STRATEGY: "none"  # invariant stage, not project dependence at all
+  cache:
+    key: "fedora-rawhide-dnf"
+    paths:
+      - ".cache/fedora-rawhide/dnf/rawhide-*"
+      - "xml/.relaxng.org/relaxng.rng"
+  script:
+    - mkdir -p .cache/fedora-rawhide/dnf xml/.relaxng.org
+    - pushd .cache/fedora-rawhide
+    - mv dnf/rawhide-* /var/cache/dnf 2>/dev/null || true
+    - dnf-custom() { timeout 192 dnf -y --noplugins --nodocs
+                                 --setopt=tsflags=test
+                                 --setopt=install_weak_deps=0
+                                 --setopt=keepcache=1
+                                 --setopt=autocheck_running_kernel=0
+                                 --disablerepo='*' --enablerepo=rawhide "$@"; };
+      dnf-custom install $GLOBAL_RPM_BR_BASIC
+                         $GLOBAL_RPM_BR_GCC
+                         $GLOBAL_RPM_BR_CLANG
+                         $GLOBAL_RPM_BR_LIBS_PLAIN
+                         $GLOBAL_RPM_BR_LIBS_PKGCONFIG
+                         $GLOBAL_RPM_REQ_LIBS
+                         findutils
+                         libxml libxslt
+                         psmisc which
+                         gcovr
+    - mv /var/cache/dnf/rawhide-* dnf
+    - popd
+    # we don't have any other warm-up-cache job around, so piggyback it here
+    - test -s xml/.relaxng.org/relaxng.rng 2>/dev/null
+         || curl -SsLo xml/.relaxng.org/relaxng.rng
+            'http://relaxng.org/relaxng.rng'
+
+# build
+
+maint:fedora-rawhide:
+  # to run some compilation-less checks
+  <<: *fedora-rawhide-anchor  #extends: .fedora-rawhide
+  stage: build
+  cache:
+    key: "fedora-rawhide-dnf"
+    policy: pull
+    paths:
+      - ".cache/fedora-rawhide/dnf/rawhide-*"
+      - "xml/.relaxng.org/relaxng.rng"
+  before_script:
+    - mkdir -p .cache/fedora-rawhide/dnf
+    - pushd .cache/fedora-rawhide
+    - mv dnf/rawhide-* /var/cache/dnf 2>/dev/null || true
+    - dnf-custom() { timeout 96 dnf -y --cacheonly --noplugins --nodocs
+                                --setopt=install_weak_deps=0
+                                --setopt=autocheck_running_kernel=0
+                                --disablerepo='*' --enablerepo=rawhide "$@"; };
+      dnf-custom install findutils
+                         make
+                         libxml
+                         libxslt
+    - popd
+    - ( cd xml;
+        { cat Makefile.am; printf 'hack_rng\x3a %s' '${RNG_generated}'; }
+          | make -f- top_srcdir=$(pwd)/.. top_builddir=$(pwd)/.. hack_rng )
+
+  script:
+   - echo 'looking for presence of control characters...';
+      { git ls-files
+        | xargs grep -Ensv "^([^[:cntrl:]]*|$(printf '\t'))*$"||:; } 2>/dev/null
+        | { ! grep -Ev '^Binary file' && echo 'ALL OK'; };
+
+   # ./regression.sh && ./regression.sh -B && ./regression.sh -S && {
+   - cd xml;
+     ./regression.sh && ./regression.sh -B  && {
+       schemas=; for schema in *.rng; do
+         case ${schema} in *cibtr*);; *)schemas="${schemas} ${schema}";; esac;
+       done;
+       test -s .relaxng.org/relaxng.rng 2>/dev/null
+         || curl --create-dirs -Lo .relaxng.org/relaxng.rng
+            'http://relaxng.org/relaxng.rng';
+       xmllint --noout --relaxng .relaxng.org/relaxng.rng ${schemas};
+     }
+
+build:fedora-rawhide:gcc: &build-fedora-rawhide-gcc-anchor
+  # to build using GCC
+  <<: *compilation-anchor  #extends: .compilation
+  <<: *fedora-rawhide-gcc-anchor  #extends: .fedora-rawhide-gcc
+  stage: build
+  cache:
+    key: "fedora-rawhide-dnf"
+    policy: pull
+    paths:
+      - ".cache/fedora-rawhide/dnf/rawhide-*"
+  artifacts:
+    name: "fedora-rawhide-gcc-$CI_COMMIT_REF_SLUG"
+    untracked: true
+    expire_in: "10h"
+  before_script:
+    - mkdir -p .cache/fedora-rawhide/dnf
+    - pushd .cache/fedora-rawhide
+    - mv dnf/rawhide-* /var/cache/dnf 2>/dev/null || true
+    - dnf-custom() { timeout 96 dnf -y --cacheonly --noplugins --nodocs
+                                --setopt=install_weak_deps=0
+                                --setopt=autocheck_running_kernel=0
+                                --disablerepo='*' --enablerepo=rawhide "$@"; };
+      dnf-custom install $GLOBAL_RPM_BR_BASIC
+                         $LOCAL_RPM_COMPILER
+                         $GLOBAL_RPM_BR_LIBS_PLAIN
+                         $GLOBAL_RPM_BR_LIBS_PKGCONFIG
+    - popd
+  script:
+    - ./autogen.sh
+    - CC=$(echo $LOCAL_RPM_COMPILER | cut -d ' ' -f1)
+      ./configure --enable-silent-rules $LOCAL_WITH_COVERAGE
+      || { cat config.log; false; }
+    - timeout 480 make -j$(nproc)  # -j$(($(nproc) + 1)) all
+    - find \( -name '*.l[ao]' -o -name 'config.*' -o -name configure -o -name
+        Makefile.in -o -name Makefile \) -delete  # *.o need to remain for test
+
+build:fedora-rawhide:clang:
+  # to build using Clang
+  <<: *build-fedora-rawhide-gcc-anchor  #extends build:fedora-rawhide:gcc
+  <<: *fedora-rawhide-clang-anchor  #extends: .fedora-rawhide-clang
+
+# test
+
+test:fedora-rawhide:gcc: &test-fedora-rawhide-gcc-anchor
+  # to test the result of GCC build + measure coverage for that
+  <<: *compilation-anchor  #extends: .compilation
+  <<: *fedora-rawhide-gcc-anchor  #extends: .fedora-rawhide-gcc
+  stage: test
+  cache:
+    key: "fedora-rawhide-dnf"
+    policy: pull
+    paths:
+      - ".cache/fedora-rawhide/dnf/rawhide-*"
+  dependencies:
+   - build:fedora-rawhide:gcc
+  before_script:
+    - mkdir -p .cache/fedora-rawhide/dnf
+    - pushd .cache/fedora-rawhide
+    - mv dnf/rawhide-* /var/cache/dnf 2>/dev/null || true
+    - dnf-custom() { timeout 96 dnf -y --cacheonly --noplugins --nodocs
+                                --setopt=install_weak_deps=0
+                                --setopt=autocheck_running_kernel=0
+                                --disablerepo='*' --enablerepo=rawhide "$@"; };
+      dnf-custom install $LOCAL_RPM_COMPILER
+                         $GLOBAL_RPM_BR_LIBS_PLAIN
+                         $GLOBAL_RPM_BR_LIBS_PKGCONFIG
+                         psmisc which
+                         $(test -z "$LOCAL_WITH_COVERAGE" || echo gcovr)
+                         findutils
+    - popd
+  script:
+    - timeout 600 ./cts/cts-regression -V cli scheduler
+  after_script:
+    - gcovr -r .
+    - find -name 'core*' || true
+  coverage: '/^TOTAL.*\s+(\d+\%)$/'
+
+test:fedora-rawhide:clang:
+  # to test the result of Clang build (+ possibly measure coverage for that)
+  <<: *test-fedora-rawhide-gcc-anchor  #extends: test:fedora-rawhide:gcc
+  <<: *fedora-rawhide-clang-anchor  #extends: .fedora-rawhide-clang
+  dependencies:
+    - build:fedora-rawhide:clang


### PR DESCRIPTION
We start with a matrix similar to that in .travis.yml:
* build + tests, using
  - gcc
  - clang
* various compilation-free immediate maintenance checks

All using Fedora Rawhide, for various reasons:
- spot the possible breakages down the line early
  (incompatibility in the surrounding software, etc.)
- is reasonably trimmed down (now that glibc-langpacks-all
  doesn't hog the installation)
- close familiarity on the side of developer(s), at least me :-)

As an extra, experimental measure, we put some hard time limits
on some time-criticial execution, since when they get breached
regularly, we shall reconsider whether just to bump that value
or to change the approach/restructure whole pipeline.
Conversely, when we are blocked on an RPM repo mirror, we
shall rather give up early.

Another notable point is trying hard to cache the floating bits,
so that we, e.g., do not have to run the full round trip to
redownload the packages from an RPM repo mirror all the time.
And yet another, we don't trigger full-fledged build + test
jobs when there's not reason -- neither of relevant source
files got changed, meaning another optimization for as
lightweight testing as possible.

Unlike with .travis.yml, some properties of the CI run are configured
directly in the web interface of the project within GitLab instance
(e.g. CI verdict notifications).

Note that thanks to the staged approach, it might be viable (cf.
build-once-reuse-arbitrarily) to consider replaying some very basic
two node scenarios, for instance; all that's needed:
- addressability of the other peer (introspection via API?)
- ability to run corosync with some very loose parameters
  (note that plain udpu appears more container-friendly
  than kronosnet mediation)
- ssh-based inter-communication?
- way to synchronize initially (since even within the same stage,
  the individual starts may be triggered in a lockstep for waiting
  on free capacities)

TODO:
- extend the range of tests ("exec" set omitted as it requires
  more dependencies and perhaps some extra fiddling)
- verify coverage measurement works as expected
  (test jobs seems to regenerate binaires lazily, perhaps because
  we trim down the artifacts carried between stages, and hence
  possibly without proper flags?)
- fix coverage not working with clang
- generate coverage report in a nice format to be stored
  as an artifact for later perusal
- possibly extend over other distributions (Debian/Ubuntu ecosystem
  is satisfactorily saturated with Travis CI, though, IMHO)