### PR TITLE
Mid : attrd: Ignoring delayed updating of attributes when integrating disjointed clusters without stonith.

### DIFF
--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -875,11 +875,11 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
 
     } else {
         if (is_force_write && a->timeout_ms && a->timer) {
- 	    /* Save forced writing and set change flag. */
- 	    /* The actual attribute is written by Writer after election. */
- 	    crm_trace("Unchanged %s[%s] from %s is %s(Set the forced write flag)", attr, host, peer->uname, value);
- 	    a->force_write = TRUE;
- 	} else {
+            /* Save forced writing and set change flag. */
+            /* The actual attribute is written by Writer after election. */
+            crm_trace("Unchanged %s[%s] from %s is %s(Set the forced write flag)", attr, host, peer->uname, value);
+            a->force_write = TRUE;
+        } else {
             crm_trace("Unchanged %s[%s] from %s is %s", attr, host, peer->uname, value);
         }
     }

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -92,6 +92,8 @@ typedef struct attribute_s {
 
     char *user;
 
+    gboolean force_write; /* Flag for updating attribute by ignoring delay */
+
 } attribute_t;
 
 typedef struct attribute_value_s {

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -196,6 +196,7 @@ pid_t pcmk_locate_sbd(void);
 #  define F_ATTRD_RESOURCE          "attr_resource"
 #  define F_ATTRD_OPERATION         "attr_clear_operation"
 #  define F_ATTRD_INTERVAL          "attr_clear_interval"
+#  define F_ATTRD_IS_FORCE_WRITE "attrd_is_force_write"
 
 /* attrd operations */
 #  define ATTRD_OP_PEER_REMOVE   "peer-remove"


### PR DESCRIPTION
Hi All,

This PR is a modified version of the content discussed in the next PR.
 - https://github.com/ClusterLabs/pacemaker/pull/1625

Currently, this patch works quite as expected, but it is not perfect.
If election of attrd is delayed and problems arise, please set the transition-delay parameter.

Best Regards,
Hideo Yamauchi.
