### PR TITLE
Feature: pengine: formatted output for text

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -108,8 +108,11 @@ int pe__name_and_nvpairs_xml(pcmk__output_t *out, bool is_list, const char *tag_
                          , size_t pairs_count, ...);
 
 int pe__clone_xml(pcmk__output_t *out, va_list args);
+int pe__clone_text(pcmk__output_t *out, va_list args);
 int pe__bundle_xml(pcmk__output_t *out, va_list args);
+int pe__bundle_text(pcmk__output_t *out, va_list args);
 int pe__resource_xml(pcmk__output_t *out, va_list args);
+int pe__resource_text(pcmk__output_t *out, va_list args);
 
 void native_free(resource_t * rsc);
 void group_free(resource_t * rsc);
@@ -346,12 +349,15 @@ gboolean add_tag_ref(GHashTable * tags, const char * tag_name,  const char * obj
 
 void print_rscs_brief(GListPtr rsc_list, const char * pre_text, long options,
                       void * print_data, gboolean print_all);
+void pe__rscs_brief_output_text(pcmk__output_t *out, GListPtr rsc_list, const char *pre_text,
+                                long options, gboolean print_all);
 void pe_fence_node(pe_working_set_t * data_set, node_t * node, const char *reason);
 
 node_t *pe_create_node(const char *id, const char *uname, const char *type,
                        const char *score, pe_working_set_t * data_set);
 bool remote_id_conflict(const char *remote_name, pe_working_set_t *data);
 void common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options, void *print_data);
+void pe__common_output_text(pcmk__output_t *out, resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options);
 pe_resource_t *pe__find_bundle_replica(const pe_resource_t *bundle,
                                        const pe_node_t *node);
 bool pe__bundle_needs_remote_name(pe_resource_t *rsc);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -80,7 +80,7 @@ allocate_ip(pe__bundle_variant_data_t *data, pe__bundle_replica_t *replica,
 }
 
 static xmlNode *
-create_resource(const char *name, const char *provider, const char *kind) 
+create_resource(const char *name, const char *provider, const char *kind)
 {
     xmlNode *rsc = create_xml_node(NULL, XML_CIB_TAG_RESOURCE);
 
@@ -1535,6 +1535,85 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
     }
     pcmk__xml_pop_parent(out); // bundle
     return rc;
+}
+
+static void
+pe__bundle_replica_output_text(pcmk__output_t *out, pe__bundle_replica_t *replica,
+                               const char *pre_text, long options)
+{
+    node_t *node = NULL;
+    pe_resource_t *rsc = replica->child;
+
+    int offset = 0;
+    char buffer[LINE_MAX];
+
+    if(rsc == NULL) {
+        rsc = replica->container;
+    }
+
+    if (replica->remote) {
+        offset += snprintf(buffer + offset, LINE_MAX - offset, "%s",
+                           rsc_printable_id(replica->remote));
+    } else {
+        offset += snprintf(buffer + offset, LINE_MAX - offset, "%s",
+                           rsc_printable_id(replica->container));
+    }
+    if (replica->ipaddr) {
+        offset += snprintf(buffer + offset, LINE_MAX - offset, " (%s)",
+                           replica->ipaddr);
+    }
+
+    node = pe__current_node(replica->container);
+    pe__common_output_text(out, rsc, pre_text, buffer, node, options);
+}
+
+int
+pe__bundle_text(pcmk__output_t *out, va_list args)
+{
+    long options = va_arg(args, int);
+    resource_t *rsc = va_arg(args, resource_t *);
+    const char *pre_text = va_arg(args, char *);
+
+    pe__bundle_variant_data_t *bundle_data = NULL;
+    char *child_text = NULL;
+
+    CRM_ASSERT(rsc != NULL);
+
+    get_bundle_variant_data(bundle_data, rsc);
+
+    if (pre_text == NULL) {
+        pre_text = " ";
+    }
+
+    fprintf(out->dest, "%sContainer bundle%s: %s [%s]%s%s\n",
+            pre_text, ((bundle_data->nreplicas > 1)? " set" : ""),
+            rsc->id, bundle_data->image,
+            is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
+            is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
+
+    for (GList *gIter = bundle_data->replicas; gIter != NULL;
+         gIter = gIter->next) {
+        pe__bundle_replica_t *replica = gIter->data;
+
+        CRM_ASSERT(replica);
+
+        if (is_set(options, pe_print_implicit)) {
+            child_text = crm_strdup_printf("     %s", pre_text);
+            if(g_list_length(bundle_data->replicas) > 1) {
+                fprintf(out->dest, "  %sReplica[%d]\n", pre_text, replica->offset);
+            }
+
+            out->message(out, crm_element_name(replica->ip->xml), options, replica->ip, child_text);
+            out->message(out, crm_element_name(replica->child->xml), options, replica->child, child_text);
+            out->message(out, crm_element_name(replica->container->xml), options, replica->container, child_text);
+            out->message(out, crm_element_name(replica->remote->xml), options, replica->remote, child_text);
+        } else {
+            child_text = crm_strdup_printf("%s  ", pre_text);
+            pe__bundle_replica_output_text(out, replica, child_text, options);
+        }
+        free(child_text);
+    }
+    return 0;
 }
 
 static void

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -279,6 +279,24 @@ short_print(char *list, const char *prefix, const char *type, const char *suffix
     }
 }
 
+static void
+pe__short_output_text(pcmk__output_t *out, char *list, const char *prefix, const char *type, const char *suffix, long options)
+{
+    if(suffix == NULL) {
+        suffix = "";
+    }
+
+    if (list) {
+        fprintf(out->dest, "%s%s: [%s ]%s", prefix, type, list, suffix);
+
+        if (options & pe_print_suppres_nl) {
+            /* nothing */
+        } else {
+            fprintf(out->dest, "\n");
+        }
+    }
+}
+
 static const char *
 configured_role_str(resource_t * rsc)
 {
@@ -595,6 +613,193 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
     return rc;
 }
 
+int
+pe__clone_text(pcmk__output_t *out, va_list args)
+{
+    long options = va_arg(args, long);
+    resource_t *rsc = va_arg(args, resource_t *);
+    const char *pre_text = va_arg(args, char *);
+
+    char *list_text = NULL;
+    char *child_text = NULL;
+    char *stopped_list = NULL;
+
+    GListPtr master_list = NULL;
+    GListPtr started_list = NULL;
+    GListPtr gIter = rsc->children;
+
+    clone_variant_data_t *clone_data = NULL;
+    int active_instances = 0;
+
+    if (pre_text == NULL) {
+        pre_text = " ";
+    }
+
+    get_clone_variant_data(clone_data, rsc);
+
+    child_text = crm_concat(pre_text, "   ", ' ');
+
+    fprintf(out->dest, "%sClone Set: %s [%s]%s%s%s",
+            pre_text ? pre_text : "", rsc->id, ID(clone_data->xml_obj_child),
+            is_set(rsc->flags, pe_rsc_promotable) ? " (promotable)" : "",
+            is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
+            is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
+
+    for (; gIter != NULL; gIter = gIter->next) {
+        gboolean print_full = FALSE;
+        resource_t *child_rsc = (resource_t *) gIter->data;
+        gboolean partially_active = child_rsc->fns->active(child_rsc, FALSE);
+
+        if (options & pe_print_clone_details) {
+            print_full = TRUE;
+        }
+
+        if (is_set(rsc->flags, pe_rsc_unique)) {
+            // Print individual instance when unique (except stopped orphans)
+            if (partially_active || is_not_set(rsc->flags, pe_rsc_orphan)) {
+                print_full = TRUE;
+            }
+
+        // Everything else in this block is for anonymous clones
+
+        } else if (is_set(options, pe_print_pending)
+                   && (child_rsc->pending_task != NULL)
+                   && strcmp(child_rsc->pending_task, "probe")) {
+            // Print individual instance when non-probe action is pending
+            print_full = TRUE;
+
+        } else if (partially_active == FALSE) {
+            // List stopped instances when requested (except orphans)
+            if (is_not_set(child_rsc->flags, pe_rsc_orphan)
+                && is_not_set(options, pe_print_clone_active)) {
+                stopped_list = add_list_element(stopped_list, child_rsc->id);
+            }
+
+        } else if (is_set_recursive(child_rsc, pe_rsc_orphan, TRUE)
+                   || is_set_recursive(child_rsc, pe_rsc_managed, FALSE) == FALSE
+                   || is_set_recursive(child_rsc, pe_rsc_failed, TRUE)) {
+
+            // Print individual instance when active orphaned/unmanaged/failed
+            print_full = TRUE;
+
+        } else if (child_rsc->fns->active(child_rsc, TRUE)) {
+            // Instance of fully active anonymous clone
+
+            node_t *location = child_rsc->fns->location(child_rsc, NULL, TRUE);
+
+            if (location) {
+                // Instance is active on a single node
+
+                enum rsc_role_e a_role = child_rsc->fns->state(child_rsc, TRUE);
+
+                if (location->details->online == FALSE && location->details->unclean) {
+                    print_full = TRUE;
+
+                } else if (a_role > RSC_ROLE_SLAVE) {
+                    master_list = g_list_append(master_list, location);
+
+                } else {
+                    started_list = g_list_append(started_list, location);
+                }
+
+            } else {
+                /* uncolocated group - bleh */
+                print_full = TRUE;
+            }
+
+        } else {
+            // Instance of partially active anonymous clone
+            print_full = TRUE;
+        }
+
+        if (print_full) {
+            out->message(out, crm_element_name(child_rsc->xml), options, child_rsc, child_text);
+        }
+    }
+
+    /* Masters */
+    master_list = g_list_sort(master_list, sort_node_uname);
+    for (gIter = master_list; gIter; gIter = gIter->next) {
+        node_t *host = gIter->data;
+
+        list_text = add_list_element(list_text, host->details->uname);
+        active_instances++;
+    }
+
+    pe__short_output_text(out, list_text, child_text, "Masters", NULL, options);
+    g_list_free(master_list);
+    free(list_text);
+    list_text = NULL;
+
+    /* Started/Slaves */
+    started_list = g_list_sort(started_list, sort_node_uname);
+    for (gIter = started_list; gIter; gIter = gIter->next) {
+        node_t *host = gIter->data;
+
+        list_text = add_list_element(list_text, host->details->uname);
+        active_instances++;
+    }
+
+    if (is_set(rsc->flags, pe_rsc_promotable)) {
+        enum rsc_role_e role = configured_role(rsc);
+
+        if(role == RSC_ROLE_SLAVE) {
+            pe__short_output_text(out, list_text, child_text, "Slaves (target-role)", NULL, options);
+        } else {
+            pe__short_output_text(out, list_text, child_text, "Slaves", NULL, options);
+        }
+    } else {
+        pe__short_output_text(out, list_text, child_text, "Started", NULL, options);
+    }
+
+    g_list_free(started_list);
+    free(list_text);
+    list_text = NULL;
+
+    if (is_not_set(options, pe_print_clone_active)) {
+        const char *state = "Stopped";
+        enum rsc_role_e role = configured_role(rsc);
+
+        if (role == RSC_ROLE_STOPPED) {
+            state = "Stopped (disabled)";
+        }
+
+        if (is_not_set(rsc->flags, pe_rsc_unique)
+            && (clone_data->clone_max > active_instances)) {
+
+            GListPtr nIter;
+            GListPtr list = g_hash_table_get_values(rsc->allowed_nodes);
+
+            /* Custom stopped list for non-unique clones */
+            free(stopped_list);
+            stopped_list = NULL;
+
+            if (g_list_length(list) == 0) {
+                /* Clusters with symmetrical=false haven't calculated allowed_nodes yet
+                 * If we've not probed for them yet, the Stopped list will be empty
+                 */
+                list = g_hash_table_get_values(rsc->known_on);
+            }
+
+            list = g_list_sort(list, sort_node_uname);
+            for (nIter = list; nIter != NULL; nIter = nIter->next) {
+                node_t *node = (node_t *)nIter->data;
+
+                if (pe_find_node(rsc->running_on, node->details->uname) == NULL) {
+                    stopped_list = add_list_element(stopped_list, node->details->uname);
+                }
+            }
+            g_list_free(list);
+        }
+
+        pe__short_output_text(out, stopped_list, child_text, state, NULL, options);
+        free(stopped_list);
+    }
+
+    free(child_text);
+
+    return 0;
+}
 void
 clone_free(resource_t * rsc)
 {

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -13,7 +13,7 @@
 int
 pe__name_and_nvpairs_xml(pcmk__output_t *out, bool is_list, const char *tag_name
                          , size_t pairs_count, ...)
-{ 
+{
     xmlNodePtr xml_node = NULL;
     va_list args;
 
@@ -66,12 +66,46 @@ pe__group_xml(pcmk__output_t *out, va_list args)
     return rc;
 }
 
+static int
+pe__group_text(pcmk__output_t *out, va_list args)
+{
+    long options = va_arg(args, long);
+    resource_t *rsc = va_arg(args, resource_t *);
+    const char *pre_text = va_arg(args, char *);
+    char *child_text = NULL;
+
+    if (pre_text == NULL) {
+        pre_text = " ";
+    }
+
+    child_text = crm_concat(pre_text, "   ", ' ');
+
+    fprintf(out->dest, "%sResource Group: %s", pre_text ? pre_text : "", rsc->id);
+    if (options & pe_print_brief) {
+        pe__rscs_brief_output_text(out, rsc->children, child_text, options, TRUE);
+
+    } else {
+        for (GListPtr gIter = rsc->children; gIter; gIter = gIter->next) {
+            resource_t *child_rsc = (resource_t *) gIter->data;
+
+            out->message(out, crm_element_name(child_rsc->xml), options, child_rsc, child_text);
+        }
+    }
+
+    free(child_text);
+    return 0;
+}
+
 static pcmk__message_entry_t fmt_functions[] = {
     { "bundle", "xml",  pe__bundle_xml },
+    { "bundle", "text",  pe__bundle_text },
     { "clone", "xml",  pe__clone_xml },
+    { "clone", "text",  pe__clone_text },
     { "group", "xml",  pe__group_xml },
+    { "group", "text",  pe__group_text },
     { "primitive", "xml",  pe__resource_xml },
-    
+    { "primitive", "text",  pe__resource_text },
+
     { NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
This commit complements the 2735a7d0cb15041eb29ffe09232efa2b07bb6091. It adds the functions-messages
to print information about resources in plain-text.

DON'T MERGE! The PR is incomplete.

This PR together with the PR #1788 bring 8 new functions by splitting/refactoring the existing ones

  native_print --> (pe__resource_xml + pe__resource_text)
  group_print --> (pe__group_xml + pe__group_text)
  clone_print --> (pe__clone_text + pe__clone_text)
  pe__bundle_print --> (pe__bundle_xml + pe__bundle_text)

I tried to keep the logic between the xml and text version similar. I
removed the pre_text and print_data paramenters from both the *_xml and *_text
functions. In case of xml it should work fine, but in case of *_text
functions it could break the reverse compatibility. I SIMPLY DON'T PRINT
THE pre_text parameter. Removing the print_data parameter, I think, should not
harm much.