### PR TITLE
Log: controld: improve message indicating the RA execution request

### DIFF
--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -2248,8 +2248,10 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc,
     }
 
     /* now do the op */
-    crm_info("Performing key=%s op=" PCMK__OP_FMT,
-             transition, rsc->id, operation, op->interval_ms);
+    crm_notice("Requesting local execution of %s operation for %s on %s "
+               CRM_XS " transition_key=%s op_key=" PCMK__OP_FMT,
+               crm_action_str(op->op_type, op->interval_ms), rsc->id, lrm_state->node_name,
+               transition, rsc->id, operation, op->interval_ms);
 
     if (is_set(fsa_input_register, R_SHUTDOWN) && safe_str_eq(operation, RSC_START)) {
         register_fsa_input(C_SHUTDOWN, I_SHUTDOWN, NULL);


### PR DESCRIPTION
This patch makes the message indicating a request to execute RA clearer to the user. (see https://github.com/ClusterLabs/pacemaker/pull/2115 for the process of making the change.)
```
(in syslog)
Jul 22 16:17:43 r81-1 pacemaker-controld[2520]:
 notice: Requesting local execution of start operation for pgsql on r81-1

(in pacemaker.log)
Jul 22 16:17:43 r81-1 pacemaker-controld  [2520] (do_lrm_rsc_op)
 notice: Requesting local execution of start operation for pgsql on r81-1 | transition_key=14:2:0:46e432eb-62f3-45d2-9cea-ffd972daae2f op_key=pgsql_start_0
```