### PR TITLE
[1.1] Fix: libcrmcluster: use uint64_t type for corosync ringid (membership id) when updating node state

### DIFF
--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -453,7 +453,7 @@ crm_node_t *crm_update_peer(const char *source, unsigned int id, uint64_t born,
 crm_node_t *crm_update_peer_proc(const char *source, crm_node_t * peer,
                                  uint32_t flag, const char *status);
 crm_node_t *crm_update_peer_state(const char *source, crm_node_t * node,
-                                  const char *state, int membership);
+                                  const char *state, uint64_t membership);
 
 void crm_update_peer_uname(crm_node_t *node, const char *uname);
 void crm_update_peer_expected(const char *source, crm_node_t * node, const char *expected);

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -1021,7 +1021,7 @@ crm_update_peer_expected(const char *source, crm_node_t * node, const char *expe
  *       within a peer cache iteration if the iterator is supplied.
  */
 static crm_node_t *
-crm_update_peer_state_iter(const char *source, crm_node_t * node, const char *state, int membership, GHashTableIter *iter)
+crm_update_peer_state_iter(const char *source, crm_node_t * node, const char *state, uint64_t membership, GHashTableIter *iter)
 {
     gboolean is_member;
 
@@ -1087,7 +1087,7 @@ crm_update_peer_state_iter(const char *source, crm_node_t * node, const char *st
  *       otherwise reaping could invalidate the iterator.
  */
 crm_node_t *
-crm_update_peer_state(const char *source, crm_node_t * node, const char *state, int membership)
+crm_update_peer_state(const char *source, crm_node_t * node, const char *state, uint64_t membership)
 {
     return crm_update_peer_state_iter(source, node, state, membership, NULL);
 }


### PR DESCRIPTION
Backport of https://github.com/ClusterLabs/pacemaker/pull/2030 for 1.1 branch.

The culprit is clear now: https://github.com/corosync/corosync/pull/532#issuecomment-617647233 

Cluster with mixed versions of corosync with or without those commits could run into the
situation that corosync unexpectedly bumped the ringid to a huge number like
"4294967300" which is exactly greater than the maximum uint32_t:

```
corosync[...]:   [TOTEM ] A new membership (X.X.X.X:4294967300) was
formed. Members
```

Node state got updated but with a wrong "last_seen" assigned to an
incomplete ringid:
```
pacemaker-controld  [...] info: Quorum retained | membership=4294967300
members=1
pacemaker-controld  [...] notice: Node node1 state is now member |
nodeid=... previous=unknown source=pcmk_quorum_notification
pacemaker-controld  [...] info: Cluster node node1 is now member (was in
unknown state)
```

And it immediately reaped itself from the membership cache because the
wrong "last_seen" of course was not consistent with the ringid:
```
pacemaker-controld  [...] notice: Node node1 state is now lost |
nodeid=... previous=member source=crm_reap_unseen_nodes
pacemaker-controld  [...] info: Cluster node node1 is now lost (was
member)
pacemaker-controld  [...] error: We're not part of the cluster anymore
```

pacemaker-controld would exit, get respawned and again ...

Anyway, corosync ringid is uint64_t type, which should be correctly
passed and kept.