### PR TITLE
[2.0.1] Refactor: make "nvpairs" wrapped (in an abstraced way) in singly-linked list as opposed to original doubly-linked one

### DIFF
--- a/daemons/schedulerd/sched_notif.c
+++ b/daemons/schedulerd/sched_notif.c
@@ -225,7 +225,7 @@ dup_attr(gpointer key, gpointer value, gpointer user_data)
 static void
 add_notify_data_to_action_meta(notify_data_t *n_data, pe_action_t *action)
 {
-    for (GList *item = n_data->keys; item; item = item->next) {
+    for (pcmk_nvpairs_t *item = n_data->keys; item; item = item->next) {
         pcmk_nvpair_t *nvpair = item->data;
 
         add_hash_param(action->meta, nvpair->name, nvpair->value);

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -148,4 +148,11 @@ crm_lastfailure_name(const char *rsc_id, const char *op, guint interval_ms)
     return crm_fail_attr_name(CRM_LAST_FAILURE_PREFIX, rsc_id, op, interval_ms);
 }
 
+/* name/value pair(s) functions/types (from nvpair.c) */
+
+typedef struct pcmk_nvpair_s {
+    char *name;
+    char *value;
+} pcmk_nvpair_t;
+
 #endif /* CRM_COMMON_INTERNAL__H */

--- a/include/crm/common/nvpair.h
+++ b/include/crm/common/nvpair.h
@@ -23,16 +23,72 @@ extern "C" {
 #  include <libxml/tree.h>  // xmlNode
 #  include <crm/crm.h>
 
-typedef struct pcmk_nvpair_s {
-    char *name;
-    char *value;
-} pcmk_nvpair_t;
+/*
+ *  nvpairs (list of nvpair objects) encapsulating datatype
+ *  + basic public operations
+ */
 
-GList *pcmk_prepend_nvpair(GList *nvpairs, const char *name, const char *value);
-void pcmk_free_nvpairs(GList *nvpairs);
-GList *pcmk_sort_nvpairs(GList *list);
-GList *pcmk_xml_attrs2nvpairs(xmlNode *xml);
-void pcmk_nvpairs2xml_attrs(GList *list, xmlNode *xml);
+/* name that wouldn't need to be exposed if -fms-extensions CFLAG was a norm */
+#define pcmk_nvpairs_s _GSList
+struct pcmk_nvpairs_s;
+
+/*!
+ * \brief Opaque encapsulation of a list of name/value pairs
+ */
+typedef struct pcmk_nvpairs_s pcmk_nvpairs_t;
+
+/*!
+ * \brief Prepend a name/value pair to (a list of) nvpairs
+ *
+ * \param[in,out] nvpairs  List to modify
+ * \param[in]     name     New entry's name
+ * \param[in]     value    New entry's value
+ *
+ * \return New head (of list) of nvpairs
+ * \note The caller is responsible for freeing the nvpairs object
+ *       with \c pcmk_free_nvpairs().
+ */
+pcmk_nvpairs_t *pcmk_prepend_nvpair(pcmk_nvpairs_t *nvpairs, const char *name,
+                                    const char *value);
+
+/*!
+ * \brief Free (a list of) nvpairs (name/value pairs)
+ *
+ * \param[in] nvpairs  Nvpairs to free
+ */
+void pcmk_free_nvpairs(pcmk_nvpairs_t *nvpairs);
+
+/*!
+ * \brief Sort (a list of) nvpairs (name/value pairs)
+ *
+ * \param[in,out] list  Nvpairs to sort
+ *
+ * \return New head (of list) of nvpairs.
+ */
+pcmk_nvpairs_t *pcmk_sort_nvpairs(pcmk_nvpairs_t *nvpairs);
+
+/*!
+ * \brief Create (a list of) nvpairs from an XML node's attributes
+ *
+ * \param[in]  XML to parse
+ *
+ * \return New (list of) nvpairs (name/value pairs)
+ * \note The caller is responsible for freeing the nvpairs object
+ *       with \c pcmk_free_nvpairs().
+ */
+pcmk_nvpairs_t *pcmk_xml_attrs2nvpairs(xmlNode *xml);
+
+/*!
+ * \brief Add XML attributes based on (a list of) nvpairs
+ *
+ * \param[in]     nvpairs  (List of) nvpairs (name/value pairs)
+ * \param[in,out] xml      XML node to add attributes to
+ */
+void pcmk_nvpairs2xml_attrs(pcmk_nvpairs_t *nvpairs, xmlNode *xml);
+
+/*
+ *  other related functions
+ */
 
 xmlNode *crm_create_nvpair_xml(xmlNode *parent, const char *id,
                                const char *name, const char *value);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -46,7 +46,7 @@ typedef struct pe__order_constraint_s {
 } pe__ordering_t;
 
 typedef struct notify_data_s {
-    GList *keys;                // Environment variable name/value pairs
+    pcmk_nvpairs_t *keys;       // Environment variable name/value pairs
 
     const char *action;
 

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -69,32 +69,19 @@ pcmk__free_nvpair(gpointer data)
     }
 }
 
-/*!
- * \brief Prepend a name/value pair to a list
- *
- * \param[in,out] nvpairs  List to modify
- * \param[in]     name     New entry's name
- * \param[in]     value    New entry's value
- *
- * \return New head of list
- * \note The caller is responsible for freeing the list with
- *       \c pcmk_free_nvpairs().
- */
-GList *
-pcmk_prepend_nvpair(GList *nvpairs, const char *name, const char *value)
+/* nvpairs (singly-linked list of nvpair objects) encapsulating datatype
+   + basic operations */
+
+pcmk_nvpairs_t *
+pcmk_prepend_nvpair(pcmk_nvpairs_t *nvpairs, const char *name, const char *value)
 {
-    return g_list_prepend(nvpairs, pcmk__new_nvpair(name, value));
+    return g_slist_prepend(nvpairs, pcmk__new_nvpair(name, value));
 }
 
-/*!
- * \brief Free a list of name/value pairs
- *
- * \param[in] list  List to free
- */
 void
-pcmk_free_nvpairs(GList *nvpairs)
+pcmk_free_nvpairs(pcmk_nvpairs_t *nvpairs)
 {
-    g_list_free_full(nvpairs, pcmk__free_nvpair);
+    g_slist_free_full(nvpairs, pcmk__free_nvpair);
 }
 
 /*!
@@ -128,32 +115,16 @@ pcmk__compare_nvpair(gconstpointer a, gconstpointer b)
     return 0;
 }
 
-/*!
- * \brief Sort a list of name/value pairs
- *
- * \param[in,out] list  List to sort
- *
- * \return New head of list
- */
-GList *
-pcmk_sort_nvpairs(GList *list)
+pcmk_nvpairs_t *
+pcmk_sort_nvpairs(pcmk_nvpairs_t *nvpairs)
 {
-    return g_list_sort(list, pcmk__compare_nvpair);
+    return g_slist_sort(nvpairs, pcmk__compare_nvpair);
 }
 
-/*!
- * \brief Create a list of name/value pairs from an XML node's attributes
- *
- * \param[in]  XML to parse
- *
- * \return New list of name/value pairs
- * \note It is the caller's responsibility to free the list with
- *       \c pcmk_free_nvpairs().
- */
-GList *
+pcmk_nvpairs_t *
 pcmk_xml_attrs2nvpairs(xmlNode *xml)
 {
-    GList *result = NULL;
+    pcmk_nvpairs_t *result = NULL;
 
     for (xmlAttrPtr iter = pcmk__first_xml_attr(xml); iter != NULL;
          iter = iter->next) {
@@ -169,7 +140,7 @@ pcmk_xml_attrs2nvpairs(xmlNode *xml)
  * \internal
  * \brief Add an XML attribute corresponding to a name/value pair
  *
- * Suitable for \c g_list_foreach(), this function adds a NAME=VALUE
+ * Suitable for \c g_slist_foreach(), this function adds a NAME=VALUE
  * XML attribute based on a given name/value pair.
  *
  * \param[in]  data       Name/value pair
@@ -184,16 +155,10 @@ pcmk__nvpair_add_xml_attr(gpointer data, gpointer user_data)
     crm_xml_add(parent, pair->name, pair->value);
 }
 
-/*!
- * \brief Add XML attributes based on a list of name/value pairs
- *
- * \param[in]     list  List of name/value pairs
- * \param[in,out] xml   XML node to add attributes to
- */
 void
-pcmk_nvpairs2xml_attrs(GList *list, xmlNode *xml)
+pcmk_nvpairs2xml_attrs(pcmk_nvpairs_t *nvpairs, xmlNode *xml)
 {
-    g_list_foreach(list, pcmk__nvpair_add_xml_attr, xml);
+    g_slist_foreach(nvpairs, pcmk__nvpair_add_xml_attr, xml);
 }
 
 // XML attribute handling

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -4092,7 +4092,7 @@ xmlNode *
 sorted_xml(xmlNode *input, xmlNode *parent, gboolean recursive)
 {
     xmlNode *child = NULL;
-    GList *nvpairs = NULL;
+    pcmk_nvpairs_t *nvpairs = NULL;
     xmlNode *result = NULL;
     const char *name = NULL;
 


### PR DESCRIPTION
Looks like we have ongoing difficulties to pick the right ADT
for the job.  There may be more cases like this, but I stumbled
upon this use since it got introduced just a few commits back,
so this change is not expected to break any API/ABI expectations
beyond what gets already changed.