### PR TITLE
Detect unresponsive scheduler

### DIFF
--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -260,7 +260,7 @@ crmd_exit(crm_exit_t exit_code)
     crm_timer_stop(recheck_timer);
 
     te_cleanup_stonith_history_sync(NULL, TRUE);
-    controld_sched_cleanup();
+    controld_free_sched_timer();
 
     free(transition_timer); transition_timer = NULL;
     free(integration_timer); integration_timer = NULL;

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -260,6 +260,7 @@ crmd_exit(crm_exit_t exit_code)
     crm_timer_stop(recheck_timer);
 
     te_cleanup_stonith_history_sync(NULL, TRUE);
+    controld_sched_cleanup();
 
     free(transition_timer); transition_timer = NULL;
     free(integration_timer); integration_timer = NULL;
@@ -277,7 +278,6 @@ crmd_exit(crm_exit_t exit_code)
     free(fsa_cluster_name); fsa_cluster_name = NULL;
 
     free(te_uuid); te_uuid = NULL;
-    free(fsa_pe_ref); fsa_pe_ref = NULL;
     free(failed_stop_offset); failed_stop_offset = NULL;
     free(failed_start_offset); failed_start_offset = NULL;
 

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -251,6 +251,7 @@ do_dc_release(long long action,
     if (action & A_DC_RELEASE) {
         crm_debug("Releasing the role of DC");
         clear_bit(fsa_input_register, R_THE_DC);
+        controld_expect_sched_reply(NULL);
 
     } else if (action & A_DC_RELEASED) {
         crm_info("DC role released");

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -1018,9 +1018,9 @@ handle_response(xmlNode * stored_msg)
         } else if (safe_str_eq(msg_ref, fsa_pe_ref)) {
             ha_msg_input_t fsa_input;
 
+            controld_stop_sched_timer();
             fsa_input.msg = stored_msg;
             register_fsa_input_later(C_IPC_MESSAGE, I_PE_SUCCESS, &fsa_input);
-            crm_trace("Completed: %s...", fsa_pe_ref);
 
         } else {
             crm_info("%s calculation %s is obsolete", op, msg_ref);

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -210,6 +212,36 @@ do_pe_control(long long action,
 int fsa_pe_query = 0;
 char *fsa_pe_ref = NULL;
 
+/*!
+ * \internal
+ * \brief Set the scheduler request currently being waited on
+ *
+ * \param[in] msg  Request to expect reply to (or NULL for none)
+ */
+void
+controld_expect_sched_reply(xmlNode *msg)
+{
+    char *ref = NULL;
+
+    if (msg) {
+        ref = crm_element_value_copy(msg, XML_ATTR_REFERENCE);
+        CRM_ASSERT(ref != NULL);
+    }
+    free(fsa_pe_ref);
+    fsa_pe_ref = ref;
+}
+
+/*!
+ * \internal
+ * \brief Clean up all memory used by controller scheduler handling
+ */
+void
+controld_sched_cleanup()
+{
+    pe_subsystem_free();
+    controld_expect_sched_reply(NULL);
+}
+
 /*	 A_PE_INVOKE	*/
 void
 do_pe_invoke(long long action,
@@ -254,10 +286,7 @@ do_pe_invoke(long long action,
     crm_debug("Query %d: Requesting the current CIB: %s", fsa_pe_query,
               fsa_state2string(fsa_state));
 
-    /* Make sure any queued calculations are discarded */
-    free(fsa_pe_ref);
-    fsa_pe_ref = NULL;
-
+    controld_expect_sched_reply(NULL);
     fsa_register_cib_callback(fsa_pe_query, FALSE, NULL, do_pe_invoke_callback);
 }
 
@@ -370,16 +399,15 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 
     cmd = create_request(CRM_OP_PECALC, output, NULL, CRM_SYSTEM_PENGINE, CRM_SYSTEM_DC, NULL);
 
-    free(fsa_pe_ref);
-    fsa_pe_ref = crm_element_value_copy(cmd, XML_ATTR_REFERENCE);
-
     rc = pe_subsystem_send(cmd);
     if (rc < 0) {
         crm_err("Could not contact the scheduler: %s " CRM_XS " rc=%d",
                 pcmk_strerror(rc), rc);
         register_fsa_error_adv(C_FSA_INTERNAL, I_ERROR, NULL, NULL, __FUNCTION__);
+    } else {
+        controld_expect_sched_reply(cmd);
+        crm_debug("Invoking the scheduler: query=%d, ref=%s, seq=%llu, quorate=%d",
+                  fsa_pe_query, fsa_pe_ref, crm_peer_seq, fsa_has_quorum);
     }
-    crm_debug("Invoking the scheduler: query=%d, ref=%s, seq=%llu, quorate=%d",
-              fsa_pe_query, fsa_pe_ref, crm_peer_seq, fsa_has_quorum);
     free_xml(cmd);
 }

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -30,6 +30,9 @@ static mainloop_io_t *pe_subsystem = NULL;
 void
 pe_subsystem_free(void)
 {
+    // If we aren't connected to the scheduler, we can't expect a reply
+    controld_expect_sched_reply(NULL);
+
     if (pe_subsystem) {
         mainloop_del_ipc_client(pe_subsystem);
         pe_subsystem = NULL;
@@ -282,17 +285,15 @@ controld_expect_sched_reply(xmlNode *msg)
 
 /*!
  * \internal
- * \brief Clean up all memory used by controller scheduler handling
+ * \brief Free the scheduler reply timer
  */
 void
-controld_sched_cleanup()
+controld_free_sched_timer()
 {
     if (controld_sched_timer != NULL) {
         mainloop_timer_del(controld_sched_timer);
         controld_sched_timer = NULL;
     }
-    pe_subsystem_free();
-    controld_expect_sched_reply(NULL);
 }
 
 /*	 A_PE_INVOKE	*/

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -165,10 +165,7 @@ abort_transition_graph(int abort_priority, enum transition_action abort_action,
     }
 
     abort_timer.aborted = TRUE;
-
-    /* Make sure any queued calculations are discarded ASAP */
-    free(fsa_pe_ref);
-    fsa_pe_ref = NULL;
+    controld_expect_sched_reply(NULL);
 
     if (transition_graph->complete == FALSE) {
         if(update_abort_priority(transition_graph, abort_priority, abort_action, abort_text)) {

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -62,6 +62,8 @@ gboolean is_timer_started(fsa_timer_t * timer);
 crm_exit_t crmd_exit(crm_exit_t exit_code);
 _Noreturn void crmd_fast_exit(crm_exit_t exit_code);
 void pe_subsystem_free(void);
+void controld_expect_sched_reply(xmlNode *msg);
+void controld_sched_cleanup(void);
 
 void fsa_dump_actions(long long action, const char *text);
 void fsa_dump_inputs(int log_level, const char *text, long long input_register);

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -62,6 +62,7 @@ gboolean is_timer_started(fsa_timer_t * timer);
 crm_exit_t crmd_exit(crm_exit_t exit_code);
 _Noreturn void crmd_fast_exit(crm_exit_t exit_code);
 void pe_subsystem_free(void);
+void controld_stop_sched_timer(void);
 void controld_expect_sched_reply(xmlNode *msg);
 void controld_sched_cleanup(void);
 

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -63,8 +63,8 @@ crm_exit_t crmd_exit(crm_exit_t exit_code);
 _Noreturn void crmd_fast_exit(crm_exit_t exit_code);
 void pe_subsystem_free(void);
 void controld_stop_sched_timer(void);
+void controld_free_sched_timer(void);
 void controld_expect_sched_reply(xmlNode *msg);
-void controld_sched_cleanup(void);
 
 void fsa_dump_actions(long long action, const char *text);
 void fsa_dump_inputs(int log_level, const char *text, long long input_register);


### PR DESCRIPTION
If the DC is able to successfully send a calculation request to the scheduler, but the scheduler never returns a result, the controller would previously not detect this, and the cluster would become blocked. Now, the DC fatally exits if the scheduler doesn't return a result within 2 minutes of a request.