### PR TITLE
Fix: libfencing: Change return type on stonith_agent_exists.

### DIFF
--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -532,7 +532,7 @@ stonith_api_time_helper(uint32_t nodeid, bool in_progress)
  *
  * \return A boolean
  */
-gboolean stonith_agent_exists(const char *agent, int timeout);
+bool stonith_agent_exists(const char *agent, int timeout);
 
 #ifdef __cplusplus
 }

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2468,13 +2468,13 @@ stonith_api_time(uint32_t nodeid, const char *uname, bool in_progress)
     return when;
 }
 
-gboolean
+bool
 stonith_agent_exists(const char *agent, int timeout)
 {
     stonith_t *st = NULL;
     stonith_key_value_t *devices = NULL;
     stonith_key_value_t *dIter = NULL;
-    gboolean rc = FALSE;
+    bool rc = FALSE;
 
     if (agent == NULL) {
         return rc;


### PR DESCRIPTION
There's no need for this to return a gboolean, which requires then
including glib.h.  It can just be a bool.