### PR TITLE
Fix: libcrmcommon: Enforce NULL in pcmk__html_add_header args.

### DIFF
--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -698,7 +698,8 @@ pcmk__output_create_html_node(pcmk__output_t *out, const char *element_name, con
  * \param[in]     ...    A NULL-terminated key/value list of attributes.
  */
 void
-pcmk__html_add_header(xmlNodePtr parent, const char *name, ...);
+pcmk__html_add_header(xmlNodePtr parent, const char *name, ...)
+G_GNUC_NULL_TERMINATED;
 
 #ifdef __cplusplus
 }

--- a/tools/crm_mon_output.c
+++ b/tools/crm_mon_output.c
@@ -804,7 +804,7 @@ node_text(pcmk__output_t *out, va_list args) {
 static int
 node_xml(pcmk__output_t *out, va_list args) {
     node_t *node = va_arg(args, node_t *);
-    unsigned int mon_ops __attribute__((unused)) = va_arg(args, unsigned int);
+    unsigned int mon_ops G_GNUC_UNUSED = va_arg(args, unsigned int);
     gboolean full = va_arg(args, gboolean);
 
     if (full) {


### PR DESCRIPTION
Using the function attribute means the compiler will check that callers
include a NULL at the end.