### PR TITLE
CI: .gitlab-ci.yml: note a workaround for "troublesome Fedora branching"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,10 @@ stages:
 #
 # Fedora Rawhide
 #
+# In case of failure imposed with branching/changed GPG keys, downgrade, e.g.:
+# sed -i.orig 's|fedora-rawhide|fedora|g;s|rawhide|fedora|g;s|:rawhide|:29|' \
+#   .gitlab-ci.yml
+# and run it through your side branch (omit such changes for upstream request).
 #
 .fedora-rawhide: &fedora-rawhide-anchor
   tags:


### PR DESCRIPTION
At this time, it seems better to retain signature checking enabled,
though it would be a definitive solution when the triggering out-of-sync
scenario is more a norm than an exception (unexpected).

Context:
<https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/OCFJJYQY65GBMAPDGAJKMJMYLVZ6AQYI/>