### PR TITLE
Add messages for crm_mon's cluster summary

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -129,6 +129,8 @@ int pe__cluster_options_xml(pcmk__output_t *out, va_list args);
 int pe__cluster_stack_html(pcmk__output_t *out, va_list args);
 int pe__cluster_stack_text(pcmk__output_t *out, va_list args);
 int pe__cluster_stack_xml(pcmk__output_t *out, va_list args);
+int pe__cluster_summary(pcmk__output_t *out, va_list args);
+int pe__cluster_summary_html(pcmk__output_t *out, va_list args);
 int pe__cluster_times_html(pcmk__output_t *out, va_list args);
 int pe__cluster_times_xml(pcmk__output_t *out, va_list args);
 int pe__cluster_times_text(pcmk__output_t *out, va_list args);

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -57,6 +57,14 @@ failed_action_string(xmlNodePtr xml_op) {
     }
 }
 
+static const char *
+get_cluster_stack(pe_working_set_t *data_set)
+{
+    xmlNode *stack = get_xpath_object("//nvpair[@name='cluster-infrastructure']",
+                                      data_set->input, LOG_DEBUG);
+    return stack? crm_element_value(stack, XML_NVPAIR_ATTR_VALUE) : "unknown";
+}
+
 static char *
 last_changed_string(const char *last_written, const char *user,
                     const char *client, const char *origin) {

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -12,6 +12,13 @@
 #include <crm/msg_xml.h>
 #include <crm/pengine/internal.h>
 
+#define SUMMARY_HEADER(printed, out) do { \
+        if (printed == FALSE) { \
+            out->begin_list(out, NULL, NULL, "Cluster Summary"); \
+            printed = TRUE; \
+        } \
+    } while (0)
+
 static char *
 failed_action_string(xmlNodePtr xml_op) {
     const char *op_key = crm_element_value(xml_op, XML_LRM_ATTR_TASK_KEY);
@@ -195,6 +202,146 @@ resource_history_string(resource_t *rsc, const char *rsc_id, gboolean all,
     }
 
     return buf;
+}
+
+int
+pe__cluster_summary(pcmk__output_t *out, va_list args) {
+    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    gboolean print_clone_detail = va_arg(args, gboolean);
+    gboolean show_stack = va_arg(args, gboolean);
+    gboolean show_dc = va_arg(args, gboolean);
+    gboolean show_times = va_arg(args, gboolean);
+    gboolean show_counts = va_arg(args, gboolean);
+    gboolean show_options = va_arg(args, gboolean);
+
+    const char *stack_s = get_cluster_stack(data_set);
+    gboolean header_printed = FALSE;
+
+    if (show_stack) {
+        SUMMARY_HEADER(header_printed, out);
+        out->message(out, "cluster-stack", stack_s);
+    }
+
+    /* Always print DC if none, even if not requested */
+    if (data_set->dc_node == NULL || show_dc) {
+        xmlNode *dc_version = get_xpath_object("//nvpair[@name='dc-version']",
+                                               data_set->input, LOG_DEBUG);
+        const char *dc_version_s = dc_version?
+                                   crm_element_value(dc_version, XML_NVPAIR_ATTR_VALUE)
+                                   : NULL;
+        const char *quorum = crm_element_value(data_set->input, XML_ATTR_HAVE_QUORUM);
+        char *dc_name = data_set->dc_node ? pe__node_display_name(data_set->dc_node, print_clone_detail) : NULL;
+
+        SUMMARY_HEADER(header_printed, out);
+        out->message(out, "cluster-dc", data_set->dc_node, quorum, dc_version_s, dc_name);
+        free(dc_name);
+    }
+
+    if (show_times) {
+        const char *last_written = crm_element_value(data_set->input, XML_CIB_ATTR_WRITTEN);
+        const char *user = crm_element_value(data_set->input, XML_ATTR_UPDATE_USER);
+        const char *client = crm_element_value(data_set->input, XML_ATTR_UPDATE_CLIENT);
+        const char *origin = crm_element_value(data_set->input, XML_ATTR_UPDATE_ORIG);
+
+        SUMMARY_HEADER(header_printed, out);
+        out->message(out, "cluster-times", last_written, user, client, origin);
+    }
+
+    if (show_counts) {
+        SUMMARY_HEADER(header_printed, out);
+        out->message(out, "cluster-counts", g_list_length(data_set->nodes),
+                     data_set->ninstances, data_set->disabled_resources,
+                     data_set->blocked_resources);
+    }
+
+    if (show_options) {
+        SUMMARY_HEADER(header_printed, out);
+        out->message(out, "cluster-options", data_set);
+    }
+
+    if (header_printed) {
+        out->end_list(out);
+    }
+
+    if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
+        out->message(out, "maint-mode");
+    }
+
+    return 0;
+}
+
+int
+pe__cluster_summary_html(pcmk__output_t *out, va_list args) {
+    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    gboolean print_clone_detail = va_arg(args, gboolean);
+    gboolean show_stack = va_arg(args, gboolean);
+    gboolean show_dc = va_arg(args, gboolean);
+    gboolean show_times = va_arg(args, gboolean);
+    gboolean show_counts = va_arg(args, gboolean);
+    gboolean show_options = va_arg(args, gboolean);
+
+    const char *stack_s = get_cluster_stack(data_set);
+    gboolean header_printed = FALSE;
+
+    if (show_stack) {
+        SUMMARY_HEADER(header_printed, out);
+        out->message(out, "cluster-stack", stack_s);
+    }
+
+    /* Always print DC if none, even if not requested */
+    if (data_set->dc_node == NULL || show_dc) {
+        xmlNode *dc_version = get_xpath_object("//nvpair[@name='dc-version']",
+                                               data_set->input, LOG_DEBUG);
+        const char *dc_version_s = dc_version?
+                                   crm_element_value(dc_version, XML_NVPAIR_ATTR_VALUE)
+                                   : NULL;
+        const char *quorum = crm_element_value(data_set->input, XML_ATTR_HAVE_QUORUM);
+        char *dc_name = data_set->dc_node ? pe__node_display_name(data_set->dc_node, print_clone_detail) : NULL;
+
+        SUMMARY_HEADER(header_printed, out);
+        out->message(out, "cluster-dc", data_set->dc_node, quorum, dc_version_s, dc_name);
+        free(dc_name);
+    }
+
+    if (show_times) {
+        const char *last_written = crm_element_value(data_set->input, XML_CIB_ATTR_WRITTEN);
+        const char *user = crm_element_value(data_set->input, XML_ATTR_UPDATE_USER);
+        const char *client = crm_element_value(data_set->input, XML_ATTR_UPDATE_CLIENT);
+        const char *origin = crm_element_value(data_set->input, XML_ATTR_UPDATE_ORIG);
+
+        SUMMARY_HEADER(header_printed, out);
+        out->message(out, "cluster-times", last_written, user, client, origin);
+    }
+
+    if (show_counts) {
+        SUMMARY_HEADER(header_printed, out);
+        out->message(out, "cluster-counts", g_list_length(data_set->nodes),
+                     data_set->ninstances, data_set->disabled_resources,
+                     data_set->blocked_resources);
+    }
+
+    if (show_options) {
+        /* Kind of a hack - close the list we may have opened earlier in this
+         * function so we can put all the options into their own list.  We
+         * only want to do this on HTML output, though.
+         */
+        if (header_printed == TRUE) {
+            out->end_list(out);
+        }
+
+        out->begin_list(out, NULL, NULL, "Config Options");
+        out->message(out, "cluster-options", data_set);
+    }
+
+    if (header_printed) {
+        out->end_list(out);
+    }
+
+    if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
+        out->message(out, "maint-mode");
+    }
+
+    return 0;
 }
 
 char *
@@ -1292,6 +1439,10 @@ static pcmk__message_entry_t fmt_functions[] = {
     { "cluster-options", "log", pe__cluster_options_log },
     { "cluster-options", "text", pe__cluster_options_text },
     { "cluster-options", "xml", pe__cluster_options_xml },
+    { "cluster-summary", "html", pe__cluster_summary_html },
+    { "cluster-summary", "log", pe__cluster_summary },
+    { "cluster-summary", "text", pe__cluster_summary },
+    { "cluster-summary", "xml", pe__cluster_summary },
     { "cluster-stack", "html", pe__cluster_stack_html },
     { "cluster-stack", "log", pe__cluster_stack_text },
     { "cluster-stack", "text", pe__cluster_stack_text },

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1943,8 +1943,8 @@ mon_refresh_display(gpointer user_data)
     switch (output_format) {
         case mon_output_html:
         case mon_output_cgi:
-            if (print_html_status(out, output_format, mon_data_set, stonith_history,
-                                  options.mon_ops, show, options.neg_location_prefix) != 0) {
+            if (print_html_status(out, mon_data_set, stonith_history, options.mon_ops,
+                                  show, options.neg_location_prefix) != 0) {
                 out->err(out, "Critical: Unable to output html file");
                 clean_up(CRM_EX_CANTCREAT);
                 return FALSE;
@@ -1953,8 +1953,8 @@ mon_refresh_display(gpointer user_data)
 
         case mon_output_legacy_xml:
         case mon_output_xml:
-            print_xml_status(out, output_format, mon_data_set, stonith_history,
-                             options.mon_ops, show, options.neg_location_prefix);
+            print_xml_status(out, mon_data_set, stonith_history, options.mon_ops,
+                             show, options.neg_location_prefix);
             break;
 
         case mon_output_monitor:
@@ -1971,15 +1971,15 @@ mon_refresh_display(gpointer user_data)
              */
 #if CURSES_ENABLED
             blank_screen();
-            print_status(out, output_format, mon_data_set, stonith_history, options.mon_ops,
-                         show, options.neg_location_prefix);
+            print_status(out, mon_data_set, stonith_history, options.mon_ops, show,
+                         options.neg_location_prefix);
             refresh();
             break;
 #endif
 
         case mon_output_plain:
-            print_status(out, output_format, mon_data_set, stonith_history, options.mon_ops,
-                         show, options.neg_location_prefix);
+            print_status(out, mon_data_set, stonith_history, options.mon_ops, show,
+                         options.neg_location_prefix);
             break;
 
         case mon_output_unset:

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -108,7 +108,6 @@ int print_html_status(pcmk__output_t *out, mon_output_format_t output_format,
 GList *append_attr_list(GList *attr_list, char *name);
 void blank_screen(void);
 void crm_mon_get_parameters(resource_t *rsc, pe_working_set_t *data_set);
-const char *get_cluster_stack(pe_working_set_t *data_set);
 unsigned int get_resource_display_options(unsigned int mon_ops);
 
 void crm_mon_register_messages(pcmk__output_t *out);

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -95,15 +95,15 @@ typedef enum mon_output_format_e {
 
 #define mon_op_default              (mon_op_print_pending | mon_op_fence_history | mon_op_fence_connect)
 
-void print_status(pcmk__output_t *out, mon_output_format_t output_format,
-                  pe_working_set_t *data_set, stonith_history_t *stonith_history,
-                  unsigned int mon_ops, unsigned int show, char *prefix);
-void print_xml_status(pcmk__output_t *out, mon_output_format_t output_format,
-                      pe_working_set_t *data_set, stonith_history_t *stonith_history,
-                      unsigned int mon_ops, unsigned int show, char *prefix);
-int print_html_status(pcmk__output_t *out, mon_output_format_t output_format,
-                      pe_working_set_t *data_set, stonith_history_t *stonith_history,
-                      unsigned int mon_ops, unsigned int show, char *prefix);
+void print_status(pcmk__output_t *out, pe_working_set_t *data_set,
+                  stonith_history_t *stonith_history, unsigned int mon_ops,
+                  unsigned int show, char *prefix);
+void print_xml_status(pcmk__output_t *out, pe_working_set_t *data_set,
+                      stonith_history_t *stonith_history, unsigned int mon_ops,
+                      unsigned int show, char *prefix);
+int print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
+                      stonith_history_t *stonith_history, unsigned int mon_ops,
+                      unsigned int show, char *prefix);
 
 GList *append_attr_list(GList *attr_list, char *name);
 void blank_screen(void);

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -346,6 +346,7 @@ static pcmk__message_entry_t fmt_functions[] = {
     { "cluster-dc", "console", pe__cluster_dc_text },
     { "cluster-options", "console", pe__cluster_options_text },
     { "cluster-stack", "console", pe__cluster_stack_text },
+    { "cluster-summary", "console", pe__cluster_summary },
     { "cluster-times", "console", pe__cluster_times_text },
     { "failed-action", "console", pe__failed_action_text },
     { "group", "console", pe__group_text },

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -48,7 +48,6 @@ static void print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set,
                                     unsigned int mon_ops, const char *prefix);
 static void print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set,
                                   unsigned int mon_ops);
-static void print_cluster_times(pcmk__output_t *out, pe_working_set_t *data_set);
 static void print_cluster_dc(pcmk__output_t *out, pe_working_set_t *data_set,
                              unsigned int mon_ops);
 static gboolean print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
@@ -637,24 +636,6 @@ print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set, unsigned 
 
 /*!
  * \internal
- * \brief Print times the display was last updated and CIB last changed
- *
- * \param[in] out      The output functions structure.
- * \param[in] data_set Cluster state to display.
- */
-static void
-print_cluster_times(pcmk__output_t *out, pe_working_set_t *data_set)
-{
-    const char *last_written = crm_element_value(data_set->input, XML_CIB_ATTR_WRITTEN);
-    const char *user = crm_element_value(data_set->input, XML_ATTR_UPDATE_USER);
-    const char *client = crm_element_value(data_set->input, XML_ATTR_UPDATE_CLIENT);
-    const char *origin = crm_element_value(data_set->input, XML_ATTR_UPDATE_ORIG);
-
-    out->message(out, "cluster-times", last_written, user, client, origin);
-}
-
-/*!
- * \internal
  * \brief Print current DC and its version
  *
  * \param[in] out      The output functions structure.
@@ -711,11 +692,17 @@ print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
     }
 
     if (is_set(show, mon_show_times)) {
+        const char *last_written = crm_element_value(data_set->input, XML_CIB_ATTR_WRITTEN);
+        const char *user = crm_element_value(data_set->input, XML_ATTR_UPDATE_USER);
+        const char *client = crm_element_value(data_set->input, XML_ATTR_UPDATE_CLIENT);
+        const char *origin = crm_element_value(data_set->input, XML_ATTR_UPDATE_ORIG);
+
         if (header_printed == FALSE) {
             out->begin_list(out, NULL, NULL, "Cluster Summary");
             header_printed = TRUE;
         }
-        print_cluster_times(out, data_set);
+
+        out->message(out, "cluster-times", last_written, user, client, origin);
     }
 
     if (is_set(show, mon_show_counts)) {

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -48,9 +48,6 @@ static void print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set,
                                     unsigned int mon_ops, const char *prefix);
 static void print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set,
                                   unsigned int mon_ops);
-static gboolean print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
-                                      unsigned int mon_ops, unsigned int show,
-                                      mon_output_format_t fmt);
 static void print_failed_actions(pcmk__output_t *out, pe_working_set_t *data_set);
 static void print_failed_stonith_actions(pcmk__output_t *out, stonith_history_t *history,
                                          unsigned int mon_ops);
@@ -634,103 +631,6 @@ print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set, unsigned 
 
 /*!
  * \internal
- * \brief Print a summary of cluster-wide information
- *
- * \param[in] out      The output functions structure.
- * \param[in] data_set Cluster state to display.
- * \param[in] mon_ops  Bitmask of mon_op_*.
- * \param[in] show     Bitmask of mon_show_*.
- */
-static gboolean
-print_cluster_summary(pcmk__output_t *out, pe_working_set_t *data_set,
-                      unsigned int mon_ops, unsigned int show, mon_output_format_t fmt)
-{
-    const char *stack_s = get_cluster_stack(data_set);
-    gboolean header_printed = FALSE;
-
-    if (is_set(show, mon_show_stack)) {
-        if (header_printed == FALSE) {
-            out->begin_list(out, NULL, NULL, "Cluster Summary");
-            header_printed = TRUE;
-        }
-        out->message(out, "cluster-stack", stack_s);
-    }
-
-    /* Always print DC if none, even if not requested */
-    if ((data_set->dc_node == NULL) || is_set(show, mon_show_dc)) {
-        xmlNode *dc_version = get_xpath_object("//nvpair[@name='dc-version']",
-                                               data_set->input, LOG_DEBUG);
-        const char *dc_version_s = dc_version?
-                                   crm_element_value(dc_version, XML_NVPAIR_ATTR_VALUE)
-                                   : NULL;
-        const char *quorum = crm_element_value(data_set->input, XML_ATTR_HAVE_QUORUM);
-        char *dc_name = data_set->dc_node ? pe__node_display_name(data_set->dc_node, is_set(mon_ops, mon_op_print_clone_detail)) : NULL;
-
-        if (header_printed == FALSE) {
-            out->begin_list(out, NULL, NULL, "Cluster Summary");
-            header_printed = TRUE;
-        }
-
-        out->message(out, "cluster-dc", data_set->dc_node, quorum, dc_version_s, dc_name);
-        free(dc_name);
-    }
-
-    if (is_set(show, mon_show_times)) {
-        const char *last_written = crm_element_value(data_set->input, XML_CIB_ATTR_WRITTEN);
-        const char *user = crm_element_value(data_set->input, XML_ATTR_UPDATE_USER);
-        const char *client = crm_element_value(data_set->input, XML_ATTR_UPDATE_CLIENT);
-        const char *origin = crm_element_value(data_set->input, XML_ATTR_UPDATE_ORIG);
-
-        if (header_printed == FALSE) {
-            out->begin_list(out, NULL, NULL, "Cluster Summary");
-            header_printed = TRUE;
-        }
-
-        out->message(out, "cluster-times", last_written, user, client, origin);
-    }
-
-    if (is_set(show, mon_show_counts)) {
-        if (header_printed == FALSE) {
-            out->begin_list(out, NULL, NULL, "Cluster Summary");
-            header_printed = TRUE;
-        }
-        out->message(out, "cluster-counts", g_list_length(data_set->nodes),
-                     data_set->ninstances, data_set->disabled_resources,
-                     data_set->blocked_resources);
-    }
-
-    if (is_set(show, mon_show_options)) {
-        if (fmt == mon_output_html || fmt == mon_output_cgi) {
-            /* Kind of a hack - close the list we may have opened earlier in this
-             * function so we can put all the options into their own list.  We
-             * only want to do this on HTML output, though.
-             */
-            if (header_printed == TRUE) {
-                out->end_list(out);
-            }
-
-            out->begin_list(out, NULL, NULL, "Config Options");
-        } else if (header_printed == FALSE) {
-            out->begin_list(out, NULL, NULL, "Cluster Summary");
-            header_printed = TRUE;
-        }
-
-        out->message(out, "cluster-options", data_set);
-    }
-
-    if (header_printed) {
-        out->end_list(out);
-    }
-
-    if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
-        out->message(out, "maint-mode");
-    }
-
-    return header_printed;
-}
-
-/*!
- * \internal
  * \brief Print a section for failed actions
  *
  * \param[in] out      The output functions structure.
@@ -937,7 +837,6 @@ print_stonith_history_full(pcmk__output_t *out, stonith_history_t *history, unsi
  * \brief Top-level printing function for text/curses output.
  *
  * \param[in] out             The output functions structure.
- * \param[in] output_format   Is this text or curses output?
  * \param[in] data_set        Cluster state to display.
  * \param[in] stonith_history List of stonith actions.
  * \param[in] mon_ops         Bitmask of mon_op_*.
@@ -945,13 +844,12 @@ print_stonith_history_full(pcmk__output_t *out, stonith_history_t *history, unsi
  * \param[in] prefix          ID prefix to filter results by.
  */
 void
-print_status(pcmk__output_t *out, mon_output_format_t output_format,
-             pe_working_set_t *data_set, stonith_history_t *stonith_history,
-             unsigned int mon_ops, unsigned int show, char *prefix)
+print_status(pcmk__output_t *out, pe_working_set_t *data_set,
+             stonith_history_t *stonith_history, unsigned int mon_ops,
+             unsigned int show, char *prefix)
 {
     GListPtr gIter = NULL;
     unsigned int print_opts = get_resource_display_options(mon_ops);
-    gboolean printed = FALSE;
 
     /* space-separated lists of node names */
     char *online_nodes = NULL;
@@ -960,13 +858,25 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
     char *offline_nodes = NULL;
     char *offline_remote_nodes = NULL;
 
-    printed = print_cluster_summary(out, data_set, mon_ops, show, output_format);
+    gboolean show_stack = is_set(show, mon_show_stack);
+    gboolean show_dc = is_set(show, mon_show_dc);
+    gboolean show_times = is_set(show, mon_show_times);
+    gboolean show_counts = is_set(show, mon_show_counts);
+    gboolean show_options = is_set(show, mon_show_options);
+
+    out->message(out, "cluster-summary", data_set,
+                 is_set(mon_ops, mon_op_print_clone_detail),
+                 show_stack, show_dc, show_times, show_counts, show_options);
 
     /* Gather node information (and print if in bad state or grouping by node) */
     if (is_set(show, mon_show_nodes)) {
-        if (printed) {
+        /* If any of these conditions are met, the cluster-summary message will
+         * have printed out something.  In that case, we need to leave a blank
+         * line between the summary and the nodes.
+         */
+        if (show_stack || data_set->dc_node == NULL || show_dc || show_times ||
+            show_counts || show_options) {
             out->info(out, "%s", "");
-            printed = FALSE;
         }
 
         out->begin_list(out, NULL, NULL, "Node List");
@@ -1135,14 +1045,20 @@ print_status(pcmk__output_t *out, mon_output_format_t output_format,
  * \param[in] prefix          ID prefix to filter results by.
  */
 void
-print_xml_status(pcmk__output_t *out, mon_output_format_t output_format,
-                 pe_working_set_t *data_set, stonith_history_t *stonith_history,
-                 unsigned int mon_ops, unsigned int show, char *prefix)
+print_xml_status(pcmk__output_t *out, pe_working_set_t *data_set,
+                 stonith_history_t *stonith_history, unsigned int mon_ops,
+                 unsigned int show, char *prefix)
 {
     GListPtr gIter = NULL;
     unsigned int print_opts = get_resource_display_options(mon_ops);
 
-    print_cluster_summary(out, data_set, mon_ops, show, output_format);
+    out->message(out, "cluster-summary", data_set,
+                 is_set(mon_ops, mon_op_print_clone_detail),
+                 is_set(show, mon_show_stack),
+                 is_set(show, mon_show_dc),
+                 is_set(show, mon_show_times),
+                 is_set(show, mon_show_counts),
+                 is_set(show, mon_show_options));
 
     /*** NODES ***/
     if (is_set(show, mon_show_nodes)) {
@@ -1199,7 +1115,6 @@ print_xml_status(pcmk__output_t *out, mon_output_format_t output_format,
  * \brief Top-level printing function for HTML output.
  *
  * \param[in] out             The output functions structure.
- * \param[in] output_format   Is this HTML or CGI output?
  * \param[in] data_set        Cluster state to display.
  * \param[in] stonith_history List of stonith actions.
  * \param[in] mon_ops         Bitmask of mon_op_*.
@@ -1207,14 +1122,20 @@ print_xml_status(pcmk__output_t *out, mon_output_format_t output_format,
  * \param[in] prefix          ID prefix to filter results by.
  */
 int
-print_html_status(pcmk__output_t *out, mon_output_format_t output_format,
-                  pe_working_set_t *data_set, stonith_history_t *stonith_history,
-                  unsigned int mon_ops, unsigned int show, char *prefix)
+print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
+                  stonith_history_t *stonith_history, unsigned int mon_ops,
+                  unsigned int show, char *prefix)
 {
     GListPtr gIter = NULL;
     unsigned int print_opts = get_resource_display_options(mon_ops);
 
-    print_cluster_summary(out, data_set, mon_ops, show, output_format);
+    out->message(out, "cluster-summary", data_set,
+                 is_set(mon_ops, mon_op_print_clone_detail),
+                 is_set(show, mon_show_stack),
+                 is_set(show, mon_show_dc),
+                 is_set(show, mon_show_times),
+                 is_set(show, mon_show_counts),
+                 is_set(show, mon_show_options));
 
     /*** NODE LIST ***/
     if (is_set(show, mon_show_nodes)) {

--- a/tools/crm_mon_runtime.c
+++ b/tools/crm_mon_runtime.c
@@ -81,22 +81,6 @@ crm_mon_get_parameters(resource_t *rsc, pe_working_set_t * data_set)
 
 /*!
  * \internal
- * \brief Get the name of the stack in use (or "unknown" if not available)
- *
- * \param[in] data_set   Working set of CIB state
- *
- * \return String representing stack name
- */
-const char *
-get_cluster_stack(pe_working_set_t *data_set)
-{
-    xmlNode *stack = get_xpath_object("//nvpair[@name='cluster-infrastructure']",
-                                      data_set->input, LOG_DEBUG);
-    return stack? crm_element_value(stack, XML_NVPAIR_ATTR_VALUE) : "unknown";
-}
-
-/*!
- * \internal
  * \brief Return resource display options corresponding to command-line choices
  *
  * \return Bitmask of pe_print_options suitable for resource print functions


### PR DESCRIPTION
This adds new formatted output messages that do all the cluster summary stuff, which largely consists of calling lower level formatted output messages.  My big interest in doing this PR was getting rid of the output_format parameter in tools/crm_mon_print.c so adding the history_rc parameter in the other PR wouldn't be quite so bad.