### PR TITLE
Fix: tools: Correct the crm_mon man page.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -76,7 +76,7 @@ HELP2MAN_ARGS = -N --section 8 --name "Part of the Pacemaker cluster resource ma
 			-h --help-all 						\
 			--no-discard-stderr 					\
 			-i $(top_srcdir)/tools/$@.inc $(abs_builddir)/$<		\
-			| sed -e '/.SS "Usage:"/,+3d' > $@ ;			\
+			| sed -f $(top_srcdir)/tools/fix-manpages > $@ ; \
 	else									\
 		PATH=$(abs_builddir):$$PATH $(HELP2MAN) $(HELP2MAN_ARGS)	\
 			$(abs_builddir)/$< --output $@ ;			\

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST		= crm_diff.8.inc \
 			  crm_mon.sysconfig		\
 			  crm_mon.8.inc			\
 			  crm_node.8.inc \
+			  fix-manpages \
 			  stonith_admin.8.inc
 
 sbin_PROGRAMS		= attrd_updater \

--- a/tools/crm_mon.8.inc
+++ b/tools/crm_mon.8.inc
@@ -3,3 +3,9 @@ crm_mon mode [options]
 
 /number of different formats/
 .SH OPTIONS
+
+/less descriptive in output./
+.SH NOTES
+
+/command line arguments./
+.SH TIME SPECIFICATION

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -764,10 +764,14 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
         { NULL }
     };
 
-    const char *description = "*Notes*\n\n"
+    const char *description = "Notes:\n\n"
                               "If this program is called as crm_mon.cgi, --output-as=html --html-cgi will\n"
                               "automatically be added to the command line arguments.\n\n"
-                              "*Examples*\n\n"
+                              "Time Specification:\n\n"
+                              "The TIMESPEC in any command line option can be specified in many different\n"
+                              "formats.  It can be just an integer number of seconds, a number plus units\n"
+                              "(ms/msec/us/usec/s/sec/m/min/h/hr), or an ISO 8601 period specification.\n\n"
+                              "Examples:\n\n"
                               "Display the cluster status on the console with updates as they occur:\n\n"
                               "\tcrm_mon\n\n"
                               "Display the cluster status on the console just once then exit:\n\n"
@@ -777,11 +781,7 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
                               "Start crm_mon as a background daemon and have it write the cluster status to an HTML file:\n\n"
                               "\tcrm_mon --daemonize --output-as html --output-to /path/to/docroot/filename.html\n\n"
                               "Start crm_mon and export the current cluster status as XML to stdout, then exit:\n\n"
-                              "\tcrm_mon --output-as xml\n\n"
-                              "*Time Specification*\n\n"
-                              "The TIMESPEC in any command line option can be specified in many different\n"
-                              "formats.  It can be just an integer number of seconds, a number plus units\n"
-                              "(ms/msec/us/usec/s/sec/m/min/h/hr), or an ISO 8601 period specification.\n";
+                              "\tcrm_mon --output-as xml\n\n";
 
     context = pcmk__build_arg_context(args, "console (default), html, text, xml", group);
     pcmk__add_main_args(context, extra_prog_entries);

--- a/tools/fix-manpages
+++ b/tools/fix-manpages
@@ -1,0 +1,33 @@
+# Because tools/*.8.inc include a synopsis, the following line removes
+# a redundant Usage: header from the man page and the couple lines after
+# it.
+/.SS "Usage:"/,+3d
+
+# The tools/*.8.inc files also include some additional section headers
+# on a per-tool basis.  These section headers will get printed out as
+# .SH lines, but then the header from the --help-all output will also
+# get turned into groff.  For instance, the following will be in the
+# man page for NOTES:
+#
+# .SH NOTES
+# .PP
+# Notes:
+# .PP
+#
+# The following block looks for any of those additional headers.  The
+# 'n' command puts the next line in the pattern space, the two 'N'
+# commands append the next two lines, and then the 'd' command deletes
+# them.  So basically, this just deletes
+#
+# .PP
+#  Notes:
+# .PP
+#
+# This leaves the --help-all output looking good and removes redundant
+# stuff from the man page.  Feel free to add additional headers here.
+# Not all tools will have all headers.
+/.SH NOTES\|.SH TIME SPECIFICATION/{ n
+N
+N
+d
+}


### PR DESCRIPTION
This moves the notes and time specification sections out of crm_mon's
help output and into crm_mon.8.inc so they get included in the man page.
The help output contains a reference to the man page so people know
what's up with TIMESPEC.

Previously, I was using asterisks around the section names to set them
apart in the man page.  This served to turn those names into proper man
page sections, while as the same time looking reasonably good in the
help output.  However, this asterisk trick does not work with older
versions of help2man, such as is used in the epel7 mock chroot (and
therefore presumably, on RHEL7 builders).