### PR TITLE
Abstract controller API from crm_resource

### DIFF
--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -118,18 +118,6 @@ attrd_ipc_accept(qb_ipcs_connection_t *c, uid_t uid, gid_t gid)
 
 /*!
  * \internal
- * \brief Callback for successful client connection
- *
- * \param[in] c  New connection
- */
-static void
-attrd_ipc_created(qb_ipcs_connection_t *c)
-{
-    crm_trace("Client connection %p accepted", c);
-}
-
-/*!
- * \internal
  * \brief Destroy a client IPC connection
  *
  * \param[in] c  Connection to destroy
@@ -179,7 +167,7 @@ attrd_init_ipc(qb_ipcs_service_t **ipcs, qb_ipcs_msg_process_fn dispatch_fn)
 
     static struct qb_ipcs_service_handlers ipc_callbacks = {
         .connection_accept = attrd_ipc_accept,
-        .connection_created = attrd_ipc_created,
+        .connection_created = NULL,
         .msg_process = NULL,
         .connection_closed = attrd_ipc_closed,
         .connection_destroyed = attrd_ipc_destroy

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -250,7 +250,7 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
         crm_debug("No IPC data from PID %d", pcmk__client_pid(c));
         return 0;
     }
-    xml = pcmk__client_data2xml(client, data, size, &id, &flags);
+    xml = pcmk__client_data2xml(client, data, &id, &flags);
     if (xml == NULL) {
         crm_debug("Unrecognizable IPC data from PID %d", pcmk__client_pid(c));
         return 0;
@@ -260,8 +260,6 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
     CRM_ASSERT(client->user != NULL);
     crm_acl_get_set_user(xml, F_ATTRD_USER, client->user);
 #endif
-
-    crm_log_xml_trace(xml, __FUNCTION__);
 
     op = crm_element_value(xml, F_ATTRD_TASK);
 

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -207,8 +207,7 @@ cib_common_callback(qb_ipcs_connection_t * c, void *data, size_t size, gboolean 
     uint32_t flags = 0;
     int call_options = 0;
     pcmk__client_t *cib_client = pcmk__find_client(c);
-    xmlNode *op_request = pcmk__client_data2xml(cib_client, data, size, &id,
-                                                &flags);
+    xmlNode *op_request = pcmk__client_data2xml(cib_client, data, &id, &flags);
 
     if (op_request) {
         crm_element_value_int(op_request, F_CIB_CALLOPTS, &call_options);
@@ -260,8 +259,6 @@ cib_common_callback(qb_ipcs_connection_t * c, void *data, size_t size, gboolean 
     CRM_LOG_ASSERT(cib_client->user != NULL);
     crm_acl_get_set_user(op_request, F_CIB_USER, cib_client->user);
 #endif
-
-    crm_log_xml_trace(op_request, "Client[inbound]");
 
     cib_common_callback_worker(id, flags, op_request, cib_client, privileged);
     free_xml(op_request);

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -81,12 +81,6 @@ cib_ipc_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid)
     return 0;
 }
 
-static void
-cib_ipc_created(qb_ipcs_connection_t * c)
-{
-    crm_trace("Connection %p", c);
-}
-
 static int32_t
 cib_ipc_dispatch_rw(qb_ipcs_connection_t * c, void *data, size_t size)
 {
@@ -131,7 +125,7 @@ cib_ipc_destroy(qb_ipcs_connection_t * c)
 
 struct qb_ipcs_service_handlers ipc_ro_callbacks = {
     .connection_accept = cib_ipc_accept,
-    .connection_created = cib_ipc_created,
+    .connection_created = NULL,
     .msg_process = cib_ipc_dispatch_ro,
     .connection_closed = cib_ipc_closed,
     .connection_destroyed = cib_ipc_destroy
@@ -139,7 +133,7 @@ struct qb_ipcs_service_handlers ipc_ro_callbacks = {
 
 struct qb_ipcs_service_handlers ipc_rw_callbacks = {
     .connection_accept = cib_ipc_accept,
-    .connection_created = cib_ipc_created,
+    .connection_created = NULL,
     .msg_process = cib_ipc_dispatch_rw,
     .connection_closed = cib_ipc_closed,
     .connection_destroyed = cib_ipc_destroy

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -364,12 +364,6 @@ crmd_ipc_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid)
     return 0;
 }
 
-static void
-crmd_ipc_created(qb_ipcs_connection_t * c)
-{
-    crm_trace("Connection %p", c);
-}
-
 static int32_t
 crmd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
 {
@@ -446,7 +440,7 @@ do_started(long long action,
 {
     static struct qb_ipcs_service_handlers crmd_callbacks = {
         .connection_accept = crmd_ipc_accept,
-        .connection_created = crmd_ipc_created,
+        .connection_created = NULL,
         .msg_process = crmd_ipc_dispatch,
         .connection_closed = crmd_ipc_closed,
         .connection_destroyed = crmd_ipc_destroy

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -373,7 +373,7 @@ dispatch_controller_ipc(qb_ipcs_connection_t * c, void *data, size_t size)
     uint32_t flags = 0;
     pcmk__client_t *client = pcmk__find_client(c);
 
-    xmlNode *msg = pcmk__client_data2xml(client, data, size, &id, &flags);
+    xmlNode *msg = pcmk__client_data2xml(client, data, &id, &flags);
 
     pcmk__ipc_send_ack(client, id, flags, "ack");
     if (msg == NULL) {
@@ -385,7 +385,6 @@ dispatch_controller_ipc(qb_ipcs_connection_t * c, void *data, size_t size)
     crm_acl_get_set_user(msg, F_CRM_USER, client->user);
 #endif
 
-    crm_log_xml_trace(msg, "controller[inbound]");
     crm_xml_add(msg, F_CRM_SYS_FROM, client->id);
     if (controld_authorize_ipc_message(msg, client, NULL)) {
         crm_trace("Processing IPC message from %s", pcmk__client_name(client));

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -391,11 +391,11 @@ crmd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
     crm_acl_get_set_user(msg, F_CRM_USER, client->user);
 #endif
 
-    crm_trace("Processing msg from %s", pcmk__client_name(client));
+    crm_trace("Processing IPC message from %s", pcmk__client_name(client));
     crm_log_xml_trace(msg, "controller[inbound]");
 
     crm_xml_add(msg, F_CRM_SYS_FROM, client->id);
-    if (crmd_authorize_message(msg, client, NULL)) {
+    if (controld_authorize_ipc_message(msg, client, NULL)) {
         route_message(C_IPC_MESSAGE, msg);
     }
 

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -435,14 +435,12 @@ crmd_proxy_send(const char *session, xmlNode *msg)
 static void
 crmd_proxy_dispatch(const char *session, xmlNode *msg)
 {
-
-    crm_log_xml_trace(msg, "controller-proxy[inbound]");
-
+    crm_trace("Processing proxied IPC message from session %s", session);
+    crm_log_xml_trace(msg, "controller[inbound]");
     crm_xml_add(msg, F_CRM_SYS_FROM, session);
-    if (crmd_authorize_message(msg, NULL, session)) {
+    if (controld_authorize_ipc_message(msg, NULL, session)) {
         route_message(C_IPC_MESSAGE, msg);
     }
-
     trigger_fsa(fsa_source);
 }
 

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -31,8 +31,7 @@ static void handle_response(xmlNode *stored_msg);
 static enum crmd_fsa_input handle_request(xmlNode *stored_msg,
                                           enum crmd_fsa_cause cause);
 static enum crmd_fsa_input handle_shutdown_request(xmlNode *stored_msg);
-
-#define ROUTER_RESULT(x)	crm_trace("Router result: %s", x)
+static void send_msg_via_ipc(xmlNode * msg, const char *sys);
 
 /* debug only, can wrap all it likes */
 int last_data_id = 0;
@@ -97,9 +96,10 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
     }
 
     last_data_id++;
-    crm_trace("%s %s FSA input %d (%s) (cause=%s) %s data",
-              raised_from, prepend ? "prepended" : "appended", last_data_id,
-              fsa_input2string(input), fsa_cause2string(cause), data ? "with" : "without");
+    crm_trace("%s %s FSA input %d (%s) due to %s, %s data",
+              raised_from, (prepend? "prepended" : "appended"), last_data_id,
+              fsa_input2string(input), fsa_cause2string(cause),
+              (data? "with" : "without"));
 
     fsa_data = calloc(1, sizeof(fsa_data_t));
     fsa_data->id = last_data_id;
@@ -120,10 +120,10 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
             case C_CRMD_STATUS_CALLBACK:
             case C_IPC_MESSAGE:
             case C_HA_MESSAGE:
-                crm_trace("Copying %s data from %s as a HA msg",
-                          fsa_cause2string(cause), raised_from);
                 CRM_CHECK(((ha_msg_input_t *) data)->msg != NULL,
                           crm_err("Bogus data from %s", raised_from));
+                crm_trace("Copying %s data from %s as cluster message data",
+                          fsa_cause2string(cause), raised_from);
                 fsa_data->data = copy_ha_msg_input(data);
                 fsa_data->data_type = fsa_dt_ha_msg;
                 break;
@@ -139,23 +139,22 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
             case C_SHUTDOWN:
             case C_UNKNOWN:
             case C_STARTUP:
-                crm_err("Copying %s data (from %s)"
-                        " not yet implemented", fsa_cause2string(cause), raised_from);
+                crm_crit("Copying %s data (from %s) is not yet implemented",
+                         fsa_cause2string(cause), raised_from);
                 crmd_exit(CRM_EX_SOFTWARE);
                 break;
         }
-        crm_trace("%s data copied", fsa_cause2string(fsa_data->fsa_cause));
     }
 
     /* make sure to free it properly later */
     if (prepend) {
-        crm_trace("Prepending input");
         fsa_message_queue = g_list_prepend(fsa_message_queue, fsa_data);
     } else {
         fsa_message_queue = g_list_append(fsa_message_queue, fsa_data);
     }
 
-    crm_trace("Queue len: %d", g_list_length(fsa_message_queue));
+    crm_trace("FSA message queue length is %d",
+              g_list_length(fsa_message_queue));
 
     /* fsa_dump_queue(LOG_TRACE); */
 
@@ -164,7 +163,7 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
     }
 
     if (fsa_source && input != I_WAIT_FOR_EVENT) {
-        crm_trace("Triggering FSA: %s", __FUNCTION__);
+        crm_trace("Triggering FSA");
         mainloop_set_trigger(fsa_source);
     }
     return last_data_id;
@@ -190,20 +189,11 @@ fsa_dump_queue(int log_level)
 ha_msg_input_t *
 copy_ha_msg_input(ha_msg_input_t * orig)
 {
-    ha_msg_input_t *copy = NULL;
-    xmlNodePtr data = NULL;
+    ha_msg_input_t *copy = calloc(1, sizeof(ha_msg_input_t));
 
-    if (orig != NULL) {
-        crm_trace("Copy msg");
-        data = copy_xml(orig->msg);
-
-    } else {
-        crm_trace("No message to copy");
-    }
-    copy = new_ha_msg_input(data);
-    if (orig && orig->msg != NULL) {
-        CRM_CHECK(copy->msg != NULL, crm_err("copy failed"));
-    }
+    CRM_ASSERT(copy != NULL);
+    copy->msg = (orig && orig->msg)? copy_xml(orig->msg) : NULL;
+    copy->xml = get_message_xml(copy->msg, F_CRM_DATA);
     return copy;
 }
 
@@ -418,39 +408,39 @@ relay_message(xmlNode * msg, gboolean originated_locally)
 
     if (is_for_dc || is_for_dcib || is_for_te) {
         if (AM_I_DC && is_for_te) {
-            ROUTER_RESULT("Message result: Local relay");
+            crm_trace("Message routing: Process locally as transition request");
             send_msg_via_ipc(msg, sys_to);
 
         } else if (AM_I_DC) {
-            ROUTER_RESULT("Message result: DC/controller process");
+            crm_trace("Message routing: Process locally as DC request");
             processing_complete = FALSE;        /* more to be done by caller */
         } else if (originated_locally && safe_str_neq(sys_from, CRM_SYSTEM_PENGINE)
                    && safe_str_neq(sys_from, CRM_SYSTEM_TENGINE)) {
-
-            /* Neither the TE nor the scheduler should be sending messages
-             * to DCs on other nodes. By definition, if we are no longer the DC,
-             * then the scheduler's or TE's data should be discarded.
-             */
 
 #if SUPPORT_COROSYNC
             if (is_corosync_cluster()) {
                 dest = text2msg_type(sys_to);
             }
 #endif
-            ROUTER_RESULT("Message result: External relay to DC");
+            crm_trace("Message routing: Relay to DC");
             send_cluster_message(host_to ? crm_get_peer(0, host_to) : NULL, dest, msg, TRUE);
 
         } else {
-            /* discard */
-            ROUTER_RESULT("Message result: Discard, not DC");
+            /* Neither the TE nor the scheduler should be sending messages
+             * to DCs on other nodes. By definition, if we are no longer the DC,
+             * then the scheduler's or TE's data should be discarded.
+             */
+            crm_trace("Message routing: Discard because we are not DC");
         }
 
     } else if (is_local && (is_for_crm || is_for_cib)) {
-        ROUTER_RESULT("Message result: controller process");
+        crm_trace("Message routing: Process locally as controller request");
         processing_complete = FALSE;    /* more to be done by caller */
 
     } else if (is_local) {
-        ROUTER_RESULT("Message result: Local relay");
+        crm_trace("Message routing: Local relay to %s",
+                  (sys_to? sys_to : "unknown client"));
+        crm_log_xml_trace(msg, "[IPC relay]");
         send_msg_via_ipc(msg, sys_to);
 
     } else {
@@ -472,9 +462,11 @@ relay_message(xmlNode * msg, gboolean originated_locally)
                crm_err("Cannot route message to unknown node %s", host_to);
                return TRUE;
             }
+            crm_trace("Message routing: Relay to %s",
+                      (node_to->uname? node_to->uname : "peer"));
+        } else {
+            crm_trace("Message routing: Relay to all peers");
         }
-
-        ROUTER_RESULT("Message result: External relay");
         send_cluster_message(host_to ? node_to : NULL, dest, msg, TRUE);
     }
 
@@ -877,7 +869,7 @@ handle_request(xmlNode *stored_msg, enum crmd_fsa_cause cause)
     /* Optimize this for the DC - it has the most to do */
 
     if (op == NULL) {
-        crm_log_xml_err(stored_msg, "Bad message");
+        crm_log_xml_warn(stored_msg, "[request without " F_CRM_TASK "]");
         return I_NULL;
     }
 
@@ -1133,10 +1125,9 @@ handle_shutdown_request(xmlNode * stored_msg)
 /* msg is deleted by the time this returns */
 extern gboolean process_te_message(xmlNode * msg, xmlNode * xml_data);
 
-gboolean
+static void
 send_msg_via_ipc(xmlNode * msg, const char *sys)
 {
-    gboolean send_ok = TRUE;
     pcmk__client_t *client_channel = pcmk__find_client_by_id(sys);
 
     if (crm_element_value(msg, F_CRM_HOST_FROM) == NULL) {
@@ -1145,10 +1136,7 @@ send_msg_via_ipc(xmlNode * msg, const char *sys)
 
     if (client_channel != NULL) {
         /* Transient clients such as crmadmin */
-        if (pcmk__ipc_send_xml(client_channel, 0, msg,
-                               crm_ipc_server_event) != pcmk_rc_ok) {
-            send_ok = FALSE;
-        }
+        pcmk__ipc_send_xml(client_channel, 0, msg, crm_ipc_server_event);
 
     } else if (sys != NULL && strcmp(sys, CRM_SYSTEM_TENGINE) == 0) {
         xmlNode *data = get_message_xml(msg, F_CRM_DATA);
@@ -1170,9 +1158,6 @@ send_msg_via_ipc(xmlNode * msg, const char *sys)
         fsa_data.origin = __FUNCTION__;
         fsa_data.data_type = fsa_dt_ha_msg;
 
-#ifdef FSA_TRACE
-        crm_trace("Invoking action A_LRM_INVOKE (%.16llx)", A_LRM_INVOKE);
-#endif
         do_lrm_invoke(A_LRM_INVOKE, C_IPC_MESSAGE, fsa_state, I_MESSAGE, &fsa_data);
 
     } else if (sys != NULL && crmd_is_proxy_session(sys)) {
@@ -1180,21 +1165,7 @@ send_msg_via_ipc(xmlNode * msg, const char *sys)
 
     } else {
         crm_debug("Unknown Sub-system (%s)... discarding message.", crm_str(sys));
-        send_ok = FALSE;
     }
-
-    return send_ok;
-}
-
-ha_msg_input_t *
-new_ha_msg_input(xmlNode * orig)
-{
-    ha_msg_input_t *input_copy = NULL;
-
-    input_copy = calloc(1, sizeof(ha_msg_input_t));
-    input_copy->msg = orig;
-    input_copy->xml = get_message_xml(input_copy->msg, F_CRM_DATA);
-    return input_copy;
 }
 
 void

--- a/daemons/controld/controld_messages.h
+++ b/daemons/controld/controld_messages.h
@@ -80,9 +80,9 @@ extern gboolean send_msg_via_ipc(xmlNode * msg, const char *sys);
 gboolean crmd_is_proxy_session(const char *session);
 void crmd_proxy_send(const char *session, xmlNode *msg);
 
-gboolean crmd_authorize_message(xmlNode *client_msg,
-                                pcmk__client_t *curr_client,
-                                const char *proxy_session);
+bool controld_authorize_ipc_message(xmlNode *client_msg,
+                                    pcmk__client_t *curr_client,
+                                    const char *proxy_session);
 
 extern gboolean send_request(xmlNode * msg, char **msg_reference);
 

--- a/daemons/controld/controld_messages.h
+++ b/daemons/controld/controld_messages.h
@@ -75,8 +75,6 @@ fsa_data_t *get_message(void);
 
 extern gboolean relay_message(xmlNode * relay_message, gboolean originated_locally);
 
-extern gboolean send_msg_via_ipc(xmlNode * msg, const char *sys);
-
 gboolean crmd_is_proxy_session(const char *session);
 void crmd_proxy_send(const char *session, xmlNode *msg);
 

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1841,8 +1841,7 @@ process_lrmd_message(pcmk__client_t *client, uint32_t id, xmlNode *request)
     } else {
         rc = -EOPNOTSUPP;
         do_reply = 1;
-        crm_err("Unknown %s from %s", op, client->name);
-        crm_log_xml_warn(request, "UnknownOp");
+        crm_err("Unknown IPC request '%s' from %s", op, client->name);
     }
 
     crm_debug("Processed %s operation from %s: rc=%d, reply=%d, notify=%d",

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -111,7 +111,7 @@ lrmd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
     uint32_t id = 0;
     uint32_t flags = 0;
     pcmk__client_t *client = pcmk__find_client(c);
-    xmlNode *request = pcmk__client_data2xml(client, data, size, &id, &flags);
+    xmlNode *request = pcmk__client_data2xml(client, data, &id, &flags);
 
     CRM_CHECK(client != NULL, crm_err("Invalid client");
               return FALSE);

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -132,12 +132,6 @@ cib_proxy_accept_ro(qb_ipcs_connection_t * c, uid_t uid, gid_t gid)
     return ipc_proxy_accept(c, uid, gid, CIB_CHANNEL_RO);
 }
 
-static void
-ipc_proxy_created(qb_ipcs_connection_t * c)
-{
-    crm_trace("Connection %p", c);
-}
-
 void
 ipc_proxy_forward_client(pcmk__client_t *ipc_proxy, xmlNode *xml)
 {
@@ -335,7 +329,7 @@ ipc_proxy_destroy(qb_ipcs_connection_t * c)
 
 static struct qb_ipcs_service_handlers crmd_proxy_callbacks = {
     .connection_accept = crmd_proxy_accept,
-    .connection_created = ipc_proxy_created,
+    .connection_created = NULL,
     .msg_process = ipc_proxy_dispatch,
     .connection_closed = ipc_proxy_closed,
     .connection_destroyed = ipc_proxy_destroy
@@ -343,7 +337,7 @@ static struct qb_ipcs_service_handlers crmd_proxy_callbacks = {
 
 static struct qb_ipcs_service_handlers attrd_proxy_callbacks = {
     .connection_accept = attrd_proxy_accept,
-    .connection_created = ipc_proxy_created,
+    .connection_created = NULL,
     .msg_process = ipc_proxy_dispatch,
     .connection_closed = ipc_proxy_closed,
     .connection_destroyed = ipc_proxy_destroy
@@ -351,7 +345,7 @@ static struct qb_ipcs_service_handlers attrd_proxy_callbacks = {
 
 static struct qb_ipcs_service_handlers stonith_proxy_callbacks = {
     .connection_accept = stonith_proxy_accept,
-    .connection_created = ipc_proxy_created,
+    .connection_created = NULL,
     .msg_process = ipc_proxy_dispatch,
     .connection_closed = ipc_proxy_closed,
     .connection_destroyed = ipc_proxy_destroy
@@ -359,7 +353,7 @@ static struct qb_ipcs_service_handlers stonith_proxy_callbacks = {
 
 static struct qb_ipcs_service_handlers cib_proxy_callbacks_ro = {
     .connection_accept = cib_proxy_accept_ro,
-    .connection_created = ipc_proxy_created,
+    .connection_created = NULL,
     .msg_process = ipc_proxy_dispatch,
     .connection_closed = ipc_proxy_closed,
     .connection_destroyed = ipc_proxy_destroy
@@ -367,7 +361,7 @@ static struct qb_ipcs_service_handlers cib_proxy_callbacks_ro = {
 
 static struct qb_ipcs_service_handlers cib_proxy_callbacks_rw = {
     .connection_accept = cib_proxy_accept_rw,
-    .connection_created = ipc_proxy_created,
+    .connection_created = NULL,
     .msg_process = ipc_proxy_dispatch,
     .connection_closed = ipc_proxy_closed,
     .connection_destroyed = ipc_proxy_destroy

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -234,7 +234,7 @@ ipc_proxy_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
      * This function is receiving a request from connection
      * 1 and forwarding it to connection 2.
      */
-    request = pcmk__client_data2xml(client, data, size, &id, &flags);
+    request = pcmk__client_data2xml(client, data, &id, &flags);
 
     if (!request) {
         return 0;

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2641,8 +2641,8 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
         return pcmk_ok;
 
     } else {
-        crm_err("Unknown %s from %s", op, client ? client->name : remote_peer);
-        crm_log_xml_warn(request, "UnknownOp");
+        crm_err("Unknown IPC request %s from %s",
+                op, (client? client->name : remote_peer));
     }
 
   done:

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -74,12 +74,6 @@ st_ipc_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid)
     return 0;
 }
 
-static void
-st_ipc_created(qb_ipcs_connection_t * c)
-{
-    crm_trace("Connection created for %p", c);
-}
-
 /* Exit code means? */
 static int32_t
 st_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
@@ -1227,7 +1221,7 @@ setup_cib(void)
 
 struct qb_ipcs_service_handlers ipc_callbacks = {
     .connection_accept = st_ipc_accept,
-    .connection_created = st_ipc_created,
+    .connection_created = NULL,
     .msg_process = st_ipc_dispatch,
     .connection_closed = st_ipc_closed,
     .connection_destroyed = st_ipc_destroy

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -90,7 +90,7 @@ st_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
         return 0;
     }
 
-    request = pcmk__client_data2xml(c, data, size, &id, &flags);
+    request = pcmk__client_data2xml(c, data, &id, &flags);
     if (request == NULL) {
         pcmk__ipc_send_ack(c, id, flags, "nack");
         return 0;
@@ -133,7 +133,6 @@ st_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
     crm_xml_add(request, F_STONITH_CLIENTNAME, pcmk__client_name(c));
     crm_xml_add(request, F_STONITH_CLIENTNODE, stonith_our_uname);
 
-    crm_log_xml_trace(request, "Client[inbound]");
     stonith_command(c, id, flags, request, NULL);
 
     free_xml(request);

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -557,7 +557,7 @@ pcmk_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
     uint32_t flags = 0;
     const char *task = NULL;
     pcmk__client_t *c = pcmk__find_client(qbc);
-    xmlNode *msg = pcmk__client_data2xml(c, data, size, &id, &flags);
+    xmlNode *msg = pcmk__client_data2xml(c, data, &id, &flags);
 
     pcmk__ipc_send_ack(c, id, flags, "ack");
     if (msg == NULL) {

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -549,12 +549,6 @@ pcmk_ipc_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid)
     return 0;
 }
 
-static void
-pcmk_ipc_created(qb_ipcs_connection_t * c)
-{
-    crm_trace("Connection %p", c);
-}
-
 /* Exit code means? */
 static int32_t
 pcmk_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
@@ -623,7 +617,7 @@ pcmk_ipc_destroy(qb_ipcs_connection_t * c)
 
 struct qb_ipcs_service_handlers mcp_ipc_callbacks = {
     .connection_accept = pcmk_ipc_accept,
-    .connection_created = pcmk_ipc_created,
+    .connection_created = NULL,
     .msg_process = pcmk_ipc_dispatch,
     .connection_closed = pcmk_ipc_closed,
     .connection_destroyed = pcmk_ipc_destroy

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -214,12 +214,6 @@ pe_ipc_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid)
     return 0;
 }
 
-static void
-pe_ipc_created(qb_ipcs_connection_t * c)
-{
-    crm_trace("Connection %p", c);
-}
-
 gboolean process_pe_message(xmlNode *msg, xmlNode *xml_data,
                             pcmk__client_t *sender);
 
@@ -264,7 +258,7 @@ pe_ipc_destroy(qb_ipcs_connection_t * c)
 
 struct qb_ipcs_service_handlers ipc_callbacks = {
     .connection_accept = pe_ipc_accept,
-    .connection_created = pe_ipc_created,
+    .connection_created = NULL,
     .msg_process = pe_ipc_dispatch,
     .connection_closed = pe_ipc_closed,
     .connection_destroyed = pe_ipc_destroy

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -223,7 +223,7 @@ pe_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
     uint32_t id = 0;
     uint32_t flags = 0;
     pcmk__client_t *c = pcmk__find_client(qbc);
-    xmlNode *msg = pcmk__client_data2xml(c, data, size, &id, &flags);
+    xmlNode *msg = pcmk__client_data2xml(c, data, &id, &flags);
 
     pcmk__ipc_send_ack(c, id, flags, "ack");
     if (msg != NULL) {

--- a/include/crm/common/ipcs_internal.h
+++ b/include/crm/common/ipcs_internal.h
@@ -121,7 +121,7 @@ int pcmk__ipc_prepare_iov(uint32_t request, xmlNode *message,
 int pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request, xmlNode *message,
                        uint32_t flags);
 int pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags);
-xmlNode *pcmk__client_data2xml(pcmk__client_t *c, void *data, size_t size,
+xmlNode *pcmk__client_data2xml(pcmk__client_t *c, void *data,
                                uint32_t *id, uint32_t *flags);
 
 int pcmk__client_pid(qb_ipcs_connection_t *c);

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -425,7 +425,7 @@ pcmk__new_client(qb_ipcs_connection_t *c, uid_t uid_client, gid_t gid_client)
     }
 
     if (uid_client != 0) {
-        crm_trace("Giving access to group %u", gid_cluster);
+        crm_trace("Giving group %u access to new IPC connection", gid_cluster);
         /* Passing -1 to chown(2) means don't change */
         qb_ipcs_connection_auth_set(c, -1, gid_cluster, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
     }
@@ -441,8 +441,8 @@ pcmk__new_client(qb_ipcs_connection_t *c, uid_t uid_client, gid_t gid_client)
         set_bit(client->flags, pcmk__client_privileged);
     }
 
-    crm_debug("Connecting %p for uid=%d gid=%d pid=%u id=%s", c, uid_client, gid_client, client->pid, client->id);
-
+    crm_debug("New IPC client %s for PID %u with uid %d and gid %d",
+              client->id, client->pid, uid_client, gid_client);
     return client;
 }
 

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -1680,23 +1680,35 @@ create_hello_message(const char *uuid,
     xmlNode *hello_node = NULL;
     xmlNode *hello = NULL;
 
-    if (uuid == NULL || strlen(uuid) == 0
-        || client_name == NULL || strlen(client_name) == 0
-        || major_version == NULL || strlen(major_version) == 0
-        || minor_version == NULL || strlen(minor_version) == 0) {
-        crm_err("Missing fields, Hello message will not be valid.");
+    if (crm_strlen_zero(uuid) || crm_strlen_zero(client_name)
+        || crm_strlen_zero(major_version) || crm_strlen_zero(minor_version)) {
+        crm_err("Could not create IPC hello message from %s (UUID %s): "
+                "missing information",
+                client_name? client_name : "unknown client",
+                uuid? uuid : "unknown");
         return NULL;
     }
 
     hello_node = create_xml_node(NULL, XML_TAG_OPTIONS);
+    if (hello_node == NULL) {
+        crm_err("Could not create IPC hello message from %s (UUID %s): "
+                "Message data creation failed", client_name, uuid);
+        return NULL;
+    }
+
     crm_xml_add(hello_node, "major_version", major_version);
     crm_xml_add(hello_node, "minor_version", minor_version);
     crm_xml_add(hello_node, "client_name", client_name);
     crm_xml_add(hello_node, "client_uuid", uuid);
 
-    crm_trace("creating hello message");
     hello = create_request(CRM_OP_HELLO, hello_node, NULL, NULL, client_name, uuid);
+    if (hello == NULL) {
+        crm_err("Could not create IPC hello message from %s (UUID %s): "
+                "Request creation failed", client_name, uuid);
+        return NULL;
+    }
     free_xml(hello_node);
 
+    crm_trace("Created hello message from %s (UUID %s)", client_name, uuid);
     return hello;
 }

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -562,8 +562,19 @@ pcmk__client_pid(qb_ipcs_connection_t *c)
     return stats.client_pid;
 }
 
+/*!
+ * \internal
+ * \brief Retrieve message XML from data read from client IPC
+ *
+ * \param[in]  c       IPC client connection
+ * \param[in]  data    Data read from client connection
+ * \param[out] id      Where to store message ID from libqb header
+ * \param[out] flags   Where to store flags from libqb header
+ *
+ * \return Message XML on success, NULL otherwise
+ */
 xmlNode *
-pcmk__client_data2xml(pcmk__client_t *c, void *data, size_t size, uint32_t *id,
+pcmk__client_data2xml(pcmk__client_t *c, void *data, uint32_t *id,
                       uint32_t *flags)
 {
     xmlNode *xml = NULL;
@@ -613,8 +624,8 @@ pcmk__client_data2xml(pcmk__client_t *c, void *data, size_t size, uint32_t *id,
 
     CRM_ASSERT(text[header->size_uncompressed - 1] == 0);
 
-    crm_trace("Received %.200s", text);
     xml = string2xml(text);
+    crm_log_xml_trace(xml, "[IPC received]");
 
     free(uncompressed);
     return xml;

--- a/maint/mocked/based.c
+++ b/maint/mocked/based.c
@@ -57,13 +57,6 @@ mock_based_ipc_accept(qb_ipcs_connection_t *c, uid_t uid, gid_t gid)
     return ret;
 }
 
-/* see based/based_callbacks.c:cib_ipc_created */
-static void
-mock_based_ipc_created(qb_ipcs_connection_t *c)
-{
-    crm_trace("Connection %p", c);
-}
-
 /* see based/based_callbacks.c:cib_ipc_closed */
 static int32_t
 mock_based_ipc_closed(qb_ipcs_connection_t *c)
@@ -313,7 +306,7 @@ int main(int argc, char *argv[])
     if (mock_based_options(ctxt, false, argc, (const char **) argv) > 0) {
         struct qb_ipcs_service_handlers cib_ipc_callbacks = {
             .connection_accept = mock_based_ipc_accept,
-            .connection_created = mock_based_ipc_created,
+            .connection_created = NULL,
             .msg_process = mock_based_dispatch_command,
             .connection_closed = mock_based_ipc_closed,
             .connection_destroyed = mock_based_ipc_destroy,

--- a/maint/mocked/based.c
+++ b/maint/mocked/based.c
@@ -182,8 +182,7 @@ mock_based_dispatch_command(qb_ipcs_connection_t *c, void *data, size_t size)
     uint32_t id = 0, flags = 0;
     int call_options = 0;
     pcmk__client_t *cib_client = pcmk__find_client(c);
-    xmlNode *op_request = pcmk__client_data2xml(cib_client, data, size, &id,
-                                                &flags);
+    xmlNode *op_request = pcmk__client_data2xml(cib_client, data, &id, &flags);
 
     crm_notice("Got connection %p", c);
     assert(op_request != NULL);

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -12,7 +12,7 @@ if BUILD_SYSTEMD
 systemdsystemunit_DATA	= crm_mon.service
 endif
 
-noinst_HEADERS		= crm_mon.h crm_resource.h
+noinst_HEADERS		= crm_mon.h crm_resource.h crm_resource_controller.h
 
 pcmkdir			= $(datadir)/$(PACKAGE)
 pcmk_DATA		= report.common report.collector
@@ -110,7 +110,11 @@ crm_attribute_LDADD	= $(top_builddir)/lib/cluster/libcrmcluster.la	\
 			  $(top_builddir)/lib/cib/libcib.la		\
 			  $(top_builddir)/lib/common/libcrmcommon.la
 
-crm_resource_SOURCES	= crm_resource.c crm_resource_ban.c crm_resource_runtime.c crm_resource_print.c
+crm_resource_SOURCES	= crm_resource.c		\
+			  crm_resource_ban.c		\
+			  crm_resource_controller.c	\
+			  crm_resource_print.c		\
+			  crm_resource_runtime.c
 crm_resource_LDADD	= $(top_builddir)/lib/pengine/libpe_rules.la  	\
 			  $(top_builddir)/lib/fencing/libstonithd.la	\
 			  $(top_builddir)/lib/lrmd/liblrmd.la 		\

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -21,6 +21,7 @@
 #include <crm/pengine/status.h>
 #include <crm/pengine/internal.h>
 #include <pacemaker-internal.h>
+#include "crm_resource_controller.h"
 
 extern bool print_pending;
 
@@ -30,11 +31,12 @@ extern bool BE_QUIET;
 extern int resource_verbose;
 
 extern int cib_options;
-extern int crmd_replies_needed;
 
 extern char *move_lifetime;
 
 extern const char *attr_set_type;
+
+extern pcmk_controld_api_cb_t controld_api_cb;
 
 /* ban */
 int cli_resource_prefer(const char *rsc_id, const char *host, cib_t * cib_conn);
@@ -61,14 +63,16 @@ int cli_resource_print_operations(const char *rsc_id, const char *host_uname, bo
 
 /* runtime */
 void cli_resource_check(cib_t * cib, resource_t *rsc);
-int cli_resource_fail(crm_ipc_t * crmd_channel, const char *host_uname, const char *rsc_id, pe_working_set_t * data_set);
+int cli_resource_fail(pcmk_controld_api_t *controld_api,
+                      const char *host_uname, const char *rsc_id,
+                      pe_working_set_t *data_set);
 int cli_resource_search(resource_t *rsc, const char *requested_name,
                         pe_working_set_t *data_set);
-int cli_resource_delete(crm_ipc_t *crmd_channel, const char *host_uname,
-                        resource_t *rsc, const char *operation,
-                        const char *interval_spec, bool just_failures,
-                        pe_working_set_t *data_set);
-int cli_cleanup_all(crm_ipc_t *crmd_channel, const char *node_name,
+int cli_resource_delete(pcmk_controld_api_t *controld_api,
+                        const char *host_uname, pe_resource_t *rsc,
+                        const char *operation, const char *interval_spec,
+                        bool just_failures, pe_working_set_t *data_set);
+int cli_cleanup_all(pcmk_controld_api_t *controld_api, const char *node_name,
                     const char *operation, const char *interval_spec,
                     pe_working_set_t *data_set);
 int cli_resource_restart(pe_resource_t *rsc, const char *host, int timeout_ms,

--- a/tools/crm_resource_controller.c
+++ b/tools/crm_resource_controller.c
@@ -1,0 +1,425 @@
+/*
+ * Copyright 2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+#include <stdio.h>
+#include <errno.h>
+#include "crm_resource.h"
+
+// API object's private members
+struct controller_private {
+    char *client_name;              // Client name to use with IPC
+    char *client_uuid;              // Client UUID to use with IPC
+    mainloop_io_t *source;          // If main loop used, I/O source for IPC
+    crm_ipc_t *ipc;                 // IPC connection to controller
+    int replies_expected;           // How many controller replies are expected
+    pcmk_controld_api_cb_t dispatch_cb; // Caller's registered dispatch callback
+    pcmk_controld_api_cb_t destroy_cb;  // Caller's registered destroy callback
+};
+
+static void
+call_client_callback(pcmk_controld_api_t *api, pcmk_controld_api_cb_t *cb,
+                     void *api_data)
+{
+    if ((cb != NULL) && (cb->callback != NULL)) {
+        cb->callback(api, api_data, cb->user_data);
+    }
+}
+
+/*
+ * IPC callbacks when used with main loop
+ */
+
+static void
+controller_ipc_destroy(gpointer user_data)
+{
+    pcmk_controld_api_t *api = user_data;
+    struct controller_private *private = api->private;
+
+    private->ipc = NULL;
+    private->source = NULL;
+    call_client_callback(api, &(private->destroy_cb), NULL);
+}
+
+// \return < 0 if connection is no longer required, >= 0 if it is
+static int
+controller_ipc_dispatch(const char *buffer, ssize_t length, gpointer user_data)
+{
+    xmlNode *msg = NULL;
+    pcmk_controld_api_t *api = user_data;
+
+    CRM_CHECK(buffer && api && api->private, return 0);
+
+    msg = string2xml(buffer);
+    if (msg == NULL) {
+        crm_warn("Received malformed controller IPC message");
+    } else {
+        struct controller_private *private = api->private;
+
+        crm_log_xml_trace(msg, "controller-reply");
+        private->replies_expected--;
+        call_client_callback(api, &(private->dispatch_cb),
+                             get_message_xml(msg, F_CRM_DATA));
+        free_xml(msg);
+    }
+    return 0;
+}
+
+/*
+ * IPC utilities
+ */
+
+// \return Standard Pacemaker return code
+static int
+send_hello(crm_ipc_t *ipc, const char *client_name, const char *client_uuid)
+{
+    xmlNode *hello = create_hello_message(client_uuid, client_name, "0", "1");
+    int rc = crm_ipc_send(ipc, hello, 0, 0, NULL);
+
+    free_xml(hello);
+    if (rc < 0) {
+        rc = pcmk_legacy2rc(rc);
+        crm_info("Could not send IPC hello to %s: %s " CRM_XS " rc=%s",
+                 CRM_SYSTEM_CRMD /* ipc->name */,
+                 pcmk_rc_str(rc), rc);
+        return rc;
+    }
+    crm_debug("Sent IPC hello to %s", CRM_SYSTEM_CRMD /* ipc->name */);
+    return pcmk_rc_ok;
+}
+
+// \return Standard Pacemaker return code
+static int
+send_controller_request(pcmk_controld_api_t *api, const char *op,
+                        xmlNode *msg_data, const char *node)
+{
+    int rc;
+    struct controller_private *private = api->private;
+    xmlNode *cmd = create_request(op, msg_data, node, CRM_SYSTEM_CRMD,
+                                  private->client_name, private->client_uuid);
+    const char *reference = crm_element_value(cmd, XML_ATTR_REFERENCE);
+
+    if ((cmd == NULL) || (reference == NULL)) {
+        return EINVAL;
+    }
+
+    //@TODO pass as args? 0=crm_ipc_flags, 0=timeout_ms (default 5s), NULL=reply
+    crm_log_xml_trace(cmd, "controller-request");
+    rc = crm_ipc_send(private->ipc, cmd, 0, 0, NULL);
+    free_xml(cmd);
+    if (rc < 0) {
+        return pcmk_legacy2rc(rc);
+    }
+    private->replies_expected++;
+    return pcmk_rc_ok;
+}
+
+/*
+ * pcmk_controld_api_t methods
+ */
+
+static int
+controller_connect_mainloop(pcmk_controld_api_t *api)
+{
+    struct controller_private *private = api->private;
+    struct ipc_client_callbacks callbacks = {
+        .dispatch = controller_ipc_dispatch,
+        .destroy = controller_ipc_destroy,
+    };
+
+    private->source = mainloop_add_ipc_client(CRM_SYSTEM_CRMD,
+                                              G_PRIORITY_DEFAULT, 0, api,
+                                              &callbacks);
+    if (private->source == NULL) {
+        return ENOTCONN;
+    }
+
+    private->ipc = mainloop_get_ipc_client(private->source);
+    if (private->ipc == NULL) {
+        (void) api->disconnect(api);
+        return ENOTCONN;
+    }
+
+    crm_debug("Connected to %s IPC (attaching to main loop)", CRM_SYSTEM_CRMD);
+    return pcmk_rc_ok;
+}
+
+static int
+controller_connect_no_mainloop(pcmk_controld_api_t *api)
+{
+    struct controller_private *private = api->private;
+
+    private->ipc = crm_ipc_new(CRM_SYSTEM_CRMD, 0);
+    if (private->ipc == NULL) {
+        return ENOTCONN;
+    }
+    if (!crm_ipc_connect(private->ipc)) {
+        crm_ipc_close(private->ipc);
+        crm_ipc_destroy(private->ipc);
+        private->ipc = NULL;
+        return errno;
+    }
+    /* @TODO caller needs crm_ipc_get_fd(private->ipc); either add method for
+     * that, or replace use_mainloop with int *fd
+     */
+    crm_debug("Connected to %s IPC", CRM_SYSTEM_CRMD);
+    return pcmk_rc_ok;
+}
+
+static void
+set_callback(pcmk_controld_api_cb_t *dest, pcmk_controld_api_cb_t *source)
+{
+    if (source) {
+        dest->callback  = source->callback;
+        dest->user_data = source->user_data;
+    }
+}
+
+static int
+controller_api_connect(pcmk_controld_api_t *api, bool use_mainloop,
+                       pcmk_controld_api_cb_t *dispatch_cb,
+                       pcmk_controld_api_cb_t *destroy_cb)
+{
+    int rc = pcmk_rc_ok;
+    struct controller_private *private;
+
+    if (api == NULL) {
+        return EINVAL;
+    }
+    private = api->private;
+
+    set_callback(&(private->dispatch_cb), dispatch_cb);
+    set_callback(&(private->destroy_cb), destroy_cb);
+
+    if (private->ipc != NULL) {
+        return pcmk_rc_ok; // already connected
+    }
+
+    if (use_mainloop) {
+        rc = controller_connect_mainloop(api);
+    } else {
+        rc = controller_connect_no_mainloop(api);
+    }
+    if (rc != pcmk_rc_ok) {
+        return rc;
+    }
+
+    rc = send_hello(private->ipc, private->client_name, private->client_uuid);
+    if (rc != pcmk_rc_ok) {
+        (void) api->disconnect(api);
+    }
+    return rc;
+}
+
+static int
+controller_api_disconnect(pcmk_controld_api_t *api)
+{
+    struct controller_private *private = api->private;
+
+    if (private->source != NULL) {
+        // Attached to main loop
+        mainloop_del_ipc_client(private->source);
+        private->source = NULL;
+        private->ipc = NULL;
+
+    } else if (private->ipc != NULL) {
+        // Not attached to main loop
+        crm_ipc_t *ipc = private->ipc;
+
+        private->ipc = NULL;
+        crm_ipc_close(ipc);
+        crm_ipc_destroy(ipc);
+    }
+    crm_debug("Disconnected from %s IPC", CRM_SYSTEM_CRMD /* ipc->name */);
+    return pcmk_rc_ok;
+}
+
+//@TODO dispatch function for non-mainloop a la stonith_dispatch()
+//@TODO convenience retry-connect function a la stonith_api_connect_retry()
+
+static unsigned int
+controller_api_replies_expected(pcmk_controld_api_t *api)
+{
+    if (api != NULL) {
+        struct controller_private *private = api->private;
+
+        return private->replies_expected;
+    }
+    return 0;
+}
+
+static xmlNode *
+create_reprobe_message_data(const char *target_node, const char *router_node)
+{
+    xmlNode *msg_data;
+
+    msg_data = create_xml_node(NULL, "data_for_" CRM_OP_REPROBE);
+    crm_xml_add(msg_data, XML_LRM_ATTR_TARGET, target_node);
+    if ((router_node != NULL) && safe_str_neq(router_node, target_node)) {
+        crm_xml_add(msg_data, XML_LRM_ATTR_ROUTER_NODE, router_node);
+    }
+    return msg_data;
+}
+
+static int
+controller_api_reprobe(pcmk_controld_api_t *api, const char *target_node,
+                       const char *router_node)
+{
+    int rc = EINVAL;
+
+    if (api != NULL) {
+        xmlNode *msg_data;
+
+        crm_debug("Sending %s IPC request to reprobe %s via %s",
+                  CRM_SYSTEM_CRMD, crm_str(target_node), crm_str(router_node));
+        msg_data = create_reprobe_message_data(target_node, router_node);
+        rc = send_controller_request(api, CRM_OP_REPROBE, msg_data,
+                                     (router_node? router_node : target_node));
+        free_xml(msg_data);
+    }
+    return rc;
+}
+
+// \return Standard Pacemaker return code
+static int
+controller_resource_op(pcmk_controld_api_t *api, const char *op,
+                       const char *target_node, const char *router_node,
+                       bool cib_only, const char *rsc_id,
+                       const char *rsc_long_id, const char *standard,
+                       const char *provider, const char *type)
+{
+    int rc;
+    char *key;
+    xmlNode *msg_data, *xml_rsc, *params;
+
+    if (api == NULL) {
+        return EINVAL;
+    }
+    if (router_node == NULL) {
+        router_node = target_node;
+    }
+
+    msg_data = create_xml_node(NULL, XML_GRAPH_TAG_RSC_OP);
+
+    /* The controller logs the transition key from resource op requests, so we
+     * need to have *something* for it.
+     */
+    key = generate_transition_key(0, getpid(), 0,
+                                  "xxxxxxxx-xrsc-opxx-xcrm-resourcexxxx");
+    crm_xml_add(msg_data, XML_ATTR_TRANSITION_KEY, key);
+    free(key);
+
+    crm_xml_add(msg_data, XML_LRM_ATTR_TARGET, target_node);
+    if (safe_str_neq(router_node, target_node)) {
+        crm_xml_add(msg_data, XML_LRM_ATTR_ROUTER_NODE, router_node);
+    }
+
+    if (cib_only) {
+        // Indicate that only the CIB needs to be cleaned
+        crm_xml_add(msg_data, PCMK__XA_MODE, XML_TAG_CIB);
+    }
+
+    xml_rsc = create_xml_node(msg_data, XML_CIB_TAG_RESOURCE);
+    crm_xml_add(xml_rsc, XML_ATTR_ID, rsc_id);
+    crm_xml_add(xml_rsc, XML_ATTR_ID_LONG, rsc_long_id);
+    crm_xml_add(xml_rsc, XML_AGENT_ATTR_CLASS, standard);
+    crm_xml_add(xml_rsc, XML_AGENT_ATTR_PROVIDER, provider);
+    crm_xml_add(xml_rsc, XML_ATTR_TYPE, type);
+
+    params = create_xml_node(msg_data, XML_TAG_ATTRS);
+    crm_xml_add(params, XML_ATTR_CRM_VERSION, CRM_FEATURE_SET);
+
+    // The controller parses the timeout from the request
+    key = crm_meta_name(XML_ATTR_TIMEOUT);
+    crm_xml_add(params, key, "60000");  /* 1 minute */ //@TODO pass as arg
+    free(key);
+
+    rc = send_controller_request(api, op, msg_data, router_node);
+    free_xml(msg_data);
+    return rc;
+}
+
+static int
+controller_api_fail_resource(pcmk_controld_api_t *api,
+                             const char *target_node, const char *router_node,
+                             const char *rsc_id, const char *rsc_long_id,
+                             const char *standard, const char *provider,
+                             const char *type)
+{
+    crm_debug("Sending %s IPC request to fail %s (a.k.a. %s) on %s via %s",
+              CRM_SYSTEM_CRMD, crm_str(rsc_id), crm_str(rsc_long_id),
+              crm_str(target_node), crm_str(router_node));
+    return controller_resource_op(api, CRM_OP_LRM_FAIL, target_node,
+                                  router_node, false, rsc_id, rsc_long_id,
+                                  standard, provider, type);
+}
+
+static int
+controller_api_refresh_resource(pcmk_controld_api_t *api,
+                                const char *target_node,
+                                const char *router_node,
+                                const char *rsc_id, const char *rsc_long_id,
+                                const char *standard, const char *provider,
+                                const char *type, bool cib_only)
+{
+    crm_debug("Sending %s IPC request to refresh %s (a.k.a. %s) on %s via %s",
+              CRM_SYSTEM_CRMD, crm_str(rsc_id), crm_str(rsc_long_id),
+              crm_str(target_node), crm_str(router_node));
+    return controller_resource_op(api, CRM_OP_LRM_DELETE, target_node,
+                                  router_node, cib_only, rsc_id, rsc_long_id,
+                                  standard, provider, type);
+}
+
+pcmk_controld_api_t *
+pcmk_new_controld_api(const char *client_name, const char *client_uuid)
+{
+    struct controller_private *private;
+    pcmk_controld_api_t *api = calloc(1, sizeof(pcmk_controld_api_t));
+
+    CRM_ASSERT(api != NULL);
+
+    api->private = calloc(1, sizeof(struct controller_private));
+    CRM_ASSERT(api->private != NULL);
+    private = api->private;
+
+    if (client_name == NULL) {
+        client_name = crm_system_name? crm_system_name : "client";
+    }
+    private->client_name = strdup(client_name);
+    CRM_ASSERT(private->client_name != NULL);
+
+    if (client_uuid == NULL) {
+        private->client_uuid = crm_generate_uuid();
+    } else {
+        private->client_uuid = strdup(client_uuid);
+    }
+    CRM_ASSERT(private->client_uuid != NULL);
+
+    api->connect = controller_api_connect;
+    api->disconnect = controller_api_disconnect;
+    api->replies_expected = controller_api_replies_expected;
+    api->reprobe = controller_api_reprobe;
+    api->fail_resource = controller_api_fail_resource;
+    api->refresh_resource = controller_api_refresh_resource;
+    return api;
+}
+
+void
+pcmk_free_controld_api(pcmk_controld_api_t *api)
+{
+    if (api != NULL) {
+        struct controller_private *private = api->private;
+
+        api->disconnect(api);
+        free(private->client_name);
+        free(private->client_uuid);
+        free(api->private);
+        free(api);
+    }
+}

--- a/tools/crm_resource_controller.h
+++ b/tools/crm_resource_controller.h
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+#ifndef PCMK__CONTROLD_API_H
+#define PCMK__CONTROLD_API_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>                // bool
+
+/* This is a demonstration of an abstracted controller IPC API. It is expected
+ * that this will be improved and moved to libcrmcommon.
+ *
+ * @TODO We could consider whether it's reasonable to have a single type for
+ * all daemons' IPC APIs (e.g. pcmk_ipc_api_t instead of pcmk_*_api_t). They
+ * could potentially have common connect/disconnect methods and then a void* to
+ * a group of API-specific methods.
+ *
+ * In that case, the callback type would also need to be generic, taking
+ * (pcmk_ipc_api_t *api, void *api_data, void *user_data), with individual APIs
+ * having functions for getting useful info from api_data. If all APIs followed
+ * the call_id model, we could use int call_id instead of api_data.
+ *
+ * A major annoyance is that the controller IPC protocol currently does not have
+ * any way to tie a particular reply to a particular request. The current
+ * clients (crmadmin, crm_node, and crm_resource) simply know what kind of reply
+ * to expect for the kind of request they sent. In crm_resource's case, all it
+ * does is count replies, ignoring their content altogether.
+ *
+ * That really forces us to have a single callback for all events rather than a
+ * per-request callback. That in turn implies that callers can only provide a
+ * single user data pointer.
+ *
+ * @TODO Define protocol version constants to use in hello message.
+ * @TODO Allow callers to specify timeouts.
+ * @TODO Define call IDs for controller ops, while somehow maintaining backward
+ *       compatibility, since a client running on a Pacemaker Remote node could
+ *       be older or newer than the controller on the connection's cluster
+ *       node.
+ * @TODO The controller currently does not respond to hello messages. We should
+ *       establish a common connection handshake protocol for all daemons that
+ *       involves a hello message and acknowledgement. We should support sync
+ *       or async connection (i.e. block until the ack is received, or return
+ *       after the hello is sent and call a connection callback when the hello
+ *       ack is received).
+ */
+
+//! \internal
+typedef struct pcmk_controld_api_s pcmk_controld_api_t;
+
+//! \internal
+typedef struct pcmk_controld_api_callback_s {
+    void (*callback)(pcmk_controld_api_t *api, void *api_data, void *user_data);
+    void *user_data;
+} pcmk_controld_api_cb_t;
+
+//! \internal
+struct pcmk_controld_api_s {
+    //! \internal
+    void *private;
+
+    /*!
+     * \internal
+     * \brief Connect to the local controller
+     *
+     * \param[in] api           Controller API instance
+     * \param[in] use_mainloop  If true, attach IPC to main loop
+     * \param[in] dispatch_cb   If not NULL, call this when replies are received
+     * \param[in] destroy_cb    If not NULL, call this if connection drops
+     *
+     * \return Standard Pacemaker return code
+     * \note Only the pointers inside the callback objects need to be
+     *       persistent, not the callback objects themselves. The destroy_cb
+     *       will be called only for unrequested disconnects.
+     */
+    int (*connect)(pcmk_controld_api_t *api, bool use_mainloop,
+                   pcmk_controld_api_cb_t *dispatch_cb,
+                   pcmk_controld_api_cb_t *destroy_cb);
+
+    /*!
+     * \internal
+     * \brief Disconnect from the local controller
+     *
+     * \param[in] api       Controller API instance
+     *
+     * \return Standard Pacemaker return code
+     */
+    int (*disconnect)(pcmk_controld_api_t *api);
+
+    /*!
+     * \internal
+     * \brief Check number of replies still expected from controller
+     *
+     * \param[in] api       Controller API instance
+     *
+     * \return Number of expected replies
+     */
+    unsigned int (*replies_expected)(pcmk_controld_api_t *api);
+
+    /*!
+     * \internal
+     * \brief Send a reprobe controller operation
+     *
+     * \param[in] api          Controller API instance
+     * \param[in] target_node  Name of node to reprobe
+     * \param[in] router_node  Router node for host
+     *
+     * \return Standard Pacemaker return code
+     */
+    int (*reprobe)(pcmk_controld_api_t *api, const char *target_node,
+                   const char *router_node);
+
+    /* @TODO These methods have a lot of arguments. One possibility would be to
+     * make a struct for agent info (standard/provider/type), which theortically
+     * could be used throughout pacemaker code. However that would end up being
+     * really awkward to use generically, since sometimes you need to allocate
+     * those strings (char *) and other times you only have references into XML
+     * (const char *). We could make some structs just for this API.
+     */
+
+    /*!
+     * \internal
+     * \brief Ask the controller to fail a resource
+     *
+     * \param[in] api          Controller API instance
+     * \param[in] target_node  Name of node resource is on
+     * \param[in] router_node  Router node for target
+     * \param[in] rsc_id       ID of resource to fail
+     * \param[in] rsc_long_id  Long ID of resource (if any)
+     * \param[in] standard     Standard of resource
+     * \param[in] provider     Provider of resource (if any)
+     * \param[in] type         Type of resource to fail
+     *
+     * \return Standard Pacemaker return code
+     */
+    int (*fail_resource)(pcmk_controld_api_t *api, const char *target_node,
+                         const char *router_node, const char *rsc_id,
+                         const char *rsc_long_id, const char *standard,
+                         const char *provider, const char *type);
+
+    /*!
+     * \internal
+     * \brief Ask the controller to refresh a resource
+     *
+     * \param[in] api          Controller API instance
+     * \param[in] target_node  Name of node resource is on
+     * \param[in] router_node  Router node for target
+     * \param[in] rsc_id       ID of resource to refresh
+     * \param[in] rsc_long_id  Long ID of resource (if any)
+     * \param[in] standard     Standard of resource
+     * \param[in] provider     Provider of resource (if any)
+     * \param[in] type         Type of resource
+     * \param[in] cib_only     If true, clean resource from CIB only
+     *
+     * \return Standard Pacemaker return code
+     */
+    int (*refresh_resource)(pcmk_controld_api_t *api, const char *target_node,
+                            const char *router_node, const char *rsc_id,
+                            const char *rsc_long_id, const char *standard,
+                            const char *provider, const char *type,
+                            bool cib_only);
+};
+
+/*!
+ * \internal
+ * \brief Create new controller IPC API object for clients
+ *
+ * \param[in] client_name  Client name to use with IPC
+ * \param[in] client_uuid  Client UUID to use with IPC
+ *
+ * \return Newly allocated object
+ * \note This function asserts on errors, so it will never return NULL.
+ *       The caller is responsible for freeing the result with
+ *       pcmk_free_controld_api().
+ */
+pcmk_controld_api_t *pcmk_new_controld_api(const char *client_name,
+                                           const char *client_uuid);
+
+/*!
+ * \internal
+ * \brief Free a controller IPC API object
+ *
+ * \param[in] api  Controller IPC API object to free
+ */
+void pcmk_free_controld_api(pcmk_controld_api_t *api);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This isolates the controller-related code of crm_resource into new files crm_resource_controller.h and crm_resource_controller.c, creating an IPC API interface for the controller somewhat like what we have for other daemons. This is intended as a first step toward a common model for daemon IPC APIs, to be refined and eventually moved to libcrmcommon.

It is also hoped to fix CLBZ#5420, or at least make it easier to fix.