### PR TITLE
Initial formatted output support in crm_mon

### DIFF
--- a/include/crm/common/cmdline_internal.h
+++ b/include/crm/common/cmdline_internal.h
@@ -84,6 +84,28 @@ pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts);
 char **
 pcmk__cmdline_preproc(int argc, char **argv, const char *special);
 
+/*!
+ * \internal
+ * \brief Process extra arguments as if they were provided by the user on the
+ *        command line.
+ *
+ * \param[in,out] context The command line option processing context.
+ * \param[out]    error   A place for errors to be collected.
+ * \param[in]     format  The command line to be processed, potentially with
+ *                        format specifiers.
+ * \param[in]     ...     Arguments to be formatted.
+ *
+ * \note The first item in the list of arguments must be the name of the
+ *       program, exactly as if the format string were coming from the
+ *       command line.  Otherwise, the first argument will be ignored.
+ *
+ * \return TRUE if processing succeeded, or FALSE otherwise.  If FALSE, error
+ *         should be checked and displayed to the user.
+ */
+G_GNUC_PRINTF(3, 4)
+gboolean
+pcmk__force_args(GOptionContext *context, GError **error, const char *format, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -7,9 +7,14 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+
 #include <config.h>
 #include <glib.h>
 
+#include <crm/crm.h>
 #include <crm/common/cmdline_internal.h>
 #include <crm/common/util.h>
 
@@ -153,5 +158,27 @@ pcmk__cmdline_preproc(int argc, char **argv, const char *special) {
 
     g_ptr_array_free(arr, FALSE);
 
+    return retval;
+}
+
+G_GNUC_PRINTF(3, 4)
+gboolean
+pcmk__force_args(GOptionContext *context, GError **error, const char *format, ...) {
+    int len = 0;
+    char *buf = NULL;
+    gchar **extra_args = NULL;
+    va_list ap;
+    gboolean retval = TRUE;
+
+    va_start(ap, format);
+    len = vasprintf(&buf, format, ap);
+    CRM_ASSERT(len > 0);
+    va_end(ap);
+
+    extra_args = g_strsplit(buf, " ", -1);
+    retval = g_option_context_parse_strv(context, &extra_args, error);
+
+    g_strfreev(extra_args);
+    free(buf);
     return retval;
 }

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -30,19 +30,19 @@ static char *stylesheet_link = NULL;
 static char *title = NULL;
 
 GOptionEntry pcmk__html_output_entries[] = {
-    { "cgi-output", 0, 0, G_OPTION_ARG_NONE, &cgi_output,
+    { "output-cgi", 0, 0, G_OPTION_ARG_NONE, &cgi_output,
       "Add text needed to use output in a CGI program",
       NULL },
 
-    { "meta-refresh", 0, 0, G_OPTION_ARG_INT, &meta_refresh,
+    { "output-meta-refresh", 0, 0, G_OPTION_ARG_INT, &meta_refresh,
       "How often to refresh",
       "SECONDS" },
 
-    { "stylesheet-link", 0, 0, G_OPTION_ARG_STRING, &stylesheet_link,
+    { "output-stylesheet-link", 0, 0, G_OPTION_ARG_STRING, &stylesheet_link,
       "Link to an external CSS stylesheet",
       "URI" },
 
-    { "title", 0, 0, G_OPTION_ARG_STRING, &title,
+    { "output-title", 0, 0, G_OPTION_ARG_STRING, &title,
       "Page title (defaults to command line)",
       "TITLE" },
 

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -15,7 +15,7 @@
 static gboolean fancy = FALSE;
 
 GOptionEntry pcmk__text_output_entries[] = {
-    { "fancy", 0, 0, G_OPTION_ARG_NONE, &fancy,
+    { "output-fancy", 0, 0, G_OPTION_ARG_NONE, &fancy,
       "Use more highly formatted output",
       NULL },
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -81,7 +81,7 @@ crm_simulate_LDADD	= $(top_builddir)/lib/pengine/libpe_status.la	\
 crm_diff_SOURCES	= crm_diff.c
 crm_diff_LDADD		= $(top_builddir)/lib/common/libcrmcommon.la
 
-crm_mon_SOURCES		= crm_mon.c crm_mon_print.c crm_mon_runtime.c
+crm_mon_SOURCES		= crm_mon.c crm_mon_curses.c crm_mon_print.c crm_mon_runtime.c
 crm_mon_LDADD		= $(top_builddir)/lib/pengine/libpe_status.la	\
 			  $(top_builddir)/lib/fencing/libstonithd.la	\
 			  $(top_builddir)/lib/pacemaker/libpacemaker.la	\

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1648,7 +1648,7 @@ mon_refresh_display(gpointer user_data)
     /* stdout for everything except the HTML case, which does a bunch of file
      * renaming.  We'll handle changing stream in print_html_status.
      */
-    mon_state_t state = { .stream = stdout, .output_format = output_format };
+    mon_state_t state = { .stream = stdout, .output_format = output_format, .out = out };
 
     last_refresh = time(NULL);
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -34,6 +34,7 @@
 #include <crm/common/ipc.h>
 #include <crm/common/iso8601_internal.h>
 #include <crm/common/mainloop.h>
+#include <crm/common/output.h>
 #include <crm/common/util.h>
 #include <crm/common/xml.h>
 
@@ -42,6 +43,7 @@
 #include <crm/pengine/internal.h>
 #include <pacemaker-internal.h>
 #include <crm/stonith-ng.h>
+#include <crm/fencing/internal.h>
 
 #include "crm_mon.h"
 
@@ -55,7 +57,7 @@ static unsigned int show = mon_show_default;
  * Definitions indicating how to output
  */
 
-static mon_output_format_t output_format = mon_output_console;
+static mon_output_format_t output_format = mon_output_unset;
 
 static char *output_filename = NULL;   /* if sending output to a file, its name */
 
@@ -69,6 +71,8 @@ static cib_t *cib = NULL;
 static stonith_t *st = NULL;
 static xmlNode *current_cib = NULL;
 
+static pcmk__common_args_t *args = NULL;
+static pcmk__output_t *out = NULL;
 static GOptionContext *context = NULL;
 
 #if CURSES_ENABLED
@@ -80,6 +84,14 @@ const char *print_neg_location_prefix = "";
 
 long last_refresh = 0;
 crm_trigger_t *refresh_trigger = NULL;
+
+static pcmk__supported_format_t formats[] = {
+    PCMK__SUPPORTED_FORMAT_HTML,
+    PCMK__SUPPORTED_FORMAT_NONE,
+    PCMK__SUPPORTED_FORMAT_TEXT,
+    PCMK__SUPPORTED_FORMAT_XML,
+    { NULL, NULL, NULL }
+};
 
 /* Define exit codes for monitoring-compatible output
  * For nagios plugins, the possibilities are
@@ -116,6 +128,11 @@ static void kick_refresh(gboolean data_updated);
 
 static gboolean
 as_cgi_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+    if (args->output_ty != NULL) {
+        free(args->output_ty);
+    }
+
+    args->output_ty = strdup("html");
     output_format = mon_output_cgi;
     options.mon_ops |= mon_op_one_shot;
     return TRUE;
@@ -128,6 +145,11 @@ as_html_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError 
         return FALSE;
     }
 
+    if (args->output_ty != NULL) {
+        free(args->output_ty);
+    }
+
+    args->output_ty = strdup("html");
     output_format = mon_output_html;
     output_filename = strdup(optarg);
     umask(S_IWGRP | S_IWOTH);
@@ -136,6 +158,11 @@ as_html_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError 
 
 static gboolean
 as_simple_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+    if (args->output_ty != NULL) {
+        free(args->output_ty);
+    }
+
+    args->output_ty = strdup("text");
     output_format = mon_output_monitor;
     options.mon_ops |= mon_op_one_shot;
     return TRUE;
@@ -143,6 +170,11 @@ as_simple_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErro
 
 static gboolean
 as_xml_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+    if (args->output_ty != NULL) {
+        free(args->output_ty);
+    }
+
+    args->output_ty = strdup("xml");
     output_format = mon_output_xml;
     options.mon_ops |= mon_op_one_shot;
     return TRUE;
@@ -182,10 +214,7 @@ inactive_resources_cb(const gchar *option_name, const gchar *optarg, gpointer da
 
 static gboolean
 no_curses_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
-    if (output_format == mon_output_console) {
-        output_format = mon_output_plain;
-    }
-
+    output_format = mon_output_plain;
     return TRUE;
 }
 
@@ -738,7 +767,7 @@ build_arg_context(pcmk__common_args_t *args) {
                            "Start crm_mon and export the current cluster status as XML to stdout, then exit:\n\n"
                            "\tcrm_mon --as-xml\n";
 
-    context = pcmk__build_arg_context(args, NULL);
+    context = pcmk__build_arg_context(args, "text (default), html, xml");
     g_option_context_set_description(context, examples);
 
     /* Add the -Q option, which cannot be part of the globally supported options
@@ -768,10 +797,9 @@ main(int argc, char **argv)
     int rc = pcmk_ok;
     char **processed_args = NULL;
 
-    pcmk__common_args_t *args = calloc(1, sizeof(pcmk__common_args_t));
-
     GError *error = NULL;
 
+    args = calloc(1, sizeof(pcmk__common_args_t));
     if (args == NULL) {
         crm_exit(crm_errno2exit(-ENOMEM));
     }
@@ -779,6 +807,7 @@ main(int argc, char **argv)
     args->summary = strdup("Provides a summary of cluster's current state.\n\n"
                            "Outputs varying levels of detail in a number of different formats.");
     context = build_arg_context(args);
+    pcmk__register_formats(context, formats);
 
     options.pid_file = strdup("/tmp/ClusterMon.pid");
     crm_log_cli_init("crm_mon");
@@ -802,8 +831,84 @@ main(int argc, char **argv)
         crm_bump_log_level(argc, argv);
     }
 
+    /* Which output format to use could come from two places:  The --as-xml
+     * style arguments we gave in mode_entries above, or the formatted output
+     * arguments added by pcmk__register_formats.  If the latter were used,
+     * output_format will be mon_output_unset.
+     *
+     * Call the callbacks as if those older style arguments were provided so
+     * the various things they do get done.
+     */
+    if (output_format == mon_output_unset) {
+        gboolean retval = TRUE;
+
+        g_clear_error(&error);
+
+        /* NOTE:  There is no way to specify CGI mode or simple mode with --output-as.
+         * Those will need to get handled eventually, at which point something else
+         * will need to be added to this block.
+         */
+        if (safe_str_eq(args->output_ty, "html")) {
+            retval = as_html_cb("h", args->output_dest, NULL, &error);
+        } else if (safe_str_eq(args->output_ty, "text")) {
+            retval = no_curses_cb("N", NULL, NULL, &error);
+        } else if (safe_str_eq(args->output_ty, "xml")) {
+            as_xml_cb("X", args->output_dest, NULL, &error);
+        } else {
+            /* Neither old nor new arguments were given, so set the default. */
+            if (args->output_ty != NULL) {
+                free(args->output_ty);
+            }
+
+            args->output_ty = strdup("console");
+            output_format = mon_output_console;
+        }
+
+        if (!retval) {
+            fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
+            return clean_up(CRM_EX_USAGE);
+        }
+    }
+
+    /* If certain format options were specified, we want to set some extra
+     * options.  We can just process these like they were given on the
+     * command line.
+     */
+    g_clear_error(&error);
+
+    if (output_format == mon_output_plain) {
+        if (!pcmk__force_args(context, &error, "%s --output-fancy", g_get_prgname())) {
+            fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
+            return clean_up(CRM_EX_USAGE);
+        }
+    } else if (output_format == mon_output_html) {
+        if (!pcmk__force_args(context, &error, "%s --output-meta-refresh %d",
+                              g_get_prgname(), options.reconnect_msec/1000)) {
+            fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
+            return clean_up(CRM_EX_USAGE);
+        }
+    } else if (output_format == mon_output_cgi) {
+        if (!pcmk__force_args(context, &error, "%s --output-cgi", g_get_prgname())) {
+            fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
+            return clean_up(CRM_EX_USAGE);
+        }
+    }
+
+    rc = pcmk__output_new(&out, args->output_ty, args->output_dest, argv);
+    if (rc != 0) {
+        fprintf(stderr, "Error creating output format %s: %s\n", args->output_ty, pcmk_strerror(rc));
+        return clean_up(CRM_EX_ERROR);
+    }
+
+    stonith__register_messages(out);
+
     if (args->version) {
-        crm_help('$', CRM_EX_OK);
+        /* FIXME: For the moment, this won't do anything on XML or HTML formats
+         * because finish is not getting called.  That's commented out in
+         * clean_up.
+         */
+        out->version(out, false);
+        return clean_up(CRM_EX_OK);
     }
 
     if (args->quiet) {
@@ -1632,6 +1737,7 @@ mon_refresh_display(gpointer user_data)
                          show, print_neg_location_prefix);
             break;
 
+        case mon_output_unset:
         case mon_output_none:
             break;
     }
@@ -1760,5 +1866,16 @@ clean_up(crm_exit_t exit_code)
             fprintf(stderr, "%s", g_option_context_get_help(context, TRUE, NULL));
         }
     }
+
+    g_option_context_free(context);
+
+    if (out != NULL) {
+        /* FIXME: When we are ready to enable formatted output, uncomment
+         * the following line:
+         */
+        /* out->finish(out, exit_code, true, NULL); */
+        pcmk__output_free(out);
+    }
+
     crm_exit(exit_code);
 }

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -119,3 +119,11 @@ const char *get_cluster_stack(pe_working_set_t *data_set);
 char *get_node_display_name(node_t *node, unsigned int mon_ops);
 int get_resource_display_options(unsigned int mon_ops,
                                  mon_output_format_t output_format);
+
+pcmk__output_t *crm_mon_mk_curses_output(char **argv);
+void curses_indented_printf(pcmk__output_t *out, const char *format, ...) G_GNUC_PRINTF(2, 3);
+
+#if CURSES_ENABLED
+extern GOptionEntry crm_mon_curses_output_entries[];
+#define CRM_MON_SUPPORTED_FORMAT_CURSES { "console", crm_mon_mk_curses_output, crm_mon_curses_output_entries }
+#endif

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -47,6 +47,7 @@
 #endif
 
 typedef enum mon_output_format_e {
+    mon_output_unset,
     mon_output_none,
     mon_output_monitor,
     mon_output_plain,

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -97,6 +97,7 @@ typedef enum mon_output_format_e {
 typedef struct {
     FILE *stream;
     mon_output_format_t output_format;
+    pcmk__output_t *out;
 } mon_state_t;
 
 void print_status(mon_state_t *state, pe_working_set_t *data_set,

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -53,6 +53,7 @@ typedef enum mon_output_format_e {
     mon_output_plain,
     mon_output_console,
     mon_output_xml,
+    mon_output_legacy_xml,
     mon_output_html,
     mon_output_cgi
 } mon_output_format_t;

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <stdlib.h>
+#include <crm/crm.h>
+#include <crm/common/curses_internal.h>
+#include <crm/common/output.h>
+#include <glib.h>
+
+#include "crm_mon.h"
+
+#if CURSES_ENABLED
+
+GOptionEntry crm_mon_curses_output_entries[] = {
+    { NULL }
+};
+
+typedef struct curses_list_data_s {
+    unsigned int len;
+    char *singular_noun;
+    char *plural_noun;
+} curses_list_data_t;
+
+typedef struct private_data_s {
+    GQueue *parent_q;
+} private_data_t;
+
+static void
+curses_free_priv(pcmk__output_t *out) {
+    private_data_t *priv = out->priv;
+
+    if (priv == NULL) {
+        return;
+    }
+
+    g_queue_free(priv->parent_q);
+    free(priv);
+}
+
+static bool
+curses_init(pcmk__output_t *out) {
+    private_data_t *priv = NULL;
+
+    /* If curses_init was previously called on this output struct, just return. */
+    if (out->priv != NULL) {
+        return true;
+    } else {
+        out->priv = calloc(1, sizeof(private_data_t));
+        if (out->priv == NULL) {
+            return false;
+        }
+
+        priv = out->priv;
+    }
+
+    priv->parent_q = g_queue_new();
+
+    return true;
+}
+
+static void
+curses_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_dest) {
+}
+
+static void
+curses_reset(pcmk__output_t *out) {
+    CRM_ASSERT(out->priv != NULL);
+
+    curses_free_priv(out);
+    curses_init(out);
+}
+
+static void
+curses_subprocess_output(pcmk__output_t *out, int exit_status,
+                         const char *proc_stdout, const char *proc_stderr) {
+    if (proc_stdout != NULL) {
+        printw("%s\n", proc_stdout);
+    }
+
+    if (proc_stderr != NULL) {
+        printw("%s\n", proc_stderr);
+    }
+
+    clrtoeol();
+    refresh();
+}
+
+/* curses_version is defined in curses.h, so we can't use that name here.
+ * Note that this function prints out via text, not with curses.
+ */
+static void
+curses_ver(pcmk__output_t *out, bool extended) {
+    if (extended) {
+        printf("Pacemaker %s (Build: %s): %s\n", PACEMAKER_VERSION, BUILD_VERSION, CRM_FEATURES);
+    } else {
+        printf("Pacemaker %s\n", PACEMAKER_VERSION);
+        printf("Written by Andrew Beekhof\n");
+    }
+}
+
+G_GNUC_PRINTF(2, 3)
+static void
+curses_err_info(pcmk__output_t *out, const char *format, ...) {
+    va_list ap;
+
+    /* Informational output does not get indented, to separate it from other
+     * potentially indented list output.
+     */
+    va_start(ap, format);
+    vw_printw(stdscr, format, ap);
+    va_end(ap);
+
+    /* Add a newline. */
+    addch('\n');
+
+    clrtoeol();
+    refresh();
+}
+
+static void
+curses_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
+    private_data_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+    curses_indented_printf(out, "%s", buf);
+}
+
+static void
+curses_begin_list(pcmk__output_t *out, const char *name, const char *singular_noun,
+                const char *plural_noun) {
+    private_data_t *priv = out->priv;
+    curses_list_data_t *new_list = NULL;
+
+    CRM_ASSERT(priv != NULL);
+
+    curses_indented_printf(out, "%s:\n", name);
+
+    new_list = calloc(1, sizeof(curses_list_data_t));
+    new_list->len = 0;
+    new_list->singular_noun = singular_noun == NULL ? NULL : strdup(singular_noun);
+    new_list->plural_noun = plural_noun == NULL ? NULL : strdup(plural_noun);
+
+    g_queue_push_tail(priv->parent_q, new_list);
+}
+
+static void
+curses_list_item(pcmk__output_t *out, const char *id, const char *content) {
+    private_data_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    if (id != NULL) {
+        curses_indented_printf(out, "* %s: %s\n", id, content);
+    } else {
+        curses_indented_printf(out, "* %s\n", content);
+    }
+
+    ((curses_list_data_t *) g_queue_peek_tail(priv->parent_q))->len++;
+}
+
+static void
+curses_end_list(pcmk__output_t *out) {
+    private_data_t *priv = out->priv;
+    curses_list_data_t *node = NULL;
+
+    CRM_ASSERT(priv != NULL);
+    node = g_queue_pop_tail(priv->parent_q);
+
+    if (node->singular_noun != NULL && node->plural_noun != NULL) {
+        if (node->len == 1) {
+            curses_indented_printf(out, "%d %s found\n", node->len, node->singular_noun);
+        } else {
+            curses_indented_printf(out, "%d %s found\n", node->len, node->plural_noun);
+        }
+    } else {
+        putc('\n', out->dest);
+    }
+
+    free(node);
+}
+
+pcmk__output_t *
+crm_mon_mk_curses_output(char **argv) {
+    pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
+
+    if (retval == NULL) {
+        return NULL;
+    }
+
+    retval->fmt_name = "console";
+    retval->request = g_strjoinv(" ", argv);
+    retval->supports_quiet = true;
+
+    retval->init = curses_init;
+    retval->free_priv = curses_free_priv;
+    retval->finish = curses_finish;
+    retval->reset = curses_reset;
+
+    retval->register_message = pcmk__register_message;
+    retval->message = pcmk__call_message;
+
+    retval->subprocess_output = curses_subprocess_output;
+    retval->version = curses_ver;
+    retval->err = curses_err_info;
+    retval->info = curses_err_info;
+    retval->output_xml = curses_output_xml;
+
+    retval->begin_list = curses_begin_list;
+    retval->list_item = curses_list_item;
+    retval->end_list = curses_end_list;
+
+    return retval;
+}
+
+G_GNUC_PRINTF(2, 3)
+void
+curses_indented_printf(pcmk__output_t *out, const char *format, ...) {
+    va_list ap;
+    int level = 0;
+    private_data_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    level = g_queue_get_length(priv->parent_q);
+
+    for (int i = 0; i < level; i++) {
+        addch('\t');
+    }
+
+    if (level > 0) {
+        printw("* ");
+    }
+
+    va_start(ap, format);
+    vw_printw(stdscr, format, ap);
+    va_end(ap);
+
+    clrtoeol();
+    refresh();
+}
+
+#else
+
+pcmk__output_t *
+crm_mon_mk_curses_output(char **argv) {
+    /* curses was disabled in the build, so fall back to text. */
+    return pcmk__mk_text_output(argv);
+}
+
+G_GNUC_PRINTF(2, 3)
+void
+curses_indented_printf(pcmk__output_t *out, const char *format, ...) {
+    return;
+}
+
+#endif

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -2450,7 +2450,6 @@ print_xml_status(mon_state_t *state, pe_working_set_t *data_set,
 
     fprintf(state->stream, "</crm_mon>\n");
     fflush(state->stream);
-    fclose(state->stream);
 }
 
 int
@@ -2583,7 +2582,6 @@ print_html_status(mon_state_t *state, pe_working_set_t *data_set,
     fprintf(state->stream, "</body>\n");
     fprintf(state->stream, "</html>\n");
     fflush(state->stream);
-    fclose(state->stream);
 
     if (state->output_format != mon_output_cgi) {
         if (rename(filename_tmp, filename) != 0) {


### PR DESCRIPTION
These patches add the formatted output command line options, a curses formatted, and a special XML formatted to crm_mon.  There's a lot of code to make sure both the older mode options and the newer formatted output options both work and both do the same things.  Also note that while the formatted output options are present, there's no formatted output yet.