### PR TITLE
Fix: all: restrict XML children loops to XML elements where appropriate

### DIFF
--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -147,8 +147,8 @@ __xml_acl_parse_entry(xmlNode *acl_top, xmlNode *acl_entry, GList *acls)
 {
     xmlNode *child = NULL;
 
-    for (child = __xml_first_child(acl_entry); child;
-         child = __xml_next(child)) {
+    for (child = __xml_first_child_element(acl_entry); child;
+         child = __xml_next_element(child)) {
         const char *tag = crm_element_name(child);
         const char *kind = crm_element_value(child, XML_ACL_ATTR_KIND);
 
@@ -167,8 +167,8 @@ __xml_acl_parse_entry(xmlNode *acl_top, xmlNode *acl_entry, GList *acls)
             if (ref_role) {
                 xmlNode *role = NULL;
 
-                for (role = __xml_first_child(acl_top); role;
-                     role = __xml_next(role)) {
+                for (role = __xml_first_child_element(acl_top); role;
+                     role = __xml_next_element(role)) {
                     if (!strcmp(XML_ACL_TAG_ROLE, (const char *) role->name)) {
                         const char *role_id = crm_element_value(role,
                                                                 XML_ATTR_ID);
@@ -335,8 +335,8 @@ pcmk__unpack_acl(xmlNode *source, xmlNode *target, const char *user)
         if (acls) {
             xmlNode *child = NULL;
 
-            for (child = __xml_first_child(acls); child;
-                 child = __xml_next(child)) {
+            for (child = __xml_first_child_element(acls); child;
+                 child = __xml_next_element(child)) {
                 const char *tag = crm_element_name(child);
 
                 if (!strcmp(tag, XML_ACL_TAG_USER)

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -4380,7 +4380,8 @@ first_named_child(const xmlNode *parent, const char *name)
 {
     xmlNode *match = NULL;
 
-    for (match = __xml_first_child(parent); match != NULL; match = __xml_next(match)) {
+    for (match = __xml_first_child_element(parent); match != NULL;
+         match = __xml_next_element(match)) {
         /*
          * name == NULL gives first child regardless of name; this is
          * semantically incorrect in this function, but may be necessary
@@ -4403,14 +4404,14 @@ first_named_child(const xmlNode *parent, const char *name)
 xmlNode *
 crm_next_same_xml(const xmlNode *sibling)
 {
-    xmlNode *match = __xml_next(sibling);
+    xmlNode *match = __xml_next_element(sibling);
     const char *name = crm_element_name(sibling);
 
     while (match != NULL) {
         if (!strcmp(crm_element_name(match), name)) {
             return match;
         }
-        match = __xml_next(match);
+        match = __xml_next_element(match);
     }
     return NULL;
 }

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -436,7 +436,9 @@ check_actions_for(xmlNode * rsc_entry, resource_t * rsc, node_t * node, pe_worki
         DeleteRsc(rsc, node, FALSE, data_set);
     }
 
-    for (rsc_op = __xml_first_child(rsc_entry); rsc_op != NULL; rsc_op = __xml_next_element(rsc_op)) {
+    for (rsc_op = __xml_first_child_element(rsc_entry); rsc_op != NULL;
+         rsc_op = __xml_next_element(rsc_op)) {
+
         if (crm_str_eq((const char *)rsc_op->name, XML_LRM_TAG_RSC_OP, TRUE)) {
             op_list = g_list_prepend(op_list, rsc_op);
         }
@@ -567,7 +569,7 @@ check_actions(pe_working_set_t * data_set)
 
     xmlNode *node_state = NULL;
 
-    for (node_state = __xml_first_child(status); node_state != NULL;
+    for (node_state = __xml_first_child_element(status); node_state != NULL;
          node_state = __xml_next_element(node_state)) {
         if (crm_str_eq((const char *)node_state->name, XML_CIB_TAG_STATE, TRUE)) {
             id = crm_element_value(node_state, XML_ATTR_ID);
@@ -590,8 +592,10 @@ check_actions(pe_working_set_t * data_set)
             if (node->details->online || is_set(data_set->flags, pe_flag_stonith_enabled)) {
                 xmlNode *rsc_entry = NULL;
 
-                for (rsc_entry = __xml_first_child(lrm_rscs); rsc_entry != NULL;
+                for (rsc_entry = __xml_first_child_element(lrm_rscs);
+                     rsc_entry != NULL;
                      rsc_entry = __xml_next_element(rsc_entry)) {
+
                     if (crm_str_eq((const char *)rsc_entry->name, XML_LRM_TAG_RESOURCE, TRUE)) {
 
                         if (xml_has_children(rsc_entry)) {

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -53,7 +55,7 @@ unpack_constraints(xmlNode * xml_constraints, pe_working_set_t * data_set)
     xmlNode *xml_obj = NULL;
     xmlNode *lifetime = NULL;
 
-    for (xml_obj = __xml_first_child(xml_constraints); xml_obj != NULL;
+    for (xml_obj = __xml_first_child_element(xml_constraints); xml_obj != NULL;
          xml_obj = __xml_next_element(xml_obj)) {
         const char *id = crm_element_value(xml_obj, XML_ATTR_ID);
         const char *tag = crm_element_name(xml_obj);
@@ -498,7 +500,9 @@ expand_tags_in_sets(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t
     new_xml = copy_xml(xml_obj);
     cons_id = ID(new_xml);
 
-    for (set = __xml_first_child(new_xml); set != NULL; set = __xml_next_element(set)) {
+    for (set = __xml_first_child_element(new_xml); set != NULL;
+         set = __xml_next_element(set)) {
+
         xmlNode *xml_rsc = NULL;
         GListPtr tag_refs = NULL;
         GListPtr gIter = NULL;
@@ -507,7 +511,9 @@ expand_tags_in_sets(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t
             continue;
         }
 
-        for (xml_rsc = __xml_first_child(set); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             resource_t *rsc = NULL;
             tag_t *tag = NULL;
             const char *id = ID(xml_rsc);
@@ -792,7 +798,7 @@ unpack_rsc_location(xmlNode * xml_obj, resource_t * rsc_lh, const char * role,
     } else {
         xmlNode *rule_xml = NULL;
 
-        for (rule_xml = __xml_first_child(xml_obj); rule_xml != NULL;
+        for (rule_xml = __xml_first_child_element(xml_obj); rule_xml != NULL;
              rule_xml = __xml_next_element(rule_xml)) {
             if (crm_str_eq((const char *)rule_xml->name, XML_TAG_RULE, TRUE)) {
                 empty = FALSE;
@@ -936,7 +942,9 @@ unpack_location_set(xmlNode * location, xmlNode * set, pe_working_set_t * data_s
     role = crm_element_value(set, "role");
     local_score = crm_element_value(set, XML_RULE_ATTR_SCORE);
 
-    for (xml_rsc = __xml_first_child(set); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+    for (xml_rsc = __xml_first_child_element(set); xml_rsc != NULL;
+         xml_rsc = __xml_next_element(xml_rsc)) {
+
         if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
             EXPAND_CONSTRAINT_IDREF(set_id, resource, ID(xml_rsc));
             unpack_rsc_location(location, resource, role, local_score, data_set, NULL);
@@ -964,7 +972,9 @@ unpack_location(xmlNode * xml_obj, pe_working_set_t * data_set)
         xml_obj = expanded_xml;
     }
 
-    for (set = __xml_first_child(xml_obj); set != NULL; set = __xml_next_element(set)) {
+    for (set = __xml_first_child_element(xml_obj); set != NULL;
+         set = __xml_next_element(set)) {
+
         if (crm_str_eq((const char *)set->name, XML_CONS_TAG_RSC_SET, TRUE)) {
             any_sets = TRUE;
             set = expand_idref(set, data_set->input);
@@ -1666,7 +1676,9 @@ unpack_order_set(xmlNode * set, enum pe_order_kind parent_kind, resource_t ** rs
         flags = get_asymmetrical_flags(local_kind);
     }
 
-    for (xml_rsc = __xml_first_child(set); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+    for (xml_rsc = __xml_first_child_element(set); xml_rsc != NULL;
+         xml_rsc = __xml_next_element(xml_rsc)) {
+
         if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
             EXPAND_CONSTRAINT_IDREF(id, resource, ID(xml_rsc));
             resources = g_list_append(resources, resource);
@@ -1843,7 +1855,9 @@ order_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, enum pe_order_kin
         free(task);
         update_action_flags(unordered_action, pe_action_requires_any, __FUNCTION__, __LINE__);
 
-        for (xml_rsc = __xml_first_child(set1); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set1); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             if (!crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 continue;
             }
@@ -1856,7 +1870,9 @@ order_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, enum pe_order_kin
                                 NULL, NULL, unordered_action,
                                 pe_order_one_or_more | pe_order_implies_then_printed, data_set);
         }
-        for (xml_rsc_2 = __xml_first_child(set2); xml_rsc_2 != NULL; xml_rsc_2 = __xml_next_element(xml_rsc_2)) {
+        for (xml_rsc_2 = __xml_first_child_element(set2); xml_rsc_2 != NULL;
+             xml_rsc_2 = __xml_next_element(xml_rsc_2)) {
+
             if (!crm_str_eq((const char *)xml_rsc_2->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 continue;
             }
@@ -1878,7 +1894,9 @@ order_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, enum pe_order_kin
             /* get the last one */
             const char *rid = NULL;
 
-            for (xml_rsc = __xml_first_child(set1); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+            for (xml_rsc = __xml_first_child_element(set1); xml_rsc != NULL;
+                 xml_rsc = __xml_next_element(xml_rsc)) {
+
                 if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                     rid = ID(xml_rsc);
                 }
@@ -1887,7 +1905,9 @@ order_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, enum pe_order_kin
 
         } else {
             /* get the first one */
-            for (xml_rsc = __xml_first_child(set1); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+            for (xml_rsc = __xml_first_child_element(set1); xml_rsc != NULL;
+                 xml_rsc = __xml_next_element(xml_rsc)) {
+
                 if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                     EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
                     break;
@@ -1899,7 +1919,9 @@ order_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, enum pe_order_kin
     if (crm_is_true(sequential_2)) {
         if (invert == FALSE) {
             /* get the first one */
-            for (xml_rsc = __xml_first_child(set2); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+            for (xml_rsc = __xml_first_child_element(set2); xml_rsc != NULL;
+                 xml_rsc = __xml_next_element(xml_rsc)) {
+
                 if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                     EXPAND_CONSTRAINT_IDREF(id, rsc_2, ID(xml_rsc));
                     break;
@@ -1910,7 +1932,9 @@ order_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, enum pe_order_kin
             /* get the last one */
             const char *rid = NULL;
 
-            for (xml_rsc = __xml_first_child(set2); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+            for (xml_rsc = __xml_first_child_element(set2); xml_rsc != NULL;
+                 xml_rsc = __xml_next_element(xml_rsc)) {
+
                 if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                     rid = ID(xml_rsc);
                 }
@@ -1923,7 +1947,9 @@ order_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, enum pe_order_kin
         new_rsc_order(rsc_1, action_1, rsc_2, action_2, flags, data_set);
 
     } else if (rsc_1 != NULL) {
-        for (xml_rsc = __xml_first_child(set2); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set2); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 EXPAND_CONSTRAINT_IDREF(id, rsc_2, ID(xml_rsc));
                 new_rsc_order(rsc_1, action_1, rsc_2, action_2, flags, data_set);
@@ -1933,7 +1959,9 @@ order_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, enum pe_order_kin
     } else if (rsc_2 != NULL) {
         xmlNode *xml_rsc = NULL;
 
-        for (xml_rsc = __xml_first_child(set1); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set1); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
                 new_rsc_order(rsc_1, action_1, rsc_2, action_2, flags, data_set);
@@ -1941,14 +1969,18 @@ order_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, enum pe_order_kin
         }
 
     } else {
-        for (xml_rsc = __xml_first_child(set1); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set1); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 xmlNode *xml_rsc_2 = NULL;
 
                 EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
 
-                for (xml_rsc_2 = __xml_first_child(set2); xml_rsc_2 != NULL;
+                for (xml_rsc_2 = __xml_first_child_element(set2);
+                     xml_rsc_2 != NULL;
                      xml_rsc_2 = __xml_next_element(xml_rsc_2)) {
+
                     if (crm_str_eq((const char *)xml_rsc_2->name, XML_TAG_RESOURCE_REF, TRUE)) {
                         EXPAND_CONSTRAINT_IDREF(id, rsc_2, ID(xml_rsc_2));
                         new_rsc_order(rsc_1, action_1, rsc_2, action_2, flags, data_set);
@@ -2116,7 +2148,9 @@ unpack_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
         return FALSE;
     }
 
-    for (set = __xml_first_child(xml_obj); set != NULL; set = __xml_next_element(set)) {
+    for (set = __xml_first_child_element(xml_obj); set != NULL;
+         set = __xml_next_element(set)) {
+
         if (crm_str_eq((const char *)set->name, XML_CONS_TAG_RSC_SET, TRUE)) {
             any_sets = TRUE;
             set = expand_idref(set, data_set->input);
@@ -2221,7 +2255,9 @@ unpack_colocation_set(xmlNode * set, int score, pe_working_set_t * data_set)
         return TRUE;
 
     } else if (local_score >= 0 && safe_str_eq(ordering, "group")) {
-        for (xml_rsc = __xml_first_child(set); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 EXPAND_CONSTRAINT_IDREF(set_id, resource, ID(xml_rsc));
                 if (with != NULL) {
@@ -2235,7 +2271,9 @@ unpack_colocation_set(xmlNode * set, int score, pe_working_set_t * data_set)
         }
     } else if (local_score >= 0) {
         resource_t *last = NULL;
-        for (xml_rsc = __xml_first_child(set); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 EXPAND_CONSTRAINT_IDREF(set_id, resource, ID(xml_rsc));
                 if (last != NULL) {
@@ -2254,14 +2292,18 @@ unpack_colocation_set(xmlNode * set, int score, pe_working_set_t * data_set)
          * (i.e. that no one in the set can run with anyone else in the set)
          */
 
-        for (xml_rsc = __xml_first_child(set); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 xmlNode *xml_rsc_with = NULL;
 
                 EXPAND_CONSTRAINT_IDREF(set_id, resource, ID(xml_rsc));
 
-                for (xml_rsc_with = __xml_first_child(set); xml_rsc_with != NULL;
+                for (xml_rsc_with = __xml_first_child_element(set);
+                     xml_rsc_with != NULL;
                      xml_rsc_with = __xml_next_element(xml_rsc_with)) {
+
                     if (crm_str_eq((const char *)xml_rsc_with->name, XML_TAG_RESOURCE_REF, TRUE)) {
                         if (safe_str_eq(resource->id, ID(xml_rsc_with))) {
                             break;
@@ -2296,7 +2338,9 @@ colocate_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, int score,
 
     if (sequential_1 == NULL || crm_is_true(sequential_1)) {
         /* get the first one */
-        for (xml_rsc = __xml_first_child(set1); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set1); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
                 break;
@@ -2308,7 +2352,9 @@ colocate_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, int score,
         /* get the last one */
         const char *rid = NULL;
 
-        for (xml_rsc = __xml_first_child(set2); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set2); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 rid = ID(xml_rsc);
             }
@@ -2320,7 +2366,9 @@ colocate_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, int score,
         rsc_colocation_new(id, NULL, score, rsc_1, rsc_2, role_1, role_2, data_set);
 
     } else if (rsc_1 != NULL) {
-        for (xml_rsc = __xml_first_child(set2); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set2); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 EXPAND_CONSTRAINT_IDREF(id, rsc_2, ID(xml_rsc));
                 rsc_colocation_new(id, NULL, score, rsc_1, rsc_2, role_1, role_2, data_set);
@@ -2328,7 +2376,9 @@ colocate_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, int score,
         }
 
     } else if (rsc_2 != NULL) {
-        for (xml_rsc = __xml_first_child(set1); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set1); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
                 rsc_colocation_new(id, NULL, score, rsc_1, rsc_2, role_1, role_2, data_set);
@@ -2336,14 +2386,18 @@ colocate_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, int score,
         }
 
     } else {
-        for (xml_rsc = __xml_first_child(set1); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(set1); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             if (crm_str_eq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF, TRUE)) {
                 xmlNode *xml_rsc_2 = NULL;
 
                 EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
 
-                for (xml_rsc_2 = __xml_first_child(set2); xml_rsc_2 != NULL;
+                for (xml_rsc_2 = __xml_first_child_element(set2);
+                     xml_rsc_2 != NULL;
                      xml_rsc_2 = __xml_next_element(xml_rsc_2)) {
+
                     if (crm_str_eq((const char *)xml_rsc_2->name, XML_TAG_RESOURCE_REF, TRUE)) {
                         EXPAND_CONSTRAINT_IDREF(id, rsc_2, ID(xml_rsc_2));
                         rsc_colocation_new(id, NULL, score, rsc_1, rsc_2, role_1, role_2, data_set);
@@ -2576,7 +2630,9 @@ unpack_rsc_colocation(xmlNode * xml_obj, pe_working_set_t * data_set)
         return FALSE;
     }
 
-    for (set = __xml_first_child(xml_obj); set != NULL; set = __xml_next_element(set)) {
+    for (set = __xml_first_child_element(xml_obj); set != NULL;
+         set = __xml_next_element(set)) {
+
         if (crm_str_eq((const char *)set->name, XML_CONS_TAG_RSC_SET, TRUE)) {
             any_sets = TRUE;
             set = expand_idref(set, data_set->input);
@@ -2926,7 +2982,9 @@ unpack_rsc_ticket(xmlNode * xml_obj, pe_working_set_t * data_set)
         return FALSE;
     }
 
-    for (set = __xml_first_child(xml_obj); set != NULL; set = __xml_next_element(set)) {
+    for (set = __xml_first_child_element(xml_obj); set != NULL;
+         set = __xml_next_element(set)) {
+
         if (crm_str_eq((const char *)set->name, XML_CONS_TAG_RSC_SET, TRUE)) {
             any_sets = TRUE;
             set = expand_idref(set, data_set->input);

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -596,8 +596,9 @@ is_op_dup(resource_t *rsc, const char *name, guint interval_ms)
     guint interval2_ms = 0;
 
     CRM_ASSERT(rsc);
-    for (operation = __xml_first_child(rsc->ops_xml); operation != NULL;
+    for (operation = __xml_first_child_element(rsc->ops_xml); operation != NULL;
          operation = __xml_next_element(operation)) {
+
         if (crm_str_eq((const char *)operation->name, "op", TRUE)) {
             value = crm_element_value(operation, "name");
             if (safe_str_neq(value, name)) {
@@ -820,8 +821,10 @@ Recurring(resource_t * rsc, action_t * start, node_t * node, pe_working_set_t * 
         (node == NULL || node->details->maintenance == FALSE)) {
         xmlNode *operation = NULL;
 
-        for (operation = __xml_first_child(rsc->ops_xml); operation != NULL;
+        for (operation = __xml_first_child_element(rsc->ops_xml);
+             operation != NULL;
              operation = __xml_next_element(operation)) {
+
             if (crm_str_eq((const char *)operation->name, "op", TRUE)) {
                 RecurringOp(rsc, start, node, operation, data_set);
             }
@@ -1027,8 +1030,10 @@ Recurring_Stopped(resource_t * rsc, action_t * start, node_t * node, pe_working_
         (node == NULL || node->details->maintenance == FALSE)) {
         xmlNode *operation = NULL;
 
-        for (operation = __xml_first_child(rsc->ops_xml); operation != NULL;
+        for (operation = __xml_first_child_element(rsc->ops_xml);
+             operation != NULL;
              operation = __xml_next_element(operation)) {
+
             if (crm_str_eq((const char *)operation->name, "op", TRUE)) {
                 RecurringOp_Stopped(rsc, start, node, operation, data_set);
             }

--- a/lib/pacemaker/pcmk_sched_transition.c
+++ b/lib/pacemaker/pcmk_sched_transition.c
@@ -1,6 +1,8 @@
 /*
  * Copyright 2009-2019 the Pacemaker project contributors
  *
+ * The version control history for this file may have further details.
+ *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
  */
@@ -142,7 +144,9 @@ create_op(xmlNode *cib_resource, const char *task, guint interval_ms,
     op->t_rcchange = op->t_run;
 
     op->call_id = 0;
-    for (xop = __xml_first_child(cib_resource); xop != NULL; xop = __xml_next(xop)) {
+    for (xop = __xml_first_child_element(cib_resource); xop != NULL;
+         xop = __xml_next_element(xop)) {
+
         int tmp = 0;
 
         crm_element_value_int(xop, XML_LRM_ATTR_CALLID, &tmp);

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -181,7 +181,7 @@ clone_unpack(resource_t * rsc, pe_working_set_t * data_set)
                  is_set(rsc->flags, pe_rsc_promotable) ? "true" : "false");
 
     // Clones may contain a single group or primitive
-    for (a_child = __xml_first_child(xml_obj); a_child != NULL;
+    for (a_child = __xml_first_child_element(xml_obj); a_child != NULL;
          a_child = __xml_next_element(a_child)) {
 
         if (crm_str_eq((const char *)a_child->name, XML_CIB_TAG_RESOURCE, TRUE)

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -246,7 +246,7 @@ unpack_template(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t * d
 
     template_ops = find_xml_node(new_xml, "operations", FALSE);
 
-    for (child_xml = __xml_first_child(xml_obj); child_xml != NULL;
+    for (child_xml = __xml_first_child_element(xml_obj); child_xml != NULL;
          child_xml = __xml_next_element(child_xml)) {
         xmlNode *new_child = NULL;
 
@@ -263,13 +263,17 @@ unpack_template(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t * d
                                                          g_str_equal, free,
                                                          NULL);
 
-        for (op = __xml_first_child(rsc_ops); op != NULL; op = __xml_next_element(op)) {
+        for (op = __xml_first_child_element(rsc_ops); op != NULL;
+             op = __xml_next_element(op)) {
+
             char *key = template_op_key(op);
 
             g_hash_table_insert(rsc_ops_hash, key, op);
         }
 
-        for (op = __xml_first_child(template_ops); op != NULL; op = __xml_next_element(op)) {
+        for (op = __xml_first_child_element(template_ops); op != NULL;
+             op = __xml_next_element(op)) {
+
             char *key = template_op_key(op);
 
             if (g_hash_table_lookup(rsc_ops_hash, key) == NULL) {

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -46,7 +48,7 @@ group_unpack(resource_t * rsc, pe_working_set_t * data_set)
 
     clone_id = crm_element_value(rsc->xml, XML_RSC_ATTR_INCARNATION);
 
-    for (xml_native_rsc = __xml_first_child(xml_obj); xml_native_rsc != NULL;
+    for (xml_native_rsc = __xml_first_child_element(xml_obj); xml_native_rsc != NULL;
          xml_native_rsc = __xml_next_element(xml_native_rsc)) {
         if (crm_str_eq((const char *)xml_native_rsc->name, XML_CIB_TAG_RESOURCE, TRUE)) {
             resource_t *new_rsc = NULL;

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -1,19 +1,10 @@
-/* 
- * Copyright (C) 2004 Andrew Beekhof <andrew@beekhof.net>
- * 
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- * 
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+/*
+ * Copyright 2004-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
 #include <crm_internal.h>
@@ -39,7 +30,9 @@ test_ruleset(xmlNode * ruleset, GHashTable * node_hash, crm_time_t * now)
     gboolean ruleset_default = TRUE;
     xmlNode *rule = NULL;
 
-    for (rule = __xml_first_child(ruleset); rule != NULL; rule = __xml_next_element(rule)) {
+    for (rule = __xml_first_child_element(ruleset); rule != NULL;
+         rule = __xml_next_element(rule)) {
+
         if (crm_str_eq((const char *)rule->name, XML_TAG_RULE, TRUE)) {
             ruleset_default = FALSE;
             if (test_rule(rule, node_hash, RSC_ROLE_UNKNOWN, now)) {
@@ -86,7 +79,9 @@ pe_test_rule_full(xmlNode * rule, GHashTable * node_hash, enum rsc_role_e role, 
     }
 
     crm_trace("Testing rule %s", ID(rule));
-    for (expr = __xml_first_child(rule); expr != NULL; expr = __xml_next_element(expr)) {
+    for (expr = __xml_first_child_element(rule); expr != NULL;
+         expr = __xml_next_element(expr)) {
+
         test = pe_test_expression_full(expr, node_hash, role, now, match_data);
         empty = FALSE;
 
@@ -707,7 +702,9 @@ populate_hash(xmlNode * nvpair_list, GHashTable * hash, gboolean overwrite, xmlN
         list = list->children;
     }
 
-    for (an_attr = __xml_first_child(list); an_attr != NULL; an_attr = __xml_next_element(an_attr)) {
+    for (an_attr = __xml_first_child_element(list); an_attr != NULL;
+         an_attr = __xml_next_element(an_attr)) {
+
         if (crm_str_eq((const char *)an_attr->name, XML_CIB_TAG_NVPAIR, TRUE)) {
             xmlNode *ref_nvpair = expand_idref(an_attr, top);
 
@@ -754,9 +751,13 @@ get_versioned_rule(xmlNode * attr_set)
     xmlNode * rule = NULL;
     xmlNode * expr = NULL;
 
-    for (rule = __xml_first_child(attr_set); rule != NULL; rule = __xml_next_element(rule)) {
+    for (rule = __xml_first_child_element(attr_set); rule != NULL;
+         rule = __xml_next_element(rule)) {
+
         if (crm_str_eq((const char *)rule->name, XML_TAG_RULE, TRUE)) {
-            for (expr = __xml_first_child(rule); expr != NULL; expr = __xml_next_element(expr)) {
+            for (expr = __xml_first_child_element(rule); expr != NULL;
+                 expr = __xml_next_element(expr)) {
+
                 if (find_expression_type(expr) == version_expr) {
                     return rule;
                 }
@@ -786,7 +787,7 @@ add_versioned_attributes(xmlNode * attr_set, xmlNode * versioned_attrs)
         return;
     }
 
-    expr = __xml_first_child(rule);
+    expr = __xml_first_child_element(rule);
     while (expr != NULL) {
         if (find_expression_type(expr) != version_expr) {
             xmlNode *node = expr;
@@ -864,7 +865,9 @@ make_pairs_and_populate_data(xmlNode * top, xmlNode * xml_obj, const char *set_n
     }
 
     crm_trace("Checking for attributes");
-    for (attr_set = __xml_first_child(xml_obj); attr_set != NULL; attr_set = __xml_next_element(attr_set)) {
+    for (attr_set = __xml_first_child_element(xml_obj); attr_set != NULL;
+         attr_set = __xml_next_element(attr_set)) {
+
         /* Uncertain if set_name == NULL check is strictly necessary here */
         if (set_name == NULL || crm_str_eq((const char *)attr_set->name, set_name, TRUE)) {
             pair = NULL;
@@ -996,7 +999,7 @@ pe_unpack_versioned_parameters(xmlNode *versioned_params, const char *ra_version
 
     if (versioned_params && ra_version) {
         GHashTable *node_hash = crm_str_table_new();
-        xmlNode *attr_set = __xml_first_child(versioned_params);
+        xmlNode *attr_set = __xml_first_child_element(versioned_params);
 
         if (attr_set) {
             g_hash_table_insert(node_hash, strdup(CRM_ATTR_RA_VERSION),

--- a/lib/pengine/rules_alerts.c
+++ b/lib/pengine/rules_alerts.c
@@ -97,8 +97,8 @@ unpack_alert_filter(xmlNode *basenode, crm_alert_entry_t *entry)
     xmlNode *event_type = NULL;
     uint32_t flags = crm_alert_none;
 
-    for (event_type = __xml_first_child(select); event_type != NULL;
-         event_type = __xml_next(event_type)) {
+    for (event_type = __xml_first_child_element(select); event_type != NULL;
+         event_type = __xml_next_element(event_type)) {
 
         const char *tagname = crm_element_name(event_type);
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -402,7 +402,9 @@ remote_id_conflict(const char *remote_name, pe_working_set_t *data)
 #else
     if (data->name_check == NULL) {
         data->name_check = g_hash_table_new(crm_str_hash, g_str_equal);
-        for (xml_rsc = __xml_first_child(parent); xml_rsc != NULL; xml_rsc = __xml_next_element(xml_rsc)) {
+        for (xml_rsc = __xml_first_child_element(parent); xml_rsc != NULL;
+             xml_rsc = __xml_next_element(xml_rsc)) {
+
             const char *id = ID(xml_rsc);
 
             /* avoiding heap allocation here because we know the duration of this hashtable allows us to */
@@ -436,12 +438,14 @@ expand_remote_rsc_meta(xmlNode *xml_obj, xmlNode *parent, pe_working_set_t *data
     const char *remote_allow_migrate=NULL;
     const char *is_managed = NULL;
 
-    for (attr_set = __xml_first_child(xml_obj); attr_set != NULL; attr_set = __xml_next_element(attr_set)) {
+    for (attr_set = __xml_first_child_element(xml_obj); attr_set != NULL;
+         attr_set = __xml_next_element(attr_set)) {
         if (safe_str_neq((const char *)attr_set->name, XML_TAG_META_SETS)) {
             continue;
         }
 
-        for (attr = __xml_first_child(attr_set); attr != NULL; attr = __xml_next_element(attr)) {
+        for (attr = __xml_first_child_element(attr_set); attr != NULL;
+             attr = __xml_next_element(attr)) {
             const char *value = crm_element_value(attr, XML_NVPAIR_ATTR_VALUE);
             const char *name = crm_element_value(attr, XML_NVPAIR_ATTR_NAME);
 
@@ -510,7 +514,9 @@ unpack_nodes(xmlNode * xml_nodes, pe_working_set_t * data_set)
     const char *type = NULL;
     const char *score = NULL;
 
-    for (xml_obj = __xml_first_child(xml_nodes); xml_obj != NULL; xml_obj = __xml_next_element(xml_obj)) {
+    for (xml_obj = __xml_first_child_element(xml_nodes); xml_obj != NULL;
+         xml_obj = __xml_next_element(xml_obj)) {
+
         if (crm_str_eq((const char *)xml_obj->name, XML_CIB_TAG_NODE, TRUE)) {
             new_node = NULL;
 
@@ -594,7 +600,9 @@ unpack_remote_nodes(xmlNode * xml_resources, pe_working_set_t * data_set)
     /* Create remote nodes and guest nodes from the resource configuration
      * before unpacking resources.
      */
-    for (xml_obj = __xml_first_child(xml_resources); xml_obj != NULL; xml_obj = __xml_next_element(xml_obj)) {
+    for (xml_obj = __xml_first_child_element(xml_resources); xml_obj != NULL;
+         xml_obj = __xml_next_element(xml_obj)) {
+
         const char *new_node_id = NULL;
 
         /* Check for remote nodes, which are defined by ocf:pacemaker:remote
@@ -636,7 +644,8 @@ unpack_remote_nodes(xmlNode * xml_resources, pe_working_set_t * data_set)
          */
         if (crm_str_eq((const char *)xml_obj->name, XML_CIB_TAG_GROUP, TRUE)) {
             xmlNode *xml_obj2 = NULL;
-            for (xml_obj2 = __xml_first_child(xml_obj); xml_obj2 != NULL; xml_obj2 = __xml_next_element(xml_obj2)) {
+            for (xml_obj2 = __xml_first_child_element(xml_obj); xml_obj2 != NULL;
+                 xml_obj2 = __xml_next_element(xml_obj2)) {
 
                 new_node_id = expand_remote_rsc_meta(xml_obj2, xml_resources, data_set);
 
@@ -730,7 +739,9 @@ unpack_resources(xmlNode * xml_resources, pe_working_set_t * data_set)
                                                         g_str_equal, free,
                                                         destroy_tag);
 
-    for (xml_obj = __xml_first_child(xml_resources); xml_obj != NULL; xml_obj = __xml_next_element(xml_obj)) {
+    for (xml_obj = __xml_first_child_element(xml_resources); xml_obj != NULL;
+         xml_obj = __xml_next_element(xml_obj)) {
+
         resource_t *new_rsc = NULL;
 
         if (crm_str_eq((const char *)xml_obj->name, XML_CIB_TAG_RSC_TEMPLATE, TRUE)) {
@@ -788,7 +799,9 @@ unpack_tags(xmlNode * xml_tags, pe_working_set_t * data_set)
     data_set->tags = g_hash_table_new_full(crm_str_hash, g_str_equal, free,
                                            destroy_tag);
 
-    for (xml_tag = __xml_first_child(xml_tags); xml_tag != NULL; xml_tag = __xml_next_element(xml_tag)) {
+    for (xml_tag = __xml_first_child_element(xml_tags); xml_tag != NULL;
+         xml_tag = __xml_next_element(xml_tag)) {
+
         xmlNode *xml_obj_ref = NULL;
         const char *tag_id = ID(xml_tag);
 
@@ -802,7 +815,9 @@ unpack_tags(xmlNode * xml_tags, pe_working_set_t * data_set)
             continue;
         }
 
-        for (xml_obj_ref = __xml_first_child(xml_tag); xml_obj_ref != NULL; xml_obj_ref = __xml_next_element(xml_obj_ref)) {
+        for (xml_obj_ref = __xml_first_child_element(xml_tag); xml_obj_ref != NULL;
+             xml_obj_ref = __xml_next_element(xml_obj_ref)) {
+
             const char *obj_ref = ID(xml_obj_ref);
 
             if (crm_str_eq((const char *)xml_obj_ref->name, XML_CIB_TAG_OBJ_REF, TRUE) == FALSE) {
@@ -896,7 +911,9 @@ unpack_tickets_state(xmlNode * xml_tickets, pe_working_set_t * data_set)
 {
     xmlNode *xml_obj = NULL;
 
-    for (xml_obj = __xml_first_child(xml_tickets); xml_obj != NULL; xml_obj = __xml_next_element(xml_obj)) {
+    for (xml_obj = __xml_first_child_element(xml_tickets); xml_obj != NULL;
+         xml_obj = __xml_next_element(xml_obj)) {
+
         if (crm_str_eq((const char *)xml_obj->name, XML_CIB_TAG_TICKET_STATE, TRUE) == FALSE) {
             continue;
         }
@@ -976,7 +993,9 @@ unpack_node_loop(xmlNode * status, bool fence, pe_working_set_t * data_set)
     bool changed = false;
     xmlNode *lrm_rsc = NULL;
 
-    for (xmlNode *state = __xml_first_child(status); state != NULL; state = __xml_next_element(state)) {
+    for (xmlNode *state = __xml_first_child_element(status); state != NULL;
+         state = __xml_next_element(state)) {
+
         const char *id = NULL;
         const char *uname = NULL;
         node_t *this_node = NULL;
@@ -1076,7 +1095,9 @@ unpack_status(xmlNode * status, pe_working_set_t * data_set)
                                                   free, destroy_ticket);
     }
 
-    for (state = __xml_first_child(status); state != NULL; state = __xml_next_element(state)) {
+    for (state = __xml_first_child_element(status); state != NULL;
+         state = __xml_next_element(state)) {
+
         if (crm_str_eq((const char *)state->name, XML_CIB_TAG_TICKETS, TRUE)) {
             unpack_tickets_state((xmlNode *) state, data_set);
 
@@ -2189,7 +2210,8 @@ unpack_lrm_rsc_state(node_t * node, xmlNode * rsc_entry, pe_working_set_t * data
     op_list = NULL;
     sorted_op_list = NULL;
 
-    for (rsc_op = __xml_first_child(rsc_entry); rsc_op != NULL; rsc_op = __xml_next_element(rsc_op)) {
+    for (rsc_op = __xml_first_child_element(rsc_entry); rsc_op != NULL;
+         rsc_op = __xml_next_element(rsc_op)) {
         if (crm_str_eq((const char *)rsc_op->name, XML_LRM_TAG_RSC_OP, TRUE)) {
             op_list = g_list_prepend(op_list, rsc_op);
         }
@@ -2258,8 +2280,8 @@ static void
 handle_orphaned_container_fillers(xmlNode * lrm_rsc_list, pe_working_set_t * data_set)
 {
     xmlNode *rsc_entry = NULL;
-    for (rsc_entry = __xml_first_child(lrm_rsc_list); rsc_entry != NULL;
-        rsc_entry = __xml_next_element(rsc_entry)) {
+    for (rsc_entry = __xml_first_child_element(lrm_rsc_list); rsc_entry != NULL;
+         rsc_entry = __xml_next_element(rsc_entry)) {
 
         resource_t *rsc;
         resource_t *container;
@@ -2305,7 +2327,7 @@ unpack_lrm_resources(node_t * node, xmlNode * lrm_rsc_list, pe_working_set_t * d
 
     crm_trace("Unpacking resources on %s", node->details->uname);
 
-    for (rsc_entry = __xml_first_child(lrm_rsc_list); rsc_entry != NULL;
+    for (rsc_entry = __xml_first_child_element(lrm_rsc_list); rsc_entry != NULL;
          rsc_entry = __xml_next_element(rsc_entry)) {
 
         if (crm_str_eq((const char *)rsc_entry->name, XML_LRM_TAG_RESOURCE, TRUE)) {
@@ -3501,7 +3523,8 @@ extract_operations(const char *node, const char *rsc, xmlNode * rsc_entry, gbool
     op_list = NULL;
     sorted_op_list = NULL;
 
-    for (rsc_op = __xml_first_child(rsc_entry); rsc_op != NULL; rsc_op = __xml_next_element(rsc_op)) {
+    for (rsc_op = __xml_first_child_element(rsc_entry);
+         rsc_op != NULL; rsc_op = __xml_next_element(rsc_op)) {
         if (crm_str_eq((const char *)rsc_op->name, XML_LRM_TAG_RSC_OP, TRUE)) {
             crm_xml_add(rsc_op, "resource", rsc);
             crm_xml_add(rsc_op, XML_ATTR_UNAME, node);
@@ -3559,7 +3582,7 @@ find_operations(const char *rsc, const char *node, gboolean active_filter,
 
     xmlNode *node_state = NULL;
 
-    for (node_state = __xml_first_child(status); node_state != NULL;
+    for (node_state = __xml_first_child_element(status); node_state != NULL;
          node_state = __xml_next_element(node_state)) {
 
         if (crm_str_eq((const char *)node_state->name, XML_CIB_TAG_STATE, TRUE)) {
@@ -3591,7 +3614,7 @@ find_operations(const char *rsc, const char *node, gboolean active_filter,
                 tmp = find_xml_node(node_state, XML_CIB_TAG_LRM, FALSE);
                 tmp = find_xml_node(tmp, XML_LRM_TAG_RESOURCES, FALSE);
 
-                for (lrm_rsc = __xml_first_child(tmp); lrm_rsc != NULL;
+                for (lrm_rsc = __xml_first_child_element(tmp); lrm_rsc != NULL;
                      lrm_rsc = __xml_next_element(lrm_rsc)) {
                     if (crm_str_eq((const char *)lrm_rsc->name, XML_LRM_TAG_RESOURCE, TRUE)) {
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -660,7 +660,7 @@ unpack_operation_on_fail(action_t * action)
 
         CRM_CHECK(action->rsc != NULL, return NULL);
 
-        for (operation = __xml_first_child(action->rsc->ops_xml);
+        for (operation = __xml_first_child_element(action->rsc->ops_xml);
              operation && !value; operation = __xml_next_element(operation)) {
 
             if (!crm_str_eq((const char *)operation->name, "op", TRUE)) {
@@ -699,7 +699,7 @@ find_min_interval_mon(resource_t * rsc, gboolean include_disabled)
     xmlNode *op = NULL;
     xmlNode *operation = NULL;
 
-    for (operation = __xml_first_child(rsc->ops_xml); operation != NULL;
+    for (operation = __xml_first_child_element(rsc->ops_xml); operation != NULL;
          operation = __xml_next_element(operation)) {
 
         if (crm_str_eq((const char *)operation->name, "op", TRUE)) {
@@ -862,8 +862,12 @@ unpack_versioned_meta(xmlNode *versioned_meta, xmlNode *xml_obj,
     xmlNode *attrs = NULL;
     xmlNode *attr = NULL;
 
-    for (attrs = __xml_first_child(versioned_meta); attrs != NULL; attrs = __xml_next_element(attrs)) {
-        for (attr = __xml_first_child(attrs); attr != NULL; attr = __xml_next_element(attr)) {
+    for (attrs = __xml_first_child_element(versioned_meta); attrs != NULL;
+         attrs = __xml_next_element(attrs)) {
+
+        for (attr = __xml_first_child_element(attrs); attr != NULL;
+             attr = __xml_next_element(attr)) {
+
             const char *name = crm_element_value(attr, XML_NVPAIR_ATTR_NAME);
             const char *value = crm_element_value(attr, XML_NVPAIR_ATTR_VALUE);
 
@@ -1191,7 +1195,7 @@ find_rsc_op_entry_helper(resource_t * rsc, const char *key, gboolean include_dis
     xmlNode *operation = NULL;
 
   retry:
-    for (operation = __xml_first_child(rsc->ops_xml); operation != NULL;
+    for (operation = __xml_first_child_element(rsc->ops_xml); operation != NULL;
          operation = __xml_next_element(operation)) {
         if (crm_str_eq((const char *)operation->name, "op", TRUE)) {
             name = crm_element_value(operation, "name");

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1522,7 +1522,9 @@ crm_diff_update_v2(const char *event, xmlNode * msg)
             xmlNode *state = NULL;
             xmlNode *status = first_named_child(match, XML_CIB_TAG_STATUS);
 
-            for (state = __xml_first_child(status); state != NULL; state = __xml_next(state)) {
+            for (state = __xml_first_child_element(status); state != NULL;
+                 state = __xml_next_element(state)) {
+
                 node = crm_element_value(state, XML_ATTR_UNAME);
                 if (node == NULL) {
                     node = ID(state);
@@ -1533,7 +1535,9 @@ crm_diff_update_v2(const char *event, xmlNode * msg)
         } else if(strcmp(name, XML_CIB_TAG_STATUS) == 0) {
             xmlNode *state = NULL;
 
-            for (state = __xml_first_child(match); state != NULL; state = __xml_next(state)) {
+            for (state = __xml_first_child_element(match); state != NULL;
+                 state = __xml_next_element(state)) {
+
                 node = crm_element_value(state, XML_ATTR_UNAME);
                 if (node == NULL) {
                     node = ID(state);

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -685,7 +685,8 @@ print_rsc_history(mon_state_t *state, pe_working_set_t *data_set, node_t *node,
     }
 
     /* Create a list of this resource's operations */
-    for (rsc_op = __xml_first_child(rsc_entry); rsc_op != NULL; rsc_op = __xml_next(rsc_op)) {
+    for (rsc_op = __xml_first_child_element(rsc_entry); rsc_op != NULL;
+         rsc_op = __xml_next_element(rsc_op)) {
         if (crm_str_eq((const char *)rsc_op->name, XML_LRM_TAG_RSC_OP, TRUE)) {
             op_list = g_list_append(op_list, rsc_op);
         }
@@ -756,8 +757,8 @@ print_node_history(mon_state_t *state, pe_working_set_t *data_set,
         lrm_rsc = find_xml_node(lrm_rsc, XML_LRM_TAG_RESOURCES, FALSE);
 
         /* Print history of each of the node's resources */
-        for (rsc_entry = __xml_first_child(lrm_rsc); rsc_entry != NULL;
-             rsc_entry = __xml_next(rsc_entry)) {
+        for (rsc_entry = __xml_first_child_element(lrm_rsc); rsc_entry != NULL;
+             rsc_entry = __xml_next_element(rsc_entry)) {
 
             if (crm_str_eq((const char *)rsc_entry->name, XML_LRM_TAG_RESOURCE, TRUE)) {
                 print_rsc_history(state, data_set, node, rsc_entry, operations, mon_ops);
@@ -951,8 +952,8 @@ print_node_summary(mon_state_t *state, pe_working_set_t * data_set,
     }
 
     /* Print each node in the CIB status */
-    for (node_state = __xml_first_child(cib_status); node_state != NULL;
-         node_state = __xml_next(node_state)) {
+    for (node_state = __xml_first_child_element(cib_status); node_state != NULL;
+         node_state = __xml_next_element(node_state)) {
         if (crm_str_eq((const char *)node_state->name, XML_CIB_TAG_STATE, TRUE)) {
             print_node_history(state, data_set, node_state, operations, mon_ops);
         }

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2018 the Pacemaker project contributors
+ * Copyright 2004-2019 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -17,8 +17,8 @@ cli_resource_print_cts_constraints(pe_working_set_t * data_set)
     xmlNode *lifetime = NULL;
     xmlNode *cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS, data_set->input);
 
-    for (xml_obj = __xml_first_child(cib_constraints); xml_obj != NULL;
-         xml_obj = __xml_next(xml_obj)) {
+    for (xml_obj = __xml_first_child_element(cib_constraints); xml_obj != NULL;
+         xml_obj = __xml_next_element(xml_obj)) {
         const char *id = crm_element_value(xml_obj, XML_ATTR_ID);
 
         if (id == NULL) {

--- a/tools/crmadmin.c
+++ b/tools/crmadmin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2018 the Pacemaker project contributors
+ * Copyright 2004-2019 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -448,7 +448,9 @@ do_find_node_list(xmlNode * xml_node)
     xmlNode *node = NULL;
     xmlNode *nodes = get_object_root(XML_CIB_TAG_NODES, xml_node);
 
-    for (node = __xml_first_child(nodes); node != NULL; node = __xml_next(node)) {
+    for (node = __xml_first_child_element(nodes); node != NULL;
+         node = __xml_next_element(node)) {
+
         if (crm_str_eq((const char *)node->name, XML_CIB_TAG_NODE, TRUE)) {
 
             if (BASH_EXPORT) {


### PR DESCRIPTION
__xml_first_child() and __xml_next() are intended to be used in "for" loops
where all XML node types (elements, comments, etc.) are desired.

__xml_first_child_element() and __xml_next_element() are intended when
only element children are desired.

Previously, many element-only loops properly used __xml_next_element() but
started with __xml_first_child(). In most cases, this would (by lucky
circumstance) work without harm. However, there were cases where a comment as
the first child of an element would case problems (for example,
unpack_resources() would log a configuration error).

Now, __xml_first_child_element() is always used in such cases.

Additionally, there were some loops using __xml_first_child()/__xml_next() that
clearly were expecting only elements. These have been converted to
__xml_first_child_element()/__xml_next_element().

Many more cases exist where __xml_first_child()/__xml_next() is used with IPC
messages and patchsets. This commit does not convert those, though that would
probably be a good idea for the future.