### PR TITLE
Get "make check" working in VPATH builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,9 +35,13 @@ MAINTAINERCLEANFILES	= Makefile.in		\
 # some of our book sources are in the source directory, while others are
 # dynamically generated in the build directory, and publican can't handle that.
 #
-# @TODO To support VPATH builds for Publican, we'd probably have to create
-# a separate subtree of the build directory to use as Publican's source
-# directory, and copy the static sources into it.
+# In a non-VPATH build, doc isn't entered with a plain "make" because the
+# GNUmakefile sets "core" as the default target. However in a VPATH build,
+# there is no GNUmakefile, so "all" becomes the default target.
+#
+# @TODO To support VPATH builds for Publican, we could use the same "copy all
+# static inputs into the build tree" trick that xml/Makefile.am uses for
+# static schema files.
 AM_DISTCHECK_CONFIGURE_FLAGS	= --with-brand=""
 
 # Only these will get installed with a plain "make install"

--- a/cts/Makefile.am
+++ b/cts/Makefile.am
@@ -78,10 +78,12 @@ dist_pe_DATA	= $(PE_TESTS) \
 		  $(wildcard scheduler/*.stderr)
 
 # For "make check", run a single scheduler test
-TESTS = scheduler/bug-rh-1097457.xml
-TEST_EXTENSIONS = .xml
-XML_LOG_COMPILER = ./cts-scheduler
-AM_XML_LOG_FLAGS = -V --run
+TESTS			= scheduler/bug-rh-1097457.xml
+TEST_EXTENSIONS		= .xml
+XML_LOG_COMPILER	= ./cts-scheduler
+AM_XML_LOG_FLAGS	= --io-dir="$(srcdir)/scheduler"	\
+			  --out-dir="$(builddir)"		\
+			  -V --run
 
 scheduler-list:
 	@for T in "$(srcdir)"/scheduler/*.xml; do       \

--- a/cts/cts-scheduler.in
+++ b/cts/cts-scheduler.in
@@ -1065,6 +1065,9 @@ class CtsScheduler(object):
         parser.add_argument('-i', '--io-dir', metavar='PATH',
                             help='Specify path to regression test data directory')
 
+        parser.add_argument('-o', '--out-dir', metavar='PATH',
+                            help='Specify where intermediate and output files should go')
+
         parser.add_argument('-v', '--valgrind', action='store_true',
                             help='Run all commands under valgrind')
 
@@ -1162,10 +1165,14 @@ class CtsScheduler(object):
         # Where test data resides
         if self.args.io_dir is None:
             self.args.io_dir = os.path.join(self.test_home, "scheduler")
-        os.environ['CIB_shadow_dir'] = self.args.io_dir
 
-        # Where to store results of failed tests
-        self.failed_filename = os.path.join(self.test_home, ".regression.failed.diff")
+        # Where to store generated files
+        if self.args.out_dir is None:
+            self.args.out_dir = self.args.io_dir
+            self.failed_filename = os.path.join(self.test_home, ".regression.failed.diff")
+        else:
+            self.failed_filename = os.path.join(self.args.out_dir, ".regression.failed.diff")
+        os.environ['CIB_shadow_dir'] = self.args.out_dir
         self.failed_file = None
 
         # Single test mode (if requested)
@@ -1212,12 +1219,12 @@ class CtsScheduler(object):
         stderr_expected_filename = "%s/%s.stderr" % (self.args.io_dir, test_name)
 
         # (Intermediate) test outputs
-        output_filename = "%s/%s.out" % (self.args.io_dir, test_name)
-        dot_output_filename = "%s/%s.pe.dot" % (self.args.io_dir, test_name)
-        score_output_filename = "%s/%s.scores.pe" % (self.args.io_dir, test_name)
-        summary_output_filename = "%s/%s.summary.pe" % (self.args.io_dir, test_name)
-        stderr_output_filename = "%s/%s.stderr.pe" % (self.args.io_dir, test_name)
-        valgrind_output_filename = "%s/%s.valgrind" % (self.args.io_dir, test_name)
+        output_filename = "%s/%s.out" % (self.args.out_dir, test_name)
+        dot_output_filename = "%s/%s.pe.dot" % (self.args.out_dir, test_name)
+        score_output_filename = "%s/%s.scores.pe" % (self.args.out_dir, test_name)
+        summary_output_filename = "%s/%s.summary.pe" % (self.args.out_dir, test_name)
+        stderr_output_filename = "%s/%s.stderr.pe" % (self.args.out_dir, test_name)
+        valgrind_output_filename = "%s/%s.valgrind" % (self.args.out_dir, test_name)
 
         # Common arguments for running test
         test_cmd = []

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -54,10 +54,25 @@ CIB_cfg_base		= options nodes resources constraints fencing acls tags alerts
 API_base		= $(API_request_base) item status
 CIB_base		= cib $(CIB_cfg_base) status score rule nvset
 
-# All static schema files
+# Static schema files and transforms (only CIB has transforms)
+# 
+# This is more complicated than it should be due to the need to support
+# VPATH builds and "make distcheck". We need the absolute paths for reliable
+# substitution back and forth, and relative paths for distributed files.
+API_abs_files		= $(foreach base,$(API_base),$(wildcard $(abs_srcdir)/api/$(base)*.rng))
+CIB_abs_files		= $(foreach base,$(CIB_base),$(wildcard $(abs_srcdir)/$(base).rng $(abs_srcdir)/$(base)-*.rng))
+CIB_abs_xsl		= $(abs_srcdir)/upgrade-1.3.xsl			\
+			  $(abs_srcdir)/upgrade-2.10.xsl		\
+			  $(wildcard $(abs_srcdir)/upgrade-*enter.xsl)	\
+			  $(wildcard $(abs_srcdir)/upgrade-*leave.xsl)
+MON_abs_files		= $(abs_srcdir)/crm_mon.rng
 API_files		= $(foreach base,$(API_base),$(wildcard $(srcdir)/api/$(base)*.rng))
 CIB_files		= $(foreach base,$(CIB_base),$(wildcard $(srcdir)/$(base).rng $(srcdir)/$(base)-*.rng))
-MON_files		= crm_mon.rng
+CIB_xsl			= $(srcdir)/upgrade-1.3.xsl			\
+			  $(srcdir)/upgrade-2.10.xsl		\
+			  $(wildcard $(srcdir)/upgrade-*enter.xsl)	\
+			  $(wildcard $(srcdir)/upgrade-*leave.xsl)
+MON_files		= $(srcdir)/crm_mon.rng
 
 # Sorted lists of all numeric schema versions
 API_numeric_versions	= $(call numeric_versions,${API_files})
@@ -71,6 +86,11 @@ CIB_max			?= $(lastword $(CIB_numeric_versions))
 API_versions		= next $(API_numeric_versions)
 CIB_versions		= next $(CIB_numeric_versions)
 
+# Build tree locations of static schema files and transforms (for VPATH builds)
+API_build_copies	= $(foreach f,$(API_abs_files),$(subst $(abs_srcdir),$(abs_builddir),$(f)))
+CIB_build_copies	= $(foreach f,$(CIB_abs_files) $(CIB_abs_xsl),$(subst $(abs_srcdir),$(abs_builddir),$(f)))
+MON_build_copies	= $(foreach f,$(MON_abs_files),$(subst $(abs_srcdir),$(abs_builddir),$(f)))
+
 # Dynamically generated schema files
 API_generated		= api/api-result.rng $(foreach base,$(API_versions),api/api-result-$(base).rng)
 CIB_generated		= pacemaker.rng $(foreach base,$(CIB_versions),pacemaker-$(base).rng) versions.rng
@@ -80,11 +100,7 @@ CIB_version_pairs_cnt	= $(words ${CIB_version_pairs})
 CIB_version_pairs_last  = $(call version_pairs_last,${CIB_version_pairs_cnt},${CIB_version_pairs})
 
 dist_API_DATA		= $(API_files)
-dist_CIB_DATA		= $(CIB_files)					\
-			  upgrade-1.3.xsl				\
-			  upgrade-2.10.xsl				\
-			  $(wildcard $(srcdir)/upgrade-*enter.xsl)	\
-			  $(wildcard $(srcdir)/upgrade-*leave.xsl)
+dist_CIB_DATA		= $(CIB_files) $(CIB_xsl)
 dist_MON_DATA		= $(MON_files)
 
 nodist_API_DATA		= $(API_generated)
@@ -118,8 +134,7 @@ api/api-result.rng: api/api-result-$(API_max).rng
 	$(AM_V_at)$(MKDIR_P) api # might not exist in VPATH build
 	$(AM_V_SCHEMA)cp $(top_builddir)/xml/$< $@
 
-api/api-result-%.rng: $(API_files) best-match.sh Makefile.am
-	$(AM_V_at)$(MKDIR_P) api # might not exist in VPATH build
+api/api-result-%.rng: $(API_build_copies) best-match.sh Makefile.am
 	$(AM_V_at)echo '<?xml version="1.0" encoding="UTF-8"?>' > $@
 	$(AM_V_at)echo '<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">' >> $@
 	$(AM_V_at)echo '  <start>' >> $@
@@ -140,7 +155,7 @@ api/api-result-%.rng: $(API_files) best-match.sh Makefile.am
 pacemaker.rng: pacemaker-$(CIB_max).rng
 	$(AM_V_SCHEMA)cp $(top_builddir)/xml/$< $@
 
-pacemaker-%.rng: $(CIB_files) best-match.sh Makefile.am
+pacemaker-%.rng: $(CIB_build_copies) best-match.sh Makefile.am
 	$(AM_V_at)echo '<?xml version="1.0" encoding="UTF-8"?>' > $@
 	$(AM_V_at)echo '<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">' >> $@
 	$(AM_V_at)echo '  <start>' >> $@
@@ -231,3 +246,13 @@ fulldiff: best-match.sh
 	$(call version_diff,${CIB_version_pairs})
 
 CLEANFILES = $(API_generated) $(CIB_generated)
+
+# Enable ability to use $@ in prerequisite
+.SECONDEXPANSION:
+
+# For VPATH builds, copy the static schema files into the build tree
+$(API_build_copies) $(CIB_build_copies) $(MON_build_copies): $$(subst $(abs_builddir),$(srcdir),$$(@))
+	$(AM_V_GEN)if [ "x$(srcdir)" != "x$(builddir)" ]; then	\
+		$(MKDIR_P) "$(dir $(@))";			\
+		cp "$(<)" "$(@)";				\
+	fi


### PR DESCRIPTION
This is part of a larger project to get "make distcheck" working for CI purposes. This handles the second step of make distcheck, running "make check" from the build tree of a VPATH build with a read-only source directory created by "make dist".

This does not address later steps of make distcheck, which still fails.