### PR TITLE
Put all formatted output command line args into a single group

### DIFF
--- a/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Tools.txt
@@ -16,7 +16,7 @@ command line options for changing the style of the output.  For instance:
 
 ======
 -------
-# crm_mon --help-output-html
+# crm_mon --help-output
 Usage:
   crm_mon [OPTION?]
 
@@ -24,11 +24,13 @@ Provides a summary of cluster's current state.
 
 Outputs varying levels of detail in a number of different formats.
 
-Output Options (html):
-  --output-cgi                      Add text needed to use output in a CGI program
-  --output-meta-refresh=SECONDS     How often to refresh
-  --output-stylesheet-link=URI      Link to an external CSS stylesheet
-  --output-title=TITLE              Page title
+Output Options:
+  --output-as=FORMAT                Specify output format as one of: console (default), html, text, xml
+  --output-to=DEST                  Specify file name for output (or "-" for stdout)
+  --html-cgi                        Add text needed to use output in a CGI program
+  --html-stylesheet=URI             Link to an external CSS stylesheet
+  --html-title=TITLE                Page title
+  --text-fancy                      Use more highly formatted output
 -------
 ======
 
@@ -133,7 +135,7 @@ in the above example is:
 ======
 
 If you want to override some or all of the styling, simply create your own
-stylesheet, place it on a web server, and pass `--output-stylesheet-link=<URL>`
+stylesheet, place it on a web server, and pass `--html-stylesheet=<URL>`
 to `crm_mon`.  The link is added after the default stylesheet, so your
 changes take precedence.  You don't need to duplicate the entire default.
 Only include what you want to change.

--- a/include/crm/common/cmdline_internal.h
+++ b/include/crm/common/cmdline_internal.h
@@ -52,12 +52,15 @@ pcmk__new_common_args(const char *summary);
  *       pcmk__register_formats() as that function adds its own command line
  *       options.
  *
- * \param[in,out] common_args A ::pcmk__common_args_t structure where the
- *                            results of handling command options will be written.
- * \param[in]     fmts        The help string for which formats are supported.
+ * \param[in,out] common_args  A ::pcmk__common_args_t structure where the
+ *                             results of handling command options will be written.
+ * \param[in]     fmts         The help string for which formats are supported.
+ * \param[in,out] output_group A ::GOptionGroup that formatted output related
+ *                             command line arguments should be added to.
  */
 GOptionContext *
-pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts);
+pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts,
+                        GOptionGroup **output_group);
 
 /*!
  * \internal

--- a/include/crm/common/cmdline_internal.h
+++ b/include/crm/common/cmdline_internal.h
@@ -18,6 +18,7 @@ extern "C" {
 
 typedef struct {
     char *summary;
+    char *output_as_descr;
 
     gboolean version;
     gboolean quiet;
@@ -61,6 +62,16 @@ pcmk__new_common_args(const char *summary);
 GOptionContext *
 pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts,
                         GOptionGroup **output_group);
+
+/*!
+ * \internal
+ * \brief Clean up after pcmk__build_arg_context().  This should be called
+ *        instead of ::g_option_context_free at program termination.
+ *
+ * \param[in,out] context Argument context to free
+ */
+void
+pcmk__free_arg_context(GOptionContext *context);
 
 /*!
  * \internal

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -480,8 +480,9 @@ int pcmk__output_new(pcmk__output_t **out, const char *fmt_name,
  * \brief Register a new output formatter, making it available for use
  *        the same as a base formatter.
  *
- * \param[in,out] context A context to add any format-specific options to.  This
- *                        can be NULL for use outside of command line programs.
+ * \param[in,out] group   A ::GOptionGroup that formatted output related command
+ *                        line arguments should be added to.  This can be NULL
+ *                        for use outside of command line programs.
  * \param[in]     name    The name of the format.  This will be used to select a
  *                        format from command line options and for displaying help.
  * \param[in]     create  A function that creates a ::pcmk__output_t.
@@ -491,21 +492,22 @@ int pcmk__output_new(pcmk__output_t **out, const char *fmt_name,
  * \return 0 on success or an error code on error.
  */
 int
-pcmk__register_format(GOptionContext *context, const char *name,
+pcmk__register_format(GOptionGroup *group, const char *name,
                       pcmk__output_factory_t create, GOptionEntry *options);
 
 /*!
  * \internal
  * \brief Register an entire table of output formatters at once.
  *
- * \param[in,out] context A context to add any format-specific options to.  This
- *                        can be NULL for use outside of command line programs.
+ * \param[in,out] group A ::GOptionGroup that formatted output related command
+ *                      line arguments should be added to.  This can be NULL
+ *                      for use outside of command line programs.
  * \param[in]     table An array of ::pcmk__supported_format_t which should
  *                      all be registered.  This array must be NULL-terminated.
  *
  */
 void
-pcmk__register_formats(GOptionContext *context, pcmk__supported_format_t *table);
+pcmk__register_formats(GOptionGroup *group, pcmk__supported_format_t *table);
 
 /*!
  * \internal

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -54,7 +54,8 @@ free_common_args(gpointer data) {
 }
 
 GOptionContext *
-pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts) {
+pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts,
+                        GOptionGroup **output_group) {
     char *desc = crm_strdup_printf("Report bugs to %s\n", PACKAGE_BUGREPORT);
     GOptionContext *context;
     GOptionGroup *main_group;
@@ -79,7 +80,7 @@ pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts) {
     g_option_context_set_main_group(context, main_group);
 
     if (fmts != NULL) {
-        GOptionEntry output_main_entries[3] = {
+        GOptionEntry output_entries[3] = {
             { "output-as", 0, 0, G_OPTION_ARG_STRING, &(common_args->output_ty),
               NULL,
               "FORMAT" },
@@ -89,8 +90,13 @@ pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts) {
             { NULL }
         };
 
-        output_main_entries[0].description = crm_strdup_printf("Specify output format as one of: %s", fmts);
-        g_option_context_add_main_entries(context, output_main_entries, NULL);
+        if (*output_group == NULL) {
+            *output_group = g_option_group_new("output", "Output Options:", "Show output help", NULL, NULL);
+        }
+
+        output_entries[0].description = crm_strdup_printf("Specify output format as one of: %s", fmts);
+        g_option_group_add_entries(*output_group, output_entries);
+        g_option_context_add_group(context, *output_group);
     }
 
     free(desc);

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -50,6 +50,11 @@ free_common_args(gpointer data) {
     free(common_args->summary);
     free(common_args->output_ty);
     free(common_args->output_dest);
+
+    if (common_args->output_as_descr != NULL) {
+        free(common_args->output_as_descr);
+    }
+
     free(common_args);
 }
 
@@ -94,7 +99,8 @@ pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts,
             *output_group = g_option_group_new("output", "Output Options:", "Show output help", NULL, NULL);
         }
 
-        output_entries[0].description = crm_strdup_printf("Specify output format as one of: %s", fmts);
+        common_args->output_as_descr = crm_strdup_printf("Specify output format as one of: %s", fmts);
+        output_entries[0].description = common_args->output_as_descr;
         g_option_group_add_entries(*output_group, output_entries);
         g_option_context_add_group(context, *output_group);
     }
@@ -102,6 +108,15 @@ pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts,
     free(desc);
 
     return context;
+}
+
+void
+pcmk__free_arg_context(GOptionContext *context) {
+    if (context == NULL) {
+        return;
+    }
+
+    g_option_context_free(context);
 }
 
 void

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -74,7 +74,7 @@ pcmk__output_new(pcmk__output_t **out, const char *fmt_name, const char *filenam
 }
 
 int
-pcmk__register_format(GOptionContext *context, const char *name,
+pcmk__register_format(GOptionGroup *group, const char *name,
                       pcmk__output_factory_t create, GOptionEntry *options) {
     if (create == NULL) {
         return -EINVAL;
@@ -84,20 +84,8 @@ pcmk__register_format(GOptionContext *context, const char *name,
         formatters = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, NULL);
     }
 
-    if (options != NULL && context != NULL) {
-        char *group_name = crm_strdup_printf("output-%s", name);
-        char *group_desc = crm_strdup_printf("Output Options (%s):", name);
-        char *group_help = crm_strdup_printf("Show %s output help", name);
-
-        GOptionGroup *group = g_option_group_new(group_name, group_desc,
-                                                 group_help, NULL, NULL);
-
+    if (options != NULL && group != NULL) {
         g_option_group_add_entries(group, options);
-        g_option_context_add_group(context, group);
-
-        free(group_name);
-        free(group_desc);
-        free(group_help);
     }
 
     g_hash_table_insert(formatters, strdup(name), create);
@@ -105,7 +93,7 @@ pcmk__register_format(GOptionContext *context, const char *name,
 }
 
 void
-pcmk__register_formats(GOptionContext *context, pcmk__supported_format_t *formats) {
+pcmk__register_formats(GOptionGroup *group, pcmk__supported_format_t *formats) {
     pcmk__supported_format_t *entry = NULL;
 
     if (formats == NULL) {
@@ -113,7 +101,7 @@ pcmk__register_formats(GOptionContext *context, pcmk__supported_format_t *format
     }
 
     for (entry = formats; entry->name != NULL; entry++) {
-        pcmk__register_format(context, entry->name, entry->create, entry->options);
+        pcmk__register_format(group, entry->name, entry->create, entry->options);
     }
 }
 

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -38,15 +38,15 @@ static char *stylesheet_link = NULL;
 static char *title = NULL;
 
 GOptionEntry pcmk__html_output_entries[] = {
-    { "output-cgi", 0, 0, G_OPTION_ARG_NONE, &cgi_output,
+    { "html-cgi", 0, 0, G_OPTION_ARG_NONE, &cgi_output,
       "Add text needed to use output in a CGI program",
       NULL },
 
-    { "output-stylesheet-link", 0, 0, G_OPTION_ARG_STRING, &stylesheet_link,
+    { "html-stylesheet", 0, 0, G_OPTION_ARG_STRING, &stylesheet_link,
       "Link to an external CSS stylesheet",
       "URI" },
 
-    { "output-title", 0, 0, G_OPTION_ARG_STRING, &title,
+    { "html-title", 0, 0, G_OPTION_ARG_STRING, &title,
       "Page title",
       "TITLE" },
 
@@ -144,7 +144,7 @@ html_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy
 
     /* Stylesheets are included two different ways.  The first is via a built-in
      * default (see the stylesheet_default const above).  The second is via the
-     * "stylesheet-link" option, and this should obviously be a link to a
+     * html-stylesheet option, and this should obviously be a link to a
      * stylesheet.  The second can override the first.  At least one should be
      * given.
      */

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -16,7 +16,7 @@
 static gboolean fancy = FALSE;
 
 GOptionEntry pcmk__text_output_entries[] = {
-    { "output-fancy", 0, 0, G_OPTION_ARG_NONE, &fancy,
+    { "text-fancy", 0, 0, G_OPTION_ARG_NONE, &fancy,
       "Use more highly formatted output",
       NULL },
 

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -25,10 +25,10 @@ static gboolean legacy_xml = FALSE;
 static gboolean simple_list = FALSE;
 
 GOptionEntry pcmk__xml_output_entries[] = {
-    { "output-legacy-xml", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &legacy_xml,
+    { "xml-legacy", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &legacy_xml,
       NULL,
       NULL },
-    { "output-simple-list", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &simple_list,
+    { "xml-simple-list", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &simple_list,
       NULL,
       NULL },
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -753,7 +753,7 @@ avoid_zombies()
 }
 
 static GOptionContext *
-build_arg_context(pcmk__common_args_t *args) {
+build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
 
     GOptionEntry extra_prog_entries[] = {
@@ -780,7 +780,7 @@ build_arg_context(pcmk__common_args_t *args) {
                               "formats.  It can be just an integer number of seconds, a number plus units\n"
                               "(ms/msec/us/usec/s/sec/m/min/h/hr), or an ISO 8601 period specification.\n";
 
-    context = pcmk__build_arg_context(args, "console (default), html, text, xml");
+    context = pcmk__build_arg_context(args, "console (default), html, text, xml", group);
     pcmk__add_main_args(context, extra_prog_entries);
     g_option_context_set_description(context, description);
 
@@ -896,12 +896,13 @@ main(int argc, char **argv)
 {
     int rc = pcmk_ok;
     char **processed_args = NULL;
+    GOptionGroup *output_group = NULL;
 
     GError *error = NULL;
 
     args = pcmk__new_common_args(SUMMARY);
-    context = build_arg_context(args);
-    pcmk__register_formats(context, formats);
+    context = build_arg_context(args, &output_group);
+    pcmk__register_formats(output_group, formats);
 
     options.pid_file = strdup("/tmp/ClusterMon.pid");
     crm_log_cli_init("crm_mon");

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1885,9 +1885,7 @@ clean_up(crm_exit_t exit_code)
         }
     }
 
-    if (context != NULL) {
-        g_option_context_free(context);
-    }
+    pcmk__free_arg_context(context);
 
     if (out != NULL) {
         if (output_format == mon_output_cgi || output_format == mon_output_html) {

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -435,7 +435,7 @@ static GOptionEntry deprecated_entries[] = {
 
     { "web-cgi", 'w', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, as_cgi_cb,
       "Web mode with output suitable for CGI (preselected when run as *.cgi).\n"
-      INDENT "Use --output-as=html --output-cgi instead.",
+      INDENT "Use --output-as=html --html-cgi instead.",
       NULL },
 
     { NULL }
@@ -803,29 +803,29 @@ add_output_args() {
     GError *error = NULL;
 
     if (output_format == mon_output_plain) {
-        if (!pcmk__force_args(context, &error, "%s --output-fancy", g_get_prgname())) {
+        if (!pcmk__force_args(context, &error, "%s --text-fancy", g_get_prgname())) {
             fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
             clean_up(CRM_EX_USAGE);
         }
     } else if (output_format == mon_output_html) {
-        if (!pcmk__force_args(context, &error, "%s --output-title \"Cluster Status\"",
+        if (!pcmk__force_args(context, &error, "%s --html-title \"Cluster Status\"",
                               g_get_prgname())) {
             fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
             clean_up(CRM_EX_USAGE);
         }
     } else if (output_format == mon_output_cgi) {
-        if (!pcmk__force_args(context, &error, "%s --output-cgi --output-title \"Cluster Status\"", g_get_prgname())) {
+        if (!pcmk__force_args(context, &error, "%s --html-cgi --html-title \"Cluster Status\"", g_get_prgname())) {
             fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
             clean_up(CRM_EX_USAGE);
         }
     } else if (output_format == mon_output_xml) {
-        if (!pcmk__force_args(context, &error, "%s --output-simple-list", g_get_prgname())) {
+        if (!pcmk__force_args(context, &error, "%s --xml-simple-list", g_get_prgname())) {
             fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
             clean_up(CRM_EX_USAGE);
         }
     } else if (output_format == mon_output_legacy_xml) {
         output_format = mon_output_xml;
-        if (!pcmk__force_args(context, &error, "%s --output-legacy-xml", g_get_prgname())) {
+        if (!pcmk__force_args(context, &error, "%s --xml-legacy", g_get_prgname())) {
             fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
             clean_up(CRM_EX_USAGE);
         }

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -566,7 +566,7 @@ run_pacemakerd_mainloop()
 }
 
 static GOptionContext *
-build_arg_context(pcmk__common_args_t *args) {
+build_arg_context(pcmk__common_args_t *args, GOptionGroup *group) {
     GOptionContext *context = NULL;
 
     GOptionEntry extra_prog_entries[] = {
@@ -577,7 +577,7 @@ build_arg_context(pcmk__common_args_t *args) {
         { NULL }
     };
 
-    context = pcmk__build_arg_context(args, NULL);
+    context = pcmk__build_arg_context(args, NULL, &group);
 
     /* Add the -q option, which cannot be part of the globally supported options
      * because some tools use that flag for something else.
@@ -598,9 +598,10 @@ main(int argc, char **argv)
 
     GError *error = NULL;
     GOptionContext *context = NULL;
+    GOptionGroup *output_group = NULL;
     gchar **processed_args = NULL;
 
-    context = build_arg_context(args);
+    context = build_arg_context(args, output_group);
 
     crm_log_cli_init("crm_node");
 

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -658,11 +658,7 @@ main(int argc, char **argv)
 
 done:
     g_strfreev(processed_args);
-
-    if (context != NULL) {
-        g_option_context_free(context);
-    }
-
+    pcmk__free_arg_context(context);
     crm_node_exit(exit_code);
     return exit_code;
 }

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -834,10 +834,7 @@ main(int argc, char **argv)
 
   done:
     g_strfreev(processed_args);
-
-    if (context != NULL) {
-        g_option_context_free(context);
-    }
+    pcmk__free_arg_context(context);
 
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -524,7 +524,7 @@ show_metadata(pcmk__output_t *out, stonith_t *st, char *agent, int timeout)
 }
 
 static GOptionContext *
-build_arg_context(pcmk__common_args_t *args) {
+build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
 
     GOptionEntry extra_prog_entries[] = {
@@ -535,7 +535,7 @@ build_arg_context(pcmk__common_args_t *args) {
         { NULL }
     };
 
-    context = pcmk__build_arg_context(args, "text (default), html, xml");
+    context = pcmk__build_arg_context(args, "text (default), html, xml", group);
 
     /* Add the -q option, which cannot be part of the globally supported options
      * because some tools use that flag for something else.
@@ -573,10 +573,11 @@ main(int argc, char **argv)
 
     GError *error = NULL;
     GOptionContext *context = NULL;
+    GOptionGroup *output_group = NULL;
     gchar **processed_args = NULL;
 
-    context = build_arg_context(args);
-    pcmk__register_formats(context, formats);
+    context = build_arg_context(args, &output_group);
+    pcmk__register_formats(output_group, formats);
 
     crm_log_cli_init("stonith_admin");
 


### PR DESCRIPTION
Also, rename them from --output-whatever to --<format>-whatever.