### PR TITLE
Continue updating libcrmcommon to current best practices

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -879,11 +879,10 @@ dnl ========================================================================
 dnl Headers
 dnl ========================================================================
 
-# Some distributions insert #warnings into deprecated headers such as
-# timeb.h used at some point in past. If we will enable fatal warnings
-# for the build, then enable them for the header checks as well, otherwise
-# the build could fail even though the header check succeeds.
-# (We should probably be doing this in more places.)
+# Some distributions insert #warnings into deprecated headers. If we will
+# enable fatal warnings for the build, then enable them for the header checks
+# as well, otherwise the build could fail even though the header check
+# succeeds. (We should probably be doing this in more places.)
 if test "x${enable_fatal_warnings}" = xyes ; then
     cc_temp_flags "$CFLAGS $WERROR"
 fi
@@ -1418,7 +1417,7 @@ case $SUPPORT_NAGIOS in
         else
             SUPPORT_NAGIOS=1
         fi
-        ``
+        ;;
     *)
         SUPPORT_NAGIOS=0
         ;;

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -317,7 +317,7 @@ process_ping_reply(xmlNode *reply)
     const char *digest = crm_element_value(pong, XML_ATTR_DIGEST);
 
     if (seq_s) {
-        seq = crm_int_helper(seq_s, NULL);
+        seq = (uint64_t) crm_parse_ll(seq_s, NULL);
     }
 
     if(digest == NULL) {

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -421,7 +421,7 @@ do_local_notify(xmlNode * notify_src, const char *client_id,
         case PCMK__CLIENT_TLS:
 #endif
         case PCMK__CLIENT_TCP:
-            crm_remote_send(client_obj->remote, notify_src);
+            pcmk__remote_send_xml(client_obj->remote, notify_src);
             break;
         default:
             crm_err("Unknown transport %d for %s", client_obj->kind, client_obj->name);

--- a/daemons/based/based_io.c
+++ b/daemons/based/based_io.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -129,7 +131,7 @@ static int cib_archive_filter(const struct dirent * a)
     } else if(strstr(a->d_name, "cib-") != a->d_name) {
         crm_trace("%s - wrong prefix", a->d_name);
 
-    } else if (crm_ends_with_ext(a->d_name, ".sig")) {
+    } else if (pcmk__ends_with_ext(a->d_name, ".sig")) {
         crm_trace("%s - wrong suffix", a->d_name);
 
     } else {

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -92,7 +92,7 @@ cib_notify_send_one(gpointer key, gpointer value, gpointer user_data)
 #endif
             case PCMK__CLIENT_TCP:
                 crm_debug("Sent %s notification to client %s/%s", type, client->name, client->id);
-                crm_remote_send(client->remote, update->msg);
+                pcmk__remote_send_xml(client->remote, update->msg);
                 break;
             default:
                 crm_err("Unknown transport %d for %s", client->kind, client->name);

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1876,7 +1876,6 @@ construct_op(lrm_state_t * lrm_state, xmlNode * rsc_op, const char *rsc_id, cons
     lrmd_event_data_t *op = NULL;
     const char *op_delay = NULL;
     const char *op_timeout = NULL;
-    const char *interval_ms_s = NULL;
     GHashTable *params = NULL;
 
     const char *transition = NULL;
@@ -1910,12 +1909,15 @@ construct_op(lrm_state_t * lrm_state, xmlNode * rsc_op, const char *rsc_id, cons
     g_hash_table_remove(params, CRM_META "_op_target_rc");
 
     op_delay = crm_meta_value(params, XML_OP_ATTR_START_DELAY);
-    op_timeout = crm_meta_value(params, XML_ATTR_TIMEOUT);
-    interval_ms_s = crm_meta_value(params, XML_LRM_ATTR_INTERVAL_MS);
-
-    op->interval_ms = crm_parse_ms(interval_ms_s);
-    op->timeout = crm_parse_int(op_timeout, "0");
     op->start_delay = crm_parse_int(op_delay, "0");
+
+    op_timeout = crm_meta_value(params, XML_ATTR_TIMEOUT);
+    op->timeout = crm_parse_int(op_timeout, "0");
+
+    if (pcmk__guint_from_hash(params, CRM_META "_" XML_LRM_ATTR_INTERVAL_MS, 0,
+                              &(op->interval_ms)) != pcmk_rc_ok) {
+        op->interval_ms = 0;
+    }
 
 #if ENABLE_VERSIONED_ATTRS
     // Resolve any versioned parameters

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -33,13 +33,14 @@ static bool fence_reaction_panic = FALSE;
 static unsigned long int stonith_max_attempts = 10;
 static GHashTable *stonith_failures = NULL;
 
+// crmd_opts defines default for stonith-max-attempts, so value is never NULL
 void
 update_stonith_max_attempts(const char *value)
 {
     if (safe_str_eq(value, CRM_INFINITY_S)) {
        stonith_max_attempts = CRM_SCORE_INFINITY;
     } else {
-       stonith_max_attempts = crm_int_helper(value, NULL);
+       stonith_max_attempts = (unsigned long int) crm_parse_ll(value, NULL);
     }
 }
 

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -271,8 +271,8 @@ compare_int_fields(xmlNode * left, xmlNode * right, const char *field)
     const char *elem_l = crm_element_value(left, field);
     const char *elem_r = crm_element_value(right, field);
 
-    int int_elem_l = crm_int_helper(elem_l, NULL);
-    int int_elem_r = crm_int_helper(elem_r, NULL);
+    long long int_elem_l = elem_l? crm_parse_ll(elem_l, NULL) : -1;
+    long long int_elem_r = elem_r? crm_parse_ll(elem_r, NULL) : -1;
 
     if (int_elem_l < int_elem_r) {
         return -1;

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -616,7 +616,6 @@ handle_failcount_op(xmlNode * stored_msg)
     const char *rsc = NULL;
     const char *uname = NULL;
     const char *op = NULL;
-    const char *interval_ms_s = NULL;
     char *interval_spec = NULL;
     guint interval_ms = 0;
     gboolean is_remote_node = FALSE;
@@ -632,9 +631,9 @@ handle_failcount_op(xmlNode * stored_msg)
         if (xml_attrs) {
             op = crm_element_value(xml_attrs,
                                    CRM_META "_" XML_RSC_ATTR_CLEAR_OP);
-            interval_ms_s = crm_element_value(xml_attrs,
-                                              CRM_META "_" XML_RSC_ATTR_CLEAR_INTERVAL);
-            interval_ms = crm_parse_ms(interval_ms_s);
+            crm_element_value_ms(xml_attrs,
+                                 CRM_META "_" XML_RSC_ATTR_CLEAR_INTERVAL,
+                                 &interval_ms);
         }
     }
     uname = crm_element_value(xml_op, XML_LRM_ATTR_TARGET);

--- a/daemons/controld/controld_throttle.c
+++ b/daemons/controld/controld_throttle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the Pacemaker project contributors
+ * Copyright 2013-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -76,9 +76,9 @@ load2str(enum throttle_state_e mode)
 static char *
 find_cib_loadfile(void)
 {
-    int pid = crm_procfs_pid_of("pacemaker-based");
+    pid_t pid = pcmk__procfs_pid_of("pacemaker-based");
 
-    return pid? crm_strdup_printf("/proc/%d/stat", pid) : NULL;
+    return pid? crm_strdup_printf("/proc/%lld/stat", (long long) pid) : NULL;
 }
 
 static bool
@@ -306,7 +306,7 @@ throttle_mode(void)
     float load;
     float thresholds[4];
 
-    cores = crm_procfs_num_cores();
+    cores = pcmk__procfs_num_cores();
     if(throttle_cib_load(&load)) {
         float cib_max_cpu = 0.95;
 
@@ -401,7 +401,7 @@ throttle_update_job_max(const char *preference)
 {
     int max = 0;
 
-    throttle_job_max = 2 * crm_procfs_num_cores();
+    throttle_job_max = 2 * pcmk__procfs_num_cores();
 
     if(preference) {
         /* Global preference from the CIB */

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -214,11 +214,7 @@ lrmd_server_send_reply(pcmk__client_t *client, uint32_t id, xmlNode *reply)
             return pcmk__ipc_send_xml(client, id, reply, FALSE);
 #ifdef ENABLE_PCMK_REMOTE
         case PCMK__CLIENT_TLS:
-            {
-                int legacy_rc = lrmd_tls_send_msg(client->remote, reply, id,
-                                                  "reply");
-                return (legacy_rc >= 0)? pcmk_rc_ok : pcmk_legacy2rc(legacy_rc);
-            }
+            return lrmd_tls_send_msg(client->remote, reply, id, "reply");
 #endif
         default:
             crm_err("Could not send reply: unknown client type %d",
@@ -245,10 +241,7 @@ lrmd_server_send_notify(pcmk__client_t *client, xmlNode *msg)
                 crm_trace("Could not notify remote client: disconnected");
                 return ENOTCONN;
             } else {
-                int legacy_rc = lrmd_tls_send_msg(client->remote, msg, 0,
-                                                  "notify");
-
-                return (legacy_rc >= 0)? pcmk_rc_ok : pcmk_legacy2rc(legacy_rc);
+                return lrmd_tls_send_msg(client->remote, msg, 0, "notify");
             }
 #endif
         default:

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -128,7 +128,7 @@ process_pe_message(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
         value = pe_pref(sched_data_set->config_hash, series[series_id].param);
 
         if (value != NULL) {
-            series_wrap = crm_int_helper(value, NULL);
+            series_wrap = (int) crm_parse_ll(value, NULL);
             if (errno != 0) {
                 series_wrap = series[series_id].wrap;
             }

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -105,7 +105,8 @@ const char *pcmk_message_name(const char *name);
 
 /* internal generic string functions (from strings.c) */
 
-guint crm_parse_ms(const char *text);
+int pcmk__guint_from_hash(GHashTable *table, const char *key, guint default_val,
+                          guint *result);
 bool crm_starts_with(const char *str, const char *prefix);
 gboolean crm_ends_with(const char *s, const char *match);
 gboolean crm_ends_with_ext(const char *s, const char *match);

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -107,13 +107,12 @@ const char *pcmk_message_name(const char *name);
 
 int pcmk__guint_from_hash(GHashTable *table, const char *key, guint default_val,
                           guint *result);
-bool crm_starts_with(const char *str, const char *prefix);
-gboolean crm_ends_with(const char *s, const char *match);
-gboolean crm_ends_with_ext(const char *s, const char *match);
-char *add_list_element(char *list, const char *value);
-bool crm_compress_string(const char *data, int length, int max, char **result,
-                         unsigned int *result_len);
-gint crm_alpha_sort(gconstpointer a, gconstpointer b);
+bool pcmk__starts_with(const char *str, const char *prefix);
+bool pcmk__ends_with(const char *s, const char *match);
+bool pcmk__ends_with_ext(const char *s, const char *match);
+char *pcmk__add_word(char *list, const char *word);
+int pcmk__compress(const char *data, unsigned int length, unsigned int max,
+                   char **result, unsigned int *result_len);
 
 /* Correctly displaying singular or plural is complicated; consider "1 node has"
  * vs. "2 nodes have". A flexible solution is to pluralize entire strings, e.g.

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -52,9 +52,8 @@ void pcmk__close_fds_in_child(bool);
 
 /* internal procfs utilities (from procfs.c) */
 
-int crm_procfs_process_info(struct dirent *entry, char *name, int *pid);
-int crm_procfs_pid_of(const char *name);
-unsigned int crm_procfs_num_cores(void);
+pid_t pcmk__procfs_pid_of(const char *name);
+unsigned int pcmk__procfs_num_cores(void);
 
 
 /* internal XML schema functions (from xml.c) */

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -105,7 +105,6 @@ const char *pcmk_message_name(const char *name);
 
 /* internal generic string functions (from strings.c) */
 
-long long crm_int_helper(const char *text, char **end_text);
 guint crm_parse_ms(const char *text);
 bool crm_starts_with(const char *str, const char *prefix);
 gboolean crm_ends_with(const char *s, const char *match);

--- a/include/crm/common/remote_internal.h
+++ b/include/crm/common/remote_internal.h
@@ -14,18 +14,15 @@
 
 typedef struct pcmk__remote_s pcmk__remote_t;
 
-int crm_remote_send(pcmk__remote_t *remote, xmlNode *msg);
-int crm_remote_ready(pcmk__remote_t *remote, int total_timeout /*ms */ );
-gboolean crm_remote_recv(pcmk__remote_t *remote, int total_timeout /*ms */,
-                         int *disconnected);
-xmlNode *crm_remote_parse_buffer(pcmk__remote_t *remote);
-int crm_remote_tcp_connect(const char *host, int port);
-int crm_remote_tcp_connect_async(const char *host, int port,
-                                 int timeout /*ms */,
-                                 int *timer_id, void *userdata,
-                                 void (*callback) (void *userdata, int sock));
-int crm_remote_accept(int ssock);
-void crm_sockaddr2str(void *sa, char *s);
+int pcmk__remote_send_xml(pcmk__remote_t *remote, xmlNode *msg);
+int pcmk__remote_ready(pcmk__remote_t *remote, int timeout_ms);
+int pcmk__read_remote_message(pcmk__remote_t *remote, int timeout_ms);
+xmlNode *pcmk__remote_message_xml(pcmk__remote_t *remote);
+int pcmk__connect_remote(const char *host, int port, int timeout_ms,
+                         int *timer_id, int *sock_fd, void *userdata,
+                         void (*callback) (void *userdata, int rc, int sock));
+int pcmk__accept_remote_connection(int ssock, int *csock);
+void pcmk__sockaddr2str(void *sa, char *s);
 
 #  ifdef HAVE_GNUTLS_GNUTLS_H
 #    include <gnutls/gnutls.h>
@@ -38,13 +35,14 @@ int pcmk__read_handshake_data(pcmk__client_t *client);
 
 /*!
  * \internal
- * \brief Initiate the client handshake after establishing the tcp socket
+ * \brief Perform client TLS handshake after establishing TCP socket
  *
- * \return 0 on success, negative number on failure
- * \note This function will block until the entire handshake is complete or
- *        until the timeout period is reached.
+ * \param[in] remote      Newly established remote connection
+ * \param[in] timeout_ms  Abort if entire handshake is not complete within this
+ *
+ * \return Standard Pacemaker return code
  */
-int crm_initiate_client_tls_handshake(pcmk__remote_t *remote, int timeout_ms);
+int pcmk__tls_client_handshake(pcmk__remote_t *remote, int timeout_ms);
 
 #  endif    // HAVE_GNUTLS_GNUTLS_H
 #endif      // PCMK__REMOTE__H

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -50,6 +50,7 @@ gboolean crm_is_true(const char *s);
 int crm_str_to_boolean(const char *s, int *ret);
 long long crm_parse_ll(const char *text, const char *default_text);
 int crm_parse_int(const char *text, const char *default_text);
+long long crm_get_msec(const char *input);
 char * crm_strip_trailing_newline(char *str);
 gboolean crm_str_eq(const char *a, const char *b, gboolean use_case);
 gboolean safe_str_neq(const char *a, const char *b);
@@ -112,7 +113,6 @@ GHashTable *crm_str_table_dup(GHashTable *old_table);
 /* public I/O functions (from io.c) */
 void crm_build_path(const char *path_c, mode_t mode);
 
-long long crm_get_msec(const char *input);
 guint crm_parse_interval_spec(const char *input);
 int char2score(const char *score);
 char *score2char(int score);

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -258,16 +258,20 @@ void cib_ipc_servers_destroy(qb_ipcs_service_t *ipcs_ro,
         qb_ipcs_service_t *ipcs_rw,
         qb_ipcs_service_t *ipcs_shm);
 
-static inline void *realloc_safe(void *ptr, size_t size)
+static inline void *
+realloc_safe(void *ptr, size_t size)
 {
-    void *ret = realloc(ptr, size);
+    void *new_ptr;
 
-    if (ret == NULL) {
-        free(ptr); /* make coverity happy */
+    // realloc(p, 0) can replace free(p) but this wrapper can't
+    CRM_ASSERT(size > 0);
+
+    new_ptr = realloc(ptr, size);
+    if (new_ptr == NULL) {
+        free(ptr);
         abort();
     }
-
-    return ret;
+    return new_ptr;
 }
 
 const char *crm_xml_add_last_written(xmlNode *xml_node);

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -691,7 +691,7 @@ cib_file_signoff(cib_t * cib)
 
         /* Otherwise, it's a simple write */
         } else {
-            gboolean do_bzip = crm_ends_with_ext(private->filename, ".bz2");
+            gboolean do_bzip = pcmk__ends_with_ext(private->filename, ".bz2");
 
             if (write_xml_file(in_mem_cib, private->filename, do_bzip) <= 0) {
                 rc = pcmk_err_generic;

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -199,7 +201,7 @@ crm_peer_uname(const char *uuid)
 
 #if SUPPORT_COROSYNC
     if (is_corosync_cluster()) {
-        uint32_t id = crm_int_helper(uuid, NULL);
+        uint32_t id = (uint32_t) crm_parse_ll(uuid, NULL);
 
         if (id != 0) {
             node = crm_find_peer(id, NULL);

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -729,7 +729,8 @@ send_cluster_text(enum crm_ais_msg_class msg_class, const char *data,
         unsigned int new_size = 0;
         char *uncompressed = strdup(data);
 
-        if (crm_compress_string(uncompressed, msg->size, 0, &compressed, &new_size)) {
+        if (pcmk__compress(uncompressed, (unsigned int) msg->size, 0,
+                           &compressed, &new_size) == pcmk_rc_ok) {
 
             msg->header.size = sizeof(AIS_Message) + new_size;
             msg = realloc_safe(msg, msg->header.size);

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -803,8 +803,9 @@ pcmk__ipc_prepare_iov(uint32_t request, xmlNode *message,
     } else {
         unsigned int new_size = 0;
 
-        if (crm_compress_string
-            (buffer, header->size_uncompressed, max_send_size, &compressed, &new_size)) {
+        if (pcmk__compress(buffer, (unsigned int) header->size_uncompressed,
+                           (unsigned int) max_send_size, &compressed,
+                           &new_size) == pcmk_rc_ok) {
 
             header->flags |= crm_ipc_compressed;
             header->size_compressed = new_size;

--- a/lib/common/ipc.c
+++ b/lib/common/ipc.c
@@ -528,10 +528,11 @@ pcmk__free_client(pcmk__client_t *c)
 }
 
 /*!
+ * \internal
  * \brief Raise IPC eviction threshold for a client, if allowed
  *
  * \param[in,out] client     Client to modify
- * \param[in]     queue_max  New threshold (as string)
+ * \param[in]     qmax       New threshold (as non-NULL string)
  *
  * \return TRUE if change was allowed, FALSE otherwise
  */
@@ -539,10 +540,12 @@ bool
 pcmk__set_client_queue_max(pcmk__client_t *client, const char *qmax)
 {
     if (is_set(client->flags, pcmk__client_privileged)) {
-        int qmax_int = crm_int_helper(qmax, NULL);
+        long long qmax_int;
 
+        errno = 0;
+        qmax_int = crm_parse_ll(qmax, NULL);
         if ((errno == 0) && (qmax_int > 0)) {
-            client->queue_max = qmax_int;
+            client->queue_max = (unsigned int) qmax_int;
             return TRUE;
         }
     }

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -591,7 +591,7 @@ crm_element_value_ll(const xmlNode *data, const char *name, long long *dest)
     value = crm_element_value(data, name);
     if (value) {
         errno = 0;
-        *dest = crm_int_helper(value, NULL);
+        *dest = crm_parse_ll(value, NULL);
         if (errno == 0) {
             return 0;
         }

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -614,11 +614,24 @@ int
 crm_element_value_ms(const xmlNode *data, const char *name, guint *dest)
 {
     const char *value = NULL;
+    long long value_ll;
 
     CRM_CHECK(dest != NULL, return -1);
+    *dest = 0;
+
     value = crm_element_value(data, name);
-    *dest = crm_parse_ms(value);
-    return errno? -1 : 0;
+    if (value == NULL) {
+        return pcmk_ok;
+    }
+
+    errno = 0;
+    value_ll = crm_parse_ll(value, NULL);
+    if ((errno != 0) || (value_ll < 0) || (value_ll > G_MAXUINT)) {
+        return -1;
+    }
+
+    *dest = (guint) value_ll;
+    return pcmk_ok;
 }
 
 /*!

--- a/lib/common/procfs.c
+++ b/lib/common/procfs.c
@@ -155,7 +155,7 @@ pcmk__procfs_num_cores(void)
         char buffer[2048];
 
         while (fgets(buffer, sizeof(buffer), stream)) {
-            if (crm_starts_with(buffer, "cpu") && isdigit(buffer[3])) {
+            if (pcmk__starts_with(buffer, "cpu") && isdigit(buffer[3])) {
                 ++cores;
             }
         }

--- a/lib/common/procfs.c
+++ b/lib/common/procfs.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2015-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2015-2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -123,7 +125,7 @@ crm_procfs_pid_of(const char *name)
     while ((entry = readdir(dp)) != NULL) {
         if ((crm_procfs_process_info(entry, entry_name, &pid) == 0)
             && safe_str_eq(entry_name, name)
-            && (crm_pid_active(pid, NULL) == 1)) {
+            && (pcmk__pid_active((pid_t) pid, NULL) == pcmk_rc_ok)) {
 
             crm_info("Found %s active as process %d", name, pid);
             break;

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -69,8 +69,7 @@
 #define REMOTE_MSG_VERSION 1
 #define ENDIAN_LOCAL 0xBADADBBD
 
-struct crm_remote_header_v0 
-{
+struct remote_header_v0 {
     uint32_t endian;    /* Detect messages from hosts with different endian-ness */
     uint32_t version;
     uint64_t id;
@@ -84,11 +83,22 @@ struct crm_remote_header_v0
 
 } __attribute__ ((packed));
 
-static struct crm_remote_header_v0 *
-crm_remote_header(pcmk__remote_t *remote)
+/*!
+ * \internal
+ * \brief Retrieve remote message header, in local endianness
+ *
+ * Return a pointer to the header portion of a remote connection's message
+ * buffer, converting the header to local endianness if needed.
+ *
+ * \param[in,out] remote  Remote connection with new message
+ *
+ * \return Pointer to message header, localized if necessary
+ */
+static struct remote_header_v0 *
+localized_remote_header(pcmk__remote_t *remote)
 {
-    struct crm_remote_header_v0 *header = (struct crm_remote_header_v0 *)remote->buffer;
-    if(remote->buffer_offset < sizeof(struct crm_remote_header_v0)) {
+    struct remote_header_v0 *header = (struct remote_header_v0 *)remote->buffer;
+    if(remote->buffer_offset < sizeof(struct remote_header_v0)) {
         return NULL;
 
     } else if(header->endian != ENDIAN_LOCAL) {
@@ -119,29 +129,31 @@ crm_remote_header(pcmk__remote_t *remote)
 #ifdef HAVE_GNUTLS_GNUTLS_H
 
 int
-crm_initiate_client_tls_handshake(pcmk__remote_t *remote, int timeout_ms)
+pcmk__tls_client_handshake(pcmk__remote_t *remote, int timeout_ms)
 {
     int rc = 0;
     int pollrc = 0;
-    time_t start = time(NULL);
+    time_t time_limit = time(NULL) + timeout_ms / 1000;
 
     do {
         rc = gnutls_handshake(*remote->tls_session);
-        if (rc == GNUTLS_E_INTERRUPTED || rc == GNUTLS_E_AGAIN) {
-            pollrc = crm_remote_ready(remote, 1000);
-            if (pollrc < 0) {
+        if ((rc == GNUTLS_E_INTERRUPTED) || (rc == GNUTLS_E_AGAIN)) {
+            pollrc = pcmk__remote_ready(remote, 1000);
+            if ((pollrc != pcmk_rc_ok) && (pollrc != ETIME)) {
                 /* poll returned error, there is no hope */
-                rc = -1;
+                crm_trace("TLS handshake poll failed: %s (%d)",
+                          pcmk_strerror(pollrc), pollrc);
+                return pcmk_legacy2rc(pollrc);
             }
+        } else if (rc < 0) {
+            crm_trace("TLS handshake failed: %s (%d)",
+                      gnutls_strerror(rc), rc);
+            return EPROTO;
+        } else {
+            return pcmk_rc_ok;
         }
-
-    } while (((time(NULL) - start) < (timeout_ms / 1000)) &&
-             (rc == GNUTLS_E_INTERRUPTED || rc == GNUTLS_E_AGAIN));
-
-    if (rc < 0) {
-        crm_trace("gnutls_handshake() failed with %d", rc);
-    }
-    return rc;
+    } while (time(NULL) < time_limit);
+    return ETIME;
 }
 
 /*!
@@ -151,7 +163,7 @@ crm_initiate_client_tls_handshake(pcmk__remote_t *remote, int timeout_ms)
  * \param[in] session  TLS session to affect
  */
 static void
-pcmk__set_minimum_dh_bits(gnutls_session_t *session)
+set_minimum_dh_bits(gnutls_session_t *session)
 {
     const char *dh_min_bits_s = getenv("PCMK_dh_min_bits");
 
@@ -171,7 +183,7 @@ pcmk__set_minimum_dh_bits(gnutls_session_t *session)
 }
 
 static unsigned int
-pcmk__bound_dh_bits(unsigned int dh_bits)
+get_bound_dh_bits(unsigned int dh_bits)
 {
     const char *dh_min_bits_s = getenv("PCMK_dh_min_bits");
     const char *dh_max_bits_s = getenv("PCMK_dh_max_bits");
@@ -252,7 +264,7 @@ pcmk__new_tls_session(int csock, unsigned int conn_type,
         goto error;
     }
     if (conn_type == GNUTLS_CLIENT) {
-        pcmk__set_minimum_dh_bits(session);
+        set_minimum_dh_bits(session);
     }
 
     gnutls_transport_set_ptr(*session,
@@ -284,7 +296,7 @@ error:
  *
  * \param[out] dh_params  Parameter object to initialize
  *
- * \return GNUTLS_E_SUCCESS on success, GnuTLS error code on error
+ * \return Standard Pacemaker return code
  * \todo The current best practice is to allow the client and server to
  *       negotiate the Diffie-Hellman parameters via a TLS extension (RFC 7919).
  *       However, we have to support both older versions of GnuTLS (<3.6) that
@@ -314,7 +326,7 @@ pcmk__init_tls_dh(gnutls_dh_params_t *dh_params)
 #else
     dh_bits = 1024;
 #endif
-    dh_bits = pcmk__bound_dh_bits(dh_bits);
+    dh_bits = get_bound_dh_bits(dh_bits);
 
     crm_info("Generating Diffie-Hellman parameters with %u-bit prime for TLS",
              dh_bits);
@@ -323,13 +335,12 @@ pcmk__init_tls_dh(gnutls_dh_params_t *dh_params)
         goto error;
     }
 
-    return rc;
+    return pcmk_rc_ok;
 
 error:
     crm_err("Could not initialize Diffie-Hellman parameters for TLS: %s "
             CRM_XS " rc=%d", gnutls_strerror(rc), rc);
-    CRM_ASSERT(rc == GNUTLS_E_SUCCESS);
-    return rc;
+    return EPROTO;
 }
 
 /*!
@@ -340,9 +351,8 @@ error:
  *
  * \param[in] client  Client connection
  *
- * \retval GnuTLS error code on error
- * \retval 0 if more data is needed
- * \retval 1 if handshake is successfully completed
+ * \return Standard Pacemaker return code (of particular interest, EAGAIN
+ *         if some data was successfully read but more data is needed)
  */
 int
 pcmk__read_handshake_data(pcmk__client_t *client)
@@ -359,140 +369,154 @@ pcmk__read_handshake_data(pcmk__client_t *client)
         /* No more data is available at the moment. This function should be
          * invoked again once the client sends more.
          */
-        return 0;
+        return EAGAIN;
     } else if (rc != GNUTLS_E_SUCCESS) {
-        return rc;
+        crm_err("TLS handshake with remote client failed: %s "
+                CRM_XS " rc=%d", gnutls_strerror(rc), rc);
+        return EPROTO;
     }
-    return 1;
+    return pcmk_rc_ok;
 }
 
+// \return Standard Pacemaker return code
 static int
-crm_send_tls(gnutls_session_t * session, const char *buf, size_t len)
+send_tls(gnutls_session_t *session, struct iovec *iov)
 {
-    const char *unsent = buf;
-    int rc = 0;
-    int total_send;
+    const char *unsent = iov->iov_base;
+    size_t unsent_len = iov->iov_len;
+    ssize_t gnutls_rc;
 
-    if (buf == NULL) {
-        return -EINVAL;
+    if (unsent == NULL) {
+        return EINVAL;
     }
 
-    total_send = len;
-    crm_trace("Message size: %llu", (unsigned long long) len);
+    crm_debug("Sending TLS message of %llu bytes",
+              (unsigned long long) unsent_len);
+    while (true) {
+        gnutls_rc = gnutls_record_send(*session, unsent, unsent_len);
 
-    while (TRUE) {
-        rc = gnutls_record_send(*session, unsent, len);
+        if (gnutls_rc == GNUTLS_E_INTERRUPTED || gnutls_rc == GNUTLS_E_AGAIN) {
+            crm_trace("Retrying to send %llu bytes remaining",
+                      (unsigned long long) unsent_len);
 
-        if (rc == GNUTLS_E_INTERRUPTED || rc == GNUTLS_E_AGAIN) {
-            crm_trace("Retrying to send %llu bytes",
-                      (unsigned long long) len);
-
-        } else if (rc < 0) {
+        } else if (gnutls_rc < 0) {
             // Caller can log as error if necessary
-            crm_info("TLS connection terminated: %s " CRM_XS " rc=%d",
-                     gnutls_strerror(rc), rc);
-            rc = -ECONNABORTED;
-            break;
+            crm_info("TLS connection terminated: %s " CRM_XS " rc=%lld",
+                     gnutls_strerror((int) gnutls_rc),
+                     (long long) gnutls_rc);
+            return ECONNABORTED;
 
-        } else if (rc < len) {
-            crm_debug("Sent %d of %llu bytes", rc, (unsigned long long) len);
-            len -= rc;
-            unsent += rc;
+        } else if (gnutls_rc < unsent_len) {
+            crm_trace("Sent %lld of %llu bytes remaining",
+                      (long long) gnutls_rc, (unsigned long long) unsent_len);
+            unsent_len -= gnutls_rc;
+            unsent += gnutls_rc;
         } else {
-            crm_trace("Sent all %d bytes", rc);
+            crm_trace("Sent all %lld bytes remaining", (long long) gnutls_rc);
             break;
         }
     }
-
-    return rc < 0 ? rc : total_send;
+    return pcmk_rc_ok;
 }
 #endif
 
+// \return Standard Pacemaker return code
 static int
-crm_send_plaintext(int sock, const char *buf, size_t len)
+send_plaintext(int sock, struct iovec *iov)
 {
+    const char *unsent = iov->iov_base;
+    size_t unsent_len = iov->iov_len;
+    ssize_t write_rc;
 
-    int rc = 0;
-    const char *unsent = buf;
-    int total_send;
-
-    if (buf == NULL) {
-        return -EINVAL;
+    if (unsent == NULL) {
+        return EINVAL;
     }
-    total_send = len;
 
-    crm_trace("Message on socket %d: size=%llu",
-              sock, (unsigned long long) len);
-  retry:
-    rc = write(sock, unsent, len);
-    if (rc < 0) {
-        rc = -errno;
-        switch (errno) {
-            case EINTR:
-            case EAGAIN:
-                crm_trace("Retry");
-                goto retry;
-            default:
-                crm_perror(LOG_INFO,
-                           "Could only write %d of the remaining %llu bytes",
-                           rc, (unsigned long long) len);
-                break;
+    crm_debug("Sending plaintext message of %llu bytes to socket %d",
+              (unsigned long long) unsent_len, sock);
+    while (true) {
+        write_rc = write(sock, unsent, unsent_len);
+        if (write_rc < 0) {
+            int rc = errno;
+
+            if ((errno == EINTR) || (errno == EAGAIN)) {
+                crm_trace("Retrying to send %llu bytes remaining to socket %d",
+                          (unsigned long long) unsent_len, sock);
+                continue;
+            }
+
+            // Caller can log as error if necessary
+            crm_info("Could not send message: %s " CRM_XS " rc=%d socket=%d",
+                     pcmk_rc_str(rc), rc, sock);
+            return rc;
+
+        } else if (write_rc < unsent_len) {
+            crm_trace("Sent %lld of %llu bytes remaining",
+                      (long long) write_rc, (unsigned long long) unsent_len);
+            unsent += write_rc;
+            unsent_len -= write_rc;
+            continue;
+
+        } else {
+            crm_trace("Sent all %lld bytes remaining: %.100s",
+                      (long long) write_rc, (char *) (iov->iov_base));
+            break;
         }
-
-    } else if (rc < len) {
-        crm_trace("Only sent %d of %llu remaining bytes",
-                  rc, (unsigned long long) len);
-        len -= rc;
-        unsent += rc;
-        goto retry;
-
-    } else {
-        crm_trace("Sent %d bytes: %.100s", rc, buf);
     }
-
-    return rc < 0 ? rc : total_send;
-
+    return pcmk_rc_ok;
 }
 
+// \return Standard Pacemaker return code
 static int
-crm_remote_sendv(pcmk__remote_t *remote, struct iovec * iov, int iovs)
+remote_send_iovs(pcmk__remote_t *remote, struct iovec *iov, int iovs)
 {
-    int rc = 0;
+    int rc = pcmk_rc_ok;
 
-    for (int lpc = 0; (lpc < iovs) && (rc >= 0); lpc++) {
+    for (int lpc = 0; (lpc < iovs) && (rc == pcmk_rc_ok); lpc++) {
 #ifdef HAVE_GNUTLS_GNUTLS_H
         if (remote->tls_session) {
-            rc = crm_send_tls(remote->tls_session, iov[lpc].iov_base, iov[lpc].iov_len);
+            rc = send_tls(remote->tls_session, &(iov[lpc]));
             continue;
         }
 #endif
         if (remote->tcp_socket) {
-            rc = crm_send_plaintext(remote->tcp_socket, iov[lpc].iov_base, iov[lpc].iov_len);
+            rc = send_plaintext(remote->tcp_socket, &(iov[lpc]));
         } else {
-            rc = -ESOCKTNOSUPPORT;
+            rc = ESOCKTNOSUPPORT;
         }
     }
     return rc;
 }
 
+/*!
+ * \internal
+ * \brief Send an XML message over a Pacemaker Remote connection
+ *
+ * \param[in] remote  Pacemaker Remote connection to use
+ * \param[in] msg     XML to send
+ *
+ * \return Standard Pacemaker return code
+ */
 int
-crm_remote_send(pcmk__remote_t *remote, xmlNode *msg)
+pcmk__remote_send_xml(pcmk__remote_t *remote, xmlNode *msg)
 {
-    int rc = pcmk_ok;
+    int rc = pcmk_rc_ok;
     static uint64_t id = 0;
-    char *xml_text = dump_xml_unformatted(msg);
+    char *xml_text = NULL;
 
     struct iovec iov[2];
-    struct crm_remote_header_v0 *header;
+    struct remote_header_v0 *header;
 
-    if (xml_text == NULL) {
-        crm_err("Could not send remote message: no message provided");
-        return -EINVAL;
-    }
+    CRM_CHECK((remote != NULL) && (msg != NULL), return EINVAL);
 
-    header = calloc(1, sizeof(struct crm_remote_header_v0));
+    xml_text = dump_xml_unformatted(msg);
+    CRM_CHECK(xml_text != NULL, return EINVAL);
+
+    header = calloc(1, sizeof(struct remote_header_v0));
+    CRM_ASSERT(header != NULL);
+
     iov[0].iov_base = header;
-    iov[0].iov_len = sizeof(struct crm_remote_header_v0);
+    iov[0].iov_len = sizeof(struct remote_header_v0);
 
     iov[1].iov_base = xml_text;
     iov[1].iov_len = 1 + strlen(xml_text);
@@ -505,12 +529,10 @@ crm_remote_send(pcmk__remote_t *remote, xmlNode *msg)
     header->payload_uncompressed = iov[1].iov_len;
     header->size_total = iov[0].iov_len + iov[1].iov_len;
 
-    crm_trace("Sending len[0]=%d, start=%x",
-              (int)iov[0].iov_len, *(int*)(void*)xml_text);
-    rc = crm_remote_sendv(remote, iov, 2);
-    if (rc < 0) {
+    rc = remote_send_iovs(remote, iov, 2);
+    if (rc != pcmk_rc_ok) {
         crm_err("Could not send remote message: %s " CRM_XS " rc=%d",
-                pcmk_strerror(rc), rc);
+                pcmk_rc_str(rc), rc);
     }
 
     free(iov[0].iov_base);
@@ -518,19 +540,22 @@ crm_remote_send(pcmk__remote_t *remote, xmlNode *msg)
     return rc;
 }
 
-
 /*!
  * \internal
- * \brief handles the recv buffer and parsing out msgs.
- * \note new_data is owned by this function once it is passed in.
+ * \brief Obtain the XML from the currently buffered remote connection message
+ *
+ * \param[in] remote  Remote connection possibly with message available
+ *
+ * \return Newly allocated XML object corresponding to message data, or NULL
+ * \note This effectively removes the message from the connection buffer.
  */
 xmlNode *
-crm_remote_parse_buffer(pcmk__remote_t *remote)
+pcmk__remote_message_xml(pcmk__remote_t *remote)
 {
     xmlNode *xml = NULL;
-    struct crm_remote_header_v0 *header = crm_remote_header(remote);
+    struct remote_header_v0 *header = localized_remote_header(remote);
 
-    if (remote->buffer == NULL || header == NULL) {
+    if (header == NULL) {
         return NULL;
     }
 
@@ -567,13 +592,13 @@ crm_remote_parse_buffer(pcmk__remote_t *remote)
 
         free(remote->buffer);
         remote->buffer = uncompressed;
-        header = crm_remote_header(remote);
+        header = localized_remote_header(remote);
     }
 
     /* take ownership of the buffer */
     remote->buffer_offset = 0;
 
-    CRM_LOG_ASSERT(remote->buffer[sizeof(struct crm_remote_header_v0) + header->payload_uncompressed - 1] == 0);
+    CRM_LOG_ASSERT(remote->buffer[sizeof(struct remote_header_v0) + header->payload_uncompressed - 1] == 0);
 
     xml = string2xml(remote->buffer + header->payload_offset);
     if (xml == NULL && header->version > REMOTE_MSG_VERSION) {
@@ -587,41 +612,49 @@ crm_remote_parse_buffer(pcmk__remote_t *remote)
     return xml;
 }
 
+static int
+get_remote_socket(pcmk__remote_t *remote)
+{
+#ifdef HAVE_GNUTLS_GNUTLS_H
+    if (remote->tls_session) {
+        void *sock_ptr = gnutls_transport_get_ptr(*remote->tls_session);
+
+        return GPOINTER_TO_INT(sock_ptr);
+    }
+#endif
+
+    if (remote->tcp_socket) {
+        return remote->tcp_socket;
+    }
+
+    crm_err("Remote connection type undetermined (bug?)");
+    return -1;
+}
+
 /*!
  * \internal
  * \brief Wait for a remote session to have data to read
  *
- * \param[in] remote         Connection to check
- * \param[in] total_timeout  Maximum time (in ms) to wait
+ * \param[in] remote      Connection to check
+ * \param[in] timeout_ms  Maximum time (in ms) to wait
  *
- * \return Positive value if ready to be read, 0 on timeout, -errno on error
+ * \return Standard Pacemaker return code (of particular interest, pcmk_rc_ok if
+ *         there is data ready to be read, and ETIME if there is no data within
+ *         the specified timeout)
  */
 int
-crm_remote_ready(pcmk__remote_t *remote, int total_timeout)
+pcmk__remote_ready(pcmk__remote_t *remote, int timeout_ms)
 {
     struct pollfd fds = { 0, };
     int sock = 0;
     int rc = 0;
     time_t start;
-    int timeout = total_timeout;
+    int timeout = timeout_ms;
 
-#ifdef HAVE_GNUTLS_GNUTLS_H
-    if (remote->tls_session) {
-        void *sock_ptr = gnutls_transport_get_ptr(*remote->tls_session);
-
-        sock = GPOINTER_TO_INT(sock_ptr);
-    } else if (remote->tcp_socket) {
-#else
-    if (remote->tcp_socket) {
-#endif
-        sock = remote->tcp_socket;
-    } else {
-        crm_err("Unsupported connection type");
-    }
-
+    sock = get_remote_socket(remote);
     if (sock <= 0) {
         crm_trace("No longer connected");
-        return -ENOTCONN;
+        return ENOTCONN;
     }
 
     start = time(NULL);
@@ -634,7 +667,7 @@ crm_remote_ready(pcmk__remote_t *remote, int total_timeout)
          * specific timeout we are trying to honor, attempt
          * to adjust the timeout to the closest second. */
         if (errno == EINTR && (timeout > 0)) {
-            timeout = total_timeout - ((time(NULL) - start) * 1000);
+            timeout = timeout_ms - ((time(NULL) - start) * 1000);
             if (timeout < 1000) {
                 timeout = 1000;
             }
@@ -643,26 +676,32 @@ crm_remote_ready(pcmk__remote_t *remote, int total_timeout)
         rc = poll(&fds, 1, timeout);
     } while (rc < 0 && errno == EINTR);
 
-    return (rc < 0)? -errno : rc;
+    if (rc < 0) {
+        return errno;
+    }
+    return (rc == 0)? ETIME : pcmk_rc_ok;
 }
-
 
 /*!
  * \internal
- * \brief Read bytes off non blocking remote connection.
+ * \brief Read bytes from non-blocking remote connection
  *
- * \note only use with NON-Blocking sockets. Should only be used after polling socket.
- *       This function will return once max_size is met, the socket read buffer
- *       is empty, or an error is encountered.
+ * \param[in] remote  Remote connection to read
  *
- * \retval number of bytes received
+ * \return Standard Pacemaker return code (of particular interest, pcmk_rc_ok if
+ *         a full message has been received, or EAGAIN for a partial message)
+ * \note Use only with non-blocking sockets after polling the socket.
+ * \note This function will return when the socket read buffer is empty or an
+ *       error is encountered.
  */
-static size_t
-crm_remote_recv_once(pcmk__remote_t *remote)
+static int
+read_available_remote_data(pcmk__remote_t *remote)
 {
-    int rc = 0;
-    size_t read_len = sizeof(struct crm_remote_header_v0);
-    struct crm_remote_header_v0 *header = crm_remote_header(remote);
+    int rc = pcmk_rc_ok;
+    size_t read_len = sizeof(struct remote_header_v0);
+    struct remote_header_v0 *header = localized_remote_header(remote);
+    bool received = false;
+    ssize_t read_rc;
 
     if(header) {
         /* Stop at the end of the current message */
@@ -671,246 +710,261 @@ crm_remote_recv_once(pcmk__remote_t *remote)
 
     /* automatically grow the buffer when needed */
     if(remote->buffer_size < read_len) {
-           remote->buffer_size = 2 * read_len;
+        remote->buffer_size = 2 * read_len;
         crm_trace("Expanding buffer to %llu bytes",
                   (unsigned long long) remote->buffer_size);
-
         remote->buffer = realloc_safe(remote->buffer, remote->buffer_size + 1);
-        CRM_ASSERT(remote->buffer != NULL);
     }
 
 #ifdef HAVE_GNUTLS_GNUTLS_H
-    if (remote->tls_session) {
-        rc = gnutls_record_recv(*(remote->tls_session),
-                                remote->buffer + remote->buffer_offset,
-                                remote->buffer_size - remote->buffer_offset);
-        if (rc == GNUTLS_E_INTERRUPTED) {
-            rc = -EINTR;
-        } else if (rc == GNUTLS_E_AGAIN) {
-            rc = -EAGAIN;
-        } else if (rc < 0) {
-            crm_debug("TLS receive failed: %s (%d)", gnutls_strerror(rc), rc);
-            rc = -pcmk_err_generic;
+    if (!received && remote->tls_session) {
+        read_rc = gnutls_record_recv(*(remote->tls_session),
+                                     remote->buffer + remote->buffer_offset,
+                                     remote->buffer_size - remote->buffer_offset);
+        if (read_rc == GNUTLS_E_INTERRUPTED) {
+            rc = EINTR;
+        } else if (read_rc == GNUTLS_E_AGAIN) {
+            rc = EAGAIN;
+        } else if (read_rc < 0) {
+            crm_debug("TLS receive failed: %s (%lld)",
+                      gnutls_strerror(read_rc), (long long) read_rc);
+            rc = EIO;
         }
-    } else if (remote->tcp_socket) {
-#else
-    if (remote->tcp_socket) {
+        received = true;
+    }
 #endif
-        errno = 0;
-        rc = read(remote->tcp_socket,
-                  remote->buffer + remote->buffer_offset,
-                  remote->buffer_size - remote->buffer_offset);
-        if(rc < 0) {
-            rc = -errno;
-        }
 
-    } else {
-        crm_err("Unsupported connection type");
-        return -ESOCKTNOSUPPORT;
+    if (!received && remote->tcp_socket) {
+        read_rc = read(remote->tcp_socket,
+                       remote->buffer + remote->buffer_offset,
+                       remote->buffer_size - remote->buffer_offset);
+        if (read_rc < 0) {
+            rc = errno;
+        }
+        received = true;
+    }
+
+    if (!received) {
+        crm_err("Remote connection type undetermined (bug?)");
+        return ESOCKTNOSUPPORT;
     }
 
     /* process any errors. */
-    if (rc > 0) {
-        remote->buffer_offset += rc;
+    if (read_rc > 0) {
+        remote->buffer_offset += read_rc;
         /* always null terminate buffer, the +1 to alloc always allows for this. */
         remote->buffer[remote->buffer_offset] = '\0';
-        crm_trace("Received %u more bytes, %llu total",
-                  rc, (unsigned long long) remote->buffer_offset);
-
-    } else if (rc == -EINTR || rc == -EAGAIN) {
-        crm_trace("non-blocking, exiting read: %s (%d)", pcmk_strerror(rc), rc);
-
-    } else if (rc == 0) {
-        crm_debug("EOF encoutered after %llu bytes",
+        crm_trace("Received %lld more bytes (%llu total)",
+                  (long long) read_rc,
                   (unsigned long long) remote->buffer_offset);
-        return -ENOTCONN;
+
+    } else if ((rc == EINTR) || (rc == EAGAIN)) {
+        crm_trace("No data available for non-blocking remote read: %s (%d)",
+                  pcmk_rc_str(rc), rc);
+
+    } else if (read_rc == 0) {
+        crm_debug("End of remote data encountered after %llu bytes",
+                  (unsigned long long) remote->buffer_offset);
+        return ENOTCONN;
 
     } else {
-        crm_debug("Error receiving message after %llu bytes: %s (%d)",
+        crm_debug("Error receiving remote data after %llu bytes: %s (%d)",
                   (unsigned long long) remote->buffer_offset,
-                  pcmk_strerror(rc), rc);
-        return -ENOTCONN;
+                  pcmk_rc_str(rc), rc);
+        return ENOTCONN;
     }
 
-    header = crm_remote_header(remote);
+    header = localized_remote_header(remote);
     if(header) {
         if(remote->buffer_offset < header->size_total) {
-            crm_trace("Read less than the advertised length: %llu < %u bytes",
+            crm_trace("Read partial remote message (%llu of %u bytes)",
                       (unsigned long long) remote->buffer_offset,
                       header->size_total);
         } else {
-            crm_trace("Read full message of %llu bytes",
+            crm_trace("Read full remote message of %llu bytes",
                       (unsigned long long) remote->buffer_offset);
-            return remote->buffer_offset;
+            return pcmk_rc_ok;
         }
     }
 
-    return -EAGAIN;
+    return EAGAIN;
 }
 
 /*!
  * \internal
- * \brief Read message(s) from a remote connection
+ * \brief Read one message from a remote connection
  *
- * \param[in]  remote         Remote connection to read
- * \param[in]  total_timeout  Fail if message not read in this time (ms)
- * \param[out] disconnected   Will be set to 1 if disconnect detected
+ * \param[in]  remote      Remote connection to read
+ * \param[in]  timeout_ms  Fail if message not read in this many milliseconds
+ *                         (10s will be used if 0, and 60s if negative)
  *
- * \return TRUE if at least one full message read, FALSE otherwise
+ * \return Standard Pacemaker return code
  */
-gboolean
-crm_remote_recv(pcmk__remote_t *remote, int total_timeout, int *disconnected)
+int
+pcmk__read_remote_message(pcmk__remote_t *remote, int timeout_ms)
 {
-    int rc;
+    int rc = pcmk_rc_ok;
     time_t start = time(NULL);
     int remaining_timeout = 0;
 
-    if (total_timeout == 0) {
-        total_timeout = 10000;
-    } else if (total_timeout < 0) {
-        total_timeout = 60000;
+    if (timeout_ms == 0) {
+        timeout_ms = 10000;
+    } else if (timeout_ms < 0) {
+        timeout_ms = 60000;
     }
-    *disconnected = 0;
 
-    remaining_timeout = total_timeout;
-    while ((remaining_timeout > 0) && !(*disconnected)) {
+    remaining_timeout = timeout_ms;
+    while (remaining_timeout > 0) {
 
-        crm_trace("Waiting for remote data (%d of %d ms timeout remaining)",
-                  remaining_timeout, total_timeout);
-        rc = crm_remote_ready(remote, remaining_timeout);
+        crm_trace("Waiting for remote data (%d ms of %d ms timeout remaining)",
+                  remaining_timeout, timeout_ms);
+        rc = pcmk__remote_ready(remote, remaining_timeout);
 
-        if (rc == 0) {
+        if (rc == ETIME) {
             crm_err("Timed out (%d ms) while waiting for remote data",
                     remaining_timeout);
-            return FALSE;
+            return rc;
 
-        } else if (rc < 0) {
-            crm_debug("Wait for remote data aborted, will try again: %s "
-                      CRM_XS " rc=%d", pcmk_strerror(rc), rc);
+        } else if (rc != pcmk_rc_ok) {
+            crm_debug("Wait for remote data aborted (will retry): %s "
+                      CRM_XS " rc=%d", pcmk_rc_str(rc), rc);
 
         } else {
-            rc = crm_remote_recv_once(remote);
-            if (rc > 0) {
-                return TRUE;
-            } else if (rc == -EAGAIN) {
-                crm_trace("Still waiting for remote data");
-            } else if (rc < 0) {
+            rc = read_available_remote_data(remote);
+            if (rc == pcmk_rc_ok) {
+                return rc;
+            } else if (rc == EAGAIN) {
+                crm_trace("Waiting for more remote data");
+            } else {
                 crm_debug("Could not receive remote data: %s " CRM_XS " rc=%d",
-                          pcmk_strerror(rc), rc);
+                          pcmk_rc_str(rc), rc);
             }
         }
 
-        if (rc == -ENOTCONN) {
-            *disconnected = 1;
-            return FALSE;
+        // Don't waste time retrying after fatal errors
+        if ((rc == ENOTCONN) || (rc == ESOCKTNOSUPPORT)) {
+            return rc;
         }
 
-        remaining_timeout = total_timeout - ((time(NULL) - start) * 1000);
+        remaining_timeout = timeout_ms - ((time(NULL) - start) * 1000);
     }
-
-    return FALSE;
+    return ETIME;
 }
 
 struct tcp_async_cb_data {
-    gboolean success;
     int sock;
-    void *userdata;
-    void (*callback) (void *userdata, int sock);
-    int timeout;                /*ms */
+    int timeout_ms;
     time_t start;
+    void *userdata;
+    void (*callback) (void *userdata, int rc, int sock);
 };
 
+// \return TRUE if timer should be rescheduled, FALSE otherwise
 static gboolean
 check_connect_finished(gpointer userdata)
 {
     struct tcp_async_cb_data *cb_data = userdata;
-    int cb_arg = 0; // socket fd on success, -errno on error
-    int sock = cb_data->sock;
-    int error = 0;
+    int rc;
 
     fd_set rset, wset;
-    socklen_t len = sizeof(error);
     struct timeval ts = { 0, };
 
-    if (cb_data->success == TRUE) {
+    if (cb_data->start == 0) {
+        // Last connect() returned success immediately
+        rc = pcmk_rc_ok;
         goto dispatch_done;
     }
 
+    // If the socket is ready for reading or writing, the connect succeeded
     FD_ZERO(&rset);
-    FD_SET(sock, &rset);
+    FD_SET(cb_data->sock, &rset);
     wset = rset;
+    rc = select(cb_data->sock + 1, &rset, &wset, NULL, &ts);
 
-    crm_trace("fd %d: checking to see if connect finished", sock);
-    cb_arg = select(sock + 1, &rset, &wset, NULL, &ts);
-
-    if (cb_arg < 0) {
-        cb_arg = -errno;
-        if ((errno == EINPROGRESS) || (errno == EAGAIN)) {
-            /* reschedule if there is still time left */
-            if ((time(NULL) - cb_data->start) < (cb_data->timeout / 1000)) {
-                goto reschedule;
+    if (rc < 0) { // select() error
+        rc = errno;
+        if ((rc == EINPROGRESS) || (rc == EAGAIN)) {
+            if ((time(NULL) - cb_data->start) < (cb_data->timeout_ms / 1000)) {
+                return TRUE; // There is time left, so reschedule timer
             } else {
-                cb_arg = -ETIMEDOUT;
+                rc = ETIMEDOUT;
             }
         }
-        crm_trace("fd %d: select failed %d connect dispatch ", sock, cb_arg);
-        goto dispatch_done;
-    } else if (cb_arg == 0) {
-        if ((time(NULL) - cb_data->start) < (cb_data->timeout / 1000)) {
-            goto reschedule;
-        }
-        crm_debug("fd %d: timeout during select", sock);
-        cb_arg = -ETIMEDOUT;
-        goto dispatch_done;
-    } else {
-        crm_trace("fd %d: select returned success", sock);
-        cb_arg = 0;
-    }
+        crm_trace("Could not check socket %d for connection success: %s (%d)",
+                  cb_data->sock, pcmk_rc_str(rc), rc);
 
-    /* can we read or write to the socket now? */
-    if (FD_ISSET(sock, &rset) || FD_ISSET(sock, &wset)) {
-        if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &error, &len) < 0) {
-            cb_arg = -errno;
-            crm_trace("fd %d: call to getsockopt failed", sock);
-            goto dispatch_done;
+    } else if (rc == 0) { // select() timeout
+        if ((time(NULL) - cb_data->start) < (cb_data->timeout_ms / 1000)) {
+            return TRUE; // There is time left, so reschedule timer
         }
-        if (error) {
-            crm_trace("fd %d: error returned from getsockopt: %d", sock, error);
-            cb_arg = -error;
-            goto dispatch_done;
+        crm_debug("Timed out while waiting for socket %d connection success",
+                  cb_data->sock);
+        rc = ETIMEDOUT;
+
+    // select() returned number of file descriptors that are ready
+
+    } else if (FD_ISSET(cb_data->sock, &rset)
+               || FD_ISSET(cb_data->sock, &wset)) {
+
+        // The socket is ready; check it for connection errors
+        int error = 0;
+        socklen_t len = sizeof(error);
+
+        if (getsockopt(cb_data->sock, SOL_SOCKET, SO_ERROR, &error, &len) < 0) {
+            rc = errno;
+            crm_trace("Couldn't check socket %d for connection errors: %s (%d)",
+                      cb_data->sock, pcmk_rc_str(rc), rc);
+        } else if (error != 0) {
+            rc = error;
+            crm_trace("Socket %d connected with error: %s (%d)",
+                      cb_data->sock, pcmk_rc_str(rc), rc);
+        } else {
+            rc = pcmk_rc_ok;
         }
-    } else {
-        crm_trace("neither read nor write set after select");
-        cb_arg = -EAGAIN;
-        goto dispatch_done;
+
+    } else { // Should not be possible
+        crm_trace("select() succeeded, but socket %d not in resulting "
+                  "read/write sets", cb_data->sock);
+        rc = EAGAIN;
     }
 
   dispatch_done:
-    if (!cb_arg) {
-        crm_trace("fd %d: connected", sock);
-        /* Success, set the return code to the sock to report to the callback */
-        cb_arg = cb_data->sock;
-        cb_data->sock = 0;
+    if (rc == pcmk_rc_ok) {
+        crm_trace("Socket %d is connected", cb_data->sock);
     } else {
-        close(sock);
+        close(cb_data->sock);
+        cb_data->sock = -1;
     }
 
     if (cb_data->callback) {
-        cb_data->callback(cb_data->userdata, cb_arg);
+        cb_data->callback(cb_data->userdata, rc, cb_data->sock);
     }
     free(cb_data);
-    return FALSE;
-
-  reschedule:
-
-    /* will check again next interval */
-    return TRUE;
+    return FALSE; // Do not reschedule timer
 }
 
+/*!
+ * \internal
+ * \brief Attempt to connect socket, calling callback when done
+ *
+ * Set a given socket non-blocking, then attempt to connect to it,
+ * retrying periodically until success or a timeout is reached.
+ * Call a caller-supplied callback function when completed.
+ *
+ * \param[in]  sock        Newly created socket
+ * \param[in]  addr        Socket address information for connect
+ * \param[in]  addrlen     Size of socket address information in bytes
+ * \param[in]  timeout_ms  Fail if not connected within this much time
+ * \param[out] timer_id    If not NULL, store retry timer ID here
+ * \param[in]  userdata    User data to pass to callback
+ * \param[in]  callback    Function to call when connection attempt completes
+ *
+ * \return Standard Pacemaker return code
+ */
 static int
-internal_tcp_connect_async(int sock,
-                           const struct sockaddr *addr, socklen_t addrlen, int timeout /* ms */ ,
-                           int *timer_id, void *userdata, void (*callback) (void *userdata, int sock))
+connect_socket_retry(int sock, const struct sockaddr *addr, socklen_t addrlen,
+                     int timeout_ms, int *timer_id, void *userdata,
+                     void (*callback) (void *userdata, int rc, int sock))
 {
     int rc = 0;
     int interval = 500;
@@ -921,40 +975,43 @@ internal_tcp_connect_async(int sock,
     if (rc != pcmk_rc_ok) {
         crm_warn("Could not set socket non-blocking: %s " CRM_XS " rc=%d",
                  pcmk_rc_str(rc), rc);
-        close(sock);
-        return -1;
+        return rc;
     }
 
     rc = connect(sock, addr, addrlen);
     if (rc < 0 && (errno != EINPROGRESS) && (errno != EAGAIN)) {
-        crm_perror(LOG_WARNING, "connect");
-        return -1;
+        rc = errno;
+        crm_warn("Could not connect socket: %s " CRM_XS " rc=%d",
+                 pcmk_rc_str(rc), rc);
+        return rc;
     }
 
     cb_data = calloc(1, sizeof(struct tcp_async_cb_data));
     cb_data->userdata = userdata;
     cb_data->callback = callback;
     cb_data->sock = sock;
-    cb_data->timeout = timeout;
-    cb_data->start = time(NULL);
+    cb_data->timeout_ms = timeout_ms;
 
     if (rc == 0) {
         /* The connect was successful immediately, we still return to mainloop
          * and let this callback get called later. This avoids the user of this api
          * to have to account for the fact the callback could be invoked within this
          * function before returning. */
-        cb_data->success = TRUE;
+        cb_data->start = 0;
         interval = 1;
+    } else {
+        cb_data->start = time(NULL);
     }
 
-    /* Check connect finished is mostly doing a non-block poll on the socket
-     * to see if we can read/write to it. Once we can, the connect has completed.
-     * This method allows us to connect to the server without blocking mainloop.
+    /* This timer function does a non-blocking poll on the socket to see if we
+     * can use it. Once we can, the connect has completed. This method allows us
+     * to connect without blocking the mainloop.
      *
-     * This is a poor man's way of polling to see when the connection finished.
-     * At some point we should figure out a way to use a mainloop fd callback for this.
-     * Something about the way mainloop is currently polling prevents this from working at the
-     * moment though. */
+     * @TODO Use a mainloop fd callback for this instead of polling. Something
+     *       about the way mainloop is currently polling prevents this from
+     *       working at the moment though. (See connect(2) regarding EINPROGRESS
+     *       for possible new handling needed.)
+     */
     crm_trace("Scheduling check in %dms for whether connect to fd %d finished",
               interval, sock);
     timer = g_timeout_add(interval, check_connect_finished, cb_data);
@@ -962,18 +1019,28 @@ internal_tcp_connect_async(int sock,
         *timer_id = timer;
     }
 
-    return 0;
+    return pcmk_rc_ok;
 }
 
+/*!
+ * \internal
+ * \brief Attempt once to connect socket and set it non-blocking
+ *
+ * \param[in]  sock        Newly created socket
+ * \param[in]  addr        Socket address information for connect
+ * \param[in]  addrlen     Size of socket address information in bytes
+ *
+ * \return Standard Pacemaker return code
+ */
 static int
-internal_tcp_connect(int sock, const struct sockaddr *addr, socklen_t addrlen)
+connect_socket_once(int sock, const struct sockaddr *addr, socklen_t addrlen)
 {
     int rc = connect(sock, addr, addrlen);
 
     if (rc < 0) {
-        rc = -errno;
+        rc = errno;
         crm_warn("Could not connect socket: %s " CRM_XS " rc=%d",
-                 pcmk_strerror(rc), rc);
+                 pcmk_rc_str(rc), rc);
         return rc;
     }
 
@@ -981,7 +1048,7 @@ internal_tcp_connect(int sock, const struct sockaddr *addr, socklen_t addrlen)
     if (rc != pcmk_rc_ok) {
         crm_warn("Could not set socket non-blocking: %s " CRM_XS " rc=%d",
                  pcmk_rc_str(rc), rc);
-        return pcmk_rc2legacy(rc);
+        return rc;
     }
 
     return pcmk_ok;
@@ -991,41 +1058,48 @@ internal_tcp_connect(int sock, const struct sockaddr *addr, socklen_t addrlen)
  * \internal
  * \brief Connect to server at specified TCP port
  *
- * \param[in]  host      Name of server to connect to
- * \param[in]  port      Server port to connect to
- * \param[in]  timeout   Report error if not connected in this many milliseconds
- * \param[out] timer_id  If non-NULL, will be set to timer ID, if asynchronous
- * \param[in]  userdata  Data to pass to callback, if asynchronous
- * \param[in]  callback  If non-NULL, connect asynchronously then call this
+ * \param[in]  host        Name of server to connect to
+ * \param[in]  port        Server port to connect to
+ * \param[in]  timeout_ms  If asynchronous, fail if not connected in this time
+ * \param[out] timer_id    If asynchronous and this is non-NULL, retry timer ID
+ *                         will be put here (for ease of cancelling by caller)
+ * \param[out] sock_fd     Where to store socket file descriptor
+ * \param[in]  userdata    If asynchronous, data to pass to callback
+ * \param[in]  callback    If NULL, attempt a single synchronous connection,
+ *                         otherwise retry asynchronously then call this
  *
- * \return File descriptor of connected socket on success, -ENOTCONN otherwise
+ * \return Standard Pacemaker return code
  */
 int
-crm_remote_tcp_connect_async(const char *host, int port, int timeout,
-                             int *timer_id, void *userdata,
-                             void (*callback) (void *userdata, int sock))
+pcmk__connect_remote(const char *host, int port, int timeout, int *timer_id,
+                     int *sock_fd, void *userdata,
+                     void (*callback) (void *userdata, int rc, int sock))
 {
     char buffer[INET6_ADDRSTRLEN];
     struct addrinfo *res = NULL;
     struct addrinfo *rp = NULL;
     struct addrinfo hints;
     const char *server = host;
-    int ret_ga;
-    int sock = -ENOTCONN;
+    int rc;
+    int sock = -1;
+
+    CRM_CHECK((host != NULL) && (sock_fd != NULL), return EINVAL);
 
     // Get host's IP address(es)
     memset(&hints, 0, sizeof(struct addrinfo));
     hints.ai_family = AF_UNSPEC;        /* Allow IPv4 or IPv6 */
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_flags = AI_CANONNAME;
-    ret_ga = getaddrinfo(server, NULL, &hints, &res);
-    if (ret_ga) {
+    rc = getaddrinfo(server, NULL, &hints, &res);
+    if (rc != 0) {
         crm_err("Unable to get IP address info for %s: %s",
-                server, gai_strerror(ret_ga));
+                server, gai_strerror(rc));
+        rc = ENOTCONN;
         goto async_cleanup;
     }
     if (!res || !res->ai_addr) {
         crm_err("Unable to get IP address info for %s: no result", server);
+        rc = ENOTCONN;
         goto async_cleanup;
     }
 
@@ -1044,9 +1118,9 @@ crm_remote_tcp_connect_async(const char *host, int port, int timeout,
 
         sock = socket(rp->ai_family, SOCK_STREAM, IPPROTO_TCP);
         if (sock == -1) {
-            crm_perror(LOG_WARNING, "creating socket for connection to %s",
-                       server);
-            sock = -ENOTCONN;
+            rc = errno;
+            crm_warn("Could not create socket for remote connection to %s:%d: "
+                     "%s " CRM_XS " rc=%d", server, port, pcmk_rc_str(rc), rc);
             continue;
         }
 
@@ -1059,21 +1133,24 @@ crm_remote_tcp_connect_async(const char *host, int port, int timeout,
         }
 
         memset(buffer, 0, DIMOF(buffer));
-        crm_sockaddr2str(addr, buffer);
-        crm_info("Attempting TCP connection to %s:%d", buffer, port);
+        pcmk__sockaddr2str(addr, buffer);
+        crm_info("Attempting remote connection to %s:%d", buffer, port);
 
         if (callback) {
-            if (internal_tcp_connect_async
-                (sock, rp->ai_addr, rp->ai_addrlen, timeout, timer_id, userdata, callback) == 0) {
+            if (connect_socket_retry(sock, rp->ai_addr, rp->ai_addrlen, timeout,
+                                     timer_id, userdata, callback) == pcmk_rc_ok) {
                 goto async_cleanup; /* Success for now, we'll hear back later in the callback */
             }
 
-        } else if (internal_tcp_connect(sock, rp->ai_addr, rp->ai_addrlen) == 0) {
+        } else if (connect_socket_once(sock, rp->ai_addr,
+                                       rp->ai_addrlen) == pcmk_rc_ok) {
             break;          /* Success */
         }
 
+        // Connect failed
         close(sock);
-        sock = -ENOTCONN;
+        sock = -1;
+        rc = ENOTCONN;
     }
 
 async_cleanup:
@@ -1081,16 +1158,12 @@ async_cleanup:
     if (res) {
         freeaddrinfo(res);
     }
-    return sock;
-}
-
-int
-crm_remote_tcp_connect(const char *host, int port)
-{
-    return crm_remote_tcp_connect_async(host, port, -1, NULL, NULL, NULL);
+    *sock_fd = sock;
+    return rc;
 }
 
 /*!
+ * \internal
  * \brief Convert an IP address (IPv4 or IPv6) to a string for logging
  *
  * \param[in]  sa  Socket address for IP
@@ -1101,7 +1174,7 @@ crm_remote_tcp_connect(const char *host, int port)
  *          as long as its sa_family member is set correctly.
  */
 void
-crm_sockaddr2str(void *sa, char *s)
+pcmk__sockaddr2str(void *sa, char *s)
 {
     switch (((struct sockaddr*)sa)->sa_family) {
         case AF_INET:
@@ -1119,54 +1192,63 @@ crm_sockaddr2str(void *sa, char *s)
     }
 }
 
+/*!
+ * \internal
+ * \brief Accept a client connection on a remote server socket
+ *
+ * \param[in]  ssock  Server socket file descriptor being listened on
+ * \param[out] csock  Where to put new client socket's file descriptor
+ *
+ * \return Standard Pacemaker return code
+ */
 int
-crm_remote_accept(int ssock)
+pcmk__accept_remote_connection(int ssock, int *csock)
 {
-    int csock = 0;
-    int rc = 0;
-    unsigned laddr = 0;
+    int rc;
     struct sockaddr_storage addr;
+    socklen_t laddr = sizeof(addr);
     char addr_str[INET6_ADDRSTRLEN];
-#ifdef TCP_USER_TIMEOUT
-    int optval;
-    long sbd_timeout = crm_get_sbd_timeout();
-#endif
 
     /* accept the connection */
-    laddr = sizeof(addr);
     memset(&addr, 0, sizeof(addr));
-    csock = accept(ssock, (struct sockaddr *)&addr, &laddr);
-    crm_sockaddr2str(&addr, addr_str);
-    crm_info("New remote connection from %s", addr_str);
-
-    if (csock == -1) {
-        crm_err("accept socket failed");
-        return -1;
+    *csock = accept(ssock, (struct sockaddr *)&addr, &laddr);
+    if (*csock == -1) {
+        rc = errno;
+        crm_err("Could not accept remote client connection: %s "
+                CRM_XS " rc=%d", pcmk_rc_str(rc), rc);
+        return rc;
     }
+    pcmk__sockaddr2str(&addr, addr_str);
+    crm_info("Accepted new remote client connection from %s", addr_str);
 
-    rc = pcmk__set_nonblocking(csock);
+    rc = pcmk__set_nonblocking(*csock);
     if (rc != pcmk_rc_ok) {
         crm_err("Could not set socket non-blocking: %s " CRM_XS " rc=%d",
                 pcmk_rc_str(rc), rc);
-        close(csock);
-        return pcmk_rc2legacy(rc);
+        close(*csock);
+        *csock = -1;
+        return rc;
     }
 
 #ifdef TCP_USER_TIMEOUT
-    if (sbd_timeout > 0) {
-        optval = sbd_timeout / 2; /* time to fail and retry before watchdog */
-        rc = setsockopt(csock, SOL_TCP, TCP_USER_TIMEOUT,
+    if (crm_get_sbd_timeout() > 0) {
+        // Time to fail and retry before watchdog
+        unsigned int optval = (unsigned int) crm_get_sbd_timeout() / 2;
+
+        rc = setsockopt(*csock, SOL_TCP, TCP_USER_TIMEOUT,
                         &optval, sizeof(optval));
         if (rc < 0) {
-            crm_err("setting TCP_USER_TIMEOUT (%d) on client socket failed",
-                    optval);
-            close(csock);
+            rc = errno;
+            crm_err("Could not set TCP timeout to %d ms on remote connection: "
+                    "%s " CRM_XS " rc=%d", optval, pcmk_rc_str(rc), rc);
+            close(*csock);
+            *csock = -1;
             return rc;
         }
     }
 #endif
 
-    return csock;
+    return rc;
 }
 
 /*!

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -34,21 +34,7 @@
 #include <crm/common/remote_internal.h>
 
 #ifdef HAVE_GNUTLS_GNUTLS_H
-#  undef KEYFILE
 #  include <gnutls/gnutls.h>
-
-const int psk_tls_kx_order[] = {
-    GNUTLS_KX_DHE_PSK,
-    GNUTLS_KX_PSK,
-};
-
-const int anon_tls_kx_order[] = {
-    GNUTLS_KX_ANON_DH,
-    GNUTLS_KX_DHE_RSA,
-    GNUTLS_KX_DHE_DSS,
-    GNUTLS_KX_RSA,
-    0
-};
 #endif
 
 /* Swab macros from linux/swab.h */

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -240,7 +240,8 @@ add_schema(enum schema_validator_e validator, const schema_version_t *version,
 /*!
  * \internal
  * \brief Add version-specified schema + auxiliary data to internal bookkeeping.
- * \return \c -ENOENT when no upgrade schema associated, \c pcmk_ok otherwise.
+ * \return Standard Pacemaker return value (the only possible values are
+ * \c ENOENT when no upgrade schema is associated, or \c pcmk_rc_ok otherwise.
  *
  * \note There's no reliance on the particular order of schemas entering here.
  *
@@ -269,7 +270,7 @@ add_schema_by_version(const schema_version_t *version, int next,
                       bool transform_expected)
 {
     bool transform_onleave = FALSE;
-    int rc = pcmk_ok;
+    int rc = pcmk_rc_ok;
     struct stat s;
     char *xslt = NULL,
          *transform_upgrade = NULL,
@@ -323,7 +324,7 @@ add_schema_by_version(const schema_version_t *version, int next,
         free(transform_upgrade);
         transform_upgrade = NULL;
         next = -1;
-        rc = -ENOENT;
+        rc = ENOENT;
     }
 
     add_schema(schema_validator_rng, version, NULL,
@@ -335,7 +336,7 @@ add_schema_by_version(const schema_version_t *version, int next,
     return rc;
 }
 
-static int
+static void
 wrap_libxslt(bool finalize)
 {
     static xsltSecurityPrefsPtr secprefs;
@@ -354,7 +355,7 @@ wrap_libxslt(bool finalize)
               | xsltSetSecurityPrefs(secprefs, XSLT_SECPREF_WRITE_NETWORK,
                                      xsltSecurityForbid);
         if (ret != 0) {
-            return -1;
+            return;
         }
     } else {
         xsltFreeSecurityPrefs(secprefs);
@@ -365,8 +366,6 @@ wrap_libxslt(bool finalize)
     if (finalize) {
         xsltCleanupGlobals();
     }
-
-    return ret;
 }
 
 /*!
@@ -416,7 +415,7 @@ crm_schema_init(void)
                 next = -1;
             }
             if (add_schema_by_version(&version, next, transform_expected)
-                    == -ENOENT) {
+                    == ENOENT) {
                 break;
             }
         }

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -134,7 +134,7 @@ schema_filter(const struct dirent *a)
     if (strstr(a->d_name, "pacemaker-") != a->d_name) {
         /* crm_trace("%s - wrong prefix", a->d_name); */
 
-    } else if (!crm_ends_with_ext(a->d_name, ".rng")) {
+    } else if (!pcmk__ends_with_ext(a->d_name, ".rng")) {
         /* crm_trace("%s - wrong suffix", a->d_name); */
 
     } else if (!version_from_filename(a->d_name, &version)) {

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -147,7 +147,7 @@ guint
 crm_parse_ms(const char *text)
 {
     if (text) {
-        long long ms = crm_int_helper(text, NULL);
+        long long ms = crm_parse_ll(text, NULL);
 
         if ((ms < 0) || (ms > G_MAXUINT)) {
             errno = ERANGE;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -30,53 +30,62 @@ crm_itoa_stack(int an_int, char *buffer, size_t len)
     return buffer;
 }
 
-static long long
-crm_int_helper(const char *text, char **end_text)
+/*!
+ * \internal
+ * \brief Scan a long long integer from a string
+ *
+ * \param[in]  text      String to scan
+ * \param[out] result    If not NULL, where to store scanned value
+ * \param[out] end_text  If not NULL, where to store pointer to just after value
+ *
+ * \return Standard Pacemaker return code (also set errno on error)
+ */
+static int
+scan_ll(const char *text, long long *result, char **end_text)
 {
-    long long result = -1;
+    long long local_result = -1;
     char *local_end_text = NULL;
-    int saved_errno = 0;
+    int rc = pcmk_rc_ok;
 
     errno = 0;
-
     if (text != NULL) {
 #ifdef ANSI_ONLY
-        if (end_text != NULL) {
-            result = strtol(text, end_text, 10);
-        } else {
-            result = strtol(text, &local_end_text, 10);
-        }
+        local_result = (long long) strtol(text, &local_end_text, 10);
 #else
-        if (end_text != NULL) {
-            result = strtoll(text, end_text, 10);
-        } else {
-            result = strtoll(text, &local_end_text, 10);
-        }
+        local_result = strtoll(text, &local_end_text, 10);
 #endif
-
-        saved_errno = errno;
-        if (errno == EINVAL) {
-            crm_err("Conversion of %s failed", text);
-            result = -1;
-
-        } else if (errno == ERANGE) {
-            crm_err("Conversion of %s was clipped: %lld", text, result);
+        if (errno == ERANGE) {
+            rc = errno;
+            crm_warn("Integer parsed from %s was clipped to %lld",
+                     text, local_result);
 
         } else if (errno != 0) {
-            crm_perror(LOG_ERR, "Conversion of %s failed", text);
+            rc = errno;
+            local_result = -1;
+            crm_err("Could not parse integer from %s (using -1 instead): %s",
+                    text, pcmk_rc_str(rc));
 
         } else if (local_end_text == text) {
-            crm_err("Text contained no digits: %s", text);
-            result = -1;
+            rc = EINVAL;
+            local_result = -1;
+            crm_err("Could not parse integer from %s (using -1 instead): "
+                    "No digits found", text);
         }
 
-        if (local_end_text != NULL && local_end_text[0] != '\0') {
-            crm_err("Characters left over after parsing '%s': '%s'", text, local_end_text);
+        if ((end_text == NULL) && (local_end_text != NULL)
+            && (local_end_text[0] != '\0')) {
+            crm_warn("Characters left over after parsing '%s': '%s'",
+                     text, local_end_text);
         }
-
-        errno = saved_errno;
+        errno = rc;
     }
-    return result;
+    if (end_text != NULL) {
+        *end_text = local_end_text;
+    }
+    if (result != NULL) {
+        *result = local_result;
+    }
+    return rc;
 }
 
 /*!
@@ -90,6 +99,8 @@ crm_int_helper(const char *text, char **end_text)
 long long
 crm_parse_ll(const char *text, const char *default_text)
 {
+    long long result;
+
     if (text == NULL) {
         text = default_text;
         if (text == NULL) {
@@ -98,7 +109,8 @@ crm_parse_ll(const char *text, const char *default_text)
             return -1;
         }
     }
-    return crm_int_helper(text, NULL);
+    scan_ll(text, &result, NULL);
+    return result;
 }
 
 /*!
@@ -237,7 +249,7 @@ crm_get_msec(const char *input)
         return -1;
     }
 
-    msec = crm_int_helper(num_start, &end_text);
+    scan_ll(num_start, &msec, &end_text);
     if (msec > (LLONG_MAX / multiplier)) {
         // Arithmetics overflow while multiplier/divisor mutually exclusive
         return LLONG_MAX;
@@ -330,58 +342,54 @@ crm_str_eq(const char *a, const char *b, gboolean use_case)
     return FALSE;
 }
 
-static inline const char * null2emptystr(const char *);
-static inline const char *
-null2emptystr(const char *input)
-{
-    return (input == NULL) ? "" : input;
-}
-
 /*!
  * \brief Check whether a string starts with a certain sequence
  *
  * \param[in] str    String to check
  * \param[in] match  Sequence to match against beginning of \p str
  *
- * \return \c TRUE if \p str begins with match, \c FALSE otherwise
+ * \return \c true if \p str begins with match, \c false otherwise
  * \note This is equivalent to !strncmp(s, prefix, strlen(prefix))
  *       but is likely less efficient when prefix is a string literal
  *       if the compiler optimizes away the strlen() at compile time,
  *       and more efficient otherwise.
  */
 bool
-crm_starts_with(const char *str, const char *prefix)
+pcmk__starts_with(const char *str, const char *prefix)
 {
     const char *s = str;
     const char *p = prefix;
 
     if (!s || !p) {
-        return FALSE;
+        return false;
     }
     while (*s && *p) {
         if (*s++ != *p++) {
-            return FALSE;
+            return false;
         }
     }
     return (*p == 0);
 }
 
-static inline int crm_ends_with_internal(const char *, const char *, gboolean);
-static inline int
-crm_ends_with_internal(const char *s, const char *match, gboolean as_extension)
+static inline bool
+ends_with(const char *s, const char *match, bool as_extension)
 {
-    if ((s == NULL) || (match == NULL)) {
-        return 0;
+    if ((match == NULL) || (match[0] == '\0')) {
+        return true;
+    } else if (s == NULL) {
+        return false;
     } else {
         size_t slen, mlen;
 
-        if (match[0] != '\0'
-            && (as_extension /* following commented out for inefficiency:
-                || strchr(&match[1], match[0]) == NULL */))
-                return !strcmp(null2emptystr(strrchr(s, match[0])), match);
+        /* Besides as_extension, we could also check
+           !strchr(&match[1], match[0]) but that would be inefficient.
+         */
+        if (as_extension) {
+            s = strrchr(s, match[0]);
+            return (s == NULL)? false : !strcmp(s, match);
+        }
 
-        if ((mlen = strlen(match)) == 0)
-            return 1;
+        mlen = strlen(match);
         slen = strlen(s);
         return ((slen >= mlen) && !strcmp(s + slen - mlen, match));
     }
@@ -394,15 +402,14 @@ crm_ends_with_internal(const char *s, const char *match, gboolean as_extension)
  * \param[in] s      String to check
  * \param[in] match  Sequence to match against end of \p s
  *
- * \return \c TRUE if \p s ends (verbatim, i.e., case sensitively)
- *         with match (including empty string), \c FALSE otherwise
- *
- * \see crm_ends_with_ext()
+ * \return \c true if \p s ends case-sensitively with match, \c false otherwise
+ * \note pcmk__ends_with_ext() can be used if the first character of match
+ *       does not recur in match.
  */
-gboolean
-crm_ends_with(const char *s, const char *match)
+bool
+pcmk__ends_with(const char *s, const char *match)
 {
-    return crm_ends_with_internal(s, match, FALSE);
+    return ends_with(s, match, false);
 }
 
 /*!
@@ -417,21 +424,19 @@ crm_ends_with(const char *s, const char *match)
  *                   e.g., ".html"); incorrect results may be
  *                   returned otherwise.
  *
- * \return \c TRUE if \p s ends (verbatim, i.e., case sensitively)
+ * \return \c true if \p s ends (verbatim, i.e., case sensitively)
  *         with "extension" designated as \p match (including empty
- *         string), \c FALSE otherwise
+ *         string), \c false otherwise
  *
- * \note Main incentive to prefer this function over \c crm_ends_with
+ * \note Main incentive to prefer this function over \c pcmk__ends_with()
  *       where possible is the efficiency (at the cost of added
  *       restriction on \p match as stated; the complexity class
  *       remains the same, though: BigO(M+N) vs. BigO(M+2N)).
- *
- * \see crm_ends_with()
  */
-gboolean
-crm_ends_with_ext(const char *s, const char *match)
+bool
+pcmk__ends_with_ext(const char *s, const char *match)
 {
-    return crm_ends_with_internal(s, match, TRUE);
+    return ends_with(s, match, true);
 }
 
 /*
@@ -498,27 +503,43 @@ crm_str_table_dup(GHashTable *old_table)
     return new_table;
 }
 
+/*!
+ * \internal
+ * \brief Add a word to a space-separated string list
+ *
+ * \param[in,out] list  Pointer to beginning of list
+ * \param[in]     word  Word to add to list
+ *
+ * \return (Potentially new) beginning of list
+ * \note This dynamically reallocates list as needed.
+ */
 char *
-add_list_element(char *list, const char *value)
+pcmk__add_word(char *list, const char *word)
 {
-    int len = 0;
-    int last = 0;
+    if (word != NULL) {
+        size_t len = list? strlen(list) : 0;
 
-    if (value == NULL) {
-        return list;
+        list = realloc_safe(list, len + strlen(word) + 2); // 2 = space + EOS
+        sprintf(list + len, " %s", word);
     }
-    if (list) {
-        last = strlen(list);
-    }
-    len = last + 2;             /* +1 space, +1 EOS */
-    len += strlen(value);
-    list = realloc_safe(list, len);
-    sprintf(list + last, " %s", value);
     return list;
 }
 
-bool
-crm_compress_string(const char *data, int length, int max, char **result, unsigned int *result_len)
+/*!
+ * \internal
+ * \brief Compress data
+ *
+ * \param[in]  data        Data to compress
+ * \param[in]  length      Number of characters of data to compress
+ * \param[in]  max         Maximum size of compressed data (or 0 to estimate)
+ * \param[out] result      Where to store newly allocated compressed result
+ * \param[out] result_len  Where to store actual compressed length of result
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+pcmk__compress(const char *data, unsigned int length, unsigned int max,
+               char **result, unsigned int *result_len)
 {
     int rc;
     char *compressed = NULL;
@@ -528,28 +549,26 @@ crm_compress_string(const char *data, int length, int max, char **result, unsign
     struct timespec before_t;
 #endif
 
-    if(max == 0) {
-        max = (length * 1.1) + 600; /* recommended size */
+    if (max == 0) {
+        max = (length * 1.01) + 601; // Size guaranteed to hold result
     }
 
 #ifdef CLOCK_MONOTONIC
     clock_gettime(CLOCK_MONOTONIC, &before_t);
 #endif
 
-    compressed = calloc(max, sizeof(char));
+    compressed = calloc((size_t) max, sizeof(char));
     CRM_ASSERT(compressed);
 
     *result_len = max;
-    rc = BZ2_bzBuffToBuffCompress(compressed, result_len, uncompressed, length, CRM_BZ2_BLOCKS, 0,
-                                  CRM_BZ2_WORK);
-
+    rc = BZ2_bzBuffToBuffCompress(compressed, result_len, uncompressed, length,
+                                  CRM_BZ2_BLOCKS, 0, CRM_BZ2_WORK);
     free(uncompressed);
-
     if (rc != BZ_OK) {
         crm_err("Compression of %d bytes failed: %s " CRM_XS " bzerror=%d",
                 length, bz2_strerror(rc), rc);
         free(compressed);
-        return FALSE;
+        return pcmk_rc_error;
     }
 
 #ifdef CLOCK_MONOTONIC
@@ -565,31 +584,7 @@ crm_compress_string(const char *data, int length, int max, char **result, unsign
 #endif
 
     *result = compressed;
-    return TRUE;
-}
-
-/*!
- * \brief Compare two strings alphabetically (case-insensitive)
- *
- * \param[in] a  First string to compare
- * \param[in] b  Second string to compare
- *
- * \return 0 if strings are equal, -1 if a < b, 1 if a > b
- *
- * \note Usable as a GCompareFunc with g_list_sort().
- *       NULL is considered less than non-NULL.
- */
-gint
-crm_alpha_sort(gconstpointer a, gconstpointer b)
-{
-    if (!a && !b) {
-        return 0;
-    } else if (!a) {
-        return -1;
-    } else if (!b) {
-        return 1;
-    }
-    return strcasecmp(a, b);
+    return pcmk_rc_ok;
 }
 
 char *

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -563,8 +563,6 @@ compare_version(const char *version1, const char *version2)
     return rc;
 }
 
-gboolean do_stderr = FALSE;
-
 #ifndef NUMCHARS
 #  define	NUMCHARS	"0123456789."
 #endif

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -110,7 +110,7 @@ check_number(const char *value)
     } else if (safe_str_eq(value, CRM_INFINITY_S)) {
 
     } else {
-        crm_int_helper(value, NULL);
+        crm_parse_ll(value, NULL);
     }
 
     if (errno != 0) {

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -563,14 +563,6 @@ compare_version(const char *version1, const char *version2)
     return rc;
 }
 
-#ifndef NUMCHARS
-#  define	NUMCHARS	"0123456789."
-#endif
-
-#ifndef WHITESPACE
-#  define	WHITESPACE	" \t\n\r\f"
-#endif
-
 guint
 crm_parse_interval_spec(const char *input)
 {
@@ -599,61 +591,6 @@ crm_parse_interval_spec(const char *input)
     }
 
     return (msec <= 0)? 0 : ((msec >= G_MAXUINT)? G_MAXUINT : (guint) msec);
-}
-
-long long
-crm_get_msec(const char *input)
-{
-    const char *cp = input;
-    const char *units;
-    long long multiplier = 1000;
-    long long divisor = 1;
-    long long msec = -1;
-    char *end_text = NULL;
-
-    /* double dret; */
-
-    if (input == NULL) {
-        return msec;
-    }
-
-    cp += strspn(cp, WHITESPACE);
-    units = cp + strspn(cp, NUMCHARS);
-    units += strspn(units, WHITESPACE);
-
-    if (strchr(NUMCHARS, *cp) == NULL) {
-        return msec;
-    }
-
-    if (strncasecmp(units, "ms", 2) == 0 || strncasecmp(units, "msec", 4) == 0) {
-        multiplier = 1;
-        divisor = 1;
-    } else if (strncasecmp(units, "us", 2) == 0 || strncasecmp(units, "usec", 4) == 0) {
-        multiplier = 1;
-        divisor = 1000;
-    } else if (strncasecmp(units, "s", 1) == 0 || strncasecmp(units, "sec", 3) == 0) {
-        multiplier = 1000;
-        divisor = 1;
-    } else if (strncasecmp(units, "m", 1) == 0 || strncasecmp(units, "min", 3) == 0) {
-        multiplier = 60 * 1000;
-        divisor = 1;
-    } else if (strncasecmp(units, "h", 1) == 0 || strncasecmp(units, "hr", 2) == 0) {
-        multiplier = 60 * 60 * 1000;
-        divisor = 1;
-    } else if (*units != EOS && *units != '\n' && *units != '\r') {
-        return msec;
-    }
-
-    msec = crm_int_helper(cp, &end_text);
-    if (msec > LLONG_MAX/multiplier) {
-        /* arithmetics overflow while multiplier/divisor mutually exclusive */
-        return LLONG_MAX;
-    }
-    msec *= multiplier;
-    msec /= divisor;
-    /* dret += 0.5; */
-    /* msec = (long long)dret; */
-    return msec;
 }
 
 extern bool crm_is_daemon;

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -120,12 +120,10 @@ check_number(const char *value)
 }
 
 gboolean
-check_positive_number(const char* value)
+check_positive_number(const char *value)
 {
-    if (safe_str_eq(value, CRM_INFINITY_S) || (crm_int_helper(value, NULL))) {
-        return TRUE;
-    }
-    return FALSE;
+    return safe_str_eq(value, CRM_INFINITY_S)
+           || (crm_parse_ll(value, NULL) > 0);
 }
 
 gboolean

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -2367,7 +2367,7 @@ filename2xml(const char *filename)
     xmlSetGenericErrorFunc(ctxt, crm_xml_err);
 
     if (filename) {
-        uncompressed = !crm_ends_with_ext(filename, ".bz2");
+        uncompressed = !pcmk__ends_with_ext(filename, ".bz2");
     }
 
     if (filename == NULL) {

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2023,7 +2023,7 @@ stonith_api_validate(stonith_t *st, int call_options, const char *rsc_id,
     for (; params; params = params->next) {
 
         // Strip out Pacemaker-implemented parameters
-        if (!crm_starts_with(params->key, "pcmk_")
+        if (!pcmk__starts_with(params->key, "pcmk_")
                 && strcmp(params->key, "provides")
                 && strcmp(params->key, "stonith-timeout")) {
             g_hash_table_insert(params_table, strdup(params->key),

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -47,7 +47,7 @@ stonith__list_rhcs_agents(stonith_key_value_t **devices)
     for (i = 0; i < file_num; i++) {
         struct stat prop;
 
-        if (crm_starts_with(namelist[i]->d_name, RH_STONITH_PREFIX)) {
+        if (pcmk__starts_with(namelist[i]->d_name, RH_STONITH_PREFIX)) {
 #if _POSIX_C_SOURCE < 200809L && !(defined(O_SEARCH) || defined(O_PATH))
             snprintf(buffer, sizeof(buffer), "%s/%s", RH_STONITH_DIR,
                      namelist[i]->d_name);

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -786,7 +786,7 @@ calculate_system_health(gpointer gKey, gpointer gValue, gpointer user_data)
         return;
     }
 
-    if (crm_starts_with(key, "#health")) {
+    if (pcmk__starts_with(key, "#health")) {
         int score;
 
         /* Convert the value into an integer */
@@ -2405,7 +2405,7 @@ order_first_probes_imply_stops(pe_working_set_t * data_set)
 
         } else if (lh_action == NULL
                    && lh_action_task
-                   && crm_ends_with(lh_action_task, "_" RSC_STOP "_0") == FALSE) {
+                   && !pcmk__ends_with(lh_action_task, "_" RSC_STOP "_0")) {
             continue;
         }
 
@@ -2418,7 +2418,7 @@ order_first_probes_imply_stops(pe_working_set_t * data_set)
                 continue;
 
             } else if (rh_action == NULL && rh_action_task
-                       && crm_ends_with(rh_action_task,"_" RSC_STOP "_0")) {
+                       && pcmk__ends_with(rh_action_task,"_" RSC_STOP "_0")) {
                 continue;
             }
         }

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -199,16 +199,13 @@ CancelXmlOp(resource_t * rsc, xmlNode * xml_op, node_t * active_node,
 
     const char *task = NULL;
     const char *call_id = NULL;
-    const char *interval_ms_s = NULL;
 
     CRM_CHECK(xml_op != NULL, return);
     CRM_CHECK(active_node != NULL, return);
 
     task = crm_element_value(xml_op, XML_LRM_ATTR_TASK);
     call_id = crm_element_value(xml_op, XML_LRM_ATTR_CALLID);
-    interval_ms_s = crm_element_value(xml_op, XML_LRM_ATTR_INTERVAL_MS);
-
-    interval_ms = crm_parse_ms(interval_ms_s);
+    crm_element_value_ms(xml_op, XML_LRM_ATTR_INTERVAL_MS, &interval_ms);
 
     crm_info("Action " CRM_OP_FMT " on %s will be stopped: %s",
              rsc->id, task, interval_ms,
@@ -225,7 +222,6 @@ check_action_definition(resource_t * rsc, node_t * active_node, xmlNode * xml_op
 {
     char *key = NULL;
     guint interval_ms = 0;
-    const char *interval_ms_s = NULL;
     const op_digest_cache_t *digest_data = NULL;
     gboolean did_change = FALSE;
 
@@ -234,9 +230,7 @@ check_action_definition(resource_t * rsc, node_t * active_node, xmlNode * xml_op
 
     CRM_CHECK(active_node != NULL, return FALSE);
 
-    interval_ms_s = crm_element_value(xml_op, XML_LRM_ATTR_INTERVAL_MS);
-    interval_ms = crm_parse_ms(interval_ms_s);
-
+    crm_element_value_ms(xml_op, XML_LRM_ATTR_INTERVAL_MS, &interval_ms);
     if (interval_ms > 0) {
         xmlNode *op_match = NULL;
 
@@ -396,12 +390,10 @@ check_actions_for(xmlNode * rsc_entry, resource_t * rsc, node_t * node, pe_worki
 {
     GListPtr gIter = NULL;
     int offset = -1;
-    guint interval_ms = 0;
     int stop_index = 0;
     int start_index = 0;
 
     const char *task = NULL;
-    const char *interval_ms_s = NULL;
 
     xmlNode *rsc_op = NULL;
     GListPtr op_list = NULL;
@@ -449,6 +441,7 @@ check_actions_for(xmlNode * rsc_entry, resource_t * rsc, node_t * node, pe_worki
 
     for (gIter = sorted_op_list; gIter != NULL; gIter = gIter->next) {
         xmlNode *rsc_op = (xmlNode *) gIter->data;
+        guint interval_ms = 0;
 
         offset++;
 
@@ -461,9 +454,7 @@ check_actions_for(xmlNode * rsc_entry, resource_t * rsc, node_t * node, pe_worki
         }
 
         task = crm_element_value(rsc_op, XML_LRM_ATTR_TASK);
-
-        interval_ms_s = crm_element_value(rsc_op, XML_LRM_ATTR_INTERVAL_MS);
-        interval_ms = crm_parse_ms(interval_ms_s);
+        crm_element_value_ms(rsc_op, XML_LRM_ATTR_INTERVAL_MS, &interval_ms);
 
         if ((interval_ms > 0) &&
             (is_set(rsc->flags, pe_rsc_maintenance) || node->details->maintenance)) {

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -985,7 +985,7 @@ shutdown_time(pe_node_t *node, pe_working_set_t *data_set)
 
     if (shutdown) {
         errno = 0;
-        result = (time_t) crm_int_helper(shutdown, NULL);
+        result = (time_t) crm_parse_ll(shutdown, NULL);
         if (errno != 0) {
             result = 0;
         }
@@ -2947,7 +2947,7 @@ stage8(pe_working_set_t * data_set)
     crm_xml_add_int(data_set->graph, "transition_id", transition_id);
 
     value = pe_pref(data_set->config_hash, "migration-limit");
-    if (crm_int_helper(value, NULL) > 0) {
+    if (crm_parse_ll(value, NULL) > 0) {
         crm_xml_add(data_set->graph, "migration-limit", value);
     }
 

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -1919,12 +1919,15 @@ extern void update_colo_start_chain(pe_action_t *action,
                                     pe_working_set_t *data_set);
 
 static int
-is_recurring_action(action_t *action) 
+is_recurring_action(action_t *action)
 {
-    const char *interval_ms_s = g_hash_table_lookup(action->meta,
-                                                    XML_LRM_ATTR_INTERVAL_MS);
-    guint interval_ms = crm_parse_ms(interval_ms_s);
+    guint interval_ms;
 
+    if (pcmk__guint_from_hash(action->meta,
+                              XML_LRM_ATTR_INTERVAL_MS, 0,
+                              &interval_ms) != pcmk_rc_ok) {
+        return 0;
+    }
     return (interval_ms > 0);
 }
 

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -647,8 +647,8 @@ multi_update_interleave_actions(pe_action_t *first, pe_action_t *then,
     enum pe_graph_flags changed = pe_graph_none;
 
     /* Fix this - lazy */
-    if (crm_ends_with(first->uuid, "_stopped_0")
-        || crm_ends_with(first->uuid, "_demoted_0")) {
+    if (pcmk__ends_with(first->uuid, "_stopped_0")
+        || pcmk__ends_with(first->uuid, "_demoted_0")) {
         current = TRUE;
     }
 
@@ -792,7 +792,8 @@ can_interleave_actions(pe_action_t *first, pe_action_t *then)
         return FALSE;
     }
 
-    if (crm_ends_with(then->uuid, "_stop_0") || crm_ends_with(then->uuid, "_demote_0")) {
+    if (pcmk__ends_with(then->uuid, "_stop_0")
+        || pcmk__ends_with(then->uuid, "_demote_0")) {
         rsc = first->rsc;
     } else {
         rsc = then->rsc;

--- a/lib/pacemaker/pcmk_sched_graph.c
+++ b/lib/pacemaker/pcmk_sched_graph.c
@@ -1533,7 +1533,7 @@ check_dump_input(pe_action_t *action, pe_action_wrapper_t *input)
 
     } else if ((input->type == pe_order_optional)
                && is_set(input->action->flags, pe_action_migrate_runnable)
-               && crm_ends_with(input->action->uuid, "_stop_0")) {
+               && pcmk__ends_with(input->action->uuid, "_stop_0")) {
         crm_trace("Ignoring %s (%d) input %s (%d): "
                   "optional but stop in migration",
                   action->uuid, action->id,
@@ -1608,7 +1608,7 @@ check_dump_input(pe_action_t *action, pe_action_wrapper_t *input)
                && input->action->rsc != action->rsc
                && is_set(input->action->rsc->flags, pe_rsc_failed)
                && is_not_set(input->action->rsc->flags, pe_rsc_managed)
-               && crm_ends_with(input->action->uuid, "_stop_0")
+               && pcmk__ends_with(input->action->uuid, "_stop_0")
                && action->rsc && pe_rsc_is_clone(action->rsc)) {
         crm_warn("Ignoring requirement that %s complete before %s:"
                  " unmanaged failed resources cannot prevent clone shutdown",

--- a/lib/pacemaker/pcmk_sched_graph.c
+++ b/lib/pacemaker/pcmk_sched_graph.c
@@ -1067,9 +1067,13 @@ action2xml(action_t * action, gboolean as_input, pe_working_set_t *data_set)
     crm_xml_add(action_xml, XML_LRM_ATTR_TASK, action->task);
     if (action->rsc != NULL && action->rsc->clone_name != NULL) {
         char *clone_key = NULL;
-        const char *interval_ms_s = g_hash_table_lookup(action->meta,
-                                                        XML_LRM_ATTR_INTERVAL_MS);
-        guint interval_ms = crm_parse_ms(interval_ms_s);
+        guint interval_ms;
+
+        if (pcmk__guint_from_hash(action->meta,
+                                  XML_LRM_ATTR_INTERVAL_MS, 0,
+                                  &interval_ms) != pcmk_rc_ok) {
+            interval_ms = 0;
+        }
 
         if (safe_str_eq(action->task, RSC_NOTIFY)) {
             const char *n_type = g_hash_table_lookup(action->meta, "notify_type");

--- a/lib/pacemaker/pcmk_trans_unpack.c
+++ b/lib/pacemaker/pcmk_trans_unpack.c
@@ -64,9 +64,10 @@ unpack_action(synapse_t * parent, xmlNode * xml_action)
         action->timeout += crm_parse_int(value, NULL);
     }
 
-    value = g_hash_table_lookup(action->params, "CRM_meta_interval");
-    if (value != NULL) {
-        action->interval_ms = crm_parse_ms(value);
+    if (pcmk__guint_from_hash(action->params,
+                              CRM_META "_" XML_LRM_ATTR_INTERVAL, 0,
+                              &(action->interval_ms)) != pcmk_rc_ok) {
+        action->interval_ms = 0;
     }
 
     value = g_hash_table_lookup(action->params, "CRM_meta_can_fail");

--- a/lib/pacemaker/pcmk_trans_utils.c
+++ b/lib/pacemaker/pcmk_trans_utils.c
@@ -156,14 +156,14 @@ synapse_pending_inputs(crm_graph_t *graph, synapse_t *synapse)
         crm_action_t *input = (crm_action_t *) lpc->data;
 
         if (input->failed) {
-            pending = add_list_element(pending, ID(input->xml));
+            pending = pcmk__add_word(pending, ID(input->xml));
 
         } else if (input->confirmed) {
             // Confirmed successful inputs are not pending
 
         } else if (find_action(graph, input->id) != NULL) {
             // In-flight or pending
-            pending = add_list_element(pending, ID(input->xml));
+            pending = pcmk__add_word(pending, ID(input->xml));
         }
     }
     if (pending == NULL) {

--- a/lib/pacemaker/pcmk_trans_utils.c
+++ b/lib/pacemaker/pcmk_trans_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -25,7 +25,7 @@ pseudo_action_dummy(crm_graph_t * graph, crm_action_t * action)
         char *fail_s = getenv("PE_fail");
 
         if (fail_s) {
-            fail = crm_int_helper(fail_s, NULL);
+            fail = (int) crm_parse_ll(fail_s, NULL);
         } else {
             fail = 0;
         }

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -430,7 +430,7 @@ clone_print(resource_t * rsc, const char *pre_text, long options, void *print_da
             // List stopped instances when requested (except orphans)
             if (is_not_set(child_rsc->flags, pe_rsc_orphan)
                 && is_not_set(options, pe_print_clone_active)) {
-                stopped_list = add_list_element(stopped_list, child_rsc->id);
+                stopped_list = pcmk__add_word(stopped_list, child_rsc->id);
             }
 
         } else if (is_set_recursive(child_rsc, pe_rsc_orphan, TRUE)
@@ -486,7 +486,7 @@ clone_print(resource_t * rsc, const char *pre_text, long options, void *print_da
     for (gIter = master_list; gIter; gIter = gIter->next) {
         node_t *host = gIter->data;
 
-        list_text = add_list_element(list_text, host->details->uname);
+        list_text = pcmk__add_word(list_text, host->details->uname);
 	active_instances++;
     }
 
@@ -500,7 +500,7 @@ clone_print(resource_t * rsc, const char *pre_text, long options, void *print_da
     for (gIter = started_list; gIter; gIter = gIter->next) {
         node_t *host = gIter->data;
 
-        list_text = add_list_element(list_text, host->details->uname);
+        list_text = pcmk__add_word(list_text, host->details->uname);
 	active_instances++;
     }
 
@@ -550,7 +550,8 @@ clone_print(resource_t * rsc, const char *pre_text, long options, void *print_da
                 node_t *node = (node_t *)nIter->data;
 
                 if (pe_find_node(rsc->running_on, node->details->uname) == NULL) {
-                    stopped_list = add_list_element(stopped_list, node->details->uname);
+                    stopped_list = pcmk__add_word(stopped_list,
+                                                  node->details->uname);
                 }
             }
             g_list_free(list);
@@ -646,7 +647,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
             // List stopped instances when requested (except orphans)
             if (is_not_set(child_rsc->flags, pe_rsc_orphan)
                 && is_not_set(options, pe_print_clone_active)) {
-                stopped_list = add_list_element(stopped_list, child_rsc->id);
+                stopped_list = pcmk__add_word(stopped_list, child_rsc->id);
             }
 
         } else if (is_set_recursive(child_rsc, pe_rsc_orphan, TRUE)
@@ -696,7 +697,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
     for (gIter = master_list; gIter; gIter = gIter->next) {
         node_t *host = gIter->data;
 
-        list_text = add_list_element(list_text, host->details->uname);
+        list_text = pcmk__add_word(list_text, host->details->uname);
         active_instances++;
     }
 
@@ -712,7 +713,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
     for (gIter = started_list; gIter; gIter = gIter->next) {
         node_t *host = gIter->data;
 
-        list_text = add_list_element(list_text, host->details->uname);
+        list_text = pcmk__add_word(list_text, host->details->uname);
         active_instances++;
     }
 
@@ -765,7 +766,8 @@ pe__clone_html(pcmk__output_t *out, va_list args)
                 node_t *node = (node_t *)nIter->data;
 
                 if (pe_find_node(rsc->running_on, node->details->uname) == NULL) {
-                    stopped_list = add_list_element(stopped_list, node->details->uname);
+                    stopped_list = pcmk__add_word(stopped_list,
+                                                  node->details->uname);
                 }
             }
             g_list_free(list);
@@ -833,7 +835,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
             // List stopped instances when requested (except orphans)
             if (is_not_set(child_rsc->flags, pe_rsc_orphan)
                 && is_not_set(options, pe_print_clone_active)) {
-                stopped_list = add_list_element(stopped_list, child_rsc->id);
+                stopped_list = pcmk__add_word(stopped_list, child_rsc->id);
             }
 
         } else if (is_set_recursive(child_rsc, pe_rsc_orphan, TRUE)
@@ -883,7 +885,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
     for (gIter = master_list; gIter; gIter = gIter->next) {
         node_t *host = gIter->data;
 
-        list_text = add_list_element(list_text, host->details->uname);
+        list_text = pcmk__add_word(list_text, host->details->uname);
         active_instances++;
     }
 
@@ -899,7 +901,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
     for (gIter = started_list; gIter; gIter = gIter->next) {
         node_t *host = gIter->data;
 
-        list_text = add_list_element(list_text, host->details->uname);
+        list_text = pcmk__add_word(list_text, host->details->uname);
         active_instances++;
     }
 
@@ -951,7 +953,8 @@ pe__clone_text(pcmk__output_t *out, va_list args)
                 node_t *node = (node_t *)nIter->data;
 
                 if (pe_find_node(rsc->running_on, node->details->uname) == NULL) {
-                    stopped_list = add_list_element(stopped_list, node->details->uname);
+                    stopped_list = pcmk__add_word(stopped_list,
+                                                  node->details->uname);
                 }
             }
             g_list_free(list);

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -266,7 +266,7 @@ pe_get_failcount(node_t *node, resource_t *rsc, time_t *last_failure,
         if (regexec(&failcount_re, key, 0, NULL, 0) == 0) {
             failcount = merge_weights(failcount, char2score(value));
         } else if (regexec(&lastfailure_re, key, 0, NULL, 0) == 0) {
-            last = QB_MAX(last, crm_int_helper(value, NULL));
+            last = QB_MAX(last, (time_t) crm_parse_ll(value, NULL));
         }
     }
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -744,10 +744,14 @@ pe__failed_action_xml(pcmk__output_t *out, va_list args) {
                (pcmkXmlStr) services_lrm_status_str(status));
 
     if (last) {
-        char *s = crm_itoa(crm_parse_ms(crm_element_value(xml_op, XML_LRM_ATTR_INTERVAL_MS)));
+        guint interval_ms = 0;
+        char *s = NULL;
         time_t when = crm_parse_int(last, "0");
         crm_time_t *crm_when = crm_time_new(NULL);
         char *rc_change = NULL;
+
+        crm_element_value_ms(xml_op, XML_LRM_ATTR_INTERVAL_MS, &interval_ms);
+        s = crm_itoa(interval_ms);
 
         crm_time_set_timet(crm_when, &when);
         rc_change = crm_time_as_string(crm_when, crm_time_log_date | crm_time_log_timeofday | crm_time_log_with_timezone);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -3153,7 +3153,7 @@ check_operation_expiry(pe_resource_t *rsc, pe_node_t *node, int rc,
                        xmlNode *xml_op, pe_working_set_t *data_set)
 {
     bool expired = FALSE;
-    bool is_last_failure = crm_ends_with(ID(xml_op), "_last_failure_0");
+    bool is_last_failure = pcmk__ends_with(ID(xml_op), "_last_failure_0");
     time_t last_run = 0;
     guint interval_ms = 0;
     int unexpired_fail_count = 0;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2086,7 +2086,6 @@ process_recurring(node_t * node, resource_t * rsc,
         guint interval_ms = 0;
         char *key = NULL;
         const char *id = ID(rsc_op);
-        const char *interval_ms_s = NULL;
 
         counter++;
 
@@ -2104,8 +2103,7 @@ process_recurring(node_t * node, resource_t * rsc,
             continue;
         }
 
-        interval_ms_s = crm_element_value(rsc_op, XML_LRM_ATTR_INTERVAL_MS);
-        interval_ms = crm_parse_ms(interval_ms_s);
+        crm_element_value_ms(rsc_op, XML_LRM_ATTR_INTERVAL_MS, &interval_ms);
         if (interval_ms == 0) {
             pe_rsc_trace(rsc, "Skipping %s/%s: non-recurring", id, node->details->uname);
             continue;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -2112,8 +2112,6 @@ rsc_action_digest_cmp(resource_t * rsc, xmlNode * xml_op, node_t * node,
 
     const char *op_version;
     const char *task = crm_element_value(xml_op, XML_LRM_ATTR_TASK);
-    const char *interval_ms_s = crm_element_value(xml_op,
-                                                  XML_LRM_ATTR_INTERVAL_MS);
     const char *digest_all;
     const char *digest_restart;
 
@@ -2123,7 +2121,7 @@ rsc_action_digest_cmp(resource_t * rsc, xmlNode * xml_op, node_t * node,
     digest_all = crm_element_value(xml_op, XML_LRM_ATTR_OP_DIGEST);
     digest_restart = crm_element_value(xml_op, XML_LRM_ATTR_RESTART_DIGEST);
 
-    interval_ms = crm_parse_ms(interval_ms_s);
+    crm_element_value_ms(xml_op, XML_LRM_ATTR_INTERVAL_MS, &interval_ms);
     key = pcmk__op_key(rsc->id, task, interval_ms);
     data = rsc_action_digest(rsc, task, key, node, xml_op,
                              is_set(data_set->flags, pe_flag_sanitized),

--- a/lib/services/services_lsb.c
+++ b/lib/services/services_lsb.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2010-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2010-2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -87,7 +89,7 @@
 static inline gboolean
 lsb_meta_helper_get_value(const char *line, char **value, const char *prefix)
 {
-    if (!*value && crm_starts_with(line, prefix)) {
+    if (!*value && pcmk__starts_with(line, prefix)) {
         *value = (char *)xmlEncodeEntitiesReentrant(NULL, BAD_CAST line+strlen(prefix));
         return TRUE;
     }
@@ -132,7 +134,7 @@ services__get_lsb_metadata(const char *type, char **output)
     while (fgets(buffer, sizeof(buffer), fp)) {
 
         // Ignore lines up to and including the block delimiter
-        if (crm_starts_with(buffer, LSB_INITSCRIPT_INFOBEGIN_TAG)) {
+        if (pcmk__starts_with(buffer, LSB_INITSCRIPT_INFOBEGIN_TAG)) {
             in_header = TRUE;
             continue;
         }
@@ -168,7 +170,7 @@ services__get_lsb_metadata(const char *type, char **output)
 
         /* Long description may cross multiple lines */
         if ((offset == 0) // haven't already found long description
-            && crm_starts_with(buffer, DESCRIPTION)) {
+            && pcmk__starts_with(buffer, DESCRIPTION)) {
             bool processed_line = TRUE;
 
             // Get remainder of description line itself
@@ -178,8 +180,8 @@ services__get_lsb_metadata(const char *type, char **output)
             // Read any continuation lines of the description
             buffer[0] = '\0';
             while (fgets(buffer, sizeof(buffer), fp)) {
-                if (crm_starts_with(buffer, "#  ")
-                    || crm_starts_with(buffer, "#\t")) {
+                if (pcmk__starts_with(buffer, "#  ")
+                    || pcmk__starts_with(buffer, "#\t")) {
                     /* '#' followed by a tab or more than one space indicates a
                      * continuation of the long description.
                      */
@@ -204,7 +206,7 @@ services__get_lsb_metadata(const char *type, char **output)
         }
 
         // Stop if we leave the header block
-        if (crm_starts_with(buffer, LSB_INITSCRIPT_INFOEND_TAG)) {
+        if (pcmk__starts_with(buffer, LSB_INITSCRIPT_INFOEND_TAG)) {
             break;
         }
         if (buffer[0] != '#') {

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the Pacemaker project contributors
+ * Copyright 2012-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -360,6 +360,31 @@ systemd_unit_by_name(const gchar * arg_name, svc_action_t *op)
     return NULL;
 }
 
+/*!
+ * \internal
+ * \brief Compare two strings alphabetically (case-insensitive)
+ *
+ * \param[in] a  First string to compare
+ * \param[in] b  Second string to compare
+ *
+ * \return 0 if strings are equal, -1 if a < b, 1 if a > b
+ *
+ * \note Usable as a GCompareFunc with g_list_sort().
+ *       NULL is considered less than non-NULL.
+ */
+static gint
+sort_str(gconstpointer a, gconstpointer b)
+{
+    if (!a && !b) {
+        return 0;
+    } else if (!a) {
+        return -1;
+    } else if (!b) {
+        return 1;
+    }
+    return strcasecmp(a, b);
+}
+
 GList *
 systemd_unit_listall(void)
 {
@@ -453,7 +478,7 @@ systemd_unit_listall(void)
     dbus_message_unref(reply);
 
     crm_trace("Found %d manageable systemd unit files", nfiles);
-    units = g_list_sort(units, crm_alpha_sort);
+    units = g_list_sort(units, sort_str);
     return units;
 }
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -30,7 +30,7 @@
 #include <crm/lrmd.h>
 #include <crm/common/cmdline_internal.h>
 #include <crm/common/curses_internal.h>
-#include <crm/common/internal.h>  /* crm_ends_with_ext */
+#include <crm/common/internal.h>  // pcmk__ends_with_ext()
 #include <crm/common/ipc.h>
 #include <crm/common/iso8601_internal.h>
 #include <crm/common/mainloop.h>
@@ -918,7 +918,7 @@ main(int argc, char **argv)
     // Avoid needing to wait for subprocesses forked for -E/--external-agent
     avoid_zombies();
 
-    if (crm_ends_with_ext(argv[0], ".cgi") == TRUE) {
+    if (pcmk__ends_with_ext(argv[0], ".cgi")) {
         output_format = mon_output_cgi;
         options.mon_ops |= mon_op_one_shot;
     }
@@ -1212,7 +1212,7 @@ print_simple_status(pcmk__output_t *out, pe_working_set_t * data_set,
             nodes_online++;
         } else {
             char *s = crm_strdup_printf("offline node: %s", node->details->uname);
-            offline_nodes = add_list_element(offline_nodes, s);
+            offline_nodes = pcmk__add_word(offline_nodes, s);
             free(s);
             mon_ops |= mon_op_has_warnings;
             offline = TRUE;

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -1003,11 +1003,13 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
             node_mode = "online";
             if (is_not_set(mon_ops, mon_op_group_by_node)) {
                 if (pe__is_guest_node(node)) {
-                    online_guest_nodes = add_list_element(online_guest_nodes, node_name);
+                    online_guest_nodes = pcmk__add_word(online_guest_nodes,
+                                                        node_name);
                 } else if (pe__is_remote_node(node)) {
-                    online_remote_nodes = add_list_element(online_remote_nodes, node_name);
+                    online_remote_nodes = pcmk__add_word(online_remote_nodes,
+                                                         node_name);
                 } else {
-                    online_nodes = add_list_element(online_nodes, node_name);
+                    online_nodes = pcmk__add_word(online_nodes, node_name);
                 }
                 free(node_name);
                 continue;
@@ -1017,11 +1019,12 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
             node_mode = "OFFLINE";
             if (is_not_set(mon_ops, mon_op_group_by_node)) {
                 if (pe__is_remote_node(node)) {
-                    offline_remote_nodes = add_list_element(offline_remote_nodes, node_name);
+                    offline_remote_nodes = pcmk__add_word(offline_remote_nodes,
+                                                          node_name);
                 } else if (pe__is_guest_node(node)) {
                     /* ignore offline guest nodes */
                 } else {
-                    offline_nodes = add_list_element(offline_nodes, node_name);
+                    offline_nodes = pcmk__add_word(offline_nodes, node_name);
                 }
                 free(node_name);
                 continue;

--- a/tools/crm_resource_ban.c
+++ b/tools/crm_resource_ban.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -317,11 +317,11 @@ build_clear_xpath_string(xmlNode *constraint_node, const char *rsc, const char *
     char *rsc_role_substr = NULL;
     char *date_substr = NULL;
 
-    if (crm_starts_with(ID(constraint_node), "cli-ban-")) {
+    if (pcmk__starts_with(ID(constraint_node), "cli-ban-")) {
         date_substr = crm_strdup_printf("//date_expression[@id='%s-lifetime']",
                                         ID(constraint_node));
 
-    } else if (crm_starts_with(ID(constraint_node), "cli-prefer-")) {
+    } else if (pcmk__starts_with(ID(constraint_node), "cli-prefer-")) {
         date_substr = crm_strdup_printf("//date_expression[@id='cli-prefer-lifetime-end-%s']",
                                         crm_element_value(constraint_node, "rsc"));
     } else {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1489,9 +1489,6 @@ cli_resource_restart(pe_resource_t *rsc, const char *host, int timeout_ms,
         g_list_free_full(target_active, free);
     }
     target_active = restart_target_active;
-    if (list_delta) {
-        g_list_free(list_delta);
-    }
     list_delta = subtract_lists(target_active, current_active, (GCompareFunc) strcmp);
     fprintf(stdout, "Waiting for %d resources to start again:\n", g_list_length(list_delta));
     display_list(list_delta, " * ");

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1256,7 +1256,7 @@ max_delay_for_resource(pe_working_set_t * data_set, resource_t *rsc)
         action_t *stop = custom_action(rsc, key, RSC_STOP, NULL, TRUE, FALSE, data_set);
         const char *value = g_hash_table_lookup(stop->meta, XML_ATTR_TIMEOUT);
 
-        max_delay = crm_int_helper(value, NULL);
+        max_delay = value? (int) crm_parse_ll(value, NULL) : -1;
         pe_free_action(stop);
     }
 

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -126,22 +126,25 @@ print_cluster_status(pe_working_set_t * data_set, long options)
 
         } else if (node->details->online) {
             if (pe__is_guest_node(node)) {
-                online_guest_nodes = add_list_element(online_guest_nodes, node_name);
+                online_guest_nodes = pcmk__add_word(online_guest_nodes,
+                                                    node_name);
             } else if (pe__is_remote_node(node)) {
-                online_remote_nodes = add_list_element(online_remote_nodes, node_name);
+                online_remote_nodes = pcmk__add_word(online_remote_nodes,
+                                                     node_name);
             } else {
-                online_nodes = add_list_element(online_nodes, node_name);
+                online_nodes = pcmk__add_word(online_nodes, node_name);
             }
             free(node_name);
             continue;
 
         } else {
             if (pe__is_remote_node(node)) {
-                offline_remote_nodes = add_list_element(offline_remote_nodes, node_name);
+                offline_remote_nodes = pcmk__add_word(offline_remote_nodes,
+                                                      node_name);
             } else if (pe__is_guest_node(node)) {
                 /* ignore offline container nodes */
             } else {
-                offline_nodes = add_list_element(offline_nodes, node_name);
+                offline_nodes = pcmk__add_word(offline_nodes, node_name);
             }
             free(node_name);
             continue;
@@ -569,7 +572,8 @@ profile_all(const char *dir, long long repeat, pe_working_set_t *data_set)
                 free(namelist[file_num]);
                 continue;
 
-            } else if (!crm_ends_with_ext(namelist[file_num]->d_name, ".xml")) {
+            } else if (!pcmk__ends_with_ext(namelist[file_num]->d_name,
+                                            ".xml")) {
                 free(namelist[file_num]);
                 continue;
             }

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -220,12 +220,13 @@ create_action_name(pe_action_t *action)
 
     if (clone_name) {
         char *key = NULL;
-        const char *interval_ms_s = NULL;
         guint interval_ms = 0;
 
-        interval_ms_s = g_hash_table_lookup(action->meta,
-                                            XML_LRM_ATTR_INTERVAL_MS);
-        interval_ms = crm_parse_ms(interval_ms_s);
+        if (pcmk__guint_from_hash(action->meta,
+                                  XML_LRM_ATTR_INTERVAL_MS, 0,
+                                  &interval_ms) != pcmk_rc_ok) {
+            interval_ms = 0;
+        }
 
         if (safe_str_eq(action->task, RSC_NOTIFY)
             || safe_str_eq(action->task, RSC_NOTIFIED)) {

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -782,7 +782,7 @@ main(int argc, char **argv)
 
     if (test_dir != NULL) {
         if (repeat_s != NULL) {
-            repeat = crm_int_helper(repeat_s, NULL);
+            repeat = crm_parse_ll(repeat_s, NULL);
             if (errno || (repeat < 1)) {
                 fprintf(stderr, "--repeat must be positive integer, not '%s' -- using 1",
                         repeat_s);


### PR DESCRIPTION
This is part of an ongoing project to ensure all internal library functions follow current naming and copyright guidelines, and use the new standard function return codes where appropriate. This portion takes care of most of the rest of libcrmcommon.