### PR TITLE
Removal of master/slave vocabulary

### DIFF
--- a/cts/CIB.py
+++ b/cts/CIB.py
@@ -353,10 +353,10 @@ class CIB12(ConfigBase):
         m.add_op("monitor", "P10S")
         m.commit()
 
-        # Ping the test master
+        # Ping the test main
         p = Resource(self.Factory, "ping-1","ping",  "ocf", "pacemaker")
         p.add_op("monitor", "60s")
-        p["host_list"] = self.CM.Env["cts-master"]
+        p["host_list"] = self.CM.Env["cts-main"]
         p["name"] = "connected"
         p["debug"] = "true"
 
@@ -367,7 +367,7 @@ class CIB12(ConfigBase):
         # promotable clone resource
         s = Resource(self.Factory, "stateful-1", "Stateful", "ocf", "pacemaker")
         s.add_op("monitor", "15s", timeout="60s")
-        s.add_op("monitor", "16s", timeout="60s", role="Master")
+        s.add_op("monitor", "16s", timeout="60s", role="Main")
         ms = Clone(self.Factory, "promotable-1", s)
         ms["promotable"] = "true"
         ms["clone-max"] = self.num_nodes
@@ -399,7 +399,7 @@ class CIB12(ConfigBase):
 
         # Make group depend on the promotable clone
         g.after("promotable-1", first="promote", then="start")
-        g.colocate("promotable-1", "INFINITY", withrole="Master")
+        g.colocate("promotable-1", "INFINITY", withrole="Main")
 
         g.commit()
 

--- a/cts/environment.py
+++ b/cts/environment.py
@@ -250,14 +250,14 @@ class Environment(object):
     def discover(self):
         self.target = random.Random().choice(self["nodes"])
 
-        master = socket.gethostname()
+        main = socket.gethostname()
 
         # Use the IP where possible to avoid name lookup failures
-        for ip in socket.gethostbyname_ex(master)[2]:
+        for ip in socket.gethostbyname_ex(main)[2]:
             if ip != "127.0.0.1":
-                master = ip
+                main = ip
                 break;
-        self["cts-master"] = master
+        self["cts-main"] = main
 
         if not "have_systemd" in self.data:
             self["have_systemd"] = not self.rsh(self.target,


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.