### PR TITLE
Bug: tools: Fix moving a resource with a lifetime constraint

### DIFF
--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1016,10 +1016,10 @@ main(int argc, char **argv)
                 rc = -ENXIO;
                 goto bail;
             }
-            rc = cli_resource_clear(rsc_id, dest->details->uname, NULL, cib_conn);
+            rc = cli_resource_clear(rsc_id, dest->details->uname, NULL, cib_conn, TRUE);
 
         } else {
-            rc = cli_resource_clear(rsc_id, NULL, data_set->nodes, cib_conn);
+            rc = cli_resource_clear(rsc_id, NULL, data_set->nodes, cib_conn, TRUE);
         }
 
     } else if (rsc_cmd == 'M' && host_uname) {

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -50,7 +50,8 @@ extern const char *attr_set_type;
 /* ban */
 int cli_resource_prefer(const char *rsc_id, const char *host, cib_t * cib_conn);
 int cli_resource_ban(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn);
-int cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn);
+int cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn,
+                       bool clear_ban_constraints);
 int cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, const char *rsc, const char *node, bool scope_master);
 
 /* print */

--- a/tools/crm_resource_ban.c
+++ b/tools/crm_resource_ban.c
@@ -228,15 +228,19 @@ resource_clear_node_in_expr(const char *rsc_id, const char *host, cib_t * cib_co
 }
 
 static int
-resource_clear_node_in_location(const char *rsc_id, const char *host, cib_t * cib_conn)
+resource_clear_node_in_location(const char *rsc_id, const char *host, cib_t * cib_conn,
+                                bool clear_ban_constraints)
 {
     int rc = pcmk_ok;
     xmlNode *fragment = NULL;
     xmlNode *location = NULL;
 
     fragment = create_xml_node(NULL, XML_CIB_TAG_CONSTRAINTS);
-    location = create_xml_node(fragment, XML_CONS_TAG_RSC_LOCATION);
-    crm_xml_set_id(location, "cli-ban-%s-on-%s", rsc_id, host);
+
+    if (clear_ban_constraints == TRUE) {
+        location = create_xml_node(fragment, XML_CONS_TAG_RSC_LOCATION);
+        crm_xml_set_id(location, "cli-ban-%s-on-%s", rsc_id, host);
+    }
 
     location = create_xml_node(fragment, XML_CONS_TAG_RSC_LOCATION);
     crm_xml_set_id(location, "cli-prefer-%s", rsc_id);
@@ -255,7 +259,8 @@ resource_clear_node_in_location(const char *rsc_id, const char *host, cib_t * ci
 }
 
 int
-cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn)
+cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_t * cib_conn,
+                   bool clear_ban_constraints)
 {
     int rc = pcmk_ok;
 
@@ -271,7 +276,7 @@ cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_
          * to try the second clear method.
          */
         if (rc == pcmk_ok) {
-            rc = resource_clear_node_in_location(rsc_id, host, cib_conn);
+            rc = resource_clear_node_in_location(rsc_id, host, cib_conn, clear_ban_constraints);
         }
 
     } else {
@@ -283,7 +288,7 @@ cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_
         for(; n; n = n->next) {
             node_t *target = n->data;
 
-            rc = cli_resource_clear(rsc_id, target->details->uname, NULL, cib_conn);
+            rc = cli_resource_clear(rsc_id, target->details->uname, NULL, cib_conn, clear_ban_constraints);
             if (rc != pcmk_ok) {
                 break;
             }

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1410,7 +1410,7 @@ cli_resource_restart(pe_resource_t *rsc, const char *host, int timeout_ms,
     }
 
     if (stop_via_ban) {
-        rc = cli_resource_clear(rsc_id, host, NULL, cib);
+        rc = cli_resource_clear(rsc_id, host, NULL, cib, TRUE);
 
     } else if (orig_target_role) {
         rc = cli_resource_update_attribute(rsc, rsc_id, NULL, NULL,
@@ -1492,7 +1492,7 @@ cli_resource_restart(pe_resource_t *rsc, const char *host, int timeout_ms,
 
   failure:
     if (stop_via_ban) {
-        cli_resource_clear(rsc_id, host, NULL, cib);
+        cli_resource_clear(rsc_id, host, NULL, cib, TRUE);
     } else if (orig_target_role) {
         cli_resource_update_attribute(rsc, rsc_id, NULL, NULL,
                                       XML_RSC_ATTR_TARGET_ROLE,
@@ -1910,8 +1910,11 @@ cli_resource_move(resource_t *rsc, const char *rsc_id, const char *host_name,
         }
     }
 
-    /* Clear any previous constraints for 'dest' */
-    cli_resource_clear(rsc_id, dest->details->uname, data_set->nodes, cib);
+    /* Clear any previous prefer constraints across all nodes. */
+    cli_resource_clear(rsc_id, NULL, data_set->nodes, cib, FALSE);
+
+    /* Clear any previous ban constraints on 'dest'. */
+    cli_resource_clear(rsc_id, dest->details->uname, data_set->nodes, cib, TRUE);
 
     /* Record an explicit preference for 'dest' */
     rc = cli_resource_prefer(rsc_id, dest->details->uname, cib);

--- a/tools/regression.sh
+++ b/tools/regression.sh
@@ -367,6 +367,23 @@ function test_tools() {
     desc="Delete resource child meta attribute"
     cmd="crm_resource -r test-primitive --meta -d is-managed"
     test_assert 0
+ 
+    desc="Specify a lifetime when moving a resource"
+    cmd="crm_resource -r dummy --move --node node2 --lifetime=PT1H"
+    test_assert $CRM_EX_OK
+
+    desc="Try to move a resource previously moved with a lifetime"
+    cmd="crm_resource -r dummy --move --node node1"
+    test_assert $CRM_EX_OK
+
+    desc="Ban dummy from node1 for a short time"
+    cmd="crm_resource -r dummy -B -N node1 --lifetime=PT1S"
+    test_assert $CRM_EX_OK
+
+    desc="Remove expired constraints"
+    sleep 2
+    cmd="crm_resource --clear --expired"
+    test_assert $CRM_EX_OK
 
     rm -f /tmp/$$.existing.xml /tmp/$$.resources.xml
 }
@@ -765,6 +782,8 @@ for t in $tests; do
         -e 's/schemas\.c:\([0-9][0-9]*\)/schemas.c:NNN/' \
         -e 's/constraints\.:\([0-9][0-9]*\)/constraints.:NNN/' \
         -e 's/\(validation ([0-9][0-9]* of \)[0-9][0-9]*\().*\)/\1X\2/' \
+        -e 's/^Migration will take effect until: .*/Migration will take effect until:/' \
+        -e 's/ end=\"[-: 0123456789]*Z\?\"/ end=\"\"/' \
 	$test_home/regression.$t.out
 
     if [ $do_save = 1 ]; then

--- a/tools/regression.sh
+++ b/tools/regression.sh
@@ -769,7 +769,8 @@ for t in $tests; do
     echo "Testing $t"
     test_$t > $test_home/regression.$t.out
 
-    sed -i -e 's/cib-last-written.*>/>/'\
+    sed -E \
+        -i -e 's/cib-last-written.*>/>/'\
         -e 's/ last-run=\"[0-9]*\"//'\
         -e 's/crm_feature_set="[^"]*" //'\
         -e 's/validate-with="[^"]*" //'\
@@ -778,12 +779,12 @@ for t in $tests; do
         -e 's/ last-rc-change=\"[0-9]*\"//'\
         -e 's|^/tmp/[0-9][0-9]*\.||'\
         -e 's/^Entity: line [0-9][0-9]*: //'\
-        -e 's/acl\.c:\([0-9][0-9]*\)/acl.c:NNN/' \
-        -e 's/schemas\.c:\([0-9][0-9]*\)/schemas.c:NNN/' \
-        -e 's/constraints\.:\([0-9][0-9]*\)/constraints.:NNN/' \
-        -e 's/\(validation ([0-9][0-9]* of \)[0-9][0-9]*\().*\)/\1X\2/' \
+        -e 's/acl\.c:([0-9][0-9]*)/acl.c:NNN/' \
+        -e 's/schemas\.c:([0-9][0-9]*)/schemas.c:NNN/' \
+        -e 's/constraints\.:([0-9][0-9]*)/constraints.:NNN/' \
+        -e 's/(validation \([0-9][0-9]* of )[0-9][0-9]*(\).*)/\1X\2/' \
         -e 's/^Migration will take effect until: .*/Migration will take effect until:/' \
-        -e 's/ end=\"[-: 0123456789]*Z\?\"/ end=\"\"/' \
+        -e 's/ end=\"[-: 0123456789]+Z?\"/ end=\"\"/' \
 	$test_home/regression.$t.out
 
     if [ $do_save = 1 ]; then

--- a/tools/regression.tools.exp
+++ b/tools/regression.tools.exp
@@ -2974,3 +2974,203 @@ Deleted 'test-primitive' option: id=test-primitive-meta_attributes-is-managed na
 </cib>
 =#=#=#= End test: Delete resource child meta attribute - OK (0) =#=#=#=
 * Passed: crm_resource   - Delete resource child meta attribute
+=#=#=#= Begin test: Specify a lifetime when moving a resource =#=#=#=
+Migration will take effect until:
+=#=#=#= Current cib after: Specify a lifetime when moving a resource =#=#=#=
+<cib epoch="43" num_updates="0" admin_epoch="1">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+      </node>
+      <node id="node2" uname="node2"/>
+      <node id="node3" uname="node3"/>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+      <clone id="test-clone">
+        <primitive id="test-primitive" class="ocf" provider="pacemaker" type="Dummy">
+          <meta_attributes id="test-primitive-meta_attributes"/>
+        </primitive>
+        <meta_attributes id="test-clone-meta_attributes">
+          <nvpair id="test-clone-meta_attributes-is-managed" name="is-managed" value="true"/>
+        </meta_attributes>
+      </clone>
+    </resources>
+    <constraints>
+      <rsc_location id="cli-prefer-dummy" rsc="dummy" role="Started">
+        <rule id="cli-prefer-rule-dummy" score="INFINITY" boolean-op="and">
+          <expression id="cli-prefer-expr-dummy" attribute="#uname" operation="eq" value="node2" type="string"/>
+          <date_expression id="cli-prefer-lifetime-end-dummy" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Specify a lifetime when moving a resource - OK (0) =#=#=#=
+* Passed: crm_resource   - Specify a lifetime when moving a resource
+=#=#=#= Begin test: Try to move a resource previously moved with a lifetime =#=#=#=
+=#=#=#= Current cib after: Try to move a resource previously moved with a lifetime =#=#=#=
+<cib epoch="45" num_updates="0" admin_epoch="1">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+      </node>
+      <node id="node2" uname="node2"/>
+      <node id="node3" uname="node3"/>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+      <clone id="test-clone">
+        <primitive id="test-primitive" class="ocf" provider="pacemaker" type="Dummy">
+          <meta_attributes id="test-primitive-meta_attributes"/>
+        </primitive>
+        <meta_attributes id="test-clone-meta_attributes">
+          <nvpair id="test-clone-meta_attributes-is-managed" name="is-managed" value="true"/>
+        </meta_attributes>
+      </clone>
+    </resources>
+    <constraints>
+      <rsc_location id="cli-prefer-dummy" rsc="dummy" role="Started" node="node1" score="INFINITY"/>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Try to move a resource previously moved with a lifetime - OK (0) =#=#=#=
+* Passed: crm_resource   - Try to move a resource previously moved with a lifetime
+=#=#=#= Begin test: Ban dummy from node1 for a short time =#=#=#=
+WARNING: Creating rsc_location constraint 'cli-ban-dummy-on-node1' with a score of -INFINITY for resource dummy on node1.
+       This will prevent dummy from running on node1 until the constraint is removed using the clear option or by editing the CIB with an appropriate tool
+       This will be the case even if node1 is the last node in the cluster
+Migration will take effect until:
+=#=#=#= Current cib after: Ban dummy from node1 for a short time =#=#=#=
+<cib epoch="46" num_updates="0" admin_epoch="1">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+      </node>
+      <node id="node2" uname="node2"/>
+      <node id="node3" uname="node3"/>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+      <clone id="test-clone">
+        <primitive id="test-primitive" class="ocf" provider="pacemaker" type="Dummy">
+          <meta_attributes id="test-primitive-meta_attributes"/>
+        </primitive>
+        <meta_attributes id="test-clone-meta_attributes">
+          <nvpair id="test-clone-meta_attributes-is-managed" name="is-managed" value="true"/>
+        </meta_attributes>
+      </clone>
+    </resources>
+    <constraints>
+      <rsc_location id="cli-prefer-dummy" rsc="dummy" role="Started" node="node1" score="INFINITY"/>
+      <rsc_location id="cli-ban-dummy-on-node1" rsc="dummy" role="Started">
+        <rule id="cli-ban-dummy-on-node1-rule" score="-INFINITY" boolean-op="and">
+          <expression id="cli-ban-dummy-on-node1-expr" attribute="#uname" operation="eq" value="node1" type="string"/>
+          <date_expression id="cli-ban-dummy-on-node1-lifetime" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Ban dummy from node1 for a short time - OK (0) =#=#=#=
+* Passed: crm_resource   - Ban dummy from node1 for a short time
+=#=#=#= Begin test: Remove expired constraints =#=#=#=
+=#=#=#= Current cib after: Remove expired constraints =#=#=#=
+<cib epoch="47" num_updates="0" admin_epoch="1">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+      </node>
+      <node id="node2" uname="node2"/>
+      <node id="node3" uname="node3"/>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+      <clone id="test-clone">
+        <primitive id="test-primitive" class="ocf" provider="pacemaker" type="Dummy">
+          <meta_attributes id="test-primitive-meta_attributes"/>
+        </primitive>
+        <meta_attributes id="test-clone-meta_attributes">
+          <nvpair id="test-clone-meta_attributes-is-managed" name="is-managed" value="true"/>
+        </meta_attributes>
+      </clone>
+    </resources>
+    <constraints>
+      <rsc_location id="cli-prefer-dummy" rsc="dummy" role="Started" node="node1" score="INFINITY"/>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Remove expired constraints - OK (0) =#=#=#=
+* Passed: crm_resource   - Remove expired constraints


### PR DESCRIPTION
A node can be specified two different ways - with attribute="#uname"
and value= on an expression XML node, or with node= on a rsc_location
XML node. Both possibilities need to be considered when attempting to
clear an existing constraint.

cli_resource_clear was previously only considering the second case.
This patch rearranges the code to allow for trying both, and then adds
the code to try the first case by constructing a different blob of XML
to match.

See rhbz#1648620