### PR TITLE
Fix: controller: Remove the superfluous break

### DIFF
--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -52,7 +52,6 @@ te_graph_trigger(gpointer user_data)
         case S_STOPPING:
         case S_TERMINATE:
             return TRUE;
-            break;
         default:
             break;
     }


### PR DESCRIPTION
Remove the superfuous break, as there is a 'return' before it.

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>