### PR TITLE
[1.1] Fix: fencing: Do not block concurrent fencing actions on a device

### DIFF
--- a/include/crm/services.h
+++ b/include/crm/services.h
@@ -156,6 +156,7 @@ enum nagios_exitcode {
 enum svc_action_flags {
     /* On timeout, only kill pid, do not kill entire pid group */
     SVC_ACTION_LEAVE_GROUP = 0x01,
+    SVC_ACTION_NON_BLOCKED = 0x02,
 };
 
 typedef struct svc_action_private_s svc_action_private_t;

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -914,6 +914,7 @@ internal_stonith_action_execute(stonith_action_t * action)
     svc_action->sequence = stonith_sequence++;
     svc_action->params = action->args;
     svc_action->cb_data = (void *) action;
+    set_bit(svc_action->flags, SVC_ACTION_NON_BLOCKED);
 
     /* keep retries from executing out of control and free previous results */
     if (is_retry) {

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -827,7 +827,8 @@ services_action_async_fork_notify(svc_action_t * op,
         g_hash_table_replace(recurring_actions, op->id, op);
     }
 
-    if (op->rsc && is_op_blocked(op->rsc)) {
+    if (is_not_set(op->flags, SVC_ACTION_NON_BLOCKED)
+        && op->rsc && is_op_blocked(op->rsc)) {
         blocked_ops = g_list_append(blocked_ops, op);
         return TRUE;
     }


### PR DESCRIPTION
Backport of #1902 for 1.1 branch.

Switching to common service interface for fencing actions as of
18c321e79 introduced a regression that concurrent fencing actions on a
fencing device would get blocked. The impact would be very obvious for
"slow" fencing mechanisms such as sbd.