### PR TITLE
doc: skip outdated part of example log

### DIFF
--- a/doc/Pacemaker_Administration/en-US/Ch-Troubleshooting.txt
+++ b/doc/Pacemaker_Administration/en-US/Ch-Troubleshooting.txt
@@ -42,7 +42,7 @@ then performs the actions in the transition in the proper order.
 Each transition can be identified in the logs by a line like:
 
 ----
-Nov 30 20:28:16 rhel7-1 pacemaker-schedulerd[36417] (process_pe_message)        notice: Calculated transition 19, saving inputs in /var/lib/pacemaker/pengine/pe-input-1463.bz2
+notice: Calculated transition 19, saving inputs in /var/lib/pacemaker/pengine/pe-input-1463.bz2
 ----
 
 The file listed as the "inputs" is a snapshot of the cluster configuration and


### PR DESCRIPTION
The function outputting the transition statistics is not
process_pe_message since commit 4d5fe6bf (present in 2.0.2), but
pcmk__log_transition_summary, so that part is different in the actual
log now. The first part of the log line (up to "notice") is subject to
change anyway, so just omit it altogether for simplicity.