### PR TITLE
Formatted output refactoring

### DIFF
--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -719,6 +719,13 @@ G_GNUC_NULL_TERMINATED;
         out_obj->info(out_obj, "%s", "");       \
     }
 
+#define PCMK__OUTPUT_LIST_HEADER(out_obj, cond, retcode, title...)  \
+    if (retcode == pcmk_rc_no_output) {                             \
+        PCMK__OUTPUT_SPACER_IF(out_obj, cond);                      \
+        retcode = pcmk_rc_ok;                                       \
+        out_obj->begin_list(out_obj, NULL, NULL, title);            \
+    }
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -726,6 +726,11 @@ G_GNUC_NULL_TERMINATED;
         out_obj->begin_list(out_obj, NULL, NULL, title);            \
     }
 
+#define PCMK__OUTPUT_LIST_FOOTER(out_obj, retcode)  \
+    if (retcode == pcmk_rc_ok) {                    \
+        out_obj->end_list(out_obj);                 \
+    }
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -714,6 +714,11 @@ void
 pcmk__html_add_header(xmlNodePtr parent, const char *name, ...)
 G_GNUC_NULL_TERMINATED;
 
+#define PCMK__OUTPUT_SPACER_IF(out_obj, cond)   \
+    if (cond) {                                 \
+        out_obj->info(out_obj, "%s", "");       \
+    }
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 the Pacemaker project contributors
+ * Copyright 2011-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -183,5 +183,12 @@ int stonith__event_xml(pcmk__output_t *out, va_list args);
 int stonith__validate_agent_html(pcmk__output_t *out, va_list args);
 int stonith__validate_agent_text(pcmk__output_t *out, va_list args);
 int stonith__validate_agent_xml(pcmk__output_t *out, va_list args);
+
+stonith_history_t *stonith__first_matching_event(stonith_history_t *history,
+                                                 bool (*matching_fn)(stonith_history_t *, void *),
+                                                 void *user_data);
+bool stonith__event_state_pending(stonith_history_t *history, void *user_data);
+bool stonith__event_state_eq(stonith_history_t *history, void *user_data);
+bool stonith__event_state_neq(stonith_history_t *history, void *user_data);
 
 #endif

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2619,6 +2619,38 @@ stonith__sort_history(stonith_history_t *history)
     return new;
 }
 
+stonith_history_t *
+stonith__first_matching_event(stonith_history_t *history,
+                              bool (*matching_fn)(stonith_history_t *, void *),
+                              void *user_data)
+{
+    for (stonith_history_t *hp = history; hp; hp = hp->next) {
+        if (matching_fn(hp, user_data)) {
+            return hp;
+        }
+    }
+
+    return NULL;
+}
+
+bool
+stonith__event_state_pending(stonith_history_t *history, void *user_data)
+{
+    return history->state != st_failed && history->state != st_done;
+}
+
+bool
+stonith__event_state_eq(stonith_history_t *history, void *user_data)
+{
+    return history->state == GPOINTER_TO_INT(user_data);
+}
+
+bool
+stonith__event_state_neq(stonith_history_t *history, void *user_data)
+{
+    return history->state != GPOINTER_TO_INT(user_data);
+}
+
 // Deprecated functions kept only for backward API compatibility
 const char *get_stonith_provider(const char *agent, const char *provider);
 

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -29,7 +29,7 @@ time_t_string(time_t when) {
     return buf;
 }
 
-PCMK__OUTPUT_ARGS("failed-fencing-history", "struct stonith_history_t *", "GListPtr", "gboolean", "gboolean")
+PCMK__OUTPUT_ARGS("failed-fencing-history", "stonith_history_t *", "GListPtr", "gboolean", "gboolean")
 int
 stonith__failed_history(pcmk__output_t *out, va_list args) {
     stonith_history_t *history = va_arg(args, stonith_history_t *);
@@ -57,7 +57,7 @@ stonith__failed_history(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("fencing-history", "struct stonith_history_t *", "GListPtr", "gboolean", "gboolean")
+PCMK__OUTPUT_ARGS("fencing-history", "stonith_history_t *", "GListPtr", "gboolean", "gboolean")
 int
 stonith__history(pcmk__output_t *out, va_list args) {
     stonith_history_t *history = va_arg(args, stonith_history_t *);
@@ -83,7 +83,7 @@ stonith__history(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("full-fencing-history", "crm_exit_t", "struct stonith_history_t *", "GListPtr", "gboolean", "gboolean")
+PCMK__OUTPUT_ARGS("full-fencing-history", "crm_exit_t", "stonith_history_t *", "GListPtr", "gboolean", "gboolean")
 int
 stonith__full_history(pcmk__output_t *out, va_list args) {
     crm_exit_t history_rc G_GNUC_UNUSED = va_arg(args, crm_exit_t);
@@ -108,7 +108,7 @@ stonith__full_history(pcmk__output_t *out, va_list args) {
     return rc;
 }
  
-PCMK__OUTPUT_ARGS("full-fencing-history", "crm_exit_t", "struct stonith_history_t *", "GListPtr", "gboolean", "gboolean")
+PCMK__OUTPUT_ARGS("full-fencing-history", "crm_exit_t", "stonith_history_t *", "GListPtr", "gboolean", "gboolean")
 int
 stonith__full_history_xml(pcmk__output_t *out, va_list args) {
     crm_exit_t history_rc = va_arg(args, crm_exit_t);
@@ -195,7 +195,7 @@ stonith__last_fenced_xml(pcmk__output_t *out, va_list args) {
     }
 }
 
-PCMK__OUTPUT_ARGS("pending-fencing-actions", "struct stonith_history_t *", "GListPtr", "gboolean", "gboolean")
+PCMK__OUTPUT_ARGS("pending-fencing-actions", "stonith_history_t *", "GListPtr", "gboolean", "gboolean")
 int
 stonith__pending_actions(pcmk__output_t *out, va_list args) {
     stonith_history_t *history = va_arg(args, stonith_history_t *);
@@ -224,7 +224,7 @@ stonith__pending_actions(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("stonith-event", "struct stonith_history_t *", "gboolean", "gboolean")
+PCMK__OUTPUT_ARGS("stonith-event", "stonith_history_t *", "gboolean", "gboolean")
 int
 stonith__event_html(pcmk__output_t *out, va_list args) {
     stonith_history_t *event = va_arg(args, stonith_history_t *);
@@ -272,7 +272,7 @@ stonith__event_html(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("stonith-event", "struct stonith_history_t *", "gboolean", "gboolean")
+PCMK__OUTPUT_ARGS("stonith-event", "stonith_history_t *", "gboolean", "gboolean")
 int
 stonith__event_text(pcmk__output_t *out, va_list args) {
     stonith_history_t *event = va_arg(args, stonith_history_t *);
@@ -310,7 +310,7 @@ stonith__event_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("stonith-event", "struct stonith_history_t *", "gboolean", "gboolean")
+PCMK__OUTPUT_ARGS("stonith-event", "stonith_history_t *", "gboolean", "gboolean")
 int
 stonith__event_xml(pcmk__output_t *out, va_list args) {
     xmlNodePtr node = pcmk__output_create_xml_node(out, "fence_event");

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -53,10 +53,7 @@ stonith__failed_history(pcmk__output_t *out, va_list args) {
         out->increment_list(out);
     }
 
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
-
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
     return rc;
 }
 
@@ -82,10 +79,7 @@ stonith__history(pcmk__output_t *out, va_list args) {
         }
     }
 
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
-
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
     return rc;
 }
 
@@ -110,10 +104,7 @@ stonith__full_history(pcmk__output_t *out, va_list args) {
         out->increment_list(out);
     }
 
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
-
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
     return rc;
 }
  
@@ -139,9 +130,7 @@ stonith__full_history_xml(pcmk__output_t *out, va_list args) {
             out->increment_list(out);
         }
 
-        if (rc == pcmk_rc_ok) {
-            out->end_list(out);
-        }
+        PCMK__OUTPUT_LIST_FOOTER(out, rc);
     } else {
         xmlNodePtr node = pcmk__output_create_xml_node(out, "fence_history");
         char *rc_s = crm_itoa(history_rc);
@@ -231,10 +220,7 @@ stonith__pending_actions(pcmk__output_t *out, va_list args) {
         out->increment_list(out);
     }
 
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
-
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
     return rc;
 }
 

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -48,12 +48,7 @@ stonith__failed_history(pcmk__output_t *out, va_list args) {
             continue;
         }
 
-        if (rc == pcmk_rc_no_output) {
-            PCMK__OUTPUT_SPACER_IF(out, print_spacer);
-            rc = pcmk_rc_ok;
-            out->begin_list(out, NULL, NULL, "Failed Fencing Actions");
-        }
-
+        PCMK__OUTPUT_LIST_HEADER(out, print_spacer, rc, "Failed Fencing Actions");
         out->message(out, "stonith-event", hp, full_history, stonith__later_succeeded(hp, history));
         out->increment_list(out);
     }
@@ -81,15 +76,7 @@ stonith__history(pcmk__output_t *out, va_list args) {
         }
 
         if (hp->state != st_failed) {
-            /* Print the header the first time we have an event to print out to
-             * prevent printing headers with empty sections underneath.
-             */
-            if (rc == pcmk_rc_no_output) {
-                PCMK__OUTPUT_SPACER_IF(out, print_spacer);
-                rc = pcmk_rc_ok;
-                out->begin_list(out, NULL, NULL, "Fencing History");
-            }
-
+            PCMK__OUTPUT_LIST_HEADER(out, print_spacer, rc, "Fencing History");
             out->message(out, "stonith-event", hp, full_history, stonith__later_succeeded(hp, history));
             out->increment_list(out);
         }
@@ -118,12 +105,7 @@ stonith__full_history(pcmk__output_t *out, va_list args) {
             continue;
         }
 
-        if (rc == pcmk_rc_no_output) {
-            PCMK__OUTPUT_SPACER_IF(out, print_spacer);
-            rc = pcmk_rc_ok;
-            out->begin_list(out, NULL, NULL, "Fencing History");
-        }
-
+        PCMK__OUTPUT_LIST_HEADER(out, print_spacer, rc, "Fencing History");
         out->message(out, "stonith-event", hp, full_history, stonith__later_succeeded(hp, history));
         out->increment_list(out);
     }
@@ -152,11 +134,7 @@ stonith__full_history_xml(pcmk__output_t *out, va_list args) {
                 continue;
             }
 
-            if (rc == pcmk_rc_no_output) {
-                rc = pcmk_rc_ok;
-                out->begin_list(out, NULL, NULL, "Fencing History");
-            }
-
+            PCMK__OUTPUT_LIST_HEADER(out, FALSE, rc, "Fencing History");
             out->message(out, "stonith-event", hp, full_history, stonith__later_succeeded(hp, history));
             out->increment_list(out);
         }
@@ -248,12 +226,7 @@ stonith__pending_actions(pcmk__output_t *out, va_list args) {
             break;
         }
 
-        if (rc == pcmk_rc_no_output) {
-            PCMK__OUTPUT_SPACER_IF(out, print_spacer);
-            rc = pcmk_rc_ok;
-            out->begin_list(out, NULL, NULL, "Pending Fencing Actions");
-        }
-
+        PCMK__OUTPUT_LIST_HEADER(out, print_spacer, rc, "Pending Fencing Actions");
         out->message(out, "stonith-event", hp, full_history, stonith__later_succeeded(hp, history));
         out->increment_list(out);
     }

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -49,10 +49,7 @@ stonith__failed_history(pcmk__output_t *out, va_list args) {
         }
 
         if (rc == pcmk_rc_no_output) {
-            if (print_spacer) {
-                out->info(out, "%s", "");
-            }
-
+            PCMK__OUTPUT_SPACER_IF(out, print_spacer);
             rc = pcmk_rc_ok;
             out->begin_list(out, NULL, NULL, "Failed Fencing Actions");
         }
@@ -88,11 +85,7 @@ stonith__history(pcmk__output_t *out, va_list args) {
              * prevent printing headers with empty sections underneath.
              */
             if (rc == pcmk_rc_no_output) {
-                /* Add a blank line between this section and the one before it. */
-                if (print_spacer) {
-                    out->info(out, "%s", "");
-                }
-
+                PCMK__OUTPUT_SPACER_IF(out, print_spacer);
                 rc = pcmk_rc_ok;
                 out->begin_list(out, NULL, NULL, "Fencing History");
             }
@@ -126,11 +119,7 @@ stonith__full_history(pcmk__output_t *out, va_list args) {
         }
 
         if (rc == pcmk_rc_no_output) {
-            /* Add a blank line between this section and the one before it. */
-            if (print_spacer) {
-                out->info(out, "%s", "");
-            }
-
+            PCMK__OUTPUT_SPACER_IF(out, print_spacer);
             rc = pcmk_rc_ok;
             out->begin_list(out, NULL, NULL, "Fencing History");
         }
@@ -260,10 +249,7 @@ stonith__pending_actions(pcmk__output_t *out, va_list args) {
         }
 
         if (rc == pcmk_rc_no_output) {
-            if (print_spacer) {
-                out->info(out, "%s", "");
-            }
-
+            PCMK__OUTPUT_SPACER_IF(out, print_spacer);
             rc = pcmk_rc_ok;
             out->begin_list(out, NULL, NULL, "Pending Fencing Actions");
         }

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1493,7 +1493,7 @@ bundle_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
     free(child_text);
 }
 
-PCMK__OUTPUT_ARGS("bundle", "unsigned int", "struct pe_resource_t *", "GListPtr")
+PCMK__OUTPUT_ARGS("bundle", "unsigned int", "pe_resource_t *", "GListPtr")
 int
 pe__bundle_xml(pcmk__output_t *out, va_list args)
 {
@@ -1589,7 +1589,7 @@ pe__bundle_replica_output_html(pcmk__output_t *out, pe__bundle_replica_t *replic
     pe__common_output_html(out, rsc, buffer, node, options);
 }
 
-PCMK__OUTPUT_ARGS("bundle", "unsigned int", "struct pe_resource_t *", "GListPtr")
+PCMK__OUTPUT_ARGS("bundle", "unsigned int", "pe_resource_t *", "GListPtr")
 int
 pe__bundle_html(pcmk__output_t *out, va_list args)
 {
@@ -1689,7 +1689,7 @@ pe__bundle_replica_output_text(pcmk__output_t *out, pe__bundle_replica_t *replic
     pe__common_output_text(out, rsc, buffer, node, options);
 }
 
-PCMK__OUTPUT_ARGS("bundle", "unsigned int", "struct pe_resource_t *", "GListPtr")
+PCMK__OUTPUT_ARGS("bundle", "unsigned int", "pe_resource_t *", "GListPtr")
 int
 pe__bundle_text(pcmk__output_t *out, va_list args)
 {

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -570,7 +570,7 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
     free(child_text);
 }
 
-PCMK__OUTPUT_ARGS("clone", "unsigned int", "struct pe_resource_t *", "GListPtr")
+PCMK__OUTPUT_ARGS("clone", "unsigned int", "pe_resource_t *", "GListPtr")
 int
 pe__clone_xml(pcmk__output_t *out, va_list args)
 {
@@ -614,7 +614,7 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("clone", "unsigned int", "struct pe_resource_t *", "GListPtr")
+PCMK__OUTPUT_ARGS("clone", "unsigned int", "pe_resource_t *", "GListPtr")
 int
 pe__clone_html(pcmk__output_t *out, va_list args)
 {
@@ -823,7 +823,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("clone", "unsigned int", "struct pe_resource_t *", "GListPtr")
+PCMK__OUTPUT_ARGS("clone", "unsigned int", "pe_resource_t *", "GListPtr")
 int
 pe__clone_text(pcmk__output_t *out, va_list args)
 {

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -177,7 +177,7 @@ group_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
     free(child_text);
 }
 
-PCMK__OUTPUT_ARGS("group", "unsigned int", "struct pe_resource_t *", "GListPtr")
+PCMK__OUTPUT_ARGS("group", "unsigned int", "pe_resource_t *", "GListPtr")
 int
 pe__group_xml(pcmk__output_t *out, va_list args)
 {
@@ -214,7 +214,7 @@ pe__group_xml(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("group", "unsigned int", "struct pe_resource_t *", "GListPtr")
+PCMK__OUTPUT_ARGS("group", "unsigned int", "pe_resource_t *", "GListPtr")
 int
 pe__group_html(pcmk__output_t *out, va_list args)
 {
@@ -239,7 +239,7 @@ pe__group_html(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("group", "unsigned int", "struct pe_resource_t *", "GListPtr")
+PCMK__OUTPUT_ARGS("group", "unsigned int", "pe_resource_t *", "GListPtr")
 int
 pe__group_text(pcmk__output_t *out, va_list args)
 {

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -1038,7 +1038,7 @@ native_print(pe_resource_t * rsc, const char *pre_text, long options, void *prin
     common_print(rsc, pre_text, rsc_printable_id(rsc), node, options, print_data);
 }
 
-PCMK__OUTPUT_ARGS("primitive", "unsigned int", "struct pe_resource_t *", "GListPtr")
+PCMK__OUTPUT_ARGS("primitive", "unsigned int", "pe_resource_t *", "GListPtr")
 int
 pe__resource_xml(pcmk__output_t *out, va_list args)
 {
@@ -1107,7 +1107,7 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("primitive", "unsigned int", "struct pe_resource_t *", "GListPtr")
+PCMK__OUTPUT_ARGS("primitive", "unsigned int", "pe_resource_t *", "GListPtr")
 int
 pe__resource_html(pcmk__output_t *out, va_list args)
 {
@@ -1126,7 +1126,7 @@ pe__resource_html(pcmk__output_t *out, va_list args)
     return pe__common_output_html(out, rsc, rsc_printable_id(rsc), node, options);
 }
 
-PCMK__OUTPUT_ARGS("primitive", "unsigned int", "struct pe_resource_t *", "GListPtr")
+PCMK__OUTPUT_ARGS("primitive", "unsigned int", "pe_resource_t *", "GListPtr")
 int
 pe__resource_text(pcmk__output_t *out, va_list args)
 {

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -204,8 +204,8 @@ resource_history_string(pe_resource_t *rsc, const char *rsc_id, gboolean all,
     return buf;
 }
 
-PCMK__OUTPUT_ARGS("cluster-summary", "struct pe_working_set_t *", "gboolean", "gboolean", "gboolean",
-            "gboolean", "gboolean", "gboolean")
+PCMK__OUTPUT_ARGS("cluster-summary", "pe_working_set_t *", "gboolean", "gboolean", "gboolean",
+                  "gboolean", "gboolean", "gboolean")
 int
 pe__cluster_summary(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
@@ -271,8 +271,8 @@ pe__cluster_summary(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("cluster-summary", "struct pe_working_set_t *", "gboolean", "gboolean", "gboolean",
-            "gboolean", "gboolean", "gboolean")
+PCMK__OUTPUT_ARGS("cluster-summary", "pe_working_set_t *", "gboolean", "gboolean", "gboolean",
+                  "gboolean", "gboolean", "gboolean")
 int
 pe__cluster_summary_html(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
@@ -427,7 +427,7 @@ pe__name_and_nvpairs_xml(pcmk__output_t *out, bool is_list, const char *tag_name
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("ban", "struct pe_node_t *", "struct pe__location_t *", "gboolean")
+PCMK__OUTPUT_ARGS("ban", "pe_node_t *", "pe__location_t *", "gboolean")
 int
 pe__ban_html(pcmk__output_t *out, va_list args) {
     pe_node_t *pe_node = va_arg(args, pe_node_t *);
@@ -447,7 +447,7 @@ pe__ban_html(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("ban", "struct pe_node_t *", "struct pe__location_t *", "gboolean")
+PCMK__OUTPUT_ARGS("ban", "pe_node_t *", "pe__location_t *", "gboolean")
 int
 pe__ban_text(pcmk__output_t *out, va_list args) {
     pe_node_t *pe_node = va_arg(args, pe_node_t *);
@@ -464,7 +464,7 @@ pe__ban_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("ban", "struct pe_node_t *", "struct pe__location_t *", "gboolean")
+PCMK__OUTPUT_ARGS("ban", "pe_node_t *", "pe__location_t *", "gboolean")
 int
 pe__ban_xml(pcmk__output_t *out, va_list args) {
     xmlNodePtr node = pcmk__output_create_xml_node(out, "ban");
@@ -611,7 +611,7 @@ pe__cluster_counts_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("cluster-dc", "struct pe_node_t *", "const char *", "const char *", "char *")
+PCMK__OUTPUT_ARGS("cluster-dc", "pe_node_t *", "const char *", "const char *", "char *")
 int
 pe__cluster_dc_html(pcmk__output_t *out, va_list args) {
     xmlNodePtr node = pcmk__output_create_xml_node(out, "li");
@@ -645,7 +645,7 @@ pe__cluster_dc_html(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("cluster-dc", "struct pe_node_t *", "const char *", "const char *", "char *")
+PCMK__OUTPUT_ARGS("cluster-dc", "pe_node_t *", "const char *", "const char *", "char *")
 int
 pe__cluster_dc_text(pcmk__output_t *out, va_list args) {
     pe_node_t *dc = va_arg(args, pe_node_t *);
@@ -664,7 +664,7 @@ pe__cluster_dc_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("cluster-dc", "struct pe_node_t *", "const char *", "const char *", "char *")
+PCMK__OUTPUT_ARGS("cluster-dc", "pe_node_t *", "const char *", "const char *", "char *")
 int
 pe__cluster_dc_xml(pcmk__output_t *out, va_list args) {
     xmlNodePtr node = pcmk__output_create_xml_node(out, "current_dc");
@@ -696,7 +696,7 @@ pe__cluster_maint_mode_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("cluster-options", "struct pe_working_set_t *")
+PCMK__OUTPUT_ARGS("cluster-options", "pe_working_set_t *")
 int
 pe__cluster_options_html(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
@@ -744,7 +744,7 @@ pe__cluster_options_html(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("cluster-options", "struct pe_working_set_t *")
+PCMK__OUTPUT_ARGS("cluster-options", "pe_working_set_t *")
 int
 pe__cluster_options_log(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
@@ -757,7 +757,7 @@ pe__cluster_options_log(pcmk__output_t *out, va_list args) {
     }
 }
 
-PCMK__OUTPUT_ARGS("cluster-options", "struct pe_working_set_t *")
+PCMK__OUTPUT_ARGS("cluster-options", "pe_working_set_t *")
 int
 pe__cluster_options_text(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
@@ -794,7 +794,7 @@ pe__cluster_options_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("cluster-options", "struct pe_working_set_t *")
+PCMK__OUTPUT_ARGS("cluster-options", "pe_working_set_t *")
 int
 pe__cluster_options_xml(pcmk__output_t *out, va_list args) {
     xmlNodePtr node = pcmk__output_create_xml_node(out, "cluster_options");
@@ -997,7 +997,7 @@ pe__failed_action_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node", "struct pe_node_t *", "unsigned int", "gboolean", "const char *", "gboolean", "gboolean", "gboolean", "GListPtr")
+PCMK__OUTPUT_ARGS("node", "pe_node_t *", "unsigned int", "gboolean", "const char *", "gboolean", "gboolean", "gboolean", "GListPtr")
 int
 pe__node_html(pcmk__output_t *out, va_list args) {
     pe_node_t *node = va_arg(args, pe_node_t *);
@@ -1059,7 +1059,7 @@ pe__node_html(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node", "struct pe_node_t *", "unsigned int", "gboolean", "const char *", "gboolean", "gboolean", "gboolean", "GListPtr")
+PCMK__OUTPUT_ARGS("node", "pe_node_t *", "unsigned int", "gboolean", "const char *", "gboolean", "gboolean", "gboolean", "GListPtr")
 int
 pe__node_text(pcmk__output_t *out, va_list args) {
     pe_node_t *node = va_arg(args, pe_node_t *);
@@ -1116,7 +1116,7 @@ pe__node_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node", "struct pe_node_t *", "unsigned int", "gboolean", "const char *", "gboolean", "gboolean", "gboolean", "GListPtr")
+PCMK__OUTPUT_ARGS("node", "pe_node_t *", "unsigned int", "gboolean", "const char *", "gboolean", "gboolean", "gboolean", "GListPtr")
 int
 pe__node_xml(pcmk__output_t *out, va_list args) {
     pe_node_t *node = va_arg(args, pe_node_t *);
@@ -1529,7 +1529,7 @@ pe__op_history_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-history", "struct pe_resource_t *", "const char *", "gboolean", "int", "time_t", "gboolean")
+PCMK__OUTPUT_ARGS("resource-history", "pe_resource_t *", "const char *", "gboolean", "int", "time_t", "gboolean")
 int
 pe__resource_history_text(pcmk__output_t *out, va_list args) {
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
@@ -1551,7 +1551,7 @@ pe__resource_history_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-history", "struct pe_resource_t *", "const char *", "gboolean", "int", "time_t", "gboolean")
+PCMK__OUTPUT_ARGS("resource-history", "pe_resource_t *", "const char *", "gboolean", "int", "time_t", "gboolean")
 int
 pe__resource_history_xml(pcmk__output_t *out, va_list args) {
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
@@ -1595,7 +1595,7 @@ pe__resource_history_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("ticket", "struct pe_ticket_t *")
+PCMK__OUTPUT_ARGS("ticket", "pe_ticket_t *")
 int
 pe__ticket_html(pcmk__output_t *out, va_list args) {
     pe_ticket_t *ticket = va_arg(args, pe_ticket_t *);
@@ -1616,7 +1616,7 @@ pe__ticket_html(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("ticket", "struct pe_ticket_t *")
+PCMK__OUTPUT_ARGS("ticket", "pe_ticket_t *")
 int
 pe__ticket_text(pcmk__output_t *out, va_list args) {
     pe_ticket_t *ticket = va_arg(args, pe_ticket_t *);
@@ -1637,7 +1637,7 @@ pe__ticket_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("ticket", "struct pe_ticket_t *")
+PCMK__OUTPUT_ARGS("ticket", "pe_ticket_t *")
 int
 pe__ticket_xml(pcmk__output_t *out, va_list args) {
     xmlNodePtr node = NULL;

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -261,9 +261,7 @@ pe__cluster_summary(pcmk__output_t *out, va_list args) {
         out->message(out, "cluster-options", data_set);
     }
 
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
 
     if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
         out->message(out, "maint-mode");
@@ -330,17 +328,13 @@ pe__cluster_summary_html(pcmk__output_t *out, va_list args) {
          * function so we can put all the options into their own list.  We
          * only want to do this on HTML output, though.
          */
-        if (rc == pcmk_rc_ok) {
-            out->end_list(out);
-        }
+        PCMK__OUTPUT_LIST_FOOTER(out, rc);
 
         out->begin_list(out, NULL, NULL, "Config Options");
         out->message(out, "cluster-options", data_set);
     }
 
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
 
     if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
         out->message(out, "maint-mode");
@@ -1292,10 +1286,7 @@ pe__node_list_html(pcmk__output_t *out, va_list args) {
                      print_brief, group_by_node, only_show);
     }
 
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
-
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
     return rc;
 }
 
@@ -1426,10 +1417,7 @@ pe__node_list_text(pcmk__output_t *out, va_list args) {
         free(online_guest_nodes);
     }
 
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
-
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
     return rc;
 }
 

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -309,7 +309,7 @@ curses_indented_printf(pcmk__output_t *out, const char *format, ...) {
     va_end(ap);
 }
 
-PCMK__OUTPUT_ARGS("stonith-event", "struct stonith_history_t *", "gboolean", "gboolean")
+PCMK__OUTPUT_ARGS("stonith-event", "stonith_history_t *", "gboolean", "gboolean")
 static int
 stonith_event_console(pcmk__output_t *out, va_list args) {
     stonith_history_t *event = va_arg(args, stonith_history_t *);

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -699,6 +699,11 @@ print_failed_actions(pcmk__output_t *out, pe_working_set_t *data_set,
     return rc;
 }
 
+#define CHECK_RC(retcode, retval)   \
+    if (retval == pcmk_rc_ok) {     \
+        retcode = pcmk_rc_ok;       \
+    }
+
 /*!
  * \internal
  * \brief Top-level printing function for text/curses output.
@@ -719,85 +724,57 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
 
     unsigned int print_opts = get_resource_display_options(mon_ops);
     int rc = pcmk_rc_no_output;
-    int x;
 
-    x = out->message(out, "cluster-summary", data_set,
-                     is_set(mon_ops, mon_op_print_clone_detail),
-                     is_set(show, mon_show_stack),
-                     is_set(show, mon_show_dc),
-                     is_set(show, mon_show_times),
-                     is_set(show, mon_show_counts),
-                     is_set(show, mon_show_options));
-
-    if (x == pcmk_rc_ok) {
-        rc = pcmk_rc_ok;
-    }
+    CHECK_RC(rc, out->message(out, "cluster-summary", data_set,
+                              is_set(mon_ops, mon_op_print_clone_detail),
+                              is_set(show, mon_show_stack),
+                              is_set(show, mon_show_dc),
+                              is_set(show, mon_show_times),
+                              is_set(show, mon_show_counts),
+                              is_set(show, mon_show_options)));
 
     unames = build_uname_list(data_set, only_show);
 
     if (is_set(show, mon_show_nodes) && unames) {
         PCMK__OUTPUT_SPACER_IF(out, rc == pcmk_rc_ok);
-
-        x = out->message(out, "node-list", data_set->nodes, unames, print_opts,
-                         is_set(mon_ops, mon_op_print_clone_detail),
-                         is_set(mon_ops, mon_op_print_brief),
-                         is_set(mon_ops, mon_op_group_by_node));
-
-        if (x == pcmk_rc_ok) {
-            rc = pcmk_rc_ok;
-        }
+        CHECK_RC(rc, out->message(out, "node-list", data_set->nodes, unames, print_opts,
+                                  is_set(mon_ops, mon_op_print_clone_detail),
+                                  is_set(mon_ops, mon_op_print_brief),
+                                  is_set(mon_ops, mon_op_group_by_node)));
     }
 
     /* Print resources section, if needed */
     if (is_set(show, mon_show_resources)) {
-        x = print_resources(out, data_set, print_opts, mon_ops,
-                            is_set(mon_ops, mon_op_print_brief), TRUE,
-                            unames, rc == pcmk_rc_ok);
-        if (x == pcmk_rc_ok) {
-            rc = pcmk_rc_ok;
-        }
+        CHECK_RC(rc, print_resources(out, data_set, print_opts, mon_ops,
+                                     is_set(mon_ops, mon_op_print_brief), TRUE,
+                                     unames, rc == pcmk_rc_ok));
     }
 
     /* print Node Attributes section if requested */
     if (is_set(show, mon_show_attributes)) {
-        x =  print_node_attributes(out, data_set, mon_ops, unames,
-                                   rc == pcmk_rc_ok);
-        if (x == pcmk_rc_ok) {
-            rc = pcmk_rc_ok;
-        }
+        CHECK_RC(rc, print_node_attributes(out, data_set, mon_ops, unames, rc == pcmk_rc_ok));
     }
 
     /* If requested, print resource operations (which includes failcounts)
      * or just failcounts
      */
     if (is_set(show, mon_show_operations) || is_set(show, mon_show_failcounts)) {
-        x = print_node_summary(out, data_set, is_set(show, mon_show_operations),
-                               mon_ops, unames, rc == pcmk_rc_ok);
-        if (x == pcmk_rc_ok) {
-            rc = pcmk_rc_ok;
-        }
+        CHECK_RC(rc, print_node_summary(out, data_set, is_set(show, mon_show_operations),
+                                        mon_ops, unames, rc == pcmk_rc_ok));
     }
 
     /* If there were any failed actions, print them */
     if (is_set(show, mon_show_failures) && xml_has_children(data_set->failed)) {
-        x = print_failed_actions(out, data_set, unames, rc == pcmk_rc_ok);
-        if (x == pcmk_rc_ok) {
-            rc = pcmk_rc_ok;
-        }
+        CHECK_RC(rc, print_failed_actions(out, data_set, unames, rc == pcmk_rc_ok));
     }
 
     /* Print failed stonith actions */
     if (is_set(show, mon_show_fence_failed) && is_set(mon_ops, mon_op_fence_history)) {
         for (stonith_history_t *hp = stonith_history; hp; hp = hp->next) {
             if (hp->state == st_failed) {
-                x = out->message(out, "failed-fencing-history", hp, unames,
-                                 is_set(mon_ops, mon_op_fence_full_history),
-                                 rc == pcmk_rc_ok);
-
-                if (x == pcmk_rc_ok) {
-                    rc = pcmk_rc_ok;
-                }
-
+                CHECK_RC(rc, out->message(out, "failed-fencing-history", hp, unames,
+                                          is_set(mon_ops, mon_op_fence_full_history),
+                                          rc == pcmk_rc_ok));
                 break;
             }
         }
@@ -805,18 +782,12 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
 
     /* Print tickets if requested */
     if (is_set(show, mon_show_tickets)) {
-        x = print_cluster_tickets(out, data_set, rc == pcmk_rc_ok);
-        if (x == pcmk_rc_ok) {
-            rc = pcmk_rc_ok;
-        }
+        CHECK_RC(rc, print_cluster_tickets(out, data_set, rc == pcmk_rc_ok));
     }
 
     /* Print negative location constraints if requested */
     if (is_set(show, mon_show_bans)) {
-        x = print_neg_locations(out, data_set, mon_ops, prefix, rc == pcmk_rc_ok);
-        if (x == pcmk_rc_ok) {
-            rc = pcmk_rc_ok;
-        }
+        CHECK_RC(rc, print_neg_locations(out, data_set, mon_ops, prefix, rc == pcmk_rc_ok));
     }
 
     /* Print stonith history */
@@ -824,28 +795,18 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
         if (is_set(show, mon_show_fence_worked)) {
             for (stonith_history_t *hp = stonith_history; hp; hp = hp->next) {
                 if (hp->state != st_failed) {
-                    x = out->message(out, "fencing-history", hp, unames,
-                                     is_set(mon_ops, mon_op_fence_full_history),
-                                     rc == pcmk_rc_ok);
-
-                    if (x == pcmk_rc_ok) {
-                        rc = pcmk_rc_ok;
-                    }
-
+                    CHECK_RC(rc, out->message(out, "fencing-history", hp, unames,
+                                              is_set(mon_ops, mon_op_fence_full_history),
+                                              rc == pcmk_rc_ok));
                     break;
                 }
             }
         } else if (is_set(show, mon_show_fence_pending)) {
             for (stonith_history_t *hp = stonith_history; hp; hp = hp->next) {
                 if (hp->state != st_failed && hp->state != st_done) {
-                    x = out->message(out, "pending-fencing-actions", hp, unames,
-                                     is_set(mon_ops, mon_op_fence_full_history),
-                                     rc == pcmk_rc_ok);
-
-                    if (x == pcmk_rc_ok) {
-                        rc = pcmk_rc_ok;
-                    }
-
+                    CHECK_RC(rc, out->message(out, "pending-fencing-actions", hp, unames,
+                                              is_set(mon_ops, mon_op_fence_full_history),
+                                              rc == pcmk_rc_ok));
                     break;
                 }
             }

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -165,10 +165,7 @@ print_resources(pcmk__output_t *out, pe_working_set_t *data_set,
         return rc;
     }
 
-    /* Add a blank line between this section and the one before it. */
-    if (print_spacer) {
-        out->info(out, "%s", "");
-    }
+    PCMK__OUTPUT_SPACER_IF(out, print_spacer);
 
     print_resources_heading(out, mon_ops);
 
@@ -514,10 +511,7 @@ print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
         }
 
         if (rc == pcmk_rc_no_output) {
-            /* Add a blank line between this section and the one before it. */
-            if (print_spacer) {
-                out->info(out, "%s", "");
-            }
+            PCMK__OUTPUT_SPACER_IF(out, print_spacer);
 
             if (operations) {
                 out->begin_list(out, NULL, NULL, "Operations");
@@ -557,10 +551,7 @@ print_cluster_tickets(pcmk__output_t *out, pe_working_set_t * data_set,
         return pcmk_rc_no_output;
     }
 
-    /* Add a blank line between this section and the one before it. */
-    if (print_spacer) {
-        out->info(out, "%s", "");
-    }
+    PCMK__OUTPUT_SPACER_IF(out, print_spacer);
 
     /* Print section heading */
     out->begin_list(out, NULL, NULL, "Tickets");
@@ -603,11 +594,7 @@ print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set,
 
             if (node->weight < 0) {
                 if (rc == pcmk_rc_no_output) {
-                    /* Add a blank line between this section and the one before it. */
-                    if (print_spacer) {
-                        out->info(out, "%s", "");
-                    }
-
+                    PCMK__OUTPUT_SPACER_IF(out, print_spacer);
                     rc = pcmk_rc_ok;
                     out->begin_list(out, NULL, NULL, "Negative Location Constraints");
                 }
@@ -673,11 +660,7 @@ print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set,
             }
 
             if (rc == pcmk_rc_no_output) {
-                /* Add a blank line between this section and the one before it. */
-                if (print_spacer) {
-                    out->info(out, "%s", "");
-                }
-
+                PCMK__OUTPUT_SPACER_IF(out, print_spacer);
                 rc = pcmk_rc_ok;
                 out->begin_list(out, NULL, NULL, "Node Attributes");
             }
@@ -725,11 +708,7 @@ print_failed_actions(pcmk__output_t *out, pe_working_set_t *data_set,
         }
 
         if (rc == pcmk_rc_no_output) {
-            /* Add a blank line between this section and the one before it. */
-            if (print_spacer) {
-                out->info(out, "%s", "");
-            }
-
+            PCMK__OUTPUT_SPACER_IF(out, print_spacer);
             rc = pcmk_rc_ok;
             out->begin_list(out, NULL, NULL, "Failed Resource Actions");
         }
@@ -781,9 +760,7 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
     unames = build_uname_list(data_set, only_show);
 
     if (is_set(show, mon_show_nodes) && unames) {
-        if (rc == pcmk_rc_ok) {
-            out->info(out, "%s", "");
-        }
+        PCMK__OUTPUT_SPACER_IF(out, rc == pcmk_rc_ok);
 
         x = out->message(out, "node-list", data_set->nodes, unames, print_opts,
                          is_set(mon_ops, mon_op_print_clone_detail),

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -750,13 +750,13 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
 
     /* Print failed stonith actions */
     if (is_set(show, mon_show_fence_failed) && is_set(mon_ops, mon_op_fence_history)) {
-        for (stonith_history_t *hp = stonith_history; hp; hp = hp->next) {
-            if (hp->state == st_failed) {
-                CHECK_RC(rc, out->message(out, "failed-fencing-history", hp, unames,
-                                          is_set(mon_ops, mon_op_fence_full_history),
-                                          rc == pcmk_rc_ok));
-                break;
-            }
+        stonith_history_t *hp = stonith__first_matching_event(stonith_history, stonith__event_state_eq,
+                                                              GINT_TO_POINTER(st_failed));
+
+        if (hp) {
+            CHECK_RC(rc, out->message(out, "failed-fencing-history", hp, unames,
+                                      is_set(mon_ops, mon_op_fence_full_history),
+                                      rc == pcmk_rc_ok));
         }
     }
 
@@ -773,22 +773,21 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
     /* Print stonith history */
     if (is_set(mon_ops, mon_op_fence_history)) {
         if (is_set(show, mon_show_fence_worked)) {
-            for (stonith_history_t *hp = stonith_history; hp; hp = hp->next) {
-                if (hp->state != st_failed) {
-                    CHECK_RC(rc, out->message(out, "fencing-history", hp, unames,
-                                              is_set(mon_ops, mon_op_fence_full_history),
-                                              rc == pcmk_rc_ok));
-                    break;
-                }
+            stonith_history_t *hp = stonith__first_matching_event(stonith_history, stonith__event_state_neq,
+                                                                  GINT_TO_POINTER(st_failed));
+
+            if (hp) {
+                CHECK_RC(rc, out->message(out, "fencing-history", hp, unames,
+                                          is_set(mon_ops, mon_op_fence_full_history),
+                                          rc == pcmk_rc_ok));
             }
         } else if (is_set(show, mon_show_fence_pending)) {
-            for (stonith_history_t *hp = stonith_history; hp; hp = hp->next) {
-                if (hp->state != st_failed && hp->state != st_done) {
-                    CHECK_RC(rc, out->message(out, "pending-fencing-actions", hp, unames,
-                                              is_set(mon_ops, mon_op_fence_full_history),
-                                              rc == pcmk_rc_ok));
-                    break;
-                }
+            stonith_history_t *hp = stonith__first_matching_event(stonith_history, stonith__event_state_pending, NULL);
+
+            if (hp) {
+                CHECK_RC(rc, out->message(out, "pending-fencing-actions", hp, unames,
+                                          is_set(mon_ops, mon_op_fence_full_history),
+                                          rc == pcmk_rc_ok));
             }
         }
     }
@@ -939,34 +938,33 @@ print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
 
     /* Print failed stonith actions */
     if (is_set(show, mon_show_fence_failed) && is_set(mon_ops, mon_op_fence_history)) {
-        for (stonith_history_t *hp = stonith_history; hp; hp = hp->next) {
-            if (hp->state == st_failed) {
-                out->message(out, "failed-fencing-history", hp, unames,
-                             is_set(mon_ops, mon_op_fence_full_history), FALSE);
-                break;
-            }
+        stonith_history_t *hp = stonith__first_matching_event(stonith_history, stonith__event_state_eq,
+                                                              GINT_TO_POINTER(st_failed));
+
+        if (hp) {
+            out->message(out, "failed-fencing-history", hp, unames,
+                         is_set(mon_ops, mon_op_fence_full_history), FALSE);
         }
     }
 
     /* Print stonith history */
     if (is_set(mon_ops, mon_op_fence_history)) {
         if (is_set(show, mon_show_fence_worked)) {
-            for (stonith_history_t *hp = stonith_history; hp; hp = hp->next) {
-                if (hp->state != st_failed) {
-                    out->message(out, "fencing-history", hp, unames,
-                                 is_set(mon_ops, mon_op_fence_full_history),
-                                 FALSE);
-                    break;
-                }
+            stonith_history_t *hp = stonith__first_matching_event(stonith_history, stonith__event_state_neq,
+                                                                  GINT_TO_POINTER(st_failed));
+
+            if (hp) {
+                out->message(out, "fencing-history", hp, unames,
+                             is_set(mon_ops, mon_op_fence_full_history),
+                             FALSE);
             }
         } else if (is_set(show, mon_show_fence_pending)) {
-            for (stonith_history_t *hp = stonith_history; hp; hp = hp->next) {
-                if (hp->state != st_failed && hp->state != st_done) {
-                    out->message(out, "pending-fencing-actions", hp, unames,
-                                 is_set(mon_ops, mon_op_fence_full_history),
-                                 FALSE);
-                    break;
-                }
+            stonith_history_t *hp = stonith__first_matching_event(stonith_history, stonith__event_state_pending, NULL);
+
+            if (hp) {
+                out->message(out, "pending-fencing-actions", hp, unames,
+                             is_set(mon_ops, mon_op_fence_full_history),
+                             FALSE);
             }
         }
     }

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -301,11 +301,7 @@ print_rsc_history(pcmk__output_t *out, pe_working_set_t *data_set, pe_node_t *no
     /* Free the list we created (no need to free the individual items) */
     g_list_free(op_list);
 
-    /* If we printed anything, close the resource */
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
-
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
     return rc;
 }
 
@@ -374,10 +370,7 @@ print_node_history(pcmk__output_t *out, pe_working_set_t *data_set,
         }
     }
 
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
-
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
     return rc;
 }
 
@@ -516,10 +509,7 @@ print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
                            only_show);
     }
 
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
-
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
     return rc;
 }
 
@@ -589,10 +579,7 @@ print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set,
         }
     }
 
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
-
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
     return rc;
 }
 
@@ -656,11 +643,7 @@ print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set,
         }
     }
 
-    /* Print section footer */
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
-
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
     return rc;
 }
 
@@ -692,10 +675,7 @@ print_failed_actions(pcmk__output_t *out, pe_working_set_t *data_set,
         out->message(out, "failed-action", xml_op);
     }
 
-    if (rc == pcmk_rc_ok) {
-        out->end_list(out);
-    }
-
+    PCMK__OUTPUT_LIST_FOOTER(out, rc);
     return rc;
 }
 

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -510,17 +510,7 @@ print_node_summary(pcmk__output_t *out, pe_working_set_t * data_set,
             continue;
         }
 
-        if (rc == pcmk_rc_no_output) {
-            PCMK__OUTPUT_SPACER_IF(out, print_spacer);
-
-            if (operations) {
-                out->begin_list(out, NULL, NULL, "Operations");
-            } else {
-                out->begin_list(out, NULL, NULL, "Migration Summary");
-            }
-
-            rc = pcmk_rc_ok;
-        }
+        PCMK__OUTPUT_LIST_HEADER(out, print_spacer, rc, operations ? "Operations" : "Migration Summary");
 
         print_node_history(out, data_set, node, node_state, operations, mon_ops,
                            only_show);
@@ -593,12 +583,7 @@ print_neg_locations(pcmk__output_t *out, pe_working_set_t *data_set,
             pe_node_t *node = (pe_node_t *) gIter2->data;
 
             if (node->weight < 0) {
-                if (rc == pcmk_rc_no_output) {
-                    PCMK__OUTPUT_SPACER_IF(out, print_spacer);
-                    rc = pcmk_rc_ok;
-                    out->begin_list(out, NULL, NULL, "Negative Location Constraints");
-                }
-
+                PCMK__OUTPUT_LIST_HEADER(out, print_spacer, rc, "Negative Location Constraints");
                 out->message(out, "ban", node, location, is_set(mon_ops, mon_op_print_clone_detail));
             }
         }
@@ -659,11 +644,7 @@ print_node_attributes(pcmk__output_t *out, pe_working_set_t *data_set,
                 continue;
             }
 
-            if (rc == pcmk_rc_no_output) {
-                PCMK__OUTPUT_SPACER_IF(out, print_spacer);
-                rc = pcmk_rc_ok;
-                out->begin_list(out, NULL, NULL, "Node Attributes");
-            }
+            PCMK__OUTPUT_LIST_HEADER(out, print_spacer, rc, "Node Attributes");
 
             out->message(out, "node", data.node, get_resource_display_options(mon_ops),
                          FALSE, NULL, is_set(mon_ops, mon_op_print_clone_detail),
@@ -707,12 +688,7 @@ print_failed_actions(pcmk__output_t *out, pe_working_set_t *data_set,
             continue;
         }
 
-        if (rc == pcmk_rc_no_output) {
-            PCMK__OUTPUT_SPACER_IF(out, print_spacer);
-            rc = pcmk_rc_ok;
-            out->begin_list(out, NULL, NULL, "Failed Resource Actions");
-        }
-
+        PCMK__OUTPUT_LIST_HEADER(out, print_spacer, rc, "Failed Resource Actions");
         out->message(out, "failed-action", xml_op);
     }
 


### PR DESCRIPTION
As I've been working on adding the --resource= option to crm_mon, I've noticed a lot of boilerplate code around formatted output.  This is the first set of patches to try to reduce that.  I imagine a fair bit more could be done.  I'll continue looking into it and will probably have more to add to this PR.