### PR TITLE
Document command-line tools in Pacemaker Administration

### DIFF
--- a/doc/Pacemaker_Administration/en-US/Ch-Configuring.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Configuring.txt
@@ -215,65 +215,9 @@ commands, invoke it with the `--help` option.
 ----
 ======
 
-[[s-config-testing-changes]]
-== Testing Your Configuration Changes ==
+See <<s-crm_simulate>> for how to test your changes before committing them to
+the live cluster.
 
-We saw previously how to make a series of changes to a "shadow" copy
-of the configuration.  Before loading the changes back into the
-cluster (e.g. `crm_shadow --commit mytest --force`), it is often
-advisable to simulate the effect of the changes with +crm_simulate+.
-For example:
-      
-----
-# crm_simulate --live-check -VVVVV --save-graph tmp.graph --save-dotfile tmp.dot
-----
-
-This tool uses the same library as the live cluster to show what it
-would have done given the supplied input.  Its output, in addition to
-a significant amount of logging, is stored in two files +tmp.graph+
-and +tmp.dot+. Both files are representations of the same thing: the
-cluster's response to your changes.
-
-The graph file stores the complete transition from the existing cluster state
-to your desired new state, containing a list of all the actions, their
-parameters and their pre-requisites. Because the transition graph is not
-terribly easy to read, the tool also generates a Graphviz
-footnote:[Graph visualization software. See http://www.graphviz.org/ for details.]
-dot-file representing the same information.
-
-For information on the options supported by `crm_simulate`, use
-its `--help` option.
-
-.Interpreting the Graphviz output
- * Arrows indicate ordering dependencies
- * Dashed arrows indicate dependencies that are not present in the transition graph
- * Actions with a dashed border of any color do not form part of the transition graph
- * Actions with a green border form part of the transition graph
- * Actions with a red border are ones the cluster would like to execute but cannot run
- * Actions with a blue border are ones the cluster does not feel need to be executed
- * Actions with orange text are pseudo/pretend actions that the cluster uses to simplify the graph
- * Actions with black text are sent to the executor
- * Resource actions have text of the form pass:[<replaceable>rsc</replaceable>]_pass:[<replaceable>action</replaceable>]_pass:[<replaceable>interval</replaceable>] pass:[<replaceable>node</replaceable>]
- * Any action depending on an action with a red border will not be able to execute. 
- * Loops are _really_ bad. Please report them to the development team. 
-
-=== Small Cluster Transition ===
-
-image::images/Policy-Engine-small.png["An example transition graph as represented by Graphviz",width="16cm",height="6cm",align="center"]      
-
-In the above example, it appears that a new node, *pcmk-2*, has come
-online and that the cluster is checking to make sure *rsc1*, *rsc2*
-and *rsc3* are not already running there (Indicated by the
-*rscN_monitor_0* entries).  Once it did that, and assuming the resources
-were not active there, it would have liked to stop *rsc1* and *rsc2*
-on *pcmk-1* and move them to *pcmk-2*.  However, there appears to be
-some problem and the cluster cannot or is not permitted to perform the
-stop actions which implies it also cannot perform the start actions.
-For some reason the cluster does not want to start *rsc3* anywhere.
-
-=== Complex Cluster Transition ===
-
-image::images/Policy-Engine-big.png["Another, slightly more complex, transition graph that you're not expected to be able to read",width="16cm",height="20cm",align="center"]
 
 == Working with CIB Properties ==
 

--- a/doc/Pacemaker_Administration/en-US/Ch-Configuring.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Configuring.txt
@@ -1,37 +1,35 @@
 :compat-mode: legacy
 = Configuring Pacemaker =
 
-== How Should the Configuration be Updated? ==
-
-=== General Guidelines ===
-
-Pacemaker's configuration (the CIB) is stored in XML format. Cluster
+Pacemaker's configuration, the CIB, is stored in XML format. Cluster
 administrators have multiple options for modifying the configuration either via
 the XML, or at a more abstract (and easier for humans to understand) level.
 
-Pacemaker reacts to configuration changes as soon as they are saved. Most tools
-provide the ability to batch changes together and commit them at once, rather
-than make a series of small changes, which could cause avoid unnecessary
-actions as Pacemaker responds to each change individually.
+Pacemaker reacts to configuration changes as soon as they are saved.
+Pacemaker's command-line tools and most higher-level tools provide the ability
+to batch changes together and commit them at once, rather than make a series of
+small changes, which could cause avoid unnecessary actions as Pacemaker
+responds to each change individually.
 
-Pacemaker keeps track of revisions to the configuration and will reject any
-update that is older than the current revision. Thus, it is a good idea to
-serialize all changes to the configuration. Avoid attempting simultaneous
-changes, whether on the same node or different nodes, and whether manually or
-using some automated configuration tool.
+Pacemaker tracks revisions to the configuration and will reject any update
+older than the current revision. Thus, it is a good idea to serialize all
+changes to the configuration. Avoid attempting simultaneous changes, whether on
+the same node or different nodes, and whether manually or using some automated
+configuration tool.
 
 [NOTE]
 ====
-It is not necessary to update the configuration on all cluster nodes. All
-changes are immediately synchronized to all active members of the cluster. To
+It is not necessary to update the configuration on all cluster nodes. Pacemaker
+immediately synchronizes changes to all active members of the cluster. To
 reduce bandwidth, the cluster only broadcasts the incremental updates that
-result from your changes and uses MD5 checksums to ensure that each copy is
-completely consistent.
+result from your changes and uses checksums to ensure that each copy is
+consistent.
 ====
 
-=== Higher-level Tools ===
 
-Most users will benefit from using higher-level tools that are provided by
+=== Configuration Using Higher-level Tools ===
+
+Most users will benefit from using higher-level tools provided by
 projects separate from Pacemaker. Some of the most commonly used include the
 crm shell, hawk, and pcs. footnote:[For a list, see "Configuration Tools" at
 https://clusterlabs.org/components.html]
@@ -39,10 +37,11 @@ https://clusterlabs.org/components.html]
 See those projects' documentation for details on how to configure Pacemaker
 using them.
 
-=== Pacemaker's Command-Line Tools ===
+=== Configuration Using Pacemaker's Command-Line Tools ===
 
-Most configuration tasks can be performed without needing any XML knowledge,
-using one of the lower-level command-line tools provided with Pacemaker.
+Pacemaker provides lower-level, command-line tools to manage the cluster. Most
+configuration tasks can be performed with these tools, without needing any XML
+knowledge.
 
 To enable STONITH for example, one could run:
 
@@ -70,6 +69,7 @@ See <<s-cibadmin>> for how to edit the CIB using XML.
 See <<s-crm_shadow>> for a way to make a series of changes, then commit them
 all at once to the live cluster.
 
+
 == Working with CIB Properties ==
 
 Although these fields can be written to by the user, in
@@ -84,7 +84,7 @@ for example +admin_epoch+, one should use:
 
 A complete set of CIB properties will look something like this:
 
-.Attributes set for a cib object
+.XML attributes set for a cib element
 ======
 [source,XML]
 -------
@@ -94,6 +94,7 @@ A complete set of CIB properties will look something like this:
    update-client="crm_attribute" have-quorum="1" dc-uuid="1">
 -------
 ======
+
 
 == Querying and Setting Cluster Options ==
 

--- a/doc/Pacemaker_Administration/en-US/Ch-Configuring.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Configuring.txt
@@ -65,6 +65,9 @@ Or, to change the failure threshold of *my-test-rsc*, one can use:
 Examples of using these tools for specific cases will be given throughout this
 document where appropriate. See the man pages for further details.
 
+See <<s-crm_shadow>> for a way to make a series of changes, then commit them
+all at once to the live cluster.
+
 === Editing the CIB Using XML ===
 
 The most flexible tool for modifying the configuration is Pacemaker's
@@ -138,86 +141,6 @@ See the cibadmin man page for more options.
 Never edit the live +cib.xml+ file directly. Pacemaker will detect such changes
 and refuse to use the configuration.
 ====
-
-[[s-config-sandboxes]]
-== Making Configuration Changes in a Sandbox ==
-
-Often it is desirable to preview the effects of a series of changes
-before updating the configuration all at once. For this purpose, we
-have created `crm_shadow` which creates a
-"shadow" copy of the configuration and arranges for all the command
-line tools to use it.
-
-To begin, simply invoke `crm_shadow --create` with
-the name of a configuration to create footnote:[Shadow copies are
-identified with a name, making it possible to have more than one.],
-and follow the simple on-screen instructions.
-
-[WARNING]
-====
-Read this section and the on-screen instructions carefully; failure to do so could
-result in destroying the cluster's active configuration!
-====
-      
-.Creating and displaying the active sandbox
-======
-----
-# crm_shadow --create test
-Setting up shadow instance
-Type Ctrl-D to exit the crm_shadow shell
-shadow[test]: 
-shadow[test] # crm_shadow --which
-test
-----
-======
-
-From this point on, all cluster commands will automatically use the
-shadow copy instead of talking to the cluster's active configuration.
-Once you have finished experimenting, you can either make the
-changes active via the `--commit` option, or discard them using the `--delete`
-option.  Again, be sure to follow the on-screen instructions carefully!
-      
-For a full list of `crm_shadow` options and
-commands, invoke it with the `--help` option.
-
-.Use sandbox to make multiple changes all at once, discard them, and verify real configuration is untouched
-======
-----
- shadow[test] # crm_failcount -r rsc_c001n01 -G
- scope=status  name=fail-count-rsc_c001n01 value=0
- shadow[test] # crm_standby --node c001n02 -v on
- shadow[test] # crm_standby --node c001n02 -G
- scope=nodes  name=standby value=on
-
- shadow[test] # cibadmin --erase --force
- shadow[test] # cibadmin --query
- <cib crm_feature_set="3.0.14" validate-with="pacemaker-3.0" epoch="112" num_updates="2" admin_epoch="0" cib-last-written="Mon Jan  8 23:26:47 2018" update-origin="rhel7-1" update-client="crm_node" update-user="root" have-quorum="1" dc-uuid="1">
-   <configuration>
-     <crm_config/>
-     <nodes/>
-     <resources/>
-     <constraints/>
-   </configuration>
-   <status/>
- </cib>
-  shadow[test] # crm_shadow --delete test --force
-  Now type Ctrl-D to exit the crm_shadow shell
-  shadow[test] # exit
-  # crm_shadow --which
-  No active shadow configuration defined
-  # cibadmin -Q
- <cib crm_feature_set="3.0.14" validate-with="pacemaker-3.0" epoch="110" num_updates="2" admin_epoch="0" cib-last-written="Mon Jan  8 23:26:47 2018" update-origin="rhel7-1" update-client="crm_node" update-user="root" have-quorum="1">
-    <configuration>
-       <crm_config>
-          <cluster_property_set id="cib-bootstrap-options">
-             <nvpair id="cib-bootstrap-1" name="stonith-enabled" value="1"/>
-             <nvpair id="cib-bootstrap-2" name="pe-input-series-max" value="30000"/>
-----
-======
-
-See <<s-crm_simulate>> for how to test your changes before committing them to
-the live cluster.
-
 
 == Working with CIB Properties ==
 

--- a/doc/Pacemaker_Administration/en-US/Ch-Configuring.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Configuring.txt
@@ -65,82 +65,10 @@ Or, to change the failure threshold of *my-test-rsc*, one can use:
 Examples of using these tools for specific cases will be given throughout this
 document where appropriate. See the man pages for further details.
 
+See <<s-cibadmin>> for how to edit the CIB using XML.
+
 See <<s-crm_shadow>> for a way to make a series of changes, then commit them
 all at once to the live cluster.
-
-=== Editing the CIB Using XML ===
-
-The most flexible tool for modifying the configuration is Pacemaker's
-+cibadmin+ command.  With +cibadmin+, you can query, add, remove, update
-or replace any part of the configuration. All changes take effect immediately,
-so there is no need to perform a reload-like operation.
-
-The simplest way of using `cibadmin` is to use it to save the current
-configuration to a temporary file, edit that file with your favorite
-text or XML editor, and then upload the revised configuration.
-      
-.Safely using an editor to modify the cluster configuration
-======
---------
-# cibadmin --query > tmp.xml
-# vi tmp.xml
-# cibadmin --replace --xml-file tmp.xml
---------
-======
-
-Some of the better XML editors can make use of a Relax NG schema to
-help make sure any changes you make are valid.  The schema describing
-the configuration can be found in +pacemaker.rng+, which may be
-deployed in a location such as +/usr/share/pacemaker+ depending on your
-operating system distribution and how you installed the software.
-
-If you want to modify just one section of the configuration, you can
-query and replace just that section to avoid modifying any others.
-      
-.Safely using an editor to modify only the resources section
-======
---------
-# cibadmin --query --scope resources > tmp.xml
-# vi tmp.xml
-# cibadmin --replace --scope resources --xml-file tmp.xml
---------
-======
-
-To quickly delete a part of the configuration, identify the object you wish to
-delete by XML tag and id. For example, you might search the CIB for all
-STONITH-related configuration:
-      
-.Searching for STONITH-related configuration items
-======
-----
-# cibadmin --query | grep stonith
- <nvpair id="cib-bootstrap-options-stonith-action" name="stonith-action" value="reboot"/>
- <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="1"/>
- <primitive id="child_DoFencing" class="stonith" type="external/vmware">
- <lrm_resource id="child_DoFencing:0" type="external/vmware" class="stonith">
- <lrm_resource id="child_DoFencing:0" type="external/vmware" class="stonith">
- <lrm_resource id="child_DoFencing:1" type="external/vmware" class="stonith">
- <lrm_resource id="child_DoFencing:0" type="external/vmware" class="stonith">
- <lrm_resource id="child_DoFencing:2" type="external/vmware" class="stonith">
- <lrm_resource id="child_DoFencing:0" type="external/vmware" class="stonith">
- <lrm_resource id="child_DoFencing:3" type="external/vmware" class="stonith">
-----
-======
-
-If you wanted to delete the +primitive+ tag with id +child_DoFencing+,
-you would run:
-
-----
-# cibadmin --delete --xml-text '<primitive id="child_DoFencing"/>'
-----
-
-See the cibadmin man page for more options.
-
-[IMPORTANT]
-====
-Never edit the live +cib.xml+ file directly. Pacemaker will detect such changes
-and refuse to use the configuration.
-====
 
 == Working with CIB Properties ==
 

--- a/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
@@ -62,6 +62,86 @@ made. The cluster elects a node to be DC as needed. The only significance of
 the choice of DC to an administrator is the fact that its logs will have the
 most information about why decisions were made.
 
+
+[[s-crm_shadow]]
+== Batch Configuration Changes with crm_shadow ==
+indexterm:[Command-line tool,crm_shadow]
+
+Often, it is desirable to preview the effects of a series of configuration
+changes before updating the live configuration all at once. For this purpose,
+`crm_shadow` creates a "shadow" copy of the configuration and arranges for all
+the command-line tools to use it.
+
+To begin, simply invoke `crm_shadow --create` with a name of your choice,
+and follow the simple on-screen instructions. Shadow copies are identified with
+a name to make it possible to have more than one.
+
+[WARNING]
+====
+Read this section and the on-screen instructions carefully; failure to do so could
+result in destroying the cluster's active configuration!
+====
+      
+.Creating and displaying the active sandbox
+======
+----
+# crm_shadow --create test
+Setting up shadow instance
+Type Ctrl-D to exit the crm_shadow shell
+shadow[test]: 
+shadow[test] # crm_shadow --which
+test
+----
+======
+
+From this point on, all cluster commands will automatically use the shadow copy
+instead of talking to the cluster's active configuration. Once you have
+finished experimenting, you can either make the changes active via the
+`--commit` option, or discard them using the `--delete` option. Again, be sure
+to follow the on-screen instructions carefully!
+      
+For a full list of `crm_shadow` options and commands, invoke it with the
+`--help` option.
+
+.Use sandbox to make multiple changes all at once, discard them, and verify real configuration is untouched
+======
+----
+ shadow[test] # crm_failcount -r rsc_c001n01 -G
+ scope=status  name=fail-count-rsc_c001n01 value=0
+ shadow[test] # crm_standby --node c001n02 -v on
+ shadow[test] # crm_standby --node c001n02 -G
+ scope=nodes  name=standby value=on
+
+ shadow[test] # cibadmin --erase --force
+ shadow[test] # cibadmin --query
+ <cib crm_feature_set="3.0.14" validate-with="pacemaker-3.0" epoch="112" num_updates="2" admin_epoch="0" cib-last-written="Mon Jan  8 23:26:47 2018" update-origin="rhel7-1" update-client="crm_node" update-user="root" have-quorum="1" dc-uuid="1">
+   <configuration>
+     <crm_config/>
+     <nodes/>
+     <resources/>
+     <constraints/>
+   </configuration>
+   <status/>
+ </cib>
+  shadow[test] # crm_shadow --delete test --force
+  Now type Ctrl-D to exit the crm_shadow shell
+  shadow[test] # exit
+  # crm_shadow --which
+  No active shadow configuration defined
+  # cibadmin -Q
+ <cib crm_feature_set="3.0.14" validate-with="pacemaker-3.0" epoch="110" num_updates="2" admin_epoch="0" cib-last-written="Mon Jan  8 23:26:47 2018" update-origin="rhel7-1" update-client="crm_node" update-user="root" have-quorum="1">
+    <configuration>
+       <crm_config>
+          <cluster_property_set id="cib-bootstrap-options">
+             <nvpair id="cib-bootstrap-1" name="stonith-enabled" value="1"/>
+             <nvpair id="cib-bootstrap-2" name="pe-input-series-max" value="30000"/>
+----
+======
+
+See the next section, <<s-crm_simulate>>, for how to test your changes before
+committing them to the live cluster.
+
+
 [[s-crm_simulate]]
 == Simulate Cluster Activity with crm_simulate ==
 indexterm:[Command-line tool,crm_simulate]

--- a/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
@@ -367,3 +367,78 @@ see the `crm_simulate` man page for more details.
 This capability is useful when using a shadow CIB to edit the configuration.
 Before committing the changes to the live cluster with `crm_shadow --commit`,
 you can use `crm_simulate` to see how the cluster will react to the changes.
+
+
+[[s-attrd_updater]]
+[[s-crm_attribute]]
+== Manage Node Attributes, Cluster Options and Defaults with crm_attribute and attrd_updater ==
+indexterm:[Command-line tool,attrd_updater]
+indexterm:[Command-line tool,crm_attribute]
+
+`crm_attribute` and `attrd_updater` are confusingly similar tools with subtle
+differences.
+
+`attrd_updater` can query and update node attributes. `crm_attribute` can query
+and update not only node attributes, but also cluster options,
+resource defaults, and operation defaults.
+
+To understand the differences, it helps to understand the various types of node
+attribute.
+
+.Types of Node Attributes
+[width="95%",cols="1,1,1,1,1,1",options="header",align="center"]
+|====
+
+|Type
+|Recorded in CIB?
+|Recorded in attribute manager memory?
+|Survive full cluster restart?
+|Manageable by crm_attribute?
+|Manageable by attrd_updater?
+
+|permanent
+|yes
+|no
+|yes
+|yes
+|no
+
+|transient
+|yes
+|yes
+|no
+|yes
+|yes
+
+|private
+|no
+|yes
+|no
+|no
+|yes
+
+|====
+
+As you can see from the table above, `crm_attribute` can manage permanent and
+transient node attributes, while `attrd_updater` can manage transient and
+private node attributes.
+
+The difference between the two tools lies mainly in 'how' they update node
+attributes: `attrd_updater` always contacts the Pacemaker attribute manager
+directly, while `crm_attribute` will contact the attribute manager only for
+transient node attributes, and will instead modify the CIB directly for
+permanent node attributes (and for transient node attributes when unable to
+contact the attribute manager).
+
+By contacting the attribute manager directly, `attrd_updater` can change
+an attribute's "dampening" (whether changes are immediately flushed to the CIB
+or after a specified amount of time, to minimize disk writes for frequent
+changes), set private node attributes (which are never written to the CIB), and
+set attributes for nodes that don't yet exist.
+
+By modifying the CIB directly, `crm_attribute` can set permanent node
+attributes (which are only in the CIB and not managed by the attribute
+manager), and can be used with saved CIB files and shadow CIBs.
+
+However a transient node attribute is set, it is synchronized between the CIB
+and the attribute manager, on all nodes.

--- a/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
@@ -368,7 +368,6 @@ This capability is useful when using a shadow CIB to edit the configuration.
 Before committing the changes to the live cluster with `crm_shadow --commit`,
 you can use `crm_simulate` to see how the cluster will react to the changes.
 
-
 [[s-attrd_updater]]
 [[s-crm_attribute]]
 == Manage Node Attributes, Cluster Options and Defaults with crm_attribute and attrd_updater ==
@@ -442,3 +441,24 @@ manager), and can be used with saved CIB files and shadow CIBs.
 
 However a transient node attribute is set, it is synchronized between the CIB
 and the attribute manager, on all nodes.
+
+
+== Other Commonly Used Tools ==
+
+Other command-line tools include:
+indexterm:[Command-line tool,crm_failcount]
+indexterm:[Command-line tool,crm_node]
+indexterm:[Command-line tool,crm_report]
+indexterm:[Command-line tool,crm_standby]
+indexterm:[Command-line tool,crm_verify]
+indexterm:[Command-line tool,stonith_admin]
+
+* `crm_failcount`: query or delete resource fail counts
+* `crm_node`: manage cluster nodes
+* `crm_report`: generate a detailed cluster report for bug submissions
+* `crm_resource`: manage cluster resources
+* `crm_standby`: manage standby status of nodes
+* `crm_verify`: validate a CIB
+* `stonith_admin`: manage fencing devices
+
+See the manual pages for details.

--- a/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
@@ -1,7 +1,9 @@
 :compat-mode: legacy
 = Using Pacemaker Command-Line Tools =
 
+[[s-crm_mon]]
 == Monitor a Cluster with crm_mon ==
+indexterm:[Command-line tool,crm_mon]
 
 The `crm_mon` utility displays the current state of an active cluster. It can
 show the cluster status organized by node or by resource, and can be used in
@@ -59,3 +61,152 @@ As mentioned in an earlier chapter, the DC is the node is where decisions are
 made. The cluster elects a node to be DC as needed. The only significance of
 the choice of DC to an administrator is the fact that its logs will have the
 most information about why decisions were made.
+
+[[s-crm_simulate]]
+== Simulate Cluster Activity with crm_simulate ==
+indexterm:[Command-line tool,crm_simulate]
+
+The command-line tool `crm_simulate` shows the results of the same logic
+the cluster itself uses to respond to a particular cluster configuration and
+status.
+
+As always, the man page is the primary documentation, and should be consulted
+for further details. This section aims for a better conceptual explanation and
+practical examples.
+
+=== Replaying cluster decision-making logic ===
+
+At any given time, one node in a Pacemaker cluster will be elected DC, and that
+node will run Pacemaker's scheduler to make decisions.
+
+Each time decisions need to be made (a "transition"), the DC will have log
+messages like "Calculated transition ... saving inputs in ..." with a file
+name. You can grab the named file and replay the cluster logic to see why
+particular decisions were made. The file contains the live cluster
+configuration at that moment, so you can also look at it directly to see the
+value of node attributes, etc., at that time.
+
+The simplest usage is (replacing $FILENAME with the actual file name):
+
+.Simulate cluster response to a given CIB
+====
+----
+crm_simulate --simulate --xml-file $FILENAME
+----
+====
+
+That will show the cluster state when the process started, the actions that
+need to be taken ("Transition Summary"), and the resulting cluster state if the
+actions succeed. Most actions will have a brief description of why they were
+required.
+
+The transition inputs may be compressed. `crm_simulate` can handle these
+compressed files directly, though if you want to edit the file, you'll need to
+uncompress it first.
+
+You can do the same simulation for the live cluster configuration at the
+current moment. This is useful mainly when using `crm_shadow` to create a
+sandbox version of the CIB; the `--live-check` option will use the shadow CIB
+if one is in effect.
+
+.Simulate cluster response to current live CIB or shadow CIB
+====
+----
+crm_simulate --simulate --live-check
+----
+====
+
+
+=== Why decisions were made ===
+
+To get further insight into the "why", it gets user-unfriendly very quickly. If
+you add the `--show-scores` option, you will also see all the scores that went
+into the decision-making. The node with the highest cumulative score for a
+resource will run it. You can look for +-INFINITY+ scores in particular to see
+where complete bans came into effect.
+
+You can also add `-VVVV` to get more detailed messages about what's happening
+under the hood. You can add up to two more V's even, but that's usually useful
+only if you're a masochist or tracing through the source code.
+
+=== Visualizing the action sequence ===
+
+Another handy feature is the ability to generate a visual graph of the actions
+needed, using the `--dot-file` option. This relies on the separate Graphviz
+footnote:[Graph visualization software. See http://www.graphviz.org/ for details.]
+project.
+
+.Generate a visual graph of cluster actions from a saved CIB
+====
+----
+crm_simulate --simulate --xml-file $FILENAME --dot-file $FILENAME.dot
+dot $FILENAME.dot -Tsvg > $FILENAME.svg
+----
+====
+
++$FILENAME.dot+ will contain a GraphViz representation of the cluster's
+response to your changes, including all actions with their ordering
+dependencies.
+
++$FILENAME.svg+ will be the same information in a standard graphical format
+that you can view in your browser or other app of choice. You could, of course,
+use other `dot` options to generate other formats.
+      
+How to interpret the graphical output:
+
+ * Bubbles indicate actions, and arrows indicate ordering dependencies
+ * Resource actions have text of the form
+   pass:[<replaceable>resource</replaceable>]_pass:[<replaceable>action</replaceable>]_pass:[<replaceable>interval</replaceable>]
+   pass:[<replaceable>node</replaceable>] indicating that the specified action
+   will be executed for the specified resource on the specified node, once if
+   interval is 0 or at specified recurring milliseconds interval otherwise
+ * Actions with black text will be sent to the executor (that is, the
+   appropriate agent will be invoked)
+ * Actions with orange text are "pseudo" actions that the cluster uses
+   internally for ordering but require no real activity
+ * Actions with a solid green border are part of the transition (that is, the
+   cluster will attempt to execute them in the given order -- though a
+   transition can be interrupted by action failure or new events)
+ * Dashed arrows indicate dependencies that are not present in the transition
+   graph
+ * Actions with a dashed border will not be executed. If the dashed border is
+   blue, the cluster does not feel the action needs to be executed. If the
+   dashed border is red, the cluster would like to execute the action but
+   cannot. Any actions depending on an action with a dashed border will not be
+   able to execute. 
+ * Loops should not happen, and should be reported as a bug if found.
+
+.Small Cluster Transition
+====
+image::images/Policy-Engine-small.png["An example transition graph as represented by Graphviz",width="1161",height="325",align="center"]      
+====
+
+In the above example, it appears that a new node, *pcmk-2*, has come online and
+that the cluster is checking to make sure *rsc1*, *rsc2* and *rsc3* are not
+already running there (indicated by the *rscN_monitor_0* entries). Once it did
+that, and assuming the resources were not active there, it would have liked to
+stop *rsc1* and *rsc2* on *pcmk-1* and move them to *pcmk-2*. However, there
+appears to be some problem and the cluster cannot or is not permitted to
+perform the stop actions which implies it also cannot perform the start
+actions. For some reason, the cluster does not want to start *rsc3* anywhere.
+
+.Complex Cluster Transition
+====
+image::images/Policy-Engine-big.png["Complex transition graph that you're not expected to be able to read",width="1455",height="1945",align="center"]
+====
+
+=== What-if scenarios ===
+
+You can make changes to the saved or shadow CIB and simulate it again, to see
+how Pacemaker would react differently. You can edit the XML by hand, use
+command-line tools such as `cibadmin` with either a shadow CIB or the
++CIB_file+ environment variable set to the filename, or use higher-level tool
+support (see the man pages of the specific tool you're using for how to perform
+actions on a saved CIB file rather than the live CIB).
+
+You can also inject node failures and/or action failures into the simulation;
+see the `crm_simulate` man page for more details.
+
+This capability is useful when using a shadow CIB to edit the configuration.
+Before committing the changes to the live cluster with `crm_shadow --commit`,
+you can use `crm_simulate` to see how the cluster will react to the changes.

--- a/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
@@ -1,7 +1,7 @@
 :compat-mode: legacy
-= Monitoring a Pacemaker Cluster =
+= Using Pacemaker Command-Line Tools =
 
-== Using crm_mon ==
+== Monitor a Cluster with crm_mon ==
 
 The `crm_mon` utility displays the current state of an active cluster. It can
 show the cluster status organized by node or by resource, and can be used in

--- a/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
@@ -63,6 +63,83 @@ the choice of DC to an administrator is the fact that its logs will have the
 most information about why decisions were made.
 
 
+[[s-cibadmin]]
+== Edit the CIB XML with cibadmin ==
+indexterm:[Command-line tool,cibadmin]
+
+The most flexible tool for modifying the configuration is Pacemaker's
+`cibadmin` command.  With `cibadmin`, you can query, add, remove, update
+or replace any part of the configuration. All changes take effect immediately,
+so there is no need to perform a reload-like operation.
+
+The simplest way of using `cibadmin` is to use it to save the current
+configuration to a temporary file, edit that file with your favorite
+text or XML editor, and then upload the revised configuration.
+      
+.Safely using an editor to modify the cluster configuration
+======
+--------
+# cibadmin --query > tmp.xml
+# vi tmp.xml
+# cibadmin --replace --xml-file tmp.xml
+--------
+======
+
+Some of the better XML editors can make use of a RELAX NG schema to
+help make sure any changes you make are valid.  The schema describing
+the configuration can be found in +pacemaker.rng+, which may be
+deployed in a location such as +/usr/share/pacemaker+ depending on your
+operating system distribution and how you installed the software.
+
+If you want to modify just one section of the configuration, you can
+query and replace just that section to avoid modifying any others.
+      
+.Safely using an editor to modify only the resources section
+======
+--------
+# cibadmin --query --scope resources > tmp.xml
+# vi tmp.xml
+# cibadmin --replace --scope resources --xml-file tmp.xml
+--------
+======
+
+To quickly delete a part of the configuration, identify the object you wish to
+delete by XML tag and id. For example, you might search the CIB for all
+STONITH-related configuration:
+      
+.Searching for STONITH-related configuration items
+======
+----
+# cibadmin --query | grep stonith
+ <nvpair id="cib-bootstrap-options-stonith-action" name="stonith-action" value="reboot"/>
+ <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="1"/>
+ <primitive id="child_DoFencing" class="stonith" type="external/vmware">
+ <lrm_resource id="child_DoFencing:0" type="external/vmware" class="stonith">
+ <lrm_resource id="child_DoFencing:0" type="external/vmware" class="stonith">
+ <lrm_resource id="child_DoFencing:1" type="external/vmware" class="stonith">
+ <lrm_resource id="child_DoFencing:0" type="external/vmware" class="stonith">
+ <lrm_resource id="child_DoFencing:2" type="external/vmware" class="stonith">
+ <lrm_resource id="child_DoFencing:0" type="external/vmware" class="stonith">
+ <lrm_resource id="child_DoFencing:3" type="external/vmware" class="stonith">
+----
+======
+
+If you wanted to delete the +primitive+ tag with id +child_DoFencing+,
+you would run:
+
+----
+# cibadmin --delete --xml-text '<primitive id="child_DoFencing"/>'
+----
+
+See the cibadmin man page for more options.
+
+[IMPORTANT]
+====
+Never edit the live +cib.xml+ file directly. Pacemaker will detect such changes
+and refuse to use the configuration.
+====
+
+
 [[s-crm_shadow]]
 == Batch Configuration Changes with crm_shadow ==
 indexterm:[Command-line tool,crm_shadow]

--- a/doc/Pacemaker_Administration/en-US/Ch-Troubleshooting.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Troubleshooting.txt
@@ -48,7 +48,7 @@ Nov 30 20:28:16 rhel7-1 pacemaker-schedulerd[36417] (process_pe_message)        
 The file listed as the "inputs" is a snapshot of the cluster configuration and
 state at that moment (the CIB). This file can help determine why particular
 actions were scheduled. The `crm_simulate` command, described in
-<<s-config-testing-changes>>, can be used to replay the file.
+<<s-crm_simulate>>, can be used to replay the file.
 
 == Further Information About Troubleshooting ==
 

--- a/doc/Pacemaker_Administration/en-US/Ch-Upgrading.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Upgrading.txt
@@ -325,9 +325,8 @@ You can then view shadow.svg with any compatible image viewer or web browser.
 Verify that either no resource actions will occur or that you are
 happy with any that are scheduled.  If the output contains actions you
 do not expect (possibly due to changes to the score calculations), you
-may need to make further manual changes.  See
-<<s-config-testing-changes>> for further details on how to interpret
-the output of `crm_simulate` and `dot`.
+may need to make further manual changes. See <<s-crm_simulate>> for further
+details on how to interpret the output of `crm_simulate` and `dot`.
 +
 . Upload the changes:
 +

--- a/doc/Pacemaker_Administration/en-US/Pacemaker_Administration.xml
+++ b/doc/Pacemaker_Administration/en-US/Pacemaker_Administration.xml
@@ -10,7 +10,7 @@
     <xi:include href="Ch-Installing.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="Ch-Cluster.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="Ch-Configuring.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
-    <xi:include href="Ch-Monitoring.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
+    <xi:include href="Ch-Tools.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="Ch-Troubleshooting.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="Ch-Upgrading.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="Ch-Agents.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION
This adds a new chapter to the "Pacemaker Administration" document for the command-line tools.

Existing documentation for crm_mon, cibadmin, crm_shadow, and crm_simulate has been moved to the new chapter, and documentation for attrd_updater and crm_attribute have been added. Additionally the ClusterLabs wiki page "Using crm_simulate" has been merged into the crm_simulate section.