### PR TITLE
Test: cts: simulate failure of pacemaker_remoted by freezing it with SIGSTOP

### DIFF
--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -2697,13 +2697,11 @@ class RemoteDriver(CTSTest):
                 self.pcmk_started = 1
                 break
 
-    def kill_pcmk_remote(self, node):
+    def freeze_pcmk_remote(self, node):
         """ Simulate a Pacemaker Remote daemon failure. """
 
-        # We kill the process to prevent a graceful stop,
-        # then stop it to prevent the OS from restarting it.
-        self.rsh(node, "killall -9 pacemaker-remoted")
-        self.stop_pcmk_remote(node)
+        # We freeze the process.
+        self.rsh(node, "killall -STOP pacemaker-remoted")
 
     def start_metal(self, node):
         pcmk_started = 0
@@ -2794,9 +2792,9 @@ class RemoteDriver(CTSTest):
         watch = self.create_watch(watchpats, 120)
         watch.setwatch()
 
-        # force stop the pcmk remote daemon. this will result in fencing
+        # freeze the pcmk remote daemon. this will result in fencing
         self.debug("Force stopped active remote node")
-        self.kill_pcmk_remote(node)
+        self.freeze_pcmk_remote(node)
 
         self.debug("Waiting for remote node to be fenced.")
         self.set_timer("remoteMetalFence")

--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -2905,14 +2905,14 @@ class RemoteDriver(CTSTest):
 
             # Remove dummy resource added for remote node tests
             self.debug("Cleaning up dummy rsc put on remote node")
-            self.rsh(node, "crm_resource -U -r %s" % self.remote_rsc)
+            self.rsh(self.get_othernode(node), "crm_resource -U -r %s" % self.remote_rsc)
             self.del_rsc(node, self.remote_rsc)
 
         if self.remote_node_added == 1:
 
             # Remove remote node's connection resource
             self.debug("Cleaning up remote node connection resource")
-            self.rsh(node, "crm_resource -U -r %s" % (self.remote_node))
+            self.rsh(self.get_othernode(node), "crm_resource -U -r %s" % (self.remote_node))
             self.del_rsc(node, self.remote_node)
 
         watch.lookforall()

--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -2703,6 +2703,10 @@ class RemoteDriver(CTSTest):
         # We freeze the process.
         self.rsh(node, "killall -STOP pacemaker-remoted")
 
+    def resume_pcmk_remote(self, node):
+        # We resume the process.
+        self.rsh(node, "killall -CONT pacemaker-remoted")
+
     def start_metal(self, node):
         pcmk_started = 0
 
@@ -2890,6 +2894,8 @@ class RemoteDriver(CTSTest):
             pats.append(self.templates["Pat:RscOpOK"] % ("stop", self.remote_node))
 
         self.set_timer("remoteMetalCleanup")
+
+        self.resume_pcmk_remote(node)
 
         if self.remote_use_reconnect_interval:
             self.debug("Cleaning up re-check interval")


### PR DESCRIPTION
Previously, failure of pacemaker_remoted was simulated by sending
SIGKILL and issuing additional stop to pacemaker_remote.service. But
stop of pacemaker_remote.service would also result in stop of
sbd_remote.service if used, which'd practically leave noone eating the
poison pill.