### PR TITLE
sync pacemakerd with sbd

### DIFF
--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -564,47 +564,47 @@ pcmk_ipc_created(qb_ipcs_connection_t * c)
 }
 
 static void
-pcmk_handle_ping_request( crm_client_t *c, xmlNode *msg, uint32_t id)
+pcmk_handle_ping_request(crm_client_t *c, xmlNode *msg, uint32_t id)
 {
-        const char *value = NULL;
-        xmlNode *ping = NULL;
-        xmlNode *reply = NULL;
-        time_t pinged = time(NULL);
-        const char *from = crm_element_value(msg, F_CRM_SYS_FROM);
+    const char *value = NULL;
+    xmlNode *ping = NULL;
+    xmlNode *reply = NULL;
+    time_t pinged = time(NULL);
+    const char *from = crm_element_value(msg, F_CRM_SYS_FROM);
 
-        /* Pinged for status */
-        crm_trace("Pinged from %s.%s",
-                  crm_element_value(msg, F_CRM_ORIGIN),
-                  from?from:"unknown");
-        ping = create_xml_node(NULL, XML_CRM_TAG_PING);
-        value = crm_element_value(msg, F_CRM_SYS_TO);
-        crm_xml_add(ping, XML_PING_ATTR_SYSFROM, value);
-        crm_xml_add(ping, XML_PING_ATTR_PACEMAKERDSTATE, pacemakerd_state);
-        crm_xml_add_ll(ping, XML_ATTR_TSTAMP, (long long) pinged);
-        crm_xml_add(ping, XML_PING_ATTR_STATUS, "ok");
-        reply = create_reply(msg, ping);
-        free_xml(ping);
-        if (reply) {
-            if (crm_ipcs_send(c, id, reply, crm_ipc_server_event) <= 0) {
-                crm_err("Failed sending ping-reply");
-            }
-            free_xml(reply);
-        } else {
-            crm_err("Failed building ping-reply");
+    /* Pinged for status */
+    crm_trace("Pinged from %s.%s",
+              crm_element_value(msg, F_CRM_ORIGIN),
+              from?from:"unknown");
+    ping = create_xml_node(NULL, XML_CRM_TAG_PING);
+    value = crm_element_value(msg, F_CRM_SYS_TO);
+    crm_xml_add(ping, XML_PING_ATTR_SYSFROM, value);
+    crm_xml_add(ping, XML_PING_ATTR_PACEMAKERDSTATE, pacemakerd_state);
+    crm_xml_add_ll(ping, XML_ATTR_TSTAMP, (long long) pinged);
+    crm_xml_add(ping, XML_PING_ATTR_STATUS, "ok");
+    reply = create_reply(msg, ping);
+    free_xml(ping);
+    if (reply) {
+        if (crm_ipcs_send(c, id, reply, crm_ipc_server_event) <= 0) {
+            crm_err("Failed sending ping-reply");
         }
-        /* just proceed state on sbd pinging us */
-        if (from && strstr(from, "sbd")) {
-            if (crm_str_eq(pacemakerd_state,
-                           XML_PING_ATTR_PACEMAKERDSTATE_SHUTDOWNCOMPLETE,
-                           TRUE)) {
-                shutdown_complete_state_reported_to = c->pid;
-            } else if (crm_str_eq(pacemakerd_state,
-                                  XML_PING_ATTR_PACEMAKERDSTATE_WAITPING,
-                                  TRUE)) {
-                pacemakerd_state = XML_PING_ATTR_PACEMAKERDSTATE_STARTINGDAEMONS;
-                mainloop_set_trigger(startup_trigger);
-            }
+        free_xml(reply);
+    } else {
+        crm_err("Failed building ping-reply");
+    }
+    /* just proceed state on sbd pinging us */
+    if (from && strstr(from, "sbd")) {
+        if (crm_str_eq(pacemakerd_state,
+                       XML_PING_ATTR_PACEMAKERDSTATE_SHUTDOWNCOMPLETE,
+                       TRUE)) {
+            shutdown_complete_state_reported_to = c->pid;
+        } else if (crm_str_eq(pacemakerd_state,
+                              XML_PING_ATTR_PACEMAKERDSTATE_WAITPING,
+                              TRUE)) {
+            pacemakerd_state = XML_PING_ATTR_PACEMAKERDSTATE_STARTINGDAEMONS;
+            mainloop_set_trigger(startup_trigger);
         }
+    }
 }
 
 /* Exit code means? */

--- a/include/crm/common/Makefile.am
+++ b/include/crm/common/Makefile.am
@@ -12,7 +12,7 @@ MAINTAINERCLEANFILES = Makefile.in
 headerdir=$(pkgincludedir)/crm/common
 
 header_HEADERS = xml.h ipc.h util.h iso8601.h mainloop.h logging.h results.h \
-		 nvpair.h
+		 nvpair.h pacemakerd_types.h
 noinst_HEADERS = cib_secrets.h ipcs.h internal.h alerts_internal.h \
 		 iso8601_internal.h remote_internal.h xml_internal.h \
 		 ipc_internal.h output.h cmdline_internal.h curses_internal.h

--- a/include/crm/common/pacemakerd_types.h
+++ b/include/crm/common/pacemakerd_types.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2004-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PACEMAKERD_TYPES__H
+#  define PACEMAKERD_TYPES__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <time.h>
+
+enum pacemakerd_conn_state {
+    pacemakerd_conn_connected,
+    pacemakerd_conn_disconnected
+};
+
+enum pacemakerd_state {
+    pacemakerd_state_invalid = -1,
+    pacemakerd_state_init = 0,
+    pacemakerd_state_starting_daemons,
+    pacemakerd_state_wait_for_ping,
+    pacemakerd_state_running,
+    pacemakerd_state_shutting_down,
+    pacemakerd_state_shutdown_complete,
+    pacemakerd_state_max = pacemakerd_state_shutdown_complete,
+};
+
+typedef struct pacemakerd_s pacemakerd_t;
+
+typedef struct pacemakerd_api_operations_s {
+    int (*connect) (pacemakerd_t *pacemakerd, const char *name);
+    int (*disconnect) (pacemakerd_t *pacemakerd);
+    void (*free) (pacemakerd_t *pacemakerd);
+    int (*set_ping_callback) (pacemakerd_t *pacemakerd,
+                              void (*callback) (pacemakerd_t *pacemakerd,
+                                                time_t last_good,
+                                                enum pacemakerd_state state,
+                                                int rc, gpointer userdata),
+                              gpointer userdata);
+    int (*set_disconnect_callback) (pacemakerd_t *pacemakerd,
+                                    void (*callback) (gpointer userdata),
+                                    gpointer userdata
+                                    );
+    int (*ping) (pacemakerd_t *pacemakerd, const char *name,
+                 const char *admin_uuid, int call_options);
+} pacemakerd_api_operations_t;
+
+struct pacemakerd_s {
+    enum pacemakerd_conn_state conn_state;
+    void *pacemakerd_private;
+    pacemakerd_api_operations_t *cmds;
+};
+
+pacemakerd_t * pacemakerd_api_new(void);
+void pacemakerd_api_delete(pacemakerd_t * pacemakerd);
+enum pacemakerd_state pacemakerd_state_text2enum(const char *state);
+const char *pacemakerd_state_enum2text(enum pacemakerd_state state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PACEMAKERD_TYPES__H

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -123,6 +123,13 @@ extern "C" {
 #  define XML_PING_ATTR_STATUS		"result"
 #  define XML_PING_ATTR_SYSFROM		"crm_subsystem"
 #  define XML_PING_ATTR_CRMDSTATE   "crmd_state"
+#  define XML_PING_ATTR_PACEMAKERDSTATE "pacemakerd_state"
+#  define XML_PING_ATTR_PACEMAKERDSTATE_INIT "init"
+#  define XML_PING_ATTR_PACEMAKERDSTATE_STARTINGDAEMONS "starting_daemons"
+#  define XML_PING_ATTR_PACEMAKERDSTATE_WAITPING "wait_for_ping"
+#  define XML_PING_ATTR_PACEMAKERDSTATE_RUNNING "running"
+#  define XML_PING_ATTR_PACEMAKERDSTATE_SHUTTINGDOWN "shutting_down"
+#  define XML_PING_ATTR_PACEMAKERDSTATE_SHUTDOWNCOMPLETE "shutdown_complete"
 
 #  define XML_TAG_FRAGMENT		"cib_fragment"
 

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -68,6 +68,7 @@ libcrmcommon_la_SOURCES	+= utils.c
 libcrmcommon_la_SOURCES	+= watchdog.c
 libcrmcommon_la_SOURCES	+= xml.c
 libcrmcommon_la_SOURCES	+= xpath.c
+libcrmcommon_la_SOURCES	+= pacemakerd_client.c
 
 # It's possible to build the library adding ../gnu/md5.c directly to SOURCES,
 # but distclean chokes on that because it tries to include the source's .Plo

--- a/lib/common/pacemakerd_client.c
+++ b/lib/common/pacemakerd_client.c
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2004-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include <crm/msg_xml.h>
+#include <crm/common/mainloop.h>
+#include <crm/common/pacemakerd_types.h>
+
+CRM_TRACE_INIT_DATA(pacemakerd);
+
+typedef struct pacemakerd_api_private_s {
+    mainloop_io_t *source;
+    void (*ping_callback) (pacemakerd_t *pacemakerd, time_t last_good,
+                           enum pacemakerd_state state, int rc,
+                           gpointer userdata);
+    gpointer ping_userdata;
+    void (*disconnect_callback) (gpointer userdata);
+    gpointer disconnect_userdata;
+} pacemakerd_api_private_t;
+
+const char *pacemakerd_state_str[] = {
+    XML_PING_ATTR_PACEMAKERDSTATE_INIT,
+    XML_PING_ATTR_PACEMAKERDSTATE_STARTINGDAEMONS,
+    XML_PING_ATTR_PACEMAKERDSTATE_WAITPING,
+    XML_PING_ATTR_PACEMAKERDSTATE_RUNNING,
+    XML_PING_ATTR_PACEMAKERDSTATE_SHUTTINGDOWN,
+    XML_PING_ATTR_PACEMAKERDSTATE_SHUTDOWNCOMPLETE
+};
+
+enum pacemakerd_state pacemakerd_state_text2enum(const char *state)
+{
+    int i;
+
+    if (state == NULL) {
+        return pacemakerd_state_invalid;
+    }
+    for (i=pacemakerd_state_init; i <= pacemakerd_state_max;
+         i++) {
+        if (crm_str_eq(state, pacemakerd_state_str[i], TRUE)) {
+            return i;
+        }
+    }
+    return pacemakerd_state_invalid;
+}
+
+const char *pacemakerd_state_enum2text(enum pacemakerd_state state)
+{
+    if ((state >= pacemakerd_state_init) &&
+        (state <= pacemakerd_state_max)) {
+        return pacemakerd_state_str[state];
+    }
+    return NULL;
+}
+
+static int
+pacemakerd_dispatch_internal(const char *buffer, ssize_t length, gpointer userdata)
+{
+    pacemakerd_t *pacemakerd = userdata;
+    pacemakerd_api_private_t *native;
+    const char *type = NULL;
+    const char *crm_msg_reference = NULL;
+    xmlNode *xml;
+    int rc = 0;
+
+    CRM_CHECK(pacemakerd != NULL, return rc);
+    native = pacemakerd->pacemakerd_private;
+    CRM_ASSERT(native != NULL);
+    CRM_ASSERT(native->ping_callback != NULL);
+
+    xml = string2xml(buffer);
+    if (xml == NULL) {
+        return rc;
+    }
+
+    type = crm_element_value(xml, F_CRM_MSG_TYPE);
+    crm_msg_reference = crm_element_value(xml, XML_ATTR_REFERENCE);
+
+    if (type == NULL) {
+        crm_info("No message type defined.");
+    } else if (strcasecmp(XML_ATTR_RESPONSE, type) != 0) {
+        crm_info("Expecting a (%s) message but received a (%s).",
+                 XML_ATTR_RESPONSE, type);
+    } else if (crm_msg_reference == NULL) {
+        crm_info("No message crm_msg_reference defined.");
+    } else {
+        xmlNode *data = get_message_xml(xml, F_CRM_DATA);
+        const char *state =
+            crm_element_value(data, XML_PING_ATTR_PACEMAKERDSTATE);
+        const char *status =
+            crm_element_value(data, XML_PING_ATTR_STATUS);
+        time_t pinged = (time_t) 0;
+        long long value_ll = 0;
+
+        crm_element_value_ll(data, XML_ATTR_TSTAMP, &value_ll);
+        pinged = (time_t) value_ll;
+        native->ping_callback(pacemakerd, pinged,
+            pacemakerd_state_text2enum(state),
+            crm_str_eq(status, "ok", FALSE)?pcmk_ok:pcmk_err_generic,
+            userdata);
+        rc = 1;
+    }
+
+    free_xml(xml);
+    return rc;
+}
+
+static void
+pacemakerd_connection_destroy(gpointer userdata)
+{
+    pacemakerd_t *pacemakerd = userdata;
+    pacemakerd_api_private_t *native;
+
+    CRM_CHECK(pacemakerd != NULL, return);
+    native = pacemakerd->pacemakerd_private;
+    CRM_ASSERT(native != NULL);
+    CRM_ASSERT(native->disconnect_callback != NULL);
+
+    crm_trace("Sending destroyed notification");
+    native->source = NULL;
+    pacemakerd->conn_state = pacemakerd_conn_disconnected;
+    native->disconnect_callback(native->disconnect_userdata);
+}
+
+static int
+pacemakerd_api_connect(pacemakerd_t *pacemakerd, const char *name)
+{
+    pacemakerd_api_private_t *native;
+    const char *display_name = name? name : "client";
+    static struct ipc_client_callbacks pacemakerd_callbacks = {
+        .dispatch = pacemakerd_dispatch_internal,
+        .destroy = pacemakerd_connection_destroy
+    };
+
+    CRM_CHECK(pacemakerd != NULL, return -EINVAL);
+    native = pacemakerd->pacemakerd_private;
+    CRM_ASSERT(native != NULL);
+
+    crm_debug("Attempting pacemakerd connection by %s", display_name);
+    if (pacemakerd->conn_state != pacemakerd_conn_connected) {
+        native->source =
+            mainloop_add_ipc_client(CRM_SYSTEM_MCP, G_PRIORITY_DEFAULT, 0,
+                                    (gpointer) pacemakerd,
+                                    &pacemakerd_callbacks);
+        if (native->source) {
+            pacemakerd->conn_state = pacemakerd_conn_connected;
+        }
+    }
+
+    return (pacemakerd->conn_state == pacemakerd_conn_connected)?
+                pcmk_ok:-ENOTCONN;
+}
+
+static int
+pacemakerd_api_disconnect(pacemakerd_t *pacemakerd)
+{
+    pacemakerd_api_private_t *native;
+
+    CRM_CHECK(pacemakerd != NULL, return -EINVAL);
+    native = pacemakerd->pacemakerd_private;
+    CRM_ASSERT(native != NULL);
+
+    crm_debug("Disconnecting from pacemakerd");
+
+    if (native->source) {
+        mainloop_del_ipc_client(native->source);
+        native->source = NULL;
+    }
+
+    pacemakerd->conn_state = pacemakerd_conn_disconnected;
+    return pcmk_ok;
+}
+
+static void
+pacemakerd_api_free(pacemakerd_t *pacemakerd)
+{
+    if (pacemakerd) {
+        if (pacemakerd->conn_state == pacemakerd_conn_connected) {
+            pacemakerd_api_disconnect(pacemakerd);
+        }
+        free(pacemakerd->pacemakerd_private);
+        free(pacemakerd->cmds);
+        free(pacemakerd);
+    }
+}
+
+static int
+pacemakerd_api_set_ping_callback(pacemakerd_t *pacemakerd,
+    void (*callback) (pacemakerd_t *pacemakerd,
+                      time_t last_good,
+                      enum pacemakerd_state state,
+                      int rc, gpointer userdata),
+    gpointer userdata)
+{
+    pacemakerd_api_private_t *native;
+
+    CRM_CHECK(pacemakerd != NULL, return -EINVAL);
+    native = pacemakerd->pacemakerd_private;
+    CRM_ASSERT(native != NULL);
+    native->ping_callback = callback;
+    native->ping_userdata = userdata;
+
+    return pcmk_ok;
+}
+
+static int
+pacemakerd_api_set_disconnect_callback(pacemakerd_t *pacemakerd,
+    void (*callback) (gpointer userdata),
+    gpointer userdata)
+{
+    pacemakerd_api_private_t *native;
+
+    CRM_CHECK(pacemakerd != NULL, return -EINVAL);
+    native = pacemakerd->pacemakerd_private;
+    CRM_ASSERT(native != NULL);
+    native->disconnect_callback = callback;
+    native->disconnect_userdata = userdata;
+
+    return pcmk_ok;
+}
+
+static int
+pacemakerd_api_ping(pacemakerd_t *pacemakerd, const char *name,
+                     const char *admin_uuid, int call_options)
+{
+    pacemakerd_api_private_t *native;
+    xmlNode *cmd;
+    int rc;
+
+    CRM_CHECK(pacemakerd != NULL, return -EINVAL);
+    native = pacemakerd->pacemakerd_private;
+    CRM_ASSERT(native != NULL);
+
+    cmd = create_request(CRM_OP_PING, NULL, NULL,
+                         CRM_SYSTEM_MCP, name, admin_uuid);
+
+    if (cmd) {
+        rc = crm_ipc_send(mainloop_get_ipc_client(native->source),
+                          cmd, 0, 0, NULL);
+        if (rc < 0) {
+            crm_debug("Couldn't register with the pacemakerd: %s "
+                      CRM_XS " rc=%d", pcmk_strerror(rc), rc);
+            rc = -ECOMM;
+        }
+        free_xml(cmd);
+    } else {
+        rc = -ENOMSG;
+    }
+
+    return rc;
+}
+
+pacemakerd_t *
+pacemakerd_api_new(void)
+{
+    pacemakerd_t *api = calloc(1, sizeof(pacemakerd_t));
+    pacemakerd_api_operations_t *cmds =
+        calloc(1, sizeof(pacemakerd_api_operations_t));
+    pacemakerd_api_private_t *private =
+        calloc(1, sizeof(pacemakerd_api_private_t));
+
+    if (api && cmds && private) {
+        api->pacemakerd_private = private;
+        api->cmds =               cmds;
+        api->conn_state =         pacemakerd_conn_disconnected;
+
+        cmds->connect =           pacemakerd_api_connect;
+        cmds->disconnect =        pacemakerd_api_disconnect;
+        cmds->free =              pacemakerd_api_free;
+        cmds->set_ping_callback = pacemakerd_api_set_ping_callback;
+        cmds->set_disconnect_callback =
+                                  pacemakerd_api_set_disconnect_callback;
+        cmds->ping =              pacemakerd_api_ping;
+
+    } else {
+        free(cmds);
+        free(api);
+        free(private);
+        api = NULL;
+    }
+    return api;
+}
+
+void
+pacemakerd_api_delete(pacemakerd_t * pacemakerd)
+{
+    if ((pacemakerd) && (pacemakerd->cmds) &&
+        (pacemakerd->cmds->free)) {
+        pacemakerd->cmds->free(pacemakerd);
+    }
+}


### PR DESCRIPTION
This tries to both address robust detection of graceful pacemaker-shutdown
and synchronization of sbd and pacemaker in a way that sbd not being
able to connect to the cib wouldn't automatically lead to the assumption
that neither pacemaker nor resources are active. (One reason for the latter to happen
is an selinux misconfiguration leading to ipc-connection denied for sbd.) 

Basically it adds a status-ping - similar to controld - to pacemakerd.
In case pacemakerd detects presence of sbd it will stall till being pinged once
before starting the sub-daemons.
During shutdown it will again stall (again just in case of detection of sbd)
when the sub-daemons are shut down till this state is fetched via ping.
`cibadmin -P` implements this status-ping for pacemakerd (just to the local
instance) for easy testing without need of sbd.

The implementation probably needs some polishing like e.g.:
- enum for pacemakerd-state instead of comparing strings
- less ugly approach than `sleep(5)` to make client receive ping reply in shutdown-case
- when do we really have a clean shutdown? (when one of the sub-daemons had to
  be stopped via SIGSEGV this is e.g. probably a sign for something not being that clean)
- just open the channel really needed in crmadmin
- overhauling pacemakerd for a cleaner state-machine would help detecting possible races
  (this PR so far makes things rather more obfuscated)
- possibly implement a real client-API as with cib or fencing instead of handy-crafting xml

There is a bit of ugliness in a status-ping actually influencing behavior.
But on the other hand it is very little intrusive regarding API-changes and it is local
to pacemakerd without the need for anything else to know about the new sync-mechanism.
To catch cases where sub-daemons are misbehaving we can easily add an additional
tag with a timestamp when pacemakerd has last seen all the sub-daemons alive.
For the first to satisfy the interface to sbd it is just a simple timestamp
for the moment when the ping-request is received. Later on pacemakerd can go for
checking the sub-daemons like what is done initially already now periodically (presence
of pid & ipc) and later on maybe active pings towards the sub-daemons (controld would
already support a status-ping while other daemons might still need it to be added).
But these improvements can be added over time with sbd being agnostic of the progress.

From sbd-perspective the world would look something like
https://github.com/ClusterLabs/sbd/pull/106.