### PR TITLE
(WIP) Make controller go through attribute manager to clear transient attributes.

### DIFF
--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -1218,6 +1218,8 @@ attrd_cib_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
         }
     }
 
+    /* TODO : Even if it has already been deleted and failed to update cib, it is necessary to delete it from memory. */
+
     if (a->changed == FALSE && rc == pcmk_ok) {
 
 retry_clear:

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -261,9 +261,10 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
         client->name = crm_strdup_printf("%s.%d", value?value:"unknown", client->pid);
     }
 
-    if (safe_str_eq(op, ATTRD_OP_PEER_REMOVE)) {
+    if (safe_str_eq(op, ATTRD_OP_PEER_REMOVE)
+        || safe_str_eq(op, ATTRD_OP_PEER_CLEAR)) {
         attrd_send_ack(client, id, flags);
-        attrd_client_peer_remove(client->name, xml);
+        attrd_client_peer_command(client->name, xml);
 
     } else if (safe_str_eq(op, ATTRD_OP_CLEAR_FAILURE)) {
         attrd_send_ack(client, id, flags);

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2013-2019 Andrew Beekhof <andrew@beekhof.net>
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -104,6 +104,12 @@ typedef struct attribute_value_s {
         char *current;
         char *requested;
         gboolean seen;
+#if 1
+//YAMAUCHI
+        /* After both flags are set, the attribute is cleared. */
+        gboolean need_clear; /* Mark the attrd node received in the ATTRD_OP_PEER_CLEAR message. */
+        gboolean node_left;  /* Mark the attrd node leaving the cluster. */
+#endif
 } attribute_value_t;
 
 crm_cluster_t *attrd_cluster;
@@ -117,7 +123,7 @@ GHashTable *attributes;
 void write_attributes(bool all, bool ignore_delay);
 void attrd_broadcast_protocol(void);
 void attrd_peer_message(crm_node_t *client, xmlNode *msg);
-void attrd_client_peer_remove(const char *client_name, xmlNode *xml);
+void attrd_client_peer_command(const char *client_name, xmlNode *xml);
 void attrd_client_clear_failure(xmlNode *xml);
 void attrd_client_update(xmlNode *xml);
 void attrd_client_refresh(void);

--- a/daemons/controld/controld_attrd.c
+++ b/daemons/controld/controld_attrd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2006-2019 Andrew Beekhof <andrew@beekhof.net>
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -30,6 +30,12 @@ log_attrd_error(const char *host, const char *name, const char *value,
             crm_err("Could not clear failure attributes for %s on %s node %s%s: %s "
                     CRM_XS " rc=%d", (name? name : "all resources"), node_type,
                     host, when, pcmk_strerror(rc), rc);
+            break;
+
+        case 'c':
+            crm_err("Could not clear transient attributes for %s node %s%s: %s "
+                    CRM_XS " rc=%d",
+                    node_type, host, when, pcmk_strerror(rc), rc);
             break;
 
         case 'C':
@@ -149,7 +155,22 @@ update_attrd_remote_node_removed(const char *host, const char *user_name)
 {
     crm_trace("Asking attribute manager to purge Pacemaker Remote node %s",
               host);
+
+    /* Purge the node from attrd's caches, then purge the node's transient
+     * attributes from the CIB. Attrd can't write out the changes to the CIB
+     * after the node has been purged, and there would be a race condition if we
+     * asked attrd to clear the CIB (which might get delayed) then immediately
+     * purge the node from cache.
+     */
     update_attrd_helper(host, NULL, NULL, NULL, user_name, TRUE, 'C');
+    erase_status_tag(host, XML_TAG_TRANSIENT_NODEATTRS, crmd_cib_smart_opt());
+}
+
+void
+update_attrd_clear_node(const char *host, gboolean is_remote)
+{
+    crm_trace("Asking attribute manager to clear all attributes for %s", host);
+    update_attrd_helper(host, NULL, NULL, NULL, NULL, is_remote, 'c');
 }
 
 void

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2019 Andrew Beekhof <andrew@beekhof.net>
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -205,14 +205,14 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                  * transient attributes intact until it rejoins.
                  */
                 if (compare_version(fsa_our_dc_version, "3.0.9") > 0) {
-                    erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
+                    update_attrd_clear_node(node->uname, is_remote);
                 }
 
             } else if(AM_I_DC) {
                 if (appeared) {
                     te_trigger_stonith_history_sync();
                 } else {
-                    erase_status_tag(node->uname, XML_TAG_TRANSIENT_NODEATTRS, cib_scope_local);
+                    update_attrd_clear_node(node->uname, is_remote);
                 }
             }
             break;

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 David Vossel <davidvossel@gmail.com>
+ * Copyright 2013-2019 David Vossel <davidvossel@gmail.com>
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -182,15 +182,19 @@ remote_node_up(const char *node_name)
     CRM_CHECK(node_name != NULL, return);
     crm_info("Announcing pacemaker_remote node %s", node_name);
 
-    /* Clear node's operation history. The node's transient attributes should
-     * and normally will be cleared when the node leaves, but since remote node
-     * state has a number of corner cases, clear them here as well, to be sure.
-     */
+    // Clear node's operation history.
     call_opt = crmd_cib_smart_opt();
     erase_status_tag(node_name, XML_CIB_TAG_LRM, call_opt);
-    erase_status_tag(node_name, XML_TAG_TRANSIENT_NODEATTRS, call_opt);
 
-    /* Clear node's probed attribute */
+    /* The node's transient attributes should and normally will be cleared when
+     * the node leaves, but since remote node state has a number of corner
+     * cases, clear them here as well, to be sure. Importantly, this includes
+     * the CRM_OP_PROBED ("probe_complete") attribute.
+     */
+    update_attrd_clear_node(node_name, TRUE);
+
+    /* Set the CRM_OP_PROBED ("probe_complete") attribute. */
+    /* In order to let attrd recognize the remote node, we send the attribute. */
     update_attrd(node_name, CRM_OP_PROBED, NULL, NULL, TRUE);
 
     /* Ensure node is in the remote peer cache with member status */
@@ -250,11 +254,8 @@ remote_node_down(const char *node_name, const enum down_opts opts)
     int call_opt = crmd_cib_smart_opt();
     crm_node_t *node;
 
-    /* Purge node from attrd's memory */
+    // Purge node's transient attributes
     update_attrd_remote_node_removed(node_name, NULL);
-
-    /* Purge node's transient attributes */
-    erase_status_tag(node_name, XML_TAG_TRANSIENT_NODEATTRS, call_opt);
 
     /* Normally, the LRM operation history should be kept until the node comes
      * back up. However, after a successful fence, we want to clear it, so we

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2019 Andrew Beekhof <andrew@beekhof.net>
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -73,6 +73,7 @@ void populate_cib_nodes(enum node_update_flags flags, const char *source);
 void crm_update_quorum(gboolean quorum, gboolean force_update);
 void erase_status_tag(const char *uname, const char *tag, int options);
 void update_attrd(const char *host, const char *name, const char *value, const char *user_name, gboolean is_remote_node);
+void update_attrd_clear_node(const char *host, gboolean is_remote);
 void update_attrd_remote_node_removed(const char *host, const char *user_name);
 void update_attrd_clear_failures(const char *host, const char *rsc,
                                  const char *op, const char *interval_spec,

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2006-2019 Andrew Beekhof <andrew@beekhof.net>
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -198,7 +198,9 @@ pid_t pcmk_locate_sbd(void);
 #  define F_ATTRD_IS_FORCE_WRITE "attrd_is_force_write"
 
 /* attrd operations */
+#  define ATTRD_OP_ATTR_REMOVE   "attr-remove"
 #  define ATTRD_OP_PEER_REMOVE   "peer-remove"
+#  define ATTRD_OP_PEER_CLEAR    "peer-clear"
 #  define ATTRD_OP_UPDATE        "update"
 #  define ATTRD_OP_UPDATE_BOTH   "update-both"
 #  define ATTRD_OP_UPDATE_DELAY  "update-delay"

--- a/lib/common/attrd_client.c
+++ b/lib/common/attrd_client.c
@@ -183,6 +183,10 @@ attrd_update_delegate(crm_ipc_t *ipc, char command, const char *host,
             task = ATTRD_OP_QUERY;
             name_as = F_ATTRD_ATTRIBUTE;
             break;
+        case 'c':
+            task = ATTRD_OP_PEER_CLEAR;
+            display_command = "clear";
+            break;
         case 'C':
             task = ATTRD_OP_PEER_REMOVE;
             display_command = "purge";


### PR DESCRIPTION
Hi All,

This is for discussion only.
I have confirmed the rough behavior, but the source has not been completed yet.
I think there are many missing fixes.

This PR is based on the following Ken's PR as a base.

 * https://github.com/ClusterLabs/pacemaker/pull/1695

I made the following changes as the first realization method.

It is unknown whether it can cope with clusters with many nodes or when there are many attributes.
In my modification, since clearing of attributes is handled in smaller units, improvement may be necessary.

----
* Mark when receiving the ATTRD_OP_PEER_CLEAR message.
  In order to cope with crmd restarting, we will not immediately delete the attribute.
  For remote node attributes, delete them immediately.
  Deletes the attribute when the mark of the request to delete the attribute from crmd and the event of the node leaving attrd are collected.(It should be noted that the order in which this mark and the event occur may be reversed.)
  With this fix, attributes are always deleted via the ATTRD_OP_PEER_CLEAR message.
  Although this fix alone does not solve it, it seems to be effective even if only attrd is restarted in the future.
* Add ATTRD_OP_ATTR_REMOVE as a new message.
  After completing the update of cib, the Writer is delete the memory attribute of attrd.
  At this time, send ATTRD_OP_ATTR_REMOVE to the attrd member of the cluster.
  Other attrds that received ATTRD_OP_ATTR_REMOVE also delete the memory attributes.
  In order to reliably synchronize the attributes in the cluster, we have made such a mechanism.
* It does not incorporate the correspondence of the old CRM_ATTR_PROTOCOL version.
* When the attrd leaving the cluster once again participates, the processing flag is cleared.
  It is when attrd received the CRM_ATTR_PROTOCOL message
  Actually, you should clear the processing flag when crmd comes in, but attrd can not detect it at the moment.
* Forced write decision by force_write has been moved to write_attributes () write_attribute ().
  This is because writing from write_attribute () may occur....
* For now it seems to be difficult to delete the attribute of an isolated attrd if crmd does not restart.

* etc..
----

This PR has already found the next problem.

* The flag is cleared incompletely, after crmd restarts, the attribute is deleted when attrd restarts.(Need something good way)
* ATTRD_OP_PEER_CLEAR will not be sent from the crmd of the new DC node after the cluster without STONITH is broken.
  To  @kgaillot  : Correction to send ATTRD_OP_PEER_CLEAR message from new DC node is necessary. Do you know where you need to make corrections?

----
The problem of attrd remaining after this correspondence.
* However, if Election is delayed, problems remain. (https://bugs.clusterlabs.org/show_bug.cgi?id=5358#c21).
Currently, setting the "transition-delay" only prevents the problem.

* Unlike this problem, we must also take into consideration that the attribute will be lost if only attrd is restarted in the future.
The current attrd deletes the attribute when it starts up.
Even if we exchange sync_response messages with other nodes, we reset them with NULL.
As a result, when attrd restarts, its attributes disappear.
Especially when configuring a cluster with a single node, the attribute is completely lost.
For example, when restarting attrd, it may be effective not to erase the attribute by pacemakerd passing the parameter.
----

Best Regards,
Hideo Yamauchi.
