### PR TITLE
Avoid clashes with glibc error codes on HPPA

### DIFF
--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -82,8 +82,14 @@ extern "C" {
 #  define pcmk_err_multiple             213
 #  define pcmk_err_node_unknown         214
 #  define pcmk_err_already              215
+/* On HPPA 215 is ENOSYM (Unknown error 215), which hopefully never happens. */
+#ifdef __hppa__
+#  define pcmk_err_bad_nvpair           250	/* 216 is ENOTSOCK */
+#  define pcmk_err_unknown_format       252	/* 217 is EDESTADDRREQ */
+#else
 #  define pcmk_err_bad_nvpair           216
 #  define pcmk_err_unknown_format       217
+#endif
 
 /*!
  * \enum pcmk_rc_e


### PR DESCRIPTION
In principle this is an ABI change, but the affected versions (2.0.2 and
later) were impossible to build due to duplicate case values in
lib/common/results.c.

https://bugs.clusterlabs.org/show_bug.cgi?id=5419