### PR TITLE
[1.1] Fix: fencer: avoid possible use-of-NULL when parsing metadata

### DIFF
--- a/fencing/commands.c
+++ b/fencing/commands.c
@@ -952,8 +952,11 @@ build_device_from_xml(xmlNode * msg)
     device->aliases = build_port_aliases(value, &(device->targets));
 
     device->agent_metadata = get_agent_metadata(device->agent);
-    read_action_metadata(device);
-    set_bit(device->flags, stonith__device_parameter_flags(device->agent_metadata));
+    if (device->agent_metadata) {
+        read_action_metadata(device);
+        set_bit(device->flags,
+                stonith__device_parameter_flags(device->agent_metadata));
+    }
 
     value = g_hash_table_lookup(device->params, "nodeid");
     if (!value) {

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2437,7 +2437,7 @@ stonith__device_parameter_flags(xmlNode *metadata)
     int lpc = 0;
     long long flags = 0;
 
-    CRM_CHECK(metadata, return 0);
+    CRM_CHECK(metadata != NULL, return 0);
 
     xpath = xpath_search(metadata, "//parameter");
     max = numXpathResults(xpath);


### PR DESCRIPTION
Backport of https://github.com/ClusterLabs/pacemaker/pull/2070 for 1.1 branch.