### PR TITLE
Fix: scheduler: don't schedule a dangling migration stop if one already occurred

### DIFF
--- a/cts/scheduler/migrate-fail-9.dot
+++ b/cts/scheduler/migrate-fail-9.dot
@@ -3,6 +3,4 @@
 "load_stopped_hex-13 hex-13" [ style=bold color="green" fontcolor="orange"]
 "load_stopped_hex-14 hex-14" [ style=bold color="green" fontcolor="orange"]
 "test-vm_start_0 hex-13" [ style=bold color="green" fontcolor="black"]
-"test-vm_stop_0 hex-14" -> "test-vm_start_0 hex-13" [ style = bold]
-"test-vm_stop_0 hex-14" [ style=bold color="green" fontcolor="black"]
 }

--- a/cts/scheduler/migrate-fail-9.exp
+++ b/cts/scheduler/migrate-fail-9.exp
@@ -1,7 +1,7 @@
 <transition_graph cluster-delay="60s" stonith-timeout="60s" failed-stop-offset="INFINITY" failed-start-offset="INFINITY"  transition_id="0">
   <synapse id="0">
     <action_set>
-      <rsc_op id="12" operation="start" operation_key="test-vm_start_0" on_node="hex-13" on_node_uuid="hex-13">
+      <rsc_op id="11" operation="start" operation_key="test-vm_start_0" on_node="hex-13" on_node_uuid="hex-13">
         <primitive id="test-vm" class="ocf" provider="heartbeat" type="Xen"/>
         <attributes CRM_meta_on_node="hex-13" CRM_meta_on_node_uuid="hex-13" CRM_meta_record_pending="true" CRM_meta_timeout="600000"  name="test-vm" xmfile="/var/lib/xen/images/SLES_11_SP1_JeOS_Xen_Guest.x86_64-0.0.1.xenconfig"/>
       </rsc_op>
@@ -10,21 +10,9 @@
       <trigger>
         <pseudo_event id="1" operation="load_stopped_hex-13" operation_key="load_stopped_hex-13"/>
       </trigger>
-      <trigger>
-        <rsc_op id="11" operation="stop" operation_key="test-vm_stop_0" on_node="hex-14" on_node_uuid="hex-14"/>
-      </trigger>
     </inputs>
   </synapse>
   <synapse id="1">
-    <action_set>
-      <rsc_op id="11" operation="stop" operation_key="test-vm_stop_0" on_node="hex-14" on_node_uuid="hex-14">
-        <primitive id="test-vm" class="ocf" provider="heartbeat" type="Xen"/>
-        <attributes CRM_meta_on_node="hex-14" CRM_meta_on_node_uuid="hex-14" CRM_meta_record_pending="true" CRM_meta_timeout="600000"  name="test-vm" xmfile="/var/lib/xen/images/SLES_11_SP1_JeOS_Xen_Guest.x86_64-0.0.1.xenconfig"/>
-      </rsc_op>
-    </action_set>
-    <inputs/>
-  </synapse>
-  <synapse id="2">
     <action_set>
       <pseudo_event id="2" operation="load_stopped_hex-14" operation_key="load_stopped_hex-14">
         <attributes />
@@ -32,7 +20,7 @@
     </action_set>
     <inputs/>
   </synapse>
-  <synapse id="3">
+  <synapse id="2">
     <action_set>
       <pseudo_event id="1" operation="load_stopped_hex-13" operation_key="load_stopped_hex-13">
         <attributes />

--- a/cts/scheduler/migrate-fail-9.summary
+++ b/cts/scheduler/migrate-fail-9.summary
@@ -7,10 +7,9 @@ Online: [ hex-13 hex-14 ]
      Started: [ hex-13 hex-14 ]
 
 Transition Summary:
- * Restart    test-vm     ( hex-13 )  
+ * Start      test-vm     ( hex-13 )  
 
 Executing cluster transition:
- * Resource action: test-vm         stop on hex-14
  * Pseudo action:   load_stopped_hex-14
  * Pseudo action:   load_stopped_hex-13
  * Resource action: test-vm         start on hex-13

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2627,6 +2627,17 @@ unpack_migrate_to_success(pe_resource_t *rsc, pe_node_t *node, xmlNode *xml_op,
     }
 }
 
+// Is there an action_name in node_name's rsc history newer than call_id?
+static bool
+newer_op(pe_resource_t *rsc, const char *action_name, const char *node_name,
+         int call_id, pe_working_set_t *data_set)
+{
+    xmlNode *action = find_lrm_op(rsc->id, action_name, node_name, NULL, TRUE,
+                                  data_set);
+
+    return pe__call_id(action) > call_id;
+}
+
 static void
 unpack_migrate_to_failure(pe_resource_t *rsc, pe_node_t *node, xmlNode *xml_op,
                           pe_working_set_t *data_set)
@@ -2657,7 +2668,7 @@ unpack_migrate_to_failure(pe_resource_t *rsc, pe_node_t *node, xmlNode *xml_op,
     target_migrate_from_id = pe__call_id(target_migrate_from);
 
     if ((target_stop == NULL) || (target_stop_id < target_migrate_from_id)) {
-        /* There was no stop on the source, or a stop that happened before a
+        /* There was no stop on the target, or a stop that happened before a
          * migrate_from, so assume the resource is still active on the target
          * (if it is up).
          */
@@ -2675,24 +2686,19 @@ unpack_migrate_to_failure(pe_resource_t *rsc, pe_node_t *node, xmlNode *xml_op,
          * scheduled or attempted).
          *
          * That means this could be a "dangling" migration. But first, check
-         * whether there is a newer migrate_from or start on the source node --
-         * it's possible the failed migration was followed by a successful
-         * full restart or migration in the reverse direction, in which case we
-         * don't want to force it to stop.
+         * whether there is a newer successful stop, start, or migrate_from on
+         * the source node -- it's possible the failed migration was followed by
+         * a successful stop, full restart, or migration in the reverse
+         * direction, in which case we don't want to force a stop.
          */
-        xmlNode *source_migrate_from = NULL;
-        xmlNode *source_start = NULL;
         int source_migrate_to_id = pe__call_id(xml_op);
 
-        source_migrate_from = find_lrm_op(rsc->id, CRMD_ACTION_MIGRATED, source,
-                                          NULL, TRUE, data_set);
-        if (pe__call_id(source_migrate_from) > source_migrate_to_id) {
-            return;
-        }
-
-        source_start = find_lrm_op(rsc->id, CRMD_ACTION_START, source, NULL,
-                                   TRUE, data_set);
-        if (pe__call_id(source_start) > source_migrate_to_id) {
+        if (newer_op(rsc, CRMD_ACTION_MIGRATED, source, source_migrate_to_id,
+                     data_set)
+            || newer_op(rsc, CRMD_ACTION_START, source, source_migrate_to_id,
+                     data_set)
+            || newer_op(rsc, CRMD_ACTION_STOP, source, source_migrate_to_id,
+                     data_set)) {
             return;
         }
 


### PR DESCRIPTION
See the 2020-08-18 thread to the users@clusterlabs.org list "why is node fenced ?". If a node had a dangling migration, later had a successful stop to recover, and is now shutting down, the scheduler would schedule another stop, which would be unrunnable due to the shutdown, causing unnecessary fencing.

It looks like a similar (known) problem exists with the migrate-fail-4 and migrate-fail-8 regression tests, but the fix would be different.