### PR TITLE
Log: Fix the problem that environment variable is not set when using default value of log file

### DIFF
--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -241,6 +241,7 @@ crm_add_logfile(const char *filename)
 
     if (filename == NULL && have_logfile == FALSE) {
         filename = default_logfile;
+        set_daemon_option("logfile", filename);
     }
 
     if (filename == NULL) {


### PR DESCRIPTION
Hi!
I tried to make a fix for the problem I raised below.
https://lists.clusterlabs.org/pipermail/users/2019-May/02252.3.html