### PR TITLE
Fix: libcrmcommon: return ENOMEM directly instead of errno

### DIFF
--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -608,7 +608,7 @@ pcmk__ipc_prepare_iov(uint32_t request, xmlNode *message,
 
     header = calloc(1, sizeof(pcmk__ipc_header_t));
     if (header == NULL) {
-        return errno;
+       return ENOMEM; /* errno mightn't be set by allocator */
     }
 
     buffer = dump_xml_unformatted(message);


### PR DESCRIPTION
as errno might not be set by certain allocators

one still missing from the 2.0.4-rc2 merge back to master ...