### PR TITLE
Low: fenced: Clearly log merged STONITH operations.

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1993,7 +1993,7 @@ stonith_query(xmlNode * msg, const char *remote_peer, const char *client_id, int
 
 #define ST_LOG_OUTPUT_MAX 512
 static void
-log_operation(async_command_t * cmd, int rc, int pid, const char *next, const char *output)
+log_operation(async_command_t * cmd, int rc, int pid, const char *next, const char *output, gboolean op_merged)
 {
     if (rc == 0) {
         next = NULL;
@@ -2001,15 +2001,17 @@ log_operation(async_command_t * cmd, int rc, int pid, const char *next, const ch
 
     if (cmd->victim != NULL) {
         do_crm_log(rc == 0 ? LOG_NOTICE : LOG_ERR,
-                   "Operation '%s' [%d] (call %d from %s) for host '%s' with device '%s' returned: %d (%s)%s%s",
+                   "Operation '%s' [%d] (call %d from %s) for host '%s' with device '%s' returned: %d (%s)%s%s%s",
                    cmd->action, pid, cmd->id, cmd->client_name, cmd->victim,
                    cmd->device, rc, pcmk_strerror(rc),
-                   (next? ", retrying with " : ""), (next ? next : ""));
+                   (next? ", retrying with " : ""), (next ? next : ""),
+                   (op_merged? "(merged)" : ""));
     } else {
         do_crm_log_unlikely(rc == 0 ? LOG_DEBUG : LOG_NOTICE,
-                            "Operation '%s' [%d] for device '%s' returned: %d (%s)%s%s",
+                            "Operation '%s' [%d] for device '%s' returned: %d (%s)%s%s%s",
                             cmd->action, pid, cmd->device, rc, pcmk_strerror(rc),
-                            (next? ", retrying with " : ""), (next ? next : ""));
+                            (next? ", retrying with " : ""), (next ? next : ""),
+                            (op_merged? "(merged)" : ""));
     }
 
     if (output) {
@@ -2022,7 +2024,7 @@ log_operation(async_command_t * cmd, int rc, int pid, const char *next, const ch
 }
 
 static void
-stonith_send_async_reply(async_command_t * cmd, const char *output, int rc, GPid pid)
+stonith_send_async_reply(async_command_t * cmd, const char *output, int rc, GPid pid, int options)
 {
     xmlNode *reply = NULL;
     gboolean bcast = FALSE;
@@ -2044,8 +2046,12 @@ stonith_send_async_reply(async_command_t * cmd, const char *output, int rc, GPid
         bcast = TRUE;
     }
 
-    log_operation(cmd, rc, pid, NULL, output);
+    log_operation(cmd, rc, pid, NULL, output, (options & st_reply_opt_merged ? TRUE : FALSE));
     crm_log_xml_trace(reply, "Reply");
+
+    if (options & st_reply_opt_merged) {
+        crm_xml_add(reply, F_STONITH_MERGED, "true");
+    }
 
     if (bcast) {
         crm_xml_add(reply, F_STONITH_OPERATION, T_STONITH_NOTIFY);
@@ -2151,7 +2157,7 @@ st_child_done(GPid pid, int rc, const char *output, gpointer user_data)
 
     /* this operation requires more fencing, hooray! */
     if (next_device) {
-        log_operation(cmd, rc, pid, next_device->id, output);
+        log_operation(cmd, rc, pid, next_device->id, output, FALSE);
 
         schedule_stonith_command(cmd, next_device);
         /* Prevent cmd from being freed */
@@ -2159,7 +2165,7 @@ st_child_done(GPid pid, int rc, const char *output, gpointer user_data)
         goto done;
     }
 
-    stonith_send_async_reply(cmd, output, rc, pid);
+    stonith_send_async_reply(cmd, output, rc, pid, st_reply_opt_none);
 
     if (rc != 0) {
         goto done;
@@ -2206,7 +2212,7 @@ st_child_done(GPid pid, int rc, const char *output, gpointer user_data)
 
         cmd_list = g_list_remove_link(cmd_list, gIter);
 
-        stonith_send_async_reply(cmd_other, output, rc, pid);
+        stonith_send_async_reply(cmd_other, output, rc, pid, st_reply_opt_merged);
         cancel_stonith_command(cmd_other);
 
         free_async_command(cmd_other);
@@ -2259,7 +2265,7 @@ stonith_fence_get_devices_cb(GList * devices, void *user_data)
     }
 
     /* no device found! */
-    stonith_send_async_reply(cmd, NULL, -ENODEV, 0);
+    stonith_send_async_reply(cmd, NULL, -ENODEV, 0, st_reply_opt_none);
 
     free_async_command(cmd);
     g_list_free_full(devices, free);

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -361,7 +361,7 @@ stonith_merge_in_history_list(GHashTable *history)
                trigger unexpected results at other places and to prevent
                remote_op_done from setting the delegate if not present
              */
-            stonith_bcast_result_to_peers(op, -EHOSTUNREACH);
+            stonith_bcast_result_to_peers(op, -EHOSTUNREACH, FALSE);
         }
 
         g_hash_table_insert(stonith_remote_op_list, op->id, op);

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -70,6 +70,14 @@ enum st_remap_phase {
     st_phase_max = 3
 };
 
+/* These values provide additional information for STONITH's asynchronous reply response.
+ * The st_reply_opt_merged value indicates an operation that has been merged and completed without being executed.
+ */
+enum st_replay_option {
+    st_reply_opt_none            = 0x00000000,
+    st_reply_opt_merged          = 0x00000001,
+};
+
 typedef struct remote_fencing_op_s {
     /* The unique id associated with this operation */
     char *id;
@@ -155,7 +163,7 @@ typedef struct remote_fencing_op_s {
  * \param op, Operation whose result should be broadcast
  * \param rc, Result of the operation
  */
-void stonith_bcast_result_to_peers(remote_fencing_op_t * op, int rc);
+void stonith_bcast_result_to_peers(remote_fencing_op_t * op, int rc, gboolean op_merged);
 
 enum st_callback_flags {
     st_callback_unknown               = 0x0000,

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -103,6 +103,7 @@ stonith_history_t *stonith__sort_history(stonith_history_t *history);
 #  define F_STONITH_DEVICE        "st_device_id"
 #  define F_STONITH_ACTION        "st_device_action"
 #  define F_STONITH_MODE          "st_mode"
+#  define F_STONITH_MERGED        "st_op_merged"
 
 #  define T_STONITH_NG        "stonith-ng"
 #  define T_STONITH_REPLY     "st-reply"


### PR DESCRIPTION
Hi All,

When a DC node is fencing, there are times when the second STONITH is executed by a new DC node if STONITH execution is delayed.

For example, in a configuration where fence_ipmilan is set by reboot, this situation often occurs due to the delay of fence_ipmilan off and on.

If the user examines the log in detail, it can be seen that the second STONIOTH has been treated as completed when the first STONITH is completed.

However, many users seem to determine that STONITH has completed with the next fenced log.

```
notice: Operation 'reboot' targeting xxx on xxx for pacemaker-controld.xxxx@xxxxx.xxxx: OK
```


In this situation, STONITH, which was handled as the second completion, also produces the same log as success, so the user may mistakenly think that STONITH was executed twice.
```
Dec 17 09:29:23 rh77hv-02 pacemaker-fenced[30658]: notice: Operation 'reboot' targeting rh77hv-01 on rh77hv-02 for pacemaker-controld.27372@rh77hv-02.6bf96b72: OK
Dec 17 09:29:23 rh77hv-02 pacemaker-fenced[30658]: notice: Operation 'reboot' targeting rh77hv-01 on rh77hv-02 for pacemaker-controld.30662@rh77hv-02.750c4fa9: OK
```

This fix mitigates user confusion by outputting merged and completed STONITH completions as clearly merged.
(The character string "(merged)" is put behind.)
```
Dec 17 09:29:23 rh77hv-02 pacemaker-fenced[30658]: notice: Operation 'reboot' targeting rh77hv-01 on rh77hv-02 for pacemaker-controld.27372@rh77hv-02.6bf96b72: OK
Dec 17 09:29:23 rh77hv-02 pacemaker-fenced[30658]: notice: Operation 'reboot' targeting rh77hv-01 on rh77hv-02 for pacemaker-controld.30662@rh77hv-02.750c4fa9: OK(merged)
```

Best Regards,
Hideo Yamauch.