### PR TITLE
Fix: tools: Properly close ncurses output in crm_mon.

### DIFF
--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -72,6 +72,9 @@ curses_init(pcmk__output_t *out) {
 
 static void
 curses_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_dest) {
+    echo();
+    nocbreak();
+    endwin();
 }
 
 static void


### PR DESCRIPTION
When clean_up_connections is called at the end of crm_mon, one of the
things it does is call mon_cib_connection_destroy.  This calls out->err.
However, this happens after curses has been shut down.  The result is
the terminal doesn't work as expected after crm_mon quits.

Instead, move all the curses shutdown code into curses_finish.  This
function gets called almost as the very last thing, hopefully after any
other output could possibly take place.

I did a little bit of reorganization around how out->finish is called at
the end of crm_mon too, just to make everything happen in one place.