### PR TITLE
Build: configure: Conditionalize support for sscanf's %m.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -802,6 +802,23 @@ dnl ========================================================================
 AC_CHECK_FUNCS(getopt, AC_DEFINE(HAVE_DECL_GETOPT,  1, [Have getopt function]))
 AC_CHECK_FUNCS(nanosleep, AC_DEFINE(HAVE_DECL_NANOSLEEP,  1, [Have nanosleep function]))
 
+AC_CACHE_CHECK(whether sscanf supports %m,
+               pf_cv_var_sscanf,
+               AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <stdio.h>
+const char *s = "some-command-line-arg";
+int main(int argc, char **argv) {
+char *name = NULL;
+int n = sscanf(s, "%ms", &name);
+return n == 1 ? 0 : 1;
+}
+]])],
+                                 pf_cv_var_sscanf="yes", pf_cv_var_sscanf="no", pf_cv_var_sscanf="no"))
+
+if test "$pf_cv_var_sscanf" = "yes"; then
+    AC_DEFINE(SSCANF_HAS_M, 1, [ ])
+fi
+
 dnl ========================================================================
 dnl   bzip2
 dnl ========================================================================

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -50,6 +50,7 @@ extern "C" {
 #  define pcmk_err_multiple             213
 #  define pcmk_err_node_unknown         214
 #  define pcmk_err_already              215
+#  define pcmk_err_bad_nvpair           216
 
 /*
  * Exit status codes

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -50,6 +50,7 @@ gboolean crm_strcase_equal(gconstpointer a, gconstpointer b);
 guint crm_strcase_hash(gconstpointer v);
 guint g_str_hash_traditional(gconstpointer v);
 char *crm_strdup_printf(char const *format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));
+int pcmk_scan_nvpair(const char *input, char **name, char **value);
 
 #  define safe_str_eq(a, b) crm_str_eq(a, b, FALSE)
 #  define crm_str_hash g_str_hash_traditional

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -176,6 +176,7 @@ pcmk_errorname(int rc)
         case pcmk_err_multiple: return "pcmk_err_multiple";
         case pcmk_err_node_unknown: return "pcmk_err_node_unknown";
         case pcmk_err_already: return "pcmk_err_already";
+        case pcmk_err_bad_nvpair: return "pcmk_err_bad_nvpair";
     }
     return "Unknown";
 }
@@ -220,6 +221,8 @@ pcmk_strerror(int rc)
             return "Node not found";
         case pcmk_err_already:
             return "Situation already as requested";
+        case pcmk_err_bad_nvpair:
+            return "Bad name/value pair given";
         case pcmk_err_schema_unchanged:
             return "Schema is already the latest available";
 
@@ -364,6 +367,9 @@ crm_errno2exit(int rc)
         case pcmk_err_schema_validation:
         case pcmk_err_transform_failed:
             return CRM_EX_CONFIG;
+
+        case pcmk_err_bad_nvpair:
+            return CRM_EX_INVALID_PARAM;
 
         case EACCES:
             return CRM_EX_INSUFFICIENT_PRIV;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -495,3 +495,59 @@ crm_strdup_printf(char const *format, ...)
     va_end(ap);
     return string;
 }
+
+/*!
+ * \brief Extract the name and value from an input string formatted as "name=value".
+ * If unable to extract them, they are returned as NULL.
+ *
+ * \param[in]  input The input string, likely from the command line
+ * \param[out] name  Everything before the first '=' in the input string
+ * \param[out] value Everything after the first '=' in the input string
+ *
+ * \return 2 if both name and value could be extracted, 1 if only one could, and
+ *         and error code otherwise
+ */
+int
+pcmk_scan_nvpair(const char *input, char **name, char **value) {
+#ifdef SSCANF_HAS_M
+    *name = NULL;
+    *value = NULL;
+    if (sscanf(input, "%m[^=]=%ms", name, value) <= 0) {
+        return -pcmk_err_bad_nvpair;
+    }
+#else
+    char *sep = NULL;
+    *name = NULL;
+    *value = NULL;
+
+    sep = strstr(optarg, "=");
+    if (sep == NULL) {
+        return -pcmk_err_bad_nvpair;
+    }
+
+    *name = strndup(input, sep-input);
+
+    if (*name == NULL) {
+        return -ENOMEM;
+    }
+
+    /* If the last char in optarg is =, the user gave no
+     * value for the option.  Leave it as NULL.
+     */
+    if (*(sep+1) != '\0') {
+        *value = strdup(sep+1);
+
+        if (*value == NULL) {
+            return -ENOMEM;
+        }
+    }
+#endif
+
+    if (*name != NULL && *value != NULL) {
+        return 2;
+    } else if (*name != NULL || *value != NULL) {
+        return 1;
+    } else {
+        return -pcmk_err_bad_nvpair;
+    }
+}

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -573,9 +573,10 @@ main(int argc, char **argv)
                 break;
             case 'o':
                 crm_info("Scanning: -o %s", optarg);
-                rc = sscanf(optarg, "%m[^=]=%m[^=]", &name, &value);
+                rc = pcmk_scan_nvpair(optarg, &name, &value);
+
                 if (rc != 2) {
-                    crm_err("Invalid option: -o %s", optarg);
+                    crm_err("Invalid option: -o %s: %s", optarg, pcmk_strerror(rc));
                     ++argerr;
                 } else {
                     crm_info("Got: '%s'='%s'", name, value);


### PR DESCRIPTION
This format specifier is not supported by all the OS versions that
pacemaker currently builds on.  Thus it needs to be conditionalized.  In
case that specifier is not supported, use a combination of strstr and
strdup to split the provided option apart into its name and value.