### PR TITLE
Fix: fence-lib: avoid use-after-free on early failure return

### DIFF
--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -716,6 +716,19 @@ class Tests(object):
             if test_type["use_cpg"] == 1:
                 test.add_stonith_log_pattern("Total timeout set to 6")
 
+        # test what happens when we try to use a missing fence-agent.
+        for test_type in test_types:
+            test = self.new_test("%s_fence_missing_agent" % test_type["prefix"],
+                                 "Verify proper error-handling when using a non-existent fence-agent.",
+                                 test_type["use_cpg"])
+            test.add_cmd("stonith_admin",
+                         "-R true1 -a fence_missing -o \"mode=pass\" -o \"pcmk_host_list=node3\"")
+            test.add_cmd("stonith_admin",
+                         "-R true2 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node2\"")
+
+            test.add_expected_fail_cmd("stonith_admin", "-F node3 -t 5", CrmExit.ERROR)
+            test.add_cmd("stonith_admin", "-F node2 -t 5")
+
         # simple topology test for one device
         for test_type in test_types:
             if test_type["use_cpg"] == 0:

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -577,9 +577,9 @@ class Tests(object):
                      '-R true1  -a fence_dummy -o "mode=pass" -o "pcmk_host_list=node3" -o "pcmk_off_timeout=1"')
         test.add_cmd('stonith_admin',
                      '-R false2 -a fence_dummy -o "mode=fail" -o "pcmk_host_list=node3" -o "pcmk_off_timeout=4"')
-        test.add_cmd("stonith_admin", "-F node3 -t 2")
-        # timeout is 2+1+4 = 7
-        test.add_stonith_log_pattern("Total timeout set to 7")
+        test.add_cmd("stonith_admin", "-F node3 -t 5")
+        # timeout is 5+1+4 = 10
+        test.add_stonith_log_pattern("Total timeout set to 10")
 
         # custom timeout _WITH_ topology
         test = self.new_test("cpg_custom_timeout_2",
@@ -593,9 +593,9 @@ class Tests(object):
         test.add_cmd("stonith_admin", "-r node3 -i 1 -v false1")
         test.add_cmd("stonith_admin", "-r node3 -i 2 -v true1")
         test.add_cmd("stonith_admin", "-r node3 -i 3 -v false2")
-        test.add_cmd("stonith_admin", "-F node3 -t 2")
-        # timeout is 2+1+4000 = 4003
-        test.add_stonith_log_pattern("Total timeout set to 4003")
+        test.add_cmd("stonith_admin", "-F node3 -t 5")
+        # timeout is 5+1+4000 = 4006
+        test.add_stonith_log_pattern("Total timeout set to 4006")
 
     def build_fence_merge_tests(self):
         """ Register tests to verify when fence operations should be merged """
@@ -726,10 +726,10 @@ class Tests(object):
                          "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
             test.add_cmd("stonith_admin",
                          "-R false2 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\"")
-            test.add_cmd("stonith_admin", "-F node3 -t 2")
+            test.add_cmd("stonith_admin", "-F node3 -t 5")
 
             if test_type["use_cpg"] == 1:
-                test.add_stonith_log_pattern("Total timeout set to 6")
+                test.add_stonith_log_pattern("Total timeout set to 15")
 
         # test what happens when we try to use a missing fence-agent.
         for test_type in test_types:
@@ -754,9 +754,9 @@ class Tests(object):
             test.add_cmd("stonith_admin",
                          "-R true  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
             test.add_cmd("stonith_admin", "-r node3 -i 1 -v true")
-            test.add_cmd("stonith_admin", "-F node3 -t 2")
+            test.add_cmd("stonith_admin", "-F node3 -t 5")
 
-            test.add_stonith_log_pattern("Total timeout set to 2")
+            test.add_stonith_log_pattern("Total timeout set to 5")
             test.add_stonith_log_pattern("for host 'node3' with device 'true' returned: 0")
 
 
@@ -772,9 +772,9 @@ class Tests(object):
                          "-R true  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
             test.add_cmd("stonith_admin", "-r node3 -i 1 -v true")
             test.add_cmd("stonith_admin", "-d node3 -i 1")
-            test.add_cmd("stonith_admin", "-F node3 -t 2")
+            test.add_cmd("stonith_admin", "-F node3 -t 5")
 
-            test.add_stonith_log_pattern("Total timeout set to 2")
+            test.add_stonith_log_pattern("Total timeout set to 5")
             test.add_stonith_log_pattern("for host 'node3' with device 'true' returned: 0")
 
         # test what happens when the first fencing level has multiple devices.
@@ -858,7 +858,7 @@ class Tests(object):
             test.add_cmd("stonith_admin", "-r node3 -i 3 -v true3")
             test.add_cmd("stonith_admin", "-r node3 -i 3 -v true4")
 
-            test.add_cmd("stonith_admin", "-F node3 -t 2")
+            test.add_cmd("stonith_admin", "-F node3 -t 5")
 
         # Test what happens if multiple fencing levels are defined, and then the first one is removed.
         for test_type in test_types:
@@ -911,7 +911,7 @@ class Tests(object):
             test.add_cmd("stonith_admin",
                          """-R true -a fence_dummy -o "mode=pass" -o "pcmk_host_list=node1 node2 node3" """)
             test.add_cmd("stonith_admin", """-r '@node.*' -i 1 -v true""")
-            test.add_cmd("stonith_admin", "-F node3 -t 2")
+            test.add_cmd("stonith_admin", "-F node3 -t 5")
             test.add_stonith_log_pattern("for host 'node3' with device 'true' returned: 0")
 
         # test allowing commas and semicolons as delimiters in pcmk_host_list
@@ -923,8 +923,8 @@ class Tests(object):
                          """-R true1 -a fence_dummy -o "mode=pass" -o "pcmk_host_list=node1,node2,node3" """)
             test.add_cmd("stonith_admin",
                          """-R true2 -a fence_dummy -o "mode=pass" -o "pcmk_host_list=pcmk1;pcmk2;pcmk3" """)
-            test.add_cmd("stonith_admin", "stonith_admin -F node2 -t 2")
-            test.add_cmd("stonith_admin", "stonith_admin -F pcmk3 -t 2")
+            test.add_cmd("stonith_admin", "stonith_admin -F node2 -t 5")
+            test.add_cmd("stonith_admin", "stonith_admin -F pcmk3 -t 5")
             test.add_stonith_log_pattern("for host 'node2' with device 'true1' returned: 0")
             test.add_stonith_log_pattern("for host 'pcmk3' with device 'true2' returned: 0")
 
@@ -993,7 +993,7 @@ class Tests(object):
                                  test_type["use_cpg"])
             test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3\"")
 
-            test.add_cmd("stonith_admin", "-B node3 -t 2")
+            test.add_cmd("stonith_admin", "-B node3 -t 5")
 
             test.add_cmd("stonith_admin", "-D true1")
 
@@ -1008,7 +1008,7 @@ class Tests(object):
                                  test_type["use_cpg"])
             test.add_cmd("stonith_admin", "-R true1  -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node3\"")
 
-            test.add_cmd("stonith_admin", "-F node3 -t 2 -V")
+            test.add_cmd("stonith_admin", "-F node3 -t 5 -V")
 
             test.add_cmd_check_stdout("stonith_admin", "-H node3", "succeeded turning off node node3", "")
 

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -15,6 +15,7 @@ import subprocess
 import shlex
 import time
 import tempfile
+import signal
 
 # Where to find test binaries
 # Prefer the source tree if available
@@ -252,13 +253,27 @@ class Test(object):
         """ Clean up the host after executing a test """
 
         if self.stonith_process:
-            self.stonith_process.terminate()
-            self.stonith_process.wait()
+            if self.stonith_process.poll() == None:
+                self.stonith_process.terminate()
+                self.stonith_process.wait()
+            else:
+                return_code = {
+                    getattr(signal, _signame): _signame
+                        for _signame in dir(signal)
+                        if _signame.startswith('SIG') and not _signame.startswith("SIG_")
+                }.get(-self.stonith_process.returncode, "RET=%d" % (self.stonith_process.returncode))
+                msg = "FAILURE - '%s' failed. pacemaker-fenced abnormally exited during test (%s)."
+                self.result_txt = msg % (self.name, return_code)
+                self.result_exitcode = CrmExit.ERROR
 
         self.stonith_output = ""
         self.stonith_process = None
 
-        logfile = io.open('/tmp/stonith-regression.log', 'rt')
+        # the default for utf-8 encoding would error out if e.g. memory corruption
+        # makes fenced output any kind of 8 bit value - while still interesting
+        # for debugging and we'd still like the regression-test to go over the
+        # full set of test-cases
+        logfile = io.open('/tmp/stonith-regression.log', 'rt', encoding = "ISO-8859-1")
         for line in logfile.readlines():
             self.stonith_output = self.stonith_output + line
 

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -109,6 +109,7 @@ typedef struct async_command_s {
     int last_timeout_signo;
 
     stonith_device_t *active_on;
+    stonith_device_t *activating_on;
 } async_command_t;
 
 static xmlNode *stonith_construct_async_reply(async_command_t * cmd, const char *output,
@@ -303,6 +304,19 @@ get_active_cmds(stonith_device_t * device)
     return counter;
 }
 
+static void
+fork_cb(GPid pid, gpointer user_data)
+{
+    async_command_t *cmd = (async_command_t *) user_data;
+    stonith_device_t * device = cmd->activating_on;
+
+    crm_debug("Operation %s%s%s on %s now running with pid=%d, timeout=%ds",
+                  cmd->action, cmd->victim ? " for node " : "", cmd->victim ? cmd->victim : "",
+                  device->id, pid, cmd->timeout);
+    cmd->active_on = device;
+    cmd->activating_on = NULL;
+}
+
 static gboolean
 stonith_device_execute(stonith_device_t * device)
 {
@@ -389,19 +403,17 @@ stonith_device_execute(stonith_device_t * device)
                                    cmd->victim_nodeid,
                                    cmd->timeout, device->params, device->aliases);
 
-    /* for async exec, exec_rc is pid if positive and error code if negative/zero */
-    exec_rc = stonith_action_execute_async(action, (void *)cmd, cmd->done_cb);
+    /* for async exec, exec_rc is negative for early error exit
+       otherwise handling of success/errors is done via callbacks */
+    cmd->activating_on = device;
+    exec_rc = stonith_action_execute_async(action, (void *)cmd,
+                                           cmd->done_cb, fork_cb);
 
-    if (exec_rc > 0) {
-        crm_debug("Operation %s%s%s on %s now running with pid=%d, timeout=%ds",
-                  cmd->action, cmd->victim ? " for node " : "", cmd->victim ? cmd->victim : "",
-                  device->id, exec_rc, cmd->timeout);
-        cmd->active_on = device;
-
-    } else {
+    if (exec_rc < 0) {
         crm_warn("Operation %s%s%s on %s failed: %s (%d)",
                  cmd->action, cmd->victim ? " for node " : "", cmd->victim ? cmd->victim : "",
                  device->id, pcmk_strerror(exec_rc), exec_rc);
+        cmd->activating_on = NULL;
         cmd->done_cb(0, exec_rc, NULL, cmd);
     }
     return TRUE;

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -26,11 +26,12 @@ void stonith__destroy_action(stonith_action_t *action);
 void stonith__action_result(stonith_action_t *action, int *rc, char **output,
                             char **error_output);
 
-GPid
+int
 stonith_action_execute_async(stonith_action_t * action,
                              void *userdata,
                              void (*done) (GPid pid, int rc, const char *output,
-                                           gpointer user_data));
+                                           gpointer user_data),
+                             void (*fork_cb) (GPid pid, gpointer user_data));
 
 int stonith__execute(stonith_action_t *action);
 

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -43,6 +43,7 @@ struct stonith_action_s {
     int async;
     void *userdata;
     void (*done_cb) (GPid pid, gint status, const char *output, gpointer user_data);
+    void (*fork_cb) (GPid pid, gpointer user_data);
 
     svc_action_t *svc_action;
 
@@ -728,6 +729,10 @@ stonith_action_async_forked(svc_action_t *svc_action)
     action->pid = svc_action->pid;
     action->svc_action = svc_action;
 
+    if (action->fork_cb) {
+        (action->fork_cb) (svc_action->pid, action->userdata);
+    }
+
     crm_trace("Child process %d performing action '%s' successfully forked",
               action->pid, action->action);
 }
@@ -809,25 +814,34 @@ internal_stonith_action_execute(stonith_action_t * action)
     return rc;
 }
 
-GPid
+/*!
+ * \internal
+ * \brief Kick off execution of an async stonith action
+ *
+ * \param[in,out] action        Action to be executed
+ * \param[in,out] userdata      Datapointer to be passed to callbacks
+ * \param[in]     done          Callback to notify action has failed/succeeded
+ * \param[in]     fork_callback Callback to notify successful fork of child
+ *
+ * \return pcmk_ok if ownership of action has been taken, -errno otherwise
+ */
+int
 stonith_action_execute_async(stonith_action_t * action,
                              void *userdata,
                              void (*done) (GPid pid, int rc, const char *output,
-                                           gpointer user_data))
+                                           gpointer user_data),
+                             void (*fork_cb) (GPid pid, gpointer user_data))
 {
-    int rc = 0;
-
     if (!action) {
         return -1;
     }
 
     action->userdata = userdata;
     action->done_cb = done;
+    action->fork_cb = fork_cb;
     action->async = 1;
 
-    rc = internal_stonith_action_execute(action);
-
-    return rc < 0 ? rc : action->pid;
+    return internal_stonith_action_execute(action);
 }
 
 /*!


### PR DESCRIPTION
Bailing out in case of non-existant fence-agent is such a case.
