### PR TITLE
Fix: controld: ensure existing node attributes get written back into CIB after daemons failed and got respawned

### DIFF
--- a/daemons/controld/controld_attrd.c
+++ b/daemons/controld/controld_attrd.c
@@ -171,3 +171,9 @@ update_attrd_clear_failures(const char *host, const char *rsc, const char *op,
              interval_desc, op_desc, rsc, node_type, host);
     update_attrd_helper(host, rsc, op, interval_spec, NULL, is_remote_node, 0);
 }
+
+void
+refresh_attrd(void)
+{
+    update_attrd_helper(NULL, NULL, NULL, NULL, NULL, FALSE, 'R');
+}

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -211,6 +211,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
             } else if(AM_I_DC) {
                 if (appeared) {
                     te_trigger_stonith_history_sync();
+                    refresh_attrd();
                 } else {
                     erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
                 }

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -77,6 +77,7 @@ void update_attrd_remote_node_removed(const char *host, const char *user_name);
 void update_attrd_clear_failures(const char *host, const char *rsc,
                                  const char *op, const char *interval_spec,
                                  gboolean is_remote_node);
+void refresh_attrd(void);
 
 int crmd_join_phase_count(enum crm_join_phase phase);
 void crmd_join_phase_log(int level);


### PR DESCRIPTION
If a pacemaker daemon unexpectedly exits, the daemon and probably also
other daemons including controld will try to get respawned. Previously
depending on which daemon had failed, if controld got respawned either
itself or together with some other daemons, existing attributes of this
node might not get written back into CIB again.

It was found by the cts test "Reattach" randomly failing due to loss of
the node attribute "connected" in the CIB right after the test
"ComponentFail", for example if controld or execd was the failed
component.