### PR TITLE
Mid: crm_mon: If fencing succeeds, do not display the old failed action.

### DIFF
--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -105,6 +105,7 @@ typedef struct stonith_history_s {
     int state;
     time_t completed;
     struct stonith_history_s *next;
+    gboolean ignore_old_failed;
 } stonith_history_t;
 
 typedef struct stonith_s stonith_t;


### PR DESCRIPTION
Hi All,

This fix suppresses the failure action display of completed fencing actions that cause user confusion.
The m3 option will show everything.

This was previously discussed in the next PR, but in order to throw away the complexity of the source, it has been changed to a simple flag manipulation modification.
 - https://github.com/ClusterLabs/pacemaker/pull/1785

Our users were using 1.1.20 and were confused by this display.
If possible, I would like this correction to be included in 1.1.21.

@clumens: I heard that you are modifying crm_mon. This fix may require your review.

Best Regards,
Hideo Yamauchi.