### PR TITLE
Minor enhancements to pacemaker-attrd

### DIFF
--- a/daemons/attrd/attrd_alerts.c
+++ b/daemons/attrd/attrd_alerts.c
@@ -127,7 +127,7 @@ attrd_read_options(gpointer user_data)
 void
 attrd_cib_updated_cb(const char *event, xmlNode * msg)
 {
-    if (crm_patchset_contains_alert(msg, FALSE)) {
+    if (!attrd_shutting_down() && crm_patchset_contains_alert(msg, FALSE)) {
         mainloop_set_trigger(attrd_config_read);
     }
 }

--- a/daemons/attrd/attrd_alerts.c
+++ b/daemons/attrd/attrd_alerts.c
@@ -111,19 +111,16 @@ attrd_read_options(gpointer user_data)
 {
     int call_id;
 
-    if (the_cib) {
-        call_id = the_cib->cmds->query(the_cib, XPATH_ALERTS, NULL,
-                                       cib_xpath | cib_scope_local);
+    CRM_CHECK(the_cib != NULL, return TRUE);
 
-        the_cib->cmds->register_callback_full(the_cib, call_id, 120, FALSE,
-                                              NULL,
-                                              "config_query_callback",
-                                              config_query_callback, free);
+    call_id = the_cib->cmds->query(the_cib, XPATH_ALERTS, NULL,
+                                   cib_xpath | cib_scope_local);
 
-        crm_trace("Querying the CIB... call %d", call_id);
-    } else {
-        crm_err("Could not check for alerts configuration: CIB connection not active");
-    }
+    the_cib->cmds->register_callback_full(the_cib, call_id, 120, FALSE, NULL,
+                                          "config_query_callback",
+                                          config_query_callback, free);
+
+    crm_trace("Querying the CIB... call %d", call_id);
     return TRUE;
 }
 

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -1163,11 +1163,8 @@ write_attribute(attribute_t *a, bool ignore_delay)
     if (!a->is_private) {
 
         /* Defer the write if now's not a good time */
-        if (the_cib == NULL) {
-            crm_info("Write out of '%s' delayed: cib not connected", a->id);
-            return;
-
-        } else if (a->update && (a->update < last_cib_op_done)) {
+        CRM_CHECK(the_cib != NULL, return);
+        if (a->update && (a->update < last_cib_op_done)) {
             crm_info("Write out of '%s' continuing: update %d considered lost", a->id, a->update);
 
         } else if (a->update) {

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -569,6 +569,14 @@ attrd_peer_message(crm_node_t *peer, xmlNode *xml)
         return;
     }
 
+    if (attrd_shutting_down()) {
+        /* If we're shutting down, we want to continue responding to election
+         * ops as long as we're a cluster member (because our vote may be
+         * needed). Ignore all other messages.
+         */
+        return;
+    }
+
     peer_won = attrd_check_for_new_writer(peer, xml);
 
     if (safe_str_eq(op, ATTRD_OP_UPDATE) || safe_str_eq(op, ATTRD_OP_UPDATE_BOTH) || safe_str_eq(op, ATTRD_OP_UPDATE_DELAY)) {

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -1172,6 +1172,7 @@ write_attribute(attribute_t *a, bool ignore_delay)
         CRM_CHECK(the_cib != NULL, return);
         if (a->update && (a->update < last_cib_op_done)) {
             crm_info("Write out of '%s' continuing: update %d considered lost", a->id, a->update);
+            a->update = 0; // Don't log this message again
 
         } else if (a->update) {
             crm_info("Write out of '%s' delayed: update %d in progress", a->id, a->update);

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -297,8 +297,6 @@ attrd_client_update(xmlNode *xml)
         }
     }
 
-    attrd_start_election_if_needed();
-
     crm_debug("Broadcasting %s[%s]=%s%s", attr, host, value,
               (attrd_election_won()? " (writer)" : ""));
 

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -1277,7 +1277,8 @@ write_attribute(attribute_t *a, bool ignore_delay)
                  a->update, cib_updates, s_if_plural(cib_updates),
                  a->id, (a->uuid? a->uuid : "n/a"), (a->set? a->set : "n/a"));
 
-        the_cib->cmds->register_callback_full(the_cib, a->update, 120, FALSE,
+        the_cib->cmds->register_callback_full(the_cib, a->update,
+                                              CIB_OP_TIMEOUT_S, FALSE,
                                               strdup(a->id),
                                               "attrd_cib_callback",
                                               attrd_cib_callback, free);

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -1018,7 +1018,13 @@ attrd_cib_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
     }
 
     if (a->changed && attrd_election_won()) {
-        /* If we're re-attempting a write because the original failed, delay
+        if (rc == pcmk_ok) {
+            /* We deferred a write of a new update because this update was in
+             * progress. Write out the new value without additional delay.
+             */
+            write_attribute(a, FALSE);
+
+        /* We're re-attempting a write because the original failed; delay
          * the next attempt so we don't potentially flood the CIB manager
          * and logs with a zillion attempts per second.
          *
@@ -1027,7 +1033,7 @@ attrd_cib_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
          * if all peers similarly fail to write this attribute (which may
          * indicate a corrupted attribute entry rather than a CIB issue).
          */
-        if (a->timer) {
+        } else if (a->timer) {
             // Attribute has a dampening value, so use that as delay
             if (!mainloop_timer_running(a->timer)) {
                 crm_trace("Delayed re-attempted write (%dms) for %s",
@@ -1067,7 +1073,7 @@ write_attributes(bool all, bool ignore_delay)
             /* When forced write flag is set, ignore delay. */
             write_attribute(a, (a->force_write ? TRUE : ignore_delay));
         } else {
-            crm_debug("Skipping unchanged attribute %s", a->id);
+            crm_trace("Skipping unchanged attribute %s", a->id);
         }
     }
 }

--- a/daemons/attrd/attrd_elections.c
+++ b/daemons/attrd/attrd_elections.c
@@ -32,7 +32,9 @@ void
 attrd_start_election_if_needed()
 {
     if ((peer_writer == NULL)
-        && (election_state(writer) != election_in_progress)) {
+        && (election_state(writer) != election_in_progress)
+        && !attrd_shutting_down()) {
+
         crm_info("Starting an election to determine the writer");
         election_vote(writer);
     }
@@ -51,7 +53,10 @@ attrd_handle_election_op(const crm_node_t *peer, xmlNode *xml)
     enum election_result previous = election_state(writer);
 
     crm_xml_add(xml, F_CRM_HOST_FROM, peer->uname);
-    rc = election_count_vote(writer, xml, TRUE);
+
+    // Don't become writer if we're shutting down
+    rc = election_count_vote(writer, xml, !attrd_shutting_down());
+
     switch(rc) {
         case election_start:
             free(peer_writer);

--- a/daemons/attrd/attrd_elections.c
+++ b/daemons/attrd/attrd_elections.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2013-2019 Andrew Beekhof <andrew@beekhof.net>
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -131,12 +131,20 @@ attrd_declare_winner()
 void
 attrd_remove_voter(const crm_node_t *peer)
 {
+    election_remove(writer, peer->uname);
     if (peer_writer && safe_str_eq(peer->uname, peer_writer)) {
         free(peer_writer);
         peer_writer = NULL;
         crm_notice("Lost attribute writer %s", peer->uname);
+
+        /* If the writer received attribute updates during its shutdown, it will
+         * not have written them to the CIB. Ensure we get a new writer so they
+         * are written out. This means that every node that sees the writer
+         * leave will start a new election, but that's better than losing
+         * attributes.
+         */
+        attrd_start_election_if_needed();
     }
-    election_remove(writer, peer->uname);
 }
 
 void

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -8,6 +8,7 @@
 #include <crm_internal.h>
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <errno.h>
 #include <glib.h>
 #include <regex.h>
@@ -21,7 +22,9 @@
 
 cib_t *the_cib = NULL;
 
-static gboolean shutting_down = FALSE;
+// volatile because attrd_shutdown() can be called for a signal
+static volatile bool shutting_down = FALSE;
+
 static GMainLoop *mloop = NULL;
 
 /*!
@@ -45,11 +48,25 @@ attrd_shutting_down()
 void
 attrd_shutdown(int nsig)
 {
+    // Tell various functions not to do anthing
     shutting_down = TRUE;
-    if ((mloop != NULL) && g_main_loop_is_running(mloop)) {
-        g_main_loop_quit(mloop);
-    } else {
+
+    // Don't respond to signals while shutting down
+    mainloop_destroy_signal(SIGTERM);
+    mainloop_destroy_signal(SIGCHLD);
+    mainloop_destroy_signal(SIGPIPE);
+    mainloop_destroy_signal(SIGUSR1);
+    mainloop_destroy_signal(SIGUSR2);
+    mainloop_destroy_signal(SIGTRAP);
+
+    if ((mloop == NULL) || !g_main_loop_is_running(mloop)) {
+        /* If there's no main loop active, just exit. This should be possible
+         * only if we get SIGTERM in brief windows at start-up and shutdown.
+         */
         crm_exit(CRM_EX_OK);
+    } else {
+        g_main_loop_quit(mloop);
+        g_main_loop_unref(mloop);
     }
 }
 

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -175,11 +175,10 @@ attrd_init_ipc(qb_ipcs_service_t **ipcs, qb_ipcs_msg_process_fn dispatch_fn)
 void
 attrd_cib_disconnect()
 {
-    if (the_cib) {
-        the_cib->cmds->signoff(the_cib);
-        cib_delete(the_cib);
-        the_cib = NULL;
-    }
+    CRM_CHECK(the_cib != NULL, return);
+    the_cib->cmds->signoff(the_cib);
+    cib_delete(the_cib);
+    the_cib = NULL;
 }
 
 /* strlen("value") */

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2013-2019 Andrew Beekhof <andrew@beekhof.net>
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -89,6 +89,9 @@ attrd_cib_replaced_cb(const char *event, xmlNode * msg)
         crm_notice("Updating all attributes after %s event", event);
         write_attributes(TRUE, FALSE);
     }
+
+    // Check for changes in alerts
+    mainloop_set_trigger(attrd_config_read);
 }
 
 static void

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -81,8 +81,12 @@ attrd_cpg_destroy(gpointer unused)
 static void
 attrd_cib_replaced_cb(const char *event, xmlNode * msg)
 {
-    crm_notice("Updating all attributes after %s event", event);
+    if (attrd_shutting_down()) {
+        return;
+    }
+
     if (attrd_election_won()) {
+        crm_notice("Updating all attributes after %s event", event);
         write_attributes(TRUE, FALSE);
     }
 }

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -111,6 +111,8 @@ GHashTable *attributes;
 #define attrd_send_ack(client, id, flags) \
     crm_ipcs_send_ack((client), (id), (flags), "ack", __FUNCTION__, __LINE__)
 
+#define CIB_OP_TIMEOUT_S 120
+
 void write_attributes(bool all, bool ignore_delay);
 void attrd_broadcast_protocol(void);
 void attrd_peer_message(crm_node_t *client, xmlNode *msg);

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -22,6 +22,7 @@ gboolean attrd_shutting_down(void);
 void attrd_shutdown(int nsig);
 void attrd_init_ipc(qb_ipcs_service_t **ipcs,
                     qb_ipcs_msg_process_fn dispatch_fn);
+void attrd_ipc_fini(void);
 
 void attrd_cib_disconnect(void);
 


### PR DESCRIPTION
Most significantly, avoid an unnecessary delay introduced by 73e5b6d3, start a new election as soon as the old writer is lost, and check for alert changes after a CIB replace.