### PR TITLE
Fix: scheduler: make sure cluster-wide maintenance-mode=true overrides per-resource settings

### DIFF
--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -530,7 +530,8 @@ common_unpack(xmlNode * xml_obj, resource_t ** rsc,
             set_bit((*rsc)->flags, pe_rsc_maintenance);
         }
 
-    } else if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
+    }
+    if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
         clear_bit((*rsc)->flags, pe_rsc_managed);
         set_bit((*rsc)->flags, pe_rsc_maintenance);
     }


### PR DESCRIPTION
Both primitive and cluster may have maintenance attribute.
When a primitive has is-managed=true, maintenance=false
and the cluster has maintenance-mode=true, the maintenance-mode
wouldn't previously override the is-managed attribute as expected.