### PR TITLE
More precise library dependencies

### DIFF
--- a/daemons/schedulerd/Makefile.am
+++ b/daemons/schedulerd/Makefile.am
@@ -40,7 +40,9 @@ libpengine_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 libpengine_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)
 
 libpengine_la_LIBADD	= $(top_builddir)/lib/pengine/libpe_status.la \
-			$(top_builddir)/lib/cib/libcib.la
+			$(top_builddir)/lib/pengine/libpe_rules.la \
+			$(top_builddir)/lib/cib/libcib.la \
+			$(top_builddir)/lib/common/libcrmcommon.la
 # -L$(top_builddir)/lib/pils -lpils -export-dynamic -module -avoid-version
 libpengine_la_SOURCES	= sched_allocate.c \
 			  sched_bundle.c \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -39,5 +39,5 @@ clean-local:
 	rm -f *.pc
 
 ## Subdirectories...
-SUBDIRS	= gnu common pengine transition cib fencing services lrmd cluster
+SUBDIRS	= gnu common pengine cib fencing services lrmd cluster transition
 DIST_SUBDIRS =  $(SUBDIRS)

--- a/lib/transition/Makefile.am
+++ b/lib/transition/Makefile.am
@@ -17,7 +17,8 @@ libtransitioner_la_CPPFLAGS	= -I$(top_builddir) $(AM_CPPFLAGS)
 libtransitioner_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 libtransitioner_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)
 
-libtransitioner_la_LIBADD	= $(top_builddir)/lib/common/libcrmcommon.la
+libtransitioner_la_LIBADD	= $(top_builddir)/lib/common/libcrmcommon.la \
+				  $(top_builddir)/lib/lrmd/liblrmd.la
 libtransitioner_la_SOURCES	= unpack.c graph.c utils.c
 
 clean-generic:


### PR DESCRIPTION
The internal dependency system of libtool can mostly fill in such omissions, but it's better to keep them explicit, since they help determining the correct build order, like in this case for libtransitioner.