### PR TITLE
Make stonith device probes fail after executor's stonith connection is lost

### DIFF
--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1016,18 +1016,7 @@ stonith_rc2status(const char *action, guint interval_ms, int rc)
 
         case -ENODEV:
             // The device is not registered with the fencer
-
-            if (safe_str_neq(action, "monitor")) {
-                status = PCMK_LRM_OP_ERROR;
-
-            } else if (interval_ms > 0) {
-                /* If we get here, the fencer somehow lost the registration of a
-                 * previously active device (possibly due to crash and respawn). In
-                 * that case, we need to indicate that the recurring monitor needs
-                 * to be cancelled.
-                 */
-                status = PCMK_LRM_OP_CANCELLED;
-            }
+            status = PCMK_LRM_OP_ERROR;
             break;
 
         default:

--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -1,5 +1,7 @@
 /*
- * Copyright 2012-2018 David Vossel <davidvossel@gmail.com>
+ * Copyright 2012-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -40,7 +42,7 @@ typedef struct lrmd_rsc_s {
      * that have been handed off from the pending ops list. */
     GList *recurring_ops;
 
-    int stonith_started;
+    int st_probe_rc; // What value should be returned for a probe if stonith
 
     crm_trigger_t *work;
 } lrmd_rsc_t;

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1457,6 +1457,9 @@ stonith_level_remove(xmlNode *msg, char **desc)
  * \param[out] output  Unused
  *
  * \return -EINPROGRESS on success, -errno otherwise
+ * \note If the action is monitor, the device must be registered via the API
+ *       (CIB registration is not sufficient), because monitor should not be
+ *       possible unless the device is "started" (API registered).
  */
 static int
 stonith_device_action(xmlNode * msg, char **output)
@@ -1476,7 +1479,10 @@ stonith_device_action(xmlNode * msg, char **output)
     }
 
     device = g_hash_table_lookup(device_list, id);
-    if ((device == NULL) || !device->api_registered) {
+    if ((device == NULL)
+        || (!device->api_registered && !strcmp(action, "monitor"))) {
+
+        // Monitors may run only on "started" (API-registered) devices
         crm_info("Ignoring API %s action request because device %s not found",
                  action, id);
         return -ENODEV;

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1445,38 +1445,50 @@ stonith_level_remove(xmlNode *msg, char **desc)
     return pcmk_ok;
 }
 
+/*!
+ * \internal
+ * \brief Schedule an (asynchronous) action directly on a stonith device
+ *
+ * Handle a STONITH_OP_EXEC API message by scheduling a requested agent action
+ * directly on a specified device. Only list, monitor, and status actions are
+ * expected to use this call, though it should work with any agent command.
+ *
+ * \param[in]  msg     API message XML with desired action
+ * \param[out] output  Unused
+ *
+ * \return -EINPROGRESS on success, -errno otherwise
+ */
 static int
 stonith_device_action(xmlNode * msg, char **output)
 {
-    int rc = pcmk_ok;
     xmlNode *dev = get_xpath_object("//" F_STONITH_DEVICE, msg, LOG_ERR);
+    xmlNode *op = get_xpath_object("//@" F_STONITH_ACTION, msg, LOG_ERR);
     const char *id = crm_element_value(dev, F_STONITH_DEVICE);
-
+    const char *action = crm_element_value(op, F_STONITH_ACTION);
     async_command_t *cmd = NULL;
     stonith_device_t *device = NULL;
 
-    if (id) {
-        crm_trace("Looking for '%s'", id);
-        device = g_hash_table_lookup(device_list, id);
+    if ((id == NULL) || (action == NULL)) {
+        crm_info("Malformed API action request: device %s, action %s",
+                 (id? id : "not specified"),
+                 (action? action : "not specified"));
+        return -EPROTO;
     }
 
-    if (device && device->api_registered == FALSE) {
-        rc = -ENODEV;
-
-    } else if (device) {
-        cmd = create_async_command(msg);
-        if (cmd == NULL) {
-            return -EPROTO;
-        }
-
-        schedule_stonith_command(cmd, device);
-        rc = -EINPROGRESS;
-
-    } else {
-        crm_info("Device %s not found", id ? id : "<none>");
-        rc = -ENODEV;
+    device = g_hash_table_lookup(device_list, id);
+    if ((device == NULL) || !device->api_registered) {
+        crm_info("Ignoring API %s action request because device %s not found",
+                 action, id);
+        return -ENODEV;
     }
-    return rc;
+
+    cmd = create_async_command(msg);
+    if (cmd == NULL) {
+        return -EPROTO;
+    }
+
+    schedule_stonith_command(cmd, device);
+    return -EINPROGRESS;
 }
 
 static void
@@ -2071,7 +2083,7 @@ st_child_done(GPid pid, int rc, const char *output, gpointer user_data)
     /* The device is ready to do something else now */
     device = g_hash_table_lookup(device_list, cmd->device);
     if (device) {
-        if (rc == pcmk_ok &&
+        if (!device->verified && (rc == pcmk_ok) &&
             (safe_str_eq(cmd->action, "list") ||
              safe_str_eq(cmd->action, "monitor") || safe_str_eq(cmd->action, "status"))) {
 


### PR DESCRIPTION
with a bit of other fencing improvements spurred by testing. Fixes CLBZ#5352.