### PR TITLE
[1.1.20] Missing cherry-pick from master

### DIFF
--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -2480,7 +2480,7 @@ unescape_newlines(const char *string)
     ret = strdup(string);
     pch = strstr(ret, escaped_newline);
     while (pch != NULL) {
-        strncpy(pch, "\n ", 2);
+        memcpy(pch, "\n ", 2);
         pch = strstr(pch, escaped_newline);
     }
 


### PR DESCRIPTION
> lrm.c: In function 'unescape_newlines':
> lrm.c:2483:9: error: 'strncpy' output truncated before terminating nul
>               copying 2 bytes from a string of the same length
>               [-Werror=stringop-truncation]
>          strncpy(pch, "\n ", 2);
>          ^~~~~~~~~~~~~~~~~~~~~~
> cc1: all warnings being treated as errors

Point is, we know better than compiler that is essentially a safe swap
of a pair of bytes.