### PR TITLE
Backport build changes from master to get "make distcheck" working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ doc/Pacemaker_Explained.txt
 doc/acls.html
 doc/crm_fencing.html
 doc/publican-catalog*
+/doc/shared/en-US/*.xml
 /maint/mocked/based
 /fencing/config.c
 fencing/stonith-test
@@ -147,7 +148,8 @@ tools/report.collector.1
 xml/crm.dtd
 xml/pacemaker*.rng
 xml/versions.rng
-doc/shared/en-US/*.xml
+doc/*/en-US/images/pcmk-*.png
+doc/*/en-US/images/Policy-Engine-*.png
 doc/Clusters_from_Scratch.build
 doc/Clusters_from_Scratch/en-US/Ap-*.xml
 doc/Clusters_from_Scratch/en-US/Ch-*.xml
@@ -171,6 +173,14 @@ lib/gnu/stdalign.h
 # make dist/export working directory
 pacemaker-[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]
 
+# Test detritus
+/pengine/.regression.failed.diff
+/pengine/.single
+/pengine/test10/shadow.*
+/pengine/test10/bug-rh-1097457.log
+/pengine/test10/bug-rh-1097457.trs
+/pengine/test-suite.log
+
 # Built or present only in 2.0 branch (makes switching branches easier)
 /cts/cts-cli
 /cts/cts-coverage
@@ -191,7 +201,6 @@ pacemaker-[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]
 #Other 
 HTML
 pacemaker*.spec
-pengine/.regression.failed.diff
 coverity-*
 
 compat_reports
@@ -205,4 +214,3 @@ logs
 *.orig
 *.rej
 *.swp
-pengine/test10/shadow.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,9 @@ before_script:
 # Save and restore CC so that ./configure can pass
  - export CC_SAVED=$CC
  - export CC=`echo ${CC} | sed s/cov-build/gcc/`
- # some tests (e.g. cts-exec-helper) require actual system-wide credentials
- - sed -e 's|^\(CRM_DAEMON_USER=\).*$|\1nobody|'
-       -e 's|^\(CRM_DAEMON_GROUP=\).*$|\1nobody|'
-       -i -- configure.ac
+ # some tests require actual system-wide credentials
  - ./autogen.sh
- - ./configure
+ - ./configure --with-daemon-user=nobody --with-daemon-group=nobody
  - export CC=$CC_SAVED
 
 script: 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,6 +18,11 @@
 
 default: $(shell test ! -e configure && echo init) $(shell test -e configure && echo core)
 
+# The toplevel "clean" targets are generated from Makefile.am, not this file.
+# We can't use autotools' CLEANFILES, clean-local, etc. here. Instead, we
+# define this target, which Makefile.am can use as a dependency of clean-local.
+EXTRA_CLEAN_TARGETS	= ancillary-clean
+
 -include Makefile
 
 # The main purpose of this GNUmakefile is that its targets can be invoked
@@ -437,8 +442,5 @@ gnulib-update:
 	cd gnulib && git pull
 	gnulib/gnulib-tool --source-base=lib/gnu --lgpl=2 --no-vc-files --import $(GNU_MODS)
 
-# The toplevel "clean" targets are generated from Makefile.am, not this file.
-# We can't use autotools' CLEANFILES, clean-local, etc. here. Instead, we
-# define this target, which Makefile.am can call from clean-local.
 ancillary-clean: export-clean spec-clean srpm-clean mock-clean coverity-clean
 	-rm -f $(TARFILE)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -96,9 +96,6 @@ export:
 	    echo "`date`: Using existing tarball: $(TARFILE)";			\
 	fi
 
-export-clean:
-	-rm -f $(abs_builddir)/$(PACKAGE)-*.tar.gz
-
 ## RPM-related targets
 
 # Where to put RPM artifacts; possible values:
@@ -442,5 +439,5 @@ gnulib-update:
 	cd gnulib && git pull
 	gnulib/gnulib-tool --source-base=lib/gnu --lgpl=2 --no-vc-files --import $(GNU_MODS)
 
-ancillary-clean: export-clean spec-clean srpm-clean mock-clean coverity-clean
+ancillary-clean: spec-clean srpm-clean mock-clean coverity-clean
 	-rm -f $(TARFILE)

--- a/Makefile.am
+++ b/Makefile.am
@@ -85,12 +85,9 @@ dist_test_DATA		= valgrind-pcmk.suppressions
 EXTRA_SCRIPTS		= abi-check bumplibs.sh
 
 # Scratch file for ad-hoc testing
-noinst_PROGRAMS = scratch
+EXTRA_PROGRAMS		= scratch
 nodist_scratch_SOURCES	= scratch.c
-scratch_LDADD	= $(top_builddir)/lib/common/libcrmcommon.la -lm
-
-scratch.c:
-	echo 'int main(void){}' >$@
+scratch_LDADD		= $(top_builddir)/lib/common/libcrmcommon.la
 
 core:
 	@echo "Building only core components: $(CORE)"
@@ -137,6 +134,7 @@ clean-generic:
 # clean-local target can clean up files created by GNUmakefile targets.
 # If this file is used alone, the variable will be undefined.
 clean-local: $(EXTRA_CLEAN_TARGETS)
+	-rm -f scratch
 
 distclean-local:
 	-rm -rf libltdl autom4te.cache

--- a/Makefile.am
+++ b/Makefile.am
@@ -123,8 +123,13 @@ endif
 clean-generic:
 	-rm -f *.tar.bz2 *.sed
 
-clean-local:
-	$(MAKE) $(AM_MAKEFLAGS) ancillary-clean
+# In a normal build, this file is included by GNUmakefile, which serves as the
+# "real" makefile. But in a VPATH build, GNUmakefile won't exist in the build
+# tree, and this file will be the "real" makefile. EXTRA_CLEAN_TARGETS handles
+# both cases: GNUmakefile defines it before including this file, so the
+# clean-local target can clean up files created by GNUmakefile targets.
+# If this file is used alone, the variable will be undefined.
+clean-local: $(EXTRA_CLEAN_TARGETS)
 
 distclean-local:
 	-rm -rf libltdl autom4te.cache

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,9 +46,13 @@ MAINTAINERCLEANFILES	= Makefile.in		\
 # some of our book sources are in the source directory, while others are
 # dynamically generated in the build directory, and publican can't handle that.
 #
-# @TODO To support VPATH builds for Publican, we'd probably have to create
-# a separate subtree of the build directory to use as Publican's source
-# directory, and copy the static sources into it.
+# In a non-VPATH build, doc isn't entered with a plain "make" because the
+# GNUmakefile sets "core" as the default target. However in a VPATH build,
+# there is no GNUmakefile, so "all" becomes the default target.
+#
+# @TODO To support VPATH builds for Publican, we could use the same "copy all
+# static inputs into the build tree" trick that xml/Makefile.am uses for
+# static schema files.
 AM_DISTCHECK_CONFIGURE_FLAGS	= --with-brand=""
 
 CORE	= replace include lib mcp attrd pengine cib crmd fencing lrmd tools xml

--- a/Makefile.am
+++ b/Makefile.am
@@ -111,7 +111,9 @@ core-clean:
 	done
 
 install-exec-local:
+if BUILD_CS_PLUGIN
 	$(INSTALL) -d $(DESTDIR)/$(LCRSODIR)
+endif
 	$(INSTALL) -d -m 750 $(DESTDIR)/$(CRM_CONFIG_DIR)
 	$(INSTALL) -d -m 750 $(DESTDIR)/$(CRM_CORE_DIR)
 	$(INSTALL) -d -m 750 $(DESTDIR)/$(CRM_BLACKBOX_DIR)

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,10 +50,17 @@ MAINTAINERCLEANFILES	= Makefile.in		\
 # GNUmakefile sets "core" as the default target. However in a VPATH build,
 # there is no GNUmakefile, so "all" becomes the default target.
 #
+# Also, don't try to install files outside the build directory.
+#
 # @TODO To support VPATH builds for Publican, we could use the same "copy all
 # static inputs into the build tree" trick that xml/Makefile.am uses for
 # static schema files.
-AM_DISTCHECK_CONFIGURE_FLAGS	= --with-brand=""
+AM_DISTCHECK_CONFIGURE_FLAGS	= --with-brand=""					\
+				  --prefix="$$dc_install_base/usr"			\
+				  --sysconfdir="$$dc_install_base/etc"			\
+				  --with-initdir="$$dc_install_base/etc/init.d"		\
+				  --with-ocfdir="$$dc_install_base/usr/lib/ocf"		\
+				  --with-systemdsystemunitdir="$$dc_install_base$(systemdsystemunitdir)"
 
 CORE	= replace include lib mcp attrd pengine cib crmd fencing lrmd tools xml
 SUBDIRS	= $(CORE) extra doc

--- a/Makefile.am
+++ b/Makefile.am
@@ -127,6 +127,8 @@ endif
 clean-generic:
 	-rm -f *.tar.bz2 *.sed
 
+PACKAGE         ?= pacemaker
+
 # In a normal build, this file is included by GNUmakefile, which serves as the
 # "real" makefile. But in a VPATH build, GNUmakefile won't exist in the build
 # tree, and this file will be the "real" makefile. EXTRA_CLEAN_TARGETS handles
@@ -134,7 +136,7 @@ clean-generic:
 # clean-local target can clean up files created by GNUmakefile targets.
 # If this file is used alone, the variable will be undefined.
 clean-local: $(EXTRA_CLEAN_TARGETS)
-	-rm -f scratch
+	-rm -f scratch $(builddir)/$(PACKAGE)-*.tar.gz
 
 distclean-local:
 	-rm -rf libltdl autom4te.cache

--- a/configure.ac
+++ b/configure.ac
@@ -1383,17 +1383,15 @@ if test "x${enable_systemd}" = xyes; then
 	HAVE_systemd=1
 	PCMK_FEATURES="$PCMK_FEATURES systemd"
 
-	AC_MSG_CHECKING([for systemd path for system unit files])
-	systemdunitdir="${systemdunitdir-}"
-	PKG_CHECK_VAR([systemdunitdir], [systemd],
-		      [systemdsystemunitdir], [],[
-	   systemdunitdir=no
-	])
-	AC_MSG_RESULT([${systemdunitdir}])
-	if test "x${systemdunitdir}" = xno; then
-		AC_MSG_FAILURE([cannot enable systemd when systemdunitdir unresolved])
+    AC_MSG_CHECKING([which system unit file directory to use])
+    systemdsystemunitdir="${systemdsystemunitdir-}"
+    PKG_CHECK_VAR([systemdsystemunitdir], [systemd], [systemdsystemunitdir])
+    AC_MSG_RESULT([${systemdsystemunitdir}])
+    if test "x${systemdsystemunitdir}" = x""; then
+        AC_MSG_FAILURE([cannot enable systemd when systemdsystemunitdir unresolved])
 	fi
 fi
+AC_SUBST([systemdsystemunitdir])
 
 AC_DEFINE_UNQUOTED(SUPPORT_SYSTEMD, $HAVE_systemd, Support systemd based system services)
 AM_CONDITIONAL(BUILD_SYSTEMD, test $HAVE_systemd = 1)

--- a/configure.ac
+++ b/configure.ac
@@ -306,6 +306,13 @@ AC_ARG_WITH([initdir],
     [ INITDIR="$withval" ]
 )
 
+systemdsystemunitdir="${systemdsystemunitdir-}"
+AC_ARG_WITH([systemdsystemunitdir],
+    [AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
+        [directory for systemd unit files (advanced option: must match what systemd uses)])],
+    [ systemdsystemunitdir="$withval" ]
+)
+
 SUPPORT_PROFILING=0
 AC_ARG_WITH([profiling],
     [AS_HELP_STRING([--with-profiling],
@@ -1384,7 +1391,6 @@ if test "x${enable_systemd}" = xyes; then
 	PCMK_FEATURES="$PCMK_FEATURES systemd"
 
     AC_MSG_CHECKING([which system unit file directory to use])
-    systemdsystemunitdir="${systemdsystemunitdir-}"
     PKG_CHECK_VAR([systemdsystemunitdir], [systemd], [systemdsystemunitdir])
     AC_MSG_RESULT([${systemdsystemunitdir}])
     if test "x${systemdsystemunitdir}" = x""; then

--- a/configure.ac
+++ b/configure.ac
@@ -348,6 +348,17 @@ AC_ARG_WITH([configdir],
     [ CONFIGDIR="$withval" ]
 )
 
+dnl This defaults to /usr/lib rather than libdir because it's determined by the
+dnl OCF project and not pacemaker. Even if a user wants to install pacemaker to
+dnl /usr/local or such, the OCF agents will be expected in their usual
+dnl location. However, we do give the user the option to override it.
+OCF_ROOT_DIR=""
+AC_ARG_WITH([ocfdir],
+    [AS_HELP_STRING([--with-ocfdir=DIR],
+        [OCF resource agent root directory (advanced option: changing this may break other cluster components unless similarly configured) @<:@/usr/lib/ocf@:>@])],
+    [ OCF_ROOT_DIR="$withval" ]
+)
+
 CRM_DAEMON_USER=""
 AC_ARG_WITH([daemon-user],
     [AS_HELP_STRING([--with-daemon-user=USER],
@@ -1257,9 +1268,8 @@ AC_SUBST(HA_VARLIBHBDIR)
 
 AC_DEFINE_UNQUOTED(UUID_FILE,"$localstatedir/lib/heartbeat/hb_uuid", Location of Heartbeat's UUID file)
 
-OCF_ROOT_DIR=`try_extract_header_define $GLUE_HEADER OCF_ROOT_DIR /usr/lib/ocf`
-if test "X$OCF_ROOT_DIR" = X; then
-  AC_MSG_ERROR(Could not locate OCF directory)
+if test "x$OCF_ROOT_DIR" = "x"; then
+    OCF_ROOT_DIR=`try_extract_header_define $GLUE_HEADER OCF_ROOT_DIR /usr/lib/ocf`
 fi
 AC_SUBST(OCF_ROOT_DIR)
 

--- a/configure.ac
+++ b/configure.ac
@@ -348,6 +348,15 @@ AC_ARG_WITH([configdir],
     [ CONFIGDIR="$withval" ]
 )
 
+dnl The not-yet-released autoconf 2.70 will have a --runstatedir option.
+dnl Until that's available, emulate it with our own --with-runstatedir.
+pcmk_runstatedir=""
+AC_ARG_WITH([runstatedir],
+    [AS_HELP_STRING([--with-runstatedir=DIR],
+        [modifiable per-process data @<:@LOCALSTATEDIR/run@:>@ (ignored if --runstatedir is available)])],
+    [ pcmk_runstatedir="$withval" ]
+)
+
 dnl This defaults to /usr/lib rather than libdir because it's determined by the
 dnl OCF project and not pacemaker. Even if a user wants to install pacemaker to
 dnl /usr/local or such, the OCF agents will be expected in their usual
@@ -496,6 +505,19 @@ eval infodir="`eval echo ${infodir}`"
 eval mandir="`eval echo ${mandir}`"
 
 dnl Home-grown variables
+
+if [ test "x${runstatedir}" = "x" ]; then
+    if [ test "x${pcmk_runstatedir}" = "x" ]; then
+        runstatedir="${localstatedir}/run"
+    else
+        runstatedir="${pcmk_runstatedir}"
+    fi
+fi
+eval runstatedir="$(eval echo ${runstatedir})"
+AC_DEFINE_UNQUOTED([PCMK_RUN_DIR], ["$runstatedir"],
+		   [Location for modifiable per-process data])
+AC_SUBST(runstatedir)
+
 eval INITDIR="${INITDIR}"
 eval docdir="`eval echo ${docdir}`"
 if test x"${docdir}" = x""; then
@@ -1211,10 +1233,6 @@ fi
 AC_DEFINE_UNQUOTED(CRM_DAEMON_GROUP,"$CRM_DAEMON_GROUP", Group to run Pacemaker daemons as)
 AC_SUBST(CRM_DAEMON_GROUP)
 
-CRM_STATE_DIR=${localstatedir}/run/crm
-AC_DEFINE_UNQUOTED(CRM_STATE_DIR,"$CRM_STATE_DIR", Where to keep state files and sockets)
-AC_SUBST(CRM_STATE_DIR)
-
 CRM_LOG_DIR="${localstatedir}/log/pacemaker"
 AC_DEFINE_UNQUOTED(CRM_LOG_DIR,"$CRM_LOG_DIR", Where Pacemaker can store log files)
 AC_SUBST(CRM_LOG_DIR)
@@ -1252,11 +1270,16 @@ AC_DEFINE_UNQUOTED(HB_DAEMON_DIR,"$HB_DAEMON_DIR", Location Heartbeat expects Pa
 AC_SUBST(HB_DAEMON_DIR)
 
 dnl Needed so that the Corosync plugin can clear out the directory as Heartbeat does
-HA_STATE_DIR=`try_extract_header_define $GLUE_HEADER HA_VARRUNDIR ${localstatedir}/run`
+HA_STATE_DIR=`try_extract_header_define $GLUE_HEADER HA_VARRUNDIR ${runstatedir}`
 AC_DEFINE_UNQUOTED(HA_STATE_DIR,"$HA_STATE_DIR", Where Heartbeat keeps state files and sockets)
 AC_SUBST(HA_STATE_DIR)
 
-CRM_RSCTMP_DIR=`try_extract_header_define agent_config.h HA_RSCTMPDIR $HA_STATE_DIR/resource-agents`
+CRM_STATE_DIR="${runstatedir}/crm"
+AC_DEFINE_UNQUOTED([CRM_STATE_DIR], ["$CRM_STATE_DIR"],
+		   [Where to keep state files and sockets])
+AC_SUBST(CRM_STATE_DIR)
+
+CRM_RSCTMP_DIR=`try_extract_header_define agent_config.h HA_RSCTMPDIR ${runstatedir}/resource-agents`
 AC_MSG_CHECKING(Scratch dir for resource agents)
 AC_MSG_RESULT($CRM_RSCTMP_DIR)
 AC_DEFINE_UNQUOTED(CRM_RSCTMP_DIR,"$CRM_RSCTMP_DIR", Where resource agents should keep state files)

--- a/configure.ac
+++ b/configure.ac
@@ -50,21 +50,11 @@ dnl   - Safe to include anywhere
 AM_CONFIG_HEADER(include/config.h include/crm_config.h)
 ALL_LINGUAS="en fr"
 
-AC_ARG_WITH(version,
-    [  --with-version=version   Override package version (if you're a packager needing to pretend) ],
-    [ PACKAGE_VERSION="$withval" ])
-
 dnl Older distros may need: AM_INIT_AUTOMAKE($PACKAGE_NAME, $PACKAGE_VERSION)
 dnl tar-ustar:      use (older) POSIX variant of generated tar rather than v7
 AM_INIT_AUTOMAKE([foreign tar-ustar])
-AC_DEFINE_UNQUOTED(PACEMAKER_VERSION, "$PACKAGE_VERSION", Current pacemaker version)
-
 dnl Versioned attributes implementation is not yet production-ready
 AC_DEFINE_UNQUOTED(ENABLE_VERSIONED_ATTRS, 0, Enable versioned attributes)
-
-PACKAGE_SERIES=`echo $PACKAGE_VERSION | awk -F. '{ print $1"."$2 }'`
-AC_SUBST(PACKAGE_SERIES)
-AC_SUBST(PACKAGE_VERSION)
 
 dnl automake >= 1.11 offers --enable-silent-rules for suppressing the output from
 dnl normal compilation.  When a failure occurs, it will then display the full
@@ -158,208 +148,247 @@ dnl ===============================================
 dnl Configure Options
 dnl ===============================================
 
+
+dnl --enable-* options
+
 AC_ARG_ENABLE([ansi],
-[  --enable-ansi force GCC to compile to ANSI/ANSI standard for older compilers.
-     [default=no]])
+    [AS_HELP_STRING([--enable-ansi],
+        [force GCC to compile to ANSI standard for older compilers. @<:@no@:>@])],
+)
 
 AC_ARG_ENABLE([fatal-warnings],
-[  --enable-fatal-warnings very pedantic and fatal warnings for gcc
-     [default=yes]])
+    [AS_HELP_STRING([--enable-fatal-warnings],
+        [enable pedantic and fatal warnings for gcc @<:@yes@:>@])],
+)
 
 AC_ARG_ENABLE([quiet],
-[  --enable-quiet
-     Supress make output unless there is an error
-     [default=no]])
+    [AS_HELP_STRING([--enable-quiet],
+        [suppress make output unless there is an error @<:@no@:>@])],
+)
 
 AC_ARG_ENABLE([no-stack],
-    [  --enable-no-stack
-       Only build the Policy Engine and pieces needed to support it [default=no]])
+    [AS_HELP_STRING([--enable-no-stack],
+        [build only the policy engine and its requirements @<:@no@:>@])],
+)
 
 AC_ARG_ENABLE([upstart],
-    [  --enable-upstart
-       Enable support for managing resources via Upstart [default=try]],
+    [AS_HELP_STRING([--enable-upstart],
+        [enable support for managing resources via Upstart @<:@try@:>@])],
     [],
     [enable_upstart=try],
 )
 
 AC_ARG_ENABLE([systemd],
-    [  --enable-systemd
-       Enable support for managing resources via systemd [default=try]],
+    [AS_HELP_STRING([--enable-systemd],
+        [enable support for managing resources via systemd @<:@try@:>@])],
     [],
     [enable_systemd=try],
 )
 
-AC_ARG_ENABLE(hardening,
-    [  --with-hardening
-       Harden the resulting executables/libraries (best effort by default)],
+AC_ARG_ENABLE([hardening],
+    [AS_HELP_STRING([--enable-hardening],
+        [harden the resulting executables/libraries @<:@try@:>@])],
     [ HARDENING="${enableval}" ],
     [ HARDENING=try ],
 )
 
+dnl --with-* options
+
+AC_DEFUN([VERSION_ARG],
+    [AC_ARG_WITH([version],
+        [AS_HELP_STRING([--with-version=VERSION],
+            [override package version @<:@$1@:>@])],
+        [ PACKAGE_VERSION="$withval" ])]
+)
+VERSION_ARG(VERSION_NUMBER)
+
 AC_ARG_WITH(ais,
-    [  --with-ais
-       Support the Corosync messaging and membership layer ],
+    [AS_HELP_STRING([--with-ais],
+        [support the Corosync messaging and membership layer])],
     [ SUPPORT_CS=$withval ],
     [ SUPPORT_CS=try ],
 )
 
-AC_ARG_WITH(corosync,
-    [  --with-corosync
-       Support the Corosync messaging and membership layer ],
+AC_ARG_WITH([corosync],
+    [AS_HELP_STRING([--with-corosync],
+        [support the Corosync messaging and membership layer])],
     [ SUPPORT_CS=$withval ]
 dnl	initialized in AC_ARG_WITH(ais...) already,
 dnl	don't reset to try if it was given as --without-ais
 )
 
 AC_ARG_WITH(heartbeat,
-    [  --with-heartbeat
-       Support the Heartbeat messaging and membership layer ],
+    [AS_HELP_STRING([--with-heartbeat],
+       [support the Heartbeat messaging and membership layer])],
     [ SUPPORT_HEARTBEAT=$withval ],
     [ SUPPORT_HEARTBEAT=try ],
 )
 
 AC_ARG_WITH(cman,
-    [  --with-cman
-       Support the consumption of membership and quorum from cman ],
+    [AS_HELP_STRING([--with-cman],
+       [support the consumption of membership and quorum from cman])],
     [ SUPPORT_CMAN=$withval ],
     [ SUPPORT_CMAN=try ],
 )
 
 AC_ARG_WITH(cpg,
-    [  --with-cs-quorum
-       Support the consumption of membership and quorum from corosync ],
+    [AS_HELP_STRING([--with-cs-quorum],
+       [support the consumption of membership and quorum from corosync])],
     [ SUPPORT_CS_QUORUM=$withval ],
     [ SUPPORT_CS_QUORUM=try ],
 )
 
-AC_ARG_WITH(nagios,
-    [  --with-nagios
-       Support nagios remote monitoring ],
+AC_ARG_WITH([nagios],
+    [AS_HELP_STRING([--with-nagios],
+        [support nagios remote monitoring])],
     [ SUPPORT_NAGIOS=$withval ],
     [ SUPPORT_NAGIOS=try ],
 )
 
-AC_ARG_WITH(nagios-plugin-dir,
-    [  --with-nagios-plugin-dir=DIR
-       Directory for nagios plugins [${NAGIOS_PLUGIN_DIR}]],
+AC_ARG_WITH([nagios-plugin-dir],
+    [AS_HELP_STRING([--with-nagios-plugin-dir=DIR],
+        [directory for nagios plugins @<:@LIBEXECDIR/nagios/plugins@:>@])],
     [ NAGIOS_PLUGIN_DIR="$withval" ]
 )
 
-AC_ARG_WITH(nagios-metadata-dir,
-    [  --with-nagios-metadata-dir=DIR
-       Directory for nagios plugins metadata [${NAGIOS_METADATA_DIR}]],
+AC_ARG_WITH([nagios-metadata-dir],
+    [AS_HELP_STRING([--with-nagios-metadata-dir=DIR],
+        [directory for nagios plugins metadata @<:@DATADIR/nagios/plugins-metadata@:>@])],
     [ NAGIOS_METADATA_DIR="$withval" ]
 )
 
 AC_ARG_WITH(snmp,
-    [  --with-snmp
-       Support the SNMP protocol ],
+    [AS_HELP_STRING([--with-snmp],
+        [support the SNMP protocol])],
     [ SUPPORT_SNMP=$withval ],
     [ SUPPORT_SNMP=try ],
 )
 
 AC_ARG_WITH(esmtp,
-    [  --with-esmtp
-       Support the sending mail notifications with the esmtp library ],
+    [AS_HELP_STRING([--with-esmtp],
+        [support the sending mail notifications with the esmtp library])],
     [ SUPPORT_ESMTP=$withval ],
     [ SUPPORT_ESMTP=try ],
 )
 
-AC_ARG_WITH(acl,
-    [  --with-acl
-       Support CIB ACL ],
+AC_ARG_WITH([acl],
+    [AS_HELP_STRING([--with-acl],
+        [support CIB ACL])],
     [ SUPPORT_ACL=$withval ],
     [ SUPPORT_ACL=yes ],
 )
 
-AC_ARG_WITH(cibsecrets,
-    [  --with-cibsecrets
-       Support CIB secrets ],
+AC_ARG_WITH([cibsecrets],
+    [AS_HELP_STRING([--with-cibsecrets],
+        [support separate file for CIB secrets])],
     [ SUPPORT_CIBSECRETS=$withval ],
     [ SUPPORT_CIBSECRETS=no ],
 )
 
 PCMK_GNUTLS_PRIORITIES="NORMAL"
-AC_ARG_WITH(gnutls-priorities,
-    [  --with-gnutls-priorities  GnuTLS cipher priorities @<:@NORMAL@:>@ ],
-    [ test x"$withval" = x"no" || PCMK_GNUTLS_PRIORITIES="$withval" ])
+AC_ARG_WITH([gnutls-priorities],
+    [AS_HELP_STRING([--with-gnutls-priorities],
+        [default GnuTLS cipher priorities @<:@NORMAL@:>@])],
+    [ test x"$withval" = x"no" || PCMK_GNUTLS_PRIORITIES="$withval" ]
+)
 
 CSPREFIX=""
 AC_ARG_WITH(ais-prefix,
-    [  --with-ais-prefix=DIR  Prefix used when Corosync was installed [$prefix]],
+    [AS_HELP_STRING([--with-ais-prefix=DIR],
+        [prefix used when Corosync was installed @<:@PREFIX@:>@])],
     [ CSPREFIX=$withval ],
     [ CSPREFIX=$prefix ])
 
 INITDIR=""
-AC_ARG_WITH(initdir,
-    [  --with-initdir=DIR      directory for init (rc) scripts [${INITDIR}]],
-    [ INITDIR="$withval" ])
+AC_ARG_WITH([initdir],
+    [AS_HELP_STRING([--with-initdir=DIR],
+        [directory for init (rc) scripts])],
+    [ INITDIR="$withval" ]
+)
 
 SUPPORT_PROFILING=0
-AC_ARG_WITH(profiling,
-    [  --with-profiling
-       Disable optimizations for effective profiling ],
-    [ SUPPORT_PROFILING=$withval ])
+AC_ARG_WITH([profiling],
+    [AS_HELP_STRING([--with-profiling],
+        [disable optimizations for effective profiling])],
+    [ SUPPORT_PROFILING=$withval ]
+)
 
-AC_ARG_WITH(coverage,
-    [  --with-coverage
-       Disable optimizations for effective profiling ],
-    [ SUPPORT_COVERAGE=$withval ])
+AC_ARG_WITH([coverage],
+    [AS_HELP_STRING([--with-coverage],
+        [disable optimizations for effective profiling])],
+    [ SUPPORT_COVERAGE=$withval ]
+)
 
 PUBLICAN_BRAND="common"
-AC_ARG_WITH(brand,
-    [  --with-brand=brand  Brand to use for generated documentation (set empty for no docs) [$PUBLICAN_BRAND]],
-    [ test x"$withval" = x"no" || PUBLICAN_BRAND="$withval" ])
+AC_ARG_WITH([brand],
+    [AS_HELP_STRING([--with-brand=brand],
+        [brand to use for generated documentation (set empty for no docs) @<:@common@:>@])],
+    [ test x"$withval" = x"no" || PUBLICAN_BRAND="$withval" ]
+)
 AC_SUBST(PUBLICAN_BRAND)
 
 BUG_URL=""
-AC_ARG_WITH(bug-url,
-    [  --with-bug-url=DIR  Address where users should submit bug reports @<:@https://bugs.clusterlabs.org/enter_bug.cgi?product=Pacemaker@:>@],
+AC_ARG_WITH([bug-url],
+    [AS_HELP_STRING([--with-bug-url=DIR],
+        [address where users should submit bug reports @<:@https://bugs.clusterlabs.org/enter_bug.cgi?product=Pacemaker@:>@])],
     [ BUG_URL="$withval" ]
 )
 
 ASCIIDOC_CLI_TYPE="pcs"
 AC_ARG_WITH(doc-cli,
-    [  --with-doc-cli=cli_type  CLI type to use for generated documentation. [$ASCIIDOC_CLI_TYPE]],
+    [AS_HELP_STRING([--with-doc-cli=cli_type],
+        [CLI type to use for generated documentation @<:@pcs@:>@])],
     [ ASCIIDOC_CLI_TYPE="$withval" ])
 AC_SUBST(ASCIIDOC_CLI_TYPE)
 
 CONFIGDIR=""
-AC_ARG_WITH(configdir,
-    [  --with-configdir=DIR
-       Directory for Pacemaker configuration file [${CONFIGDIR}]],
+AC_ARG_WITH([configdir],
+    [AS_HELP_STRING([--with-configdir=DIR],
+        [directory for Pacemaker configuration file @<:@SYSCONFDIR/sysconfig@:>@])],
     [ CONFIGDIR="$withval" ]
 )
 
 CRM_DAEMON_USER=""
-AC_ARG_WITH(daemon-user,
-    [  --with-daemon-user=USER  User to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@hacluster@:>@ ],
+AC_ARG_WITH([daemon-user],
+    [AS_HELP_STRING([--with-daemon-user=USER],
+        [user to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@hacluster@:>@])],
     [ CRM_DAEMON_USER="$withval" ]
 )
 
 CRM_DAEMON_GROUP=""
-AC_ARG_WITH(daemon-group,
-    [  --with-daemon-group=GROUP  Group to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@haclient@:>@ ],
+AC_ARG_WITH([daemon-group],
+    [AS_HELP_STRING([--with-daemon-group=GROUP],
+        [group to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@haclient@:>@])],
     [ CRM_DAEMON_GROUP="$withval" ]
 )
 
 dnl Options deprecated in 2.0 series
 
-AC_ARG_WITH(pkg-name,
-    [  --with-pkg-name=name     Override package name (if you are a packager needing to pretend) ],
+AC_ARG_WITH([pkg-name],
+    [AS_HELP_STRING([--with-pkg-name=name],
+        [override package name (if you are a packager needing to pretend)])],
     [ PACKAGE_NAME="$withval" ]
 )
 
-AC_ARG_WITH(pkgname,
-    [  --with-pkgname=name     name for pkg (typically for Solaris) ],
+AC_ARG_WITH([pkgname],
+    [AS_HELP_STRING([--with-pkgname=name],
+        [name for pkg (typically for Solaris)])],
     [ PKGNAME="$withval" ],
     [ PKGNAME="LXHAhb" ],
 )
 AC_SUBST(PKGNAME)
 
+
 dnl ===============================================
 dnl General Processing
 dnl ===============================================
+
+AC_DEFINE_UNQUOTED(PACEMAKER_VERSION, "$PACKAGE_VERSION",
+                   [Current pacemaker version])
+
+PACKAGE_SERIES=`echo $PACKAGE_VERSION | awk -F. '{ print $1"."$2 }'`
+AC_SUBST(PACKAGE_SERIES)
+AC_SUBST(PACKAGE_VERSION)
 
 AC_SUBST(HB_PKG)
 

--- a/configure.ac
+++ b/configure.ac
@@ -279,11 +279,10 @@ AC_ARG_WITH(cibsecrets,
     [ SUPPORT_CIBSECRETS=no ],
 )
 
+PCMK_GNUTLS_PRIORITIES="NORMAL"
 AC_ARG_WITH(gnutls-priorities,
     [  --with-gnutls-priorities  GnuTLS cipher priorities @<:@NORMAL@:>@ ],
-    [ PCMK_GNUTLS_PRIORITIES="$withval" ],
-    [ PCMK_GNUTLS_PRIORITIES="NORMAL" ],
-)
+    [ test x"$withval" = x"no" || PCMK_GNUTLS_PRIORITIES="$withval" ])
 
 CSPREFIX=""
 AC_ARG_WITH(ais-prefix,
@@ -474,8 +473,12 @@ if test x"${BUG_URL}" = x""; then
 fi
 AC_SUBST(BUG_URL)
 
+
+if test x"${PCMK_GNUTLS_PRIORITIES}" = x""; then
+    AC_MSG_ERROR([Empty string not applicable with --with-gnutls-priorities])
+fi
 AC_DEFINE_UNQUOTED([PCMK_GNUTLS_PRIORITIES], ["$PCMK_GNUTLS_PRIORITIES"],
-		   [GnuTLS cipher priorities])
+                   [GnuTLS cipher priorities])
 
 for j in prefix exec_prefix bindir sbindir libexecdir datadir sysconfdir \
     sharedstatedir localstatedir libdir includedir oldincludedir infodir \

--- a/configure.ac
+++ b/configure.ac
@@ -54,10 +54,6 @@ AC_ARG_WITH(version,
     [  --with-version=version   Override package version (if you're a packager needing to pretend) ],
     [ PACKAGE_VERSION="$withval" ])
 
-AC_ARG_WITH(pkg-name,
-    [  --with-pkg-name=name     Override package name (if you're a packager needing to pretend) ],
-    [ PACKAGE_NAME="$withval" ])
-
 dnl Older distros may need: AM_INIT_AUTOMAKE($PACKAGE_NAME, $PACKAGE_VERSION)
 dnl tar-ustar:      use (older) POSIX variant of generated tar rather than v7
 AM_INIT_AUTOMAKE([foreign tar-ustar])
@@ -161,14 +157,6 @@ extract_header_define() {
 dnl ===============================================
 dnl Configure Options
 dnl ===============================================
-
-dnl Some systems, like Solaris require a custom package name
-AC_ARG_WITH(pkgname,
-    [  --with-pkgname=name     name for pkg (typically for Solaris) ],
-    [ PKGNAME="$withval" ],
-    [ PKGNAME="LXHAhb" ],
-  )
-AC_SUBST(PKGNAME)
 
 AC_ARG_ENABLE([ansi],
 [  --enable-ansi force GCC to compile to ANSI/ANSI standard for older compilers.
@@ -355,6 +343,20 @@ AC_ARG_WITH(daemon-group,
     [  --with-daemon-group=GROUP  Group to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@haclient@:>@ ],
     [ CRM_DAEMON_GROUP="$withval" ]
 )
+
+dnl Options deprecated in 2.0 series
+
+AC_ARG_WITH(pkg-name,
+    [  --with-pkg-name=name     Override package name (if you are a packager needing to pretend) ],
+    [ PACKAGE_NAME="$withval" ]
+)
+
+AC_ARG_WITH(pkgname,
+    [  --with-pkgname=name     name for pkg (typically for Solaris) ],
+    [ PKGNAME="$withval" ],
+    [ PKGNAME="LXHAhb" ],
+)
+AC_SUBST(PKGNAME)
 
 dnl ===============================================
 dnl General Processing

--- a/configure.ac
+++ b/configure.ac
@@ -344,6 +344,18 @@ AC_ARG_WITH(configdir,
     [ CONFIGDIR="$withval" ]
 )
 
+CRM_DAEMON_USER=""
+AC_ARG_WITH(daemon-user,
+    [  --with-daemon-user=USER  User to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@hacluster@:>@ ],
+    [ CRM_DAEMON_USER="$withval" ]
+)
+
+CRM_DAEMON_GROUP=""
+AC_ARG_WITH(daemon-group,
+    [  --with-daemon-group=GROUP  Group to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@haclient@:>@ ],
+    [ CRM_DAEMON_GROUP="$withval" ]
+)
+
 dnl ===============================================
 dnl General Processing
 dnl ===============================================
@@ -1142,11 +1154,15 @@ CRM_CORE_DIR=`try_extract_header_define $GLUE_HEADER HA_COREDIR ${localstatedir}
 AC_DEFINE_UNQUOTED(CRM_CORE_DIR,"$CRM_CORE_DIR", Location to store core files produced by Pacemaker daemons)
 AC_SUBST(CRM_CORE_DIR)
 
-CRM_DAEMON_USER=`try_extract_header_define $GLUE_HEADER HA_CCMUSER hacluster`
+if test x"${CRM_DAEMON_USER}" = x""; then
+    CRM_DAEMON_USER=`try_extract_header_define $GLUE_HEADER HA_CCMUSER hacluster`
+fi
 AC_DEFINE_UNQUOTED(CRM_DAEMON_USER,"$CRM_DAEMON_USER", User to run Pacemaker daemons as)
 AC_SUBST(CRM_DAEMON_USER)
 
-CRM_DAEMON_GROUP=`try_extract_header_define $GLUE_HEADER HA_APIGROUP haclient`
+if test x"${CRM_DAEMON_GROUP}" = x""; then
+    CRM_DAEMON_GROUP=`try_extract_header_define $GLUE_HEADER HA_APIGROUP haclient`
+fi
 AC_DEFINE_UNQUOTED(CRM_DAEMON_GROUP,"$CRM_DAEMON_GROUP", Group to run Pacemaker daemons as)
 AC_SUBST(CRM_DAEMON_GROUP)
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,19 +1,10 @@
 #
-# Copyright (C) 2004-2009 Andrew Beekhof
+# Copyright 2004-2019 the Pacemaker project contributors
 #
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 MAINTAINERCLEANFILES    = Makefile.in
 
@@ -39,9 +30,10 @@ clean-local:
 
 ## Subdirectories...
 SUBDIRS	= gnu common pengine transition cib services fencing lrmd cluster
-DIST_SUBDIRS =  $(SUBDIRS) ais
+DIST_SUBDIRS = $(SUBDIRS)
 
 if BUILD_CS_PLUGIN
 SUBDIRS			+= ais
+else
+DIST_SUBDIRS		+= ais
 endif
-

--- a/lib/ais/Makefile.am
+++ b/lib/ais/Makefile.am
@@ -15,7 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #
-MAINTAINERCLEANFILES    = Makefile.in
+
+include $(top_srcdir)/Makefile.common
 
 plugindir		= $(libdir)
 plugin_LTLIBRARIES	= service_crm.la

--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -1,6 +1,7 @@
 /*
- * Copyright 2013 Lars Marowsky-Bree <lmb@suse.com>
- *           2014-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2013-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -223,7 +224,7 @@ pcmk_locate_sbd(void)
     }
 
     /* Look for the pid file */
-    pidfile = crm_strdup_printf("%s/sbd.pid", HA_STATE_DIR);
+    pidfile = crm_strdup_printf(PCMK_RUN_DIR "/sbd.pid");
     sbd_path = crm_strdup_printf("%s/sbd", SBIN_DIR);
 
     /* Read the pid file */

--- a/lrmd/Makefile.am
+++ b/lrmd/Makefile.am
@@ -30,7 +30,7 @@ dist_init_SCRIPTS	= pacemaker_remote
 sbin_PROGRAMS		= pacemaker_remoted
 
 if BUILD_SYSTEMD
-systemdunit_DATA	= pacemaker_remote.service
+systemdsystemunit_DATA	= pacemaker_remote.service
 endif
 
 lrmd_CFLAGS		= $(CFLAGS_HARDENED_EXE)

--- a/mcp/Makefile.am
+++ b/mcp/Makefile.am
@@ -24,7 +24,7 @@ dist_init_SCRIPTS	= pacemaker
 sbin_PROGRAMS		= pacemakerd
 
 if BUILD_SYSTEMD
-systemdunit_DATA	= pacemaker.service
+systemdsystemunit_DATA	= pacemaker.service
 endif
 
 EXTRA_DIST		= pacemaker.sysconfig

--- a/mcp/pacemaker.c
+++ b/mcp/pacemaker.c
@@ -46,7 +46,7 @@ static bool global_keep_tracking = false;
 const char *local_name = NULL;
 uint32_t local_nodeid = 0;
 crm_trigger_t *shutdown_trigger = NULL;
-const char *pid_file = "/var/run/pacemaker.pid";
+static const char *pid_file = PCMK_RUN_DIR "/pacemaker.pid";
 
 typedef struct pcmk_child_s {
     int pid;

--- a/pengine/Makefile.am
+++ b/pengine/Makefile.am
@@ -85,5 +85,7 @@ install-exec-local:
 
 uninstall-local:
 
+CLEANFILES	= $(builddir)/.regression.failed.diff
+
 clean-local:
 	rm -f test10/*.pe.* $(man7_MANS)

--- a/pengine/Makefile.am
+++ b/pengine/Makefile.am
@@ -33,13 +33,12 @@ dist_test10_DATA	= $(PE_TESTS) $(PE_TESTS:%.scores=%.xml) $(PE_TESTS:%.scores=%.
 beekhof:
 	echo $(shell ls -1 test10/*.xml)
 
-#TESTS = test10/*.xml
-TESTS = test10/bug-rh-1097457.xml
-TEST_EXTENSIONS = .xml
-XML_LOG_COMPILER = ./regression.sh
-AM_XML_LOG_FLAGS = -V --run 
-#LOG_COMPILER = 
-#AM_LOG_FLAGS = -V
+# Don't do anything for "make check". This won't work with "make distcheck"
+# unless we backport the equivalent of 3d6906e, which isn't worth the effort.
+#TESTS = test10/bug-rh-1097457.xml
+#TEST_EXTENSIONS = .xml
+#XML_LOG_COMPILER = ./regression.sh
+#AM_XML_LOG_FLAGS = -V --run 
 
 COMMONLIBS	= $(top_builddir)/lib/common/libcrmcommon.la	\
 		$(top_builddir)/lib/pengine/libpe_status.la	\

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -88,6 +88,14 @@
 %global gnutls_priorities @SYSTEM
 %endif
 
+%if !%{defined _rundir}
+%if 0%{?fedora} >= 15 || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1200
+%define _rundir /run
+%else
+%define _rundir /var/run
+%endif
+%endif
+
 ## Different distros name certain packages differently
 %if 0%{?suse_version} > 0
 %global pkgname_bzip2_devel libbz2-devel
@@ -440,6 +448,7 @@ export LDFLAGS_HARDENED_LIB="%{?_hardening_ldflags}"
         %{!?with_hardening:  --disable-hardening}  \
         %{?gnutls_priorities: --with-gnutls-priorities="%{gnutls_priorities}"} \
         --with-initdir=%{_initrddir}               \
+        --with-runstatedir=%{_rundir}                                           \
         --localstatedir=%{_var}                    \
         --with-version=%{version}-%{release}
 

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -421,7 +421,7 @@ find . -exec touch \{\} \;
 # Early versions of autotools (e.g. RHEL <= 5) do not support --docdir
 export docdir=%{pcmk_docdir}
 
-export systemdunitdir=%{?_unitdir}%{!?_unitdir:no}
+export systemdsystemunitdir=%{?_unitdir}%{!?_unitdir:no}
 
 %if %{with hardening}
 # prefer distro-provided hardening flags in case they are defined

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -361,7 +361,7 @@ Requires:      libuuid-devel%{?_isa} %{?pkgname_libtool_devel_arch}
 Requires:      libxml2-devel%{?_isa} libxslt-devel%{?_isa}
 Requires:      %{pkgname_bzip2_devel}%{?_isa} glib2-devel%{?_isa}
 Requires:      libqb-devel%{?_isa}
-Requires:      %{pkgname_corosync_lib}-devel%{?_isa} >= 2.0.0
+Requires:      %{pkgname_corosync_lib}-devel%{?_isa}
 
 %description -n %{pkgname_pcmk_libs}-devel
 Pacemaker is an advanced, scalable High-Availability cluster resource

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -18,7 +18,7 @@
 include $(top_srcdir)/Makefile.common
 
 if BUILD_SYSTEMD
-systemdunit_DATA = crm_mon.service
+systemdsystemunit_DATA	= crm_mon.service
 endif
 
 COMMONLIBS	= 							\

--- a/tools/ipmiservicelogd.c
+++ b/tools/ipmiservicelogd.c
@@ -571,7 +571,7 @@ main(int argc, char *argv[])
     }
 #endif
 
-    crm_make_daemon("ipmiservicelogd", TRUE, "/var/run/ipmiservicelogd.pid0");
+    crm_make_daemon("ipmiservicelogd", TRUE, PCMK_RUN_DIR "/ipmiservicelogd.pid0");
     crm_log_cli_init("ipmiservicelogd");
     // Maybe this should log like a daemon instead?
     // crm_log_init("ipmiservicelogd", LOG_INFO, TRUE, FALSE, argc, argv, FALSE);

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -193,6 +193,11 @@ fulldiff: best-match.sh
 
 CLEANFILES = $(CIB_generated)
 
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then					\
+		rm -f $(CIB_build_copies) $(MON_build_copies);	\
+	fi
+
 # Enable ability to use $@ in prerequisite
 .SECONDEXPANSION:
 

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -44,9 +44,19 @@ CIB_cfg_base		= options nodes resources constraints fencing acls tags alerts
 # Names of all schemas (including top level and those included by others)
 CIB_base		= cib $(CIB_cfg_base) status score rule nvset
 
-# All static schema files
+# Static schema files and transforms (only CIB has transforms)
+#
+# This is more complicated than it should be due to the need to support
+# VPATH builds and "make distcheck". We need the absolute paths for reliable
+# substitution back and forth, and relative paths for distributed files.
+CIB_abs_files		= $(foreach base,$(CIB_base),$(wildcard $(abs_srcdir)/$(base).rng $(abs_srcdir)/$(base)-*.rng))
+CIB_abs_xsl		= $(abs_srcdir)/upgrade06.xsl			\
+			  $(abs_srcdir)/upgrade-1.3.xsl
+MON_abs_files		= $(abs_srcdir)/crm_mon.rng
 CIB_files		= $(foreach base,$(CIB_base),$(wildcard $(srcdir)/$(base).rng $(srcdir)/$(base)-*.rng))
-MON_files		= crm_mon.rng
+CIB_xsl			= $(srcdir)/upgrade06.xsl			\
+			  $(srcdir)/upgrade-1.3.xsl
+MON_files		= $(srcdir)/crm_mon.rng
 
 # Sorted lists of all numeric schema versions
 CIB_numeric_versions	= $(call numeric_versions,${CIB_files})
@@ -57,6 +67,10 @@ CIB_max			?= $(lastword $(CIB_numeric_versions))
 # Sorted lists of all schema versions (including "next")
 CIB_versions		= next $(CIB_numeric_versions)
 
+# Build tree locations of static schema files and transforms (for VPATH builds)
+CIB_build_copies	= $(foreach f,$(CIB_abs_files) $(CIB_abs_xsl),$(subst $(abs_srcdir),$(abs_builddir),$(f)))
+MON_build_copies	= $(foreach f,$(MON_abs_files),$(subst $(abs_srcdir),$(abs_builddir),$(f)))
+
 # Dynamically generated schema files
 CIB_generated		= pacemaker.rng $(foreach base,$(CIB_versions),pacemaker-$(base).rng) versions.rng
 
@@ -64,9 +78,7 @@ CIB_version_pairs	= $(call version_pairs,${CIB_numeric_versions})
 CIB_version_pairs_cnt	= $(words ${CIB_version_pairs})
 CIB_version_pairs_last  = $(call version_pairs_last,${CIB_version_pairs_cnt},${CIB_version_pairs})
 
-dist_CIB_DATA		= $(CIB_files)					\
-			  upgrade06.xsl					\
-			  upgrade-1.3.xsl				\
+dist_CIB_DATA		= $(CIB_files) $(CIB_xsl)			\
 			  crm.dtd					\
 			  crm-transitional.dtd
 dist_MON_DATA		= $(MON_files)
@@ -89,7 +101,7 @@ cib-versions:
 pacemaker.rng: pacemaker-$(CIB_max).rng
 	$(AM_V_SCHEMA)cp $(top_builddir)/xml/$< $@
 
-pacemaker-%.rng: $(CIB_files) best-match.sh Makefile.am
+pacemaker-%.rng: $(CIB_build_copies) best-match.sh Makefile.am
 	$(AM_V_at)echo '<?xml version="1.0" encoding="UTF-8"?>' > $@
 	$(AM_V_at)echo '<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">' >> $@
 	$(AM_V_at)echo '  <start>' >> $@
@@ -180,3 +192,13 @@ fulldiff: best-match.sh
 	$(call version_diff,${CIB_version_pairs})
 
 CLEANFILES = $(CIB_generated)
+
+# Enable ability to use $@ in prerequisite
+.SECONDEXPANSION:
+
+# For VPATH builds, copy the static schema files into the build tree
+$(CIB_build_copies) $(MON_build_copies): $$(subst $(abs_builddir),$(srcdir),$$(@))
+	$(AM_V_GEN)if [ "x$(srcdir)" != "x$(builddir)" ]; then	\
+		$(MKDIR_P) "$(dir $(@))";			\
+		cp "$(<)" "$(@)";				\
+	fi


### PR DESCRIPTION
"make distcheck" requires automake 1.12 or higher (for AM_DISTCHECK_CONFIGURE_FLAGS; this is true of the master branch as well), and does not work if support for the corosync 1 plugin is enabled (which could be fixed by adding a configure option for lcrsodir, but that's not worth the effort at this point)