### PR TITLE
High: tools: Add clear cib connection pointer.

### DIFF
--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -45,6 +45,7 @@ bye(crm_exit_t exit_code)
     if (cib_conn != NULL) {
         cib_conn->cmds->signoff(cib_conn);
         cib_delete(cib_conn);
+        cib_conn = NULL;
     }
     if (controld_api != NULL) {
         pcmk_free_controld_api(controld_api);


### PR DESCRIPTION
Hi All,

NULL set of cib connection pointer of bye () process added to master is missing.
For this reason, running cleanup will cause a segmentation fault.

```
[root@rh80-test01 tools]# crm_mon -1 -Af
Cluster Summary:
  * Stack: corosync
  * Current DC: rh80-test01 (version 2.0.3-78db2071e) - partition WITHOUT quorum
  * Last updated: Tue Mar 10 10:26:41 2020
  * Last change:  Tue Mar 10 10:16:54 2020 by hacluster via crmd on rh80-test01
  * 2 nodes configured
  * 12 resource instances configured

Node List:
  * Online: [ rh80-test01 ]
  * OFFLINE: [ rh80-test02 ]

Active Resources:
  * prmDummy    (ocf::heartbeat:Dummy): Started rh80-test01
  * Clone Set: prmPing-clone [prmPing]:
    * Started: [ rh80-test01 ]
  * Resource Group: grpTest:
    * prmDummy1 (ocf::heartbeat:Dummy): Started rh80-test01
    * prmDummy2 (ocf::heartbeat:Dummy): Started rh80-test01
    * prmDummy3 (ocf::heartbeat:Dummy): Started rh80-test01
    * prmDummy4 (ocf::heartbeat:Dummy): Started rh80-test01
    * prmDummy5 (ocf::heartbeat:Dummy): Started rh80-test01
    * prmDummy6 (ocf::heartbeat:Dummy): Started rh80-test01
    * prmDummy7 (ocf::heartbeat:Dummy): Started rh80-test01
    * prmDummy8 (ocf::heartbeat:Dummy): Started rh80-test01
    * prmDummy9 (ocf::heartbeat:Dummy): Started rh80-test01

Node Attributes:
  * Node: rh80-test01:
    * default_ping_set                  : 100       

Migration Summary:


[root@rh80-test01 tools]# crm_resource -C -N rh80-test01
Cleaned up all resources on rh80-test01
double free or corruption (out)
Aborted (core dumped)
[root@rh80-test01 tools]# crm_resource -C -N rh80-test01 -f
Cleaned up all resources on rh80-test01
Segmentation fault (core dumped)
[root@rh80-test01 tools]# crm_resource -C -r prmDummy6 -N rh80-test01
Cleaned up prmDummy1 on rh80-test01
Cleaned up prmDummy2 on rh80-test01
Cleaned up prmDummy3 on rh80-test01
Cleaned up prmDummy4 on rh80-test01
Cleaned up prmDummy5 on rh80-test01
Cleaned up prmDummy6 on rh80-test01
Cleaned up prmDummy7 on rh80-test01
Cleaned up prmDummy8 on rh80-test01
Cleaned up prmDummy9 on rh80-test01
double free or corruption (out)
Aborted (core dumped)
[root@rh80-test01 tools]# crm_resource -C -r prmDummy6 -N rh80-test01 -f
Cleaned up prmDummy6 on rh80-test01
Segmentation fault (core dumped)
```

Best Regards,
Hideo Yamauchi.