### PR TITLE
Build: {16% boost in configure,18% boost in single job make} time with dash in place of bash -> ~16 % boost altogether

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@
 ## Build Dependencies
 * automake 1.11 or later
 * autoconf 2.64 or later
-* bash
+* bash (configuring build alone is served with a POSIX shell)
 * libtool
 * libtool-ltdl-devel
 * libuuid-devel

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,7 @@
 # How to Install Pacemaker
 
 ## Build Dependencies
+* GNU make
 * automake 1.11 or later
 * autoconf 2.64 or later
 * bash (configuring build alone is served with a POSIX shell)
@@ -52,3 +53,9 @@
     $ ./configure
     $ make
     $ sudo make install
+
+For extra convenience (e.g. addressing the case `make` is not GNU compatible
+in your deployment, in which case you would need to switch that invocation
+above for something else like `gmake`), you can use `./autogen.sh roll along`
+instead of initial three steps (or `./autogen.sh roll` in place of just the
+first and second).

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,32 @@
 #!/bin/sh
-# Part of pacemaker project
+# Copyright 2003-2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-autoreconf -fisv || exit $?
-echo 'Now run ./configure and make'
+# portably check whether configure is up to date first unless arguments passed
+if ! { test $# -ne 0 && make -q -r -f - configure; }; then
+	autoreconf -fisv || exit $?
+fi <<EOF
+configure: autogen.sh configure.ac
+	: pass
+EOF
+
+# convenience: use "./autogen.sh roll --with-cibsecrets" etc.;
+# this is mostly to force-prefer dash on platforms where /bin/sh ~ slow bash
+if test $# -gt 0 && test "x$1" = xroll; then
+	shift
+	# shell must support LINENO variable, but that's POSIX now
+	# https://github.com/koalaman/shellcheck/issues/644
+	for sh in ${BUILD_SH} dash ash 'busybox ash' sh bash; do
+		shargs=${sh#* }; test "x$sh" != "x$shargs" || shargs=
+		sh=$(command -v ${sh%% *} 2>/dev/null)
+		#export CONFIG_SHELL=$sh  # no gain + extra shell re-exec
+		test -x "$sh" && exec $sh $shargs ./configure \
+		  "CONFIG_SHELL=$sh${shargs:+ $shargs}" \
+		  "$@"
+	done
+else
+	echo 'Now run ./configure and make'
+fi

--- a/autogen.sh
+++ b/autogen.sh
@@ -6,27 +6,32 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # portably check whether configure is up to date first unless arguments passed
-if ! { test $# -ne 0 && make -q -r -f - configure; }; then
+if ! { test $# -ne 0 && ${BUILD_MAKE:-make} -q -r -f - configure; }; then
 	autoreconf -fisv || exit $?
 fi <<EOF
 configure: autogen.sh configure.ac
 	: pass
 EOF
 
-# convenience: use "./autogen.sh roll --with-cibsecrets" etc.;
-# this is mostly to force-prefer dash on platforms where /bin/sh ~ slow bash
+# convenience: use "./autogen.sh roll [along] --with-cibsecrets" etc.;
+# this is mostly to force-prefer dash on platforms where /bin/sh ~ slow bash,
+# and with "along", to force-prefer gmake on platforms where make is not GNU
 if test $# -gt 0 && test "x$1" = xroll; then
 	shift
+	mk=$(command -v ${BUILD_MAKE:-gmake} 2>/dev/null \
+	     || command -v make 2>/dev/null) || mk=:
+	test $# -gt 0 && test "x$1" = xalong && shift && tailc=$mk || tailc=:
 	# shell must support LINENO variable, but that's POSIX now
 	# https://github.com/koalaman/shellcheck/issues/644
 	for sh in ${BUILD_SH} dash ash 'busybox ash' sh bash; do
 		shargs=${sh#* }; test "x$sh" != "x$shargs" || shargs=
 		sh=$(command -v ${sh%% *} 2>/dev/null)
 		#export CONFIG_SHELL=$sh  # no gain + extra shell re-exec
-		test -x "$sh" && exec $sh $shargs ./configure \
-		  "CONFIG_SHELL=$sh${shargs:+ $shargs}" \
-		  "SHELL=$sh${shargs:+ $shargs}" \
-		  "$@"
+		test -x "$sh" && exec $sh $shargs -c "./configure \
+		  \"CONFIG_SHELL=$sh${shargs:+ $shargs}\" \
+		  \"MAKE=$mk\" \
+		  \"SHELL=$sh${shargs:+ $shargs}\" \
+		  $* && $tailc"
 	done
 else
 	echo 'Now run ./configure and make'

--- a/autogen.sh
+++ b/autogen.sh
@@ -25,6 +25,7 @@ if test $# -gt 0 && test "x$1" = xroll; then
 		#export CONFIG_SHELL=$sh  # no gain + extra shell re-exec
 		test -x "$sh" && exec $sh $shargs ./configure \
 		  "CONFIG_SHELL=$sh${shargs:+ $shargs}" \
+		  "SHELL=$sh${shargs:+ $shargs}" \
 		  "$@"
 	done
 else

--- a/configure.ac
+++ b/configure.ac
@@ -111,14 +111,6 @@ AC_CHECK_SIZEOF(long long)
 dnl ===============================================
 dnl Helpers
 dnl ===============================================
-cc_supports_flag() {
-    local CFLAGS="-Werror $@"
-    AC_MSG_CHECKING(whether $CC supports "$@")
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ ]], [[ ]])],
-                      [RC=0; AC_MSG_RESULT(yes)],
-                      [RC=1; AC_MSG_RESULT(no)])
-    return $RC
-}
 
 # Some tests need to use their own CFLAGS
 
@@ -129,6 +121,16 @@ cc_temp_flags() {
 
 cc_restore_flags() {
     CFLAGS=$ac_save_CFLAGS
+}
+
+cc_supports_flag() {
+    cc_temp_flags "-Werror $@"
+    AC_MSG_CHECKING(whether $CC supports "$@")
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ ]], [[ ]])],
+                      [RC=0; AC_MSG_RESULT(yes)],
+                      [RC=1; AC_MSG_RESULT(no)])
+    cc_restore_flags
+    return $RC
 }
 
 dnl ===============================================
@@ -955,14 +957,14 @@ dnl Check for printw() prototype compatibility
 if test X"$CURSESLIBS" != X"" && cc_supports_flag -Wcast-qual; then
     ac_save_LIBS=$LIBS
     LIBS="$CURSESLIBS"
-    cc_temp_flags "-Wcast-qual $WERROR"
     # avoid broken test because of hardened build environment in Fedora 23+
     # - https://fedoraproject.org/wiki/Changes/Harden_All_Packages
     # - https://bugzilla.redhat.com/1297985
     if cc_supports_flag -fPIC; then
-        CFLAGS="$CFLAGS -fPIC"
+        cc_temp_flags "-Wcast-qual $WERROR -fPIC"
+    else
+        cc_temp_flags "-Wcast-qual $WERROR"
     fi
-
     AC_MSG_CHECKING(whether printw() requires argument of "const char *")
     AC_LINK_IFELSE(
         [AC_LANG_PROGRAM([


### PR DESCRIPTION
Measurements taken with i7-6820HQ and updated Fedora Rawhide.

Bash is notoriously slow, but Fedora/EL distros use it as a default
/bin/sh, so apply a convenience trick directly in ./autogen.sh so that,
when invoked with "roll [CONFIGURE-ARGS]" as argument, it will attempt
to stick with dash if available.  Merely for completeness, it will also
try to workaround the unexpected situation there's no /bin/sh on the
system (or /usr/local/bin/sh or so is preferred for casual uses
per the PATH priorities?).

In a sense, it restores some prior convenience arrangements present
till 19a1794d9, but the difference is that the new addition is terse
and very easy to grasp.

For the time being, .gitlab-ci.yml doesn't use it, as it it's expected
that the overhead of installing dash in addition to the inherently
present bash on Fedora will not gain anything, quite the contrary.
It may be reconsidered in the context of actual test executions,
though a separate measurement is needed.

Note that also drop of "local" non-POSIX extension from configure
script was in order (dash warns about that).