### PR TITLE
Fix: iso8601: Fix crm_time_parse_offset() to parse offset with plus sign.

### DIFF
--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -689,7 +689,9 @@ crm_time_parse_offset(const char *offset_str, int *offset)
 
         gboolean negate = FALSE;
 
-        if (offset_str[0] == '-') {
+        if (offset_str[0] == '+') {
+            offset_str++;
+        } else if (offset_str[0] == '-') {
             negate = TRUE;
             offset_str++;
         }


### PR DESCRIPTION
crm_time_parse_offset() incorrectly handles time offset with plus ('+') sign, e.g. +0900 while minus ('-') is handled correctly.