### PR TITLE
[1.1] Fix: fencer,libstonithd: add `port` or `plug` parameter according to metadata for RHCS-style fence-agents

### DIFF
--- a/doc/Pacemaker_Explained/en-US/Ch-Stonith.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Stonith.txt
@@ -182,11 +182,11 @@ indexterm:[Fencing,Property,pcmk_action_limit]
 
 |pcmk_host_argument
 |string
-|port
-|'Advanced use only.' Which parameter should be supplied to the resource agent
-to identify the node to be fenced. Some devices do not support the standard
-+port+ parameter or may provide additional ones. Use this to specify an
-alternate, device-specific parameter. A value of +none+ tells the
+|+port+ otherwise +plug+ if supported according to the metadata of the fence agent
+|'Advanced use only.' Which parameter should be supplied to the fence agent to
+identify the node to be fenced. Some devices support neither the standard +plug+
+nor the deprecated +port+ parameter, or may provide additional ones. Use this to
+specify an alternate, device-specific parameter. A value of +none+ tells the
 cluster not to supply any additional parameters.
  indexterm:[pcmk_host_argument,Fencing]
  indexterm:[Fencing,Property,pcmk_host_argument]

--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -327,6 +327,7 @@ stonith_device_execute(stonith_device_t * device)
 {
     int exec_rc = 0;
     const char *action_str = NULL;
+    const char *host_arg = NULL;
     async_command_t *cmd = NULL;
     stonith_action_t *action = NULL;
     int active_cmds = 0;
@@ -409,11 +410,19 @@ stonith_device_execute(stonith_device_t * device)
         action_str = "off";
     }
 
+    if (is_set(device->flags, st_device_supports_parameter_port)) {
+        host_arg = "port";
+
+    } else if (is_set(device->flags, st_device_supports_parameter_plug)) {
+        host_arg = "plug";
+    }
+
     action = stonith_action_create(device->agent,
                                    action_str,
                                    cmd->victim,
                                    cmd->victim_nodeid,
-                                   cmd->timeout, device->params, device->aliases);
+                                   cmd->timeout, device->params,
+                                   device->aliases, host_arg);
 
     /* for async exec, exec_rc is negative for early error exit
        otherwise handling of success/errors is done via callbacks */
@@ -944,6 +953,7 @@ build_device_from_xml(xmlNode * msg)
 
     device->agent_metadata = get_agent_metadata(device->agent);
     read_action_metadata(device);
+    set_bit(device->flags, stonith__device_parameter_flags(device->agent_metadata));
 
     value = g_hash_table_lookup(device->params, "nodeid");
     if (!value) {

--- a/fencing/internal.h
+++ b/fencing/internal.h
@@ -12,13 +12,6 @@
  */
 gboolean stonith_check_fence_tolerance(int tolerance, const char *target, const char *action);
 
-enum st_device_flags
-{
-    st_device_supports_list   = 0x0001,
-    st_device_supports_status = 0x0002,
-    st_device_supports_reboot = 0x0004,
-};
-
 typedef struct stonith_device_s {
     char *id;
     char *agent;

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -28,7 +28,9 @@ stonith_action_t *stonith_action_create(const char *agent,
                                         const char *victim,
                                         uint32_t victim_nodeid,
                                         int timeout,
-                                        GHashTable * device_args, GHashTable * port_map);
+                                        GHashTable * device_args,
+                                        GHashTable * port_map,
+                                        const char * host_arg);
 void stonith__destroy_action(stonith_action_t *action);
 void stonith__action_result(stonith_action_t *action, int *rc, char **output,
                             char **error_output);

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -160,7 +160,7 @@ int stonith__list_rhcs_agents(stonith_key_value_t **devices);
 int stonith__rhcs_metadata(const char *agent, int timeout, char **output);
 bool stonith__agent_is_rhcs(const char *agent);
 int stonith__rhcs_validate(stonith_t *st, int call_options, const char *target,
-                           const char *agent, GHashTable *params,
+                           const char *agent, GHashTable *params, const char *host_arg,
                            int timeout, char **output, char **error_output);
 
 #endif

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -11,6 +11,15 @@
 #  include <crm/common/ipc.h>
 #  include <crm/common/xml.h>
 
+enum st_device_flags
+{
+    st_device_supports_list   = 0x0001,
+    st_device_supports_status = 0x0002,
+    st_device_supports_reboot = 0x0004,
+    st_device_supports_parameter_plug = 0x0008,
+    st_device_supports_parameter_port = 0x0010,
+};
+
 struct stonith_action_s;
 typedef struct stonith_action_s stonith_action_t;
 
@@ -43,6 +52,8 @@ xmlNode *create_device_registration_xml(const char *id,
                                         const char *agent,
                                         stonith_key_value_t *params,
                                         const char *rsc_provides);
+
+long long stonith__device_parameter_flags(xmlNode *metadata);
 
 #  define ST_LEVEL_MAX 10
 

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2143,11 +2143,15 @@ stonith_api_validate(stonith_t *st, int call_options, const char *rsc_id,
      * that is incorrect, we will need to allow the caller to pass the target).
      */
     const char *target = "node1";
+    const char *host_arg = NULL;
 
     GHashTable *params_table = crm_str_table_new();
 
     // Convert parameter list to a hash table
     for (; params; params = params->next) {
+        if (safe_str_eq(params->key, STONITH_ATTR_HOSTARG)) {
+            host_arg = params->value;
+        }
 
         // Strip out Pacemaker-implemented parameters
         if (!crm_starts_with(params->key, "pcmk_")
@@ -2176,8 +2180,8 @@ stonith_api_validate(stonith_t *st, int call_options, const char *rsc_id,
     switch (stonith_get_namespace(agent, namespace_s)) {
         case st_namespace_rhcs:
             rc = stonith__rhcs_validate(st, call_options, target, agent,
-                                        params_table, timeout, output,
-                                        error_output);
+                                        params_table, host_arg, timeout,
+                                        output, error_output);
             break;
 
 #if HAVE_STONITH_STONITH_H

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -590,8 +590,9 @@ append_host_specific_args(const char *victim, const char *map, GHashTable * para
 }
 
 static GHashTable *
-make_args(const char *agent, const char *action, const char *victim, uint32_t victim_nodeid, GHashTable * device_args,
-          GHashTable * port_map)
+make_args(const char *agent, const char *action, const char *victim,
+          uint32_t victim_nodeid, GHashTable * device_args,
+          GHashTable * port_map, const char *host_arg)
 {
     char buffer[512];
     GHashTable *arg_list = NULL;
@@ -652,7 +653,14 @@ make_args(const char *agent, const char *action, const char *victim, uint32_t vi
             const char *map = g_hash_table_lookup(device_args, STONITH_ATTR_ARGMAP);
 
             if (map == NULL) {
-                param = "port";
+                // By default, `port` is added
+                if (host_arg == NULL) {
+                    param = "port";
+
+                } else {
+                    param = host_arg;
+                }
+
                 value = g_hash_table_lookup(device_args, param);
 
             } else {
@@ -753,12 +761,14 @@ stonith_action_create(const char *agent,
                       const char *_action,
                       const char *victim,
                       uint32_t victim_nodeid,
-                      int timeout, GHashTable * device_args, GHashTable * port_map)
+                      int timeout, GHashTable * device_args,
+                      GHashTable * port_map, const char *host_arg)
 {
     stonith_action_t *action;
 
     action = calloc(1, sizeof(stonith_action_t));
-    action->args = make_args(agent, _action, victim, victim_nodeid, device_args, port_map);
+    action->args = make_args(agent, _action, victim, victim_nodeid,
+                             device_args, port_map, host_arg);
     crm_debug("Preparing '%s' action for %s using agent %s",
               _action, (victim? victim : "no target"), agent);
     action->agent = strdup(agent);

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2414,3 +2414,45 @@ stonith_api_time(uint32_t nodeid, const char *uname, bool in_progress)
     free(name);
     return when;
 }
+
+long long
+stonith__device_parameter_flags(xmlNode *metadata)
+{
+    xmlXPathObjectPtr xpath = NULL;
+    int max = 0;
+    int lpc = 0;
+    long long flags = 0;
+
+    CRM_CHECK(metadata, return 0);
+
+    xpath = xpath_search(metadata, "//parameter");
+    max = numXpathResults(xpath);
+
+    if (max <= 0) {
+        freeXpathObject(xpath);
+        return 0;
+    }
+
+    for (lpc = 0; lpc < max; lpc++) {
+        const char *parameter = NULL;
+        xmlNode *match = getXpathResult(xpath, lpc);
+
+        CRM_LOG_ASSERT(match != NULL);
+        if (match == NULL) {
+            continue;
+        }
+
+        parameter = crm_element_value(match, "name");
+
+        if (safe_str_eq(parameter, "plug")) {
+            set_bit(flags, st_device_supports_parameter_plug);
+
+        } else if (safe_str_eq(parameter, "port")) {
+            set_bit(flags, st_device_supports_parameter_port);
+        }
+    }
+
+    freeXpathObject(xpath);
+
+    return flags;
+}

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -655,17 +655,6 @@ make_args(const char *agent, const char *action, const char *victim, uint32_t vi
                 param = "port";
                 value = g_hash_table_lookup(device_args, param);
 
-                if (value == NULL || safe_str_eq(value, "dynamic")) {
-                    crm_debug("Performing '%s' action targeting '%s' as '%s=%s'", action, victim, param,
-                              alias);
-                    append_arg(param, alias, &arg_list);
-
-                    /* The `port` parameter is massively deprecated in favor of `plug`
-                     * Add `plug` as well */
-                    param = "plug";
-                    value = g_hash_table_lookup(device_args, param);
-                }
-
             } else {
                 append_host_specific_args(alias, map, device_args, &arg_list);
                 value = map;    /* Nothing more to do */

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -251,6 +251,9 @@ stonith__rhcs_validate(stonith_t *st, int call_options, const char *target,
         if (rc == -ETIME || remaining_timeout <= 0 ) {
             return -ETIME;
         }
+
+    } else if (safe_str_eq(host_arg, "none")) {
+        host_arg = NULL;
     }
 
     action = stonith_action_create(agent, "validate-all",

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -103,7 +103,7 @@ stonith__rhcs_metadata(const char *agent, int timeout, char **output)
     xmlNode *actions = NULL;
     xmlXPathObject *xpathObj = NULL;
     stonith_action_t *action = stonith_action_create(agent, "metadata", NULL, 0,
-                                                     5, NULL, NULL);
+                                                     5, NULL, NULL, NULL);
     int rc = stonith__execute(action);
 
     if (rc < 0) {
@@ -193,7 +193,7 @@ stonith__rhcs_validate(stonith_t *st, int call_options, const char *target,
     int rc = pcmk_ok;
     stonith_action_t *action = stonith_action_create(agent, "validate-all",
                                                      target, 0, timeout, params,
-                                                     NULL);
+                                                     NULL, NULL);
 
     rc = stonith__execute(action);
     if (rc == pcmk_ok) {


### PR DESCRIPTION
Backports of https://github.com/ClusterLabs/pacemaker/pull/2059 and https://github.com/ClusterLabs/pacemaker/pull/2066 for 1.1 branch.

This addresses the issue brought up from: https://github.com/ClusterLabs/pacemaker/pull/2036#issuecomment-621529506

According to:
https://github.com/ClusterLabs/fence-agents/commit/de490e059

, `port` parameter is massively deprecated in favor of `plug`:

```
<parameter name="plug" ... obsoletes="port">...
<parameter name="port" ... deprecated="1">...
```

With this commit, according to the metadata, if `port` parameter is not
supported, `plug` parameter is added if supported. By default, `port`
is added.