### PR TITLE
low: crm_mon: remove duplicity of fence-action-state in xml-output

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -3242,7 +3242,7 @@ print_stonith_action(FILE *stream, stonith_history_t *event)
                     fprintf(stream, " completed=\"%s\"", run_at_s?run_at_s:"");
                     break;
                 default:
-                    fprintf(stream, " state=\"pending\"");
+                    break;
             }
             fprintf(stream, " />\n");
             break;
@@ -3256,8 +3256,7 @@ print_stonith_action(FILE *stream, stonith_history_t *event)
                              action_s, event->target,
                              event->delegate ? event->delegate : "",
                              event->client, event->origin,
-                             ((!fence_full_history) && (output_format != mon_output_xml))?
-                             "last-successful":"completed",
+                             fence_full_history?"completed":"last-successful",
                              run_at_s?run_at_s:"");
                     break;
                 case st_failed:
@@ -3266,8 +3265,7 @@ print_stonith_action(FILE *stream, stonith_history_t *event)
                              action_s, event->target,
                              event->delegate ? event->delegate : "",
                              event->client, event->origin,
-                             ((!fence_full_history) && (output_format != mon_output_xml))?
-                             "last-failed":"completed",
+                             fence_full_history?"completed":"last-failed",
                              run_at_s?run_at_s:"");
                     break;
                 default:
@@ -3286,9 +3284,7 @@ print_stonith_action(FILE *stream, stonith_history_t *event)
                                     action_s, event->target,
                                     event->delegate ? event->delegate : "",
                                     event->client, event->origin,
-                                    ((!fence_full_history) &&
-                                     (output_format != mon_output_xml))?
-                                    "last-successful":"completed",
+                                    fence_full_history?"completed":"last-successful",
                                     run_at_s?run_at_s:"");
                     break;
                 case st_failed:
@@ -3297,9 +3293,7 @@ print_stonith_action(FILE *stream, stonith_history_t *event)
                                     action_s, event->target,
                                     event->delegate ? event->delegate : "",
                                     event->client, event->origin,
-                                    ((!fence_full_history) &&
-                                     (output_format != mon_output_xml))?
-                                    "last-failed":"completed",
+                                    fence_full_history?"completed":"last-failed",
                                     run_at_s?run_at_s:"");
                     break;
                 default:


### PR DESCRIPTION
and unnecessary conditionals making code less readable that were
probably introduced rearranging the code.