### PR TITLE
Convert crm_simulate to use glib for command line handling

### DIFF
--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -107,6 +107,7 @@ enum pcmk_rc_e {
     /* When adding new values, use consecutively lower numbers, update the array
      * in lib/common/results.c, and test with crm_error.
      */
+    pcmk_rc_no_input            = -1027,
     pcmk_rc_no_output           = -1026,
     pcmk_rc_after_range         = -1025,
     pcmk_rc_within_range        = -1024,

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -239,6 +239,10 @@ static struct pcmk__rc_info {
     { "pcmk_rc_no_output",
       "Output message produced no output",
       -pcmk_err_generic,
+    },
+    { "pcmk_rc_no_input",
+      "Input file not available",
+      -pcmk_err_generic,
     }
 };
 
@@ -699,6 +703,9 @@ pcmk_rc2exitc(int rc)
 
         case pcmk_rc_within_range:
             return CRM_EX_OK;
+
+        case pcmk_rc_no_input:
+            return CRM_EX_NOINPUT;
 
         default:
             return CRM_EX_ERROR;

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -28,6 +28,7 @@ EXTRA_DIST		= crm_diff.8.inc \
 			  crm_mon.8.inc			\
 			  crm_node.8.inc \
 			  crm_rule.8.inc \
+			  crm_simulate.8.inc \
 			  fix-manpages \
 			  stonith_admin.8.inc
 

--- a/tools/crm_simulate.8.inc
+++ b/tools/crm_simulate.8.inc
@@ -1,0 +1,8 @@
+[synopsis]
+crm_simulate <data source> <operation> [options]
+
+/response to events/
+.SH OPTIONS
+
+/only essential output/
+.SH OPERATION SPECIFICATION

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -1139,10 +1139,6 @@ main(int argc, char **argv)
     }
 
   done:
-    pe_free_working_set(data_set);
-    global_cib->cmds->signoff(global_cib);
-    cib_delete(global_cib);
-
     /* There sure is a lot to free in options. */
     free(options.dot_file);
     free(options.graph_file);
@@ -1162,6 +1158,15 @@ main(int argc, char **argv)
     free(options.use_date);
     free(options.watchdog);
     free(options.xml_file);
+
+    if (data_set) {
+        pe_free_working_set(data_set);
+    }
+
+    if (global_cib) {
+        global_cib->cmds->signoff(global_cib);
+        cib_delete(global_cib);
+    }
 
     fflush(stderr);
 

--- a/tools/fix-manpages
+++ b/tools/fix-manpages
@@ -26,7 +26,7 @@
 # This leaves the --help-all output looking good and removes redundant
 # stuff from the man page.  Feel free to add additional headers here.
 # Not all tools will have all headers.
-/.SH NOTES\|.SH OUTPUT CONTROL\|.SH TIME SPECIFICATION/{ n
+/.SH NOTES\|.SH OPERATION SPECIFICATION\|.SH OUTPUT CONTROL\|.SH TIME SPECIFICATION/{ n
 N
 N
 d


### PR DESCRIPTION
Note that there's still one pretty big problem I can't figure out.  The last patch ("Feature: Use glib for cmdline processing in crm_simulate.") causes `cts/cts-cli` to fail.  Backing the patch out makes everything pass.  Diffing expected output against generated output produces things like this:

```--- /tmp/cts-cli.tools.e7PzKuTeCc       2020-03-27 14:40:06.532345387 -0400
+++ cts/cli/regression.tools.exp        2020-03-05 17:17:24.703884790 -0500
@@ -329,14 +329,14 @@
 
 
 Performing requested modifications
- + Bringing node UTF-16BE online
+ + Bringing node node1 online
 
 Transition Summary:
 
 Executing cluster transition:
 
 Revised cluster status:
-Online: [ UTF-16BE ]
+Online: [ node1 ]
```

I can't find any reason why that would be the case, so hopefully someone else can spot it.  Note that even with this patch applied, `cts/cts-scheduler` passes.