### PR TITLE
Fix: libcrmcommon: Add pcmk__unregister_formats.

### DIFF
--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -345,6 +345,7 @@ main(int argc, char **argv)
     g_main_loop_run(mainloop);
 
     pe_free_working_set(sched_data_set);
+    pcmk__unregister_formats();
     crm_info("Exiting %s", crm_system_name);
     crm_exit(CRM_EX_OK);
 }

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -514,6 +514,14 @@ pcmk__register_formats(GOptionGroup *group, pcmk__supported_format_t *table);
 
 /*!
  * \internal
+ * \brief Unregister a previously registered table of custom formatting
+ *        functions and destroy the internal data structures associated with them.
+ */
+void
+pcmk__unregister_formats(void);
+
+/*!
+ * \internal
  * \brief Register a function to handle a custom message.
  *
  * \note This function is for implementing custom formatters.  It should not

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -81,7 +81,7 @@ pcmk__register_format(GOptionGroup *group, const char *name,
     }
 
     if (formatters == NULL) {
-        formatters = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, NULL);
+        formatters = g_hash_table_new_full(crm_str_hash, g_str_equal, free, NULL);
     }
 
     if (options != NULL && group != NULL) {
@@ -102,6 +102,13 @@ pcmk__register_formats(GOptionGroup *group, pcmk__supported_format_t *formats) {
 
     for (entry = formats; entry->name != NULL; entry++) {
         pcmk__register_format(group, entry->name, entry->create, entry->options);
+    }
+}
+
+void
+pcmk__unregister_formats() {
+    if (formatters != NULL) {
+        g_hash_table_destroy(formatters);
     }
 }
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -2157,6 +2157,7 @@ clean_up(crm_exit_t exit_code)
         }
 
         pcmk__output_free(out);
+        pcmk__unregister_formats();
     }
 
     crm_exit(exit_code);


### PR DESCRIPTION
This functions frees the hash table previously constructed by
pcmk__register_formats and also frees the strings that are the keys.
This should be called at program termination.