### PR TITLE
Convert formatted output to use new pacemaker return codes

### DIFF
--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -303,10 +303,10 @@ struct pcmk__output_s {
      *                           previous call to register_message.
      * \param[in] ...            Arguments to be passed to the registered function.
      *
-     * \return 0 if a function was registered for the message, that function was
-     *         called, and returned successfully.  A negative value is returned if
-     *         no function was registered.  A positive value is returned if the
-     *         function was called but encountered an error.
+     * \return A standard Pacemaker return code.  Generally: 0 if a function was
+     *         registered for the message, that function was called, and returned
+     *         successfully; EINVAL if no function was registered; or pcmk_rc_no_output
+     *         if a function was called but produced no output.
      */
     int (*message) (pcmk__output_t *out, const char *message_id, ...);
 

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -107,6 +107,7 @@ enum pcmk_rc_e {
     /* When adding new values, use consecutively lower numbers, update the array
      * in lib/common/results.c, and test with crm_error.
      */
+    pcmk_rc_no_output           = -1026,
     pcmk_rc_after_range         = -1025,
     pcmk_rc_within_range        = -1024,
     pcmk_rc_before_range        = -1023,

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -395,14 +395,14 @@ gboolean add_tag_ref(GHashTable * tags, const char * tag_name,  const char * obj
 
 void print_rscs_brief(GListPtr rsc_list, const char * pre_text, long options,
                       void * print_data, gboolean print_all);
-void pe__rscs_brief_output(pcmk__output_t *out, GListPtr rsc_list, long options, gboolean print_all);
+int pe__rscs_brief_output(pcmk__output_t *out, GListPtr rsc_list, long options, gboolean print_all);
 void pe_fence_node(pe_working_set_t * data_set, node_t * node, const char *reason);
 
 node_t *pe_create_node(const char *id, const char *uname, const char *type,
                        const char *score, pe_working_set_t * data_set);
 void common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options, void *print_data);
-void pe__common_output_text(pcmk__output_t *out, resource_t * rsc, const char *name, node_t *node, long options);
-void pe__common_output_html(pcmk__output_t *out, resource_t * rsc, const char *name, node_t *node, long options);
+int pe__common_output_text(pcmk__output_t *out, resource_t * rsc, const char *name, node_t *node, long options);
+int pe__common_output_html(pcmk__output_t *out, resource_t * rsc, const char *name, node_t *node, long options);
 pe_resource_t *pe__find_bundle_replica(const pe_resource_t *bundle,
                                        const pe_node_t *node);
 bool pe__bundle_needs_remote_name(pe_resource_t *rsc);

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -108,12 +108,12 @@ pcmk__register_formats(GOptionGroup *group, pcmk__supported_format_t *formats) {
 int
 pcmk__call_message(pcmk__output_t *out, const char *message_id, ...) {
     va_list args;
-    int rc = 0;
+    int rc = pcmk_rc_ok;
     pcmk__message_fn_t fn;
 
     fn = g_hash_table_lookup(out->messages, message_id);
     if (fn == NULL) {
-        return -EINVAL;
+        return EINVAL;
     }
 
     va_start(args, message_id);

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -235,6 +235,10 @@ static struct pcmk__rc_info {
     { "pcmk_rc_after_range",
       "Result occurs after given range",
       -pcmk_err_generic,
+    },
+    { "pcmk_rc_no_output",
+      "Output message produced no output",
+      -pcmk_err_generic,
     }
 };
 
@@ -655,6 +659,7 @@ pcmk_rc2exitc(int rc)
             return CRM_EX_EXISTS;
 
         case EIO:
+        case pcmk_rc_no_output:
             return CRM_EX_IOERR;
 
         case ENOTSUP:

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -36,9 +36,10 @@ last_fenced_html(pcmk__output_t *out, va_list args) {
         char *buf = crm_strdup_printf("Node %s last fenced at: %s", target, ctime(&when));
         pcmk__output_create_html_node(out, "div", NULL, NULL, buf);
         free(buf);
+        return pcmk_rc_ok;
+    } else {
+        return pcmk_rc_no_output;
     }
-
-    return 0;
 }
 
 static int
@@ -52,7 +53,7 @@ last_fenced_text(pcmk__output_t *out, va_list args) {
         pcmk__indented_printf(out, "Node %s has never been fenced\n", target);
     }
 
-    return 0;
+    return pcmk_rc_ok;
 }
 
 static int
@@ -68,9 +69,10 @@ last_fenced_xml(pcmk__output_t *out, va_list args) {
         xmlSetProp(node, (pcmkXmlStr) "when", (pcmkXmlStr) buf);
 
         free(buf);
+        return pcmk_rc_ok;
+    } else {
+        return pcmk_rc_no_output;
     }
-
-    return 0;
 }
 
 static int
@@ -117,7 +119,7 @@ stonith_event_html(pcmk__output_t *out, va_list args) {
             break;
     }
 
-    return 0;
+    return pcmk_rc_ok;
 }
 
 static int
@@ -154,7 +156,7 @@ stonith_event_text(pcmk__output_t *out, va_list args) {
     }
 
     free(buf);
-    return 0;
+    return pcmk_rc_ok;
 }
 
 static int
@@ -199,7 +201,7 @@ stonith_event_xml(pcmk__output_t *out, va_list args) {
         free(buf);
     }
 
-    return 0;
+    return pcmk_rc_ok;
 }
 
 static int

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -286,8 +286,7 @@ pcmk__fence_last(pcmk__output_t *out, const char *target, bool as_nodeid) {
         when = stonith_api_time(0, target, FALSE);
     }
 
-    out->message(out, "last-fenced", target, when);
-    return pcmk_rc_ok;
+    return out->message(out, "last-fenced", target, when);
 }
 
 #ifdef BUILD_PUBLIC_LIBPACEMAKER

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1501,7 +1501,7 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
     unsigned int options = va_arg(args, unsigned int);
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
     pe__bundle_variant_data_t *bundle_data = NULL;
-    int rc = 0;
+    int rc = pcmk_rc_no_output;
 
     CRM_ASSERT(rsc != NULL);
 
@@ -1514,7 +1514,7 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
                  , "unique", BOOL2STR(is_set(rsc->flags, pe_rsc_unique))
                  , "managed", BOOL2STR(is_set(rsc->flags, pe_rsc_managed))
                  , "failed", BOOL2STR(is_set(rsc->flags, pe_rsc_failed)));
-    CRM_ASSERT(rc == 0);
+    CRM_ASSERT(rc == pcmk_rc_ok);
 
     for (GList *gIter = bundle_data->replicas; gIter != NULL;
          gIter = gIter->next) {
@@ -1525,7 +1525,7 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
 
         rc = pe__name_and_nvpairs_xml(out, true, "replica", 1, "id", id);
         free(id);
-        CRM_ASSERT(rc == 0);
+        CRM_ASSERT(rc == pcmk_rc_ok);
 
         if (replica->ip != NULL) {
             out->message(out, crm_map_element_name(replica->ip->xml), options, replica->ip);
@@ -1634,7 +1634,7 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
     }
 
     out->end_list(out);
-    return 0;
+    return pcmk_rc_ok;
 }
 
 static void
@@ -1719,7 +1719,7 @@ pe__bundle_text(pcmk__output_t *out, va_list args)
     }
 
     out->end_list(out);
-    return 0;
+    return pcmk_rc_ok;
 }
 
 static void

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -584,7 +584,7 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
                  , "failed", BOOL2STR(is_set(rsc->flags, pe_rsc_failed))
                  , "failure_ignored", BOOL2STR(is_set(rsc->flags, pe_rsc_failure_ignored))
                  , "target_role", configured_role_str(rsc));
-    CRM_ASSERT(rc == 0);
+    CRM_ASSERT(rc == pcmk_rc_ok);
 
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
@@ -781,7 +781,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
 
     out->end_list(out);
 
-    return 0;
+    return pcmk_rc_ok;
 }
 
 int
@@ -968,8 +968,9 @@ pe__clone_text(pcmk__output_t *out, va_list args)
 
     out->end_list(out);
 
-    return 0;
+    return pcmk_rc_ok;
 }
+
 void
 clone_free(resource_t * rsc)
 {

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -196,7 +196,7 @@ pe__group_xml(pcmk__output_t *out, va_list args)
                                       , "id", rsc->id
                                       , "number_resources", count);
     free(count);
-    CRM_ASSERT(rc == 0);
+    CRM_ASSERT(rc == pcmk_rc_ok);
 
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
@@ -228,7 +228,7 @@ pe__group_html(pcmk__output_t *out, va_list args)
 
     out->end_list(out);
 
-    return 0;
+    return pcmk_rc_ok;
 }
 
 int
@@ -251,7 +251,7 @@ pe__group_text(pcmk__output_t *out, va_list args)
     }
     out->end_list(out);
 
-    return 0;
+    return pcmk_rc_ok;
 }
 
 void

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -325,7 +325,7 @@ stonith_event_console(pcmk__output_t *out, va_list args) {
 
     free(buf);
     crm_time_free(crm_when);
-    return 0;
+    return pcmk_rc_ok;
 }
 
 static int
@@ -335,7 +335,7 @@ cluster_maint_mode_console(pcmk__output_t *out, va_list args) {
     printw("\n");
     clrtoeol();
     refresh();
-    return 0;
+    return pcmk_rc_ok;
 }
 
 static pcmk__message_entry_t fmt_functions[] = {


### PR DESCRIPTION
The point of this is to make it easier to tell whether or not something has been printed in crm_mon's text mode, getting rid of a bunch of special purpose variables I added for that purpose.  All formatted output messages should return a standard pacemaker return code now, though not all of them need to be checked.