### PR TITLE
Feature: cibadmin: render access mode for selected user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ GRTAGS
 GTAGS
 TAGS
 Makefile
+!/doc/design/Makefile
 Makefile.in
 .deps
 .dirstamp

--- a/.gitignore
+++ b/.gitignore
@@ -165,7 +165,8 @@ scratch
 /tools/iso8601
 /tools/stonith_admin
 xml/crm.dtd
-xml/pacemaker*.rng
+pacemaker*.rng
+!/xml/pacemaker-access-*.rng
 xml/versions.rng
 xml/api/api-result*.rng
 lib/gnu/libgnu.a

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,8 @@ before_script:
 
 script: 
 # Create directories needed by commands used by regression tests
+# XXX stop filtering out pacemaker-access-* when libxml2 fixed in the wild:
+#     https://gitlab.gnome.org/GNOME/libxml2/merge_requests/31
 - sudo make install-exec-local || true
 - make
 - ./cts/cts-regression -V cli scheduler exec
@@ -67,7 +69,8 @@ script:
       cd xml;
       ./regression.sh && ./regression.sh -B && ./regression.sh -S && {
         schemas=; for schema in *.rng; do
-          case ${schema} in *cibtr*);; *)schemas="${schemas} ${schema}";; esac;
+          case ${schema} in *cibtr*|pacemaker-access-*);;
+                            *)schemas="${schemas} ${schema}";; esac;
         done;
         test -s .relaxng.org/relaxng.rng 2>/dev/null
           || curl --create-dirs -SsLo .relaxng.org/relaxng.rng

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,8 @@ CORE_INSTALL	= replace include lib daemons tools xml
 # Only these will get built with a plain "make" or "make clean"
 CORE		= $(CORE_INSTALL) cts
 
-SUBDIRS	= $(CORE) doc extra maint
+# this directory needs priority treatment (install creates a relied upon dir)
+SUBDIRS	= . $(CORE) doc extra maint
 
 AM_CPPFLAGS		= -I$(top_srcdir)/include
 

--- a/configure.ac
+++ b/configure.ac
@@ -302,6 +302,13 @@ AC_ARG_WITH([bundledir],
     [ CRM_BUNDLE_DIR="$withval" ]
 )
 
+PCMK_XML_CATALOG_DIR=""
+AC_ARG_WITH([detachedxmlcatalogdir],
+    [AS_HELP_STRING([--with-detachedxmlcatalogdir=DIR],
+        [directory for detached Pacemaker XML catalog @<:@DATADIR/xml@:>@])],
+    [ PCMK_XML_CATALOG_DIR="$withval" ]
+)
+
 dnl The not-yet-released autoconf 2.70 will have a --runstatedir option.
 dnl Until that's available, emulate it with our own --with-runstatedir.
 pcmk_runstatedir=""
@@ -488,6 +495,11 @@ if test x"${CONFIGDIR}" = x""; then
     CONFIGDIR="${sysconfdir}/sysconfig"
 fi
 AC_SUBST(CONFIGDIR)
+
+if test "x${PCMK_XML_CATALOG_DIR}" = x; then
+    PCMK_XML_CATALOG_DIR="${datadir}/xml"
+fi
+AC_SUBST([PCMK_XML_CATALOG_DIR])
 
 if test x"${CRM_LOG_DIR}" = x""; then
     CRM_LOG_DIR="${localstatedir}/log/pacemaker"
@@ -747,6 +759,8 @@ AM_CONDITIONAL([BUILD_ASCIIDOC], [test "x${ASCIIDOC_CONV}" != x])
 if test "x${ASCIIDOC_CONV}" != x; then
     PCMK_FEATURES="$PCMK_FEATURES ascii-docs"
 fi
+
+AM_CONDITIONAL([HAVE_xmlcatalog], [test "x${XMLCATALOG}" != x])
 
 publican_intree_brand=no
 if test x"${PUBLICAN_BRAND}" != x"" \
@@ -2011,6 +2025,7 @@ AC_MSG_RESULT([  Header files             = ${includedir}])
 AC_MSG_RESULT([  Arch-independent files   = ${datadir}])
 AC_MSG_RESULT([  State information        = ${localstatedir}])
 AC_MSG_RESULT([  System configuration     = ${sysconfdir}])
+AC_MSG_RESULT([  Detached XML catalog dir = ${PCMK_XML_CATALOG_DIR}])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([  HA group name            = ${CRM_DAEMON_GROUP}])
 AC_MSG_RESULT([  HA user name             = ${CRM_DAEMON_USER}])

--- a/cts/Makefile.am
+++ b/cts/Makefile.am
@@ -67,7 +67,8 @@ dist_cli_DATA	= cli/crm_diff_new.xml		\
 		  cli/regression.rules.exp	\
 		  cli/regression.tools.exp	\
 		  cli/regression.upgrade.exp	\
-		  cli/regression.validity.exp
+		  cli/regression.validity.exp	\
+		  cli/regression.access_render.exp
 
 PE_TESTS	= $(wildcard scheduler/*.scores)
 pedir		= $(testdir)/scheduler

--- a/cts/cli/regression.access_render.exp
+++ b/cts/cli/regression.access_render.exp
@@ -1,0 +1,151 @@
+Created new pacemaker configuration
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= Begin test: Configure some ACLs =#=#=#=
+=#=#=#= Current cib after: Configure some ACLs =#=#=#=
+<cib epoch="1" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config/>
+    <nodes/>
+    <resources/>
+    <constraints/>
+    <acls>
+      <acl_role id="role-deny-acls">
+        <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+        <acl_permission id="read-rest" kind="read" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="tony">
+        <role id="role-deny-acls"/>
+      </acl_target>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Configure some ACLs - OK (0) =#=#=#=
+* Passed: cibadmin       - Configure some ACLs
+=#=#=#= Begin test: Enable ACLs =#=#=#=
+=#=#=#= Current cib after: Enable ACLs =#=#=#=
+<cib epoch="2" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources/>
+    <constraints/>
+    <acls>
+      <acl_role id="role-deny-acls">
+        <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+        <acl_permission id="read-rest" kind="read" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="tony">
+        <role id="role-deny-acls"/>
+      </acl_target>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Enable ACLs - OK (0) =#=#=#=
+* Passed: crm_attribute  - Enable ACLs
+=#=#=#= Begin test: An instance of ACLs render (into color) =#=#=#=
+The supplied command can provide skewed result since it is run under user that also gets guarded per ACLs on their own right. Continuing since --force flag was provided.
+<!-- ACLs as evaluated for user tony -->
+\x1b[34m<cib epoch="2" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources/>
+    <constraints/>
+    \x1b[31m<acls>
+      <acl_role id="role-deny-acls">
+        <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+        <acl_permission id="read-rest" kind="read" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="tony">
+        <role id="role-deny-acls"/>
+      </acl_target>
+    \x1b[31m</acls>
+  </configuration>
+  <status/>
+\x1b[34m</cib>[0m
+=#=#=#= Current cib after: An instance of ACLs render (into color) =#=#=#=
+<cib epoch="2" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources/>
+    <constraints/>
+    <acls>
+      <acl_role id="role-deny-acls">
+        <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+        <acl_permission id="read-rest" kind="read" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="tony">
+        <role id="role-deny-acls"/>
+      </acl_target>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: An instance of ACLs render (into color) - OK (0) =#=#=#=
+* Passed: cibadmin       - An instance of ACLs render (into color)
+=#=#=#= Begin test: An instance of ACLs render (into full namespacing) =#=#=#=
+The supplied command can provide skewed result since it is run under user that also gets guarded per ACLs on their own right. Continuing since --force flag was provided.
+<pcmk-access-readable:cib xmlns:pcmk-access-readable="http://clusterlabs.org/ns/pacemaker/access/readable" xmlns:pcmk-access-denied="http://clusterlabs.org/ns/pacemaker/access/denied" pcmk-access-readable:pcmk-access-readable:pcmk-access-readable:epoch="2" pcmk-access-readable:num_updates="0" pcmk-access-readable:admin_epoch="0">
+  <pcmk-access-readable:configuration>
+    <pcmk-access-readable:crm_config>
+      <pcmk-access-readable:cluster_property_set pcmk-access-readable:id="cib-bootstrap-options">
+        <pcmk-access-readable:nvpair pcmk-access-readable:id="cib-bootstrap-options-enable-acl" pcmk-access-readable:name="enable-acl" pcmk-access-readable:value="true"/>
+      </pcmk-access-readable:cluster_property_set>
+    </pcmk-access-readable:crm_config>
+    <pcmk-access-readable:nodes/>
+    <pcmk-access-readable:resources/>
+    <pcmk-access-readable:constraints/>
+    <pcmk-access-denied:acls>
+      <pcmk-access-denied:acl_role pcmk-access-denied:id="role-deny-acls">
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="deny-acls" pcmk-access-denied:kind="deny" pcmk-access-denied:xpath="/cib/configuration/acls"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="read-rest" pcmk-access-denied:kind="read" pcmk-access-denied:xpath="/cib"/>
+      </pcmk-access-denied:acl_role>
+      <pcmk-access-denied:acl_target pcmk-access-denied:id="tony">
+        <pcmk-access-denied:role pcmk-access-denied:id="role-deny-acls"/>
+      </pcmk-access-denied:acl_target>
+    </pcmk-access-denied:acls>
+  </pcmk-access-readable:configuration>
+  <pcmk-access-readable:status/>
+</pcmk-access-readable:cib>
+=#=#=#= Current cib after: An instance of ACLs render (into full namespacing) =#=#=#=
+<cib epoch="2" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources/>
+    <constraints/>
+    <acls>
+      <acl_role id="role-deny-acls">
+        <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+        <acl_permission id="read-rest" kind="read" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="tony">
+        <role id="role-deny-acls"/>
+      </acl_target>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: An instance of ACLs render (into full namespacing) - OK (0) =#=#=#=
+* Passed: cibadmin       - An instance of ACLs render (into full namespacing)

--- a/cts/cli/regression.acls.exp
+++ b/cts/cli/regression.acls.exp
@@ -22,8 +22,8 @@ A new shadow instance was created.  To begin using it paste the following into y
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -59,8 +59,8 @@ A new shadow instance was created.  To begin using it paste the following into y
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -97,8 +97,8 @@ A new shadow instance was created.  To begin using it paste the following into y
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -135,8 +135,8 @@ A new shadow instance was created.  To begin using it paste the following into y
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -176,8 +176,8 @@ A new shadow instance was created.  To begin using it paste the following into y
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -220,8 +220,8 @@ A new shadow instance was created.  To begin using it paste the following into y
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -303,8 +303,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -356,8 +356,8 @@ pcmk__apply_creation_acl 	trace: ACLs allow creation of <nvpair> with id="cib-bo
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -407,8 +407,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -453,8 +453,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -501,8 +501,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -571,8 +571,8 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -627,8 +627,8 @@ Stopped
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -681,8 +681,8 @@ Deleted 'dummy' option: id=dummy-meta_attributes-target-role name=target-role
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -738,8 +738,8 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -844,8 +844,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -899,8 +899,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -953,8 +953,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1007,8 +1007,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1061,8 +1061,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1112,8 +1112,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1159,8 +1159,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1236,8 +1236,8 @@ pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -1329,8 +1329,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -1390,8 +1390,8 @@ Error setting enable-acl=false (section=crm_config, set=<null>): Permission deni
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -1450,8 +1450,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -1505,8 +1505,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -1562,8 +1562,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -1641,8 +1641,8 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -1706,8 +1706,8 @@ Stopped
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -1769,8 +1769,8 @@ Deleted 'dummy' option: id=dummy-meta_attributes-target-role name=target-role
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -1835,8 +1835,8 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -1950,8 +1950,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2014,8 +2014,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2077,8 +2077,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2140,8 +2140,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2203,8 +2203,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2263,8 +2263,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2319,8 +2319,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>

--- a/cts/cli/regression.acls.exp
+++ b/cts/cli/regression.acls.exp
@@ -254,11 +254,13 @@ Error performing operation: Permission denied
 * Passed: crm_attribute  - unknownguy: Set stonith-enabled
 =#=#=#= Begin test: unknownguy: Create a resource =#=#=#=
 pcmk__check_acl 	trace: User 'unknownguy' without ACLs denied read/write access to /cib/configuration/resources/primitive[@id]
-pcmk__check_acl 	trace: User 'unknownguy' without ACLs denied read/write access to /cib/configuration/resources/primitive[@class]
-pcmk__check_acl 	trace: User 'unknownguy' without ACLs denied read/write access to /cib/configuration/resources/primitive[@provider]
-pcmk__check_acl 	trace: User 'unknownguy' without ACLs denied read/write access to /cib/configuration/resources/primitive[@type]
 pcmk__apply_creation_acl 	trace: Creation of <primitive> scaffolding with id="<unset>" is implicitly allowed
 Call failed: Permission denied
+<failed>
+  <failed_update id="dummy" object_type="primitive" operation="cib_create" reason="Permission denied">
+    <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>
+  </failed_update>
+</failed>
 =#=#=#= End test: unknownguy: Create a resource - Insufficient privileges (4) =#=#=#=
 * Passed: cibadmin       - unknownguy: Create a resource
 =#=#=#= Begin test: l33t-haxor: Query configuration =#=#=#=
@@ -1276,11 +1278,13 @@ Error performing operation: Permission denied
 * Passed: crm_attribute  - unknownguy: Set stonith-enabled
 =#=#=#= Begin test: unknownguy: Create a resource =#=#=#=
 pcmk__check_acl 	trace: User 'unknownguy' without ACLs denied read/write access to /cib/configuration/resources/primitive[@id]
-pcmk__check_acl 	trace: User 'unknownguy' without ACLs denied read/write access to /cib/configuration/resources/primitive[@class]
-pcmk__check_acl 	trace: User 'unknownguy' without ACLs denied read/write access to /cib/configuration/resources/primitive[@provider]
-pcmk__check_acl 	trace: User 'unknownguy' without ACLs denied read/write access to /cib/configuration/resources/primitive[@type]
 pcmk__apply_creation_acl 	trace: Creation of <primitive> scaffolding with id="<unset>" is implicitly allowed
 Call failed: Permission denied
+<failed>
+  <failed_update id="dummy" object_type="primitive" operation="cib_create" reason="Permission denied">
+    <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>
+  </failed_update>
+</failed>
 =#=#=#= End test: unknownguy: Create a resource - Insufficient privileges (4) =#=#=#=
 * Passed: cibadmin       - unknownguy: Create a resource
 =#=#=#= Begin test: l33t-haxor: Query configuration =#=#=#=

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -18,7 +18,7 @@ USAGE_TEXT="Usage: cts-cli [<options>]
 Options:
  --help          Display this text, then exit
  -V, --verbose   Display any differences from expected output
- -t 'TEST [...]' Run only specified tests (default: 'dates tools acls validity upgrade rules')
+ -t 'TEST [...]' Run only specified tests (default: 'dates tools acls validity upgrade rules access_render')
  -p DIR          Look for executables in DIR (may be specified multiple times)
  -v, --valgrind  Run all commands under valgrind
  -s              Save actual output as expected output"
@@ -36,7 +36,7 @@ shadow_dir=$(mktemp -d ${TMPDIR:-/tmp}/cts-cli.shadow.XXXXXXXXXX)
 num_errors=0
 num_passed=0
 verbose=0
-tests="dates tools acls validity upgrade rules"
+tests="dates tools acls validity upgrade rules access_render"
 do_save=0
 VALGRIND_CMD=
 VALGRIND_OPTS="
@@ -985,6 +985,55 @@ EOF
     unset CIB_shadow_dir
 }
 
+test_access_render() {
+    local TMPXML
+
+    # while the in-tree config would get picked normally by default,
+    # there's still a risk of artificial influence (pre-existing
+    # $PCMK_config_directory, user's local config), so eforce it here
+    if test -x "$SRCDIR/tools/cibadmin" && test -x "$SRCDIR/xml"; then
+        export PCMK_config_directory="$SRCDIR/xml/base"
+        echo "Using local configuration from: $PCMK_config_directory" >&2
+    fi
+
+    TMPXML=$(mktemp ${TMPDIR:-/tmp}/cts-cli.acls.xml.XXXXXXXXXX)
+    export CIB_shadow_dir="${shadow_dir}"
+
+    $VALGRIND_CMD crm_shadow --batch --force --create-empty $shadow 2>&1
+    export CIB_shadow=$shadow
+
+    cat <<EOF > "$TMPXML"
+    <acls>
+      <acl_role id="role-deny-acls">
+        <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+        <acl_permission id="read-rest" kind="read" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="tony">
+        <role id="role-deny-acls"/>
+      </acl_target>
+    </acls>
+EOF
+
+    desc="Configure some ACLs"
+    cmd="cibadmin -M -o acls --xml-file $TMPXML"
+    test_assert $CRM_EX_OK
+
+    desc="Enable ACLs"
+    cmd="crm_attribute -n enable-acl -v true"
+    test_assert $CRM_EX_OK
+
+    desc="An instance of ACLs render (into color)"
+    cmd="cibadmin --force --access-render=color --user tony"
+    test_assert $CRM_EX_OK
+
+    desc="An instance of ACLs render (into full namespacing)"
+    cmd="cibadmin --force --access-render=ns-full --user tony"
+    test_assert $CRM_EX_OK
+
+    unset CIB_shadow_dir
+    unset PCMK_config_directory
+}
+
 # Process command-line arguments
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -1030,6 +1079,7 @@ for t in $tests; do
         validity) ;;
         upgrade) ;;
         rules) ;;
+        access_render) ;;
         *)
             echo "error: unknown test $t"
             echo
@@ -1074,6 +1124,7 @@ for t in $tests; do
         -e 's/ end=\"[0-9][-+: 0-9]*Z*\"/ end=\"\"/' \
         -e 's/ start=\"[0-9][-+: 0-9]*Z*\"/ start=\"\"/' \
         -e 's/^Error checking rule: Device not configured/Error checking rule: No such device or address/' \
+        -e 's/\x1b/\\x1b/' \
         "$TMPFILE" > "${TMPFILE}.$$"
     mv -- "${TMPFILE}.$$" "$TMPFILE"
 

--- a/doc/Pacemaker_Development/en-US/Ch-Hacking.txt
+++ b/doc/Pacemaker_Development/en-US/Ch-Hacking.txt
@@ -22,6 +22,18 @@ contributor role, which is detailed in other chapters of this guide.
 Therefore, if you think you will not benefit from any such details
 in the scope of this chapter, feel free to skip it.
 
+For a lack of better placeholder throughout this document for such
+a generic pointer, anyone interested in serious work on the project
+shall not miss where the design level/conceptual writeups on various
+topics are kept.  These fulfill a rather unique role of getting down
+to nitty-gritty, which may deliver way more than what casual user
+would want to know, while at the same time, concentrates lateral
+knowledge that would otherwise be hard to grasp in such an entirety
+when just interspersed across the source files.  Without further
+ado, you can go check
+https://github.com/ClusterLabs/pacemaker/tree/master/doc/design[`doc/design`]
+subdirectory in the project tree.
+
 == Debugging ==
 
 In the GNU userland tradition, preferred way of debugging is based

--- a/doc/Pacemaker_Explained/en-US/Ch-ACLs.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-ACLs.txt
@@ -13,6 +13,11 @@ By default, the +root+ user or any user in the +haclient+ group can modify
 Pacemaker's CIB without restriction. Pacemaker offers 'access control lists
 (ACLs)' to provide more fine-grained authorization.
 
+In the following sections, a quick overview from a configuration perspective
+is provided, for design level details,
+https://github.com/ClusterLabs/pacemaker/blob/master/doc/design/data-access-control.md[a dedicated document]
+can be reviewed.
+
 == ACL Prerequisites ==
 
 In order to use ACLs:

--- a/doc/design/Makefile
+++ b/doc/design/Makefile
@@ -1,0 +1,28 @@
+DOCS =
+DOCS += data-access-control
+
+DOCS_HTML = $(DOCS:%=%.html)
+DOCS_PDF = $(DOCS:%=%.pdf)
+
+all: html
+
+clean:
+	-rm -f $(DOCS_HTML) $(DOCS_PDF)
+
+html: $(DOCS_HTML)
+pdf: $(DOCS_PDF)
+
+.PHONY: all clean html pdf
+
+PANDOCVARS =
+PANDOCVARS += -V colorlinks
+PANDOCVARS += -V links-as-notes
+PANDOCVARS += -V geometry:margin=2.5cm
+PANDOCVARS += -V papersize:a4
+
+# avoid recipe redundancy, since pandoc adapts respectively
+# (at the cost of staying compatible with GNU make only)
+.SECONDEXPANSION:
+
+$(DOCS_HTML) $(DOCS_PDF): %: $$(basename %).md
+	pandoc $< --pdf-engine=xelatex $(PANDOCVARS) -o $@

--- a/doc/design/data-access-control.md
+++ b/doc/design/data-access-control.md
@@ -1,0 +1,814 @@
+# Data Access Control Model (verging on ACLs/RBAC)
+
+## Table of contents
+
+* [Preface](#preface)
+	* [Abstract concepts with intuitive notions](#abstract-concepts-with-intuitive-notions)
+* [High-level design](#high-level-design)
+	* ["Access" on an atomic level](#access-on-an-atomic-level)
+	* [Access control as a set of conjunctions-of-three](#access-control-as-a-set-of-conjunctions-of-three)
+* [The access control label](#the-access-control-label)
+	* [Three levels](#three-levels)
+	* [Multi-label resolution](#multi-label-resolution)
+	* [Access control matrix completing rules: initialization + inheritance rules](#access-control-matrix-completing-rules-initialization-inheritance-rules)
+	* [Life-cycle of access control label](#life-cycle-of-access-control-label)
+* [The object](#the-object)
+	* [No attribute-level granularity](#no-attribute-level-granularity)
+	* [Historical excurse: multi-match resolution](#historical-excurse-multi-match-resolution)
+* [The subject](#the-subject)
+	* [Superactor untangled](#superactor-untangled)
+	* [Subject specification indirection through roles](#subject-specification-indirection-through-roles)
+	* [Actor matching criteria](#actor-matching-criteria)
+		* [System user identifier](#system-user-identifier)
+* [Practical examples of how the model works](#practical-examples-of-how-the-model-works)
+
+
+## Preface
+
+This design document captures the actual _access control model_ as
+implemented on top of the pacemaker distributed database (hence the emphasis
+on data, as opposed to a generic API surface) serving the configuration and
+flow coordination purposes within the cluster.  It does *not* necessarily
+closely follow what
+[a means to access control configuration](https://clusterlabs.org/pacemaker/doc/en-US/Pacemaker/2.0/html-single/Pacemaker_Explained/index.html#ch-acls)
+is there for users to steer particular instance of the model in
+the actual deployment.
+
+Some such differences, mostly comprising a *syntactic sugar*/convenience
+encoding (uninteresting from our conceptual perspective), are expressly
+pointed out, but this slight disconnect between the conceptual model
+and the final hands-on configuration experience (for versed readers)
+shall be kept in mind while reviewing this document.
+
+Conversely, the scope of this document does *not* include _communication
+layer_
+<!-- XXX: desirable to have separate communication-layer.md document -->
+(as in API end-point contact) access protections, even though it cannot
+be concealed altogether since it actually sources the authoritative
+bits about the access instigator (__Actor__), as briefly
+[touched upon](#actor-matching-criteria) later.
+
+To connect the concepts to the resulting pieces of code, implementation
+and test case references are added where suitable.
+
+### Abstract concepts with intuitive notions
+
+For better understanding, let's prefigure some abstract concepts, written
+with Capitalized first letter to hint this fact better; following is an
+ahead-of-time enumeration to help getting reader prepared:
+
++ __Asset__
+
+   - intuitively: what the _access control_ mechanism protects, to begin with
+
+   - factually: see [explained later](#the-object)
+
++ __Actor__
+
+   - intuitively: who acts towards __Assets__
+
+   - factually: see [explained later](#the-subject)
+
++ __Superactor__
+
+   - intuitively: a specialization of the former that is recognized
+     as an overlord on the __Asset__ access boundary
+
+   - factually: see [explained later](#superactor-untangled)
+
+Tautologically, abstract _access control_ could then be defined as
+a way to establish rules of under which conditions particular __Actors__
+(that are not __Superactors__) can approach particular __Assets__.
+For more formal, alternative explanatory context, it is convenient to
+reference an otherwise withdrawn
+[draft of POSIX.1e](https://simson.net/ref/1997/posix_1003.1e-990310.pdf),
+subheaded *Protection, Audit and Control Interfaces*.  Such references
+will look as follows, here likewise for _access control_:
+
+> (alternative, general term definition:
+> [POSIX.1e:2.2.2.3](https://simson.net/ref/1997/posix_1003.1e-990310.pdf#page=12))
+
+Not without remark is that it also descents as low as down to so far
+intuitively used _access_ term:
+
+> (alternative, general term definition:
+> [POSIX.1e:2.2.2.1](https://simson.net/ref/1997/posix_1003.1e-990310.pdf#page=12))
+
+As an aside, there are more possibly relevant, normative documents
+in the problem space, such as
+[DCE 1.1: Authentication and Security Services](https://pubs.opengroup.org/onlinepubs/9668899/chap1.htm#tagcjh_03_08).
+Correspondence with these was intentionally left out at this time¹.
+
+* * *
+
+> ¹ Note, for instance, that this other referenced document refers to
+>   *POSIX P1003.6 Draft 12*, which precedes this closely matched
+>   *POSIX.1e* by several years, so there are various evolutionary influences
+>   that shall be taken into account as well.
+
+* * *
+
+
+## High-level design
+
+Said pacemaker built-in distributed database is based on the tree-like
+structure for storage of particular bits.  Implementation-wise, it's an
+[*XML*](https://www.w3.org/TR/xml/) document as detailed elsewhere, but
+in this context, it's important to keep that in mind, since we are about
+to refer to it in terms of _elements_ and _attributes_ (just as with
+related, formally specified terminology like
+[_parent_ and _child_](https://www.w3.org/TR/xml/#dt-parentchild)),
+as devised in the respective specification.
+
+In turn, this XML structure is all that matters regarding assignment of
+powers onto particular __Actors__<!--fix markup malforming-->².
+It's not surprising hence it was natural to appoint XML elements
+(attributes) as __Assets__ at hand.
+
+Note this XML document alone is an abstract concept in a sense, since it
+does *not* necessarily refer to cold bits in a file system, but that's
+out of scope here.  More on-topic is the fact that the configurable
+declaration of the access control specifics is self-hosted within the
+database itself, hence there is a possibility of a reflexive self-capture
+of particular configuration directive for itself, amongst other
+interesting properties.  This makes it particular configuration snapshot
+specific as to whether this  _access control model_ is rather of
+*discretionary* (*DAC*) or *mandatory* (*MAC*) kind.
+
+> (general *DAC* term definition:
+> [POSIX.1e:2.2.2.22](https://simson.net/ref/1997/posix_1003.1e-990310.pdf#page=14))
+
+> (general *MAC* term definition:
+> [POSIX.1e:2.2.2.34](https://simson.net/ref/1997/posix_1003.1e-990310.pdf#page=15))
+
+Let's review several properties of how this XML -- access control pairing
+works in a pure high-level sense before getting to gory parts.
+
+* * *
+
+> ² Well, almost, but mangling with resources or even nodes directly and
+>   hence without a material trace in said configuration base is clearly out
+>   of scope here, since those are to be protected with regular OS enabled
+>   access control.
+
+* * *
+
+### "Access" on an atomic level
+
+Aligned with internal workings of the transitions between internal
+database's states, there are principally just two manipulations,
+therefore only these can be protected:
+
+* *create*: something new (attribute/element) is added to the tree
+
+* *delete*: something existing in the tree is remove from there
+
+In a practical sense, this is only interesting when there's any sort
+of asymmetry, which is exactly the case with
+[provisional `write` allowance rule for creation](#access-control-matrix-completing-rules-initialization-inheritance-rules).
+Otherwise, the term is used to refer to both these equally.
+
+Note that other actions, such as a change in attribute's value, is
+effectively a composition of "remove old" and "add new" steps
+(generalized over subtrees, recursively) from pacemaker's standpoint.
+
+### Access control as a set of conjunctions-of-three
+
+Notion of _access control_ in our settings can be dissected into a matrix
+of three dimensions that will get further recursively dissected over a few
+following sections, respectively:
+
+* [_the object_](#the-object): (access *to what*; which of __Assets__)
+
+   - set of elements (attributes), generally __Assets__, matched with
+     a formula in a format-specific _selection_ (capture, query) language
+     ([*XPath*](https://www.w3.org/TR/1999/REC-xpath-19991116/))
+
+   - note that each such individual element is to be interpreted as
+     a discrete, _flat_ item within the tree, *not* to be understood as
+     a _whole subtree_ delineation (unless, of course, that's how
+     explicitly the XPath query is constructed, since XPath is capable
+     of that also)
+
+   - also, there are countless ways to match a subset of what's always
+     a *finite set* (given XML document has always, now or in the
+     future, a finite number of elements/attributes, and moreover, the
+     construction of the document is constrained with a finite number
+     of elements to only be present), i.e., one _object_ (said formula)
+     from the access control matrix will always match zero or up to all
+     selectable (and countable) __Assets__ from the currently evaluated
+     document instance)
+
+   - finally, since this above implied `0..M:0..N` directed
+     _objects_:__Assets__ relation (single _object_ matches zero to `N`
+     __Assets__, and a single __Asset__ may be matched with zero to `M`
+     _objects_) leads to singular _object_ vs. plural __Assets__
+     imbalance, we can introduce a thought simplification without
+     affecting generality:
+
+     > further in the text, _object_ may resolve to a single
+     > __Asset__ only (as if some kind of preprocessor would predict that
+     > the formula will match multiple __Assets__, replacing it with
+     > a single-match-only formulae for each) --- this changes that
+     > relation to `0..M:0..1`, and slightly simplifies the view
+
+   > (intentionally aligned with the term as explained:
+   > [POSIX.1e:2.2.2.36](https://simson.net/ref/1997/posix_1003.1e-990310.pdf#page=15))
+
+* [_the subject_](#the-subject) (access *by whom*; which __Actor__)
+
+   - note that the limits as to the enumerability of all possible
+     __Actors__ strictly relies on the surrounding system
+
+   > (intentionally aligned with the term as explained:
+   > [POSIX.1e:2.2.2.50](https://simson.net/ref/1997/posix_1003.1e-990310.pdf#page=16))
+
+* [_the access control label_](#the-access-control-label)
+  (binds the former two with *which kind of access* is permissible,
+  i.e., when particular __Actor__ is to approach particular __Asset__)
+
+   - note that unlike with the former two, the value here comes from
+     a small, fixed set of [possible constants](#three-levels)
+
+   > (virtually aligned with the term *information label* as explained:
+   > [POSIX.1e:2.2.2.30](https://simson.net/ref/1997/posix_1003.1e-990310.pdf#page=12))
+
+Mathematical insight here is that the access control is formally defined
+as a subset of the Cartesian product of `O x S x L`, where the
+components correspond to particular sets of the respective individuals
+in the order stated above (and associable per the respective letters).
+Less formally, we will call a particular item in such a Cartesian
+product as _access control triple_.
+
+Apparently, such a matrix is usually initialized --- by the means of user
+configuration --- with just a fraction of all possible coincidences, and
+the rest is, [on ad-hoc basis](#life-cycle-of-access-control-label),
+derived per the access control completing rules
+[detailed below](#access-control-matrix-completing-rules-initialization-inheritance-rules).
+
+At this point, it is appropriate to remark that while this access
+control matrix is
+[marketed](https://clusterlabs.org/pacemaker/doc/en-US/Pacemaker/2.0/html-single/Pacemaker_Explained/index.html#ch-acls)
+to the users (at least at the low-level configuration grounds, but can be
+anticipated in high-level as well) as
+[_access control lists_](https://en.wikipedia.org/wiki/Access-control_list),
+the established permissions framework as implemented is actually verging on
+[_role-based access control_](https://en.wikipedia.org/wiki/Role-based_access_control)
+style of access containment (just with no particular roles predefined),
+so we will refrain from using either of these³.
+
+While this order of entities sitting in _the access control triples_ is
+intentionally like this for its intuitivness, let's start detailing these
+in another, definition-friendly one.  It feels smoother to start explaining
+which _access control labels_ are available and how they are complemented for
+cases not covered with an explicit configuration, only then _the object_ and
+_the subject_ are examined in depth, respectively.
+
+* * *
+
+> ³ This design document is not the right place to spread accidental
+>   misnomers based on imprecise demarcation (just as with *DAC*/*MAC*
+>   before).
+
+* * *
+
+
+## The access control label
+
+### Three levels
+
+There are three discrete (nominally but not semantically, as
+[explained later](#multi-label-resolution)) _access control labels_ as
+applicable to the *single* _object_ (rest is completed per the rules
+[detailed below](#access-control-matrix-completing-rules-initialization-inheritance-rules).
+
+* `read`
+
+   this *only* asserts a privilege for _the subject_ to get to know the _flat_
+   content of _the object_ in question, that is, its mere existence, and for
+   element, the attributes (children are then subjected to a separate
+   evaluation)
+
+   > (alternative, general term definition:
+   > [POSIX.1e:2.2.2.41](https://simson.net/ref/1997/posix_1003.1e-990310.pdf#page=16))
+
+* `write`
+
+   as `read`, plus a privilege is asserted for _the subject_ to:
+
+   - create such an object if not (softly) matched down to existing one
+   - delete such an object (ability to delete an attribute is currently
+     driven solely by the `write` _access control label_ at its element)
+
+   > (alternative, general term definition:
+   > [POSIX.1e:2.2.2.54](https://simson.net/ref/1997/posix_1003.1e-990310.pdf#page=17))
+
+* `deny`
+
+   all of the above privileges are declined for _the subject_
+
+### Multi-label resolution
+
+Since a single __Asset__ can be matched multiple times (for an affixed
+__Actor__ --- matter of [matching in itself](#actor-matching-criteria)
+--- otherwise trivially holds when not), multiple labels can be
+bound to the same in parallel.  In that case, following resolution rules
+are in effect:
+
+1. `deny` takes the foremost precedence when present
+
+2. `write` takes precedence over `read` when both present
+
+> (implementation reference as of
+> [`d307f9df9`](https://github.com/ClusterLabs/pacemaker/commit/d307f9df9#diff-3b508373ace569a6af4c386d9124202aR1964):
+> `lib/common/xml.c:__xml_acl_mode_test` [now
+> [`lib/common/acl.c`](https://github.com/ClusterLabs/pacemaker/tree/master/lib/common/acl.c)`:__xml_acl_mode_test`])
+
+> (sample test reference: *none* [no multi-label resolution occurs])
+
+### Access control matrix completing rules: initialization + inheritance rules
+
+Following rules are complementary to the explicit user configuration
+that always takes a precedence (as can be sensed also in the rules
+themselves).
+
+A) *Initialization rule*:
+
+   if not explicitly configured otherwise, the default access control label
+   at the root XML element is `deny`⁴
+
+   > (implementation reference as of
+   > [`f441da133`](https://github.com/ClusterLabs/pacemaker/commit/f441da133#diff-3b508373ace569a6af4c386d9124202aR566):
+   > `lib/common/xml.c:__xml_acl_apply` [now
+   > [`lib/common/acl.c`](https://github.com/ClusterLabs/pacemaker/tree/master/lib/common/acl.c)`:pcmk__apply_acl`])
+
+   > (sample test reference: *none* [top-level always explicitly bound
+   > the label])
+
+   - as an optimization, if _the subject_ is *not* known to the configuration
+     (there's not a single mention in the explicit set of coincidences),
+     the default is `deny` right away
+
+      > (implementation reference as of
+      > [`d307f9df9`](https://github.com/ClusterLabs/pacemaker/commit/d307f9df9#diff-3b508373ace569a6af4c386d9124202aR1995):
+      > `lib/common/xml.c:__xml_acl_check` [now
+      > [`lib/common/acl.c`](https://github.com/ClusterLabs/pacemaker/tree/master/lib/common/acl.c)`:pcmk__check_acl`])
+
+      > (sample test reference as of
+      > [`a802f9a0f`](https://github.com/ClusterLabs/pacemaker/commit/a802f9a0f#diff-93bbc5e3eaefb43c6c52a5113a5bffd9R371-R374))
+
+B) *Inheritance rule*:
+
+   a child (XML attribute or subelement) of an element receives an explicit
+   access control label based on the configuration, otherwise it derives its
+   access control label from its parent (possibly itself resolved using
+   either A. or B.)
+
+   > (implementation reference as of
+   > [`d307f9df9`](https://github.com/ClusterLabs/pacemaker/commit/d307f9df9#diff-3b508373ace569a6af4c386d9124202aR2005):
+   > `lib/common/xml.c:__xml_acl_check` [now
+   > [`lib/common/acl.c`](https://github.com/ClusterLabs/pacemaker/tree/master/lib/common/acl.c)`:pcmk__check_acl`])
+
+   > (sample test reference as of
+   > [`a802f9a0f`](https://github.com/ClusterLabs/pacemaker/commit/a802f9a0f#diff-93bbc5e3eaefb43c6c52a5113a5bffd9R410-R412))
+
+C) *Convenience expressiveness "sugar" of provisional `write` for creation*:
+
+   when an expressly allowed element (_object_) is [to be created](#access-on-an-atomic-level)
+   and for its existence at particular upper hiearchy throughtout XML new
+   parents elements (i.e. a complement to what already exists) would need to
+   be created, these get one-off birth-only `write` override if they satisfy:
+    - either no attribute at all, or
+    - the only attribute named `id` exists with them, and, at the same time,
+    - there is no traversal tripping over `acls` element
+
+   > (implementation reference as of
+   > [`3183a9422`](https://github.com/ClusterLabs/pacemaker/commit/3183a9422#diff-ae7f704017d4550e25f2027ade5ee23fR474):
+   > [`lib/common/acl.c`](https://github.com/ClusterLabs/pacemaker/tree/master/lib/common/acl.c)`:implicitly_allowed`)
+
+   > (sample test reference as of
+   > [`a802f9a0f`](https://github.com/ClusterLabs/pacemaker/commit/a802f9a0f#diff-93bbc5e3eaefb43c6c52a5113a5bffd9R449-R453))
+
+Note, in the context of *B.*, that between each two consecutive levels as the
+(sub)tree descends from a (sub)root element to a child element (attribute),
+it is valid to change the level of access control in both more stringent and
+more relaxed direction (and both of these have their cases of use).
+
+Also note, in the context of *C.*, that such "sugar" can be mechanically
+removed, complementing equivalently each access control definition based on
+XPath expression containing `nvpair` element (and perhaps some others as
+can be derived from the schemas) as its tail path item & binding `write`
+access control label with an additional `write` one whereby the XPath
+expression would look like:
+
+```
+<ORIGINAL-XPATH-EXPRESSION>/..[
+  (count(@*) = 0 or count(@*) = 1 and @id)
+  and
+  not(ancestor-or-self::*[name() = 'acls'])
+]
+```
+
+Apparently, there's a little catch, since this is to only be applied on
+enforced
+[creation](#access-on-an-atomic-level)
+of the missing "scaffolding", otherwise some unexpected deletions might
+be mistakenly allowed as well.
+
+* * *
+
+> ⁴ This apparently does not apply for a distinguished __Superactor__,
+>   see [below](#superactor-untangled), since access control is not evaluted
+>   per these rules for such at all, and, as a corollary, the all-over
+>   default in that case is `write` unconditionally, i.e., no child ever
+>   receives an explicit access control label per B., and C. is hence not
+>   applicable (everything is all-in implicitly).
+
+* * *
+
+
+### Life-cycle of access control label
+
+Currently, the access control labels will get bound through the XML
+tree (denoting _the object_) in the context of particular _subject_
+making the underlying request in a dynamic, short-lived fashion.
+No caching of such once evaluated assignments is attempted, perhaps
+because of the possibly fast pace of changes that would invalidate anything
+cached so far when simplistic and conservative approach would be taken,
+unless elaborate guards are put in place, which would then require
+a great amount of unit tests to assure this security sensitive handling
+is safe and sound.
+
+There are two main discrete phases in the life-cycle of _access control
+labels_:
+
+a) *passive*: preparation work whereby the applicable parts of _access control_
+              as configured will get fetched and subsequently transformed as
+              (private) properties throughout the XML tree --- in a breakdown:
+
+   - *a1*: given particular user (specified with string encoded user name),
+           matching _access control triples_ are grabbed from what's explicitly
+           configured, and stored in an auxiliary per-document cache
+
+      > (implementation reference as of
+      > [`d307f9df9`](https://github.com/ClusterLabs/pacemaker/commit/d307f9df9#diff-3b508373ace569a6af4c386d9124202aR479-R517):
+      > `lib/common/xml.c:__xml_acl_unpack` [now
+      > [`lib/common/acl.c`](https://github.com/ClusterLabs/pacemaker/tree/master/lib/common/acl.c)`:pcmk__unpack_acl`])
+
+   - *a2*: using the evaluated data from *a1*, the XML tree of the base
+           document in question will receive (in a sparse,
+           where-explicitly-configured-only manner) final private annotations
+           denoting the set of _access control labels_ towards given
+           and now implicit _subject_, without any effect of
+           [the stated completing rules](#access-control-matrix-completing-rules-initialization-inheritance-rules)
+
+      > (implementation reference as of
+      > [`e2ed85fe0`](https://github.com/ClusterLabs/pacemaker/commit/e2ed85fe#diff-3b508373ace569a6af4c386d9124202aR511):
+      > `lib/common/xml.c:__xml_acl_apply` [now
+      > [`lib/common/acl.c`](https://github.com/ClusterLabs/pacemaker/tree/master/lib/common/acl.c)`:pcmk__apply_acl`])
+
+b) *active*: as-needed comparisons of what the selected _object_ allows
+             (towards given and now implicit _subject_; either per the
+             explicit configuration as carried over in *a2*, or according
+             to [the known rules](#access-control-matrix-completing-rules-initialization-inheritance-rules))
+             vs. which access is requested
+
+   > (implementation reference as of
+   > [`d307f9df9`](https://github.com/ClusterLabs/pacemaker/commit/d307f9df9#diff-3b508373ace569a6af4c386d9124202aR1980):
+   > `lib/common/xml.c:__xml_acl_check` [now
+   > [`lib/common/acl.c`](https://github.com/ClusterLabs/pacemaker/tree/master/lib/common/acl.c)`:pcmk__check_acl`])
+
+There's also a special extension on top of *active* phase for cases where
+new element(s) can be added, that moreover plugs in
+[the rule *C.* of provisional `write`](#access-control-matrix-completing-rules-initialization-inheritance-rules)
+(also those implementation references are relevant).
+
+*Forward-looking, optimization notice*:
+The above two phases can be merged, building upon principles of lazy
+evaluation, at the cost of lower time-complexity predictability (on the
+other hand, it was WCET in a. previously, and here, it'd be better on
+average) and, indeed, complexity.  Note that application of
+[the inheritance rule *B.*](#access-control-matrix-completing-rules-initialization-inheritance-rules)
+is already a part of the *active* phase.
+
+
+## The object
+
+[Already known](#access-control-as-a-set-of-conjunctions-of-three)
+is that the __Assets__ in this access control model are
+[elements](https://www.w3.org/TR/xml/#dt-element) and
+[attributes](https://www.w3.org/TR/xml/#dt-attr) within the XML document
+that represents the key dataset of pacemaker.  At this time, other
+components of XML are treated as follows:
+
+* [comments](https://www.w3.org/TR/xml/#dt-comment):
+
+   - implicit `write` _access control label_ is assumed, that is, arbitrary
+     _subject_ can add arbitrary comments anywhere(!), regardless of any
+    [rules](#access-control-matrix-completing-rules-initialization-inheritance-rules)
+    that apply to casual __Assets__.
+
+      > (sample test reference: *none* [only elements get changed])
+
+* the rest
+  ([text nodes](https://www.w3.org/TR/xml/#dt-text) and
+  [processing instructions](https://www.w3.org/TR/xml/#dt-pi)):
+
+   - shall not figure in the XML document being processed, to begin with
+
+      > (sample test reference: *none* [ditto])
+
+Likewise, we already
+[defined](#access-control-as-a-set-of-conjunctions-of-three)
+*the object* being a declarative selection of these __Assets__, and we
+further simplified the landscape by assuming such selection applicable
+to at most a single __Asset__.
+
+### No attribute-level granularity
+
+While there's a way to select particular elements also conditionally per the
+predicates related to their attribute(s) --- stemming naturally from the
+expressiveness of the XPath selection applied under the hood --- XML attributes
+are currently below the _access control_ granularity, i.e., their _access
+control_ is solely driven by the respective containing element.
+
+*Forward-looking notice*:
+Access mode visualization per _the subject_ as exposed with
+`cibadmin --access-render` is ready to deal with attribute-level granularity
+shall it be introduced later on.  Any SW dealing with such outputs shall
+not rely on attributes always matching their parent elements on
+_the access control label_ applied.
+
+### Historical excurse: multi-match resolution
+
+It may so happen that a single _object_ will get matched multiple times
+related to _the_ same _subject_ at hand.  In that case, there used to be
+two possible behaviours possible, merely for the sake of completeness:
+
+- [*SUSE-compatibility-specific*](https://github.com/ClusterLabs/pacemaker/commit/d200ed0cd):
+
+   only the first (in
+   [document order](https://www.w3.org/TR/1999/REC-xpath-19991116/#dt-document-order)
+   within the respective configuration section in the XML tree) assignment
+   related to particular *object* and *subject* will apply
+
+- *default*:
+
+   a mix of _access control labels_ can be assigned to the *object*
+   (for particular implicit *subject*), the resolution is then governed
+   per [the stated rules](#multi-label-resolution)
+
+
+## The subject
+
+In the preceding text, the notion of __Actor__ and its "all powerful"
+specialization __Superactor__ were briefly mentioned.  It's time to look
+at these instances of _the subject_ in our access control model.
+
+### Superactor untangled
+
+Abstract __Superactor__ concept is currently defined in terms of either
+[*real*](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_315),
+`ruid` (Linux), or
+[*effective*](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_142),
+`euid` (practically all other semi/supported POSIX systems),
+*user identification*, as derived from the process connecting to one
+of the pacemaker daemons so as to make a request (_pull_ model, any _push_
+model arrangement needs to be initiated with a _pull_ of sorts),
+and resolves to either of:
+
+- `root` (beware, against intuition, regardless of `ruid=0`/`euid=0`!)
+- [`hacluster`](https://github.com/ClusterLabs/pacemaker/blob/Pacemaker-2.0.2/configure.ac#L1084)
+
+As stated, __Superactor__ is exempted from any access control considerations
+(hence this "all powerful" tag).  Plugging the raw communication layer into
+the picture for a bit again, this is a two-fold "free pass":
+
+1. when accessing pacemaker daemons' API end-points as such, since
+   this is one of the parallel prerequisites⁵ (alternatively, the user
+   connecting in needs to be in
+   [`haclient`](https://github.com/ClusterLabs/pacemaker/blob/Pacemaker-2.0.2/configure.ac#L1088)
+   group)
+
+2. access control per the discussed model (if the feature is enabled at all)
+
+* * *
+
+> ⁵ Note, however, that being `ruid=0`/`euid=0` alone in this API end-point
+>   connection context may not be sufficient in the current arrangement of
+>   pacemaker daemons that would offer the shared memory files to client
+>   under `haclient` user ownership when such nominal __Superactor__ is
+>   constrained from otherwise implicitly assumed "*DAC* override"
+>   (in Linux in particular, lacking
+>   [`CAP_DAC_OVERRIDE`](https://linux.die.net/man/7/credentials)
+>   capability) privileges, as may happen, e.g., under *SELinux* containment.
+
+* * *
+
+### Subject specification indirection through roles
+
+For casual __Actors__ (not satisifying __Superactor__ criteria), there's
+a configuration layer indirection allowing to put a multiple individually
+selected ones in to one set, and only this set can actually figure in
+_the access control triple_.  But it's only another kind of syntactic
+sugar for the configuration purposes otherwise not increasing the
+expression power a tiny bit, we will hence keep it out of this scope.
+
+Even if it is insignificant from conceptual perspective, it is worth
+mentioning, though, for two reasons:
+
+* it's what actually plugs the concept of roles (as in
+  [said](#access-control-as-a-set-of-conjunctions-of-three) _RBAC_)
+  into the picture
+
+* to rectify the gap between the design sketch here and the actual
+  configuration facilitated grip into it
+
+### Actor matching criteria
+
+At this point, there's just a single property to discriminate particular
+__Actor__ from the universum so as to expressly specify _the access control
+triple_ --- it is elaborated
+[in the following subsection](#system-user-identifier).
+
+Orthogonal to that, any __Actor__ interfacing with pacemaker API end-points
+needs to satisfy the hard-wired communication layer imposed prerequisite that
+shall be detailed elsewhere,
+<!-- XXX: desirable to have separate communication-layer.md document -->
+but for completeness, the intuitive `(user, groups)` identity of the
+process making an access needs to satisfy either of:
+
+* `ruid`/`euid` resolved to `root` (literally, without considering
+  `ruid=0`/`euid=0` once the API end-point was successfully passed!) or
+  [`hacluster`](https://github.com/ClusterLabs/pacemaker/blob/Pacemaker-2.0.2/configure.ac#L1084)
+  (corresponds to __Superactor__ [per above](#superactor-untangled))
+
+* [`egid`](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_141)
+  (group counterpart to `euid`) resolved to, or associated
+  [_supplementary groups_](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_378)
+  include one resolved to
+  [`haclient`](https://github.com/ClusterLabs/pacemaker/blob/Pacemaker-2.0.2/configure.ac#L1088)
+
+   - the above expresses (is rather a corollary of) the concept of
+     [*file group class*](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_167)
+     that is being relied upon here
+
+> (implementation reference as of
+> [`165b05e9b`](https://github.com/ClusterLabs/pacemaker/commit/165b05e9b#diff-f0c579bcdba77d0ea4c6f0a89ee91b86R238-R274):
+> `lib/common/ipc.c:crm_client_new`)
+
+#### System user identifier
+
+As preceded, this is currently the only available criterion to identify
+particular __Actor__ (_subject_) with, unless already identified as
+__Superactor__.
+
+Likewise, the communication layer authentication is to be back-referenced
+here, since that's what normally implies where said user identifier will
+be sourced from.  Simply put, there's no better assurance about the _subject_
+to make than what's derived (assurable given the OS authenticity attestation
+guarantees) from the actual Unix socket based connection.
+
+Call stack wise, let's start the excursion with
+[`libqb`](https://github.com/ClusterLabs/libqb) provided
+[`qb_ipcs_service_t` abstraction](https://clusterlabs.github.io/libqb/1.0.5/doxygen/qbipcs_8h.html#a098e863e2720e4611d49621487c9ca9d).
+This is also what encapsulates the process of obtaining such OS assured
+user identification for us, which is then passed into pacemaker
+daemon-specific `connection_accept` callback stored within such
+`qb_ipc_service_t` object, eventually triping over a common
+[client entry function](https://github.com/ClusterLabs/pacemaker/blob/Pacemaker-2.0.2/lib/common/ipc.c#L364-L408).
+Deep down, `libqb` relies on `libc` provided (and generally fairly
+[platform specific](https://docs.fedoraproject.org/en-US/Fedora_Security_Team/1/html/Defensive_Coding/sect-Defensive_Coding-Authentication-UNIX_Domain.html),
+without any POSIX imposed unification) means to obtain `ruid`/`euid` and
+`rgid`/`egid` of the _subject_.  Corollary is that whenever the process
+connecting towards pacemaker is not exercising any kind of
+[credentials](https://linux.die.net/man/7/credentials)
+twist (as in `seteuid`, `setegid`, etc., or conversely, when absolute
+reset of the respective identification is used, as in `setuid`, is made
+prior to any connection; both satisified with native pacemaker tooling),
+we can freely ignore the difference between *real* and *effective*
+tag to particular identifier.
+
+Value of interest here, `ruid`/`euid`, is then converted to full-fledged
+system user identifier using the standard `libc` function
+[`getpwuid`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpwuid.html).
+This means that eventually what can be denoted as system
+[_user database_](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_435)
+will be consulted.
+
+Moreover, corollary is that with some implementations of `libc` and their
+broader interpretation as to what _user database_ is, fully synthetic entries
+originated in, say, a particular
+[*NSS* module](https://www.gnu.org/software/libc/manual/html_node/Name-Service-Switch.html),
+can get into the mix when such overrides are not configured for strict
+consistency with the surrounding system⁶.
+
+Finally, such obtained string is matched against explicitly configured
+__Actors__ in _the access control triple_.
+
+* * *
+
+> ⁶ POSIX OS kernel really only deals with integer based identifications under
+>   the hood for access control for basic resource abstractions like files and
+>   processes; the resolution to and from human friendly names is just a user
+>   space/`libc` convenience of sorts.
+
+* * *
+
+
+## Practical examples of how the model works
+
+* _objects_ (given through XPath expressions):
+
+   - `obj1`: `/cib/configuration`
+   - `obj2`: `/cib/configuration/crm_config`
+   - `obj3`: `//crm_config` (intentionally, `obj2` = `obj3`
+     for a schema-conformant pacemaker base document)
+
+* explicitly configured _access control triples_ for _objects_:
+
+   - `act1`: `(obj1, user:alice, read)`
+   - `act2`: `(obj1, user:bob, read)`
+   - * * *
+   - `act3`: `(obj1, user:carol, deny)`
+   - `act4`: `(obj1, user:carol, read)`
+   - * * *
+   - `act5`: `(obj2, user:alice, read)`
+   - `act6`: `(obj3, user:alice, write)`
+   - `act7`: `(obj3, user:alice, deny)`
+
+* relevant system user to group(s) memberships:
+
+   - user `alice`: `haclient`
+   - user `bob`: *not in any relevant group*
+   - user `root`: *not in any relevant group*, note we assume,
+     conventionally, `uid = 0` and no kind of *DAC* override
+     involved, so it is not refused
+     [at the API end-point entry](#superactor-untangled)
+     right away
+   - user `hacluster`: `haclient` (a strict prerequisite for when
+     particular pacemaker daemon runs as [super]privileged
+     user on its own)
+   - user `carol`: `haclient`
+
+In practice:
+
+   - *Ex. 1*: for `/cib`, user `alice` gets `deny` assessment of
+     _access control_, based on the *initialization rule* (*A.*) from
+     [the stated implicit fallbacks](#access-control-matrix-completing-rules-initialization-inheritance-rules)
+     that the root XML element not explicitly configured otherwise will get
+     initialized like this
+
+   - *Ex. 2*: for `/cib/status`, user `alice` gets `read` assessment of
+     _access control_, based on the *inheritance rule* (*B.*) from
+     [the stated implicit fallbacks](#access-control-matrix-completing-rules-initialization-inheritance-rules)
+     that carries over the resolution from the immediate parent _object_,
+     which so happens to likewise not be regulated explicitly and gets
+     likewise implicitly completed --- see the previous *Ex 1.*
+
+   - *Ex. 3*: for `/cib/configuration` (`obj1`), user `alice` gets `read`
+     assessment of _access control_, since this is a trivial match with `act1`
+     explicitly resolving triple, without any further involvement
+
+   * * *
+
+   - *Ex. 4*: for `/cib/configuration` (`obj1`), user `bob` gets
+     *equivalent of* `deny` assessment of _access control_, since a basic
+     prerequisite of the API end-point layer ---
+     [membership in the `haclient` group](#actor-matching-criteria)
+     --- is not fulfilled, so that the respective data _access
+     control_ will not get questioned at all, for a premature denial
+     (the same principle applies also for *group class* resolution, and is
+     is not reproduced there for its obviousness)
+
+   - *Ex. 5*: for `/cib/configuration` (`obj1`), user `root` under
+     above assumptions
+     [will get said free pass](#superactor-untangled)
+
+   - *Ex. 6*: for `/cib/configuration` (`obj1`), user `haclient` under
+     above assumptions
+     [will get said free pass](#superactor-untangled)
+
+   - *Ex. 7*: for `/cib/configuration` (`obj1`), user `carol` (who does not
+     suffer from the lack of `haclient` group membership, which was
+     a showstopper for `bob`, see the previous *Ex. 6*) gets `deny` assessment
+     of _access control_, since the candidate set of intermediaries
+     `{deny, read}` --- coming from `act3`, `act4` respectively --- is
+     processed per [multi-label resolution](#multi-label-resolution)
+     whereby `deny` dominates the other "accomplice" label, `read` (see 1.)
+
+   * * *
+
+   - *Ex. 8*: for `/cib/configuration/crm_config` (`obj2` = `obj3`), user
+     `alice` gets `deny` assessment of _access control_, since the candidate
+     set of intermediaries `{read, write, deny}` --- coming from `act5`,
+     `act6`, `act7`, respectively --- is processed per
+     [multi-label resolution](#multi-label-resolution)
+     whereby `deny` dominates any other "accomplice" label (see 1.)
+
+   - *Ex. 9*: for `/cib/configuration/crm_config/cluster_property_set`, user
+     `alice` gets `deny` assessment of _access control_, based on the
+     *inheritance rule* (*B.*) from
+     [the stated implicit fallbacks](#access-control-matrix-completing-rules-initialization-inheritance-rules)
+     that carries over the resolution from the immediate parent _object_
+     --- see the previous *Ex. 8*

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -56,15 +56,20 @@ xmlNode *get_message_xml(xmlNode * msg, const char *field);
 xmlDoc *getDocPtr(xmlNode * node);
 
 /*
- * Replacement function for xmlCopyPropList which at the very least,
- * doesn't work the way *I* would expect it to.
+ * \brief xmlCopyPropList ACLs-sensitive replacement expading i++ notation
  *
- * Copy all the attributes/properties from src into target.
+ * The gist is the same as with \c{xmlCopyPropList(target, src->properties)}.
  *
- * Not recursive, does not return anything.
+ * \param[in,out] target  Element to receive attributes from #src element
+ * \param[in]     src     Element carrying attributes to copy over to #target
  *
+ * \note Original commit 1c632c506 sadly haven't stated which otherwise
+ *       assumed behaviours of xmlCopyPropList were missing beyond otherwise
+ *       custom extensions like said ACLs and "atomic increment" (that landed
+ *       later on, anyway).
  */
-void copy_in_properties(xmlNode * target, xmlNode * src);
+void copy_in_properties(xmlNode *target, xmlNode *src);
+
 void expand_plus_plus(xmlNode * target, const char *name, const char *value);
 void fix_plus_plus_recursive(xmlNode * target);
 

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -333,6 +333,50 @@ int xml_apply_patchset(xmlNode *xml, xmlNode *patchset, bool check_version);
 
 void patchset_process_digest(xmlNode *patch, xmlNode *source, xmlNode *target, bool with_digest);
 
+/* exclusive (should any combination make sense -> explicitly enumerated),
+   with intentional symbolic constant duality (easier to adapt to growth) */
+enum pcmk_acl_cred_type {
+#define PCMK_ACL_CRED_UNSET PCMK_ACL_CRED_UNSET
+    PCMK_ACL_CRED_UNSET = 0,
+#define PCMK_ACL_CRED_USER PCMK_ACL_CRED_USER
+    PCMK_ACL_CRED_USER,
+    /* XXX no proper support for groups yet */
+};
+
+/* need to be ORable */
+enum pcmk_acl_verdict {
+    PCMK_ACL_VERDICT_WRITABLE = 1 << 0,
+    PCMK_ACL_VERDICT_READABLE = 1 << 1,
+    PCMK_ACL_VERDICT_DENIED   = 1 << 2,
+};
+
+/*!
+ * \brief Mark CIB with namespace-encoded result of ACLs eval'd per credential
+ *
+ * \param[in] cred_type        credential type that \p cred represents
+ * \param[in] cred             credential whose ACL perspective to switch to
+ * \param[in] cib_doc          XML document representing CIB
+ * \param[out] acl_evaled_doc  XML document representing CIB, with said
+ *                             namespace-based annotations throughout
+ *
+ * \return  0 if ACLs were not applicable, >0 if it was and all went fine
+ *          (this is the only case when it's safe to touch \p acl_evaled_doc
+ *          afterwards, the result is #PCMK_ACL_VERDICT_WRITABLE,
+ *          #PCMK_ACL_VERDICT_READABLE and #PCMK_ACL_VERDICT_DENIED bits
+ *          ORed respectively), -2 on run-time unrecognized \p cred_type,
+ *          -3 on unsupported validation schema version (see below),
+ *          or -1 on any other/generic issue
+ *
+ * \note Only supported schemas are those following acls-2.0.rng, that is,
+ *       those validated with pacemaker-2.0.rng and newer (artificially caped
+ *       at 4.0, not including it (the future cannot be predicted,
+ *       compatibility needs to be confirmed, then, hopefully leading to
+ *       this comment being updated).
+ */
+int pcmk_acl_evaled_as_namespaces(enum pcmk_acl_cred_type cred_type,
+                                  const char *cred, xmlDoc *cib_doc,
+                                  xmlDoc **acl_evaled_doc);
+
 void save_xml_to_file(xmlNode * xml, const char *desc, const char *filename);
 char *xml_get_path(xmlNode *xml);
 

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -59,6 +59,11 @@ xmlDoc *getDocPtr(xmlNode * node);
  * \brief xmlCopyPropList ACLs-sensitive replacement expading i++ notation
  *
  * The gist is the same as with \c{xmlCopyPropList(target, src->properties)}.
+ * The function exits prematurely when any attribute cannot be copied for
+ * ACLs violation.  Even without bailing out, the result can possibly be
+ * incosistent with expectations in that case, hence the caller shall,
+ * aposteriori, verify that no document-level-tracked denial was indicated
+ * with \c{xml_acl_denied(target)} and drop whole such intermediate object.
  *
  * \param[in,out] target  Element to receive attributes from #src element
  * \param[in]     src     Element carrying attributes to copy over to #target

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -184,10 +184,11 @@ enum pcmk__acl_render_how {
  *
  * This function is vitally coupled with externalized material:
  * - access-render-2.xsl
+ * - access-render.cfg.xsl (referred to from the former in an abstracted way)
  *
  * In fact, it's just a wrapper for a graceful conducting of such
  * transformation, in particular, it cares about converting values of some
- * configuration parameters directly in said stylesheet since the desired
+ * configuration parameters directly in said stylesheet(s) since the desired
  * ANSI colors at the output are not expressible directly (alternative approach
  * to this preprocessing: eventual postprocessing, which is less handy here).
  *

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the Pacemaker project contributors
+ * Copyright 2017-2019 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -132,6 +132,15 @@ do {                                                                            
         free(CXLB_buf);                                                         \
     }                                                                           \
 } while (0)
+
+/*!
+ * \internal
+ * \brief Serialize XML (using libxml) into provided descriptor
+ *
+ * \param[in] fd  File descriptor to (piece-wise) write to
+ * \param[in] cur XML subtree to proceed
+ */
+void pcmk__xml_serialize_fd_formatted(int fd, xmlNode *cur);
 
 enum pcmk__xml_artefact_ns {
     pcmk__xml_artefact_ns_legacy_rng = 1,

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -30,6 +30,20 @@
 
 #  include <crm/crm.h>  /* transitively imports qblog.h */
 
+/*!
+ * \internal
+ * \brief Dummy marker to indicate the "calls itself directly".
+ *
+ * \note Having such a marker consistently used for what's inherently
+ *       a tree algoritm (and commonly, in-depth XML processing is of
+ *       this kind) is indispensable for a general reasoning in the
+ *       context of the tree (is this function meant to only be applied
+ *       to root/leave/complement of those two? etc.).
+ *
+ * \note Currently only applied in \c{acl.c}.
+ */
+#define PCMK__XML_DIRECTLY_RECURSIVE
+
 
 /*!
  * \brief Base for directing lib{xml2,xslt} log into standard libqb backend

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -172,4 +172,36 @@ pcmk__xml_artefact_root(enum pcmk__xml_artefact_ns ns);
 char *pcmk__xml_artefact_path(enum pcmk__xml_artefact_ns ns,
                               const char *filespec);
 
+enum pcmk__acl_render_how {
+    pcmk__acl_render_ns_simple = 1,
+    pcmk__acl_render_text,
+    pcmk__acl_render_color,
+};
+
+/*!
+ * \internal
+ * \brief Serialize-render already pcmk_acl_evaled_as_namespaces annotated XML
+ *
+ * This function is vitally coupled with externalized material:
+ * - access-render-2.xsl
+ *
+ * In fact, it's just a wrapper for a graceful conducting of such
+ * transformation, in particular, it cares about converting values of some
+ * configuration parameters directly in said stylesheet since the desired
+ * ANSI colors at the output are not expressible directly (alternative approach
+ * to this preprocessing: eventual postprocessing, which is less handy here).
+ *
+ * \param[in] annotated_doc pcmk_acl_evaled_as_namespaces annotated XML
+ * \param[in] how           render kind, see #pcmk__acl_render_how enumeration
+ * \param[out] doc_txt_ptr  where to put the final outcome string
+ * \param[out] doc_txt_len  length of the output string \p doc_txt_ptr
+ * \return 0 or -1, see \c xsltSaveResultToString
+ *
+ * \note Currently, the function did not receive enough of testing regarding
+ *       leak of resources, hence it is not recommended for anything other
+ *       than short-lived processes at this time.
+ */
+int pcmk__acl_evaled_render(xmlDoc *annotated_doc, enum pcmk__acl_render_how,
+                            xmlChar **doc_txt_ptr, int *doc_txt_len);
+
 #endif

--- a/include/crm/compatibility.h
+++ b/include/crm/compatibility.h
@@ -236,6 +236,18 @@ get_resource_typename(enum pe_obj_types type)
     return "<unknown>";
 }
 
+
+/*
+ * Version compatibility tracking incl. open-ended intervals for occasional
+ * bumps (to avoid hard to follow open-coding throughout).  Grouped by context.
+ */
+
+/* Schema version vs. evaluate-as-namespace-annotations-per-credentials */
+
+#define PCMK_COMPAT_ACL_2_MIN_INCL "pacemaker-2.0"
+#define PCMK_COMPAT_ACL_2_MAX_EXCL "pacemaker-4.0"  /* bump if remains OK */
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -443,6 +443,11 @@ update_cib_object(xmlNode * parent, xmlNode * update)
 
     copy_in_properties(target, update);
 
+    if (xml_acl_denied(target)) {
+        crm_notice("Cannot update <%s id=%s>", crm_str(object_name), crm_str(object_id));
+        return -EACCES;
+    }
+
     crm_trace("Processing children of <%s id=%s>", crm_str(object_name), crm_str(object_id));
 
     for (a_child = __xml_first_child(update); a_child != NULL; a_child = __xml_next(a_child)) {

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -7,6 +7,14 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
+/*! \file
+ * \internal
+ * Implementation bits for the data access control feature.
+ *
+ * \see doc/design/data-access-control.md
+ */
+
+
 #include <crm_internal.h>
 
 #include <stdio.h>

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -153,6 +153,7 @@ __xml_acl_create(xmlNode *xml, GList *acls, enum xml_private_flags mode)
  *
  * \return New head of (possibly modified) acls
  */
+PCMK__XML_DIRECTLY_RECURSIVE
 static GList *
 __xml_acl_parse_entry(xmlNode *acl_top, xmlNode *acl_entry, GList *acls)
 {
@@ -395,6 +396,7 @@ __xml_acl_mode_test(enum xml_private_flags allowed,
 /* rc = TRUE if orig_cib has been filtered
  * That means '*result' rather than 'xml' should be exploited afterwards
  */
+PCMK__XML_DIRECTLY_RECURSIVE
 static bool
 __xml_purge_attributes(xmlNode *xml)
 {
@@ -574,6 +576,7 @@ implicitly_allowed(xmlNode *xml)
  * \param[in]     check_top  Whether to apply checks to argument itself
  *                           (if TRUE, xml might get freed)
  */
+PCMK__XML_DIRECTLY_RECURSIVE
 void
 pcmk__apply_creation_acl(xmlNode *xml, bool check_top)
 {
@@ -826,6 +829,7 @@ static const xmlChar *NS_WRITABLE = (xmlChar *) ACL_NS_PREFIX "writable";
 static const xmlChar *NS_READABLE = (xmlChar *) ACL_NS_PREFIX "readable";
 static const xmlChar *NS_DENIED =   (xmlChar *) ACL_NS_PREFIX "denied";
 
+PCMK__XML_DIRECTLY_RECURSIVE
 static int
 pcmk__eval_acl_as_namespaces_2(xmlNode *xml_modify)
 {

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -16,11 +16,20 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+#include <libxml/parser.h>
 #include <libxml/tree.h>
+#include <libxml/xpath.h>
+#if HAVE_LIBXSLT
+#  include <libxslt/transform.h>
+#  include <libxslt/variables.h>
+#  include <libxslt/xsltutils.h>
+#endif
 
+#include <crm/compatibility.h>  /* PCMK_COMPAT_ACL_2_* */
 #include <crm/crm.h>
 #include <crm/msg_xml.h>
 #include <crm/common/xml.h>
+#include <crm/common/xml_internal.h>
 #include "crmcommon_private.h"
 
 #define MAX_XPATH_LEN	4096
@@ -800,4 +809,365 @@ crm_acl_get_set_user(xmlNode *request, const char *field, const char *peer_user)
 
     return requested_user;
 }
+
+#define ACL_NS_PREFIX "http://clusterlabs.org/ns/pacemaker/access/"
+#define ACL_NS_Q_PREFIX  "pcmk-access-"
+#define ACL_NS_Q_WRITABLE (const xmlChar *) ACL_NS_Q_PREFIX   "writable"
+#define ACL_NS_Q_READABLE (const xmlChar *) ACL_NS_Q_PREFIX   "readable"
+#define ACL_NS_Q_DENIED   (const xmlChar *) ACL_NS_Q_PREFIX   "denied"
+
+static const xmlChar *NS_WRITABLE = (xmlChar *) ACL_NS_PREFIX "writable";
+static const xmlChar *NS_READABLE = (xmlChar *) ACL_NS_PREFIX "readable";
+static const xmlChar *NS_DENIED =   (xmlChar *) ACL_NS_PREFIX "denied";
+
+static int
+pcmk__eval_acl_as_namespaces_2(xmlNode *xml_modify)
+{
+
+    static xmlNs *ns_recycle_writable = NULL,
+                 *ns_recycle_readable = NULL,
+                 *ns_recycle_denied = NULL;
+    static const xmlDoc *prev_doc = NULL;
+
+    xmlNode *i_node = NULL;
+    const xmlChar *ns;
+    int ret = 0;
+
+    if (prev_doc == NULL || prev_doc != xml_modify->doc) {
+        prev_doc = xml_modify->doc;
+        ns_recycle_writable = ns_recycle_readable = ns_recycle_denied = NULL;
+    }
+
+    for (i_node = xml_modify; i_node != NULL; i_node = i_node->next) {
+        switch (i_node->type) {
+        case XML_ELEMENT_NODE:
+            pcmk__set_xml_flag(i_node, xpf_tracking);
+            ns = !pcmk__check_acl(i_node, NULL, xpf_acl_read)
+                 ? NS_DENIED
+                 : !pcmk__check_acl(i_node, NULL, xpf_acl_write)
+                   ? NS_READABLE
+                   : NS_WRITABLE;
+            if (ns == NS_WRITABLE) {
+                if (ns_recycle_writable == NULL) {
+                    ns_recycle_writable = xmlNewNs(xmlDocGetRootElement(i_node->doc),
+                                                   NS_WRITABLE, ACL_NS_Q_WRITABLE);
+                    ret |= PCMK_ACL_VERDICT_WRITABLE;
+                }
+                xmlSetNs(i_node, ns_recycle_writable);
+            } else if (ns == NS_READABLE) {
+                if (ns_recycle_readable == NULL) {
+                    ns_recycle_readable = xmlNewNs(xmlDocGetRootElement(i_node->doc),
+                                                   NS_READABLE, ACL_NS_Q_READABLE);
+                    ret |= PCMK_ACL_VERDICT_READABLE;
+                }
+                xmlSetNs(i_node, ns_recycle_readable);
+            } else if (ns == NS_DENIED) {
+                if (ns_recycle_denied == NULL) {
+                    ns_recycle_denied = xmlNewNs(xmlDocGetRootElement(i_node->doc),
+                                                 NS_DENIED, ACL_NS_Q_DENIED);
+                    ret |= PCMK_ACL_VERDICT_DENIED;
+                };
+                xmlSetNs(i_node, ns_recycle_denied);
+            }
+            /* XXX recursion can be turned into plain iteration to save stack */
+            if (i_node->properties != NULL) {
+                /* this is not entirely clear, but relies on the very same
+                   class-hierarchy emulation that libxml2 has firmly baked in
+                   its API/ABI */
+                ret |= pcmk__eval_acl_as_namespaces_2((xmlNodePtr) i_node->properties);
+            }
+            if (i_node->children != NULL) {
+                ret |= pcmk__eval_acl_as_namespaces_2(i_node->children);
+            }
+            break;
+        case XML_ATTRIBUTE_NODE:
+            /* we can utilize that parent has already been assigned the ns */
+            ns = !pcmk__check_acl(i_node->parent,
+                                 (const char *) i_node->name,
+                                 xpf_acl_read)
+                 ? NS_DENIED
+                 : !pcmk__check_acl(i_node,
+                                   (const char *) i_node->name,
+                                   xpf_acl_write)
+                   ? NS_READABLE
+                   : NS_WRITABLE;
+            if (ns == NS_WRITABLE) {
+                if (ns_recycle_writable == NULL) {
+                    ns_recycle_writable = xmlNewNs(xmlDocGetRootElement(i_node->doc),
+                                                   NS_WRITABLE, ACL_NS_Q_WRITABLE);
+                    ret |= PCMK_ACL_VERDICT_WRITABLE;
+                }
+                xmlSetNs(i_node, ns_recycle_writable);
+            } else if (ns == NS_READABLE) {
+                if (ns_recycle_readable == NULL) {
+                    ns_recycle_readable = xmlNewNs(xmlDocGetRootElement(i_node->doc),
+                                                   NS_READABLE, ACL_NS_Q_READABLE);
+                    ret |= PCMK_ACL_VERDICT_READABLE;
+                }
+                xmlSetNs(i_node, ns_recycle_readable);
+            } else if (ns == NS_DENIED) {
+                if (ns_recycle_denied == NULL) {
+                    ns_recycle_denied = xmlNewNs(xmlDocGetRootElement(i_node->doc),
+                                                 NS_DENIED, ACL_NS_Q_DENIED);
+                    ret |= PCMK_ACL_VERDICT_DENIED;
+                }
+                xmlSetNs(i_node, ns_recycle_denied);
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
+    return ret;
+}
+
+int
+pcmk_acl_evaled_as_namespaces(enum pcmk_acl_cred_type cred_type,
+                              const char *cred, xmlDoc *cib_doc,
+                              xmlDoc **acl_evaled_doc)
+{
+    /* XXX requires prior crm_xml_init */
+
+    int ret, version;
+    xmlNode *target, *comment;
+    char comment_buf[256] = "access as evaluated for user ";
+    const char *validation;
+
+    CRM_CHECK(cred != NULL, return -1);
+    CRM_CHECK(cib_doc != NULL, return -1);
+    CRM_CHECK(acl_evaled_doc != NULL, return -1);
+    /* XXX no proper support for groups yet */
+    CRM_CHECK(cred_type == PCMK_ACL_CRED_USER, return -2);
+
+    if (!pcmk_acl_required(cred)) {
+        /* nothing to evaluate */
+        return 0;
+    }
+
+    /* XXX see the comment for this function, pacemaker-4.0 may need
+           updating respectively in the future */
+    validation = crm_element_value(xmlDocGetRootElement(cib_doc),
+                                   XML_ATTR_VALIDATION);
+    version = get_schema_version(validation);
+    if (get_schema_version(PCMK_COMPAT_ACL_2_MIN_INCL) > version
+            || (-1 != get_schema_version(PCMK_COMPAT_ACL_2_MAX_EXCL)
+                    && get_schema_version(PCMK_COMPAT_ACL_2_MAX_EXCL)
+                        <= version)) {
+        return -3;
+    }
+
+    target = copy_xml(xmlDocGetRootElement(cib_doc));
+    if (target == NULL) {
+        return -1;
+    }
+
+    pcmk__unpack_acl(target, target, cred);
+    pcmk__set_xml_flag(target, xpf_acl_enabled);
+    pcmk__apply_acl(target);
+    ret = pcmk__eval_acl_as_namespaces_2(target);  /* XXX may need "switch" */
+
+    if (ret > 0) {
+        /* avoid trivial accidental XML injection */
+        if (strpbrk(cred, "<>&") == NULL) {
+            snprintf(comment_buf + strlen(comment_buf),
+                     sizeof(comment_buf) - strlen(comment_buf), "%s", cred);
+            comment = xmlNewDocComment(target->doc, (pcmkXmlStr) comment_buf);
+            if (comment == NULL) {
+                xmlFreeNode(target);
+                return -1;
+            }
+            xmlAddPrevSibling(xmlDocGetRootElement(target->doc), comment);
+        }
+        *acl_evaled_doc = target->doc;
+    } else {
+        xmlFreeNode(target);
+    }
+    return ret;
+}
+
+/* this is used to dynamically adapt to user-modified stylesheet */
+static const char **
+parse_params(xmlDoc *doc, const char **fallback)
+{
+    xmlXPathContext *xpath_ctxt;
+    xmlXPathObject *xpath_obj;
+    const char **ret = NULL;
+    size_t ret_cnt = 0, ret_iter = 0;
+
+    if (doc == NULL) {
+        return fallback;
+    }
+
+    xpath_ctxt = xmlXPathNewContext(doc);
+    CRM_ASSERT(xpath_ctxt != NULL);
+
+    if (xmlXPathRegisterNs(xpath_ctxt, (pcmkXmlStr) "xsl",
+                           (pcmkXmlStr) "http://www.w3.org/1999/XSL/Transform") != 0) {
+        return fallback;
+    }
+
+    while (*fallback != NULL) {
+        char xpath_query[1024];
+        const char *key = *fallback++;
+        const char *value = *fallback++;
+        CRM_ASSERT(value != NULL);
+
+        if (ret_iter + 1 >= ret_cnt) {
+            ret_cnt = ret_cnt ? ret_cnt : 1;
+            ret_cnt *= 2;
+            ret_cnt += 1;
+            ret = realloc(ret, ret_cnt * sizeof(*ret));
+            CRM_ASSERT(ret != NULL);
+        }
+
+        key = strdup(key);
+        CRM_ASSERT(key != NULL);
+        ret[ret_iter++] = key;
+
+        snprintf(xpath_query, sizeof(xpath_query),
+                 "substring("
+                   "/xsl:stylesheet/xsl:param[@name = '%s']/xsl:value-of/@select,"
+                   "2,"
+                   "string-length(/xsl:stylesheet/xsl:param[@name = '%s']/xsl:value-of/@select) - 2"
+                 ")",
+                 key, key);
+        xpath_obj = xmlXPathEvalExpression((pcmkXmlStr) xpath_query, xpath_ctxt);
+        if (xpath_obj != NULL && xpath_obj->type == XPATH_STRING
+                && *xpath_obj->stringval != '\0') {
+            /* XXX convert first! */
+            char *origval = strdup((const char *) xpath_obj->stringval);
+            size_t reminder = strlen(origval) + 1;
+            xmlXPathFreeObject(xpath_obj);
+            value = origval;
+            /* reconcile "\x1b" (3 chars) -> '\x1b' (single char) */
+            while ((origval = strstr(origval, "\\x1b")) != NULL) {
+                origval[0] = '\x1b';
+                memmove(origval + 1, origval + (sizeof("\\x1b") - 1),
+                        (reminder -= (sizeof("\\x1b") - 1)));
+            }
+        } else {
+            value = strdup(value);
+        }
+        CRM_ASSERT(value != NULL);
+        ret[ret_iter++] = value;
+    }
+    ret[ret_iter] = NULL;
+
+    return ret;
+}
+
+int
+pcmk__acl_evaled_render(xmlDoc *annotated_doc, enum pcmk__acl_render_how how,
+                        xmlChar **doc_txt_ptr, int *doc_txt_len)
+{
+#if HAVE_LIBXSLT
+    xmlDoc *xslt_doc;
+    xsltStylesheet *xslt;
+    xsltTransformContext *xslt_ctxt;
+    xmlDoc *res;
+    char *sfile;
+    static const char *params_ns_simple[] = {
+        "accessrendercfg:c-writable",           ACL_NS_Q_PREFIX "writable:",
+        "accessrendercfg:c-readable",           ACL_NS_Q_PREFIX "readable:",
+        "accessrendercfg:c-denied",             ACL_NS_Q_PREFIX "denied:",
+        "accessrendercfg:c-reset",              "",
+        "accessrender:extra-spacing",           "no",
+        "accessrender:self-reproducing-prefix", ACL_NS_Q_PREFIX,
+        NULL
+    }, *params_useansi[] = {
+        /* start with hard-coded defaults, then adapt per the template ones */
+        "accessrendercfg:c-writable",           "\x1b[32m",
+        "accessrendercfg:c-readable",           "\x1b[34m",
+        "accessrendercfg:c-denied",             "\x1b[31m",
+        "accessrendercfg:c-reset",              "\x1b[0m",
+        "accessrender:extra-spacing",           "no",
+        "accessrender:self-reproducing-prefix", ACL_NS_Q_PREFIX,
+        NULL
+    }, *params_noansi[] = {
+        "accessrendercfg:c-writable",           "vvv---[ WRITABLE ]---vvv",
+        "accessrendercfg:c-readable",           "vvv---[ READABLE ]---vvv",
+        "accessrendercfg:c-denied",             "vvv---[ ~DENIED~ ]---vvv",
+        "accessrendercfg:c-reset",              "",
+        "accessrender:extra-spacing",           "yes",
+        "accessrender:self-reproducing-prefix", "",
+        NULL
+    };
+    const char **params;
+    int ret;
+    xmlParserCtxtPtr parser_ctxt;
+
+    /* unfortunately, the input (coming from CIB originally) was parsed with
+       blanks ignored, and since the output is a conversion of XML to text
+       format (we would be covered otherwise thanks to implicit
+       pretty-printing), we need to dump the tree to string output first,
+       only to subsequently reparse it -- this time with blanks honoured */
+    xmlChar *annotated_dump;
+    int dump_size;
+    xmlDocDumpFormatMemory(annotated_doc, &annotated_dump, &dump_size, 1);
+    res = xmlReadDoc(annotated_dump, "on-the-fly-access-render", NULL,
+                     XML_PARSE_NONET);
+    CRM_ASSERT(res != NULL);
+    xmlFree(annotated_dump);
+    xmlFreeDoc(annotated_doc);
+    annotated_doc = res;
+
+    sfile = pcmk__xml_artefact_path(pcmk__xml_artefact_ns_base_xslt,
+                                    "access-render-2");
+    parser_ctxt = xmlNewParserCtxt();
+
+    CRM_ASSERT(sfile != NULL);
+    CRM_ASSERT(parser_ctxt != NULL);
+
+    xslt_doc = xmlCtxtReadFile(parser_ctxt, sfile, NULL, XML_PARSE_NONET);
+
+    xslt = xsltParseStylesheetDoc(xslt_doc);  /* acquires xslt_doc! */
+    if (xslt == NULL) {
+        crm_crit("Problem in parsing %s", sfile);
+        return -1;
+    }
+    free(sfile);
+    sfile = NULL;
+    xmlFreeParserCtxt(parser_ctxt);
+
+    xslt_ctxt = xsltNewTransformContext(xslt, annotated_doc);
+    CRM_ASSERT(xslt_ctxt != NULL);
+
+    params = (how == pcmk__acl_render_ns_simple)
+             ? params_ns_simple
+             : (how == pcmk__acl_render_text)
+             ? params_noansi
+             : parse_params(xslt_doc, params_useansi);
+
+    xsltQuoteUserParams(xslt_ctxt, params);
+
+    res = xsltApplyStylesheetUser(xslt, annotated_doc, NULL,
+                                  NULL, NULL, xslt_ctxt);
+
+    xmlFreeDoc(annotated_doc);
+    annotated_doc = NULL;
+    xsltFreeTransformContext(xslt_ctxt);
+    xslt_ctxt = NULL;
+
+    if (how == pcmk__acl_render_color && params != params_useansi) {
+        char **param_i = (char **) params;
+        do {
+            free(*param_i);
+        } while (*param_i++ != NULL);
+        free(params);
+    }
+
+    if (res == NULL) {
+        ret = -1;
+    } else {
+        ret = xsltSaveResultToString(doc_txt_ptr, doc_txt_len, res, xslt);
+        xmlFreeDoc(res);
+    }
+    xsltFreeStylesheet(xslt);
+    return ret;
+#else
+    return -1;
+#endif
+}
+
 #endif

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -36,13 +36,18 @@ enum xml_private_flags {
      xpf_lazy        = 0x4000,
 };
 
-typedef struct xml_private_s {
+typedef struct xml_node_private_s {
+        long check;
+        uint32_t flags;
+} xml_node_private_t;
+
+typedef struct xml_doc_private_s {
         long check;
         uint32_t flags;
         char *user;
         GListPtr acls;
         GListPtr deleted_objs;
-} xml_private_t;
+} xml_doc_private_t;
 
 G_GNUC_INTERNAL
 void pcmk__set_xml_flag(xmlNode *xml, enum xml_private_flags flag);

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -91,4 +91,22 @@ pcmk__xml_attr_value(const xmlAttr *attr)
            : (const char *) attr->children->content;
 }
 
+/*!
+ * \internal
+ * \brief Derive full path to where the pacemaker's user config is expected
+ *
+ * Priorities:
+ * - $XDG_CONFIG_HOME/pacemaker if $XDG_CONFIG_HOME defined
+ * - $HOME/.config/pacemaker if $HOME defined
+ * - /home/$(id -nu)/.config/pacemaker otherwise
+ *
+ * See also:
+ * https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ *
+ * \param[in] basename  final path segment for the configuration file
+ *                      in question
+ * \return full path (dynamically allocated!) or \c NULL in case of error
+ */
+char *pcmk__user_config(const char *basename);
+
 #endif  // CRMCOMMON_PRIVATE__H

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -19,6 +19,7 @@
 #include <crm/crm.h>
 #include <crm/common/output.h>
 #include <crm/common/xml.h>
+#include <crm/common/xml_internal.h>  /* pcmk__xml_serialize_fd_formatted */
 #include <glib.h>
 
 static gboolean legacy_xml = FALSE;
@@ -132,9 +133,7 @@ xml_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_
     }
 
     if (print) {
-        char *buf = dump_xml_formatted_with_text(priv->root);
-        fprintf(out->dest, "%s", buf);
-        free(buf);
+        pcmk__xml_serialize_fd_formatted(fileno(out->dest), priv->root);
     }
 
     if (copy_dest != NULL) {
@@ -144,15 +143,12 @@ xml_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_
 
 static void
 xml_reset(pcmk__output_t *out) {
-    char *buf = NULL;
     private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
 
-    buf = dump_xml_formatted_with_text(priv->root);
-    fprintf(out->dest, "%s", buf);
+    pcmk__xml_serialize_fd_formatted(fileno(out->dest), priv->root);
 
-    free(buf);
     xml_free_priv(out);
     xml_init(out);
 }

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -42,6 +42,8 @@
 #include <crm/common/mainloop.h>
 #include <libxml2/libxml/relaxng.h>
 
+#include "crmcommon_private.h"  /* pcmk__user_config */
+
 #ifndef MAXLINE
 #  define MAXLINE 512
 #endif
@@ -1203,4 +1205,26 @@ pcmk_hostname()
     struct utsname hostinfo;
 
     return (uname(&hostinfo) < 0)? NULL : strdup(hostinfo.nodename);
+}
+
+char *
+pcmk__user_config(const char *basename)
+{
+    struct passwd *pw;
+
+    const char *envstore = getenv("XDG_CONFIG_HOME");
+    if (envstore != NULL) {
+        return crm_strdup_printf("%s/pacemaker/%s", envstore, basename);
+    }
+    envstore = getenv("HOME");
+    if (envstore != NULL) {
+        return crm_strdup_printf("%s/.config/pacemaker/%s", envstore, basename);
+    }
+
+    if ((pw = getpwuid(geteuid())) == NULL || pw->pw_name == NULL
+            || *pw->pw_name == '\0') {
+        return NULL;
+    }
+
+    return crm_strdup_printf("/home/%s/.config/pacemaker/%s", pw->pw_name, basename);
 }

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1857,6 +1857,10 @@ copy_in_properties(xmlNode * target, xmlNode * src)
             const char *p_value = pcmk__xml_attr_value(pIter);
 
             expand_plus_plus(target, p_name, p_value);
+            if (xml_acl_denied(target)) {
+                crm_trace("Cannot copy %s=%s to %s", p_name, p_value, target->name);
+                return;
+            }
         }
     }
 

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -270,6 +270,7 @@ BuildRequires: automake autoconf gcc libtool pkgconfig %{?pkgname_libtool_devel}
 BuildRequires: pkgconfig(glib-2.0) >= 2.16
 BuildRequires: libxml2-devel libxslt-devel libuuid-devel
 BuildRequires: %{pkgname_bzip2_devel}
+BuildRequires: xml-common
 
 # Enables optional functionality
 BuildRequires: ncurses-devel %{pkgname_docbook_xsl}
@@ -460,6 +461,8 @@ manager.
 License:       GPLv2+
 Summary:       Schemas and upgrade stylesheets for Pacemaker
 BuildArch:     noarch
+Requires(post):%{_sysconfdir}/xml/catalog
+Requires(post):libxml2
 
 %description   schemas
 Schemas and upgrade stylesheets for Pacemaker
@@ -692,6 +695,19 @@ exit 0
 %postun cluster-libs -p /sbin/ldconfig
 %endif
 
+%post schemas
+xmlcatalog --noout --add delegateURI \
+  http://clusterlabs.org/nsredir/pacemaker/ \
+  file://%{_datadir}/xml/pacemaker.xml \
+  %{_sysconfdir}/xml/catalog
+
+%postun schemas
+if test "$1" = 0; then
+    xmlcatalog --noout --del \
+      http://clusterlabs.org/nsredir/pacemaker/ \
+      %{_sysconfdir}/xml/catalog || :
+fi
+
 %files
 ###########################################################
 %config(noreplace) %{_sysconfdir}/sysconfig/pacemaker
@@ -744,7 +760,6 @@ exit 0
 %endif
 
 %files cli
-%dir %attr (750, root, %{gname}) %{_sysconfdir}/pacemaker
 %config(noreplace) %{_sysconfdir}/logrotate.d/pacemaker
 %config(noreplace) %{_sysconfdir}/sysconfig/crm_mon
 
@@ -881,10 +896,13 @@ exit 0
 %files schemas
 %license licenses/GPLv2
 %dir %{_datadir}/pacemaker
+%{_datadir}/xml/pacemaker.xml
 %{_datadir}/pacemaker/*.rng
 %{_datadir}/pacemaker/*.xsl
 %{_datadir}/pacemaker/api
 %{_datadir}/pacemaker/base
+%dir %attr (750, root, %{gname}) %{_sysconfdir}/pacemaker
+%config %{_sysconfdir}/pacemaker/access-render.cfg.xsl
 %{_datadir}/pkgconfig/pacemaker-schemas.pc
 
 %changelog

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -884,6 +884,7 @@ exit 0
 %{_datadir}/pacemaker/*.rng
 %{_datadir}/pacemaker/*.xsl
 %{_datadir}/pacemaker/api
+%{_datadir}/pacemaker/base
 %{_datadir}/pkgconfig/pacemaker-schemas.pc
 
 %changelog

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -12,6 +12,7 @@
 #include <crm/crm.h>
 #include <crm/msg_xml.h>
 #include <crm/common/xml.h>
+#include <crm/common/xml_internal.h>  /* pcmk__xml_serialize_fd_formatted */
 #include <crm/common/ipc.h>
 #include <crm/cib/internal.h>
 
@@ -131,8 +132,6 @@ static struct crm_option long_options[] = {
 static void
 print_xml_output(xmlNode * xml)
 {
-    char *buffer;
-
     if (!xml) {
         return;
     } else if (xml->type != XML_ELEMENT_NODE) {
@@ -154,9 +153,7 @@ print_xml_output(xmlNode * xml)
         }
 
     } else {
-        buffer = dump_xml_formatted(xml);
-        fprintf(stdout, "%s", crm_str(buffer));
-        free(buffer);
+        pcmk__xml_serialize_fd_formatted(STDOUT_FILENO, xml);
     }
 }
 
@@ -387,8 +384,8 @@ main(int argc, char **argv)
         if (optind < argc) {
             crm_xml_add(output, XML_ATTR_VALIDATION, argv[optind]);
         }
-        admin_input_xml = dump_xml_formatted(output);
-        fprintf(stdout, "%s\n", crm_str(admin_input_xml));
+        pcmk__xml_serialize_fd_formatted(STDOUT_FILENO, output);
+        xmlFreeDoc(output->doc);
         crm_exit(CRM_EX_OK);
 
     } else if (safe_str_eq(cib_action, "md5-sum")) {

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -16,6 +16,10 @@
 #include <crm/common/ipc.h>
 #include <crm/cib/internal.h>
 
+#define local_barf(...) \
+  do { (void)(fprintf(stderr, __VA_ARGS__) > 0 && fflush(stderr)); } while (0)
+#define local_const_barf(_s) local_barf("%s\n", _s);
+
 static int message_timeout_ms = 30;
 static int command_options = 0;
 static int request_id = 0;
@@ -60,6 +64,17 @@ static struct crm_option long_options[] = {
     {"empty",       0, 0, 'a', "\tOutput an empty CIB"},
     {"md5-sum",	    0, 0, '5', "\tCalculate the on-disk CIB digest"},
     {"md5-sum-versioned",  0, 0, '6', "Calculate an on-the-wire versioned CIB digest"},
+#if ENABLE_ACL
+    {"access-render", optional_argument, 0, 'S',
+                               "Like -Q + evaluate access for --user specified user, presented in particular way"},
+    {"-spacer-",    0, 0, '-', "\n\tThat amounts to one of \"color\" (default for terminal),"
+                               " \"text\" (otherwise), \"ns-full\", \"ns-simple\", or \"auto\""
+                               " (per former defaults)."},
+    {"-spacer-",    0, 0, '-', "\n\tParticular appearance for \"color\" can be administratively modified in"
+                               " /etc/pacemaker/access-render.cfg.xsl file (or equivalent), which can also"
+                               " be overridden per user in $XDG_CONFIG_HOME/pacemaker/access-render.cfg.xsl,"
+                               " where $XDG_CONFIG_HOME is to be understood as ~/.config by default.\n"},
+#endif
     {"blank",       0, 0, '-', NULL, 1},
 
     {"-spacer-",1, 0, '-', "\nAdditional options:"},
@@ -118,6 +133,11 @@ static struct crm_option long_options[] = {
     {"-spacer-",    0, 0, '-', " cibadmin --query > $HOME/local.xml", pcmk_option_example},
     {"-spacer-",    0, 0, '-', " $EDITOR $HOME/local.xml", pcmk_option_example},
     {"-spacer-",    0, 0, '-', " cibadmin --replace --xml-file $HOME/local.xml", pcmk_option_example},
+
+#if ENABLE_ACL
+    {"-spacer-",    0, 0, '-', "Render configuration in color (assuming terminal) visualizing access as evaluated for user tony:", pcmk_option_paragraph},
+    {"-spacer-",    0, 0, '-', " cibadmin --access-render --user tony", pcmk_option_example},
+#endif
 
     {"-spacer-",    0, 0, '-', "SEE ALSO:"},
     {"-spacer-",    0, 0, '-', " crm(8), pcs(8), crm_shadow(8), crm_diff(8)"},
@@ -182,6 +202,18 @@ main(int argc, char **argv)
     gboolean admin_input_stdin = FALSE;
     xmlNode *output = NULL;
     xmlNode *input = NULL;
+#if ENABLE_ACL
+    char *username = NULL;
+    const char *acl_cred = NULL;
+    enum acl_eval_how {
+        acl_eval_unused,
+        acl_eval_auto,
+        acl_eval_ns_full,
+        acl_eval_ns_simple,
+        acl_eval_text,
+        acl_eval_color,
+    } acl_eval_how = acl_eval_unused;
+#endif
 
     int option_index = 0;
 
@@ -224,6 +256,34 @@ main(int argc, char **argv)
                 cib_action = CIB_OP_ERASE;
                 dangerous_cmd = TRUE;
                 break;
+#if ENABLE_ACL
+            case 'S':
+                if (optarg != NULL) {
+                    if (!strcmp(optarg, "auto")) {
+                        acl_eval_how = acl_eval_auto;
+                    } else if (!strcmp(optarg, "ns-full")) {
+                        acl_eval_how = acl_eval_ns_full;
+                    } else if (!strcmp(optarg, "ns-simple")) {
+                        acl_eval_how = acl_eval_ns_simple;
+                    } else if (!strcmp(optarg, "text")) {
+                        acl_eval_how = acl_eval_text;
+                    } else if (!strcmp(optarg, "color")) {
+                        acl_eval_how = acl_eval_color;
+                    } else {
+                        printf("Unrecognized option for --access-render: \"%s\"\n",
+                               optarg);
+                        ++argerr;
+                    }
+                } else {
+                    acl_eval_how = acl_eval_auto;
+                }
+                /* XXX this is a workaround until we unify happy paths for
+                       both a/sync handling; the respective extra code is
+                       only in sync path now, but does it matter at all for
+                       query-like request wrt. what blackbox users observe? */
+                command_options |= cib_sync_call;
+                /* fall-through */
+#endif
             case 'Q':
                 cib_action = CIB_OP_QUERY;
                 break;
@@ -369,6 +429,42 @@ main(int argc, char **argv)
     } else if (admin_input_stdin) {
         source = "STDIN";
         input = stdin2xml();
+
+#if ENABLE_ACL
+    } else if (acl_eval_how != acl_eval_unused) {
+        username = uid2username(geteuid());
+        if (pcmk_acl_required(username)) {
+            if (force_flag == TRUE) {
+                local_const_barf("The supplied command can provide skewed"
+                                 " result since it is run under user that also"
+                                 " gets guarded per ACLs on their own right."
+                                 " Continuing since --force flag was"
+                                 " provided.");
+
+            } else {
+                local_const_barf("The supplied command can provide skewed"
+                                 " result since it is run under user that also"
+                                 " gets guarded per ACLs in their own right."
+                                 " To accept the risk of such a possible"
+                                 " distortion (without even knowing it at this"
+                                 " time), use the --force flag.");
+                crm_exit(CRM_EX_UNSAFE);
+            }
+
+        }
+        free(username);
+        username = NULL;
+
+        if (cib_user == NULL) {
+            local_const_barf("The supplied command requires -U user specified.");
+            crm_exit(CRM_EX_USAGE);
+        }
+
+        /* we already stopped/warned ACL-controlled users about consequences */
+        acl_cred = cib_user;
+        cib_user = NULL;  /* XXX CRM_DAEMON_USER as it's IPC guarded anyway? */
+        /* XXX should likely differenciate per admin_input_* */
+#endif
     }
 
     if (input != NULL) {
@@ -470,6 +566,47 @@ main(int argc, char **argv)
         }
         exit_code = crm_errno2exit(rc);
     }
+
+#if ENABLE_ACL
+    if (output != NULL && acl_eval_how != acl_eval_unused) {
+        xmlDoc *acl_evaled_doc;
+        rc = pcmk_acl_evaled_as_namespaces(PCMK_ACL_CRED_USER, acl_cred,
+                                           output->doc, &acl_evaled_doc);
+        if (rc > 0) {
+            free_xml(output);
+            if (acl_eval_how != acl_eval_ns_full) {
+                xmlChar *rendered = NULL;
+                int rendered_len = 0;
+                enum pcmk__acl_render_how how = (acl_eval_how == acl_eval_ns_simple)
+                                                ? pcmk__acl_render_ns_simple
+                                                : (acl_eval_how == acl_eval_text)
+                                                ? pcmk__acl_render_text
+                                                : (acl_eval_how == acl_eval_color)
+                                                ? pcmk__acl_render_color
+                                                : /*acl_eval_auto*/ isatty(STDOUT_FILENO)
+                                                ? pcmk__acl_render_color
+                                                : pcmk__acl_render_text;
+                if (!pcmk__acl_evaled_render(acl_evaled_doc, how,
+                                             &rendered, &rendered_len)) {
+                    printf("%s\n", (char *) rendered);
+                    free(rendered);
+                } else {
+                    local_const_barf("Could not render evaluated access");
+                    crm_exit(CRM_EX_CONFIG);
+                }
+                output = NULL;
+            } else {
+                output = xmlDocGetRootElement(acl_evaled_doc);
+            }
+        } else if (rc == 0) {
+
+        } else if (rc < 0) {
+            local_barf("Could not evaluate access per request (%s, rc=%d)\n",
+                       acl_cred, rc);
+            crm_exit(CRM_EX_CONFIG);
+        }
+    }
+#endif
 
     if (output != NULL) {
         print_xml_output(output);

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -22,6 +22,9 @@ APIdir	= $(CRM_SCHEMA_DIRECTORY)/api
 CIBdir	= $(CRM_SCHEMA_DIRECTORY)
 MONdir	= $(CRM_SCHEMA_DIRECTORY)
 
+basexsltdir		= $(CRM_SCHEMA_DIRECTORY)/base
+dist_basexslt_DATA	= $(srcdir)/base/access-render-2.xsl
+
 # Extract a sorted list of available numeric schema versions
 # from filenames like NAME-MAJOR[.MINOR][.MINOR-MINOR].rng
 numeric_versions = $(shell ls -1 $(1) \

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -25,6 +25,58 @@ MONdir	= $(CRM_SCHEMA_DIRECTORY)
 basexsltdir		= $(CRM_SCHEMA_DIRECTORY)/base
 dist_basexslt_DATA	= $(srcdir)/base/access-render-2.xsl
 
+cfgdir			= $(PACEMAKER_CONFIG_DIR)
+dist_cfg_DATA		= $(srcdir)/base/access-render.cfg.xsl
+
+# note: second step needs to be performed separately in a staged
+#       installation (like, in %post in RPM spec file), so we mark it as
+#       non-critical -- do NOT forget to rerun it at later stage, then
+# note: $(PCMK_XML_CATALOG_DIR)/pacemaker.xml cannot contain rewriteURI
+#       target constructed as file://$(DESTDIR)/$(PACEMAKER_CONFIG_DIR),
+#       since rpmbuild (check-buildroot helper in particular) would
+#       explode, complaining about the occurrence of dist $(DESTDIR)
+#       resolved string
+install-data-hook:
+	mkdir -p $(DESTDIR)/$(PCMK_XML_CATALOG_DIR)
+if HAVE_xmlcatalog
+	$(XMLCATALOG) --noout --create --add rewriteURI \
+	  http://clusterlabs.org/nsredir/pacemaker/cfg \
+	  file://$(PACEMAKER_CONFIG_DIR) \
+	  $(DESTDIR)/$(PCMK_XML_CATALOG_DIR)/pacemaker.xml
+else
+	>$(DESTDIR)/$(PCMK_XML_CATALOG_DIR)/pacemaker.xml cat <<-EOF \
+	<catalog xmlns='urn:oasis:names:tc:entity:xmlns:xml:catalog'>
+	  <rewriteURI uriStartString='http://clusterlabs.org/nsredir/pacemaker/cfg' rewritePrefix='$(PACEMAKER_CONFIG_DIR)'/>
+	</catalog>
+	EOF
+endif
+	-test "x$(XMLCATALOG)" != x \
+	  && test -w $(DESTDIR)/$(sysconfdir)/xml/catalog \
+	  && $(XMLCATALOG) --noout --add delegateURI \
+	    http://clusterlabs.org/nsredir/pacemaker/ \
+	    file://$(DESTDIR)/$(PCMK_XML_CATALOG_DIR)/pacemaker.xml \
+	    $(DESTDIR)/$(sysconfdir)/xml/catalog \
+	  || \
+	    printf "%s\n%s %s %s %s\n" "do not forget to run (with privs):" \
+	    "$(XMLCATALOG) --noout --add delegateURI" \
+	    http://clusterlabs.org/nsredir/pacemaker/ \
+	    file://$(PCMK_XML_CATALOG_DIR)/pacemaker.xml \
+	    $(sysconfdir)/xml/catalog >&2
+
+# see above wrt. two-staged install, uninstall will likely be totally separate
+uninstall-hook:
+	-test "x$(XMLCATALOG)" != x \
+	  && test -w $(DESTDIR)/$(sysconfdir)/xml/catalog \
+	  && $(XMLCATALOG) --noout --del \
+	    http://clusterlabs.org/nsredir/pacemaker/ \
+	    $(DESTDIR)/$(sysconfdir)/xml/catalog \
+	  || \
+	    printf "%s\n%s %s %s\n" "do not forget to run (with privs):" \
+	    "$(XMLCATALOG) --noout --del" \
+	    http://clusterlabs.org/nsredir/pacemaker/ \
+	    $(sysconfdir)/xml/catalog >&2
+	-rm $(DESTDIR)/$(PCMK_XML_CATALOG_DIR)/pacemaker.xml
+
 # Extract a sorted list of available numeric schema versions
 # from filenames like NAME-MAJOR[.MINOR][.MINOR-MINOR].rng
 numeric_versions = $(shell ls -1 $(1) \

--- a/xml/base/access-render-2.xsl
+++ b/xml/base/access-render-2.xsl
@@ -1,0 +1,256 @@
+<!--
+ Copyright 2019 the Pacemaker project contributors
+
+ The version control history for this file may have further details.
+
+ Licensed under the GNU General Public License version 2 or later (GPLv2+).
+ -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                              xmlns:accessrender="http://clusterlabs.org/ns/pacemaker/access/render/2"
+                              xmlns:accessrendercfg="http://clusterlabs.org/ns/pacemaker/access/render/cfg">
+
+<xsl:output method="text" encoding="UTF-8"/>
+
+<!--
+ see https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bith;
+ note that we need to retain XML 1.0 (as opposed to 1.1, which in turn
+ is not supported in libxml) compatibility in this very template, meaning
+ we cannot output a superset of what's expressible in the template itself
+ (escaped or not), hence we are forced to work that around for \x1b (ESC,
+ unavoidable for ANSI colorized output) character with encoding it in some
+ way (here using "\x1b" literal notation) and requiring a trivial
+ "xsltproc ... | sed 's/\\x1b/\x1b/'" postprocessing;
+ the above, however, only applies when used directly (which may be the
+ reason to pay attention to this comment to begin with), but fortunately
+ it is conveniently avoidable when XSLT triggered programatically (see
+ pcmk__acl_evaled_render), since libxslt allows for passing raw (further
+ unchecked) parameter strings, in which case the actual content of those
+ parameters is decoded on the fly, meaning that this file is still open
+ to compilation-free customizations if there's an irresistible need...
+-->
+<xsl:param name="accessrendercfg:c-writable"><!-- green -->\x1b[32m</xsl:param>
+<xsl:param name="accessrendercfg:c-readable"><!-- blue  -->\x1b[34m</xsl:param>
+<xsl:param name="accessrendercfg:c-denied"><!--   red   -->\x1b[31m</xsl:param>
+<xsl:param name="accessrendercfg:c-reset"><!--    reset -->\x1b[0m</xsl:param>
+
+<xsl:param name="accessrender:extra-spacing">
+  <xsl:value-of select="'no'"/>
+</xsl:param>
+<xsl:param name="accessrender:self-reproducing-prefix">
+  <xsl:value-of select="''"/>
+</xsl:param>
+
+<xsl:variable name="accessrender:ns-writable" select="'http://clusterlabs.org/ns/pacemaker/access/writable'"/>
+<xsl:variable name="accessrender:ns-readable" select="'http://clusterlabs.org/ns/pacemaker/access/readable'"/>
+<xsl:variable name="accessrender:ns-denied"   select="'http://clusterlabs.org/ns/pacemaker/access/denied'"/>
+
+<!--
+
+ accessrender:interpolate-annotation named template
+
+ -->
+
+<xsl:template name="accessrender:interpolate-annotation">
+  <xsl:choose>
+    <xsl:when test="namespace-uri() = $accessrender:ns-writable">
+      <xsl:value-of select="$accessrendercfg:c-writable"/>
+    </xsl:when>
+    <xsl:when test="namespace-uri() = $accessrender:ns-readable">
+      <xsl:value-of select="$accessrendercfg:c-readable"/>
+    </xsl:when>
+    <xsl:when test="namespace-uri() = $accessrender:ns-denied">
+      <xsl:value-of select="$accessrendercfg:c-denied"/>
+    </xsl:when>
+  </xsl:choose>
+</xsl:template>
+
+<!--
+
+ accessrender:namespaces mode
+
+ -->
+
+<xsl:template match="*" mode="accessrender:namespaces">
+  <!-- assume c-writable is representative of others (c-readable, c-denied) -->
+  <xsl:if test="concat(
+                  substring-before($accessrendercfg:c-writable, ':'),
+                  ':'
+                ) = $accessrendercfg:c-writable">
+    <xsl:if test="//*[namespace-uri() = $accessrender:ns-writable]
+                  or
+                  //@*[namespace-uri() = $accessrender:ns-writable]">
+      <xsl:value-of select="concat(' xmlns:',
+                                   substring-before($accessrendercfg:c-writable, ':'),
+                                   '=&quot;', $accessrender:ns-writable, '&quot;')"/>
+    </xsl:if>
+    <xsl:if test="//*[namespace-uri() = $accessrender:ns-readable]
+                  or
+                  //@*[namespace-uri() = $accessrender:ns-readable]">
+      <xsl:value-of select="concat(' xmlns:',
+                                   substring-before($accessrendercfg:c-readable, ':'),
+                                   '=&quot;', $accessrender:ns-readable, '&quot;')"/>
+    </xsl:if>
+    <xsl:if test="//*[namespace-uri() = $accessrender:ns-denied]
+                  or
+                  //@*[namespace-uri() = $accessrender:ns-denied]">
+      <xsl:value-of select="concat(' xmlns:',
+                                   substring-before($accessrendercfg:c-denied, ':'),
+                                   '=&quot;', $accessrender:ns-denied, '&quot;')"/>
+    </xsl:if>
+  </xsl:if>
+</xsl:template>
+
+<!--
+
+ accessrender:proceed mode
+
+ -->
+
+<xsl:template match="*" mode="accessrender:proceed">
+  <xsl:variable name="whitespace-before">
+    <!-- ensure newline also for the root element -->
+    <xsl:choose>
+      <xsl:when test="preceding-sibling::text()[last()] != ''">
+        <xsl:value-of select="preceding-sibling::text()[last()]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'&#xA;'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+  <xsl:variable name="extra-annotation">
+    <xsl:if test="namespace-uri() != namespace-uri(..)">
+      <xsl:call-template name="accessrender:interpolate-annotation"/>
+    </xsl:if>
+  </xsl:variable>
+  <!-- tag opening -->
+  <xsl:choose>
+    <!-- special-casing based on $extra-annotation ending with colon -->
+    <xsl:when test="$accessrender:self-reproducing-prefix != ''
+                    and
+                    concat(
+                      substring-before($extra-annotation, ':'),
+                      ':'
+                    ) = $extra-annotation">
+      <xsl:value-of select="concat('&lt;', $extra-annotation, local-name())"/>
+    </xsl:when>
+    <xsl:when test="$accessrender:extra-spacing = 'yes'
+                    and
+                    $extra-annotation != ''">
+      <xsl:value-of select="concat(
+                              preceding-sibling::text()[last()],
+                              $extra-annotation,
+                              $whitespace-before,
+                              '&lt;',
+                              local-name()
+                            )"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:value-of select="concat($extra-annotation, '&lt;', local-name())"/>
+    </xsl:otherwise>
+  </xsl:choose>
+
+  <xsl:apply-templates mode="accessrender:proceed" select="@*"/>
+
+  <!-- for root and true XML output, figure out the namespaces used -->
+  <xsl:if test=". = /*
+               and
+               $accessrender:self-reproducing-prefix != ''">
+    <xsl:apply-templates mode="accessrender:namespaces" select="."/>
+  </xsl:if>
+
+  <!-- tag closing -->
+  <xsl:choose>
+    <xsl:when test="*|comment()|processing-instruction()">
+      <xsl:value-of select="'&gt;'"/>
+      <xsl:apply-templates mode="accessrender:proceed" select="node()"/>
+      <xsl:choose>
+        <!-- special-casing based on $extra-annotation ending with colon -->
+        <xsl:when test="$accessrender:self-reproducing-prefix != ''
+                        and
+                        concat(
+                          substring-before($extra-annotation, ':'),
+                          ':'
+                        ) = $extra-annotation">
+          <xsl:value-of select="concat(
+                                  '&lt;/',
+                                  $extra-annotation,
+                                  local-name(), '&gt;'
+                                )"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:if test="$accessrender:extra-spacing = 'no'">
+            <xsl:value-of select="$extra-annotation"/>
+          </xsl:if>
+          <xsl:value-of select="concat(
+                                  '&lt;/',
+                                  local-name(),
+                                  '&gt;'
+                                )"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:value-of select="'/&gt;'"/>
+      <xsl:apply-templates mode="accessrender:proceed" select="node()"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<xsl:template match="@*" mode="accessrender:proceed">
+  <!-- XXX especially "text" output untest{ed,able} since no support for
+           attribute granularity for now -->
+  <xsl:variable name="extra-annotation">
+    <xsl:if test="namespace-uri() != namespace-uri(..)">
+      <xsl:call-template name="accessrender:interpolate-annotation"/>
+    </xsl:if>
+  </xsl:variable>
+  <xsl:choose>
+    <xsl:when test="namespace-uri() != namespace-uri(..)
+                    and
+                    $accessrender:self-reproducing-prefix != ''">
+      <xsl:value-of select="' '"/>
+      <xsl:choose>
+        <xsl:when test="concat(
+                          substring-before($extra-annotation, ':'),
+                          ':'
+                        ) = $extra-annotation">
+          <xsl:value-of select="substring-before($extra-annotation, ':')"/>
+        </xsl:when>
+      </xsl:choose>
+      <xsl:value-of select="concat(':', local-name(), '=&quot;', ., '&quot;')"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:value-of select="concat(' ', local-name(), '=&quot;', ., '&quot;')"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<xsl:template match="comment()|processing-instruction()|text()" mode="accessrender:proceed">
+  <xsl:choose>
+    <xsl:when test="self::comment()">
+      <xsl:value-of select="'&lt;!-- '"/>
+    </xsl:when>
+    <xsl:when test="self::processing-instruction()">
+      <xsl:value-of select="'&lt;? '"/>
+    </xsl:when>
+  </xsl:choose>
+  <xsl:value-of select="."/>
+  <xsl:choose>
+    <xsl:when test="self::comment()">
+      <xsl:value-of select="' --&gt;&#xA;'"/>
+    </xsl:when>
+    <xsl:when test="self::processing-instruction()">
+      <xsl:value-of select="'?&gt;'&#xA;"/>
+    </xsl:when>
+  </xsl:choose>
+</xsl:template>
+
+<!-- mode-less, easy to override kick-off -->
+<xsl:template match="/">
+  <xsl:apply-templates mode="accessrender:proceed" select="@*|node()"/>
+  <!-- do not taint any subsequent terminal session -->
+  <xsl:value-of select="$accessrendercfg:c-reset"/>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xml/base/access-render-2.xsl
+++ b/xml/base/access-render-2.xsl
@@ -11,22 +11,18 @@
 
 <xsl:output method="text" encoding="UTF-8"/>
 
-<!--
- see https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bith;
- note that we need to retain XML 1.0 (as opposed to 1.1, which in turn
- is not supported in libxml) compatibility in this very template, meaning
- we cannot output a superset of what's expressible in the template itself
- (escaped or not), hence we are forced to work that around for \x1b (ESC,
- unavoidable for ANSI colorized output) character with encoding it in some
- way (here using "\x1b" literal notation) and requiring a trivial
- "xsltproc ... | sed 's/\\x1b/\x1b/'" postprocessing;
- the above, however, only applies when used directly (which may be the
- reason to pay attention to this comment to begin with), but fortunately
- it is conveniently avoidable when XSLT triggered programatically (see
- pcmk__acl_evaled_render), since libxslt allows for passing raw (further
- unchecked) parameter strings, in which case the actual content of those
- parameters is decoded on the fly, meaning that this file is still open
- to compilation-free customizations if there's an irresistible need...
+<!-- for direct use, you may want to stick with:
+     PATH-TO-PCMK-CHECKOUT/xml/base/access-render.cfg.xsl,
+     all should work automagically from within code (cibadmin) -->
+<xsl:include href="http://clusterlabs.org/nsredir/pacemaker/cfg/access-render.cfg.xsl"/>
+
+<!-- see access-render.cfg.xsl;
+ Regarding said client-side specific preprocessing as a way to avoid
+ full-string postprocessing, fortunately libxslt allows for passing raw
+ (further unchecked) parameter strings, in which case the actual content
+ of those parameters (regardless is from here or from the above include)
+ is decoded on the fly, allowing for compilation-free customizations if
+ there's any need...
 -->
 <xsl:param name="accessrendercfg:c-writable"><!-- green -->\x1b[32m</xsl:param>
 <xsl:param name="accessrendercfg:c-readable"><!-- blue  -->\x1b[34m</xsl:param>

--- a/xml/base/access-render.cfg.xsl
+++ b/xml/base/access-render.cfg.xsl
@@ -1,0 +1,72 @@
+<!--
+ Configuration for the ACLs visualization
+ ========================================
+
+ To be deployed in Pacemaker configuration directory (normally /etc/pacemaker).
+
+
+ Minimal Guidance for the Configuration Format
+ =============================================
+
+ All that's needed is familiarity with XML[1] (how elements, attributes,
+ and comment sections are constructed), then follow the hopefully intuitive
+ commented out per-item configuration directives, that is, when you intend
+ to override something, comment the respective part out (comment delimiters
+ are on separate lines for convenience) and overwrite the value captured
+ by the "select" element.
+
+ Avoiding characters known to be sensitive in XML context is recommended,
+ and should not be needed for the purpose at hand, anyway.
+
+ Advanced use, which is intentionally not detailed here, comprises
+ transitive "xsl:include" processing and some other tricks.
+
+
+ Regarding Configuration of Color Codes to Be Emitted Respectively (c-*)
+ =======================================================================
+
+ Refer to https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bit.
+ Note that we need to retain XML 1.0 (as opposed to 1.1, which in turn
+ is not supported in libxml) compatibility in this very template, meaning
+ we cannot output a superset of what's expressible in the template itself
+ (escaped or not), hence we are forced to work that around for \x1b (ESC,
+ unavoidable for ANSI colorized output) character with encoding it in some
+ way (here using "\x1b" literal notation) and requiring a trivial
+ "xsltproc ... | sed 's/\\x1b/\x1b/'" postprocessing (or client-side
+ specific preprocessing when carried out programmatically).
+
+
+ [1] https://www.w3.org/TR/xml/
+ [2] https://www.w3.org/TR/1999/REC-xpath-19991116/
+ [3] https://www.w3.org/TR/1999/REC-xslt-19991116
+
+-->
+<stylesheet version="1.0"
+            xmlns="http://www.w3.org/1999/XSL/Transform"
+            xmlns:accessrendercfg="http://clusterlabs.org/ns/pacemaker/access/render/cfg">
+
+<!--
+  ANSI escape code encoded and escaped (see above) sequence for ...
+ -->
+
+<!-- ... writable entity (default: green, \x1b[32m) -->
+<!--
+<param name="accessrendercfg:c-writable">\x1b[32m</param>
+-->
+
+<!-- ... just readable entity (default: blue, \x1b[34m) -->
+<!--
+<param name="accessrendercfg:c-readable">\x1b[34m</param>
+-->
+
+<!-- ... completely denied entity (default: red, \x1b[31m) -->
+<!--
+<param name="accessrendercfg:c-denied">\x1b[31m</param>
+-->
+
+<!-- ... a final reset of the output at the end, for completeness (\x1b[0m) -->
+<!--
+<param name="accessrendercfg:c-reset">\x1b[0m</param>
+-->
+
+</stylesheet>

--- a/xml/base/access-render.cfg.xsl
+++ b/xml/base/access-render.cfg.xsl
@@ -1,6 +1,6 @@
 <!--
- Configuration for the ACLs visualization
- ========================================
+ Configuration for the ACLs visualization (as with cibadmin -S)
+ ==============================================================
 
  To be deployed in Pacemaker configuration directory (normally /etc/pacemaker).
 

--- a/xml/helpers/access-render-convert-rng.xsl
+++ b/xml/helpers/access-render-convert-rng.xsl
@@ -1,0 +1,105 @@
+<!--
+ Copyright 2019 the Pacemaker project contributors
+
+ The version control history for this file may have further details.
+
+ Licensed under the GNU General Public License version 2 or later (GPLv2+).
+ -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                              xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                              xmlns="http://relaxng.org/ns/structure/1.0">
+<xsl:output method="xml" encoding="UTF-8" indent="yes" omit-xml-declaration="yes"/>
+
+<xsl:param name="ns-full" select="'yes'"/>
+
+
+<!--
+
+ helpers
+
+ -->
+
+<xsl:template name="quantify-namespaces">
+  <choice>
+    <xsl:if test="$ns-full != 'yes'">
+      <name ns=""><xsl:value-of select="@name"/></name>
+    </xsl:if>
+    <name ns="http://clusterlabs.org/ns/pacemaker/access/writable">
+      <xsl:value-of select="@name"/>
+    </name>
+    <name ns="http://clusterlabs.org/ns/pacemaker/access/readable">
+      <xsl:value-of select="@name"/>
+    </name>
+    <name ns="http://clusterlabs.org/ns/pacemaker/access/denied">
+      <xsl:value-of select="@name"/>
+    </name>
+  </choice>
+</xsl:template>
+
+<!-- drop these -->
+<xsl:template match="@ns[. = '']"/>
+<xsl:template match="@datatypeLibrary[. = '']"/>
+
+<xsl:template match="rng:element[@name] | rng:attribute[not(.//rng:anyName)]">
+  <xsl:copy>
+    <xsl:apply-templates select="@*[name() != 'name']"/>
+    <xsl:call-template name="quantify-namespaces"/>
+    <xsl:apply-templates select="node()"/>
+  </xsl:copy>
+</xsl:template>
+
+<xsl:template match="rng:attribute[
+                       @name
+                       and
+                       rng:data[
+                         (
+                           @type='ID'
+                           or
+                           @type='IDREF'
+                         )
+                         and
+                         @datatypeLibrary='http://www.w3.org/2001/XMLSchema-datatypes'
+                       ]
+                     ]">
+  <xsl:copy>
+    <xsl:apply-templates select="@*[name() != 'name']"/>
+    <xsl:call-template name="quantify-namespaces"/>
+    <xsl:for-each select="node()">
+      <xsl:choose>
+        <xsl:when test="self::rng:data[
+                          @type='ID'
+                          and
+                          @datatypeLibrary='http://www.w3.org/2001/XMLSchema-datatypes'
+                        ]">
+          <xsl:copy>
+            <xsl:attribute name="type">NCName</xsl:attribute>
+            <xsl:apply-templates select="@*[name() != 'type']"/>
+            <xsl:apply-templates select="node()"/>
+          </xsl:copy>
+        </xsl:when>
+        <xsl:when test="self::rng:data[
+                          @type='IDREF'
+                          and
+                          @datatypeLibrary='http://www.w3.org/2001/XMLSchema-datatypes'
+                        ]">
+          <xsl:copy>
+            <xsl:attribute name="type">NCName</xsl:attribute>
+            <xsl:apply-templates select="@*[name() != 'type']"/>
+            <xsl:apply-templates select="node()"/>
+          </xsl:copy>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:copy>
+</xsl:template>
+
+<xsl:template match="@*|node()">
+  <xsl:copy>
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:copy>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xml/helpers/schema-singularize.sh
+++ b/xml/helpers/schema-singularize.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Copyright 2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Substantial part carried over from:
+# https://pagure.io/clufter/blob/master/f/misc/pacemaker-borrow-schemas
+
+die() { echo; echo "$@"; exit 1; }
+
+# $1 ... input directory with original pacemaker schemas
+# $2 ... output directory with consolidated schemas
+# $3 ... schemas to skip (as posix-egrep expression)
+# $4 ... clobber existing files?  (true if set and non-null)
+singularize() {
+	inputdir="${1}"; outputdir="${2}"; skipschemas="${3}"
+	test "${#}" -lt 4 || clobber="${4}"
+	mkdir -p -- "${outputdir}"
+	# for all the schema versions at the boundary of the "major" bump,
+	# except for the lower boundary of the first one (i.e. pacemaker-1.0)
+	# -- the versions in between are not interesting from validation POV
+	for base in $(
+	  find "${inputdir}" -type d -name helpers -prune \
+	    -o -regextype posix-egrep -regex "${skipschemas}" -prune \
+	    -o -name 'pacemaker-*.rng' -printf '%P\n' | sort -V \
+	  | sed -e 'N;/^\(pacemaker-[0-9]\)\.\([0-9][0-9]*\)\.rng\n\1\.\([0-9][0-9]*\)\.rng$/!p;D'); do
+		f="${inputdir}/${base}"
+		printf "processing: ${f} ... "
+		test -f "${f}" || continue
+		sentinel=10; old=/dev/null; new="${f}"
+		# until the jing output converged (simplification gets idempotent)
+		# as prescribed by did-size-change heuristic (or sentinel is hit)
+		while [ "$(stat -c '%s' "${old}")" != "$(stat -c '%s' "${new}")" ]; do
+			[ "$((sentinel -= 1))" -gt 0 ] || break
+			[ "${old}" = "${f}" ] && old="${outputdir}/${base}";
+			[ "${new}" = "${f}" ] \
+			  && { old="${f}"; new="${outputdir}/${base}.new"; } \
+			  || cp -f "${new}" "${old}"
+			jing -is "${old}" > "${new}"
+			#printf "(%d -> %d) " "$(stat -c '%s' "${old}")" "$(stat -c '%s' "${new}")"
+		done
+		printf "%d iterations\n" "$((10 - ${sentinel}))"
+		test -z "${clobber-}" && test -s "${old}" && die "file ${old} already exists" || :
+		mv "${new}" "${old}"
+	done
+}
+
+which jing >/dev/null 2>&1 || die "jing (from jing-trang project) required"
+
+: "${INPUTDIR=$(dirname $0)/..}"
+test -n "${INPUTDIR}" || die "Input dir with pacemaker schemas not known"
+
+: "${OUTPUTDIR=schemas-consolidated}"
+test -n "${OUTPUTDIR}" || die "Output dir for consolidated schemas not known"
+
+# skip non-defaults of upstream releases
+#: "${SKIPSCHEMAS=.*/pacemaker-(1\.0|2\.[126]).rng}"
+: "${SKIPSCHEMAS=".*/pacemaker-next\.rng"}"  # only skip WIP schema by default
+
+singularize "${INPUTDIR}" "${OUTPUTDIR}" "${SKIPSCHEMAS}" "${@}"

--- a/xml/pacemaker-access-3.0.rng
+++ b/xml/pacemaker-access-3.0.rng
@@ -1,0 +1,3114 @@
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <ref name="cib"/>
+  </start>
+  <define name="cib">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">cib</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">cib</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">cib</name></choice>
+      <group>
+        <interleave>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">validate-with</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">validate-with</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">validate-with</name></choice>
+              <choice>
+                <value type="token">none</value>
+                <value type="token">pacemaker-0.6</value>
+                <value type="token">transitional-0.6</value>
+                <value type="token">pacemaker-0.7</value>
+                <value type="token">pacemaker-1.1</value>
+                <value type="token">pacemaker-next</value>
+                <value type="token">pacemaker-1.0</value>
+                <value type="token">pacemaker-1.2</value>
+                <value type="token">pacemaker-1.3</value>
+                <value type="token">pacemaker-2.0</value>
+                <value type="token">pacemaker-2.1</value>
+                <value type="token">pacemaker-2.2</value>
+                <value type="token">pacemaker-2.3</value>
+                <value type="token">pacemaker-2.4</value>
+                <value type="token">pacemaker-2.5</value>
+                <value type="token">pacemaker-2.6</value>
+                <value type="token">pacemaker-2.7</value>
+                <value type="token">pacemaker-2.8</value>
+                <value type="token">pacemaker-2.9</value>
+                <value type="token">pacemaker-2.10</value>
+                <value type="token">pacemaker-3.0</value>
+                <value type="token">pacemaker-3.1</value>
+                <value type="token">pacemaker-3.2</value>
+              </choice>
+            </attribute>
+          </optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">admin_epoch</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">admin_epoch</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">admin_epoch</name></choice>
+            <data type="nonNegativeInteger" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">epoch</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">epoch</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">epoch</name></choice>
+            <data type="nonNegativeInteger" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">num_updates</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">num_updates</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">num_updates</name></choice>
+            <data type="nonNegativeInteger" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </interleave>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">crm_feature_set</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">crm_feature_set</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">crm_feature_set</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">remote-tls-port</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">remote-tls-port</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">remote-tls-port</name></choice>
+            <data type="nonNegativeInteger" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">remote-clear-port</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">remote-clear-port</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">remote-clear-port</name></choice>
+            <data type="nonNegativeInteger" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">have-quorum</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">have-quorum</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">have-quorum</name></choice>
+            <data type="boolean" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">dc-uuid</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">dc-uuid</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">dc-uuid</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">cib-last-written</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">cib-last-written</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">cib-last-written</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">no-quorum-panic</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">no-quorum-panic</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">no-quorum-panic</name></choice>
+            <data type="boolean" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">update-origin</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">update-origin</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">update-origin</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">update-client</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">update-client</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">update-client</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">update-user</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">update-user</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">update-user</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">execution-date</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">execution-date</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">execution-date</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <ref name="configuration"/>
+        <optional>
+          <ref name="status"/>
+        </optional>
+      </group>
+    </element>
+  </define>
+  <define name="configuration">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">configuration</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">configuration</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">configuration</name></choice>
+      <interleave>
+        <ref name="crm_config"/>
+        <optional>
+          <ref name="rsc_defaults"/>
+        </optional>
+        <optional>
+          <ref name="op_defaults"/>
+        </optional>
+        <ref name="nodes"/>
+        <ref name="resources"/>
+        <ref name="constraints"/>
+        <optional>
+          <ref name="fencing-topology"/>
+        </optional>
+        <optional>
+          <ref name="acls"/>
+        </optional>
+        <optional>
+          <ref name="tags"/>
+        </optional>
+        <optional>
+          <ref name="alerts"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="status">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">status</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">status</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">status</name></choice>
+      <oneOrMore>
+        <choice>
+          <attribute>
+            <anyName/>
+            <text/>
+          </attribute>
+          <ref name="_1"/>
+          <text/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="crm_config">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">crm_config</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">crm_config</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">crm_config</name></choice>
+      <zeroOrMore>
+        <ref name="cluster_property_set"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="rsc_defaults">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rsc_defaults</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rsc_defaults</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rsc_defaults</name></choice>
+      <zeroOrMore>
+        <ref name="meta_attributes"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="op_defaults">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">op_defaults</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">op_defaults</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">op_defaults</name></choice>
+      <zeroOrMore>
+        <ref name="meta_attributes_2"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="nodes">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">nodes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">nodes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">nodes</name></choice>
+      <zeroOrMore>
+        <ref name="node"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="resources">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">resources</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">resources</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">resources</name></choice>
+      <zeroOrMore>
+        <choice>
+          <ref name="primitive"/>
+          <ref name="template"/>
+          <ref name="group"/>
+          <ref name="clone"/>
+          <ref name="master"/>
+          <ref name="bundle"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="constraints">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">constraints</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">constraints</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">constraints</name></choice>
+      <zeroOrMore>
+        <choice>
+          <ref name="rsc_location"/>
+          <ref name="rsc_colocation"/>
+          <ref name="rsc_order"/>
+          <ref name="rsc_ticket"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="fencing-topology">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">fencing-topology</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">fencing-topology</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">fencing-topology</name></choice>
+      <zeroOrMore>
+        <ref name="fencing-level"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="acls">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">acls</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">acls</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">acls</name></choice>
+      <zeroOrMore>
+        <choice>
+          <ref name="acl_target"/>
+          <ref name="acl_group"/>
+          <ref name="acl_role"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="tags">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">tags</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">tags</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">tags</name></choice>
+      <zeroOrMore>
+        <ref name="tag"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="alerts">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">alerts</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">alerts</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">alerts</name></choice>
+      <zeroOrMore>
+        <ref name="alert"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="_1">
+    <element>
+      <anyName/>
+      <oneOrMore>
+        <choice>
+          <attribute>
+            <anyName/>
+            <text/>
+          </attribute>
+          <ref name="_1"/>
+          <text/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cluster_property_set">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">cluster_property_set</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">cluster_property_set</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">cluster_property_set</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="meta_attributes">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">meta_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">meta_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">meta_attributes</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_2"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_2"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="meta_attributes_2">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">meta_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">meta_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">meta_attributes</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_3"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_2"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="node">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">node</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">node</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">node</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <text/>
+        </attribute>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">uname</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">uname</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">uname</name></choice>
+          <text/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">type</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">type</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">type</name></choice>
+            <choice>
+              <value type="token">member</value>
+              <value type="token">ping</value>
+              <value type="token">remote</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">description</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+            <choice>
+              <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+              <value type="token">INFINITY</value>
+              <value type="token">+INFINITY</value>
+              <value type="token">-INFINITY</value>
+            </choice>
+          </attribute>
+        </optional>
+        <zeroOrMore>
+          <choice>
+            <ref name="instance_attributes"/>
+            <ref name="utilization"/>
+          </choice>
+        </zeroOrMore>
+      </group>
+    </element>
+  </define>
+  <define name="primitive">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">primitive</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">primitive</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">primitive</name></choice>
+      <interleave>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <choice>
+          <group>
+            <choice>
+              <group>
+                <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">class</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">class</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">class</name></choice>
+                  <value type="token">ocf</value>
+                </attribute>
+                <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">provider</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">provider</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">provider</name></choice>
+                  <text/>
+                </attribute>
+              </group>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">class</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">class</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">class</name></choice>
+                <choice>
+                  <value type="token">lsb</value>
+                  <value type="token">heartbeat</value>
+                  <value type="token">stonith</value>
+                  <value type="token">upstart</value>
+                  <value type="token">service</value>
+                  <value type="token">systemd</value>
+                  <value type="token">nagios</value>
+                </choice>
+              </attribute>
+            </choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">type</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">type</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">type</name></choice>
+              <text/>
+            </attribute>
+          </group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">template</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">template</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">template</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </choice>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">description</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <zeroOrMore>
+          <choice>
+            <ref name="meta_attributes_3"/>
+            <ref name="instance_attributes_2"/>
+          </choice>
+        </zeroOrMore>
+        <optional>
+          <ref name="operations"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="utilization_2"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="template">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">template</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">template</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">template</name></choice>
+      <interleave>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <choice>
+          <group>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">class</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">class</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">class</name></choice>
+              <value type="token">ocf</value>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">provider</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">provider</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">provider</name></choice>
+              <text/>
+            </attribute>
+          </group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">class</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">class</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">class</name></choice>
+            <choice>
+              <value type="token">lsb</value>
+              <value type="token">heartbeat</value>
+              <value type="token">stonith</value>
+              <value type="token">upstart</value>
+              <value type="token">service</value>
+              <value type="token">systemd</value>
+              <value type="token">nagios</value>
+            </choice>
+          </attribute>
+        </choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">type</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">type</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">type</name></choice>
+          <text/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">description</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <zeroOrMore>
+          <choice>
+            <ref name="meta_attributes_3"/>
+            <ref name="instance_attributes_2"/>
+          </choice>
+        </zeroOrMore>
+        <optional>
+          <ref name="operations"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="utilization_3"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="group">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">group</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">group</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">group</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">description</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <interleave>
+          <zeroOrMore>
+            <choice>
+              <ref name="meta_attributes_4"/>
+              <ref name="instance_attributes_3"/>
+            </choice>
+          </zeroOrMore>
+          <oneOrMore>
+            <ref name="primitive"/>
+          </oneOrMore>
+        </interleave>
+      </group>
+    </element>
+  </define>
+  <define name="clone">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">clone</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">clone</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">clone</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">description</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <interleave>
+          <zeroOrMore>
+            <choice>
+              <ref name="meta_attributes_4"/>
+              <ref name="instance_attributes_3"/>
+            </choice>
+          </zeroOrMore>
+          <choice>
+            <ref name="primitive"/>
+            <ref name="group"/>
+          </choice>
+        </interleave>
+      </group>
+    </element>
+  </define>
+  <define name="master">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">master</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">master</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">master</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">description</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <interleave>
+          <zeroOrMore>
+            <choice>
+              <ref name="meta_attributes_4"/>
+              <ref name="instance_attributes_3"/>
+            </choice>
+          </zeroOrMore>
+          <choice>
+            <ref name="primitive"/>
+            <ref name="group"/>
+          </choice>
+        </interleave>
+      </group>
+    </element>
+  </define>
+  <define name="bundle">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">bundle</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">bundle</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">bundle</name></choice>
+      <interleave>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">description</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <zeroOrMore>
+          <choice>
+            <ref name="meta_attributes_4"/>
+            <ref name="instance_attributes_3"/>
+          </choice>
+        </zeroOrMore>
+        <choice>
+          <ref name="docker"/>
+          <ref name="rkt"/>
+        </choice>
+        <optional>
+          <ref name="network"/>
+        </optional>
+        <optional>
+          <ref name="storage"/>
+        </optional>
+        <optional>
+          <ref name="primitive"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="rsc_location">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rsc_location</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rsc_location</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rsc_location</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <choice>
+          <group>
+            <choice>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rsc</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rsc</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rsc</name></choice>
+                <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+              </attribute>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rsc-pattern</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rsc-pattern</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rsc-pattern</name></choice>
+                <text/>
+              </attribute>
+            </choice>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+                <choice>
+                  <value type="token">Stopped</value>
+                  <value type="token">Started</value>
+                  <value type="token">Master</value>
+                  <value type="token">Slave</value>
+                </choice>
+              </attribute>
+            </optional>
+          </group>
+          <oneOrMore>
+            <ref name="resource_set"/>
+          </oneOrMore>
+        </choice>
+        <choice>
+          <group>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">node</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">node</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">node</name></choice>
+              <text/>
+            </attribute>
+          </group>
+          <oneOrMore>
+            <ref name="rule_4"/>
+          </oneOrMore>
+        </choice>
+        <optional>
+          <ref name="lifetime"/>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">resource-discovery</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">resource-discovery</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">resource-discovery</name></choice>
+            <choice>
+              <value type="token">always</value>
+              <value type="token">never</value>
+              <value type="token">exclusive</value>
+            </choice>
+          </attribute>
+        </optional>
+      </group>
+    </element>
+  </define>
+  <define name="rsc_colocation">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rsc_colocation</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rsc_colocation</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rsc_colocation</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+            <choice>
+              <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+              <value type="token">INFINITY</value>
+              <value type="token">+INFINITY</value>
+              <value type="token">-INFINITY</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <ref name="lifetime"/>
+        </optional>
+        <choice>
+          <oneOrMore>
+            <ref name="resource_set"/>
+          </oneOrMore>
+          <group>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rsc</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rsc</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rsc</name></choice>
+              <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">with-rsc</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">with-rsc</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">with-rsc</name></choice>
+              <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+            </attribute>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">node-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">node-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">node-attribute</name></choice>
+                <text/>
+              </attribute>
+            </optional>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rsc-role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rsc-role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rsc-role</name></choice>
+                <choice>
+                  <value type="token">Stopped</value>
+                  <value type="token">Started</value>
+                  <value type="token">Master</value>
+                  <value type="token">Slave</value>
+                </choice>
+              </attribute>
+            </optional>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">with-rsc-role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">with-rsc-role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">with-rsc-role</name></choice>
+                <choice>
+                  <value type="token">Stopped</value>
+                  <value type="token">Started</value>
+                  <value type="token">Master</value>
+                  <value type="token">Slave</value>
+                </choice>
+              </attribute>
+            </optional>
+          </group>
+        </choice>
+      </group>
+    </element>
+  </define>
+  <define name="rsc_order">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rsc_order</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rsc_order</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rsc_order</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <optional>
+          <ref name="lifetime"/>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">symmetrical</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">symmetrical</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">symmetrical</name></choice>
+            <data type="boolean" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">require-all</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">require-all</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">require-all</name></choice>
+            <data type="boolean" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">kind</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">kind</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">kind</name></choice>
+              <choice>
+                <value type="token">Optional</value>
+                <value type="token">Mandatory</value>
+                <value type="token">Serialize</value>
+              </choice>
+            </attribute>
+          </choice>
+        </optional>
+        <choice>
+          <oneOrMore>
+            <ref name="resource_set"/>
+          </oneOrMore>
+          <group>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">first</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">first</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">first</name></choice>
+              <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">then</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">then</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">then</name></choice>
+              <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+            </attribute>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">first-action</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">first-action</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">first-action</name></choice>
+                <choice>
+                  <value type="token">start</value>
+                  <value type="token">promote</value>
+                  <value type="token">demote</value>
+                  <value type="token">stop</value>
+                </choice>
+              </attribute>
+            </optional>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">then-action</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">then-action</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">then-action</name></choice>
+                <choice>
+                  <value type="token">start</value>
+                  <value type="token">promote</value>
+                  <value type="token">demote</value>
+                  <value type="token">stop</value>
+                </choice>
+              </attribute>
+            </optional>
+          </group>
+        </choice>
+      </group>
+    </element>
+  </define>
+  <define name="rsc_ticket">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rsc_ticket</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rsc_ticket</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rsc_ticket</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <choice>
+          <oneOrMore>
+            <ref name="resource_set"/>
+          </oneOrMore>
+          <group>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rsc</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rsc</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rsc</name></choice>
+              <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+            </attribute>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rsc-role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rsc-role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rsc-role</name></choice>
+                <choice>
+                  <value type="token">Stopped</value>
+                  <value type="token">Started</value>
+                  <value type="token">Master</value>
+                  <value type="token">Slave</value>
+                </choice>
+              </attribute>
+            </optional>
+          </group>
+        </choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">ticket</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">ticket</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">ticket</name></choice>
+          <text/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">loss-policy</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">loss-policy</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">loss-policy</name></choice>
+            <choice>
+              <value type="token">stop</value>
+              <value type="token">demote</value>
+              <value type="token">fence</value>
+              <value type="token">freeze</value>
+            </choice>
+          </attribute>
+        </optional>
+      </group>
+    </element>
+  </define>
+  <define name="fencing-level">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">fencing-level</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">fencing-level</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">fencing-level</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <choice>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">target</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">target</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">target</name></choice>
+            <text/>
+          </attribute>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">target-pattern</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">target-pattern</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">target-pattern</name></choice>
+            <text/>
+          </attribute>
+          <group>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">target-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">target-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">target-attribute</name></choice>
+              <text/>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">target-value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">target-value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">target-value</name></choice>
+              <text/>
+            </attribute>
+          </group>
+        </choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">index</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">index</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">index</name></choice>
+          <data type="positiveInteger" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">devices</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">devices</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">devices</name></choice>
+          <data type="string" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+            <param name="pattern">([a-zA-Z0-9_\.\-]+)(,[a-zA-Z0-9_\.\-]+)*</param>
+          </data>
+        </attribute>
+      </group>
+    </element>
+  </define>
+  <define name="acl_target">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">acl_target</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">acl_target</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">acl_target</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <text/>
+        </attribute>
+        <zeroOrMore>
+          <ref name="role"/>
+        </zeroOrMore>
+      </group>
+    </element>
+  </define>
+  <define name="acl_group">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">acl_group</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">acl_group</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">acl_group</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <zeroOrMore>
+          <ref name="role"/>
+        </zeroOrMore>
+      </group>
+    </element>
+  </define>
+  <define name="acl_role">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">acl_role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">acl_role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">acl_role</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">description</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <zeroOrMore>
+          <ref name="acl_permission"/>
+        </zeroOrMore>
+      </group>
+    </element>
+  </define>
+  <define name="tag">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">tag</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">tag</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">tag</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <oneOrMore>
+          <ref name="obj_ref"/>
+        </oneOrMore>
+      </group>
+    </element>
+  </define>
+  <define name="alert">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">alert</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">alert</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">alert</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">description</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">path</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">path</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">path</name></choice>
+          <text/>
+        </attribute>
+        <interleave>
+          <zeroOrMore>
+            <choice>
+              <ref name="meta_attributes_5"/>
+              <ref name="instance_attributes_4"/>
+            </choice>
+          </zeroOrMore>
+          <optional>
+            <ref name="select"/>
+          </optional>
+          <zeroOrMore>
+            <ref name="recipient"/>
+          </zeroOrMore>
+        </interleave>
+      </group>
+    </element>
+  </define>
+  <define name="rule">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="nvpair">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">nvpair</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">nvpair</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">nvpair</name></choice>
+      <choice>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+        </group>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <group>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+                <value type="string" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">cluster-infrastructure</value>
+              </attribute>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">value</name></choice>
+                <data type="string" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+                  <except>
+                    <choice>
+                      <value type="token">heartbeat</value>
+                      <value type="token">openais</value>
+                      <value type="token">classic openais</value>
+                      <value type="token">classic openais (with plugin)</value>
+                      <value type="token">cman</value>
+                    </choice>
+                  </except>
+                </data>
+              </attribute>
+            </group>
+            <group>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+                <data type="string" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+                  <except>
+                    <choice>
+                      <value type="token">cluster-infrastructure</value>
+                      <value type="token">cluster_recheck_interval</value>
+                      <value type="token">dc_deadtime</value>
+                      <value type="token">default-action-timeout</value>
+                      <value type="token">default_action_timeout</value>
+                      <value type="token">default-migration-threshold</value>
+                      <value type="token">default_migration_threshold</value>
+                      <value type="token">default-resource-failure-stickiness</value>
+                      <value type="token">default_resource_failure_stickiness</value>
+                      <value type="token">default-resource-stickiness</value>
+                      <value type="token">default_resource_stickiness</value>
+                      <value type="token">election_timeout</value>
+                      <value type="token">expected-quorum-votes</value>
+                      <value type="token">is-managed-default</value>
+                      <value type="token">is_managed_default</value>
+                      <value type="token">no_quorum_policy</value>
+                      <value type="token">notification-agent</value>
+                      <value type="token">notification-recipient</value>
+                      <value type="token">remove_after_stop</value>
+                      <value type="token">shutdown_escalation</value>
+                      <value type="token">startup_fencing</value>
+                      <value type="token">stonith_action</value>
+                      <value type="token">stonith_enabled</value>
+                      <value type="token">stop_orphan_actions</value>
+                      <value type="token">stop_orphan_resources</value>
+                      <value type="token">symmetric_cluster</value>
+                      <value type="token">transition_idle_timeout</value>
+                    </choice>
+                  </except>
+                </data>
+              </attribute>
+              <optional>
+                <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">value</name></choice>
+                  <text/>
+                </attribute>
+              </optional>
+            </group>
+          </choice>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="rule_2">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_2"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="nvpair_2">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">nvpair</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">nvpair</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">nvpair</name></choice>
+      <choice>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+        </group>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+            <text/>
+          </attribute>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">value</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="rule_3">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_3"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="instance_attributes">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">instance_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">instance_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">instance_attributes</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_5"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_2"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="utilization">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">utilization</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">utilization</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">utilization</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_6"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_2"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="meta_attributes_3">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">meta_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">meta_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">meta_attributes</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_7"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_3"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="instance_attributes_2">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">instance_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">instance_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">instance_attributes</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_8"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_4"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="operations">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">operations</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">operations</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">operations</name></choice>
+      <group>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <zeroOrMore>
+          <ref name="op"/>
+        </zeroOrMore>
+      </group>
+    </element>
+  </define>
+  <define name="utilization_2">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">utilization</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">utilization</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">utilization</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_9"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_2"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="utilization_3">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">utilization</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">utilization</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">utilization</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_10"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_2"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="meta_attributes_4">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">meta_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">meta_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">meta_attributes</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_11"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_2"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="instance_attributes_3">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">instance_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">instance_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">instance_attributes</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_12"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_2"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="docker">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">docker</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">docker</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">docker</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">image</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">image</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">image</name></choice>
+          <text/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">replicas</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">replicas</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">replicas</name></choice>
+            <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">replicas-per-host</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">replicas-per-host</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">replicas-per-host</name></choice>
+            <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">masters</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">masters</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">masters</name></choice>
+              <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">promoted-max</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">promoted-max</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">promoted-max</name></choice>
+              <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+            </attribute>
+          </choice>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">run-command</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">run-command</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">run-command</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">network</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">network</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">network</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">options</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">options</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">options</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+      </group>
+    </element>
+  </define>
+  <define name="rkt">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rkt</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rkt</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rkt</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">image</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">image</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">image</name></choice>
+          <text/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">replicas</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">replicas</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">replicas</name></choice>
+            <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">replicas-per-host</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">replicas-per-host</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">replicas-per-host</name></choice>
+            <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">masters</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">masters</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">masters</name></choice>
+              <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">promoted-max</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">promoted-max</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">promoted-max</name></choice>
+              <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+            </attribute>
+          </choice>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">run-command</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">run-command</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">run-command</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">network</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">network</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">network</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">options</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">options</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">options</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+      </group>
+    </element>
+  </define>
+  <define name="network">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">network</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">network</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">network</name></choice>
+      <group>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">ip-range-start</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">ip-range-start</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">ip-range-start</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">control-port</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">control-port</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">control-port</name></choice>
+            <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">host-interface</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">host-interface</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">host-interface</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">host-netmask</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">host-netmask</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">host-netmask</name></choice>
+            <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">add-host</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">add-host</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">add-host</name></choice>
+            <data type="boolean" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <zeroOrMore>
+          <ref name="port-mapping"/>
+        </zeroOrMore>
+      </group>
+    </element>
+  </define>
+  <define name="storage">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">storage</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">storage</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">storage</name></choice>
+      <zeroOrMore>
+        <ref name="storage-mapping"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="resource_set">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">resource_set</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">resource_set</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">resource_set</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">sequential</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">sequential</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">sequential</name></choice>
+              <data type="boolean" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">require-all</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">require-all</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">require-all</name></choice>
+              <data type="boolean" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">ordering</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">ordering</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">ordering</name></choice>
+              <choice>
+                <value type="token">group</value>
+                <value type="token">listed</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">action</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">action</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">action</name></choice>
+              <choice>
+                <value type="token">start</value>
+                <value type="token">promote</value>
+                <value type="token">demote</value>
+                <value type="token">stop</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <choice>
+                <value type="token">Stopped</value>
+                <value type="token">Started</value>
+                <value type="token">Master</value>
+                <value type="token">Slave</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <choice>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">kind</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">kind</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">kind</name></choice>
+                <choice>
+                  <value type="token">Optional</value>
+                  <value type="token">Mandatory</value>
+                  <value type="token">Serialize</value>
+                </choice>
+              </attribute>
+            </choice>
+          </optional>
+          <oneOrMore>
+            <ref name="resource_ref"/>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="rule_4">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_4"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="lifetime">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">lifetime</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">lifetime</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">lifetime</name></choice>
+      <oneOrMore>
+        <ref name="rule_13"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="role">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+      <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+        <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+      </attribute>
+    </element>
+  </define>
+  <define name="acl_permission">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">acl_permission</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">acl_permission</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">acl_permission</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">kind</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">kind</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">kind</name></choice>
+          <choice>
+            <value type="token">read</value>
+            <value type="token">write</value>
+            <value type="token">deny</value>
+          </choice>
+        </attribute>
+        <choice>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">xpath</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">xpath</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">xpath</name></choice>
+            <text/>
+          </attribute>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">reference</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">reference</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">reference</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <group>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">object-type</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">object-type</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">object-type</name></choice>
+              <text/>
+            </attribute>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">attribute</name></choice>
+                <text/>
+              </attribute>
+            </optional>
+          </group>
+        </choice>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">description</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+      </group>
+    </element>
+  </define>
+  <define name="obj_ref">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">obj_ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">obj_ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">obj_ref</name></choice>
+      <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+        <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+      </attribute>
+    </element>
+  </define>
+  <define name="meta_attributes_5">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">meta_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">meta_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">meta_attributes</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_14"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_2"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="instance_attributes_4">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">instance_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">instance_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">instance_attributes</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_15"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_2"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="select">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">select</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">select</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">select</name></choice>
+      <interleave>
+        <optional>
+          <ref name="select_attributes"/>
+        </optional>
+        <optional>
+          <ref name="select_fencing"/>
+        </optional>
+        <optional>
+          <ref name="select_nodes"/>
+        </optional>
+        <optional>
+          <ref name="select_resources"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="recipient">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">recipient</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">recipient</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">recipient</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">description</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">value</name></choice>
+          <text/>
+        </attribute>
+        <zeroOrMore>
+          <choice>
+            <ref name="meta_attributes_5"/>
+            <ref name="instance_attributes_4"/>
+          </choice>
+        </zeroOrMore>
+      </group>
+    </element>
+  </define>
+  <define name="expression">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">expression</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">expression</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">expression</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">attribute</name></choice>
+          <text/>
+        </attribute>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">operation</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">operation</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">operation</name></choice>
+          <choice>
+            <value type="token">lt</value>
+            <value type="token">gt</value>
+            <value type="token">lte</value>
+            <value type="token">gte</value>
+            <value type="token">eq</value>
+            <value type="token">ne</value>
+            <value type="token">defined</value>
+            <value type="token">not_defined</value>
+          </choice>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">value</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">type</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">type</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">type</name></choice>
+            <choice>
+              <value type="token">string</value>
+              <value type="token">number</value>
+              <value type="token">version</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">value-source</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">value-source</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">value-source</name></choice>
+            <choice>
+              <value type="token">literal</value>
+              <value type="token">param</value>
+              <value type="token">meta</value>
+            </choice>
+          </attribute>
+        </optional>
+      </group>
+    </element>
+  </define>
+  <define name="date_expression">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">date_expression</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">date_expression</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">date_expression</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <choice>
+          <group>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">operation</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">operation</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">operation</name></choice>
+              <value type="token">in_range</value>
+            </attribute>
+            <choice>
+              <group>
+                <optional>
+                  <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">start</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">start</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">start</name></choice>
+                    <text/>
+                  </attribute>
+                </optional>
+                <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">end</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">end</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">end</name></choice>
+                  <text/>
+                </attribute>
+              </group>
+              <group>
+                <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">start</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">start</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">start</name></choice>
+                  <text/>
+                </attribute>
+                <ref name="duration"/>
+              </group>
+            </choice>
+          </group>
+          <group>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">operation</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">operation</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">operation</name></choice>
+              <value type="token">gt</value>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">start</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">start</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">start</name></choice>
+              <text/>
+            </attribute>
+          </group>
+          <group>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">operation</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">operation</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">operation</name></choice>
+              <value type="token">lt</value>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">end</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">end</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">end</name></choice>
+              <text/>
+            </attribute>
+          </group>
+          <group>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">operation</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">operation</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">operation</name></choice>
+              <value type="token">date_spec</value>
+            </attribute>
+            <ref name="date_spec"/>
+          </group>
+        </choice>
+      </group>
+    </element>
+  </define>
+  <define name="rule_5">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_5"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="rule_6">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_6"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="rule_7">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_7"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="nvpair_3">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">nvpair</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">nvpair</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">nvpair</name></choice>
+      <choice>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+        </group>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+            <data type="string" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+              <except>
+                <choice>
+                  <value type="token">isolation</value>
+                  <value type="token">isolation-host</value>
+                  <value type="token">isolation-instance</value>
+                  <value type="token">isolation-wrapper</value>
+                </choice>
+              </except>
+            </data>
+          </attribute>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">value</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="rule_8">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_8"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="nvpair_4">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">nvpair</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">nvpair</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">nvpair</name></choice>
+      <choice>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+        </group>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+            <data type="string" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+              <except>
+                <choice>
+                  <value type="token">pcmk_arg_map</value>
+                  <value type="token">pcmk_list_cmd</value>
+                  <value type="token">pcmk_monitor_cmd</value>
+                  <value type="token">pcmk_off_cmd</value>
+                  <value type="token">pcmk_on_cmd</value>
+                  <value type="token">pcmk_reboot_cmd</value>
+                  <value type="token">pcmk_status_cmd</value>
+                </choice>
+              </except>
+            </data>
+          </attribute>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">value</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="op">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">op</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+          <text/>
+        </attribute>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">interval</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">interval</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">interval</name></choice>
+          <text/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">description</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">description</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">start-delay</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">start-delay</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">start-delay</name></choice>
+              <text/>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">interval-origin</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">interval-origin</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">interval-origin</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">timeout</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">timeout</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">timeout</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">enabled</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">enabled</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">enabled</name></choice>
+            <data type="boolean" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">record-pending</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">record-pending</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">record-pending</name></choice>
+            <data type="boolean" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+            <choice>
+              <value type="token">Stopped</value>
+              <value type="token">Started</value>
+              <value type="token">Slave</value>
+              <value type="token">Master</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">on-fail</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">on-fail</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">on-fail</name></choice>
+            <choice>
+              <value type="token">ignore</value>
+              <value type="token">block</value>
+              <value type="token">stop</value>
+              <value type="token">restart</value>
+              <value type="token">standby</value>
+              <value type="token">fence</value>
+              <value type="token">restart-container</value>
+            </choice>
+          </attribute>
+        </optional>
+        <zeroOrMore>
+          <choice>
+            <ref name="meta_attributes_6"/>
+            <ref name="instance_attributes_5"/>
+          </choice>
+        </zeroOrMore>
+      </group>
+    </element>
+  </define>
+  <define name="rule_9">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_9"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="rule_10">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_10"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="rule_11">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_11"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="rule_12">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_12"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="port-mapping">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">port-mapping</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">port-mapping</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">port-mapping</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <choice>
+          <group>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">port</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">port</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">port</name></choice>
+              <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+            </attribute>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">internal-port</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">internal-port</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">internal-port</name></choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+              </attribute>
+            </optional>
+          </group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">range</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">range</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">range</name></choice>
+            <data type="string" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+              <param name="pattern">([0-9\-]+)</param>
+            </data>
+          </attribute>
+        </choice>
+      </group>
+    </element>
+  </define>
+  <define name="storage-mapping">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">storage-mapping</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">storage-mapping</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">storage-mapping</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <choice>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">source-dir</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">source-dir</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">source-dir</name></choice>
+            <text/>
+          </attribute>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">source-dir-root</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">source-dir-root</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">source-dir-root</name></choice>
+            <text/>
+          </attribute>
+        </choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">target-dir</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">target-dir</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">target-dir</name></choice>
+          <text/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">options</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">options</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">options</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+      </group>
+    </element>
+  </define>
+  <define name="resource_ref">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">resource_ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">resource_ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">resource_ref</name></choice>
+      <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+        <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+      </attribute>
+    </element>
+  </define>
+  <define name="rule_13">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_13"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="rule_14">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_14"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="rule_15">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_15"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="select_attributes">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">select_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">select_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">select_attributes</name></choice>
+      <zeroOrMore>
+        <ref name="attribute"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="select_fencing">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">select_fencing</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">select_fencing</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">select_fencing</name></choice>
+      <empty/>
+    </element>
+  </define>
+  <define name="select_nodes">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">select_nodes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">select_nodes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">select_nodes</name></choice>
+      <empty/>
+    </element>
+  </define>
+  <define name="select_resources">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">select_resources</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">select_resources</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">select_resources</name></choice>
+      <empty/>
+    </element>
+  </define>
+  <define name="duration">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">duration</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">duration</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">duration</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">hours</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">hours</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">hours</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">monthdays</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">monthdays</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">monthdays</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">weekdays</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">weekdays</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">weekdays</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">yearsdays</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">yearsdays</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">yearsdays</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">months</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">months</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">months</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">weeks</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">weeks</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">weeks</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">years</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">years</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">years</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">weekyears</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">weekyears</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">weekyears</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">moon</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">moon</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">moon</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+      </group>
+    </element>
+  </define>
+  <define name="date_spec">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">date_spec</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">date_spec</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">date_spec</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">hours</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">hours</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">hours</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">monthdays</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">monthdays</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">monthdays</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">weekdays</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">weekdays</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">weekdays</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">yearsdays</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">yearsdays</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">yearsdays</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">months</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">months</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">months</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">weeks</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">weeks</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">weeks</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">years</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">years</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">years</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">weekyears</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">weekyears</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">weekyears</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">moon</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">moon</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">moon</name></choice>
+            <text/>
+          </attribute>
+        </optional>
+      </group>
+    </element>
+  </define>
+  <define name="meta_attributes_6">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">meta_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">meta_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">meta_attributes</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_16"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_5"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="instance_attributes_5">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">instance_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">instance_attributes</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">instance_attributes</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <interleave>
+            <optional>
+              <ref name="rule_17"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="nvpair_6"/>
+            </zeroOrMore>
+            <optional>
+              <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+                <choice>
+                  <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  <value type="token">INFINITY</value>
+                  <value type="token">+INFINITY</value>
+                  <value type="token">-INFINITY</value>
+                </choice>
+              </attribute>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="attribute">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">attribute</name></choice>
+      <group>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+          <text/>
+        </attribute>
+      </group>
+    </element>
+  </define>
+  <define name="rule_16">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_16"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="nvpair_5">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">nvpair</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">nvpair</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">nvpair</name></choice>
+      <choice>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+        </group>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+            <data type="string" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+              <except>
+                <value type="token">requires</value>
+              </except>
+            </data>
+          </attribute>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">value</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="rule_17">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">rule</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">rule</name></choice>
+      <choice>
+        <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+          <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+        </attribute>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <choice>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score</name></choice>
+              <choice>
+                <data type="integer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                <value type="token">INFINITY</value>
+                <value type="token">+INFINITY</value>
+                <value type="token">-INFINITY</value>
+              </choice>
+            </attribute>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">score-attribute</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">score-attribute</name></choice>
+              <text/>
+            </attribute>
+          </choice>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">boolean-op</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">boolean-op</name></choice>
+              <choice>
+                <value type="token">or</value>
+                <value type="token">and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">role</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">role</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rule_17"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="nvpair_6">
+    <element><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">nvpair</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">nvpair</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">nvpair</name></choice>
+      <choice>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id-ref</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id-ref</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+        </group>
+        <group>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">id</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">id</name></choice>
+            <data type="NCName" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+          </attribute>
+          <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">name</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">name</name></choice>
+            <data type="string" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+              <except>
+                <choice>
+                  <value type="token">interval-origin</value>
+                  <value type="token">start-delay</value>
+                  <value type="token">enabled</value>
+                  <value type="token">on-fail</value>
+                  <value type="token">record-pending</value>
+                  <value type="token">role</value>
+                  <value type="token">timeout</value>
+                  <value type="token">requires</value>
+                </choice>
+              </except>
+            </data>
+          </attribute>
+          <optional>
+            <attribute><choice xmlns:rng="http://relaxng.org/ns/structure/1.0"><name ns="http://clusterlabs.org/ns/pacemaker/access/writable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/readable">value</name><name ns="http://clusterlabs.org/ns/pacemaker/access/denied">value</name></choice>
+              <text/>
+            </attribute>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+</grammar>

--- a/xml/regression.sh
+++ b/xml/regression.sh
@@ -306,9 +306,10 @@ EOF
 	fi
 
 	# only respond with the flags except for "-B", i.e., when both:
-	# - _tru_mode non-zero
+	# - _tru_mode non-zero (drop internal-only ~ higher bits first)
 	# - "-B" in _tru_mode is zero (hence non-zero when flipped with XOR)
-	if test "$((_tru_mode * ((_tru_mode ^ (1 << 2)) & (1 << 2))))" -ne 0; then
+	if test "$(((_tru_mode & ((1 << 3) - 1))
+			* ((_tru_mode ^ (1 << 2)) & (1 << 2))))" -ne 0; then
 		if test $((_tru_mode & (1 << 0))) -ne 0; then
 			cp -a "${_tru_target}" "${_tru_ref}"
 			cp -a "${_tru_target_err}" "${_tru_ref_err}"
@@ -360,6 +361,14 @@ EOF
 		return 1
 	fi
 
+	if test $((_tru_mode & (1 << 3))) -ne 0; then
+		# remove ANSI marks (assume no other customization)
+		_tru_ref_err=$(mktemp)
+		mv "${_tru_target}" "${_tru_ref_err}"
+		sed 's/\\x1b[[0-9;]*m//g' "${_tru_ref_err}" > "${_tru_target}"
+		rm -f "${_tru_ref_err}"
+	fi
+
 	echo "${_tru_target}"
 }
 
@@ -398,10 +407,11 @@ test_runner() {
 		-G) _tr_mode=$((_tr_mode | (1 << 0)));;
 		-D) _tr_mode=$((_tr_mode | (1 << 1)));;
 		-B) _tr_mode=$((_tr_mode | (1 << 2)));;
+		-@=*) _tr_mode=$((_tr_mode | ${1#-@=}));;
 		esac
 		shift
 	done
-	_tr_template="upgrade-${_tr_action:-${_tr_template:?}}.xsl"
+	_tr_template="${_tr_action:-upgrade-${_tr_template:?}}.xsl"
 
 	if ! test -f "${_tr_schema_o:?}" || ! test -f "${_tr_schema_t:?}"; then
 		emit_error "Origin and/or target schema missing, rerun make"
@@ -490,7 +500,8 @@ test2to3enter() {
 	      *\ -S\ *) test_selfcheck -a=enter -o=2.10 ${_t23e_cleanopt};;
 	      *\ -W\ *) emit_result "not implemented" "option -W";;
 	      *\ -X\ *) emit_result "not implemented" "option -X";;
-	      *) test_runner -a=2.10-enter -o=2.10 -t=2.10 "$@" || return $?;;
+	      *) test_runner -a=upgrade-2.10-enter -o=2.10 -t=2.10 "$@" \
+	          || return $?;;
 	      esac; }
 }
 tests="${tests} test2to3enter"
@@ -514,7 +525,8 @@ test2to3leave() {
 	      *\ -S\ *) test_selfcheck -a=leave -o=2.10 ${_t23l_cleanopt};;
 	      *\ -W\ *) emit_result "not implemented" "option -W";;
 	      *\ -X\ *) emit_result "not implemented" "option -X";;
-	      *) test_runner -a=2.10-leave -o=3.0 -t=3.0 "$@" || return $?;;
+	      *) test_runner -a=upgrade-2.10-leave -o=3.0 -t=3.0 "$@" \
+	          || return $?;;
 	      esac; }
 }
 tests="${tests} test2to3leave"
@@ -538,10 +550,76 @@ test2to3roundtrip() {
 	      *\ -S\ *) test_selfcheck -a=roundtrip -o=2.10 ${_t23rt_cleanopt};;
 	      *\ -W\ *) test_browser ${_t23rt_cleanopt};;
 	      *\ -X\ *) emit_result "not implemented" "option -X";;
-	      *) test_runner -a=2.10-roundtrip -o=2.10 -t=3.0 "$@" || return $?;;
+	      *) test_runner -a=upgrade-2.10-roundtrip -o=2.10 -t=3.0 "$@" \
+	          || return $?;;
 	      esac; }
 }
 tests="${tests} test2to3roundtrip"
+
+# just generated the singular + ACLs annotations aware schema clone
+access_render_prep() {
+	test -s pacemaker-access-3.0.rng || {
+	    (
+	    export OUTPUTDIR=test-access-render \
+	        SKIPSCHEMAS=".*/test-2-render/.*|.*/pacemaker-(3\.[^0]|[^3].*)\.rng"
+	    helpers/schema-singularize.sh --clobber
+	    )
+	    xsltproc helpers/access-render-convert-rng.xsl \
+	      test-access-render/pacemaker-3.0.rng > pacemaker-access-3.0.rng
+	}
+
+	rm -f test-access-render/pacemaker-3.0.rng
+}
+
+# XXX only run with RNGVALIDATOR="jing -i" or xmllint with this patchset:
+#     https://gitlab.gnome.org/GNOME/libxml2/merge_requests/31
+# XXX also, only XML_CATALOG_FILES env. var. compatible XSLTPROCESSOR will work
+access_render() {
+	_ar_cleanopt=
+	_ar_pattern=
+	_ar_catalog=
+	_ar_prev_catalog=
+	_ar_ret=
+
+	while read _ar_spec; do
+		_ar_spec=${_ar_spec%.xml}
+		_ar_spec=${_ar_spec%\*}
+		_ar_pattern="${_ar_pattern} -name ${_ar_spec}*.xml -o"
+	done
+	test -z "${_ar_pattern}" || _ar_pattern="( ${_ar_pattern%-o} )"
+	case " $* " in *\ -r\ *) _ar_cleanopt=-r; esac
+
+	find test-access-render -name test-access-render -o -type d -prune \
+	  -o -name '*.xml' ${_ar_pattern} -print | env LC_ALL=C sort \
+	  | { case " $* " in
+	      *\ -C\ *) test_cleaner;;
+	      *\ -S\ *) emit_result "not implemented" "option -S";;
+	      *\ -W\ *) emit_result "not implemented" "option -W";;
+	      *\ -X\ *) emit_result "not implemented" "option -X";;
+	      *)
+		access_render_prep
+		_ar_catalog=$(mktemp)
+	>${_ar_catalog} printf "%s\n%s%s\n%s\n%s\n" \
+    "<catalog xmlns='urn:oasis:names:tc:entity:xmlns:xml:catalog'>" \
+    "  <rewriteURI uriStartString='http://clusterlabs.org/nsredir/pacemaker/cfg'" \
+         " rewritePrefix='file://$PWD/base'/>" \
+      "'<nextCatalog catalog='file:///etc/xml/catalog'/>" \
+    "</catalog>"
+		_ar_prev_catalog="${XML_CATALOG_FILES-no}"
+		export XML_CATALOG_FILES=${_ar_catalog}
+		test_runner -a=base/access-render-2 -o=access-3.0 -t=3.0 \
+		            -@=$((1 << 3)) "$@"
+		_ar_ret=$?
+		if test "${_ar_prev_catalog}" = no; then
+			unset XML_CATALOG_FILES
+		else
+			export XML_CATALOG_FILES="${_ar_prev_catalog}"
+		fi
+		rm -f "${_ar_catalog}"
+		return ${_ar_ret};;
+	      esac; }
+}
+tests="${tests} access_render"
 
 # -B
 # -D

--- a/xml/test-access-render/010-ref-alice.ref
+++ b/xml/test-access-render/010-ref-alice.ref
@@ -1,0 +1,159 @@
+\x1b[34m<cib crm_feature_set="3.0.14" validate-with="pacemaker-3.0" epoch="6815" num_updates="15" admin_epoch="2" cib-last-written="Thu Jun  6 15:41:29 2019" update-origin="ha-idg-2" update-client="crm_attribute" update-user="root" have-quorum="1" dc-uuid="1084777482" execution-date="1559829405">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair name="have-watchdog" value="false" id="cib-bootstrap-options-have-watchdog"/>
+        <nvpair name="dc-version" value="1.1.19+20181105.ccd6b5b10-3.3.1-1.1.19+20181105.ccd6b5b10" id="cib-bootstrap-options-dc-version"/>
+        <nvpair name="cluster-infrastructure" value="corosync" id="cib-bootstrap-options-cluster-infrastructure"/>
+        <nvpair name="last-lrm-refresh" value="1559146053" id="cib-bootstrap-options-last-lrm-refresh"/>
+        <nvpair name="cluster-name" value="ha-idg" id="cib-bootstrap-options-cluster-name"/>
+        <nvpair name="no-quorum-policy" value="ignore" id="cib-bootstrap-options-no-quorum-policy"/>
+        <nvpair name="stonith-enabled" value="true" id="cib-bootstrap-options-stonith-enabled"/>
+        <nvpair name="stonith-action" value="Off" id="cib-bootstrap-options-stonith-action"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="1084777492" uname="ha-idg-2">
+        \x1b[31m<instance_attributes id="nodes-1084777492">
+          \x1b[34m<nvpair id="nodes-1084777492-maintenance" name="maintenance" value="off"/>
+          \x1b[34m<nvpair id="nodes-1084777492-standby" name="standby" value="on"/>
+        \x1b[31m</instance_attributes>
+      </node>
+      <node id="1084777482" uname="ha-idg-1">
+        \x1b[31m<instance_attributes id="nodes-1084777482">
+          \x1b[34m<nvpair id="nodes-1084777482-maintenance" name="maintenance" value="off"/>
+          \x1b[34m<nvpair id="nodes-1084777482-standby" name="standby" value="off"/>
+        \x1b[31m</instance_attributes>
+      </node>
+    </nodes>
+    \x1b[31m<acls>
+      <acl_role id="read_all">
+        <acl_permission id="read_all-cib" kind="read" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="operator">
+        <acl_permission id="operator-maintenance" kind="write" xpath="//crm_config//nvpair[@name='maintenance-mode']"/>
+        <acl_permission id="operator-target-role" kind="write" xpath="//crm_config//nvpair[@name='target-role']"/>
+        <acl_permission id="operator-is-managed" kind="write" xpath="//resources//nvpair[@name='is-managed']"/>
+        <acl_permission id="operator-rsc_location" kind="write" object-type="rsc_location"/>
+      </acl_role>
+      <acl_role id="administrator">
+        <acl_permission id="administrator-cib" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="minimal">
+        <acl_permission id="minimal-standby" kind="read" description="allow reading standby node attribute (permanent or transient)" xpath="//instance_attributes/nvpair[@name='standby']"/>
+        <acl_permission id="minimal-maintenance" kind="read" description="allow reading maintenance node attribute (permanent or transient)" xpath="//instance_attributes/nvpair[@name='maintenance']"/>
+        <acl_permission id="minimal-target-role" kind="read" description="allow reading resource target roles" xpath="//meta_attributes/nvpair[@name='target-role']"/>
+        <acl_permission id="minimal-is-managed" kind="read" description="allow reading resource managed status" xpath="//meta_attributes/nvpair[@name='is-managed']"/>
+        <acl_permission id="minimal-deny-instance-attributes" kind="deny" xpath="//instance_attributes"/>
+        <acl_permission id="minimal-deny-meta-attributes" kind="deny" xpath="//meta_attributes"/>
+        <acl_permission id="minimal-deny-operations" kind="deny" xpath="//operations"/>
+        <acl_permission id="minimal-deny-utilization" kind="deny" xpath="//utilization"/>
+        <acl_permission id="minimal-nodes" kind="read" description="allow reading node names/IDs (attributes are denied separately)" xpath="/cib/configuration/nodes"/>
+        <acl_permission id="minimal-resources" kind="read" description="allow reading resource names/agents (parameters are denied separately)" xpath="/cib/configuration/resources"/>
+        <acl_permission id="minimal-deny-constraints" kind="deny" xpath="/cib/configuration/constraints"/>
+        <acl_permission id="minimal-deny-topology" kind="deny" xpath="/cib/configuration/fencing-topology"/>
+        <acl_permission id="minimal-deny-op_defaults" kind="deny" xpath="/cib/configuration/op_defaults"/>
+        <acl_permission id="minimal-deny-rsc_defaults" kind="deny" xpath="/cib/configuration/rsc_defaults"/>
+        <acl_permission id="minimal-deny-alerts" kind="deny" xpath="/cib/configuration/alerts"/>
+        <acl_permission id="minimal-deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+        <acl_permission id="minimal-cib" kind="read" description="allow reading cib element and crm_config/status sections" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="alice">
+        <role id="minimal"/>
+      </acl_target>
+      <acl_target id="bob">
+        <role id="read_all"/>
+      </acl_target>
+      <acl_target id="carol">
+        <role id="read_all"/>
+        <role id="operator"/>
+      </acl_target>
+      <acl_target id="dave">
+        <role id="administrator"/>
+      </acl_target>
+    \x1b[31m</acls>
+    <resources>
+      <primitive id="fence_ilo_ha-idg-2" class="stonith" type="fence_ilo2" description="fenct ha-idg-2 mit ILO">
+        \x1b[31m<operations>
+          <op name="monitor" interval="30m" timeout="120s" id="fence_ha-idg-2-monitor-30m"/>
+        \x1b[31m</operations>
+      </primitive>
+      <primitive id="fence_ilo_ha-idg-1" class="stonith" type="fence_ilo4" description="fenct ha-idg-1 mit ILO">
+        \x1b[31m<operations>
+          <op name="monitor" interval="30m" timeout="120s" id="fence_ha-idg-1-monitor-30m"/>
+        \x1b[31m</operations>
+      </primitive>
+      <primitive id="vm_idcc_devel" class="ocf" provider="heartbeat" type="VirtualDomain">
+        \x1b[31m<instance_attributes id="vm_idcc-devel-instance_attributes">
+          <nvpair name="config" value="/mnt/share/idcc_devel.xml" id="vm_idcc-devel-instance_attributes-config"/>
+        \x1b[31m</instance_attributes>
+        \x1b[31m<instance_attributes id="vm_idcc-devel-instance_attributes-0">
+          <nvpair name="hypervisor" value="qemu:///system" id="vm_idcc-devel-instance_attributes-0-hypervisor"/>
+        \x1b[31m</instance_attributes>
+        \x1b[31m<instance_attributes id="vm_idcc-devel-instance_attributes-1">
+          <nvpair name="migration_transport" value="ssh" id="vm_idcc-devel-instance_attributes-1-migration_transport"/>
+        \x1b[31m</instance_attributes>
+        \x1b[31m<instance_attributes id="vm_idcc-devel-instance_attributes-2">
+          <nvpair name="migration_network_suffix" value="-private" id="vm_idcc-devel-instance_attributes-2-migration_network_suffix"/>
+        \x1b[31m</instance_attributes>
+        \x1b[31m<operations>
+          <op name="start" interval="0" timeout="120" id="vm_idcc-devel-start-0"/>
+          <op name="stop" interval="0" timeout="130" id="vm_idcc-devel-stop-0"/>
+          <op name="monitor" interval="30" timeout="25" id="vm_idcc-devel-monitor-30"/>
+          <op name="migrate_from" interval="0" timeout="300" id="vm_idcc-devel-migrate_from-0"/>
+          <op name="migrate_to" interval="0" timeout="300" id="vm_idcc-devel-migrate_to-0"/>
+        \x1b[31m</operations>
+        \x1b[31m<meta_attributes id="vm_idcc-devel-meta_attributes">
+          <nvpair name="allow-migrate" value="true" id="vm_idcc-devel-meta_attributes-allow-migrate"/>
+          \x1b[34m<nvpair name="target-role" value="Started" id="vm_idcc-devel-meta_attributes-target-role"/>
+          \x1b[34m<nvpair name="is-managed" value="true" id="vm_idcc-devel-meta_attributes-is-managed"/>
+        \x1b[31m</meta_attributes>
+        \x1b[31m<utilization id="vm_idcc-devel-utilization">
+          <nvpair name="cpu" value="1" id="vm_idcc-devel-utilization-cpu"/>
+          <nvpair name="hv_memory" value="1020" id="vm_idcc-devel-utilization-hv_memory"/>
+        \x1b[31m</utilization>
+      </primitive>
+      <primitive id="vm_severin" class="ocf" provider="heartbeat" type="VirtualDomain">
+        \x1b[31m<instance_attributes id="vm_severin-instance_attributes">
+          <nvpair name="config" value="/mnt/share/severin.xml" id="vm_severin-instance_attributes-config"/>
+        \x1b[31m</instance_attributes>
+        \x1b[31m<instance_attributes id="vm_severin-instance_attributes-0">
+          <nvpair name="hypervisor" value="qemu:///system" id="vm_severin-instance_attributes-0-hypervisor"/>
+        \x1b[31m</instance_attributes>
+        \x1b[31m<instance_attributes id="vm_severin-instance_attributes-1">
+          <nvpair name="migration_transport" value="ssh" id="vm_severin-instance_attributes-1-migration_transport"/>
+        \x1b[31m</instance_attributes>
+        \x1b[31m<instance_attributes id="vm_severin-instance_attributes-2">
+          <nvpair name="migration_network_suffix" value="-private" id="vm_severin-instance_attributes-2-migration_network_suffix"/>
+        \x1b[31m</instance_attributes>
+        \x1b[31m<operations>
+          <op name="start" interval="0" timeout="120" id="vm_severin-start-0"/>
+          <op name="stop" interval="0" timeout="130" id="vm_severin-stop-0"/>
+          <op name="monitor" interval="30" timeout="25" id="vm_severin-monitor-30"/>
+          <op name="migrate_from" interval="0" timeout="300" id="vm_severin-migrate_from-0"/>
+          <op name="migrate_to" interval="0" timeout="300" id="vm_severin-migrate_to-0"/>
+        \x1b[31m</operations>
+        \x1b[31m<meta_attributes id="vm_severin-meta_attributes">
+          <nvpair name="allow-migrate" value="true" id="vm_severin-meta_attributes-allow-migrate"/>
+          \x1b[34m<nvpair name="target-role" value="Started" id="vm_severin-meta_attributes-target-role"/>
+          \x1b[34m<nvpair name="is-managed" value="true" id="vm_severin-meta_attributes-is-managed"/>
+        \x1b[31m</meta_attributes>
+        \x1b[31m<utilization id="vm_severin-utilization">
+          <nvpair name="cpu" value="2" id="vm_severin-utilization-cpu"/>
+          <nvpair name="hv_memory" value="2176" id="vm_severin-utilization-hv_memory"/>
+        \x1b[31m</utilization>
+      </primitive>
+    </resources>
+    \x1b[31m<constraints>
+      <rsc_location id="loc_fence_ilo_ha-idg-2" rsc="fence_ilo_ha-idg-2" score="-INFINITY" node="ha-idg-2"/>
+      <rsc_location id="loc_fence_ilo_ha-idg-1" rsc="fence_ilo_ha-idg-1" score="-INFINITY" node="ha-idg-1"/>
+    \x1b[31m</constraints>
+    \x1b[31m<rsc_defaults>
+      <meta_attributes id="rsc-options">
+        <nvpair name="resource-stickiness" value="200" id="rsc-options-resource-stickiness"/>
+      </meta_attributes>
+    \x1b[31m</rsc_defaults>
+    \x1b[31m<alerts/>
+  </configuration>
+  <status/>
+\x1b[34m</cib>\x1b[0m

--- a/xml/test-access-render/010-ref-alice.xml
+++ b/xml/test-access-render/010-ref-alice.xml
@@ -1,0 +1,162 @@
+<pcmk-access-readable:cib
+  xmlns:pcmk-access-readable="http://clusterlabs.org/ns/pacemaker/access/readable"
+  xmlns:pcmk-access-denied="http://clusterlabs.org/ns/pacemaker/access/denied"
+  pcmk-access-readable:crm_feature_set="3.0.14" pcmk-access-readable:validate-with="pacemaker-3.0" pcmk-access-readable:epoch="6815" pcmk-access-readable:num_updates="15" pcmk-access-readable:admin_epoch="2" pcmk-access-readable:cib-last-written="Thu Jun  6 15:41:29 2019" pcmk-access-readable:update-origin="ha-idg-2" pcmk-access-readable:update-client="crm_attribute" pcmk-access-readable:update-user="root" pcmk-access-readable:have-quorum="1" pcmk-access-readable:dc-uuid="1084777482" pcmk-access-readable:execution-date="1559829405">
+  <pcmk-access-readable:configuration>
+    <pcmk-access-readable:crm_config>
+      <pcmk-access-readable:cluster_property_set pcmk-access-readable:id="cib-bootstrap-options">
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="have-watchdog" pcmk-access-readable:value="false" pcmk-access-readable:id="cib-bootstrap-options-have-watchdog"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="dc-version" pcmk-access-readable:value="1.1.19+20181105.ccd6b5b10-3.3.1-1.1.19+20181105.ccd6b5b10" pcmk-access-readable:id="cib-bootstrap-options-dc-version"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="cluster-infrastructure" pcmk-access-readable:value="corosync" pcmk-access-readable:id="cib-bootstrap-options-cluster-infrastructure"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="last-lrm-refresh" pcmk-access-readable:value="1559146053" pcmk-access-readable:id="cib-bootstrap-options-last-lrm-refresh"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="cluster-name" pcmk-access-readable:value="ha-idg" pcmk-access-readable:id="cib-bootstrap-options-cluster-name"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="no-quorum-policy" pcmk-access-readable:value="ignore" pcmk-access-readable:id="cib-bootstrap-options-no-quorum-policy"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="stonith-enabled" pcmk-access-readable:value="true" pcmk-access-readable:id="cib-bootstrap-options-stonith-enabled"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="stonith-action" pcmk-access-readable:value="Off" pcmk-access-readable:id="cib-bootstrap-options-stonith-action"/>
+      </pcmk-access-readable:cluster_property_set>
+    </pcmk-access-readable:crm_config>
+    <pcmk-access-readable:nodes>
+      <pcmk-access-readable:node pcmk-access-readable:id="1084777492" pcmk-access-readable:uname="ha-idg-2">
+        <pcmk-access-denied:instance_attributes pcmk-access-denied:id="nodes-1084777492">
+          <pcmk-access-readable:nvpair pcmk-access-readable:id="nodes-1084777492-maintenance" pcmk-access-readable:name="maintenance" pcmk-access-readable:value="off"/>
+          <pcmk-access-readable:nvpair pcmk-access-readable:id="nodes-1084777492-standby" pcmk-access-readable:name="standby" pcmk-access-readable:value="on"/>
+        </pcmk-access-denied:instance_attributes>
+      </pcmk-access-readable:node>
+      <pcmk-access-readable:node pcmk-access-readable:id="1084777482" pcmk-access-readable:uname="ha-idg-1">
+        <pcmk-access-denied:instance_attributes pcmk-access-denied:id="nodes-1084777482">
+          <pcmk-access-readable:nvpair pcmk-access-readable:id="nodes-1084777482-maintenance" pcmk-access-readable:name="maintenance" pcmk-access-readable:value="off"/>
+          <pcmk-access-readable:nvpair pcmk-access-readable:id="nodes-1084777482-standby" pcmk-access-readable:name="standby" pcmk-access-readable:value="off"/>
+        </pcmk-access-denied:instance_attributes>
+      </pcmk-access-readable:node>
+    </pcmk-access-readable:nodes>
+    <pcmk-access-denied:acls>
+      <pcmk-access-denied:acl_role pcmk-access-denied:id="read_all">
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="read_all-cib" pcmk-access-denied:kind="read" pcmk-access-denied:xpath="/cib"/>
+      </pcmk-access-denied:acl_role>
+      <pcmk-access-denied:acl_role pcmk-access-denied:id="operator">
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="operator-maintenance" pcmk-access-denied:kind="write" pcmk-access-denied:xpath="//crm_config//nvpair[@name='maintenance-mode']"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="operator-target-role" pcmk-access-denied:kind="write" pcmk-access-denied:xpath="//crm_config//nvpair[@name='target-role']"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="operator-is-managed" pcmk-access-denied:kind="write" pcmk-access-denied:xpath="//resources//nvpair[@name='is-managed']"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="operator-rsc_location" pcmk-access-denied:kind="write" pcmk-access-denied:object-type="rsc_location"/>
+      </pcmk-access-denied:acl_role>
+      <pcmk-access-denied:acl_role pcmk-access-denied:id="administrator">
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="administrator-cib" pcmk-access-denied:kind="write" pcmk-access-denied:xpath="/cib"/>
+      </pcmk-access-denied:acl_role>
+      <pcmk-access-denied:acl_role pcmk-access-denied:id="minimal">
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-standby" pcmk-access-denied:kind="read" pcmk-access-denied:description="allow reading standby node attribute (permanent or transient)" pcmk-access-denied:xpath="//instance_attributes/nvpair[@name='standby']"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-maintenance" pcmk-access-denied:kind="read" pcmk-access-denied:description="allow reading maintenance node attribute (permanent or transient)" pcmk-access-denied:xpath="//instance_attributes/nvpair[@name='maintenance']"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-target-role" pcmk-access-denied:kind="read" pcmk-access-denied:description="allow reading resource target roles" pcmk-access-denied:xpath="//meta_attributes/nvpair[@name='target-role']"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-is-managed" pcmk-access-denied:kind="read" pcmk-access-denied:description="allow reading resource managed status" pcmk-access-denied:xpath="//meta_attributes/nvpair[@name='is-managed']"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-deny-instance-attributes" pcmk-access-denied:kind="deny" pcmk-access-denied:xpath="//instance_attributes"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-deny-meta-attributes" pcmk-access-denied:kind="deny" pcmk-access-denied:xpath="//meta_attributes"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-deny-operations" pcmk-access-denied:kind="deny" pcmk-access-denied:xpath="//operations"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-deny-utilization" pcmk-access-denied:kind="deny" pcmk-access-denied:xpath="//utilization"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-nodes" pcmk-access-denied:kind="read" pcmk-access-denied:description="allow reading node names/IDs (attributes are denied separately)" pcmk-access-denied:xpath="/cib/configuration/nodes"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-resources" pcmk-access-denied:kind="read" pcmk-access-denied:description="allow reading resource names/agents (parameters are denied separately)" pcmk-access-denied:xpath="/cib/configuration/resources"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-deny-constraints" pcmk-access-denied:kind="deny" pcmk-access-denied:xpath="/cib/configuration/constraints"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-deny-topology" pcmk-access-denied:kind="deny" pcmk-access-denied:xpath="/cib/configuration/fencing-topology"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-deny-op_defaults" pcmk-access-denied:kind="deny" pcmk-access-denied:xpath="/cib/configuration/op_defaults"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-deny-rsc_defaults" pcmk-access-denied:kind="deny" pcmk-access-denied:xpath="/cib/configuration/rsc_defaults"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-deny-alerts" pcmk-access-denied:kind="deny" pcmk-access-denied:xpath="/cib/configuration/alerts"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-deny-acls" pcmk-access-denied:kind="deny" pcmk-access-denied:xpath="/cib/configuration/acls"/>
+        <pcmk-access-denied:acl_permission pcmk-access-denied:id="minimal-cib" pcmk-access-denied:kind="read" pcmk-access-denied:description="allow reading cib element and crm_config/status sections" pcmk-access-denied:xpath="/cib"/>
+      </pcmk-access-denied:acl_role>
+      <pcmk-access-denied:acl_target pcmk-access-denied:id="alice">
+        <pcmk-access-denied:role pcmk-access-denied:id="minimal"/>
+      </pcmk-access-denied:acl_target>
+      <pcmk-access-denied:acl_target pcmk-access-denied:id="bob">
+        <pcmk-access-denied:role pcmk-access-denied:id="read_all"/>
+      </pcmk-access-denied:acl_target>
+      <pcmk-access-denied:acl_target pcmk-access-denied:id="carol">
+        <pcmk-access-denied:role pcmk-access-denied:id="read_all"/>
+        <pcmk-access-denied:role pcmk-access-denied:id="operator"/>
+      </pcmk-access-denied:acl_target>
+      <pcmk-access-denied:acl_target pcmk-access-denied:id="dave">
+        <pcmk-access-denied:role pcmk-access-denied:id="administrator"/>
+      </pcmk-access-denied:acl_target>
+    </pcmk-access-denied:acls>
+    <pcmk-access-readable:resources>
+      <pcmk-access-readable:primitive pcmk-access-readable:id="fence_ilo_ha-idg-2" pcmk-access-readable:class="stonith" pcmk-access-readable:type="fence_ilo2" pcmk-access-readable:description="fenct ha-idg-2 mit ILO">
+        <pcmk-access-denied:operations>
+          <pcmk-access-denied:op pcmk-access-denied:name="monitor" pcmk-access-denied:interval="30m" pcmk-access-denied:timeout="120s" pcmk-access-denied:id="fence_ha-idg-2-monitor-30m"/>
+        </pcmk-access-denied:operations>
+      </pcmk-access-readable:primitive>
+      <pcmk-access-readable:primitive pcmk-access-readable:id="fence_ilo_ha-idg-1" pcmk-access-readable:class="stonith" pcmk-access-readable:type="fence_ilo4" pcmk-access-readable:description="fenct ha-idg-1 mit ILO">
+        <pcmk-access-denied:operations>
+          <pcmk-access-denied:op pcmk-access-denied:name="monitor" pcmk-access-denied:interval="30m" pcmk-access-denied:timeout="120s" pcmk-access-denied:id="fence_ha-idg-1-monitor-30m"/>
+        </pcmk-access-denied:operations>
+      </pcmk-access-readable:primitive>
+      <pcmk-access-readable:primitive pcmk-access-readable:id="vm_idcc_devel" pcmk-access-readable:class="ocf" pcmk-access-readable:provider="heartbeat" pcmk-access-readable:type="VirtualDomain">
+        <pcmk-access-denied:instance_attributes pcmk-access-denied:id="vm_idcc-devel-instance_attributes">
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="config" pcmk-access-denied:value="/mnt/share/idcc_devel.xml" pcmk-access-denied:id="vm_idcc-devel-instance_attributes-config"/>
+        </pcmk-access-denied:instance_attributes>
+        <pcmk-access-denied:instance_attributes pcmk-access-denied:id="vm_idcc-devel-instance_attributes-0">
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="hypervisor" pcmk-access-denied:value="qemu:///system" pcmk-access-denied:id="vm_idcc-devel-instance_attributes-0-hypervisor"/>
+        </pcmk-access-denied:instance_attributes>
+        <pcmk-access-denied:instance_attributes pcmk-access-denied:id="vm_idcc-devel-instance_attributes-1">
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="migration_transport" pcmk-access-denied:value="ssh" pcmk-access-denied:id="vm_idcc-devel-instance_attributes-1-migration_transport"/>
+        </pcmk-access-denied:instance_attributes>
+        <pcmk-access-denied:instance_attributes pcmk-access-denied:id="vm_idcc-devel-instance_attributes-2">
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="migration_network_suffix" pcmk-access-denied:value="-private" pcmk-access-denied:id="vm_idcc-devel-instance_attributes-2-migration_network_suffix"/>
+        </pcmk-access-denied:instance_attributes>
+        <pcmk-access-denied:operations>
+          <pcmk-access-denied:op pcmk-access-denied:name="start" pcmk-access-denied:interval="0" pcmk-access-denied:timeout="120" pcmk-access-denied:id="vm_idcc-devel-start-0"/>
+          <pcmk-access-denied:op pcmk-access-denied:name="stop" pcmk-access-denied:interval="0" pcmk-access-denied:timeout="130" pcmk-access-denied:id="vm_idcc-devel-stop-0"/>
+          <pcmk-access-denied:op pcmk-access-denied:name="monitor" pcmk-access-denied:interval="30" pcmk-access-denied:timeout="25" pcmk-access-denied:id="vm_idcc-devel-monitor-30"/>
+          <pcmk-access-denied:op pcmk-access-denied:name="migrate_from" pcmk-access-denied:interval="0" pcmk-access-denied:timeout="300" pcmk-access-denied:id="vm_idcc-devel-migrate_from-0"/>
+          <pcmk-access-denied:op pcmk-access-denied:name="migrate_to" pcmk-access-denied:interval="0" pcmk-access-denied:timeout="300" pcmk-access-denied:id="vm_idcc-devel-migrate_to-0"/>
+        </pcmk-access-denied:operations>
+        <pcmk-access-denied:meta_attributes pcmk-access-denied:id="vm_idcc-devel-meta_attributes">
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="allow-migrate" pcmk-access-denied:value="true" pcmk-access-denied:id="vm_idcc-devel-meta_attributes-allow-migrate"/>
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="target-role" pcmk-access-readable:value="Started" pcmk-access-readable:id="vm_idcc-devel-meta_attributes-target-role"/>
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="is-managed" pcmk-access-readable:value="true" pcmk-access-readable:id="vm_idcc-devel-meta_attributes-is-managed"/>
+        </pcmk-access-denied:meta_attributes>
+        <pcmk-access-denied:utilization pcmk-access-denied:id="vm_idcc-devel-utilization">
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="cpu" pcmk-access-denied:value="1" pcmk-access-denied:id="vm_idcc-devel-utilization-cpu"/>
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="hv_memory" pcmk-access-denied:value="1020" pcmk-access-denied:id="vm_idcc-devel-utilization-hv_memory"/>
+        </pcmk-access-denied:utilization>
+      </pcmk-access-readable:primitive>
+      <pcmk-access-readable:primitive pcmk-access-readable:id="vm_severin" pcmk-access-readable:class="ocf" pcmk-access-readable:provider="heartbeat" pcmk-access-readable:type="VirtualDomain">
+        <pcmk-access-denied:instance_attributes pcmk-access-denied:id="vm_severin-instance_attributes">
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="config" pcmk-access-denied:value="/mnt/share/severin.xml" pcmk-access-denied:id="vm_severin-instance_attributes-config"/>
+        </pcmk-access-denied:instance_attributes>
+        <pcmk-access-denied:instance_attributes pcmk-access-denied:id="vm_severin-instance_attributes-0">
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="hypervisor" pcmk-access-denied:value="qemu:///system" pcmk-access-denied:id="vm_severin-instance_attributes-0-hypervisor"/>
+        </pcmk-access-denied:instance_attributes>
+        <pcmk-access-denied:instance_attributes pcmk-access-denied:id="vm_severin-instance_attributes-1">
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="migration_transport" pcmk-access-denied:value="ssh" pcmk-access-denied:id="vm_severin-instance_attributes-1-migration_transport"/>
+        </pcmk-access-denied:instance_attributes>
+        <pcmk-access-denied:instance_attributes pcmk-access-denied:id="vm_severin-instance_attributes-2">
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="migration_network_suffix" pcmk-access-denied:value="-private" pcmk-access-denied:id="vm_severin-instance_attributes-2-migration_network_suffix"/>
+        </pcmk-access-denied:instance_attributes>
+        <pcmk-access-denied:operations>
+          <pcmk-access-denied:op pcmk-access-denied:name="start" pcmk-access-denied:interval="0" pcmk-access-denied:timeout="120" pcmk-access-denied:id="vm_severin-start-0"/>
+          <pcmk-access-denied:op pcmk-access-denied:name="stop" pcmk-access-denied:interval="0" pcmk-access-denied:timeout="130" pcmk-access-denied:id="vm_severin-stop-0"/>
+          <pcmk-access-denied:op pcmk-access-denied:name="monitor" pcmk-access-denied:interval="30" pcmk-access-denied:timeout="25" pcmk-access-denied:id="vm_severin-monitor-30"/>
+          <pcmk-access-denied:op pcmk-access-denied:name="migrate_from" pcmk-access-denied:interval="0" pcmk-access-denied:timeout="300" pcmk-access-denied:id="vm_severin-migrate_from-0"/>
+          <pcmk-access-denied:op pcmk-access-denied:name="migrate_to" pcmk-access-denied:interval="0" pcmk-access-denied:timeout="300" pcmk-access-denied:id="vm_severin-migrate_to-0"/>
+        </pcmk-access-denied:operations>
+        <pcmk-access-denied:meta_attributes pcmk-access-denied:id="vm_severin-meta_attributes">
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="allow-migrate" pcmk-access-denied:value="true" pcmk-access-denied:id="vm_severin-meta_attributes-allow-migrate"/>
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="target-role" pcmk-access-readable:value="Started" pcmk-access-readable:id="vm_severin-meta_attributes-target-role"/>
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="is-managed" pcmk-access-readable:value="true" pcmk-access-readable:id="vm_severin-meta_attributes-is-managed"/>
+        </pcmk-access-denied:meta_attributes>
+        <pcmk-access-denied:utilization pcmk-access-denied:id="vm_severin-utilization">
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="cpu" pcmk-access-denied:value="2" pcmk-access-denied:id="vm_severin-utilization-cpu"/>
+          <pcmk-access-denied:nvpair pcmk-access-denied:name="hv_memory" pcmk-access-denied:value="2176" pcmk-access-denied:id="vm_severin-utilization-hv_memory"/>
+        </pcmk-access-denied:utilization>
+      </pcmk-access-readable:primitive>
+    </pcmk-access-readable:resources>
+    <pcmk-access-denied:constraints>
+      <pcmk-access-denied:rsc_location pcmk-access-denied:id="loc_fence_ilo_ha-idg-2" pcmk-access-denied:rsc="fence_ilo_ha-idg-2" pcmk-access-denied:score="-INFINITY" pcmk-access-denied:node="ha-idg-2"/>
+      <pcmk-access-denied:rsc_location pcmk-access-denied:id="loc_fence_ilo_ha-idg-1" pcmk-access-denied:rsc="fence_ilo_ha-idg-1" pcmk-access-denied:score="-INFINITY" pcmk-access-denied:node="ha-idg-1"/>
+    </pcmk-access-denied:constraints>
+    <pcmk-access-denied:rsc_defaults>
+      <pcmk-access-denied:meta_attributes pcmk-access-denied:id="rsc-options">
+        <pcmk-access-denied:nvpair pcmk-access-denied:name="resource-stickiness" pcmk-access-denied:value="200" pcmk-access-denied:id="rsc-options-resource-stickiness"/>
+      </pcmk-access-denied:meta_attributes>
+    </pcmk-access-denied:rsc_defaults>
+    <pcmk-access-denied:alerts/>
+  </pcmk-access-readable:configuration>
+  <pcmk-access-readable:status/>
+</pcmk-access-readable:cib>

--- a/xml/test-access-render/011-ref-carol.ref
+++ b/xml/test-access-render/011-ref-carol.ref
@@ -1,0 +1,159 @@
+\x1b[34m<cib crm_feature_set="3.0.14" validate-with="pacemaker-3.0" epoch="6815" num_updates="15" admin_epoch="2" cib-last-written="Thu Jun  6 15:41:29 2019" update-origin="ha-idg-2" update-client="crm_attribute" update-user="root" have-quorum="1" dc-uuid="1084777482" execution-date="1559829405">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair name="have-watchdog" value="false" id="cib-bootstrap-options-have-watchdog"/>
+        <nvpair name="dc-version" value="1.1.19+20181105.ccd6b5b10-3.3.1-1.1.19+20181105.ccd6b5b10" id="cib-bootstrap-options-dc-version"/>
+        <nvpair name="cluster-infrastructure" value="corosync" id="cib-bootstrap-options-cluster-infrastructure"/>
+        <nvpair name="last-lrm-refresh" value="1559146053" id="cib-bootstrap-options-last-lrm-refresh"/>
+        <nvpair name="cluster-name" value="ha-idg" id="cib-bootstrap-options-cluster-name"/>
+        <nvpair name="no-quorum-policy" value="ignore" id="cib-bootstrap-options-no-quorum-policy"/>
+        <nvpair name="stonith-enabled" value="true" id="cib-bootstrap-options-stonith-enabled"/>
+        <nvpair name="stonith-action" value="Off" id="cib-bootstrap-options-stonith-action"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="1084777492" uname="ha-idg-2">
+        <instance_attributes id="nodes-1084777492">
+          <nvpair id="nodes-1084777492-maintenance" name="maintenance" value="off"/>
+          <nvpair id="nodes-1084777492-standby" name="standby" value="on"/>
+        </instance_attributes>
+      </node>
+      <node id="1084777482" uname="ha-idg-1">
+        <instance_attributes id="nodes-1084777482">
+          <nvpair id="nodes-1084777482-maintenance" name="maintenance" value="off"/>
+          <nvpair id="nodes-1084777482-standby" name="standby" value="off"/>
+        </instance_attributes>
+      </node>
+    </nodes>
+    <acls>
+      <acl_role id="read_all">
+        <acl_permission id="read_all-cib" kind="read" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="operator">
+        <acl_permission id="operator-maintenance" kind="write" xpath="//crm_config//nvpair[@name='maintenance-mode']"/>
+        <acl_permission id="operator-target-role" kind="write" xpath="//crm_config//nvpair[@name='target-role']"/>
+        <acl_permission id="operator-is-managed" kind="write" xpath="//resources//nvpair[@name='is-managed']"/>
+        <acl_permission id="operator-rsc_location" kind="write" object-type="rsc_location"/>
+      </acl_role>
+      <acl_role id="administrator">
+        <acl_permission id="administrator-cib" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="minimal">
+        <acl_permission id="minimal-standby" kind="read" description="allow reading standby node attribute (permanent or transient)" xpath="//instance_attributes/nvpair[@name='standby']"/>
+        <acl_permission id="minimal-maintenance" kind="read" description="allow reading maintenance node attribute (permanent or transient)" xpath="//instance_attributes/nvpair[@name='maintenance']"/>
+        <acl_permission id="minimal-target-role" kind="read" description="allow reading resource target roles" xpath="//meta_attributes/nvpair[@name='target-role']"/>
+        <acl_permission id="minimal-is-managed" kind="read" description="allow reading resource managed status" xpath="//meta_attributes/nvpair[@name='is-managed']"/>
+        <acl_permission id="minimal-deny-instance-attributes" kind="deny" xpath="//instance_attributes"/>
+        <acl_permission id="minimal-deny-meta-attributes" kind="deny" xpath="//meta_attributes"/>
+        <acl_permission id="minimal-deny-operations" kind="deny" xpath="//operations"/>
+        <acl_permission id="minimal-deny-utilization" kind="deny" xpath="//utilization"/>
+        <acl_permission id="minimal-nodes" kind="read" description="allow reading node names/IDs (attributes are denied separately)" xpath="/cib/configuration/nodes"/>
+        <acl_permission id="minimal-resources" kind="read" description="allow reading resource names/agents (parameters are denied separately)" xpath="/cib/configuration/resources"/>
+        <acl_permission id="minimal-deny-constraints" kind="deny" xpath="/cib/configuration/constraints"/>
+        <acl_permission id="minimal-deny-topology" kind="deny" xpath="/cib/configuration/fencing-topology"/>
+        <acl_permission id="minimal-deny-op_defaults" kind="deny" xpath="/cib/configuration/op_defaults"/>
+        <acl_permission id="minimal-deny-rsc_defaults" kind="deny" xpath="/cib/configuration/rsc_defaults"/>
+        <acl_permission id="minimal-deny-alerts" kind="deny" xpath="/cib/configuration/alerts"/>
+        <acl_permission id="minimal-deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+        <acl_permission id="minimal-cib" kind="read" description="allow reading cib element and crm_config/status sections" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="alice">
+        <role id="minimal"/>
+      </acl_target>
+      <acl_target id="bob">
+        <role id="read_all"/>
+      </acl_target>
+      <acl_target id="carol">
+        <role id="read_all"/>
+        <role id="operator"/>
+      </acl_target>
+      <acl_target id="dave">
+        <role id="administrator"/>
+      </acl_target>
+    </acls>
+    <resources>
+      <primitive id="fence_ilo_ha-idg-2" class="stonith" type="fence_ilo2" description="fenct ha-idg-2 mit ILO">
+        <operations>
+          <op name="monitor" interval="30m" timeout="120s" id="fence_ha-idg-2-monitor-30m"/>
+        </operations>
+      </primitive>
+      <primitive id="fence_ilo_ha-idg-1" class="stonith" type="fence_ilo4" description="fenct ha-idg-1 mit ILO">
+        <operations>
+          <op name="monitor" interval="30m" timeout="120s" id="fence_ha-idg-1-monitor-30m"/>
+        </operations>
+      </primitive>
+      <primitive id="vm_idcc_devel" class="ocf" provider="heartbeat" type="VirtualDomain">
+        <instance_attributes id="vm_idcc-devel-instance_attributes">
+          <nvpair name="config" value="/mnt/share/idcc_devel.xml" id="vm_idcc-devel-instance_attributes-config"/>
+        </instance_attributes>
+        <instance_attributes id="vm_idcc-devel-instance_attributes-0">
+          <nvpair name="hypervisor" value="qemu:///system" id="vm_idcc-devel-instance_attributes-0-hypervisor"/>
+        </instance_attributes>
+        <instance_attributes id="vm_idcc-devel-instance_attributes-1">
+          <nvpair name="migration_transport" value="ssh" id="vm_idcc-devel-instance_attributes-1-migration_transport"/>
+        </instance_attributes>
+        <instance_attributes id="vm_idcc-devel-instance_attributes-2">
+          <nvpair name="migration_network_suffix" value="-private" id="vm_idcc-devel-instance_attributes-2-migration_network_suffix"/>
+        </instance_attributes>
+        <operations>
+          <op name="start" interval="0" timeout="120" id="vm_idcc-devel-start-0"/>
+          <op name="stop" interval="0" timeout="130" id="vm_idcc-devel-stop-0"/>
+          <op name="monitor" interval="30" timeout="25" id="vm_idcc-devel-monitor-30"/>
+          <op name="migrate_from" interval="0" timeout="300" id="vm_idcc-devel-migrate_from-0"/>
+          <op name="migrate_to" interval="0" timeout="300" id="vm_idcc-devel-migrate_to-0"/>
+        </operations>
+        <meta_attributes id="vm_idcc-devel-meta_attributes">
+          <nvpair name="allow-migrate" value="true" id="vm_idcc-devel-meta_attributes-allow-migrate"/>
+          <nvpair name="target-role" value="Started" id="vm_idcc-devel-meta_attributes-target-role"/>
+          \x1b[32m<nvpair name="is-managed" value="true" id="vm_idcc-devel-meta_attributes-is-managed"/>
+        </meta_attributes>
+        <utilization id="vm_idcc-devel-utilization">
+          <nvpair name="cpu" value="1" id="vm_idcc-devel-utilization-cpu"/>
+          <nvpair name="hv_memory" value="1020" id="vm_idcc-devel-utilization-hv_memory"/>
+        </utilization>
+      </primitive>
+      <primitive id="vm_severin" class="ocf" provider="heartbeat" type="VirtualDomain">
+        <instance_attributes id="vm_severin-instance_attributes">
+          <nvpair name="config" value="/mnt/share/severin.xml" id="vm_severin-instance_attributes-config"/>
+        </instance_attributes>
+        <instance_attributes id="vm_severin-instance_attributes-0">
+          <nvpair name="hypervisor" value="qemu:///system" id="vm_severin-instance_attributes-0-hypervisor"/>
+        </instance_attributes>
+        <instance_attributes id="vm_severin-instance_attributes-1">
+          <nvpair name="migration_transport" value="ssh" id="vm_severin-instance_attributes-1-migration_transport"/>
+        </instance_attributes>
+        <instance_attributes id="vm_severin-instance_attributes-2">
+          <nvpair name="migration_network_suffix" value="-private" id="vm_severin-instance_attributes-2-migration_network_suffix"/>
+        </instance_attributes>
+        <operations>
+          <op name="start" interval="0" timeout="120" id="vm_severin-start-0"/>
+          <op name="stop" interval="0" timeout="130" id="vm_severin-stop-0"/>
+          <op name="monitor" interval="30" timeout="25" id="vm_severin-monitor-30"/>
+          <op name="migrate_from" interval="0" timeout="300" id="vm_severin-migrate_from-0"/>
+          <op name="migrate_to" interval="0" timeout="300" id="vm_severin-migrate_to-0"/>
+        </operations>
+        <meta_attributes id="vm_severin-meta_attributes">
+          <nvpair name="allow-migrate" value="true" id="vm_severin-meta_attributes-allow-migrate"/>
+          <nvpair name="target-role" value="Started" id="vm_severin-meta_attributes-target-role"/>
+          \x1b[32m<nvpair name="is-managed" value="true" id="vm_severin-meta_attributes-is-managed"/>
+        </meta_attributes>
+        <utilization id="vm_severin-utilization">
+          <nvpair name="cpu" value="2" id="vm_severin-utilization-cpu"/>
+          <nvpair name="hv_memory" value="2176" id="vm_severin-utilization-hv_memory"/>
+        </utilization>
+      </primitive>
+    </resources>
+    <constraints>
+      \x1b[32m<rsc_location id="loc_fence_ilo_ha-idg-2" rsc="fence_ilo_ha-idg-2" score="-INFINITY" node="ha-idg-2"/>
+      \x1b[32m<rsc_location id="loc_fence_ilo_ha-idg-1" rsc="fence_ilo_ha-idg-1" score="-INFINITY" node="ha-idg-1"/>
+    </constraints>
+    <rsc_defaults>
+      <meta_attributes id="rsc-options">
+        <nvpair name="resource-stickiness" value="200" id="rsc-options-resource-stickiness"/>
+      </meta_attributes>
+    </rsc_defaults>
+    <alerts/>
+  </configuration>
+  <status/>
+\x1b[34m</cib>\x1b[0m

--- a/xml/test-access-render/011-ref-carol.xml
+++ b/xml/test-access-render/011-ref-carol.xml
@@ -1,0 +1,162 @@
+<pcmk-access-readable:cib
+  xmlns:pcmk-access-readable="http://clusterlabs.org/ns/pacemaker/access/readable"
+  xmlns:pcmk-access-writable="http://clusterlabs.org/ns/pacemaker/access/writable"
+  pcmk-access-readable:crm_feature_set="3.0.14" pcmk-access-readable:validate-with="pacemaker-3.0" pcmk-access-readable:epoch="6815" pcmk-access-readable:num_updates="15" pcmk-access-readable:admin_epoch="2" pcmk-access-readable:cib-last-written="Thu Jun  6 15:41:29 2019" pcmk-access-readable:update-origin="ha-idg-2" pcmk-access-readable:update-client="crm_attribute" pcmk-access-readable:update-user="root" pcmk-access-readable:have-quorum="1" pcmk-access-readable:dc-uuid="1084777482" pcmk-access-readable:execution-date="1559829405">
+  <pcmk-access-readable:configuration>
+    <pcmk-access-readable:crm_config>
+      <pcmk-access-readable:cluster_property_set pcmk-access-readable:id="cib-bootstrap-options">
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="have-watchdog" pcmk-access-readable:value="false" pcmk-access-readable:id="cib-bootstrap-options-have-watchdog"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="dc-version" pcmk-access-readable:value="1.1.19+20181105.ccd6b5b10-3.3.1-1.1.19+20181105.ccd6b5b10" pcmk-access-readable:id="cib-bootstrap-options-dc-version"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="cluster-infrastructure" pcmk-access-readable:value="corosync" pcmk-access-readable:id="cib-bootstrap-options-cluster-infrastructure"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="last-lrm-refresh" pcmk-access-readable:value="1559146053" pcmk-access-readable:id="cib-bootstrap-options-last-lrm-refresh"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="cluster-name" pcmk-access-readable:value="ha-idg" pcmk-access-readable:id="cib-bootstrap-options-cluster-name"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="no-quorum-policy" pcmk-access-readable:value="ignore" pcmk-access-readable:id="cib-bootstrap-options-no-quorum-policy"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="stonith-enabled" pcmk-access-readable:value="true" pcmk-access-readable:id="cib-bootstrap-options-stonith-enabled"/>
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="stonith-action" pcmk-access-readable:value="Off" pcmk-access-readable:id="cib-bootstrap-options-stonith-action"/>
+      </pcmk-access-readable:cluster_property_set>
+    </pcmk-access-readable:crm_config>
+    <pcmk-access-readable:nodes>
+      <pcmk-access-readable:node pcmk-access-readable:id="1084777492" pcmk-access-readable:uname="ha-idg-2">
+        <pcmk-access-readable:instance_attributes pcmk-access-readable:id="nodes-1084777492">
+          <pcmk-access-readable:nvpair pcmk-access-readable:id="nodes-1084777492-maintenance" pcmk-access-readable:name="maintenance" pcmk-access-readable:value="off"/>
+          <pcmk-access-readable:nvpair pcmk-access-readable:id="nodes-1084777492-standby" pcmk-access-readable:name="standby" pcmk-access-readable:value="on"/>
+        </pcmk-access-readable:instance_attributes>
+      </pcmk-access-readable:node>
+      <pcmk-access-readable:node pcmk-access-readable:id="1084777482" pcmk-access-readable:uname="ha-idg-1">
+        <pcmk-access-readable:instance_attributes pcmk-access-readable:id="nodes-1084777482">
+          <pcmk-access-readable:nvpair pcmk-access-readable:id="nodes-1084777482-maintenance" pcmk-access-readable:name="maintenance" pcmk-access-readable:value="off"/>
+          <pcmk-access-readable:nvpair pcmk-access-readable:id="nodes-1084777482-standby" pcmk-access-readable:name="standby" pcmk-access-readable:value="off"/>
+        </pcmk-access-readable:instance_attributes>
+      </pcmk-access-readable:node>
+    </pcmk-access-readable:nodes>
+    <pcmk-access-readable:acls>
+      <pcmk-access-readable:acl_role pcmk-access-readable:id="read_all">
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="read_all-cib" pcmk-access-readable:kind="read" pcmk-access-readable:xpath="/cib"/>
+      </pcmk-access-readable:acl_role>
+      <pcmk-access-readable:acl_role pcmk-access-readable:id="operator">
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="operator-maintenance" pcmk-access-readable:kind="write" pcmk-access-readable:xpath="//crm_config//nvpair[@name='maintenance-mode']"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="operator-target-role" pcmk-access-readable:kind="write" pcmk-access-readable:xpath="//crm_config//nvpair[@name='target-role']"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="operator-is-managed" pcmk-access-readable:kind="write" pcmk-access-readable:xpath="//resources//nvpair[@name='is-managed']"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="operator-rsc_location" pcmk-access-readable:kind="write" pcmk-access-readable:object-type="rsc_location"/>
+      </pcmk-access-readable:acl_role>
+      <pcmk-access-readable:acl_role pcmk-access-readable:id="administrator">
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="administrator-cib" pcmk-access-readable:kind="write" pcmk-access-readable:xpath="/cib"/>
+      </pcmk-access-readable:acl_role>
+      <pcmk-access-readable:acl_role pcmk-access-readable:id="minimal">
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-standby" pcmk-access-readable:kind="read" pcmk-access-readable:description="allow reading standby node attribute (permanent or transient)" pcmk-access-readable:xpath="//instance_attributes/nvpair[@name='standby']"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-maintenance" pcmk-access-readable:kind="read" pcmk-access-readable:description="allow reading maintenance node attribute (permanent or transient)" pcmk-access-readable:xpath="//instance_attributes/nvpair[@name='maintenance']"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-target-role" pcmk-access-readable:kind="read" pcmk-access-readable:description="allow reading resource target roles" pcmk-access-readable:xpath="//meta_attributes/nvpair[@name='target-role']"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-is-managed" pcmk-access-readable:kind="read" pcmk-access-readable:description="allow reading resource managed status" pcmk-access-readable:xpath="//meta_attributes/nvpair[@name='is-managed']"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-deny-instance-attributes" pcmk-access-readable:kind="deny" pcmk-access-readable:xpath="//instance_attributes"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-deny-meta-attributes" pcmk-access-readable:kind="deny" pcmk-access-readable:xpath="//meta_attributes"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-deny-operations" pcmk-access-readable:kind="deny" pcmk-access-readable:xpath="//operations"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-deny-utilization" pcmk-access-readable:kind="deny" pcmk-access-readable:xpath="//utilization"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-nodes" pcmk-access-readable:kind="read" pcmk-access-readable:description="allow reading node names/IDs (attributes are denied separately)" pcmk-access-readable:xpath="/cib/configuration/nodes"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-resources" pcmk-access-readable:kind="read" pcmk-access-readable:description="allow reading resource names/agents (parameters are denied separately)" pcmk-access-readable:xpath="/cib/configuration/resources"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-deny-constraints" pcmk-access-readable:kind="deny" pcmk-access-readable:xpath="/cib/configuration/constraints"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-deny-topology" pcmk-access-readable:kind="deny" pcmk-access-readable:xpath="/cib/configuration/fencing-topology"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-deny-op_defaults" pcmk-access-readable:kind="deny" pcmk-access-readable:xpath="/cib/configuration/op_defaults"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-deny-rsc_defaults" pcmk-access-readable:kind="deny" pcmk-access-readable:xpath="/cib/configuration/rsc_defaults"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-deny-alerts" pcmk-access-readable:kind="deny" pcmk-access-readable:xpath="/cib/configuration/alerts"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-deny-acls" pcmk-access-readable:kind="deny" pcmk-access-readable:xpath="/cib/configuration/acls"/>
+        <pcmk-access-readable:acl_permission pcmk-access-readable:id="minimal-cib" pcmk-access-readable:kind="read" pcmk-access-readable:description="allow reading cib element and crm_config/status sections" pcmk-access-readable:xpath="/cib"/>
+      </pcmk-access-readable:acl_role>
+      <pcmk-access-readable:acl_target pcmk-access-readable:id="alice">
+        <pcmk-access-readable:role pcmk-access-readable:id="minimal"/>
+      </pcmk-access-readable:acl_target>
+      <pcmk-access-readable:acl_target pcmk-access-readable:id="bob">
+        <pcmk-access-readable:role pcmk-access-readable:id="read_all"/>
+      </pcmk-access-readable:acl_target>
+      <pcmk-access-readable:acl_target pcmk-access-readable:id="carol">
+        <pcmk-access-readable:role pcmk-access-readable:id="read_all"/>
+        <pcmk-access-readable:role pcmk-access-readable:id="operator"/>
+      </pcmk-access-readable:acl_target>
+      <pcmk-access-readable:acl_target pcmk-access-readable:id="dave">
+        <pcmk-access-readable:role pcmk-access-readable:id="administrator"/>
+      </pcmk-access-readable:acl_target>
+    </pcmk-access-readable:acls>
+    <pcmk-access-readable:resources>
+      <pcmk-access-readable:primitive pcmk-access-readable:id="fence_ilo_ha-idg-2" pcmk-access-readable:class="stonith" pcmk-access-readable:type="fence_ilo2" pcmk-access-readable:description="fenct ha-idg-2 mit ILO">
+        <pcmk-access-readable:operations>
+          <pcmk-access-readable:op pcmk-access-readable:name="monitor" pcmk-access-readable:interval="30m" pcmk-access-readable:timeout="120s" pcmk-access-readable:id="fence_ha-idg-2-monitor-30m"/>
+        </pcmk-access-readable:operations>
+      </pcmk-access-readable:primitive>
+      <pcmk-access-readable:primitive pcmk-access-readable:id="fence_ilo_ha-idg-1" pcmk-access-readable:class="stonith" pcmk-access-readable:type="fence_ilo4" pcmk-access-readable:description="fenct ha-idg-1 mit ILO">
+        <pcmk-access-readable:operations>
+          <pcmk-access-readable:op pcmk-access-readable:name="monitor" pcmk-access-readable:interval="30m" pcmk-access-readable:timeout="120s" pcmk-access-readable:id="fence_ha-idg-1-monitor-30m"/>
+        </pcmk-access-readable:operations>
+      </pcmk-access-readable:primitive>
+      <pcmk-access-readable:primitive pcmk-access-readable:id="vm_idcc_devel" pcmk-access-readable:class="ocf" pcmk-access-readable:provider="heartbeat" pcmk-access-readable:type="VirtualDomain">
+        <pcmk-access-readable:instance_attributes pcmk-access-readable:id="vm_idcc-devel-instance_attributes">
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="config" pcmk-access-readable:value="/mnt/share/idcc_devel.xml" pcmk-access-readable:id="vm_idcc-devel-instance_attributes-config"/>
+        </pcmk-access-readable:instance_attributes>
+        <pcmk-access-readable:instance_attributes pcmk-access-readable:id="vm_idcc-devel-instance_attributes-0">
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="hypervisor" pcmk-access-readable:value="qemu:///system" pcmk-access-readable:id="vm_idcc-devel-instance_attributes-0-hypervisor"/>
+        </pcmk-access-readable:instance_attributes>
+        <pcmk-access-readable:instance_attributes pcmk-access-readable:id="vm_idcc-devel-instance_attributes-1">
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="migration_transport" pcmk-access-readable:value="ssh" pcmk-access-readable:id="vm_idcc-devel-instance_attributes-1-migration_transport"/>
+        </pcmk-access-readable:instance_attributes>
+        <pcmk-access-readable:instance_attributes pcmk-access-readable:id="vm_idcc-devel-instance_attributes-2">
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="migration_network_suffix" pcmk-access-readable:value="-private" pcmk-access-readable:id="vm_idcc-devel-instance_attributes-2-migration_network_suffix"/>
+        </pcmk-access-readable:instance_attributes>
+        <pcmk-access-readable:operations>
+          <pcmk-access-readable:op pcmk-access-readable:name="start" pcmk-access-readable:interval="0" pcmk-access-readable:timeout="120" pcmk-access-readable:id="vm_idcc-devel-start-0"/>
+          <pcmk-access-readable:op pcmk-access-readable:name="stop" pcmk-access-readable:interval="0" pcmk-access-readable:timeout="130" pcmk-access-readable:id="vm_idcc-devel-stop-0"/>
+          <pcmk-access-readable:op pcmk-access-readable:name="monitor" pcmk-access-readable:interval="30" pcmk-access-readable:timeout="25" pcmk-access-readable:id="vm_idcc-devel-monitor-30"/>
+          <pcmk-access-readable:op pcmk-access-readable:name="migrate_from" pcmk-access-readable:interval="0" pcmk-access-readable:timeout="300" pcmk-access-readable:id="vm_idcc-devel-migrate_from-0"/>
+          <pcmk-access-readable:op pcmk-access-readable:name="migrate_to" pcmk-access-readable:interval="0" pcmk-access-readable:timeout="300" pcmk-access-readable:id="vm_idcc-devel-migrate_to-0"/>
+        </pcmk-access-readable:operations>
+        <pcmk-access-readable:meta_attributes pcmk-access-readable:id="vm_idcc-devel-meta_attributes">
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="allow-migrate" pcmk-access-readable:value="true" pcmk-access-readable:id="vm_idcc-devel-meta_attributes-allow-migrate"/>
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="target-role" pcmk-access-readable:value="Started" pcmk-access-readable:id="vm_idcc-devel-meta_attributes-target-role"/>
+          <pcmk-access-writable:nvpair pcmk-access-writable:name="is-managed" pcmk-access-writable:value="true" pcmk-access-writable:id="vm_idcc-devel-meta_attributes-is-managed"/>
+        </pcmk-access-readable:meta_attributes>
+        <pcmk-access-readable:utilization pcmk-access-readable:id="vm_idcc-devel-utilization">
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="cpu" pcmk-access-readable:value="1" pcmk-access-readable:id="vm_idcc-devel-utilization-cpu"/>
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="hv_memory" pcmk-access-readable:value="1020" pcmk-access-readable:id="vm_idcc-devel-utilization-hv_memory"/>
+        </pcmk-access-readable:utilization>
+      </pcmk-access-readable:primitive>
+      <pcmk-access-readable:primitive pcmk-access-readable:id="vm_severin" pcmk-access-readable:class="ocf" pcmk-access-readable:provider="heartbeat" pcmk-access-readable:type="VirtualDomain">
+        <pcmk-access-readable:instance_attributes pcmk-access-readable:id="vm_severin-instance_attributes">
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="config" pcmk-access-readable:value="/mnt/share/severin.xml" pcmk-access-readable:id="vm_severin-instance_attributes-config"/>
+        </pcmk-access-readable:instance_attributes>
+        <pcmk-access-readable:instance_attributes pcmk-access-readable:id="vm_severin-instance_attributes-0">
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="hypervisor" pcmk-access-readable:value="qemu:///system" pcmk-access-readable:id="vm_severin-instance_attributes-0-hypervisor"/>
+        </pcmk-access-readable:instance_attributes>
+        <pcmk-access-readable:instance_attributes pcmk-access-readable:id="vm_severin-instance_attributes-1">
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="migration_transport" pcmk-access-readable:value="ssh" pcmk-access-readable:id="vm_severin-instance_attributes-1-migration_transport"/>
+        </pcmk-access-readable:instance_attributes>
+        <pcmk-access-readable:instance_attributes pcmk-access-readable:id="vm_severin-instance_attributes-2">
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="migration_network_suffix" pcmk-access-readable:value="-private" pcmk-access-readable:id="vm_severin-instance_attributes-2-migration_network_suffix"/>
+        </pcmk-access-readable:instance_attributes>
+        <pcmk-access-readable:operations>
+          <pcmk-access-readable:op pcmk-access-readable:name="start" pcmk-access-readable:interval="0" pcmk-access-readable:timeout="120" pcmk-access-readable:id="vm_severin-start-0"/>
+          <pcmk-access-readable:op pcmk-access-readable:name="stop" pcmk-access-readable:interval="0" pcmk-access-readable:timeout="130" pcmk-access-readable:id="vm_severin-stop-0"/>
+          <pcmk-access-readable:op pcmk-access-readable:name="monitor" pcmk-access-readable:interval="30" pcmk-access-readable:timeout="25" pcmk-access-readable:id="vm_severin-monitor-30"/>
+          <pcmk-access-readable:op pcmk-access-readable:name="migrate_from" pcmk-access-readable:interval="0" pcmk-access-readable:timeout="300" pcmk-access-readable:id="vm_severin-migrate_from-0"/>
+          <pcmk-access-readable:op pcmk-access-readable:name="migrate_to" pcmk-access-readable:interval="0" pcmk-access-readable:timeout="300" pcmk-access-readable:id="vm_severin-migrate_to-0"/>
+        </pcmk-access-readable:operations>
+        <pcmk-access-readable:meta_attributes pcmk-access-readable:id="vm_severin-meta_attributes">
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="allow-migrate" pcmk-access-readable:value="true" pcmk-access-readable:id="vm_severin-meta_attributes-allow-migrate"/>
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="target-role" pcmk-access-readable:value="Started" pcmk-access-readable:id="vm_severin-meta_attributes-target-role"/>
+          <pcmk-access-writable:nvpair pcmk-access-writable:name="is-managed" pcmk-access-writable:value="true" pcmk-access-writable:id="vm_severin-meta_attributes-is-managed"/>
+        </pcmk-access-readable:meta_attributes>
+        <pcmk-access-readable:utilization pcmk-access-readable:id="vm_severin-utilization">
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="cpu" pcmk-access-readable:value="2" pcmk-access-readable:id="vm_severin-utilization-cpu"/>
+          <pcmk-access-readable:nvpair pcmk-access-readable:name="hv_memory" pcmk-access-readable:value="2176" pcmk-access-readable:id="vm_severin-utilization-hv_memory"/>
+        </pcmk-access-readable:utilization>
+      </pcmk-access-readable:primitive>
+    </pcmk-access-readable:resources>
+    <pcmk-access-readable:constraints>
+      <pcmk-access-writable:rsc_location pcmk-access-writable:id="loc_fence_ilo_ha-idg-2" pcmk-access-writable:rsc="fence_ilo_ha-idg-2" pcmk-access-writable:score="-INFINITY" pcmk-access-writable:node="ha-idg-2"/>
+      <pcmk-access-writable:rsc_location pcmk-access-writable:id="loc_fence_ilo_ha-idg-1" pcmk-access-writable:rsc="fence_ilo_ha-idg-1" pcmk-access-writable:score="-INFINITY" pcmk-access-writable:node="ha-idg-1"/>
+    </pcmk-access-readable:constraints>
+    <pcmk-access-readable:rsc_defaults>
+      <pcmk-access-readable:meta_attributes pcmk-access-readable:id="rsc-options">
+        <pcmk-access-readable:nvpair pcmk-access-readable:name="resource-stickiness" pcmk-access-readable:value="200" pcmk-access-readable:id="rsc-options-resource-stickiness"/>
+      </pcmk-access-readable:meta_attributes>
+    </pcmk-access-readable:rsc_defaults>
+    <pcmk-access-readable:alerts/>
+  </pcmk-access-readable:configuration>
+  <pcmk-access-readable:status/>
+</pcmk-access-readable:cib>


### PR DESCRIPTION
Known rough edges:

* [x] fix oddities spotted by Ken
* [x] missing deployment stuff (Makefile/spec) for new `acls-render.xsl`
* [x] cibadmin's help should show an example usage
* [x] not tested user friendliness under all circumstances (`-U` required etc.)
* [x] no CLI tests
* [ ] public API not reflecting the intent to generalize for groups alike (worked on)
* [x] check that we are working with eligible schema (to begin with)