### PR TITLE
Improve the log level to output the log required for the user.

### DIFF
--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -865,8 +865,8 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
         free_xml(sync);
 
     } else if (safe_str_neq(v->current, value)) {
-        crm_info("Setting %s[%s]: %s -> %s from %s",
-                 attr, host, v->current, value, peer->uname);
+        crm_notice("Setting %s[%s]: %s -> %s " CRM_XS " from %s",
+                   attr, host, v->current? v->current : "(unset)", value? value : "(unset)", peer->uname);
         free(v->current);
         v->current = (value? strdup(value) : NULL);
         a->changed = TRUE;

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -2697,8 +2697,7 @@ process_lrm_event(lrm_state_t *lrm_state, lrmd_event_data_t *op,
             break;
 
         case PCMK_LRM_OP_DONE:
-            do_crm_log((op->interval_ms? LOG_INFO : LOG_NOTICE),
-                       "Result of %s operation for %s on %s: %d (%s) "
+            crm_notice("Result of %s operation for %s on %s: %d (%s) "
                        CRM_XS " call=%d key=%s confirmed=%s cib-update=%d",
                        crm_action_str(op->op_type, op->interval_ms),
                        op->rsc_id, node_name,

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1473,14 +1473,14 @@ call_remote_stonith(remote_fencing_op_t * op, st_query_result_t * peer)
         if (device) {
             timeout_one = TIMEOUT_MULTIPLY_FACTOR *
                           get_device_timeout(op, peer, device);
-            crm_info("Requesting that '%s' perform op '%s %s' with '%s' for %s (%ds)", peer->host,
+            crm_notice("Requesting that '%s' perform op '%s %s' with '%s' " CRM_XS " for %s (%ds)", peer->host,
                      op->target, op->action, device, op->client_name, timeout_one);
             crm_xml_add(remote_op, F_STONITH_DEVICE, device);
             crm_xml_add(remote_op, F_STONITH_MODE, "slave");
 
         } else {
             timeout_one = TIMEOUT_MULTIPLY_FACTOR * get_peer_timeout(op, peer);
-            crm_info("Requesting that '%s' perform op '%s %s' for %s (%ds, %lds)",
+            crm_notice("Requesting that '%s' perform op '%s %s' " CRM_XS " for %s (%ds, %lds)",
                      peer->host, op->target, op->action, op->client_name, timeout_one, stonith_watchdog_timeout_ms);
             crm_xml_add(remote_op, F_STONITH_MODE, "smart");
 


### PR DESCRIPTION
We propose the following three log level improvements to output the necessary logs for the user.

1: Fix monitor's log to match other operation's log level
The log level of monitor is currently output as info and does not appear in syslog.
In this case, it is difficult to understand the movement of resources triggered by a monitor error.
By the way, even if you change this level, the log of the monitor that is repeatedly executed will not be output, so I think that the log will not become noisy.

2: Fix the log level when the node attribute changes to notice
Even if the attribute changes, it may trigger the move of the resource, so it is better to change it to notice level and notify the user.
Since this is also a log that is output only when the attribute changes, I think that the log will not become noisy.

3: Increase the log level of STONITH execution start to notice
Currently, the log when STONITH execution is completed is output as notice as shown below.
``
pacemaker-fenced [2000]: notice: Operation 'reboot' [16475] (call 3 from pacemaker-controld. 2006) for host 'srv02' with device 'fence-srv02' returned: 0 (OK)
``
It would be nice if this change could also output a log of the start and see it as a pair between start and completion.