### PR TITLE
Refactor: libcrmcommon: Add crm_now_string.

### DIFF
--- a/include/crm/common/iso8601_internal.h
+++ b/include/crm/common/iso8601_internal.h
@@ -33,6 +33,7 @@ crm_time_hr_t *crm_time_timeval_hr_convert(crm_time_hr_t *target,
 crm_time_hr_t *crm_time_hr_new(const char *date_time);
 void crm_time_hr_free(crm_time_hr_t * hr_dt);
 char *crm_time_format_hr(const char *format, crm_time_hr_t * hr_dt);
+const char *crm_now_string(void);
 
 crm_time_t *parse_date(const char *date_str); /* in iso8601.c global but
                                                  not in header */

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -29,6 +29,7 @@
 #include <crm/crm.h>
 #include <crm/cib/internal.h>
 #include <crm/msg_xml.h>
+#include <crm/common/iso8601_internal.h>
 #include <crm/common/xml.h>
 #include <crm/pengine/rules.h>
 
@@ -442,12 +443,9 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
      */
 
     if (*config_changed && is_not_set(call_options, cib_no_mtime)) {
-        char *now_str = NULL;
-        time_t now = time(NULL);
+        const char *now_str = crm_now_string();
         const char *schema = crm_element_value(scratch, XML_ATTR_VALIDATION);
 
-        now_str = ctime(&now);
-        now_str[24] = EOS;      /* replace the newline */
         crm_xml_replace(scratch, XML_CIB_ATTR_WRITTEN, now_str);
 
         if (schema) {

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1433,3 +1433,25 @@ crm_time_format_hr(const char *format, crm_time_hr_t * hr_dt)
 
     return (date_len == 0)?NULL:strdup(date_s);
 }
+
+/*!
+ * \internal
+ * \brief Return human-friendly string representing current time
+ *
+ * \return Current time as string (as by ctime() but without newline) on success
+ *         or "Could not determine current time" on error
+ * \note The return value points to a statically allocated string which might be
+ *       overwritten by subsequent calls to any of the C library date and time functions.
+ */
+const char *
+crm_now_string(void)
+{
+    time_t a_time = time(NULL);
+    char *since_epoch = ctime(&a_time);
+
+    if ((a_time == (time_t) -1) || (since_epoch == NULL)) {
+        return "Could not determine current time";
+    }
+    since_epoch[strlen(since_epoch) - 1] = EOS; /* trim newline */
+    return (since_epoch);
+}

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -22,6 +22,7 @@
 
 #include <crm/crm.h>
 #include <crm/msg_xml.h>
+#include <crm/common/iso8601_internal.h>
 #include <crm/common/xml.h>
 #include <crm/common/xml_internal.h>  /* CRM_XML_LOG_BASE */
 #include "crmcommon_private.h"
@@ -2309,10 +2310,7 @@ filename2xml(const char *filename)
 const char *
 crm_xml_add_last_written(xmlNode *xml_node)
 {
-    time_t now = time(NULL);
-    char *now_str = ctime(&now);
-
-    now_str[24] = EOS; /* replace the newline */
+    const char *now_str = crm_now_string();
     return crm_xml_add(xml_node, XML_CIB_ATTR_WRITTEN, now_str);
 }
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -30,6 +30,7 @@
 #include <crm/lrmd.h>
 #include <crm/common/internal.h>  /* crm_ends_with_ext */
 #include <crm/common/ipc.h>
+#include <crm/common/iso8601_internal.h>
 #include <crm/common/mainloop.h>
 #include <crm/common/util.h>
 #include <crm/common/xml.h>
@@ -2343,27 +2344,6 @@ get_resource_display_options(void)
     return print_opts;
 }
 
-/*!
- * \internal
- * \brief Return human-friendly string representing current time
- *
- * \return Current time as string (as by ctime() but without newline) on success
- *         or "Could not determine current time" on error
- * \note The return value points to a statically allocated string which might be
- *       overwritten by subsequent calls to any of the C library date and time functions.
- */
-static const char *
-crm_now_string(void)
-{
-    time_t a_time = time(NULL);
-    char *since_epoch = ctime(&a_time);
-
-    if ((a_time == (time_t) -1) || (since_epoch == NULL)) {
-        return "Could not determine current time";
-    }
-    since_epoch[strlen(since_epoch) - 1] = EOS; /* trim newline */
-    return (since_epoch);
-}
 
 /*!
  * \internal


### PR DESCRIPTION
This code is defined in a couple different places, so it might as well
get moved into one single public spot in libcrmcommon.  Plus, it's less
stuff in crm_mon to deal with later.