### PR TITLE
Complete the fix for losing attribute write-out at node shutdown

### DIFF
--- a/daemons/attrd/attrd_elections.c
+++ b/daemons/attrd/attrd_elections.c
@@ -59,10 +59,10 @@ attrd_handle_election_op(const crm_node_t *peer, xmlNode *xml)
 
     switch(rc) {
         case election_start:
-            free(peer_writer);
-            peer_writer = NULL;
             crm_debug("Unsetting writer (was %s) and starting new election",
                       peer_writer? peer_writer : "unset");
+            free(peer_writer);
+            peer_writer = NULL;
             election_vote(writer);
             break;
 

--- a/daemons/attrd/attrd_elections.c
+++ b/daemons/attrd/attrd_elections.c
@@ -137,6 +137,11 @@ attrd_remove_voter(const crm_node_t *peer)
         peer_writer = NULL;
         crm_notice("Lost attribute writer %s", peer->uname);
 
+        /* Clear any election dampening in effect. Otherwise, if the lost writer
+         * had just won, the election could fizzle out with no new writer.
+         */
+        election_clear_dampening(writer);
+
         /* If the writer received attribute updates during its shutdown, it will
          * not have written them to the CIB. Ensure we get a new writer so they
          * are written out. This means that every node that sees the writer

--- a/include/crm/cluster/election.h
+++ b/include/crm/cluster/election.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2009-2019 Andrew Beekhof <andrew@beekhof.net>
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -76,6 +76,7 @@ bool election_check(election_t *e);
 void election_remove(election_t *e, const char *uname);
 enum election_result election_state(election_t *e);
 enum election_result election_count_vote(election_t *e, xmlNode *vote, bool can_win);
+void election_clear_dampening(election_t *e);
 
 #ifdef __cplusplus
 }

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -706,3 +706,14 @@ election_count_vote(election_t *e, xmlNode *message, bool can_win)
     e->state = election_lost;
     return e->state;
 }
+
+/*!
+ * \brief Reset any election dampening currently in effect
+ *
+ * \param[in] e        Election object to clear
+ */
+void
+election_clear_dampening(election_t *e)
+{
+    e->last_election_loss = 0;
+}

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2019 Andrew Beekhof <andrew@beekhof.net>
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -644,6 +644,7 @@ election_count_vote(election_t *e, xmlNode *message, bool can_win)
                  * write a blackbox on every Nth occurrence.
                  */
                 crm_write_blackbox(0, NULL);
+                wrote_blackbox = TRUE;
             }
         }
     }


### PR DESCRIPTION
Commit 435b7728 ironically made a second avenue for the problem it fixed more likely, by making it easier to hit a pre-existing timing issue in the libcrmcluster election code. This fixes that second avenue.