### PR TITLE
Low: libstonithd: Changing the log level.

### DIFF
--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -523,7 +523,7 @@ make_args(const char *agent, const char *action, const char *victim, uint32_t vi
         value = g_hash_table_lookup(device_args, buffer);
     }
     if (value) {
-        crm_info("Substituting action '%s' for requested operation '%s'", value, action);
+        crm_debug("Substituting action '%s' for requested operation '%s'", value, action);
         action = value;
     }
 


### PR DESCRIPTION
Hi All,

When pcmk_monitor_action is specified in fence_mpath etc., the following log is output in the monitor cycle and it is very noisy.

```
Aug 30 13:06:47 rh80-04 pacemaker-fenced    [17361] (make_args)         info: Substituting action 'metadata' for requested operation 'monitor'
Aug 30 13:07:48 rh80-04 pacemaker-fenced    [17361] (make_args)         info: Substituting action 'metadata' for requested operation 'monitor'
Aug 30 13:08:48 rh80-04 pacemaker-fenced    [17361] (make_args)         info: Substituting action 'metadata' for requested operation 'monitor'
Aug 30 13:09:48 rh80-04 pacemaker-fenced    [17361] (make_args)         info: Substituting action 'metadata' for requested operation 'monitor'
Aug 30 13:10:48 rh80-04 pacemaker-fenced    [17361] (make_args)         info: Substituting action 'metadata' for requested operation 'monitor'
Aug 30 13:11:48 rh80-04 pacemaker-fenced    [17361] (make_args)         info: Substituting action 'metadata' for requested operation 'monitor'
Aug 30 13:12:49 rh80-04 pacemaker-fenced    [17361] (make_args)         info: Substituting action 'metadata' for requested operation 'monitor'
Aug 30 13:13:49 rh80-04 pacemaker-fenced    [17361] (make_args)         info: Substituting action 'metadata' for requested operation 'monitor'
Aug 30 13:14:49 rh80-04 pacemaker-fenced    [17361] (make_args)         info: Substituting action 'metadata' for requested operation 'monitor'
Aug 30 13:15:49 rh80-04 pacemaker-fenced    [17361] (make_args)         info: Substituting action 'metadata' for requested operation 'monitor'
```

I think that debugging is sufficient for the log level of this message.

Best Regards,
Hideo Yamauchi.