### PR TITLE
Low: fenced: Remove relayed stonith operation.(Fix:CLBZ#5401)

### DIFF
--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -978,6 +978,7 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
     remote_fencing_op_t *op = NULL;
     xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, request, LOG_NEVER);
     int call_options = 0;
+    const char *operation = NULL;
 
     init_stonith_remote_op_hash_table(&stonith_remote_op_list);
 
@@ -1026,7 +1027,15 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
         op->client_id = strdup(client);
     }
 
-    op->client_name = crm_element_value_copy(request, F_STONITH_CLIENTNAME);
+    /* For a RELAY operation, set fenced on the client. */
+    operation = crm_element_value(request, F_STONITH_OPERATION);
+
+    if (crm_str_eq(operation, STONITH_OP_RELAY, TRUE)) {
+        op->client_name = crm_strdup_printf("%s.%lu", crm_system_name,
+                                         (unsigned long) getpid());
+    } else {
+        op->client_name = crm_element_value_copy(request, F_STONITH_CLIENTNAME);
+    }
 
     op->target = crm_element_value_copy(dev, F_STONITH_TARGET);
     op->request = copy_xml(request);    /* TODO: Figure out how to avoid this */
@@ -1076,6 +1085,8 @@ initiate_remote_stonith_op(crm_client_t * client, xmlNode * request, gboolean ma
     xmlNode *query = NULL;
     const char *client_id = NULL;
     remote_fencing_op_t *op = NULL;
+    const char *relay_op_id = NULL;
+    const char *operation = NULL;
 
     if (client) {
         client_id = client->id;
@@ -1126,6 +1137,15 @@ initiate_remote_stonith_op(crm_client_t * client, xmlNode * request, gboolean ma
     crm_xml_add(query, F_STONITH_CLIENTID, op->client_id);
     crm_xml_add(query, F_STONITH_CLIENTNAME, op->client_name);
     crm_xml_add_int(query, F_STONITH_TIMEOUT, op->base_timeout);
+
+    /* In case of RELAY operation, RELAY information is added to the query to delete the original operation of RELAY. */
+    operation = crm_element_value(request, F_STONITH_OPERATION);
+    if (crm_str_eq(operation, STONITH_OP_RELAY, TRUE)) {
+        relay_op_id = crm_element_value(request, F_STONITH_REMOTE_OP_ID);
+        if (relay_op_id) {
+            crm_xml_add(query, F_STONITH_REMOTE_OP_ID_RELAY, relay_op_id);
+        }
+    }
 
     send_cluster_message(NULL, crm_msg_stonith_ng, query, FALSE);
     free_xml(query);

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -64,6 +64,7 @@ stonith_history_t *stonith__sort_history(stonith_history_t *history);
 #  define F_STONITH_OPERATION     "st_op"
 #  define F_STONITH_TARGET        "st_target"
 #  define F_STONITH_REMOTE_OP_ID  "st_remote_op"
+#  define F_STONITH_REMOTE_OP_ID_RELAY  "st_remote_op_relay"
 #  define F_STONITH_RC            "st_rc"
 /*! Timeout period per a device execution */
 #  define F_STONITH_TIMEOUT       "st_timeout"


### PR DESCRIPTION
Hi All,

This is a revised version of the next modified PR.
 - https://github.com/ClusterLabs/pacemaker/pull/1951

Delete the DC node RELAY operation and remove the duplicate fencing remote-op.

Best Regards,
Hideo Yamauchi.