### PR TITLE
Fix: scheduler: Add the node name back to bundle instances.

### DIFF
--- a/cts/cli/regression.crm_mon.exp
+++ b/cts/cli/regression.crm_mon.exp
@@ -623,8 +623,8 @@ Active Resources:
     * Started: [ cluster01 ]
   * Fencing	(stonith:fence_xvm):	 Started cluster01
   * Container bundle set: httpd-bundle [pcmk:http]:
-    * httpd-bundle-0 (192.168.122.131)	(ocf::heartbeat:apache):	 Started
-    * httpd-bundle-1 (192.168.122.132)	(ocf::heartbeat:apache):	 Stopped
+    * httpd-bundle-0 (192.168.122.131)	(ocf::heartbeat:apache):	 Started cluster02
+    * httpd-bundle-1 (192.168.122.132)	(ocf::heartbeat:apache):	 Stopped cluster01
 =#=#=#= End test: Text output of partially active resources - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of partially active resources
 =#=#=#= Begin test: XML output of partially active resources =#=#=#=
@@ -757,8 +757,8 @@ Full List of Resources:
     * Stopped: [ cluster02 ]
   * Fencing	(stonith:fence_xvm):	 Started cluster01
   * Container bundle set: httpd-bundle [pcmk:http]:
-    * httpd-bundle-0 (192.168.122.131)	(ocf::heartbeat:apache):	 Started
-    * httpd-bundle-1 (192.168.122.132)	(ocf::heartbeat:apache):	 Stopped
+    * httpd-bundle-0 (192.168.122.131)	(ocf::heartbeat:apache):	 Started cluster02
+    * httpd-bundle-1 (192.168.122.132)	(ocf::heartbeat:apache):	 Stopped cluster01
 =#=#=#= End test: Text output of partially active resources, with inactive resources - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of partially active resources, with inactive resources
 =#=#=#= Begin test: Text output of partially active resources, with inactive resources, filtered by node =#=#=#=
@@ -778,7 +778,7 @@ Full List of Resources:
     * Started: [ cluster01 ]
   * Fencing	(stonith:fence_xvm):	 Started cluster01
   * Container bundle set: httpd-bundle [pcmk:http]:
-    * httpd-bundle-1 (192.168.122.132)	(ocf::heartbeat:apache):	 Stopped
+    * httpd-bundle-1 (192.168.122.132)	(ocf::heartbeat:apache):	 Stopped cluster01
 =#=#=#= End test: Text output of partially active resources, with inactive resources, filtered by node - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of partially active resources, with inactive resources, filtered by node
 =#=#=#= Begin test: Text output of partially active resources, filtered by node =#=#=#=

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1563,9 +1563,8 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
 
 static void
 pe__bundle_replica_output_html(pcmk__output_t *out, pe__bundle_replica_t *replica,
-                               long options)
+                               pe_node_t *node, long options)
 {
-    pe_node_t *node = NULL;
     pe_resource_t *rsc = replica->child;
 
     int offset = 0;
@@ -1647,7 +1646,12 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
 
             out->end_list(out);
         } else {
-            pe__bundle_replica_output_html(out, replica, options);
+            if (pcmk__rsc_is_filtered(replica->container, only_show)) {
+                continue;
+            }
+
+            pe__bundle_replica_output_html(out, replica, pe__current_node(replica->container),
+                                           options);
         }
 
         pcmk__output_xml_pop_parent(out);
@@ -1659,9 +1663,8 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
 
 static void
 pe__bundle_replica_output_text(pcmk__output_t *out, pe__bundle_replica_t *replica,
-                               long options)
+                               pe_node_t *node, long options)
 {
-    pe_node_t *node = NULL;
     pe_resource_t *rsc = replica->child;
 
     int offset = 0;
@@ -1739,7 +1742,12 @@ pe__bundle_text(pcmk__output_t *out, va_list args)
 
             out->end_list(out);
         } else {
-            pe__bundle_replica_output_text(out, replica, options);
+            if (pcmk__rsc_is_filtered(replica->container, only_show)) {
+                continue;
+            }
+
+            pe__bundle_replica_output_text(out, replica, pe__current_node(replica->container),
+                                           options);
         }
     }
 


### PR DESCRIPTION
This regression was introduced by 037c8ece42dabc55f9ce19dc4b4c807ff70a7c9b.