### PR TITLE
Mid: fenced: If fencing succeeds, clear the failed history.

### DIFF
--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -417,6 +417,11 @@ handle_local_reply_and_notify(remote_fencing_op_t * op, xmlNode * data, int rc)
     do_stonith_notify(0, T_STONITH_NOTIFY_FENCE, rc, notify_data);
     do_stonith_notify(0, T_STONITH_NOTIFY_HISTORY, 0, NULL);
 
+    if (rc == pcmk_ok) {
+        /* If fencing succeeds, clear the failed history. */
+        stonith_fence_history_cleanup(op->target, TRUE, TRUE);
+    }
+
     /* mark this op as having notify's already sent */
     op->notify_sent = TRUE;
     free_xml(reply);

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -235,6 +235,8 @@ void *create_remote_stonith_op(const char *client, xmlNode * request, gboolean p
 int stonith_fence_history(xmlNode *msg, xmlNode **output,
                           const char *remote_peer, int options);
 
+void stonith_fence_history_cleanup(const char *target, gboolean broadcast, gboolean only_failed);
+
 void stonith_fence_history_trim(void);
 
 bool fencing_peer_active(crm_node_t *peer);

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -60,6 +60,8 @@ enum stonith_call_options {
     st_opt_cleanup         = 0x000080000,
     /* used where ever apropriate - e.g. send out a history query to all nodes */
     st_opt_broadcast       = 0x000100000,
+    /* used where ever apropriate - e.g. cleanup of failed history */
+    st_opt_cleanup_only_failed = 0x001000000,
 };
 
 /*! Order matters here, do not change values */


### PR DESCRIPTION
Hi All,

In Pacemaker 1.1.20 or later, the history function of fencing is added and it is displayed by default in crm_mon if it fails.(The default option of crm_mon is the same as the -m1 option.)

```
[root@rh76hv-02 ~]# crm_mon -1 -Af
Stack: corosync
Current DC: rh76hv-02 (version 2.0.2-2e6ed0773f) - partition WITHOUT quorum
Last updated: Wed May 22 08:34:59 2019
Last change: Wed May 22 08:33:41 2019 by root via cibadmin on rh76hv-01

3 nodes configured
3 resources configured

Node rh76hv-01: UNCLEAN (offline)
Online: [ rh76hv-02 ]
OFFLINE: [ rh76hv-03 ]

Active resources:

 prmDummy       (ocf::heartbeat:Dummy): Started rh76hv-01 (UNCLEAN)
 Resource Group: grpStonith1
     prmStonith1-2      (stonith:external/ssh): Started rh76hv-02
 Resource Group: grpStonith2
     prmStonith2-2      (stonith:external/ssh): Started rh76hv-01 (UNCLEAN)

Node Attributes:
* Node rh76hv-02:

Migration Summary:
* Node rh76hv-02:

Failed Fencing Actions:
* reboot of rh76hv-01 failed: delegate=rh76hv-02, client=pacemaker-controld.122691, origin=rh76hv-02,
    last-failed='Wed May 22 08:34:54 2019'

```

The display of crm_mon can only be cleared with the stonith_admin -c command.


If fencing fails, it will remain visible even if fencing succeeds.

```
[root@rh76hv-02 ~]# crm_mon -1 -Af
Stack: corosync
Current DC: rh76hv-02 (version 2.0.2-2e6ed0773f) - partition WITHOUT quorum
Last updated: Wed May 22 08:30:24 2019
Last change: Wed May 22 08:27:56 2019 by root via cibadmin on rh76hv-01

3 nodes configured
3 resources configured

Online: [ rh76hv-02 ]
OFFLINE: [ rh76hv-01 rh76hv-03 ]

Active resources:

 prmDummy       (ocf::heartbeat:Dummy): Started rh76hv-02
 Resource Group: grpStonith1
     prmStonith1-2      (stonith:external/ssh): Started rh76hv-02

Node Attributes:
* Node rh76hv-02:

Migration Summary:
* Node rh76hv-02:

Failed Fencing Actions:
* reboot of rh76hv-01 failed: delegate=rh76hv-02, client=pacemaker-controld.121938, origin=rh76hv-02,
    last-failed='Wed May 22 08:29:50 2019'
```


This can be confusing to users.
I think it is better to clear the history of fencing that failed when fencing is successful.


This PR clears the history of failed fencing when fencing is successful.
Other history will remain, so it needs to be cleared with stonith_admin command.

```
[root@rh76hv-02 ~]# crm_mon -1 -Af
Stack: corosync
Current DC: rh76hv-02 (version 2.0.2-c20e92d638) - partition WITHOUT quorum
Last updated: Wed May 22 08:40:54 2019
Last change: Wed May 22 08:39:17 2019 by root via cibadmin on rh76hv-01

3 nodes configured
3 resources configured

Online: [ rh76hv-02 ]
OFFLINE: [ rh76hv-01 rh76hv-03 ]

Active resources:

 prmDummy       (ocf::heartbeat:Dummy): Started rh76hv-02
 Resource Group: grpStonith1
     prmStonith1-2      (stonith:external/ssh): Started rh76hv-02

Node Attributes:
* Node rh76hv-02:

Migration Summary:
* Node rh76hv-02:

[root@rh76hv-02 ~]# crm_mon -1 -Af -m2
Stack: corosync
Current DC: rh76hv-02 (version 2.0.2-c20e92d638) - partition WITHOUT quorum
Last updated: Wed May 22 08:41:07 2019
Last change: Wed May 22 08:39:17 2019 by root via cibadmin on rh76hv-01

3 nodes configured
3 resources configured

Online: [ rh76hv-02 ]
OFFLINE: [ rh76hv-01 rh76hv-03 ]

Active resources:

 prmDummy       (ocf::heartbeat:Dummy): Started rh76hv-02
 Resource Group: grpStonith1
     prmStonith1-2      (stonith:external/ssh): Started rh76hv-02

Node Attributes:
* Node rh76hv-02:

Migration Summary:
* Node rh76hv-02:

Fencing History:
* reboot of rh76hv-01 successful: delegate=rh76hv-02, client=pacemaker-controld.24497, origin=rh76hv-02,
    last-successful='Wed May 22 08:40:50 2019'
[root@rh76hv-02 ~]# crm_mon -1 -Af -m3
Stack: corosync
Current DC: rh76hv-02 (version 2.0.2-c20e92d638) - partition WITHOUT quorum
Last updated: Wed May 22 08:41:08 2019
Last change: Wed May 22 08:39:17 2019 by root via cibadmin on rh76hv-01

3 nodes configured
3 resources configured

Online: [ rh76hv-02 ]
OFFLINE: [ rh76hv-01 rh76hv-03 ]

Active resources:

 prmDummy       (ocf::heartbeat:Dummy): Started rh76hv-02
 Resource Group: grpStonith1
     prmStonith1-2      (stonith:external/ssh): Started rh76hv-02

Node Attributes:
* Node rh76hv-02:

Migration Summary:
* Node rh76hv-02:

Fencing History:
* reboot of rh76hv-01 successful: delegate=rh76hv-02, client=pacemaker-controld.24497, origin=rh76hv-02,
    completed='Wed May 22 08:40:50 2019'

```

Best Regards,
Hideo Yamauchi.