### PR TITLE
Update copyright notice policy

### DIFF
--- a/doc/Pacemaker_Development/en-US/Ch-Coding.txt
+++ b/doc/Pacemaker_Development/en-US/Ch-Coding.txt
@@ -5,7 +5,7 @@
 We prefer [[ch-NAME]], but older versions of asciidoc don't deal well
 with that construct for chapter headings
 ////
-anchor:ch-c-coding[Chapter 2, C Coding Guidelines]
+anchor:ch-c-coding[Chapter 3, C Coding Guidelines]
 
 == Style Guidelines ==
 
@@ -23,30 +23,20 @@ writing, and reviewing code easier.
 indexterm:[C,boilerplate]
 indexterm:[licensing,C boilerplate]
 
-Every C file should start with a short copyright notice listing the original
-author, like:
+Every C file should start with a short copyright notice:
 
 ====
 [source,C]
 ----
 /*
- * Copyright <YYYY[-YYYY]> Andrew Beekhof <andrew@beekhof.net>
+ * Copyright <YYYY[-YYYY]> the Pacemaker project contributors
  * 
+ * The version control history for this file may have further details.
+ *
  * This source code is licensed under <LICENSE> WITHOUT ANY WARRANTY.
  */
 ----
 ====
-
-The first +<YYYY>+ is the year the code was 'originally' created.
-footnote:[
-See the U.S. Copyright Office's https://www.copyright.gov/comp3/["Compendium
-of U.S. Copyright Office Practices"], particularly "Chapter 2200: Notice of
-Copyright", sections 2205.1(A) and 2205.1(F), or
-https://techwhirl.com/updating-copyright-notices/["Updating Copyright
-Notices"] for a more readable summary.
-]
-If the code is modified in later years, add +-YYYY+ with the most recent year
-of modification.
 
 +<LICENSE>+ should follow the policy set forth in the
 https://github.com/ClusterLabs/pacemaker/blob/master/COPYING[+COPYING+] file,

--- a/doc/Pacemaker_Development/en-US/Ch-Evolution.txt
+++ b/doc/Pacemaker_Development/en-US/Ch-Evolution.txt
@@ -1,7 +1,7 @@
 :compat-mode: legacy
 = Evolution of the project =
 
-anchor:ch-evolution[Chapter 3. Evolution]
+anchor:ch-evolution[Chapter 5. Evolution]
 
 == Foreword ==
 

--- a/doc/Pacemaker_Development/en-US/Ch-FAQ.txt
+++ b/doc/Pacemaker_Development/en-US/Ch-FAQ.txt
@@ -106,7 +106,9 @@ How can I contribute my changes to the project?::
  via GitHub (the preferred method, due to its excellent
  https://github.com/features/[features]), or e-mailed to the
  http://clusterlabs.org/mailman/listinfo/developers[developers@clusterlabs.org]
- mailing list as an attachment in a format Git can import.
+ mailing list as an attachment in a format Git can import. Authors may only
+ submit changes that they have the right to submit under the open source
+ license indicated in the affected files.
 
 What if I still have questions?::
  indexterm:[mailing lists]

--- a/doc/Pacemaker_Development/en-US/Ch-General.txt
+++ b/doc/Pacemaker_Development/en-US/Ch-General.txt
@@ -1,0 +1,33 @@
+:compat-mode: legacy
+= General Guidelines for All Languages =
+
+== Copyright ==
+
+indexterm:[copyright]
+
+When copyright notices are added to a file, they should look like this:
+====
+Copyright <YYYY[-YYYY]> the Pacemaker project contributors
+
+The version control history for this file may have further details.
+====
+
+The first +<YYYY>+ is the year the file was originally published. The original
+date is important for two reasons: when two entities claim copyright ownership
+of the same work, the earlier claim generally prevails; and copyright
+expiration is generally calculated from the original publication date.
+footnote:[
+See the U.S. Copyright Office's https://www.copyright.gov/comp3/["Compendium
+of U.S. Copyright Office Practices"], particularly "Chapter 2200: Notice of
+Copyright", sections 2205.1(A) and 2205.1(F), or
+https://techwhirl.com/updating-copyright-notices/["Updating Copyright
+Notices"] for a more readable summary.
+]
+
+If the file is modified in later years, add +-YYYY+ with the most recent year
+of modification. Even though Pacemaker is an ongoing project, copyright notices
+are about the years of 'publication' of specific content.
+
+Copyright notices are intended to indicate, but do not affect, copyright
+'ownership', which is determined by applicable laws and regulations. Authors
+may put more specific copyright notices in their commit messages if desired.

--- a/doc/Pacemaker_Development/en-US/Ch-Python.txt
+++ b/doc/Pacemaker_Development/en-US/Ch-Python.txt
@@ -5,7 +5,7 @@
 We prefer [[ch-NAME]], but older versions of asciidoc don't deal well
 with that construct for chapter headings
 ////
-anchor:ch-python-coding[Chapter 3, Python Coding Guidelines]
+anchor:ch-python-coding[Chapter 4, Python Coding Guidelines]
 
 [[s-python-boilerplate]]
 == Python Boilerplate ==
@@ -35,30 +35,16 @@ After the above line if any, every Python file should start like this:
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright <YYYY[-YYYY]> Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright <YYYY[-YYYY]> the Pacemaker project contributors"
 __license__ = "<LICENSE> WITHOUT ANY WARRANTY"
 ----
 ====
-
-If the file is meant to be directly executed, the first line (+<SHEBANG>+)
-should be +#!/usr/bin/python+. If it is meant to be imported, omit this line.
 
 +<BRIEF-DESCRIPTION>+ is obviously a brief description of the file's
 purpose. The string may contain any other information typically used in
 a Python file https://www.python.org/dev/peps/pep-0257/[docstring].
 
 The +import+ statement is discussed further in <<s-python-future-imports>>.
-
-+<YYYY>+ is the year the code was 'originally' created.
-footnote:[
-See the U.S. Copyright Office's https://www.copyright.gov/comp3/["Compendium
-of U.S. Copyright Office Practices"], particularly "Chapter 2200: Notice of
-Copyright", sections 2205.1(A) and 2205.1(F), or
-https://techwhirl.com/updating-copyright-notices/["Updating Copyright
-Notices"] for a more readable summary.
-]
-If the code is modified in later years, add +-YYYY+ with the most recent year
-of modification.
 
 +<LICENSE>+ should follow the policy set forth in the
 https://github.com/ClusterLabs/pacemaker/blob/master/COPYING[+COPYING+] file,

--- a/doc/Pacemaker_Development/en-US/Pacemaker_Development.xml
+++ b/doc/Pacemaker_Development/en-US/Pacemaker_Development.xml
@@ -6,6 +6,7 @@
 <book>
     <xi:include href="Book_Info.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="Ch-FAQ.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
+    <xi:include href="Ch-General.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="Ch-Coding.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="Ch-Python.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="Ch-Evolution.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION
The previous policy of listing solely the original author's name was inconsistent with the reality of copyrights. The new policy has been added to a new "general guidelines" chapter.