### PR TITLE
Log: libpe_status: downgrade the message about the meaning of `have-watchdog=true` to info

### DIFF
--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -612,10 +612,26 @@ static pcmk__cluster_option_t crmd_opts[] = {
     },
     {
         "stonith-watchdog-timeout", NULL, "time", NULL,
-        NULL, pcmk__valid_sbd_timeout,
+        "0", pcmk__valid_sbd_timeout,
         "How long to wait before we can assume nodes are safely down "
-            "when sbd is in use",
-        NULL
+            "when watchdog-based self-fencing via SBD is in use",
+        "If nonzero, along with `have-watchdog=true` automatically set by the "
+            "cluster, when fencing is required, watchdog-based self-fencing "
+            "will be performed via SBD without requiring a fencing resource "
+            "explicitly configured. "
+            "If `stonith-watchdog-timeout` is set to a positive value, unseen "
+            "nodes are assumed to self-fence within this much time. +WARNING:+ "
+            "It must be ensured that this value is larger than the "
+            "`SBD_WATCHDOG_TIMEOUT` environment variable on all nodes. "
+            "Pacemaker verifies the settings individually on all nodes and "
+            "prevents startup or shuts down if configured wrongly on the fly. "
+            "It's strongly recommended that `SBD_WATCHDOG_TIMEOUT` is set to "
+            "the same value on all nodes. "
+            "If `stonith-watchdog-timeout` is set to a negative value, and "
+            "`SBD_WATCHDOG_TIMEOUT` is set, twice that value will be used. "
+            "+WARNING:+ In this case, it's essential (currently not verified by "
+            "pacemaker) that `SBD_WATCHDOG_TIMEOUT` is set to the same value on "
+            "all nodes."
     },
     {
         "stonith-max-attempts", NULL, "integer", NULL,

--- a/doc/Pacemaker_Explained/en-US/Ch-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Options.txt
@@ -274,9 +274,23 @@ immediately re-attempt it.
 | stonith-watchdog-timeout | 0 |
 indexterm:[stonith-watchdog-timeout,Cluster Option]
 indexterm:[Cluster,Option,stonith-watchdog-timeout]
-If nonzero, rely on hardware watchdog self-fencing. If positive, assume unseen
-nodes self-fence within this much time. If negative, and the
-SBD_WATCHDOG_TIMEOUT environment variable is set, use twice that value.
+If nonzero, along with `have-watchdog=true` automatically set by the
+cluster, when fencing is required, watchdog-based self-fencing
+will be performed via SBD without requiring a fencing resource
+explicitly configured.
+If `stonith-watchdog-timeout` is set to a positive value, unseen
+nodes are assumed to self-fence within this much time. +WARNING:+
+It must be ensured that this value is larger than the
+`SBD_WATCHDOG_TIMEOUT` environment variable on all nodes.
+Pacemaker verifies the settings individually on all nodes and
+prevents startup or shuts down if configured wrongly on the fly.
+It's strongly recommended that `SBD_WATCHDOG_TIMEOUT` is set to
+the same value on all nodes.
+If `stonith-watchdog-timeout` is set to a negative value, and
+`SBD_WATCHDOG_TIMEOUT` is set, twice that value will be used.
++WARNING:+ In this case, it's essential (currently not verified by
+pacemaker) that `SBD_WATCHDOG_TIMEOUT` is set to the same value on
+all nodes.
 
 | concurrent-fencing | FALSE |
 indexterm:[concurrent-fencing,Cluster Option]

--- a/doc/sphinx/Pacemaker_Explained/options.rst
+++ b/doc/sphinx/Pacemaker_Explained/options.rst
@@ -276,10 +276,24 @@ Cluster-Wide Configuration
    | stonith-watchdog-timeout | 0 |
    indexterm:[stonith-watchdog-timeout,Cluster Option]
    indexterm:[Cluster,Option,stonith-watchdog-timeout]
-   If nonzero, rely on hardware watchdog self-fencing. If positive, assume unseen
-   nodes self-fence within this much time. If negative, and the
-   SBD_WATCHDOG_TIMEOUT environment variable is set, use twice that value.
-   
+   If nonzero, along with `have-watchdog=true` automatically set by the
+   cluster, when fencing is required, watchdog-based self-fencing
+   will be performed via SBD without requiring a fencing resource
+   explicitly configured.
+   If `stonith-watchdog-timeout` is set to a positive value, unseen
+   nodes are assumed to self-fence within this much time. +WARNING:+
+   It must be ensured that this value is larger than the
+   `SBD_WATCHDOG_TIMEOUT` environment variable on all nodes.
+   Pacemaker verifies the settings individually on all nodes and
+   prevents startup or shuts down if configured wrongly on the fly.
+   It's strongly recommended that `SBD_WATCHDOG_TIMEOUT` is set to
+   the same value on all nodes.
+   If `stonith-watchdog-timeout` is set to a negative value, and
+   `SBD_WATCHDOG_TIMEOUT` is set, twice that value will be used.
+   +WARNING:+ In this case, it's essential (currently not verified by
+   pacemaker) that `SBD_WATCHDOG_TIMEOUT` is set to the same value on
+   all nodes.
+
    | concurrent-fencing | FALSE |
    indexterm:[concurrent-fencing,Cluster Option]
    indexterm:[Cluster,Option,concurrent-fencing]

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -131,7 +131,11 @@ static pcmk__cluster_option_t pe_opts[] = {
         "false", pcmk__valid_boolean,
         "Whether watchdog integration is enabled",
         "This is set automatically by the cluster according to whether SBD "
-            "is detected to be in use. User-configured values are ignored."
+            "is detected to be in use. User-configured values are ignored. "
+            "The value `true` is meaningful if diskless SBD is used and "
+            "`stonith-watchdog-timeout` is nonzero. In that case, if fencing "
+            "is required, watchdog-based self-fencing will be performed via "
+            "SBD without requiring a fencing resource explicitly configured."
     },
     {
         "concurrent-fencing", NULL, "boolean", NULL,

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -211,8 +211,8 @@ unpack_config(xmlNode * config, pe_working_set_t * data_set)
 
     value = pe_pref(data_set->config_hash, XML_ATTR_HAVE_WATCHDOG);
     if (value && crm_is_true(value)) {
-        crm_notice("Watchdog will be used via SBD if fencing is required "
-                   "and stonith-watchdog-timeout is nonzero");
+        crm_info("Watchdog-based self-fencing will be performed via SBD if "
+                 "fencing is required and stonith-watchdog-timeout is nonzero");
         pe__set_working_set_flags(data_set, pe_flag_have_stonith_resource);
     }
 


### PR DESCRIPTION
The message actually only indicates there's the setting
`have-watchdog=true` and describes the meaning of it. It's rather
confusing to constantly appear if normal SBD with disk is used.

On the other hand, we should improve the documentation about the cluster
options related to watchdog.