### PR TITLE
Build: include: install crm/pengine/pe_types.h

### DIFF
--- a/include/crm/pengine/Makefile.am
+++ b/include/crm/pengine/Makefile.am
@@ -22,4 +22,4 @@ MAINTAINERCLEANFILES    = Makefile.in
 headerdir=$(pkgincludedir)/crm/pengine
 
 noinst_HEADERS		= internal.h rules_internal.h
-header_HEADERS		= common.h complex.h remote.h rules.h status.h
+header_HEADERS		= common.h complex.h pe_types.h remote.h rules.h status.h


### PR DESCRIPTION
It should've been done in b368355.

For instance sbd is encountering:

```
In file included from sbd-pacemaker.c:57:0:
/usr/include/pacemaker/crm/pengine/status.h:28:12: fatal error: crm/pengine/pe_types.h: No such file or directory
 #  include <crm/pengine/pe_types.h> // pe_node_t, pe_resource_t, etc.
            ^~~~~~~~~~~~~~~~~~~~~~~~
```