### PR TITLE
fix: crm_resource: apply maintenance property to all group primitives and the group itself

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -2970,10 +2970,124 @@ Deleted 'test-primitive' option: id=test-primitive-meta_attributes-is-managed na
 </cib>
 =#=#=#= End test: Delete resource child meta attribute - OK (0) =#=#=#=
 * Passed: crm_resource   - Delete resource child meta attribute
+=#=#=#= Begin test: Create a resource meta attribute in dummy1 =#=#=#=
+Set 'dummy1' option: id=dummy1-meta_attributes-is-managed set=dummy1-meta_attributes name=is-managed value=true
+=#=#=#= Current cib after: Create a resource meta attribute in dummy1 =#=#=#=
+<cib epoch="43" num_updates="0" admin_epoch="1">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+      </node>
+      <node id="node2" uname="node2"/>
+      <node id="node3" uname="node3"/>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+      <clone id="test-clone">
+        <primitive id="test-primitive" class="ocf" provider="pacemaker" type="Dummy">
+          <meta_attributes id="test-primitive-meta_attributes"/>
+        </primitive>
+        <meta_attributes id="test-clone-meta_attributes">
+          <nvpair id="test-clone-meta_attributes-is-managed" name="is-managed" value="true"/>
+        </meta_attributes>
+      </clone>
+      <group id="dummy-group">
+        <primitive id="dummy1" class="ocf" provider="pacemaker" type="Dummy">
+          <meta_attributes id="dummy1-meta_attributes">
+            <nvpair id="dummy1-meta_attributes-is-managed" name="is-managed" value="true"/>
+          </meta_attributes>
+        </primitive>
+        <primitive id="dummy2" class="ocf" provider="pacemaker" type="Dummy"/>
+      </group>
+    </resources>
+    <constraints>
+      <rsc_location id="cli-prefer-dummy" rsc="dummy" role="Started" node="node1" score="INFINITY"/>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Create a resource meta attribute in dummy1 - OK (0) =#=#=#=
+* Passed: crm_resource   - Create a resource meta attribute in dummy1
+=#=#=#= Begin test: Create a resource meta attribute in dummy-group =#=#=#=
+Set 'dummy1' option: id=dummy1-meta_attributes-is-managed name=is-managed value=false
+Set 'dummy-group' option: id=dummy-group-meta_attributes-is-managed set=dummy-group-meta_attributes name=is-managed value=false
+=#=#=#= Current cib after: Create a resource meta attribute in dummy-group =#=#=#=
+<cib epoch="45" num_updates="0" admin_epoch="1">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+      </node>
+      <node id="node2" uname="node2"/>
+      <node id="node3" uname="node3"/>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+      <clone id="test-clone">
+        <primitive id="test-primitive" class="ocf" provider="pacemaker" type="Dummy">
+          <meta_attributes id="test-primitive-meta_attributes"/>
+        </primitive>
+        <meta_attributes id="test-clone-meta_attributes">
+          <nvpair id="test-clone-meta_attributes-is-managed" name="is-managed" value="true"/>
+        </meta_attributes>
+      </clone>
+      <group id="dummy-group">
+        <primitive id="dummy1" class="ocf" provider="pacemaker" type="Dummy">
+          <meta_attributes id="dummy1-meta_attributes">
+            <nvpair id="dummy1-meta_attributes-is-managed" name="is-managed" value="false"/>
+          </meta_attributes>
+        </primitive>
+        <primitive id="dummy2" class="ocf" provider="pacemaker" type="Dummy"/>
+        <meta_attributes id="dummy-group-meta_attributes">
+          <nvpair id="dummy-group-meta_attributes-is-managed" name="is-managed" value="false"/>
+        </meta_attributes>
+      </group>
+    </resources>
+    <constraints>
+      <rsc_location id="cli-prefer-dummy" rsc="dummy" role="Started" node="node1" score="INFINITY"/>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Create a resource meta attribute in dummy-group - OK (0) =#=#=#=
+* Passed: crm_resource   - Create a resource meta attribute in dummy-group
 =#=#=#= Begin test: Specify a lifetime when moving a resource =#=#=#=
 Migration will take effect until:
 =#=#=#= Current cib after: Specify a lifetime when moving a resource =#=#=#=
-<cib epoch="43" num_updates="0" admin_epoch="1">
+<cib epoch="48" num_updates="0" admin_epoch="1">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -3024,7 +3138,7 @@ Migration will take effect until:
 * Passed: crm_resource   - Specify a lifetime when moving a resource
 =#=#=#= Begin test: Try to move a resource previously moved with a lifetime =#=#=#=
 =#=#=#= Current cib after: Try to move a resource previously moved with a lifetime =#=#=#=
-<cib epoch="45" num_updates="0" admin_epoch="1">
+<cib epoch="50" num_updates="0" admin_epoch="1">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -3074,7 +3188,7 @@ WARNING: Creating rsc_location constraint 'cli-ban-dummy-on-node1' with a score 
 	This will be the case even if node1 is the last node in the cluster
 Migration will take effect until:
 =#=#=#= Current cib after: Ban dummy from node1 for a short time =#=#=#=
-<cib epoch="46" num_updates="0" admin_epoch="1">
+<cib epoch="51" num_updates="0" admin_epoch="1">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -3127,7 +3241,7 @@ Migration will take effect until:
 =#=#=#= Begin test: Remove expired constraints =#=#=#=
 Removing constraint: cli-ban-dummy-on-node1
 =#=#=#= Current cib after: Remove expired constraints =#=#=#=
-<cib epoch="47" num_updates="0" admin_epoch="1">
+<cib epoch="52" num_updates="0" admin_epoch="1">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -398,6 +398,21 @@ function test_tools() {
     cmd="crm_resource -r test-primitive --meta -d is-managed"
     test_assert $CRM_EX_OK
 
+    cibadmin -C -o resources --xml-text '<group id="dummy-group"> \
+        <primitive id="dummy1" class="ocf" provider="pacemaker" type="Dummy"\/> \
+        <primitive id="dummy2" class="ocf" provider="pacemaker" type="Dummy"\/> \
+      </group>'
+
+    desc="Create a resource meta attribute in dummy1"
+    cmd="crm_resource -r dummy1 --meta -p is-managed -v true"
+    test_assert $CRM_EX_OK
+
+    desc="Create a resource meta attribute in dummy-group"
+    cmd="crm_resource -r dummy-group --meta -p is-managed -v false"
+    test_assert $CRM_EX_OK
+
+    cibadmin -D -o resource --xml-text '<group id="dummy-group">'
+
     desc="Specify a lifetime when moving a resource"
     cmd="crm_resource -r dummy --move --node node2 --lifetime=PT1H"
     test_assert $CRM_EX_OK


### PR DESCRIPTION
When applying maintenance to a group of primitives, it applies it to the
first primitive in the group, but leaves the group maintenance property and
all other primitives unchanged.
This patch makes all primitives in the group and the group itself inherit the maintenance attribute.