### PR TITLE
Get "make distcheck" working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,8 @@ install:
 
 before_script:
 # some tests (e.g. cts-exec-helper) require actual system-wide credentials
- -   sed -e 's|^\(CRM_DAEMON_USER=\).*$|\1nobody|'
-         -e 's|^\(CRM_DAEMON_GROUP=\).*$|\1nobody|'
-         -i -- configure.ac
  -   ./autogen.sh
- -   ./configure
+ -   ./configure --with-daemon-user=nobody --with-daemon-group=nobody
 
 script: 
 # Create directories needed by commands used by regression tests

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,6 +10,11 @@
 default: build
 .PHONY: default
 
+# The toplevel "clean" targets are generated from Makefile.am, not this file.
+# We can't use autotools' CLEANFILES, clean-local, etc. here. Instead, we
+# define this target, which Makefile.am can use as a dependency of clean-local.
+EXTRA_CLEAN_TARGETS	= ancillary-clean
+
 -include Makefile
 
 # The main purpose of this GNUmakefile is that its targets can be invoked
@@ -410,8 +415,5 @@ gnulib-update:
 	  --source-base=lib/gnu --lgpl=2 --no-vc-files --no-conditional-dependencies \
 	  $(GNU_MODS_AVOID:%=--avoid %) --import $(GNU_MODS)
 
-# The toplevel "clean" targets are generated from Makefile.am, not this file.
-# We can't use autotools' CLEANFILES, clean-local, etc. here. Instead, we
-# define this target, which Makefile.am can call from clean-local.
 ancillary-clean: export-clean spec-clean srpm-clean mock-clean coverity-clean
 	-rm -f $(TARFILE)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -88,9 +88,6 @@ export:
 	    echo "`date`: Using existing tarball: $(TARFILE)";			\
 	fi
 
-export-clean:
-	-rm -f $(abs_builddir)/$(PACKAGE)-*.tar.gz
-
 ## RPM-related targets
 
 # Where to put RPM artifacts; possible values:
@@ -415,5 +412,5 @@ gnulib-update:
 	  --source-base=lib/gnu --lgpl=2 --no-vc-files --no-conditional-dependencies \
 	  $(GNU_MODS_AVOID:%=--avoid %) --import $(GNU_MODS)
 
-ancillary-clean: export-clean spec-clean srpm-clean mock-clean coverity-clean
+ancillary-clean: spec-clean srpm-clean mock-clean coverity-clean
 	-rm -f $(TARFILE)

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,10 +39,17 @@ MAINTAINERCLEANFILES	= Makefile.in		\
 # GNUmakefile sets "core" as the default target. However in a VPATH build,
 # there is no GNUmakefile, so "all" becomes the default target.
 #
+# Also, don't try to install files outside the build directory.
+#
 # @TODO To support VPATH builds for Publican, we could use the same "copy all
 # static inputs into the build tree" trick that xml/Makefile.am uses for
 # static schema files.
-AM_DISTCHECK_CONFIGURE_FLAGS	= --with-brand=""
+AM_DISTCHECK_CONFIGURE_FLAGS	= --with-brand=""					\
+				  --prefix="$$dc_install_base/usr"			\
+				  --sysconfdir="$$dc_install_base/etc"			\
+				  --with-initdir="$$dc_install_base/etc/init.d"		\
+				  --with-ocfdir="$$dc_install_base/usr/lib/ocf"		\
+				  --with-systemdsystemunitdir="$$dc_install_base$(systemdsystemunitdir)"
 
 # Only these will get installed with a plain "make install"
 CORE_INSTALL	= replace include lib daemons tools xml

--- a/Makefile.am
+++ b/Makefile.am
@@ -106,8 +106,13 @@ install-exec-local:
 clean-generic:
 	-rm -f *.tar.bz2 *.sed
 
-clean-local:
-	$(MAKE) $(AM_MAKEFLAGS) ancillary-clean
+# In a normal build, this file is included by GNUmakefile, which serves as the
+# "real" makefile. But in a VPATH build, GNUmakefile won't exist in the build
+# tree, and this file will be the "real" makefile. EXTRA_CLEAN_TARGETS handles
+# both cases: GNUmakefile defines it before including this file, so the
+# clean-local target can clean up files created by GNUmakefile targets.
+# If this file is used alone, the variable will be undefined.
+clean-local: $(EXTRA_CLEAN_TARGETS)
 
 distclean-local:
 	-rm -rf libltdl autom4te.cache

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,12 +67,9 @@ licensedir              = $(docdir)/licenses/
 dist_license_DATA	= $(wildcard licenses/*)
 
 # Scratch file for ad-hoc testing
-noinst_PROGRAMS = scratch
+EXTRA_PROGRAMS		= scratch
 nodist_scratch_SOURCES	= scratch.c
-scratch_LDADD	= $(top_builddir)/lib/common/libcrmcommon.la -lm
-
-scratch.c:
-	echo 'int main(void){}' >$@
+scratch_LDADD		= $(top_builddir)/lib/common/libcrmcommon.la
 
 core:
 	@echo "Building only core components and tests: $(CORE)"
@@ -120,6 +117,7 @@ clean-generic:
 # clean-local target can clean up files created by GNUmakefile targets.
 # If this file is used alone, the variable will be undefined.
 clean-local: $(EXTRA_CLEAN_TARGETS)
+	-rm -f scratch
 
 distclean-local:
 	-rm -rf libltdl autom4te.cache

--- a/Makefile.am
+++ b/Makefile.am
@@ -110,6 +110,8 @@ install-exec-local:
 clean-generic:
 	-rm -f *.tar.bz2 *.sed
 
+PACKAGE         ?= pacemaker
+
 # In a normal build, this file is included by GNUmakefile, which serves as the
 # "real" makefile. But in a VPATH build, GNUmakefile won't exist in the build
 # tree, and this file will be the "real" makefile. EXTRA_CLEAN_TARGETS handles
@@ -117,7 +119,7 @@ clean-generic:
 # clean-local target can clean up files created by GNUmakefile targets.
 # If this file is used alone, the variable will be undefined.
 clean-local: $(EXTRA_CLEAN_TARGETS)
-	-rm -f scratch
+	-rm -f scratch $(builddir)/$(PACKAGE)-*.tar.gz
 
 distclean-local:
 	-rm -rf libltdl autom4te.cache

--- a/configure.ac
+++ b/configure.ac
@@ -1330,16 +1330,15 @@ if test "x${enable_systemd}" = xyes; then
     HAVE_systemd=1
     PCMK_FEATURES="$PCMK_FEATURES systemd"
 
-    AC_MSG_CHECKING([for systemd path for system unit files])
-    systemdunitdir="${systemdunitdir-}"
-    PKG_CHECK_VAR([systemdunitdir], [systemd],
-                  [systemdsystemunitdir], [], [systemdunitdir=no])
-    AC_MSG_RESULT([${systemdunitdir}])
-    if test "x${systemdunitdir}" = xno; then
-        AC_MSG_FAILURE([cannot enable systemd when systemdunitdir unresolved])
+    AC_MSG_CHECKING([which system unit file directory to use])
+    systemdsystemunitdir="${systemdsystemunitdir-}"
+    PKG_CHECK_VAR([systemdsystemunitdir], [systemd], [systemdsystemunitdir])
+    AC_MSG_RESULT([${systemdsystemunitdir}])
+    if test "x${systemdsystemunitdir}" = x""; then
+        AC_MSG_FAILURE([cannot enable systemd when systemdsystemunitdir unresolved])
     fi
 fi
-AC_SUBST(systemdunitdir)
+AC_SUBST([systemdsystemunitdir])
 
 AC_DEFINE_UNQUOTED(SUPPORT_SYSTEMD, $HAVE_systemd, Support systemd based system services)
 AM_CONDITIONAL(BUILD_SYSTEMD, test $HAVE_systemd = 1)

--- a/configure.ac
+++ b/configure.ac
@@ -52,10 +52,6 @@ dnl   - Should not include HAVE_* defines
 dnl   - Safe to include anywhere
 AC_CONFIG_HEADERS([include/config.h include/crm_config.h])
 
-AC_ARG_WITH(version,
-    [  --with-version=version   Override package version (if you are a packager needing to pretend) ],
-    [ PACKAGE_VERSION="$withval" ])
-
 dnl 1.11:           minimum automake version required
 dnl foreign:        don't require GNU-standard top-level files
 dnl tar-ustar:      use (older) POSIX variant of generated tar rather than v7
@@ -67,15 +63,8 @@ dnl Example 2.4. Silent Custom Rule to Generate a File
 dnl %-bar.pc: %.pc
 dnl	$(AM_V_GEN)$(LN_S) $(notdir $^) $@
 
-AC_DEFINE_UNQUOTED(PACEMAKER_VERSION, "$PACKAGE_VERSION",
-                   [Current pacemaker version])
-
 dnl Versioned attributes implementation is not yet production-ready
 AC_DEFINE_UNQUOTED(ENABLE_VERSIONED_ATTRS, 0, [Enable versioned attributes])
-
-PACKAGE_SERIES=`echo $PACKAGE_VERSION | awk -F. '{ print $1"."$2 }'`
-AC_SUBST(PACKAGE_SERIES)
-AC_SUBST(PACKAGE_VERSION)
 
 CC_IN_CONFIGURE=yes
 export CC_IN_CONFIGURE
@@ -132,32 +121,46 @@ dnl ===============================================
 dnl Configure Options
 dnl ===============================================
 
+
+dnl --enable-* options
+
 AC_ARG_ENABLE([ansi],
-    [  --enable-ansi  Force GCC to compile to ANSI standard for older compilers. @<:@no@:>@])
+    [AS_HELP_STRING([--enable-ansi],
+        [force GCC to compile to ANSI standard for older compilers. @<:@no@:>@])],
+)
 
 AC_ARG_ENABLE([fatal-warnings],
-    [  --enable-fatal-warnings  Enable pedantic and fatal warnings for gcc @<:@yes@:>@])
+    [AS_HELP_STRING([--enable-fatal-warnings],
+        [enable pedantic and fatal warnings for gcc @<:@yes@:>@])],
+)
 
 AC_ARG_ENABLE([quiet],
-    [  --enable-quiet  Suppress make output unless there is an error @<:@no@:>@])
+    [AS_HELP_STRING([--enable-quiet],
+        [suppress make output unless there is an error @<:@no@:>@])],
+)
 
 AC_ARG_ENABLE([no-stack],
-    [  --enable-no-stack  Build only the scheduler and its requirements @<:@no@:>@])
+    [AS_HELP_STRING([--enable-no-stack],
+        [build only the scheduler and its requirements @<:@no@:>@])],
+)
 
 AC_ARG_ENABLE([upstart],
-    [  --enable-upstart  Enable support for managing resources via Upstart @<:@try@:>@ ],
+    [AS_HELP_STRING([--enable-upstart],
+        [enable support for managing resources via Upstart @<:@try@:>@])],
     [],
     [enable_upstart=try],
 )
 
 AC_ARG_ENABLE([systemd],
-    [  --enable-systemd  Enable support for managing resources via systemd @<:@try@:>@],
+    [AS_HELP_STRING([--enable-systemd],
+        [enable support for managing resources via systemd @<:@try@:>@])],
     [],
     [enable_systemd=try],
 )
 
-AC_ARG_ENABLE(hardening,
-    [  --enable-hardening  Harden the resulting executables/libraries @<:@try@:>@],
+AC_ARG_ENABLE([hardening],
+    [AS_HELP_STRING([--enable-hardening],
+        [harden the resulting executables/libraries @<:@try@:>@])],
     [ HARDENING="${enableval}" ],
     [ HARDENING=try ],
 )
@@ -170,121 +173,166 @@ AC_ARG_ENABLE(hardening,
 # disable this option. Once the above use cases are no longer in wide use, we
 # can disable this option by default, and once we no longer want to support
 # them at all, we can drop the option altogether.
-AC_ARG_ENABLE(legacy-links,
-    [  --enable-legacy-links  Add symlinks for old daemon names @<:@yes@:>@],
+AC_ARG_ENABLE([legacy-links],
+    [AS_HELP_STRING([--enable-legacy-links],
+        [add symlinks for old daemon names @<:@yes@:>@])],
     [ LEGACY_LINKS="${enableval}" ],
     [ LEGACY_LINKS=yes ],
 )
 AM_CONDITIONAL(BUILD_LEGACY_LINKS, test "x${LEGACY_LINKS}" = "xyes")
 
-AC_ARG_WITH(corosync,
-    [  --with-corosync  Support the Corosync messaging and membership layer ],
+
+dnl --with-* options
+
+AC_DEFUN([VERSION_ARG],
+    [AC_ARG_WITH([version],
+        [AS_HELP_STRING([--with-version=VERSION],
+            [override package version @<:@$1@:>@])],
+        [ PACKAGE_VERSION="$withval" ])]
+)
+VERSION_ARG(VERSION_NUMBER)
+
+AC_ARG_WITH([corosync],
+    [AS_HELP_STRING([--with-corosync],
+        [support the Corosync messaging and membership layer])],
     [ SUPPORT_CS=$withval ],
     [ SUPPORT_CS=try ],
 )
 
-AC_ARG_WITH(nagios,
-    [  --with-nagios  Support nagios remote monitoring ],
+AC_ARG_WITH([nagios],
+    [AS_HELP_STRING([--with-nagios],
+        [support nagios remote monitoring])],
     [ SUPPORT_NAGIOS=$withval ],
     [ SUPPORT_NAGIOS=try ],
 )
 
-AC_ARG_WITH(nagios-plugin-dir,
-    [  --with-nagios-plugin-dir=DIR  Directory for nagios plugins @<:@LIBEXECDIR/nagios/plugins@:>@],
+AC_ARG_WITH([nagios-plugin-dir],
+    [AS_HELP_STRING([--with-nagios-plugin-dir=DIR],
+        [directory for nagios plugins @<:@LIBEXECDIR/nagios/plugins@:>@])],
     [ NAGIOS_PLUGIN_DIR="$withval" ]
 )
 
-AC_ARG_WITH(nagios-metadata-dir,
-    [  --with-nagios-metadata-dir=DIR  Directory for nagios plugins metadata @<:@DATADIR/nagios/plugins-metadata@:>@],
+AC_ARG_WITH([nagios-metadata-dir],
+    [AS_HELP_STRING([--with-nagios-metadata-dir=DIR],
+        [directory for nagios plugins metadata @<:@DATADIR/nagios/plugins-metadata@:>@])],
     [ NAGIOS_METADATA_DIR="$withval" ]
 )
 
-AC_ARG_WITH(acl,
-    [  --with-acl  Support CIB ACL ],
+AC_ARG_WITH([acl],
+    [AS_HELP_STRING([--with-acl],
+        [support CIB ACL])],
     [ SUPPORT_ACL=$withval ],
     [ SUPPORT_ACL=yes ],
 )
 
-AC_ARG_WITH(cibsecrets,
-    [  --with-cibsecrets  Support separate file for CIB secrets ],
+AC_ARG_WITH([cibsecrets],
+    [AS_HELP_STRING([--with-cibsecrets],
+        [support separate file for CIB secrets])],
     [ SUPPORT_CIBSECRETS=$withval ],
     [ SUPPORT_CIBSECRETS=no ],
 )
 
 PCMK_GNUTLS_PRIORITIES="NORMAL"
-AC_ARG_WITH(gnutls-priorities,
-    [  --with-gnutls-priorities  Default GnuTLS cipher priorities @<:@NORMAL@:>@ ],
-    [ test x"$withval" = x"no" || PCMK_GNUTLS_PRIORITIES="$withval" ])
+AC_ARG_WITH([gnutls-priorities],
+    [AS_HELP_STRING([--with-gnutls-priorities],
+        [default GnuTLS cipher priorities @<:@NORMAL@:>@])],
+    [ test x"$withval" = x"no" || PCMK_GNUTLS_PRIORITIES="$withval" ]
+)
 
 INITDIR=""
-AC_ARG_WITH(initdir,
-    [  --with-initdir=DIR  Directory for init (rc) scripts],
-    [ INITDIR="$withval" ])
+AC_ARG_WITH([initdir],
+    [AS_HELP_STRING([--with-initdir=DIR],
+        [directory for init (rc) scripts])],
+    [ INITDIR="$withval" ]
+)
 
 SUPPORT_PROFILING=0
-AC_ARG_WITH(profiling,
-    [  --with-profiling  Disable optimizations for effective profiling ],
-    [ SUPPORT_PROFILING=$withval ])
+AC_ARG_WITH([profiling],
+    [AS_HELP_STRING([--with-profiling],
+        [disable optimizations for effective profiling])],
+    [ SUPPORT_PROFILING=$withval ]
+)
 
-AC_ARG_WITH(coverage,
-    [  --with-coverage   Disable optimizations for effective profiling ],
-    [ SUPPORT_COVERAGE=$withval ])
+AC_ARG_WITH([coverage],
+    [AS_HELP_STRING([--with-coverage],
+        [disable optimizations for effective profiling])],
+    [ SUPPORT_COVERAGE=$withval ]
+)
 
 PUBLICAN_BRAND="common"
-AC_ARG_WITH(brand,
-    [  --with-brand=brand  Brand to use for generated documentation (set empty for no docs) @<:@common@:>@],
-    [ test x"$withval" = x"no" || PUBLICAN_BRAND="$withval" ])
+AC_ARG_WITH([brand],
+    [AS_HELP_STRING([--with-brand=brand],
+        [brand to use for generated documentation (set empty for no docs) @<:@common@:>@])],
+    [ test x"$withval" = x"no" || PUBLICAN_BRAND="$withval" ]
+)
 AC_SUBST(PUBLICAN_BRAND)
 
 BUG_URL=""
-AC_ARG_WITH(bug-url,
-    [  --with-bug-url=DIR  Address where users should submit bug reports @<:@https://bugs.clusterlabs.org/enter_bug.cgi?product=Pacemaker@:>@],
+AC_ARG_WITH([bug-url],
+    [AS_HELP_STRING([--with-bug-url=DIR],
+        [address where users should submit bug reports @<:@https://bugs.clusterlabs.org/enter_bug.cgi?product=Pacemaker@:>@])],
     [ BUG_URL="$withval" ]
 )
 
 CONFIGDIR=""
-AC_ARG_WITH(configdir,
-    [  --with-configdir=DIR  Directory for Pacemaker configuration file @<:@SYSCONFDIR/sysconfig@:>@],
+AC_ARG_WITH([configdir],
+    [AS_HELP_STRING([--with-configdir=DIR],
+        [directory for Pacemaker configuration file @<:@SYSCONFDIR/sysconfig@:>@])],
     [ CONFIGDIR="$withval" ]
 )
 
 CRM_LOG_DIR=""
-AC_ARG_WITH(logdir,
-    [  --with-logdir=DIR  Directory for Pacemaker log file @<:@LOCALSTATEDIR/log/pacemaker@:>@ ],
+AC_ARG_WITH([logdir],
+    [AS_HELP_STRING([--with-logdir=DIR],
+        [directory for Pacemaker log file @<:@LOCALSTATEDIR/log/pacemaker@:>@])],
     [ CRM_LOG_DIR="$withval" ]
 )
 
 CRM_BUNDLE_DIR=""
-AC_ARG_WITH(bundledir,
-    [  --with-bundledir=DIR  Directory for Pacemaker bundle logs @<:@LOCALSTATEDIR/log/pacemaker/bundles@:>@ ],
+AC_ARG_WITH([bundledir],
+    [AS_HELP_STRING([--with-bundledir=DIR],
+        [directory for Pacemaker bundle logs @<:@LOCALSTATEDIR/log/pacemaker/bundles@:>@])],
     [ CRM_BUNDLE_DIR="$withval" ]
 )
 
 CRM_DAEMON_USER=""
-AC_ARG_WITH(daemon-user,
-    [  --with-daemon-user=USER  User to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@hacluster@:>@ ],
+AC_ARG_WITH([daemon-user],
+    [AS_HELP_STRING([--with-daemon-user=USER],
+        [user to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@hacluster@:>@])],
     [ CRM_DAEMON_USER="$withval" ]
 )
 
 CRM_DAEMON_GROUP=""
-AC_ARG_WITH(daemon-group,
-    [  --with-daemon-group=GROUP  Group to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@haclient@:>@ ],
+AC_ARG_WITH([daemon-group],
+    [AS_HELP_STRING([--with-daemon-group=GROUP],
+        [group to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@haclient@:>@])],
     [ CRM_DAEMON_GROUP="$withval" ]
 )
 
+
 dnl Deprecated options
 
-AC_ARG_WITH(pkg-name,
-    [  --with-pkg-name=name   Deprecated and unused (will be removed in a future release) ],
+AC_ARG_WITH([pkg-name],
+    [AS_HELP_STRING([--with-pkg-name=name],
+        [deprecated and unused (will be removed in a future release)])],
 )
 
-AC_ARG_WITH(pkgname,
-    [  --with-pkgname=name    Deprecated and unused (will be removed in a future release) ],
+AC_ARG_WITH([pkgname],
+    [AS_HELP_STRING([--with-pkgname=name],
+        [deprecated and unused (will be removed in a future release)])],
 )
+
 
 dnl ===============================================
 dnl General Processing
 dnl ===============================================
+
+AC_DEFINE_UNQUOTED(PACEMAKER_VERSION, "$PACKAGE_VERSION",
+                   [Current pacemaker version])
+
+PACKAGE_SERIES=`echo $PACKAGE_VERSION | awk -F. '{ print $1"."$2 }'`
+AC_SUBST(PACKAGE_SERIES)
+AC_SUBST(PACKAGE_VERSION)
 
 AC_PROG_LN_S
 AC_PROG_MKDIR_P

--- a/configure.ac
+++ b/configure.ac
@@ -295,6 +295,18 @@ AC_ARG_WITH([bundledir],
     [ CRM_BUNDLE_DIR="$withval" ]
 )
 
+dnl This defaults to /usr/lib rather than libdir because it's determined by the
+dnl OCF project and not pacemaker. Even if a user wants to install pacemaker to
+dnl /usr/local or such, the OCF agents will be expected in their usual
+dnl location. However, we do give the user the option to override it.
+OCF_ROOT_DIR="/usr/lib/ocf"
+AC_ARG_WITH([ocfdir],
+    [AS_HELP_STRING([--with-ocfdir=DIR],
+        [OCF resource agent root directory (advanced option: changing this may break other cluster components unless similarly configured) @<:@/usr/lib/ocf@:>@])],
+    [ OCF_ROOT_DIR="$withval" ]
+)
+AC_SUBST(OCF_ROOT_DIR)
+
 CRM_DAEMON_USER=""
 AC_ARG_WITH([daemon-user],
     [AS_HELP_STRING([--with-daemon-user=USER],
@@ -1216,12 +1228,6 @@ AC_SUBST(CRM_RSCTMP_DIR)
 PACEMAKER_CONFIG_DIR="${sysconfdir}/pacemaker"
 AC_DEFINE_UNQUOTED(PACEMAKER_CONFIG_DIR,"$PACEMAKER_CONFIG_DIR", Where to keep configuration files like authkey)
 AC_SUBST(PACEMAKER_CONFIG_DIR)
-
-OCF_ROOT_DIR="/usr/lib/ocf"
-if test "X$OCF_ROOT_DIR" = X; then
-    AC_MSG_ERROR(Could not locate OCF directory)
-fi
-AC_SUBST(OCF_ROOT_DIR)
 
 OCF_RA_DIR="$OCF_ROOT_DIR/resource.d"
 AC_DEFINE_UNQUOTED(OCF_RA_DIR,"$OCF_RA_DIR", Location for OCF RAs)

--- a/configure.ac
+++ b/configure.ac
@@ -295,6 +295,15 @@ AC_ARG_WITH([bundledir],
     [ CRM_BUNDLE_DIR="$withval" ]
 )
 
+dnl The not-yet-released autoconf 2.70 will have a --runstatedir option.
+dnl Until that's available, emulate it with our own --with-runstatedir.
+pcmk_runstatedir=""
+AC_ARG_WITH([runstatedir],
+    [AS_HELP_STRING([--with-runstatedir=DIR],
+        [modifiable per-process data @<:@LOCALSTATEDIR/run@:>@ (ignored if --runstatedir is available)])],
+    [ pcmk_runstatedir="$withval" ]
+)
+
 dnl This defaults to /usr/lib rather than libdir because it's determined by the
 dnl OCF project and not pacemaker. Even if a user wants to install pacemaker to
 dnl /usr/local or such, the OCF agents will be expected in their usual
@@ -449,6 +458,19 @@ eval infodir="`eval echo ${infodir}`"
 eval mandir="`eval echo ${mandir}`"
 
 dnl Home-grown variables
+
+if [ test "x${runstatedir}" = "x" ]; then
+    if [ test "x${pcmk_runstatedir}" = "x" ]; then
+        runstatedir="${localstatedir}/run"
+    else
+        runstatedir="${pcmk_runstatedir}"
+    fi
+fi
+eval runstatedir="$(eval echo ${runstatedir})"
+AC_DEFINE_UNQUOTED([PCMK_RUN_DIR], ["$runstatedir"],
+		   [Location for modifiable per-process data])
+AC_SUBST(runstatedir)
+
 eval INITDIR="${INITDIR}"
 eval docdir="`eval echo ${docdir}`"
 if test x"${docdir}" = x""; then
@@ -1189,10 +1211,6 @@ fi
 AC_DEFINE_UNQUOTED(CRM_DAEMON_GROUP,"$CRM_DAEMON_GROUP", Group to run Pacemaker daemons as)
 AC_SUBST(CRM_DAEMON_GROUP)
 
-CRM_STATE_DIR=${localstatedir}/run/crm
-AC_DEFINE_UNQUOTED(CRM_STATE_DIR,"$CRM_STATE_DIR", Where to keep state files and sockets)
-AC_SUBST(CRM_STATE_DIR)
-
 CRM_PACEMAKER_DIR=${localstatedir}/lib/pacemaker
 AC_DEFINE_UNQUOTED(CRM_PACEMAKER_DIR,"$CRM_PACEMAKER_DIR", Location to store directory produced by Pacemaker daemons)
 AC_SUBST(CRM_PACEMAKER_DIR)
@@ -1217,11 +1235,12 @@ CRM_DAEMON_DIR="${libexecdir}/pacemaker"
 AC_DEFINE_UNQUOTED(CRM_DAEMON_DIR,"$CRM_DAEMON_DIR", Location for Pacemaker daemons)
 AC_SUBST(CRM_DAEMON_DIR)
 
-HA_STATE_DIR="${localstatedir}/run"
-AC_DEFINE_UNQUOTED(HA_STATE_DIR,"$HA_STATE_DIR", Where sbd keeps its PID file)
-AC_SUBST(HA_STATE_DIR)
+CRM_STATE_DIR="${runstatedir}/crm"
+AC_DEFINE_UNQUOTED([CRM_STATE_DIR], ["$CRM_STATE_DIR"],
+		   [Where to keep state files and sockets])
+AC_SUBST(CRM_STATE_DIR)
 
-CRM_RSCTMP_DIR="${localstatedir}/run/resource-agents"
+CRM_RSCTMP_DIR="${runstatedir}/resource-agents"
 AC_DEFINE_UNQUOTED(CRM_RSCTMP_DIR,"$CRM_RSCTMP_DIR", Where resource agents should keep state files)
 AC_SUBST(CRM_RSCTMP_DIR)
 

--- a/configure.ac
+++ b/configure.ac
@@ -272,6 +272,18 @@ AC_ARG_WITH(bundledir,
     [ CRM_BUNDLE_DIR="$withval" ]
 )
 
+CRM_DAEMON_USER=""
+AC_ARG_WITH(daemon-user,
+    [  --with-daemon-user=USER  User to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@hacluster@:>@ ],
+    [ CRM_DAEMON_USER="$withval" ]
+)
+
+CRM_DAEMON_GROUP=""
+AC_ARG_WITH(daemon-group,
+    [  --with-daemon-group=GROUP  Group to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@haclient@:>@ ],
+    [ CRM_DAEMON_GROUP="$withval" ]
+)
+
 dnl ===============================================
 dnl General Processing
 dnl ===============================================
@@ -1107,11 +1119,15 @@ CRM_CORE_DIR="${localstatedir}/lib/pacemaker/cores"
 AC_DEFINE_UNQUOTED(CRM_CORE_DIR,"$CRM_CORE_DIR", Location to store core files produced by Pacemaker daemons)
 AC_SUBST(CRM_CORE_DIR)
 
-CRM_DAEMON_USER="hacluster"
+if test x"${CRM_DAEMON_USER}" = x""; then
+    CRM_DAEMON_USER="hacluster"
+fi
 AC_DEFINE_UNQUOTED(CRM_DAEMON_USER,"$CRM_DAEMON_USER", User to run Pacemaker daemons as)
 AC_SUBST(CRM_DAEMON_USER)
 
-CRM_DAEMON_GROUP="haclient"
+if test x"${CRM_DAEMON_GROUP}" = x""; then
+    CRM_DAEMON_GROUP="haclient"
+fi
 AC_DEFINE_UNQUOTED(CRM_DAEMON_GROUP,"$CRM_DAEMON_GROUP", Group to run Pacemaker daemons as)
 AC_SUBST(CRM_DAEMON_GROUP)
 

--- a/configure.ac
+++ b/configure.ac
@@ -246,6 +246,13 @@ AC_ARG_WITH([initdir],
     [ INITDIR="$withval" ]
 )
 
+systemdsystemunitdir="${systemdsystemunitdir-}"
+AC_ARG_WITH([systemdsystemunitdir],
+    [AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
+        [directory for systemd unit files (advanced option: must match what systemd uses)])],
+    [ systemdsystemunitdir="$withval" ]
+)
+
 SUPPORT_PROFILING=0
 AC_ARG_WITH([profiling],
     [AS_HELP_STRING([--with-profiling],
@@ -1331,7 +1338,6 @@ if test "x${enable_systemd}" = xyes; then
     PCMK_FEATURES="$PCMK_FEATURES systemd"
 
     AC_MSG_CHECKING([which system unit file directory to use])
-    systemdsystemunitdir="${systemdsystemunitdir-}"
     PKG_CHECK_VAR([systemdsystemunitdir], [systemd], [systemdsystemunitdir])
     AC_MSG_RESULT([${systemdsystemunitdir}])
     if test "x${systemdsystemunitdir}" = x""; then

--- a/configure.ac
+++ b/configure.ac
@@ -56,10 +56,6 @@ AC_ARG_WITH(version,
     [  --with-version=version   Override package version (if you are a packager needing to pretend) ],
     [ PACKAGE_VERSION="$withval" ])
 
-AC_ARG_WITH(pkg-name,
-    [  --with-pkg-name=name     Override package name (if you are a packager needing to pretend) ],
-    [ PACKAGE_NAME="$withval" ])
-
 dnl 1.11:           minimum automake version required
 dnl foreign:        don't require GNU-standard top-level files
 dnl tar-ustar:      use (older) POSIX variant of generated tar rather than v7
@@ -277,6 +273,10 @@ AC_ARG_WITH(daemon-group,
 )
 
 dnl Deprecated options
+
+AC_ARG_WITH(pkg-name,
+    [  --with-pkg-name=name   Deprecated and unused (will be removed in a future release) ],
+)
 
 AC_ARG_WITH(pkgname,
     [  --with-pkgname=name    Deprecated and unused (will be removed in a future release) ],

--- a/configure.ac
+++ b/configure.ac
@@ -136,14 +136,6 @@ dnl ===============================================
 dnl Configure Options
 dnl ===============================================
 
-dnl Some systems, like Solaris require a custom package name
-AC_ARG_WITH(pkgname,
-    [  --with-pkgname=name     name for pkg (typically for Solaris) ],
-    [ PKGNAME="$withval" ],
-    [ PKGNAME="LXHAhb" ],
-  )
-AC_SUBST(PKGNAME)
-
 AC_ARG_ENABLE([ansi],
     [  --enable-ansi  Force GCC to compile to ANSI standard for older compilers. @<:@no@:>@])
 
@@ -282,6 +274,12 @@ CRM_DAEMON_GROUP=""
 AC_ARG_WITH(daemon-group,
     [  --with-daemon-group=GROUP  Group to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@haclient@:>@ ],
     [ CRM_DAEMON_GROUP="$withval" ]
+)
+
+dnl Deprecated options
+
+AC_ARG_WITH(pkgname,
+    [  --with-pkgname=name    Deprecated and unused (will be removed in a future release) ],
 )
 
 dnl ===============================================

--- a/cts/Makefile.am
+++ b/cts/Makefile.am
@@ -90,6 +90,8 @@ scheduler-list:
 		echo $$(basename $$T .xml);             \
 	done
 
+CLEANFILES	= $(builddir)/.regression.failed.diff
+
 clean-local:
 	rm -f scheduler/*.pe.*
 

--- a/cts/cts-support.in
+++ b/cts/cts-support.in
@@ -2,7 +2,7 @@
 #
 # Installer for support files needed by Pacemaker's Cluster Test Suite
 #
-# Copyright 2018 the Pacemaker project contributors
+# Copyright 2018-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -22,7 +22,7 @@ CRM_EX_OK=0
 CRM_EX_ERROR=1
 CRM_EX_USAGE=64
 
-UNIT_DIR="@systemdunitdir@"
+UNIT_DIR="@systemdsystemunitdir@"
 LIBEXEC_DIR="@libexecdir@/pacemaker"
 INIT_DIR="@INITDIR@"
 SBIN_DIR="@sbindir@"

--- a/daemons/execd/Makefile.am
+++ b/daemons/execd/Makefile.am
@@ -18,7 +18,7 @@ init_SCRIPTS		= pacemaker_remote
 sbin_PROGRAMS		= pacemaker-remoted
 
 if BUILD_SYSTEMD
-systemdunit_DATA	= pacemaker_remote.service
+systemdsystemunit_DATA	= pacemaker_remote.service
 endif
 
 pacemaker_execd_CFLAGS		= $(CFLAGS_HARDENED_EXE)

--- a/daemons/pacemakerd/Makefile.am
+++ b/daemons/pacemakerd/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2004-2018 the Pacemaker project contributors
+# Copyright 2004-2019 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -16,7 +16,7 @@ init_SCRIPTS		= pacemaker
 sbin_PROGRAMS		= pacemakerd
 
 if BUILD_SYSTEMD
-systemdunit_DATA	= pacemaker.service
+systemdsystemunit_DATA	= pacemaker.service
 endif
 
 EXTRA_DIST		= pacemaker.sysconfig

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -46,7 +46,7 @@ static bool global_keep_tracking = false;
 static const char *local_name = NULL;
 static uint32_t local_nodeid = 0;
 static crm_trigger_t *shutdown_trigger = NULL;
-static const char *pid_file = "/var/run/pacemaker.pid";
+static const char *pid_file = PCMK_RUN_DIR "/pacemaker.pid";
 
 typedef struct pcmk_child_s {
     int pid;

--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -1,6 +1,7 @@
 /*
- * Copyright 2013 Lars Marowsky-Bree <lmb@suse.com>
- *           2014-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2013-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -181,7 +182,7 @@ pcmk_locate_sbd(void)
     }
 
     /* Look for the pid file */
-    pidfile = crm_strdup_printf("%s/sbd.pid", HA_STATE_DIR);
+    pidfile = crm_strdup_printf(PCMK_RUN_DIR "/sbd.pid");
     sbd_path = crm_strdup_printf("%s/sbd", SBIN_DIR);
 
     /* Read the pid file */

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -467,7 +467,7 @@ manager.
 # Early versions of autotools (e.g. RHEL <= 5) do not support --docdir
 export docdir=%{pcmk_docdir}
 
-export systemdunitdir=%{?_unitdir}%{!?_unitdir:no}
+export systemdsystemunitdir=%{?_unitdir}%{!?_unitdir:no}
 
 %if %{with hardening}
 # prefer distro-provided hardening flags in case they are defined

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -76,6 +76,14 @@
 %define gnutls_priorities %{?pcmk_gnutls_priorities}%{!?pcmk_gnutls_priorities:@SYSTEM}
 %endif
 
+%if !%{defined _rundir}
+%if 0%{?fedora} >= 15 || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1200
+%define _rundir /run
+%else
+%define _rundir /var/run
+%endif
+%endif
+
 ## Different distros name certain packages differently
 %if 0%{?suse_version} > 0
 %global pkgname_bzip2_devel libbz2-devel
@@ -484,6 +492,7 @@ export LDFLAGS_HARDENED_LIB="%{?_hardening_ldflags}"
         %{!?with_doc:          --with-brand=}                                   \
         %{?gnutls_priorities:  --with-gnutls-priorities="%{gnutls_priorities}"} \
         --with-initdir=%{_initrddir}                                            \
+        --with-runstatedir=%{_rundir}                                           \
         --localstatedir=%{_var}                                                 \
         --with-version=%{version}-%{release}
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -9,7 +9,7 @@
 include $(top_srcdir)/Makefile.common
 
 if BUILD_SYSTEMD
-systemdunit_DATA = crm_mon.service
+systemdsystemunit_DATA	= crm_mon.service
 endif
 
 noinst_HEADERS		= crm_mon.h crm_resource.h

--- a/tools/ipmiservicelogd.c
+++ b/tools/ipmiservicelogd.c
@@ -10,7 +10,7 @@
  *         Jeff Zheng <Jeff.Zheng@Intel.com>
  *
  * Original copyright 2009 International Business Machines, IBM
- * Later changes copyright 2009-2018 the Pacemaker project contributors
+ * Later changes copyright 2009-2019 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -563,7 +563,7 @@ main(int argc, char *argv[])
     }
 #endif
 
-    crm_make_daemon("ipmiservicelogd", TRUE, "/var/run/ipmiservicelogd.pid0");
+    crm_make_daemon("ipmiservicelogd", TRUE, PCMK_RUN_DIR "/ipmiservicelogd.pid0");
     crm_log_cli_init("ipmiservicelogd");
     // Maybe this should log like a daemon instead?
     // crm_log_init("ipmiservicelogd", LOG_INFO, TRUE, FALSE, argc, argv, FALSE);

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -247,6 +247,11 @@ fulldiff: best-match.sh
 
 CLEANFILES = $(API_generated) $(CIB_generated)
 
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then					\
+		rm -f $(API_build_copies) $(CIB_build_copies) $(MON_build_copies);	\
+	fi
+
 # Enable ability to use $@ in prerequisite
 .SECONDEXPANSION:
 


### PR DESCRIPTION
These are the final changes to get "make distcheck" working. They take care of the last two steps in the process: running "make install" in a VPATH build (for non-root accounts), and ensuring "make distclean" doesn't leave anything behind.

This involves adding several new configure options for normally hardcoded locations. In addition there are a few related commits cleaning up the configure script and makefiles. Two unused configure options are now officially deprecated.