### PR TITLE
 Refactor: libcrmcommon: Convert pcmk__str_none_of() to macro

### DIFF
--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -221,7 +221,8 @@ int pcmk__parse_ll_range(const char *srcstring, long long *start, long long *end
 gboolean pcmk__str_in_list(GList *lst, const gchar *s);
 
 bool pcmk__str_any_of(const char *s, ...) G_GNUC_NULL_TERMINATED;
-bool pcmk__str_none_of(const char *s, ...) G_GNUC_NULL_TERMINATED;
+
+#define pcmk__str_none_of(s, ...) !pcmk__str_any_of(s, __VA_ARGS__)
 
 /* Correctly displaying singular or plural is complicated; consider "1 node has"
  * vs. "2 nodes have". A flexible solution is to pluralize entire strings, e.g.

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -222,6 +222,19 @@ gboolean pcmk__str_in_list(GList *lst, const gchar *s);
 
 bool pcmk__str_any_of(const char *s, ...) G_GNUC_NULL_TERMINATED;
 
+/*!
+ * \internal
+ * \def pcmk__str_none_of(s, ...)
+ * \brief Check whether a string matches none of a list of strings
+ *
+ * \param[in]     s    String to search for in \p ...
+ * \param[in]     ...  Strings to compare \p s against. Final argument
+ *                     must be \c NULL.
+ *
+ * \return \c true if \p s is not found in \p ..., or \c false otherwise
+ * \note The match is case-insensitive. \p ... must contain at least one
+ *       argument (\c NULL).
+ */
 #define pcmk__str_none_of(s, ...) !pcmk__str_any_of(s, __VA_ARGS__)
 
 /* Correctly displaying singular or plural is complicated; consider "1 node has"

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -671,6 +671,18 @@ pcmk__str_in_list(GList *lst, const gchar *s)
     return g_list_find_custom(lst, s, (GCompareFunc) strcmp) != NULL;
 }
 
+/*!
+ * \internal
+ * \brief Check whether a string matches any of a list of strings
+ *
+ * \param[in]     s    String to search for in \p ...
+ * \param[in]     ...  Strings to compare \p s against. Final argument
+ *                     must be \c NULL.
+ *
+ * \return \c true if \p s is found in \p ..., or \c false otherwise
+ * \note The match is case-insensitive. \p ... must contain at least one
+ *       argument (\c NULL).
+ */
 bool
 pcmk__str_any_of(const char *s, ...)
 {

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -694,28 +694,6 @@ pcmk__str_any_of(const char *s, ...)
     return rc;
 }
 
-bool
-pcmk__str_none_of(const char *s, ...)
-{
-    bool rc = true;
-    va_list ap;
-
-    va_start(ap, s);
-
-    while (1) {
-        const char *ele = va_arg(ap, const char *);
-
-        if (ele == NULL) {
-            break;
-        } else if (crm_str_eq(s, ele, FALSE)) {
-            rc = false;
-            break;
-        }
-    }
-
-    va_end(ap);
-    return rc;
-}
 
 /*
  * \brief Sort strings, with numeric portions sorted numerically


### PR DESCRIPTION
The logic is identical to pcmk__str_any_of() with inverted return codes.
This commit defines pcmk__str_none_of() as !pcmk__str_any_of().