### PR TITLE
[2.0.1] restore gcc9 buildability

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -594,8 +594,8 @@ parse_peer_options_v1(int call_type, xmlNode * request,
         return TRUE;
     }
 
-    crm_trace("Processing %s request sent by %s", op, originator);
     op = crm_element_value(request, F_CIB_OPERATION);
+    crm_trace("Processing %s request sent by %s", op, originator);
     if (safe_str_eq(op, "cib_shutdown_req")) {
         /* Always process these */
         *local_notify = FALSE;
@@ -650,11 +650,11 @@ parse_peer_options_v1(int call_type, xmlNode * request,
 
     } else if (safe_str_eq(op, "cib_shutdown_req")) {
         if (reply_to != NULL) {
-            crm_debug("Processing %s from %s", op, host);
+            crm_debug("Processing %s from %s", op, originator);
             *needs_reply = FALSE;
 
         } else {
-            crm_debug("Processing %s reply from %s", op, host);
+            crm_debug("Processing %s reply from %s", op, originator);
         }
         return TRUE;
 

--- a/tools/test.iso8601.c
+++ b/tools/test.iso8601.c
@@ -8,6 +8,7 @@
 #include <crm_internal.h>
 #include <crm/crm.h>
 #include <crm/common/iso8601.h>
+#include <crm/common/util.h>  /* CRM_ASSERT */
 #include <unistd.h>
 
 char command = 0;
@@ -46,13 +47,9 @@ static struct crm_option long_options[] = {
 static void
 log_time_period(int log_level, crm_time_period_t * dtp, int flags)
 {
-    char *end = NULL;
-    char *start = NULL;
-
-    if(dtp) {
-        start = crm_time_as_string(dtp->start, flags);
-        end = crm_time_as_string(dtp->end, flags);
-    }
+    char *start = crm_time_as_string(dtp->start, flags);
+    char *end = crm_time_as_string(dtp->end, flags);
+    CRM_ASSERT(start != NULL && end != NULL);
 
     if (log_level < LOG_CRIT) {
         printf("Period: %s to %s\n", start, end);


### PR DESCRIPTION
Sadly, pacemaker codebase seems to be possibly heavily spoiled with
this undefined behaviour when possibly passing NULL corresponding to
'%s' format specifier argument, so for the time being, fix just what
new GCC 9 started to spot[*] (due to build-time constant NULLs, which
is an immediate proof) since these occurrences boil down to mere
thinkos.  Related to that, would be wise to start rolling out
nonnull annotations to preserve more general sanity in this self
explanatory aspect.

Looking at libqb code (end destination of "crm_log" processing), there's
nothing to implicitly mask NULL with a predestined string explicitly
(like glibc make do with "(null)" in majority of the cases), so unless
merely a blackbox is used for logging (qb_vsnprintf_serialize seems to
deal with such a NULL gracefully), passing NULLs where a character array
is expected is rather dangerous without the prior knowledge of
particular libc implementation.

[*] https://gcc.gnu.org/git/?p=gcc.git;a=blobdiff;f=gcc/gimple-ssa-sprintf.c;h=456a7d400115713a6600b1ce7bb303b6c971550e;hb=7b2ced2fa2c0597ba083461864c9026c3c9d3720;hpb=b07bf3b9730bebfc9953ea2eeee86a1274e39022