### PR TITLE
[1.1] make fully buildable again

### DIFF
--- a/tools/regression.sh
+++ b/tools/regression.sh
@@ -784,7 +784,7 @@ for t in $tests; do
         -e 's/constraints\.:([0-9][0-9]*)/constraints.:NNN/' \
         -e 's/(validation \([0-9][0-9]* of )[0-9][0-9]*(\).*)/\1X\2/' \
         -e 's/^Migration will take effect until: .*/Migration will take effect until:/' \
-        -e 's/ end=\"[-: 0123456789]+Z?\"/ end=\"\"/' \
+        -e 's/ end=\"[0-9][-+: 0-9]*Z*\"/ end=\"\"/' \
 	$test_home/regression.$t.out
 
     if [ $do_save = 1 ]; then


### PR DESCRIPTION
Previously, the cts-cli would only work with a zero-offset time zone
(suggesting that it was only run in the CI that may be expected to
have it like that).  Also drop the atypical enumeration of all digits
vs. range capture.

Backport-from-master-of: bfa3ddc527b8bfafe60b44185c1aa44abbdb5b7c