### PR TITLE
Build: spec: fix redundantly carried /usr/share/pacemaker/api/ files

### DIFF
--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -724,11 +724,10 @@ exit 0
 %{_sbindir}/crm_report
 %{_sbindir}/crm_ticket
 %{_sbindir}/stonith_admin
-%exclude %{_datadir}/pacemaker/alerts
-%exclude %{_datadir}/pacemaker/tests
-%{_datadir}/pacemaker
-%exclude %{_datadir}/pacemaker/*.rng
-%exclude %{_datadir}/pacemaker/*.xsl
+# "dirname" is owned by -schemas, which is a prerequisite
+%{_datadir}/pacemaker/report.collector
+%{_datadir}/pacemaker/report.common
+# XXX "dirname" is not owned by any prerequisite
 %{_datadir}/snmp/mibs/PCMK-MIB.txt
 
 %exclude /usr/lib/ocf/resource.d/pacemaker/controld
@@ -831,9 +830,10 @@ exit 0
 
 %files schemas
 %license licenses/GPLv2
+%dir %{_datadir}/pacemaker
 %{_datadir}/pacemaker/*.rng
 %{_datadir}/pacemaker/*.xsl
-%{_datadir}/pacemaker/api/*.rng
+%{_datadir}/pacemaker/api
 
 %changelog
 


### PR DESCRIPTION
These would be delivered (co-owned in practice) with both -cli & -libs
and since the former cannot exist without the latter and since -cli
doesn't make any direct references to the particular new API schemas
anyway (judging per "Use formatted output in stonith_admin" commit),
just follow standard "include here, exclude-but-parent" there pattern.