### PR TITLE
Move stonith_admin into a library

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -12,6 +12,7 @@ MAINTAINERCLEANFILES    = Makefile.in config.h.in
 noinst_HEADERS	        = config.h 			\
 			  crm_internal.h		\
 			  doxygen.h			\
+			  pacemaker.h \
 			  pacemaker-internal.h		\
 			  portability.h
 pkginclude_HEADERS	= crm_config.h

--- a/include/crm/common/cmdline_internal.h
+++ b/include/crm/common/cmdline_internal.h
@@ -131,13 +131,12 @@ void pcmk__add_arg_group(GOptionContext *context, const char *name,
  * of all the command line arguments.  It is up to the caller to free this memory
  * after use.
  *
- * \param[in] argc    The length of argv.
  * \param[in] argv    The command line arguments.
  * \param[in] special Single-letter command line arguments that take a value.
  *                    These letters will all have pre-processing applied.
  */
 char **
-pcmk__cmdline_preproc(int argc, char **argv, const char *special);
+pcmk__cmdline_preproc(char **argv, const char *special);
 
 /*!
  * \internal

--- a/include/crm/common/cmdline_internal.h
+++ b/include/crm/common/cmdline_internal.h
@@ -135,7 +135,7 @@ void pcmk__add_arg_group(GOptionContext *context, const char *name,
  * \param[in] special Single-letter command line arguments that take a value.
  *                    These letters will all have pre-processing applied.
  */
-char **
+gchar **
 pcmk__cmdline_preproc(char **argv, const char *special);
 
 /*!

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -162,7 +162,7 @@ struct pcmk__output_s {
      * In the case of command line usage, this would be the command line
      * arguments.  For other use cases, it could be different.
      */
-    char *request;
+    gchar *request;
 
     /*!
      * \brief Does this formatter support a special quiet mode?

--- a/include/doxygen.h
+++ b/include/doxygen.h
@@ -25,6 +25,7 @@
  * \defgroup lrmd Executor API
  * \defgroup pengine Scheduler API
  * \defgroup fencing Fencing API
+ * \defgroup pacemaker Pacemaker High Level API
  */
 
 /**
@@ -42,6 +43,7 @@
  *  - \ref lrmd
  *  - \ref pengine
  *  - \ref fencing
+ *  - \ref pacemaker
  *
  * Contributing to the Pacemaker Project:
  * - <a href="https://clusterlabs.org/pacemaker/doc/en-US/Pacemaker/2.0/html-single/Pacemaker_Development/">Pacemaker Development</a>

--- a/include/pacemaker-internal.h
+++ b/include/pacemaker-internal.h
@@ -11,6 +11,8 @@
 #  define PACEMAKER_INTERNAL__H
 
 #  include <pcmki/pcmki_error.h>
+#  include <pcmki/pcmki_fence.h>
+#  include <pcmki/pcmki_output.h>
 #  include <pcmki/pcmki_sched_allocate.h>
 #  include <pcmki/pcmki_sched_notif.h>
 #  include <pcmki/pcmki_sched_utils.h>

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -30,15 +30,15 @@ extern "C" {
  * \param[in] target    The node receiving the action.
  * \param[in] action    The action to perform.
  * \param[in] name      Who requested the fence action?
- * \param[in] timeout   How long to wait for the operation to complete (in seconds).
+ * \param[in] timeout   How long to wait for the operation to complete (in ms).
  * \param[in] tolerance If a successful action for \p target happened within
- *                      this many seconds, return 0 without performing the
- *                      action again.
+ *                      this many ms, return 0 without performing the action
+ *                      again.
  *
  * \return 0 on success, or various error codes on error.
  */
 int pcmk_fence_action(stonith_t *st, const char *target, const char *action,
-                      const char *name, int timeout, int tolerance);
+                      const char *name, unsigned int timeout, unsigned int tolerance);
 
 /*!
  * \brief List the fencing operations that have occurred for a specific node.
@@ -49,7 +49,7 @@ int pcmk_fence_action(stonith_t *st, const char *target, const char *action,
  * \param[in,out] xml       The destination for the result, as an XML tree.
  * \param[in]     st        A connection to the STONITH API.
  * \param[in]     target    The node to get history for.
- * \param[in]     timeout   How long to wait for the operation to complete (in seconds).
+ * \param[in]     timeout   How long to wait for the operation to complete (in ms).
  * \param[in]     quiet     Suppress most output.
  * \param[in]     verbose   Include additional output.
  * \param[in]     broadcast Gather fencing history from all nodes.
@@ -57,8 +57,9 @@ int pcmk_fence_action(stonith_t *st, const char *target, const char *action,
  *
  * \return 0 on success, or various error codes on error.
  */
-int pcmk_fence_history(xmlNodePtr *xml, stonith_t *st, char *target, int timeout,
-                       bool quiet, int verbose, bool broadcast, bool cleanup);
+int pcmk_fence_history(xmlNodePtr *xml, stonith_t *st, char *target,
+                       unsigned int timeout, bool quiet, int verbose,
+                       bool broadcast, bool cleanup);
 
 /*!
  * \brief List all installed STONITH agents.
@@ -68,11 +69,11 @@ int pcmk_fence_history(xmlNodePtr *xml, stonith_t *st, char *target, int timeout
  *
  * \param[in,out] xml     The destination for the result, as an XML tree.
  * \param[in]     st      A connection to the STONITH API.
- * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
  * \return 0 on success, or various error codes on error.
  */
-int pcmk_fence_installed(xmlNodePtr *xml, stonith_t *st, int timeout);
+int pcmk_fence_installed(xmlNodePtr *xml, stonith_t *st, unsigned int timeout);
 
 /*!
  * \brief When was a device last fenced?
@@ -97,11 +98,12 @@ int pcmk_fence_last(xmlNodePtr *xml, const char *target, bool as_nodeid);
  * \param[in,out] xml     The destination for the result, as an XML tree.
  * \param[in]     st      A connection to the STONITH API.
  * \param[in]     agent   The agent that can do the fencing.
- * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
  * \return 0 on success, or various error codes on error.
  */
-int pcmk_fence_list_targets(xmlNodePtr *xml, stonith_t *st, char *agent, int timeout);
+int pcmk_fence_list_targets(xmlNodePtr *xml, stonith_t *st, char *agent,
+                            unsigned int timeout);
 
 /*!
  * \brief Get metadata for a resource.
@@ -112,11 +114,12 @@ int pcmk_fence_list_targets(xmlNodePtr *xml, stonith_t *st, char *agent, int tim
  * \param[in,out] xml     The destination for the result, as an XML tree.
  * \param[in]     st      A connection to the STONITH API.
  * \param[in]     agent   The fence agent to get metadata for.
- * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
  * \return 0 on success, or various error codes on error.
  */
-int pcmk_fence_metadata(xmlNodePtr *xml, stonith_t *st, char *agent, int timeout);
+int pcmk_fence_metadata(xmlNodePtr *xml, stonith_t *st, char *agent,
+                        unsigned int timeout);
 
 /*!
  * \brief List registered fence devices.
@@ -128,11 +131,12 @@ int pcmk_fence_metadata(xmlNodePtr *xml, stonith_t *st, char *agent, int timeout
  * \param[in]     st      A connection to the STONITH API.
  * \param[in]     target  If not NULL, only return devices that can fence
  *                        this node.
- * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
  * \return 0 on success, or various error codes on error.
  */
-int pcmk_fence_registered(xmlNodePtr *xml, stonith_t *st, char *target, int timeout);
+int pcmk_fence_registered(xmlNodePtr *xml, stonith_t *st, char *target,
+                          unsigned int timeout);
 
 /*!
  * \brief Register a fencing level for a specific node, node regex, or attribute.
@@ -179,12 +183,13 @@ int pcmk_fence_unregister_level(stonith_t *st, char *target, int fence_level);
  * \param[in]     agent   The agent to validate (for example, "fence_xvm").
  * \param[in]     id      STONITH device ID (may be NULL).
  * \param[in]     params  STONITH device configuration parameters.
- * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
  * \return 0 on success, or various error codes on error.
  */
 int pcmk_fence_validate(xmlNodePtr *xml, stonith_t *st, const char *agent,
-                        const char *id, stonith_key_value_t *params, int timeout);
+                        const char *id, stonith_key_value_t *params,
+                        unsigned int timeout);
 
 #ifdef __cplusplus
 }

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -35,7 +35,7 @@ extern "C" {
  *                      this many ms, return 0 without performing the action
  *                      again.
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk_fence_action(stonith_t *st, const char *target, const char *action,
                       const char *name, unsigned int timeout, unsigned int tolerance);
@@ -55,7 +55,7 @@ int pcmk_fence_action(stonith_t *st, const char *target, const char *action,
  * \param[in]     broadcast Gather fencing history from all nodes.
  * \param[in]     cleanup   Clean up fencing history after listing.
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk_fence_history(xmlNodePtr *xml, stonith_t *st, char *target,
                        unsigned int timeout, bool quiet, int verbose,
@@ -71,7 +71,7 @@ int pcmk_fence_history(xmlNodePtr *xml, stonith_t *st, char *target,
  * \param[in]     st      A connection to the STONITH API.
  * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk_fence_installed(xmlNodePtr *xml, stonith_t *st, unsigned int timeout);
 
@@ -85,7 +85,7 @@ int pcmk_fence_installed(xmlNodePtr *xml, stonith_t *st, unsigned int timeout);
  * \param[in]     target    The node that was fenced.
  * \param[in]     as_nodeid 
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk_fence_last(xmlNodePtr *xml, const char *target, bool as_nodeid);
 
@@ -100,7 +100,7 @@ int pcmk_fence_last(xmlNodePtr *xml, const char *target, bool as_nodeid);
  * \param[in]     agent   The agent that can do the fencing.
  * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk_fence_list_targets(xmlNodePtr *xml, stonith_t *st, char *agent,
                             unsigned int timeout);
@@ -116,7 +116,7 @@ int pcmk_fence_list_targets(xmlNodePtr *xml, stonith_t *st, char *agent,
  * \param[in]     agent   The fence agent to get metadata for.
  * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk_fence_metadata(xmlNodePtr *xml, stonith_t *st, char *agent,
                         unsigned int timeout);
@@ -133,7 +133,7 @@ int pcmk_fence_metadata(xmlNodePtr *xml, stonith_t *st, char *agent,
  *                        this node.
  * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk_fence_registered(xmlNodePtr *xml, stonith_t *st, char *target,
                           unsigned int timeout);
@@ -151,7 +151,7 @@ int pcmk_fence_registered(xmlNodePtr *xml, stonith_t *st, char *target,
  * \param[in] fence_level Index number of level to add.
  * \param[in] devices     Devices to use in level.
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk_fence_register_level(stonith_t *st, char *target, int fence_level,
                               stonith_key_value_t *devices);
@@ -168,7 +168,7 @@ int pcmk_fence_register_level(stonith_t *st, char *target, int fence_level,
  * \param[in] target      The object to unregister a fencing level for.
  * \param[in] fence_level Index number of level to remove.
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk_fence_unregister_level(stonith_t *st, char *target, int fence_level);
 
@@ -185,7 +185,7 @@ int pcmk_fence_unregister_level(stonith_t *st, char *target, int fence_level);
  * \param[in]     params  STONITH device configuration parameters.
  * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk_fence_validate(xmlNodePtr *xml, stonith_t *st, const char *agent,
                         const char *id, stonith_key_value_t *params,

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PACEMAKER__H
+#  define PACEMAKER__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \file
+ * \brief High Level API
+ * \ingroup pacemaker
+ */
+
+#  include <crm/stonith-ng.h>
+#  include <libxml/tree.h>
+
+/*!
+ * \brief Perform a STONITH action.
+ *
+ * \param[in] st        A connection to the STONITH API.
+ * \param[in] target    The node receiving the action.
+ * \param[in] action    The action to perform.
+ * \param[in] name      Who requested the fence action?
+ * \param[in] timeout   How long to wait for the operation to complete (in seconds).
+ * \param[in] tolerance If a successful action for \p target happened within
+ *                      this many seconds, return 0 without performing the
+ *                      action again.
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk_fence_action(stonith_t *st, const char *target, const char *action,
+                      const char *name, int timeout, int tolerance);
+
+/*!
+ * \brief List the fencing operations that have occurred for a specific node.
+ *
+ * \note If \p xml is not NULL, it will be freed first and the previous
+ *       contents lost.
+ *
+ * \param[in,out] xml       The destination for the result, as an XML tree.
+ * \param[in]     st        A connection to the STONITH API.
+ * \param[in]     target    The node to get history for.
+ * \param[in]     timeout   How long to wait for the operation to complete (in seconds).
+ * \param[in]     quiet     Suppress most output.
+ * \param[in]     verbose   Include additional output.
+ * \param[in]     broadcast Gather fencing history from all nodes.
+ * \param[in]     cleanup   Clean up fencing history after listing.
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk_fence_history(xmlNodePtr *xml, stonith_t *st, char *target, int timeout,
+                       bool quiet, int verbose, bool broadcast, bool cleanup);
+
+/*!
+ * \brief List all installed STONITH agents.
+ *
+ * \note If \p xml is not NULL, it will be freed first and the previous
+ *       contents lost.
+ *
+ * \param[in,out] xml     The destination for the result, as an XML tree.
+ * \param[in]     st      A connection to the STONITH API.
+ * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk_fence_installed(xmlNodePtr *xml, stonith_t *st, int timeout);
+
+/*!
+ * \brief When was a device last fenced?
+ *
+ * \note If \p xml is not NULL, it will be freed first and the previous
+ *       contents lost.
+ *
+ * \param[in,out] xml       The destination for the result, as an XML tree.
+ * \param[in]     target    The node that was fenced.
+ * \param[in]     as_nodeid 
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk_fence_last(xmlNodePtr *xml, const char *target, bool as_nodeid);
+
+/*!
+ * \brief List nodes that can be fenced.
+ *
+ * \note If \p xml is not NULL, it will be freed first and the previous
+ *       contents lost.
+ *
+ * \param[in,out] xml     The destination for the result, as an XML tree.
+ * \param[in]     st      A connection to the STONITH API.
+ * \param[in]     agent   The agent that can do the fencing.
+ * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk_fence_list_targets(xmlNodePtr *xml, stonith_t *st, char *agent, int timeout);
+
+/*!
+ * \brief Get metadata for a resource.
+ *
+ * \note If \p xml is not NULL, it will be freed first and the previous
+ *       contents lost.
+ *
+ * \param[in,out] xml     The destination for the result, as an XML tree.
+ * \param[in]     st      A connection to the STONITH API.
+ * \param[in]     agent   The fence agent to get metadata for.
+ * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk_fence_metadata(xmlNodePtr *xml, stonith_t *st, char *agent, int timeout);
+
+/*!
+ * \brief List registered fence devices.
+ *
+ * \note If \p xml is not NULL, it will be freed first and the previous
+ *       contents lost.
+ *
+ * \param[in,out] xml     The destination for the result, as an XML tree.
+ * \param[in]     st      A connection to the STONITH API.
+ * \param[in]     target  If not NULL, only return devices that can fence
+ *                        this node.
+ * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk_fence_registered(xmlNodePtr *xml, stonith_t *st, char *target, int timeout);
+
+/*!
+ * \brief Register a fencing level for a specific node, node regex, or attribute.
+ *
+ * \p target can take three different forms:
+ *   - name=value, in which case \p target is an attribute.
+ *   - @pattern, in which case \p target is a node regex.
+ *   - Otherwise, \p target is a node name.
+ *
+ * \param[in] st          A connection to the STONITH API.
+ * \param[in] target      The object to register a fencing level for.
+ * \param[in] fence_level Index number of level to add.
+ * \param[in] devices     Devices to use in level.
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk_fence_register_level(stonith_t *st, char *target, int fence_level,
+                              stonith_key_value_t *devices);
+
+/*!
+ * \brief Unregister a fencing level for a specific node, node regex, or attribute.
+ *
+ * \p target can take three different forms:
+ *   - name=value, in which case \p target is an attribute.
+ *   - @pattern, in which case \p target is a node regex.
+ *   - Otherwise, \p target is a node name.
+ *
+ * \param[in] st          A connection to the STONITH API.
+ * \param[in] target      The object to unregister a fencing level for.
+ * \param[in] fence_level Index number of level to remove.
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk_fence_unregister_level(stonith_t *st, char *target, int fence_level);
+
+/*!
+ * \brief Validate a STONITH device configuration.
+ *
+ * \note If \p xml is not NULL, it will be freed first and the previous
+ *       contents lost.
+ *
+ * \param[in,out] xml     The destination for the result, as an XML tree.
+ * \param[in]     st      A connection to the STONITH API.
+ * \param[in]     agent   The agent to validate (for example, "fence_xvm").
+ * \param[in]     id      STONITH device ID (may be NULL).
+ * \param[in]     params  STONITH device configuration parameters.
+ * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk_fence_validate(xmlNodePtr *xml, stonith_t *st, const char *agent,
+                        const char *id, stonith_key_value_t *params, int timeout);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -14,6 +14,8 @@
 extern "C" {
 #endif
 
+#ifdef BUILD_PUBLIC_LIBPACEMAKER
+
 /**
  * \file
  * \brief High Level API
@@ -190,6 +192,8 @@ int pcmk_fence_unregister_level(stonith_t *st, char *target, int fence_level);
 int pcmk_fence_validate(xmlNodePtr *xml, stonith_t *st, const char *agent,
                         const char *id, stonith_key_value_t *params,
                         unsigned int timeout);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/pcmki/Makefile.am
+++ b/include/pcmki/Makefile.am
@@ -10,6 +10,8 @@
 MAINTAINERCLEANFILES    = Makefile.in
 
 noinst_HEADERS		= pcmki_error.h \
+			  pcmki_fence.h \
+			  pcmki_output.h \
 			  pcmki_sched_allocate.h \
 			  pcmki_sched_notif.h \
 			  pcmki_sched_utils.h \

--- a/include/pcmki/pcmki_fence.h
+++ b/include/pcmki/pcmki_fence.h
@@ -27,7 +27,7 @@
  *                      this many ms, return 0 without performing the action
  *                      again.
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk__fence_action(stonith_t *st, const char *target, const char *action,
                       const char *name, unsigned int timeout, unsigned int tolerance);
@@ -51,7 +51,7 @@ int pcmk__fence_action(stonith_t *st, const char *target, const char *action,
  * \param[in]     broadcast Gather fencing history from all nodes.
  * \param[in]     cleanup   Clean up fencing history after listing.
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk__fence_history(pcmk__output_t *out, stonith_t *st, char *target,
                         unsigned int timeout, bool quiet, int verbose,
@@ -71,7 +71,7 @@ int pcmk__fence_history(pcmk__output_t *out, stonith_t *st, char *target,
  * \param[in]     st      A connection to the STONITH API.
  * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk__fence_installed(pcmk__output_t *out, stonith_t *st, unsigned int timeout);
 
@@ -89,7 +89,7 @@ int pcmk__fence_installed(pcmk__output_t *out, stonith_t *st, unsigned int timeo
  * \param[in]     target    The node that was fenced.
  * \param[in]     as_nodeid 
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk__fence_last(pcmk__output_t *out, const char *target, bool as_nodeid);
 
@@ -108,7 +108,7 @@ int pcmk__fence_last(pcmk__output_t *out, const char *target, bool as_nodeid);
  * \param[in]     agent   The agent that can do the fencing.
  * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk__fence_list_targets(pcmk__output_t *out, stonith_t *st, char *agent,
                              unsigned int timeout);
@@ -128,7 +128,7 @@ int pcmk__fence_list_targets(pcmk__output_t *out, stonith_t *st, char *agent,
  * \param[in]     agent   The fence agent to get metadata for.
  * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk__fence_metadata(pcmk__output_t *out, stonith_t *st, char *agent,
                          unsigned int timeout);
@@ -149,7 +149,7 @@ int pcmk__fence_metadata(pcmk__output_t *out, stonith_t *st, char *agent,
  *                        this node.
  * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk__fence_registered(pcmk__output_t *out, stonith_t *st, char *target,
                            unsigned int timeout);
@@ -170,7 +170,7 @@ int pcmk__fence_registered(pcmk__output_t *out, stonith_t *st, char *target,
  * \param[in] fence_level Index number of level to add.
  * \param[in] devices     Devices to use in level.
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk__fence_register_level(stonith_t *st, char *target, int fence_level,
                               stonith_key_value_t *devices);
@@ -190,7 +190,7 @@ int pcmk__fence_register_level(stonith_t *st, char *target, int fence_level,
  * \param[in] target      The object to unregister a fencing level for.
  * \param[in] fence_level Index number of level to remove.
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk__fence_unregister_level(stonith_t *st, char *target, int fence_level);
 
@@ -211,7 +211,7 @@ int pcmk__fence_unregister_level(stonith_t *st, char *target, int fence_level);
  * \param[in]     params  STONITH device configuration parameters.
  * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
- * \return 0 on success, or various error codes on error.
+ * \return Standard Pacemaker return code
  */
 int pcmk__fence_validate(pcmk__output_t *out, stonith_t *st, const char *agent,
                          const char *id, stonith_key_value_t *params,

--- a/include/pcmki/pcmki_fence.h
+++ b/include/pcmki/pcmki_fence.h
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+#ifndef PCMKI_STONITH_H
+#  define PCMKI_STONITH_H
+
+#  include <crm/common/output.h>
+#  include <crm/stonith-ng.h>
+
+/*!
+ * \brief Perform a STONITH action.
+ *
+ * \note This is the internal version of pcmk_fence_action().  External users
+ *       of the pacemaker API should use that function instead.
+ *
+ * \param[in] st        A connection to the STONITH API.
+ * \param[in] target    The node receiving the action.
+ * \param[in] action    The action to perform.
+ * \param[in] name      Who requested the fence action?
+ * \param[in] timeout   How long to wait for the operation to complete (in seconds).
+ * \param[in] tolerance If a successful action for \p target happened within
+ *                      this many seconds, return 0 without performing the
+ *                      action again.
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk__fence_action(stonith_t *st, const char *target, const char *action,
+                      const char *name, int timeout, int tolerance);
+
+/*!
+ * \brief List the fencing operations that have occurred for a specific node.
+ *
+ * \note This is the internal version of pcmk_fence_history().  External users
+ *       of the pacemaker API should use that function instead.
+ *
+ * \note \p out should be initialized with pcmk__output_new() before calling this
+ *       function and destroyed with out->finish and pcmk__output_free() before
+ *       reusing it with any other functions in this library.
+ *
+ * \param[in,out] out       The output functions structure.
+ * \param[in]     st        A connection to the STONITH API.
+ * \param[in]     target    The node to get history for.
+ * \param[in]     timeout   How long to wait for the operation to complete (in seconds).
+ * \param[in]     quiet     Suppress most output.
+ * \param[in]     verbose   Include additional output.
+ * \param[in]     broadcast Gather fencing history from all nodes.
+ * \param[in]     cleanup   Clean up fencing history after listing.
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk__fence_history(pcmk__output_t *out, stonith_t *st, char *target,
+                       int timeout, bool quiet, int verbose, bool broadcast,
+                       bool cleanup);
+
+/**
+ * \brief List all installed STONITH agents.
+ *
+ * \note This is the internal version of pcmk_fence_installed().  External users
+ *       of the pacemaker API should use that function instead.
+ *
+ * \note \p out should be initialized with pcmk__output_new() before calling this
+ *       function and destroyed with out->finish and pcmk__output_free() before
+ *       reusing it with any other functions in this library.
+ *
+ * \param[in,out] out     The output functions structure.
+ * \param[in]     st      A connection to the STONITH API.
+ * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk__fence_installed(pcmk__output_t *out, stonith_t *st, int timeout);
+
+/*!
+ * \brief When was a device last fenced?
+ *
+ * \note This is the internal version of pcmk_fence_last().  External users
+ *       of the pacemaker API should use that function instead.
+ *
+ * \note \p out should be initialized with pcmk__output_new() before calling this
+ *       function and destroyed with out->finish and pcmk__output_free() before
+ *       reusing it with any other functions in this library.
+ *
+ * \param[in,out] out       The output functions structure.
+ * \param[in]     target    The node that was fenced.
+ * \param[in]     as_nodeid 
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk__fence_last(pcmk__output_t *out, const char *target, bool as_nodeid);
+
+/*!
+ * \brief List nodes that can be fenced.
+ *
+ * \note This is the internal version of pcmk_fence_list_targets().  External users
+ *       of the pacemaker API should use that function instead.
+ *
+ * \note \p out should be initialized with pcmk__output_new() before calling this
+ *       function and destroyed with out->finish and pcmk__output_free() before
+ *       reusing it with any other functions in this library.
+ *
+ * \param[in,out] out     The output functions structure.
+ * \param[in]     st      A connection to the STONITH API.
+ * \param[in]     agent   The agent that can do the fencing.
+ * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk__fence_list_targets(pcmk__output_t *out, stonith_t *st, char *agent, int timeout);
+
+/*!
+ * \brief Get metadata for a resource.
+ *
+ * \note This is the internal version of pcmk_fence_metadata().  External users
+ *       of the pacemaker API should use that function instead.
+ *
+ * \note \p out should be initialized with pcmk__output_new() before calling this
+ *       function and destroyed with out->finish and pcmk__output_free() before
+ *       reusing it with any other functions in this library.
+ *
+ * \param[in,out] out     The output functions structure.
+ * \param[in]     st      A connection to the STONITH API.
+ * \param[in]     agent   The fence agent to get metadata for.
+ * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk__fence_metadata(pcmk__output_t *out, stonith_t *st, char *agent, int timeout);
+
+/*!
+ * \brief List registered fence devices.
+ *
+ * \note This is the internal version of pcmk_fence_metadata().  External users
+ *       of the pacemaker API should use that function instead.
+ *
+ * \note \p out should be initialized with pcmk__output_new() before calling this
+ *       function and destroyed with out->finish and pcmk__output_free() before
+ *       reusing it with any other functions in this library.
+ *
+ * \param[in,out] out     The output functions structure.
+ * \param[in]     st      A connection to the STONITH API.
+ * \param[in]     target  If not NULL, only return devices that can fence
+ *                        this node.
+ * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk__fence_registered(pcmk__output_t *out, stonith_t *st, char *target, int timeout);
+
+/*!
+ * \brief Register a fencing level for a specific node, node regex, or attribute.
+ *
+ * \note This is the internal version of pcmk_fence_register_level().  External users
+ *       of the pacemaker API should use that function instead.
+ *
+ * \p target can take three different forms:
+ *   - name=value, in which case \p target is an attribute.
+ *   - @pattern, in which case \p target is a node regex.
+ *   - Otherwise, \p target is a node name.
+ *
+ * \param[in] st          A connection to the STONITH API.
+ * \param[in] target      The object to register a fencing level for.
+ * \param[in] fence_level Index number of level to add.
+ * \param[in] devices     Devices to use in level.
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk__fence_register_level(stonith_t *st, char *target, int fence_level,
+                              stonith_key_value_t *devices);
+
+/*!
+ * \brief Unregister a fencing level for a specific node, node regex, or attribute.
+ *
+ * \note This is the internal version of pcmk_fence_unregister_level().  External users
+ *       of the pacemaker API should use that function instead.
+ *
+ * \p target can take three different forms:
+ *   - name=value, in which case \p target is an attribute.
+ *   - @pattern, in which case \p target is a node regex.
+ *   - Otherwise, \p target is a node name.
+ *
+ * \param[in] st          A connection to the STONITH API.
+ * \param[in] target      The object to unregister a fencing level for.
+ * \param[in] fence_level Index number of level to remove.
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk__fence_unregister_level(stonith_t *st, char *target, int fence_level);
+
+/**
+ * \brief Validate a STONITH device configuration.
+ *
+ * \note This is the internal version of pcmk_stonith_validate().  External users
+ *       of the pacemaker API should use that function instead.
+ *
+ * \note \p out should be initialized with pcmk__output_new() before calling this
+ *       function and destroyed with out->finish and pcmk__output_free() before
+ *       reusing it with any other functions in this library.
+ *
+ * \param[in,out] out     The output functions structure.
+ * \param[in]     st      A connection to the STONITH API.
+ * \param[in]     agent   The agent to validate (for example, "fence_xvm").
+ * \param[in]     id      STONITH device ID (may be NULL).
+ * \param[in]     params  STONITH device configuration parameters.
+ * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ *
+ * \return 0 on success, or various error codes on error.
+ */
+int pcmk__fence_validate(pcmk__output_t *out, stonith_t *st, const char *agent,
+                        const char *id, stonith_key_value_t *params, int timeout);
+
+#endif

--- a/include/pcmki/pcmki_fence.h
+++ b/include/pcmki/pcmki_fence.h
@@ -22,15 +22,15 @@
  * \param[in] target    The node receiving the action.
  * \param[in] action    The action to perform.
  * \param[in] name      Who requested the fence action?
- * \param[in] timeout   How long to wait for the operation to complete (in seconds).
+ * \param[in] timeout   How long to wait for the operation to complete (in ms).
  * \param[in] tolerance If a successful action for \p target happened within
- *                      this many seconds, return 0 without performing the
- *                      action again.
+ *                      this many ms, return 0 without performing the action
+ *                      again.
  *
  * \return 0 on success, or various error codes on error.
  */
 int pcmk__fence_action(stonith_t *st, const char *target, const char *action,
-                      const char *name, int timeout, int tolerance);
+                      const char *name, unsigned int timeout, unsigned int tolerance);
 
 /*!
  * \brief List the fencing operations that have occurred for a specific node.
@@ -45,7 +45,7 @@ int pcmk__fence_action(stonith_t *st, const char *target, const char *action,
  * \param[in,out] out       The output functions structure.
  * \param[in]     st        A connection to the STONITH API.
  * \param[in]     target    The node to get history for.
- * \param[in]     timeout   How long to wait for the operation to complete (in seconds).
+ * \param[in]     timeout   How long to wait for the operation to complete (in ms).
  * \param[in]     quiet     Suppress most output.
  * \param[in]     verbose   Include additional output.
  * \param[in]     broadcast Gather fencing history from all nodes.
@@ -54,8 +54,8 @@ int pcmk__fence_action(stonith_t *st, const char *target, const char *action,
  * \return 0 on success, or various error codes on error.
  */
 int pcmk__fence_history(pcmk__output_t *out, stonith_t *st, char *target,
-                       int timeout, bool quiet, int verbose, bool broadcast,
-                       bool cleanup);
+                        unsigned int timeout, bool quiet, int verbose,
+                        bool broadcast, bool cleanup);
 
 /**
  * \brief List all installed STONITH agents.
@@ -69,11 +69,11 @@ int pcmk__fence_history(pcmk__output_t *out, stonith_t *st, char *target,
  *
  * \param[in,out] out     The output functions structure.
  * \param[in]     st      A connection to the STONITH API.
- * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
  * \return 0 on success, or various error codes on error.
  */
-int pcmk__fence_installed(pcmk__output_t *out, stonith_t *st, int timeout);
+int pcmk__fence_installed(pcmk__output_t *out, stonith_t *st, unsigned int timeout);
 
 /*!
  * \brief When was a device last fenced?
@@ -106,11 +106,12 @@ int pcmk__fence_last(pcmk__output_t *out, const char *target, bool as_nodeid);
  * \param[in,out] out     The output functions structure.
  * \param[in]     st      A connection to the STONITH API.
  * \param[in]     agent   The agent that can do the fencing.
- * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
  * \return 0 on success, or various error codes on error.
  */
-int pcmk__fence_list_targets(pcmk__output_t *out, stonith_t *st, char *agent, int timeout);
+int pcmk__fence_list_targets(pcmk__output_t *out, stonith_t *st, char *agent,
+                             unsigned int timeout);
 
 /*!
  * \brief Get metadata for a resource.
@@ -125,11 +126,12 @@ int pcmk__fence_list_targets(pcmk__output_t *out, stonith_t *st, char *agent, in
  * \param[in,out] out     The output functions structure.
  * \param[in]     st      A connection to the STONITH API.
  * \param[in]     agent   The fence agent to get metadata for.
- * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
  * \return 0 on success, or various error codes on error.
  */
-int pcmk__fence_metadata(pcmk__output_t *out, stonith_t *st, char *agent, int timeout);
+int pcmk__fence_metadata(pcmk__output_t *out, stonith_t *st, char *agent,
+                         unsigned int timeout);
 
 /*!
  * \brief List registered fence devices.
@@ -145,11 +147,12 @@ int pcmk__fence_metadata(pcmk__output_t *out, stonith_t *st, char *agent, int ti
  * \param[in]     st      A connection to the STONITH API.
  * \param[in]     target  If not NULL, only return devices that can fence
  *                        this node.
- * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
  * \return 0 on success, or various error codes on error.
  */
-int pcmk__fence_registered(pcmk__output_t *out, stonith_t *st, char *target, int timeout);
+int pcmk__fence_registered(pcmk__output_t *out, stonith_t *st, char *target,
+                           unsigned int timeout);
 
 /*!
  * \brief Register a fencing level for a specific node, node regex, or attribute.
@@ -206,11 +209,12 @@ int pcmk__fence_unregister_level(stonith_t *st, char *target, int fence_level);
  * \param[in]     agent   The agent to validate (for example, "fence_xvm").
  * \param[in]     id      STONITH device ID (may be NULL).
  * \param[in]     params  STONITH device configuration parameters.
- * \param[in]     timeout How long to wait for the operation to complete (in seconds).
+ * \param[in]     timeout How long to wait for the operation to complete (in ms).
  *
  * \return 0 on success, or various error codes on error.
  */
 int pcmk__fence_validate(pcmk__output_t *out, stonith_t *st, const char *agent,
-                        const char *id, stonith_key_value_t *params, int timeout);
+                         const char *id, stonith_key_value_t *params,
+                         unsigned int timeout);
 
 #endif

--- a/include/pcmki/pcmki_output.h
+++ b/include/pcmki/pcmki_output.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+#ifndef PCMKI_OUTPUT_H
+#  define PCMKI_OUTPUT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#  include <crm/common/output.h>
+#  include <libxml/tree.h>
+
+extern pcmk__supported_format_t pcmk__out_formats[];
+
+int pcmk__out_prologue(pcmk__output_t **out, xmlNodePtr *xml);
+void pcmk__out_epilogue(pcmk__output_t *out, xmlNodePtr *xml, int retval);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -140,12 +140,16 @@ pcmk__add_arg_group(GOptionContext *context, const char *name,
 }
 
 char **
-pcmk__cmdline_preproc(int argc, char **argv, const char *special) {
+pcmk__cmdline_preproc(char **argv, const char *special) {
     char **retval = NULL;
     GPtrArray *arr = g_ptr_array_new();
     bool saw_dash_dash = false;
 
-    for (int i = 0; i < argc; i++) {
+    if (argv == NULL) {
+        return retval;
+    }
+
+    for (int i = 0; argv[i] != NULL; i++) {
         /* If this is the first time we saw "--" in the command line, set
          * a flag so we know to just copy everything after it over.  We also
          * want to copy the "--" over so whatever actually parses the command

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -139,9 +139,9 @@ pcmk__add_arg_group(GOptionContext *context, const char *name,
     g_option_context_add_group(context, group);
 }
 
-char **
+gchar **
 pcmk__cmdline_preproc(char **argv, const char *special) {
-    char **retval = NULL;
+    gchar **retval = NULL;
     GPtrArray *arr = g_ptr_array_new();
     bool saw_dash_dash = false;
 
@@ -219,13 +219,13 @@ pcmk__cmdline_preproc(char **argv, const char *special) {
         }
     }
 
-    /* Convert the GPtrArray into a char **, which the command line parsing
+    /* Convert the GPtrArray into a gchar **, which the command line parsing
      * code knows how to deal with.  Then we can free the array (but not its
      * contents).
      */
     retval = calloc(arr->len+1, sizeof(char *));
     for (int i = 0; i < arr->len; i++) {
-        retval [i] = (char *) g_ptr_array_index(arr, i);
+        retval[i] = (gchar *) g_ptr_array_index(arr, i);
     }
 
     g_ptr_array_free(arr, FALSE);

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -23,7 +23,7 @@ pcmk__output_free(pcmk__output_t *out) {
         g_hash_table_destroy(out->messages);
     }
 
-    free(out->request);
+    g_free(out->request);
     free(out);
 }
 

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -352,7 +352,7 @@ pcmk__mk_html_output(char **argv) {
     }
 
     retval->fmt_name = "html";
-    retval->request = g_strjoinv(" ", argv);
+    retval->request = argv == NULL ? NULL : g_strjoinv(" ", argv);
     retval->supports_quiet = false;
 
     retval->init = html_init;

--- a/lib/common/output_log.c
+++ b/lib/common/output_log.c
@@ -225,7 +225,7 @@ pcmk__mk_log_output(char **argv) {
     }
 
     retval->fmt_name = "log";
-    retval->request = g_strjoinv(" ", argv);
+    retval->request = argv == NULL ? NULL : g_strjoinv(" ", argv);
     retval->supports_quiet = false;
 
     retval->init = log_init;

--- a/lib/common/output_none.c
+++ b/lib/common/output_none.c
@@ -97,7 +97,7 @@ pcmk__mk_none_output(char **argv) {
     }
 
     retval->fmt_name = "none";
-    retval->request = g_strjoinv(" ", argv);
+    retval->request = argv == NULL ? NULL : g_strjoinv(" ", argv);
     retval->supports_quiet = true;
 
     retval->init = none_init;

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -243,7 +243,7 @@ pcmk__mk_text_output(char **argv) {
     }
 
     retval->fmt_name = "text";
-    retval->request = g_strjoinv(" ", argv);
+    retval->request = argv == NULL ? NULL : g_strjoinv(" ", argv);
     retval->supports_quiet = true;
 
     retval->init = text_init;

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -312,7 +312,7 @@ pcmk__mk_xml_output(char **argv) {
     }
 
     retval->fmt_name = "xml";
-    retval->request = g_strjoinv(" ", argv);
+    retval->request = argv == NULL ? NULL : g_strjoinv(" ", argv);
     retval->supports_quiet = false;
 
     retval->init = xml_init;

--- a/lib/pacemaker/Makefile.am
+++ b/lib/pacemaker/Makefile.am
@@ -28,6 +28,8 @@ libpacemaker_la_LIBADD	= $(top_builddir)/lib/pengine/libpe_status.la \
 # -L$(top_builddir)/lib/pils -lpils -export-dynamic -module -avoid-version
 # Use += rather than backlashed continuation lines for parsing by bumplibs.sh
 libpacemaker_la_SOURCES	=
+libpacemaker_la_SOURCES += pcmk_fence.c
+libpacemaker_la_SOURCES += pcmk_output.c
 libpacemaker_la_SOURCES	+= pcmk_sched_allocate.c
 libpacemaker_la_SOURCES += pcmk_sched_bundle.c
 libpacemaker_la_SOURCES += pcmk_sched_clone.c

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -154,11 +154,13 @@ pcmk__fence_action(stonith_t *st, const char *target, const char *action,
     return pcmk_legacy2rc(async_fence_data.rc);
 }
 
+#ifdef BUILD_PUBLIC_LIBPACEMAKER
 int
 pcmk_fence_action(stonith_t *st, const char *target, const char *action,
                   const char *name, unsigned int timeout, unsigned int tolerance) {
     return pcmk__fence_action(st, target, action, name, timeout, tolerance);
 }
+#endif
 
 int
 pcmk__fence_history(pcmk__output_t *out, stonith_t *st, char *target,
@@ -213,6 +215,7 @@ pcmk__fence_history(pcmk__output_t *out, stonith_t *st, char *target,
     return pcmk_legacy2rc(rc);
 }
 
+#ifdef BUILD_PUBLIC_LIBPACEMAKER
 int
 pcmk_fence_history(xmlNodePtr *xml, stonith_t *st, char *target, unsigned int timeout,
                    bool quiet, int verbose, bool broadcast, bool cleanup) {
@@ -229,6 +232,7 @@ pcmk_fence_history(xmlNodePtr *xml, stonith_t *st, char *target, unsigned int ti
     pcmk__out_epilogue(out, xml, rc);
     return rc;
 }
+#endif
 
 int
 pcmk__fence_installed(pcmk__output_t *out, stonith_t *st, unsigned int timeout) {
@@ -250,6 +254,7 @@ pcmk__fence_installed(pcmk__output_t *out, stonith_t *st, unsigned int timeout) 
     return pcmk_rc_ok;
 }
 
+#ifdef BUILD_PUBLIC_LIBPACEMAKER
 int
 pcmk_fence_installed(xmlNodePtr *xml, stonith_t *st, unsigned int timeout) {
     pcmk__output_t *out = NULL;
@@ -264,6 +269,7 @@ pcmk_fence_installed(xmlNodePtr *xml, stonith_t *st, unsigned int timeout) {
     pcmk__out_epilogue(out, xml, rc);
     return rc;
 }
+#endif
 
 int
 pcmk__fence_last(pcmk__output_t *out, const char *target, bool as_nodeid) {
@@ -283,6 +289,7 @@ pcmk__fence_last(pcmk__output_t *out, const char *target, bool as_nodeid) {
     return pcmk_rc_ok;
 }
 
+#ifdef BUILD_PUBLIC_LIBPACEMAKER
 int
 pcmk_fence_last(xmlNodePtr *xml, const char *target, bool as_nodeid) {
     pcmk__output_t *out = NULL;
@@ -297,6 +304,7 @@ pcmk_fence_last(xmlNodePtr *xml, const char *target, bool as_nodeid) {
     pcmk__out_epilogue(out, xml, rc);
     return rc;
 }
+#endif
 
 int
 pcmk__fence_list_targets(pcmk__output_t *out, stonith_t *st, char *agent,
@@ -323,6 +331,7 @@ pcmk__fence_list_targets(pcmk__output_t *out, stonith_t *st, char *agent,
     return rc;
 }
 
+#ifdef BUILD_PUBLIC_LIBPACEMAKER
 int
 pcmk_fence_list_targets(xmlNodePtr *xml, stonith_t *st, char *agent,
                         unsigned int timeout) {
@@ -338,6 +347,7 @@ pcmk_fence_list_targets(xmlNodePtr *xml, stonith_t *st, char *agent,
     pcmk__out_epilogue(out, xml, rc);
     return rc;
 }
+#endif
 
 int
 pcmk__fence_metadata(pcmk__output_t *out, stonith_t *st, char *agent,
@@ -355,6 +365,7 @@ pcmk__fence_metadata(pcmk__output_t *out, stonith_t *st, char *agent,
     return rc;
 }
 
+#ifdef BUILD_PUBLIC_LIBPACEMAKER
 int
 pcmk_fence_metadata(xmlNodePtr *xml, stonith_t *st, char *agent,
                     unsigned int timeout) {
@@ -370,6 +381,7 @@ pcmk_fence_metadata(xmlNodePtr *xml, stonith_t *st, char *agent,
     pcmk__out_epilogue(out, xml, rc);
     return rc;
 }
+#endif
 
 int
 pcmk__fence_registered(pcmk__output_t *out, stonith_t *st, char *target,
@@ -392,6 +404,7 @@ pcmk__fence_registered(pcmk__output_t *out, stonith_t *st, char *target,
     return rc;
 }
 
+#ifdef BUILD_PUBLIC_LIBPACEMAKER
 int
 pcmk_fence_registered(xmlNodePtr *xml, stonith_t *st, char *target,
                       unsigned int timeout) {
@@ -407,6 +420,7 @@ pcmk_fence_registered(xmlNodePtr *xml, stonith_t *st, char *target,
     pcmk__out_epilogue(out, xml, rc);
     return rc;
 }
+#endif
 
 int
 pcmk__fence_register_level(stonith_t *st, char *target, int fence_level,
@@ -414,21 +428,25 @@ pcmk__fence_register_level(stonith_t *st, char *target, int fence_level,
     return handle_level(st, target, fence_level, devices, true);
 }
 
+#ifdef BUILD_PUBLIC_LIBPACEMAKER
 int
 pcmk_fence_register_level(stonith_t *st, char *target, int fence_level,
                             stonith_key_value_t *devices) {
     return pcmk__fence_register_level(st, target, fence_level, devices);
 }
+#endif
 
 int
 pcmk__fence_unregister_level(stonith_t *st, char *target, int fence_level) {
     return handle_level(st, target, fence_level, NULL, false);
 }
 
+#ifdef BUILD_PUBLIC_LIBPACEMAKER
 int
 pcmk_fence_unregister_level(stonith_t *st, char *target, int fence_level) {
     return pcmk__fence_unregister_level(st, target, fence_level);
 }
+#endif
 
 int
 pcmk__fence_validate(pcmk__output_t *out, stonith_t *st, const char *agent,
@@ -444,6 +462,7 @@ pcmk__fence_validate(pcmk__output_t *out, stonith_t *st, const char *agent,
     return pcmk_legacy2rc(rc);
 }
 
+#ifdef BUILD_PUBLIC_LIBPACEMAKER
 int
 pcmk_fence_validate(xmlNodePtr *xml, stonith_t *st, const char *agent,
                     const char *id, stonith_key_value_t *params,
@@ -460,3 +479,4 @@ pcmk_fence_validate(xmlNodePtr *xml, stonith_t *st, const char *agent,
     pcmk__out_epilogue(out, xml, rc);
     return rc;
 }
+#endif

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -1,0 +1,449 @@
+/*
+ * Copyright 2009-2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+#include <crm/common/mainloop.h>
+#include <crm/common/output.h>
+#include <crm/stonith-ng.h>
+#include <crm/fencing/internal.h>
+#include <glib.h>
+#include <libxml/tree.h>
+#include <pacemaker.h>
+#include <pcmki/pcmki_output.h>
+#include <pcmki/pcmki_fence.h>
+
+static int st_opts = st_opt_sync_call | st_opt_allow_suicide;
+
+static GMainLoop *mainloop = NULL;
+
+static struct {
+    stonith_t *st;
+    const char *target;
+    const char *action;
+    char *name;
+    int timeout;
+    int tolerance;
+    int rc;
+} async_fence_data;
+
+static int
+handle_level(stonith_t *st, char *target, int fence_level,
+             stonith_key_value_t *devices, bool added) {
+    char *node = NULL;
+    char *pattern = NULL;
+    char *name = NULL;
+    char *value = NULL;
+
+    if (target == NULL) {
+        // Not really possible, but makes static analysis happy
+        return -EINVAL;
+    }
+
+    /* Determine if targeting by attribute, node name pattern or node name */
+    value = strchr(target, '=');
+    if (value != NULL)  {
+        name = target;
+        *value++ = '\0';
+    } else if (*target == '@') {
+        pattern = target + 1;
+    } else {
+        node = target;
+    }
+
+    /* Register or unregister level as appropriate */
+    if (added) {
+        return st->cmds->register_level_full(st, st_opts, node, pattern,
+                                             name, value, fence_level,
+                                             devices);
+    }
+
+    return st->cmds->remove_level_full(st, st_opts, node, pattern,
+                                       name, value, fence_level);
+}
+
+static void
+notify_callback(stonith_t * st, stonith_event_t * e)
+{
+    if (e->result != pcmk_ok) {
+        return;
+    }
+
+    if (safe_str_eq(async_fence_data.target, e->target) &&
+        safe_str_eq(async_fence_data.action, e->action)) {
+
+        async_fence_data.rc = e->result;
+        g_main_loop_quit(mainloop);
+    }
+}
+
+static void
+fence_callback(stonith_t * stonith, stonith_callback_data_t * data)
+{
+    async_fence_data.rc = data->rc;
+
+    g_main_loop_quit(mainloop);
+}
+
+static gboolean
+async_fence_helper(gpointer user_data)
+{
+    stonith_t *st = async_fence_data.st;
+    int call_id = 0;
+    int rc = stonith_api_connect_retry(st, async_fence_data.name, 10);
+
+    if (rc != pcmk_ok) {
+        fprintf(stderr, "Could not connect to fencer: %s\n", pcmk_strerror(rc));
+        g_main_loop_quit(mainloop);
+        return TRUE;
+    }
+
+    st->cmds->register_notification(st, T_STONITH_NOTIFY_FENCE, notify_callback);
+
+    call_id = st->cmds->fence(st,
+                              st_opt_allow_suicide,
+                              async_fence_data.target,
+                              async_fence_data.action,
+                              async_fence_data.timeout, async_fence_data.tolerance);
+
+    if (call_id < 0) {
+        g_main_loop_quit(mainloop);
+        return TRUE;
+    }
+
+    st->cmds->register_callback(st,
+                                call_id,
+                                async_fence_data.timeout,
+                                st_opt_timeout_updates, NULL, "callback", fence_callback);
+
+    return TRUE;
+}
+
+int
+pcmk__fence_action(stonith_t *st, const char *target, const char *action,
+                   const char *name, int timeout, int tolerance)
+{
+    crm_trigger_t *trig;
+
+    async_fence_data.st = st;
+    async_fence_data.name = strdup(name);
+    async_fence_data.target = target;
+    async_fence_data.action = action;
+    async_fence_data.timeout = timeout;
+    async_fence_data.tolerance = tolerance;
+    async_fence_data.rc = -1;
+
+    trig = mainloop_add_trigger(G_PRIORITY_HIGH, async_fence_helper, NULL);
+    mainloop_set_trigger(trig);
+
+    mainloop = g_main_loop_new(NULL, FALSE);
+    g_main_loop_run(mainloop);
+
+    free(async_fence_data.name);
+
+    return async_fence_data.rc;
+}
+
+int
+pcmk_fence_action(stonith_t *st, const char *target, const char *action,
+                  const char *name, int timeout, int tolerance) {
+    return pcmk__fence_action(st, target, action, name, timeout, tolerance);
+}
+
+int
+pcmk__fence_history(pcmk__output_t *out, stonith_t *st, char *target,
+                    int timeout, bool quiet, int verbose, bool broadcast,
+                    bool cleanup) {
+    stonith_history_t *history = NULL, *hp, *latest = NULL;
+    int rc = 0;
+
+    if (!quiet) {
+        if (cleanup) {
+            out->info(out, "cleaning up fencing-history%s%s",
+                      target ? " for node " : "", target ? target : "");
+        }
+        if (broadcast) {
+            out->info(out, "gather fencing-history from all nodes");
+        }
+    }
+
+    rc = st->cmds->history(st, st_opts | (cleanup ? st_opt_cleanup : 0) |
+                           broadcast ? st_opt_broadcast : 0,
+                           safe_str_eq(target, "*") ? NULL : target,
+                           &history, timeout);
+
+    out->begin_list(out, "event", "events", "Fencing history");
+
+    history = stonith__sort_history(history);
+    for (hp = history; hp; hp = hp->next) {
+        if (hp->state == st_done) {
+            latest = hp;
+        }
+
+        if (quiet || !verbose) {
+            continue;
+        }
+
+        out->message(out, "stonith-event", hp, 1, stonith__later_succeeded(hp, history));
+        out->increment_list(out);
+    }
+
+    if (latest) {
+        if (quiet && out->supports_quiet) {
+            out->info(out, "%lld", (long long) latest->completed);
+        } else if (!verbose) { // already printed if verbose
+            out->message(out, "stonith-event", latest, 0, FALSE);
+            out->increment_list(out);
+        }
+    }
+
+    out->end_list(out);
+
+    stonith_history_free(history);
+    return rc;
+}
+
+int
+pcmk_fence_history(xmlNodePtr *xml, stonith_t *st, char *target, int timeout,
+                   bool quiet, int verbose, bool broadcast, bool cleanup) {
+    pcmk__output_t *out = NULL;
+    int rc = 0;
+
+    rc = pcmk__out_prologue(&out, xml);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = pcmk__fence_history(out, st, target, timeout, quiet, verbose,
+                             broadcast, cleanup);
+    pcmk__out_epilogue(out, xml, rc);
+    return rc;
+}
+
+int
+pcmk__fence_installed(pcmk__output_t *out, stonith_t *st, int timeout) {
+    stonith_key_value_t *devices = NULL;
+    int rc;
+
+    rc = st->cmds->list_agents(st, st_opt_sync_call, NULL, &devices, timeout);
+    if (rc < 0) {
+        return rc;
+    }
+
+    out->begin_list(out, "fence device", "fence devices", "Installed fence devices");
+    for (stonith_key_value_t *dIter = devices; dIter; dIter = dIter->next) {
+        out->list_item(out, "device", "%s", dIter->value);
+    }
+    out->end_list(out);
+
+    stonith_key_value_freeall(devices, 1, 1);
+    return 0;
+}
+
+int
+pcmk_fence_installed(xmlNodePtr *xml, stonith_t *st, int timeout) {
+    pcmk__output_t *out = NULL;
+    int rc = 0;
+
+    rc = pcmk__out_prologue(&out, xml);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = pcmk__fence_installed(out, st, timeout);
+    pcmk__out_epilogue(out, xml, rc);
+    return rc;
+}
+
+int
+pcmk__fence_last(pcmk__output_t *out, const char *target, bool as_nodeid) {
+    time_t when = 0;
+
+    if (target == NULL) {
+        return 0;
+    }
+
+    if (as_nodeid) {
+        when = stonith_api_time(atol(target), NULL, FALSE);
+    } else {
+        when = stonith_api_time(0, target, FALSE);
+    }
+
+    out->message(out, "last-fenced", target, when);
+    return 0;
+}
+
+int
+pcmk_fence_last(xmlNodePtr *xml, const char *target, bool as_nodeid) {
+    pcmk__output_t *out = NULL;
+    int rc = 0;
+
+    rc = pcmk__out_prologue(&out, xml);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = pcmk__fence_last(out, target, as_nodeid);
+    pcmk__out_epilogue(out, xml, rc);
+    return rc;
+}
+
+int
+pcmk__fence_list_targets(pcmk__output_t *out, stonith_t *st, char *agent, int timeout) {
+    GList *targets = NULL;
+    char *lists = NULL;
+    int rc = 0;
+
+    rc = st->cmds->list(st, st_opts, agent, &lists, timeout);
+    if (rc != 0) {
+        return rc;
+    }
+
+    targets = stonith__parse_targets(lists);
+
+    out->begin_list(out, "fence target", "fence targets", "Fence Targets");
+    while (targets != NULL) {
+        out->list_item(out, NULL, "%s", (const char *) targets->data);
+        targets = targets->next;
+    }
+    out->end_list(out);
+
+    free(lists);
+    return 0;
+}
+
+int
+pcmk_fence_list_targets(xmlNodePtr *xml, stonith_t *st, char *agent, int timeout) {
+    pcmk__output_t *out = NULL;
+    int rc = 0;
+
+    rc = pcmk__out_prologue(&out, xml);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = pcmk__fence_list_targets(out, st, agent, timeout);
+    pcmk__out_epilogue(out, xml, rc);
+    return rc;
+}
+
+int
+pcmk__fence_metadata(pcmk__output_t *out, stonith_t *st, char *agent, int timeout) {
+    char *buffer = NULL;
+    int rc = st->cmds->metadata(st, st_opt_sync_call, agent, NULL, &buffer,
+                                timeout);
+
+    if (rc != pcmk_ok) {
+        return rc;
+    }
+
+    out->output_xml(out, "metadata", buffer);
+    free(buffer);
+    return rc;
+}
+
+int
+pcmk_fence_metadata(xmlNodePtr *xml, stonith_t *st, char *agent, int timeout) {
+    pcmk__output_t *out = NULL;
+    int rc = 0;
+
+    rc = pcmk__out_prologue(&out, xml);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = pcmk__fence_metadata(out, st, agent, timeout);
+    pcmk__out_epilogue(out, xml, rc);
+    return rc;
+}
+
+int
+pcmk__fence_registered(pcmk__output_t *out, stonith_t *st, char *target, int timeout) {
+    stonith_key_value_t *devices = NULL;
+    int rc;
+
+    rc = st->cmds->query(st, st_opts, target, &devices, timeout);
+    if (rc < 0) {
+        return rc;
+    }
+
+    out->begin_list(out, "fence device", "fence devices", "Registered fence devices");
+    for (stonith_key_value_t *dIter = devices; dIter; dIter = dIter->next) {
+        out->list_item(out, "device", "%s", dIter->value);
+    }
+    out->end_list(out);
+
+    stonith_key_value_freeall(devices, 1, 1);
+    return 0;
+}
+
+int
+pcmk_fence_registered(xmlNodePtr *xml, stonith_t *st, char *target, int timeout) {
+    pcmk__output_t *out = NULL;
+    int rc = 0;
+
+    rc = pcmk__out_prologue(&out, xml);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = pcmk__fence_registered(out, st, target, timeout);
+    pcmk__out_epilogue(out, xml, rc);
+    return rc;
+}
+
+int
+pcmk__fence_register_level(stonith_t *st, char *target, int fence_level,
+                           stonith_key_value_t *devices) {
+    return handle_level(st, target, fence_level, devices, true);
+}
+
+int
+pcmk_fence_register_level(stonith_t *st, char *target, int fence_level,
+                            stonith_key_value_t *devices) {
+    return pcmk__fence_register_level(st, target, fence_level, devices);
+}
+
+int
+pcmk__fence_unregister_level(stonith_t *st, char *target, int fence_level) {
+    return handle_level(st, target, fence_level, NULL, false);
+}
+
+int
+pcmk_fence_unregister_level(stonith_t *st, char *target, int fence_level) {
+    return pcmk__fence_unregister_level(st, target, fence_level);
+}
+
+int
+pcmk__fence_validate(pcmk__output_t *out, stonith_t *st, const char *agent,
+                     const char *id, stonith_key_value_t *params, int timeout) {
+    char *output = NULL;
+    char *error_output = NULL;
+    int rc;
+
+    rc  = st->cmds->validate(st, st_opt_sync_call, id, NULL, agent, params,
+                             timeout, &output, &error_output);
+    out->message(out, "validate", agent, id, output, error_output, rc);
+    return rc;
+}
+
+int
+pcmk_fence_validate(xmlNodePtr *xml, stonith_t *st, const char *agent,
+                    const char *id, stonith_key_value_t *params, int timeout) {
+    pcmk__output_t *out = NULL;
+    int rc = 0;
+
+    rc = pcmk__out_prologue(&out, xml);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = pcmk__fence_validate(out, st, agent, id, params, timeout);
+    pcmk__out_epilogue(out, xml, rc);
+    return rc;
+}

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+#include <crm/common/output.h>
+#include <crm/stonith-ng.h>
+#include <crm/fencing/internal.h>
+#include <libxml/tree.h>
+#include <pcmki/pcmki_output.h>
+
+pcmk__supported_format_t pcmk__out_formats[] = {
+    PCMK__SUPPORTED_FORMAT_XML,
+    { NULL, NULL, NULL }
+};
+
+int
+pcmk__out_prologue(pcmk__output_t **out, xmlNodePtr *xml) {
+    int rc = 0;
+
+    if (*xml != NULL) {
+        xmlFreeNode(*xml);
+    }
+
+    pcmk__register_formats(NULL, pcmk__out_formats);
+    rc = pcmk__output_new(out, "xml", NULL, NULL);
+    if (rc != 0) {
+        return rc;
+    }
+
+    stonith__register_messages(*out);
+    return rc;
+}
+
+void
+pcmk__out_epilogue(pcmk__output_t *out, xmlNodePtr *xml, int retval) {
+    if (retval == 0) {
+        out->finish(out, 0, FALSE, (void **) xml);
+    }
+
+    pcmk__output_free(out);
+}

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the Pacemaker project contributors
+ * Copyright 2019-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,6 +9,7 @@
 
 #include <crm_internal.h>
 #include <crm/common/output.h>
+#include <crm/common/results.h>
 #include <crm/stonith-ng.h>
 #include <crm/fencing/internal.h>
 #include <libxml/tree.h>
@@ -21,7 +22,7 @@ pcmk__supported_format_t pcmk__out_formats[] = {
 
 int
 pcmk__out_prologue(pcmk__output_t **out, xmlNodePtr *xml) {
-    int rc = 0;
+    int rc = pcmk_rc_ok;
 
     if (*xml != NULL) {
         xmlFreeNode(*xml);
@@ -29,7 +30,7 @@ pcmk__out_prologue(pcmk__output_t **out, xmlNodePtr *xml) {
 
     pcmk__register_formats(NULL, pcmk__out_formats);
     rc = pcmk__output_new(out, "xml", NULL, NULL);
-    if (rc != 0) {
+    if (rc != pcmk_rc_ok) {
         return rc;
     }
 
@@ -39,7 +40,7 @@ pcmk__out_prologue(pcmk__output_t **out, xmlNodePtr *xml) {
 
 void
 pcmk__out_epilogue(pcmk__output_t *out, xmlNodePtr *xml, int retval) {
-    if (retval == 0) {
+    if (retval == pcmk_rc_ok) {
         out->finish(out, 0, FALSE, (void **) xml);
     }
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -140,10 +140,11 @@ crm_ticket_LDADD	= $(top_builddir)/lib/pengine/libpe_rules.la	\
 			  $(top_builddir)/lib/common/libcrmcommon.la
 
 stonith_admin_SOURCES	= stonith_admin.c
-stonith_admin_LDADD	= $(top_builddir)/lib/common/libcrmcommon.la	\
+stonith_admin_LDADD	= $(top_builddir)/lib/pacemaker/libpacemaker.la	\
 			  $(top_builddir)/lib/cib/libcib.la		\
 			  $(top_builddir)/lib/pengine/libpe_status.la	\
-			  $(top_builddir)/lib/fencing/libstonithd.la
+			  $(top_builddir)/lib/fencing/libstonithd.la \
+			  $(top_builddir)/lib/common/libcrmcommon.la
 
 if BUILD_SERVICELOG
 notifyServicelogEvent_SOURCES	= notifyServicelogEvent.c

--- a/tools/crm_diff.c
+++ b/tools/crm_diff.c
@@ -314,7 +314,7 @@ main(int argc, char **argv)
 
     crm_log_cli_init("crm_diff");
 
-    processed_args = pcmk__cmdline_preproc(argc, argv, "nopNO");
+    processed_args = pcmk__cmdline_preproc(argv, "nopNO");
 
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
         fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);

--- a/tools/crm_diff.c
+++ b/tools/crm_diff.c
@@ -385,6 +385,7 @@ main(int argc, char **argv)
     }
 
 done:
+    g_clear_error(&error);
     pcmk__free_arg_context(context);
     free(options.xml_file_1);
     free(options.xml_file_2);

--- a/tools/crm_diff.c
+++ b/tools/crm_diff.c
@@ -385,6 +385,7 @@ main(int argc, char **argv)
     }
 
 done:
+    g_strfreev(processed_args);
     g_clear_error(&error);
     pcmk__free_arg_context(context);
     free(options.xml_file_1);

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -72,6 +72,7 @@ static cib_t *cib = NULL;
 static stonith_t *st = NULL;
 static xmlNode *current_cib = NULL;
 
+static GError *error = NULL;
 static pcmk__common_args_t *args = NULL;
 static pcmk__output_t *out = NULL;
 static GOptionContext *context = NULL;
@@ -128,7 +129,7 @@ static void mon_st_callback_display(stonith_t * st, stonith_event_t * e);
 static void kick_refresh(gboolean data_updated);
 
 static gboolean
-as_cgi_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+as_cgi_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     if (args->output_ty != NULL) {
         free(args->output_ty);
     }
@@ -140,7 +141,7 @@ as_cgi_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError *
 }
 
 static gboolean
-as_html_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+as_html_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     if (args->output_ty != NULL) {
         free(args->output_ty);
     }
@@ -160,7 +161,7 @@ as_html_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError 
 }
 
 static gboolean
-as_simple_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+as_simple_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     if (args->output_ty != NULL) {
         free(args->output_ty);
     }
@@ -172,7 +173,7 @@ as_simple_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErro
 }
 
 static gboolean
-as_xml_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+as_xml_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     if (args->output_ty != NULL) {
         free(args->output_ty);
     }
@@ -184,11 +185,11 @@ as_xml_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError *
 }
 
 static gboolean
-fence_history_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+fence_history_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     int rc = crm_atoi(optarg, "2");
 
     if (rc == -1 || rc > 3) {
-        g_set_error(error, G_OPTION_ERROR, CRM_EX_INVALID_PARAM, "Fence history must be 0-3");
+        g_set_error(err, G_OPTION_ERROR, CRM_EX_INVALID_PARAM, "Fence history must be 0-3");
         return FALSE;
     } else {
         options.fence_history_level = rc;
@@ -198,66 +199,66 @@ fence_history_cb(const gchar *option_name, const gchar *optarg, gpointer data, G
 }
 
 static gboolean
-group_by_node_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+group_by_node_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     options.mon_ops |= mon_op_group_by_node;
     return TRUE;
 }
 
 static gboolean
-hide_headers_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+hide_headers_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     show &= ~mon_show_headers;
     return TRUE;
 }
 
 static gboolean
-inactive_resources_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+inactive_resources_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     options.mon_ops |= mon_op_inactive_resources;
     return TRUE;
 }
 
 static gboolean
-no_curses_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+no_curses_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     output_format = mon_output_plain;
     return TRUE;
 }
 
 static gboolean
-one_shot_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+one_shot_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     options.mon_ops |= mon_op_one_shot;
     return TRUE;
 }
 
 static gboolean
-print_brief_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+print_brief_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     options.mon_ops |= mon_op_print_brief;
     return TRUE;
 }
 
 static gboolean
-print_clone_detail_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+print_clone_detail_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     options.mon_ops |= mon_op_print_clone_detail;
     return TRUE;
 }
 
 static gboolean
-print_pending_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+print_pending_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     options.mon_ops |= mon_op_print_pending;
     return TRUE;
 }
 
 static gboolean
-print_timing_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+print_timing_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     options.mon_ops |= mon_op_print_timing;
     show |= mon_show_operations;
     return TRUE;
 }
 
 static gboolean
-reconnect_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+reconnect_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     int rc = crm_get_msec(optarg);
 
     if (rc == -1) {
-        g_set_error(error, G_OPTION_ERROR, CRM_EX_INVALID_PARAM, "Invalid value for -i: %s", optarg);
+        g_set_error(err, G_OPTION_ERROR, CRM_EX_INVALID_PARAM, "Invalid value for -i: %s", optarg);
         return FALSE;
     } else {
         options.reconnect_msec = crm_parse_interval_spec(optarg);
@@ -267,13 +268,13 @@ reconnect_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErro
 }
 
 static gboolean
-show_attributes_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+show_attributes_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     show |= mon_show_attributes;
     return TRUE;
 }
 
 static gboolean
-show_bans_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+show_bans_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     show |= mon_show_bans;
 
     if (optarg != NULL) {
@@ -284,32 +285,32 @@ show_bans_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErro
 }
 
 static gboolean
-show_failcounts_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+show_failcounts_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     show |= mon_show_failcounts;
     return TRUE;
 }
 
 static gboolean
-show_operations_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+show_operations_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     show |= mon_show_operations;
     return TRUE;
 }
 
 static gboolean
-show_tickets_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+show_tickets_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     show |= mon_show_tickets;
     return TRUE;
 }
 
 static gboolean
-use_cib_file_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+use_cib_file_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     setenv("CIB_file", optarg, 1);
     options.mon_ops |= mon_op_one_shot;
     return TRUE;
 }
 
 static gboolean
-watch_fencing_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+watch_fencing_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     options.mon_ops |= mon_op_watch_fencing;
     return TRUE;
 }
@@ -803,33 +804,38 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
  */
 static void
 add_output_args() {
-    GError *error = NULL;
+    GError *err = NULL;
 
     if (output_format == mon_output_plain) {
-        if (!pcmk__force_args(context, &error, "%s --text-fancy", g_get_prgname())) {
-            fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
+        if (!pcmk__force_args(context, &err, "%s --text-fancy", g_get_prgname())) {
+            fprintf(stderr, "%s: %s\n", g_get_prgname(), err->message);
+            g_clear_error(&err);
             clean_up(CRM_EX_USAGE);
         }
     } else if (output_format == mon_output_html) {
-        if (!pcmk__force_args(context, &error, "%s --html-title \"Cluster Status\"",
+        if (!pcmk__force_args(context, &err, "%s --html-title \"Cluster Status\"",
                               g_get_prgname())) {
-            fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
+            fprintf(stderr, "%s: %s\n", g_get_prgname(), err->message);
+            g_clear_error(&err);
             clean_up(CRM_EX_USAGE);
         }
     } else if (output_format == mon_output_cgi) {
-        if (!pcmk__force_args(context, &error, "%s --html-cgi --html-title \"Cluster Status\"", g_get_prgname())) {
-            fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
+        if (!pcmk__force_args(context, &err, "%s --html-cgi --html-title \"Cluster Status\"", g_get_prgname())) {
+            fprintf(stderr, "%s: %s\n", g_get_prgname(), err->message);
+            g_clear_error(&err);
             clean_up(CRM_EX_USAGE);
         }
     } else if (output_format == mon_output_xml) {
-        if (!pcmk__force_args(context, &error, "%s --xml-simple-list", g_get_prgname())) {
-            fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
+        if (!pcmk__force_args(context, &err, "%s --xml-simple-list", g_get_prgname())) {
+            fprintf(stderr, "%s: %s\n", g_get_prgname(), err->message);
+            g_clear_error(&err);
             clean_up(CRM_EX_USAGE);
         }
     } else if (output_format == mon_output_legacy_xml) {
         output_format = mon_output_xml;
-        if (!pcmk__force_args(context, &error, "%s --xml-legacy", g_get_prgname())) {
-            fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
+        if (!pcmk__force_args(context, &err, "%s --xml-legacy", g_get_prgname())) {
+            fprintf(stderr, "%s: %s\n", g_get_prgname(), err->message);
+            g_clear_error(&err);
             clean_up(CRM_EX_USAGE);
         }
     }
@@ -846,7 +852,7 @@ add_output_args() {
 static void
 reconcile_output_format(pcmk__common_args_t *args) {
     gboolean retval = TRUE;
-    GError *error = NULL;
+    GError *err = NULL;
 
     if (output_format != mon_output_unset) {
         return;
@@ -859,10 +865,10 @@ reconcile_output_format(pcmk__common_args_t *args) {
             dest = strdup(args->output_dest);
         }
 
-        retval = as_html_cb("h", dest, NULL, &error);
+        retval = as_html_cb("h", dest, NULL, &err);
         free(dest);
     } else if (safe_str_eq(args->output_ty, "text")) {
-        retval = no_curses_cb("N", NULL, NULL, &error);
+        retval = no_curses_cb("N", NULL, NULL, &err);
     } else if (safe_str_eq(args->output_ty, "xml")) {
         if (args->output_ty != NULL) {
             free(args->output_ty);
@@ -889,7 +895,8 @@ reconcile_output_format(pcmk__common_args_t *args) {
     }
 
     if (!retval) {
-        fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
+        fprintf(stderr, "%s: %s\n", g_get_prgname(), err->message);
+        g_clear_error(&err);
         clean_up(CRM_EX_USAGE);
     }
 }
@@ -900,8 +907,6 @@ main(int argc, char **argv)
     int rc = pcmk_ok;
     char **processed_args = NULL;
     GOptionGroup *output_group = NULL;
-
-    GError *error = NULL;
 
     args = pcmk__new_common_args(SUMMARY);
     context = build_arg_context(args, &output_group);
@@ -1890,6 +1895,8 @@ clean_up(crm_exit_t exit_code)
     }
 
     pcmk__free_arg_context(context);
+
+    g_clear_error(&error);
 
     if (out != NULL) {
         if (output_format == mon_output_cgi || output_format == mon_output_html) {

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -76,6 +76,7 @@ static GError *error = NULL;
 static pcmk__common_args_t *args = NULL;
 static pcmk__output_t *out = NULL;
 static GOptionContext *context = NULL;
+static gchar **processed_args = NULL;
 
 /* FIXME allow, detect, and correctly interpret glob pattern or regex? */
 const char *print_neg_location_prefix = "";
@@ -905,7 +906,6 @@ int
 main(int argc, char **argv)
 {
     int rc = pcmk_ok;
-    char **processed_args = NULL;
     GOptionGroup *output_group = NULL;
 
     args = pcmk__new_common_args(SUMMARY);
@@ -1908,5 +1908,6 @@ clean_up(crm_exit_t exit_code)
         pcmk__output_free(out);
     }
 
+    g_strfreev(processed_args);
     crm_exit(exit_code);
 }

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -918,7 +918,7 @@ main(int argc, char **argv)
         options.mon_ops |= mon_op_one_shot;
     }
 
-    processed_args = pcmk__cmdline_preproc(argc, argv, "ehimpxEL");
+    processed_args = pcmk__cmdline_preproc(argv, "ehimpxEL");
 
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
         fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -224,7 +224,7 @@ crm_mon_mk_curses_output(char **argv) {
     }
 
     retval->fmt_name = "console";
-    retval->request = g_strjoinv(" ", argv);
+    retval->request = argv == NULL ? NULL : g_strjoinv(" ", argv);
     retval->supports_quiet = true;
 
     retval->init = curses_init;

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -605,7 +605,7 @@ main(int argc, char **argv)
 
     crm_log_cli_init("crm_node");
 
-    processed_args = pcmk__cmdline_preproc(argc, argv, "NR");
+    processed_args = pcmk__cmdline_preproc(argv, "NR");
 
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
         fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -658,6 +658,7 @@ main(int argc, char **argv)
 
 done:
     g_strfreev(processed_args);
+    g_clear_error(&error);
     pcmk__free_arg_context(context);
     crm_node_exit(exit_code);
     return exit_code;

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -834,6 +834,7 @@ main(int argc, char **argv)
 
   done:
     g_strfreev(processed_args);
+    g_clear_error(&error);
     pcmk__free_arg_context(context);
 
     if (out != NULL) {

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -583,7 +583,7 @@ main(int argc, char **argv)
 
     async_fence_data.name = strdup(crm_system_name);
 
-    processed_args = pcmk__cmdline_preproc(argc, argv, "adehilorstvBCDFHQRTU");
+    processed_args = pcmk__cmdline_preproc(argv, "adehilorstvBCDFHQRTU");
 
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
         fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -27,7 +27,6 @@
 #include <crm/common/ipc.h>
 #include <crm/cluster/internal.h>
 #include <crm/common/cmdline_internal.h>
-#include <crm/common/mainloop.h>
 #include <crm/common/output.h>
 
 #include <crm/stonith-ng.h>
@@ -36,6 +35,7 @@
 #include <crm/pengine/status.h>
 
 #include <crm/common/xml.h>
+#include <pacemaker-internal.h>
 
 #define SUMMARY "stonith_admin - Access the Pacemaker fencing API"
 
@@ -228,16 +228,7 @@ static pcmk__supported_format_t formats[] = {
 
 static int st_opts = st_opt_sync_call | st_opt_allow_suicide;
 
-static GMainLoop *mainloop = NULL;
-struct {
-    stonith_t *st;
-    const char *target;
-    const char *action;
-    char *name;
-    int timeout;
-    int tolerance;
-    int rc;
-} async_fence_data;
+static char *name = NULL;
 
 gboolean
 add_env_params(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
@@ -297,230 +288,9 @@ add_stonith_params(const gchar *option_name, const gchar *optarg, gpointer data,
 
 gboolean
 set_tag(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
-    free(async_fence_data.name);
-    async_fence_data.name = crm_strdup_printf("%s.%s", crm_system_name, optarg);
+    free(name);
+    name = crm_strdup_printf("%s.%s", crm_system_name, optarg);
     return TRUE;
-}
-
-static void
-notify_callback(stonith_t * st, stonith_event_t * e)
-{
-    if (e->result != pcmk_ok) {
-        return;
-    }
-
-    if (safe_str_eq(async_fence_data.target, e->target) &&
-        safe_str_eq(async_fence_data.action, e->action)) {
-
-        async_fence_data.rc = e->result;
-        g_main_loop_quit(mainloop);
-    }
-}
-
-static void
-fence_callback(stonith_t * stonith, stonith_callback_data_t * data)
-{
-    async_fence_data.rc = data->rc;
-
-    g_main_loop_quit(mainloop);
-}
-
-static gboolean
-async_fence_helper(gpointer user_data)
-{
-    stonith_t *st = async_fence_data.st;
-    int call_id = 0;
-    int rc = stonith_api_connect_retry(st, async_fence_data.name, 10);
-
-    if (rc != pcmk_ok) {
-        fprintf(stderr, "Could not connect to fencer: %s\n", pcmk_strerror(rc));
-        g_main_loop_quit(mainloop);
-        return TRUE;
-    }
-
-    st->cmds->register_notification(st, T_STONITH_NOTIFY_FENCE, notify_callback);
-
-    call_id = st->cmds->fence(st,
-                              st_opt_allow_suicide,
-                              async_fence_data.target,
-                              async_fence_data.action,
-                              async_fence_data.timeout, async_fence_data.tolerance);
-
-    if (call_id < 0) {
-        g_main_loop_quit(mainloop);
-        return TRUE;
-    }
-
-    st->cmds->register_callback(st,
-                                call_id,
-                                async_fence_data.timeout,
-                                st_opt_timeout_updates, NULL, "callback", fence_callback);
-
-    return TRUE;
-}
-
-static int
-mainloop_fencing(stonith_t * st, const char *target, const char *action, int timeout, int tolerance)
-{
-    crm_trigger_t *trig;
-
-    async_fence_data.st = st;
-    async_fence_data.target = target;
-    async_fence_data.action = action;
-    async_fence_data.timeout = timeout;
-    async_fence_data.tolerance = tolerance;
-    async_fence_data.rc = -1;
-
-    trig = mainloop_add_trigger(G_PRIORITY_HIGH, async_fence_helper, NULL);
-    mainloop_set_trigger(trig);
-
-    mainloop = g_main_loop_new(NULL, FALSE);
-    g_main_loop_run(mainloop);
-
-    return async_fence_data.rc;
-}
-
-static int
-handle_level(stonith_t *st, char *target, int fence_level,
-             stonith_key_value_t *devices, bool added)
-{
-    char *node = NULL;
-    char *pattern = NULL;
-    char *name = NULL;
-    char *value = NULL;
-
-    if (target == NULL) {
-        // Not really possible, but makes static analysis happy
-        return -EINVAL;
-    }
-
-    /* Determine if targeting by attribute, node name pattern or node name */
-    value = strchr(target, '=');
-    if (value != NULL)  {
-        name = target;
-        *value++ = '\0';
-    } else if (*target == '@') {
-        pattern = target + 1;
-    } else {
-        node = target;
-    }
-
-    /* Register or unregister level as appropriate */
-    if (added) {
-        return st->cmds->register_level_full(st, st_opts, node, pattern,
-                                             name, value, fence_level,
-                                             devices);
-    }
-    return st->cmds->remove_level_full(st, st_opts, node, pattern,
-                                       name, value, fence_level);
-}
-
-static int
-handle_history(stonith_t *st, const char *target, int timeout, int quiet,
-             int verbose, int cleanup, int broadcast, pcmk__output_t *out)
-{
-    stonith_history_t *history = NULL, *hp, *latest = NULL;
-    int rc = 0;
-
-    if (!quiet) {
-        if (cleanup) {
-            out->info(out, "cleaning up fencing-history%s%s",
-                      target ? " for node " : "", target ? target : "");
-        }
-        if (broadcast) {
-            out->info(out, "gather fencing-history from all nodes");
-        }
-    }
-
-    rc = st->cmds->history(st, st_opts | (cleanup?st_opt_cleanup:0) |
-                           (broadcast?st_opt_broadcast:0),
-                           (safe_str_eq(target, "*")? NULL : target),
-                           &history, timeout);
-
-    out->begin_list(out, "event", "events", "Fencing history");
-
-    history = stonith__sort_history(history);
-    for (hp = history; hp; hp = hp->next) {
-        if (hp->state == st_done) {
-            latest = hp;
-        }
-
-        if (quiet || !verbose) {
-            continue;
-        }
-
-        out->message(out, "stonith-event", hp, 1, stonith__later_succeeded(hp, history));
-        out->increment_list(out);
-    }
-
-    if (latest) {
-        if (quiet && out->supports_quiet) {
-            out->info(out, "%lld", (long long) latest->completed);
-        } else if (!verbose) { // already printed if verbose
-            out->message(out, "stonith-event", latest, 0, FALSE);
-            out->increment_list(out);
-        }
-    }
-
-    out->end_list(out);
-
-    stonith_history_free(history);
-    return rc;
-}
-
-static int
-validate(stonith_t *st, const char *agent, const char *id,
-         stonith_key_value_t *params, int timeout, int quiet,
-         pcmk__output_t *out)
-{
-    int rc = 1;
-    char *output = NULL;
-    char *error_output = NULL;
-
-    rc = st->cmds->validate(st, st_opt_sync_call, id, NULL, agent, params,
-                            timeout, &output, &error_output);
-
-    if (quiet) {
-        return rc;
-    }
-
-    out->message(out, "validate", agent, id, output, error_output, rc); 
-    return rc;
-}
-
-static void
-show_last_fenced(pcmk__output_t *out, const char *target)
-{
-    time_t when = 0;
-
-    if (target == NULL) {
-        // Not really possible, but makes static analysis happy
-        return;
-    }
-    if (options.as_nodeid) {
-        uint32_t nodeid = atol(target);
-        when = stonith_api_time(nodeid, NULL, FALSE);
-    } else {
-        when = stonith_api_time(0, target, FALSE);
-    }
-    out->message(out, "last-fenced", target, when);
-}
-
-static int
-show_metadata(pcmk__output_t *out, stonith_t *st, char *agent, int timeout)
-{
-    char *buffer = NULL;
-    int rc = st->cmds->metadata(st, st_opt_sync_call, agent, NULL, &buffer,
-                                timeout);
-
-    if (rc == pcmk_ok) {
-        out->output_xml(out, "metadata", buffer);
-    } else {
-        out->err(out, "Can't get fence agent meta-data: %s",
-                 pcmk_strerror(rc));
-    }
-    free(buffer);
-    return rc;
 }
 
 static GOptionContext *
@@ -561,12 +331,10 @@ main(int argc, char **argv)
     bool required_agent = false;
 
     char *target = NULL;
-    char *lists = NULL;
     const char *device = NULL;
 
     crm_exit_t exit_code = CRM_EX_OK;
     stonith_t *st = NULL;
-    stonith_key_value_t *dIter = NULL;
 
     pcmk__output_t *out = NULL;
     pcmk__common_args_t *args = pcmk__new_common_args(SUMMARY);
@@ -581,7 +349,7 @@ main(int argc, char **argv)
 
     crm_log_cli_init("stonith_admin");
 
-    async_fence_data.name = strdup(crm_system_name);
+    name = strdup(crm_system_name);
 
     processed_args = pcmk__cmdline_preproc(argv, "adehilorstvBCDFHQRTU");
 
@@ -720,7 +488,7 @@ main(int argc, char **argv)
     if (st == NULL) {
         rc = -ENOMEM;
     } else if (!no_connect) {
-        rc = st->cmds->connect(st, async_fence_data.name, NULL);
+        rc = st->cmds->connect(st, name, NULL);
     }
     if (rc < 0) {
         out->err(out, "Could not connect to fencer: %s", pcmk_strerror(rc));
@@ -730,39 +498,19 @@ main(int argc, char **argv)
 
     switch (action) {
         case 'I':
-            rc = st->cmds->list_agents(st, st_opt_sync_call, NULL, &options.devices, options.timeout);
+            rc = pcmk__fence_installed(out, st, options.timeout);
             if (rc < 0) {
                 out->err(out, "Failed to list installed devices: %s", pcmk_strerror(rc));
-                break;
             }
 
-            out->begin_list(out, "fence device", "fence devices", "Installed fence devices");
-            for (dIter = options.devices; dIter; dIter = dIter->next) {
-                out->list_item(out, "device", "%s", dIter->value);
-            }
-
-            out->end_list(out);
-            rc = 0;
-
-            stonith_key_value_freeall(options.devices, 1, 1);
             break;
 
         case 'L':
-            rc = st->cmds->query(st, st_opts, target, &options.devices, options.timeout);
+            rc = pcmk__fence_registered(out, st, target, options.timeout);
             if (rc < 0) {
                 out->err(out, "Failed to list registered devices: %s", pcmk_strerror(rc));
-                break;
             }
 
-            out->begin_list(out, "fence device", "fence devices", "Registered fence devices");
-            for (dIter = options.devices; dIter; dIter = dIter->next) {
-                out->list_item(out, "device", "%s", dIter->value);
-            }
-
-            out->end_list(out);
-            rc = 0;
-
-            stonith_key_value_freeall(options.devices, 1, 1);
             break;
 
         case 'Q':
@@ -771,61 +519,72 @@ main(int argc, char **argv)
                 rc = st->cmds->list(st, st_opts, device, NULL, options.timeout);
             }
             break;
+
         case 's':
-            rc = st->cmds->list(st, st_opts, device, &lists, options.timeout);
-            if (rc == 0) {
-                GList *targets = stonith__parse_targets(lists);
-
-                out->begin_list(out, "fence target", "fence targets", "Fence Targets");
-                while (targets != NULL) {
-                    out->list_item(out, NULL, "%s", (const char *) targets->data);
-                    targets = targets->next;
-                }
-                out->end_list(out);
-                free(lists);
-
-            } else if (rc != 0) {
+            rc = pcmk__fence_list_targets(out, st, target, options.timeout);
+            if (rc < 0) {
                 out->err(out, "Couldn't list targets: %s", pcmk_strerror(rc));
             }
+
             break;
+
         case 'R':
             rc = st->cmds->register_device(st, st_opts, device, NULL, options.agent,
                                            options.params);
             break;
+
         case 'D':
             rc = st->cmds->remove_device(st, st_opts, device);
             break;
+
         case 'd':
+            rc = pcmk__fence_unregister_level(st, target, options.fence_level);
+            break;
+
         case 'r':
-            rc = handle_level(st, target, options.fence_level, options.devices, action == 'r');
+            rc = pcmk__fence_register_level(st, target, options.fence_level, options.devices);
             break;
+
         case 'M':
-            rc = show_metadata(out, st, options.agent, options.timeout);
+            rc = pcmk__fence_metadata(out, st, options.agent, options.timeout);
+            if (rc != 0) {
+                out->err(out, "Can't get fence agent meta-data: %s", pcmk_strerror(rc));
+            }
+
             break;
+
         case 'C':
             rc = st->cmds->confirm(st, st_opts, target);
             break;
+
         case 'B':
-            rc = mainloop_fencing(st, target, "reboot", options.timeout, options.tolerance);
+            rc = pcmk__fence_action(st, target, "reboot", name, options.timeout,
+                                      options.tolerance);
             break;
+
         case 'F':
-            rc = mainloop_fencing(st, target, "off", options.timeout, options.tolerance);
+            rc = pcmk__fence_action(st, target, "off", name, options.timeout,
+                                      options.tolerance);
             break;
+
         case 'U':
-            rc = mainloop_fencing(st, target, "on", options.timeout, options.tolerance);
+            rc = pcmk__fence_action(st, target, "on", name, options.timeout,
+                                      options.tolerance);
             break;
+
         case 'h':
-            show_last_fenced(out, target);
+            rc = pcmk__fence_last(out, target, options.as_nodeid);
             break;
+
         case 'H':
-            rc = handle_history(st, target, options.timeout, args->quiet,
-                                args->verbosity, options.cleanup,
-                                options.broadcast, out);
+            rc = pcmk__fence_history(out, st, target, options.timeout, args->quiet,
+                                       args->verbosity, options.broadcast, options.cleanup);
             break;
+
         case 'K':
-            device = (options.devices ? options.devices->key : NULL);
-            rc = validate(st, options.agent, device, options.params,
-                          options.timeout, args->quiet, out);
+            device = options.devices ? options.devices->key : NULL;
+            rc = pcmk__fence_validate(out, st, options.agent, device, options.params,
+                                        options.timeout);
             break;
     }
 
@@ -841,7 +600,7 @@ main(int argc, char **argv)
         out->finish(out, exit_code, true, NULL);
         pcmk__output_free(out);
     }
-    free(async_fence_data.name);
+    free(name);
     stonith_key_value_freeall(options.params, 1, 1);
 
     if (st != NULL) {


### PR DESCRIPTION
At the least, I sitll need to add a bunch of documentation to the headers.  Return codes will need to be synced up with that PR.  I haven't really taken much care with return values at the moment because of that.  Here's some other things to think about:

* The pcmk__preproc_cmdline patch ends up being totally standalone, but I think it's worth it.
* I got rid of the pcmk__output_fnew/pcmk__output_dnew patch, but it could come back.  Nothing ended up needing it.
* Some of the public functions in lib/pacemaker/pcmk_stonith.c are just wrappers around the private versions.  I thought it was important to have both to keep the completeness of both APIs.
* Not everything that stonith_admin does ended up getting turned into API functions.  For instance, the register and remove device blocks in the big case statement are unchanged.  stonith_admin doesn't actually do anything around these - it just calls into `st->cmds`.  There didn't seem like enough there to warrant making a separate function, though maybe I should anyway just to keep it complete.
* Testing has been pretty minimal, but I wanted to get more people looking at the direction first.