### PR TITLE
Fix: tools: Remove an extra space in crm_mon filtered output.

### DIFF
--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -716,6 +716,10 @@ pe__clone_html(pcmk__output_t *out, va_list args)
     for (gIter = master_list; gIter; gIter = gIter->next) {
         pe_node_t *host = gIter->data;
 
+        if (!pcmk__str_in_list(only_show, host->details->uname)) {
+            continue;
+        }
+
         list_text = pcmk__add_word(list_text, host->details->uname);
         active_instances++;
     }
@@ -731,6 +735,10 @@ pe__clone_html(pcmk__output_t *out, va_list args)
     started_list = g_list_sort(started_list, sort_node_uname);
     for (gIter = started_list; gIter; gIter = gIter->next) {
         pe_node_t *host = gIter->data;
+
+        if (!pcmk__str_in_list(only_show, host->details->uname)) {
+            continue;
+        }
 
         list_text = pcmk__add_word(list_text, host->details->uname);
         active_instances++;
@@ -784,7 +792,8 @@ pe__clone_html(pcmk__output_t *out, va_list args)
             for (nIter = list; nIter != NULL; nIter = nIter->next) {
                 pe_node_t *node = (pe_node_t *)nIter->data;
 
-                if (pe_find_node(rsc->running_on, node->details->uname) == NULL) {
+                if (pe_find_node(rsc->running_on, node->details->uname) == NULL &&
+                    pcmk__str_in_list(only_show, node->details->uname)) {
                     stopped_list = pcmk__add_word(stopped_list,
                                                   node->details->uname);
                 }
@@ -915,6 +924,10 @@ pe__clone_text(pcmk__output_t *out, va_list args)
     for (gIter = master_list; gIter; gIter = gIter->next) {
         pe_node_t *host = gIter->data;
 
+        if (!pcmk__str_in_list(only_show, host->details->uname)) {
+            continue;
+        }
+
         list_text = pcmk__add_word(list_text, host->details->uname);
         active_instances++;
     }
@@ -930,6 +943,10 @@ pe__clone_text(pcmk__output_t *out, va_list args)
     started_list = g_list_sort(started_list, sort_node_uname);
     for (gIter = started_list; gIter; gIter = gIter->next) {
         pe_node_t *host = gIter->data;
+
+        if (!pcmk__str_in_list(only_show, host->details->uname)) {
+            continue;
+        }
 
         list_text = pcmk__add_word(list_text, host->details->uname);
         active_instances++;
@@ -982,7 +999,8 @@ pe__clone_text(pcmk__output_t *out, va_list args)
             for (nIter = list; nIter != NULL; nIter = nIter->next) {
                 pe_node_t *node = (pe_node_t *)nIter->data;
 
-                if (pe_find_node(rsc->running_on, node->details->uname) == NULL) {
+                if (pe_find_node(rsc->running_on, node->details->uname) == NULL &&
+                    pcmk__str_in_list(only_show, node->details->uname)) {
                     stopped_list = pcmk__add_word(stopped_list,
                                                   node->details->uname);
                 }

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -783,7 +783,7 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
 
     unames = build_uname_list(data_set, only_show);
 
-    if (is_set(show, mon_show_nodes)) {
+    if (is_set(show, mon_show_nodes) && unames) {
         if (rc == pcmk_rc_ok) {
             out->info(out, "%s", "");
         }
@@ -1015,7 +1015,7 @@ print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
     unames = build_uname_list(data_set, only_show);
 
     /*** NODE LIST ***/
-    if (is_set(show, mon_show_nodes)) {
+    if (is_set(show, mon_show_nodes) && unames) {
         out->message(out, "node-list", data_set->nodes, unames, print_opts,
                      is_set(mon_ops, mon_op_print_clone_detail),
                      is_set(mon_ops, mon_op_print_brief),


### PR DESCRIPTION
If we are filtering crm_mon output by node and give a node that doesn't
exist, an extra blank line will be output.  The node-list message knows
not to print out anything including its header, but the caller doesn't
know it won't print anything out so it adds the extra blank line between
sections.

However, the caller does know which nodes will be output.  The unames
list either has something in it (names of nodes, or "*" which means
everything) or it's an empty list because the user gave something that
didn't exist.  So we can just check to see if unames is empty.

Note that we don't do this for XML output - we want an empty list there.