### PR TITLE
Fix: rectify thinko possibly behind spurious "process will not die" msg

### DIFF
--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -1075,7 +1075,7 @@ child_timeout_callback(gpointer p)
     }
 
     rc = child_kill_helper(child);
-    if (rc == ESRCH) {
+    if (rc == -ESRCH) {
         /* Nothing left to do. pid doesn't exist */
         return FALSE;
     }


### PR DESCRIPTION
Problem of not explicating how exactly the function is supposed to
behave that would allow for a straightforward cross-check, as opposed
to examining the callers into full depth that often gets substituted
with guestimation.