### PR TITLE
 Fix: libcrmcommon: Use truly implicit deny for ACLs

### DIFF
--- a/cts/cli/regression.acls.exp
+++ b/cts/cli/regression.acls.exp
@@ -20,6 +20,15 @@ A new shadow instance was created.  To begin using it paste the following into y
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -28,6 +37,17 @@ A new shadow instance was created.  To begin using it paste the following into y
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
     </acls>
   </configuration>
@@ -57,6 +77,15 @@ A new shadow instance was created.  To begin using it paste the following into y
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -65,6 +94,17 @@ A new shadow instance was created.  To begin using it paste the following into y
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
     </acls>
   </configuration>
@@ -95,6 +135,15 @@ A new shadow instance was created.  To begin using it paste the following into y
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -103,6 +152,17 @@ A new shadow instance was created.  To begin using it paste the following into y
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
     </acls>
   </configuration>
@@ -133,6 +193,15 @@ A new shadow instance was created.  To begin using it paste the following into y
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -141,6 +210,17 @@ A new shadow instance was created.  To begin using it paste the following into y
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -174,6 +254,15 @@ A new shadow instance was created.  To begin using it paste the following into y
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -182,6 +271,17 @@ A new shadow instance was created.  To begin using it paste the following into y
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -218,6 +318,15 @@ A new shadow instance was created.  To begin using it paste the following into y
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -226,6 +335,17 @@ A new shadow instance was created.  To begin using it paste the following into y
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -301,6 +421,15 @@ Call failed: Permission denied
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -309,6 +438,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -354,6 +494,15 @@ pcmk__apply_creation_acl 	trace: ACLs allow creation of <nvpair> with id="cib-bo
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -362,6 +511,17 @@ pcmk__apply_creation_acl 	trace: ACLs allow creation of <nvpair> with id="cib-bo
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -405,6 +565,15 @@ Call failed: Permission denied
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -413,6 +582,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -451,6 +631,15 @@ Call failed: Permission denied
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -459,6 +648,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -499,6 +699,15 @@ Call failed: Permission denied
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -507,6 +716,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -569,6 +789,15 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -577,6 +806,17 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -625,6 +865,15 @@ Stopped
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -633,6 +882,17 @@ Stopped
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -679,6 +939,15 @@ Deleted 'dummy' option: id=dummy-meta_attributes-target-role name=target-role
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -687,6 +956,17 @@ Deleted 'dummy' option: id=dummy-meta_attributes-target-role name=target-role
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -736,6 +1016,15 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -744,6 +1033,17 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -842,6 +1142,15 @@ Call failed: Permission denied
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -850,6 +1159,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -897,6 +1217,15 @@ Call failed: Permission denied
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -905,6 +1234,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -951,6 +1291,15 @@ Call failed: Permission denied
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -959,6 +1308,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -1005,6 +1365,15 @@ Call failed: Permission denied
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1013,6 +1382,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -1059,6 +1439,15 @@ Call failed: Permission denied
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1067,6 +1456,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -1079,9 +1479,9 @@ Call failed: Permission denied
   </configuration>
   <status/>
 </cib>
-=#=#=#= Begin test: bob: Replace - create attribute (allow) =#=#=#=
-=#=#=#= End test: bob: Replace - create attribute (allow) - OK (0) =#=#=#=
-* Passed: cibadmin       - bob: Replace - create attribute (allow)
+=#=#=#= Begin test: bob: Replace - create attribute (direct allow) =#=#=#=
+=#=#=#= End test: bob: Replace - create attribute (direct allow) - OK (0) =#=#=#=
+* Passed: cibadmin       - bob: Replace - create attribute (direct allow)
 <cib epoch="14" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
@@ -1110,6 +1510,15 @@ Call failed: Permission denied
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1118,6 +1527,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -1130,9 +1550,9 @@ Call failed: Permission denied
   </configuration>
   <status/>
 </cib>
-=#=#=#= Begin test: bob: Replace - modify attribute (allow) =#=#=#=
-=#=#=#= End test: bob: Replace - modify attribute (allow) - OK (0) =#=#=#=
-* Passed: cibadmin       - bob: Replace - modify attribute (allow)
+=#=#=#= Begin test: bob: Replace - modify attribute (direct allow) =#=#=#=
+=#=#=#= End test: bob: Replace - modify attribute (direct allow) - OK (0) =#=#=#=
+* Passed: cibadmin       - bob: Replace - modify attribute (direct allow)
 <cib epoch="15" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
@@ -1157,6 +1577,15 @@ Call failed: Permission denied
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1165,6 +1594,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
       <acl_user id="badidea">
         <read id="badidea-resources" xpath="//meta_attributes"/>
@@ -1177,9 +1617,618 @@ Call failed: Permission denied
   </configuration>
   <status/>
 </cib>
-=#=#=#= Begin test: bob: Replace - delete attribute (allow) =#=#=#=
-=#=#=#= End test: bob: Replace - delete attribute (allow) - OK (0) =#=#=#=
-* Passed: cibadmin       - bob: Replace - delete attribute (allow)
+=#=#=#= Begin test: bob: Replace - delete attribute (direct allow) =#=#=#=
+=#=#=#= End test: bob: Replace - delete attribute (direct allow) - OK (0) =#=#=#=
+* Passed: cibadmin       - bob: Replace - delete attribute (direct allow)
+<cib epoch="16" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="nothing interesting"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_user id="l33t-haxor">
+        <deny id="crook-nothing" xpath="/cib"/>
+      </acl_user>
+      <acl_user id="niceguy">
+        <role_ref id="observer"/>
+      </acl_user>
+      <acl_user id="bob">
+        <role_ref id="admin"/>
+      </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
+      <acl_role id="observer">
+        <read id="observer-read-1" xpath="/cib"/>
+        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <read id="admin-read-1" xpath="/cib"/>
+        <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
+      </acl_role>
+      <acl_user id="badidea">
+        <read id="badidea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+      <acl_user id="betteridea">
+        <deny id="betteridea-nothing" xpath="/cib"/>
+        <read id="betteridea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: joe: Replace - create attribute (inherited allow) =#=#=#=
+=#=#=#= End test: joe: Replace - create attribute (inherited allow) - OK (0) =#=#=#=
+* Passed: cibadmin       - joe: Replace - create attribute (inherited allow)
+<cib epoch="17" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="something interesting"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_user id="l33t-haxor">
+        <deny id="crook-nothing" xpath="/cib"/>
+      </acl_user>
+      <acl_user id="niceguy">
+        <role_ref id="observer"/>
+      </acl_user>
+      <acl_user id="bob">
+        <role_ref id="admin"/>
+      </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
+      <acl_role id="observer">
+        <read id="observer-read-1" xpath="/cib"/>
+        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <read id="admin-read-1" xpath="/cib"/>
+        <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
+      </acl_role>
+      <acl_user id="badidea">
+        <read id="badidea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+      <acl_user id="betteridea">
+        <deny id="betteridea-nothing" xpath="/cib"/>
+        <read id="betteridea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: joe: Replace - modify attribute (inherited allow) =#=#=#=
+=#=#=#= End test: joe: Replace - modify attribute (inherited allow) - OK (0) =#=#=#=
+* Passed: cibadmin       - joe: Replace - modify attribute (inherited allow)
+<cib epoch="18" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_user id="l33t-haxor">
+        <deny id="crook-nothing" xpath="/cib"/>
+      </acl_user>
+      <acl_user id="niceguy">
+        <role_ref id="observer"/>
+      </acl_user>
+      <acl_user id="bob">
+        <role_ref id="admin"/>
+      </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
+      <acl_role id="observer">
+        <read id="observer-read-1" xpath="/cib"/>
+        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <read id="admin-read-1" xpath="/cib"/>
+        <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
+      </acl_role>
+      <acl_user id="badidea">
+        <read id="badidea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+      <acl_user id="betteridea">
+        <deny id="betteridea-nothing" xpath="/cib"/>
+        <read id="betteridea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: joe: Replace - delete attribute (inherited allow) =#=#=#=
+=#=#=#= End test: joe: Replace - delete attribute (inherited allow) - OK (0) =#=#=#=
+* Passed: cibadmin       - joe: Replace - delete attribute (inherited allow)
+<cib epoch="19" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="nothing interesting"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_user id="l33t-haxor">
+        <deny id="crook-nothing" xpath="/cib"/>
+      </acl_user>
+      <acl_user id="niceguy">
+        <role_ref id="observer"/>
+      </acl_user>
+      <acl_user id="bob">
+        <role_ref id="admin"/>
+      </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
+      <acl_role id="observer">
+        <read id="observer-read-1" xpath="/cib"/>
+        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <read id="admin-read-1" xpath="/cib"/>
+        <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
+      </acl_role>
+      <acl_user id="badidea">
+        <read id="badidea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+      <acl_user id="betteridea">
+        <deny id="betteridea-nothing" xpath="/cib"/>
+        <read id="betteridea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: mike: Replace - create attribute (allow overrides deny) =#=#=#=
+=#=#=#= End test: mike: Replace - create attribute (allow overrides deny) - OK (0) =#=#=#=
+* Passed: cibadmin       - mike: Replace - create attribute (allow overrides deny)
+<cib epoch="20" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="something interesting"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_user id="l33t-haxor">
+        <deny id="crook-nothing" xpath="/cib"/>
+      </acl_user>
+      <acl_user id="niceguy">
+        <role_ref id="observer"/>
+      </acl_user>
+      <acl_user id="bob">
+        <role_ref id="admin"/>
+      </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
+      <acl_role id="observer">
+        <read id="observer-read-1" xpath="/cib"/>
+        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <read id="admin-read-1" xpath="/cib"/>
+        <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
+      </acl_role>
+      <acl_user id="badidea">
+        <read id="badidea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+      <acl_user id="betteridea">
+        <deny id="betteridea-nothing" xpath="/cib"/>
+        <read id="betteridea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: mike: Replace - modify attribute (allow overrides deny) =#=#=#=
+=#=#=#= End test: mike: Replace - modify attribute (allow overrides deny) - OK (0) =#=#=#=
+* Passed: cibadmin       - mike: Replace - modify attribute (allow overrides deny)
+<cib epoch="21" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_user id="l33t-haxor">
+        <deny id="crook-nothing" xpath="/cib"/>
+      </acl_user>
+      <acl_user id="niceguy">
+        <role_ref id="observer"/>
+      </acl_user>
+      <acl_user id="bob">
+        <role_ref id="admin"/>
+      </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
+      <acl_role id="observer">
+        <read id="observer-read-1" xpath="/cib"/>
+        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <read id="admin-read-1" xpath="/cib"/>
+        <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
+      </acl_role>
+      <acl_user id="badidea">
+        <read id="badidea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+      <acl_user id="betteridea">
+        <deny id="betteridea-nothing" xpath="/cib"/>
+        <read id="betteridea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: mike: Replace - delete attribute (allow overrides deny) =#=#=#=
+=#=#=#= End test: mike: Replace - delete attribute (allow overrides deny) - OK (0) =#=#=#=
+* Passed: cibadmin       - mike: Replace - delete attribute (allow overrides deny)
+<cib epoch="22" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="nothing interesting"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_user id="l33t-haxor">
+        <deny id="crook-nothing" xpath="/cib"/>
+      </acl_user>
+      <acl_user id="niceguy">
+        <role_ref id="observer"/>
+      </acl_user>
+      <acl_user id="bob">
+        <role_ref id="admin"/>
+      </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
+      <acl_role id="observer">
+        <read id="observer-read-1" xpath="/cib"/>
+        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <read id="admin-read-1" xpath="/cib"/>
+        <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
+      </acl_role>
+      <acl_user id="badidea">
+        <read id="badidea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+      <acl_user id="betteridea">
+        <deny id="betteridea-nothing" xpath="/cib"/>
+        <read id="betteridea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: chris: Replace - create attribute (deny overrides allow) =#=#=#=
+pcmk__check_acl 	trace: Parent ACL denies user 'chris' read/write access to /cib/configuration/resources/primitive[@id='dummy'][@description]
+Call failed: Permission denied
+=#=#=#= End test: chris: Replace - create attribute (deny overrides allow) - Insufficient privileges (4) =#=#=#=
+* Passed: cibadmin       - chris: Replace - create attribute (deny overrides allow)
+<cib epoch="23" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="something interesting"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_user id="l33t-haxor">
+        <deny id="crook-nothing" xpath="/cib"/>
+      </acl_user>
+      <acl_user id="niceguy">
+        <role_ref id="observer"/>
+      </acl_user>
+      <acl_user id="bob">
+        <role_ref id="admin"/>
+      </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
+      <acl_role id="observer">
+        <read id="observer-read-1" xpath="/cib"/>
+        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <read id="admin-read-1" xpath="/cib"/>
+        <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
+      </acl_role>
+      <acl_user id="badidea">
+        <read id="badidea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+      <acl_user id="betteridea">
+        <deny id="betteridea-nothing" xpath="/cib"/>
+        <read id="betteridea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: chris: Replace - modify attribute (deny overrides allow) =#=#=#=
+pcmk__check_acl 	trace: Parent ACL denies user 'chris' read/write access to /cib/configuration/resources/primitive[@id='dummy'][@description]
+Call failed: Permission denied
+=#=#=#= End test: chris: Replace - modify attribute (deny overrides allow) - Insufficient privileges (4) =#=#=#=
+* Passed: cibadmin       - chris: Replace - modify attribute (deny overrides allow)
+<cib epoch="24" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_user id="l33t-haxor">
+        <deny id="crook-nothing" xpath="/cib"/>
+      </acl_user>
+      <acl_user id="niceguy">
+        <role_ref id="observer"/>
+      </acl_user>
+      <acl_user id="bob">
+        <role_ref id="admin"/>
+      </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
+      <acl_role id="observer">
+        <read id="observer-read-1" xpath="/cib"/>
+        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <read id="admin-read-1" xpath="/cib"/>
+        <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
+      </acl_role>
+      <acl_user id="badidea">
+        <read id="badidea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+      <acl_user id="betteridea">
+        <deny id="betteridea-nothing" xpath="/cib"/>
+        <read id="betteridea-resources" xpath="//meta_attributes"/>
+      </acl_user>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: chris: Replace - delete attribute (deny overrides allow) =#=#=#=
+pcmk__check_acl 	trace: Parent ACL denies user 'chris' read/write access to /cib/configuration/resources/primitive[@id='dummy']
+Call failed: Permission denied
+=#=#=#= End test: chris: Replace - delete attribute (deny overrides allow) - Insufficient privileges (4) =#=#=#=
+* Passed: cibadmin       - chris: Replace - delete attribute (deny overrides allow)
 
 
     !#!#!#!#! Upgrading to latest CIB schema and re-testing !#!#!#!#!
@@ -1189,6 +2238,11 @@ pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id
 pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id="observer-write-2"
 pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id="admin-read-1"
 pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id="admin-write-1"
+pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id="super_user-write-1"
+pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id="rsc-writer-deny-1"
+pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id="rsc-writer-write-1"
+pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id="rsc-denied-write-1"
+pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id="rsc-denied-deny-1"
 pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_target> with id="l33t-haxor"
 pcmk__apply_creation_acl 	trace: ACLs allow creation of <role> with id="auto-l33t-haxor"
 pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_role> with id="auto-l33t-haxor"
@@ -1197,6 +2251,12 @@ pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_target> with id="ni
 pcmk__apply_creation_acl 	trace: ACLs allow creation of <role> with id="observer"
 pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_target> with id="bob"
 pcmk__apply_creation_acl 	trace: ACLs allow creation of <role> with id="admin"
+pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_target> with id="joe"
+pcmk__apply_creation_acl 	trace: ACLs allow creation of <role> with id="super_user"
+pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_target> with id="mike"
+pcmk__apply_creation_acl 	trace: ACLs allow creation of <role> with id="rsc_writer"
+pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_target> with id="chris"
+pcmk__apply_creation_acl 	trace: ACLs allow creation of <role> with id="rsc_denied"
 pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_target> with id="badidea"
 pcmk__apply_creation_acl 	trace: ACLs allow creation of <role> with id="auto-badidea"
 pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_role> with id="auto-badidea"
@@ -1218,7 +2278,7 @@ pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id
     </crm_config>
     <nodes/>
     <resources>
-      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="something interesting"/>
     </resources>
     <constraints/>
     <acls>
@@ -1234,6 +2294,15 @@ pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1242,6 +2311,17 @@ pcmk__apply_creation_acl 	trace: ACLs allow creation of <acl_permission> with id
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -1327,6 +2407,15 @@ Call failed: Permission denied
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1335,6 +2424,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -1388,6 +2488,15 @@ Error setting enable-acl=false (section=crm_config, set=<null>): Permission deni
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1396,6 +2505,17 @@ Error setting enable-acl=false (section=crm_config, set=<null>): Permission deni
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -1448,6 +2568,15 @@ Call failed: Permission denied
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1456,6 +2585,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -1503,6 +2643,15 @@ Call failed: Permission denied
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1511,6 +2660,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -1560,6 +2720,15 @@ Call failed: Permission denied
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1568,6 +2737,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -1639,6 +2819,15 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1647,6 +2836,17 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -1704,6 +2904,15 @@ Stopped
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1712,6 +2921,17 @@ Stopped
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -1767,6 +2987,15 @@ Deleted 'dummy' option: id=dummy-meta_attributes-target-role name=target-role
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1775,6 +3004,17 @@ Deleted 'dummy' option: id=dummy-meta_attributes-target-role name=target-role
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -1833,6 +3073,15 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1841,6 +3090,17 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -1948,6 +3208,15 @@ Call failed: Permission denied
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -1956,6 +3225,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -2012,6 +3292,15 @@ Call failed: Permission denied
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -2020,6 +3309,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -2075,6 +3375,15 @@ Call failed: Permission denied
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -2083,6 +3392,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -2138,6 +3458,15 @@ Call failed: Permission denied
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -2146,6 +3475,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -2201,6 +3541,15 @@ Call failed: Permission denied
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -2209,6 +3558,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -2227,9 +3587,9 @@ Call failed: Permission denied
   </configuration>
   <status/>
 </cib>
-=#=#=#= Begin test: bob: Replace - create attribute (allow) =#=#=#=
-=#=#=#= End test: bob: Replace - create attribute (allow) - OK (0) =#=#=#=
-* Passed: cibadmin       - bob: Replace - create attribute (allow)
+=#=#=#= Begin test: bob: Replace - create attribute (direct allow) =#=#=#=
+=#=#=#= End test: bob: Replace - create attribute (direct allow) - OK (0) =#=#=#=
+* Passed: cibadmin       - bob: Replace - create attribute (direct allow)
 <cib epoch="15" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
@@ -2261,6 +3621,15 @@ Call failed: Permission denied
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -2269,6 +3638,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -2287,9 +3667,9 @@ Call failed: Permission denied
   </configuration>
   <status/>
 </cib>
-=#=#=#= Begin test: bob: Replace - modify attribute (allow) =#=#=#=
-=#=#=#= End test: bob: Replace - modify attribute (allow) - OK (0) =#=#=#=
-* Passed: cibadmin       - bob: Replace - modify attribute (allow)
+=#=#=#= Begin test: bob: Replace - modify attribute (direct allow) =#=#=#=
+=#=#=#= End test: bob: Replace - modify attribute (direct allow) - OK (0) =#=#=#=
+* Passed: cibadmin       - bob: Replace - modify attribute (direct allow)
 <cib epoch="16" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
@@ -2317,6 +3697,15 @@ Call failed: Permission denied
       <acl_target id="bob">
         <role id="admin"/>
       </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -2325,6 +3714,17 @@ Call failed: Permission denied
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
         <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
       </acl_role>
       <acl_target id="badidea">
         <role id="auto-badidea"/>
@@ -2343,6 +3743,696 @@ Call failed: Permission denied
   </configuration>
   <status/>
 </cib>
-=#=#=#= Begin test: bob: Replace - delete attribute (allow) =#=#=#=
-=#=#=#= End test: bob: Replace - delete attribute (allow) - OK (0) =#=#=#=
-* Passed: cibadmin       - bob: Replace - delete attribute (allow)
+=#=#=#= Begin test: bob: Replace - delete attribute (direct allow) =#=#=#=
+=#=#=#= End test: bob: Replace - delete attribute (direct allow) - OK (0) =#=#=#=
+* Passed: cibadmin       - bob: Replace - delete attribute (direct allow)
+<cib epoch="17" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="nothing interesting"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_target id="l33t-haxor">
+        <role id="auto-l33t-haxor"/>
+      </acl_target>
+      <acl_role id="auto-l33t-haxor">
+        <acl_permission id="crook-nothing" kind="deny" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="niceguy">
+        <role id="observer"/>
+      </acl_target>
+      <acl_target id="bob">
+        <role id="admin"/>
+      </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
+      <acl_role id="observer">
+        <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
+      </acl_role>
+      <acl_target id="badidea">
+        <role id="auto-badidea"/>
+      </acl_target>
+      <acl_role id="auto-badidea">
+        <acl_permission id="badidea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+      <acl_target id="betteridea">
+        <role id="auto-betteridea"/>
+      </acl_target>
+      <acl_role id="auto-betteridea">
+        <acl_permission id="betteridea-nothing" kind="deny" xpath="/cib"/>
+        <acl_permission id="betteridea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: joe: Replace - create attribute (inherited allow) =#=#=#=
+=#=#=#= End test: joe: Replace - create attribute (inherited allow) - OK (0) =#=#=#=
+* Passed: cibadmin       - joe: Replace - create attribute (inherited allow)
+<cib epoch="18" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="something interesting"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_target id="l33t-haxor">
+        <role id="auto-l33t-haxor"/>
+      </acl_target>
+      <acl_role id="auto-l33t-haxor">
+        <acl_permission id="crook-nothing" kind="deny" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="niceguy">
+        <role id="observer"/>
+      </acl_target>
+      <acl_target id="bob">
+        <role id="admin"/>
+      </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
+      <acl_role id="observer">
+        <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
+      </acl_role>
+      <acl_target id="badidea">
+        <role id="auto-badidea"/>
+      </acl_target>
+      <acl_role id="auto-badidea">
+        <acl_permission id="badidea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+      <acl_target id="betteridea">
+        <role id="auto-betteridea"/>
+      </acl_target>
+      <acl_role id="auto-betteridea">
+        <acl_permission id="betteridea-nothing" kind="deny" xpath="/cib"/>
+        <acl_permission id="betteridea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: joe: Replace - modify attribute (inherited allow) =#=#=#=
+=#=#=#= End test: joe: Replace - modify attribute (inherited allow) - OK (0) =#=#=#=
+* Passed: cibadmin       - joe: Replace - modify attribute (inherited allow)
+<cib epoch="19" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_target id="l33t-haxor">
+        <role id="auto-l33t-haxor"/>
+      </acl_target>
+      <acl_role id="auto-l33t-haxor">
+        <acl_permission id="crook-nothing" kind="deny" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="niceguy">
+        <role id="observer"/>
+      </acl_target>
+      <acl_target id="bob">
+        <role id="admin"/>
+      </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
+      <acl_role id="observer">
+        <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
+      </acl_role>
+      <acl_target id="badidea">
+        <role id="auto-badidea"/>
+      </acl_target>
+      <acl_role id="auto-badidea">
+        <acl_permission id="badidea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+      <acl_target id="betteridea">
+        <role id="auto-betteridea"/>
+      </acl_target>
+      <acl_role id="auto-betteridea">
+        <acl_permission id="betteridea-nothing" kind="deny" xpath="/cib"/>
+        <acl_permission id="betteridea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: joe: Replace - delete attribute (inherited allow) =#=#=#=
+=#=#=#= End test: joe: Replace - delete attribute (inherited allow) - OK (0) =#=#=#=
+* Passed: cibadmin       - joe: Replace - delete attribute (inherited allow)
+<cib epoch="20" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="nothing interesting"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_target id="l33t-haxor">
+        <role id="auto-l33t-haxor"/>
+      </acl_target>
+      <acl_role id="auto-l33t-haxor">
+        <acl_permission id="crook-nothing" kind="deny" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="niceguy">
+        <role id="observer"/>
+      </acl_target>
+      <acl_target id="bob">
+        <role id="admin"/>
+      </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
+      <acl_role id="observer">
+        <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
+      </acl_role>
+      <acl_target id="badidea">
+        <role id="auto-badidea"/>
+      </acl_target>
+      <acl_role id="auto-badidea">
+        <acl_permission id="badidea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+      <acl_target id="betteridea">
+        <role id="auto-betteridea"/>
+      </acl_target>
+      <acl_role id="auto-betteridea">
+        <acl_permission id="betteridea-nothing" kind="deny" xpath="/cib"/>
+        <acl_permission id="betteridea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: mike: Replace - create attribute (allow overrides deny) =#=#=#=
+=#=#=#= End test: mike: Replace - create attribute (allow overrides deny) - OK (0) =#=#=#=
+* Passed: cibadmin       - mike: Replace - create attribute (allow overrides deny)
+<cib epoch="21" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="something interesting"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_target id="l33t-haxor">
+        <role id="auto-l33t-haxor"/>
+      </acl_target>
+      <acl_role id="auto-l33t-haxor">
+        <acl_permission id="crook-nothing" kind="deny" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="niceguy">
+        <role id="observer"/>
+      </acl_target>
+      <acl_target id="bob">
+        <role id="admin"/>
+      </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
+      <acl_role id="observer">
+        <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
+      </acl_role>
+      <acl_target id="badidea">
+        <role id="auto-badidea"/>
+      </acl_target>
+      <acl_role id="auto-badidea">
+        <acl_permission id="badidea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+      <acl_target id="betteridea">
+        <role id="auto-betteridea"/>
+      </acl_target>
+      <acl_role id="auto-betteridea">
+        <acl_permission id="betteridea-nothing" kind="deny" xpath="/cib"/>
+        <acl_permission id="betteridea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: mike: Replace - modify attribute (allow overrides deny) =#=#=#=
+=#=#=#= End test: mike: Replace - modify attribute (allow overrides deny) - OK (0) =#=#=#=
+* Passed: cibadmin       - mike: Replace - modify attribute (allow overrides deny)
+<cib epoch="22" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_target id="l33t-haxor">
+        <role id="auto-l33t-haxor"/>
+      </acl_target>
+      <acl_role id="auto-l33t-haxor">
+        <acl_permission id="crook-nothing" kind="deny" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="niceguy">
+        <role id="observer"/>
+      </acl_target>
+      <acl_target id="bob">
+        <role id="admin"/>
+      </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
+      <acl_role id="observer">
+        <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
+      </acl_role>
+      <acl_target id="badidea">
+        <role id="auto-badidea"/>
+      </acl_target>
+      <acl_role id="auto-badidea">
+        <acl_permission id="badidea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+      <acl_target id="betteridea">
+        <role id="auto-betteridea"/>
+      </acl_target>
+      <acl_role id="auto-betteridea">
+        <acl_permission id="betteridea-nothing" kind="deny" xpath="/cib"/>
+        <acl_permission id="betteridea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: mike: Replace - delete attribute (allow overrides deny) =#=#=#=
+=#=#=#= End test: mike: Replace - delete attribute (allow overrides deny) - OK (0) =#=#=#=
+* Passed: cibadmin       - mike: Replace - delete attribute (allow overrides deny)
+<cib epoch="23" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="nothing interesting"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_target id="l33t-haxor">
+        <role id="auto-l33t-haxor"/>
+      </acl_target>
+      <acl_role id="auto-l33t-haxor">
+        <acl_permission id="crook-nothing" kind="deny" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="niceguy">
+        <role id="observer"/>
+      </acl_target>
+      <acl_target id="bob">
+        <role id="admin"/>
+      </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
+      <acl_role id="observer">
+        <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
+      </acl_role>
+      <acl_target id="badidea">
+        <role id="auto-badidea"/>
+      </acl_target>
+      <acl_role id="auto-badidea">
+        <acl_permission id="badidea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+      <acl_target id="betteridea">
+        <role id="auto-betteridea"/>
+      </acl_target>
+      <acl_role id="auto-betteridea">
+        <acl_permission id="betteridea-nothing" kind="deny" xpath="/cib"/>
+        <acl_permission id="betteridea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: chris: Replace - create attribute (deny overrides allow) =#=#=#=
+pcmk__check_acl 	trace: Parent ACL denies user 'chris' read/write access to /cib/configuration/resources/primitive[@id='dummy'][@description]
+Call failed: Permission denied
+=#=#=#= End test: chris: Replace - create attribute (deny overrides allow) - Insufficient privileges (4) =#=#=#=
+* Passed: cibadmin       - chris: Replace - create attribute (deny overrides allow)
+<cib epoch="24" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy" description="something interesting"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_target id="l33t-haxor">
+        <role id="auto-l33t-haxor"/>
+      </acl_target>
+      <acl_role id="auto-l33t-haxor">
+        <acl_permission id="crook-nothing" kind="deny" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="niceguy">
+        <role id="observer"/>
+      </acl_target>
+      <acl_target id="bob">
+        <role id="admin"/>
+      </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
+      <acl_role id="observer">
+        <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
+      </acl_role>
+      <acl_target id="badidea">
+        <role id="auto-badidea"/>
+      </acl_target>
+      <acl_role id="auto-badidea">
+        <acl_permission id="badidea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+      <acl_target id="betteridea">
+        <role id="auto-betteridea"/>
+      </acl_target>
+      <acl_role id="auto-betteridea">
+        <acl_permission id="betteridea-nothing" kind="deny" xpath="/cib"/>
+        <acl_permission id="betteridea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: chris: Replace - modify attribute (deny overrides allow) =#=#=#=
+pcmk__check_acl 	trace: Parent ACL denies user 'chris' read/write access to /cib/configuration/resources/primitive[@id='dummy'][@description]
+Call failed: Permission denied
+=#=#=#= End test: chris: Replace - modify attribute (deny overrides allow) - Insufficient privileges (4) =#=#=#=
+* Passed: cibadmin       - chris: Replace - modify attribute (deny overrides allow)
+<cib epoch="25" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-enable-acl" name="enable-acl" value="true"/>
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes/>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>
+    </resources>
+    <constraints/>
+    <acls>
+      <acl_target id="l33t-haxor">
+        <role id="auto-l33t-haxor"/>
+      </acl_target>
+      <acl_role id="auto-l33t-haxor">
+        <acl_permission id="crook-nothing" kind="deny" xpath="/cib"/>
+      </acl_role>
+      <acl_target id="niceguy">
+        <role id="observer"/>
+      </acl_target>
+      <acl_target id="bob">
+        <role id="admin"/>
+      </acl_target>
+      <acl_target id="joe">
+        <role id="super_user"/>
+      </acl_target>
+      <acl_target id="mike">
+        <role id="rsc_writer"/>
+      </acl_target>
+      <acl_target id="chris">
+        <role id="rsc_denied"/>
+      </acl_target>
+      <acl_role id="observer">
+        <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+      </acl_role>
+      <acl_role id="admin">
+        <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
+        <acl_permission id="admin-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <acl_permission id="super_user-write-1" kind="write" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <acl_permission id="rsc-writer-deny-1" kind="deny" xpath="/cib"/>
+        <acl_permission id="rsc-writer-write-1" kind="write" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <acl_permission id="rsc-denied-write-1" kind="write" xpath="/cib"/>
+        <acl_permission id="rsc-denied-deny-1" kind="deny" xpath="//resources"/>
+      </acl_role>
+      <acl_target id="badidea">
+        <role id="auto-badidea"/>
+      </acl_target>
+      <acl_role id="auto-badidea">
+        <acl_permission id="badidea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+      <acl_target id="betteridea">
+        <role id="auto-betteridea"/>
+      </acl_target>
+      <acl_role id="auto-betteridea">
+        <acl_permission id="betteridea-nothing" kind="deny" xpath="/cib"/>
+        <acl_permission id="betteridea-resources" kind="read" xpath="//meta_attributes"/>
+      </acl_role>
+    </acls>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= Begin test: chris: Replace - delete attribute (deny overrides allow) =#=#=#=
+pcmk__check_acl 	trace: Parent ACL denies user 'chris' read/write access to /cib/configuration/resources/primitive[@id='dummy']
+Call failed: Permission denied
+=#=#=#= End test: chris: Replace - delete attribute (deny overrides allow) - Insufficient privileges (4) =#=#=#=
+* Passed: cibadmin       - chris: Replace - delete attribute (deny overrides allow)

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -701,6 +701,7 @@ function test_acl_loop() {
 
     CIB_user=root cibadmin --replace --xml-text '<resources/>'
 
+    ### no ACL ###
     export CIB_user=unknownguy
     desc="$CIB_user: Query configuration"
     cmd="cibadmin -Q"
@@ -718,6 +719,7 @@ function test_acl_loop() {
     cmd="cibadmin -C -o resources --xml-text '<primitive id=\"dummy\" class=\"ocf\" provider=\"pacemaker\" type=\"Dummy\"/>'"
     test_assert $CRM_EX_INSUFFICIENT_PRIV 0
 
+    ### deny /cib permission ###
     export CIB_user=l33t-haxor
     desc="$CIB_user: Query configuration"
     cmd="cibadmin -Q"
@@ -735,6 +737,7 @@ function test_acl_loop() {
     cmd="cibadmin -C -o resources --xml-text '<primitive id=\"dummy\" class=\"ocf\" provider=\"pacemaker\" type=\"Dummy\"/>'"
     test_assert $CRM_EX_INSUFFICIENT_PRIV 0
 
+    ### observer role ###
     export CIB_user=niceguy
     desc="$CIB_user: Query configuration"
     cmd="cibadmin -Q"
@@ -765,6 +768,7 @@ function test_acl_loop() {
     cmd="cibadmin -C -o resources --xml-text '<primitive id=\"dummy\" class=\"ocf\" provider=\"pacemaker\" type=\"Dummy\"/>'"
     test_assert $CRM_EX_OK
 
+    ### deny /cib permission ###
     export CIB_user=l33t-haxor
 
     desc="$CIB_user: Create a resource meta attribute"
@@ -779,6 +783,7 @@ function test_acl_loop() {
     cmd="crm_resource -r dummy --meta -d target-role"
     test_assert $CRM_EX_INSUFFICIENT_PRIV 0
 
+    ### observer role ###
     export CIB_user=niceguy
 
     desc="$CIB_user: Create a resource meta attribute"
@@ -797,11 +802,13 @@ function test_acl_loop() {
     cmd="crm_resource -r dummy --meta -p target-role -v Started"
     test_assert $CRM_EX_OK
 
+    ### read //meta_attributes ###
     export CIB_user=badidea
     desc="$CIB_user: Query configuration - implied deny"
     cmd="cibadmin -Q"
     test_assert $CRM_EX_OK 0
 
+    ### deny /cib, read //meta_attributes ###
     export CIB_user=betteridea
     desc="$CIB_user: Query configuration - explicit deny"
     cmd="cibadmin -Q"
@@ -811,6 +818,7 @@ function test_acl_loop() {
     CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --delete --xml-text '<acls/>'
     CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
 
+    ### observer role ###
     export CIB_user=niceguy
     desc="$CIB_user: Replace - remove acls"
     cmd="cibadmin --replace --xml-file $TMPXML"
@@ -848,12 +856,13 @@ function test_acl_loop() {
     cmd="cibadmin --replace --xml-file $TMPXML"
     test_assert $CRM_EX_INSUFFICIENT_PRIV 0
 
+    ### admin role ###
     CIB_user=bob
     CIB_user=root cibadmin -Q > "$TMPXML"
     CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --modify --xml-text '<primitive id="dummy" description="nothing interesting"/>'
     CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
 
-    desc="$CIB_user: Replace - create attribute (allow)"
+    desc="$CIB_user: Replace - create attribute (direct allow)"
     cmd="cibadmin --replace -o resources --xml-file $TMPXML"
     test_assert $CRM_EX_OK 0
 
@@ -861,7 +870,7 @@ function test_acl_loop() {
     CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --modify --xml-text '<primitive id="dummy" description="something interesting"/>'
     CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
 
-    desc="$CIB_user: Replace - modify attribute (allow)"
+    desc="$CIB_user: Replace - modify attribute (direct allow)"
     cmd="cibadmin --replace -o resources --xml-file $TMPXML"
     test_assert $CRM_EX_OK 0
 
@@ -869,9 +878,96 @@ function test_acl_loop() {
     CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --replace -o resources --xml-text '<primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>'
     CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
 
-    desc="$CIB_user: Replace - delete attribute (allow)"
+    desc="$CIB_user: Replace - delete attribute (direct allow)"
     cmd="cibadmin --replace -o resources --xml-file $TMPXML"
     test_assert $CRM_EX_OK 0
+
+    ### super_user role ###
+    export CIB_user=joe
+
+    CIB_user=root cibadmin -Q > "$TMPXML"
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --modify --xml-text '<primitive id="dummy" description="nothing interesting"/>'
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
+
+    desc="$CIB_user: Replace - create attribute (inherited allow)"
+    cmd="cibadmin --replace -o resources --xml-file $TMPXML"
+    test_assert $CRM_EX_OK 0
+
+    CIB_user=root cibadmin -Q > "$TMPXML"
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --modify --xml-text '<primitive id="dummy" description="something interesting"/>'
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
+
+    desc="$CIB_user: Replace - modify attribute (inherited allow)"
+    cmd="cibadmin --replace -o resources --xml-file $TMPXML"
+    test_assert $CRM_EX_OK 0
+
+    CIB_user=root cibadmin -Q > "$TMPXML"
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --replace -o resources --xml-text '<primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>'
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
+
+    desc="$CIB_user: Replace - delete attribute (inherited allow)"
+    cmd="cibadmin --replace -o resources --xml-file $TMPXML"
+    test_assert $CRM_EX_OK 0
+
+    ### rsc_writer role ###
+    export CIB_user=mike
+
+    CIB_user=root cibadmin -Q > "$TMPXML"
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --modify --xml-text '<primitive id="dummy" description="nothing interesting"/>'
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
+
+    desc="$CIB_user: Replace - create attribute (allow overrides deny)"
+    cmd="cibadmin --replace -o resources --xml-file $TMPXML"
+    test_assert $CRM_EX_OK 0
+
+    CIB_user=root cibadmin -Q > "$TMPXML"
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --modify --xml-text '<primitive id="dummy" description="something interesting"/>'
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
+
+    desc="$CIB_user: Replace - modify attribute (allow overrides deny)"
+    cmd="cibadmin --replace -o resources --xml-file $TMPXML"
+    test_assert $CRM_EX_OK 0
+
+    CIB_user=root cibadmin -Q > "$TMPXML"
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --replace -o resources --xml-text '<primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>'
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
+
+    desc="$CIB_user: Replace - delete attribute (allow overrides deny)"
+    cmd="cibadmin --replace -o resources --xml-file $TMPXML"
+    test_assert $CRM_EX_OK 0
+
+    ### rsc_denied role ###
+    export CIB_user=chris
+
+    CIB_user=root cibadmin -Q > "$TMPXML"
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --modify --xml-text '<primitive id="dummy" description="nothing interesting"/>'
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
+
+    desc="$CIB_user: Replace - create attribute (deny overrides allow)"
+    cmd="cibadmin --replace -o resources --xml-file $TMPXML"
+    test_assert $CRM_EX_INSUFFICIENT_PRIV 0
+
+    # Set as root since setting as chris failed
+    CIB_user=root cibadmin --modify --xml-text '<primitive id="dummy" description="nothing interesting"/>'
+
+    CIB_user=root cibadmin -Q > "$TMPXML"
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --modify --xml-text '<primitive id="dummy" description="something interesting"/>'
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
+
+    desc="$CIB_user: Replace - modify attribute (deny overrides allow)"
+    cmd="cibadmin --replace -o resources --xml-file $TMPXML"
+    test_assert $CRM_EX_INSUFFICIENT_PRIV 0
+
+    # Set as root since setting as chris failed
+    CIB_user=root cibadmin --modify --xml-text '<primitive id="dummy" description="something interesting"/>'
+
+    CIB_user=root cibadmin -Q > "$TMPXML"
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin --replace -o resources --xml-text '<primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"/>'
+    CIB_user=root CIB_file="$TMPXML" CIB_shadow="" cibadmin -Ql
+
+    desc="$CIB_user: Replace - delete attribute (deny overrides allow)"
+    cmd="cibadmin --replace -o resources --xml-file $TMPXML"
+    test_assert $CRM_EX_INSUFFICIENT_PRIV 0
 }
 
 function test_acls() {
@@ -895,6 +991,15 @@ function test_acls() {
       <acl_user id="bob">
         <role_ref id="admin"/>
       </acl_user>
+      <acl_user id="joe">
+        <role_ref id="super_user"/>
+      </acl_user>
+      <acl_user id="mike">
+        <role_ref id="rsc_writer"/>
+      </acl_user>
+      <acl_user id="chris">
+        <role_ref id="rsc_denied"/>
+      </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
         <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
@@ -903,6 +1008,17 @@ function test_acls() {
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
         <write id="admin-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="super_user">
+        <write id="super_user-write-1" xpath="/cib"/>
+      </acl_role>
+      <acl_role id="rsc_writer">
+        <deny id="rsc-writer-deny-1" xpath="/cib"/>
+        <write id="rsc-writer-write-1" xpath="//resources"/>
+      </acl_role>
+      <acl_role id="rsc_denied">
+        <write id="rsc-denied-write-1" xpath="/cib"/>
+        <deny id="rsc-denied-deny-1" xpath="//resources"/>
       </acl_role>
     </acls>
 EOF

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -439,7 +439,6 @@ xml_acl_filtered_copy(const char *user, xmlNode *acl_source, xmlNode *xml,
 {
     GListPtr aIter = NULL;
     xmlNode *target = NULL;
-    xml_private_t *p = NULL;
     xml_private_t *doc = NULL;
 
     *result = NULL;
@@ -488,9 +487,7 @@ xml_acl_filtered_copy(const char *user, xmlNode *acl_source, xmlNode *xml,
         }
     }
 
-    p = target->_private;
-    if (is_set(p->flags, xpf_acl_deny)
-        && (__xml_purge_attributes(target) == FALSE)) {
+    if (__xml_purge_attributes(target) == FALSE) {
         crm_trace("ACLs deny user '%s' access to entire XML document", user);
         return TRUE;
     }

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -679,8 +679,9 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
                 return TRUE;
 
             } else if (is_set(p->flags, xpf_acl_deny)) {
-                crm_trace("Parent ACL denies user '%s' %s access to %s",
-                          docp->user, __xml_acl_to_text(mode), buffer);
+                crm_trace("%sACL denies user '%s' %s access to %s",
+                          (parent != xml) ? "Parent " : "", docp->user,
+                          __xml_acl_to_text(mode), buffer);
                 pcmk__set_xml_flag(xml, xpf_acl_denied);
                 return FALSE;
             }

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -288,17 +288,6 @@ pcmk__apply_acl(xmlNode *xml)
                   ((max == 1)? "" : "es"));
         freeXpathObject(xpathObj);
     }
-
-    p = xml->_private;
-    if (is_not_set(p->flags, xpf_acl_read)
-        && is_not_set(p->flags, xpf_acl_write)) {
-
-        p->flags |= xpf_acl_deny;
-        p = xml->doc->_private;
-        crm_info("Applied default deny ACL for user '%s' to <%s>",
-                 p->user, crm_element_name(xml));
-    }
-
 }
 
 /*!


### PR DESCRIPTION
If a node does not have any ACLs set for it explicitly, it's assigned a
deny flag. However, in the case of scoped commands, the input to
`pcmk__apply_acl()` may be a section rather than the whole CIB. The
node at the root of the section that's passed in gets assigned a deny
flag after no ACLs match it.

This causes `pcmk__check_acl()` to fail prematurely when it walks up
the tree of parents. It reaches the node at the root of the section
that was passed to `pcmk__apply_acl()`, finds a deny flag, and returns
FALSE. If that node's parent (e.g., `/cib`) has a read or write ACL,
the parent's ACL is not reached and thus not considered.

The fix is to avoid setting a deny flag for a node if there is no ACL
for that node. `pcmk__check_acl()` already denies access implicitly if
neither read nor write is set for a node or any of its parents. The only
other change required is to have `xml_acl_filtered_copy()` check for the
absence of read and write instead of the presence of deny.

Resolves: RHBZ#1833173