### PR TITLE
Low: pacemaker.service: Add option that does not restart Pacemaker if…

### DIFF
--- a/daemons/pacemakerd/pacemaker.service.in
+++ b/daemons/pacemakerd/pacemaker.service.in
@@ -73,6 +73,14 @@ SendSIGKILL=no
 #
 # ExecStopPost=/bin/sh -c 'pidof pacemaker-controld || killall -TERM corosync'
 
+# Pacemaker will restart along with Corosync if Corosync is stopped while
+# Pacemaker is running.
+# In this case, if you want to be fenced always (if you do not want to restart)
+# uncomment ExecStopPost below.
+# 
+# ExecStopPost=/bin/sh -c 'pidof corosync || \
+#              /usr/bin/systemctl --no-block stop pacemaker'
+
 # When the service functions properly, it will wait to exit until all resources
 # have been stopped on the local node, and potentially across all nodes that
 # are shutting down.  The default of 30min should cover most typical cluster


### PR DESCRIPTION
… Corosync stops

If Corosync is stopped while Pacemaker is running, (for example, sending a SIGTERM to corosync), Pacemaker will restart along with Corosync, but in most cases of Pacemaker-1.1, the node will be fenced before re-joining the cluster.
However, depending on the timing, it may not be fenced, so I considered about "how to always fencing".

I attached crm_report.
* fenced : https://github.com/inouekazu/pcmk_report/blob/master/pcmk-Tue-14-May-2019_fenced.tar.bz2
* NOT fenced : https://github.com/inouekazu/pcmk_report/blob/master/pcmk-Tue-14-May-2019_NOT-fenced.tar.bz2