### PR TITLE
Add formatted output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ scratch
 xml/crm.dtd
 xml/pacemaker*.rng
 xml/versions.rng
+xml/api/api-result*.rng
 lib/gnu/libgnu.a
 lib/gnu/stdalign.h
 *.coverity

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -1,0 +1,513 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef CRM_OUTPUT__H
+#  define CRM_OUTPUT__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \file
+ * \brief Formatted output for pacemaker tools
+ */
+
+#  include <stdio.h>
+#  include <libxml/tree.h>
+
+#  include <glib.h>
+#  include <crm/common/results.h>
+
+#  define PCMK__API_VERSION "1.0"
+
+/* Add to the long_options block in each tool to get the formatted output
+ * command line options added.  Then call pcmk__parse_output_args to handle
+ * them.
+ */
+#  define PCMK__OUTPUT_OPTIONS(fmts) \
+    {   "output-as", required_argument, NULL, 0, \
+        "Specify the format for output, one of: " fmts \
+    }, \
+    {   "output-to", required_argument, NULL, 0, \
+        "Specify the destination for formatted output, \"-\" for stdout or a filename" \
+    }
+
+typedef struct pcmk__output_s pcmk__output_t;
+
+/*!
+ * \internal
+ * \brief The type of a function that creates a ::pcmk__output_t.
+ *
+ * Instances of this type are passed to pcmk__register_format(), stored in an
+ * internal data structure, and later accessed by pcmk__output_new().  For 
+ * examples, see pcmk__mk_xml_output() and pcmk__mk_text_output().
+ *
+ * \param[in] argv The list of command line arguments.
+ */
+typedef pcmk__output_t * (*pcmk__output_factory_t)(char **argv);
+
+/*!
+ * \internal
+ * \brief The type of a custom message formatting function.
+ *
+ * These functions are defined by various libraries to support formatting of
+ * types aside from the basic types provided by a ::pcmk__output_t.
+ *
+ * The meaning of the return value will be different for each message.
+ * In general, however, 0 should be returned on success and a positive value
+ * on error.
+ *
+ * \note These functions must not call va_start or va_end - that is done
+ *       automatically before the custom formatting function is called.
+ */
+typedef int (*pcmk__message_fn_t)(pcmk__output_t *out, va_list args);
+
+/*!
+ * \internal
+ * \brief Internal type for tracking custom messages.
+ *
+ * Each library can register functions that format custom message types.  These
+ * are commonly used to handle some library-specific type.  Registration is
+ * done by first defining a table of ::pcmk__message_entry_t structures and
+ * then passing that table to pcmk__register_messages().  Separate handlers
+ * can be defined for the same message, but for different formats (xml vs.
+ * text).  Unknown formats will be ignored.
+ */
+typedef struct pcmk__message_entry_s {
+    /*!
+     * \brief The message to be handled.
+     *
+     * This must be the same ID that is passed to the message function of
+     * a ::pcmk__output_t.  Unknown message IDs will be ignored.
+     */
+    const char *message_id;
+
+    /*!
+     * \brief The format type this handler is for.
+     *
+     * This name must match the fmt_name of the currently active formatter in
+     * order for the registered function to be called.  It is valid to have
+     * multiple entries for the same message_id but with different fmt_name
+     * values.
+     */
+    const char *fmt_name;
+
+    /*!
+     * \brief The function to be called for message_id given a match on
+     *        fmt_name.  See comments on ::pcmk__message_fn_t.
+     */
+    pcmk__message_fn_t fn;
+} pcmk__message_entry_t;
+
+/* Basic formatters everything supports.  This block needs to be updated every
+ * time a new base formatter is added.
+ */
+pcmk__output_t *pcmk__mk_text_output(char **argv);
+pcmk__output_t *pcmk__mk_xml_output(char **argv);
+
+/*!
+ * \brief This structure contains everything that makes up a single output
+ *        formatter.
+ *
+ * Instances of this structure may be created by calling pcmk__output_new()
+ * with the name of the desired formatter.  They should later be freed with
+ * pcmk__output_free().
+ */
+struct pcmk__output_s {
+    /*!
+     * \brief The name of this output formatter.
+     */
+    char *fmt_name;
+
+    /*!
+     * \brief A copy of the request that generated this output.
+     *
+     * In the case of command line usage, this would be the command line
+     * arguments.  For other use cases, it could be different.
+     */
+    char *request;
+
+    /*!
+     * \brief Does this formatter support a special quiet mode?
+     *
+     * In this mode, most output can be supressed but some information is still
+     * displayed to an interactive user.  In general, machine-readable output
+     * formats will not support this while user-oriented formats will.
+     */
+    bool supports_quiet;
+
+    /*!
+     * \brief Where output should be written.
+     *
+     * This could be a file handle, or stdout or stderr.  This is really only
+     * useful internally.
+     */
+    FILE *dest;
+
+    /*!
+     * \brief Custom messages that are currently registered on this formatter.
+     *
+     * Keys are the string message IDs, values are ::pcmk__message_fn_t function
+     * pointers.
+     */
+    GHashTable *messages;
+
+    /*!
+     * \brief Implementation-specific private data.
+     *
+     * Each individual formatter may have some private data useful in its
+     * implementation.  This points to that data.  Callers should not rely on
+     * its contents or structure.
+     */
+    void *priv;
+
+    /*!
+     * \internal
+     * \brief Take whatever actions are necessary to prepare out for use.  This is
+     *        called by pcmk__output_new().  End users should not need to call this.
+     *
+     * \note For formatted output implementers - This function should be written in
+     *       such a way that it can be called repeatedly on an already initialized
+     *       object without causing problems, or on a previously finished object
+     *       without crashing.
+     *
+     * \param[in,out] out The output functions structure.
+     *
+     * \return true on success, false on error.
+     */
+    bool (*init) (pcmk__output_t *out);
+
+    /*!
+     * \internal
+     * \brief Free the private formatter-specific data.
+     *
+     * This is called from pcmk__output_free() and does not typically need to be
+     * called directly.
+     *
+     * \param[in,out] out The output functions structure.
+     */
+    void (*free_priv)(pcmk__output_t *out);
+
+    /*!
+     * \internal
+     * \brief Take whatever actions are necessary to end formatted output.
+     *
+     * This could include flushing output to a file, but does not include freeing
+     * anything.  Note that pcmk__output_free() will automatically call this
+     * function, so there is typically no need to do so manually.
+     *
+     * \note For formatted output implementers - This function should be written in
+     *       such a way that it can be called repeatedly on a previously finished
+     *       object without crashing.
+     *
+     * \param[in,out] out         The output functions structure.
+     * \param[in]     exit_status The exit value of the whole program.
+     */
+    void (*finish) (pcmk__output_t *out, crm_exit_t exit_status);
+
+    /*!
+     * \internal
+     * \brief Finalize output and then immediately set back up to start a new set
+     *        of output.
+     *
+     * This is conceptually the same as calling finish and then init, though in
+     * practice more be happening behind the scenes.
+     *
+     * \note This function differs from finish in that no exit_status is added.
+     *       The idea is that the program is not shutting down, so there is not
+     *       yet a final exit code.  Call finish on the last time through if this
+     *       is needed.
+     *
+     * \param[in,out] out The output functions structure.
+     */
+    void (*reset) (pcmk__output_t *out);
+
+    /*!
+     * \internal
+     * \brief Register a custom message.
+     *
+     * \param[in,out] out        The output functions structure.
+     * \param[in]     message_id The name of the message to register.  This name
+     *                           will be used as the message_id parameter to the
+     *                           message function in order to call the custom
+     *                           format function.
+     * \param[in]     fn         The custom format function to call for message_id.
+     */
+    void (*register_message) (pcmk__output_t *out, const char *message_id,
+                              pcmk__message_fn_t fn);
+
+    /*!
+     * \internal
+     * \brief Call a previously registered custom message.
+     *
+     * \param[in,out] out        The output functions structure.
+     * \param[in]     message_id The name of the message to call.  This name must
+     *                           be the same as the message_id parameter of some
+     *                           previous call to register_message.
+     * \param[in] ...            Arguments to be passed to the registered function.
+     *
+     * \return 0 if a function was registered for the message, that function was
+     *         called, and returned successfully.  A negative value is returned if
+     *         no function was registered.  A positive value is returned if the
+     *         function was called but encountered an error.
+     */
+    int (*message) (pcmk__output_t *out, const char *message_id, ...);
+
+    /*!
+     * \internal
+     * \brief Format the output of a completed subprocess.
+     *
+     * \param[in,out] out         The output functions structure.
+     * \param[in]     exit_status The exit value of the subprocess.
+     * \param[in]     proc_stdout stdout from the completed subprocess.
+     * \param[in]     proc_stderr stderr from the completed subprocess.
+     */
+    void (*subprocess_output) (pcmk__output_t *out, int exit_status,
+                               const char *proc_stdout, const char *proc_stderr);
+
+    /*!
+     * \internal
+     * \brief Format an informational message that should be shown to
+     *        to an interactive user.  Not all formatters will do this.
+     *
+     * \note A newline will automatically be added to the end of the format
+     *       string, so callers should not include a newline.
+     *
+     * \param[in,out] out The output functions structure.
+     * \param[in]     buf The message to be printed.
+     * \param[in]     ... Arguments to be formatted.
+     */
+    void (*info) (pcmk__output_t *out, const char *format, ...) G_GNUC_PRINTF(2, 3);
+
+    /*!
+     * \internal
+     * \brief Format already formatted XML.
+     *
+     * \param[in,out] out  The output functions structure.
+     * \param[in]     name A name to associate with the XML.
+     * \param[in]     buf  The XML in a string.
+     */
+    void (*output_xml) (pcmk__output_t *out, const char *name, const char *buf);
+
+    /*!
+     * \internal
+     * \brief Start a new list of items.
+     *
+     * \note For text output, this corresponds to another level of indentation.  For
+     *       XML output, this corresponds to wrapping any following output in another
+     *       layer of tags.
+     *
+     * \note If singular_noun and plural_noun are non-NULL, calling end_list will
+     *       result in a summary being added.
+     *
+     * \param[in,out] out           The output functions structure.
+     * \param[in]     name          A descriptive, user-facing name for this list.
+     * \param[in]     singular_noun When outputting the summary for a list with
+     *                              one item, the noun to use.
+     * \param[in]     plural_noun   When outputting the summary for a list with
+     *                              more than one item, the noun to use.
+     */
+    void (*begin_list) (pcmk__output_t *out, const char *name,
+                        const char *singular_noun, const char *plural_noun);
+
+    /*!
+     * \internal
+     * \brief Format a single item in a list.
+     *
+     * \param[in,out] out     The output functions structure.
+     * \param[in]     name    A name to associate with this item.
+     * \param[in]     content The item to be formatted.
+     */
+    void (*list_item) (pcmk__output_t *out, const char *name, const char *content);
+
+    /*!
+     * \internal
+     * \brief Conclude a list.
+     *
+     * \note If begin_list was called with non-NULL for both the singular_noun
+     *       and plural_noun arguments, this function will output a summary.
+     *       Otherwise, no summary will be added.
+     *
+     * \param[in,out] out The output functions structure.
+     */
+    void (*end_list) (pcmk__output_t *out);
+};
+
+/*!
+ * \internal
+ * \brief Call a formatting function for a previously registered message.
+ *
+ * \note This function is for implementing custom formatters.  It should not
+ *       be called directly.  Instead, call out->message.
+ *
+ * \param[in,out] out        The output functions structure.
+ * \param[in]     message_id The message to be handled.  Unknown messages
+ *                           will be ignored.
+ * \param[in]     ...        Arguments to be passed to the registered function.
+ */
+int
+pcmk__call_message(pcmk__output_t *out, const char *message_id, ...);
+
+/*!
+ * \internal
+ * \brief Free a ::pcmk__output_t structure that was previously created by
+ *        pcmk__output_new().  This will first call the finish function.
+ *
+ * \note While the create and finish functions are designed in such a way that
+ *       they can be called repeatedly, this function will completely free the
+ *       memory of the object.  Once this function has been called, producing
+ *       more output requires starting over from pcmk__output_new().
+ *
+ * \param[in,out] out         The output structure.
+ * \param[in]     exit_status The exit value of the whole program.
+ */
+void pcmk__output_free(pcmk__output_t *out, crm_exit_t exit_status);
+
+/*!
+ * \internal
+ * \brief Create a new ::pcmk__output_t structure.
+ *
+ * \param[in,out] out      The destination of the new ::pcmk__output_t.
+ * \param[in]     fmt_name How should output be formatted?
+ * \param[in]     filename Where should formatted output be written to?  This
+ *                         can be a filename (which will be overwritten if it
+ *                         already exists), or NULL or "-" for stdout.  For no
+ *                         output, pass a filename of "/dev/null".
+ * \param[in]     argv     The list of command line arguments.
+ *
+ * \return 0 on success or an error code on error.
+ */
+int pcmk__output_new(pcmk__output_t **out, const char *fmt_name,
+                     const char *filename, char **argv);
+
+/*!
+ * \internal
+ * \brief Process formatted output related command line options.  This should
+ *        be called wherever other long options are handled.
+ *
+ * \param[in]  argname      The long command line argument to process.
+ * \param[in]  argvalue     The value of the command line argument.
+ * \param[out] output_ty   How should output be formatted? ("text", "xml", etc.)
+ * \param[out] output_dest Where should formatted output be written to?  This is
+ *                         typically a filename, but could be NULL or "-".
+ *
+ * \return true if longname was handled, false otherwise.
+ */
+bool
+pcmk__parse_output_args(const char *argname, char *argvalue, char **output_ty,
+                        char **output_dest);
+
+/*!
+ * \internal
+ * \brief Register a new output formatter, making it available for use
+ *        the same as a base formatter.
+ *
+ * \param[in] fmt The new output formatter to register.
+ *
+ * \return 0 on success or an error code on error.
+ */
+int
+pcmk__register_format(const char *fmt_name, pcmk__output_factory_t create);
+
+
+/*!
+ * \internal
+ * \brief Register a function to handle a custom message.
+ *
+ * \note This function is for implementing custom formatters.  It should not
+ *       be called directly.  Instead, call out->register_message.
+ *
+ * \param[in,out] out        The output functions structure.
+ * \param[in]     message_id The message to be handled.
+ * \param[in]     fn         The custom format function to call for message_id.
+ */
+void
+pcmk__register_message(pcmk__output_t *out, const char *message_id,
+                       pcmk__message_fn_t fn);
+
+/*!
+ * \internal
+ * \brief Register an entire table of custom formatting functions at once.
+ *
+ * This table can contain multiple formatting functions for the same message ID
+ * if they are for different format types.
+ *
+ * \param[in,out] out   The output functions structure.
+ * \param[in]     table An array of ::pcmk__message_entry_t values which should
+ *                      all be registered.  This array must be NULL-terminated.
+ */
+void
+pcmk__register_messages(pcmk__output_t *out, pcmk__message_entry_t *table);
+
+/* Functions that are useful for implementing custom message formatters */
+
+/*!
+ * \internal
+ * \brief A printf-like function.
+ *
+ * This function writes to out->dest and indents the text to the current level
+ * of the text formatter's nesting.  This should be used when implementing
+ * custom message functions instead of printf.
+ *
+ * \param[in,out] out The output functions structure.
+ */
+void
+pcmk__indented_printf(pcmk__output_t *out, const char *format, ...) G_GNUC_PRINTF(2, 3);
+
+/*!
+ * \internal
+ * \brief Add the given node as a child of the current list parent.  This is
+ *        used when implementing custom message functions.
+ *
+ * \param[in,out] out  The output functions structure.
+ * \param[in]     node An XML node to be added as a child.
+ */
+void
+pcmk__xml_add_node(pcmk__output_t *out, xmlNodePtr node);
+
+/*!
+ * \internal
+ * \brief Push a parent XML node onto the stack.  This is used when implementing
+ *        custom message functions.
+ *
+ * The XML output formatter maintains an internal stack to keep track of which nodes
+ * are parents in order to build up the tree structure.  This function can be used
+ * to temporarily push a new node onto the stack.  After calling this function, any
+ * other formatting functions will have their nodes added as children of this new
+ * parent.
+ *
+ * \param[in,out] out  The output functions structure.
+ * \param[in]     node The node to be added/
+ */
+void
+pcmk__xml_push_parent(pcmk__output_t *out, xmlNodePtr node);
+
+/*!
+ * \internal
+ * \brief Pop a parent XML node onto the stack.  This is used when implementing
+ *        custom message functions.
+ *
+ * This function removes a parent node from the stack.  See pcmk__xml_push_parent()
+ * for more details.
+ *
+ * \note Little checking is done with this function.  Be sure you only pop parents
+ * that were previously pushed.  In general, it is best to keep the code between
+ * push and pop simple.
+ *
+ * \param[in,out] out The output functions structure.
+ */
+void
+pcmk__xml_pop_parent(pcmk__output_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -53,6 +53,7 @@ extern "C" {
 #  define pcmk_err_node_unknown         214
 #  define pcmk_err_already              215
 #  define pcmk_err_bad_nvpair           216
+#  define pcmk_err_unknown_format       217
 
 /*
  * Exit status codes

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -26,6 +26,8 @@ extern "C" {
 #  include <stdint.h>   // uint32_t
 #  include <time.h>     // time_t
 
+#  include <crm/common/output.h>
+
 #  define T_STONITH_NOTIFY_DISCONNECT     "st_notify_disconnect"
 #  define T_STONITH_NOTIFY_FENCE          "st_notify_fence"
 #  define T_STONITH_NOTIFY_HISTORY        "st_notify_history"
@@ -537,9 +539,16 @@ stonith_api_time_helper(uint32_t nodeid, bool in_progress)
 bool stonith_agent_exists(const char *agent, int timeout);
 
 /*!
- * \brief Turn stonith action into a more readable string
+ * \brief Register stonith-specific messages.
  *
- * \param[in] action Stonith action
+ * \param out The output functions structure.
+ */
+void stonith_register_messages(pcmk__output_t *out);
+
+/*!
+ * \brief Turn stonith action into a more readable string.
+ *
+ * \param action Stonith action
  */
 const char *stonith_action_str(const char *action);
 

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -32,7 +32,8 @@ libcrmcommon_la_LIBADD	= @LIBADD_DL@ $(GNUTLSLIBS)
 libcrmcommon_la_SOURCES	= compat.c digest.c ipc.c io.c procfs.c utils.c xml.c	\
 			  iso8601.c remote.c mainloop.c logging.c watchdog.c	\
 			  schemas.c strings.c xpath.c attrd_client.c alerts.c	\
-			  operations.c pid.c results.c acl.c agents.c nvpair.c
+			  operations.c pid.c results.c acl.c agents.c nvpair.c \
+			  output.c output_text.c output_xml.c
 if BUILD_CIBSECRETS
 libcrmcommon_la_SOURCES	+= cib_secrets.c
 endif

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm/common/util.h>
+#include <crm/common/xml.h>
+#include <crm/common/internal.h>
+#include <crm/common/output.h>
+#include <libxml/tree.h>
+
+static GHashTable *formatters = NULL;
+
+void
+pcmk__output_free(pcmk__output_t *out, crm_exit_t exit_status) {
+    pcmk__output_factory_t fn = g_hash_table_lookup(formatters, out->fmt_name);
+    CRM_ASSERT(fn != NULL);
+
+    out->finish(out, exit_status);
+    out->free_priv(out);
+
+    g_hash_table_destroy(out->messages);
+    free(out->fmt_name);
+    free(out->request);
+    free(out);
+}
+
+int
+pcmk__output_new(pcmk__output_t **out, const char *fmt_name, const char *filename,
+                 char **argv) {
+    pcmk__output_factory_t create = NULL;;
+
+    if (formatters == NULL) {
+        return EINVAL;
+    }
+
+    /* If no name was given, just try "text".  It's up to each tool to register
+     * what it supports so this also may not be valid.
+     */
+    if (fmt_name == NULL) {
+        create = g_hash_table_lookup(formatters, "text");
+    } else {
+        create = g_hash_table_lookup(formatters, fmt_name);
+    }
+
+    if (create == NULL) {
+        return pcmk_err_unknown_format;
+    }
+
+    *out = create(argv);
+    if (*out == NULL) {
+        return ENOMEM;
+    }
+
+    if (fmt_name == NULL) {
+        (*out)->fmt_name = strdup("text");
+    } else {
+        (*out)->fmt_name = strdup(fmt_name);
+    }
+
+    if (filename == NULL || safe_str_eq(filename, "-")) {
+        (*out)->dest = stdout;
+    } else {
+        (*out)->dest = fopen(filename, "w");
+        if ((*out)->dest == NULL) {
+            return errno;
+        }
+    }
+
+    (*out)->messages = g_hash_table_new_full(crm_str_hash, g_str_equal, free, NULL);
+
+    if ((*out)->init(*out) == false) {
+        pcmk__output_free(*out, 0);
+        return ENOMEM;
+    }
+
+    return 0;
+}
+
+bool
+pcmk__parse_output_args(const char *argname, char *argvalue, char **output_ty, char **output_dest) {
+    if (safe_str_eq("output-as", argname)) {
+        *output_ty = argvalue;
+        return true;
+    } else if (safe_str_eq("output-to", argname)) {
+        if (safe_str_eq(argvalue, "-")) {
+            *output_dest = NULL;
+        } else {
+            *output_dest = argvalue;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+int
+pcmk__register_format(const char *fmt_name, pcmk__output_factory_t create) {
+    if (create == NULL) {
+        return -EINVAL;
+    }
+
+    if (formatters == NULL) {
+        formatters = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, NULL);
+    }
+
+    g_hash_table_insert(formatters, strdup(fmt_name), create);
+    return 0;
+}
+
+int
+pcmk__call_message(pcmk__output_t *out, const char *message_id, ...) {
+    va_list args;
+    int rc = 0;
+    pcmk__message_fn_t fn;
+
+    fn = g_hash_table_lookup(out->messages, message_id);
+    if (fn == NULL) {
+        return -EINVAL;
+    }
+
+    va_start(args, message_id);
+    rc = fn(out, args);
+    va_end(args);
+
+    return rc;
+}
+
+void
+pcmk__register_message(pcmk__output_t *out, const char *message_id,
+                       pcmk__message_fn_t fn) {
+    g_hash_table_replace(out->messages, strdup(message_id), fn);
+}
+
+void
+pcmk__register_messages(pcmk__output_t *out, pcmk__message_entry_t *table) {
+    pcmk__message_entry_t *entry;
+
+    for (entry = table; entry->message_id != NULL; entry++) {
+        if (safe_str_eq(out->fmt_name, entry->fmt_name)) {
+            pcmk__register_message(out, entry->message_id, entry->fn);
+        }
+    }
+}

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <stdlib.h>
+#include <crm/crm.h>
+#include <crm/common/output.h>
+
+/* Disabled for the moment, but we can enable it (or remove it entirely)
+ * when we make a decision on whether this is preferred output.
+ */
+#define FANCY_TEXT_OUTPUT 0
+
+typedef struct text_list_data_s {
+    unsigned int len;
+    char *singular_noun;
+    char *plural_noun;
+} text_list_data_t;
+
+typedef struct text_private_s {
+    GQueue *parent_q;
+} text_private_t;
+
+static void
+text_free_priv(pcmk__output_t *out) {
+    text_private_t *priv = out->priv;
+
+    if (priv == NULL) {
+        return;
+    }
+
+    g_queue_free(priv->parent_q);
+    free(priv);
+}
+
+static bool
+text_init(pcmk__output_t *out) {
+    text_private_t *priv = NULL;
+
+    /* If text_init was previously called on this output struct, just return. */
+    if (out->priv != NULL) {
+        return true;
+    } else {
+        out->priv = calloc(1, sizeof(text_private_t));
+        if (out->priv == NULL) {
+            return false;
+        }
+
+        priv = out->priv;
+    }
+
+    priv->parent_q = g_queue_new();
+    return true;
+}
+
+static void
+text_finish(pcmk__output_t *out, crm_exit_t exit_status) {
+    /* This function intentionally left blank */
+}
+
+static void
+text_reset(pcmk__output_t *out) {
+    CRM_ASSERT(out->priv != NULL);
+
+    text_free_priv(out);
+    text_init(out);
+}
+
+static void
+text_subprocess_output(pcmk__output_t *out, int exit_status,
+                       const char *proc_stdout, const char *proc_stderr) {
+    if (proc_stdout != NULL) {
+        fprintf(out->dest, "%s\n", proc_stdout);
+    }
+
+    if (proc_stderr != NULL) {
+        fprintf(out->dest, "%s\n", proc_stderr);
+    }
+}
+
+G_GNUC_PRINTF(2, 3)
+static void
+text_info(pcmk__output_t *out, const char *format, ...) {
+    va_list ap;
+    int len = 0;
+
+    va_start(ap, format);
+
+    /* Informational output does not get indented, to separate it from other
+     * potentially indented list output.
+     */
+    len = vfprintf(out->dest, format, ap);
+    CRM_ASSERT(len > 0);
+    va_end(ap);
+
+    /* Add a newline. */
+    fprintf(out->dest, "\n");
+}
+
+static void
+text_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
+    text_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+    pcmk__indented_printf(out, "%s", buf);
+}
+
+static void
+text_begin_list(pcmk__output_t *out, const char *name, const char *singular_noun,
+                const char *plural_noun) {
+    text_private_t *priv = out->priv;
+    text_list_data_t *new_list = NULL;
+
+    CRM_ASSERT(priv != NULL);
+
+#if FANCY_TEXT_OUTPUT > 0
+    pcmk__indented_printf(out, "%s:\n", name);
+#endif
+
+    new_list = calloc(1, sizeof(text_list_data_t));
+    new_list->len = 0;
+    new_list->singular_noun = strdup(singular_noun);
+    new_list->plural_noun = strdup(plural_noun);
+
+    g_queue_push_tail(priv->parent_q, new_list);
+}
+
+static void
+text_list_item(pcmk__output_t *out, const char *id, const char *content) {
+    text_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+#if FANCY_TEXT_OUTPUT > 0
+    if (id != NULL) {
+        pcmk__indented_printf(out, "* %s: %s\n", id, content);
+    } else {
+        pcmk__indented_printf(out, "* %s\n", content);
+    }
+#else
+    fprintf(out->dest, "%s\n", content);
+#endif
+
+    ((text_list_data_t *) g_queue_peek_tail(priv->parent_q))->len++;
+}
+
+static void
+text_end_list(pcmk__output_t *out) {
+    text_private_t *priv = out->priv;
+    text_list_data_t *node = NULL;
+
+    CRM_ASSERT(priv != NULL);
+    node = g_queue_pop_tail(priv->parent_q);
+
+    if (node->singular_noun != NULL && node->plural_noun != NULL) {
+        if (node->len == 1) {
+            pcmk__indented_printf(out, "%d %s found\n", node->len, node->singular_noun);
+        } else {
+            pcmk__indented_printf(out, "%d %s found\n", node->len, node->plural_noun);
+        }
+    }
+
+    free(node);
+}
+
+pcmk__output_t *
+pcmk__mk_text_output(char **argv) {
+    pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
+
+    if (retval == NULL) {
+        return NULL;
+    }
+
+    retval->request = g_strjoinv(" ", argv);
+    retval->supports_quiet = true;
+
+    retval->init = text_init;
+    retval->free_priv = text_free_priv;
+    retval->finish = text_finish;
+    retval->reset = text_reset;
+
+    retval->register_message = pcmk__register_message;
+    retval->message = pcmk__call_message;
+
+    retval->subprocess_output = text_subprocess_output;
+    retval->info = text_info;
+    retval->output_xml = text_output_xml;
+
+    retval->begin_list = text_begin_list;
+    retval->list_item = text_list_item;
+    retval->end_list = text_end_list;
+
+    return retval;
+}
+
+G_GNUC_PRINTF(2, 3)
+void
+pcmk__indented_printf(pcmk__output_t *out, const char *format, ...) {
+    va_list ap;
+    int len = 0;
+#if FANCY_TEXT_OUTPUT > 0
+    int level = 0;
+    text_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    level = g_queue_get_length(priv->parent_q);
+
+    for (int i = 0; i < level; i++) {
+        putc('\t', out->dest);
+    }
+#endif
+
+    va_start(ap, format);
+    len = vfprintf(out->dest, format, ap);
+    CRM_ASSERT(len > 0);
+    va_end(ap);
+}

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <crm/crm.h>
+#include <crm/common/output.h>
+#include <crm/common/xml.h>
+
+typedef struct xml_private_s {
+    xmlNode *root;
+    GQueue *parent_q;
+} xml_private_t;
+
+static void
+xml_free_priv(pcmk__output_t *out) {
+    xml_private_t *priv = out->priv;
+
+    if (priv == NULL) {
+        return;
+    }
+
+    xmlFreeNode(priv->root);
+    g_queue_free(priv->parent_q);
+    free(priv);
+}
+
+static bool
+xml_init(pcmk__output_t *out) {
+    xml_private_t *priv = NULL;
+
+    /* If xml_init was previously called on this output struct, just return. */
+    if (out->priv != NULL) {
+        return true;
+    } else {
+        out->priv = calloc(1, sizeof(xml_private_t));
+        if (out->priv == NULL) {
+            return false;
+        }
+
+        priv = out->priv;
+    }
+
+    priv->root = create_xml_node(NULL, "pacemaker-result");
+    xmlSetProp(priv->root, (pcmkXmlStr) "api-version", (pcmkXmlStr) PCMK__API_VERSION);
+
+    if (out->request != NULL) {
+        xmlSetProp(priv->root, (pcmkXmlStr) "request", (pcmkXmlStr) out->request);
+    }
+
+    priv->parent_q = g_queue_new();
+    g_queue_push_tail(priv->parent_q, priv->root);
+
+    return true;
+}
+
+static void
+xml_finish(pcmk__output_t *out, crm_exit_t exit_status) {
+    xmlNodePtr node;
+    char *rc_as_str = NULL;
+    char *buf = NULL;
+    xml_private_t *priv = out->priv;
+
+    /* If root is NULL, xml_init failed and we are being called from pcmk__output_free
+     * in the pcmk__output_new path.
+     */
+    if (priv->root == NULL) {
+        return;
+    }
+
+    rc_as_str = crm_itoa(exit_status);
+
+    node = xmlNewTextChild(priv->root, NULL, (pcmkXmlStr) "status",
+                           (pcmkXmlStr) crm_exit_str(exit_status));
+    xmlSetProp(node, (pcmkXmlStr) "code", (pcmkXmlStr) rc_as_str);
+
+    buf = dump_xml_formatted_with_text(priv->root);
+    fprintf(out->dest, "%s", buf);
+
+    free(rc_as_str);
+    free(buf);
+}
+
+static void
+xml_reset(pcmk__output_t *out) {
+    char *buf = NULL;
+    xml_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    buf = dump_xml_formatted_with_text(priv->root);
+    fprintf(out->dest, "%s", buf);
+
+    free(buf);
+    xml_free_priv(out);
+    xml_init(out);
+}
+
+static void
+xml_subprocess_output(pcmk__output_t *out, int exit_status,
+                      const char *proc_stdout, const char *proc_stderr) {
+    xmlNodePtr node, child_node;
+    char *rc_as_str = NULL;
+    xml_private_t *priv = out->priv;
+    CRM_ASSERT(priv != NULL);
+
+    rc_as_str = crm_itoa(exit_status);
+
+    node = xmlNewNode(g_queue_peek_tail(priv->parent_q), (pcmkXmlStr) "command");
+    xmlSetProp(node, (pcmkXmlStr) "code", (pcmkXmlStr) rc_as_str);
+
+    if (proc_stdout != NULL) {
+        child_node = xmlNewTextChild(node, NULL, (pcmkXmlStr) "output",
+                                     (pcmkXmlStr) proc_stdout);
+        xmlSetProp(child_node, (pcmkXmlStr) "source", (pcmkXmlStr) "stdout");
+    }
+
+    if (proc_stderr != NULL) {
+        child_node = xmlNewTextChild(node, NULL, (pcmkXmlStr) "output",
+                                     (pcmkXmlStr) proc_stderr);
+        xmlSetProp(node, (pcmkXmlStr) "source", (pcmkXmlStr) "stderr");
+    }
+
+    pcmk__xml_add_node(out, node);
+    free(rc_as_str);
+}
+
+G_GNUC_PRINTF(2, 3)
+static void
+xml_info(pcmk__output_t *out, const char *format, ...) {
+    /* This function intentially left blank */
+}
+
+static void
+xml_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
+    xmlNodePtr parent = NULL;
+    xmlNodePtr cdata_node = NULL;
+    xml_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    parent = xmlNewChild(g_queue_peek_tail(priv->parent_q), NULL,
+                         (pcmkXmlStr) name, NULL);
+    cdata_node = xmlNewCDataBlock(getDocPtr(parent), (pcmkXmlStr) buf, strlen(buf));
+    xmlAddChild(parent, cdata_node);
+}
+
+static void
+xml_begin_list(pcmk__output_t *out, const char *name,
+               const char *singular_noun, const char *plural_noun) {
+    xmlNodePtr list_node = NULL;
+    xml_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    list_node = create_xml_node(g_queue_peek_tail(priv->parent_q), "list");
+    xmlSetProp(list_node, (pcmkXmlStr) "name", (pcmkXmlStr) name);
+    g_queue_push_tail(priv->parent_q, list_node);
+}
+
+static void
+xml_list_item(pcmk__output_t *out, const char *name, const char *content) {
+    xml_private_t *priv = out->priv;
+    xmlNodePtr item_node = NULL;
+
+    CRM_ASSERT(priv != NULL);
+
+    item_node = xmlNewChild(g_queue_peek_tail(priv->parent_q), NULL,
+                            (pcmkXmlStr) "item", (pcmkXmlStr) content);
+    xmlSetProp(item_node, (pcmkXmlStr) "name", (pcmkXmlStr) name);
+}
+
+static void
+xml_end_list(pcmk__output_t *out) {
+    char *buf = NULL;
+    xml_private_t *priv = out->priv;
+    xmlNodePtr node;
+
+    CRM_ASSERT(priv != NULL);
+
+    node = g_queue_pop_tail(priv->parent_q);
+    buf = crm_strdup_printf("%lu", xmlChildElementCount(node));
+    xmlSetProp(node, (pcmkXmlStr) "count", (pcmkXmlStr) buf);
+    free(buf);
+}
+
+pcmk__output_t *
+pcmk__mk_xml_output(char **argv) {
+    pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
+
+    if (retval == NULL) {
+        return NULL;
+    }
+
+    retval->request = g_strjoinv(" ", argv);
+    retval->supports_quiet = false;
+
+    retval->init = xml_init;
+    retval->free_priv = xml_free_priv;
+    retval->finish = xml_finish;
+    retval->reset = xml_reset;
+
+    retval->register_message = pcmk__register_message;
+    retval->message = pcmk__call_message;
+
+    retval->subprocess_output = xml_subprocess_output;
+    retval->info = xml_info;
+    retval->output_xml = xml_output_xml;
+
+    retval->begin_list = xml_begin_list;
+    retval->list_item = xml_list_item;
+    retval->end_list = xml_end_list;
+
+    return retval;
+}
+
+void
+pcmk__xml_add_node(pcmk__output_t *out, xmlNodePtr node) {
+    xml_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+    CRM_ASSERT(node != NULL);
+
+    xmlAddChild(g_queue_peek_tail(priv->parent_q), node);
+}
+
+void
+pcmk__xml_push_parent(pcmk__output_t *out, xmlNodePtr parent) {
+    xml_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+    CRM_ASSERT(parent != NULL);
+
+    g_queue_push_tail(priv->parent_q, parent);
+}
+
+void
+pcmk__xml_pop_parent(pcmk__output_t *out) {
+    xml_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+    CRM_ASSERT(g_queue_get_length(priv->parent_q) > 0);
+
+    g_queue_pop_tail(priv->parent_q);
+}

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -179,6 +179,7 @@ pcmk_errorname(int rc)
         case pcmk_err_node_unknown: return "pcmk_err_node_unknown";
         case pcmk_err_already: return "pcmk_err_already";
         case pcmk_err_bad_nvpair: return "pcmk_err_bad_nvpair";
+        case pcmk_err_unknown_format: return "pcmk_err_unknown_format";
     }
     return "Unknown";
 }
@@ -227,6 +228,8 @@ pcmk_strerror(int rc)
             return "Bad name/value pair given";
         case pcmk_err_schema_unchanged:
             return "Schema is already the latest available";
+        case pcmk_err_unknown_format:
+            return "Unknown output format";
 
             /* The following cases will only be hit on systems for which they are non-standard */
             /* coverity[dead_error_condition] False positive on non-Linux */
@@ -424,6 +427,7 @@ crm_errno2exit(int rc)
 
         case ENXIO:
         case pcmk_err_node_unknown:
+        case pcmk_err_unknown_format:
             return CRM_EX_NOSUCH;
 
         case ETIME:

--- a/lib/fencing/Makefile.am
+++ b/lib/fencing/Makefile.am
@@ -17,7 +17,7 @@ libstonithd_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)
 libstonithd_la_LIBADD	= $(top_builddir)/lib/common/libcrmcommon.la
 libstonithd_la_LIBADD   += $(top_builddir)/lib/services/libcrmservice.la
 
-libstonithd_la_SOURCES	= st_client.c st_rhcs.c
+libstonithd_la_SOURCES	= st_client.c st_output.c st_rhcs.c
 if BUILD_LHA_SUPPORT
 libstonithd_la_SOURCES	+= st_lha.c
 endif

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <stdarg.h>
+
+#include <crm/stonith-ng.h>
+#include <crm/common/output.h>
+#include <crm/common/util.h>
+#include <crm/common/xml.h>
+
+static int
+fence_target_text(pcmk__output_t *out, va_list args) {
+    const char *hostname = va_arg(args, const char *);
+    const char *uuid = va_arg(args, const char *);
+    const char *status = va_arg(args, const char *);
+
+    pcmk__indented_printf(out, "%s\t%s\t%s\n", hostname, uuid, status);
+    return 0;
+}
+
+static int
+fence_target_xml(pcmk__output_t *out, va_list args) {
+    xmlNodePtr node = NULL;
+    const char *hostname = va_arg(args, const char *);
+    const char *uuid = va_arg(args, const char *);
+    const char *status = va_arg(args, const char *);
+
+    node = xmlNewNode(NULL, (pcmkXmlStr) "target");
+    xmlSetProp(node, (pcmkXmlStr) "hostname", (pcmkXmlStr) hostname);
+    xmlSetProp(node, (pcmkXmlStr) "uuid", (pcmkXmlStr) uuid);
+    xmlSetProp(node, (pcmkXmlStr) "status", (pcmkXmlStr) status);
+
+    pcmk__xml_add_node(out, node);
+    return 0;
+}
+
+static int
+last_fenced_text(pcmk__output_t *out, va_list args) {
+    const char *target = va_arg(args, const char *);
+    time_t when = va_arg(args, time_t);
+
+    if (when) {
+        pcmk__indented_printf(out, "Node %s last fenced at: %s\n", target, ctime(&when));
+    } else {
+        pcmk__indented_printf(out, "Node %s has never been fenced\n", target);
+    }
+
+    return 0;
+}
+
+static int
+last_fenced_xml(pcmk__output_t *out, va_list args) {
+    const char *target = va_arg(args, const char *);
+    time_t when = va_arg(args, time_t);
+
+    if (when) {
+        xmlNodePtr node = xmlNewNode(NULL, (pcmkXmlStr) "last-fenced");
+
+        /* Remove the newline that ctime automatically adds. */
+        char *ts = ctime(&when);
+        char *buf = crm_strdup_printf("%.*s", (int) strcspn(ts, "\n"), ts);
+
+        xmlSetProp(node, (pcmkXmlStr) "target", (pcmkXmlStr) target);
+        xmlSetProp(node, (pcmkXmlStr) "when", (pcmkXmlStr) buf);
+
+        pcmk__xml_add_node(out, node);
+
+        free(buf);
+    }
+
+    return 0;
+}
+
+static int
+stonith_event_text(pcmk__output_t *out, va_list args) {
+    stonith_history_t *event = va_arg(args, stonith_history_t *);
+
+    switch (event->state) {
+        case st_failed:
+            pcmk__indented_printf(out, "%s failed %s node %s on behalf of %s from %s at %s\n",
+                                  event->delegate ? event->delegate : "We",
+                                  stonith_action_str(event->action), event->target,
+                                  event->client, event->origin, ctime(&event->completed));
+            break;
+
+        case st_done:
+            pcmk__indented_printf(out, "%s succeeded %s node %s on behalf of %s from %s at %s\n",
+                                  event->delegate ? event->delegate : "This node",
+                                  stonith_action_str(event->action), event->target,
+                                  event->client, event->origin, ctime(&event->completed));
+            break;
+
+        default:
+            /* ocf:pacemaker:controld depends on "wishes to" being
+             * in this output, when used with older versions of DLM
+             * that don't report stateful_merge_wait
+             */
+            pcmk__indented_printf(out, "%s at %s wishes to %s node %s - %d %lld\n",
+                                  event->client, event->origin, stonith_action_str(event->action),
+                                  event->target, event->state, (long long) event->completed);
+            break;
+    }
+
+    return 0;
+}
+
+static int
+stonith_event_xml(pcmk__output_t *out, va_list args) {
+    xmlNodePtr node = NULL;
+    stonith_history_t *event = va_arg(args, stonith_history_t *);
+
+    node = xmlNewNode(NULL, (pcmkXmlStr) "stonith-event");
+
+    switch (event->state) {
+        case st_failed:
+            xmlSetProp(node, (pcmkXmlStr) "status", (pcmkXmlStr) "failed");
+            break;
+
+        case st_done:
+            xmlSetProp(node, (pcmkXmlStr) "status", (pcmkXmlStr) "done");
+            break;
+
+        default: {
+            char *state = crm_itoa(event->state);
+            xmlSetProp(node, (pcmkXmlStr) "status", (pcmkXmlStr) state);
+            free(state);
+            break;
+        }
+    }
+
+    if (event->delegate != NULL) {
+        xmlSetProp(node, (pcmkXmlStr) "delegate", (pcmkXmlStr) event->delegate);
+    }
+
+    xmlSetProp(node, (pcmkXmlStr) "action", (pcmkXmlStr) stonith_action_str(event->action));
+    xmlSetProp(node, (pcmkXmlStr) "target", (pcmkXmlStr) event->target);
+    xmlSetProp(node, (pcmkXmlStr) "client", (pcmkXmlStr) event->client);
+    xmlSetProp(node, (pcmkXmlStr) "origin", (pcmkXmlStr) event->origin);
+    xmlSetProp(node, (pcmkXmlStr) "when", (pcmkXmlStr) ctime(&event->completed));
+
+    pcmk__xml_add_node(out, node);
+
+    return 0;
+}
+
+static int
+validate_agent_text(pcmk__output_t *out, va_list args) {
+    const char *agent = va_arg(args, const char *);
+    const char *device = va_arg(args, const char *);
+    const char *output = va_arg(args, const char *);
+    const char *error_output = va_arg(args, const char *);
+    int rc = va_arg(args, int);
+
+    if (device) {
+        pcmk__indented_printf(out, "Validation of %s on %s %s\n", agent, device,
+                              rc ? "failed" : "succeeded");
+    } else {
+        pcmk__indented_printf(out, "Validation of %s %s\n", agent,
+                              rc ? "failed" : "succeeded");
+    }
+
+    if (output) {
+        puts(output);
+    }
+
+    if (error_output) {
+        puts(error_output);
+    }
+
+    return rc;
+}
+
+static int
+validate_agent_xml(pcmk__output_t *out, va_list args) {
+    xmlNodePtr node = NULL;
+
+    const char *agent = va_arg(args, const char *);
+    const char *device = va_arg(args, const char *);
+    const char *output = va_arg(args, const char *);
+    const char *error_output = va_arg(args, const char *);
+    int rc = va_arg(args, int);
+
+    node = xmlNewNode(NULL, (pcmkXmlStr) "validate");
+    xmlSetProp(node, (pcmkXmlStr) "agent", (pcmkXmlStr) agent);
+    if (device != NULL) {
+        xmlSetProp(node, (pcmkXmlStr) "device", (pcmkXmlStr) device);
+    }
+    xmlSetProp(node, (pcmkXmlStr) "valid", (pcmkXmlStr) (rc ? "false" : "true"));
+
+    pcmk__xml_push_parent(out, node);
+    out->subprocess_output(out, rc, output, error_output);
+    pcmk__xml_pop_parent(out);
+
+    pcmk__xml_add_node(out, node);
+    return rc;
+}
+
+static pcmk__message_entry_t fmt_functions[] = {
+    { "fence-target", "text", fence_target_text },
+    { "fence-target", "xml", fence_target_xml },
+    { "last-fenced", "text", last_fenced_text },
+    { "last-fenced", "xml", last_fenced_xml },
+    { "stonith-event", "text", stonith_event_text },
+    { "stonith-event", "xml", stonith_event_xml },
+    { "validate", "text", validate_agent_text },
+    { "validate", "xml", validate_agent_xml },
+
+    { NULL, NULL, NULL }
+};
+
+void
+stonith_register_messages(pcmk__output_t *out) {
+    pcmk__register_messages(out, fmt_functions);
+}

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -833,6 +833,7 @@ exit 0
 %license licenses/GPLv2
 %{_datadir}/pacemaker/*.rng
 %{_datadir}/pacemaker/*.xsl
+%{_datadir}/pacemaker/api/*.rng
 
 %changelog
 

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -25,6 +25,7 @@
 #include <crm/common/ipc.h>
 #include <crm/cluster/internal.h>
 #include <crm/common/mainloop.h>
+#include <crm/common/output.h>
 
 #include <crm/stonith-ng.h>
 #include <crm/cib.h>
@@ -53,6 +54,7 @@ static struct crm_option long_options[] = {
     {   "broadcast", no_argument, NULL, 'b',
         "Broadcast wherever appropriate."
     },
+    PCMK__OUTPUT_OPTIONS("text, xml"),
     {   "-spacer-", no_argument, NULL, '-', "\nDevice definition commands:" },
 
     {   "register", required_argument, NULL, 'R',
@@ -323,57 +325,31 @@ handle_level(stonith_t *st, char *target, int fence_level,
                                        name, value, fence_level);
 }
 
-static char *
-fence_action_str(const char *action)
-{
-    char *str = NULL;
-
-    if (action == NULL) {
-        str = strdup("unknown");
-    } else if (action[0] == 'o') { // on, off
-        str = crm_concat("turn", action, ' ');
-    } else {
-        str = strdup(action);
-    }
-    return str;
-}
-
-static void
-print_fence_event(stonith_history_t *event)
-{
-    char *action_s = fence_action_str(event->action);
-    time_t complete = event->completed;
-
-    printf("%s was able to %s node %s on behalf of %s from %s at %s\n",
-           (event->delegate? event->delegate : "This node"), action_s,
-           event->target, event->client, event->origin, ctime(&complete));
-    free(action_s);
-}
-
 static int
 handle_history(stonith_t *st, const char *target, int timeout, int quiet,
-             int verbose, int cleanup, int broadcast)
+             int verbose, int cleanup, int broadcast, pcmk__output_t *out)
 {
     stonith_history_t *history = NULL, *hp, *latest = NULL;
     int rc = 0;
 
     if (!quiet) {
         if (cleanup) {
-            printf("cleaning up fencing-history%s%s\n",
-                   target?" for node ":"", target?target:"");
+            out->info(out, "cleaning up fencing-history%s%s",
+                      target ? " for node " : "", target ? target : "");
         }
         if (broadcast) {
-            printf("gather fencing-history from all nodes\n");
+            out->info(out, "gather fencing-history from all nodes");
         }
     }
+
     rc = st->cmds->history(st, st_opts | (cleanup?st_opt_cleanup:0) |
                            (broadcast?st_opt_broadcast:0),
                            (safe_str_eq(target, "*")? NULL : target),
                            &history, timeout);
-    for (hp = history; hp; hp = hp->next) {
-        char *action_s = NULL;
-        time_t complete = hp->completed;
 
+    out->begin_list(out, "Fencing history", "event", "events");
+
+    for (hp = history; hp; hp = hp->next) {
         if (hp->state == st_done) {
             latest = hp;
         }
@@ -382,36 +358,18 @@ handle_history(stonith_t *st, const char *target, int timeout, int quiet,
             continue;
         }
 
-        if (hp->state == st_failed) {
-            action_s = fence_action_str(hp->action);
-            printf("%s failed to %s node %s on behalf of %s from %s at %s\n",
-                   hp->delegate ? hp->delegate : "We", action_s, hp->target,
-                   hp->client, hp->origin, ctime(&complete));
-
-        } else if (hp->state == st_done) {
-            print_fence_event(latest);
-
-        } else {
-            /* ocf:pacemaker:controld depends on "wishes to" being
-             * in this output, when used with older versions of DLM
-             * that don't report stateful_merge_wait
-             */
-            action_s = fence_action_str(hp->action);
-            printf("%s at %s wishes to %s node %s - %d %lld\n",
-                   hp->client, hp->origin, action_s, hp->target, hp->state,
-                   (long long) complete);
-        }
-
-        free(action_s);
+        out->message(out, "stonith-event", hp);
     }
 
     if (latest) {
-        if (quiet) {
-            printf("%lld\n", (long long) latest->completed);
+        if (quiet && out->supports_quiet) {
+            out->info(out, "%lld", (long long) latest->completed);
         } else if (!verbose) { // already printed if verbose
-            print_fence_event(latest);
+            out->message(out, "stonith-event", latest);
         }
     }
+
+    out->end_list(out);
 
     stonith_history_free(history);
     return rc;
@@ -419,7 +377,8 @@ handle_history(stonith_t *st, const char *target, int timeout, int quiet,
 
 static int
 validate(stonith_t *st, const char *agent, const char *id,
-         stonith_key_value_t *params, int timeout, int quiet)
+         stonith_key_value_t *params, int timeout, int quiet,
+         pcmk__output_t *out)
 {
     int rc = 1;
     char *output = NULL;
@@ -428,17 +387,11 @@ validate(stonith_t *st, const char *agent, const char *id,
     rc = st->cmds->validate(st, st_opt_sync_call, id, NULL, agent, params,
                             timeout, &output, &error_output);
 
-    if (!quiet) {
-        printf("Validation of %s %s\n", agent, (rc? "failed" : "succeeded"));
-        if (output && *output) {
-            puts(output);
-            free(output);
-        }
-        if (error_output && *error_output) {
-            puts(error_output);
-            free(error_output);
-        }
+    if (quiet) {
+        return rc;
     }
+
+    out->message(out, "validate", agent, id, output, error_output, rc); 
     return rc;
 }
 
@@ -474,6 +427,10 @@ main(int argc, char **argv)
     stonith_key_value_t *params = NULL;
     stonith_key_value_t *devices = NULL;
     stonith_key_value_t *dIter = NULL;
+
+    char *output_ty = NULL;
+    char *output_dest = NULL;
+    pcmk__output_t *out = NULL;
 
     crm_log_cli_init("stonith_admin");
     crm_set_options(NULL, "<command> [<options>]", long_options,
@@ -603,7 +560,12 @@ main(int argc, char **argv)
             case 0:
                 if (safe_str_eq("tolerance", longname)) {
                     tolerance = crm_get_msec(optarg) / 1000;    /* Send in seconds */
+                } else if (pcmk__parse_output_args(longname, optarg, &output_ty,
+                                                   &output_dest) == false) {
+                    fprintf(stderr, "Unknown long option used: %s\n", longname);
+                    ++argerr;
                 }
+
                 break;
             default:
                 ++argerr;
@@ -616,13 +578,25 @@ main(int argc, char **argv)
     }
 
     if (required_agent && agent == NULL) {
-        printf("Please specify an agent to query using -a,--agent [value]\n");
+        fprintf(stderr, "Please specify an agent to query using -a,--agent [value]\n");
         ++argerr;
     }
 
     if (argerr) {
         crm_help('?', CRM_EX_USAGE);
     }
+
+    CRM_ASSERT(pcmk__register_format("text", pcmk__mk_text_output) == 0);
+    CRM_ASSERT(pcmk__register_format("xml", pcmk__mk_xml_output) == 0);
+
+    rc = pcmk__output_new(&out, output_ty, output_dest, argv);
+    if (rc != 0) {
+        fprintf(stderr, "Error creating output format %s: %s\n", output_ty, pcmk_strerror(rc));
+        exit_code = CRM_EX_ERROR;
+        goto done;
+    }
+
+    stonith_register_messages(out);
 
     st = stonith_api_new();
 
@@ -639,30 +613,40 @@ main(int argc, char **argv)
     switch (action) {
         case 'I':
             rc = st->cmds->list_agents(st, st_opt_sync_call, NULL, &devices, timeout);
+            if (rc < 0) {
+                fprintf(stderr, "Failed to list installed devices: %s\n", pcmk_strerror(rc));
+                break;
+            }
+
+            out->begin_list(out, "Installed fence devices", "fence device", "fence devices");
             for (dIter = devices; dIter; dIter = dIter->next) {
-                fprintf(stdout, " %s\n", dIter->value);
+                out->list_item(out, "device", dIter->value);
             }
-            if (rc == 0) {
-                fprintf(stderr, "No devices found\n");
-            } else if (rc > 0) {
-                fprintf(stderr, "%d devices found\n", rc);
-                rc = 0;
-            }
+
+            out->end_list(out);
+            rc = 0;
+
             stonith_key_value_freeall(devices, 1, 1);
             break;
+
         case 'L':
             rc = st->cmds->query(st, st_opts, target, &devices, timeout);
+            if (rc < 0) {
+                fprintf(stderr, "Failed to list registered devices: %s\n", pcmk_strerror(rc));
+                break;
+            }
+
+            out->begin_list(out, "Registered fence devices", "fence device", "fence devices");
             for (dIter = devices; dIter; dIter = dIter->next) {
-                fprintf(stdout, " %s\n", dIter->value);
+                out->list_item(out, "device", dIter->value);
             }
-            if (rc == 0) {
-                fprintf(stderr, "No devices found\n");
-            } else if (rc > 0) {
-                fprintf(stderr, "%d devices found\n", rc);
-                rc = 0;
-            }
+
+            out->end_list(out);
+            rc = 0;
+
             stonith_key_value_freeall(devices, 1, 1);
             break;
+
         case 'Q':
             rc = st->cmds->monitor(st, st_opts, device, timeout);
             if (rc < 0) {
@@ -671,32 +655,54 @@ main(int argc, char **argv)
             break;
         case 's':
             rc = st->cmds->list(st, st_opts, device, &lists, timeout);
-            if (rc == 0) {
-                if (lists) {
-                    char *source = lists, *dest = lists; 
+            if (rc == 0 && lists) {
+                char *head = lists;
+                char *eol = NULL;
 
-                    while (*dest) {
-                        if ((*dest == '\\') && (*(dest+1) == 'n')) {
-                            *source = '\n';
-                            dest++;
-                            dest++;
-                            source++;
-                        } else if ((*dest == ',') || (*dest == ';')) {
-                            dest++;
-                        } else {
-                            *source = *dest;
-                            dest++;
-                            source++;
+                out->begin_list(out, "Fence targets", "fence target", "fence targets");
+
+                do {
+                    char *line = NULL;
+                    char *elem = NULL;
+
+                    char *hostname = NULL;
+                    char *uuid = NULL;
+                    char *status = NULL;
+
+                    eol = strstr(head, "\\n");
+                    line = strndup(head, eol-head);
+
+                    while ((elem = strsep(&line, " ")) != NULL) {
+                        if (strcmp(elem, "") == 0) {
+                            continue;
                         }
 
-                        if (!(*dest)) {
-                            *source = 0;
+                        if (hostname == NULL) {
+                            hostname = elem;
+                        } else if (uuid == NULL) {
+                            uuid = elem;
+                        } else if (status == NULL) {
+                            char *end = NULL;
+                            status = elem;
+
+                            end = strchr(status, '\n');
+                            if (end != NULL) {
+                                *end = '\0';
+                            }
                         }
                     }
-                    fprintf(stdout, "%s", lists);
-                    free(lists);
-                }
-            } else {
+
+                    if (hostname != NULL && uuid != NULL && status != NULL) {
+                        out->message(out, "fence-target", hostname, uuid, status);
+                    }
+
+                    free(line);
+
+                    head = eol+2;
+                } while (eol != NULL);
+
+                out->end_list(out);
+            } else if (rc != 0) {
                 fprintf(stderr, "List command returned error. rc : %d\n", rc);
             }
             break;
@@ -717,7 +723,7 @@ main(int argc, char **argv)
 
                 rc = st->cmds->metadata(st, st_opt_sync_call, agent, NULL, &buffer, timeout);
                 if (rc == pcmk_ok) {
-                    printf("%s\n", buffer);
+                    out->output_xml(out, "metadata", buffer);
                 }
                 free(buffer);
             }
@@ -744,30 +750,34 @@ main(int argc, char **argv)
                 } else {
                     when = stonith_api_time(0, target, FALSE);
                 }
-                if(when) {
-                    printf("Node %s last kicked at: %s\n", target, ctime(&when));
-                } else {
-                    printf("Node %s has never been kicked\n", target);
-                }
+
+                out->message(out, "last-fenced", target, when);
             }
+
             break;
         case 'H':
             rc = handle_history(st, target, timeout, quiet,
-                                verbose, cleanup, broadcast);
+                                verbose, cleanup, broadcast, out);
             break;
         case 'K':
             device = (devices? devices->key : NULL);
-            rc = validate(st, agent, device, params, timeout, quiet);
+            rc = validate(st, agent, device, params, timeout, quiet, out);
             break;
     }
 
     crm_info("Command returned: %s (%d)", pcmk_strerror(rc), rc);
     exit_code = crm_errno2exit(rc);
 
+    pcmk__output_free(out, exit_code);
+
   done:
     free(async_fence_data.name);
     stonith_key_value_freeall(params, 1, 1);
-    st->cmds->disconnect(st);
-    stonith_api_delete(st);
+
+    if (st != NULL) {
+        st->cmds->disconnect(st);
+        stonith_api_delete(st);
+    }
+
     return exit_code;
 }

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -19,6 +19,7 @@
 #
 MAINTAINERCLEANFILES    = Makefile.in
 
+APIdir 			= $(CRM_SCHEMA_DIRECTORY)/api
 RNGdir			= $(CRM_SCHEMA_DIRECTORY)
 
 xsltdir			= $(RNGdir)
@@ -33,31 +34,44 @@ noinst_DATA		= context-of.xsl
 
 # Sorted list of available numeric RNG versions,
 # extracted from filenames like NAME-MAJOR[.MINOR][.MINOR-MINOR].rng
-RNG_numeric_versions    = $(shell ls -1 $(top_srcdir)/xml/*.rng \
+numeric_versions = $(shell ls -1 $(1) \
 			  | sed -n -e 's/^.*-\([0-9][0-9.]*\).rng$$/\1/p' \
 			  | sort -u -t. -k 1,1n -k 2,2n -k 3,3n)
 
-# The highest numeric version
-RNG_max			?= $(lastword $(RNG_numeric_versions))
-
-# A sorted list of all RNG versions (numeric and "next")
-RNG_versions		= next $(RNG_numeric_versions)
-RNG_version_pairs	= $(join \
-			    ${RNG_numeric_versions},$(addprefix \
+version_pairs = $(join \
+			    $(1),$(addprefix \
 			      -,$(wordlist \
-			        2,$(words ${RNG_numeric_versions}),${RNG_numeric_versions} \
+			        2,$(words $(1)),$(1) \
 			      ) next \
 			    ) \
 			  )
-RNG_version_pairs_cnt	= $(words ${RNG_version_pairs})
-RNG_version_pairs_last  = $(wordlist \
+
+version_pairs_last = $(wordlist \
 			    $(words \
 			      $(wordlist \
-			        2,${RNG_version_pairs_cnt},${RNG_version_pairs} \
+			        2,$(1),$(2) \
 			      ) \
-			    ),${RNG_version_pairs_cnt},${RNG_version_pairs} \
+			    ),$(1),$(2) \
 			  )
 
+API_numeric_versions = $(call numeric_versions,${API_files})
+RNG_numeric_versions = $(call numeric_versions,${RNG_files})
+
+# The highest numeric version
+API_max 		?= $(lastword $(API_numeric_versions))
+RNG_max			?= $(lastword $(RNG_numeric_versions))
+
+# A sorted list of all API and RNG versions (numeric and "next")
+API_versions 		= next $(API_numeric_versions)
+API_base 			= command-output stonith_admin
+API_files 			= $(foreach base,$(API_base),$(wildcard api/$(base)*.rng))
+
+RNG_versions		= next $(RNG_numeric_versions)
+RNG_version_pairs	= $(call version_pairs,${RNG_numeric_versions})
+RNG_version_pairs_cnt	= $(words ${RNG_version_pairs})
+RNG_version_pairs_last  = $(call version_pairs_last,${RNG_version_pairs_cnt},${RNG_version_pairs})
+
+API_generated 		= api/api-result.rng $(foreach base,$(API_versions),api/api-result-$(base).rng)
 RNG_generated		= pacemaker.rng $(foreach base,$(RNG_versions),pacemaker-$(base).rng) versions.rng
 
 RNG_cfg_base		= options nodes resources constraints fencing acls tags alerts
@@ -67,7 +81,9 @@ RNG_files		= $(foreach base,$(RNG_base),$(wildcard $(base).rng $(base)-*.rng))
 # List of non-Pacemaker RNGs
 RNG_extra		= crm_mon.rng
 
+dist_API_DATA 		= $(API_files)
 dist_RNG_DATA		= $(RNG_files) $(RNG_extra)
+nodist_API_DATA 	= $(API_generated)
 nodist_RNG_DATA		= $(RNG_generated)
 
 EXTRA_DIST		= best-match.sh
@@ -75,6 +91,10 @@ EXTRA_DIST		= best-match.sh
 versions:
 	echo "Max: $(RNG_max)"
 	echo "Available: $(RNG_versions)"
+
+api-versions:
+	echo "Max: $(API_max)"
+	echo "Available: $(API_versions)"
 
 versions.rng: Makefile.am
 	echo "  RNG      $@"
@@ -101,9 +121,34 @@ versions.rng: Makefile.am
 	echo '  </start>' >> $@
 	echo '</grammar>' >> $@
 
+api/api-result.rng: api/api-result-$(API_max).rng
+	echo "  RNG      $@"
+	cp $(top_builddir)/xml/$< $@
+
 pacemaker.rng: pacemaker-$(RNG_max).rng
 	echo "  RNG      $@"
 	cp $(top_builddir)/xml/$< $@
+
+api/api-result-%.rng: $(API_files) Makefile.am
+	echo "  RNG      $@"
+	echo '<?xml version="1.0" encoding="UTF-8"?>' > $@
+	echo '<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">' >> $@
+	echo '  <start>' >> $@
+	echo '    <element name="pacemaker-result">' >> $@
+	echo '      <attribute name="api-version"> <text /> </attribute>' >> $@
+	echo '      <attribute name="request"> <text /> </attribute>' >> $@
+	echo '      <optional>' >> $@
+	echo '        <choice>' >> $@
+	for rng in $(API_base); do $(top_srcdir)/xml/best-match.sh api/$$rng $(*) $(@) "          " || :; done
+	echo '        </choice>' >> $@
+	echo '      </optional>' >> $@
+	echo '      <element name="status">' >> $@
+	echo '        <attribute name="code"> <data type="integer" /> </attribute>' >> $@
+	echo '        <text />' >> $@
+	echo '      </element>' >> $@
+	echo '    </element>' >> $@
+	echo '  </start>' >> $@
+	echo '</grammar>' >> $@
 
 pacemaker-%.rng: $(RNG_files) best-match.sh Makefile.am
 	echo "  RNG      $@"
@@ -175,4 +220,4 @@ sync:
 	git rm -f $(wildcard *-next.rng)
 	make pacemaker-next.rng
 
-CLEANFILES = $(RNG_generated)
+CLEANFILES = $(API_generated) $(RNG_generated)

--- a/xml/api/command-output-1.0.rng
+++ b/xml/api/command-output-1.0.rng
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="command-output" />
+    </start>
+
+    <define name="command-output">
+        <element name="command">
+            <attribute name="code"> <data type="integer" /> </attribute>
+            <optional>
+                <element name="output">
+                    <attribute name="source"><value>stdout</value></attribute>
+                    <text />
+                </element>
+            </optional>
+            <optional>
+                <element name="output">
+                    <attribute name="source"><value>stderr</value></attribute>
+                    <text />
+                </element>
+            </optional>
+        </element>
+    </define>
+</grammar>

--- a/xml/api/stonith_admin-1.0.rng
+++ b/xml/api/stonith_admin-1.0.rng
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-stonith-admin"/>
+    </start>
+
+    <define name="element-stonith-admin">
+        <choice>
+            <ref name="stonith-admin-list" />
+            <ref name="element-last-fenced" />
+            <ref name="element-validation" />
+            <element name="metadata"> <text /> </element>
+        </choice>
+    </define>
+
+    <define name="stonith-admin-list">
+        <element name="list">
+            <attribute name="name"> <text /> </attribute>
+            <attribute name="count"> <data type="nonNegativeInteger" /> </attribute>
+            <choice>
+                <zeroOrMore>
+                    <ref name="fencing-history-event" />
+                </zeroOrMore>
+                <zeroOrMore>
+                    <ref name="fencing-target" />
+                </zeroOrMore>
+                <zeroOrMore>
+                    <ref name="device" />
+                </zeroOrMore>
+            </choice>
+        </element>
+    </define>
+
+    <define name="device">
+        <element name="item">
+            <attribute name="name"> <value>device</value> </attribute>
+            <data type="NCName" />
+        </element>
+    </define>
+
+    <define name="fencing-target">
+        <element name="target">
+            <attribute name="hostname"> <text /> </attribute>
+            <attribute name="uuid"> <text /> </attribute>
+            <attribute name="status"> <text /> </attribute>
+        </element>
+    </define>
+
+    <define name="element-last-fenced">
+        <element name="last-fenced">
+            <attribute name="target"> <text /> </attribute>
+            <attribute name="when"> <text /> </attribute>
+        </element>
+    </define>
+
+    <define name="element-validation">
+        <element name="validate">
+            <attribute name="agent"> <text /> </attribute>
+            <attribute name="valid"> <data type="boolean" /> </attribute>
+            <optional>
+                <externalRef href="command-output-1.0.rng" />
+            </optional>
+        </element>
+    </define>
+
+    <define name="fencing-history-event">
+        <element name="stonith-event">
+            <attribute name="status"> <text /> </attribute>
+            <optional>
+                <attribute name="delegate"> <text /> </attribute>
+            </optional>
+            <attribute name="action"> <text /> </attribute>
+            <attribute name="target"> <text /> </attribute>
+            <attribute name="client"> <text /> </attribute>
+            <attribute name="origin"> <text /> </attribute>
+            <attribute name="when"> <text /> </attribute>
+        </element>
+    </define>
+</grammar>

--- a/xml/best-match.sh
+++ b/xml/best-match.sh
@@ -88,9 +88,9 @@ done
 if [ "$best" != "0.0" ]; then
     found=$(filename_from_version "$best" "$base")
     if [ -z "$destination" ]; then
-        echo "$found"
+        echo "$(basename $found)"
     else
-        echo "${prefix}<externalRef href=\"${found}\"/>" >> "$destination"
+        echo "${prefix}<externalRef href=\"$(basename $found)\"/>" >> "$destination"
     fi
     exit 0
 fi


### PR DESCRIPTION
This is an initial draft of a patch set to add formatted, machine-readable output to various pacemaker command line tools.  For now, all that's present is the basics to choose the output format, inital formatting functions, and changes to stonith_admin to use it all.  Everything should be pretty well explained in individual commit messages.  It's not especially complicated stuff.