### PR TITLE
Low: libcrmservice: don't close descriptors above current limit

### DIFF
--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -13,6 +13,8 @@
 #include <pwd.h>
 #include <grp.h>
 #include <poll.h>
+#include <stdio.h>
+#include <stdbool.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/time.h>
@@ -290,10 +292,8 @@ static char *opts_vgrind[] = { NULL, NULL, NULL, NULL, NULL };
 static gboolean
 start_child(pcmk_child_t * child)
 {
-    int lpc = 0;
     uid_t uid = 0;
     gid_t gid = 0;
-    struct rlimit oflimits;
     gboolean use_valgrind = FALSE;
     gboolean use_callgrind = FALSE;
     const char *devnull = "/dev/null";
@@ -396,11 +396,7 @@ start_child(pcmk_child_t * child)
             crm_perror(LOG_ERR, "Could not set user to %d (%s)", uid, child->uid);
         }
 
-        /* Close all open file descriptors */
-        getrlimit(RLIMIT_NOFILE, &oflimits);
-        for (lpc = 0; lpc < oflimits.rlim_cur; lpc++) {
-            close(lpc);
-        }
+        pcmk__close_fds_in_child(true);
 
         (void)open(devnull, O_RDONLY);  /* Stdin:  fd 0 */
         (void)open(devnull, O_WRONLY);  /* Stdout: fd 1 */

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -13,6 +13,7 @@
 #include <glib.h>       /* for gboolean */
 #include <dirent.h>     /* for struct dirent */
 #include <unistd.h>     /* for getpid() */
+#include <stdbool.h>    /* for bool */
 #include <sys/types.h>  /* for uid_t and gid_t */
 
 #include <crm/common/logging.h>
@@ -32,6 +33,8 @@ char *crm_read_contents(const char *filename);
 int crm_write_sync(int fd, const char *contents);
 int crm_set_nonblocking(int fd);
 const char *crm_get_tmpdir(void);
+
+void pcmk__close_fds_in_child(bool);
 
 
 /* internal procfs utilities (from procfs.c) */

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -444,9 +444,6 @@ services_handle_exec_error(svc_action_t * op, int error)
 static void
 action_launch_child(svc_action_t *op)
 {
-    int lpc;
-    DIR *dir;
-
     /* SIGPIPE is ignored (which is different from signal blocking) by the gnutls library.
      * Depending on the libqb version in use, libqb may set SIGPIPE to be ignored as well. 
      * We do not want this to be inherited by the child process. By resetting this the signal
@@ -476,31 +473,7 @@ action_launch_child(svc_action_t *op)
      */
     setpgid(0, 0);
 
-    // Close all file descriptors except stdin/stdout/stderr
-#if SUPPORT_PROCFS
-    dir = opendir("/proc/self/fd");
-#else
-    dir = opendir("/dev/fd");
-#endif
-    if (dir == NULL) { /* /proc or /dev/fd not available */
-	/* Iterate over all possible fds, might be slow */
-        for (lpc = getdtablesize() - 1; lpc > STDERR_FILENO; lpc--) {
-            close(lpc);
-        }
-    } else {
-        /* Iterate over fds obtained from /proc or /dev/fd */
-        struct dirent *entry;
-        int dir_fd = dirfd(dir);
-
-        while ((entry = readdir(dir)) != NULL) {
-            lpc = atoi(entry->d_name);
-            if (lpc > STDERR_FILENO && lpc != dir_fd) {
-                close(lpc);
-            }
-        }
-
-        closedir(dir);
-    }
+    pcmk__close_fds_in_child(false);
 
 #if SUPPORT_CIBSECRETS
     if (replace_secret_params(op->rsc, op->params) < 0) {


### PR DESCRIPTION
This is irrelevant in normal use. However, valgrind can open high-numbered
file descriptors for its own use above the soft limit of the process being run
under valgrind. If that process forks a child that tries to close all open file
descriptors (e.g. the executor running an agent), the close fails because the
file descriptors are invalid, and (ironically) valgrind warns about that.

This allows 5a73027 to work under valgrind. Additionally, we extend the
efficient close method from that commit to pacemakerd's spawning of children.