### PR TITLE
* Test: cts: DummySD --> pacemaker-cts-dummyd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2068,6 +2068,7 @@ cts/Makefile					        	\
 	cts/benchmark/Makefile					\
 	cts/benchmark/clubench					\
 	cts/lxc_autogen.sh					\
+	cts/pacemaker-cts-dummyd.service			\
 cib/Makefile							\
 attrd/Makefile							\
 crmd/Makefile							\
@@ -2129,6 +2130,8 @@ tools/Makefile							\
 xml/Makefile							\
 lib/gnu/Makefile						\
 		)
+
+AC_CONFIG_FILES([cts/pacemaker-cts-dummyd], [chmod +x cts/pacemaker-cts-dummyd])
 
 dnl Now process the entire list of files added by previous
 dnl  calls to AC_CONFIG_FILES()

--- a/cts/Makefile.am
+++ b/cts/Makefile.am
@@ -42,13 +42,14 @@ ctslib_PYTHON	=	__init__.py		\
 			remote.py		\
 			watcher.py
 
-cts_DATA	=	README.md cts.supp
+cts_DATA	=	README.md cts.supp pacemaker-cts-dummyd.service
 
 cts_SCRIPTS	=	cts		\
 			CTSlab.py		\
 			lxc_autogen.sh	\
 			LSBDummy		\
 			HBDummy		\
+			pacemaker-cts-dummyd	\
 			$(top_srcdir)/fencing/fence_dummy
 
 SUBDIRS	= benchmark

--- a/cts/pacemaker-cts-dummyd.in
+++ b/cts/pacemaker-cts-dummyd.in
@@ -1,0 +1,58 @@
+#!@PYTHON@
+""" Slow-starting idle daemon that notifies systemd when it starts
+"""
+
+# Pacemaker targets compatibility with Python 2.7 and 3.2+
+from __future__ import print_function, unicode_literals, absolute_import, division
+
+__copyright__ = "Copyright 2014-2018 Andrew Beekhof <andrew@beekhof.net>"
+__license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
+
+import sys
+import time
+import signal
+import subprocess
+have_systemd_daemon = True
+try:
+    import systemd.daemon
+except ImportError:
+    have_systemd_daemon = False
+
+delay = None
+
+def parse_args():
+    global delay
+
+    # Lone argument is a number of seconds to delay start and stop
+    if len(sys.argv) > 0:
+        try:
+            delay = float(sys.argv[1])
+        except ValueError:
+            delay = None
+
+
+def twiddle():
+    global delay
+
+    if delay is not None:
+        time.sleep(delay)
+
+
+def bye(signum, frame):
+    twiddle()
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+
+    parse_args()
+    signal.signal(signal.SIGTERM, bye)
+    twiddle()
+    if have_systemd_daemon:
+        systemd.daemon.notify("READY=1")
+    else:
+        subprocess.call(["systemd-notify", "READY=1"])
+
+    # This isn't a "proper" daemon, but that would be overkill for testing purposes
+    while True:
+        time.sleep(600.0)

--- a/cts/pacemaker-cts-dummyd.service.in
+++ b/cts/pacemaker-cts-dummyd.service.in
@@ -1,0 +1,6 @@
+[Unit]
+Description=Dummy daemon for Pacemaker CTS testing
+
+[Service]
+Type=notify
+ExecStart=@CRM_DAEMON_DIR@/pacemaker-cts-dummyd 10


### PR DESCRIPTION
- This pull request complements the pull request #1639. The overall idea
is to replace the systemd.daemon.notify python method with its bash
analog, because the systemd.daemon is provided by neither of SUSE
Enterprise Linuxes. This implementation not only replaces the
method, but also backports the pacemaker-cts-dummyd files from the master
branch.