### PR TITLE
Doc: fix stop-all-resources self-documenting text

### DIFF
--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -118,7 +118,7 @@ static pe_cluster_option pe_opts[] = {
 
 	/* Orphans and stopping */
 	{ "stop-all-resources", NULL, "boolean", NULL, "false", &check_boolean,
-	  "Should the cluster stop all active resources (except those needed for fencing)", NULL },
+	  "Should the cluster stop all active resources", NULL },
 	{ "stop-orphan-resources", NULL, "boolean", NULL, "true", &check_boolean,
 	  "Should deleted resources be stopped", NULL },
 	{ "stop-orphan-actions", NULL, "boolean", NULL, "true", &check_boolean,


### PR DESCRIPTION
cluster option "stop-all-resources" behaviour was changed in f4d8a29d6d
at 2010. It was reverted by ecd95f7f10 at 2012, but only left the
self-documenting text behind. It makes 'man pengine' and 'man
pacemaker-schedulerd' conflict with the actual behaviour since then.
BTW, "Pacemaker Explained" is up-to-date and in the good shape for it.

Signed-off-by: Roger Zhou <zzhou@suse.com>