### PR TITLE
Fix: Remove superfluous breaks

### DIFF
--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -52,7 +52,6 @@ te_graph_trigger(gpointer user_data)
         case S_STOPPING:
         case S_TERMINATE:
             return TRUE;
-            break;
         default:
             break;
     }

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -365,7 +365,6 @@ init_cs_connection(crm_cluster_t * cluster)
         switch (rc) {
             case CS_OK:
                 return TRUE;
-                break;
             case CS_ERR_TRY_AGAIN:
             case CS_ERR_QUEUE_FULL:
                 sleep(retries);

--- a/lib/common/operations.c
+++ b/lib/common/operations.c
@@ -343,7 +343,6 @@ did_rsc_op_fail(lrmd_event_data_t * op, int target_rc)
         case PCMK_LRM_OP_CANCELLED:
         case PCMK_LRM_OP_PENDING:
             return FALSE;
-            break;
 
         case PCMK_LRM_OP_NOTSUPPORTED:
         case PCMK_LRM_OP_TIMEOUT:
@@ -351,7 +350,6 @@ did_rsc_op_fail(lrmd_event_data_t * op, int target_rc)
         case PCMK_LRM_OP_NOT_CONNECTED:
         case PCMK_LRM_OP_INVALID:
             return TRUE;
-            break;
 
         default:
             if (target_rc != op->rc) {

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -806,11 +806,9 @@ lrmd_api_is_connected(lrmd_t * lrmd)
     switch (native->type) {
         case PCMK__CLIENT_IPC:
             return crm_ipc_connected(native->ipc);
-            break;
 #ifdef HAVE_GNUTLS_GNUTLS_H
         case PCMK__CLIENT_TLS:
             return lrmd_tls_connected(lrmd);
-            break;
 #endif
         default:
             crm_err("Unsupported connection type: %d", native->type);

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1469,7 +1469,6 @@ get_complex_task(pe_resource_t * rsc, const char *name, gboolean allow_non_atomi
             case action_promoted:
                 crm_trace("Folding %s back into its atomic counterpart for %s", name, rsc->id);
                 return task - 1;
-                break;
             default:
                 break;
         }

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -146,22 +146,18 @@ default_includes(mon_output_format_t fmt) {
         case mon_output_console:
             return mon_show_stack | mon_show_dc | mon_show_times | mon_show_counts |
                    mon_show_nodes | mon_show_resources | mon_show_failures;
-            break;
 
         case mon_output_xml:
         case mon_output_legacy_xml:
             return all_includes(fmt);
-            break;
 
         case mon_output_html:
         case mon_output_cgi:
             return mon_show_summary | mon_show_nodes | mon_show_resources |
                    mon_show_failures;
-            break;
 
         default:
             return 0;
-            break;
     }
 }
 


### PR DESCRIPTION
Remove superfluous breaks, as there is a "return" before them.

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>