### PR TITLE
Mid: crm_mon: Displays completed failed actions as processed.

### DIFF
--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -74,7 +74,7 @@ static void print_cluster_summary(mon_state_t *state, pe_working_set_t *data_set
                                   unsigned int mon_ops, unsigned int show);
 static void print_failed_action(mon_state_t *state, xmlNode *xml_op);
 static void print_failed_actions(mon_state_t *state, pe_working_set_t *data_set);
-static void print_stonith_action(mon_state_t *state, stonith_history_t *event, unsigned int mon_ops);
+static void print_stonith_action(mon_state_t *state, stonith_history_t *event, unsigned int mon_ops, stonith_history_t *top_history);
 static void print_failed_stonith_actions(mon_state_t *state, stonith_history_t *history, unsigned int mon_ops);
 static void print_stonith_pending(mon_state_t *state, stonith_history_t *history, unsigned int mon_ops);
 static void print_stonith_history(mon_state_t *state, stonith_history_t *history, unsigned int mon_ops);
@@ -1889,8 +1889,31 @@ print_failed_actions(mon_state_t *state, pe_working_set_t *data_set)
  * \param[in] stream     File stream to display output to
  * \param[in] event      stonith event
  */
+static gboolean 
+is_later_succeeded(stonith_history_t *event, stonith_history_t *top_history)
+{
+
+     gboolean ret = FALSE;
+
+     for (stonith_history_t *prev_hp = top_history; prev_hp; prev_hp = prev_hp->next) {
+        if (prev_hp == event) {
+            break;
+        }
+
+         if ((prev_hp->state == st_done) &&
+            safe_str_eq(event->target, prev_hp->target) &&
+            safe_str_eq(event->action, prev_hp->action) &&
+            safe_str_eq(event->delegate, prev_hp->delegate) &&
+            (event->completed < prev_hp->completed)) {
+            ret = TRUE;
+            break;
+        }
+    }
+    return ret;
+}
+
 static void
-print_stonith_action(mon_state_t *state, stonith_history_t *event, unsigned int mon_ops)
+print_stonith_action(mon_state_t *state, stonith_history_t *event, unsigned int mon_ops, stonith_history_t *top_history)
 {
     const char *action_s = stonith_action_str(event->action);
     char *run_at_s = ctime(&event->completed);
@@ -1943,12 +1966,13 @@ print_stonith_action(mon_state_t *state, stonith_history_t *event, unsigned int 
                     break;
                 case st_failed:
                     print_as(state->output_format, "* %s of %s failed: delegate=%s, client=%s, origin=%s,\n"
-                             "    %s='%s'\n",
+                             "    %s='%s' %s\n",
                              action_s, event->target,
                              event->delegate ? event->delegate : "",
                              event->client, event->origin,
                              is_set(mon_ops, mon_op_fence_full_history) ? "completed" : "last-failed",
-                             run_at_s?run_at_s:"");
+                             run_at_s?run_at_s:"",
+                             is_later_succeeded(event, top_history) ? "(a later attempt succeeded)" : "");
                     break;
                 default:
                     print_as(state->output_format, "* %s of %s pending: client=%s, origin=%s\n",
@@ -1971,12 +1995,13 @@ print_stonith_action(mon_state_t *state, stonith_history_t *event, unsigned int 
                     break;
                 case st_failed:
                     fprintf(state->stream, "  <li>%s of %s failed: delegate=%s, "
-                                    "client=%s, origin=%s, %s='%s'</li>\n",
+                                    "client=%s, origin=%s, %s='%s' %s</li>\n",
                                     action_s, event->target,
                                     event->delegate ? event->delegate : "",
                                     event->client, event->origin,
                                     is_set(mon_ops, mon_op_fence_full_history) ? "completed" : "last-failed",
-                                    run_at_s?run_at_s:"");
+                                    run_at_s?run_at_s:"",
+                                    is_later_succeeded(event, top_history) ? "(a later attempt succeeded)" : "");
                     break;
                 default:
                     fprintf(state->stream, "  <li>%s of %s pending: client=%s, "
@@ -2036,7 +2061,7 @@ print_failed_stonith_actions(mon_state_t *state, stonith_history_t *history, uns
     /* Print each failed stonith action */
     for (hp = history; hp; hp = hp->next) {
         if (hp->state == st_failed) {
-            print_stonith_action(state, hp, mon_ops);
+            print_stonith_action(state, hp, mon_ops, history);
         }
     }
 
@@ -2091,7 +2116,7 @@ print_stonith_pending(mon_state_t *state, stonith_history_t *history, unsigned i
             if ((hp->state == st_failed) || (hp->state == st_done)) {
                 break;
             }
-            print_stonith_action(state, hp, mon_ops);
+            print_stonith_action(state, hp, mon_ops, NULL);
         }
 
         /* End section */
@@ -2142,7 +2167,7 @@ print_stonith_history(mon_state_t *state, stonith_history_t *history, unsigned i
 
     for (hp = history; hp; hp = hp->next) {
         if ((hp->state != st_failed) || (state->output_format == mon_output_xml)) {
-            print_stonith_action(state, hp, mon_ops);
+            print_stonith_action(state, hp, mon_ops, NULL);
         }
     }
 


### PR DESCRIPTION
Hi All,
Hi Ken,
Hi wenningerk,

This is a modification of crm_mon discussed in the next PR.
 - https://github.com/ClusterLabs/pacemaker/pull/1872

This should reduce user confusion.



(After failure)
```
[root@rh76hv-02 ~]# crm_mon -1 -Af
Stack: corosync
Current DC: rh76hv-02 (version 2.0.2-3e18b2a5a0) - partition WITHOUT quorum
Last updated: Wed Sep  4 14:10:37 2019
Last change: Wed Sep  4 13:56:49 2019 by root via cibadmin on rh76hv-01

2 nodes configured
2 resources configured

Node rh76hv-01: UNCLEAN (offline)
Online: [ rh76hv-02 ]

Active resources:

 Resource Group: grpStonith1
     prmStonith1-2      (stonith:external/ssh): Started rh76hv-02
 Resource Group: grpStonith2
     prmStonith2-2      (stonith:external/ssh): Started rh76hv-01 (UNCLEAN)

Node Attributes:
* Node rh76hv-02:

Migration Summary:
* Node rh76hv-02:

Failed Fencing Actions:
* reboot of rh76hv-01 failed: delegate=rh76hv-02, client=pacemaker-controld.21865, origin=rh76hv-02,
    last-failed='Wed Sep  4 13:59:15 2019' 

```


(After completion)
```
[root@rh76hv-02 ~]# crm_mon -1 -Af
Stack: corosync
Current DC: rh76hv-02 (version 2.0.2-3e18b2a5a0) - partition WITHOUT quorum
Last updated: Wed Sep  4 14:14:52 2019
Last change: Wed Sep  4 13:56:49 2019 by root via cibadmin on rh76hv-01

2 nodes configured
2 resources configured

Online: [ rh76hv-02 ]
OFFLINE: [ rh76hv-01 ]

Active resources:

 Resource Group: grpStonith1
     prmStonith1-2      (stonith:external/ssh): Started rh76hv-02

Node Attributes:
* Node rh76hv-02:

Migration Summary:
* Node rh76hv-02:

Failed Fencing Actions:
* reboot of rh76hv-01 failed: delegate=rh76hv-02, client=pacemaker-controld.21865, origin=rh76hv-02,
    last-failed='Wed Sep  4 13:59:15 2019' (a later attempt succeeded)
```

Best Regards,
Hideo Yamauchi.

