### PR TITLE
* DON'T MERGE. This commit is the modified #1699.

### DIFF
--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -54,6 +54,25 @@ void attrd_current_only_attribute_update(crm_node_t *peer, xmlNode *xml);
 void attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter);
 void attrd_peer_sync(crm_node_t *peer, xmlNode *xml);
 void attrd_peer_remove(const char *host, gboolean uncache, const char *source);
+void attrd_attr_remove(crm_node_t *peer, xmlNode *xml);
+void attrd_peer_clear(const char *host, const char *source, bool filter);
+
+/*!
+ * \internal
+ * \brief Trigger a (potentially delayed) write-out of an attribute
+ *
+ * \param[in] a  Attribute to write out
+ */
+static void
+trigger_write(attribute_t *a)
+{
+    if (a->timeout_ms && a->timer && a->force_write == FALSE) {
+        crm_trace("Delayed write out (%dms) for %s", a->timeout_ms, a->id);
+        mainloop_timer_start(a->timer);
+    } else {
+        write_or_elect_attribute(a);
+    }
+}
 
 static gboolean
 send_attrd_message(crm_node_t * node, xmlNode * data)
@@ -601,6 +620,13 @@ attrd_peer_message(crm_node_t *peer, xmlNode *xml)
     } else if (safe_str_eq(op, PCMK__ATTRD_CMD_PEER_REMOVE)) {
         attrd_peer_remove(host, TRUE, peer->uname);
 
+    } else if (safe_str_eq(op, PCMK__ATTRD_CMD_ATTR_REMOVE)
+               && safe_str_neq(peer->uname, attrd_cluster->uname)) {
+        attrd_attr_remove(peer, xml);
+
+    } else if (safe_str_eq(op, PCMK__ATTRD_CMD_PEER_CLEAR)) {
+        attrd_peer_clear(host, peer->uname, FALSE);
+
     } else if (safe_str_eq(op, PCMK__ATTRD_CMD_CLEAR_FAILURE)) {
         /* It is not currently possible to receive this as a peer command,
          * but will be, if we one day enable propagating this operation.
@@ -689,6 +715,105 @@ attrd_peer_remove(const char *host, gboolean uncache, const char *source)
 
 /*!
  * \internal
+ * \brief Remove all attributes from both memory and CIB for a node
+ *
+ * \param[in] peer  Peer that sent clear request
+ * \param[in] xml   Request XML
+ */
+void
+attrd_attr_remove(crm_node_t *peer, xmlNode *xml)
+{
+    xmlNode *child = NULL;
+
+    //Todo : Now we only receive deletion of a single attribute, but it also supports multiple attributes.
+    for (child = __xml_first_child(xml); child != NULL; child = __xml_next(child)) {
+        GHashTableIter iter;
+        attribute_t *a = NULL;
+        attribute_value_t *v = NULL;
+        const char *host = NULL, *attr = NULL;
+
+        host = crm_element_value(child, PCMK__XA_ATTR_NODE_NAME);
+        attr = crm_element_value(child, PCMK__XA_ATTR_NAME);
+
+        if (host == NULL || attr == NULL) {
+            continue;
+        }
+
+        a = g_hash_table_lookup(attributes, attr);
+        if(a == NULL) {
+            crm_info("Attribute %s no exists", attr);
+            continue;
+        }
+
+        crm_notice("Removing %s attributes id = %s for peer %s", host, attr, peer->uname);
+
+        g_hash_table_iter_init(&iter, a->values);
+        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & v)) {
+            if (safe_str_eq(v->nodename, host)) {
+                if(g_hash_table_remove(a->values, v->nodename)) {
+                    crm_debug("Removing clear attribute %s[%s] for peer %s : completed", a->id, host, peer->uname);
+                }
+                break;
+            }
+        }
+    }
+}
+
+/*!
+ * \internal
+ * \brief Remove all attributes from both memory and CIB for a node
+ *
+ * \param[in] host     Name of node to purge
+ * \param[in] source   Who requested removal (for logging)
+ */
+void
+attrd_peer_clear(const char *host, const char *source, bool filter)
+{
+    attribute_t *a = NULL;
+    GHashTableIter attr_iter;
+
+    CRM_CHECK(host && source, return);
+    crm_notice("Clearing all %s attributes for %s", host, source);
+
+    g_hash_table_iter_init(&attr_iter, attributes);
+    while (g_hash_table_iter_next(&attr_iter, NULL, (gpointer *) &a)) {
+        attribute_value_t *v = g_hash_table_lookup(a->values, host);
+        gboolean need_clear = FALSE;
+
+        if (v) {
+            /* Even if the attribute is set to NULL on stop, we do not evaluate v->current to delete it. */
+            if (filter) {
+                crm_debug("Marking attributes of lost node : %s[%s]", a->id, host);
+                v->node_left = TRUE;
+                if (v->need_clear) {
+                    need_clear = TRUE;
+                }
+            } else {
+                crm_debug("Marking the requested node for attribute clearing : %s[%s] = %s", a->id, host, v->current);
+                v->need_clear = TRUE;
+                if (v->is_remote || v->node_left) {
+                    /* In the case of a remote node, we immediately perform attribute clearing. */
+                    /* Because there is no attrd process on the remote node. */
+                    /* Even if attrd detects detachment first, it also deletes the attribute. */
+                    need_clear = TRUE;
+                }
+            }
+
+            if (need_clear) {
+                crm_info("Clearing %s[%s]=%s for %s",
+                      a->id, host, v->current, source);
+                free(v->current);
+                v->current = NULL;
+                a->changed = TRUE;
+                a->force_write = TRUE;
+                trigger_write(a);
+            }
+        }
+    }
+}
+
+/*!
+ * \internal
  * \brief Return host's hash table entry (creating one if needed)
  *
  * \param[in] values Hash table of values
@@ -726,6 +851,8 @@ attrd_lookup_or_create_value(GHashTable *values, const char *host, xmlNode *xml)
         CRM_ASSERT(v->nodename != NULL);
 
         v->is_remote = is_remote;
+	v->need_clear = FALSE;
+        v->node_left  = FALSE;
         g_hash_table_replace(values, v->nodename, v);
     }
     return(v);
@@ -767,6 +894,26 @@ attrd_current_only_attribute_update(crm_node_t *peer, xmlNode *xml)
     free_xml(sync);
 }
 
+static void
+reset_remove_attr_flag(const char *host)
+{
+    attribute_t *a = NULL;
+    GHashTableIter attr_iter;
+    g_hash_table_iter_init(&attr_iter, attributes);
+
+    while (g_hash_table_iter_next(&attr_iter, NULL, (gpointer *) &a)) {
+        attribute_value_t *v = g_hash_table_lookup(a->values, host);
+        if (v) {
+            if (safe_str_neq(v->nodename, host)) {
+                crm_debug("Reset clear attribute %s[%s]=%s for %s",
+                                      a->id, host, v->current, host);
+                v->need_clear = FALSE;
+                v->node_left = FALSE;
+            }
+        }
+    }
+}
+
 void
 attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
 {
@@ -785,6 +932,12 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
         return;
     }
 
+    /* When only attrd is restarted, if the attribute remains, clear the flag. */
+    /* Todo : However, in the current situation, if attrd restarts, the attribute will be deleted. */
+    if (safe_str_eq(attr, CRM_ATTR_PROTOCOL) &&  safe_str_neq(host, attrd_cluster->uname) && (host != NULL)) {
+        reset_remove_attr_flag(host);
+    }
+    
     // NULL because PCMK__ATTRD_CMD_SYNC_RESPONSE has no PCMK__XA_TASK
     update_both = ((op == NULL)
                    || safe_str_eq(op, PCMK__ATTRD_CMD_UPDATE_BOTH));
@@ -886,12 +1039,7 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
         a->changed = TRUE;
 
         // Write out new value or start dampening timer
-        if (a->timeout_ms && a->timer) {
-            crm_trace("Delayed write out (%dms) for %s", a->timeout_ms, attr);
-            mainloop_timer_start(a->timer);
-        } else {
-            write_or_elect_attribute(a);
-        }
+	trigger_write(a);
 
     } else {
         if (is_force_write && a->timeout_ms && a->timer) {
@@ -971,8 +1119,16 @@ attrd_peer_change_cb(enum crm_status_type kind, crm_node_t *peer, const void *da
                     attrd_peer_sync(peer, NULL);
                 }
             } else {
+	        /* TODO The controller should ask us to clear attributes from
+                 * lost nodes, so we shouldn't do that here. But we need to
+                 * consider corner cases such as the controller not being up.
+                 */
                 // Remove all attribute values associated with lost nodes
                 attrd_peer_remove(peer->uname, FALSE, "loss");
+		/* If the attrd of the node receiving the ATTRD_OP_PEER_CLEAR message leaves,
+                 * delete the attribute.
+                 */
+                attrd_peer_clear(peer->uname, attrd_cluster->uname, TRUE);
                 remove_voter = TRUE;
             }
             break;
@@ -994,6 +1150,7 @@ attrd_cib_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
 
     char *name = user_data;
     attribute_t *a = g_hash_table_lookup(attributes, name);
+    gboolean retry_clear = FALSE;
 
     if(a == NULL) {
         crm_info("Attribute %s no longer exists", name);
@@ -1070,6 +1227,42 @@ attrd_cib_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
                                           attribute_timer_cb, a);
             mainloop_timer_start(a->timer);
         }
+    }
+
+    if (a->changed == FALSE && rc == pcmk_ok) {
+
+        do {
+            /* Deletes the attribute that was updated successfully from the memory table. */
+            /* It also sends a delete message to attrd of another node. */
+            /* TODO : In the ATTRD_OP_ATTR_REMOVE message, only notification of a single attribute is performed, but multiple should be done simultaneously.*/
+            retry_clear = FALSE;
+            g_hash_table_iter_init(&iter, a->values);
+            while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & v)) {
+                if (v->need_clear && v->node_left && safe_str_neq(v->nodename, attrd_cluster->uname)) {
+
+                    char *host = strdup(v->nodename);
+                    xmlNode *attr_remove = create_xml_node(NULL, __FUNCTION__);
+                    crm_xml_add(attr_remove, PCMK__XA_TASK, PCMK__ATTRD_CMD_ATTR_REMOVE);
+
+                    /* Notify attrd of cluster member to delete attribute. */
+                    build_attribute_xml(attr_remove, a->id, a->set, a->uuid, a->timeout_ms, a->user, a->is_private,
+                                        v->nodename, v->nodeid, v->current, FALSE);
+
+                    send_attrd_message(NULL, attr_remove);
+                    free_xml(attr_remove);
+
+                    /* Delete attribute of own node(Writer). */
+                    if(g_hash_table_remove(a->values, v->nodename)) {
+                        crm_debug("Removing clear attribute %s[%s] for peer %s : completed.(Writer)", a->id, host, attrd_cluster->uname);
+                        free(host);
+                        /* Deleted the attribute from the table, so I will search from the beginning. */
+                        retry_clear = TRUE;
+                        break;
+                    }
+                    free(host);
+                }
+            }
+        } while(retry_clear);
     }
 }
 

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -272,6 +272,10 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
         attrd_send_ack(client, id, flags);
         attrd_client_peer_remove(client->name, xml);
 
+    } else if (safe_str_eq(op, PCMK__ATTRD_CMD_PEER_CLEAR)) {
+        attrd_send_ack(client, id, flags);
+        attrd_client_peer_remove(client->name, xml);
+	
     } else if (safe_str_eq(op, PCMK__ATTRD_CMD_CLEAR_FAILURE)) {
         attrd_send_ack(client, id, flags);
         attrd_client_clear_failure(xml);

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -106,6 +106,10 @@ typedef struct attribute_value_s {
         char *current;
         char *requested;
         gboolean seen;
+  	//YAMAUCHI
+	/* After both flags are set, the attribute is cleared. */
+	gboolean need_clear; /* Mark the attrd node received in the ATTRD_OP_PEER_CLEAR message. */
+	gboolean node_left;  /* Mark the attrd node leaving the cluster. */
 } attribute_value_t;
 
 extern crm_cluster_t *attrd_cluster;

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -262,6 +262,7 @@ controld_delete_node_state(const char *uname, enum controld_section_e section,
         // CIB library handles freeing desc
     }
     free(xpath);
+    update_attrd_helper(uname, NULL, NULL, NULL, NULL, FALSE, 'c');
 }
 
 // Takes node name and resource ID

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -78,6 +78,10 @@ void update_attrd_clear_failures(const char *host, const char *rsc,
                                  const char *op, const char *interval_spec,
                                  gboolean is_remote_node);
 
+void update_attrd_helper(const char *host, const char *name, const char *value,
+                    const char *interval_spec, const char *user_name,
+                    gboolean is_remote_node, char command);
+
 int crmd_join_phase_count(enum crm_join_phase phase);
 void crmd_join_phase_log(int level);
 

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -121,7 +121,9 @@ pid_t pcmk_locate_sbd(void);
  * IPC commands that can be sent to Pacemaker daemons
  */
 
+#define PCMK__ATTRD_CMD_ATTR_REMOVE     "attr-remove"
 #define PCMK__ATTRD_CMD_PEER_REMOVE     "peer-remove"
+#define PCMK__ATTRD_CMD_PEER_CLEAR      "peer-clear"
 #define PCMK__ATTRD_CMD_UPDATE          "update"
 #define PCMK__ATTRD_CMD_UPDATE_BOTH     "update-both"
 #define PCMK__ATTRD_CMD_UPDATE_DELAY    "update-delay"

--- a/lib/common/attrd_client.c
+++ b/lib/common/attrd_client.c
@@ -183,6 +183,10 @@ pcmk__node_attr_request(crm_ipc_t *ipc, char command, const char *host,
             task = PCMK__ATTRD_CMD_QUERY;
             name_as = PCMK__XA_ATTR_NAME;
             break;
+	case 'c':
+            task = PCMK__ATTRD_CMD_PEER_CLEAR;
+            display_command = "clear";
+            break;
         case 'C':
             task = PCMK__ATTRD_CMD_PEER_REMOVE;
             display_command = "purge";


### PR DESCRIPTION
- Please, don't merge, it is under development. This PR takes over the #1699 .  It clears transient attributes when a pacemaker daemon unexpectedly exits. Without this patch, the Reattach test might fail when the transient attributes, after component failure, are not written back in the CIB.