### PR TITLE
Fix: tools: Fix definition of curses_indented_printf.

### DIFF
--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -368,7 +368,7 @@ curses_indented_vprintf(pcmk__output_t *out, const char *format, va_list args) {
 
 G_GNUC_PRINTF(2, 3)
 void
-curses_indented_printf(pcmk__output_t *out, const char *format, va_list args) {
+curses_indented_printf(pcmk__output_t *out, const char *format, ...) {
     return;
 }
 


### PR DESCRIPTION
The placeholder version that is built if curses is not enabled does not
have a type that matches the header file.  Correct that.