### PR TITLE
Low: pacemaker-based: defer to fully customizable PAM service config

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,7 @@ CORE_INSTALL	= replace include lib daemons tools xml
 # Only these will get built with a plain "make" or "make clean"
 CORE		= $(CORE_INSTALL) cts
 
-SUBDIRS	= $(CORE) doc extra maint
+SUBDIRS	= $(CORE) data doc extra maint
 
 AM_CPPFLAGS		= -I$(top_srcdir)/include
 

--- a/configure.ac
+++ b/configure.ac
@@ -1444,6 +1444,8 @@ dnl    PAM
 dnl ========================================================================
 
 AC_CHECK_HEADERS(security/pam_appl.h pam/pam_appl.h)
+AM_CONDITIONAL([HAVE_PAM], [test $HAVE_SECURITY_PAM_APPL_H = 1
+                            || test $HAVE_PAM_PAM_APPL_H = 1])
 
 dnl ========================================================================
 dnl    System Health
@@ -1806,6 +1808,7 @@ AC_CONFIG_FILES(Makefile                                            \
                 daemons/pacemakerd/pacemaker.upstart                \
                 daemons/pacemakerd/pacemaker.combined.upstart       \
                 daemons/schedulerd/Makefile                         \
+                data/Makefile                                       \
                 doc/Doxyfile                                        \
                 doc/Makefile                                        \
                 doc/Clusters_from_Scratch/publican.cfg              \

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -636,7 +636,7 @@ authenticate_user(const char *user, const char *passwd)
         pam_name = getenv("CIB_pam_service");
     }
     if (pam_name == NULL) {
-        pam_name = "login";
+        pam_name = "pacemaker-base";
     }
 
     p_conv.conv = construct_pam_passwd;

--- a/data/pam.d/pacemaker-base
+++ b/data/pam.d/pacemaker-base
@@ -1,0 +1,3 @@
+%PAM-1.0
+auth       include  password-auth
+account    include  password-auth

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -693,6 +693,8 @@ exit 0
 %config(noreplace) %{_sysconfdir}/init/pacemaker.combined.conf
 %endif
 
+%config(noreplace) %{_sysconfdir}/pam.d/pacemaker-base
+
 %files cli
 %dir %attr (750, root, %{gname}) %{_sysconfdir}/pacemaker
 %config(noreplace) %{_sysconfdir}/logrotate.d/pacemaker


### PR DESCRIPTION
This would be great to squeeze into 2.0.2 since some more follow-up
work is very likely to arrive at later stage for new requested features,
so that the evolution is seemless.

I need to check the general sanity of this patch, yet, will signal
when sufficiently tested (function, portability, packaging).

* * *

This affords us (but also the users) some wiggle space for customization
going forwards.  It deliberately points to the more global configuration
shipped with PAM stack that is in particular to deal with password-based
authentication (presumably pam_unix.so plays the key role there, so that
standard local user dataset gets used, which is exactly what we want,
since that's in-line with the other check pertaining the same "user"
at hand, that is, whether such user belongs to the "haclient" group
per the counterpart local dataset[*]).

[*] note that it woud be quite a stretch when totally disjoint sets
    (as allowed with PAM) were examined using the same user identifier
    as a key, since no overlap/correlation is guranteed then