### PR TITLE
Fix: libcrmcommon: Accept a single dash on the command line.

### DIFF
--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -138,6 +138,14 @@ pcmk__cmdline_preproc(int argc, char **argv, const char *special) {
             continue;
         }
 
+        /* This is just a dash by itself.  That could indicate stdin/stdout, or
+         * it could be user error.  Copy it over and let glib figure it out.
+         */
+        if (safe_str_eq(argv[i], "-")) {
+            g_ptr_array_add(arr, strdup(argv[i]));
+            continue;
+        }
+
         /* This is a short argument, or perhaps several.  Iterate over it
          * and explode them out into individual arguments.
          */


### PR DESCRIPTION
These were getting skipped, meaning there was no way of specifying
stdin/stdout as command line parameters.  Just pass them through and let
the rest of the command line handling code decide if it's an error or
not.