### PR TITLE
Fix: libpengine: Correct display of master resources.

### DIFF
--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -173,6 +173,18 @@ crm_element_name(const xmlNode *xml)
     return xml? (const char *)(xml->name) : NULL;
 }
 
+static inline const char *
+crm_map_element_name(const xmlNode *xml)
+{
+    const char *name = crm_element_name(xml);
+
+    if (crm_str_eq(name, "master", TRUE)) {
+        return "clone";
+    } else {
+        return name;
+    }
+}
+
 gboolean xml_has_children(const xmlNode * root);
 
 char *calculate_on_disk_digest(xmlNode * local_cib);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1527,17 +1527,17 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
         CRM_ASSERT(rc == 0);
 
         if (replica->ip != NULL) {
-            out->message(out, crm_element_name(replica->ip->xml), options, replica->ip);
+            out->message(out, crm_map_element_name(replica->ip->xml), options, replica->ip);
         }
 
         if (replica->child != NULL) {
-            out->message(out, crm_element_name(replica->child->xml), options, replica->child);
+            out->message(out, crm_map_element_name(replica->child->xml), options, replica->child);
         }
 
-        out->message(out, crm_element_name(replica->container->xml), options, replica->container);
+        out->message(out, crm_map_element_name(replica->container->xml), options, replica->container);
 
         if (replica->remote != NULL) {
-            out->message(out, crm_element_name(replica->remote->xml), options, replica->remote);
+            out->message(out, crm_map_element_name(replica->remote->xml), options, replica->remote);
         }
 
         pcmk__output_xml_pop_parent(out); // replica
@@ -1611,17 +1611,17 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
             out->begin_list(out, NULL, NULL, NULL);
 
             if (replica->ip != NULL) {
-                out->message(out, crm_element_name(replica->ip->xml), options, replica->ip);
+                out->message(out, crm_map_element_name(replica->ip->xml), options, replica->ip);
             }
 
             if (replica->child != NULL) {
-                out->message(out, crm_element_name(replica->child->xml), options, replica->child);
+                out->message(out, crm_map_element_name(replica->child->xml), options, replica->child);
             }
 
-            out->message(out, crm_element_name(replica->container->xml), options, replica->container);
+            out->message(out, crm_map_element_name(replica->container->xml), options, replica->container);
 
             if (replica->remote != NULL) {
-                out->message(out, crm_element_name(replica->remote->xml), options, replica->remote);
+                out->message(out, crm_map_element_name(replica->remote->xml), options, replica->remote);
             }
 
             out->end_list(out);
@@ -1698,17 +1698,17 @@ pe__bundle_text(pcmk__output_t *out, va_list args)
             out->begin_list(out, NULL, NULL, NULL);
 
             if (replica->ip != NULL) {
-                out->message(out, crm_element_name(replica->ip->xml), options, replica->ip);
+                out->message(out, crm_map_element_name(replica->ip->xml), options, replica->ip);
             }
 
             if (replica->child != NULL) {
-                out->message(out, crm_element_name(replica->child->xml), options, replica->child);
+                out->message(out, crm_map_element_name(replica->child->xml), options, replica->child);
             }
 
-            out->message(out, crm_element_name(replica->container->xml), options, replica->container);
+            out->message(out, crm_map_element_name(replica->container->xml), options, replica->container);
 
             if (replica->remote != NULL) {
-                out->message(out, crm_element_name(replica->remote->xml), options, replica->remote);
+                out->message(out, crm_map_element_name(replica->remote->xml), options, replica->remote);
             }
 
             out->end_list(out);

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -590,7 +590,7 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
     for (; gIter != NULL; gIter = gIter->next) {
         resource_t *child_rsc = (resource_t *) gIter->data;
 
-        out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
+        out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc);
     }
 
     pcmk__output_xml_pop_parent(out);
@@ -689,7 +689,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
         }
 
         if (print_full) {
-            out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
+            out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc);
         }
     }
 
@@ -876,7 +876,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
         }
 
         if (print_full) {
-            out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
+            out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc);
         }
     }
 

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -200,7 +200,7 @@ pe__group_xml(pcmk__output_t *out, va_list args)
     for (; gIter != NULL; gIter = gIter->next) {
         resource_t *child_rsc = (resource_t *) gIter->data;
 
-        out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
+        out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc);
     }
 
     pcmk__output_xml_pop_parent(out);
@@ -221,7 +221,7 @@ pe__group_html(pcmk__output_t *out, va_list args)
     } else {
         for (GListPtr gIter = rsc->children; gIter; gIter = gIter->next) {
             resource_t *child_rsc = (resource_t *) gIter->data;
-            out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
+            out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc);
         }
     }
 
@@ -245,7 +245,7 @@ pe__group_text(pcmk__output_t *out, va_list args)
         for (GListPtr gIter = rsc->children; gIter; gIter = gIter->next) {
             resource_t *child_rsc = (resource_t *) gIter->data;
 
-            out->message(out, crm_element_name(child_rsc->xml), options, child_rsc);
+            out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc);
         }
     }
     out->end_list(out);

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -169,5 +169,5 @@ pe__output_resource(int log_level, resource_t *rsc, gboolean details, pcmk__outp
     if (details) {
         options |= pe_print_details;
     }
-    out->message(out, crm_element_name(rsc->xml), options, rsc);
+    out->message(out, crm_map_element_name(rsc->xml), options, rsc);
 }

--- a/tools/crm_mon_output.c
+++ b/tools/crm_mon_output.c
@@ -734,7 +734,7 @@ node_html(pcmk__output_t *out, va_list args) {
             out->begin_list(out, NULL, NULL, NULL);
             for (lpc2 = node->details->running_rsc; lpc2 != NULL; lpc2 = lpc2->next) {
                 resource_t *rsc = (resource_t *) lpc2->data;
-                out->message(out, crm_element_name(rsc->xml), print_opts | pe_print_rsconly, rsc);
+                out->message(out, crm_map_element_name(rsc->xml), print_opts | pe_print_rsconly, rsc);
             }
             out->end_list(out);
         }
@@ -782,7 +782,7 @@ node_text(pcmk__output_t *out, va_list args) {
 
                 for (gIter2 = node->details->running_rsc; gIter2 != NULL; gIter2 = gIter2->next) {
                     resource_t *rsc = (resource_t *) gIter2->data;
-                    out->message(out, crm_element_name(rsc->xml), print_opts | pe_print_rsconly, rsc);
+                    out->message(out, crm_map_element_name(rsc->xml), print_opts | pe_print_rsconly, rsc);
                 }
             }
 
@@ -849,7 +849,7 @@ node_xml(pcmk__output_t *out, va_list args) {
 
             for (lpc = node->details->running_rsc; lpc != NULL; lpc = lpc->next) {
                 resource_t *rsc = (resource_t *) lpc->data;
-                out->message(out, crm_element_name(rsc->xml), print_opts | pe_print_rsconly, rsc);
+                out->message(out, crm_map_element_name(rsc->xml), print_opts | pe_print_rsconly, rsc);
             }
         }
 

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -183,7 +183,7 @@ print_resources(pcmk__output_t *out, pe_working_set_t *data_set,
         if (printed_resource == FALSE) {
             printed_resource = TRUE;
         }
-        out->message(out, crm_element_name(rsc->xml), print_opts, rsc);
+        out->message(out, crm_map_element_name(rsc->xml), print_opts, rsc);
     }
 
     if (print_summary && !printed_resource) {


### PR DESCRIPTION
crm_element_name will return "master" for these resources but there is
no message registered for that, so master resources will just get
ignored.  We need to map "master" to "clone" before calling the message
function.  crm_map_element_name does that, giving us a place to do
future mappings if necessary.