### PR TITLE
Fix: libs: Remove the superfluous break

### DIFF
--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1430,7 +1430,6 @@ get_complex_task(pe_resource_t * rsc, const char *name, gboolean allow_non_atomi
             case action_promoted:
                 crm_trace("Folding %s back into its atomic counterpart for %s", name, rsc->id);
                 return task - 1;
-                break;
             default:
                 break;
         }


### PR DESCRIPTION
Remove the superfuous break, as there is a 'return' before it.

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>