### PR TITLE
Bug: tools: Fix moving a resource with a lifetime constraint

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,270 @@
+# Copyright 2018 Red Hat, Inc.
+# Author: Jan Pokorny <jpokorny@redhat.com>
+# Part of pacemaker project
+# SPDX-License-Identifier: FSFAP
+
+# Conventions:
+# 0/ subject to change: compatibility with GitLab (CE) as old as 10.8
+# 1/ heavy reuse (compatible map merges for now, see fedora-rawhide example)
+# 2/ consolidated prefixes for custom variable names: GLOBAL_* and LOCAL_*
+
+variables:
+  GIT_DEPTH: "16"  # nice-to-have automatic "bisect" for even more convenience
+
+stages:
+  - buildenv
+  - build
+  - test
+
+# currently, 1:1 with the eponymous stage
+.buildenv: &buildenv-anchor
+  stage: buildenv
+
+# currently, subset of all jobs pertaining "build" stage
+.compilation: &compilation-anchor
+  variables:
+    GLOBAL_COMPILATION: "1"  # bogus content so that this anchor is not empty
+  # only since GitLab 11.4
+  #  changes:
+  #    - "configure.ac"
+  #    - "**/*.[ch]"
+  #    - "**/*.xml"
+  #    - "**/*.xsl"
+  #    - "**/Makefile.am"
+  #    - ".gitlab-ci.yml"
+
+
+#
+# Fedora Rawhide
+#
+#
+.fedora-rawhide: &fedora-rawhide-anchor
+  tags:
+    - docker
+  image: fedora:rawhide
+
+.fedora-rawhide-variables-rpm: &fedora-rawhide-variables-rpm-anchor
+  # below are captured major sets of packages that need to be installed on top
+  # of what the base image contains; some packages named individually later;
+  # transitive dependencies preferably kept at minimum, i.e., w/o proliferation
+  GLOBAL_RPM_BR_BASIC:          autoconf
+                                automake
+                                pkgconf-pkg-config
+                                libtool
+                                libtool-ltdl-devel
+                                make
+  # with these two, first word denotes also the derived value of CC variable
+  GLOBAL_RPM_BR_GCC:            gcc
+  GLOBAL_RPM_BR_CLANG:          clang  # compiler-rt  # for when with coverage
+  GLOBAL_RPM_BR_LIBS_PLAIN:     libuuid-devel
+                                libxslt-devel
+                                bzip2-devel
+  # note a special trick using \v escaped character, since it's not in IFS
+  # (word separators) in Bash, while fulfilling the requirements in libdnf
+  # (cf. https://github.com/rpm-software-management/libdnf/pull/476)
+  GLOBAL_RPM_BR_LIBS_PKGCONFIG: "pkgconfig(glib-2.0)\v>=2.16.0
+                                pkgconfig(libxml-2.0)
+                                pkgconfig(libqb)\v>=0.13
+                                pkgconfig(libcpg)"
+  GLOBAL_RPM_REQ_LIBS:          bzip2-libs glib2  # not dragged transitively
+
+.fedora-rawhide-gcc: &fedora-rawhide-gcc-anchor
+  <<: *fedora-rawhide-anchor  #extends: .fedora-rawhide
+  variables:
+    <<: *fedora-rawhide-variables-rpm-anchor
+    LOCAL_RPM_COMPILER:  $GLOBAL_RPM_BR_GCC
+    LOCAL_WITH_COVERAGE: --with-coverage
+
+.fedora-rawhide-clang: &fedora-rawhide-clang-anchor
+  <<: *fedora-rawhide-anchor  #extends: .fedora-rawhide
+  variables:
+    <<: *fedora-rawhide-variables-rpm-anchor
+    LOCAL_RPM_COMPILER:  $GLOBAL_RPM_BR_CLANG
+    LOCAL_WITH_COVERAGE: ""  # override from enabling in GCC case for now
+
+# buildenv
+
+buildenv:fedora-rawhide:info:
+  # to gather some info about the image itself/container settings
+  <<: *buildenv-anchor  #extends: .buildenv
+  <<: *fedora-rawhide-anchor  #extends: .fedora-rawhide
+  variables:
+    GIT_STRATEGY: "none"  # invariant stage, not project dependence at all
+  script:
+   - cat /proc/meminfo | grep Free
+   - df -H
+   - lsblk
+   - nproc
+   - ulimit -a
+   - uname -r
+   - dnf --version
+
+buildenv:fedora-rawhide:rpms:
+  # primarily to download RPMs, but alas, "download" plugin not baked into image
+  <<: *buildenv-anchor  #extends: .buildenv
+  <<: *fedora-rawhide-anchor  #extends: .fedora-rawhide
+  variables:
+    <<: *fedora-rawhide-variables-rpm-anchor
+    GIT_STRATEGY: "none"  # invariant stage, not project dependence at all
+  cache:
+    key: "fedora-rawhide-dnf"
+    paths:
+      - ".cache/fedora-rawhide/dnf/rawhide-*"
+      - "xml/.relaxng.org/relaxng.rng"
+  script:
+    - mkdir -p .cache/fedora-rawhide/dnf xml/.relaxng.org
+    - pushd .cache/fedora-rawhide
+    - mv dnf/rawhide-* /var/cache/dnf 2>/dev/null || true
+    - dnf-custom() { timeout 192 dnf -y --noplugins --nodocs
+                                 --setopt=tsflags=test
+                                 --setopt=install_weak_deps=0
+                                 --setopt=keepcache=1
+                                 --setopt=autocheck_running_kernel=0
+                                 --disablerepo='*' --enablerepo=rawhide "$@"; };
+      dnf-custom install $GLOBAL_RPM_BR_BASIC
+                         $GLOBAL_RPM_BR_GCC
+                         $GLOBAL_RPM_BR_CLANG
+                         $GLOBAL_RPM_BR_LIBS_PLAIN
+                         $GLOBAL_RPM_BR_LIBS_PKGCONFIG
+                         $GLOBAL_RPM_REQ_LIBS
+                         findutils
+                         libxml libxslt
+                         psmisc which
+                         gcovr
+    - mv /var/cache/dnf/rawhide-* dnf
+    - popd
+    # we don't have any other warm-up-cache job around, so piggyback it here
+    - test -s xml/.relaxng.org/relaxng.rng 2>/dev/null
+         || curl -SsLo xml/.relaxng.org/relaxng.rng
+            'http://relaxng.org/relaxng.rng'
+
+# build
+
+maint:fedora-rawhide:
+  # to run some compilation-less checks
+  <<: *fedora-rawhide-anchor  #extends: .fedora-rawhide
+  stage: build
+  cache:
+    key: "fedora-rawhide-dnf"
+    policy: pull
+    paths:
+      - ".cache/fedora-rawhide/dnf/rawhide-*"
+      - "xml/.relaxng.org/relaxng.rng"
+  before_script:
+    - mkdir -p .cache/fedora-rawhide/dnf
+    - pushd .cache/fedora-rawhide
+    - mv dnf/rawhide-* /var/cache/dnf 2>/dev/null || true
+    - dnf-custom() { timeout 96 dnf -y --cacheonly --noplugins --nodocs
+                                --setopt=install_weak_deps=0
+                                --setopt=autocheck_running_kernel=0
+                                --disablerepo='*' --enablerepo=rawhide "$@"; };
+      dnf-custom install findutils
+                         make
+                         libxml
+                         libxslt
+    - popd
+    - ( cd xml;
+        { cat Makefile.am; printf 'hack_rng\x3a %s' '${RNG_generated}'; }
+          | make -f- top_srcdir=$(pwd)/.. top_builddir=$(pwd)/.. hack_rng )
+
+  script:
+   - echo 'looking for presence of control characters...';
+      { git ls-files
+        | xargs grep -Ensv "^([^[:cntrl:]]*|$(printf '\t'))*$"||:; } 2>/dev/null
+        | { ! grep -Ev '^Binary file' && echo 'ALL OK'; };
+
+   # ./regression.sh && ./regression.sh -B && ./regression.sh -S && {
+   - cd xml;
+     ./regression.sh && ./regression.sh -B  && {
+       schemas=; for schema in *.rng; do
+         case ${schema} in *cibtr*);; *)schemas="${schemas} ${schema}";; esac;
+       done;
+       test -s .relaxng.org/relaxng.rng 2>/dev/null
+         || curl --create-dirs -Lo .relaxng.org/relaxng.rng
+            'http://relaxng.org/relaxng.rng';
+       xmllint --noout --relaxng .relaxng.org/relaxng.rng ${schemas};
+     }
+
+build:fedora-rawhide:gcc: &build-fedora-rawhide-gcc-anchor
+  # to build using GCC
+  <<: *compilation-anchor  #extends: .compilation
+  <<: *fedora-rawhide-gcc-anchor  #extends: .fedora-rawhide-gcc
+  stage: build
+  cache:
+    key: "fedora-rawhide-dnf"
+    policy: pull
+    paths:
+      - ".cache/fedora-rawhide/dnf/rawhide-*"
+  artifacts:
+    name: "fedora-rawhide-gcc-$CI_COMMIT_REF_SLUG"
+    untracked: true
+    expire_in: "10h"
+  before_script:
+    - mkdir -p .cache/fedora-rawhide/dnf
+    - pushd .cache/fedora-rawhide
+    - mv dnf/rawhide-* /var/cache/dnf 2>/dev/null || true
+    - dnf-custom() { timeout 96 dnf -y --cacheonly --noplugins --nodocs
+                                --setopt=install_weak_deps=0
+                                --setopt=autocheck_running_kernel=0
+                                --disablerepo='*' --enablerepo=rawhide "$@"; };
+      dnf-custom install $GLOBAL_RPM_BR_BASIC
+                         $LOCAL_RPM_COMPILER
+                         $GLOBAL_RPM_BR_LIBS_PLAIN
+                         $GLOBAL_RPM_BR_LIBS_PKGCONFIG
+    - popd
+  script:
+    - ./autogen.sh
+    - CC=$(echo $LOCAL_RPM_COMPILER | cut -d ' ' -f1)
+      ./configure --enable-silent-rules $LOCAL_WITH_COVERAGE
+      || { cat config.log; false; }
+    - timeout 480 make -j$(nproc)  # -j$(($(nproc) + 1)) all
+    - find \( -name '*.l[ao]' -o -name 'config.*' -o -name configure -o -name
+        Makefile.in -o -name Makefile \) -delete  # *.o need to remain for test
+
+build:fedora-rawhide:clang:
+  # to build using Clang
+  <<: *build-fedora-rawhide-gcc-anchor  #extends build:fedora-rawhide:gcc
+  <<: *fedora-rawhide-clang-anchor  #extends: .fedora-rawhide-clang
+
+# test
+
+test:fedora-rawhide:gcc: &test-fedora-rawhide-gcc-anchor
+  # to test the result of GCC build + measure coverage for that
+  <<: *compilation-anchor  #extends: .compilation
+  <<: *fedora-rawhide-gcc-anchor  #extends: .fedora-rawhide-gcc
+  stage: test
+  cache:
+    key: "fedora-rawhide-dnf"
+    policy: pull
+    paths:
+      - ".cache/fedora-rawhide/dnf/rawhide-*"
+  dependencies:
+   - build:fedora-rawhide:gcc
+  before_script:
+    - mkdir -p .cache/fedora-rawhide/dnf
+    - pushd .cache/fedora-rawhide
+    - mv dnf/rawhide-* /var/cache/dnf 2>/dev/null || true
+    - dnf-custom() { timeout 96 dnf -y --cacheonly --noplugins --nodocs
+                                --setopt=install_weak_deps=0
+                                --setopt=autocheck_running_kernel=0
+                                --disablerepo='*' --enablerepo=rawhide "$@"; };
+      dnf-custom install $LOCAL_RPM_COMPILER
+                         $GLOBAL_RPM_BR_LIBS_PLAIN
+                         $GLOBAL_RPM_BR_LIBS_PKGCONFIG
+                         psmisc which
+                         $(test -z "$LOCAL_WITH_COVERAGE" || echo gcovr)
+                         findutils
+    - popd
+  script:
+    - timeout 600 ./cts/cts-regression -V cli scheduler
+  after_script:
+    - gcovr -r .
+    - find -name 'core*' || true
+  coverage: '/^TOTAL.*\s+(\d+\%)$/'
+
+test:fedora-rawhide:clang:
+  # to test the result of Clang build (+ possibly measure coverage for that)
+  <<: *test-fedora-rawhide-gcc-anchor  #extends: test:fedora-rawhide:gcc
+  <<: *fedora-rawhide-clang-anchor  #extends: .fedora-rawhide-clang
+  dependencies:
+    - build:fedora-rawhide:clang

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -2968,3 +2968,101 @@ Deleted 'test-primitive' option: id=test-primitive-meta_attributes-is-managed na
 </cib>
 =#=#=#= End test: Delete resource child meta attribute - OK (0) =#=#=#=
 * Passed: crm_resource   - Delete resource child meta attribute
+=#=#=#= Begin test: Specify a lifetime when moving a resource =#=#=#=
+Migration will take effect until:
+=#=#=#= Current cib after: Specify a lifetime when moving a resource =#=#=#=
+<cib epoch="42" num_updates="0" admin_epoch="1">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+      </node>
+      <node id="node2" uname="node2"/>
+      <node id="node3" uname="node3"/>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+      <clone id="test-clone">
+        <primitive id="test-primitive" class="ocf" provider="pacemaker" type="Dummy">
+          <meta_attributes id="test-primitive-meta_attributes"/>
+        </primitive>
+        <meta_attributes id="test-clone-meta_attributes">
+          <nvpair id="test-clone-meta_attributes-is-managed" name="is-managed" value="true"/>
+        </meta_attributes>
+      </clone>
+    </resources>
+    <constraints>
+      <rsc_location id="cli-prefer-dummy" rsc="dummy" role="Started">
+        <rule id="cli-prefer-rule-dummy" score="INFINITY" boolean-op="and">
+          <expression id="cli-prefer-expr-dummy" attribute="#uname" operation="eq" value="node2" type="string"/>
+          <date_expression id="cli-prefer-lifetime-end-dummy" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Specify a lifetime when moving a resource - OK (0) =#=#=#=
+* Passed: crm_resource   - Specify a lifetime when moving a resource
+=#=#=#= Begin test: Try to move a resource previously moved with a lifetime =#=#=#=
+=#=#=#= Current cib after: Try to move a resource previously moved with a lifetime =#=#=#=
+<cib epoch="44" num_updates="0" admin_epoch="1">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+      </node>
+      <node id="node2" uname="node2"/>
+      <node id="node3" uname="node3"/>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+      <clone id="test-clone">
+        <primitive id="test-primitive" class="ocf" provider="pacemaker" type="Dummy">
+          <meta_attributes id="test-primitive-meta_attributes"/>
+        </primitive>
+        <meta_attributes id="test-clone-meta_attributes">
+          <nvpair id="test-clone-meta_attributes-is-managed" name="is-managed" value="true"/>
+        </meta_attributes>
+      </clone>
+    </resources>
+    <constraints>
+      <rsc_location id="cli-prefer-dummy" rsc="dummy" role="Started" node="node1" score="INFINITY"/>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Try to move a resource previously moved with a lifetime - OK (0) =#=#=#=
+* Passed: crm_resource   - Try to move a resource previously moved with a lifetime

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -2971,7 +2971,7 @@ Deleted 'test-primitive' option: id=test-primitive-meta_attributes-is-managed na
 =#=#=#= Begin test: Specify a lifetime when moving a resource =#=#=#=
 Migration will take effect until:
 =#=#=#= Current cib after: Specify a lifetime when moving a resource =#=#=#=
-<cib epoch="42" num_updates="0" admin_epoch="1">
+<cib epoch="43" num_updates="0" admin_epoch="1">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -3022,7 +3022,7 @@ Migration will take effect until:
 * Passed: crm_resource   - Specify a lifetime when moving a resource
 =#=#=#= Begin test: Try to move a resource previously moved with a lifetime =#=#=#=
 =#=#=#= Current cib after: Try to move a resource previously moved with a lifetime =#=#=#=
-<cib epoch="44" num_updates="0" admin_epoch="1">
+<cib epoch="45" num_updates="0" admin_epoch="1">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -393,6 +393,14 @@ function test_tools() {
     cmd="crm_resource -r test-primitive --meta -d is-managed"
     test_assert $CRM_EX_OK
 
+    desc="Specify a lifetime when moving a resource"
+    cmd="crm_resource -r dummy --move --node node2 --lifetime=PT1S"
+    test_assert $CRM_EX_OK
+
+    desc="Try to move a resource previously moved with a lifetime"
+    cmd="crm_resource -r dummy --move --node node1"
+    test_assert $CRM_EX_OK
+
     unset CIB_shadow_dir
     rm -f "$TMPXML" "$TMPORIG"
 }
@@ -919,6 +927,8 @@ for t in $tests; do
         -e 's|^/tmp/cts-cli\.validity\.bad.xml\.[^:]*:|validity.bad.xml:|'\
         -e 's/^Entity: line [0-9][0-9]*: //'\
         -e 's/\(validation ([0-9][0-9]* of \)[0-9][0-9]*\().*\)/\1X\2/' \
+        -e 's/^Migration will take effect until: .*/Migration will take effect until:/' \
+        -e 's/ end=\"[-: 0123456789]\+Z\?\"/ end=\"\"/' \
         "$TMPFILE" > "${TMPFILE}.$$"
     mv -- "${TMPFILE}.$$" "$TMPFILE"
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -982,10 +982,10 @@ main(int argc, char **argv)
                 rc = -pcmk_err_node_unknown;
                 goto bail;
             }
-            rc = cli_resource_clear(rsc_id, dest->details->uname, NULL, cib_conn);
+            rc = cli_resource_clear(rsc_id, dest->details->uname, NULL, cib_conn, TRUE);
 
         } else {
-            rc = cli_resource_clear(rsc_id, NULL, data_set->nodes, cib_conn);
+            rc = cli_resource_clear(rsc_id, NULL, data_set->nodes, cib_conn, TRUE);
         }
 
     } else if (rsc_cmd == 'M' && host_uname) {

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -38,7 +38,8 @@ extern const char *attr_set_type;
 /* ban */
 int cli_resource_prefer(const char *rsc_id, const char *host, cib_t * cib_conn);
 int cli_resource_ban(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn);
-int cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn);
+int cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn,
+                       bool clear_ban_constraints);
 int cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, const char *rsc, const char *node, bool scope_master);
 
 /* print */

--- a/tools/crm_resource_ban.c
+++ b/tools/crm_resource_ban.c
@@ -228,15 +228,19 @@ resource_clear_node_in_expr(const char *rsc_id, const char *host, cib_t * cib_co
 }
 
 static int
-resource_clear_node_in_location(const char *rsc_id, const char *host, cib_t * cib_conn)
+resource_clear_node_in_location(const char *rsc_id, const char *host, cib_t * cib_conn,
+                                bool clear_ban_constraints)
 {
     int rc = pcmk_ok;
     xmlNode *fragment = NULL;
     xmlNode *location = NULL;
 
     fragment = create_xml_node(NULL, XML_CIB_TAG_CONSTRAINTS);
-    location = create_xml_node(fragment, XML_CONS_TAG_RSC_LOCATION);
-    crm_xml_set_id(location, "cli-ban-%s-on-%s", rsc_id, host);
+
+    if (clear_ban_constraints == TRUE) {
+        location = create_xml_node(fragment, XML_CONS_TAG_RSC_LOCATION);
+        crm_xml_set_id(location, "cli-ban-%s-on-%s", rsc_id, host);
+    }
 
     location = create_xml_node(fragment, XML_CONS_TAG_RSC_LOCATION);
     crm_xml_set_id(location, "cli-prefer-%s", rsc_id);
@@ -255,7 +259,8 @@ resource_clear_node_in_location(const char *rsc_id, const char *host, cib_t * ci
 }
 
 int
-cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn)
+cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn,
+                   bool clear_ban_constraints)
 {
     int rc = pcmk_ok;
 
@@ -271,7 +276,7 @@ cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_
          * to try the second clear method.
          */
         if (rc == pcmk_ok) {
-            rc = resource_clear_node_in_location(rsc_id, host, cib_conn);
+            rc = resource_clear_node_in_location(rsc_id, host, cib_conn, clear_ban_constraints);
         }
 
     } else {
@@ -283,7 +288,7 @@ cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_
         for(; n; n = n->next) {
             node_t *target = n->data;
 
-            rc = cli_resource_clear(rsc_id, target->details->uname, NULL, cib_conn);
+            rc = cli_resource_clear(rsc_id, target->details->uname, NULL, cib_conn, clear_ban_constraints);
             if (rc != pcmk_ok) {
                 break;
             }

--- a/tools/crm_resource_ban.c
+++ b/tools/crm_resource_ban.c
@@ -191,37 +191,56 @@ cli_resource_prefer(const char *rsc_id, const char *host, cib_t * cib_conn)
     return rc;
 }
 
-int
-cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn)
+/* Nodes can be specified two different ways in the CIB, so we have two different
+ * functions to try clearing out any constraints on them:
+ *
+ * (1) The node could be given by attribute=/value= in an expression XML node.
+ * That's what resource_clear_node_in_expr handles.  That XML looks like this:
+ *
+ * <rsc_location id="cli-prefer-dummy" rsc="dummy" role="Started">
+ *   <rule id="cli-prefer-rule-dummy" score="INFINITY" boolean-op="and">
+ *     <expression id="cli-prefer-expr-dummy" attribute="#uname" operation="eq" value="test02" type="string"/>
+ *     <date_expression id="cli-prefer-lifetime-end-dummy" operation="lt" end="2018-12-12 14:05:37 -05:00"/>
+ *   </rule>
+ * </rsc_location>
+ *
+ * (2) The mode could be given by node= in an rsc_location XML node.  That's
+ * what resource_clear_node_in_location handles.  That XML looks like this:
+ *
+ * <rsc_location id="cli-prefer-dummy" rsc="dummy" role="Started" node="node1" score="INFINITY"/>
+ */
+static int
+resource_clear_node_in_expr(const char *rsc_id, const char *host, cib_t * cib_conn)
+{
+    int rc = pcmk_ok;
+    char *xpath_string = NULL;
+
+    xpath_string = crm_strdup_printf("//rsc_location[@id='cli-prefer-%s'][rule[@id='cli-prefer-rule-%s']/expression[@attribute='#uname' and @value='%s']]",
+                                     rsc_id, rsc_id, host);
+
+    rc = cib_conn->cmds->remove(cib_conn, xpath_string, NULL, cib_xpath | cib_options);
+    if (rc == -ENXIO) {
+        rc = pcmk_ok;
+    }
+
+    free(xpath_string);
+    return rc;
+}
+
+static int
+resource_clear_node_in_location(const char *rsc_id, const char *host, cib_t * cib_conn)
 {
     int rc = pcmk_ok;
     xmlNode *fragment = NULL;
     xmlNode *location = NULL;
 
-    if(cib_conn == NULL) {
-        return -ENOTCONN;
-    }
-
     fragment = create_xml_node(NULL, XML_CIB_TAG_CONSTRAINTS);
-
-    if(host) {
-        location = create_xml_node(fragment, XML_CONS_TAG_RSC_LOCATION);
-        crm_xml_set_id(location, "cli-ban-%s-on-%s", rsc_id, host);
-
-    } else {
-        GListPtr n = allnodes;
-        for(; n; n = n->next) {
-            node_t *target = n->data;
-
-            location = create_xml_node(fragment, XML_CONS_TAG_RSC_LOCATION);
-            crm_xml_set_id(location, "cli-ban-%s-on-%s",
-                           rsc_id, target->details->uname);
-        }
-    }
+    location = create_xml_node(fragment, XML_CONS_TAG_RSC_LOCATION);
+    crm_xml_set_id(location, "cli-ban-%s-on-%s", rsc_id, host);
 
     location = create_xml_node(fragment, XML_CONS_TAG_RSC_LOCATION);
     crm_xml_set_id(location, "cli-prefer-%s", rsc_id);
-    if(host && do_force == FALSE) {
+    if (do_force == FALSE) {
         crm_xml_add(location, XML_CIB_TAG_NODE, host);
     }
 
@@ -229,13 +248,48 @@ cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_
     rc = cib_conn->cmds->remove(cib_conn, XML_CIB_TAG_CONSTRAINTS, fragment, cib_options);
     if (rc == -ENXIO) {
         rc = pcmk_ok;
-
-    } else if (rc != pcmk_ok) {
-        goto bail;
     }
 
-  bail:
-    free_xml(fragment);
+    free(fragment);
+    return rc;
+}
+
+int
+cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn)
+{
+    int rc = pcmk_ok;
+
+    if(cib_conn == NULL) {
+        return -ENOTCONN;
+    }
+
+    if (host) {
+        rc = resource_clear_node_in_expr(rsc_id, host, cib_conn);
+
+        /* rc does not tell us whether the previous operation did anything, only
+         * whether it failed or not.  Thus, as long as it did not fail, we need
+         * to try the second clear method.
+         */
+        if (rc == pcmk_ok) {
+            rc = resource_clear_node_in_location(rsc_id, host, cib_conn);
+        }
+
+    } else {
+        GListPtr n = allnodes;
+
+        /* Iterate over all nodes, attempting to clear the constraint from each.
+         * On the first error, abort.
+         */
+        for(; n; n = n->next) {
+            node_t *target = n->data;
+
+            rc = cli_resource_clear(rsc_id, target->details->uname, NULL, cib_conn);
+            if (rc != pcmk_ok) {
+                break;
+            }
+        }
+    }
+
     return rc;
 }
 

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1378,7 +1378,7 @@ cli_resource_restart(pe_resource_t *rsc, const char *host, int timeout_ms,
     }
 
     if (stop_via_ban) {
-        rc = cli_resource_clear(rsc_id, host, NULL, cib);
+        rc = cli_resource_clear(rsc_id, host, NULL, cib, TRUE);
 
     } else if (orig_target_role) {
         rc = cli_resource_update_attribute(rsc, rsc_id, NULL, NULL,
@@ -1460,7 +1460,7 @@ cli_resource_restart(pe_resource_t *rsc, const char *host, int timeout_ms,
 
   failure:
     if (stop_via_ban) {
-        cli_resource_clear(rsc_id, host, NULL, cib);
+        cli_resource_clear(rsc_id, host, NULL, cib, TRUE);
     } else if (orig_target_role) {
         cli_resource_update_attribute(rsc, rsc_id, NULL, NULL,
                                       XML_RSC_ATTR_TARGET_ROLE,
@@ -1874,8 +1874,11 @@ cli_resource_move(resource_t *rsc, const char *rsc_id, const char *host_name,
         }
     }
 
-    /* Clear any previous constraints for 'dest' */
-    cli_resource_clear(rsc_id, dest->details->uname, data_set->nodes, cib);
+    /* Clear any previous prefer constraints across all nodes. */
+    cli_resource_clear(rsc_id, NULL, data_set->nodes, cib, FALSE);
+
+    /* Clear any previous ban constraints on 'dest'. */
+    cli_resource_clear(rsc_id, dest->details->uname, data_set->nodes, cib, TRUE);
 
     /* Record an explicit preference for 'dest' */
     rc = cli_resource_prefer(rsc_id, dest->details->uname, cib);


### PR DESCRIPTION
A node can be specified two different ways - with attribute="#uname"
and value= on an expression XML node, or with node= on a rsc_location
XML node.  Both possibilities need to be considered when attempting to
clear an existing constraint.

cli_resource_clear was previously only considering the second case.
This patch rearranges the code to allow for trying both, and then adds
the code to try the first case by constructing a different blob of XML
to match.

See rhbz#1648620