### PR TITLE
Test: cts: temporarily disable any enabled cluster serivces when running remote tests

### DIFF
--- a/cts/environment.py
+++ b/cts/environment.py
@@ -180,20 +180,25 @@ class Environment(object):
                 # default
                 self["syslogd"] = "rsyslog"
 
+    def service_is_enabled(self, node, service):
+        if self["have_systemd"]:
+            # Systemd
+
+            # With "systemctl is-enabled", we should check if the service is
+            # explicitly "enabled" instead of the return code. For example it returns
+            # 0 if the service is "static" or "indirect", but they don't really count
+            # as "enabled".
+            return not self.rsh(node, "systemctl is-enabled %s | grep enabled" % service)
+
+        else:
+            # SYS-V
+            return not self.rsh(node, "chkconfig --list | grep -e %s.*on" % service)
+
     def detect_at_boot(self):
         # Detect if the cluster starts at boot
         if not "at-boot" in self.data:
-            atboot = 0
-
-            if self["have_systemd"]:
-            # Systemd
-                atboot = atboot or not self.rsh(self.target, "systemctl is-enabled corosync.service")
-                atboot = atboot or not self.rsh(self.target, "systemctl is-enabled pacemaker.service")
-            else:
-                # SYS-V
-                atboot = atboot or not self.rsh(self.target, "chkconfig --list | grep -e corosync.*on -e pacemaker.*on")
-
-            self["at-boot"] = atboot
+            self["at-boot"] = self.service_is_enabled(self.target, "corosync") \
+                              or self.service_is_enabled(self.target, "pacemaker")
 
     def detect_ip_offset(self):
         # Try to determine an offset for IPaddr resources

--- a/cts/environment.py
+++ b/cts/environment.py
@@ -180,6 +180,24 @@ class Environment(object):
                 # default
                 self["syslogd"] = "rsyslog"
 
+    def disable_service(self, node, service):
+        if self["have_systemd"]:
+            # Systemd
+            return self.rsh(node, "systemctl disable %s" % service)
+
+        else:
+            # SYS-V
+            return self.rsh(node, "chkconfig %s off" % service)
+
+    def enable_service(self, node, service):
+        if self["have_systemd"]:
+            # Systemd
+            return self.rsh(node, "systemctl enable %s" % service)
+
+        else:
+            # SYS-V
+            return self.rsh(node, "chkconfig %s on" % service)
+
     def service_is_enabled(self, node, service):
         if self["have_systemd"]:
             # Systemd


### PR DESCRIPTION
Cluster nodes are reused as remote nodes in remote tests. If cluster
services were enabled at boot, in case the remote node got fenced, the
cluster node would join instead of the expected remote one. Meanwhile
pacemaker_remote would not be able to start. Depending on the chances,
the situations might not be able to be orchestrated gracefully any more.