### PR TITLE
Fix: libpe_status: allow bundle /var/log to work with SELinux

### DIFF
--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -50,6 +50,7 @@ extern "C" {
  *           XML v2 patchsets are created by default
  * >=3.0.13: Fail counts include operation name and interval
  * >=3.2.0:  DC supports PCMK_LRM_OP_INVALID and PCMK_LRM_OP_NOT_CONNECTED
+ *           Docker and podman bundles get "Z" added to implicit /var/log mounts
  */
 #  define CRM_FEATURE_SET		"3.2.0"
 


### PR DESCRIPTION
Local SELinux policies may prevent processes running in a bundle's container
from reading or writing the mount pacemaker provides for the bundle's /var/log.
The solution (at least for Docker and podman, which support it) is to pass the
"Z" mount option, which causes the container launcher to create a custom
SELinux context for the mount and container.

This bumps the CRM feature set since older DCs will create the implicit
resource with different parameters. The newer code will not add the "Z" unless
the DC supports it, to avoid e.g. crm_simulate or crm_resource --wait giving
different results depending on the node.

Note that this causes the definition of the implicit container resource to
change once all nodes in the cluster are upgraded, which means that all active
bundles will restart. There is no practical way around that.