### PR TITLE
Log: controld: improve messages indicating execution result of RA

### DIFF
--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -343,6 +343,7 @@ process_graph_event(xmlNode *event, const char *event_node)
     const char *desc = NULL;
     const char *magic = NULL;
     const char *uname = NULL;
+    const char *operation = NULL;
 
     CRM_ASSERT(event != NULL);
 
@@ -455,6 +456,10 @@ process_graph_event(xmlNode *event, const char *event_node)
         }
     }
 
+    operation = crm_element_value(event, XML_LRM_ATTR_TASK);
+    if (!strcmp(operation, CRMD_ACTION_NOTIFY)) {
+        id = crm_element_value(event, XML_ATTR_ID);
+    }
     if (id == NULL) {
         id = "unknown action";
     }
@@ -465,40 +470,39 @@ process_graph_event(xmlNode *event, const char *event_node)
 
     if (status == PCMK_LRM_OP_INVALID) {
         // We couldn't attempt the action
-        crm_info("Transition %d action %d (%s on %s): %s",
-                 transition_num, action_num, id, uname,
-                 services_lrm_status_str(status));
+        crm_notice("Received result operation %s on %s: %s (rc=%d) "
+                   CRM_XS " Transition %d action %d target-rc=%d call-id=%d",
+                   id, uname, services_lrm_status_str(status), rc,
+                   transition_num, action_num, target_rc, callid);
 
     } else if (desc && update_failcount(event, event_node, rc, target_rc,
                                         (transition_num == -1), FALSE)) {
-        crm_notice("Transition %d action %d (%s on %s): expected '%s' but got '%s' "
-                   CRM_XS " target-rc=%d rc=%d call-id=%d event='%s'",
-                   transition_num, action_num, id, uname,
-                   services_ocf_exitcode_str(target_rc),
-                   services_ocf_exitcode_str(rc),
-                   target_rc, rc, callid, desc);
+        crm_notice("Received result operation %s on %s: %s (rc=%d) "
+                   CRM_XS " Transition %d action %d target-rc=%d call-id=%d event='%s'",
+                   id, uname, status == PCMK_LRM_OP_DONE ?
+                       services_ocf_exitcode_str(rc) : services_lrm_status_str(status), rc,
+                   transition_num, action_num, target_rc, callid, desc);
 
     } else if (desc) {
-        crm_info("Transition %d action %d (%s on %s): %s "
-                 CRM_XS " rc=%d target-rc=%d call-id=%d",
-                 transition_num, action_num, id, uname,
-                 desc, rc, target_rc, callid);
+        crm_info("Received result operation %s on %s: %s (rc=%d) "
+                 CRM_XS " Transition %d action %d target-rc=%d call-id=%d event='%s'",
+                 id, uname, services_ocf_exitcode_str(rc), rc,
+                 transition_num, action_num, target_rc, callid, desc);
 
     } else if (rc == target_rc) {
-        crm_info("Transition %d action %d (%s on %s) confirmed: %s "
-                 CRM_XS " rc=%d call-id=%d",
-                 transition_num, action_num, id, uname,
-                 services_ocf_exitcode_str(rc), rc, callid);
+        crm_notice("Received result operation %s on %s: %s (rc=%d) "
+                   CRM_XS " Transition %d action %d call-id=%d",
+                   id, uname, services_ocf_exitcode_str(rc), rc,
+                   transition_num, action_num, callid);
 
     } else {
         update_failcount(event, event_node, rc, target_rc,
                          (transition_num == -1), ignore_failures);
-        crm_notice("Transition %d action %d (%s on %s): expected '%s' but got '%s' "
-                   CRM_XS " target-rc=%d rc=%d call-id=%d",
-                   transition_num, action_num, id, uname,
-                   services_ocf_exitcode_str(target_rc),
-                   services_ocf_exitcode_str(rc),
-                   target_rc, rc, callid);
+        crm_notice("Received result operation %s on %s: %s (rc=%d) "
+                   CRM_XS " Transition %d action %d target-rc=%d call-id=%d",
+                   id, uname, status == PCMK_LRM_OP_DONE ?
+                       services_ocf_exitcode_str(rc) : services_lrm_status_str(status), rc,
+                   transition_num, action_num, target_rc, callid);
     }
 
   bail:

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -457,7 +457,7 @@ process_graph_event(xmlNode *event, const char *event_node)
     }
 
     operation = crm_element_value(event, XML_LRM_ATTR_TASK);
-    if (!strcmp(operation, CRMD_ACTION_NOTIFY)) {
+    if (safe_str_eq(operation, CRMD_ACTION_NOTIFY)) {
         id = crm_element_value(event, XML_ATTR_ID);
     }
     if (id == NULL) {
@@ -470,39 +470,39 @@ process_graph_event(xmlNode *event, const char *event_node)
 
     if (status == PCMK_LRM_OP_INVALID) {
         // We couldn't attempt the action
-        crm_notice("Received result operation %s on %s: %s (rc=%d) "
-                   CRM_XS " Transition %d action %d target-rc=%d call-id=%d",
-                   id, uname, services_lrm_status_str(status), rc,
-                   transition_num, action_num, target_rc, callid);
+        crm_notice("Result of operation %s on %s: %s "
+                   CRM_XS " Transition %d action %d target-rc=%d rc=%d call-id=%d",
+                   id, uname, services_lrm_status_str(status),
+                   transition_num, action_num, target_rc, rc, callid);
 
     } else if (desc && update_failcount(event, event_node, rc, target_rc,
                                         (transition_num == -1), FALSE)) {
-        crm_notice("Received result operation %s on %s: %s (rc=%d) "
-                   CRM_XS " Transition %d action %d target-rc=%d call-id=%d event='%s'",
+        crm_notice("Result of operation %s on %s: %s "
+                   CRM_XS " Transition %d action %d target-rc=%d rc=%d call-id=%d event='%s'",
                    id, uname, status == PCMK_LRM_OP_DONE ?
-                       services_ocf_exitcode_str(rc) : services_lrm_status_str(status), rc,
-                   transition_num, action_num, target_rc, callid, desc);
+                       services_ocf_exitcode_str(rc) : services_lrm_status_str(status),
+                   transition_num, action_num, target_rc, rc, callid, desc);
 
     } else if (desc) {
-        crm_info("Received result operation %s on %s: %s (rc=%d) "
-                 CRM_XS " Transition %d action %d target-rc=%d call-id=%d event='%s'",
-                 id, uname, services_ocf_exitcode_str(rc), rc,
-                 transition_num, action_num, target_rc, callid, desc);
+        crm_info("Result of operation %s on %s: %s "
+                 CRM_XS " Transition %d action %d target-rc=%d rc=%d call-id=%d event='%s'",
+                 id, uname, services_ocf_exitcode_str(rc),
+                 transition_num, action_num, target_rc, rc, callid, desc);
 
     } else if (rc == target_rc) {
-        crm_notice("Received result operation %s on %s: %s (rc=%d) "
-                   CRM_XS " Transition %d action %d call-id=%d",
-                   id, uname, services_ocf_exitcode_str(rc), rc,
-                   transition_num, action_num, callid);
+        crm_notice("Result of operation %s on %s: %s "
+                   CRM_XS " Transition %d action %d rc=%d call-id=%d",
+                   id, uname, services_ocf_exitcode_str(rc),
+                   transition_num, action_num, rc, callid);
 
     } else {
         update_failcount(event, event_node, rc, target_rc,
                          (transition_num == -1), ignore_failures);
-        crm_notice("Received result operation %s on %s: %s (rc=%d) "
-                   CRM_XS " Transition %d action %d target-rc=%d call-id=%d",
+        crm_notice("Result of operation %s on %s: %s "
+                   CRM_XS " Transition %d action %d target-rc=%d rc=%d call-id=%d",
                    id, uname, status == PCMK_LRM_OP_DONE ?
-                       services_ocf_exitcode_str(rc) : services_lrm_status_str(status), rc,
-                   transition_num, action_num, target_rc, callid);
+                       services_ocf_exitcode_str(rc) : services_lrm_status_str(status),
+                   transition_num, action_num, target_rc, rc, callid);
     }
 
   bail:


### PR DESCRIPTION
This change results in a log in the DC's syslog indicating the **end** of RA execution.
As a result, the **start** and **end** logs are output in DC, making it easier for the user to verify.

For more information on how this log was targeted for change, see
https://lists.clusterlabs.org/pipermail/users/2020-July/027344.html

* RA execution: ok
```
(in syslog)
Jul 14 15:05:39 r81-2 pacemaker-controld[20253]:
 notice: Received result operation dummy1_start_0 on r81-1: ok (rc=0)

(in detail log)
Jul 14 15:05:39 r81-2 pacemaker-controld  [20253] (process_graph_event)
 notice: Received result operation dummy1_start_0 on r81-1: ok (rc=0) | Transition 1 action 7 call-id=10
```
* RA execution: error (Time Out)
```
(in syslog)
Jul 14 15:21:38 r81-2 pacemaker-controld[10998]:
 notice: Received result operation dummy1_start_0 on r81-1: Timed Out (rc=1)

(in detail log)
Jul 14 15:21:38 r81-2 pacemaker-controld  [10998] (process_graph_event)
 notice: Received result operation dummy1_start_0 on r81-1: Timed Out (rc=1) | Transition 3 action 3 target-rc=0 call-id=6
```
The reason for outputting **rc** is that some users consider it important.

Also, by matching the **operation**(```<resourceID>_<action>_<interval>```), I think it is easy to recognize that it is a pair of start and end.
```
# grep -e Initiating -e Received /var/logmessages
Jul 14 17:01:50 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation filesystem1_monitor_0 locally on r81-2
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation filesystem1_monitor_0 on r81-1
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation filesystem2_monitor_0 locally on r81-2
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation filesystem2_monitor_0 on r81-1
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation filesystem2_monitor_0 on r81-1: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation filesystem3_monitor_0 on r81-1
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation filesystem1_monitor_0 on r81-1: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation ipaddr_monitor_0 on r81-1
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation filesystem2_monitor_0 on r81-2: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation filesystem3_monitor_0 locally on r81-2
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation filesystem1_monitor_0 on r81-2: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation ipaddr_monitor_0 locally on r81-2
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation filesystem3_monitor_0 on r81-1: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation pgsql_monitor_0 on r81-1
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation filesystem3_monitor_0 on r81-2: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation pgsql_monitor_0 locally on r81-2
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation ipaddr_monitor_0 on r81-1: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation ping:0_monitor_0 on r81-1
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation ipaddr_monitor_0 on r81-2: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation ping:1_monitor_0 locally on r81-2
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation ping_monitor_0 on r81-1: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation fence1-ipmilan_monitor_0 on r81-1
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation ping_monitor_0 on r81-2: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation fence1-ipmilan_monitor_0 locally on r81-2
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation fence1-ipmilan_monitor_0 on r81-1: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation pgsql_monitor_0 on r81-1: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation fence1-ipmilan_monitor_0 on r81-2: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating start operation ping:0_start_0 on r81-1
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating start operation ping:1_start_0 locally on r81-2
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation fence2-ipmilan_monitor_0 on r81-1
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation fence2-ipmilan_monitor_0 on r81-1: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation pgsql_monitor_0 on r81-2: not running (rc=7)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating start operation fence1-ipmilan_start_0 locally on r81-2
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Received result operation fence1-ipmilan_start_0 on r81-2: ok (rc=0)
Jul 14 17:01:51 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation fence1-ipmilan_monitor_3600000 locally on r81-2
Jul 14 17:01:52 r81-2 pacemaker-controld[15629]: notice: Received result operation fence1-ipmilan_monitor_3600000 on r81-2: ok (rc=0)
Jul 14 17:01:52 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation fence2-ipmilan_monitor_0 locally on r81-2
Jul 14 17:01:52 r81-2 pacemaker-controld[15629]: notice: Received result operation fence2-ipmilan_monitor_0 on r81-2: not running (rc=7)
Jul 14 17:01:52 r81-2 pacemaker-controld[15629]: notice: Initiating start operation fence2-ipmilan_start_0 on r81-1
Jul 14 17:01:52 r81-2 pacemaker-controld[15629]: notice: Received result operation fence2-ipmilan_start_0 on r81-1: ok (rc=0)
Jul 14 17:01:52 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation fence2-ipmilan_monitor_3600000 on r81-1
Jul 14 17:01:52 r81-2 pacemaker-controld[15629]: notice: Received result operation fence2-ipmilan_monitor_3600000 on r81-1: ok (rc=0)
Jul 14 17:01:52 r81-2 pacemaker-controld[15629]: notice: Received result operation ping_start_0 on r81-1: ok (rc=0)
Jul 14 17:01:52 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation ping:0_monitor_10000 on r81-1
Jul 14 17:01:52 r81-2 pacemaker-controld[15629]: notice: Received result operation ping_start_0 on r81-2: ok (rc=0)
Jul 14 17:01:52 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation ping:1_monitor_10000 locally on r81-2
Jul 14 17:01:53 r81-2 pacemaker-controld[15629]: notice: Received result operation ping_monitor_10000 on r81-1: ok (rc=0)
Jul 14 17:01:53 r81-2 pacemaker-controld[15629]: notice: Received result operation ping_monitor_10000 on r81-2: ok (rc=0)
Jul 14 17:01:57 r81-2 pacemaker-controld[15629]: notice: Initiating start operation filesystem1_start_0 on r81-1
Jul 14 17:01:58 r81-2 pacemaker-controld[15629]: notice: Received result operation filesystem1_start_0 on r81-1: ok (rc=0)
Jul 14 17:01:58 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation filesystem1_monitor_10000 on r81-1
Jul 14 17:01:58 r81-2 pacemaker-controld[15629]: notice: Initiating start operation filesystem2_start_0 on r81-1
Jul 14 17:01:58 r81-2 pacemaker-controld[15629]: notice: Received result operation filesystem1_monitor_10000 on r81-1: ok (rc=0)
Jul 14 17:01:58 r81-2 pacemaker-controld[15629]: notice: Received result operation filesystem2_start_0 on r81-1: ok (rc=0)
Jul 14 17:01:58 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation filesystem2_monitor_10000 on r81-1
Jul 14 17:01:58 r81-2 pacemaker-controld[15629]: notice: Initiating start operation filesystem3_start_0 on r81-1
Jul 14 17:01:58 r81-2 pacemaker-controld[15629]: notice: Received result operation filesystem2_monitor_10000 on r81-1: ok (rc=0)
Jul 14 17:01:58 r81-2 pacemaker-controld[15629]: notice: Received result operation filesystem3_start_0 on r81-1: ok (rc=0)
Jul 14 17:01:58 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation filesystem3_monitor_10000 on r81-1
Jul 14 17:01:58 r81-2 pacemaker-controld[15629]: notice: Initiating start operation ipaddr_start_0 on r81-1
Jul 14 17:01:59 r81-2 pacemaker-controld[15629]: notice: Received result operation filesystem3_monitor_10000 on r81-1: ok (rc=0)
Jul 14 17:01:59 r81-2 pacemaker-controld[15629]: notice: Received result operation ipaddr_start_0 on r81-1: ok (rc=0)
Jul 14 17:01:59 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation ipaddr_monitor_10000 on r81-1
Jul 14 17:01:59 r81-2 pacemaker-controld[15629]: notice: Initiating start operation pgsql_start_0 on r81-1
Jul 14 17:01:59 r81-2 pacemaker-controld[15629]: notice: Received result operation ipaddr_monitor_10000 on r81-1: ok (rc=0)
Jul 14 17:02:00 r81-2 pacemaker-controld[15629]: notice: Received result operation pgsql_start_0 on r81-1: ok (rc=0)
Jul 14 17:02:00 r81-2 pacemaker-controld[15629]: notice: Initiating monitor operation pgsql_monitor_10000 on r81-1
Jul 14 17:02:00 r81-2 pacemaker-controld[15629]: notice: Received result operation pgsql_monitor_10000 on r81-1: ok (rc=0)
```
 * If possible, I would like to align the subscripts (ping```:0```, ping```:1```) as well...