### PR TITLE
Fix: libcrmcommon: Add pcmk_str_is_infinity and pcmk_str_is_minus_inf…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2009,6 +2009,7 @@ AC_CONFIG_FILES(Makefile                                            \
                 lib/common/Makefile                                 \
                 lib/common/tests/Makefile                           \
                 lib/common/tests/strings/Makefile                   \
+                lib/common/tests/utils/Makefile                     \
                 lib/cluster/Makefile                                \
                 lib/cib/Makefile                                    \
                 lib/gnu/Makefile                                    \

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -156,7 +156,7 @@ update_failcount(xmlNode * event, const char *event_node_uuid, int rc,
     }
 
     /* Fail count will be either incremented or set to infinity */
-    if (value == NULL || safe_str_neq(value, CRM_INFINITY_S)) {
+    if (!pcmk_str_is_infinity(value)) {
         value = XML_NVPAIR_ATTR_VALUE "++";
     }
 

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -205,6 +205,9 @@ void crm_gnutls_global_init(void);
 
 char *pcmk_hostname(void);
 
+bool pcmk_str_is_infinity(const char *s);
+bool pcmk_str_is_minus_infinity(const char *s);
+
 #ifndef PCMK__NO_COMPAT
 /* Everything here is deprecated and kept only for public API backward
  * compatibility. It will be moved to compatibility.h when 2.1.0 is released.

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -382,8 +382,8 @@ pcmk__valid_number(const char *value)
     if (value == NULL) {
         return false;
 
-    } else if (safe_str_eq(value, CRM_MINUS_INFINITY_S)
-               || safe_str_eq(value, CRM_INFINITY_S)) {
+    } else if (pcmk_str_is_minus_infinity(value) ||
+               pcmk_str_is_infinity(value)) {
         return true;
     }
 
@@ -395,8 +395,8 @@ pcmk__valid_number(const char *value)
 bool
 pcmk__valid_positive_number(const char *value)
 {
-    return safe_str_eq(value, CRM_INFINITY_S)
-           || (crm_parse_ll(value, NULL) > 0);
+    return pcmk_str_is_infinity(value) ||
+           (crm_parse_ll(value, NULL) > 0);
 }
 
 bool

--- a/lib/common/tests/Makefile.am
+++ b/lib/common/tests/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = strings
+SUBDIRS = strings utils

--- a/lib/common/tests/utils/Makefile.am
+++ b/lib/common/tests/utils/Makefile.am
@@ -1,0 +1,20 @@
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
+LDADD = $(top_builddir)/lib/common/libcrmcommon.la
+
+include $(top_srcdir)/mk/glib-tap.mk
+
+# Add each test program here.  Each test should be written as a little standalone
+# program using the glib unit testing functions.  See the documentation for more
+# information.
+#
+# https://developer.gnome.org/glib/unstable/glib-Testing.html
+test_programs = pcmk_str_is_infinity \
+				pcmk_str_is_minus_infinity
+
+# If any extra data needs to be added to the source distribution, add it to the
+# following list.
+dist_test_data =
+
+# If any extra data needs to be used by tests but should not be added to the
+# source distribution, add it to the following list.
+test_data =

--- a/lib/common/tests/utils/pcmk_str_is_infinity.c
+++ b/lib/common/tests/utils/pcmk_str_is_infinity.c
@@ -1,0 +1,48 @@
+#include <glib.h>
+
+#include <crm_internal.h>
+
+static void
+uppercase_str_passes(void) {
+    g_assert(pcmk_str_is_infinity("INFINITY") == TRUE);
+    g_assert(pcmk_str_is_infinity("+INFINITY") == TRUE);
+}
+
+static void
+mixed_case_str_fails(void) {
+    g_assert(pcmk_str_is_infinity("infinity") == FALSE);
+    g_assert(pcmk_str_is_infinity("+infinity") == FALSE);
+    g_assert(pcmk_str_is_infinity("Infinity") == FALSE);
+    g_assert(pcmk_str_is_infinity("+Infinity") == FALSE);
+}
+
+static void
+added_whitespace_fails(void) {
+    g_assert(pcmk_str_is_infinity(" INFINITY") == FALSE);
+    g_assert(pcmk_str_is_infinity("INFINITY ") == FALSE);
+    g_assert(pcmk_str_is_infinity(" INFINITY ") == FALSE);
+    g_assert(pcmk_str_is_infinity("+ INFINITY") == FALSE);
+}
+
+static void
+empty_str_fails(void) {
+    g_assert(pcmk_str_is_infinity(NULL) == FALSE);
+    g_assert(pcmk_str_is_infinity("") == FALSE);
+}
+
+static void
+minus_infinity_fails(void) {
+    g_assert(pcmk_str_is_infinity("-INFINITY") == FALSE);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/common/utils/infinity/uppercase", uppercase_str_passes);
+    g_test_add_func("/common/utils/infinity/mixed_case", mixed_case_str_fails);
+    g_test_add_func("/common/utils/infinity/whitespace", added_whitespace_fails);
+    g_test_add_func("/common/utils/infinity/empty", empty_str_fails);
+    g_test_add_func("/common/utils/infinity/minus_infinity", minus_infinity_fails);
+
+    return g_test_run();
+}

--- a/lib/common/tests/utils/pcmk_str_is_minus_infinity.c
+++ b/lib/common/tests/utils/pcmk_str_is_minus_infinity.c
@@ -1,0 +1,45 @@
+#include <glib.h>
+
+#include <crm_internal.h>
+
+static void
+uppercase_str_passes(void) {
+    g_assert(pcmk_str_is_minus_infinity("-INFINITY") == TRUE);
+}
+
+static void
+mixed_case_str_fails(void) {
+    g_assert(pcmk_str_is_minus_infinity("-infinity") == FALSE);
+    g_assert(pcmk_str_is_minus_infinity("-Infinity") == FALSE);
+}
+
+static void
+added_whitespace_fails(void) {
+    g_assert(pcmk_str_is_minus_infinity(" -INFINITY") == FALSE);
+    g_assert(pcmk_str_is_minus_infinity("-INFINITY ") == FALSE);
+    g_assert(pcmk_str_is_minus_infinity(" -INFINITY ") == FALSE);
+    g_assert(pcmk_str_is_minus_infinity("- INFINITY") == FALSE);
+}
+
+static void
+empty_str_fails(void) {
+    g_assert(pcmk_str_is_minus_infinity(NULL) == FALSE);
+    g_assert(pcmk_str_is_minus_infinity("") == FALSE);
+}
+
+static void
+infinity_fails(void) {
+    g_assert(pcmk_str_is_minus_infinity("INFINITY") == FALSE);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/common/utils/minus_infinity/uppercase", uppercase_str_passes);
+    g_test_add_func("/common/utils/minus_infinity/mixed_case", mixed_case_str_fails);
+    g_test_add_func("/common/utils/minus_infinity/whitespace", added_whitespace_fails);
+    g_test_add_func("/common/utils/minus_infinity/empty", empty_str_fails);
+    g_test_add_func("/common/utils/minus_infinity/infinity", infinity_fails);
+
+    return g_test_run();
+}

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -67,13 +67,10 @@ char2score(const char *score)
 
     if (score == NULL) {
 
-    } else if (safe_str_eq(score, CRM_MINUS_INFINITY_S)) {
+    } else if (pcmk_str_is_minus_infinity(score)) {
         score_f = -CRM_SCORE_INFINITY;
 
-    } else if (safe_str_eq(score, CRM_INFINITY_S)) {
-        score_f = CRM_SCORE_INFINITY;
-
-    } else if (safe_str_eq(score, CRM_PLUS_INFINITY_S)) {
+    } else if (pcmk_str_is_infinity(score)) {
         score_f = CRM_SCORE_INFINITY;
 
     } else if (safe_str_eq(score, "red")) {
@@ -651,4 +648,14 @@ pcmk_hostname()
     struct utsname hostinfo;
 
     return (uname(&hostinfo) < 0)? NULL : strdup(hostinfo.nodename);
+}
+
+bool
+pcmk_str_is_infinity(const char *s) {
+    return crm_str_eq(s, CRM_INFINITY_S, TRUE) || crm_str_eq(s, CRM_PLUS_INFINITY_S, TRUE);
+}
+
+bool
+pcmk_str_is_minus_infinity(const char *s) {
+    return crm_str_eq(s, CRM_MINUS_INFINITY_S, TRUE);
 }


### PR DESCRIPTION
…inity.

There's multiple ways of specifying a positive infinity in a string,
like "INFINITY" and "+INFINITY".  The first new function provides a way
of comparing against both to check for infinity.  The second new
function is just for consistency, since there is only one way to specify
a negative infinity.