### PR TITLE
CI: travis: disable selfchecks of XSL regression for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ script:
         | { ! grep -Ev '^Binary file' && echo 'ALL OK'; };
     } && (
       cd xml;
-      ./regression.sh && ./regression.sh -B && ./regression.sh -S && {
+      ./regression.sh && ./regression.sh -B && {
         schemas=; for schema in *.rng; do
           case ${schema} in *cibtr*);; *)schemas="${schemas} ${schema}";; esac;
         done;


### PR DESCRIPTION
Caused with a permanent redirect to https URI at relaxng.org.