### PR TITLE
[1.1] Fix: controller: confirm cancel of failed monitors

### DIFF
--- a/crmd/crmd_utils.h
+++ b/crmd/crmd_utils.h
@@ -112,6 +112,8 @@ void crmd_peer_down(crm_node_t *peer, bool full);
 unsigned int cib_op_timeout(void);
 bool controld_action_is_recordable(const char *action);
 
+const char *get_node_id(xmlNode *lrm_rsc_op);
+
 /* Convenience macro for registering a CIB callback
  * (assumes that data can be freed with free())
  */

--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -2487,6 +2487,30 @@ unescape_newlines(const char *string)
     return ret;
 }
 
+static bool
+did_lrm_rsc_op_fail(lrm_state_t *lrm_state, const char * rsc_id,
+                    const char * op_type, guint interval_ms)
+{
+    rsc_history_t *entry = NULL;
+
+    CRM_CHECK(lrm_state != NULL, return FALSE);
+    CRM_CHECK(rsc_id != NULL, return FALSE);
+    CRM_CHECK(op_type != NULL, return FALSE);
+
+    entry = g_hash_table_lookup(lrm_state->resource_history, rsc_id);
+    if (entry == NULL || entry->failed == NULL) {
+        return FALSE;
+    }
+
+    if (crm_str_eq(entry->failed->rsc_id, rsc_id, TRUE)
+        && safe_str_eq(entry->failed->op_type, op_type)
+        && entry->failed->interval == interval_ms) {
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
 void
 process_lrm_event(lrm_state_t *lrm_state, lrmd_event_data_t *op,
                   struct recurring_op_s *pending, xmlNode *action_xml)
@@ -2614,6 +2638,20 @@ process_lrm_event(lrm_state_t *lrm_state, lrmd_event_data_t *op,
          */
         if (lrm_state) {
             erase_lrm_history_by_op(lrm_state, op);
+        }
+
+        /* If the recurring operation had failed, the lrm_rsc_op is recorded as
+         * "last_failure" which won't get erased from the cib given the logic on
+         * purpose in erase_lrm_history_by_op(). So that the cancel action won't
+         * have a chance to get confirmed by DC with process_op_deletion().
+         * Cluster transition would get stuck waiting for the remaining action
+         * timer to time out.
+         *
+         * Directly acknowledge the cancel operation in this case.
+         */
+        if (did_lrm_rsc_op_fail(lrm_state, pending->rsc_id,
+                                pending->op_type, pending->interval)) {
+            need_direct_ack = TRUE;
         }
 
     } else if (op->rsc_deleted) {

--- a/crmd/te_callbacks.c
+++ b/crmd/te_callbacks.c
@@ -42,19 +42,6 @@ static unsigned long int stonith_max_attempts = 10;
 /* #define rsc_op_template "//"XML_TAG_DIFF_ADDED"//"XML_TAG_CIB"//"XML_CIB_TAG_STATE"[@uname='%s']"//"XML_LRM_TAG_RSC_OP"[@id='%s]" */
 #define rsc_op_template "//"XML_TAG_DIFF_ADDED"//"XML_TAG_CIB"//"XML_LRM_TAG_RSC_OP"[@id='%s']"
 
-static const char *
-get_node_id(xmlNode * rsc_op)
-{
-    xmlNode *node = rsc_op;
-
-    while (node != NULL && safe_str_neq(XML_CIB_TAG_STATE, TYPE(node))) {
-        node = node->parent;
-    }
-
-    CRM_CHECK(node != NULL, return NULL);
-    return ID(node);
-}
-
 void
 update_stonith_max_attempts(const char* value)
 {
@@ -384,12 +371,8 @@ process_op_deletion(const char *xpath, xmlNode *change)
     node_uuid = extract_node_uuid(xpath);
     cancel = get_cancel_action(key, node_uuid);
     if (cancel) {
-        crm_info("Cancellation of %s on %s confirmed (%d)",
-                 key, node_uuid, cancel->id);
-        stop_te_timer(cancel->timer);
-        te_action_confirmed(cancel);
-        update_graph(transition_graph, cancel);
-        trigger_graph();
+        confirm_cancel_action(cancel);
+
     } else {
         abort_transition(INFINITY, tg_restart, "Resource operation removal",
                          change);

--- a/crmd/te_events.c
+++ b/crmd/te_events.c
@@ -373,6 +373,27 @@ get_cancel_action(const char *id, const char *node)
     return NULL;
 }
 
+void
+confirm_cancel_action(crm_action_t *cancel)
+{
+    const char *op_key = NULL;
+    const char *node_name = NULL;
+
+    CRM_ASSERT(cancel != NULL);
+
+    op_key = crm_element_value(cancel->xml, XML_LRM_ATTR_TASK_KEY);
+    node_name = crm_element_value(cancel->xml, XML_LRM_ATTR_TARGET);
+
+    stop_te_timer(cancel->timer);
+    te_action_confirmed(cancel);
+    update_graph(transition_graph, cancel);
+
+    crm_info("Cancellation of %s on %s confirmed (action %d)",
+             op_key, node_name, cancel->id);
+
+    trigger_graph();
+}
+
 /* downed nodes are listed like: <downed> <node id="UUID1" /> ... </downed> */
 #define XPATH_DOWNED "//" XML_GRAPH_TAG_DOWNED \
                      "/" XML_CIB_TAG_NODE "[@" XML_ATTR_UUID "='%s']"
@@ -493,6 +514,17 @@ process_graph_event(xmlNode *event, const char *event_node)
             /* Recurring actions have the transition number they were first
              * scheduled in.
              */
+
+            if (status == PCMK_LRM_OP_CANCELLED) {
+                const char *node_id = get_node_id(event);
+
+                action = get_cancel_action(id, node_id);
+                if (action) {
+                    confirm_cancel_action(action);
+                }
+                goto bail;
+            }
+
             desc = "arrived after initial scheduling";
             abort_transition(INFINITY, tg_restart, "Change in recurring result",
                              event);

--- a/crmd/tengine.h
+++ b/crmd/tengine.h
@@ -35,6 +35,7 @@ void execute_stonith_cleanup(void);
 /* tengine */
 extern crm_action_t *match_down_event(const char *target, bool quiet);
 extern crm_action_t *get_cancel_action(const char *id, const char *node);
+void confirm_cancel_action(crm_action_t *cancel);
 
 void controld_record_action_timeout(crm_action_t *action);
 extern gboolean fail_incompletable_actions(crm_graph_t * graph, const char *down_node);

--- a/crmd/utils.c
+++ b/crmd/utils.c
@@ -1054,3 +1054,16 @@ cib_op_timeout()
     }
     return calculated_timeout;
 }
+
+const char *
+get_node_id(xmlNode *lrm_rsc_op)
+{
+    xmlNode *node = lrm_rsc_op;
+
+    while (node != NULL && safe_str_neq(XML_CIB_TAG_STATE, TYPE(node))) {
+        node = node->parent;
+    }
+
+    CRM_CHECK(node != NULL, return NULL);
+    return ID(node);
+}


### PR DESCRIPTION
Backports of https://github.com/ClusterLabs/pacemaker/commit/4f0399336d47162035fde6d0d23077bfd8ae4119 and https://github.com/ClusterLabs/pacemaker/pull/1772 for 1.1 branch.