### PR TITLE
Count resources correctly for status displays

### DIFF
--- a/cts/scheduler/8-am-then-bm-a-migrating-b-stopping.summary
+++ b/cts/scheduler/8-am-then-bm-a-migrating-b-stopping.summary
@@ -1,4 +1,4 @@
-1 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ 18node1 18node2 18node3 ]

--- a/cts/scheduler/9-am-then-bm-b-migrating-a-stopping.summary
+++ b/cts/scheduler/9-am-then-bm-b-migrating-a-stopping.summary
@@ -1,4 +1,4 @@
-1 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ 18node1 18node2 18node3 ]

--- a/cts/scheduler/asymmetrical-order-move.summary
+++ b/cts/scheduler/asymmetrical-order-move.summary
@@ -1,5 +1,5 @@
 Using the original execution date of: 2016-04-28 11:50:29Z
-1 of 3 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 3 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ sle12sp2-1 sle12sp2-2 ]

--- a/cts/scheduler/asymmetrical-order-restart.summary
+++ b/cts/scheduler/asymmetrical-order-restart.summary
@@ -1,5 +1,5 @@
 Using the original execution date of: 2018-08-09 18:55:41Z
-1 of 3 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 3 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ cesr105-p16 cesr109-p16 ]

--- a/cts/scheduler/bug-1718.summary
+++ b/cts/scheduler/bug-1718.summary
@@ -1,4 +1,4 @@
-2 of 5 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 5 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ biggame.ds9 heartbeat.ds9 ops.ds9 ]

--- a/cts/scheduler/bug-5014-A-stop-B-started.summary
+++ b/cts/scheduler/bug-5014-A-stop-B-started.summary
@@ -1,4 +1,4 @@
-1 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/bug-5014-A-stopped-B-stopped.summary
+++ b/cts/scheduler/bug-5014-A-stopped-B-stopped.summary
@@ -1,4 +1,4 @@
-1 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/bug-5014-CLONE-A-stop-B-started.summary
+++ b/cts/scheduler/bug-5014-CLONE-A-stop-B-started.summary
@@ -1,4 +1,4 @@
-1 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/bug-5014-CthenAthenB-C-stopped.summary
+++ b/cts/scheduler/bug-5014-CthenAthenB-C-stopped.summary
@@ -1,4 +1,4 @@
-1 of 3 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 3 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/bug-5014-GROUP-A-stopped-B-started.summary
+++ b/cts/scheduler/bug-5014-GROUP-A-stopped-B-started.summary
@@ -1,4 +1,4 @@
-2 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/bug-5014-GROUP-A-stopped-B-stopped.summary
+++ b/cts/scheduler/bug-5014-GROUP-A-stopped-B-stopped.summary
@@ -1,4 +1,4 @@
-2 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/bug-5014-ordered-set-symmetrical-false.summary
+++ b/cts/scheduler/bug-5014-ordered-set-symmetrical-false.summary
@@ -1,4 +1,4 @@
-1 of 3 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 3 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/bug-5014-ordered-set-symmetrical-true.summary
+++ b/cts/scheduler/bug-5014-ordered-set-symmetrical-true.summary
@@ -1,4 +1,4 @@
-1 of 3 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 3 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/bug-5028-bottom.summary
+++ b/cts/scheduler/bug-5028-bottom.summary
@@ -1,3 +1,4 @@
+0 of 2 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ bl460g6a bl460g6b ]

--- a/cts/scheduler/bug-5028-detach.summary
+++ b/cts/scheduler/bug-5028-detach.summary
@@ -1,6 +1,7 @@
 
               *** Resource management is DISABLED ***
   The cluster will not attempt to start, stop or recover services
+0 of 2 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ bl460g6a bl460g6b ]

--- a/cts/scheduler/bug-5028.summary
+++ b/cts/scheduler/bug-5028.summary
@@ -1,3 +1,4 @@
+0 of 2 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ bl460g6a bl460g6b ]

--- a/cts/scheduler/bug-5140-require-all-false.summary
+++ b/cts/scheduler/bug-5140-require-all-false.summary
@@ -1,4 +1,4 @@
-4 of 35 resources DISABLED and 0 BLOCKED from being started due to failures
+4 of 35 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Node hex-1: standby

--- a/cts/scheduler/bug-5143-ms-shuffle.summary
+++ b/cts/scheduler/bug-5143-ms-shuffle.summary
@@ -1,4 +1,4 @@
-2 of 34 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 34 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ hex-1 hex-2 hex-3 ]

--- a/cts/scheduler/bug-cl-5170.summary
+++ b/cts/scheduler/bug-cl-5170.summary
@@ -1,3 +1,4 @@
+0 of 4 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Node TCS-1: OFFLINE (standby)

--- a/cts/scheduler/bug-cl-5219.summary
+++ b/cts/scheduler/bug-cl-5219.summary
@@ -1,4 +1,4 @@
-1 of 9 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 9 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ ha1.test.anchor.net.au ha2.test.anchor.net.au ]

--- a/cts/scheduler/bug-lf-2171.summary
+++ b/cts/scheduler/bug-lf-2171.summary
@@ -1,4 +1,4 @@
-3 of 4 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 4 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ xenserver1 xenserver2 ]

--- a/cts/scheduler/bug-lf-2358.summary
+++ b/cts/scheduler/bug-lf-2358.summary
@@ -1,4 +1,4 @@
-2 of 15 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 15 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ alice.demo bob.demo ]

--- a/cts/scheduler/bug-lf-2422.summary
+++ b/cts/scheduler/bug-lf-2422.summary
@@ -1,4 +1,4 @@
-8 of 21 resources DISABLED and 0 BLOCKED from being started due to failures
+4 of 21 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ qa-suse-1 qa-suse-2 qa-suse-3 qa-suse-4 ]

--- a/cts/scheduler/bug-lf-2453.summary
+++ b/cts/scheduler/bug-lf-2453.summary
@@ -1,4 +1,4 @@
-2 of 5 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 5 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ domu1 domu2 ]

--- a/cts/scheduler/bug-lf-2606.summary
+++ b/cts/scheduler/bug-lf-2606.summary
@@ -1,4 +1,4 @@
-1 of 5 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 5 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Node node2: UNCLEAN (online)

--- a/cts/scheduler/bug-rh-1097457.summary
+++ b/cts/scheduler/bug-rh-1097457.summary
@@ -1,4 +1,4 @@
-2 of 26 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 26 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ lama2 lama3 ]

--- a/cts/scheduler/bug-suse-707150.summary
+++ b/cts/scheduler/bug-suse-707150.summary
@@ -1,4 +1,4 @@
-9 of 28 resources DISABLED and 0 BLOCKED from being started due to failures
+5 of 28 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ hex-0 hex-9 ]

--- a/cts/scheduler/clone-fail-block-colocation.summary
+++ b/cts/scheduler/clone-fail-block-colocation.summary
@@ -1,3 +1,4 @@
+0 of 10 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ DEM-1 DEM-2 ]

--- a/cts/scheduler/clone-order-16instances.summary
+++ b/cts/scheduler/clone-order-16instances.summary
@@ -1,4 +1,4 @@
-16 of 33 resources DISABLED and 0 BLOCKED from being started due to failures
+16 of 33 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ virt-009.cluster-qe.lab.eng.brq.redhat.com virt-010.cluster-qe.lab.eng.brq.redhat.com virt-012.cluster-qe.lab.eng.brq.redhat.com virt-013.cluster-qe.lab.eng.brq.redhat.com virt-014.cluster-qe.lab.eng.brq.redhat.com virt-015.cluster-qe.lab.eng.brq.redhat.com virt-016.cluster-qe.lab.eng.brq.redhat.com virt-020.cluster-qe.lab.eng.brq.redhat.com virt-027.cluster-qe.lab.eng.brq.redhat.com virt-028.cluster-qe.lab.eng.brq.redhat.com virt-029.cluster-qe.lab.eng.brq.redhat.com virt-030.cluster-qe.lab.eng.brq.redhat.com virt-031.cluster-qe.lab.eng.brq.redhat.com virt-032.cluster-qe.lab.eng.brq.redhat.com virt-033.cluster-qe.lab.eng.brq.redhat.com virt-034.cluster-qe.lab.eng.brq.redhat.com ]

--- a/cts/scheduler/cloned-group-stop.summary
+++ b/cts/scheduler/cloned-group-stop.summary
@@ -1,4 +1,4 @@
-2 of 20 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 20 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ rhos4-node3 rhos4-node4 ]

--- a/cts/scheduler/coloc-clone-stays-active.summary
+++ b/cts/scheduler/coloc-clone-stays-active.summary
@@ -1,4 +1,4 @@
-12 of 87 resources DISABLED and 0 BLOCKED from being started due to failures
+9 of 87 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ s01-0 s01-1 ]

--- a/cts/scheduler/colocation_constraint_stops_slave.summary
+++ b/cts/scheduler/colocation_constraint_stops_slave.summary
@@ -1,4 +1,4 @@
-1 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/complex_enforce_colo.summary
+++ b/cts/scheduler/complex_enforce_colo.summary
@@ -1,4 +1,4 @@
-3 of 132 resources DISABLED and 0 BLOCKED from being started due to failures
+3 of 132 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ rhos6-node1 rhos6-node2 rhos6-node3 ]

--- a/cts/scheduler/container-is-remote-node.summary
+++ b/cts/scheduler/container-is-remote-node.summary
@@ -1,4 +1,4 @@
-3 of 19 resources DISABLED and 0 BLOCKED from being started due to failures
+3 of 19 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ lama2 lama3 ]

--- a/cts/scheduler/enforce-colo1.summary
+++ b/cts/scheduler/enforce-colo1.summary
@@ -1,4 +1,4 @@
-3 of 6 resources DISABLED and 0 BLOCKED from being started due to failures
+3 of 6 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ rhel7-auto1 rhel7-auto2 rhel7-auto3 ]

--- a/cts/scheduler/expire-non-blocked-failure.summary
+++ b/cts/scheduler/expire-non-blocked-failure.summary
@@ -1,3 +1,4 @@
+0 of 3 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/failcount-block.summary
+++ b/cts/scheduler/failcount-block.summary
@@ -1,3 +1,4 @@
+0 of 5 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ pcmk-1 ]

--- a/cts/scheduler/group-stop-ordering.summary
+++ b/cts/scheduler/group-stop-ordering.summary
@@ -1,3 +1,4 @@
+0 of 5 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fastvm-rhel-7-5-73 fastvm-rhel-7-5-74 ]

--- a/cts/scheduler/group11.summary
+++ b/cts/scheduler/group11.summary
@@ -1,4 +1,4 @@
-2 of 3 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 3 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 ]

--- a/cts/scheduler/intervals.summary
+++ b/cts/scheduler/intervals.summary
@@ -1,4 +1,5 @@
 Using the original execution date of: 2018-03-21 23:12:42Z
+0 of 7 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 rhel7-5 ]

--- a/cts/scheduler/load-stopped-loop-2.summary
+++ b/cts/scheduler/load-stopped-loop-2.summary
@@ -1,4 +1,4 @@
-4 of 25 resources DISABLED and 0 BLOCKED from being started due to failures
+4 of 25 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ xfc0 xfc1 xfc2 xfc3 ]

--- a/cts/scheduler/load-stopped-loop.summary
+++ b/cts/scheduler/load-stopped-loop.summary
@@ -1,4 +1,4 @@
-32 of 308 resources DISABLED and 0 BLOCKED from being started due to failures
+32 of 308 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ mgmt01 v03-a v03-b ]

--- a/cts/scheduler/master-asymmetrical-order.summary
+++ b/cts/scheduler/master-asymmetrical-order.summary
@@ -1,4 +1,4 @@
-2 of 4 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 4 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/master-demote-block.summary
+++ b/cts/scheduler/master-demote-block.summary
@@ -1,3 +1,4 @@
+0 of 2 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Node dl380g5c (21c624bd-c426-43dc-9665-bbfb92054bcd): standby

--- a/cts/scheduler/master-depend.summary
+++ b/cts/scheduler/master-depend.summary
@@ -1,4 +1,4 @@
-3 of 10 resources DISABLED and 0 BLOCKED from being started due to failures
+3 of 10 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ vbox4 ]

--- a/cts/scheduler/master-probed-score.summary
+++ b/cts/scheduler/master-probed-score.summary
@@ -1,4 +1,4 @@
-2 of 60 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 60 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ hypatia-corosync.nevis.columbia.edu orestes-corosync.nevis.columbia.edu ]

--- a/cts/scheduler/master-promotion-constraint.summary
+++ b/cts/scheduler/master-promotion-constraint.summary
@@ -1,4 +1,4 @@
-4 of 5 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 5 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ hex-13 hex-14 ]

--- a/cts/scheduler/multiple-active-block-group.summary
+++ b/cts/scheduler/multiple-active-block-group.summary
@@ -1,3 +1,4 @@
+0 of 4 resource instances DISABLED and 3 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node2 node3 ]

--- a/cts/scheduler/not-reschedule-unneeded-monitor.summary
+++ b/cts/scheduler/not-reschedule-unneeded-monitor.summary
@@ -1,4 +1,4 @@
-1 of 11 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 11 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ castor kimball ]

--- a/cts/scheduler/novell-251689.summary
+++ b/cts/scheduler/novell-251689.summary
@@ -1,4 +1,4 @@
-1 of 11 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 11 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/one-or-more-1.summary
+++ b/cts/scheduler/one-or-more-1.summary
@@ -1,4 +1,4 @@
-1 of 4 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 4 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/one-or-more-2.summary
+++ b/cts/scheduler/one-or-more-2.summary
@@ -1,4 +1,4 @@
-1 of 4 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 4 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/one-or-more-3.summary
+++ b/cts/scheduler/one-or-more-3.summary
@@ -1,4 +1,4 @@
-2 of 4 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 4 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/one-or-more-4.summary
+++ b/cts/scheduler/one-or-more-4.summary
@@ -1,4 +1,4 @@
-1 of 4 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 4 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/one-or-more-5.summary
+++ b/cts/scheduler/one-or-more-5.summary
@@ -1,4 +1,4 @@
-2 of 6 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 6 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/one-or-more-6.summary
+++ b/cts/scheduler/one-or-more-6.summary
@@ -1,4 +1,4 @@
-1 of 3 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 3 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/one-or-more-7.summary
+++ b/cts/scheduler/one-or-more-7.summary
@@ -1,4 +1,4 @@
-1 of 3 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 3 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/order-clone.summary
+++ b/cts/scheduler/order-clone.summary
@@ -1,4 +1,4 @@
-4 of 25 resources DISABLED and 0 BLOCKED from being started due to failures
+4 of 25 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ hex-0 hex-7 hex-8 hex-9 ]

--- a/cts/scheduler/order7.summary
+++ b/cts/scheduler/order7.summary
@@ -1,3 +1,4 @@
+0 of 6 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 ]

--- a/cts/scheduler/order_constraint_stops_master.summary
+++ b/cts/scheduler/order_constraint_stops_master.summary
@@ -1,4 +1,4 @@
-1 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder fc16-builder2 ]

--- a/cts/scheduler/order_constraint_stops_slave.summary
+++ b/cts/scheduler/order_constraint_stops_slave.summary
@@ -1,4 +1,4 @@
-1 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/ordered-set-basic-startup.summary
+++ b/cts/scheduler/ordered-set-basic-startup.summary
@@ -1,4 +1,4 @@
-2 of 6 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 6 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ fc16-builder ]

--- a/cts/scheduler/ordered-set-natural.summary
+++ b/cts/scheduler/ordered-set-natural.summary
@@ -1,4 +1,4 @@
-4 of 15 resources DISABLED and 0 BLOCKED from being started due to failures
+3 of 15 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/params-6.summary
+++ b/cts/scheduler/params-6.summary
@@ -1,4 +1,4 @@
-90 of 337 resources DISABLED and 0 BLOCKED from being started due to failures
+90 of 337 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ mgmt01 v03-a v03-b ]

--- a/cts/scheduler/rec-rsc-4.summary
+++ b/cts/scheduler/rec-rsc-4.summary
@@ -1,3 +1,4 @@
+0 of 1 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/rec-rsc-8.summary
+++ b/cts/scheduler/rec-rsc-8.summary
@@ -1,3 +1,4 @@
+0 of 1 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/remote-disable.summary
+++ b/cts/scheduler/remote-disable.summary
@@ -1,4 +1,4 @@
-2 of 6 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 6 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ 18builder 18node1 18node2 ]

--- a/cts/scheduler/remote-probe-disable.summary
+++ b/cts/scheduler/remote-probe-disable.summary
@@ -1,4 +1,4 @@
-2 of 6 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 6 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ 18builder 18node1 18node2 ]

--- a/cts/scheduler/rsc-maintenance.summary
+++ b/cts/scheduler/rsc-maintenance.summary
@@ -1,4 +1,4 @@
-4 of 4 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 4 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/rsc-sets-clone-1.summary
+++ b/cts/scheduler/rsc-sets-clone-1.summary
@@ -1,4 +1,4 @@
-5 of 24 resources DISABLED and 0 BLOCKED from being started due to failures
+5 of 24 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ sys2 sys3 ]

--- a/cts/scheduler/stop-failure-no-fencing.summary
+++ b/cts/scheduler/stop-failure-no-fencing.summary
@@ -1,3 +1,4 @@
+0 of 9 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Node pcmk-3 (103): UNCLEAN (offline)

--- a/cts/scheduler/stop-failure-no-quorum.summary
+++ b/cts/scheduler/stop-failure-no-quorum.summary
@@ -1,3 +1,4 @@
+0 of 10 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Node pcmk-2 (102): UNCLEAN (online)

--- a/cts/scheduler/stopped-monitor-03.summary
+++ b/cts/scheduler/stopped-monitor-03.summary
@@ -1,4 +1,4 @@
-1 of 1 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 1 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/stopped-monitor-04.summary
+++ b/cts/scheduler/stopped-monitor-04.summary
@@ -1,4 +1,4 @@
-1 of 1 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 1 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/stopped-monitor-05.summary
+++ b/cts/scheduler/stopped-monitor-05.summary
@@ -1,3 +1,4 @@
+0 of 1 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/stopped-monitor-06.summary
+++ b/cts/scheduler/stopped-monitor-06.summary
@@ -1,4 +1,4 @@
-1 of 1 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 1 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/stopped-monitor-07.summary
+++ b/cts/scheduler/stopped-monitor-07.summary
@@ -1,3 +1,4 @@
+0 of 1 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/stopped-monitor-11.summary
+++ b/cts/scheduler/stopped-monitor-11.summary
@@ -1,4 +1,4 @@
-1 of 1 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 1 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/stopped-monitor-12.summary
+++ b/cts/scheduler/stopped-monitor-12.summary
@@ -1,4 +1,4 @@
-1 of 1 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 1 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/stopped-monitor-20.summary
+++ b/cts/scheduler/stopped-monitor-20.summary
@@ -1,4 +1,4 @@
-1 of 1 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 1 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/stopped-monitor-21.summary
+++ b/cts/scheduler/stopped-monitor-21.summary
@@ -1,4 +1,4 @@
-1 of 1 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 1 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/stopped-monitor-22.summary
+++ b/cts/scheduler/stopped-monitor-22.summary
@@ -1,4 +1,4 @@
-1 of 1 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 1 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/stopped-monitor-24.summary
+++ b/cts/scheduler/stopped-monitor-24.summary
@@ -1,4 +1,4 @@
-1 of 1 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 1 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/stopped-monitor-25.summary
+++ b/cts/scheduler/stopped-monitor-25.summary
@@ -1,4 +1,4 @@
-1 of 1 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 1 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/stopped-monitor-31.summary
+++ b/cts/scheduler/stopped-monitor-31.summary
@@ -1,4 +1,4 @@
-1 of 1 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 1 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 node3 ]

--- a/cts/scheduler/target-1.summary
+++ b/cts/scheduler/target-1.summary
@@ -1,4 +1,4 @@
-1 of 5 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 5 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ c001n01 c001n02 c001n03 c001n08 ]

--- a/cts/scheduler/target-2.summary
+++ b/cts/scheduler/target-2.summary
@@ -1,4 +1,4 @@
-1 of 5 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 5 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ c001n01 c001n02 c001n03 c001n08 ]

--- a/cts/scheduler/template-1.summary
+++ b/cts/scheduler/template-1.summary
@@ -1,4 +1,4 @@
-1 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ node1 node2 ]

--- a/cts/scheduler/unmanaged-block-restart.summary
+++ b/cts/scheduler/unmanaged-block-restart.summary
@@ -1,3 +1,4 @@
+0 of 4 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ yingying.site ]

--- a/cts/scheduler/unmanaged-stop-1.summary
+++ b/cts/scheduler/unmanaged-stop-1.summary
@@ -1,4 +1,4 @@
-1 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ yingying.site ]

--- a/cts/scheduler/unmanaged-stop-2.summary
+++ b/cts/scheduler/unmanaged-stop-2.summary
@@ -1,4 +1,4 @@
-1 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 2 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ yingying.site ]

--- a/cts/scheduler/unmanaged-stop-3.summary
+++ b/cts/scheduler/unmanaged-stop-3.summary
@@ -1,4 +1,4 @@
-4 of 2 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 2 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ yingying.site ]

--- a/cts/scheduler/unmanaged-stop-4.summary
+++ b/cts/scheduler/unmanaged-stop-4.summary
@@ -1,4 +1,4 @@
-6 of 3 resources DISABLED and 0 BLOCKED from being started due to failures
+3 of 3 resource instances DISABLED and 1 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ yingying.site ]

--- a/cts/scheduler/unrunnable-2.summary
+++ b/cts/scheduler/unrunnable-2.summary
@@ -1,4 +1,4 @@
-6 of 117 resources DISABLED and 0 BLOCKED from being started due to failures
+6 of 117 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ overcloud-controller-0 overcloud-controller-1 overcloud-controller-2 ]

--- a/cts/scheduler/use-after-free-merge.summary
+++ b/cts/scheduler/use-after-free-merge.summary
@@ -1,4 +1,4 @@
-4 of 5 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 5 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ hex-13 hex-14 ]

--- a/cts/scheduler/utilization-order4.summary
+++ b/cts/scheduler/utilization-order4.summary
@@ -1,4 +1,4 @@
-2 of 13 resources DISABLED and 0 BLOCKED from being started due to failures
+2 of 13 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Node deglxen002: standby

--- a/cts/scheduler/whitebox-asymmetric.summary
+++ b/cts/scheduler/whitebox-asymmetric.summary
@@ -1,4 +1,4 @@
-2 of 7 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 7 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ 18builder ]

--- a/cts/scheduler/whitebox-stop.summary
+++ b/cts/scheduler/whitebox-stop.summary
@@ -1,4 +1,4 @@
-1 of 14 resources DISABLED and 0 BLOCKED from being started due to failures
+1 of 14 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 Current cluster status:
 Online: [ 18node1 18node2 18node3 ]

--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2012-2019 David Vossel <davidvossel@gmail.com>
+ * Copyright 2012-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -367,6 +369,7 @@ generate_params(void)
         crm_crit("Could not allocate working set");
         return -ENOMEM;
     }
+    set_bit(data_set->flags, pe_flag_no_counts);
 
     cib_conn = cib_new();
     rc = cib_conn->cmds->signon(cib_conn, "cts-exec-helper", cib_query);

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -607,8 +607,7 @@ static void cib_device_update(resource_t *rsc, pe_working_set_t *data_set)
     }
 
     /* If this STONITH resource is disabled, just remove it. */
-    value = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_TARGET_ROLE);
-    if (safe_str_eq(value, RSC_STOPPED)) {
+    if (pe__resource_is_disabled(rsc)) {
         crm_info("Device %s has been disabled", rsc->id);
         goto update_done;
     }

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -1457,6 +1457,7 @@ main(int argc, char **argv)
 
     fenced_data_set = pe_new_working_set();
     CRM_ASSERT(fenced_data_set != NULL);
+    set_bit(fenced_data_set->flags, pe_flag_no_counts);
 
     if (stand_alone == FALSE) {
 

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -96,6 +96,7 @@ process_pe_message(xmlNode * msg, xmlNode * xml_data, crm_client_t * sender)
         if (sched_data_set == NULL) {
             sched_data_set = pe_new_working_set();
             CRM_ASSERT(sched_data_set != NULL);
+            set_bit(sched_data_set->flags, pe_flag_no_counts);
         }
 
         digest = calculate_xml_versioned_digest(xml_data, FALSE, FALSE, CRM_FEATURE_SET);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -194,9 +194,6 @@ extern void print_node(const char *pre_text, node_t * node, gboolean details);
 extern void print_str_str(gpointer key, gpointer value, gpointer user_data);
 extern void pe__output_node(node_t * node, gboolean details, pcmk__output_t *out);
 
-extern void print_resource(int log_level, const char *pre_text, resource_t * rsc, gboolean details);
-extern void pe__output_resource(int log_level, resource_t * rsc, gboolean details, pcmk__output_t *out);
-
 extern void dump_node_scores_worker(int level, const char *file, const char *function, int line,
                                     resource_t * rsc, const char *comment, GHashTable * nodes);
 

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -395,4 +395,6 @@ void pe__unpack_dataset_nvpairs(xmlNode *xml_obj, const char *set_name,
                                 const char *always_first, gboolean overwrite,
                                 pe_working_set_t *data_set);
 
+bool pe__resource_is_disabled(pe_resource_t *rsc);
+
 #endif

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -131,6 +131,9 @@ enum rsc_role_e clone_resource_state(const resource_t * rsc, gboolean current);
 enum rsc_role_e pe__bundle_resource_state(const pe_resource_t *rsc,
                                           gboolean current);
 
+void pe__count_common(pe_resource_t *rsc);
+void pe__count_bundle(pe_resource_t *rsc);
+
 gboolean common_unpack(xmlNode * xml_obj, resource_t ** rsc, resource_t * parent,
                        pe_working_set_t * data_set);
 void common_free(resource_t * rsc);

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -52,6 +52,7 @@ typedef struct resource_object_functions_s {
     enum rsc_role_e (*state) (const pe_resource_t*, gboolean);
     pe_node_t *(*location) (const pe_resource_t*, GList**, int);
     void (*free) (pe_resource_t*);
+    void (*count) (pe_resource_t*);
 } resource_object_functions_t;
 
 typedef struct resource_alloc_functions_s resource_alloc_functions_t;
@@ -110,6 +111,9 @@ enum pe_find {
 #  define pe_flag_sanitized             0x00200000ULL
 #  define pe_flag_stdout                0x00400000ULL
 
+//! Don't count total, disabled and blocked resource instances
+#  define pe_flag_no_counts             0x00800000ULL
+
 struct pe_working_set_s {
     xmlNode *input;
     crm_time_t *now;
@@ -162,6 +166,7 @@ struct pe_working_set_s {
     GList *param_check; // History entries that need to be checked
     GList *stop_needed; // Containers that need stop actions
     time_t recheck_by;  // Hint to controller to re-run scheduler by this time
+    int ninstances;     // Total number of resource instances
 };
 
 enum pe_check_parameters {

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -331,8 +331,8 @@ group_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
     get_group_variant_data(group_data, rsc_rh);
     CRM_CHECK(rsc_lh->variant == pe_native, return);
 
-    pe_rsc_trace(rsc_rh, "Processing RH of constraint %s", constraint->id);
-    print_resource(LOG_TRACE, "LHS", rsc_lh, TRUE);
+    pe_rsc_trace(rsc_rh, "Processing RH %s of constraint %s (LH is %s)",
+                 rsc_rh->id, constraint->id, rsc_lh->id);
 
     if (is_set(rsc_rh->flags, pe_rsc_provisional)) {
         return;

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -456,7 +456,6 @@ native_color(resource_t * rsc, node_t * prefer, pe_working_set_t * data_set)
     }
 
     set_bit(rsc->flags, pe_rsc_allocating);
-    print_resource(alloc_details, "Allocating: ", rsc, FALSE);
     dump_node_scores(alloc_details, rsc, "Pre-alloc", rsc->allowed_nodes);
 
     for (gIter = rsc->rsc_cons; gIter != NULL; gIter = gIter->next) {
@@ -497,7 +496,6 @@ native_color(resource_t * rsc, node_t * prefer, pe_working_set_t * data_set)
                                                     pe_weights_rollback);
     }
 
-    print_resource(LOG_TRACE, "Allocating: ", rsc, FALSE);
     if (rsc->next_role == RSC_ROLE_STOPPED) {
         pe_rsc_trace(rsc, "Making sure %s doesn't get allocated", rsc->id);
         /* make sure it doesn't come up again */
@@ -559,7 +557,6 @@ native_color(resource_t * rsc, node_t * prefer, pe_working_set_t * data_set)
     }
 
     clear_bit(rsc->flags, pe_rsc_allocating);
-    print_resource(LOG_TRACE, "Allocated ", rsc, TRUE);
 
     if (rsc->is_remote_node) {
         node_t *remote_node = pe_find_node(data_set->nodes, rsc->id);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1913,3 +1913,27 @@ pe_bundle_replicas(const resource_t *rsc)
         return bundle_data->nreplicas;
     }
 }
+
+void
+pe__count_bundle(pe_resource_t *rsc)
+{
+    pe__bundle_variant_data_t *bundle_data = NULL;
+
+    get_bundle_variant_data(bundle_data, rsc);
+    for (GList *item = bundle_data->replicas; item != NULL; item = item->next) {
+        pe__bundle_replica_t *replica = item->data;
+
+        if (replica->ip) {
+            replica->ip->fns->count(replica->ip);
+        }
+        if (replica->child) {
+            replica->child->fns->count(replica->child);
+        }
+        if (replica->container) {
+            replica->container->fns->count(replica->container);
+        }
+        if (replica->remote) {
+            replica->remote->fns->count(replica->remote);
+        }
+    }
+}

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -99,8 +99,7 @@ pe__create_clone_child(pe_resource_t *rsc, pe_working_set_t *data_set)
     }
 
     add_hash_param(child_rsc->meta, XML_RSC_ATTR_INCARNATION_MAX, inc_max);
-
-    print_resource(LOG_TRACE, "Added ", child_rsc, FALSE);
+    pe_rsc_trace(rsc, "Added %s instance %s", rsc->id, child_rsc->id);
 
   bail:
     free(inc_num);

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -19,44 +19,48 @@ void populate_hash(xmlNode * nvpair_list, GHashTable * hash, const char **attrs,
 
 resource_object_functions_t resource_class_functions[] = {
     {
-     native_unpack,
-     native_find_rsc,
-     native_parameter,
-     native_print,
-     native_active,
-     native_resource_state,
-     native_location,
-     native_free
+         native_unpack,
+         native_find_rsc,
+         native_parameter,
+         native_print,
+         native_active,
+         native_resource_state,
+         native_location,
+         native_free,
+         pe__count_common,
     },
     {
-     group_unpack,
-     native_find_rsc,
-     native_parameter,
-     group_print,
-     group_active,
-     group_resource_state,
-     native_location,
-     group_free
+         group_unpack,
+         native_find_rsc,
+         native_parameter,
+         group_print,
+         group_active,
+         group_resource_state,
+         native_location,
+         group_free,
+         pe__count_common,
     },
     {
-     clone_unpack,
-     native_find_rsc,
-     native_parameter,
-     clone_print,
-     clone_active,
-     clone_resource_state,
-     native_location,
-     clone_free
+         clone_unpack,
+         native_find_rsc,
+         native_parameter,
+         clone_print,
+         clone_active,
+         clone_resource_state,
+         native_location,
+         clone_free,
+         pe__count_common,
     },
     {
-     pe__unpack_bundle,
-     native_find_rsc,
-     native_parameter,
-     pe__print_bundle,
-     pe__bundle_active,
-     pe__bundle_resource_state,
-     native_location,
-     pe__free_bundle
+         pe__unpack_bundle,
+         native_find_rsc,
+         native_parameter,
+         pe__print_bundle,
+         pe__bundle_active,
+         pe__bundle_resource_state,
+         native_location,
+         pe__free_bundle,
+         pe__count_bundle,
     }
 };
 
@@ -939,4 +943,24 @@ pe__find_active_requires(const pe_resource_t *rsc, unsigned int *count)
         return pe__find_active_on(rsc, NULL, count);
     }
     return pe__find_active_on(rsc, count, NULL);
+}
+
+void
+pe__count_common(pe_resource_t *rsc)
+{
+    if (rsc->children != NULL) {
+        for (GList *item = rsc->children; item != NULL; item = item->next) {
+            ((pe_resource_t *) item->data)->fns->count(item->data);
+        }
+
+    } else if (is_not_set(rsc->flags, pe_rsc_orphan)
+               || (rsc->role > RSC_ROLE_STOPPED)) {
+        rsc->cluster->ninstances++;
+        if (pe__resource_is_disabled(rsc)) {
+            rsc->cluster->disabled_resources++;
+        }
+        if (is_set(rsc->flags, pe_rsc_block)) {
+            rsc->cluster->blocked_resources++;
+        }
+    }
 }

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -68,7 +68,7 @@ group_unpack(resource_t * rsc, pe_working_set_t * data_set)
                 group_data->first_child = new_rsc;
             }
             group_data->last_child = new_rsc;
-            print_resource(LOG_TRACE, "Added ", new_rsc, FALSE);
+            pe_rsc_trace(rsc, "Added %s member %s", rsc->id, new_rsc->id);
         }
     }
 

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -528,18 +528,15 @@ flags_string(pe_resource_t *rsc, pe_node_t *node, long options,
          * Show if target role limits our abilities. */
         if (target_role_e == RSC_ROLE_STOPPED) {
             flags[ndx++] = strdup("disabled");
-            rsc->cluster->disabled_resources++;
 
         } else if (is_set(uber_parent(rsc)->flags, pe_rsc_promotable)
                    && target_role_e == RSC_ROLE_SLAVE) {
             flags[ndx++] = crm_strdup_printf("target-role:%s", target_role);
-            rsc->cluster->disabled_resources++;
         }
     }
 
     if (is_set(rsc->flags, pe_rsc_block)) {
         flags[ndx++] = strdup("blocked");
-        rsc->cluster->blocked_resources++;
 
     } else if (is_not_set(rsc->flags, pe_rsc_managed)) {
         flags[ndx++] = strdup("unmanaged");
@@ -917,20 +914,17 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
         if (target_role_e == RSC_ROLE_STOPPED) {
             flagOffset += snprintf(flagBuffer + flagOffset, LINE_MAX - flagOffset,
                                    "%sdisabled", comma_if(flagOffset));
-            rsc->cluster->disabled_resources++;
 
         } else if (is_set(uber_parent(rsc)->flags, pe_rsc_promotable)
                    && target_role_e == RSC_ROLE_SLAVE) {
             flagOffset += snprintf(flagBuffer + flagOffset, LINE_MAX - flagOffset,
                                    "%starget-role:%s", comma_if(flagOffset), target_role);
-            rsc->cluster->disabled_resources++;
         }
     }
 
     if (is_set(rsc->flags, pe_rsc_block)) {
         flagOffset += snprintf(flagBuffer + flagOffset, LINE_MAX - flagOffset,
                                "%sblocked", comma_if(flagOffset));
-        rsc->cluster->blocked_resources++;
 
     } else if (is_not_set(rsc->flags, pe_rsc_managed)) {
         flagOffset += snprintf(flagBuffer + flagOffset, LINE_MAX - flagOffset,

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -152,22 +152,9 @@ pe__output_node(node_t *node, gboolean details, pcmk__output_t *out)
         for (; gIter != NULL; gIter = gIter->next) {
             resource_t *rsc = (resource_t *) gIter->data;
 
-            pe__output_resource(LOG_TRACE, rsc, FALSE, out);
+            // @TODO pe_print_log probably doesn't belong here
+            out->message(out, crm_map_element_name(rsc->xml),
+                         pe_print_log|pe_print_pending, rsc);
         }
     }
-}
-
-void
-pe__output_resource(int log_level, resource_t *rsc, gboolean details, pcmk__output_t  *out)
-{
-    long options = pe_print_log | pe_print_pending;
-
-    if (rsc == NULL) {
-        do_crm_log(log_level - 1, "<NULL>");
-        return;
-    }
-    if (details) {
-        options |= pe_print_details;
-    }
-    out->message(out, crm_map_element_name(rsc->xml), options, rsc);
 }

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -121,6 +121,13 @@ cluster_status(pe_working_set_t * data_set)
         unpack_status(cib_status, data_set);
     }
 
+    if (is_not_set(data_set->flags, pe_flag_no_counts)) {
+        for (GList *item = data_set->resources; item != NULL;
+             item = item->next) {
+            ((pe_resource_t *) (item->data))->fns->count(item->data);
+        }
+    }
+
     set_bit(data_set->flags, pe_flag_have_status);
     return TRUE;
 }

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -687,11 +687,11 @@ link_rsc2remotenode(pe_working_set_t *data_set, resource_t *new_rsc)
         return;
     }
 
-    print_resource(LOG_TRACE, "Linking remote-node connection resource, ", new_rsc, FALSE);
-
     remote_node = pe_find_node(data_set->nodes, new_rsc->id);
     CRM_CHECK(remote_node != NULL, return;);
 
+    pe_rsc_trace(new_rsc, "Linking remote connection resource %s to node %s",
+                 new_rsc->id, remote_node->details->uname);
     remote_node->details->remote_rsc = new_rsc;
 
     if (new_rsc->container == NULL) {
@@ -762,7 +762,7 @@ unpack_resources(xmlNode * xml_resources, pe_working_set_t * data_set)
         crm_trace("Beginning unpack... <%s id=%s... >", crm_element_name(xml_obj), ID(xml_obj));
         if (common_unpack(xml_obj, &new_rsc, NULL, data_set)) {
             data_set->resources = g_list_append(data_set->resources, new_rsc);
-            print_resource(LOG_TRACE, "Added ", new_rsc, FALSE);
+            pe_rsc_trace(new_rsc, "Added resource %s", new_rsc->id);
 
         } else {
             crm_config_err("Failed unpacking %s %s",
@@ -1840,9 +1840,8 @@ process_orphan_resource(xmlNode * rsc_entry, node_t * node, pe_working_set_t * d
         clear_bit(rsc->flags, pe_rsc_managed);
 
     } else {
-        print_resource(LOG_TRACE, "Added orphan", rsc, FALSE);
-
         CRM_CHECK(rsc != NULL, return NULL);
+        pe_rsc_trace(rsc, "Added orphan %s", rsc->id);
         resource_location(rsc, NULL, -INFINITY, "__orphan_do_not_run__", data_set);
     }
     return rsc;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -2571,3 +2571,22 @@ pe__unpack_dataset_nvpairs(xmlNode *xml_obj, const char *set_name,
     }
     crm_time_free(next_change);
 }
+
+bool
+pe__resource_is_disabled(pe_resource_t *rsc)
+{
+    const char *target_role = NULL;
+
+    CRM_CHECK(rsc != NULL, return false);
+    target_role = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_TARGET_ROLE);
+    if (target_role) {
+        enum rsc_role_e target_role_e = text2role(target_role);
+
+        if ((target_role_e == RSC_ROLE_STOPPED)
+            || ((target_role_e == RSC_ROLE_SLAVE)
+                && is_set(uber_parent(rsc)->flags, pe_rsc_promotable))) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1279,6 +1279,8 @@ print_node(const char *pre_text, node_t * node, gboolean details)
               node->details->uname, node->weight, node->fixed ? "True" : "False");
 
     if (details) {
+        int log_level = LOG_TRACE;
+
         char *pe_mutable = strdup("\t\t");
         GListPtr gIter = node->details->running_rsc;
 
@@ -1289,9 +1291,10 @@ print_node(const char *pre_text, node_t * node, gboolean details)
         crm_trace("\t\t=== Resources");
 
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *rsc = (resource_t *) gIter->data;
+            pe_resource_t *rsc = (pe_resource_t *) gIter->data;
 
-            print_resource(LOG_TRACE, "\t\t", rsc, FALSE);
+            rsc->fns->print(rsc, "\t\t", pe_print_log|pe_print_pending,
+                            &log_level);
         }
     }
 }
@@ -1305,22 +1308,6 @@ print_str_str(gpointer key, gpointer value, gpointer user_data)
     crm_trace("%s%s %s ==> %s",
               user_data == NULL ? "" : (char *)user_data,
               user_data == NULL ? "" : ": ", (char *)key, (char *)value);
-}
-
-void
-print_resource(int log_level, const char *pre_text, resource_t * rsc, gboolean details)
-{
-    long options = pe_print_log | pe_print_pending;
-
-    if (rsc == NULL) {
-        do_crm_log(log_level - 1, "%s%s: <NULL>",
-                   pre_text == NULL ? "" : pre_text, pre_text == NULL ? "" : ": ");
-        return;
-    }
-    if (details) {
-        options |= pe_print_details;
-    }
-    rsc->fns->print(rsc, pre_text, options, &log_level);
 }
 
 void

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1217,7 +1217,6 @@ print_simple_status(pcmk__output_t *out, pe_working_set_t * data_set,
                   offline ? offline_nodes : "");
         free(offline_nodes);
     } else {
-        int nresources = count_resources(data_set, NULL);
         char *nodes_standby_s = NULL;
         char *nodes_maint_s = NULL;
 
@@ -1227,15 +1226,17 @@ print_simple_status(pcmk__output_t *out, pe_working_set_t * data_set,
         }
 
         if (nodes_maintenance > 0) {
-            nodes_maint_s = crm_strdup_printf(", %d maintenance node%s", nresources,
-                                              s_if_plural(nresources));
+            nodes_maint_s = crm_strdup_printf(", %d maintenance node%s",
+                                              data_set->ninstances,
+                                              s_if_plural(data_set->ninstances));
         }
 
-        out->info(out, "CLUSTER OK: %dnode%s online%s%s, %d resource%s configured",
+        out->info(out, "CLUSTER OK: %dnode%s online%s%s, "
+                       "%d resource instance%s configured",
                   nodes_online, s_if_plural(nodes_online),
                   nodes_standby_s != NULL ? nodes_standby_s : "",
                   nodes_maint_s != NULL ? nodes_maint_s : "",
-                  nresources, s_if_plural(nresources));
+                  data_set->ninstances, s_if_plural(data_set->ninstances));
 
         free(nodes_standby_s);
         free(nodes_maint_s);

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -107,7 +107,6 @@ int print_html_status(pcmk__output_t *out, mon_output_format_t output_format,
 
 GList *append_attr_list(GList *attr_list, char *name);
 void blank_screen(void);
-int count_resources(pe_working_set_t *data_set, resource_t *rsc);
 void crm_mon_get_parameters(resource_t *rsc, pe_working_set_t *data_set);
 const char *get_cluster_stack(pe_working_set_t *data_set);
 char *get_node_display_name(node_t *node, unsigned int mon_ops);

--- a/tools/crm_mon_output.c
+++ b/tools/crm_mon_output.c
@@ -266,7 +266,9 @@ cluster_counts_html(pcmk__output_t *out, va_list args) {
     free(nnodes_str);
 
     if (ndisabled && nblocked) {
-        char *s = crm_strdup_printf("%d resource%s configured (%d ", nresources, s_if_plural(nresources), ndisabled);
+        char *s = crm_strdup_printf("%d resource instance%s configured (%d ",
+                                    nresources, s_if_plural(nresources),
+                                    ndisabled);
         pcmk_create_html_node(resources_node, "span", NULL, NULL, s);
         free(s);
 
@@ -279,21 +281,26 @@ cluster_counts_html(pcmk__output_t *out, va_list args) {
         pcmk_create_html_node(resources_node, "span", NULL, "bold", "BLOCKED");
         pcmk_create_html_node(resources_node, "span", NULL, NULL, " from starting due to failure)");
     } else if (ndisabled && !nblocked) {
-        char *s = crm_strdup_printf("%d resource%s configured (%d ", nresources, s_if_plural(nresources), ndisabled);
+        char *s = crm_strdup_printf("%d resource instance%s configured (%d ",
+                                    nresources, s_if_plural(nresources),
+                                    ndisabled);
         pcmk_create_html_node(resources_node, "span", NULL, NULL, s);
         free(s);
 
         pcmk_create_html_node(resources_node, "span", NULL, "bold", "DISABLED");
         pcmk_create_html_node(resources_node, "span", NULL, NULL, ")");
     } else if (!ndisabled && nblocked) {
-        char *s = crm_strdup_printf("%d resource%s configured (%d ", nresources, s_if_plural(nresources), nblocked);
+        char *s = crm_strdup_printf("%d resource instance%s configured (%d ",
+                                    nresources, s_if_plural(nresources),
+                                    nblocked);
         pcmk_create_html_node(resources_node, "span", NULL, NULL, s);
         free(s);
 
         pcmk_create_html_node(resources_node, "span", NULL, "bold", "BLOCKED");
         pcmk_create_html_node(resources_node, "span", NULL, NULL, " from starting due to failure)");
     } else {
-        char *s = crm_strdup_printf("%d resource%s configured", nresources, s_if_plural(nresources));
+        char *s = crm_strdup_printf("%d resource instance%s configured",
+                                    nresources, s_if_plural(nresources));
         pcmk_create_html_node(resources_node, "span", NULL, NULL, s);
         free(s);
     }
@@ -311,16 +318,23 @@ cluster_counts_text(pcmk__output_t *out, va_list args) {
     out->list_item(out, NULL, "%d node%s configured", nnodes, s_if_plural(nnodes));
 
     if (ndisabled && nblocked) {
-        out->list_item(out, NULL, "%d resource%s configured (%d DISABLED, %d BLOCKED from starting due to failure",
-                       nresources, s_if_plural(nresources), ndisabled, nblocked);
+        out->list_item(out, NULL, "%d resource instance%s configured "
+                                  "(%d DISABLED, %d BLOCKED from "
+                                  "further action due to failure)",
+                       nresources, s_if_plural(nresources), ndisabled,
+                       nblocked);
     } else if (ndisabled && !nblocked) {
-        out->list_item(out, NULL, "%d resource%s configured (%d DISABLED)",
+        out->list_item(out, NULL, "%d resource instance%s configured "
+                                  "(%d DISABLED)",
                        nresources, s_if_plural(nresources), ndisabled);
     } else if (!ndisabled && nblocked) {
-        out->list_item(out, NULL, "%d resource%s configured (%d BLOCKED from starting due to failure)",
+        out->list_item(out, NULL, "%d resource instance%s configured "
+                                  "(%d BLOCKED from further action "
+                                  "due to failure)",
                        nresources, s_if_plural(nresources), nblocked);
     } else {
-        out->list_item(out, NULL, "%d resource%s configured", nresources, s_if_plural(nresources));
+        out->list_item(out, NULL, "%d resource instance%s configured",
+                       nresources, s_if_plural(nresources));
     }
 
     return 0;

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -706,7 +706,7 @@ print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
             header_printed = TRUE;
         }
         out->message(out, "cluster-counts", g_list_length(data_set->nodes),
-                     count_resources(data_set, NULL), data_set->disabled_resources,
+                     data_set->ninstances, data_set->disabled_resources,
                      data_set->blocked_resources);
     }
 

--- a/tools/crm_mon_runtime.c
+++ b/tools/crm_mon_runtime.c
@@ -66,26 +66,6 @@ append_attr_list(GList *attr_list, char *name)
     return g_list_insert_sorted(attr_list, name, compare_attribute);
 }
 
-int
-count_resources(pe_working_set_t * data_set, resource_t * rsc)
-{
-    int count = 0;
-    GListPtr gIter = NULL;
-
-    if (rsc == NULL) {
-        gIter = data_set->resources;
-    } else if (rsc->children) {
-        gIter = rsc->children;
-    } else {
-        return is_not_set(rsc->flags, pe_rsc_orphan);
-    }
-
-    for (; gIter != NULL; gIter = gIter->next) {
-        count += count_resources(data_set, gIter->data);
-    }
-    return count;
-}
-
 void
 crm_mon_get_parameters(resource_t *rsc, pe_working_set_t * data_set)
 {

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -966,6 +966,7 @@ main(int argc, char **argv)
             rc = -ENOMEM;
             goto bail;
         }
+        set_bit(data_set->flags, pe_flag_no_counts);
         rc = update_working_set_xml(data_set, &cib_xml_copy);
         if (rc != pcmk_ok) {
             goto bail;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1336,6 +1336,7 @@ cli_resource_restart(pe_resource_t *rsc, const char *host, int timeout_ms,
         rc = -ENOMEM;
         goto done;
     }
+    set_bit(data_set->flags, pe_flag_no_counts);
     rc = update_dataset(cib, data_set, FALSE);
     if(rc != pcmk_ok) {
         fprintf(stdout, "Could not get new resource list: %s (%d)\n", pcmk_strerror(rc), rc);
@@ -1641,6 +1642,7 @@ wait_till_stable(int timeout_ms, cib_t * cib)
     if (data_set == NULL) {
         return -ENOMEM;
     }
+    set_bit(data_set->flags, pe_flag_no_counts);
 
     do {
 

--- a/tools/crm_rule.c
+++ b/tools/crm_rule.c
@@ -235,6 +235,7 @@ main(int argc, char **argv)
         exit_code = crm_errno2exit(ENOMEM);
         goto bail;
     }
+    set_bit(data_set->flags, pe_flag_no_counts);
 
     data_set->input = input;
     data_set->now = rule_date;

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -582,26 +582,6 @@ profile_all(const char *dir, long long repeat, pe_working_set_t *data_set)
     }
 }
 
-static int
-count_resources(pe_working_set_t * data_set, resource_t * rsc)
-{
-    int count = 0;
-    GListPtr gIter = NULL;
-
-    if (rsc == NULL) {
-        gIter = data_set->resources;
-    } else if (rsc->children) {
-        gIter = rsc->children;
-    } else {
-        return is_not_set(rsc->flags, pe_rsc_orphan);
-    }
-
-    for (; gIter != NULL; gIter = gIter->next) {
-        count += count_resources(data_set, gIter->data);
-    }
-    return count;
-}
-
 int
 main(int argc, char **argv)
 {
@@ -846,9 +826,9 @@ main(int argc, char **argv)
         }
 
         if (data_set->disabled_resources || data_set->blocked_resources) {
-            quiet_log("%d of %d resources DISABLED and %d BLOCKED from being started due to failures\n",
-                      data_set->disabled_resources,
-                      count_resources(data_set, NULL),
+            quiet_log("%d of %d resource instances DISABLED and %d BLOCKED "
+                      "from further action due to failure\n",
+                      data_set->disabled_resources, data_set->ninstances,
                       data_set->blocked_resources);
         }
 

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -682,6 +682,7 @@ main(int argc, char **argv)
         exit_code = CRM_EX_OSERR;
         goto bail;
     }
+    set_bit(data_set->flags, pe_flag_no_counts);
 
     cib_conn = cib_new();
     if (cib_conn == NULL) {

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -232,6 +232,7 @@ main(int argc, char **argv)
         crm_perror(LOG_CRIT, "Unable to allocate working set");
         goto done;
     }
+    set_bit(data_set->flags, pe_flag_no_counts);
 
     if (cib_object == NULL) {
     } else if (status != NULL || USE_LIVE_CIB) {


### PR DESCRIPTION
The total number of resources and number of disabled and blocked resources has always been incorrect due to a variety of issues. These are all addressed by taking the counting code out of resources' print() method and putting it in a dedicated loop at the end of cluster_status(). Also, a new flag controls whether the counts are done, since only crm_mon and crm_simulate need them.