### PR TITLE
Expand what crm_rule can check

### DIFF
--- a/cts/cli/regression.rules.exp
+++ b/cts/cli/regression.rules.exp
@@ -9,7 +9,7 @@ unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure 
 No rule found with ID=blahblah
 Error checking rule: No such device or address
 =#=#=#= Current cib after: Try to check a rule that doesn't exist =#=#=#=
-<cib epoch="7" num_updates="0" admin_epoch="0">
+<cib epoch="8" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -17,7 +17,12 @@ Error checking rule: No such device or address
       <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
     </resources>
     <constraints>
-      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
+        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
+          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
+          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
       <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
@@ -47,6 +52,11 @@ Error checking rule: No such device or address
           <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
             <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
           </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-no-date_expression" rsc="dummy">
+        <rule id="cli-no-date_expression-rule" score="INFINITY">
+          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
         </rule>
       </rsc_location>
     </constraints>
@@ -55,14 +65,14 @@ Error checking rule: No such device or address
 </cib>
 =#=#=#= End test: Try to check a rule that doesn't exist - No such object (105) =#=#=#=
 * Passed: crm_rule       - Try to check a rule that doesn't exist
-=#=#=#= Begin test: Try to check a rule that has no date_expression =#=#=#=
+=#=#=#= Begin test: Try to check a rule that has too many date_expressions =#=#=#=
 unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
 unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
-No rule found with ID=no-date-expression
+No rule found with ID=cli-too-many-date-expressions
 Error checking rule: No such device or address
-=#=#=#= Current cib after: Try to check a rule that has no date_expression =#=#=#=
-<cib epoch="7" num_updates="0" admin_epoch="0">
+=#=#=#= Current cib after: Try to check a rule that has too many date_expressions =#=#=#=
+<cib epoch="8" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -70,7 +80,12 @@ Error checking rule: No such device or address
       <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
     </resources>
     <constraints>
-      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
+        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
+          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
+          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
       <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
@@ -100,21 +115,26 @@ Error checking rule: No such device or address
           <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
             <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
           </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-no-date_expression" rsc="dummy">
+        <rule id="cli-no-date_expression-rule" score="INFINITY">
+          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
         </rule>
       </rsc_location>
     </constraints>
   </configuration>
   <status/>
 </cib>
-=#=#=#= End test: Try to check a rule that has no date_expression - No such object (105) =#=#=#=
-* Passed: crm_rule       - Try to check a rule that has no date_expression
+=#=#=#= End test: Try to check a rule that has too many date_expressions - No such object (105) =#=#=#=
+* Passed: crm_rule       - Try to check a rule that has too many date_expressions
 =#=#=#= Begin test: Verify basic rule is expired =#=#=#=
 unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
 unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
 Rule cli-prefer-rule-dummy-expired is expired
 =#=#=#= Current cib after: Verify basic rule is expired =#=#=#=
-<cib epoch="7" num_updates="0" admin_epoch="0">
+<cib epoch="8" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -122,7 +142,12 @@ Rule cli-prefer-rule-dummy-expired is expired
       <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
     </resources>
     <constraints>
-      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
+        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
+          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
+          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
       <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
@@ -152,6 +177,11 @@ Rule cli-prefer-rule-dummy-expired is expired
           <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
             <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
           </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-no-date_expression" rsc="dummy">
+        <rule id="cli-no-date_expression-rule" score="INFINITY">
+          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
         </rule>
       </rsc_location>
     </constraints>
@@ -166,7 +196,7 @@ unpack_resources 	error: Either configure some or disable STONITH with the stoni
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
 Rule cli-prefer-rule-dummy-expired is still in effect
 =#=#=#= Current cib after: Verify basic rule worked in the past =#=#=#=
-<cib epoch="7" num_updates="0" admin_epoch="0">
+<cib epoch="8" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -174,7 +204,12 @@ Rule cli-prefer-rule-dummy-expired is still in effect
       <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
     </resources>
     <constraints>
-      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
+        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
+          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
+          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
       <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
@@ -204,6 +239,11 @@ Rule cli-prefer-rule-dummy-expired is still in effect
           <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
             <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
           </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-no-date_expression" rsc="dummy">
+        <rule id="cli-no-date_expression-rule" score="INFINITY">
+          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
         </rule>
       </rsc_location>
     </constraints>
@@ -218,7 +258,7 @@ unpack_resources 	error: Either configure some or disable STONITH with the stoni
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
 Rule cli-prefer-rule-dummy-not-yet has not yet taken effect
 =#=#=#= Current cib after: Verify basic rule is not yet in effect =#=#=#=
-<cib epoch="7" num_updates="0" admin_epoch="0">
+<cib epoch="8" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -226,7 +266,12 @@ Rule cli-prefer-rule-dummy-not-yet has not yet taken effect
       <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
     </resources>
     <constraints>
-      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
+        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
+          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
+          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
       <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
@@ -256,6 +301,11 @@ Rule cli-prefer-rule-dummy-not-yet has not yet taken effect
           <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
             <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
           </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-no-date_expression" rsc="dummy">
+        <rule id="cli-no-date_expression-rule" score="INFINITY">
+          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
         </rule>
       </rsc_location>
     </constraints>
@@ -264,13 +314,13 @@ Rule cli-prefer-rule-dummy-not-yet has not yet taken effect
 </cib>
 =#=#=#= End test: Verify basic rule is not yet in effect - Requested item is not yet in effect (111) =#=#=#=
 * Passed: crm_rule       - Verify basic rule is not yet in effect
-=#=#=#= Begin test: Verify date_spec rule with years doesn't match =#=#=#=
+=#=#=#= Begin test: Verify date_spec rule with years has expired =#=#=#=
 unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
 unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
-Rule cli-prefer-rule-dummy-date_spec-only-years does not satisfy conditions
-=#=#=#= Current cib after: Verify date_spec rule with years doesn't match =#=#=#=
-<cib epoch="7" num_updates="0" admin_epoch="0">
+Rule cli-prefer-rule-dummy-date_spec-only-years is expired
+=#=#=#= Current cib after: Verify date_spec rule with years has expired =#=#=#=
+<cib epoch="8" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -278,7 +328,12 @@ Rule cli-prefer-rule-dummy-date_spec-only-years does not satisfy conditions
       <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
     </resources>
     <constraints>
-      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
+        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
+          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
+          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
       <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
@@ -310,19 +365,24 @@ Rule cli-prefer-rule-dummy-date_spec-only-years does not satisfy conditions
           </date_expression>
         </rule>
       </rsc_location>
+      <rsc_location id="cli-no-date_expression" rsc="dummy">
+        <rule id="cli-no-date_expression-rule" score="INFINITY">
+          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
+        </rule>
+      </rsc_location>
     </constraints>
   </configuration>
   <status/>
 </cib>
-=#=#=#= End test: Verify date_spec rule with years doesn't match - Requested item does not satisfy constraints (113) =#=#=#=
-* Passed: crm_rule       - Verify date_spec rule with years doesn't match
-=#=#=#= Begin test: Verify date_spec rule with years does match =#=#=#=
+=#=#=#= End test: Verify date_spec rule with years has expired - Requested item has expired (110) =#=#=#=
+* Passed: crm_rule       - Verify date_spec rule with years has expired
+=#=#=#= Begin test: Verify date_spec rule with years is in effect =#=#=#=
 unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
 unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
 Rule cli-prefer-rule-dummy-date_spec-only-years satisfies conditions
-=#=#=#= Current cib after: Verify date_spec rule with years does match =#=#=#=
-<cib epoch="7" num_updates="0" admin_epoch="0">
+=#=#=#= Current cib after: Verify date_spec rule with years is in effect =#=#=#=
+<cib epoch="8" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -330,7 +390,12 @@ Rule cli-prefer-rule-dummy-date_spec-only-years satisfies conditions
       <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
     </resources>
     <constraints>
-      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
+        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
+          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
+          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
       <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
@@ -362,12 +427,17 @@ Rule cli-prefer-rule-dummy-date_spec-only-years satisfies conditions
           </date_expression>
         </rule>
       </rsc_location>
+      <rsc_location id="cli-no-date_expression" rsc="dummy">
+        <rule id="cli-no-date_expression-rule" score="INFINITY">
+          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
+        </rule>
+      </rsc_location>
     </constraints>
   </configuration>
   <status/>
 </cib>
-=#=#=#= End test: Verify date_spec rule with years does match - OK (0) =#=#=#=
-* Passed: crm_rule       - Verify date_spec rule with years does match
+=#=#=#= End test: Verify date_spec rule with years is in effect - OK (0) =#=#=#=
+* Passed: crm_rule       - Verify date_spec rule with years is in effect
 =#=#=#= Begin test: Try to check a rule whose date_spec does not contain years= =#=#=#=
 unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
 unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
@@ -375,7 +445,7 @@ unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure 
 Rule either must not use date_spec, or use date_spec with years= but not moon=
 Error checking rule: No such device or address
 =#=#=#= Current cib after: Try to check a rule whose date_spec does not contain years= =#=#=#=
-<cib epoch="7" num_updates="0" admin_epoch="0">
+<cib epoch="8" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -383,7 +453,12 @@ Error checking rule: No such device or address
       <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
     </resources>
     <constraints>
-      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
+        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
+          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
+          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
       <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
@@ -413,6 +488,11 @@ Error checking rule: No such device or address
           <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
             <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
           </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-no-date_expression" rsc="dummy">
+        <rule id="cli-no-date_expression-rule" score="INFINITY">
+          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
         </rule>
       </rsc_location>
     </constraints>
@@ -428,7 +508,7 @@ unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure 
 Rule either must not use date_spec, or use date_spec with years= but not moon=
 Error checking rule: No such device or address
 =#=#=#= Current cib after: Try to check a rule whose date_spec contains years= and moon= =#=#=#=
-<cib epoch="7" num_updates="0" admin_epoch="0">
+<cib epoch="8" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -436,7 +516,12 @@ Error checking rule: No such device or address
       <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
     </resources>
     <constraints>
-      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
+        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
+          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
+          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
       <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
@@ -468,9 +553,77 @@ Error checking rule: No such device or address
           </date_expression>
         </rule>
       </rsc_location>
+      <rsc_location id="cli-no-date_expression" rsc="dummy">
+        <rule id="cli-no-date_expression-rule" score="INFINITY">
+          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
+        </rule>
+      </rsc_location>
     </constraints>
   </configuration>
   <status/>
 </cib>
 =#=#=#= End test: Try to check a rule whose date_spec contains years= and moon= - No such object (105) =#=#=#=
 * Passed: crm_rule       - Try to check a rule whose date_spec contains years= and moon=
+=#=#=#= Begin test: Try to check a rule with no date_expression =#=#=#=
+unpack_resources       error: Resource start-up disabled since no STONITH resources have been defined
+unpack_resources       error: Either configure some or disable STONITH with the stonith-enabled option
+unpack_resources       error: NOTE: Clusters with shared data need STONITH to ensure data integrity
+Can't check rule cli-no-date_expression-rule because it does not have exactly one date_expression
+Error checking rule: Operation not supported
+=#=#=#= Current cib after: Try to check a rule with no date_expression =#=#=#=
+<cib epoch="8" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config/>
+    <nodes/>
+    <resources>
+      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
+    </resources>
+    <constraints>
+      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
+        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
+          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
+          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
+          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
+          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-no-date_expression" rsc="dummy">
+        <rule id="cli-no-date_expression-rule" score="INFINITY">
+          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
+        </rule>
+      </rsc_location>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Try to check a rule with no date_expression - Unimplemented (3) =#=#=#=
+* Passed: crm_rule       - Try to check a rule with no date_expression

--- a/cts/cli/regression.rules.exp
+++ b/cts/cli/regression.rules.exp
@@ -69,8 +69,8 @@ Error checking rule: No such device or address
 unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
 unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
-No rule found with ID=cli-too-many-date-expressions
-Error checking rule: No such device or address
+Can't check rule cli-rule-too-many-date-expressions because it does not have exactly one date_expression
+Error checking rule: Operation not supported
 =#=#=#= Current cib after: Try to check a rule that has too many date_expressions =#=#=#=
 <cib epoch="8" num_updates="0" admin_epoch="0">
   <configuration>
@@ -126,7 +126,7 @@ Error checking rule: No such device or address
   </configuration>
   <status/>
 </cib>
-=#=#=#= End test: Try to check a rule that has too many date_expressions - No such object (105) =#=#=#=
+=#=#=#= End test: Try to check a rule that has too many date_expressions - Unimplemented (3) =#=#=#=
 * Passed: crm_rule       - Try to check a rule that has too many date_expressions
 =#=#=#= Begin test: Verify basic rule is expired =#=#=#=
 unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined

--- a/cts/cli/regression.rules.exp
+++ b/cts/cli/regression.rules.exp
@@ -6,7 +6,7 @@ A new shadow instance was created.  To begin using it paste the following into y
 unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
 unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
-No rule found with ID=blahblah containing a date_expression
+No rule found with ID=blahblah
 Error checking rule: No such device or address
 =#=#=#= Current cib after: Try to check a rule that doesn't exist =#=#=#=
 <cib epoch="4" num_updates="0" admin_epoch="0">
@@ -38,7 +38,7 @@ Error checking rule: No such device or address
 unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
 unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
-No rule found with ID=no-date-expression containing a date_expression
+No rule found with ID=no-date-expression
 Error checking rule: No such device or address
 =#=#=#= Current cib after: Try to check a rule that has no date_expression =#=#=#=
 <cib epoch="4" num_updates="0" admin_epoch="0">

--- a/cts/cli/regression.rules.exp
+++ b/cts/cli/regression.rules.exp
@@ -9,7 +9,7 @@ unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure 
 No rule found with ID=blahblah
 Error checking rule: No such device or address
 =#=#=#= Current cib after: Try to check a rule that doesn't exist =#=#=#=
-<cib epoch="4" num_updates="0" admin_epoch="0">
+<cib epoch="7" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -26,6 +26,27 @@ Error checking rule: No such device or address
       <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
+          </date_expression>
         </rule>
       </rsc_location>
     </constraints>
@@ -41,7 +62,7 @@ unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure 
 No rule found with ID=no-date-expression
 Error checking rule: No such device or address
 =#=#=#= Current cib after: Try to check a rule that has no date_expression =#=#=#=
-<cib epoch="4" num_updates="0" admin_epoch="0">
+<cib epoch="7" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -58,6 +79,27 @@ Error checking rule: No such device or address
       <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
+          </date_expression>
         </rule>
       </rsc_location>
     </constraints>
@@ -72,7 +114,7 @@ unpack_resources 	error: Either configure some or disable STONITH with the stoni
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
 Rule cli-prefer-rule-dummy-expired is expired
 =#=#=#= Current cib after: Verify basic rule is expired =#=#=#=
-<cib epoch="4" num_updates="0" admin_epoch="0">
+<cib epoch="7" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -89,6 +131,27 @@ Rule cli-prefer-rule-dummy-expired is expired
       <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
+          </date_expression>
         </rule>
       </rsc_location>
     </constraints>
@@ -103,7 +166,7 @@ unpack_resources 	error: Either configure some or disable STONITH with the stoni
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
 Rule cli-prefer-rule-dummy-expired is still in effect
 =#=#=#= Current cib after: Verify basic rule worked in the past =#=#=#=
-<cib epoch="4" num_updates="0" admin_epoch="0">
+<cib epoch="7" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -120,6 +183,27 @@ Rule cli-prefer-rule-dummy-expired is still in effect
       <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
         <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
           <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
+          </date_expression>
         </rule>
       </rsc_location>
     </constraints>
@@ -134,7 +218,7 @@ unpack_resources 	error: Either configure some or disable STONITH with the stoni
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
 Rule cli-prefer-rule-dummy-not-yet has not yet taken effect
 =#=#=#= Current cib after: Verify basic rule is not yet in effect =#=#=#=
-<cib epoch="4" num_updates="0" admin_epoch="0">
+<cib epoch="7" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -153,9 +237,240 @@ Rule cli-prefer-rule-dummy-not-yet has not yet taken effect
           <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
         </rule>
       </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
     </constraints>
   </configuration>
   <status/>
 </cib>
 =#=#=#= End test: Verify basic rule is not yet in effect - Requested item is not yet in effect (111) =#=#=#=
 * Passed: crm_rule       - Verify basic rule is not yet in effect
+=#=#=#= Begin test: Verify date_spec rule with years doesn't match =#=#=#=
+unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
+unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
+unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
+Rule cli-prefer-rule-dummy-date_spec-only-years does not satisfy conditions
+=#=#=#= Current cib after: Verify date_spec rule with years doesn't match =#=#=#=
+<cib epoch="7" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config/>
+    <nodes/>
+    <resources>
+      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
+    </resources>
+    <constraints>
+      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
+          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
+          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Verify date_spec rule with years doesn't match - Requested item does not satisfy constraints (113) =#=#=#=
+* Passed: crm_rule       - Verify date_spec rule with years doesn't match
+=#=#=#= Begin test: Verify date_spec rule with years does match =#=#=#=
+unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
+unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
+unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
+Rule cli-prefer-rule-dummy-date_spec-only-years satisfies conditions
+=#=#=#= Current cib after: Verify date_spec rule with years does match =#=#=#=
+<cib epoch="7" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config/>
+    <nodes/>
+    <resources>
+      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
+    </resources>
+    <constraints>
+      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
+          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
+          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Verify date_spec rule with years does match - OK (0) =#=#=#=
+* Passed: crm_rule       - Verify date_spec rule with years does match
+=#=#=#= Begin test: Try to check a rule whose date_spec does not contain years= =#=#=#=
+unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
+unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
+unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
+Rule either must not use date_spec, or use date_spec with years= but not moon=
+Error checking rule: No such device or address
+=#=#=#= Current cib after: Try to check a rule whose date_spec does not contain years= =#=#=#=
+<cib epoch="7" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config/>
+    <nodes/>
+    <resources>
+      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
+    </resources>
+    <constraints>
+      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
+          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
+          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Try to check a rule whose date_spec does not contain years= - No such object (105) =#=#=#=
+* Passed: crm_rule       - Try to check a rule whose date_spec does not contain years=
+=#=#=#= Begin test: Try to check a rule whose date_spec contains years= and moon= =#=#=#=
+unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
+unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
+unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
+Rule either must not use date_spec, or use date_spec with years= but not moon=
+Error checking rule: No such device or address
+=#=#=#= Current cib after: Try to check a rule whose date_spec contains years= and moon= =#=#=#=
+<cib epoch="7" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config/>
+    <nodes/>
+    <resources>
+      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
+    </resources>
+    <constraints>
+      <rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01"/>
+      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
+          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
+          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
+        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
+          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
+            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
+          </date_expression>
+        </rule>
+      </rsc_location>
+    </constraints>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Try to check a rule whose date_spec contains years= and moon= - No such object (105) =#=#=#=
+* Passed: crm_rule       - Try to check a rule whose date_spec contains years= and moon=

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -932,7 +932,19 @@ test_rules() {
     export CIB_shadow=$shadow
 
     cibadmin -C -o resources   --xml-text '<primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy" />'
-    cibadmin -C -o constraints --xml-text '<rsc_location id="no-date-expression" rsc="dummy" score="-INFINITY" node="node01" />'
+
+    TMPXML=$(mktemp ${TMPDIR:-/tmp}/cts-cli.tools.xml.XXXXXXXXXX)
+    cat <<EOF > "$TMPXML"
+<rsc_location id="cli-too-many-date-expressions" rsc="dummy">
+  <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
+    <date_expression id="cli-date-expression-1" operation="gt" start="2020-01-01 01:00:00 -0500"/>
+    <date_expression id="cli-date-expression-2" operation="lt" end="2019-01-01 01:00:00 -0500"/>
+  </rule>
+</rsc_location>
+EOF
+
+    cibadmin -C -o constraints -x "$TMPXML"
+    rm -f "$TMPXML"
 
     TMPXML=$(mktemp ${TMPDIR:-/tmp}/cts-cli.tools.xml.XXXXXXXXXX)
     cat <<EOF > "$TMPXML"
@@ -1006,12 +1018,24 @@ EOF
     cibadmin -C -o constraints -x "$TMPXML"
     rm -f "$TMPXML"
 
+    TMPXML=$(mktemp ${TMPDIR:-/tmp}/cts-cli.tools.xml.XXXXXXXXXX)
+    cat <<EOF > "$TMPXML"
+<rsc_location id="cli-no-date_expression" rsc="dummy">
+  <rule id="cli-no-date_expression-rule" score="INFINITY">
+    <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
+  </rule>
+</rsc_location>
+EOF
+
+    cibadmin -C -o constraints -x "$TMPXML"
+    rm -f "$TMPXML"
+
     desc="Try to check a rule that doesn't exist"
     cmd="crm_rule -c -r blahblah"
     test_assert $CRM_EX_NOSUCH
 
-    desc="Try to check a rule that has no date_expression"
-    cmd="crm_rule -c -r no-date-expression"
+    desc="Try to check a rule that has too many date_expressions"
+    cmd="crm_rule -c -r cli-too-many-date-expressions"
     test_assert $CRM_EX_NOSUCH
 
     desc="Verify basic rule is expired"
@@ -1026,11 +1050,11 @@ EOF
     cmd="crm_rule -c -r cli-prefer-rule-dummy-not-yet"
     test_assert $CRM_EX_NOT_YET_IN_EFFECT
 
-    desc="Verify date_spec rule with years doesn't match"
+    desc="Verify date_spec rule with years has expired"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-only-years"
-    test_assert $CRM_EX_UNSATISFIED
+    test_assert $CRM_EX_EXPIRED
 
-    desc="Verify date_spec rule with years does match"
+    desc="Verify date_spec rule with years is in effect"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-only-years -d 20190201"
     test_assert $CRM_EX_OK
 
@@ -1041,6 +1065,10 @@ EOF
     desc="Try to check a rule whose date_spec contains years= and moon="
     cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-years-moon"
     test_assert $CRM_EX_NOSUCH
+
+    desc="Try to check a rule with no date_expression"
+    cmd="crm_rule -c -r cli-no-date_expression-rule"
+    test_assert $CRM_EX_UNIMPLEMENT_FEATURE
 
     unset CIB_shadow_dir
 }

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -964,6 +964,48 @@ EOF
     cibadmin -C -o constraints -x "$TMPXML"
     rm -f "$TMPXML"
 
+    TMPXML=$(mktemp ${TMPDIR:-/tmp}/cts-cli.tools.xml.XXXXXXXXXX)
+    cat <<EOF > "$TMPXML"
+<rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
+  <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
+    <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
+      <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
+    </date_expression>
+  </rule>
+</rsc_location>
+EOF
+
+    cibadmin -C -o constraints -x "$TMPXML"
+    rm -f "$TMPXML"
+
+    TMPXML=$(mktemp ${TMPDIR:-/tmp}/cts-cli.tools.xml.XXXXXXXXXX)
+    cat <<EOF > "$TMPXML"
+<rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
+  <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
+    <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
+      <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
+    </date_expression>
+  </rule>
+</rsc_location>
+EOF
+
+    cibadmin -C -o constraints -x "$TMPXML"
+    rm -f "$TMPXML"
+
+    TMPXML=$(mktemp ${TMPDIR:-/tmp}/cts-cli.tools.xml.XXXXXXXXXX)
+    cat <<EOF > "$TMPXML"
+<rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
+  <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
+    <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
+      <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
+    </date_expression>
+  </rule>
+</rsc_location>
+EOF
+
+    cibadmin -C -o constraints -x "$TMPXML"
+    rm -f "$TMPXML"
+
     desc="Try to check a rule that doesn't exist"
     cmd="crm_rule -c -r blahblah"
     test_assert $CRM_EX_NOSUCH
@@ -983,6 +1025,22 @@ EOF
     desc="Verify basic rule is not yet in effect"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-not-yet"
     test_assert $CRM_EX_NOT_YET_IN_EFFECT
+
+    desc="Verify date_spec rule with years doesn't match"
+    cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-only-years"
+    test_assert $CRM_EX_UNSATISFIED
+
+    desc="Verify date_spec rule with years does match"
+    cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-only-years -d 20190201"
+    test_assert $CRM_EX_OK
+
+    desc="Try to check a rule whose date_spec does not contain years="
+    cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-without-years"
+    test_assert $CRM_EX_NOSUCH
+
+    desc="Try to check a rule whose date_spec contains years= and moon="
+    cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-years-moon"
+    test_assert $CRM_EX_NOSUCH
 
     unset CIB_shadow_dir
 }

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1,6 +1,6 @@
 #!@BASH_PATH@
 #
-# Copyright 2008-2019 the Pacemaker project contributors
+# Copyright 2008-2020 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -65,6 +65,8 @@ CRM_EX_EXISTS=108
 CRM_EX_MULTIPLE=109
 CRM_EX_EXPIRED=110
 CRM_EX_NOT_YET_IN_EFFECT=111
+CRM_EX_INDETERMINATE=112
+CRM_EX_UNSATISFIED=113
 
 function test_assert() {
     target=$1; shift

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -54,6 +54,7 @@ VALGRIND_OPTS="
 CRM_EX_OK=0
 CRM_EX_ERROR=1
 CRM_EX_INVALID_PARAM=2
+CRM_EX_UNIMPLEMENT_FEATURE=3
 CRM_EX_INSUFFICIENT_PRIV=4
 CRM_EX_USAGE=64
 CRM_EX_CONFIG=78
@@ -1035,8 +1036,8 @@ EOF
     test_assert $CRM_EX_NOSUCH
 
     desc="Try to check a rule that has too many date_expressions"
-    cmd="crm_rule -c -r cli-too-many-date-expressions"
-    test_assert $CRM_EX_NOSUCH
+    cmd="crm_rule -c -r cli-rule-too-many-date-expressions"
+    test_assert $CRM_EX_UNIMPLEMENT_FEATURE
 
     desc="Verify basic rule is expired"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-expired"

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -107,6 +107,11 @@ enum pcmk_rc_e {
     /* When adding new values, use consecutively lower numbers, update the array
      * in lib/common/results.c, and test with crm_error.
      */
+    pcmk_rc_after_range         = -1025,
+    pcmk_rc_within_range        = -1024,
+    pcmk_rc_before_range        = -1023,
+    pcmk_rc_undetermined        = -1022,
+    pcmk_rc_op_unsatisfied      = -1021,
     pcmk_rc_ipc_pid_only        = -1020,
     pcmk_rc_ipc_unresponsive    = -1019,
     pcmk_rc_ipc_unauthorized    = -1018,

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -205,6 +205,7 @@ typedef enum crm_exit_e {
     CRM_EX_EXPIRED              = 110, // requested item has expired
     CRM_EX_NOT_YET_IN_EFFECT    = 111, // requested item is not in effect
     CRM_EX_INDETERMINATE        = 112, // could not determine status
+    CRM_EX_UNSATISFIED          = 113, // requested item does not satisfy constraints
 
     // Other
     CRM_EX_TIMEOUT              = 124, // convention from timeout(1)

--- a/include/crm/pengine/rules_internal.h
+++ b/include/crm/pengine/rules_internal.h
@@ -16,26 +16,17 @@
 #include <crm/pengine/common.h>
 #include <crm/pengine/rules.h>
 
-typedef enum {
-    pe_date_before_range,
-    pe_date_within_range,
-    pe_date_after_range,
-    pe_date_result_undetermined,
-    pe_date_op_satisfied,
-    pe_date_op_unsatisfied
-} pe_eval_date_result_t;
-
 GListPtr pe_unpack_alerts(xmlNode *alerts);
 void pe_free_alert_list(GListPtr alert_list);
 
 crm_time_t *pe_parse_xml_duration(crm_time_t * start, xmlNode * duration_spec);
 
-pe_eval_date_result_t pe_eval_date_expression(xmlNode *time_expr,
-                                              crm_time_t *now,
-                                              crm_time_t *next_change);
+int pe_eval_date_expression(xmlNode *time_expr,
+                            crm_time_t *now,
+                            crm_time_t *next_change);
 gboolean pe_test_date_expression(xmlNode *time_expr, crm_time_t *now,
                                  crm_time_t *next_change);
-pe_eval_date_result_t pe_cron_range_satisfied(crm_time_t * now, xmlNode * cron_spec);
+int pe_cron_range_satisfied(crm_time_t * now, xmlNode * cron_spec);
 gboolean pe_test_attr_expression(xmlNode *expr, GHashTable *hash, crm_time_t *now,
                                  pe_match_data_t *match_data);
 gboolean pe_test_role_expression(xmlNode * expr, enum rsc_role_e role, crm_time_t * now);

--- a/include/crm/pengine/rules_internal.h
+++ b/include/crm/pengine/rules_internal.h
@@ -35,7 +35,7 @@ pe_eval_date_result_t pe_eval_date_expression(xmlNode *time_expr,
                                               crm_time_t *next_change);
 gboolean pe_test_date_expression(xmlNode *time_expr, crm_time_t *now,
                                  crm_time_t *next_change);
-gboolean pe_cron_range_satisfied(crm_time_t * now, xmlNode * cron_spec);
+pe_eval_date_result_t pe_cron_range_satisfied(crm_time_t * now, xmlNode * cron_spec);
 gboolean pe_test_attr_expression(xmlNode *expr, GHashTable *hash, crm_time_t *now,
                                  pe_match_data_t *match_data);
 gboolean pe_test_role_expression(xmlNode * expr, enum rsc_role_e role, crm_time_t * now);

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -216,6 +216,26 @@ static struct pcmk__rc_info {
       "IPC server is blocked by unauthorized process",
       -pcmk_err_generic,
     },
+    { "pcmk_rc_op_unsatisifed",
+      "Not applicable under current conditions",
+      -pcmk_err_generic,
+    },
+    { "pcmk_rc_undetermined",
+      "Result undetermined",
+      -pcmk_err_generic,
+    },
+    { "pcmk_rc_before_range",
+      "Result occurs before given range",
+      -pcmk_err_generic,
+    },
+    { "pcmk_rc_within_range",
+      "Result occurs within given range",
+      -pcmk_err_generic,
+    },
+    { "pcmk_rc_after_range",
+      "Result occurs after given range",
+      -pcmk_err_generic,
+    }
 };
 
 #define PCMK__N_RC (sizeof(pcmk__rcs) / sizeof(struct pcmk__rc_info))
@@ -659,6 +679,21 @@ pcmk_rc2exitc(int rc)
         case EAGAIN:
         case EBUSY:
             return CRM_EX_UNSATISFIED;
+
+        case pcmk_rc_before_range:
+            return CRM_EX_NOT_YET_IN_EFFECT;
+
+        case pcmk_rc_after_range:
+            return CRM_EX_EXPIRED;
+
+        case pcmk_rc_undetermined:
+            return CRM_EX_INDETERMINATE;
+
+        case pcmk_rc_op_unsatisfied:
+            return CRM_EX_UNSATISFIED;
+
+        case pcmk_rc_within_range:
+            return CRM_EX_OK;
 
         default:
             return CRM_EX_ERROR;

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -479,6 +479,7 @@ crm_exit_name(crm_exit_t exit_code)
         case CRM_EX_EXPIRED: return "CRM_EX_EXPIRED";
         case CRM_EX_NOT_YET_IN_EFFECT: return "CRM_EX_NOT_YET_IN_EFFECT";
         case CRM_EX_INDETERMINATE: return "CRM_EX_INDETERMINATE";
+        case CRM_EX_UNSATISFIED: return "CRM_EX_UNSATISFIED";
         case CRM_EX_OLD: return "CRM_EX_OLD";
         case CRM_EX_TIMEOUT: return "CRM_EX_TIMEOUT";
         case CRM_EX_MAX: return "CRM_EX_UNKNOWN";
@@ -525,6 +526,7 @@ crm_exit_str(crm_exit_t exit_code)
         case CRM_EX_EXPIRED: return "Requested item has expired";
         case CRM_EX_NOT_YET_IN_EFFECT: return "Requested item is not yet in effect";
         case CRM_EX_INDETERMINATE: return "Could not determine status";
+        case CRM_EX_UNSATISFIED: return "Not applicable under current conditions";
         case CRM_EX_OLD: return "Update was older than existing configuration";
         case CRM_EX_TIMEOUT: return "Timeout occurred";
         case CRM_EX_MAX: return "Error occurred";
@@ -653,6 +655,10 @@ pcmk_rc2exitc(int rc)
         case ETIME:
         case ETIMEDOUT:
             return CRM_EX_TIMEOUT;
+
+        case EAGAIN:
+        case EBUSY:
+            return CRM_EX_UNSATISFIED;
 
         default:
             return CRM_EX_ERROR;

--- a/lib/pengine/tests/rules/pe_cron_range_satisfied.c
+++ b/lib/pengine/tests/rules/pe_cron_range_satisfied.c
@@ -4,7 +4,7 @@
 #include <crm/pengine/rules_internal.h>
 
 static void
-run_one_test(const char *t, const char *x, pe_eval_date_result_t expected) {
+run_one_test(const char *t, const char *x, int expected) {
     crm_time_t *tm = crm_time_new(t);
     xmlNodePtr xml = string2xml(x);
 
@@ -16,87 +16,87 @@ run_one_test(const char *t, const char *x, pe_eval_date_result_t expected) {
 
 static void
 no_time_given(void) {
-    g_assert_cmpint(pe_cron_range_satisfied(NULL, NULL), ==, pe_date_op_unsatisfied);
+    g_assert_cmpint(pe_cron_range_satisfied(NULL, NULL), ==, pcmk_rc_op_unsatisfied);
 }
 
 static void
 any_time_satisfies_empty_spec(void) {
     crm_time_t *tm = crm_time_new(NULL);
 
-    g_assert_cmpint(pe_cron_range_satisfied(tm, NULL), ==, pe_date_op_satisfied);
+    g_assert_cmpint(pe_cron_range_satisfied(tm, NULL), ==, pcmk_rc_ok);
 
     crm_time_free(tm);
 }
 
 static void
 time_satisfies_year_spec(void) {
-    run_one_test("2020-01-01", "<date_spec id='spec' years='2020'/>", pe_date_op_satisfied);
+    run_one_test("2020-01-01", "<date_spec id='spec' years='2020'/>", pcmk_rc_ok);
 }
 
 static void
 time_after_year_spec(void) {
-    run_one_test("2020-01-01", "<date_spec id='spec' years='2019'/>", pe_date_after_range);
+    run_one_test("2020-01-01", "<date_spec id='spec' years='2019'/>", pcmk_rc_after_range);
 }
 
 static void
 time_satisfies_year_range(void) {
-    run_one_test("2020-01-01", "<date_spec id='spec' years='2010-2030'/>", pe_date_op_satisfied);
+    run_one_test("2020-01-01", "<date_spec id='spec' years='2010-2030'/>", pcmk_rc_ok);
 }
 
 static void
 time_before_year_range(void) {
-    run_one_test("2000-01-01", "<date_spec id='spec' years='2010-2030'/>", pe_date_before_range);
+    run_one_test("2000-01-01", "<date_spec id='spec' years='2010-2030'/>", pcmk_rc_before_range);
 }
 
 static void
 time_after_year_range(void) {
-    run_one_test("2020-01-01", "<date_spec id='spec' years='2010-2015'/>", pe_date_after_range);
+    run_one_test("2020-01-01", "<date_spec id='spec' years='2010-2015'/>", pcmk_rc_after_range);
 }
 
 static void
 range_without_start_year_passes(void) {
-    run_one_test("2010-01-01", "<date_spec id='spec' years='-2020'/>", pe_date_op_satisfied);
+    run_one_test("2010-01-01", "<date_spec id='spec' years='-2020'/>", pcmk_rc_ok);
 }
 
 static void
 range_without_end_year_passes(void) {
-    run_one_test("2010-01-01", "<date_spec id='spec' years='2000-'/>", pe_date_op_satisfied);
-    run_one_test("2000-10-01", "<date_spec id='spec' years='2000-'/>", pe_date_op_satisfied);
+    run_one_test("2010-01-01", "<date_spec id='spec' years='2000-'/>", pcmk_rc_ok);
+    run_one_test("2000-10-01", "<date_spec id='spec' years='2000-'/>", pcmk_rc_ok);
 }
 
 static void
 yeardays_satisfies(void) {
-    run_one_test("2020-01-30", "<date_spec id='spec' yeardays='30'/>", pe_date_op_satisfied);
+    run_one_test("2020-01-30", "<date_spec id='spec' yeardays='30'/>", pcmk_rc_ok);
 }
 
 static void
 time_after_yeardays_spec(void) {
-    run_one_test("2020-02-15", "<date_spec id='spec' yeardays='40'/>", pe_date_after_range);
+    run_one_test("2020-02-15", "<date_spec id='spec' yeardays='40'/>", pcmk_rc_after_range);
 }
 
 static void
 yeardays_feb_29_satisfies(void) {
-    run_one_test("2016-02-29", "<date_spec id='spec' yeardays='60'/>", pe_date_op_satisfied);
+    run_one_test("2016-02-29", "<date_spec id='spec' yeardays='60'/>", pcmk_rc_ok);
 }
 
 static void
 exact_ymd_satisfies(void) {
-    run_one_test("2001-12-31", "<date_spec id='spec' years='2001' months='12' monthdays='31'/>", pe_date_op_satisfied);
+    run_one_test("2001-12-31", "<date_spec id='spec' years='2001' months='12' monthdays='31'/>", pcmk_rc_ok);
 }
 
 static void
 range_in_month_satisfies(void) {
-    run_one_test("2001-06-10", "<date_spec id='spec' years='2001' months='6' monthdays='1-10'/>", pe_date_op_satisfied);
+    run_one_test("2001-06-10", "<date_spec id='spec' years='2001' months='6' monthdays='1-10'/>", pcmk_rc_ok);
 }
 
 static void
 exact_ymd_after_range(void) {
-    run_one_test("2001-12-31", "<date_spec id='spec' years='2001' months='12' monthdays='30'/>", pe_date_after_range);
+    run_one_test("2001-12-31", "<date_spec id='spec' years='2001' months='12' monthdays='30'/>", pcmk_rc_after_range);
 }
 
 static void
 time_after_monthdays_range(void) {
-    run_one_test("2001-06-10", "<date_spec id='spec' years='2001' months='6' monthdays='11-15'/>", pe_date_before_range);
+    run_one_test("2001-06-10", "<date_spec id='spec' years='2001' months='6' monthdays='11-15'/>", pcmk_rc_before_range);
 }
 
 int main(int argc, char **argv) {

--- a/lib/pengine/tests/rules/pe_cron_range_satisfied.c
+++ b/lib/pengine/tests/rules/pe_cron_range_satisfied.c
@@ -4,11 +4,11 @@
 #include <crm/pengine/rules_internal.h>
 
 static void
-run_one_test(const char *t, const char *x, gboolean expected) {
+run_one_test(const char *t, const char *x, pe_eval_date_result_t expected) {
     crm_time_t *tm = crm_time_new(t);
     xmlNodePtr xml = string2xml(x);
 
-    g_assert(pe_cron_range_satisfied(tm, xml) == expected);
+    g_assert_cmpint(pe_cron_range_satisfied(tm, xml), ==, expected);
 
     crm_time_free(tm);
     xmlFreeNode(xml);
@@ -16,95 +16,96 @@ run_one_test(const char *t, const char *x, gboolean expected) {
 
 static void
 no_time_given(void) {
-    g_assert(pe_cron_range_satisfied(NULL, NULL) == FALSE);
+    g_assert_cmpint(pe_cron_range_satisfied(NULL, NULL), ==, pe_date_op_unsatisfied);
 }
 
 static void
 any_time_satisfies_empty_spec(void) {
     crm_time_t *tm = crm_time_new(NULL);
 
-    g_assert(pe_cron_range_satisfied(tm, NULL) == TRUE);
+    g_assert_cmpint(pe_cron_range_satisfied(tm, NULL), ==, pe_date_op_satisfied);
 
     crm_time_free(tm);
 }
 
 static void
 time_satisfies_year_spec(void) {
-    run_one_test("2020-01-01", "<date_spec id='spec' years='2020'/>", TRUE);
+    run_one_test("2020-01-01", "<date_spec id='spec' years='2020'/>", pe_date_op_satisfied);
 }
 
 static void
-time_doesnt_satisfy_year_spec(void) {
-    run_one_test("2020-01-01", "<date_spec id='spec' years='2019'/>", FALSE);
+time_after_year_spec(void) {
+    run_one_test("2020-01-01", "<date_spec id='spec' years='2019'/>", pe_date_after_range);
 }
 
 static void
 time_satisfies_year_range(void) {
-    run_one_test("2020-01-01", "<date_spec id='spec' years='2010-2030'/>", TRUE);
+    run_one_test("2020-01-01", "<date_spec id='spec' years='2010-2030'/>", pe_date_op_satisfied);
 }
 
 static void
 time_before_year_range(void) {
-    run_one_test("2000-01-01", "<date_spec id='spec' years='2010-2030'/>", FALSE);
+    run_one_test("2000-01-01", "<date_spec id='spec' years='2010-2030'/>", pe_date_before_range);
 }
 
 static void
 time_after_year_range(void) {
-    run_one_test("2020-01-01", "<date_spec id='spec' years='2010-2015'/>", FALSE);
+    run_one_test("2020-01-01", "<date_spec id='spec' years='2010-2015'/>", pe_date_after_range);
 }
 
 static void
 range_without_start_year_passes(void) {
-    run_one_test("2010-01-01", "<date_spec id='spec' years='-2020'/>", TRUE);
+    run_one_test("2010-01-01", "<date_spec id='spec' years='-2020'/>", pe_date_op_satisfied);
 }
 
 static void
 range_without_end_year_passes(void) {
-    run_one_test("2010-01-01", "<date_spec id='spec' years='2000-'/>", TRUE);
-    run_one_test("2000-10-01", "<date_spec id='spec' years='2000-'/>", TRUE);
+    run_one_test("2010-01-01", "<date_spec id='spec' years='2000-'/>", pe_date_op_satisfied);
+    run_one_test("2000-10-01", "<date_spec id='spec' years='2000-'/>", pe_date_op_satisfied);
 }
 
 static void
 yeardays_satisfies(void) {
-    run_one_test("2020-01-30", "<date_spec id='spec' yeardays='30'/>", TRUE);
+    run_one_test("2020-01-30", "<date_spec id='spec' yeardays='30'/>", pe_date_op_satisfied);
 }
 
 static void
-yeardays_doesnt_satisfy(void) {
-    run_one_test("2020-02-15", "<date_spec id='spec' yeardays='40'/>", FALSE);
+time_after_yeardays_spec(void) {
+    run_one_test("2020-02-15", "<date_spec id='spec' yeardays='40'/>", pe_date_after_range);
 }
 
 static void
 yeardays_feb_29_satisfies(void) {
-    run_one_test("2016-02-29", "<date_spec id='spec' yeardays='60'/>", TRUE);
+    run_one_test("2016-02-29", "<date_spec id='spec' yeardays='60'/>", pe_date_op_satisfied);
 }
 
 static void
 exact_ymd_satisfies(void) {
-    run_one_test("2001-12-31", "<date_spec id='spec' years='2001' months='12' monthdays='31'/>", TRUE);
+    run_one_test("2001-12-31", "<date_spec id='spec' years='2001' months='12' monthdays='31'/>", pe_date_op_satisfied);
 }
 
 static void
 range_in_month_satisfies(void) {
-    run_one_test("2001-06-10", "<date_spec id='spec' years='2001' months='6' monthdays='1-10'/>", TRUE);
+    run_one_test("2001-06-10", "<date_spec id='spec' years='2001' months='6' monthdays='1-10'/>", pe_date_op_satisfied);
 }
 
 static void
-exact_ymd_doesnt_satisfy(void) {
-    run_one_test("2001-12-31", "<date_spec id='spec' years='2001' months='12' monthdays='30'/>", FALSE);
+exact_ymd_after_range(void) {
+    run_one_test("2001-12-31", "<date_spec id='spec' years='2001' months='12' monthdays='30'/>", pe_date_after_range);
 }
 
 static void
-range_in_month_doesnt_satisfy(void) {
-    run_one_test("2001-06-10", "<date_spec id='spec' years='2001' months='6' monthdays='11-15'/>", FALSE);
+time_after_monthdays_range(void) {
+    run_one_test("2001-06-10", "<date_spec id='spec' years='2001' months='6' monthdays='11-15'/>", pe_date_before_range);
 }
 
 int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
+
     g_test_add_func("/pengine/rules/cron_range/no_time_given", no_time_given);
     g_test_add_func("/pengine/rules/cron_range/empty_spec", any_time_satisfies_empty_spec);
     g_test_add_func("/pengine/rules/cron_range/year/time_satisfies", time_satisfies_year_spec);
-    g_test_add_func("/pengine/rules/cron_range/year/time_doesnt_satisfy", time_doesnt_satisfy_year_spec);
+    g_test_add_func("/pengine/rules/cron_range/year/time_after", time_after_year_spec);
     g_test_add_func("/pengine/rules/cron_range/range/time_satisfies_year", time_satisfies_year_range);
     g_test_add_func("/pengine/rules/cron_range/range/time_before_year", time_before_year_range);
     g_test_add_func("/pengine/rules/cron_range/range/time_after_year", time_after_year_range);
@@ -112,12 +113,12 @@ int main(int argc, char **argv) {
     g_test_add_func("/pengine/rules/cron_range/range/no_end_year_passes", range_without_end_year_passes);
 
     g_test_add_func("/pengine/rules/cron_range/yeardays/satisfies", yeardays_satisfies);
-    g_test_add_func("/pengine/rules/cron_range/yeardays/doesnt_satisfy", yeardays_doesnt_satisfy);
+    g_test_add_func("/pengine/rules/cron_range/yeardays/time_after", time_after_yeardays_spec);
     g_test_add_func("/pengine/rules/cron_range/yeardays/feb_29_sasitfies", yeardays_feb_29_satisfies);
 
     g_test_add_func("/pengine/rules/cron_range/exact/ymd_satisfies", exact_ymd_satisfies);
     g_test_add_func("/pengine/rules/cron_range/range/in_month_satisfies", range_in_month_satisfies);
-    g_test_add_func("/pengine/rules/cron_range/exact/ymd_doesnt_satisfy", exact_ymd_doesnt_satisfy);
-    g_test_add_func("/pengine/rules/cron_range/range/in_month_doesnt_satisfy", range_in_month_doesnt_satisfy);
+    g_test_add_func("/pengine/rules/cron_range/exact/ymd_after_range", exact_ymd_after_range);
+    g_test_add_func("/pengine/rules/cron_range/range/in_month_after", time_after_monthdays_range);
     return g_test_run();
 }

--- a/tools/crm_rule.c
+++ b/tools/crm_rule.c
@@ -125,7 +125,7 @@ crm_rule_check(pe_working_set_t *data_set, const char *rule_id, crm_time_t *effe
     max = numXpathResults(xpathObj);
 
     if (max != 1) {
-        CMD_ERR("Can't check rule %s because it has more than one date_expression", rule_id);
+        CMD_ERR("Can't check rule %s because it does not have exactly one date_expression", rule_id);
         rc = EOPNOTSUPP;
         goto bail;
     }


### PR DESCRIPTION
I'm not really convinced the CRM_EX_UNSATISFIED patch is necessary, but it seemed worth it to differentiate between the expired/unexpired and currently-in-effect/not-in-effect cases.  They seem subtly different to me.