### PR TITLE
Fixes: libstonithd: handling parameters of RHCS-style fence-agents

### DIFF
--- a/cts/fence_dummy.in
+++ b/cts/fence_dummy.in
@@ -129,6 +129,14 @@ ALL_OPT = {
         "default" : "0",
         "order" : 3
         },
+    "plug" : {
+        "getopt" : "n:",
+        "longopt" : "plug",
+        "help" : "-n, --plug=[id]                Physical plug number on device (ignored)",
+        "required" : "1",
+        "shortdesc" : "Ignored",
+        "order" : 4
+        },
     "port" : {
         "getopt" : "n:",
         "longopt" : "plug",

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -553,6 +553,17 @@ make_args(const char *agent, const char *action, const char *victim, uint32_t vi
             param = "port";
             value = g_hash_table_lookup(device_args, param);
 
+            if (value == NULL || safe_str_eq(value, "dynamic")) {
+                crm_debug("Performing '%s' action targeting '%s' as '%s=%s'", action, victim, param,
+                          alias);
+                append_arg(param, alias, &arg_list);
+
+                /* The `port` parameter is massively deprecated in favor of `plug`
+                 * Add `plug` as well */
+                param = "plug";
+                value = g_hash_table_lookup(device_args, param);
+            }
+
         } else if (safe_str_eq(param, "none")) {
             value = param;      /* Nothing more to do */
 

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -179,6 +179,7 @@ stonith__rhcs_metadata(const char *agent, int timeout, char **output)
 
     // Fudge metadata so parameters are not required in config (pacemaker adds them)
     stonith_rhcs_parameter_not_required(xml, "action");
+    stonith_rhcs_parameter_not_required(xml, "plug");
     stonith_rhcs_parameter_not_required(xml, "port");
 
     buffer = dump_xml_formatted_with_text(xml);

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -177,7 +177,8 @@ stonith__rhcs_metadata(const char *agent, int timeout, char **output)
     }
     freeXpathObject(xpathObj);
 
-    // Fudge metadata so port isn't required in config (pacemaker adds it)
+    // Fudge metadata so parameters are not required in config (pacemaker adds them)
+    stonith_rhcs_parameter_not_required(xml, "action");
     stonith_rhcs_parameter_not_required(xml, "port");
 
     buffer = dump_xml_formatted_with_text(xml);

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -85,6 +85,28 @@ stonith__list_rhcs_agents(stonith_key_value_t **devices)
     return count;
 }
 
+static void
+stonith_rhcs_parameter_not_required(xmlNode *metadata, const char *parameter)
+{
+    char *xpath = NULL;
+    xmlXPathObject *xpathObj = NULL;
+
+    CRM_CHECK(metadata != NULL, return);
+    CRM_CHECK(parameter != NULL, return);
+
+    xpath = crm_strdup_printf("//parameter[@name='%s']", parameter);
+    /* Fudge metadata so that the parameter isn't required in config
+     * Pacemaker handles and adds it */
+    xpathObj = xpath_search(metadata, xpath);
+    if (numXpathResults(xpathObj) > 0) {
+        xmlNode *tmp = getXpathResult(xpathObj, 0);
+
+        crm_xml_add(tmp, "required", "0");
+    }
+    freeXpathObject(xpathObj);
+    free(xpath);
+}
+
 /*!
  * \brief Execute RHCS-compatible agent's meta-data action
  *
@@ -156,13 +178,7 @@ stonith__rhcs_metadata(const char *agent, int timeout, char **output)
     freeXpathObject(xpathObj);
 
     // Fudge metadata so port isn't required in config (pacemaker adds it)
-    xpathObj = xpath_search(xml, "//parameter[@name='port']");
-    if (numXpathResults(xpathObj) > 0) {
-        xmlNode *tmp = getXpathResult(xpathObj, 0);
-
-        crm_xml_add(tmp, "required", "0");
-    }
-    freeXpathObject(xpathObj);
+    stonith_rhcs_parameter_not_required(xml, "port");
 
     buffer = dump_xml_formatted_with_text(xml);
     free_xml(xml);


### PR DESCRIPTION
-  Add `plug` parameter besides `port` for RHCS-style fence-agents

According to:
https://github.com/ClusterLabs/fence-agents/commit/de490e059

, `port` parameter is massively deprecated in favor of `plug`:
```
<parameter name="plug" ... obsoletes="port">...
<parameter name="port" ... deprecated="1">...
```

The relatively new agent:

https://github.com/ClusterLabs/fence-agents/blob/master/agents/gce/fence_gce.py

doesn't even correctly handle `port`.

With the commit, `plug` parameter is added besides `port` with the same value.

- The `action` and `plug` parameters of RHCS-style fence-agents are shown as non-required in the metadata

The parameter `action` of RHCS-style fence-agents shouldn't usually be
specified in fencing resource configuration, although it'd be properly
remapped anyways with 9c0c3d6.

With the commits, the `action` and `plug`  parameters  of RHCS-style fence-agents are
fudged to be shown as `required="0"` in the metadata output by
`stonith_admin --metadata` or `crm_resource --show-metadata`. So that
users know they don't have to configure them. Pacemaker handles and passes
the parameters to the agent when executing it.