### PR TITLE
Make sense of our various XML functions in formatted output

### DIFF
--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -540,6 +540,29 @@ pcmk__output_xml_add_node(pcmk__output_t *out, xmlNodePtr node);
 
 /*!
  * \internal
+ * \brief Create and return a new XML node with the given name, as a child of the
+ *        current list parent.  This is used when implementing custom functions.
+ *
+ * \param[in,out] out  The output functions structure.
+ * \param[in]     name The name of the node to be created.
+ */
+xmlNodePtr
+pcmk__output_create_xml_node(pcmk__output_t *out, const char *name);
+
+/*!
+ * \internal
+ * \brief Like pcmk__output_create_xml_node(), but add the given text content to the
+ *        new node.
+ *
+ * \param[in,out] out     The output functions structure.
+ * \param[in]     name    The name of the node to be created.
+ * \param[in]     content The text content of the node.
+ */
+xmlNodePtr
+pcmk__output_create_xml_text_node(pcmk__output_t *out, const char *name, const char *content);
+
+/*!
+ * \internal
  * \brief Push a parent XML node onto the stack.  This is used when implementing
  *        custom message functions.
  *

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -604,8 +604,8 @@ pcmk__output_xml_peek_parent(pcmk__output_t *out);
  * \param[in]     text         The text content of the node.
  */
 xmlNodePtr
-pcmk__html_add_node(pcmk__output_t *out, const char *element_name, const char *id,
-                    const char *class_name, const char *text);
+pcmk__output_create_html_node(pcmk__output_t *out, const char *element_name, const char *id,
+                              const char *class_name, const char *text);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -517,16 +517,15 @@ pcmk__indented_printf(pcmk__output_t *out, const char *format, ...) G_GNUC_PRINT
 /*!
  * \internal
  * \brief Create and return a new XML node with the given name, as a child of the
- *        current list parent.  This is used when implementing custom message
- *        functions.
- *
- * \note This function is similar to create_xml_node.
+ *        current list parent.  The new node is then added as the new list parent,
+ *        meaning all subsequent nodes will be its children.  This is used when
+ *        implementing custom functions.
  *
  * \param[in,out] out  The output functions structure.
  * \param[in]     name The name of the node to be created.
  */
 xmlNodePtr
-pcmk__output_xml_node(pcmk__output_t *out, const char *name);
+pcmk__output_xml_create_parent(pcmk__output_t *out, const char *name);
 
 /*!
  * \internal

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -537,7 +537,7 @@ pcmk__output_xml_node(pcmk__output_t *out, const char *name);
  * \param[in]     node An XML node to be added as a child.
  */
 void
-pcmk__xml_add_node(pcmk__output_t *out, xmlNodePtr node);
+pcmk__output_xml_add_node(pcmk__output_t *out, xmlNodePtr node);
 
 /*!
  * \internal
@@ -554,7 +554,7 @@ pcmk__xml_add_node(pcmk__output_t *out, xmlNodePtr node);
  * \param[in]     node The node to be added/
  */
 void
-pcmk__xml_push_parent(pcmk__output_t *out, xmlNodePtr node);
+pcmk__output_xml_push_parent(pcmk__output_t *out, xmlNodePtr node);
 
 /*!
  * \internal
@@ -571,7 +571,7 @@ pcmk__xml_push_parent(pcmk__output_t *out, xmlNodePtr node);
  * \param[in,out] out The output functions structure.
  */
 void
-pcmk__xml_pop_parent(pcmk__output_t *out);
+pcmk__output_xml_pop_parent(pcmk__output_t *out);
 
 /*!
  * \internal
@@ -588,7 +588,7 @@ pcmk__xml_pop_parent(pcmk__output_t *out);
  * \return NULL if stack is empty, otherwise the parent of the stack.
  */
 xmlNodePtr
-pcmk__xml_peek_parent(pcmk__output_t *out);
+pcmk__output_xml_peek_parent(pcmk__output_t *out);
 
 /*!
  * \internal

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -88,6 +88,15 @@ xmlNode *create_xml_node(xmlNode * parent, const char *name);
 xmlNode *pcmk_create_xml_text_node(xmlNode * parent, const char *name, const char *content);
 
 /*
+ * Create a new HTML node named "element_name" as a child of "parent", giving it the
+ * provided text content.  Optionally, apply a CSS #id and #class.
+ *
+ * Returns the created node.
+ */
+xmlNode *pcmk_create_html_node(xmlNode * parent, const char *element_name, const char *id,
+                               const char *class_name, const char *text);
+
+/*
  *
  */
 void purge_diff_markers(xmlNode * a_node);

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -338,6 +338,6 @@ pcmk__html_add_node(pcmk__output_t *out, const char *element_name, const char *i
         xmlSetProp(node, (pcmkXmlStr) "id", (pcmkXmlStr) id);
     }
 
-    pcmk__xml_add_node(out, node);
+    pcmk__output_xml_add_node(out, node);
     return node;
 }

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -94,7 +94,7 @@ html_init(pcmk__output_t *out) {
     g_queue_push_tail(priv->parent_q, priv->root);
     priv->errors = NULL;
 
-    pcmk__output_xml_node(out, "body");
+    pcmk__output_xml_create_parent(out, "body");
 
     return true;
 }
@@ -263,7 +263,7 @@ html_begin_list(pcmk__output_t *out, const char *name,
         pcmk_create_xml_text_node(g_queue_peek_tail(priv->parent_q), "h2", name);
     }
 
-    pcmk__output_xml_node(out, "ul");
+    pcmk__output_xml_create_parent(out, "ul");
 }
 
 static void

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -190,7 +190,7 @@ html_subprocess_output(pcmk__output_t *out, int exit_status,
 
     rc_buf = crm_strdup_printf("Return code: %d", exit_status);
 
-    pcmk_create_xml_text_node(g_queue_peek_tail(priv->parent_q), "h2", "Command Output");
+    pcmk__output_create_xml_text_node(out, "h2", "Command Output");
     pcmk__output_create_html_node(out, "div", NULL, NULL, rc_buf);
 
     if (proc_stdout != NULL) {
@@ -210,7 +210,7 @@ html_version(pcmk__output_t *out, bool extended) {
     private_data_t *priv = out->priv;
     CRM_ASSERT(priv != NULL);
 
-    pcmk_create_xml_text_node(g_queue_peek_tail(priv->parent_q), "h2", "Version Information");
+    pcmk__output_create_xml_text_node(out, "h2", "Version Information");
     pcmk__output_create_html_node(out, "div", NULL, NULL, "Program: Pacemaker");
     pcmk__output_create_html_node(out, "div", NULL, NULL, crm_strdup_printf("Version: %s", PACEMAKER_VERSION));
     pcmk__output_create_html_node(out, "div", NULL, NULL, "Author: Andrew Beekhof");
@@ -260,7 +260,7 @@ html_begin_list(pcmk__output_t *out, const char *name,
     CRM_ASSERT(priv != NULL);
 
     if (name != NULL) {
-        pcmk_create_xml_text_node(g_queue_peek_tail(priv->parent_q), "h2", name);
+        pcmk__output_create_xml_text_node(out, "h2", name);
     }
 
     pcmk__output_xml_create_parent(out, "ul");
@@ -273,7 +273,7 @@ html_list_item(pcmk__output_t *out, const char *name, const char *content) {
 
     CRM_ASSERT(priv != NULL);
 
-    item_node = pcmk_create_xml_text_node(g_queue_peek_tail(priv->parent_q), "li", content);
+    item_node = pcmk__output_create_xml_text_node(out, "li", content);
 
     if (name != NULL) {
         xmlSetProp(item_node, (pcmkXmlStr) "class", (pcmkXmlStr) name);
@@ -325,9 +325,7 @@ pcmk__mk_html_output(char **argv) {
 xmlNodePtr
 pcmk__output_create_html_node(pcmk__output_t *out, const char *element_name, const char *id,
                        const char *class_name, const char *text) {
-    htmlNodePtr node = xmlNewNode(NULL, (pcmkXmlStr) element_name);
-
-    xmlNodeSetContent(node, (pcmkXmlStr) text);
+    htmlNodePtr node = pcmk__output_create_xml_text_node(out, element_name, text);
 
     if (class_name != NULL) {
         xmlSetProp(node, (pcmkXmlStr) "class", (pcmkXmlStr) class_name);
@@ -337,6 +335,5 @@ pcmk__output_create_html_node(pcmk__output_t *out, const char *element_name, con
         xmlSetProp(node, (pcmkXmlStr) "id", (pcmkXmlStr) id);
     }
 
-    pcmk__output_xml_add_node(out, node);
     return node;
 }

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -191,16 +191,15 @@ html_subprocess_output(pcmk__output_t *out, int exit_status,
     rc_buf = crm_strdup_printf("Return code: %d", exit_status);
 
     pcmk_create_xml_text_node(g_queue_peek_tail(priv->parent_q), "h2", "Command Output");
-
-    pcmk__html_add_node(out, "div", NULL, NULL, rc_buf);
+    pcmk__output_create_html_node(out, "div", NULL, NULL, rc_buf);
 
     if (proc_stdout != NULL) {
-        pcmk__html_add_node(out, "div", NULL, NULL, "Stdout");
-        pcmk__html_add_node(out, "div", NULL, "output", proc_stdout);
+        pcmk__output_create_html_node(out, "div", NULL, NULL, "Stdout");
+        pcmk__output_create_html_node(out, "div", NULL, "output", proc_stdout);
     }
     if (proc_stderr != NULL) {
-        pcmk__html_add_node(out, "div", NULL, NULL, "Stderr");
-        pcmk__html_add_node(out, "div", NULL, "output", proc_stderr);
+        pcmk__output_create_html_node(out, "div", NULL, NULL, "Stderr");
+        pcmk__output_create_html_node(out, "div", NULL, "output", proc_stderr);
     }
 
     free(rc_buf);
@@ -212,11 +211,11 @@ html_version(pcmk__output_t *out, bool extended) {
     CRM_ASSERT(priv != NULL);
 
     pcmk_create_xml_text_node(g_queue_peek_tail(priv->parent_q), "h2", "Version Information");
-    pcmk__html_add_node(out, "div", NULL, NULL, "Program: Pacemaker");
-    pcmk__html_add_node(out, "div", NULL, NULL, crm_strdup_printf("Version: %s", PACEMAKER_VERSION));
-    pcmk__html_add_node(out, "div", NULL, NULL, "Author: Andrew Beekhof");
-    pcmk__html_add_node(out, "div", NULL, NULL, crm_strdup_printf("Build: %s", BUILD_VERSION));
-    pcmk__html_add_node(out, "div", NULL, NULL, crm_strdup_printf("Features: %s", CRM_FEATURES));
+    pcmk__output_create_html_node(out, "div", NULL, NULL, "Program: Pacemaker");
+    pcmk__output_create_html_node(out, "div", NULL, NULL, crm_strdup_printf("Version: %s", PACEMAKER_VERSION));
+    pcmk__output_create_html_node(out, "div", NULL, NULL, "Author: Andrew Beekhof");
+    pcmk__output_create_html_node(out, "div", NULL, NULL, crm_strdup_printf("Build: %s", BUILD_VERSION));
+    pcmk__output_create_html_node(out, "div", NULL, NULL, crm_strdup_printf("Features: %s", CRM_FEATURES));
 }
 
 G_GNUC_PRINTF(2, 3)
@@ -249,7 +248,7 @@ html_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
 
     CRM_ASSERT(priv != NULL);
 
-    node = pcmk__html_add_node(out, "pre", NULL, NULL, buf);
+    node = pcmk__output_create_html_node(out, "pre", NULL, NULL, buf);
     xmlSetProp(node, (pcmkXmlStr) "lang", (pcmkXmlStr) "xml");
 }
 
@@ -324,8 +323,8 @@ pcmk__mk_html_output(char **argv) {
 }
 
 xmlNodePtr
-pcmk__html_add_node(pcmk__output_t *out, const char *element_name, const char *id,
-                    const char *class_name, const char *text) {
+pcmk__output_create_html_node(pcmk__output_t *out, const char *element_name, const char *id,
+                       const char *class_name, const char *text) {
     htmlNodePtr node = xmlNewNode(NULL, (pcmkXmlStr) element_name);
 
     xmlNodeSetContent(node, (pcmkXmlStr) text);

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -149,7 +149,7 @@ xml_subprocess_output(pcmk__output_t *out, int exit_status,
         xmlSetProp(child_node, (pcmkXmlStr) "source", (pcmkXmlStr) "stderr");
     }
 
-    pcmk__xml_add_node(out, node);
+    pcmk__output_xml_add_node(out, node);
     free(rc_as_str);
 }
 
@@ -279,12 +279,12 @@ pcmk__output_xml_node(pcmk__output_t *out, const char *name) {
     CRM_ASSERT(priv != NULL);
 
     node = create_xml_node(g_queue_peek_tail(priv->parent_q), name);
-    pcmk__xml_push_parent(out, node);
+    pcmk__output_xml_push_parent(out, node);
     return node;
 }
 
 void
-pcmk__xml_add_node(pcmk__output_t *out, xmlNodePtr node) {
+pcmk__output_xml_add_node(pcmk__output_t *out, xmlNodePtr node) {
     private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
@@ -294,7 +294,7 @@ pcmk__xml_add_node(pcmk__output_t *out, xmlNodePtr node) {
 }
 
 void
-pcmk__xml_push_parent(pcmk__output_t *out, xmlNodePtr parent) {
+pcmk__output_xml_push_parent(pcmk__output_t *out, xmlNodePtr parent) {
     private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
@@ -304,7 +304,7 @@ pcmk__xml_push_parent(pcmk__output_t *out, xmlNodePtr parent) {
 }
 
 void
-pcmk__xml_pop_parent(pcmk__output_t *out) {
+pcmk__output_xml_pop_parent(pcmk__output_t *out) {
     private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);
@@ -314,7 +314,7 @@ pcmk__xml_pop_parent(pcmk__output_t *out) {
 }
 
 xmlNodePtr
-pcmk__xml_peek_parent(pcmk__output_t *out) {
+pcmk__output_xml_peek_parent(pcmk__output_t *out) {
     private_data_t *priv = out->priv;
 
     CRM_ASSERT(priv != NULL);

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -136,7 +136,7 @@ xml_subprocess_output(pcmk__output_t *out, int exit_status,
 
     rc_as_str = crm_itoa(exit_status);
 
-    node = pcmk__output_xml_node(out, "command");
+    node = pcmk__output_xml_create_parent(out, "command");
     xmlSetProp(node, (pcmkXmlStr) "code", (pcmkXmlStr) rc_as_str);
 
     if (proc_stdout != NULL) {
@@ -209,7 +209,7 @@ xml_begin_list(pcmk__output_t *out, const char *name,
                const char *singular_noun, const char *plural_noun) {
     xmlNodePtr list_node = NULL;
 
-    list_node = pcmk__output_xml_node(out, "list");
+    list_node = pcmk__output_xml_create_parent(out, "list");
     xmlSetProp(list_node, (pcmkXmlStr) "name", (pcmkXmlStr) name);
 }
 
@@ -272,7 +272,7 @@ pcmk__mk_xml_output(char **argv) {
 }
 
 xmlNodePtr
-pcmk__output_xml_node(pcmk__output_t *out, const char *name) {
+pcmk__output_xml_create_parent(pcmk__output_t *out, const char *name) {
     private_data_t *priv = out->priv;
     xmlNodePtr node = NULL;
 

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -273,12 +273,7 @@ pcmk__mk_xml_output(char **argv) {
 
 xmlNodePtr
 pcmk__output_xml_create_parent(pcmk__output_t *out, const char *name) {
-    private_data_t *priv = out->priv;
-    xmlNodePtr node = NULL;
-
-    CRM_ASSERT(priv != NULL);
-
-    node = create_xml_node(g_queue_peek_tail(priv->parent_q), name);
+    xmlNodePtr node = pcmk__output_create_xml_node(out, name);
     pcmk__output_xml_push_parent(out, node);
     return node;
 }
@@ -291,6 +286,22 @@ pcmk__output_xml_add_node(pcmk__output_t *out, xmlNodePtr node) {
     CRM_ASSERT(node != NULL);
 
     xmlAddChild(g_queue_peek_tail(priv->parent_q), node);
+}
+
+xmlNodePtr
+pcmk__output_create_xml_node(pcmk__output_t *out, const char *name) {
+    private_data_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    return create_xml_node(g_queue_peek_tail(priv->parent_q), name);
+}
+
+xmlNodePtr
+pcmk__output_create_xml_text_node(pcmk__output_t *out, const char *name, const char *content) {
+    xmlNodePtr node = pcmk__output_create_xml_node(out, name);
+    xmlNodeSetContent(node, (pcmkXmlStr) content);
+    return node;
 }
 
 void

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -159,8 +159,7 @@ xml_version(pcmk__output_t *out, bool extended) {
     private_data_t *priv = out->priv;
     CRM_ASSERT(priv != NULL);
 
-    node = create_xml_node(g_queue_peek_tail(priv->parent_q), "version");
-
+    node = pcmk__output_create_xml_node(out, "version");
     xmlSetProp(node, (pcmkXmlStr) "program", (pcmkXmlStr) "Pacemaker");
     xmlSetProp(node, (pcmkXmlStr) "version", (pcmkXmlStr) PACEMAKER_VERSION);
     xmlSetProp(node, (pcmkXmlStr) "author", (pcmkXmlStr) "Andrew Beekhof");
@@ -199,7 +198,7 @@ xml_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
 
     CRM_ASSERT(priv != NULL);
 
-    parent = create_xml_node(g_queue_peek_tail(priv->parent_q), name);
+    parent = pcmk__output_create_xml_node(out, name);
     cdata_node = xmlNewCDataBlock(getDocPtr(parent), (pcmkXmlStr) buf, strlen(buf));
     xmlAddChild(parent, cdata_node);
 }
@@ -220,7 +219,7 @@ xml_list_item(pcmk__output_t *out, const char *name, const char *content) {
 
     CRM_ASSERT(priv != NULL);
 
-    item_node = pcmk_create_xml_text_node(g_queue_peek_tail(priv->parent_q), "item", content);
+    item_node = pcmk__output_create_xml_text_node(out, "item", content);
     xmlSetProp(item_node, (pcmkXmlStr) "name", (pcmkXmlStr) name);
 }
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1994,6 +1994,23 @@ pcmk_create_xml_text_node(xmlNode * parent, const char *name, const char *conten
     return node;
 }
 
+xmlNode *
+pcmk_create_html_node(xmlNode * parent, const char *element_name, const char *id,
+                      const char *class_name, const char *text)
+{
+    xmlNode *node = pcmk_create_xml_text_node(parent, element_name, text);
+
+    if (class_name != NULL) {
+        xmlSetProp(node, (pcmkXmlStr) "class", (pcmkXmlStr) class_name);
+    }
+
+    if (id != NULL) {
+        xmlSetProp(node, (pcmkXmlStr) "id", (pcmkXmlStr) id);
+    }
+
+    return node;
+}
+
 int
 pcmk__element_xpath(const char *prefix, xmlNode *xml, char *buffer,
                     int offset, size_t buffer_size)

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -37,7 +37,7 @@ last_fenced_xml(pcmk__output_t *out, va_list args) {
 
     if (when) {
         crm_time_t *crm_when = crm_time_new(NULL);
-        xmlNodePtr node = pcmk__output_xml_node(out, "last-fenced");
+        xmlNodePtr node = pcmk__output_xml_create_parent(out, "last-fenced");
         char *buf = NULL;
 
         crm_time_set_timet(crm_when, &when);
@@ -88,7 +88,7 @@ stonith_event_text(pcmk__output_t *out, va_list args) {
 
 static int
 stonith_event_xml(pcmk__output_t *out, va_list args) {
-    xmlNodePtr node = pcmk__output_xml_node(out, "fence_event");
+    xmlNodePtr node = pcmk__output_xml_create_parent(out, "fence_event");
     stonith_history_t *event = va_arg(args, stonith_history_t *);
     crm_time_t *crm_when = crm_time_new(NULL);
     char *buf = NULL;
@@ -160,7 +160,7 @@ validate_agent_text(pcmk__output_t *out, va_list args) {
 
 static int
 validate_agent_xml(pcmk__output_t *out, va_list args) {
-    xmlNodePtr node = pcmk__output_xml_node(out, "validate");
+    xmlNodePtr node = pcmk__output_xml_create_parent(out, "validate");
 
     const char *agent = va_arg(args, const char *);
     const char *device = va_arg(args, const char *);

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -37,7 +37,7 @@ last_fenced_xml(pcmk__output_t *out, va_list args) {
 
     if (when) {
         crm_time_t *crm_when = crm_time_new(NULL);
-        xmlNodePtr node = pcmk__output_xml_create_parent(out, "last-fenced");
+        xmlNodePtr node = pcmk__output_create_xml_node(out, "last-fenced");
         char *buf = NULL;
 
         crm_time_set_timet(crm_when, &when);
@@ -88,7 +88,7 @@ stonith_event_text(pcmk__output_t *out, va_list args) {
 
 static int
 stonith_event_xml(pcmk__output_t *out, va_list args) {
-    xmlNodePtr node = pcmk__output_xml_create_parent(out, "fence_event");
+    xmlNodePtr node = pcmk__output_create_xml_node(out, "fence_event");
     stonith_history_t *event = va_arg(args, stonith_history_t *);
     crm_time_t *crm_when = crm_time_new(NULL);
     char *buf = NULL;
@@ -160,7 +160,7 @@ validate_agent_text(pcmk__output_t *out, va_list args) {
 
 static int
 validate_agent_xml(pcmk__output_t *out, va_list args) {
-    xmlNodePtr node = pcmk__output_xml_create_parent(out, "validate");
+    xmlNodePtr node = pcmk__output_create_xml_node(out, "validate");
 
     const char *agent = va_arg(args, const char *);
     const char *device = va_arg(args, const char *);

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -174,9 +174,9 @@ validate_agent_xml(pcmk__output_t *out, va_list args) {
     }
     xmlSetProp(node, (pcmkXmlStr) "valid", (pcmkXmlStr) (rc ? "false" : "true"));
 
-    pcmk__xml_push_parent(out, node);
+    pcmk__output_xml_push_parent(out, node);
     out->subprocess_output(out, rc, output, error_output);
-    pcmk__xml_pop_parent(out);
+    pcmk__output_xml_pop_parent(out);
 
     return rc;
 }

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1594,7 +1594,7 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
 
         CRM_ASSERT(replica);
 
-        pcmk__output_xml_node(out, "li");
+        pcmk__output_xml_create_parent(out, "li");
         if (is_set(options, pe_print_implicit)) {
             if(g_list_length(bundle_data->replicas) > 1) {
                 snprintf(buffer, LINE_MAX, " Replica[%d]", replica->offset);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1531,9 +1531,9 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
         out->message(out, crm_element_name(replica->container->xml), options, replica->container);
         out->message(out, crm_element_name(replica->remote->xml), options, replica->remote);
 
-        pcmk__xml_pop_parent(out); // replica
+        pcmk__output_xml_pop_parent(out); // replica
     }
-    pcmk__xml_pop_parent(out); // bundle
+    pcmk__output_xml_pop_parent(out); // bundle
     return rc;
 }
 
@@ -1598,9 +1598,9 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
         if (is_set(options, pe_print_implicit)) {
             if(g_list_length(bundle_data->replicas) > 1) {
                 snprintf(buffer, LINE_MAX, " Replica[%d]", replica->offset);
-                xmlNodeSetContent(pcmk__xml_peek_parent(out), (pcmkXmlStr) buffer);
+                xmlNodeSetContent(pcmk__output_xml_peek_parent(out), (pcmkXmlStr) buffer);
             }
-            xmlNewChild(pcmk__xml_peek_parent(out), NULL, (pcmkXmlStr) "br", NULL);
+            xmlNewChild(pcmk__output_xml_peek_parent(out), NULL, (pcmkXmlStr) "br", NULL);
             out->begin_list(out, NULL, NULL, NULL);
 
             out->message(out, crm_element_name(replica->ip->xml), options, replica->ip);
@@ -1613,7 +1613,7 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
             pe__bundle_replica_output_html(out, replica, options);
         }
 
-        pcmk__xml_pop_parent(out);
+        pcmk__output_xml_pop_parent(out);
     }
 
     out->end_list(out);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1585,7 +1585,7 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
                  is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
                  is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
 
-    xmlNewChild(pcmk__xml_peek_parent(out), NULL, (pcmkXmlStr) "br", NULL);
+    pcmk__output_create_xml_node(out, "br");
     out->begin_list(out, buffer, NULL, NULL);
 
     for (GList *gIter = bundle_data->replicas; gIter != NULL;
@@ -1600,7 +1600,7 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
                 snprintf(buffer, LINE_MAX, " Replica[%d]", replica->offset);
                 xmlNodeSetContent(pcmk__output_xml_peek_parent(out), (pcmkXmlStr) buffer);
             }
-            xmlNewChild(pcmk__output_xml_peek_parent(out), NULL, (pcmkXmlStr) "br", NULL);
+            pcmk__output_create_xml_node(out, "br");
             out->begin_list(out, NULL, NULL, NULL);
 
             out->message(out, crm_element_name(replica->ip->xml), options, replica->ip);

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -721,7 +721,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
         }
 
         if (print_full) {
-            pcmk__output_xml_node(out, "li");
+            pcmk__output_xml_create_parent(out, "li");
             out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
             pcmk__output_xml_pop_parent(out);
         }

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -622,7 +622,7 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
         out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
     }
 
-    pcmk__xml_pop_parent(out);
+    pcmk__output_xml_pop_parent(out);
     return rc;
 }
 
@@ -723,7 +723,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
         if (print_full) {
             pcmk__output_xml_node(out, "li");
             out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
-            pcmk__xml_pop_parent(out);
+            pcmk__output_xml_pop_parent(out);
         }
     }
 

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -548,7 +548,7 @@ pe__common_output_html(pcmk__output_t *out, resource_t * rsc,
         node = NULL;
     }
 
-    pcmk__output_xml_node(out, "font");
+    pcmk__output_xml_create_parent(out, "font");
 
     if (is_not_set(rsc->flags, pe_rsc_managed)) {
         color = "yellow";

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -671,7 +671,7 @@ pe__common_output_html(pcmk__output_t *out, resource_t * rsc,
         out->end_list(out);
     }
 
-    xmlNewChild(pcmk__xml_peek_parent(out), NULL, (pcmkXmlStr) "br", NULL);
+    pcmk__output_create_xml_node(out, "br");
 
     if (options & pe_print_details) {
         g_hash_table_foreach(rsc->parameters, pe__native_output_attr_html, out);

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -351,7 +351,7 @@ pe__native_output_attr_html(gpointer key, gpointer value, gpointer user_data)
     char content[LINE_MAX];
 
     snprintf(content, LINE_MAX, "Option: %s = %s<br/>", (char *)key, (char *)value);
-    xmlNodeAddContent(pcmk__xml_peek_parent(out), (pcmkXmlStr)content);
+    xmlNodeAddContent(pcmk__output_xml_peek_parent(out), (pcmkXmlStr)content);
 }
 
 static void
@@ -568,7 +568,7 @@ pe__common_output_html(pcmk__output_t *out, resource_t * rsc,
     } else {
         color = "green";
     }
-    xmlSetProp(pcmk__xml_peek_parent(out), (pcmkXmlStr)"color", (pcmkXmlStr)color);
+    xmlSetProp(pcmk__output_xml_peek_parent(out), (pcmkXmlStr)"color", (pcmkXmlStr)color);
 
     offset += snprintf(buffer + offset, LINE_MAX - offset, "%s", name);
     offset += snprintf(buffer + offset, LINE_MAX - offset, "\t(%s", class);
@@ -653,8 +653,8 @@ pe__common_output_html(pcmk__output_t *out, resource_t * rsc,
         snprintf(buffer2, LINE_MAX*3, "%s%s%s", buffer, desc?" ":"", desc?desc:"");
     }
 
-    xmlNodeSetContent(pcmk__xml_peek_parent(out), (pcmkXmlStr)buffer2);
-    pcmk__xml_pop_parent(out); // </font>
+    xmlNodeSetContent(pcmk__output_xml_peek_parent(out), (pcmkXmlStr)buffer2);
+    pcmk__output_xml_pop_parent(out); // </font>
 
     if ((options & pe_print_rsconly)) {
         /* nothing */
@@ -685,12 +685,12 @@ pe__common_output_html(pcmk__output_t *out, resource_t * rsc,
                      is_set(rsc->flags, pe_rsc_provisional) ? "provisional, " : "",
                      is_set(rsc->flags, pe_rsc_runnable) ? "" : "non-startable, ",
                      crm_element_name(rsc->xml), (double)rsc->priority);
-        xmlNodeAddContent(pcmk__xml_peek_parent(out), (pcmkXmlStr)buffer);
-        xmlNodeAddContent(pcmk__xml_peek_parent(out), (pcmkXmlStr)" \tAllowed Nodes");
+        xmlNodeAddContent(pcmk__output_xml_peek_parent(out), (pcmkXmlStr)buffer);
+        xmlNodeAddContent(pcmk__output_xml_peek_parent(out), (pcmkXmlStr)" \tAllowed Nodes");
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
         while (g_hash_table_iter_next(&iter, NULL, (void **)&n)) {
             snprintf(buffer, LINE_MAX, " \t * %s %d", n->details->uname, n->weight);
-            xmlNodeAddContent(pcmk__xml_peek_parent(out), (pcmkXmlStr)buffer);
+            xmlNodeAddContent(pcmk__output_xml_peek_parent(out), (pcmkXmlStr)buffer);
         }
     }
 
@@ -698,7 +698,7 @@ pe__common_output_html(pcmk__output_t *out, resource_t * rsc,
         GHashTableIter iter;
         node_t *n = NULL;
 
-        xmlNodeAddContent(pcmk__xml_peek_parent(out), (pcmkXmlStr)" \t=== Allowed Nodes\n");
+        xmlNodeAddContent(pcmk__output_xml_peek_parent(out), (pcmkXmlStr)" \t=== Allowed Nodes\n");
 
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
         while (g_hash_table_iter_next(&iter, NULL, (void **)&n)) {
@@ -1210,7 +1210,7 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
         }
     }
 
-    pcmk__xml_pop_parent(out);
+    pcmk__output_xml_pop_parent(out);
     return rc;
 }
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -19,7 +19,7 @@ pe__name_and_nvpairs_xml(pcmk__output_t *out, bool is_list, const char *tag_name
 
     CRM_ASSERT(tag_name != NULL);
 
-    xml_node = pcmk__xml_peek_parent(out);
+    xml_node = pcmk__output_xml_peek_parent(out);
     CRM_ASSERT(xml_node != NULL);
     xml_node = is_list
         ? create_xml_node(xml_node, tag_name)
@@ -36,7 +36,7 @@ pe__name_and_nvpairs_xml(pcmk__output_t *out, bool is_list, const char *tag_name
     va_end(args);
 
     if (is_list) {
-        pcmk__xml_push_parent(out, xml_node);
+        pcmk__output_xml_push_parent(out, xml_node);
     }
     return 0;
 }
@@ -62,7 +62,7 @@ pe__group_xml(pcmk__output_t *out, va_list args)
         out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
     }
 
-    pcmk__xml_pop_parent(out);
+    pcmk__output_xml_pop_parent(out);
     return rc;
 }
 
@@ -86,7 +86,7 @@ pe__group_html(pcmk__output_t *out, va_list args)
 
             pcmk__output_xml_node(out, "li");
             out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
-            pcmk__xml_pop_parent(out);
+            pcmk__output_xml_pop_parent(out);
         }
     }
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -84,7 +84,7 @@ pe__group_html(pcmk__output_t *out, va_list args)
         for (GListPtr gIter = rsc->children; gIter; gIter = gIter->next) {
             resource_t *child_rsc = (resource_t *) gIter->data;
 
-            pcmk__output_xml_node(out, "li");
+            pcmk__output_create_xml_node(out, "li");
             out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
             pcmk__output_xml_pop_parent(out);
         }


### PR DESCRIPTION
This PR renames a bunch of functions to a consistent naming scheme, adds a couple useful functions, and in general just tries to straighten out the mess that is the XML node creating functions in formatted output.  I kind of hate how long the function names are, but it seems necessary for explaining which function does what.

I additionally have started a cheat sheet locally for when you should use which function.  It could be added somewhere, but I couldn't find a great place for it.