### PR TITLE
Fix: libcluster: Remove the superfluous break

### DIFF
--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -365,7 +365,6 @@ init_cs_connection(crm_cluster_t * cluster)
         switch (rc) {
             case CS_OK:
                 return TRUE;
-                break;
             case CS_ERR_TRY_AGAIN:
             case CS_ERR_QUEUE_FULL:
                 sleep(retries);


### PR DESCRIPTION
Remove the superfuous break, as there is a 'return' before it.

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>