### PR TITLE
Maint: pacemaker.service: cleanup/commentary on TimeoutStopSec directive

### DIFF
--- a/daemons/execd/pacemaker_remote.service.in
+++ b/daemons/execd/pacemaker_remote.service.in
@@ -33,8 +33,11 @@ ExecStart=@sbindir@/pacemaker-remoted
 # get rid of the resulting log warnings, comment out this option.
 TasksMax=infinity
 
-# Pacemaker Remote can exit only after all managed services have shut down;
-# an HA database could conceivably take even longer than this 
+# If connected to the cluster and when the service functions properly, it will
+# wait to exit until the cluster notifies it all resources on the remote node
+# have been stopped.  The default of 30min should cover most typical cluster
+# configurations, but it may need an increase to adapt to local conditions
+# (e.g. a large, clustered database could conceivably take longer to stop).
 TimeoutStopSec=30min
 TimeoutStartSec=30s
 

--- a/daemons/pacemakerd/pacemaker.service.in
+++ b/daemons/pacemakerd/pacemaker.service.in
@@ -73,12 +73,11 @@ SendSIGKILL=no
 #
 # ExecStopPost=/bin/sh -c 'pidof pacemaker-controld || killall -TERM corosync'
 
-# Uncomment this for older versions of systemd that didn't support
-# TimeoutStopSec
-# TimeoutSec=30min
-
-# Pacemaker can only exit after all managed services have shut down
-# A HA database could conceivably take even longer than this 
+# When the service functions properly, it will wait to exit until all resources
+# have been stopped on the local node, and potentially across all nodes that
+# are shutting down.  The default of 30min should cover most typical cluster
+# configurations, but it may need an increase to adapt to local conditions
+# (e.g. a large, clustered database could conceivably take longer to stop).
 TimeoutStopSec=30min
 TimeoutStartSec=60s
 


### PR DESCRIPTION
Also unify the pacemaker_remote.service counterpart.