### PR TITLE
Refactor: get rid of redundancy/wasted effort incurred with crm_perror

### DIFF
--- a/daemons/based/based_io.c
+++ b/daemons/based/based_io.c
@@ -45,7 +45,7 @@ cib_rename(const char *old)
     umask(S_IWGRP | S_IWOTH | S_IROTH);
     new_fd = mkstemp(new);
     if ((new_fd < 0) || (rename(old, new) < 0)) {
-        crm_perror(LOG_ERR, "Couldn't rename %s as %s", old, new);
+        crm_log_perror(LOG_ERR, "Couldn't rename %s as %s", old, new);
         crm_err("Disabling disk writes and continuing");
         cib_writes_enabled = FALSE;
     }
@@ -208,7 +208,7 @@ readCibXmlFile(const char *dir, const char *file, gboolean discard_status)
         crm_warn("Primary configuration corrupt or unusable, trying backups in %s", cib_root);
         lpc = scandir(cib_root, &namelist, cib_archive_filter, cib_archive_sort);
         if (lpc < 0) {
-            crm_perror(LOG_NOTICE, "scandir(%s) failed", cib_root);
+            crm_log_perror(LOG_NOTICE, "scandir(%s) failed", cib_root);
         }
     }
 
@@ -406,7 +406,7 @@ write_cib_contents(gpointer p)
 
         pid = fork();
         if (pid < 0) {
-            crm_perror(LOG_ERR, "Disabling disk writes after fork failure");
+            crm_log_perror(LOG_ERR, "Disabling disk writes after fork failure");
             cib_writes_enabled = FALSE;
             return FALSE;
         }

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -124,13 +124,13 @@ init_remote_listener(int port, gboolean encrypted)
     /* create server socket */
     ssock = malloc(sizeof(int));
     if(ssock == NULL) {
-        crm_perror(LOG_ERR, "Listener socket allocation failed");
+        crm_log_perror(LOG_ERR, "Listener socket allocation failed");
         return -1;
     }
 
     *ssock = socket(AF_INET, SOCK_STREAM, 0);
     if (*ssock == -1) {
-        crm_perror(LOG_ERR, "Listener socket creation failed");
+        crm_log_perror(LOG_ERR, "Listener socket creation failed");
         free(ssock);
         return -1;
     }
@@ -139,8 +139,8 @@ init_remote_listener(int port, gboolean encrypted)
     optval = 1;
     rc = setsockopt(*ssock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
     if (rc < 0) {
-        crm_perror(LOG_WARNING,
-                   "Local address reuse not allowed on listener socket");
+        crm_log_perror(LOG_WARNING,
+                       "Local address reuse not allowed on listener socket");
     }
 
     /* bind server socket */
@@ -149,13 +149,13 @@ init_remote_listener(int port, gboolean encrypted)
     saddr.sin_addr.s_addr = INADDR_ANY;
     saddr.sin_port = htons(port);
     if (bind(*ssock, (struct sockaddr *)&saddr, sizeof(saddr)) == -1) {
-        crm_perror(LOG_ERR, "Cannot bind to listener socket");
+        crm_log_perror(LOG_ERR, "Cannot bind to listener socket");
         close(*ssock);
         free(ssock);
         return -2;
     }
     if (listen(*ssock, 10) == -1) {
-        crm_perror(LOG_ERR, "Cannot listen on socket");
+        crm_log_perror(LOG_ERR, "Cannot listen on socket");
         close(*ssock);
         free(ssock);
         return -3;
@@ -294,7 +294,7 @@ cib_remote_listen(gpointer data)
     memset(&addr, 0, sizeof(addr));
     csock = accept(ssock, (struct sockaddr *)&addr, &laddr);
     if (csock == -1) {
-        crm_perror(LOG_ERR, "Could not accept socket connection");
+        crm_log_perror(LOG_ERR, "Could not accept socket connection");
         return TRUE;
     }
 

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -117,24 +117,28 @@ main(int argc, char **argv)
 
                 pwentry = getpwnam(CRM_DAEMON_USER);
                 CRM_CHECK(pwentry != NULL,
-                          crm_perror(LOG_ERR, "Invalid uid (%s) specified", CRM_DAEMON_USER);
+                          crm_log_perror(LOG_ERR, "Invalid uid (%s) specified",
+                                         CRM_DAEMON_USER);
                           return CRM_EX_FATAL);
 
                 rc = setgid(pwentry->pw_gid);
                 if (rc < 0) {
-                    crm_perror(LOG_ERR, "Could not set group to %d", pwentry->pw_gid);
+                    crm_log_perror(LOG_ERR, "Could not set group to %d",
+                                   pwentry->pw_gid);
                     return CRM_EX_FATAL;
                 }
 
                 rc = initgroups(CRM_DAEMON_USER, pwentry->pw_gid);
                 if (rc < 0) {
-                    crm_perror(LOG_ERR, "Could not setup groups for user %d", pwentry->pw_uid);
+                    crm_log_perror(LOG_ERR, "Could not setup groups for user %d",
+                                   pwentry->pw_uid);
                     return CRM_EX_FATAL;
                 }
 
                 rc = setuid(pwentry->pw_uid);
                 if (rc < 0) {
-                    crm_perror(LOG_ERR, "Could not set user to %d", pwentry->pw_uid);
+                    crm_log_perror(LOG_ERR, "Could not set user to %d",
+                                   pwentry->pw_uid);
                     return CRM_EX_FATAL;
                 }
                 break;

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -225,7 +225,7 @@ remote_node_up(const char *node_name)
      */
     fsa_cib_update(XML_CIB_TAG_STATUS, update, call_opt, call_id, NULL);
     if (call_id < 0) {
-        crm_perror(LOG_WARNING, "%s CIB node state setup", node_name);
+        crm_log_perror(LOG_WARNING, "%s CIB node state setup", node_name);
     }
     free_xml(update);
 }
@@ -277,7 +277,7 @@ remote_node_down(const char *node_name, const enum down_opts opts)
     create_node_state_update(node, node_update_cluster, update, __FUNCTION__);
     fsa_cib_update(XML_CIB_TAG_STATUS, update, call_opt, call_id, NULL);
     if (call_id < 0) {
-        crm_perror(LOG_ERR, "%s CIB node state update", node_name);
+        crm_log_perror(LOG_ERR, "%s CIB node state update", node_name);
     }
     free_xml(update);
 }
@@ -1227,7 +1227,8 @@ remote_ra_maintenance(lrm_state_t * lrm_state, gboolean maintenance)
     crm_xml_add(state, XML_NODE_IS_MAINTENANCE, maintenance?"1":"0");
     fsa_cib_update(XML_CIB_TAG_STATUS, update, call_opt, call_id, NULL);
     if (call_id < 0) {
-        crm_perror(LOG_WARNING, "%s CIB node state update failed", lrm_state->node_name);
+        crm_log_perror(LOG_WARNING, "%s CIB node state update failed",
+                       lrm_state->node_name);
     } else {
         /* TODO: still not 100% sure that async update will succeed ... */
         ra_data->is_maintenance = maintenance;

--- a/daemons/execd/remoted_tls.c
+++ b/daemons/execd/remoted_tls.c
@@ -261,7 +261,7 @@ bind_and_listen(struct addrinfo *addr)
 
     fd = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
     if (fd < 0) {
-        crm_perror(LOG_ERR, "Listener socket creation failed");
+        crm_log_perror(LOG_ERR, "Listener socket creation failed");
         return -1;
     }
 
@@ -269,7 +269,8 @@ bind_and_listen(struct addrinfo *addr)
     optval = 1;
     rc = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
     if (rc < 0) {
-        crm_perror(LOG_ERR, "Local address reuse not allowed on %s", buffer);
+        crm_log_perror(LOG_ERR, "Local address reuse not allowed on %s",
+                       buffer);
         close(fd);
         return -1;
     }
@@ -278,20 +279,21 @@ bind_and_listen(struct addrinfo *addr)
         optval = 0;
         rc = setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &optval, sizeof(optval));
         if (rc < 0) {
-            crm_perror(LOG_INFO, "Couldn't disable IPV6-only on %s", buffer);
+            crm_log_perror(LOG_INFO, "Couldn't disable IPV6-only on %s",
+                           buffer);
             close(fd);
             return -1;
         }
     }
 
     if (bind(fd, addr->ai_addr, addr->ai_addrlen) != 0) {
-        crm_perror(LOG_ERR, "Cannot bind to %s", buffer);
+        crm_log_perror(LOG_ERR, "Cannot bind to %s", buffer);
         close(fd);
         return -1;
     }
 
     if (listen(fd, 10) == -1) {
-        crm_perror(LOG_ERR, "Cannot listen on %s", buffer);
+        crm_log_perror(LOG_ERR, "Cannot listen on %s", buffer);
         close(fd);
         return -1;
     }

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -232,8 +232,8 @@ stop_child(pcmk_child_t * child, int signal)
                    child->name, signal, child->pid);
 
     } else {
-        crm_perror(LOG_ERR, "Could not stop %s (process %d) with signal %d",
-                   child->name, child->pid, signal);
+        crm_log_perror(LOG_ERR, "Could not stop %s (process %d) with signal %d",
+                       child->name, child->pid, signal);
     }
 
     return TRUE;
@@ -336,7 +336,7 @@ start_child(pcmk_child_t * child)
 
             // Drop root group access if not needed
             if (!need_root_group && (setgid(gid) < 0)) {
-                crm_perror(LOG_ERR, "Could not set group to %d", gid);
+                crm_log_perror(LOG_ERR, "Could not set group to %d", gid);
             }
 
             /* Initialize supplementary groups to only those always granted to
@@ -348,7 +348,8 @@ start_child(pcmk_child_t * child)
         }
 
         if (uid && setuid(uid) < 0) {
-            crm_perror(LOG_ERR, "Could not set user to %d (%s)", uid, child->uid);
+            crm_log_perror(LOG_ERR, "Could not set user to %d (%s)",
+                           uid, child->uid);
         }
 
         /* Close all open file descriptors */
@@ -366,7 +367,7 @@ start_child(pcmk_child_t * child)
         } else {
             (void)execvp(child->command, opts_default);
         }
-        crm_perror(LOG_ERR, "FATAL: Cannot exec %s", child->command);
+        crm_log_perror(LOG_ERR, "FATAL: Cannot exec %s", child->command);
         crm_exit(CRM_EX_FATAL);
     }
     return TRUE;                /* never reached */
@@ -1023,7 +1024,7 @@ main(int argc, char **argv)
 
     rc = getrlimit(RLIMIT_CORE, &cores);
     if (rc < 0) {
-        crm_perror(LOG_ERR, "Cannot determine current maximum core size.");
+        crm_log_perror(LOG_ERR, "Cannot determine current maximum core size.");
     } else {
         if (cores.rlim_max == 0 && geteuid() == 0) {
             cores.rlim_max = RLIM_INFINITY;
@@ -1034,10 +1035,10 @@ main(int argc, char **argv)
 
         rc = setrlimit(RLIMIT_CORE, &cores);
         if (rc < 0) {
-            crm_perror(LOG_ERR,
-                       "Core file generation will remain disabled."
-                       " Core files are an important diagnostic tool, so"
-                       " please consider enabling them by default.");
+            crm_log_perror(LOG_ERR,
+                           "Core file generation will remain disabled."
+                           " Core files are an important diagnostic tool, so"
+                           " please consider enabling them by default.");
         }
     }
 

--- a/include/crm/common/logging.h
+++ b/include/crm/common/logging.h
@@ -223,6 +223,29 @@ unsigned int get_crm_log_level(void);
  * \note Because crm_perror() adds the system error message and error number
  *       onto the end of fmt, that information will become extended information
  *       if CRM_XS is used inside fmt and will not show up in syslog.
+ * \note Unlike with \c crm_perror, you only want to use this function with
+ *       logging already set up, since there's no dual sink to stderr, which
+ *       is what makes this very variant more appealing for that use case:
+ *       no redundancy/wasted effort in formatting string that may be get
+ *       dropped anyway, e.g., when stderr is redirected to /dev/null.
+ */
+#  define crm_log_perror(level, fmt, args...) do {			\
+        const char *err = strerror(errno);                              \
+        do_crm_log(level, fmt ": %s (%d)" , ##args, err, errno);        \
+    } while(0)
+
+/*!
+ * \brief Log + emit to stderr a system error message
+ *
+ * \param[in] level  Severity at which to log the message
+ * \param[in] fmt    printf-style format string for message
+ * \param[in] args   Any arguments needed by format string
+ *
+ * \note Because crm_perror() adds the system error message and error number
+ *       onto the end of fmt, that information will become extended information
+ *       if CRM_XS is used inside fmt and will not show up in syslog.
+ * \note Unlike with \c crm_log_perror, this function shall not be used
+ *       once you have logging already set up.
  */
 #  define crm_perror(level, fmt, args...) do {				\
         const char *err = strerror(errno);                              \

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -95,7 +95,7 @@ find_nvpair_attr_delegate(cib_t * the_cib, const char *attr, const char *section
 
     xpath_string = calloc(1, XPATH_MAX);
     if (xpath_string == NULL) {
-        crm_perror(LOG_CRIT, "Could not create xpath");
+        crm_log_perror(LOG_CRIT, "Could not create xpath");
         return -ENOMEM;
     }
 

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -221,9 +221,9 @@ get_shadow_file(const char *suffix)
             user = pwent->pw_name;
         } else {
             user = getenv("USER");
-            crm_perror(LOG_ERR,
-                       "Assuming %s because cannot get user details for user ID %d",
-                       (user? user : "unprivileged user"), uid);
+            crm_log_perror(LOG_ERR,
+                           "Assuming %s because cannot get user details for user ID %d",
+                           (user? user : "unprivileged user"), uid);
         }
 
         if (safe_str_eq(user, "root") || safe_str_eq(user, CRM_DAEMON_USER)) {
@@ -246,8 +246,9 @@ get_shadow_file(const char *suffix)
 
                 rc = mkdir(cib_home, 0700);
                 if (rc < 0 && errno != EEXIST) {
-                    crm_perror(LOG_ERR, "Couldn't create user-specific shadow directory: %s",
-                               cib_home);
+                    crm_log_perror(LOG_ERR,
+                                   "Couldn't create user-specific shadow directory: %s",
+                                   cib_home);
                     errno = 0;
 
                 } else {

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -212,7 +212,8 @@ cib_native_signon_raw(cib_t * cib, const char *name, enum cib_conn_type type, in
             *async_fd = crm_ipc_get_fd(native->ipc);
 
         } else if (native->ipc) {
-            crm_perror(LOG_ERR, "Connection to cluster information base failed");
+            crm_log_perror(LOG_ERR,
+                           "Connection to cluster information base failed");
             rc = -ENOTCONN;
         }
 

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -211,8 +211,8 @@ cib_tls_signon(cib_t * cib, crm_remote_t * connection, gboolean event_channel)
 #endif
     sock = crm_remote_tcp_connect(private->server, private->port);
     if (sock < 0) {
-        crm_perror(LOG_ERR, "remote tcp connection to %s:%d failed", private->server,
-                   private->port);
+        crm_log_perror(LOG_ERR, "remote tcp connection to %s:%d failed",
+                       private->server, private->port);
         return -ENOTCONN;
     }
 

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -90,13 +90,13 @@ election_init(const char *name, const char *uname, guint period_ms, GSourceFunc 
 
     e = calloc(1, sizeof(election_t));
     if (e == NULL) {
-        crm_perror(LOG_CRIT, "Cannot create election");
+        crm_log_perror(LOG_CRIT, "Cannot create election");
         return NULL;
     }
 
     e->uname = strdup(uname);
     if (e->uname == NULL) {
-        crm_perror(LOG_CRIT, "Cannot create election");
+        crm_log_perror(LOG_CRIT, "Cannot create election");
         free(e);
         return NULL;
     }
@@ -224,7 +224,7 @@ crm_uptime(struct timeval *output)
         output->tv_usec = 0;
 
         if (rc < 0) {
-            crm_perror(LOG_ERR, "Could not calculate the current uptime");
+            crm_log_perror(LOG_ERR, "Could not calculate the current uptime");
             expires = 0;
             return -1;
         }

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -646,7 +646,7 @@ uid2username(uid_t uid)
     struct passwd *pwent = getpwuid(uid);
 
     if (pwent == NULL) {
-        crm_perror(LOG_INFO, "Cannot get user details for user ID %d", uid);
+        crm_log_perror(LOG_INFO, "Cannot get user details for user ID %d", uid);
         return NULL;
     }
     return strdup(pwent->pw_name);

--- a/lib/common/attrd_client.c
+++ b/lib/common/attrd_client.c
@@ -78,7 +78,8 @@ send_attrd_op(crm_ipc_t *ipc, xmlNode *attrd_op)
         if (connected) {
             rc = crm_ipc_send(ipc, attrd_op, flags, 0, NULL);
         } else {
-            crm_perror(LOG_INFO, "Connection to cluster attribute manager failed");
+            crm_log_perror(LOG_INFO,
+                           "Connection to cluster attribute manager failed");
         }
 
         if (ipc != local_ipc) {

--- a/lib/common/cib_secrets.c
+++ b/lib/common/cib_secrets.c
@@ -62,13 +62,13 @@ read_local_file(char *local_file)
 
     if (!fp) {
         if (errno != ENOENT) {
-            crm_perror(LOG_ERR, "cannot open %s" , local_file);
+            crm_log_perror(LOG_ERR, "cannot open %s" , local_file);
         }
         return NULL;
     }
 
     if (!fgets(buf, MAX_VALUE_LEN, fp)) {
-        crm_perror(LOG_ERR, "cannot read %s", local_file);
+        crm_log_perror(LOG_ERR, "cannot read %s", local_file);
         fclose(fp);
         return NULL;
     }

--- a/lib/common/digest.c
+++ b/lib/common/digest.c
@@ -231,7 +231,8 @@ crm_digest_verify(xmlNode *input, const char *expected)
     if (input != NULL) {
         calculated = calculate_on_disk_digest(input);
         if (calculated == NULL) {
-            crm_perror(LOG_ERR, "Could not calculate digest for comparison");
+            crm_log_perror(LOG_ERR,
+                           "Could not calculate digest for comparison");
             return FALSE;
         }
     }

--- a/lib/common/io.c
+++ b/lib/common/io.c
@@ -46,14 +46,15 @@ crm_build_path(const char *path_c, mode_t mode)
         if (path[offset] == '/') {
             path[offset] = 0;
             if (mkdir(path, mode) < 0 && errno != EEXIST) {
-                crm_perror(LOG_ERR, "Could not create directory '%s'", path);
+                crm_log_perror(LOG_ERR, "Could not create directory '%s'",
+                               path);
                 break;
             }
             path[offset] = '/';
         }
     }
     if (mkdir(path, mode) < 0 && errno != EEXIST) {
-        crm_perror(LOG_ERR, "Could not create directory '%s'", path);
+        crm_log_perror(LOG_ERR, "Could not create directory '%s'", path);
     }
 
     free(path);
@@ -186,7 +187,8 @@ write_last_sequence(const char *directory, const char *series, int sequence, int
     if (file_strm != NULL) {
         rc = fprintf(file_strm, "%d", sequence);
         if (rc < 0) {
-            crm_perror(LOG_ERR, "Cannot write to series file %s", series_file);
+            crm_log_perror(LOG_ERR, "Cannot write to series file %s",
+                           series_file);
         }
 
     } else {
@@ -377,21 +379,22 @@ crm_sync_directory(const char *name)
 
     directory = opendir(name);
     if (directory == NULL) {
-        crm_perror(LOG_ERR, "Could not open %s for syncing", name);
+        crm_log_perror(LOG_ERR, "Could not open %s for syncing", name);
         return;
     }
 
     fd = dirfd(directory);
     if (fd < 0) {
-        crm_perror(LOG_ERR, "Could not obtain file descriptor for %s", name);
+        crm_log_perror(LOG_ERR, "Could not obtain file descriptor for %s",
+                       name);
         return;
     }
 
     if (fsync(fd) < 0) {
-        crm_perror(LOG_ERR, "Could not sync %s", name);
+        crm_log_perror(LOG_ERR, "Could not sync %s", name);
     }
     if (closedir(directory) < 0) {
-        crm_perror(LOG_ERR, "Could not close %s after fsync", name);
+        crm_log_perror(LOG_ERR, "Could not close %s after fsync", name);
     }
 }
 

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -294,7 +294,7 @@ client_from_connection(qb_ipcs_connection_t *c, void *key, uid_t uid_client)
     crm_client_t *client = calloc(1, sizeof(crm_client_t));
 
     if (client == NULL) {
-        crm_perror(LOG_ERR, "Allocating client");
+        crm_log_perror(LOG_ERR, "Allocating client");
         return NULL;
     }
 
@@ -1012,8 +1012,8 @@ crm_ipc_get_fd(crm_ipc_t * client)
         return fd;
     }
     errno = EINVAL;
-    crm_perror(LOG_ERR, "Could not obtain file IPC descriptor for %s",
-               (client? client->name : "unspecified client"));
+    crm_log_perror(LOG_ERR, "Could not obtain file IPC descriptor for %s",
+                   (client? client->name : "unspecified client"));
     return -errno;
 }
 

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -294,7 +294,7 @@ crm_signal(int sig, void (*dispatch) (int sig))
     struct sigaction old;
 
     if (sigemptyset(&mask) < 0) {
-        crm_perror(LOG_ERR, "Call to sigemptyset failed");
+        crm_log_perror(LOG_ERR, "Call to sigemptyset failed");
         return FALSE;
     }
 
@@ -304,7 +304,9 @@ crm_signal(int sig, void (*dispatch) (int sig))
     sa.sa_mask = mask;
 
     if (sigaction(sig, &sa, &old) < 0) {
-        crm_perror(LOG_ERR, "Could not install signal handler for signal %d", sig);
+        crm_log_perror(LOG_ERR,
+                       "Could not install signal handler for signal %d",
+                       sig);
         return FALSE;
     }
 
@@ -369,7 +371,9 @@ mainloop_add_signal(int sig, void (*dispatch) (int sig))
      * For now, just enforce a low timeout
      */
     if (siginterrupt(sig, 1) < 0) {
-        crm_perror(LOG_INFO, "Could not enable system call interruptions for signal %d", sig);
+        crm_log_perror(LOG_INFO,
+                       "Could not enable system call interruptions for signal %d",
+                       sig);
     }
 #endif
 
@@ -384,7 +388,9 @@ mainloop_destroy_signal(int sig)
         return FALSE;
 
     } else if (crm_signal(sig, NULL) == FALSE) {
-        crm_perror(LOG_ERR, "Could not uninstall signal handler for signal %d", sig);
+        crm_log_perror(LOG_ERR,
+                       "Could not uninstall signal handler for signal %d",
+                       sig);
         return FALSE;
 
     } else if (crm_signals[sig] == NULL) {
@@ -771,7 +777,7 @@ mainloop_add_ipc_client(const char *name, int priority, size_t max_size, void *u
     }
 
     if (client == NULL) {
-        crm_perror(LOG_TRACE, "Connection to %s failed", name);
+        crm_log_perror(LOG_TRACE, "Connection to %s failed", name);
         if (conn) {
             crm_ipc_close(conn);
             crm_ipc_destroy(conn);
@@ -918,7 +924,7 @@ child_kill_helper(mainloop_child_t *child)
 
     if (rc < 0) {
         if (errno != ESRCH) {
-            crm_perror(LOG_ERR, "kill(%d, KILL) failed", child->pid);
+            crm_log_perror(LOG_ERR, "kill(%d, KILL) failed", child->pid);
         }
         return -errno;
     }
@@ -961,14 +967,14 @@ child_waitpid(mainloop_child_t *child, int flags)
 
     rc = waitpid(child->pid, &status, flags);
     if(rc == 0) {
-        crm_perror(LOG_DEBUG, "wait(%d) = %d", child->pid, rc);
+        crm_log_perror(LOG_DEBUG, "wait(%d) = %d", child->pid, rc);
         return FALSE;
 
     } else if(rc != child->pid) {
         signo = SIGCHLD;
         exitcode = 1;
         status = 1;
-        crm_perror(LOG_ERR, "Call to waitpid(%d) failed", child->pid);
+        crm_log_perror(LOG_ERR, "Call to waitpid(%d) failed", child->pid);
 
     } else {
         crm_trace("Managed process %d exited: %p", child->pid, child);

--- a/lib/common/pid.c
+++ b/lib/common/pid.c
@@ -53,10 +53,10 @@ crm_pid_active(long pid, const char *daemon)
 
         rc = readlink(proc_path, exe_path, PATH_MAX - 1);
         if ((rc < 0) && (errno == EACCES)) {
-            crm_perror(LOG_INFO, "Could not read from %s", proc_path);
+            crm_log_perror(LOG_INFO, "Could not read from %s", proc_path);
             return 1;
         } else if (rc < 0) {
-            crm_perror(LOG_ERR, "Could not read from %s", proc_path);
+            crm_log_perror(LOG_ERR, "Could not read from %s", proc_path);
             return 0;
         }
 
@@ -175,7 +175,7 @@ crm_lock_pidfile(const char *filename, const char *name)
     close(fd);
 
     if (rc != LOCKSTRLEN) {
-        crm_perror(LOG_ERR, "Incomplete write to %s", filename);
+        crm_log_perror(LOG_ERR, "Incomplete write to %s", filename);
         return -errno;
     }
 

--- a/lib/common/procfs.c
+++ b/lib/common/procfs.c
@@ -149,7 +149,7 @@ crm_procfs_num_cores(void)
     /* Parse /proc/stat instead of /proc/cpuinfo because it's smaller */
     stream = fopen("/proc/stat", "r");
     if (stream == NULL) {
-        crm_perror(LOG_INFO, "Could not open /proc/stat");
+        crm_log_perror(LOG_INFO, "Could not open /proc/stat");
     } else {
         char buffer[2048];
 

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -435,9 +435,9 @@ crm_send_plaintext(int sock, const char *buf, size_t len)
                 crm_trace("Retry");
                 goto retry;
             default:
-                crm_perror(LOG_INFO,
-                           "Could only write %d of the remaining %llu bytes",
-                           rc, (unsigned long long) len);
+                crm_log_perror(LOG_INFO,
+                               "Could only write %d of the remaining %llu bytes",
+                               rc, (unsigned long long) len);
                 break;
         }
 
@@ -929,7 +929,7 @@ internal_tcp_connect_async(int sock,
 
     rc = connect(sock, addr, addrlen);
     if (rc < 0 && (errno != EINPROGRESS) && (errno != EAGAIN)) {
-        crm_perror(LOG_WARNING, "connect");
+        crm_log_perror(LOG_WARNING, "connect");
         return -1;
     }
 
@@ -1046,8 +1046,8 @@ crm_remote_tcp_connect_async(const char *host, int port, int timeout,
 
         sock = socket(rp->ai_family, SOCK_STREAM, IPPROTO_TCP);
         if (sock == -1) {
-            crm_perror(LOG_WARNING, "creating socket for connection to %s",
-                       server);
+            crm_log_perror(LOG_WARNING, "creating socket for connection to %s",
+                           server);
             sock = -ENOTCONN;
             continue;
         }

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -642,7 +642,7 @@ dump_file(const char *filename)
 
     fp = fopen(filename, "r");
     if (fp == NULL) {
-        crm_perror(LOG_ERR, "Could not open %s for reading", filename);
+        crm_log_perror(LOG_ERR, "Could not open %s for reading", filename);
         return;
     }
 

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -61,7 +61,7 @@ crm_int_helper(const char *text, char **end_text)
             crm_err("Conversion of %s was clipped: %lld", text, result);
 
         } else if (errno != 0) {
-            crm_perror(LOG_ERR, "Conversion of %s failed", text);
+            crm_log_perror(LOG_ERR, "Conversion of %s failed", text);
         }
 
         if (local_end_text != NULL && local_end_text[0] != '\0') {

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -678,7 +678,7 @@ crm_abort(const char *file, const char *function, int line,
         crm_trace("Cannot wait on forked child %d - SIGCHLD is probably set to SIG_IGN", pid);
         return;
     }
-    crm_perror(LOG_ERR, "Cannot wait on forked child %d", pid);
+    crm_log_perror(LOG_ERR, "Cannot wait on forked child %d", pid);
 }
 
 void
@@ -704,7 +704,7 @@ crm_make_daemon(const char *name, gboolean daemonize, const char *pidfile)
     pid = fork();
     if (pid < 0) {
         fprintf(stderr, "%s: could not start daemon\n", name);
-        crm_perror(LOG_ERR, "fork");
+        crm_log_perror(LOG_ERR, "fork");
         crm_exit(CRM_EX_OSERR);
 
     } else if (pid > 0) {

--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -42,7 +42,7 @@ sysrq_trigger(char t)
     // Root can always write here, regardless of kernel.sysrq value
     procf = fopen("/proc/sysrq-trigger", "a");
     if (!procf) {
-        crm_perror(LOG_WARNING, "Opening sysrq-trigger failed");
+        crm_log_perror(LOG_WARNING, "Opening sysrq-trigger failed");
         return;
     }
     crm_info("sysrq-trigger: %c", t);
@@ -84,7 +84,8 @@ pcmk_panic_local(void)
         do_crm_log_always(LOG_EMERG, "Signaling pacemakerd(%d) to panic", ppid);
 
         if(ppid > 1 && sigqueue(ppid, SIGQUIT, signal_value) < 0) {
-            crm_perror(LOG_EMERG, "Cannot signal pacemakerd(%d) to panic", ppid);
+            crm_log_perror(LOG_EMERG, "Cannot signal pacemakerd(%d) to panic",
+                           ppid);
         }
 #endif // SUPPORT_PROCFS
 
@@ -126,7 +127,8 @@ pcmk_panic_sbd(void)
     memset(&signal_value, 0, sizeof(signal_value));
     /* TODO: Arrange for a slightly less brutal option? */
     if(sigqueue(sbd_pid, SIGKILL, signal_value) < 0) {
-        crm_perror(LOG_EMERG, "Cannot signal SBD(%d) to terminate", sbd_pid);
+        crm_log_perror(LOG_EMERG, "Cannot signal SBD(%d) to terminate",
+                       sbd_pid);
         pcmk_panic_local();
     }
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -79,7 +79,7 @@ pcmk__tracking_xml_changes(xmlNode *xml, bool lazy)
             rc = snprintf((buffer) + (offset), (max) - (offset), fmt, ##args); \
         }                                                               \
         if(buffer && rc < 0) {                                          \
-            crm_perror(LOG_ERR, "snprintf failed at offset %d", offset); \
+            crm_log_perror(LOG_ERR, "snprintf failed at offset %d", offset); \
             (buffer)[(offset)] = 0;                                     \
             break;                                                      \
         } else if(rc >= ((max) - (offset))) {                           \
@@ -2286,7 +2286,7 @@ decompress_file(const char *filename)
     FILE *input = fopen(filename, "r");
 
     if (input == NULL) {
-        crm_perror(LOG_ERR, "Could not open %s for reading", filename);
+        crm_log_perror(LOG_ERR, "Could not open %s for reading", filename);
         return NULL;
     }
 
@@ -2553,7 +2553,7 @@ write_xml_stream(xmlNode * xml_node, const char *filename, FILE * stream, gboole
         res = fprintf(stream, "%s", buffer);
         if (res < 0) {
             res = -errno;
-            crm_perror(LOG_ERR, "writing %s", filename);
+            crm_log_perror(LOG_ERR, "writing %s", filename);
             goto bail;
         }
     }
@@ -2562,13 +2562,13 @@ write_xml_stream(xmlNode * xml_node, const char *filename, FILE * stream, gboole
 
     if (fflush(stream) != 0) {
         res = -errno;
-        crm_perror(LOG_ERR, "flushing %s", filename);
+        crm_log_perror(LOG_ERR, "flushing %s", filename);
     }
 
     /* Don't report error if the file does not support synchronization */
     if (fsync(fileno(stream)) < 0 && errno != EROFS  && errno != EINVAL) {
         res = -errno;
-        crm_perror(LOG_ERR, "synchronizing %s", filename);
+        crm_log_perror(LOG_ERR, "synchronizing %s", filename);
     }
 
     fclose(stream);

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -395,7 +395,7 @@ create_level_registration_xml(const char *node, const char *pattern,
         crm_trace("Adding %s (%dc) at offset %d", device_list->value, adding, len);
         list = realloc_safe(list, len + adding + 1);       /* +1 EOS */
         if (list == NULL) {
-            crm_perror(LOG_CRIT, "Could not create device list");
+            crm_log_perror(LOG_CRIT, "Could not create device list");
             free_xml(data);
             return NULL;
         }
@@ -557,7 +557,7 @@ st_child_term(gpointer data)
     track->last_timeout_signo = SIGTERM;
     rc = kill(-track->pid, SIGTERM);
     if (rc < 0) {
-        crm_perror(LOG_ERR, "Couldn't send SIGTERM to %d", track->pid);
+        crm_log_perror(LOG_ERR, "Couldn't send SIGTERM to %d", track->pid);
     }
     return FALSE;
 }
@@ -573,7 +573,7 @@ st_child_kill(gpointer data)
     track->last_timeout_signo = SIGKILL;
     rc = kill(-track->pid, SIGKILL);
     if (rc < 0) {
-        crm_perror(LOG_ERR, "Couldn't send SIGKILL to %d", track->pid);
+        crm_log_perror(LOG_ERR, "Couldn't send SIGKILL to %d", track->pid);
     }
     return FALSE;
 }
@@ -934,7 +934,7 @@ internal_stonith_action_execute(stonith_action_t * action)
     } while (errno == EINTR && total < len);
 
     if (total != len) {
-        crm_perror(LOG_ERR, "Sent %d not %d bytes", total, len);
+        crm_log_perror(LOG_ERR, "Sent %d not %d bytes", total, len);
         if (ret >= 0) {
             rc = -ECOMM;
         }
@@ -996,7 +996,7 @@ internal_stonith_action_execute(stonith_action_t * action)
         }
 
         if (p <= 0) {
-            crm_perror(LOG_ERR, "waitpid(%d)", pid);
+            crm_log_perror(LOG_ERR, "waitpid(%d)", pid);
 
         } else if (p != pid) {
             crm_err("Waited for %d, got %d", pid, p);
@@ -1147,9 +1147,9 @@ stonith_api_device_metadata(stonith_t * stonith, int call_options, const char *a
 
         default:
             errno = EINVAL;
-            crm_perror(LOG_ERR,
-                       "Agent %s not found or does not support meta-data",
-                       agent);
+            crm_log_perror(LOG_ERR,
+                          "Agent %s not found or does not support meta-data",
+                           agent);
             break;
     }
     return -EINVAL;
@@ -1661,7 +1661,7 @@ stonith_api_signon(stonith_t * stonith, const char *name, int *stonith_fd)
         if (native->ipc && crm_ipc_connect(native->ipc)) {
             *stonith_fd = crm_ipc_get_fd(native->ipc);
         } else if (native->ipc) {
-            crm_perror(LOG_ERR, "Connection to fencer failed");
+            crm_log_perror(LOG_ERR, "Connection to fencer failed");
             rc = -ENOTCONN;
         }
 
@@ -1687,7 +1687,7 @@ stonith_api_signon(stonith_t * stonith, const char *name, int *stonith_fd)
         rc = crm_ipc_send(native->ipc, hello, crm_ipc_client_response, -1, &reply);
 
         if (rc < 0) {
-            crm_perror(LOG_DEBUG, "Couldn't complete registration with the fencing API: %d", rc);
+            crm_log_perror(LOG_DEBUG, "Couldn't complete registration with the fencing API: %d", rc);
             rc = -ECOMM;
 
         } else if (reply == NULL) {
@@ -1750,7 +1750,7 @@ stonith_set_notification(stonith_t * stonith, const char *callback, int enabled)
 
         rc = crm_ipc_send(native->ipc, notify_msg, crm_ipc_client_response, -1, NULL);
         if (rc < 0) {
-            crm_perror(LOG_DEBUG, "Couldn't register for fencing notifications: %d", rc);
+            crm_log_perror(LOG_DEBUG, "Couldn't register for fencing notifications: %d", rc);
             rc = -ECOMM;
         } else {
             rc = pcmk_ok;
@@ -2047,7 +2047,7 @@ stonith_send_command(stonith_t * stonith, const char *op, xmlNode * data, xmlNod
     free_xml(op_msg);
 
     if (rc < 0) {
-        crm_perror(LOG_ERR, "Couldn't perform %s operation (timeout=%ds): %d", op, timeout, rc);
+        crm_log_perror(LOG_ERR, "Couldn't perform %s operation (timeout=%ds): %d", op, timeout, rc);
         rc = -ECOMM;
         goto done;
     }
@@ -2237,9 +2237,9 @@ stonith_api_validate(stonith_t *st, int call_options, const char *rsc_id,
         default:
             rc = -EINVAL;
             errno = EINVAL;
-            crm_perror(LOG_ERR,
-                       "Agent %s not found or does not support validation",
-                       agent);
+            crm_log_perror(LOG_ERR,
+                           "Agent %s not found or does not support validation",
+                           agent);
             break;
     }
     g_hash_table_destroy(params_table);

--- a/lib/fencing/st_lha.c
+++ b/lib/fencing/st_lha.c
@@ -206,7 +206,7 @@ stonith__lha_metadata(const char *agent, int timeout, char **output)
             (*st_del_fn) (stonith_obj);
         } else {
             errno = EINVAL;
-            crm_perror(LOG_ERR, "Agent %s not found", agent);
+            crm_log_perror(LOG_ERR, "Agent %s not found", agent);
             return -EINVAL;
         }
 
@@ -253,6 +253,6 @@ stonith__lha_validate(stonith_t *st, int call_options, const char *target,
                       char **output, char **error_output)
 {
     errno = EOPNOTSUPP;
-    crm_perror(LOG_ERR, "Cannot validate Linux-HA fence agents");
+    crm_log_perror(LOG_ERR, "Cannot validate Linux-HA fence agents");
     return -EOPNOTSUPP;
 }

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -817,7 +817,8 @@ lrmd_send_command(lrmd_t *lrmd, const char *op, xmlNode *data,
     }
 
     if (rc < 0) {
-        crm_perror(LOG_ERR, "Couldn't perform %s operation (timeout=%d): %d", op, timeout, rc);
+        crm_log_perror(LOG_ERR, "Couldn't perform %s operation (timeout=%d): %d",
+                       op, timeout, rc);
         rc = -ECOMM;
         goto done;
 
@@ -904,7 +905,9 @@ lrmd_handshake(lrmd_t * lrmd, const char *name)
     rc = lrmd_send_xml(lrmd, hello, -1, &reply);
 
     if (rc < 0) {
-        crm_perror(LOG_DEBUG, "Couldn't complete registration with the executor API: %d", rc);
+        crm_log_perror(LOG_DEBUG,
+                       "Couldn't complete registration with the executor API: %d",
+                       rc);
         rc = -ECOMM;
     } else if (reply == NULL) {
         crm_err("Did not receive registration reply");
@@ -965,7 +968,7 @@ lrmd_ipc_connect(lrmd_t * lrmd, int *fd)
         if (native->ipc && crm_ipc_connect(native->ipc)) {
             *fd = crm_ipc_get_fd(native->ipc);
         } else if (native->ipc) {
-            crm_perror(LOG_ERR, "Connection to executor failed");
+            crm_log_perror(LOG_ERR, "Connection to executor failed");
             rc = -ENOTCONN;
         }
     } else {

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -384,8 +384,8 @@ set_alert_env(gpointer key, gpointer value, gpointer user_data)
     }
 
     if (rc < 0) {
-        crm_perror(LOG_ERR, "setenv %s=%s",
-                  (char*)key, (value? (char*)value : ""));
+        crm_log_perror(LOG_ERR, "setenv %s=%s",
+                       (char*)key, (value? (char*)value : ""));
     } else {
         crm_trace("setenv %s=%s", (char*)key, (value? (char*)value : ""));
     }
@@ -395,7 +395,7 @@ static void
 unset_alert_env(gpointer key, gpointer value, gpointer user_data)
 {
     if (unsetenv(key) < 0) {
-        crm_perror(LOG_ERR, "unset %s", (char*)key);
+        crm_log_perror(LOG_ERR, "unset %s", (char*)key);
     } else {
         crm_trace("unset %s", (char*)key);
     }

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -632,8 +632,8 @@ systemd_create_override(const char *agent, int timeout)
 
         free(override);
         if (rc < 0) {
-            crm_perror(LOG_WARNING, "Cannot write to systemd override file %s",
-                       override_file);
+            crm_log_perror(LOG_WARNING, "Cannot write to systemd override file %s",
+                           override_file);
         }
         fflush(file_strm);
         fclose(file_strm);
@@ -651,8 +651,8 @@ systemd_remove_override(const char *agent, int timeout)
 
     if (rc < 0) {
         // Stop may be called when already stopped, which is fine
-        crm_perror(LOG_DEBUG, "Cannot remove systemd override file %s",
-                   override_file);
+        crm_log_perror(LOG_DEBUG, "Cannot remove systemd override file %s",
+                       override_file);
     } else {
         systemd_daemon_reload(timeout);
     }

--- a/lib/transition/unpack.c
+++ b/lib/transition/unpack.c
@@ -42,7 +42,7 @@ unpack_action(synapse_t * parent, xmlNode * xml_action)
 
     action = calloc(1, sizeof(crm_action_t));
     if (action == NULL) {
-        crm_perror(LOG_CRIT, "Cannot unpack action");
+        crm_log_perror(LOG_CRIT, "Cannot unpack action");
         crm_log_xml_trace(xml_action, "Lost action");
         return NULL;
     }

--- a/maint/coccinelle/crm_log_perror.cocci
+++ b/maint/coccinelle/crm_log_perror.cocci
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ * Author: Jan Pokorny <jpokorny@redhat.com>
+ * Part of pacemaker project
+ * SPDX-License-Identifier: FSFAP
+ *
+ * As a rule of thumb, we require that crm_log_perror instead of crm_perror
+ * that usually incurs redundancy/wasted effort.  The only explicit exception
+ * is logging.c file since it's use of crm_perror may happen before the
+ * logging being set up.
+ *
+ * Known issues: doesn't currently work inside CRM_ASSERT macro.
+ */
+
+@crm_perror_turned_crm_log_perror depends on
+ !(file in "lib/common/logging.c" || file in "common/logging.c")@
+@@
+- crm_perror
++ crm_log_perror
+  (...);

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -216,7 +216,7 @@ send_attrd_query(const char *name, const char *host, xmlNode **reply)
     crm_debug("Sending query for value of %s on %s", name, (host? host : "all nodes"));
     ipc = crm_ipc_new(T_ATTRD, 0);
     if (crm_ipc_connect(ipc) == FALSE) {
-        crm_perror(LOG_ERR, "Connection to cluster attribute manager failed");
+        crm_log_perror(LOG_ERR, "Connection to cluster attribute manager failed");
         rc = -ENOTCONN;
     } else {
         rc = crm_ipc_send(ipc, query, crm_ipc_flags_none|crm_ipc_client_response, 0, reply);

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -3755,7 +3755,7 @@ print_html_status(pe_working_set_t * data_set,
         filename_tmp = crm_concat(filename, "tmp", '.');
         stream = fopen(filename_tmp, "w");
         if (stream == NULL) {
-            crm_perror(LOG_ERR, "Cannot open %s for writing", filename_tmp);
+            crm_log_perror(LOG_ERR, "Cannot open %s for writing", filename_tmp);
             free(filename_tmp);
             return -1;
         }
@@ -3872,7 +3872,8 @@ print_html_status(pe_working_set_t * data_set,
 
     if (output_format != mon_output_cgi) {
         if (rename(filename_tmp, filename) != 0) {
-            crm_perror(LOG_ERR, "Unable to rename %s->%s", filename_tmp, filename);
+            crm_log_perror(LOG_ERR, "Unable to rename %s->%s",
+                           filename_tmp, filename);
         }
         free(filename_tmp);
     }
@@ -3907,7 +3908,7 @@ send_custom_trap(const char *node, const char *rsc, const char *task, int target
 
     pid = fork();
     if (pid == -1) {
-        crm_perror(LOG_ERR, "notification fork() failed.");
+        crm_log_perror(LOG_ERR, "notification fork() failed.");
     }
     if (pid == 0) {
         /* crm_debug("notification: I am the child. Executing the nofitication program."); */

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -323,7 +323,7 @@ tools_remove_node_cache(const char *node_name, long nodeid, const char *target)
     }
 
     if (!crm_ipc_connect(conn)) {
-        crm_perror(LOG_ERR, "Connection to %s failed", target);
+        crm_log_perror(LOG_ERR, "Connection to %s failed", target);
         crm_ipc_destroy(conn);
         return -ENOTCONN;
     }

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1278,7 +1278,7 @@ cli_resource_restart(pe_resource_t *rsc, const char *host, int timeout_ms,
 
     data_set = pe_new_working_set();
     if (data_set == NULL) {
-        crm_perror(LOG_ERR, "Could not allocate working set");
+        crm_log_perror(LOG_ERR, "Could not allocate working set");
         rc = -ENOMEM;
         goto done;
     }

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -275,7 +275,7 @@ create_dotfile(pe_working_set_t * data_set, const char *dot_file, gboolean all_a
     FILE *dot_strm = fopen(dot_file, "w");
 
     if (dot_strm == NULL) {
-        crm_perror(LOG_ERR, "Could not open %s for writing", dot_file);
+        crm_log_perror(LOG_ERR, "Could not open %s for writing", dot_file);
         return;
     }
 
@@ -776,7 +776,7 @@ main(int argc, char **argv)
 
     data_set = pe_new_working_set();
     if (data_set == NULL) {
-        crm_perror(LOG_ERR, "Could not allocate working set");
+        crm_log_perror(LOG_ERR, "Could not allocate working set");
         rc = -ENOMEM;
         goto done;
     }

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -681,7 +681,7 @@ main(int argc, char **argv)
 
     data_set = pe_new_working_set();
     if (data_set == NULL) {
-        crm_perror(LOG_CRIT, "Could not allocate working set");
+        crm_log_perror(LOG_CRIT, "Could not allocate working set");
         exit_code = CRM_EX_OSERR;
         goto bail;
     }

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -227,7 +227,7 @@ main(int argc, char **argv)
     data_set = pe_new_working_set();
     if (data_set == NULL) {
         rc = -errno;
-        crm_perror(LOG_CRIT, "Unable to allocate working set");
+        crm_log_perror(LOG_CRIT, "Unable to allocate working set");
         goto done;
     }
 


### PR DESCRIPTION
Problem with crm_perror macro is that it bypasses the a priori made
decisions about how/where the log messages should go since it logs
also to stderr, which makes for redundant journal entries at best
(see also 32dc10b0c).

But the convention makes it clear that logging shall be configured
early on, and from that point, it's well enough to only use that
as the only sink.

It would be unfortunate to change the semantics of crm_perror, though,
so we roll out the new crm_log_perror one, which hopefully makes it
apparent that the intended scope of its use is the same as with
crm_log (i.e. once the logging is configured).  This macro is applied
everywhere but in logging.c, since those functions may be those that
actually contribute to setting the logging up.

Also added is a new semantic patch meant to guard correct use of
crm_log_perror vs. crm_perror in the future.