### PR TITLE
Fix: libpe_status: Use pcmk_monitor_timeout for stonith start timeout

### DIFF
--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -144,6 +144,7 @@ enum pcmk_ra_caps {
     pcmk_ra_cap_unique       = (1 << 3), // Supports unique clones
     pcmk_ra_cap_promotable   = (1 << 4), // Supports promotable clones
     pcmk_ra_cap_stdin        = (1 << 5), // Reads from standard input
+    pcmk_ra_cap_fence_params = (1 << 6), // Supports pcmk_monitor_timeout, etc.
 };
 
 uint32_t pcmk_get_ra_caps(const char *standard);

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -51,7 +51,7 @@ extern "C" {
  * >=3.0.13: Fail counts include operation name and interval
  * >=3.2.0:  DC supports PCMK_LRM_OP_INVALID and PCMK_LRM_OP_NOT_CONNECTED
  */
-#  define CRM_FEATURE_SET		"3.5.0"
+#  define CRM_FEATURE_SET		"3.6.0"
 
 #  define EOS		'\0'
 #  define DIMOF(a)	((int) (sizeof(a)/sizeof(a[0])) )

--- a/lib/common/agents.c
+++ b/lib/common/agents.c
@@ -48,7 +48,8 @@ pcmk_get_ra_caps(const char *standard)
          * @TODO Remove pcmk_ra_cap_unique at the next major schema version
          * bump, with a transform to remove globally-unique from the config.
          */
-        return pcmk_ra_cap_params | pcmk_ra_cap_unique | pcmk_ra_cap_stdin;
+        return pcmk_ra_cap_params | pcmk_ra_cap_unique | pcmk_ra_cap_stdin
+               | pcmk_ra_cap_fence_params;
 
     } else if (!strcasecmp(standard, PCMK_RESOURCE_CLASS_SYSTEMD)
                || !strcasecmp(standard, PCMK_RESOURCE_CLASS_SERVICE)

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1078,7 +1078,8 @@ unpack_operation(pe_action_t * action, xmlNode * xml_obj, pe_resource_t * contai
 
     } else {
         // Probe timeouts default to minimum-interval monitor's
-        if (pcmk__str_eq(action->task, RSC_STATUS, pcmk__str_casei) && (interval_ms == 0)) {
+        if (pcmk__str_eq(action->task, RSC_STATUS, pcmk__str_casei)
+                && (interval_ms == 0)) {
 
             xmlNode *min_interval_mon = find_min_interval_mon(action->rsc, FALSE);
 
@@ -1098,6 +1099,11 @@ unpack_operation(pe_action_t * action, xmlNode * xml_obj, pe_resource_t * contai
                                 default_timeout);
         }
     }
+
+    value = g_hash_table_lookup(action->meta, XML_ATTR_TIMEOUT);
+    timeout = unpack_timeout(value);
+    g_hash_table_replace(action->meta, strdup(XML_ATTR_TIMEOUT),
+                         crm_itoa(timeout));
 
     if (!pcmk__strcase_any_of(action->task, RSC_START, RSC_PROMOTE, NULL)) {
         action->needs = rsc_req_nothing;
@@ -1267,10 +1273,6 @@ unpack_operation(pe_action_t * action, xmlNode * xml_obj, pe_resource_t * contai
                                  crm_strdup_printf("%lld", start_delay));
         }
     }
-
-    value = g_hash_table_lookup(action->meta, XML_ATTR_TIMEOUT);
-    timeout = unpack_timeout(value);
-    g_hash_table_replace(action->meta, strdup(XML_ATTR_TIMEOUT), crm_itoa(timeout));
 
 #if ENABLE_VERSIONED_ATTRS
     unpack_versioned_meta(rsc_details->versioned_meta, xml_obj, interval_ms,

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -990,7 +990,6 @@ unpack_operation(pe_action_t * action, xmlNode * xml_obj, pe_resource_t * contai
                  pe_working_set_t * data_set, guint interval_ms)
 {
     int timeout_ms = 0;
-    char *value_ms = NULL;
     const char *value = NULL;
     const char *field = XML_LRM_ATTR_INTERVAL;
     char *default_timeout_spec = NULL;
@@ -1066,10 +1065,9 @@ unpack_operation(pe_action_t * action, xmlNode * xml_obj, pe_resource_t * contai
 
     // Normalize interval to milliseconds
     if (interval_ms > 0) {
-        value_ms = crm_strdup_printf("%u", interval_ms);
-        g_hash_table_replace(action->meta, strdup(field), value_ms);
-
-    } else if (g_hash_table_lookup(action->meta, field) != NULL) {
+        g_hash_table_replace(action->meta, strdup(field),
+                             crm_strdup_printf("%u", interval_ms));
+    } else {
         g_hash_table_remove(action->meta, field);
     }
 


### PR DESCRIPTION
`pcmk_monitor_timeout` is applied partially to stonith monitor ops but
not to stonith start ops. Start ops use the op timeout
(`CRM_meta_timeout`) even though they perform monitor actions.

For both monitor and start, if an op times out, the "Result of" error
message says the timeout was equal to the meta timeout (default:
20000ms).

This patch overrides the `CRM_meta_timeout` with the
`pcmk_monitor_timeout` for stonith start and monitor actions.

Resolves: RHBZ#1856015
Related to: RHBZ#1677345