### PR TITLE
Fix: libpe_status: Add node list arg to output messages.

### DIFF
--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1532,17 +1532,17 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
         CRM_ASSERT(rc == pcmk_rc_ok);
 
         if (replica->ip != NULL) {
-            out->message(out, crm_map_element_name(replica->ip->xml), options, replica->ip);
+            out->message(out, crm_map_element_name(replica->ip->xml), options, replica->ip, only_show);
         }
 
         if (replica->child != NULL) {
-            out->message(out, crm_map_element_name(replica->child->xml), options, replica->child);
+            out->message(out, crm_map_element_name(replica->child->xml), options, replica->child, only_show);
         }
 
-        out->message(out, crm_map_element_name(replica->container->xml), options, replica->container);
+        out->message(out, crm_map_element_name(replica->container->xml), options, replica->container, only_show);
 
         if (replica->remote != NULL) {
-            out->message(out, crm_map_element_name(replica->remote->xml), options, replica->remote);
+            out->message(out, crm_map_element_name(replica->remote->xml), options, replica->remote, only_show);
         }
 
         pcmk__output_xml_pop_parent(out); // replica
@@ -1624,17 +1624,17 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
             out->begin_list(out, NULL, NULL, NULL);
 
             if (replica->ip != NULL) {
-                out->message(out, crm_map_element_name(replica->ip->xml), options, replica->ip);
+                out->message(out, crm_map_element_name(replica->ip->xml), options, replica->ip, only_show);
             }
 
             if (replica->child != NULL) {
-                out->message(out, crm_map_element_name(replica->child->xml), options, replica->child);
+                out->message(out, crm_map_element_name(replica->child->xml), options, replica->child, only_show);
             }
 
-            out->message(out, crm_map_element_name(replica->container->xml), options, replica->container);
+            out->message(out, crm_map_element_name(replica->container->xml), options, replica->container, only_show);
 
             if (replica->remote != NULL) {
-                out->message(out, crm_map_element_name(replica->remote->xml), options, replica->remote);
+                out->message(out, crm_map_element_name(replica->remote->xml), options, replica->remote, only_show);
             }
 
             out->end_list(out);
@@ -1718,17 +1718,17 @@ pe__bundle_text(pcmk__output_t *out, va_list args)
             out->begin_list(out, NULL, NULL, NULL);
 
             if (replica->ip != NULL) {
-                out->message(out, crm_map_element_name(replica->ip->xml), options, replica->ip);
+                out->message(out, crm_map_element_name(replica->ip->xml), options, replica->ip, only_show);
             }
 
             if (replica->child != NULL) {
-                out->message(out, crm_map_element_name(replica->child->xml), options, replica->child);
+                out->message(out, crm_map_element_name(replica->child->xml), options, replica->child, only_show);
             }
 
-            out->message(out, crm_map_element_name(replica->container->xml), options, replica->container);
+            out->message(out, crm_map_element_name(replica->container->xml), options, replica->container, only_show);
 
             if (replica->remote != NULL) {
-                out->message(out, crm_map_element_name(replica->remote->xml), options, replica->remote);
+                out->message(out, crm_map_element_name(replica->remote->xml), options, replica->remote, only_show);
             }
 
             out->end_list(out);

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -596,7 +596,7 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
             continue;
         }
 
-        out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc);
+        out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc, only_show);
     }
 
     pcmk__output_xml_pop_parent(out);
@@ -700,7 +700,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
         }
 
         if (print_full) {
-            out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc);
+            out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc, only_show);
         }
     }
 
@@ -893,7 +893,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
         }
 
         if (print_full) {
-            out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc);
+            out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc, only_show);
         }
     }
 

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -196,7 +196,7 @@ pe__group_xml(pcmk__output_t *out, va_list args)
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
-        out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc);
+        out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc, only_show);
     }
 
     pcmk__output_xml_pop_parent(out);
@@ -218,7 +218,7 @@ pe__group_html(pcmk__output_t *out, va_list args)
     } else {
         for (GListPtr gIter = rsc->children; gIter; gIter = gIter->next) {
             pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
-            out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc);
+            out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc, only_show);
         }
     }
 
@@ -243,7 +243,7 @@ pe__group_text(pcmk__output_t *out, va_list args)
         for (GListPtr gIter = rsc->children; gIter; gIter = gIter->next) {
             pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
-            out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc);
+            out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc, only_show);
         }
     }
     out->end_list(out);

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -979,6 +979,7 @@ pe__node_html(pcmk__output_t *out, va_list args) {
     gboolean print_clone_detail = va_arg(args, gboolean);
     gboolean print_brief = va_arg(args, gboolean);
     gboolean group_by_node = va_arg(args, gboolean);
+    GListPtr only_show = va_arg(args, GListPtr);
 
     char *node_name = pe__node_display_name(node, print_clone_detail);
     char *buf = crm_strdup_printf("Node: %s", node_name);
@@ -1017,7 +1018,7 @@ pe__node_html(pcmk__output_t *out, va_list args) {
             out->begin_list(out, NULL, NULL, NULL);
             for (lpc2 = node->details->running_rsc; lpc2 != NULL; lpc2 = lpc2->next) {
                 pe_resource_t *rsc = (pe_resource_t *) lpc2->data;
-                out->message(out, crm_map_element_name(rsc->xml), print_opts | pe_print_rsconly, rsc);
+                out->message(out, crm_map_element_name(rsc->xml), print_opts | pe_print_rsconly, rsc, only_show);
             }
             out->end_list(out);
         }
@@ -1039,6 +1040,7 @@ pe__node_text(pcmk__output_t *out, va_list args) {
     gboolean print_clone_detail = va_arg(args, gboolean);
     gboolean print_brief = va_arg(args, gboolean);
     gboolean group_by_node = va_arg(args, gboolean);
+    GListPtr only_show = va_arg(args, GListPtr);
 
     if (full) {
         char *node_name = pe__node_display_name(node, print_clone_detail);
@@ -1066,7 +1068,7 @@ pe__node_text(pcmk__output_t *out, va_list args) {
 
                 for (gIter2 = node->details->running_rsc; gIter2 != NULL; gIter2 = gIter2->next) {
                     pe_resource_t *rsc = (pe_resource_t *) gIter2->data;
-                    out->message(out, crm_map_element_name(rsc->xml), print_opts | pe_print_rsconly, rsc);
+                    out->message(out, crm_map_element_name(rsc->xml), print_opts | pe_print_rsconly, rsc, only_show);
                 }
             }
 
@@ -1094,6 +1096,7 @@ pe__node_xml(pcmk__output_t *out, va_list args) {
     gboolean print_clone_detail G_GNUC_UNUSED = va_arg(args, gboolean);
     gboolean print_brief G_GNUC_UNUSED = va_arg(args, gboolean);
     gboolean group_by_node = va_arg(args, gboolean);
+    GListPtr only_show = va_arg(args, GListPtr);
 
     if (full) {
         const char *node_type = "unknown";
@@ -1136,7 +1139,7 @@ pe__node_xml(pcmk__output_t *out, va_list args) {
 
             for (lpc = node->details->running_rsc; lpc != NULL; lpc = lpc->next) {
                 pe_resource_t *rsc = (pe_resource_t *) lpc->data;
-                out->message(out, crm_map_element_name(rsc->xml), print_opts | pe_print_rsconly, rsc);
+                out->message(out, crm_map_element_name(rsc->xml), print_opts | pe_print_rsconly, rsc, only_show);
             }
         }
 
@@ -1527,6 +1530,9 @@ pe__output_node(pe_node_t *node, gboolean details, pcmk__output_t *out)
     if (details) {
         char *pe_mutable = strdup("\t\t");
         GListPtr gIter = node->details->running_rsc;
+        GListPtr unames = NULL;
+
+        unames = g_list_prepend(unames, strdup("*"));
 
         crm_trace("\t\t===Node Attributes");
         g_hash_table_foreach(node->details->attrs, print_str_str, pe_mutable);
@@ -1538,7 +1544,9 @@ pe__output_node(pe_node_t *node, gboolean details, pcmk__output_t *out)
             pe_resource_t *rsc = (pe_resource_t *) gIter->data;
 
             out->message(out, crm_map_element_name(rsc->xml),
-                         pe_print_pending, rsc);
+                         pe_print_pending, rsc, unames);
         }
+
+        g_list_free_full(unames, free);
     }
 }

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -37,7 +37,7 @@ static int print_rsc_history(pcmk__output_t *out, pe_working_set_t *data_set,
                              GListPtr op_list);
 static int print_node_history(pcmk__output_t *out, pe_working_set_t *data_set,
                               pe_node_t *node, xmlNode *node_state, gboolean operations,
-                              unsigned int mon_ops);
+                              unsigned int mon_ops, GListPtr only_show);
 static gboolean add_extra_info(pcmk__output_t *out, pe_node_t * node, GListPtr rsc_list,
                                const char *attrname, int *expected_score);
 static void print_node_attribute(gpointer name, gpointer user_data);
@@ -328,7 +328,7 @@ print_rsc_history(pcmk__output_t *out, pe_working_set_t *data_set, pe_node_t *no
 static int
 print_node_history(pcmk__output_t *out, pe_working_set_t *data_set,
                    pe_node_t *node, xmlNode *node_state, gboolean operations,
-                   unsigned int mon_ops)
+                   unsigned int mon_ops, GListPtr only_show)
 {
     xmlNode *lrm_rsc = NULL;
     xmlNode *rsc_entry = NULL;
@@ -356,7 +356,8 @@ print_node_history(pcmk__output_t *out, pe_working_set_t *data_set,
                     rc = pcmk_rc_ok;
                     out->message(out, "node", node, get_resource_display_options(mon_ops),
                                  FALSE, NULL, is_set(mon_ops, mon_op_print_clone_detail),
-                                 is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node));
+                                 is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node),
+                                 only_show);
                 }
 
                 out->message(out, "resource-history", rsc, rsc_id, FALSE,
@@ -369,7 +370,8 @@ print_node_history(pcmk__output_t *out, pe_working_set_t *data_set,
                 rc = pcmk_rc_ok;
                 out->message(out, "node", node, get_resource_display_options(mon_ops),
                              FALSE, NULL, is_set(mon_ops, mon_op_print_clone_detail),
-                             is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node));
+                             is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node),
+                             only_show);
             }
 
             if (op_list != NULL) {
@@ -529,7 +531,8 @@ print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
             rc = pcmk_rc_ok;
         }
 
-        print_node_history(out, data_set, node, node_state, operations, mon_ops);
+        print_node_history(out, data_set, node, node_state, operations, mon_ops,
+                           only_show);
     }
 
     if (rc == pcmk_rc_ok) {
@@ -684,7 +687,8 @@ print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set,
 
             out->message(out, "node", data.node, get_resource_display_options(mon_ops),
                          FALSE, NULL, is_set(mon_ops, mon_op_print_clone_detail),
-                         is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node));
+                         is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node),
+                         only_show);
             g_list_foreach(attr_list, print_node_attribute, &data);
             g_list_free(attr_list);
             out->end_list(out);
@@ -878,7 +882,8 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
             /* If we get here, node is in bad state, or we're grouping by node */
             out->message(out, "node", node, get_resource_display_options(mon_ops), TRUE,
                          node_mode, is_set(mon_ops, mon_op_print_clone_detail),
-                         is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node));
+                         is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node),
+                         unames);
             free(node_name);
         }
 
@@ -1060,7 +1065,8 @@ print_xml_status(pcmk__output_t *out, pe_working_set_t *data_set,
 
             out->message(out, "node", node, get_resource_display_options(mon_ops), TRUE,
                          NULL, is_set(mon_ops, mon_op_print_clone_detail),
-                         is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node));
+                         is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node),
+                         only_show);
         }
         out->end_list(out);
     }
@@ -1156,7 +1162,8 @@ print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
 
             out->message(out, "node", node, get_resource_display_options(mon_ops), TRUE,
                          NULL, is_set(mon_ops, mon_op_print_clone_detail),
-                         is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node));
+                         is_set(mon_ops, mon_op_print_brief), is_set(mon_ops, mon_op_group_by_node),
+                         only_show);
         }
 
         if (printed_header == TRUE) {


### PR DESCRIPTION
The calls to these messages were all missing the argument showing which
nodes should be output, which would have resulted in some weird bugs
(and potentially segfaults).  Doing this also requires adding the same
argument to the node message so it can be passed through.

Finally, pe__output_node passes the complete node list instead of
obeying the --node= option.  This function is marked in the header file
as a debugging function so it seems reasonable to not do any filtering.