### PR TITLE
Improve flag setting/clearing trace logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,8 +201,10 @@ pacemaker-[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]
 # Test results
 *.log
 *.trs
-/lib/common/tests/strings/pcmk__scan_double
+/lib/common/tests/flags/pcmk__clear_flags_as
+/lib/common/tests/flags/pcmk__set_flags_as
 /lib/common/tests/strings/pcmk__parse_ll_range
+/lib/common/tests/strings/pcmk__scan_double
 /lib/common/tests/strings/pcmk__str_any_of
 /lib/common/tests/strings/pcmk__strcmp
 /lib/common/tests/strings/pcmk__char_in_any_str

--- a/configure.ac
+++ b/configure.ac
@@ -2014,6 +2014,7 @@ AC_CONFIG_FILES(Makefile                                            \
                 lib/pacemaker-cluster.pc                            \
                 lib/common/Makefile                                 \
                 lib/common/tests/Makefile                           \
+                lib/common/tests/flags/Makefile                     \
                 lib/common/tests/strings/Makefile                   \
                 lib/common/tests/utils/Makefile                     \
                 lib/cluster/Makefile                                \

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -1278,7 +1278,8 @@ write_attribute(attribute_t *a, bool ignore_delay)
             /* Older attrd versions don't know about the cib_mixed_update
              * flag so make sure it goes to the local cib which does
              */
-            flags |= cib_mixed_update|cib_scope_local;
+            cib__set_call_options(flags, crm_system_name,
+                                  cib_mixed_update|cib_scope_local);
         }
     }
 

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -930,7 +930,9 @@ cib_process_request(xmlNode *request, gboolean force_synchronous,
 
     crm_element_value_int(request, F_CIB_CALLOPTS, &call_options);
     if (force_synchronous) {
-        call_options |= cib_sync_call;
+        cib__set_call_options(call_options,
+                              (client_name? client_name : "client"),
+                              cib_sync_call);
     }
 
     if (host != NULL && strlen(host) == 0) {
@@ -1207,7 +1209,7 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     if (global_update) {
         /* legacy code */
         manage_counters = FALSE;
-        call_options |= cib_force_diff;
+        cib__set_call_options(call_options, "call", cib_force_diff);
         crm_trace("Global update detected");
 
         CRM_CHECK(call_type == 3 || call_type == 4, crm_err("Call type: %d", call_type);
@@ -1224,9 +1226,9 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
 
         if (is_not_set(call_options, cib_dryrun) && pcmk__str_eq(section, XML_CIB_TAG_STATUS, pcmk__str_casei)) {
             /* Copying large CIBs accounts for a huge percentage of our CIB usage */
-            call_options |= cib_zero_copy;
+            cib__set_call_options(call_options, "call", cib_zero_copy);
         } else {
-            clear_bit(call_options, cib_zero_copy);
+            cib__clear_call_options(call_options, "call", cib_zero_copy);
         }
 
         /* result_cib must not be modified after cib_perform_op() returns */

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -31,15 +31,17 @@
 #  include <gnutls/gnutls.h>
 #endif
 
-enum cib_notifications {
-    cib_notify_pre     = 0x0001,
-    cib_notify_post    = 0x0002,
-    cib_notify_replace = 0x0004,
-    cib_notify_confirm = 0x0008,
-    cib_notify_diff    = 0x0010,
+// CIB-specific client flags
+enum cib_client_flags {
+    // Notifications
+    cib_notify_pre     = (UINT64_C(1) << 0),
+    cib_notify_post    = (UINT64_C(1) << 1),
+    cib_notify_replace = (UINT64_C(1) << 2),
+    cib_notify_confirm = (UINT64_C(1) << 3),
+    cib_notify_diff    = (UINT64_C(1) << 4),
 
-    // Not a notification, but uses the same IPC bitmask
-    cib_is_daemon      = 0x1000, // Whether client is another cluster daemon
+    // Whether client is another cluster daemon
+    cib_is_daemon      = (UINT64_C(1) << 12),
 };
 
 typedef struct cib_operation_s {

--- a/daemons/controld/controld_attrd.c
+++ b/daemons/controld/controld_attrd.c
@@ -84,7 +84,7 @@ update_attrd_helper(const char *host, const char *name, const char *value,
     int attrd_opts = pcmk__node_attr_none;
 
     if (is_remote_node) {
-        attrd_opts |= pcmk__node_attr_remote;
+        pcmk__set_node_attr_flags(attrd_opts, pcmk__node_attr_remote);
     }
 
     if (attrd_ipc == NULL) {

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -144,7 +144,7 @@ int crmd_cib_smart_opt()
 
     if (fsa_state == S_ELECTION || fsa_state == S_PENDING) {
         crm_info("Sending update to local CIB in state: %s", fsa_state2string(fsa_state));
-        call_opt |= cib_scope_local;
+        cib__set_call_options(call_opt, "update", cib_scope_local);
     }
     return call_opt;
 }
@@ -249,7 +249,8 @@ controld_delete_node_state(const char *uname, enum controld_section_e section,
     } else {
         int call_id;
 
-        options |= cib_quorum_override|cib_xpath|cib_multiple;
+        cib__set_call_options(options, "node state deletion",
+                              cib_quorum_override|cib_xpath|cib_multiple);
         call_id = fsa_cib_conn->cmds->remove(fsa_cib_conn, xpath, NULL, options);
         crm_info("Deleting %s (via CIB call %d) " CRM_XS " xpath=%s",
                  desc, call_id, xpath);

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -63,7 +63,7 @@ do_cib_control(long long action,
         }
 
         crm_info("Disconnecting from the CIB manager");
-        clear_bit(fsa_input_register, R_CIB_CONNECTED);
+        controld_clear_fsa_input_flags(R_CIB_CONNECTED);
 
         fsa_cib_conn->cmds->del_notify_callback(fsa_cib_conn, T_CIB_DIFF_NOTIFY, do_cib_updated);
 
@@ -109,7 +109,7 @@ do_cib_control(long long action,
             crm_err("Could not set CIB notification callback (update)");
 
         } else {
-            set_bit(fsa_input_register, R_CIB_CONNECTED);
+            controld_set_fsa_input_flags(R_CIB_CONNECTED);
             cib_retries = 0;
         }
 

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -111,7 +111,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
      * cluster node, indicate that we have it.
      */
     if (!is_remote) {
-        set_bit(fsa_input_register, R_PEER_DATA);
+        controld_set_fsa_input_flags(R_PEER_DATA);
     }
 
     if (node->uname == NULL) {
@@ -328,7 +328,7 @@ crmd_cib_connection_destroy(gpointer user_data)
     // @TODO This should trigger a reconnect, not a shutdown
     crm_crit("Lost connection to the CIB manager, shutting down");
     register_fsa_input(C_FSA_INTERNAL, I_ERROR, NULL);
-    clear_bit(fsa_input_register, R_CIB_CONNECTED);
+    controld_clear_fsa_input_flags(R_CIB_CONNECTED);
 
     return;
 }

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -63,7 +63,7 @@ crmd_ha_msg_filter(xmlNode * msg)
     route_message(C_HA_MESSAGE, msg);
 
   done:
-    trigger_fsa(fsa_source);
+    trigger_fsa();
 }
 
 /*!
@@ -308,7 +308,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
         free_xml(update);
     }
 
-    trigger_fsa(fsa_source);
+    trigger_fsa();
 }
 
 void
@@ -317,7 +317,7 @@ crmd_cib_connection_destroy(gpointer user_data)
     CRM_CHECK(user_data == fsa_cib_conn,;);
 
     crm_trace("Invoked");
-    trigger_fsa(fsa_source);
+    trigger_fsa();
     fsa_cib_conn->state = cib_disconnected;
 
     if (is_set(fsa_input_register, R_CIB_CONNECTED) == FALSE) {

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -391,7 +391,7 @@ dispatch_controller_ipc(qb_ipcs_connection_t * c, void *data, size_t size)
         route_message(C_IPC_MESSAGE, msg);
     }
 
-    trigger_fsa(fsa_source);
+    trigger_fsa();
     free_xml(msg);
     return 0;
 }
@@ -407,7 +407,7 @@ crmd_ipc_closed(qb_ipcs_connection_t * c)
                   c, client);
         free(client->userdata);
         pcmk__free_client(client);
-        trigger_fsa(fsa_source);
+        trigger_fsa();
     }
     return 0;
 }

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -55,7 +55,7 @@ do_ha_control(long long action,
         crm_cluster_disconnect(cluster);
         crm_info("Disconnected from the cluster");
 
-        set_bit(fsa_input_register, R_HA_DISCONNECTED);
+        controld_set_fsa_input_flags(R_HA_DISCONNECTED);
     }
 
     if (action & A_HA_CONNECT) {
@@ -79,13 +79,13 @@ do_ha_control(long long action,
         }
 
         if (registered == FALSE) {
-            set_bit(fsa_input_register, R_HA_DISCONNECTED);
+            controld_set_fsa_input_flags(R_HA_DISCONNECTED);
             register_fsa_error(C_FSA_INTERNAL, I_ERROR, NULL);
             return;
         }
 
         populate_cib_nodes(node_update_none, __FUNCTION__);
-        clear_bit(fsa_input_register, R_HA_DISCONNECTED);
+        controld_clear_fsa_input_flags(R_HA_DISCONNECTED);
         crm_info("Connected to the cluster");
     }
 
@@ -101,7 +101,7 @@ do_shutdown(long long action,
             enum crmd_fsa_state cur_state, enum crmd_fsa_input current_input, fsa_data_t * msg_data)
 {
     /* just in case */
-    set_bit(fsa_input_register, R_SHUTDOWN);
+    controld_set_fsa_input_flags(R_SHUTDOWN);
     controld_disconnect_fencer(FALSE);
 }
 
@@ -114,12 +114,12 @@ do_shutdown_req(long long action,
 {
     xmlNode *msg = NULL;
 
-    set_bit(fsa_input_register, R_SHUTDOWN);
+    controld_set_fsa_input_flags(R_SHUTDOWN);
+    //controld_set_fsa_input_flags(R_STAYDOWN);
     crm_info("Sending shutdown request to all peers (DC is %s)",
              (fsa_our_dc? fsa_our_dc : "not set"));
     msg = create_request(CRM_OP_SHUTDOWN_REQ, NULL, NULL, CRM_SYSTEM_CRMD, CRM_SYSTEM_CRMD, NULL);
 
-/* 	set_bit(fsa_input_register, R_STAYDOWN); */
     if (send_cluster_message(NULL, crm_msg_crmd, msg, TRUE) == FALSE) {
         register_fsa_error(C_FSA_INTERNAL, I_ERROR, NULL);
     }
@@ -171,7 +171,7 @@ crmd_exit(crm_exit_t exit_code)
               exit_code, crm_exit_str(exit_code));
 
     /* Suppress secondary errors resulting from us disconnecting everything */
-    set_bit(fsa_input_register, R_HA_DISCONNECTED);
+    controld_set_fsa_input_flags(R_HA_DISCONNECTED);
 
 /* Close all IPC servers and clients to ensure any and all shared memory files are cleaned up */
 
@@ -215,7 +215,7 @@ crmd_exit(crm_exit_t exit_code)
         delete_fsa_input(fsa_data);
     }
 
-    clear_bit(fsa_input_register, R_MEMBERSHIP);
+    controld_clear_fsa_input_flags(R_MEMBERSHIP);
     g_list_free(fsa_message_queue); fsa_message_queue = NULL;
 
     metadata_cache_fini();
@@ -228,7 +228,7 @@ crmd_exit(crm_exit_t exit_code)
     fsa_cib_conn->cmds->signoff(fsa_cib_conn);
 
     verify_stopped(fsa_state, LOG_WARNING);
-    clear_bit(fsa_input_register, R_LRM_CONNECTED);
+    controld_clear_fsa_input_flags(R_LRM_CONNECTED);
     lrm_state_destroy_all();
 
     /* This basically will not work, since mainloop has a reference to it */
@@ -489,7 +489,7 @@ do_started(long long action,
     }
     controld_trigger_fencer_connect();
 
-    clear_bit(fsa_input_register, R_STARTING);
+    controld_clear_fsa_input_flags(R_STARTING);
     register_fsa_input(msg_data->fsa_cause, I_PENDING, NULL);
 }
 
@@ -499,7 +499,7 @@ do_recover(long long action,
            enum crmd_fsa_cause cause,
            enum crmd_fsa_state cur_state, enum crmd_fsa_input current_input, fsa_data_t * msg_data)
 {
-    set_bit(fsa_input_register, R_IN_RECOVERY);
+    controld_set_fsa_input_flags(R_IN_RECOVERY);
     crm_warn("Fast-tracking shutdown in response to errors");
 
     register_fsa_input(C_FSA_INTERNAL, I_TERMINATE, NULL);
@@ -674,7 +674,7 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 
         if (rc == -EACCES || rc == -pcmk_err_schema_validation) {
             crm_err("The cluster is mis-configured - shutting down and staying down");
-            set_bit(fsa_input_register, R_STAYDOWN);
+            controld_set_fsa_input_flags(R_STAYDOWN);
         }
         goto bail;
     }
@@ -756,7 +756,7 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     alerts = first_named_child(output, XML_CIB_TAG_ALERTS);
     crmd_unpack_alerts(alerts);
 
-    set_bit(fsa_input_register, R_READ_CONFIG);
+    controld_set_fsa_input_flags(R_READ_CONFIG);
     crm_trace("Triggering FSA: %s", __FUNCTION__);
     mainloop_set_trigger(fsa_source);
 
@@ -803,7 +803,7 @@ crm_shutdown(int nsig)
         return;
     }
 
-    set_bit(fsa_input_register, R_SHUTDOWN);
+    controld_set_fsa_input_flags(R_SHUTDOWN);
     register_fsa_input(C_SHUTDOWN, I_SHUTDOWN, NULL);
 
     if (shutdown_escalation_timer->period_ms == 0) {

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -193,12 +193,11 @@ do_dc_takeover(long long action,
     pid_t watchdog = pcmk_locate_sbd();
 
     crm_info("Taking over DC status for this partition");
-    set_bit(fsa_input_register, R_THE_DC);
+    controld_set_fsa_input_flags(R_THE_DC);
     execute_stonith_cleanup();
 
     election_reset(fsa_election);
-    set_bit(fsa_input_register, R_JOIN_OK);
-    set_bit(fsa_input_register, R_INVOKE_PE);
+    controld_set_fsa_input_flags(R_JOIN_OK|R_INVOKE_PE);
 
     fsa_cib_conn->cmds->set_master(fsa_cib_conn, cib_scope_local);
 
@@ -241,7 +240,7 @@ do_dc_release(long long action,
 {
     if (action & A_DC_RELEASE) {
         crm_debug("Releasing the role of DC");
-        clear_bit(fsa_input_register, R_THE_DC);
+        controld_clear_fsa_input_flags(R_THE_DC);
         controld_expect_sched_reply(NULL);
 
     } else if (action & A_DC_RELEASED) {

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -53,7 +53,7 @@ lrm_connection_destroy(void)
     if (is_set(fsa_input_register, R_LRM_CONNECTED)) {
         crm_crit("Connection to executor failed");
         register_fsa_input(C_FSA_INTERNAL, I_ERROR, NULL);
-        clear_bit(fsa_input_register, R_LRM_CONNECTED);
+        controld_clear_fsa_input_flags(R_LRM_CONNECTED);
 
     } else {
         crm_info("Disconnected from executor");
@@ -342,7 +342,7 @@ do_lrm_control(long long action,
             }
         }
 
-        clear_bit(fsa_input_register, R_LRM_CONNECTED);
+        controld_clear_fsa_input_flags(R_LRM_CONNECTED);
         crm_info("Disconnecting from the executor");
         lrm_state_disconnect(lrm_state);
         lrm_state_reset_tables(lrm_state, FALSE);
@@ -376,7 +376,7 @@ do_lrm_control(long long action,
             return;
         }
 
-        set_bit(fsa_input_register, R_LRM_CONNECTED);
+        controld_set_fsa_input_flags(R_LRM_CONNECTED);
         crm_info("Connection to the executor established");
     }
 
@@ -2129,7 +2129,7 @@ verify_stopped(enum crmd_fsa_state cur_state, int log_level)
         }
     }
 
-    set_bit(fsa_input_register, R_SENT_RSC_STOP);
+    controld_set_fsa_input_flags(R_SENT_RSC_STOP);
     g_list_free(lrm_state_list); lrm_state_list = NULL;
     return res;
 }

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1145,7 +1145,7 @@ cancel_op(lrm_state_t * lrm_state, const char *rsc_id, const char *key, int op, 
 
     if (pending) {
         if (remove && is_not_set(pending->flags, active_op_remove)) {
-            set_bit(pending->flags, active_op_remove);
+            controld_set_active_op_flags(pending, active_op_remove);
             crm_debug("Scheduling %s for removal", key);
         }
 
@@ -1154,7 +1154,7 @@ cancel_op(lrm_state_t * lrm_state, const char *rsc_id, const char *key, int op, 
             free(local_key);
             return FALSE;
         }
-        set_bit(pending->flags, active_op_cancelled);
+        controld_set_active_op_flags(pending, active_op_cancelled);
 
     } else {
         crm_info("No pending op found for %s", key);

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -2391,7 +2391,7 @@ cib_rsc_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *use
 
     if (call_id == last_resource_update) {
         last_resource_update = 0;
-        trigger_fsa(fsa_source);
+        trigger_fsa();
     }
 }
 

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -441,7 +441,7 @@ crmd_proxy_dispatch(const char *session, xmlNode *msg)
     if (controld_authorize_ipc_message(msg, NULL, session)) {
         route_message(C_IPC_MESSAGE, msg);
     }
-    trigger_fsa(fsa_source);
+    trigger_fsa();
 }
 
 static void

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -11,6 +11,7 @@
 #include <crm/crm.h>
 #include <crm/msg_xml.h>
 #include <crm/common/xml.h>
+#include <crm/fencing/internal.h>
 
 #include <pacemaker-controld.h>
 
@@ -814,7 +815,7 @@ fence_with_delay(const char *target, const char *type, const char *delay)
     int timeout_sec = (int) (transition_graph->stonith_timeout / 1000);
 
     if (crmd_join_phase_count(crm_join_confirmed) == 1) {
-        options |= st_opt_allow_suicide;
+        stonith__set_call_options(options, target, st_opt_allow_suicide);
     }
     return stonith_api->cmds->fence_with_delay(stonith_api, options, target,
                                                type, timeout_sec, 0,

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -654,7 +654,7 @@ controld_trigger_fencer_connect()
                                                  te_connect_stonith,
                                                  GINT_TO_POINTER(TRUE));
     }
-    set_bit(fsa_input_register, R_ST_REQUIRED);
+    controld_set_fsa_input_flags(R_ST_REQUIRED);
     mainloop_set_trigger(stonith_reconnect);
 }
 
@@ -663,7 +663,7 @@ controld_disconnect_fencer(bool destroy)
 {
     if (stonith_api) {
         // Prevent fencer connection from coming up again
-        clear_bit(fsa_input_register, R_ST_REQUIRED);
+        controld_clear_fsa_input_flags(R_ST_REQUIRED);
 
         if (stonith_api->state != stonith_disconnected) {
             stonith_api->cmds->disconnect(stonith_api);

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -11,6 +11,7 @@
 
 #include <sys/param.h>
 #include <stdio.h>
+#include <stdint.h>                 // uint64_t
 #include <string.h>
 #include <time.h>
 
@@ -36,7 +37,7 @@ char *fsa_cluster_name = NULL;
 
 gboolean do_fsa_stall = FALSE;
 uint64_t fsa_input_register = 0;
-long long fsa_actions = A_NOTHING;
+uint64_t fsa_actions = A_NOTHING;
 enum crmd_fsa_state fsa_state = S_STARTING;
 
 extern uint highest_born_on;
@@ -45,9 +46,9 @@ extern uint num_join_invites;
 #define DOT_PREFIX "actions:trace: "
 #define do_dot_log(fmt, args...)     crm_trace( fmt, ##args)
 
-long long do_state_transition(long long actions,
-                              enum crmd_fsa_state cur_state,
-                              enum crmd_fsa_state next_state, fsa_data_t * msg_data);
+static void do_state_transition(enum crmd_fsa_state cur_state,
+                                enum crmd_fsa_state next_state,
+                                fsa_data_t *msg_data);
 
 void s_crmd_fsa_actions(fsa_data_t * fsa_data);
 void log_fsa_input(fsa_data_t * stored_msg);
@@ -104,12 +105,12 @@ do_fsa_action(fsa_data_t * fsa_data, long long an_action,
                                 enum crmd_fsa_state cur_state,
                                 enum crmd_fsa_input cur_input, fsa_data_t * msg_data))
 {
-    fsa_actions &= ~an_action;
+    controld_clear_fsa_action_flags(an_action);
     crm_trace(DOT_PREFIX "\t// %s", fsa_action2string(an_action));
     function(an_action, fsa_data->fsa_cause, fsa_state, fsa_data->fsa_input, fsa_data);
 }
 
-static long long startup_actions =
+static const uint64_t startup_actions =
     A_STARTUP | A_CIB_START | A_LRM_CONNECT | A_HA_CONNECT | A_READCONFIG |
     A_STARTED | A_CL_JOIN_QUERY;
 
@@ -159,7 +160,7 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
 {
     fsa_data_t *fsa_data = NULL;
     uint64_t register_copy = fsa_input_register;
-    long long new_actions = A_NOTHING;
+    uint64_t new_actions = A_NOTHING;
     enum crmd_fsa_state last_state;
 
     crm_trace("FSA invoked with Cause: %s\tState: %s",
@@ -189,12 +190,12 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
         log_fsa_input(fsa_data);
 
         /* add any actions back to the queue */
-        fsa_actions |= fsa_data->actions;
+        controld_set_fsa_action_flags(fsa_data->actions);
         fsa_dump_actions(fsa_data->actions, "Restored actions");
 
         /* get the next batch of actions */
         new_actions = crmd_fsa_actions[fsa_data->fsa_input][fsa_state];
-        fsa_actions |= new_actions;
+        controld_set_fsa_action_flags(new_actions);
         fsa_dump_actions(new_actions, "New actions");
 
         if (fsa_data->fsa_input != I_NULL && fsa_data->fsa_input != I_ROUTER) {
@@ -223,7 +224,7 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
          * Remove certain actions during shutdown
          */
         if (fsa_state == S_STOPPING || ((fsa_input_register & R_SHUTDOWN) == R_SHUTDOWN)) {
-            clear_bit(fsa_actions, startup_actions);
+            controld_clear_fsa_action_flags(startup_actions);
         }
 
         /*
@@ -231,7 +232,7 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
          * Allows actions to be added or removed when entering a state
          */
         if (last_state != fsa_state) {
-            fsa_actions = do_state_transition(fsa_actions, last_state, fsa_state, fsa_data);
+            do_state_transition(last_state, fsa_state, fsa_data);
         } else {
             do_dot_log(DOT_PREFIX "\t// FSA input: State=%s \tCause=%s"
                        " \tInput=%s \tOrigin=%s() \tid=%d",
@@ -249,7 +250,9 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
     if ((fsa_message_queue != NULL) || (fsa_actions != A_NOTHING)
         || do_fsa_stall) {
         crm_debug("Exiting the FSA: queue=%d, fsa_actions=0x%llx, stalled=%s",
-                  g_list_length(fsa_message_queue), fsa_actions, do_fsa_stall ? "true" : "false");
+                  g_list_length(fsa_message_queue),
+                  (unsigned long long) fsa_actions,
+                  (do_fsa_stall? "true" : "false"));
     } else {
         crm_trace("Exiting the FSA");
     }
@@ -435,7 +438,8 @@ s_crmd_fsa_actions(fsa_data_t * fsa_data)
             /* Error checking and reporting */
         } else {
             crm_err("Action %s not supported "CRM_XS" 0x%llx",
-                    fsa_action2string(fsa_actions), fsa_actions);
+                    fsa_action2string(fsa_actions),
+                    (unsigned long long) fsa_actions);
             register_fsa_error_adv(C_FSA_INTERNAL, I_ERROR, fsa_data, NULL, __FUNCTION__);
         }
     }
@@ -500,15 +504,16 @@ check_join_counts(fsa_data_t *msg_data)
     }
 }
 
-long long
-do_state_transition(long long actions,
-                    enum crmd_fsa_state cur_state,
-                    enum crmd_fsa_state next_state, fsa_data_t * msg_data)
+static void
+do_state_transition(enum crmd_fsa_state cur_state,
+                    enum crmd_fsa_state next_state, fsa_data_t *msg_data)
 {
     int level = LOG_INFO;
     int count = 0;
-    long long tmp = actions;
     gboolean clear_recovery_bit = TRUE;
+#if 0
+    uint64_t original_fsa_actions = fsa_actions;
+#endif
 
     enum crmd_fsa_cause cause = msg_data->fsa_cause;
     enum crmd_fsa_input current_input = msg_data->fsa_input;
@@ -544,23 +549,23 @@ do_state_transition(long long actions,
     }
 #if 0
     if ((fsa_input_register & R_SHUTDOWN)) {
-        set_bit(tmp, A_DC_TIMER_STOP);
+        controld_set_fsa_action_flags(A_DC_TIMER_STOP);
     }
 #endif
     if (next_state == S_INTEGRATION) {
-        set_bit(tmp, A_INTEGRATE_TIMER_START);
+        controld_set_fsa_action_flags(A_INTEGRATE_TIMER_START);
     } else {
-        set_bit(tmp, A_INTEGRATE_TIMER_STOP);
+        controld_set_fsa_action_flags(A_INTEGRATE_TIMER_STOP);
     }
 
     if (next_state == S_FINALIZE_JOIN) {
-        set_bit(tmp, A_FINALIZE_TIMER_START);
+        controld_set_fsa_action_flags(A_FINALIZE_TIMER_START);
     } else {
-        set_bit(tmp, A_FINALIZE_TIMER_STOP);
+        controld_set_fsa_action_flags(A_FINALIZE_TIMER_STOP);
     }
 
     if (next_state != S_PENDING) {
-        set_bit(tmp, A_DC_TIMER_STOP);
+        controld_set_fsa_action_flags(A_DC_TIMER_STOP);
     }
     if (next_state != S_ELECTION) {
         highest_born_on = 0;
@@ -587,7 +592,7 @@ do_state_transition(long long actions,
 
             if (is_set(fsa_input_register, R_SHUTDOWN)) {
                 crm_info("(Re)Issuing shutdown request now" " that we have a new DC");
-                set_bit(tmp, A_SHUTDOWN_REQ);
+                controld_set_fsa_action_flags(A_SHUTDOWN_REQ);
             }
             CRM_LOG_ASSERT(fsa_our_dc != NULL);
             if (fsa_our_dc == NULL) {
@@ -636,7 +641,7 @@ do_state_transition(long long actions,
             CRM_LOG_ASSERT(AM_I_DC);
             if (is_set(fsa_input_register, R_SHUTDOWN)) {
                 crm_info("(Re)Issuing shutdown request now" " that we are the DC");
-                set_bit(tmp, A_SHUTDOWN_REQ);
+                controld_set_fsa_action_flags(A_SHUTDOWN_REQ);
             }
             controld_start_recheck_timer();
             break;
@@ -646,15 +651,14 @@ do_state_transition(long long actions,
     }
 
     if (clear_recovery_bit && next_state != S_PENDING) {
-        tmp &= ~A_RECOVER;
+        controld_clear_fsa_action_flags(A_RECOVER);
     } else if (clear_recovery_bit == FALSE) {
-        tmp |= A_RECOVER;
+        controld_set_fsa_action_flags(A_RECOVER);
     }
 
-    if (tmp != actions) {
-        /* fsa_dump_actions(actions ^ tmp, "New actions"); */
-        actions = tmp;
+#if 0
+    if (original_fsa_actions != fsa_actions) {
+        fsa_dump_actions(original_fsa_actions ^ fsa_actions, "New actions");
     }
-
-    return actions;
+#endif
 }

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -35,7 +35,7 @@ char *fsa_our_uname = NULL;
 char *fsa_cluster_name = NULL;
 
 gboolean do_fsa_stall = FALSE;
-long long fsa_input_register = 0;
+uint64_t fsa_input_register = 0;
 long long fsa_actions = A_NOTHING;
 enum crmd_fsa_state fsa_state = S_STARTING;
 
@@ -158,7 +158,7 @@ enum crmd_fsa_state
 s_crmd_fsa(enum crmd_fsa_cause cause)
 {
     fsa_data_t *fsa_data = NULL;
-    long long register_copy = fsa_input_register;
+    uint64_t register_copy = fsa_input_register;
     long long new_actions = A_NOTHING;
     enum crmd_fsa_state last_state;
 
@@ -256,7 +256,7 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
 
     /* cleanup inputs? */
     if (register_copy != fsa_input_register) {
-        long long same = register_copy & fsa_input_register;
+        uint64_t same = register_copy & fsa_input_register;
 
         fsa_dump_inputs(LOG_DEBUG, "Added", fsa_input_register ^ same);
         fsa_dump_inputs(LOG_DEBUG, "Removed", register_copy ^ same);
@@ -629,7 +629,7 @@ do_state_transition(long long actions,
         case S_STOPPING:
         case S_TERMINATE:
             /* possibly redundant */
-            set_bit(fsa_input_register, R_SHUTDOWN);
+            controld_set_fsa_input_flags(R_SHUTDOWN);
             break;
 
         case S_IDLE:

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -452,7 +452,7 @@ struct fsa_data_s {
     int id;
     enum crmd_fsa_input fsa_input;
     enum crmd_fsa_cause fsa_cause;
-    long long actions;
+    uint64_t actions;
     const char *origin;
     void *data;
     enum fsa_data_type data_type;
@@ -462,7 +462,7 @@ struct fsa_data_s {
 extern gboolean do_fsa_stall;
 extern enum crmd_fsa_state fsa_state;
 extern uint64_t fsa_input_register;
-extern long long fsa_actions;
+extern uint64_t fsa_actions;
 
 #define controld_set_fsa_input_flags(flags_to_set) do {                     \
         fsa_input_register = pcmk__set_flags_as(__FUNCTION__, __LINE__,     \
@@ -480,6 +480,22 @@ extern long long fsa_actions;
                                                   fsa_input_register,       \
                                                   (flags_to_clear),         \
                                                   #flags_to_clear);         \
+    } while (0)
+
+#define controld_set_fsa_action_flags(flags_to_set) do {                    \
+        fsa_actions = pcmk__set_flags_as(__FUNCTION__, __LINE__,            \
+                                         LOG_DEBUG,                         \
+                                         "FSA action", "controller",        \
+                                         fsa_actions, (flags_to_set),       \
+                                         #flags_to_set);                    \
+    } while (0)
+
+#define controld_clear_fsa_action_flags(flags_to_clear) do {                \
+        fsa_actions = pcmk__clear_flags_as(__FUNCTION__, __LINE__,          \
+                                           LOG_DEBUG,                       \
+                                           "FSA action", "controller",      \
+                                           fsa_actions, (flags_to_clear),   \
+                                           #flags_to_clear);                \
     } while (0)
 
 extern cib_t *fsa_cib_conn;

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -513,9 +513,11 @@ enum crmd_fsa_state s_crmd_fsa(enum crmd_fsa_cause cause);
 
 #  define AM_I_DC is_set(fsa_input_register, R_THE_DC)
 #  define AM_I_OPERATIONAL (is_set(fsa_input_register, R_STARTING) == FALSE)
-#  define trigger_fsa(source) do { \
-        crm_trace("Triggering FSA: %s", __FUNCTION__); \
-        mainloop_set_trigger(source); \
+#  define trigger_fsa() do {                    \
+        if (fsa_source != NULL) {               \
+            crm_trace("Triggering FSA");        \
+            mainloop_set_trigger(fsa_source);   \
+        }                                       \
     } while(0)
 
 /* A_READCONFIG */

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -461,8 +461,26 @@ struct fsa_data_s {
 /* Global FSA stuff */
 extern gboolean do_fsa_stall;
 extern enum crmd_fsa_state fsa_state;
-extern long long fsa_input_register;
+extern uint64_t fsa_input_register;
 extern long long fsa_actions;
+
+#define controld_set_fsa_input_flags(flags_to_set) do {                     \
+        fsa_input_register = pcmk__set_flags_as(__FUNCTION__, __LINE__,     \
+                                                LOG_TRACE,                  \
+                                                "FSA input", "controller",  \
+                                                fsa_input_register,         \
+                                                (flags_to_set),             \
+                                                #flags_to_set);             \
+    } while (0)
+
+#define controld_clear_fsa_input_flags(flags_to_clear) do {                 \
+        fsa_input_register = pcmk__clear_flags_as(__FUNCTION__, __LINE__,   \
+                                                  LOG_TRACE,                \
+                                                  "FSA input", "controller",\
+                                                  fsa_input_register,       \
+                                                  (flags_to_clear),         \
+                                                  #flags_to_clear);         \
+    } while (0)
 
 extern cib_t *fsa_cib_conn;
 

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -144,7 +144,7 @@ do_cl_join_offer_respond(long long action,
     fsa_register_cib_callback(query_call_id, FALSE, strdup(join_id), join_query_callback);
     crm_trace("Registered join query callback: %d", query_call_id);
 
-    register_fsa_action(A_DC_TIMER_STOP);
+    controld_set_fsa_action_flags(A_DC_TIMER_STOP);
     trigger_fsa();
 }
 

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -145,6 +145,7 @@ do_cl_join_offer_respond(long long action,
     crm_trace("Registered join query callback: %d", query_call_id);
 
     register_fsa_action(A_DC_TIMER_STOP);
+    trigger_fsa();
 }
 
 void

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -87,8 +87,7 @@ start_join_round(void)
         free_xml(max_generation_xml);
         max_generation_xml = NULL;
     }
-    clear_bit(fsa_input_register, R_HAVE_CIB);
-    clear_bit(fsa_input_register, R_CIB_ASKED);
+    controld_clear_fsa_input_flags(R_HAVE_CIB|R_CIB_ASKED);
 }
 
 /*!
@@ -433,9 +432,9 @@ do_dc_join_finalize(long long action,
         return;
     }
 
-    clear_bit(fsa_input_register, R_HAVE_CIB);
+    controld_clear_fsa_input_flags(R_HAVE_CIB);
     if (pcmk__str_eq(max_generation_from, fsa_our_uname, pcmk__str_null_matches | pcmk__str_casei)) {
-        set_bit(fsa_input_register, R_HAVE_CIB);
+        controld_set_fsa_input_flags(R_HAVE_CIB);
     }
 
     if (is_set(fsa_input_register, R_IN_TRANSITION)) {
@@ -449,7 +448,7 @@ do_dc_join_finalize(long long action,
     if (max_generation_from && is_set(fsa_input_register, R_HAVE_CIB) == FALSE) {
         /* ask for the agreed best CIB */
         sync_from = strdup(max_generation_from);
-        set_bit(fsa_input_register, R_CIB_ASKED);
+        controld_set_fsa_input_flags(R_CIB_ASKED);
         crm_notice("Finalizing join-%d for %d node%s (sync'ing CIB from %s)",
                    current_join_id, count_integrated,
                    pcmk__plural_s(count_integrated), sync_from);
@@ -473,7 +472,7 @@ void
 finalize_sync_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *user_data)
 {
     CRM_LOG_ASSERT(-EPERM != rc);
-    clear_bit(fsa_input_register, R_CIB_ASKED);
+    controld_clear_fsa_input_flags(R_CIB_ASKED);
     if (rc != pcmk_ok) {
         do_crm_log(((rc == -pcmk_err_old_data)? LOG_WARNING : LOG_ERR),
                    "Could not sync CIB from %s in join-%d: %s",
@@ -490,8 +489,8 @@ finalize_sync_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, voi
                   current_join_id, fsa_state2string(fsa_state));
 
     } else {
-        set_bit(fsa_input_register, R_HAVE_CIB);
-        clear_bit(fsa_input_register, R_CIB_ASKED);
+        controld_set_fsa_input_flags(R_HAVE_CIB);
+        controld_clear_fsa_input_flags(R_CIB_ASKED);
 
         /* make sure dc_uuid is re-set to us */
         if (check_join_state(fsa_state, __FUNCTION__) == FALSE) {

--- a/daemons/controld/controld_lrm.h
+++ b/daemons/controld/controld_lrm.h
@@ -54,6 +54,18 @@ typedef struct active_op_s {
     GHashTable *params;
 } active_op_t;
 
+#define controld_set_active_op_flags(active_op, flags_to_set) do {          \
+        (active_op)->flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,     \
+            LOG_TRACE, "Active operation", (active_op)->op_key,             \
+            (active_op)->flags, (flags_to_set), #flags_to_set);             \
+    } while (0)
+
+#define controld_clear_active_op_flags(active_op, flags_to_clear) do {      \
+        (active_op)->flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__,   \
+            LOG_TRACE, "Active operation", (active_op)->op_key,             \
+            (active_op)->flags, (flags_to_clear), #flags_to_clear);         \
+    } while (0)
+
 typedef struct lrm_state_s {
     const char *node_name;
     void *conn;                 // Reserved for controld_execd_state.c usage

--- a/daemons/controld/controld_matrix.h
+++ b/daemons/controld/controld_matrix.h
@@ -1,19 +1,10 @@
 /*
- * Copyright (C) 2004 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * The version control history for this file may have further details.
  *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
 #ifndef XML_FSA_MATRIX__H
@@ -627,7 +618,7 @@ const enum crmd_fsa_state crmd_fsa_state[MAXINPUT][MAXSTATE] = {
 
 /* NOTE: In the fsa, the actions are extracted then state is updated. */
 
-const long long crmd_fsa_actions[MAXINPUT][MAXSTATE] = {
+const uint64_t crmd_fsa_actions[MAXINPUT][MAXSTATE] = {
 
 /* Got an I_NULL */
     {

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -77,7 +77,7 @@ post_cache_update(int instance)
      * If we lost nodes, we should re-check the election status
      * Safe to call outside of an election
      */
-    register_fsa_action(A_ELECTION_CHECK);
+    controld_set_fsa_action_flags(A_ELECTION_CHECK);
     trigger_fsa();
 
     /* Membership changed, remind everyone we're here.

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -66,7 +66,7 @@ post_cache_update(int instance)
     crm_debug("Updated cache after membership event %d.", instance);
 
     g_hash_table_foreach(crm_peer_cache, reap_dead_nodes, NULL);
-    set_bit(fsa_input_register, R_MEMBERSHIP);
+    controld_set_fsa_input_flags(R_MEMBERSHIP);
 
     if (AM_I_DC) {
         populate_cib_nodes(node_update_quick | node_update_cluster | node_update_peer |

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -78,6 +78,7 @@ post_cache_update(int instance)
      * Safe to call outside of an election
      */
     register_fsa_action(A_ELECTION_CHECK);
+    trigger_fsa();
 
     /* Membership changed, remind everyone we're here.
      * This will aid detection of duplicate DCs

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -58,7 +58,7 @@ register_fsa_error_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
 
 int
 register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
-                       void *data, long long with_actions,
+                       void *data, uint64_t with_actions,
                        gboolean prepend, const char *raised_from)
 {
     unsigned old_len = g_list_length(fsa_message_queue);
@@ -85,7 +85,7 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
         }
 
         if (data == NULL) {
-            fsa_actions |= with_actions;
+            controld_set_fsa_action_flags(with_actions);
             fsa_dump_actions(with_actions, "Restored");
             return 0;
         }
@@ -111,7 +111,8 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
     fsa_data->actions = with_actions;
 
     if (with_actions != A_NOTHING) {
-        crm_trace("Adding actions %.16llx to input", with_actions);
+        crm_trace("Adding actions %.16llx to input",
+                  (unsigned long long) with_actions);
     }
 
     if (data != NULL) {

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -897,7 +897,7 @@ verify_feature_set(xmlNode *msg)
                 CRM_FEATURE_SET, dc_version);
 
         // Nothing is likely to improve without administrator involvement
-        set_bit(fsa_input_register, R_STAYDOWN);
+        controld_set_fsa_input_flags(R_STAYDOWN);
         crmd_exit(CRM_EX_FATAL);
     }
 }
@@ -954,7 +954,7 @@ handle_shutdown_ack(xmlNode *stored_msg)
         } else {
             crm_err("Shutting down controller after unexpected "
                     "shutdown request from %s", host_from);
-            set_bit(fsa_input_register, R_STAYDOWN);
+            controld_set_fsa_input_flags(R_STAYDOWN);
         }
         return I_STOP;
     }

--- a/daemons/controld/controld_messages.h
+++ b/daemons/controld/controld_messages.h
@@ -36,7 +36,7 @@ extern void register_fsa_error_adv(enum crmd_fsa_cause cause, enum crmd_fsa_inpu
 #  define register_fsa_error(cause, input, new_data) register_fsa_error_adv(cause, input, msg_data, new_data, __FUNCTION__)
 
 extern int register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
-                                  void *data, long long with_actions,
+                                  void *data, uint64_t with_actions,
                                   gboolean prepend, const char *raised_from);
 
 extern void fsa_dump_queue(int log_level);
@@ -55,12 +55,6 @@ extern void route_message(enum crmd_fsa_cause cause, xmlNode * input);
     } while(0)
 
 #  define register_fsa_input(cause, input, data) register_fsa_input_adv(cause, input, data, A_NOTHING, FALSE, __FUNCTION__)
-
-#  define register_fsa_action(action) {					\
-		fsa_actions |= action;					\
-		crm_debug("%s added action %s to the FSA",		\
-			  __FUNCTION__, fsa_action2string(action));	\
-	}
 
 #  define register_fsa_input_before(cause, input, data) register_fsa_input_adv(cause, input, data, A_NOTHING, TRUE, __FUNCTION__)
 

--- a/daemons/controld/controld_messages.h
+++ b/daemons/controld/controld_messages.h
@@ -58,9 +58,6 @@ extern void route_message(enum crmd_fsa_cause cause, xmlNode * input);
 
 #  define register_fsa_action(action) {					\
 		fsa_actions |= action;					\
-		if(fsa_source) {					\
-			mainloop_set_trigger(fsa_source);			\
-		}							\
 		crm_debug("%s added action %s to the FSA",		\
 			  __FUNCTION__, fsa_action2string(action));	\
 	}

--- a/daemons/controld/controld_metadata.c
+++ b/daemons/controld/controld_metadata.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the Pacemaker project contributors
+ * Copyright 2017-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -164,12 +164,12 @@ ra_param_from_xml(xmlNode *param_xml)
 
     value = crm_element_value(param_xml, "unique");
     if (crm_is_true(value)) {
-        set_bit(p->rap_flags, ra_param_unique);
+        controld_set_ra_param_flags(p, ra_param_unique);
     }
 
     value = crm_element_value(param_xml, "private");
     if (crm_is_true(value)) {
-        set_bit(p->rap_flags, ra_param_private);
+        controld_set_ra_param_flags(p, ra_param_private);
     }
     return p;
 }
@@ -216,7 +216,7 @@ metadata_cache_update(GHashTable *mdc, lrmd_rsc_info_t *rsc,
         const char *action_name = crm_element_value(match, "name");
 
         if (pcmk__str_eq(action_name, "reload", pcmk__str_casei)) {
-            set_bit(md->ra_flags, ra_supports_reload);
+            controld_set_ra_flags(md, key, ra_supports_reload);
             break; // since this is the only action we currently care about
         }
     }
@@ -238,7 +238,7 @@ metadata_cache_update(GHashTable *mdc, lrmd_rsc_info_t *rsc,
                 goto err;
             }
             if (is_set(p->rap_flags, ra_param_private)) {
-                set_bit(md->ra_flags, ra_uses_private);
+                controld_set_ra_flags(md, key, ra_uses_private);
             }
             md->ra_params = g_list_prepend(md->ra_params, p);
         }

--- a/daemons/controld/controld_metadata.h
+++ b/daemons/controld/controld_metadata.h
@@ -1,12 +1,14 @@
-#ifndef CRMD_METADATA_H
-#define CRMD_METADATA_H
-
 /*
- * Copyright (C) 2017 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2017-2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
  */
+
+#ifndef CRMD_METADATA_H
+#define CRMD_METADATA_H
 
 enum ra_flags_e {
     ra_supports_reload  = 0x01,
@@ -28,6 +30,18 @@ struct ra_metadata_s {
     GList *ra_params;   // ra_param_s
     uint32_t ra_flags;  // bitmask of ra_flags_e
 };
+
+#define controld_set_ra_flags(ra_md, ra_key, flags_to_set) do {             \
+        (ra_md)->ra_flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,      \
+            LOG_TRACE, "Resource agent", ra_key,                            \
+            (ra_md)->ra_flags, (flags_to_set), #flags_to_set);              \
+    } while (0)
+
+#define controld_set_ra_param_flags(ra_param, flags_to_set) do {            \
+        (ra_param)->rap_flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,  \
+            LOG_TRACE, "Resource agent parameter", (ra_param)->rap_name,    \
+            (ra_param)->rap_flags, (flags_to_set), #flags_to_set);          \
+    } while (0)
 
 GHashTable *metadata_cache_new(void);
 void metadata_cache_free(GHashTable *mdc);

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -28,12 +28,12 @@ static mainloop_io_t *pe_subsystem = NULL;
 void
 pe_subsystem_free(void)
 {
-    clear_bit(fsa_input_register, R_PE_REQUIRED);
+    controld_clear_fsa_input_flags(R_PE_REQUIRED);
     if (pe_subsystem) {
         controld_expect_sched_reply(NULL);
         mainloop_del_ipc_client(pe_subsystem);
         pe_subsystem = NULL;
-        clear_bit(fsa_input_register, R_PE_CONNECTED);
+        controld_clear_fsa_input_flags(R_PE_CONNECTED);
     }
 }
 
@@ -108,7 +108,7 @@ pe_ipc_destroy(gpointer user_data)
         crm_info("Connection to the scheduler released");
     }
 
-    clear_bit(fsa_input_register, R_PE_CONNECTED);
+    controld_clear_fsa_input_flags(R_PE_CONNECTED);
     pe_subsystem = NULL;
     mainloop_set_trigger(fsa_source);
     return;
@@ -150,7 +150,7 @@ pe_subsystem_new(void)
         .destroy = pe_ipc_destroy
     };
 
-    set_bit(fsa_input_register, R_PE_REQUIRED);
+    controld_set_fsa_input_flags(R_PE_REQUIRED);
     pe_subsystem = mainloop_add_ipc_client(CRM_SYSTEM_PENGINE,
                                            G_PRIORITY_DEFAULT,
                                            5 * 1024 * 1024 /* 5MB */,
@@ -158,7 +158,7 @@ pe_subsystem_new(void)
     if (pe_subsystem == NULL) {
         return FALSE;
     }
-    set_bit(fsa_input_register, R_PE_CONNECTED);
+    controld_set_fsa_input_flags(R_PE_CONNECTED);
     return TRUE;
 }
 

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -319,6 +319,7 @@ do_pe_invoke(long long action,
             crm_info("Waiting for the scheduler to connect");
             crmd_fsa_stall(FALSE);
             register_fsa_action(A_PE_START);
+            trigger_fsa();
         }
         return;
     }
@@ -430,6 +431,7 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
                   (num_cib_op_callbacks() - 1));
         sleep(1);
         register_fsa_action(A_PE_INVOKE);
+        trigger_fsa();
         return;
 
     } else if (fsa_state != S_POLICY_ENGINE) {

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -318,7 +318,7 @@ do_pe_invoke(long long action,
         } else {
             crm_info("Waiting for the scheduler to connect");
             crmd_fsa_stall(FALSE);
-            register_fsa_action(A_PE_START);
+            controld_set_fsa_action_flags(A_PE_START);
             trigger_fsa();
         }
         return;
@@ -430,7 +430,7 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
         crm_debug("Re-asking for the CIB: %d other peer updates still pending",
                   (num_cib_op_callbacks() - 1));
         sleep(1);
-        register_fsa_action(A_PE_INVOKE);
+        controld_set_fsa_action_flags(A_PE_INVOKE);
         trigger_fsa();
         return;
 

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -612,7 +612,7 @@ notify_crmd(crm_graph_t * graph)
                 }
 
             } else if (fsa_state == S_POLICY_ENGINE) {
-                register_fsa_action(A_PE_INVOKE);
+                controld_set_fsa_action_flags(A_PE_INVOKE);
                 trigger_fsa();
             }
             break;

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -631,7 +631,7 @@ notify_crmd(crm_graph_t * graph)
 
     graph->abort_reason = NULL;
     graph->completion_action = tg_done;
-    clear_bit(fsa_input_register, R_IN_TRANSITION);
+    controld_clear_fsa_input_flags(R_IN_TRANSITION);
 
     if (event != I_NULL) {
         register_fsa_input(C_FSA_INTERNAL, event, NULL);

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -613,6 +613,7 @@ notify_crmd(crm_graph_t * graph)
 
             } else if (fsa_state == S_POLICY_ENGINE) {
                 register_fsa_action(A_PE_INVOKE);
+                trigger_fsa();
             }
             break;
 

--- a/daemons/controld/controld_transition.c
+++ b/daemons/controld/controld_transition.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -53,7 +53,7 @@ do_te_control(long long action,
                                                     te_update_diff);
         }
 
-        clear_bit(fsa_input_register, R_TE_CONNECTED);
+        controld_clear_fsa_input_flags(R_TE_CONNECTED);
         crm_info("Transitioner is now inactive");
     }
 
@@ -105,7 +105,7 @@ do_te_control(long long action,
         /* create a blank one */
         crm_debug("Transitioner is now active");
         transition_graph = create_blank_graph();
-        set_bit(fsa_input_register, R_TE_CONNECTED);
+        controld_set_fsa_input_flags(R_TE_CONNECTED);
     }
 }
 

--- a/daemons/controld/controld_utils.c
+++ b/daemons/controld/controld_utils.c
@@ -10,6 +10,7 @@
 #include <crm_internal.h>
 
 #include <stdlib.h>
+#include <stdint.h>                 // uint64_t
 
 #include <crm/crm.h>
 #include <crm/cib.h>
@@ -529,7 +530,7 @@ fsa_dump_inputs(int log_level, const char *text, long long input_register)
 }
 
 void
-fsa_dump_actions(long long action, const char *text)
+fsa_dump_actions(uint64_t action, const char *text)
 {
     if (is_set(action, A_READCONFIG)) {
         crm_trace("Action %.16llx (A_READCONFIG) %s", A_READCONFIG, text);
@@ -717,7 +718,7 @@ update_dc(xmlNode * msg)
                 crm_warn("New DC %s is not %s", welcome_from, fsa_our_dc);
             }
 
-            register_fsa_action(A_CL_JOIN_QUERY | A_DC_TIMER_START);
+            controld_set_fsa_action_flags(A_CL_JOIN_QUERY | A_DC_TIMER_START);
             trigger_fsa();
             return FALSE;
         }

--- a/daemons/controld/controld_utils.c
+++ b/daemons/controld/controld_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -718,6 +718,7 @@ update_dc(xmlNode * msg)
             }
 
             register_fsa_action(A_CL_JOIN_QUERY | A_DC_TIMER_START);
+            trigger_fsa();
             return FALSE;
         }
     }

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -62,7 +62,7 @@ void controld_stop_sched_timer(void);
 void controld_free_sched_timer(void);
 void controld_expect_sched_reply(xmlNode *msg);
 
-void fsa_dump_actions(long long action, const char *text);
+void fsa_dump_actions(uint64_t action, const char *text);
 void fsa_dump_inputs(int log_level, const char *text, long long input_register);
 
 gboolean update_dc(xmlNode * msg);

--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -17,6 +17,7 @@
 #include <crm/common/mainloop.h>
 
 #include <crm/pengine/status.h>
+#include <crm/pengine/internal.h>
 #include <crm/cib.h>
 #include <crm/lrmd.h>
 
@@ -439,8 +440,7 @@ generate_params(void)
         crm_crit("Could not allocate working set");
         return -ENOMEM;
     }
-    set_bit(data_set->flags, pe_flag_no_counts);
-    set_bit(data_set->flags, pe_flag_no_compat);
+    pe__set_working_set_flags(data_set, pe_flag_no_counts|pe_flag_no_compat);
 
     cib_conn = cib_new();
     rc = cib_conn->cmds->signon(cib_conn, "cts-exec-helper", cib_query);

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -292,7 +292,11 @@ create_lrmd_cmd(xmlNode *msg, pcmk__client_t *client)
         crm_debug("Setting flag to leave pid group on timeout and "
                   "only kill action pid for " PCMK__OP_FMT,
                   cmd->rsc_id, cmd->action, cmd->interval_ms);
-        cmd->service_flags |= SVC_ACTION_LEAVE_GROUP;
+        cmd->service_flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,
+                                                LOG_TRACE, "Action",
+                                                cmd->action, 0,
+                                                SVC_ACTION_LEAVE_GROUP,
+                                                "SVC_ACTION_LEAVE_GROUP");
     }
     return cmd;
 }

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -209,16 +209,17 @@ int
 lrmd_server_send_reply(pcmk__client_t *client, uint32_t id, xmlNode *reply)
 {
     crm_trace("Sending reply (%d) to client (%s)", id, client->id);
-    switch (client->kind) {
-        case PCMK__CLIENT_IPC:
+    switch (PCMK__CLIENT_TYPE(client)) {
+        case pcmk__client_ipc:
             return pcmk__ipc_send_xml(client, id, reply, FALSE);
 #ifdef ENABLE_PCMK_REMOTE
-        case PCMK__CLIENT_TLS:
+        case pcmk__client_tls:
             return lrmd_tls_send_msg(client->remote, reply, id, "reply");
 #endif
         default:
-            crm_err("Could not send reply: unknown client type %d",
-                    client->kind);
+            crm_err("Could not send reply: unknown client type for %s "
+                    CRM_XS " flags=0x%llx",
+                    pcmk__client_name(client), client->flags);
     }
     return ENOTCONN;
 }
@@ -228,15 +229,15 @@ int
 lrmd_server_send_notify(pcmk__client_t *client, xmlNode *msg)
 {
     crm_trace("Sending notification to client (%s)", client->id);
-    switch (client->kind) {
-        case PCMK__CLIENT_IPC:
+    switch (PCMK__CLIENT_TYPE(client)) {
+        case pcmk__client_ipc:
             if (client->ipcs == NULL) {
                 crm_trace("Could not notify local client: disconnected");
                 return ENOTCONN;
             }
             return pcmk__ipc_send_xml(client, 0, msg, crm_ipc_server_event);
 #ifdef ENABLE_PCMK_REMOTE
-        case PCMK__CLIENT_TLS:
+        case pcmk__client_tls:
             if (client->remote == NULL) {
                 crm_trace("Could not notify remote client: disconnected");
                 return ENOTCONN;
@@ -245,7 +246,9 @@ lrmd_server_send_notify(pcmk__client_t *client, xmlNode *msg)
             }
 #endif
         default:
-            crm_err("Could not notify client: unknown type %d", client->kind);
+            crm_err("Could not notify client %s with unknown transport "
+                    CRM_XS " flags=0x%llx",
+                    pcmk__client_name(client), client->flags);
     }
     return ENOTCONN;
 }

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -253,7 +253,7 @@ ipc_proxy_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
     /* This ensures that synced request/responses happen over the event channel
      * in the controller, allowing the controller to process the messages async.
      */
-    set_bit(flags, crm_ipc_proxied);
+    pcmk__set_ipc_flags(flags, pcmk__client_name(client), crm_ipc_proxied);
     client->request_id = id;
 
     msg = create_xml_node(NULL, T_LRMD_IPC_PROXY);

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -91,7 +91,7 @@ ipc_proxy_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid, const char *ipc
     /* Allow remote executor to distinguish between proxied local clients and
      * actual executor API clients
      */
-    set_bit(client->flags, pcmk__client_to_proxy);
+    pcmk__set_client_flags(client, pcmk__client_to_proxy);
 
     g_hash_table_insert(ipc_clients, client->id, client);
 

--- a/daemons/execd/remoted_tls.c
+++ b/daemons/execd/remoted_tls.c
@@ -222,7 +222,7 @@ lrmd_remote_listen(gpointer data)
 
     new_client = pcmk__new_unauth_client(NULL);
     new_client->remote = calloc(1, sizeof(pcmk__remote_t));
-    new_client->kind = PCMK__CLIENT_TLS;
+    pcmk__set_client_flags(new_client, pcmk__client_tls);
     new_client->remote->tls_session = session;
 
     // Require the client to authenticate within this time

--- a/daemons/fenced/cts-fence-helper.c
+++ b/daemons/fenced/cts-fence-helper.c
@@ -88,7 +88,7 @@ static pcmk__cli_option_t long_options[] = {
 
 static stonith_t *st = NULL;
 static struct pollfd pollfd;
-static int st_opts = st_opt_sync_call;
+static const int st_opts = st_opt_sync_call;
 static int expected_notifications = 0;
 static int verbose = 0;
 

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -781,11 +781,14 @@ read_action_metadata(stonith_device_t *device)
         action = crm_element_value(match, "name");
 
         if(pcmk__str_eq(action, "list", pcmk__str_casei)) {
-            set_bit(device->flags, st_device_supports_list);
+            stonith__set_device_flags(device->flags, device->id,
+                                      st_device_supports_list);
         } else if(pcmk__str_eq(action, "status", pcmk__str_casei)) {
-            set_bit(device->flags, st_device_supports_status);
+            stonith__set_device_flags(device->flags, device->id,
+                                      st_device_supports_status);
         } else if(pcmk__str_eq(action, "reboot", pcmk__str_casei)) {
-            set_bit(device->flags, st_device_supports_reboot);
+            stonith__set_device_flags(device->flags, device->id,
+                                      st_device_supports_reboot);
         } else if (pcmk__str_eq(action, "on", pcmk__str_casei)) {
             /* "automatic" means the cluster will unfence node when it joins */
             const char *automatic = crm_element_value(match, "automatic");
@@ -903,8 +906,8 @@ build_device_from_xml(xmlNode * msg)
     device->agent_metadata = get_agent_metadata(device->agent);
     if (device->agent_metadata) {
         read_action_metadata(device);
-        set_bit(device->flags,
-                stonith__device_parameter_flags(device->agent_metadata));
+        stonith__device_parameter_flags(&(device->flags), device->id,
+                                        device->agent_metadata);
     }
 
     value = g_hash_table_lookup(device->params, "nodeid");

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2587,13 +2587,13 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
         flag_name = crm_element_value(request, F_STONITH_NOTIFY_ACTIVATE);
         if (flag_name) {
             crm_debug("Setting %s callbacks for %s (%s): ON", flag_name, client->name, client->id);
-            client->options |= get_stonith_flag(flag_name);
+            pcmk__set_client_flags(client, get_stonith_flag(flag_name));
         }
 
         flag_name = crm_element_value(request, F_STONITH_NOTIFY_DEACTIVATE);
         if (flag_name) {
             crm_debug("Setting %s callbacks for %s (%s): off", flag_name, client->name, client->id);
-            client->options |= get_stonith_flag(flag_name);
+            pcmk__set_client_flags(client, get_stonith_flag(flag_name));
         }
 
         if (flags & crm_ipc_client_response) {

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -826,7 +826,7 @@ advance_topology_level(remote_fencing_op_t *op, bool empty_ok)
         return empty_ok? pcmk_rc_ok : ENODEV;
     }
 
-    set_bit(op->call_options, st_opt_topology);
+    stonith__set_call_options(op->call_options, op->id, st_opt_topology);
 
     /* This is a new level, so undo any remapping left over from previous */
     undo_op_remap(op);
@@ -1063,7 +1063,7 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
         crm_node_t *node = crm_find_known_peer_full(nodeid, NULL, CRM_GET_PEER_ANY);
 
         /* Ensure the conversion only happens once */
-        op->call_options &= ~st_opt_cs_nodeid;
+        stonith__clear_call_options(op->call_options, op->id, st_opt_cs_nodeid);
 
         if (node && node->uname) {
             free(op->target);

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -260,7 +260,7 @@ do_local_reply(xmlNode * notify_src, const char *client_id, gboolean sync_reply,
     }
 }
 
-long long
+uint64_t
 get_stonith_flag(const char *name)
 {
     if (pcmk__str_eq(name, T_STONITH_NOTIFY_FENCE, pcmk__str_casei)) {
@@ -301,7 +301,7 @@ stonith_notify_client(gpointer key, gpointer value, gpointer user_data)
         return;
     }
 
-    if (client->options & get_stonith_flag(type)) {
+    if (is_set(client->flags, get_stonith_flag(type))) {
         int rc = pcmk__ipc_send_xml(client, 0, update_msg,
                                     crm_ipc_server_event|crm_ipc_server_error);
 

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -696,8 +696,8 @@ cib_devices_update(void)
     CRM_ASSERT(fenced_data_set != NULL);
     fenced_data_set->input = local_cib;
     fenced_data_set->now = crm_time_new(NULL);
-    fenced_data_set->flags |= pe_flag_quick_location;
     fenced_data_set->localhost = stonith_our_uname;
+    pe__set_working_set_flags(fenced_data_set, pe_flag_quick_location);
 
     cluster_status(fenced_data_set);
     pcmk__schedule_actions(fenced_data_set, NULL, NULL);
@@ -1464,8 +1464,8 @@ main(int argc, char **argv)
 
     fenced_data_set = pe_new_working_set();
     CRM_ASSERT(fenced_data_set != NULL);
-    set_bit(fenced_data_set->flags, pe_flag_no_counts);
-    set_bit(fenced_data_set->flags, pe_flag_no_compat);
+    pe__set_working_set_flags(fenced_data_set,
+                              pe_flag_no_counts|pe_flag_no_compat);
 
     if (stand_alone == FALSE) {
 

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -118,8 +118,8 @@ typedef struct remote_fencing_op_s {
     char *delegate;
     /*! The point at which the remote operation completed */
     time_t completed;
-    /*! The stonith_call_options associated with this remote operation */
-    long long call_options;
+    //! Group of enum stonith_call_options associated with this operation
+    uint32_t call_options;
 
     /*! The current state of the remote operation. This indicates
      * what stage the op is in, query, exec, done, duplicate, failed. */

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -5,6 +5,7 @@
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
  */
 
+#include <stdint.h>                 // uint32_t, uint64_t
 #include <crm/common/mainloop.h>
 
 /*!
@@ -162,13 +163,14 @@ typedef struct remote_fencing_op_s {
  */
 void stonith_bcast_result_to_peers(remote_fencing_op_t * op, int rc, gboolean op_merged);
 
-enum st_callback_flags {
-    st_callback_unknown               = 0x0000,
-    st_callback_notify_fence          = 0x0001,
-    st_callback_device_add            = 0x0004,
-    st_callback_device_del            = 0x0010,
-    st_callback_notify_history        = 0x0020,
-    st_callback_notify_history_synced = 0x0040
+// Fencer-specific client flags
+enum st_client_flags {
+    st_callback_unknown               =  UINT64_C(0),
+    st_callback_notify_fence          = (UINT64_C(1) << 0),
+    st_callback_device_add            = (UINT64_C(1) << 2),
+    st_callback_device_del            = (UINT64_C(1) << 4),
+    st_callback_notify_history        = (UINT64_C(1) << 5),
+    st_callback_notify_history_synced = (UINT64_C(1) << 6)
 };
 
 /*
@@ -207,7 +209,7 @@ void free_stonith_remote_op_list(void);
 void init_stonith_remote_op_hash_table(GHashTable **table);
 void free_metadata_cache(void);
 
-long long get_stonith_flag(const char *name);
+uint64_t get_stonith_flag(const char *name);
 
 void stonith_command(pcmk__client_t *client, uint32_t id, uint32_t flags,
                             xmlNode *op_request, const char *remote_peer);

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -36,7 +36,7 @@ typedef struct stonith_device_s {
     gboolean automatic_unfencing;
     guint priority;
 
-    enum st_device_flags flags;
+    uint32_t flags; // Group of enum st_device_flags
 
     GHashTable *params;
     GHashTable *aliases;

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -96,8 +96,8 @@ process_pe_message(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
         if (sched_data_set == NULL) {
             sched_data_set = pe_new_working_set();
             CRM_ASSERT(sched_data_set != NULL);
-            set_bit(sched_data_set->flags, pe_flag_no_counts);
-            set_bit(sched_data_set->flags, pe_flag_no_compat);
+            pe__set_working_set_flags(sched_data_set,
+                                      pe_flag_no_counts|pe_flag_no_compat);
         }
 
         digest = calculate_xml_versioned_digest(xml_data, FALSE, FALSE, CRM_FEATURE_SET);

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -98,6 +98,18 @@ struct timer_rec_s {
     cib_t *cib;
 };
 
+#define cib__set_call_options(cib_call_opts, call_for, flags_to_set) do {   \
+        cib_call_opts = pcmk__set_flags_as(__FUNCTION__, __LINE__,          \
+            LOG_TRACE, "CIB call", (call_for), (cib_call_opts),             \
+            (flags_to_set), #flags_to_set); \
+    } while (0)
+
+#define cib__clear_call_options(cib_call_opts, call_for, flags_to_clear) do {  \
+        cib_call_opts = pcmk__clear_flags_as(__FUNCTION__, __LINE__,           \
+            LOG_TRACE, "CIB call", (call_for), (cib_call_opts),                \
+            (flags_to_clear), #flags_to_clear);                                \
+    } while (0)
+
 typedef int (*cib_op_t) (const char *, int, const char *, xmlNode *,
                          xmlNode *, xmlNode *, xmlNode **, xmlNode **);
 

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2018 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -11,6 +11,21 @@
 #  define CRM_CLUSTER_INTERNAL__H
 
 #  include <crm/cluster.h>
+
+#define pcmk__set_peer_flags(peer, flags_to_set) do {                         \
+        (peer)->flags = pcmk__set_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, \
+                                           "Peer", (peer)->uname,             \
+                                           (peer)->flags, (flags_to_set),     \
+                                           #flags_to_set);                    \
+    } while (0)
+
+#define pcmk__clear_peer_flags(peer, flags_to_clear) do {                     \
+        (peer)->flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__,          \
+                                             LOG_TRACE,                       \
+                                             "Peer", (peer)->uname,           \
+                                             (peer)->flags, (flags_to_clear), \
+                                             #flags_to_clear);                \
+    } while (0)
 
 typedef struct crm_ais_host_s AIS_Host;
 typedef struct crm_ais_msg_s AIS_Message;

--- a/include/crm/common/attrd_internal.h
+++ b/include/crm/common/attrd_internal.h
@@ -23,6 +23,12 @@ enum pcmk__node_attr_opts {
     pcmk__node_attr_private = (1 << 1),
 };
 
+#define pcmk__set_node_attr_flags(node_attr_flags, flags_to_set) do {   \
+        node_attr_flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,    \
+            LOG_TRACE, "Node attribute", crm_system_name,               \
+            (node_attr_flags), (flags_to_set), #flags_to_set);          \
+    } while (0)
+
 int pcmk__node_attr_request(crm_ipc_t * ipc, char command, const char *host,
                             const char *name, const char *value,
                             const char *section, const char *set,

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -261,18 +261,6 @@ pcmk__clear_flags_as(const char *function, int line, uint8_t log_level,
     return result;
 }
 
-//! \deprecated
-#  define set_bit(word, bit) do {                                       \
-        word = pcmk__set_flags_as(__FUNCTION__, __LINE__, LOG_TRACE,    \
-                                  NULL, NULL, word, bit, NULL);         \
-    } while (0)
-
-//! \deprecated
-#  define clear_bit(word, bit) do {                                     \
-        word = pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE,  \
-                                    NULL, NULL, word, bit, NULL);       \
-    } while (0)
-
 // miscellaneous utilities (from utils.c)
 
 const char *pcmk_message_name(const char *name);

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -173,6 +173,20 @@ struct pcmk__client_s {
             (client)->flags, (flags_to_clear), #flags_to_clear);        \
     } while (0)
 
+#define pcmk__set_ipc_flags(ipc_flags, ipc_name, flags_to_set) do {         \
+        ipc_flags = pcmk__set_flags_as(__FUNCTION__, __LINE__, LOG_TRACE,   \
+                                       "IPC", (ipc_name),                   \
+                                       (ipc_flags), (flags_to_set),         \
+                                       #flags_to_set);                      \
+    } while (0)
+
+#define pcmk__clear_ipc_flags(ipc_flags, ipc_name, flags_to_clear) do {     \
+        ipc_flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, \
+                                         "IPC", (ipc_name),                 \
+                                         (ipc_flags), (flags_to_clear),     \
+                                         #flags_to_clear);                  \
+    } while (0)
+
 guint pcmk__ipc_client_count(void);
 void pcmk__foreach_ipc_client(GHFunc func, gpointer user_data);
 void pcmk__foreach_ipc_client_remove(GHRFunc func, gpointer user_data);

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -14,6 +14,7 @@
 #  include <crm/common/ipc.h>
 #  include <crm/common/output.h>
 #  include <crm/common/xml.h>
+#  include <crm/stonith-ng.h>
 
 enum st_device_flags
 {
@@ -29,6 +30,20 @@ enum st_device_flags
                                           "Fence device", device_id,          \
                                           (device_flags), (flags_to_set),     \
                                           #flags_to_set);                     \
+    } while (0)
+
+#define stonith__set_call_options(st_call_opts, call_for, flags_to_set) do { \
+        st_call_opts = pcmk__set_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, \
+                                          "Fencer call", (call_for),         \
+                                          (st_call_opts), (flags_to_set),    \
+                                          #flags_to_set);                    \
+    } while (0)
+
+#define stonith__clear_call_options(st_call_opts, call_for, flags_to_clear) do { \
+        st_call_opts = pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, \
+                                            "Fencer call", (call_for),         \
+                                            (st_call_opts), (flags_to_clear),  \
+                                            #flags_to_clear);                  \
     } while (0)
 
 struct stonith_action_s;

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -24,6 +24,13 @@ enum st_device_flags
     st_device_supports_parameter_port = 0x0010,
 };
 
+#define stonith__set_device_flags(device_flags, device_id, flags_to_set) do { \
+        device_flags = pcmk__set_flags_as(__FUNCTION__, __LINE__, LOG_TRACE,  \
+                                          "Fence device", device_id,          \
+                                          (device_flags), (flags_to_set),     \
+                                          #flags_to_set);                     \
+    } while (0)
+
 struct stonith_action_s;
 typedef struct stonith_action_s stonith_action_t;
 
@@ -66,7 +73,9 @@ GList *stonith__parse_targets(const char *hosts);
 gboolean stonith__later_succeeded(stonith_history_t *event, stonith_history_t *top_history);
 stonith_history_t *stonith__sort_history(stonith_history_t *history);
 
-long long stonith__device_parameter_flags(xmlNode *metadata);
+void stonith__device_parameter_flags(uint32_t *device_flags,
+                                     const char *device_name,
+                                     xmlNode *metadata);
 
 #  define ST_LEVEL_MAX 10
 

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -23,18 +23,40 @@
 #  define pe_proc_err(fmt...) { was_processing_error = TRUE; crm_err(fmt); }
 #  define pe_proc_warn(fmt...) { was_processing_warning = TRUE; crm_warn(fmt); }
 
-#define pe_set_action_bit(action, bit) do {                                 \
+#define pe__set_action_flags(action, flags_to_set) do {                     \
         (action)->flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,        \
                                              LOG_TRACE,                     \
                                              "Action", (action)->uuid,      \
-                                             (action)->flags, bit, #bit);   \
+                                             (action)->flags,               \
+                                             (flags_to_set),                \
+                                             #flags_to_set);                \
     } while (0)
 
-#define pe_clear_action_bit(action, bit) do {                               \
+#define pe__clear_action_flags(action, flags_to_clear) do {                 \
         (action)->flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__,      \
                                                LOG_TRACE,                   \
                                                "Action", (action)->uuid,    \
-                                               (action)->flags, bit, #bit); \
+                                               (action)->flags,             \
+                                               (flags_to_clear),            \
+                                               #flags_to_clear);            \
+    } while (0)
+
+#define pe__set_action_flags_as(function, line, action, flags_to_set) do {  \
+        (action)->flags = pcmk__set_flags_as((function), (line),            \
+                                             LOG_TRACE,                     \
+                                             "Action", (action)->uuid,      \
+                                             (action)->flags,               \
+                                             (flags_to_set),                \
+                                             #flags_to_set);                \
+    } while (0)
+
+#define pe__clear_action_flags_as(function, line, action, flags_to_clear) do { \
+        (action)->flags = pcmk__clear_flags_as((function), (line),          \
+                                               LOG_TRACE,                   \
+                                               "Action", (action)->uuid,    \
+                                               (action)->flags,             \
+                                               (flags_to_clear),            \
+                                               #flags_to_clear);            \
     } while (0)
 
 // Some warnings we don't want to print every transition

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -35,6 +35,18 @@
             (working_set)->flags, (flags_to_clear), #flags_to_clear);       \
     } while (0)
 
+#define pe__set_resource_flags(resource, flags_to_set) do {                 \
+        (resource)->flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,      \
+            LOG_TRACE, "Resource", (resource)->id, (resource)->flags,       \
+            (flags_to_set), #flags_to_set);                                 \
+    } while (0)
+
+#define pe__clear_resource_flags(resource, flags_to_clear) do {             \
+        (resource)->flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__,    \
+            LOG_TRACE, "Resource", (resource)->id, (resource)->flags,       \
+            (flags_to_clear), #flags_to_clear);                             \
+    } while (0)
+
 #define pe__set_action_flags(action, flags_to_set) do {                     \
         (action)->flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,        \
                                              LOG_TRACE,                     \
@@ -479,8 +491,8 @@ void pe_action_set_flag_reason(const char *function, long line, pe_action_t *act
 #define pe_action_required(action, reason, text) pe_action_set_flag_reason(__FUNCTION__, __LINE__, action, reason, text, pe_action_optional, FALSE)
 #define pe_action_implies(action, reason, flag) pe_action_set_flag_reason(__FUNCTION__, __LINE__, action, reason, NULL, flag, FALSE)
 
-void set_bit_recursive(pe_resource_t * rsc, unsigned long long flag);
-void clear_bit_recursive(pe_resource_t * rsc, unsigned long long flag);
+void pe__set_resource_flags_recursive(pe_resource_t *rsc, uint64_t flags);
+void pe__clear_resource_flags_recursive(pe_resource_t *rsc, uint64_t flags);
 
 gboolean add_tag_ref(GHashTable * tags, const char * tag_name,  const char * obj_ref);
 

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -22,8 +22,20 @@
 #  define pe_warn(fmt...) { was_processing_warning = TRUE; crm_config_warning = TRUE; crm_warn(fmt); }
 #  define pe_proc_err(fmt...) { was_processing_error = TRUE; crm_err(fmt); }
 #  define pe_proc_warn(fmt...) { was_processing_warning = TRUE; crm_warn(fmt); }
-#  define pe_set_action_bit(action, bit) action->flags = crm_set_bit(__FUNCTION__, __LINE__, action->uuid, action->flags, bit)
-#  define pe_clear_action_bit(action, bit) action->flags = crm_clear_bit(__FUNCTION__, __LINE__, action->uuid, action->flags, bit)
+
+#define pe_set_action_bit(action, bit) do {                                 \
+        (action)->flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,        \
+                                             LOG_TRACE,                     \
+                                             "Action", (action)->uuid,      \
+                                             (action)->flags, bit, #bit);   \
+    } while (0)
+
+#define pe_clear_action_bit(action, bit) do {                               \
+        (action)->flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__,      \
+                                               LOG_TRACE,                   \
+                                               "Action", (action)->uuid,    \
+                                               (action)->flags, bit, #bit); \
+    } while (0)
 
 // Some warnings we don't want to print every transition
 

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -41,6 +41,22 @@
                                                #flags_to_clear);            \
     } while (0)
 
+#define pe__set_raw_action_flags(action_flags, action_name, flags_to_set) do { \
+        action_flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,           \
+                                          LOG_TRACE, "Action", action_name, \
+                                          (action_flags),                   \
+                                          (flags_to_set), #flags_to_set);   \
+    } while (0)
+
+#define pe__clear_raw_action_flags(action_flags, action_name, flags_to_clear) do { \
+        action_flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__,         \
+                                            LOG_TRACE,                      \
+                                            "Action", action_name,          \
+                                            (action_flags),                 \
+                                            (flags_to_clear),               \
+                                            #flags_to_clear);               \
+    } while (0)
+
 #define pe__set_action_flags_as(function, line, action, flags_to_set) do {  \
         (action)->flags = pcmk__set_flags_as((function), (line),            \
                                              LOG_TRACE,                     \

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -23,6 +23,18 @@
 #  define pe_proc_err(fmt...) { was_processing_error = TRUE; crm_err(fmt); }
 #  define pe_proc_warn(fmt...) { was_processing_warning = TRUE; crm_warn(fmt); }
 
+#define pe__set_working_set_flags(working_set, flags_to_set) do {           \
+        (working_set)->flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,   \
+            LOG_TRACE, "Working set", crm_system_name,                      \
+            (working_set)->flags, (flags_to_set), #flags_to_set);           \
+    } while (0)
+
+#define pe__clear_working_set_flags(working_set, flags_to_clear) do {       \
+        (working_set)->flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__, \
+            LOG_TRACE, "Working set", crm_system_name,                      \
+            (working_set)->flags, (flags_to_clear), #flags_to_clear);       \
+    } while (0)
+
 #define pe__set_action_flags(action, flags_to_set) do {                     \
         (action)->flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,        \
                                              LOG_TRACE,                     \

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -99,6 +99,20 @@
                                                #flags_to_clear);            \
     } while (0)
 
+#define pe__set_order_flags(order_flags, flags_to_set) do {                 \
+        order_flags = pcmk__set_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, \
+                                         "Ordering", "constraint",          \
+                                         order_flags, (flags_to_set),       \
+                                         #flags_to_set);                    \
+    } while (0)
+
+#define pe__clear_order_flags(order_flags, flags_to_clear) do {               \
+        order_flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, \
+                                           "Ordering", "constraint",          \
+                                           order_flags, (flags_to_clear),     \
+                                           #flags_to_clear);                  \
+    } while (0)
+
 // Some warnings we don't want to print every transition
 
 enum pe_warn_once_e {

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -108,7 +108,9 @@ extern uint32_t pe_wo;
             } else {                            \
                 pe_warn(fmt);                   \
             }                                   \
-            set_bit(pe_wo, pe_wo_bit);          \
+            pe_wo = pcmk__set_flags_as(__FUNCTION__, __LINE__, LOG_TRACE,   \
+                                      "Warn-once", "logging", pe_wo,        \
+                                      (pe_wo_bit), #pe_wo_bit);             \
         }                                       \
     } while (0);
 

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -113,6 +113,20 @@
                                            #flags_to_clear);                  \
     } while (0)
 
+#define pe__set_graph_flags(graph_flags, gr_action, flags_to_set) do {      \
+        graph_flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,            \
+                                         LOG_TRACE, "Graph",                \
+                                         (gr_action)->uuid, graph_flags,    \
+                                         (flags_to_set), #flags_to_set);    \
+    } while (0)
+
+#define pe__clear_graph_flags(graph_flags, gr_action, flags_to_clear) do {     \
+        graph_flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__,             \
+                                           LOG_TRACE, "Graph",                 \
+                                           (gr_action)->uuid, graph_flags,     \
+                                           (flags_to_clear), #flags_to_clear); \
+    } while (0)
+
 // Some warnings we don't want to print every transition
 
 enum pe_warn_once_e {

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -33,41 +33,6 @@
 /* Assorted convenience functions */
 void crm_make_daemon(const char *name, gboolean daemonize, const char *pidfile);
 
-static inline long long
-crm_clear_bit(const char *function, int line, const char *target, long long word, long long bit)
-{
-    long long rc = (word & ~bit);
-
-    if (rc == word) {
-        /* Unchanged */
-    } else if (target) {
-        crm_trace("Bit 0x%.8llx for %s cleared by %s:%d", bit, target, function, line);
-    } else {
-        crm_trace("Bit 0x%.8llx cleared by %s:%d", bit, function, line);
-    }
-
-    return rc;
-}
-
-static inline long long
-crm_set_bit(const char *function, int line, const char *target, long long word, long long bit)
-{
-    long long rc = (word | bit);
-
-    if (rc == word) {
-        /* Unchanged */
-    } else if (target) {
-        crm_trace("Bit 0x%.8llx for %s set by %s:%d", bit, target, function, line);
-    } else {
-        crm_trace("Bit 0x%.8llx set by %s:%d", bit, function, line);
-    }
-
-    return rc;
-}
-
-#  define set_bit(word, bit) word = crm_set_bit(__FUNCTION__, __LINE__, NULL, word, bit)
-#  define clear_bit(word, bit) word = crm_clear_bit(__FUNCTION__, __LINE__, NULL, word, bit)
-
 void strip_text_nodes(xmlNode * xml);
 void pcmk_panic(const char *origin);
 pid_t pcmk_locate_sbd(void);

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
@@ -25,14 +26,33 @@
 #include <crm/common/ipc.h>
 #include <crm/common/xml.h>
 
-#define CIB_FLAG_DIRTY 0x00001
-#define CIB_FLAG_LIVE  0x00002
+enum cib_file_flags {
+    cib_file_flag_dirty = (1 << 0),
+    cib_file_flag_live  = (1 << 1),
+};
 
 typedef struct cib_file_opaque_s {
-    int flags;
+    uint32_t flags; // Group of enum cib_file_flags
     char *filename;
-
 } cib_file_opaque_t;
+
+#define cib_set_file_flags(cibfile, flags_to_set) do {                  \
+        (cibfile)->flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,   \
+                                              LOG_TRACE, "CIB file",    \
+                                              cibfile->filename,        \
+                                              (cibfile)->flags,         \
+                                              (flags_to_set),           \
+                                              #flags_to_set);           \
+    } while (0)
+
+#define cib_clear_file_flags(cibfile, flags_to_clear) do {              \
+        (cibfile)->flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__, \
+                                                LOG_TRACE, "CIB file",  \
+                                                cibfile->filename,      \
+                                                (cibfile)->flags,       \
+                                                (flags_to_clear),       \
+                                                #flags_to_clear);       \
+    } while (0)
 
 int cib_file_perform_op(cib_t * cib, const char *op, const char *host, const char *section,
                         xmlNode * data, xmlNode ** output_data, int call_options);
@@ -485,7 +505,7 @@ cib_file_new(const char *cib_location)
     }
     private->flags = 0;
     if (cib_file_is_live(cib_location)) {
-        set_bit(private->flags, CIB_FLAG_LIVE);
+        cib_set_file_flags(private, cib_file_flag_live);
         crm_trace("File %s detected as live CIB", cib_location);
     }
     private->filename = strdup(cib_location);
@@ -681,10 +701,10 @@ cib_file_signoff(cib_t * cib)
     cib->type = cib_no_connection;
 
     /* If the in-memory CIB has been changed, write it to disk */
-    if (is_set(private->flags, CIB_FLAG_DIRTY)) {
+    if (is_set(private->flags, cib_file_flag_dirty)) {
 
         /* If this is the live CIB, write it out with a digest */
-        if (is_set(private->flags, CIB_FLAG_LIVE)) {
+        if (is_set(private->flags, cib_file_flag_live)) {
             if (cib_file_write_live(private->filename) < 0) {
                 rc = pcmk_err_generic;
             }
@@ -700,7 +720,7 @@ cib_file_signoff(cib_t * cib)
 
         if (rc == pcmk_ok) {
             crm_info("Wrote CIB to %s", private->filename);
-            clear_bit(private->flags, CIB_FLAG_DIRTY);
+            cib_clear_file_flags(private, cib_file_flag_dirty);
         } else {
             crm_err("Could not write CIB to %s", private->filename);
         }
@@ -846,7 +866,7 @@ cib_file_perform_op_delegate(cib_t * cib, const char *op, const char *host, cons
         xml_log_patchset(LOG_DEBUG, "cib:diff", cib_diff);
         free_xml(in_mem_cib);
         in_mem_cib = result_cib;
-        set_bit(private->flags, CIB_FLAG_DIRTY);
+        cib_set_file_flags(private, cib_file_flag_dirty);
     }
 
     free_xml(cib_diff);

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -811,7 +811,8 @@ cib_file_perform_op_delegate(cib_t * cib, const char *op, const char *host, cons
              (op? op : "invalid"), (section? section : "entire CIB"));
 #endif
 
-    call_options |= (cib_no_mtime | cib_inhibit_bcast | cib_scope_local);
+    cib__set_call_options(call_options, "file operation",
+                          cib_no_mtime|cib_inhibit_bcast|cib_scope_local);
 
     if (cib->state == cib_disconnected) {
         return -ENOTCONN;

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -328,7 +328,7 @@ cib_native_perform_op_delegate(cib_t * cib, const char *op, const char *host, co
     }
 
     if (call_options & cib_sync_call) {
-        ipc_flags |= crm_ipc_client_response;
+        pcmk__set_ipc_flags(ipc_flags, "client", crm_ipc_client_response);
     }
 
     cib->call_id++;

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -99,7 +99,7 @@ crm_remote_peer_get(const char *node_name)
     }
 
     /* Populate the essential information */
-    node->flags = crm_remote_node;
+    pcmk__set_peer_flags(node, crm_remote_node);
     node->uuid = strdup(node_name);
     if (node->uuid == NULL) {
         free(node);
@@ -190,7 +190,7 @@ remote_cache_refresh_helper(xmlNode *result, void *user_data)
 
     } else if (is_set(node->flags, crm_node_dirty)) {
         /* Node is in cache and hasn't been updated already, so mark it clean */
-        clear_bit(node->flags, crm_node_dirty);
+        pcmk__clear_peer_flags(node, crm_node_dirty);
         if (state) {
             crm_update_peer_state(__FUNCTION__, node, state, 0);
         }
@@ -200,7 +200,7 @@ remote_cache_refresh_helper(xmlNode *result, void *user_data)
 static void
 mark_dirty(gpointer key, gpointer value, gpointer user_data)
 {
-    set_bit(((crm_node_t*)value)->flags, crm_node_dirty);
+    pcmk__set_peer_flags((crm_node_t *) value, crm_node_dirty);
 }
 
 static gboolean
@@ -1122,7 +1122,7 @@ known_peer_cache_refresh_helper(xmlNode *xml_node, void *user_data)
         }
 
         /* Node is in cache and hasn't been updated already, so mark it clean */
-        clear_bit(node->flags, crm_node_dirty);
+        pcmk__clear_peer_flags(node, crm_node_dirty);
     }
 
 }

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -804,12 +804,18 @@ crm_update_peer_proc(const char *source, crm_node_t * node, uint32_t flag, const
 
     } else if (pcmk__str_eq(status, ONLINESTATUS, pcmk__str_casei)) {
         if ((node->processes & flag) != flag) {
-            set_bit(node->processes, flag);
+            node->processes = pcmk__set_flags_as(__FUNCTION__, __LINE__,
+                                                 LOG_TRACE, "Peer process",
+                                                 node->uname, node->processes,
+                                                 flag, "processes");
             changed = TRUE;
         }
 
     } else if (node->processes & flag) {
-        clear_bit(node->processes, flag);
+        node->processes = pcmk__clear_flags_as(__FUNCTION__, __LINE__,
+                                               LOG_TRACE, "Peer process",
+                                               node->uname, node->processes,
+                                               flag, "processes");
         changed = TRUE;
     }
 

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -444,7 +444,7 @@ xml_acl_filtered_copy(const char *user, xmlNode *acl_source, xmlNode *xml,
     }
 
     pcmk__unpack_acl(acl_source, target, user);
-    pcmk__set_xml_flag(target, xpf_acl_enabled);
+    pcmk__set_xml_doc_flag(target, xpf_acl_enabled);
     pcmk__apply_acl(target);
 
     doc = target->doc->_private;
@@ -642,7 +642,7 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
         if (docp->acls == NULL) {
             crm_trace("User '%s' without ACLs denied %s access to %s",
                       docp->user, __xml_acl_to_text(mode), buffer);
-            pcmk__set_xml_flag(xml, xpf_acl_denied);
+            pcmk__set_xml_doc_flag(xml, xpf_acl_denied);
             return FALSE;
         }
 
@@ -668,7 +668,7 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
                 crm_trace("%sACL denies user '%s' %s access to %s",
                           (parent != xml) ? "Parent " : "", docp->user,
                           __xml_acl_to_text(mode), buffer);
-                pcmk__set_xml_flag(xml, xpf_acl_denied);
+                pcmk__set_xml_doc_flag(xml, xpf_acl_denied);
                 return FALSE;
             }
             parent = parent->parent;
@@ -676,7 +676,7 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
 
         crm_trace("Default ACL denies user '%s' %s access to %s",
                   docp->user, __xml_acl_to_text(mode), buffer);
-        pcmk__set_xml_flag(xml, xpf_acl_denied);
+        pcmk__set_xml_doc_flag(xml, xpf_acl_denied);
         return FALSE;
     }
 #endif

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -280,7 +280,7 @@ pcmk__apply_acl(xmlNode *xml)
                 continue;
             }
 #endif
-            p->flags |= acl->mode;
+            pcmk__set_xml_flags(p, acl->mode);
             free(path);
         }
         crm_trace("Applied %s ACL %s (%d match%s)",
@@ -602,7 +602,7 @@ xml_acl_disable(xmlNode *xml)
         /* Catch anything that was created but shouldn't have been */
         pcmk__apply_acl(xml);
         pcmk__apply_creation_acl(xml, FALSE);
-        clear_bit(p->flags, xpf_acl_enabled);
+        pcmk__clear_xml_flags(p, xpf_acl_enabled);
     }
 }
 

--- a/lib/common/attrd_client.c
+++ b/lib/common/attrd_client.c
@@ -62,7 +62,7 @@ send_attrd_op(crm_ipc_t *ipc, xmlNode *attrd_op)
 
     if (ipc == NULL && local_ipc == NULL) {
         local_ipc = crm_ipc_new(T_ATTRD, 0);
-        flags |= crm_ipc_client_response;
+        pcmk__set_ipc_flags(flags, "client", crm_ipc_client_response);
         connected = FALSE;
     }
 

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -56,7 +56,7 @@ typedef struct xml_private_s {
 } xml_private_t;
 
 G_GNUC_INTERNAL
-void pcmk__set_xml_flag(xmlNode *xml, enum xml_private_flags flag);
+void pcmk__set_xml_doc_flag(xmlNode *xml, enum xml_private_flags flag);
 
 G_GNUC_INTERNAL
 bool pcmk__tracking_xml_changes(xmlNode *xml, bool lazy);

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -55,6 +55,18 @@ typedef struct xml_private_s {
         GList *deleted_objs;
 } xml_private_t;
 
+#define pcmk__set_xml_flags(xml_priv, flags_to_set) do {                    \
+        (xml_priv)->flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,      \
+            LOG_NEVER, "XML", "XML node", (xml_priv)->flags,                \
+            (flags_to_set), #flags_to_set);                                 \
+    } while (0)
+
+#define pcmk__clear_xml_flags(xml_priv, flags_to_clear) do {                \
+        (xml_priv)->flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__,    \
+            LOG_NEVER, "XML", "XML node", (xml_priv)->flags,                \
+            (flags_to_clear), #flags_to_clear);                             \
+    } while (0)
+
 G_GNUC_INTERNAL
 void pcmk__set_xml_doc_flag(xmlNode *xml, enum xml_private_flags flag);
 

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1187,11 +1187,11 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
     }
 
     header = iov[0].iov_base;
-    header->flags |= flags;
+    pcmk__set_ipc_flags(header->flags, client->name, flags);
 
     if(is_set(flags, crm_ipc_proxied)) {
         /* Don't look for a synchronous response */
-        clear_bit(flags, crm_ipc_client_response);
+        pcmk__clear_ipc_flags(flags, "client", crm_ipc_client_response);
     }
 
     if(header->size_compressed) {

--- a/lib/common/ipc_common.c
+++ b/lib/common/ipc_common.c
@@ -10,6 +10,7 @@
 #include <crm_internal.h>
 
 #include <stdio.h>
+#include <stdint.h>         // uint64_t
 #include <sys/types.h>
 
 #include <crm/msg_xml.h>
@@ -86,15 +87,15 @@ pcmk__valid_ipc_header(const pcmk__ipc_header_t *header)
 }
 
 const char *
-pcmk__client_type_str(enum pcmk__client_type client_type)
+pcmk__client_type_str(uint64_t client_type)
 {
     switch (client_type) {
-        case PCMK__CLIENT_IPC:
+        case pcmk__client_ipc:
             return "IPC";
-        case PCMK__CLIENT_TCP:
+        case pcmk__client_tcp:
             return "TCP";
 #ifdef HAVE_GNUTLS_GNUTLS_H
-        case PCMK__CLIENT_TLS:
+        case pcmk__client_tls:
             return "TLS";
 #endif
         default:

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -638,7 +638,7 @@ pcmk__ipc_prepare_iov(uint32_t request, xmlNode *message,
                            (unsigned int) max_send_size, &compressed,
                            &new_size) == pcmk_rc_ok) {
 
-            header->flags |= crm_ipc_compressed;
+            pcmk__set_ipc_flags(header->flags, "send data", crm_ipc_compressed);
             header->size_compressed = new_size;
 
             iov[1].iov_len = header->size_compressed;
@@ -685,14 +685,16 @@ pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags)
     if (c->flags & pcmk__client_proxied) {
         /* _ALL_ replies to proxied connections need to be sent as events */
         if (is_not_set(flags, crm_ipc_server_event)) {
-            flags |= crm_ipc_server_event;
-            /* this flag lets us know this was originally meant to be a response.
-             * even though we're sending it over the event channel. */
-            flags |= crm_ipc_proxied_relay_response;
+            /* The proxied flag lets us know this was originally meant to be a
+             * response, even though we're sending it over the event channel.
+             */
+            pcmk__set_ipc_flags(flags, "server event",
+                                crm_ipc_server_event
+                                |crm_ipc_proxied_relay_response);
         }
     }
 
-    header->flags |= flags;
+    pcmk__set_ipc_flags(header->flags, "server event", flags);
     if (flags & crm_ipc_server_event) {
         header->qb.id = id++;   /* We don't really use it, but doesn't hurt to set one */
 
@@ -765,7 +767,8 @@ pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request, xmlNode *message,
     rc = pcmk__ipc_prepare_iov(request, message, crm_ipc_default_buffer_size(),
                                &iov, NULL);
     if (rc == pcmk_rc_ok) {
-        rc = pcmk__ipc_send_iov(c, iov, flags | crm_ipc_server_free);
+        pcmk__set_ipc_flags(flags, "send data", crm_ipc_server_free);
+        rc = pcmk__ipc_send_iov(c, iov, flags);
     } else {
         pcmk_free_ipc_event(iov);
         crm_notice("IPC message to pid %d failed: %s " CRM_XS " rc=%d",

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -186,7 +186,7 @@ client_from_connection(qb_ipcs_connection_t *c, void *key, uid_t uid_client)
         }
 #endif
         client->ipcs = c;
-        client->kind = PCMK__CLIENT_IPC;
+        pcmk__set_client_flags(client, pcmk__client_ipc);
         client->pid = pcmk__client_pid(c);
         if (key == NULL) {
             key = c;
@@ -261,7 +261,7 @@ pcmk__new_client(qb_ipcs_connection_t *c, uid_t uid_client, gid_t gid_client)
 
     if ((uid_client == 0) || (uid_client == uid_cluster)) {
         /* Remember when a connection came from root or hacluster */
-        set_bit(client->flags, pcmk__client_privileged);
+        pcmk__set_client_flags(client, pcmk__client_privileged);
     }
 
     crm_debug("New IPC client %s for PID %u with uid %d and gid %d",
@@ -421,7 +421,7 @@ pcmk__client_data2xml(pcmk__client_t *c, void *data, uint32_t *id,
          * Proxy connections responses are sent on the event channel, to avoid
          * blocking the controller serving as proxy.
          */
-        c->flags |= pcmk__client_proxied;
+        pcmk__set_client_flags(c, pcmk__client_proxied);
     }
 
     if (header->size_compressed) {

--- a/lib/common/tests/Makefile.am
+++ b/lib/common/tests/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = strings utils
+SUBDIRS = flags strings utils

--- a/lib/common/tests/flags/Makefile.am
+++ b/lib/common/tests/flags/Makefile.am
@@ -1,0 +1,28 @@
+#
+# Copyright 2020 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+#
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
+LDADD = $(top_builddir)/lib/common/libcrmcommon.la
+
+include $(top_srcdir)/mk/glib-tap.mk
+
+# Add each test program here.  Each test should be written as a little standalone
+# program using the glib unit testing functions.  See the documentation for more
+# information.
+#
+# https://developer.gnome.org/glib/unstable/glib-Testing.html
+test_programs = pcmk__clear_flags_as		\
+		pcmk__set_flags_as
+
+# If any extra data needs to be added to the source distribution, add it to the
+# following list.
+dist_test_data =
+
+# If any extra data needs to be used by tests but should not be added to the
+# source distribution, add it to the following list.
+test_data =

--- a/lib/common/tests/flags/pcmk__clear_flags_as.c
+++ b/lib/common/tests/flags/pcmk__clear_flags_as.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+static void
+clear_none(void) {
+    g_assert(pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, "Test",
+                                  "test", 0x0f0, 0x00f, NULL) == 0x0f0);
+    g_assert(pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, "Test",
+                                  "test", 0x0f0, 0xf0f, NULL) == 0x0f0);
+}
+
+static void
+clear_some(void) {
+    g_assert(pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, "Test",
+                                  "test", 0x0f0, 0x020, NULL) == 0x0d0);
+    g_assert(pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, "Test",
+                                  "test", 0x0f0, 0x030, NULL) == 0x0c0);
+}
+
+static void
+clear_all(void) {
+    g_assert(pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, "Test",
+                                  "test", 0x0f0, 0x0f0, NULL) == 0x000);
+    g_assert(pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, "Test",
+                                  "test", 0x0f0, 0xfff, NULL) == 0x000);
+}
+
+int
+main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/common/flags/clear/clear_none", clear_none);
+    g_test_add_func("/common/flags/clear/clear_some", clear_some);
+    g_test_add_func("/common/flags/clear/clear_all", clear_all);
+    return g_test_run();
+}

--- a/lib/common/tests/flags/pcmk__set_flags_as.c
+++ b/lib/common/tests/flags/pcmk__set_flags_as.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+static void
+set_flags(void) {
+    g_assert(pcmk__set_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, "Test",
+                                "test", 0x0f0, 0x00f, NULL) == 0x0ff);
+    g_assert(pcmk__set_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, "Test",
+                                "test", 0x0f0, 0xf0f, NULL) == 0xfff);
+    g_assert(pcmk__set_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, "Test",
+                                "test", 0x0f0, 0xfff, NULL) == 0xfff);
+}
+
+int
+main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/common/flags/set/set_flags", set_flags);
+    return g_test_run();
+}

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -137,7 +137,7 @@ set_parent_flag(xmlNode *xml, long flag)
 }
 
 void
-pcmk__set_xml_flag(xmlNode *xml, enum xml_private_flags flag)
+pcmk__set_xml_doc_flag(xmlNode *xml, enum xml_private_flags flag)
 {
 
     if(xml && xml->doc && xml->doc->_private){
@@ -152,7 +152,7 @@ pcmk__set_xml_flag(xmlNode *xml, enum xml_private_flags flag)
 static void
 __xml_node_dirty(xmlNode *xml) 
 {
-    pcmk__set_xml_flag(xml, xpf_dirty);
+    pcmk__set_xml_doc_flag(xml, xpf_dirty);
     set_parent_flag(xml, xpf_dirty);
 }
 
@@ -300,7 +300,6 @@ pcmkRegisterNode(xmlNodePtr node)
         /* XML_ELEMENT_NODE doesn't get picked up here, node->doc is
          * not hooked up at the point we are called
          */
-        pcmk__set_xml_flag(node, xpf_dirty);
         __xml_node_dirty(node);
     }
 }
@@ -310,12 +309,12 @@ xml_track_changes(xmlNode * xml, const char *user, xmlNode *acl_source, bool enf
 {
     xml_accept_changes(xml);
     crm_trace("Tracking changes%s to %p", enforce_acls?" with ACLs":"", xml);
-    pcmk__set_xml_flag(xml, xpf_tracking);
+    pcmk__set_xml_doc_flag(xml, xpf_tracking);
     if(enforce_acls) {
         if(acl_source == NULL) {
             acl_source = xml;
         }
-        pcmk__set_xml_flag(xml, xpf_acl_enabled);
+        pcmk__set_xml_doc_flag(xml, xpf_acl_enabled);
         pcmk__unpack_acl(acl_source, xml, user);
         pcmk__apply_acl(xml);
     }
@@ -2125,7 +2124,7 @@ free_xml_with_position(xmlNode * child, int position)
 
                     p = doc->_private;
                     p->deleted_objs = g_list_append(p->deleted_objs, deleted_obj);
-                    pcmk__set_xml_flag(child, xpf_dirty);
+                    pcmk__set_xml_doc_flag(child, xpf_dirty);
                 }
             }
             pcmk_free_xml_subtree(child);
@@ -3753,7 +3752,7 @@ __xml_diff_object(xmlNode *old_xml, xmlNode *new_xml, bool check_top)
 void
 xml_calculate_significant_changes(xmlNode *old_xml, xmlNode *new_xml)
 {
-    pcmk__set_xml_flag(new_xml, xpf_lazy);
+    pcmk__set_xml_doc_flag(new_xml, xpf_lazy);
     xml_calculate_changes(old_xml, new_xml);
 }
 

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -819,7 +819,11 @@ internal_stonith_action_execute(stonith_action_t * action)
     svc_action->sequence = stonith_sequence++;
     svc_action->params = action->args;
     svc_action->cb_data = (void *) action;
-    set_bit(svc_action->flags, SVC_ACTION_NON_BLOCKED);
+    svc_action->flags = pcmk__set_flags_as(__FUNCTION__, __LINE__,
+                                           LOG_TRACE, "Action",
+                                           svc_action->id, svc_action->flags,
+                                           SVC_ACTION_NON_BLOCKED,
+                                           "SVC_ACTION_NON_BLOCKED");
 
     /* keep retries from executing out of control and free previous results */
     if (is_retry) {

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1896,7 +1896,8 @@ stonith_send_command(stonith_t * stonith, const char *op, xmlNode * data, xmlNod
         enum crm_ipc_flags ipc_flags = crm_ipc_flags_none;
 
         if (call_options & st_opt_sync_call) {
-            ipc_flags |= crm_ipc_client_response;
+            pcmk__set_ipc_flags(ipc_flags, "stonith command",
+                                crm_ipc_client_response);
         }
         rc = crm_ipc_send(native->ipc, op_msg, ipc_flags,
                           1000 * (timeout + 60), &op_reply);

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2664,22 +2664,22 @@ get_stonith_provider(const char *agent, const char *provider)
     return stonith_namespace2text(stonith_get_namespace(agent, provider));
 }
 
-long long
-stonith__device_parameter_flags(xmlNode *metadata)
+void
+stonith__device_parameter_flags(uint32_t *device_flags, const char *device_name,
+                                xmlNode *metadata)
 {
     xmlXPathObjectPtr xpath = NULL;
     int max = 0;
     int lpc = 0;
-    long long flags = 0;
 
-    CRM_CHECK(metadata != NULL, return 0);
+    CRM_CHECK((device_flags != NULL) && (metadata != NULL), return);
 
     xpath = xpath_search(metadata, "//parameter");
     max = numXpathResults(xpath);
 
     if (max <= 0) {
         freeXpathObject(xpath);
-        return 0;
+        return;
     }
 
     for (lpc = 0; lpc < max; lpc++) {
@@ -2694,14 +2694,14 @@ stonith__device_parameter_flags(xmlNode *metadata)
         parameter = crm_element_value(match, "name");
 
         if (pcmk__str_eq(parameter, "plug", pcmk__str_casei)) {
-            set_bit(flags, st_device_supports_parameter_plug);
+            stonith__set_device_flags(*device_flags, device_name,
+                                      st_device_supports_parameter_plug);
 
         } else if (pcmk__str_eq(parameter, "port", pcmk__str_casei)) {
-            set_bit(flags, st_device_supports_parameter_port);
+            stonith__set_device_flags(*device_flags, device_name,
+                                      st_device_supports_parameter_port);
         }
     }
 
     freeXpathObject(xpath);
-
-    return flags;
 }

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -255,8 +255,9 @@ stonith__rhcs_validate(stonith_t *st, int call_options, const char *target,
         rc = stonith__rhcs_get_metadata(agent, remaining_timeout, &metadata);
 
         if (rc == pcmk_ok) {
-            long long device_flags = stonith__device_parameter_flags(metadata);
+            uint32_t device_flags = 0;
 
+            stonith__device_parameter_flags(&device_flags, agent, metadata);
             if (is_set(device_flags, st_device_supports_parameter_port)) {
                 host_arg = "port";
 

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -181,7 +181,7 @@ check_rsc_parameters(pe_resource_t * rsc, pe_node_t * node, xmlNode * rsc_entry,
     if (force_restart) {
         /* make sure the restart happens */
         stop_action(rsc, node, FALSE);
-        set_bit(rsc->flags, pe_rsc_start_pending);
+        pe__set_resource_flags(rsc, pe_rsc_start_pending);
         delete_resource = TRUE;
 
     } else if (changed) {

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -124,9 +124,13 @@ update_action_flags(pe_action_t * action, enum pe_action_flags flags, const char
     enum pe_action_flags last = action->flags;
 
     if (clear) {
-        action->flags = crm_clear_bit(source, line, action->uuid, action->flags, flags);
+        action->flags = pcmk__clear_flags_as(source, line, LOG_TRACE, "Action",
+                                             action->uuid, action->flags,
+                                             flags, NULL);
     } else {
-        action->flags = crm_set_bit(source, line, action->uuid, action->flags, flags);
+        action->flags = pcmk__set_flags_as(source, line, LOG_TRACE, "Action",
+                                           action->uuid, action->flags,
+                                           flags, NULL);
     }
 
     if (last != action->flags) {

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -134,7 +134,7 @@ update_action_flags(pe_action_t * action, enum pe_action_flags flags, const char
         changed = TRUE;
         /* Useful for tracking down _who_ changed a specific flag */
         /* CRM_ASSERT(calls != 534); */
-        clear_bit(flags, pe_action_clear);
+        pe__clear_raw_action_flags(flags, "action update", pe_action_clear);
         crm_trace("%s on %s: %sset flags 0x%.6x (was 0x%.6x, now 0x%.6x, %lu, %s)",
                   action->uuid, action->node ? action->node->details->uname : "[none]",
                   clear ? "un-" : "", flags, last, action->flags, calls, source);
@@ -316,7 +316,7 @@ check_action_definition(pe_resource_t * rsc, pe_node_t * active_node, xmlNode * 
 #else
             /* Re-sending the recurring op is sufficient - the old one will be cancelled automatically */
             op = custom_action(rsc, key, task, active_node, TRUE, TRUE, data_set);
-            set_bit(op->flags, pe_action_reschedule);
+            pe__set_action_flags(op, pe_action_reschedule);
 #endif
 
         } else if (digest_restart) {

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -1817,7 +1817,7 @@ rsc_order_then(pe_action_t *lh_action, pe_resource_t *rsc,
     if (lh_action && lh_action->rsc == rsc && is_set(lh_action->flags, pe_action_dangle)) {
         pe_rsc_trace(rsc, "Detected dangling operation %s -> %s", lh_action->uuid,
                      order->rh_action_task);
-        clear_bit(type, pe_order_implies_then);
+        pe__clear_order_flags(type, pe_order_implies_then);
     }
 
     gIter = rh_actions;
@@ -2130,7 +2130,7 @@ apply_remote_ordering(pe_action_t *action, pe_working_set_t *data_set)
 
             if (state == remote_state_failed) {
                 /* Force recovery, by making this action required */
-                order_opts |= pe_order_implies_then;
+                pe__set_order_flags(order_opts, pe_order_implies_then);
             }
 
             /* Ensure connection is up before running this action */
@@ -2415,11 +2415,12 @@ order_first_probes_imply_stops(pe_working_set_t * data_set)
 
         // Preserve the order options for future filtering
         if (is_set(order->type, pe_order_apply_first_non_migratable)) {
-            set_bit(order_type, pe_order_apply_first_non_migratable);
+            pe__set_order_flags(order_type,
+                                pe_order_apply_first_non_migratable);
         }
 
         if (is_set(order->type, pe_order_same_node)) {
-            set_bit(order_type, pe_order_same_node);
+            pe__set_order_flags(order_type, pe_order_same_node);
         }
 
         // Keep the order types for future filtering

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -124,13 +124,9 @@ update_action_flags(pe_action_t * action, enum pe_action_flags flags, const char
     enum pe_action_flags last = action->flags;
 
     if (clear) {
-        action->flags = pcmk__clear_flags_as(source, line, LOG_TRACE, "Action",
-                                             action->uuid, action->flags,
-                                             flags, NULL);
+        pe__clear_action_flags_as(source, line, action, flags);
     } else {
-        action->flags = pcmk__set_flags_as(source, line, LOG_TRACE, "Action",
-                                           action->uuid, action->flags,
-                                           flags, NULL);
+        pe__set_action_flags_as(source, line, action, flags);
     }
 
     if (last != action->flags) {
@@ -2499,7 +2495,7 @@ order_first_probe_then_restart_repromote(pe_action_t * probe,
         return;
     }
 
-    pe_set_action_bit(after, pe_action_tracking);
+    pe__set_action_flags(after, pe_action_tracking);
 
     crm_trace("Processing based on %s %s -> %s %s",
               probe->uuid,
@@ -2614,7 +2610,7 @@ static void clear_actions_tracking_flag(pe_working_set_t * data_set)
         pe_action_t *action = (pe_action_t *) gIter->data;
 
         if (is_set(action->flags, pe_action_tracking)) {
-            pe_clear_action_bit(action, pe_action_tracking);
+            pe__clear_action_flags(action, pe_action_tracking);
         }
     }
 }

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -109,7 +109,7 @@ pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *prefer,
 
     get_bundle_variant_data(bundle_data, rsc);
 
-    set_bit(rsc->flags, pe_rsc_allocating);
+    pe__set_resource_flags(rsc, pe_rsc_allocating);
     containers = get_container_list(rsc);
 
     pe__show_node_weights(!show_scores, rsc, __FUNCTION__, rsc->allowed_nodes);
@@ -168,12 +168,13 @@ pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *prefer,
                 }
             }
 
-            set_bit(replica->child->parent->flags, pe_rsc_allocating);
+            pe__set_resource_flags(replica->child->parent, pe_rsc_allocating);
             pe_rsc_trace(rsc, "Allocating bundle %s replica child %s",
                          rsc->id, replica->child->id);
             replica->child->cmds->allocate(replica->child, replica->node,
                                            data_set);
-            clear_bit(replica->child->parent->flags, pe_rsc_allocating);
+            pe__clear_resource_flags(replica->child->parent,
+                                       pe_rsc_allocating);
         }
     }
 
@@ -193,8 +194,7 @@ pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *prefer,
         bundle_data->child->cmds->allocate(bundle_data->child, prefer, data_set);
     }
 
-    clear_bit(rsc->flags, pe_rsc_allocating);
-    clear_bit(rsc->flags, pe_rsc_provisional);
+    pe__clear_resource_flags(rsc, pe_rsc_allocating|pe_rsc_provisional);
     return NULL;
 }
 

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -674,7 +674,7 @@ multi_update_interleave_actions(pe_action_t *first, pe_action_t *then,
             if (type & (pe_order_runnable_left | pe_order_implies_then) /* Mandatory */ ) {
                 pe_rsc_info(then->rsc, "Inhibiting %s from being active", then_child->id);
                 if(assign_node(then_child, NULL, TRUE)) {
-                    changed |= pe_graph_updated_then;
+                    pe__set_graph_flags(changed, first, pe_graph_updated_then);
                 }
             }
 
@@ -751,7 +751,8 @@ multi_update_interleave_actions(pe_action_t *first, pe_action_t *then,
                 crm_debug("Created constraint for %s (%d) -> %s (%d) %.6x",
                           first_action->uuid, is_set(first_action->flags, pe_action_optional),
                           then_action->uuid, is_set(then_action->flags, pe_action_optional), type);
-                changed |= (pe_graph_updated_first | pe_graph_updated_then);
+                pe__set_graph_flags(changed, first,
+                                    pe_graph_updated_first|pe_graph_updated_then);
             }
             if(first_action && then_action) {
                 changed |= then_child->cmds->update_actions(first_action,

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -1200,6 +1200,12 @@ clone_child_action(pe_action_t * action)
     return result;
 }
 
+#define pe__clear_action_summary_flags(flags, action, flag) do {        \
+        flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE, \
+                                     "Action summary", action->rsc->id, \
+                                     flags, flag, #flag);               \
+    } while (0)
+
 enum pe_action_flags
 summary_action_flags(pe_action_t * action, GListPtr children, pe_node_t * node)
 {
@@ -1224,10 +1230,8 @@ summary_action_flags(pe_action_t * action, GListPtr children, pe_node_t * node)
                 && is_set(child_flags, pe_action_optional) == FALSE) {
                 pe_rsc_trace(child, "%s is mandatory because of %s", action->uuid,
                              child_action->uuid);
-                flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE,
-                                             "Action summary", action->rsc->id,
-                                             flags, pe_action_optional, NULL);
-                pe_clear_action_bit(action, pe_action_optional);
+                pe__clear_action_summary_flags(flags, action, pe_action_optional);
+                pe__clear_action_flags(action, pe_action_optional);
             }
             if (is_set(child_flags, pe_action_runnable)) {
                 any_runnable = TRUE;
@@ -1237,11 +1241,9 @@ summary_action_flags(pe_action_t * action, GListPtr children, pe_node_t * node)
 
     if (check_runnable && any_runnable == FALSE) {
         pe_rsc_trace(action->rsc, "%s is not runnable because no children are", action->uuid);
-        flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE,
-                                     "Action summary", action->rsc->id,
-                                     flags, pe_action_runnable, NULL);
+        pe__clear_action_summary_flags(flags, action, pe_action_runnable);
         if (node == NULL) {
-            pe_clear_action_bit(action, pe_action_runnable);
+            pe__clear_action_flags(action, pe_action_runnable);
         }
     }
 

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -639,7 +639,7 @@ pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *prefer,
         apply_master_prefs(rsc);
     }
 
-    set_bit(rsc->flags, pe_rsc_allocating);
+    pe__set_resource_flags(rsc, pe_rsc_allocating);
 
     /* this information is used by sort_clone_instance() when deciding in which 
      * order to allocate clone instances
@@ -680,8 +680,7 @@ pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *prefer,
         pcmk__set_instance_roles(rsc, data_set);
     }
 
-    clear_bit(rsc->flags, pe_rsc_provisional);
-    clear_bit(rsc->flags, pe_rsc_allocating);
+    pe__clear_resource_flags(rsc, pe_rsc_provisional|pe_rsc_allocating);
     pe_rsc_trace(rsc, "Done allocating %s", rsc->id);
     return NULL;
 }

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -1224,7 +1224,9 @@ summary_action_flags(pe_action_t * action, GListPtr children, pe_node_t * node)
                 && is_set(child_flags, pe_action_optional) == FALSE) {
                 pe_rsc_trace(child, "%s is mandatory because of %s", action->uuid,
                              child_action->uuid);
-                flags = crm_clear_bit(__FUNCTION__, __LINE__, action->rsc->id, flags, pe_action_optional);
+                flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE,
+                                             "Action summary", action->rsc->id,
+                                             flags, pe_action_optional, NULL);
                 pe_clear_action_bit(action, pe_action_optional);
             }
             if (is_set(child_flags, pe_action_runnable)) {
@@ -1235,7 +1237,9 @@ summary_action_flags(pe_action_t * action, GListPtr children, pe_node_t * node)
 
     if (check_runnable && any_runnable == FALSE) {
         pe_rsc_trace(action->rsc, "%s is not runnable because no children are", action->uuid);
-        flags = crm_clear_bit(__FUNCTION__, __LINE__, action->rsc->id, flags, pe_action_runnable);
+        flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE,
+                                     "Action summary", action->rsc->id,
+                                     flags, pe_action_runnable, NULL);
         if (node == NULL) {
             pe_clear_action_bit(action, pe_action_runnable);
         }

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -409,13 +409,14 @@ unpack_simple_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
 
     if (kind == pe_order_kind_optional && rsc_then->restart_type == pe_restart_restart) {
         crm_trace("Upgrade : recovery - implies right");
-        cons_weight |= pe_order_implies_then;
+        pe__set_order_flags(cons_weight, pe_order_implies_then);
     }
 
     if (invert_bool == FALSE) {
-        cons_weight |= get_asymmetrical_flags(kind);
+        pe__set_order_flags(cons_weight, get_asymmetrical_flags(kind));
     } else {
-        cons_weight |= get_flags(id, kind, action_first, action_then, FALSE);
+        pe__set_order_flags(cons_weight,
+                              get_flags(id, kind, action_first, action_then, FALSE));
     }
 
     if (pe_rsc_is_clone(rsc_first)) {
@@ -495,10 +496,11 @@ unpack_simple_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
     cons_weight = pe_order_optional;
     if (kind == pe_order_kind_optional && rsc_then->restart_type == pe_restart_restart) {
         crm_trace("Upgrade : recovery - implies left");
-        cons_weight |= pe_order_implies_first;
+        pe__set_order_flags(cons_weight, pe_order_implies_first);
     }
 
-    cons_weight |= get_flags(id, kind, action_first, action_then, TRUE);
+    pe__set_order_flags(cons_weight,
+                          get_flags(id, kind, action_first, action_then, TRUE));
 
     order_id = new_rsc_order(rsc_then, action_then, rsc_first, action_first, cons_weight, data_set);
 
@@ -1491,7 +1493,7 @@ handle_migration_ordering(pe__ordering_t *order, pe_working_set_t *data_set)
 
         if (rh_migratable) {
             if (lh_migratable) {
-                flags |= pe_order_apply_first_non_migratable;
+                pe__set_order_flags(flags, pe_order_apply_first_non_migratable);
             }
 
             /* A start then B start
@@ -1507,7 +1509,7 @@ handle_migration_ordering(pe__ordering_t *order, pe_working_set_t *data_set)
         int flags = pe_order_optional;
 
         if (lh_migratable) {
-            flags |= pe_order_apply_first_non_migratable;
+            pe__set_order_flags(flags, pe_order_apply_first_non_migratable);
         }
 
         /* rh side is at the bottom of the stack during a stop. If we have a constraint
@@ -1637,9 +1639,9 @@ get_asymmetrical_flags(enum pe_order_kind kind)
     enum pe_ordering flags = pe_order_optional;
 
     if (kind == pe_order_kind_mandatory) {
-        flags |= pe_order_asymmetrical;
+        pe__set_order_flags(flags, pe_order_asymmetrical);
     } else if (kind == pe_order_kind_serialize) {
-        flags |= pe_order_serialize_only;
+        pe__set_order_flags(flags, pe_order_serialize_only);
     }
     return flags;
 }
@@ -1652,18 +1654,18 @@ get_flags(const char *id, enum pe_order_kind kind,
 
     if (invert && kind == pe_order_kind_mandatory) {
         crm_trace("Upgrade %s: implies left", id);
-        flags |= pe_order_implies_first;
+        pe__set_order_flags(flags, pe_order_implies_first);
 
     } else if (kind == pe_order_kind_mandatory) {
         crm_trace("Upgrade %s: implies right", id);
-        flags |= pe_order_implies_then;
+        pe__set_order_flags(flags, pe_order_implies_then);
         if (pcmk__strcase_any_of(action_first, RSC_START, RSC_PROMOTE, NULL)) {
             crm_trace("Upgrade %s: runnable", id);
-            flags |= pe_order_runnable_left;
+            pe__set_order_flags(flags, pe_order_runnable_left);
         }
 
     } else if (kind == pe_order_kind_serialize) {
-        flags |= pe_order_serialize_only;
+        pe__set_order_flags(flags, pe_order_serialize_only);
     }
 
     return flags;

--- a/lib/pacemaker/pcmk_sched_graph.c
+++ b/lib/pacemaker/pcmk_sched_graph.c
@@ -212,7 +212,7 @@ graph_update_action(pe_action_t * first, pe_action_t * then, pe_node_t * node,
 
         } else if (is_set(first_flags, pe_action_optional) == FALSE) {
             if (update_action_flags(then, pe_action_optional | pe_action_clear, __FUNCTION__, __LINE__)) {
-                changed |= pe_graph_updated_then;
+                pe__set_graph_flags(changed, first, pe_graph_updated_then);
             }
         }
         if (changed) {
@@ -248,7 +248,7 @@ graph_update_action(pe_action_t * first, pe_action_t * then, pe_node_t * node,
                          first->uuid, is_set(first_flags, pe_action_optional),
                          then->uuid, is_set(then_flags, pe_action_optional));
             if (update_action_flags(first, pe_action_runnable | pe_action_clear, __FUNCTION__, __LINE__)) {
-                changed |= pe_graph_updated_first;
+                pe__set_graph_flags(changed, first, pe_graph_updated_first);
             }
         }
 
@@ -295,7 +295,7 @@ graph_update_action(pe_action_t * first, pe_action_t * then, pe_node_t * node,
              * of "before" runnable actions... mark then as runnable */
             if (then->runnable_before >= then->required_runnable_before) {
                 if (update_action_flags(then, pe_action_runnable, __FUNCTION__, __LINE__)) {
-                    changed |= pe_graph_updated_then;
+                    pe__set_graph_flags(changed, first, pe_graph_updated_then);
                 }
             }
         }
@@ -340,7 +340,7 @@ graph_update_action(pe_action_t * first, pe_action_t * then, pe_node_t * node,
         } else if (is_set(first_flags, pe_action_runnable) == FALSE) {
             pe_rsc_trace(then->rsc, "then unrunnable: %s then %s", first->uuid, then->uuid);
             if (update_action_flags(then, pe_action_runnable | pe_action_clear, __FUNCTION__, __LINE__)) {
-                 changed |= pe_graph_updated_then;
+                pe__set_graph_flags(changed, first, pe_graph_updated_then);
             }
         }
         if (changed) {
@@ -430,7 +430,7 @@ graph_update_action(pe_action_t * first, pe_action_t * then, pe_node_t * node,
         && is_not_set(first->flags, pe_action_runnable)) {
 
         if (update_action_flags(then, pe_action_runnable | pe_action_clear, __FUNCTION__, __LINE__)) {
-            changed |= pe_graph_updated_then;
+            pe__set_graph_flags(changed, first, pe_graph_updated_then);
         }
 
         if (changed) {
@@ -580,7 +580,7 @@ update_action(pe_action_t *then, pe_working_set_t *data_set)
             continue;
         }
 
-        clear_bit(changed, pe_graph_updated_first);
+        pe__clear_graph_flags(changed, then, pe_graph_updated_first);
 
         if (first->rsc && is_set(other->type, pe_order_then_cancels_first)
             && is_not_set(then->flags, pe_action_optional)) {
@@ -644,13 +644,14 @@ update_action(pe_action_t *then, pe_working_set_t *data_set)
             /* This was the first time 'first' and 'then' were associated,
              * start again to get the new actions_before list
              */
-            changed |= (pe_graph_updated_then | pe_graph_disable);
+            pe__set_graph_flags(changed, then,
+                                pe_graph_updated_then|pe_graph_disable);
         }
 
         if (changed & pe_graph_disable) {
             crm_trace("Disabled constraint %s -> %s in favor of %s -> %s",
                       other->action->uuid, then->uuid, first->uuid, then->uuid);
-            clear_bit(changed, pe_graph_disable);
+            pe__clear_graph_flags(changed, then, pe_graph_disable);
             other->type = pe_order_none;
         }
 
@@ -675,9 +676,9 @@ update_action(pe_action_t *then, pe_working_set_t *data_set)
 
     if (is_set(then->flags, pe_action_requires_any)) {
         if (last_flags != then->flags) {
-            changed |= pe_graph_updated_then;
+            pe__set_graph_flags(changed, then, pe_graph_updated_then);
         } else {
-            clear_bit(changed, pe_graph_updated_then);
+            pe__clear_graph_flags(changed, then, pe_graph_updated_then);
         }
     }
 

--- a/lib/pacemaker/pcmk_sched_graph.c
+++ b/lib/pacemaker/pcmk_sched_graph.c
@@ -590,7 +590,7 @@ update_action(pe_action_t *then, pe_working_set_t *data_set)
              */
             pe__set_action_flags(other->action, pe_action_optional);
             if (!strcmp(first->task, CRMD_ACTION_RELOAD)) {
-                clear_bit(first->rsc->flags, pe_rsc_reload);
+                pe__clear_resource_flags(first->rsc, pe_rsc_reload);
             }
         }
 

--- a/lib/pacemaker/pcmk_sched_graph.c
+++ b/lib/pacemaker/pcmk_sched_graph.c
@@ -535,7 +535,7 @@ update_action(pe_action_t *then, pe_working_set_t *data_set)
         if (then->required_runnable_before == 0) {
             then->required_runnable_before = 1;
         }
-        pe_clear_action_bit(then, pe_action_runnable);
+        pe__clear_action_flags(then, pe_action_runnable);
         /* We are relying on the pe_order_one_or_more clause of
          * graph_update_action(), called as part of the:
          *
@@ -738,7 +738,7 @@ shutdown_constraints(pe_node_t * node, pe_action_t * shutdown_op, pe_working_set
 
         pe_rsc_trace(action->rsc, "Ordering %s before shutdown on %s", action->uuid,
                      node->details->uname);
-        pe_clear_action_bit(action, pe_action_optional);
+        pe__clear_action_flags(action, pe_action_optional);
         custom_action_order(action->rsc, NULL, action,
                             NULL, strdup(CRM_OP_SHUTDOWN), shutdown_op,
                             pe_order_optional | pe_order_runnable_left, data_set);
@@ -1692,7 +1692,7 @@ graph_has_loop(pe_action_t *init_action, pe_action_t *action,
     }
 
 done:
-    pe_clear_action_bit(input->action, pe_action_tracking);
+    pe__clear_action_flags(input->action, pe_action_tracking);
 
     if (!has_loop) {
         crm_trace("No input loop found in %s@%s -> %s@%s (0x%.6x)",

--- a/lib/pacemaker/pcmk_sched_graph.c
+++ b/lib/pacemaker/pcmk_sched_graph.c
@@ -195,8 +195,8 @@ graph_update_action(pe_action_t * first, pe_action_t * then, pe_node_t * node,
          * like any other 'pe_order_implies_then'
          */
 
-        clear_bit(type, pe_order_implies_then_on_node);
-        set_bit(type, pe_order_implies_then);
+        pe__clear_order_flags(type, pe_order_implies_then_on_node);
+        pe__set_order_flags(type, pe_order_implies_then);
         node = first->node;
     }
 
@@ -1480,9 +1480,9 @@ check_dump_input(pe_action_t *action, pe_action_wrapper_t *input)
         return true;
     }
 
-    type &= ~pe_order_implies_first_printed;
-    type &= ~pe_order_implies_then_printed;
-    type &= ~pe_order_optional;
+    pe__clear_order_flags(type, pe_order_implies_first_printed
+                                |pe_order_implies_then_printed
+                                |pe_order_optional);
 
     if (input->type == pe_order_none) {
         crm_trace("Ignoring %s (%d) input %s (%d): "

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -37,11 +37,11 @@ pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer,
 
     if (group_data->first_child == NULL) {
         // Nothing to allocate
-        clear_bit(rsc->flags, pe_rsc_provisional);
+        pe__clear_resource_flags(rsc, pe_rsc_provisional);
         return NULL;
     }
 
-    set_bit(rsc->flags, pe_rsc_allocating);
+    pe__set_resource_flags(rsc, pe_rsc_allocating);
     rsc->role = group_data->first_child->role;
 
     group_data->first_child->rsc_cons =
@@ -67,8 +67,7 @@ pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer,
     }
 
     rsc->next_role = group_data->first_child->next_role;
-    clear_bit(rsc->flags, pe_rsc_allocating);
-    clear_bit(rsc->flags, pe_rsc_provisional);
+    pe__clear_resource_flags(rsc, pe_rsc_allocating|pe_rsc_provisional);
 
     if (group_data->colocated) {
         return group_node;
@@ -505,7 +504,7 @@ pcmk__group_merge_weights(pe_resource_t *rsc, const char *rhs,
         return nodes;
     }
 
-    set_bit(rsc->flags, pe_rsc_merging);
+    pe__set_resource_flags(rsc, pe_rsc_merging);
 
     nodes =
         group_data->first_child->cmds->merge_weights(group_data->first_child, rhs, nodes, attr,
@@ -523,7 +522,7 @@ pcmk__group_merge_weights(pe_resource_t *rsc, const char *rhs,
                                            flags);
     }
 
-    clear_bit(rsc->flags, pe_rsc_merging);
+    pe__clear_resource_flags(rsc, pe_rsc_merging);
     return nodes;
 }
 

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -95,34 +95,32 @@ group_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set)
     }
 
     op = start_action(rsc, NULL, TRUE /* !group_data->child_starting */ );
-    set_bit(op->flags, pe_action_pseudo | pe_action_runnable);
+    pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
 
     op = custom_action(rsc, started_key(rsc),
                        RSC_STARTED, NULL, TRUE /* !group_data->child_starting */ , TRUE, data_set);
-    set_bit(op->flags, pe_action_pseudo | pe_action_runnable);
+    pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
 
     op = stop_action(rsc, NULL, TRUE /* !group_data->child_stopping */ );
-    set_bit(op->flags, pe_action_pseudo | pe_action_runnable);
+    pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
 
     op = custom_action(rsc, stopped_key(rsc),
                        RSC_STOPPED, NULL, TRUE /* !group_data->child_stopping */ , TRUE, data_set);
-    set_bit(op->flags, pe_action_pseudo | pe_action_runnable);
+    pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
 
     value = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_PROMOTABLE);
     if (crm_is_true(value)) {
         op = custom_action(rsc, demote_key(rsc), RSC_DEMOTE, NULL, TRUE, TRUE, data_set);
-        set_bit(op->flags, pe_action_pseudo);
-        set_bit(op->flags, pe_action_runnable);
+        pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
+
         op = custom_action(rsc, demoted_key(rsc), RSC_DEMOTED, NULL, TRUE, TRUE, data_set);
-        set_bit(op->flags, pe_action_pseudo);
-        set_bit(op->flags, pe_action_runnable);
+        pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
 
         op = custom_action(rsc, promote_key(rsc), RSC_PROMOTE, NULL, TRUE, TRUE, data_set);
-        set_bit(op->flags, pe_action_pseudo);
-        set_bit(op->flags, pe_action_runnable);
+        pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
+
         op = custom_action(rsc, promoted_key(rsc), RSC_PROMOTED, NULL, TRUE, TRUE, data_set);
-        set_bit(op->flags, pe_action_pseudo);
-        set_bit(op->flags, pe_action_runnable);
+        pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
     }
 }
 
@@ -397,7 +395,8 @@ group_action_flags(pe_action_t * action, pe_node_t * node)
                 && is_set(child_flags, pe_action_optional) == FALSE) {
                 pe_rsc_trace(action->rsc, "%s is mandatory because of %s", action->uuid,
                              child_action->uuid);
-                clear_bit(flags, pe_action_optional);
+                pe__clear_raw_action_flags(flags, "group action",
+                                           pe_action_optional);
                 pe__clear_action_flags(action, pe_action_optional);
             }
             if (!pcmk__str_eq(task_s, action->task, pcmk__str_casei)
@@ -405,14 +404,16 @@ group_action_flags(pe_action_t * action, pe_node_t * node)
                 && is_set(child_flags, pe_action_runnable) == FALSE) {
                 pe_rsc_trace(action->rsc, "%s is not runnable because of %s", action->uuid,
                              child_action->uuid);
-                clear_bit(flags, pe_action_runnable);
+                pe__clear_raw_action_flags(flags, "group action",
+                                           pe_action_runnable);
                 pe__clear_action_flags(action, pe_action_runnable);
             }
 
         } else if (task != stop_rsc && task != action_demote) {
             pe_rsc_trace(action->rsc, "%s is not runnable because of %s (not found in %s)",
                          action->uuid, task_s, child->id);
-            clear_bit(flags, pe_action_runnable);
+            pe__clear_raw_action_flags(flags, "group action",
+                                       pe_action_runnable);
         }
     }
 

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -185,7 +185,7 @@ group_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set)
 
         if (last_rsc == NULL) {
             if (group_data->ordered) {
-                stop |= pe_order_optional;
+                pe__set_order_flags(stop, pe_order_optional);
                 stopped = pe_order_implies_then;
             }
 

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -398,7 +398,7 @@ group_action_flags(pe_action_t * action, pe_node_t * node)
                 pe_rsc_trace(action->rsc, "%s is mandatory because of %s", action->uuid,
                              child_action->uuid);
                 clear_bit(flags, pe_action_optional);
-                pe_clear_action_bit(action, pe_action_optional);
+                pe__clear_action_flags(action, pe_action_optional);
             }
             if (!pcmk__str_eq(task_s, action->task, pcmk__str_casei)
                 && is_set(flags, pe_action_runnable)
@@ -406,7 +406,7 @@ group_action_flags(pe_action_t * action, pe_node_t * node)
                 pe_rsc_trace(action->rsc, "%s is not runnable because of %s", action->uuid,
                              child_action->uuid);
                 clear_bit(flags, pe_action_runnable);
-                pe_clear_action_bit(action, pe_action_runnable);
+                pe__clear_action_flags(action, pe_action_runnable);
             }
 
         } else if (task != stop_rsc && task != action_demote) {

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -72,6 +72,12 @@ static rsc_transition_fn rsc_action_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX] = {
     /* Master  */ { RoleError, DemoteRsc, DemoteRsc, DemoteRsc, NullOp      , },
 };
 
+#define clear_node_weights_flags(nw_flags, nw_rsc, flags_to_clear) do {     \
+        flags = pcmk__clear_flags_as(__FUNCTION__, __LINE__, LOG_TRACE,     \
+                                     "Node weight", (nw_rsc)->id, (flags),  \
+                                     (flags_to_clear), #flags_to_clear);    \
+    } while (0)
+
 static gboolean
 native_choose_node(pe_resource_t * rsc, pe_node_t * prefer, pe_working_set_t * data_set)
 {
@@ -373,7 +379,7 @@ pcmk__native_merge_weights(pe_resource_t *rsc, const char *rhs,
         } else {
             work = pcmk__copy_node_table(rsc->allowed_nodes);
         }
-        clear_bit(flags, pe_weights_init);
+        clear_node_weights_flags(flags, rsc, pe_weights_init);
 
     } else if (is_nonempty_group(rsc)) {
         /* The first member of the group will recursively incorporate any

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -1131,14 +1131,14 @@ handle_migration_actions(pe_resource_t * rsc, pe_node_t *current, pe_node_t *cho
 
     if ((migrate_to && migrate_from) || (migrate_from && partial)) {
 
-        set_bit(start->flags, pe_action_migrate_runnable);
-        set_bit(stop->flags, pe_action_migrate_runnable);
+        pe__set_action_flags(start, pe_action_migrate_runnable);
+        pe__set_action_flags(stop, pe_action_migrate_runnable);
 
         update_action_flags(start, pe_action_pseudo, __FUNCTION__, __LINE__);       /* easier than trying to delete it from the graph */
 
         /* order probes before migrations */
         if (partial) {
-            set_bit(migrate_from->flags, pe_action_migrate_runnable);
+            pe__set_action_flags(migrate_from, pe_action_migrate_runnable);
             migrate_from->needs = start->needs;
 
             custom_action_order(rsc, pcmk__op_key(rsc->id, RSC_STATUS, 0), NULL,
@@ -1146,8 +1146,8 @@ handle_migration_actions(pe_resource_t * rsc, pe_node_t *current, pe_node_t *cho
                                 NULL, pe_order_optional, data_set);
 
         } else {
-            set_bit(migrate_from->flags, pe_action_migrate_runnable);
-            set_bit(migrate_to->flags, pe_action_migrate_runnable);
+            pe__set_action_flags(migrate_from, pe_action_migrate_runnable);
+            pe__set_action_flags(migrate_to, pe_action_migrate_runnable);
             migrate_to->needs = start->needs;
 
             custom_action_order(rsc, pcmk__op_key(rsc->id, RSC_STATUS, 0), NULL,
@@ -1234,7 +1234,7 @@ native_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set)
 
         pe_action_t *stop = stop_action(rsc, dangling_source, FALSE);
 
-        set_bit(stop->flags, pe_action_dangle);
+        pe__set_action_flags(stop, pe_action_dangle);
         pe_rsc_trace(rsc, "Forcing a cleanup of %s on %s",
                      rsc->id, dangling_source->details->uname);
 
@@ -1298,7 +1298,7 @@ native_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set)
 
     if (is_set(rsc->flags, pe_rsc_start_pending)) {
         start = start_action(rsc, chosen, TRUE);
-        set_bit(start->flags, pe_action_print_always);
+        pe__set_action_flags(start, pe_action_print_always);
     }
 
     if (current && chosen && current->details != chosen->details) {

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -358,7 +358,7 @@ pcmk__native_merge_weights(pe_resource_t *rsc, const char *rhs,
         pe_rsc_info(rsc, "%s: Breaking dependency loop at %s", rhs, rsc->id);
         return nodes;
     }
-    set_bit(rsc->flags, pe_rsc_merging);
+    pe__set_resource_flags(rsc, pe_rsc_merging);
 
     if (is_set(flags, pe_weights_init)) {
         if (is_nonempty_group(rsc)) {
@@ -453,7 +453,7 @@ pcmk__native_merge_weights(pe_resource_t *rsc, const char *rhs,
         pe_rsc_info(rsc, "%s: Rolling back optional scores from %s",
                     rhs, rsc->id);
         g_hash_table_destroy(work);
-        clear_bit(rsc->flags, pe_rsc_merging);
+        pe__clear_resource_flags(rsc, pe_rsc_merging);
         return nodes;
     }
 
@@ -474,7 +474,7 @@ pcmk__native_merge_weights(pe_resource_t *rsc, const char *rhs,
         g_hash_table_destroy(nodes);
     }
 
-    clear_bit(rsc->flags, pe_rsc_merging);
+    pe__clear_resource_flags(rsc, pe_rsc_merging);
     return work;
 }
 
@@ -515,7 +515,7 @@ pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *prefer,
         return NULL;
     }
 
-    set_bit(rsc->flags, pe_rsc_allocating);
+    pe__set_resource_flags(rsc, pe_rsc_allocating);
     pe__show_node_weights(true, rsc, "Pre-alloc", rsc->allowed_nodes);
 
     for (gIter = rsc->rsc_cons; gIter != NULL; gIter = gIter->next) {
@@ -584,7 +584,7 @@ pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *prefer,
     pe__show_node_weights(!show_scores, rsc, __FUNCTION__, rsc->allowed_nodes);
     if (is_set(data_set->flags, pe_flag_stonith_enabled)
         && is_set(data_set->flags, pe_flag_have_stonith_resource) == FALSE) {
-        clear_bit(rsc->flags, pe_rsc_managed);
+        pe__clear_resource_flags(rsc, pe_rsc_managed);
     }
 
     if (is_not_set(rsc->flags, pe_rsc_managed)) {
@@ -627,7 +627,7 @@ pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *prefer,
                      rsc->allocated_to->details->uname);
     }
 
-    clear_bit(rsc->flags, pe_rsc_allocating);
+    pe__clear_resource_flags(rsc, pe_rsc_allocating);
 
     if (rsc->is_remote_node) {
         pe_node_t *remote_node = pe_find_node(data_set->nodes, rsc->id);
@@ -2003,8 +2003,8 @@ rsc_ticket_constraint(pe_resource_t * rsc_lh, rsc_ticket_t * rsc_ticket, pe_work
                     return;
                 }
                 if (rsc_lh->running_on != NULL) {
-                    clear_bit(rsc_lh->flags, pe_rsc_managed);
-                    set_bit(rsc_lh->flags, pe_rsc_block);
+                    pe__clear_resource_flags(rsc_lh, pe_rsc_managed);
+                    pe__set_resource_flags(rsc_lh, pe_rsc_block);
                 }
                 break;
         }
@@ -3418,7 +3418,7 @@ ReloadRsc(pe_resource_t * rsc, pe_node_t *node, pe_working_set_t * data_set)
     }
 
     pe_rsc_trace(rsc, "Processing %s", rsc->id);
-    set_bit(rsc->flags, pe_rsc_reload);
+    pe__set_resource_flags(rsc, pe_rsc_reload);
 
     reload = custom_action(
         rsc, reload_key(rsc), CRMD_ACTION_RELOAD, node, FALSE, TRUE, data_set);

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -2202,7 +2202,7 @@ native_update_actions(pe_action_t *first, pe_action_t *then, pe_node_t *node,
 
         if ((first->flags & pe_action_runnable) == FALSE) {
             pe_action_implies(then, first, pe_action_migrate_runnable);
-            pe_clear_action_bit(then, pe_action_pseudo);
+            pe__clear_action_flags(then, pe_action_pseudo);
             pe_rsc_trace(then->rsc, "Unset pseudo on %s because %s is not runnable", then->uuid, first->uuid);
         }
 

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -2240,7 +2240,7 @@ native_update_actions(pe_action_t *first, pe_action_t *then, pe_node_t *node,
     }
 
     if (then_flags != then->flags) {
-        changed |= pe_graph_updated_then;
+        pe__set_graph_flags(changed, first, pe_graph_updated_then);
         pe_rsc_trace(then->rsc,
                      "Then: Flags for %s on %s are now  0x%.6x (was 0x%.6x) because of %s 0x%.6x",
                      then->uuid, then->node ? then->node->details->uname : "[none]", then->flags,
@@ -2253,7 +2253,7 @@ native_update_actions(pe_action_t *first, pe_action_t *then, pe_node_t *node,
     }
 
     if (first_flags != first->flags) {
-        changed |= pe_graph_updated_first;
+        pe__set_graph_flags(changed, first, pe_graph_updated_first);
         pe_rsc_trace(first->rsc,
                      "First: Flags for %s on %s are now  0x%.6x (was 0x%.6x) because of %s 0x%.6x",
                      first->uuid, first->node ? first->node->details->uname : "[none]",

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -3083,7 +3083,7 @@ native_create_probe(pe_resource_t * rsc, pe_node_t * node, pe_action_t * complet
         /* Prevent the start from occurring if rsc isn't active, but
          * don't cause it to stop if it was active already
          */
-        flags |= pe_order_runnable_left;
+        pe__set_order_flags(flags, pe_order_runnable_left);
     }
 
     custom_action_order(rsc, NULL, probe,

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -270,7 +270,7 @@ promotion_order(pe_resource_t *rsc, pe_working_set_t *data_set)
     }
     clone_data->merged_master_weights = TRUE;
     pe_rsc_trace(rsc, "Merging weights for %s", rsc->id);
-    set_bit(rsc->flags, pe_rsc_merging);
+    pe__set_resource_flags(rsc, pe_rsc_merging);
 
     for (gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child = (pe_resource_t *) gIter->data;
@@ -384,7 +384,7 @@ promotion_order(pe_resource_t *rsc, pe_working_set_t *data_set)
 
     rsc->children = g_list_sort_with_data(rsc->children,
                                           sort_promotable_instance, data_set);
-    clear_bit(rsc->flags, pe_rsc_merging);
+    pe__clear_resource_flags(rsc, pe_rsc_merging);
 }
 
 static gboolean

--- a/lib/pacemaker/pcmk_sched_utils.c
+++ b/lib/pacemaker/pcmk_sched_utils.c
@@ -255,7 +255,7 @@ native_deallocate(pe_resource_t * rsc)
         pe_node_t *old = rsc->allocated_to;
 
         crm_info("Deallocating %s from %s", rsc->id, old->details->uname);
-        set_bit(rsc->flags, pe_rsc_provisional);
+        pe__set_resource_flags(rsc, pe_rsc_provisional);
         rsc->allocated_to = NULL;
 
         old->details->allocated_rsc = g_list_remove(old->details->allocated_rsc, rsc);
@@ -296,7 +296,7 @@ native_assign_node(pe_resource_t * rsc, GListPtr nodes, pe_node_t * chosen, gboo
      */
 
     native_deallocate(rsc);
-    clear_bit(rsc->flags, pe_rsc_provisional);
+    pe__clear_resource_flags(rsc, pe_rsc_provisional);
 
     if (chosen == NULL) {
         GListPtr gIter = NULL;
@@ -315,7 +315,7 @@ native_assign_node(pe_resource_t * rsc, GListPtr nodes, pe_node_t * chosen, gboo
 
             } else if(pcmk__str_eq(RSC_START, op->task, pcmk__str_casei)) {
                 update_action_flags(op, pe_action_runnable | pe_action_clear, __FUNCTION__, __LINE__);
-                /* set_bit(rsc->flags, pe_rsc_block); */
+                //pe__set_resource_flags(rsc, pe_rsc_block);
 
             } else if (interval_ms_s && !pcmk__str_eq(interval_ms_s, "0", pcmk__str_casei)) {
                 if(pcmk__str_eq(rc_inactive, g_hash_table_lookup(op->meta, XML_ATTR_TE_TARGET_RC), pcmk__str_casei)) {

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -114,7 +114,7 @@ valid_network(pe__bundle_variant_data_t *data)
         if(data->nreplicas_per_host > 1) {
             pe_err("Specifying the 'control-port' for %s requires 'replicas-per-host=1'", data->prefix);
             data->nreplicas_per_host = 1;
-            /* @TODO to be sure: clear_bit(rsc->flags, pe_rsc_unique); */
+            // @TODO to be sure: pe__clear_resource_flags(rsc, pe_rsc_unique);
         }
         return TRUE;
     }
@@ -887,7 +887,7 @@ create_container(pe_resource_t *parent, pe__bundle_variant_data_t *data,
          * containers with pacemaker-remoted inside in order to start
          * services inside those containers.
          */
-        set_bit(replica->remote->flags, pe_rsc_allow_remote_remotes);
+        pe__set_resource_flags(replica->remote, pe_rsc_allow_remote_remotes);
     }
 
     return TRUE;
@@ -1090,7 +1090,7 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
         bundle_data->nreplicas_per_host = 1;
     }
     if (bundle_data->nreplicas_per_host == 1) {
-        clear_bit(rsc->flags, pe_rsc_unique);
+        pe__clear_resource_flags(rsc, pe_rsc_unique);
     }
 
     bundle_data->container_command = crm_element_value_copy(xml_obj, "run-command");
@@ -1290,7 +1290,7 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
 
             // Ensure the child's notify gets set based on the underlying primitive's value
             if (is_set(replica->child->flags, pe_rsc_notify)) {
-                set_bit(bundle_data->child->flags, pe_rsc_notify);
+                pe__set_resource_flags(bundle_data->child, pe_rsc_notify);
             }
 
             offset += allocate_ip(bundle_data, replica, buffer+offset,

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1021,6 +1021,12 @@ pe__add_bundle_remote_name(pe_resource_t *rsc, xmlNode *xml, const char *field)
     return node->details->uname;
 }
 
+#define pe__set_bundle_mount_flags(mount_xml, flags, flags_to_set) do {     \
+        flags = pcmk__set_flags_as(__FUNCTION__, __LINE__, LOG_TRACE,       \
+                                   "Bundle mount", ID(mount_xml), flags,    \
+                                   (flags_to_set), #flags_to_set);          \
+    } while (0)
+
 gboolean
 pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
 {
@@ -1146,7 +1152,8 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
 
         if (source == NULL) {
             source = crm_element_value(xml_child, "source-dir-root");
-            set_bit(flags, pe__bundle_mount_subdir);
+            pe__set_bundle_mount_flags(xml_child, flags,
+                                       pe__bundle_mount_subdir);
         }
 
         if (source && target) {

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -94,7 +94,7 @@ pe__create_clone_child(pe_resource_t *rsc, pe_working_set_t *data_set)
     pe_rsc_trace(child_rsc, "Setting clone attributes for: %s", child_rsc->id);
     rsc->children = g_list_append(rsc->children, child_rsc);
     if (as_orphan) {
-        set_bit_recursive(child_rsc, pe_rsc_orphan);
+        pe__set_resource_flags_recursive(child_rsc, pe_rsc_orphan);
     }
 
     add_hash_param(child_rsc->meta, XML_RSC_ATTR_INCARNATION_MAX, inc_max);

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -619,7 +619,7 @@ common_unpack(xmlNode * xml_obj, pe_resource_t ** rsc,
     }
 
     if (pcmk__str_eq(rclass, PCMK_RESOURCE_CLASS_STONITH, pcmk__str_casei)) {
-        set_bit(data_set->flags, pe_flag_have_stonith_resource);
+        pe__set_working_set_flags(data_set, pe_flag_have_stonith_resource);
         set_bit((*rsc)->flags, pe_rsc_fence_device);
     }
 

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -105,7 +105,7 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
     }
 
     if (rsc->variant == pe_native && node->details->maintenance) {
-        clear_bit(rsc->flags, pe_rsc_managed);
+        pe__clear_resource_flags(rsc, pe_rsc_managed);
     }
 
     if (is_not_set(rsc->flags, pe_rsc_managed)) {
@@ -143,8 +143,8 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
             case recovery_stop_start:
                 break;
             case recovery_block:
-                clear_bit(rsc->flags, pe_rsc_managed);
-                set_bit(rsc->flags, pe_rsc_block);
+                pe__clear_resource_flags(rsc, pe_rsc_managed);
+                pe__set_resource_flags(rsc, pe_rsc_block);
 
                 /* If the resource belongs to a group or bundle configured with
                  * multiple-active=block, block the entire entity.
@@ -157,8 +157,8 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
                     for (; gIter != NULL; gIter = gIter->next) {
                         pe_resource_t *child = (pe_resource_t *) gIter->data;
 
-                        clear_bit(child->flags, pe_rsc_managed);
-                        set_bit(child->flags, pe_rsc_block);
+                        pe__clear_resource_flags(child, pe_rsc_managed);
+                        pe__set_resource_flags(child, pe_rsc_block);
                     }
                 }
                 break;
@@ -179,7 +179,7 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
 static void
 recursive_clear_unique(pe_resource_t *rsc)
 {
-    clear_bit(rsc->flags, pe_rsc_unique);
+    pe__clear_resource_flags(rsc, pe_rsc_unique);
     add_hash_param(rsc->meta, XML_RSC_ATTR_UNIQUE, XML_BOOLEAN_FALSE);
 
     for (GList *child = rsc->children; child != NULL; child = child->next) {

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -95,9 +95,10 @@ cluster_status(pe_working_set_t * data_set)
                                                    XML_ATTR_DC_UUID);
     }
 
-    clear_bit(data_set->flags, pe_flag_have_quorum);
     if (crm_is_true(value)) {
-        set_bit(data_set->flags, pe_flag_have_quorum);
+        pe__set_working_set_flags(data_set, pe_flag_have_quorum);
+    } else {
+        pe__clear_working_set_flags(data_set, pe_flag_have_quorum);
     }
 
     data_set->op_defaults = get_xpath_object("//" XML_CIB_TAG_OPCONFIG,
@@ -133,7 +134,7 @@ cluster_status(pe_working_set_t * data_set)
         }
     }
 
-    set_bit(data_set->flags, pe_flag_have_status);
+    pe__set_working_set_flags(data_set, pe_flag_have_status);
     return TRUE;
 }
 
@@ -271,7 +272,7 @@ cleanup_calculations(pe_working_set_t * data_set)
         return;
     }
 
-    clear_bit(data_set->flags, pe_flag_have_status);
+    pe__clear_working_set_flags(data_set, pe_flag_have_status);
     if (data_set->config_hash != NULL) {
         g_hash_table_destroy(data_set->config_hash);
     }
@@ -363,12 +364,14 @@ set_working_set_defaults(pe_working_set_t * data_set)
     data_set->no_quorum_policy = no_quorum_stop;
 
     data_set->flags = 0x0ULL;
-    set_bit(data_set->flags, pe_flag_stop_rsc_orphans);
-    set_bit(data_set->flags, pe_flag_symmetric_cluster);
-    set_bit(data_set->flags, pe_flag_stop_action_orphans);
+    pe__set_working_set_flags(data_set,
+                              pe_flag_stop_rsc_orphans
+                              |pe_flag_symmetric_cluster
+                              |pe_flag_stop_action_orphans
 #ifdef DEFAULT_CONCURRENT_FENCING_TRUE
-    set_bit(data_set->flags, pe_flag_concurrent_fencing);
+                              |pe_flag_concurrent_fencing
 #endif
+                              );
 }
 
 pe_resource_t *

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2117,7 +2117,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
         for (; gIter != NULL; gIter = gIter->next) {
             pe_action_t *stop = (pe_action_t *) gIter->data;
 
-            stop->flags |= pe_action_optional;
+            pe__set_action_flags(stop, pe_action_optional);
         }
 
         g_list_free(possible_matches);

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -676,12 +676,12 @@ custom_action(pe_resource_t * rsc, char *key, const char *task,
         if (save_action) {
             switch (a_task) {
                 case stop_rsc:
-                    set_bit(rsc->flags, pe_rsc_stopping);
+                    pe__set_resource_flags(rsc, pe_rsc_stopping);
                     break;
                 case start_rsc:
-                    clear_bit(rsc->flags, pe_rsc_starting);
+                    pe__clear_resource_flags(rsc, pe_rsc_starting);
                     if (is_set(action->flags, pe_action_runnable)) {
-                        set_bit(rsc->flags, pe_rsc_starting);
+                        pe__set_resource_flags(rsc, pe_rsc_starting);
                     }
                     break;
                 default:
@@ -1907,15 +1907,9 @@ order_actions(pe_action_t * lh_action, pe_action_t * rh_action, enum pe_ordering
     wrapper = calloc(1, sizeof(pe_action_wrapper_t));
     wrapper->action = rh_action;
     wrapper->type = order;
-
     list = lh_action->actions_after;
     list = g_list_prepend(list, wrapper);
     lh_action->actions_after = list;
-
-    wrapper = NULL;
-
-/* 	order |= pe_order_implies_then; */
-/* 	order ^= pe_order_implies_then; */
 
     wrapper = calloc(1, sizeof(pe_action_wrapper_t));
     wrapper->action = lh_action;
@@ -2336,28 +2330,20 @@ const char *rsc_printable_id(pe_resource_t *rsc)
 }
 
 void
-clear_bit_recursive(pe_resource_t * rsc, unsigned long long flag)
+pe__clear_resource_flags_recursive(pe_resource_t *rsc, uint64_t flags)
 {
-    GListPtr gIter = rsc->children;
-
-    clear_bit(rsc->flags, flag);
-    for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
-
-        clear_bit_recursive(child_rsc, flag);
+    pe__clear_resource_flags(rsc, flags);
+    for (GList *gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
+        pe__clear_resource_flags_recursive((pe_resource_t *) gIter->data, flags);
     }
 }
 
 void
-set_bit_recursive(pe_resource_t * rsc, unsigned long long flag)
+pe__set_resource_flags_recursive(pe_resource_t *rsc, uint64_t flags)
 {
-    GListPtr gIter = rsc->children;
-
-    set_bit(rsc->flags, flag);
-    for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
-
-        set_bit_recursive(child_rsc, flag);
+    pe__set_resource_flags(rsc, flags);
+    for (GList *gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
+        pe__set_resource_flags_recursive((pe_resource_t *) gIter->data, flags);
     }
 }
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -2655,13 +2655,17 @@ void pe_action_set_flag_reason(const char *function, long line,
 
     if(unset) {
         if(is_set(action->flags, flags)) {
-            action->flags = crm_clear_bit(function, line, action->uuid, action->flags, flags);
+            action->flags = pcmk__clear_flags_as(function, line, LOG_TRACE,
+                                                 "Action", action->uuid,
+                                                 action->flags, flags, NULL);
             update = TRUE;
         }
 
     } else {
         if(is_not_set(action->flags, flags)) {
-            action->flags = crm_set_bit(function, line, action->uuid, action->flags, flags);
+            action->flags = pcmk__set_flags_as(function, line, LOG_TRACE,
+                                               "Action", action->uuid,
+                                               action->flags, flags, NULL);
             update = TRUE;
         }
     }

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1936,8 +1936,7 @@ get_pseudo_op(const char *name, pe_working_set_t * data_set)
     }
     if (op == NULL) {
         op = custom_action(NULL, strdup(name), name, NULL, TRUE, TRUE, data_set);
-        set_bit(op->flags, pe_action_pseudo);
-        set_bit(op->flags, pe_action_runnable);
+        pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
     }
 
     return op;

--- a/maint/mocked/based-notifyfenced.c
+++ b/maint/mocked/based-notifyfenced.c
@@ -137,7 +137,7 @@ mock_based_notifyfencedmer_callback_worker(gpointer data)
     int options;
     char update_str[4096];
 
-    options |= cib_zero_copy;
+    cib__set_call_options(options, crm_system_name, cib_zero_copy);
 
 
     input = create_xml_node(NULL, "cib");

--- a/maint/mocked/based.c
+++ b/maint/mocked/based.c
@@ -153,7 +153,7 @@ mock_based_common_callback_worker(uint32_t id, uint32_t flags,
                   type, cib_client->name, cib_client->id, on_off ? "on" : "off");
 
         if (!strcmp(type, T_CIB_DIFF_NOTIFY) && on_off) {
-            cib_client->options |= cib_notify_diff;
+            pcmk__set_client_flags(cib_client, cib_notify_diff);
         }
 
         ctxt = (mock_based_context_t *) cib_client->userdata;

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -314,7 +314,7 @@ send_attrd_query(const char *name, const char *host, xmlNode **reply)
         crm_perror(LOG_ERR, "Connection to cluster attribute manager failed");
         rc = -ENOTCONN;
     } else {
-        rc = crm_ipc_send(ipc, query, crm_ipc_flags_none|crm_ipc_client_response, 0, reply);
+        rc = crm_ipc_send(ipc, query, crm_ipc_client_response, 0, reply);
         if (rc > 0) {
             rc = pcmk_ok;
         }

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -222,7 +222,7 @@ main(int argc, char **argv)
                 query_all = TRUE;
                 break;
             case 'p':
-                set_bit(attr_options, pcmk__node_attr_private);
+                pcmk__set_node_attr_flags(attr_options, pcmk__node_attr_private);
                 break;
             case 'q':
                 break;

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -430,10 +430,12 @@ main(int argc, char **argv)
                 break;
             case 'A':
                 obj_type = optarg;
-                command_options |= cib_xpath;
+                cib__set_call_options(command_options, crm_system_name,
+                                      cib_xpath);
                 break;
             case 'e':
-                command_options |= cib_xpath_address;
+                cib__set_call_options(command_options, crm_system_name,
+                                      cib_xpath_address);
                 break;
             case 'u':
                 cib_action = CIB_OP_UPGRADE;
@@ -471,17 +473,20 @@ main(int argc, char **argv)
                 cib_action = "md5-sum-versioned";
                 break;
             case 'c':
-                command_options |= cib_can_create;
+                cib__set_call_options(command_options, crm_system_name,
+                                      cib_can_create);
                 break;
             case 'n':
-                command_options |= cib_no_children;
+                cib__set_call_options(command_options, crm_system_name,
+                                      cib_no_children);
                 break;
             case 'B':
                 cib_action = CIB_OP_BUMP;
                 crm_log_args(argc, argv);
                 break;
             case 'V':
-                command_options = command_options | cib_verbose;
+                cib__set_call_options(command_options, crm_system_name,
+                                      cib_verbose);
                 bump_log_num++;
                 break;
             case '?':
@@ -512,24 +517,28 @@ main(int argc, char **argv)
                 host = strdup(optarg);
                 break;
             case 'l':
-                command_options |= cib_scope_local;
+                cib__set_call_options(command_options, crm_system_name,
+                                      cib_scope_local);
                 break;
             case 'd':
                 cib_action = CIB_OP_DELETE;
-                command_options |= cib_multiple;
+                cib__set_call_options(command_options, crm_system_name,
+                                      cib_multiple);
                 dangerous_cmd = TRUE;
                 break;
             case 'b':
                 dangerous_cmd = TRUE;
-                command_options |= cib_inhibit_bcast;
-                command_options |= cib_scope_local;
+                cib__set_call_options(command_options, crm_system_name,
+                                      cib_inhibit_bcast|cib_scope_local);
                 break;
             case 's':
-                command_options |= cib_sync_call;
+                cib__set_call_options(command_options, crm_system_name,
+                                      cib_sync_call);
                 break;
             case 'f':
                 force_flag = TRUE;
-                command_options |= cib_quorum_override;
+                cib__set_call_options(command_options, crm_system_name,
+                                      cib_quorum_override);
                 crm_log_args(argc, argv);
                 break;
             case 'a':

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -28,6 +28,7 @@
 #include <crm/cluster.h>
 
 #include <crm/cib.h>
+#include <crm/cib/internal.h>
 #include <crm/common/attrd_internal.h>
 #include <sys/utsname.h>
 
@@ -326,7 +327,8 @@ main(int argc, char **argv)
                 break;
             case '!':
                 crm_warn("Inhibiting notifications for this update");
-                cib_opts |= cib_inhibit_notify;
+                cib__set_call_options(cib_opts, crm_system_name,
+                                      cib_inhibit_notify);
                 break;
             default:
                 printf("Argument code 0%o (%c) is not (?yet?) supported\n", flag, flag);

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1963,7 +1963,7 @@ mon_refresh_display(gpointer user_data)
         mon_data_set = pe_new_working_set();
         CRM_ASSERT(mon_data_set != NULL);
     }
-    set_bit(mon_data_set->flags, pe_flag_no_compat);
+    pe__set_working_set_flags(mon_data_set, pe_flag_no_compat);
 
     mon_data_set->input = cib_copy;
     cluster_status(mon_data_set);

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -24,6 +24,7 @@
 #include <crm/crm.h>
 #include <crm/stonith-ng.h>
 #include <crm/common/ipc_controld.h>
+#include <crm/cib/internal.h>
 
 #define SUMMARY "crm_resource - perform tasks related to Pacemaker cluster resources"
 
@@ -1492,7 +1493,8 @@ main(int argc, char **argv)
 
     if (options.force) {
         crm_debug("Forcing...");
-        options.cib_options |= cib_quorum_override;
+        cib__set_call_options(options.cib_options, crm_system_name,
+                              cib_quorum_override);
     }
 
     if (options.require_resource && !options.rsc_id) {

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1075,15 +1075,11 @@ populate_working_set(xmlNodePtr *cib_xml_copy)
         return rc;
     }
 
-    set_bit(data_set->flags, pe_flag_no_counts);
-    set_bit(data_set->flags, pe_flag_no_compat);
-
+    pe__set_working_set_flags(data_set, pe_flag_no_counts|pe_flag_no_compat);
     rc = update_working_set_xml(data_set, cib_xml_copy);
-    if (rc != pcmk_rc_ok) {
-        return rc;
+    if (rc == pcmk_rc_ok) {
+        cluster_status(data_set);
     }
-
-    cluster_status(data_set);
     return rc;
 }
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1035,7 +1035,7 @@ list_stacks_and_constraints(pe_resource_t *rsc)
     for (lpc = data_set->resources; lpc != NULL; lpc = lpc->next) {
         pe_resource_t *r = (pe_resource_t *) lpc->data;
 
-        clear_bit(r->flags, pe_rsc_allocating);
+        pe__clear_resource_flags(r, pe_rsc_allocating);
     }
 
     cli_resource_print_colocation(rsc, TRUE, options.rsc_cmd == 'A', 1);
@@ -1046,7 +1046,7 @@ list_stacks_and_constraints(pe_resource_t *rsc)
     for (lpc = data_set->resources; lpc != NULL; lpc = lpc->next) {
         pe_resource_t *r = (pe_resource_t *) lpc->data;
 
-        clear_bit(r->flags, pe_rsc_allocating);
+        pe__clear_resource_flags(r, pe_rsc_allocating);
     }
 
     cli_resource_print_colocation(rsc, FALSE, options.rsc_cmd == 'A', 1);

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -218,7 +218,7 @@ cli_resource_print_colocation(pe_resource_t * rsc, bool dependents, bool recursi
         return;
     }
 
-    set_bit(rsc->flags, pe_rsc_allocating);
+    pe__set_resource_flags(rsc, pe_rsc_allocating);
     for (lpc = list; lpc != NULL; lpc = lpc->next) {
         rsc_colocation_t *cons = (rsc_colocation_t *) lpc->data;
 

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -370,12 +370,12 @@ cli_resource_update_attribute(pe_resource_t *rsc, const char *requested_name,
                 for (lpc = data_set->resources; lpc != NULL; lpc = lpc->next) {
                     pe_resource_t *r = (pe_resource_t *) lpc->data;
 
-                    clear_bit(r->flags, pe_rsc_allocating);
+                    pe__clear_resource_flags(r, pe_rsc_allocating);
                 }
             }
 
             crm_debug("Looking for dependencies %p", rsc->rsc_cons_lhs);
-            set_bit(rsc->flags, pe_rsc_allocating);
+            pe__set_resource_flags(rsc, pe_rsc_allocating);
             for (lpc = rsc->rsc_cons_lhs; lpc != NULL; lpc = lpc->next) {
                 rsc_colocation_t *cons = (rsc_colocation_t *) lpc->data;
                 pe_resource_t *peer = cons->rsc_lh;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1337,8 +1337,7 @@ cli_resource_restart(pe_resource_t *rsc, const char *host, int timeout_ms,
         rc = ENOMEM;
         goto done;
     }
-    set_bit(data_set->flags, pe_flag_no_counts);
-    set_bit(data_set->flags, pe_flag_no_compat);
+    pe__set_working_set_flags(data_set, pe_flag_no_counts|pe_flag_no_compat);
     rc = update_dataset(cib, data_set, FALSE);
     if(rc != pcmk_rc_ok) {
         fprintf(stdout, "Could not get new resource list: %s (%d)\n", pcmk_strerror(rc), rc);
@@ -1643,8 +1642,7 @@ wait_till_stable(int timeout_ms, cib_t * cib)
     if (data_set == NULL) {
         return ENOMEM;
     }
-    set_bit(data_set->flags, pe_flag_no_counts);
-    set_bit(data_set->flags, pe_flag_no_compat);
+    pe__set_working_set_flags(data_set, pe_flag_no_counts|pe_flag_no_compat);
 
     do {
 

--- a/tools/crm_rule.c
+++ b/tools/crm_rule.c
@@ -320,8 +320,7 @@ main(int argc, char **argv)
         exit_code = crm_errno2exit(ENOMEM);
         goto bail;
     }
-    set_bit(data_set->flags, pe_flag_no_counts);
-    set_bit(data_set->flags, pe_flag_no_compat);
+    pe__set_working_set_flags(data_set, pe_flag_no_counts|pe_flag_no_compat);
 
     data_set->input = input;
     data_set->now = rule_date;

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -26,6 +26,7 @@
 #include <crm/common/ipc.h>
 
 #include <crm/cib.h>
+#include <crm/cib/internal.h>
 
 static int command_options = cib_sync_call;
 static cib_t *real_cib = NULL;
@@ -323,7 +324,8 @@ main(int argc, char **argv)
                 pcmk__cli_help(flag, CRM_EX_OK);
                 break;
             case 'f':
-                command_options |= cib_quorum_override;
+                cib__set_call_options(command_options, crm_system_name,
+                                      cib_quorum_override);
                 force_flag = 1;
                 break;
             case 'b':

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -627,7 +627,7 @@ create_dotfile(pe_working_set_t * data_set, const char *dot_file, gboolean all_a
                 );
         }
 
-        set_bit(action->flags, pe_action_dumped);
+        pe__set_action_flags(action, pe_action_dumped);
         crm_trace("\"%s\" [ style=%s color=\"%s\" fontcolor=\"%s\"]",
                 action_name, style, color, font);
         fprintf(dot_strm, "\"%s\" [ style=%s color=\"%s\" fontcolor=\"%s\"]\n",

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -936,7 +936,7 @@ main(int argc, char **argv)
         g_set_error(&error, PCMK__RC_ERROR, rc, "Could not allocate working set");
         goto done;
     }
-    set_bit(data_set->flags, pe_flag_no_compat);
+    pe__set_working_set_flags(data_set, pe_flag_no_compat);
 
     if (options.test_dir != NULL) {
         profile_all(options.test_dir, options.repeat, data_set, options.use_date);
@@ -969,9 +969,9 @@ main(int argc, char **argv)
     data_set->input = input;
     get_date(data_set, true, options.use_date);
     if(options.xml_file) {
-        set_bit(data_set->flags, pe_flag_sanitized);
+        pe__set_working_set_flags(data_set, pe_flag_sanitized);
     }
-    set_bit(data_set->flags, pe_flag_stdout);
+    pe__set_working_set_flags(data_set, pe_flag_stdout);
     cluster_status(data_set);
 
     if (quiet == FALSE) {
@@ -1014,9 +1014,9 @@ main(int argc, char **argv)
         get_date(data_set, true, options.use_date);
 
         if(options.xml_file) {
-            set_bit(data_set->flags, pe_flag_sanitized);
+            pe__set_working_set_flags(data_set, pe_flag_sanitized);
         }
-        set_bit(data_set->flags, pe_flag_stdout);
+        pe__set_working_set_flags(data_set, pe_flag_stdout);
         cluster_status(data_set);
     }
 
@@ -1080,7 +1080,7 @@ main(int argc, char **argv)
             get_date(data_set, true, options.use_date);
 
             quiet_log("\nRevised cluster status:\n");
-            set_bit(data_set->flags, pe_flag_stdout);
+            pe__set_working_set_flags(data_set, pe_flag_stdout);
             cluster_status(data_set);
             print_cluster_status(data_set, 0);
         }

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -849,8 +849,7 @@ main(int argc, char **argv)
         exit_code = CRM_EX_OSERR;
         goto bail;
     }
-    set_bit(data_set->flags, pe_flag_no_counts);
-    set_bit(data_set->flags, pe_flag_no_compat);
+    pe__set_working_set_flags(data_set, pe_flag_no_counts|pe_flag_no_compat);
 
     cib_conn = cib_new();
     if (cib_conn == NULL) {

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -279,8 +279,7 @@ main(int argc, char **argv)
         crm_perror(LOG_CRIT, "Unable to allocate working set");
         goto done;
     }
-    set_bit(data_set->flags, pe_flag_no_counts);
-    set_bit(data_set->flags, pe_flag_no_compat);
+    pe__set_working_set_flags(data_set, pe_flag_no_counts|pe_flag_no_compat);
 
     if (cib_object == NULL) {
     } else if (status != NULL || USE_LIVE_CIB) {

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -234,7 +234,7 @@ static pcmk__supported_format_t formats[] = {
     { NULL, NULL, NULL }
 };
 
-static int st_opts = st_opt_sync_call | st_opt_allow_suicide;
+static const int st_opts = st_opt_sync_call | st_opt_allow_suicide;
 
 static char *name = NULL;
 


### PR DESCRIPTION
This ridiculously large PR addresses a long-time pain point when debugging complex cluster issues, especially in the scheduler. This replaces the set_bit()/clear_bit() wrappers with new object-specific wrappers, allowing us to change trace logs like:

    Bit 0x00000020 set by some_function:100

to:

    Ordering flags 0x00000020 (pe_order_implies_then) for constraint set by some_function:100

The log lines get really long, and some of the information is not always available, but on the whole it makes trace logging a lot more intelligible.