### PR TITLE
Doc: pcmk_action_timeout update

### DIFF
--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -1407,13 +1407,13 @@ main(int argc, char **argv)
 
             printf("  <parameter name=\"pcmk_%s_timeout\" unique=\"0\">\n", actions[lpc]);
             printf
-                ("    <shortdesc lang=\"en\">Advanced use only: Specify an alternate timeout to use for %s actions instead of stonith-timeout</shortdesc>\n",
+                ("    <shortdesc lang=\"en\">Advanced use only: Specify an alternate timeout to use for %s actions instead of the default.</shortdesc>\n",
                  actions[lpc]);
             printf
                 ("    <longdesc lang=\"en\">Some devices need much more/less time to complete than normal.\n"
                  "Use this to specify an alternate, device-specific, timeout for '%s' actions.</longdesc>\n",
                  actions[lpc]);
-            printf("    <content type=\"time\" default=\"60s\"/>\n");
+            printf("    <content type=\"time\" default=\"%ds\"/>\n", safe_str_eq(actions[lpc], "monitor") ? 20 : 120);
             printf("  </parameter>\n");
 
             printf("  <parameter name=\"pcmk_%s_retries\" unique=\"0\">\n", actions[lpc]);

--- a/doc/Pacemaker_Explained/en-US/Ch-Fencing.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Fencing.txt
@@ -250,11 +250,10 @@ additional ones. Use this to specify an alternate, device-specific command.
 
 |pcmk_reboot_timeout
 |time
-|60s
+|120s
 |'Advanced use only.' Specify an alternate timeout to use for `reboot` actions
-instead of the value of +stonith-timeout+. Some devices need much more or less
-time to complete than normal. Use this to specify an alternate, device-specific
-timeout.
+instead of the default. Some devices need much more or less time to complete
+than normal. Use this to specify an alternate, device-specific timeout.
  indexterm:[pcmk_reboot_timeout,Fencing]
  indexterm:[Fencing,Property,pcmk_reboot_timeout]
  indexterm:[stonith-timeout,Fencing]
@@ -282,11 +281,10 @@ additional ones. Use this to specify an alternate, device-specific command.
 
 |pcmk_off_timeout
 |time
-|60s
+|120s
 |'Advanced use only.' Specify an alternate timeout to use for `off` actions
-instead of the value of +stonith-timeout+. Some devices need much more or less
-time to complete than normal. Use this to specify an alternate, device-specific
-timeout.
+instead of the default. Some devices need much more or less time to complete
+than normal. Use this to specify an alternate, device-specific timeout.
  indexterm:[pcmk_off_timeout,Fencing]
  indexterm:[Fencing,Property,pcmk_off_timeout]
  indexterm:[stonith-timeout,Fencing]
@@ -314,11 +312,10 @@ additional ones. Use this to specify an alternate, device-specific command.
 
 |pcmk_list_timeout
 |time
-|60s
+|120s
 |'Advanced use only.' Specify an alternate timeout to use for `list` actions
-instead of the value of +stonith-timeout+. Some devices need much more or less
-time to complete than normal. Use this to specify an alternate, device-specific
-timeout.
+instead of the default. Some devices need much more or less time to complete
+than normal. Use this to specify an alternate, device-specific timeout.
  indexterm:[pcmk_list_timeout,Fencing]
  indexterm:[Fencing,Property,pcmk_list_timeout]
 
@@ -344,11 +341,10 @@ additional ones. Use this to specify an alternate, device-specific command.
 
 |pcmk_monitor_timeout
 |time
-|60s
+|20s
 |'Advanced use only.' Specify an alternate timeout to use for `monitor` actions
-instead of the value of +stonith-timeout+. Some devices need much more or less
-time to complete than normal. Use this to specify an alternate, device-specific
-timeout.
+instead of the default. Some devices need much more or less time to complete
+than normal. Use this to specify an alternate, device-specific timeout.
  indexterm:[pcmk_monitor_timeout,Fencing]
  indexterm:[Fencing,Property,pcmk_monitor_timeout]
 
@@ -374,11 +370,10 @@ additional ones. Use this to specify an alternate, device-specific command.
 
 |pcmk_status_timeout
 |time
-|60s
+|120s
 |'Advanced use only.' Specify an alternate timeout to use for `status` actions
-instead of the value of +stonith-timeout+. Some devices need much more or less
-time to complete than normal. Use this to specify an alternate, device-specific
-timeout.
+instead of the default. Some devices need much more or less time to complete
+than normal. Use this to specify an alternate, device-specific timeout.
  indexterm:[pcmk_status_timeout,Fencing]
  indexterm:[Fencing,Property,pcmk_status_timeout]
 

--- a/doc/sphinx/Pacemaker_Explained/fencing.rst
+++ b/doc/sphinx/Pacemaker_Explained/fencing.rst
@@ -248,11 +248,10 @@ Fencing
    
    |pcmk_reboot_timeout
    |time
-   |60s
+   |120s
    |'Advanced use only.' Specify an alternate timeout to use for `reboot` actions
-   instead of the value of +stonith-timeout+. Some devices need much more or less
-   time to complete than normal. Use this to specify an alternate, device-specific
-   timeout.
+   instead of the default. Some devices need much more or less time to complete
+   than normal. Use this to specify an alternate, device-specific timeout.
     indexterm:[pcmk_reboot_timeout,Fencing]
     indexterm:[Fencing,Property,pcmk_reboot_timeout]
     indexterm:[stonith-timeout,Fencing]
@@ -280,11 +279,10 @@ Fencing
    
    |pcmk_off_timeout
    |time
-   |60s
+   |120s
    |'Advanced use only.' Specify an alternate timeout to use for `off` actions
-   instead of the value of +stonith-timeout+. Some devices need much more or less
-   time to complete than normal. Use this to specify an alternate, device-specific
-   timeout.
+   instead of the default. Some devices need much more or less time to complete
+   than normal. Use this to specify an alternate, device-specific timeout.
     indexterm:[pcmk_off_timeout,Fencing]
     indexterm:[Fencing,Property,pcmk_off_timeout]
     indexterm:[stonith-timeout,Fencing]
@@ -312,11 +310,10 @@ Fencing
    
    |pcmk_list_timeout
    |time
-   |60s
+   |120s
    |'Advanced use only.' Specify an alternate timeout to use for `list` actions
-   instead of the value of +stonith-timeout+. Some devices need much more or less
-   time to complete than normal. Use this to specify an alternate, device-specific
-   timeout.
+   instead of the default. Some devices need much more or less time to complete
+   than normal. Use this to specify an alternate, device-specific timeout.
     indexterm:[pcmk_list_timeout,Fencing]
     indexterm:[Fencing,Property,pcmk_list_timeout]
    
@@ -342,11 +339,10 @@ Fencing
    
    |pcmk_monitor_timeout
    |time
-   |60s
+   |20s
    |'Advanced use only.' Specify an alternate timeout to use for `monitor` actions
-   instead of the value of +stonith-timeout+. Some devices need much more or less
-   time to complete than normal. Use this to specify an alternate, device-specific
-   timeout.
+   instead of the default. Some devices need much more or less time to complete
+   than normal. Use this to specify an alternate, device-specific timeout.
     indexterm:[pcmk_monitor_timeout,Fencing]
     indexterm:[Fencing,Property,pcmk_monitor_timeout]
    
@@ -372,11 +368,10 @@ Fencing
    
    |pcmk_status_timeout
    |time
-   |60s
+   |120s
    |'Advanced use only.' Specify an alternate timeout to use for `status` actions
-   instead of the value of +stonith-timeout+. Some devices need much more or less
-   time to complete than normal. Use this to specify an alternate, device-specific
-   timeout.
+   instead of the default. Some devices need much more or less time to complete
+   than normal. Use this to specify an alternate, device-specific timeout.
     indexterm:[pcmk_status_timeout,Fencing]
     indexterm:[Fencing,Property,pcmk_status_timeout]
    


### PR DESCRIPTION
The default `pcmk_<action>_timeout` values listed in the doc are
incorrect in my experience. The monitor timeout defaults to 20s, and all
the rest default to 120s.

Also, `lib/pengine/common.c` states that `stonith-timeout` is now
unused. If so, then `pcmk_<action>_timeout` shouldn't be described as
an alternative or override to `stonith-timeout`.