### PR TITLE
Add HTML and none formatters

### DIFF
--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -22,6 +22,7 @@ extern "C" {
 #  include <stdbool.h>
 #  include <stdio.h>
 #  include <libxml/tree.h>
+#  include <libxml/HTMLtree.h>
 
 #  include <glib.h>
 #  include <crm/common/results.h>
@@ -123,12 +124,15 @@ typedef struct pcmk__supported_format_s {
  * is added.
  */
 
+extern GOptionEntry pcmk__html_output_entries[];
 extern GOptionEntry pcmk__text_output_entries[];
 extern GOptionEntry pcmk__xml_output_entries[];
 
+pcmk__output_t *pcmk__mk_html_output(char **argv);
 pcmk__output_t *pcmk__mk_text_output(char **argv);
 pcmk__output_t *pcmk__mk_xml_output(char **argv);
 
+#define PCMK__SUPPORTED_FORMAT_HTML { "html", pcmk__mk_html_output, pcmk__html_output_entries }
 #define PCMK__SUPPORTED_FORMAT_TEXT { "text", pcmk__mk_text_output, pcmk__text_output_entries }
 #define PCMK__SUPPORTED_FORMAT_XML  { "xml", pcmk__mk_xml_output, pcmk__xml_output_entries }
 
@@ -582,6 +586,23 @@ pcmk__xml_pop_parent(pcmk__output_t *out);
  */
 xmlNodePtr
 pcmk__xml_peek_parent(pcmk__output_t *out);
+
+/*!
+ * \internal
+ * \brief Create a new XML node consisting of the provided text inside an HTML
+ *        element node of the given name.
+ *
+ * \param[in,out] out          The output functions structure.
+ * \param[in]     element_name The name of the new HTML element.
+ * \param[in]     id           The CSS ID selector to apply to this element.
+ *                             If NULL, no ID is added.
+ * \param[in]     class_name   The CSS class selector to apply to this element.
+ *                             If NULL, no class is added.
+ * \param[in]     text         The text content of the node.
+ */
+xmlNodePtr
+pcmk__html_add_node(pcmk__output_t *out, const char *element_name, const char *id,
+                    const char *class_name, const char *text);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -125,14 +125,17 @@ typedef struct pcmk__supported_format_s {
  */
 
 extern GOptionEntry pcmk__html_output_entries[];
+extern GOptionEntry pcmk__none_output_entries[];
 extern GOptionEntry pcmk__text_output_entries[];
 extern GOptionEntry pcmk__xml_output_entries[];
 
 pcmk__output_t *pcmk__mk_html_output(char **argv);
+pcmk__output_t *pcmk__mk_none_output(char **argv);
 pcmk__output_t *pcmk__mk_text_output(char **argv);
 pcmk__output_t *pcmk__mk_xml_output(char **argv);
 
 #define PCMK__SUPPORTED_FORMAT_HTML { "html", pcmk__mk_html_output, pcmk__html_output_entries }
+#define PCMK__SUPPORTED_FORMAT_NONE { "none", pcmk__mk_none_output, pcmk__none_output_entries }
 #define PCMK__SUPPORTED_FORMAT_TEXT { "text", pcmk__mk_text_output, pcmk__text_output_entries }
 #define PCMK__SUPPORTED_FORMAT_XML  { "xml", pcmk__mk_xml_output, pcmk__xml_output_entries }
 

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -509,6 +509,20 @@ pcmk__indented_printf(pcmk__output_t *out, const char *format, ...) G_GNUC_PRINT
 
 /*!
  * \internal
+ * \brief Create and return a new XML node with the given name, as a child of the
+ *        current list parent.  This is used when implementing custom message
+ *        functions.
+ *
+ * \note This function is similar to create_xml_node.
+ *
+ * \param[in,out] out  The output functions structure.
+ * \param[in]     name The name of the node to be created.
+ */
+xmlNodePtr
+pcmk__output_xml_node(pcmk__output_t *out, const char *name);
+
+/*!
+ * \internal
  * \brief Add the given node as a child of the current list parent.  This is
  *        used when implementing custom message functions.
  *

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -144,7 +144,7 @@ struct pcmk__output_s {
     /*!
      * \brief The name of this output formatter.
      */
-    char *fmt_name;
+    const char *fmt_name;
 
     /*!
      * \brief A copy of the request that generated this output.

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -78,6 +78,16 @@ void fix_plus_plus_recursive(xmlNode * target);
 xmlNode *create_xml_node(xmlNode * parent, const char *name);
 
 /*
+ * Create a node named "name" as a child of "parent", giving it the provided
+ * text content.
+ * If parent is NULL, creates an unconnected node.
+ *
+ * Returns the created node
+ *
+ */
+xmlNode *pcmk_create_xml_text_node(xmlNode * parent, const char *name, const char *content);
+
+/*
  *
  */
 void purge_diff_markers(xmlNode * a_node);

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -49,6 +49,7 @@ libcrmcommon_la_SOURCES	+= mainloop.c
 libcrmcommon_la_SOURCES	+= nvpair.c
 libcrmcommon_la_SOURCES	+= operations.c
 libcrmcommon_la_SOURCES	+= output.c
+libcrmcommon_la_SOURCES	+= output_html.c
 libcrmcommon_la_SOURCES	+= output_text.c
 libcrmcommon_la_SOURCES	+= output_xml.c
 libcrmcommon_la_SOURCES	+= pid.c

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -50,6 +50,7 @@ libcrmcommon_la_SOURCES	+= nvpair.c
 libcrmcommon_la_SOURCES	+= operations.c
 libcrmcommon_la_SOURCES	+= output.c
 libcrmcommon_la_SOURCES	+= output_html.c
+libcrmcommon_la_SOURCES	+= output_none.c
 libcrmcommon_la_SOURCES	+= output_text.c
 libcrmcommon_la_SOURCES	+= output_xml.c
 libcrmcommon_la_SOURCES	+= pid.c

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -24,7 +24,6 @@ pcmk__output_free(pcmk__output_t *out, crm_exit_t exit_status) {
     out->free_priv(out);
 
     g_hash_table_destroy(out->messages);
-    free(out->fmt_name);
     free(out->request);
     free(out);
 }
@@ -54,12 +53,6 @@ pcmk__output_new(pcmk__output_t **out, const char *fmt_name, const char *filenam
     *out = create(argv);
     if (*out == NULL) {
         return ENOMEM;
-    }
-
-    if (fmt_name == NULL) {
-        (*out)->fmt_name = strdup("text");
-    } else {
-        (*out)->fmt_name = strdup(fmt_name);
     }
 
     if (filename == NULL || safe_str_eq(filename, "-")) {

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+
+#include <ctype.h>
+#include <libxml/HTMLtree.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <crm/crm.h>
+#include <crm/common/output.h>
+#include <crm/common/xml.h>
+
+static const char *stylesheet_default =
+    ".bold { font-weight: bold }\n"
+    ".warning { color: red, font-weight: bold }";
+
+static gboolean cgi_output = FALSE;
+static int meta_refresh = 0;
+static char *stylesheet_link = NULL;
+static char *title = NULL;
+
+GOptionEntry pcmk__html_output_entries[] = {
+    { "cgi-output", 0, 0, G_OPTION_ARG_NONE, &cgi_output,
+      "Add text needed to use output in a CGI program",
+      NULL },
+
+    { "meta-refresh", 0, 0, G_OPTION_ARG_INT, &meta_refresh,
+      "How often to refresh",
+      "SECONDS" },
+
+    { "stylesheet-link", 0, 0, G_OPTION_ARG_STRING, &stylesheet_link,
+      "Link to an external CSS stylesheet",
+      "URI" },
+
+    { "title", 0, 0, G_OPTION_ARG_STRING, &title,
+      "Page title (defaults to command line)",
+      "TITLE" },
+
+    { NULL }
+};
+
+typedef struct private_data_s {
+    xmlNode *root;
+    GQueue *parent_q;
+    GSList *errors;
+} private_data_t;
+
+static void
+html_free_priv(pcmk__output_t *out) {
+    private_data_t *priv = out->priv;
+
+    if (priv == NULL) {
+        return;
+    }
+
+    xmlFreeNode(priv->root);
+    g_queue_free(priv->parent_q);
+    g_slist_free(priv->errors);
+    free(priv);
+}
+
+static bool
+html_init(pcmk__output_t *out) {
+    private_data_t *priv = NULL;
+
+    /* If html_init was previously called on this output struct, just return. */
+    if (out->priv != NULL) {
+        return true;
+    } else {
+        out->priv = calloc(1, sizeof(private_data_t));
+        if (out->priv == NULL) {
+            return false;
+        }
+
+        priv = out->priv;
+    }
+
+    priv->parent_q = g_queue_new();
+
+    priv->root = create_xml_node(NULL, "html");
+    xmlCreateIntSubset(priv->root->doc, (pcmkXmlStr) "html", NULL, NULL);
+
+    xmlSetProp(priv->root, (pcmkXmlStr) "lang", (pcmkXmlStr) "en");
+    g_queue_push_tail(priv->parent_q, priv->root);
+    priv->errors = NULL;
+
+    pcmk__output_xml_node(out, "body");
+
+    return true;
+}
+
+static void
+add_error_node(gpointer data, gpointer user_data) {
+    char *str = (char *) data;
+    pcmk__output_t *out = (pcmk__output_t *) user_data;
+    out->list_item(out, NULL, str);
+}
+
+static void
+html_finish(pcmk__output_t *out, crm_exit_t exit_status) {
+    private_data_t *priv = out->priv;
+    htmlNodePtr head_node = NULL;
+    htmlNodePtr charset_node = NULL;
+
+    /* If root is NULL, html_init failed and we are being called from pcmk__output_free
+     * in the pcmk__output_new path.
+     */
+    if (priv->root == NULL) {
+        return;
+    }
+
+    if (cgi_output) {
+        fprintf(out->dest, "Content-Type: text/html\n\n");
+    }
+
+    /* Add the head node last - it's not needed earlier because it doesn't contain
+     * anything else that the user could add, and we want it done last to pick up
+     * any options that may have been given.
+     */
+    head_node = xmlNewNode(NULL, (pcmkXmlStr) "head");
+
+    if (title != NULL ) {
+        pcmk_create_xml_text_node(head_node, "title", title);
+    } else if (out->request != NULL) {
+        pcmk_create_xml_text_node(head_node, "title", out->request);
+    }
+
+    charset_node = create_xml_node(head_node, "meta");
+    xmlSetProp(charset_node, (pcmkXmlStr) "charset", (pcmkXmlStr) "utf-8");
+
+    if (meta_refresh != 0) {
+        htmlNodePtr refresh_node = create_xml_node(head_node, "meta");
+        xmlSetProp(refresh_node, (pcmkXmlStr) "http-equiv", (pcmkXmlStr) "refresh");
+        xmlSetProp(refresh_node, (pcmkXmlStr) "content", (pcmkXmlStr) crm_itoa(meta_refresh));
+    }
+
+    /* Stylesheets are included two different ways.  The first is via a built-in
+     * default (see the stylesheet_default const above).  The second is via the
+     * "stylesheet-link" option, and this should obviously be a link to a
+     * stylesheet.  The second can override the first.  At least one should be
+     * given.
+     */
+    pcmk_create_xml_text_node(head_node, "style", stylesheet_default);
+
+    if (stylesheet_link != NULL) {
+        htmlNodePtr link_node = create_xml_node(head_node, "link");
+        xmlSetProp(link_node, (pcmkXmlStr) "rel", (pcmkXmlStr) "stylesheet");
+        xmlSetProp(link_node, (pcmkXmlStr) "href", (pcmkXmlStr) stylesheet_link);
+    }
+
+    xmlAddPrevSibling(priv->root->children, head_node);
+
+    if (g_slist_length(priv->errors) > 0) {
+        out->begin_list(out, "Errors", NULL, NULL);
+        g_slist_foreach(priv->errors, add_error_node, (gpointer) out);
+        out->end_list(out);
+    }
+
+    htmlDocDump(out->dest, priv->root->doc);
+}
+
+static void
+html_reset(pcmk__output_t *out) {
+    private_data_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    htmlDocDump(out->dest, priv->root->doc);
+
+    html_free_priv(out);
+    html_init(out);
+}
+
+static void
+html_subprocess_output(pcmk__output_t *out, int exit_status,
+                      const char *proc_stdout, const char *proc_stderr) {
+    char *rc_buf = NULL;
+    private_data_t *priv = out->priv;
+    CRM_ASSERT(priv != NULL);
+
+    rc_buf = crm_strdup_printf("Return code: %d", exit_status);
+
+    pcmk_create_xml_text_node(g_queue_peek_tail(priv->parent_q), "h2", "Command Output");
+
+    pcmk__html_add_node(out, "div", NULL, NULL, rc_buf);
+
+    if (proc_stdout != NULL) {
+        pcmk__html_add_node(out, "div", NULL, NULL, "Stdout");
+        pcmk__html_add_node(out, "div", NULL, "output", proc_stdout);
+    }
+    if (proc_stderr != NULL) {
+        pcmk__html_add_node(out, "div", NULL, NULL, "Stderr");
+        pcmk__html_add_node(out, "div", NULL, "output", proc_stderr);
+    }
+
+    free(rc_buf);
+}
+
+static void
+html_version(pcmk__output_t *out, bool extended) {
+    private_data_t *priv = out->priv;
+    CRM_ASSERT(priv != NULL);
+
+    pcmk_create_xml_text_node(g_queue_peek_tail(priv->parent_q), "h2", "Version Information");
+    pcmk__html_add_node(out, "div", NULL, NULL, "Program: Pacemaker");
+    pcmk__html_add_node(out, "div", NULL, NULL, crm_strdup_printf("Version: %s", PACEMAKER_VERSION));
+    pcmk__html_add_node(out, "div", NULL, NULL, "Author: Andrew Beekhof");
+    pcmk__html_add_node(out, "div", NULL, NULL, crm_strdup_printf("Build: %s", BUILD_VERSION));
+    pcmk__html_add_node(out, "div", NULL, NULL, crm_strdup_printf("Features: %s", CRM_FEATURES));
+}
+
+G_GNUC_PRINTF(2, 3)
+static void
+html_err(pcmk__output_t *out, const char *format, ...) {
+    private_data_t *priv = out->priv;
+    int len = 0;
+    char *buf = NULL;
+    va_list ap;
+
+    CRM_ASSERT(priv != NULL);
+    va_start(ap, format);
+    len = vasprintf(&buf, format, ap);
+    CRM_ASSERT(len > 0);
+    va_end(ap);
+
+    priv->errors = g_slist_append(priv->errors, buf);
+}
+
+G_GNUC_PRINTF(2, 3)
+static void
+html_info(pcmk__output_t *out, const char *format, ...) {
+    /* This function intentially left blank */
+}
+
+static void
+html_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
+    htmlNodePtr node = NULL;
+    private_data_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    node = pcmk__html_add_node(out, "pre", NULL, NULL, buf);
+    xmlSetProp(node, (pcmkXmlStr) "lang", (pcmkXmlStr) "xml");
+}
+
+static void
+html_begin_list(pcmk__output_t *out, const char *name,
+               const char *singular_noun, const char *plural_noun) {
+    private_data_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    if (name != NULL) {
+        pcmk_create_xml_text_node(g_queue_peek_tail(priv->parent_q), "h2", name);
+    }
+
+    pcmk__output_xml_node(out, "ul");
+}
+
+static void
+html_list_item(pcmk__output_t *out, const char *name, const char *content) {
+    private_data_t *priv = out->priv;
+    htmlNodePtr item_node = NULL;
+
+    CRM_ASSERT(priv != NULL);
+
+    item_node = pcmk_create_xml_text_node(g_queue_peek_tail(priv->parent_q), "li", content);
+
+    if (name != NULL) {
+        xmlSetProp(item_node, (pcmkXmlStr) "class", (pcmkXmlStr) name);
+    }
+}
+
+static void
+html_end_list(pcmk__output_t *out) {
+    private_data_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    g_queue_pop_tail(priv->parent_q);
+}
+
+pcmk__output_t *
+pcmk__mk_html_output(char **argv) {
+    pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
+
+    if (retval == NULL) {
+        return NULL;
+    }
+
+    retval->fmt_name = "html";
+    retval->request = g_strjoinv(" ", argv);
+    retval->supports_quiet = false;
+
+    retval->init = html_init;
+    retval->free_priv = html_free_priv;
+    retval->finish = html_finish;
+    retval->reset = html_reset;
+
+    retval->register_message = pcmk__register_message;
+    retval->message = pcmk__call_message;
+
+    retval->subprocess_output = html_subprocess_output;
+    retval->version = html_version;
+    retval->info = html_info;
+    retval->err = html_err;
+    retval->output_xml = html_output_xml;
+
+    retval->begin_list = html_begin_list;
+    retval->list_item = html_list_item;
+    retval->end_list = html_end_list;
+
+    return retval;
+}
+
+xmlNodePtr
+pcmk__html_add_node(pcmk__output_t *out, const char *element_name, const char *id,
+                    const char *class_name, const char *text) {
+    htmlNodePtr node = xmlNewNode(NULL, (pcmkXmlStr) element_name);
+
+    xmlNodeSetContent(node, (pcmkXmlStr) text);
+
+    if (class_name != NULL) {
+        xmlSetProp(node, (pcmkXmlStr) "class", (pcmkXmlStr) class_name);
+    }
+
+    if (id != NULL) {
+        xmlSetProp(node, (pcmkXmlStr) "id", (pcmkXmlStr) id);
+    }
+
+    pcmk__xml_add_node(out, node);
+    return node;
+}

--- a/lib/common/output_none.c
+++ b/lib/common/output_none.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <stdlib.h>
+#include <crm/crm.h>
+#include <crm/common/output.h>
+#include <glib.h>
+
+GOptionEntry pcmk__none_output_entries[] = {
+    { NULL }
+};
+
+static void
+none_free_priv(pcmk__output_t *out) {
+    /* This function intentionally left blank */
+}
+
+static bool
+none_init(pcmk__output_t *out) {
+    return true;
+}
+
+static void
+none_finish(pcmk__output_t *out, crm_exit_t exit_status) {
+    /* This function intentionally left blank */
+}
+
+static void
+none_reset(pcmk__output_t *out) {
+    none_free_priv(out);
+    none_init(out);
+}
+
+static void
+none_subprocess_output(pcmk__output_t *out, int exit_status,
+                       const char *proc_stdout, const char *proc_stderr) {
+    /* This function intentionally left blank */
+}
+
+static void
+none_version(pcmk__output_t *out, bool extended) {
+    /* This function intentionally left blank */
+}
+
+G_GNUC_PRINTF(2, 3)
+static void
+none_err(pcmk__output_t *out, const char *format, ...) {
+    /* This function intentionally left blank */
+}
+
+G_GNUC_PRINTF(2, 3)
+static void
+none_info(pcmk__output_t *out, const char *format, ...) {
+    /* This function intentionally left blank */
+}
+
+static void
+none_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
+    /* This function intentionally left blank */
+}
+
+static void
+none_begin_list(pcmk__output_t *out, const char *name, const char *singular_noun,
+                const char *plural_noun) {
+    /* This function intentionally left blank */
+}
+
+static void
+none_list_item(pcmk__output_t *out, const char *id, const char *content) {
+    /* This function intentionally left blank */
+}
+
+static void
+none_end_list(pcmk__output_t *out) {
+    /* This function intentionally left blank */
+}
+
+pcmk__output_t *
+pcmk__mk_none_output(char **argv) {
+    pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
+
+    if (retval == NULL) {
+        return NULL;
+    }
+
+    retval->fmt_name = "none";
+    retval->request = g_strjoinv(" ", argv);
+    retval->supports_quiet = true;
+
+    retval->init = none_init;
+    retval->free_priv = none_free_priv;
+    retval->finish = none_finish;
+    retval->reset = none_reset;
+
+    retval->register_message = pcmk__register_message;
+    retval->message = pcmk__call_message;
+
+    retval->subprocess_output = none_subprocess_output;
+    retval->version = none_version;
+    retval->info = none_info;
+    retval->err = none_err;
+    retval->output_xml = none_output_xml;
+
+    retval->begin_list = none_begin_list;
+    retval->list_item = none_list_item;
+    retval->end_list = none_end_list;
+
+    return retval;
+}

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -210,6 +210,7 @@ pcmk__mk_text_output(char **argv) {
         return NULL;
     }
 
+    retval->fmt_name = "text";
     retval->request = g_strjoinv(" ", argv);
     retval->supports_quiet = true;
 

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -27,13 +27,13 @@ typedef struct text_list_data_s {
     char *plural_noun;
 } text_list_data_t;
 
-typedef struct text_private_s {
+typedef struct private_data_s {
     GQueue *parent_q;
-} text_private_t;
+} private_data_t;
 
 static void
 text_free_priv(pcmk__output_t *out) {
-    text_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     if (priv == NULL) {
         return;
@@ -45,13 +45,13 @@ text_free_priv(pcmk__output_t *out) {
 
 static bool
 text_init(pcmk__output_t *out) {
-    text_private_t *priv = NULL;
+    private_data_t *priv = NULL;
 
     /* If text_init was previously called on this output struct, just return. */
     if (out->priv != NULL) {
         return true;
     } else {
-        out->priv = calloc(1, sizeof(text_private_t));
+        out->priv = calloc(1, sizeof(private_data_t));
         if (out->priv == NULL) {
             return false;
         }
@@ -138,7 +138,7 @@ text_info(pcmk__output_t *out, const char *format, ...) {
 
 static void
 text_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
-    text_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
     pcmk__indented_printf(out, "%s", buf);
@@ -147,7 +147,7 @@ text_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
 static void
 text_begin_list(pcmk__output_t *out, const char *name, const char *singular_noun,
                 const char *plural_noun) {
-    text_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
     text_list_data_t *new_list = NULL;
 
     CRM_ASSERT(priv != NULL);
@@ -166,7 +166,7 @@ text_begin_list(pcmk__output_t *out, const char *name, const char *singular_noun
 
 static void
 text_list_item(pcmk__output_t *out, const char *id, const char *content) {
-    text_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
 
@@ -185,7 +185,7 @@ text_list_item(pcmk__output_t *out, const char *id, const char *content) {
 
 static void
 text_end_list(pcmk__output_t *out) {
-    text_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
     text_list_data_t *node = NULL;
 
     CRM_ASSERT(priv != NULL);
@@ -241,7 +241,7 @@ pcmk__indented_printf(pcmk__output_t *out, const char *format, ...) {
     int len = 0;
 #if FANCY_TEXT_OUTPUT > 0
     int level = 0;
-    text_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
 

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -257,6 +257,7 @@ pcmk__mk_xml_output(char **argv) {
         return NULL;
     }
 
+    retval->fmt_name = "xml";
     retval->request = g_strjoinv(" ", argv);
     retval->supports_quiet = false;
 

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -24,15 +24,15 @@ GOptionEntry pcmk__xml_output_entries[] = {
     { NULL }
 };
 
-typedef struct xml_private_s {
+typedef struct private_data_s {
     xmlNode *root;
     GQueue *parent_q;
     GSList *errors;
-} xml_private_t;
+} private_data_t;
 
 static void
 xml_free_priv(pcmk__output_t *out) {
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     if (priv == NULL) {
         return;
@@ -46,13 +46,13 @@ xml_free_priv(pcmk__output_t *out) {
 
 static bool
 xml_init(pcmk__output_t *out) {
-    xml_private_t *priv = NULL;
+    private_data_t *priv = NULL;
 
     /* If xml_init was previously called on this output struct, just return. */
     if (out->priv != NULL) {
         return true;
     } else {
-        out->priv = calloc(1, sizeof(xml_private_t));
+        out->priv = calloc(1, sizeof(private_data_t));
         if (out->priv == NULL) {
             return false;
         }
@@ -87,7 +87,7 @@ xml_finish(pcmk__output_t *out, crm_exit_t exit_status) {
     xmlNodePtr node;
     char *rc_as_str = NULL;
     char *buf = NULL;
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     /* If root is NULL, xml_init failed and we are being called from pcmk__output_free
      * in the pcmk__output_new path.
@@ -117,7 +117,7 @@ xml_finish(pcmk__output_t *out, crm_exit_t exit_status) {
 static void
 xml_reset(pcmk__output_t *out) {
     char *buf = NULL;
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
 
@@ -134,7 +134,7 @@ xml_subprocess_output(pcmk__output_t *out, int exit_status,
                       const char *proc_stdout, const char *proc_stderr) {
     xmlNodePtr node, child_node;
     char *rc_as_str = NULL;
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
     CRM_ASSERT(priv != NULL);
 
     rc_as_str = crm_itoa(exit_status);
@@ -161,7 +161,7 @@ xml_subprocess_output(pcmk__output_t *out, int exit_status,
 static void
 xml_version(pcmk__output_t *out, bool extended) {
     xmlNodePtr node;
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
     CRM_ASSERT(priv != NULL);
 
     node = xmlNewChild(g_queue_peek_tail(priv->parent_q), NULL, (pcmkXmlStr) "version", NULL);
@@ -176,7 +176,7 @@ xml_version(pcmk__output_t *out, bool extended) {
 G_GNUC_PRINTF(2, 3)
 static void
 xml_err(pcmk__output_t *out, const char *format, ...) {
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
     int len = 0;
     char *buf = NULL;
     va_list ap;
@@ -200,7 +200,7 @@ static void
 xml_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
     xmlNodePtr parent = NULL;
     xmlNodePtr cdata_node = NULL;
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
 
@@ -214,7 +214,7 @@ static void
 xml_begin_list(pcmk__output_t *out, const char *name,
                const char *singular_noun, const char *plural_noun) {
     xmlNodePtr list_node = NULL;
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
 
@@ -225,7 +225,7 @@ xml_begin_list(pcmk__output_t *out, const char *name,
 
 static void
 xml_list_item(pcmk__output_t *out, const char *name, const char *content) {
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
     xmlNodePtr item_node = NULL;
 
     CRM_ASSERT(priv != NULL);
@@ -238,7 +238,7 @@ xml_list_item(pcmk__output_t *out, const char *name, const char *content) {
 static void
 xml_end_list(pcmk__output_t *out) {
     char *buf = NULL;
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
     xmlNodePtr node;
 
     CRM_ASSERT(priv != NULL);
@@ -283,7 +283,7 @@ pcmk__mk_xml_output(char **argv) {
 
 void
 pcmk__xml_add_node(pcmk__output_t *out, xmlNodePtr node) {
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
     CRM_ASSERT(node != NULL);
@@ -293,7 +293,7 @@ pcmk__xml_add_node(pcmk__output_t *out, xmlNodePtr node) {
 
 void
 pcmk__xml_push_parent(pcmk__output_t *out, xmlNodePtr parent) {
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
     CRM_ASSERT(parent != NULL);
@@ -303,7 +303,7 @@ pcmk__xml_push_parent(pcmk__output_t *out, xmlNodePtr parent) {
 
 void
 pcmk__xml_pop_parent(pcmk__output_t *out) {
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
     CRM_ASSERT(g_queue_get_length(priv->parent_q) > 0);
@@ -313,7 +313,7 @@ pcmk__xml_pop_parent(pcmk__output_t *out) {
 
 xmlNodePtr
 pcmk__xml_peek_parent(pcmk__output_t *out) {
-    xml_private_t *priv = out->priv;
+    private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1982,6 +1982,18 @@ create_xml_node(xmlNode * parent, const char *name)
     return node;
 }
 
+xmlNode *
+pcmk_create_xml_text_node(xmlNode * parent, const char *name, const char *content)
+{
+    xmlNode *node = create_xml_node(parent, name);
+
+    if (node != NULL) {
+        xmlNodeSetContent(node, (pcmkXmlStr) content);
+    }
+
+    return node;
+}
+
 int
 pcmk__element_xpath(const char *prefix, xmlNode *xml, char *buffer,
                     int offset, size_t buffer_size)

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -37,7 +37,7 @@ last_fenced_xml(pcmk__output_t *out, va_list args) {
 
     if (when) {
         crm_time_t *crm_when = crm_time_new(NULL);
-        xmlNodePtr node = xmlNewNode(NULL, (pcmkXmlStr) "last-fenced");
+        xmlNodePtr node = pcmk__output_xml_node(out, "last-fenced");
         char *buf = NULL;
 
         crm_time_set_timet(crm_when, &when);
@@ -45,8 +45,6 @@ last_fenced_xml(pcmk__output_t *out, va_list args) {
 
         xmlSetProp(node, (pcmkXmlStr) "target", (pcmkXmlStr) target);
         xmlSetProp(node, (pcmkXmlStr) "when", (pcmkXmlStr) buf);
-
-        pcmk__xml_add_node(out, node);
 
         crm_time_free(crm_when);
         free(buf);
@@ -90,12 +88,10 @@ stonith_event_text(pcmk__output_t *out, va_list args) {
 
 static int
 stonith_event_xml(pcmk__output_t *out, va_list args) {
-    xmlNodePtr node = NULL;
+    xmlNodePtr node = pcmk__output_xml_node(out, "fence_event");
     stonith_history_t *event = va_arg(args, stonith_history_t *);
     crm_time_t *crm_when = crm_time_new(NULL);
     char *buf = NULL;
-
-    node = xmlNewNode(NULL, (pcmkXmlStr) "fence_event");
 
     switch (event->state) {
         case st_failed:
@@ -131,8 +127,6 @@ stonith_event_xml(pcmk__output_t *out, va_list args) {
         free(buf);
     }
 
-    pcmk__xml_add_node(out, node);
-
     crm_time_free(crm_when);
     return 0;
 }
@@ -166,7 +160,7 @@ validate_agent_text(pcmk__output_t *out, va_list args) {
 
 static int
 validate_agent_xml(pcmk__output_t *out, va_list args) {
-    xmlNodePtr node = NULL;
+    xmlNodePtr node = pcmk__output_xml_node(out, "validate");
 
     const char *agent = va_arg(args, const char *);
     const char *device = va_arg(args, const char *);
@@ -174,7 +168,6 @@ validate_agent_xml(pcmk__output_t *out, va_list args) {
     const char *error_output = va_arg(args, const char *);
     int rc = va_arg(args, int);
 
-    node = xmlNewNode(NULL, (pcmkXmlStr) "validate");
     xmlSetProp(node, (pcmkXmlStr) "agent", (pcmkXmlStr) agent);
     if (device != NULL) {
         xmlSetProp(node, (pcmkXmlStr) "device", (pcmkXmlStr) device);
@@ -185,7 +178,6 @@ validate_agent_xml(pcmk__output_t *out, va_list args) {
     out->subprocess_output(out, rc, output, error_output);
     pcmk__xml_pop_parent(out);
 
-    pcmk__xml_add_node(out, node);
     return rc;
 }
 


### PR DESCRIPTION
This splits a couple commits out of PR #1798, introducing just the new formatters.  The other two commits fix a couple of minor problems just so I don't have to do them later and the new formatters can start off without those problems.