### PR TITLE
Clean up ocf:pacemaker resource agents

### DIFF
--- a/extra/resources/ClusterMon.in
+++ b/extra/resources/ClusterMon.in
@@ -137,14 +137,24 @@ ClusterMon_stop() {
 }
 
 ClusterMon_monitor() {
+    local USERARG=""
+    local header
+    local pid
+
     if [ -f "$OCF_RESKEY_pidfile" ]; then
         pid=$(cat "$OCF_RESKEY_pidfile")
         if [ -n "$pid" ]; then
-            str=$(echo "su - \"$OCF_RESKEY_user\" -c \"$CMON_CMD\"" | tr 'crmon, \t' 'xxxxxxxx')
-            ps -o "args=${str}" -p $pid 2>/dev/null | \
+            if [ -n "$OCF_RESKEY_user" ]; then
+                USERARG="-u $OCF_RESKEY_user"
+            fi
+
+            # Use column header wide as command, to ensure it's shown in full
+            header=$(echo $CMON_CMD | tr 'crmon, \t' 'xxxxxxxx')
+
+            ps $USERARG -o "args=${header}" -p $pid 2>/dev/null | \
                 grep -qE "[c]rm_mon.*${OCF_RESKEY_pidfile}"
-            rc=$?
-            case $rc in
+
+            case $? in
                 0) exit $OCF_SUCCESS;;
                 1) exit $OCF_NOT_RUNNING;;
                 *) exit $OCF_ERR_GENERIC;;

--- a/extra/resources/ClusterMon.in
+++ b/extra/resources/ClusterMon.in
@@ -127,7 +127,7 @@ ClusterMon_start() {
 
 ClusterMon_stop() {
     if [ -f "$OCF_RESKEY_pidfile" ]; then
-        pid=`cat "$OCF_RESKEY_pidfile"`
+        pid=$(cat "$OCF_RESKEY_pidfile")
         if [ ! -z "$pid" ]; then
             kill -s 9 $pid
             rm -f "$OCF_RESKEY_pidfile"
@@ -138,7 +138,7 @@ ClusterMon_stop() {
 
 ClusterMon_monitor() {
     if [ -f "$OCF_RESKEY_pidfile" ]; then
-        pid=`cat "$OCF_RESKEY_pidfile"`
+        pid=$(cat "$OCF_RESKEY_pidfile")
         if [ ! -z "$pid" ]; then
             str=$(echo "su - \"$OCF_RESKEY_user\" -c \"$CMON_CMD\"" | tr 'crmon, \t' 'xxxxxxxx')
             ps -o "args=${str}" -p $pid 2>/dev/null | \

--- a/extra/resources/ClusterMon.in
+++ b/extra/resources/ClusterMon.in
@@ -258,3 +258,5 @@ usage|help)     ClusterMon_usage
 esac
 
 exit $?
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/ClusterMon.in
+++ b/extra/resources/ClusterMon.in
@@ -23,9 +23,9 @@
 
 #######################################################################
 # Initialization:
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 #######################################################################
 
@@ -117,30 +117,30 @@ ClusterMon_exit() {
 }
 
 ClusterMon_start() {
-    if [ ! -z $OCF_RESKEY_user ]; then
-        su - $OCF_RESKEY_user -c "$CMON_CMD"
+    if [ ! -z "$OCF_RESKEY_user" ]; then
+        su - "$OCF_RESKEY_user" -c "$CMON_CMD"
     else
-        $CMON_CMD
+        eval $CMON_CMD
     fi
     ClusterMon_exit $?
 }
 
 ClusterMon_stop() {
-    if [ -f $OCF_RESKEY_pidfile ]; then
-        pid=`cat $OCF_RESKEY_pidfile`
-        if [ ! -z $pid ]; then
+    if [ -f "$OCF_RESKEY_pidfile" ]; then
+        pid=`cat "$OCF_RESKEY_pidfile"`
+        if [ ! -z "$pid" ]; then
             kill -s 9 $pid
-            rm -f $OCF_RESKEY_pidfile
+            rm -f "$OCF_RESKEY_pidfile"
         fi
     fi
     ClusterMon_exit 0
 }
 
 ClusterMon_monitor() {
-    if [ -f $OCF_RESKEY_pidfile ]; then
-        pid=`cat $OCF_RESKEY_pidfile`
-        if [ ! -z $pid ]; then
-            str=$(echo "su - $OCF_RESKEY_user -c \"$CMON_CMD\"" | tr 'crmon, \t' 'xxxxxxxx')
+    if [ -f "$OCF_RESKEY_pidfile" ]; then
+        pid=`cat "$OCF_RESKEY_pidfile"`
+        if [ ! -z "$pid" ]; then
+            str=$(echo "su - \"$OCF_RESKEY_user\" -c \"$CMON_CMD\"" | tr 'crmon, \t' 'xxxxxxxx')
             ps -o "args=${str}" -p $pid 2>/dev/null | \
                 grep -qE "[c]rm_mon.*${OCF_RESKEY_pidfile}"
             rc=$?
@@ -157,7 +157,7 @@ ClusterMon_monitor() {
 CheckOptions() {
 while getopts Vi:nrh:cdp: OPTION
 do
-    case $OPTION in
+    case "$OPTION" in
     V|n|r|c|d);;
     i)  ocf_log warn "You should not have specified the -i option, since OCF_RESKEY_update is set already!";;
     h)  ocf_log warn "You should not have specified the -h option, since OCF_RESKEY_htmlfile is set already!";;
@@ -181,7 +181,7 @@ fi
 
 ClusterMon_validate() {
 # Existence of the user
-    if [ ! -z $OCF_RESKEY_user ]; then
+    if [ ! -z "$OCF_RESKEY_user" ]; then
         getent passwd "$OCF_RESKEY_user" >/dev/null
         if [ $? -eq 0 ]; then
             : Yes, user exists. We can further check his permission on crm_mon if necessary
@@ -192,7 +192,7 @@ ClusterMon_validate() {
     fi
 
 # Pidfile better be an absolute path
-    case $OCF_RESKEY_pidfile in
+    case "$OCF_RESKEY_pidfile" in
         /*) ;;
         *) ocf_log warn "You should have pidfile($OCF_RESKEY_pidfile) of absolute path!" ;;
     esac
@@ -213,7 +213,7 @@ ClusterMon_validate() {
     fi
 
 # Htmlfile better be an absolute path
-    case $OCF_RESKEY_htmlfile in
+    case "$OCF_RESKEY_htmlfile" in
         /*) ;;
         *) ocf_log warn "You should have htmlfile($OCF_RESKEY_htmlfile) of absolute path!" ;;
     esac
@@ -235,9 +235,9 @@ if [ ${OCF_RESKEY_update} -ge 1000 ]; then
     OCF_RESKEY_update=$(( $OCF_RESKEY_update / 1000 ))
 fi
 
-CMON_CMD="${HA_SBIN_DIR}/crm_mon -p $OCF_RESKEY_pidfile -d -i $OCF_RESKEY_update $OCF_RESKEY_extra_options -h $OCF_RESKEY_htmlfile"
+CMON_CMD="${HA_SBIN_DIR}/crm_mon -p \"$OCF_RESKEY_pidfile\" -d -i $OCF_RESKEY_update $OCF_RESKEY_extra_options -h \"$OCF_RESKEY_htmlfile\""
 
-case $__OCF_ACTION in
+case "$__OCF_ACTION" in
 meta-data)      meta_data
                 exit $OCF_SUCCESS
                 ;;

--- a/extra/resources/ClusterMon.in
+++ b/extra/resources/ClusterMon.in
@@ -3,7 +3,7 @@
 # ocf:pacemaker:ClusterMon resource agent
 #
 # Original copyright 2004 SUSE LINUX AG, Lars Marowsky-Br<E9>e
-# Later changes copyright 2008-2018 the Pacemaker project contributors
+# Later changes copyright 2008-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -11,15 +11,15 @@
 # (GPLv2) WITHOUT ANY WARRANTY.
 #
 
-#	Starts crm_mon in background which logs cluster status as
-#	html to the specified file.
+# Starts crm_mon in background which logs cluster status as
+# html to the specified file.
 #
 # OCF instance parameters:
-#	OCF_RESKEY_user
-#	OCF_RESKEY_pidfile
-#	OCF_RESKEY_update
-#	OCF_RESKEY_extra_options
-#	OCF_RESKEY_htmlfile
+#  OCF_RESKEY_user
+#  OCF_RESKEY_pidfile
+#  OCF_RESKEY_update
+#  OCF_RESKEY_extra_options
+#  OCF_RESKEY_htmlfile
 
 #######################################################################
 # Initialization:
@@ -30,7 +30,7 @@
 #######################################################################
 
 meta_data() {
-	cat <<END
+    cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
 <resource-agent name="ClusterMon" version="1.0">
@@ -101,7 +101,7 @@ END
 #######################################################################
 
 ClusterMon_usage() {
-	cat <<END
+    cat <<END
 usage: $0 {start|stop|monitor|validate-all|meta-data}
 
 Expects to have a fully populated OCF RA-compliant environment set.
@@ -109,47 +109,47 @@ END
 }
 
 ClusterMon_exit() {
-	if [ $1 != 0 ]; then
-		exit $OCF_ERR_GENERIC
-	else
-		exit $OCF_SUCCESS
-	fi
+    if [ $1 != 0 ]; then
+        exit $OCF_ERR_GENERIC
+    else
+        exit $OCF_SUCCESS
+    fi
 }
 
 ClusterMon_start() {
     if [ ! -z $OCF_RESKEY_user ]; then
-	su - $OCF_RESKEY_user -c "$CMON_CMD"
+        su - $OCF_RESKEY_user -c "$CMON_CMD"
     else
-	$CMON_CMD
+        $CMON_CMD
     fi
     ClusterMon_exit $?
 }
 
 ClusterMon_stop() {
     if [ -f $OCF_RESKEY_pidfile ]; then
-	pid=`cat $OCF_RESKEY_pidfile`
-	if [ ! -z $pid ]; then
-	    kill -s 9 $pid
-	    rm -f $OCF_RESKEY_pidfile
-	fi
+        pid=`cat $OCF_RESKEY_pidfile`
+        if [ ! -z $pid ]; then
+            kill -s 9 $pid
+            rm -f $OCF_RESKEY_pidfile
+        fi
     fi
     ClusterMon_exit 0
 }
 
 ClusterMon_monitor() {
     if [ -f $OCF_RESKEY_pidfile ]; then
-	pid=`cat $OCF_RESKEY_pidfile`
-	if [ ! -z $pid ]; then
-	    str=$(echo "su - $OCF_RESKEY_user -c \"$CMON_CMD\"" | tr 'crmon, \t' 'xxxxxxxx')
-	    ps -o "args=${str}" -p $pid 2>/dev/null | \
-		grep -qE "[c]rm_mon.*${OCF_RESKEY_pidfile}"
-	    rc=$?
-	    case $rc in
-		0) exit $OCF_SUCCESS;;
-		1) exit $OCF_NOT_RUNNING;;
-		*) exit $OCF_ERR_GENERIC;;
-	    esac
-	fi
+        pid=`cat $OCF_RESKEY_pidfile`
+        if [ ! -z $pid ]; then
+            str=$(echo "su - $OCF_RESKEY_user -c \"$CMON_CMD\"" | tr 'crmon, \t' 'xxxxxxxx')
+            ps -o "args=${str}" -p $pid 2>/dev/null | \
+                grep -qE "[c]rm_mon.*${OCF_RESKEY_pidfile}"
+            rc=$?
+            case $rc in
+                0) exit $OCF_SUCCESS;;
+                1) exit $OCF_NOT_RUNNING;;
+                *) exit $OCF_ERR_GENERIC;;
+            esac
+        fi
     fi
     exit $OCF_NOT_RUNNING
 }
@@ -159,12 +159,12 @@ while getopts Vi:nrh:cdp: OPTION
 do
     case $OPTION in
     V|n|r|c|d);;
-    i)	ocf_log warn "You should not have specified the -i option, since OCF_RESKEY_update is set already!";;
-    h)	ocf_log warn "You should not have specified the -h option, since OCF_RESKEY_htmlfile is set already!";;
-    p)	ocf_log warn "You should not have specified the -p option, since OCF_RESKEY_pidfile is set already!";;
+    i)  ocf_log warn "You should not have specified the -i option, since OCF_RESKEY_update is set already!";;
+    h)  ocf_log warn "You should not have specified the -h option, since OCF_RESKEY_htmlfile is set already!";;
+    p)  ocf_log warn "You should not have specified the -p option, since OCF_RESKEY_pidfile is set already!";;
     *)  return $OCF_ERR_ARGS;;
     esac
-done		
+done
 
 if [ $? -ne 0 ]; then
     return $OCF_ERR_ARGS
@@ -182,40 +182,40 @@ fi
 ClusterMon_validate() {
 # Existence of the user
     if [ ! -z $OCF_RESKEY_user ]; then
-	getent passwd "$OCF_RESKEY_user" >/dev/null
-	if [ $? -eq 0 ]; then
-	    : Yes, user exists. We can further check his permission on crm_mon if necessary
-	else
-	    ocf_log err "The user $OCF_RESKEY_user does not exist!"
-	    exit $OCF_ERR_ARGS
-	fi
+        getent passwd "$OCF_RESKEY_user" >/dev/null
+        if [ $? -eq 0 ]; then
+            : Yes, user exists. We can further check his permission on crm_mon if necessary
+        else
+            ocf_log err "The user $OCF_RESKEY_user does not exist!"
+            exit $OCF_ERR_ARGS
+        fi
     fi
 
 # Pidfile better be an absolute path
     case $OCF_RESKEY_pidfile in
-	/*) ;;
-	*) ocf_log warn "You should have pidfile($OCF_RESKEY_pidfile) of absolute path!" ;;
+        /*) ;;
+        *) ocf_log warn "You should have pidfile($OCF_RESKEY_pidfile) of absolute path!" ;;
     esac
 
 # Check the update interval
     if ocf_is_decimal "$OCF_RESKEY_update" && [ $OCF_RESKEY_update -gt 0 ]; then
-	:
+        :
     else
-	ocf_log err "Invalid update interval $OCF_RESKEY_update. It should be positive integer!"
-	exit $OCF_ERR_ARGS
+        ocf_log err "Invalid update interval $OCF_RESKEY_update. It should be positive integer!"
+        exit $OCF_ERR_ARGS
     fi
 
     if CheckOptions $OCF_RESKEY_extra_options; then
-	:
+        :
     else
-	ocf_log err "Invalid options $OCF_RESKEY_extra_options!"
-	exit $OCF_ERR_ARGS
+        ocf_log err "Invalid options $OCF_RESKEY_extra_options!"
+        exit $OCF_ERR_ARGS
     fi
 
 # Htmlfile better be an absolute path
     case $OCF_RESKEY_htmlfile in
-	/*) ;;
-	*) ocf_log warn "You should have htmlfile($OCF_RESKEY_htmlfile) of absolute path!" ;;
+        /*) ;;
+        *) ocf_log warn "You should have htmlfile($OCF_RESKEY_htmlfile) of absolute path!" ;;
     esac
 
      
@@ -233,29 +233,29 @@ fi
 : ${OCF_RESKEY_htmlfile:="/tmp/ClusterMon_${OCF_RESOURCE_INSTANCE}.html"}
 
 if [ ${OCF_RESKEY_update} -ge 1000 ]; then
-	OCF_RESKEY_update=$(( $OCF_RESKEY_update / 1000 ))
+    OCF_RESKEY_update=$(( $OCF_RESKEY_update / 1000 ))
 fi
 
 CMON_CMD="${HA_SBIN_DIR}/crm_mon -p $OCF_RESKEY_pidfile -d -i $OCF_RESKEY_update $OCF_RESKEY_extra_options -h $OCF_RESKEY_htmlfile"
 
 case $__OCF_ACTION in
-meta-data)	meta_data
-		exit $OCF_SUCCESS
-		;;
-start)		ClusterMon_start
-		;;
-stop)		ClusterMon_stop
-		;;
-monitor)	ClusterMon_monitor
-		;;
-validate-all)	ClusterMon_validate
-		;;
-usage|help)	ClusterMon_usage
-		exit $OCF_SUCCESS
-		;;
-*)		ClusterMon_usage
-		exit $OCF_ERR_UNIMPLEMENTED
-		;;
+meta-data)      meta_data
+                exit $OCF_SUCCESS
+                ;;
+start)          ClusterMon_start
+                ;;
+stop)           ClusterMon_stop
+                ;;
+monitor)        ClusterMon_monitor
+                ;;
+validate-all)   ClusterMon_validate
+                ;;
+usage|help)     ClusterMon_usage
+                exit $OCF_SUCCESS
+                ;;
+*)              ClusterMon_usage
+                exit $OCF_ERR_UNIMPLEMENTED
+                ;;
 esac
 
 exit $?

--- a/extra/resources/ClusterMon.in
+++ b/extra/resources/ClusterMon.in
@@ -1,31 +1,18 @@
 #!@BASH_PATH@
 #
+# ocf:pacemaker:ClusterMon resource agent
 #
-#	ClusterMon OCF RA.
+# Original copyright 2004 SUSE LINUX AG, Lars Marowsky-Br<E9>e
+# Later changes copyright 2008-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# (GPLv2) WITHOUT ANY WARRANTY.
+#
+
 #	Starts crm_mon in background which logs cluster status as
 #	html to the specified file.
-#
-# Copyright 2004-2018 SUSE LINUX AG, Lars Marowsky-Brée
-#                    All Rights Reserved.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of version 2 of the GNU General Public License as
-# published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it would be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# Further, this software is distributed without any warranty that it is
-# free of the rightful claim of any third person regarding infringement
-# or the like.  Any license provided herein, whether implied or
-# otherwise, applies only to this software file.  Patent licenses, if
-# any, provided herein do not apply to combinations of this program with
-# other software, or any other product whatsoever.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write the Free Software Foundation,
-# Inc., 59 Temple Place - Suite 330, Boston MA 02111-1307, USA.
 #
 # OCF instance parameters:
 #	OCF_RESKEY_user

--- a/extra/resources/ClusterMon.in
+++ b/extra/resources/ClusterMon.in
@@ -23,9 +23,9 @@
 
 #######################################################################
 # Initialization:
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 #######################################################################
 

--- a/extra/resources/ClusterMon.in
+++ b/extra/resources/ClusterMon.in
@@ -218,7 +218,6 @@ ClusterMon_validate() {
         *) ocf_log warn "You should have htmlfile($OCF_RESKEY_htmlfile) of absolute path!" ;;
     esac
 
-     
     echo "Validate OK"
     return $OCF_SUCCESS
 }

--- a/extra/resources/ClusterMon.in
+++ b/extra/resources/ClusterMon.in
@@ -109,7 +109,7 @@ END
 }
 
 ClusterMon_exit() {
-    if [ $1 != 0 ]; then
+    if [ $1 -ne 0 ]; then
         exit $OCF_ERR_GENERIC
     else
         exit $OCF_SUCCESS
@@ -117,7 +117,7 @@ ClusterMon_exit() {
 }
 
 ClusterMon_start() {
-    if [ ! -z "$OCF_RESKEY_user" ]; then
+    if [ -n "$OCF_RESKEY_user" ]; then
         su - "$OCF_RESKEY_user" -c "$CMON_CMD"
     else
         eval $CMON_CMD
@@ -128,7 +128,7 @@ ClusterMon_start() {
 ClusterMon_stop() {
     if [ -f "$OCF_RESKEY_pidfile" ]; then
         pid=$(cat "$OCF_RESKEY_pidfile")
-        if [ ! -z "$pid" ]; then
+        if [ -n "$pid" ]; then
             kill -s 9 $pid
             rm -f "$OCF_RESKEY_pidfile"
         fi
@@ -139,7 +139,7 @@ ClusterMon_stop() {
 ClusterMon_monitor() {
     if [ -f "$OCF_RESKEY_pidfile" ]; then
         pid=$(cat "$OCF_RESKEY_pidfile")
-        if [ ! -z "$pid" ]; then
+        if [ -n "$pid" ]; then
             str=$(echo "su - \"$OCF_RESKEY_user\" -c \"$CMON_CMD\"" | tr 'crmon, \t' 'xxxxxxxx')
             ps -o "args=${str}" -p $pid 2>/dev/null | \
                 grep -qE "[c]rm_mon.*${OCF_RESKEY_pidfile}"
@@ -181,7 +181,7 @@ fi
 
 ClusterMon_validate() {
 # Existence of the user
-    if [ ! -z "$OCF_RESKEY_user" ]; then
+    if [ -n "$OCF_RESKEY_user" ]; then
         getent passwd "$OCF_RESKEY_user" >/dev/null
         if [ $? -eq 0 ]; then
             : Yes, user exists. We can further check his permission on crm_mon if necessary

--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -11,7 +11,27 @@
 # (GPLv2) WITHOUT ANY WARRANTY.
 
 #
-# Does nothing but wait a few seconds, can be configured to fail occassionally
+# The Dummy agent is intended primarily for testing, and has various options to
+# make actions intentionally fail or take a long time. It may also be used as a
+# template for resource agent writers, in which case:
+#
+# - Replace all occurrences of "dummy" and "Dummy" with your agent name.
+# - Update the meta-data appropriately for your agent, such as the description
+#   and supported options. Pay particular attention to the timeouts specified in
+#   the actions section; they should be meaningful for the kind of service the
+#   agent manages. They should be the minimum advised timeouts, but shouldn't
+#   try to cover _all_ possible instances. So, try to be neither overly generous
+#   nor too stingy, but moderate. The minimum timeouts should never be below 10
+#   seconds.
+# - Don't copy the stuff here that is just for testing, such as the
+#   sigterm_handler() or dump_env().
+# - You don't need the state file stuff here if you have a better way of
+#   determining whether your service is running. It's only useful for agents
+#   such as health agents that don't actually correspond to a running service.
+# - Implement the actions appropriately for your service. Your monitor action
+#   must differentiate correctly between running, not running, and failed (that
+#   is THREE states, not just yes/no). The migrate_to, migrate_from, and reload
+#   actions are optional and not appropriate to all services.
 #
 
 #######################################################################
@@ -31,16 +51,10 @@ meta_data() {
 <version>1.0</version>
 
 <longdesc lang="en">
-This is a Dummy Resource Agent. It does absolutely nothing except
-keep track of whether its running or not.
-Its purpose in life is for testing and to serve as a template for RA writers.
-
-NB: Please pay attention to the timeouts specified in the actions
-section below. They should be meaningful for the kind of resource
-the agent manages. They should be the minimum advised timeouts,
-but they shouldn't/cannot cover _all_ possible resource
-instances. So, try to be neither overly generous nor too stingy,
-but moderate. The minimum timeouts should never be below 10 seconds.
+This is a dummy OCF resource agent. It does absolutely nothing except keep track
+of whether it is running or not, and can be configured so that actions fail or
+take a long time. Its purpose is primarily for testing, and to serve as a
+template for resource agent writers.
 </longdesc>
 <shortdesc lang="en">Example stateless resource agent</shortdesc>
 
@@ -170,10 +184,6 @@ dummy_stop() {
 }
 
 dummy_monitor() {
-    # Monitor _MUST!_ differentiate correctly between running
-    # (SUCCESS), failed (ERROR) or _cleanly_ stopped (NOT RUNNING).
-    # That is THREE states, not just yes/no.
-
     if [ $OCF_RESKEY_op_sleep -ne 0 ]; then
         if [ "$1" = "" ] && [ -f "${VERIFY_SERIALIZED_FILE}" ]; then
             # two monitor ops have occurred at the same time.
@@ -220,15 +230,12 @@ dummy_monitor() {
 }
 
 dummy_validate() {
-
     # Is the state directory writable?
     state_dir=$(dirname "$OCF_RESKEY_state")
-    touch "$state_dir/$$"
+    [ -d "$state_dir" ] && [ -w "$state_dir" ] && [ -x "$state_dir" ]
     if [ $? -ne 0 ]; then
         return $OCF_ERR_ARGS
     fi
-    rm "$state_dir/$$"
-
     return $OCF_SUCCESS
 }
 

--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -17,9 +17,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 #######################################################################
 
@@ -163,7 +163,7 @@ dummy_start() {
 dummy_stop() {
     dummy_monitor --force
     if [ $? -eq $OCF_SUCCESS ]; then
-        rm ${OCF_RESKEY_state}
+        rm "${OCF_RESKEY_state}"
     fi
     rm -f "${VERIFY_SERIALIZED_FILE}"
     return $OCF_SUCCESS
@@ -232,7 +232,7 @@ dummy_validate() {
     return $OCF_SUCCESS
 }
 
-: ${OCF_RESKEY_fake:=dummy}
+: ${OCF_RESKEY_fake:="dummy"}
 : ${OCF_RESKEY_op_sleep:=0}
 : ${OCF_RESKEY_CRM_meta_interval:=0}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
@@ -240,7 +240,7 @@ dummy_validate() {
 if [ -z "$OCF_RESKEY_state" ]; then
     OCF_RESKEY_state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
 
-    if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
+    if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
         # Strip off the trailing clone marker (note + is not portable in sed)
         OCF_RESKEY_state=`echo $OCF_RESKEY_state | sed s/:[0-9][0-9]*\.state/.state/`
     fi
@@ -249,7 +249,7 @@ VERIFY_SERIALIZED_FILE="${OCF_RESKEY_state}.serialized"
 
 dump_env
 
-case $__OCF_ACTION in
+case "$__OCF_ACTION" in
 meta-data)      meta_data
                 exit $OCF_SUCCESS
                 ;;

--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -3,7 +3,7 @@
 # ocf:pacemaker:Dummy resource agent
 #
 # Original copyright 2004 SUSE LINUX AG, Lars Marowsky-Br<E9>e
-# Later changes copyright 2008-2018 the Pacemaker project contributors
+# Later changes copyright 2008-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -276,3 +276,5 @@ esac
 rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
 exit $rc
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -17,9 +17,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 #######################################################################
 
@@ -232,9 +232,9 @@ dummy_validate() {
     return $OCF_SUCCESS
 }
 
-: ${OCF_RESKEY_fake=dummy}
-: ${OCF_RESKEY_op_sleep=0}
-: ${OCF_RESKEY_CRM_meta_interval=0}
+: ${OCF_RESKEY_fake:=dummy}
+: ${OCF_RESKEY_op_sleep:=0}
+: ${OCF_RESKEY_CRM_meta_interval:=0}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
 if [ -z "$OCF_RESKEY_state" ]; then

--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -222,7 +222,7 @@ dummy_monitor() {
 dummy_validate() {
 
     # Is the state directory writable?
-    state_dir=`dirname "$OCF_RESKEY_state"`
+    state_dir=$(dirname "$OCF_RESKEY_state")
     touch "$state_dir/$$"
     if [ $? -ne 0 ]; then
         return $OCF_ERR_ARGS
@@ -242,7 +242,7 @@ if [ -z "$OCF_RESKEY_state" ]; then
 
     if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
         # Strip off the trailing clone marker (note + is not portable in sed)
-        OCF_RESKEY_state=`echo $OCF_RESKEY_state | sed s/:[0-9][0-9]*\.state/.state/`
+        OCF_RESKEY_state=$(echo $OCF_RESKEY_state | sed s/:[0-9][0-9]*\.state/.state/)
     fi
 fi
 VERIFY_SERIALIZED_FILE="${OCF_RESKEY_state}.serialized"

--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -1,13 +1,17 @@
 #!/bin/sh
 #
-# Dummy OCF RA. Does nothing but wait a few seconds, can be
-# configured to fail occassionally.
+# ocf:pacemaker:Dummy resource agent
 #
-# Copyright 2004-2018 SUSE LINUX AG, Lars Marowsky-Brée
-# All Rights Reserved.
+# Original copyright 2004 SUSE LINUX AG, Lars Marowsky-Br<E9>e
+# Later changes copyright 2008-2018 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # (GPLv2) WITHOUT ANY WARRANTY.
+
+#
+# Does nothing but wait a few seconds, can be configured to fail occassionally
 #
 
 #######################################################################

--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -31,7 +31,7 @@ meta_data() {
 <version>1.0</version>
 
 <longdesc lang="en">
-This is a Dummy Resource Agent. It does absolutely nothing except 
+This is a Dummy Resource Agent. It does absolutely nothing except
 keep track of whether its running or not.
 Its purpose in life is for testing and to serve as a template for RA writers.
 
@@ -187,7 +187,7 @@ dummy_monitor() {
         sleep ${OCF_RESKEY_op_sleep}
         rm "${VERIFY_SERIALIZED_FILE}"
     fi
-    
+
     if [ -f "${OCF_RESKEY_state}" ]; then
         # Multiple monitor levels are defined to support various tests
         case "$OCF_CHECK_LEVEL" in
@@ -220,8 +220,8 @@ dummy_monitor() {
 }
 
 dummy_validate() {
-    
-    # Is the state directory writable? 
+
+    # Is the state directory writable?
     state_dir=`dirname "$OCF_RESKEY_state"`
     touch "$state_dir/$$"
     if [ $? -ne 0 ]; then

--- a/extra/resources/HealthCPU
+++ b/extra/resources/HealthCPU
@@ -1,7 +1,6 @@
 #!/bin/sh
 #
-# HealthCPU OCF RA
-# Measures CPUs idling and writes #health-cpu status into the CIB
+# ocf:pacemaker:HealthCPU resource agent
 #
 # Copyright 2004-2018 the Pacemaker project contributors
 #
@@ -9,6 +8,10 @@
 #
 # This source code is licensed under the GNU General Public License version 2
 # (GPLv2) WITHOUT ANY WARRANTY.
+#
+
+#
+# Measures CPUs idling and writes #health-cpu status into the CIB
 #
 ################################
 #

--- a/extra/resources/HealthCPU
+++ b/extra/resources/HealthCPU
@@ -114,7 +114,7 @@ dummy_monitor() {
 
     if [ -f "${OCF_RESKEY_state}" ]; then
 
-        IDLE=`top -b -n2 | grep Cpu | tail -1 | awk -F",|.[0-9][ %]id" '{ print $4 }'`
+        IDLE=$(top -b -n2 | grep Cpu | tail -1 | awk -F",|.[0-9][ %]id" '{ print $4 }')
         # echo "System idle: " $IDLE
         # echo "$OCF_RESKEY_red_limit"
         # echo $OCF_RESKEY_yellow_limit
@@ -145,7 +145,7 @@ dummy_monitor() {
 dummy_validate() {
 
     # Is the state directory writable?
-    state_dir=`dirname "$OCF_RESKEY_state"`
+    state_dir=$(dirname "$OCF_RESKEY_state")
     touch "$state_dir/$$"
     if [ $? != 0 ]; then
         return $OCF_ERR_ARGS
@@ -163,7 +163,7 @@ if [ "x$OCF_RESKEY_state" = "x" ]; then
         state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
 
         # Strip off the trailing clone marker
-        OCF_RESKEY_state=`echo $state | sed s/:[0-9][0-9]*\.state/.state/`
+        OCF_RESKEY_state=$(echo $state | sed s/:[0-9][0-9]*\.state/.state/)
     else
         OCF_RESKEY_state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
     fi

--- a/extra/resources/HealthCPU
+++ b/extra/resources/HealthCPU
@@ -93,7 +93,7 @@ END
 
 dummy_start() {
     dummy_monitor
-    if [ $? =  $OCF_SUCCESS ]; then
+    if [ $? -eq $OCF_SUCCESS ]; then
         return $OCF_SUCCESS
     fi
     touch "${OCF_RESKEY_state}"
@@ -101,7 +101,7 @@ dummy_start() {
 
 dummy_stop() {
     dummy_monitor
-    if [ $? =  $OCF_SUCCESS ]; then
+    if [ $? -eq $OCF_SUCCESS ]; then
         rm "${OCF_RESKEY_state}"
     fi
     return $OCF_SUCCESS
@@ -147,7 +147,7 @@ dummy_validate() {
     # Is the state directory writable?
     state_dir=$(dirname "$OCF_RESKEY_state")
     touch "$state_dir/$$"
-    if [ $? != 0 ]; then
+    if [ $? -ne 0 ]; then
         return $OCF_ERR_ARGS
     fi
     rm "$state_dir/$$"
@@ -158,7 +158,7 @@ dummy_validate() {
 : ${OCF_RESKEY_CRM_meta_interval:=0}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
-if [ "x$OCF_RESKEY_state" = "x" ]; then
+if [ -z "$OCF_RESKEY_state" ]; then
     if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
         state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
 
@@ -169,11 +169,11 @@ if [ "x$OCF_RESKEY_state" = "x" ]; then
     fi
 fi
 
-if [ "x${OCF_RESKEY_red_limit}" = "x" ] ; then
+if [ -z "${OCF_RESKEY_red_limit}" ] ; then
     OCF_RESKEY_red_limit=10
 fi
 
-if [ "x${OCF_RESKEY_yellow_limit}" = "x" ] ; then
+if [ -z "${OCF_RESKEY_yellow_limit}" ] ; then
     OCF_RESKEY_yellow_limit=50
 fi
 

--- a/extra/resources/HealthCPU
+++ b/extra/resources/HealthCPU
@@ -23,9 +23,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 #######################################################################
 
@@ -155,7 +155,7 @@ dummy_validate() {
     return $OCF_SUCCESS
 }
 
-: ${OCF_RESKEY_CRM_meta_interval=0}
+: ${OCF_RESKEY_CRM_meta_interval:=0}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
 if [ "x$OCF_RESKEY_state" = "x" ]; then

--- a/extra/resources/HealthCPU
+++ b/extra/resources/HealthCPU
@@ -111,7 +111,7 @@ dummy_monitor() {
     # Monitor _MUST!_ differentiate correctly between running
     # (SUCCESS), failed (ERROR) or _cleanly_ stopped (NOT RUNNING).
     # That is THREE states, not just yes/no.
-        
+
     if [ -f ${OCF_RESKEY_state} ]; then
 
         IDLE=`top -b -n2 | grep Cpu | tail -1 | awk -F",|.[0-9][ %]id" '{ print $4 }'`
@@ -132,7 +132,7 @@ dummy_monitor() {
             # echo "System state green."
             attrd_updater -n "#health-cpu" -U "green" -d "30s"
         fi
-        
+
         return $OCF_SUCCESS
     fi
 
@@ -143,8 +143,8 @@ dummy_monitor() {
 }
 
 dummy_validate() {
-    
-    # Is the state directory writable? 
+
+    # Is the state directory writable?
     state_dir=`dirname "$OCF_RESKEY_state"`
     touch "$state_dir/$$"
     if [ $? != 0 ]; then
@@ -161,10 +161,10 @@ dummy_validate() {
 if [ "x$OCF_RESKEY_state" = "x" ]; then
     if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
         state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
-        
+
         # Strip off the trailing clone marker
         OCF_RESKEY_state=`echo $state | sed s/:[0-9][0-9]*\.state/.state/`
-    else 
+    else
         OCF_RESKEY_state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
     fi
 fi

--- a/extra/resources/HealthCPU
+++ b/extra/resources/HealthCPU
@@ -195,3 +195,5 @@ esac
 rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
 exit $rc
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/HealthCPU
+++ b/extra/resources/HealthCPU
@@ -83,7 +83,7 @@ END
 
 #######################################################################
 
-dummy_usage() {
+healthcpu_usage() {
     cat <<END
 usage: $0 {start|stop|monitor|validate-all|meta-data}
 
@@ -91,27 +91,23 @@ Expects to have a fully populated OCF RA-compliant environment set.
 END
 }
 
-dummy_start() {
-    dummy_monitor
+healthcpu_start() {
+    healthcpu_monitor
     if [ $? -eq $OCF_SUCCESS ]; then
         return $OCF_SUCCESS
     fi
     touch "${OCF_RESKEY_state}"
 }
 
-dummy_stop() {
-    dummy_monitor
+healthcpu_stop() {
+    healthcpu_monitor
     if [ $? -eq $OCF_SUCCESS ]; then
         rm "${OCF_RESKEY_state}"
     fi
     return $OCF_SUCCESS
 }
 
-dummy_monitor() {
-    # Monitor _MUST!_ differentiate correctly between running
-    # (SUCCESS), failed (ERROR) or _cleanly_ stopped (NOT RUNNING).
-    # That is THREE states, not just yes/no.
-
+healthcpu_monitor() {
     if [ -f "${OCF_RESKEY_state}" ]; then
 
         IDLE=$(top -b -n2 | grep Cpu | tail -1 | awk -F",|.[0-9][ %]id" '{ print $4 }')
@@ -136,22 +132,16 @@ dummy_monitor() {
         return $OCF_SUCCESS
     fi
 
-    if false ; then
-        return $OCF_ERR_GENERIC
-    fi
     return $OCF_NOT_RUNNING
 }
 
-dummy_validate() {
-
+healthcpu_validate() {
     # Is the state directory writable?
     state_dir=$(dirname "$OCF_RESKEY_state")
-    touch "$state_dir/$$"
+    [ -d "$state_dir" ] && [ -w "$state_dir" ] && [ -x "$state_dir" ]
     if [ $? -ne 0 ]; then
         return $OCF_ERR_ARGS
     fi
-    rm "$state_dir/$$"
-
     return $OCF_SUCCESS
 }
 
@@ -159,13 +149,12 @@ dummy_validate() {
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
 if [ -z "$OCF_RESKEY_state" ]; then
+    state="${HA_VARRUN%%/}/HealthCPU-${OCF_RESOURCE_INSTANCE}.state"
     if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
-        state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
-
         # Strip off the trailing clone marker
         OCF_RESKEY_state=$(echo $state | sed s/:[0-9][0-9]*\.state/.state/)
     else
-        OCF_RESKEY_state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
+        OCF_RESKEY_state="$state"
     fi
 fi
 
@@ -181,14 +170,14 @@ case "$__OCF_ACTION" in
 meta-data)      meta_data
                 exit $OCF_SUCCESS
                 ;;
-start)          dummy_start;;
-stop)           dummy_stop;;
-monitor)        dummy_monitor;;
-validate-all)   dummy_validate;;
-usage|help)     dummy_usage
+start)          healthcpu_start;;
+stop)           healthcpu_stop;;
+monitor)        healthcpu_monitor;;
+validate-all)   healthcpu_validate;;
+usage|help)     healthcpu_usage
                 exit $OCF_SUCCESS
                 ;;
-*)              dummy_usage
+*)              healthcpu_usage
                 exit $OCF_ERR_UNIMPLEMENTED
                 ;;
 esac

--- a/extra/resources/HealthCPU
+++ b/extra/resources/HealthCPU
@@ -23,9 +23,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 #######################################################################
 
@@ -96,13 +96,13 @@ dummy_start() {
     if [ $? =  $OCF_SUCCESS ]; then
         return $OCF_SUCCESS
     fi
-    touch ${OCF_RESKEY_state}
+    touch "${OCF_RESKEY_state}"
 }
 
 dummy_stop() {
     dummy_monitor
     if [ $? =  $OCF_SUCCESS ]; then
-        rm ${OCF_RESKEY_state}
+        rm "${OCF_RESKEY_state}"
     fi
     return $OCF_SUCCESS
 }
@@ -112,7 +112,7 @@ dummy_monitor() {
     # (SUCCESS), failed (ERROR) or _cleanly_ stopped (NOT RUNNING).
     # That is THREE states, not just yes/no.
 
-    if [ -f ${OCF_RESKEY_state} ]; then
+    if [ -f "${OCF_RESKEY_state}" ]; then
 
         IDLE=`top -b -n2 | grep Cpu | tail -1 | awk -F",|.[0-9][ %]id" '{ print $4 }'`
         # echo "System idle: " $IDLE
@@ -159,7 +159,7 @@ dummy_validate() {
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
 if [ "x$OCF_RESKEY_state" = "x" ]; then
-    if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
+    if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
         state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
 
         # Strip off the trailing clone marker
@@ -177,7 +177,7 @@ if [ "x${OCF_RESKEY_yellow_limit}" = "x" ] ; then
     OCF_RESKEY_yellow_limit=50
 fi
 
-case $__OCF_ACTION in
+case "$__OCF_ACTION" in
 meta-data)      meta_data
                 exit $OCF_SUCCESS
                 ;;

--- a/extra/resources/HealthCPU
+++ b/extra/resources/HealthCPU
@@ -2,7 +2,7 @@
 #
 # ocf:pacemaker:HealthCPU resource agent
 #
-# Copyright 2004-2018 the Pacemaker project contributors
+# Copyright 2004-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -15,8 +15,8 @@
 #
 ################################
 #
-#	TODO: Enter default values
-#		Error handling in getting uptime
+# TODO: Enter default values
+#       Error handling in getting uptime
 #
 ##################################
 
@@ -30,7 +30,7 @@
 #######################################################################
 
 meta_data() {
-	cat <<END
+    cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
 <resource-agent name="HealthCPU" version="0.1">
@@ -84,7 +84,7 @@ END
 #######################################################################
 
 dummy_usage() {
-	cat <<END
+    cat <<END
 usage: $0 {start|stop|monitor|validate-all|meta-data}
 
 Expects to have a fully populated OCF RA-compliant environment set.
@@ -94,7 +94,7 @@ END
 dummy_start() {
     dummy_monitor
     if [ $? =  $OCF_SUCCESS ]; then
-	return $OCF_SUCCESS
+        return $OCF_SUCCESS
     fi
     touch ${OCF_RESKEY_state}
 }
@@ -102,46 +102,44 @@ dummy_start() {
 dummy_stop() {
     dummy_monitor
     if [ $? =  $OCF_SUCCESS ]; then
-	rm ${OCF_RESKEY_state}
+        rm ${OCF_RESKEY_state}
     fi
     return $OCF_SUCCESS
 }
 
 dummy_monitor() {
-	# Monitor _MUST!_ differentiate correctly between running
-	# (SUCCESS), failed (ERROR) or _cleanly_ stopped (NOT RUNNING).
-	# That is THREE states, not just yes/no.
-	
-	if [ -f ${OCF_RESKEY_state} ]; then
+    # Monitor _MUST!_ differentiate correctly between running
+    # (SUCCESS), failed (ERROR) or _cleanly_ stopped (NOT RUNNING).
+    # That is THREE states, not just yes/no.
+        
+    if [ -f ${OCF_RESKEY_state} ]; then
 
-	  IDLE=`top -b -n2 | grep Cpu | tail -1 | awk -F",|.[0-9][ %]id" '{ print $4 }'`
-	  # echo "System idle: " $IDLE
-	  # echo "$OCF_RESKEY_red_limit"
-	  # echo $OCF_RESKEY_yellow_limit
+        IDLE=`top -b -n2 | grep Cpu | tail -1 | awk -F",|.[0-9][ %]id" '{ print $4 }'`
+        # echo "System idle: " $IDLE
+        # echo "$OCF_RESKEY_red_limit"
+        # echo $OCF_RESKEY_yellow_limit
 
-	  if [ $IDLE -lt ${OCF_RESKEY_red_limit} ] ; then
-	    # echo "System state RED!"
-	    attrd_updater -n "#health-cpu" -U "red" -d "30s"
-	    return $OCF_SUCCESS
-          fi
-
-	  if [ $IDLE -lt ${OCF_RESKEY_yellow_limit} ] ; then
-	    # echo "System state yellow."
-            attrd_updater -n "#health-cpu" -U "yellow" -d "30s"
-	  else
-	    # echo "System state green."
-	    attrd_updater -n "#health-cpu" -U "green" -d "30s"
-
-          fi
-	
-	  return $OCF_SUCCESS
-	fi
-
-	if false ; then
-                return $OCF_ERR_GENERIC
+        if [ $IDLE -lt ${OCF_RESKEY_red_limit} ] ; then
+            # echo "System state RED!"
+            attrd_updater -n "#health-cpu" -U "red" -d "30s"
+            return $OCF_SUCCESS
         fi
-        return $OCF_NOT_RUNNING
 
+        if [ $IDLE -lt ${OCF_RESKEY_yellow_limit} ] ; then
+            # echo "System state yellow."
+            attrd_updater -n "#health-cpu" -U "yellow" -d "30s"
+        else
+            # echo "System state green."
+            attrd_updater -n "#health-cpu" -U "green" -d "30s"
+        fi
+        
+        return $OCF_SUCCESS
+    fi
+
+    if false ; then
+        return $OCF_ERR_GENERIC
+    fi
+    return $OCF_NOT_RUNNING
 }
 
 dummy_validate() {
@@ -150,7 +148,7 @@ dummy_validate() {
     state_dir=`dirname "$OCF_RESKEY_state"`
     touch "$state_dir/$$"
     if [ $? != 0 ]; then
-	return $OCF_ERR_ARGS
+        return $OCF_ERR_ARGS
     fi
     rm "$state_dir/$$"
 
@@ -162,39 +160,38 @@ dummy_validate() {
 
 if [ "x$OCF_RESKEY_state" = "x" ]; then
     if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
-	state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
-	
-	# Strip off the trailing clone marker
-	OCF_RESKEY_state=`echo $state | sed s/:[0-9][0-9]*\.state/.state/`
+        state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
+        
+        # Strip off the trailing clone marker
+        OCF_RESKEY_state=`echo $state | sed s/:[0-9][0-9]*\.state/.state/`
     else 
-	OCF_RESKEY_state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
+        OCF_RESKEY_state="${HA_VARRUN%%/}/Dummy-${OCF_RESOURCE_INSTANCE}.state"
     fi
 fi
 
 if [ "x${OCF_RESKEY_red_limit}" = "x" ] ; then
-  OCF_RESKEY_red_limit=10
+    OCF_RESKEY_red_limit=10
 fi
 
 if [ "x${OCF_RESKEY_yellow_limit}" = "x" ] ; then
-  OCF_RESKEY_yellow_limit=50
+    OCF_RESKEY_yellow_limit=50
 fi
 
 case $__OCF_ACTION in
-meta-data)	meta_data
-		exit $OCF_SUCCESS
-		;;
-start)		dummy_start;;
-stop)		dummy_stop;;
-monitor)	dummy_monitor;;
-validate-all)	dummy_validate;;
-usage|help)	dummy_usage
-		exit $OCF_SUCCESS
-		;;
-*)		dummy_usage
-		exit $OCF_ERR_UNIMPLEMENTED
-		;;
+meta-data)      meta_data
+                exit $OCF_SUCCESS
+                ;;
+start)          dummy_start;;
+stop)           dummy_stop;;
+monitor)        dummy_monitor;;
+validate-all)   dummy_validate;;
+usage|help)     dummy_usage
+                exit $OCF_SUCCESS
+                ;;
+*)              dummy_usage
+                exit $OCF_ERR_UNIMPLEMENTED
+                ;;
 esac
 rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
 exit $rc
-

--- a/extra/resources/HealthCPU
+++ b/extra/resources/HealthCPU
@@ -37,7 +37,7 @@ meta_data() {
 <version>1.0</version>
 
 <longdesc lang="en">
-Systhem health agent that measures the CPU idling and updates the #health-cpu attribute.
+System health agent that measures the CPU idling and updates the #health-cpu attribute.
 </longdesc>
 <shortdesc lang="en">System health CPU usage</shortdesc>
 

--- a/extra/resources/HealthIOWait
+++ b/extra/resources/HealthIOWait
@@ -16,9 +16,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 #######################################################################
 
@@ -135,7 +135,7 @@ agent_validate() {
     return $OCF_SUCCESS
 }
 
-: ${OCF_RESKEY_CRM_meta_interval=0}
+: ${OCF_RESKEY_CRM_meta_interval:=0}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
 if [ "x$OCF_RESKEY_state" = "x" ]; then

--- a/extra/resources/HealthIOWait
+++ b/extra/resources/HealthIOWait
@@ -86,7 +86,7 @@ END
 
 agent_start() {
     agent_monitor
-    if [ $? =  $OCF_SUCCESS ]; then
+    if [ $? -eq $OCF_SUCCESS ]; then
       return $OCF_SUCCESS
     fi
     touch "${OCF_RESKEY_state}"
@@ -94,7 +94,7 @@ agent_start() {
 
 agent_stop() {
     agent_monitor
-    if [ $? =  $OCF_SUCCESS ]; then
+    if [ $? -eq $OCF_SUCCESS ]; then
         rm "${OCF_RESKEY_state}"
     fi
     return $OCF_SUCCESS
@@ -138,7 +138,7 @@ agent_validate() {
 : ${OCF_RESKEY_CRM_meta_interval:=0}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
-if [ "x$OCF_RESKEY_state" = "x" ]; then
+if [ -z "$OCF_RESKEY_state" ]; then
     if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
       state="${HA_VARRUN%%/}/HealthIoWait-${OCF_RESOURCE_INSTANCE}.state"
       #Strip off the trailing clone marker
@@ -148,11 +148,11 @@ if [ "x$OCF_RESKEY_state" = "x" ]; then
     fi
 fi
 
-if [ "x${OCF_RESKEY_red_limit}" = "x" ] ; then
+if [ -z "${OCF_RESKEY_red_limit}" ] ; then
   OCF_RESKEY_red_limit=15
 fi
 
-if [ "x${OCF_RESKEY_yellow_limit}" = "x" ] ; then
+if [ -z "${OCF_RESKEY_yellow_limit}" ] ; then
   OCF_RESKEY_yellow_limit=10
 fi
 

--- a/extra/resources/HealthIOWait
+++ b/extra/resources/HealthIOWait
@@ -16,9 +16,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 #######################################################################
 
@@ -95,7 +95,7 @@ agent_start() {
 agent_stop() {
     agent_monitor
     if [ $? =  $OCF_SUCCESS ]; then
-        rm ${OCF_RESKEY_state}
+        rm "${OCF_RESKEY_state}"
     fi
     return $OCF_SUCCESS
 }
@@ -104,7 +104,7 @@ agent_monitor() {
         # Monitor _MUST!_ differentiate correctly between running
         # (SUCCESS), failed (ERROR) or _cleanly_ stopped (NOT RUNNING).
         # That is THREE states, not just yes/no.
-        if [ -f ${OCF_RESKEY_state} ]; then
+        if [ -f "${OCF_RESKEY_state}" ]; then
           WAIT=`top -b -n2 | grep Cpu | tail -1 | awk -F",|.[0-9][ %]wa" '{ print $5 }'`
           # echo "System iowait: " $WAIT
           # echo $OCF_RESKEY_yellow_limit
@@ -139,7 +139,7 @@ agent_validate() {
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
 if [ "x$OCF_RESKEY_state" = "x" ]; then
-    if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
+    if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
       state="${HA_VARRUN%%/}/HealthIoWait-${OCF_RESOURCE_INSTANCE}.state"
       #Strip off the trailing clone marker
       OCF_RESKEY_state=`echo $state | sed s/:[0-9][0-9]*\.state/.state/`

--- a/extra/resources/HealthIOWait
+++ b/extra/resources/HealthIOWait
@@ -2,7 +2,7 @@
 #
 # ocf:pacemaker:HealthIOWait resource agent
 #
-# Copyright 2004-2018 the Pacemaker project contributors
+# Copyright 2004-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -174,3 +174,5 @@ esac
 rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
 exit $rc
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/HealthIOWait
+++ b/extra/resources/HealthIOWait
@@ -30,7 +30,7 @@ meta_data() {
 <version>1.0</version>
 
 <longdesc lang="en">
-Systhem health agent that measures the CPU iowait via top and updates the #health-iowait attribute.
+System health agent that measures the CPU iowait via top and updates the #health-iowait attribute.
 </longdesc>
 <shortdesc lang="en">System health based on CPU iowait measurement</shortdesc>
 

--- a/extra/resources/HealthIOWait
+++ b/extra/resources/HealthIOWait
@@ -1,7 +1,6 @@
 #!/bin/sh
 #
-# IOWait RA
-# Measures CPU iowait % via top and writes #health-iowait status into the CIB
+# ocf:pacemaker:HealthIOWait resource agent
 #
 # Copyright 2004-2018 the Pacemaker project contributors
 #
@@ -9,6 +8,10 @@
 #
 # This source code is licensed under the GNU General Public License version 2
 # (GPLv2) WITHOUT ANY WARRANTY.
+#
+
+#
+# Measures CPU iowait % via top and writes #health-iowait status into the CIB
 #
 #######################################################################
 # Initialization:

--- a/extra/resources/HealthIOWait
+++ b/extra/resources/HealthIOWait
@@ -105,7 +105,7 @@ agent_monitor() {
         # (SUCCESS), failed (ERROR) or _cleanly_ stopped (NOT RUNNING).
         # That is THREE states, not just yes/no.
         if [ -f "${OCF_RESKEY_state}" ]; then
-          WAIT=`top -b -n2 | grep Cpu | tail -1 | awk -F",|.[0-9][ %]wa" '{ print $5 }'`
+          WAIT=$(top -b -n2 | grep Cpu | tail -1 | awk -F",|.[0-9][ %]wa" '{ print $5 }')
           # echo "System iowait: " $WAIT
           # echo $OCF_RESKEY_yellow_limit
           if [ $WAIT -gt ${OCF_RESKEY_red_limit} ] ; then
@@ -128,7 +128,7 @@ agent_monitor() {
 
 agent_validate() {
     # Is the state directory writable?
-    state_dir=`dirname "$OCF_RESKEY_state"`
+    state_dir=$(dirname "$OCF_RESKEY_state")
     if [ -d "$state_dir" ] && [ -w "$state_dir" ] && [ -x "$state_dir" ]; then
       return $OCF_ERR_ARGS
     fi
@@ -142,7 +142,7 @@ if [ "x$OCF_RESKEY_state" = "x" ]; then
     if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
       state="${HA_VARRUN%%/}/HealthIoWait-${OCF_RESOURCE_INSTANCE}.state"
       #Strip off the trailing clone marker
-      OCF_RESKEY_state=`echo $state | sed s/:[0-9][0-9]*\.state/.state/`
+      OCF_RESKEY_state=$(echo $state | sed s/:[0-9][0-9]*\.state/.state/)
     else
       OCF_RESKEY_state="${HA_VARRUN%%/}/HealthIoWait-${OCF_RESOURCE_INSTANCE}.state"
     fi

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -36,7 +36,7 @@ meta_data() {
 <version>1.0</version>
 
 <longdesc lang="en">
-Systhem health agent that checks the S.M.A.R.T. status of the given drives and
+System health agent that checks the S.M.A.R.T. status of the given drives and
 updates the #health-smart attribute.
 </longdesc>
 <shortdesc lang="en">SMART health status</shortdesc>

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -1,31 +1,18 @@
 #!@BASH_PATH@
 #
-#
-# HealthSMART OCF RA. Checks the S.M.A.R.T. status of all given
-# drives and writes the #health-smart status into the CIB
+# ocf:pacemaker:HealthSMART resource agent
 #
 # Copyright 2009-2018 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of version 2 of the GNU General Public License as
-# published by the Free Software Foundation.
+# This source code is licensed under the GNU General Public License version 2
+# (GPLv2) WITHOUT ANY WARRANTY.
 #
-# This program is distributed in the hope that it would be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
 #
-# Further, this software is distributed without any warranty that it is
-# free of the rightful claim of any third person regarding infringement
-# or the like.  Any license provided herein, whether implied or
-# otherwise, applies only to this software file.  Patent licenses, if
-# any, provided herein do not apply to combinations of this program with
-# other software, or any other product whatsoever.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write the Free Software Foundation,
-# Inc., 59 Temple Place - Suite 330, Boston MA 02111-1307, USA.
+# Checks the S.M.A.R.T. status of all given drives and writes the #health-smart
+# status into the CIB
 #
 #######################################################################
 

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -2,7 +2,7 @@
 #
 # ocf:pacemaker:HealthSMART resource agent
 #
-# Copyright 2009-2018 the Pacemaker project contributors
+# Copyright 2009-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -109,27 +109,27 @@ END
 check_temperature() {
     
     if [ $1 -lt ${lower_red_limit} ] ; then
-	ocf_log info "Drive ${DRIVE} ${DEVICE} too cold: ${1} C"
-	$ATTRDUP -n "#health-smart" -U "red" -d "5s"
-	return 1
+        ocf_log info "Drive ${DRIVE} ${DEVICE} too cold: ${1} C"
+        $ATTRDUP -n "#health-smart" -U "red" -d "5s"
+        return 1
     fi
 
     if [ $1 -gt ${upper_red_limit} ] ; then
-	ocf_log info "Drive ${DRIVE} ${DEVICE} too hot: ${1} C"
-	$ATTRDUP -n "#health-smart" -U "red" -d "5s"
-	return 1
+        ocf_log info "Drive ${DRIVE} ${DEVICE} too hot: ${1} C"
+        $ATTRDUP -n "#health-smart" -U "red" -d "5s"
+        return 1
     fi
     
     if [ $1 -lt ${lower_yellow_limit} ] ; then
-	ocf_log info "Drive ${DRIVE} ${DEVICE} quite cold: ${1} C"
-	$ATTRDUP -n "#health-smart" -U "yellow" -d "5s"
-	return 1
+        ocf_log info "Drive ${DRIVE} ${DEVICE} quite cold: ${1} C"
+        $ATTRDUP -n "#health-smart" -U "yellow" -d "5s"
+        return 1
     fi
     
     if [ $1 -gt ${upper_yellow_limit} ] ; then
-	ocf_log info "Drive ${DRIVE} ${DEVICE} quite hot: ${1} C"
-	$ATTRDUP -n "#health-smart" -U "yellow" -d "5s"
-	return 1
+        ocf_log info "Drive ${DRIVE} ${DEVICE} quite hot: ${1} C"
+        $ATTRDUP -n "#health-smart" -U "yellow" -d "5s"
+        return 1
     fi
 }
 
@@ -137,7 +137,7 @@ check_temperature() {
 init_smart() {
     #Set temperature defaults
     if [ -z ${OCF_RESKEY_temp_warning} ]; then
-	yellow_threshold=5
+        yellow_threshold=5
     else
         yellow_threshold=${OCF_RESKEY_temp_warning}
     fi
@@ -170,21 +170,21 @@ init_smart() {
     fi
 
     for DRIVE in $DRIVES; do
-	if [ "${OCF_RESKEY_devices}" ]; then
-	    for DEVICE in ${OCF_RESKEY_devices}; do
-		$SMARTCTL -d $DEVICE -i ${DRIVE} | grep -q "SMART support is: Enabled"
-		if [ $? -ne "0" ] ; then
-		    ocf_log err "S.M.A.R.T. not enabled for drive "${DRIVE}
-		    exit $OCF_ERR_INSTALLED
-		fi
-	    done
-	else
-	    $SMARTCTL -i ${DRIVE} | grep -q "SMART support is: Enabled"
-	    if [ $? -ne "0" ] ; then
-		ocf_log err "S.M.A.R.T. not enabled for drive "${DRIVE}
-		exit $OCF_ERR_INSTALLED
-	    fi
-	fi
+        if [ "${OCF_RESKEY_devices}" ]; then
+            for DEVICE in ${OCF_RESKEY_devices}; do
+                $SMARTCTL -d $DEVICE -i ${DRIVE} | grep -q "SMART support is: Enabled"
+                if [ $? -ne "0" ] ; then
+                    ocf_log err "S.M.A.R.T. not enabled for drive "${DRIVE}
+                    exit $OCF_ERR_INSTALLED
+                fi
+            done
+        else
+            $SMARTCTL -i ${DRIVE} | grep -q "SMART support is: Enabled"
+            if [ $? -ne "0" ] ; then
+                ocf_log err "S.M.A.R.T. not enabled for drive "${DRIVE}
+                exit $OCF_ERR_INSTALLED
+            fi
+        fi
     done
 }
 
@@ -224,36 +224,36 @@ HealthSMART_monitor() {
 
         # Check overall S.M.A.R.T. status
         for DRIVE in $DRIVES; do
-	    if [ "${OCF_RESKEY_devices}" ]; then
-		for DEVICE in ${OCF_RESKEY_devices}; do
-		    $SMARTCTL -d $DEVICE -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
-		    if [ $? -ne "0" ]; then
-			$ATTRDUP -n "#health-smart" -U "red" -d "5s"
-			return $OCF_SUCCESS
-		    fi
-		done
-	    else
-		$SMARTCTL -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
-		if [ $? -ne "0" ]; then
-		    $ATTRDUP -n "#health-smart" -U "red" -d "5s"
-		    return $OCF_SUCCESS
-		fi
-	    fi
-	    
+            if [ "${OCF_RESKEY_devices}" ]; then
+                for DEVICE in ${OCF_RESKEY_devices}; do
+                    $SMARTCTL -d $DEVICE -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
+                    if [ $? -ne "0" ]; then
+                        $ATTRDUP -n "#health-smart" -U "red" -d "5s"
+                        return $OCF_SUCCESS
+                    fi
+                done
+            else
+                $SMARTCTL -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
+                if [ $? -ne "0" ]; then
+                    $ATTRDUP -n "#health-smart" -U "red" -d "5s"
+                    return $OCF_SUCCESS
+                fi
+            fi
+            
             # Check drive temperature(s)
-	    if [ "${OCF_RESKEY_devices}" ]; then
-		for DEVICE in ${OCF_RESKEY_devices}; do
-		    check_temperature "$("$SMARTCTL" -d "$DEVICE" -A "${DRIVE}" | awk '/^194/ { print $10 }')"
-		    if [ $? -ne 0 ]; then
-			return $OCF_SUCCESS
-		    fi
-		done
-	    else
-		check_temperature "$("$SMARTCTL" -A "${DRIVE}" | awk '/^194/ { print $10 }')"
-		if [ $? -ne 0 ]; then
-		    return $OCF_SUCCESS
-		fi
-	    fi
+            if [ "${OCF_RESKEY_devices}" ]; then
+                for DEVICE in ${OCF_RESKEY_devices}; do
+                    check_temperature "$("$SMARTCTL" -d "$DEVICE" -A "${DRIVE}" | awk '/^194/ { print $10 }')"
+                    if [ $? -ne 0 ]; then
+                        return $OCF_SUCCESS
+                    fi
+                done
+            else
+                check_temperature "$("$SMARTCTL" -A "${DRIVE}" | awk '/^194/ { print $10 }')"
+                if [ $? -ne 0 ]; then
+                    return $OCF_SUCCESS
+                fi
+            fi
         done
 
         $ATTRDUP -n "#health-smart" -U "green" -d "5s"
@@ -268,7 +268,7 @@ HealthSMART_validate() {
 
     init_smart
 
-  # Is the state directory writable?
+    # Is the state directory writable?
     state_dir=`dirname "$OCF_RESKEY_state"`
     touch "$state_dir/$$"
     if [ $? != 0 ]; then
@@ -286,7 +286,7 @@ if [ "x$OCF_RESKEY_state" = "x" ]; then
     if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
         state="${HA_VARRUN%%/}/HealthSMART-${OCF_RESOURCE_INSTANCE}.state"
 
-  # Strip off the trailing clone marker
+        # Strip off the trailing clone marker
         OCF_RESKEY_state=`echo $state | sed s/:[0-9][0-9]*\.state/.state/`
     else
         OCF_RESKEY_state="${HA_VARRUN%%/}/HealthSMART-${OCF_RESOURCE_INSTANCE}.state"
@@ -294,21 +294,21 @@ if [ "x$OCF_RESKEY_state" = "x" ]; then
 fi
 
 case $__OCF_ACTION in
-    start)	  HealthSMART_start;;
-    stop)	  HealthSMART_stop;;
-    monitor)	  HealthSMART_monitor;;
+    start)        HealthSMART_start;;
+    stop)         HealthSMART_stop;;
+    monitor)      HealthSMART_monitor;;
     validate-all) HealthSMART_validate;;
     meta-data) 
-	meta_data
-	exit $OCF_SUCCESS
-	;;
+        meta_data
+        exit $OCF_SUCCESS
+        ;;
     usage|help)
-	HealthSMART_usage
-	exit $OCF_SUCCESS
-	;;
+        HealthSMART_usage
+        exit $OCF_SUCCESS
+        ;;
     *)  HealthSMART_usage
-	exit $OCF_ERR_UNIMPLEMENTED
-	;;
+        exit $OCF_ERR_UNIMPLEMENTED
+        ;;
 esac
 rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -269,7 +269,7 @@ HealthSMART_validate() {
     init_smart
 
     # Is the state directory writable?
-    state_dir=`dirname "$OCF_RESKEY_state"`
+    state_dir=$(dirname "$OCF_RESKEY_state")
     touch "$state_dir/$$"
     if [ $? != 0 ]; then
         return $OCF_ERR_ARGS
@@ -287,7 +287,7 @@ if [ "x$OCF_RESKEY_state" = "x" ]; then
         state="${HA_VARRUN%%/}/HealthSMART-${OCF_RESOURCE_INSTANCE}.state"
 
         # Strip off the trailing clone marker
-        OCF_RESKEY_state=`echo $state | sed s/:[0-9][0-9]*\.state/.state/`
+        OCF_RESKEY_state=$(echo $state | sed s/:[0-9][0-9]*\.state/.state/)
     else
         OCF_RESKEY_state="${HA_VARRUN%%/}/HealthSMART-${OCF_RESOURCE_INSTANCE}.state"
     fi

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -19,9 +19,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 #
 SMARTCTL=/usr/sbin/smartctl
 ATTRDUP=/usr/sbin/attrd_updater
@@ -279,7 +279,7 @@ HealthSMART_validate() {
     return $OCF_SUCCESS
 }
 
-: ${OCF_RESKEY_CRM_meta_interval=0}
+: ${OCF_RESKEY_CRM_meta_interval:=0}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="true"}
 
 if [ "x$OCF_RESKEY_state" = "x" ]; then

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -107,7 +107,7 @@ END
 #######################################################################
 
 check_temperature() {
-    
+
     if [ $1 -lt ${lower_red_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} too cold: ${1} C"
         $ATTRDUP -n "#health-smart" -U "red" -d "5s"
@@ -119,13 +119,13 @@ check_temperature() {
         $ATTRDUP -n "#health-smart" -U "red" -d "5s"
         return 1
     fi
-    
+
     if [ $1 -lt ${lower_yellow_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} quite cold: ${1} C"
         $ATTRDUP -n "#health-smart" -U "yellow" -d "5s"
         return 1
     fi
-    
+
     if [ $1 -gt ${upper_yellow_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} quite hot: ${1} C"
         $ATTRDUP -n "#health-smart" -U "yellow" -d "5s"
@@ -239,7 +239,7 @@ HealthSMART_monitor() {
                     return $OCF_SUCCESS
                 fi
             fi
-            
+
             # Check drive temperature(s)
             if [ "${OCF_RESKEY_devices}" ]; then
                 for DEVICE in ${OCF_RESKEY_devices}; do
@@ -298,7 +298,7 @@ case $__OCF_ACTION in
     stop)         HealthSMART_stop;;
     monitor)      HealthSMART_monitor;;
     validate-all) HealthSMART_validate;;
-    meta-data) 
+    meta-data)
         meta_data
         exit $OCF_SUCCESS
         ;;

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -170,7 +170,7 @@ init_smart() {
     fi
 
     for DRIVE in $DRIVES; do
-        if [ "${OCF_RESKEY_devices}" ]; then
+        if [ -n "${OCF_RESKEY_devices}" ]; then
             for DEVICE in ${OCF_RESKEY_devices}; do
                 "$SMARTCTL" -d "$DEVICE" -i "${DRIVE}" | grep -q "SMART support is: Enabled"
                 if [ $? -ne 0 ] ; then
@@ -198,7 +198,7 @@ END
 
 HealthSMART_start() {
     HealthSMART_monitor
-    if [ $? =  $OCF_SUCCESS ]; then
+    if [ $? -eq $OCF_SUCCESS ]; then
         return $OCF_SUCCESS
     fi
     touch "${OCF_RESKEY_state}"
@@ -206,7 +206,7 @@ HealthSMART_start() {
 
 HealthSMART_stop() {
     HealthSMART_monitor
-    if [ $? =  $OCF_SUCCESS ]; then
+    if [ $? -eq $OCF_SUCCESS ]; then
         rm "${OCF_RESKEY_state}"
     fi
     return $OCF_SUCCESS
@@ -224,7 +224,7 @@ HealthSMART_monitor() {
 
         # Check overall S.M.A.R.T. status
         for DRIVE in $DRIVES; do
-            if [ "${OCF_RESKEY_devices}" ]; then
+            if [ -n "${OCF_RESKEY_devices}" ]; then
                 for DEVICE in ${OCF_RESKEY_devices}; do
                     "$SMARTCTL" -d "$DEVICE" -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
                     if [ $? -ne 0 ]; then
@@ -241,7 +241,7 @@ HealthSMART_monitor() {
             fi
 
             # Check drive temperature(s)
-            if [ "${OCF_RESKEY_devices}" ]; then
+            if [ -n "${OCF_RESKEY_devices}" ]; then
                 for DEVICE in ${OCF_RESKEY_devices}; do
                     check_temperature "$("$SMARTCTL" -d "$DEVICE" -A "${DRIVE}" | awk '/^194/ { print $10 }')"
                     if [ $? -ne 0 ]; then
@@ -271,7 +271,7 @@ HealthSMART_validate() {
     # Is the state directory writable?
     state_dir=$(dirname "$OCF_RESKEY_state")
     touch "$state_dir/$$"
-    if [ $? != 0 ]; then
+    if [ $? -ne 0 ]; then
         return $OCF_ERR_ARGS
     fi
     rm "$state_dir/$$"
@@ -282,7 +282,7 @@ HealthSMART_validate() {
 : ${OCF_RESKEY_CRM_meta_interval:=0}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="true"}
 
-if [ "x$OCF_RESKEY_state" = "x" ]; then
+if [ -z "$OCF_RESKEY_state" ]; then
     if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
         state="${HA_VARRUN%%/}/HealthSMART-${OCF_RESOURCE_INSTANCE}.state"
 

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -313,3 +313,5 @@ esac
 rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
 exit $rc
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -19,9 +19,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 #
 SMARTCTL=/usr/sbin/smartctl
 ATTRDUP=/usr/sbin/attrd_updater
@@ -110,25 +110,25 @@ check_temperature() {
 
     if [ $1 -lt ${lower_red_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} too cold: ${1} C"
-        $ATTRDUP -n "#health-smart" -U "red" -d "5s"
+        "$ATTRDUP" -n "#health-smart" -U "red" -d "5s"
         return 1
     fi
 
     if [ $1 -gt ${upper_red_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} too hot: ${1} C"
-        $ATTRDUP -n "#health-smart" -U "red" -d "5s"
+        "$ATTRDUP" -n "#health-smart" -U "red" -d "5s"
         return 1
     fi
 
     if [ $1 -lt ${lower_yellow_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} quite cold: ${1} C"
-        $ATTRDUP -n "#health-smart" -U "yellow" -d "5s"
+        "$ATTRDUP" -n "#health-smart" -U "yellow" -d "5s"
         return 1
     fi
 
     if [ $1 -gt ${upper_yellow_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} quite hot: ${1} C"
-        $ATTRDUP -n "#health-smart" -U "yellow" -d "5s"
+        "$ATTRDUP" -n "#health-smart" -U "yellow" -d "5s"
         return 1
     fi
 }
@@ -136,20 +136,20 @@ check_temperature() {
 
 init_smart() {
     #Set temperature defaults
-    if [ -z ${OCF_RESKEY_temp_warning} ]; then
+    if [ -z "${OCF_RESKEY_temp_warning}" ]; then
         yellow_threshold=5
     else
         yellow_threshold=${OCF_RESKEY_temp_warning}
     fi
 
-    if [ -z ${OCF_RESKEY_temp_lower_limit} ] ; then
+    if [ -z "${OCF_RESKEY_temp_lower_limit}" ] ; then
         lower_red_limit=0
     else
         lower_red_limit=${OCF_RESKEY_temp_lower_limit}
     fi
     lower_yellow_limit=$((${lower_red_limit}+${yellow_threshold}))
 
-    if [ -z ${OCF_RESKEY_temp_upper_limit} ] ; then
+    if [ -z "${OCF_RESKEY_temp_upper_limit}" ] ; then
         upper_red_limit=60
     else
         upper_red_limit=${OCF_RESKEY_temp_upper_limit}
@@ -164,7 +164,7 @@ init_smart() {
     fi
 
     #Test for presence of smartctl
-    if [ ! -x $SMARTCTL ] ; then
+    if [ ! -x "$SMARTCTL" ] ; then
         ocf_log err "${SMARTCTL} not installed."
         exit $OCF_ERR_INSTALLED
     fi
@@ -172,15 +172,15 @@ init_smart() {
     for DRIVE in $DRIVES; do
         if [ "${OCF_RESKEY_devices}" ]; then
             for DEVICE in ${OCF_RESKEY_devices}; do
-                $SMARTCTL -d $DEVICE -i ${DRIVE} | grep -q "SMART support is: Enabled"
-                if [ $? -ne "0" ] ; then
+                "$SMARTCTL" -d "$DEVICE" -i "${DRIVE}" | grep -q "SMART support is: Enabled"
+                if [ $? -ne 0 ] ; then
                     ocf_log err "S.M.A.R.T. not enabled for drive "${DRIVE}
                     exit $OCF_ERR_INSTALLED
                 fi
             done
         else
-            $SMARTCTL -i ${DRIVE} | grep -q "SMART support is: Enabled"
-            if [ $? -ne "0" ] ; then
+            "$SMARTCTL" -i "${DRIVE}" | grep -q "SMART support is: Enabled"
+            if [ $? -ne 0 ] ; then
                 ocf_log err "S.M.A.R.T. not enabled for drive "${DRIVE}
                 exit $OCF_ERR_INSTALLED
             fi
@@ -201,13 +201,13 @@ HealthSMART_start() {
     if [ $? =  $OCF_SUCCESS ]; then
         return $OCF_SUCCESS
     fi
-    touch ${OCF_RESKEY_state}
+    touch "${OCF_RESKEY_state}"
 }
 
 HealthSMART_stop() {
     HealthSMART_monitor
     if [ $? =  $OCF_SUCCESS ]; then
-        rm ${OCF_RESKEY_state}
+        rm "${OCF_RESKEY_state}"
     fi
     return $OCF_SUCCESS
 }
@@ -220,22 +220,22 @@ HealthSMART_monitor() {
     # (SUCCESS), failed (ERROR) or _cleanly_ stopped (NOT RUNNING).
     # That is THREE states, not just yes/no.
 
-    if [ -f ${OCF_RESKEY_state} ]; then
+    if [ -f "${OCF_RESKEY_state}" ]; then
 
         # Check overall S.M.A.R.T. status
         for DRIVE in $DRIVES; do
             if [ "${OCF_RESKEY_devices}" ]; then
                 for DEVICE in ${OCF_RESKEY_devices}; do
-                    $SMARTCTL -d $DEVICE -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
-                    if [ $? -ne "0" ]; then
-                        $ATTRDUP -n "#health-smart" -U "red" -d "5s"
+                    "$SMARTCTL" -d "$DEVICE" -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
+                    if [ $? -ne 0 ]; then
+                        "$ATTRDUP" -n "#health-smart" -U "red" -d "5s"
                         return $OCF_SUCCESS
                     fi
                 done
             else
-                $SMARTCTL -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
-                if [ $? -ne "0" ]; then
-                    $ATTRDUP -n "#health-smart" -U "red" -d "5s"
+                "$SMARTCTL" -H "${DRIVE}" | grep -q "SMART overall-health self-assessment test result: PASSED"
+                if [ $? -ne 0 ]; then
+                    "$ATTRDUP" -n "#health-smart" -U "red" -d "5s"
                     return $OCF_SUCCESS
                 fi
             fi
@@ -256,7 +256,7 @@ HealthSMART_monitor() {
             fi
         done
 
-        $ATTRDUP -n "#health-smart" -U "green" -d "5s"
+        "$ATTRDUP" -n "#health-smart" -U "green" -d "5s"
         return $OCF_SUCCESS
     fi
 
@@ -283,7 +283,7 @@ HealthSMART_validate() {
 : ${OCF_RESKEY_CRM_meta_globally_unique:="true"}
 
 if [ "x$OCF_RESKEY_state" = "x" ]; then
-    if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
+    if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
         state="${HA_VARRUN%%/}/HealthSMART-${OCF_RESOURCE_INSTANCE}.state"
 
         # Strip off the trailing clone marker
@@ -293,7 +293,7 @@ if [ "x$OCF_RESKEY_state" = "x" ]; then
     fi
 fi
 
-case $__OCF_ACTION in
+case "$__OCF_ACTION" in
     start)        HealthSMART_start;;
     stop)         HealthSMART_stop;;
     monitor)      HealthSMART_monitor;;

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -131,7 +131,7 @@ stateful_start() {
 }
 
 stateful_demote() {
-    stateful_check_state 
+    stateful_check_state
     if [ $? = 0 ]; then
         # CRM Error - Should never happen
         return $OCF_NOT_RUNNING
@@ -142,7 +142,7 @@ stateful_demote() {
 }
 
 stateful_promote() {
-    stateful_check_state 
+    stateful_check_state
     if [ $? = 0 ]; then
         return $OCF_NOT_RUNNING
     fi
@@ -212,10 +212,10 @@ stateful_validate() {
 if [ "x$OCF_RESKEY_state" = "x" ]; then
     if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
         state="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state"
-        
+
         # Strip off the trailing clone marker
         OCF_RESKEY_state=`echo $state | sed s/:[0-9][0-9]*\.state/.state/`
-    else 
+    else
         OCF_RESKEY_state="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state"
     fi
 fi

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -97,12 +97,12 @@ stateful_check_state() {
     target="$1"
     if [ -f "${OCF_RESKEY_state}" ]; then
         state=$(cat "${OCF_RESKEY_state}")
-        if [ "x$target" = "x$state" ]; then
+        if [ "$target" = "$state" ]; then
             return 0
         fi
 
     else
-        if [ "x$target" = "x" ]; then
+        if [ -z "$target" ]; then
             return 0
         fi
     fi
@@ -124,7 +124,7 @@ set_master_score() {
 
 stateful_start() {
     stateful_check_state master
-    if [ $? = 0 ]; then
+    if [ $? -eq 0 ]; then
         # CRM Error - Should never happen
         return $OCF_RUNNING_MASTER
     fi
@@ -135,7 +135,7 @@ stateful_start() {
 
 stateful_demote() {
     stateful_check_state
-    if [ $? = 0 ]; then
+    if [ $? -eq 0 ]; then
         # CRM Error - Should never happen
         return $OCF_NOT_RUNNING
     fi
@@ -146,7 +146,7 @@ stateful_demote() {
 
 stateful_promote() {
     stateful_check_state
-    if [ $? = 0 ]; then
+    if [ $? -eq 0 ]; then
         return $OCF_NOT_RUNNING
     fi
     stateful_update master
@@ -157,7 +157,7 @@ stateful_promote() {
 stateful_stop() {
     "${HA_SBIN_DIR}/crm_master" -l reboot -D
     stateful_check_state master
-    if [ $? = 0 ]; then
+    if [ $? -eq 0 ]; then
         # CRM Error - Should never happen
         return $OCF_RUNNING_MASTER
     fi
@@ -169,8 +169,8 @@ stateful_stop() {
 
 stateful_monitor() {
     stateful_check_state "master"
-    if [ $? = 0 ]; then
-        if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
+    if [ $? -eq 0 ]; then
+        if [ $OCF_RESKEY_CRM_meta_interval -eq 0 ]; then
             # Restore the master setting during probes
             set_master_score "${master_score}"
         fi
@@ -178,8 +178,8 @@ stateful_monitor() {
     fi
 
     stateful_check_state "slave"
-    if [ $? = 0 ]; then
-        if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
+    if [ $? -eq 0 ]; then
+        if [ $OCF_RESKEY_CRM_meta_interval -eq 0 ]; then
             # Restore the master setting during probes
             set_master_score "${slave_score}"
         fi
@@ -212,7 +212,7 @@ stateful_validate() {
 : ${OCF_RESKEY_notify_delay:=0}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
-if [ "x$OCF_RESKEY_state" = "x" ]; then
+if [ -z "$OCF_RESKEY_state" ]; then
     if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
         state="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state"
 

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -17,10 +17,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
-CRM_MASTER="${HA_SBIN_DIR}/crm_master -l reboot"
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 #######################################################################
 
@@ -91,13 +90,13 @@ END
 }
 
 stateful_update() {
-    echo $1 > ${OCF_RESKEY_state}
+    echo $1 > "${OCF_RESKEY_state}"
 }
 
 stateful_check_state() {
-    target=$1
-    if [ -f ${OCF_RESKEY_state} ]; then
-        state=`cat ${OCF_RESKEY_state}`
+    target="$1"
+    if [ -f "${OCF_RESKEY_state}" ]; then
+        state=`cat "${OCF_RESKEY_state}"`
         if [ "x$target" = "x$state" ]; then
             return 0
         fi
@@ -119,6 +118,10 @@ $(env | sort)
     fi
 }
 
+set_master_score() {
+    "${HA_SBIN_DIR}/crm_master" -l reboot -v "$1"
+}
+
 stateful_start() {
     stateful_check_state master
     if [ $? = 0 ]; then
@@ -126,7 +129,7 @@ stateful_start() {
         return $OCF_RUNNING_MASTER
     fi
     stateful_update slave
-    $CRM_MASTER -v ${slave_score}
+    set_master_score "${slave_score}"
     return 0
 }
 
@@ -137,7 +140,7 @@ stateful_demote() {
         return $OCF_NOT_RUNNING
     fi
     stateful_update slave
-    $CRM_MASTER -v ${slave_score}
+    set_master_score "${slave_score}"
     return 0
 }
 
@@ -147,19 +150,19 @@ stateful_promote() {
         return $OCF_NOT_RUNNING
     fi
     stateful_update master
-    $CRM_MASTER -v ${master_score}
+    set_master_score "${master_score}"
     return 0
 }
 
 stateful_stop() {
-    $CRM_MASTER -D
+    "${HA_SBIN_DIR}/crm_master" -l reboot -D
     stateful_check_state master
     if [ $? = 0 ]; then
         # CRM Error - Should never happen
         return $OCF_RUNNING_MASTER
     fi
-    if [ -f ${OCF_RESKEY_state} ]; then
-        rm ${OCF_RESKEY_state}
+    if [ -f "${OCF_RESKEY_state}" ]; then
+        rm "${OCF_RESKEY_state}"
     fi
     return 0
 }
@@ -169,7 +172,7 @@ stateful_monitor() {
     if [ $? = 0 ]; then
         if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
             # Restore the master setting during probes
-            $CRM_MASTER -v ${master_score}
+            set_master_score "${master_score}"
         fi
         return $OCF_RUNNING_MASTER
     fi
@@ -178,14 +181,14 @@ stateful_monitor() {
     if [ $? = 0 ]; then
         if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
             # Restore the master setting during probes
-            $CRM_MASTER -v ${slave_score}
+            set_master_score "${slave_score}"
         fi
         return $OCF_SUCCESS
     fi
 
-    if [ -f ${OCF_RESKEY_state} ]; then
+    if [ -f "${OCF_RESKEY_state}" ]; then
         echo "File '${OCF_RESKEY_state}' exists but contains unexpected contents"
-        cat ${OCF_RESKEY_state}
+        cat "${OCF_RESKEY_state}"
         return $OCF_ERR_GENERIC
     fi
     return 7
@@ -210,7 +213,7 @@ stateful_validate() {
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
 if [ "x$OCF_RESKEY_state" = "x" ]; then
-    if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
+    if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
         state="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state"
 
         # Strip off the trailing clone marker
@@ -222,7 +225,7 @@ fi
 
 dump_env
 
-case $__OCF_ACTION in
+case "$__OCF_ACTION" in
 meta-data)      meta_data;;
 start)          stateful_start;;
 promote)        stateful_promote;;

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -2,7 +2,7 @@
 #
 # ocf:pacemaker:Stateful resource agent
 #
-# Copyright 2006-2018 the Pacemaker project contributors
+# Copyright 2006-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -25,7 +25,7 @@ CRM_MASTER="${HA_SBIN_DIR}/crm_master -l reboot"
 #######################################################################
 
 meta_data() {
-	cat <<END
+    cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
 <resource-agent name="Stateful" version="1.1">
@@ -76,36 +76,36 @@ to simulate a long-running notify.
 </actions>
 </resource-agent>
 END
-	exit $OCF_SUCCESS
+    exit $OCF_SUCCESS
 }
 
 #######################################################################
 
 stateful_usage() {
-	cat <<END
+    cat <<END
 usage: $0 {start|stop|promote|demote|monitor|validate-all|meta-data}
 
 Expects to have a fully populated OCF RA-compliant environment set.
 END
-	exit $1
+    exit $1
 }
 
 stateful_update() {
-	echo $1 > ${OCF_RESKEY_state}
+    echo $1 > ${OCF_RESKEY_state}
 }
 
 stateful_check_state() {
     target=$1
     if [ -f ${OCF_RESKEY_state} ]; then
-	state=`cat ${OCF_RESKEY_state}`
-	if [ "x$target" = "x$state" ]; then
-	    return 0
-	fi
+        state=`cat ${OCF_RESKEY_state}`
+        if [ "x$target" = "x$state" ]; then
+            return 0
+        fi
 
     else
-	if [ "x$target" = "x" ]; then
-	    return 0
-	fi
+        if [ "x$target" = "x" ]; then
+            return 0
+        fi
     fi
 
     return 1
@@ -122,8 +122,8 @@ $(env | sort)
 stateful_start() {
     stateful_check_state master
     if [ $? = 0 ]; then
-       	# CRM Error - Should never happen
-	return $OCF_RUNNING_MASTER
+        # CRM Error - Should never happen
+        return $OCF_RUNNING_MASTER
     fi
     stateful_update slave
     $CRM_MASTER -v ${slave_score}
@@ -133,8 +133,8 @@ stateful_start() {
 stateful_demote() {
     stateful_check_state 
     if [ $? = 0 ]; then
-       	# CRM Error - Should never happen
-	return $OCF_NOT_RUNNING
+        # CRM Error - Should never happen
+        return $OCF_NOT_RUNNING
     fi
     stateful_update slave
     $CRM_MASTER -v ${slave_score}
@@ -144,7 +144,7 @@ stateful_demote() {
 stateful_promote() {
     stateful_check_state 
     if [ $? = 0 ]; then
-	return $OCF_NOT_RUNNING
+        return $OCF_NOT_RUNNING
     fi
     stateful_update master
     $CRM_MASTER -v ${master_score}
@@ -155,11 +155,11 @@ stateful_stop() {
     $CRM_MASTER -D
     stateful_check_state master
     if [ $? = 0 ]; then
-       	# CRM Error - Should never happen
-	return $OCF_RUNNING_MASTER
+        # CRM Error - Should never happen
+        return $OCF_RUNNING_MASTER
     fi
     if [ -f ${OCF_RESKEY_state} ]; then
-	rm ${OCF_RESKEY_state}
+        rm ${OCF_RESKEY_state}
     fi
     return 0
 }
@@ -167,26 +167,26 @@ stateful_stop() {
 stateful_monitor() {
     stateful_check_state "master"
     if [ $? = 0 ]; then
-	if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
-	    # Restore the master setting during probes
-	    $CRM_MASTER -v ${master_score}
-	fi
-	return $OCF_RUNNING_MASTER
+        if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
+            # Restore the master setting during probes
+            $CRM_MASTER -v ${master_score}
+        fi
+        return $OCF_RUNNING_MASTER
     fi
 
     stateful_check_state "slave"
     if [ $? = 0 ]; then
-	if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
-	    # Restore the master setting during probes
-	    $CRM_MASTER -v ${slave_score}
-	fi
-	return $OCF_SUCCESS
+        if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
+            # Restore the master setting during probes
+            $CRM_MASTER -v ${slave_score}
+        fi
+        return $OCF_SUCCESS
     fi
 
     if [ -f ${OCF_RESKEY_state} ]; then
-	echo "File '${OCF_RESKEY_state}' exists but contains unexpected contents"
-	cat ${OCF_RESKEY_state}
-	return $OCF_ERR_GENERIC
+        echo "File '${OCF_RESKEY_state}' exists but contains unexpected contents"
+        cat ${OCF_RESKEY_state}
+        return $OCF_ERR_GENERIC
     fi
     return 7
 }
@@ -199,7 +199,7 @@ stateful_notify() {
 }
 
 stateful_validate() {
-	exit $OCF_SUCCESS
+    exit $OCF_SUCCESS
 }
 
 : ${slave_score=5}
@@ -211,28 +211,28 @@ stateful_validate() {
 
 if [ "x$OCF_RESKEY_state" = "x" ]; then
     if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
-	state="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state"
-	
-	# Strip off the trailing clone marker
-	OCF_RESKEY_state=`echo $state | sed s/:[0-9][0-9]*\.state/.state/`
+        state="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state"
+        
+        # Strip off the trailing clone marker
+        OCF_RESKEY_state=`echo $state | sed s/:[0-9][0-9]*\.state/.state/`
     else 
-	OCF_RESKEY_state="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state"
+        OCF_RESKEY_state="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state"
     fi
 fi
 
 dump_env
 
 case $__OCF_ACTION in
-meta-data)	meta_data;;
-start)		stateful_start;;
-promote)	stateful_promote;;
-demote)		stateful_demote;;
+meta-data)      meta_data;;
+start)          stateful_start;;
+promote)        stateful_promote;;
+demote)         stateful_demote;;
 notify)         stateful_notify ;;
-stop)		stateful_stop;;
-monitor)	stateful_monitor;;
-validate-all)	stateful_validate;;
-usage|help)	stateful_usage $OCF_SUCCESS;;
-*)		stateful_usage $OCF_ERR_UNIMPLEMENTED;;
+stop)           stateful_stop;;
+monitor)        stateful_monitor;;
+validate-all)   stateful_validate;;
+usage|help)     stateful_usage $OCF_SUCCESS;;
+*)              stateful_usage $OCF_ERR_UNIMPLEMENTED;;
 esac
 
 exit $?

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -1,12 +1,17 @@
 #!/bin/sh
 #
-# Example of a stateful OCF Resource Agent
+# ocf:pacemaker:Stateful resource agent
+#
 # Copyright 2006-2018 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
+#
+
+#
+# Example of a stateful OCF Resource Agent
 #
 
 #######################################################################

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -236,3 +236,5 @@ usage|help)     stateful_usage $OCF_SUCCESS;;
 esac
 
 exit $?
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -67,8 +67,10 @@ to simulate a long-running notify.
 <actions>
 <action name="start"   timeout="20s" />
 <action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="10s" role="Master"/>
-<action name="monitor" depth="0"  timeout="20s" interval="10s" role="Slave"/>
+<action name="monitor" depth="0" timeout="20s" interval="10s" role="Master"/>
+<action name="monitor" depth="0" timeout="20s" interval="11s" role="Slave"/>
+<action name="promote" timeout="10s" />
+<action name="demote"  timeout="10s" />
 <action name="notify"  timeout="5s" />
 <action name="meta-data"  timeout="5s" />
 <action name="validate-all"  timeout="30s" />

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -17,9 +17,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 CRM_MASTER="${HA_SBIN_DIR}/crm_master -l reboot"
 
 #######################################################################
@@ -202,11 +202,11 @@ stateful_validate() {
     exit $OCF_SUCCESS
 }
 
-: ${slave_score=5}
-: ${master_score=10}
+: ${slave_score:=5}
+: ${master_score:=10}
 
-: ${OCF_RESKEY_CRM_meta_interval=0}
-: ${OCF_RESKEY_notify_delay=0}
+: ${OCF_RESKEY_CRM_meta_interval:=0}
+: ${OCF_RESKEY_notify_delay:=0}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
 if [ "x$OCF_RESKEY_state" = "x" ]; then

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -96,7 +96,7 @@ stateful_update() {
 stateful_check_state() {
     target="$1"
     if [ -f "${OCF_RESKEY_state}" ]; then
-        state=`cat "${OCF_RESKEY_state}"`
+        state=$(cat "${OCF_RESKEY_state}")
         if [ "x$target" = "x$state" ]; then
             return 0
         fi
@@ -217,7 +217,7 @@ if [ "x$OCF_RESKEY_state" = "x" ]; then
         state="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state"
 
         # Strip off the trailing clone marker
-        OCF_RESKEY_state=`echo $state | sed s/:[0-9][0-9]*\.state/.state/`
+        OCF_RESKEY_state=$(echo $state | sed s/:[0-9][0-9]*\.state/.state/)
     else
         OCF_RESKEY_state="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state"
     fi

--- a/extra/resources/SysInfo.in
+++ b/extra/resources/SysInfo.in
@@ -146,52 +146,52 @@ UpdateStat() {
 
 SysInfoStats() {
 
-    UpdateStat arch "`uname -m`"
-    UpdateStat os "`uname -s`-`uname -r`"
+    UpdateStat arch "$(uname -m)"
+    UpdateStat os "$(uname -s)-$(uname -r)"
 
-    case `uname -s` in
+    case $(uname -s) in
         "Darwin")
-            mem=`top -l 1 | grep Mem: | awk '{print $10}'`
-            mem_used=`top -l 1 | grep Mem: | awk '{print $8}'`
-            mem=`SysInfo_mem_units "$mem"`
-            mem_used=`SysInfo_mem_units "$mem_used"`
-            mem_total=`expr $mem_used + $mem`
-            cpu_type=`system_profiler SPHardwareDataType | awk -F': ' '/^CPU Type/ {print $2; exit}'`
-            cpu_speed=`system_profiler SPHardwareDataType | awk -F': ' '/^CPU Speed/ {print $2; exit}'`
-            cpu_cores=`system_profiler SPHardwareDataType | awk -F': ' '/^Number Of/ {print $2; exit}'`
-            cpu_load=`uptime | awk '{ print $10 }'`
+            mem=$(top -l 1 | grep Mem: | awk '{print $10}')
+            mem_used=$(top -l 1 | grep Mem: | awk '{print $8}')
+            mem=$(SysInfo_mem_units "$mem")
+            mem_used=$(SysInfo_mem_units "$mem_used")
+            mem_total=$(expr $mem_used + $mem)
+            cpu_type=$(system_profiler SPHardwareDataType | awk -F': ' '/^CPU Type/ {print $2; exit}')
+            cpu_speed=$(system_profiler SPHardwareDataType | awk -F': ' '/^CPU Speed/ {print $2; exit}')
+            cpu_cores=$(system_profiler SPHardwareDataType | awk -F': ' '/^Number Of/ {print $2; exit}')
+            cpu_load=$(uptime | awk '{ print $10 }')
         ;;
         "FreeBSD")
-            cpu_type=`sysctl -in hw.model`
-            cpu_speed=`sysctl -in dev.cpu.0.freq`
-            cpu_cores=`sysctl -in hw.ncpu`
-            cpu_load=`sysctl -in vm.loadavg | awk '{ print $4 }'`
+            cpu_type=$(sysctl -in hw.model)
+            cpu_speed=$(sysctl -in dev.cpu.0.freq)
+            cpu_cores=$(sysctl -in hw.ncpu)
+            cpu_load=$(sysctl -in vm.loadavg | awk '{ print $4 }')
 
-            free_pages=`sysctl -in vm.stats.vm.v_free_count`
-            page_count=`sysctl -in vm.stats.vm.v_page_count`
-            page_size=`sysctl -in vm.stats.vm.v_page_size`
+            free_pages=$(sysctl -in vm.stats.vm.v_free_count)
+            page_count=$(sysctl -in vm.stats.vm.v_page_count)
+            page_size=$(sysctl -in vm.stats.vm.v_page_size)
 
-            mem=`expr $free_pages \* $page_size / 1024 / 1024`M
-            mem_total=`expr $page_count \* $page_size / 1024 / 1024`M
+            mem=$(expr $free_pages \* $page_size / 1024 / 1024)M
+            mem_total=$(expr $page_count \* $page_size / 1024 / 1024)M
         ;;
         "Linux")
             if [ -f /proc/cpuinfo ]; then
-                cpu_type=`awk -F': ' '/model name/ {print $2; exit}' /proc/cpuinfo`
-                cpu_speed=`awk -F': ' '/bogomips/ {print $2; exit}' /proc/cpuinfo`
-                cpu_cores=`grep "^processor" /proc/cpuinfo | wc -l`
+                cpu_type=$(awk -F': ' '/model name/ {print $2; exit}' /proc/cpuinfo)
+                cpu_speed=$(awk -F': ' '/bogomips/ {print $2; exit}' /proc/cpuinfo)
+                cpu_cores=$(grep "^processor" /proc/cpuinfo | wc -l)
             fi
-            cpu_load=`uptime | awk '{ print $10 }'`
+            cpu_load=$(uptime | awk '{ print $10 }')
 
             if [ -f /proc/meminfo ]; then
                 # meminfo results are in kB
-                mem=`grep "SwapFree" /proc/meminfo | awk '{print $2"k"}'`
+                mem=$(grep "SwapFree" /proc/meminfo | awk '{print $2"k"}')
                 if [ ! -z "$mem" ]; then
                     UpdateStat free_swap "$(SysInfo_mem_units "$mem")"
                 fi
-                mem=`grep "Inactive" /proc/meminfo | awk '{print $2"k"}'`
-                mem_total=`grep "MemTotal" /proc/meminfo | awk '{print $2"k"}'`
+                mem=$(grep "Inactive" /proc/meminfo | awk '{print $2"k"}')
+                mem_total=$(grep "MemTotal" /proc/meminfo | awk '{print $2"k"}')
             else
-                mem=`top -n 1 | grep Mem: | awk '{print $7}'`
+                mem=$(top -n 1 | grep Mem: | awk '{print $7}')
             fi
             ;;
         *)
@@ -224,10 +224,10 @@ SysInfoStats() {
     #     'tail -n <c>' to the equivalent 'tail -<c>'.
     for disk in "/" ${OCF_RESKEY_disks}; do
         unset disk_free disk_label
-        disk_free=`df -h "${disk}" | tail -1 | awk '{print $4}'`
+        disk_free=$(df -h "${disk}" | tail -1 | awk '{print $4}')
         if [ x != x"$disk_free" ]; then
-            disk_label=`echo $disk | sed -e 's#^/$#root#;s#^/*##;s#/#_#g'`
-            disk_free=`SysInfo_hdd_units "$disk_free"`
+            disk_label=$(echo $disk | sed -e 's#^/$#root#;s#^/*##;s#/#_#g')
+            disk_free=$(SysInfo_hdd_units "$disk_free")
             UpdateStat "${disk_label}_free" $disk_free
             if [ -n "$MIN_FREE" ]; then
                 if [ $disk_free -le $MIN_FREE ]; then
@@ -305,7 +305,7 @@ SysInfo_stop() {
 
 SysInfo_monitor() {
     if [ -f "$OCF_RESKEY_pidfile" ]; then
-        clone=`cat "$OCF_RESKEY_pidfile"`
+        clone=$(cat "$OCF_RESKEY_pidfile")
     fi
 
     if [ "x$clone" = "x" ]; then
@@ -344,7 +344,7 @@ MIN_FREE=""
 if [ -n "$OCF_RESKEY_min_disk_free" ]; then
     ocf_is_decimal "$OCF_RESKEY_min_disk_free" &&
         OCF_RESKEY_min_disk_free="$OCF_RESKEY_min_disk_free$OCF_RESKEY_disk_unit"
-    MIN_FREE=`SysInfo_hdd_units $OCF_RESKEY_min_disk_free`
+    MIN_FREE=$(SysInfo_hdd_units $OCF_RESKEY_min_disk_free)
 fi
 
 case "$__OCF_ACTION" in

--- a/extra/resources/SysInfo.in
+++ b/extra/resources/SysInfo.in
@@ -1,30 +1,18 @@
 #!@BASH_PATH@
 #
+# ocf:pacemaker:SysInfo resource agent
 #
-#	SysInfo OCF Resource Agent
-#	It records (in the CIB) various attributes of a node
+# Original copyright 2004 SUSE LINUX AG, Lars Marowsky-Br<E9>e
+# Later changes copyright 2008-2018 the Pacemaker project contributors
 #
-# Copyright 2004-2018 SUSE LINUX AG, Lars Marowsky-Brée
-#                    All Rights Reserved.
+# The version control history for this file may have further details.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of version 2 of the GNU General Public License as
-# published by the Free Software Foundation.
+# This source code is licensed under the GNU General Public License version 2
+# (GPLv2) WITHOUT ANY WARRANTY.
 #
-# This program is distributed in the hope that it would be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
 #
-# Further, this software is distributed without any warranty that it is
-# free of the rightful claim of any third person regarding infringement
-# or the like.  Any license provided herein, whether implied or
-# otherwise, applies only to this software file.  Patent licenses, if
-# any, provided herein do not apply to combinations of this program with
-# other software, or any other product whatsoever.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write the Free Software Foundation,
-# Inc., 59 Temple Place - Suite 330, Boston MA 02111-1307, USA.
+#	This agent records (in the CIB) various attributes of a node
 #
 #######################################################################
 # Initialization:

--- a/extra/resources/SysInfo.in
+++ b/extra/resources/SysInfo.in
@@ -139,7 +139,7 @@ UpdateStat() {
     printf "%s:\t%s\n" "$name" "$value"
     if [ "$__OCF_ACTION" = "start" ] ; then
         ${HA_SBIN_DIR}/attrd_updater ${OCF_RESKEY_delay} -S status -n $name -B "$value"
-    else 
+    else
         ${HA_SBIN_DIR}/attrd_updater ${OCF_RESKEY_delay} -S status -n $name -v "$value"
     fi
 }
@@ -254,7 +254,7 @@ SysInfo_megabytes() {
 SysInfo_mem_units() {
     mem=$1
 
-    if [ -z $1 ]; then 
+    if [ -z $1 ]; then
         return
     fi
 
@@ -265,20 +265,20 @@ SysInfo_mem_units() {
         mem=$(($mem + 50 - $r))
     fi
 
-    echo $mem    
+    echo $mem
 }
 
 SysInfo_hdd_units() {
     # Defauts to size in gigabytes
 
-    case $OCF_RESKEY_disk_unit in 
+    case $OCF_RESKEY_disk_unit in
         [Pp]) echo $(($(SysInfo_megabytes "$1") / 1024 / 1024 / 1024));;
         [Tt]) echo $(($(SysInfo_megabytes "$1") / 1024 / 1024));;
         [Gg]) echo $(($(SysInfo_megabytes "$1") / 1024));;
         [Mm]) echo "$(SysInfo_megabytes "$1")" ;;
         [Kk]) echo $(($(SysInfo_megabytes "$1") * 1024));;
         [Bb]) echo $(($(SysInfo_megabytes "$1") * 1024 * 1024));;
-        *) 
+        *)
             ocf_log err "Invalid value for disk_unit: $OCF_RESKEY_disk_unit"
             echo $(($(SysInfo_megabytes "$1") / 1024));;
     esac
@@ -337,7 +337,7 @@ fi
 : ${OCF_RESKEY_clone:="0"}
 if [ x != x${OCF_RESKEY_delay} ]; then
     OCF_RESKEY_delay="-d ${OCF_RESKEY_delay}"
-else 
+else
     OCF_RESKEY_delay="-d 0"
 fi
 MIN_FREE=""

--- a/extra/resources/SysInfo.in
+++ b/extra/resources/SysInfo.in
@@ -3,7 +3,7 @@
 # ocf:pacemaker:SysInfo resource agent
 #
 # Original copyright 2004 SUSE LINUX AG, Lars Marowsky-Br<E9>e
-# Later changes copyright 2008-2018 the Pacemaker project contributors
+# Later changes copyright 2008-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -12,7 +12,7 @@
 #
 
 #
-#	This agent records (in the CIB) various attributes of a node
+# This agent records (in the CIB) various attributes of a node
 #
 #######################################################################
 # Initialization:
@@ -24,7 +24,7 @@
 #######################################################################
 
 meta_data() {
-	cat <<END
+    cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
 <resource-agent name="SysInfo" version="1.0">
@@ -150,101 +150,101 @@ SysInfoStats() {
     UpdateStat os "`uname -s`-`uname -r`"
 
     case `uname -s` in
-	"Darwin")
-	    mem=`top -l 1 | grep Mem: | awk '{print $10}'`
-	    mem_used=`top -l 1 | grep Mem: | awk '{print $8}'`
-	    mem=`SysInfo_mem_units $mem`
-	    mem_used=`SysInfo_mem_units $mem_used`
-	    mem_total=`expr $mem_used + $mem`
-	    cpu_type=`system_profiler SPHardwareDataType | awk -F': ' '/^CPU Type/ {print $2; exit}'`
-	    cpu_speed=`system_profiler SPHardwareDataType | awk -F': ' '/^CPU Speed/ {print $2; exit}'`
-	    cpu_cores=`system_profiler SPHardwareDataType | awk -F': ' '/^Number Of/ {print $2; exit}'`
-	    cpu_load=`uptime | awk '{ print $10 }'`
-	;;
-	"FreeBSD")
-	    cpu_type=`sysctl -in hw.model`
-	    cpu_speed=`sysctl -in dev.cpu.0.freq`
-	    cpu_cores=`sysctl -in hw.ncpu`
-	    cpu_load=`sysctl -in vm.loadavg | awk '{ print $4 }'`
+        "Darwin")
+            mem=`top -l 1 | grep Mem: | awk '{print $10}'`
+            mem_used=`top -l 1 | grep Mem: | awk '{print $8}'`
+            mem=`SysInfo_mem_units $mem`
+            mem_used=`SysInfo_mem_units $mem_used`
+            mem_total=`expr $mem_used + $mem`
+            cpu_type=`system_profiler SPHardwareDataType | awk -F': ' '/^CPU Type/ {print $2; exit}'`
+            cpu_speed=`system_profiler SPHardwareDataType | awk -F': ' '/^CPU Speed/ {print $2; exit}'`
+            cpu_cores=`system_profiler SPHardwareDataType | awk -F': ' '/^Number Of/ {print $2; exit}'`
+            cpu_load=`uptime | awk '{ print $10 }'`
+        ;;
+        "FreeBSD")
+            cpu_type=`sysctl -in hw.model`
+            cpu_speed=`sysctl -in dev.cpu.0.freq`
+            cpu_cores=`sysctl -in hw.ncpu`
+            cpu_load=`sysctl -in vm.loadavg | awk '{ print $4 }'`
 
-	    free_pages=`sysctl -in vm.stats.vm.v_free_count`
-	    page_count=`sysctl -in vm.stats.vm.v_page_count`
-	    page_size=`sysctl -in vm.stats.vm.v_page_size`
+            free_pages=`sysctl -in vm.stats.vm.v_free_count`
+            page_count=`sysctl -in vm.stats.vm.v_page_count`
+            page_size=`sysctl -in vm.stats.vm.v_page_size`
 
-	    mem=`expr $free_pages \* $page_size / 1024 / 1024`M
-	    mem_total=`expr $page_count \* $page_size / 1024 / 1024`M
-	;;
-	"Linux")
-	    if [ -f /proc/cpuinfo ]; then
-		cpu_type=`awk -F': ' '/model name/ {print $2; exit}' /proc/cpuinfo`
-		cpu_speed=`awk -F': ' '/bogomips/ {print $2; exit}' /proc/cpuinfo`
-		cpu_cores=`grep "^processor" /proc/cpuinfo | wc -l`
-	    fi
-	    cpu_load=`uptime | awk '{ print $10 }'`
+            mem=`expr $free_pages \* $page_size / 1024 / 1024`M
+            mem_total=`expr $page_count \* $page_size / 1024 / 1024`M
+        ;;
+        "Linux")
+            if [ -f /proc/cpuinfo ]; then
+                cpu_type=`awk -F': ' '/model name/ {print $2; exit}' /proc/cpuinfo`
+                cpu_speed=`awk -F': ' '/bogomips/ {print $2; exit}' /proc/cpuinfo`
+                cpu_cores=`grep "^processor" /proc/cpuinfo | wc -l`
+            fi
+            cpu_load=`uptime | awk '{ print $10 }'`
 
-	    if [ -f /proc/meminfo ]; then
-	        # meminfo results are in kB
-		mem=`grep "SwapFree" /proc/meminfo | awk '{print $2"k"}'`
-		if [ ! -z $mem ]; then
-		    UpdateStat free_swap "$(SysInfo_mem_units "$mem")"
-		fi
-		mem=`grep "Inactive" /proc/meminfo | awk '{print $2"k"}'`
-		mem_total=`grep "MemTotal" /proc/meminfo | awk '{print $2"k"}'`
-	    else
-		mem=`top -n 1 | grep Mem: | awk '{print $7}'`
-	    fi
-	    ;;
-	*)
+            if [ -f /proc/meminfo ]; then
+                # meminfo results are in kB
+                mem=`grep "SwapFree" /proc/meminfo | awk '{print $2"k"}'`
+                if [ ! -z $mem ]; then
+                    UpdateStat free_swap "$(SysInfo_mem_units "$mem")"
+                fi
+                mem=`grep "Inactive" /proc/meminfo | awk '{print $2"k"}'`
+                mem_total=`grep "MemTotal" /proc/meminfo | awk '{print $2"k"}'`
+            else
+                mem=`top -n 1 | grep Mem: | awk '{print $7}'`
+            fi
+            ;;
+        *)
     esac
 
     if [ x != x"$cpu_type" ]; then
-	UpdateStat cpu_info "$cpu_type"
+        UpdateStat cpu_info "$cpu_type"
     fi
 
     if [ x != x"$cpu_speed" ]; then
-	UpdateStat cpu_speed "$cpu_speed"
+        UpdateStat cpu_speed "$cpu_speed"
     fi
 
     if [ x != x"$cpu_cores" ]; then
-	UpdateStat cpu_cores "$cpu_cores"
+        UpdateStat cpu_cores "$cpu_cores"
     fi
 
     if [ x != x"$cpu_load" ]; then
-	UpdateStat cpu_load "$cpu_load"
+        UpdateStat cpu_load "$cpu_load"
     fi
 
     if [ ! -z "$mem" ]; then
         # Massage the memory values
- 	UpdateStat ram_total "$(SysInfo_mem_units "$mem_total")"
-	UpdateStat ram_free "$(SysInfo_mem_units "$mem")"
+        UpdateStat ram_total "$(SysInfo_mem_units "$mem_total")"
+        UpdateStat ram_free "$(SysInfo_mem_units "$mem")"
     fi
 
     # Portability notes:
     #   o tail: explicit "-n" not available in Solaris; instead simplify
-    #	  'tail -n <c>' to the equivalent 'tail -<c>'.
+    #     'tail -n <c>' to the equivalent 'tail -<c>'.
     for disk in "/" ${OCF_RESKEY_disks}; do
-	unset disk_free disk_label
-	disk_free=`df -h ${disk} | tail -1 | awk '{print $4}'`
-	if [ x != x"$disk_free" ]; then
-	    disk_label=`echo $disk | sed -e 's#^/$#root#;s#^/*##;s#/#_#g'`
-	    disk_free=`SysInfo_hdd_units $disk_free`
-	    UpdateStat ${disk_label}_free $disk_free
-	    if [ -n "$MIN_FREE" ]; then
-		if [ $disk_free -le $MIN_FREE ]; then
-		    UpdateStat "#health_disk" "red"
-		else
-		    UpdateStat "#health_disk" "green"
-		fi
-	    fi
-	fi
+        unset disk_free disk_label
+        disk_free=`df -h ${disk} | tail -1 | awk '{print $4}'`
+        if [ x != x"$disk_free" ]; then
+            disk_label=`echo $disk | sed -e 's#^/$#root#;s#^/*##;s#/#_#g'`
+            disk_free=`SysInfo_hdd_units $disk_free`
+            UpdateStat ${disk_label}_free $disk_free
+            if [ -n "$MIN_FREE" ]; then
+                if [ $disk_free -le $MIN_FREE ]; then
+                    UpdateStat "#health_disk" "red"
+                else
+                    UpdateStat "#health_disk" "green"
+                fi
+            fi
+        fi
     done
 }
 
 SysInfo_megabytes() {
     # Size in megabytes
     echo $1 | awk '{ n = $0;
-		     sub(/[0-9]+(.[0-9]+)?/, "");
-		     split(n, a, $0);
+                     sub(/[0-9]+(.[0-9]+)?/, "");
+                     split(n, a, $0);
                      n=a[1];
                      if ($0 == "G" || $0 == "") { n *= 1024 };
                      if (/^kB?/) { n /= 1024 };
@@ -255,14 +255,14 @@ SysInfo_mem_units() {
     mem=$1
 
     if [ -z $1 ]; then 
-	return
+        return
     fi
 
     mem=$(SysInfo_megabytes "$1")
     # Round to the next multiple of 50
     r=$(($mem % 50))
     if [ $r != 0 ]; then
-	mem=$(($mem + 50 - $r))
+        mem=$(($mem + 50 - $r))
     fi
 
     echo $mem    
@@ -272,20 +272,20 @@ SysInfo_hdd_units() {
     # Defauts to size in gigabytes
 
     case $OCF_RESKEY_disk_unit in 
-	[Pp]) echo $(($(SysInfo_megabytes "$1") / 1024 / 1024 / 1024));;
-	[Tt]) echo $(($(SysInfo_megabytes "$1") / 1024 / 1024));;
-	[Gg]) echo $(($(SysInfo_megabytes "$1") / 1024));;
-	[Mm]) echo "$(SysInfo_megabytes "$1")" ;;
-	[Kk]) echo $(($(SysInfo_megabytes "$1") * 1024));;
-	[Bb]) echo $(($(SysInfo_megabytes "$1") * 1024 * 1024));;
-	*) 
-	    ocf_log err "Invalid value for disk_unit: $OCF_RESKEY_disk_unit"
-	    echo $(($(SysInfo_megabytes "$1") / 1024));;
+        [Pp]) echo $(($(SysInfo_megabytes "$1") / 1024 / 1024 / 1024));;
+        [Tt]) echo $(($(SysInfo_megabytes "$1") / 1024 / 1024));;
+        [Gg]) echo $(($(SysInfo_megabytes "$1") / 1024));;
+        [Mm]) echo "$(SysInfo_megabytes "$1")" ;;
+        [Kk]) echo $(($(SysInfo_megabytes "$1") * 1024));;
+        [Bb]) echo $(($(SysInfo_megabytes "$1") * 1024 * 1024));;
+        *) 
+            ocf_log err "Invalid value for disk_unit: $OCF_RESKEY_disk_unit"
+            echo $(($(SysInfo_megabytes "$1") / 1024));;
     esac
 }
 
 SysInfo_usage() {
-	cat <<END
+    cat <<END
 usage: $0 {start|stop|monitor|validate-all|meta-data}
 
 Expects to have a fully populated OCF RA-compliant environment set.
@@ -305,20 +305,20 @@ SysInfo_stop() {
 
 SysInfo_monitor() {
     if [ -f $OCF_RESKEY_pidfile ]; then
-	clone=`cat $OCF_RESKEY_pidfile`
+        clone=`cat $OCF_RESKEY_pidfile`
     fi
 
     if [ x$clone = x ]; then
-	rm $OCF_RESKEY_pidfile
-	exit $OCF_NOT_RUNNING
+        rm $OCF_RESKEY_pidfile
+        exit $OCF_NOT_RUNNING
 
     elif [ $clone = $OCF_RESKEY_clone ]; then
-	SysInfoStats
-	exit $OCF_SUCCESS
+        SysInfoStats
+        exit $OCF_SUCCESS
 
     elif ocf_is_true "$OCF_RESKEY_CRM_meta_globally_unique"; then
-	SysInfoStats
-	exit $OCF_SUCCESS
+        SysInfoStats
+        exit $OCF_SUCCESS
     fi
     exit $OCF_NOT_RUNNING
 }
@@ -342,29 +342,29 @@ else
 fi
 MIN_FREE=""
 if [ -n "$OCF_RESKEY_min_disk_free" ]; then
-	ocf_is_decimal "$OCF_RESKEY_min_disk_free" &&
-		OCF_RESKEY_min_disk_free="$OCF_RESKEY_min_disk_free$OCF_RESKEY_disk_unit"
+    ocf_is_decimal "$OCF_RESKEY_min_disk_free" &&
+        OCF_RESKEY_min_disk_free="$OCF_RESKEY_min_disk_free$OCF_RESKEY_disk_unit"
     MIN_FREE=`SysInfo_hdd_units $OCF_RESKEY_min_disk_free`
 fi
 
 case $__OCF_ACTION in
-meta-data)	meta_data
-		exit $OCF_SUCCESS
-		;;
-start)		SysInfo_start
-		;;
-stop)		SysInfo_stop
-		;;
-monitor)	SysInfo_monitor
-		;;
-validate-all)	SysInfo_validate
-		;;
-usage|help)	SysInfo_usage
-		exit $OCF_SUCCESS
-		;;
-*)		SysInfo_usage
-		exit $OCF_ERR_UNIMPLEMENTED
-		;;
+meta-data)      meta_data
+                exit $OCF_SUCCESS
+                ;;
+start)          SysInfo_start
+                ;;
+stop)           SysInfo_stop
+                ;;
+monitor)        SysInfo_monitor
+                ;;
+validate-all)   SysInfo_validate
+                ;;
+usage|help)     SysInfo_usage
+                exit $OCF_SUCCESS
+                ;;
+*)              SysInfo_usage
+                exit $OCF_ERR_UNIMPLEMENTED
+                ;;
 esac
 
 exit $?

--- a/extra/resources/SysInfo.in
+++ b/extra/resources/SysInfo.in
@@ -17,9 +17,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 #######################################################################
 

--- a/extra/resources/SysInfo.in
+++ b/extra/resources/SysInfo.in
@@ -368,3 +368,5 @@ usage|help)     SysInfo_usage
 esac
 
 exit $?
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/SysInfo.in
+++ b/extra/resources/SysInfo.in
@@ -185,7 +185,7 @@ SysInfoStats() {
             if [ -f /proc/meminfo ]; then
                 # meminfo results are in kB
                 mem=$(grep "SwapFree" /proc/meminfo | awk '{print $2"k"}')
-                if [ ! -z "$mem" ]; then
+                if [ -n "$mem" ]; then
                     UpdateStat free_swap "$(SysInfo_mem_units "$mem")"
                 fi
                 mem=$(grep "Inactive" /proc/meminfo | awk '{print $2"k"}')
@@ -197,23 +197,23 @@ SysInfoStats() {
         *)
     esac
 
-    if [ x != x"$cpu_type" ]; then
+    if [ -n "$cpu_type" ]; then
         UpdateStat cpu_info "$cpu_type"
     fi
 
-    if [ x != x"$cpu_speed" ]; then
+    if [ -n "$cpu_speed" ]; then
         UpdateStat cpu_speed "$cpu_speed"
     fi
 
-    if [ x != x"$cpu_cores" ]; then
+    if [ -n "$cpu_cores" ]; then
         UpdateStat cpu_cores "$cpu_cores"
     fi
 
-    if [ x != x"$cpu_load" ]; then
+    if [ -n "$cpu_load" ]; then
         UpdateStat cpu_load "$cpu_load"
     fi
 
-    if [ ! -z "$mem" ]; then
+    if [ -n "$mem" ]; then
         # Massage the memory values
         UpdateStat ram_total "$(SysInfo_mem_units "$mem_total")"
         UpdateStat ram_free "$(SysInfo_mem_units "$mem")"
@@ -225,7 +225,7 @@ SysInfoStats() {
     for disk in "/" ${OCF_RESKEY_disks}; do
         unset disk_free disk_label
         disk_free=$(df -h "${disk}" | tail -1 | awk '{print $4}')
-        if [ x != x"$disk_free" ]; then
+        if [ -n "$disk_free" ]; then
             disk_label=$(echo $disk | sed -e 's#^/$#root#;s#^/*##;s#/#_#g')
             disk_free=$(SysInfo_hdd_units "$disk_free")
             UpdateStat "${disk_label}_free" $disk_free
@@ -261,7 +261,7 @@ SysInfo_mem_units() {
     mem=$(SysInfo_megabytes "$1")
     # Round to the next multiple of 50
     r=$(($mem % 50))
-    if [ $r != 0 ]; then
+    if [ $r -ne 0 ]; then
         mem=$(($mem + 50 - $r))
     fi
 
@@ -308,7 +308,7 @@ SysInfo_monitor() {
         clone=$(cat "$OCF_RESKEY_pidfile")
     fi
 
-    if [ "x$clone" = "x" ]; then
+    if [ -z "$clone" ]; then
         rm "$OCF_RESKEY_pidfile"
         exit $OCF_NOT_RUNNING
 
@@ -335,7 +335,7 @@ fi
 : ${OCF_RESKEY_pidfile:="${HA_VARRUN%%/}/SysInfo-${OCF_RESOURCE_INSTANCE}"}
 : ${OCF_RESKEY_disk_unit:="G"}
 : ${OCF_RESKEY_clone:="0"}
-if [ "x" != "x${OCF_RESKEY_delay}" ]; then
+if [ -n "${OCF_RESKEY_delay}" ]; then
     OCF_RESKEY_delay="-d ${OCF_RESKEY_delay}"
 else
     OCF_RESKEY_delay="-d 0"

--- a/extra/resources/SysInfo.in
+++ b/extra/resources/SysInfo.in
@@ -17,9 +17,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 #######################################################################
 
@@ -134,13 +134,13 @@ END
 #######################################################################
 
 UpdateStat() {
-    name=$1; shift
+    name="$1"; shift
     value="$*"
     printf "%s:\t%s\n" "$name" "$value"
     if [ "$__OCF_ACTION" = "start" ] ; then
-        ${HA_SBIN_DIR}/attrd_updater ${OCF_RESKEY_delay} -S status -n $name -B "$value"
+        "${HA_SBIN_DIR}/attrd_updater" ${OCF_RESKEY_delay} -S status -n $name -B "$value"
     else
-        ${HA_SBIN_DIR}/attrd_updater ${OCF_RESKEY_delay} -S status -n $name -v "$value"
+        "${HA_SBIN_DIR}/attrd_updater" ${OCF_RESKEY_delay} -S status -n $name -v "$value"
     fi
 }
 
@@ -153,8 +153,8 @@ SysInfoStats() {
         "Darwin")
             mem=`top -l 1 | grep Mem: | awk '{print $10}'`
             mem_used=`top -l 1 | grep Mem: | awk '{print $8}'`
-            mem=`SysInfo_mem_units $mem`
-            mem_used=`SysInfo_mem_units $mem_used`
+            mem=`SysInfo_mem_units "$mem"`
+            mem_used=`SysInfo_mem_units "$mem_used"`
             mem_total=`expr $mem_used + $mem`
             cpu_type=`system_profiler SPHardwareDataType | awk -F': ' '/^CPU Type/ {print $2; exit}'`
             cpu_speed=`system_profiler SPHardwareDataType | awk -F': ' '/^CPU Speed/ {print $2; exit}'`
@@ -185,7 +185,7 @@ SysInfoStats() {
             if [ -f /proc/meminfo ]; then
                 # meminfo results are in kB
                 mem=`grep "SwapFree" /proc/meminfo | awk '{print $2"k"}'`
-                if [ ! -z $mem ]; then
+                if [ ! -z "$mem" ]; then
                     UpdateStat free_swap "$(SysInfo_mem_units "$mem")"
                 fi
                 mem=`grep "Inactive" /proc/meminfo | awk '{print $2"k"}'`
@@ -224,11 +224,11 @@ SysInfoStats() {
     #     'tail -n <c>' to the equivalent 'tail -<c>'.
     for disk in "/" ${OCF_RESKEY_disks}; do
         unset disk_free disk_label
-        disk_free=`df -h ${disk} | tail -1 | awk '{print $4}'`
+        disk_free=`df -h "${disk}" | tail -1 | awk '{print $4}'`
         if [ x != x"$disk_free" ]; then
             disk_label=`echo $disk | sed -e 's#^/$#root#;s#^/*##;s#/#_#g'`
-            disk_free=`SysInfo_hdd_units $disk_free`
-            UpdateStat ${disk_label}_free $disk_free
+            disk_free=`SysInfo_hdd_units "$disk_free"`
+            UpdateStat "${disk_label}_free" $disk_free
             if [ -n "$MIN_FREE" ]; then
                 if [ $disk_free -le $MIN_FREE ]; then
                     UpdateStat "#health_disk" "red"
@@ -252,9 +252,9 @@ SysInfo_megabytes() {
 }
 
 SysInfo_mem_units() {
-    mem=$1
+    mem="$1"
 
-    if [ -z $1 ]; then
+    if [ -z "$1" ]; then
         return
     fi
 
@@ -271,7 +271,7 @@ SysInfo_mem_units() {
 SysInfo_hdd_units() {
     # Defauts to size in gigabytes
 
-    case $OCF_RESKEY_disk_unit in
+    case "$OCF_RESKEY_disk_unit" in
         [Pp]) echo $(($(SysInfo_megabytes "$1") / 1024 / 1024 / 1024));;
         [Tt]) echo $(($(SysInfo_megabytes "$1") / 1024 / 1024));;
         [Gg]) echo $(($(SysInfo_megabytes "$1") / 1024));;
@@ -293,26 +293,26 @@ END
 }
 
 SysInfo_start() {
-    echo $OCF_RESKEY_clone > $OCF_RESKEY_pidfile
+    echo $OCF_RESKEY_clone > "$OCF_RESKEY_pidfile"
     SysInfoStats
     exit $OCF_SUCCESS
 }
 
 SysInfo_stop() {
-    rm $OCF_RESKEY_pidfile
+    rm "$OCF_RESKEY_pidfile"
     exit $OCF_SUCCESS
 }
 
 SysInfo_monitor() {
-    if [ -f $OCF_RESKEY_pidfile ]; then
-        clone=`cat $OCF_RESKEY_pidfile`
+    if [ -f "$OCF_RESKEY_pidfile" ]; then
+        clone=`cat "$OCF_RESKEY_pidfile"`
     fi
 
-    if [ x$clone = x ]; then
-        rm $OCF_RESKEY_pidfile
+    if [ "x$clone" = "x" ]; then
+        rm "$OCF_RESKEY_pidfile"
         exit $OCF_NOT_RUNNING
 
-    elif [ $clone = $OCF_RESKEY_clone ]; then
+    elif [ "$clone" = "$OCF_RESKEY_clone" ]; then
         SysInfoStats
         exit $OCF_SUCCESS
 
@@ -335,7 +335,7 @@ fi
 : ${OCF_RESKEY_pidfile:="${HA_VARRUN%%/}/SysInfo-${OCF_RESOURCE_INSTANCE}"}
 : ${OCF_RESKEY_disk_unit:="G"}
 : ${OCF_RESKEY_clone:="0"}
-if [ x != x${OCF_RESKEY_delay} ]; then
+if [ "x" != "x${OCF_RESKEY_delay}" ]; then
     OCF_RESKEY_delay="-d ${OCF_RESKEY_delay}"
 else
     OCF_RESKEY_delay="-d 0"
@@ -347,7 +347,7 @@ if [ -n "$OCF_RESKEY_min_disk_free" ]; then
     MIN_FREE=`SysInfo_hdd_units $OCF_RESKEY_min_disk_free`
 fi
 
-case $__OCF_ACTION in
+case "$__OCF_ACTION" in
 meta-data)      meta_data
                 exit $OCF_SUCCESS
                 ;;

--- a/extra/resources/SysInfo.in
+++ b/extra/resources/SysInfo.in
@@ -145,6 +145,7 @@ UpdateStat() {
 }
 
 SysInfoStats() {
+    local DISK_STATUS="green"
 
     UpdateStat arch "$(uname -m)"
     UpdateStat os "$(uname -s)-$(uname -r)"
@@ -229,15 +230,12 @@ SysInfoStats() {
             disk_label=$(echo $disk | sed -e 's#^/$#root#;s#^/*##;s#/#_#g')
             disk_free=$(SysInfo_hdd_units "$disk_free")
             UpdateStat "${disk_label}_free" $disk_free
-            if [ -n "$MIN_FREE" ]; then
-                if [ $disk_free -le $MIN_FREE ]; then
-                    UpdateStat "#health_disk" "red"
-                else
-                    UpdateStat "#health_disk" "green"
-                fi
+            if [ -n "$MIN_FREE" ] && [ $disk_free -le $MIN_FREE ]; then
+                DISK_STATUS="red"
             fi
         fi
     done
+    UpdateStat "#health_disk" "$DISK_STATUS"
 }
 
 SysInfo_megabytes() {

--- a/extra/resources/SystemHealth
+++ b/extra/resources/SystemHealth
@@ -61,7 +61,7 @@ SystemHealth_check_tools() {
     which servicelog_notify > /dev/null 2>&1
     RC=$?
 
-    if [ $RC != 0 ]; then
+    if [ $RC -ne 0 ]; then
         ocf_log err "servicelog_notify not found!"
         return $OCF_ERR_INSTALLED
     fi
@@ -69,7 +69,7 @@ SystemHealth_check_tools() {
     which ipmiservicelogd > /dev/null 2>&1
     RC=$?
 
-    if [ $RC != 0 ]; then
+    if [ $RC -ne 0 ]; then
         ocf_log err "ipmiservicelogd not found!"
         return $OCF_ERR_INSTALLED
     fi
@@ -77,7 +77,7 @@ SystemHealth_check_tools() {
     test -x "$OCF_RESKEY_program"
     RC=$?
 
-    if [ $RC != 0 ]; then
+    if [ $RC -ne 0 ]; then
         ocf_log err "$OCF_RESKEY_program not found!"
         return $OCF_ERR_INSTALLED
     fi
@@ -87,9 +87,9 @@ SystemHealth_start() {
     SystemHealth_monitor
     RC=$?
 
-    if [ $RC = $OCF_ERR_GENERIC ]; then
+    if [ $RC -eq $OCF_ERR_GENERIC ]; then
         return $OCF_ERR_GENERIC
-    elif [ $RC =  $OCF_SUCCESS ]; then
+    elif [ $RC -eq $OCF_SUCCESS ]; then
         ocf_log warn "starting an already started SystemHealth"
         return $OCF_SUCCESS
     fi
@@ -97,7 +97,7 @@ SystemHealth_start() {
     service ipmi start > /dev/null 2>&1
     RC=$?
 
-    if [ $RC != 0 ]; then
+    if [ $RC -ne 0 ]; then
         ocf_log err "Could not start service IPMI!"
         return $OCF_ERR_GENERIC
     fi
@@ -105,7 +105,7 @@ SystemHealth_start() {
     ipmiservicelogd smi 0 > /dev/null 2>&1 &
     RC=$?
 
-    if [ $RC != 0 ]; then
+    if [ $RC -ne 0 ]; then
         ocf_log err "Could not start ipmiservicelogd!"
         return $OCF_ERR_GENERIC
     fi
@@ -113,7 +113,7 @@ SystemHealth_start() {
     servicelog_notify --add --type=EVENT --command="$OCF_RESKEY_program" --method=num_arg --match='type=4' > /dev/null 2>&1
     RC=$?
 
-    if [ $RC != 0 ]; then
+    if [ $RC -ne 0 ]; then
         ocf_log err "servicelog_notify register handler failed!"
         return $OCF_ERR_GENERIC
     fi
@@ -125,20 +125,20 @@ SystemHealth_stop() {
     SystemHealth_monitor
     RC=$?
 
-    if [ $RC = $OCF_ERR_GENERIC ]; then
+    if [ $RC -eq $OCF_ERR_GENERIC ]; then
         return $OCF_ERR_GENERIC
-    elif [ $RC =  $OCF_SUCCESS ]; then
+    elif [ $RC -eq  $OCF_SUCCESS ]; then
         killall ipmiservicelogd
         RC1=$?
 
-        if [ $RC1 != 0 ]; then
+        if [ $RC1 -ne 0 ]; then
             ocf_log err "Could not stop ipmiservicelogd!"
         fi
 
         servicelog_notify --remove --command="$OCF_RESKEY_program" > /dev/null 2>&1
         RC2=$?
 
-        if [ $RC2 != 0 ]; then
+        if [ $RC2 -ne 0 ]; then
             ocf_log err "servicelog_notify remove handler failed!"
         fi
 
@@ -147,7 +147,7 @@ SystemHealth_stop() {
         else
             return $OCF_ERR_GENERIC
         fi
-    elif [ $RC = $OCF_NOT_RUNNING ]; then
+    elif [ $RC -eq $OCF_NOT_RUNNING ]; then
         ocf_log warn "stopping an already stopped SystemHealth"
         return $OCF_SUCCESS
     else
@@ -169,7 +169,7 @@ SystemHealth_monitor() {
     ps -p "$(cat /var/run/ipmiservicelogd.pid0)" >/dev/null 2>&1
     RC=$?
 
-    if [ $RC != 0 ]; then
+    if [ $RC -ne 0 ]; then
         ocf_log debug "ipmiservicelogd's pid $(cat /var/run/ipmiservicelogd.pid0) is not running!"
 
         rm /var/run/ipmiservicelogd.pid0
@@ -180,7 +180,7 @@ SystemHealth_monitor() {
     servicelog_notify --list --command="$OCF_RESKEY_program" > /dev/null 2>&1
     RC=$?
 
-    if [ $RC = 0 ]; then
+    if [ $RC -eq 0 ]; then
         return $OCF_SUCCESS
     else
         return $OCF_NOT_RUNNING
@@ -192,7 +192,7 @@ SystemHealth_validate() {
     SystemHealth_check_tools
     RC=$?
 
-    if [ $RC != 0 ]; then
+    if [ $RC -ne 0 ]; then
         return $RC
     fi
 
@@ -213,7 +213,7 @@ esac
 SystemHealth_check_tools
 RC=$?
 
-if [ $RC != 0 ]; then
+if [ $RC -ne 0 ]; then
         case "$__OCF_ACTION" in
         stop)           exit $OCF_SUCCESS;;
         *)              exit $RC;;

--- a/extra/resources/SystemHealth
+++ b/extra/resources/SystemHealth
@@ -188,7 +188,7 @@ SystemHealth_monitor() {
 }
 
 SystemHealth_validate() {
-    
+
     SystemHealth_check_tools
     RC=$?
 

--- a/extra/resources/SystemHealth
+++ b/extra/resources/SystemHealth
@@ -2,7 +2,7 @@
 #
 # ocf:pacemaker:SystemHealth resource agent
 #
-# Copyright 2009-2018 the Pacemaker project contributors
+# Copyright 2009-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -20,7 +20,7 @@
 #######################################################################
 
 meta_data() {
-	cat <<END
+    cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
 <resource-agent name="SystemHealth" version="0.1">
@@ -36,12 +36,12 @@ the health of a system via IPMI.
 </parameters>
 
 <actions>
-<action name="start"		timeout="20s" />
-<action name="stop"		timeout="20s" />
-<action name="monitor"		timeout="20s" />
-<action name="reload"		timeout="20s" />
-<action name="meta-data"	timeout="5s" />
-<action name="validate-all"	timeout="20s" />
+<action name="start"        timeout="20s" />
+<action name="stop"         timeout="20s" />
+<action name="monitor"      timeout="20s" />
+<action name="reload"       timeout="20s" />
+<action name="meta-data"    timeout="5s" />
+<action name="validate-all" timeout="20s" />
 </actions>
 </resource-agent>
 END
@@ -50,7 +50,7 @@ END
 #######################################################################
 
 SystemHealth_usage() {
-	cat <<END
+    cat <<END
 usage: $0 {start|stop|monitor|validate-all|meta-data}
 
 Expects to have a fully populated OCF RA-compliant environment set.
@@ -62,24 +62,24 @@ SystemHealth_check_tools() {
     RC=$?
 
     if [ $RC != 0 ]; then
-	ocf_log err "servicelog_notify not found!"
-	return $OCF_ERR_INSTALLED
+        ocf_log err "servicelog_notify not found!"
+        return $OCF_ERR_INSTALLED
     fi
 
     which ipmiservicelogd > /dev/null 2>&1
     RC=$?
 
     if [ $RC != 0 ]; then
-	ocf_log err "ipmiservicelogd not found!"
-	return $OCF_ERR_INSTALLED
+        ocf_log err "ipmiservicelogd not found!"
+        return $OCF_ERR_INSTALLED
     fi
 
     test -x $OCF_RESKEY_program
     RC=$?
 
     if [ $RC != 0 ]; then
-	ocf_log err "$OCF_RESKEY_program not found!"
-	return $OCF_ERR_INSTALLED
+        ocf_log err "$OCF_RESKEY_program not found!"
+        return $OCF_ERR_INSTALLED
     fi
 }
 
@@ -88,34 +88,34 @@ SystemHealth_start() {
     RC=$?
 
     if [ $RC = $OCF_ERR_GENERIC ]; then
-	return $OCF_ERR_GENERIC
+        return $OCF_ERR_GENERIC
     elif [ $RC =  $OCF_SUCCESS ]; then
-	ocf_log warn "starting an already started SystemHealth"
-	return $OCF_SUCCESS
+        ocf_log warn "starting an already started SystemHealth"
+        return $OCF_SUCCESS
     fi
 
     service ipmi start > /dev/null 2>&1
     RC=$?
 
     if [ $RC != 0 ]; then
-	ocf_log err "Could not start service IPMI!"
-	return $OCF_ERR_GENERIC
+        ocf_log err "Could not start service IPMI!"
+        return $OCF_ERR_GENERIC
     fi
 
     ipmiservicelogd smi 0 > /dev/null 2>&1 &
     RC=$?
 
     if [ $RC != 0 ]; then
-	ocf_log err "Could not start ipmiservicelogd!"
-	return $OCF_ERR_GENERIC
+        ocf_log err "Could not start ipmiservicelogd!"
+        return $OCF_ERR_GENERIC
     fi
 
     servicelog_notify --add --type=EVENT --command="$OCF_RESKEY_program" --method=num_arg --match='type=4' > /dev/null 2>&1
     RC=$?
 
     if [ $RC != 0 ]; then
-	ocf_log err "servicelog_notify register handler failed!"
-	return $OCF_ERR_GENERIC
+        ocf_log err "servicelog_notify register handler failed!"
+        return $OCF_ERR_GENERIC
     fi
 
     return $OCF_SUCCESS
@@ -126,33 +126,33 @@ SystemHealth_stop() {
     RC=$?
 
     if [ $RC = $OCF_ERR_GENERIC ]; then
-	return $OCF_ERR_GENERIC
+        return $OCF_ERR_GENERIC
     elif [ $RC =  $OCF_SUCCESS ]; then
-	killall ipmiservicelogd
-	RC1=$?
+        killall ipmiservicelogd
+        RC1=$?
 
-	if [ $RC1 != 0 ]; then
-	    ocf_log err "Could not stop ipmiservicelogd!"
-	fi
+        if [ $RC1 != 0 ]; then
+            ocf_log err "Could not stop ipmiservicelogd!"
+        fi
 
-	servicelog_notify --remove --command="$OCF_RESKEY_program" > /dev/null 2>&1
-	RC2=$?
+        servicelog_notify --remove --command="$OCF_RESKEY_program" > /dev/null 2>&1
+        RC2=$?
 
-	if [ $RC2 != 0 ]; then
-	    ocf_log err "servicelog_notify remove handler failed!"
-	fi
+        if [ $RC2 != 0 ]; then
+            ocf_log err "servicelog_notify remove handler failed!"
+        fi
 
-	if [ $RC1 -eq 0 ] && [ $RC2 -eq 0 ]; then
-	    return $OCF_SUCCESS
-	else
-	    return $OCF_ERR_GENERIC
-	fi
+        if [ $RC1 -eq 0 ] && [ $RC2 -eq 0 ]; then
+            return $OCF_SUCCESS
+        else
+            return $OCF_ERR_GENERIC
+        fi
     elif [ $RC = $OCF_NOT_RUNNING ]; then
-	ocf_log warn "stopping an already stopped SystemHealth"
-	return $OCF_SUCCESS
+        ocf_log warn "stopping an already stopped SystemHealth"
+        return $OCF_SUCCESS
     else
-	ocf_log err "SystemHealth_stop: should not be here!"
-	return $OCF_ERR_GENERIC
+        ocf_log err "SystemHealth_stop: should not be here!"
+        return $OCF_ERR_GENERIC
     fi
 }
 
@@ -162,28 +162,28 @@ SystemHealth_monitor() {
     # That is THREE states, not just yes/no.
 
     if [ ! -f /var/run/ipmiservicelogd.pid0 ]; then
-	ocf_log debug "ipmiservicelogd is not running!"
-	return $OCF_NOT_RUNNING
+        ocf_log debug "ipmiservicelogd is not running!"
+        return $OCF_NOT_RUNNING
     fi
 
     ps -p "$(cat /var/run/ipmiservicelogd.pid0)" >/dev/null 2>&1
     RC=$?
 
     if [ $RC != 0 ]; then
-	ocf_log debug "ipmiservicelogd's pid `cat /var/run/ipmiservicelogd.pid0` is not running!"
+        ocf_log debug "ipmiservicelogd's pid `cat /var/run/ipmiservicelogd.pid0` is not running!"
 
-	rm /var/run/ipmiservicelogd.pid0
+        rm /var/run/ipmiservicelogd.pid0
 
-	return $OCF_ERR_GENERIC
+        return $OCF_ERR_GENERIC
     fi
 
     servicelog_notify --list --command="$OCF_RESKEY_program" > /dev/null 2>&1
     RC=$?
 
     if [ $RC = 0 ]; then
-	return $OCF_SUCCESS
+        return $OCF_SUCCESS
     else
-	return $OCF_NOT_RUNNING
+        return $OCF_NOT_RUNNING
     fi
 }
 
@@ -193,7 +193,7 @@ SystemHealth_validate() {
     RC=$?
 
     if [ $RC != 0 ]; then
-	return $RC
+        return $RC
     fi
 
     return $OCF_SUCCESS
@@ -202,35 +202,35 @@ SystemHealth_validate() {
 : ${OCF_RESKEY_program=/usr/sbin/notifyServicelogEvent}
 
 case $__OCF_ACTION in
-meta-data)	meta_data
-		exit $OCF_SUCCESS
-		;;
-usage|help)	SystemHealth_usage
-		exit $OCF_SUCCESS
-		;;
+meta-data)      meta_data
+                exit $OCF_SUCCESS
+                ;;
+usage|help)     SystemHealth_usage
+                exit $OCF_SUCCESS
+                ;;
 esac
 
 SystemHealth_check_tools
 RC=$?
 
 if [ $RC != 0 ]; then
-	case $__OCF_ACTION in
-	stop)		exit $OCF_SUCCESS;;
-	*)		exit $RC;;
-	esac
+        case $__OCF_ACTION in
+        stop)           exit $OCF_SUCCESS;;
+        *)              exit $RC;;
+        esac
 fi
 
 case $__OCF_ACTION in
-start)		SystemHealth_start;;
-stop)		SystemHealth_stop;;
-monitor)	SystemHealth_monitor;;
-reload)		ocf_log info "Reloading..."
-	        SystemHealth_start
-		;;
-validate-all)	;;
-*)		SystemHealth_usage
-		exit $OCF_ERR_UNIMPLEMENTED
-		;;
+start)          SystemHealth_start;;
+stop)           SystemHealth_stop;;
+monitor)        SystemHealth_monitor;;
+reload)         ocf_log info "Reloading..."
+                SystemHealth_start
+                ;;
+validate-all)   ;;
+*)              SystemHealth_usage
+                exit $OCF_ERR_UNIMPLEMENTED
+                ;;
 esac
 rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"

--- a/extra/resources/SystemHealth
+++ b/extra/resources/SystemHealth
@@ -13,9 +13,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 #######################################################################
 
@@ -199,7 +199,7 @@ SystemHealth_validate() {
     return $OCF_SUCCESS
 }
 
-: ${OCF_RESKEY_program=/usr/sbin/notifyServicelogEvent}
+: ${OCF_RESKEY_program:=/usr/sbin/notifyServicelogEvent}
 
 case $__OCF_ACTION in
 meta-data)      meta_data

--- a/extra/resources/SystemHealth
+++ b/extra/resources/SystemHealth
@@ -235,3 +235,5 @@ esac
 rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
 exit $rc
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/SystemHealth
+++ b/extra/resources/SystemHealth
@@ -1,29 +1,13 @@
 #!/bin/sh
 #
-#	SystemHealth OCF RA.
+# ocf:pacemaker:SystemHealth resource agent
 #
 # Copyright 2009-2018 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of version 2 of the GNU General Public License as
-# published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it would be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# Further, this software is distributed without any warranty that it is
-# free of the rightful claim of any third person regarding infringement
-# or the like.  Any license provided herein, whether implied or
-# otherwise, applies only to this software file.  Patent licenses, if
-# any, provided herein do not apply to combinations of this program with
-# other software, or any other product whatsoever.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write the Free Software Foundation,
-# Inc., 59 Temple Place - Suite 330, Boston MA 02111-1307, USA.
+# This source code is licensed under the GNU General Public License version 2
+# (GPLv2) WITHOUT ANY WARRANTY.
 #
 
 #######################################################################

--- a/extra/resources/SystemHealth
+++ b/extra/resources/SystemHealth
@@ -170,7 +170,7 @@ SystemHealth_monitor() {
     RC=$?
 
     if [ $RC != 0 ]; then
-        ocf_log debug "ipmiservicelogd's pid `cat /var/run/ipmiservicelogd.pid0` is not running!"
+        ocf_log debug "ipmiservicelogd's pid $(cat /var/run/ipmiservicelogd.pid0) is not running!"
 
         rm /var/run/ipmiservicelogd.pid0
 

--- a/extra/resources/SystemHealth
+++ b/extra/resources/SystemHealth
@@ -13,9 +13,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 #######################################################################
 
@@ -74,7 +74,7 @@ SystemHealth_check_tools() {
         return $OCF_ERR_INSTALLED
     fi
 
-    test -x $OCF_RESKEY_program
+    test -x "$OCF_RESKEY_program"
     RC=$?
 
     if [ $RC != 0 ]; then
@@ -214,13 +214,13 @@ SystemHealth_check_tools
 RC=$?
 
 if [ $RC != 0 ]; then
-        case $__OCF_ACTION in
+        case "$__OCF_ACTION" in
         stop)           exit $OCF_SUCCESS;;
         *)              exit $RC;;
         esac
 fi
 
-case $__OCF_ACTION in
+case "$__OCF_ACTION" in
 start)          SystemHealth_start;;
 stop)           SystemHealth_stop;;
 monitor)        SystemHealth_monitor;;

--- a/extra/resources/attribute
+++ b/extra/resources/attribute
@@ -15,9 +15,9 @@ USAGE="Usage: $0 {start|stop|monitor|migrate_to|migrate_from|validate-all|meta-d
 Expects to have a fully populated OCF RA-compliant environment set."
 
 # Load OCF helper functions
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 # Ensure certain variables are set and not empty
 : ${HA_VARRUN:="/var/run"}
@@ -25,7 +25,7 @@ Expects to have a fully populated OCF RA-compliant environment set."
 : ${OCF_RESOURCE_INSTANCE:="undef"}
 
 DEFAULT_STATE_FILE="${HA_VARRUN%%/}/opa-${OCF_RESOURCE_INSTANCE}.state"
-if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
+if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
     # Strip off any trailing clone marker (note + is not portable in sed)
     DEFAULT_STATE_FILE=$(echo "$DEFAULT_STATE_FILE" | sed s/:[0-9][0-9]*\.state/.state/)
 fi
@@ -38,10 +38,10 @@ DEFAULT_INACTIVE_VALUE="0"
 : ${OCF_RESKEY_name:="$DEFAULT_ATTR_NAME"}
 
 # Values may be empty string
-if [ -z ${OCF_RESKEY_active_value+x} ]; then
+if [ -z "${OCF_RESKEY_active_value+x}" ]; then
     OCF_RESKEY_active_value="$DEFAULT_ACTIVE_VALUE"
 fi
-if [ -z ${OCF_RESKEY_inactive_value+x} ]; then
+if [ -z "${OCF_RESKEY_inactive_value+x}" ]; then
     OCF_RESKEY_inactive_value="$DEFAULT_INACTIVE_VALUE"
 fi
 

--- a/extra/resources/attribute
+++ b/extra/resources/attribute
@@ -2,7 +2,7 @@
 #
 # ocf:pacemaker:attribute resource agent
 #
-# Copyright 2016-2018 the Pacemaker project contributors
+# Copyright 2016-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -232,4 +232,4 @@ esac
 
 exit $?
 
-# vim: expandtab:tabstop=4:softtabstop=4:shiftwidth=4:textwidth=80
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/attribute
+++ b/extra/resources/attribute
@@ -37,7 +37,8 @@ DEFAULT_INACTIVE_VALUE="0"
 : ${OCF_RESKEY_state:="$DEFAULT_STATE_FILE"}
 : ${OCF_RESKEY_name:="$DEFAULT_ATTR_NAME"}
 
-# Values may be empty string
+# If the user did not set a value, use the default. If the user explicitly set
+# a value to the empty string, use that (-z "${V+x}" tests whether $V was set).
 if [ -z "${OCF_RESKEY_active_value+x}" ]; then
     OCF_RESKEY_active_value="$DEFAULT_ACTIVE_VALUE"
 fi

--- a/extra/resources/attribute
+++ b/extra/resources/attribute
@@ -15,9 +15,9 @@ USAGE="Usage: $0 {start|stop|monitor|migrate_to|migrate_from|validate-all|meta-d
 Expects to have a fully populated OCF RA-compliant environment set."
 
 # Load OCF helper functions
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 # Ensure certain variables are set and not empty
 : ${HA_VARRUN:="/var/run"}

--- a/extra/resources/attribute
+++ b/extra/resources/attribute
@@ -6,8 +6,8 @@
 #
 # The version control history for this file may have further details.
 #
-# This source code is licensed under GNU General Public License version 2 or
-# later (GPLv2+) WITHOUT ANY WARRANTY.
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
 USAGE="Usage: $0 {start|stop|monitor|migrate_to|migrate_from|validate-all|meta-data}

--- a/extra/resources/controld
+++ b/extra/resources/controld
@@ -147,7 +147,7 @@ controld_start() {
     fi
 
     if ! ocf_is_true "$OCF_RESKEY_allow_stonith_disabled" && \
-        ! ocf_is_true "`crm_attribute --type=crm_config --name=stonith-enabled --query --quiet --default=true`"; then
+        ! ocf_is_true "$(crm_attribute --type=crm_config --name=stonith-enabled --query --quiet --default=true)"; then
         ocf_log err "The cluster property stonith-enabled may not be deactivated to use the DLM"
         return $OCF_ERR_CONFIGURED
     fi

--- a/extra/resources/controld
+++ b/extra/resources/controld
@@ -181,23 +181,23 @@ controld_start() {
 controld_stop() {
     controld_monitor; rc=$?
 
-    if [ $rc = $OCF_NOT_RUNNING ]; then
+    if [ $rc -eq $OCF_NOT_RUNNING ]; then
         return $OCF_SUCCESS
     fi
 
     killall -TERM "${OCF_RESKEY_daemon}"; rc=$?
 
-    if [ $rc != 0 ]; then
+    if [ $rc -ne 0 ]; then
         return $OCF_ERR_GENERIC
     fi
 
     rc=$OCF_SUCCESS
-    while [ $rc = $OCF_SUCCESS ]; do
+    while [ $rc -eq $OCF_SUCCESS ]; do
         controld_monitor; rc=$?
         sleep 1
     done
 
-    if [ $rc = $OCF_NOT_RUNNING ]; then
+    if [ $rc -eq $OCF_NOT_RUNNING ]; then
         rc=$OCF_SUCCESS
     fi
 

--- a/extra/resources/controld
+++ b/extra/resources/controld
@@ -166,10 +166,10 @@ controld_start() {
                 return $OCF_SUCCESS
             fi
             ;;
-          $OCF_NOT_RUNNING) 
+          $OCF_NOT_RUNNING)
             return $OCF_NOT_RUNNING
             ;;
-          *) 
+          *)
             return $OCF_ERR_GENERIC
             ;;
         esac
@@ -238,7 +238,7 @@ controld_validate() {
     check_binary ${OCF_RESKEY_daemon}
 
     case ${OCF_RESKEY_CRM_meta_globally_unique} in
-        yes|Yes|true|True|1) 
+        yes|Yes|true|True|1)
             ocf_log err "$OCF_RESOURCE_INSTANCE must be configured with the globally_unique=false meta attribute"
             exit $OCF_ERR_CONFIGURED
             ;;
@@ -253,7 +253,7 @@ controld_validate() {
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
 case "$OCF_RESOURCE_INSTANCE" in
-    *[gG][fF][sS]*) 
+    *[gG][fF][sS]*)
         : ${OCF_RESKEY_args=-g 0}
         : ${OCF_RESKEY_daemon=gfs_controld}
         ;;

--- a/extra/resources/controld
+++ b/extra/resources/controld
@@ -1,30 +1,16 @@
 #!/bin/sh
 #
-# OCF resource agent for managing the DLM controld process
+# ocf:pacemaker:controld resource agent
 #
 # Copyright 2008-2018 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
-#                    All Rights Reserved.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of version 2 of the GNU General Public License as
-# published by the Free Software Foundation.
+# This source code is licensed under the GNU General Public License version 2
+# (GPLv2) WITHOUT ANY WARRANTY.
+
 #
-# This program is distributed in the hope that it would be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# Further, this software is distributed without any warranty that it is
-# free of the rightful claim of any third person regarding infringement
-# or the like.  Any license provided herein, whether implied or
-# otherwise, applies only to this software file.  Patent licenses, if
-# any, provided herein do not apply to combinations of this program with
-# other software, or any other product whatsoever.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write the Free Software Foundation,
-# Inc., 59 Temple Place - Suite 330, Boston MA 02111-1307, USA.
+# Manages the DLM controld process
 #
 
 #######################################################################

--- a/extra/resources/controld
+++ b/extra/resources/controld
@@ -2,7 +2,7 @@
 #
 # ocf:pacemaker:controld resource agent
 #
-# Copyright 2008-2018 the Pacemaker project contributors
+# Copyright 2008-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -284,3 +284,5 @@ esac
 rc=$?
 
 exit $rc
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/controld
+++ b/extra/resources/controld
@@ -16,9 +16,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 #######################################################################
 
@@ -249,21 +249,21 @@ controld_validate() {
     return $OCF_SUCCESS
 }
 
-: ${OCF_RESKEY_sctp=false}
+: ${OCF_RESKEY_sctp:=false}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
 case "$OCF_RESOURCE_INSTANCE" in
     *[gG][fF][sS]*)
         : ${OCF_RESKEY_args=-g 0}
-        : ${OCF_RESKEY_daemon=gfs_controld}
+        : ${OCF_RESKEY_daemon:=gfs_controld}
         ;;
     *[dD][lL][mM]*)
         : ${OCF_RESKEY_args=-s 0}
-        : ${OCF_RESKEY_daemon=dlm_controld}
+        : ${OCF_RESKEY_daemon:=dlm_controld}
         ;;
     *)
         : ${OCF_RESKEY_args=-s 0}
-        : ${OCF_RESKEY_daemon=dlm_controld}
+        : ${OCF_RESKEY_daemon:=dlm_controld}
 esac
 
 case $__OCF_ACTION in

--- a/extra/resources/controld
+++ b/extra/resources/controld
@@ -16,15 +16,15 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 #######################################################################
 
 if [ -e "$OCF_ROOT/resource.d/heartbeat/controld" ]; then
     ocf_log info "Using heartbeat controld agent"
-    $OCF_ROOT/resource.d/heartbeat/controld $1
+    "$OCF_ROOT/resource.d/heartbeat/controld" "$1"
     exit $?
 fi
 
@@ -103,7 +103,7 @@ END
 
 check_uncontrolled_locks()
 {
-    CUL_TMP=$(ls $DLM_SYSFS_DIR 2>&1)
+    CUL_TMP=$(ls "$DLM_SYSFS_DIR" 2>&1)
     if [ $? -eq 0 ]; then
         if [ -n "$CUL_TMP" ]; then
 
@@ -152,7 +152,7 @@ controld_start() {
         return $OCF_ERR_CONFIGURED
     fi
 
-    ${OCF_RESKEY_daemon} $OCF_RESKEY_args
+    "${OCF_RESKEY_daemon}" $OCF_RESKEY_args
 
     while true
     do
@@ -185,7 +185,7 @@ controld_stop() {
         return $OCF_SUCCESS
     fi
 
-    killall -TERM ${OCF_RESKEY_daemon}; rc=$?
+    killall -TERM "${OCF_RESKEY_daemon}"; rc=$?
 
     if [ $rc != 0 ]; then
         return $OCF_ERR_GENERIC
@@ -235,9 +235,9 @@ controld_monitor() {
 
 controld_validate() {
     check_binary killall
-    check_binary ${OCF_RESKEY_daemon}
+    check_binary "${OCF_RESKEY_daemon}"
 
-    case ${OCF_RESKEY_CRM_meta_globally_unique} in
+    case "${OCF_RESKEY_CRM_meta_globally_unique}" in
         yes|Yes|true|True|1)
             ocf_log err "$OCF_RESOURCE_INSTANCE must be configured with the globally_unique=false meta attribute"
             exit $OCF_ERR_CONFIGURED
@@ -249,7 +249,7 @@ controld_validate() {
     return $OCF_SUCCESS
 }
 
-: ${OCF_RESKEY_sctp:=false}
+: ${OCF_RESKEY_sctp:="false"}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
 case "$OCF_RESOURCE_INSTANCE" in
@@ -266,7 +266,7 @@ case "$OCF_RESOURCE_INSTANCE" in
         : ${OCF_RESKEY_daemon:=dlm_controld}
 esac
 
-case $__OCF_ACTION in
+case "$__OCF_ACTION" in
 meta-data)      meta_data
                 exit $OCF_SUCCESS
                 ;;

--- a/extra/resources/ifspeed.in
+++ b/extra/resources/ifspeed.in
@@ -33,15 +33,15 @@
 #
 # Initialization:
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 
 # If these aren't available, we can still show help,
 # which is all that is needed to build the man pages.
 [ -r "${OCF_FUNCTIONS}" ] && . "${OCF_FUNCTIONS}"
 [ -r "${OCF_FUNCTIONS_DIR}/findif.sh" ] && . "${OCF_FUNCTIONS_DIR}/findif.sh"
-: ${OCF_SUCCESS=0}
+: ${OCF_SUCCESS:=0}
 
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 FINDIF=findif
 
@@ -51,10 +51,10 @@ OCF_RESKEY_bridge_ports_default="detect"
 OCF_RESKEY_weight_base_default=1000
 OCF_RESKEY_dampen_default=5
 
-: ${OCF_RESKEY_name=${OCF_RESKEY_name_default}}
-: ${OCF_RESKEY_bridge_ports=${OCF_RESKEY_bridge_ports_default}}
-: ${OCF_RESKEY_weight_base=${OCF_RESKEY_weight_base_default}}
-: ${OCF_RESKEY_dampen=${OCF_RESKEY_dampen_default}}
+: ${OCF_RESKEY_name:=${OCF_RESKEY_name_default}}
+: ${OCF_RESKEY_bridge_ports:=${OCF_RESKEY_bridge_ports_default}}
+: ${OCF_RESKEY_weight_base:=${OCF_RESKEY_weight_base_default}}
+: ${OCF_RESKEY_dampen:=${OCF_RESKEY_dampen_default}}
 
 meta_data() {
         cat <<END

--- a/extra/resources/ifspeed.in
+++ b/extra/resources/ifspeed.in
@@ -27,7 +27,7 @@
 #    OCF_RESKEY_iface:        network interface to monitor
 #    OCF_RESKEY_bridge_ports: if not null and OCF_RESKEY_iface is a bridge, list of
 #                             bridge ports to consider.
-#                             Default is all ports which have designated_bridge=root_id 
+#                             Default is all ports which have designated_bridge=root_id
 #    OCF_RESKEY_weight_base:  Relative weight of 1Gbps. This can be used to tune
 #                             value of resulting CIB attribute.
 #
@@ -85,7 +85,7 @@ For balancing bonds this RA summs speeds of underlying "up" slave interfaces
 (and applies coefficient 0.8 to result).
 
 For non-balancing bonds ('active-backup' and probably 'broadcast'), only the
-speed of the currently active slave is used. 
+speed of the currently active slave is used.
 </longdesc>
 <shortdesc lang="en">Network interface speed monitor</shortdesc>
 
@@ -319,7 +319,7 @@ bridge_get_root_ports() {
 
     root_ports=${root_ports# }
 
-    if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell. 
+    if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell.
         eval "$2=\${root_ports}"
     else # Expect sub-shell
         echo ${root_ports}
@@ -363,7 +363,7 @@ bridge_get_active_ports() {
         fi
     done
     if [ ${warn} -eq 1 ] ; then
-        ocf_log warning "More then one upstream port in bridge '${bridge}' is in forwarding state while STP is enabled: ${active_ports}" 
+        ocf_log warning "More then one upstream port in bridge '${bridge}' is in forwarding state while STP is enabled: ${active_ports}"
     fi
     echo "${active_ports# }"
 }
@@ -381,7 +381,7 @@ bridge_get_speed() {
     for port in ${BGS_PORTS} ; do
         : $(( aggregate_speed += $( iface_get_speed ${port} ) ))
     done
-    if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell. 
+    if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell.
         eval "$2=\${aggregate_speed}"
     else # Expect sub-shell
         echo ${aggregate_speed}
@@ -400,8 +400,8 @@ hfi1_get_speed() {
     # [root@es-host0 ~]# cat /sys/class/net/ib0/device/infiniband/*/ports/*/rate
     # 100 Gb/sec (4X EDR)
     read hfi1_speed hfi1_value hfi1_desc < /sys/class/net/${iface}/device/infiniband/*/ports/*/rate
-    ocf_is_true ${OCF_RESKEY_debug} && ocf_log debug "Detected speed $hfi1_speed $hfi1_value $hfi1_desc" 
-    
+    ocf_is_true ${OCF_RESKEY_debug} && ocf_log debug "Detected speed $hfi1_speed $hfi1_value $hfi1_desc"
+
     # hfi1_value always in Gb/sec, so we need to convert hfi1_speed in Mb/sec
     echo $(( hfi1_speed * 1000 ))
 }
@@ -410,7 +410,7 @@ bond_get_slaves() {
     local iface=$1
     local slaves
     read slaves < "/sys/class/net/${iface}/bonding/slaves"
-    if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell. 
+    if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell.
         eval "$2=\${slaves}"
     else # Expect sub-shell
         echo ${slaves}
@@ -421,7 +421,7 @@ bond_get_active_iface() {
     local iface=$1
     local active
     read active < "/sys/class/net/${iface}/bonding/active_slave"
-    if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell. 
+    if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell.
         eval "$2=\${active}"
     else # Expect sub-shell
         echo ${active}
@@ -465,7 +465,7 @@ bond_get_speed() {
         bond_get_active_iface ${iface} active_iface
         aggregate_speed=$( iface_get_speed $active_iface )
     fi
-    if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell. 
+    if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell.
         eval "$2=\${aggregate_speed}"
     else # Expect sub-shell
         echo ${aggregate_speed}
@@ -487,7 +487,7 @@ update() {
     : $(( score = speed * ${OCF_RESKEY_weight_base} / 1000 ))
     if [ "$__OCF_ACTION" = "start" ] ; then
         attrd_updater -n ${OCF_RESKEY_name} -B ${score} -d ${OCF_RESKEY_dampen} ${attrd_options}
-    else 
+    else
         attrd_updater -n ${OCF_RESKEY_name} -v ${score} -d ${OCF_RESKEY_dampen} ${attrd_options}
     fi
     rc=$?

--- a/extra/resources/ifspeed.in
+++ b/extra/resources/ifspeed.in
@@ -1,12 +1,20 @@
 #!@BASH_PATH@
 #
-# OCF resource agent which monitors state of network interface and records it
-# as a node attribute in the CIB based on the sum of speeds of its active (up,
-# link detected, not blocked) underlying interfaces.
+# ocf:pacemaker:ifspeed resource agent
 #
 # Copyright 2011-2018 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+#
+
+#
+# OCF resource agent which monitors state of network interface and records it
+# as a node attribute in the CIB based on the sum of speeds of its active (up,
+# link detected, not blocked) underlying interfaces.
+#
 # Partially based on 'ping' RA by Andrew Beekhof
 #
 # Change on 2017 by Tomer Azran <tomerazran@gmail.com>:

--- a/extra/resources/ifspeed.in
+++ b/extra/resources/ifspeed.in
@@ -2,7 +2,7 @@
 #
 # ocf:pacemaker:ifspeed resource agent
 #
-# Copyright 2011-2018 the Pacemaker project contributors
+# Copyright 2011-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -546,3 +546,5 @@ case $__OCF_ACTION in
 esac
 
 exit $?
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/ifspeed.in
+++ b/extra/resources/ifspeed.in
@@ -33,7 +33,7 @@
 #
 # Initialization:
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
 
 # If these aren't available, we can still show help,
 # which is all that is needed to build the man pages.
@@ -184,14 +184,14 @@ start() {
 }
 
 stop() {
-    ha_pseudo_resource ${ha_pseudo_resource_name} stop
-    attrd_updater -D -n ${OCF_RESKEY_name} -d ${OCF_RESKEY_dampen} ${attrd_options}
+    ha_pseudo_resource "${ha_pseudo_resource_name}" stop
+    attrd_updater -D -n "${OCF_RESKEY_name}" -d "${OCF_RESKEY_dampen}" ${attrd_options}
     return $OCF_SUCCESS
 }
 
 monitor() {
     local ret
-    ha_pseudo_resource ${ha_pseudo_resource_name} monitor
+    ha_pseudo_resource "${ha_pseudo_resource_name}" monitor
     ret=$?
     if [ ${ret} -eq $OCF_SUCCESS ] ; then
         update
@@ -204,7 +204,7 @@ get_nic_name_by_ip(){
     # $FINDIF takes its parameters from the environment.
     # Its output is as follows:
     # [NIC_NAME] netmask [NETMASK] broadcast [BROADCAST}
-    NICINFO=$( ${FINDIF} )
+    NICINFO=$( "${FINDIF}" )
     rc=$?
     if [ $rc -eq 0 ];then
         # Get NIC_NAME part of findif function output.
@@ -235,20 +235,20 @@ validate() {
 }
 
 iface_get_speed() {
-    local iface=$1
+    local iface="$1"
     local operstate
     local carrier
     local speed
 
     if [ ! -e "/sys/class/net/${iface}" ] ; then
         echo "0"
-    elif iface_is_bridge ${iface} ; then # bridges do not have operstate
+    elif iface_is_bridge "${iface}" ; then # bridges do not have operstate
         read carrier < "/sys/class/net/${iface}/carrier"
 
         if [ "${carrier}" != "1" ] ; then
             echo "0"
         else
-            bridge_get_speed ${iface}
+            bridge_get_speed "${iface}"
         fi
     else
         read operstate < "/sys/class/net/${iface}/operstate"
@@ -256,54 +256,54 @@ iface_get_speed() {
 
         if [ "${operstate}" != "up" ] || [ "${carrier}" != "1" ] ; then
             echo "0"
-        elif iface_is_bond ${iface} ; then
-            bond_get_speed ${iface}
-        elif iface_is_vlan ${iface} ; then
+        elif iface_is_bond "${iface}" ; then
+            bond_get_speed "${iface}"
+        elif iface_is_vlan "${iface}" ; then
             iface_get_speed "$(vlan_get_phy "${iface}")"
         elif iface_is_hfi1 "${iface}" ; then
             hfi1_get_speed "${iface}"
         else
             read speed < "/sys/class/net/${iface}/speed"
-            echo ${speed}
+            echo "${speed}"
         fi
     fi
 }
 
 iface_is_vlan() {
-    local iface=$1
+    local iface="$1"
     [ -e "/proc/net/vlan/${iface}" ] && return 0 || return 1
 }
 
 iface_is_bridge() {
-    local iface=$1
+    local iface="$1"
     [ -e "/sys/class/net/${iface}/bridge" ] && return 0 || return 1
 }
 
 iface_is_bond() {
-    local iface=$1
+    local iface="$1"
     [ -e "/sys/class/net/${iface}/bonding" ] && return 0 || return 1
 }
 
 iface_is_hfi1() {
-    local iface=$1
-    driver=$(readlink /sys/class/net/${iface}/device/driver)
-    [[ $(basename ${driver}) =~ "hfi1" ]] && return 0 || return 1
+    local iface="$1"
+    driver=$(readlink "/sys/class/net/${iface}/device/driver")
+    [[ $(basename "${driver}") =~ "hfi1" ]] && return 0 || return 1
 }
 
 vlan_get_phy() {
-    local iface=$1
+    local iface="$1"
     sed -ne "s/^${iface} .*| *//p" < /proc/net/vlan/config
 }
 
 bridge_is_stp_enabled() {
-    local iface=$1
+    local iface="$1"
     local stp
     read stp < "/sys/class/net/${iface}/bridge/stp_state"
     [ "${stp}" = "1" ] && return 0 || return 1
 }
 
 bridge_get_root_ports() {
-    local bridge=$1
+    local bridge="$1"
     local root_id
     local root_ports=""
     local bridge_id
@@ -334,7 +334,7 @@ bridge_get_root_ports() {
 #define BR_STATE_BLOCKING 4
 
 bridge_get_active_ports() {
-    local bridge=$1
+    local bridge="$1"
     shift 1
     local ports="$*"
     local active_ports=""
@@ -342,11 +342,11 @@ bridge_get_active_ports() {
     local stp_state
     local warn=0
 
-    bridge_is_stp_enabled ${bridge}
+    bridge_is_stp_enabled "${bridge}"
     stp_state=$?
 
     if [ -z "${ports}" ] || [ "${ports}" = "detect" ] ; then
-        bridge_get_root_ports ${bridge} ports
+        bridge_get_root_ports "${bridge}" ports
     fi
 
     for port in $ports ; do
@@ -369,17 +369,17 @@ bridge_get_active_ports() {
 }
 
 bridge_get_speed() {
-    local iface=$1
+    local iface="$1"
     local aggregate_speed=0
 
-    if ! iface_is_bridge ${iface} ; then
+    if ! iface_is_bridge "${iface}" ; then
         echo 0
         return
     fi
 
     BGS_PORTS=$( bridge_get_active_ports "${iface}" "${OCF_RESKEY_bridge_ports}" )
     for port in ${BGS_PORTS} ; do
-        : $(( aggregate_speed += $( iface_get_speed ${port} ) ))
+        : $(( aggregate_speed += $( iface_get_speed "${port}" ) ))
     done
     if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell.
         eval "$2=\${aggregate_speed}"
@@ -389,7 +389,7 @@ bridge_get_speed() {
 }
 
 hfi1_get_speed() {
-    local iface=$1
+    local iface="$1"
     local hfi1_speed
     local hfi1_value
     local hfi1_desc
@@ -399,15 +399,15 @@ hfi1_get_speed() {
     # method to get the speed. Example output:
     # [root@es-host0 ~]# cat /sys/class/net/ib0/device/infiniband/*/ports/*/rate
     # 100 Gb/sec (4X EDR)
-    read hfi1_speed hfi1_value hfi1_desc < /sys/class/net/${iface}/device/infiniband/*/ports/*/rate
-    ocf_is_true ${OCF_RESKEY_debug} && ocf_log debug "Detected speed $hfi1_speed $hfi1_value $hfi1_desc"
+    read hfi1_speed hfi1_value hfi1_desc < "/sys/class/net/${iface}/device/infiniband"/*/ports/*/rate
+    ocf_is_true "${OCF_RESKEY_debug}" && ocf_log debug "Detected speed $hfi1_speed $hfi1_value $hfi1_desc"
 
     # hfi1_value always in Gb/sec, so we need to convert hfi1_speed in Mb/sec
     echo $(( hfi1_speed * 1000 ))
 }
 
 bond_get_slaves() {
-    local iface=$1
+    local iface="$1"
     local slaves
     read slaves < "/sys/class/net/${iface}/bonding/slaves"
     if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell.
@@ -418,7 +418,7 @@ bond_get_slaves() {
 }
 
 bond_get_active_iface() {
-    local iface=$1
+    local iface="$1"
     local active
     read active < "/sys/class/net/${iface}/bonding/active_slave"
     if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell.
@@ -429,10 +429,10 @@ bond_get_active_iface() {
 }
 
 bond_is_balancing() {
-    local iface=$1
+    local iface="$1"
     read mode mode_index < "/sys/class/net/${iface}/bonding/mode"
-    ocf_is_true ${OCF_RESKEY_debug} && ocf_log debug "Detected balancing $mode $mode_index"
-    case ${mode} in
+    ocf_is_true "${OCF_RESKEY_debug}" && ocf_log debug "Detected balancing $mode $mode_index"
+    case "${mode}" in
         "balance-rr"|"balance-xor"|"802.3ad"|"balance-tlb"|"balance-alb")
             return 0
             ;;
@@ -443,27 +443,27 @@ bond_is_balancing() {
 }
 
 bond_get_speed() {
-    local iface=$1
+    local iface="$1"
     local aggregate_speed=0
     local active_iface
     local bond_slaves
 
-    if ! iface_is_bond ${iface} ; then
+    if ! iface_is_bond "${iface}" ; then
         echo 0
         return
     fi
 
-    bond_get_slaves ${iface} bond_slaves
+    bond_get_slaves "${iface}" bond_slaves
 
-    if bond_is_balancing ${iface} ; then
+    if bond_is_balancing "${iface}" ; then
         for slave in ${bond_slaves} ; do
-            : $(( aggregate_speed += $( iface_get_speed ${slave} ) ))
+            : $(( aggregate_speed += $( iface_get_speed "${slave}" ) ))
         done
         # Bonding is unable to get speed*n
         : $(( aggregate_speed = aggregate_speed * 8 / 10 ))
     else
-        bond_get_active_iface ${iface} active_iface
-        aggregate_speed=$( iface_get_speed $active_iface )
+        bond_get_active_iface "${iface}" "active_iface"
+        aggregate_speed=$( iface_get_speed "$active_iface" )
     fi
     if [ -n "$2" ] ; then # Record value in specified var. This expects we were called not in a sub-shell.
         eval "$2=\${aggregate_speed}"
@@ -474,7 +474,7 @@ bond_get_speed() {
 
 update() {
     local speed;
-    local nic=${OCF_RESKEY_iface};
+    local nic="${OCF_RESKEY_iface}";
     if [ -z "${OCF_RESKEY_iface}" ]; then
         nic=$( get_nic_name_by_ip )
         if [ -z "${nic}" ];then
@@ -482,18 +482,18 @@ update() {
             exit $OCF_ERR_GENERIC
         fi
     fi
-    speed=$( iface_get_speed ${nic} )
+    speed=$( iface_get_speed "${nic}" )
 
     : $(( score = speed * ${OCF_RESKEY_weight_base} / 1000 ))
     if [ "$__OCF_ACTION" = "start" ] ; then
-        attrd_updater -n ${OCF_RESKEY_name} -B ${score} -d ${OCF_RESKEY_dampen} ${attrd_options}
+        attrd_updater -n "${OCF_RESKEY_name}" -B "${score}" -d "${OCF_RESKEY_dampen}" ${attrd_options}
     else
-        attrd_updater -n ${OCF_RESKEY_name} -v ${score} -d ${OCF_RESKEY_dampen} ${attrd_options}
+        attrd_updater -n "${OCF_RESKEY_name}" -v "${score}" -d "${OCF_RESKEY_dampen}" ${attrd_options}
     fi
     rc=$?
     case ${rc} in
         0)
-            ocf_is_true ${OCF_RESKEY_debug} && ocf_log debug "Updated ${OCF_RESKEY_name} = ${score}"
+            ocf_is_true "${OCF_RESKEY_debug}" && ocf_log debug "Updated ${OCF_RESKEY_name} = ${score}"
             ;;
         *)
             ocf_log warn "Could not update ${OCF_RESKEY_name} = ${score}: rc=${rc}"
@@ -521,13 +521,13 @@ fi
 : ${ha_pseudo_resource_name:="ifspeed-${OCF_RESOURCE_INSTANCE}"}
 
 attrd_options='-q'
-if ocf_is_true ${OCF_RESKEY_debug} ; then
+if ocf_is_true "${OCF_RESKEY_debug}" ; then
     attrd_options=''
 fi
 
 validate || exit $?
 
-case $__OCF_ACTION in
+case "$__OCF_ACTION" in
     start)
         start
         ;;

--- a/extra/resources/o2cb.in
+++ b/extra/resources/o2cb.in
@@ -69,7 +69,7 @@ check_filesystem()
 }
 
 #
-# Unload a filesystem driver.  
+# Unload a filesystem driver.
 # Be careful to notice if the driver is built-in and do nothing.
 #
 # 0 is success, 1 is error, 2 is already unloaded.
@@ -214,7 +214,7 @@ unload_module()
 o2cb_start() {
 
     o2cb_monitor; rc=$?
-    if [ $rc != $OCF_NOT_RUNNING ]; then 
+    if [ $rc != $OCF_NOT_RUNNING ]; then
         return $rc
     fi
 
@@ -277,7 +277,7 @@ o2cb_stop() {
     ocf_log info "Stopping $OCF_RESOURCE_INSTANCE"
 
     kill_daemon
-    if [ $? != 0 ]; then 
+    if [ $? != 0 ]; then
         ocf_log err "Unable to unload modules: the cluster is still online"
         return $OCF_ERR_GENERIC
     fi
@@ -357,7 +357,7 @@ o2cb_validate() {
     check_binary ${DAEMON}
 
     case ${OCF_RESKEY_CRM_meta_globally_unique} in
-        yes|Yes|true|True|1) 
+        yes|Yes|true|True|1)
             ocf_log err "$OCF_RESOURCE_INSTANCE must be configured with the globally_unique=false meta attribute"
             exit $OCF_ERR_CONFIGURED
             ;;

--- a/extra/resources/o2cb.in
+++ b/extra/resources/o2cb.in
@@ -3,7 +3,7 @@
 # ocf:pacemaker:o2cb resource agent
 #
 # Original copyright 2005-2008 Oracle
-# Later changes copyright 2008-2018 the Pacemaker project contributors
+# Later changes copyright 2008-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -118,7 +118,7 @@ status_daemon()
 {
     PID=`pidof "$DAEMON"`
     if [ -n "$PID" ]; then
-	return $OCF_SUCCESS
+        return $OCF_SUCCESS
     fi
     return $OCF_NOT_RUNNING
 }
@@ -126,14 +126,14 @@ status_daemon()
 bringup_daemon()
 {
     if [ ! -e "$DAEMON" ]; then
-	ocf_log err "Required binary not found: $DAEMON"
-	return $OCF_ERR_INSTALLED
+        ocf_log err "Required binary not found: $DAEMON"
+        return $OCF_ERR_INSTALLED
     fi
 
     "$DAEMON"; rc=$?
     if [ $rc != 0 ]; then
-	ocf_log err "Could not start $DAEMON"
-	return $OCF_ERR_GENERIC
+        ocf_log err "Could not start $DAEMON"
+        return $OCF_ERR_GENERIC
     fi
 
     sleep 1
@@ -143,10 +143,10 @@ bringup_daemon()
     while [ $rc = $OCF_NOT_RUNNING ]; do
         COUNT=`expr $COUNT + 1`
         if [ $COUNT -gt $OCF_RESKEY_daemon_timeout ]; then
-	    ocf_log err "`basename $DAEMON` did not come up"
-	    return $OCF_ERR_GENERIC
+            ocf_log err "`basename $DAEMON` did not come up"
+            return $OCF_ERR_GENERIC
         fi
-	status_daemon; rc=$?
+        status_daemon; rc=$?
         sleep 1
     done
 
@@ -157,7 +157,7 @@ kill_daemon()
 {
     status_daemon; rc=$?
     if [ $rc != $OCF_SUCCESS ]; then
-	return $rc
+        return $rc
     fi
 
     ocf_log info "Stopping `basename "$DAEMON"`"
@@ -165,7 +165,7 @@ kill_daemon()
 
     while [ $rc = $OCF_NOT_RUNNING ]; do
         sleep 1
-	status_daemon; rc=$?
+        status_daemon; rc=$?
     done
 
     return $OCF_SUCCESS
@@ -179,7 +179,7 @@ unload_module()
 {
     if [ "$#" -lt "1" -o -z "$1" ]
     then
-	ocf_log err  "unload_module(): Requires an argument"
+        ocf_log err  "unload_module(): Requires an argument"
         return 1
     fi
     MODNAME="$1"
@@ -197,14 +197,14 @@ unload_module()
         return 2
         ;;
     *)
-	ocf_log err "Invalid module parsing!"
+        ocf_log err "Invalid module parsing!"
         return 1
         ;;
     esac
 
     modprobe -rs "$MODNAME"
     if [ "$?" != 0 ]; then
-	ocf_log err "Unable to unload module \"$MODNAME\""
+        ocf_log err "Unable to unload module \"$MODNAME\""
         return 1
     fi
 
@@ -215,53 +215,53 @@ o2cb_start() {
 
     o2cb_monitor; rc=$?
     if [ $rc != $OCF_NOT_RUNNING ]; then 
-	return $rc
+        return $rc
     fi
 
     ocf_log info "Starting $OCF_RESOURCE_INSTANCE"
 
     if [ ! -e "$CLUSTER_STACK_FILE" ]; then
-	modprobe -s ocfs2_stackglue
-	if [ $? != 0 ]; then
-	    ocf_log err "Could not load ocfs2_stackglue"
-	    return $OCF_ERR_INSTALLED
-	fi
+        modprobe -s ocfs2_stackglue
+        if [ $? != 0 ]; then
+            ocf_log err "Could not load ocfs2_stackglue"
+            return $OCF_ERR_INSTALLED
+        fi
     fi
 
     SP_OUT="$(awk '/^'user'$/{print; exit}' "$LOADED_PLUGINS_FILE" 2>/dev/null)"
     if [ -z "$SP_OUT" ]
     then
         modprobe -s ocfs2_stack_user
-	if [ $? != 0 ]; then
-	    ocf_log err "Could not load ocfs2_stack_user"
-	    return $OCF_ERR_INSTALLED
-	fi
+        if [ $? != 0 ]; then
+            ocf_log err "Could not load ocfs2_stack_user"
+            return $OCF_ERR_INSTALLED
+        fi
     fi
 
     SP_OUT="$(awk '/^'user'$/{print; exit}' "$LOADED_PLUGINS_FILE" 2>/dev/null)"
     if [ -z "$SP_OUT" ]; then
-	ocf_log err "Switch to userspace stack unsuccessful"
-	return $OCF_ERR_INSTALLED
+        ocf_log err "Switch to userspace stack unsuccessful"
+        return $OCF_ERR_INSTALLED
     fi
 
     if [ -f "$CLUSTER_STACK_FILE" ]; then
         echo "$OCF_RESKEY_stack" >"$CLUSTER_STACK_FILE"
         if [ $? != 0 ]; then
-	    ocf_log err "Userspace stack '$OCF_RESKEY_stack' not supported"
-	    return $OCF_ERR_INSTALLED
-	fi
+            ocf_log err "Userspace stack '$OCF_RESKEY_stack' not supported"
+            return $OCF_ERR_INSTALLED
+        fi
     else
-	ocf_log err "Switch to userspace stack not supported"
-	return $OCF_ERR_INSTALLED
+        ocf_log err "Switch to userspace stack not supported"
+        return $OCF_ERR_INSTALLED
     fi
 
     driver_filesystem ocfs2; rc=$?
     if [ $rc != 0 ]; then
-	modprobe -s ocfs2
-	if [ "$?" != 0 ]; then
+        modprobe -s ocfs2
+        if [ "$?" != 0 ]; then
             ocf_log err "Unable to load ocfs2 module"
             return $OCF_ERR_INSTALLED
-	fi
+        fi
     fi
 
     bringup_daemon
@@ -271,7 +271,7 @@ o2cb_start() {
 o2cb_stop() {
     o2cb_monitor; rc=$?
     case $rc in
-	$OCF_NOT_RUNNING) return $OCF_SUCCESS;;
+        $OCF_NOT_RUNNING) return $OCF_SUCCESS;;
     esac
 
     ocf_log info "Stopping $OCF_RESOURCE_INSTANCE"
@@ -279,13 +279,13 @@ o2cb_stop() {
     kill_daemon
     if [ $? != 0 ]; then 
         ocf_log err "Unable to unload modules: the cluster is still online"
-	return $OCF_ERR_GENERIC
+        return $OCF_ERR_GENERIC
     fi
 
     unload_filesystem ocfs2
     if [ $? = 1 ]; then
-	ocf_log err "Unable to unload ocfs2 module"
-	return $OCF_ERR_GENERIC
+        ocf_log err "Unable to unload ocfs2 module"
+        return $OCF_ERR_GENERIC
     fi
 
     # If we can't find the stack glue, we have nothing to do.
@@ -295,15 +295,15 @@ o2cb_stop() {
     do
         unload_module "ocfs2_stack_${plugin}"
         if [ $? = 1 ]; then
-	    ocf_log err "Unable to unload ocfs2_stack_${plugin}"
-	    return $OCF_ERR_GENERIC
-	fi
+            ocf_log err "Unable to unload ocfs2_stack_${plugin}"
+            return $OCF_ERR_GENERIC
+        fi
     done <"$LOADED_PLUGINS_FILE"
 
     unload_module "ocfs2_stackglue"
     if [ $? = 1 ]; then
-	ocf_log err "Unable to unload ocfs2_stackglue"
-	return $OCF_ERR_GENERIC
+        ocf_log err "Unable to unload ocfs2_stackglue"
+        return $OCF_ERR_GENERIC
     fi
 
     # Don't unmount configfs - it's always in use by libdlm
@@ -316,31 +316,31 @@ o2cb_monitor() {
 
     driver_filesystem configfs; rc=$?
     if [ $rc != 0 ]; then
-	ocf_log info "configfs not loaded"
-	return $OCF_NOT_RUNNING
+        ocf_log info "configfs not loaded"
+        return $OCF_NOT_RUNNING
     fi
 
     check_filesystem configfs "${OCF_RESKEY_configfs}"; rc=$?
     if [ $rc != 0 ]; then
-	ocf_log info "configfs not mounted"
-	return $OCF_NOT_RUNNING
+        ocf_log info "configfs not mounted"
+        return $OCF_NOT_RUNNING
     fi
 
     if [ ! -e "$LOADED_PLUGINS_FILE" ]; then
-	ocf_log info "Stack glue driver not loaded"
-	return $OCF_NOT_RUNNING
+        ocf_log info "Stack glue driver not loaded"
+        return $OCF_NOT_RUNNING
     fi
 
     grep user "$LOADED_PLUGINS_FILE" >/dev/null 2>&1; rc=$?
     if [ $rc != 0 ]; then
-	ocf_log err "Wrong stack `cat $LOADED_PLUGINS_FILE`"
-	return $OCF_ERR_INSTALLED
+        ocf_log err "Wrong stack `cat $LOADED_PLUGINS_FILE`"
+        return $OCF_ERR_INSTALLED
     fi
 
     driver_filesystem ocfs2; rc=$?
     if [ $rc != 0 ]; then
-	ocf_log info "ocfs2 not loaded"
-	return $OCF_NOT_RUNNING
+        ocf_log info "ocfs2 not loaded"
+        return $OCF_NOT_RUNNING
     fi
 
     status_daemon
@@ -357,17 +357,17 @@ o2cb_validate() {
     check_binary ${DAEMON}
 
     case ${OCF_RESKEY_CRM_meta_globally_unique} in
-	yes|Yes|true|True|1) 
-	    ocf_log err "$OCF_RESOURCE_INSTANCE must be configured with the globally_unique=false meta attribute"
-	    exit $OCF_ERR_CONFIGURED
-	    ;;
+        yes|Yes|true|True|1) 
+            ocf_log err "$OCF_RESOURCE_INSTANCE must be configured with the globally_unique=false meta attribute"
+            exit $OCF_ERR_CONFIGURED
+            ;;
     esac
 
     return $OCF_SUCCESS
 }
 
 meta_data() {
-	cat <<END
+        cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
 <resource-agent name="o2cb" version="1.0">
@@ -423,23 +423,23 @@ END
 }
 
 case $__OCF_ACTION in
-meta-data)	meta_data
-		exit $OCF_SUCCESS
-		;;
-start)		o2cb_start
-		;;
-stop)		o2cb_stop
-		;;
-monitor)	o2cb_monitor
-		;;
-validate-all)	o2cb_validate
-		;;
-usage|help)	o2cb_usage
-		exit $OCF_SUCCESS
-		;;
-*)		o2cb_usage
-		exit $OCF_ERR_UNIMPLEMENTED
-		;;
+meta-data)      meta_data
+                exit $OCF_SUCCESS
+                ;;
+start)          o2cb_start
+                ;;
+stop)           o2cb_stop
+                ;;
+monitor)        o2cb_monitor
+                ;;
+validate-all)   o2cb_validate
+                ;;
+usage|help)     o2cb_usage
+                exit $OCF_SUCCESS
+                ;;
+*)              o2cb_usage
+                exit $OCF_ERR_UNIMPLEMENTED
+                ;;
 esac
 
 exit $?

--- a/extra/resources/o2cb.in
+++ b/extra/resources/o2cb.in
@@ -1,25 +1,16 @@
 #!@BASH_PATH@
 #
+# ocf:pacemaker:o2cb resource agent
+#
 # Original copyright 2005-2008 Oracle
 # Later changes copyright 2008-2018 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of version 2 of the GNU General Public License as
-# published by the Free Software Foundation.
+# This source code is licensed under the GNU General Public License version 2
+# (GPLv2) WITHOUT ANY WARRANTY.
 #
-# This program is distributed in the hope that it would be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# Further, this software is distributed without any warranty that it is
-# free of the rightful claim of any third person regarding infringement
-# or the like.  Any license provided herein, whether implied or
-# otherwise, applies only to this software file.  Patent licenses, if
-# any, provided herein do not apply to combinations of this program with
-# other software, or any other product whatsoever.
-#
+
 #######################################################################
 
 : ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}

--- a/extra/resources/o2cb.in
+++ b/extra/resources/o2cb.in
@@ -62,8 +62,8 @@ check_filesystem()
     FSNAME="$1"
     MOUNTPOINT="$2"
 
-    FULL_MOUNTSEARCH="`echo "$MOUNTPOINT" | sed -e 's/\//\\\\\//g'`"
-    MOUNTOUT="`awk '$2 ~ /^'$FULL_MOUNTSEARCH'$/ && $3 ~ /^'$FSNAME'$/{print $2; exit}' < /proc/mounts 2>/dev/null`"
+    FULL_MOUNTSEARCH=$(echo "$MOUNTPOINT" | sed -e 's/\//\\\\\//g')
+    MOUNTOUT=$(awk '$2 ~ /^'$FULL_MOUNTSEARCH'$/ && $3 ~ /^'$FSNAME'$/{print $2; exit}' < /proc/mounts 2>/dev/null)
     test -n "$MOUNTOUT"
     return $?
 }
@@ -85,7 +85,7 @@ unload_filesystem()
 
     driver_filesystem "$FSNAME" || return 2
 
-    MODOUT="`awk '$1 ~ /^'$FSNAME'$/{print $1,$3;exit}' < /proc/modules 2>/dev/null`"
+    MODOUT=$(awk '$1 ~ /^'$FSNAME'$/{print $1,$3;exit}' < /proc/modules 2>/dev/null)
     if [ -z "$MODOUT" ]; then
         # The driver is built in, we can't unload it.
         return 0
@@ -116,7 +116,7 @@ unload_filesystem()
 
 status_daemon()
 {
-    PID=`pidof "$DAEMON"`
+    PID=$(pidof "$DAEMON")
     if [ -n "$PID" ]; then
         return $OCF_SUCCESS
     fi
@@ -141,9 +141,9 @@ bringup_daemon()
     rc=$OCF_NOT_RUNNING
 
     while [ $rc = $OCF_NOT_RUNNING ]; do
-        COUNT=`expr $COUNT + 1`
+        COUNT=$(expr $COUNT + 1)
         if [ $COUNT -gt $OCF_RESKEY_daemon_timeout ]; then
-            ocf_log err "`basename $DAEMON` did not come up"
+            ocf_log err "$(basename $DAEMON) did not come up"
             return $OCF_ERR_GENERIC
         fi
         status_daemon; rc=$?
@@ -160,7 +160,7 @@ kill_daemon()
         return $rc
     fi
 
-    ocf_log info "Stopping `basename "$DAEMON"`"
+    ocf_log info "Stopping $(basename "$DAEMON")"
     killproc "$DAEMON"
 
     while [ $rc = $OCF_NOT_RUNNING ]; do
@@ -184,7 +184,7 @@ unload_module()
     fi
     MODNAME="$1"
 
-    MODOUT="`awk '$1 ~ /^'$MODNAME'$/{print $1,$3;exit}' < /proc/modules 2>/dev/null`"
+    MODOUT=$(awk '$1 ~ /^'$MODNAME'$/{print $1,$3;exit}' < /proc/modules 2>/dev/null)
     if [ -z "$MODOUT" ]
     then
         return 2
@@ -333,7 +333,7 @@ o2cb_monitor() {
 
     grep user "$LOADED_PLUGINS_FILE" >/dev/null 2>&1; rc=$?
     if [ $rc != 0 ]; then
-        ocf_log err "Wrong stack `cat $LOADED_PLUGINS_FILE`"
+        ocf_log err "Wrong stack $(cat $LOADED_PLUGINS_FILE)"
         return $OCF_ERR_INSTALLED
     fi
 

--- a/extra/resources/o2cb.in
+++ b/extra/resources/o2cb.in
@@ -443,3 +443,5 @@ usage|help)     o2cb_usage
 esac
 
 exit $?
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/o2cb.in
+++ b/extra/resources/o2cb.in
@@ -54,7 +54,7 @@ driver_filesystem() {
 #
 check_filesystem()
 {
-    if [ $# != 2 -o -z "$1" -o -z "$2" ]
+    if [ $# -ne 2 -o -z "$1" -o -z "$2" ]
     then
         ocf_log err "check_filesystem(): Missing arguments"
         exit 4
@@ -76,7 +76,7 @@ check_filesystem()
 #
 unload_filesystem()
 {
-    if [ $# != 1 -o -z "$1" ]
+    if [ $# -ne 1 -o -z "$1" ]
     then
         ocf_log err "unload_filesystem(): Missing an argument"
         return 1
@@ -106,7 +106,7 @@ unload_filesystem()
     esac
 
     modprobe -rs "$FSNAME"
-    if [ $? != 0 ]; then
+    if [ $? -ne 0 ]; then
         ocf_log err "Unable to unload module: $FSNAME"
         return 1
     fi
@@ -131,7 +131,7 @@ bringup_daemon()
     fi
 
     "$DAEMON"; rc=$?
-    if [ $rc != 0 ]; then
+    if [ $rc -ne 0 ]; then
         ocf_log err "Could not start $DAEMON"
         return $OCF_ERR_GENERIC
     fi
@@ -140,7 +140,7 @@ bringup_daemon()
     COUNT=0
     rc=$OCF_NOT_RUNNING
 
-    while [ $rc = $OCF_NOT_RUNNING ]; do
+    while [ $rc -eq $OCF_NOT_RUNNING ]; do
         COUNT=$(expr $COUNT + 1)
         if [ $COUNT -gt $OCF_RESKEY_daemon_timeout ]; then
             ocf_log err "$(basename $DAEMON) did not come up"
@@ -156,14 +156,14 @@ bringup_daemon()
 kill_daemon()
 {
     status_daemon; rc=$?
-    if [ $rc != $OCF_SUCCESS ]; then
+    if [ $rc -ne $OCF_SUCCESS ]; then
         return $rc
     fi
 
     ocf_log info "Stopping $(basename "$DAEMON")"
     killproc "$DAEMON"
 
-    while [ $rc = $OCF_NOT_RUNNING ]; do
+    while [ $rc -eq $OCF_NOT_RUNNING ]; do
         sleep 1
         status_daemon; rc=$?
     done
@@ -203,7 +203,7 @@ unload_module()
     esac
 
     modprobe -rs "$MODNAME"
-    if [ $? != 0 ]; then
+    if [ $? -ne 0 ]; then
         ocf_log err "Unable to unload module \"$MODNAME\""
         return 1
     fi
@@ -214,7 +214,7 @@ unload_module()
 o2cb_start() {
 
     o2cb_monitor; rc=$?
-    if [ $rc != $OCF_NOT_RUNNING ]; then
+    if [ $rc -ne $OCF_NOT_RUNNING ]; then
         return $rc
     fi
 
@@ -222,7 +222,7 @@ o2cb_start() {
 
     if [ ! -e "$CLUSTER_STACK_FILE" ]; then
         modprobe -s ocfs2_stackglue
-        if [ $? != 0 ]; then
+        if [ $? -ne 0 ]; then
             ocf_log err "Could not load ocfs2_stackglue"
             return $OCF_ERR_INSTALLED
         fi
@@ -232,7 +232,7 @@ o2cb_start() {
     if [ -z "$SP_OUT" ]
     then
         modprobe -s ocfs2_stack_user
-        if [ $? != 0 ]; then
+        if [ $? -ne 0 ]; then
             ocf_log err "Could not load ocfs2_stack_user"
             return $OCF_ERR_INSTALLED
         fi
@@ -246,7 +246,7 @@ o2cb_start() {
 
     if [ -f "$CLUSTER_STACK_FILE" ]; then
         echo "$OCF_RESKEY_stack" >"$CLUSTER_STACK_FILE"
-        if [ $? != 0 ]; then
+        if [ $? -ne 0 ]; then
             ocf_log err "Userspace stack '$OCF_RESKEY_stack' not supported"
             return $OCF_ERR_INSTALLED
         fi
@@ -256,9 +256,9 @@ o2cb_start() {
     fi
 
     driver_filesystem ocfs2; rc=$?
-    if [ $rc != 0 ]; then
+    if [ $rc -ne 0 ]; then
         modprobe -s ocfs2
-        if [ $? != 0 ]; then
+        if [ $? -ne 0 ]; then
             ocf_log err "Unable to load ocfs2 module"
             return $OCF_ERR_INSTALLED
         fi
@@ -277,13 +277,13 @@ o2cb_stop() {
     ocf_log info "Stopping $OCF_RESOURCE_INSTANCE"
 
     kill_daemon
-    if [ $? != 0 ]; then
+    if [ $? -ne 0 ]; then
         ocf_log err "Unable to unload modules: the cluster is still online"
         return $OCF_ERR_GENERIC
     fi
 
     unload_filesystem ocfs2
-    if [ $? = 1 ]; then
+    if [ $? -eq 1 ]; then
         ocf_log err "Unable to unload ocfs2 module"
         return $OCF_ERR_GENERIC
     fi
@@ -294,14 +294,14 @@ o2cb_stop() {
     while read plugin
     do
         unload_module "ocfs2_stack_${plugin}"
-        if [ $? = 1 ]; then
+        if [ $? -eq 1 ]; then
             ocf_log err "Unable to unload ocfs2_stack_${plugin}"
             return $OCF_ERR_GENERIC
         fi
     done <"$LOADED_PLUGINS_FILE"
 
     unload_module "ocfs2_stackglue"
-    if [ $? = 1 ]; then
+    if [ $? -eq 1 ]; then
         ocf_log err "Unable to unload ocfs2_stackglue"
         return $OCF_ERR_GENERIC
     fi
@@ -315,13 +315,13 @@ o2cb_monitor() {
     # Assume that ocfs2_controld will terminate if any of the conditions below are met
 
     driver_filesystem configfs; rc=$?
-    if [ $rc != 0 ]; then
+    if [ $rc -ne 0 ]; then
         ocf_log info "configfs not loaded"
         return $OCF_NOT_RUNNING
     fi
 
     check_filesystem configfs "${OCF_RESKEY_configfs}"; rc=$?
-    if [ $rc != 0 ]; then
+    if [ $rc -ne 0 ]; then
         ocf_log info "configfs not mounted"
         return $OCF_NOT_RUNNING
     fi
@@ -332,13 +332,13 @@ o2cb_monitor() {
     fi
 
     grep user "$LOADED_PLUGINS_FILE" >/dev/null 2>&1; rc=$?
-    if [ $rc != 0 ]; then
+    if [ $rc -ne 0 ]; then
         ocf_log err "Wrong stack $(cat $LOADED_PLUGINS_FILE)"
         return $OCF_ERR_INSTALLED
     fi
 
     driver_filesystem ocfs2; rc=$?
-    if [ $rc != 0 ]; then
+    if [ $rc -ne 0 ]; then
         ocf_log info "ocfs2 not loaded"
         return $OCF_NOT_RUNNING
     fi

--- a/extra/resources/o2cb.in
+++ b/extra/resources/o2cb.in
@@ -13,9 +13,9 @@
 
 #######################################################################
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 : ${OCF_RESKEY_stack:="pcmk"}
 : ${OCF_RESKEY_sysfs:="/sys/fs"}

--- a/extra/resources/o2cb.in
+++ b/extra/resources/o2cb.in
@@ -13,9 +13,9 @@
 
 #######################################################################
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 : ${OCF_RESKEY_stack:="pcmk"}
 : ${OCF_RESKEY_sysfs:="/sys/fs"}
@@ -54,7 +54,7 @@ driver_filesystem() {
 #
 check_filesystem()
 {
-    if [ "$#" != "2" -o -z "$1" -o -z "$2" ]
+    if [ $# != 2 -o -z "$1" -o -z "$2" ]
     then
         ocf_log err "check_filesystem(): Missing arguments"
         exit 4
@@ -76,7 +76,7 @@ check_filesystem()
 #
 unload_filesystem()
 {
-    if [ "$#" != "1" -o -z "$1" ]
+    if [ $# != 1 -o -z "$1" ]
     then
         ocf_log err "unload_filesystem(): Missing an argument"
         return 1
@@ -106,7 +106,7 @@ unload_filesystem()
     esac
 
     modprobe -rs "$FSNAME"
-    if [ "$?" != 0 ]; then
+    if [ $? != 0 ]; then
         ocf_log err "Unable to unload module: $FSNAME"
         return 1
     fi
@@ -177,7 +177,7 @@ kill_daemon()
 #
 unload_module()
 {
-    if [ "$#" -lt "1" -o -z "$1" ]
+    if [ $# -lt 1 -o -z "$1" ]
     then
         ocf_log err  "unload_module(): Requires an argument"
         return 1
@@ -203,7 +203,7 @@ unload_module()
     esac
 
     modprobe -rs "$MODNAME"
-    if [ "$?" != 0 ]; then
+    if [ $? != 0 ]; then
         ocf_log err "Unable to unload module \"$MODNAME\""
         return 1
     fi
@@ -258,7 +258,7 @@ o2cb_start() {
     driver_filesystem ocfs2; rc=$?
     if [ $rc != 0 ]; then
         modprobe -s ocfs2
-        if [ "$?" != 0 ]; then
+        if [ $? != 0 ]; then
             ocf_log err "Unable to load ocfs2 module"
             return $OCF_ERR_INSTALLED
         fi
@@ -356,7 +356,7 @@ o2cb_usage() {
 o2cb_validate() {
     check_binary ${DAEMON}
 
-    case ${OCF_RESKEY_CRM_meta_globally_unique} in
+    case "${OCF_RESKEY_CRM_meta_globally_unique}" in
         yes|Yes|true|True|1)
             ocf_log err "$OCF_RESOURCE_INSTANCE must be configured with the globally_unique=false meta attribute"
             exit $OCF_ERR_CONFIGURED
@@ -422,7 +422,7 @@ Number of seconds to allow the control daemon to come up
 END
 }
 
-case $__OCF_ACTION in
+case "$__OCF_ACTION" in
 meta-data)      meta_data
                 exit $OCF_SUCCESS
                 ;;

--- a/extra/resources/ping
+++ b/extra/resources/ping
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Ping OCF RA that utilizes the system ping 
+# ocf:pacemaker:ping resource agent
 #
 # Copyright 2009-2018 the Pacemaker project contributors
 #
@@ -9,6 +9,7 @@
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
+
 #######################################################################
 # Initialization:
 

--- a/extra/resources/ping
+++ b/extra/resources/ping
@@ -13,9 +13,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 #######################################################################
 

--- a/extra/resources/ping
+++ b/extra/resources/ping
@@ -153,7 +153,7 @@ END
 
 ping_start() {
     ping_monitor
-    if [ $? =  $OCF_SUCCESS ]; then
+    if [ $? -eq $OCF_SUCCESS ]; then
         return $OCF_SUCCESS
     fi
     touch "${OCF_RESKEY_pidfile}"
@@ -184,7 +184,7 @@ ping_validate() {
     # Is the state directory writable?
     state_dir=$(dirname "$OCF_RESKEY_pidfile")
     touch "$state_dir/$$"
-    if [ $? != 0 ]; then
+    if [ $? -ne 0 ]; then
         ocf_log err "Invalid location for 'state': $state_dir is not writable"
         return $OCF_ERR_ARGS
     fi
@@ -197,7 +197,7 @@ ping_validate() {
     esac
 
 # Check the host list
-    if [ "x" = "x$OCF_RESKEY_host_list" ]; then
+    if [ -z "$OCF_RESKEY_host_list" ]; then
         ocf_log err "Empty host_list.  Please specify some nodes to ping"
         exit $OCF_ERR_CONFIGURED
     fi
@@ -361,7 +361,7 @@ case "${OCF_RESKEY_timeout}" in
 esac
 
 if [ -z "${OCF_RESKEY_timeout}" ]; then
-    if [ x"$OCF_RESKEY_host_list" != x ]; then
+    if [ -n "$OCF_RESKEY_host_list" ]; then
         host_count=$(echo $OCF_RESKEY_host_list | awk '{print NF}')
         OCF_RESKEY_timeout=$(expr $OCF_RESKEY_CRM_meta_timeout / $host_count / $OCF_RESKEY_attempts)
         OCF_RESKEY_timeout=$(expr $OCF_RESKEY_timeout / 1100) # Convert to seconds and finish 10% early

--- a/extra/resources/ping
+++ b/extra/resources/ping
@@ -182,7 +182,7 @@ ping_monitor() {
 
 ping_validate() {
     # Is the state directory writable?
-    state_dir=`dirname "$OCF_RESKEY_pidfile"`
+    state_dir=$(dirname "$OCF_RESKEY_pidfile")
     touch "$state_dir/$$"
     if [ $? != 0 ]; then
         ocf_log err "Invalid location for 'state': $state_dir is not writable"
@@ -227,22 +227,22 @@ fping_check() {
 
     active=0
 
-    timeout=`expr $OCF_RESKEY_timeout \* 1000 / $OCF_RESKEY_attempts`
+    timeout=$(expr $OCF_RESKEY_timeout \* 1000 / $OCF_RESKEY_attempts)
 
     cmd="$p_exe -r $OCF_RESKEY_attempts -t $timeout -B 1.0 $OCF_RESKEY_options $OCF_RESKEY_host_list"
-    output=`$cmd 2>&1`; rc=$?
-    active=`echo "$output" | grep "is alive" | wc -l`
+    output=$($cmd 2>&1); rc=$?
+    active=$(echo "$output" | grep "is alive" | wc -l)
 
     case $rc in
         0)
             ;;
         1)
-            for h in `echo "$output" | grep "is unreachable" | awk '{print $1}'`; do
+            for h in $(echo "$output" | grep "is unreachable" | awk '{print $1}'); do
                 ping_conditional_log warn "$h is inactive"
             done
             ;;
         *)
-            ocf_log err "Unexpected result for '$cmd' $rc: `echo "$output" | tr '\n' ';'`"
+            ocf_log err "Unexpected result for '$cmd' $rc: $(echo "$output" | tr '\n' ';')"
             ;;
     esac
 
@@ -254,21 +254,21 @@ ping_check() {
     for host in $OCF_RESKEY_host_list; do
         p_exe=ping
 
-        case `uname` in
+        case $(uname) in
             Linux) p_args="-n -q -W $OCF_RESKEY_timeout -c $OCF_RESKEY_attempts";;
             Darwin) p_args="-n -q -t $OCF_RESKEY_timeout -c $OCF_RESKEY_attempts -o";;
             FreeBSD) p_args="-n -q -t $OCF_RESKEY_timeout -c $OCF_RESKEY_attempts -o";;
-            *) ocf_log err "Unknown host type: `uname`"; exit $OCF_ERR_INSTALLED;;
+            *) ocf_log err "Unknown host type: $(uname)"; exit $OCF_ERR_INSTALLED;;
         esac
 
         case "$host" in
             *:*) p_exe=ping6
         esac
 
-        p_out=`$p_exe $p_args $OCF_RESKEY_options $host 2>&1`; rc=$?
+        p_out=$($p_exe $p_args $OCF_RESKEY_options $host 2>&1); rc=$?
 
         case $rc in
-            0) active=`expr $active + 1`;;
+            0) active=$(expr $active + 1);;
             1) ping_conditional_log warn "$host is inactive: $p_out";;
             *) ocf_log err "Unexpected result for '$p_exe $p_args $OCF_RESKEY_options $host' $rc: $p_out";;
         esac
@@ -286,7 +286,7 @@ ping_update() {
         active=$?
     fi
 
-    score=`expr $active \* $OCF_RESKEY_multiplier`
+    score=$(expr $active \* $OCF_RESKEY_multiplier)
     if [ "$__OCF_ACTION" = "start" ] ; then
         attrd_updater -n "$OCF_RESKEY_name" -B "$score" -d "$OCF_RESKEY_dampen" $attrd_options
     else
@@ -352,19 +352,19 @@ hosts_family() {
 : ${OCF_RESKEY_CRM_meta_timeout:="20000"}
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
-integer=`echo ${OCF_RESKEY_timeout} | egrep -o '[0-9]*'`
+integer=$(echo ${OCF_RESKEY_timeout} | egrep -o '[0-9]*')
 case "${OCF_RESKEY_timeout}" in
-    *[0-9]ms|*[0-9]msec) OCF_RESKEY_timeout=`expr $integer / 1000`;;
-    *[0-9]m|*[0-9]min) OCF_RESKEY_timeout=`expr $integer \* 60`;;
-    *[0-9]h|*[0-9]hr)  OCF_RESKEY_timeout=`expr $integer \* 60 \* 60`;;
+    *[0-9]ms|*[0-9]msec) OCF_RESKEY_timeout=$(expr $integer / 1000);;
+    *[0-9]m|*[0-9]min) OCF_RESKEY_timeout=$(expr $integer \* 60);;
+    *[0-9]h|*[0-9]hr)  OCF_RESKEY_timeout=$(expr $integer \* 60 \* 60);;
     *) OCF_RESKEY_timeout=$integer;;
 esac
 
 if [ -z "${OCF_RESKEY_timeout}" ]; then
     if [ x"$OCF_RESKEY_host_list" != x ]; then
-        host_count=`echo $OCF_RESKEY_host_list | awk '{print NF}'`
-        OCF_RESKEY_timeout=`expr $OCF_RESKEY_CRM_meta_timeout / $host_count / $OCF_RESKEY_attempts`
-        OCF_RESKEY_timeout=`expr $OCF_RESKEY_timeout / 1100` # Convert to seconds and finish 10% early
+        host_count=$(echo $OCF_RESKEY_host_list | awk '{print NF}')
+        OCF_RESKEY_timeout=$(expr $OCF_RESKEY_CRM_meta_timeout / $host_count / $OCF_RESKEY_attempts)
+        OCF_RESKEY_timeout=$(expr $OCF_RESKEY_timeout / 1100) # Convert to seconds and finish 10% early
     else
         OCF_RESKEY_timeout=5
     fi

--- a/extra/resources/ping
+++ b/extra/resources/ping
@@ -137,7 +137,7 @@ END
 #######################################################################
 
 ping_conditional_log() {
-    level=$1; shift 
+    level=$1; shift
     if [ ${OCF_RESKEY_debug} = "true" ]; then
         ocf_log $level "$*"
     fi
@@ -163,9 +163,9 @@ ping_start() {
 ping_stop() {
 
     rm -f ${OCF_RESKEY_pidfile}
-    
+
     attrd_updater -D -n $OCF_RESKEY_name -d $OCF_RESKEY_dampen $attrd_options
-    
+
     return $OCF_SUCCESS
 }
 
@@ -181,7 +181,7 @@ ping_monitor() {
 }
 
 ping_validate() {
-    # Is the state directory writable? 
+    # Is the state directory writable?
     state_dir=`dirname "$OCF_RESKEY_pidfile"`
     touch "$state_dir/$$"
     if [ $? != 0 ]; then
@@ -195,9 +195,9 @@ ping_validate() {
         /*) ;;
         *) ocf_log warn "You should use an absolute path for pidfile not: $OCF_RESKEY_pidfile" ;;
     esac
-    
+
 # Check the host list
-    if [ "x" = "x$OCF_RESKEY_host_list" ]; then 
+    if [ "x" = "x$OCF_RESKEY_host_list" ]; then
         ocf_log err "Empty host_list.  Please specify some nodes to ping"
         exit $OCF_ERR_CONFIGURED
     fi
@@ -234,14 +234,14 @@ fping_check() {
     active=`echo "$output" | grep "is alive" | wc -l`
 
     case $rc in
-        0) 
+        0)
             ;;
-        1) 
+        1)
             for h in `echo "$output" | grep "is unreachable" | awk '{print $1}'`; do
                 ping_conditional_log warn "$h is inactive"
             done
             ;;
-        *) 
+        *)
             ocf_log err "Unexpected result for '$cmd' $rc: `echo "$output" | tr '\n' ';'`"
             ;;
     esac
@@ -264,7 +264,7 @@ ping_check() {
         case $host in
             *:*) p_exe=ping6
         esac
-        
+
         p_out=`$p_exe $p_args $OCF_RESKEY_options $host 2>&1`; rc=$?
 
         case $rc in
@@ -277,7 +277,7 @@ ping_check() {
 }
 
 ping_update() {
-    
+
     if use_fping; then
         fping_check
         active=$?
@@ -293,7 +293,7 @@ ping_update() {
         attrd_updater -n $OCF_RESKEY_name -v $score -d $OCF_RESKEY_dampen $attrd_options
     fi
     rc=$?
-    case $rc in 
+    case $rc in
         0) ping_conditional_log debug "Updated $OCF_RESKEY_name = $score" ;;
         *) ocf_log warn "Could not update $OCF_RESKEY_name = $score: rc=$rc";;
     esac
@@ -331,7 +331,7 @@ hosts_family() {
     family=0
     for host in $OCF_RESKEY_host_list; do
         host_family $host
-        f=$?        
+        f=$?
         if [ $family -ne 0 ] && [ $f -ne 0 ] && [ $f -ne $family ] ; then
             family=99
             break
@@ -379,7 +379,7 @@ fi
 
 if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
     : ${OCF_RESKEY_pidfile:="${HA_VARRUN%%/}/ping-${OCF_RESKEY_name}"}
-else 
+else
     : ${OCF_RESKEY_pidfile:="${HA_VARRUN%%/}/ping-${OCF_RESOURCE_INSTANCE}"}
 fi
 

--- a/extra/resources/ping
+++ b/extra/resources/ping
@@ -414,3 +414,5 @@ usage|help)     ping_usage
                 ;;
 esac
 exit $?
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/ping
+++ b/extra/resources/ping
@@ -13,9 +13,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 #######################################################################
 
@@ -137,9 +137,9 @@ END
 #######################################################################
 
 ping_conditional_log() {
-    level=$1; shift
-    if [ ${OCF_RESKEY_debug} = "true" ]; then
-        ocf_log $level "$*"
+    level="$1"; shift
+    if [ "${OCF_RESKEY_debug}" = "true" ]; then
+        ocf_log "$level" "$*"
     fi
 }
 
@@ -156,21 +156,21 @@ ping_start() {
     if [ $? =  $OCF_SUCCESS ]; then
         return $OCF_SUCCESS
     fi
-    touch ${OCF_RESKEY_pidfile}
+    touch "${OCF_RESKEY_pidfile}"
     ping_update
 }
 
 ping_stop() {
 
-    rm -f ${OCF_RESKEY_pidfile}
+    rm -f "${OCF_RESKEY_pidfile}"
 
-    attrd_updater -D -n $OCF_RESKEY_name -d $OCF_RESKEY_dampen $attrd_options
+    attrd_updater -D -n "$OCF_RESKEY_name" -d "$OCF_RESKEY_dampen" $attrd_options
 
     return $OCF_SUCCESS
 }
 
 ping_monitor() {
-    if [ -f ${OCF_RESKEY_pidfile} ]; then
+    if [ -f "${OCF_RESKEY_pidfile}" ]; then
         ping_update
         if [ $? -eq 0 ]; then
             return $OCF_SUCCESS
@@ -191,7 +191,7 @@ ping_validate() {
     rm "$state_dir/$$"
 
 # Pidfile better be an absolute path
-    case $OCF_RESKEY_pidfile in
+    case "$OCF_RESKEY_pidfile" in
         /*) ;;
         *) ocf_log warn "You should use an absolute path for pidfile not: $OCF_RESKEY_pidfile" ;;
     esac
@@ -261,7 +261,7 @@ ping_check() {
             *) ocf_log err "Unknown host type: `uname`"; exit $OCF_ERR_INSTALLED;;
         esac
 
-        case $host in
+        case "$host" in
             *:*) p_exe=ping6
         esac
 
@@ -288,9 +288,9 @@ ping_update() {
 
     score=`expr $active \* $OCF_RESKEY_multiplier`
     if [ "$__OCF_ACTION" = "start" ] ; then
-        attrd_updater -n $OCF_RESKEY_name -B $score -d $OCF_RESKEY_dampen $attrd_options
+        attrd_updater -n "$OCF_RESKEY_name" -B "$score" -d "$OCF_RESKEY_dampen" $attrd_options
     else
-        attrd_updater -n $OCF_RESKEY_name -v $score -d $OCF_RESKEY_dampen $attrd_options
+        attrd_updater -n "$OCF_RESKEY_name" -v "$score" -d "$OCF_RESKEY_dampen" $attrd_options
     fi
     rc=$?
     case $rc in
@@ -330,7 +330,7 @@ hosts_family() {
     # For fping allow only same IP versions or hostnames
     family=0
     for host in $OCF_RESKEY_host_list; do
-        host_family $host
+        host_family "$host"
         f=$?
         if [ $family -ne 0 ] && [ $f -ne 0 ] && [ $f -ne $family ] ; then
             family=99
@@ -353,14 +353,14 @@ hosts_family() {
 : ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
 
 integer=`echo ${OCF_RESKEY_timeout} | egrep -o '[0-9]*'`
-case ${OCF_RESKEY_timeout} in
+case "${OCF_RESKEY_timeout}" in
     *[0-9]ms|*[0-9]msec) OCF_RESKEY_timeout=`expr $integer / 1000`;;
     *[0-9]m|*[0-9]min) OCF_RESKEY_timeout=`expr $integer \* 60`;;
     *[0-9]h|*[0-9]hr)  OCF_RESKEY_timeout=`expr $integer \* 60 \* 60`;;
     *) OCF_RESKEY_timeout=$integer;;
 esac
 
-if [ -z ${OCF_RESKEY_timeout} ]; then
+if [ -z "${OCF_RESKEY_timeout}" ]; then
     if [ x"$OCF_RESKEY_host_list" != x ]; then
         host_count=`echo $OCF_RESKEY_host_list | awk '{print NF}'`
         OCF_RESKEY_timeout=`expr $OCF_RESKEY_CRM_meta_timeout / $host_count / $OCF_RESKEY_attempts`
@@ -377,7 +377,7 @@ elif [ ${OCF_RESKEY_timeout} -gt 1000 ]; then
     OCF_RESKEY_timeout=300
 fi
 
-if [ ${OCF_RESKEY_CRM_meta_globally_unique} = "false" ]; then
+if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
     : ${OCF_RESKEY_pidfile:="${HA_VARRUN%%/}/ping-${OCF_RESKEY_name}"}
 else
     : ${OCF_RESKEY_pidfile:="${HA_VARRUN%%/}/ping-${OCF_RESOURCE_INSTANCE}"}
@@ -394,11 +394,11 @@ case "${OCF_RESKEY_debug}" in
 esac
 
 attrd_options='-q'
-if [ ${OCF_RESKEY_debug} = "true" ]; then
+if [ "${OCF_RESKEY_debug}" = "true" ]; then
     attrd_options=''
 fi
 
-case $__OCF_ACTION in
+case "$__OCF_ACTION" in
 meta-data)      meta_data
                 exit $OCF_SUCCESS
                 ;;

--- a/extra/resources/ping
+++ b/extra/resources/ping
@@ -2,7 +2,7 @@
 #
 # ocf:pacemaker:ping resource agent
 #
-# Copyright 2009-2018 the Pacemaker project contributors
+# Copyright 2009-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -20,7 +20,7 @@
 #######################################################################
 
 meta_data() {
-	cat <<END
+     cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
 <resource-agent name="ping" version="1.0">
@@ -139,12 +139,12 @@ END
 ping_conditional_log() {
     level=$1; shift 
     if [ ${OCF_RESKEY_debug} = "true" ]; then
-	ocf_log $level "$*"
+        ocf_log $level "$*"
     fi
 }
 
 ping_usage() {
-	cat <<END
+    cat <<END
 usage: $0 {start|stop|monitor|validate-all|meta-data}
 
 Expects to have a fully populated OCF RA-compliant environment set.
@@ -154,7 +154,7 @@ END
 ping_start() {
     ping_monitor
     if [ $? =  $OCF_SUCCESS ]; then
-	return $OCF_SUCCESS
+        return $OCF_SUCCESS
     fi
     touch ${OCF_RESKEY_pidfile}
     ping_update
@@ -162,7 +162,7 @@ ping_start() {
 
 ping_stop() {
 
-	rm -f ${OCF_RESKEY_pidfile}
+    rm -f ${OCF_RESKEY_pidfile}
     
     attrd_updater -D -n $OCF_RESKEY_name -d $OCF_RESKEY_dampen $attrd_options
     
@@ -171,7 +171,7 @@ ping_stop() {
 
 ping_monitor() {
     if [ -f ${OCF_RESKEY_pidfile} ]; then
-	ping_update
+        ping_update
         if [ $? -eq 0 ]; then
             return $OCF_SUCCESS
         fi
@@ -185,21 +185,21 @@ ping_validate() {
     state_dir=`dirname "$OCF_RESKEY_pidfile"`
     touch "$state_dir/$$"
     if [ $? != 0 ]; then
-	ocf_log err "Invalid location for 'state': $state_dir is not writable"
-	return $OCF_ERR_ARGS
+        ocf_log err "Invalid location for 'state': $state_dir is not writable"
+        return $OCF_ERR_ARGS
     fi
     rm "$state_dir/$$"
 
 # Pidfile better be an absolute path
     case $OCF_RESKEY_pidfile in
-	/*) ;;
-	*) ocf_log warn "You should use an absolute path for pidfile not: $OCF_RESKEY_pidfile" ;;
+        /*) ;;
+        *) ocf_log warn "You should use an absolute path for pidfile not: $OCF_RESKEY_pidfile" ;;
     esac
     
 # Check the host list
     if [ "x" = "x$OCF_RESKEY_host_list" ]; then 
-	ocf_log err "Empty host_list.  Please specify some nodes to ping"
-	exit $OCF_ERR_CONFIGURED
+        ocf_log err "Empty host_list.  Please specify some nodes to ping"
+        exit $OCF_ERR_CONFIGURED
     fi
 
     # For fping allow only same IP versions or hostnames
@@ -234,16 +234,16 @@ fping_check() {
     active=`echo "$output" | grep "is alive" | wc -l`
 
     case $rc in
- 	0) 
-	    ;;
- 	1) 
-	    for h in `echo "$output" | grep "is unreachable" | awk '{print $1}'`; do
-		ping_conditional_log warn "$h is inactive"
-	    done
-	    ;;
- 	*) 
-	    ocf_log err "Unexpected result for '$cmd' $rc: `echo "$output" | tr '\n' ';'`"
-	    ;;
+        0) 
+            ;;
+        1) 
+            for h in `echo "$output" | grep "is unreachable" | awk '{print $1}'`; do
+                ping_conditional_log warn "$h is inactive"
+            done
+            ;;
+        *) 
+            ocf_log err "Unexpected result for '$cmd' $rc: `echo "$output" | tr '\n' ';'`"
+            ;;
     esac
 
     return $active
@@ -252,26 +252,26 @@ fping_check() {
 ping_check() {
     active=0
     for host in $OCF_RESKEY_host_list; do
-	p_exe=ping
+        p_exe=ping
 
-	case `uname` in
-	    Linux) p_args="-n -q -W $OCF_RESKEY_timeout -c $OCF_RESKEY_attempts";;
-	    Darwin) p_args="-n -q -t $OCF_RESKEY_timeout -c $OCF_RESKEY_attempts -o";;
-	    FreeBSD) p_args="-n -q -t $OCF_RESKEY_timeout -c $OCF_RESKEY_attempts -o";;
-	    *) ocf_log err "Unknown host type: `uname`"; exit $OCF_ERR_INSTALLED;;
-	esac
+        case `uname` in
+            Linux) p_args="-n -q -W $OCF_RESKEY_timeout -c $OCF_RESKEY_attempts";;
+            Darwin) p_args="-n -q -t $OCF_RESKEY_timeout -c $OCF_RESKEY_attempts -o";;
+            FreeBSD) p_args="-n -q -t $OCF_RESKEY_timeout -c $OCF_RESKEY_attempts -o";;
+            *) ocf_log err "Unknown host type: `uname`"; exit $OCF_ERR_INSTALLED;;
+        esac
 
-	case $host in
-	    *:*) p_exe=ping6
-	esac
-	
-	p_out=`$p_exe $p_args $OCF_RESKEY_options $host 2>&1`; rc=$?
+        case $host in
+            *:*) p_exe=ping6
+        esac
+        
+        p_out=`$p_exe $p_args $OCF_RESKEY_options $host 2>&1`; rc=$?
 
-	case $rc in
-	    0) active=`expr $active + 1`;;
-	    1) ping_conditional_log warn "$host is inactive: $p_out";;
-	    *) ocf_log err "Unexpected result for '$p_exe $p_args $OCF_RESKEY_options $host' $rc: $p_out";;
-	esac
+        case $rc in
+            0) active=`expr $active + 1`;;
+            1) ping_conditional_log warn "$host is inactive: $p_out";;
+            *) ocf_log err "Unexpected result for '$p_exe $p_args $OCF_RESKEY_options $host' $rc: $p_out";;
+        esac
     done
     return $active
 }
@@ -279,11 +279,11 @@ ping_check() {
 ping_update() {
     
     if use_fping; then
-	fping_check
-	active=$?
+        fping_check
+        active=$?
     else
-	ping_check
-	active=$?
+        ping_check
+        active=$?
     fi
 
     score=`expr $active \* $OCF_RESKEY_multiplier`
@@ -294,8 +294,8 @@ ping_update() {
     fi
     rc=$?
     case $rc in 
-	0) ping_conditional_log debug "Updated $OCF_RESKEY_name = $score" ;;
-	*) ocf_log warn "Could not update $OCF_RESKEY_name = $score: rc=$rc";;
+        0) ping_conditional_log debug "Updated $OCF_RESKEY_name = $score" ;;
+        *) ocf_log warn "Could not update $OCF_RESKEY_name = $score: rc=$rc";;
     esac
     if [ $rc -ne 0 ]; then
         return $rc
@@ -318,9 +318,9 @@ use_fping() {
 #     0 indefinite (i.e. hostname)
 host_family() {
     case $1 in
-	*[0-9].*[0-9].*[0-9].*[0-9]) return 4 ;;
-	*:*) return 6 ;;
-	*) return 0 ;;
+        *[0-9].*[0-9].*[0-9].*[0-9]) return 4 ;;
+        *:*) return 6 ;;
+        *) return 0 ;;
     esac
 }
 
@@ -362,11 +362,11 @@ esac
 
 if [ -z ${OCF_RESKEY_timeout} ]; then
     if [ x"$OCF_RESKEY_host_list" != x ]; then
-	host_count=`echo $OCF_RESKEY_host_list | awk '{print NF}'`
-	OCF_RESKEY_timeout=`expr $OCF_RESKEY_CRM_meta_timeout / $host_count / $OCF_RESKEY_attempts`
-	OCF_RESKEY_timeout=`expr $OCF_RESKEY_timeout / 1100` # Convert to seconds and finish 10% early
+        host_count=`echo $OCF_RESKEY_host_list | awk '{print NF}'`
+        OCF_RESKEY_timeout=`expr $OCF_RESKEY_CRM_meta_timeout / $host_count / $OCF_RESKEY_attempts`
+        OCF_RESKEY_timeout=`expr $OCF_RESKEY_timeout / 1100` # Convert to seconds and finish 10% early
     else
-	OCF_RESKEY_timeout=5
+        OCF_RESKEY_timeout=5
     fi
 fi
 
@@ -399,19 +399,18 @@ if [ ${OCF_RESKEY_debug} = "true" ]; then
 fi
 
 case $__OCF_ACTION in
-meta-data)	meta_data
-		exit $OCF_SUCCESS
-		;;
-start)		ping_start;;
-stop)		ping_stop;;
-monitor)	ping_monitor;;
-validate-all)	ping_validate;;
-usage|help)	ping_usage
-		exit $OCF_SUCCESS
-		;;
-*)		ping_usage
-		exit $OCF_ERR_UNIMPLEMENTED
-		;;
+meta-data)      meta_data
+                exit $OCF_SUCCESS
+                ;;
+start)          ping_start;;
+stop)           ping_stop;;
+monitor)        ping_monitor;;
+validate-all)   ping_validate;;
+usage|help)     ping_usage
+                exit $OCF_SUCCESS
+                ;;
+*)              ping_usage
+                exit $OCF_ERR_UNIMPLEMENTED
+                ;;
 esac
 exit $?
-

--- a/extra/resources/pingd
+++ b/extra/resources/pingd
@@ -17,9 +17,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 : ${OCF_RESKEY_name:="pingd"}
 : ${OCF_RESKEY_interval:="1"}

--- a/extra/resources/pingd
+++ b/extra/resources/pingd
@@ -185,3 +185,5 @@ esac
 
 ${OCF_ROOT}/resource.d/pacemaker/ping $1
 exit $?
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/pingd
+++ b/extra/resources/pingd
@@ -2,7 +2,7 @@
 #
 # ocf:pacemaker:pingd resource agent
 #
-# Copyright 2006-2018 the Pacemaker project contributors
+# Copyright 2006-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -11,8 +11,8 @@
 #
 
 #
-#	Records (in the CIB) the current number of ping nodes a 
-#	   cluster node can connect to.
+# Records (in the CIB) the current number of ping nodes a cluster node can
+# connect to.
 #
 #######################################################################
 # Initialization:
@@ -31,36 +31,36 @@ upgrade3="You will need to remove the existing resource and replace it with one 
 
 case $__OCF_ACTION in
     start|monitor)
-	if [ "x" != "x$OCF_RESKEY_host_list" ]; then
-	    ocf_log err "$upgrade1"
-	    ocf_log err "$upgrade2"
-	    ocf_log err "Automatic conversion to ocf:pacemaker:ping failed: no hosts were configured to check for connectivity"
-	    ocf_log err "$upgrade3"
-	    exit $OCF_ERR_ARGS
-	fi
+        if [ "x" != "x$OCF_RESKEY_host_list" ]; then
+            ocf_log err "$upgrade1"
+            ocf_log err "$upgrade2"
+            ocf_log err "Automatic conversion to ocf:pacemaker:ping failed: no hosts were configured to check for connectivity"
+            ocf_log err "$upgrade3"
+            exit $OCF_ERR_ARGS
+        fi
 
-	recurring=`crm configure show $OCF_RESOURCE_INSTANCE | grep "op monitor.*interval=\"[1-9]" | sed s/.*interval=// | awk -F\" '{print $2}' | sed s/.*interval=// | awk -F\" '{print $2}' | sort | head -n 1`
+        recurring=`crm configure show $OCF_RESOURCE_INSTANCE | grep "op monitor.*interval=\"[1-9]" | sed s/.*interval=// | awk -F\" '{print $2}' | sed s/.*interval=// | awk -F\" '{print $2}' | sort | head -n 1`
 
-	if [ -z $recurring ]; then
-	    ocf_log err "$upgrade1"
-	    ocf_log err "$upgrade2"
-	    ocf_log err "Automatic conversion to ocf:pacemaker:ping failed: no monitor operation configured"
-	    ocf_log err "Without an explicit monitor operation for '$OCF_RESOURCE_INSTANCE', connectivity changes will not be noticed"
-	    ocf_log err "Preventing startup to ensure the issue is addressed before it matters"
-	    exit $OCF_ERR_ARGS
-	fi
-	
-	if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
-	    ocf_log warn "$upgrade1"
-	    ocf_log warn "$upgrade2"
-	    if [ $recurring != $OCF_RESKEY_interval ]; then
-		ocf_log warn "Your monitor operation happens every $recurring, which means that the $OCF_RESKEY_name attribute will be updated with a different frequency than the previously configured ( $OCF_RESKEY_interval )"
-		ocf_log warn "Either change the monitor interval to match or, ideally, switch to the ocf:pacemaker:ping agent and avoid all this compatibility nonsense."
-	    fi
-	fi
-	;;
+        if [ -z $recurring ]; then
+            ocf_log err "$upgrade1"
+            ocf_log err "$upgrade2"
+            ocf_log err "Automatic conversion to ocf:pacemaker:ping failed: no monitor operation configured"
+            ocf_log err "Without an explicit monitor operation for '$OCF_RESOURCE_INSTANCE', connectivity changes will not be noticed"
+            ocf_log err "Preventing startup to ensure the issue is addressed before it matters"
+            exit $OCF_ERR_ARGS
+        fi
+        
+        if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
+            ocf_log warn "$upgrade1"
+            ocf_log warn "$upgrade2"
+            if [ $recurring != $OCF_RESKEY_interval ]; then
+                ocf_log warn "Your monitor operation happens every $recurring, which means that the $OCF_RESKEY_name attribute will be updated with a different frequency than the previously configured ( $OCF_RESKEY_interval )"
+                ocf_log warn "Either change the monitor interval to match or, ideally, switch to the ocf:pacemaker:ping agent and avoid all this compatibility nonsense."
+            fi
+        fi
+        ;;
     meta-data)
-	cat <<END
+        cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
 <resource-agent name="pingd" version="1.0">
@@ -179,8 +179,8 @@ A catch all for any other options that need to be passed to pingd.
 </actions>
 </resource-agent>
 END
-	exit $OCF_SUCCESS
-	;;
+        exit $OCF_SUCCESS
+        ;;
 esac
 
 ${OCF_ROOT}/resource.d/pacemaker/ping $1

--- a/extra/resources/pingd
+++ b/extra/resources/pingd
@@ -49,7 +49,7 @@ case $__OCF_ACTION in
             ocf_log err "Preventing startup to ensure the issue is addressed before it matters"
             exit $OCF_ERR_ARGS
         fi
-        
+
         if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
             ocf_log warn "$upgrade1"
             ocf_log warn "$upgrade2"

--- a/extra/resources/pingd
+++ b/extra/resources/pingd
@@ -17,9 +17,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 : ${OCF_RESKEY_name:="pingd"}
 : ${OCF_RESKEY_interval:="1"}
@@ -29,7 +29,7 @@ upgrade1="This agent (ocf:pacemaker:pingd) has been replaced by the more reliabl
 upgrade2="Attempting automated conversion, run 'crm ra info ocf:pacemaker:ping' for all configuration options"
 upgrade3="You will need to remove the existing resource and replace it with one that uses 'ocf:pacemaker:ping' directly"
 
-case $__OCF_ACTION in
+case "$__OCF_ACTION" in
     start|monitor)
         if [ "x" != "x$OCF_RESKEY_host_list" ]; then
             ocf_log err "$upgrade1"
@@ -39,9 +39,9 @@ case $__OCF_ACTION in
             exit $OCF_ERR_ARGS
         fi
 
-        recurring=`crm configure show $OCF_RESOURCE_INSTANCE | grep "op monitor.*interval=\"[1-9]" | sed s/.*interval=// | awk -F\" '{print $2}' | sed s/.*interval=// | awk -F\" '{print $2}' | sort | head -n 1`
+        recurring=`crm configure show "$OCF_RESOURCE_INSTANCE" | grep "op monitor.*interval=\"[1-9]" | sed s/.*interval=// | awk -F\" '{print $2}' | sed s/.*interval=// | awk -F\" '{print $2}' | sort | head -n 1`
 
-        if [ -z $recurring ]; then
+        if [ -z "$recurring" ]; then
             ocf_log err "$upgrade1"
             ocf_log err "$upgrade2"
             ocf_log err "Automatic conversion to ocf:pacemaker:ping failed: no monitor operation configured"
@@ -183,7 +183,7 @@ END
         ;;
 esac
 
-${OCF_ROOT}/resource.d/pacemaker/ping $1
+"${OCF_ROOT}/resource.d/pacemaker/ping" "$1"
 exit $?
 
 # vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/extra/resources/pingd
+++ b/extra/resources/pingd
@@ -31,7 +31,7 @@ upgrade3="You will need to remove the existing resource and replace it with one 
 
 case "$__OCF_ACTION" in
     start|monitor)
-        if [ "x" != "x$OCF_RESKEY_host_list" ]; then
+        if [ -n "$OCF_RESKEY_host_list" ]; then
             ocf_log err "$upgrade1"
             ocf_log err "$upgrade2"
             ocf_log err "Automatic conversion to ocf:pacemaker:ping failed: no hosts were configured to check for connectivity"
@@ -50,10 +50,10 @@ case "$__OCF_ACTION" in
             exit $OCF_ERR_ARGS
         fi
 
-        if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
+        if [ $OCF_RESKEY_CRM_meta_interval -eq 0 ]; then
             ocf_log warn "$upgrade1"
             ocf_log warn "$upgrade2"
-            if [ $recurring != $OCF_RESKEY_interval ]; then
+            if [ $recurring -ne $OCF_RESKEY_interval ]; then
                 ocf_log warn "Your monitor operation happens every $recurring, which means that the $OCF_RESKEY_name attribute will be updated with a different frequency than the previously configured ( $OCF_RESKEY_interval )"
                 ocf_log warn "Either change the monitor interval to match or, ideally, switch to the ocf:pacemaker:ping agent and avoid all this compatibility nonsense."
             fi

--- a/extra/resources/pingd
+++ b/extra/resources/pingd
@@ -25,25 +25,21 @@
 : ${OCF_RESKEY_interval:="1"}
 : ${OCF_RESKEY_CRM_meta_interval:=0}
 
-upgrade1="This agent (ocf:pacemaker:pingd) has been replaced by the more reliable ocf:pacemaker:ping."
-upgrade2="Attempting automated conversion, run 'crm ra info ocf:pacemaker:ping' for all configuration options"
-upgrade3="You will need to remove the existing resource and replace it with one that uses 'ocf:pacemaker:ping' directly"
+ocf_log err "This agent (ocf:pacemaker:pingd) is deprecated, does not work, and"
+ocf_log err "will be removed in a future release (use ocf:pacemaker:ping instead)"
 
 case "$__OCF_ACTION" in
     start|monitor)
+        # BUG: The sense of this test is reversed. Rather than fix it now, we
+        # will formally deprecate the agent and remove it in a future release.
         if [ -n "$OCF_RESKEY_host_list" ]; then
-            ocf_log err "$upgrade1"
-            ocf_log err "$upgrade2"
             ocf_log err "Automatic conversion to ocf:pacemaker:ping failed: no hosts were configured to check for connectivity"
-            ocf_log err "$upgrade3"
             exit $OCF_ERR_ARGS
         fi
 
         recurring=$(crm configure show "$OCF_RESOURCE_INSTANCE" | grep "op monitor.*interval=\"[1-9]" | sed s/.*interval=// | awk -F\" '{print $2}' | sed s/.*interval=// | awk -F\" '{print $2}' | sort | head -n 1)
 
         if [ -z "$recurring" ]; then
-            ocf_log err "$upgrade1"
-            ocf_log err "$upgrade2"
             ocf_log err "Automatic conversion to ocf:pacemaker:ping failed: no monitor operation configured"
             ocf_log err "Without an explicit monitor operation for '$OCF_RESOURCE_INSTANCE', connectivity changes will not be noticed"
             ocf_log err "Preventing startup to ensure the issue is addressed before it matters"
@@ -51,8 +47,6 @@ case "$__OCF_ACTION" in
         fi
 
         if [ $OCF_RESKEY_CRM_meta_interval -eq 0 ]; then
-            ocf_log warn "$upgrade1"
-            ocf_log warn "$upgrade2"
             if [ $recurring -ne $OCF_RESKEY_interval ]; then
                 ocf_log warn "Your monitor operation happens every $recurring, which means that the $OCF_RESKEY_name attribute will be updated with a different frequency than the previously configured ( $OCF_RESKEY_interval )"
                 ocf_log warn "Either change the monitor interval to match or, ideally, switch to the ocf:pacemaker:ping agent and avoid all this compatibility nonsense."
@@ -66,8 +60,10 @@ case "$__OCF_ACTION" in
 <resource-agent name="pingd" version="1.0">
 <version>1.0</version>
 <longdesc lang="en">
-This agent (ocf:pacemaker:pingd) has been replaced by the more reliable ocf:pacemaker:ping.
-It records (in the CIB) the current number of ping nodes (specified in the 'host_list' parameter) a cluster node can connect to.
+This agent (ocf:pacemaker:pingd) is deprecated and broken, and has been
+replaced by the more reliable ocf:pacemaker:ping. It records (in the CIB)
+the current number of ping nodes (specified in the 'host_list' parameter)
+a cluster node can connect to.
 </longdesc>
 <shortdesc lang="en">pingd resource agent</shortdesc>
 

--- a/extra/resources/pingd
+++ b/extra/resources/pingd
@@ -39,7 +39,7 @@ case "$__OCF_ACTION" in
             exit $OCF_ERR_ARGS
         fi
 
-        recurring=`crm configure show "$OCF_RESOURCE_INSTANCE" | grep "op monitor.*interval=\"[1-9]" | sed s/.*interval=// | awk -F\" '{print $2}' | sed s/.*interval=// | awk -F\" '{print $2}' | sort | head -n 1`
+        recurring=$(crm configure show "$OCF_RESOURCE_INSTANCE" | grep "op monitor.*interval=\"[1-9]" | sed s/.*interval=// | awk -F\" '{print $2}' | sed s/.*interval=// | awk -F\" '{print $2}' | sort | head -n 1)
 
         if [ -z "$recurring" ]; then
             ocf_log err "$upgrade1"

--- a/extra/resources/pingd
+++ b/extra/resources/pingd
@@ -1,33 +1,18 @@
 #!/bin/sh
 #
-#
-#	pingd OCF Resource Agent
-#	Records (in the CIB) the current number of ping nodes a 
-#	   cluster node can connect to.
+# ocf:pacemaker:pingd resource agent
 #
 # Copyright 2006-2018 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
-#                    All Rights Reserved.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of version 2 of the GNU General Public License as
-# published by the Free Software Foundation.
+# This source code is licensed under the GNU General Public License version 2
+# (GPLv2) WITHOUT ANY WARRANTY.
 #
-# This program is distributed in the hope that it would be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
 #
-# Further, this software is distributed without any warranty that it is
-# free of the rightful claim of any third person regarding infringement
-# or the like.  Any license provided herein, whether implied or
-# otherwise, applies only to this software file.  Patent licenses, if
-# any, provided herein do not apply to combinations of this program with
-# other software, or any other product whatsoever.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write the Free Software Foundation,
-# Inc., 59 Temple Place - Suite 330, Boston MA 02111-1307, USA.
+#	Records (in the CIB) the current number of ping nodes a 
+#	   cluster node can connect to.
 #
 #######################################################################
 # Initialization:

--- a/extra/resources/remote
+++ b/extra/resources/remote
@@ -19,9 +19,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
+: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
 . ${OCF_FUNCTIONS}
-: ${__OCF_ACTION=$1}
+: ${__OCF_ACTION:=$1}
 
 #######################################################################
 

--- a/extra/resources/remote
+++ b/extra/resources/remote
@@ -19,9 +19,9 @@
 #######################################################################
 # Initialization:
 
-: ${OCF_FUNCTIONS:=${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs}
-. ${OCF_FUNCTIONS}
-: ${__OCF_ACTION:=$1}
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
 
 #######################################################################
 

--- a/extra/resources/remote
+++ b/extra/resources/remote
@@ -2,7 +2,7 @@
 #
 # ocf:pacemaker:remote OCF resource agent
 #
-# Copyright 2013-2018 the Pacemaker project contributors
+# Copyright 2013-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -26,7 +26,7 @@
 #######################################################################
 
 meta_data() {
-	cat <<END
+    cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
 <resource-agent name="remote" version="0.1">
@@ -76,7 +76,7 @@ END
 #######################################################################
 
 remote_usage() {
-	cat <<END
+    cat <<END
 usage: $0 {meta-data}
 
 Expects to have a fully populated OCF RA-compliant environment set.
@@ -84,27 +84,27 @@ END
 }
 
 remote_unsupported() {
-	ocf_log info "The ocf:pacemaker:remote agent should not be directly invoked except for meta-data action"
-	return $OCF_ERR_GENERIC
+    ocf_log info "The ocf:pacemaker:remote agent should not be directly invoked except for meta-data action"
+    return $OCF_ERR_GENERIC
 }
 
 case $__OCF_ACTION in
-meta-data)	meta_data
-		exit $OCF_SUCCESS
-		;;
-start)		remote_unsupported;;
-stop)		remote_unsupported;;
-monitor)	remote_unsupported;;
-migrate_to)	remote_unsupported;;
-migrate_from)	remote_unsupported;;
-reload)		remote_unsupported;;
-validate-all)	remote_unsupported;;
-usage|help)	remote_usage
-		exit $OCF_SUCCESS
-		;;
-*)		remote_usage
-		exit $OCF_ERR_UNIMPLEMENTED
-		;;
+meta-data)      meta_data
+                exit $OCF_SUCCESS
+                ;;
+start)          remote_unsupported;;
+stop)           remote_unsupported;;
+monitor)        remote_unsupported;;
+migrate_to)     remote_unsupported;;
+migrate_from)   remote_unsupported;;
+reload)         remote_unsupported;;
+validate-all)   remote_unsupported;;
+usage|help)     remote_usage
+                exit $OCF_SUCCESS
+                ;;
+*)              remote_usage
+                exit $OCF_ERR_UNIMPLEMENTED
+                ;;
 esac
 rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"

--- a/extra/resources/remote
+++ b/extra/resources/remote
@@ -1,12 +1,6 @@
 #!/bin/sh
 #
-# ocf:pacmaker:remote OCF resource agent
-#
-# This script provides metadata for Pacemaker's internal remote agent.
-# Outside of acting as a placeholder so the agent can be indexed, and
-# providing metadata, this script should never be invoked. The actual
-# functionality behind the remote connection lives within Pacemaker's
-# controller daemon.
+# ocf:pacemaker:remote OCF resource agent
 #
 # Copyright 2013-2018 the Pacemaker project contributors
 #
@@ -16,6 +10,12 @@
 # (GPLv2) WITHOUT ANY WARRANTY.
 #
 
+# This script provides metadata for Pacemaker's internal remote agent.
+# Outside of acting as a placeholder so the agent can be indexed, and
+# providing metadata, this script should never be invoked. The actual
+# functionality behind the remote connection lives within Pacemaker's
+# controller daemon.
+#
 #######################################################################
 # Initialization:
 

--- a/extra/resources/remote
+++ b/extra/resources/remote
@@ -109,3 +109,5 @@ esac
 rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
 exit $rc
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:


### PR DESCRIPTION
The main incentive for this is that a pacemaker agent is often used as a template for new agents, which has resulted in various ugliness being propagated around. I decided to do a general clean-up of all the agents to use good shell programming practices, and fixed a few bugs discovered in the process.

There are a few more things I'd like to do, but this has taken enough time already.