### PR TITLE
Stop using deprecated type aliases

### DIFF
--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -425,7 +425,7 @@ generate_params(void)
     int rc = 0;
     pe_working_set_t *data_set = NULL;
     xmlNode *cib_xml_copy = NULL;
-    resource_t *rsc = NULL;
+    pe_resource_t *rsc = NULL;
     GHashTable *params = NULL;
     GHashTable *meta = NULL;
     GHashTableIter iter;

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -550,11 +550,11 @@ fencing_topology_init()
  *
  * \return Pointer to node object if found, NULL otherwise
  */
-static node_t *
+static pe_node_t *
 our_node_allowed_for(pe_resource_t *rsc)
 {
     GHashTableIter iter;
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
 
     if (rsc && stonith_our_uname) {
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
@@ -578,10 +578,10 @@ our_node_allowed_for(pe_resource_t *rsc)
  */
 static void cib_device_update(pe_resource_t *rsc, pe_working_set_t *data_set)
 {
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
     const char *value = NULL;
     const char *rclass = NULL;
-    node_t *parent = NULL;
+    pe_node_t *parent = NULL;
     gboolean remove = TRUE;
 
     /* If this is a complex resource, check children rather than this resource itself.

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -551,7 +551,7 @@ fencing_topology_init()
  * \return Pointer to node object if found, NULL otherwise
  */
 static node_t *
-our_node_allowed_for(resource_t *rsc)
+our_node_allowed_for(pe_resource_t *rsc)
 {
     GHashTableIter iter;
     node_t *node = NULL;
@@ -576,7 +576,7 @@ our_node_allowed_for(resource_t *rsc)
  * \param[in] rsc       Resource to check
  * \param[in] data_set  Cluster working set with device information
  */
-static void cib_device_update(resource_t *rsc, pe_working_set_t *data_set)
+static void cib_device_update(pe_resource_t *rsc, pe_working_set_t *data_set)
 {
     node_t *node = NULL;
     const char *value = NULL;

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -38,12 +38,12 @@ typedef struct pe__order_constraint_s {
     enum pe_ordering type;
 
     void *lh_opaque;
-    resource_t *lh_rsc;
+    pe_resource_t *lh_rsc;
     pe_action_t *lh_action;
     char *lh_action_task;
 
     void *rh_opaque;
-    resource_t *rh_rsc;
+    pe_resource_t *rh_rsc;
     pe_action_t *rh_action;
     char *rh_action_task;
 } pe__ordering_t;
@@ -75,32 +75,32 @@ bool pe_can_fence(pe_working_set_t *data_set, node_t *node);
 int merge_weights(int w1, int w2);
 void add_hash_param(GHashTable * hash, const char *name, const char *value);
 
-char *native_parameter(resource_t * rsc, node_t * node, gboolean create, const char *name,
+char *native_parameter(pe_resource_t * rsc, node_t * node, gboolean create, const char *name,
                        pe_working_set_t * data_set);
 pe_node_t *native_location(const pe_resource_t *rsc, GList **list, int current);
 
 void pe_metadata(void);
 void verify_pe_options(GHashTable * options);
 
-void common_update_score(resource_t * rsc, const char *id, int score);
-void native_add_running(resource_t * rsc, node_t * node, pe_working_set_t * data_set);
+void common_update_score(pe_resource_t * rsc, const char *id, int score);
+void native_add_running(pe_resource_t * rsc, node_t * node, pe_working_set_t * data_set);
 
-gboolean native_unpack(resource_t * rsc, pe_working_set_t * data_set);
-gboolean group_unpack(resource_t * rsc, pe_working_set_t * data_set);
-gboolean clone_unpack(resource_t * rsc, pe_working_set_t * data_set);
+gboolean native_unpack(pe_resource_t * rsc, pe_working_set_t * data_set);
+gboolean group_unpack(pe_resource_t * rsc, pe_working_set_t * data_set);
+gboolean clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set);
 gboolean pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set);
 
-resource_t *native_find_rsc(resource_t *rsc, const char *id, const node_t *node,
-                            int flags);
+pe_resource_t *native_find_rsc(pe_resource_t *rsc, const char *id, const node_t *node,
+                               int flags);
 
-gboolean native_active(resource_t * rsc, gboolean all);
-gboolean group_active(resource_t * rsc, gboolean all);
-gboolean clone_active(resource_t * rsc, gboolean all);
+gboolean native_active(pe_resource_t * rsc, gboolean all);
+gboolean group_active(pe_resource_t * rsc, gboolean all);
+gboolean clone_active(pe_resource_t * rsc, gboolean all);
 gboolean pe__bundle_active(pe_resource_t *rsc, gboolean all);
 
-void native_print(resource_t * rsc, const char *pre_text, long options, void *print_data);
-void group_print(resource_t * rsc, const char *pre_text, long options, void *print_data);
-void clone_print(resource_t * rsc, const char *pre_text, long options, void *print_data);
+void native_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data);
+void group_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data);
+void clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data);
 void pe__print_bundle(pe_resource_t *rsc, const char *pre_text, long options,
                       void *print_data);
 
@@ -159,23 +159,23 @@ int pe__ticket_html(pcmk__output_t *out, va_list args);
 int pe__ticket_text(pcmk__output_t *out, va_list args);
 int pe__ticket_xml(pcmk__output_t *out, va_list args);
 
-void native_free(resource_t * rsc);
-void group_free(resource_t * rsc);
-void clone_free(resource_t * rsc);
+void native_free(pe_resource_t * rsc);
+void group_free(pe_resource_t * rsc);
+void clone_free(pe_resource_t * rsc);
 void pe__free_bundle(pe_resource_t *rsc);
 
-enum rsc_role_e native_resource_state(const resource_t * rsc, gboolean current);
-enum rsc_role_e group_resource_state(const resource_t * rsc, gboolean current);
-enum rsc_role_e clone_resource_state(const resource_t * rsc, gboolean current);
+enum rsc_role_e native_resource_state(const pe_resource_t * rsc, gboolean current);
+enum rsc_role_e group_resource_state(const pe_resource_t * rsc, gboolean current);
+enum rsc_role_e clone_resource_state(const pe_resource_t * rsc, gboolean current);
 enum rsc_role_e pe__bundle_resource_state(const pe_resource_t *rsc,
                                           gboolean current);
 
 void pe__count_common(pe_resource_t *rsc);
 void pe__count_bundle(pe_resource_t *rsc);
 
-gboolean common_unpack(xmlNode * xml_obj, resource_t ** rsc, resource_t * parent,
+gboolean common_unpack(xmlNode * xml_obj, pe_resource_t ** rsc, pe_resource_t * parent,
                        pe_working_set_t * data_set);
-void common_free(resource_t * rsc);
+void common_free(pe_resource_t * rsc);
 
 extern node_t *node_copy(const node_t *this_node);
 extern time_t get_effective_time(pe_working_set_t * data_set);
@@ -189,7 +189,7 @@ enum pe_fc_flags_e {
     pe_fc_fillers   = 0x02, // if container, include filler failures in count
 };
 
-int pe_get_failcount(node_t *node, resource_t *rsc, time_t *last_failure,
+int pe_get_failcount(node_t *node, pe_resource_t *rsc, time_t *last_failure,
                      uint32_t flags, xmlNode *xml_op,
                      pe_working_set_t *data_set);
 
@@ -237,7 +237,7 @@ extern void print_str_str(gpointer key, gpointer value, gpointer user_data);
 extern void pe__output_node(node_t * node, gboolean details, pcmk__output_t *out);
 
 extern void dump_node_capacity(int level, const char *comment, node_t * node);
-extern void dump_rsc_utilization(int level, const char *comment, resource_t * rsc, node_t * node);
+extern void dump_rsc_utilization(int level, const char *comment, pe_resource_t * rsc, node_t * node);
 
 void pe__show_node_weights_as(const char *file, const char *function,
                               int line, bool to_log, pe_resource_t *rsc,
@@ -251,9 +251,9 @@ void pe__show_node_weights_as(const char *file, const char *function,
 extern gint sort_rsc_priority(gconstpointer a, gconstpointer b);
 extern gint sort_rsc_index(gconstpointer a, gconstpointer b);
 
-extern xmlNode *find_rsc_op_entry(resource_t * rsc, const char *key);
+extern xmlNode *find_rsc_op_entry(pe_resource_t * rsc, const char *key);
 
-extern pe_action_t *custom_action(resource_t * rsc, char *key, const char *task, node_t * on_node,
+extern pe_action_t *custom_action(pe_resource_t * rsc, char *key, const char *task, node_t * on_node,
                                   gboolean optional, gboolean foo, pe_working_set_t * data_set);
 
 #  define delete_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_DELETE, 0)
@@ -302,12 +302,12 @@ extern pe_action_t *custom_action(resource_t * rsc, char *key, const char *task,
 		rsc, demoted_key(rsc), CRMD_ACTION_DEMOTED, node,	\
 		optional, TRUE, data_set)
 
-extern int pe_get_configured_timeout(resource_t *rsc, const char *action,
+extern int pe_get_configured_timeout(pe_resource_t *rsc, const char *action,
                                      pe_working_set_t *data_set);
 
 extern pe_action_t *find_first_action(GListPtr input, const char *uuid, const char *task,
                                       node_t * on_node);
-extern enum action_tasks get_complex_task(resource_t * rsc, const char *name,
+extern enum action_tasks get_complex_task(pe_resource_t * rsc, const char *name,
                                           gboolean allow_non_atomic);
 
 extern GListPtr find_actions(GListPtr input, const char *key, const node_t *on_node);
@@ -319,14 +319,14 @@ GList *pe__resource_actions(const pe_resource_t *rsc, const pe_node_t *node,
 
 extern void pe_free_action(pe_action_t * action);
 
-extern void resource_location(resource_t * rsc, node_t * node, int score, const char *tag,
+extern void resource_location(pe_resource_t * rsc, node_t * node, int score, const char *tag,
                               pe_working_set_t * data_set);
 
 extern gint sort_op_by_callid(gconstpointer a, gconstpointer b);
-extern gboolean get_target_role(resource_t * rsc, enum rsc_role_e *role);
+extern gboolean get_target_role(pe_resource_t * rsc, enum rsc_role_e *role);
 
-extern resource_t *find_clone_instance(resource_t * rsc, const char *sub_id,
-                                       pe_working_set_t * data_set);
+extern pe_resource_t *find_clone_instance(pe_resource_t * rsc, const char *sub_id,
+                                          pe_working_set_t * data_set);
 
 extern void destroy_ticket(gpointer data);
 extern pe_ticket_t *ticket_new(const char *ticket_id, pe_working_set_t * data_set);
@@ -337,7 +337,7 @@ char *clone_strip(const char *last_rsc_id);
 char *clone_zero(const char *last_rsc_id);
 
 static inline bool
-pe_base_name_eq(resource_t *rsc, const char *id)
+pe_base_name_eq(pe_resource_t *rsc, const char *id)
 {
     if (id && rsc && rsc->id) {
         // Number of characters in rsc->id before any clone suffix
@@ -351,7 +351,7 @@ pe_base_name_eq(resource_t *rsc, const char *id)
 int pe__target_rc_from_xml(xmlNode *xml_op);
 
 gint sort_node_uname(gconstpointer a, gconstpointer b);
-bool is_set_recursive(resource_t * rsc, long long flag, bool any);
+bool is_set_recursive(pe_resource_t * rsc, long long flag, bool any);
 
 enum rsc_digest_cmp_val {
     /*! Digests are the same */
@@ -375,12 +375,12 @@ typedef struct op_digest_cache_s {
     char *digest_restart_calc;
 } op_digest_cache_t;
 
-op_digest_cache_t *rsc_action_digest_cmp(resource_t * rsc, xmlNode * xml_op, node_t * node,
+op_digest_cache_t *rsc_action_digest_cmp(pe_resource_t * rsc, xmlNode * xml_op, node_t * node,
                                          pe_working_set_t * data_set);
 
 pe_action_t *pe_fence_op(node_t * node, const char *op, bool optional, const char *reason, pe_working_set_t * data_set);
 void trigger_unfencing(
-    resource_t * rsc, node_t *node, const char *reason, pe_action_t *dependency, pe_working_set_t * data_set);
+    pe_resource_t * rsc, node_t *node, const char *reason, pe_action_t *dependency, pe_working_set_t * data_set);
 
 void pe_action_set_reason(pe_action_t *action, const char *reason, bool overwrite);
 void pe_action_set_flag_reason(const char *function, long line, pe_action_t *action, pe_action_t *reason, const char *text, enum pe_action_flags flags, bool overwrite);
@@ -388,8 +388,8 @@ void pe_action_set_flag_reason(const char *function, long line, pe_action_t *act
 #define pe_action_required(action, reason, text) pe_action_set_flag_reason(__FUNCTION__, __LINE__, action, reason, text, pe_action_optional, FALSE)
 #define pe_action_implies(action, reason, flag) pe_action_set_flag_reason(__FUNCTION__, __LINE__, action, reason, NULL, flag, FALSE)
 
-void set_bit_recursive(resource_t * rsc, unsigned long long flag);
-void clear_bit_recursive(resource_t * rsc, unsigned long long flag);
+void set_bit_recursive(pe_resource_t * rsc, unsigned long long flag);
+void clear_bit_recursive(pe_resource_t * rsc, unsigned long long flag);
 
 gboolean add_tag_ref(GHashTable * tags, const char * tag_name,  const char * obj_ref);
 
@@ -400,9 +400,9 @@ void pe_fence_node(pe_working_set_t * data_set, node_t * node, const char *reaso
 
 node_t *pe_create_node(const char *id, const char *uname, const char *type,
                        const char *score, pe_working_set_t * data_set);
-void common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options, void *print_data);
-int pe__common_output_text(pcmk__output_t *out, resource_t * rsc, const char *name, node_t *node, long options);
-int pe__common_output_html(pcmk__output_t *out, resource_t * rsc, const char *name, node_t *node, long options);
+void common_print(pe_resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options, void *print_data);
+int pe__common_output_text(pcmk__output_t *out, pe_resource_t * rsc, const char *name, node_t *node, long options);
+int pe__common_output_html(pcmk__output_t *out, pe_resource_t * rsc, const char *name, node_t *node, long options);
 pe_resource_t *pe__find_bundle_replica(const pe_resource_t *bundle,
                                        const pe_node_t *node);
 bool pe__bundle_needs_remote_name(pe_resource_t *rsc);
@@ -410,7 +410,7 @@ const char *pe__add_bundle_remote_name(pe_resource_t *rsc, xmlNode *xml,
                                        const char *field);
 const char *pe_node_attribute_calculated(const pe_node_t *node,
                                          const char *name,
-                                         const resource_t *rsc);
+                                         const pe_resource_t *rsc);
 const char *pe_node_attribute_raw(pe_node_t *node, const char *name);
 bool pe__is_universal_clone(pe_resource_t *rsc,
                             pe_working_set_t *data_set);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -329,7 +329,7 @@ extern resource_t *find_clone_instance(resource_t * rsc, const char *sub_id,
                                        pe_working_set_t * data_set);
 
 extern void destroy_ticket(gpointer data);
-extern ticket_t *ticket_new(const char *ticket_id, pe_working_set_t * data_set);
+extern pe_ticket_t *ticket_new(const char *ticket_id, pe_working_set_t * data_set);
 
 // Resources for manipulating resource names
 const char *pe_base_name_end(const char *id);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -70,12 +70,12 @@ typedef struct notify_data_s {
 
 } notify_data_t;
 
-bool pe_can_fence(pe_working_set_t *data_set, node_t *node);
+bool pe_can_fence(pe_working_set_t *data_set, pe_node_t *node);
 
 int merge_weights(int w1, int w2);
 void add_hash_param(GHashTable * hash, const char *name, const char *value);
 
-char *native_parameter(pe_resource_t * rsc, node_t * node, gboolean create, const char *name,
+char *native_parameter(pe_resource_t * rsc, pe_node_t * node, gboolean create, const char *name,
                        pe_working_set_t * data_set);
 pe_node_t *native_location(const pe_resource_t *rsc, GList **list, int current);
 
@@ -83,14 +83,14 @@ void pe_metadata(void);
 void verify_pe_options(GHashTable * options);
 
 void common_update_score(pe_resource_t * rsc, const char *id, int score);
-void native_add_running(pe_resource_t * rsc, node_t * node, pe_working_set_t * data_set);
+void native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * data_set);
 
 gboolean native_unpack(pe_resource_t * rsc, pe_working_set_t * data_set);
 gboolean group_unpack(pe_resource_t * rsc, pe_working_set_t * data_set);
 gboolean clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set);
 gboolean pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set);
 
-pe_resource_t *native_find_rsc(pe_resource_t *rsc, const char *id, const node_t *node,
+pe_resource_t *native_find_rsc(pe_resource_t *rsc, const char *id, const pe_node_t *node,
                                int flags);
 
 gboolean native_active(pe_resource_t * rsc, gboolean all);
@@ -106,7 +106,7 @@ void pe__print_bundle(pe_resource_t *rsc, const char *pre_text, long options,
 
 int pe__name_and_nvpairs_xml(pcmk__output_t *out, bool is_list, const char *tag_name
                          , size_t pairs_count, ...);
-char *pe__node_display_name(node_t *node, bool print_detail);
+char *pe__node_display_name(pe_node_t *node, bool print_detail);
 
 int pe__ban_html(pcmk__output_t *out, va_list args);
 int pe__ban_text(pcmk__output_t *out, va_list args);
@@ -177,7 +177,7 @@ gboolean common_unpack(xmlNode * xml_obj, pe_resource_t ** rsc, pe_resource_t * 
                        pe_working_set_t * data_set);
 void common_free(pe_resource_t * rsc);
 
-extern node_t *node_copy(const node_t *this_node);
+extern pe_node_t *node_copy(const pe_node_t *this_node);
 extern time_t get_effective_time(pe_working_set_t * data_set);
 
 /* Failure handling utilities (from failcounts.c) */
@@ -189,7 +189,7 @@ enum pe_fc_flags_e {
     pe_fc_fillers   = 0x02, // if container, include filler failures in count
 };
 
-int pe_get_failcount(node_t *node, pe_resource_t *rsc, time_t *last_failure,
+int pe_get_failcount(pe_node_t *node, pe_resource_t *rsc, time_t *last_failure,
                      uint32_t flags, xmlNode *xml_op,
                      pe_working_set_t *data_set);
 
@@ -232,12 +232,12 @@ extern gboolean order_actions(pe_action_t * lh_action, pe_action_t * rh_action, 
 GHashTable *node_hash_dup(GHashTable * hash);
 
 /* Printing functions for debug */
-extern void print_node(const char *pre_text, node_t * node, gboolean details);
+extern void print_node(const char *pre_text, pe_node_t * node, gboolean details);
 extern void print_str_str(gpointer key, gpointer value, gpointer user_data);
-extern void pe__output_node(node_t * node, gboolean details, pcmk__output_t *out);
+extern void pe__output_node(pe_node_t * node, gboolean details, pcmk__output_t *out);
 
-extern void dump_node_capacity(int level, const char *comment, node_t * node);
-extern void dump_rsc_utilization(int level, const char *comment, pe_resource_t * rsc, node_t * node);
+extern void dump_node_capacity(int level, const char *comment, pe_node_t * node);
+extern void dump_rsc_utilization(int level, const char *comment, pe_resource_t * rsc, pe_node_t * node);
 
 void pe__show_node_weights_as(const char *file, const char *function,
                               int line, bool to_log, pe_resource_t *rsc,
@@ -253,7 +253,7 @@ extern gint sort_rsc_index(gconstpointer a, gconstpointer b);
 
 extern xmlNode *find_rsc_op_entry(pe_resource_t * rsc, const char *key);
 
-extern pe_action_t *custom_action(pe_resource_t * rsc, char *key, const char *task, node_t * on_node,
+extern pe_action_t *custom_action(pe_resource_t * rsc, char *key, const char *task, pe_node_t * on_node,
                                   gboolean optional, gboolean foo, pe_working_set_t * data_set);
 
 #  define delete_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_DELETE, 0)
@@ -306,20 +306,20 @@ extern int pe_get_configured_timeout(pe_resource_t *rsc, const char *action,
                                      pe_working_set_t *data_set);
 
 extern pe_action_t *find_first_action(GListPtr input, const char *uuid, const char *task,
-                                      node_t * on_node);
+                                      pe_node_t * on_node);
 extern enum action_tasks get_complex_task(pe_resource_t * rsc, const char *name,
                                           gboolean allow_non_atomic);
 
-extern GListPtr find_actions(GListPtr input, const char *key, const node_t *on_node);
+extern GListPtr find_actions(GListPtr input, const char *key, const pe_node_t *on_node);
 GList *find_actions_exact(GList *input, const char *key,
                           const pe_node_t *on_node);
-extern GListPtr find_recurring_actions(GListPtr input, node_t * not_on_node);
+extern GListPtr find_recurring_actions(GListPtr input, pe_node_t * not_on_node);
 GList *pe__resource_actions(const pe_resource_t *rsc, const pe_node_t *node,
                             const char *task, bool require_node);
 
 extern void pe_free_action(pe_action_t * action);
 
-extern void resource_location(pe_resource_t * rsc, node_t * node, int score, const char *tag,
+extern void resource_location(pe_resource_t * rsc, pe_node_t * node, int score, const char *tag,
                               pe_working_set_t * data_set);
 
 extern gint sort_op_by_callid(gconstpointer a, gconstpointer b);
@@ -375,12 +375,12 @@ typedef struct op_digest_cache_s {
     char *digest_restart_calc;
 } op_digest_cache_t;
 
-op_digest_cache_t *rsc_action_digest_cmp(pe_resource_t * rsc, xmlNode * xml_op, node_t * node,
+op_digest_cache_t *rsc_action_digest_cmp(pe_resource_t * rsc, xmlNode * xml_op, pe_node_t * node,
                                          pe_working_set_t * data_set);
 
-pe_action_t *pe_fence_op(node_t * node, const char *op, bool optional, const char *reason, pe_working_set_t * data_set);
+pe_action_t *pe_fence_op(pe_node_t * node, const char *op, bool optional, const char *reason, pe_working_set_t * data_set);
 void trigger_unfencing(
-    pe_resource_t * rsc, node_t *node, const char *reason, pe_action_t *dependency, pe_working_set_t * data_set);
+    pe_resource_t * rsc, pe_node_t *node, const char *reason, pe_action_t *dependency, pe_working_set_t * data_set);
 
 void pe_action_set_reason(pe_action_t *action, const char *reason, bool overwrite);
 void pe_action_set_flag_reason(const char *function, long line, pe_action_t *action, pe_action_t *reason, const char *text, enum pe_action_flags flags, bool overwrite);
@@ -396,13 +396,13 @@ gboolean add_tag_ref(GHashTable * tags, const char * tag_name,  const char * obj
 void print_rscs_brief(GListPtr rsc_list, const char * pre_text, long options,
                       void * print_data, gboolean print_all);
 int pe__rscs_brief_output(pcmk__output_t *out, GListPtr rsc_list, long options, gboolean print_all);
-void pe_fence_node(pe_working_set_t * data_set, node_t * node, const char *reason);
+void pe_fence_node(pe_working_set_t * data_set, pe_node_t * node, const char *reason);
 
-node_t *pe_create_node(const char *id, const char *uname, const char *type,
-                       const char *score, pe_working_set_t * data_set);
-void common_print(pe_resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options, void *print_data);
-int pe__common_output_text(pcmk__output_t *out, pe_resource_t * rsc, const char *name, node_t *node, long options);
-int pe__common_output_html(pcmk__output_t *out, pe_resource_t * rsc, const char *name, node_t *node, long options);
+pe_node_t *pe_create_node(const char *id, const char *uname, const char *type,
+                          const char *score, pe_working_set_t * data_set);
+void common_print(pe_resource_t * rsc, const char *pre_text, const char *name, pe_node_t *node, long options, void *print_data);
+int pe__common_output_text(pcmk__output_t *out, pe_resource_t * rsc, const char *name, pe_node_t *node, long options);
+int pe__common_output_html(pcmk__output_t *out, pe_resource_t * rsc, const char *name, pe_node_t *node, long options);
 pe_resource_t *pe__find_bundle_replica(const pe_resource_t *bundle,
                                        const pe_node_t *node);
 bool pe__bundle_needs_remote_name(pe_resource_t *rsc);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -39,12 +39,12 @@ typedef struct pe__order_constraint_s {
 
     void *lh_opaque;
     resource_t *lh_rsc;
-    action_t *lh_action;
+    pe_action_t *lh_action;
     char *lh_action_task;
 
     void *rh_opaque;
     resource_t *rh_rsc;
-    action_t *rh_action;
+    pe_action_t *rh_action;
     char *rh_action_task;
 } pe__ordering_t;
 
@@ -53,10 +53,10 @@ typedef struct notify_data_s {
 
     const char *action;
 
-    action_t *pre;
-    action_t *post;
-    action_t *pre_done;
-    action_t *post_done;
+    pe_action_t *pre;
+    pe_action_t *post;
+    pe_action_t *pre_done;
+    pe_action_t *post_done;
 
     GListPtr active;            /* notify_entry_t*  */
     GListPtr inactive;          /* notify_entry_t*  */
@@ -226,8 +226,8 @@ pe_hash_table_lookup(GHashTable * hash, gconstpointer key)
     return NULL;
 }
 
-extern action_t *get_pseudo_op(const char *name, pe_working_set_t * data_set);
-extern gboolean order_actions(action_t * lh_action, action_t * rh_action, enum pe_ordering order);
+extern pe_action_t *get_pseudo_op(const char *name, pe_working_set_t * data_set);
+extern gboolean order_actions(pe_action_t * lh_action, pe_action_t * rh_action, enum pe_ordering order);
 
 GHashTable *node_hash_dup(GHashTable * hash);
 
@@ -253,8 +253,8 @@ extern gint sort_rsc_index(gconstpointer a, gconstpointer b);
 
 extern xmlNode *find_rsc_op_entry(resource_t * rsc, const char *key);
 
-extern action_t *custom_action(resource_t * rsc, char *key, const char *task, node_t * on_node,
-                               gboolean optional, gboolean foo, pe_working_set_t * data_set);
+extern pe_action_t *custom_action(resource_t * rsc, char *key, const char *task, node_t * on_node,
+                                  gboolean optional, gboolean foo, pe_working_set_t * data_set);
 
 #  define delete_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_DELETE, 0)
 #  define delete_action(rsc, node, optional) custom_action(		\
@@ -305,8 +305,8 @@ extern action_t *custom_action(resource_t * rsc, char *key, const char *task, no
 extern int pe_get_configured_timeout(resource_t *rsc, const char *action,
                                      pe_working_set_t *data_set);
 
-extern action_t *find_first_action(GListPtr input, const char *uuid, const char *task,
-                                   node_t * on_node);
+extern pe_action_t *find_first_action(GListPtr input, const char *uuid, const char *task,
+                                      node_t * on_node);
 extern enum action_tasks get_complex_task(resource_t * rsc, const char *name,
                                           gboolean allow_non_atomic);
 
@@ -317,7 +317,7 @@ extern GListPtr find_recurring_actions(GListPtr input, node_t * not_on_node);
 GList *pe__resource_actions(const pe_resource_t *rsc, const pe_node_t *node,
                             const char *task, bool require_node);
 
-extern void pe_free_action(action_t * action);
+extern void pe_free_action(pe_action_t * action);
 
 extern void resource_location(resource_t * rsc, node_t * node, int score, const char *tag,
                               pe_working_set_t * data_set);
@@ -378,9 +378,9 @@ typedef struct op_digest_cache_s {
 op_digest_cache_t *rsc_action_digest_cmp(resource_t * rsc, xmlNode * xml_op, node_t * node,
                                          pe_working_set_t * data_set);
 
-action_t *pe_fence_op(node_t * node, const char *op, bool optional, const char *reason, pe_working_set_t * data_set);
+pe_action_t *pe_fence_op(node_t * node, const char *op, bool optional, const char *reason, pe_working_set_t * data_set);
 void trigger_unfencing(
-    resource_t * rsc, node_t *node, const char *reason, action_t *dependency, pe_working_set_t * data_set);
+    resource_t * rsc, node_t *node, const char *reason, pe_action_t *dependency, pe_working_set_t * data_set);
 
 void pe_action_set_reason(pe_action_t *action, const char *reason, bool overwrite);
 void pe_action_set_flag_reason(const char *function, long line, pe_action_t *action, pe_action_t *reason, const char *text, enum pe_action_flags flags, bool overwrite);

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -510,9 +510,18 @@ typedef struct pe_action_s action_t;                 //!< \deprecated Use pe_act
 typedef struct pe_action_wrapper_s action_wrapper_t; //!< \deprecated Use pe_action_wrapper_t instead
 typedef struct pe_node_s node_t;                     //!< \deprecated Use pe_node_t instead
 typedef struct pe_resource_s resource_t;             //!< \deprecated Use pe_resource_t instead
-typedef struct pe_tag_s tag_t;                       //!< \deprecated Use pe_tag_t instead
 typedef struct pe_ticket_s ticket_t;                 //!< \deprecated Use pe_ticket_t instead
 typedef enum pe_quorum_policy no_quorum_policy_t;    //!< \deprecated Use enum pe_quorum_policy instead
+
+#ifndef PCMK__NO_COMPAT
+/* Everything here is deprecated and kept only for public API backward
+ * compatibility. It will be moved to compatibility.h when 2.1.0 is released.
+ */
+
+//!< \deprecated Use pe_tag_t instead
+typedef struct pe_tag_s tag_t;
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -506,7 +506,6 @@ typedef struct pe_action_wrapper_s {
 } pe_action_wrapper_t;
 
 // Deprecated type aliases
-typedef struct pe_action_s action_t;                 //!< \deprecated Use pe_action_t instead
 typedef struct pe_action_wrapper_s action_wrapper_t; //!< \deprecated Use pe_action_wrapper_t instead
 typedef struct pe_node_s node_t;                     //!< \deprecated Use pe_node_t instead
 typedef struct pe_resource_s resource_t;             //!< \deprecated Use pe_resource_t instead
@@ -518,6 +517,8 @@ typedef enum pe_quorum_policy no_quorum_policy_t;    //!< \deprecated Use enum p
  * compatibility. It will be moved to compatibility.h when 2.1.0 is released.
  */
 
+//!< \deprecated Use pe_action_t instead
+typedef struct pe_action_s action_t;
 //!< \deprecated Use pe_tag_t instead
 typedef struct pe_tag_s tag_t;
 

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -508,7 +508,6 @@ typedef struct pe_action_wrapper_s {
 // Deprecated type aliases
 typedef struct pe_node_s node_t;                     //!< \deprecated Use pe_node_t instead
 typedef struct pe_resource_s resource_t;             //!< \deprecated Use pe_resource_t instead
-typedef struct pe_ticket_s ticket_t;                 //!< \deprecated Use pe_ticket_t instead
 
 #ifndef PCMK__NO_COMPAT
 /* Everything here is deprecated and kept only for public API backward
@@ -523,6 +522,8 @@ typedef struct pe_action_wrapper_s action_wrapper_t;
 typedef enum pe_quorum_policy no_quorum_policy_t;
 //!< \deprecated Use pe_tag_t instead
 typedef struct pe_tag_s tag_t;
+//!< \deprecated Use pe_ticket_t instead
+typedef struct pe_ticket_s ticket_t;
 
 #endif
 

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -506,7 +506,6 @@ typedef struct pe_action_wrapper_s {
 } pe_action_wrapper_t;
 
 // Deprecated type aliases
-typedef struct pe_action_wrapper_s action_wrapper_t; //!< \deprecated Use pe_action_wrapper_t instead
 typedef struct pe_node_s node_t;                     //!< \deprecated Use pe_node_t instead
 typedef struct pe_resource_s resource_t;             //!< \deprecated Use pe_resource_t instead
 typedef struct pe_ticket_s ticket_t;                 //!< \deprecated Use pe_ticket_t instead
@@ -519,6 +518,8 @@ typedef enum pe_quorum_policy no_quorum_policy_t;    //!< \deprecated Use enum p
 
 //!< \deprecated Use pe_action_t instead
 typedef struct pe_action_s action_t;
+//!< \deprecated Use pe_action_wrapper_t instead
+typedef struct pe_action_wrapper_s action_wrapper_t;
 //!< \deprecated Use pe_tag_t instead
 typedef struct pe_tag_s tag_t;
 

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -505,9 +505,6 @@ typedef struct pe_action_wrapper_s {
     pe_action_t *action;
 } pe_action_wrapper_t;
 
-// Deprecated type aliases
-typedef struct pe_node_s node_t;                     //!< \deprecated Use pe_node_t instead
-
 #ifndef PCMK__NO_COMPAT
 /* Everything here is deprecated and kept only for public API backward
  * compatibility. It will be moved to compatibility.h when 2.1.0 is released.
@@ -517,6 +514,8 @@ typedef struct pe_node_s node_t;                     //!< \deprecated Use pe_nod
 typedef struct pe_action_s action_t;
 //!< \deprecated Use pe_action_wrapper_t instead
 typedef struct pe_action_wrapper_s action_wrapper_t;
+//!< \deprecated Use pe_node_t instead
+typedef struct pe_node_s node_t;
 //!< \deprecated Use enum pe_quorum_policy instead
 typedef enum pe_quorum_policy no_quorum_policy_t;
 //!< \deprecated use pe_resource_t instead

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -509,7 +509,6 @@ typedef struct pe_action_wrapper_s {
 typedef struct pe_node_s node_t;                     //!< \deprecated Use pe_node_t instead
 typedef struct pe_resource_s resource_t;             //!< \deprecated Use pe_resource_t instead
 typedef struct pe_ticket_s ticket_t;                 //!< \deprecated Use pe_ticket_t instead
-typedef enum pe_quorum_policy no_quorum_policy_t;    //!< \deprecated Use enum pe_quorum_policy instead
 
 #ifndef PCMK__NO_COMPAT
 /* Everything here is deprecated and kept only for public API backward
@@ -520,6 +519,8 @@ typedef enum pe_quorum_policy no_quorum_policy_t;    //!< \deprecated Use enum p
 typedef struct pe_action_s action_t;
 //!< \deprecated Use pe_action_wrapper_t instead
 typedef struct pe_action_wrapper_s action_wrapper_t;
+//!< \deprecated Use enum pe_quorum_policy instead
+typedef enum pe_quorum_policy no_quorum_policy_t;
 //!< \deprecated Use pe_tag_t instead
 typedef struct pe_tag_s tag_t;
 

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -507,7 +507,6 @@ typedef struct pe_action_wrapper_s {
 
 // Deprecated type aliases
 typedef struct pe_node_s node_t;                     //!< \deprecated Use pe_node_t instead
-typedef struct pe_resource_s resource_t;             //!< \deprecated Use pe_resource_t instead
 
 #ifndef PCMK__NO_COMPAT
 /* Everything here is deprecated and kept only for public API backward
@@ -520,6 +519,8 @@ typedef struct pe_action_s action_t;
 typedef struct pe_action_wrapper_s action_wrapper_t;
 //!< \deprecated Use enum pe_quorum_policy instead
 typedef enum pe_quorum_policy no_quorum_policy_t;
+//!< \deprecated use pe_resource_t instead
+typedef struct pe_resource_s resource_t;
 //!< \deprecated Use pe_tag_t instead
 typedef struct pe_tag_s tag_t;
 //!< \deprecated Use pe_ticket_t instead

--- a/include/crm/pengine/remote_internal.h
+++ b/include/crm/pengine/remote_internal.h
@@ -25,8 +25,8 @@ gboolean pe__is_guest_or_remote_node(pe_node_t *node);
 gboolean pe__resource_is_remote_conn(pe_resource_t *rsc, pe_working_set_t *data_set);
 pe_resource_t *pe__resource_contains_guest_node(const pe_working_set_t *data_set,
                                                 const pe_resource_t *rsc);
-void pe_foreach_guest_node(const pe_working_set_t *data_set, const node_t *host,
-                           void (*helper)(const node_t*, void*), void *user_data);
+void pe_foreach_guest_node(const pe_working_set_t *data_set, const pe_node_t *host,
+                           void (*helper)(const pe_node_t*, void*), void *user_data);
 xmlNode *pe_create_remote_xml(xmlNode *parent, const char *uname,
                               const char *container_id, const char *migrateable,
                               const char *is_managed, const char *start_timeout,

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -20,9 +20,9 @@
 struct resource_alloc_functions_s {
     GHashTable *(*merge_weights) (pe_resource_t *, const char *, GHashTable *, const char *, float,
                                   enum pe_weights);
-    node_t *(*allocate) (pe_resource_t *, node_t *, pe_working_set_t *);
+    pe_node_t *(*allocate) (pe_resource_t *, pe_node_t *, pe_working_set_t *);
     void (*create_actions) (pe_resource_t *, pe_working_set_t *);
-     gboolean(*create_probe) (pe_resource_t *, node_t *, pe_action_t *, gboolean, pe_working_set_t *);
+     gboolean(*create_probe) (pe_resource_t *, pe_node_t *, pe_action_t *, gboolean, pe_working_set_t *);
     void (*internal_constraints) (pe_resource_t *, pe_working_set_t *);
 
     void (*rsc_colocation_lh) (pe_resource_t *, pe_resource_t *,
@@ -32,7 +32,7 @@ struct resource_alloc_functions_s {
 
     void (*rsc_location) (pe_resource_t *, pe__location_t *);
 
-    enum pe_action_flags (*action_flags) (pe_action_t *, node_t *);
+    enum pe_action_flags (*action_flags) (pe_action_t *, pe_node_t *);
     enum pe_graph_flags (*update_actions) (pe_action_t *, pe_action_t *,
                                            pe_node_t *, enum pe_action_flags,
                                            enum pe_action_flags,
@@ -63,11 +63,11 @@ void native_rsc_colocation_rh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                               pe_working_set_t *data_set);
 extern void rsc_ticket_constraint(pe_resource_t * lh_rsc, rsc_ticket_t * rsc_ticket,
                                   pe_working_set_t * data_set);
-extern enum pe_action_flags native_action_flags(pe_action_t * action, node_t * node);
+extern enum pe_action_flags native_action_flags(pe_action_t * action, pe_node_t * node);
 
 void native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern void native_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
-extern gboolean native_create_probe(pe_resource_t * rsc, node_t * node, pe_action_t * complete,
+extern gboolean native_create_probe(pe_resource_t * rsc, pe_node_t * node, pe_action_t * complete,
                                     gboolean force, pe_working_set_t * data_set);
 extern void native_append_meta(pe_resource_t * rsc, xmlNode * xml);
 
@@ -81,7 +81,7 @@ void group_rsc_colocation_lh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
 void group_rsc_colocation_rh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                              rsc_colocation_t *constraint,
                              pe_working_set_t *data_set);
-extern enum pe_action_flags group_action_flags(pe_action_t * action, node_t * node);
+extern enum pe_action_flags group_action_flags(pe_action_t * action, pe_node_t * node);
 void group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern void group_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
 extern void group_append_meta(pe_resource_t * rsc, xmlNode * xml);
@@ -120,9 +120,9 @@ void clone_rsc_colocation_rh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                              rsc_colocation_t *constraint,
                              pe_working_set_t *data_set);
 void clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
-extern enum pe_action_flags clone_action_flags(pe_action_t * action, node_t * node);
+extern enum pe_action_flags clone_action_flags(pe_action_t * action, pe_node_t * node);
 extern void clone_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
-extern gboolean clone_create_probe(pe_resource_t * rsc, node_t * node, pe_action_t * complete,
+extern gboolean clone_create_probe(pe_resource_t * rsc, pe_node_t * node, pe_action_t * complete,
                                    gboolean force, pe_working_set_t * data_set);
 extern void clone_append_meta(pe_resource_t * rsc, xmlNode * xml);
 

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -22,7 +22,7 @@ struct resource_alloc_functions_s {
                                   enum pe_weights);
     node_t *(*allocate) (resource_t *, node_t *, pe_working_set_t *);
     void (*create_actions) (resource_t *, pe_working_set_t *);
-     gboolean(*create_probe) (resource_t *, node_t *, action_t *, gboolean, pe_working_set_t *);
+     gboolean(*create_probe) (resource_t *, node_t *, pe_action_t *, gboolean, pe_working_set_t *);
     void (*internal_constraints) (resource_t *, pe_working_set_t *);
 
     void (*rsc_colocation_lh) (pe_resource_t *, pe_resource_t *,
@@ -32,7 +32,7 @@ struct resource_alloc_functions_s {
 
     void (*rsc_location) (pe_resource_t *, pe__location_t *);
 
-    enum pe_action_flags (*action_flags) (action_t *, node_t *);
+    enum pe_action_flags (*action_flags) (pe_action_t *, node_t *);
     enum pe_graph_flags (*update_actions) (pe_action_t *, pe_action_t *,
                                            pe_node_t *, enum pe_action_flags,
                                            enum pe_action_flags,
@@ -63,11 +63,11 @@ void native_rsc_colocation_rh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                               pe_working_set_t *data_set);
 extern void rsc_ticket_constraint(resource_t * lh_rsc, rsc_ticket_t * rsc_ticket,
                                   pe_working_set_t * data_set);
-extern enum pe_action_flags native_action_flags(action_t * action, node_t * node);
+extern enum pe_action_flags native_action_flags(pe_action_t * action, node_t * node);
 
 void native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern void native_expand(resource_t * rsc, pe_working_set_t * data_set);
-extern gboolean native_create_probe(resource_t * rsc, node_t * node, action_t * complete,
+extern gboolean native_create_probe(resource_t * rsc, node_t * node, pe_action_t * complete,
                                     gboolean force, pe_working_set_t * data_set);
 extern void native_append_meta(resource_t * rsc, xmlNode * xml);
 
@@ -81,7 +81,7 @@ void group_rsc_colocation_lh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
 void group_rsc_colocation_rh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                              rsc_colocation_t *constraint,
                              pe_working_set_t *data_set);
-extern enum pe_action_flags group_action_flags(action_t * action, node_t * node);
+extern enum pe_action_flags group_action_flags(pe_action_t * action, node_t * node);
 void group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern void group_expand(resource_t * rsc, pe_working_set_t * data_set);
 extern void group_append_meta(resource_t * rsc, xmlNode * xml);
@@ -120,9 +120,9 @@ void clone_rsc_colocation_rh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                              rsc_colocation_t *constraint,
                              pe_working_set_t *data_set);
 void clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
-extern enum pe_action_flags clone_action_flags(action_t * action, node_t * node);
+extern enum pe_action_flags clone_action_flags(pe_action_t * action, node_t * node);
 extern void clone_expand(resource_t * rsc, pe_working_set_t * data_set);
-extern gboolean clone_create_probe(resource_t * rsc, node_t * node, action_t * complete,
+extern gboolean clone_create_probe(resource_t * rsc, node_t * node, pe_action_t * complete,
                                    gboolean force, pe_working_set_t * data_set);
 extern void clone_append_meta(resource_t * rsc, xmlNode * xml);
 
@@ -152,7 +152,7 @@ void LogActions(resource_t * rsc, pe_working_set_t * data_set, gboolean terminal
 void pcmk__bundle_log_actions(pe_resource_t *rsc, pe_working_set_t *data_set,
                               gboolean terminal);
 
-extern void rsc_stonith_ordering(resource_t * rsc, action_t * stonith_op,
+extern void rsc_stonith_ordering(resource_t * rsc, pe_action_t * stonith_op,
                                  pe_working_set_t * data_set);
 
 enum pe_graph_flags native_update_actions(pe_action_t *first, pe_action_t *then,
@@ -175,7 +175,7 @@ enum pe_graph_flags pcmk__multi_update_actions(pe_action_t *first,
                                                enum pe_ordering type,
                                                pe_working_set_t *data_set);
 
-gboolean update_action_flags(action_t * action, enum pe_action_flags flags, const char *source, int line);
+gboolean update_action_flags(pe_action_t * action, enum pe_action_flags flags, const char *source, int line);
 gboolean update_action(pe_action_t *action, pe_working_set_t *data_set);
 void complex_set_cmds(resource_t * rsc);
 void pcmk__log_transition_summary(const char *filename);

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -18,12 +18,12 @@
 #  include <pcmki/pcmki_scheduler.h>
 
 struct resource_alloc_functions_s {
-    GHashTable *(*merge_weights) (resource_t *, const char *, GHashTable *, const char *, float,
+    GHashTable *(*merge_weights) (pe_resource_t *, const char *, GHashTable *, const char *, float,
                                   enum pe_weights);
-    node_t *(*allocate) (resource_t *, node_t *, pe_working_set_t *);
-    void (*create_actions) (resource_t *, pe_working_set_t *);
-     gboolean(*create_probe) (resource_t *, node_t *, pe_action_t *, gboolean, pe_working_set_t *);
-    void (*internal_constraints) (resource_t *, pe_working_set_t *);
+    node_t *(*allocate) (pe_resource_t *, node_t *, pe_working_set_t *);
+    void (*create_actions) (pe_resource_t *, pe_working_set_t *);
+     gboolean(*create_probe) (pe_resource_t *, node_t *, pe_action_t *, gboolean, pe_working_set_t *);
+    void (*internal_constraints) (pe_resource_t *, pe_working_set_t *);
 
     void (*rsc_colocation_lh) (pe_resource_t *, pe_resource_t *,
                                rsc_colocation_t *, pe_working_set_t *);
@@ -39,8 +39,8 @@ struct resource_alloc_functions_s {
                                            enum pe_ordering,
                                            pe_working_set_t *data_set);
 
-    void (*expand) (resource_t *, pe_working_set_t *);
-    void (*append_meta) (resource_t * rsc, xmlNode * xml);
+    void (*expand) (pe_resource_t *, pe_working_set_t *);
+    void (*append_meta) (pe_resource_t * rsc, xmlNode * xml);
 };
 
 GHashTable *pcmk__native_merge_weights(pe_resource_t *rsc, const char *rhs,
@@ -53,28 +53,28 @@ GHashTable *pcmk__group_merge_weights(pe_resource_t *rsc, const char *rhs,
 
 pe_node_t *pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *preferred,
                                  pe_working_set_t *data_set);
-extern void native_create_actions(resource_t * rsc, pe_working_set_t * data_set);
-extern void native_internal_constraints(resource_t * rsc, pe_working_set_t * data_set);
+extern void native_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set);
+extern void native_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set);
 void native_rsc_colocation_lh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                               rsc_colocation_t *constraint,
                               pe_working_set_t *data_set);
 void native_rsc_colocation_rh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                               rsc_colocation_t *constraint,
                               pe_working_set_t *data_set);
-extern void rsc_ticket_constraint(resource_t * lh_rsc, rsc_ticket_t * rsc_ticket,
+extern void rsc_ticket_constraint(pe_resource_t * lh_rsc, rsc_ticket_t * rsc_ticket,
                                   pe_working_set_t * data_set);
 extern enum pe_action_flags native_action_flags(pe_action_t * action, node_t * node);
 
 void native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
-extern void native_expand(resource_t * rsc, pe_working_set_t * data_set);
-extern gboolean native_create_probe(resource_t * rsc, node_t * node, pe_action_t * complete,
+extern void native_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
+extern gboolean native_create_probe(pe_resource_t * rsc, node_t * node, pe_action_t * complete,
                                     gboolean force, pe_working_set_t * data_set);
-extern void native_append_meta(resource_t * rsc, xmlNode * xml);
+extern void native_append_meta(pe_resource_t * rsc, xmlNode * xml);
 
 pe_node_t *pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *preferred,
                                 pe_working_set_t *data_set);
-extern void group_create_actions(resource_t * rsc, pe_working_set_t * data_set);
-extern void group_internal_constraints(resource_t * rsc, pe_working_set_t * data_set);
+extern void group_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set);
+extern void group_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set);
 void group_rsc_colocation_lh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                              rsc_colocation_t *constraint,
                              pe_working_set_t *data_set);
@@ -83,8 +83,8 @@ void group_rsc_colocation_rh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                              pe_working_set_t *data_set);
 extern enum pe_action_flags group_action_flags(pe_action_t * action, node_t * node);
 void group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
-extern void group_expand(resource_t * rsc, pe_working_set_t * data_set);
-extern void group_append_meta(resource_t * rsc, xmlNode * xml);
+extern void group_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
+extern void group_append_meta(pe_resource_t * rsc, xmlNode * xml);
 
 pe_node_t *pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *preferred,
                                  pe_working_set_t *data_set);
@@ -111,8 +111,8 @@ void pcmk__bundle_append_meta(pe_resource_t *rsc, xmlNode *xml);
 
 pe_node_t *pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *preferred,
                                 pe_working_set_t *data_set);
-extern void clone_create_actions(resource_t * rsc, pe_working_set_t * data_set);
-extern void clone_internal_constraints(resource_t * rsc, pe_working_set_t * data_set);
+extern void clone_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set);
+extern void clone_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set);
 void clone_rsc_colocation_lh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                              rsc_colocation_t *constraint,
                              pe_working_set_t *data_set);
@@ -121,18 +121,18 @@ void clone_rsc_colocation_rh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                              pe_working_set_t *data_set);
 void clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern enum pe_action_flags clone_action_flags(pe_action_t * action, node_t * node);
-extern void clone_expand(resource_t * rsc, pe_working_set_t * data_set);
-extern gboolean clone_create_probe(resource_t * rsc, node_t * node, pe_action_t * complete,
+extern void clone_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
+extern gboolean clone_create_probe(pe_resource_t * rsc, node_t * node, pe_action_t * complete,
                                    gboolean force, pe_working_set_t * data_set);
-extern void clone_append_meta(resource_t * rsc, xmlNode * xml);
+extern void clone_append_meta(pe_resource_t * rsc, xmlNode * xml);
 
-void apply_master_prefs(resource_t *rsc);
+void apply_master_prefs(pe_resource_t *rsc);
 pe_node_t *pcmk__set_instance_roles(pe_resource_t *rsc,
                                     pe_working_set_t *data_set);
-void create_promotable_actions(resource_t *rsc, pe_working_set_t *data_set);
-void promote_demote_constraints(resource_t *rsc, pe_working_set_t *data_set);
-void promotable_constraints(resource_t *rsc, pe_working_set_t *data_set);
-void promotable_colocation_rh(resource_t *lh_rsc, resource_t *rh_rsc,
+void create_promotable_actions(pe_resource_t *rsc, pe_working_set_t *data_set);
+void promote_demote_constraints(pe_resource_t *rsc, pe_working_set_t *data_set);
+void promotable_constraints(pe_resource_t *rsc, pe_working_set_t *data_set);
+void promotable_colocation_rh(pe_resource_t *lh_rsc, pe_resource_t *rh_rsc,
                               rsc_colocation_t *constraint,
                               pe_working_set_t *data_set);
 
@@ -148,11 +148,11 @@ extern gboolean unpack_location(xmlNode * xml_obj, pe_working_set_t * data_set);
 extern gboolean unpack_rsc_ticket(xmlNode * xml_obj, pe_working_set_t * data_set);
 
 void LogNodeActions(pe_working_set_t * data_set, gboolean terminal);
-void LogActions(resource_t * rsc, pe_working_set_t * data_set, gboolean terminal);
+void LogActions(pe_resource_t * rsc, pe_working_set_t * data_set, gboolean terminal);
 void pcmk__bundle_log_actions(pe_resource_t *rsc, pe_working_set_t *data_set,
                               gboolean terminal);
 
-extern void rsc_stonith_ordering(resource_t * rsc, pe_action_t * stonith_op,
+extern void rsc_stonith_ordering(pe_resource_t * rsc, pe_action_t * stonith_op,
                                  pe_working_set_t * data_set);
 
 enum pe_graph_flags native_update_actions(pe_action_t *first, pe_action_t *then,
@@ -177,8 +177,8 @@ enum pe_graph_flags pcmk__multi_update_actions(pe_action_t *first,
 
 gboolean update_action_flags(pe_action_t * action, enum pe_action_flags flags, const char *source, int line);
 gboolean update_action(pe_action_t *action, pe_working_set_t *data_set);
-void complex_set_cmds(resource_t * rsc);
+void complex_set_cmds(pe_resource_t * rsc);
 void pcmk__log_transition_summary(const char *filename);
 void clone_create_pseudo_actions(
-    resource_t * rsc, GListPtr children, notify_data_t **start_notify, notify_data_t **stop_notify,  pe_working_set_t * data_set);
+    pe_resource_t * rsc, GListPtr children, notify_data_t **start_notify, notify_data_t **stop_notify,  pe_working_set_t * data_set);
 #endif

--- a/include/pcmki/pcmki_sched_notif.h
+++ b/include/pcmki/pcmki_sched_notif.h
@@ -22,23 +22,23 @@
 
 #  include <crm/pengine/internal.h>
 
-notify_data_t * create_notification_boundaries(resource_t *rsc,
+notify_data_t * create_notification_boundaries(pe_resource_t *rsc,
                                                const char *action,
                                                pe_action_t *start, pe_action_t *end,
                                                pe_working_set_t *data_set);
 
-void collect_notification_data(resource_t *rsc, gboolean state,
+void collect_notification_data(pe_resource_t *rsc, gboolean state,
                                gboolean activity, notify_data_t *n_data);
 
-gboolean expand_notification_data(resource_t *rsc, notify_data_t *n_data,
+gboolean expand_notification_data(pe_resource_t *rsc, notify_data_t *n_data,
                                   pe_working_set_t *data_set);
 
-void create_notifications(resource_t *rsc, notify_data_t *n_data,
+void create_notifications(pe_resource_t *rsc, notify_data_t *n_data,
                           pe_working_set_t *data_set);
 
 void free_notification_data(notify_data_t *n_data);
 
-void create_secondary_notification(pe_action_t *action, resource_t *rsc,
+void create_secondary_notification(pe_action_t *action, pe_resource_t *rsc,
                                    pe_action_t *stonith_op,
                                    pe_working_set_t *data_set);
 

--- a/include/pcmki/pcmki_sched_notif.h
+++ b/include/pcmki/pcmki_sched_notif.h
@@ -24,7 +24,7 @@
 
 notify_data_t * create_notification_boundaries(resource_t *rsc,
                                                const char *action,
-                                               action_t *start, action_t *end,
+                                               pe_action_t *start, pe_action_t *end,
                                                pe_working_set_t *data_set);
 
 void collect_notification_data(resource_t *rsc, gboolean state,

--- a/include/pcmki/pcmki_sched_utils.h
+++ b/include/pcmki/pcmki_sched_utils.h
@@ -46,7 +46,7 @@ extern gboolean native_assign_node(resource_t * rsc, GListPtr candidates, node_t
 void native_deallocate(resource_t * rsc);
 
 extern void log_action(unsigned int log_level, const char *pre_text,
-                       action_t * action, gboolean details);
+                       pe_action_t * action, gboolean details);
 
 gboolean can_run_any(GHashTable * nodes);
 pe_resource_t *find_compatible_child(pe_resource_t *local_child,
@@ -57,8 +57,8 @@ resource_t *find_compatible_child_by_node(resource_t * local_child, node_t * loc
                                           enum rsc_role_e filter, gboolean current);
 gboolean is_child_compatible(resource_t *child_rsc, node_t * local_node, enum rsc_role_e filter, gboolean current);
 bool assign_node(resource_t * rsc, node_t * node, gboolean force);
-enum pe_action_flags summary_action_flags(action_t * action, GListPtr children, node_t * node);
-enum action_tasks clone_child_action(action_t * action);
+enum pe_action_flags summary_action_flags(pe_action_t * action, GListPtr children, node_t * node);
+enum action_tasks clone_child_action(pe_action_t * action);
 int copies_per_node(resource_t * rsc);
 
 enum filter_colocation_res {

--- a/include/pcmki/pcmki_sched_utils.h
+++ b/include/pcmki/pcmki_sched_utils.h
@@ -40,8 +40,8 @@ extern gboolean rsc_ticket_new(const char *id, pe_resource_t * rsc_lh, pe_ticket
 GList *sort_nodes_by_weight(GList *nodes, pe_node_t *active_node,
                             pe_working_set_t *data_set);
 
-extern gboolean can_run_resources(const node_t * node);
-extern gboolean native_assign_node(pe_resource_t * rsc, GListPtr candidates, node_t * chosen,
+extern gboolean can_run_resources(const pe_node_t * node);
+extern gboolean native_assign_node(pe_resource_t * rsc, GListPtr candidates, pe_node_t * chosen,
                                    gboolean force);
 void native_deallocate(pe_resource_t * rsc);
 
@@ -53,11 +53,11 @@ pe_resource_t *find_compatible_child(pe_resource_t *local_child,
                                      pe_resource_t *rsc, enum rsc_role_e filter,
                                      gboolean current,
                                      pe_working_set_t *data_set);
-pe_resource_t *find_compatible_child_by_node(pe_resource_t * local_child, node_t * local_node, pe_resource_t * rsc,
+pe_resource_t *find_compatible_child_by_node(pe_resource_t * local_child, pe_node_t * local_node, pe_resource_t * rsc,
                                              enum rsc_role_e filter, gboolean current);
-gboolean is_child_compatible(pe_resource_t *child_rsc, node_t * local_node, enum rsc_role_e filter, gboolean current);
-bool assign_node(pe_resource_t * rsc, node_t * node, gboolean force);
-enum pe_action_flags summary_action_flags(pe_action_t * action, GListPtr children, node_t * node);
+gboolean is_child_compatible(pe_resource_t *child_rsc, pe_node_t * local_node, enum rsc_role_e filter, gboolean current);
+bool assign_node(pe_resource_t * rsc, pe_node_t * node, gboolean force);
+enum pe_action_flags summary_action_flags(pe_action_t * action, GListPtr children, pe_node_t * node);
 enum action_tasks clone_child_action(pe_action_t * action);
 int copies_per_node(pe_resource_t * rsc);
 
@@ -71,11 +71,11 @@ extern enum filter_colocation_res
 filter_colocation_constraint(pe_resource_t * rsc_lh, pe_resource_t * rsc_rh,
                              rsc_colocation_t * constraint, gboolean preview);
 
-extern int compare_capacity(const node_t * node1, const node_t * node2);
+extern int compare_capacity(const pe_node_t * node1, const pe_node_t * node2);
 extern void calculate_utilization(GHashTable * current_utilization,
                                   GHashTable * utilization, gboolean plus);
 
-extern void process_utilization(pe_resource_t * rsc, node_t ** prefer, pe_working_set_t * data_set);
+extern void process_utilization(pe_resource_t * rsc, pe_node_t ** prefer, pe_working_set_t * data_set);
 pe_action_t *create_pseudo_resource_op(pe_resource_t * rsc, const char *task, bool optional, bool runnable, pe_working_set_t *data_set);
 pe_action_t *pe_cancel_op(pe_resource_t *rsc, const char *name,
                           guint interval_ms, pe_node_t *node,

--- a/include/pcmki/pcmki_sched_utils.h
+++ b/include/pcmki/pcmki_sched_utils.h
@@ -29,11 +29,11 @@ pe__location_t *rsc2node_new(const char *id, pe_resource_t *rsc, int weight,
                              pe_working_set_t *data_set);
 
 extern gboolean rsc_colocation_new(const char *id, const char *node_attr, int score,
-                                   resource_t * rsc_lh, resource_t * rsc_rh,
+                                   pe_resource_t * rsc_lh, pe_resource_t * rsc_rh,
                                    const char *state_lh, const char *state_rh,
                                    pe_working_set_t * data_set);
 
-extern gboolean rsc_ticket_new(const char *id, resource_t * rsc_lh, pe_ticket_t * ticket,
+extern gboolean rsc_ticket_new(const char *id, pe_resource_t * rsc_lh, pe_ticket_t * ticket,
                                const char *state_lh, const char *loss_policy,
                                pe_working_set_t * data_set);
 
@@ -41,9 +41,9 @@ GList *sort_nodes_by_weight(GList *nodes, pe_node_t *active_node,
                             pe_working_set_t *data_set);
 
 extern gboolean can_run_resources(const node_t * node);
-extern gboolean native_assign_node(resource_t * rsc, GListPtr candidates, node_t * chosen,
+extern gboolean native_assign_node(pe_resource_t * rsc, GListPtr candidates, node_t * chosen,
                                    gboolean force);
-void native_deallocate(resource_t * rsc);
+void native_deallocate(pe_resource_t * rsc);
 
 extern void log_action(unsigned int log_level, const char *pre_text,
                        pe_action_t * action, gboolean details);
@@ -53,13 +53,13 @@ pe_resource_t *find_compatible_child(pe_resource_t *local_child,
                                      pe_resource_t *rsc, enum rsc_role_e filter,
                                      gboolean current,
                                      pe_working_set_t *data_set);
-resource_t *find_compatible_child_by_node(resource_t * local_child, node_t * local_node, resource_t * rsc,
-                                          enum rsc_role_e filter, gboolean current);
-gboolean is_child_compatible(resource_t *child_rsc, node_t * local_node, enum rsc_role_e filter, gboolean current);
-bool assign_node(resource_t * rsc, node_t * node, gboolean force);
+pe_resource_t *find_compatible_child_by_node(pe_resource_t * local_child, node_t * local_node, pe_resource_t * rsc,
+                                             enum rsc_role_e filter, gboolean current);
+gboolean is_child_compatible(pe_resource_t *child_rsc, node_t * local_node, enum rsc_role_e filter, gboolean current);
+bool assign_node(pe_resource_t * rsc, node_t * node, gboolean force);
 enum pe_action_flags summary_action_flags(pe_action_t * action, GListPtr children, node_t * node);
 enum action_tasks clone_child_action(pe_action_t * action);
-int copies_per_node(resource_t * rsc);
+int copies_per_node(pe_resource_t * rsc);
 
 enum filter_colocation_res {
     influence_nothing = 0,
@@ -68,15 +68,15 @@ enum filter_colocation_res {
 };
 
 extern enum filter_colocation_res
-filter_colocation_constraint(resource_t * rsc_lh, resource_t * rsc_rh,
+filter_colocation_constraint(pe_resource_t * rsc_lh, pe_resource_t * rsc_rh,
                              rsc_colocation_t * constraint, gboolean preview);
 
 extern int compare_capacity(const node_t * node1, const node_t * node2);
 extern void calculate_utilization(GHashTable * current_utilization,
                                   GHashTable * utilization, gboolean plus);
 
-extern void process_utilization(resource_t * rsc, node_t ** prefer, pe_working_set_t * data_set);
-pe_action_t *create_pseudo_resource_op(resource_t * rsc, const char *task, bool optional, bool runnable, pe_working_set_t *data_set);
+extern void process_utilization(pe_resource_t * rsc, node_t ** prefer, pe_working_set_t * data_set);
+pe_action_t *create_pseudo_resource_op(pe_resource_t * rsc, const char *task, bool optional, bool runnable, pe_working_set_t *data_set);
 pe_action_t *pe_cancel_op(pe_resource_t *rsc, const char *name,
                           guint interval_ms, pe_node_t *node,
                           pe_working_set_t *data_set);

--- a/include/pcmki/pcmki_sched_utils.h
+++ b/include/pcmki/pcmki_sched_utils.h
@@ -33,7 +33,7 @@ extern gboolean rsc_colocation_new(const char *id, const char *node_attr, int sc
                                    const char *state_lh, const char *state_rh,
                                    pe_working_set_t * data_set);
 
-extern gboolean rsc_ticket_new(const char *id, resource_t * rsc_lh, ticket_t * ticket,
+extern gboolean rsc_ticket_new(const char *id, resource_t * rsc_lh, pe_ticket_t * ticket,
                                const char *state_lh, const char *loss_policy,
                                pe_working_set_t * data_set);
 

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -79,13 +79,13 @@ extern gboolean summary(GListPtr resources);
 
 extern gboolean unpack_constraints(xmlNode * xml_constraints, pe_working_set_t * data_set);
 
-extern gboolean shutdown_constraints(node_t * node, action_t * shutdown_op,
+extern gboolean shutdown_constraints(node_t * node, pe_action_t * shutdown_op,
                                      pe_working_set_t * data_set);
 
 void pcmk__order_vs_fence(pe_action_t *stonith_op, pe_working_set_t *data_set);
 
-extern int custom_action_order(resource_t * lh_rsc, char *lh_task, action_t * lh_action,
-                               resource_t * rh_rsc, char *rh_task, action_t * rh_action,
+extern int custom_action_order(resource_t * lh_rsc, char *lh_task, pe_action_t * lh_action,
+                               resource_t * rh_rsc, char *rh_task, pe_action_t * rh_action,
                                enum pe_ordering type, pe_working_set_t * data_set);
 
 extern int new_rsc_order(resource_t * lh_rsc, const char *lh_task,
@@ -97,7 +97,7 @@ extern int new_rsc_order(resource_t * lh_rsc, const char *lh_task,
 #  define order_stop_stop(rsc1, rsc2, type)				\
     new_rsc_order(rsc1, CRMD_ACTION_STOP, rsc2, CRMD_ACTION_STOP, type, data_set)
 
-extern void graph_element_from_action(action_t * action, pe_working_set_t * data_set);
+extern void graph_element_from_action(pe_action_t * action, pe_working_set_t * data_set);
 extern void add_maintenance_update(pe_working_set_t *data_set);
 xmlNode *pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input,
                                 crm_time_t *now);

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -40,8 +40,8 @@ enum pe_weights {
 struct rsc_colocation_s {
     const char *id;
     const char *node_attribute;
-    resource_t *rsc_lh;
-    resource_t *rsc_rh;
+    pe_resource_t *rsc_lh;
+    pe_resource_t *rsc_rh;
 
     int role_lh;
     int role_rh;
@@ -58,7 +58,7 @@ enum loss_ticket_policy_e {
 
 struct rsc_ticket_s {
     const char *id;
-    resource_t *rsc_lh;
+    pe_resource_t *rsc_lh;
     pe_ticket_t *ticket;
     enum loss_ticket_policy_e loss_policy;
 
@@ -84,12 +84,12 @@ extern gboolean shutdown_constraints(node_t * node, pe_action_t * shutdown_op,
 
 void pcmk__order_vs_fence(pe_action_t *stonith_op, pe_working_set_t *data_set);
 
-extern int custom_action_order(resource_t * lh_rsc, char *lh_task, pe_action_t * lh_action,
-                               resource_t * rh_rsc, char *rh_task, pe_action_t * rh_action,
+extern int custom_action_order(pe_resource_t * lh_rsc, char *lh_task, pe_action_t * lh_action,
+                               pe_resource_t * rh_rsc, char *rh_task, pe_action_t * rh_action,
                                enum pe_ordering type, pe_working_set_t * data_set);
 
-extern int new_rsc_order(resource_t * lh_rsc, const char *lh_task,
-                         resource_t * rh_rsc, const char *rh_task,
+extern int new_rsc_order(pe_resource_t * lh_rsc, const char *lh_task,
+                         pe_resource_t * rh_rsc, const char *rh_task,
                          enum pe_ordering type, pe_working_set_t * data_set);
 
 #  define order_start_start(rsc1,rsc2, type)				\

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -79,7 +79,7 @@ extern gboolean summary(GListPtr resources);
 
 extern gboolean unpack_constraints(xmlNode * xml_constraints, pe_working_set_t * data_set);
 
-extern gboolean shutdown_constraints(node_t * node, pe_action_t * shutdown_op,
+extern gboolean shutdown_constraints(pe_node_t * node, pe_action_t * shutdown_op,
                                      pe_working_set_t * data_set);
 
 void pcmk__order_vs_fence(pe_action_t *stonith_op, pe_working_set_t *data_set);

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -59,7 +59,7 @@ enum loss_ticket_policy_e {
 struct rsc_ticket_s {
     const char *id;
     resource_t *rsc_lh;
-    ticket_t *ticket;
+    pe_ticket_t *ticket;
     enum loss_ticket_policy_e loss_policy;
 
     int role_lh;

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -2747,7 +2747,7 @@ order_then_probes(pe_working_set_t * data_set)
         probes = pe__resource_actions(rsc, NULL, RSC_STATUS, FALSE);
 
         for (actions = start->actions_before; actions != NULL; actions = actions->next) {
-            action_wrapper_t *before = (action_wrapper_t *) actions->data;
+            pe_action_wrapper_t *before = (pe_action_wrapper_t *) actions->data;
 
             GListPtr pIter = NULL;
             pe_action_t *first = before->action;
@@ -2756,7 +2756,7 @@ order_then_probes(pe_working_set_t * data_set)
             if(first->required_runnable_before) {
                 GListPtr clone_actions = NULL;
                 for (clone_actions = first->actions_before; clone_actions != NULL; clone_actions = clone_actions->next) {
-                    before = (action_wrapper_t *) clone_actions->data;
+                    before = (pe_action_wrapper_t *) clone_actions->data;
 
                     crm_trace("Testing %s -> %s (%p) for %s", first->uuid, before->action->uuid, before->action->rsc, start->uuid);
 

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -59,7 +59,7 @@ get_containers_or_children(pe_resource_t *rsc)
 }
 
 static bool
-migration_threshold_reached(pe_resource_t *rsc, node_t *node,
+migration_threshold_reached(pe_resource_t *rsc, pe_node_t *node,
                             pe_working_set_t *data_set)
 {
     int fail_count, countdown;
@@ -397,7 +397,7 @@ compatible_replica(pe_resource_t *rsc_lh, pe_resource_t *rsc,
 {
     GListPtr scratch = NULL;
     pe_resource_t *pair = NULL;
-    node_t *active_node_lh = NULL;
+    pe_node_t *active_node_lh = NULL;
 
     active_node_lh = rsc_lh->fns->location(rsc_lh, NULL, current);
     if (active_node_lh) {
@@ -409,7 +409,7 @@ compatible_replica(pe_resource_t *rsc_lh, pe_resource_t *rsc,
     scratch = sort_nodes_by_weight(scratch, NULL, data_set);
 
     for (GListPtr gIter = scratch; gIter != NULL; gIter = gIter->next) {
-        node_t *node = (node_t *) gIter->data;
+        pe_node_t *node = (pe_node_t *) gIter->data;
 
         pair = compatible_replica_for_node(rsc_lh, node, rsc, filter, current);
         if (pair) {
@@ -522,8 +522,8 @@ pcmk__bundle_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc,
                                                         constraint, data_set);
 
         } else {
-            node_t *chosen = replica->container->fns->location(replica->container,
-                                                               NULL, FALSE);
+            pe_node_t *chosen = replica->container->fns->location(replica->container,
+                                                                  NULL, FALSE);
 
             if ((chosen == NULL)
                 || is_set_recursive(replica->container, pe_rsc_block, TRUE)) {
@@ -580,7 +580,7 @@ pcmk__bundle_action_flags(pe_action_t *action, pe_node_t *node)
 }
 
 pe_resource_t *
-find_compatible_child_by_node(pe_resource_t * local_child, node_t * local_node, pe_resource_t * rsc,
+find_compatible_child_by_node(pe_resource_t * local_child, pe_node_t * local_node, pe_resource_t * rsc,
                               enum rsc_role_e filter, gboolean current)
 {
     GListPtr gIter = NULL;

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -834,7 +834,7 @@ pcmk__multi_update_actions(pe_action_t *first, pe_action_t *then,
         for (gIter = children; gIter != NULL; gIter = gIter->next) {
             resource_t *then_child = (resource_t *) gIter->data;
             enum pe_graph_flags then_child_changed = pe_graph_none;
-            action_t *then_child_action = find_first_action(then_child->actions, NULL, then->task, node);
+            pe_action_t *then_child_action = find_first_action(then_child->actions, NULL, then->task, node);
 
             if (then_child_action) {
                 enum pe_action_flags then_child_flags = then_child->cmds->action_flags(then_child_action, node);
@@ -1031,8 +1031,8 @@ pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node,
              */
             char *probe_uuid = pcmk__op_key(replica->remote->id, RSC_STATUS,
                                                0);
-            action_t *probe = find_first_action(replica->remote->actions,
-                                                probe_uuid, NULL, node);
+            pe_action_t *probe = find_first_action(replica->remote->actions,
+                                                   probe_uuid, NULL, node);
 
             free(probe_uuid);
             if (probe) {

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -29,7 +29,7 @@ is_bundle_node(pe__bundle_variant_data_t *data, pe_node_t *node)
 }
 
 gint sort_clone_instance(gconstpointer a, gconstpointer b, gpointer data_set);
-void distribute_children(resource_t *rsc, GListPtr children, GListPtr nodes,
+void distribute_children(pe_resource_t *rsc, GListPtr children, GListPtr nodes,
                          int max, int per_host_max, pe_working_set_t * data_set);
 
 static GList *
@@ -59,7 +59,7 @@ get_containers_or_children(pe_resource_t *rsc)
 }
 
 static bool
-migration_threshold_reached(resource_t *rsc, node_t *node,
+migration_threshold_reached(pe_resource_t *rsc, node_t *node,
                             pe_working_set_t *data_set)
 {
     int fail_count, countdown;
@@ -396,7 +396,7 @@ compatible_replica(pe_resource_t *rsc_lh, pe_resource_t *rsc,
                    pe_working_set_t *data_set)
 {
     GListPtr scratch = NULL;
-    resource_t *pair = NULL;
+    pe_resource_t *pair = NULL;
     node_t *active_node_lh = NULL;
 
     active_node_lh = rsc_lh->fns->location(rsc_lh, NULL, current);
@@ -435,7 +435,7 @@ pcmk__bundle_rsc_colocation_lh(pe_resource_t *rsc, pe_resource_t *rsc_rh,
     CRM_ASSERT(FALSE);
 }
 
-int copies_per_node(resource_t * rsc) 
+int copies_per_node(pe_resource_t * rsc) 
 {
     /* Strictly speaking, there should be a 'copies_per_node' addition
      * to the resource function table and each case would be a
@@ -488,7 +488,7 @@ pcmk__bundle_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc,
         return;
 
     } else if(constraint->rsc_lh->variant > pe_group) {
-        resource_t *rh_child = compatible_replica(rsc_lh, rsc,
+        pe_resource_t *rh_child = compatible_replica(rsc_lh, rsc,
                                                   RSC_ROLE_UNKNOWN, FALSE,
                                                   data_set);
 
@@ -579,8 +579,8 @@ pcmk__bundle_action_flags(pe_action_t *action, pe_node_t *node)
     return flags;
 }
 
-resource_t *
-find_compatible_child_by_node(resource_t * local_child, node_t * local_node, resource_t * rsc,
+pe_resource_t *
+find_compatible_child_by_node(pe_resource_t * local_child, node_t * local_node, pe_resource_t * rsc,
                               enum rsc_role_e filter, gboolean current)
 {
     GListPtr gIter = NULL;
@@ -596,7 +596,7 @@ find_compatible_child_by_node(resource_t * local_child, node_t * local_node, res
 
     children = get_containers_or_children(rsc);
     for (gIter = children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         if(is_child_compatible(child_rsc, local_node, filter, current)) {
             crm_trace("Pairing %s with %s on %s",
@@ -778,7 +778,7 @@ static bool
 can_interleave_actions(pe_action_t *first, pe_action_t *then)
 {
     bool interleave = FALSE;
-    resource_t *rsc = NULL;
+    pe_resource_t *rsc = NULL;
     const char *interleave_s = NULL;
 
     if(first->rsc == NULL || then->rsc == NULL) {
@@ -832,7 +832,7 @@ pcmk__multi_update_actions(pe_action_t *first, pe_action_t *then,
         // Now any children (or containers in the case of a bundle)
         children = get_containers_or_children(then->rsc);
         for (gIter = children; gIter != NULL; gIter = gIter->next) {
-            resource_t *then_child = (resource_t *) gIter->data;
+            pe_resource_t *then_child = (pe_resource_t *) gIter->data;
             enum pe_graph_flags then_child_changed = pe_graph_none;
             pe_action_t *then_child_action = find_first_action(then_child->actions, NULL, then->task, node);
 

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -846,7 +846,7 @@ pcmk__multi_update_actions(pe_action_t *first, pe_action_t *then,
                 changed |= then_child_changed;
                 if (then_child_changed & pe_graph_updated_then) {
                     for (GListPtr lpc = then_child_action->actions_after; lpc != NULL; lpc = lpc->next) {
-                        action_wrapper_t *next = (action_wrapper_t *) lpc->data;
+                        pe_action_wrapper_t *next = (pe_action_wrapper_t *) lpc->data;
                         update_action(next->action, data_set);
                     }
                 }

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -710,7 +710,7 @@ clone_update_pseudo_status(resource_t * rsc, gboolean * stopping, gboolean * sta
 
     gIter = rsc->actions;
     for (; gIter != NULL; gIter = gIter->next) {
-        action_t *action = (action_t *) gIter->data;
+        pe_action_t *action = (pe_action_t *) gIter->data;
 
         if (*starting && *stopping) {
             return;
@@ -744,11 +744,11 @@ clone_update_pseudo_status(resource_t * rsc, gboolean * stopping, gboolean * sta
     }
 }
 
-static action_t *
+static pe_action_t *
 find_rsc_action(pe_resource_t *rsc, const char *task, gboolean active_only,
                 GList **list)
 {
-    action_t *match = NULL;
+    pe_action_t *match = NULL;
     GListPtr possible = NULL;
     GListPtr active = NULL;
 
@@ -758,7 +758,7 @@ find_rsc_action(pe_resource_t *rsc, const char *task, gboolean active_only,
         GListPtr gIter = possible;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            action_t *op = (action_t *) gIter->data;
+            pe_action_t *op = (pe_action_t *) gIter->data;
 
             if (is_set(op->flags, pe_action_optional) == FALSE) {
                 active = g_list_prepend(active, op);
@@ -796,10 +796,10 @@ find_rsc_action(pe_resource_t *rsc, const char *task, gboolean active_only,
 static void
 child_ordering_constraints(resource_t * rsc, pe_working_set_t * data_set)
 {
-    action_t *stop = NULL;
-    action_t *start = NULL;
-    action_t *last_stop = NULL;
-    action_t *last_start = NULL;
+    pe_action_t *stop = NULL;
+    pe_action_t *start = NULL;
+    pe_action_t *last_stop = NULL;
+    pe_action_t *last_start = NULL;
     GListPtr gIter = NULL;
     gboolean active_only = TRUE;        /* change to false to get the old behavior */
     clone_variant_data_t *clone_data = NULL;
@@ -857,11 +857,11 @@ clone_create_pseudo_actions(
     gboolean child_stopping = FALSE;
     gboolean allow_dependent_migrations = TRUE;
 
-    action_t *stop = NULL;
-    action_t *stopped = NULL;
+    pe_action_t *stop = NULL;
+    pe_action_t *stopped = NULL;
 
-    action_t *start = NULL;
-    action_t *started = NULL;
+    pe_action_t *start = NULL;
+    pe_action_t *started = NULL;
 
     pe_rsc_trace(rsc, "Creating actions for %s", rsc->id);
 
@@ -1159,7 +1159,7 @@ clone_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
 }
 
 enum action_tasks
-clone_child_action(action_t * action)
+clone_child_action(pe_action_t * action)
 {
     enum action_tasks result = no_action;
     resource_t *child = (resource_t *) action->rsc->children->data;
@@ -1198,7 +1198,7 @@ clone_child_action(action_t * action)
 }
 
 enum pe_action_flags
-summary_action_flags(action_t * action, GListPtr children, node_t * node)
+summary_action_flags(pe_action_t * action, GListPtr children, node_t * node)
 {
     GListPtr gIter = NULL;
     gboolean any_runnable = FALSE;
@@ -1208,7 +1208,7 @@ summary_action_flags(action_t * action, GListPtr children, node_t * node)
     const char *task_s = task2text(task);
 
     for (gIter = children; gIter != NULL; gIter = gIter->next) {
-        action_t *child_action = NULL;
+        pe_action_t *child_action = NULL;
         resource_t *child = (resource_t *) gIter->data;
 
         child_action = find_first_action(child->actions, NULL, task_s, child->children ? NULL : node);
@@ -1242,7 +1242,7 @@ summary_action_flags(action_t * action, GListPtr children, node_t * node)
 }
 
 enum pe_action_flags
-clone_action_flags(action_t * action, node_t * node)
+clone_action_flags(pe_action_t * action, node_t * node)
 {
     return summary_action_flags(action, action->rsc->children, node);
 }
@@ -1273,7 +1273,7 @@ clone_expand(resource_t * rsc, pe_working_set_t * data_set)
 
     gIter = rsc->actions;
     for (; gIter != NULL; gIter = gIter->next) {
-        action_t *op = (action_t *) gIter->data;
+        pe_action_t *op = (pe_action_t *) gIter->data;
 
         rsc->cmds->action_flags(op, NULL);
     }
@@ -1417,7 +1417,7 @@ probe_anonymous_clone(pe_resource_t *rsc, pe_node_t *node,
 }
 
 gboolean
-clone_create_probe(resource_t * rsc, node_t * node, action_t * complete,
+clone_create_probe(resource_t * rsc, node_t * node, pe_action_t * complete,
                    gboolean force, pe_working_set_t * data_set)
 {
     gboolean any_created = FALSE;

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -42,10 +42,10 @@ sort_rsc_id(gconstpointer a, gconstpointer b)
     return 0;
 }
 
-static node_t *
-parent_node_instance(const pe_resource_t * rsc, node_t * node)
+static pe_node_t *
+parent_node_instance(const pe_resource_t * rsc, pe_node_t * node)
 {
-    node_t *ret = NULL;
+    pe_node_t *ret = NULL;
 
     if (node != NULL && rsc->parent) {
         ret = pe_hash_table_lookup(rsc->parent->allowed_nodes, node->details->id);
@@ -78,10 +78,10 @@ gint
 sort_clone_instance(gconstpointer a, gconstpointer b, gpointer data_set)
 {
     int rc = 0;
-    node_t *node1 = NULL;
-    node_t *node2 = NULL;
-    node_t *current_node1 = NULL;
-    node_t *current_node2 = NULL;
+    pe_node_t *node1 = NULL;
+    pe_node_t *node2 = NULL;
+    pe_node_t *current_node1 = NULL;
+    pe_node_t *current_node2 = NULL;
     unsigned int nnodes1 = 0;
     unsigned int nnodes2 = 0;
 
@@ -119,7 +119,7 @@ sort_clone_instance(gconstpointer a, gconstpointer b, gpointer data_set)
     node1 = current_node1;
     node2 = current_node2;
     if (node1) {
-        node_t *match = pe_hash_table_lookup(resource1->allowed_nodes, node1->details->id);
+        pe_node_t *match = pe_hash_table_lookup(resource1->allowed_nodes, node1->details->id);
 
         if (match == NULL || match->weight < 0) {
             crm_trace("%s: current location is unavailable", resource1->id);
@@ -129,7 +129,7 @@ sort_clone_instance(gconstpointer a, gconstpointer b, gpointer data_set)
     }
 
     if (node2) {
-        node_t *match = pe_hash_table_lookup(resource2->allowed_nodes, node2->details->id);
+        pe_node_t *match = pe_hash_table_lookup(resource2->allowed_nodes, node2->details->id);
 
         if (match == NULL || match->weight < 0) {
             crm_trace("%s: current location is unavailable", resource2->id);
@@ -220,7 +220,7 @@ sort_clone_instance(gconstpointer a, gconstpointer b, gpointer data_set)
     if (node1 && node2) {
         int lpc = 0;
         int max = 0;
-        node_t *n = NULL;
+        pe_node_t *n = NULL;
         GListPtr gIter = NULL;
         GListPtr list1 = NULL;
         GListPtr list2 = NULL;
@@ -369,10 +369,10 @@ sort_clone_instance(gconstpointer a, gconstpointer b, gpointer data_set)
     return rc;
 }
 
-static node_t *
-can_run_instance(pe_resource_t * rsc, node_t * node, int limit)
+static pe_node_t *
+can_run_instance(pe_resource_t * rsc, pe_node_t * node, int limit)
 {
-    node_t *local_node = NULL;
+    pe_node_t *local_node = NULL;
 
     if (node == NULL && rsc->allowed_nodes) {
         GHashTableIter iter;
@@ -422,7 +422,7 @@ static pe_node_t *
 allocate_instance(pe_resource_t *rsc, pe_node_t *prefer, gboolean all_coloc,
                   int limit, pe_working_set_t *data_set)
 {
-    node_t *chosen = NULL;
+    pe_node_t *chosen = NULL;
     GHashTable *backup = NULL;
 
     CRM_ASSERT(rsc);
@@ -444,7 +444,7 @@ allocate_instance(pe_resource_t *rsc, pe_node_t *prefer, gboolean all_coloc,
     append_parent_colocation(rsc->parent, rsc, all_coloc);
 
     if (prefer) {
-        node_t *local_prefer = g_hash_table_lookup(rsc->allowed_nodes, prefer->details->id);
+        pe_node_t *local_prefer = g_hash_table_lookup(rsc->allowed_nodes, prefer->details->id);
 
         if (local_prefer == NULL || local_prefer->weight < 0) {
             pe_rsc_trace(rsc, "Not pre-allocating %s to %s - unavailable", rsc->id,
@@ -557,8 +557,8 @@ distribute_children(pe_resource_t *rsc, GListPtr children, GListPtr nodes,
 
         if (child->running_on && is_set(child->flags, pe_rsc_provisional)
             && is_not_set(child->flags, pe_rsc_failed)) {
-            node_t *child_node = pe__current_node(child);
-            node_t *local_node = parent_node_instance(child, child_node);
+            pe_node_t *child_node = pe__current_node(child);
+            pe_node_t *local_node = parent_node_instance(child, child_node);
 
             pe_rsc_trace(rsc, "Checking pre-allocation of %s to %s (%d remaining of %d)",
                          child->id, child_node->details->uname, max - allocated, max);
@@ -588,8 +588,8 @@ distribute_children(pe_resource_t *rsc, GListPtr children, GListPtr nodes,
         pe_resource_t *child = (pe_resource_t *) gIter->data;
 
         if (child->running_on != NULL) {
-            node_t *child_node = pe__current_node(child);
-            node_t *local_node = parent_node_instance(child, child_node);
+            pe_node_t *child_node = pe__current_node(child);
+            pe_node_t *local_node = parent_node_instance(child, child_node);
 
             if (local_node == NULL) {
                 crm_err("%s is running on %s which isn't allowed",
@@ -960,7 +960,7 @@ clone_internal_constraints(pe_resource_t *rsc, pe_working_set_t *data_set)
 }
 
 bool
-assign_node(pe_resource_t * rsc, node_t * node, gboolean force)
+assign_node(pe_resource_t * rsc, pe_node_t * node, gboolean force)
 {
     bool changed = FALSE;
 
@@ -984,9 +984,9 @@ assign_node(pe_resource_t * rsc, node_t * node, gboolean force)
 }
 
 gboolean
-is_child_compatible(pe_resource_t *child_rsc, node_t * local_node, enum rsc_role_e filter, gboolean current) 
+is_child_compatible(pe_resource_t *child_rsc, pe_node_t * local_node, enum rsc_role_e filter, gboolean current) 
 {
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
     enum rsc_role_e next_role = child_rsc->fns->state(child_rsc, current);
 
     CRM_CHECK(child_rsc && local_node, return FALSE);
@@ -1021,7 +1021,7 @@ find_compatible_child(pe_resource_t *local_child, pe_resource_t *rsc,
     pe_resource_t *pair = NULL;
     GListPtr gIter = NULL;
     GListPtr scratch = NULL;
-    node_t *local_node = NULL;
+    pe_node_t *local_node = NULL;
 
     local_node = local_child->fns->location(local_child, NULL, current);
     if (local_node) {
@@ -1033,7 +1033,7 @@ find_compatible_child(pe_resource_t *local_child, pe_resource_t *rsc,
 
     gIter = scratch;
     for (; gIter != NULL; gIter = gIter->next) {
-        node_t *node = (node_t *) gIter->data;
+        pe_node_t *node = (pe_node_t *) gIter->data;
 
         pair = find_compatible_child_by_node(local_child, node, rsc, filter, current);
         if (pair) {
@@ -1136,7 +1136,7 @@ clone_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
         gIter = rsc_rh->children;
         for (; gIter != NULL; gIter = gIter->next) {
             pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
-            node_t *chosen = child_rsc->fns->location(child_rsc, NULL, FALSE);
+            pe_node_t *chosen = child_rsc->fns->location(child_rsc, NULL, FALSE);
 
             if (chosen != NULL && is_set_recursive(child_rsc, pe_rsc_block, TRUE) == FALSE) {
                 pe_rsc_trace(rsc_rh, "Allowing %s: %s %d", constraint->id, chosen->details->uname, chosen->weight);
@@ -1198,7 +1198,7 @@ clone_child_action(pe_action_t * action)
 }
 
 enum pe_action_flags
-summary_action_flags(pe_action_t * action, GListPtr children, node_t * node)
+summary_action_flags(pe_action_t * action, GListPtr children, pe_node_t * node)
 {
     GListPtr gIter = NULL;
     gboolean any_runnable = FALSE;
@@ -1242,7 +1242,7 @@ summary_action_flags(pe_action_t * action, GListPtr children, node_t * node)
 }
 
 enum pe_action_flags
-clone_action_flags(pe_action_t * action, node_t * node)
+clone_action_flags(pe_action_t * action, pe_node_t * node)
 {
     return summary_action_flags(action, action->rsc->children, node);
 }
@@ -1341,7 +1341,7 @@ rsc_known_on(const pe_resource_t *rsc, const pe_node_t *node)
 
     } else if (rsc->known_on) {
         GHashTableIter iter;
-        node_t *known_node = NULL;
+        pe_node_t *known_node = NULL;
 
         g_hash_table_iter_init(&iter, rsc->known_on);
         while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &known_node)) {
@@ -1399,7 +1399,7 @@ probe_anonymous_clone(pe_resource_t *rsc, pe_node_t *node,
         for (GList *child_iter = rsc->children; child_iter && !child;
              child_iter = child_iter->next) {
 
-            node_t *local_node = NULL;
+            pe_node_t *local_node = NULL;
             pe_resource_t *child_rsc = (pe_resource_t *) child_iter->data;
 
             local_node = child_rsc->fns->location(child_rsc, NULL, FALSE);
@@ -1417,7 +1417,7 @@ probe_anonymous_clone(pe_resource_t *rsc, pe_node_t *node,
 }
 
 gboolean
-clone_create_probe(pe_resource_t * rsc, node_t * node, pe_action_t * complete,
+clone_create_probe(pe_resource_t * rsc, pe_node_t * node, pe_action_t * complete,
                    gboolean force, pe_working_set_t * data_set)
 {
     gboolean any_created = FALSE;
@@ -1431,7 +1431,7 @@ clone_create_probe(pe_resource_t * rsc, node_t * node, pe_action_t * complete,
     }
 
     if (rsc->exclusive_discover) {
-        node_t *allowed = g_hash_table_lookup(rsc->allowed_nodes, node->details->id);
+        pe_node_t *allowed = g_hash_table_lookup(rsc->allowed_nodes, node->details->id);
         if (allowed && allowed->rsc_discover_mode != pe_discover_exclusive) {
             /* exclusive discover is enabled and this node is not marked
              * as a node this resource should be discovered on

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -16,13 +16,13 @@
 #include <lib/pengine/variant.h>
 
 gint sort_clone_instance(gconstpointer a, gconstpointer b, gpointer data_set);
-static void append_parent_colocation(resource_t * rsc, resource_t * child, gboolean all);
+static void append_parent_colocation(pe_resource_t * rsc, pe_resource_t * child, gboolean all);
 
 static gint
 sort_rsc_id(gconstpointer a, gconstpointer b)
 {
-    const resource_t *resource1 = (const resource_t *)a;
-    const resource_t *resource2 = (const resource_t *)b;
+    const pe_resource_t *resource1 = (const pe_resource_t *)a;
+    const pe_resource_t *resource2 = (const pe_resource_t *)b;
     long num1, num2;
 
     CRM_ASSERT(resource1 != NULL);
@@ -43,7 +43,7 @@ sort_rsc_id(gconstpointer a, gconstpointer b)
 }
 
 static node_t *
-parent_node_instance(const resource_t * rsc, node_t * node)
+parent_node_instance(const pe_resource_t * rsc, node_t * node)
 {
     node_t *ret = NULL;
 
@@ -56,7 +56,7 @@ parent_node_instance(const resource_t * rsc, node_t * node)
 }
 
 static gboolean
-did_fail(const resource_t * rsc)
+did_fail(const pe_resource_t * rsc)
 {
     GListPtr gIter = rsc->children;
 
@@ -65,7 +65,7 @@ did_fail(const resource_t * rsc)
     }
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         if (did_fail(child_rsc)) {
             return TRUE;
@@ -88,8 +88,8 @@ sort_clone_instance(gconstpointer a, gconstpointer b, gpointer data_set)
     gboolean can1 = TRUE;
     gboolean can2 = TRUE;
 
-    const resource_t *resource1 = (const resource_t *)a;
-    const resource_t *resource2 = (const resource_t *)b;
+    const pe_resource_t *resource1 = (const pe_resource_t *)a;
+    const pe_resource_t *resource2 = (const pe_resource_t *)b;
 
     CRM_ASSERT(resource1 != NULL);
     CRM_ASSERT(resource2 != NULL);
@@ -370,7 +370,7 @@ sort_clone_instance(gconstpointer a, gconstpointer b, gpointer data_set)
 }
 
 static node_t *
-can_run_instance(resource_t * rsc, node_t * node, int limit)
+can_run_instance(pe_resource_t * rsc, node_t * node, int limit)
 {
     node_t *local_node = NULL;
 
@@ -488,7 +488,7 @@ allocate_instance(pe_resource_t *rsc, pe_node_t *prefer, gboolean all_coloc,
 }
 
 static void
-append_parent_colocation(resource_t * rsc, resource_t * child, gboolean all)
+append_parent_colocation(pe_resource_t * rsc, pe_resource_t * child, gboolean all)
 {
 
     GListPtr gIter = NULL;
@@ -520,11 +520,11 @@ append_parent_colocation(resource_t * rsc, resource_t * child, gboolean all)
 
 
 void
-distribute_children(resource_t *rsc, GListPtr children, GListPtr nodes,
+distribute_children(pe_resource_t *rsc, GListPtr children, GListPtr nodes,
                     int max, int per_host_max, pe_working_set_t * data_set);
 
 void
-distribute_children(resource_t *rsc, GListPtr children, GListPtr nodes,
+distribute_children(pe_resource_t *rsc, GListPtr children, GListPtr nodes,
                     int max, int per_host_max, pe_working_set_t * data_set) 
 {
     int loop_max = 0;
@@ -553,7 +553,7 @@ distribute_children(resource_t *rsc, GListPtr children, GListPtr nodes,
 
     /* Pre-allocate as many instances as we can to their current location */
     for (GListPtr gIter = children; gIter != NULL && allocated < max; gIter = gIter->next) {
-        resource_t *child = (resource_t *) gIter->data;
+        pe_resource_t *child = (pe_resource_t *) gIter->data;
 
         if (child->running_on && is_set(child->flags, pe_rsc_provisional)
             && is_not_set(child->flags, pe_rsc_failed)) {
@@ -585,7 +585,7 @@ distribute_children(resource_t *rsc, GListPtr children, GListPtr nodes,
     pe_rsc_trace(rsc, "Done pre-allocating (%d of %d)", allocated, max);
 
     for (GListPtr gIter = children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child = (resource_t *) gIter->data;
+        pe_resource_t *child = (pe_resource_t *) gIter->data;
 
         if (child->running_on != NULL) {
             node_t *child_node = pe__current_node(child);
@@ -683,7 +683,7 @@ pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *prefer,
 }
 
 static void
-clone_update_pseudo_status(resource_t * rsc, gboolean * stopping, gboolean * starting,
+clone_update_pseudo_status(pe_resource_t * rsc, gboolean * stopping, gboolean * starting,
                            gboolean * active)
 {
     GListPtr gIter = NULL;
@@ -692,7 +692,7 @@ clone_update_pseudo_status(resource_t * rsc, gboolean * stopping, gboolean * sta
 
         gIter = rsc->children;
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *child = (resource_t *) gIter->data;
+            pe_resource_t *child = (pe_resource_t *) gIter->data;
 
             clone_update_pseudo_status(child, stopping, starting, active);
         }
@@ -794,7 +794,7 @@ find_rsc_action(pe_resource_t *rsc, const char *task, gboolean active_only,
 }
 
 static void
-child_ordering_constraints(resource_t * rsc, pe_working_set_t * data_set)
+child_ordering_constraints(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
     pe_action_t *stop = NULL;
     pe_action_t *start = NULL;
@@ -813,7 +813,7 @@ child_ordering_constraints(resource_t * rsc, pe_working_set_t * data_set)
     rsc->children = g_list_sort(rsc->children, sort_rsc_id);
 
     for (gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child = (resource_t *) gIter->data;
+        pe_resource_t *child = (pe_resource_t *) gIter->data;
 
         stop = find_rsc_action(child, RSC_STOP, active_only, NULL);
         if (stop) {
@@ -836,7 +836,7 @@ child_ordering_constraints(resource_t * rsc, pe_working_set_t * data_set)
 }
 
 void
-clone_create_actions(resource_t *rsc, pe_working_set_t *data_set)
+clone_create_actions(pe_resource_t *rsc, pe_working_set_t *data_set)
 {
     clone_variant_data_t *clone_data = NULL;
 
@@ -850,7 +850,7 @@ clone_create_actions(resource_t *rsc, pe_working_set_t *data_set)
 
 void
 clone_create_pseudo_actions(
-    resource_t * rsc, GListPtr children, notify_data_t **start_notify, notify_data_t **stop_notify,  pe_working_set_t * data_set)
+    pe_resource_t * rsc, GListPtr children, notify_data_t **start_notify, notify_data_t **stop_notify,  pe_working_set_t * data_set)
 {
     gboolean child_active = FALSE;
     gboolean child_starting = FALSE;
@@ -866,7 +866,7 @@ clone_create_pseudo_actions(
     pe_rsc_trace(rsc, "Creating actions for %s", rsc->id);
 
     for (GListPtr gIter = children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
         gboolean starting = FALSE;
         gboolean stopping = FALSE;
 
@@ -911,9 +911,9 @@ clone_create_pseudo_actions(
 }
 
 void
-clone_internal_constraints(resource_t *rsc, pe_working_set_t *data_set)
+clone_internal_constraints(pe_resource_t *rsc, pe_working_set_t *data_set)
 {
-    resource_t *last_rsc = NULL;
+    pe_resource_t *last_rsc = NULL;
     GListPtr gIter;
     clone_variant_data_t *clone_data = NULL;
 
@@ -934,7 +934,7 @@ clone_internal_constraints(resource_t *rsc, pe_working_set_t *data_set)
         rsc->children = g_list_sort(rsc->children, sort_rsc_id);
     }
     for (gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         child_rsc->cmds->internal_constraints(child_rsc, data_set);
 
@@ -960,14 +960,14 @@ clone_internal_constraints(resource_t *rsc, pe_working_set_t *data_set)
 }
 
 bool
-assign_node(resource_t * rsc, node_t * node, gboolean force)
+assign_node(pe_resource_t * rsc, node_t * node, gboolean force)
 {
     bool changed = FALSE;
 
     if (rsc->children) {
 
         for (GListPtr gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-            resource_t *child_rsc = (resource_t *) gIter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
             changed |= assign_node(child_rsc, node, force);
         }
@@ -984,7 +984,7 @@ assign_node(resource_t * rsc, node_t * node, gboolean force)
 }
 
 gboolean
-is_child_compatible(resource_t *child_rsc, node_t * local_node, enum rsc_role_e filter, gboolean current) 
+is_child_compatible(pe_resource_t *child_rsc, node_t * local_node, enum rsc_role_e filter, gboolean current) 
 {
     node_t *node = NULL;
     enum rsc_role_e next_role = child_rsc->fns->state(child_rsc, current);
@@ -1018,7 +1018,7 @@ find_compatible_child(pe_resource_t *local_child, pe_resource_t *rsc,
                       enum rsc_role_e filter, gboolean current,
                       pe_working_set_t *data_set)
 {
-    resource_t *pair = NULL;
+    pe_resource_t *pair = NULL;
     GListPtr gIter = NULL;
     GListPtr scratch = NULL;
     node_t *local_node = NULL;
@@ -1110,7 +1110,7 @@ clone_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
         return;
 
     } else if (do_interleave) {
-        resource_t *rh_child = NULL;
+        pe_resource_t *rh_child = NULL;
 
         rh_child = find_compatible_child(rsc_lh, rsc_rh, RSC_ROLE_UNKNOWN,
                                          FALSE, data_set);
@@ -1135,7 +1135,7 @@ clone_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
 
         gIter = rsc_rh->children;
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *child_rsc = (resource_t *) gIter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
             node_t *chosen = child_rsc->fns->location(child_rsc, NULL, FALSE);
 
             if (chosen != NULL && is_set_recursive(child_rsc, pe_rsc_block, TRUE) == FALSE) {
@@ -1151,7 +1151,7 @@ clone_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
 
     gIter = rsc_rh->children;
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         child_rsc->cmds->rsc_colocation_rh(rsc_lh, child_rsc, constraint,
                                            data_set);
@@ -1162,7 +1162,7 @@ enum action_tasks
 clone_child_action(pe_action_t * action)
 {
     enum action_tasks result = no_action;
-    resource_t *child = (resource_t *) action->rsc->children->data;
+    pe_resource_t *child = (pe_resource_t *) action->rsc->children->data;
 
     if (safe_str_eq(action->task, "notify")
         || safe_str_eq(action->task, "notified")) {
@@ -1209,7 +1209,7 @@ summary_action_flags(pe_action_t * action, GListPtr children, node_t * node)
 
     for (gIter = children; gIter != NULL; gIter = gIter->next) {
         pe_action_t *child_action = NULL;
-        resource_t *child = (resource_t *) gIter->data;
+        pe_resource_t *child = (pe_resource_t *) gIter->data;
 
         child_action = find_first_action(child->actions, NULL, task_s, child->children ? NULL : node);
         pe_rsc_trace(action->rsc, "Checking for %s in %s on %s (%s)", task_s, child->id,
@@ -1257,14 +1257,14 @@ clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
     native_rsc_location(rsc, constraint);
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         child_rsc->cmds->rsc_location(child_rsc, constraint);
     }
 }
 
 void
-clone_expand(resource_t * rsc, pe_working_set_t * data_set)
+clone_expand(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
     clone_variant_data_t *clone_data = NULL;
@@ -1306,7 +1306,7 @@ clone_expand(resource_t * rsc, pe_working_set_t * data_set)
 
     gIter = rsc->children;
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         child_rsc->cmds->expand(child_rsc, data_set);
     }
@@ -1332,7 +1332,7 @@ rsc_known_on(const pe_resource_t *rsc, const pe_node_t *node)
         for (GList *child_iter = rsc->children; child_iter != NULL;
              child_iter = child_iter->next) {
 
-            resource_t *child = (resource_t *) child_iter->data;
+            pe_resource_t *child = (pe_resource_t *) child_iter->data;
 
             if (rsc_known_on(child, node)) {
                 return TRUE;
@@ -1358,7 +1358,7 @@ static pe_resource_t *
 find_instance_on(const pe_resource_t *clone, const pe_node_t *node)
 {
     for (GList *gIter = clone->children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child = (resource_t *) gIter->data;
+        pe_resource_t *child = (pe_resource_t *) gIter->data;
 
         if (rsc_known_on(child, node)) {
             return child;
@@ -1377,7 +1377,7 @@ probe_unique_clone(pe_resource_t *rsc, pe_node_t *node, pe_action_t *complete,
     for (GList *child_iter = rsc->children; child_iter != NULL;
          child_iter = child_iter->next) {
 
-        resource_t *child = (resource_t *) child_iter->data;
+        pe_resource_t *child = (pe_resource_t *) child_iter->data;
 
         any_created |= child->cmds->create_probe(child, node, complete, force,
                                                  data_set);
@@ -1400,7 +1400,7 @@ probe_anonymous_clone(pe_resource_t *rsc, pe_node_t *node,
              child_iter = child_iter->next) {
 
             node_t *local_node = NULL;
-            resource_t *child_rsc = (resource_t *) child_iter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) child_iter->data;
 
             local_node = child_rsc->fns->location(child_rsc, NULL, FALSE);
             if (local_node && (local_node->details == node->details)) {
@@ -1417,7 +1417,7 @@ probe_anonymous_clone(pe_resource_t *rsc, pe_node_t *node,
 }
 
 gboolean
-clone_create_probe(resource_t * rsc, node_t * node, pe_action_t * complete,
+clone_create_probe(pe_resource_t * rsc, node_t * node, pe_action_t * complete,
                    gboolean force, pe_working_set_t * data_set)
 {
     gboolean any_created = FALSE;
@@ -1457,7 +1457,7 @@ clone_create_probe(resource_t * rsc, node_t * node, pe_action_t * complete,
 }
 
 void
-clone_append_meta(resource_t * rsc, xmlNode * xml)
+clone_append_meta(pe_resource_t * rsc, xmlNode * xml)
 {
     char *name = NULL;
     clone_variant_data_t *clone_data = NULL;

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -811,7 +811,7 @@ unpack_rsc_location(xmlNode * xml_obj, pe_resource_t * rsc_lh, const char * role
 
     if (node != NULL && score != NULL) {
         int score_i = char2score(score);
-        node_t *match = pe_find_node(data_set->nodes, node);
+        pe_node_t *match = pe_find_node(data_set->nodes, node);
 
         if (!match) {
             return FALSE;
@@ -1036,7 +1036,7 @@ unpack_location(xmlNode * xml_obj, pe_working_set_t * data_set)
 }
 
 static int
-get_node_score(const char *rule, const char *score, gboolean raw, node_t * node, pe_resource_t *rsc)
+get_node_score(const char *rule, const char *score, gboolean raw, pe_node_t * node, pe_resource_t *rsc)
 {
     int score_f = 0;
 
@@ -1138,7 +1138,7 @@ generate_location_rule(pe_resource_t *rsc, xmlNode *rule_xml,
 
         match_L = node_list_dup(data_set->nodes, TRUE, FALSE);
         for (gIter = match_L; gIter != NULL; gIter = gIter->next) {
-            node_t *node = (node_t *) gIter->data;
+            pe_node_t *node = (pe_node_t *) gIter->data;
 
             node->weight = get_node_score(rule_id, score, raw_score, node, rsc);
         }
@@ -1146,7 +1146,7 @@ generate_location_rule(pe_resource_t *rsc, xmlNode *rule_xml,
 
     for (gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
         int score_f = 0;
-        node_t *node = (node_t *) gIter->data;
+        pe_node_t *node = (pe_node_t *) gIter->data;
 
         accept = pe_test_rule(rule_xml, node->details->attrs, RSC_ROLE_UNKNOWN,
                               data_set->now, next_change, match_data);
@@ -1160,7 +1160,7 @@ generate_location_rule(pe_resource_t *rsc, xmlNode *rule_xml,
 /* 			} */
 
         if (accept) {
-            node_t *local = pe_find_node_id(match_L, node->details->id);
+            pe_node_t *local = pe_find_node_id(match_L, node->details->id);
 
             if (local == NULL && do_and) {
                 continue;
@@ -1177,7 +1177,7 @@ generate_location_rule(pe_resource_t *rsc, xmlNode *rule_xml,
 
         } else if (do_and && !accept) {
             /* remove it */
-            node_t *delete = pe_find_node_id(match_L, node->details->id);
+            pe_node_t *delete = pe_find_node_id(match_L, node->details->id);
 
             if (delete != NULL) {
                 match_L = g_list_remove(match_L, delete);

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -452,7 +452,7 @@ unpack_simple_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
     if (min_required_before) {
         GListPtr rIter = NULL;
         char *task = crm_strdup_printf(CRM_OP_RELAXED_CLONE ":%s", id);
-        action_t *unordered_action = get_pseudo_op(task, data_set);
+        pe_action_t *unordered_action = get_pseudo_op(task, data_set);
         free(task);
 
         /* require the pseudo action to have "min_required_before" number of
@@ -1424,7 +1424,7 @@ new_rsc_order(resource_t * lh_rsc, const char *lh_task,
 }
 
 static char *
-task_from_action_or_key(action_t *action, const char *key)
+task_from_action_or_key(pe_action_t *action, const char *key)
 {
     char *res = NULL;
 
@@ -1574,8 +1574,8 @@ cleanup_order:
 
 /* LHS before RHS */
 int
-custom_action_order(resource_t * lh_rsc, char *lh_action_task, action_t * lh_action,
-                    resource_t * rh_rsc, char *rh_action_task, action_t * rh_action,
+custom_action_order(resource_t * lh_rsc, char *lh_action_task, pe_action_t * lh_action,
+                    resource_t * rh_rsc, char *rh_action_task, pe_action_t * rh_action,
                     enum pe_ordering type, pe_working_set_t * data_set)
 {
     pe__ordering_t *order = NULL;
@@ -1675,8 +1675,9 @@ get_flags(const char *id, enum pe_order_kind kind,
 
 static gboolean
 unpack_order_set(xmlNode * set, enum pe_order_kind parent_kind, resource_t ** rsc,
-                 action_t ** begin, action_t ** end, action_t ** inv_begin, action_t ** inv_end,
-                 const char *parent_symmetrical_s, pe_working_set_t * data_set)
+                 pe_action_t ** begin, pe_action_t ** end, pe_action_t ** inv_begin,
+                 pe_action_t ** inv_end, const char *parent_symmetrical_s,
+                 pe_working_set_t * data_set)
 {
     xmlNode *xml_rsc = NULL;
     GListPtr set_iter = NULL;
@@ -1896,7 +1897,7 @@ order_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, enum pe_order_kin
     /* If we have an un-ordered set1, whether it is sequential or not is irrelevant in regards to set2. */
     if (!require_all) {
         char *task = crm_strdup_printf(CRM_OP_RELAXED_SET ":%s", ID(set1));
-        action_t *unordered_action = get_pseudo_op(task, data_set);
+        pe_action_t *unordered_action = get_pseudo_op(task, data_set);
 
         free(task);
         update_action_flags(unordered_action, pe_action_requires_any, __FUNCTION__, __LINE__);
@@ -2160,11 +2161,11 @@ unpack_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
        resource_t *last_rsc = NULL;
      */
 
-    action_t *set_end = NULL;
-    action_t *set_begin = NULL;
+    pe_action_t *set_end = NULL;
+    pe_action_t *set_begin = NULL;
 
-    action_t *set_inv_end = NULL;
-    action_t *set_inv_begin = NULL;
+    pe_action_t *set_inv_end = NULL;
+    pe_action_t *set_inv_begin = NULL;
 
     xmlNode *set = NULL;
     xmlNode *last = NULL;
@@ -2173,10 +2174,10 @@ unpack_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
     xmlNode *expanded_xml = NULL;
 
     /*
-       action_t *last_end = NULL;
-       action_t *last_begin = NULL;
-       action_t *last_inv_end = NULL;
-       action_t *last_inv_begin = NULL;
+       pe_action_t *last_end = NULL;
+       pe_action_t *last_begin = NULL;
+       pe_action_t *last_inv_end = NULL;
+       pe_action_t *last_inv_begin = NULL;
      */
 
     const char *id = crm_element_value(xml_obj, XML_ATTR_ID);

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -2712,7 +2712,7 @@ unpack_rsc_colocation(xmlNode * xml_obj, pe_working_set_t * data_set)
 }
 
 gboolean
-rsc_ticket_new(const char *id, resource_t * rsc_lh, ticket_t * ticket,
+rsc_ticket_new(const char *id, resource_t * rsc_lh, pe_ticket_t * ticket,
                const char *state_lh, const char *loss_policy, pe_working_set_t * data_set)
 {
     rsc_ticket_t *new_rsc_ticket = NULL;
@@ -2801,7 +2801,7 @@ rsc_ticket_new(const char *id, resource_t * rsc_lh, ticket_t * ticket,
 }
 
 static gboolean
-unpack_rsc_ticket_set(xmlNode * set, ticket_t * ticket, const char *loss_policy,
+unpack_rsc_ticket_set(xmlNode * set, pe_ticket_t * ticket, const char *loss_policy,
                       pe_working_set_t * data_set)
 {
     xmlNode *xml_rsc = NULL;
@@ -2840,7 +2840,7 @@ unpack_simple_rsc_ticket(xmlNode * xml_obj, pe_working_set_t * data_set)
     const char *ticket_str = crm_element_value(xml_obj, XML_TICKET_ATTR_TICKET);
     const char *loss_policy = crm_element_value(xml_obj, XML_TICKET_ATTR_LOSS_POLICY);
 
-    ticket_t *ticket = NULL;
+    pe_ticket_t *ticket = NULL;
 
     const char *id_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE);
     const char *state_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE_ROLE);
@@ -2995,7 +2995,7 @@ unpack_rsc_ticket(xmlNode * xml_obj, pe_working_set_t * data_set)
     const char *ticket_str = crm_element_value(xml_obj, XML_TICKET_ATTR_TICKET);
     const char *loss_policy = crm_element_value(xml_obj, XML_TICKET_ATTR_LOSS_POLICY);
 
-    ticket_t *ticket = NULL;
+    pe_ticket_t *ticket = NULL;
 
     xmlNode *orig_xml = NULL;
     xmlNode *expanded_xml = NULL;

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -212,7 +212,7 @@ pe_find_constraint_resource(GListPtr rsc_list, const char *id)
 }
 
 static gboolean
-pe_find_constraint_tag(pe_working_set_t * data_set, const char * id, tag_t ** tag)
+pe_find_constraint_tag(pe_working_set_t * data_set, const char * id, pe_tag_t ** tag)
 {
     gboolean rc = FALSE;
 
@@ -243,7 +243,7 @@ pe_find_constraint_tag(pe_working_set_t * data_set, const char * id, tag_t ** ta
 
 static gboolean
 valid_resource_or_tag(pe_working_set_t * data_set, const char * id,
-                      resource_t ** rsc, tag_t ** tag)
+                      resource_t ** rsc, pe_tag_t ** tag)
 {
     gboolean rc = FALSE;
 
@@ -541,7 +541,7 @@ expand_tags_in_sets(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t
              xml_rsc = __xml_next_element(xml_rsc)) {
 
             resource_t *rsc = NULL;
-            tag_t *tag = NULL;
+            pe_tag_t *tag = NULL;
             const char *id = ID(xml_rsc);
 
             if (safe_str_neq((const char *)xml_rsc->name, XML_TAG_RESOURCE_REF)) {
@@ -641,7 +641,7 @@ tag_to_set(xmlNode * xml_obj, xmlNode ** rsc_set, const char * attr,
     const char *id = NULL;
 
     resource_t *rsc = NULL;
-    tag_t *tag = NULL;
+    pe_tag_t *tag = NULL;
 
     *rsc_set = NULL;
 
@@ -888,7 +888,7 @@ unpack_location_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_
 
     resource_t *rsc_lh = NULL;
 
-    tag_t *tag_lh = NULL;
+    pe_tag_t *tag_lh = NULL;
 
     xmlNode *new_xml = NULL;
     xmlNode *rsc_set_lh = NULL;
@@ -2051,8 +2051,8 @@ unpack_order_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t *
 
     resource_t *rsc_first = NULL;
     resource_t *rsc_then = NULL;
-    tag_t *tag_first = NULL;
-    tag_t *tag_then = NULL;
+    pe_tag_t *tag_first = NULL;
+    pe_tag_t *tag_then = NULL;
 
     xmlNode *new_xml = NULL;
     xmlNode *rsc_set_first = NULL;
@@ -2548,8 +2548,8 @@ unpack_colocation_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_se
     resource_t *rsc_lh = NULL;
     resource_t *rsc_rh = NULL;
 
-    tag_t *tag_lh = NULL;
-    tag_t *tag_rh = NULL;
+    pe_tag_t *tag_lh = NULL;
+    pe_tag_t *tag_rh = NULL;
 
     xmlNode *new_xml = NULL;
     xmlNode *rsc_set_lh = NULL;
@@ -2913,7 +2913,7 @@ unpack_rsc_ticket_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_se
     const char *state_lh = NULL;
 
     resource_t *rsc_lh = NULL;
-    tag_t *tag_lh = NULL;
+    pe_tag_t *tag_lh = NULL;
 
     xmlNode *new_xml = NULL;
     xmlNode *rsc_set_lh = NULL;

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -188,15 +188,15 @@ get_ordering_type(xmlNode * xml_obj)
     return kind_e;
 }
 
-static resource_t *
+static pe_resource_t *
 pe_find_constraint_resource(GListPtr rsc_list, const char *id)
 {
     GListPtr rIter = NULL;
 
     for (rIter = rsc_list; id && rIter; rIter = rIter->next) {
-        resource_t *parent = rIter->data;
-        resource_t *match = parent->fns->find_rsc(parent, id, NULL,
-                                                  pe_find_renamed);
+        pe_resource_t *parent = rIter->data;
+        pe_resource_t *match = parent->fns->find_rsc(parent, id, NULL,
+                                                     pe_find_renamed);
 
         if (match != NULL) {
             if(safe_str_neq(match->id, id)) {
@@ -243,7 +243,7 @@ pe_find_constraint_tag(pe_working_set_t * data_set, const char * id, pe_tag_t **
 
 static gboolean
 valid_resource_or_tag(pe_working_set_t * data_set, const char * id,
-                      resource_t ** rsc, pe_tag_t ** tag)
+                      pe_resource_t ** rsc, pe_tag_t ** tag)
 {
     gboolean rc = FALSE;
 
@@ -307,8 +307,8 @@ static gboolean
 unpack_simple_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
 {
     int order_id = 0;
-    resource_t *rsc_then = NULL;
-    resource_t *rsc_first = NULL;
+    pe_resource_t *rsc_then = NULL;
+    pe_resource_t *rsc_first = NULL;
     gboolean invert_bool = TRUE;
     int min_required_before = 0;
     enum pe_order_kind kind = pe_order_kind_mandatory;
@@ -462,7 +462,7 @@ unpack_simple_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
         update_action_flags(unordered_action, pe_action_requires_any, __FUNCTION__, __LINE__);
 
         for (rIter = rsc_first->children; id && rIter; rIter = rIter->next) {
-            resource_t *child = rIter->data;
+            pe_resource_t *child = rIter->data;
             /* order each clone instance before the pseudo action */
             custom_action_order(child, pcmk__op_key(child->id, action_first, 0),
                                 NULL, NULL, NULL, unordered_action,
@@ -540,7 +540,7 @@ expand_tags_in_sets(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t
         for (xml_rsc = __xml_first_child_element(set); xml_rsc != NULL;
              xml_rsc = __xml_next_element(xml_rsc)) {
 
-            resource_t *rsc = NULL;
+            pe_resource_t *rsc = NULL;
             pe_tag_t *tag = NULL;
             const char *id = ID(xml_rsc);
 
@@ -640,7 +640,7 @@ tag_to_set(xmlNode * xml_obj, xmlNode ** rsc_set, const char * attr,
     const char *cons_id = NULL;
     const char *id = NULL;
 
-    resource_t *rsc = NULL;
+    pe_resource_t *rsc = NULL;
     pe_tag_t *tag = NULL;
 
     *rsc_set = NULL;
@@ -707,7 +707,7 @@ tag_to_set(xmlNode * xml_obj, xmlNode ** rsc_set, const char * attr,
     return TRUE;
 }
 
-static gboolean unpack_rsc_location(xmlNode * xml_obj, resource_t * rsc_lh, const char * role,
+static gboolean unpack_rsc_location(xmlNode * xml_obj, pe_resource_t * rsc_lh, const char * role,
                              const char * score, pe_working_set_t * data_set, pe_match_data_t * match_data);
 
 static gboolean
@@ -717,7 +717,7 @@ unpack_simple_location(xmlNode * xml_obj, pe_working_set_t * data_set)
     const char *value = crm_element_value(xml_obj, XML_LOC_ATTR_SOURCE);
 
     if(value) {
-        resource_t *rsc_lh = pe_find_constraint_resource(data_set->resources, value);
+        pe_resource_t *rsc_lh = pe_find_constraint_resource(data_set->resources, value);
 
         return unpack_rsc_location(xml_obj, rsc_lh, NULL, NULL, data_set, NULL);
     }
@@ -743,7 +743,7 @@ unpack_simple_location(xmlNode * xml_obj, pe_working_set_t * data_set)
         }
 
         for (rIter = data_set->resources; rIter; rIter = rIter->next) {
-            resource_t *r = rIter->data;
+            pe_resource_t *r = rIter->data;
             int nregs = 0;
             regmatch_t *pmatch = NULL;
             int status;
@@ -790,7 +790,7 @@ unpack_simple_location(xmlNode * xml_obj, pe_working_set_t * data_set)
 }
 
 static gboolean
-unpack_rsc_location(xmlNode * xml_obj, resource_t * rsc_lh, const char * role,
+unpack_rsc_location(xmlNode * xml_obj, pe_resource_t * rsc_lh, const char * role,
                     const char * score, pe_working_set_t * data_set, pe_match_data_t * match_data)
 {
     pe__location_t *location = NULL;
@@ -886,7 +886,7 @@ unpack_location_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_
     const char *id_lh = NULL;
     const char *state_lh = NULL;
 
-    resource_t *rsc_lh = NULL;
+    pe_resource_t *rsc_lh = NULL;
 
     pe_tag_t *tag_lh = NULL;
 
@@ -960,7 +960,7 @@ static gboolean
 unpack_location_set(xmlNode * location, xmlNode * set, pe_working_set_t * data_set)
 {
     xmlNode *xml_rsc = NULL;
-    resource_t *resource = NULL;
+    pe_resource_t *resource = NULL;
     const char *set_id;
     const char *role;
     const char *local_score;
@@ -1036,7 +1036,7 @@ unpack_location(xmlNode * xml_obj, pe_working_set_t * data_set)
 }
 
 static int
-get_node_score(const char *rule, const char *score, gboolean raw, node_t * node, resource_t *rsc)
+get_node_score(const char *rule, const char *score, gboolean raw, node_t * node, pe_resource_t *rsc)
 {
     int score_f = 0;
 
@@ -1298,8 +1298,8 @@ sort_cons_priority_rh(gconstpointer a, gconstpointer b)
 }
 
 static void
-anti_colocation_order(resource_t * first_rsc, int first_role,
-                      resource_t * then_rsc, int then_role,
+anti_colocation_order(pe_resource_t * first_rsc, int first_role,
+                      pe_resource_t * then_rsc, int then_role,
                       pe_working_set_t * data_set)
 {
     const char *first_tasks[] = { NULL, NULL };
@@ -1341,7 +1341,7 @@ anti_colocation_order(resource_t * first_rsc, int first_role,
 
 gboolean
 rsc_colocation_new(const char *id, const char *node_attr, int score,
-                   resource_t * rsc_lh, resource_t * rsc_rh,
+                   pe_resource_t * rsc_lh, pe_resource_t * rsc_rh,
                    const char *state_lh, const char *state_rh, pe_working_set_t * data_set)
 {
     rsc_colocation_t *new_con = NULL;
@@ -1396,8 +1396,8 @@ rsc_colocation_new(const char *id, const char *node_attr, int score,
 
 /* LHS before RHS */
 int
-new_rsc_order(resource_t * lh_rsc, const char *lh_task,
-              resource_t * rh_rsc, const char *rh_task,
+new_rsc_order(pe_resource_t * lh_rsc, const char *lh_task,
+              pe_resource_t * rh_rsc, const char *rh_task,
               enum pe_ordering type, pe_working_set_t * data_set)
 {
     char *lh_key = NULL;
@@ -1574,8 +1574,8 @@ cleanup_order:
 
 /* LHS before RHS */
 int
-custom_action_order(resource_t * lh_rsc, char *lh_action_task, pe_action_t * lh_action,
-                    resource_t * rh_rsc, char *rh_action_task, pe_action_t * rh_action,
+custom_action_order(pe_resource_t * lh_rsc, char *lh_action_task, pe_action_t * lh_action,
+                    pe_resource_t * rh_rsc, char *rh_action_task, pe_action_t * rh_action,
                     enum pe_ordering type, pe_working_set_t * data_set)
 {
     pe__ordering_t *order = NULL;
@@ -1674,7 +1674,7 @@ get_flags(const char *id, enum pe_order_kind kind,
 }
 
 static gboolean
-unpack_order_set(xmlNode * set, enum pe_order_kind parent_kind, resource_t ** rsc,
+unpack_order_set(xmlNode * set, enum pe_order_kind parent_kind, pe_resource_t ** rsc,
                  pe_action_t ** begin, pe_action_t ** end, pe_action_t ** inv_begin,
                  pe_action_t ** inv_end, const char *parent_symmetrical_s,
                  pe_working_set_t * data_set)
@@ -1683,8 +1683,8 @@ unpack_order_set(xmlNode * set, enum pe_order_kind parent_kind, resource_t ** rs
     GListPtr set_iter = NULL;
     GListPtr resources = NULL;
 
-    resource_t *last = NULL;
-    resource_t *resource = NULL;
+    pe_resource_t *last = NULL;
+    pe_resource_t *resource = NULL;
 
     int local_kind = parent_kind;
     gboolean sequential = FALSE;
@@ -1760,7 +1760,7 @@ unpack_order_set(xmlNode * set, enum pe_order_kind parent_kind, resource_t ** rs
 
     set_iter = resources;
     while (set_iter != NULL) {
-        resource = (resource_t *) set_iter->data;
+        resource = (pe_resource_t *) set_iter->data;
         set_iter = set_iter->next;
 
         key = pcmk__op_key(resource->id, action, 0);
@@ -1779,7 +1779,7 @@ unpack_order_set(xmlNode * set, enum pe_order_kind parent_kind, resource_t ** rs
             GListPtr gIter = NULL;
 
             for (gIter = set_iter; gIter != NULL; gIter = gIter->next) {
-                resource_t *then_rsc = (resource_t *) gIter->data;
+                pe_resource_t *then_rsc = (pe_resource_t *) gIter->data;
                 char *then_key = pcmk__op_key(then_rsc->id, action, 0);
 
                 custom_action_order(resource, strdup(key), NULL, then_rsc, then_key, NULL,
@@ -1819,7 +1819,7 @@ unpack_order_set(xmlNode * set, enum pe_order_kind parent_kind, resource_t ** rs
 
     set_iter = resources;
     while (set_iter != NULL) {
-        resource = (resource_t *) set_iter->data;
+        resource = (pe_resource_t *) set_iter->data;
         set_iter = set_iter->next;
 
         /*
@@ -1853,8 +1853,8 @@ order_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, enum pe_order_kin
     xmlNode *xml_rsc = NULL;
     xmlNode *xml_rsc_2 = NULL;
 
-    resource_t *rsc_1 = NULL;
-    resource_t *rsc_2 = NULL;
+    pe_resource_t *rsc_1 = NULL;
+    pe_resource_t *rsc_2 = NULL;
 
     const char *action_1 = crm_element_value(set1, "action");
     const char *action_2 = crm_element_value(set2, "action");
@@ -2050,8 +2050,8 @@ unpack_order_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t *
     const char *action_first = NULL;
     const char *action_then = NULL;
 
-    resource_t *rsc_first = NULL;
-    resource_t *rsc_then = NULL;
+    pe_resource_t *rsc_first = NULL;
+    pe_resource_t *rsc_then = NULL;
     pe_tag_t *tag_first = NULL;
     pe_tag_t *tag_then = NULL;
 
@@ -2155,10 +2155,10 @@ unpack_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
 {
     gboolean any_sets = FALSE;
 
-    resource_t *rsc = NULL;
+    pe_resource_t *rsc = NULL;
 
     /*
-       resource_t *last_rsc = NULL;
+       pe_resource_t *last_rsc = NULL;
      */
 
     pe_action_t *set_end = NULL;
@@ -2281,8 +2281,8 @@ static gboolean
 unpack_colocation_set(xmlNode * set, int score, pe_working_set_t * data_set)
 {
     xmlNode *xml_rsc = NULL;
-    resource_t *with = NULL;
-    resource_t *resource = NULL;
+    pe_resource_t *with = NULL;
+    pe_resource_t *resource = NULL;
     const char *set_id = ID(set);
     const char *role = crm_element_value(set, "role");
     const char *sequential = crm_element_value(set, "sequential");
@@ -2318,7 +2318,7 @@ unpack_colocation_set(xmlNode * set, int score, pe_working_set_t * data_set)
             }
         }
     } else if (local_score >= 0) {
-        resource_t *last = NULL;
+        pe_resource_t *last = NULL;
         for (xml_rsc = __xml_first_child_element(set); xml_rsc != NULL;
              xml_rsc = __xml_next_element(xml_rsc)) {
 
@@ -2375,8 +2375,8 @@ colocate_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, int score,
                   pe_working_set_t * data_set)
 {
     xmlNode *xml_rsc = NULL;
-    resource_t *rsc_1 = NULL;
-    resource_t *rsc_2 = NULL;
+    pe_resource_t *rsc_1 = NULL;
+    pe_resource_t *rsc_2 = NULL;
 
     const char *role_1 = crm_element_value(set1, "role");
     const char *role_2 = crm_element_value(set2, "role");
@@ -2477,8 +2477,8 @@ unpack_simple_colocation(xmlNode * xml_obj, pe_working_set_t * data_set)
     const char *instance_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE_INSTANCE);
     const char *instance_rh = crm_element_value(xml_obj, XML_COLOC_ATTR_TARGET_INSTANCE);
 
-    resource_t *rsc_lh = pe_find_constraint_resource(data_set->resources, id_lh);
-    resource_t *rsc_rh = pe_find_constraint_resource(data_set->resources, id_rh);
+    pe_resource_t *rsc_lh = pe_find_constraint_resource(data_set->resources, id_lh);
+    pe_resource_t *rsc_rh = pe_find_constraint_resource(data_set->resources, id_rh);
 
     if (rsc_lh == NULL) {
         pcmk__config_err("Ignoring constraint '%s' because resource '%s' "
@@ -2546,8 +2546,8 @@ unpack_colocation_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_se
     const char *state_lh = NULL;
     const char *state_rh = NULL;
 
-    resource_t *rsc_lh = NULL;
-    resource_t *rsc_rh = NULL;
+    pe_resource_t *rsc_lh = NULL;
+    pe_resource_t *rsc_rh = NULL;
 
     pe_tag_t *tag_lh = NULL;
     pe_tag_t *tag_rh = NULL;
@@ -2712,7 +2712,7 @@ unpack_rsc_colocation(xmlNode * xml_obj, pe_working_set_t * data_set)
 }
 
 gboolean
-rsc_ticket_new(const char *id, resource_t * rsc_lh, pe_ticket_t * ticket,
+rsc_ticket_new(const char *id, pe_resource_t * rsc_lh, pe_ticket_t * ticket,
                const char *state_lh, const char *loss_policy, pe_working_set_t * data_set)
 {
     rsc_ticket_t *new_rsc_ticket = NULL;
@@ -2805,7 +2805,7 @@ unpack_rsc_ticket_set(xmlNode * set, pe_ticket_t * ticket, const char *loss_poli
                       pe_working_set_t * data_set)
 {
     xmlNode *xml_rsc = NULL;
-    resource_t *resource = NULL;
+    pe_resource_t *resource = NULL;
     const char *set_id = NULL;
     const char *role = NULL;
 
@@ -2848,7 +2848,7 @@ unpack_simple_rsc_ticket(xmlNode * xml_obj, pe_working_set_t * data_set)
     // experimental syntax from pacemaker-next (unlikely to be adopted as-is)
     const char *instance_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE_INSTANCE);
 
-    resource_t *rsc_lh = NULL;
+    pe_resource_t *rsc_lh = NULL;
 
     CRM_CHECK(xml_obj != NULL, return FALSE);
 
@@ -2913,7 +2913,7 @@ unpack_rsc_ticket_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_se
     const char *id_lh = NULL;
     const char *state_lh = NULL;
 
-    resource_t *rsc_lh = NULL;
+    pe_resource_t *rsc_lh = NULL;
     pe_tag_t *tag_lh = NULL;
 
     xmlNode *new_xml = NULL;

--- a/lib/pacemaker/pcmk_sched_graph.c
+++ b/lib/pacemaker/pcmk_sched_graph.c
@@ -23,7 +23,7 @@ void update_colo_start_chain(pe_action_t *action, pe_working_set_t *data_set);
 gboolean rsc_update_action(pe_action_t * first, pe_action_t * then, enum pe_ordering type);
 
 static enum pe_action_flags
-get_action_flags(pe_action_t * action, node_t * node)
+get_action_flags(pe_action_t * action, pe_node_t * node)
 {
     enum pe_action_flags flags = action->flags;
 
@@ -172,7 +172,7 @@ rsc_expand_action(pe_action_t * action)
 }
 
 static enum pe_graph_flags
-graph_update_action(pe_action_t * first, pe_action_t * then, node_t * node,
+graph_update_action(pe_action_t * first, pe_action_t * then, pe_node_t * node,
                     enum pe_action_flags first_flags, enum pe_action_flags then_flags,
                     pe_action_wrapper_t *order, pe_working_set_t *data_set)
 {
@@ -549,8 +549,8 @@ update_action(pe_action_t *then, pe_working_set_t *data_set)
         pe_action_wrapper_t *other = (pe_action_wrapper_t *) lpc->data;
         pe_action_t *first = other->action;
 
-        node_t *then_node = then->node;
-        node_t *first_node = first->node;
+        pe_node_t *then_node = then->node;
+        pe_node_t *first_node = first->node;
 
         enum pe_action_flags then_flags = 0;
         enum pe_action_flags first_flags = 0;
@@ -632,7 +632,7 @@ update_action(pe_action_t *then, pe_working_set_t *data_set)
              *   constraint to instances on the supplied node
              *
              */
-            node_t *node = then->node;
+            pe_node_t *node = then->node;
             changed |= graph_update_action(first, then, node, first_flags,
                                            then_flags, other, data_set);
 
@@ -704,7 +704,7 @@ update_action(pe_action_t *then, pe_working_set_t *data_set)
 }
 
 gboolean
-shutdown_constraints(node_t * node, pe_action_t * shutdown_op, pe_working_set_t * data_set)
+shutdown_constraints(pe_node_t * node, pe_action_t * shutdown_op, pe_working_set_t * data_set)
 {
     /* add the stop to the before lists so it counts as a pre-req
      * for the shutdown
@@ -767,12 +767,12 @@ pcmk__order_vs_fence(pe_action_t *stonith_op, pe_working_set_t *data_set)
     }
 }
 
-static node_t *
+static pe_node_t *
 get_router_node(pe_action_t *action)
 {
-    node_t *began_on = NULL;
-    node_t *ended_on = NULL;
-    node_t *router_node = NULL;
+    pe_node_t *began_on = NULL;
+    pe_node_t *ended_on = NULL;
+    pe_node_t *router_node = NULL;
     bool partial_migration = FALSE;
     const char *task = action->task;
 
@@ -868,7 +868,7 @@ add_node_to_xml_by_id(const char *id, xmlNode *xml)
  * \param[in,out] xml   XML to add node to
  */
 static void
-add_node_to_xml(const node_t *node, void *xml)
+add_node_to_xml(const pe_node_t *node, void *xml)
 {
     add_node_to_xml_by_id(node->details->id, (xmlNode *) xml);
 }
@@ -890,7 +890,7 @@ add_maintenance_nodes(xmlNode *xml, const pe_working_set_t *data_set)
 
     for (gIter = data_set->nodes; gIter != NULL;
          gIter = gIter->next) {
-        node_t *node = (node_t *) gIter->data;
+        pe_node_t *node = (pe_node_t *) gIter->data;
         struct pe_node_shared_s *details = node->details;
 
         if (!pe__is_guest_or_remote_node(node)) {
@@ -1103,7 +1103,7 @@ action2xml(pe_action_t * action, gboolean as_input, pe_working_set_t *data_set)
     }
 
     if (needs_node_info && action->node != NULL) {
-        node_t *router_node = get_router_node(action);
+        pe_node_t *router_node = get_router_node(action);
 
         crm_xml_add(action_xml, XML_LRM_ATTR_TARGET, action->node->details->uname);
         crm_xml_add(action_xml, XML_LRM_ATTR_TARGET_UUID, action->node->details->id);

--- a/lib/pacemaker/pcmk_sched_graph.c
+++ b/lib/pacemaker/pcmk_sched_graph.c
@@ -174,7 +174,7 @@ rsc_expand_action(pe_action_t * action)
 static enum pe_graph_flags
 graph_update_action(pe_action_t * first, pe_action_t * then, node_t * node,
                     enum pe_action_flags first_flags, enum pe_action_flags then_flags,
-                    action_wrapper_t *order, pe_working_set_t *data_set)
+                    pe_action_wrapper_t *order, pe_working_set_t *data_set)
 {
     enum pe_graph_flags changed = pe_graph_none;
     enum pe_ordering type = order->type;
@@ -546,7 +546,7 @@ update_action(pe_action_t *then, pe_working_set_t *data_set)
     }
 
     for (lpc = then->actions_before; lpc != NULL; lpc = lpc->next) {
-        action_wrapper_t *other = (action_wrapper_t *) lpc->data;
+        pe_action_wrapper_t *other = (pe_action_wrapper_t *) lpc->data;
         pe_action_t *first = other->action;
 
         node_t *then_node = then->node;
@@ -664,7 +664,7 @@ update_action(pe_action_t *then, pe_working_set_t *data_set)
                              pe_action_pseudo) ? "pseudo" : first->node ? first->node->details->
                       uname : "");
             for (lpc2 = first->actions_after; lpc2 != NULL; lpc2 = lpc2->next) {
-                action_wrapper_t *other = (action_wrapper_t *) lpc2->data;
+                pe_action_wrapper_t *other = (pe_action_wrapper_t *) lpc2->data;
 
                 update_action(other->action, data_set);
             }
@@ -694,7 +694,7 @@ update_action(pe_action_t *then, pe_working_set_t *data_set)
         }
         update_action(then, data_set);
         for (lpc = then->actions_after; lpc != NULL; lpc = lpc->next) {
-            action_wrapper_t *other = (action_wrapper_t *) lpc->data;
+            pe_action_wrapper_t *other = (pe_action_wrapper_t *) lpc->data;
 
             update_action(other->action, data_set);
         }
@@ -975,7 +975,7 @@ add_downed_nodes(xmlNode *xml, const pe_action_t *action,
         gboolean migrating = FALSE;
 
         for (iter = action->actions_before; iter != NULL; iter = iter->next) {
-            input = ((action_wrapper_t *) iter->data)->action;
+            input = ((pe_action_wrapper_t *) iter->data)->action;
             if (input->rsc && safe_str_eq(action->rsc->id, input->rsc->id)
                && safe_str_eq(input->task, CRMD_ACTION_MIGRATED)) {
                 migrating = TRUE;
@@ -1442,8 +1442,8 @@ should_dump_action(pe_action_t *action)
 static gint
 sort_action_id(gconstpointer a, gconstpointer b)
 {
-    const action_wrapper_t *action_wrapper2 = (const action_wrapper_t *)a;
-    const action_wrapper_t *action_wrapper1 = (const action_wrapper_t *)b;
+    const pe_action_wrapper_t *action_wrapper2 = (const pe_action_wrapper_t *)a;
+    const pe_action_wrapper_t *action_wrapper1 = (const pe_action_wrapper_t *)b;
 
     if (a == NULL) {
         return 1;

--- a/lib/pacemaker/pcmk_sched_graph.c
+++ b/lib/pacemaker/pcmk_sched_graph.c
@@ -57,7 +57,7 @@ get_action_flags(pe_action_t * action, node_t * node)
 }
 
 static char *
-convert_non_atomic_uuid(char *old_uuid, resource_t * rsc, gboolean allow_notify,
+convert_non_atomic_uuid(char *old_uuid, pe_resource_t * rsc, gboolean allow_notify,
                         gboolean free_original)
 {
     guint interval_ms = 0;
@@ -138,7 +138,7 @@ rsc_expand_action(pe_action_t * action)
 {
     gboolean notify = FALSE;
     pe_action_t *result = action;
-    resource_t *rsc = action->rsc;
+    pe_resource_t *rsc = action->rsc;
 
     if (rsc == NULL) {
         return action;
@@ -472,7 +472,7 @@ void
 update_colo_start_chain(pe_action_t *action, pe_working_set_t *data_set)
 {
     GListPtr gIter = NULL;
-    resource_t *rsc = NULL;
+    pe_resource_t *rsc = NULL;
 
     if (is_not_set(action->flags, pe_action_runnable) && safe_str_eq(action->task, RSC_START)) {
         rsc = uber_parent(action->rsc);
@@ -493,7 +493,7 @@ update_colo_start_chain(pe_action_t *action, pe_working_set_t *data_set)
     /* if rsc has children, all the children need to have start set to
      * unrunnable before we follow the colo chain for the parent. */
     for (gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child = (resource_t *)gIter->data;
+        pe_resource_t *child = (pe_resource_t *)gIter->data;
         pe_action_t *start = find_first_action(child->actions, NULL, RSC_START, NULL);
         if (start == NULL || is_set(start->flags, pe_action_runnable)) {
             return;
@@ -1246,7 +1246,7 @@ action2xml(pe_action_t * action, gboolean as_input, pe_working_set_t *data_set)
     g_hash_table_foreach(action->meta, hash2metafield, args_xml);
     if (action->rsc != NULL) {
         const char *value = g_hash_table_lookup(action->rsc->meta, "external-ip");
-        resource_t *parent = action->rsc;
+        pe_resource_t *parent = action->rsc;
 
         while (parent != NULL) {
             parent->cmds->append_meta(parent, args_xml);

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -56,7 +56,7 @@ pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer,
 
     gIter = rsc->children;
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         pe_rsc_trace(rsc, "Allocating group %s member %s",
                      rsc->id, child_rsc->id);
@@ -76,10 +76,10 @@ pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer,
     return NULL;
 }
 
-void group_update_pseudo_status(resource_t * parent, resource_t * child);
+void group_update_pseudo_status(pe_resource_t * parent, pe_resource_t * child);
 
 void
-group_create_actions(resource_t * rsc, pe_working_set_t * data_set)
+group_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
     pe_action_t *op = NULL;
     const char *value = NULL;
@@ -88,7 +88,7 @@ group_create_actions(resource_t * rsc, pe_working_set_t * data_set)
     pe_rsc_trace(rsc, "Creating actions for %s", rsc->id);
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         child_rsc->cmds->create_actions(child_rsc, data_set);
         group_update_pseudo_status(rsc, child_rsc);
@@ -127,7 +127,7 @@ group_create_actions(resource_t * rsc, pe_working_set_t * data_set)
 }
 
 void
-group_update_pseudo_status(resource_t * parent, resource_t * child)
+group_update_pseudo_status(pe_resource_t * parent, pe_resource_t * child)
 {
     GListPtr gIter = child->actions;
     group_variant_data_t *group_data = NULL;
@@ -162,12 +162,12 @@ group_update_pseudo_status(resource_t * parent, resource_t * child)
 }
 
 void
-group_internal_constraints(resource_t * rsc, pe_working_set_t * data_set)
+group_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
     GListPtr gIter = rsc->children;
-    resource_t *last_rsc = NULL;
-    resource_t *last_active = NULL;
-    resource_t *top = uber_parent(rsc);
+    pe_resource_t *last_rsc = NULL;
+    pe_resource_t *last_active = NULL;
+    pe_resource_t *top = uber_parent(rsc);
     group_variant_data_t *group_data = NULL;
 
     get_group_variant_data(group_data, rsc);
@@ -177,7 +177,7 @@ group_internal_constraints(resource_t * rsc, pe_working_set_t * data_set)
     new_rsc_order(rsc, RSC_STOP, rsc, RSC_STOPPED, pe_order_runnable_left, data_set);
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
         int stop = pe_order_none;
         int stopped = pe_order_implies_then_printed;
         int start = pe_order_implies_then | pe_order_runnable_left;
@@ -320,7 +320,7 @@ group_rsc_colocation_lh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
     }
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         child_rsc->cmds->rsc_colocation_lh(child_rsc, rsc_rh, constraint,
                                            data_set);
@@ -371,7 +371,7 @@ group_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
     }
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         child_rsc->cmds->rsc_colocation_rh(rsc_lh, child_rsc, constraint,
                                            data_set);
@@ -385,7 +385,7 @@ group_action_flags(pe_action_t * action, node_t * node)
     enum pe_action_flags flags = (pe_action_optional | pe_action_runnable | pe_action_pseudo);
 
     for (gIter = action->rsc->children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child = (resource_t *) gIter->data;
+        pe_resource_t *child = (pe_resource_t *) gIter->data;
         enum action_tasks task = get_complex_task(child, action->task, TRUE);
         const char *task_s = task2text(task);
         pe_action_t *child_action = find_first_action(child->actions, NULL, task_s, node);
@@ -432,7 +432,7 @@ group_update_actions(pe_action_t *first, pe_action_t *then, pe_node_t *node,
                                      data_set);
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child = (resource_t *) gIter->data;
+        pe_resource_t *child = (pe_resource_t *) gIter->data;
         pe_action_t *child_action = find_first_action(child->actions, NULL, then->task, node);
 
         if (child_action) {
@@ -461,7 +461,7 @@ group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
     native_rsc_location(rsc, constraint);
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         child_rsc->cmds->rsc_location(child_rsc, constraint);
         if (group_data->colocated && reset_scores) {
@@ -475,7 +475,7 @@ group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
 }
 
 void
-group_expand(resource_t * rsc, pe_working_set_t * data_set)
+group_expand(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
     CRM_CHECK(rsc != NULL, return);
 
@@ -483,7 +483,7 @@ group_expand(resource_t * rsc, pe_working_set_t * data_set)
     native_expand(rsc, data_set);
 
     for (GListPtr gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         child_rsc->cmds->expand(child_rsc, data_set);
     }
@@ -527,6 +527,6 @@ pcmk__group_merge_weights(pe_resource_t *rsc, const char *rhs,
 }
 
 void
-group_append_meta(resource_t * rsc, xmlNode * xml)
+group_append_meta(pe_resource_t * rsc, xmlNode * xml)
 {
 }

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -20,8 +20,8 @@ pe_node_t *
 pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer,
                      pe_working_set_t *data_set)
 {
-    node_t *node = NULL;
-    node_t *group_node = NULL;
+    pe_node_t *node = NULL;
+    pe_node_t *group_node = NULL;
     GListPtr gIter = NULL;
     group_variant_data_t *group_data = NULL;
 
@@ -379,7 +379,7 @@ group_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
 }
 
 enum pe_action_flags
-group_action_flags(pe_action_t * action, node_t * node)
+group_action_flags(pe_action_t * action, pe_node_t * node)
 {
     GListPtr gIter = NULL;
     enum pe_action_flags flags = (pe_action_optional | pe_action_runnable | pe_action_pseudo);

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -81,7 +81,7 @@ void group_update_pseudo_status(resource_t * parent, resource_t * child);
 void
 group_create_actions(resource_t * rsc, pe_working_set_t * data_set)
 {
-    action_t *op = NULL;
+    pe_action_t *op = NULL;
     const char *value = NULL;
     GListPtr gIter = rsc->children;
 
@@ -144,7 +144,7 @@ group_update_pseudo_status(resource_t * parent, resource_t * child)
     }
 
     for (; gIter != NULL; gIter = gIter->next) {
-        action_t *action = (action_t *) gIter->data;
+        pe_action_t *action = (pe_action_t *) gIter->data;
 
         if (is_set(action->flags, pe_action_optional)) {
             continue;
@@ -379,7 +379,7 @@ group_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
 }
 
 enum pe_action_flags
-group_action_flags(action_t * action, node_t * node)
+group_action_flags(pe_action_t * action, node_t * node)
 {
     GListPtr gIter = NULL;
     enum pe_action_flags flags = (pe_action_optional | pe_action_runnable | pe_action_pseudo);
@@ -388,7 +388,7 @@ group_action_flags(action_t * action, node_t * node)
         resource_t *child = (resource_t *) gIter->data;
         enum action_tasks task = get_complex_task(child, action->task, TRUE);
         const char *task_s = task2text(task);
-        action_t *child_action = find_first_action(child->actions, NULL, task_s, node);
+        pe_action_t *child_action = find_first_action(child->actions, NULL, task_s, node);
 
         if (child_action) {
             enum pe_action_flags child_flags = child->cmds->action_flags(child_action, node);
@@ -433,7 +433,7 @@ group_update_actions(pe_action_t *first, pe_action_t *then, pe_node_t *node,
 
     for (; gIter != NULL; gIter = gIter->next) {
         resource_t *child = (resource_t *) gIter->data;
-        action_t *child_action = find_first_action(child->actions, NULL, then->task, node);
+        pe_action_t *child_action = find_first_action(child->actions, NULL, then->task, node);
 
         if (child_action) {
             changed |= child->cmds->update_actions(first, child_action, node,

--- a/lib/pacemaker/pcmk_sched_messages.c
+++ b/lib/pacemaker/pcmk_sched_messages.c
@@ -126,7 +126,7 @@ pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input,
     if (get_crm_log_level() == LOG_TRACE) {
         gIter = data_set->actions;
         for (; gIter != NULL; gIter = gIter->next) {
-            action_t *action = (action_t *) gIter->data;
+            pe_action_t *action = (pe_action_t *) gIter->data;
 
             if (is_set(action->flags, pe_action_optional) == FALSE
                 && is_set(action->flags, pe_action_runnable) == FALSE

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -28,13 +28,13 @@ void native_rsc_colocation_rh_must(resource_t * rsc_lh, gboolean update_lh,
 void native_rsc_colocation_rh_mustnot(resource_t * rsc_lh, gboolean update_lh,
                                       resource_t * rsc_rh, gboolean update_rh);
 
-static void Recurring(resource_t *rsc, action_t *start, node_t *node,
+static void Recurring(resource_t *rsc, pe_action_t *start, node_t *node,
                       pe_working_set_t *data_set);
-static void RecurringOp(resource_t *rsc, action_t *start, node_t *node,
+static void RecurringOp(resource_t *rsc, pe_action_t *start, node_t *node,
                         xmlNode *operation, pe_working_set_t *data_set);
-static void Recurring_Stopped(resource_t *rsc, action_t *start, node_t *node,
+static void Recurring_Stopped(resource_t *rsc, pe_action_t *start, node_t *node,
                               pe_working_set_t *data_set);
-static void RecurringOp_Stopped(resource_t *rsc, action_t *start, node_t *node,
+static void RecurringOp_Stopped(resource_t *rsc, pe_action_t *start, node_t *node,
                                 xmlNode *operation, pe_working_set_t *data_set);
 
 void ReloadRsc(resource_t * rsc, node_t *node, pe_working_set_t * data_set);
@@ -678,7 +678,7 @@ op_cannot_recur(const char *name)
 }
 
 static void
-RecurringOp(resource_t * rsc, action_t * start, node_t * node,
+RecurringOp(resource_t * rsc, pe_action_t * start, node_t * node,
             xmlNode * operation, pe_working_set_t * data_set)
 {
     char *key = NULL;
@@ -688,7 +688,7 @@ RecurringOp(resource_t * rsc, action_t * start, node_t * node,
     const char *node_uname = node? node->details->uname : "n/a";
 
     guint interval_ms = 0;
-    action_t *mon = NULL;
+    pe_action_t *mon = NULL;
     gboolean is_optional = TRUE;
     GListPtr possible_matches = NULL;
 
@@ -750,7 +750,7 @@ RecurringOp(resource_t * rsc, action_t * start, node_t * node,
         GListPtr gIter = NULL;
 
         for (gIter = possible_matches; gIter != NULL; gIter = gIter->next) {
-            action_t *op = (action_t *) gIter->data;
+            pe_action_t *op = (pe_action_t *) gIter->data;
 
             if (is_set(op->flags, pe_action_reschedule)) {
                 is_optional = FALSE;
@@ -767,7 +767,7 @@ RecurringOp(resource_t * rsc, action_t * start, node_t * node,
 
         if (is_optional) {
             char *after_key = NULL;
-            action_t *cancel_op = NULL;
+            pe_action_t *cancel_op = NULL;
 
             // It's running, so cancel it
             log_level = LOG_INFO;
@@ -857,7 +857,7 @@ RecurringOp(resource_t * rsc, action_t * start, node_t * node,
 }
 
 static void
-Recurring(resource_t * rsc, action_t * start, node_t * node, pe_working_set_t * data_set)
+Recurring(resource_t * rsc, pe_action_t * start, node_t * node, pe_working_set_t * data_set)
 {
     if (is_not_set(rsc->flags, pe_rsc_maintenance) &&
         (node == NULL || node->details->maintenance == FALSE)) {
@@ -875,7 +875,7 @@ Recurring(resource_t * rsc, action_t * start, node_t * node, pe_working_set_t * 
 }
 
 static void
-RecurringOp_Stopped(resource_t * rsc, action_t * start, node_t * node,
+RecurringOp_Stopped(resource_t * rsc, pe_action_t * start, node_t * node,
                     xmlNode * operation, pe_working_set_t * data_set)
 {
     char *key = NULL;
@@ -937,7 +937,7 @@ RecurringOp_Stopped(resource_t * rsc, action_t * start, node_t * node,
     if (node != NULL) {
         possible_matches = find_actions_exact(rsc->actions, key, node);
         if (possible_matches) {
-            action_t *cancel_op = NULL;
+            pe_action_t *cancel_op = NULL;
 
             g_list_free(possible_matches);
 
@@ -961,7 +961,7 @@ RecurringOp_Stopped(resource_t * rsc, action_t * start, node_t * node,
         gboolean is_optional = TRUE;
         gboolean probe_is_optional = TRUE;
         gboolean stop_is_optional = TRUE;
-        action_t *stopped_mon = NULL;
+        pe_action_t *stopped_mon = NULL;
         char *rc_inactive = NULL;
         GListPtr probe_complete_ops = NULL;
         GListPtr stop_ops = NULL;
@@ -999,7 +999,7 @@ RecurringOp_Stopped(resource_t * rsc, action_t * start, node_t * node,
             GListPtr pIter = NULL;
 
             for (pIter = probes; pIter != NULL; pIter = pIter->next) {
-                action_t *probe = (action_t *) pIter->data;
+                pe_action_t *probe = (pe_action_t *) pIter->data;
 
                 order_actions(probe, stopped_mon, pe_order_runnable_left);
                 crm_trace("%s then %s on %s", probe->uuid, stopped_mon->uuid, stop_node->details->uname);
@@ -1015,7 +1015,7 @@ RecurringOp_Stopped(resource_t * rsc, action_t * start, node_t * node,
         stop_ops = pe__resource_actions(rsc, stop_node, RSC_STOP, TRUE);
 
         for (local_gIter = stop_ops; local_gIter != NULL; local_gIter = local_gIter->next) {
-            action_t *stop = (action_t *) local_gIter->data;
+            pe_action_t *stop = (pe_action_t *) local_gIter->data;
 
             if (is_set(stop->flags, pe_action_optional) == FALSE) {
                 stop_is_optional = FALSE;
@@ -1067,7 +1067,7 @@ RecurringOp_Stopped(resource_t * rsc, action_t * start, node_t * node,
 }
 
 static void
-Recurring_Stopped(resource_t * rsc, action_t * start, node_t * node, pe_working_set_t * data_set)
+Recurring_Stopped(resource_t * rsc, pe_action_t * start, node_t * node, pe_working_set_t * data_set)
 {
     if (is_not_set(rsc->flags, pe_rsc_maintenance) && 
         (node == NULL || node->details->maintenance == FALSE)) {
@@ -1087,10 +1087,10 @@ Recurring_Stopped(resource_t * rsc, action_t * start, node_t * node, pe_working_
 static void
 handle_migration_actions(resource_t * rsc, node_t *current, node_t *chosen, pe_working_set_t * data_set)
 {
-    action_t *migrate_to = NULL;
-    action_t *migrate_from = NULL;
-    action_t *start = NULL;
-    action_t *stop = NULL;
+    pe_action_t *migrate_to = NULL;
+    pe_action_t *migrate_from = NULL;
+    pe_action_t *start = NULL;
+    pe_action_t *stop = NULL;
     gboolean partial = rsc->partial_migration_target ? TRUE : FALSE;
 
     pe_rsc_trace(rsc, "Processing migration actions %s moving from %s to %s . partial migration = %s",
@@ -1175,7 +1175,7 @@ handle_migration_actions(resource_t * rsc, node_t *current, node_t *chosen, pe_w
 void
 native_create_actions(resource_t * rsc, pe_working_set_t * data_set)
 {
-    action_t *start = NULL;
+    pe_action_t *start = NULL;
     node_t *chosen = NULL;
     node_t *current = NULL;
     gboolean need_stop = FALSE;
@@ -1208,7 +1208,7 @@ native_create_actions(resource_t * rsc, pe_working_set_t * data_set)
     for (gIter = rsc->dangling_migrations; gIter != NULL; gIter = gIter->next) {
         node_t *dangling_source = (node_t *) gIter->data;
 
-        action_t *stop = stop_action(rsc, dangling_source, FALSE);
+        pe_action_t *stop = stop_action(rsc, dangling_source, FALSE);
 
         set_bit(stop->flags, pe_action_dangle);
         pe_rsc_trace(rsc, "Forcing a cleanup of %s on %s",
@@ -1518,7 +1518,7 @@ native_internal_constraints(resource_t * rsc, pe_working_set_t * data_set)
 
             char *load_stopped_task = crm_strdup_printf(LOAD_STOPPED "_%s",
                                                         current->details->uname);
-            action_t *load_stopped = get_pseudo_op(load_stopped_task, data_set);
+            pe_action_t *load_stopped = get_pseudo_op(load_stopped_task, data_set);
 
             if (load_stopped->node == NULL) {
                 load_stopped->node = node_copy(current);
@@ -1533,7 +1533,7 @@ native_internal_constraints(resource_t * rsc, pe_working_set_t * data_set)
             pe_node_t *next = item->data;
             char *load_stopped_task = crm_strdup_printf(LOAD_STOPPED "_%s",
                                                         next->details->uname);
-            action_t *load_stopped = get_pseudo_op(load_stopped_task, data_set);
+            pe_action_t *load_stopped = get_pseudo_op(load_stopped_task, data_set);
 
             if (load_stopped->node == NULL) {
                 load_stopped->node = node_copy(next);
@@ -1992,7 +1992,7 @@ rsc_ticket_constraint(resource_t * rsc_lh, rsc_ticket_t * rsc_ticket, pe_working
 }
 
 enum pe_action_flags
-native_action_flags(action_t * action, node_t * node)
+native_action_flags(pe_action_t * action, node_t * node)
 {
     return action->flags;
 }
@@ -2299,7 +2299,7 @@ native_expand(resource_t * rsc, pe_working_set_t * data_set)
     pe_rsc_trace(rsc, "Processing actions from %s", rsc->id);
 
     for (gIter = rsc->actions; gIter != NULL; gIter = gIter->next) {
-        action_t *action = (action_t *) gIter->data;
+        pe_action_t *action = (pe_action_t *) gIter->data;
 
         crm_trace("processing action %d for rsc=%s", action->id, rsc->id);
         graph_element_from_action(action, data_set);
@@ -2445,10 +2445,10 @@ LogActions(resource_t * rsc, pe_working_set_t * data_set, gboolean terminal)
     node_t *current = NULL;
     pe_node_t *start_node = NULL;
 
-    action_t *stop = NULL;
-    action_t *start = NULL;
-    action_t *demote = NULL;
-    action_t *promote = NULL;
+    pe_action_t *stop = NULL;
+    pe_action_t *start = NULL;
+    pe_action_t *demote = NULL;
+    pe_action_t *promote = NULL;
 
     char *key = NULL;
     gboolean moving = FALSE;
@@ -2529,7 +2529,7 @@ LogActions(resource_t * rsc, pe_working_set_t * data_set, gboolean terminal)
     }
 
     if (rsc->role == rsc->next_role) {
-        action_t *migrate_op = NULL;
+        pe_action_t *migrate_op = NULL;
 
         possible_matches = pe__resource_actions(rsc, next, RSC_MIGRATED, FALSE);
         if (possible_matches) {
@@ -2579,7 +2579,7 @@ LogActions(resource_t * rsc, pe_working_set_t * data_set, gboolean terminal)
         key = stop_key(rsc);
         for (gIter = rsc->running_on; gIter != NULL; gIter = gIter->next) {
             node_t *node = (node_t *) gIter->data;
-            action_t *stop_op = NULL;
+            pe_action_t *stop_op = NULL;
 
             possible_matches = find_actions(rsc->actions, key, node);
             if (possible_matches) {
@@ -2636,7 +2636,7 @@ StopRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * d
 
     for (gIter = rsc->running_on; gIter != NULL; gIter = gIter->next) {
         node_t *current = (node_t *) gIter->data;
-        action_t *stop;
+        pe_action_t *stop;
 
         if (rsc->partial_migration_target) {
             if (rsc->partial_migration_target->details == current->details) {
@@ -2665,7 +2665,7 @@ StopRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * d
         }
 
         if(is_set(rsc->flags, pe_rsc_needs_unfencing)) {
-            action_t *unfence = pe_fence_op(current, "on", TRUE, NULL, data_set);
+            pe_action_t *unfence = pe_fence_op(current, "on", TRUE, NULL, data_set);
 
             order_actions(stop, unfence, pe_order_implies_first);
             if (!node_has_been_unfenced(current)) {
@@ -2678,7 +2678,7 @@ StopRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * d
 }
 
 static void
-order_after_unfencing(resource_t *rsc, pe_node_t *node, action_t *action,
+order_after_unfencing(resource_t *rsc, pe_node_t *node, pe_action_t *action,
                       enum pe_ordering order, pe_working_set_t *data_set)
 {
     /* When unfencing is in use, we order unfence actions before any probe or
@@ -2695,7 +2695,7 @@ order_after_unfencing(resource_t *rsc, pe_node_t *node, action_t *action,
          * the node being unfenced, and all its resources being stopped,
          * whenever a new resource is added -- which would be highly suboptimal.
          */
-        action_t *unfence = pe_fence_op(node, "on", TRUE, NULL, data_set);
+        pe_action_t *unfence = pe_fence_op(node, "on", TRUE, NULL, data_set);
 
         order_actions(unfence, action, order);
 
@@ -2713,7 +2713,7 @@ order_after_unfencing(resource_t *rsc, pe_node_t *node, action_t *action,
 gboolean
 StartRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
-    action_t *start = NULL;
+    pe_action_t *start = NULL;
 
     CRM_ASSERT(rsc);
     pe_rsc_trace(rsc, "%s on %s %d %d", rsc->id, next ? next->details->uname : "N/A", optional, next ? next->weight : 0);
@@ -2743,7 +2743,7 @@ PromoteRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t 
     action_list = pe__resource_actions(rsc, next, RSC_START, TRUE);
 
     for (gIter = action_list; gIter != NULL; gIter = gIter->next) {
-        action_t *start = (action_t *) gIter->data;
+        pe_action_t *start = (pe_action_t *) gIter->data;
 
         if (is_set(start->flags, pe_action_runnable) == FALSE) {
             runnable = FALSE;
@@ -2761,7 +2761,7 @@ PromoteRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t 
     action_list = pe__resource_actions(rsc, next, RSC_PROMOTE, TRUE);
 
     for (gIter = action_list; gIter != NULL; gIter = gIter->next) {
-        action_t *promote = (action_t *) gIter->data;
+        pe_action_t *promote = (pe_action_t *) gIter->data;
 
         update_action_flags(promote, pe_action_runnable | pe_action_clear, __FUNCTION__, __LINE__);
     }
@@ -2836,12 +2836,12 @@ DeleteRsc(resource_t * rsc, node_t * node, gboolean optional, pe_working_set_t *
 }
 
 gboolean
-native_create_probe(resource_t * rsc, node_t * node, action_t * complete,
+native_create_probe(resource_t * rsc, node_t * node, pe_action_t * complete,
                     gboolean force, pe_working_set_t * data_set)
 {
     enum pe_ordering flags = pe_order_optional;
     char *key = NULL;
-    action_t *probe = NULL;
+    pe_action_t *probe = NULL;
     node_t *running = NULL;
     node_t *allowed = NULL;
     resource_t *top = uber_parent(rsc);
@@ -3099,7 +3099,7 @@ rsc_is_known_on(pe_resource_t *rsc, const pe_node_t *node)
  * \param[in] data_set    Cluster information
  */
 static void
-native_start_constraints(resource_t * rsc, action_t * stonith_op, pe_working_set_t * data_set)
+native_start_constraints(resource_t * rsc, pe_action_t * stonith_op, pe_working_set_t * data_set)
 {
     node_t *target;
     GListPtr gIter = NULL;
@@ -3108,7 +3108,7 @@ native_start_constraints(resource_t * rsc, action_t * stonith_op, pe_working_set
     target = stonith_op->node;
 
     for (gIter = rsc->actions; gIter != NULL; gIter = gIter->next) {
-        action_t *action = (action_t *) gIter->data;
+        pe_action_t *action = (pe_action_t *) gIter->data;
 
         switch (action->needs) {
             case rsc_req_nothing:
@@ -3144,7 +3144,7 @@ native_start_constraints(resource_t * rsc, action_t * stonith_op, pe_working_set
 }
 
 static void
-native_stop_constraints(resource_t * rsc, action_t * stonith_op, pe_working_set_t * data_set)
+native_stop_constraints(resource_t * rsc, pe_action_t * stonith_op, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
     GListPtr action_list = NULL;
@@ -3175,7 +3175,7 @@ native_stop_constraints(resource_t * rsc, action_t * stonith_op, pe_working_set_
     }
 
     for (gIter = action_list; gIter != NULL; gIter = gIter->next) {
-        action_t *action = (action_t *) gIter->data;
+        pe_action_t *action = (pe_action_t *) gIter->data;
 
         // The stop would never complete, so convert it into a pseudo-action.
         update_action_flags(action, pe_action_pseudo|pe_action_runnable,
@@ -3275,7 +3275,7 @@ native_stop_constraints(resource_t * rsc, action_t * stonith_op, pe_working_set_
     action_list = pe__resource_actions(rsc, target, RSC_DEMOTE, FALSE);
 
     for (gIter = action_list; gIter != NULL; gIter = gIter->next) {
-        action_t *action = (action_t *) gIter->data;
+        pe_action_t *action = (pe_action_t *) gIter->data;
 
         if (action->node->details->online == FALSE || action->node->details->unclean == TRUE
             || is_set(rsc->flags, pe_rsc_failed)) {
@@ -3308,7 +3308,7 @@ native_stop_constraints(resource_t * rsc, action_t * stonith_op, pe_working_set_
 }
 
 void
-rsc_stonith_ordering(resource_t * rsc, action_t * stonith_op, pe_working_set_t * data_set)
+rsc_stonith_ordering(resource_t * rsc, pe_action_t * stonith_op, pe_working_set_t * data_set)
 {
     if (rsc->children) {
         GListPtr gIter = NULL;
@@ -3332,7 +3332,7 @@ void
 ReloadRsc(resource_t * rsc, node_t *node, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
-    action_t *reload = NULL;
+    pe_action_t *reload = NULL;
 
     if (rsc->children) {
         for (gIter = rsc->children; gIter != NULL; gIter = gIter->next) {

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -22,30 +22,30 @@
 #define VARIANT_NATIVE 1
 #include <lib/pengine/variant.h>
 
-void native_rsc_colocation_rh_must(resource_t * rsc_lh, gboolean update_lh,
-                                   resource_t * rsc_rh, gboolean update_rh);
+void native_rsc_colocation_rh_must(pe_resource_t * rsc_lh, gboolean update_lh,
+                                   pe_resource_t * rsc_rh, gboolean update_rh);
 
-void native_rsc_colocation_rh_mustnot(resource_t * rsc_lh, gboolean update_lh,
-                                      resource_t * rsc_rh, gboolean update_rh);
+void native_rsc_colocation_rh_mustnot(pe_resource_t * rsc_lh, gboolean update_lh,
+                                      pe_resource_t * rsc_rh, gboolean update_rh);
 
-static void Recurring(resource_t *rsc, pe_action_t *start, node_t *node,
+static void Recurring(pe_resource_t *rsc, pe_action_t *start, node_t *node,
                       pe_working_set_t *data_set);
-static void RecurringOp(resource_t *rsc, pe_action_t *start, node_t *node,
+static void RecurringOp(pe_resource_t *rsc, pe_action_t *start, node_t *node,
                         xmlNode *operation, pe_working_set_t *data_set);
-static void Recurring_Stopped(resource_t *rsc, pe_action_t *start, node_t *node,
+static void Recurring_Stopped(pe_resource_t *rsc, pe_action_t *start, node_t *node,
                               pe_working_set_t *data_set);
-static void RecurringOp_Stopped(resource_t *rsc, pe_action_t *start, node_t *node,
+static void RecurringOp_Stopped(pe_resource_t *rsc, pe_action_t *start, node_t *node,
                                 xmlNode *operation, pe_working_set_t *data_set);
 
-void ReloadRsc(resource_t * rsc, node_t *node, pe_working_set_t * data_set);
-gboolean DeleteRsc(resource_t * rsc, node_t * node, gboolean optional, pe_working_set_t * data_set);
-gboolean StopRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
-gboolean StartRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
-gboolean DemoteRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
-gboolean PromoteRsc(resource_t * rsc, node_t * next, gboolean optional,
+void ReloadRsc(pe_resource_t * rsc, node_t *node, pe_working_set_t * data_set);
+gboolean DeleteRsc(pe_resource_t * rsc, node_t * node, gboolean optional, pe_working_set_t * data_set);
+gboolean StopRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
+gboolean StartRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
+gboolean DemoteRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
+gboolean PromoteRsc(pe_resource_t * rsc, node_t * next, gboolean optional,
                     pe_working_set_t * data_set);
-gboolean RoleError(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
-gboolean NullOp(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
+gboolean RoleError(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
+gboolean NullOp(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
 
 /* *INDENT-OFF* */
 enum rsc_role_e rsc_state_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX] = {
@@ -58,7 +58,7 @@ enum rsc_role_e rsc_state_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX] = {
     /* Master */  { RSC_ROLE_STOPPED, RSC_ROLE_SLAVE,   RSC_ROLE_SLAVE,   RSC_ROLE_SLAVE,   RSC_ROLE_MASTER, },
 };
 
-gboolean (*rsc_action_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX])(resource_t*,node_t*,gboolean,pe_working_set_t*) = {
+gboolean (*rsc_action_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX])(pe_resource_t*,node_t*,gboolean,pe_working_set_t*) = {
 /* Current State */
 /*       Next State:       Unknown	Stopped		Started		Slave		Master */
     /* Unknown */	{ RoleError,	StopRsc,	RoleError,	RoleError,	RoleError,  },
@@ -70,7 +70,7 @@ gboolean (*rsc_action_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX])(resource_t*,node_t*,gb
 /* *INDENT-ON* */
 
 static gboolean
-native_choose_node(resource_t * rsc, node_t * prefer, pe_working_set_t * data_set)
+native_choose_node(pe_resource_t * rsc, node_t * prefer, pe_working_set_t * data_set)
 {
     GListPtr nodes = NULL;
     node_t *chosen = NULL;
@@ -461,7 +461,7 @@ node_has_been_unfenced(node_t *node)
 }
 
 static inline bool
-is_unfence_device(resource_t *rsc, pe_working_set_t *data_set)
+is_unfence_device(pe_resource_t *rsc, pe_working_set_t *data_set)
 {
     return is_set(rsc->flags, pe_rsc_fence_device)
            && is_set(data_set->flags, pe_flag_enable_unfencing);
@@ -496,7 +496,7 @@ pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *prefer,
         rsc_colocation_t *constraint = (rsc_colocation_t *) gIter->data;
 
         GHashTable *archive = NULL;
-        resource_t *rsc_rh = constraint->rsc_rh;
+        pe_resource_t *rsc_rh = constraint->rsc_rh;
 
         if (constraint->score == 0) {
             continue;
@@ -629,7 +629,7 @@ pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *prefer,
 }
 
 static gboolean
-is_op_dup(resource_t *rsc, const char *name, guint interval_ms)
+is_op_dup(pe_resource_t *rsc, const char *name, guint interval_ms)
 {
     gboolean dup = FALSE;
     const char *id = NULL;
@@ -678,7 +678,7 @@ op_cannot_recur(const char *name)
 }
 
 static void
-RecurringOp(resource_t * rsc, pe_action_t * start, node_t * node,
+RecurringOp(pe_resource_t * rsc, pe_action_t * start, node_t * node,
             xmlNode * operation, pe_working_set_t * data_set)
 {
     char *key = NULL;
@@ -857,7 +857,7 @@ RecurringOp(resource_t * rsc, pe_action_t * start, node_t * node,
 }
 
 static void
-Recurring(resource_t * rsc, pe_action_t * start, node_t * node, pe_working_set_t * data_set)
+Recurring(pe_resource_t * rsc, pe_action_t * start, node_t * node, pe_working_set_t * data_set)
 {
     if (is_not_set(rsc->flags, pe_rsc_maintenance) &&
         (node == NULL || node->details->maintenance == FALSE)) {
@@ -875,7 +875,7 @@ Recurring(resource_t * rsc, pe_action_t * start, node_t * node, pe_working_set_t
 }
 
 static void
-RecurringOp_Stopped(resource_t * rsc, pe_action_t * start, node_t * node,
+RecurringOp_Stopped(pe_resource_t * rsc, pe_action_t * start, node_t * node,
                     xmlNode * operation, pe_working_set_t * data_set)
 {
     char *key = NULL;
@@ -1067,7 +1067,7 @@ RecurringOp_Stopped(resource_t * rsc, pe_action_t * start, node_t * node,
 }
 
 static void
-Recurring_Stopped(resource_t * rsc, pe_action_t * start, node_t * node, pe_working_set_t * data_set)
+Recurring_Stopped(pe_resource_t * rsc, pe_action_t * start, node_t * node, pe_working_set_t * data_set)
 {
     if (is_not_set(rsc->flags, pe_rsc_maintenance) && 
         (node == NULL || node->details->maintenance == FALSE)) {
@@ -1085,7 +1085,7 @@ Recurring_Stopped(resource_t * rsc, pe_action_t * start, node_t * node, pe_worki
 }
 
 static void
-handle_migration_actions(resource_t * rsc, node_t *current, node_t *chosen, pe_working_set_t * data_set)
+handle_migration_actions(pe_resource_t * rsc, node_t *current, node_t *chosen, pe_working_set_t * data_set)
 {
     pe_action_t *migrate_to = NULL;
     pe_action_t *migrate_from = NULL;
@@ -1173,7 +1173,7 @@ handle_migration_actions(resource_t * rsc, node_t *current, node_t *chosen, pe_w
 }
 
 void
-native_create_actions(resource_t * rsc, pe_working_set_t * data_set)
+native_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
     pe_action_t *start = NULL;
     node_t *chosen = NULL;
@@ -1374,7 +1374,7 @@ native_create_actions(resource_t * rsc, pe_working_set_t * data_set)
 }
 
 static void
-rsc_avoids_remote_nodes(resource_t *rsc)
+rsc_avoids_remote_nodes(pe_resource_t *rsc)
 {
     GHashTableIter iter;
     node_t *node = NULL;
@@ -1416,7 +1416,7 @@ allowed_nodes_as_list(pe_resource_t *rsc, pe_working_set_t *data_set)
 }
 
 void
-native_internal_constraints(resource_t * rsc, pe_working_set_t * data_set)
+native_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
     /* This function is on the critical path and worth optimizing as much as possible */
 
@@ -1552,7 +1552,7 @@ native_internal_constraints(resource_t * rsc, pe_working_set_t * data_set)
     }
 
     if (rsc->container) {
-        resource_t *remote_rsc = NULL;
+        pe_resource_t *remote_rsc = NULL;
 
         if (rsc->is_remote_node) {
             // rsc is the implicit remote connection for a guest or bundle node
@@ -1664,7 +1664,7 @@ native_rsc_colocation_lh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
 }
 
 enum filter_colocation_res
-filter_colocation_constraint(resource_t * rsc_lh, resource_t * rsc_rh,
+filter_colocation_constraint(pe_resource_t * rsc_lh, pe_resource_t * rsc_rh,
                              rsc_colocation_t * constraint, gboolean preview)
 {
     if (constraint->score == 0) {
@@ -1749,7 +1749,7 @@ filter_colocation_constraint(resource_t * rsc_lh, resource_t * rsc_rh,
 }
 
 static void
-influence_priority(resource_t * rsc_lh, resource_t * rsc_rh, rsc_colocation_t * constraint)
+influence_priority(pe_resource_t * rsc_lh, pe_resource_t * rsc_rh, rsc_colocation_t * constraint)
 {
     const char *rh_value = NULL;
     const char *lh_value = NULL;
@@ -1789,7 +1789,7 @@ influence_priority(resource_t * rsc_lh, resource_t * rsc_rh, rsc_colocation_t * 
 }
 
 static void
-colocation_match(resource_t * rsc_lh, resource_t * rsc_rh, rsc_colocation_t * constraint)
+colocation_match(pe_resource_t * rsc_lh, pe_resource_t * rsc_rh, rsc_colocation_t * constraint)
 {
     const char *tmp = NULL;
     const char *value = NULL;
@@ -1890,7 +1890,7 @@ native_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
 }
 
 static gboolean
-filter_rsc_ticket(resource_t * rsc_lh, rsc_ticket_t * rsc_ticket)
+filter_rsc_ticket(pe_resource_t * rsc_lh, rsc_ticket_t * rsc_ticket)
 {
     if (rsc_ticket->role_lh != RSC_ROLE_UNKNOWN && rsc_ticket->role_lh != rsc_lh->role) {
         pe_rsc_trace(rsc_lh, "LH: Skipping constraint: \"%s\" state filter",
@@ -1902,7 +1902,7 @@ filter_rsc_ticket(resource_t * rsc_lh, rsc_ticket_t * rsc_ticket)
 }
 
 void
-rsc_ticket_constraint(resource_t * rsc_lh, rsc_ticket_t * rsc_ticket, pe_working_set_t * data_set)
+rsc_ticket_constraint(pe_resource_t * rsc_lh, rsc_ticket_t * rsc_ticket, pe_working_set_t * data_set)
 {
     if (rsc_ticket == NULL) {
         pe_err("rsc_ticket was NULL");
@@ -1924,7 +1924,7 @@ rsc_ticket_constraint(resource_t * rsc_lh, rsc_ticket_t * rsc_ticket, pe_working
         pe_rsc_trace(rsc_lh, "Processing ticket dependencies from %s", rsc_lh->id);
 
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *child_rsc = (resource_t *) gIter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
             rsc_ticket_constraint(child_rsc, rsc_ticket, data_set);
         }
@@ -2085,7 +2085,7 @@ native_update_actions(pe_action_t *first, pe_action_t *then, pe_node_t *node,
                  first->flags, then->uuid, then->flags);
 
     if (type & pe_order_asymmetrical) {
-        resource_t *then_rsc = then->rsc;
+        pe_resource_t *then_rsc = then->rsc;
         enum rsc_role_e then_rsc_role = then_rsc ? then_rsc->fns->state(then_rsc, TRUE) : 0;
 
         if (!then_rsc) {
@@ -2291,7 +2291,7 @@ native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
 }
 
 void
-native_expand(resource_t * rsc, pe_working_set_t * data_set)
+native_expand(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
 
@@ -2306,7 +2306,7 @@ native_expand(resource_t * rsc, pe_working_set_t * data_set)
     }
 
     for (gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         child_rsc->cmds->expand(child_rsc, data_set);
     }
@@ -2339,7 +2339,7 @@ native_expand(resource_t * rsc, pe_working_set_t * data_set)
 static int rsc_width = 5;
 static int detail_width = 5;
 static void
-LogAction(const char *change, resource_t *rsc, pe_node_t *origin, pe_node_t *destination, pe_action_t *action, pe_action_t *source, gboolean terminal)
+LogAction(const char *change, pe_resource_t *rsc, pe_node_t *origin, pe_node_t *destination, pe_action_t *action, pe_action_t *source, gboolean terminal)
 {
     int len = 0;
     char *reason = NULL;
@@ -2439,7 +2439,7 @@ LogAction(const char *change, resource_t *rsc, pe_node_t *origin, pe_node_t *des
 
 
 void
-LogActions(resource_t * rsc, pe_working_set_t * data_set, gboolean terminal)
+LogActions(pe_resource_t * rsc, pe_working_set_t * data_set, gboolean terminal)
 {
     node_t *next = NULL;
     node_t *current = NULL;
@@ -2463,7 +2463,7 @@ LogActions(resource_t * rsc, pe_working_set_t * data_set, gboolean terminal)
         GListPtr gIter = NULL;
 
         for (gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-            resource_t *child_rsc = (resource_t *) gIter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
             LogActions(child_rsc, data_set, terminal);
         }
@@ -2627,7 +2627,7 @@ LogActions(resource_t * rsc, pe_working_set_t * data_set, gboolean terminal)
 }
 
 gboolean
-StopRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
+StopRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
 
@@ -2678,7 +2678,7 @@ StopRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * d
 }
 
 static void
-order_after_unfencing(resource_t *rsc, pe_node_t *node, pe_action_t *action,
+order_after_unfencing(pe_resource_t *rsc, pe_node_t *node, pe_action_t *action,
                       enum pe_ordering order, pe_working_set_t *data_set)
 {
     /* When unfencing is in use, we order unfence actions before any probe or
@@ -2711,7 +2711,7 @@ order_after_unfencing(resource_t *rsc, pe_node_t *node, pe_action_t *action,
 }
 
 gboolean
-StartRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
+StartRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
     pe_action_t *start = NULL;
 
@@ -2730,7 +2730,7 @@ StartRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * 
 }
 
 gboolean
-PromoteRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
+PromoteRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
     gboolean runnable = TRUE;
@@ -2771,7 +2771,7 @@ PromoteRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t 
 }
 
 gboolean
-DemoteRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
+DemoteRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
 
@@ -2789,7 +2789,7 @@ DemoteRsc(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t *
 }
 
 gboolean
-RoleError(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
+RoleError(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
     CRM_ASSERT(rsc);
     crm_err("%s on %s", rsc->id, next ? next->details->uname : "N/A");
@@ -2798,7 +2798,7 @@ RoleError(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t *
 }
 
 gboolean
-NullOp(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
+NullOp(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
     CRM_ASSERT(rsc);
     pe_rsc_trace(rsc, "%s", rsc->id);
@@ -2806,7 +2806,7 @@ NullOp(resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * da
 }
 
 gboolean
-DeleteRsc(resource_t * rsc, node_t * node, gboolean optional, pe_working_set_t * data_set)
+DeleteRsc(pe_resource_t * rsc, node_t * node, gboolean optional, pe_working_set_t * data_set)
 {
     if (is_set(rsc->flags, pe_rsc_failed)) {
         pe_rsc_trace(rsc, "Resource %s not deleted from %s: failed", rsc->id, node->details->uname);
@@ -2836,7 +2836,7 @@ DeleteRsc(resource_t * rsc, node_t * node, gboolean optional, pe_working_set_t *
 }
 
 gboolean
-native_create_probe(resource_t * rsc, node_t * node, pe_action_t * complete,
+native_create_probe(pe_resource_t * rsc, node_t * node, pe_action_t * complete,
                     gboolean force, pe_working_set_t * data_set)
 {
     enum pe_ordering flags = pe_order_optional;
@@ -2844,7 +2844,7 @@ native_create_probe(resource_t * rsc, node_t * node, pe_action_t * complete,
     pe_action_t *probe = NULL;
     node_t *running = NULL;
     node_t *allowed = NULL;
-    resource_t *top = uber_parent(rsc);
+    pe_resource_t *top = uber_parent(rsc);
 
     static const char *rc_master = NULL;
     static const char *rc_inactive = NULL;
@@ -2887,7 +2887,7 @@ native_create_probe(resource_t * rsc, node_t * node, pe_action_t * complete,
         gboolean any_created = FALSE;
 
         for (gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-            resource_t *child_rsc = (resource_t *) gIter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
             any_created = child_rsc->cmds->create_probe(child_rsc, node, complete, force, data_set)
                 || any_created;
@@ -2943,7 +2943,7 @@ native_create_probe(resource_t * rsc, node_t * node, pe_action_t * complete,
     }
 
     if (pe__is_guest_node(node)) {
-        resource_t *remote = node->details->remote_rsc->container;
+        pe_resource_t *remote = node->details->remote_rsc->container;
 
         if(remote->role == RSC_ROLE_STOPPED) {
             /* If the container is stopped, then we know anything that
@@ -3099,7 +3099,7 @@ rsc_is_known_on(pe_resource_t *rsc, const pe_node_t *node)
  * \param[in] data_set    Cluster information
  */
 static void
-native_start_constraints(resource_t * rsc, pe_action_t * stonith_op, pe_working_set_t * data_set)
+native_start_constraints(pe_resource_t * rsc, pe_action_t * stonith_op, pe_working_set_t * data_set)
 {
     node_t *target;
     GListPtr gIter = NULL;
@@ -3144,13 +3144,13 @@ native_start_constraints(resource_t * rsc, pe_action_t * stonith_op, pe_working_
 }
 
 static void
-native_stop_constraints(resource_t * rsc, pe_action_t * stonith_op, pe_working_set_t * data_set)
+native_stop_constraints(pe_resource_t * rsc, pe_action_t * stonith_op, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
     GListPtr action_list = NULL;
     bool order_implicit = false;
 
-    resource_t *top = uber_parent(rsc);
+    pe_resource_t *top = uber_parent(rsc);
     pe_action_t *parent_stop = NULL;
     node_t *target;
 
@@ -3308,13 +3308,13 @@ native_stop_constraints(resource_t * rsc, pe_action_t * stonith_op, pe_working_s
 }
 
 void
-rsc_stonith_ordering(resource_t * rsc, pe_action_t * stonith_op, pe_working_set_t * data_set)
+rsc_stonith_ordering(pe_resource_t * rsc, pe_action_t * stonith_op, pe_working_set_t * data_set)
 {
     if (rsc->children) {
         GListPtr gIter = NULL;
 
         for (gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-            resource_t *child_rsc = (resource_t *) gIter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
             rsc_stonith_ordering(child_rsc, stonith_op, data_set);
         }
@@ -3329,14 +3329,14 @@ rsc_stonith_ordering(resource_t * rsc, pe_action_t * stonith_op, pe_working_set_
 }
 
 void
-ReloadRsc(resource_t * rsc, node_t *node, pe_working_set_t * data_set)
+ReloadRsc(pe_resource_t * rsc, node_t *node, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
     pe_action_t *reload = NULL;
 
     if (rsc->children) {
         for (gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-            resource_t *child_rsc = (resource_t *) gIter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
             ReloadRsc(child_rsc, node, data_set);
         }
@@ -3376,10 +3376,10 @@ ReloadRsc(resource_t * rsc, node_t *node, pe_working_set_t * data_set)
 }
 
 void
-native_append_meta(resource_t * rsc, xmlNode * xml)
+native_append_meta(pe_resource_t * rsc, xmlNode * xml)
 {
     char *value = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_INCARNATION);
-    resource_t *parent;
+    pe_resource_t *parent;
 
     if (value) {
         char *name = NULL;

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -28,24 +28,24 @@ void native_rsc_colocation_rh_must(pe_resource_t * rsc_lh, gboolean update_lh,
 void native_rsc_colocation_rh_mustnot(pe_resource_t * rsc_lh, gboolean update_lh,
                                       pe_resource_t * rsc_rh, gboolean update_rh);
 
-static void Recurring(pe_resource_t *rsc, pe_action_t *start, node_t *node,
+static void Recurring(pe_resource_t *rsc, pe_action_t *start, pe_node_t *node,
                       pe_working_set_t *data_set);
-static void RecurringOp(pe_resource_t *rsc, pe_action_t *start, node_t *node,
+static void RecurringOp(pe_resource_t *rsc, pe_action_t *start, pe_node_t *node,
                         xmlNode *operation, pe_working_set_t *data_set);
-static void Recurring_Stopped(pe_resource_t *rsc, pe_action_t *start, node_t *node,
+static void Recurring_Stopped(pe_resource_t *rsc, pe_action_t *start, pe_node_t *node,
                               pe_working_set_t *data_set);
-static void RecurringOp_Stopped(pe_resource_t *rsc, pe_action_t *start, node_t *node,
+static void RecurringOp_Stopped(pe_resource_t *rsc, pe_action_t *start, pe_node_t *node,
                                 xmlNode *operation, pe_working_set_t *data_set);
 
-void ReloadRsc(pe_resource_t * rsc, node_t *node, pe_working_set_t * data_set);
-gboolean DeleteRsc(pe_resource_t * rsc, node_t * node, gboolean optional, pe_working_set_t * data_set);
-gboolean StopRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
-gboolean StartRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
-gboolean DemoteRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
-gboolean PromoteRsc(pe_resource_t * rsc, node_t * next, gboolean optional,
+void ReloadRsc(pe_resource_t * rsc, pe_node_t *node, pe_working_set_t * data_set);
+gboolean DeleteRsc(pe_resource_t * rsc, pe_node_t * node, gboolean optional, pe_working_set_t * data_set);
+gboolean StopRsc(pe_resource_t * rsc, pe_node_t * next, gboolean optional, pe_working_set_t * data_set);
+gboolean StartRsc(pe_resource_t * rsc, pe_node_t * next, gboolean optional, pe_working_set_t * data_set);
+gboolean DemoteRsc(pe_resource_t * rsc, pe_node_t * next, gboolean optional, pe_working_set_t * data_set);
+gboolean PromoteRsc(pe_resource_t * rsc, pe_node_t * next, gboolean optional,
                     pe_working_set_t * data_set);
-gboolean RoleError(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
-gboolean NullOp(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set);
+gboolean RoleError(pe_resource_t * rsc, pe_node_t * next, gboolean optional, pe_working_set_t * data_set);
+gboolean NullOp(pe_resource_t * rsc, pe_node_t * next, gboolean optional, pe_working_set_t * data_set);
 
 /* *INDENT-OFF* */
 enum rsc_role_e rsc_state_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX] = {
@@ -58,7 +58,7 @@ enum rsc_role_e rsc_state_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX] = {
     /* Master */  { RSC_ROLE_STOPPED, RSC_ROLE_SLAVE,   RSC_ROLE_SLAVE,   RSC_ROLE_SLAVE,   RSC_ROLE_MASTER, },
 };
 
-gboolean (*rsc_action_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX])(pe_resource_t*,node_t*,gboolean,pe_working_set_t*) = {
+gboolean (*rsc_action_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX])(pe_resource_t*,pe_node_t*,gboolean,pe_working_set_t*) = {
 /* Current State */
 /*       Next State:       Unknown	Stopped		Started		Slave		Master */
     /* Unknown */	{ RoleError,	StopRsc,	RoleError,	RoleError,	RoleError,  },
@@ -70,11 +70,11 @@ gboolean (*rsc_action_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX])(pe_resource_t*,node_t*
 /* *INDENT-ON* */
 
 static gboolean
-native_choose_node(pe_resource_t * rsc, node_t * prefer, pe_working_set_t * data_set)
+native_choose_node(pe_resource_t * rsc, pe_node_t * prefer, pe_working_set_t * data_set)
 {
     GListPtr nodes = NULL;
-    node_t *chosen = NULL;
-    node_t *best = NULL;
+    pe_node_t *chosen = NULL;
+    pe_node_t *best = NULL;
     int multiple = 1;
     int length = 0;
     gboolean result = FALSE;
@@ -147,14 +147,14 @@ native_choose_node(pe_resource_t * rsc, node_t * prefer, pe_working_set_t * data
              * remaining unallocated instances to prefer a node that's already
              * running another instance.
              */
-            node_t *running = pe__current_node(rsc);
+            pe_node_t *running = pe__current_node(rsc);
 
             if (running && (can_run_resources(running) == FALSE)) {
                 pe_rsc_trace(rsc, "Current node for %s (%s) can't run resources",
                              rsc->id, running->details->uname);
             } else if (running) {
                 for (GList *iter = nodes->next; iter; iter = iter->next) {
-                    node_t *tmp = (node_t *) iter->data;
+                    pe_node_t *tmp = (pe_node_t *) iter->data;
 
                     if (tmp->weight != chosen->weight) {
                         // The nodes are sorted by weight, so no more are equal
@@ -189,7 +189,7 @@ static int
 node_list_attr_score(GHashTable * list, const char *attr, const char *value)
 {
     GHashTableIter iter;
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
     int best_score = -INFINITY;
     const char *best_node = NULL;
 
@@ -229,7 +229,7 @@ node_hash_update(GHashTable * list1, GHashTable * list2, const char *attr, float
     int score = 0;
     int new_score = 0;
     GHashTableIter iter;
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
 
     if (attr == NULL) {
         attr = CRM_ATTR_UNAME;
@@ -433,7 +433,7 @@ pcmk__native_merge_weights(pe_resource_t *rsc, const char *rhs,
 
 
     if (is_set(flags, pe_weights_positive)) {
-        node_t *node = NULL;
+        pe_node_t *node = NULL;
         GHashTableIter iter;
 
         g_hash_table_iter_init(&iter, work);
@@ -453,7 +453,7 @@ pcmk__native_merge_weights(pe_resource_t *rsc, const char *rhs,
 }
 
 static inline bool
-node_has_been_unfenced(node_t *node)
+node_has_been_unfenced(pe_node_t *node)
 {
     const char *unfenced = pe_node_attribute_raw(node, CRM_ATTR_UNFENCED);
 
@@ -563,7 +563,7 @@ pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *prefer,
 
     if (is_not_set(rsc->flags, pe_rsc_managed)) {
         const char *reason = NULL;
-        node_t *assign_to = NULL;
+        pe_node_t *assign_to = NULL;
 
         rsc->next_role = rsc->role;
         assign_to = pe__current_node(rsc);
@@ -604,7 +604,7 @@ pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *prefer,
     clear_bit(rsc->flags, pe_rsc_allocating);
 
     if (rsc->is_remote_node) {
-        node_t *remote_node = pe_find_node(data_set->nodes, rsc->id);
+        pe_node_t *remote_node = pe_find_node(data_set->nodes, rsc->id);
 
         CRM_ASSERT(remote_node != NULL);
         if (rsc->allocated_to && rsc->next_role != RSC_ROLE_STOPPED) {
@@ -678,7 +678,7 @@ op_cannot_recur(const char *name)
 }
 
 static void
-RecurringOp(pe_resource_t * rsc, pe_action_t * start, node_t * node,
+RecurringOp(pe_resource_t * rsc, pe_action_t * start, pe_node_t * node,
             xmlNode * operation, pe_working_set_t * data_set)
 {
     char *key = NULL;
@@ -857,7 +857,7 @@ RecurringOp(pe_resource_t * rsc, pe_action_t * start, node_t * node,
 }
 
 static void
-Recurring(pe_resource_t * rsc, pe_action_t * start, node_t * node, pe_working_set_t * data_set)
+Recurring(pe_resource_t * rsc, pe_action_t * start, pe_node_t * node, pe_working_set_t * data_set)
 {
     if (is_not_set(rsc->flags, pe_rsc_maintenance) &&
         (node == NULL || node->details->maintenance == FALSE)) {
@@ -875,7 +875,7 @@ Recurring(pe_resource_t * rsc, pe_action_t * start, node_t * node, pe_working_se
 }
 
 static void
-RecurringOp_Stopped(pe_resource_t * rsc, pe_action_t * start, node_t * node,
+RecurringOp_Stopped(pe_resource_t * rsc, pe_action_t * start, pe_node_t * node,
                     xmlNode * operation, pe_working_set_t * data_set)
 {
     char *key = NULL;
@@ -956,7 +956,7 @@ RecurringOp_Stopped(pe_resource_t * rsc, pe_action_t * start, node_t * node,
     }
 
     for (gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
-        node_t *stop_node = (node_t *) gIter->data;
+        pe_node_t *stop_node = (pe_node_t *) gIter->data;
         const char *stop_node_uname = stop_node->details->uname;
         gboolean is_optional = TRUE;
         gboolean probe_is_optional = TRUE;
@@ -1067,7 +1067,7 @@ RecurringOp_Stopped(pe_resource_t * rsc, pe_action_t * start, node_t * node,
 }
 
 static void
-Recurring_Stopped(pe_resource_t * rsc, pe_action_t * start, node_t * node, pe_working_set_t * data_set)
+Recurring_Stopped(pe_resource_t * rsc, pe_action_t * start, pe_node_t * node, pe_working_set_t * data_set)
 {
     if (is_not_set(rsc->flags, pe_rsc_maintenance) && 
         (node == NULL || node->details->maintenance == FALSE)) {
@@ -1085,7 +1085,7 @@ Recurring_Stopped(pe_resource_t * rsc, pe_action_t * start, node_t * node, pe_wo
 }
 
 static void
-handle_migration_actions(pe_resource_t * rsc, node_t *current, node_t *chosen, pe_working_set_t * data_set)
+handle_migration_actions(pe_resource_t * rsc, pe_node_t *current, pe_node_t *chosen, pe_working_set_t * data_set)
 {
     pe_action_t *migrate_to = NULL;
     pe_action_t *migrate_from = NULL;
@@ -1176,8 +1176,8 @@ void
 native_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
     pe_action_t *start = NULL;
-    node_t *chosen = NULL;
-    node_t *current = NULL;
+    pe_node_t *chosen = NULL;
+    pe_node_t *current = NULL;
     gboolean need_stop = FALSE;
     gboolean is_moving = FALSE;
     gboolean allow_migrate = is_set(rsc->flags, pe_rsc_allow_migrate) ? TRUE : FALSE;
@@ -1206,7 +1206,7 @@ native_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set)
     current = pe__find_active_on(rsc, &num_all_active, &num_clean_active);
 
     for (gIter = rsc->dangling_migrations; gIter != NULL; gIter = gIter->next) {
-        node_t *dangling_source = (node_t *) gIter->data;
+        pe_node_t *dangling_source = (pe_node_t *) gIter->data;
 
         pe_action_t *stop = stop_action(rsc, dangling_source, FALSE);
 
@@ -1377,7 +1377,7 @@ static void
 rsc_avoids_remote_nodes(pe_resource_t *rsc)
 {
     GHashTableIter iter;
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
     g_hash_table_iter_init(&iter, rsc->allowed_nodes);
     while (g_hash_table_iter_next(&iter, NULL, (void **)&node)) {
         if (node->details->remote_rsc) {
@@ -1514,7 +1514,7 @@ native_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set)
                      rsc->id, data_set->placement_strategy);
 
         for (gIter = rsc->running_on; gIter != NULL; gIter = gIter->next) {
-            node_t *current = (node_t *) gIter->data;
+            pe_node_t *current = (pe_node_t *) gIter->data;
 
             char *load_stopped_task = crm_strdup_printf(LOAD_STOPPED "_%s",
                                                         current->details->uname);
@@ -1799,7 +1799,7 @@ colocation_match(pe_resource_t * rsc_lh, pe_resource_t * rsc_rh, rsc_colocation_
     gboolean do_check = FALSE;
 
     GHashTableIter iter;
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
 
     if (constraint->score == 0) {
         return;
@@ -1960,7 +1960,7 @@ rsc_ticket_constraint(pe_resource_t * rsc_lh, rsc_ticket_t * rsc_ticket, pe_work
                 resource_location(rsc_lh, NULL, -INFINITY, "__loss_of_ticket__", data_set);
 
                 for (gIter = rsc_lh->running_on; gIter != NULL; gIter = gIter->next) {
-                    node_t *node = (node_t *) gIter->data;
+                    pe_node_t *node = (pe_node_t *) gIter->data;
 
                     pe_fence_node(data_set, node, "deadman ticket was lost");
                 }
@@ -1992,7 +1992,7 @@ rsc_ticket_constraint(pe_resource_t * rsc_lh, rsc_ticket_t * rsc_ticket, pe_work
 }
 
 enum pe_action_flags
-native_action_flags(pe_action_t * action, node_t * node)
+native_action_flags(pe_action_t * action, pe_node_t * node)
 {
     return action->flags;
 }
@@ -2098,7 +2098,7 @@ native_update_actions(pe_action_t *first, pe_action_t *then, pe_node_t *node,
                    && is_set(then->flags, pe_action_optional)
                    && then->node
                    && pcmk__list_of_1(then_rsc->running_on)
-                   && then->node->details == ((node_t *) then_rsc->running_on->data)->details) {
+                   && then->node->details == ((pe_node_t *) then_rsc->running_on->data)->details) {
             /* Ignore. If 'then' is supposed to be started after 'first', but
              * 'then' is already started, there is nothing to be done when
              * asymmetrical -- unless the start is mandatory, which indicates
@@ -2230,7 +2230,7 @@ native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
 {
     GListPtr gIter = NULL;
     GHashTableIter iter;
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
 
     if (constraint == NULL) {
         pe_err("Constraint is NULL");
@@ -2257,10 +2257,10 @@ native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
     }
 
     for (gIter = constraint->node_list_rh; gIter != NULL; gIter = gIter->next) {
-        node_t *node = (node_t *) gIter->data;
-        node_t *other_node = NULL;
+        pe_node_t *node = (pe_node_t *) gIter->data;
+        pe_node_t *other_node = NULL;
 
-        other_node = (node_t *) pe_hash_table_lookup(rsc->allowed_nodes, node->details->id);
+        other_node = (pe_node_t *) pe_hash_table_lookup(rsc->allowed_nodes, node->details->id);
 
         if (other_node != NULL) {
             pe_rsc_trace(rsc, "%s + %s: %d + %d",
@@ -2441,8 +2441,8 @@ LogAction(const char *change, pe_resource_t *rsc, pe_node_t *origin, pe_node_t *
 void
 LogActions(pe_resource_t * rsc, pe_working_set_t * data_set, gboolean terminal)
 {
-    node_t *next = NULL;
-    node_t *current = NULL;
+    pe_node_t *next = NULL;
+    pe_node_t *current = NULL;
     pe_node_t *start_node = NULL;
 
     pe_action_t *stop = NULL;
@@ -2578,7 +2578,7 @@ LogActions(pe_resource_t * rsc, pe_working_set_t * data_set, gboolean terminal)
 
         key = stop_key(rsc);
         for (gIter = rsc->running_on; gIter != NULL; gIter = gIter->next) {
-            node_t *node = (node_t *) gIter->data;
+            pe_node_t *node = (pe_node_t *) gIter->data;
             pe_action_t *stop_op = NULL;
 
             possible_matches = find_actions(rsc->actions, key, node);
@@ -2627,7 +2627,7 @@ LogActions(pe_resource_t * rsc, pe_working_set_t * data_set, gboolean terminal)
 }
 
 gboolean
-StopRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
+StopRsc(pe_resource_t * rsc, pe_node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
 
@@ -2635,7 +2635,7 @@ StopRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t 
     pe_rsc_trace(rsc, "%s", rsc->id);
 
     for (gIter = rsc->running_on; gIter != NULL; gIter = gIter->next) {
-        node_t *current = (node_t *) gIter->data;
+        pe_node_t *current = (pe_node_t *) gIter->data;
         pe_action_t *stop;
 
         if (rsc->partial_migration_target) {
@@ -2711,7 +2711,7 @@ order_after_unfencing(pe_resource_t *rsc, pe_node_t *node, pe_action_t *action,
 }
 
 gboolean
-StartRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
+StartRsc(pe_resource_t * rsc, pe_node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
     pe_action_t *start = NULL;
 
@@ -2730,7 +2730,7 @@ StartRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t
 }
 
 gboolean
-PromoteRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
+PromoteRsc(pe_resource_t * rsc, pe_node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
     gboolean runnable = TRUE;
@@ -2771,7 +2771,7 @@ PromoteRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set
 }
 
 gboolean
-DemoteRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
+DemoteRsc(pe_resource_t * rsc, pe_node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
 
@@ -2780,7 +2780,7 @@ DemoteRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_
 
 /* 	CRM_CHECK(rsc->next_role == RSC_ROLE_SLAVE, return FALSE); */
     for (gIter = rsc->running_on; gIter != NULL; gIter = gIter->next) {
-        node_t *current = (node_t *) gIter->data;
+        pe_node_t *current = (pe_node_t *) gIter->data;
 
         pe_rsc_trace(rsc, "%s on %s", rsc->id, next ? next->details->uname : "N/A");
         demote_action(rsc, current, optional);
@@ -2789,7 +2789,7 @@ DemoteRsc(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_
 }
 
 gboolean
-RoleError(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
+RoleError(pe_resource_t * rsc, pe_node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
     CRM_ASSERT(rsc);
     crm_err("%s on %s", rsc->id, next ? next->details->uname : "N/A");
@@ -2798,7 +2798,7 @@ RoleError(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_
 }
 
 gboolean
-NullOp(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t * data_set)
+NullOp(pe_resource_t * rsc, pe_node_t * next, gboolean optional, pe_working_set_t * data_set)
 {
     CRM_ASSERT(rsc);
     pe_rsc_trace(rsc, "%s", rsc->id);
@@ -2806,7 +2806,7 @@ NullOp(pe_resource_t * rsc, node_t * next, gboolean optional, pe_working_set_t *
 }
 
 gboolean
-DeleteRsc(pe_resource_t * rsc, node_t * node, gboolean optional, pe_working_set_t * data_set)
+DeleteRsc(pe_resource_t * rsc, pe_node_t * node, gboolean optional, pe_working_set_t * data_set)
 {
     if (is_set(rsc->flags, pe_rsc_failed)) {
         pe_rsc_trace(rsc, "Resource %s not deleted from %s: failed", rsc->id, node->details->uname);
@@ -2836,14 +2836,14 @@ DeleteRsc(pe_resource_t * rsc, node_t * node, gboolean optional, pe_working_set_
 }
 
 gboolean
-native_create_probe(pe_resource_t * rsc, node_t * node, pe_action_t * complete,
+native_create_probe(pe_resource_t * rsc, pe_node_t * node, pe_action_t * complete,
                     gboolean force, pe_working_set_t * data_set)
 {
     enum pe_ordering flags = pe_order_optional;
     char *key = NULL;
     pe_action_t *probe = NULL;
-    node_t *running = NULL;
-    node_t *allowed = NULL;
+    pe_node_t *running = NULL;
+    pe_node_t *allowed = NULL;
     pe_resource_t *top = uber_parent(rsc);
 
     static const char *rc_master = NULL;
@@ -3101,7 +3101,7 @@ rsc_is_known_on(pe_resource_t *rsc, const pe_node_t *node)
 static void
 native_start_constraints(pe_resource_t * rsc, pe_action_t * stonith_op, pe_working_set_t * data_set)
 {
-    node_t *target;
+    pe_node_t *target;
     GListPtr gIter = NULL;
 
     CRM_CHECK(stonith_op && stonith_op->node, return);
@@ -3152,7 +3152,7 @@ native_stop_constraints(pe_resource_t * rsc, pe_action_t * stonith_op, pe_workin
 
     pe_resource_t *top = uber_parent(rsc);
     pe_action_t *parent_stop = NULL;
-    node_t *target;
+    pe_node_t *target;
 
     CRM_CHECK(stonith_op && stonith_op->node, return);
     target = stonith_op->node;
@@ -3329,7 +3329,7 @@ rsc_stonith_ordering(pe_resource_t * rsc, pe_action_t * stonith_op, pe_working_s
 }
 
 void
-ReloadRsc(pe_resource_t * rsc, node_t *node, pe_working_set_t * data_set)
+ReloadRsc(pe_resource_t * rsc, pe_node_t *node, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
     pe_action_t *reload = NULL;

--- a/lib/pacemaker/pcmk_sched_notif.c
+++ b/lib/pacemaker/pcmk_sched_notif.c
@@ -232,12 +232,12 @@ add_notify_data_to_action_meta(notify_data_t *n_data, pe_action_t *action)
     }
 }
 
-static action_t *
-pe_notify(resource_t * rsc, node_t * node, action_t * op, action_t * confirm,
+static pe_action_t *
+pe_notify(resource_t * rsc, node_t * node, pe_action_t * op, pe_action_t * confirm,
           notify_data_t * n_data, pe_working_set_t * data_set)
 {
     char *key = NULL;
-    action_t *trigger = NULL;
+    pe_action_t *trigger = NULL;
     const char *value = NULL;
     const char *task = NULL;
 
@@ -280,7 +280,7 @@ pe_notify(resource_t * rsc, node_t * node, action_t * op, action_t * confirm,
 static void
 pe_post_notify(resource_t * rsc, node_t * node, notify_data_t * n_data, pe_working_set_t * data_set)
 {
-    action_t *notify = NULL;
+    pe_action_t *notify = NULL;
 
     CRM_CHECK(rsc != NULL, return);
 
@@ -298,7 +298,7 @@ pe_post_notify(resource_t * rsc, node_t * node, notify_data_t * n_data, pe_worki
         GListPtr gIter = rsc->actions;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            action_t *mon = (action_t *) gIter->data;
+            pe_action_t *mon = (pe_action_t *) gIter->data;
             const char *interval_ms_s = g_hash_table_lookup(mon->meta,
                                                             XML_LRM_ATTR_INTERVAL_MS);
 
@@ -316,8 +316,8 @@ pe_post_notify(resource_t * rsc, node_t * node, notify_data_t * n_data, pe_worki
 }
 
 notify_data_t *
-create_notification_boundaries(resource_t * rsc, const char *action, action_t * start,
-                               action_t * end, pe_working_set_t * data_set)
+create_notification_boundaries(resource_t * rsc, const char *action, pe_action_t * start,
+                               pe_action_t * end, pe_working_set_t * data_set)
 {
     /* Create the pseudo ops that precede and follow the actual notifications */
 
@@ -487,7 +487,7 @@ collect_notification_data(resource_t * rsc, gboolean state, gboolean activity,
         GListPtr gIter = rsc->actions;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            action_t *op = (action_t *) gIter->data;
+            pe_action_t *op = (pe_action_t *) gIter->data;
 
             if (is_set(op->flags, pe_action_optional) == FALSE && op->node != NULL) {
                 task = text2task(op->task);
@@ -675,8 +675,8 @@ void
 create_notifications(resource_t * rsc, notify_data_t * n_data, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
-    action_t *stop = NULL;
-    action_t *start = NULL;
+    pe_action_t *stop = NULL;
+    pe_action_t *start = NULL;
     enum action_tasks task = text2task(n_data->action);
 
     if (rsc->children) {
@@ -692,7 +692,7 @@ create_notifications(resource_t * rsc, notify_data_t * n_data, pe_working_set_t 
     /* Copy notification details into standard ops */
 
     for (gIter = rsc->actions; gIter != NULL; gIter = gIter->next) {
-        action_t *op = (action_t *) gIter->data;
+        pe_action_t *op = (pe_action_t *) gIter->data;
 
         if (is_set(op->flags, pe_action_optional) == FALSE && op->node != NULL) {
             enum action_tasks t = text2task(op->task);

--- a/lib/pacemaker/pcmk_sched_notif.c
+++ b/lib/pacemaker/pcmk_sched_notif.c
@@ -12,7 +12,7 @@
 #include <pacemaker-internal.h>
 
 typedef struct notify_entry_s {
-    resource_t *rsc;
+    pe_resource_t *rsc;
     node_t *node;
 } notify_entry_t;
 
@@ -233,7 +233,7 @@ add_notify_data_to_action_meta(notify_data_t *n_data, pe_action_t *action)
 }
 
 static pe_action_t *
-pe_notify(resource_t * rsc, node_t * node, pe_action_t * op, pe_action_t * confirm,
+pe_notify(pe_resource_t * rsc, node_t * node, pe_action_t * op, pe_action_t * confirm,
           notify_data_t * n_data, pe_working_set_t * data_set)
 {
     char *key = NULL;
@@ -278,7 +278,7 @@ pe_notify(resource_t * rsc, node_t * node, pe_action_t * op, pe_action_t * confi
 }
 
 static void
-pe_post_notify(resource_t * rsc, node_t * node, notify_data_t * n_data, pe_working_set_t * data_set)
+pe_post_notify(pe_resource_t * rsc, node_t * node, notify_data_t * n_data, pe_working_set_t * data_set)
 {
     pe_action_t *notify = NULL;
 
@@ -316,7 +316,7 @@ pe_post_notify(resource_t * rsc, node_t * node, notify_data_t * n_data, pe_worki
 }
 
 notify_data_t *
-create_notification_boundaries(resource_t * rsc, const char *action, pe_action_t * start,
+create_notification_boundaries(pe_resource_t * rsc, const char *action, pe_action_t * start,
                                pe_action_t * end, pe_working_set_t * data_set)
 {
     /* Create the pseudo ops that precede and follow the actual notifications */
@@ -425,7 +425,7 @@ create_notification_boundaries(resource_t * rsc, const char *action, pe_action_t
 }
 
 void
-collect_notification_data(resource_t * rsc, gboolean state, gboolean activity,
+collect_notification_data(pe_resource_t * rsc, gboolean state, gboolean activity,
                           notify_data_t * n_data)
 {
 
@@ -437,7 +437,7 @@ collect_notification_data(resource_t * rsc, gboolean state, gboolean activity,
         GListPtr gIter = rsc->children;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *child = (resource_t *) gIter->data;
+            pe_resource_t *child = (pe_resource_t *) gIter->data;
 
             collect_notification_data(child, state, activity, n_data);
         }
@@ -534,7 +534,7 @@ collect_notification_data(resource_t * rsc, gboolean state, gboolean activity,
     } while (0)
 
 gboolean
-expand_notification_data(resource_t *rsc, notify_data_t * n_data, pe_working_set_t * data_set)
+expand_notification_data(pe_resource_t *rsc, notify_data_t * n_data, pe_working_set_t * data_set)
 {
     /* Expand the notification entries into a key=value hashtable
      * This hashtable is later used in action2xml()
@@ -672,7 +672,7 @@ find_remote_start(pe_action_t *action)
 }
 
 void
-create_notifications(resource_t * rsc, notify_data_t * n_data, pe_working_set_t * data_set)
+create_notifications(pe_resource_t * rsc, notify_data_t * n_data, pe_working_set_t * data_set)
 {
     GListPtr gIter = NULL;
     pe_action_t *stop = NULL;
@@ -682,7 +682,7 @@ create_notifications(resource_t * rsc, notify_data_t * n_data, pe_working_set_t 
     if (rsc->children) {
         gIter = rsc->children;
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *child = (resource_t *) gIter->data;
+            pe_resource_t *child = (pe_resource_t *) gIter->data;
 
             create_notifications(child, n_data, data_set);
         }
@@ -820,7 +820,7 @@ free_notification_data(notify_data_t * n_data)
 }
 
 void
-create_secondary_notification(pe_action_t *action, resource_t *rsc,
+create_secondary_notification(pe_action_t *action, pe_resource_t *rsc,
                               pe_action_t *stonith_op,
                               pe_working_set_t *data_set)
 {

--- a/lib/pacemaker/pcmk_sched_notif.c
+++ b/lib/pacemaker/pcmk_sched_notif.c
@@ -13,7 +13,7 @@
 
 typedef struct notify_entry_s {
     pe_resource_t *rsc;
-    node_t *node;
+    pe_node_t *node;
 } notify_entry_t;
 
 static gint
@@ -90,7 +90,7 @@ expand_node_list(GListPtr list, char **uname, char **metal)
     for (gIter = list; gIter != NULL; gIter = gIter->next) {
         int len = 0;
         int existing_len = 0;
-        node_t *node = (node_t *) gIter->data;
+        pe_node_t *node = (pe_node_t *) gIter->data;
 
         if (node->details->uname == NULL) {
             continue;
@@ -233,7 +233,7 @@ add_notify_data_to_action_meta(notify_data_t *n_data, pe_action_t *action)
 }
 
 static pe_action_t *
-pe_notify(pe_resource_t * rsc, node_t * node, pe_action_t * op, pe_action_t * confirm,
+pe_notify(pe_resource_t * rsc, pe_node_t * node, pe_action_t * op, pe_action_t * confirm,
           notify_data_t * n_data, pe_working_set_t * data_set)
 {
     char *key = NULL;
@@ -278,7 +278,7 @@ pe_notify(pe_resource_t * rsc, node_t * node, pe_action_t * op, pe_action_t * co
 }
 
 static void
-pe_post_notify(pe_resource_t * rsc, node_t * node, notify_data_t * n_data, pe_working_set_t * data_set)
+pe_post_notify(pe_resource_t * rsc, pe_node_t * node, notify_data_t * n_data, pe_working_set_t * data_set)
 {
     pe_action_t *notify = NULL;
 
@@ -750,7 +750,7 @@ create_notifications(pe_resource_t * rsc, notify_data_t * n_data, pe_working_set
         if (task == stop_rsc || task == action_demote) {
             gIter = rsc->running_on;
             for (; gIter != NULL; gIter = gIter->next) {
-                node_t *current_node = (node_t *) gIter->data;
+                pe_node_t *current_node = (pe_node_t *) gIter->data;
 
                 /* if this stop action is a pseudo action as a result of the current
                  * node being fenced, this stop action is implied by the fencing 

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -110,7 +110,7 @@ check_promotable_actions(resource_t *rsc, gboolean *demoting,
 
     gIter = rsc->actions;
     for (; gIter != NULL; gIter = gIter->next) {
-        action_t *action = (action_t *) gIter->data;
+        pe_action_t *action = (pe_action_t *) gIter->data;
 
         if (*promoting && *demoting) {
             return;
@@ -799,9 +799,9 @@ pcmk__set_instance_roles(pe_resource_t *rsc, pe_working_set_t *data_set)
 void
 create_promotable_actions(resource_t * rsc, pe_working_set_t * data_set)
 {
-    action_t *action = NULL;
+    pe_action_t *action = NULL;
     GListPtr gIter = rsc->children;
-    action_t *action_complete = NULL;
+    pe_action_t *action_complete = NULL;
     gboolean any_promoting = FALSE;
     gboolean any_demoting = FALSE;
     resource_t *last_promote_rsc = NULL;

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -149,11 +149,11 @@ static void apply_master_location(pe_resource_t *child, GListPtr location_constr
     }
 }
 
-static node_t *
+static pe_node_t *
 can_be_master(pe_resource_t * rsc)
 {
-    node_t *node = NULL;
-    node_t *local_node = NULL;
+    pe_node_t *node = NULL;
+    pe_node_t *local_node = NULL;
     pe_resource_t *parent = uber_parent(rsc);
     clone_variant_data_t *clone_data = NULL;
 
@@ -256,8 +256,8 @@ static void
 promotion_order(pe_resource_t *rsc, pe_working_set_t *data_set)
 {
     GListPtr gIter = NULL;
-    node_t *node = NULL;
-    node_t *chosen = NULL;
+    pe_node_t *node = NULL;
+    pe_node_t *chosen = NULL;
     clone_variant_data_t *clone_data = NULL;
     char score[33];
     size_t len = sizeof(score);
@@ -288,7 +288,7 @@ promotion_order(pe_resource_t *rsc, pe_working_set_t *data_set)
             continue;
         }
 
-        node = (node_t *) pe_hash_table_lookup(rsc->allowed_nodes, chosen->details->id);
+        node = (pe_node_t *) pe_hash_table_lookup(rsc->allowed_nodes, chosen->details->id);
         CRM_ASSERT(node != NULL);
         /* adds in master preferences and rsc_location.role=Master */
         score2char_stack(child->sort_index, score, len);
@@ -373,7 +373,7 @@ promotion_order(pe_resource_t *rsc, pe_working_set_t *data_set)
             pe_rsc_trace(rsc, "%s: %d", child->id, child->sort_index);
 
         } else {
-            node = (node_t *) pe_hash_table_lookup(rsc->allowed_nodes, chosen->details->id);
+            node = (pe_node_t *) pe_hash_table_lookup(rsc->allowed_nodes, chosen->details->id);
             CRM_ASSERT(node != NULL);
 
             child->sort_index = node->weight;
@@ -387,7 +387,7 @@ promotion_order(pe_resource_t *rsc, pe_working_set_t *data_set)
 }
 
 static gboolean
-filter_anonymous_instance(pe_resource_t *rsc, const node_t *node)
+filter_anonymous_instance(pe_resource_t *rsc, const pe_node_t *node)
 {
     GListPtr rIter = NULL;
     char *key = clone_strip(rsc->id);
@@ -439,7 +439,7 @@ filter_anonymous_instance(pe_resource_t *rsc, const node_t *node)
 }
 
 static const char *
-lookup_promotion_score(pe_resource_t *rsc, const node_t *node, const char *name)
+lookup_promotion_score(pe_resource_t *rsc, const pe_node_t *node, const char *name)
 {
     const char *attr_value = NULL;
 
@@ -453,12 +453,12 @@ lookup_promotion_score(pe_resource_t *rsc, const node_t *node, const char *name)
 }
 
 static int
-promotion_score(pe_resource_t *rsc, const node_t *node, int not_set_value)
+promotion_score(pe_resource_t *rsc, const pe_node_t *node, int not_set_value)
 {
     char *name = rsc->id;
     const char *attr_value = NULL;
     int score = not_set_value;
-    node_t *match = NULL;
+    pe_node_t *match = NULL;
 
     CRM_CHECK(node != NULL, return not_set_value);
 
@@ -488,7 +488,7 @@ promotion_score(pe_resource_t *rsc, const node_t *node, int not_set_value)
          * skip this code, to make sure we take into account any permanent
          * promotion scores set previously.
          */
-        node_t *known = pe_hash_table_lookup(rsc->known_on, node->details->id);
+        pe_node_t *known = pe_hash_table_lookup(rsc->known_on, node->details->id);
 
         match = pe_find_node_id(rsc->running_on, node->details->id);
         if ((match == NULL) && (known == NULL)) {
@@ -558,7 +558,7 @@ apply_master_prefs(pe_resource_t *rsc)
 
     for (; gIter != NULL; gIter = gIter->next) {
         GHashTableIter iter;
-        node_t *node = NULL;
+        pe_node_t *node = NULL;
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         g_hash_table_iter_init(&iter, child_rsc->allowed_nodes);
@@ -645,8 +645,8 @@ pcmk__set_instance_roles(pe_resource_t *rsc, pe_working_set_t *data_set)
     GListPtr gIter = NULL;
     GListPtr gIter2 = NULL;
     GHashTableIter iter;
-    node_t *node = NULL;
-    node_t *chosen = NULL;
+    pe_node_t *node = NULL;
+    pe_node_t *chosen = NULL;
     enum rsc_role_e next_role = RSC_ROLE_UNKNOWN;
     char score[33];
     size_t len = sizeof(score);
@@ -933,10 +933,10 @@ promotable_constraints(pe_resource_t * rsc, pe_working_set_t * data_set)
 }
 
 static void
-node_hash_update_one(GHashTable * hash, node_t * other, const char *attr, int score)
+node_hash_update_one(GHashTable * hash, pe_node_t * other, const char *attr, int score)
 {
     GHashTableIter iter;
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
     const char *value = NULL;
 
     if (other == NULL) {
@@ -973,7 +973,7 @@ promotable_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
 
         for (gIter = rsc_rh->children; gIter != NULL; gIter = gIter->next) {
             pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
-            node_t *chosen = child_rsc->fns->location(child_rsc, NULL, FALSE);
+            pe_node_t *chosen = child_rsc->fns->location(child_rsc, NULL, FALSE);
             enum rsc_role_e next_role = child_rsc->fns->state(child_rsc, FALSE);
 
             pe_rsc_trace(rsc_rh, "Processing: %s", child_rsc->id);

--- a/lib/pacemaker/pcmk_sched_transition.c
+++ b/lib/pacemaker/pcmk_sched_transition.c
@@ -545,7 +545,7 @@ modify_configuration(pe_working_set_t * data_set, cib_t *cib,
         const char *rclass = NULL;
         const char *rprovider = NULL;
 
-        resource_t *rsc = NULL;
+        pe_resource_t *rsc = NULL;
 
         quiet_log(" + Injecting %s into the configuration\n", spec);
 

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -11,13 +11,13 @@
 #include <crm/msg_xml.h>
 #include <pacemaker-internal.h>
 
-static GListPtr find_colocated_rscs(GListPtr colocated_rscs, resource_t * rsc,
-                                    resource_t * orig_rsc);
+static GListPtr find_colocated_rscs(GListPtr colocated_rscs, pe_resource_t * rsc,
+                                    pe_resource_t * orig_rsc);
 
-static GListPtr group_find_colocated_rscs(GListPtr colocated_rscs, resource_t * rsc,
-                                          resource_t * orig_rsc);
+static GListPtr group_find_colocated_rscs(GListPtr colocated_rscs, pe_resource_t * rsc,
+                                          pe_resource_t * orig_rsc);
 
-static void group_add_unallocated_utilization(GHashTable * all_utilization, resource_t * rsc,
+static void group_add_unallocated_utilization(GHashTable * all_utilization, pe_resource_t * rsc,
                                               GListPtr all_rscs);
 
 struct compare_data {
@@ -164,7 +164,7 @@ have_enough_capacity(node_t * node, const char * rsc_id, GHashTable * utilizatio
 
 
 static void
-native_add_unallocated_utilization(GHashTable * all_utilization, resource_t * rsc)
+native_add_unallocated_utilization(GHashTable * all_utilization, pe_resource_t * rsc)
 {
     if(is_set(rsc->flags, pe_rsc_provisional) == FALSE) {
         return;
@@ -174,8 +174,8 @@ native_add_unallocated_utilization(GHashTable * all_utilization, resource_t * rs
 }
 
 static void
-add_unallocated_utilization(GHashTable * all_utilization, resource_t * rsc,
-                    GListPtr all_rscs, resource_t * orig_rsc)
+add_unallocated_utilization(GHashTable * all_utilization, pe_resource_t * rsc,
+                    GListPtr all_rscs, pe_resource_t * orig_rsc)
 {
     if(is_set(rsc->flags, pe_rsc_provisional) == FALSE) {
         return;
@@ -198,7 +198,7 @@ add_unallocated_utilization(GHashTable * all_utilization, resource_t * rsc,
         /* Check if there's any child already existing in the list */
         gIter1 = rsc->children;
         for (; gIter1 != NULL; gIter1 = gIter1->next) {
-            resource_t *child = (resource_t *) gIter1->data;
+            pe_resource_t *child = (pe_resource_t *) gIter1->data;
             GListPtr gIter2 = NULL;
 
             if (g_list_find(all_rscs, child)) {
@@ -208,7 +208,7 @@ add_unallocated_utilization(GHashTable * all_utilization, resource_t * rsc,
                 /* Check if there's any child of another cloned group already existing in the list */
                 gIter2 = child->children;
                 for (; gIter2 != NULL; gIter2 = gIter2->next) {
-                    resource_t *grandchild = (resource_t *) gIter2->data;
+                    pe_resource_t *grandchild = (pe_resource_t *) gIter2->data;
 
                     if (g_list_find(all_rscs, grandchild)) {
                         pe_rsc_trace(orig_rsc, "%s: Adding %s as colocated utilization",
@@ -223,7 +223,7 @@ add_unallocated_utilization(GHashTable * all_utilization, resource_t * rsc,
 
         // rsc->children is always non-NULL but this makes static analysis happy
         if (!existing && (rsc->children != NULL)) {
-            resource_t *first_child = (resource_t *) rsc->children->data;
+            pe_resource_t *first_child = (pe_resource_t *) rsc->children->data;
 
             pe_rsc_trace(orig_rsc, "%s: Adding %s as colocated utilization",
                          orig_rsc->id, ID(first_child->xml));
@@ -233,7 +233,7 @@ add_unallocated_utilization(GHashTable * all_utilization, resource_t * rsc,
 }
 
 static GHashTable *
-sum_unallocated_utilization(resource_t * rsc, GListPtr colocated_rscs)
+sum_unallocated_utilization(pe_resource_t * rsc, GListPtr colocated_rscs)
 {
     GListPtr gIter = NULL;
     GListPtr all_rscs = NULL;
@@ -245,7 +245,7 @@ sum_unallocated_utilization(resource_t * rsc, GListPtr colocated_rscs)
     }
 
     for (gIter = all_rscs; gIter != NULL; gIter = gIter->next) {
-        resource_t *listed_rsc = (resource_t *) gIter->data;
+        pe_resource_t *listed_rsc = (pe_resource_t *) gIter->data;
 
         if(is_set(listed_rsc->flags, pe_rsc_provisional) == FALSE) {
             continue;
@@ -261,7 +261,7 @@ sum_unallocated_utilization(resource_t * rsc, GListPtr colocated_rscs)
 }
 
 static GListPtr
-find_colocated_rscs(GListPtr colocated_rscs, resource_t * rsc, resource_t * orig_rsc)
+find_colocated_rscs(GListPtr colocated_rscs, pe_resource_t * rsc, pe_resource_t * orig_rsc)
 {
     GListPtr gIter = NULL;
 
@@ -277,7 +277,7 @@ find_colocated_rscs(GListPtr colocated_rscs, resource_t * rsc, resource_t * orig
 
     for (gIter = rsc->rsc_cons; gIter != NULL; gIter = gIter->next) {
         rsc_colocation_t *constraint = (rsc_colocation_t *) gIter->data;
-        resource_t *rsc_rh = constraint->rsc_rh;
+        pe_resource_t *rsc_rh = constraint->rsc_rh;
 
         /* Break colocation loop */
         if (rsc_rh == orig_rsc) {
@@ -299,7 +299,7 @@ find_colocated_rscs(GListPtr colocated_rscs, resource_t * rsc, resource_t * orig
 
     for (gIter = rsc->rsc_cons_lhs; gIter != NULL; gIter = gIter->next) {
         rsc_colocation_t *constraint = (rsc_colocation_t *) gIter->data;
-        resource_t *rsc_lh = constraint->rsc_lh;
+        pe_resource_t *rsc_lh = constraint->rsc_lh;
 
         /* Break colocation loop */
         if (rsc_lh == orig_rsc) {
@@ -328,7 +328,7 @@ find_colocated_rscs(GListPtr colocated_rscs, resource_t * rsc, resource_t * orig
 }
 
 void
-process_utilization(resource_t * rsc, node_t ** prefer, pe_working_set_t * data_set)
+process_utilization(pe_resource_t * rsc, node_t ** prefer, pe_working_set_t * data_set)
 {
     CRM_CHECK(rsc && prefer && data_set, return);
     if (safe_str_neq(data_set->placement_strategy, "default")) {
@@ -415,7 +415,7 @@ process_utilization(resource_t * rsc, node_t ** prefer, pe_working_set_t * data_
 #include <lib/pengine/variant.h>
 
 GListPtr
-group_find_colocated_rscs(GListPtr colocated_rscs, resource_t * rsc, resource_t * orig_rsc)
+group_find_colocated_rscs(GListPtr colocated_rscs, pe_resource_t * rsc, pe_resource_t * orig_rsc)
 {
     group_variant_data_t *group_data = NULL;
 
@@ -424,7 +424,7 @@ group_find_colocated_rscs(GListPtr colocated_rscs, resource_t * rsc, resource_t 
         GListPtr gIter = rsc->children;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *child_rsc = (resource_t *) gIter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
             colocated_rscs = find_colocated_rscs(colocated_rscs, child_rsc, orig_rsc);
         }
@@ -441,7 +441,7 @@ group_find_colocated_rscs(GListPtr colocated_rscs, resource_t * rsc, resource_t 
 }
 
 static void
-group_add_unallocated_utilization(GHashTable * all_utilization, resource_t * rsc,
+group_add_unallocated_utilization(GHashTable * all_utilization, pe_resource_t * rsc,
                                   GListPtr all_rscs)
 {
     group_variant_data_t *group_data = NULL;
@@ -451,7 +451,7 @@ group_add_unallocated_utilization(GHashTable * all_utilization, resource_t * rsc
         GListPtr gIter = rsc->children;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *child_rsc = (resource_t *) gIter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
             if (is_set(child_rsc->flags, pe_rsc_provisional) &&
                 g_list_find(all_rscs, child_rsc) == FALSE) {

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -21,8 +21,8 @@ static void group_add_unallocated_utilization(GHashTable * all_utilization, pe_r
                                               GListPtr all_rscs);
 
 struct compare_data {
-    const node_t *node1;
-    const node_t *node2;
+    const pe_node_t *node1;
+    const pe_node_t *node2;
     int result;
 };
 
@@ -69,7 +69,7 @@ do_compare_capacity2(gpointer key, gpointer value, gpointer user_data)
  * rc > 0 if 'node1' has less capacity remaining
  */
 int
-compare_capacity(const node_t * node1, const node_t * node2)
+compare_capacity(const pe_node_t * node1, const pe_node_t * node2)
 {
     struct compare_data data;
 
@@ -123,7 +123,7 @@ calculate_utilization(GHashTable * current_utilization,
 
 
 struct capacity_data {
-    node_t *node;
+    pe_node_t *node;
     const char *rsc_id;
     gboolean is_enough;
 };
@@ -149,7 +149,7 @@ check_capacity(gpointer key, gpointer value, gpointer user_data)
 }
 
 static gboolean
-have_enough_capacity(node_t * node, const char * rsc_id, GHashTable * utilization)
+have_enough_capacity(pe_node_t * node, const char * rsc_id, GHashTable * utilization)
 {
     struct capacity_data data;
 
@@ -328,21 +328,21 @@ find_colocated_rscs(GListPtr colocated_rscs, pe_resource_t * rsc, pe_resource_t 
 }
 
 void
-process_utilization(pe_resource_t * rsc, node_t ** prefer, pe_working_set_t * data_set)
+process_utilization(pe_resource_t * rsc, pe_node_t ** prefer, pe_working_set_t * data_set)
 {
     CRM_CHECK(rsc && prefer && data_set, return);
     if (safe_str_neq(data_set->placement_strategy, "default")) {
         GHashTableIter iter;
         GListPtr colocated_rscs = NULL;
         gboolean any_capable = FALSE;
-        node_t *node = NULL;
+        pe_node_t *node = NULL;
 
         colocated_rscs = find_colocated_rscs(colocated_rscs, rsc, rsc);
         if (colocated_rscs) {
             GHashTable *unallocated_utilization = NULL;
             char *rscs_id = crm_strdup_printf("%s and its colocated resources",
                                               rsc->id);
-            node_t *most_capable_node = NULL;
+            pe_node_t *most_capable_node = NULL;
 
             unallocated_utilization = sum_unallocated_utilization(rsc, colocated_rscs);
 

--- a/lib/pacemaker/pcmk_sched_utils.c
+++ b/lib/pacemaker/pcmk_sched_utils.c
@@ -354,7 +354,7 @@ log_action(unsigned int log_level, const char *pre_text, pe_action_t * action, g
 
         gIter = action->actions_before;
         for (; gIter != NULL; gIter = gIter->next) {
-            action_wrapper_t *other = (action_wrapper_t *) gIter->data;
+            pe_action_wrapper_t *other = (pe_action_wrapper_t *) gIter->data;
 
             log_action(log_level + 1, "\t\t", other->action, FALSE);
         }
@@ -363,7 +363,7 @@ log_action(unsigned int log_level, const char *pre_text, pe_action_t * action, g
 
         gIter = action->actions_after;
         for (; gIter != NULL; gIter = gIter->next) {
-            action_wrapper_t *other = (action_wrapper_t *) gIter->data;
+            pe_action_wrapper_t *other = (pe_action_wrapper_t *) gIter->data;
 
             log_action(log_level + 1, "\t\t", other->action, FALSE);
         }

--- a/lib/pacemaker/pcmk_sched_utils.c
+++ b/lib/pacemaker/pcmk_sched_utils.c
@@ -193,7 +193,7 @@ sort_nodes_by_weight(GList *nodes, pe_node_t *active_node,
 }
 
 void
-native_deallocate(resource_t * rsc)
+native_deallocate(pe_resource_t * rsc)
 {
     if (rsc->allocated_to) {
         node_t *old = rsc->allocated_to;
@@ -211,7 +211,7 @@ native_deallocate(resource_t * rsc)
 }
 
 gboolean
-native_assign_node(resource_t * rsc, GListPtr nodes, node_t * chosen, gboolean force)
+native_assign_node(pe_resource_t * rsc, GListPtr nodes, node_t * chosen, gboolean force)
 {
     CRM_ASSERT(rsc->variant == pe_native);
 
@@ -397,7 +397,7 @@ can_run_any(GHashTable * nodes)
 }
 
 pe_action_t *
-create_pseudo_resource_op(resource_t * rsc, const char *task, bool optional, bool runnable, pe_working_set_t *data_set)
+create_pseudo_resource_op(pe_resource_t * rsc, const char *task, bool optional, bool runnable, pe_working_set_t *data_set)
 {
     pe_action_t *action = custom_action(rsc, pcmk__op_key(rsc->id, task, 0),
                                         task, NULL, optional, TRUE, data_set);

--- a/lib/pacemaker/pcmk_sched_utils.c
+++ b/lib/pacemaker/pcmk_sched_utils.c
@@ -250,7 +250,7 @@ native_assign_node(resource_t * rsc, GListPtr nodes, node_t * chosen, gboolean f
         rsc->next_role = RSC_ROLE_STOPPED;
 
         for (gIter = rsc->actions; gIter != NULL; gIter = gIter->next) {
-            action_t *op = (action_t *) gIter->data;
+            pe_action_t *op = (pe_action_t *) gIter->data;
             const char *interval_ms_s = g_hash_table_lookup(op->meta, XML_LRM_ATTR_INTERVAL_MS);
 
             crm_debug("Processing %s", op->uuid);
@@ -290,7 +290,7 @@ native_assign_node(resource_t * rsc, GListPtr nodes, node_t * chosen, gboolean f
 }
 
 void
-log_action(unsigned int log_level, const char *pre_text, action_t * action, gboolean details)
+log_action(unsigned int log_level, const char *pre_text, pe_action_t * action, gboolean details)
 {
     const char *node_uname = NULL;
     const char *node_uuid = NULL;

--- a/lib/pacemaker/pcmk_sched_utils.c
+++ b/lib/pacemaker/pcmk_sched_utils.c
@@ -47,7 +47,7 @@ rsc2node_new(const char *id, pe_resource_t *rsc,
         }
 
         if (foo_node != NULL) {
-            node_t *copy = node_copy(foo_node);
+            pe_node_t *copy = node_copy(foo_node);
 
             copy->weight = node_weight;
             new_con->node_list_rh = g_list_prepend(NULL, copy);
@@ -61,7 +61,7 @@ rsc2node_new(const char *id, pe_resource_t *rsc,
 }
 
 gboolean
-can_run_resources(const node_t * node)
+can_run_resources(const pe_node_t * node)
 {
     if (node == NULL) {
         return FALSE;
@@ -95,8 +95,8 @@ struct node_weight_s {
 static gint
 sort_node_weight(gconstpointer a, gconstpointer b, gpointer data)
 {
-    const node_t *node1 = (const node_t *)a;
-    const node_t *node2 = (const node_t *)b;
+    const pe_node_t *node1 = (const pe_node_t *)a;
+    const pe_node_t *node2 = (const pe_node_t *)b;
     struct node_weight_s *nw = data;
 
     int node1_weight = 0;
@@ -196,7 +196,7 @@ void
 native_deallocate(pe_resource_t * rsc)
 {
     if (rsc->allocated_to) {
-        node_t *old = rsc->allocated_to;
+        pe_node_t *old = rsc->allocated_to;
 
         crm_info("Deallocating %s from %s", rsc->id, old->details->uname);
         set_bit(rsc->flags, pe_rsc_provisional);
@@ -211,7 +211,7 @@ native_deallocate(pe_resource_t * rsc)
 }
 
 gboolean
-native_assign_node(pe_resource_t * rsc, GListPtr nodes, node_t * chosen, gboolean force)
+native_assign_node(pe_resource_t * rsc, GListPtr nodes, pe_node_t * chosen, gboolean force)
 {
     CRM_ASSERT(rsc->variant == pe_native);
 
@@ -380,7 +380,7 @@ gboolean
 can_run_any(GHashTable * nodes)
 {
     GHashTableIter iter;
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
 
     if (nodes == NULL) {
         return FALSE;

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -704,7 +704,7 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
     if (replica->child && valid_network(data)) {
         GHashTableIter gIter;
         GListPtr rsc_iter = NULL;
-        node_t *node = NULL;
+        pe_node_t *node = NULL;
         xmlNode *xml_remote = NULL;
         char *id = crm_strdup_printf("%s-%d", data->prefix, replica->offset);
         char *port_s = NULL;
@@ -799,7 +799,7 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
                             node_copy(replica->node));
 
         {
-            node_t *copy = node_copy(replica->node);
+            pe_node_t *copy = node_copy(replica->node);
             copy->weight = -INFINITY;
             g_hash_table_insert(replica->child->parent->allowed_nodes,
                                 (gpointer) replica->node->details->id, copy);
@@ -1551,7 +1551,7 @@ static void
 pe__bundle_replica_output_html(pcmk__output_t *out, pe__bundle_replica_t *replica,
                                long options)
 {
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
     pe_resource_t *rsc = replica->child;
 
     int offset = 0;
@@ -1641,7 +1641,7 @@ static void
 pe__bundle_replica_output_text(pcmk__output_t *out, pe__bundle_replica_t *replica,
                                long options)
 {
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
     pe_resource_t *rsc = replica->child;
 
     int offset = 0;
@@ -1726,7 +1726,7 @@ static void
 print_bundle_replica(pe__bundle_replica_t *replica, const char *pre_text,
                      long options, void *print_data)
 {
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
     pe_resource_t *rsc = replica->child;
 
     int offset = 0;

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -679,7 +679,7 @@ create_rkt_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
  * \param[in]     uname  Name of node to ban
  */
 static void
-disallow_node(resource_t *rsc, const char *uname)
+disallow_node(pe_resource_t *rsc, const char *uname)
 {
     gpointer match = g_hash_table_lookup(rsc->allowed_nodes, uname);
 
@@ -691,7 +691,7 @@ disallow_node(resource_t *rsc, const char *uname)
         GListPtr child;
 
         for (child = rsc->children; child != NULL; child = child->next) {
-            disallow_node((resource_t *) (child->data), uname);
+            disallow_node((pe_resource_t *) (child->data), uname);
         }
     }
 }
@@ -780,7 +780,7 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
          * resources, so the weight is correct before any copies are made.
          */
         for (rsc_iter = data_set->resources; rsc_iter; rsc_iter = rsc_iter->next) {
-            disallow_node((resource_t *) (rsc_iter->data), uname);
+            disallow_node((pe_resource_t *) (rsc_iter->data), uname);
         }
 
         replica->node = node_copy(node);
@@ -928,7 +928,7 @@ port_free(pe__bundle_port_t *port)
 static pe__bundle_replica_t *
 replica_for_remote(pe_resource_t *remote)
 {
-    resource_t *top = remote;
+    pe_resource_t *top = remote;
     pe__bundle_variant_data_t *bundle_data = NULL;
 
     if (top == NULL) {
@@ -1218,7 +1218,7 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
     if(xml_resource) {
         int lpc = 0;
         GListPtr childIter = NULL;
-        resource_t *new_rsc = NULL;
+        pe_resource_t *new_rsc = NULL;
         pe__bundle_port_t *port = NULL;
 
         int offset = 0, max = 1024;
@@ -1428,7 +1428,7 @@ pe__find_bundle_replica(const pe_resource_t *bundle, const pe_node_t *node)
 }
 
 static void
-print_rsc_in_list(resource_t *rsc, const char *pre_text, long options,
+print_rsc_in_list(pe_resource_t *rsc, const char *pre_text, long options,
                   void *print_data)
 {
     if (rsc != NULL) {
@@ -1903,7 +1903,7 @@ pe__bundle_resource_state(const pe_resource_t *rsc, gboolean current)
  * \return Number of configured replicas, or 0 on error
  */
 int
-pe_bundle_replicas(const resource_t *rsc)
+pe_bundle_replicas(const pe_resource_t *rsc)
 {
     if ((rsc == NULL) || (rsc->variant != pe_container)) {
         return 0;

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -37,11 +37,11 @@ pe__force_anon(const char *standard, pe_resource_t *rsc, const char *rid,
     }
 }
 
-resource_t *
-find_clone_instance(resource_t * rsc, const char *sub_id, pe_working_set_t * data_set)
+pe_resource_t *
+find_clone_instance(pe_resource_t * rsc, const char *sub_id, pe_working_set_t * data_set)
 {
     char *child_id = NULL;
-    resource_t *child = NULL;
+    pe_resource_t *child = NULL;
     const char *child_base = NULL;
     clone_variant_data_t *clone_data = NULL;
 
@@ -61,7 +61,7 @@ pe__create_clone_child(pe_resource_t *rsc, pe_working_set_t *data_set)
     gboolean as_orphan = FALSE;
     char *inc_num = NULL;
     char *inc_max = NULL;
-    resource_t *child_rsc = NULL;
+    pe_resource_t *child_rsc = NULL;
     xmlNode *child_copy = NULL;
     clone_variant_data_t *clone_data = NULL;
 
@@ -108,7 +108,7 @@ pe__create_clone_child(pe_resource_t *rsc, pe_working_set_t *data_set)
 }
 
 gboolean
-clone_unpack(resource_t * rsc, pe_working_set_t * data_set)
+clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
     int lpc = 0;
     xmlNode *a_child = NULL;
@@ -234,12 +234,12 @@ clone_unpack(resource_t * rsc, pe_working_set_t * data_set)
 }
 
 gboolean
-clone_active(resource_t * rsc, gboolean all)
+clone_active(pe_resource_t * rsc, gboolean all)
 {
     GListPtr gIter = rsc->children;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
         gboolean child_active = child_rsc->fns->active(child_rsc, all);
 
         if (all == FALSE && child_active) {
@@ -282,20 +282,20 @@ short_print(char *list, const char *prefix, const char *type, const char *suffix
 }
 
 static const char *
-configured_role_str(resource_t * rsc)
+configured_role_str(pe_resource_t * rsc)
 {
     const char *target_role = g_hash_table_lookup(rsc->meta,
                                                   XML_RSC_ATTR_TARGET_ROLE);
 
     if ((target_role == NULL) && rsc->children && rsc->children->data) {
-        target_role = g_hash_table_lookup(((resource_t*)rsc->children->data)->meta,
+        target_role = g_hash_table_lookup(((pe_resource_t*)rsc->children->data)->meta,
                                           XML_RSC_ATTR_TARGET_ROLE);
     }
     return target_role;
 }
 
 static enum rsc_role_e
-configured_role(resource_t * rsc)
+configured_role(pe_resource_t * rsc)
 {
     const char *target_role = configured_role_str(rsc);
 
@@ -306,7 +306,7 @@ configured_role(resource_t * rsc)
 }
 
 static void
-clone_print_xml(resource_t * rsc, const char *pre_text, long options, void *print_data)
+clone_print_xml(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
 {
     char *child_text = crm_strdup_printf("%s    ", pre_text);
     const char *target_role = configured_role_str(rsc);
@@ -326,7 +326,7 @@ clone_print_xml(resource_t * rsc, const char *pre_text, long options, void *prin
     status_print(">\n");
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         child_rsc->fns->print(child_rsc, child_text, options, print_data);
     }
@@ -335,7 +335,7 @@ clone_print_xml(resource_t * rsc, const char *pre_text, long options, void *prin
     free(child_text);
 }
 
-bool is_set_recursive(resource_t * rsc, long long flag, bool any)
+bool is_set_recursive(pe_resource_t * rsc, long long flag, bool any)
 {
     GListPtr gIter;
     bool all = !any;
@@ -366,7 +366,7 @@ bool is_set_recursive(resource_t * rsc, long long flag, bool any)
 }
 
 void
-clone_print(resource_t * rsc, const char *pre_text, long options, void *print_data)
+clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
 {
     char *list_text = NULL;
     char *child_text = NULL;
@@ -407,7 +407,7 @@ clone_print(resource_t * rsc, const char *pre_text, long options, void *print_da
 
     for (; gIter != NULL; gIter = gIter->next) {
         gboolean print_full = FALSE;
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
         gboolean partially_active = child_rsc->fns->active(child_rsc, FALSE);
 
         if (options & pe_print_clone_details) {
@@ -974,7 +974,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
 }
 
 void
-clone_free(resource_t * rsc)
+clone_free(pe_resource_t * rsc)
 {
     clone_variant_data_t *clone_data = NULL;
 
@@ -983,7 +983,7 @@ clone_free(resource_t * rsc)
     pe_rsc_trace(rsc, "Freeing %s", rsc->id);
 
     for (GListPtr gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         CRM_ASSERT(child_rsc);
         pe_rsc_trace(child_rsc, "Freeing child %s", child_rsc->id);
@@ -1008,13 +1008,13 @@ clone_free(resource_t * rsc)
 }
 
 enum rsc_role_e
-clone_resource_state(const resource_t * rsc, gboolean current)
+clone_resource_state(const pe_resource_t * rsc, gboolean current)
 {
     enum rsc_role_e clone_role = RSC_ROLE_UNKNOWN;
     GListPtr gIter = rsc->children;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
         enum rsc_role_e a_role = child_rsc->fns->state(child_rsc, current);
 
         if (a_role > clone_role) {

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -445,7 +445,7 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
         } else if (child_rsc->fns->active(child_rsc, TRUE)) {
             // Instance of fully active anonymous clone
 
-            node_t *location = child_rsc->fns->location(child_rsc, NULL, TRUE);
+            pe_node_t *location = child_rsc->fns->location(child_rsc, NULL, TRUE);
 
             if (location) {
                 // Instance is active on a single node
@@ -486,7 +486,7 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
     /* Masters */
     master_list = g_list_sort(master_list, sort_node_uname);
     for (gIter = master_list; gIter; gIter = gIter->next) {
-        node_t *host = gIter->data;
+        pe_node_t *host = gIter->data;
 
         list_text = pcmk__add_word(list_text, host->details->uname);
 	active_instances++;
@@ -500,7 +500,7 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
     /* Started/Slaves */
     started_list = g_list_sort(started_list, sort_node_uname);
     for (gIter = started_list; gIter; gIter = gIter->next) {
-        node_t *host = gIter->data;
+        pe_node_t *host = gIter->data;
 
         list_text = pcmk__add_word(list_text, host->details->uname);
 	active_instances++;
@@ -549,7 +549,7 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
 
             list = g_list_sort(list, sort_node_uname);
             for (nIter = list; nIter != NULL; nIter = nIter->next) {
-                node_t *node = (node_t *)nIter->data;
+                pe_node_t *node = (pe_node_t *)nIter->data;
 
                 if (pe_find_node(rsc->running_on, node->details->uname) == NULL) {
                     stopped_list = pcmk__add_word(stopped_list,
@@ -662,7 +662,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
         } else if (child_rsc->fns->active(child_rsc, TRUE)) {
             // Instance of fully active anonymous clone
 
-            node_t *location = child_rsc->fns->location(child_rsc, NULL, TRUE);
+            pe_node_t *location = child_rsc->fns->location(child_rsc, NULL, TRUE);
 
             if (location) {
                 // Instance is active on a single node
@@ -697,7 +697,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
     /* Masters */
     master_list = g_list_sort(master_list, sort_node_uname);
     for (gIter = master_list; gIter; gIter = gIter->next) {
-        node_t *host = gIter->data;
+        pe_node_t *host = gIter->data;
 
         list_text = pcmk__add_word(list_text, host->details->uname);
         active_instances++;
@@ -713,7 +713,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
     /* Started/Slaves */
     started_list = g_list_sort(started_list, sort_node_uname);
     for (gIter = started_list; gIter; gIter = gIter->next) {
-        node_t *host = gIter->data;
+        pe_node_t *host = gIter->data;
 
         list_text = pcmk__add_word(list_text, host->details->uname);
         active_instances++;
@@ -765,7 +765,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
 
             list = g_list_sort(list, sort_node_uname);
             for (nIter = list; nIter != NULL; nIter = nIter->next) {
-                node_t *node = (node_t *)nIter->data;
+                pe_node_t *node = (pe_node_t *)nIter->data;
 
                 if (pe_find_node(rsc->running_on, node->details->uname) == NULL) {
                     stopped_list = pcmk__add_word(stopped_list,
@@ -850,7 +850,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
         } else if (child_rsc->fns->active(child_rsc, TRUE)) {
             // Instance of fully active anonymous clone
 
-            node_t *location = child_rsc->fns->location(child_rsc, NULL, TRUE);
+            pe_node_t *location = child_rsc->fns->location(child_rsc, NULL, TRUE);
 
             if (location) {
                 // Instance is active on a single node
@@ -885,7 +885,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
     /* Masters */
     master_list = g_list_sort(master_list, sort_node_uname);
     for (gIter = master_list; gIter; gIter = gIter->next) {
-        node_t *host = gIter->data;
+        pe_node_t *host = gIter->data;
 
         list_text = pcmk__add_word(list_text, host->details->uname);
         active_instances++;
@@ -901,7 +901,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
     /* Started/Slaves */
     started_list = g_list_sort(started_list, sort_node_uname);
     for (gIter = started_list; gIter; gIter = gIter->next) {
-        node_t *host = gIter->data;
+        pe_node_t *host = gIter->data;
 
         list_text = pcmk__add_word(list_text, host->details->uname);
         active_instances++;
@@ -952,7 +952,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
 
             list = g_list_sort(list, sort_node_uname);
             for (nIter = list; nIter != NULL; nIter = nIter->next) {
-                node_t *node = (node_t *)nIter->data;
+                pe_node_t *node = (pe_node_t *)nIter->data;
 
                 if (pe_find_node(rsc->running_on, node->details->uname) == NULL) {
                     stopped_list = pcmk__add_word(stopped_list,

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -538,7 +538,7 @@ add_hash_param(GHashTable * hash, const char *name, const char *value)
 
 const char *
 pe_node_attribute_calculated(const pe_node_t *node, const char *name,
-                             const resource_t *rsc)
+                             const pe_resource_t *rsc)
 {
     const char *source;
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -95,7 +95,7 @@ dup_attr(gpointer key, gpointer value, gpointer user_data)
 
 void
 get_meta_attributes(GHashTable * meta_hash, pe_resource_t * rsc,
-                    node_t * node, pe_working_set_t * data_set)
+                    pe_node_t * node, pe_working_set_t * data_set)
 {
     GHashTable *node_hash = NULL;
 
@@ -129,7 +129,7 @@ get_meta_attributes(GHashTable * meta_hash, pe_resource_t * rsc,
 
 void
 get_rsc_attributes(GHashTable * meta_hash, pe_resource_t * rsc,
-                   node_t * node, pe_working_set_t * data_set)
+                   pe_node_t * node, pe_working_set_t * data_set)
 {
     GHashTable *node_hash = NULL;
 
@@ -154,7 +154,7 @@ get_rsc_attributes(GHashTable * meta_hash, pe_resource_t * rsc,
 #if ENABLE_VERSIONED_ATTRS
 void
 pe_get_versioned_attributes(xmlNode * meta_hash, pe_resource_t * rsc,
-                            node_t * node, pe_working_set_t * data_set)
+                            pe_node_t * node, pe_working_set_t * data_set)
 {
     GHashTable *node_hash = NULL;
 
@@ -733,7 +733,7 @@ common_unpack(xmlNode * xml_obj, pe_resource_t ** rsc,
 void
 common_update_score(pe_resource_t * rsc, const char *id, int score)
 {
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
 
     node = pe_hash_table_lookup(rsc->allowed_nodes, id);
     if (node != NULL) {

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -94,7 +94,7 @@ dup_attr(gpointer key, gpointer value, gpointer user_data)
 }
 
 void
-get_meta_attributes(GHashTable * meta_hash, resource_t * rsc,
+get_meta_attributes(GHashTable * meta_hash, pe_resource_t * rsc,
                     node_t * node, pe_working_set_t * data_set)
 {
     GHashTable *node_hash = NULL;
@@ -128,7 +128,7 @@ get_meta_attributes(GHashTable * meta_hash, resource_t * rsc,
 }
 
 void
-get_rsc_attributes(GHashTable * meta_hash, resource_t * rsc,
+get_rsc_attributes(GHashTable * meta_hash, pe_resource_t * rsc,
                    node_t * node, pe_working_set_t * data_set)
 {
     GHashTable *node_hash = NULL;
@@ -153,7 +153,7 @@ get_rsc_attributes(GHashTable * meta_hash, resource_t * rsc,
 
 #if ENABLE_VERSIONED_ATTRS
 void
-pe_get_versioned_attributes(xmlNode * meta_hash, resource_t * rsc,
+pe_get_versioned_attributes(xmlNode * meta_hash, pe_resource_t * rsc,
                             node_t * node, pe_working_set_t * data_set)
 {
     GHashTable *node_hash = NULL;
@@ -343,7 +343,7 @@ add_template_rsc(xmlNode * xml_obj, pe_working_set_t * data_set)
 }
 
 static bool
-detect_promotable(resource_t *rsc)
+detect_promotable(pe_resource_t *rsc)
 {
     const char *promotable = g_hash_table_lookup(rsc->meta,
                                                  XML_RSC_ATTR_PROMOTABLE);
@@ -365,8 +365,8 @@ detect_promotable(resource_t *rsc)
 }
 
 gboolean
-common_unpack(xmlNode * xml_obj, resource_t ** rsc,
-              resource_t * parent, pe_working_set_t * data_set)
+common_unpack(xmlNode * xml_obj, pe_resource_t ** rsc,
+              pe_resource_t * parent, pe_working_set_t * data_set)
 {
     bool isdefault = FALSE;
     xmlNode *expanded_xml = NULL;
@@ -394,7 +394,7 @@ common_unpack(xmlNode * xml_obj, resource_t ** rsc,
         return FALSE;
     }
 
-    *rsc = calloc(1, sizeof(resource_t));
+    *rsc = calloc(1, sizeof(pe_resource_t));
     (*rsc)->cluster = data_set;
 
     if (expanded_xml) {
@@ -731,7 +731,7 @@ common_unpack(xmlNode * xml_obj, resource_t ** rsc,
 }
 
 void
-common_update_score(resource_t * rsc, const char *id, int score)
+common_update_score(pe_resource_t * rsc, const char *id, int score)
 {
     node_t *node = NULL;
 
@@ -745,7 +745,7 @@ common_update_score(resource_t * rsc, const char *id, int score)
         GListPtr gIter = rsc->children;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *child_rsc = (resource_t *) gIter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
             common_update_score(child_rsc, id, score);
         }
@@ -753,9 +753,9 @@ common_update_score(resource_t * rsc, const char *id, int score)
 }
 
 gboolean
-is_parent(resource_t *child, resource_t *rsc)
+is_parent(pe_resource_t *child, pe_resource_t *rsc)
 {
-    resource_t *parent = child;
+    pe_resource_t *parent = child;
 
     if (parent == NULL || rsc == NULL) {
         return FALSE;
@@ -769,10 +769,10 @@ is_parent(resource_t *child, resource_t *rsc)
     return FALSE;
 }
 
-resource_t *
-uber_parent(resource_t * rsc)
+pe_resource_t *
+uber_parent(pe_resource_t * rsc)
 {
-    resource_t *parent = rsc;
+    pe_resource_t *parent = rsc;
 
     if (parent == NULL) {
         return NULL;
@@ -784,7 +784,7 @@ uber_parent(resource_t * rsc)
 }
 
 void
-common_free(resource_t * rsc)
+common_free(pe_resource_t * rsc)
 {
     if (rsc == NULL) {
         return;

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -77,7 +77,7 @@ is_matched_failure(const char *rsc_id, xmlNode *conf_op_xml,
 }
 
 static gboolean
-block_failure(node_t *node, resource_t *rsc, xmlNode *xml_op,
+block_failure(node_t *node, pe_resource_t *rsc, xmlNode *xml_op,
               pe_working_set_t *data_set)
 {
     char *xml_name = clone_strip(rsc->id);
@@ -174,7 +174,7 @@ block_failure(node_t *node, resource_t *rsc, xmlNode *xml_op,
  * \note The caller is responsible for freeing the result.
  */
 static inline char *
-rsc_fail_name(resource_t *rsc)
+rsc_fail_name(pe_resource_t *rsc)
 {
     const char *name = (rsc->clone_name? rsc->clone_name : rsc->id);
 
@@ -231,7 +231,7 @@ generate_fail_regex(const char *prefix, const char *rsc_name,
  * \note The caller is responsible for freeing the expressions with regfree().
  */
 static void
-generate_fail_regexes(resource_t *rsc, pe_working_set_t *data_set,
+generate_fail_regexes(pe_resource_t *rsc, pe_working_set_t *data_set,
                       regex_t *failcount_re, regex_t *lastfailure_re)
 {
     char *rsc_name = rsc_fail_name(rsc);
@@ -248,7 +248,7 @@ generate_fail_regexes(resource_t *rsc, pe_working_set_t *data_set,
 }
 
 int
-pe_get_failcount(node_t *node, resource_t *rsc, time_t *last_failure,
+pe_get_failcount(node_t *node, pe_resource_t *rsc, time_t *last_failure,
                  uint32_t flags, xmlNode *xml_op, pe_working_set_t *data_set)
 {
     char *key = NULL;
@@ -315,7 +315,7 @@ pe_get_failcount(node_t *node, resource_t *rsc, time_t *last_failure,
         GListPtr gIter = NULL;
 
         for (gIter = rsc->fillers; gIter != NULL; gIter = gIter->next) {
-            resource_t *filler = (resource_t *) gIter->data;
+            pe_resource_t *filler = (pe_resource_t *) gIter->data;
             time_t filler_last_failure = 0;
 
             failcount += pe_get_failcount(node, filler, &filler_last_failure,

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -361,7 +361,7 @@ pe__clear_failcount(pe_resource_t *rsc, pe_node_t *node,
                     const char *reason, pe_working_set_t *data_set)
 {
     char *key = NULL;
-    action_t *clear = NULL;
+    pe_action_t *clear = NULL;
 
     CRM_CHECK(rsc && node && reason && data_set, return NULL);
 

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -77,7 +77,7 @@ is_matched_failure(const char *rsc_id, xmlNode *conf_op_xml,
 }
 
 static gboolean
-block_failure(node_t *node, pe_resource_t *rsc, xmlNode *xml_op,
+block_failure(pe_node_t *node, pe_resource_t *rsc, xmlNode *xml_op,
               pe_working_set_t *data_set)
 {
     char *xml_name = clone_strip(rsc->id);
@@ -248,7 +248,7 @@ generate_fail_regexes(pe_resource_t *rsc, pe_working_set_t *data_set,
 }
 
 int
-pe_get_failcount(node_t *node, pe_resource_t *rsc, time_t *last_failure,
+pe_get_failcount(pe_node_t *node, pe_resource_t *rsc, time_t *last_failure,
                  uint32_t flags, xmlNode *xml_op, pe_working_set_t *data_set)
 {
     char *key = NULL;

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -19,7 +19,7 @@
 #include "./variant.h"
 
 gboolean
-group_unpack(resource_t * rsc, pe_working_set_t * data_set)
+group_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
     xmlNode *xml_obj = rsc->xml;
     xmlNode *xml_native_rsc = NULL;
@@ -51,7 +51,7 @@ group_unpack(resource_t * rsc, pe_working_set_t * data_set)
     for (xml_native_rsc = __xml_first_child_element(xml_obj); xml_native_rsc != NULL;
          xml_native_rsc = __xml_next_element(xml_native_rsc)) {
         if (crm_str_eq((const char *)xml_native_rsc->name, XML_CIB_TAG_RESOURCE, TRUE)) {
-            resource_t *new_rsc = NULL;
+            pe_resource_t *new_rsc = NULL;
 
             crm_xml_add(xml_native_rsc, XML_RSC_ATTR_INCARNATION, clone_id);
             if (common_unpack(xml_native_rsc, &new_rsc, rsc, data_set) == FALSE) {
@@ -84,14 +84,14 @@ group_unpack(resource_t * rsc, pe_working_set_t * data_set)
 }
 
 gboolean
-group_active(resource_t * rsc, gboolean all)
+group_active(pe_resource_t * rsc, gboolean all)
 {
     gboolean c_all = TRUE;
     gboolean c_any = FALSE;
     GListPtr gIter = rsc->children;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         if (child_rsc->fns->active(child_rsc, all)) {
             c_any = TRUE;
@@ -109,7 +109,7 @@ group_active(resource_t * rsc, gboolean all)
 }
 
 static void
-group_print_xml(resource_t * rsc, const char *pre_text, long options, void *print_data)
+group_print_xml(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
 {
     GListPtr gIter = rsc->children;
     char *child_text = crm_strdup_printf("%s     ", pre_text);
@@ -119,7 +119,7 @@ group_print_xml(resource_t * rsc, const char *pre_text, long options, void *prin
     status_print(">\n");
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         child_rsc->fns->print(child_rsc, child_text, options, print_data);
     }
@@ -129,7 +129,7 @@ group_print_xml(resource_t * rsc, const char *pre_text, long options, void *prin
 }
 
 void
-group_print(resource_t * rsc, const char *pre_text, long options, void *print_data)
+group_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
 {
     char *child_text = NULL;
     GListPtr gIter = rsc->children;
@@ -159,7 +159,7 @@ group_print(resource_t * rsc, const char *pre_text, long options, void *print_da
 
     } else {
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *child_rsc = (resource_t *) gIter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
             if (options & pe_print_html) {
                 status_print("<li>\n");
@@ -249,14 +249,14 @@ pe__group_text(pcmk__output_t *out, va_list args)
 }
 
 void
-group_free(resource_t * rsc)
+group_free(pe_resource_t * rsc)
 {
     CRM_CHECK(rsc != NULL, return);
 
     pe_rsc_trace(rsc, "Freeing %s", rsc->id);
 
     for (GListPtr gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         CRM_ASSERT(child_rsc);
         pe_rsc_trace(child_rsc, "Freeing child %s", child_rsc->id);
@@ -270,13 +270,13 @@ group_free(resource_t * rsc)
 }
 
 enum rsc_role_e
-group_resource_state(const resource_t * rsc, gboolean current)
+group_resource_state(const pe_resource_t * rsc, gboolean current)
 {
     enum rsc_role_e group_role = RSC_ROLE_UNKNOWN;
     GListPtr gIter = rsc->children;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
         enum rsc_role_e role = child_rsc->fns->state(child_rsc, current);
 
         if (role > group_role) {

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -35,7 +35,7 @@ is_multiply_active(pe_resource_t *rsc)
 }
 
 void
-native_add_running(resource_t * rsc, node_t * node, pe_working_set_t * data_set)
+native_add_running(pe_resource_t * rsc, node_t * node, pe_working_set_t * data_set)
 {
     GListPtr gIter = rsc->running_on;
 
@@ -62,7 +62,7 @@ native_add_running(resource_t * rsc, node_t * node, pe_working_set_t * data_set)
     }
 
     if (is_not_set(rsc->flags, pe_rsc_managed)) {
-        resource_t *p = rsc->parent;
+        pe_resource_t *p = rsc->parent;
 
         pe_rsc_info(rsc, "resource %s isn't managed", rsc->id);
         resource_location(rsc, node, INFINITY, "not_managed_default", data_set);
@@ -108,7 +108,7 @@ native_add_running(resource_t * rsc, node_t * node, pe_working_set_t * data_set)
                     GListPtr gIter = rsc->parent->children;
 
                     for (; gIter != NULL; gIter = gIter->next) {
-                        resource_t *child = (resource_t *) gIter->data;
+                        pe_resource_t *child = (pe_resource_t *) gIter->data;
 
                         clear_bit(child->flags, pe_rsc_managed);
                         set_bit(child->flags, pe_rsc_block);
@@ -141,9 +141,9 @@ recursive_clear_unique(pe_resource_t *rsc)
 }
 
 gboolean
-native_unpack(resource_t * rsc, pe_working_set_t * data_set)
+native_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
-    resource_t *parent = uber_parent(rsc);
+    pe_resource_t *parent = uber_parent(rsc);
     native_variant_data_t *native_data = NULL;
     const char *standard = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
     uint32_t ra_caps = pcmk_get_ra_caps(standard);
@@ -184,7 +184,7 @@ native_unpack(resource_t * rsc, pe_working_set_t * data_set)
 }
 
 static bool
-rsc_is_on_node(resource_t *rsc, const node_t *node, int flags)
+rsc_is_on_node(pe_resource_t *rsc, const node_t *node, int flags)
 {
     pe_rsc_trace(rsc, "Checking whether %s is on %s",
                  rsc->id, node->details->uname);
@@ -209,12 +209,12 @@ rsc_is_on_node(resource_t *rsc, const node_t *node, int flags)
     return FALSE;
 }
 
-resource_t *
-native_find_rsc(resource_t * rsc, const char *id, const node_t *on_node,
+pe_resource_t *
+native_find_rsc(pe_resource_t * rsc, const char *id, const node_t *on_node,
                 int flags)
 {
     bool match = FALSE;
-    resource_t *result = NULL;
+    pe_resource_t *result = NULL;
 
     CRM_CHECK(id && rsc && rsc->id, return NULL);
 
@@ -254,7 +254,7 @@ native_find_rsc(resource_t * rsc, const char *id, const node_t *on_node,
     }
 
     for (GListPtr gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-        resource_t *child = (resource_t *) gIter->data;
+        pe_resource_t *child = (pe_resource_t *) gIter->data;
 
         result = rsc->fns->find_rsc(child, id, on_node, flags);
         if (result) {
@@ -265,7 +265,7 @@ native_find_rsc(resource_t * rsc, const char *id, const node_t *on_node,
 }
 
 char *
-native_parameter(resource_t * rsc, node_t * node, gboolean create, const char *name,
+native_parameter(pe_resource_t * rsc, node_t * node, gboolean create, const char *name,
                  pe_working_set_t * data_set)
 {
     char *value_copy = NULL;
@@ -310,7 +310,7 @@ native_parameter(resource_t * rsc, node_t * node, gboolean create, const char *n
 }
 
 gboolean
-native_active(resource_t * rsc, gboolean all)
+native_active(pe_resource_t * rsc, gboolean all)
 {
     GListPtr gIter = rsc->running_on;
 
@@ -346,7 +346,7 @@ native_print_attr(gpointer key, gpointer value, gpointer user_data)
 }
 
 static const char *
-native_pending_state(resource_t * rsc)
+native_pending_state(pe_resource_t * rsc)
 {
     const char *pending_state = NULL;
 
@@ -374,7 +374,7 @@ native_pending_state(resource_t * rsc)
 }
 
 static const char *
-native_pending_task(resource_t * rsc)
+native_pending_task(pe_resource_t * rsc)
 {
     const char *pending_task = NULL;
 
@@ -396,7 +396,7 @@ native_pending_task(resource_t * rsc)
 }
 
 static enum rsc_role_e
-native_displayable_role(resource_t *rsc)
+native_displayable_role(pe_resource_t *rsc)
 {
     enum rsc_role_e role = rsc->role;
 
@@ -409,7 +409,7 @@ native_displayable_role(resource_t *rsc)
 }
 
 static const char *
-native_displayable_state(resource_t *rsc, long options)
+native_displayable_state(pe_resource_t *rsc, long options)
 {
     const char *rsc_state = NULL;
 
@@ -423,7 +423,7 @@ native_displayable_state(resource_t *rsc, long options)
 }
 
 static void
-native_print_xml(resource_t * rsc, const char *pre_text, long options, void *print_data)
+native_print_xml(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
 {
     const char *class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
     const char *prov = crm_element_value(rsc->xml, XML_AGENT_ATTR_PROVIDER);
@@ -666,7 +666,7 @@ native_output_string(pe_resource_t *rsc, const char *name, pe_node_t *node,
 }
 
 int
-pe__common_output_html(pcmk__output_t *out, resource_t * rsc,
+pe__common_output_html(pcmk__output_t *out, pe_resource_t * rsc,
                        const char *name, node_t *node, long options)
 {
     const char *kind = crm_element_value(rsc->xml, XML_ATTR_TYPE);
@@ -755,7 +755,7 @@ pe__common_output_html(pcmk__output_t *out, resource_t * rsc,
 }
 
 int
-pe__common_output_text(pcmk__output_t *out, resource_t * rsc,
+pe__common_output_text(pcmk__output_t *out, pe_resource_t * rsc,
                        const char *name, node_t *node, long options)
 {
     const char *target_role = NULL;
@@ -819,7 +819,7 @@ pe__common_output_text(pcmk__output_t *out, resource_t * rsc,
 }
 
 void
-common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options, void *print_data)
+common_print(pe_resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options, void *print_data)
 {
     const char *target_role = NULL;
 
@@ -971,7 +971,7 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
 }
 
 void
-native_print(resource_t * rsc, const char *pre_text, long options, void *print_data)
+native_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
 {
     node_t *node = NULL;
 
@@ -1092,14 +1092,14 @@ pe__resource_text(pcmk__output_t *out, va_list args)
 }
 
 void
-native_free(resource_t * rsc)
+native_free(pe_resource_t * rsc)
 {
     pe_rsc_trace(rsc, "Freeing resource action list (not the data)");
     common_free(rsc);
 }
 
 enum rsc_role_e
-native_resource_state(const resource_t * rsc, gboolean current)
+native_resource_state(const pe_resource_t * rsc, gboolean current)
 {
     enum rsc_role_e role = rsc->next_role;
 
@@ -1130,7 +1130,7 @@ native_location(const pe_resource_t *rsc, GList **list, int current)
         GListPtr gIter = rsc->children;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *child = (resource_t *) gIter->data;
+            pe_resource_t *child = (pe_resource_t *) gIter->data;
 
             child->fns->location(child, &result, current);
         }
@@ -1175,7 +1175,7 @@ get_rscs_brief(GListPtr rsc_list, GHashTable * rsc_table, GHashTable * active_ta
     GListPtr gIter = rsc_list;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *rsc = (resource_t *) gIter->data;
+        pe_resource_t *rsc = (pe_resource_t *) gIter->data;
 
         const char *class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
         const char *kind = crm_element_value(rsc->xml, XML_ATTR_TYPE);

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -35,13 +35,13 @@ is_multiply_active(pe_resource_t *rsc)
 }
 
 void
-native_add_running(pe_resource_t * rsc, node_t * node, pe_working_set_t * data_set)
+native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * data_set)
 {
     GListPtr gIter = rsc->running_on;
 
     CRM_CHECK(node != NULL, return);
     for (; gIter != NULL; gIter = gIter->next) {
-        node_t *a_node = (node_t *) gIter->data;
+        pe_node_t *a_node = (pe_node_t *) gIter->data;
 
         CRM_CHECK(a_node != NULL, return);
         if (safe_str_eq(a_node->details->id, node->details->id)) {
@@ -80,7 +80,7 @@ native_add_running(pe_resource_t * rsc, node_t * node, pe_working_set_t * data_s
             case recovery_stop_only:
                 {
                     GHashTableIter gIter;
-                    node_t *local_node = NULL;
+                    pe_node_t *local_node = NULL;
 
                     /* make sure it doesn't come up again */
                     if (rsc->allowed_nodes != NULL) {
@@ -184,7 +184,7 @@ native_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
 }
 
 static bool
-rsc_is_on_node(pe_resource_t *rsc, const node_t *node, int flags)
+rsc_is_on_node(pe_resource_t *rsc, const pe_node_t *node, int flags)
 {
     pe_rsc_trace(rsc, "Checking whether %s is on %s",
                  rsc->id, node->details->uname);
@@ -192,7 +192,7 @@ rsc_is_on_node(pe_resource_t *rsc, const node_t *node, int flags)
     if (is_set(flags, pe_find_current) && rsc->running_on) {
 
         for (GListPtr iter = rsc->running_on; iter; iter = iter->next) {
-            node_t *loc = (node_t *) iter->data;
+            pe_node_t *loc = (pe_node_t *) iter->data;
 
             if (loc->details == node->details) {
                 return TRUE;
@@ -210,7 +210,7 @@ rsc_is_on_node(pe_resource_t *rsc, const node_t *node, int flags)
 }
 
 pe_resource_t *
-native_find_rsc(pe_resource_t * rsc, const char *id, const node_t *on_node,
+native_find_rsc(pe_resource_t * rsc, const char *id, const pe_node_t *on_node,
                 int flags)
 {
     bool match = FALSE;
@@ -265,7 +265,7 @@ native_find_rsc(pe_resource_t * rsc, const char *id, const node_t *on_node,
 }
 
 char *
-native_parameter(pe_resource_t * rsc, node_t * node, gboolean create, const char *name,
+native_parameter(pe_resource_t * rsc, pe_node_t * node, gboolean create, const char *name,
                  pe_working_set_t * data_set)
 {
     char *value_copy = NULL;
@@ -315,7 +315,7 @@ native_active(pe_resource_t * rsc, gboolean all)
     GListPtr gIter = rsc->running_on;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        node_t *a_node = (node_t *) gIter->data;
+        pe_node_t *a_node = (pe_node_t *) gIter->data;
 
         if (a_node->details->unclean) {
             crm_debug("Resource %s: node %s is unclean", rsc->id, a_node->details->uname);
@@ -478,7 +478,7 @@ native_print_xml(pe_resource_t * rsc, const char *pre_text, long options, void *
 
         status_print(">\n");
         for (; gIter != NULL; gIter = gIter->next) {
-            node_t *node = (node_t *) gIter->data;
+            pe_node_t *node = (pe_node_t *) gIter->data;
 
             status_print("%s    <node name=\"%s\" id=\"%s\" cached=\"%s\"/>\n", pre_text,
                          node->details->uname, node->details->id,
@@ -667,7 +667,7 @@ native_output_string(pe_resource_t *rsc, const char *name, pe_node_t *node,
 
 int
 pe__common_output_html(pcmk__output_t *out, pe_resource_t * rsc,
-                       const char *name, node_t *node, long options)
+                       const char *name, pe_node_t *node, long options)
 {
     const char *kind = crm_element_value(rsc->xml, XML_ATTR_TYPE);
     const char *target_role = NULL;
@@ -729,7 +729,7 @@ pe__common_output_html(pcmk__output_t *out, pe_resource_t * rsc,
 
     if (is_set(options, pe_print_dev)) {
         GHashTableIter iter;
-        node_t *n = NULL;
+        pe_node_t *n = NULL;
 
         out->begin_list(out, NULL, NULL, "Allowed Nodes");
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
@@ -741,7 +741,7 @@ pe__common_output_html(pcmk__output_t *out, pe_resource_t * rsc,
 
     if (is_set(options, pe_print_max_details)) {
         GHashTableIter iter;
-        node_t *n = NULL;
+        pe_node_t *n = NULL;
 
         out->begin_list(out, NULL, NULL, "=== Allowed Nodes");
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
@@ -756,7 +756,7 @@ pe__common_output_html(pcmk__output_t *out, pe_resource_t * rsc,
 
 int
 pe__common_output_text(pcmk__output_t *out, pe_resource_t * rsc,
-                       const char *name, node_t *node, long options)
+                       const char *name, pe_node_t *node, long options)
 {
     const char *target_role = NULL;
 
@@ -793,7 +793,7 @@ pe__common_output_text(pcmk__output_t *out, pe_resource_t * rsc,
 
     if (is_set(options, pe_print_dev)) {
         GHashTableIter iter;
-        node_t *n = NULL;
+        pe_node_t *n = NULL;
 
         out->begin_list(out, NULL, NULL, "Allowed Nodes");
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
@@ -805,7 +805,7 @@ pe__common_output_text(pcmk__output_t *out, pe_resource_t * rsc,
 
     if (is_set(options, pe_print_max_details)) {
         GHashTableIter iter;
-        node_t *n = NULL;
+        pe_node_t *n = NULL;
 
         out->begin_list(out, NULL, NULL, "=== Allowed Nodes");
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
@@ -819,7 +819,7 @@ pe__common_output_text(pcmk__output_t *out, pe_resource_t * rsc,
 }
 
 void
-common_print(pe_resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options, void *print_data)
+common_print(pe_resource_t * rsc, const char *pre_text, const char *name, pe_node_t *node, long options, void *print_data)
 {
     const char *target_role = NULL;
 
@@ -900,7 +900,7 @@ common_print(pe_resource_t * rsc, const char *pre_text, const char *name, node_t
         }
 
         for (; gIter != NULL; gIter = gIter->next) {
-            node_t *n = (node_t *) gIter->data;
+            pe_node_t *n = (pe_node_t *) gIter->data;
 
             counter++;
 
@@ -949,7 +949,7 @@ common_print(pe_resource_t * rsc, const char *pre_text, const char *name, node_t
 
     if (options & pe_print_dev) {
         GHashTableIter iter;
-        node_t *n = NULL;
+        pe_node_t *n = NULL;
 
         status_print("%s\tAllowed Nodes", pre_text);
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
@@ -960,7 +960,7 @@ common_print(pe_resource_t * rsc, const char *pre_text, const char *name, node_t
 
     if (options & pe_print_max_details) {
         GHashTableIter iter;
-        node_t *n = NULL;
+        pe_node_t *n = NULL;
 
         status_print("%s\t=== Allowed Nodes\n", pre_text);
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
@@ -973,7 +973,7 @@ common_print(pe_resource_t * rsc, const char *pre_text, const char *name, node_t
 void
 native_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
 {
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
 
     CRM_ASSERT(rsc->variant == pe_native);
     if (options & pe_print_xml) {
@@ -1044,7 +1044,7 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
         GListPtr gIter = rsc->running_on;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            node_t *node = (node_t *) gIter->data;
+            pe_node_t *node = (pe_node_t *) gIter->data;
 
             rc = pe__name_and_nvpairs_xml(out, false, "node", 3
                                           , "name", node->details->uname
@@ -1063,7 +1063,7 @@ pe__resource_html(pcmk__output_t *out, va_list args)
 {
     unsigned int options = va_arg(args, unsigned int);
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
-    node_t *node = pe__current_node(rsc);
+    pe_node_t *node = pe__current_node(rsc);
 
     CRM_ASSERT(rsc->variant == pe_native);
 
@@ -1080,7 +1080,7 @@ pe__resource_text(pcmk__output_t *out, va_list args)
     unsigned int options = va_arg(args, unsigned int);
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
 
-    node_t *node = pe__current_node(rsc);
+    pe_node_t *node = pe__current_node(rsc);
 
     CRM_ASSERT(rsc->variant == pe_native);
 
@@ -1123,7 +1123,7 @@ native_resource_state(const pe_resource_t * rsc, gboolean current)
 pe_node_t *
 native_location(const pe_resource_t *rsc, GList **list, int current)
 {
-    node_t *one = NULL;
+    pe_node_t *one = NULL;
     GListPtr result = NULL;
 
     if (rsc->children) {
@@ -1157,7 +1157,7 @@ native_location(const pe_resource_t *rsc, GList **list, int current)
         GListPtr gIter = result;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            node_t *node = (node_t *) gIter->data;
+            pe_node_t *node = (pe_node_t *) gIter->data;
 
             if (*list == NULL || pe_find_node_id(*list, node->details->id) == NULL) {
                 *list = g_list_append(*list, node);
@@ -1212,7 +1212,7 @@ get_rscs_brief(GListPtr rsc_list, GHashTable * rsc_table, GHashTable * active_ta
             GListPtr gIter2 = rsc->running_on;
 
             for (; gIter2 != NULL; gIter2 = gIter2->next) {
-                node_t *node = (node_t *) gIter2->data;
+                pe_node_t *node = (pe_node_t *) gIter2->data;
                 GHashTable *node_table = NULL;
 
                 if (node->details->unclean == FALSE && node->details->online == FALSE) {

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -354,7 +354,7 @@ pe__cluster_summary_html(pcmk__output_t *out, va_list args) {
 }
 
 char *
-pe__node_display_name(node_t *node, bool print_detail)
+pe__node_display_name(pe_node_t *node, bool print_detail)
 {
     char *node_name;
     const char *node_host = NULL;
@@ -365,7 +365,7 @@ pe__node_display_name(node_t *node, bool print_detail)
 
     /* Host is displayed only if this is a guest node */
     if (pe__is_guest_node(node)) {
-        node_t *host_node = pe__current_node(node->details->remote_rsc);
+        pe_node_t *host_node = pe__current_node(node->details->remote_rsc);
 
         if (host_node && host_node->details) {
             node_host = host_node->details->uname;
@@ -618,7 +618,7 @@ int
 pe__cluster_dc_html(pcmk__output_t *out, va_list args) {
     xmlNodePtr node = pcmk__output_create_xml_node(out, "li");
 
-    node_t *dc = va_arg(args, node_t *);
+    pe_node_t *dc = va_arg(args, pe_node_t *);
     const char *quorum = va_arg(args, const char *);
     const char *dc_version_s = va_arg(args, const char *);
     char *dc_name = va_arg(args, char *);
@@ -649,7 +649,7 @@ pe__cluster_dc_html(pcmk__output_t *out, va_list args) {
 
 int
 pe__cluster_dc_text(pcmk__output_t *out, va_list args) {
-    node_t *dc = va_arg(args, node_t *);
+    pe_node_t *dc = va_arg(args, pe_node_t *);
     const char *quorum = va_arg(args, const char *);
     const char *dc_version_s = va_arg(args, const char *);
     char *dc_name = va_arg(args, char *);
@@ -669,7 +669,7 @@ int
 pe__cluster_dc_xml(pcmk__output_t *out, va_list args) {
     xmlNodePtr node = pcmk__output_create_xml_node(out, "current_dc");
 
-    node_t *dc = va_arg(args, node_t *);
+    pe_node_t *dc = va_arg(args, pe_node_t *);
     const char *quorum = va_arg(args, const char *);
     const char *dc_version_s = va_arg(args, const char *);
     char *dc_name G_GNUC_UNUSED = va_arg(args, char *);
@@ -972,7 +972,7 @@ pe__failed_action_xml(pcmk__output_t *out, va_list args) {
 
 int
 pe__node_html(pcmk__output_t *out, va_list args) {
-    node_t *node = va_arg(args, node_t *);
+    pe_node_t *node = va_arg(args, pe_node_t *);
     unsigned int print_opts = va_arg(args, unsigned int);
     gboolean full = va_arg(args, gboolean);
     const char *node_mode G_GNUC_UNUSED = va_arg(args, const char *);
@@ -1032,7 +1032,7 @@ pe__node_html(pcmk__output_t *out, va_list args) {
 
 int
 pe__node_text(pcmk__output_t *out, va_list args) {
-    node_t *node = va_arg(args, node_t *);
+    pe_node_t *node = va_arg(args, pe_node_t *);
     unsigned int print_opts = va_arg(args, unsigned int);
     gboolean full = va_arg(args, gboolean);
     const char *node_mode = va_arg(args, const char *);
@@ -1087,7 +1087,7 @@ pe__node_text(pcmk__output_t *out, va_list args) {
 
 int
 pe__node_xml(pcmk__output_t *out, va_list args) {
-    node_t *node = va_arg(args, node_t *);
+    pe_node_t *node = va_arg(args, pe_node_t *);
     unsigned int print_opts = va_arg(args, unsigned int);
     gboolean full = va_arg(args, gboolean);
     const char *node_mode G_GNUC_UNUSED = va_arg(args, const char *);
@@ -1512,7 +1512,7 @@ pe__register_messages(pcmk__output_t *out) {
 }
 
 void
-pe__output_node(node_t *node, gboolean details, pcmk__output_t *out)
+pe__output_node(pe_node_t *node, gboolean details, pcmk__output_t *out)
 {
     if (node == NULL) {
         crm_trace("<NULL>");

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -177,7 +177,7 @@ op_history_string(xmlNode *xml_op, const char *task, const char *interval_ms_s,
 }
 
 static char *
-resource_history_string(resource_t *rsc, const char *rsc_id, gboolean all,
+resource_history_string(pe_resource_t *rsc, const char *rsc_id, gboolean all,
                         int failcount, time_t last_failure) {
     char *buf = NULL;
 
@@ -1307,7 +1307,7 @@ pe__op_history_xml(pcmk__output_t *out, va_list args) {
 
 int
 pe__resource_history_text(pcmk__output_t *out, va_list args) {
-    resource_t *rsc = va_arg(args, resource_t *);
+    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
     const char *rsc_id = va_arg(args, const char *);
     gboolean all = va_arg(args, gboolean);
     int failcount = va_arg(args, int);
@@ -1328,7 +1328,7 @@ pe__resource_history_text(pcmk__output_t *out, va_list args) {
 
 int
 pe__resource_history_xml(pcmk__output_t *out, va_list args) {
-    resource_t *rsc = va_arg(args, resource_t *);
+    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
     const char *rsc_id = va_arg(args, const char *);
     gboolean all = va_arg(args, gboolean);
     int failcount = va_arg(args, int);
@@ -1535,7 +1535,7 @@ pe__output_node(node_t *node, gboolean details, pcmk__output_t *out)
         crm_trace("\t\t=== Resources");
 
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *rsc = (resource_t *) gIter->data;
+            pe_resource_t *rsc = (pe_resource_t *) gIter->data;
 
             // @TODO pe_print_log probably doesn't belong here
             out->message(out, crm_map_element_name(rsc->xml),

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1371,7 +1371,7 @@ pe__resource_history_xml(pcmk__output_t *out, va_list args) {
 
 int
 pe__ticket_html(pcmk__output_t *out, va_list args) {
-    ticket_t *ticket = va_arg(args, ticket_t *);
+    pe_ticket_t *ticket = va_arg(args, pe_ticket_t *);
 
     if (ticket->last_granted > -1) {
         char *time = pcmk_format_named_time("last-granted", ticket->last_granted);
@@ -1391,7 +1391,7 @@ pe__ticket_html(pcmk__output_t *out, va_list args) {
 
 int
 pe__ticket_text(pcmk__output_t *out, va_list args) {
-    ticket_t *ticket = va_arg(args, ticket_t *);
+    pe_ticket_t *ticket = va_arg(args, pe_ticket_t *);
 
     if (ticket->last_granted > -1) {
         char *time = pcmk_format_named_time("last-granted", ticket->last_granted);
@@ -1413,7 +1413,7 @@ int
 pe__ticket_xml(pcmk__output_t *out, va_list args) {
     xmlNodePtr node = NULL;
 
-    ticket_t *ticket = va_arg(args, ticket_t *);
+    pe_ticket_t *ticket = va_arg(args, pe_ticket_t *);
 
     node = pcmk__output_create_xml_node(out, "ticket");
     xmlSetProp(node, (pcmkXmlStr) "id", (pcmkXmlStr) ticket->id);

--- a/lib/pengine/remote.c
+++ b/lib/pengine/remote.c
@@ -122,7 +122,7 @@ pe_foreach_guest_node(const pe_working_set_t *data_set, const node_t *host,
         return;
     }
     for (iter = host->details->running_rsc; iter != NULL; iter = iter->next) {
-        resource_t *rsc = (resource_t *) iter->data;
+        pe_resource_t *rsc = (pe_resource_t *) iter->data;
 
         if (rsc->is_remote_node && (rsc->container != NULL)) {
             node_t *guest_node = pe_find_node(data_set->nodes, rsc->id);

--- a/lib/pengine/remote.c
+++ b/lib/pengine/remote.c
@@ -16,7 +16,7 @@
 gboolean
 pe__resource_is_remote_conn(pe_resource_t *rsc, pe_working_set_t *data_set)
 {
-    node_t *node;
+    pe_node_t *node;
 
     if (rsc == NULL) {
         return FALSE;
@@ -112,8 +112,8 @@ xml_contains_remote_node(xmlNode *xml)
  * \param[in,out] user_data  Pointer to pass to helper function
  */
 void
-pe_foreach_guest_node(const pe_working_set_t *data_set, const node_t *host,
-                      void (*helper)(const node_t*, void*), void *user_data)
+pe_foreach_guest_node(const pe_working_set_t *data_set, const pe_node_t *host,
+                      void (*helper)(const pe_node_t*, void*), void *user_data)
 {
     GListPtr iter;
 
@@ -125,7 +125,7 @@ pe_foreach_guest_node(const pe_working_set_t *data_set, const node_t *host,
         pe_resource_t *rsc = (pe_resource_t *) iter->data;
 
         if (rsc->is_remote_node && (rsc->container != NULL)) {
-            node_t *guest_node = pe_find_node(data_set->nodes, rsc->id);
+            pe_node_t *guest_node = pe_find_node(data_set->nodes, rsc->id);
 
             if (guest_node) {
                 (*helper)(guest_node, user_data);

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -151,11 +151,11 @@ cluster_status(pe_working_set_t * data_set)
 static void
 pe_free_resources(GListPtr resources)
 {
-    resource_t *rsc = NULL;
+    pe_resource_t *rsc = NULL;
     GListPtr iterator = resources;
 
     while (iterator != NULL) {
-        rsc = (resource_t *) iterator->data;
+        rsc = (pe_resource_t *) iterator->data;
         iterator = iterator->next;
         rsc->fns->free(rsc);
     }
@@ -371,21 +371,21 @@ set_working_set_defaults(pe_working_set_t * data_set)
 #endif
 }
 
-resource_t *
+pe_resource_t *
 pe_find_resource(GListPtr rsc_list, const char *id)
 {
     return pe_find_resource_with_flags(rsc_list, id, pe_find_renamed);
 }
 
-resource_t *
+pe_resource_t *
 pe_find_resource_with_flags(GListPtr rsc_list, const char *id, enum pe_find flags)
 {
     GListPtr rIter = NULL;
 
     for (rIter = rsc_list; id && rIter; rIter = rIter->next) {
-        resource_t *parent = rIter->data;
+        pe_resource_t *parent = rIter->data;
 
-        resource_t *match =
+        pe_resource_t *match =
             parent->fns->find_rsc(parent, id, NULL, flags);
         if (match != NULL) {
             return match;

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -395,10 +395,10 @@ pe_find_resource_with_flags(GListPtr rsc_list, const char *id, enum pe_find flag
     return NULL;
 }
 
-node_t *
+pe_node_t *
 pe_find_node_any(GListPtr nodes, const char *id, const char *uname)
 {
-    node_t *match = pe_find_node_id(nodes, id);
+    pe_node_t *match = pe_find_node_id(nodes, id);
 
     if (match) {
         return match;
@@ -407,13 +407,13 @@ pe_find_node_any(GListPtr nodes, const char *id, const char *uname)
     return pe_find_node(nodes, uname);
 }
 
-node_t *
+pe_node_t *
 pe_find_node_id(GListPtr nodes, const char *id)
 {
     GListPtr gIter = nodes;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        node_t *node = (node_t *) gIter->data;
+        pe_node_t *node = (pe_node_t *) gIter->data;
 
         if (node && safe_str_eq(node->details->id, id)) {
             return node;
@@ -423,13 +423,13 @@ pe_find_node_id(GListPtr nodes, const char *id)
     return NULL;
 }
 
-node_t *
+pe_node_t *
 pe_find_node(GListPtr nodes, const char *uname)
 {
     GListPtr gIter = nodes;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        node_t *node = (node_t *) gIter->data;
+        pe_node_t *node = (pe_node_t *) gIter->data;
 
         if (node && safe_str_eq(node->details->uname, uname)) {
             return node;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2058,7 +2058,7 @@ process_rsc_state(resource_t * rsc, node_t * node,
         GListPtr gIter = possible_matches;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            action_t *stop = (action_t *) gIter->data;
+            pe_action_t *stop = (pe_action_t *) gIter->data;
 
             stop->flags |= pe_action_optional;
         }
@@ -2749,7 +2749,7 @@ unpack_rsc_op_failure(resource_t * rsc, node_t * node, int rc, xmlNode * xml_op,
 {
     guint interval_ms = 0;
     bool is_probe = false;
-    action_t *action = NULL;
+    pe_action_t *action = NULL;
 
     const char *key = get_op_key(xml_op);
     const char *task = crm_element_value(xml_op, XML_LRM_ATTR_TASK);
@@ -3281,7 +3281,7 @@ static enum action_fail_response
 get_action_on_fail(resource_t *rsc, const char *key, const char *task, pe_working_set_t * data_set) 
 {
     int result = action_fail_recover;
-    action_t *action = custom_action(rsc, strdup(key), task, NULL, TRUE, FALSE, data_set);
+    pe_action_t *action = custom_action(rsc, strdup(key), task, NULL, TRUE, FALSE, data_set);
 
     result = action->on_fail;
     pe_free_action(action);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -839,7 +839,7 @@ unpack_ticket_state(xmlNode * xml_ticket, pe_working_set_t * data_set)
     const char *standby = NULL;
     xmlAttrPtr xIter = NULL;
 
-    ticket_t *ticket = NULL;
+    pe_ticket_t *ticket = NULL;
 
     ticket_id = ID(xml_ticket);
     if (ticket_id == NULL || strlen(ticket_id) == 0) {

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -696,7 +696,7 @@ link_rsc2remotenode(pe_working_set_t *data_set, resource_t *new_rsc)
 static void
 destroy_tag(gpointer data)
 {
-    tag_t *tag = data;
+    pe_tag_t *tag = data;
 
     if (tag) {
         free(tag->id);

--- a/lib/pengine/unpack.h
+++ b/lib/pengine/unpack.h
@@ -24,10 +24,10 @@ extern gboolean unpack_status(xmlNode * status, pe_working_set_t * data_set);
 
 extern gint sort_op_by_callid(gconstpointer a, gconstpointer b);
 
-extern gboolean unpack_lrm_resources(node_t * node, xmlNode * lrm_state,
+extern gboolean unpack_lrm_resources(pe_node_t * node, xmlNode * lrm_state,
                                      pe_working_set_t * data_set);
 
-extern gboolean determine_online_status(xmlNode * node_state, node_t * this_node,
+extern gboolean determine_online_status(xmlNode * node_state, pe_node_t * this_node,
                                         pe_working_set_t * data_set);
 
 // Some warnings we don't want to print every transition

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1907,7 +1907,7 @@ get_pseudo_op(const char *name, pe_working_set_t * data_set)
 void
 destroy_ticket(gpointer data)
 {
-    ticket_t *ticket = data;
+    pe_ticket_t *ticket = data;
 
     if (ticket->state) {
         g_hash_table_destroy(ticket->state);
@@ -1916,10 +1916,10 @@ destroy_ticket(gpointer data)
     free(ticket);
 }
 
-ticket_t *
+pe_ticket_t *
 ticket_new(const char *ticket_id, pe_working_set_t * data_set)
 {
-    ticket_t *ticket = NULL;
+    pe_ticket_t *ticket = NULL;
 
     if (ticket_id == NULL || strlen(ticket_id) == 0) {
         return NULL;
@@ -1934,7 +1934,7 @@ ticket_new(const char *ticket_id, pe_working_set_t * data_set)
     ticket = g_hash_table_lookup(data_set->tickets, ticket_id);
     if (ticket == NULL) {
 
-        ticket = calloc(1, sizeof(ticket_t));
+        ticket = calloc(1, sizeof(pe_ticket_t));
         if (ticket == NULL) {
             crm_err("Cannot allocate ticket '%s'", ticket_id);
             return NULL;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -25,9 +25,9 @@
 extern xmlNode *get_object_root(const char *object_type, xmlNode * the_root);
 void print_str_str(gpointer key, gpointer value, gpointer user_data);
 gboolean ghash_free_str_str(gpointer key, gpointer value, gpointer user_data);
-void unpack_operation(pe_action_t * action, xmlNode * xml_obj, resource_t * container,
+void unpack_operation(pe_action_t * action, xmlNode * xml_obj, pe_resource_t * container,
                       pe_working_set_t * data_set);
-static xmlNode *find_rsc_op_entry_helper(resource_t * rsc, const char *key,
+static xmlNode *find_rsc_op_entry_helper(pe_resource_t * rsc, const char *key,
                                          gboolean include_disabled);
 
 #if ENABLE_VERSIONED_ATTRS
@@ -425,7 +425,7 @@ dump_node_capacity(int level, const char *comment, node_t * node)
 }
 
 void
-dump_rsc_utilization(int level, const char *comment, resource_t * rsc, node_t * node)
+dump_rsc_utilization(int level, const char *comment, pe_resource_t * rsc, node_t * node)
 {
     char *dump_text = crm_strdup_printf("%s: %s utilization on %s:",
                                         comment, rsc->id, node->details->uname);
@@ -446,8 +446,8 @@ dump_rsc_utilization(int level, const char *comment, resource_t * rsc, node_t * 
 gint
 sort_rsc_index(gconstpointer a, gconstpointer b)
 {
-    const resource_t *resource1 = (const resource_t *)a;
-    const resource_t *resource2 = (const resource_t *)b;
+    const pe_resource_t *resource1 = (const pe_resource_t *)a;
+    const pe_resource_t *resource2 = (const pe_resource_t *)b;
 
     if (a == NULL && b == NULL) {
         return 0;
@@ -473,8 +473,8 @@ sort_rsc_index(gconstpointer a, gconstpointer b)
 gint
 sort_rsc_priority(gconstpointer a, gconstpointer b)
 {
-    const resource_t *resource1 = (const resource_t *)a;
-    const resource_t *resource2 = (const resource_t *)b;
+    const pe_resource_t *resource1 = (const pe_resource_t *)a;
+    const pe_resource_t *resource2 = (const pe_resource_t *)b;
 
     if (a == NULL && b == NULL) {
         return 0;
@@ -498,7 +498,7 @@ sort_rsc_priority(gconstpointer a, gconstpointer b)
 }
 
 pe_action_t *
-custom_action(resource_t * rsc, char *key, const char *task,
+custom_action(pe_resource_t * rsc, char *key, const char *task,
               node_t * on_node, gboolean optional, gboolean save_action,
               pe_working_set_t * data_set)
 {
@@ -772,7 +772,7 @@ unpack_operation_on_fail(pe_action_t * action)
 }
 
 static xmlNode *
-find_min_interval_mon(resource_t * rsc, gboolean include_disabled)
+find_min_interval_mon(pe_resource_t * rsc, gboolean include_disabled)
 {
     guint interval_ms = 0;
     guint min_interval_ms = G_MAXUINT;
@@ -883,7 +883,7 @@ unpack_timeout(const char *value)
 }
 
 int
-pe_get_configured_timeout(resource_t *rsc, const char *action, pe_working_set_t *data_set)
+pe_get_configured_timeout(pe_resource_t *rsc, const char *action, pe_working_set_t *data_set)
 {
     xmlNode *child = NULL;
     const char *timeout = NULL;
@@ -967,7 +967,7 @@ unpack_versioned_meta(xmlNode *versioned_meta, xmlNode *xml_obj,
  * \param[in]     data_set   Cluster state
  */
 void
-unpack_operation(pe_action_t * action, xmlNode * xml_obj, resource_t * container,
+unpack_operation(pe_action_t * action, xmlNode * xml_obj, pe_resource_t * container,
                  pe_working_set_t * data_set)
 {
     guint interval_ms = 0;
@@ -1251,7 +1251,7 @@ unpack_operation(pe_action_t * action, xmlNode * xml_obj, resource_t * container
 }
 
 static xmlNode *
-find_rsc_op_entry_helper(resource_t * rsc, const char *key, gboolean include_disabled)
+find_rsc_op_entry_helper(pe_resource_t * rsc, const char *key, gboolean include_disabled)
 {
     guint interval_ms = 0;
     gboolean do_retry = TRUE;
@@ -1317,7 +1317,7 @@ find_rsc_op_entry_helper(resource_t * rsc, const char *key, gboolean include_dis
 }
 
 xmlNode *
-find_rsc_op_entry(resource_t * rsc, const char *key)
+find_rsc_op_entry(pe_resource_t * rsc, const char *key)
 {
     return find_rsc_op_entry_helper(rsc, key, FALSE);
 }
@@ -1431,7 +1431,7 @@ find_recurring_actions(GListPtr input, node_t * not_on_node)
 }
 
 enum action_tasks
-get_complex_task(resource_t * rsc, const char *name, gboolean allow_non_atomic)
+get_complex_task(pe_resource_t * rsc, const char *name, gboolean allow_non_atomic)
 {
     enum action_tasks task = text2task(name);
 
@@ -1590,7 +1590,7 @@ pe__resource_actions(const pe_resource_t *rsc, const pe_node_t *node,
 }
 
 static void
-resource_node_score(resource_t * rsc, node_t * node, int score, const char *tag)
+resource_node_score(pe_resource_t * rsc, node_t * node, int score, const char *tag)
 {
     node_t *match = NULL;
 
@@ -1606,7 +1606,7 @@ resource_node_score(resource_t * rsc, node_t * node, int score, const char *tag)
         GListPtr gIter = rsc->children;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            resource_t *child_rsc = (resource_t *) gIter->data;
+            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
             resource_node_score(child_rsc, node, score, tag);
         }
@@ -1622,7 +1622,7 @@ resource_node_score(resource_t * rsc, node_t * node, int score, const char *tag)
 }
 
 void
-resource_location(resource_t * rsc, node_t * node, int score, const char *tag,
+resource_location(pe_resource_t * rsc, node_t * node, int score, const char *tag,
                   pe_working_set_t * data_set)
 {
     if (node != NULL) {
@@ -1798,7 +1798,7 @@ get_effective_time(pe_working_set_t * data_set)
 }
 
 gboolean
-get_target_role(resource_t * rsc, enum rsc_role_e * role)
+get_target_role(pe_resource_t * rsc, enum rsc_role_e * role)
 {
     enum rsc_role_e local_role = RSC_ROLE_UNKNOWN;
     const char *value = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_TARGET_ROLE);
@@ -2108,7 +2108,7 @@ rsc_action_digest(pe_resource_t *rsc, const char *task, const char *key,
 }
 
 op_digest_cache_t *
-rsc_action_digest_cmp(resource_t * rsc, xmlNode * xml_op, node_t * node,
+rsc_action_digest_cmp(pe_resource_t * rsc, xmlNode * xml_op, node_t * node,
                       pe_working_set_t * data_set)
 {
     op_digest_cache_t *data = NULL;
@@ -2289,7 +2289,7 @@ fencing_action_digest_cmp(pe_resource_t *rsc, const char *agent,
     return data;
 }
 
-const char *rsc_printable_id(resource_t *rsc)
+const char *rsc_printable_id(pe_resource_t *rsc)
 {
     if (is_not_set(rsc->flags, pe_rsc_unique)) {
         return ID(rsc->xml);
@@ -2298,26 +2298,26 @@ const char *rsc_printable_id(resource_t *rsc)
 }
 
 void
-clear_bit_recursive(resource_t * rsc, unsigned long long flag)
+clear_bit_recursive(pe_resource_t * rsc, unsigned long long flag)
 {
     GListPtr gIter = rsc->children;
 
     clear_bit(rsc->flags, flag);
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         clear_bit_recursive(child_rsc, flag);
     }
 }
 
 void
-set_bit_recursive(resource_t * rsc, unsigned long long flag)
+set_bit_recursive(pe_resource_t * rsc, unsigned long long flag)
 {
     GListPtr gIter = rsc->children;
 
     set_bit(rsc->flags, flag);
     for (; gIter != NULL; gIter = gIter->next) {
-        resource_t *child_rsc = (resource_t *) gIter->data;
+        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
         set_bit_recursive(child_rsc, flag);
     }
@@ -2327,7 +2327,7 @@ static GListPtr
 find_unfencing_devices(GListPtr candidates, GListPtr matches) 
 {
     for (GListPtr gIter = candidates; gIter != NULL; gIter = gIter->next) {
-        resource_t *candidate = gIter->data;
+        pe_resource_t *candidate = gIter->data;
         const char *provides = g_hash_table_lookup(candidate->meta, XML_RSC_ATTR_PROVIDES);
         const char *requires = g_hash_table_lookup(candidate->meta, XML_RSC_ATTR_REQUIRES);
 
@@ -2383,7 +2383,7 @@ pe_fence_op(node_t * node, const char *op, bool optional, const char *reason, pe
             GListPtr matches = find_unfencing_devices(data_set->resources, NULL);
 
             for (GListPtr gIter = matches; gIter != NULL; gIter = gIter->next) {
-                resource_t *match = gIter->data;
+                pe_resource_t *match = gIter->data;
                 const char *agent = g_hash_table_lookup(match->meta,
                                                         XML_ATTR_TYPE);
                 op_digest_cache_t *data = NULL;
@@ -2428,7 +2428,7 @@ pe_fence_op(node_t * node, const char *op, bool optional, const char *reason, pe
 
 void
 trigger_unfencing(
-    resource_t * rsc, node_t *node, const char *reason, pe_action_t *dependency, pe_working_set_t * data_set) 
+    pe_resource_t * rsc, node_t *node, const char *reason, pe_action_t *dependency, pe_working_set_t * data_set) 
 {
     if(is_not_set(data_set->flags, pe_flag_enable_unfencing)) {
         /* No resources require it */

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1375,8 +1375,8 @@ pe_free_action(pe_action_t * action)
     if (action == NULL) {
         return;
     }
-    g_list_free_full(action->actions_before, free);     /* action_wrapper_t* */
-    g_list_free_full(action->actions_after, free);      /* action_wrapper_t* */
+    g_list_free_full(action->actions_before, free);     /* pe_action_wrapper_t* */
+    g_list_free_full(action->actions_after, free);      /* pe_action_wrapper_t* */
     if (action->extra) {
         g_hash_table_destroy(action->extra);
     }
@@ -1839,7 +1839,7 @@ gboolean
 order_actions(pe_action_t * lh_action, pe_action_t * rh_action, enum pe_ordering order)
 {
     GListPtr gIter = NULL;
-    action_wrapper_t *wrapper = NULL;
+    pe_action_wrapper_t *wrapper = NULL;
     GListPtr list = NULL;
 
     if (order == pe_order_none) {
@@ -1858,14 +1858,14 @@ order_actions(pe_action_t * lh_action, pe_action_t * rh_action, enum pe_ordering
     /* Filter dups, otherwise update_action_states() has too much work to do */
     gIter = lh_action->actions_after;
     for (; gIter != NULL; gIter = gIter->next) {
-        action_wrapper_t *after = (action_wrapper_t *) gIter->data;
+        pe_action_wrapper_t *after = (pe_action_wrapper_t *) gIter->data;
 
         if (after->action == rh_action && (after->type & order)) {
             return FALSE;
         }
     }
 
-    wrapper = calloc(1, sizeof(action_wrapper_t));
+    wrapper = calloc(1, sizeof(pe_action_wrapper_t));
     wrapper->action = rh_action;
     wrapper->type = order;
 
@@ -1878,7 +1878,7 @@ order_actions(pe_action_t * lh_action, pe_action_t * rh_action, enum pe_ordering
 /* 	order |= pe_order_implies_then; */
 /* 	order ^= pe_order_implies_then; */
 
-    wrapper = calloc(1, sizeof(action_wrapper_t));
+    wrapper = calloc(1, sizeof(pe_action_wrapper_t));
     wrapper->action = lh_action;
     wrapper->type = order;
     list = rh_action->actions_before;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -128,14 +128,14 @@ pe_can_fence(pe_working_set_t *data_set, pe_node_t *node)
     return false;
 }
 
-node_t *
-node_copy(const node_t *this_node)
+pe_node_t *
+node_copy(const pe_node_t *this_node)
 {
-    node_t *new_node = NULL;
+    pe_node_t *new_node = NULL;
 
     CRM_CHECK(this_node != NULL, return NULL);
 
-    new_node = calloc(1, sizeof(node_t));
+    new_node = calloc(1, sizeof(pe_node_t));
     CRM_ASSERT(new_node != NULL);
 
     crm_trace("Copying %p (%s) to %p", this_node, this_node->details->uname, new_node);
@@ -153,11 +153,11 @@ void
 node_list_exclude(GHashTable * hash, GListPtr list, gboolean merge_scores)
 {
     GHashTable *result = hash;
-    node_t *other_node = NULL;
+    pe_node_t *other_node = NULL;
     GListPtr gIter = list;
 
     GHashTableIter iter;
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
 
     g_hash_table_iter_init(&iter, hash);
     while (g_hash_table_iter_next(&iter, NULL, (void **)&node)) {
@@ -171,12 +171,12 @@ node_list_exclude(GHashTable * hash, GListPtr list, gboolean merge_scores)
     }
 
     for (; gIter != NULL; gIter = gIter->next) {
-        node_t *node = (node_t *) gIter->data;
+        pe_node_t *node = (pe_node_t *) gIter->data;
 
         other_node = pe_hash_table_lookup(result, node->details->id);
 
         if (other_node == NULL) {
-            node_t *new_node = node_copy(node);
+            pe_node_t *new_node = node_copy(node);
 
             new_node->weight = -INFINITY;
             g_hash_table_insert(result, (gpointer) new_node->details->id, new_node);
@@ -192,8 +192,8 @@ node_hash_from_list(GListPtr list)
                                                free);
 
     for (; gIter != NULL; gIter = gIter->next) {
-        node_t *node = (node_t *) gIter->data;
-        node_t *n = node_copy(node);
+        pe_node_t *node = (pe_node_t *) gIter->data;
+        pe_node_t *n = node_copy(node);
 
         g_hash_table_insert(result, (gpointer) n->details->id, n);
     }
@@ -208,8 +208,8 @@ node_list_dup(GListPtr list1, gboolean reset, gboolean filter)
     GListPtr gIter = list1;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        node_t *new_node = NULL;
-        node_t *this_node = (node_t *) gIter->data;
+        pe_node_t *new_node = NULL;
+        pe_node_t *this_node = (pe_node_t *) gIter->data;
 
         if (filter && this_node->weight < 0) {
             continue;
@@ -230,8 +230,8 @@ node_list_dup(GListPtr list1, gboolean reset, gboolean filter)
 gint
 sort_node_uname(gconstpointer a, gconstpointer b)
 {
-    const char *name_a = ((const node_t *) a)->details->uname;
-    const char *name_b = ((const node_t *) b)->details->uname;
+    const char *name_a = ((const pe_node_t *) a)->details->uname;
+    const char *name_b = ((const pe_node_t *) b)->details->uname;
 
     while (*name_a && *name_b) {
         if (isdigit(*name_a) && isdigit(*name_b)) {
@@ -408,7 +408,7 @@ append_dump_text(gpointer key, gpointer value, gpointer user_data)
 }
 
 void
-dump_node_capacity(int level, const char *comment, node_t * node)
+dump_node_capacity(int level, const char *comment, pe_node_t * node)
 {
     char *dump_text = crm_strdup_printf("%s: %s capacity:",
                                         comment, node->details->uname);
@@ -425,7 +425,7 @@ dump_node_capacity(int level, const char *comment, node_t * node)
 }
 
 void
-dump_rsc_utilization(int level, const char *comment, pe_resource_t * rsc, node_t * node)
+dump_rsc_utilization(int level, const char *comment, pe_resource_t * rsc, pe_node_t * node)
 {
     char *dump_text = crm_strdup_printf("%s: %s utilization on %s:",
                                         comment, rsc->id, node->details->uname);
@@ -499,7 +499,7 @@ sort_rsc_priority(gconstpointer a, gconstpointer b)
 
 pe_action_t *
 custom_action(pe_resource_t * rsc, char *key, const char *task,
-              node_t * on_node, gboolean optional, gboolean save_action,
+              pe_node_t * on_node, gboolean optional, gboolean save_action,
               pe_working_set_t * data_set)
 {
     pe_action_t *action = NULL;
@@ -1323,7 +1323,7 @@ find_rsc_op_entry(pe_resource_t * rsc, const char *key)
 }
 
 void
-print_node(const char *pre_text, node_t * node, gboolean details)
+print_node(const char *pre_text, pe_node_t * node, gboolean details)
 {
     if (node == NULL) {
         crm_trace("%s%s: <NULL>", pre_text == NULL ? "" : pre_text, pre_text == NULL ? "" : ": ");
@@ -1397,7 +1397,7 @@ pe_free_action(pe_action_t * action)
 }
 
 GListPtr
-find_recurring_actions(GListPtr input, node_t * not_on_node)
+find_recurring_actions(GListPtr input, pe_node_t * not_on_node)
 {
     const char *value = NULL;
     GListPtr result = NULL;
@@ -1455,7 +1455,7 @@ get_complex_task(pe_resource_t * rsc, const char *name, gboolean allow_non_atomi
 }
 
 pe_action_t *
-find_first_action(GListPtr input, const char *uuid, const char *task, node_t * on_node)
+find_first_action(GListPtr input, const char *uuid, const char *task, pe_node_t * on_node)
 {
     GListPtr gIter = NULL;
 
@@ -1485,7 +1485,7 @@ find_first_action(GListPtr input, const char *uuid, const char *task, node_t * o
 }
 
 GListPtr
-find_actions(GListPtr input, const char *key, const node_t *on_node)
+find_actions(GListPtr input, const char *key, const pe_node_t *on_node)
 {
     GListPtr gIter = input;
     GListPtr result = NULL;
@@ -1590,9 +1590,9 @@ pe__resource_actions(const pe_resource_t *rsc, const pe_node_t *node,
 }
 
 static void
-resource_node_score(pe_resource_t * rsc, node_t * node, int score, const char *tag)
+resource_node_score(pe_resource_t * rsc, pe_node_t * node, int score, const char *tag)
 {
-    node_t *match = NULL;
+    pe_node_t *match = NULL;
 
     if ((rsc->exclusive_discover || (node->rsc_discover_mode == pe_discover_never))
         && safe_str_eq(tag, "symmetric_default")) {
@@ -1622,7 +1622,7 @@ resource_node_score(pe_resource_t * rsc, node_t * node, int score, const char *t
 }
 
 void
-resource_location(pe_resource_t * rsc, node_t * node, int score, const char *tag,
+resource_location(pe_resource_t * rsc, pe_node_t * node, int score, const char *tag,
                   pe_working_set_t * data_set)
 {
     if (node != NULL) {
@@ -1632,14 +1632,14 @@ resource_location(pe_resource_t * rsc, node_t * node, int score, const char *tag
         GListPtr gIter = data_set->nodes;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            node_t *node_iter = (node_t *) gIter->data;
+            pe_node_t *node_iter = (pe_node_t *) gIter->data;
 
             resource_node_score(rsc, node_iter, score, tag);
         }
 
     } else {
         GHashTableIter iter;
-        node_t *node_iter = NULL;
+        pe_node_t *node_iter = NULL;
 
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
         while (g_hash_table_iter_next(&iter, NULL, (void **)&node_iter)) {
@@ -2108,7 +2108,7 @@ rsc_action_digest(pe_resource_t *rsc, const char *task, const char *key,
 }
 
 op_digest_cache_t *
-rsc_action_digest_cmp(pe_resource_t * rsc, xmlNode * xml_op, node_t * node,
+rsc_action_digest_cmp(pe_resource_t * rsc, xmlNode * xml_op, pe_node_t * node,
                       pe_working_set_t * data_set)
 {
     op_digest_cache_t *data = NULL;
@@ -2345,7 +2345,7 @@ find_unfencing_devices(GListPtr candidates, GListPtr matches)
 
 
 pe_action_t *
-pe_fence_op(node_t * node, const char *op, bool optional, const char *reason, pe_working_set_t * data_set)
+pe_fence_op(pe_node_t * node, const char *op, bool optional, const char *reason, pe_working_set_t * data_set)
 {
     char *op_key = NULL;
     pe_action_t *stonith_op = NULL;
@@ -2428,7 +2428,7 @@ pe_fence_op(node_t * node, const char *op, bool optional, const char *reason, pe
 
 void
 trigger_unfencing(
-    pe_resource_t * rsc, node_t *node, const char *reason, pe_action_t *dependency, pe_working_set_t * data_set) 
+    pe_resource_t * rsc, pe_node_t *node, const char *reason, pe_action_t *dependency, pe_working_set_t * data_set) 
 {
     if(is_not_set(data_set->flags, pe_flag_enable_unfencing)) {
         /* No resources require it */

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -2463,7 +2463,7 @@ trigger_unfencing(
 gboolean
 add_tag_ref(GHashTable * tags, const char * tag_name,  const char * obj_ref)
 {
-    tag_t *tag = NULL;
+    pe_tag_t *tag = NULL;
     GListPtr gIter = NULL;
     gboolean is_existing = FALSE;
 
@@ -2471,7 +2471,7 @@ add_tag_ref(GHashTable * tags, const char * tag_name,  const char * obj_ref)
 
     tag = g_hash_table_lookup(tags, tag_name);
     if (tag == NULL) {
-        tag = calloc(1, sizeof(tag_t));
+        tag = calloc(1, sizeof(pe_tag_t));
         if (tag == NULL) {
             return FALSE;
         }

--- a/lib/pengine/variant.h
+++ b/lib/pengine/variant.h
@@ -100,7 +100,7 @@ typedef struct pe__bundle_variant_data_s {
         char *launcher_options;
         const char *attribute_target;
 
-        resource_t *child;
+        pe_resource_t *child;
 
         GList *replicas;    // pe__bundle_replica_t *
         GList *ports;       // pe__bundle_port_t *
@@ -119,8 +119,8 @@ typedef struct pe__bundle_variant_data_s {
 
 typedef struct group_variant_data_s {
     int num_children;
-    resource_t *first_child;
-    resource_t *last_child;
+    pe_resource_t *first_child;
+    pe_resource_t *last_child;
 
     gboolean colocated;
     gboolean ordered;

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1418,7 +1418,7 @@ print_simple_status(pcmk__output_t *out, pe_working_set_t * data_set,
     }
 
     for (gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
-        node_t *node = (node_t *) gIter->data;
+        pe_node_t *node = (pe_node_t *) gIter->data;
 
         if (node->details->standby && node->details->online) {
             nodes_standby++;

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -106,7 +106,7 @@ int print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
 
 GList *append_attr_list(GList *attr_list, char *name);
 void blank_screen(void);
-void crm_mon_get_parameters(resource_t *rsc, pe_working_set_t *data_set);
+void crm_mon_get_parameters(pe_resource_t *rsc, pe_working_set_t *data_set);
 unsigned int get_resource_display_options(unsigned int mon_ops);
 
 void crm_mon_register_messages(pcmk__output_t *out);

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -33,12 +33,12 @@ static int print_resources(pcmk__output_t *out, pe_working_set_t *data_set,
                            unsigned int print_opts, unsigned int mon_ops, gboolean brief_output,
                            gboolean print_summary, gboolean print_spacer);
 static int print_rsc_history(pcmk__output_t *out, pe_working_set_t *data_set,
-                             node_t *node, xmlNode *rsc_entry, unsigned int mon_ops,
+                             pe_node_t *node, xmlNode *rsc_entry, unsigned int mon_ops,
                              GListPtr op_list);
 static int print_node_history(pcmk__output_t *out, pe_working_set_t *data_set,
                               xmlNode *node_state, gboolean operations,
                               unsigned int mon_ops);
-static gboolean add_extra_info(pcmk__output_t *out, node_t * node, GListPtr rsc_list,
+static gboolean add_extra_info(pcmk__output_t *out, pe_node_t * node, GListPtr rsc_list,
                                const char *attrname, int *expected_score);
 static void print_node_attribute(gpointer name, gpointer user_data);
 static int print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
@@ -189,7 +189,7 @@ print_resources(pcmk__output_t *out, pe_working_set_t *data_set,
 }
 
 static int
-failure_count(pe_working_set_t *data_set, node_t *node, pe_resource_t *rsc, time_t *last_failure) {
+failure_count(pe_working_set_t *data_set, pe_node_t *node, pe_resource_t *rsc, time_t *last_failure) {
     return rsc ? pe_get_failcount(node, rsc, last_failure, pe_fc_default,
                                   NULL, data_set)
                : 0;
@@ -223,7 +223,7 @@ get_operation_list(xmlNode *rsc_entry) {
  * \param[in] op_list   A list of operations to print.
  */
 static int
-print_rsc_history(pcmk__output_t *out, pe_working_set_t *data_set, node_t *node,
+print_rsc_history(pcmk__output_t *out, pe_working_set_t *data_set, pe_node_t *node,
                   xmlNode *rsc_entry, unsigned int mon_ops, GListPtr op_list)
 {
     GListPtr gIter = NULL;
@@ -291,7 +291,7 @@ print_node_history(pcmk__output_t *out, pe_working_set_t *data_set,
                    xmlNode *node_state, gboolean operations,
                    unsigned int mon_ops)
 {
-    node_t *node = pe_find_node_id(data_set->nodes, ID(node_state));
+    pe_node_t *node = pe_find_node_id(data_set->nodes, ID(node_state));
     xmlNode *lrm_rsc = NULL;
     xmlNode *rsc_entry = NULL;
     int rc = pcmk_rc_no_output;
@@ -367,7 +367,7 @@ print_node_history(pcmk__output_t *out, pe_working_set_t *data_set,
  *       or degraded.
  */
 static gboolean
-add_extra_info(pcmk__output_t *out, node_t *node, GListPtr rsc_list,
+add_extra_info(pcmk__output_t *out, pe_node_t *node, GListPtr rsc_list,
                const char *attrname, int *expected_score)
 {
     GListPtr gIter = NULL;
@@ -418,7 +418,7 @@ add_extra_info(pcmk__output_t *out, node_t *node, GListPtr rsc_list,
 /* structure for passing multiple user data to g_list_foreach() */
 struct mon_attr_data {
     pcmk__output_t *out;
-    node_t *node;
+    pe_node_t *node;
 };
 
 static void
@@ -605,7 +605,7 @@ print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set,
         struct mon_attr_data data;
 
         data.out = out;
-        data.node = (node_t *) gIter->data;
+        data.node = (pe_node_t *) gIter->data;
 
         if (data.node && data.node->details && data.node->details->online) {
             GList *attr_list = NULL;
@@ -729,7 +729,7 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
 
         out->begin_list(out, NULL, NULL, "Node List");
         for (gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
-            node_t *node = (node_t *) gIter->data;
+            pe_node_t *node = (pe_node_t *) gIter->data;
             const char *node_mode = NULL;
             char *node_name = pe__node_display_name(node, is_set(mon_ops, mon_op_print_clone_detail));
 
@@ -933,7 +933,7 @@ print_xml_status(pcmk__output_t *out, pe_working_set_t *data_set,
     if (is_set(show, mon_show_nodes)) {
         out->begin_list(out, NULL, NULL, "nodes");
         for (gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
-            node_t *node = (node_t *) gIter->data;
+            pe_node_t *node = (pe_node_t *) gIter->data;
             out->message(out, "node", node, get_resource_display_options(mon_ops), TRUE,
                          NULL, is_set(mon_ops, mon_op_print_clone_detail),
                          is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node));
@@ -1011,7 +1011,7 @@ print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
     if (is_set(show, mon_show_nodes)) {
         out->begin_list(out, NULL, NULL, "Node List");
         for (gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
-            node_t *node = (node_t *) gIter->data;
+            pe_node_t *node = (pe_node_t *) gIter->data;
             out->message(out, "node", node, get_resource_display_options(mon_ops), TRUE,
                          NULL, is_set(mon_ops, mon_op_print_clone_detail),
                          is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node));

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -522,7 +522,7 @@ print_cluster_tickets(pcmk__output_t *out, pe_working_set_t * data_set,
     /* Print each ticket */
     g_hash_table_iter_init(&iter, data_set->tickets);
     while (g_hash_table_iter_next(&iter, &key, &value)) {
-        ticket_t *ticket = (ticket_t *) value;
+        pe_ticket_t *ticket = (pe_ticket_t *) value;
         out->message(out, "ticket", ticket);
     }
 

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -189,7 +189,7 @@ print_resources(pcmk__output_t *out, pe_working_set_t *data_set,
 }
 
 static int
-failure_count(pe_working_set_t *data_set, node_t *node, resource_t *rsc, time_t *last_failure) {
+failure_count(pe_working_set_t *data_set, node_t *node, pe_resource_t *rsc, time_t *last_failure) {
     return rsc ? pe_get_failcount(node, rsc, last_failure, pe_fc_default,
                                   NULL, data_set)
                : 0;
@@ -229,7 +229,7 @@ print_rsc_history(pcmk__output_t *out, pe_working_set_t *data_set, node_t *node,
     GListPtr gIter = NULL;
     int rc = pcmk_rc_no_output;
     const char *rsc_id = crm_element_value(rsc_entry, XML_ATTR_ID);
-    resource_t *rsc = pe_find_resource(data_set->resources, rsc_id);
+    pe_resource_t *rsc = pe_find_resource(data_set->resources, rsc_id);
 
     /* Print each operation */
     for (gIter = op_list; gIter != NULL; gIter = gIter->next) {
@@ -313,7 +313,7 @@ print_node_history(pcmk__output_t *out, pe_working_set_t *data_set,
 
         if (operations == FALSE) {
             const char *rsc_id = crm_element_value(rsc_entry, XML_ATTR_ID);
-            resource_t *rsc = pe_find_resource(data_set->resources, rsc_id);
+            pe_resource_t *rsc = pe_find_resource(data_set->resources, rsc_id);
             time_t last_failure = 0;
             int failcount = failure_count(data_set, node, rsc, &last_failure);
 
@@ -373,7 +373,7 @@ add_extra_info(pcmk__output_t *out, node_t *node, GListPtr rsc_list,
     GListPtr gIter = NULL;
 
     for (gIter = rsc_list; gIter != NULL; gIter = gIter->next) {
-        resource_t *rsc = (resource_t *) gIter->data;
+        pe_resource_t *rsc = (pe_resource_t *) gIter->data;
         const char *type = g_hash_table_lookup(rsc->meta, "type");
         const char *name = NULL;
 

--- a/tools/crm_mon_runtime.c
+++ b/tools/crm_mon_runtime.c
@@ -67,7 +67,7 @@ append_attr_list(GList *attr_list, char *name)
 }
 
 void
-crm_mon_get_parameters(resource_t *rsc, pe_working_set_t * data_set)
+crm_mon_get_parameters(pe_resource_t *rsc, pe_working_set_t * data_set)
 {
     get_rsc_attributes(rsc->parameters, rsc, NULL, data_set);
     if(rsc->children) {

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -641,7 +641,7 @@ main(int argc, char **argv)
 
     char *xml_file = NULL;
     xmlNode *cib_xml_copy = NULL;
-    resource_t *rsc = NULL;
+    pe_resource_t *rsc = NULL;
     bool recursive = FALSE;
 
     bool validate_cmdline = FALSE; /* whether we are just validating based on command line options */
@@ -1174,7 +1174,7 @@ main(int argc, char **argv)
 
         rc = pcmk_ok;
         for (lpc = data_set->resources; lpc != NULL; lpc = lpc->next) {
-            rsc = (resource_t *) lpc->data;
+            rsc = (pe_resource_t *) lpc->data;
 
             found++;
             cli_resource_print_raw(rsc);
@@ -1214,7 +1214,7 @@ main(int argc, char **argv)
         rsc = uber_parent(rsc);
 
         for (lpc = data_set->resources; lpc != NULL; lpc = lpc->next) {
-            resource_t *r = (resource_t *) lpc->data;
+            pe_resource_t *r = (pe_resource_t *) lpc->data;
 
             clear_bit(r->flags, pe_rsc_allocating);
         }
@@ -1225,7 +1225,7 @@ main(int argc, char **argv)
         cli_resource_print_location(rsc, NULL);
 
         for (lpc = data_set->resources; lpc != NULL; lpc = lpc->next) {
-            resource_t *r = (resource_t *) lpc->data;
+            pe_resource_t *r = (pe_resource_t *) lpc->data;
 
             clear_bit(r->flags, pe_rsc_allocating);
         }
@@ -1237,7 +1237,7 @@ main(int argc, char **argv)
 
         rc = pcmk_ok;
         for (lpc = data_set->resources; lpc != NULL; lpc = lpc->next) {
-            rsc = (resource_t *) lpc->data;
+            rsc = (pe_resource_t *) lpc->data;
             cli_resource_print_cts(rsc);
         }
         cli_resource_print_cts_constraints(data_set);
@@ -1359,7 +1359,7 @@ main(int argc, char **argv)
 
             current = NULL;
             for(iter = rsc->children; iter; iter = iter->next) {
-                resource_t *child = (resource_t *)iter->data;
+                pe_resource_t *child = (pe_resource_t *)iter->data;
                 enum rsc_role_e child_role = child->fns->state(child, TRUE);
 
                 if(child_role == RSC_ROLE_MASTER) {

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1268,7 +1268,7 @@ main(int argc, char **argv)
         rc = cli_resource_print(rsc, data_set, FALSE);
 
     } else if (rsc_cmd == 'Y') {
-        node_t *dest = NULL;
+        pe_node_t *dest = NULL;
 
         if (host_uname) {
             dest = pe_find_node(data_set->nodes, host_uname);
@@ -1285,7 +1285,7 @@ main(int argc, char **argv)
         GListPtr after = NULL;
         GListPtr remaining = NULL;
         GListPtr ele = NULL;
-        node_t *dest = NULL;
+        pe_node_t *dest = NULL;
 
         if (BE_QUIET == FALSE) {
             before = build_constraint_list(data_set->input);
@@ -1336,7 +1336,7 @@ main(int argc, char **argv)
         rc = cli_resource_move(rsc, rsc_id, host_uname, cib_conn, data_set);
 
     } else if (rsc_cmd == 'B' && host_uname) {
-        node_t *dest = pe_find_node(data_set->nodes, host_uname);
+        pe_node_t *dest = pe_find_node(data_set->nodes, host_uname);
 
         if (dest == NULL) {
             rc = -pcmk_err_node_unknown;
@@ -1487,7 +1487,7 @@ main(int argc, char **argv)
         int attr_options = pcmk__node_attr_none;
 
         if (host_uname) {
-            node_t *node = pe_find_node(data_set->nodes, host_uname);
+            pe_node_t *node = pe_find_node(data_set->nodes, host_uname);
 
             if (pe__is_guest_or_remote_node(node)) {
                 node = pe__current_node(node->details->remote_rsc);

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -104,4 +104,4 @@ GList* subtract_lists(GList *from, GList *items, GCompareFunc cmp);
 int update_working_set_xml(pe_working_set_t *data_set, xmlNode **xml);
 int wait_till_stable(int timeout_ms, cib_t * cib);
 void cli_resource_why(cib_t *cib_conn, GListPtr resources, pe_resource_t *rsc,
-                      node_t *node);
+                      pe_node_t *node);

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -46,27 +46,27 @@ int cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, 
 int cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, const char *rsc, const char *node, bool scope_master);
 
 /* print */
-void cli_resource_print_cts(resource_t * rsc);
-void cli_resource_print_raw(resource_t * rsc);
+void cli_resource_print_cts(pe_resource_t * rsc);
+void cli_resource_print_raw(pe_resource_t * rsc);
 void cli_resource_print_cts_constraints(pe_working_set_t * data_set);
-void cli_resource_print_location(resource_t * rsc, const char *prefix);
-void cli_resource_print_colocation(resource_t * rsc, bool dependents, bool recursive, int offset);
+void cli_resource_print_location(pe_resource_t * rsc, const char *prefix);
+void cli_resource_print_colocation(pe_resource_t * rsc, bool dependents, bool recursive, int offset);
 
-int cli_resource_print(resource_t *rsc, pe_working_set_t *data_set,
+int cli_resource_print(pe_resource_t *rsc, pe_working_set_t *data_set,
                        bool expanded);
 int cli_resource_print_list(pe_working_set_t * data_set, bool raw);
-int cli_resource_print_attribute(resource_t *rsc, const char *attr,
+int cli_resource_print_attribute(pe_resource_t *rsc, const char *attr,
                                  pe_working_set_t *data_set);
-int cli_resource_print_property(resource_t *rsc, const char *attr,
+int cli_resource_print_property(pe_resource_t *rsc, const char *attr,
                                 pe_working_set_t *data_set);
 int cli_resource_print_operations(const char *rsc_id, const char *host_uname, bool active, pe_working_set_t * data_set);
 
 /* runtime */
-void cli_resource_check(cib_t * cib, resource_t *rsc);
+void cli_resource_check(cib_t * cib, pe_resource_t *rsc);
 int cli_resource_fail(pcmk_controld_api_t *controld_api,
                       const char *host_uname, const char *rsc_id,
                       pe_working_set_t *data_set);
-int cli_resource_search(resource_t *rsc, const char *requested_name,
+int cli_resource_search(pe_resource_t *rsc, const char *requested_name,
                         pe_working_set_t *data_set);
 int cli_resource_delete(pcmk_controld_api_t *controld_api,
                         const char *host_uname, pe_resource_t *rsc,
@@ -77,24 +77,24 @@ int cli_cleanup_all(pcmk_controld_api_t *controld_api, const char *node_name,
                     pe_working_set_t *data_set);
 int cli_resource_restart(pe_resource_t *rsc, const char *host, int timeout_ms,
                          cib_t *cib);
-int cli_resource_move(resource_t *rsc, const char *rsc_id,
+int cli_resource_move(pe_resource_t *rsc, const char *rsc_id,
                       const char *host_name, cib_t *cib,
                       pe_working_set_t *data_set);
 int cli_resource_execute_from_params(const char *rsc_name, const char *rsc_class,
                                      const char *rsc_prov, const char *rsc_type,
                                      const char *rsc_action, GHashTable *params,
                                      GHashTable *override_hash, int timeout_ms);
-int cli_resource_execute(resource_t *rsc, const char *requested_name,
+int cli_resource_execute(pe_resource_t *rsc, const char *requested_name,
                          const char *rsc_action, GHashTable *override_hash,
                          int timeout_ms, cib_t *cib,
                          pe_working_set_t *data_set);
 
-int cli_resource_update_attribute(resource_t *rsc, const char *requested_name,
+int cli_resource_update_attribute(pe_resource_t *rsc, const char *requested_name,
                                   const char *attr_set, const char *attr_id,
                                   const char *attr_name, const char *attr_value,
                                   bool recursive, cib_t *cib,
                                   pe_working_set_t *data_set);
-int cli_resource_delete_attribute(resource_t *rsc, const char *requested_name,
+int cli_resource_delete_attribute(pe_resource_t *rsc, const char *requested_name,
                                   const char *attr_set, const char *attr_id,
                                   const char *attr_name, cib_t *cib,
                                   pe_working_set_t *data_set);
@@ -103,5 +103,5 @@ GList* subtract_lists(GList *from, GList *items, GCompareFunc cmp);
 
 int update_working_set_xml(pe_working_set_t *data_set, xmlNode **xml);
 int wait_till_stable(int timeout_ms, cib_t * cib);
-void cli_resource_why(cib_t *cib_conn, GListPtr resources, resource_t *rsc,
+void cli_resource_why(cib_t *cib_conn, GListPtr resources, pe_resource_t *rsc,
                       node_t *node);

--- a/tools/crm_resource_ban.c
+++ b/tools/crm_resource_ban.c
@@ -69,7 +69,7 @@ cli_resource_ban(const char *rsc_id, const char *host, GListPtr allnodes, cib_t 
     if(host == NULL) {
         GListPtr n = allnodes;
         for(; n && rc == pcmk_ok; n = n->next) {
-            node_t *target = n->data;
+            pe_node_t *target = n->data;
 
             rc = cli_resource_ban(rsc_id, target->details->uname, NULL, cib_conn);
         }
@@ -296,7 +296,7 @@ cli_resource_clear(const char *rsc_id, const char *host, GListPtr allnodes, cib_
          * On the first error, abort.
          */
         for(; n; n = n->next) {
-            node_t *target = n->data;
+            pe_node_t *target = n->data;
 
             rc = cli_resource_clear(rsc_id, target->details->uname, NULL, cib_conn, clear_ban_constraints);
             if (rc != pcmk_ok) {

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -48,7 +48,7 @@ cli_resource_print_cts_constraints(pe_working_set_t * data_set)
 }
 
 void
-cli_resource_print_cts(resource_t * rsc)
+cli_resource_print_cts(pe_resource_t * rsc)
 {
     GListPtr lpc = NULL;
     const char *host = NULL;
@@ -75,7 +75,7 @@ cli_resource_print_cts(resource_t * rsc)
            rsc->flags);
 
     for (lpc = rsc->children; lpc != NULL; lpc = lpc->next) {
-        resource_t *child = (resource_t *) lpc->data;
+        pe_resource_t *child = (pe_resource_t *) lpc->data;
 
         cli_resource_print_cts(child);
     }
@@ -83,7 +83,7 @@ cli_resource_print_cts(resource_t * rsc)
 
 
 void
-cli_resource_print_raw(resource_t * rsc)
+cli_resource_print_raw(pe_resource_t * rsc)
 {
     GListPtr lpc = NULL;
     GListPtr children = rsc->children;
@@ -93,7 +93,7 @@ cli_resource_print_raw(resource_t * rsc)
     }
 
     for (lpc = children; lpc != NULL; lpc = lpc->next) {
-        resource_t *child = (resource_t *) lpc->data;
+        pe_resource_t *child = (pe_resource_t *) lpc->data;
 
         cli_resource_print_raw(child);
     }
@@ -108,7 +108,7 @@ cli_resource_print_list(pe_working_set_t * data_set, bool raw)
     int opts = pe_print_printf | pe_print_rsconly | pe_print_pending;
 
     for (lpc = data_set->resources; lpc != NULL; lpc = lpc->next) {
-        resource_t *rsc = (resource_t *) lpc->data;
+        pe_resource_t *rsc = (pe_resource_t *) lpc->data;
 
         if (is_set(rsc->flags, pe_rsc_orphan)
             && rsc->fns->active(rsc, TRUE) == FALSE) {
@@ -130,7 +130,7 @@ int
 cli_resource_print_operations(const char *rsc_id, const char *host_uname, bool active,
                          pe_working_set_t * data_set)
 {
-    resource_t *rsc = NULL;
+    pe_resource_t *rsc = NULL;
     int opts = pe_print_printf | pe_print_rsconly | pe_print_suppres_nl | pe_print_pending;
     GListPtr ops = find_operations(rsc_id, host_uname, active, data_set);
     GListPtr lpc = NULL;
@@ -169,7 +169,7 @@ cli_resource_print_operations(const char *rsc_id, const char *host_uname, bool a
 }
 
 void
-cli_resource_print_location(resource_t * rsc, const char *prefix)
+cli_resource_print_location(pe_resource_t * rsc, const char *prefix)
 {
     GListPtr lpc = NULL;
     GListPtr list = rsc->rsc_location;
@@ -196,7 +196,7 @@ cli_resource_print_location(resource_t * rsc, const char *prefix)
 }
 
 void
-cli_resource_print_colocation(resource_t * rsc, bool dependents, bool recursive, int offset)
+cli_resource_print_colocation(pe_resource_t * rsc, bool dependents, bool recursive, int offset)
 {
     char *prefix = NULL;
     GListPtr lpc = NULL;
@@ -221,7 +221,7 @@ cli_resource_print_colocation(resource_t * rsc, bool dependents, bool recursive,
         rsc_colocation_t *cons = (rsc_colocation_t *) lpc->data;
 
         char *score = NULL;
-        resource_t *peer = cons->rsc_rh;
+        pe_resource_t *peer = cons->rsc_rh;
 
         if (dependents) {
             peer = cons->rsc_lh;
@@ -259,7 +259,7 @@ cli_resource_print_colocation(resource_t * rsc, bool dependents, bool recursive,
 }
 
 int
-cli_resource_print(resource_t *rsc, pe_working_set_t *data_set, bool expanded)
+cli_resource_print(pe_resource_t *rsc, pe_working_set_t *data_set, bool expanded)
 {
     char *rsc_xml = NULL;
     int opts = pe_print_printf | pe_print_pending;
@@ -274,7 +274,7 @@ cli_resource_print(resource_t *rsc, pe_working_set_t *data_set, bool expanded)
 }
 
 int
-cli_resource_print_attribute(resource_t *rsc, const char *attr, pe_working_set_t * data_set)
+cli_resource_print_attribute(pe_resource_t *rsc, const char *attr, pe_working_set_t * data_set)
 {
     int rc = -ENXIO;
     unsigned int count = 0;
@@ -318,7 +318,7 @@ cli_resource_print_attribute(resource_t *rsc, const char *attr, pe_working_set_t
 
 
 int
-cli_resource_print_property(resource_t *rsc, const char *attr, pe_working_set_t * data_set)
+cli_resource_print_property(pe_resource_t *rsc, const char *attr, pe_working_set_t * data_set)
 {
     const char *value = crm_element_value(rsc->xml, attr);
 

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -185,7 +185,7 @@ cli_resource_print_location(pe_resource_t * rsc, const char *prefix)
         GListPtr lpc2 = NULL;
 
         for (lpc2 = cons->node_list_rh; lpc2 != NULL; lpc2 = lpc2->next) {
-            node_t *node = (node_t *) lpc2->data;
+            pe_node_t *node = (pe_node_t *) lpc2->data;
             char *score = score2char(node->weight);
 
             fprintf(stdout, "%s: Node %-*s (score=%s, id=%s)\n",
@@ -280,7 +280,7 @@ cli_resource_print_attribute(pe_resource_t *rsc, const char *attr, pe_working_se
     unsigned int count = 0;
     GHashTable *params = NULL;
     const char *value = NULL;
-    node_t *current = pe__find_active_on(rsc, &count, NULL);
+    pe_node_t *current = pe__find_active_on(rsc, &count, NULL);
 
     if (count > 1) {
         CMD_ERR("%s is active on more than one node,"

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -21,7 +21,7 @@ do_find_resource(const char *rsc, pe_resource_t * the_rsc, pe_working_set_t * da
     GListPtr lpc = NULL;
 
     for (lpc = the_rsc->running_on; lpc != NULL; lpc = lpc->next) {
-        node_t *node = (node_t *) lpc->data;
+        pe_node_t *node = (pe_node_t *) lpc->data;
 
         if (BE_QUIET) {
             fprintf(stdout, "%s\n", node->details->uname);
@@ -666,7 +666,7 @@ clear_rsc_failures(pcmk_controld_api_t *controld_api, const char *node_name,
 
 static int
 clear_rsc_fail_attrs(pe_resource_t *rsc, const char *operation,
-                     const char *interval_spec, node_t *node)
+                     const char *interval_spec, pe_node_t *node)
 {
     int rc = pcmk_ok;
     int attr_options = pcmk__node_attr_none;
@@ -689,7 +689,7 @@ cli_resource_delete(pcmk_controld_api_t *controld_api, const char *host_uname,
                     pe_working_set_t *data_set)
 {
     int rc = pcmk_ok;
-    node_t *node = NULL;
+    pe_node_t *node = NULL;
 
     if (rsc == NULL) {
         return -ENXIO;
@@ -731,7 +731,7 @@ cli_resource_delete(pcmk_controld_api_t *controld_api, const char *host_uname,
         }
 
         for (lpc = nodes; lpc != NULL; lpc = lpc->next) {
-            node = (node_t *) lpc->data;
+            node = (pe_node_t *) lpc->data;
 
             if (node->details->online) {
                 rc = cli_resource_delete(controld_api, node->details->uname,
@@ -807,7 +807,7 @@ cli_cleanup_all(pcmk_controld_api_t *controld_api, const char *node_name,
     }
 
     if (node_name) {
-        node_t *node = pe_find_node(data_set->nodes, node_name);
+        pe_node_t *node = pe_find_node(data_set->nodes, node_name);
 
         if (node == NULL) {
             CMD_ERR("Unknown node: %s", node_name);
@@ -1893,8 +1893,8 @@ cli_resource_move(pe_resource_t *rsc, const char *rsc_id, const char *host_name,
 {
     int rc = pcmk_ok;
     unsigned int count = 0;
-    node_t *current = NULL;
-    node_t *dest = pe_find_node(data_set->nodes, host_name);
+    pe_node_t *current = NULL;
+    pe_node_t *dest = pe_find_node(data_set->nodes, host_name);
     bool cur_is_dest = FALSE;
 
     if (dest == NULL) {
@@ -2030,7 +2030,7 @@ cli_resource_why_with_rsc_and_host(cib_t *cib_conn, GListPtr resources,
 }
 
 static void
-cli_resource_why_without_rsc_with_host(cib_t *cib_conn,GListPtr resources,node_t *node)
+cli_resource_why_without_rsc_with_host(cib_t *cib_conn,GListPtr resources,pe_node_t *node)
 {
     const char* host_uname =  node->details->uname;
     GListPtr allResources = node->details->allocated_rsc;
@@ -2069,7 +2069,7 @@ cli_resource_why_with_rsc_without_host(cib_t *cib_conn, GListPtr resources,
 }
 
 void cli_resource_why(cib_t *cib_conn, GListPtr resources, pe_resource_t *rsc,
-                      node_t *node)
+                      pe_node_t *node)
 {
     const char *host_uname = (node == NULL)? NULL : node->details->uname;
 

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1209,7 +1209,7 @@ max_delay_for_resource(pe_working_set_t * data_set, resource_t *rsc)
 
     } else if(rsc) {
         char *key = crm_strdup_printf("%s_%s_0", rsc->id, RSC_STOP);
-        action_t *stop = custom_action(rsc, key, RSC_STOP, NULL, TRUE, FALSE, data_set);
+        pe_action_t *stop = custom_action(rsc, key, RSC_STOP, NULL, TRUE, FALSE, data_set);
         const char *value = g_hash_table_lookup(stop->meta, XML_ATTR_TIMEOUT);
 
         max_delay = value? (int) crm_parse_ll(value, NULL) : -1;
@@ -1529,7 +1529,7 @@ done:
     return rc;
 }
 
-static inline int action_is_pending(action_t *action) 
+static inline int action_is_pending(pe_action_t *action) 
 {
     if(is_set(action->flags, pe_action_optional)) {
         return FALSE;
@@ -1557,7 +1557,7 @@ actions_are_pending(GListPtr actions)
     GListPtr action;
 
     for (action = actions; action != NULL; action = action->next) {
-        action_t *a = (action_t *)action->data;
+        pe_action_t *a = (pe_action_t *)action->data;
         if (action_is_pending(a)) {
             crm_notice("Waiting for %s (flags=0x%.8x)", a->uuid, a->flags);
             return TRUE;
@@ -1581,7 +1581,7 @@ print_pending_actions(GListPtr actions)
 
     fprintf(stderr, "Pending actions:\n");
     for (action = actions; action != NULL; action = action->next) {
-        action_t *a = (action_t *) action->data;
+        pe_action_t *a = (pe_action_t *) action->data;
 
         if (action_is_pending(a)) {
             fprintf(stderr, "\tAction %d: %s", a->id, a->uuid);

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -83,7 +83,7 @@ print_cluster_status(pe_working_set_t * data_set, long options)
     GListPtr gIter = NULL;
 
     for (gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
-        node_t *node = (node_t *) gIter->data;
+        pe_node_t *node = (pe_node_t *) gIter->data;
         const char *node_mode = NULL;
         char *node_name = NULL;
 

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -186,7 +186,7 @@ print_cluster_status(pe_working_set_t * data_set, long options)
 
     fprintf(stdout, "\n");
     for (gIter = data_set->resources; gIter != NULL; gIter = gIter->next) {
-        resource_t *rsc = (resource_t *) gIter->data;
+        pe_resource_t *rsc = (pe_resource_t *) gIter->data;
 
         if (is_set(rsc->flags, pe_rsc_orphan)
             && rsc->role == RSC_ROLE_STOPPED) {
@@ -1071,7 +1071,7 @@ main(int argc, char **argv)
 
             LogNodeActions(data_set, TRUE);
             for (gIter = data_set->resources; gIter != NULL; gIter = gIter->next) {
-                resource_t *rsc = (resource_t *) gIter->data;
+                pe_resource_t *rsc = (pe_resource_t *) gIter->data;
 
                 LogActions(rsc, data_set, TRUE);
             }

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -338,7 +338,7 @@ create_dotfile(pe_working_set_t * data_set, const char *dot_file, gboolean all_a
         GListPtr gIter2 = NULL;
 
         for (gIter2 = action->actions_before; gIter2 != NULL; gIter2 = gIter2->next) {
-            action_wrapper_t *before = (action_wrapper_t *) gIter2->data;
+            pe_action_wrapper_t *before = (pe_action_wrapper_t *) gIter2->data;
 
             char *before_name = NULL;
             char *after_name = NULL;

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -288,7 +288,7 @@ create_dotfile(pe_working_set_t * data_set, const char *dot_file, gboolean all_a
 
     fprintf(dot_strm, " digraph \"g\" {\n");
     for (gIter = data_set->actions; gIter != NULL; gIter = gIter->next) {
-        action_t *action = (action_t *) gIter->data;
+        pe_action_t *action = (pe_action_t *) gIter->data;
         const char *style = "dashed";
         const char *font = "black";
         const char *color = "black";
@@ -333,7 +333,7 @@ create_dotfile(pe_working_set_t * data_set, const char *dot_file, gboolean all_a
     }
 
     for (gIter = data_set->actions; gIter != NULL; gIter = gIter->next) {
-        action_t *action = (action_t *) gIter->data;
+        pe_action_t *action = (pe_action_t *) gIter->data;
 
         GListPtr gIter2 = NULL;
 

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -45,10 +45,10 @@ char ticket_cmd = 'S';
 char *xml_file = NULL;
 int cib_options = cib_sync_call;
 
-static ticket_t *
+static pe_ticket_t *
 find_ticket(const char *ticket_id, pe_working_set_t * data_set)
 {
-    ticket_t *ticket = NULL;
+    pe_ticket_t *ticket = NULL;
 
     ticket = g_hash_table_lookup(data_set->tickets, ticket_id);
 
@@ -71,7 +71,7 @@ print_date(time_t time)
 }
 
 static int
-print_ticket(ticket_t * ticket, gboolean raw, gboolean details)
+print_ticket(pe_ticket_t * ticket, gboolean raw, gboolean details)
 {
     if (raw) {
         fprintf(stdout, "%s\n", ticket->id);
@@ -122,7 +122,7 @@ static int
 print_ticket_list(pe_working_set_t * data_set, gboolean raw, gboolean details)
 {
     GHashTableIter iter;
-    ticket_t *ticket = NULL;
+    pe_ticket_t *ticket = NULL;
 
     g_hash_table_iter_init(&iter, data_set->tickets);
 
@@ -266,7 +266,7 @@ static int
 get_ticket_state_attr(const char *ticket_id, const char *attr_name, const char **attr_value,
                       pe_working_set_t * data_set)
 {
-    ticket_t *ticket = NULL;
+    pe_ticket_t *ticket = NULL;
 
     CRM_ASSERT(attr_value != NULL);
     *attr_value = NULL;
@@ -379,7 +379,7 @@ modify_ticket_state(const char * ticket_id, GListPtr attr_delete, GHashTable * a
     char *key = NULL;
     char *value = NULL;
 
-    ticket_t *ticket = NULL;
+    pe_ticket_t *ticket = NULL;
 
     rc = find_ticket_state(cib, ticket_id, &ticket_state_xml);
     if (rc == pcmk_ok) {
@@ -906,7 +906,7 @@ main(int argc, char **argv)
         }
 
         if (ticket_id) {
-            ticket_t *ticket = find_ticket(ticket_id, data_set);
+            pe_ticket_t *ticket = find_ticket(ticket_id, data_set);
 
             if (ticket == NULL) {
                 CMD_ERR("No such ticket '%s'", ticket_id);
@@ -963,7 +963,7 @@ main(int argc, char **argv)
         }
 
         if (do_force == FALSE) {
-            ticket_t *ticket = NULL;
+            pe_ticket_t *ticket = NULL;
 
             ticket = find_ticket(ticket_id, data_set);
             if (ticket == NULL) {


### PR DESCRIPTION
Note: It occurs to me that I might not have caught all of these.  I worked on it by moving a deprecated alias behind PCMK__NO_COMPAT, trying to build, and fixing each file that failed.  It's possible other uses are hiding behind ifdefs that were not set in my build.  I'll try to track down more uses later.