### PR TITLE
Fix: libcrmcommon:  Restore getopt behavior in stonith_admin.

### DIFF
--- a/include/crm/common/cmdline_internal.h
+++ b/include/crm/common/cmdline_internal.h
@@ -31,6 +31,45 @@ typedef struct {
 GOptionContext *
 pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts);
 
+/*!
+ * \internal
+ * \brief Pre-process command line arguments to preserve compatibility with
+ *        getopt behavior.
+ *
+ * getopt and glib have slightly different behavior when it comes to processing
+ * single command line arguments.  getopt allows this:  -x<val>, while glib will
+ * try to handle <val> like it is additional single letter arguments.  glib
+ * prefers -x <val> instead.
+ *
+ * This function scans argv, looking for any single letter command line options
+ * (indicated by the 'special' parameter).  When one is found, everything after
+ * that argument to the next whitespace is converted into its own value.  Single
+ * letter command line options can come in a group after a single dash, but
+ * this function will expand each group into many arguments.
+ *
+ * Long options and anything after "--" is preserved.  The result of this function
+ * can then be passed to ::g_option_context_parse_strv for actual processing.
+ *
+ * In pseudocode, this:
+ *
+ * pcmk__cmdline_preproc(4, ["-XbA", "--blah=foo", "-aF", "-Fval", "--", "--extra", "-args"], "aF")
+ *
+ * Would be turned into this:
+ *
+ * ["-X", "-b", "-A", "--blah=foo", "-a", "F", "-F", "val", "--", "--extra", "-args"]
+ *
+ * This function does not modify argv, and the return value is built of copies
+ * of all the command line arguments.  It is up to the caller to free this memory
+ * after use.
+ *
+ * \param[in] argc    The length of argv.
+ * \param[in] argv    The command line arguments.
+ * \param[in] special Single-letter command line arguments that take a value.
+ *                    These letters will all have pre-processing applied.
+ */
+char **
+pcmk__cmdline_preproc(int argc, char **argv, const char *special);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This patch introduces a new pcmk__cmdline_preproc function which
restores getopt's single character argument behavior that was lost when
switching to glib.  getopt recognizes a string like "-xval" to be the -x
command line option with a value of val.  glib would recognize that as
the four command line options -x, -v, -a, and -l.

Passing the command line through this new function converts it into
something that glib understands.  See the documentation and comments on
this function for more details.