### PR TITLE
Add support for validating resources based on command line options

### DIFF
--- a/include/crm/services.h
+++ b/include/crm/services.h
@@ -228,6 +228,17 @@ typedef struct svc_action_s {
  */
     GList *resources_list_standards(void);
 
+/**
+ * Does the given standard, provider, and agent describe a resource that can exist?
+ *
+ * \param[in] standard  Which class of agent does the resource belong to?
+ * \param[in] provider  What provides the agent (NULL for most standards)?
+ * \param[in] agent     What is the name of the agent?
+ *
+ * \return A boolean
+ */
+    gboolean resources_agent_exists(const char *standard, const char *provider, const char *agent);
+
 svc_action_t *services_action_create(const char *name, const char *action,
                                      guint interval_ms, int timeout /* ms */);
 

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -521,6 +521,17 @@ stonith_api_time_helper(uint32_t nodeid, bool in_progress)
     return (*st_time_fn) (nodeid, NULL, in_progress);
 }
 
+/**
+ * Does the given agent describe a stonith resource that can exist?
+ *
+ * \param[in] agent     What is the name of the agent?
+ * \param[in] timeout   Timeout to use when querying.  If 0 is given,
+ *                      use a default of 120.
+ *
+ * \return A boolean
+ */
+gboolean stonith_agent_exists(const char *agent, int timeout);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2467,3 +2467,30 @@ stonith_api_time(uint32_t nodeid, const char *uname, bool in_progress)
     free(name);
     return when;
 }
+
+gboolean
+stonith_agent_exists(const char *agent, int timeout)
+{
+    stonith_t *st = NULL;
+    stonith_key_value_t *devices = NULL;
+    stonith_key_value_t *dIter = NULL;
+    gboolean rc = FALSE;
+
+    if (agent == NULL) {
+        return rc;
+    }
+
+    st = stonith_api_new();
+    st->cmds->list_agents(st, st_opt_sync_call, NULL, &devices, timeout == 0 ? 120 : timeout);
+
+    for (dIter = devices; dIter != NULL; dIter = dIter->next) {
+        if (crm_str_eq(dIter->value, agent, TRUE)) {
+            rc = TRUE;
+            break;
+        }
+    }
+
+    stonith_key_value_freeall(devices, 1, 1);
+    stonith_api_delete(st);
+    return rc;
+}

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -21,6 +21,7 @@
 #include <crm/crm.h>
 #include <crm/common/mainloop.h>
 #include <crm/services.h>
+#include <crm/stonith-ng.h>
 #include <crm/msg_xml.h>
 #include "services_private.h"
 #include "services_lsb.h"
@@ -1078,4 +1079,91 @@ resources_list_agents(const char *standard, const char *provider)
     }
 
     return NULL;
+}
+
+gboolean
+resources_agent_exists(const char *standard, const char *provider, const char *agent)
+{
+    GList *standards = NULL;
+    GList *providers = NULL;
+    GListPtr iter = NULL;
+    gboolean rc = FALSE;
+    gboolean has_providers = FALSE;
+
+    standards = resources_list_standards();
+    for (iter = standards; iter != NULL; iter = iter->next) {
+        if (crm_str_eq(iter->data, standard, TRUE)) {
+            rc = TRUE;
+            break;
+        }
+    }
+
+    if (rc == FALSE) {
+        goto done;
+    }
+
+    rc = FALSE;
+
+    has_providers = is_set(pcmk_get_ra_caps(standard), pcmk_ra_cap_provider);
+    if (has_providers == TRUE && provider != NULL) {
+        providers = resources_list_providers(standard);
+        for (iter = providers; iter != NULL; iter = iter->next) {
+            if (crm_str_eq(iter->data, provider, TRUE)) {
+                rc = TRUE;
+                break;
+            }
+        }
+    } else if (has_providers == FALSE && provider == NULL) {
+        rc = TRUE;
+    }
+
+    if (rc == FALSE) {
+        goto done;
+    }
+
+    if (safe_str_eq(standard, PCMK_RESOURCE_CLASS_SERVICE)) {
+        if (services__lsb_agent_exists(agent)) {
+            rc = TRUE;
+#if SUPPORT_SYSTEMD
+        } else if (systemd_unit_exists(agent)) {
+            rc = TRUE;
+#endif
+
+#if SUPPORT_UPSTART
+        } else if (upstart_job_exists(agent)) {
+            rc = TRUE;
+#endif
+        } else {
+            rc = FALSE;
+        }
+
+    } else if (safe_str_eq(standard, PCMK_RESOURCE_CLASS_OCF)) {
+        rc = services__ocf_agent_exists(provider, agent);
+
+    } else if (safe_str_eq(standard, PCMK_RESOURCE_CLASS_LSB)) {
+        rc = services__lsb_agent_exists(agent);
+
+#if SUPPORT_SYSTEMD
+    } else if (safe_str_eq(standard, PCMK_RESOURCE_CLASS_SYSTEMD)) {
+        rc = systemd_unit_exists(agent);
+#endif
+
+#if SUPPORT_UPSTART
+    } else if (safe_str_eq(standard, PCMK_RESOURCE_CLASS_UPSTART)) {
+        rc = upstart_job_exists(agent);
+#endif
+
+#if SUPPORT_NAGIOS
+    } else if (safe_str_eq(standard, PCMK_RESOURCE_CLASS_NAGIOS)) {
+        rc = services__nagios_agent_exists(agent);
+#endif
+
+    } else {
+        rc = FALSE;
+    }
+
+done:
+    g_list_free(standards);
+    g_list_free(providers);
+    return rc;
 }

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -911,6 +911,26 @@ resources_os_list_ocf_agents(const char *provider)
     return result;
 }
 
+gboolean
+services__ocf_agent_exists(const char *provider, const char *agent)
+{
+    char *buf = NULL;
+    gboolean rc = FALSE;
+    struct stat st;
+
+    if (provider == NULL || agent == NULL) {
+        return rc;
+    }
+
+    buf = crm_strdup_printf(OCF_ROOT_DIR "/resource.d/%s/%s", provider, agent);
+    if (stat(buf, &st) == 0) {
+        rc = TRUE;
+    }
+
+    free(buf);
+    return rc;
+}
+
 #if SUPPORT_NAGIOS
 GList *
 resources_os_list_nagios_agents(void)
@@ -935,5 +955,25 @@ resources_os_list_nagios_agents(void)
     }
     g_list_free_full(plugin_list, free);
     return result;
+}
+
+gboolean
+services__nagios_agent_exists(const char *name)
+{
+    char *buf = NULL;
+    gboolean rc = FALSE;
+    struct stat st;
+
+    if (name == NULL) {
+        return rc;
+    }
+
+    buf = crm_strdup_printf(NAGIOS_PLUGIN_DIR "/%s", name);
+    if (stat(buf, &st) == 0) {
+        rc = TRUE;
+    }
+
+    free(buf);
+    return rc;
 }
 #endif

--- a/lib/services/services_private.h
+++ b/lib/services/services_private.h
@@ -50,7 +50,13 @@ G_GNUC_INTERNAL
 GList *resources_os_list_ocf_agents(const char *provider);
 
 G_GNUC_INTERNAL
+gboolean services__ocf_agent_exists(const char *provider, const char *agent);
+
+G_GNUC_INTERNAL
 GList *resources_os_list_nagios_agents(void);
+
+G_GNUC_INTERNAL
+gboolean services__nagios_agent_exists(const char *agent);
 
 G_GNUC_INTERNAL
 gboolean cancel_recurring_action(svc_action_t * op);

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -106,6 +106,7 @@ crm_attribute_LDADD	= $(top_builddir)/lib/cluster/libcrmcluster.la	\
 crm_resource_SOURCES	= crm_resource.c crm_resource_ban.c crm_resource_runtime.c crm_resource_print.c fake_transition.c
 crm_resource_CFLAGS	= -I$(top_srcdir)/daemons/schedulerd
 crm_resource_LDADD	= $(top_builddir)/lib/pengine/libpe_rules.la  	\
+			  $(top_builddir)/lib/fencing/libstonithd.la	\
 			  $(top_builddir)/lib/lrmd/liblrmd.la 		\
 			  $(top_builddir)/lib/services/libcrmservice.la \
 			  $(top_builddir)/lib/pengine/libpe_status.la 	\

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -10,6 +10,7 @@
 #include <sys/param.h>
 
 #include <crm/crm.h>
+#include <crm/stonith-ng.h>
 
 #include <stdio.h>
 #include <sys/types.h>
@@ -219,7 +220,10 @@ static struct crm_option long_options[] = {
     { "-spacer-", no_argument, NULL, '-', "\nCommands:" },
     {
         "validate", no_argument, NULL, 0,
-        "\t\tCall the validate-all action of the local given resource"
+        "\t\tCall the validate-all action.  There are two different things that can be validated.  One\n"
+        "\t\t\t\tmethod is to validate the resource given by the -r option.  The other method is to validate\n"
+        "\t\t\t\ta not-yet-existing resource.  This method requires the --class, --agent, and --provider\n"
+        "\t\t\t\targuments, plus at least one --option argument."
     },
     {
         "cleanup", no_argument, NULL, 'C',
@@ -339,6 +343,29 @@ static struct crm_option long_options[] = {
         "\t(Advanced) Bypass the cluster and check the state of a resource on the local node."
     },
 
+    { "-spacer-", no_argument, NULL, '-', "\nValidate Options:" },
+    {
+        "class", required_argument, NULL, 0,
+        "\tThe standard the resource agent confirms to (for example, ocf).\n"
+        "\t\t\t\tUse with --agent, --provider, --option, and --validate."
+    },
+    {
+        "agent", required_argument, NULL, 0,
+        "\tThe agent to use (for example, IPaddr).\n"
+        "\t\t\t\tUse with --class, --provider, --option, and --validate."
+    },
+    {
+        "provider", required_argument, NULL, 0,
+        "\tThe vendor that supplies the resource agent (for example, heartbeat).\n"
+        "\t\t\t\tuse with --class, --agent, --option, and --validate."
+    },
+    {
+        "option", required_argument, NULL, 0,
+        "\tSpecify a device configuration parameter as NAME=VALUE\n"
+        "\t\t\t\t(may be specified multiple times).  Use with --validate\n"
+        "\t\t\t\tand without the -r option."
+    },
+
     { "-spacer-", no_argument, NULL, '-', "\nAdditional Options:" },
     {
         "node", required_argument, NULL, 'N',
@@ -427,6 +454,13 @@ main(int argc, char **argv)
 {
     char rsc_cmd = 'L';
 
+    const char *v_class = NULL;
+    const char *v_agent = NULL;
+    const char *v_provider = NULL;
+    char *name = NULL;
+    char *value = NULL;
+    GHashTable *validate_options = NULL;
+
     const char *rsc_id = NULL;
     const char *host_uname = NULL;
     const char *prop_name = NULL;
@@ -450,6 +484,7 @@ main(int argc, char **argv)
     bool recursive = FALSE;
     char *our_pid = NULL;
 
+    bool validate_cmdline = FALSE; /* whether we are just validating based on command line options */
     bool require_resource = TRUE; /* whether command requires that resource be specified */
     bool require_dataset = TRUE;  /* whether command requires populated dataset instance */
     bool require_crmd = FALSE;    // whether command requires controller connection
@@ -467,6 +502,8 @@ main(int argc, char **argv)
     crm_log_cli_init("crm_resource");
     crm_set_options(NULL, "(query|command) [options]", long_options,
                     "Perform tasks related to cluster resources.\nAllows resources to be queried (definition and location), modified, and moved around the cluster.\n");
+
+    validate_options = crm_str_table_new();
 
     while (1) {
         flag = crm_get_option_long(argc, argv, &option_index, &longname);
@@ -588,6 +625,43 @@ main(int argc, char **argv)
                     }
                     lrmd_api_delete(lrmd_conn);
                     crm_exit(exit_code);
+
+                } else if (safe_str_eq("class", longname)) {
+                    if (!(pcmk_get_ra_caps(optarg) & pcmk_ra_cap_params)) {
+                        if (BE_QUIET == FALSE) {
+                            fprintf(stdout, "Standard %s does not support parameters\n",
+                                    optarg);
+                        }
+
+                        crm_exit(exit_code);
+                    } else {
+                        v_class = optarg;
+                    }
+
+                    validate_cmdline = TRUE;
+                    require_resource = FALSE;
+
+                } else if (safe_str_eq("agent", longname)) {
+                    validate_cmdline = TRUE;
+                    require_resource = FALSE;
+                    v_agent = optarg;
+
+                } else if (safe_str_eq("provider", longname)) {
+                    validate_cmdline = TRUE;
+                    require_resource = FALSE;
+                    v_provider = optarg;
+
+                } else if (safe_str_eq("option", longname)) {
+                    crm_info("Scanning: --option %s", optarg);
+                    rc = pcmk_scan_nvpair(optarg, &name, &value);
+                    if (rc != 2) {
+                        fprintf(stderr, "Invalid option: --option %s: %s", optarg, pcmk_strerror(rc));
+                        argerr++;
+                    } else {
+                        crm_info("Got: '%s'='%s'", name, value);
+                    }
+
+                    g_hash_table_replace(validate_options, name, value);
 
                 } else {
                     crm_err("Unhandled long option: %s", longname);
@@ -792,6 +866,45 @@ main(int argc, char **argv)
 
     if (optind > argc) {
         ++argerr;
+    }
+
+    // Sanity check validating from command line parameters.  If everything checks out,
+    // go ahead and run the validation.  This way we don't need a CIB connection.
+    if (validate_cmdline == TRUE) {
+        // -r cannot be used with any of --class, --agent, or --provider
+        if (rsc_id != NULL) {
+            CMD_ERR("--resource cannot be used with --class, --agent, and --provider");
+            argerr++;
+
+        // If --class, --agent, or --provider are given, --validate must also be given.
+        } else if (!safe_str_eq(rsc_long_cmd, "validate")) {
+            CMD_ERR("--class, --agent, and --provider require --validate");
+            argerr++;
+
+        // Not all of --class, --agent, and --provider need to be given.  Not all
+        // classes support the concept of a provider.  Check that what we were given
+        // is valid.
+        } else if (crm_str_eq(v_class, "stonith", TRUE)) {
+            if (v_provider != NULL) {
+                CMD_ERR("stonith does not support providers");
+                argerr++;
+
+            } else if (stonith_agent_exists(v_agent, 0) == FALSE) {
+                CMD_ERR("%s is not a known stonith agent", v_agent ? v_agent : "");
+                argerr++;
+            }
+
+        } else if (resources_agent_exists(v_class, v_provider, v_agent) == FALSE) {
+            CMD_ERR("%s:%s:%s is not a known resource",
+                    v_class ? v_class : "",
+                    v_provider ? v_provider : "",
+                    v_agent ? v_agent : "");
+            argerr++;
+
+        } else {
+            exit_code = crm_errno2exit(rc);
+            return crm_exit(exit_code);
+        }
     }
 
     if (argerr) {

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -900,8 +900,12 @@ main(int argc, char **argv)
                     v_provider ? v_provider : "",
                     v_agent ? v_agent : "");
             argerr++;
+        }
 
-        } else {
+        if (argerr == 0) {
+            rc = cli_resource_execute_from_params("test", v_class, v_provider, v_agent,
+                                                  "validate-all", validate_options,
+                                                  override_params, timeout_ms);
             exit_code = crm_errno2exit(rc);
             return crm_exit(exit_code);
         }

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -75,6 +75,10 @@ int cli_resource_restart(pe_resource_t *rsc, const char *host, int timeout_ms,
 int cli_resource_move(resource_t *rsc, const char *rsc_id,
                       const char *host_name, cib_t *cib,
                       pe_working_set_t *data_set);
+int cli_resource_execute_from_params(const char *rsc_name, const char *rsc_class,
+                                     const char *rsc_prov, const char *rsc_type,
+                                     const char *rsc_action, GHashTable *params,
+                                     GHashTable *override_hash, int timeout_ms);
 int cli_resource_execute(resource_t *rsc, const char *requested_name,
                          const char *rsc_action, GHashTable *override_hash,
                          int timeout_ms, cib_t *cib,


### PR DESCRIPTION
Here's a first draft at adding support for running the validate-all action based upon command line parameters, and not against some existing resource in the CIB.  Not all standards support validate-all at this time, but this patch set should handle any future updates along these lines without changes.  This patch currently requires a CIB connection but I think I can fix that if necessary - it's just because of where the code is positioned in crm_resource.c.