### PR TITLE
[WIP] Med: libcrmcommon/iso8601: fix train of thinkos regarding time offsets

### DIFF
--- a/cts/cli/regression.dates.exp
+++ b/cts/cli/regression.dates.exp
@@ -240,3 +240,11 @@ Duration: -1 month
 Duration ends at: 2009-02-28 00:00:00Z
 =#=#=#= End test: 2009-03-31 - 1 Month - OK (0) =#=#=#=
 * Passed: iso8601        - 2009-03-31 - 1 Month
+=#=#=#= Begin test: Test correct immediate plus-sign at timezone parsing =#=#=#=
+Date: 1556221374
+=#=#=#= End test: Test correct immediate plus-sign at timezone parsing - OK (0) =#=#=#=
+* Passed: iso8601        - Test correct immediate plus-sign at timezone parsing
+=#=#=#= Begin test: Like the previous, with exotic timezone to avoid false negative =#=#=#=
+Date: 1556212974
+=#=#=#= End test: Like the previous, with exotic timezone to avoid false negative - OK (0) =#=#=#=
+* Passed: iso8601        - Like the previous, with exotic timezone to avoid false negative

--- a/cts/cli/regression.dates.exp
+++ b/cts/cli/regression.dates.exp
@@ -1,243 +1,243 @@
 =#=#=#= Begin test: 2014-01-01 00:30:00 - 1 Hour =#=#=#=
-Date: 2014-01-01 00:30:00Z
+Date: 2014-01-01T00:30:00Z
 Duration: -3600 seconds ( 1 hour )
-Duration ends at: 2013-12-31 23:30:00Z
+Duration ends at: 2013-12-31T23:30:00Z
 =#=#=#= End test: 2014-01-01 00:30:00 - 1 Hour - OK (0) =#=#=#=
 * Passed: iso8601        - 2014-01-01 00:30:00 - 1 Hour
 =#=#=#= Begin test: 2006-W01-7 =#=#=#=
-Date: 2006-01-08 00:00:00Z
+Date: 2006-01-08T00:00:00Z
 =#=#=#= End test: 2006-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2006-W01-7
 =#=#=#= Begin test: 2006-W01-7 - round-trip =#=#=#=
-Date: 2006-W01-7 00:00:00Z
+Date: 2006-W01-7T00:00:00Z
 =#=#=#= End test: 2006-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2006-W01-7 - round-trip
 =#=#=#= Begin test: 2006-W01-1 =#=#=#=
-Date: 2006-01-02 00:00:00Z
+Date: 2006-01-02T00:00:00Z
 =#=#=#= End test: 2006-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2006-W01-1
 =#=#=#= Begin test: 2006-W01-1 - round-trip =#=#=#=
-Date: 2006-W01-1 00:00:00Z
+Date: 2006-W01-1T00:00:00Z
 =#=#=#= End test: 2006-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2006-W01-1 - round-trip
 =#=#=#= Begin test: 2007-W01-7 =#=#=#=
-Date: 2007-01-07 00:00:00Z
+Date: 2007-01-07T00:00:00Z
 =#=#=#= End test: 2007-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2007-W01-7
 =#=#=#= Begin test: 2007-W01-7 - round-trip =#=#=#=
-Date: 2007-W01-7 00:00:00Z
+Date: 2007-W01-7T00:00:00Z
 =#=#=#= End test: 2007-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2007-W01-7 - round-trip
 =#=#=#= Begin test: 2007-W01-1 =#=#=#=
-Date: 2007-01-01 00:00:00Z
+Date: 2007-01-01T00:00:00Z
 =#=#=#= End test: 2007-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2007-W01-1
 =#=#=#= Begin test: 2007-W01-1 - round-trip =#=#=#=
-Date: 2007-W01-1 00:00:00Z
+Date: 2007-W01-1T00:00:00Z
 =#=#=#= End test: 2007-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2007-W01-1 - round-trip
 =#=#=#= Begin test: 2008-W01-7 =#=#=#=
-Date: 2008-01-06 00:00:00Z
+Date: 2008-01-06T00:00:00Z
 =#=#=#= End test: 2008-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2008-W01-7
 =#=#=#= Begin test: 2008-W01-7 - round-trip =#=#=#=
-Date: 2008-W01-7 00:00:00Z
+Date: 2008-W01-7T00:00:00Z
 =#=#=#= End test: 2008-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2008-W01-7 - round-trip
 =#=#=#= Begin test: 2008-W01-1 =#=#=#=
-Date: 2007-12-31 00:00:00Z
+Date: 2007-12-31T00:00:00Z
 =#=#=#= End test: 2008-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2008-W01-1
 =#=#=#= Begin test: 2008-W01-1 - round-trip =#=#=#=
-Date: 2008-W01-1 00:00:00Z
+Date: 2008-W01-1T00:00:00Z
 =#=#=#= End test: 2008-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2008-W01-1 - round-trip
 =#=#=#= Begin test: 2009-W01-7 =#=#=#=
-Date: 2009-01-04 00:00:00Z
+Date: 2009-01-04T00:00:00Z
 =#=#=#= End test: 2009-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2009-W01-7
 =#=#=#= Begin test: 2009-W01-7 - round-trip =#=#=#=
-Date: 2009-W01-7 00:00:00Z
+Date: 2009-W01-7T00:00:00Z
 =#=#=#= End test: 2009-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2009-W01-7 - round-trip
 =#=#=#= Begin test: 2009-W01-1 =#=#=#=
-Date: 2008-12-29 00:00:00Z
+Date: 2008-12-29T00:00:00Z
 =#=#=#= End test: 2009-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2009-W01-1
 =#=#=#= Begin test: 2009-W01-1 - round-trip =#=#=#=
-Date: 2009-W01-1 00:00:00Z
+Date: 2009-W01-1T00:00:00Z
 =#=#=#= End test: 2009-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2009-W01-1 - round-trip
 =#=#=#= Begin test: 2010-W01-7 =#=#=#=
-Date: 2010-01-10 00:00:00Z
+Date: 2010-01-10T00:00:00Z
 =#=#=#= End test: 2010-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2010-W01-7
 =#=#=#= Begin test: 2010-W01-7 - round-trip =#=#=#=
-Date: 2010-W01-7 00:00:00Z
+Date: 2010-W01-7T00:00:00Z
 =#=#=#= End test: 2010-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2010-W01-7 - round-trip
 =#=#=#= Begin test: 2010-W01-1 =#=#=#=
-Date: 2010-01-04 00:00:00Z
+Date: 2010-01-04T00:00:00Z
 =#=#=#= End test: 2010-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2010-W01-1
 =#=#=#= Begin test: 2010-W01-1 - round-trip =#=#=#=
-Date: 2010-W01-1 00:00:00Z
+Date: 2010-W01-1T00:00:00Z
 =#=#=#= End test: 2010-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2010-W01-1 - round-trip
 =#=#=#= Begin test: 2011-W01-7 =#=#=#=
-Date: 2011-01-09 00:00:00Z
+Date: 2011-01-09T00:00:00Z
 =#=#=#= End test: 2011-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2011-W01-7
 =#=#=#= Begin test: 2011-W01-7 - round-trip =#=#=#=
-Date: 2011-W01-7 00:00:00Z
+Date: 2011-W01-7T00:00:00Z
 =#=#=#= End test: 2011-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2011-W01-7 - round-trip
 =#=#=#= Begin test: 2011-W01-1 =#=#=#=
-Date: 2011-01-03 00:00:00Z
+Date: 2011-01-03T00:00:00Z
 =#=#=#= End test: 2011-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2011-W01-1
 =#=#=#= Begin test: 2011-W01-1 - round-trip =#=#=#=
-Date: 2011-W01-1 00:00:00Z
+Date: 2011-W01-1T00:00:00Z
 =#=#=#= End test: 2011-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2011-W01-1 - round-trip
 =#=#=#= Begin test: 2012-W01-7 =#=#=#=
-Date: 2012-01-08 00:00:00Z
+Date: 2012-01-08T00:00:00Z
 =#=#=#= End test: 2012-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2012-W01-7
 =#=#=#= Begin test: 2012-W01-7 - round-trip =#=#=#=
-Date: 2012-W01-7 00:00:00Z
+Date: 2012-W01-7T00:00:00Z
 =#=#=#= End test: 2012-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2012-W01-7 - round-trip
 =#=#=#= Begin test: 2012-W01-1 =#=#=#=
-Date: 2012-01-02 00:00:00Z
+Date: 2012-01-02T00:00:00Z
 =#=#=#= End test: 2012-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2012-W01-1
 =#=#=#= Begin test: 2012-W01-1 - round-trip =#=#=#=
-Date: 2012-W01-1 00:00:00Z
+Date: 2012-W01-1T00:00:00Z
 =#=#=#= End test: 2012-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2012-W01-1 - round-trip
 =#=#=#= Begin test: 2013-W01-7 =#=#=#=
-Date: 2013-01-06 00:00:00Z
+Date: 2013-01-06T00:00:00Z
 =#=#=#= End test: 2013-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2013-W01-7
 =#=#=#= Begin test: 2013-W01-7 - round-trip =#=#=#=
-Date: 2013-W01-7 00:00:00Z
+Date: 2013-W01-7T00:00:00Z
 =#=#=#= End test: 2013-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2013-W01-7 - round-trip
 =#=#=#= Begin test: 2013-W01-1 =#=#=#=
-Date: 2012-12-31 00:00:00Z
+Date: 2012-12-31T00:00:00Z
 =#=#=#= End test: 2013-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2013-W01-1
 =#=#=#= Begin test: 2013-W01-1 - round-trip =#=#=#=
-Date: 2013-W01-1 00:00:00Z
+Date: 2013-W01-1T00:00:00Z
 =#=#=#= End test: 2013-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2013-W01-1 - round-trip
 =#=#=#= Begin test: 2014-W01-7 =#=#=#=
-Date: 2014-01-05 00:00:00Z
+Date: 2014-01-05T00:00:00Z
 =#=#=#= End test: 2014-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2014-W01-7
 =#=#=#= Begin test: 2014-W01-7 - round-trip =#=#=#=
-Date: 2014-W01-7 00:00:00Z
+Date: 2014-W01-7T00:00:00Z
 =#=#=#= End test: 2014-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2014-W01-7 - round-trip
 =#=#=#= Begin test: 2014-W01-1 =#=#=#=
-Date: 2013-12-30 00:00:00Z
+Date: 2013-12-30T00:00:00Z
 =#=#=#= End test: 2014-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2014-W01-1
 =#=#=#= Begin test: 2014-W01-1 - round-trip =#=#=#=
-Date: 2014-W01-1 00:00:00Z
+Date: 2014-W01-1T00:00:00Z
 =#=#=#= End test: 2014-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2014-W01-1 - round-trip
 =#=#=#= Begin test: 2015-W01-7 =#=#=#=
-Date: 2015-01-04 00:00:00Z
+Date: 2015-01-04T00:00:00Z
 =#=#=#= End test: 2015-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2015-W01-7
 =#=#=#= Begin test: 2015-W01-7 - round-trip =#=#=#=
-Date: 2015-W01-7 00:00:00Z
+Date: 2015-W01-7T00:00:00Z
 =#=#=#= End test: 2015-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2015-W01-7 - round-trip
 =#=#=#= Begin test: 2015-W01-1 =#=#=#=
-Date: 2014-12-29 00:00:00Z
+Date: 2014-12-29T00:00:00Z
 =#=#=#= End test: 2015-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2015-W01-1
 =#=#=#= Begin test: 2015-W01-1 - round-trip =#=#=#=
-Date: 2015-W01-1 00:00:00Z
+Date: 2015-W01-1T00:00:00Z
 =#=#=#= End test: 2015-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2015-W01-1 - round-trip
 =#=#=#= Begin test: 2016-W01-7 =#=#=#=
-Date: 2016-01-10 00:00:00Z
+Date: 2016-01-10T00:00:00Z
 =#=#=#= End test: 2016-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2016-W01-7
 =#=#=#= Begin test: 2016-W01-7 - round-trip =#=#=#=
-Date: 2016-W01-7 00:00:00Z
+Date: 2016-W01-7T00:00:00Z
 =#=#=#= End test: 2016-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2016-W01-7 - round-trip
 =#=#=#= Begin test: 2016-W01-1 =#=#=#=
-Date: 2016-01-04 00:00:00Z
+Date: 2016-01-04T00:00:00Z
 =#=#=#= End test: 2016-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2016-W01-1
 =#=#=#= Begin test: 2016-W01-1 - round-trip =#=#=#=
-Date: 2016-W01-1 00:00:00Z
+Date: 2016-W01-1T00:00:00Z
 =#=#=#= End test: 2016-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2016-W01-1 - round-trip
 =#=#=#= Begin test: 2017-W01-7 =#=#=#=
-Date: 2017-01-08 00:00:00Z
+Date: 2017-01-08T00:00:00Z
 =#=#=#= End test: 2017-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2017-W01-7
 =#=#=#= Begin test: 2017-W01-7 - round-trip =#=#=#=
-Date: 2017-W01-7 00:00:00Z
+Date: 2017-W01-7T00:00:00Z
 =#=#=#= End test: 2017-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2017-W01-7 - round-trip
 =#=#=#= Begin test: 2017-W01-1 =#=#=#=
-Date: 2017-01-02 00:00:00Z
+Date: 2017-01-02T00:00:00Z
 =#=#=#= End test: 2017-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2017-W01-1
 =#=#=#= Begin test: 2017-W01-1 - round-trip =#=#=#=
-Date: 2017-W01-1 00:00:00Z
+Date: 2017-W01-1T00:00:00Z
 =#=#=#= End test: 2017-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2017-W01-1 - round-trip
 =#=#=#= Begin test: 2018-W01-7 =#=#=#=
-Date: 2018-01-07 00:00:00Z
+Date: 2018-01-07T00:00:00Z
 =#=#=#= End test: 2018-W01-7 - OK (0) =#=#=#=
 * Passed: iso8601        - 2018-W01-7
 =#=#=#= Begin test: 2018-W01-7 - round-trip =#=#=#=
-Date: 2018-W01-7 00:00:00Z
+Date: 2018-W01-7T00:00:00Z
 =#=#=#= End test: 2018-W01-7 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2018-W01-7 - round-trip
 =#=#=#= Begin test: 2018-W01-1 =#=#=#=
-Date: 2018-01-01 00:00:00Z
+Date: 2018-01-01T00:00:00Z
 =#=#=#= End test: 2018-W01-1 - OK (0) =#=#=#=
 * Passed: iso8601        - 2018-W01-1
 =#=#=#= Begin test: 2018-W01-1 - round-trip =#=#=#=
-Date: 2018-W01-1 00:00:00Z
+Date: 2018-W01-1T00:00:00Z
 =#=#=#= End test: 2018-W01-1 - round-trip - OK (0) =#=#=#=
 * Passed: iso8601        - 2018-W01-1 - round-trip
 =#=#=#= Begin test: 2009-W53-07 =#=#=#=
-Date: 2009-W53-7 00:00:00Z
+Date: 2009-W53-7T00:00:00Z
 =#=#=#= End test: 2009-W53-07 - OK (0) =#=#=#=
 * Passed: iso8601        - 2009-W53-07
 =#=#=#= Begin test: 2009-01-31 + 1 Month =#=#=#=
-Date: 2009-01-31 00:00:00Z
+Date: 2009-01-31T00:00:00Z
 Duration:  1 month 
-Duration ends at: 2009-02-28 00:00:00Z
+Duration ends at: 2009-02-28T00:00:00Z
 =#=#=#= End test: 2009-01-31 + 1 Month - OK (0) =#=#=#=
 * Passed: iso8601        - 2009-01-31 + 1 Month
 =#=#=#= Begin test: 2009-01-31 + 2 Months =#=#=#=
-Date: 2009-01-31 00:00:00Z
+Date: 2009-01-31T00:00:00Z
 Duration:  2 months 
-Duration ends at: 2009-03-31 00:00:00Z
+Duration ends at: 2009-03-31T00:00:00Z
 =#=#=#= End test: 2009-01-31 + 2 Months - OK (0) =#=#=#=
 * Passed: iso8601        - 2009-01-31 + 2 Months
 =#=#=#= Begin test: 2009-01-31 + 3 Months =#=#=#=
-Date: 2009-01-31 00:00:00Z
+Date: 2009-01-31T00:00:00Z
 Duration:  3 months 
-Duration ends at: 2009-04-30 00:00:00Z
+Duration ends at: 2009-04-30T00:00:00Z
 =#=#=#= End test: 2009-01-31 + 3 Months - OK (0) =#=#=#=
 * Passed: iso8601        - 2009-01-31 + 3 Months
 =#=#=#= Begin test: 2009-03-31 - 1 Month =#=#=#=
-Date: 2009-03-31 00:00:00Z
+Date: 2009-03-31T00:00:00Z
 Duration: -1 month 
-Duration ends at: 2009-02-28 00:00:00Z
+Duration ends at: 2009-02-28T00:00:00Z
 =#=#=#= End test: 2009-03-31 - 1 Month - OK (0) =#=#=#=
 * Passed: iso8601        - 2009-03-31 - 1 Month
 =#=#=#= Begin test: Test correct immediate plus-sign at timezone parsing =#=#=#=

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -462,6 +462,16 @@ function test_dates() {
     desc="2009-03-31 - 1 Month"
     cmd="iso8601 -d '2009-03-31 00:00:00Z' -D P-1M -E '2009-02-28 00:00:00Z'"
     test_assert $CRM_EX_OK 0
+
+    # would be 1556302734 previously instead of expected 1556221374
+    # (see also date -d '2019-04-25T21:42:54+0200' '+%s')
+    desc="Test correct immediate plus-sign at timezone parsing"
+    cmd="iso8601 -d 2019-04-25T21:42:54+0200 -S"
+    test_assert $CRM_EX_OK 0
+
+    desc="Like the previous, with exotic timezone to avoid false negative"
+    cmd="iso8601 -d 2019-04-25T21:42:54+0420 -S"
+    test_assert $CRM_EX_OK 0
 }
 
 function test_acl_loop() {

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -422,45 +422,45 @@ function test_tools() {
 
 function test_dates() {
     desc="2014-01-01 00:30:00 - 1 Hour"
-    cmd="iso8601 -d '2014-01-01 00:30:00Z' -D P-1H -E '2013-12-31 23:30:00Z'"
+    cmd="iso8601 -d 2014-01-01T00:30:00Z -D P-1H -E 2013-12-31T23:30:00Z"
     test_assert $CRM_EX_OK 0
 
     for y in 06 07 08 09 10 11 12 13 14 15 16 17 18; do
         desc="20$y-W01-7"
-        cmd="iso8601 -d '20$y-W01-7 00Z'"
+        cmd="iso8601 -d 20$y-W01-7T00Z"
         test_assert $CRM_EX_OK 0
 
         desc="20$y-W01-7 - round-trip"
-        cmd="iso8601 -d '20$y-W01-7 00Z' -W -E '20$y-W01-7 00:00:00Z'"
+        cmd="iso8601 -d 20$y-W01-7T00Z -W -E 20$y-W01-7T00:00:00Z"
         test_assert $CRM_EX_OK 0
 
         desc="20$y-W01-1"
-        cmd="iso8601 -d '20$y-W01-1 00Z'"
+        cmd="iso8601 -d 20$y-W01-1T00Z"
         test_assert $CRM_EX_OK 0
 
         desc="20$y-W01-1 - round-trip"
-        cmd="iso8601 -d '20$y-W01-1 00Z' -W -E '20$y-W01-1 00:00:00Z'"
+        cmd="iso8601 -d 20$y-W01-1T00Z -W -E 20$y-W01-1T00:00:00Z"
         test_assert $CRM_EX_OK 0
     done
 
     desc="2009-W53-07"
-    cmd="iso8601 -d '2009-W53-7 00:00:00Z' -W -E '2009-W53-7 00:00:00Z'"
+    cmd="iso8601 -d 2009-W53-7T00:00:00Z -W -E 2009-W53-7T00:00:00Z"
     test_assert $CRM_EX_OK 0
 
     desc="2009-01-31 + 1 Month"
-    cmd="iso8601 -d '2009-01-31 00:00:00Z' -D P1M -E '2009-02-28 00:00:00Z'"
+    cmd="iso8601 -d 2009-01-31T00:00:00Z -D P1M -E 2009-02-28T00:00:00Z"
     test_assert $CRM_EX_OK 0
 
     desc="2009-01-31 + 2 Months"
-    cmd="iso8601 -d '2009-01-31 00:00:00Z' -D P2M -E '2009-03-31 00:00:00Z'"
+    cmd="iso8601 -d 2009-01-31T00:00:00Z -D P2M -E 2009-03-31T00:00:00Z"
     test_assert $CRM_EX_OK 0
 
     desc="2009-01-31 + 3 Months"
-    cmd="iso8601 -d '2009-01-31 00:00:00Z' -D P3M -E '2009-04-30 00:00:00Z'"
+    cmd="iso8601 -d 2009-01-31T00:00:00Z -D P3M -E 2009-04-30T00:00:00Z"
     test_assert $CRM_EX_OK 0
 
     desc="2009-03-31 - 1 Month"
-    cmd="iso8601 -d '2009-03-31 00:00:00Z' -D P-1M -E '2009-02-28 00:00:00Z'"
+    cmd="iso8601 -d 2009-03-31T00:00:00Z -D P-1M -E 2009-02-28T00:00:00Z"
     test_assert $CRM_EX_OK 0
 
     # would be 1556302734 previously instead of expected 1556221374
@@ -882,7 +882,7 @@ test_rules() {
     cat <<EOF > "$TMPXML"
 <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
   <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
-    <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end="2019-01-01 12:00:00 -05:00"/>
+    <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end="2019-01-01T12:00:00-05:00"/>
   </rule>
 </rsc_location>
 EOF
@@ -891,9 +891,9 @@ EOF
     rm -f "$TMPXML"
 
     if [ "$(uname)" == "FreeBSD" ]; then
-        tomorrow=$(date -v+1d +"%F %T %z")
+        tomorrow=$(date -v+1d -Iminutes)
     else
-        tomorrow=$(date --date=tomorrow +"%F %T %z")
+        tomorrow=$(date --date=tomorrow -Iminutes)
     fi
 
     TMPXML=$(mktemp ${TMPDIR:-/tmp}/cts-cli.tools.xml.XXXXXXXXXX)
@@ -1017,8 +1017,8 @@ for t in $tests; do
         -e 's/^Entity: line [0-9][0-9]*: //'\
         -e 's/\(validation ([0-9][0-9]* of \)[0-9][0-9]*\().*\)/\1X\2/' \
         -e 's/^Migration will take effect until: .*/Migration will take effect until:/' \
-        -e 's/ end=\"[0-9][-+: 0-9]*Z*\"/ end=\"\"/' \
-        -e 's/ start=\"[0-9][-+: 0-9]*Z*\"/ start=\"\"/' \
+        -e 's/ end=\"[0-9][-+:T0-9]*Z*\"/ end=\"\"/' \
+        -e 's/ start=\"[0-9][-+:T0-9]*Z*\"/ start=\"\"/' \
         -e 's/^Error checking rule: Device not configured/Error checking rule: No such device or address/' \
         "$TMPFILE" > "${TMPFILE}.$$"
     mv -- "${TMPFILE}.$$" "$TMPFILE"

--- a/cts/scheduler/anti-colocation-master.scores
+++ b/cts/scheduler/anti-colocation-master.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2016-04-29 09:06:59Z
+Using the original execution date of: 2016-04-29T09:06:59Z
 clone_color: ms1 allocation score on sle12sp2-1: 0
 clone_color: ms1 allocation score on sle12sp2-2: 0
 clone_color: state1:0 allocation score on sle12sp2-1: 0

--- a/cts/scheduler/anti-colocation-master.summary
+++ b/cts/scheduler/anti-colocation-master.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2016-04-29 09:06:59Z
+Using the original execution date of: 2016-04-29T09:06:59Z
 
 Current cluster status:
 Online: [ sle12sp2-1 sle12sp2-2 ]
@@ -23,7 +23,7 @@ Executing cluster transition:
  * Resource action: dummy1          start on sle12sp2-1
  * Resource action: state1          promote on sle12sp2-2
  * Pseudo action:   ms1_promoted_0
-Using the original execution date of: 2016-04-29 09:06:59Z
+Using the original execution date of: 2016-04-29T09:06:59Z
 
 Revised cluster status:
 Online: [ sle12sp2-1 sle12sp2-2 ]

--- a/cts/scheduler/asymmetrical-order-move.scores
+++ b/cts/scheduler/asymmetrical-order-move.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2016-04-28 11:50:29Z
+Using the original execution date of: 2016-04-28T11:50:29Z
 native_color: dummy1 allocation score on sle12sp2-1: -INFINITY
 native_color: dummy1 allocation score on sle12sp2-2: -INFINITY
 native_color: dummy2 allocation score on sle12sp2-1: -INFINITY

--- a/cts/scheduler/asymmetrical-order-move.summary
+++ b/cts/scheduler/asymmetrical-order-move.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2016-04-28 11:50:29Z
+Using the original execution date of: 2016-04-28T11:50:29Z
 1 of 3 resources DISABLED and 0 BLOCKED from being started due to failures
 
 Current cluster status:
@@ -13,7 +13,7 @@ Transition Summary:
 
 Executing cluster transition:
  * Resource action: dummy2          stop on sle12sp2-1
-Using the original execution date of: 2016-04-28 11:50:29Z
+Using the original execution date of: 2016-04-28T11:50:29Z
 
 Revised cluster status:
 Online: [ sle12sp2-1 sle12sp2-2 ]

--- a/cts/scheduler/asymmetrical-order-restart.scores
+++ b/cts/scheduler/asymmetrical-order-restart.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2018-08-09 18:55:41Z
+Using the original execution date of: 2018-08-09T18:55:41Z
 native_color: cesr104ipmi allocation score on cesr105-p16: 0
 native_color: cesr104ipmi allocation score on cesr109-p16: 0
 native_color: sleep_a allocation score on cesr105-p16: -INFINITY

--- a/cts/scheduler/asymmetrical-order-restart.summary
+++ b/cts/scheduler/asymmetrical-order-restart.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2018-08-09 18:55:41Z
+Using the original execution date of: 2018-08-09T18:55:41Z
 1 of 3 resources DISABLED and 0 BLOCKED from being started due to failures
 
 Current cluster status:
@@ -17,7 +17,7 @@ Executing cluster transition:
  * Resource action: cesr104ipmi     start on cesr105-p16
  * Resource action: cesr104ipmi     monitor=60000 on cesr105-p16
  * Resource action: sleep_b         stop on cesr109-p16
-Using the original execution date of: 2018-08-09 18:55:41Z
+Using the original execution date of: 2018-08-09T18:55:41Z
 
 Revised cluster status:
 Online: [ cesr105-p16 cesr109-p16 ]

--- a/cts/scheduler/bug-cl-5247.scores
+++ b/cts/scheduler/bug-cl-5247.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2015-08-12 02:53:40Z
+Using the original execution date of: 2015-08-12T02:53:40Z
 clone_color: msPostgresql allocation score on bl460g8n3: -INFINITY
 clone_color: msPostgresql allocation score on bl460g8n4: -INFINITY
 clone_color: msPostgresql allocation score on pgsr01: 0

--- a/cts/scheduler/bug-cl-5247.summary
+++ b/cts/scheduler/bug-cl-5247.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2015-08-12 02:53:40Z
+Using the original execution date of: 2015-08-12T02:53:40Z
 
 Current cluster status:
 Online: [ bl460g8n3 bl460g8n4 ]
@@ -80,7 +80,7 @@ Executing cluster transition:
  * Pseudo action:   msPostgresql_confirmed-post_notify_stopped_0
  * Pseudo action:   pgsql_notified_0
  * Resource action: pgsql           monitor=9000 on pgsr01
-Using the original execution date of: 2015-08-12 02:53:40Z
+Using the original execution date of: 2015-08-12T02:53:40Z
 
 Revised cluster status:
 Online: [ bl460g8n3 bl460g8n4 ]

--- a/cts/scheduler/bundle-nested-colocation.scores
+++ b/cts/scheduler/bundle-nested-colocation.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-07-14 08:50:25Z
+Using the original execution date of: 2017-07-14T08:50:25Z
 clone_color: rabbitmq-bundle-clone allocation score on overcloud-controller-0: -INFINITY
 clone_color: rabbitmq-bundle-clone allocation score on overcloud-controller-1: -INFINITY
 clone_color: rabbitmq-bundle-clone allocation score on overcloud-controller-2: -INFINITY

--- a/cts/scheduler/bundle-nested-colocation.summary
+++ b/cts/scheduler/bundle-nested-colocation.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-07-14 08:50:25Z
+Using the original execution date of: 2017-07-14T08:50:25Z
 
 Current cluster status:
 Online: [ overcloud-controller-0 overcloud-controller-1 overcloud-controller-2 overcloud-galera-0 overcloud-galera-1 overcloud-galera-2 ]
@@ -83,7 +83,7 @@ Executing cluster transition:
  * Resource action: rabbitmq:0      monitor=10000 on rabbitmq-bundle-0
  * Resource action: rabbitmq:1      monitor=10000 on rabbitmq-bundle-1
  * Resource action: rabbitmq:2      monitor=10000 on rabbitmq-bundle-2
-Using the original execution date of: 2017-07-14 08:50:25Z
+Using the original execution date of: 2017-07-14T08:50:25Z
 
 Revised cluster status:
 Online: [ overcloud-controller-0 overcloud-controller-1 overcloud-controller-2 overcloud-galera-0 overcloud-galera-1 overcloud-galera-2 ]

--- a/cts/scheduler/bundle-order-fencing.scores
+++ b/cts/scheduler/bundle-order-fencing.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-09-12 10:51:59Z
+Using the original execution date of: 2017-09-12T10:51:59Z
 clone_color: galera-bundle-master allocation score on controller-0: -INFINITY
 clone_color: galera-bundle-master allocation score on controller-1: -INFINITY
 clone_color: galera-bundle-master allocation score on controller-2: -INFINITY

--- a/cts/scheduler/bundle-order-fencing.summary
+++ b/cts/scheduler/bundle-order-fencing.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-09-12 10:51:59Z
+Using the original execution date of: 2017-09-12T10:51:59Z
 
 Current cluster status:
 Node controller-0 (1): UNCLEAN (offline)
@@ -182,7 +182,7 @@ Executing cluster transition:
  * Pseudo action:   redis-bundle-master_confirmed-post_notify_promoted_0
  * Pseudo action:   redis-bundle_promoted_0
  * Resource action: redis           monitor=20000 on redis-bundle-1
-Using the original execution date of: 2017-09-12 10:51:59Z
+Using the original execution date of: 2017-09-12T10:51:59Z
 
 Revised cluster status:
 Online: [ controller-1 controller-2 ]

--- a/cts/scheduler/bundle-probe-order-1.scores
+++ b/cts/scheduler/bundle-probe-order-1.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-10-12 07:31:56Z
+Using the original execution date of: 2017-10-12T07:31:56Z
 clone_color: galera-bundle-master allocation score on centos1: -INFINITY
 clone_color: galera-bundle-master allocation score on centos2: -INFINITY
 clone_color: galera-bundle-master allocation score on centos3: -INFINITY

--- a/cts/scheduler/bundle-probe-order-1.summary
+++ b/cts/scheduler/bundle-probe-order-1.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-10-12 07:31:56Z
+Using the original execution date of: 2017-10-12T07:31:56Z
 
 Current cluster status:
 Online: [ centos1 centos2 centos3 ]
@@ -20,7 +20,7 @@ Executing cluster transition:
  * Resource action: galera-bundle-docker-2 monitor on centos3
  * Resource action: galera-bundle-docker-2 monitor on centos2
  * Resource action: galera-bundle-docker-2 monitor on centos1
-Using the original execution date of: 2017-10-12 07:31:56Z
+Using the original execution date of: 2017-10-12T07:31:56Z
 
 Revised cluster status:
 Online: [ centos1 centos2 centos3 ]

--- a/cts/scheduler/bundle-probe-order-2.scores
+++ b/cts/scheduler/bundle-probe-order-2.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-10-12 07:31:57Z
+Using the original execution date of: 2017-10-12T07:31:57Z
 clone_color: galera-bundle-master allocation score on centos1: -INFINITY
 clone_color: galera-bundle-master allocation score on centos2: -INFINITY
 clone_color: galera-bundle-master allocation score on centos3: -INFINITY

--- a/cts/scheduler/bundle-probe-order-2.summary
+++ b/cts/scheduler/bundle-probe-order-2.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-10-12 07:31:57Z
+Using the original execution date of: 2017-10-12T07:31:57Z
 
 Current cluster status:
 GuestNode galera-bundle-0:galera-bundle-docker-0: maintenance
@@ -16,7 +16,7 @@ Executing cluster transition:
  * Resource action: galera-bundle-docker-2 monitor on centos3
  * Resource action: galera-bundle-docker-2 monitor on centos2
  * Resource action: galera-bundle-docker-2 monitor on centos1
-Using the original execution date of: 2017-10-12 07:31:57Z
+Using the original execution date of: 2017-10-12T07:31:57Z
 
 Revised cluster status:
 GuestNode galera-bundle-0:galera-bundle-docker-0: maintenance

--- a/cts/scheduler/bundle-probe-order-3.scores
+++ b/cts/scheduler/bundle-probe-order-3.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-10-12 07:31:57Z
+Using the original execution date of: 2017-10-12T07:31:57Z
 clone_color: galera-bundle-master allocation score on centos1: -INFINITY
 clone_color: galera-bundle-master allocation score on centos2: -INFINITY
 clone_color: galera-bundle-master allocation score on centos3: -INFINITY

--- a/cts/scheduler/bundle-probe-order-3.summary
+++ b/cts/scheduler/bundle-probe-order-3.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-10-12 07:31:57Z
+Using the original execution date of: 2017-10-12T07:31:57Z
 
 Current cluster status:
 Online: [ centos1 centos2 centos3 ]
@@ -18,7 +18,7 @@ Executing cluster transition:
  * Resource action: galera-bundle-docker-2 monitor on centos3
  * Resource action: galera-bundle-docker-2 monitor on centos2
  * Resource action: galera-bundle-docker-2 monitor on centos1
-Using the original execution date of: 2017-10-12 07:31:57Z
+Using the original execution date of: 2017-10-12T07:31:57Z
 
 Revised cluster status:
 Online: [ centos1 centos2 centos3 ]

--- a/cts/scheduler/clone-requires-quorum-recovery.scores
+++ b/cts/scheduler/clone-requires-quorum-recovery.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2018-05-24 15:29:56Z
+Using the original execution date of: 2018-05-24T15:29:56Z
 clone_color: dummy-boss-clone allocation score on rhel7-1: 0
 clone_color: dummy-boss-clone allocation score on rhel7-2: 0
 clone_color: dummy-boss-clone allocation score on rhel7-3: 0

--- a/cts/scheduler/clone-requires-quorum-recovery.summary
+++ b/cts/scheduler/clone-requires-quorum-recovery.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2018-05-24 15:29:56Z
+Using the original execution date of: 2018-05-24T15:29:56Z
 
 Current cluster status:
 Node rhel7-5 (5): UNCLEAN (offline)
@@ -29,7 +29,7 @@ Executing cluster transition:
  * Resource action: dummy-crowd     start on rhel7-2
  * Pseudo action:   dummy-crowd-clone_running_0
  * Resource action: dummy-crowd     monitor=10000 on rhel7-2
-Using the original execution date of: 2018-05-24 15:29:56Z
+Using the original execution date of: 2018-05-24T15:29:56Z
 
 Revised cluster status:
 Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 ]

--- a/cts/scheduler/clone-requires-quorum.scores
+++ b/cts/scheduler/clone-requires-quorum.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2018-05-24 15:30:29Z
+Using the original execution date of: 2018-05-24T15:30:29Z
 clone_color: dummy-boss-clone allocation score on rhel7-1: 0
 clone_color: dummy-boss-clone allocation score on rhel7-2: 0
 clone_color: dummy-boss-clone allocation score on rhel7-3: 0

--- a/cts/scheduler/clone-requires-quorum.summary
+++ b/cts/scheduler/clone-requires-quorum.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2018-05-24 15:30:29Z
+Using the original execution date of: 2018-05-24T15:30:29Z
 
 Current cluster status:
 Node rhel7-5 (5): UNCLEAN (offline)
@@ -23,7 +23,7 @@ Executing cluster transition:
  * Fencing rhel7-5 (reboot)
  * Pseudo action:   dummy-crowd_stop_0
  * Pseudo action:   dummy-crowd-clone_stopped_0
-Using the original execution date of: 2018-05-24 15:30:29Z
+Using the original execution date of: 2018-05-24T15:30:29Z
 
 Revised cluster status:
 Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 ]

--- a/cts/scheduler/dc-fence-ordering.scores
+++ b/cts/scheduler/dc-fence-ordering.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2018-11-28 18:37:16Z
+Using the original execution date of: 2018-11-28T18:37:16Z
 clone_color: Connectivity allocation score on rhel7-1: 0
 clone_color: Connectivity allocation score on rhel7-2: 0
 clone_color: Connectivity allocation score on rhel7-3: 0

--- a/cts/scheduler/dc-fence-ordering.summary
+++ b/cts/scheduler/dc-fence-ordering.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2018-11-28 18:37:16Z
+Using the original execution date of: 2018-11-28T18:37:16Z
 
 Current cluster status:
 Node rhel7-1 (1): UNCLEAN (online)
@@ -56,7 +56,7 @@ Executing cluster transition:
  * Cluster action:  do_shutdown on rhel7-5
  * Cluster action:  do_shutdown on rhel7-4
  * Cluster action:  do_shutdown on rhel7-2
-Using the original execution date of: 2018-11-28 18:37:16Z
+Using the original execution date of: 2018-11-28T18:37:16Z
 
 Revised cluster status:
 Online: [ rhel7-2 rhel7-4 rhel7-5 ]

--- a/cts/scheduler/failed-demote-recovery-master.scores
+++ b/cts/scheduler/failed-demote-recovery-master.scores
@@ -1,7 +1,7 @@
 Allocation scores:
 DB2_HADR:0 promotion score on fastvm-rhel-7-4-95: -1
 DB2_HADR:1 promotion score on fastvm-rhel-7-4-96: 10000
-Using the original execution date of: 2017-11-30 12:37:50Z
+Using the original execution date of: 2017-11-30T12:37:50Z
 clone_color: DB2_HADR-master allocation score on fastvm-rhel-7-4-95: 0
 clone_color: DB2_HADR-master allocation score on fastvm-rhel-7-4-96: 0
 clone_color: DB2_HADR:0 allocation score on fastvm-rhel-7-4-95: 1

--- a/cts/scheduler/failed-demote-recovery-master.summary
+++ b/cts/scheduler/failed-demote-recovery-master.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-11-30 12:37:50Z
+Using the original execution date of: 2017-11-30T12:37:50Z
 
 Current cluster status:
 Online: [ fastvm-rhel-7-4-95 fastvm-rhel-7-4-96 ]
@@ -45,7 +45,7 @@ Executing cluster transition:
  * Resource action: DB2_HADR        notify on fastvm-rhel-7-4-96
  * Pseudo action:   DB2_HADR-master_confirmed-post_notify_promoted_0
  * Resource action: DB2_HADR        monitor=22000 on fastvm-rhel-7-4-96
-Using the original execution date of: 2017-11-30 12:37:50Z
+Using the original execution date of: 2017-11-30T12:37:50Z
 
 Revised cluster status:
 Online: [ fastvm-rhel-7-4-95 fastvm-rhel-7-4-96 ]

--- a/cts/scheduler/failed-demote-recovery.scores
+++ b/cts/scheduler/failed-demote-recovery.scores
@@ -1,7 +1,7 @@
 Allocation scores:
 DB2_HADR:0 promotion score on fastvm-rhel-7-4-95: -1
 DB2_HADR:1 promotion score on fastvm-rhel-7-4-96: -1
-Using the original execution date of: 2017-11-30 12:37:50Z
+Using the original execution date of: 2017-11-30T12:37:50Z
 clone_color: DB2_HADR-master allocation score on fastvm-rhel-7-4-95: 0
 clone_color: DB2_HADR-master allocation score on fastvm-rhel-7-4-96: 0
 clone_color: DB2_HADR:0 allocation score on fastvm-rhel-7-4-95: 1

--- a/cts/scheduler/failed-demote-recovery.summary
+++ b/cts/scheduler/failed-demote-recovery.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-11-30 12:37:50Z
+Using the original execution date of: 2017-11-30T12:37:50Z
 
 Current cluster status:
 Online: [ fastvm-rhel-7-4-95 fastvm-rhel-7-4-96 ]
@@ -34,7 +34,7 @@ Executing cluster transition:
  * Resource action: DB2_HADR        notify on fastvm-rhel-7-4-96
  * Pseudo action:   DB2_HADR-master_confirmed-post_notify_running_0
  * Resource action: DB2_HADR        monitor=5000 on fastvm-rhel-7-4-96
-Using the original execution date of: 2017-11-30 12:37:50Z
+Using the original execution date of: 2017-11-30T12:37:50Z
 
 Revised cluster status:
 Online: [ fastvm-rhel-7-4-95 fastvm-rhel-7-4-96 ]

--- a/cts/scheduler/guest-node-cleanup.scores
+++ b/cts/scheduler/guest-node-cleanup.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2018-10-15 16:02:04Z
+Using the original execution date of: 2018-10-15T16:02:04Z
 clone_color: lxc-ms-master allocation score on lxc1: INFINITY
 clone_color: lxc-ms-master allocation score on lxc2: INFINITY
 clone_color: lxc-ms-master allocation score on rhel7-1: 0

--- a/cts/scheduler/guest-node-cleanup.summary
+++ b/cts/scheduler/guest-node-cleanup.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2018-10-15 16:02:04Z
+Using the original execution date of: 2018-10-15T16:02:04Z
 
 Current cluster status:
 Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 rhel7-5 ]
@@ -37,7 +37,7 @@ Executing cluster transition:
  * Pseudo action:   lxc-ms-master_promote_0
  * Resource action: lxc-ms          promote on lxc1
  * Pseudo action:   lxc-ms-master_promoted_0
-Using the original execution date of: 2018-10-15 16:02:04Z
+Using the original execution date of: 2018-10-15T16:02:04Z
 
 Revised cluster status:
 Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 rhel7-5 ]

--- a/cts/scheduler/intervals.scores
+++ b/cts/scheduler/intervals.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2018-03-21 23:12:42Z
+Using the original execution date of: 2018-03-21T23:12:42Z
 native_color: Fencing allocation score on rhel7-1: 0
 native_color: Fencing allocation score on rhel7-2: 0
 native_color: Fencing allocation score on rhel7-3: 0

--- a/cts/scheduler/intervals.summary
+++ b/cts/scheduler/intervals.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2018-03-21 23:12:42Z
+Using the original execution date of: 2018-03-21T23:12:42Z
 
 Current cluster status:
 Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 rhel7-5 ]
@@ -33,7 +33,7 @@ Executing cluster transition:
  * Resource action: rsc2            monitor=40000 on rhel7-3
  * Resource action: rsc5            monitor=20000 on rhel7-2
  * Resource action: rsc6            monitor=28000 on rhel7-1
-Using the original execution date of: 2018-03-21 23:12:42Z
+Using the original execution date of: 2018-03-21T23:12:42Z
 
 Revised cluster status:
 Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 rhel7-5 ]

--- a/cts/scheduler/migration-behind-migrating-remote.scores
+++ b/cts/scheduler/migration-behind-migrating-remote.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 native_color: Fencing allocation score on node1: 0
 native_color: Fencing allocation score on node2: INFINITY
 native_color: Fencing allocation score on remote1: -INFINITY

--- a/cts/scheduler/migration-behind-migrating-remote.summary
+++ b/cts/scheduler/migration-behind-migrating-remote.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 
 Current cluster status:
 Online: [ node1 node2 ]
@@ -24,7 +24,7 @@ Executing cluster transition:
  * Pseudo action:   remote1_start_0
  * Resource action: rsc1            monitor=10000 on remote2
  * Resource action: remote1         monitor=60000 on node2
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 
 Revised cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/multiply-active-stonith.scores
+++ b/cts/scheduler/multiply-active-stonith.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2018-05-09 09:54:39Z
+Using the original execution date of: 2018-05-09T09:54:39Z
 native_color: fencer allocation score on node1: -INFINITY
 native_color: fencer allocation score on node2: 0
 native_color: fencer allocation score on node3: 0

--- a/cts/scheduler/multiply-active-stonith.summary
+++ b/cts/scheduler/multiply-active-stonith.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2018-05-09 09:54:39Z
+Using the original execution date of: 2018-05-09T09:54:39Z
 
 Current cluster status:
 Node node2 (2): UNCLEAN (online)
@@ -15,7 +15,7 @@ Executing cluster transition:
  * Resource action: fencer          monitor=60000 on node3
  * Fencing node2 (reboot)
  * Pseudo action:   rsc1_stop_0
-Using the original execution date of: 2018-05-09 09:54:39Z
+Using the original execution date of: 2018-05-09T09:54:39Z
 
 Revised cluster status:
 Online: [ node1 node3 ]

--- a/cts/scheduler/nested-remote-recovery.scores
+++ b/cts/scheduler/nested-remote-recovery.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2018-09-11 21:23:25Z
+Using the original execution date of: 2018-09-11T21:23:25Z
 clone_color: galera-bundle-master allocation score on controller-0: -INFINITY
 clone_color: galera-bundle-master allocation score on controller-1: -INFINITY
 clone_color: galera-bundle-master allocation score on controller-2: -INFINITY

--- a/cts/scheduler/nested-remote-recovery.summary
+++ b/cts/scheduler/nested-remote-recovery.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2018-09-11 21:23:25Z
+Using the original execution date of: 2018-09-11T21:23:25Z
 
 Current cluster status:
 Online: [ controller-0 controller-1 controller-2 ]
@@ -116,7 +116,7 @@ Executing cluster transition:
  * Pseudo action:   galera-bundle-master_promoted_0
  * Pseudo action:   galera-bundle_promoted_0
  * Resource action: galera          monitor=10000 on galera-bundle-0
-Using the original execution date of: 2018-09-11 21:23:25Z
+Using the original execution date of: 2018-09-11T21:23:25Z
 
 Revised cluster status:
 Online: [ controller-0 controller-1 controller-2 ]

--- a/cts/scheduler/notifs-for-unrunnable.scores
+++ b/cts/scheduler/notifs-for-unrunnable.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2018-02-13 23:40:47Z
+Using the original execution date of: 2018-02-13T23:40:47Z
 clone_color: galera-bundle-master allocation score on controller-0: -INFINITY
 clone_color: galera-bundle-master allocation score on controller-1: -INFINITY
 clone_color: galera-bundle-master allocation score on controller-2: -INFINITY

--- a/cts/scheduler/notifs-for-unrunnable.summary
+++ b/cts/scheduler/notifs-for-unrunnable.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2018-02-13 23:40:47Z
+Using the original execution date of: 2018-02-13T23:40:47Z
 
 Current cluster status:
 Online: [ controller-1 controller-2 ]
@@ -73,7 +73,7 @@ Executing cluster transition:
  * Pseudo action:   redis-bundle-master_confirmed-post_notify_running_0
  * Pseudo action:   redis-bundle_running_0
  * Pseudo action:   rabbitmq-bundle_running_0
-Using the original execution date of: 2018-02-13 23:40:47Z
+Using the original execution date of: 2018-02-13T23:40:47Z
 
 Revised cluster status:
 Online: [ controller-1 controller-2 ]

--- a/cts/scheduler/notify-behind-stopping-remote.scores
+++ b/cts/scheduler/notify-behind-stopping-remote.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2018-11-22 20:36:07Z
+Using the original execution date of: 2018-11-22T20:36:07Z
 clone_color: redis-bundle-master allocation score on ra1: -INFINITY
 clone_color: redis-bundle-master allocation score on ra2: -INFINITY
 clone_color: redis-bundle-master allocation score on ra3: -INFINITY

--- a/cts/scheduler/notify-behind-stopping-remote.summary
+++ b/cts/scheduler/notify-behind-stopping-remote.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2018-11-22 20:36:07Z
+Using the original execution date of: 2018-11-22T20:36:07Z
 
 Current cluster status:
 Online: [ ra1 ra2 ra3 ]
@@ -49,7 +49,7 @@ Executing cluster transition:
  * Pseudo action:   redis-bundle-master_confirmed-post_notify_promoted_0
  * Pseudo action:   redis-bundle_promoted_0
  * Resource action: redis           monitor=20000 on redis-bundle-0
-Using the original execution date of: 2018-11-22 20:36:07Z
+Using the original execution date of: 2018-11-22T20:36:07Z
 
 Revised cluster status:
 Online: [ ra1 ra2 ra3 ]

--- a/cts/scheduler/on-fail-ignore.scores
+++ b/cts/scheduler/on-fail-ignore.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-10-26 14:23:50Z
+Using the original execution date of: 2017-10-26T14:23:50Z
 native_color: fence_db1 allocation score on 407888-db1: 0
 native_color: fence_db1 allocation score on 407892-db2: 100
 native_color: fence_db2 allocation score on 407888-db1: 100

--- a/cts/scheduler/on-fail-ignore.summary
+++ b/cts/scheduler/on-fail-ignore.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-10-26 14:23:50Z
+Using the original execution date of: 2017-10-26T14:23:50Z
 
 Current cluster status:
 Online: [ 407888-db1 407892-db2 ]
@@ -18,7 +18,7 @@ Executing cluster transition:
  * Resource action: fence_db2       stop on 407888-db1
  * Resource action: fence_db2       start on 407888-db1
  * Resource action: fence_db2       monitor=60000 on 407888-db1
-Using the original execution date of: 2017-10-26 14:23:50Z
+Using the original execution date of: 2017-10-26T14:23:50Z
 
 Revised cluster status:
 Online: [ 407888-db1 407892-db2 ]

--- a/cts/scheduler/order-expired-failure.scores
+++ b/cts/scheduler/order-expired-failure.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2018-04-09 07:55:35Z
+Using the original execution date of: 2018-04-09T07:55:35Z
 clone_color: compute-unfence-trigger-clone allocation score on controller-0: -INFINITY
 clone_color: compute-unfence-trigger-clone allocation score on controller-1: -INFINITY
 clone_color: compute-unfence-trigger-clone allocation score on controller-2: -INFINITY

--- a/cts/scheduler/order-expired-failure.summary
+++ b/cts/scheduler/order-expired-failure.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2018-04-09 07:55:35Z
+Using the original execution date of: 2018-04-09T07:55:35Z
 
 Current cluster status:
 RemoteNode overcloud-novacompute-1: UNCLEAN (offline)
@@ -63,7 +63,7 @@ Executing cluster transition:
  * Pseudo action:   compute-unfence-trigger_stop_0
  * Pseudo action:   compute-unfence-trigger-clone_stopped_0
  * Resource action: overcloud-novacompute-1 stop on controller-1
-Using the original execution date of: 2018-04-09 07:55:35Z
+Using the original execution date of: 2018-04-09T07:55:35Z
 
 Revised cluster status:
 RemoteNode overcloud-novacompute-1: UNCLEAN (offline)

--- a/cts/scheduler/order-first-probes.scores
+++ b/cts/scheduler/order-first-probes.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2016-10-05 07:32:34Z
+Using the original execution date of: 2016-10-05T07:32:34Z
 group_color: grpDummy allocation score on rh72-01: 200
 group_color: grpDummy allocation score on rh72-02: 100
 group_color: prmDummy1 allocation score on rh72-01: INFINITY

--- a/cts/scheduler/order-first-probes.summary
+++ b/cts/scheduler/order-first-probes.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2016-10-05 07:32:34Z
+Using the original execution date of: 2016-10-05T07:32:34Z
 
 Current cluster status:
 Node rh72-01 (3232238257): standby
@@ -23,7 +23,7 @@ Executing cluster transition:
  * Pseudo action:   grpDummy_running_0
  * Resource action: prmDummy1       monitor=10000 on rh72-02
  * Resource action: prmDummy2       monitor=10000 on rh72-02
-Using the original execution date of: 2016-10-05 07:32:34Z
+Using the original execution date of: 2016-10-05T07:32:34Z
 
 Revised cluster status:
 Node rh72-01 (3232238257): standby

--- a/cts/scheduler/per-op-failcount.scores
+++ b/cts/scheduler/per-op-failcount.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-04-06 09:04:22Z
+Using the original execution date of: 2017-04-06T09:04:22Z
 native_color: prmDummy allocation score on rh73-01-snmp: -INFINITY
 native_color: prmDummy allocation score on rh73-02-snmp: 200
 native_color: prmStonith1-1 allocation score on rh73-01-snmp: 0

--- a/cts/scheduler/per-op-failcount.summary
+++ b/cts/scheduler/per-op-failcount.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-04-06 09:04:22Z
+Using the original execution date of: 2017-04-06T09:04:22Z
 
 Current cluster status:
 Node rh73-01-snmp (3232238265): UNCLEAN (online)
@@ -20,7 +20,7 @@ Executing cluster transition:
  * Resource action: prmStonith2-1   start on rh73-02-snmp
  * Resource action: prmDummy        start on rh73-02-snmp
  * Resource action: prmDummy        monitor=10000 on rh73-02-snmp
-Using the original execution date of: 2017-04-06 09:04:22Z
+Using the original execution date of: 2017-04-06T09:04:22Z
 
 Revised cluster status:
 Online: [ rh73-02-snmp ]

--- a/cts/scheduler/reload-becomes-restart.scores
+++ b/cts/scheduler/reload-becomes-restart.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2016-12-12 20:28:26Z
+Using the original execution date of: 2016-12-12T20:28:26Z
 clone_color: cl-rsc1 allocation score on node1: 0
 clone_color: cl-rsc1 allocation score on node2: 0
 clone_color: cl-rsc2 allocation score on node1: 0

--- a/cts/scheduler/reload-becomes-restart.summary
+++ b/cts/scheduler/reload-becomes-restart.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2016-12-12 20:28:26Z
+Using the original execution date of: 2016-12-12T20:28:26Z
 
 Current cluster status:
 Online: [ node1 node2 ]
@@ -40,7 +40,7 @@ Executing cluster transition:
  * Resource action: rsc2            start on node2
  * Pseudo action:   cl-rsc2_running_0
  * Resource action: rsc2            monitor=200000 on node2
-Using the original execution date of: 2016-12-12 20:28:26Z
+Using the original execution date of: 2016-12-12T20:28:26Z
 
 Revised cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/remote-reconnect-delay.scores
+++ b/cts/scheduler/remote-reconnect-delay.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 clone_color: Connectivity allocation score on remote-rhel7-3: 0
 clone_color: Connectivity allocation score on rhel7-1: 0
 clone_color: Connectivity allocation score on rhel7-2: 0

--- a/cts/scheduler/remote-reconnect-delay.summary
+++ b/cts/scheduler/remote-reconnect-delay.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 
 Current cluster status:
 Online: [ rhel7-1 rhel7-2 rhel7-4 rhel7-5 ]
@@ -34,7 +34,7 @@ Executing cluster transition:
  * Resource action: Fencing         stop on rhel7-2
  * Resource action: Fencing         start on rhel7-2
  * Resource action: Fencing         monitor=120000 on rhel7-2
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 
 Revised cluster status:
 Online: [ rhel7-1 rhel7-2 rhel7-4 rhel7-5 ]

--- a/cts/scheduler/remote-recover-all.scores
+++ b/cts/scheduler/remote-recover-all.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 clone_color: galera-master allocation score on controller-0: -INFINITY
 clone_color: galera-master allocation score on controller-1: -INFINITY
 clone_color: galera-master allocation score on controller-2: -INFINITY

--- a/cts/scheduler/remote-recover-all.summary
+++ b/cts/scheduler/remote-recover-all.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 
 Current cluster status:
 Node controller-1 (2): UNCLEAN (offline)
@@ -112,7 +112,7 @@ Executing cluster transition:
  * Resource action: ip-172.17.1.14  monitor=10000 on controller-2
  * Resource action: ip-172.17.1.17  monitor=10000 on controller-2
  * Resource action: ip-172.17.4.11  monitor=10000 on controller-2
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 
 Revised cluster status:
 Online: [ controller-0 controller-2 ]

--- a/cts/scheduler/remote-recover-connection.scores
+++ b/cts/scheduler/remote-recover-connection.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 clone_color: galera-master allocation score on controller-0: -INFINITY
 clone_color: galera-master allocation score on controller-1: -INFINITY
 clone_color: galera-master allocation score on controller-2: -INFINITY

--- a/cts/scheduler/remote-recover-connection.summary
+++ b/cts/scheduler/remote-recover-connection.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 
 Current cluster status:
 Node controller-1 (2): UNCLEAN (offline)
@@ -99,7 +99,7 @@ Executing cluster transition:
  * Resource action: ip-172.17.1.14  monitor=10000 on controller-2
  * Resource action: ip-172.17.1.17  monitor=10000 on controller-2
  * Resource action: ip-172.17.4.11  monitor=10000 on controller-2
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 
 Revised cluster status:
 Online: [ controller-0 controller-2 ]

--- a/cts/scheduler/remote-recover-no-resources.scores
+++ b/cts/scheduler/remote-recover-no-resources.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 clone_color: galera-master allocation score on controller-0: -INFINITY
 clone_color: galera-master allocation score on controller-1: -INFINITY
 clone_color: galera-master allocation score on controller-2: -INFINITY

--- a/cts/scheduler/remote-recover-no-resources.summary
+++ b/cts/scheduler/remote-recover-no-resources.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 
 Current cluster status:
 Node controller-1 (2): UNCLEAN (offline)
@@ -103,7 +103,7 @@ Executing cluster transition:
  * Resource action: ip-172.17.1.14  monitor=10000 on controller-2
  * Resource action: ip-172.17.1.17  monitor=10000 on controller-2
  * Resource action: ip-172.17.4.11  monitor=10000 on controller-2
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 
 Revised cluster status:
 Online: [ controller-0 controller-2 ]

--- a/cts/scheduler/remote-recover-unknown.scores
+++ b/cts/scheduler/remote-recover-unknown.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 clone_color: galera-master allocation score on controller-0: -INFINITY
 clone_color: galera-master allocation score on controller-1: -INFINITY
 clone_color: galera-master allocation score on controller-2: -INFINITY

--- a/cts/scheduler/remote-recover-unknown.summary
+++ b/cts/scheduler/remote-recover-unknown.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 
 Current cluster status:
 Node controller-1 (2): UNCLEAN (offline)
@@ -105,7 +105,7 @@ Executing cluster transition:
  * Resource action: ip-172.17.1.14  monitor=10000 on controller-2
  * Resource action: ip-172.17.1.17  monitor=10000 on controller-2
  * Resource action: ip-172.17.4.11  monitor=10000 on controller-2
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 
 Revised cluster status:
 Online: [ controller-0 controller-2 ]

--- a/cts/scheduler/remote-recovery.scores
+++ b/cts/scheduler/remote-recovery.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 clone_color: galera-master allocation score on controller-0: -INFINITY
 clone_color: galera-master allocation score on controller-1: -INFINITY
 clone_color: galera-master allocation score on controller-2: -INFINITY

--- a/cts/scheduler/remote-recovery.summary
+++ b/cts/scheduler/remote-recovery.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 
 Current cluster status:
 Node controller-1 (2): UNCLEAN (offline)
@@ -99,7 +99,7 @@ Executing cluster transition:
  * Resource action: ip-172.17.1.14  monitor=10000 on controller-2
  * Resource action: ip-172.17.1.17  monitor=10000 on controller-2
  * Resource action: ip-172.17.4.11  monitor=10000 on controller-2
-Using the original execution date of: 2017-05-03 13:33:24Z
+Using the original execution date of: 2017-05-03T13:33:24Z
 
 Revised cluster status:
 Online: [ controller-0 controller-2 ]

--- a/cts/scheduler/route-remote-notify.scores
+++ b/cts/scheduler/route-remote-notify.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2018-10-31 11:51:32Z
+Using the original execution date of: 2018-10-31T11:51:32Z
 clone_color: rabbitmq-bundle-clone allocation score on controller-0: -INFINITY
 clone_color: rabbitmq-bundle-clone allocation score on controller-1: -INFINITY
 clone_color: rabbitmq-bundle-clone allocation score on controller-2: -INFINITY

--- a/cts/scheduler/route-remote-notify.summary
+++ b/cts/scheduler/route-remote-notify.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2018-10-31 11:51:32Z
+Using the original execution date of: 2018-10-31T11:51:32Z
 
 Current cluster status:
 Online: [ controller-0 controller-1 controller-2 ]
@@ -72,7 +72,7 @@ Executing cluster transition:
  * Pseudo action:   rabbitmq-bundle-clone_post_notify_running_0
  * Pseudo action:   rabbitmq-bundle-clone_confirmed-post_notify_running_0
  * Pseudo action:   rabbitmq-bundle_running_0
-Using the original execution date of: 2018-10-31 11:51:32Z
+Using the original execution date of: 2018-10-31T11:51:32Z
 
 Revised cluster status:
 Online: [ controller-0 controller-1 controller-2 ]

--- a/cts/scheduler/suicide-needed-inquorate.scores
+++ b/cts/scheduler/suicide-needed-inquorate.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 native_color: Fencing allocation score on node1: 0
 native_color: Fencing allocation score on node2: 0
 native_color: Fencing allocation score on node3: 0

--- a/cts/scheduler/suicide-needed-inquorate.summary
+++ b/cts/scheduler/suicide-needed-inquorate.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 
 Current cluster status:
 Node node1 (1): UNCLEAN (online)
@@ -16,7 +16,7 @@ Executing cluster transition:
  * Fencing node1 (reboot)
  * Fencing node3 (reboot)
  * Fencing node2 (reboot)
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 
 Revised cluster status:
 OFFLINE: [ node1 node2 node3 ]

--- a/cts/scheduler/suicide-not-needed-initial-quorum.scores
+++ b/cts/scheduler/suicide-not-needed-initial-quorum.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 native_color: Fencing allocation score on node1: 0
 native_color: Fencing allocation score on node2: 0
 native_color: Fencing allocation score on node3: 0

--- a/cts/scheduler/suicide-not-needed-initial-quorum.summary
+++ b/cts/scheduler/suicide-not-needed-initial-quorum.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 
 Current cluster status:
 Online: [ node1 node2 node3 ]
@@ -14,7 +14,7 @@ Executing cluster transition:
  * Resource action: Fencing         monitor on node1
  * Resource action: Fencing         start on node1
  * Resource action: Fencing         monitor=120000 on node1
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 
 Revised cluster status:
 Online: [ node1 node2 node3 ]

--- a/cts/scheduler/suicide-not-needed-never-quorate.scores
+++ b/cts/scheduler/suicide-not-needed-never-quorate.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 native_color: Fencing allocation score on node1: 0
 native_color: Fencing allocation score on node2: 0
 native_color: Fencing allocation score on node3: 0

--- a/cts/scheduler/suicide-not-needed-never-quorate.summary
+++ b/cts/scheduler/suicide-not-needed-never-quorate.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 
 Current cluster status:
 Online: [ node1 node2 node3 ]
@@ -12,7 +12,7 @@ Executing cluster transition:
  * Resource action: Fencing         monitor on node3
  * Resource action: Fencing         monitor on node2
  * Resource action: Fencing         monitor on node1
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 
 Revised cluster status:
 Online: [ node1 node2 node3 ]

--- a/cts/scheduler/suicide-not-needed-quorate.scores
+++ b/cts/scheduler/suicide-not-needed-quorate.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 native_color: Fencing allocation score on node1: 0
 native_color: Fencing allocation score on node2: 0
 native_color: Fencing allocation score on node3: 0

--- a/cts/scheduler/suicide-not-needed-quorate.summary
+++ b/cts/scheduler/suicide-not-needed-quorate.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 
 Current cluster status:
 Online: [ node1 node2 node3 ]
@@ -14,7 +14,7 @@ Executing cluster transition:
  * Resource action: Fencing         monitor on node1
  * Resource action: Fencing         start on node1
  * Resource action: Fencing         monitor=120000 on node1
-Using the original execution date of: 2017-08-21 17:12:54Z
+Using the original execution date of: 2017-08-21T17:12:54Z
 
 Revised cluster status:
 Online: [ node1 node2 node3 ]

--- a/cts/scheduler/unfence-device.scores
+++ b/cts/scheduler/unfence-device.scores
@@ -1,5 +1,5 @@
 Allocation scores:
-Using the original execution date of: 2017-11-30 10:44:29Z
+Using the original execution date of: 2017-11-30T10:44:29Z
 native_color: fence_scsi allocation score on virt-008: 0
 native_color: fence_scsi allocation score on virt-009: 0
 native_color: fence_scsi allocation score on virt-013: 0

--- a/cts/scheduler/unfence-device.summary
+++ b/cts/scheduler/unfence-device.summary
@@ -1,4 +1,4 @@
-Using the original execution date of: 2017-11-30 10:44:29Z
+Using the original execution date of: 2017-11-30T10:44:29Z
 
 Current cluster status:
 Online: [ virt-008 virt-009 virt-013 ]
@@ -20,7 +20,7 @@ Executing cluster transition:
  * Resource action: fence_scsi      monitor on virt-008
  * Resource action: fence_scsi      start on virt-008
  * Resource action: fence_scsi      monitor=60000 on virt-008
-Using the original execution date of: 2017-11-30 10:44:29Z
+Using the original execution date of: 2017-11-30T10:44:29Z
 
 Revised cluster status:
 Online: [ virt-008 virt-009 virt-013 ]

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -520,7 +520,7 @@ crm_time_as_string(crm_time_t * date_time, int flags)
     result_s = calloc(1, 100);
 
     snprintf(result_s, 100, "%s%s%s%s",
-             date_s ? date_s : "", (date_s != NULL && time_s != NULL) ? " " : "",
+             date_s ? date_s : "", (date_s != NULL && time_s != NULL) ? "T" : "",
              time_s ? time_s : "", offset_s ? offset_s : "");
 
   cleanup:

--- a/tools/crm_rule.c
+++ b/tools/crm_rule.c
@@ -28,14 +28,14 @@ static int crm_rule_check(pe_working_set_t *data_set, const char *rule_id, crm_t
 static struct crm_option long_options[] = {
     /* Top-level Options */
     {"help",       no_argument,       NULL, '?', "\tThis text"},
-    {"version",    no_argument,       NULL, '$', "\tVersion information"  },
+    {"version",    no_argument,       NULL, '$', "\tVersion information"},
     {"verbose",    no_argument,       NULL, 'V', "\tIncrease debug output"},
 
-    {"-spacer-",   required_argument, NULL, '-', "\nModes (mutually exclusive):" },
-    {"check",      no_argument,       NULL, 'c', "\tCheck whether a rule is in effect" },
+    {"-spacer-",   required_argument, NULL, '-', "\nModes (mutually exclusive):"},
+    {"check",      no_argument,       NULL, 'c', "\tCheck if a rule is in effect, now or at given date/time"},
 
-    {"-spacer-",   required_argument, NULL, '-', "\nAdditional options:" },
-    {"date",       required_argument, NULL, 'd', "Whether the rule is in effect on a given date" },
+    {"-spacer-",   required_argument, NULL, '-', "\nAdditional options:"},
+    {"date",       required_argument, NULL, 'd', "Date/time (ISO 8601) specification as a mode's input"},
     {"rule",       required_argument, NULL, 'r', "The ID of the rule to check" },
 
     {"-spacer-",   no_argument,       NULL, '-', "\nData:"},
@@ -44,7 +44,19 @@ static struct crm_option long_options[] = {
     {"-spacer-",   required_argument, NULL, '-', "\n\nThis tool is currently experimental.",
      pcmk_option_paragraph},
     {"-spacer-",   required_argument, NULL, '-', "The interface, behavior, and output may "
-                                                 "change with any version of pacemaker.", pcmk_option_paragraph},
+                                                 "change with any version of pacemaker.",
+     pcmk_option_paragraph},
+    {"-spacer-",   required_argument, NULL, '-', "Important: avoid making conclusion based on"
+                                                 " this tool when it is not of the same version as"
+                                                 " an overall pacemaker deployment."
+                                                 "\nThe exact date/time parsing behaviour may get altered"
+                                                 " over time, so only the above requirement guarantees"
+                                                 " reliable outcomes related to particular deployment"
+                                                 " (i.e. without a generic validity for older/newer"
+                                                 " versions of pacemaker, possibly -- depending on the"
+                                                 " permanency of the arising decisions -- mandating"
+                                                 " any such to be re-evaluated anew upon an update).",
+     pcmk_option_paragraph},
 
     {0, 0, 0, 0}
 };


### PR DESCRIPTION
Previously, the above example would be parsed as (+0020), which may
apparently derail the carefully polished execution plans of the users.
Also add a respective test to capture any regression.