### PR TITLE
Refactor: libcrmcommon: introduce new set of return codes

### DIFF
--- a/daemons/attrd/attrd_alerts.c
+++ b/daemons/attrd/attrd_alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the Pacemaker project contributors
+ * Copyright 2015-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -129,7 +129,7 @@ attrd_read_options(gpointer user_data)
 void
 attrd_cib_updated_cb(const char *event, xmlNode * msg)
 {
-    if (!attrd_shutting_down() && crm_patchset_contains_alert(msg, FALSE)) {
+    if (!attrd_shutting_down() && pcmk__alert_in_patchset(msg, FALSE)) {
         mainloop_set_trigger(attrd_config_read);
     }
 }

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -29,7 +29,7 @@
 #include <crm/common/xml.h>
 #include <crm/cluster/internal.h>
 
-#include <crm/attrd.h>
+#include <crm/common/attrd_internal.h>
 #include "pacemaker-attrd.h"
 
 lrmd_t *the_lrmd = NULL;

--- a/daemons/controld/controld_attrd.c
+++ b/daemons/controld/controld_attrd.c
@@ -10,7 +10,7 @@
 #include <crm_internal.h>
 
 #include <crm/crm.h>
-#include <crm/attrd.h>
+#include <crm/common/attrd_internal.h>
 #include <crm/msg_xml.h>
 
 #include <pacemaker-controld.h>

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -23,7 +23,7 @@ int cib_retries = 0;
 static void
 do_cib_updated(const char *event, xmlNode * msg)
 {
-    if (crm_patchset_contains_alert(msg, TRUE)) {
+    if (pcmk__alert_in_patchset(msg, TRUE)) {
         mainloop_set_trigger(config_read);
     }
 }

--- a/daemons/execd/execd_alerts.c
+++ b/daemons/execd/execd_alerts.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2016-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2016-2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -103,8 +105,8 @@ process_lrmd_alert_exec(crm_client_t *client, uint32_t id, xmlNode *request)
     crm_info("Executing alert %s for %s", alert_id, client->id);
 
     params = xml2list(alert_xml);
-    crm_insert_alert_key_int(params, CRM_alert_node_sequence,
-                             ++alert_sequence_no);
+    pcmk__add_alert_key_int(params, PCMK__alert_key_node_sequence,
+                            ++alert_sequence_no);
 
     cb_data = calloc(1, sizeof(struct alert_cb_s));
     CRM_CHECK(cb_data != NULL,

--- a/include/crm/Makefile.am
+++ b/include/crm/Makefile.am
@@ -11,7 +11,7 @@ MAINTAINERCLEANFILES	= Makefile.in
 
 headerdir=$(pkgincludedir)/crm
 
-header_HEADERS		= attrd.h cib.h cluster.h compatibility.h crm.h \
+header_HEADERS		= cib.h cluster.h compatibility.h crm.h \
 			  lrmd.h msg_xml.h services.h stonith-ng.h
 
 noinst_HEADERS		= lrmd_internal.h

--- a/include/crm/common/Makefile.am
+++ b/include/crm/common/Makefile.am
@@ -15,4 +15,5 @@ header_HEADERS = xml.h ipc.h util.h iso8601.h mainloop.h logging.h results.h \
 		 nvpair.h
 noinst_HEADERS = cib_secrets.h ipcs.h internal.h alerts_internal.h \
 		 iso8601_internal.h remote_internal.h xml_internal.h \
-		 ipc_internal.h output.h cmdline_internal.h curses_internal.h
+		 ipc_internal.h output.h cmdline_internal.h curses_internal.h \
+		 attrd_internal.h

--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the Pacemaker project contributors
+ * Copyright 2015-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,18 +14,19 @@
 #include <stdbool.h>
 
 /* Default-Timeout to use before killing a alerts script (in milliseconds) */
-#  define CRM_ALERT_DEFAULT_TIMEOUT_MS (30000)
+#  define PCMK__ALERT_DEFAULT_TIMEOUT_MS (30000)
 
 /* Default-Format-String used to pass timestamps to the alerts scripts */
-#  define CRM_ALERT_DEFAULT_TSTAMP_FORMAT "%H:%M:%S.%06N"
+#  define PCMK__ALERT_DEFAULT_TSTAMP_FORMAT "%H:%M:%S.%06N"
 
-enum crm_alert_flags {
-    crm_alert_none         = 0x0000,
-    crm_alert_node         = 0x0001,
-    crm_alert_fencing      = 0x0002,
-    crm_alert_resource     = 0x0004,
-    crm_alert_attribute    = 0x0008,
-    crm_alert_default      = crm_alert_node|crm_alert_fencing|crm_alert_resource
+enum pcmk__alert_flags {
+    pcmk__alert_none         = 0,
+    pcmk__alert_node         = (1 << 0),
+    pcmk__alert_fencing      = (1 << 1),
+    pcmk__alert_resource     = (1 << 2),
+    pcmk__alert_attribute    = (1 << 3),
+    pcmk__alert_default      = pcmk__alert_node|pcmk__alert_fencing|
+                               pcmk__alert_resource,
 };
 
 typedef struct {
@@ -37,63 +38,55 @@ typedef struct {
     GHashTable *envvars;
     int timeout;
     uint32_t flags;
-} crm_alert_entry_t;
+} pcmk__alert_t;
 
-enum crm_alert_keys_e {
-    CRM_alert_recipient = 0,
-    CRM_alert_node,
-    CRM_alert_nodeid,
-    CRM_alert_rsc,
-    CRM_alert_task,
-    CRM_alert_interval,
-    CRM_alert_desc,
-    CRM_alert_status,
-    CRM_alert_target_rc,
-    CRM_alert_rc,
-    CRM_alert_kind,
-    CRM_alert_version,
-    CRM_alert_node_sequence,
-    CRM_alert_timestamp,
-    CRM_alert_attribute_name,
-    CRM_alert_attribute_value,
-    CRM_alert_timestamp_epoch,
-    CRM_alert_timestamp_usec,
-    CRM_alert_exec_time,
-    CRM_alert_select_kind,
-    CRM_alert_select_attribute_name
+enum pcmk__alert_keys_e {
+    PCMK__alert_key_recipient = 0,
+    PCMK__alert_key_node,
+    PCMK__alert_key_nodeid,
+    PCMK__alert_key_rsc,
+    PCMK__alert_key_task,
+    PCMK__alert_key_interval,
+    PCMK__alert_key_desc,
+    PCMK__alert_key_status,
+    PCMK__alert_key_target_rc,
+    PCMK__alert_key_rc,
+    PCMK__alert_key_kind,
+    PCMK__alert_key_version,
+    PCMK__alert_key_node_sequence,
+    PCMK__alert_key_timestamp,
+    PCMK__alert_key_attribute_name,
+    PCMK__alert_key_attribute_value,
+    PCMK__alert_key_timestamp_epoch,
+    PCMK__alert_key_timestamp_usec,
+    PCMK__alert_key_exec_time,
+    PCMK__alert_key_select_kind,
+    PCMK__alert_key_select_attribute_name
 };
 
-#define CRM_ALERT_INTERNAL_KEY_MAX 19
-#define CRM_ALERT_NODE_SEQUENCE "CRM_alert_node_sequence"
+#define PCMK__ALERT_INTERNAL_KEY_MAX 19
+#define PCMK__ALERT_NODE_SEQUENCE "CRM_alert_node_sequence"
 
-extern const char *crm_alert_keys[CRM_ALERT_INTERNAL_KEY_MAX][3];
+extern const char *pcmk__alert_keys[PCMK__ALERT_INTERNAL_KEY_MAX][3];
 
-crm_alert_entry_t *crm_dup_alert_entry(crm_alert_entry_t *entry);
-crm_alert_entry_t *crm_alert_entry_new(const char *id, const char *path);
-void crm_free_alert_entry(crm_alert_entry_t *entry);
-void crm_insert_alert_key(GHashTable *table, enum crm_alert_keys_e name,
-                          const char *value);
-void crm_insert_alert_key_int(GHashTable *table, enum crm_alert_keys_e name,
-                              int value);
-void crm_unset_alert_keys(void);
-void crm_set_envvar_list(crm_alert_entry_t *entry);
-void crm_unset_envvar_list(crm_alert_entry_t *entry);
-bool crm_patchset_contains_alert(xmlNode *msg, bool config);
+pcmk__alert_t *pcmk__dup_alert(pcmk__alert_t *entry);
+pcmk__alert_t *pcmk__alert_new(const char *id, const char *path);
+void pcmk__free_alert(pcmk__alert_t *entry);
+void pcmk__add_alert_key(GHashTable *table, enum pcmk__alert_keys_e name,
+                         const char *value);
+void pcmk__add_alert_key_int(GHashTable *table, enum pcmk__alert_keys_e name,
+                             int value);
+bool pcmk__alert_in_patchset(xmlNode *msg, bool config);
 
 static inline const char *
-crm_alert_flag2text(enum crm_alert_flags flag)
+pcmk__alert_flag2text(enum pcmk__alert_flags flag)
 {
     switch (flag) {
-        case crm_alert_node:
-            return "node";
-        case crm_alert_fencing:
-            return "fencing";
-        case crm_alert_resource:
-            return "resource";
-        case crm_alert_attribute:
-            return "attribute";
-        default:
-            return "unknown";
+        case pcmk__alert_node:      return "node";
+        case pcmk__alert_fencing:   return "fencing";
+        case pcmk__alert_resource:  return "resource";
+        case pcmk__alert_attribute: return "attribute";
+        default:                    return "unknown";
     }
 }
 #endif

--- a/include/crm/common/attrd_internal.h
+++ b/include/crm/common/attrd_internal.h
@@ -1,22 +1,12 @@
-/* 
- * Copyright 2004-2018 the Pacemaker project contributors
+/*
+ * Copyright 2004-2019 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
- * 
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
+
 #ifndef CRM_ATTRD__H
 #  define CRM_ATTRD__H
 

--- a/include/crm/common/attrd_internal.h
+++ b/include/crm/common/attrd_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -16,19 +16,25 @@ extern "C" {
 
 #  include <crm/common/ipc.h>
 
-/* attribute options for clients to use with these functions */
-#define attrd_opt_none    0x000
-#define attrd_opt_remote  0x001
-#define attrd_opt_private 0x002
+// Options for clients to use with functions below
+enum pcmk__node_attr_opts {
+    pcmk__node_attr_none    = 0,
+    pcmk__node_attr_remote  = (1 << 0),
+    pcmk__node_attr_private = (1 << 1),
+};
 
-const char *attrd_get_target(const char *name);
+int pcmk__node_attr_request(crm_ipc_t * ipc, char command, const char *host,
+                            const char *name, const char *value,
+                            const char *section, const char *set,
+                            const char *dampen, const char *user_name,
+                            int options);
 
-int attrd_update_delegate(crm_ipc_t * ipc, char command, const char *host,
-                          const char *name, const char *value, const char *section,
-                          const char *set, const char *dampen, const char *user_name, int options);
-int attrd_clear_delegate(crm_ipc_t *ipc, const char *host, const char *resource,
-                         const char *operation, const char *interval_spec,
-                         const char *user_name, int options);
+int pcmk__node_attr_request_clear(crm_ipc_t *ipc, const char *host,
+                                  const char *resource, const char *operation,
+                                  const char *interval_spec,
+                                  const char *user_name, int options);
+
+const char *pcmk__node_attr_target(const char *name);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the Pacemaker project contributors
+ * Copyright 2012-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -49,11 +49,21 @@ extern "C" {
 /*
  * Function return codes
  *
+ * Most Pacemaker API functions return an integer return code. There are two
+ * alternative interpretations. The legacy interpration is that the absolute
+ * value of the return code is either a system error number or a custom
+ * pcmk_err_* number. This is less than ideal because system error numbers are
+ * constrained only to the positive int range, so there's the possibility
+ * (though not noticed in the wild) that system errors and custom errors could
+ * collide. The new intepretation is that negative values are from the pcmk_rc_e
+ * enum, and positive values are system error numbers. Both use 0 for success.
+ *
  * For system error codes, see:
  * - /usr/include/asm-generic/errno.h
  * - /usr/include/asm-generic/errno-base.h
  */
 
+// Legacy custom return codes for Pacemaker API functions (deprecated)
 #  define pcmk_ok                       0
 #  define PCMK_ERROR_OFFSET             190    /* Replacements on non-linux systems, see include/portability.h */
 #  define PCMK_CUSTOM_OFFSET            200    /* Purely custom codes */
@@ -74,6 +84,48 @@ extern "C" {
 #  define pcmk_err_already              215
 #  define pcmk_err_bad_nvpair           216
 #  define pcmk_err_unknown_format       217
+
+/*!
+ * \enum pcmk_rc_e
+ * \brief Return codes for Pacemaker API functions
+ *
+ * Any Pacemaker API function documented as returning a "standard Pacemaker
+ * return code" will return pcmk_rc_ok (0) on success, and one of this
+ * enumeration's other (negative) values or a (positive) system error number
+ * otherwise. The custom codes are at -1001 and lower, so that the caller may
+ * use -1 through -1000 for their own custom values if desired. While generally
+ * referred to as "errors", nonzero values simply indicate a result, which might
+ * or might not be an error depending on the calling context.
+ */
+enum pcmk_rc_e {
+    /* When adding new values, use consecutively lower numbers, update the array
+     * in lib/common/results.c, and test with crm_error.
+     */
+    pcmk_rc_no_quorum           = -1017,
+    pcmk_rc_schema_validation   = -1016,
+    pcmk_rc_schema_unchanged    = -1015,
+    pcmk_rc_transform_failed    = -1014,
+    pcmk_rc_old_data            = -1013,
+    pcmk_rc_diff_failed         = -1012,
+    pcmk_rc_diff_resync         = -1011,
+    pcmk_rc_cib_modified        = -1010,
+    pcmk_rc_cib_backup          = -1009,
+    pcmk_rc_cib_save            = -1008,
+    pcmk_rc_cib_corrupt         = -1007,
+    pcmk_rc_multiple            = -1006,
+    pcmk_rc_node_unknown        = -1005,
+    pcmk_rc_already             = -1004,
+    pcmk_rc_bad_nvpair          = -1003,
+    pcmk_rc_unknown_format      = -1002,
+    // Developers: Use a more specific code than pcmk_rc_error whenever possible
+    pcmk_rc_error               = -1001,
+
+    // Values -1 through -1000 reserved for caller use
+
+    pcmk_rc_ok                  =     0
+
+    // Positive values reserved for system error numbers
+};
 
 /*
  * Exit status codes
@@ -150,6 +202,11 @@ typedef enum crm_exit_e {
     CRM_EX_MAX                  = 255, // ensure crm_exit_t can hold this
 } crm_exit_t;
 
+const char *pcmk_rc_name(int rc);
+const char *pcmk_rc_str(int rc);
+crm_exit_t pcmk_rc2exitc(int rc);
+int pcmk_rc2legacy(int rc);
+int pcmk_legacy2rc(int legacy_rc);
 const char *pcmk_strerror(int rc);
 const char *pcmk_errorname(int rc);
 const char *bz2_strerror(int rc);

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the Pacemaker project contributors
+ * Copyright 2006-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -31,7 +31,7 @@
 void *find_library_function(void **handle, const char *lib, const char *fn, int fatal);
 
 /* For ACLs */
-char *uid2username(uid_t uid);
+char *pcmk__uid2username(uid_t uid);
 const char *crm_acl_get_set_user(xmlNode * request, const char *field, const char *peer_user);
 
 #  if ENABLE_ACL

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -719,7 +719,7 @@ pcmk_acl_required(const char *user)
 
 #if ENABLE_ACL
 char *
-uid2username(uid_t uid)
+pcmk__uid2username(uid_t uid)
 {
     struct passwd *pwent = getpwuid(uid);
 
@@ -738,7 +738,7 @@ crm_acl_get_set_user(xmlNode *request, const char *field, const char *peer_user)
     const char *user = NULL;
 
     if (effective_user == NULL) {
-        effective_user = uid2username(geteuid());
+        effective_user = pcmk__uid2username(geteuid());
         if (effective_user == NULL) {
             effective_user = strdup("#unprivileged");
             CRM_CHECK(effective_user != NULL, return NULL);

--- a/lib/common/agents.c
+++ b/lib/common/agents.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.

--- a/lib/common/attrd_client.c
+++ b/lib/common/attrd_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 the Pacemaker project contributors
+ * Copyright 2011-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -45,15 +45,15 @@ create_attrd_op(const char *user_name)
  * \internal
  * \brief Send an operation to pacemaker-attrd via IPC
  *
- * \param[in] ipc       Connection to pacemaker-attrd (or NULL to use a local connection)
+ * \param[in] ipc       Connection to pacemaker-attrd (or create one if NULL)
  * \param[in] attrd_op  XML of pacemaker-attrd operation to send
  *
- * \return pcmk_ok on success, -errno otherwise
+ * \return Standard Pacemaker return code
  */
 static int
 send_attrd_op(crm_ipc_t *ipc, xmlNode *attrd_op)
 {
-    int rc = -ENOTCONN;
+    int rc = -ENOTCONN; // initially handled as legacy return code
     int max = 5;
 
     static gboolean connected = TRUE;
@@ -103,7 +103,7 @@ send_attrd_op(crm_ipc_t *ipc, xmlNode *attrd_op)
     if (rc > 0) {
         rc = pcmk_ok;
     }
-    return rc;
+    return pcmk_legacy2rc(rc);
 }
 
 /*!
@@ -127,19 +127,17 @@ send_attrd_op(crm_ipc_t *ipc, xmlNode *attrd_op)
  * \param[in] set      ID of attribute set to use (or NULL to choose first)
  * \param[in] dampen   Attribute dampening to use with B/Y, and U/v if creating
  * \param[in] user_name ACL user to pass to pacemaker-attrd
- * \param[in] options  Bitmask that may include:
- *                     attrd_opt_remote: host is a Pacemaker Remote node
- *                     attrd_opt_private: attribute is private (not kept in CIB)
+ * \param[in] options  Bitmask of pcmk__node_attr_opts
  *
- * \return pcmk_ok if request was successfully submitted to pacemaker-attrd, else -errno
+ * \return Standard Pacemaker return code
  */
 int
-attrd_update_delegate(crm_ipc_t *ipc, char command, const char *host,
-                      const char *name, const char *value, const char *section,
-                      const char *set, const char *dampen,
-                      const char *user_name, int options)
+pcmk__node_attr_request(crm_ipc_t *ipc, char command, const char *host,
+                        const char *name, const char *value,
+                        const char *section, const char *set,
+                        const char *dampen, const char *user_name, int options)
 {
-    int rc = pcmk_ok;
+    int rc = pcmk_rc_ok;
     const char *task = NULL;
     const char *name_as = NULL;
     const char *display_host = (host ? host : "localhost");
@@ -193,7 +191,7 @@ attrd_update_delegate(crm_ipc_t *ipc, char command, const char *host,
 
     if (name_as != NULL) {
         if (name == NULL) {
-            rc = -EINVAL;
+            rc = EINVAL;
             goto done;
         }
         crm_xml_add(update, name_as, name);
@@ -205,8 +203,10 @@ attrd_update_delegate(crm_ipc_t *ipc, char command, const char *host,
     crm_xml_add(update, F_ATTRD_SECTION, section);
     crm_xml_add(update, F_ATTRD_HOST, host);
     crm_xml_add(update, F_ATTRD_SET, set);
-    crm_xml_add_int(update, F_ATTRD_IS_REMOTE, is_set(options, attrd_opt_remote));
-    crm_xml_add_int(update, F_ATTRD_IS_PRIVATE, is_set(options, attrd_opt_private));
+    crm_xml_add_int(update, F_ATTRD_IS_REMOTE,
+                    is_set(options, pcmk__node_attr_remote));
+    crm_xml_add_int(update, F_ATTRD_IS_PRIVATE,
+                    is_set(options, pcmk__node_attr_private));
 
     rc = send_attrd_op(ipc, update);
 
@@ -215,10 +215,10 @@ done:
 
     if (display_command) {
         crm_debug("Asked pacemaker-attrd to %s %s: %s (%d)",
-                  display_command, display_host, pcmk_strerror(rc), rc);
+                  display_command, display_host, pcmk_rc_str(rc), rc);
     } else {
         crm_debug("Asked pacemaker-attrd to update %s=%s for %s: %s (%d)",
-                  name, value, display_host, pcmk_strerror(rc), rc);
+                  name, value, display_host, pcmk_rc_str(rc), rc);
     }
     return rc;
 }
@@ -233,16 +233,17 @@ done:
  * \param[in] operation     Name of operation to clear (or NULL for all)
  * \param[in] interval_spec If operation is not NULL, its interval
  * \param[in] user_name     ACL user to pass to pacemaker-attrd
- * \param[in] options       attrd_opt_remote if host is a Pacemaker Remote node
+ * \param[in] options       Bitmask of pcmk__node_attr_opts
  *
  * \return pcmk_ok if request was successfully submitted to pacemaker-attrd, else -errno
  */
 int
-attrd_clear_delegate(crm_ipc_t *ipc, const char *host, const char *resource,
-                     const char *operation, const char *interval_spec,
-                     const char *user_name, int options)
+pcmk__node_attr_request_clear(crm_ipc_t *ipc, const char *host,
+                              const char *resource, const char *operation,
+                              const char *interval_spec, const char *user_name,
+                              int options)
 {
-    int rc = pcmk_ok;
+    int rc = pcmk_rc_ok;
     xmlNode *clear_op = create_attrd_op(user_name);
     const char *interval_desc = NULL;
     const char *op_desc = NULL;
@@ -252,7 +253,8 @@ attrd_clear_delegate(crm_ipc_t *ipc, const char *host, const char *resource,
     crm_xml_add(clear_op, F_ATTRD_RESOURCE, resource);
     crm_xml_add(clear_op, F_ATTRD_OPERATION, operation);
     crm_xml_add(clear_op, F_ATTRD_INTERVAL, interval_spec);
-    crm_xml_add_int(clear_op, F_ATTRD_IS_REMOTE, is_set(options, attrd_opt_remote));
+    crm_xml_add_int(clear_op, F_ATTRD_IS_REMOTE,
+                    is_set(options, pcmk__node_attr_remote));
 
     rc = send_attrd_op(ipc, clear_op);
     free_xml(clear_op);
@@ -266,7 +268,7 @@ attrd_clear_delegate(crm_ipc_t *ipc, const char *host, const char *resource,
     }
     crm_debug("Asked pacemaker-attrd to clear failure of %s %s for %s on %s: %s (%d)",
               interval_desc, op_desc, (resource? resource : "all resources"),
-              (host? host : "all nodes"), pcmk_strerror(rc), rc);
+              (host? host : "all nodes"), pcmk_rc_str(rc), rc);
     return rc;
 }
 
@@ -276,7 +278,7 @@ attrd_clear_delegate(crm_ipc_t *ipc, const char *host, const char *resource,
  * \internal
  */
 const char *
-attrd_get_target(const char *name)
+pcmk__node_attr_target(const char *name)
 {
     if(safe_str_eq(name, "auto") || safe_str_eq(name, "localhost")) {
         name = NULL;

--- a/lib/common/attrd_client.c
+++ b/lib/common/attrd_client.c
@@ -1,10 +1,11 @@
 /*
- * Copyright 2011-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2011-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
-
 
 #ifndef _GNU_SOURCE
 #  define _GNU_SOURCE
@@ -16,7 +17,7 @@
 
 #include <crm/crm.h>
 #include <crm/msg_xml.h>
-#include <crm/attrd.h>
+#include <crm/common/attrd_internal.h>
 
 /*!
  * \internal
@@ -106,6 +107,7 @@ send_attrd_op(crm_ipc_t *ipc, xmlNode *attrd_op)
 }
 
 /*!
+ * \internal
  * \brief Send a request to pacemaker-attrd
  *
  * \param[in] ipc      Connection to pacemaker-attrd (or NULL to use a local connection)
@@ -222,6 +224,7 @@ done:
 }
 
 /*!
+ * \internal
  * \brief Send a request to pacemaker-attrd to clear resource failure
  *
  * \param[in] ipc           Connection to pacemaker-attrd (NULL to use local connection)
@@ -269,6 +272,9 @@ attrd_clear_delegate(crm_ipc_t *ipc, const char *host, const char *resource,
 
 #define LRM_TARGET_ENV "OCF_RESKEY_" CRM_META "_" XML_LRM_ATTR_TARGET
 
+/*!
+ * \internal
+ */
 const char *
 attrd_get_target(const char *name)
 {

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -315,7 +315,7 @@ client_from_connection(qb_ipcs_connection_t *c, void *key, uid_t uid_client)
 
     if (c) {
 #if ENABLE_ACL
-        client->user = uid2username(uid_client);
+        client->user = pcmk__uid2username(uid_client);
         if (client->user == NULL) {
             client->user = strdup("#unprivileged");
             CRM_CHECK(client->user != NULL, free(client); return NULL);

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -22,148 +22,14 @@
 #include <crm/common/mainloop.h>
 #include <crm/common/xml.h>
 
+// @COMPAT Legacy function return codes
+
+//! \deprecated Use standard return codes and pcmk_rc_name() instead
 const char *
 pcmk_errorname(int rc)
 {
-    int error = abs(rc);
-
-    switch (error) {
-        case E2BIG: return "E2BIG";
-        case EACCES: return "EACCES";
-        case EADDRINUSE: return "EADDRINUSE";
-        case EADDRNOTAVAIL: return "EADDRNOTAVAIL";
-        case EAFNOSUPPORT: return "EAFNOSUPPORT";
-        case EAGAIN: return "EAGAIN";
-        case EALREADY: return "EALREADY";
-        case EBADF: return "EBADF";
-        case EBADMSG: return "EBADMSG";
-        case EBUSY: return "EBUSY";
-        case ECANCELED: return "ECANCELED";
-        case ECHILD: return "ECHILD";
-        case ECOMM: return "ECOMM";
-        case ECONNABORTED: return "ECONNABORTED";
-        case ECONNREFUSED: return "ECONNREFUSED";
-        case ECONNRESET: return "ECONNRESET";
-        /* case EDEADLK: return "EDEADLK"; */
-        case EDESTADDRREQ: return "EDESTADDRREQ";
-        case EDOM: return "EDOM";
-        case EDQUOT: return "EDQUOT";
-        case EEXIST: return "EEXIST";
-        case EFAULT: return "EFAULT";
-        case EFBIG: return "EFBIG";
-        case EHOSTDOWN: return "EHOSTDOWN";
-        case EHOSTUNREACH: return "EHOSTUNREACH";
-        case EIDRM: return "EIDRM";
-        case EILSEQ: return "EILSEQ";
-        case EINPROGRESS: return "EINPROGRESS";
-        case EINTR: return "EINTR";
-        case EINVAL: return "EINVAL";
-        case EIO: return "EIO";
-        case EISCONN: return "EISCONN";
-        case EISDIR: return "EISDIR";
-        case ELIBACC: return "ELIBACC";
-        case ELOOP: return "ELOOP";
-        case EMFILE: return "EMFILE";
-        case EMLINK: return "EMLINK";
-        case EMSGSIZE: return "EMSGSIZE";
-#ifdef EMULTIHOP // Not available on OpenBSD
-        case EMULTIHOP: return "EMULTIHOP";
-#endif
-        case ENAMETOOLONG: return "ENAMETOOLONG";
-        case ENETDOWN: return "ENETDOWN";
-        case ENETRESET: return "ENETRESET";
-        case ENETUNREACH: return "ENETUNREACH";
-        case ENFILE: return "ENFILE";
-        case ENOBUFS: return "ENOBUFS";
-        case ENODATA: return "ENODATA";
-        case ENODEV: return "ENODEV";
-        case ENOENT: return "ENOENT";
-        case ENOEXEC: return "ENOEXEC";
-        case ENOKEY: return "ENOKEY";
-        case ENOLCK: return "ENOLCK";
-#ifdef ENOLINK // Not available on OpenBSD
-        case ENOLINK: return "ENOLINK";
-#endif
-        case ENOMEM: return "ENOMEM";
-        case ENOMSG: return "ENOMSG";
-        case ENOPROTOOPT: return "ENOPROTOOPT";
-        case ENOSPC: return "ENOSPC";
-        case ENOSR: return "ENOSR";
-        case ENOSTR: return "ENOSTR";
-        case ENOSYS: return "ENOSYS";
-        case ENOTBLK: return "ENOTBLK";
-        case ENOTCONN: return "ENOTCONN";
-        case ENOTDIR: return "ENOTDIR";
-        case ENOTEMPTY: return "ENOTEMPTY";
-        case ENOTSOCK: return "ENOTSOCK";
-        /* case ENOTSUP: return "ENOTSUP"; */
-        case ENOTTY: return "ENOTTY";
-        case ENOTUNIQ: return "ENOTUNIQ";
-        case ENXIO: return "ENXIO";
-        case EOPNOTSUPP: return "EOPNOTSUPP";
-        case EOVERFLOW: return "EOVERFLOW";
-        case EPERM: return "EPERM";
-        case EPFNOSUPPORT: return "EPFNOSUPPORT";
-        case EPIPE: return "EPIPE";
-        case EPROTO: return "EPROTO";
-        case EPROTONOSUPPORT: return "EPROTONOSUPPORT";
-        case EPROTOTYPE: return "EPROTOTYPE";
-        case ERANGE: return "ERANGE";
-        case EREMOTE: return "EREMOTE";
-        case EREMOTEIO: return "EREMOTEIO";
-
-        case EROFS: return "EROFS";
-        case ESHUTDOWN: return "ESHUTDOWN";
-        case ESPIPE: return "ESPIPE";
-        case ESOCKTNOSUPPORT: return "ESOCKTNOSUPPORT";
-        case ESRCH: return "ESRCH";
-        case ESTALE: return "ESTALE";
-        case ETIME: return "ETIME";
-        case ETIMEDOUT: return "ETIMEDOUT";
-        case ETXTBSY: return "ETXTBSY";
-        case EUNATCH: return "EUNATCH";
-        case EUSERS: return "EUSERS";
-        /* case EWOULDBLOCK: return "EWOULDBLOCK"; */
-        case EXDEV: return "EXDEV";
-
-#ifdef EBADE
-            /* Not available on OSX */
-        case EBADE: return "EBADE";
-        case EBADFD: return "EBADFD";
-        case EBADSLT: return "EBADSLT";
-        case EDEADLOCK: return "EDEADLOCK";
-        case EBADR: return "EBADR";
-        case EBADRQC: return "EBADRQC";
-        case ECHRNG: return "ECHRNG";
-#ifdef EISNAM /* Not available on Illumos/Solaris */
-        case EISNAM: return "EISNAM";
-        case EKEYEXPIRED: return "EKEYEXPIRED";
-        case EKEYREJECTED: return "EKEYREJECTED";
-        case EKEYREVOKED: return "EKEYREVOKED";
-#endif
-        case EL2HLT: return "EL2HLT";
-        case EL2NSYNC: return "EL2NSYNC";
-        case EL3HLT: return "EL3HLT";
-        case EL3RST: return "EL3RST";
-        case ELIBBAD: return "ELIBBAD";
-        case ELIBMAX: return "ELIBMAX";
-        case ELIBSCN: return "ELIBSCN";
-        case ELIBEXEC: return "ELIBEXEC";
-#ifdef ENOMEDIUM  /* Not available on Illumos/Solaris */
-        case ENOMEDIUM: return "ENOMEDIUM";
-        case EMEDIUMTYPE: return "EMEDIUMTYPE";
-#endif
-        case ENONET: return "ENONET";
-        case ENOPKG: return "ENOPKG";
-        case EREMCHG: return "EREMCHG";
-        case ERESTART: return "ERESTART";
-        case ESTRPIPE: return "ESTRPIPE";
-#ifdef EUCLEAN  /* Not available on Illumos/Solaris */
-        case EUCLEAN: return "EUCLEAN";
-#endif
-        case EXFULL: return "EXFULL";
-#endif
-
+    rc = abs(rc);
+    switch (rc) {
         case pcmk_err_generic: return "pcmk_err_generic";
         case pcmk_err_no_quorum: return "pcmk_err_no_quorum";
         case pcmk_err_schema_validation: return "pcmk_err_schema_validation";
@@ -180,24 +46,26 @@ pcmk_errorname(int rc)
         case pcmk_err_already: return "pcmk_err_already";
         case pcmk_err_bad_nvpair: return "pcmk_err_bad_nvpair";
         case pcmk_err_unknown_format: return "pcmk_err_unknown_format";
+        default: return pcmk_rc_name(rc); // system errno
     }
-    return "Unknown";
 }
 
+//! \deprecated Use standard return codes and pcmk_rc_str() instead
 const char *
 pcmk_strerror(int rc)
 {
-    int error = abs(rc);
-
-    if (error == 0) {
+    if (rc == 0) {
         return "OK";
-
-    // Of course error > 0 ... unless someone passed INT_MIN as rc
-    } else if ((error > 0) && (error < PCMK_ERROR_OFFSET)) {
-        return strerror(error);
     }
 
-    switch (error) {
+    rc = abs(rc);
+
+    // Of course rc > 0 ... unless someone passed INT_MIN as rc
+    if ((rc > 0) && (rc < PCMK_ERROR_OFFSET)) {
+        return strerror(rc);
+    }
+
+    switch (rc) {
         case pcmk_err_generic:
             return "Generic Pacemaker error";
         case pcmk_err_no_quorum:
@@ -253,10 +121,312 @@ pcmk_strerror(int rc)
         case ENOKEY:
             return "Required key not available";
     }
-
     crm_err("Unknown error code: %d", rc);
     return "Unknown error";
 }
+
+// Standard Pacemaker API return codes
+
+/* This array is used only for nonzero values of pcmk_rc_e. Its values must be
+ * kept in the exact reverse order of the enum value numbering (i.e. add new
+ * values to the end of the array).
+ */
+static struct pcmk__rc_info {
+    const char *name;
+    const char *desc;
+    int legacy_rc;
+} pcmk__rcs[] = {
+    { "pcmk_rc_error",
+      "Error",
+      -pcmk_err_generic,
+    },
+    { "pcmk_rc_unknown_format",
+      "Unknown output format",
+      -pcmk_err_unknown_format,
+    },
+    { "pcmk_rc_bad_nvpair",
+      "Bad name/value pair given",
+      -pcmk_err_bad_nvpair,
+    },
+    { "pcmk_rc_already",
+      "Already in requested state",
+      -pcmk_err_already,
+    },
+    { "pcmk_rc_node_unknown",
+      "Node not found",
+      -pcmk_err_node_unknown,
+    },
+    { "pcmk_rc_multiple",
+      "Resource active on multiple nodes",
+      -pcmk_err_multiple,
+    },
+    { "pcmk_rc_cib_corrupt",
+      "Could not parse on-disk configuration",
+      -pcmk_err_cib_corrupt,
+    },
+    { "pcmk_rc_cib_save",
+      "Could not save new configuration to disk",
+      -pcmk_err_cib_save,
+    },
+    { "pcmk_rc_cib_backup",
+      "Could not archive previous configuration",
+      -pcmk_err_cib_backup,
+    },
+    { "pcmk_rc_cib_modified",
+      "On-disk configuration was manually modified",
+      -pcmk_err_cib_modified,
+    },
+    { "pcmk_rc_diff_resync",
+      "Application of update diff failed, requesting full refresh",
+      -pcmk_err_diff_resync,
+    },
+    { "pcmk_rc_diff_failed",
+      "Application of update diff failed",
+      -pcmk_err_diff_failed,
+    },
+    { "pcmk_rc_old_data",
+      "Update was older than existing configuration",
+      -pcmk_err_old_data,
+    },
+    { "pcmk_rc_transform_failed",
+      "Schema transform failed",
+      -pcmk_err_transform_failed,
+    },
+    { "pcmk_rc_schema_unchanged",
+      "Schema is already the latest available",
+      -pcmk_err_schema_unchanged,
+    },
+    { "pcmk_rc_schema_validation",
+      "Update does not conform to the configured schema",
+      -pcmk_err_schema_validation,
+    },
+    { "pcmk_rc_no_quorum",
+      "Operation requires quorum",
+      -pcmk_err_no_quorum,
+    },
+};
+
+#define PCMK__N_RC (sizeof(pcmk__rcs) / sizeof(struct pcmk__rc_info))
+
+/*!
+ * \brief Get a return code constant name as a string
+ *
+ * \param[in] rc  Integer return code to convert
+ *
+ * \return String of constant name corresponding to rc
+ */
+const char *
+pcmk_rc_name(int rc)
+{
+    if ((rc <= pcmk_rc_error) && ((pcmk_rc_error - rc) < PCMK__N_RC)) {
+        return pcmk__rcs[pcmk_rc_error - rc].name;
+    }
+    switch (rc) {
+        case pcmk_rc_ok:        return "pcmk_rc_ok";
+        case E2BIG:             return "E2BIG";
+        case EACCES:            return "EACCES";
+        case EADDRINUSE:        return "EADDRINUSE";
+        case EADDRNOTAVAIL:     return "EADDRNOTAVAIL";
+        case EAFNOSUPPORT:      return "EAFNOSUPPORT";
+        case EAGAIN:            return "EAGAIN";
+        case EALREADY:          return "EALREADY";
+        case EBADF:             return "EBADF";
+        case EBADMSG:           return "EBADMSG";
+        case EBUSY:             return "EBUSY";
+        case ECANCELED:         return "ECANCELED";
+        case ECHILD:            return "ECHILD";
+        case ECOMM:             return "ECOMM";
+        case ECONNABORTED:      return "ECONNABORTED";
+        case ECONNREFUSED:      return "ECONNREFUSED";
+        case ECONNRESET:        return "ECONNRESET";
+        /* case EDEADLK:        return "EDEADLK"; */
+        case EDESTADDRREQ:      return "EDESTADDRREQ";
+        case EDOM:              return "EDOM";
+        case EDQUOT:            return "EDQUOT";
+        case EEXIST:            return "EEXIST";
+        case EFAULT:            return "EFAULT";
+        case EFBIG:             return "EFBIG";
+        case EHOSTDOWN:         return "EHOSTDOWN";
+        case EHOSTUNREACH:      return "EHOSTUNREACH";
+        case EIDRM:             return "EIDRM";
+        case EILSEQ:            return "EILSEQ";
+        case EINPROGRESS:       return "EINPROGRESS";
+        case EINTR:             return "EINTR";
+        case EINVAL:            return "EINVAL";
+        case EIO:               return "EIO";
+        case EISCONN:           return "EISCONN";
+        case EISDIR:            return "EISDIR";
+        case ELIBACC:           return "ELIBACC";
+        case ELOOP:             return "ELOOP";
+        case EMFILE:            return "EMFILE";
+        case EMLINK:            return "EMLINK";
+        case EMSGSIZE:          return "EMSGSIZE";
+#ifdef EMULTIHOP // Not available on OpenBSD
+        case EMULTIHOP:         return "EMULTIHOP";
+#endif
+        case ENAMETOOLONG:      return "ENAMETOOLONG";
+        case ENETDOWN:          return "ENETDOWN";
+        case ENETRESET:         return "ENETRESET";
+        case ENETUNREACH:       return "ENETUNREACH";
+        case ENFILE:            return "ENFILE";
+        case ENOBUFS:           return "ENOBUFS";
+        case ENODATA:           return "ENODATA";
+        case ENODEV:            return "ENODEV";
+        case ENOENT:            return "ENOENT";
+        case ENOEXEC:           return "ENOEXEC";
+        case ENOKEY:            return "ENOKEY";
+        case ENOLCK:            return "ENOLCK";
+#ifdef ENOLINK // Not available on OpenBSD
+        case ENOLINK:           return "ENOLINK";
+#endif
+        case ENOMEM:            return "ENOMEM";
+        case ENOMSG:            return "ENOMSG";
+        case ENOPROTOOPT:       return "ENOPROTOOPT";
+        case ENOSPC:            return "ENOSPC";
+        case ENOSR:             return "ENOSR";
+        case ENOSTR:            return "ENOSTR";
+        case ENOSYS:            return "ENOSYS";
+        case ENOTBLK:           return "ENOTBLK";
+        case ENOTCONN:          return "ENOTCONN";
+        case ENOTDIR:           return "ENOTDIR";
+        case ENOTEMPTY:         return "ENOTEMPTY";
+        case ENOTSOCK:          return "ENOTSOCK";
+#if ENOTSUP != EOPNOTSUPP
+        case ENOTSUP:           return "ENOTSUP";
+#endif
+        case ENOTTY:            return "ENOTTY";
+        case ENOTUNIQ:          return "ENOTUNIQ";
+        case ENXIO:             return "ENXIO";
+        case EOPNOTSUPP:        return "EOPNOTSUPP";
+        case EOVERFLOW:         return "EOVERFLOW";
+        case EPERM:             return "EPERM";
+        case EPFNOSUPPORT:      return "EPFNOSUPPORT";
+        case EPIPE:             return "EPIPE";
+        case EPROTO:            return "EPROTO";
+        case EPROTONOSUPPORT:   return "EPROTONOSUPPORT";
+        case EPROTOTYPE:        return "EPROTOTYPE";
+        case ERANGE:            return "ERANGE";
+        case EREMOTE:           return "EREMOTE";
+        case EREMOTEIO:         return "EREMOTEIO";
+        case EROFS:             return "EROFS";
+        case ESHUTDOWN:         return "ESHUTDOWN";
+        case ESPIPE:            return "ESPIPE";
+        case ESOCKTNOSUPPORT:   return "ESOCKTNOSUPPORT";
+        case ESRCH:             return "ESRCH";
+        case ESTALE:            return "ESTALE";
+        case ETIME:             return "ETIME";
+        case ETIMEDOUT:         return "ETIMEDOUT";
+        case ETXTBSY:           return "ETXTBSY";
+        case EUNATCH:           return "EUNATCH";
+        case EUSERS:            return "EUSERS";
+        /* case EWOULDBLOCK:    return "EWOULDBLOCK"; */
+        case EXDEV:             return "EXDEV";
+
+#ifdef EBADE // Not available on OS X
+        case EBADE:             return "EBADE";
+        case EBADFD:            return "EBADFD";
+        case EBADSLT:           return "EBADSLT";
+        case EDEADLOCK:         return "EDEADLOCK";
+        case EBADR:             return "EBADR";
+        case EBADRQC:           return "EBADRQC";
+        case ECHRNG:            return "ECHRNG";
+#ifdef EISNAM // Not available on OS X, Illumos, Solaris
+        case EISNAM:            return "EISNAM";
+        case EKEYEXPIRED:       return "EKEYEXPIRED";
+        case EKEYREJECTED:      return "EKEYREJECTED";
+        case EKEYREVOKED:       return "EKEYREVOKED";
+#endif
+        case EL2HLT:            return "EL2HLT";
+        case EL2NSYNC:          return "EL2NSYNC";
+        case EL3HLT:            return "EL3HLT";
+        case EL3RST:            return "EL3RST";
+        case ELIBBAD:           return "ELIBBAD";
+        case ELIBMAX:           return "ELIBMAX";
+        case ELIBSCN:           return "ELIBSCN";
+        case ELIBEXEC:          return "ELIBEXEC";
+#ifdef ENOMEDIUM // Not available on OS X, Illumos, Solaris
+        case ENOMEDIUM:         return "ENOMEDIUM";
+        case EMEDIUMTYPE:       return "EMEDIUMTYPE";
+#endif
+        case ENONET:            return "ENONET";
+        case ENOPKG:            return "ENOPKG";
+        case EREMCHG:           return "EREMCHG";
+        case ERESTART:          return "ERESTART";
+        case ESTRPIPE:          return "ESTRPIPE";
+#ifdef EUCLEAN // Not available on OS X, Illumos, Solaris
+        case EUCLEAN:           return "EUCLEAN";
+#endif
+        case EXFULL:            return "EXFULL";
+#endif // EBADE
+        default:                return "Unknown";
+    }
+}
+
+/*!
+ * \brief Get a user-friendly description of a return code
+ *
+ * \param[in] rc  Integer return code to convert
+ *
+ * \return String description of rc
+ */
+const char *
+pcmk_rc_str(int rc)
+{
+    if (rc == pcmk_rc_ok) {
+        return "OK";
+    }
+    if ((rc <= pcmk_rc_error) && ((pcmk_rc_error - rc) < PCMK__N_RC)) {
+        return pcmk__rcs[pcmk_rc_error - rc].desc;
+    }
+    if (rc < 0) {
+        return "Unknown error";
+    }
+    return strerror(rc);
+}
+
+// This returns negative values for errors
+//! \deprecated Use standard return codes instead
+int
+pcmk_rc2legacy(int rc)
+{
+    if (rc >= 0) {
+        return -rc; // OK or system errno
+    }
+    if ((rc <= pcmk_rc_error) && ((pcmk_rc_error - rc) < PCMK__N_RC)) {
+        return pcmk__rcs[pcmk_rc_error - rc].legacy_rc;
+    }
+    return -pcmk_err_generic;
+}
+
+//! \deprecated Use standard return codes instead
+int
+pcmk_legacy2rc(int legacy_rc)
+{
+    legacy_rc = abs(legacy_rc);
+    switch (legacy_rc) {
+        case pcmk_err_no_quorum:            return pcmk_rc_no_quorum;
+        case pcmk_err_schema_validation:    return pcmk_rc_schema_validation;
+        case pcmk_err_schema_unchanged:     return pcmk_rc_schema_unchanged;
+        case pcmk_err_transform_failed:     return pcmk_rc_transform_failed;
+        case pcmk_err_old_data:             return pcmk_rc_old_data;
+        case pcmk_err_diff_failed:          return pcmk_rc_diff_failed;
+        case pcmk_err_diff_resync:          return pcmk_rc_diff_resync;
+        case pcmk_err_cib_modified:         return pcmk_rc_cib_modified;
+        case pcmk_err_cib_backup:           return pcmk_rc_cib_backup;
+        case pcmk_err_cib_save:             return pcmk_rc_cib_save;
+        case pcmk_err_cib_corrupt:          return pcmk_rc_cib_corrupt;
+        case pcmk_err_multiple:             return pcmk_rc_multiple;
+        case pcmk_err_node_unknown:         return pcmk_rc_node_unknown;
+        case pcmk_err_already:              return pcmk_rc_already;
+        case pcmk_err_bad_nvpair:           return pcmk_rc_bad_nvpair;
+        case pcmk_err_unknown_format:       return pcmk_rc_unknown_format;
+        case pcmk_err_generic:              return pcmk_rc_error;
+        case pcmk_ok:                       return pcmk_rc_ok;
+        default:                            return legacy_rc; // system errno
+    }
+}
+
+// Exit status codes
 
 const char *
 crm_exit_name(crm_exit_t exit_code)
@@ -347,26 +517,17 @@ crm_exit_str(crm_exit_t exit_code)
         case CRM_EX_TIMEOUT: return "Timeout occurred";
         case CRM_EX_MAX: return "Error occurred";
     }
-    if (exit_code > 128) {
+    if ((exit_code > 128) && (exit_code < CRM_EX_MAX)) {
         return "Interrupted by signal";
     }
     return "Unknown exit status";
 }
 
-/*!
- * \brief Map an errno to a similar exit status
- *
- * \param[in] errno  Error number to map
- *
- * \return Exit status corresponding to errno
- */
+//! \deprecated Use standard return codes and pcmk_rc2exitc() instead
 crm_exit_t
 crm_errno2exit(int rc)
 {
     rc = abs(rc); // Convenience for functions that return -errno
-    if (rc == EOPNOTSUPP) {
-        rc = ENOTSUP; // Values are same on Linux, can't use both in case
-    }
     switch (rc) {
         case pcmk_ok:
             return CRM_EX_OK;
@@ -382,6 +543,48 @@ crm_errno2exit(int rc)
             return CRM_EX_CONFIG;
 
         case pcmk_err_bad_nvpair:
+            return CRM_EX_INVALID_PARAM;
+
+        case pcmk_err_already:
+            return CRM_EX_EXISTS;
+
+        case pcmk_err_multiple:
+            return CRM_EX_MULTIPLE;
+
+        case pcmk_err_node_unknown:
+        case pcmk_err_unknown_format:
+            return CRM_EX_NOSUCH;
+
+        default:
+            return pcmk_rc2exitc(rc); // system errno
+    }
+}
+
+/*!
+ * \brief Map a function return code to the most similar exit code
+ *
+ * \param[in] rc  Function return code
+ *
+ * \return Most similar exit code
+ */
+crm_exit_t
+pcmk_rc2exitc(int rc)
+{
+    switch (rc) {
+        case pcmk_rc_ok:
+            return CRM_EX_OK;
+
+        case pcmk_rc_no_quorum:
+            return CRM_EX_QUORUM;
+
+        case pcmk_rc_old_data:
+            return CRM_EX_OLD;
+
+        case pcmk_rc_schema_validation:
+        case pcmk_rc_transform_failed:
+            return CRM_EX_CONFIG;
+
+        case pcmk_rc_bad_nvpair:
             return CRM_EX_INVALID_PARAM;
 
         case EACCES:
@@ -414,22 +617,25 @@ crm_errno2exit(int rc)
             return CRM_EX_DISCONNECT;
 
         case EEXIST:
-        case pcmk_err_already:
+        case pcmk_rc_already:
             return CRM_EX_EXISTS;
 
         case EIO:
             return CRM_EX_IOERR;
 
         case ENOTSUP:
+#if EOPNOTSUPP != ENOTSUP
+        case EOPNOTSUPP:
+#endif
             return CRM_EX_UNIMPLEMENT_FEATURE;
 
         case ENOTUNIQ:
-        case pcmk_err_multiple:
+        case pcmk_rc_multiple:
             return CRM_EX_MULTIPLE;
 
         case ENXIO:
-        case pcmk_err_node_unknown:
-        case pcmk_err_unknown_format:
+        case pcmk_rc_node_unknown:
+        case pcmk_rc_unknown_format:
             return CRM_EX_NOSUCH;
 
         case ETIME:
@@ -440,6 +646,8 @@ crm_errno2exit(int rc)
             return CRM_EX_ERROR;
     }
 }
+
+// Other functions
 
 const char *
 bz2_strerror(int rc)

--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the Pacemaker project contributors
+ * Copyright 2015-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -25,7 +25,7 @@
 #include <crm/lrmd.h>
 
 static lrmd_key_value_t *
-alert_key2param(lrmd_key_value_t *head, enum crm_alert_keys_e name,
+alert_key2param(lrmd_key_value_t *head, enum pcmk__alert_keys_e name,
                 const char *value)
 {
     const char **key;
@@ -33,7 +33,7 @@ alert_key2param(lrmd_key_value_t *head, enum crm_alert_keys_e name,
     if (value == NULL) {
         value = "";
     }
-    for (key = crm_alert_keys[name]; *key; key++) {
+    for (key = pcmk__alert_keys[name]; *key; key++) {
         crm_trace("Setting alert key %s = '%s'", *key, value);
         head = lrmd_key_value_add(head, *key, value);
     }
@@ -41,7 +41,7 @@ alert_key2param(lrmd_key_value_t *head, enum crm_alert_keys_e name,
 }
 
 static lrmd_key_value_t *
-alert_key2param_int(lrmd_key_value_t *head, enum crm_alert_keys_e name,
+alert_key2param_int(lrmd_key_value_t *head, enum pcmk__alert_keys_e name,
                     int value)
 {
     char *value_s = crm_itoa(value);
@@ -52,7 +52,7 @@ alert_key2param_int(lrmd_key_value_t *head, enum crm_alert_keys_e name,
 }
 
 static lrmd_key_value_t *
-alert_key2param_ms(lrmd_key_value_t *head, enum crm_alert_keys_e name,
+alert_key2param_ms(lrmd_key_value_t *head, enum pcmk__alert_keys_e name,
                    guint value)
 {
     char *value_s = crm_strdup_printf("%u", value);
@@ -75,7 +75,7 @@ set_ev_kv(gpointer key, gpointer value, gpointer user_data)
 }
 
 static lrmd_key_value_t *
-alert_envvar2params(lrmd_key_value_t *head, crm_alert_entry_t *entry)
+alert_envvar2params(lrmd_key_value_t *head, pcmk__alert_t *entry)
 {
     if (entry->envvars) {
         g_hash_table_foreach(entry->envvars, set_ev_kv, &head);
@@ -117,7 +117,7 @@ is_target_alert(char **list, const char *value)
  * \param[in]     lrmd        Executor connection to use
  * \param[in]     alert_list  Alerts to execute
  * \param[in]     kind        Type of event that is being alerted for
- * \param[in]     attr_name   If crm_alert_attribute, the attribute name
+ * \param[in]     attr_name   If pcmk__alert_attribute, the attribute name
  * \param[in,out] params      Environment variables to pass to agents
  *
  * \retval pcmk_ok on success
@@ -125,21 +125,21 @@ is_target_alert(char **list, const char *value)
  * \retval -2 if all alerts failed
  */
 static int
-exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum crm_alert_flags kind,
+exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum pcmk__alert_flags kind,
                 const char *attr_name, lrmd_key_value_t *params)
 {
     bool any_success = FALSE, any_failure = FALSE;
-    const char *kind_s = crm_alert_flag2text(kind);
+    const char *kind_s = pcmk__alert_flag2text(kind);
     crm_time_hr_t *now = NULL;
     struct timeval tv_now;
     char timestamp_epoch[20];
     char timestamp_usec[7];
 
-    params = alert_key2param(params, CRM_alert_kind, kind_s);
-    params = alert_key2param(params, CRM_alert_version, VERSION);
+    params = alert_key2param(params, PCMK__alert_key_kind, kind_s);
+    params = alert_key2param(params, PCMK__alert_key_version, VERSION);
 
     for (GList *iter = g_list_first(alert_list); iter; iter = g_list_next(iter)) {
-        crm_alert_entry_t *entry = (crm_alert_entry_t *)(iter->data);
+        pcmk__alert_t *entry = (pcmk__alert_t *)(iter->data);
         lrmd_key_value_t *copy_params = NULL;
         lrmd_key_value_t *head = NULL;
         int rc;
@@ -150,7 +150,7 @@ exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum crm_alert_flags kind,
             continue;
         }
 
-        if ((kind == crm_alert_attribute)
+        if ((kind == pcmk__alert_attribute)
             && !is_target_alert(entry->select_attribute_name, attr_name)) {
 
             crm_trace("Filtering unwanted attribute '%s' alert to %s via %s",
@@ -171,23 +171,28 @@ exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum crm_alert_flags kind,
             copy_params = lrmd_key_value_add(copy_params, head->key, head->value);
         }
 
-        copy_params = alert_key2param(copy_params, CRM_alert_recipient,
+        copy_params = alert_key2param(copy_params, PCMK__alert_key_recipient,
                                       entry->recipient);
 
         if (now) {
             char *timestamp = crm_time_format_hr(entry->tstamp_format, now);
 
             if (timestamp) {
-                copy_params = alert_key2param(copy_params, CRM_alert_timestamp,
+                copy_params = alert_key2param(copy_params,
+                                              PCMK__alert_key_timestamp,
                                               timestamp);
                 free(timestamp);
             }
 
             snprintf(timestamp_epoch, sizeof(timestamp_epoch), "%lld",
                      (long long) tv_now.tv_sec);
-            copy_params = alert_key2param(copy_params, CRM_alert_timestamp_epoch, timestamp_epoch);
+            copy_params = alert_key2param(copy_params,
+                                          PCMK__alert_key_timestamp_epoch,
+                                          timestamp_epoch);
             snprintf(timestamp_usec, sizeof(timestamp_usec), "%06d", now->useconds);
-            copy_params = alert_key2param(copy_params, CRM_alert_timestamp_usec, timestamp_usec);
+            copy_params = alert_key2param(copy_params,
+                                          PCMK__alert_key_timestamp_usec,
+                                          timestamp_usec);
         }
 
         copy_params = alert_envvar2params(copy_params, entry);
@@ -240,12 +245,13 @@ lrmd_send_attribute_alert(lrmd_t *lrmd, GList *alert_list,
         return -2;
     }
 
-    params = alert_key2param(params, CRM_alert_node, node);
-    params = alert_key2param_int(params, CRM_alert_nodeid, nodeid);
-    params = alert_key2param(params, CRM_alert_attribute_name, attr_name);
-    params = alert_key2param(params, CRM_alert_attribute_value, attr_value);
+    params = alert_key2param(params, PCMK__alert_key_node, node);
+    params = alert_key2param_int(params, PCMK__alert_key_nodeid, nodeid);
+    params = alert_key2param(params, PCMK__alert_key_attribute_name, attr_name);
+    params = alert_key2param(params, PCMK__alert_key_attribute_value,
+                             attr_value);
 
-    rc = exec_alert_list(lrmd, alert_list, crm_alert_attribute, attr_name,
+    rc = exec_alert_list(lrmd, alert_list, pcmk__alert_attribute, attr_name,
                          params);
     lrmd_key_value_freeall(params);
     return rc;
@@ -276,11 +282,11 @@ lrmd_send_node_alert(lrmd_t *lrmd, GList *alert_list,
         return -2;
     }
 
-    params = alert_key2param(params, CRM_alert_node, node);
-    params = alert_key2param(params, CRM_alert_desc, state);
-    params = alert_key2param_int(params, CRM_alert_nodeid, nodeid);
+    params = alert_key2param(params, PCMK__alert_key_node, node);
+    params = alert_key2param(params, PCMK__alert_key_desc, state);
+    params = alert_key2param_int(params, PCMK__alert_key_nodeid, nodeid);
 
-    rc = exec_alert_list(lrmd, alert_list, crm_alert_node, NULL, params);
+    rc = exec_alert_list(lrmd, alert_list, pcmk__alert_node, NULL, params);
     lrmd_key_value_freeall(params);
     return rc;
 }
@@ -312,12 +318,12 @@ lrmd_send_fencing_alert(lrmd_t *lrmd, GList *alert_list,
         return -2;
     }
 
-    params = alert_key2param(params, CRM_alert_node, target);
-    params = alert_key2param(params, CRM_alert_task, task);
-    params = alert_key2param(params, CRM_alert_desc, desc);
-    params = alert_key2param_int(params, CRM_alert_rc, op_rc);
+    params = alert_key2param(params, PCMK__alert_key_node, target);
+    params = alert_key2param(params, PCMK__alert_key_task, task);
+    params = alert_key2param(params, PCMK__alert_key_desc, desc);
+    params = alert_key2param_int(params, PCMK__alert_key_rc, op_rc);
 
-    rc = exec_alert_list(lrmd, alert_list, crm_alert_fencing, NULL, params);
+    rc = exec_alert_list(lrmd, alert_list, pcmk__alert_fencing, NULL, params);
     lrmd_key_value_freeall(params);
     return rc;
 }
@@ -359,30 +365,35 @@ lrmd_send_resource_alert(lrmd_t *lrmd, GList *alert_list,
         return pcmk_ok;
     }
 
-    params = alert_key2param(params, CRM_alert_node, node);
-    params = alert_key2param(params, CRM_alert_rsc, op->rsc_id);
-    params = alert_key2param(params, CRM_alert_task, op->op_type);
-    params = alert_key2param_ms(params, CRM_alert_interval, op->interval_ms);
-    params = alert_key2param_int(params, CRM_alert_target_rc, target_rc);
-    params = alert_key2param_int(params, CRM_alert_status, op->op_status);
-    params = alert_key2param_int(params, CRM_alert_rc, op->rc);
+    params = alert_key2param(params, PCMK__alert_key_node, node);
+    params = alert_key2param(params, PCMK__alert_key_rsc, op->rsc_id);
+    params = alert_key2param(params, PCMK__alert_key_task, op->op_type);
+    params = alert_key2param_ms(params, PCMK__alert_key_interval,
+                                op->interval_ms);
+    params = alert_key2param_int(params, PCMK__alert_key_target_rc, target_rc);
+    params = alert_key2param_int(params, PCMK__alert_key_status, op->op_status);
+    params = alert_key2param_int(params, PCMK__alert_key_rc, op->rc);
 
     /* Reoccurring operations do not set exec_time, so on timeout, set it
      * to the operation timeout since that's closer to the actual value.
      */
     if (op->op_status == PCMK_LRM_OP_TIMEOUT && op->exec_time == 0) {
-        params = alert_key2param_int(params, CRM_alert_exec_time, op->timeout);
+        params = alert_key2param_int(params, PCMK__alert_key_exec_time,
+                                     op->timeout);
     } else {
-        params = alert_key2param_int(params, CRM_alert_exec_time, op->exec_time);
+        params = alert_key2param_int(params, PCMK__alert_key_exec_time,
+                                     op->exec_time);
     }
 
     if (op->op_status == PCMK_LRM_OP_DONE) {
-        params = alert_key2param(params, CRM_alert_desc, services_ocf_exitcode_str(op->rc));
+        params = alert_key2param(params, PCMK__alert_key_desc,
+                                 services_ocf_exitcode_str(op->rc));
     } else {
-        params = alert_key2param(params, CRM_alert_desc, services_lrm_status_str(op->op_status));
+        params = alert_key2param(params, PCMK__alert_key_desc,
+                                 services_lrm_status_str(op->op_status));
     }
 
-    rc = exec_alert_list(lrmd, alert_list, crm_alert_resource, NULL, params);
+    rc = exec_alert_list(lrmd, alert_list, pcmk__alert_resource, NULL, params);
     lrmd_key_value_freeall(params);
     return rc;
 }

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -81,7 +81,7 @@ main(int argc, char **argv)
 {
     int index = 0;
     int argerr = 0;
-    int attr_options = attrd_opt_none;
+    int attr_options = pcmk__node_attr_none;
     int flag;
     crm_exit_t exit_code = CRM_EX_OK;
     char *attr_node = NULL;
@@ -136,7 +136,7 @@ main(int argc, char **argv)
                 query_all = TRUE;
                 break;
             case 'p':
-                set_bit(attr_options, attrd_opt_private);
+                set_bit(attr_options, pcmk__node_attr_private);
                 break;
             case 'q':
                 break;
@@ -177,14 +177,15 @@ main(int argc, char **argv)
         exit_code = crm_errno2exit(do_query(attr_name, attr_node, query_all));
     } else {
         /* @TODO We don't know whether the specified node is a Pacemaker Remote
-         * node or not, so we can't set attrd_opt_remote when appropriate.
+         * node or not, so we can't set pcmk__node_attr_remote when appropriate.
          * However, it's not a big problem, because pacemaker-attrd will learn
          * and remember a node's "remoteness".
          */
-        exit_code = crm_errno2exit(do_update(command,
-                                   attrd_get_target(attr_node), attr_name,
-                                   attr_value, attr_section, attr_set,
-                                   attr_dampen, attr_options));
+        exit_code = pcmk_rc2exitc(do_update(command,
+                                            pcmk__node_attr_target(attr_node),
+                                            attr_name, attr_value,
+                                            attr_section, attr_set,
+                                            attr_dampen, attr_options));
     }
 
     cleanup_memory();
@@ -332,7 +333,7 @@ do_query(const char *attr_name, const char *attr_node, gboolean query_all)
     if (query_all == TRUE) {
         attr_node = NULL;
     } else {
-        attr_node = attrd_get_target(attr_node);
+        attr_node = pcmk__node_attr_target(attr_node);
     }
 
     /* Build and send pacemaker-attrd request, and get XML reply */
@@ -368,11 +369,12 @@ do_update(char command, const char *attr_node, const char *attr_name,
           const char *attr_value, const char *attr_section,
           const char *attr_set, const char *attr_dampen, int attr_options)
 {
-    int rc = attrd_update_delegate(NULL, command, attr_node, attr_name,
-                                   attr_value, attr_section, attr_set,
-                                   attr_dampen, NULL, attr_options);
-    if (rc != pcmk_ok) {
-        fprintf(stderr, "Could not update %s=%s: %s (%d)\n", attr_name, attr_value, pcmk_strerror(rc), rc);
+    int rc = pcmk__node_attr_request(NULL, command, attr_node, attr_name,
+                                     attr_value, attr_section, attr_set,
+                                     attr_dampen, NULL, attr_options);
+    if (rc != pcmk_rc_ok) {
+        fprintf(stderr, "Could not update %s=%s: %s (%d)\n",
+                attr_name, attr_value, pcmk_rc_str(rc), rc);
     }
     return rc;
 }

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -21,7 +21,7 @@
 #include <crm/msg_xml.h>
 #include <crm/common/ipc.h>
 
-#include <crm/attrd.h>
+#include <crm/common/attrd_internal.h>
 
 /* *INDENT-OFF* */
 static struct crm_option long_options[] = {

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -116,6 +116,7 @@ main(int argc, char **argv)
     int is_remote_node = 0;
 
     bool try_attrd = true;
+    int attrd_opts = pcmk__node_attr_none;
 
     crm_log_cli_init("crm_attribute");
     crm_set_options(NULL, "<command> -n <attribute> [options]", long_options,
@@ -239,7 +240,7 @@ main(int argc, char **argv)
          * the correct local node name will be passed as an environment
          * variable. Otherwise, we have to ask the cluster.
          */
-        dest_uname = attrd_get_target(dest_uname);
+        dest_uname = pcmk__node_attr_target(dest_uname);
         if (dest_uname == NULL) {
             dest_uname = get_local_node_name();
         }
@@ -278,10 +279,13 @@ main(int argc, char **argv)
         try_attrd = FALSE;
     }
 
+    if (is_remote_node) {
+        attrd_opts = pcmk__node_attr_remote;
+    }
     if (((command == 'v') || (command == 'D') || (command == 'u')) && try_attrd
-        && pcmk_ok == attrd_update_delegate(NULL, command, dest_uname, attr_name,
-                                            attr_value, type, set_name, NULL, NULL,
-                                            is_remote_node?attrd_opt_remote:attrd_opt_none)) {
+        && (pcmk__node_attr_request(NULL, command, dest_uname, attr_name,
+                                    attr_value, type, set_name, NULL, NULL,
+                                    attrd_opts) == pcmk_rc_ok)) {
         crm_info("Update %s=%s sent via pacemaker-attrd",
                  attr_name, ((command == 'D')? "<none>" : attr_value));
 

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -28,7 +28,7 @@
 #include <crm/cluster.h>
 
 #include <crm/cib.h>
-#include <crm/attrd.h>
+#include <crm/common/attrd_internal.h>
 #include <sys/utsname.h>
 
 gboolean BE_QUIET = FALSE;

--- a/tools/crm_error.c
+++ b/tools/crm_error.c
@@ -1,21 +1,10 @@
-/* 
- * Copyright 2012-2018 the Pacemaker project contributors
+/*
+ * Copyright 2012-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
- * 
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
  */
 
 #include <crm_internal.h>
@@ -33,11 +22,30 @@ static struct crm_option long_options[] = {
      "\n\t\t\tUseful for looking for sources of the error in source code"},
 
     {"list",    0, 0, 'l', "\tShow all known errors."},
-    {"exit",    0, 0, 'X', "\tInterpret as exit code rather than function return value"},
+    {"exit",    0, 0, 'X', "\tInterpret as exit code rather than legacy function return value"},
+    {"rc",      0, 0, 'r', "\tInterpret as return code rather than legacy function return value"},
 
     {0, 0, 0, 0}
 };
 /* *INDENT-ON* */
+
+static bool as_exit_code = false;
+static bool as_rc = false;
+
+static void
+get_strings(int rc, const char **name, const char **str)
+{
+    if (as_exit_code) {
+        *str = crm_exit_str((crm_exit_t) rc);
+        *name = crm_exit_name(rc);
+    } else if (as_rc) {
+        *str = pcmk_rc_str(rc);
+        *name = pcmk_rc_name(rc);
+    } else {
+        *str = pcmk_strerror(rc);
+        *name = pcmk_errorname(rc);
+    }
+}
 
 int
 main(int argc, char **argv)
@@ -49,10 +57,12 @@ main(int argc, char **argv)
 
     bool do_list = FALSE;
     bool with_name = FALSE;
-    bool as_exit_code = FALSE;
+
+    const char *name = NULL;
+    const char *desc = NULL;
 
     crm_log_cli_init("crm_error");
-    crm_set_options(NULL, "[options] -- rc", long_options,
+    crm_set_options(NULL, "[options] -- <rc> [...]", long_options,
                     "Tool for displaying the textual name or description of a reported error code");
 
     while (flag >= 0) {
@@ -73,6 +83,9 @@ main(int argc, char **argv)
             case 'l':
                 do_list = TRUE;
                 break;
+            case 'r':
+                as_rc = true;
+                break;
             case 'X':
                 as_exit_code = TRUE;
                 break;
@@ -83,30 +96,43 @@ main(int argc, char **argv)
     }
 
     if(do_list) {
-        for (rc = 0; rc < 256; rc++) {
-            const char *name = as_exit_code? crm_exit_name(rc) : pcmk_errorname(rc);
-            const char *desc = as_exit_code? crm_exit_str(rc) : pcmk_strerror(rc);
+        int start, end, width;
+
+        // 256 is a hacky magic number that "should" be enough
+        if (as_rc) {
+            start = pcmk_rc_error - 256;
+            end = PCMK_CUSTOM_OFFSET;
+            width = 4;
+        } else {
+            start = 0;
+            end = 256;
+            width = 3;
+        }
+
+        for (rc = start; rc < end; rc++) {
+            if (rc == (pcmk_rc_error + 1)) {
+                // Values in between are reserved for callers, no use iterating
+                rc = pcmk_rc_ok;
+            }
+            get_strings(rc, &name, &desc);
             if (!name || !strcmp(name, "Unknown") || !strcmp(name, "CRM_EX_UNKNOWN")) {
-                /* Unknown */
+                // Undefined
             } else if(with_name) {
-                printf("%.3d: %-26s  %s\n", rc, name, desc);
+                printf("% .*d: %-26s  %s\n", width, rc, name, desc);
             } else {
-                printf("%.3d: %s\n", rc, desc);
+                printf("% .*d: %s\n", width, rc, desc);
             }
         }
-        return CRM_EX_OK;
-    }
 
-    for (lpc = optind; lpc < argc; lpc++) {
-        const char *str, *name;
-
-        rc = crm_atoi(argv[lpc], NULL);
-        str = as_exit_code? crm_exit_str(rc) : pcmk_strerror(rc);
-        if(with_name) {
-            name = as_exit_code? crm_exit_name(rc) : pcmk_errorname(rc);
-            printf("%s - %s\n", name, str);
-        } else {
-            printf("%s\n", str);
+    } else {
+        for (lpc = optind; lpc < argc; lpc++) {
+            rc = crm_atoi(argv[lpc], NULL);
+            get_strings(rc, &name, &desc);
+            if (with_name) {
+                printf("%s - %s\n", name, desc);
+            } else {
+                printf("%s\n", desc);
+            }
         }
     }
     return CRM_EX_OK;

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -19,7 +19,7 @@
 #include <crm/common/mainloop.h>
 #include <crm/msg_xml.h>
 #include <crm/cib.h>
-#include <crm/attrd.h>
+#include <crm/common/attrd_internal.h>
 
 #define SUMMARY "crm_node - Tool for displaying low-level node information"
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1327,7 +1327,7 @@ main(int argc, char **argv)
         const char *router_node = host_uname;
         xmlNode *msg_data = NULL;
         xmlNode *cmd = NULL;
-        int attr_options = attrd_opt_none;
+        int attr_options = pcmk__node_attr_none;
 
         if (host_uname) {
             node_t *node = pe_find_node(data_set->nodes, host_uname);
@@ -1341,7 +1341,7 @@ main(int argc, char **argv)
                     goto bail;
                 }
                 router_node = node->details->uname;
-                attr_options |= attrd_opt_remote;
+                attr_options |= pcmk__node_attr_remote;
             }
         }
 
@@ -1364,8 +1364,9 @@ main(int argc, char **argv)
 
         crm_debug("Re-checking the state of all resources on %s", host_uname?host_uname:"all nodes");
 
-        rc = attrd_clear_delegate(NULL, host_uname, NULL, NULL, NULL, NULL,
-                                  attr_options);
+        rc = pcmk_rc2legacy(pcmk__node_attr_request_clear(NULL, host_uname,
+                                                          NULL, NULL, NULL,
+                                                          NULL, attr_options));
 
         if (crm_ipc_send(crmd_channel, cmd, 0, 0, NULL) > 0) {
             start_mainloop();

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -16,7 +16,7 @@
 #include <crm/common/mainloop.h>
 
 #include <crm/cib.h>
-#include <crm/attrd.h>
+#include <crm/common/attrd_internal.h>
 #include <crm/pengine/rules.h>
 #include <crm/pengine/status.h>
 #include <crm/pengine/internal.h>

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -692,14 +692,15 @@ clear_rsc_fail_attrs(resource_t *rsc, const char *operation,
                      const char *interval_spec, node_t *node)
 {
     int rc = pcmk_ok;
-    int attr_options = attrd_opt_none;
+    int attr_options = pcmk__node_attr_none;
     char *rsc_name = rsc_fail_name(rsc);
 
     if (pe__is_guest_or_remote_node(node)) {
-        attr_options |= attrd_opt_remote;
+        attr_options |= pcmk__node_attr_remote;
     }
-    rc = attrd_clear_delegate(NULL, node->details->uname, rsc_name, operation,
-                              interval_spec, NULL, attr_options);
+    rc = pcmk__node_attr_request_clear(NULL, node->details->uname, rsc_name,
+                                       operation, interval_spec, NULL,
+                                       attr_options);
     free(rsc_name);
     return rc;
 }
@@ -791,10 +792,10 @@ cli_resource_delete(crm_ipc_t *crmd_channel, const char *host_uname,
     }
 
     rc = clear_rsc_fail_attrs(rsc, operation, interval_spec, node);
-    if (rc != pcmk_ok) {
+    if (rc != pcmk_rc_ok) {
         printf("Unable to clean up %s failures on %s: %s\n",
-                rsc->id, host_uname, pcmk_strerror(rc));
-        return rc;
+                rsc->id, host_uname, pcmk_rc_str(rc));
+        return pcmk_rc2legacy(rc);
     }
 
     if (just_failures) {
@@ -818,7 +819,7 @@ cli_cleanup_all(crm_ipc_t *crmd_channel, const char *node_name,
                 pe_working_set_t *data_set)
 {
     int rc = pcmk_ok;
-    int attr_options = attrd_opt_none;
+    int attr_options = pcmk__node_attr_none;
     const char *display_name = node_name? node_name : "all nodes";
 
     if (crmd_channel == NULL) {
@@ -836,16 +837,16 @@ cli_cleanup_all(crm_ipc_t *crmd_channel, const char *node_name,
             return -ENXIO;
         }
         if (pe__is_guest_or_remote_node(node)) {
-            attr_options |= attrd_opt_remote;
+            attr_options |= pcmk__node_attr_remote;
         }
     }
 
-    rc = attrd_clear_delegate(NULL, node_name, NULL, operation, interval_spec,
-                              NULL, attr_options);
-    if (rc != pcmk_ok) {
+    rc = pcmk__node_attr_request_clear(NULL, node_name, NULL, operation,
+                                       interval_spec, NULL, attr_options);
+    if (rc != pcmk_rc_ok) {
         printf("Unable to clean up all failures on %s: %s\n",
-                display_name, pcmk_strerror(rc));
-        return rc;
+                display_name, pcmk_rc_str(rc));
+        return pcmk_rc2legacy(rc);
     }
 
     if (node_name) {

--- a/tools/notifyServicelogEvent.c
+++ b/tools/notifyServicelogEvent.c
@@ -1,6 +1,6 @@
 /*
  * Original copyright 2009 International Business Machines, IBM, Mark Hamzy
- * Later changes copyright 2009-2018 the Pacemaker project contributors
+ * Later changes copyright 2009-2019 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -25,7 +25,7 @@
 
 #include <crm/common/xml.h>
 #include <crm/common/util.h>
-#include <crm/attrd.h>
+#include <crm/common/attrd_internal.h>
 
 typedef enum { STATUS_GREEN = 1, STATUS_YELLOW, STATUS_RED } STATUS;
 

--- a/tools/notifyServicelogEvent.c
+++ b/tools/notifyServicelogEvent.c
@@ -1,6 +1,6 @@
 /*
  * Original copyright 2009 International Business Machines, IBM, Mark Hamzy
- * Later changes copyright 2009-2019 the Pacemaker project contributors
+ * Later changes copyright 2009-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -161,14 +161,15 @@ main(int argc, char *argv[])
         health_status = status2char(status);
 
         if (health_status) {
-            gboolean rc;
+            int attrd_rc;
 
-            /* @TODO pass attrd_opt_remote when appropriate */
-            rc = (attrd_update_delegate(NULL, 'v', NULL, health_component,
-                                        health_status, NULL, NULL, NULL, NULL,
-                                        attrd_opt_none) > 0);
+            // @TODO pass pcmk__node_attr_remote when appropriate
+            attrd_rc = pcmk__node_attr_request(NULL, 'v', NULL,
+                                               health_component, health_status,
+                                               NULL, NULL, NULL, NULL,
+                                               pcmk__node_attr_none);
             crm_debug("Updating attribute ('%s', '%s') = %d",
-                      health_component, health_status, rc);
+                      health_component, health_status, attrd_rc);
         } else {
             crm_err("Error: status2char failed, status = %d", status);
             rc = 1;


### PR DESCRIPTION
Since we are soon introducing a high-level public API, it's a good time to
address issues with the current model of function return codes.

Most Pacemaker API functions currently return an integer return code, such that the
absolute value of the return code is either a system error number or a custom
pcmk_err_* number. This is less than ideal because system error numbers are
constrained only to the positive int range, so there's the possibility (though
not noticed in the wild) that system errors and custom errors could collide.

The new method being introduced here still uses an integer return code,
but negative values are from a new enum pcmk_rc_e, and positive values are
system error numbers. 0 still represents success.

It is expected that the new method will be used with new public API functions,
and internal API functions will be gradually refactored to use it as well.
Existing public API functions can be addressed at the next minor version
(2.1.0).