### PR TITLE
Tie up some loose ends

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -821,10 +821,10 @@ dnl     strerror: returns a string that corresponds to an errno.
 dnl             A replacement function is supplied for it.
 dnl
 dnl     strnlen: is a gnu function similar to strlen, but safer.
-dnl            We wrote a tolearably-fast replacement function for it.
+dnl            We wrote a tolerably-fast replacement function for it.
 dnl
 dnl     strndup: is a gnu function similar to strdup, but safer.
-dnl            We wrote a tolearably-fast replacement function for it.
+dnl            We wrote a tolerably-fast replacement function for it.
 
 AC_REPLACE_FUNCS(alphasort NoSuchFunctionName scandir setenv strerror strchrnul unsetenv strnlen strndup)
 

--- a/cts/cli/regression.dates.exp
+++ b/cts/cli/regression.dates.exp
@@ -1,9 +1,85 @@
+=#=#=#= Begin test: Invalid period - [] =#=#=#=
+Invalid interval specified: 
+=#=#=#= End test: Invalid period - [] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - []
+=#=#=#= Begin test: Invalid period - [2019-01-01 00:00:00Z] =#=#=#=
+Invalid interval specified: 2019-01-01 00:00:00Z
+=#=#=#= End test: Invalid period - [2019-01-01 00:00:00Z] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [2019-01-01 00:00:00Z]
+=#=#=#= Begin test: Invalid period - [2019-01-01 00:00:00Z/] =#=#=#=
+Invalid interval specified: 2019-01-01 00:00:00Z/
+=#=#=#= End test: Invalid period - [2019-01-01 00:00:00Z/] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [2019-01-01 00:00:00Z/]
+=#=#=#= Begin test: Invalid period - [PT2S/P1M] =#=#=#=
+Invalid interval specified: PT2S/P1M
+=#=#=#= End test: Invalid period - [PT2S/P1M] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [PT2S/P1M]
+=#=#=#= Begin test: Invalid period - [2019-13-01 00:00:00Z/P1M] =#=#=#=
+Invalid interval specified: 2019-13-01 00:00:00Z/P1M
+=#=#=#= End test: Invalid period - [2019-13-01 00:00:00Z/P1M] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [2019-13-01 00:00:00Z/P1M]
+=#=#=#= Begin test: Invalid period - [20191077T15/P1M] =#=#=#=
+Invalid interval specified: 20191077T15/P1M
+=#=#=#= End test: Invalid period - [20191077T15/P1M] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [20191077T15/P1M]
+=#=#=#= Begin test: Invalid period - [2019-10-01T25:00:00Z/P1M] =#=#=#=
+Invalid interval specified: 2019-10-01T25:00:00Z/P1M
+=#=#=#= End test: Invalid period - [2019-10-01T25:00:00Z/P1M] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [2019-10-01T25:00:00Z/P1M]
+=#=#=#= Begin test: Invalid period - [2019-10-01T24:00:01Z/P1M] =#=#=#=
+Invalid interval specified: 2019-10-01T24:00:01Z/P1M
+=#=#=#= End test: Invalid period - [2019-10-01T24:00:01Z/P1M] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [2019-10-01T24:00:01Z/P1M]
+=#=#=#= Begin test: Invalid period - [PT5H/20191001T007000Z] =#=#=#=
+Invalid interval specified: PT5H/20191001T007000Z
+=#=#=#= End test: Invalid period - [PT5H/20191001T007000Z] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [PT5H/20191001T007000Z]
+=#=#=#= Begin test: Invalid period - [2019-10-01 00:00:80Z/P1M] =#=#=#=
+Invalid interval specified: 2019-10-01 00:00:80Z/P1M
+=#=#=#= End test: Invalid period - [2019-10-01 00:00:80Z/P1M] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [2019-10-01 00:00:80Z/P1M]
+=#=#=#= Begin test: Invalid period - [2019-10-01 00:00:10 +25:00/P1M] =#=#=#=
+Invalid interval specified: 2019-10-01 00:00:10 +25:00/P1M
+=#=#=#= End test: Invalid period - [2019-10-01 00:00:10 +25:00/P1M] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [2019-10-01 00:00:10 +25:00/P1M]
+=#=#=#= Begin test: Invalid period - [20191001T000010 -00:61/P1M] =#=#=#=
+Invalid interval specified: 20191001T000010 -00:61/P1M
+=#=#=#= End test: Invalid period - [20191001T000010 -00:61/P1M] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [20191001T000010 -00:61/P1M]
+=#=#=#= Begin test: Invalid period - [P1Y/2019-02-29 00:00:00Z] =#=#=#=
+Invalid interval specified: P1Y/2019-02-29 00:00:00Z
+=#=#=#= End test: Invalid period - [P1Y/2019-02-29 00:00:00Z] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [P1Y/2019-02-29 00:00:00Z]
+=#=#=#= Begin test: Invalid period - [2019-01-01 00:00:00Z/P] =#=#=#=
+Invalid interval specified: 2019-01-01 00:00:00Z/P
+=#=#=#= End test: Invalid period - [2019-01-01 00:00:00Z/P] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [2019-01-01 00:00:00Z/P]
+=#=#=#= Begin test: Invalid period - [P1Z/2019-02-20 00:00:00Z] =#=#=#=
+Invalid interval specified: P1Z/2019-02-20 00:00:00Z
+=#=#=#= End test: Invalid period - [P1Z/2019-02-20 00:00:00Z] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [P1Z/2019-02-20 00:00:00Z]
+=#=#=#= Begin test: Invalid period - [P1YM/2019-02-20 00:00:00Z] =#=#=#=
+Invalid interval specified: P1YM/2019-02-20 00:00:00Z
+=#=#=#= End test: Invalid period - [P1YM/2019-02-20 00:00:00Z] - Invalid parameter (2) =#=#=#=
+* Passed: iso8601        - Invalid period - [P1YM/2019-02-20 00:00:00Z]
 =#=#=#= Begin test: 2014-01-01 00:30:00 - 1 Hour =#=#=#=
 Date: 2014-01-01 00:30:00Z
 Duration: -3600 seconds (1 hour)
 Duration ends at: 2013-12-31 23:30:00Z
 =#=#=#= End test: 2014-01-01 00:30:00 - 1 Hour - OK (0) =#=#=#=
 * Passed: iso8601        - 2014-01-01 00:30:00 - 1 Hour
+=#=#=#= Begin test: Valid date - Feb 29 in leap year =#=#=#=
+Date: 2020-02-29 00:00:00Z
+=#=#=#= End test: Valid date - Feb 29 in leap year - OK (0) =#=#=#=
+* Passed: iso8601        - Valid date - Feb 29 in leap year
+=#=#=#= Begin test: Valid date - using 'T' and offset =#=#=#=
+Date: 2019-12-01 18:12:11Z
+=#=#=#= End test: Valid date - using 'T' and offset - OK (0) =#=#=#=
+* Passed: iso8601        - Valid date - using 'T' and offset
+=#=#=#= Begin test: 24:00:00 equivalent to 00:00:00 of next day =#=#=#=
+Date: 2020-01-01 00:00:00Z
+=#=#=#= End test: 24:00:00 equivalent to 00:00:00 of next day - OK (0) =#=#=#=
+* Passed: iso8601        - 24:00:00 equivalent to 00:00:00 of next day
 =#=#=#= Begin test: 2006-W01-7 =#=#=#=
 Date: 2006-01-08 00:00:00Z
 =#=#=#= End test: 2006-W01-7 - OK (0) =#=#=#=
@@ -232,6 +308,12 @@ Date: 2040-W01-1 00:00:00Z
 Date: 2009-W53-7 00:00:00Z
 =#=#=#= End test: 2009-W53-07 - OK (0) =#=#=#=
 * Passed: iso8601        - 2009-W53-07
+=#=#=#= Begin test: epoch + 2 Years 5 Months 6 Minutes =#=#=#=
+Date: 1970-01-01 00:00:00Z
+Duration:    2 years  5 months 360 seconds (6 minutes)
+Duration ends at: 1972-06-01 00:06:00Z
+=#=#=#= End test: epoch + 2 Years 5 Months 6 Minutes - OK (0) =#=#=#=
+* Passed: iso8601        - epoch + 2 Years 5 Months 6 Minutes
 =#=#=#= Begin test: 2009-01-31 + 1 Month =#=#=#=
 Date: 2009-01-31 00:00:00Z
 Duration:  1 month 
@@ -253,7 +335,7 @@ Duration ends at: 2009-04-30 00:00:00Z
 =#=#=#= Begin test: 2009-03-31 - 1 Month =#=#=#=
 Date: 2009-03-31 00:00:00Z
 Duration: -1 months 
-Duration ends at: 2009-02-28 00:00:00Z
+Duration ends at: 2009-02-28 01:00:00 +01:00
 =#=#=#= End test: 2009-03-31 - 1 Month - OK (0) =#=#=#=
 * Passed: iso8601        - 2009-03-31 - 1 Month
 =#=#=#= Begin test: 2038-01-01 + 3 Months =#=#=#=

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -53,6 +53,7 @@ VALGRIND_OPTS="
 # These constants must track crm_exit_t values
 CRM_EX_OK=0
 CRM_EX_ERROR=1
+CRM_EX_INVALID_PARAM=2
 CRM_EX_INSUFFICIENT_PRIV=4
 CRM_EX_USAGE=64
 CRM_EX_CONFIG=78
@@ -438,9 +439,46 @@ function test_tools() {
     test_assert $CRM_EX_ERROR 0
 }
 
+INVALID_PERIODS=(
+    "2019-01-01 00:00:00Z"              # Start with no end
+    "2019-01-01 00:00:00Z/"             # Start with only a trailing slash
+    "PT2S/P1M"                          # Two durations
+    "2019-13-01 00:00:00Z/P1M"          # Out-of-range month
+    "20191077T15/P1M"                   # Out-of-range day
+    "2019-10-01T25:00:00Z/P1M"          # Out-of-range hour
+    "2019-10-01T24:00:01Z/P1M"          # Hour 24 with anything but :00:00
+    "PT5H/20191001T007000Z"             # Out-of-range minute
+    "2019-10-01 00:00:80Z/P1M"          # Out-of-range second
+    "2019-10-01 00:00:10 +25:00/P1M"    # Out-of-range offset hour
+    "20191001T000010 -00:61/P1M"        # Out-of-range offset minute
+    "P1Y/2019-02-29 00:00:00Z"          # Feb. 29 in non-leap-year
+    "2019-01-01 00:00:00Z/P"            # Duration with no values
+    "P1Z/2019-02-20 00:00:00Z"          # Invalid duration unit
+    "P1YM/2019-02-20 00:00:00Z"         # No number for duration unit
+)
+        
 function test_dates() {
+    # Ensure invalid period specifications are rejected
+    for spec in '' "${INVALID_PERIODS[@]}"; do
+        desc="Invalid period - [$spec]"
+        cmd="iso8601 -p \"$spec\""
+        test_assert $CRM_EX_INVALID_PARAM 0
+    done
+
     desc="2014-01-01 00:30:00 - 1 Hour"
     cmd="iso8601 -d '2014-01-01 00:30:00Z' -D P-1H -E '2013-12-31 23:30:00Z'"
+    test_assert $CRM_EX_OK 0
+
+    desc="Valid date - Feb 29 in leap year"
+    cmd="iso8601 -d '2020-02-29 00:00:00Z' -E '2020-02-29 00:00:00Z'"
+    test_assert $CRM_EX_OK 0
+
+    desc="Valid date - using 'T' and offset"
+    cmd="iso8601 -d '20191201T131211 -05:00' -E '2019-12-01 18:12:11Z'"
+    test_assert $CRM_EX_OK 0
+
+    desc="24:00:00 equivalent to 00:00:00 of next day"
+    cmd="iso8601 -d '2019-12-31 24:00:00Z' -E '2020-01-01 00:00:00Z'"
     test_assert $CRM_EX_OK 0
 
     for y in 06 07 08 09 10 11 12 13 14 15 16 17 18 40; do
@@ -465,8 +503,12 @@ function test_dates() {
     cmd="iso8601 -d '2009-W53-7 00:00:00Z' -W -E '2009-W53-7 00:00:00Z'"
     test_assert $CRM_EX_OK 0
 
+    desc="epoch + 2 Years 5 Months 6 Minutes"
+    cmd="iso8601 -d 'epoch' -D P2Y5MT6M -E '1972-06-01 00:06:00Z'"
+    test_assert $CRM_EX_OK 0
+
     desc="2009-01-31 + 1 Month"
-    cmd="iso8601 -d '2009-01-31 00:00:00Z' -D P1M -E '2009-02-28 00:00:00Z'"
+    cmd="iso8601 -d '20090131T000000Z' -D P1M -E '2009-02-28 00:00:00Z'"
     test_assert $CRM_EX_OK 0
 
     desc="2009-01-31 + 2 Months"
@@ -478,7 +520,7 @@ function test_dates() {
     test_assert $CRM_EX_OK 0
 
     desc="2009-03-31 - 1 Month"
-    cmd="iso8601 -d '2009-03-31 00:00:00Z' -D P-1M -E '2009-02-28 00:00:00Z'"
+    cmd="iso8601 -d '2009-03-31 01:00:00 +01:00' -D P-1M -E '2009-02-28 00:00:00Z'"
     test_assert $CRM_EX_OK 0
 
     desc="2038-01-01 + 3 Months"

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -251,7 +251,7 @@ function test_tools() {
     test_assert $CRM_EX_USAGE
 
     desc="Don't support migration to non-existent locations"
-    cmd="crm_resource -r dummy -M -N i.dont.exist"
+    cmd="crm_resource -r dummy -M -N i.do.not.exist"
     test_assert $CRM_EX_NOSUCH
 
     desc="Create a fencing resource"

--- a/cts/cts-scheduler.in
+++ b/cts/cts-scheduler.in
@@ -430,7 +430,7 @@ TESTS = [
         [ "master-13", "Include preferences of colocated resources when placing master" ],
         [ "master-demote", "Ordering when actions depends on demoting a slave resource" ],
         [ "master-ordering", "Prevent resources from starting that need a master" ],
-        [ "bug-1765", "Master-Master Colocation (dont stop the slaves)" ],
+        [ "bug-1765", "Master-Master Colocation (do not stop the slaves)" ],
         [ "master-group", "Promotion of cloned groups" ],
         [ "bug-lf-1852", "Don't shuffle master/slave instances unnecessarily" ],
         [ "master-failed-demote", "Don't retry failed demote actions" ],
@@ -972,7 +972,7 @@ TESTS = [
 ]
 
 
-# Constants subsituted in the build process
+# Constants substituted in the build process
 class BuildVars(object):
     SBINDIR = "@sbindir@"
     BUILDDIR = "@abs_top_builddir@"

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -58,7 +58,7 @@ controld_election_fini()
 void
 controld_set_election_period(const char *value)
 {
-    election_timeout_set_period(fsa_election, crm_get_msec(value));
+    election_timeout_set_period(fsa_election, crm_parse_interval_spec(value));
 }
 
 void

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -833,7 +833,7 @@ te_fence_node(crm_graph_t *graph, crm_action_t *action)
     }
 
     crm_notice("Requesting fencing (%s) of node %s "
-               CRM_XS " action=%s timeout=%d",
+               CRM_XS " action=%s timeout=%u",
                type, target, id, transition_graph->stonith_timeout);
 
     /* Passing NULL means block until we can connect... */
@@ -844,9 +844,11 @@ te_fence_node(crm_graph_t *graph, crm_action_t *action)
     }
 
     rc = stonith_api->cmds->fence(stonith_api, options, target, type,
-                                  transition_graph->stonith_timeout / 1000, 0);
+                                  (int) (transition_graph->stonith_timeout / 1000),
+                                  0);
 
-    stonith_api->cmds->register_callback(stonith_api, rc, transition_graph->stonith_timeout / 1000,
+    stonith_api->cmds->register_callback(stonith_api, rc,
+                                         (int) (transition_graph->stonith_timeout / 1000),
                                          st_opt_timeout_updates,
                                          generate_transition_key(transition_graph->id, action->id,
                                                                  0, te_uuid),

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -158,9 +158,9 @@ te_crm_command(crm_graph_t * graph, crm_action_t * action)
 
     } else {
         if (action->timeout <= 0) {
-            crm_err("Action %d: %s on %s had an invalid timeout (%dms).  Using %dms instead",
+            crm_err("Action %d: %s on %s had an invalid timeout (%dms).  Using %ums instead",
                     action->id, task, on_node, action->timeout, graph->network_delay);
-            action->timeout = graph->network_delay;
+            action->timeout = (int) graph->network_delay;
         }
         te_start_action_timer(graph, action);
     }
@@ -361,9 +361,9 @@ te_rsc_command(crm_graph_t * graph, crm_action_t * action)
                   action->id, task, task_uuid, on_node, action->timeout);
     } else {
         if (action->timeout <= 0) {
-            crm_err("Action %d: %s %s on %s had an invalid timeout (%dms).  Using %dms instead",
+            crm_err("Action %d: %s %s on %s had an invalid timeout (%dms).  Using %ums instead",
                     action->id, task, task_uuid, on_node, action->timeout, graph->network_delay);
-            action->timeout = graph->network_delay;
+            action->timeout = (int) graph->network_delay;
         }
         te_update_job_count(action, 1);
         te_start_action_timer(graph, action);

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -446,7 +446,7 @@ time_diff_ms(struct timeb *now, struct timeb *old)
     if ((old == NULL) || (old->time == 0)) {
         return 0;
     }
-    return difftime(now->time, old->time) * 1000 + now->millitm - old->millitm;
+    return (now->time - old->time) * 1000 + now->millitm - old->millitm;
 }
 
 /*!

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -42,7 +42,7 @@ typedef struct series_s {
 } series_t;
 
 series_t series[] = {
-    {"pe-unknown", "_dont_match_anything_", -1},
+    {"pe-unknown", "_do_not_match_anything_", -1},
     {"pe-error", "pe-error-series-max", -1},
     {"pe-warn", "pe-warn-series-max", 200},
     {"pe-input", "pe-input-series-max", 400},

--- a/doc/Pacemaker_Explained/en-US/Ch-Advanced-Resources.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Advanced-Resources.txt
@@ -963,12 +963,10 @@ ways:
 
 [[s-resource-bundle]]
 == Bundles - Isolated Environments ==
-indexterm:[bundle]
-indexterm:[Resource,bundle]
-indexterm:[container,bundle]
-indexterm:[Docker,bundle]
-indexterm:[podman,bundle]
-indexterm:[rkt,bundle]
+indexterm:[Resource,Bundle]
+indexterm:[Container,Docker,Bundle]
+indexterm:[Container,podman,Bundle]
+indexterm:[Container,rkt,Bundle]
 
 Pacemaker supports a special syntax for launching a
 https://en.wikipedia.org/wiki/Operating-system-level_virtualization[container]
@@ -1011,7 +1009,7 @@ association with Docker, Inc. is implied.]
 ====
 
 === Bundle Prerequisites ===
-indexterm:[bundle,prerequisites]
+indexterm:[Resource,Bundle,Prerequisites]
 
 Before configuring a bundle in Pacemaker, the user must install the appropriate
 container launch technology (Docker, podman, or rkt), and supply a fully
@@ -1024,89 +1022,119 @@ installed on every node allowed to run the bundle.
 
 === Bundle Properties ===
 
-.Properties of a Bundle
+indexterm:[XML element,bundle element]
+
+.XML Attributes of a bundle Element
 [width="95%",cols="3m,<5",options="header",align="center"]
 |=========================================================
 
-|Field
+|Attribute
 |Description
 
 |id
 |A unique name for the bundle (required)
- indexterm:[id,bundle]
- indexterm:[bundle,Property,id]
+ indexterm:[XML attribute,id attribute,bundle element]
+ indexterm:[XML element,bundle element,id attribute]
 
 |description
 |Arbitrary text (not used by Pacemaker)
- indexterm:[description,bundle]
- indexterm:[bundle,Property,description]
+ indexterm:[XML attribute,description attribute,bundle element]
+ indexterm:[XML element,bundle element,description attribute]
 
 |=========================================================
 
-A bundle must contain exactly one +<docker>+, +<podman>+, or +<rkt>+ element.
+A bundle must contain exactly one +docker+, +podman+, or +rkt+ element.
 
 === Bundle Container Properties ===
-indexterm:[container,Properties]
-indexterm:[Docker,Properties]
-indexterm:[podman,Properties]
-indexterm:[rkt,Properties]
+indexterm:[XML element,docker element]
+indexterm:[XML element,podman element]
+indexterm:[XML element,rkt element]
+indexterm:[Resource,Bundle,Container]
 
-.Properties of a Bundle's docker, podman, or rkt Element
+.XML attributes of a docker, podman, or rkt Element
 [width="95%",cols="3m,4,<5",options="header",align="center"]
 |====
 
-|Field
+|Attribute
 |Default
 |Description
 
 |image
 |
 |Container image tag (required)
- indexterm:[image,container]
- indexterm:[container,Property,image]
+ indexterm:[XML attribute,image attribute,docker element]
+ indexterm:[XML element,docker element,image attribute]
+ indexterm:[XML attribute,image attribute,podman element]
+ indexterm:[XML element,podman element,image attribute]
+ indexterm:[XML attribute,image attribute,rkt element]
+ indexterm:[XML element,rkt element,image attribute]
 
 |replicas
 |Value of +promoted-max+ if that is positive, else 1
 |A positive integer specifying the number of container instances to launch
- indexterm:[replicas,container]
- indexterm:[container,Property,replicas]
+ indexterm:[XML attribute,replicas attribute,docker element]
+ indexterm:[XML element,docker element,replicas attribute]
+ indexterm:[XML attribute,replicas attribute,podman element]
+ indexterm:[XML element,podman element,replicas attribute]
+ indexterm:[XML attribute,replicas attribute,rkt element]
+ indexterm:[XML element,rkt element,replicas attribute]
 
 |replicas-per-host
 |1
 |A positive integer specifying the number of container instances allowed to run
  on a single node
- indexterm:[replicas-per-host,container]
- indexterm:[container,Property,replicas-per-host]
+ indexterm:[XML attribute,replicas-per-host attribute,docker element]
+ indexterm:[XML element,docker element,replicas-per-host attribute]
+ indexterm:[XML attribute,replicas-per-host attribute,podman element]
+ indexterm:[XML element,podman element,replicas-per-host attribute]
+ indexterm:[XML attribute,replicas-per-host attribute,rkt element]
+ indexterm:[XML element,rkt element,replicas-per-host attribute]
 
 |promoted-max
 |0
 |A non-negative integer that, if positive, indicates that the containerized
  service should be treated as a promotable service, with this many replicas
  allowed to run the service in the master role
- indexterm:[promoted-max,container]
- indexterm:[container,Property,promoted-max]
+ indexterm:[XML attribute,promoted-max attribute,docker element]
+ indexterm:[XML element,docker element,promoted-max attribute]
+ indexterm:[XML attribute,promoted-max attribute,podman element]
+ indexterm:[XML element,podman element,promoted-max attribute]
+ indexterm:[XML attribute,promoted-max attribute,rkt element]
+ indexterm:[XML element,rkt element,promoted-max attribute]
 
 |network
 |
 |If specified, this will be passed to the `docker run`, `podman run`, or
  `rkt run` command as the network setting for the container.
- indexterm:[network,container]
- indexterm:[container,Property,network]
+ indexterm:[XML attribute,network attribute,docker element]
+ indexterm:[XML element,docker element,network attribute]
+ indexterm:[XML attribute,network attribute,podman element]
+ indexterm:[XML element,podman element,network attribute]
+ indexterm:[XML attribute,network attribute,rkt element]
+ indexterm:[XML element,rkt element,network attribute]
 
 |run-command
 |`/usr/sbin/pacemaker-remoted` if bundle contains a +primitive+, otherwise none
 |This command will be run inside the container when launching it ("PID 1"). If
  the bundle contains a +primitive+, this command 'must' start pacemaker-remoted
  (but could, for example, be a script that does other stuff, too).
- indexterm:[run-command,container]
- indexterm:[container,Property,run-command]
+ indexterm:[XML attribute,run-command attribute,docker element]
+ indexterm:[XML element,docker element,run-command attribute]
+ indexterm:[XML attribute,run-command attribute,podman element]
+ indexterm:[XML element,podman element,run-command attribute]
+ indexterm:[XML attribute,run-command attribute,rkt element]
+ indexterm:[XML element,rkt element,run-command attribute]
 
 |options
 |
 |Extra command-line options to pass to the `docker run`, `podman run`, or
  `rkt run` command
- indexterm:[options,container]
- indexterm:[container,Property,options]
+ indexterm:[XML attribute,options attribute,docker element]
+ indexterm:[XML element,docker element,options attribute]
+ indexterm:[XML attribute,options attribute,podman element]
+ indexterm:[XML element,podman element,options attribute]
+ indexterm:[XML attribute,options attribute,rkt element]
+ indexterm:[XML element,rkt element,options attribute]
 
 |====
 
@@ -1125,13 +1153,14 @@ to +/usr/sbin/pacemaker_remoted+ (note the underbar instead of dash).
 === Bundle Network Properties ===
 
 A bundle may optionally contain one +<network>+ element.
-indexterm:[bundle,network]
+indexterm:[XML element,network element]
+indexterm:[Resource,Bundle,Networking]
 
-.Properties of a Bundle's Network Element
+.XML attributes of a network Element
 [width="95%",cols="2m,1,<4",options="header",align="center"]
 |=========================================================
 
-|Field
+|Attribute
 |Default
 |Description
 
@@ -1140,8 +1169,8 @@ indexterm:[bundle,network]
 |If TRUE, and +ip-range-start+ is used, Pacemaker will automatically ensure
  that +/etc/hosts+ inside the containers has entries for each
  <<s-resource-bundle-note-replica-names,replica name>> and its assigned IP.
- indexterm:[add-host,network]
- indexterm:[network,Property,add-host]
+ indexterm:[XML element,add-host attribute,network element]
+ indexterm:[XML attribute,network element,add-host attribute]
 
 |ip-range-start
 |
@@ -1151,22 +1180,22 @@ indexterm:[bundle,network]
  from the host's network to reach the service inside the container, though
  it is not visible within the container itself. Only IPv4 addresses are
  currently supported.
- indexterm:[ip-range-start,network]
- indexterm:[network,Property,ip-range-start]
+ indexterm:[XML element,ip-range-start attribute,network element]
+ indexterm:[XML attribute,network element,ip-range-start attribute]
 
 |host-netmask
 |32
 |If +ip-range-start+ is specified, the IP addresses are created with this
  CIDR netmask (as a number of bits).
- indexterm:[host-netmask,network]
- indexterm:[network,Property,host-netmask]
+ indexterm:[XML element,host-netmask attribute,network element]
+ indexterm:[XML attribute,network element,host-netmask attribute]
 
 |host-interface
 |
 |If +ip-range-start+ is specified, the IP addresses are created on this
  host interface (by default, it will be determined from the IP address).
- indexterm:[host-interface,network]
- indexterm:[network,Property,host-interface]
+ indexterm:[XML element,host-interface attribute,network element]
+ indexterm:[XML attribute,network element,host-interface attribute]
 
 |control-port
 |3121
@@ -1178,8 +1207,8 @@ indexterm:[bundle,network]
  bundle may run on a Pacemaker Remote node that is already listening on the
  default port. Any PCMK_remote_port environment variable set on the host or in
  the container is ignored for bundle connections.
- indexterm:[control-port,network]
- indexterm:[network,Property,control-port]
+ indexterm:[XML element,control-port attribute,network element]
+ indexterm:[XML attribute,network element,control-port attribute]
 
 |=========================================================
 
@@ -1191,23 +1220,23 @@ with zero. For example, if a bundle named +httpd-bundle+ has +replicas=2+, its
 containers will be named +httpd-bundle-0+ and +httpd-bundle-1+.
 ====
 
-Additionally, a +<network>+ element may optionally contain one or more
-+<port-mapping>+ elements.
-indexterm:[bundle,network,port-mapping]
+Additionally, a +network+ element may optionally contain one or more
++port-mapping+ elements.
+indexterm:[XML element,port-mapping]
 
-.Properties of a Bundle's Port-Mapping Element
+.Attributes of a port-mapping Element
 [width="95%",cols="2m,1,<4",options="header",align="center"]
 |=========================================================
 
-|Field
+|Attribute
 |Default
 |Description
 
 |id
 |
 |A unique name for the port mapping (required)
- indexterm:[id,port-mapping]
- indexterm:[port-mapping,Property,id]
+ indexterm:[XML attribute,id attribute,port-mapping element]
+ indexterm:[XML element,port-mapping element,id attribute]
 
 |port
 |
@@ -1215,15 +1244,15 @@ indexterm:[bundle,network,port-mapping]
  (on the container's assigned IP address, if +ip-range-start+ is specified)
  will be forwarded to the container network. Exactly one of +port+ or +range+
  must be specified in a +port-mapping+.
- indexterm:[port,port-mapping]
- indexterm:[port-mapping,Property,port]
+ indexterm:[XML attribute,port attribute,port-mapping element]
+ indexterm:[XML element,port-mapping element,port attribute]
 
 |internal-port
 |value of +port+
 |If +port+ and this are specified, connections to +port+ on the host's network
  will be forwarded to this port on the container network.
- indexterm:[internal-port,port-mapping]
- indexterm:[port-mapping,Property,internal-port]
+ indexterm:[XML attribute,internal-port attribute,port-mapping element]
+ indexterm:[XML element,port-mapping element,internal-port attribute]
 
 |range
 |
@@ -1232,8 +1261,8 @@ indexterm:[bundle,network,port-mapping]
  address, if +ip-range-start+ is specified) will be forwarded to the same ports
  in the container network. Exactly one of +port+ or +range+ must be specified
  in a +port-mapping+.
- indexterm:[range,port-mapping]
- indexterm:[port-mapping,Property,range]
+ indexterm:[XML attribute,range attribute,port-mapping element]
+ indexterm:[XML element,port-mapping element,range attribute]
 
 |=========================================================
 
@@ -1244,34 +1273,37 @@ If the bundle contains a +primitive+, Pacemaker will automatically map the
 +port-mapping+.
 ====
 
+[[s-bundle-storage]]
 === Bundle Storage Properties ===
 
-A bundle may optionally contain one +<storage>+ element. A +<storage>+ element
-has no properties of its own, but may contain one or more +<storage-mapping>+
+A bundle may optionally contain one +storage+ element. A +storage+ element
+has no properties of its own, but may contain one or more +storage-mapping+
 elements.
-indexterm:[bundle,storage,storage-mapping]
+indexterm:[XML element,storage element]
+indexterm:[XML element,storage-mapping element]
+indexterm:[Resource,Bundle,Storage]
 
-.Properties of a Bundle's Storage-Mapping Element
+.Attributes of a storage-mapping Element
 [width="95%",cols="2m,1,<4",options="header",align="center"]
 |=========================================================
 
-|Field
+|Attribute
 |Default
 |Description
 
 |id
 |
 |A unique name for the storage mapping (required)
- indexterm:[id,storage-mapping]
- indexterm:[storage-mapping,Property,id]
+ indexterm:[XML attribute,id attribute,storage-mapping element]
+ indexterm:[XML element,storage-mapping element,id attribute]
 
 |source-dir
 |
 |The absolute path on the host's filesystem that will be mapped into the
  container. Exactly one of +source-dir+ and +source-dir-root+ must be specified
  in a +storage-mapping+.
- indexterm:[source-dir,storage-mapping]
- indexterm:[storage-mapping,Property,source-dir]
+ indexterm:[XML attribute,source-dir attribute,storage-mapping element]
+ indexterm:[XML element,storage-mapping element,source-dir attribute]
 
 |source-dir-root
 |
@@ -1281,22 +1313,22 @@ indexterm:[bundle,storage,storage-mapping]
  <<s-resource-bundle-note-replica-names,replica name>>.
  Exactly one of +source-dir+ and +source-dir-root+ must be specified in a
  +storage-mapping+.
- indexterm:[source-dir-root,storage-mapping]
- indexterm:[storage-mapping,Property,source-dir-root]
+ indexterm:[XML attribute,source-dir-root attribute,storage-mapping element]
+ indexterm:[XML element,storage-mapping element,source-dir-root attribute]
 
 |target-dir
 |
 |The path name within the container where the host storage will be mapped
  (required)
- indexterm:[target-dir,storage-mapping]
- indexterm:[storage-mapping,Property,target-dir]
+ indexterm:[XML attribute,target-dir attribute,storage-mapping element]
+ indexterm:[XML element,storage-mapping element,target-dir attribute]
 
 |options
 |
 |A comma-separated list of file system mount options to use when mapping the
  storage
- indexterm:[options,storage-mapping]
- indexterm:[storage-mapping,Property,options]
+ indexterm:[XML attribute,options attribute,storage-mapping element]
+ indexterm:[XML element,storage-mapping element,options attribute]
 
 |=========================================================
 
@@ -1333,9 +1365,11 @@ mount that allows the container access.
 
 === Bundle Primitive ===
 
-A bundle may optionally contain one +<primitive>+ resource
-(see <<s-resource-primitive>>). The primitive may have operations,
-instance attributes and meta-attributes defined, as usual.
+indexterm:[Resource,Bundle,Primitive]
+
+A bundle may optionally contain one <<s-resource-primitive,primitive>>
+resource. The primitive may have operations, instance attributes, and
+meta-attributes defined, as usual.
 
 If a bundle contains a primitive resource, the container image must include
 the Pacemaker Remote daemon, and at least one of +ip-range-start+ or
@@ -1345,28 +1379,44 @@ Pacemaker Remote within the container, and monitor and manage the primitive
 resource via Pacemaker Remote.
 
 If the bundle has more than one container instance (replica), the primitive
-resource will function as an implicit clone (see <<s-resource-clone>>) --
-a promotable clone if the bundle has +masters+ greater than zero
-(see <<s-resource-promotable>>).
+resource will function as an implicit <<s-resource-clone,clone>> -- a
+<<s-resource-promotable,promotable clone>> if the bundle has +masters+ greater
+than zero.
  
+[NOTE]
+====
+If you want to pass environment variables to a bundle's Pacemaker Remote
+connection or primitive, you have two options:
+
+* Environment variables whose value is the same regardless of the underlying host
+  may be set using the container element's +options+ attribute.
+* If you want variables to have host-specific values, you can use the
+  <<s-bundle-storage,+storage-mapping+>> element to map a file on the host as
+  +/etc/pacemaker/pcmk-init.env+ in the container. Pacemaker Remote will parse
+  this file as a shell-like format, with variables set as NAME=VALUE, ignoring
+  blank lines and comments starting with "#".
+====
+
 [IMPORTANT]
 ====
 When a bundle has a +primitive+, Pacemaker on all cluster nodes must be able to
 contact Pacemaker Remote inside the bundle's containers.
 
-* The containers must have an accessible network (for example, the `--net=none`
-  Docker or podman option should not be used with a +primitive+).
+* The containers must have an accessible network (for example, +network+ should
+  not be set to "none" with a +primitive+).
 * The default, using a distinct network space inside the container, works in
   combination with +ip-range-start+. Any firewall must allow access from all
   cluster nodes to the +control-port+ on the container IPs.
-* If the container shares the host's network space (for example, by using the
-  `--net=host` Docker or podman option), a unique +control-port+ should be
-  specified for each bundle. Any firewall must allow access from all cluster
-  nodes to the +control-port+ on all cluster and remote node IPs.
+* If the container shares the host's network space (for example, by setting
+  +network+ to "host"), a unique +control-port+ should be specified for each
+  bundle. Any firewall must allow access from all cluster nodes to the
+  +control-port+ on all cluster and remote node IPs.
 ====
 
 [[s-bundle-attributes]]
 === Bundle Node Attributes ===
+
+indexterm:[Resource,Bundle,Node Attributes]
 
 If the bundle has a +primitive+, the primitive's resource agent may want to set
 node attributes such as <<s-promotion-scores,promotion scores>>. However, with
@@ -1396,12 +1446,14 @@ underlying host).
 
 [NOTE]
 ====
-When called by a resource agent, the attrd_updater and crm_attribute commands
-will automatically check those environment variables and set attributes
-appropriately.
+When called by a resource agent, the `attrd_updater` and `crm_attribute`
+commands will automatically check those environment variables and set
+attributes appropriately.
 ====
 
 === Bundle Meta-Attributes ===
+
+indexterm:[Resource,Bundle,Meta-attributes]
 
 Any meta-attribute set on a bundle will be inherited by the bundle's
 primitive and any resources implicitly created by Pacemaker for the bundle.

--- a/doc/Pacemaker_Explained/en-US/Ch-Constraints.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Constraints.txt
@@ -210,8 +210,8 @@ of the above opt-in configuration.
 -------
 <constraints>
     <rsc_location id="loc-1" rsc="Webserver" node="sles-1" score="200"/>
-    <rsc_location id="loc-2-dont-run" rsc="Webserver" node="sles-2" score="-INFINITY"/>
-    <rsc_location id="loc-3-dont-run" rsc="Database" node="sles-1" score="-INFINITY"/>
+    <rsc_location id="loc-2-do-not-run" rsc="Webserver" node="sles-2" score="-INFINITY"/>
+    <rsc_location id="loc-3-do-not-run" rsc="Database" node="sles-1" score="-INFINITY"/>
     <rsc_location id="loc-4" rsc="Database" node="sles-2" score="200"/>
 </constraints>
 -------

--- a/extra/cluster-helper
+++ b/extra/cluster-helper
@@ -19,7 +19,7 @@ function helptext() {
     echo "cluster-helper - A tool for running commands on multiple hosts"
     echo ""
     echo "Attempt to use pdsh, qarsh, or ssh (in that order) to execute commands"
-    echo "on mutiple hosts"
+    echo "on multiple hosts"
     echo ""
     echo "DSH groups can be configured and specified with -g instead of listing"
     echo "the individual hosts every time"

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -17,5 +17,3 @@ noinst_HEADERS	        = config.h 			\
 pkginclude_HEADERS	= crm_config.h
 
 SUBDIRS                 =  crm pcmki
-
-.PHONY: $(ARCHIVE_VERSION)

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -74,6 +74,7 @@ void crm_time_log_alias(int log_level, const char *file, const char *function, i
 crm_time_t *crm_time_parse_duration(const char *duration_str);
 crm_time_t *crm_time_calculate_duration(crm_time_t * dt, crm_time_t * value);
 crm_time_period_t *crm_time_parse_period(const char *period_str);
+void crm_time_free_period(crm_time_period_t *period);
 
 int crm_time_compare(crm_time_t * dt, crm_time_t * rhs);
 

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -46,9 +46,9 @@ typedef struct crm_time_period_s {
  *   Only one of date, time is required
  *   If date or timezone is unspecified, they default to the current one
  *   Supplying NULL results in the current date/time
- *   Dashes may be ommitted from dates
- *   Colons may be ommitted from times and timezones
- *   A timezone of 'Z' denoted UTC time
+ *   Dashes may be omitted from dates
+ *   Colons may be omitted from times and timezones
+ *   A timezone of 'Z' denotes UTC time
  */
 crm_time_t *crm_time_new(const char *string);
 crm_time_t *crm_time_new_undefined(void);

--- a/include/crm/common/iso8601_internal.h
+++ b/include/crm/common/iso8601_internal.h
@@ -35,9 +35,6 @@ void crm_time_hr_free(crm_time_hr_t * hr_dt);
 char *crm_time_format_hr(const char *format, crm_time_hr_t * hr_dt);
 const char *crm_now_string(time_t *when);
 
-crm_time_t *parse_date(const char *date_str); /* in iso8601.c global but
-                                                 not in header */
-
 struct crm_time_us {
     int years;
     int months;                 /* Only for durations */

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -142,7 +142,6 @@ void promotable_colocation_rh(resource_t *lh_rsc, resource_t *rh_rsc,
 
 /* extern resource_object_functions_t resource_variants[]; */
 extern resource_alloc_functions_t resource_class_alloc_functions[];
-gboolean is_active(pe__location_t *cons);
 
 extern gboolean unpack_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set);
 

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -91,7 +91,6 @@ struct crm_graph_s {
     int batch_limit;
     guint network_delay;
     guint stonith_timeout;
-    int transition_timeout;
 
     int fired;
     int pending;

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -14,6 +14,7 @@
 extern "C" {
 #endif
 
+#include <glib.h>
 #include <crm/crm.h>
 #include <crm/msg_xml.h>
 #include <crm/common/xml.h>
@@ -88,8 +89,8 @@ struct crm_graph_s {
     int num_synapses;
 
     int batch_limit;
-    int network_delay;
-    int stonith_timeout;
+    guint network_delay;
+    guint stonith_timeout;
     int transition_timeout;
 
     int fired;

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -769,7 +769,15 @@ cib_file_perform_op_delegate(cib_t * cib, const char *op, const char *host, cons
     static int max_msg_types = DIMOF(cib_file_ops);
     cib_file_opaque_t *private = cib->variant_opaque;
 
-    crm_info("%s on %s", op, section);
+#if ENABLE_ACL
+    crm_info("Handling %s operation for %s as %s",
+             (op? op : "invalid"), (section? section : "entire CIB"),
+             (user_name? user_name : "default user"));
+#else
+    crm_info("Handling %s operation for %s",
+             (op? op : "invalid"), (section? section : "entire CIB"));
+#endif
+
     call_options |= (cib_no_mtime | cib_inhibit_bcast | cib_scope_local);
 
     if (cib->state == cib_disconnected) {
@@ -802,7 +810,6 @@ cib_file_perform_op_delegate(cib_t * cib, const char *op, const char *host, cons
     if(user_name) {
         crm_xml_add(request, XML_ACL_TAG_USER, user_name);
     }
-    crm_trace("Performing %s operation as %s", op, user_name);
 #endif
 
     /* Mirror the logic in cib_prepare_common() */

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -60,10 +60,10 @@ pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts) {
 
     GOptionEntry main_entries[3] = {
         { "version", '$', 0, G_OPTION_ARG_NONE, &(common_args->version),
-          "Display version information and exit.",
+          "Display software version and exit",
           NULL },
         { "verbose", 'V', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, bump_verbosity,
-          "Increase debug output (may be specified multiple times).",
+          "Increase debug output (may be specified multiple times)",
           NULL },
 
         { NULL }
@@ -83,12 +83,12 @@ pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts) {
               NULL,
               "FORMAT" },
             { "output-to", 0, 0, G_OPTION_ARG_STRING, &(common_args->output_dest),
-              "Specify the destination for output, \"-\" for stdout or a filename.", "DEST" },
+              "Specify file name for output (or \"-\" for stdout)", "DEST" },
 
             { NULL }
         };
 
-        output_main_entries[0].description = crm_strdup_printf("Specify the format for output, one of: %s", fmts);
+        output_main_entries[0].description = crm_strdup_printf("Specify output format as one of: %s", fmts);
         g_option_context_add_main_entries(context, output_main_entries, NULL);
     }
 

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -17,6 +17,7 @@
 #include <crm/crm.h>
 #include <time.h>
 #include <ctype.h>
+#include <string.h>
 #include <stdbool.h>
 #include <crm/common/iso8601.h>
 #include <crm/common/iso8601_internal.h>
@@ -851,13 +852,11 @@ parse_date(const char *date_str)
   parse_time:
 
     if (time_s == NULL) {
-        // @TODO look immediately after date spec rather than anywhere
-        time_s = strstr(date_str, " ");
-        if (time_s == NULL) {
-            time_s = strstr(date_str, "T");
-        }
-        if (time_s != NULL) {
+        time_s = date_str + strspn(date_str, "0123456789-W");
+        if ((time_s[0] == ' ') || (time_s[0] == 'T')) {
             ++time_s;
+        } else {
+            time_s = NULL;
         }
     }
     if ((time_s != NULL) && (crm_time_parse(time_s, dt) == FALSE)) {

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -294,12 +294,12 @@ crm_time_get_seconds(crm_time_t * dt)
         in_seconds += 60 * 60 * 24 * dmax;
     }
 
-    /* utc->months is an offset that can only be set for a duration
-     * By definiton, the value is variable depending on the date to
-     * which it is applied
+    /* utc->months is an offset that can only be set for a duration.
+     * By definition, the value is variable depending on the date to
+     * which it is applied.
      *
      * Force 30-day months so that something vaguely sane happens
-     * for anyone that tries to use a month in this way
+     * for anyone that tries to use a month in this way.
      */
     if (utc->months > 0) {
         in_seconds += 60 * 60 * 24 * 30 * utc->months;

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -60,7 +60,7 @@ gboolean check_for_ordinal(const char *str);
 static crm_time_t *
 crm_get_utc_time(crm_time_t * dt)
 {
-    crm_time_t *utc = calloc(1, sizeof(crm_time_t));
+    crm_time_t *utc = crm_time_new_undefined();
 
     utc->years = dt->years;
     utc->days = dt->days;
@@ -90,7 +90,7 @@ crm_time_new(const char *date_time)
     tzset();
     if (date_time == NULL) {
         tm_now = time(NULL);
-        dt = calloc(1, sizeof(crm_time_t));
+        dt = crm_time_new_undefined();
         crm_time_set_timet(dt, &tm_now);
     } else {
         dt = parse_date(date_time);
@@ -108,7 +108,10 @@ crm_time_new(const char *date_time)
 crm_time_t *
 crm_time_new_undefined()
 {
-    return calloc(1, sizeof(crm_time_t));
+    crm_time_t *result = calloc(1, sizeof(crm_time_t));
+
+    CRM_ASSERT(result != NULL);
+    return result;
 }
 
 /*!
@@ -637,7 +640,7 @@ crm_time_parse(const char *time_str, crm_time_t * a_time)
 
     tzset();
     if (a_time == NULL) {
-        dt = calloc(1, sizeof(crm_time_t));
+        dt = crm_time_new_undefined();
     }
 
     if (time_str) {
@@ -682,7 +685,7 @@ parse_date(const char *date_str)
         goto done;
 
     } else {
-        dt = calloc(1, sizeof(crm_time_t));
+        dt = crm_time_new_undefined();
     }
 
     if (safe_str_eq("epoch", date_str)) {
@@ -856,7 +859,7 @@ crm_time_parse_duration(const char *period_s)
     CRM_CHECK(period_s[0] == 'P', goto bail);
     period_s++;
 
-    diff = calloc(1, sizeof(crm_time_t));
+    diff = crm_time_new_undefined();
 
     while (isspace((int)period_s[0]) == FALSE) {
         int an_int = 0, rc;
@@ -929,6 +932,7 @@ crm_time_parse_period(const char *period_str)
 
     tzset();
     period = calloc(1, sizeof(crm_time_period_t));
+    CRM_ASSERT(period != NULL);
 
     if (period_str[0] == 'P') {
         period->diff = crm_time_parse_duration(period_str);
@@ -1071,7 +1075,7 @@ crm_time_add(crm_time_t * dt, crm_time_t * value)
 
     CRM_CHECK(dt != NULL && value != NULL, return NULL);
 
-    answer = calloc(1, sizeof(crm_time_t));
+    answer = crm_time_new_undefined();
     crm_time_set(answer, dt);
 
     utc = crm_get_utc_time(value);
@@ -1116,7 +1120,7 @@ crm_time_subtract(crm_time_t * dt, crm_time_t * value)
 
     CRM_CHECK(dt != NULL && value != NULL, return NULL);
 
-    answer = calloc(1, sizeof(crm_time_t));
+    answer = crm_time_new_undefined();
     crm_time_set(answer, dt);
     utc = crm_get_utc_time(value);
 
@@ -1326,16 +1330,15 @@ crm_time_hr_convert(crm_time_hr_t *target, crm_time_t *dt)
 
     if (dt) {
         hr_dt = target?target:calloc(1, sizeof(crm_time_hr_t));
-        if (hr_dt) {
-            *hr_dt = (crm_time_hr_t) {
-                .years = dt->years,
-                .months = dt->months,
-                .days = dt->days,
-                .seconds = dt->seconds,
-                .offset = dt->offset,
-                .duration = dt->duration
-            };
-        }
+        CRM_ASSERT(hr_dt != NULL);
+        *hr_dt = (crm_time_hr_t) {
+            .years = dt->years,
+            .months = dt->months,
+            .days = dt->days,
+            .seconds = dt->seconds,
+            .offset = dt->offset,
+            .duration = dt->duration
+        };
     }
 
     return hr_dt;

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -999,6 +999,22 @@ crm_time_parse_period(const char *period_str)
     return period;
 }
 
+/*!
+ * \brief Free a dynamically allocated time period object
+ *
+ * \param[in] period  Time period to free
+ */
+void
+crm_time_free_period(crm_time_period_t *period)
+{
+    if (period) {
+        crm_time_free(period->start);
+        crm_time_free(period->end);
+        crm_time_free(period->diff);
+        free(period);
+    }
+}
+
 void
 crm_time_set(crm_time_t * target, crm_time_t * source)
 {

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -46,13 +46,14 @@
 #define HOUR_SECONDS    (60 * 60)
 #define DAY_SECONDS     (HOUR_SECONDS * 24)
 
+// A date/time or duration
 struct crm_time_s {
-    int years;
-    int months;                 /* Only for durations */
-    int days;
-    int seconds;
-    int offset;                 /* Seconds */
-    bool duration;
+    int years;      // Calendar year (date/time) or number of years (duration)
+    int months;     // Number of months (duration only)
+    int days;       // Ordinal day of year (date/time) or number of days (duration)
+    int seconds;    // Seconds of day (date/time) or number of seconds (duration)
+    int offset;     // Seconds offset from UTC (date/time only)
+    bool duration;  // True if duration
 };
 
 char *crm_time_as_string(crm_time_t * date_time, int flags);
@@ -1347,23 +1348,29 @@ crm_time_compare(crm_time_t * a, crm_time_t * b)
     return rc;
 }
 
+/*!
+ * \brief Add a given number of seconds to a date/time or duration
+ *
+ * \param[in] a_time  Date/time or duration to add seconds to
+ * \param[in] extra   Number of seconds to add
+ */
 void
-crm_time_add_seconds(crm_time_t * a_time, int extra)
+crm_time_add_seconds(crm_time_t *a_time, int extra)
 {
     int days = 0;
 
-    crm_trace("Adding %d seconds to %d (max=%d)", extra, a_time->seconds, DAY_SECONDS);
-
+    crm_trace("Adding %d seconds to %d (max=%d)",
+              extra, a_time->seconds, DAY_SECONDS);
     a_time->seconds += extra;
-    while (a_time->seconds >= DAY_SECONDS) {
-        a_time->seconds -= DAY_SECONDS;
-        days++;
+    days = a_time->seconds / DAY_SECONDS;
+    a_time->seconds %= DAY_SECONDS;
+
+    // Don't have negative seconds
+    if (a_time->seconds < 0) {
+        a_time->seconds += DAY_SECONDS;
+        --days;
     }
 
-    while (a_time->seconds < 0) {
-        a_time->seconds += DAY_SECONDS;
-        days--;
-    }
     crm_time_add_days(a_time, days);
 }
 

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -748,8 +748,8 @@ parse_date(const char *date_str)
 
     dt = crm_time_new_undefined();
 
-    // @TODO This does not handle "epoch" as a period start (e.g. "epoch/P1S")
-    if (safe_str_eq("epoch", date_str)) {
+    if (!strncasecmp("epoch", date_str, 5)
+        && ((date_str[5] == '\0') || (date_str[5] == '/') || isspace(date_str[5]))) {
         dt->days = 1;
         dt->years = 1970;
         crm_time_log(LOG_TRACE, "Unpacked", dt, crm_time_log_date | crm_time_log_timeofday);

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -53,7 +53,7 @@ struct crm_time_s {
 };
 
 char *crm_time_as_string(crm_time_t * date_time, int flags);
-crm_time_t *parse_date(const char *date_str);
+static crm_time_t *parse_date(const char *date_str);
 
 gboolean check_for_ordinal(const char *str);
 
@@ -718,7 +718,7 @@ crm_time_parse(const char *time_str, crm_time_t *a_time)
  *
  * \return New time object on success, NULL (and set errno) otherwise
  */
-crm_time_t *
+static crm_time_t *
 parse_date(const char *date_str)
 {
     const char *time_s = NULL;

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -453,7 +453,8 @@ crm_duration_as_string(crm_time_t *dt, char *result)
                            dt->days, s_if_plural(dt->days));
     }
 
-    if ((dt->seconds != 0) && (dt->seconds > -60) && (dt->seconds < 60)) {
+    if (((offset == 0) || (dt->seconds != 0))
+        && (dt->seconds > -60) && (dt->seconds < 60)) {
         offset += snprintf(result + offset, DATE_MAX - offset, "%d second%s",
                            dt->seconds, s_if_plural(dt->seconds));
     } else if (dt->seconds) {
@@ -965,6 +966,7 @@ crm_time_parse_duration(const char *period_s)
     }
 
     diff = crm_time_new_undefined();
+    diff->duration = TRUE;
 
     for (const char *current = period_s + 1;
          current[0] && (current[0] != '/') && !isspace(current[0]);

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -467,7 +467,7 @@ crm_compress_string(const char *data, int length, int max, char **result, unsign
 
     crm_trace("Compressed %d bytes into %d (ratio %d:1) in %.0fms",
              length, *result_len, length / (*result_len),
-             difftime (after_t.tv_sec, before_t.tv_sec) * 1000 +
+             (after_t.tv_sec - before_t.tv_sec) * 1000 +
              (after_t.tv_nsec - before_t.tv_nsec) / 1e6);
 #else
     crm_trace("Compressed %d bytes into %d (ratio %d:1)",

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -556,8 +556,13 @@ crm_parse_interval_spec(const char *input)
     } else {
         crm_time_t *period_s = crm_time_parse_duration(input);
 
-        msec = 1000 * crm_time_get_seconds(period_s);
-        crm_time_free(period_s);
+        if (period_s) {
+            msec = 1000 * crm_time_get_seconds(period_s);
+            crm_time_free(period_s);
+        } else {
+            // Reason why not valid has already been logged
+            crm_warn("Using 0 instead of '%s'", input);
+        }
     }
 
     return (msec <= 0)? 0 : ((msec >= G_MAXUINT)? G_MAXUINT : (guint) msec);

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -3038,9 +3038,3 @@ unpack_rsc_ticket(xmlNode * xml_obj, pe_working_set_t * data_set)
 
     return TRUE;
 }
-
-gboolean
-is_active(pe__location_t *cons)
-{
-    return TRUE;
-}

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -2174,10 +2174,6 @@ native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
         pe_rsc_debug(rsc, "Constraint (%s) is not active (role : %s vs. %s)",
                      constraint->id, role2text(constraint->role_filter), role2text(rsc->next_role));
         return;
-
-    } else if (is_active(constraint) == FALSE) {
-        pe_rsc_trace(rsc, "Constraint (%s) is not active", constraint->id);
-        return;
     }
 
     if (constraint->node_list_rh == NULL) {

--- a/lib/pacemaker/pcmk_trans_unpack.c
+++ b/lib/pacemaker/pcmk_trans_unpack.c
@@ -182,7 +182,6 @@ unpack_graph(xmlNode * xml_graph, const char *reference)
     new_graph->id = -1;
     new_graph->abort_priority = 0;
     new_graph->network_delay = 0;
-    new_graph->transition_timeout = -1;
     new_graph->stonith_timeout = 0;
     new_graph->completion_action = tg_done;
 

--- a/lib/pacemaker/pcmk_trans_unpack.c
+++ b/lib/pacemaker/pcmk_trans_unpack.c
@@ -181,9 +181,9 @@ unpack_graph(xmlNode * xml_graph, const char *reference)
 
     new_graph->id = -1;
     new_graph->abort_priority = 0;
-    new_graph->network_delay = -1;
+    new_graph->network_delay = 0;
     new_graph->transition_timeout = -1;
-    new_graph->stonith_timeout = -1;
+    new_graph->stonith_timeout = 0;
     new_graph->completion_action = tg_done;
 
     if (reference) {
@@ -201,13 +201,13 @@ unpack_graph(xmlNode * xml_graph, const char *reference)
         time = crm_element_value(xml_graph, "cluster-delay");
         CRM_CHECK(time != NULL, free(new_graph);
                   return NULL);
-        new_graph->network_delay = crm_get_msec(time);
+        new_graph->network_delay = crm_parse_interval_spec(time);
 
         time = crm_element_value(xml_graph, "stonith-timeout");
         if (time == NULL) {
             new_graph->stonith_timeout = new_graph->network_delay;
         } else {
-            new_graph->stonith_timeout = crm_get_msec(time);
+            new_graph->stonith_timeout = crm_parse_interval_spec(time);
         }
 
         t_id = crm_element_value(xml_graph, "batch-limit");

--- a/lib/pacemaker/pcmk_trans_utils.c
+++ b/lib/pacemaker/pcmk_trans_utils.c
@@ -221,7 +221,7 @@ print_graph(unsigned int log_level, crm_graph_t * graph)
     }
 
     do_crm_log(log_level, "Graph %d with %d actions:"
-               " batch-limit=%d jobs, network-delay=%dms",
+               " batch-limit=%d jobs, network-delay=%ums",
                graph->id, graph->num_actions,
                graph->batch_limit, graph->network_delay);
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -665,8 +665,8 @@ common_unpack(xmlNode * xml_obj, resource_t ** rsc,
     pe_rsc_trace((*rsc), "\tRequired to start: %s%s", value, isdefault?" (default)":"");
     value = g_hash_table_lookup((*rsc)->meta, XML_RSC_ATTR_FAIL_TIMEOUT);
     if (value != NULL) {
-        /* call crm_get_msec() and convert back to seconds */
-        (*rsc)->failure_timeout = (crm_get_msec(value) / 1000);
+        // Stored as seconds
+        (*rsc)->failure_timeout = (int) (crm_parse_interval_spec(value) / 1000);
     }
 
     if (remote_node) {

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -200,7 +200,7 @@ unpack_config(xmlNode * config, pe_working_set_t * data_set)
     set_if_xpath(pe_flag_enable_unfencing, XPATH_ENABLE_UNFENCING, data_set);
 
     value = pe_pref(data_set->config_hash, "stonith-timeout");
-    data_set->stonith_timeout = crm_get_msec(value);
+    data_set->stonith_timeout = (int) crm_parse_interval_spec(value);
     crm_debug("STONITH timeout: %d", data_set->stonith_timeout);
 
     set_config_flag(data_set, "stonith-enabled", pe_flag_stonith_enabled);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1842,7 +1842,7 @@ process_orphan_resource(xmlNode * rsc_entry, node_t * node, pe_working_set_t * d
         print_resource(LOG_TRACE, "Added orphan", rsc, FALSE);
 
         CRM_CHECK(rsc != NULL, return NULL);
-        resource_location(rsc, NULL, -INFINITY, "__orphan_dont_run__", data_set);
+        resource_location(rsc, NULL, -INFINITY, "__orphan_do_not_run__", data_set);
     }
     return rsc;
 }

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1625,7 +1625,7 @@ sort_op_by_callid(gconstpointer a, gconstpointer b)
 
     if (safe_str_eq(a_xml_id, b_xml_id)) {
         /* We have duplicate lrm_rsc_op entries in the status
-         *    section which is unliklely to be a good thing
+         * section which is unlikely to be a good thing
          *    - we can handle it easily enough, but we need to get
          *    to the bottom of why it's happening.
          */

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -89,13 +89,13 @@
 %endif
 
 ## Different distros name certain packages differently
+## (note: corosync libraries also differ, but all provide corosync-devel)
 %if 0%{?suse_version} > 0
 %global pkgname_bzip2_devel libbz2-devel
 %global pkgname_docbook_xsl docbook-xsl-stylesheets
 %global pkgname_gnutls_devel libgnutls-devel
 %global pkgname_shadow_utils shadow
 %global pkgname_procps procps
-%global pkgname_corosync_lib libcorosync
 %global pkgname_glue_libs libglue
 %global pkgname_pcmk_libs lib%{name}3
 %global hacluster_id 90
@@ -108,7 +108,6 @@
 %global pkgname_shadow_utils shadow-utils
 %global pkgname_procps procps-ng
 %global pkgname_publican publican
-%global pkgname_corosync_lib corosynclib
 %global pkgname_glue_libs cluster-glue-libs
 %global pkgname_pcmk_libs %{name}-libs
 %global hacluster_id 189
@@ -277,7 +276,7 @@ BuildRequires: pkgconfig(systemd)
 %endif
 
 Requires:      corosync >= 2.0.0
-BuildRequires: %{pkgname_corosync_lib}-devel >= 2.0.0
+BuildRequires: corosync-devel >= 2.0.0
 
 %if %{with stonithd}
 BuildRequires: %{pkgname_glue_libs}-devel
@@ -405,7 +404,7 @@ Requires:      libuuid-devel%{?_isa} %{?pkgname_libtool_devel_arch}
 Requires:      libxml2-devel%{?_isa} libxslt-devel%{?_isa}
 Requires:      %{pkgname_bzip2_devel}%{?_isa} glib2-devel%{?_isa}
 Requires:      libqb-devel%{?_isa}
-Requires:      %{pkgname_corosync_lib}-devel%{?_isa} >= 2.0.0
+Requires:      corosync-devel >= 2.0.0
 
 %description -n %{pkgname_pcmk_libs}-devel
 Pacemaker is an advanced, scalable High-Availability cluster resource

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -84,6 +84,10 @@
 %endif
 %endif
 
+%if 0%{?fedora} > 22 || 0%{?rhel} > 7
+%global supports_recommends 1
+%endif
+
 ## Different distros name certain packages differently
 %if 0%{?suse_version} > 0
 %global pkgname_bzip2_devel libbz2-devel
@@ -315,7 +319,7 @@ License:       GPLv2+ and LGPLv2+
 Summary:       Command line tools for controlling Pacemaker clusters
 Group:         System Environment/Daemons
 Requires:      %{pkgname_pcmk_libs}%{?_isa} = %{version}-%{release}
-%if 0%{?fedora} > 22 || 0%{?rhel} > 7
+%if 0%{?supports_recommends}
 Recommends:    pcmk-cluster-manager = %{version}-%{release}
 # For crm_report
 Recommends:    tar

--- a/tools/crm_resource_ban.c
+++ b/tools/crm_resource_ban.c
@@ -36,6 +36,14 @@ parse_cli_lifetime(const char *input)
 
     now = crm_time_new(NULL);
     later = crm_time_add(now, duration);
+    if (later == NULL) {
+        CMD_ERR("Unable to add %s to current time", move_lifetime);
+        CMD_ERR("Please report to " PACKAGE_BUGREPORT " as possible bug");
+        crm_time_free(now);
+        crm_time_free(duration);
+        return NULL;
+    }
+
     crm_time_log(LOG_INFO, "now     ", now,
                  crm_time_log_date | crm_time_log_timeofday | crm_time_log_with_timezone);
     crm_time_log(LOG_INFO, "later   ", later,

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -297,13 +297,13 @@ create_dotfile(pe_working_set_t * data_set, const char *dot_file, gboolean all_a
             color = "red";
             font = "purple";
             if (all_actions == FALSE) {
-                goto dont_write;
+                goto do_not_write;
             }
 
         } else if (is_set(action->flags, pe_action_optional)) {
             color = "blue";
             if (all_actions == FALSE) {
-                goto dont_write;
+                goto do_not_write;
             }
 
         } else {
@@ -317,7 +317,7 @@ create_dotfile(pe_working_set_t * data_set, const char *dot_file, gboolean all_a
                 action_name, style, color, font);
         fprintf(dot_strm, "\"%s\" [ style=%s color=\"%s\" fontcolor=\"%s\"]\n",
                 action_name, style, color, font);
-  dont_write:
+  do_not_write:
         free(action_name);
     }
 

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -490,7 +490,7 @@ static struct crm_option long_options[] = {
     
     {"-spacer-",   1, 0, '-', "\nAdvanced Commands:"},
     {"get-attr",   1, 0, 'G', "\tDisplay the named attribute for a ticket"},
-    {"set-attr",   1, 0, 'S', "\tSet the named attribtue for a ticket"},
+    {"set-attr",   1, 0, 'S', "\tSet the named attribute for a ticket"},
     {"delete-attr",1, 0, 'D', "\tDelete the named attribute for a ticket"},
     {"cleanup",    0, 0, 'C', "\t\tDelete all state of a ticket at this cluster site"},
     

--- a/tools/iso8601.c
+++ b/tools/iso8601.c
@@ -30,10 +30,10 @@ static struct crm_option long_options[] = {
       "Parse an ISO 8601 period (interval) with start time (for example, '2005-040/2005-043')"
     },
     { "duration", 1, 0, 'D',
-      "Parse an ISO 8601 duration with start time (for example, '2005-040/P1M')"
+      "Parse an ISO 8601 duration (for example, 'P1M')"
     },
     { "expected", 1, 0, 'E',
-      "Parse an ISO 8601 duration with start time (for example, '2005-040/P1M')"
+      "Exit with error status if result does not match this text. Requires: -n or -d"
     },
     {"-spacer-",0, 0, '-', "\nOutput Modifiers:"},
     {"seconds", 0, 0, 's', "\tShow result as a seconds since 0000-001 00:00:00Z"},

--- a/tools/iso8601.c
+++ b/tools/iso8601.c
@@ -153,7 +153,7 @@ main(int argc, char **argv)
         date_time = crm_time_new(date_time_s);
 
         if (date_time == NULL) {
-            fprintf(stderr, "Invalid date/time specified: %s\n", optarg);
+            fprintf(stderr, "Invalid date/time specified: %s\n", date_time_s);
             crm_exit(CRM_EX_INVALID_PARAM);
         }
         crm_time_log(LOG_TRACE, "Date", date_time,
@@ -177,7 +177,7 @@ main(int argc, char **argv)
         period = crm_time_parse_period(period_s);
 
         if (period == NULL) {
-            fprintf(stderr, "Invalid interval specified: %s\n", optarg);
+            fprintf(stderr, "Invalid interval specified: %s\n", period_s);
             crm_exit(CRM_EX_INVALID_PARAM);
         }
         log_time_period(LOG_TRACE, period,

--- a/tools/iso8601.c
+++ b/tools/iso8601.c
@@ -189,6 +189,11 @@ main(int argc, char **argv)
     if (date_time && duration) {
         crm_time_t *later = crm_time_add(date_time, duration);
 
+        if (later == NULL) {
+            fprintf(stderr, "Unable to calculate ending time of %s plus %s",
+                    date_time_s, duration_s);
+            crm_exit(CRM_EX_SOFTWARE);
+        }
         crm_time_log(LOG_TRACE, "Duration ends at", later,
                      crm_time_ordinal | crm_time_log_date | crm_time_log_timeofday);
         crm_time_log(-1, "Duration ends at", later,

--- a/tools/iso8601.c
+++ b/tools/iso8601.c
@@ -75,7 +75,6 @@ main(int argc, char **argv)
     int print_options = 0;
     crm_time_t *duration = NULL;
     crm_time_t *date_time = NULL;
-    crm_time_period_t *period = NULL;
 
     const char *period_s = NULL;
     const char *duration_s = NULL;
@@ -174,7 +173,7 @@ main(int argc, char **argv)
     }
 
     if (period_s) {
-        period = crm_time_parse_period(period_s);
+        crm_time_period_t *period = crm_time_parse_period(period_s);
 
         if (period == NULL) {
             fprintf(stderr, "Invalid interval specified: %s\n", period_s);
@@ -184,6 +183,7 @@ main(int argc, char **argv)
                         print_options | crm_time_log_date | crm_time_log_timeofday);
         log_time_period(-1, period,
                         print_options | crm_time_log_date | crm_time_log_timeofday);
+        crm_time_free_period(period);
     }
 
     if (date_time && duration) {
@@ -217,12 +217,5 @@ main(int argc, char **argv)
 
     crm_time_free(date_time);
     crm_time_free(duration);
-    if (period) {
-        crm_time_free(period->start);
-        crm_time_free(period->end);
-        crm_time_free(period->diff);
-        free(period);
-    }
-
     crm_exit(exit_code);
 }

--- a/tools/iso8601.c
+++ b/tools/iso8601.c
@@ -24,15 +24,16 @@ static struct crm_option long_options[] = {
 
     {"-spacer-",    0, 0, '-', "\nCommands:"},
     {"now",      0, 0, 'n', "\tDisplay the current date/time"},
-    {"date",     1, 0, 'd', "Parse an ISO8601 date/time.  Eg. '2005-01-20 00:30:00 +01:00' or '2005-040'"},
+    { "date",     1, 0, 'd',
+      "Parse an ISO 8601 date/time (for example, '2019-09-24 00:30:00 +01:00' or '2019-040')"},
     { "period",   1, 0, 'p',
-      "Parse an ISO8601 period (interval) with start time (for example, '2005-040/2005-043')"
+      "Parse an ISO 8601 period (interval) with start time (for example, '2005-040/2005-043')"
     },
     { "duration", 1, 0, 'D',
-      "Parse an ISO8601 duration with start time (for example, '2005-040/P1M')"
+      "Parse an ISO 8601 duration with start time (for example, '2005-040/P1M')"
     },
     { "expected", 1, 0, 'E',
-      "Parse an ISO8601 duration with start time (for example, '2005-040/P1M')"
+      "Parse an ISO 8601 duration with start time (for example, '2005-040/P1M')"
     },
     {"-spacer-",0, 0, '-', "\nOutput Modifiers:"},
     {"seconds", 0, 0, 's', "\tShow result as a seconds since 0000-001 00:00:00Z"},
@@ -40,8 +41,10 @@ static struct crm_option long_options[] = {
     {"local",   0, 0, 'L', "\tShow result as a 'local' date/time"},
     {"ordinal", 0, 0, 'O', "\tShow result as an 'ordinal' date/time"},
     {"week",    0, 0, 'W', "\tShow result as an 'calendar week' date/time"},
-    {"-spacer-",0, 0, '-', "\nFor more information on the ISO8601 standard, see https://en.wikipedia.org/wiki/ISO_8601"},
-    
+    { "-spacer-",0, 0, '-',
+      "\nFor more information on the ISO 8601 standard, see https://en.wikipedia.org/wiki/ISO_8601"
+    },
+
     {0, 0, 0, 0}
 };
 /* *INDENT-ON* */
@@ -81,7 +84,7 @@ main(int argc, char **argv)
 
     crm_log_cli_init("iso8601");
     crm_set_options(NULL, "command [output modifier] ", long_options,
-                    "Display and parse ISO8601 dates and times");
+                    "Display and parse ISO 8601 dates and times");
 
     if (argc < 2) {
         argerr++;

--- a/tools/iso8601.c
+++ b/tools/iso8601.c
@@ -154,7 +154,7 @@ main(int argc, char **argv)
 
         if (date_time == NULL) {
             fprintf(stderr, "Invalid date/time specified: %s\n", optarg);
-            crm_help('?', CRM_EX_USAGE);
+            crm_exit(CRM_EX_INVALID_PARAM);
         }
         crm_time_log(LOG_TRACE, "Date", date_time,
                      crm_time_ordinal | crm_time_log_date | crm_time_log_timeofday);
@@ -167,7 +167,7 @@ main(int argc, char **argv)
 
         if (duration == NULL) {
             fprintf(stderr, "Invalid duration specified: %s\n", duration_s);
-            crm_help('?', CRM_EX_USAGE);
+            crm_exit(CRM_EX_INVALID_PARAM);
         }
         crm_time_log(LOG_TRACE, "Duration", duration, crm_time_log_duration);
         crm_time_log(-1, "Duration", duration, print_options | crm_time_log_duration);
@@ -178,7 +178,7 @@ main(int argc, char **argv)
 
         if (period == NULL) {
             fprintf(stderr, "Invalid interval specified: %s\n", optarg);
-            crm_help('?', CRM_EX_USAGE);
+            crm_exit(CRM_EX_INVALID_PARAM);
         }
         log_time_period(LOG_TRACE, period,
                         print_options | crm_time_log_date | crm_time_log_timeofday);

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -763,7 +763,7 @@ main(int argc, char **argv)
                 free(lists);
 
             } else if (rc != 0) {
-                out->err(out, "List command returned error. rc : %d", rc);
+                out->err(out, "Couldn't list targets: %s", pcmk_strerror(rc));
             }
             break;
         case 'R':


### PR DESCRIPTION
This started as a small PR for trivial fixes for minor unrelated issues found in recent projects.

It grew a significant detour into overhauling the ISO 8601 code when additional issues were found there. The major improvement is in validation of ISO 8601 specifications -- valid specifications that were previously handled wrongly are now handled correctly (e.g. "{date}T{time} {offset}" and "{date}T24:00:00"), and invalid specifications that were handled as (wrong) dates are now rejected (e.g. month/day/hour/minute/second out of range).