### PR TITLE
More command line options to control crm_mon output

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -120,6 +120,8 @@ int pe__cluster_counts_xml(pcmk__output_t *out, va_list args);
 int pe__cluster_dc_html(pcmk__output_t *out, va_list args);
 int pe__cluster_dc_text(pcmk__output_t *out, va_list args);
 int pe__cluster_dc_xml(pcmk__output_t *out, va_list args);
+int pe__cluster_maint_mode_html(pcmk__output_t *out, va_list args);
+int pe__cluster_maint_mode_text(pcmk__output_t *out, va_list args);
 int pe__cluster_options_html(pcmk__output_t *out, va_list args);
 int pe__cluster_options_log(pcmk__output_t *out, va_list args);
 int pe__cluster_options_text(pcmk__output_t *out, va_list args);

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -520,6 +520,14 @@ pe__cluster_dc_xml(pcmk__output_t *out, va_list args) {
 }
 
 int
+pe__cluster_maint_mode_text(pcmk__output_t *out, va_list args) {
+    fprintf(out->dest, "\n              *** Resource management is DISABLED ***");
+    fprintf(out->dest, "\n  The cluster will not attempt to start, stop or recover services");
+    fprintf(out->dest, "\n");
+    return 0;
+}
+
+int
 pe__cluster_options_html(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
 
@@ -598,12 +606,6 @@ pe__cluster_options_text(pcmk__output_t *out, va_list args) {
         case no_quorum_suicide:
             out->list_item(out, NULL, "No quorum policy: Suicide");
             break;
-    }
-
-    if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
-        out->list_item(out, NULL, "Resource management DISABLED (the cluster will not attempt to start, stop, or recover services)");
-    } else {
-        out->list_item(out, NULL, "Resource management enabled");
     }
 
     return 0;
@@ -1292,6 +1294,11 @@ static pcmk__message_entry_t fmt_functions[] = {
     { "group", "html",  pe__group_html },
     { "group", "text",  pe__group_text },
     { "group", "log",  pe__group_text },
+    /* maint-mode only exists for text and log.  Other formatters output it as
+     * part of the cluster-options handler.
+     */
+    { "maint-mode", "log", pe__cluster_maint_mode_text },
+    { "maint-mode", "text", pe__cluster_maint_mode_text },
     { "node", "html", pe__node_html },
     { "node", "log", pe__node_text },
     { "node", "text", pe__node_text },

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -576,10 +576,34 @@ int
 pe__cluster_options_text(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
 
+    out->list_item(out, NULL, "STONITH of failed nodes %s",
+                   is_set(data_set->flags, pe_flag_stonith_enabled) ? "enabled" : "disabled");
+
+    out->list_item(out, NULL, "Cluster is %s",
+                   is_set(data_set->flags, pe_flag_symmetric_cluster) ? "symmetric" : "asymmetric");
+
+    switch (data_set->no_quorum_policy) {
+        case no_quorum_freeze:
+            out->list_item(out, NULL, "No quorum policy: Freeze resources");
+            break;
+
+        case no_quorum_stop:
+            out->list_item(out, NULL, "No quorum policy: Stop ALL resources");
+            break;
+
+        case no_quorum_ignore:
+            out->list_item(out, NULL, "No quorum policy: Ignore");
+            break;
+
+        case no_quorum_suicide:
+            out->list_item(out, NULL, "No quorum policy: Suicide");
+            break;
+    }
+
     if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
-        out->info(out, "\n");
-        out->info(out, "              *** Resource management is DISABLED ***");
-        out->info(out, "  The cluster will not attempt to start, stop or recover services");
+        out->list_item(out, NULL, "Resource management DISABLED (the cluster will not attempt to start, stop, or recover services)");
+    } else {
+        out->list_item(out, NULL, "Resource management enabled");
     }
 
     return 0;

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1164,7 +1164,7 @@ pe__resource_history_xml(pcmk__output_t *out, va_list args) {
     gboolean all = va_arg(args, gboolean);
     int failcount = va_arg(args, int);
     time_t last_failure = va_arg(args, int);
-    gboolean as_header G_GNUC_UNUSED = va_arg(args, gboolean);
+    gboolean as_header = va_arg(args, gboolean);
 
     xmlNodePtr node = pcmk__output_xml_create_parent(out, "resource_history");
     xmlSetProp(node, (pcmkXmlStr) "id", (pcmkXmlStr) rsc_id);
@@ -1189,6 +1189,10 @@ pe__resource_history_xml(pcmk__output_t *out, va_list args) {
             xmlSetProp(node, (pcmkXmlStr) CRM_LAST_FAILURE_PREFIX,
                        (pcmkXmlStr) pcmk__epoch2str(&last_failure));
         }
+    }
+
+    if (as_header == FALSE) {
+        pcmk__output_xml_pop_parent(out);
     }
 
     return 0;

--- a/tools/crm_mon.8.inc
+++ b/tools/crm_mon.8.inc
@@ -7,5 +7,8 @@ crm_mon mode [options]
 /less descriptive in output./
 .SH NOTES
 
+/period specification./
+.SH OUTPUT CONTROL
+
 /command line arguments./
 .SH TIME SPECIFICATION

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -207,7 +207,7 @@ group_by_node_cb(const gchar *option_name, const gchar *optarg, gpointer data, G
 
 static gboolean
 hide_headers_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    show &= ~mon_show_headers;
+    show &= ~mon_show_summary;
     return TRUE;
 }
 
@@ -652,7 +652,7 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
                         mon_cib_connection_destroy(NULL);
                     }
                 }
-                show ^= mon_show_fence_history;
+                show ^= mon_show_fencing;
                 break;
             case 'c':
                 show ^= mon_show_tickets;
@@ -689,10 +689,10 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
                 break;
             case 'D':
                 /* If any header is shown, clear them all, otherwise set them all */
-                if (show & mon_show_headers) {
-                    show &= ~mon_show_headers;
+                if (show & mon_show_summary) {
+                    show &= ~mon_show_summary;
                 } else {
-                    show |= mon_show_headers;
+                    show |= mon_show_summary;
                 }
                 break;
             case 'b':
@@ -722,11 +722,11 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
         print_option_help(out, 't', is_set(options.mon_ops, mon_op_print_timing));
         print_option_help(out, 'A', show & mon_show_attributes);
         print_option_help(out, 'L', show & mon_show_bans);
-        print_option_help(out, 'D', (show & mon_show_headers) == 0);
+        print_option_help(out, 'D', (show & mon_show_summary) == 0);
         print_option_help(out, 'R', is_set(options.mon_ops, mon_op_print_clone_detail));
         print_option_help(out, 'b', is_set(options.mon_ops, mon_op_print_brief));
         print_option_help(out, 'j', is_set(options.mon_ops, mon_op_print_pending));
-        print_option_help(out, 'm', (show & mon_show_fence_history));
+        print_option_help(out, 'm', (show & mon_show_fencing));
         out->info(out, "%s", "\nToggle fields via field letter, type any other key to return");
     }
 
@@ -989,7 +989,7 @@ main(int argc, char **argv)
                 options.mon_ops |= mon_op_fence_full_history;
                 /* fall through to next lower level */
             case 2:
-                show |= mon_show_fence_history;
+                show |= mon_show_fencing;
                 /* fall through to next lower level */
             case 1:
                 options.mon_ops |= mon_op_fence_history;

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -382,8 +382,7 @@ group_by_node_cb(const gchar *option_name, const gchar *optarg, gpointer data, G
 
 static gboolean
 hide_headers_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    show &= ~mon_show_summary;
-    return TRUE;
+    return include_exclude_cb("--exclude", "summary", data, err);
 }
 
 static gboolean
@@ -425,8 +424,7 @@ print_pending_cb(const gchar *option_name, const gchar *optarg, gpointer data, G
 static gboolean
 print_timing_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     options.mon_ops |= mon_op_print_timing;
-    show |= mon_show_operations;
-    return TRUE;
+    return include_exclude_cb("--include", "operations", data, err);
 }
 
 static gboolean
@@ -445,37 +443,31 @@ reconnect_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErro
 
 static gboolean
 show_attributes_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    show |= mon_show_attributes;
-    return TRUE;
+    return include_exclude_cb("--include", "attributes", data, err);
 }
 
 static gboolean
 show_bans_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    show |= mon_show_bans;
-
     if (optarg != NULL) {
         print_neg_location_prefix = optarg;
     }
 
-    return TRUE;
+    return include_exclude_cb("--include", "bans", data, err);
 }
 
 static gboolean
 show_failcounts_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    show |= mon_show_failcounts;
-    return TRUE;
+    return include_exclude_cb("--include", "failcounts", data, err);
 }
 
 static gboolean
 show_operations_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    show |= mon_show_operations;
-    return TRUE;
+    return include_exclude_cb("--include", "failcounts,operations", data, err);
 }
 
 static gboolean
 show_tickets_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    show |= mon_show_tickets;
-    return TRUE;
+    return include_exclude_cb("--include", "tickets", data, err);
 }
 
 static gboolean
@@ -1132,7 +1124,7 @@ main(int argc, char **argv)
 
     if (!args->version) {
         if (args->quiet) {
-            show &= ~mon_show_times;
+            include_exclude_cb("--exclude", "times", NULL, NULL);
         }
 
         if (is_set(options.mon_ops, mon_op_watch_fencing)) {

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -665,7 +665,7 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
                 break;
             case 'o':
                 show ^= mon_show_operations;
-                if ((show & mon_show_operations) == 0) {
+                if (is_not_set(show, mon_show_operations)) {
                     options.mon_ops &= ~mon_op_print_timing;
                 }
                 break;
@@ -689,7 +689,7 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
                 break;
             case 'D':
                 /* If any header is shown, clear them all, otherwise set them all */
-                if (show & mon_show_summary) {
+                if (is_set(show, mon_show_summary)) {
                     show &= ~mon_show_summary;
                 } else {
                     show |= mon_show_summary;
@@ -714,19 +714,19 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
         blank_screen();
 
         out->info(out, "%s", "Display option change mode\n");
-        print_option_help(out, 'c', show & mon_show_tickets);
-        print_option_help(out, 'f', show & mon_show_failcounts);
+        print_option_help(out, 'c', is_set(show, mon_show_tickets));
+        print_option_help(out, 'f', is_set(show, mon_show_failcounts));
         print_option_help(out, 'n', is_set(options.mon_ops, mon_op_group_by_node));
-        print_option_help(out, 'o', show & mon_show_operations);
+        print_option_help(out, 'o', is_set(show, mon_show_operations));
         print_option_help(out, 'r', is_set(options.mon_ops, mon_op_inactive_resources));
         print_option_help(out, 't', is_set(options.mon_ops, mon_op_print_timing));
-        print_option_help(out, 'A', show & mon_show_attributes);
-        print_option_help(out, 'L', show & mon_show_bans);
-        print_option_help(out, 'D', (show & mon_show_summary) == 0);
+        print_option_help(out, 'A', is_set(show, mon_show_attributes));
+        print_option_help(out, 'L', is_set(show,mon_show_bans));
+        print_option_help(out, 'D', is_not_set(show, mon_show_summary));
         print_option_help(out, 'R', is_set(options.mon_ops, mon_op_print_clone_detail));
         print_option_help(out, 'b', is_set(options.mon_ops, mon_op_print_brief));
         print_option_help(out, 'j', is_set(options.mon_ops, mon_op_print_pending));
-        print_option_help(out, 'm', (show & mon_show_fencing));
+        print_option_help(out, 'm', is_set(show, mon_show_fencing));
         out->info(out, "%s", "\nToggle fields via field letter, type any other key to return");
     }
 
@@ -1710,7 +1710,7 @@ mon_refresh_display(gpointer user_data)
     /* Unpack constraints if any section will need them
      * (tickets may be referenced in constraints but not granted yet,
      * and bans need negative location constraints) */
-    if (show & (mon_show_bans | mon_show_tickets)) {
+    if (is_set(show, mon_show_bans) || is_set(show, mon_show_tickets)) {
         xmlNode *cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS,
                                                    mon_data_set->input);
         unpack_constraints(cib_constraints, mon_data_set);

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -54,7 +54,7 @@
  * Definitions indicating which items to print
  */
 
-static unsigned int show = mon_show_default;
+static unsigned int show;
 
 /*
  * Definitions indicating how to output
@@ -114,6 +114,8 @@ struct {
     char *external_agent;
     char *external_recipient;
     unsigned int mon_ops;
+    GSList *user_includes_excludes;
+    GSList *includes_excludes;
 } options = {
     .reconnect_msec = RECONNECT_MSECS,
     .fence_history_level = 1,
@@ -128,6 +130,179 @@ static int cib_connect(gboolean full);
 static void mon_st_callback_event(stonith_t * st, stonith_event_t * e);
 static void mon_st_callback_display(stonith_t * st, stonith_event_t * e);
 static void kick_refresh(gboolean data_updated);
+
+static unsigned int
+all_includes(mon_output_format_t fmt) {
+    if (fmt == mon_output_monitor || fmt == mon_output_plain || fmt == mon_output_console) {
+        return ~mon_show_options;
+    } else {
+        return mon_show_all;
+    }
+}
+
+static unsigned int
+default_includes(mon_output_format_t fmt) {
+    switch (fmt) {
+        case mon_output_monitor:
+        case mon_output_plain:
+        case mon_output_console:
+            return mon_show_stack | mon_show_dc | mon_show_times | mon_show_counts |
+                   mon_show_nodes | mon_show_resources;
+            break;
+
+        case mon_output_xml:
+        case mon_output_legacy_xml:
+            return all_includes(fmt);
+            break;
+
+        case mon_output_html:
+        case mon_output_cgi:
+            return mon_show_summary | mon_show_nodes | mon_show_resources;
+            break;
+
+        default:
+            return 0;
+            break;
+    }
+}
+
+struct {
+    const char *name;
+    unsigned int bit;
+} sections[] = {
+    { "attributes", mon_show_attributes },
+    { "bans", mon_show_bans },
+    { "counts", mon_show_counts },
+    { "dc", mon_show_dc },
+    { "failcounts", mon_show_failcounts },
+    { "fencing", mon_show_fencing },
+    { "nodes", mon_show_nodes },
+    { "operations", mon_show_operations },
+    { "options", mon_show_options },
+    { "resources", mon_show_resources },
+    { "stack", mon_show_stack },
+    { "summary", mon_show_summary },
+    { "tickets", mon_show_tickets },
+    { "times", mon_show_times },
+    { NULL }
+};
+
+static unsigned int
+find_section_bit(const char *name) {
+    for (int i = 0; sections[i].name != NULL; i++) {
+        if (crm_str_eq(sections[i].name, name, FALSE)) {
+            return sections[i].bit;
+        }
+    }
+
+    return 0;
+}
+
+static gboolean
+apply_exclude(const gchar *excludes, GError **error) {
+    char **parts = NULL;
+
+    parts = g_strsplit(excludes, ",", 0);
+    for (char **s = parts; *s != NULL; s++) {
+        unsigned int bit = find_section_bit(*s);
+
+        if (crm_str_eq(*s, "all", TRUE)) {
+            show = 0;
+        } else if (crm_str_eq(*s, "none", TRUE)) {
+            show = all_includes(output_format);
+        } else if (bit != 0) {
+            show &= ~bit;
+        } else {
+            g_set_error(error, G_OPTION_ERROR, CRM_EX_USAGE,
+                        "--exclude options: all, attributes, bans, counts, dc, "
+                        "failcounts, fencing, nodes, none, operations, options, "
+                        "resources, stack, summary, tickets, times");
+            return FALSE;
+        }
+    }
+    g_strfreev(parts);
+
+    return TRUE;
+}
+
+static gboolean
+apply_include(const gchar *includes, GError **error) {
+    char **parts = NULL;
+
+    parts = g_strsplit(includes, ",", 0);
+    for (char **s = parts; *s != NULL; s++) {
+        unsigned int bit = find_section_bit(*s);
+
+        if (crm_str_eq(*s, "all", TRUE)) {
+            show = all_includes(output_format);
+        } else if (crm_str_eq(*s, "default", TRUE) || crm_str_eq(*s, "defaults", TRUE)) {
+            show |= default_includes(output_format);
+        } else if (crm_str_eq(*s, "none", TRUE)) {
+            show = 0;
+        } else if (bit != 0) {
+            show |= bit;
+        } else {
+            g_set_error(error, G_OPTION_ERROR, CRM_EX_USAGE,
+                        "--include options: all, attributes, bans, counts, dc, default, "
+                        "defaults, failcounts, fencing, nodes, none, operations, options, "
+                        "resources, stack, summary, tickets, times");
+            return FALSE;
+        }
+    }
+    g_strfreev(parts);
+
+    return TRUE;
+}
+
+static gboolean
+apply_include_exclude(GSList *lst, mon_output_format_t fmt, GError **error) {
+    gboolean rc = TRUE;
+    GSList *node = lst;
+
+    /* Set the default of what to display here.  Note that we OR everything to
+     * show instead of set show directly because it could have already had some
+     * settings applied to it in main.
+     */
+    show |= default_includes(fmt);
+
+    while (node != NULL) {
+        char *s = node->data;
+
+        if (pcmk__starts_with(s, "--include=")) {
+            rc = apply_include(s+10, error);
+        } else if (pcmk__starts_with(s, "-I=")) {
+            rc = apply_include(s+3, error);
+        } else if (pcmk__starts_with(s, "--exclude=")) {
+            rc = apply_exclude(s+10, error);
+        } else if (pcmk__starts_with(s, "-U=")) {
+            rc = apply_exclude(s+3, error);
+        }
+
+        if (rc != TRUE) {
+            break;
+        }
+
+        node = node->next;
+    }
+
+    return rc;
+}
+
+static gboolean
+user_include_exclude_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+    char *s = crm_strdup_printf("%s=%s", option_name, optarg);
+
+    options.user_includes_excludes = g_slist_append(options.user_includes_excludes, s);
+    return TRUE;
+}
+
+static gboolean
+include_exclude_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+    char *s = crm_strdup_printf("%s=%s", option_name, optarg);
+
+    options.includes_excludes = g_slist_append(options.includes_excludes, s);
+    return TRUE;
+}
 
 static gboolean
 as_cgi_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
@@ -357,6 +532,16 @@ static GOptionEntry addl_entries[] = {
 };
 
 static GOptionEntry display_entries[] = {
+    { "include", 'I', 0, G_OPTION_ARG_CALLBACK, user_include_exclude_cb,
+      "A list of sections to include in the output.\n"
+      INDENT "See `Output Control` help for more information.",
+      "SECTION(s)" },
+
+    { "exclude", 'U', 0, G_OPTION_ARG_CALLBACK, user_include_exclude_cb,
+      "A list of sections to exclude from the output.\n"
+      INDENT "See `Output Control` help for more information.",
+      "SECTION(s)" },
+
     { "group-by-node", 'n', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, group_by_node_cb,
       "Group resources by node",
       NULL },
@@ -689,11 +874,14 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
                 break;
             case 'D':
                 /* If any header is shown, clear them all, otherwise set them all */
-                if (is_set(show, mon_show_summary)) {
+                if (is_set(show, mon_show_stack) || is_set(show, mon_show_dc) ||
+                    is_set(show, mon_show_times) || is_set(show, mon_show_counts)) {
                     show &= ~mon_show_summary;
                 } else {
                     show |= mon_show_summary;
                 }
+                /* Regardless, we don't show options in console mode. */
+                show &= ~mon_show_options;
                 break;
             case 'b':
                 options.mon_ops ^= mon_op_print_brief;
@@ -773,6 +961,14 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
                               "The TIMESPEC in any command line option can be specified in many different\n"
                               "formats.  It can be just an integer number of seconds, a number plus units\n"
                               "(ms/msec/us/usec/s/sec/m/min/h/hr), or an ISO 8601 period specification.\n\n"
+                              "Output Control:\n\n"
+                              "By default, a certain list of sections are written to the output destination.\n"
+                              "The default varies based on the output format - XML includes everything, while\n"
+                              "other output formats will display less.  This list can be modified with the\n"
+                              "--include and --exclude command line options.  Each option may be given multiple\n"
+                              "times on the command line, and each can give a comma-separated list of sections.\n"
+                              "The options are applied to the default set, from left to right as seen on the\n"
+                              "command line.  For a list of valid sections, pass --include=list or --exclude=list.\n\n"
                               "Examples:\n\n"
                               "Display the cluster status on the console with updates as they occur:\n\n"
                               "\tcrm_mon\n\n"
@@ -923,7 +1119,7 @@ main(int argc, char **argv)
         options.mon_ops |= mon_op_one_shot;
     }
 
-    processed_args = pcmk__cmdline_preproc(argv, "ehimpxEL");
+    processed_args = pcmk__cmdline_preproc(argv, "ehimpxEILU");
 
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
         fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
@@ -1053,7 +1249,6 @@ main(int argc, char **argv)
     reconcile_output_format(args);
     add_output_args();
 
-    /* Create the output format - output_format must not be changed after this point. */
     if (args->version && output_format == mon_output_console) {
         /* Use the text output format here if we are in curses mode but were given
          * --version.  Displaying version information uses printf, and then we
@@ -1068,6 +1263,22 @@ main(int argc, char **argv)
         fprintf(stderr, "Error creating output format %s: %s\n",
                 args->output_ty, pcmk_rc_str(rc));
         return clean_up(CRM_EX_ERROR);
+    }
+
+    /* output_format MUST NOT BE CHANGED AFTER THIS POINT. */
+
+    /* Apply --include/--exclude flags we used internally.  There's no error reporting
+     * here because this would be a programming error.
+     */
+    apply_include_exclude(options.includes_excludes, output_format, &error);
+
+    /* And now apply any --include/--exclude flags the user gave on the command line.
+     * These are done in a separate pass from the internal ones because we want to
+     * make sure whatever the user specifies overrides whatever we do.
+     */
+    if (!apply_include_exclude(options.user_includes_excludes, output_format, &error)) {
+        out->err(out, "%s: %s", g_get_prgname(), error->message);
+        return clean_up(0);
     }
 
     crm_mon_register_messages(out);
@@ -1093,9 +1304,7 @@ main(int argc, char **argv)
         }
     }
 
-    /* XML output always prints everything */
     if (output_format == mon_output_xml || output_format == mon_output_legacy_xml) {
-        show = mon_show_all;
         options.mon_ops |= mon_op_print_timing;
     }
 
@@ -1882,6 +2091,7 @@ clean_up(crm_exit_t exit_code)
 
     clean_up_connections();
     free(options.pid_file);
+    g_slist_free_full(options.includes_excludes, free);
 
     pe_free_working_set(mon_data_set);
     mon_data_set = NULL;

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -143,7 +143,7 @@ default_includes(mon_output_format_t fmt) {
         case mon_output_plain:
         case mon_output_console:
             return mon_show_stack | mon_show_dc | mon_show_times | mon_show_counts |
-                   mon_show_nodes | mon_show_resources;
+                   mon_show_nodes | mon_show_resources | mon_show_failures;
             break;
 
         case mon_output_xml:
@@ -153,7 +153,8 @@ default_includes(mon_output_format_t fmt) {
 
         case mon_output_html:
         case mon_output_cgi:
-            return mon_show_summary | mon_show_nodes | mon_show_resources;
+            return mon_show_summary | mon_show_nodes | mon_show_resources |
+                   mon_show_failures;
             break;
 
         default:
@@ -171,6 +172,7 @@ struct {
     { "counts", mon_show_counts },
     { "dc", mon_show_dc },
     { "failcounts", mon_show_failcounts },
+    { "failures", mon_show_failures },
     { "fencing", mon_show_fencing_all },
     { "fencing-failed", mon_show_fence_failed },
     { "fencing-pending", mon_show_fence_pending },
@@ -214,9 +216,10 @@ apply_exclude(const gchar *excludes, GError **error) {
         } else {
             g_set_error(error, G_OPTION_ERROR, CRM_EX_USAGE,
                         "--exclude options: all, attributes, bans, counts, dc, "
-                        "failcounts, fencing, fencing-failed, fencing-pending, "
-                        "fencing-succeeded, nodes, none, operations, options, "
-                        "resources, stack, summary, tickets, times");
+                        "failcounts, failures, fencing, fencing-failed, "
+                        "fencing-pending, fencing-succeeded, nodes, none, "
+                        "operations, options, resources, stack, summary, "
+                        "tickets, times");
             return FALSE;
         }
     }
@@ -254,9 +257,9 @@ apply_include(const gchar *includes, GError **error) {
         } else {
             g_set_error(error, G_OPTION_ERROR, CRM_EX_USAGE,
                         "--include options: all, attributes, bans[:PREFIX], counts, dc, "
-                        "default, failcounts, fencing, fencing-failed, fencing-pending, "
-                        "fencing-succeeded, nodes, none, operations, options, resources, "
-                        "stack, summary, tickets, times");
+                        "default, failcounts, failures, fencing, fencing-failed, "
+                        "fencing-pending, fencing-succeeded, nodes, none, operations, "
+                        "options, resources, stack, summary, tickets, times");
             return FALSE;
         }
     }

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -71,7 +71,6 @@ typedef enum mon_output_format_e {
 
 #define mon_show_summary        (mon_show_stack | mon_show_dc | mon_show_times | \
                                  mon_show_counts | mon_show_options)
-#define mon_show_default        (mon_show_summary | mon_show_nodes | mon_show_resources)
 #define mon_show_all            (mon_show_summary | mon_show_nodes | mon_show_resources | \
                                  mon_show_attributes | mon_show_failcounts | mon_show_operations | \
                                  mon_show_fencing | mon_show_tickets | mon_show_bans)

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -55,27 +55,26 @@ typedef enum mon_output_format_e {
     mon_output_cgi
 } mon_output_format_t;
 
-#define mon_show_times         (0x0001U)
-#define mon_show_stack         (0x0002U)
-#define mon_show_dc            (0x0004U)
-#define mon_show_count         (0x0008U)
-#define mon_show_nodes         (0x0010U)
-#define mon_show_resources     (0x0020U)
-#define mon_show_attributes    (0x0040U)
-#define mon_show_failcounts    (0x0080U)
-#define mon_show_operations    (0x0100U)
-#define mon_show_tickets       (0x0200U)
-#define mon_show_bans          (0x0400U)
-#define mon_show_fence_history (0x0800U)
+#define mon_show_stack          (1 << 0)
+#define mon_show_dc             (1 << 1)
+#define mon_show_times          (1 << 2)
+#define mon_show_counts         (1 << 3)
+#define mon_show_options        (1 << 4)
+#define mon_show_nodes          (1 << 5)
+#define mon_show_resources      (1 << 6)
+#define mon_show_attributes     (1 << 7)
+#define mon_show_failcounts     (1 << 8)
+#define mon_show_operations     (1 << 9)
+#define mon_show_fencing        (1 << 10)
+#define mon_show_tickets        (1 << 11)
+#define mon_show_bans           (1 << 12)
 
-#define mon_show_headers       (mon_show_times | mon_show_stack | mon_show_dc \
-                               | mon_show_count)
-#define mon_show_default       (mon_show_headers | mon_show_nodes \
-                               | mon_show_resources)
-#define mon_show_all           (mon_show_default | mon_show_attributes \
-                               | mon_show_failcounts | mon_show_operations \
-                               | mon_show_tickets | mon_show_bans \
-                               | mon_show_fence_history)
+#define mon_show_summary        (mon_show_stack | mon_show_dc | mon_show_times | \
+                                 mon_show_counts | mon_show_options)
+#define mon_show_default        (mon_show_summary | mon_show_nodes | mon_show_resources)
+#define mon_show_all            (mon_show_summary | mon_show_nodes | mon_show_resources | \
+                                 mon_show_attributes | mon_show_failcounts | mon_show_operations | \
+                                 mon_show_fencing | mon_show_tickets | mon_show_bans)
 
 #define mon_op_group_by_node        (0x0001U)
 #define mon_op_inactive_resources   (0x0002U)

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -65,15 +65,18 @@ typedef enum mon_output_format_e {
 #define mon_show_attributes     (1 << 7)
 #define mon_show_failcounts     (1 << 8)
 #define mon_show_operations     (1 << 9)
-#define mon_show_fencing        (1 << 10)
-#define mon_show_tickets        (1 << 11)
-#define mon_show_bans           (1 << 12)
+#define mon_show_fence_failed   (1 << 10)
+#define mon_show_fence_pending  (1 << 11)
+#define mon_show_fence_worked   (1 << 12)
+#define mon_show_tickets        (1 << 13)
+#define mon_show_bans           (1 << 14)
 
+#define mon_show_fencing_all    (mon_show_fence_failed | mon_show_fence_pending | mon_show_fence_worked)
 #define mon_show_summary        (mon_show_stack | mon_show_dc | mon_show_times | \
                                  mon_show_counts | mon_show_options)
 #define mon_show_all            (mon_show_summary | mon_show_nodes | mon_show_resources | \
                                  mon_show_attributes | mon_show_failcounts | mon_show_operations | \
-                                 mon_show_fencing | mon_show_tickets | mon_show_bans)
+                                 mon_show_fencing_all | mon_show_tickets | mon_show_bans)
 
 #define mon_op_group_by_node        (0x0001U)
 #define mon_op_inactive_resources   (0x0002U)
@@ -88,7 +91,7 @@ typedef enum mon_output_format_e {
 #define mon_op_print_pending        (0x0400U)
 #define mon_op_print_clone_detail   (0x0800U)
 
-#define mon_op_default              (mon_op_print_pending)
+#define mon_op_default              (mon_op_print_pending | mon_op_fence_history | mon_op_fence_connect)
 
 void print_status(pcmk__output_t *out, mon_output_format_t output_format,
                   pe_working_set_t *data_set, stonith_history_t *stonith_history,

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -92,13 +92,13 @@ typedef enum mon_output_format_e {
 
 void print_status(pcmk__output_t *out, mon_output_format_t output_format,
                   pe_working_set_t *data_set, stonith_history_t *stonith_history,
-                  unsigned int mon_ops, unsigned int show, const char *prefix);
+                  unsigned int mon_ops, unsigned int show, char *prefix);
 void print_xml_status(pcmk__output_t *out, mon_output_format_t output_format,
                       pe_working_set_t *data_set, stonith_history_t *stonith_history,
-                      unsigned int mon_ops, unsigned int show, const char *prefix);
+                      unsigned int mon_ops, unsigned int show, char *prefix);
 int print_html_status(pcmk__output_t *out, mon_output_format_t output_format,
                       pe_working_set_t *data_set, stonith_history_t *stonith_history,
-                      unsigned int mon_ops, unsigned int show, const char *prefix);
+                      unsigned int mon_ops, unsigned int show, char *prefix);
 
 GList *append_attr_list(GList *attr_list, char *name);
 void blank_screen(void);

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -70,13 +70,15 @@ typedef enum mon_output_format_e {
 #define mon_show_fence_worked   (1 << 12)
 #define mon_show_tickets        (1 << 13)
 #define mon_show_bans           (1 << 14)
+#define mon_show_failures       (1 << 15)
 
 #define mon_show_fencing_all    (mon_show_fence_failed | mon_show_fence_pending | mon_show_fence_worked)
 #define mon_show_summary        (mon_show_stack | mon_show_dc | mon_show_times | \
                                  mon_show_counts | mon_show_options)
 #define mon_show_all            (mon_show_summary | mon_show_nodes | mon_show_resources | \
                                  mon_show_attributes | mon_show_failcounts | mon_show_operations | \
-                                 mon_show_fencing_all | mon_show_tickets | mon_show_bans)
+                                 mon_show_fencing_all | mon_show_tickets | mon_show_bans | \
+                                 mon_show_failures)
 
 #define mon_op_group_by_node        (0x0001U)
 #define mon_op_inactive_resources   (0x0002U)

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -325,6 +325,16 @@ stonith_event_console(pcmk__output_t *out, va_list args) {
     return 0;
 }
 
+static int
+cluster_maint_mode_console(pcmk__output_t *out, va_list args) {
+    printw("\n              *** Resource management is DISABLED ***");
+    printw("\n  The cluster will not attempt to start, stop or recover services");
+    printw("\n");
+    clrtoeol();
+    refresh();
+    return 0;
+}
+
 static pcmk__message_entry_t fmt_functions[] = {
     { "ban", "console", pe__ban_text },
     { "bundle", "console", pe__bundle_text },
@@ -336,6 +346,7 @@ static pcmk__message_entry_t fmt_functions[] = {
     { "cluster-times", "console", pe__cluster_times_text },
     { "failed-action", "console", pe__failed_action_text },
     { "group", "console", pe__group_text },
+    { "maint-mode", "console", cluster_maint_mode_console },
     { "node", "console", pe__node_text },
     { "node-attribute", "console", pe__node_attribute_text },
     { "op-history", "console", pe__op_history_text },

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -732,6 +732,10 @@ print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
         out->end_list(out);
     }
 
+    if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
+        out->message(out, "maint-mode");
+    }
+
     return header_printed;
 }
 

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -705,7 +705,7 @@ print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
     if (is_set(data_set->flags, pe_flag_maintenance_mode)
         || data_set->disabled_resources
         || data_set->blocked_resources
-        || is_set(show, mon_show_count)) {
+        || is_set(show, mon_show_counts)) {
         if (header_printed == FALSE) {
             out->begin_list(out, NULL, NULL, "Cluster Summary");
             header_printed = TRUE;
@@ -952,7 +952,7 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
 
     print_cluster_summary(out, data_set, mon_ops, show, output_format);
 
-    if (is_set(show, mon_show_headers)) {
+    if (is_set(show, mon_show_summary)) {
         out->info(out, "%s", "");
     }
 
@@ -1130,7 +1130,7 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
             out->info(out, "%s", "");
         }
 
-        if (show & mon_show_fence_history) {
+        if (show & mon_show_fencing) {
             print_stonith_history(out, stonith_history, mon_ops);
         } else {
             print_stonith_pending(out, stonith_history, mon_ops);
@@ -1267,7 +1267,7 @@ print_html_status(pcmk__output_t *out, mon_output_format_t output_format,
 
     /* Print stonith history */
     if (is_set(mon_ops, mon_op_fence_history)) {
-        if (show & mon_show_fence_history) {
+        if (is_set(show, mon_show_fencing)) {
             print_stonith_history(out, stonith_history, mon_ops);
         } else {
             print_stonith_pending(out, stonith_history, mon_ops);

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -530,7 +530,7 @@ print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set, unsigned in
     /* Print each ban */
     for (gIter = data_set->placement_constraints; gIter != NULL; gIter = gIter->next) {
         pe__location_t *location = gIter->data;
-        if (!g_str_has_prefix(location->id, prefix))
+        if (prefix != NULL && !g_str_has_prefix(location->id, prefix))
             continue;
         for (gIter2 = location->node_list_rh; gIter2 != NULL; gIter2 = gIter2->next) {
             pe_node_t *node = (pe_node_t *) gIter2->data;
@@ -933,7 +933,7 @@ print_stonith_history_full(pcmk__output_t *out, stonith_history_t *history, unsi
 void
 print_status(pcmk__output_t *out, mon_output_format_t output_format,
              pe_working_set_t *data_set, stonith_history_t *stonith_history,
-             unsigned int mon_ops, unsigned int show, const char *prefix)
+             unsigned int mon_ops, unsigned int show, char *prefix)
 {
     GListPtr gIter = NULL;
     unsigned int print_opts = get_resource_display_options(mon_ops);
@@ -1157,7 +1157,7 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
 void
 print_xml_status(pcmk__output_t *out, mon_output_format_t output_format,
                  pe_working_set_t *data_set, stonith_history_t *stonith_history,
-                 unsigned int mon_ops, unsigned int show, const char *prefix)
+                 unsigned int mon_ops, unsigned int show, char *prefix)
 {
     GListPtr gIter = NULL;
     unsigned int print_opts = get_resource_display_options(mon_ops);
@@ -1229,7 +1229,7 @@ print_xml_status(pcmk__output_t *out, mon_output_format_t output_format,
 int
 print_html_status(pcmk__output_t *out, mon_output_format_t output_format,
                   pe_working_set_t *data_set, stonith_history_t *stonith_history,
-                  unsigned int mon_ops, unsigned int show, const char *prefix)
+                  unsigned int mon_ops, unsigned int show, char *prefix)
 {
     GListPtr gIter = NULL;
     unsigned int print_opts = get_resource_display_options(mon_ops);

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -69,7 +69,7 @@ static gboolean print_stonith_history_full(pcmk__output_t *out, stonith_history_
  * \brief Print resources section heading appropriate to options
  *
  * \param[in] out     The output functions structure.
- * \param[in] mon_ops Bitmask of mon_op_options.
+ * \param[in] mon_ops Bitmask of mon_op_*.
  */
 static void
 print_resources_heading(pcmk__output_t *out, unsigned int mon_ops)
@@ -97,7 +97,7 @@ print_resources_heading(pcmk__output_t *out, unsigned int mon_ops)
  * \brief Print whatever resource section closing is appropriate
  *
  * \param[in] out     The output functions structure.
- * \param[in] mon_ops Bitmask of mon_op_options.
+ * \param[in] mon_ops Bitmask of mon_op_*.
  */
 static void
 print_resources_closing(pcmk__output_t *out, unsigned int mon_ops)
@@ -122,8 +122,8 @@ print_resources_closing(pcmk__output_t *out, unsigned int mon_ops)
  *
  * \param[in] out           The output functions structure.
  * \param[in] data_set      Cluster state to display.
- * \param[in] print_opts    Bitmask of pe_print_options.
- * \param[in] mon_ops       Bitmask of mon_op_options.
+ * \param[in] print_opts    Bitmask of pe_print_*.
+ * \param[in] mon_ops       Bitmask of mon_op_*.
  * \param[in] brief_output  Whether to display full or brief output.
  * \param[in] print_summary Whether to display a failure summary.
  */
@@ -227,7 +227,7 @@ get_operation_list(xmlNode *rsc_entry) {
  * \param[in] data_set  Cluster state to display.
  * \param[in] node      Node that ran this resource.
  * \param[in] rsc_entry Root of XML tree describing resource status.
- * \param[in] mon_ops   Bitmask of mon_op_options.
+ * \param[in] mon_ops   Bitmask of mon_op_*.
  * \param[in] op_list   A list of operations to print.
  */
 static void
@@ -290,7 +290,7 @@ print_rsc_history(pcmk__output_t *out, pe_working_set_t *data_set, node_t *node,
  * \param[in] data_set   Cluster state to display.
  * \param[in] node_state Root of XML tree describing node status.
  * \param[in] operations Whether to print operations or just failcounts.
- * \param[in] mon_ops    Bitmask of mon_op_options.
+ * \param[in] mon_ops    Bitmask of mon_op_*.
  */
 static void
 print_node_history(pcmk__output_t *out, pe_working_set_t *data_set,
@@ -446,7 +446,7 @@ print_node_attribute(gpointer name, gpointer user_data)
  * \param[in] out        The output functions structure.
  * \param[in] data_set   Cluster state to display.
  * \param[in] operations Whether to print operations or just failcounts.
- * \param[in] mon_ops    Bitmask of mon_op_options.
+ * \param[in] mon_ops    Bitmask of mon_op_*.
  */
 static gboolean
 print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
@@ -517,7 +517,7 @@ print_cluster_tickets(pcmk__output_t *out, pe_working_set_t * data_set)
  *
  * \param[in] out      The output functions structure.
  * \param[in] data_set Cluster state to display.
- * \param[in] mon_ops  Bitmask of mon_op_options.
+ * \param[in] mon_ops  Bitmask of mon_op_*.
  * \param[in] prefix   ID prefix to filter results by.
  */
 static gboolean
@@ -560,7 +560,7 @@ print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set, unsigned in
  *
  * \param[in] out      The output functions structure.
  * \param[in] data_set Cluster state to display.
- * \param[in] mon_ops  Bitmask of mon_op_options.
+ * \param[in] mon_ops  Bitmask of mon_op_*.
  */
 static gboolean
 print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set, unsigned int mon_ops)
@@ -643,7 +643,7 @@ print_cluster_times(pcmk__output_t *out, pe_working_set_t *data_set)
  *
  * \param[in] out      The output functions structure.
  * \param[in] data_set Cluster state to display.
- * \param[in] mon_ops  Bitmask of mon_op_options.
+ * \param[in] mon_ops  Bitmask of mon_op_*.
  */
 static void
 print_cluster_dc(pcmk__output_t *out, pe_working_set_t *data_set, unsigned int mon_ops)
@@ -667,8 +667,8 @@ print_cluster_dc(pcmk__output_t *out, pe_working_set_t *data_set, unsigned int m
  *
  * \param[in] out      The output functions structure.
  * \param[in] data_set Cluster state to display.
- * \param[in] mon_ops  Bitmask of mon_op_options.
- * \param[in] show     Bitmask of mon_show_options.
+ * \param[in] mon_ops  Bitmask of mon_op_*.
+ * \param[in] show     Bitmask of mon_show_*.
  */
 static gboolean
 print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
@@ -773,7 +773,7 @@ print_failed_actions(pcmk__output_t *out, pe_working_set_t *data_set)
  *
  * \param[in] out      The output functions structure.
  * \param[in] history  List of stonith actions.
- * \param[in] mon_ops  Bitmask of mon_op_options.
+ * \param[in] mon_ops  Bitmask of mon_op_*.
  */
 static gboolean
 print_failed_stonith_actions(pcmk__output_t *out, stonith_history_t *history, unsigned int mon_ops)
@@ -815,7 +815,7 @@ print_failed_stonith_actions(pcmk__output_t *out, stonith_history_t *history, un
  *
  * \param[in] out      The output functions structure.
  * \param[in] history  List of stonith actions.
- * \param[in] mon_ops  Bitmask of mon_op_options.
+ * \param[in] mon_ops  Bitmask of mon_op_*.
  */
 static gboolean
 print_stonith_pending(pcmk__output_t *out, stonith_history_t *history, unsigned int mon_ops)
@@ -857,7 +857,7 @@ print_stonith_pending(pcmk__output_t *out, stonith_history_t *history, unsigned 
  *
  * \param[in] out      The output functions structure.
  * \param[in] history  List of stonith actions.
- * \param[in] mon_ops  Bitmask of mon_op_options.
+ * \param[in] mon_ops  Bitmask of mon_op_*.
  */
 static gboolean
 print_stonith_history(pcmk__output_t *out, stonith_history_t *history, unsigned int mon_ops)
@@ -893,7 +893,7 @@ print_stonith_history(pcmk__output_t *out, stonith_history_t *history, unsigned 
  *
  * \param[in] out      The output functions structure.
  * \param[in] history  List of stonith actions.
- * \param[in] mon_ops  Bitmask of mon_op_options.
+ * \param[in] mon_ops  Bitmask of mon_op_*.
  */
 static gboolean
 print_stonith_history_full(pcmk__output_t *out, stonith_history_t *history, unsigned int mon_ops)
@@ -926,8 +926,8 @@ print_stonith_history_full(pcmk__output_t *out, stonith_history_t *history, unsi
  * \param[in] output_format   Is this text or curses output?
  * \param[in] data_set        Cluster state to display.
  * \param[in] stonith_history List of stonith actions.
- * \param[in] mon_ops         Bitmask of mon_op_options.
- * \param[in] show            Bitmask of mon_show_options.
+ * \param[in] mon_ops         Bitmask of mon_op_*.
+ * \param[in] show            Bitmask of mon_show_*.
  * \param[in] prefix          ID prefix to filter results by.
  */
 void
@@ -1150,8 +1150,8 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
  * \param[in] out             The output functions structure.
  * \param[in] data_set        Cluster state to display.
  * \param[in] stonith_history List of stonith actions.
- * \param[in] mon_ops         Bitmask of mon_op_options.
- * \param[in] show            Bitmask of mon_show_options.
+ * \param[in] mon_ops         Bitmask of mon_op_*.
+ * \param[in] show            Bitmask of mon_show_*.
  * \param[in] prefix          ID prefix to filter results by.
  */
 void
@@ -1222,8 +1222,8 @@ print_xml_status(pcmk__output_t *out, mon_output_format_t output_format,
  * \param[in] output_format   Is this HTML or CGI output?
  * \param[in] data_set        Cluster state to display.
  * \param[in] stonith_history List of stonith actions.
- * \param[in] mon_ops         Bitmask of mon_op_options.
- * \param[in] show            Bitmask of mon_show_options.
+ * \param[in] mon_ops         Bitmask of mon_op_*.
+ * \param[in] show            Bitmask of mon_show_*.
  * \param[in] prefix          ID prefix to filter results by.
  */
 int

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -723,6 +723,9 @@ print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
             }
 
             out->begin_list(out, NULL, NULL, "Config Options");
+        } else if (header_printed == FALSE) {
+            out->begin_list(out, NULL, NULL, "Cluster Summary");
+            header_printed = TRUE;
         }
 
         out->message(out, "cluster-options", data_set);

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -29,9 +29,9 @@
 
 static void print_resources_heading(pcmk__output_t *out, unsigned int mon_ops);
 static void print_resources_closing(pcmk__output_t *out, unsigned int mon_ops);
-static gboolean print_resources(pcmk__output_t *out, pe_working_set_t *data_set,
-                                unsigned int print_opts, unsigned int mon_ops, gboolean brief_output,
-                                gboolean print_summary);
+static void print_resources(pcmk__output_t *out, pe_working_set_t *data_set,
+                            unsigned int print_opts, unsigned int mon_ops, gboolean brief_output,
+                            gboolean print_summary);
 static void print_rsc_history(pcmk__output_t *out, pe_working_set_t *data_set,
                               node_t *node, xmlNode *rsc_entry, unsigned int mon_ops,
                               GListPtr op_list);
@@ -41,26 +41,26 @@ static void print_node_history(pcmk__output_t *out, pe_working_set_t *data_set,
 static gboolean add_extra_info(pcmk__output_t *out, node_t * node, GListPtr rsc_list,
                                const char *attrname, int *expected_score);
 static void print_node_attribute(gpointer name, gpointer user_data);
-static gboolean print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
-                                   gboolean operations, unsigned int mon_ops);
-static gboolean print_cluster_tickets(pcmk__output_t *out, pe_working_set_t * data_set);
-static gboolean print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set,
+static void print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
+                               gboolean operations, unsigned int mon_ops);
+static void print_cluster_tickets(pcmk__output_t *out, pe_working_set_t * data_set);
+static void print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set,
                                     unsigned int mon_ops, const char *prefix);
-static gboolean print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set,
-                                      unsigned int mon_ops);
+static void print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set,
+                                  unsigned int mon_ops);
 static void print_cluster_times(pcmk__output_t *out, pe_working_set_t *data_set);
 static void print_cluster_dc(pcmk__output_t *out, pe_working_set_t *data_set,
                              unsigned int mon_ops);
 static gboolean print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
                                       unsigned int mon_ops, unsigned int show,
                                       mon_output_format_t fmt);
-static gboolean print_failed_actions(pcmk__output_t *out, pe_working_set_t *data_set);
-static gboolean print_failed_stonith_actions(pcmk__output_t *out, stonith_history_t *history,
-                                             unsigned int mon_ops);
-static gboolean print_stonith_pending(pcmk__output_t *out, stonith_history_t *history,
-                                      unsigned int mon_ops);
-static gboolean print_stonith_history(pcmk__output_t *out, stonith_history_t *history,
-                                      unsigned int mon_ops);
+static void print_failed_actions(pcmk__output_t *out, pe_working_set_t *data_set);
+static void print_failed_stonith_actions(pcmk__output_t *out, stonith_history_t *history,
+                                         unsigned int mon_ops);
+static void print_stonith_pending(pcmk__output_t *out, stonith_history_t *history,
+                                  unsigned int mon_ops);
+static void print_stonith_history(pcmk__output_t *out, stonith_history_t *history,
+                                  unsigned int mon_ops);
 static gboolean print_stonith_history_full(pcmk__output_t *out, stonith_history_t *history,
                                            unsigned int mon_ops);
 
@@ -127,7 +127,7 @@ print_resources_closing(pcmk__output_t *out, unsigned int mon_ops)
  * \param[in] brief_output  Whether to display full or brief output.
  * \param[in] print_summary Whether to display a failure summary.
  */
-static gboolean
+static void
 print_resources(pcmk__output_t *out, pe_working_set_t *data_set,
                 unsigned int print_opts, unsigned int mon_ops, gboolean brief_output,
                 gboolean print_summary)
@@ -139,8 +139,11 @@ print_resources(pcmk__output_t *out, pe_working_set_t *data_set,
      * we're not showing inactive resources, we have nothing to do
      */
     if (is_set(mon_ops, mon_op_group_by_node) && is_not_set(mon_ops, mon_op_inactive_resources)) {
-        return FALSE;
+        return;
     }
+
+    /* Add a blank line between this section and the one before it. */
+    out->info(out, "%s", "");
 
     print_resources_heading(out, mon_ops);
 
@@ -192,8 +195,6 @@ print_resources(pcmk__output_t *out, pe_working_set_t *data_set,
     }
 
     out->end_list(out);
-
-    return TRUE;
 }
 
 static int
@@ -452,7 +453,7 @@ print_node_attribute(gpointer name, gpointer user_data)
  * \param[in] operations Whether to print operations or just failcounts.
  * \param[in] mon_ops    Bitmask of mon_op_*.
  */
-static gboolean
+static void
 print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
                    gboolean operations, unsigned int mon_ops)
 {
@@ -461,7 +462,7 @@ print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
     gboolean printed_header = FALSE;
 
     if (xmlChildElementCount(cib_status) == 0) {
-        return FALSE;
+        return;
     }
 
     /* Print each node in the CIB status */
@@ -472,6 +473,9 @@ print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
         }
 
         if (printed_header == FALSE) {
+            /* Add a blank line between this section and the one before it. */
+            out->info(out, "%s", "");
+
             if (operations) {
                 out->begin_list(out, NULL, NULL, "Operations");
             } else {
@@ -487,8 +491,6 @@ print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
     if (printed_header == TRUE) {
         out->end_list(out);
     }
-
-    return TRUE;
 }
 
 /*!
@@ -498,15 +500,18 @@ print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
  * \param[in] out      The output functions structure.
  * \param[in] data_set Cluster state to display.
  */
-static gboolean
+static void
 print_cluster_tickets(pcmk__output_t *out, pe_working_set_t * data_set)
 {
     GHashTableIter iter;
     gpointer key, value;
 
     if (g_hash_table_size(data_set->tickets) == 0) {
-        return FALSE;
+        return;
     }
+
+    /* Add a blank line between this section and the one before it. */
+    out->info(out, "%s", "");
 
     /* Print section heading */
     out->begin_list(out, NULL, NULL, "Tickets");
@@ -520,7 +525,6 @@ print_cluster_tickets(pcmk__output_t *out, pe_working_set_t * data_set)
 
     /* Close section */
     out->end_list(out);
-    return TRUE;
 }
 
 /*!
@@ -532,7 +536,7 @@ print_cluster_tickets(pcmk__output_t *out, pe_working_set_t * data_set)
  * \param[in] mon_ops  Bitmask of mon_op_*.
  * \param[in] prefix   ID prefix to filter results by.
  */
-static gboolean
+static void
 print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set, unsigned int mon_ops,
                     const char *prefix)
 {
@@ -549,6 +553,9 @@ print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set, unsigned in
 
             if (node->weight < 0) {
                 if (printed_header == FALSE) {
+                    /* Add a blank line between this section and the one before it. */
+                    out->info(out, "%s", "");
+
                     printed_header = TRUE;
                     out->begin_list(out, NULL, NULL, "Negative Location Constraints");
                 }
@@ -560,9 +567,6 @@ print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set, unsigned in
 
     if (printed_header) {
         out->end_list(out);
-        return TRUE;
-    } else {
-        return FALSE;
     }
 }
 
@@ -574,7 +578,7 @@ print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set, unsigned in
  * \param[in] data_set Cluster state to display.
  * \param[in] mon_ops  Bitmask of mon_op_*.
  */
-static gboolean
+static void
 print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set, unsigned int mon_ops)
 {
     GListPtr gIter = NULL;
@@ -609,6 +613,9 @@ print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set, unsigned 
             }
 
             if (printed_header == FALSE) {
+                /* Add a blank line between this section and the one before it. */
+                out->info(out, "%s", "");
+
                 printed_header = TRUE;
                 out->begin_list(out, NULL, NULL, "Node Attributes");
             }
@@ -625,9 +632,6 @@ print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set, unsigned 
     /* Print section footer */
     if (printed_header) {
         out->end_list(out);
-        return TRUE;
-    } else {
-        return FALSE;
     }
 }
 
@@ -761,14 +765,17 @@ print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
  * \param[in] out      The output functions structure.
  * \param[in] data_set Cluster state to display.
  */
-static gboolean
+static void
 print_failed_actions(pcmk__output_t *out, pe_working_set_t *data_set)
 {
     xmlNode *xml_op = NULL;
 
     if (xmlChildElementCount(data_set->failed) == 0) {
-        return FALSE;
+        return;
     }
+
+    /* Add a blank line between this section and the one before it. */
+    out->info(out, "%s", "");
 
     /* Print section heading */
     out->begin_list(out, NULL, NULL, "Failed Resource Actions");
@@ -781,7 +788,6 @@ print_failed_actions(pcmk__output_t *out, pe_working_set_t *data_set)
 
     /* End section */
     out->end_list(out);
-    return TRUE;
 }
 
 /*!
@@ -794,7 +800,7 @@ print_failed_actions(pcmk__output_t *out, pe_working_set_t *data_set)
  * \param[in] history  List of stonith actions.
  * \param[in] mon_ops  Bitmask of mon_op_*.
  */
-static gboolean
+static void
 print_failed_stonith_actions(pcmk__output_t *out, stonith_history_t *history, unsigned int mon_ops)
 {
     stonith_history_t *hp;
@@ -805,8 +811,11 @@ print_failed_stonith_actions(pcmk__output_t *out, stonith_history_t *history, un
         }
     }
     if (!hp) {
-        return FALSE;
+        return;
     }
+
+    /* Add a blank line between this section and the one before it. */
+    out->info(out, "%s", "");
 
     /* Print section heading */
     out->begin_list(out, NULL, NULL, "Failed Fencing Actions");
@@ -822,8 +831,6 @@ print_failed_stonith_actions(pcmk__output_t *out, stonith_history_t *history, un
 
     /* End section */
     out->end_list(out);
-
-    return TRUE;
 }
 
 /*!
@@ -836,9 +843,11 @@ print_failed_stonith_actions(pcmk__output_t *out, stonith_history_t *history, un
  * \param[in] history  List of stonith actions.
  * \param[in] mon_ops  Bitmask of mon_op_*.
  */
-static gboolean
+static void
 print_stonith_pending(pcmk__output_t *out, stonith_history_t *history, unsigned int mon_ops)
 {
+    gboolean printed_header = FALSE;
+
     /* xml-output always shows the full history
      * so we'll never have to show pending-actions
      * separately
@@ -848,7 +857,14 @@ print_stonith_pending(pcmk__output_t *out, stonith_history_t *history, unsigned 
         stonith_history_t *hp;
 
         /* Print section heading */
-        out->begin_list(out, NULL, NULL, "Pending Fencing Actions");
+        if (printed_header == FALSE) {
+            printed_header = TRUE;
+
+            /* Add a blank line between this section and the one before it. */
+            out->info(out, "%s", "");
+
+            out->begin_list(out, NULL, NULL, "Pending Fencing Actions");
+        }
 
         for (hp = history; hp; hp = hp->next) {
             if ((hp->state == st_failed) || (hp->state == st_done)) {
@@ -860,12 +876,10 @@ print_stonith_pending(pcmk__output_t *out, stonith_history_t *history, unsigned 
         }
 
         /* End section */
-        out->end_list(out);
-
-        return TRUE;
+        if (printed_header == TRUE) {
+            out->end_list(out);
+        }
     }
-
-    return FALSE;
 }
 
 /*!
@@ -878,29 +892,39 @@ print_stonith_pending(pcmk__output_t *out, stonith_history_t *history, unsigned 
  * \param[in] history  List of stonith actions.
  * \param[in] mon_ops  Bitmask of mon_op_*.
  */
-static gboolean
+static void
 print_stonith_history(pcmk__output_t *out, stonith_history_t *history, unsigned int mon_ops)
 {
     stonith_history_t *hp;
+    gboolean printed_header = FALSE;
 
     if (history == NULL) {
-        return FALSE;
+        return;
     }
-
-    /* Print section heading */
-    out->begin_list(out, NULL, NULL, "Fencing History");
 
     for (hp = history; hp; hp = hp->next) {
         if (hp->state != st_failed) {
+            /* Print the header the first time we have an event to print out to
+             * prevent printing headers with empty sections underneath.
+             */
+            if (printed_header == FALSE) {
+                printed_header = TRUE;
+
+                /* Add a blank line between this section and the one before it. */
+                out->info(out, "%s", "");
+
+                out->begin_list(out, NULL, NULL, "Fencing History");
+            }
+
             out->message(out, "stonith-event", hp, is_set(mon_ops, mon_op_fence_full_history),
                          stonith__later_succeeded(hp, history));
             out->increment_list(out);
         }
     }
 
-    /* End section */
-    out->end_list(out);
-    return TRUE;
+    if (printed_header == TRUE) {
+        out->end_list(out);
+    }
 }
 
 /*!
@@ -967,13 +991,13 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
 
     printed = print_cluster_summary(out, data_set, mon_ops, show, output_format);
 
-    if (printed) {
-        out->info(out, "%s", "");
-        printed = FALSE;
-    }
-
     /* Gather node information (and print if in bad state or grouping by node) */
     if (is_set(show, mon_show_nodes)) {
+        if (printed) {
+            out->info(out, "%s", "");
+            printed = FALSE;
+        }
+
         out->begin_list(out, NULL, NULL, "Node List");
         for (gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
             node_t *node = (node_t *) gIter->data;
@@ -1077,83 +1101,49 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
             free(online_guest_nodes);
         }
 
-        printed = TRUE;
         out->end_list(out);
     }
 
     /* Print resources section, if needed */
     if (is_set(show, mon_show_resources)) {
-        if (printed) {
-            out->info(out, "%s", "");
-        }
-
-        printed = print_resources(out, data_set, print_opts, mon_ops,
-                                  is_set(mon_ops, mon_op_print_brief), TRUE);
+        print_resources(out, data_set, print_opts, mon_ops,
+                        is_set(mon_ops, mon_op_print_brief), TRUE);
     }
 
     /* print Node Attributes section if requested */
     if (is_set(show, mon_show_attributes)) {
-        if (printed) {
-            out->info(out, "%s", "");
-        }
-
-        printed = print_node_attributes(out, data_set, mon_ops);
+        print_node_attributes(out, data_set, mon_ops);
     }
 
     /* If requested, print resource operations (which includes failcounts)
      * or just failcounts
      */
     if (is_set(show, mon_show_operations) || is_set(show, mon_show_failcounts)) {
-        if (printed) {
-            out->info(out, "%s", "");
-        }
-
-        printed = print_node_summary(out, data_set,
-                                     is_set(show, mon_show_operations), mon_ops);
+        print_node_summary(out, data_set, is_set(show, mon_show_operations), mon_ops);
     }
 
     /* If there were any failed actions, print them */
     if (is_set(show, mon_show_failures) && xml_has_children(data_set->failed)) {
-        if (printed) {
-            out->info(out, "%s", "");
-        }
-
-        printed = print_failed_actions(out, data_set);
+        print_failed_actions(out, data_set);
     }
 
     /* Print failed stonith actions */
     if (is_set(show, mon_show_fence_failed) && is_set(mon_ops, mon_op_fence_history)) {
-        if (printed) {
-            out->info(out, "%s", "");
-        }
-
-        printed = print_failed_stonith_actions(out, stonith_history, mon_ops);
+        print_failed_stonith_actions(out, stonith_history, mon_ops);
     }
 
     /* Print tickets if requested */
     if (is_set(show, mon_show_tickets)) {
-        if (printed) {
-            out->info(out, "%s", "");
-        }
-
-        printed = print_cluster_tickets(out, data_set);
+        print_cluster_tickets(out, data_set);
     }
 
     /* Print negative location constraints if requested */
     if (is_set(show, mon_show_bans)) {
-        if (printed) {
-            out->info(out, "%s", "");
-        }
-
-        printed = print_neg_locations(out, data_set, mon_ops, prefix);
+        print_neg_locations(out, data_set, mon_ops, prefix);
     }
 
     /* Print stonith history */
     if (is_set(mon_ops, mon_op_fence_history)) {
-        if (printed) {
-            out->info(out, "%s", "");
-        }
-
         if (is_set(show, mon_show_fence_worked)) {
             print_stonith_history(out, stonith_history, mon_ops);
         } else if (is_set(show, mon_show_fence_pending)) {

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -1103,7 +1103,7 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
     }
 
     /* Print failed stonith actions */
-    if (is_set(show, mon_show_fencing) && is_set(mon_ops, mon_op_fence_history)) {
+    if (is_set(show, mon_show_fence_failed) && is_set(mon_ops, mon_op_fence_history)) {
         if (printed) {
             out->info(out, "%s", "");
         }
@@ -1135,9 +1135,9 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
             out->info(out, "%s", "");
         }
 
-        if (is_set(show, mon_show_fencing)) {
+        if (is_set(show, mon_show_fence_worked)) {
             print_stonith_history(out, stonith_history, mon_ops);
-        } else {
+        } else if (is_set(show, mon_show_fence_pending)) {
             print_stonith_pending(out, stonith_history, mon_ops);
         }
     }
@@ -1199,7 +1199,7 @@ print_xml_status(pcmk__output_t *out, mon_output_format_t output_format,
     }
 
     /* Print stonith history */
-    if (is_set(show, mon_show_fencing) && is_set(mon_ops, mon_op_fence_history)) {
+    if (is_set(show, mon_show_fencing_all) && is_set(mon_ops, mon_op_fence_history)) {
         print_stonith_history_full(out, stonith_history, mon_ops);
     }
 
@@ -1272,15 +1272,15 @@ print_html_status(pcmk__output_t *out, mon_output_format_t output_format,
     }
 
     /* Print failed stonith actions */
-    if (is_set(show, mon_show_fencing) && is_set(mon_ops, mon_op_fence_history)) {
+    if (is_set(show, mon_show_fence_failed) && is_set(mon_ops, mon_op_fence_history)) {
         print_failed_stonith_actions(out, stonith_history, mon_ops);
     }
 
     /* Print stonith history */
     if (is_set(mon_ops, mon_op_fence_history)) {
-        if (is_set(show, mon_show_fencing)) {
+        if (is_set(show, mon_show_fence_worked)) {
             print_stonith_history(out, stonith_history, mon_ops);
-        } else {
+        } else if (is_set(show, mon_show_fence_pending)) {
             print_stonith_pending(out, stonith_history, mon_ops);
         }
     }

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -1098,7 +1098,7 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
     }
 
     /* If there were any failed actions, print them */
-    if (xml_has_children(data_set->failed)) {
+    if (is_set(show, mon_show_failures) && xml_has_children(data_set->failed)) {
         if (printed) {
             out->info(out, "%s", "");
         }
@@ -1198,7 +1198,7 @@ print_xml_status(pcmk__output_t *out, mon_output_format_t output_format,
     }
 
     /* If there were any failed actions, print them */
-    if (xml_has_children(data_set->failed)) {
+    if (is_set(show, mon_show_failures) && xml_has_children(data_set->failed)) {
         print_failed_actions(out, data_set);
     }
 
@@ -1271,7 +1271,7 @@ print_html_status(pcmk__output_t *out, mon_output_format_t output_format,
     }
 
     /* If there were any failed actions, print them */
-    if (xml_has_children(data_set->failed)) {
+    if (is_set(show, mon_show_failures) && xml_has_children(data_set->failed)) {
         print_failed_actions(out, data_set);
     }
 

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -677,7 +677,7 @@ print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
     const char *stack_s = get_cluster_stack(data_set);
     gboolean header_printed = FALSE;
 
-    if (show & mon_show_stack) {
+    if (is_set(show, mon_show_stack)) {
         if (header_printed == FALSE) {
             out->begin_list(out, NULL, NULL, "Cluster Summary");
             header_printed = TRUE;
@@ -686,7 +686,7 @@ print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
     }
 
     /* Always print DC if none, even if not requested */
-    if ((data_set->dc_node == NULL) || (show & mon_show_dc)) {
+    if ((data_set->dc_node == NULL) || is_set(show, mon_show_dc)) {
         if (header_printed == FALSE) {
             out->begin_list(out, NULL, NULL, "Cluster Summary");
             header_printed = TRUE;
@@ -694,7 +694,7 @@ print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
         print_cluster_dc(out, data_set, mon_ops);
     }
 
-    if (show & mon_show_times) {
+    if (is_set(show, mon_show_times)) {
         if (header_printed == FALSE) {
             out->begin_list(out, NULL, NULL, "Cluster Summary");
             header_printed = TRUE;
@@ -715,10 +715,7 @@ print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
                      data_set->blocked_resources);
     }
 
-    /* There is not a separate option for showing cluster options, so show with
-     * stack for now; a separate option could be added if there is demand
-     */
-    if (show & mon_show_stack) {
+    if (is_set(show, mon_show_options)) {
         if (fmt == mon_output_html || fmt == mon_output_cgi) {
             /* Kind of a hack - close the list we may have opened earlier in this
              * function so we can put all the options into their own list.  We
@@ -1068,7 +1065,7 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
                               is_set(mon_ops, mon_op_print_brief), TRUE);
 
     /* print Node Attributes section if requested */
-    if (show & mon_show_attributes) {
+    if (is_set(show, mon_show_attributes)) {
         if (printed) {
             out->info(out, "%s", "");
         }
@@ -1079,13 +1076,13 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
     /* If requested, print resource operations (which includes failcounts)
      * or just failcounts
      */
-    if (show & (mon_show_operations | mon_show_failcounts)) {
+    if (is_set(show, mon_show_operations) || is_set(show, mon_show_failcounts)) {
         if (printed) {
             out->info(out, "%s", "");
         }
 
         printed = print_node_summary(out, data_set,
-                                     ((show & mon_show_operations)? TRUE : FALSE), mon_ops);
+                                     is_set(show, mon_show_operations), mon_ops);
     }
 
     /* If there were any failed actions, print them */
@@ -1107,7 +1104,7 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
     }
 
     /* Print tickets if requested */
-    if (show & mon_show_tickets) {
+    if (is_set(show, mon_show_tickets)) {
         if (printed) {
             out->info(out, "%s", "");
         }
@@ -1116,7 +1113,7 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
     }
 
     /* Print negative location constraints if requested */
-    if (show & mon_show_bans) {
+    if (is_set(show, mon_show_bans)) {
         if (printed) {
             out->info(out, "%s", "");
         }
@@ -1130,7 +1127,7 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
             out->info(out, "%s", "");
         }
 
-        if (show & mon_show_fencing) {
+        if (is_set(show, mon_show_fencing)) {
             print_stonith_history(out, stonith_history, mon_ops);
         } else {
             print_stonith_pending(out, stonith_history, mon_ops);
@@ -1173,16 +1170,15 @@ print_xml_status(pcmk__output_t *out, mon_output_format_t output_format,
     print_resources(out, data_set, print_opts, mon_ops, FALSE, FALSE);
 
     /* print Node Attributes section if requested */
-    if (show & mon_show_attributes) {
+    if (is_set(show, mon_show_attributes)) {
         print_node_attributes(out, data_set, mon_ops);
     }
 
     /* If requested, print resource operations (which includes failcounts)
      * or just failcounts
      */
-    if (show & (mon_show_operations | mon_show_failcounts)) {
-        print_node_summary(out, data_set,
-                           ((show & mon_show_operations)? TRUE : FALSE), mon_ops);
+    if (is_set(show, mon_show_operations) || is_set(show, mon_show_failcounts)) {
+        print_node_summary(out, data_set, is_set(show, mon_show_operations), mon_ops);
     }
 
     /* If there were any failed actions, print them */
@@ -1196,12 +1192,12 @@ print_xml_status(pcmk__output_t *out, mon_output_format_t output_format,
     }
 
     /* Print tickets if requested */
-    if (show & mon_show_tickets) {
+    if (is_set(show, mon_show_tickets)) {
         print_cluster_tickets(out, data_set);
     }
 
     /* Print negative location constraints if requested */
-    if (show & mon_show_bans) {
+    if (is_set(show, mon_show_bans)) {
         print_neg_locations(out, data_set, mon_ops, prefix);
     }
 }
@@ -1243,16 +1239,15 @@ print_html_status(pcmk__output_t *out, mon_output_format_t output_format,
                     is_set(mon_ops, mon_op_print_brief), TRUE);
 
     /* print Node Attributes section if requested */
-    if (show & mon_show_attributes) {
+    if (is_set(show, mon_show_attributes)) {
         print_node_attributes(out, data_set, mon_ops);
     }
 
     /* If requested, print resource operations (which includes failcounts)
      * or just failcounts
      */
-    if (show & (mon_show_operations | mon_show_failcounts)) {
-        print_node_summary(out, data_set,
-                           ((show & mon_show_operations)? TRUE : FALSE), mon_ops);
+    if (is_set(show, mon_show_operations) || is_set(show, mon_show_failcounts)) {
+        print_node_summary(out, data_set, is_set(show, mon_show_operations), mon_ops);
     }
 
     /* If there were any failed actions, print them */
@@ -1275,12 +1270,12 @@ print_html_status(pcmk__output_t *out, mon_output_format_t output_format,
     }
 
     /* Print tickets if requested */
-    if (show & mon_show_tickets) {
+    if (is_set(show, mon_show_tickets)) {
         print_cluster_tickets(out, data_set);
     }
 
     /* Print negative location constraints if requested */
-    if (show & mon_show_bans) {
+    if (is_set(show, mon_show_bans)) {
         print_neg_locations(out, data_set, mon_ops, prefix);
     }
 

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -458,28 +458,36 @@ print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
 {
     xmlNode *node_state = NULL;
     xmlNode *cib_status = get_object_root(XML_CIB_TAG_STATUS, data_set->input);
+    gboolean printed_header = FALSE;
 
     if (xmlChildElementCount(cib_status) == 0) {
         return FALSE;
     }
 
-    /* Print heading */
-    if (operations) {
-        out->begin_list(out, NULL, NULL, "Operations");
-    } else {
-        out->begin_list(out, NULL, NULL, "Migration Summary");
-    }
-
     /* Print each node in the CIB status */
     for (node_state = __xml_first_child_element(cib_status); node_state != NULL;
          node_state = __xml_next_element(node_state)) {
-        if (crm_str_eq((const char *)node_state->name, XML_CIB_TAG_STATE, TRUE)) {
-            print_node_history(out, data_set, node_state, operations, mon_ops);
+        if (!crm_str_eq((const char *)node_state->name, XML_CIB_TAG_STATE, TRUE)) {
+            continue;
         }
+
+        if (printed_header == FALSE) {
+            if (operations) {
+                out->begin_list(out, NULL, NULL, "Operations");
+            } else {
+                out->begin_list(out, NULL, NULL, "Migration Summary");
+            }
+
+            printed_header = TRUE;
+        }
+
+        print_node_history(out, data_set, node_state, operations, mon_ops);
     }
 
-    /* Close section */
-    out->end_list(out);
+    if (printed_header == TRUE) {
+        out->end_list(out);
+    }
+
     return TRUE;
 }
 

--- a/tools/fix-manpages
+++ b/tools/fix-manpages
@@ -26,7 +26,7 @@
 # This leaves the --help-all output looking good and removes redundant
 # stuff from the man page.  Feel free to add additional headers here.
 # Not all tools will have all headers.
-/.SH NOTES\|.SH TIME SPECIFICATION/{ n
+/.SH NOTES\|.SH OUTPUT CONTROL\|.SH TIME SPECIFICATION/{ n
 N
 N
 d

--- a/xml/api/crm_mon-2.1.rng
+++ b/xml/api/crm_mon-2.1.rng
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crm-mon"/>
+    </start>
+
+    <define name="element-crm-mon">
+        <optional>
+            <ref name="element-summary" />
+        </optional>
+        <optional>
+            <ref name="nodes-list" />
+        </optional>
+        <optional>
+            <ref name="resources-list" />
+        </optional>
+        <optional>
+            <ref name="node-attributes-list" />
+        </optional>
+        <optional>
+            <ref name="node-history-list" />
+        </optional>
+        <optional>
+            <ref name="failures-list" />
+        </optional>
+        <optional>
+            <ref name="fence-event-list" />
+        </optional>
+        <optional>
+            <ref name="tickets-list" />
+        </optional>
+        <optional>
+            <ref name="bans-list" />
+        </optional>
+    </define>
+
+    <define name="element-summary">
+        <element name="summary">
+            <optional>
+                <element name="stack">
+                    <attribute name="type"> <text /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="current_dc">
+                    <attribute name="present"> <data type="boolean" /> </attribute>
+                    <optional>
+                        <group>
+                            <attribute name="version"> <text /> </attribute>
+                            <attribute name="name"> <text /> </attribute>
+                            <attribute name="id"> <text /> </attribute>
+                            <attribute name="with_quorum"> <data type="boolean" /> </attribute>
+                        </group>
+                    </optional>
+                </element>
+            </optional>
+            <optional>
+                <element name="last_update">
+                    <attribute name="time"> <text /> </attribute>
+                </element>
+                <element name="last_change">
+                    <attribute name="time"> <text /> </attribute>
+                    <attribute name="user"> <text /> </attribute>
+                    <attribute name="client"> <text /> </attribute>
+                    <attribute name="origin"> <text /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="nodes_configured">
+                    <attribute name="number"> <data type="nonNegativeInteger" /> </attribute>
+                </element>
+                <element name="resources_configured">
+                    <attribute name="number"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="disabled"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="blocked"> <data type="nonNegativeInteger" /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="cluster_options">
+                    <attribute name="stonith-enabled"> <data type="boolean" /> </attribute>
+                    <attribute name="symmetric-cluster"> <data type="boolean" /> </attribute>
+                    <attribute name="no-quorum-policy"> <text /> </attribute>
+                    <attribute name="maintenance-mode"> <data type="boolean" /> </attribute>
+                </element>
+            </optional>
+        </element>
+    </define>
+
+    <define name="resources-list">
+        <element name="resources">
+            <zeroOrMore>
+                <ref name="element-resource-list" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="nodes-list">
+        <element name="nodes">
+            <zeroOrMore>
+                <ref name="element-full-node" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="node-attributes-list">
+        <element name="node_attributes">
+            <zeroOrMore>
+                <ref name="element-node-with-attributes" />
+            </zeroOrMore>
+        </element>
+    </define>
+ 
+    <define name="node-history-list">
+        <element name="node_history">
+            <zeroOrMore>
+                <ref name="element-node-history" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="failures-list">
+        <element name="failures">
+            <zeroOrMore>
+                <ref name="element-failure" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="fence-event-list">
+        <element name="fence_history">
+            <zeroOrMore>
+                <externalRef href="fence-event-2.0.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="tickets-list">
+        <element name="tickets">
+            <zeroOrMore>
+                <ref name="element-ticket" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="bans-list">
+        <element name="bans">
+            <zeroOrMore>
+                <ref name="element-ban" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="element-full-node">
+        <element name="node">
+            <attribute name="name"> <text/> </attribute>
+            <attribute name="id"> <text/> </attribute>
+            <attribute name="online"> <data type="boolean" /> </attribute>
+            <attribute name="standby"> <data type="boolean" /> </attribute>
+            <attribute name="standby_onfail"> <data type="boolean" /> </attribute>
+            <attribute name="maintenance"> <data type="boolean" /> </attribute>
+            <attribute name="pending"> <data type="boolean" /> </attribute>
+            <attribute name="unclean"> <data type="boolean" /> </attribute>
+            <attribute name="shutdown"> <data type="boolean" /> </attribute>
+            <attribute name="expected_up"> <data type="boolean" /> </attribute>
+            <attribute name="is_dc"> <data type="boolean" /> </attribute>
+            <attribute name="resources_running"> <data type="nonNegativeInteger" /> </attribute>
+            <attribute name="type">
+                <choice>
+                    <value>unknown</value>
+                    <value>member</value>
+                    <value>remote</value>
+                    <value>ping</value>
+                </choice>
+            </attribute>
+            <optional>
+                <!-- for virtualized pacemaker_remote nodes, crm_mon 1.1.13 uses
+                     "container_id" while later versions use "id_as_resource" -->
+                <choice>
+                    <attribute name="container_id"> <text/> </attribute>
+                    <attribute name="id_as_resource"> <text/> </attribute>
+                </choice>
+            </optional>
+            <ref name="element-resource-list" />
+        </element>
+    </define>
+
+    <define name="element-node-with-attributes">
+        <element name="node">
+            <attribute name="name"> <text /> </attribute>
+            <zeroOrMore>
+                <element name="attribute">
+                    <attribute name="name"> <text /> </attribute>
+                    <attribute name="value"> <text /> </attribute>
+                    <optional>
+                        <attribute name="expected"> <data type="nonNegativeInteger" /> </attribute>
+                    </optional>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="element-node-history">
+        <element name="node">
+            <attribute name="name"> <text /> </attribute>
+            <zeroOrMore>
+                <ref name="element-resource-history" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="element-resource-history">
+        <element name="resource_history">
+            <attribute name="id"> <text /> </attribute>
+            <attribute name="orphan"> <data type="boolean" /> </attribute>
+            <optional>
+                <group>
+                    <attribute name="migration-threshold"> <data type="nonNegativeInteger" /> </attribute>
+                    <optional>
+                        <attribute name="fail-count"> <text /> </attribute>
+                    </optional>
+                    <optional>
+                        <attribute name="last-failure"> <text /> </attribute>
+                    </optional>
+                </group>
+            </optional>
+            <zeroOrMore>
+                <ref name="element-operation-history" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="element-operation-history">
+        <element name="operation_history">
+            <attribute name="call"> <text /> </attribute>
+            <attribute name="task"> <text /> </attribute>
+            <optional>
+                <attribute name="interval"> <text /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="last-rc-change"> <text /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="last-run"> <text /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="exec-time"> <text /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="queue-time"> <text /> </attribute>
+            </optional>
+            <attribute name="rc"> <data type="integer" /> </attribute>
+            <attribute name="rc_text"> <text /> </attribute>
+        </element>
+    </define>
+
+    <define name="element-failure">
+        <element name="failure">
+            <choice>
+                <attribute name="op_key"> <text/> </attribute>
+                <attribute name="id"> <text/> </attribute>
+            </choice>
+            <attribute name="node"> <text /> </attribute>
+            <attribute name="exitstatus"> <text /> </attribute>
+            <attribute name="exitreason"> <text /> </attribute>
+            <attribute name="exitcode"> <data type="nonNegativeInteger" /> </attribute>
+            <attribute name="call"> <data type="nonNegativeInteger" /> </attribute>
+            <attribute name="status"> <text /> </attribute>
+            <optional>
+                <group>
+                    <attribute name="last-rc-change"> <text /> </attribute>
+                    <attribute name="queued"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="exec"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="interval"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="task"> <text /> </attribute>
+                </group>
+            </optional>
+        </element>
+    </define>
+
+    <define name="element-ticket">
+        <element name="ticket">
+            <attribute name="id"> <text /> </attribute>
+            <attribute name="status">
+                <choice>
+                    <value>granted</value>
+                    <value>revoked</value>
+                </choice>
+            </attribute>
+            <attribute name="standby"> <data type="boolean" /> </attribute>
+            <optional>
+                <attribute name="last-granted"> <text /> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="element-ban">
+        <element name="ban">
+            <attribute name="id"> <text /> </attribute>
+            <attribute name="resource"> <text /> </attribute>
+            <attribute name="node"> <text /> </attribute>
+            <attribute name="weight"> <data type="integer" /> </attribute>
+            <attribute name="master_only"> <data type="boolean" /> </attribute>
+        </element>
+    </define>
+
+    <define name="element-resource-list">
+        <interleave>
+            <zeroOrMore>
+                <ref name="element-bundle" />
+            </zeroOrMore>
+            <zeroOrMore>
+                <ref name="element-clone" />
+            </zeroOrMore>
+            <zeroOrMore>
+                <ref name="element-group" />
+            </zeroOrMore>
+            <zeroOrMore>
+                <ref name="element-resource" />
+            </zeroOrMore>
+        </interleave>
+    </define>
+
+    <define name="element-bundle">
+        <element name="bundle">
+            <attribute name="id"> <text/> </attribute>
+            <attribute name="type">
+                <choice>
+                    <value>docker</value>
+                    <value>rkt</value>
+                    <value>podman</value>
+                </choice>
+            </attribute>
+            <attribute name="image"> <text/> </attribute>
+            <attribute name="unique"> <data type="boolean" /> </attribute>
+            <attribute name="managed"> <data type="boolean" /> </attribute>
+            <attribute name="failed"> <data type="boolean" /> </attribute>
+            <zeroOrMore>
+                <element name="replica">
+                    <attribute name="id"> <data type="nonNegativeInteger" /> </attribute>
+                    <zeroOrMore>
+                        <ref name="element-resource" />
+                    </zeroOrMore>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="element-clone">
+        <element name="clone">
+            <attribute name="id"> <text/> </attribute>
+            <attribute name="multi_state"> <data type="boolean" /> </attribute>
+            <attribute name="unique"> <data type="boolean" /> </attribute>
+            <attribute name="managed"> <data type="boolean" /> </attribute>
+            <attribute name="failed"> <data type="boolean" /> </attribute>
+            <attribute name="failure_ignored"> <data type="boolean" /> </attribute>
+            <optional>
+                <attribute name="target_role"> <text/> </attribute>
+            </optional>
+            <ref name="element-resource-list" />
+        </element>
+    </define>
+
+    <define name="element-group">
+        <element name="group">
+            <attribute name="id"> <text/> </attribute>
+            <attribute name="number_resources"> <data type="nonNegativeInteger" /> </attribute>
+            <ref name="element-resource-list" />
+        </element>
+    </define>
+
+    <define name="element-resource">
+        <element name="resource">
+            <attribute name="id"> <text/> </attribute>
+            <attribute name="resource_agent"> <text/> </attribute>
+            <attribute name="role"> <text/> </attribute>
+            <optional>
+                <attribute name="target_role"> <text/> </attribute>
+            </optional>
+            <attribute name="active"> <data type="boolean" /> </attribute>
+            <attribute name="orphaned"> <data type="boolean" /> </attribute>
+            <optional>
+                <attribute name="blocked"> <data type="boolean" /> </attribute>
+            </optional>
+            <attribute name="managed"> <data type="boolean" /> </attribute>
+            <attribute name="failed"> <data type="boolean" /> </attribute>
+            <attribute name="failure_ignored"> <data type="boolean" /> </attribute>
+            <attribute name="nodes_running_on"> <data type="nonNegativeInteger" />  </attribute>
+            <optional>
+                <attribute name="pending"> <text/> </attribute>
+            </optional>
+            <zeroOrMore>
+                <!-- crm_mon prints the node only if group-by-node is false -->
+                <element name="node">
+                    <attribute name="name"> <text/> </attribute>
+                    <attribute name="id"> <text/> </attribute>
+                    <attribute name="cached"> <data type="boolean" /> </attribute>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+</grammar>

--- a/xml/crm_mon.rng
+++ b/xml/crm_mon.rng
@@ -9,7 +9,7 @@
     <define name="element-crm_mon-old">
         <element name="crm_mon">
             <attribute name="version"> <text/> </attribute>
-            <externalRef href="api/crm_mon-2.0.rng" />
+            <externalRef href="api/crm_mon-2.1.rng" />
         </element>
     </define>
 


### PR DESCRIPTION
I'm not sure I am done testing this, but the final patches are likely to look very much like these.  Basically, --include and --exclude are added as command line options.  Each can be specified multiple times, and each time can have a comma-separated list of output sections.  These options build off the defaults and can be mixed with older options line --failcounts, --inactive, and --operations.  They are just different ways of manipulating the `show` bitfield.