### PR TITLE
Build: add truly noarch indirection towards pacemaker schemas

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -585,7 +585,18 @@ AC_PATH_PROG([XSLTPROC], [xsltproc])
 AC_PATH_PROG([XMLCATALOG], [xmlcatalog])
 dnl BASH is already an environment variable, so use something else
 AC_PATH_PROG([BASH_PATH], [bash])
+
 PKG_PROG_PKG_CONFIG
+# PKG_NOARCH_INSTALLDIR not available prior to pkg-config 0.27 and
+# pkgconf 0.8.10, respectively (next line is to mimic that scenario)
+dnl m4_ifdef([PKG_NOARCH_INSTALLDIR], [m4_undefine([PKG_NOARCH_INSTALLDIR])])
+m4_ifndef([PKG_NOARCH_INSTALLDIR], [
+    AC_DEFUN([PKG_NOARCH_INSTALLDIR], [
+        AC_SUBST([noarch_pkgconfigdir], ['${datadir}/pkgconfig'])
+    ])
+])
+PKG_NOARCH_INSTALLDIR
+
 AC_PATH_PROGS(VALGRIND_BIN, valgrind, /usr/bin/valgrind)
 AC_DEFINE_UNQUOTED(VALGRIND_BIN, "$VALGRIND_BIN", Valgrind command)
 
@@ -1883,6 +1894,7 @@ AC_CONFIG_FILES(Makefile                                            \
                 tools/crm_mon.service                               \
                 tools/crm_mon.upstart                               \
                 xml/Makefile                                        \
+                xml/pacemaker-schemas.pc                            \
 )
 
 dnl Now process the entire list of files added by previous

--- a/lib/pacemaker-cib.pc.in
+++ b/lib/pacemaker-cib.pc.in
@@ -3,6 +3,7 @@ libdir=@libdir@
 includedir=@includedir@/@PACKAGE_TARNAME@
 
 configdir=@CRM_CONFIG_DIR@
+# for this and related variables, you may rather query pacemaker-schemas.pc
 schemadir=@CRM_SCHEMA_DIRECTORY@
 
 Name:             lib${sub}

--- a/pacemaker.spec.in
+++ b/pacemaker.spec.in
@@ -834,6 +834,7 @@ exit 0
 %{_datadir}/pacemaker/*.rng
 %{_datadir}/pacemaker/*.xsl
 %{_datadir}/pacemaker/api
+%{_datadir}/pkgconfig/pacemaker-schemas.pc
 
 %changelog
 

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -9,6 +9,8 @@
 
 include $(top_srcdir)/Makefile.common
 
+noarch_pkgconfig_DATA	= $(builddir)/pacemaker-schemas.pc
+
 # Pacemaker has 3 schemas: the CIB schema, the API schema (for command-line
 # tool XML output), and a legacy schema for crm_mon --as-xml.
 #

--- a/xml/pacemaker-schemas.pc.in
+++ b/xml/pacemaker-schemas.pc.in
@@ -1,0 +1,12 @@
+# compatible with pacemaker-cib.pc:schemadir
+schemadir=@CRM_SCHEMA_DIRECTORY@
+
+# where machine-friendly API interchange format is formalized as schemas
+schemadir4api=${schemadir}/api
+
+Name:             Pacemaker Schemas & Transformations
+Version:          @PACKAGE_VERSION@
+Description:      XML validation & transformation variables per Pacemaker build
+URL:              @PACKAGE_URL@
+
+# no linker/compiler properties to associate


### PR DESCRIPTION
This need stems from the downstream parcelling of the bits (where
it irrefutably, unlike with upstream one trying to be as suitable
and universal preimage as possible [hence this upstream change],
interacts with other software packages such as clufter [see also
6ef3f776b]), since previously, any external package only interested
in the actual schemas or transformation stylesheets would (in
systemically constructed approach not relying on any kind of
pacemaker-related hardwiring, which is recommended for obvious
reasons) query pacemaker-cib.pc for schemadir variable.  However,
for that file to be present, the avalanche of packages starting
with pacemaker devel package (and consequently corosync libraries,
libqb, ...) is needed for that, adding up to the from-ground-up
requirements unreasonably.

The solution is to devise a brand new pkg-config file
pacemaker-schemas.pc that would only serve that indirection
purpose.  It will overlap with pacemaker-cib.pc at the mentioned
item, however, this new file is the only to receive all the updates
as such top directory becomes sub-divided, as already manifested
with a brand new schemadir4api variable.

All the users of schemas/transformations alone are hence suggested
to primarily aim (arch-independent) pacemaker-schemas.pc first now,
and pacemaker-cib.pc only as a fallback when older version of
pacemaker lacking the former is encountered.

Regarding the change in the upstream spec file, note that in practice
(with some downstreams, at least, observed with Fedora), this adds
a new automatic dependency of pacemaker-schemas subpackage on pkg-config
tool, however it is rather self-contained (unlike the transitive cluster
library dependencies), and is likely to reside on real use-systems/roots
anyway.  If that'd be a blocker for some minimalistic use cases, it
shall be straightforward to turn that into something like Recommends:.