### PR TITLE
Fix: fence-history: resync fence-history after fenced crash

### DIFF
--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -347,6 +347,21 @@ stonith_merge_in_history_list(GHashTable *history)
 
         updated = TRUE;
         g_hash_table_iter_steal(&iter);
+
+        if ((op->state != st_failed) &&
+            (op->state != st_done) &&
+            safe_str_eq(op->originator, stonith_our_uname)) {
+            crm_warn("received pending action we are supposed to be the "
+                     "owner but it's not in our records -> fail it");
+            op->state = st_failed;
+            op->completed = time(NULL);
+            /* use -EHOSTUNREACH to not introduce a new return-code that might
+               trigger unexpected results at other places and to prevent
+               remote_op_done from setting the delegate if not present
+             */
+            stonith_bcast_result_to_peers(op, -EHOSTUNREACH);
+        }
+
         g_hash_table_insert(stonith_remote_op_list, op->id, op);
         /* we could trim the history here but if we bail
          * out after trim we might miss more recent entries

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -369,8 +369,8 @@ create_op_done_notify(remote_fencing_op_t * op, int rc)
     return notify_data;
 }
 
-static void
-bcast_result_to_peers(remote_fencing_op_t * op, int rc)
+void
+stonith_bcast_result_to_peers(remote_fencing_op_t * op, int rc)
 {
     static int count = 0;
     xmlNode *bcast = create_xml_node(NULL, T_STONITH_REPLY);
@@ -509,7 +509,7 @@ remote_op_done(remote_fencing_op_t * op, xmlNode * data, int rc, int dup)
     subt = crm_element_value(data, F_SUBTYPE);
     if (dup == FALSE && safe_str_neq(subt, "broadcast")) {
         /* Defer notification until the bcast message arrives */
-        bcast_result_to_peers(op, rc);
+        stonith_bcast_result_to_peers(op, rc);
         goto remote_op_done_cleanup;
     }
 

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -149,6 +149,14 @@ typedef struct remote_fencing_op_s {
 
 } remote_fencing_op_t;
 
+/*!
+ * \internal
+ * \brief Broadcast the result of an operation to the peers.
+ * \param op, Operation whose result should be broadcast
+ * \param rc, Result of the operation
+ */
+void stonith_bcast_result_to_peers(remote_fencing_op_t * op, int rc);
+
 enum st_callback_flags {
     st_callback_unknown        = 0x0000,
     st_callback_notify_fence   = 0x0001,


### PR DESCRIPTION
Fence-history handling after a restart of fenced after e.g. a segfault isn't working properly:

- usually DC is triggering a fence-history-sync when a new node appears
  Just restarting fenced of course doesn't trigger that mechanism leaving the newly started fenced
  with an empty history till something else triggers a history-sync or some new history comes in.
- when a fence-action was pending in the node that restarted fenced it stays in pending-state and
  never times out or anything. It even isn't possible to purge it using stonith_admin

The patch for the 2nd bullet-item checks, when getting history-sync data, if there are pending actions that seem to originate from the node itself. If the node doesn't have it in its own list it makes the action fail and distributes that info to the other nodes.
Like this, after all nodes are upgrades all lingering pending-actions should be converted into failed actions if every node takes care of the pending actions that were originally coming from it.
Thus a further possibility to clean pending-actions via stonith_admin seems not to be necessary (given it would be quite dangerous as the pending actions in the list where the history is stored otherwise do influence fencing-behavior).

Don't merge it is against 2.0-branch as we aren't in rc-state. I'll create a PR against master once
both items are taken care of. Just for discussion for now ...