### PR TITLE
Low: fenced: Remove relayed stonith operation.(Fix:CLBZ#5401)

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2441,6 +2441,50 @@ stonith_send_reply(xmlNode * reply, int call_options, const char *remote_peer,
     }
 }
 
+static void remove_relay_op(xmlNode * request)
+{
+    xmlNode *dev = get_xpath_object("//@" F_STONITH_ACTION, request, LOG_TRACE);
+    xmlNode *dev2 = get_xpath_object("//"F_STONITH_CALLDATA"//"STONITH_OP_RELAY, request, LOG_TRACE);
+    const char *relay_op_id = NULL;
+    const char *target = NULL;
+    remote_fencing_op_t *relay_op = NULL;
+
+    if (dev2) {
+        relay_op_id = crm_element_value(dev2, F_STONITH_REMOTE_OP_ID);
+    }
+
+    if (dev) {
+        target = crm_element_value(dev, F_STONITH_TARGET); 
+    }
+
+    /* Delete RELAY operation. */
+    if (relay_op_id && target && safe_str_eq(target, stonith_our_uname)) {
+        relay_op = g_hash_table_lookup(stonith_remote_op_list, relay_op_id);
+
+        if (relay_op) {
+            GHashTableIter iter;
+            remote_fencing_op_t *list_op = NULL;
+            g_hash_table_iter_init(&iter, stonith_remote_op_list);
+        
+            /* If the operation to be deleted is registered as a duplicate, delete the registration. */
+            while (g_hash_table_iter_next(&iter, NULL, (void **)&list_op)) {
+                GListPtr dup_iter = NULL;
+                if (list_op != relay_op) {
+                    for (dup_iter = list_op->duplicates; dup_iter != NULL; dup_iter = dup_iter->next) {
+                        remote_fencing_op_t *other = dup_iter->data;
+                        if (other == relay_op) {
+                            other->duplicates = g_list_remove(other->duplicates, relay_op);
+                            break;
+                        }
+                    }
+                }
+            }
+            crm_info("Delete the relay op: %s - %s of %s for %s", 
+                  relay_op->id, relay_op->action, relay_op->target, relay_op->client_name);
+            g_hash_table_remove(stonith_remote_op_list, relay_op_id);
+        }
+    }
+}
 static int
 handle_request(crm_client_t * client, uint32_t id, uint32_t flags, xmlNode * request,
                const char *remote_peer)
@@ -2488,6 +2532,9 @@ handle_request(crm_client_t * client, uint32_t id, uint32_t flags, xmlNode * req
         if (remote_peer) {
             create_remote_stonith_op(client_id, request, TRUE); /* Record it for the future notification */
         }
+
+        remove_relay_op(request);
+
         stonith_query(request, remote_peer, client_id, call_options);
         return 0;
 
@@ -2568,6 +2615,7 @@ handle_request(crm_client_t * client, uint32_t id, uint32_t flags, xmlNode * req
 
             if (alternate_host && client) {
                 const char *client_id = NULL;
+                remote_fencing_op_t *op = NULL;
 
                 crm_notice("Forwarding complex self fencing request to peer %s", alternate_host);
 
@@ -2578,8 +2626,9 @@ handle_request(crm_client_t * client, uint32_t id, uint32_t flags, xmlNode * req
                 }
 
                 /* Create a record of it, otherwise call_id will be 0 if we need to notify of failures */
-                create_remote_stonith_op(client_id, request, FALSE);
+                op = create_remote_stonith_op(client_id, request, FALSE);
 
+                crm_xml_add(request, F_STONITH_REMOTE_OP_ID, op->id);
                 crm_xml_add(request, F_STONITH_OPERATION, STONITH_OP_RELAY);
                 crm_xml_add(request, F_STONITH_CLIENTID, client->id);
                 send_cluster_message(crm_get_peer(0, alternate_host), crm_msg_stonith_ng, request,

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -965,6 +965,7 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
     remote_fencing_op_t *op = NULL;
     xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, request, LOG_TRACE);
     int call_options = 0;
+    const char *operation = NULL;
 
     init_stonith_remote_op_hash_table(&stonith_remote_op_list);
 
@@ -1013,7 +1014,15 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
         op->client_id = strdup(client);
     }
 
-    op->client_name = crm_element_value_copy(request, F_STONITH_CLIENTNAME);
+    /* For a RELAY operation, set fenced on the client. */
+    operation = crm_element_value(request, F_STONITH_OPERATION);
+
+    if (crm_str_eq(operation, STONITH_OP_RELAY, TRUE)) { 
+        op->client_name = crm_strdup_printf("%s.%lu", crm_system_name,
+                                         (unsigned long) getpid());
+    } else {
+        op->client_name = crm_element_value_copy(request, F_STONITH_CLIENTNAME);
+    } 
 
     op->target = crm_element_value_copy(dev, F_STONITH_TARGET);
     op->request = copy_xml(request);    /* TODO: Figure out how to avoid this */
@@ -1063,6 +1072,9 @@ initiate_remote_stonith_op(crm_client_t * client, xmlNode * request, gboolean ma
     xmlNode *query = NULL;
     const char *client_id = NULL;
     remote_fencing_op_t *op = NULL;
+    xmlNode *data = NULL;
+    const char *relay_op_id = NULL;
+    const char *operation = NULL;
 
     if (client) {
         client_id = client->id;
@@ -1103,8 +1115,19 @@ initiate_remote_stonith_op(crm_client_t * client, xmlNode * request, gboolean ma
                        op->action, op->target, op->id, op->state);
     }
 
+    /* In case of RELAY operation, RELAY information is added to the query to delete the original operation of RELAY. */
+    operation = crm_element_value(request, F_STONITH_OPERATION);
+
+    if (crm_str_eq(operation, STONITH_OP_RELAY, TRUE)) { 
+        data = create_xml_node(NULL, STONITH_OP_RELAY);
+        relay_op_id = crm_element_value(request, F_STONITH_REMOTE_OP_ID);     
+        if (relay_op_id) {
+            crm_xml_add(data, F_STONITH_REMOTE_OP_ID, relay_op_id);
+        }
+    }
+
     query = stonith_create_op(op->client_callid, op->id, STONITH_OP_QUERY,
-                              NULL, op->call_options);
+                              data, op->call_options);
 
     crm_xml_add(query, F_STONITH_REMOTE_OP_ID, op->id);
     crm_xml_add(query, F_STONITH_TARGET, op->target);


### PR DESCRIPTION
Hi All,

This fix corrects the following Bugzilla issue.

 - https://bugs.clusterlabs.org/show_bug.cgi?id=5401

In this modification, the message is embedded in the query data that responds to the RELAY message, and the RELAY message created by the DC node is deleted.

This fix also changes the client from which the relayed STONITH is run to a fenced process.
```
[root@rh77hv-02 ~]# crm_mon -1 -Af -m3
Cluster Summary:
  * Stack: corosync
  * Current DC: rh77hv-01 (version 2.0.3-31b90be8ef) - partition with quorum
  * Last updated: Thu Nov 21 14:25:36 2019
  * Last change:  Thu Nov 21 14:23:41 2019 by root via cibadmin on rh77hv-01
  * 3 nodes configured
  * 3 resource instances configured

Node List:
  * Node rh77hv-01: UNCLEAN (online)
  * Online: [ rh77hv-02 ]
(snip)
Failed Fencing Actions:
  * reboot of rh77hv-01 failed: delegate=rh77hv-02, client=pacemaker-fenced.2864, origin=rh77hv-02, completed='2019-11-21 14:25:08 +09:00' 
(snip)
```

This problem does not occur except for relayed STONITH operation.

Best Regards,
Hideo Yamauchi.
