### PR TITLE
WIP: Refactor: libcrmcommon: Introduce GString for XML

### DIFF
--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -62,8 +62,7 @@ G_GNUC_INTERNAL
 bool pcmk__tracking_xml_changes(xmlNode *xml, bool lazy);
 
 G_GNUC_INTERNAL
-int pcmk__element_xpath(const char *prefix, xmlNode *xml, char *buffer,
-                        int offset, size_t buffer_size);
+void pcmk__element_xpath(xmlNode *xml, GString *buffer);
 
 G_GNUC_INTERNAL
 void pcmk__free_acls(GList *acls);


### PR DESCRIPTION
**WIP**

Update `xml.c` and `acl.c` to use `GString` in a couple of places for
dynamic allocation. Eliminates risk of overflowing `char` array.

Resolves: RHBZ#1822125

---

I'd like to get maintainers' thoughts on the general approach so far 
before I go any further with refactoring to use `GString`.