### PR TITLE
Build: libcib: install cib_types.h

### DIFF
--- a/include/crm/cib/Makefile.am
+++ b/include/crm/cib/Makefile.am
@@ -22,4 +22,4 @@ MAINTAINERCLEANFILES	= Makefile.in
 headerdir=$(pkgincludedir)/crm/cib
 
 noinst_HEADERS		= internal.h
-header_HEADERS		= util.h
+header_HEADERS		= util.h cib_types.h


### PR DESCRIPTION
Since it's included in other external headers.
It should have been done in 70f21e6f8.