### PR TITLE
Feature: shutdown locks

### DIFF
--- a/cts/cts-scheduler.in
+++ b/cts/cts-scheduler.in
@@ -5,7 +5,7 @@
 # Pacemaker targets compatibility with Python 2.7 and 3.2+
 from __future__ import print_function, unicode_literals, absolute_import, division
 
-__copyright__ = "Copyright 2004-2019 the Pacemaker project contributors"
+__copyright__ = "Copyright 2004-2020 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import io
@@ -956,6 +956,8 @@ TESTS = [
     [
         [ "resource-discovery", "Exercises resource-discovery location constraint option" ],
         [ "rsc-discovery-per-node", "Disable resource discovery per node" ],
+        [ "shutdown-lock", "Ensure shutdown lock works properly" ],
+        [ "shutdown-lock-expiration", "Ensure shutdown lock expiration works properly" ],
     ],
     
     # @TODO: If pacemaker implements versioned attributes, uncomment these tests

--- a/cts/scheduler/shutdown-lock-expiration.dot
+++ b/cts/scheduler/shutdown-lock-expiration.dot
@@ -1,0 +1,11 @@
+ digraph "g" {
+"Fencing_monitor_120000 node3" [ style=bold color="green" fontcolor="black"]
+"Fencing_start_0 node3" -> "Fencing_monitor_120000 node3" [ style = bold]
+"Fencing_start_0 node3" [ style=bold color="green" fontcolor="black"]
+"Fencing_stop_0 node3" -> "Fencing_start_0 node3" [ style = bold]
+"Fencing_stop_0 node3" [ style=bold color="green" fontcolor="black"]
+"rsc2_lrm_delete_0 node2" [ style=bold color="green" fontcolor="black"]
+"rsc2_monitor_10000 node4" [ style=bold color="green" fontcolor="black"]
+"rsc2_start_0 node4" -> "rsc2_monitor_10000 node4" [ style = bold]
+"rsc2_start_0 node4" [ style=bold color="green" fontcolor="black"]
+}

--- a/cts/scheduler/shutdown-lock-expiration.exp
+++ b/cts/scheduler/shutdown-lock-expiration.exp
@@ -1,0 +1,68 @@
+<transition_graph cluster-delay="60s" stonith-timeout="60s" failed-stop-offset="INFINITY" failed-start-offset="1"  transition_id="0" recheck-by="1578348740">
+  <synapse id="0">
+    <action_set>
+      <rsc_op id="4" operation="stop" operation_key="Fencing_stop_0" on_node="node3" on_node_uuid="3">
+        <primitive id="Fencing" class="stonith" type="fence_xvm"/>
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="node3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="60000"  key_file="/etc/pacemaker/fence_xvm.key" multicast_address="239.255.100.100" pcmk_host_list="node1 node2 node3 node4 node5"/>
+      </rsc_op>
+    </action_set>
+    <inputs/>
+  </synapse>
+  <synapse id="1">
+    <action_set>
+      <rsc_op id="3" operation="start" operation_key="Fencing_start_0" on_node="node3" on_node_uuid="3">
+        <primitive id="Fencing" class="stonith" type="fence_xvm"/>
+        <attributes CRM_meta_name="start" CRM_meta_on_node="node3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="60000"  key_file="/etc/pacemaker/fence_xvm.key" multicast_address="239.255.100.100" pcmk_host_list="node1 node2 node3 node4 node5"/>
+      </rsc_op>
+    </action_set>
+    <inputs>
+      <trigger>
+        <rsc_op id="4" operation="stop" operation_key="Fencing_stop_0" on_node="node3" on_node_uuid="3"/>
+      </trigger>
+    </inputs>
+  </synapse>
+  <synapse id="2">
+    <action_set>
+      <rsc_op id="2" operation="monitor" operation_key="Fencing_monitor_120000" on_node="node3" on_node_uuid="3">
+        <primitive id="Fencing" class="stonith" type="fence_xvm"/>
+        <attributes CRM_meta_interval="120000" CRM_meta_name="monitor" CRM_meta_on_node="node3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="120000"  key_file="/etc/pacemaker/fence_xvm.key" multicast_address="239.255.100.100" pcmk_host_list="node1 node2 node3 node4 node5"/>
+      </rsc_op>
+    </action_set>
+    <inputs>
+      <trigger>
+        <rsc_op id="3" operation="start" operation_key="Fencing_start_0" on_node="node3" on_node_uuid="3"/>
+      </trigger>
+    </inputs>
+  </synapse>
+  <synapse id="3">
+    <action_set>
+      <rsc_op id="6" operation="monitor" operation_key="rsc2_monitor_10000" on_node="node4" on_node_uuid="4">
+        <primitive id="rsc2" class="ocf" provider="pacemaker" type="Dummy"/>
+        <attributes CRM_meta_interval="10000" CRM_meta_name="monitor" CRM_meta_on_node="node4" CRM_meta_on_node_uuid="4" CRM_meta_timeout="20000" />
+      </rsc_op>
+    </action_set>
+    <inputs>
+      <trigger>
+        <rsc_op id="5" operation="start" operation_key="rsc2_start_0" on_node="node4" on_node_uuid="4"/>
+      </trigger>
+    </inputs>
+  </synapse>
+  <synapse id="4">
+    <action_set>
+      <rsc_op id="5" operation="start" operation_key="rsc2_start_0" on_node="node4" on_node_uuid="4">
+        <primitive id="rsc2" class="ocf" provider="pacemaker" type="Dummy"/>
+        <attributes CRM_meta_name="start" CRM_meta_on_node="node4" CRM_meta_on_node_uuid="4" CRM_meta_timeout="20000" />
+      </rsc_op>
+    </action_set>
+    <inputs/>
+  </synapse>
+  <synapse id="5">
+    <action_set>
+      <crm_event mode="cib" id="1" operation="lrm_delete" operation_key="rsc2_lrm_delete_0" on_node="node2" on_node_uuid="2">
+        <primitive id="rsc2" class="ocf" provider="pacemaker" type="Dummy"/>
+        <attributes CRM_meta_on_node="node2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="90000" />
+      </crm_event>
+    </action_set>
+    <inputs/>
+  </synapse>
+</transition_graph>

--- a/cts/scheduler/shutdown-lock-expiration.scores
+++ b/cts/scheduler/shutdown-lock-expiration.scores
@@ -1,0 +1,17 @@
+Allocation scores:
+Using the original execution date of: 2020-01-06 22:11:40Z
+native_color: Fencing allocation score on node1: 0
+native_color: Fencing allocation score on node2: 0
+native_color: Fencing allocation score on node3: 0
+native_color: Fencing allocation score on node4: 0
+native_color: Fencing allocation score on node5: 0
+native_color: rsc1 allocation score on node1: INFINITY
+native_color: rsc1 allocation score on node2: -INFINITY
+native_color: rsc1 allocation score on node3: -INFINITY
+native_color: rsc1 allocation score on node4: -INFINITY
+native_color: rsc1 allocation score on node5: -INFINITY
+native_color: rsc2 allocation score on node1: 0
+native_color: rsc2 allocation score on node2: INFINITY
+native_color: rsc2 allocation score on node3: 0
+native_color: rsc2 allocation score on node4: 0
+native_color: rsc2 allocation score on node5: 0

--- a/cts/scheduler/shutdown-lock-expiration.summary
+++ b/cts/scheduler/shutdown-lock-expiration.summary
@@ -1,0 +1,31 @@
+Using the original execution date of: 2020-01-06 22:11:40Z
+
+Current cluster status:
+Online: [ node3 node4 node5 ]
+OFFLINE: [ node1 node2 ]
+
+ Fencing	(stonith:fence_xvm):	Started node3
+ rsc1	(ocf::pacemaker:Dummy):	Stopped node1 (LOCKED)
+ rsc2	(ocf::pacemaker:Dummy):	Stopped
+
+Transition Summary:
+ * Restart    Fencing     ( node3 )   due to resource definition change
+ * Start      rsc2        ( node4 )  
+
+Executing cluster transition:
+ * Resource action: Fencing         stop on node3
+ * Resource action: Fencing         start on node3
+ * Resource action: Fencing         monitor=120000 on node3
+ * Resource action: rsc2            start on node4
+ * Cluster action:  lrm_delete for rsc2 on node2
+ * Resource action: rsc2            monitor=10000 on node4
+Using the original execution date of: 2020-01-06 22:11:40Z
+
+Revised cluster status:
+Online: [ node3 node4 node5 ]
+OFFLINE: [ node1 node2 ]
+
+ Fencing	(stonith:fence_xvm):	Started node3
+ rsc1	(ocf::pacemaker:Dummy):	Stopped node1 (LOCKED)
+ rsc2	(ocf::pacemaker:Dummy):	Started node4
+

--- a/cts/scheduler/shutdown-lock-expiration.xml
+++ b/cts/scheduler/shutdown-lock-expiration.xml
@@ -1,0 +1,187 @@
+<cib crm_feature_set="3.3.0" validate-with="pacemaker-3.0" epoch="155" num_updates="14" admin_epoch="0" cib-last-written="Mon Jan  6 16:05:00 2020" update-origin="node2" update-client="cibadmin" update-user="root" have-quorum="1" dc-uuid="3" execution-date="1578348700">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cts-stonith-enabled" name="stonith-enabled" value="1"/>
+        <nvpair id="cts-start-failure-is-fatal" name="start-failure-is-fatal" value="false"/>
+        <nvpair id="cts-pe-input-series-max" name="pe-input-series-max" value="5000"/>
+        <nvpair id="cts-shutdown-escalation" name="shutdown-escalation" value="5min"/>
+        <nvpair id="cts-batch-limit" name="batch-limit" value="10"/>
+        <nvpair id="cts-dc-deadtime" name="dc-deadtime" value="5s"/>
+        <nvpair id="cts-no-quorum-policy" name="no-quorum-policy" value="stop"/>
+        <nvpair id="cib-bootstrap-options-have-watchdog" name="have-watchdog" value="false"/>
+        <nvpair id="cib-bootstrap-options-dc-version" name="dc-version" value="2.0.3-402.d0d0762.git.el7-d0d0762"/>
+        <nvpair id="cib-bootstrap-options-cluster-infrastructure" name="cluster-infrastructure" value="corosync"/>
+        <nvpair id="cib-bootstrap-options-cluster-name" name="cluster-name" value="mycluster"/>
+        <!-- This regression test ensures that shutdown lock expiration works properly, for both
+             non-expired locks (rsc1 on node1) and expired locks (rsc2 on node2). This will also
+             ensure that the next recheck time is calculated properly.
+          -->
+        <nvpair id="cib-bootstrap-options-shutdown-lock" name="shutdown-lock" value="true"/>
+        <nvpair id="cib-bootstrap-options-shutdown-lock-limit" name="shutdown-lock-limit" value="5m"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="1" uname="node1">
+        <instance_attributes id="nodes-1">
+          <nvpair id="nodes-1-standby" name="standby" value="off"/>
+        </instance_attributes>
+      </node>
+      <node id="2" uname="node2"/>
+      <node id="3" uname="node3">
+        <instance_attributes id="nodes-3">
+          <nvpair id="nodes-3-standby" name="standby" value="off"/>
+        </instance_attributes>
+      </node>
+      <node id="4" uname="node4">
+        <instance_attributes id="nodes-4">
+          <nvpair id="nodes-4-standby" name="standby" value="off"/>
+        </instance_attributes>
+      </node>
+      <node id="5" uname="node5"/>
+    </nodes>
+    <resources>
+      <primitive class="stonith" id="Fencing" type="fence_xvm">
+        <meta_attributes id="Fencing-meta">
+          <nvpair id="Fencing-migration-threshold" name="migration-threshold" value="5"/>
+        </meta_attributes>
+        <instance_attributes id="Fencing-params">
+          <nvpair id="Fencing-key_file" name="key_file" value="/etc/pacemaker/fence_xvm.key"/>
+          <nvpair id="Fencing-multicast_address" name="multicast_address" value="239.255.100.100"/>
+          <nvpair id="Fencing-pcmk_host_list" name="pcmk_host_list" value="node1 node2 node3 node4 node5"/>
+        </instance_attributes>
+        <operations>
+          <op id="Fencing-monitor-120s" interval="120s" name="monitor" timeout="120s"/>
+          <op id="Fencing-stop-0" interval="0" name="stop" timeout="60s"/>
+          <op id="Fencing-start-0" interval="0" name="start" timeout="60s"/>
+        </operations>
+      </primitive>
+      <primitive class="ocf" id="rsc1" provider="pacemaker" type="Dummy">
+        <operations>
+          <op id="rsc1-migrate_from-interval-0s" interval="0s" name="migrate_from" timeout="20s"/>
+          <op id="rsc1-migrate_to-interval-0s" interval="0s" name="migrate_to" timeout="20s"/>
+          <op id="rsc1-monitor-interval-10s" interval="10s" name="monitor" timeout="20s"/>
+          <op id="rsc1-reload-interval-0s" interval="0s" name="reload" timeout="20s"/>
+          <op id="rsc1-start-interval-0s" interval="0s" name="start" timeout="20s"/>
+          <op id="rsc1-stop-interval-0s" interval="0s" name="stop" timeout="20s"/>
+        </operations>
+      </primitive>
+      <primitive class="ocf" id="rsc2" provider="pacemaker" type="Dummy">
+        <operations>
+          <op id="rsc2-migrate_from-interval-0s" interval="0s" name="migrate_from" timeout="20s"/>
+          <op id="rsc2-migrate_to-interval-0s" interval="0s" name="migrate_to" timeout="20s"/>
+          <op id="rsc2-monitor-interval-10s" interval="10s" name="monitor" timeout="20s"/>
+          <op id="rsc2-reload-interval-0s" interval="0s" name="reload" timeout="20s"/>
+          <op id="rsc2-start-interval-0s" interval="0s" name="start" timeout="20s"/>
+          <op id="rsc2-stop-interval-0s" interval="0s" name="stop" timeout="20s"/>
+        </operations>
+      </primitive>
+    </resources>
+    <constraints>
+      <rsc_location id="location-rsc1-node1-INFINITY" node="node1" rsc="rsc1" score="INFINITY"/>
+      <rsc_location id="location-rsc2-node2-INFINITY" node="node2" rsc="rsc2" score="INFINITY"/>
+    </constraints>
+    <op_defaults>
+      <meta_attributes id="cts-op_defaults-meta">
+        <nvpair id="cts-op_defaults-timeout" name="timeout" value="90s"/>
+      </meta_attributes>
+    </op_defaults>
+    <alerts>
+      <alert id="alert-1" path="/var/lib/pacemaker/notify.sh">
+        <recipient id="alert-1-recipient-1" value="/run/crm/alert.log"/>
+      </alert>
+    </alerts>
+    <rsc_defaults>
+      <meta_attributes id="rsc_defaults-options"/>
+    </rsc_defaults>
+  </configuration>
+  <status>
+    <node_state id="2" uname="node2" in_ccm="false" crmd="offline" crm-debug-origin="post_cache_update" join="down" expected="down">
+      <lrm id="2">
+        <lrm_resources>
+          <lrm_resource id="rsc2" type="Dummy" class="ocf" provider="pacemaker" shutdown-lock="1578348332">
+            <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_stop_0" operation="stop" crm-debug-origin="do_update_resource" crm_feature_set="3.3.0" transition-key="8:6:0:398bf005-bb15-4098-9a72-d8373456b457" transition-magic="0:0;8:6:0:398bf005-bb15-4098-9a72-d8373456b457" exit-reason="" on_node="node2" call-id="24" rc-code="0" op-status="0" interval="0" last-rc-change="1578348332" last-run="1578348332" exec-time="24" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="rsc2_monitor_10000" operation_key="rsc2_monitor_10000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.3.0" transition-key="9:4:0:398bf005-bb15-4098-9a72-d8373456b457" transition-magic="0:0;9:4:0:398bf005-bb15-4098-9a72-d8373456b457" exit-reason="" on_node="node2" call-id="21" rc-code="0" op-status="0" interval="10000" last-rc-change="1578348257" exec-time="21" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="Fencing" type="fence_xvm" class="stonith">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_monitor_0" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.3.0" transition-key="3:3:7:398bf005-bb15-4098-9a72-d8373456b457" transition-magic="0:7;3:3:7:398bf005-bb15-4098-9a72-d8373456b457" exit-reason="" on_node="node2" call-id="10" rc-code="7" op-status="0" interval="0" last-rc-change="1578348256" last-run="1578348256" exec-time="6" queue-time="0" op-digest="c7e1af5a2f7b98510353dc9f9edfef70"/>
+          </lrm_resource>
+          <lrm_resource id="rsc1" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_monitor_0" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.3.0" transition-key="4:3:7:398bf005-bb15-4098-9a72-d8373456b457" transition-magic="0:7;4:3:7:398bf005-bb15-4098-9a72-d8373456b457" exit-reason="" on_node="node2" call-id="14" rc-code="7" op-status="0" interval="0" last-rc-change="1578348257" last-run="1578348257" exec-time="38" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state id="5" uname="node5" in_ccm="true" crmd="online" crm-debug-origin="post_cache_update" join="member" expected="member">
+      <transient_attributes id="5">
+        <instance_attributes id="status-5"/>
+      </transient_attributes>
+      <lrm id="5">
+        <lrm_resources>
+          <lrm_resource id="Fencing" type="fence_xvm" class="stonith">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="61:0:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;61:0:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node5" call-id="5" rc-code="7" op-status="0" interval="0" last-rc-change="1578347670" last-run="1578347670" exec-time="7" queue-time="0" op-digest="c7e1af5a2f7b98510353dc9f9edfef70"/>
+          </lrm_resource>
+          <lrm_resource id="rsc1" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="6:59:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;6:59:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node5" call-id="104" rc-code="7" op-status="0" interval="0" last-rc-change="1578347819" last-run="1578347819" exec-time="33" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="rsc2" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_stop_0" operation="stop" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="12:62:0:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:0;12:62:0:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node5" call-id="114" rc-code="0" op-status="0" interval="0" last-rc-change="1578347832" last-run="1578347832" exec-time="29" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state id="3" uname="node3" in_ccm="true" crmd="online" crm-debug-origin="post_cache_update" join="member" expected="member">
+      <transient_attributes id="3">
+        <instance_attributes id="status-3"/>
+      </transient_attributes>
+      <lrm id="3">
+        <lrm_resources>
+          <lrm_resource id="Fencing" type="fence_xvm" class="stonith">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_start_0" operation="start" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="4:68:0:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:0;4:68:0:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node3" call-id="115" rc-code="0" op-status="0" interval="0" last-rc-change="1578347951" last-run="1578347951" exec-time="41" queue-time="0" op-digest="c7e1af5a2f7b98510353dc9f9edfef70"/>
+            <lrm_rsc_op id="Fencing_monitor_120000" operation_key="Fencing_monitor_120000" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="5:68:0:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:0;5:68:0:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node3" call-id="117" rc-code="0" op-status="0" interval="120000" last-rc-change="1578347951" exec-time="32" queue-time="1" op-digest="cb34bc19df153021ce8f301baa293f35"/>
+          </lrm_resource>
+          <lrm_resource id="rsc1" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="4:59:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;4:59:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node3" call-id="105" rc-code="7" op-status="0" interval="0" last-rc-change="1578347819" last-run="1578347819" exec-time="30" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="rsc2" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="5:60:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;5:60:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node3" call-id="109" rc-code="7" op-status="0" interval="0" last-rc-change="1578347822" last-run="1578347822" exec-time="48" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state id="4" uname="node4" in_ccm="true" crmd="online" crm-debug-origin="post_cache_update" join="member" expected="member">
+      <transient_attributes id="4">
+        <instance_attributes id="status-4"/>
+      </transient_attributes>
+      <lrm id="4">
+        <lrm_resources>
+          <lrm_resource id="Fencing" type="fence_xvm" class="stonith">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="46:0:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;46:0:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node4" call-id="5" rc-code="7" op-status="0" interval="0" last-rc-change="1578347670" last-run="1578347670" exec-time="7" queue-time="0" op-digest="c7e1af5a2f7b98510353dc9f9edfef70"/>
+          </lrm_resource>
+          <lrm_resource id="rsc1" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_stop_0" operation="stop" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="10:61:0:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:0;10:61:0:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node4" call-id="121" rc-code="0" op-status="0" interval="0" last-rc-change="1578347828" last-run="1578347828" exec-time="25" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="rsc2" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="6:60:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;6:60:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node4" call-id="119" rc-code="7" op-status="0" interval="0" last-rc-change="1578347822" last-run="1578347822" exec-time="29" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state id="1" uname="node1" in_ccm="false" crmd="offline" crm-debug-origin="post_cache_update" join="down" expected="down">
+      <lrm id="1">
+        <lrm_resources>
+          <lrm_resource id="rsc1" type="Dummy" class="ocf" provider="pacemaker" shutdown-lock="1578348439">
+            <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_stop_0" operation="stop" crm-debug-origin="do_update_resource" crm_feature_set="3.3.0" transition-key="5:7:0:398bf005-bb15-4098-9a72-d8373456b457" transition-magic="0:0;5:7:0:398bf005-bb15-4098-9a72-d8373456b457" exit-reason="" on_node="node1" call-id="25" rc-code="0" op-status="0" interval="0" last-rc-change="1578348439" last-run="1578348439" exec-time="22" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="rsc1_monitor_10000" operation_key="rsc1_monitor_10000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.3.0" transition-key="6:2:0:398bf005-bb15-4098-9a72-d8373456b457" transition-magic="0:0;6:2:0:398bf005-bb15-4098-9a72-d8373456b457" exit-reason="" on_node="node1" call-id="21" rc-code="0" op-status="0" interval="10000" last-rc-change="1578348254" exec-time="16" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="Fencing" type="fence_xvm" class="stonith">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_monitor_0" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.3.0" transition-key="2:1:7:398bf005-bb15-4098-9a72-d8373456b457" transition-magic="0:7;2:1:7:398bf005-bb15-4098-9a72-d8373456b457" exit-reason="" on_node="node1" call-id="10" rc-code="7" op-status="0" interval="0" last-rc-change="1578348254" last-run="1578348254" exec-time="4" queue-time="0" op-digest="c7e1af5a2f7b98510353dc9f9edfef70"/>
+          </lrm_resource>
+          <lrm_resource id="rsc2" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_monitor_0" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.3.0" transition-key="4:1:7:398bf005-bb15-4098-9a72-d8373456b457" transition-magic="0:7;4:1:7:398bf005-bb15-4098-9a72-d8373456b457" exit-reason="" on_node="node1" call-id="18" rc-code="7" op-status="0" interval="0" last-rc-change="1578348254" last-run="1578348254" exec-time="35" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+  </status>
+</cib>

--- a/cts/scheduler/shutdown-lock.dot
+++ b/cts/scheduler/shutdown-lock.dot
@@ -1,0 +1,11 @@
+ digraph "g" {
+"Fencing_monitor_120000 node3" [ style=bold color="green" fontcolor="black"]
+"Fencing_start_0 node3" -> "Fencing_monitor_120000 node3" [ style = bold]
+"Fencing_start_0 node3" [ style=bold color="green" fontcolor="black"]
+"Fencing_stop_0 node1" -> "Fencing_start_0 node3" [ style = bold]
+"Fencing_stop_0 node1" -> "do_shutdown node1" [ style = bold]
+"Fencing_stop_0 node1" [ style=bold color="green" fontcolor="black"]
+"do_shutdown node1" [ style=bold color="green" fontcolor="black"]
+"rsc1_stop_0 node1" -> "do_shutdown node1" [ style = bold]
+"rsc1_stop_0 node1" [ style=bold color="green" fontcolor="black"]
+}

--- a/cts/scheduler/shutdown-lock.exp
+++ b/cts/scheduler/shutdown-lock.exp
@@ -1,0 +1,64 @@
+<transition_graph cluster-delay="60s" stonith-timeout="60s" failed-stop-offset="INFINITY" failed-start-offset="INFINITY"  transition_id="0">
+  <synapse id="0">
+    <action_set>
+      <rsc_op id="5" operation="monitor" operation_key="Fencing_monitor_120000" on_node="node3" on_node_uuid="3">
+        <primitive id="Fencing" class="stonith" type="fence_xvm"/>
+        <attributes CRM_meta_interval="120000" CRM_meta_name="monitor" CRM_meta_on_node="node3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="120000"  key_file="/etc/pacemaker/fence_xvm.key" multicast_address="239.255.100.100" pcmk_host_list="node1 node2 node3 node4 node5"/>
+      </rsc_op>
+    </action_set>
+    <inputs>
+      <trigger>
+        <rsc_op id="4" operation="start" operation_key="Fencing_start_0" on_node="node3" on_node_uuid="3"/>
+      </trigger>
+    </inputs>
+  </synapse>
+  <synapse id="1">
+    <action_set>
+      <rsc_op id="4" operation="start" operation_key="Fencing_start_0" on_node="node3" on_node_uuid="3">
+        <primitive id="Fencing" class="stonith" type="fence_xvm"/>
+        <attributes CRM_meta_name="start" CRM_meta_on_node="node3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="60000"  key_file="/etc/pacemaker/fence_xvm.key" multicast_address="239.255.100.100" pcmk_host_list="node1 node2 node3 node4 node5"/>
+      </rsc_op>
+    </action_set>
+    <inputs>
+      <trigger>
+        <rsc_op id="3" operation="stop" operation_key="Fencing_stop_0" on_node="node1" on_node_uuid="1"/>
+      </trigger>
+    </inputs>
+  </synapse>
+  <synapse id="2">
+    <action_set>
+      <rsc_op id="3" operation="stop" operation_key="Fencing_stop_0" on_node="node1" on_node_uuid="1">
+        <primitive id="Fencing" class="stonith" type="fence_xvm"/>
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000"  key_file="/etc/pacemaker/fence_xvm.key" multicast_address="239.255.100.100" pcmk_host_list="node1 node2 node3 node4 node5"/>
+      </rsc_op>
+    </action_set>
+    <inputs/>
+  </synapse>
+  <synapse id="3">
+    <action_set>
+      <rsc_op id="6" operation="stop" operation_key="rsc1_stop_0" on_node="node1" on_node_uuid="1" shutdown-lock="1578347951">
+        <primitive id="rsc1" class="ocf" provider="pacemaker" type="Dummy"/>
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" />
+      </rsc_op>
+    </action_set>
+    <inputs/>
+  </synapse>
+  <synapse id="4">
+    <action_set>
+      <crm_event id="7" operation="do_shutdown" operation_key="do_shutdown-node1" on_node="node1" on_node_uuid="1">
+        <attributes CRM_meta_on_node="node1" CRM_meta_on_node_uuid="1" CRM_meta_op_no_wait="true" />
+        <downed>
+          <node id="1"/>
+        </downed>
+      </crm_event>
+    </action_set>
+    <inputs>
+      <trigger>
+        <rsc_op id="3" operation="stop" operation_key="Fencing_stop_0" on_node="node1" on_node_uuid="1"/>
+      </trigger>
+      <trigger>
+        <rsc_op id="6" operation="stop" operation_key="rsc1_stop_0" on_node="node1" on_node_uuid="1"/>
+      </trigger>
+    </inputs>
+  </synapse>
+</transition_graph>

--- a/cts/scheduler/shutdown-lock.scores
+++ b/cts/scheduler/shutdown-lock.scores
@@ -1,0 +1,17 @@
+Allocation scores:
+Using the original execution date of: 2020-01-06 21:59:11Z
+native_color: Fencing allocation score on node1: 0
+native_color: Fencing allocation score on node2: 0
+native_color: Fencing allocation score on node3: 0
+native_color: Fencing allocation score on node4: 0
+native_color: Fencing allocation score on node5: 0
+native_color: rsc1 allocation score on node1: INFINITY
+native_color: rsc1 allocation score on node2: -INFINITY
+native_color: rsc1 allocation score on node3: -INFINITY
+native_color: rsc1 allocation score on node4: -INFINITY
+native_color: rsc1 allocation score on node5: -INFINITY
+native_color: rsc2 allocation score on node1: -INFINITY
+native_color: rsc2 allocation score on node2: INFINITY
+native_color: rsc2 allocation score on node3: -INFINITY
+native_color: rsc2 allocation score on node4: -INFINITY
+native_color: rsc2 allocation score on node5: -INFINITY

--- a/cts/scheduler/shutdown-lock.summary
+++ b/cts/scheduler/shutdown-lock.summary
@@ -1,0 +1,31 @@
+Using the original execution date of: 2020-01-06 21:59:11Z
+
+Current cluster status:
+Online: [ node1 node3 node4 node5 ]
+OFFLINE: [ node2 ]
+
+ Fencing	(stonith:fence_xvm):	Started node1
+ rsc1	(ocf::pacemaker:Dummy):	Started node1
+ rsc2	(ocf::pacemaker:Dummy):	Stopped node2 (LOCKED)
+
+Transition Summary:
+ * Shutdown node1
+ * Move       Fencing     ( node1 -> node3 )  
+ * Stop       rsc1        (          node1 )   due to node availability
+
+Executing cluster transition:
+ * Resource action: Fencing         stop on node1
+ * Resource action: rsc1            stop on node1
+ * Cluster action:  do_shutdown on node1
+ * Resource action: Fencing         start on node3
+ * Resource action: Fencing         monitor=120000 on node3
+Using the original execution date of: 2020-01-06 21:59:11Z
+
+Revised cluster status:
+Online: [ node1 node3 node4 node5 ]
+OFFLINE: [ node2 ]
+
+ Fencing	(stonith:fence_xvm):	Started node3
+ rsc1	(ocf::pacemaker:Dummy):	Stopped
+ rsc2	(ocf::pacemaker:Dummy):	Stopped node2 (LOCKED)
+

--- a/cts/scheduler/shutdown-lock.xml
+++ b/cts/scheduler/shutdown-lock.xml
@@ -1,0 +1,186 @@
+<cib crm_feature_set="3.3.0" validate-with="pacemaker-3.0" epoch="154" num_updates="21" admin_epoch="0" cib-last-written="Mon Jan  6 15:58:11 2020" update-origin="node1" update-client="cibadmin" update-user="root" have-quorum="1" dc-uuid="1" execution-date="1578347951">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cts-stonith-enabled" name="stonith-enabled" value="1"/>
+        <nvpair id="cib-bootstrap-options-have-watchdog" name="have-watchdog" value="false"/>
+        <nvpair id="cib-bootstrap-options-dc-version" name="dc-version" value="2.0.3-402.d0d0762.git.el7-d0d0762"/>
+        <nvpair id="cib-bootstrap-options-cluster-infrastructure" name="cluster-infrastructure" value="corosync"/>
+        <nvpair id="cib-bootstrap-options-cluster-name" name="cluster-name" value="mycluster"/>
+        <!-- This regression test ensures that resources are properly locked to a node when shutdown-lock
+             is true, both when active on a node that is shutting down (rsc1 on node1), and when
+             inactive on a node already shut down (rsc2 on node2). It also ensures that stonith-class
+             resources are not locked.
+          -->
+        <nvpair id="cib-bootstrap-options-shutdown-lock" name="shutdown-lock" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="1" uname="node1">
+        <instance_attributes id="nodes-1">
+          <nvpair id="nodes-1-standby" name="standby" value="off"/>
+        </instance_attributes>
+      </node>
+      <node id="2" uname="node2"/>
+      <node id="3" uname="node3">
+        <instance_attributes id="nodes-3">
+          <nvpair id="nodes-3-standby" name="standby" value="off"/>
+        </instance_attributes>
+      </node>
+      <node id="4" uname="node4">
+        <instance_attributes id="nodes-4">
+          <nvpair id="nodes-4-standby" name="standby" value="off"/>
+        </instance_attributes>
+      </node>
+      <node id="5" uname="node5"/>
+    </nodes>
+    <resources>
+      <primitive class="stonith" id="Fencing" type="fence_xvm">
+        <meta_attributes id="Fencing-meta">
+          <nvpair id="Fencing-migration-threshold" name="migration-threshold" value="5"/>
+        </meta_attributes>
+        <instance_attributes id="Fencing-params">
+          <nvpair id="Fencing-key_file" name="key_file" value="/etc/pacemaker/fence_xvm.key"/>
+          <nvpair id="Fencing-multicast_address" name="multicast_address" value="239.255.100.100"/>
+          <nvpair id="Fencing-pcmk_host_list" name="pcmk_host_list" value="node1 node2 node3 node4 node5"/>
+        </instance_attributes>
+        <operations>
+          <op id="Fencing-monitor-120s" interval="120s" name="monitor" timeout="120s"/>
+          <op id="Fencing-stop-0" interval="0" name="stop" timeout="60s"/>
+          <op id="Fencing-start-0" interval="0" name="start" timeout="60s"/>
+        </operations>
+      </primitive>
+      <primitive class="ocf" id="rsc1" provider="pacemaker" type="Dummy">
+        <operations>
+          <op id="rsc1-migrate_from-interval-0s" interval="0s" name="migrate_from" timeout="20s"/>
+          <op id="rsc1-migrate_to-interval-0s" interval="0s" name="migrate_to" timeout="20s"/>
+          <op id="rsc1-monitor-interval-10s" interval="10s" name="monitor" timeout="20s"/>
+          <op id="rsc1-reload-interval-0s" interval="0s" name="reload" timeout="20s"/>
+          <op id="rsc1-start-interval-0s" interval="0s" name="start" timeout="20s"/>
+          <op id="rsc1-stop-interval-0s" interval="0s" name="stop" timeout="20s"/>
+        </operations>
+      </primitive>
+      <primitive class="ocf" id="rsc2" provider="pacemaker" type="Dummy">
+        <operations>
+          <op id="rsc2-migrate_from-interval-0s" interval="0s" name="migrate_from" timeout="20s"/>
+          <op id="rsc2-migrate_to-interval-0s" interval="0s" name="migrate_to" timeout="20s"/>
+          <op id="rsc2-monitor-interval-10s" interval="10s" name="monitor" timeout="20s"/>
+          <op id="rsc2-reload-interval-0s" interval="0s" name="reload" timeout="20s"/>
+          <op id="rsc2-start-interval-0s" interval="0s" name="start" timeout="20s"/>
+          <op id="rsc2-stop-interval-0s" interval="0s" name="stop" timeout="20s"/>
+        </operations>
+      </primitive>
+    </resources>
+    <constraints>
+      <rsc_location id="location-rsc1-node1-INFINITY" node="node1" rsc="rsc1" score="INFINITY"/>
+      <rsc_location id="location-rsc2-node2-INFINITY" node="node2" rsc="rsc2" score="INFINITY"/>
+    </constraints>
+    <op_defaults>
+      <meta_attributes id="cts-op_defaults-meta">
+        <nvpair id="cts-op_defaults-timeout" name="timeout" value="90s"/>
+      </meta_attributes>
+    </op_defaults>
+    <alerts>
+      <alert id="alert-1" path="/var/lib/pacemaker/notify.sh">
+        <recipient id="alert-1-recipient-1" value="/run/crm/alert.log"/>
+      </alert>
+    </alerts>
+    <rsc_defaults>
+      <meta_attributes id="rsc_defaults-options"/>
+    </rsc_defaults>
+  </configuration>
+  <status>
+    <node_state id="2" uname="node2" in_ccm="false" crmd="offline" crm-debug-origin="post_cache_update" join="down" expected="down">
+      <lrm id="2">
+        <lrm_resources>
+          <lrm_resource id="Fencing" type="fence_xvm" class="stonith">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="16:0:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;16:0:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node2" call-id="5" rc-code="7" op-status="0" interval="0" last-rc-change="1578347670" last-run="1578347670" exec-time="6" queue-time="0" op-digest="c7e1af5a2f7b98510353dc9f9edfef70"/>
+          </lrm_resource>
+          <lrm_resource id="rsc1" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="3:59:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;3:59:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node2" call-id="141" rc-code="7" op-status="0" interval="0" last-rc-change="1578347819" last-run="1578347819" exec-time="44" queue-time="1" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="rsc2" type="Dummy" class="ocf" provider="pacemaker" shutdown-lock="1578347927">
+            <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_stop_0" operation="stop" crm-debug-origin="do_update_resource" crm_feature_set="3.3.0" transition-key="8:67:0:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:0;8:67:0:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node2" call-id="155" rc-code="0" op-status="0" interval="0" last-rc-change="1578347927" last-run="1578347927" exec-time="28" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="rsc2_monitor_10000" operation_key="rsc2_monitor_10000" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="14:62:0:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:0;14:62:0:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node2" call-id="148" rc-code="0" op-status="0" interval="10000" last-rc-change="1578347832" exec-time="18" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state id="5" uname="node5" in_ccm="true" crmd="online" crm-debug-origin="post_cache_update" join="member" expected="member">
+      <transient_attributes id="5">
+        <instance_attributes id="status-5"/>
+      </transient_attributes>
+      <lrm id="5">
+        <lrm_resources>
+          <lrm_resource id="Fencing" type="fence_xvm" class="stonith">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="61:0:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;61:0:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node5" call-id="5" rc-code="7" op-status="0" interval="0" last-rc-change="1578347670" last-run="1578347670" exec-time="7" queue-time="0" op-digest="c7e1af5a2f7b98510353dc9f9edfef70"/>
+          </lrm_resource>
+          <lrm_resource id="rsc1" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="6:59:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;6:59:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node5" call-id="104" rc-code="7" op-status="0" interval="0" last-rc-change="1578347819" last-run="1578347819" exec-time="33" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="rsc2" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_stop_0" operation="stop" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="12:62:0:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:0;12:62:0:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node5" call-id="114" rc-code="0" op-status="0" interval="0" last-rc-change="1578347832" last-run="1578347832" exec-time="29" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state id="3" uname="node3" in_ccm="true" crmd="online" crm-debug-origin="post_cache_update" join="member" expected="member">
+      <transient_attributes id="3">
+        <instance_attributes id="status-3"/>
+      </transient_attributes>
+      <lrm id="3">
+        <lrm_resources>
+          <lrm_resource id="Fencing" type="fence_xvm" class="stonith">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="31:0:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;31:0:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node3" call-id="5" rc-code="7" op-status="0" interval="0" last-rc-change="1578347670" last-run="1578347670" exec-time="4" queue-time="0" op-digest="c7e1af5a2f7b98510353dc9f9edfef70"/>
+          </lrm_resource>
+          <lrm_resource id="rsc1" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="4:59:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;4:59:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node3" call-id="105" rc-code="7" op-status="0" interval="0" last-rc-change="1578347819" last-run="1578347819" exec-time="30" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="rsc2" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="5:60:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;5:60:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node3" call-id="109" rc-code="7" op-status="0" interval="0" last-rc-change="1578347822" last-run="1578347822" exec-time="48" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state id="4" uname="node4" in_ccm="true" crmd="online" crm-debug-origin="post_cache_update" join="member" expected="member">
+      <transient_attributes id="4">
+        <instance_attributes id="status-4"/>
+      </transient_attributes>
+      <lrm id="4">
+        <lrm_resources>
+          <lrm_resource id="Fencing" type="fence_xvm" class="stonith">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="46:0:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;46:0:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node4" call-id="5" rc-code="7" op-status="0" interval="0" last-rc-change="1578347670" last-run="1578347670" exec-time="7" queue-time="0" op-digest="c7e1af5a2f7b98510353dc9f9edfef70"/>
+          </lrm_resource>
+          <lrm_resource id="rsc1" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_stop_0" operation="stop" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="10:61:0:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:0;10:61:0:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node4" call-id="121" rc-code="0" op-status="0" interval="0" last-rc-change="1578347828" last-run="1578347828" exec-time="25" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="rsc2" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="6:60:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;6:60:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node4" call-id="119" rc-code="7" op-status="0" interval="0" last-rc-change="1578347822" last-run="1578347822" exec-time="29" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state id="1" uname="node1" in_ccm="true" crmd="online" crm-debug-origin="post_cache_update" join="member" expected="member">
+      <transient_attributes id="1">
+        <instance_attributes id="status-1">
+          <nvpair id="status-1-shutdown" name="shutdown" value="1578347951"/>
+        </instance_attributes>
+      </transient_attributes>
+      <lrm id="1">
+        <lrm_resources>
+          <lrm_resource id="Fencing" type="fence_xvm" class="stonith">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_start_0" operation="start" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="76:0:0:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:0;76:0:0:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node1" call-id="10" rc-code="0" op-status="0" interval="0" last-rc-change="1578347670" last-run="1578347670" exec-time="121" queue-time="0" op-digest="c7e1af5a2f7b98510353dc9f9edfef70"/>
+            <lrm_rsc_op id="Fencing_monitor_120000" operation_key="Fencing_monitor_120000" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="77:0:0:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:0;77:0:0:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node1" call-id="12" rc-code="0" op-status="0" interval="120000" last-rc-change="1578347670" exec-time="92" queue-time="0" op-digest="cb34bc19df153021ce8f301baa293f35"/>
+          </lrm_resource>
+          <lrm_resource id="rsc1" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_start_0" operation="start" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="11:61:0:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:0;11:61:0:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node1" call-id="112" rc-code="0" op-status="0" interval="0" last-rc-change="1578347828" last-run="1578347828" exec-time="22" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="rsc1_monitor_10000" operation_key="rsc1_monitor_10000" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="12:61:0:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:0;12:61:0:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node1" call-id="114" rc-code="0" op-status="0" interval="10000" last-rc-change="1578347828" exec-time="21" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="rsc2" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_monitor_0" operation="monitor" crm-debug-origin="build_active_RAs" crm_feature_set="3.3.0" transition-key="3:60:7:4502288b-71ea-43d2-a481-d2c360266103" transition-magic="0:7;3:60:7:4502288b-71ea-43d2-a481-d2c360266103" exit-reason="" on_node="node1" call-id="111" rc-code="7" op-status="0" interval="0" last-rc-change="1578347822" last-run="1578347822" exec-time="47" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+  </status>
+</cib>

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -35,6 +35,7 @@ gboolean fsa_has_quorum = FALSE;
 crm_trigger_t *fsa_source = NULL;
 crm_trigger_t *config_read = NULL;
 bool no_quorum_suicide_escalation = FALSE;
+bool controld_shutdown_lock_enabled = false;
 
 /*	 A_HA_CONNECT	*/
 void
@@ -587,7 +588,10 @@ static pe_cluster_option crmd_opts[] = {
         { "stonith-max-attempts",NULL,"integer",NULL,"10",&check_positive_number,
           "How many times stonith can fail before it will no longer be attempted on a target"
         },   
+
+    // Already documented in libpe_status (other values must be kept identical)
 	{ "no-quorum-policy", NULL, "enum", "stop, freeze, ignore, suicide", "stop", &check_quorum, NULL, NULL },
+    { XML_CONFIG_ATTR_SHUTDOWN_LOCK, NULL, "boolean", NULL, "false", &check_boolean, NULL, NULL },
 };
 /* *INDENT-ON* */
 
@@ -697,6 +701,9 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 
     value = crmd_pref(config_hash, "join-finalization-timeout");
     finalization_timer->period_ms = crm_parse_interval_spec(value);
+
+    value = crmd_pref(config_hash, XML_CONFIG_ATTR_SHUTDOWN_LOCK);
+    controld_shutdown_lock_enabled = crm_is_true(value);
 
     free(fsa_cluster_name);
     fsa_cluster_name = NULL;

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1769,7 +1769,9 @@ do_lrm_invoke(long long action,
     crm_trace("Executor %s command from %s", crm_op, from_sys);
 
     if (safe_str_eq(crm_op, CRM_OP_LRM_DELETE)) {
-        crm_rsc_delete = TRUE; // Only crm_resource uses this op
+        if (safe_str_neq(from_sys, CRM_SYSTEM_TENGINE)) {
+            crm_rsc_delete = TRUE; // from crm_resource
+        }
         operation = CRMD_ACTION_DELETE;
 
     } else if (safe_str_eq(crm_op, CRM_OP_LRM_FAIL)) {

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1878,15 +1878,10 @@ construct_op(lrm_state_t * lrm_state, xmlNode * rsc_op, const char *rsc_id, cons
 
     CRM_ASSERT(rsc_id && operation);
 
-    op = calloc(1, sizeof(lrmd_event_data_t));
-    CRM_ASSERT(op != NULL);
-
+    op = lrmd_new_event(rsc_id, operation, 0);
     op->type = lrmd_event_exec_complete;
-    op->op_type = strdup(operation);
     op->op_status = PCMK_LRM_OP_PENDING;
     op->rc = -1;
-    op->rsc_id = strdup(rsc_id);
-    op->interval_ms = 0;
     op->timeout = 0;
     op->start_delay = 0;
 

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -36,8 +36,6 @@ struct delete_event_s {
 static gboolean is_rsc_active(lrm_state_t * lrm_state, const char *rsc_id);
 static gboolean build_active_RAs(lrm_state_t * lrm_state, xmlNode * rsc_list);
 static gboolean stop_recurring_actions(gpointer key, gpointer value, gpointer user_data);
-static int delete_rsc_status(lrm_state_t * lrm_state, const char *rsc_id, int call_options,
-                             const char *user_name);
 
 static lrmd_event_data_t *construct_op(lrm_state_t * lrm_state, xmlNode * rsc_op,
                                        const char *rsc_id, const char *operation);
@@ -169,7 +167,8 @@ update_history_cache(lrm_state_t * lrm_state, lrmd_rsc_info_t * rsc, lrmd_event_
 
     if (op->rsc_deleted) {
         crm_debug("Purged history for '%s' after %s", op->rsc_id, op->op_type);
-        delete_rsc_status(lrm_state, op->rsc_id, cib_quorum_override, NULL);
+        controld_delete_resource_history(op->rsc_id, lrm_state->node_name,
+                                         NULL, crmd_cib_smart_opt());
         return;
     }
 
@@ -917,31 +916,6 @@ lrm_remove_deleted_op(gpointer key, gpointer value, gpointer user_data)
     return FALSE;
 }
 
-/*
- * Remove the rsc from the CIB
- *
- * Avoids refreshing the entire LRM section of this host
- */
-#define RSC_TEMPLATE "//"XML_CIB_TAG_STATE"[@uname='%s']//"XML_LRM_TAG_RESOURCE"[@id='%s']"
-
-static int
-delete_rsc_status(lrm_state_t * lrm_state, const char *rsc_id, int call_options,
-                  const char *user_name)
-{
-    char *rsc_xpath = NULL;
-    int rc = pcmk_ok;
-
-    CRM_CHECK(rsc_id != NULL, return -ENXIO);
-
-    rsc_xpath = crm_strdup_printf(RSC_TEMPLATE, lrm_state->node_name, rsc_id);
-
-    rc = cib_internal_op(fsa_cib_conn, CIB_OP_DELETE, NULL, rsc_xpath,
-                         NULL, NULL, call_options | cib_xpath, user_name);
-
-    free(rsc_xpath);
-    return rc;
-}
-
 static void
 delete_rsc_entry(lrm_state_t * lrm_state, ha_msg_input_t * input, const char *rsc_id,
                  GHashTableIter * rsc_gIter, int rc, const char *user_name)
@@ -958,7 +932,8 @@ delete_rsc_entry(lrm_state_t * lrm_state, ha_msg_input_t * input, const char *rs
         else
             g_hash_table_remove(lrm_state->resource_history, rsc_id_copy);
         crm_debug("sync: Sending delete op for %s", rsc_id_copy);
-        delete_rsc_status(lrm_state, rsc_id_copy, cib_quorum_override, user_name);
+        controld_delete_resource_history(rsc_id_copy, lrm_state->node_name,
+                                         user_name, crmd_cib_smart_opt());
 
         g_hash_table_foreach_remove(lrm_state->pending_ops, lrm_remove_deleted_op, rsc_id_copy);
         free(rsc_id_copy);
@@ -1694,21 +1669,17 @@ do_lrm_delete(ha_msg_input_t *input, lrm_state_t *lrm_state,
     gboolean unregister = TRUE;
 
 #if ENABLE_ACL
-    int cib_rc = delete_rsc_status(lrm_state, rsc->id,
-                                   cib_dryrun|cib_sync_call, user_name);
+    int cib_rc = controld_delete_resource_history(rsc->id, lrm_state->node_name,
+                                                  user_name,
+                                                  cib_dryrun|cib_sync_call);
 
-    if (cib_rc != pcmk_ok) {
+    if (cib_rc != pcmk_rc_ok) {
         lrmd_event_data_t *op = NULL;
-
-        crm_err("Could not delete resource status of %s for %s (user %s) on %s: %s"
-                CRM_XS " rc=%d",
-                rsc->id, from_sys, (user_name? user_name : "unknown"),
-                from_host, pcmk_strerror(cib_rc), cib_rc);
 
         op = construct_op(lrm_state, input->xml, rsc->id, CRMD_ACTION_DELETE);
         op->op_status = PCMK_LRM_OP_ERROR;
 
-        if (cib_rc == -EACCES) {
+        if (cib_rc == EACCES) {
             op->rc = PCMK_OCF_INSUFFICIENT_PRIV;
         } else {
             op->rc = PCMK_OCF_UNKNOWN_ERROR;

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -534,6 +534,7 @@ do_dc_join_ack(long long action,
     int join_id = -1;
     int call_id = 0;
     ha_msg_input_t *join_ack = fsa_typed_data(fsa_dt_ha_msg);
+    enum controld_section_e section = controld_section_lrm;
 
     const char *op = crm_element_value(join_ack->msg, F_CRM_TASK);
     const char *join_from = crm_element_value(join_ack->msg, F_CRM_HOST_FROM);
@@ -583,8 +584,10 @@ do_dc_join_ack(long long action,
     /* Update CIB with node's current executor state. A new transition will be
      * triggered later, when the CIB notifies us of the change.
      */
-    controld_delete_node_state(join_from, controld_section_lrm,
-                               cib_scope_local);
+    if (controld_shutdown_lock_enabled) {
+        section = controld_section_lrm_unlocked;
+    }
+    controld_delete_node_state(join_from, section, cib_scope_local);
     if (safe_str_eq(join_from, fsa_our_uname)) {
         xmlNode *now_dc_lrmd_state = controld_query_executor_state(fsa_our_uname);
 

--- a/daemons/controld/controld_lrm.h
+++ b/daemons/controld/controld_lrm.h
@@ -1,11 +1,13 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
+#ifndef CONTROLD_LRM__H
+#  define CONTROLD_LRM__H
 
 #include <controld_messages.h>
 #include <controld_metadata.h>
@@ -169,3 +171,10 @@ gboolean remote_ra_controlling_guest(lrm_state_t * lrm_state);
 
 void process_lrm_event(lrm_state_t *lrm_state, lrmd_event_data_t *op,
                        active_op_t *pending, xmlNode *action_xml);
+void controld_ack_event_directly(const char *to_host, const char *to_sys,
+                                 lrmd_rsc_info_t *rsc, lrmd_event_data_t *op,
+                                 const char *rsc_id);
+void controld_rc2event(lrmd_event_data_t *event, int rc);
+void controld_trigger_delete_refresh(const char *from_sys, const char *rsc_id);
+
+#endif

--- a/daemons/controld/controld_lrm.h
+++ b/daemons/controld/controld_lrm.h
@@ -46,6 +46,7 @@ typedef struct active_op_s {
     int call_id;
     uint32_t flags; // bitmask of active_op_e
     time_t start_time;
+    time_t lock_time;
     char *rsc_id;
     char *op_type;
     char *op_key;

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -107,6 +107,13 @@ te_crm_command(crm_graph_t * graph, crm_action_t * action)
 
     if (!router_node) {
         router_node = on_node;
+        if (safe_str_eq(task, CRM_OP_LRM_DELETE)) {
+            const char *mode = crm_element_value(action->xml, PCMK__XA_MODE);
+
+            if (safe_str_eq(mode, XML_TAG_CIB)) {
+                router_node = fsa_our_uname;
+            }
+        }
     }
 
     CRM_CHECK(on_node != NULL && strlen(on_node) != 0,

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -90,8 +90,10 @@ bool controld_action_is_recordable(const char *action);
 // Subsections of node_state
 enum controld_section_e {
     controld_section_lrm,
+    controld_section_lrm_unlocked,
     controld_section_attrs,
     controld_section_all,
+    controld_section_all_unlocked
 };
 
 void controld_delete_node_state(const char *uname,

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -95,6 +95,8 @@ enum controld_section_e {
 
 void controld_delete_node_state(const char *uname,
                                 enum controld_section_e section, int options);
+int controld_delete_resource_history(const char *rsc_id, const char *node,
+                                     const char *user_name, int call_options);
 
 const char *get_node_id(xmlNode *lrm_rsc_op);
 

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -41,6 +41,7 @@ fsa_cib_anon_update(const char *section, xmlNode *data) {
 }
 
 extern gboolean fsa_has_quorum;
+extern bool controld_shutdown_lock_enabled;
 extern int last_peer_update;
 extern int last_resource_update;
 

--- a/doc/Pacemaker_Explained/en-US/Ch-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Options.txt
@@ -389,6 +389,33 @@ rules with +date_spec+ are only guaranteed to be checked this often, and it
 also serves as a fail-safe for certain classes of scheduler bugs. A value of 0
 disables this polling; positive values are a time interval.
 
+| shutdown-lock | false |
+The default of false allows active resources to be recovered elsewhere when
+their node is cleanly shut down, which is what the vast majority of users will
+want. However, some users prefer to make resources highly available only for
+failures, with no recovery for clean shutdowns. If this option is true,
+resources active on a node when it is cleanly shut down are kept "locked" to
+that node (not allowed to run elsewhere) until they start again on that node
+after it rejoins (or for at most shutdown-lock-limit, if set). Stonith
+resources and Pacemaker Remote connections are never locked. Clone and bundle
+instances and the master role of promotable clones are currently never locked,
+though support could be added in a future release. Locks may be manually
+cleared using the `--refresh` option of `crm_resource` (both the resource and
+node must be specified; this works with remote nodes if their connection
+resource's target-role is set to Stopped, but not if Pacemaker Remote is
+stopped on the remote node without disabling the connection resource).
+indexterm:[shutdown-lock,Cluster Option]
+indexterm:[Cluster,Option,shutdown-lock]
+
+| shutdown-lock-limit | 0 |
+If shutdown-lock is true, and this is set to a nonzero time duration, locked
+resources will be allowed to start after this much time has passed since the
+node shutdown was initiated, even if the node has not rejoined. (This works
+with remote nodes only if their connection resource's target-role is set to
+Stopped.)
+indexterm:[shutdown-lock-limit,Cluster Option]
+indexterm:[Cluster,Option,shutdown-lock-limit]
+
 | remove-after-stop | FALSE |
 indexterm:[remove-after-stop,Cluster Option]
 indexterm:[Cluster,Option,remove-after-stop]

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -51,7 +51,7 @@ extern "C" {
  * >=3.0.13: Fail counts include operation name and interval
  * >=3.2.0:  DC supports PCMK_LRM_OP_INVALID and PCMK_LRM_OP_NOT_CONNECTED
  */
-#  define CRM_FEATURE_SET		"3.2.0"
+#  define CRM_FEATURE_SET		"3.3.0"
 
 #  define EOS		'\0'
 #  define DIMOF(a)	((int) (sizeof(a)/sizeof(a[0])) )

--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -248,6 +248,8 @@ typedef struct lrmd_event_data_s {
     const char *exit_reason;
 } lrmd_event_data_t;
 
+lrmd_event_data_t *lrmd_new_event(const char *rsc_id, const char *task,
+                                  guint interval_ms);
 lrmd_event_data_t *lrmd_copy_event(lrmd_event_data_t * event);
 void lrmd_free_event(lrmd_event_data_t * event);
 

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -346,6 +346,8 @@ extern "C" {
 #  define XML_CONFIG_ATTR_FORCE_QUIT	"shutdown-escalation"
 #  define XML_CONFIG_ATTR_RECHECK	"cluster-recheck-interval"
 #  define XML_CONFIG_ATTR_FENCE_REACTION	"fence-reaction"
+#  define XML_CONFIG_ATTR_SHUTDOWN_LOCK         "shutdown-lock"
+#  define XML_CONFIG_ATTR_SHUTDOWN_LOCK_LIMIT   "shutdown-lock-limit"
 
 #  define XML_ALERT_ATTR_PATH		"path"
 #  define XML_ALERT_ATTR_TIMEOUT	"timeout"

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -435,5 +435,7 @@ void pe__unpack_dataset_nvpairs(xmlNode *xml_obj, const char *set_name,
                                 pe_working_set_t *data_set);
 
 bool pe__resource_is_disabled(pe_resource_t *rsc);
+pe_action_t *pe__clear_resource_history(pe_resource_t *rsc, pe_node_t *node,
+                                        pe_working_set_t *data_set);
 
 #endif

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -102,6 +102,7 @@ enum pe_find {
 #  define pe_flag_start_failure_fatal   0x00001000ULL
 #  define pe_flag_remove_after_stop     0x00002000ULL
 #  define pe_flag_startup_fencing       0x00004000ULL
+#  define pe_flag_shutdown_lock         0x00008000ULL
 
 #  define pe_flag_startup_probes        0x00010000ULL
 #  define pe_flag_have_status           0x00020000ULL
@@ -167,6 +168,7 @@ struct pe_working_set_s {
     GList *stop_needed; // Containers that need stop actions
     time_t recheck_by;  // Hint to controller to re-run scheduler by this time
     int ninstances;     // Total number of resource instances
+    guint shutdown_lock;// How long (seconds) to lock resources to shutdown node
 };
 
 enum pe_check_parameters {

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -354,6 +354,8 @@ struct pe_resource_s {
     GListPtr fillers;
 
     pe_node_t *pending_node;    // Node on which pending_task is happening
+    pe_node_t *lock_node;       // Resource is shutdown-locked to this node
+    time_t lock_time;           // When shutdown lock started
 
 #if ENABLE_VERSIONED_ATTRS
     xmlNode *versioned_parameters;

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -287,6 +287,8 @@ enum pe_action_flags {
     pe_action_reschedule = 0x02000,
     pe_action_tracking = 0x04000,
     pe_action_dedup = 0x08000, //! Internal state tracking when creating graph
+
+    pe_action_dc = 0x10000,         //! Action may run on DC instead of target
 };
 /* *INDENT-ON* */
 

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -216,6 +216,8 @@ pid_t pcmk_locate_sbd(void);
 #  define ATTRD_OP_SYNC_RESPONSE "sync-response"
 #  define ATTRD_OP_CLEAR_FAILURE "clear-failure"
 
+#  define PCMK__XA_MODE             "mode"
+
 #  define PCMK_ENV_PHYSICAL_HOST "physical_host"
 
 

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2012-2018 David Vossel <davidvossel@gmail.com>
+ * Copyright 2012-2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -173,6 +175,36 @@ lrmd_key_value_freeall(lrmd_key_value_t * head)
         free(head);
         head = p;
     }
+}
+
+/*!
+ * Create a new lrmd_event_data_t object
+ *
+ * \param[in] rsc_id       ID of resource involved in event
+ * \param[in] task         Action name
+ * \param[in] interval_ms  Action interval
+ *
+ * \return Newly allocated and initialized lrmd_event_data_t
+ * \note This functions asserts on memory errors, so the return value is
+ *       guaranteed to be non-NULL. The caller is responsible for freeing the
+ *       result with lrmd_free_event().
+ */
+lrmd_event_data_t *
+lrmd_new_event(const char *rsc_id, const char *task, guint interval_ms)
+{
+    lrmd_event_data_t *event = calloc(1, sizeof(lrmd_event_data_t));
+
+    CRM_ASSERT(event != NULL);
+    if (rsc_id != NULL) {
+        event->rsc_id = strdup(rsc_id);
+        CRM_ASSERT(event->rsc_id != NULL);
+    }
+    if (task != NULL) {
+        event->op_type = strdup(task);
+        CRM_ASSERT(event->op_type != NULL);
+    }
+    event->interval_ms = interval_ms;
+    return event;
 }
 
 lrmd_event_data_t *

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -1026,6 +1026,7 @@ apply_shutdown_lock(pe_resource_t *rsc, pe_working_set_t *data_set)
             pe_rsc_info(rsc,
                         "Cancelling shutdown lock because %s is already active",
                         rsc->id);
+            pe__clear_resource_history(rsc, rsc->lock_node, data_set);
             rsc->lock_node = NULL;
             rsc->lock_time = 0;
         }

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -977,6 +977,87 @@ rsc_discover_filter(resource_t *rsc, node_t *node)
     }
 }
 
+static time_t
+shutdown_time(pe_node_t *node, pe_working_set_t *data_set)
+{
+    const char *shutdown = pe_node_attribute_raw(node, XML_CIB_ATTR_SHUTDOWN);
+    time_t result = 0;
+
+    if (shutdown) {
+        errno = 0;
+        result = (time_t) crm_int_helper(shutdown, NULL);
+        if (errno != 0) {
+            result = 0;
+        }
+    }
+    return result? result : get_effective_time(data_set);
+}
+
+static void
+apply_shutdown_lock(pe_resource_t *rsc, pe_working_set_t *data_set)
+{
+    const char *class;
+
+    // Only primitives and (uncloned) groups may be locked
+    if (rsc->variant == pe_group) {
+        for (GList *item = rsc->children; item != NULL;
+             item = item->next) {
+            apply_shutdown_lock((pe_resource_t *) item->data, data_set);
+        }
+    } else if (rsc->variant != pe_native) {
+        return;
+    }
+
+    // Fence devices and remote connections can't be locked
+    class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
+    if ((class == NULL) || !strcmp(class, PCMK_RESOURCE_CLASS_STONITH)
+        || pe__resource_is_remote_conn(rsc, data_set)) {
+        return;
+    }
+
+    // Only a resource active on exactly one node can be locked
+    if (pcmk__list_of_1(rsc->running_on)) {
+        pe_node_t *node = rsc->running_on->data;
+
+        if (node->details->shutdown) {
+            if (node->details->unclean) {
+                pe_rsc_debug(rsc, "Not locking %s to unclean %s for shutdown",
+                             rsc->id, node->details->uname);
+            } else {
+                rsc->lock_node = node;
+                rsc->lock_time = shutdown_time(node, data_set);
+            }
+        }
+    }
+
+    if (rsc->lock_node == NULL) {
+        // No lock needed
+        return;
+    }
+
+    if (data_set->shutdown_lock > 0) {
+        time_t lock_expiration = rsc->lock_time + data_set->shutdown_lock;
+
+        pe_rsc_info(rsc, "Locking %s to %s due to shutdown (expires @%lld)",
+                    rsc->id, rsc->lock_node->details->uname,
+                    (long long) lock_expiration);
+        pe__update_recheck_time(++lock_expiration, data_set);
+    } else {
+        pe_rsc_info(rsc, "Locking %s to %s due to shutdown",
+                    rsc->id, rsc->lock_node->details->uname);
+    }
+
+    // If resource is locked to one node, ban it from all other nodes
+    for (GList *item = data_set->nodes; item != NULL; item = item->next) {
+        pe_node_t *node = item->data;
+
+        if (strcmp(node->details->uname, rsc->lock_node->details->uname)) {
+            resource_location(rsc, node, -CRM_SCORE_INFINITY,
+                              XML_CONFIG_ATTR_SHUTDOWN_LOCK, data_set);
+        }
+    }
+}
+
 /*
  * Count how many valid nodes we have (so we know the maximum number of
  *  colors we can resolve).
@@ -987,6 +1068,12 @@ gboolean
 stage2(pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
+
+    if (is_set(data_set->flags, pe_flag_shutdown_lock)) {
+        for (gIter = data_set->resources; gIter != NULL; gIter = gIter->next) {
+            apply_shutdown_lock((pe_resource_t *) gIter->data, data_set);
+        }
+    }
 
     for (gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
         node_t *node = (node_t *) gIter->data;

--- a/lib/pacemaker/pcmk_sched_graph.c
+++ b/lib/pacemaker/pcmk_sched_graph.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -988,6 +988,26 @@ add_downed_nodes(xmlNode *xml, const action_t *action,
     }
 }
 
+static bool
+should_lock_action(pe_action_t *action)
+{
+    // Only actions taking place on resource's lock node are locked
+    if ((action->rsc->lock_node == NULL) || (action->node == NULL)
+        || (action->node->details != action->rsc->lock_node->details)) {
+        return false;
+    }
+
+    /* During shutdown, only stops are locked (otherwise, another action such as
+     * a demote would cause the controller to clear the lock)
+     */
+    if (action->node->details->shutdown && action->task
+        && strcmp(action->task, RSC_STOP)) {
+        return false;
+    }
+
+    return true;
+}
+
 static xmlNode *
 action2xml(action_t * action, gboolean as_input, pe_working_set_t *data_set)
 {
@@ -1096,6 +1116,14 @@ action2xml(action_t * action, gboolean as_input, pe_working_set_t *data_set)
             XML_AGENT_ATTR_PROVIDER,
             XML_ATTR_TYPE
         };
+
+        /* If a resource is locked to a node via shutdown-lock, mark its actions
+         * so the controller can preserve the lock when the action completes.
+         */
+        if (should_lock_action(action)) {
+            crm_xml_add_ll(action_xml, XML_CONFIG_ATTR_SHUTDOWN_LOCK,
+                           (long long) action->rsc->lock_time);
+        }
 
         // List affected resource
 

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -1403,6 +1403,12 @@ native_internal_constraints(resource_t * rsc, pe_working_set_t * data_set)
                             pe_order_runnable_left, data_set);
     }
 
+    // Don't clear resource history if probing on same node
+    custom_action_order(rsc, generate_op_key(rsc->id, CRM_OP_LRM_DELETE, 0),
+                        NULL, rsc, generate_op_key(rsc->id, RSC_STATUS, 0),
+                        NULL, pe_order_same_node|pe_order_then_cancels_first,
+                        data_set);
+
     // Certain checks need allowed nodes
     if (check_unfencing || check_utilization || rsc->container) {
         allowed_nodes = allowed_nodes_as_list(rsc, data_set);

--- a/lib/pacemaker/pcmk_sched_transition.c
+++ b/lib/pacemaker/pcmk_sched_transition.c
@@ -131,12 +131,7 @@ create_op(xmlNode *cib_resource, const char *task, guint interval_ms,
     lrmd_event_data_t *op = NULL;
     xmlNode *xop = NULL;
 
-    op = calloc(1, sizeof(lrmd_event_data_t));
-
-    op->rsc_id = strdup(ID(cib_resource));
-    op->interval_ms = interval_ms;
-    op->op_type = strdup(task);
-
+    op = lrmd_new_event(ID(cib_resource), task, interval_ms);
     op->rc = outcome;
     op->op_status = 0;
     op->params = NULL;          /* TODO: Fill me in */

--- a/lib/pacemaker/pcmk_trans_unpack.c
+++ b/lib/pacemaker/pcmk_trans_unpack.c
@@ -298,12 +298,9 @@ convert_graph_action(xmlNode * resource, crm_action_t * action, int status, int 
     CRM_CHECK(action_resource != NULL, crm_log_xml_warn(action->xml, "Bad");
               return NULL);
 
-    op = calloc(1, sizeof(lrmd_event_data_t));
-
-    op->rsc_id = strdup(ID(action_resource));
-    op->interval_ms = action->interval_ms;
-    op->op_type = strdup(crm_element_value(action->xml, XML_LRM_ATTR_TASK));
-
+    op = lrmd_new_event(ID(action_resource),
+                        crm_element_value(action->xml, XML_LRM_ATTR_TASK),
+                        action->interval_ms);
     op->rc = rc;
     op->op_status = status;
     op->t_run = time(NULL);

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -85,6 +87,26 @@ static pe_cluster_option pe_opts[] = {
 	  "When set to TRUE, the cluster will immediately ban a resource from a node if it fails to start there. When FALSE, the cluster will instead check the resource's fail count against its migration-threshold." },
 	{ "enable-startup-probes", NULL, "boolean", NULL, "true", &check_boolean,
 	  "Should the cluster check for active resources during startup", NULL },
+    {
+        XML_CONFIG_ATTR_SHUTDOWN_LOCK,
+        NULL, "boolean", NULL, "false", &check_boolean,
+        "Whether to lock resources to a cleanly shut down node",
+        "When true, resources active on a node when it is cleanly shut down "
+            "are kept \"locked\" to that node (not allowed to run elsewhere) "
+            "until they start again on that node after it rejoins (or for at "
+            "most shutdown-lock-limit, if set). Stonith resources and "
+            "Pacemaker Remote connections are never locked. Clone and bundle "
+            "instances and the master role of promotable clones are currently "
+            "never locked, though support could be added in a future release."
+    },
+    {
+        XML_CONFIG_ATTR_SHUTDOWN_LOCK_LIMIT,
+        NULL, "time", NULL, "0", &check_timer,
+        "Do not lock resources to a cleanly shut down node longer than this",
+        "If shutdown-lock is true and this is set to a nonzero time duration, "
+            "shutdown locks will expire after this much time has passed since "
+            "the shutdown was initiated, even if the node has not rejoined."
+    },
 
 	/* Stonith Options */
 	{ "stonith-enabled", NULL, "boolean", NULL, "true", &check_boolean,

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -541,6 +541,9 @@ native_output_string(pe_resource_t *rsc, const char *name, pe_node_t *node,
         provider = crm_element_value(rsc->xml, XML_AGENT_ATTR_PROVIDER);
     }
 
+    if ((node == NULL) && (rsc->lock_node != NULL)) {
+        node = rsc->lock_node;
+    }
     if (is_set(options, pe_print_rsconly)
         || pcmk__list_of_multiple(rsc->running_on)) {
         node = NULL;
@@ -582,6 +585,9 @@ native_output_string(pe_resource_t *rsc, const char *name, pe_node_t *node,
     // Flags, as: (<flag> [...])
     if (node && !(node->details->online) && node->details->unclean) {
         have_flags = add_output_flag(outstr, "UNCLEAN", have_flags);
+    }
+    if (node && (node == rsc->lock_node)) {
+        have_flags = add_output_flag(outstr, "LOCKED", have_flags);
     }
     if (is_set(options, pe_print_pending)) {
         const char *pending_task = native_pending_task(rsc);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -319,6 +319,16 @@ unpack_config(xmlNode * config, pe_working_set_t * data_set)
     data_set->placement_strategy = pe_pref(data_set->config_hash, "placement-strategy");
     crm_trace("Placement strategy: %s", data_set->placement_strategy);
 
+    set_config_flag(data_set, "shutdown-lock", pe_flag_shutdown_lock);
+    crm_trace("Resources will%s be locked to cleanly shut down nodes",
+              (is_set(data_set->flags, pe_flag_shutdown_lock)? "" : " not"));
+    if (is_set(data_set->flags, pe_flag_shutdown_lock)) {
+        value = pe_pref(data_set->config_hash,
+                        XML_CONFIG_ATTR_SHUTDOWN_LOCK_LIMIT);
+        data_set->shutdown_lock = crm_parse_interval_spec(value) / 1000;
+        crm_trace("Shutdown locks expire after %us", data_set->shutdown_lock);
+    }
+
     return TRUE;
 }
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2218,6 +2218,7 @@ unpack_shutdown_lock(xmlNode *rsc_entry, pe_resource_t *rsc, pe_node_t *node,
                 > (lock_time + data_set->shutdown_lock))) {
             pe_rsc_info(rsc, "Shutdown lock for %s on %s expired",
                         rsc->id, node->details->uname);
+            pe__clear_resource_history(rsc, node, data_set);
         } else {
             rsc->lock_node = node;
             rsc->lock_time = lock_time;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -928,6 +928,11 @@ cli_resource_check(cib_t * cib_conn, resource_t *rsc)
     }
     free(managed);
 
+    if (rsc->lock_node) {
+        printf("%s  * '%s' is locked to node %s due to shutdown\n",
+               (printed? "" : "\n"), parent->id, rsc->lock_node->details->uname);
+    }
+
     if (printed) {
         printf("\n");
     }

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -878,7 +878,7 @@ cli_cleanup_all(crm_ipc_t *crmd_channel, const char *node_name,
 void
 cli_resource_check(cib_t * cib_conn, resource_t *rsc)
 {
-    int need_nl = 0;
+    bool printed = false;
     char *role_s = NULL;
     char *managed = NULL;
     resource_t *parent = uber_parent(rsc);
@@ -897,23 +897,26 @@ cli_resource_check(cib_t * cib_conn, resource_t *rsc)
             // Treated as if unset
 
         } else if(role == RSC_ROLE_STOPPED) {
-            printf("\n  * The configuration specifies that '%s' should remain stopped\n", parent->id);
-            need_nl++;
+            printf("\n  * Configuration specifies '%s' should remain stopped\n",
+                   parent->id);
+            printed = true;
 
         } else if (is_set(parent->flags, pe_rsc_promotable)
                    && (role == RSC_ROLE_SLAVE)) {
-            printf("\n  * The configuration specifies that '%s' should not be promoted\n", parent->id);
-            need_nl++;
+            printf("\n  * Configuration specifies '%s' should not be promoted\n",
+                   parent->id);
+            printed = true;
         }
     }
 
-    if(managed && crm_is_true(managed) == FALSE) {
-        printf("%s  * The configuration prevents the cluster from stopping or starting '%s' (unmanaged)\n", need_nl == 0?"\n":"", parent->id);
-        need_nl++;
+    if (managed && !crm_is_true(managed)) {
+        printf("%s  * Configuration prevents cluster from stopping or starting unmanaged '%s'\n",
+               (printed? "" : "\n"), parent->id);
+        printed = true;
     }
     free(managed);
 
-    if(need_nl) {
+    if (printed) {
         printf("\n");
     }
 }


### PR DESCRIPTION
This "feature" is implemented for parity with proprietary high-availability software, to make it easier for users of that software to switch to open source. It is unlikely to be of interest to existing users of Pacemaker.

The scenario where this comes in useful is when an organization has a large number of clusters with an active/failover model, with a high cost (time-wise) to failing over, where host software updates and reboots are performed during scheduled maintenance windows by junior system administrators who may not have any cluster awareness. In such a case, it is desirable that high availability is only for resource failures, and resources should stop and not be recovered elsewhere for clean node shutdowns. This must happen automatically, without any administrator intervention, rather than via existing mechanisms such as temporarily setting target-role.

The solution here is a new cluster option shutdown-lock which can be set to true to enable this behavior. When enabled, it works as follows:

* Clones, bundles, Pacemaker Remote connection resources, and stonith-class resources are exempted from shutdown locks. Shutdown locks apply only to other types of primitives, and groups of them. Shutdown locks apply to cluster nodes and remote nodes, but not guest nodes, since those do not have a true shutdown (locks could theoretically be implemented for them later if there is sufficient demand, but the complexity is likely not worth it). Shutdown locks do not apply to bundle nodes either, but that doesn't matter since a bundle's resource is already locked to it inherently.

* When applying constraints, the scheduler checks for eligible resources that are running on a (single) node that is cleanly shutting down, and creates implicit -INFINITY location constraints for the resource on all other nodes. This locks the resource to the node during the transition when the node is in the process of shutting down.

* When the scheduler schedules a stop action on a node that's cleanly shutting down, or any action for a resource that's already locked to a node (generally the probe after the node rejoins), it will add "shutdown-lock" to the graph action, set to the timestamp of the shutdown request.

* When the controller receives the result of an action marked with shutdown-lock after sending it to the executor, it adds "shutdown-lock" to the action's lrm_resource entry in the CIB resource history. The value is the shutdown timestamp if the action is a successful stop or a probe finding the resource inactive, or 0 for any other result (including a start, or a probe that finds it already active), which effectively erases the lock (and aborts the transition).

* When the scheduler sees a nonzero "shutdown-lock" in lrm_resource history, it applies the same bans as mentioned earlier. This locks inactive resources to the node during transitions when the node is already down.

* When a cluster node joins or a remote node comes up, when its LRM history is normally reset, shutdown locks are preserved by clearing only entire lrm_resource entries without locks, and all lrm_rsc_op entries for lrm_resource entries with locks. This keeps the resources locked until they are started again on the node.

* Tools have been updated appropriately: crm_mon and crm_simulate will display locked resources with "LOCKED", and crm_resource --why will mention any shutdown locks.

* To handle certain corner cases, the controller IPC command CRM_OP_LRM_DELETE has been modified to behave differently when marked as mode="cib". Normally, the command is relayed to the target node, which unregisters the resource with the executor and clears the resource history from the CIB. However to be able to clear locks for nodes that are down, mode="cib" will cause the DC to handle the CIB clearing itself instead, and skip all other processing. crm_resource --refresh uses this new mode to offer a way to manually clear shutdown locks (both the resource and node must be specified).

* There is also a shutdown-lock-expiration cluster option that can be set to put an upper limit on how long a shutdown lock can last. This serves as an optional backstop in case the node never rejoins. The scheduler checks for expiration when unpacking resource history with shutdown locks. The scheduler also schedules a CRM_OP_LRM_DELETE with mode="cib" for expired locks, to ensure the locks are cleared even if no actions are scheduled on the node.

The main advantage of this implementation is that it is free of timing issues; the lock is atomic with the resource stop confirmation, and the unlock is atomic with the resource start after the node rejoins. It works whether or not there is a DC elected at any given moment in the process, and it works for remote nodes (except for lock expiration, which could be implemented for remote nodes if there is sufficient demand). Extending CRM_OP_LRM_DELETE (as opposed to a new command for clearing locks) means there are no version compatibility issues between cluster nodes and remote nodes.

Alternative implementations were considered but rejected. A less intrusive approach would be to use systemd drop-in units to run new crm_node --lock/--unlock commands that would configure existing Pacemaker location constraints. However if the unlock timed out (especially possible with remote nodes), the locks would remain in place without any obvious notice to the user, it would not work unless systemd is used to start and stop pacemaker (not for example if SIGTERM were received by some other mechanism, or crmadmin -K were sent), and there are possible time-of-check/time-of-use issues. Another approach considered was a new transient constraints section; the scheduler would pass the necessary constraints to the controller, which would modify the CIB before stop and after start. However not being atomic with the stop and start, it would have potential timing issues, and would have more of a chance of locks getting "stuck".