### PR TITLE
Backport recent fixes from master branch

### DIFF
--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -399,6 +399,32 @@ static int cmp_member_list_nodeid(const void *first,
     return 0;
 }
 
+static const char *
+cpgreason2str(cpg_reason_t reason)
+{
+    switch (reason) {
+        case CPG_REASON_JOIN:       return " via cpg_join";
+        case CPG_REASON_LEAVE:      return " via cpg_leave";
+        case CPG_REASON_NODEDOWN:   return " via cluster exit";
+        case CPG_REASON_NODEUP:     return " via cluster join";
+        case CPG_REASON_PROCDOWN:   return " for unknown reason";
+        default:                    break;
+    }
+    return "";
+}
+
+static inline const char *
+peer_name(crm_node_t *peer)
+{
+    if (peer == NULL) {
+        return "unknown node";
+    } else if (peer->uname == NULL) {
+        return "peer node";
+    } else {
+        return peer->uname;
+    }
+}
+
 void
 pcmk_cpg_membership(cpg_handle_t handle,
                     const struct cpg_name *groupName,
@@ -410,7 +436,7 @@ pcmk_cpg_membership(cpg_handle_t handle,
     gboolean found = FALSE;
     static int counter = 0;
     uint32_t local_nodeid = get_local_nodeid(handle);
-    const struct cpg_address *key, **rival, **sorted;
+    const struct cpg_address *key, **sorted;
 
     sorted = malloc(member_list_entries * sizeof(const struct cpg_address *));
     CRM_ASSERT(sorted != NULL);
@@ -424,11 +450,7 @@ pcmk_cpg_membership(cpg_handle_t handle,
 
     for (i = 0; i < left_list_entries; i++) {
         crm_node_t *peer = crm_find_peer(left_list[i].nodeid, NULL);
-
-        crm_info("Node %u left group %s (peer=%s:%llu, counter=%d.%d)",
-                 left_list[i].nodeid, groupName->value,
-                 (peer? peer->uname : "<none>"),
-                 (unsigned long long) left_list[i].pid, counter, i);
+        const struct cpg_address **rival = NULL;
 
         /* in CPG world, NODE:PROCESS-IN-MEMBERSHIP-OF-G is an 1:N relation
            and not playing by this rule may go wild in case of multiple
@@ -442,7 +464,7 @@ pcmk_cpg_membership(cpg_handle_t handle,
            also API end-point carriers, and that's what matters locally
            (who's the winner);
            remotely, we will just compare leave_list and member_list and if
-           the left process has it's node retained in member_list (under some
+           the left process has its node retained in member_list (under some
            other PID, anyway) we will just ignore it as well
            XXX: long-term fix is to establish in-out PID-aware tracking? */
         if (peer) {
@@ -450,51 +472,51 @@ pcmk_cpg_membership(cpg_handle_t handle,
             rival = bsearch(&key, sorted, member_list_entries,
                             sizeof(const struct cpg_address *),
                             cmp_member_list_nodeid);
-            if (rival == NULL) {
+        }
+
+        if (rival == NULL) {
+            crm_info("Group %s event %d: %s (node %u pid %u) left%s",
+                     groupName->value, counter, peer_name(peer),
+                     left_list[i].nodeid, left_list[i].pid,
+                     cpgreason2str(left_list[i].reason));
+            if (peer) {
                 crm_update_peer_proc(__FUNCTION__, peer, crm_proc_cpg,
                                      OFFLINESTATUS);
-            } else if (left_list[i].nodeid == local_nodeid) {
-                crm_info("Ignoring the above event %s.%d, comes from a local"
-                         " rival process (presumably not us): %llu",
-                         groupName->value, counter,
-                         (unsigned long long) left_list[i].pid);
-            } else {
-                crm_info("Ignoring the above event %s.%d, comes from"
-                         " a rival-rich node: %llu (e.g. %llu process"
-                         " carries on)",
-                         groupName->value, counter,
-                         (unsigned long long) left_list[i].pid,
-                         (unsigned long long) (*rival)->pid);
             }
+        } else if (left_list[i].nodeid == local_nodeid) {
+            crm_warn("Group %s event %d: duplicate local pid %u left%s",
+                     groupName->value, counter,
+                     left_list[i].pid, cpgreason2str(left_list[i].reason));
+        } else {
+            crm_warn("Group %s event %d: "
+                     "%s (node %u) duplicate pid %u left%s (%u remains)",
+                     groupName->value, counter, peer_name(peer),
+                     left_list[i].nodeid, left_list[i].pid,
+                     cpgreason2str(left_list[i].reason), (*rival)->pid);
         }
     }
     free(sorted);
     sorted = NULL;
 
     for (i = 0; i < joined_list_entries; i++) {
-        crm_info("Node %u joined group %s (counter=%d.%d, pid=%llu,"
-                 " unchecked for rivals)",
-                 joined_list[i].nodeid, groupName->value, counter, i,
-                 (unsigned long long) left_list[i].pid);
+        crm_info("Group %s event %d: node %u pid %u joined%s",
+                 groupName->value, counter, joined_list[i].nodeid,
+                 joined_list[i].pid, cpgreason2str(joined_list[i].reason));
     }
 
     for (i = 0; i < member_list_entries; i++) {
         crm_node_t *peer = crm_get_peer(member_list[i].nodeid, NULL);
 
-        crm_info("Node %u still member of group %s (peer=%s:%llu,"
-                 " counter=%d.%d, at least once)",
-                 member_list[i].nodeid, groupName->value,
-                 (peer? peer->uname : "<none>"), member_list[i].pid,
-                 counter, i);
-
         if (member_list[i].nodeid == local_nodeid
                 && member_list[i].pid != getpid()) {
             /* see the note above */
-            crm_info("Ignoring the above event %s.%d, comes from a local rival"
-                     " process: %llu", groupName->value, counter,
-                     (unsigned long long) member_list[i].pid);
+            crm_warn("Group %s event %d: detected duplicate local pid %u",
+                     groupName->value, counter, member_list[i].pid);
             continue;
         }
+        crm_info("Group %s event %d: %s (node %u pid %u) is member",
+                 groupName->value, counter, peer_name(peer),
+                 member_list[i].nodeid, member_list[i].pid);
 
         /* Anyone that is sending us CPG messages must also be a _CPG_ member.
          * But it's _not_ safe to assume it's in the quorum membership.
@@ -514,9 +536,8 @@ pcmk_cpg_membership(cpg_handle_t handle,
                  *
                  * Set the threshold to 1 minute
                  */
-                crm_err("Node %s[%u] appears to be online even though we think"
-                        " it is dead (unchecked for rivals)",
-                        peer->uname, peer->id);
+                crm_warn("Node %u is member of group %s but was believed offline",
+                         member_list[i].nodeid, groupName->value);
                 if (crm_update_peer_state(__FUNCTION__, peer, CRM_NODE_MEMBER, 0)) {
                     peer->votes = 0;
                 }
@@ -529,7 +550,7 @@ pcmk_cpg_membership(cpg_handle_t handle,
     }
 
     if (!found) {
-        crm_err("We're not part of CPG group '%s' anymore!", groupName->value);
+        crm_err("Local node was evicted from group %s", groupName->value);
         cpg_evicted = TRUE;
     }
 

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -91,15 +91,13 @@ uint32_t get_local_nodeid(cpg_handle_t handle)
         crm_trace("Creating connection");
         cs_repeat(retries, 5, rc = cpg_initialize(&local_handle, &cb));
         if (rc != CS_OK) {
-            crm_err("Could not connect to the CPG API: %s (%d)",
-                    cs_strerror(rc), rc);
+            crm_err("Could not connect to the CPG API (rc=%d)", rc);
             return 0;
         }
 
         rc = cpg_fd_get(local_handle, &fd);
         if (rc != CS_OK) {
-            crm_err("Could not obtain the CPG API connection: %s (%d)",
-                    cs_strerror(rc), rc);
+            crm_err("Could not obtain the CPG API connection (rc=%d)", rc);
             goto bail;
         }
 
@@ -594,15 +592,13 @@ cluster_connect_cpg(crm_cluster_t *cluster)
 
     cs_repeat(retries, 30, rc = cpg_initialize(&handle, &cpg_callbacks));
     if (rc != CS_OK) {
-        crm_err("Could not connect to the CPG API: %s (%d)",
-                cs_strerror(rc), rc);
+        crm_err("Could not connect to the CPG API (rc=%d)", rc);
         goto bail;
     }
 
     rc = cpg_fd_get(handle, &fd);
     if (rc != CS_OK) {
-        crm_err("Could not obtain the CPG API connection: %s (%d)",
-                cs_strerror(rc), rc);
+        crm_err("Could not obtain the CPG API connection (rc=%d)", rc);
         goto bail;
     }
 

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -150,17 +150,31 @@ crm_parse_ll(const char *text, const char *default_text)
  * \param[in] text          The string to parse
  * \param[in] default_text  Default string to parse if text is NULL
  *
- * \return Parsed value on success, -1 (and set errno) on error
+ * \return Parsed value on success, INT_MIN or INT_MAX (and set errno to ERANGE)
+ *         if parsed value is out of integer range, otherwise -1 (and set errno)
  */
 int
 crm_parse_int(const char *text, const char *default_text)
 {
     long long result = crm_parse_ll(text, default_text);
 
-    if ((result < INT_MIN) || (result > INT_MAX)) {
-        errno = ERANGE;
-        return -1;
+    if (result < INT_MIN) {
+        // If errno is ERANGE, crm_parse_ll() has already logged a message
+        if (errno != ERANGE) {
+            crm_err("Conversion of %s was clipped: %lld", text, result);
+            errno = ERANGE;
+        }
+        return INT_MIN;
+
+    } else if (result > INT_MAX) {
+        // If errno is ERANGE, crm_parse_ll() has already logged a message
+        if (errno != ERANGE) {
+            crm_err("Conversion of %s was clipped: %lld", text, result);
+            errno = ERANGE;
+        }
+        return INT_MAX;
     }
+
     return (int) result;
 }
 

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -688,7 +688,7 @@ services_os_action_execute(svc_action_t * op)
     int stdin_fd[2] = {-1, -1};
     int rc;
     struct stat st;
-    sigset_t *pmask;
+    sigset_t *pmask = NULL;
 
 #ifdef HAVE_SYS_SIGNALFD_H
     sigset_t mask;

--- a/lrmd/ipc_proxy.c
+++ b/lrmd/ipc_proxy.c
@@ -1,5 +1,7 @@
 /*
- * Copyright (c) 2012 David Vossel <davidvossel@gmail.com>
+ * Copyright 2012-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -62,6 +64,17 @@ ipc_proxy_get_provider()
     return ipc_providers? (crm_client_t*) (ipc_providers->data) : NULL;
 }
 
+/*!
+ * \internal
+ * \brief Accept a client connection on a proxy IPC server
+ *
+ * \param[in] c            Client's IPC connection
+ * \param[in] uid          Client's user ID
+ * \param[in] gid          Client's group ID
+ * \param[in] ipc_channel  Name of IPC server to proxy
+ *
+ * \return pcmk_ok on success, -errno on error
+ */
 static int32_t
 ipc_proxy_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid, const char *ipc_channel)
 {
@@ -69,15 +82,15 @@ ipc_proxy_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid, const char *ipc
     crm_client_t *ipc_proxy = ipc_proxy_get_provider();
     xmlNode *msg;
 
-    crm_trace("Connection %p on channel %s", c, ipc_channel);
-
     if (ipc_proxy == NULL) {
-        crm_err("No ipc providers available for uid %d gid %d", uid, gid);
+        crm_warn("Cannot proxy request from uid %d gid %d "
+                 "because not connected to cluster", uid, gid);
         return -EREMOTEIO;
     }
 
-    /* this new client is a local ipc client on a remote
-     * guest wanting to access the ipc on any available cluster nodes */
+    /* This new client is a local IPC client on a Pacemaker Remote controlled
+     * node, needing to access cluster node IPC services.
+     */
     client = crm_client_new(c, uid, gid);
     if (client == NULL) {
         return -EREMOTEIO;
@@ -96,7 +109,9 @@ ipc_proxy_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid, const char *ipc
     crm_xml_add(msg, F_LRMD_IPC_SESSION, client->id);
     lrmd_server_send_notify(ipc_proxy, msg);
     free_xml(msg);
-    crm_debug("created new ipc proxy with session id %s", client->id);
+    crm_debug("Accepted IPC proxy connection (session ID %s) "
+              "from uid %d gid %d on channel %s",
+              client->id, uid, gid, ipc_channel);
     return 0;
 }
 

--- a/lrmd/lrmd.c
+++ b/lrmd/lrmd.c
@@ -1,5 +1,7 @@
 /*
- * Copyright (c) 2012 David Vossel <davidvossel@gmail.com>
+ * Copyright 2012-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -919,8 +921,15 @@ action_complete(svc_action_t * action)
                 cmd_original_times(cmd);
 #endif
 
-                if(cmd->lrmd_op_status == PCMK_LRM_OP_DONE && cmd->exec_rc == PCMK_OCF_NOT_RUNNING && safe_str_eq(cmd->real_action, "stop")) {
-                    cmd->exec_rc = PCMK_OCF_OK;
+                // Monitors may return "not running", but start/stop shouldn't
+                if ((cmd->lrmd_op_status == PCMK_LRM_OP_DONE)
+                    && (cmd->exec_rc == PCMK_OCF_NOT_RUNNING)) {
+
+                    if (safe_str_eq(cmd->real_action, "start")) {
+                        cmd->exec_rc = PCMK_OCF_UNKNOWN_ERROR;
+                    } else if (safe_str_eq(cmd->real_action, "stop")) {
+                        cmd->exec_rc = PCMK_OCF_OK;
+                    }
                 }
             }
         }

--- a/mcp/corosync.c
+++ b/mcp/corosync.c
@@ -118,13 +118,13 @@ cluster_connect_cfg(uint32_t * nodeid)
     cs_repeat(retries, 30, rc = corosync_cfg_initialize(&cfg_handle, &cfg_callbacks));
 
     if (rc != CS_OK) {
-        crm_err("corosync cfg init: %s (%d)", cs_strerror(rc), rc);
+        crm_err("corosync cfg init error %d", rc);
         return FALSE;
     }
 
     rc = corosync_cfg_fd_get(cfg_handle, &fd);
     if (rc != CS_OK) {
-        crm_err("corosync cfg fd_get: %s (%d)", cs_strerror(rc), rc);
+        crm_err("corosync cfg fd_get error %d", rc);
         goto bail;
     }
 
@@ -314,8 +314,8 @@ mcp_read_config(void)
         rc = cmap_initialize(&local_handle);
         if (rc != CS_OK) {
             retries++;
-            printf("cmap connection setup failed: %s.  Retrying in %ds\n", cs_strerror(rc), retries);
-            crm_info("cmap connection setup failed: %s.  Retrying in %ds", cs_strerror(rc), retries);
+            printf("cmap connection setup failed: error %d.  Retrying in %ds\n", rc, retries);
+            crm_info("cmap connection setup failed: error %d.  Retrying in %ds", rc, retries);
             sleep(retries);
 
         } else {
@@ -331,10 +331,10 @@ mcp_read_config(void)
         return FALSE;
     }
 
+#if HAVE_CMAP
     rc = cmap_fd_get(local_handle, &fd);
     if (rc != CS_OK) {
-        crm_err("Could not obtain the CMAP API connection: %s (%d)",
-                cs_strerror(rc), rc);
+        crm_err("Could not obtain the CMAP API connection: error %d", rc);
         cmap_finalize(local_handle);
         return FALSE;
     }
@@ -354,6 +354,7 @@ mcp_read_config(void)
         cmap_finalize(local_handle);
         return FALSE;
     }
+#endif
 
     stack = get_cluster_type();
     crm_info("Reading configure for stack: %s", name_for_cluster_type(stack));

--- a/pengine/constraints.c
+++ b/pengine/constraints.c
@@ -241,6 +241,46 @@ valid_resource_or_tag(pe_working_set_t * data_set, const char * id,
 }
 
 static gboolean
+order_is_symmetrical(xmlNode * xml_obj,
+                     enum pe_order_kind parent_kind, const char * parent_symmetrical_s)
+{
+    const char *id = crm_element_value(xml_obj, XML_ATTR_ID);
+    const char *kind_s = crm_element_value(xml_obj, XML_ORDER_ATTR_KIND);
+    const char *score_s = crm_element_value(xml_obj, XML_RULE_ATTR_SCORE);
+    const char *symmetrical_s = crm_element_value(xml_obj, XML_CONS_ATTR_SYMMETRICAL);
+    enum pe_order_kind kind = parent_kind;
+
+    if (kind_s || score_s) {
+        kind = get_ordering_type(xml_obj);
+    }
+
+    if (symmetrical_s == NULL) {
+        symmetrical_s = parent_symmetrical_s;
+    }
+
+    if (symmetrical_s) {
+        gboolean symmetrical = crm_is_true(symmetrical_s);
+
+        if (symmetrical && kind == pe_order_kind_serialize) {
+            crm_config_warn("Cannot invert serialized order %s."
+                            " Ignoring symmetrical=\"%s\"",
+                            id, symmetrical_s);
+            return FALSE;
+        }
+
+        return symmetrical;
+
+    } else {
+        if (kind == pe_order_kind_serialize) {
+            return FALSE;
+
+        } else {
+            return TRUE;
+        }
+    }
+}
+
+static gboolean
 unpack_simple_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
 {
     int order_id = 0;
@@ -260,7 +300,6 @@ unpack_simple_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
     const char *require_all_s = NULL;
 
     const char *id = NULL;
-    const char *invert = NULL;
 
     if (xml_obj == NULL) {
         crm_config_err("No constraint object to process.");
@@ -273,8 +312,7 @@ unpack_simple_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
         return FALSE;
     }
 
-    invert = crm_element_value(xml_obj, XML_CONS_ATTR_SYMMETRICAL);
-    crm_str_to_boolean(invert, &invert_bool);
+    invert_bool = order_is_symmetrical(xml_obj, kind, NULL);
 
     id_then = crm_element_value(xml_obj, XML_ORDER_ATTR_THEN);
     id_first = crm_element_value(xml_obj, XML_ORDER_ATTR_FIRST);
@@ -406,13 +444,6 @@ unpack_simple_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
                  order_id, id, rsc_first->id, action_first, rsc_then->id, action_then, cons_weight);
 
     if (invert_bool == FALSE) {
-        return TRUE;
-
-    } else if (invert && kind == pe_order_kind_serialize) {
-        crm_config_warn("Cannot invert serialized constraint set %s", id);
-        return TRUE;
-
-    } else if (kind == pe_order_kind_serialize) {
         return TRUE;
     }
 
@@ -1549,9 +1580,9 @@ get_flags(const char *id, enum pe_order_kind kind,
 }
 
 static gboolean
-unpack_order_set(xmlNode * set, enum pe_order_kind kind, resource_t ** rsc,
+unpack_order_set(xmlNode * set, enum pe_order_kind parent_kind, resource_t ** rsc,
                  action_t ** begin, action_t ** end, action_t ** inv_begin, action_t ** inv_end,
-                 const char *symmetrical, pe_working_set_t * data_set)
+                 const char *parent_symmetrical_s, pe_working_set_t * data_set)
 {
     xmlNode *xml_rsc = NULL;
     GListPtr set_iter = NULL;
@@ -1560,9 +1591,10 @@ unpack_order_set(xmlNode * set, enum pe_order_kind kind, resource_t ** rsc,
     resource_t *last = NULL;
     resource_t *resource = NULL;
 
-    int local_kind = kind;
+    int local_kind = parent_kind;
     gboolean sequential = FALSE;
     enum pe_ordering flags = pe_order_optional;
+    gboolean symmetrical = TRUE;
 
     char *key = NULL;
     const char *id = ID(set);
@@ -1588,7 +1620,9 @@ unpack_order_set(xmlNode * set, enum pe_order_kind kind, resource_t ** rsc,
     }
 
     sequential = crm_is_true(sequential_s);
-    if (crm_is_true(symmetrical)) {
+
+    symmetrical = order_is_symmetrical(set, parent_kind, parent_symmetrical_s);
+    if (symmetrical) {
         flags = get_flags(id, local_kind, action, action, FALSE);
     } else {
         flags = get_asymmetrical_flags(local_kind);
@@ -1664,14 +1698,7 @@ unpack_order_set(xmlNode * set, enum pe_order_kind kind, resource_t ** rsc,
         free(key);
     }
 
-    if (crm_is_true(symmetrical) == FALSE) {
-        goto done;
-
-    } else if (symmetrical && local_kind == pe_order_kind_serialize) {
-        crm_config_warn("Cannot invert serialized constraint set %s", id);
-        goto done;
-
-    } else if (local_kind == pe_order_kind_serialize) {
+    if (symmetrical == FALSE) {
         goto done;
     }
 
@@ -2039,14 +2066,8 @@ unpack_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
     const char *invert = crm_element_value(xml_obj, XML_CONS_ATTR_SYMMETRICAL);
     enum pe_order_kind kind = get_ordering_type(xml_obj);
 
-    gboolean invert_bool = TRUE;
+    gboolean invert_bool = order_is_symmetrical(xml_obj, kind, NULL);
     gboolean rc = TRUE;
-
-    if (invert == NULL) {
-        invert = "true";
-    }
-
-    invert_bool = crm_is_true(invert);
 
     rc = unpack_order_tags(xml_obj, &expanded_xml, data_set);
     if (expanded_xml) {


### PR DESCRIPTION
Most importantly, correct a typo in a previous backport that could lead to use of uninitialized or invalid memory.

The backport of the "symmetrical" change could be considered a change in defaults that is questionably backward-compatible, but the behavior is identical other than silencing a spammy log message, so it's also reasonable to consider it merely a logging change.