### PR TITLE
[2.0.1?] Avoid "stuck deployment" for unavailable user/group + OpenIndiana tweaks

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@
 ## Build Dependencies
 * automake 1.11 or later
 * autoconf 2.64 or later
-* bash
+* bash (configuring build alone makes do with POSIX shell)
 * libtool
 * libtool-ltdl-devel
 * libuuid-devel

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,13 +57,41 @@ install-exec-local:
 	$(INSTALL) -d -m 750 $(DESTDIR)/$(CRM_BLACKBOX_DIR)
 	$(INSTALL) -d -m 770 $(DESTDIR)/$(CRM_LOG_DIR)
 	$(INSTALL) -d -m 770 $(DESTDIR)/$(CRM_BUNDLE_DIR)
+ # leaving a space here to work around automake's conditionals
+ ifeq ($(host_os),linux-gnu)
+	getent group $(CRM_DAEMON_GROUP) >/dev/null \
+	 || groupadd -r $(CRM_DAEMON_GROUP) \
+	 || echo 'cannot add group $(CRM_DAEMON_GROUP)'
+	getent passwd $(CRM_DAEMON_USER) >/dev/null \
+	 || useradd -r -g $(CRM_DAEMON_GROUP) -s /sbin/nologin \
+	     -c "cluster user" $(CRM_DAEMON_USER) \
+	 || echo 'cannot add user $(CRM_DAEMON_USER)'
+ else ifneq ($(strip $(filter solaris%,$(host_os))),)
+	getent group $(CRM_DAEMON_GROUP) >/dev/null \
+	 || groupadd $(CRM_DAEMON_GROUP) \
+	 || echo 'cannot add group $(CRM_DAEMON_GROUP)'
+	getent passwd $(CRM_DAEMON_USER) >/dev/null \
+	 || useradd -g $(CRM_DAEMON_GROUP) -s /usr/bin/false \
+	     -c "cluster user" $(CRM_DAEMON_USER) \
+	 || echo 'cannot add user $(CRM_DAEMON_USER)'
+ else ifneq ($(strip $(filter freebsd%,$(host_os))),)
+	pw showgroup $(CRM_DAEMON_GROUP) >/dev/null \
+	 || pw groupadd $(CRM_DAEMON_GROUP) \
+	 || echo 'cannot add group $(CRM_DAEMON_GROUP)'
+	pw showuser $(CRM_DAEMON_USER) >/dev/null \
+	 || pw useradd -g $(CRM_DAEMON_GROUP) \
+	     -c "cluster user" $(CRM_DAEMON_USER) \
+	 || echo 'cannot add user $(CRM_DAEMON_USER)'
+ else
+	echo 'unknown platform $(host_os): cannot check/add group $(CRM_DAEMON_GROUP)'
+	echo 'unknown platform $(host_os): cannot check/add user $(CRM_DAEMON_USER)'
+ endif
 	-chgrp $(CRM_DAEMON_GROUP) $(DESTDIR)/$(PACEMAKER_CONFIG_DIR)
 	-chown $(CRM_DAEMON_USER):$(CRM_DAEMON_GROUP) $(DESTDIR)/$(CRM_CONFIG_DIR)
 	-chown $(CRM_DAEMON_USER):$(CRM_DAEMON_GROUP) $(DESTDIR)/$(CRM_CORE_DIR)
 	-chown $(CRM_DAEMON_USER):$(CRM_DAEMON_GROUP) $(DESTDIR)/$(CRM_BLACKBOX_DIR)
 	-chown $(CRM_DAEMON_USER):$(CRM_DAEMON_GROUP) $(DESTDIR)/$(CRM_LOG_DIR)
 	-chown $(CRM_DAEMON_USER):$(CRM_DAEMON_GROUP) $(DESTDIR)/$(CRM_BUNDLE_DIR)
-# Use chown because the user/group may not exist
 
 clean-generic:
 	rm -f $(TARFILE) *.tar.bz2 *.sed

--- a/configure.ac
+++ b/configure.ac
@@ -416,6 +416,8 @@ case "$host_os" in
         ;;
     *solaris*)
         AC_DEFINE_UNQUOTED(ON_SOLARIS, 1, Compiling for Solaris platform)
+        # get getpwnam_r declaration right
+        CPPFLAGS="$CPPFLAGS -D_POSIX_PTHREAD_SEMANTICS"
         ;;
     *linux*)
         AC_DEFINE_UNQUOTED(ON_LINUX, 1, Compiling for Linux platform)

--- a/configure.ac
+++ b/configure.ac
@@ -131,14 +131,6 @@ dnl ===============================================
 dnl Configure Options
 dnl ===============================================
 
-dnl Some systems, like Solaris require a custom package name
-AC_ARG_WITH(pkgname,
-    [  --with-pkgname=name     name for pkg (typically for Solaris) ],
-    [ PKGNAME="$withval" ],
-    [ PKGNAME="LXHAhb" ],
-  )
-AC_SUBST(PKGNAME)
-
 AC_ARG_ENABLE([ansi],
     [  --enable-ansi  Force GCC to compile to ANSI standard for older compilers. @<:@no@:>@])
 

--- a/configure.ac
+++ b/configure.ac
@@ -106,11 +106,13 @@ dnl ===============================================
 dnl Helpers
 dnl ===============================================
 cc_supports_flag() {
-    local CFLAGS="-Werror $@"
+    save_CFLAGS=$CFLAGS
+    CFLAGS="-Werror $@"
     AC_MSG_CHECKING(whether $CC supports "$@")
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ ]], [[ ]])],
                       [RC=0; AC_MSG_RESULT(yes)],
                       [RC=1; AC_MSG_RESULT(no)])
+    CFLAGS="$save_CFLAGS"
     return $RC
 }
 

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -229,7 +229,7 @@ tengine_stonith_notify(stonith_t * st, stonith_event_t * st_event)
          */
 
 #ifdef RB_HALT_SYSTEM
-        reboot(RB_HALT_SYSTEM);
+        pcmk__reboot(RB_HALT_SYSTEM);
 #endif
 
         /*

--- a/include/portability.h
+++ b/include/portability.h
@@ -183,4 +183,32 @@ typedef union
 #    define __FUNCTION__ "__FUNCTION__"
 #  endif
 
+
+/* ad-hoc portability helpers */
+
+#include <unistd.h>
+#include <sys/reboot.h>
+
+/*!
+ * \internal
+ * \brief reboot(2) (as in sys/reboot.h) compatibility wrapper for non-linuxen
+ *
+ * \param[in] cmd  One of supported, enumerated commands (RB_HALT_SYSTEM, etc.)
+ *
+ * \return Success/failure indication per platform, if the call returns at all.
+ *
+ * \note This is a very superficial wrapper to barely make Solaris/OpenIndiana
+ *       compile.  More elaboration can arrive later.
+ */
+static inline int
+pcmk__reboot(int cmd)
+{
+#ifdef ON_SOLARIS
+    char ignore = '\0';
+    return reboot(cmd, &ignore);
+#else
+    return reboot(cmd);
+#endif
+}
+
 #endif                          /* PORTABILITY_H */

--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -100,8 +100,8 @@ pcmk_panic_local(void)
     } else {
         sysrq_trigger('b');
     }
-    /* reboot(RB_HALT_SYSTEM); rc = errno; */
-    reboot(RB_AUTOBOOT);
+    /* pcmk__reboot(RB_HALT_SYSTEM); */
+    pcmk__reboot(RB_AUTOBOOT);
     rc = errno;
 
     do_crm_log_always(LOG_EMERG, "Reboot failed, escalating to %d: %s (%d)", ppid, pcmk_strerror(rc), rc);


### PR DESCRIPTION
Since these ACL entitites are an unavoidable prerequisite currently,
do the consumers of "make install" a favour and create them
conditionally in "make install".

Only plain GNU/Linux and FreeBSD are currently supported, patches
welcome.  Possible future extensions include detecting of phony
environments only used to pick the actual results of the installation
without propagating any further environment changes (e.g. mock used
for RPM building) and skip that, too, but since these commands are
tolerated to fail, it would be merely a cosmetic optimization.