### PR TITLE
Fix: libpe_status: Skip summary output of cloned resources.

### DIFF
--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -706,6 +706,11 @@ pe__clone_html(pcmk__output_t *out, va_list args)
         }
     }
 
+    if (is_set(options, pe_print_clone_details)) {
+        out->end_list(out);
+        return pcmk_rc_ok;
+    }
+
     /* Masters */
     master_list = g_list_sort(master_list, sort_node_uname);
     for (gIter = master_list; gIter; gIter = gIter->next) {
@@ -898,6 +903,11 @@ pe__clone_text(pcmk__output_t *out, va_list args)
         if (print_full) {
             out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc, only_show);
         }
+    }
+
+    if (is_set(options, pe_print_clone_details)) {
+        out->end_list(out);
+        return pcmk_rc_ok;
     }
 
     /* Masters */


### PR DESCRIPTION
If "crm_mon --show-detail" is given, the summary lists should not be
displayed in the non-XML formats.