### PR TITLE
Fix: libpe_status: Remove extra colons from operations output.

### DIFF
--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -147,7 +147,8 @@ op_history_string(xmlNode *xml_op, const char *task, const char *interval_ms_s,
             free(queue_str);
         }
     } else {
-        buf = crm_strdup_printf("(%s) %s:%s", call, task,
+        buf = crm_strdup_printf("(%s) %s%s%s", call, task,
+                                interval_str ? ":" : "",
                                 interval_str ? interval_str : "");
     }
 


### PR DESCRIPTION
This patch turns this output:

    Operations:
      * Node: cluster01:
        * stonithid: migration-threshold=1000000 fail-count=1000000:
          * (11) start:
          * (14) stop:

Into this:

    Operations:
      * Node: cluster01:
        * stonithid: migration-threshold=1000000 fail-count=1000000:
          * (11) start
          * (14) stop