### PR TITLE
Fix: fencer,libstonithd: add `port` or `plug` parameter according to metadata for RHCS-style fence-agents

### DIFF
--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -19,13 +19,6 @@
  */
 gboolean stonith_check_fence_tolerance(int tolerance, const char *target, const char *action);
 
-enum st_device_flags
-{
-    st_device_supports_list   = 0x0001,
-    st_device_supports_status = 0x0002,
-    st_device_supports_reboot = 0x0004,
-};
-
 typedef struct stonith_device_s {
     char *id;
     char *agent;

--- a/doc/Pacemaker_Explained/en-US/Ch-Fencing.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Fencing.txt
@@ -230,11 +230,11 @@ indexterm:[Fencing,Property,pcmk_action_limit]
 
 |pcmk_host_argument
 |string
-|port
-|'Advanced use only.' Which parameter should be supplied to the resource agent
-to identify the node to be fenced. Some devices do not support the standard
-+port+ parameter or may provide additional ones. Use this to specify an
-alternate, device-specific parameter. A value of +none+ tells the
+|+port+ otherwise +plug+ if supported according to the metadata of the fence agent
+|'Advanced use only.' Which parameter should be supplied to the fence agent to
+identify the node to be fenced. Some devices support neither the standard +plug+
+nor the deprecated +port+ parameter, or may provide additional ones. Use this to
+specify an alternate, device-specific parameter. A value of +none+ tells the
 cluster not to supply any additional parameters.
  indexterm:[pcmk_host_argument,Fencing]
  indexterm:[Fencing,Property,pcmk_host_argument]

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -165,7 +165,7 @@ int stonith__list_rhcs_agents(stonith_key_value_t **devices);
 int stonith__rhcs_metadata(const char *agent, int timeout, char **output);
 bool stonith__agent_is_rhcs(const char *agent);
 int stonith__rhcs_validate(stonith_t *st, int call_options, const char *target,
-                           const char *agent, GHashTable *params,
+                           const char *agent, GHashTable *params, const char *host_arg,
                            int timeout, char **output, char **error_output);
 
 int stonith__failed_history(pcmk__output_t *out, va_list args);

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -32,7 +32,9 @@ stonith_action_t *stonith_action_create(const char *agent,
                                         const char *victim,
                                         uint32_t victim_nodeid,
                                         int timeout,
-                                        GHashTable * device_args, GHashTable * port_map);
+                                        GHashTable * device_args,
+                                        GHashTable * port_map,
+                                        const char * host_arg);
 void stonith__destroy_action(stonith_action_t *action);
 void stonith__action_result(stonith_action_t *action, int *rc, char **output,
                             char **error_output);

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -15,6 +15,15 @@
 #  include <crm/common/output.h>
 #  include <crm/common/xml.h>
 
+enum st_device_flags
+{
+    st_device_supports_list   = 0x0001,
+    st_device_supports_status = 0x0002,
+    st_device_supports_reboot = 0x0004,
+    st_device_supports_parameter_plug = 0x0008,
+    st_device_supports_parameter_port = 0x0010,
+};
+
 struct stonith_action_s;
 typedef struct stonith_action_s stonith_action_t;
 
@@ -54,6 +63,8 @@ GList *stonith__parse_targets(const char *hosts);
 
 gboolean stonith__later_succeeded(stonith_history_t *event, stonith_history_t *top_history);
 stonith_history_t *stonith__sort_history(stonith_history_t *history);
+
+long long stonith__device_parameter_flags(xmlNode *metadata);
 
 #  define ST_LEVEL_MAX 10
 

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2043,11 +2043,15 @@ stonith_api_validate(stonith_t *st, int call_options, const char *rsc_id,
      * that is incorrect, we will need to allow the caller to pass the target).
      */
     const char *target = "node1";
+    const char *host_arg = NULL;
 
     GHashTable *params_table = crm_str_table_new();
 
     // Convert parameter list to a hash table
     for (; params; params = params->next) {
+        if (safe_str_eq(params->key, STONITH_ATTR_HOSTARG)) {
+            host_arg = params->value;
+        }
 
         // Strip out Pacemaker-implemented parameters
         if (!pcmk__starts_with(params->key, "pcmk_")
@@ -2077,8 +2081,8 @@ stonith_api_validate(stonith_t *st, int call_options, const char *rsc_id,
     switch (stonith_get_namespace(agent, namespace_s)) {
         case st_namespace_rhcs:
             rc = stonith__rhcs_validate(st, call_options, target, agent,
-                                        params_table, timeout, output,
-                                        error_output);
+                                        params_table, host_arg, timeout,
+                                        output, error_output);
             break;
 
 #if HAVE_STONITH_STONITH_H

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -505,8 +505,9 @@ append_config_arg(gpointer key, gpointer value, gpointer user_data)
 }
 
 static GHashTable *
-make_args(const char *agent, const char *action, const char *victim, uint32_t victim_nodeid, GHashTable * device_args,
-          GHashTable * port_map)
+make_args(const char *agent, const char *action, const char *victim,
+          uint32_t victim_nodeid, GHashTable * device_args,
+          GHashTable * port_map, const char *host_arg)
 {
     char buffer[512];
     GHashTable *arg_list = NULL;
@@ -550,7 +551,14 @@ make_args(const char *agent, const char *action, const char *victim, uint32_t vi
             value = agent;
 
         } else if (param == NULL) {
-            param = "port";
+            // By default, `port` is added
+            if (host_arg == NULL) {
+                param = "port";
+
+            } else {
+                param = host_arg;
+            }
+
             value = g_hash_table_lookup(device_args, param);
 
         } else if (safe_str_eq(param, "none")) {
@@ -646,12 +654,14 @@ stonith_action_create(const char *agent,
                       const char *_action,
                       const char *victim,
                       uint32_t victim_nodeid,
-                      int timeout, GHashTable * device_args, GHashTable * port_map)
+                      int timeout, GHashTable * device_args,
+                      GHashTable * port_map, const char *host_arg)
 {
     stonith_action_t *action;
 
     action = calloc(1, sizeof(stonith_action_t));
-    action->args = make_args(agent, _action, victim, victim_nodeid, device_args, port_map);
+    action->args = make_args(agent, _action, victim, victim_nodeid,
+                             device_args, port_map, host_arg);
     crm_debug("Preparing '%s' action for %s using agent %s",
               _action, (victim? victim : "no target"), agent);
     action->agent = strdup(agent);

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -124,7 +124,7 @@ stonith__rhcs_metadata(const char *agent, int timeout, char **output)
     xmlNode *actions = NULL;
     xmlXPathObject *xpathObj = NULL;
     stonith_action_t *action = stonith_action_create(agent, "metadata", NULL, 0,
-                                                     5, NULL, NULL);
+                                                     5, NULL, NULL, NULL);
     int rc = stonith__execute(action);
 
     if (rc < 0) {
@@ -213,7 +213,7 @@ stonith__rhcs_validate(stonith_t *st, int call_options, const char *target,
     int rc = pcmk_ok;
     stonith_action_t *action = stonith_action_create(agent, "validate-all",
                                                      target, 0, timeout, params,
-                                                     NULL);
+                                                     NULL, NULL);
 
     rc = stonith__execute(action);
     if (rc == pcmk_ok) {

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -179,6 +179,7 @@ stonith__rhcs_metadata(const char *agent, int timeout, char **output)
 
     // Fudge metadata so parameters are not required in config (pacemaker adds them)
     stonith_rhcs_parameter_not_required(xml, "action");
+    stonith_rhcs_parameter_not_required(xml, "plug");
     stonith_rhcs_parameter_not_required(xml, "port");
 
     buffer = dump_xml_formatted_with_text(xml);

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -112,12 +112,12 @@ stonith_rhcs_parameter_not_required(xmlNode *metadata, const char *parameter)
  *
  * \param[in]  agent    Agent to execute
  * \param[in]  timeout  Action timeout
- * \param[out] output   Where to store action output (or NULL to ignore)
+ * \param[out] metadata Where to store output xmlNode (or NULL to ignore)
  *
  * \todo timeout is currently ignored; shouldn't we use it?
  */
-int
-stonith__rhcs_metadata(const char *agent, int timeout, char **output)
+static int
+stonith__rhcs_get_metadata(const char *agent, int timeout, xmlNode **metadata)
 {
     char *buffer = NULL;
     xmlNode *xml = NULL;
@@ -182,6 +182,38 @@ stonith__rhcs_metadata(const char *agent, int timeout, char **output)
     stonith_rhcs_parameter_not_required(xml, "plug");
     stonith_rhcs_parameter_not_required(xml, "port");
 
+    if (metadata) {
+        *metadata = xml;
+
+    } else {
+        free_xml(xml);
+    }
+
+    return pcmk_ok;
+}
+
+/*!
+ * \brief Execute RHCS-compatible agent's meta-data action
+ *
+ * \param[in]  agent    Agent to execute
+ * \param[in]  timeout  Action timeout
+ * \param[out] output   Where to store action output (or NULL to ignore)
+ *
+ * \todo timeout is currently ignored; shouldn't we use it?
+ */
+int
+stonith__rhcs_metadata(const char *agent, int timeout, char **output)
+{
+    char *buffer = NULL;
+    xmlNode *xml = NULL;
+
+    int rc = stonith__rhcs_get_metadata(agent, timeout, &xml);
+
+    if (rc != pcmk_ok) {
+        free_xml(xml);
+        return rc;
+    }
+
     buffer = dump_xml_formatted_with_text(xml);
     free_xml(xml);
     if (buffer == NULL) {
@@ -208,13 +240,43 @@ stonith__agent_is_rhcs(const char *agent)
 
 int
 stonith__rhcs_validate(stonith_t *st, int call_options, const char *target,
-                       const char *agent, GHashTable *params, int timeout,
+                       const char *agent, GHashTable *params,
+                       const char * host_arg, int timeout,
                        char **output, char **error_output)
 {
     int rc = pcmk_ok;
-    stonith_action_t *action = stonith_action_create(agent, "validate-all",
-                                                     target, 0, timeout, params,
-                                                     NULL, NULL);
+    int remaining_timeout = timeout;
+    xmlNode *metadata = NULL;
+    stonith_action_t *action = NULL;
+
+    if (host_arg == NULL) {
+        time_t start_time = time(NULL);
+
+        rc = stonith__rhcs_get_metadata(agent, remaining_timeout, &metadata);
+
+        if (rc == pcmk_ok) {
+            long long device_flags = stonith__device_parameter_flags(metadata);
+
+            if (is_set(device_flags, st_device_supports_parameter_port)) {
+                host_arg = "port";
+
+            } else if (is_set(device_flags, st_device_supports_parameter_plug)) {
+                host_arg = "plug";
+            }
+        }
+
+        free_xml(metadata);
+
+        remaining_timeout -= time(NULL) - start_time;
+
+        if (rc == -ETIME || remaining_timeout <= 0 ) {
+            return -ETIME;
+        }
+    }
+
+    action = stonith_action_create(agent, "validate-all",
+                                   target, 0, remaining_timeout, params,
+                                   NULL, host_arg);
 
     rc = stonith__execute(action);
     if (rc == pcmk_ok) {


### PR DESCRIPTION
This addresses the issue brought up from: https://github.com/ClusterLabs/pacemaker/pull/2036#issuecomment-621529506

According to:
https://github.com/ClusterLabs/fence-agents/commit/de490e059

, `port` parameter is massively deprecated in favor of `plug`:

```
<parameter name="plug" ... obsoletes="port">...
<parameter name="port" ... deprecated="1">...
```

With this commit, according to the metadata, if `port` parameter is not
supported, `plug` parameter is added if supported. By default, `port`
is added.