### PR TITLE
Fix: libpe_status: Add resource-header messages for other formats.

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -146,7 +146,6 @@ int pe__node_attribute_text(pcmk__output_t *out, va_list args);
 int pe__node_attribute_xml(pcmk__output_t *out, va_list args);
 int pe__op_history_text(pcmk__output_t *out, va_list args);
 int pe__op_history_xml(pcmk__output_t *out, va_list args);
-int pe__resource_header_text(pcmk__output_t *out, va_list args);
 int pe__resource_history_text(pcmk__output_t *out, va_list args);
 int pe__resource_history_xml(pcmk__output_t *out, va_list args);
 int pe__resource_xml(pcmk__output_t *out, va_list args);

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1100,21 +1100,6 @@ pe__op_history_xml(pcmk__output_t *out, va_list args) {
 }
 
 int
-pe__resource_header_text(pcmk__output_t *out, va_list args) {
-    resource_t *rsc = va_arg(args, resource_t *);
-    const char *rsc_id = va_arg(args, const char *);
-    gboolean all = va_arg(args, gboolean);
-    int failcount = va_arg(args, int);
-    time_t last_failure = va_arg(args, int);
-
-    char *buf = resource_history_string(rsc, rsc_id, all, failcount, last_failure);
-
-    out->begin_list(out, NULL, NULL, "%s", buf);
-    free(buf);
-    return 0;
-}
-
-int
 pe__resource_history_text(pcmk__output_t *out, va_list args) {
     resource_t *rsc = va_arg(args, resource_t *);
     const char *rsc_id = va_arg(args, const char *);
@@ -1124,7 +1109,7 @@ pe__resource_history_text(pcmk__output_t *out, va_list args) {
 
     char *buf = resource_history_string(rsc, rsc_id, all, failcount, last_failure);
 
-    out->list_item(out, NULL, "%s", buf);
+    out->begin_list(out, NULL, NULL, "%s", buf);
     free(buf);
     return 0;
 }
@@ -1281,7 +1266,6 @@ static pcmk__message_entry_t fmt_functions[] = {
     { "primitive", "html",  pe__resource_html },
     { "primitive", "text",  pe__resource_text },
     { "primitive", "log",  pe__resource_text },
-    { "resource-header", "text", pe__resource_header_text },
     { "resource-history", "html", pe__resource_history_text },
     { "resource-history", "log", pe__resource_history_text },
     { "resource-history", "text", pe__resource_history_text },

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1106,10 +1106,16 @@ pe__resource_history_text(pcmk__output_t *out, va_list args) {
     gboolean all = va_arg(args, gboolean);
     int failcount = va_arg(args, int);
     time_t last_failure = va_arg(args, int);
+    gboolean as_header = va_arg(args, gboolean);
 
     char *buf = resource_history_string(rsc, rsc_id, all, failcount, last_failure);
 
-    out->begin_list(out, NULL, NULL, "%s", buf);
+    if (as_header) {
+        out->begin_list(out, NULL, NULL, "%s", buf);
+    } else {
+        out->list_item(out, NULL, "%s", buf);
+    }
+
     free(buf);
     return 0;
 }
@@ -1121,6 +1127,7 @@ pe__resource_history_xml(pcmk__output_t *out, va_list args) {
     gboolean all = va_arg(args, gboolean);
     int failcount = va_arg(args, int);
     time_t last_failure = va_arg(args, int);
+    gboolean as_header G_GNUC_UNUSED = va_arg(args, gboolean);
 
     xmlNodePtr node = pcmk__output_xml_create_parent(out, "resource_history");
     xmlSetProp(node, (pcmkXmlStr) "id", (pcmkXmlStr) rsc_id);

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -340,7 +340,6 @@ static pcmk__message_entry_t fmt_functions[] = {
     { "node-attribute", "console", pe__node_attribute_text },
     { "op-history", "console", pe__op_history_text },
     { "primitive", "console", pe__resource_text },
-    { "resource-header", "console", pe__resource_history_text },
     { "resource-history", "console", pe__resource_history_text },
     { "stonith-event", "console", stonith_event_console },
     { "ticket", "console", pe__ticket_text },

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -264,7 +264,7 @@ print_rsc_history(pcmk__output_t *out, pe_working_set_t *data_set, node_t *node,
             time_t last_failure = 0;
             int failcount = failure_count(data_set, node, rsc, &last_failure);
 
-            out->message(out, "resource-history", rsc, rsc_id, TRUE, failcount, last_failure);
+            out->message(out, "resource-history", rsc, rsc_id, TRUE, failcount, last_failure, TRUE);
             printed = TRUE;
         }
 
@@ -326,8 +326,7 @@ print_node_history(pcmk__output_t *out, pe_working_set_t *data_set,
                         }
 
                         out->message(out, "resource-history", rsc, rsc_id, FALSE,
-                                     failcount, last_failure);
-                        out->end_list(out);
+                                     failcount, last_failure, FALSE);
                     }
                 } else {
                     GListPtr op_list = get_operation_list(rsc_entry);

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -264,7 +264,7 @@ print_rsc_history(pcmk__output_t *out, pe_working_set_t *data_set, node_t *node,
             time_t last_failure = 0;
             int failcount = failure_count(data_set, node, rsc, &last_failure);
 
-            out->message(out, "resource-header", rsc, rsc_id, TRUE, failcount, last_failure);
+            out->message(out, "resource-history", rsc, rsc_id, TRUE, failcount, last_failure);
             printed = TRUE;
         }
 


### PR DESCRIPTION
Previously, I had changed print_rsc_history to call the new
resource-header message instead of resource-history.  The thinking there
was the previous message was being used in two different ways and we
needed two different messages to cover each case.

However, this change means that all the non-text formats are calling a
non-existent resource-header message and not getting anything output
here at all.  For these formats, I still want the old message to be
called.  There are a couple ways to accomplish this, but it seems like
the easiest is to just have the resource-header message go to the same
place that resource-history does.

Note that this means the handlers for those two messages must always
take the same arguments.