### PR TITLE
Low: crm: Fix argument order in declarations

### DIFF
--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -93,7 +93,7 @@ int pcmk__lock_pidfile(const char *filename, const char *name);
 char *pcmk__op_key(const char *rsc_id, const char *op_type, guint interval_ms);
 char *generate_notify_key(const char *rsc_id, const char *notify_type,
                           const char *op_type);
-char *generate_transition_key(int action, int transition_id, int target_rc,
+char *generate_transition_key(int transition_id, int action_id, int target_rc,
                               const char *node);
 void filter_action_parameters(xmlNode *param_set, const char *version);
 

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -122,8 +122,8 @@ char *score2char_stack(int score, char *buf, size_t len);
 /* public operation functions (from operations.c) */
 gboolean parse_op_key(const char *key, char **rsc_id, char **op_type,
                       guint *interval_ms);
-gboolean decode_transition_key(const char *key, char **uuid, int *action,
-                               int *transition_id, int *target_rc);
+gboolean decode_transition_key(const char *key, char **uuid, int *transition_id,
+                               int *action_id, int *target_rc);
 gboolean decode_transition_magic(const char *magic, char **uuid,
                                  int *transition_id, int *action_id,
                                  int *op_status, int *op_rc, int *target_rc);


### PR DESCRIPTION
The argument orders of definition and declaration for decode_transition_key() and generate_transition_key()  do not match.
This fixes the order in the declarations, the order in the definitions is correct.
Found with the help of Cppcheck.