### PR TITLE
Fix: controller: properly detect remote node info requests

### DIFF
--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -540,7 +540,7 @@ crmd_remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
          */
         if (safe_str_eq(crm_element_value(request, F_CRM_TASK),
                         CRM_OP_NODE_INFO)) {
-            int node_id;
+            int node_id = 0;
 
             crm_element_value_int(request, XML_ATTR_ID, &node_id);
             if ((node_id <= 0)


### PR DESCRIPTION
This fixes a regression introduced in 1.1.19 / 2.0.0

Ironically the original change was intended to make crm_node -n work reliably
on Pacemaker Remote nodes (even when the node name in the cluster differed from
the local hostname). However, the remote request might not be detected
appropriately depending on what the value of an uninitialized variable happened
to be.

The fix is to initialize the variable.