### PR TITLE
Feature: pengine: formatted output for html

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -108,10 +108,13 @@ int pe__name_and_nvpairs_xml(pcmk__output_t *out, bool is_list, const char *tag_
                          , size_t pairs_count, ...);
 
 int pe__clone_xml(pcmk__output_t *out, va_list args);
+int pe__clone_html(pcmk__output_t *out, va_list args);
 int pe__clone_text(pcmk__output_t *out, va_list args);
 int pe__bundle_xml(pcmk__output_t *out, va_list args);
+int pe__bundle_html(pcmk__output_t *out, va_list args);
 int pe__bundle_text(pcmk__output_t *out, va_list args);
 int pe__resource_xml(pcmk__output_t *out, va_list args);
+int pe__resource_html(pcmk__output_t *out, va_list args);
 int pe__resource_text(pcmk__output_t *out, va_list args);
 
 void native_free(resource_t * rsc);
@@ -351,6 +354,8 @@ void print_rscs_brief(GListPtr rsc_list, const char * pre_text, long options,
                       void * print_data, gboolean print_all);
 void pe__rscs_brief_output_text(pcmk__output_t *out, GListPtr rsc_list, const char *pre_text,
                                 long options, gboolean print_all);
+void pe__rscs_brief_output_html(pcmk__output_t *out, GListPtr rsc_list,
+                                long options, gboolean print_all);
 void pe_fence_node(pe_working_set_t * data_set, node_t * node, const char *reason);
 
 node_t *pe_create_node(const char *id, const char *uname, const char *type,
@@ -358,6 +363,7 @@ node_t *pe_create_node(const char *id, const char *uname, const char *type,
 bool remote_id_conflict(const char *remote_name, pe_working_set_t *data);
 void common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options, void *print_data);
 void pe__common_output_text(pcmk__output_t *out, resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options);
+void pe__common_output_html(pcmk__output_t *out, resource_t * rsc, const char *name, node_t *node, long options);
 pe_resource_t *pe__find_bundle_replica(const pe_resource_t *bundle,
                                        const pe_node_t *node);
 bool pe__bundle_needs_remote_name(pe_resource_t *rsc);

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -297,6 +297,19 @@ pe__short_output_text(pcmk__output_t *out, char *list, const char *prefix, const
     }
 }
 
+static void
+pe__short_output_html(pcmk__output_t *out, char *list, const char *type, const char *suffix, long options)
+{
+    char buffer[LINE_MAX];
+
+    if (list == NULL) {
+        return;
+    }
+
+    snprintf(buffer, LINE_MAX, " %s: [%s ]%s", type, list, suffix ? suffix : "");
+    out->list_item(out, NULL, buffer);
+}
+
 static const char *
 configured_role_str(resource_t * rsc)
 {
@@ -611,6 +624,192 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
 
     pcmk__xml_pop_parent(out);
     return rc;
+}
+
+int
+pe__clone_html(pcmk__output_t *out, va_list args)
+{
+    long options = va_arg(args, long);
+    resource_t *rsc = va_arg(args, resource_t *);
+
+    char *list_text = NULL;
+    char *stopped_list = NULL;
+
+    GListPtr master_list = NULL;
+    GListPtr started_list = NULL;
+    GListPtr gIter = rsc->children;
+
+    clone_variant_data_t *clone_data = NULL;
+    int active_instances = 0;
+    char buffer[LINE_MAX];
+
+    get_clone_variant_data(clone_data, rsc);
+
+    snprintf(buffer, LINE_MAX, "Clone Set: %s [%s]%s%s%s",
+                 rsc->id, ID(clone_data->xml_obj_child),
+                 is_set(rsc->flags, pe_rsc_promotable) ? " (promotable)" : "",
+                 is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
+                 is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
+
+    out->begin_list(out, buffer, NULL, NULL);
+
+    for (; gIter != NULL; gIter = gIter->next) {
+        gboolean print_full = FALSE;
+        resource_t *child_rsc = (resource_t *) gIter->data;
+        gboolean partially_active = child_rsc->fns->active(child_rsc, FALSE);
+
+        if (options & pe_print_clone_details) {
+            print_full = TRUE;
+        }
+
+        if (is_set(rsc->flags, pe_rsc_unique)) {
+            // Print individual instance when unique (except stopped orphans)
+            if (partially_active || is_not_set(rsc->flags, pe_rsc_orphan)) {
+                print_full = TRUE;
+            }
+
+        // Everything else in this block is for anonymous clones
+
+        } else if (is_set(options, pe_print_pending)
+                   && (child_rsc->pending_task != NULL)
+                   && strcmp(child_rsc->pending_task, "probe")) {
+            // Print individual instance when non-probe action is pending
+            print_full = TRUE;
+
+        } else if (partially_active == FALSE) {
+            // List stopped instances when requested (except orphans)
+            if (is_not_set(child_rsc->flags, pe_rsc_orphan)
+                && is_not_set(options, pe_print_clone_active)) {
+                stopped_list = add_list_element(stopped_list, child_rsc->id);
+            }
+
+        } else if (is_set_recursive(child_rsc, pe_rsc_orphan, TRUE)
+                   || is_set_recursive(child_rsc, pe_rsc_managed, FALSE) == FALSE
+                   || is_set_recursive(child_rsc, pe_rsc_failed, TRUE)) {
+
+            // Print individual instance when active orphaned/unmanaged/failed
+            print_full = TRUE;
+
+        } else if (child_rsc->fns->active(child_rsc, TRUE)) {
+            // Instance of fully active anonymous clone
+
+            node_t *location = child_rsc->fns->location(child_rsc, NULL, TRUE);
+
+            if (location) {
+                // Instance is active on a single node
+
+                enum rsc_role_e a_role = child_rsc->fns->state(child_rsc, TRUE);
+
+                if (location->details->online == FALSE && location->details->unclean) {
+                    print_full = TRUE;
+
+                } else if (a_role > RSC_ROLE_SLAVE) {
+                    master_list = g_list_append(master_list, location);
+
+                } else {
+                    started_list = g_list_append(started_list, location);
+                }
+
+            } else {
+                /* uncolocated group - bleh */
+                print_full = TRUE;
+            }
+
+        } else {
+            // Instance of partially active anonymous clone
+            print_full = TRUE;
+        }
+
+        if (print_full) {
+            pcmk__output_xml_node(out, "li");
+            out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
+            pcmk__xml_pop_parent(out);
+        }
+    }
+
+    /* Masters */
+    master_list = g_list_sort(master_list, sort_node_uname);
+    for (gIter = master_list; gIter; gIter = gIter->next) {
+        node_t *host = gIter->data;
+
+        list_text = add_list_element(list_text, host->details->uname);
+        active_instances++;
+    }
+
+    pe__short_output_html(out, list_text, "Masters", NULL, options);
+    g_list_free(master_list);
+    free(list_text);
+    list_text = NULL;
+
+    /* Started/Slaves */
+    started_list = g_list_sort(started_list, sort_node_uname);
+    for (gIter = started_list; gIter; gIter = gIter->next) {
+        node_t *host = gIter->data;
+
+        list_text = add_list_element(list_text, host->details->uname);
+        active_instances++;
+    }
+
+    if (is_set(rsc->flags, pe_rsc_promotable)) {
+        enum rsc_role_e role = configured_role(rsc);
+
+        if(role == RSC_ROLE_SLAVE) {
+            pe__short_output_html(out, list_text, "Slaves (target-role)", NULL, options);
+        } else {
+            pe__short_output_html(out, list_text, "Slaves", NULL, options);
+        }
+
+    } else {
+        pe__short_output_html(out, list_text, "Started", NULL, options);
+    }
+
+    g_list_free(started_list);
+    free(list_text);
+    list_text = NULL;
+
+    if (is_not_set(options, pe_print_clone_active)) {
+        const char *state = "Stopped";
+        enum rsc_role_e role = configured_role(rsc);
+
+        if (role == RSC_ROLE_STOPPED) {
+            state = "Stopped (disabled)";
+        }
+
+        if (is_not_set(rsc->flags, pe_rsc_unique)
+            && (clone_data->clone_max > active_instances)) {
+
+            GListPtr nIter;
+            GListPtr list = g_hash_table_get_values(rsc->allowed_nodes);
+
+            /* Custom stopped list for non-unique clones */
+            free(stopped_list);
+            stopped_list = NULL;
+
+            if (g_list_length(list) == 0) {
+                /* Clusters with symmetrical=false haven't calculated allowed_nodes yet
+                 * If we've not probed for them yet, the Stopped list will be empty
+                 */
+                list = g_hash_table_get_values(rsc->known_on);
+            }
+
+            list = g_list_sort(list, sort_node_uname);
+            for (nIter = list; nIter != NULL; nIter = nIter->next) {
+                node_t *node = (node_t *)nIter->data;
+
+                if (pe_find_node(rsc->running_on, node->details->uname) == NULL) {
+                    stopped_list = add_list_element(stopped_list, node->details->uname);
+                }
+            }
+            g_list_free(list);
+        }
+
+        pe__short_output_html(out, stopped_list, state, NULL, options);
+        free(stopped_list);
+    }
+
+    out->end_list(out);
+
+    return 0;
 }
 
 int

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -67,6 +67,35 @@ pe__group_xml(pcmk__output_t *out, va_list args)
 }
 
 static int
+pe__group_html(pcmk__output_t *out, va_list args)
+{
+    long options = va_arg(args, long);
+    resource_t *rsc = va_arg(args, resource_t *);
+    char buffer[LINE_MAX];
+
+    snprintf(buffer, LINE_MAX, "Resource Group: %s", rsc->id);
+
+    out->begin_list(out, buffer, NULL, NULL);
+
+    if (options & pe_print_brief) {
+        pe__rscs_brief_output_html(out, rsc->children, options, TRUE);
+
+    } else {
+        for (GListPtr gIter = rsc->children; gIter; gIter = gIter->next) {
+            resource_t *child_rsc = (resource_t *) gIter->data;
+
+            pcmk__output_xml_node(out, "li");
+            out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
+            pcmk__xml_pop_parent(out);
+        }
+    }
+
+    out->end_list(out);
+
+    return 0;
+}
+
+static int
 pe__group_text(pcmk__output_t *out, va_list args)
 {
     long options = va_arg(args, long);
@@ -98,12 +127,16 @@ pe__group_text(pcmk__output_t *out, va_list args)
 
 static pcmk__message_entry_t fmt_functions[] = {
     { "bundle", "xml",  pe__bundle_xml },
+    { "bundle", "html",  pe__bundle_html },
     { "bundle", "text",  pe__bundle_text },
     { "clone", "xml",  pe__clone_xml },
+    { "clone", "html",  pe__clone_html },
     { "clone", "text",  pe__clone_text },
     { "group", "xml",  pe__group_xml },
+    { "group", "html",  pe__group_html },
     { "group", "text",  pe__group_text },
     { "primitive", "xml",  pe__resource_xml },
+    { "primitive", "html",  pe__resource_html },
     { "primitive", "text",  pe__resource_text },
 
     { NULL, NULL, NULL }


### PR DESCRIPTION
This PR complements the PRs #1821 and #1788. It adds other 4 functions-messages
 to print information about resources in HTML by splitting/refactoring

    native_print --> pe__resource_html
    group_print --> pe__group_html
    clone_print --> pe__clone_html
    pe__print_bundle --> pe__bundle_html

Like the *_xml functions, the *_html functions don't have the pre_text
parameter. A single space used instead. (It's fair for html).
Like the PR #1821, it adds the supplementary functions:

    print_bundle_replica --> pe__bundle_replica_output_html
    common_print --> pe__common_output_html
    print_rscs_brief --> pe__rscs_brief_output_html
    short_print --> pe__short_output_html
    native_print_attr --> pe__native_output_attr_html