### PR TITLE
Feature: remote: allow run-time configurable TLS priorities

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -225,7 +225,7 @@ AC_ARG_WITH(cibsecrets,
 
 PCMK_GNUTLS_PRIORITIES="NORMAL"
 AC_ARG_WITH(gnutls-priorities,
-    [  --with-gnutls-priorities  GnuTLS cipher priorities @<:@NORMAL@:>@ ],
+    [  --with-gnutls-priorities  Default GnuTLS cipher priorities @<:@NORMAL@:>@ ],
     [ test x"$withval" = x"no" || PCMK_GNUTLS_PRIORITIES="$withval" ])
 
 INITDIR=""

--- a/daemons/pacemakerd/pacemaker.sysconfig
+++ b/daemons/pacemakerd/pacemaker.sysconfig
@@ -93,6 +93,15 @@
 # value must be the same on all nodes. The default is "3121".
 # PCMK_remote_port=3121
 
+# Use these GnuTLS cipher priorities for TLS connections. See:
+#
+#   https://gnutls.org/manual/html_node/Priority-Strings.html
+#
+# Pacemaker will append ":+ANON-DH" for remote CIB access (when enabled) and
+# ":+DHE-PSK:+PSK" for Pacemaker Remote connections, as they are required for
+# the respective functionality.
+# PCMK_tls_priorities="NORMAL"
+
 # Set bounds on the bit length of the prime number generated for Diffie-Hellman
 # parameters needed by TLS connections. The default is not to set any bounds.
 #


### PR DESCRIPTION
Pacemaker 2.0.0 allowed GnuTLS cipher priorities to be specified at build time via a configure script switch. With this commit, that sets the default priorities, but the user can now configure the priorities list at runtime using an environment variable (/etc/sysconfig or equivalent).