### PR TITLE
Fix LogWatcher cursor bug with local logfile

### DIFF
--- a/cts/watcher.py
+++ b/cts/watcher.py
@@ -31,7 +31,7 @@ class SearchObj(object):
         self.offset = "EOF"
 
         if host == None:
-            host = "localhost"
+            self.host = "localhost"
 
     def __str__(self):
         if self.host:
@@ -63,8 +63,7 @@ class FileObj(SearchObj):
     def __init__(self, filename, host=None, name=None):
         SearchObj.__init__(self, filename, host, name)
 
-        if host is not None:
-            self.harvest()
+        self.harvest()
 
     def async_complete(self, pid, returncode, outLines, errLines):
         for line in outLines:


### PR DESCRIPTION
When calling setwatch(), LogWatcher is supposed to record the current
cursor position in log using a harvest() call. It then look for given
patterns starting from this recorded position as soon as look() is
called, usualy after some actions were called and logged useful
informations we are looking for.

However, harvest() was not called for local logfile, so the starting
cursor position was in fact recorded during the first call of look(),
most probably *after* the actions wrote to the local logfile.

This bug was leading to permanently failing cluster manager start
or tests when using combined syslog-based log reader.

It's not clear why harvest() was explicitly not called for
localhost in a first place...