### PR TITLE
Doc: various: update copyright notices

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,7 @@
 #
-# Copyright 2008-2019 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2008-2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,7 @@
 #
-# Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2003-2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,9 @@
 dnl
 dnl autoconf for Pacemaker
 dnl
-dnl Copyright 2009-2018 Andrew Beekhof <andrew@beekhof.net>
+dnl Copyright 2009-2019 the Pacemaker project contributors
+dnl
+dnl The version control history for this file may have further details.
 dnl
 dnl This source code is licensed under the GNU General Public License version 2
 dnl or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/cts/CIB.py
+++ b/cts/CIB.py
@@ -4,7 +4,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2008-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2008-2019 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import os

--- a/cts/CM_common.py
+++ b/cts/CM_common.py
@@ -9,12 +9,11 @@ easier.
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = """
-Author: Huang Zhen <zhenhltc@cn.ibm.com>
+__copyright__ = """Original Author: Huang Zhen <zhenhltc@cn.ibm.com>
 Copyright 2004 International Business Machines
 
-Additional Audits, Revised Start action, Default Configuration:
-     Copyright 2004 Andrew Beekhof <andrew@beekhof.net>
+with later changes copyright 2004-2018 the Pacemaker project contributors.
+The version control history for this file may have further details.
 """
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 

--- a/cts/CM_corosync.py
+++ b/cts/CM_corosync.py
@@ -4,7 +4,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2007-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2007-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from cts.CTSvars import *

--- a/cts/CTS.py.in
+++ b/cts/CTS.py.in
@@ -4,7 +4,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2000-2018 Alan Robertson <alanr@unix.sh>"
+__copyright__ = "Copyright 2000-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import os

--- a/cts/CTSaudits.py
+++ b/cts/CTSaudits.py
@@ -4,7 +4,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2000-2018 Alan Robertson <alanr@unix.sh>"
+__copyright__ = "Copyright 2000-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import time, re, uuid

--- a/cts/CTSlab.py.in
+++ b/cts/CTSlab.py.in
@@ -5,9 +5,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = """Copyright 2001, 2005 Alan Robertson <alanr@unix.sh>
-"""
-
+__copyright__ = "Copyright 2001-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import sys, signal, os

--- a/cts/CTSscenarios.py
+++ b/cts/CTSscenarios.py
@@ -4,7 +4,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2000-2018 Alan Robertson <alanr@unix.sh>"
+__copyright__ = "Copyright 2000-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from cts.CTS import *

--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -4,10 +4,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = """Copyright 2000, 2001 Alan Robertson <alanr@unix.sh>
-Add RecourceRecover testcase Zhao Kai <zhaokai@cn.ibm.com>
-"""
-
+__copyright__ = "Copyright 2000-2019 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 #

--- a/cts/LSBDummy.in
+++ b/cts/LSBDummy.in
@@ -3,8 +3,9 @@
 #
 #	Dummy LSB RA. Does nothing but touch and remove a state file
 #
-# Copyright (c) 2010 Andrew Beekhof
-#                    All Rights Reserved.
+# Copyright 2006-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of version 2 of the GNU General Public License as

--- a/cts/Makefile.am
+++ b/cts/Makefile.am
@@ -1,5 +1,7 @@
 #
-# Copyright 2001-2018 Michael Moerz
+# Copyright 2001-2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/cts/OCFIPraTest.py.in
+++ b/cts/OCFIPraTest.py.in
@@ -5,8 +5,12 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = """Copyright 2004 International Business Machines
-Author: Huang Zhen <zhenhltc@cn.ibm.com>"""
+__copyright__ = """Original Author: Huang Zhen <zhenhltc@cn.ibm.com>
+Copyright 2004 International Business Machines
+
+with later changes copyright 2005-2018 the Pacemaker project contributors.
+The version control history for this file may have further details.
+"""
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import os

--- a/cts/benchmark/Makefile.am
+++ b/cts/benchmark/Makefile.am
@@ -1,5 +1,7 @@
 #
-# Copyright (C) 2001 Michael Moerz
+# Copyright 2001-2017 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/cts/cib_xml.py
+++ b/cts/cib_xml.py
@@ -4,7 +4,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2008-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2008-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import sys

--- a/cts/cluster_test.in
+++ b/cts/cluster_test.in
@@ -1,6 +1,8 @@
 #!@BASH_PATH@
 #
-# Copyright 2008-2018 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2008-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1,6 +1,8 @@
 #!@BASH_PATH@
 #
-# Copyright 2008-2018 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2008-2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/cts/cts-coverage.in
+++ b/cts/cts-coverage.in
@@ -1,6 +1,8 @@
 #!@BASH_PATH@
 #
-# Copyright 2012-2018 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2012-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -5,7 +5,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2012-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2012-2019 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import io

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -5,7 +5,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2012-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2012-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import io

--- a/cts/cts-log-watcher.in
+++ b/cts/cts-log-watcher.in
@@ -9,7 +9,7 @@ Contains logic for handling truncation
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2014-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2014-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import sys

--- a/cts/cts-regression.in
+++ b/cts/cts-regression.in
@@ -4,7 +4,9 @@
 #
 # Convenience wrapper for running any of the Pacemaker regression tests
 #
-# Copyright 2012-2018 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2012-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/cts/cts-scheduler.in
+++ b/cts/cts-scheduler.in
@@ -1,6 +1,8 @@
 #!@BASH_PATH@
 #
-# Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2004-2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/cts/cts-support.in
+++ b/cts/cts-support.in
@@ -2,7 +2,9 @@
 #
 # Installer for support files needed by Pacemaker's Cluster Test Suite
 #
-# Copyright 2018 Red Hat, Inc.
+# Copyright 2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/cts/cts.in
+++ b/cts/cts.in
@@ -1,6 +1,8 @@
 #!@BASH_PATH@
 #
-# Copyright 2012-2018 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2012-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/cts/environment.py
+++ b/cts/environment.py
@@ -4,7 +4,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2014-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2014-2019 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import sys, time, os, socket, random

--- a/cts/fence_dummy.in
+++ b/cts/fence_dummy.in
@@ -5,7 +5,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright (C) 2012-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2012-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import io

--- a/cts/logging.py
+++ b/cts/logging.py
@@ -4,7 +4,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright (C) 2014-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2014-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import io

--- a/cts/lxc_autogen.sh.in
+++ b/cts/lxc_autogen.sh.in
@@ -1,6 +1,8 @@
 #!@BASH_PATH@
 #
-# Copyright 2013-2018 David Vossel <davidvossel@gmail.com>
+# Copyright 2013-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/cts/pacemaker-cts-dummyd.in
+++ b/cts/pacemaker-cts-dummyd.in
@@ -5,7 +5,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2014-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2014-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import sys

--- a/cts/patterns.py
+++ b/cts/patterns.py
@@ -4,7 +4,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2008-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2008-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import sys, os

--- a/cts/remote.py
+++ b/cts/remote.py
@@ -4,7 +4,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2014-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2014-2018 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import re

--- a/cts/watcher.py
+++ b/cts/watcher.py
@@ -4,7 +4,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2014-2018 Andrew Beekhof <andrew@beekhof.net>"
+__copyright__ = "Copyright 2014-2019 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import re

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,5 +1,7 @@
 #
-# Copyright 2004-2019 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2003-2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/extra/Makefile.am
+++ b/extra/Makefile.am
@@ -1,5 +1,7 @@
 #
-# Copyright (C) 2004-2009 Andrew Beekhof
+# Copyright 2004-2016 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/extra/alerts/Makefile.am
+++ b/extra/alerts/Makefile.am
@@ -1,5 +1,7 @@
 #
-# Copyright (C) 2016 Ken Gaillot <kgaillot@redhat.com>
+# Copyright 2016 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/extra/alerts/alert_file.sh.sample
+++ b/extra/alerts/alert_file.sh.sample
@@ -1,6 +1,8 @@
 #!/bin/sh
 #
-# Copyright (C) 2015 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2015-2017 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public

--- a/extra/alerts/alert_smtp.sh.sample
+++ b/extra/alerts/alert_smtp.sh.sample
@@ -1,6 +1,8 @@
 #!/bin/sh
 #
-# Copyright (C) 2016 Klaus Wenninger <kwenning@redhat.com>
+# Copyright 2016-2017 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public

--- a/extra/alerts/alert_snmp.sh.sample
+++ b/extra/alerts/alert_snmp.sh.sample
@@ -2,6 +2,8 @@
 #
 # Copyright 2016-2018 NIPPON TELEGRAPH AND TELEPHONE CORPORATION
 #
+# The version control history for this file may have further details.
+#
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #

--- a/extra/ansible/docker/roles/docker-host/files/fence_docker_cts
+++ b/extra/ansible/docker/roles/docker-host/files/fence_docker_cts
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
-# Copyright (c) 2014 David Vossel <davidvossel@gmail.com>
-#					All Rights Reserved.
+# Copyright 2014-2015 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of version 2 of the GNU General Public License as

--- a/extra/cluster-clean
+++ b/extra/cluster-clean
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
-# Copyright 2011-2018 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2011-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/extra/cluster-init
+++ b/extra/cluster-init
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
-# Copyright 2011-2018 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2011-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/extra/clustermon.sh
+++ b/extra/clustermon.sh
@@ -5,7 +5,9 @@
 # (However, alerts are the recommended means of doing this since
 # Pacemaker 1.1.15.)
 #
-# Copyright 2013 Rob Thomas <xrobau@gmail.com>
+# Copyright 2013-2017 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/extra/gdb/gdbhelpers
+++ b/extra/gdb/gdbhelpers
@@ -1,4 +1,6 @@
-# Copyright 2018 Red Hat, Inc.
+# Copyright 2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 # Author: Jan Pokorny <jpokorny@redhat.com>
 # Part of pacemaker project
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/extra/logrotate/Makefile.am
+++ b/extra/logrotate/Makefile.am
@@ -1,5 +1,7 @@
 #
-# Copyright (C) 2014 Gao,Yan <ygao@suse.com>
+# Copyright 2014 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/extra/resources/HealthCPU
+++ b/extra/resources/HealthCPU
@@ -3,11 +3,9 @@
 # HealthCPU OCF RA
 # Measures CPUs idling and writes #health-cpu status into the CIB
 #
-# Originally based on ocf:pacemaker:Dummy RA
-# Copyright 2004-2009 SUSE LINUX AG, Lars Marowsky-Brée. All Rights Reserved.
+# Copyright 2004-2018 the Pacemaker project contributors
 #
-# Later changes copyright 2009-2018 Michael Schwartzkopff
-# in collaboration with the Bull company. Merci! All Rights Reserved.
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # (GPLv2) WITHOUT ANY WARRANTY.

--- a/extra/resources/HealthIOWait
+++ b/extra/resources/HealthIOWait
@@ -3,13 +3,9 @@
 # IOWait RA
 # Measures CPU iowait % via top and writes #health-iowait status into the CIB
 #
-# Originally based on ocf:pacemaker:HealthCPU RA
-# Copyright 2004-2009 SUSE LINUX AG, Lars Marowsky-Brée. All Rights Reserved.
+# Copyright 2004-2018 the Pacemaker project contributors
 #
-# Later changes copyright 2009-2018 Michael Schwartzkopff
-# in collaboration with the Bull company. Merci! All Rights Reserved.
-#
-# Later changes copyright 2018 Maciej Sobkowiak <asm@egnyte.com>
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # (GPLv2) WITHOUT ANY WARRANTY.

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -4,9 +4,9 @@
 # HealthSMART OCF RA. Checks the S.M.A.R.T. status of all given
 # drives and writes the #health-smart status into the CIB
 #
-# Copyright (c) 2009 Michael Schwartzkopff, 2010 Matthew Richardson
+# Copyright 2009-2018 the Pacemaker project contributors
 #
-#                    All Rights Reserved.
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of version 2 of the GNU General Public License as

--- a/extra/resources/Makefile.am
+++ b/extra/resources/Makefile.am
@@ -1,7 +1,9 @@
 # Makefile.am for OCF RAs
 #
 # Author: Andrew Beekhof
-# Copyright (C) 2008 Andrew Beekhof
+# Copyright 2008-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
 # Example of a stateful OCF Resource Agent
-# Copyright 2006-2018 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2006-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/extra/resources/SystemHealth
+++ b/extra/resources/SystemHealth
@@ -2,8 +2,9 @@
 #
 #	SystemHealth OCF RA.
 #
-# Copyright 2009-2018 International Business Machines (IBM), Mark Hamzy
-#                    All Rights Reserved.
+# Copyright 2009-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of version 2 of the GNU General Public License as

--- a/extra/resources/attribute
+++ b/extra/resources/attribute
@@ -2,7 +2,9 @@
 #
 # ocf:pacemaker:attribute resource agent
 #
-# Copyright 2016-2018 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2016-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under GNU General Public License version 2 or
 # later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/extra/resources/controld
+++ b/extra/resources/controld
@@ -2,7 +2,9 @@
 #
 # OCF resource agent for managing the DLM controld process
 #
-# Copyright 2009-2018 Novell, Inc
+# Copyright 2008-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #                    All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/extra/resources/ifspeed.in
+++ b/extra/resources/ifspeed.in
@@ -4,7 +4,9 @@
 # as a node attribute in the CIB based on the sum of speeds of its active (up,
 # link detected, not blocked) underlying interfaces.
 #
-# Copyright 2011-2018 Vladislav Bogdanov <bubble@hoster-ok.com>
+# Copyright 2011-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 # Partially based on 'ping' RA by Andrew Beekhof
 #
 # Change on 2017 by Tomer Azran <tomerazran@gmail.com>:

--- a/extra/resources/o2cb.in
+++ b/extra/resources/o2cb.in
@@ -1,7 +1,9 @@
 #!@BASH_PATH@
-# Copyright (c) 2005,2008 Oracle 
-# Copyright (c) 2008 Andrew Beekhof
-#                    All Rights Reserved.
+#
+# Original copyright 2005-2008 Oracle
+# Later changes copyright 2008-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of version 2 of the GNU General Public License as

--- a/extra/resources/ping
+++ b/extra/resources/ping
@@ -2,7 +2,9 @@
 #
 # Ping OCF RA that utilizes the system ping 
 #
-# Copyright 2009-2018 Andrew Beekhof <andrew@beekhof.net>
+# Copyright 2009-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/extra/resources/pingd
+++ b/extra/resources/pingd
@@ -5,7 +5,9 @@
 #	Records (in the CIB) the current number of ping nodes a 
 #	   cluster node can connect to.
 #
-# Copyright (c) 2006 Andrew Beekhof
+# Copyright 2006-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #                    All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/extra/resources/remote
+++ b/extra/resources/remote
@@ -8,7 +8,9 @@
 # functionality behind the remote connection lives within Pacemaker's
 # controller daemon.
 #
-# Copyright 2013-2018 David Vossel <davidvossel@gmail.com>
+# Copyright 2013-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # (GPLv2) WITHOUT ANY WARRANTY.

--- a/extra/showscores.sh
+++ b/extra/showscores.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
-# Copyright (C) 2008-2010 Dominik Klein
+# Copyright 2008-2017 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/maint/Makefile.am
+++ b/maint/Makefile.am
@@ -1,5 +1,7 @@
 #
-# Copyright 2019 Red Hat Inc.
+# Copyright 2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.

--- a/maint/bumplibs.sh
+++ b/maint/bumplibs.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+#
+# Copyright 2012-2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+#
 
 declare -A headers
 headers[crmcommon]="include/crm/common include/crm/crm.h"

--- a/maint/testcc.cc
+++ b/maint/testcc.cc
@@ -1,5 +1,7 @@
 /*
- * Copyright 2019 Red Hat, Inc.
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.

--- a/maint/travisci_build_coverity_scan.sh
+++ b/maint/travisci_build_coverity_scan.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
+#
+# Copyright 2014-2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+#
 
 set -e
 

--- a/scratch.c
+++ b/scratch.c
@@ -1,5 +1,7 @@
 /* 
- * Copyright (C) 2004 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2013 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -1,5 +1,7 @@
 #
-# Copyright (C) 2004 Andrew Beekhof
+# Copyright 2004-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Update copyright notices on everything except daemons/, include/, lib/, and
tools/ to conform to the new notice policy. (Updates are being made in stages
to help reduce the chance of merge conflicts.)