### PR TITLE
WIP: Fixes for crm_mon output bugs

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -471,6 +471,6 @@ pe_action_t *pe__clear_resource_history(pe_resource_t *rsc, pe_node_t *node,
 GListPtr pe__unames_with_tag(pe_working_set_t *data_set, const char *tag_name);
 bool pe__uname_has_tag(pe_working_set_t *data_set, const char *node, const char *tag);
 
-bool pe__rsc_running_on_any_node_in_list(GListPtr rsc_nodes, GListPtr node_list);
+bool pe__rsc_running_on_any_node_in_list(pe_resource_t *rsc, GListPtr node_list);
 
 #endif

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1503,19 +1503,11 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
 
     pe__bundle_variant_data_t *bundle_data = NULL;
     int rc = pcmk_rc_no_output;
+    gboolean printed_header = FALSE;
 
     CRM_ASSERT(rsc != NULL);
 
     get_bundle_variant_data(bundle_data, rsc);
-
-    rc = pe__name_and_nvpairs_xml(out, true, "bundle", 6
-                 , "id", rsc->id
-                 , "type", container_agent_str(bundle_data->agent_type)
-                 , "image", bundle_data->image
-                 , "unique", BOOL2STR(is_set(rsc->flags, pe_rsc_unique))
-                 , "managed", BOOL2STR(is_set(rsc->flags, pe_rsc_managed))
-                 , "failed", BOOL2STR(is_set(rsc->flags, pe_rsc_failed)));
-    CRM_ASSERT(rc == pcmk_rc_ok);
 
     for (GList *gIter = bundle_data->replicas; gIter != NULL;
          gIter = gIter->next) {
@@ -1526,6 +1518,19 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
 
         if (!pe__rsc_running_on_any_node_in_list(replica->container, only_show)) {
             continue;
+        }
+
+        if (!printed_header) {
+            printed_header = TRUE;
+
+            rc = pe__name_and_nvpairs_xml(out, true, "bundle", 6
+                         , "id", rsc->id
+                         , "type", container_agent_str(bundle_data->agent_type)
+                         , "image", bundle_data->image
+                         , "unique", BOOL2STR(is_set(rsc->flags, pe_rsc_unique))
+                         , "managed", BOOL2STR(is_set(rsc->flags, pe_rsc_managed))
+                         , "failed", BOOL2STR(is_set(rsc->flags, pe_rsc_failed)));
+            CRM_ASSERT(rc == pcmk_rc_ok);
         }
 
         rc = pe__name_and_nvpairs_xml(out, true, "replica", 1, "id", id);
@@ -1548,7 +1553,11 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
 
         pcmk__output_xml_pop_parent(out); // replica
     }
-    pcmk__output_xml_pop_parent(out); // bundle
+
+    if (printed_header) {
+        pcmk__output_xml_pop_parent(out); // bundle
+    }
+
     return rc;
 }
 

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1562,8 +1562,8 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
 }
 
 static void
-pe__bundle_replica_output_html(pcmk__output_t *out, GListPtr only_show,
-                               pe__bundle_replica_t *replica, long options)
+pe__bundle_replica_output_html(pcmk__output_t *out, pe__bundle_replica_t *replica,
+                               long options)
 {
     pe_node_t *node = NULL;
     pe_resource_t *rsc = replica->child;
@@ -1587,10 +1587,7 @@ pe__bundle_replica_output_html(pcmk__output_t *out, GListPtr only_show,
                            replica->ipaddr);
     }
 
-    node = pe__current_node(replica->container);
-    if (pcmk__str_in_list(only_show, node->details->uname)) {
-        pe__common_output_html(out, rsc, buffer, node, options);
-    }
+    pe__common_output_html(out, rsc, buffer, node, options);
 }
 
 PCMK__OUTPUT_ARGS("bundle", "unsigned int", "struct pe_resource_t *", "GListPtr")
@@ -1650,7 +1647,7 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
 
             out->end_list(out);
         } else {
-            pe__bundle_replica_output_html(out, only_show, replica, options);
+            pe__bundle_replica_output_html(out, replica, options);
         }
 
         pcmk__output_xml_pop_parent(out);
@@ -1661,8 +1658,8 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
 }
 
 static void
-pe__bundle_replica_output_text(pcmk__output_t *out, GListPtr only_show,
-                               pe__bundle_replica_t *replica, long options)
+pe__bundle_replica_output_text(pcmk__output_t *out, pe__bundle_replica_t *replica,
+                               long options)
 {
     pe_node_t *node = NULL;
     pe_resource_t *rsc = replica->child;
@@ -1686,10 +1683,7 @@ pe__bundle_replica_output_text(pcmk__output_t *out, GListPtr only_show,
                            replica->ipaddr);
     }
 
-    node = pe__current_node(replica->container);
-    if (pcmk__str_in_list(only_show, node->details->uname)) {
-        pe__common_output_text(out, rsc, buffer, node, options);
-    }
+    pe__common_output_text(out, rsc, buffer, node, options);
 }
 
 PCMK__OUTPUT_ARGS("bundle", "unsigned int", "struct pe_resource_t *", "GListPtr")
@@ -1745,7 +1739,7 @@ pe__bundle_text(pcmk__output_t *out, va_list args)
 
             out->end_list(out);
         } else {
-            pe__bundle_replica_output_text(out, only_show, replica, options);
+            pe__bundle_replica_output_text(out, replica, options);
         }
     }
 

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1524,7 +1524,7 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
 
         CRM_ASSERT(replica);
 
-        if (!pe__rsc_running_on_any_node_in_list(replica->container->running_on, only_show)) {
+        if (!pe__rsc_running_on_any_node_in_list(replica->container, only_show)) {
             continue;
         }
 
@@ -1612,7 +1612,7 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
 
         CRM_ASSERT(replica);
 
-        if (!pe__rsc_running_on_any_node_in_list(replica->container->running_on, only_show)) {
+        if (!pe__rsc_running_on_any_node_in_list(replica->container, only_show)) {
             continue;
         }
 
@@ -1709,7 +1709,7 @@ pe__bundle_text(pcmk__output_t *out, va_list args)
 
         CRM_ASSERT(replica);
 
-        if (!pe__rsc_running_on_any_node_in_list(replica->container->running_on, only_show)) {
+        if (!pe__rsc_running_on_any_node_in_list(replica->container, only_show)) {
             continue;
         }
 

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -580,15 +580,8 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
 
     GListPtr gIter = rsc->children;
 
-    int rc = pe__name_and_nvpairs_xml(out, true, "clone", 7
-                 , "id", rsc->id
-                 , "multi_state", BOOL2STR(is_set(rsc->flags, pe_rsc_promotable))
-                 , "unique", BOOL2STR(is_set(rsc->flags, pe_rsc_unique))
-                 , "managed", BOOL2STR(is_set(rsc->flags, pe_rsc_managed))
-                 , "failed", BOOL2STR(is_set(rsc->flags, pe_rsc_failed))
-                 , "failure_ignored", BOOL2STR(is_set(rsc->flags, pe_rsc_failure_ignored))
-                 , "target_role", configured_role_str(rsc));
-    CRM_ASSERT(rc == pcmk_rc_ok);
+    int rc = pcmk_rc_no_output;
+    gboolean printed_header = FALSE;
 
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
@@ -597,10 +590,27 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
             continue;
         }
 
+        if (!printed_header) {
+            printed_header = TRUE;
+
+            rc = pe__name_and_nvpairs_xml(out, true, "clone", 7
+                     , "id", rsc->id
+                     , "multi_state", BOOL2STR(is_set(rsc->flags, pe_rsc_promotable))
+                     , "unique", BOOL2STR(is_set(rsc->flags, pe_rsc_unique))
+                     , "managed", BOOL2STR(is_set(rsc->flags, pe_rsc_managed))
+                     , "failed", BOOL2STR(is_set(rsc->flags, pe_rsc_failed))
+                     , "failure_ignored", BOOL2STR(is_set(rsc->flags, pe_rsc_failure_ignored))
+                     , "target_role", configured_role_str(rsc));
+            CRM_ASSERT(rc == pcmk_rc_ok);
+        }
+
         out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc, only_show);
     }
 
-    pcmk__output_xml_pop_parent(out);
+    if (printed_header) {
+        pcmk__output_xml_pop_parent(out);
+    }
+
     return rc;
 }
 

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -593,7 +593,7 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
-        if (!pe__rsc_running_on_any_node_in_list(child_rsc->running_on, only_show)) {
+        if (!pe__rsc_running_on_any_node_in_list(child_rsc, only_show)) {
             continue;
         }
 
@@ -635,7 +635,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
         gboolean partially_active = child_rsc->fns->active(child_rsc, FALSE);
 
-        if (!pe__rsc_running_on_any_node_in_list(child_rsc->running_on, only_show)) {
+        if (!pe__rsc_running_on_any_node_in_list(child_rsc, only_show)) {
             continue;
         }
 
@@ -834,7 +834,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
         gboolean partially_active = child_rsc->fns->active(child_rsc, FALSE);
 
-        if (!pe__rsc_running_on_any_node_in_list(child_rsc->running_on, only_show)) {
+        if (!pe__rsc_running_on_any_node_in_list(child_rsc, only_show)) {
             continue;
         }
 

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -717,6 +717,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
     }
 
     if (is_set(options, pe_print_clone_details)) {
+        free(stopped_list);
         out->end_list(out);
         return pcmk_rc_ok;
     }
@@ -916,6 +917,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
     }
 
     if (is_set(options, pe_print_clone_details)) {
+        free(stopped_list);
         out->end_list(out);
         return pcmk_rc_ok;
     }

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -188,19 +188,29 @@ pe__group_xml(pcmk__output_t *out, va_list args)
     GListPtr gIter = rsc->children;
     char *count = crm_itoa(g_list_length(gIter));
 
-    int rc = pe__name_and_nvpairs_xml(out, true, "group", 2
-                                      , "id", rsc->id
-                                      , "number_resources", count);
-    free(count);
-    CRM_ASSERT(rc == pcmk_rc_ok);
+    int rc = pcmk_rc_no_output;
+    gboolean printed_header = FALSE;
 
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
+        if (!printed_header) {
+            printed_header = TRUE;
+
+            rc = pe__name_and_nvpairs_xml(out, true, "group", 2
+                                          , "id", rsc->id
+                                          , "number_resources", count);
+            free(count);
+            CRM_ASSERT(rc == pcmk_rc_ok);
+        }
+
         out->message(out, crm_map_element_name(child_rsc->xml), options, child_rsc, only_show);
     }
 
-    pcmk__output_xml_pop_parent(out);
+    if (printed_header) {
+        pcmk__output_xml_pop_parent(out);
+    }
+
     return rc;
 }
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -2750,9 +2750,24 @@ pe__clear_resource_history(pe_resource_t *rsc, pe_node_t *node,
 }
 
 bool
-pe__rsc_running_on_any_node_in_list(GListPtr rsc_nodes, GListPtr node_list)
+pe__rsc_running_on_any_node_in_list(pe_resource_t *rsc, GListPtr node_list)
 {
-    for (GListPtr ele = rsc_nodes; ele; ele = ele->next) {
+    /* If this resource is inactive, we will always return false unless
+     * node_list contains just '*'.  Inactive resources aren't running on
+     * any node.
+     */
+    gboolean is_active = rsc->fns->active(rsc, TRUE);
+    gboolean partially_active = rsc->fns->active(rsc, FALSE);
+
+    if (!is_active && !partially_active &&
+        node_list != NULL && strcmp(node_list->data, "*") == 0 && node_list->next == NULL) {
+        return true;
+    }
+
+    /* Otherwise, this resource must be running on one of the nodes in the
+     * given list.
+     */
+    for (GListPtr ele = rsc->running_on; ele; ele = ele->next) {
         pe_node_t *node = (pe_node_t *) ele->data;
         if (pcmk__str_in_list(node_list, node->details->uname)) {
             return true;

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1346,7 +1346,7 @@ main(int argc, char **argv)
     }
 
     if (output_format == mon_output_xml || output_format == mon_output_legacy_xml) {
-        options.mon_ops |= mon_op_print_timing;
+        options.mon_ops |= mon_op_print_timing | mon_op_inactive_resources;
     }
 
     crm_info("Starting %s", crm_system_name);

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -208,10 +208,8 @@ print_resources(pcmk__output_t *out, pe_working_set_t *data_set,
             continue;
         }
 
-        if (is_active || partially_active) {
-            if (!pe__rsc_running_on_any_node_in_list(rsc->running_on, only_show)) {
-                continue;
-            }
+        if (!pe__rsc_running_on_any_node_in_list(rsc, only_show)) {
+            continue;
         }
 
         /* Print this resource */


### PR DESCRIPTION
These patches aim to fix a couple problems in 2.0.4-rc1 with crm_mon's output.  In particular, inactive resources do not get printed by default XML output, and inactive resources do not get printed anywhere (even with -r) due to the --node= option.

I'm still working on testing these.  There's a lot that can go wrong.  Also, I'll need to rebase to the 2.0 branch.  I till thought it might be worth talking about them.