### PR TITLE
Move decodeNVpair into libcrmcommon, rename, and extend.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,7 @@ pacemaker-[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]
 # Test results
 *.log
 *.trs
+/lib/common/tests/strings/pcmk__split_range
 /lib/pengine/tests/rules/pe_cron_range_satisfied
 
 # Release maintenance detritus

--- a/.gitignore
+++ b/.gitignore
@@ -198,7 +198,7 @@ pacemaker-[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]
 # Test results
 *.log
 *.trs
-/lib/common/tests/strings/pcmk__split_range
+/lib/common/tests/strings/pcmk__parse_ll_range
 /lib/pengine/tests/rules/pe_cron_range_satisfied
 
 # Release maintenance detritus

--- a/configure.ac
+++ b/configure.ac
@@ -1999,6 +1999,8 @@ AC_CONFIG_FILES(Makefile                                            \
                 lib/pacemaker-fencing.pc                            \
                 lib/pacemaker-cluster.pc                            \
                 lib/common/Makefile                                 \
+                lib/common/tests/Makefile                           \
+                lib/common/tests/strings/Makefile                   \
                 lib/cluster/Makefile                                \
                 lib/cib/Makefile                                    \
                 lib/gnu/Makefile                                    \

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -58,7 +58,7 @@ gboolean crm_strcase_equal(gconstpointer a, gconstpointer b);
 guint crm_strcase_hash(gconstpointer v);
 guint g_str_hash_traditional(gconstpointer v);
 char *crm_strdup_printf(char const *format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));
-int pcmk__split_range(const char *srcstring, long long *start, long long *end);
+int pcmk__parse_ll_range(const char *srcstring, long long *start, long long *end);
 
 #  define safe_str_eq(a, b) crm_str_eq(a, b, FALSE)
 #  define crm_str_hash g_str_hash_traditional

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -58,6 +58,7 @@ gboolean crm_strcase_equal(gconstpointer a, gconstpointer b);
 guint crm_strcase_hash(gconstpointer v);
 guint g_str_hash_traditional(gconstpointer v);
 char *crm_strdup_printf(char const *format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));
+bool pcmk__split_range(const char *srcstring, char separator, char **name, char **value);
 
 #  define safe_str_eq(a, b) crm_str_eq(a, b, FALSE)
 #  define crm_str_hash g_str_hash_traditional

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -58,7 +58,7 @@ gboolean crm_strcase_equal(gconstpointer a, gconstpointer b);
 guint crm_strcase_hash(gconstpointer v);
 guint g_str_hash_traditional(gconstpointer v);
 char *crm_strdup_printf(char const *format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));
-bool pcmk__split_range(const char *srcstring, char separator, char **name, char **value);
+int pcmk__split_range(const char *srcstring, char separator, char **start, char **end);
 
 #  define safe_str_eq(a, b) crm_str_eq(a, b, FALSE)
 #  define crm_str_hash g_str_hash_traditional

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -58,7 +58,7 @@ gboolean crm_strcase_equal(gconstpointer a, gconstpointer b);
 guint crm_strcase_hash(gconstpointer v);
 guint g_str_hash_traditional(gconstpointer v);
 char *crm_strdup_printf(char const *format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));
-int pcmk__split_range(const char *srcstring, char separator, char **start, char **end);
+int pcmk__split_range(const char *srcstring, long long *start, long long *end);
 
 #  define safe_str_eq(a, b) crm_str_eq(a, b, FALSE)
 #  define crm_str_hash g_str_hash_traditional

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -24,6 +24,8 @@ lib_LTLIBRARIES	= libcrmcommon.la
 
 CFLAGS		= $(CFLAGS_COPY:-Wcast-qual=) -fPIC
 
+SUBDIRS = tests
+
 noinst_HEADERS		= crmcommon_private.h
 
 libcrmcommon_la_LDFLAGS	= -version-info 37:0:3

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -602,7 +602,7 @@ crm_strdup_printf(char const *format, ...)
 }
 
 int
-pcmk__split_range(const char *srcstring, long long *start, long long *end)
+pcmk__parse_ll_range(const char *srcstring, long long *start, long long *end)
 {
     char *remainder = NULL;
 

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -602,38 +602,55 @@ crm_strdup_printf(char const *format, ...)
 }
 
 int
-pcmk__split_range(const char *srcstring, char separator, char **start, char **end)
+pcmk__split_range(const char *srcstring, long long *start, long long *end)
 {
-    const char *seploc = NULL;
+    char *remainder = NULL;
 
     CRM_ASSERT(start != NULL && end != NULL);
-    *start = NULL;
-    *end = NULL;
+
+    *start = -1;
+    *end = -1;
 
     crm_trace("Attempting to decode: [%s]", srcstring);
-    if (srcstring == NULL || strcmp(srcstring, "") == 0) {
+    if (srcstring == NULL || strcmp(srcstring, "") == 0 || strcmp(srcstring, "-") == 0) {
         return pcmk_rc_unknown_format;
     }
 
-    seploc = strchr(srcstring, separator);
-    if (!seploc) {
-        return pcmk_rc_ok;
-    } else if (strlen(srcstring) == 1) {
-        /* The source string contained only the separator. */
+    /* String starts with a dash, so this is either a range with
+     * no beginning or garbage.
+     * */
+    if (*srcstring == '-') {
+        int rc = scan_ll(srcstring+1, end, &remainder);
+
+        if (rc != pcmk_rc_ok || *remainder != '\0') {
+            return pcmk_rc_unknown_format;
+        } else {
+            return pcmk_rc_ok;
+        }
+    }
+
+    if (scan_ll(srcstring, start, &remainder) != pcmk_rc_ok) {
         return pcmk_rc_unknown_format;
-    } else if (seploc == srcstring && *(seploc + 1)) {
-        /* Separator is the first character of the range, so this
-         * range only has an end.
-         */
-        *end = strdup(seploc + 1);
-    } else if (! *(seploc + 1)) {
-        /* Separator is the last character of the range, so this
-         * range only has a start.
-         */
-        *start = strndup(srcstring, seploc - srcstring);
+    }
+
+    if (*remainder && *remainder == '-') {
+        if (*(remainder+1)) {
+            char *more_remainder = NULL;
+            int rc = scan_ll(remainder+1, end, &more_remainder);
+
+            if (rc != pcmk_rc_ok || *more_remainder != '\0') {
+                return pcmk_rc_unknown_format;
+            }
+        }
+    } else if (*remainder && *remainder != '-') {
+        *start = -1;
+        return pcmk_rc_unknown_format;
     } else {
-        *start = strndup(srcstring, seploc - srcstring);
-        *end = strdup(seploc + 1);
+        /* The input string contained only one number.  Set start and end
+         * to the same value and return pcmk_rc_ok.  This gives the caller
+         * a way to tell this condition apart from a range with no end.
+         */
+        *end = *start;
     }
 
     return pcmk_rc_ok;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -600,3 +600,26 @@ crm_strdup_printf(char const *format, ...)
     va_end(ap);
     return string;
 }
+
+bool
+pcmk__split_range(const char *srcstring, char separator, char **name, char **value)
+{
+    const char *seploc = NULL;
+
+    CRM_ASSERT(name != NULL && value != NULL);
+    *name = NULL;
+    *value = NULL;
+
+    crm_trace("Attempting to decode: [%s]", srcstring);
+    if (srcstring != NULL) {
+        seploc = strchr(srcstring, separator);
+        if (seploc) {
+            *name = strndup(srcstring, seploc - srcstring);
+            if (*(seploc + 1)) {
+                *value = strdup(seploc + 1);
+            }
+            return true;
+        }
+    }
+    return false;
+}

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -602,24 +602,39 @@ crm_strdup_printf(char const *format, ...)
 }
 
 bool
-pcmk__split_range(const char *srcstring, char separator, char **name, char **value)
+pcmk__split_range(const char *srcstring, char separator, char **start, char **end)
 {
     const char *seploc = NULL;
 
-    CRM_ASSERT(name != NULL && value != NULL);
-    *name = NULL;
-    *value = NULL;
+    CRM_ASSERT(start != NULL && end != NULL);
+    *start = NULL;
+    *end = NULL;
 
     crm_trace("Attempting to decode: [%s]", srcstring);
-    if (srcstring != NULL) {
-        seploc = strchr(srcstring, separator);
-        if (seploc) {
-            *name = strndup(srcstring, seploc - srcstring);
-            if (*(seploc + 1)) {
-                *value = strdup(seploc + 1);
-            }
-            return true;
-        }
+    if (srcstring == NULL) {
+        return false;
     }
-    return false;
+
+    seploc = strchr(srcstring, separator);
+    if (!seploc) {
+        return false;
+    } else if (strlen(srcstring) == 1) {
+        /* The source string contained only the separator. */
+        return false;
+    } else if (seploc == srcstring && *(seploc + 1)) {
+        /* Separator is the first character of the range, so this
+         * range only has an end.
+         */
+        *end = strdup(seploc + 1);
+    } else if (! *(seploc + 1)) {
+        /* Separator is the last character of the range, so this
+         * range only has a start.
+         */
+        *start = strndup(srcstring, seploc - srcstring);
+    } else {
+        *start = strndup(srcstring, seploc - srcstring);
+        *end = strdup(seploc + 1);
+    }
+
+    return true;
 }

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -601,7 +601,7 @@ crm_strdup_printf(char const *format, ...)
     return string;
 }
 
-bool
+int
 pcmk__split_range(const char *srcstring, char separator, char **start, char **end)
 {
     const char *seploc = NULL;
@@ -611,16 +611,16 @@ pcmk__split_range(const char *srcstring, char separator, char **start, char **en
     *end = NULL;
 
     crm_trace("Attempting to decode: [%s]", srcstring);
-    if (srcstring == NULL) {
-        return false;
+    if (srcstring == NULL || strcmp(srcstring, "") == 0) {
+        return pcmk_rc_unknown_format;
     }
 
     seploc = strchr(srcstring, separator);
     if (!seploc) {
-        return false;
+        return pcmk_rc_ok;
     } else if (strlen(srcstring) == 1) {
         /* The source string contained only the separator. */
-        return false;
+        return pcmk_rc_unknown_format;
     } else if (seploc == srcstring && *(seploc + 1)) {
         /* Separator is the first character of the range, so this
          * range only has an end.
@@ -636,5 +636,5 @@ pcmk__split_range(const char *srcstring, char separator, char **start, char **en
         *end = strdup(seploc + 1);
     }
 
-    return true;
+    return pcmk_rc_ok;
 }

--- a/lib/common/tests/Makefile.am
+++ b/lib/common/tests/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = strings

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -1,0 +1,19 @@
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
+LDADD = $(top_builddir)/lib/common/libcrmcommon.la
+
+include $(top_srcdir)/mk/glib-tap.mk
+
+# Add each test program here.  Each test should be written as a little standalone
+# program using the glib unit testing functions.  See the documentation for more
+# information.
+#
+# https://developer.gnome.org/glib/unstable/glib-Testing.html
+test_programs = pcmk__split_range
+
+# If any extra data needs to be added to the source distribution, add it to the
+# following list.
+dist_test_data =
+
+# If any extra data needs to be used by tests but should not be added to the
+# source distribution, add it to the following list.
+test_data =

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -8,7 +8,7 @@ include $(top_srcdir)/mk/glib-tap.mk
 # information.
 #
 # https://developer.gnome.org/glib/unstable/glib-Testing.html
-test_programs = pcmk__split_range
+test_programs = pcmk__parse_ll_range
 
 # If any extra data needs to be added to the source distribution, add it to the
 # following list.

--- a/lib/common/tests/strings/pcmk__parse_ll_range.c
+++ b/lib/common/tests/strings/pcmk__parse_ll_range.c
@@ -6,15 +6,15 @@ static void
 empty_input_string(void) {
     long long start, end;
 
-    g_assert(pcmk__split_range(NULL, &start, &end) == pcmk_rc_unknown_format);
-    g_assert(pcmk__split_range("", &start, &end) == pcmk_rc_unknown_format);
+    g_assert(pcmk__parse_ll_range(NULL, &start, &end) == pcmk_rc_unknown_format);
+    g_assert(pcmk__parse_ll_range("", &start, &end) == pcmk_rc_unknown_format);
 }
 
 static void
 missing_separator(void) {
     long long start, end;
 
-    g_assert(pcmk__split_range("1234", &start, &end) == pcmk_rc_ok);
+    g_assert(pcmk__parse_ll_range("1234", &start, &end) == pcmk_rc_ok);
     g_assert_cmpint(start, ==, 1234);
     g_assert_cmpint(end, ==, 1234);
 }
@@ -23,7 +23,7 @@ static void
 only_separator(void) {
     long long start, end;
 
-    g_assert(pcmk__split_range("-", &start, &end) == pcmk_rc_unknown_format);
+    g_assert(pcmk__parse_ll_range("-", &start, &end) == pcmk_rc_unknown_format);
     g_assert_cmpint(start, ==, -1);
     g_assert_cmpint(end, ==, -1);
 }
@@ -32,7 +32,7 @@ static void
 no_range_end(void) {
     long long start, end;
 
-    g_assert(pcmk__split_range("2000-", &start, &end) == pcmk_rc_ok);
+    g_assert(pcmk__parse_ll_range("2000-", &start, &end) == pcmk_rc_ok);
     g_assert_cmpint(start, ==, 2000);
     g_assert_cmpint(end, ==, -1);
 }
@@ -41,7 +41,7 @@ static void
 no_range_start(void) {
     long long start, end;
 
-    g_assert(pcmk__split_range("-2020", &start, &end) == pcmk_rc_ok);
+    g_assert(pcmk__parse_ll_range("-2020", &start, &end) == pcmk_rc_ok);
     g_assert_cmpint(start, ==, -1);
     g_assert_cmpint(end, ==, 2020);
 }
@@ -50,7 +50,7 @@ static void
 range_start_and_end(void) {
     long long start, end;
 
-    g_assert(pcmk__split_range("2000-2020", &start, &end) == pcmk_rc_ok);
+    g_assert(pcmk__parse_ll_range("2000-2020", &start, &end) == pcmk_rc_ok);
     g_assert_cmpint(start, ==, 2000);
     g_assert_cmpint(end, ==, 2020);
 }

--- a/lib/common/tests/strings/pcmk__split_range.c
+++ b/lib/common/tests/strings/pcmk__split_range.c
@@ -4,68 +4,68 @@
 
 static void
 empty_input_string(void) {
-    char *start = NULL;
-    char *end = NULL;
+    long long start, end;
 
-    g_assert(pcmk__split_range(NULL, '-', &start, &end) == pcmk_rc_unknown_format);
-    g_assert(pcmk__split_range("", '-', &start, &end) == pcmk_rc_unknown_format);
+    g_assert(pcmk__split_range(NULL, &start, &end) == pcmk_rc_unknown_format);
+    g_assert(pcmk__split_range("", &start, &end) == pcmk_rc_unknown_format);
 }
 
 static void
 missing_separator(void) {
-    char *start = NULL;
-    char *end = NULL;
+    long long start, end;
 
-    g_assert(pcmk__split_range("1234", '-', &start, &end) == pcmk_rc_ok);
-    g_assert(start == NULL);
-    g_assert(end == NULL);
+    g_assert(pcmk__split_range("1234", &start, &end) == pcmk_rc_ok);
+    g_assert_cmpint(start, ==, 1234);
+    g_assert_cmpint(end, ==, 1234);
 }
 
 static void
 only_separator(void) {
-    char *start = NULL;
-    char *end = NULL;
+    long long start, end;
 
-    g_assert(pcmk__split_range("-", '-', &start, &end) == pcmk_rc_unknown_format);
-    g_assert(start == NULL);
-    g_assert(end == NULL);
+    g_assert(pcmk__split_range("-", &start, &end) == pcmk_rc_unknown_format);
+    g_assert_cmpint(start, ==, -1);
+    g_assert_cmpint(end, ==, -1);
 }
 
 static void
 no_range_end(void) {
-    char *start = NULL;
-    char *end = NULL;
+    long long start, end;
 
-    g_assert(pcmk__split_range("2000-", '-', &start, &end) == pcmk_rc_ok);
-    g_assert_cmpstr(start, ==, "2000");
-    g_assert(end == NULL);
-
-    free(start);
+    g_assert(pcmk__split_range("2000-", &start, &end) == pcmk_rc_ok);
+    g_assert_cmpint(start, ==, 2000);
+    g_assert_cmpint(end, ==, -1);
 }
 
 static void
 no_range_start(void) {
-    char *start = NULL;
-    char *end = NULL;
+    long long start, end;
 
-    g_assert(pcmk__split_range("-2020", '-', &start, &end) == pcmk_rc_ok);
-    g_assert(start == NULL);
-    g_assert_cmpstr(end, ==, "2020");
-
-    free(end);
+    g_assert(pcmk__split_range("-2020", &start, &end) == pcmk_rc_ok);
+    g_assert_cmpint(start, ==, -1);
+    g_assert_cmpint(end, ==, 2020);
 }
 
 static void
 range_start_and_end(void) {
-    char *start = NULL;
-    char *end = NULL;
+    long long start, end;
 
-    g_assert(pcmk__split_range("2000-2020", '-', &start, &end) == pcmk_rc_ok);
-    g_assert_cmpstr(start, ==, "2000");
-    g_assert_cmpstr(end, ==, "2020");
+    g_assert(pcmk__split_range("2000-2020", &start, &end) == pcmk_rc_ok);
+    g_assert_cmpint(start, ==, 2000);
+    g_assert_cmpint(end, ==, 2020);
+}
 
-    free(start);
-    free(end);
+static void
+garbage(void) {
+    long long start, end;
+
+    g_assert(pcmk__parse_ll_range("2000x-", &start, &end) == pcmk_rc_unknown_format);
+    g_assert_cmpint(start, ==, -1);
+    g_assert_cmpint(end, ==, -1);
+
+    g_assert(pcmk__parse_ll_range("-x2000", &start, &end) == pcmk_rc_unknown_format);
+    g_assert_cmpint(start, ==, -1);
+    g_assert_cmpint(end, ==, -1);
 }
 
 int main(int argc, char **argv) {
@@ -77,6 +77,8 @@ int main(int argc, char **argv) {
     g_test_add_func("/common/strings/range/no_end", no_range_end);
     g_test_add_func("/common/strings/range/no_start", no_range_start);
     g_test_add_func("/common/strings/range/start_and_end", range_start_and_end);
+
+    g_test_add_func("/common/strings/range/garbage", garbage);
 
     return g_test_run();
 }

--- a/lib/common/tests/strings/pcmk__split_range.c
+++ b/lib/common/tests/strings/pcmk__split_range.c
@@ -7,8 +7,8 @@ empty_input_string(void) {
     char *start = NULL;
     char *end = NULL;
 
-    g_assert(pcmk__split_range(NULL, '-', &start, &end) == false);
-    g_assert(pcmk__split_range("", '-', &start, &end) == false);
+    g_assert(pcmk__split_range(NULL, '-', &start, &end) == pcmk_rc_unknown_format);
+    g_assert(pcmk__split_range("", '-', &start, &end) == pcmk_rc_unknown_format);
 }
 
 static void
@@ -16,7 +16,7 @@ missing_separator(void) {
     char *start = NULL;
     char *end = NULL;
 
-    g_assert(pcmk__split_range("1234", '-', &start, &end) == false);
+    g_assert(pcmk__split_range("1234", '-', &start, &end) == pcmk_rc_ok);
     g_assert(start == NULL);
     g_assert(end == NULL);
 }
@@ -26,7 +26,7 @@ only_separator(void) {
     char *start = NULL;
     char *end = NULL;
 
-    g_assert(pcmk__split_range("-", '-', &start, &end) == false);
+    g_assert(pcmk__split_range("-", '-', &start, &end) == pcmk_rc_unknown_format);
     g_assert(start == NULL);
     g_assert(end == NULL);
 }
@@ -36,7 +36,7 @@ no_range_end(void) {
     char *start = NULL;
     char *end = NULL;
 
-    g_assert(pcmk__split_range("2000-", '-', &start, &end) == true);
+    g_assert(pcmk__split_range("2000-", '-', &start, &end) == pcmk_rc_ok);
     g_assert_cmpstr(start, ==, "2000");
     g_assert(end == NULL);
 
@@ -48,7 +48,7 @@ no_range_start(void) {
     char *start = NULL;
     char *end = NULL;
 
-    g_assert(pcmk__split_range("-2020", '-', &start, &end) == true);
+    g_assert(pcmk__split_range("-2020", '-', &start, &end) == pcmk_rc_ok);
     g_assert(start == NULL);
     g_assert_cmpstr(end, ==, "2020");
 
@@ -60,7 +60,7 @@ range_start_and_end(void) {
     char *start = NULL;
     char *end = NULL;
 
-    g_assert(pcmk__split_range("2000-2020", '-', &start, &end) == true);
+    g_assert(pcmk__split_range("2000-2020", '-', &start, &end) == pcmk_rc_ok);
     g_assert_cmpstr(start, ==, "2000");
     g_assert_cmpstr(end, ==, "2020");
 

--- a/lib/common/tests/strings/pcmk__split_range.c
+++ b/lib/common/tests/strings/pcmk__split_range.c
@@ -1,0 +1,58 @@
+#include <glib.h>
+
+#include <crm_internal.h>
+
+static void
+empty_input_string(void) {
+    char *start = NULL;
+    char *end = NULL;
+
+    g_assert(pcmk__split_range(NULL, '-', &start, &end) == false);
+    g_assert(pcmk__split_range("", '-', &start, &end) == false);
+}
+
+static void
+missing_separator(void) {
+    char *start = NULL;
+    char *end = NULL;
+
+    g_assert(pcmk__split_range("1234", '-', &start, &end) == false);
+    g_assert(start == NULL);
+    g_assert(end == NULL);
+}
+
+static void
+no_range_end(void) {
+    char *start = NULL;
+    char *end = NULL;
+
+    g_assert(pcmk__split_range("2000-", '-', &start, &end) == true);
+    g_assert_cmpstr(start, ==, "2000");
+    g_assert(end == NULL);
+
+    free(start);
+}
+
+static void
+range_start_and_end(void) {
+    char *start = NULL;
+    char *end = NULL;
+
+    g_assert(pcmk__split_range("2000-2020", '-', &start, &end) == true);
+    g_assert_cmpstr(start, ==, "2000");
+    g_assert_cmpstr(end, ==, "2020");
+
+    free(start);
+    free(end);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/common/strings/range/empty", empty_input_string);
+    g_test_add_func("/common/strings/range/no_sep", missing_separator);
+    g_test_add_func("/common/strings/range/no_end", no_range_end);
+    g_test_add_func("/common/strings/range/start_and_end", range_start_and_end);
+
+    return g_test_run();
+}

--- a/lib/common/tests/strings/pcmk__split_range.c
+++ b/lib/common/tests/strings/pcmk__split_range.c
@@ -22,6 +22,16 @@ missing_separator(void) {
 }
 
 static void
+only_separator(void) {
+    char *start = NULL;
+    char *end = NULL;
+
+    g_assert(pcmk__split_range("-", '-', &start, &end) == false);
+    g_assert(start == NULL);
+    g_assert(end == NULL);
+}
+
+static void
 no_range_end(void) {
     char *start = NULL;
     char *end = NULL;
@@ -31,6 +41,18 @@ no_range_end(void) {
     g_assert(end == NULL);
 
     free(start);
+}
+
+static void
+no_range_start(void) {
+    char *start = NULL;
+    char *end = NULL;
+
+    g_assert(pcmk__split_range("-2020", '-', &start, &end) == true);
+    g_assert(start == NULL);
+    g_assert_cmpstr(end, ==, "2020");
+
+    free(end);
 }
 
 static void
@@ -51,7 +73,9 @@ int main(int argc, char **argv) {
 
     g_test_add_func("/common/strings/range/empty", empty_input_string);
     g_test_add_func("/common/strings/range/no_sep", missing_separator);
+    g_test_add_func("/common/strings/range/only_sep", only_separator);
     g_test_add_func("/common/strings/range/no_end", no_range_end);
+    g_test_add_func("/common/strings/range/no_start", no_range_start);
     g_test_add_func("/common/strings/range/start_and_end", range_start_and_end);
 
     return g_test_run();

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -447,23 +447,29 @@ phase_of_the_moon(crm_time_t * now)
     value = crm_element_value(cron_spec, xml_field);			\
     if(value != NULL) {							\
 	gboolean pass = TRUE;						\
-	pcmk__split_range(value, '-', &value_low, &value_high);		\
-        if (value_low == NULL && value_high != NULL) {                  \
-            value_low = strdup("0");                                    \
-        } else if (value_low == NULL) {                                 \
-	    value_low = strdup(value);				        \
-	}								\
-	value_low_i = crm_parse_int(value_low, "0");			\
-	value_high_i = crm_parse_int(value_high, "-1");			\
-	if(value_high_i < 0) {						\
-	    if(value_low_i != time_field) {				\
-		pass = FALSE;						\
-	    }								\
-	} else if(value_low_i > time_field) {				\
-	    pass = FALSE;						\
-	} else if(value_high_i < time_field) {				\
-	    pass = FALSE;						\
-	}								\
+	gboolean rc = pcmk__split_range(value, '-', &value_low, &value_high); \
+        if (rc == false) {                                              \
+            value_low_i = crm_parse_int(value, NULL);                   \
+            if (value_low_i != time_field) {                            \
+                pass = FALSE;                                           \
+            }                                                           \
+        } else if (value_low == NULL && value_high != NULL) {           \
+            value_high_i = crm_parse_int(value_high, "-1");             \
+            if (time_field > value_high_i) {                            \
+                pass = FALSE;                                           \
+            }                                                           \
+        } else if (value_low != NULL && value_high == NULL) {           \
+            value_low_i = crm_parse_int(value_low, "0");                \
+            if (value_low_i > time_field) {                             \
+                pass = FALSE;                                           \
+            }                                                           \
+	} else {                                                        \
+            value_low_i = crm_parse_int(value_low, "0");                \
+            value_high_i = crm_parse_int(value_high, "-1");             \
+            if (value_low_i > time_field || value_high_i < time_field) {\
+                pass = FALSE;                                           \
+            }                                                           \
+        }                                                               \
 	free(value_low);						\
 	free(value_high);						\
 	if(pass == FALSE) {						\

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -443,34 +443,11 @@ phase_of_the_moon(crm_time_t * now)
     return ((((((diy + epact) * 6) + 11) % 177) / 22) & 7);
 }
 
-static gboolean
-decodeNVpair(const char *srcstring, char separator, char **name, char **value)
-{
-    const char *seploc = NULL;
-
-    CRM_ASSERT(name != NULL && value != NULL);
-    *name = NULL;
-    *value = NULL;
-
-    crm_trace("Attempting to decode: [%s]", srcstring);
-    if (srcstring != NULL) {
-        seploc = strchr(srcstring, separator);
-        if (seploc) {
-            *name = strndup(srcstring, seploc - srcstring);
-            if (*(seploc + 1)) {
-                *value = strdup(seploc + 1);
-            }
-            return TRUE;
-        }
-    }
-    return FALSE;
-}
-
 #define cron_check(xml_field, time_field)				\
     value = crm_element_value(cron_spec, xml_field);			\
     if(value != NULL) {							\
 	gboolean pass = TRUE;						\
-	decodeNVpair(value, '-', &value_low, &value_high);		\
+	pcmk__split_range(value, '-', &value_low, &value_high);		\
 	if(value_low == NULL) {						\
 	    value_low = strdup(value);				\
 	}								\

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -447,8 +447,10 @@ phase_of_the_moon(crm_time_t * now)
     value = crm_element_value(cron_spec, xml_field);			\
     if(value != NULL) {							\
 	gboolean pass = TRUE;						\
-	gboolean rc = pcmk__split_range(value, '-', &value_low, &value_high); \
-        if (rc == false) {                                              \
+	int rc = pcmk__split_range(value, '-', &value_low, &value_high);\
+        if (rc == pcmk_rc_unknown_format) {                             \
+            return FALSE;                                               \
+        } else if (value_low == NULL && value_high == NULL) {           \
             value_low_i = crm_parse_int(value, NULL);                   \
             if (value_low_i != time_field) {                            \
                 pass = FALSE;                                           \

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -447,33 +447,26 @@ phase_of_the_moon(crm_time_t * now)
     value = crm_element_value(cron_spec, xml_field);			\
     if(value != NULL) {							\
 	gboolean pass = TRUE;						\
-	int rc = pcmk__split_range(value, '-', &value_low, &value_high);\
+	int rc = pcmk__split_range(value, &value_low, &value_high);     \
         if (rc == pcmk_rc_unknown_format) {                             \
             return FALSE;                                               \
-        } else if (value_low == NULL && value_high == NULL) {           \
-            value_low_i = crm_parse_int(value, NULL);                   \
-            if (value_low_i != time_field) {                            \
+        } else if (value_low == value_high) {                           \
+            if (value_low != time_field) {                              \
                 pass = FALSE;                                           \
             }                                                           \
-        } else if (value_low == NULL && value_high != NULL) {           \
-            value_high_i = crm_parse_int(value_high, "-1");             \
-            if (time_field > value_high_i) {                            \
+        } else if (value_low == -1 && value_high != -1) {               \
+            if (time_field > value_high) {                              \
                 pass = FALSE;                                           \
             }                                                           \
-        } else if (value_low != NULL && value_high == NULL) {           \
-            value_low_i = crm_parse_int(value_low, "0");                \
-            if (value_low_i > time_field) {                             \
+        } else if (value_low != -1 && value_high == -1) {               \
+            if (value_low > time_field) {                               \
                 pass = FALSE;                                           \
             }                                                           \
 	} else {                                                        \
-            value_low_i = crm_parse_int(value_low, "0");                \
-            value_high_i = crm_parse_int(value_high, "-1");             \
-            if (value_low_i > time_field || value_high_i < time_field) {\
+            if (value_low > time_field || value_high < time_field) {    \
                 pass = FALSE;                                           \
             }                                                           \
         }                                                               \
-	free(value_low);						\
-	free(value_high);						\
 	if(pass == FALSE) {						\
 	    crm_debug("Condition '%s' in %s: failed", value, xml_field); \
 	    return pass;						\
@@ -485,11 +478,9 @@ gboolean
 pe_cron_range_satisfied(crm_time_t * now, xmlNode * cron_spec)
 {
     const char *value = NULL;
-    char *value_low = NULL;
-    char *value_high = NULL;
 
-    int value_low_i = 0;
-    int value_high_i = 0;
+    long long value_low = -1;
+    long long value_high = -1;
 
     uint32_t h, m, s, y, d, w;
 

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -448,8 +448,10 @@ phase_of_the_moon(crm_time_t * now)
     if(value != NULL) {							\
 	gboolean pass = TRUE;						\
 	pcmk__split_range(value, '-', &value_low, &value_high);		\
-	if(value_low == NULL) {						\
-	    value_low = strdup(value);				\
+        if (value_low == NULL && value_high != NULL) {                  \
+            value_low = strdup("0");                                    \
+        } else if (value_low == NULL) {                                 \
+	    value_low = strdup(value);				        \
 	}								\
 	value_low_i = crm_parse_int(value_low, "0");			\
 	value_high_i = crm_parse_int(value_high, "-1");			\

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -447,7 +447,7 @@ phase_of_the_moon(crm_time_t * now)
     value = crm_element_value(cron_spec, xml_field);			\
     if(value != NULL) {							\
 	gboolean pass = TRUE;						\
-	int rc = pcmk__split_range(value, &value_low, &value_high);     \
+	int rc = pcmk__parse_ll_range(value, &value_low, &value_high);  \
         if (rc == pcmk_rc_unknown_format) {                             \
             return FALSE;                                               \
         } else if (value_low == value_high) {                           \

--- a/lib/pengine/tests/rules/pe_cron_range_satisfied.c
+++ b/lib/pengine/tests/rules/pe_cron_range_satisfied.c
@@ -54,17 +54,13 @@ time_after_year_range(void) {
 }
 
 static void
-range_without_start_year_fails(void) {
-    run_one_test("2010-01-01", "<date_spec id='spec' years='-2020'/>", FALSE);
-}
-
-static void
-range_without_end_year_fails(void) {
-    run_one_test("2010-01-01", "<date_spec id='spec' years='2000-'/>", FALSE);
+range_without_start_year_passes(void) {
+    run_one_test("2010-01-01", "<date_spec id='spec' years='-2020'/>", TRUE);
 }
 
 static void
 range_without_end_year_passes(void) {
+    run_one_test("2010-01-01", "<date_spec id='spec' years='2000-'/>", TRUE);
     run_one_test("2000-10-01", "<date_spec id='spec' years='2000-'/>", TRUE);
 }
 
@@ -112,8 +108,7 @@ int main(int argc, char **argv) {
     g_test_add_func("/pengine/rules/cron_range/range/time_satisfies_year", time_satisfies_year_range);
     g_test_add_func("/pengine/rules/cron_range/range/time_before_year", time_before_year_range);
     g_test_add_func("/pengine/rules/cron_range/range/time_after_year", time_after_year_range);
-    g_test_add_func("/pengine/rules/cron_range/range/no_start_year_fails", range_without_start_year_fails);
-    g_test_add_func("/pengine/rules/cron_range/range/no_end_year_fails", range_without_end_year_fails);
+    g_test_add_func("/pengine/rules/cron_range/range/no_start_year_passes", range_without_start_year_passes);
     g_test_add_func("/pengine/rules/cron_range/range/no_end_year_passes", range_without_end_year_passes);
 
     g_test_add_func("/pengine/rules/cron_range/yeardays/satisfies", yeardays_satisfies);


### PR DESCRIPTION
This is in support of #1982.  If it would help, I could make a bunch of other improvements here like skipping whitespace, returning ints instead of chars, and returning errors if the bounds aren't valid ints.  This function is only used in one spot at the moment but maybe it'll prove more broadly useful once it's in a library.