### PR TITLE
Refactor+optimize: no XML tree private tracking bloat for being coarse

### DIFF
--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -36,13 +36,18 @@ enum xml_private_flags {
      xpf_lazy        = 0x4000,
 };
 
-typedef struct xml_private_s {
+typedef struct xml_node_private_s {
+        long check;
+        uint32_t flags;
+} xml_node_private_t;
+
+typedef struct xml_doc_private_s {
         long check;
         uint32_t flags;
         char *user;
         GListPtr acls;
         GListPtr deleted_objs;
-} xml_private_t;
+} xml_doc_private_t;
 
 G_GNUC_INTERNAL
 void pcmk__set_xml_flag(xmlNode *xml, enum xml_private_flags flag);


### PR DESCRIPTION
Being coarse meant that while whole document representing "data node"
(xmlDoc struct) is indeed meant to privately track a lot of intermediate
and document-global metadata, it originally also spoiled all proper
"data nodes" (xmlNode) within the tree with here-superfluous data
members, not used whatsoever in that context.

Solution was to introduce a proper dichotomy for these two structures
(these softly overlap in the libxml2's internal handling since the same
node de/registration callback framework is applied to both header-global
and proper "data nodes" of XML representation uniformly, which may have
caused said coarseness in the first place), allowing them to evolve
independently.

What was left in place is the private member integrity checking based
on a static magic byte sequence being set on "data node" registration
and conversely checked on its deregistration (i.e. when it is being
disposed) -- it is actually helpful as an extra assurance, especially
as it has received such dichotomy as well.

Empiric testing:

1. one-off characteristics
   * crm_simulate -x cts/scheduler/one-or-more-unrunnable-instances.xml -S
     (i.e., 335039 bytes in size, 12042 elements & attributes[*],
     even without any access control related tangents in the config)
   * peak memory usage
     - before split:       23.5 MiB
     - after split:        21.8 MiB
     - absolute reduction:  1.7 MiB (~148 B per element/attribute)
     - relative reduction: ~7.2 % (noticable thanks to big config)

2. pacemaker as a collection of daemons after 10 minutes of run
   * systemctl start pacemaker
   * custom smallish config ( in size statically after 10 minutes
     of run, 183 elements & attributes[*], with enable-acl=true
     and few access control items indeed configured)
   * systemctl status pacemaker
     - before split:       92.9 MiB
     - after split:        90.8 MiB
     - absolute reduction:  2.1 MiB (~11.75 KiB per element/attribute)
     - relative reduction: ~2.3 % (negligible due to small config)

Conclusion:
As the configuration grows and gets more complex over time, the impact
of this change becomes noticable, possibly downright welcome if you
consider the estimated 12 KiB reduction per single attribute/element as
spread over all pacemaker daemons that do full processing of this base
document).  IOW, the original approach wasn't apparently shaped with
concerns of scalability, here memory-wise.  Further optimizations could
be taken, but for instance, the sanity rechecking trade-off is kept in
for the time being, as it already discovered some subtleties in the
past (cf. 399ee472f).

[*] xsltproc - FILE <<-EOF
	<stylesheet version="1.0" xmlns="http://www.w3.org/1999/XSL/Transform">
	<template match="/"><value-of select="count(//@*|//*)"/></template>
        </stylesheet>
	EOF