### PR TITLE
Mid: crm_mon: Displays completed failed actions as processed.

### DIFF
--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -843,7 +843,7 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
                                                               GINT_TO_POINTER(st_failed));
 
         if (hp) {
-            CHECK_RC(rc, out->message(out, "failed-fencing-history", hp, unames,
+            CHECK_RC(rc, out->message(out, "failed-fencing-history", stonith_history, unames,
                                       is_set(mon_ops, mon_op_fence_full_history),
                                       rc == pcmk_rc_ok));
         }
@@ -1043,7 +1043,7 @@ print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
                                                               GINT_TO_POINTER(st_failed));
 
         if (hp) {
-            out->message(out, "failed-fencing-history", hp, unames,
+            out->message(out, "failed-fencing-history", stonith_history, unames,
                          is_set(mon_ops, mon_op_fence_full_history), FALSE);
         }
     }


### PR DESCRIPTION
Hi All,

The following modified PR features are no longer working.
 - https://github.com/ClusterLabs/pacemaker/pull/1877

The problem is that the beginning of the history passed to "failed-fencing-history" is from the history of failure.
Need to pass the entire history for proper processing.
Otherwise, crm_mon will not be able to mark failed history as successful success history.

Best Regards,
Hideo Yamauchi.