### PR TITLE
Test: cts-exec: still run the tests for the other resource classes even without python systemd bindings

### DIFF
--- a/lrmd/regression.py.in
+++ b/lrmd/regression.py.in
@@ -307,9 +307,9 @@ class Tests(object):
                 # systemd tests to fail.
                 import systemd.daemon
             except ImportError:
-                print("Fatal error: python systemd bindings not found. Is package installed?",
-                      file=sys.stderr)
-                sys.exit(1)
+                print("Python systemd bindings not found.")
+                print("The tests for systemd class are not going to be run.")
+                self.rsc_classes.remove("systemd")
 
         print("Testing "+repr(self.rsc_classes))
 


### PR DESCRIPTION
Backport for 1.1 branch.