### PR TITLE
cluster: Close corosync handles when they disconnect

### DIFF
--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -63,6 +63,7 @@ static void
 cfg_connection_destroy(gpointer user_data)
 {
     crm_err("Lost connection to Corosync");
+    corosync_cfg_finalize(cfg_handle);
     cfg_handle = 0;
     pcmk_shutdown(SIGTERM);
 }

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -189,6 +189,7 @@ pcmk_quorum_dispatch(gpointer user_data)
     rc = quorum_dispatch(pcmk_quorum_handle, CS_DISPATCH_ALL);
     if (rc < 0) {
         crm_err("Connection to the Quorum API failed: %d", rc);
+        quorum_finalize(pcmk_quorum_handle);
         pcmk_quorum_handle = 0;
         return -1;
     }

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -237,6 +237,7 @@ pcmk_cpg_dispatch(gpointer user_data)
     rc = cpg_dispatch(cluster->cpg_handle, CS_DISPATCH_ONE);
     if (rc != CS_OK) {
         crm_err("Connection to the CPG API failed: %s (%d)", ais_error2text(rc), rc);
+        cpg_finalize(cluster->cpg_handle);
         cluster->cpg_handle = 0;
         return -1;
 


### PR DESCRIPTION
I'll be honest here I'm not sure how much this fixes. It's for
bz#1614166 but I can't reproduce that particular issue as
my nodes get (correctly) fenced every time I try it and even with
fencing disabled I dont get that behaviour.

Still, they can't hurt and libqb needs all the help it can
get tidying up after itself