### PR TITLE
Fix: libstonithd: respect `pcmk_host_argument=none` on `validate`

### DIFF
--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -272,6 +272,9 @@ stonith__rhcs_validate(stonith_t *st, int call_options, const char *target,
         if (rc == -ETIME || remaining_timeout <= 0 ) {
             return -ETIME;
         }
+
+    } else if (safe_str_eq(host_arg, "none")) {
+        host_arg = NULL;
     }
 
     action = stonith_action_create(agent, "validate-all",


### PR DESCRIPTION
Although for now by default, `port` is still added in make_args() for
backward compatibility. This will be really respected in the future
possibly since 2.1.0.