### PR TITLE
Function renames for current style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,7 @@ pacemaker-[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]
 *.trs
 /lib/common/tests/flags/pcmk__clear_flags_as
 /lib/common/tests/flags/pcmk__set_flags_as
+/lib/common/tests/strings/pcmk__btoa
 /lib/common/tests/strings/pcmk__parse_ll_range
 /lib/common/tests/strings/pcmk__scan_double
 /lib/common/tests/strings/pcmk__str_any_of

--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,8 @@ pacemaker-[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]
 *.trs
 /lib/common/tests/flags/pcmk__clear_flags_as
 /lib/common/tests/flags/pcmk__set_flags_as
+/lib/common/tests/flags/pcmk_all_flags_set
+/lib/common/tests/flags/pcmk_any_flags_set
 /lib/common/tests/strings/pcmk__btoa
 /lib/common/tests/strings/pcmk__parse_ll_range
 /lib/common/tests/strings/pcmk__scan_double

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -955,7 +955,7 @@ attrd_peer_change_cb(enum crm_status_type kind, crm_node_t *peer, const void *da
             break;
 
         case crm_status_processes:
-            if (is_not_set(peer->processes, crm_get_cluster_proc())) {
+            if (!pcmk_is_set(peer->processes, crm_get_cluster_proc())) {
                 remove_voter = TRUE;
             }
             break;
@@ -966,7 +966,7 @@ attrd_peer_change_cb(enum crm_status_type kind, crm_node_t *peer, const void *da
                  * (unless it's a remote node, which doesn't run its own attrd)
                  */
                 if (attrd_election_won()
-                    && !is_set(peer->flags, crm_remote_node)) {
+                    && !pcmk_is_set(peer->flags, crm_remote_node)) {
                     attrd_peer_sync(peer, NULL);
                 }
             } else {

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -61,24 +61,24 @@ cib_notify_send_one(gpointer key, gpointer value, gpointer user_data)
     type = crm_element_value(update->msg, F_SUBTYPE);
     CRM_LOG_ASSERT(type != NULL);
 
-    if (is_set(client->flags, cib_notify_diff)
+    if (pcmk_is_set(client->flags, cib_notify_diff)
         && pcmk__str_eq(type, T_CIB_DIFF_NOTIFY, pcmk__str_casei)) {
 
         do_send = TRUE;
 
-    } else if (is_set(client->flags, cib_notify_replace)
+    } else if (pcmk_is_set(client->flags, cib_notify_replace)
                && pcmk__str_eq(type, T_CIB_REPLACE_NOTIFY, pcmk__str_casei)) {
         do_send = TRUE;
 
-    } else if (is_set(client->flags, cib_notify_confirm)
+    } else if (pcmk_is_set(client->flags, cib_notify_confirm)
                && pcmk__str_eq(type, T_CIB_UPDATE_CONFIRM, pcmk__str_casei)) {
         do_send = TRUE;
 
-    } else if (is_set(client->flags, cib_notify_pre)
+    } else if (pcmk_is_set(client->flags, cib_notify_pre)
                && pcmk__str_eq(type, T_CIB_PRE_NOTIFY, pcmk__str_casei)) {
         do_send = TRUE;
 
-    } else if (is_set(client->flags, cib_notify_post)
+    } else if (pcmk_is_set(client->flags, cib_notify_post)
                && pcmk__str_eq(type, T_CIB_POST_NOTIFY, pcmk__str_casei)) {
 
         do_send = TRUE;

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -280,7 +280,7 @@ cib_peer_update_callback(enum crm_status_type type, crm_node_t * node, const voi
     switch (type) {
         case crm_status_processes:
             if (cib_legacy_mode()
-                && is_not_set(node->processes, crm_get_cluster_proc())) {
+                && !pcmk_is_set(node->processes, crm_get_cluster_proc())) {
 
                 uint32_t old = data? *(const uint32_t *)data : 0;
 

--- a/daemons/controld/controld_attrd.c
+++ b/daemons/controld/controld_attrd.c
@@ -33,7 +33,7 @@ log_attrd_error(const char *host, const char *name, const char *value,
                 gboolean is_remote, char command, int rc)
 {
     const char *node_type = (is_remote? "Pacemaker Remote" : "cluster");
-    gboolean shutting_down = is_set(fsa_input_register, R_SHUTDOWN);
+    gboolean shutting_down = pcmk_is_set(fsa_input_register, R_SHUTDOWN);
     const char *when = (shutting_down? " at shutdown" : "");
 
     switch (command) {

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -31,7 +31,7 @@ do_cib_updated(const char *event, xmlNode * msg)
 static void
 do_cib_replaced(const char *event, xmlNode * msg)
 {
-    crm_debug("Updating the CIB after a replace: DC=%s", AM_I_DC ? "true" : "false");
+    crm_debug("Updating the CIB after a replace: DC=%s", pcmk__btoa(AM_I_DC));
     if (AM_I_DC == FALSE) {
         return;
 

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -35,7 +35,8 @@ do_cib_replaced(const char *event, xmlNode * msg)
     if (AM_I_DC == FALSE) {
         return;
 
-    } else if (fsa_state == S_FINALIZE_JOIN && is_set(fsa_input_register, R_CIB_ASKED)) {
+    } else if ((fsa_state == S_FINALIZE_JOIN)
+               && pcmk_is_set(fsa_input_register, R_CIB_ASKED)) {
         /* no need to restart the join - we asked for this replace op */
         return;
     }
@@ -113,7 +114,7 @@ do_cib_control(long long action,
             cib_retries = 0;
         }
 
-        if (is_not_set(fsa_input_register, R_CIB_CONNECTED)) {
+        if (!pcmk_is_set(fsa_input_register, R_CIB_CONNECTED)) {
 
             cib_retries++;
             crm_warn("Couldn't complete CIB registration %d"
@@ -312,8 +313,8 @@ controld_delete_resource_history(const char *rsc_id, const char *node,
         return rc;
     }
 
-    if (is_set(call_options, cib_sync_call)) {
-        if (is_set(call_options, cib_dryrun)) {
+    if (pcmk_is_set(call_options, cib_sync_call)) {
+        if (pcmk_is_set(call_options, cib_dryrun)) {
             crm_debug("Deletion of %s would succeed", desc);
         } else {
             crm_debug("Deletion of %s succeeded", desc);

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -134,13 +134,13 @@ extern GHashTable *voted;
 void
 crmd_fast_exit(crm_exit_t exit_code)
 {
-    if (is_set(fsa_input_register, R_STAYDOWN)) {
+    if (pcmk_is_set(fsa_input_register, R_STAYDOWN)) {
         crm_warn("Inhibiting respawn "CRM_XS" remapping exit code %d to %d",
                  exit_code, CRM_EX_FATAL);
         exit_code = CRM_EX_FATAL;
 
     } else if ((exit_code == CRM_EX_OK)
-               && is_set(fsa_input_register, R_IN_RECOVERY)) {
+               && pcmk_is_set(fsa_input_register, R_IN_RECOVERY)) {
         crm_err("Could not recover from internal error");
         exit_code = CRM_EX_ERROR;
     }
@@ -448,31 +448,31 @@ do_started(long long action,
         crm_err("Start cancelled... %s", fsa_state2string(cur_state));
         return;
 
-    } else if (is_set(fsa_input_register, R_MEMBERSHIP) == FALSE) {
+    } else if (!pcmk_is_set(fsa_input_register, R_MEMBERSHIP)) {
         crm_info("Delaying start, no membership data (%.16llx)", R_MEMBERSHIP);
 
         crmd_fsa_stall(TRUE);
         return;
 
-    } else if (is_set(fsa_input_register, R_LRM_CONNECTED) == FALSE) {
+    } else if (!pcmk_is_set(fsa_input_register, R_LRM_CONNECTED)) {
         crm_info("Delaying start, not connected to executor (%.16llx)", R_LRM_CONNECTED);
 
         crmd_fsa_stall(TRUE);
         return;
 
-    } else if (is_set(fsa_input_register, R_CIB_CONNECTED) == FALSE) {
+    } else if (!pcmk_is_set(fsa_input_register, R_CIB_CONNECTED)) {
         crm_info("Delaying start, CIB not connected (%.16llx)", R_CIB_CONNECTED);
 
         crmd_fsa_stall(TRUE);
         return;
 
-    } else if (is_set(fsa_input_register, R_READ_CONFIG) == FALSE) {
+    } else if (!pcmk_is_set(fsa_input_register, R_READ_CONFIG)) {
         crm_info("Delaying start, Config not read (%.16llx)", R_READ_CONFIG);
 
         crmd_fsa_stall(TRUE);
         return;
 
-    } else if (is_set(fsa_input_register, R_PEER_DATA) == FALSE) {
+    } else if (!pcmk_is_set(fsa_input_register, R_PEER_DATA)) {
 
         crm_info("Delaying start, No peer data (%.16llx)", R_PEER_DATA);
         crmd_fsa_stall(TRUE);
@@ -797,7 +797,7 @@ crm_shutdown(int nsig)
         return;
     }
 
-    if (is_set(fsa_input_register, R_SHUTDOWN)) {
+    if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
         crm_err("Escalating shutdown");
         register_fsa_input_before(C_SHUTDOWN, I_ERROR, NULL);
         return;

--- a/daemons/controld/controld_corosync.c
+++ b/daemons/controld/controld_corosync.c
@@ -50,7 +50,7 @@ crmd_cs_dispatch(cpg_handle_t handle, const struct cpg_name *groupName,
         /* crm_xml_add_int(xml, F_SEQ, wrapper->id); Fake? */
 
         peer = crm_get_peer(0, from);
-        if (is_not_set(peer->processes, crm_proc_cpg)) {
+        if (!pcmk_is_set(peer->processes, crm_proc_cpg)) {
             /* If we can still talk to our peer process on that node,
              * then it must be part of the corosync membership
              */
@@ -78,7 +78,7 @@ crmd_quorum_callback(unsigned long long seq, gboolean quorate)
 static void
 crmd_cs_destroy(gpointer user_data)
 {
-    if (is_not_set(fsa_input_register, R_HA_DISCONNECTED)) {
+    if (!pcmk_is_set(fsa_input_register, R_HA_DISCONNECTED)) {
         crm_crit("Lost connection to cluster layer, shutting down");
         crmd_exit(CRM_EX_DISCONNECT);
 

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -95,7 +95,7 @@ do_election_vote(long long action,
     }
 
     if (not_voting == FALSE) {
-        if (is_set(fsa_input_register, R_STARTING)) {
+        if (pcmk_is_set(fsa_input_register, R_STARTING)) {
             not_voting = TRUE;
         }
     }
@@ -138,7 +138,7 @@ do_election_count_vote(long long action,
     ha_msg_input_t *vote = fsa_typed_data(fsa_dt_ha_msg);
 
     if(crm_peer_cache == NULL) {
-        if(is_not_set(fsa_input_register, R_SHUTDOWN)) {
+        if (!pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
             crm_err("Internal error, no peer cache");
         }
         return;
@@ -253,7 +253,7 @@ do_dc_release(long long action,
             result = I_SHUTDOWN;
         }
 #endif
-        if (is_set(fsa_input_register, R_SHUTDOWN)) {
+        if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
             xmlNode *update = NULL;
             crm_node_t *node = crm_get_peer(0, fsa_our_uname);
 

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -206,8 +206,9 @@ do_dc_takeover(long long action,
     fsa_cib_update(XML_TAG_CIB, cib, cib_quorum_override, rc, NULL);
     fsa_register_cib_callback(rc, FALSE, NULL, feature_update_callback);
 
-    update_attr_delegate(fsa_cib_conn, cib_none, XML_CIB_TAG_CRMCONFIG, NULL, NULL, NULL, NULL,
-                         XML_ATTR_HAVE_WATCHDOG, watchdog?"true":"false", FALSE, NULL, NULL);
+    update_attr_delegate(fsa_cib_conn, cib_none, XML_CIB_TAG_CRMCONFIG, NULL,
+                         NULL, NULL, NULL, XML_ATTR_HAVE_WATCHDOG,
+                         pcmk__btoa(watchdog), FALSE, NULL, NULL);
 
     update_attr_delegate(fsa_cib_conn, cib_none, XML_CIB_TAG_CRMCONFIG, NULL, NULL, NULL, NULL,
                          "dc-version", PACEMAKER_VERSION "-" BUILD_VERSION, FALSE, NULL, NULL);

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -50,7 +50,7 @@ static int do_update_resource(const char *node_name, lrmd_rsc_info_t *rsc,
 static void
 lrm_connection_destroy(void)
 {
-    if (is_set(fsa_input_register, R_LRM_CONNECTED)) {
+    if (pcmk_is_set(fsa_input_register, R_LRM_CONNECTED)) {
         crm_crit("Connection to executor failed");
         register_fsa_input(C_FSA_INTERNAL, I_ERROR, NULL);
         controld_clear_fsa_input_flags(R_LRM_CONNECTED);
@@ -403,7 +403,7 @@ lrm_state_verify_stopped(lrm_state_t * lrm_state, enum crmd_fsa_state cur_state,
         log_level = LOG_ERR;
         when = "shutdown";
 
-    } else if (is_set(fsa_input_register, R_SHUTDOWN)) {
+    } else if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
         when = "shutdown... waiting";
     }
 
@@ -432,7 +432,8 @@ lrm_state_verify_stopped(lrm_state_t * lrm_state, enum crmd_fsa_state cur_state,
         do_crm_log(log_level, "%d pending executor operation%s at %s",
                    counter, pcmk__plural_s(counter), when);
 
-        if (cur_state == S_TERMINATE || !is_set(fsa_input_register, R_SENT_RSC_STOP)) {
+        if ((cur_state == S_TERMINATE)
+            || !pcmk_is_set(fsa_input_register, R_SENT_RSC_STOP)) {
             g_hash_table_iter_init(&gIter, lrm_state->pending_ops);
             while (g_hash_table_iter_next(&gIter, (gpointer*)&key, (gpointer*)&pending)) {
                 do_crm_log(log_level, "Pending action: %s (%s)", key, pending->op_key);
@@ -448,7 +449,7 @@ lrm_state_verify_stopped(lrm_state_t * lrm_state, enum crmd_fsa_state cur_state,
         return rc;
     }
 
-    if (is_set(fsa_input_register, R_SHUTDOWN)) {
+    if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
         /* At this point we're not waiting, we're just shutting down */
         when = "shutdown";
     }
@@ -509,7 +510,7 @@ build_parameter_list(const lrmd_event_data_t *op,
         "user",
     };
 
-    if (is_not_set(metadata->ra_flags, ra_uses_private)
+    if (!pcmk_is_set(metadata->ra_flags, ra_uses_private)
         && (param_type == ra_param_private)) {
 
         max = DIMOF(secure_terms);
@@ -519,7 +520,7 @@ build_parameter_list(const lrmd_event_data_t *op,
         struct ra_param_s *param = (struct ra_param_s *) iter->data;
         bool accept = FALSE;
 
-        if (is_set(param->rap_flags, param_type)) {
+        if (pcmk_is_set(param->rap_flags, param_type)) {
             accept = TRUE;
 
         } else if (max) {
@@ -574,7 +575,7 @@ append_restart_list(lrmd_event_data_t *op, struct ra_metadata_s *metadata,
         return;
     }
 
-    if (is_set(metadata->ra_flags, ra_supports_reload)) {
+    if (pcmk_is_set(metadata->ra_flags, ra_supports_reload)) {
         restart = create_xml_node(NULL, XML_TAG_PARAMS);
         /* Add any parameters with unique="1" to the "op-force-restart" list.
          *
@@ -1144,12 +1145,12 @@ cancel_op(lrm_state_t * lrm_state, const char *rsc_id, const char *key, int op, 
     pending = g_hash_table_lookup(lrm_state->pending_ops, key);
 
     if (pending) {
-        if (remove && is_not_set(pending->flags, active_op_remove)) {
+        if (remove && !pcmk_is_set(pending->flags, active_op_remove)) {
             controld_set_active_op_flags(pending, active_op_remove);
             crm_debug("Scheduling %s for removal", key);
         }
 
-        if (is_set(pending->flags, active_op_cancelled)) {
+        if (pcmk_is_set(pending->flags, active_op_cancelled)) {
             crm_debug("Operation %s already cancelled", key);
             free(local_key);
             return FALSE;
@@ -1983,7 +1984,7 @@ construct_op(lrm_state_t *lrm_state, xmlNode *rsc_op, const char *rsc_id,
     primitive = find_xml_node(rsc_op, XML_CIB_TAG_RESOURCE, FALSE);
     class = crm_element_value(primitive, XML_AGENT_ATTR_CLASS);
 
-    if (is_set(pcmk_get_ra_caps(class), pcmk_ra_cap_fence_params)
+    if (pcmk_is_set(pcmk_get_ra_caps(class), pcmk_ra_cap_fence_params)
             && pcmk__str_eq(operation, CRMD_ACTION_STATUS, pcmk__str_casei)
             && (op->interval_ms > 0)) {
 
@@ -2273,7 +2274,9 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc,
                crm_action_str(op->op_type, op->interval_ms), rsc->id, lrm_state->node_name,
                transition, rsc->id, operation, op->interval_ms);
 
-    if (is_set(fsa_input_register, R_SHUTDOWN) && pcmk__str_eq(operation, RSC_START, pcmk__str_casei)) {
+    if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)
+        && pcmk__str_eq(operation, RSC_START, pcmk__str_casei)) {
+
         register_fsa_input(C_SHUTDOWN, I_SHUTDOWN, NULL);
         send_nack = TRUE;
 
@@ -2287,7 +2290,7 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc,
     if(send_nack) {
         crm_notice("Discarding attempt to perform action %s on %s in state %s (shutdown=%s)",
                    operation, rsc->id, fsa_state2string(fsa_state),
-                   pcmk__btoa(is_set(fsa_input_register, R_SHUTDOWN)));
+                   pcmk__btoa(pcmk_is_set(fsa_input_register, R_SHUTDOWN)));
 
         op->rc = PCMK_OCF_UNKNOWN_ERROR;
         op->op_status = PCMK_LRM_OP_INVALID;
@@ -2726,7 +2729,7 @@ process_lrm_event(lrm_state_t *lrm_state, lrmd_event_data_t *op,
         crm_err("Recurring operation %s was cancelled without transition information",
                 op_key);
 
-    } else if (is_set(pending->flags, active_op_remove)) {
+    } else if (pcmk_is_set(pending->flags, active_op_remove)) {
         /* This recurring operation was cancelled (by us) and pending, and we
          * have been waiting for it to finish.
          */

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -2287,7 +2287,7 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc,
     if(send_nack) {
         crm_notice("Discarding attempt to perform action %s on %s in state %s (shutdown=%s)",
                    operation, rsc->id, fsa_state2string(fsa_state),
-                   is_set(fsa_input_register, R_SHUTDOWN)?"true":"false");
+                   pcmk__btoa(is_set(fsa_input_register, R_SHUTDOWN)));
 
         op->rc = PCMK_OCF_UNKNOWN_ERROR;
         op->op_status = PCMK_LRM_OP_INVALID;
@@ -2798,7 +2798,7 @@ process_lrm_event(lrm_state_t *lrm_state, lrmd_event_data_t *op,
                      crm_action_str(op->op_type, op->interval_ms),
                      op->rsc_id, node_name,
                      services_lrm_status_str(op->op_status),
-                     op->call_id, op_key, (removed? "true" : "false"));
+                     op->call_id, op_key, pcmk__btoa(removed));
             break;
 
         case PCMK_LRM_OP_DONE:
@@ -2807,8 +2807,7 @@ process_lrm_event(lrm_state_t *lrm_state, lrmd_event_data_t *op,
                        crm_action_str(op->op_type, op->interval_ms),
                        op->rsc_id, node_name,
                        services_ocf_exitcode_str(op->rc), op->rc,
-                       op->call_id, op_key, (removed? "true" : "false"),
-                       update_id);
+                       op->call_id, op_key, pcmk__btoa(removed), update_id);
             break;
 
         case PCMK_LRM_OP_TIMEOUT:
@@ -2826,7 +2825,7 @@ process_lrm_event(lrm_state_t *lrm_state, lrmd_event_data_t *op,
                     crm_action_str(op->op_type, op->interval_ms),
                     op->rsc_id, node_name,
                     services_lrm_status_str(op->op_status), op->call_id, op_key,
-                    (removed? "true" : "false"), op->op_status, update_id);
+                    pcmk__btoa(removed), op->op_status, update_id);
     }
 
     if (op->output) {

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -338,7 +338,7 @@ lrm_state_disconnect_only(lrm_state_t * lrm_state)
 
     ((lrmd_t *) lrm_state->conn)->cmds->disconnect(lrm_state->conn);
 
-    if (is_not_set(fsa_input_register, R_SHUTDOWN)) {
+    if (!pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
         removed = g_hash_table_foreach_remove(lrm_state->pending_ops, fail_pending_op, lrm_state);
         crm_trace("Synthesized %d operation failures for %s", removed, lrm_state->node_name);
     }

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -410,7 +410,7 @@ tengine_stonith_connection_destroy(stonith_t *st, stonith_event_t *e)
 {
     te_cleanup_stonith_history_sync(st, FALSE);
 
-    if (is_set(fsa_input_register, R_ST_REQUIRED)) {
+    if (pcmk_is_set(fsa_input_register, R_ST_REQUIRED)) {
         crm_crit("Fencing daemon connection failed");
         mainloop_set_trigger(stonith_reconnect);
 
@@ -548,7 +548,7 @@ tengine_stonith_notify(stonith_t *st, stonith_event_t *st_event)
 
             /* Assume it was our leader if we don't currently have one */
         } else if (pcmk__str_eq(fsa_our_dc, st_event->target, pcmk__str_null_matches | pcmk__str_casei)
-                   && is_not_set(peer->flags, crm_remote_node)) {
+                   && !pcmk_is_set(peer->flags, crm_remote_node)) {
 
             crm_notice("Fencing target %s %s our leader",
                        st_event->target, (fsa_our_dc? "was" : "may have been"));
@@ -568,7 +568,7 @@ tengine_stonith_notify(stonith_t *st, stonith_event_t *st_event)
          * The connection won't necessarily drop when a remote node is fenced,
          * so the failure might not otherwise be detected until the next poke.
          */
-        if (is_set(peer->flags, crm_remote_node)) {
+        if (pcmk_is_set(peer->flags, crm_remote_node)) {
             remote_ra_fail(st_event->target);
         }
 
@@ -614,7 +614,7 @@ te_connect_stonith(gpointer user_data)
         // Non-blocking (retry failures later in main loop)
         rc = stonith_api->cmds->connect(stonith_api, crm_system_name, NULL);
         if (rc != pcmk_ok) {
-            if (is_set(fsa_input_register, R_ST_REQUIRED)) {
+            if (pcmk_is_set(fsa_input_register, R_ST_REQUIRED)) {
                 crm_notice("Fencer connection failed (will retry): %s "
                            CRM_XS " rc=%d", pcmk_strerror(rc), rc);
                 mainloop_set_trigger(stonith_reconnect);

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -251,8 +251,7 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
         || do_fsa_stall) {
         crm_debug("Exiting the FSA: queue=%d, fsa_actions=0x%llx, stalled=%s",
                   g_list_length(fsa_message_queue),
-                  (unsigned long long) fsa_actions,
-                  (do_fsa_stall? "true" : "false"));
+                  (unsigned long long) fsa_actions, pcmk__btoa(do_fsa_stall));
     } else {
         crm_trace("Exiting the FSA");
     }

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -206,13 +206,13 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
         }
 
         /* logging : *before* the state is changed */
-        if (is_set(fsa_actions, A_ERROR)) {
+        if (pcmk_is_set(fsa_actions, A_ERROR)) {
             do_fsa_action(fsa_data, A_ERROR, do_log);
         }
-        if (is_set(fsa_actions, A_WARN)) {
+        if (pcmk_is_set(fsa_actions, A_WARN)) {
             do_fsa_action(fsa_data, A_WARN, do_log);
         }
-        if (is_set(fsa_actions, A_LOG)) {
+        if (pcmk_is_set(fsa_actions, A_LOG)) {
             do_fsa_action(fsa_data, A_LOG, do_log);
         }
 
@@ -589,7 +589,7 @@ do_state_transition(enum crmd_fsa_state cur_state,
             election_trigger->counter = 0;
             purge_stonith_cleanup();
 
-            if (is_set(fsa_input_register, R_SHUTDOWN)) {
+            if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
                 crm_info("(Re)Issuing shutdown request now" " that we have a new DC");
                 controld_set_fsa_action_flags(A_SHUTDOWN_REQ);
             }
@@ -638,7 +638,7 @@ do_state_transition(enum crmd_fsa_state cur_state,
 
         case S_IDLE:
             CRM_LOG_ASSERT(AM_I_DC);
-            if (is_set(fsa_input_register, R_SHUTDOWN)) {
+            if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
                 crm_info("(Re)Issuing shutdown request now" " that we are the DC");
                 controld_set_fsa_action_flags(A_SHUTDOWN_REQ);
             }

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -527,8 +527,8 @@ const char *fsa_action2string(long long action);
 
 enum crmd_fsa_state s_crmd_fsa(enum crmd_fsa_cause cause);
 
-#  define AM_I_DC is_set(fsa_input_register, R_THE_DC)
-#  define AM_I_OPERATIONAL (is_set(fsa_input_register, R_STARTING) == FALSE)
+#  define AM_I_DC pcmk_is_set(fsa_input_register, R_THE_DC)
+#  define AM_I_OPERATIONAL !pcmk_is_set(fsa_input_register, R_STARTING)
 #  define trigger_fsa() do {                    \
         if (fsa_source != NULL) {               \
             crm_trace("Triggering FSA");        \

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -287,7 +287,7 @@ do_cl_join_finalize_respond(long long action,
          * are _NOT_ lucky, we will probe for the "wrong" instance of anonymous
          * clones and end up with multiple active instances on the machine.
          */
-        if (first_join && is_not_set(fsa_input_register, R_SHUTDOWN)) {
+        if (first_join && !pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
             first_join = FALSE;
             if (start_state) {
                 set_join_state(start_state);

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -40,7 +40,7 @@ crm_update_peer_join(const char *source, crm_node_t * node, enum crm_join_phase 
     CRM_CHECK(node != NULL, return);
 
     /* Remote nodes do not participate in joins */
-    if (is_set(node->flags, crm_remote_node)) {
+    if (pcmk_is_set(node->flags, crm_remote_node)) {
         return;
     }
 
@@ -110,7 +110,7 @@ create_dc_message(const char *join_op, const char *host_to)
      * joining node from fencing the old DC if it becomes the new DC.
      */
     crm_xml_add_boolean(msg, F_CRM_DC_LEAVING,
-                        is_set(fsa_input_register, R_SHUTDOWN));
+                        pcmk_is_set(fsa_input_register, R_SHUTDOWN));
     return msg;
 }
 
@@ -437,7 +437,7 @@ do_dc_join_finalize(long long action,
         controld_set_fsa_input_flags(R_HAVE_CIB);
     }
 
-    if (is_set(fsa_input_register, R_IN_TRANSITION)) {
+    if (pcmk_is_set(fsa_input_register, R_IN_TRANSITION)) {
         crm_warn("Delaying join-%d finalization while transition in progress",
                  current_join_id);
         crmd_join_phase_log(LOG_DEBUG);
@@ -445,7 +445,7 @@ do_dc_join_finalize(long long action,
         return;
     }
 
-    if (max_generation_from && is_set(fsa_input_register, R_HAVE_CIB) == FALSE) {
+    if (max_generation_from && !pcmk_is_set(fsa_input_register, R_HAVE_CIB)) {
         /* ask for the agreed best CIB */
         sync_from = strdup(max_generation_from);
         controld_set_fsa_input_flags(R_CIB_ASKED);
@@ -690,7 +690,7 @@ check_join_state(enum crmd_fsa_state cur_state, const char *source)
         }
 
     } else if (cur_state == S_FINALIZE_JOIN) {
-        if (is_set(fsa_input_register, R_HAVE_CIB) == FALSE) {
+        if (!pcmk_is_set(fsa_input_register, R_HAVE_CIB)) {
             crm_debug("join-%d: Delaying finalization until we have CIB "
                       CRM_XS " state=%s for=%s",
                       current_join_id, fsa_state2string(cur_state), source);

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -409,7 +409,8 @@ crm_update_quorum(gboolean quorum, gboolean force_update)
         crm_xml_add(update, XML_ATTR_DC_UUID, fsa_our_uuid);
 
         fsa_cib_update(XML_TAG_CIB, update, call_options, call_id, NULL);
-        crm_debug("Updating quorum status to %s (call=%d)", quorum ? "true" : "false", call_id);
+        crm_debug("Updating quorum status to %s (call=%d)",
+                  pcmk__btoa(quorum), call_id);
         fsa_register_cib_callback(call_id, FALSE, NULL, cib_quorum_update_complete);
         free_xml(update);
 

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -136,7 +136,7 @@ create_node_state_update(crm_node_t *node, int flags, xmlNode *parent,
 
     node_state = create_xml_node(parent, XML_CIB_TAG_STATE);
 
-    if (is_set(node->flags, crm_remote_node)) {
+    if (pcmk_is_set(node->flags, crm_remote_node)) {
         crm_xml_add(node_state, XML_NODE_IS_REMOTE, XML_BOOLEAN_TRUE);
     }
 
@@ -155,10 +155,10 @@ create_node_state_update(crm_node_t *node, int flags, xmlNode *parent,
                             pcmk__str_eq(node->state, CRM_NODE_MEMBER, pcmk__str_casei));
     }
 
-    if (!is_set(node->flags, crm_remote_node)) {
+    if (!pcmk_is_set(node->flags, crm_remote_node)) {
         if (flags & node_update_peer) {
             value = OFFLINESTATUS;
-            if (is_set(node->processes, crm_get_cluster_proc())) {
+            if (pcmk_is_set(node->processes, crm_get_cluster_proc())) {
                 value = ONLINESTATUS;
             }
             crm_xml_add(node_state, XML_NODE_IS_PEER, value);
@@ -302,7 +302,7 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
     xmlNode *node_list = create_xml_node(NULL, XML_CIB_TAG_NODES);
 
 #if SUPPORT_COROSYNC
-    if (is_not_set(flags, node_update_quick) && is_corosync_cluster()) {
+    if (!pcmk_is_set(flags, node_update_quick) && is_corosync_cluster()) {
         from_hashtable = corosync_initialize_nodelist(NULL, FALSE, node_list);
     }
 #endif

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -909,7 +909,7 @@ handle_shutdown_self_ack(xmlNode *stored_msg)
 {
     const char *host_from = crm_element_value(stored_msg, F_CRM_HOST_FROM);
 
-    if (is_set(fsa_input_register, R_SHUTDOWN)) {
+    if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
         // The expected case -- we initiated own shutdown sequence
         crm_info("Shutting down controller");
         return I_STOP;
@@ -949,7 +949,7 @@ handle_shutdown_ack(xmlNode *stored_msg)
 
     if ((fsa_our_dc == NULL) || (strcmp(host_from, fsa_our_dc) == 0)) {
 
-        if (is_set(fsa_input_register, R_SHUTDOWN)) {
+        if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
             crm_info("Shutting down controller after confirmation from %s",
                      host_from);
         } else {

--- a/daemons/controld/controld_metadata.c
+++ b/daemons/controld/controld_metadata.c
@@ -237,7 +237,7 @@ metadata_cache_update(GHashTable *mdc, lrmd_rsc_info_t *rsc,
             if (p == NULL) {
                 goto err;
             }
-            if (is_set(p->rap_flags, ra_param_private)) {
+            if (pcmk_is_set(p->rap_flags, ra_param_private)) {
                 controld_set_ra_flags(md, key, ra_uses_private);
             }
             md->ra_params = g_list_prepend(md->ra_params, p);

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -448,7 +448,7 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     crm_xml_add(output, XML_ATTR_DC_UUID, fsa_our_uuid);
     crm_xml_add_int(output, XML_ATTR_HAVE_QUORUM, fsa_has_quorum);
 
-    force_local_option(output, XML_ATTR_HAVE_WATCHDOG, watchdog?"true":"false");
+    force_local_option(output, XML_ATTR_HAVE_WATCHDOG, pcmk__btoa(watchdog));
 
     if (ever_had_quorum && crm_have_quorum == FALSE) {
         crm_xml_add_int(output, XML_ATTR_QUORUM_PANIC, 1);

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -84,7 +84,7 @@ pe_ipc_destroy(gpointer user_data)
     // If we aren't connected to the scheduler, we can't expect a reply
     controld_expect_sched_reply(NULL);
 
-    if (is_set(fsa_input_register, R_PE_REQUIRED)) {
+    if (pcmk_is_set(fsa_input_register, R_PE_REQUIRED)) {
         int rc = pcmk_ok;
         char *uuid_str = crm_generate_uuid();
 
@@ -201,7 +201,7 @@ do_pe_control(long long action,
         pe_subsystem_free();
     }
     if ((action & A_PE_START)
-        && (is_not_set(fsa_input_register, R_PE_CONNECTED))) {
+        && !pcmk_is_set(fsa_input_register, R_PE_CONNECTED)) {
 
         if (cur_state == S_STOPPING) {
             crm_info("Ignoring request to connect to scheduler while shutting down");
@@ -310,8 +310,8 @@ do_pe_invoke(long long action,
         return;
     }
 
-    if (is_set(fsa_input_register, R_PE_CONNECTED) == FALSE) {
-        if (is_set(fsa_input_register, R_SHUTDOWN)) {
+    if (!pcmk_is_set(fsa_input_register, R_PE_CONNECTED)) {
+        if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
             crm_err("Cannot shut down gracefully without the scheduler");
             register_fsa_input_before(C_FSA_INTERNAL, I_TERMINATE, NULL);
 
@@ -329,7 +329,7 @@ do_pe_invoke(long long action,
                    fsa_state2string(cur_state));
         return;
     }
-    if (is_set(fsa_input_register, R_HAVE_CIB) == FALSE) {
+    if (!pcmk_is_set(fsa_input_register, R_HAVE_CIB)) {
         crm_err("Attempted to invoke scheduler without consistent Cluster Information Base!");
 
         /* start the join from scratch */
@@ -416,7 +416,7 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
         crm_trace("Skipping superseded CIB query: %d (current=%d)", call_id, fsa_pe_query);
         return;
 
-    } else if (AM_I_DC == FALSE || is_set(fsa_input_register, R_PE_CONNECTED) == FALSE) {
+    } else if (!AM_I_DC || !pcmk_is_set(fsa_input_register, R_PE_CONNECTED)) {
         crm_debug("No need to invoke the scheduler anymore");
         return;
 

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -619,7 +619,7 @@ notify_crmd(crm_graph_t * graph)
 
         case tg_shutdown:
             type = "shutdown";
-            if (is_set(fsa_input_register, R_SHUTDOWN)) {
+            if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
                 event = I_STOP;
 
             } else {

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -195,7 +195,7 @@ abort_transition_graph(int abort_priority, enum transition_action abort_action,
     if(reason == NULL) {
         do_crm_log(level, "Transition %d aborted: %s "CRM_XS" source=%s:%d complete=%s",
                    transition_graph->id, abort_text, fn, line,
-                   (transition_graph->complete? "true" : "false"));
+                   pcmk__btoa(transition_graph->complete));
 
     } else if(change == NULL) {
         char *local_path = xml_get_path(reason);
@@ -204,7 +204,7 @@ abort_transition_graph(int abort_priority, enum transition_action abort_action,
                    CRM_XS " cib=%d.%d.%d source=%s:%d path=%s complete=%s",
                    transition_graph->id, TYPE(reason), ID(reason), abort_text,
                    add[0], add[1], add[2], fn, line, local_path,
-                   (transition_graph->complete? "true" : "false"));
+                   pcmk__btoa(transition_graph->complete));
         free(local_path);
 
     } else {
@@ -233,7 +233,7 @@ abort_transition_graph(int abort_priority, enum transition_action abort_action,
                        transition_graph->id,
                        (shortpath? (shortpath + 1) : path), abort_text,
                        add[0], add[1], add[2], fn, line, path,
-                       (transition_graph->complete? "true" : "false"));
+                       pcmk__btoa(transition_graph->complete));
 
         } else if (pcmk__str_eq(XML_CIB_TAG_NVPAIR, kind, pcmk__str_casei)) { 
             do_crm_log(level, "Transition %d aborted by %s doing %s %s=%s: %s "
@@ -243,7 +243,7 @@ abort_transition_graph(int abort_priority, enum transition_action abort_action,
                        crm_element_value(reason, XML_NVPAIR_ATTR_NAME),
                        crm_element_value(reason, XML_NVPAIR_ATTR_VALUE),
                        abort_text, add[0], add[1], add[2], fn, line, path,
-                       (transition_graph->complete? "true" : "false"));
+                       pcmk__btoa(transition_graph->complete));
 
         } else if (pcmk__str_eq(XML_LRM_TAG_RSC_OP, kind, pcmk__str_casei)) {
             const char *magic = crm_element_value(reason, XML_ATTR_TRANSITION_MAGIC);
@@ -254,7 +254,7 @@ abort_transition_graph(int abort_priority, enum transition_action abort_action,
                        crm_element_value(reason, XML_LRM_ATTR_TASK_KEY), op,
                        crm_element_value(reason, XML_LRM_ATTR_TARGET), abort_text,
                        magic, add[0], add[1], add[2], fn, line,
-                       (transition_graph->complete? "true" : "false"));
+                       pcmk__btoa(transition_graph->complete));
 
         } else if (pcmk__strcase_any_of(kind, XML_CIB_TAG_STATE, XML_CIB_TAG_NODE, NULL)) {
             const char *uname = crm_peer_uname(ID(reason));
@@ -264,7 +264,7 @@ abort_transition_graph(int abort_priority, enum transition_action abort_action,
                        transition_graph->id,
                        kind, op, (uname? uname : ID(reason)), abort_text,
                        add[0], add[1], add[2], fn, line,
-                       (transition_graph->complete? "true" : "false"));
+                       pcmk__btoa(transition_graph->complete));
 
         } else {
             const char *id = ID(reason);
@@ -274,7 +274,7 @@ abort_transition_graph(int abort_priority, enum transition_action abort_action,
                        transition_graph->id,
                        TYPE(reason), (id? id : ""), (op? op : "change"),
                        abort_text, add[0], add[1], add[2], fn, line, path,
-                       (transition_graph->complete? "true" : "false"));
+                       pcmk__btoa(transition_graph->complete));
         }
     }
 

--- a/daemons/controld/controld_transition.c
+++ b/daemons/controld/controld_transition.c
@@ -60,7 +60,7 @@ do_te_control(long long action,
     if ((action & A_TE_START) == 0) {
         return;
 
-    } else if (is_set(fsa_input_register, R_TE_CONNECTED)) {
+    } else if (pcmk_is_set(fsa_input_register, R_TE_CONNECTED)) {
         crm_debug("The transitioner is already active");
         return;
 

--- a/daemons/controld/controld_utils.c
+++ b/daemons/controld/controld_utils.c
@@ -455,76 +455,76 @@ fsa_dump_inputs(int log_level, const char *text, long long input_register)
         text = "Input register contents:";
     }
 
-    if (is_set(input_register, R_THE_DC)) {
+    if (pcmk_is_set(input_register, R_THE_DC)) {
         crm_trace("%s %.16llx (R_THE_DC)", text, R_THE_DC);
     }
-    if (is_set(input_register, R_STARTING)) {
+    if (pcmk_is_set(input_register, R_STARTING)) {
         crm_trace("%s %.16llx (R_STARTING)", text, R_STARTING);
     }
-    if (is_set(input_register, R_SHUTDOWN)) {
+    if (pcmk_is_set(input_register, R_SHUTDOWN)) {
         crm_trace("%s %.16llx (R_SHUTDOWN)", text, R_SHUTDOWN);
     }
-    if (is_set(input_register, R_STAYDOWN)) {
+    if (pcmk_is_set(input_register, R_STAYDOWN)) {
         crm_trace("%s %.16llx (R_STAYDOWN)", text, R_STAYDOWN);
     }
-    if (is_set(input_register, R_JOIN_OK)) {
+    if (pcmk_is_set(input_register, R_JOIN_OK)) {
         crm_trace("%s %.16llx (R_JOIN_OK)", text, R_JOIN_OK);
     }
-    if (is_set(input_register, R_READ_CONFIG)) {
+    if (pcmk_is_set(input_register, R_READ_CONFIG)) {
         crm_trace("%s %.16llx (R_READ_CONFIG)", text, R_READ_CONFIG);
     }
-    if (is_set(input_register, R_INVOKE_PE)) {
+    if (pcmk_is_set(input_register, R_INVOKE_PE)) {
         crm_trace("%s %.16llx (R_INVOKE_PE)", text, R_INVOKE_PE);
     }
-    if (is_set(input_register, R_CIB_CONNECTED)) {
+    if (pcmk_is_set(input_register, R_CIB_CONNECTED)) {
         crm_trace("%s %.16llx (R_CIB_CONNECTED)", text, R_CIB_CONNECTED);
     }
-    if (is_set(input_register, R_PE_CONNECTED)) {
+    if (pcmk_is_set(input_register, R_PE_CONNECTED)) {
         crm_trace("%s %.16llx (R_PE_CONNECTED)", text, R_PE_CONNECTED);
     }
-    if (is_set(input_register, R_TE_CONNECTED)) {
+    if (pcmk_is_set(input_register, R_TE_CONNECTED)) {
         crm_trace("%s %.16llx (R_TE_CONNECTED)", text, R_TE_CONNECTED);
     }
-    if (is_set(input_register, R_LRM_CONNECTED)) {
+    if (pcmk_is_set(input_register, R_LRM_CONNECTED)) {
         crm_trace("%s %.16llx (R_LRM_CONNECTED)", text, R_LRM_CONNECTED);
     }
-    if (is_set(input_register, R_CIB_REQUIRED)) {
+    if (pcmk_is_set(input_register, R_CIB_REQUIRED)) {
         crm_trace("%s %.16llx (R_CIB_REQUIRED)", text, R_CIB_REQUIRED);
     }
-    if (is_set(input_register, R_PE_REQUIRED)) {
+    if (pcmk_is_set(input_register, R_PE_REQUIRED)) {
         crm_trace("%s %.16llx (R_PE_REQUIRED)", text, R_PE_REQUIRED);
     }
-    if (is_set(input_register, R_TE_REQUIRED)) {
+    if (pcmk_is_set(input_register, R_TE_REQUIRED)) {
         crm_trace("%s %.16llx (R_TE_REQUIRED)", text, R_TE_REQUIRED);
     }
-    if (is_set(input_register, R_REQ_PEND)) {
+    if (pcmk_is_set(input_register, R_REQ_PEND)) {
         crm_trace("%s %.16llx (R_REQ_PEND)", text, R_REQ_PEND);
     }
-    if (is_set(input_register, R_PE_PEND)) {
+    if (pcmk_is_set(input_register, R_PE_PEND)) {
         crm_trace("%s %.16llx (R_PE_PEND)", text, R_PE_PEND);
     }
-    if (is_set(input_register, R_TE_PEND)) {
+    if (pcmk_is_set(input_register, R_TE_PEND)) {
         crm_trace("%s %.16llx (R_TE_PEND)", text, R_TE_PEND);
     }
-    if (is_set(input_register, R_RESP_PEND)) {
+    if (pcmk_is_set(input_register, R_RESP_PEND)) {
         crm_trace("%s %.16llx (R_RESP_PEND)", text, R_RESP_PEND);
     }
-    if (is_set(input_register, R_CIB_DONE)) {
+    if (pcmk_is_set(input_register, R_CIB_DONE)) {
         crm_trace("%s %.16llx (R_CIB_DONE)", text, R_CIB_DONE);
     }
-    if (is_set(input_register, R_HAVE_CIB)) {
+    if (pcmk_is_set(input_register, R_HAVE_CIB)) {
         crm_trace("%s %.16llx (R_HAVE_CIB)", text, R_HAVE_CIB);
     }
-    if (is_set(input_register, R_CIB_ASKED)) {
+    if (pcmk_is_set(input_register, R_CIB_ASKED)) {
         crm_trace("%s %.16llx (R_CIB_ASKED)", text, R_CIB_ASKED);
     }
-    if (is_set(input_register, R_MEMBERSHIP)) {
+    if (pcmk_is_set(input_register, R_MEMBERSHIP)) {
         crm_trace("%s %.16llx (R_MEMBERSHIP)", text, R_MEMBERSHIP);
     }
-    if (is_set(input_register, R_PEER_DATA)) {
+    if (pcmk_is_set(input_register, R_PEER_DATA)) {
         crm_trace("%s %.16llx (R_PEER_DATA)", text, R_PEER_DATA);
     }
-    if (is_set(input_register, R_IN_RECOVERY)) {
+    if (pcmk_is_set(input_register, R_IN_RECOVERY)) {
         crm_trace("%s %.16llx (R_IN_RECOVERY)", text, R_IN_RECOVERY);
     }
 }
@@ -532,157 +532,157 @@ fsa_dump_inputs(int log_level, const char *text, long long input_register)
 void
 fsa_dump_actions(uint64_t action, const char *text)
 {
-    if (is_set(action, A_READCONFIG)) {
+    if (pcmk_is_set(action, A_READCONFIG)) {
         crm_trace("Action %.16llx (A_READCONFIG) %s", A_READCONFIG, text);
     }
-    if (is_set(action, A_STARTUP)) {
+    if (pcmk_is_set(action, A_STARTUP)) {
         crm_trace("Action %.16llx (A_STARTUP) %s", A_STARTUP, text);
     }
-    if (is_set(action, A_STARTED)) {
+    if (pcmk_is_set(action, A_STARTED)) {
         crm_trace("Action %.16llx (A_STARTED) %s", A_STARTED, text);
     }
-    if (is_set(action, A_HA_CONNECT)) {
+    if (pcmk_is_set(action, A_HA_CONNECT)) {
         crm_trace("Action %.16llx (A_CONNECT) %s", A_HA_CONNECT, text);
     }
-    if (is_set(action, A_HA_DISCONNECT)) {
+    if (pcmk_is_set(action, A_HA_DISCONNECT)) {
         crm_trace("Action %.16llx (A_DISCONNECT) %s", A_HA_DISCONNECT, text);
     }
-    if (is_set(action, A_LRM_CONNECT)) {
+    if (pcmk_is_set(action, A_LRM_CONNECT)) {
         crm_trace("Action %.16llx (A_LRM_CONNECT) %s", A_LRM_CONNECT, text);
     }
-    if (is_set(action, A_LRM_EVENT)) {
+    if (pcmk_is_set(action, A_LRM_EVENT)) {
         crm_trace("Action %.16llx (A_LRM_EVENT) %s", A_LRM_EVENT, text);
     }
-    if (is_set(action, A_LRM_INVOKE)) {
+    if (pcmk_is_set(action, A_LRM_INVOKE)) {
         crm_trace("Action %.16llx (A_LRM_INVOKE) %s", A_LRM_INVOKE, text);
     }
-    if (is_set(action, A_LRM_DISCONNECT)) {
+    if (pcmk_is_set(action, A_LRM_DISCONNECT)) {
         crm_trace("Action %.16llx (A_LRM_DISCONNECT) %s", A_LRM_DISCONNECT, text);
     }
-    if (is_set(action, A_DC_TIMER_STOP)) {
+    if (pcmk_is_set(action, A_DC_TIMER_STOP)) {
         crm_trace("Action %.16llx (A_DC_TIMER_STOP) %s", A_DC_TIMER_STOP, text);
     }
-    if (is_set(action, A_DC_TIMER_START)) {
+    if (pcmk_is_set(action, A_DC_TIMER_START)) {
         crm_trace("Action %.16llx (A_DC_TIMER_START) %s", A_DC_TIMER_START, text);
     }
-    if (is_set(action, A_INTEGRATE_TIMER_START)) {
+    if (pcmk_is_set(action, A_INTEGRATE_TIMER_START)) {
         crm_trace("Action %.16llx (A_INTEGRATE_TIMER_START) %s", A_INTEGRATE_TIMER_START, text);
     }
-    if (is_set(action, A_INTEGRATE_TIMER_STOP)) {
+    if (pcmk_is_set(action, A_INTEGRATE_TIMER_STOP)) {
         crm_trace("Action %.16llx (A_INTEGRATE_TIMER_STOP) %s", A_INTEGRATE_TIMER_STOP, text);
     }
-    if (is_set(action, A_FINALIZE_TIMER_START)) {
+    if (pcmk_is_set(action, A_FINALIZE_TIMER_START)) {
         crm_trace("Action %.16llx (A_FINALIZE_TIMER_START) %s", A_FINALIZE_TIMER_START, text);
     }
-    if (is_set(action, A_FINALIZE_TIMER_STOP)) {
+    if (pcmk_is_set(action, A_FINALIZE_TIMER_STOP)) {
         crm_trace("Action %.16llx (A_FINALIZE_TIMER_STOP) %s", A_FINALIZE_TIMER_STOP, text);
     }
-    if (is_set(action, A_ELECTION_COUNT)) {
+    if (pcmk_is_set(action, A_ELECTION_COUNT)) {
         crm_trace("Action %.16llx (A_ELECTION_COUNT) %s", A_ELECTION_COUNT, text);
     }
-    if (is_set(action, A_ELECTION_VOTE)) {
+    if (pcmk_is_set(action, A_ELECTION_VOTE)) {
         crm_trace("Action %.16llx (A_ELECTION_VOTE) %s", A_ELECTION_VOTE, text);
     }
-    if (is_set(action, A_ELECTION_CHECK)) {
+    if (pcmk_is_set(action, A_ELECTION_CHECK)) {
         crm_trace("Action %.16llx (A_ELECTION_CHECK) %s", A_ELECTION_CHECK, text);
     }
-    if (is_set(action, A_CL_JOIN_ANNOUNCE)) {
+    if (pcmk_is_set(action, A_CL_JOIN_ANNOUNCE)) {
         crm_trace("Action %.16llx (A_CL_JOIN_ANNOUNCE) %s", A_CL_JOIN_ANNOUNCE, text);
     }
-    if (is_set(action, A_CL_JOIN_REQUEST)) {
+    if (pcmk_is_set(action, A_CL_JOIN_REQUEST)) {
         crm_trace("Action %.16llx (A_CL_JOIN_REQUEST) %s", A_CL_JOIN_REQUEST, text);
     }
-    if (is_set(action, A_CL_JOIN_RESULT)) {
+    if (pcmk_is_set(action, A_CL_JOIN_RESULT)) {
         crm_trace("Action %.16llx (A_CL_JOIN_RESULT) %s", A_CL_JOIN_RESULT, text);
     }
-    if (is_set(action, A_DC_JOIN_OFFER_ALL)) {
+    if (pcmk_is_set(action, A_DC_JOIN_OFFER_ALL)) {
         crm_trace("Action %.16llx (A_DC_JOIN_OFFER_ALL) %s", A_DC_JOIN_OFFER_ALL, text);
     }
-    if (is_set(action, A_DC_JOIN_OFFER_ONE)) {
+    if (pcmk_is_set(action, A_DC_JOIN_OFFER_ONE)) {
         crm_trace("Action %.16llx (A_DC_JOIN_OFFER_ONE) %s", A_DC_JOIN_OFFER_ONE, text);
     }
-    if (is_set(action, A_DC_JOIN_PROCESS_REQ)) {
+    if (pcmk_is_set(action, A_DC_JOIN_PROCESS_REQ)) {
         crm_trace("Action %.16llx (A_DC_JOIN_PROCESS_REQ) %s", A_DC_JOIN_PROCESS_REQ, text);
     }
-    if (is_set(action, A_DC_JOIN_PROCESS_ACK)) {
+    if (pcmk_is_set(action, A_DC_JOIN_PROCESS_ACK)) {
         crm_trace("Action %.16llx (A_DC_JOIN_PROCESS_ACK) %s", A_DC_JOIN_PROCESS_ACK, text);
     }
-    if (is_set(action, A_DC_JOIN_FINALIZE)) {
+    if (pcmk_is_set(action, A_DC_JOIN_FINALIZE)) {
         crm_trace("Action %.16llx (A_DC_JOIN_FINALIZE) %s", A_DC_JOIN_FINALIZE, text);
     }
-    if (is_set(action, A_MSG_PROCESS)) {
+    if (pcmk_is_set(action, A_MSG_PROCESS)) {
         crm_trace("Action %.16llx (A_MSG_PROCESS) %s", A_MSG_PROCESS, text);
     }
-    if (is_set(action, A_MSG_ROUTE)) {
+    if (pcmk_is_set(action, A_MSG_ROUTE)) {
         crm_trace("Action %.16llx (A_MSG_ROUTE) %s", A_MSG_ROUTE, text);
     }
-    if (is_set(action, A_RECOVER)) {
+    if (pcmk_is_set(action, A_RECOVER)) {
         crm_trace("Action %.16llx (A_RECOVER) %s", A_RECOVER, text);
     }
-    if (is_set(action, A_DC_RELEASE)) {
+    if (pcmk_is_set(action, A_DC_RELEASE)) {
         crm_trace("Action %.16llx (A_DC_RELEASE) %s", A_DC_RELEASE, text);
     }
-    if (is_set(action, A_DC_RELEASED)) {
+    if (pcmk_is_set(action, A_DC_RELEASED)) {
         crm_trace("Action %.16llx (A_DC_RELEASED) %s", A_DC_RELEASED, text);
     }
-    if (is_set(action, A_DC_TAKEOVER)) {
+    if (pcmk_is_set(action, A_DC_TAKEOVER)) {
         crm_trace("Action %.16llx (A_DC_TAKEOVER) %s", A_DC_TAKEOVER, text);
     }
-    if (is_set(action, A_SHUTDOWN)) {
+    if (pcmk_is_set(action, A_SHUTDOWN)) {
         crm_trace("Action %.16llx (A_SHUTDOWN) %s", A_SHUTDOWN, text);
     }
-    if (is_set(action, A_SHUTDOWN_REQ)) {
+    if (pcmk_is_set(action, A_SHUTDOWN_REQ)) {
         crm_trace("Action %.16llx (A_SHUTDOWN_REQ) %s", A_SHUTDOWN_REQ, text);
     }
-    if (is_set(action, A_STOP)) {
+    if (pcmk_is_set(action, A_STOP)) {
         crm_trace("Action %.16llx (A_STOP  ) %s", A_STOP, text);
     }
-    if (is_set(action, A_EXIT_0)) {
+    if (pcmk_is_set(action, A_EXIT_0)) {
         crm_trace("Action %.16llx (A_EXIT_0) %s", A_EXIT_0, text);
     }
-    if (is_set(action, A_EXIT_1)) {
+    if (pcmk_is_set(action, A_EXIT_1)) {
         crm_trace("Action %.16llx (A_EXIT_1) %s", A_EXIT_1, text);
     }
-    if (is_set(action, A_CIB_START)) {
+    if (pcmk_is_set(action, A_CIB_START)) {
         crm_trace("Action %.16llx (A_CIB_START) %s", A_CIB_START, text);
     }
-    if (is_set(action, A_CIB_STOP)) {
+    if (pcmk_is_set(action, A_CIB_STOP)) {
         crm_trace("Action %.16llx (A_CIB_STOP) %s", A_CIB_STOP, text);
     }
-    if (is_set(action, A_TE_INVOKE)) {
+    if (pcmk_is_set(action, A_TE_INVOKE)) {
         crm_trace("Action %.16llx (A_TE_INVOKE) %s", A_TE_INVOKE, text);
     }
-    if (is_set(action, A_TE_START)) {
+    if (pcmk_is_set(action, A_TE_START)) {
         crm_trace("Action %.16llx (A_TE_START) %s", A_TE_START, text);
     }
-    if (is_set(action, A_TE_STOP)) {
+    if (pcmk_is_set(action, A_TE_STOP)) {
         crm_trace("Action %.16llx (A_TE_STOP) %s", A_TE_STOP, text);
     }
-    if (is_set(action, A_TE_CANCEL)) {
+    if (pcmk_is_set(action, A_TE_CANCEL)) {
         crm_trace("Action %.16llx (A_TE_CANCEL) %s", A_TE_CANCEL, text);
     }
-    if (is_set(action, A_PE_INVOKE)) {
+    if (pcmk_is_set(action, A_PE_INVOKE)) {
         crm_trace("Action %.16llx (A_PE_INVOKE) %s", A_PE_INVOKE, text);
     }
-    if (is_set(action, A_PE_START)) {
+    if (pcmk_is_set(action, A_PE_START)) {
         crm_trace("Action %.16llx (A_PE_START) %s", A_PE_START, text);
     }
-    if (is_set(action, A_PE_STOP)) {
+    if (pcmk_is_set(action, A_PE_STOP)) {
         crm_trace("Action %.16llx (A_PE_STOP) %s", A_PE_STOP, text);
     }
-    if (is_set(action, A_NODE_BLOCK)) {
+    if (pcmk_is_set(action, A_NODE_BLOCK)) {
         crm_trace("Action %.16llx (A_NODE_BLOCK) %s", A_NODE_BLOCK, text);
     }
-    if (is_set(action, A_UPDATE_NODESTATUS)) {
+    if (pcmk_is_set(action, A_UPDATE_NODESTATUS)) {
         crm_trace("Action %.16llx (A_UPDATE_NODESTATUS) %s", A_UPDATE_NODESTATUS, text);
     }
-    if (is_set(action, A_LOG)) {
+    if (pcmk_is_set(action, A_LOG)) {
         crm_trace("Action %.16llx (A_LOG   ) %s", A_LOG, text);
     }
-    if (is_set(action, A_ERROR)) {
+    if (pcmk_is_set(action, A_ERROR)) {
         crm_trace("Action %.16llx (A_ERROR ) %s", A_ERROR, text);
     }
-    if (is_set(action, A_WARN)) {
+    if (pcmk_is_set(action, A_WARN)) {
         crm_trace("Action %.16llx (A_WARN  ) %s", A_WARN, text);
     }
 }

--- a/daemons/controld/pacemaker-controld.c
+++ b/daemons/controld/pacemaker-controld.c
@@ -158,7 +158,7 @@ crmd_init(void)
         /* Create the mainloop and run it... */
         crm_trace("Starting %s's mainloop", crm_system_name);
         g_main_loop_run(crmd_mainloop);
-        if (is_set(fsa_input_register, R_STAYDOWN)) {
+        if (pcmk_is_set(fsa_input_register, R_STAYDOWN)) {
             crm_info("Inhibiting automated respawn");
             exit_code = CRM_EX_FATAL;
         }

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -237,7 +237,7 @@ static const char *
 normalize_action_name(lrmd_rsc_t * rsc, const char *action)
 {
     if (pcmk__str_eq(action, "monitor", pcmk__str_casei) &&
-        is_set(pcmk_get_ra_caps(rsc->class), pcmk_ra_cap_status)) {
+        pcmk_is_set(pcmk_get_ra_caps(rsc->class), pcmk_ra_cap_status)) {
         return "status";
     }
     return action;
@@ -511,7 +511,7 @@ send_client_notify(gpointer key, gpointer value, gpointer user_data)
         crm_trace("Skipping notification to client without name");
         return;
     }
-    if (is_set(client->flags, pcmk__client_to_proxy)) {
+    if (pcmk_is_set(client->flags, pcmk__client_to_proxy)) {
         /* We only want to notify clients of the executor IPC API. If we are
          * running as Pacemaker Remote, we may have clients proxied to other
          * IPC services in the cluster, so skip those.

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1182,7 +1182,7 @@ find_best_peer(const char *device, remote_fencing_op_t * op, enum find_best_peer
     GListPtr iter = NULL;
     gboolean verified_devices_only = (options & FIND_PEER_VERIFIED_ONLY) ? TRUE : FALSE;
 
-    if (!device && is_set(op->call_options, st_opt_topology)) {
+    if (!device && pcmk_is_set(op->call_options, st_opt_topology)) {
         return NULL;
     }
 
@@ -1198,7 +1198,7 @@ find_best_peer(const char *device, remote_fencing_op_t * op, enum find_best_peer
             continue;
         }
 
-        if (is_set(op->call_options, st_opt_topology)) {
+        if (pcmk_is_set(op->call_options, st_opt_topology)) {
 
             if (grab_peer_device(op, peer, device, verified_devices_only)) {
                 return peer;
@@ -1267,7 +1267,7 @@ stonith_choose_peer(remote_fencing_op_t * op)
          * phase of a remapped "reboot", because we ignore errors in that case)
          */
     } while ((op->phase != st_phase_on)
-             && is_set(op->call_options, st_opt_topology)
+             && pcmk_is_set(op->call_options, st_opt_topology)
              && (advance_topology_level(op, false) == pcmk_rc_ok));
 
     crm_notice("Couldn't find anyone to fence (%s) %s with %s",
@@ -1344,7 +1344,7 @@ get_op_total_timeout(const remote_fencing_op_t *op,
     int total_timeout = 0;
     stonith_topology_t *tp = find_topology_for_host(op->target);
 
-    if (is_set(op->call_options, st_opt_topology) && tp) {
+    if (pcmk_is_set(op->call_options, st_opt_topology) && tp) {
         int i;
         GListPtr device_list = NULL;
         GListPtr iter = NULL;
@@ -1500,7 +1500,7 @@ call_remote_stonith(remote_fencing_op_t * op, st_query_result_t * peer)
     int timeout = op->base_timeout;
 
     crm_trace("State for %s.%.8s: %s %d", op->target, op->client_name, op->id, op->state);
-    if (peer == NULL && !is_set(op->call_options, st_opt_topology)) {
+    if ((peer == NULL) && !pcmk_is_set(op->call_options, st_opt_topology)) {
         peer = stonith_choose_peer(op);
     }
 
@@ -1515,7 +1515,7 @@ call_remote_stonith(remote_fencing_op_t * op, st_query_result_t * peer)
                  total_timeout, op->target, op->client_name, op->id);
     }
 
-    if (is_set(op->call_options, st_opt_topology) && op->devices) {
+    if (pcmk_is_set(op->call_options, st_opt_topology) && op->devices) {
         /* Ignore any peer preference, they might not have the device we need */
         /* When using topology, stonith_choose_peer() removes the device from
          * further consideration, so be sure to calculate timeout beforehand */
@@ -1922,7 +1922,7 @@ process_remote_stonith_query(xmlNode * msg)
         result = add_result(op, host, ndevices, dev);
     }
 
-    if (is_set(op->call_options, st_opt_topology)) {
+    if (pcmk_is_set(op->call_options, st_opt_topology)) {
         /* If we start the fencing before all the topology results are in,
          * it is possible fencing levels will be skipped because of the missing
          * query results. */
@@ -2041,7 +2041,7 @@ process_remote_stonith_exec(xmlNode * msg)
         return rc;
     }
 
-    if (is_set(op->call_options, st_opt_topology)) {
+    if (pcmk_is_set(op->call_options, st_opt_topology)) {
         const char *device = crm_element_value(msg, F_STONITH_DEVICE);
 
         crm_notice("Action '%s' targeting %s using %s on behalf of %s@%s: %s "

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -122,7 +122,7 @@ st_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
     crm_trace("Flags %" X32T "/%u for command %" U32T " from %s",
               flags, call_options, id, pcmk__client_name(c));
 
-    if (is_set(call_options, st_opt_sync_call)) {
+    if (pcmk_is_set(call_options, st_opt_sync_call)) {
         CRM_ASSERT(flags & crm_ipc_client_response);
         CRM_LOG_ASSERT(c->request_id == 0);     /* This means the client has two synchronous events in-flight */
         c->request_id = id;     /* Reply only to the last one */
@@ -301,7 +301,7 @@ stonith_notify_client(gpointer key, gpointer value, gpointer user_data)
         return;
     }
 
-    if (is_set(client->flags, get_stonith_flag(type))) {
+    if (pcmk_is_set(client->flags, get_stonith_flag(type))) {
         int rc = pcmk__ipc_send_xml(client, 0, update_msg,
                                     crm_ipc_server_event|crm_ipc_server_error);
 
@@ -1244,7 +1244,8 @@ struct qb_ipcs_service_handlers ipc_callbacks = {
 static void
 st_peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *data)
 {
-    if ((type != crm_status_processes) && !is_set(node->flags, crm_remote_node)) {
+    if ((type != crm_status_processes)
+        && !pcmk_is_set(node->flags, crm_remote_node)) {
         /*
          * This is a hack until we can send to a nodeid and/or we fix node name lookups
          * These messages are ignored in stonith_peer_callback()

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -14,6 +14,7 @@
 #include <stdbool.h>            // bool
 #include <stdint.h>             // uint8_t, uint64_t
 #include <string.h>             // strcmp()
+#include <fcntl.h>              // open()
 #include <sys/types.h>          // uid_t, gid_t, pid_t
 
 #include <glib.h>               // guint, GList, GHashTable
@@ -277,7 +278,6 @@ GQuark pcmk__exitc_error_quark(void);
 
 #define PCMK__RC_ERROR       pcmk__rc_error_quark()
 #define PCMK__EXITC_ERROR    pcmk__exitc_error_quark()
-
 
 static inline char *
 pcmk__getpid_s(void)

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -83,4 +83,11 @@ pcmk__str_empty(const char *s)
     return (s == NULL) || (s[0] == '\0');
 }
 
+// note this returns const not allocated
+static inline const char *
+pcmk__btoa(bool condition)
+{
+    return condition? "true" : "false";
+}
+
 #endif /* PCMK__STRINGS_INTERNAL__H */

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -160,18 +160,54 @@ int compare_version(const char *version1, const char *version2);
 void crm_abort(const char *file, const char *function, int line,
                const char *condition, gboolean do_core, gboolean do_fork);
 
+/*!
+ * \brief Check whether any of specified flags are set in a flag group
+ *
+ * \param[in] flag_group        The flag group being examined
+ * \param[in] flags_to_check    Which flags in flag_group should be checked
+ *
+ * \return true if any of flags_to_check are set in flag_group
+ */
+static inline bool
+pcmk_any_flags_set(uint64_t flag_group, uint64_t flags_to_check)
+{
+    return (flag_group & flags_to_check) != 0;
+}
+
+/*!
+ * \brief Check whether all of specified flags are set in a flag group
+ *
+ * \param[in] flag_group        The flag group being examined
+ * \param[in] flags_to_check    Which flags in flag_group should be checked
+ *
+ * \return true if all of flags_to_check are set in flag_group
+ */
+static inline bool
+pcmk_all_flags_set(uint64_t flag_group, uint64_t flags_to_check)
+{
+    return (flag_group & flags_to_check) == flags_to_check;
+}
+
+/*!
+ * \brief Convenience alias for pcmk_all_flags_set(), to check single flag
+ */
+#define pcmk_is_set(g, f)   pcmk_all_flags_set((g), (f))
+
+//! \deprecated Use !pcmk_is_set() or !pcmk_all_flags_set() instead
 static inline gboolean
 is_not_set(long long word, long long bit)
 {
     return ((word & bit) == 0);
 }
 
+//! \deprecated Use pcmk_is_set() or pcmk_all_flags_set() instead
 static inline gboolean
 is_set(long long word, long long bit)
 {
     return ((word & bit) == bit);
 }
 
+//! \deprecated Use pcmk_any_flags_set() instead
 static inline gboolean
 is_set_any(long long word, long long bit)
 {

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -193,27 +193,6 @@ pcmk_all_flags_set(uint64_t flag_group, uint64_t flags_to_check)
  */
 #define pcmk_is_set(g, f)   pcmk_all_flags_set((g), (f))
 
-//! \deprecated Use !pcmk_is_set() or !pcmk_all_flags_set() instead
-static inline gboolean
-is_not_set(long long word, long long bit)
-{
-    return ((word & bit) == 0);
-}
-
-//! \deprecated Use pcmk_is_set() or pcmk_all_flags_set() instead
-static inline gboolean
-is_set(long long word, long long bit)
-{
-    return ((word & bit) == bit);
-}
-
-//! \deprecated Use pcmk_any_flags_set() instead
-static inline gboolean
-is_set_any(long long word, long long bit)
-{
-    return ((word & bit) != 0);
-}
-
 static inline guint
 crm_hash_table_size(GHashTable * hashtable)
 {
@@ -250,6 +229,27 @@ bool pcmk_str_is_minus_infinity(const char *s);
 
 //! \deprecated Use crm_parse_interval_spec() instead
 #define crm_get_interval crm_parse_interval_spec
+
+//! \deprecated Use !pcmk_is_set() or !pcmk_all_flags_set() instead
+static inline gboolean
+is_not_set(long long word, long long bit)
+{
+    return ((word & bit) == 0);
+}
+
+//! \deprecated Use pcmk_is_set() or pcmk_all_flags_set() instead
+static inline gboolean
+is_set(long long word, long long bit)
+{
+    return ((word & bit) == bit);
+}
+
+//! \deprecated Use pcmk_any_flags_set() instead
+static inline gboolean
+is_set_any(long long word, long long bit)
+{
+    return ((word & bit) != 0);
+}
 
 //! \deprecated Use pcmk_get_ra_caps() instead
 bool crm_provider_required(const char *standard);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -13,6 +13,7 @@
 #  include <crm/pengine/status.h>
 #  include <crm/pengine/remote_internal.h>
 #  include <crm/common/output.h>
+#  include <crm/common/internal.h>
 
 #  define pe_rsc_info(rsc, fmt, args...)  crm_log_tag(LOG_INFO,  rsc ? rsc->id : "<NULL>", fmt, ##args)
 #  define pe_rsc_debug(rsc, fmt, args...) crm_log_tag(LOG_DEBUG, rsc ? rsc->id : "<NULL>", fmt, ##args)
@@ -237,6 +238,12 @@ void pe__print_bundle(pe_resource_t *rsc, const char *pre_text, long options,
 int pe__name_and_nvpairs_xml(pcmk__output_t *out, bool is_list, const char *tag_name
                          , size_t pairs_count, ...);
 char *pe__node_display_name(pe_node_t *node, bool print_detail);
+
+static inline const char *
+pe__rsc_bool_str(pe_resource_t *rsc, uint64_t rsc_flag)
+{
+    return pcmk__btoa(is_set(rsc->flags, rsc_flag));
+}
 
 int pe__ban_html(pcmk__output_t *out, va_list args);
 int pe__ban_text(pcmk__output_t *out, va_list args);
@@ -556,7 +563,6 @@ void pe__free_param_checks(pe_working_set_t *data_set);
 bool pe__shutdown_requested(pe_node_t *node);
 void pe__update_recheck_time(time_t recheck, pe_working_set_t *data_set);
 
-#define BOOL2STR(x) ((x) ? "true" : "false")
 /*!
  * \internal
  * \brief Register xml formatting message functions.

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -143,7 +143,7 @@ enum pe_warn_once_e {
 extern uint32_t pe_wo;
 
 #define pe_warn_once(pe_wo_bit, fmt...) do {    \
-        if (is_not_set(pe_wo, pe_wo_bit)) {     \
+        if (!pcmk_is_set(pe_wo, pe_wo_bit)) {  \
             if (pe_wo_bit == pe_wo_blind) {     \
                 crm_warn(fmt);                  \
             } else {                            \
@@ -242,7 +242,7 @@ char *pe__node_display_name(pe_node_t *node, bool print_detail);
 static inline const char *
 pe__rsc_bool_str(pe_resource_t *rsc, uint64_t rsc_flag)
 {
-    return pcmk__btoa(is_set(rsc->flags, rsc_flag));
+    return pcmk__btoa(pcmk_is_set(rsc->flags, rsc_flag));
 }
 
 int pe__ban_html(pcmk__output_t *out, va_list args);

--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -70,7 +70,7 @@ pe_rsc_is_clone(pe_resource_t *rsc)
 static inline bool
 pe_rsc_is_unique_clone(pe_resource_t *rsc)
 {
-    return pe_rsc_is_clone(rsc) && is_set(rsc->flags, pe_rsc_unique);
+    return pe_rsc_is_clone(rsc) && pcmk_is_set(rsc->flags, pe_rsc_unique);
 }
 
 /*!
@@ -83,7 +83,7 @@ pe_rsc_is_unique_clone(pe_resource_t *rsc)
 static inline bool
 pe_rsc_is_anon_clone(pe_resource_t *rsc)
 {
-    return pe_rsc_is_clone(rsc) && is_not_set(rsc->flags, pe_rsc_unique);
+    return pe_rsc_is_clone(rsc) && !pcmk_is_set(rsc->flags, pe_rsc_unique);
 }
 
 /*!

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -701,10 +701,10 @@ cib_file_signoff(cib_t * cib)
     cib->type = cib_no_connection;
 
     /* If the in-memory CIB has been changed, write it to disk */
-    if (is_set(private->flags, cib_file_flag_dirty)) {
+    if (pcmk_is_set(private->flags, cib_file_flag_dirty)) {
 
         /* If this is the live CIB, write it out with a digest */
-        if (is_set(private->flags, cib_file_flag_live)) {
+        if (pcmk_is_set(private->flags, cib_file_flag_live)) {
             if (cib_file_write_live(private->filename) < 0) {
                 rc = pcmk_err_generic;
             }

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2004-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2004-2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -583,8 +585,9 @@ cib_process_diff(const char *op, int options, const char *section, xmlNode * req
         originator = crm_element_value(req, F_ORIG);
     }
 
-    crm_trace("Processing \"%s\" event from %s %s",
-              op, originator, is_set(options, cib_force_diff)?"(global update)":"");
+    crm_trace("Processing \"%s\" event from %s%s",
+              op, originator,
+              (pcmk_is_set(options, cib_force_diff)? " (global update)" : ""));
 
     free_xml(*result_cib);
     *result_cib = copy_xml(existing_cib);

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -461,7 +461,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
         }
     }
 
-    crm_trace("Perform validation: %s", (check_schema? "true" : "false"));
+    crm_trace("Perform validation: %s", pcmk__btoa(check_schema));
     if ((rc == pcmk_ok) && check_schema && !validate_xml(scratch, NULL, TRUE)) {
         const char *current_schema = crm_element_value(scratch,
                                                        XML_ATTR_VALIDATION);

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -219,7 +219,9 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
     const char *user = crm_element_value(req, F_CIB_USER);
     bool with_digest = FALSE;
 
-    crm_trace("Begin %s%s%s op", is_set(call_options, cib_dryrun)?"dry-run of ":"", is_query ? "read-only " : "", op);
+    crm_trace("Begin %s%s%s op",
+              (pcmk_is_set(call_options, cib_dryrun)? "dry run of " : ""),
+              (is_query? "read-only " : ""), op);
 
     CRM_CHECK(output != NULL, return -ENOMSG);
     CRM_CHECK(result_cib != NULL, return -ENOMSG);
@@ -276,7 +278,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
     }
 
 
-    if (is_set(call_options, cib_zero_copy)) {
+    if (pcmk_is_set(call_options, cib_zero_copy)) {
         /* Conditional on v2 patch style */
 
         scratch = current_cib;
@@ -359,7 +361,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
     strip_text_nodes(scratch);
     fix_plus_plus_recursive(scratch);
 
-    if (is_set(call_options, cib_zero_copy)) {
+    if (pcmk_is_set(call_options, cib_zero_copy)) {
         /* At this point, current_cib is just the 'cib' tag and its properties,
          *
          * The v1 format would barf on this, but we know the v2 patch
@@ -393,7 +395,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
         crm_log_xml_trace(local_diff, "raw patch");
     }
 
-    if (is_not_set(call_options, cib_zero_copy) /* The original to compare against doesn't exist */
+    if (!pcmk_is_set(call_options, cib_zero_copy) // Original to compare against doesn't exist
         && local_diff
         && crm_is_callsite_active(diff_cs, LOG_TRACE, 0)) {
 
@@ -434,7 +436,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
      };
      */
 
-    if (*config_changed && is_not_set(call_options, cib_no_mtime)) {
+    if (*config_changed && !pcmk_is_set(call_options, cib_no_mtime)) {
         const char *schema = crm_element_value(scratch, XML_ATTR_VALIDATION);
 
         crm_xml_add_last_written(scratch);

--- a/lib/common/agents.c
+++ b/lib/common/agents.c
@@ -114,7 +114,7 @@ crm_parse_agent_spec(const char *spec, char **standard, char **provider,
     *standard = strndup(spec, colon - spec);
     spec = colon + 1;
 
-    if (is_set(pcmk_get_ra_caps(*standard), pcmk_ra_cap_provider)) {
+    if (pcmk_is_set(pcmk_get_ra_caps(*standard), pcmk_ra_cap_provider)) {
         colon = strchr(spec, ':');
         if ((colon == NULL) || (colon == spec)) {
             free(*standard);
@@ -148,5 +148,5 @@ bool crm_provider_required(const char *standard);
 bool
 crm_provider_required(const char *standard)
 {
-    return is_set(pcmk_get_ra_caps(standard), pcmk_ra_cap_provider);
+    return pcmk_is_set(pcmk_get_ra_caps(standard), pcmk_ra_cap_provider);
 }

--- a/lib/common/attrd_client.c
+++ b/lib/common/attrd_client.c
@@ -204,9 +204,9 @@ pcmk__node_attr_request(crm_ipc_t *ipc, char command, const char *host,
     crm_xml_add(update, PCMK__XA_ATTR_NODE_NAME, host);
     crm_xml_add(update, PCMK__XA_ATTR_SET, set);
     crm_xml_add_int(update, PCMK__XA_ATTR_IS_REMOTE,
-                    is_set(options, pcmk__node_attr_remote));
+                    pcmk_is_set(options, pcmk__node_attr_remote));
     crm_xml_add_int(update, PCMK__XA_ATTR_IS_PRIVATE,
-                    is_set(options, pcmk__node_attr_private));
+                    pcmk_is_set(options, pcmk__node_attr_private));
 
     rc = send_attrd_op(ipc, update);
 
@@ -254,7 +254,7 @@ pcmk__node_attr_request_clear(crm_ipc_t *ipc, const char *host,
     crm_xml_add(clear_op, PCMK__XA_ATTR_OPERATION, operation);
     crm_xml_add(clear_op, PCMK__XA_ATTR_INTERVAL, interval_spec);
     crm_xml_add_int(clear_op, PCMK__XA_ATTR_IS_REMOTE,
-                    is_set(options, pcmk__node_attr_remote));
+                    pcmk_is_set(options, pcmk__node_attr_remote));
 
     rc = send_attrd_op(ipc, clear_op);
     free_xml(clear_op);

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1189,7 +1189,7 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
     header = iov[0].iov_base;
     pcmk__set_ipc_flags(header->flags, client->name, flags);
 
-    if(is_set(flags, crm_ipc_proxied)) {
+    if (pcmk_is_set(flags, crm_ipc_proxied)) {
         /* Don't look for a synchronous response */
         pcmk__clear_ipc_flags(flags, "client", crm_ipc_client_response);
     }
@@ -1207,7 +1207,7 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
     crm_trace("Sending %s IPC request %d of %u bytes using %dms timeout",
               client->name, header->qb.id, header->qb.size, ms_timeout);
 
-    if (ms_timeout > 0 || is_not_set(flags, crm_ipc_client_response)) {
+    if ((ms_timeout > 0) || !pcmk_is_set(flags, crm_ipc_client_response)) {
 
         time_t timeout = time(NULL) + 1 + (ms_timeout / 1000);
 
@@ -1226,7 +1226,7 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
         if (qb_rc <= 0) {
             goto send_cleanup;
 
-        } else if (is_not_set(flags, crm_ipc_client_response)) {
+        } else if (!pcmk_is_set(flags, crm_ipc_client_response)) {
             crm_trace("Not waiting for reply to %s IPC request %d",
                       client->name, header->qb.id);
             goto send_cleanup;

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -362,7 +362,7 @@ pcmk__free_client(pcmk__client_t *c)
 bool
 pcmk__set_client_queue_max(pcmk__client_t *client, const char *qmax)
 {
-    if (is_set(client->flags, pcmk__client_privileged)) {
+    if (pcmk_is_set(client->flags, pcmk__client_privileged)) {
         long long qmax_int;
 
         errno = 0;
@@ -416,7 +416,7 @@ pcmk__client_data2xml(pcmk__client_t *c, void *data, uint32_t *id,
         *flags = header->flags;
     }
 
-    if (is_set(header->flags, crm_ipc_proxied)) {
+    if (pcmk_is_set(header->flags, crm_ipc_proxied)) {
         /* Mark this client as being the endpoint of a proxy connection.
          * Proxy connections responses are sent on the event channel, to avoid
          * blocking the controller serving as proxy.
@@ -684,7 +684,7 @@ pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags)
 
     if (c->flags & pcmk__client_proxied) {
         /* _ALL_ replies to proxied connections need to be sent as events */
-        if (is_not_set(flags, crm_ipc_server_event)) {
+        if (!pcmk_is_set(flags, crm_ipc_server_event)) {
             /* The proxied flag lets us know this was originally meant to be a
              * response, even though we're sending it over the event channel.
              */

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -504,7 +504,7 @@ crm_time_as_string(crm_time_t * date_time, int flags)
 
     // Convert to UTC if local timezone was not requested
     if (date_time && date_time->offset
-        && is_not_set(flags, crm_time_log_with_timezone)) {
+        && !pcmk_is_set(flags, crm_time_log_with_timezone)) {
         crm_trace("UTC conversion");
         utc = crm_get_utc_time(date_time);
         dt = utc;

--- a/lib/common/operations.c
+++ b/lib/common/operations.c
@@ -409,7 +409,7 @@ crm_op_needs_metadata(const char *rsc_class, const char *op)
     CRM_CHECK(rsc_class || op, return FALSE);
 
     if (rsc_class
-        && is_not_set(pcmk_get_ra_caps(rsc_class), pcmk_ra_cap_params)) {
+        && !pcmk_is_set(pcmk_get_ra_caps(rsc_class), pcmk_ra_cap_params)) {
         /* Meta-data is only needed for resource classes that use parameters */
         return FALSE;
     }

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -979,9 +979,9 @@ int
 pcmk__strcmp(const char *s1, const char *s2, uint32_t flags)
 {
     /* If this flag is set, the second string is a regex. */
-    if (is_set(flags, pcmk__str_regex)) {
+    if (pcmk_is_set(flags, pcmk__str_regex)) {
         regex_t *r_patt = calloc(1, sizeof(regex_t));
-        int reg_flags = REG_EXTENDED | REG_NOSUB | (is_set(flags, pcmk__str_casei) ? REG_ICASE : 0);
+        int reg_flags = REG_EXTENDED | REG_NOSUB;
         int regcomp_rc = 0;
         int rc = 0;
 
@@ -990,6 +990,9 @@ pcmk__strcmp(const char *s1, const char *s2, uint32_t flags)
             return 1;
         }
 
+        if (pcmk_is_set(flags, pcmk__str_casei)) {
+            reg_flags |= REG_ICASE;
+        }
         regcomp_rc = regcomp(r_patt, s2, reg_flags);
         if (regcomp_rc != 0) {
             rc = 1;
@@ -1016,7 +1019,7 @@ pcmk__strcmp(const char *s1, const char *s2, uint32_t flags)
      * are NULL.  If neither one is NULL, we need to continue and compare
      * them normally.
      */
-    if (is_set(flags, pcmk__str_null_matches)) {
+    if (pcmk_is_set(flags, pcmk__str_null_matches)) {
         if (s1 == NULL || s2 == NULL) {
             return 0;
         }
@@ -1031,7 +1034,7 @@ pcmk__strcmp(const char *s1, const char *s2, uint32_t flags)
         return 1;
     }
 
-    if (is_set(flags, pcmk__str_casei)) {
+    if (pcmk_is_set(flags, pcmk__str_casei)) {
         return strcasecmp(s1, s2);
     } else {
         return strcmp(s1, s2);

--- a/lib/common/tests/flags/Makefile.am
+++ b/lib/common/tests/flags/Makefile.am
@@ -17,7 +17,9 @@ include $(top_srcdir)/mk/glib-tap.mk
 #
 # https://developer.gnome.org/glib/unstable/glib-Testing.html
 test_programs = pcmk__clear_flags_as		\
-		pcmk__set_flags_as
+		pcmk__set_flags_as		\
+		pcmk_all_flags_set		\
+		pcmk_any_flags_set
 
 # If any extra data needs to be added to the source distribution, add it to the
 # following list.

--- a/lib/common/tests/flags/pcmk_all_flags_set.c
+++ b/lib/common/tests/flags/pcmk_all_flags_set.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+static void
+all_set(void) {
+    g_assert(pcmk_all_flags_set(0x000, 0x003) == false);
+    g_assert(pcmk_all_flags_set(0x00f, 0x003) == true);
+    g_assert(pcmk_all_flags_set(0x00f, 0x010) == false);
+    g_assert(pcmk_all_flags_set(0x00f, 0x011) == false);
+}
+
+static void
+one_is_set(void) {
+    // pcmk_is_set() is a simple macro alias for pcmk_all_flags_set()
+    g_assert(pcmk_is_set(0x00f, 0x001) == true);
+    g_assert(pcmk_is_set(0x00f, 0x010) == false);
+}
+
+int
+main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/common/flags/all_set/all_set", all_set);
+    g_test_add_func("/common/flags/all_set/is_set", one_is_set);
+    return g_test_run();
+}

--- a/lib/common/tests/flags/pcmk_any_flags_set.c
+++ b/lib/common/tests/flags/pcmk_any_flags_set.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+static void
+any_set(void) {
+    g_assert(pcmk_any_flags_set(0x000, 0x000) == false);
+    g_assert(pcmk_any_flags_set(0x000, 0x001) == false);
+    g_assert(pcmk_any_flags_set(0x00f, 0x001) == true);
+    g_assert(pcmk_any_flags_set(0x00f, 0x010) == false);
+    g_assert(pcmk_any_flags_set(0x00f, 0x011) == true);
+}
+
+int
+main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/common/flags/any_set/any_set", any_set);
+    return g_test_run();
+}

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -8,8 +8,9 @@ include $(top_srcdir)/mk/glib-tap.mk
 # information.
 #
 # https://developer.gnome.org/glib/unstable/glib-Testing.html
-test_programs = pcmk__scan_double \
-				pcmk__parse_ll_range \
+test_programs =	pcmk__btoa			\
+		pcmk__parse_ll_range		\
+		pcmk__scan_double		\
 				pcmk__str_any_of \
 				pcmk__strcmp \
 				pcmk__char_in_any_str

--- a/lib/common/tests/strings/pcmk__btoa.c
+++ b/lib/common/tests/strings/pcmk__btoa.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+static void
+btoa(void) {
+    g_assert(strcmp(pcmk__btoa(false), "false") == 0);
+    g_assert(strcmp(pcmk__btoa(true), "true") == 0);
+    g_assert(strcmp(pcmk__btoa(1 == 0), "false") == 0);
+}
+
+int
+main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/common/strings/btoa/btoa", btoa);
+    return g_test_run();
+}

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -424,7 +424,7 @@ stonith__validate_agent_xml(pcmk__output_t *out, va_list args) {
     if (device != NULL) {
         xmlSetProp(node, (pcmkXmlStr) "device", (pcmkXmlStr) device);
     }
-    xmlSetProp(node, (pcmkXmlStr) "valid", (pcmkXmlStr) (rc ? "false" : "true"));
+    xmlSetProp(node, (pcmkXmlStr) "valid", (pcmkXmlStr) pcmk__btoa(rc));
 
     pcmk__output_xml_push_parent(out, node);
     out->subprocess_output(out, rc, output, error_output);

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -258,10 +258,11 @@ stonith__rhcs_validate(stonith_t *st, int call_options, const char *target,
             uint32_t device_flags = 0;
 
             stonith__device_parameter_flags(&device_flags, agent, metadata);
-            if (is_set(device_flags, st_device_supports_parameter_port)) {
+            if (pcmk_is_set(device_flags, st_device_supports_parameter_port)) {
                 host_arg = "port";
 
-            } else if (is_set(device_flags, st_device_supports_parameter_plug)) {
+            } else if (pcmk_is_set(device_flags,
+                                   st_device_supports_parameter_plug)) {
                 host_arg = "plug";
             }
         }

--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -144,7 +144,7 @@ exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum pcmk__alert_flags kind,
         lrmd_key_value_t *head = NULL;
         int rc;
 
-        if (is_not_set(entry->flags, kind)) {
+        if (!pcmk_is_set(entry->flags, kind)) {
             crm_trace("Filtering unwanted %s alert to %s via %s",
                       kind_s, entry->recipient, entry->id);
             continue;

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1503,7 +1503,8 @@ lrmd_api_register_rsc(lrmd_t * lrmd,
     if (!class || !type || !rsc_id) {
         return -EINVAL;
     }
-    if (is_set(pcmk_get_ra_caps(class), pcmk_ra_cap_provider) && !provider) {
+    if (pcmk_is_set(pcmk_get_ra_caps(class), pcmk_ra_cap_provider)
+        && (provider == NULL)) {
         return -EINVAL;
     }
 
@@ -1606,7 +1607,7 @@ lrmd_api_get_rsc_info(lrmd_t * lrmd, const char *rsc_id, enum lrmd_call_options 
     if (!class || !type) {
         free_xml(output);
         return NULL;
-    } else if (is_set(pcmk_get_ra_caps(class), pcmk_ra_cap_provider)
+    } else if (pcmk_is_set(pcmk_get_ra_caps(class), pcmk_ra_cap_provider)
                && !provider) {
         free_xml(output);
         return NULL;

--- a/lib/lrmd/proxy_common.c
+++ b/lib/lrmd/proxy_common.c
@@ -253,7 +253,7 @@ remote_proxy_cb(lrmd_t *lrmd, const char *node_name, xmlNode *msg)
         pcmk__update_acl_user(request, F_LRMD_IPC_USER, node_name);
 #endif
 
-        if(is_set(flags, crm_ipc_proxied)) {
+        if (pcmk_is_set(flags, crm_ipc_proxied)) {
             const char *type = crm_element_value(request, F_TYPE);
             int rc = 0;
 

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -70,7 +70,7 @@ migration_threshold_reached(pe_resource_t *rsc, pe_node_t *node,
     }
 
     // If we're ignoring failures, also ignore the migration threshold
-    if (is_set(rsc->flags, pe_rsc_failure_ignored)) {
+    if (pcmk_is_set(rsc->flags, pe_rsc_failure_ignored)) {
         return FALSE;
     }
 
@@ -232,7 +232,7 @@ pcmk__bundle_create_actions(pe_resource_t *rsc, pe_working_set_t *data_set)
     if (bundle_data->child) {
         bundle_data->child->cmds->create_actions(bundle_data->child, data_set);
 
-        if (is_set(bundle_data->child->flags, pe_rsc_promotable)) {
+        if (pcmk_is_set(bundle_data->child->flags, pe_rsc_promotable)) {
             /* promote */
             action = create_pseudo_resource_op(rsc, RSC_PROMOTE, TRUE, TRUE, data_set);
             action = create_pseudo_resource_op(rsc, RSC_PROMOTED, TRUE, TRUE, data_set);
@@ -334,7 +334,7 @@ pcmk__bundle_internal_constraints(pe_resource_t *rsc,
 
     if (bundle_data->child) {
         bundle_data->child->cmds->internal_constraints(bundle_data->child, data_set);
-        if (is_set(bundle_data->child->flags, pe_rsc_promotable)) {
+        if (pcmk_is_set(bundle_data->child->flags, pe_rsc_promotable)) {
             promote_demote_constraints(rsc, data_set);
 
             /* child demoted before global demoted */
@@ -483,7 +483,7 @@ pcmk__bundle_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc,
     if (constraint->score == 0) {
         return;
     }
-    if (is_set(rsc->flags, pe_rsc_provisional)) {
+    if (pcmk_is_set(rsc->flags, pe_rsc_provisional)) {
         pe_rsc_trace(rsc, "%s is still provisional", rsc->id);
         return;
 
@@ -719,7 +719,7 @@ multi_update_interleave_actions(pe_action_t *first, pe_action_t *then,
             }
 
             if (first_action == NULL) {
-                if (is_not_set(first_child->flags, pe_rsc_orphan)
+                if (!pcmk_is_set(first_child->flags, pe_rsc_orphan)
                     && !pcmk__str_any_of(first_task, RSC_STOP, RSC_DEMOTE, NULL)) {
                     crm_err("Internal error: No action found for %s in %s (first)",
                             first_task, first_child->id);
@@ -727,14 +727,14 @@ multi_update_interleave_actions(pe_action_t *first, pe_action_t *then,
                 } else {
                     crm_trace("No action found for %s in %s%s (first)",
                               first_task, first_child->id,
-                              is_set(first_child->flags, pe_rsc_orphan) ? " (ORPHAN)" : "");
+                              pcmk_is_set(first_child->flags, pe_rsc_orphan)? " (ORPHAN)" : "");
                 }
                 continue;
             }
 
             /* We're only interested if 'then' is neither stopping nor being demoted */ 
             if (then_action == NULL) {
-                if (is_not_set(then_child->flags, pe_rsc_orphan)
+                if (!pcmk_is_set(then_child->flags, pe_rsc_orphan)
                     && !pcmk__str_any_of(then->task, RSC_STOP, RSC_DEMOTE, NULL)) {
                     crm_err("Internal error: No action found for %s in %s (then)",
                             then->task, then_child->id);
@@ -742,15 +742,18 @@ multi_update_interleave_actions(pe_action_t *first, pe_action_t *then,
                 } else {
                     crm_trace("No action found for %s in %s%s (then)",
                               then->task, then_child->id,
-                              is_set(then_child->flags, pe_rsc_orphan) ? " (ORPHAN)" : "");
+                              pcmk_is_set(then_child->flags, pe_rsc_orphan)? " (ORPHAN)" : "");
                 }
                 continue;
             }
 
             if (order_actions(first_action, then_action, type)) {
                 crm_debug("Created constraint for %s (%d) -> %s (%d) %.6x",
-                          first_action->uuid, is_set(first_action->flags, pe_action_optional),
-                          then_action->uuid, is_set(then_action->flags, pe_action_optional), type);
+                          first_action->uuid,
+                          pcmk_is_set(first_action->flags, pe_action_optional),
+                          then_action->uuid,
+                          pcmk_is_set(then_action->flags, pe_action_optional),
+                          type);
                 pe__set_graph_flags(changed, first,
                                     pe_graph_updated_first|pe_graph_updated_then);
             }
@@ -838,7 +841,7 @@ pcmk__multi_update_actions(pe_action_t *first, pe_action_t *then,
             if (then_child_action) {
                 enum pe_action_flags then_child_flags = then_child->cmds->action_flags(then_child_action, node);
 
-                if (is_set(then_child_flags, pe_action_runnable)) {
+                if (pcmk_is_set(then_child_flags, pe_action_runnable)) {
                     then_child_changed |= then_child->cmds->update_actions(first,
                         then_child_action, node, flags, filter, type, data_set);
                 }

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -1476,11 +1476,11 @@ clone_append_meta(pe_resource_t * rsc, xmlNode * xml)
     get_clone_variant_data(clone_data, rsc);
 
     name = crm_meta_name(XML_RSC_ATTR_UNIQUE);
-    crm_xml_add(xml, name, is_set(rsc->flags, pe_rsc_unique) ? "true" : "false");
+    crm_xml_add(xml, name, pe__rsc_bool_str(rsc, pe_rsc_unique));
     free(name);
 
     name = crm_meta_name(XML_RSC_ATTR_NOTIFY);
-    crm_xml_add(xml, name, is_set(rsc->flags, pe_rsc_notify) ? "true" : "false");
+    crm_xml_add(xml, name, pe__rsc_bool_str(rsc, pe_rsc_notify));
     free(name);
 
     name = crm_meta_name(XML_RSC_ATTR_INCARNATION_MAX);

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -1236,11 +1236,11 @@ sort_cons_priority_lh(gconstpointer a, gconstpointer b)
      * tests)
      */
     if (rsc_constraint1->rsc_lh->variant == pe_clone) {
-        if (is_set(rsc_constraint1->rsc_lh->flags, pe_rsc_promotable)
-            && is_not_set(rsc_constraint2->rsc_lh->flags, pe_rsc_promotable)) {
+        if (pcmk_is_set(rsc_constraint1->rsc_lh->flags, pe_rsc_promotable)
+            && !pcmk_is_set(rsc_constraint2->rsc_lh->flags, pe_rsc_promotable)) {
             return -1;
-        } else if (is_not_set(rsc_constraint1->rsc_lh->flags, pe_rsc_promotable)
-            && is_set(rsc_constraint2->rsc_lh->flags, pe_rsc_promotable)) {
+        } else if (!pcmk_is_set(rsc_constraint1->rsc_lh->flags, pe_rsc_promotable)
+            && pcmk_is_set(rsc_constraint2->rsc_lh->flags, pe_rsc_promotable)) {
             return 1;
         }
     }
@@ -1284,11 +1284,11 @@ sort_cons_priority_rh(gconstpointer a, gconstpointer b)
      * tests)
      */
     if (rsc_constraint1->rsc_rh->variant == pe_clone) {
-        if (is_set(rsc_constraint1->rsc_rh->flags, pe_rsc_promotable)
-            && is_not_set(rsc_constraint2->rsc_rh->flags, pe_rsc_promotable)) {
+        if (pcmk_is_set(rsc_constraint1->rsc_rh->flags, pe_rsc_promotable)
+            && !pcmk_is_set(rsc_constraint2->rsc_rh->flags, pe_rsc_promotable)) {
             return -1;
-        } else if (is_not_set(rsc_constraint1->rsc_rh->flags, pe_rsc_promotable)
-            && is_set(rsc_constraint2->rsc_rh->flags, pe_rsc_promotable)) {
+        } else if (!pcmk_is_set(rsc_constraint1->rsc_rh->flags, pe_rsc_promotable)
+            && pcmk_is_set(rsc_constraint2->rsc_rh->flags, pe_rsc_promotable)) {
             return 1;
         }
     }
@@ -1459,8 +1459,8 @@ handle_migration_ordering(pe__ordering_t *order, pe_working_set_t *data_set)
         return;
     }
 
-    lh_migratable = is_set(order->lh_rsc->flags, pe_rsc_allow_migrate);
-    rh_migratable = is_set(order->rh_rsc->flags, pe_rsc_allow_migrate);
+    lh_migratable = pcmk_is_set(order->lh_rsc->flags, pe_rsc_allow_migrate);
+    rh_migratable = pcmk_is_set(order->rh_rsc->flags, pe_rsc_allow_migrate);
 
     /* one of them has to be migratable for
      * the migrate ordering logic to be applied */
@@ -2736,7 +2736,7 @@ rsc_ticket_new(const char *id, pe_resource_t * rsc_lh, pe_ticket_t * ticket,
     new_rsc_ticket->role_lh = text2role(state_lh);
 
     if (pcmk__str_eq(loss_policy, "fence", pcmk__str_casei)) {
-        if (is_set(data_set->flags, pe_flag_stonith_enabled)) {
+        if (pcmk_is_set(data_set->flags, pe_flag_stonith_enabled)) {
             new_rsc_ticket->loss_policy = loss_ticket_fence;
         } else {
             pcmk__config_err("Resetting '" XML_TICKET_ATTR_LOSS_POLICY

--- a/lib/pacemaker/pcmk_sched_messages.c
+++ b/lib/pacemaker/pcmk_sched_messages.c
@@ -57,7 +57,7 @@ log_resource_details(pe_working_set_t *data_set)
         pe_resource_t *rsc = (pe_resource_t *) item->data;
 
         // Log all resources except inactive orphans
-        if (is_not_set(rsc->flags, pe_rsc_orphan)
+        if (!pcmk_is_set(rsc->flags, pe_rsc_orphan)
             || (rsc->role != RSC_ROLE_STOPPED)) {
             out->message(out, crm_map_element_name(rsc->xml), 0, rsc, all, all);
         }
@@ -83,9 +83,9 @@ pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input,
 
 /*	pe_debug_on(); */
 
-    CRM_ASSERT(xml_input || is_set(data_set->flags, pe_flag_have_status));
+    CRM_ASSERT(xml_input || pcmk_is_set(data_set->flags, pe_flag_have_status));
 
-    if (is_set(data_set->flags, pe_flag_have_status) == FALSE) {
+    if (!pcmk_is_set(data_set->flags, pe_flag_have_status)) {
         set_working_set_defaults(data_set);
         data_set->input = xml_input;
         data_set->now = now;
@@ -100,14 +100,14 @@ pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input,
 
     crm_trace("Calculate cluster status");
     stage0(data_set);
-    if (is_not_set(data_set->flags, pe_flag_quick_location)) {
+    if (!pcmk_is_set(data_set->flags, pe_flag_quick_location)) {
         log_resource_details(data_set);
     }
 
     crm_trace("Applying placement constraints");
     stage2(data_set);
 
-    if(is_set(data_set->flags, pe_flag_quick_location)){
+    if (pcmk_is_set(data_set->flags, pe_flag_quick_location)) {
         return NULL;
     }
 
@@ -136,9 +136,10 @@ pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input,
         for (; gIter != NULL; gIter = gIter->next) {
             pe_action_t *action = (pe_action_t *) gIter->data;
 
-            if (is_set(action->flags, pe_action_optional) == FALSE
-                && is_set(action->flags, pe_action_runnable) == FALSE
-                && is_set(action->flags, pe_action_pseudo) == FALSE) {
+            if (!pcmk_any_flags_set(action->flags,
+                                    pe_action_optional
+                                    |pe_action_runnable
+                                    |pe_action_pseudo)) {
                 log_action(LOG_TRACE, "\t", action, TRUE);
             }
         }

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -115,7 +115,7 @@ check_promotable_actions(pe_resource_t *rsc, gboolean *demoting,
         if (*promoting && *demoting) {
             return;
 
-        } else if (is_set(action->flags, pe_action_optional)) {
+        } else if (pcmk_is_set(action->flags, pe_action_optional)) {
             continue;
 
         } else if (pcmk__str_eq(RSC_DEMOTE, action->task, pcmk__str_casei)) {
@@ -183,7 +183,7 @@ can_be_master(pe_resource_t * rsc)
         pe_rsc_trace(rsc, "%s cannot be master: not allocated", rsc->id);
         return NULL;
 
-    } else if (is_not_set(rsc->flags, pe_rsc_managed)) {
+    } else if (!pcmk_is_set(rsc->flags, pe_rsc_managed)) {
         if (rsc->fns->state(rsc, TRUE) == RSC_ROLE_MASTER) {
             crm_notice("Forcing unmanaged master %s to remain promoted on %s",
                        rsc->id, node->details->uname);
@@ -209,7 +209,7 @@ can_be_master(pe_resource_t * rsc)
         return NULL;
 
     } else if ((local_node->count < clone_data->promoted_node_max)
-               || is_not_set(rsc->flags, pe_rsc_managed)) {
+               || !pcmk_is_set(rsc->flags, pe_rsc_managed)) {
         return local_node;
 
     } else {
@@ -367,7 +367,8 @@ promotion_order(pe_resource_t *rsc, pe_working_set_t *data_set)
         pe_resource_t *child = (pe_resource_t *) gIter->data;
 
         chosen = child->fns->location(child, NULL, FALSE);
-        if (is_not_set(child->flags, pe_rsc_managed) && child->next_role == RSC_ROLE_MASTER) {
+        if (!pcmk_is_set(child->flags, pe_rsc_managed)
+            && (child->next_role == RSC_ROLE_MASTER)) {
             child->sort_index = INFINITY;
 
         } else if (chosen == NULL || child->sort_index < 0) {
@@ -479,7 +480,9 @@ promotion_score(pe_resource_t *rsc, const pe_node_t *node, int not_set_value)
         return score;
     }
 
-    if (is_not_set(rsc->flags, pe_rsc_unique) && filter_anonymous_instance(rsc, node)) {
+    if (!pcmk_is_set(rsc->flags, pe_rsc_unique)
+        && filter_anonymous_instance(rsc, node)) {
+
         pe_rsc_trace(rsc, "Anonymous clone %s is allowed on %s", rsc->id, node->details->uname);
 
     } else if (rsc->running_on || g_hash_table_size(rsc->known_on)) {
@@ -520,7 +523,7 @@ promotion_score(pe_resource_t *rsc, const pe_node_t *node, int not_set_value)
     pe_rsc_trace(rsc, "promotion score for %s on %s = %s",
                  name, node->details->uname, crm_str(attr_value));
 
-    if ((attr_value == NULL) && is_not_set(rsc->flags, pe_rsc_unique)) {
+    if ((attr_value == NULL) && !pcmk_is_set(rsc->flags, pe_rsc_unique)) {
         /* If we don't have any LRM history yet, we won't have clone_name -- in
          * that case, for anonymous clones, try the resource name without any
          * instance number.
@@ -746,7 +749,7 @@ pcmk__set_instance_roles(pe_resource_t *rsc, pe_working_set_t *data_set)
 
         chosen = child_rsc->fns->location(child_rsc, NULL, FALSE);
         if (show_scores) {
-            if (is_set(data_set->flags, pe_flag_stdout)) {
+            if (pcmk_is_set(data_set->flags, pe_flag_stdout)) {
                 printf("%s promotion score on %s: %s\n",
                        child_rsc->id,
                        (chosen? chosen->details->uname : "none"), score);
@@ -765,7 +768,7 @@ pcmk__set_instance_roles(pe_resource_t *rsc, pe_working_set_t *data_set)
             pe_rsc_trace(rsc, "Not supposed to promote child: %s", child_rsc->id);
 
         } else if ((promoted < clone_data->promoted_max)
-                   || is_not_set(rsc->flags, pe_rsc_managed)) {
+                   || !pcmk_is_set(rsc->flags, pe_rsc_managed)) {
             chosen = can_be_master(child_rsc);
         }
 
@@ -776,7 +779,7 @@ pcmk__set_instance_roles(pe_resource_t *rsc, pe_working_set_t *data_set)
             continue;
 
         } else if(child_rsc->role < RSC_ROLE_MASTER
-              && is_set(data_set->flags, pe_flag_have_quorum) == FALSE
+              && !pcmk_is_set(data_set->flags, pe_flag_have_quorum)
               && data_set->no_quorum_policy == no_quorum_freeze) {
             crm_notice("Resource %s cannot be elevated from %s to %s: no-quorum-policy=freeze",
                        child_rsc->id, role2text(child_rsc->role), role2text(child_rsc->next_role));
@@ -969,7 +972,7 @@ promotable_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
     if (constraint->score == 0) {
         return;
     }
-    if (is_set(rsc_lh->flags, pe_rsc_provisional)) {
+    if (pcmk_is_set(rsc_lh->flags, pe_rsc_provisional)) {
         GListPtr rhs = NULL;
 
         for (gIter = rsc_rh->children; gIter != NULL; gIter = gIter->next) {

--- a/lib/pacemaker/pcmk_sched_transition.c
+++ b/lib/pacemaker/pcmk_sched_transition.c
@@ -284,7 +284,7 @@ inject_resource(xmlNode * cib_node, const char *resource, const char *lrm_name,
         fprintf(stderr, "Invalid class for %s: %s\n", resource, rclass);
         return NULL;
 
-    } else if (is_set(pcmk_get_ra_caps(rclass), pcmk_ra_cap_provider)
+    } else if (pcmk_is_set(pcmk_get_ra_caps(rclass), pcmk_ra_cap_provider)
                 && (rprovider == NULL)) {
         fprintf(stderr, "Please specify the provider for resource %s\n", resource);
         return NULL;

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -166,7 +166,7 @@ have_enough_capacity(pe_node_t * node, const char * rsc_id, GHashTable * utiliza
 static void
 native_add_unallocated_utilization(GHashTable * all_utilization, pe_resource_t * rsc)
 {
-    if(is_set(rsc->flags, pe_rsc_provisional) == FALSE) {
+    if (!pcmk_is_set(rsc->flags, pe_rsc_provisional)) {
         return;
     }
 
@@ -177,7 +177,7 @@ static void
 add_unallocated_utilization(GHashTable * all_utilization, pe_resource_t * rsc,
                     GListPtr all_rscs, pe_resource_t * orig_rsc)
 {
-    if(is_set(rsc->flags, pe_rsc_provisional) == FALSE) {
+    if (!pcmk_is_set(rsc->flags, pe_rsc_provisional)) {
         return;
     }
 
@@ -247,7 +247,7 @@ sum_unallocated_utilization(pe_resource_t * rsc, GListPtr colocated_rscs)
     for (gIter = all_rscs; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *listed_rsc = (pe_resource_t *) gIter->data;
 
-        if(is_set(listed_rsc->flags, pe_rsc_provisional) == FALSE) {
+        if (!pcmk_is_set(listed_rsc->flags, pe_rsc_provisional)) {
             continue;
         }
 
@@ -453,7 +453,7 @@ group_add_unallocated_utilization(GHashTable * all_utilization, pe_resource_t * 
         for (; gIter != NULL; gIter = gIter->next) {
             pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
-            if (is_set(child_rsc->flags, pe_rsc_provisional) &&
+            if (pcmk_is_set(child_rsc->flags, pe_rsc_provisional) &&
                 g_list_find(all_rscs, child_rsc) == FALSE) {
                 native_add_unallocated_utilization(all_utilization, child_rsc);
             }
@@ -461,7 +461,7 @@ group_add_unallocated_utilization(GHashTable * all_utilization, pe_resource_t * 
 
     } else {
         if (group_data->first_child &&
-            is_set(group_data->first_child->flags, pe_rsc_provisional) &&
+            pcmk_is_set(group_data->first_child->flags, pe_rsc_provisional) &&
             g_list_find(all_rscs, group_data->first_child) == FALSE) {
             native_add_unallocated_utilization(all_utilization, group_data->first_child);
         }

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1551,13 +1551,13 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
         if (!printed_header) {
             printed_header = TRUE;
 
-            rc = pe__name_and_nvpairs_xml(out, true, "bundle", 6
-                         , "id", rsc->id
-                         , "type", container_agent_str(bundle_data->agent_type)
-                         , "image", bundle_data->image
-                         , "unique", BOOL2STR(is_set(rsc->flags, pe_rsc_unique))
-                         , "managed", BOOL2STR(is_set(rsc->flags, pe_rsc_managed))
-                         , "failed", BOOL2STR(is_set(rsc->flags, pe_rsc_failed)));
+            rc = pe__name_and_nvpairs_xml(out, true, "bundle", 6,
+                     "id", rsc->id,
+                     "type", container_agent_str(bundle_data->agent_type),
+                     "image", bundle_data->image,
+                     "unique", pe__rsc_bool_str(rsc, pe_rsc_unique),
+                     "managed", pe__rsc_bool_str(rsc, pe_rsc_managed),
+                     "failed", pe__rsc_bool_str(rsc, pe_rsc_failed));
             CRM_ASSERT(rc == pcmk_rc_ok);
         }
 

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1198,8 +1198,7 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
         free(value);
 
         crm_create_nvpair_xml(xml_set, NULL, XML_RSC_ATTR_UNIQUE,
-                (bundle_data->nreplicas_per_host > 1)?
-                XML_BOOLEAN_TRUE : XML_BOOLEAN_FALSE);
+                              pcmk__btoa(bundle_data->nreplicas_per_host > 1));
 
         if (bundle_data->promoted_max) {
             crm_create_nvpair_xml(xml_set, NULL,
@@ -1479,9 +1478,9 @@ bundle_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
     status_print("id=\"%s\" ", rsc->id);
     status_print("type=\"%s\" ", container_agent_str(bundle_data->agent_type));
     status_print("image=\"%s\" ", bundle_data->image);
-    status_print("unique=\"%s\" ", is_set(rsc->flags, pe_rsc_unique)? "true" : "false");
-    status_print("managed=\"%s\" ", is_set(rsc->flags, pe_rsc_managed) ? "true" : "false");
-    status_print("failed=\"%s\" ", is_set(rsc->flags, pe_rsc_failed) ? "true" : "false");
+    status_print("unique=\"%s\" ", pe__rsc_bool_str(rsc, pe_rsc_unique));
+    status_print("managed=\"%s\" ", pe__rsc_bool_str(rsc, pe_rsc_managed));
+    status_print("failed=\"%s\" ", pe__rsc_bool_str(rsc, pe_rsc_failed));
     status_print(">\n");
 
     for (GList *gIter = bundle_data->replicas; gIter != NULL;

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -228,7 +228,7 @@ create_docker_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
         for(GListPtr pIter = data->mounts; pIter != NULL; pIter = pIter->next) {
             pe__bundle_mount_t *mount = pIter->data;
 
-            if (is_set(mount->flags, pe__bundle_mount_subdir)) {
+            if (pcmk_is_set(mount->flags, pe__bundle_mount_subdir)) {
                 char *source = crm_strdup_printf(
                     "%s/%s-%d", mount->source, data->prefix, replica->offset);
 
@@ -396,7 +396,7 @@ create_podman_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
         for(GListPtr pIter = data->mounts; pIter != NULL; pIter = pIter->next) {
             pe__bundle_mount_t *mount = pIter->data;
 
-            if (is_set(mount->flags, pe__bundle_mount_subdir)) {
+            if (pcmk_is_set(mount->flags, pe__bundle_mount_subdir)) {
                 char *source = crm_strdup_printf(
                     "%s/%s-%d", mount->source, data->prefix, replica->offset);
 
@@ -562,7 +562,7 @@ create_rkt_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
         for(GListPtr pIter = data->mounts; pIter != NULL; pIter = pIter->next) {
             pe__bundle_mount_t *mount = pIter->data;
 
-            if (is_set(mount->flags, pe__bundle_mount_subdir)) {
+            if (pcmk_is_set(mount->flags, pe__bundle_mount_subdir)) {
                 char *source = crm_strdup_printf(
                     "%s/%s-%d", mount->source, data->prefix, replica->offset);
 
@@ -1295,7 +1295,7 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
             replica->offset = lpc++;
 
             // Ensure the child's notify gets set based on the underlying primitive's value
-            if (is_set(replica->child->flags, pe_rsc_notify)) {
+            if (pcmk_is_set(replica->child->flags, pe_rsc_notify)) {
                 pe__set_resource_flags(bundle_data->child, pe_rsc_notify);
             }
 
@@ -1665,12 +1665,16 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
         print_remote = replica->remote != NULL &&
                        !replica->remote->fns->is_filtered(replica->remote, only_rsc, print_everything);
 
-        if (is_set(options, pe_print_implicit) ||
+        if (pcmk_is_set(options, pe_print_implicit) ||
             (print_everything == FALSE && (print_ip || print_child || print_ctnr || print_remote))) {
             /* The text output messages used below require pe_print_implicit to
              * be set to do anything.
              */
-            unsigned int new_options = is_set(options, pe_print_implicit) ? options : options | pe_print_implicit;
+            unsigned int new_options = options;
+
+            if (!pcmk_is_set(options, pe_print_implicit)) {
+                new_options |= pe_print_implicit;
+            }
 
             if (rc == pcmk_rc_no_output) {
                 pcmk__output_create_xml_node(out, "br");
@@ -1679,8 +1683,8 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
             PCMK__OUTPUT_LIST_HEADER(out, FALSE, rc, "Container bundle%s: %s [%s]%s%s",
                                      (bundle_data->nreplicas > 1)? " set" : "",
                                      rsc->id, bundle_data->image,
-                                     is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
-                                     is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
+                                     pcmk_is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
+                                     pcmk_is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
 
             pcmk__output_xml_create_parent(out, "li");
 
@@ -1718,8 +1722,8 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
             PCMK__OUTPUT_LIST_HEADER(out, FALSE, rc, "Container bundle%s: %s [%s]%s%s",
                                      (bundle_data->nreplicas > 1)? " set" : "",
                                      rsc->id, bundle_data->image,
-                                     is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
-                                     is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
+                                     pcmk_is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
+                                     pcmk_is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
 
             pe__bundle_replica_output_html(out, replica, pe__current_node(replica->container),
                                            options);
@@ -1802,18 +1806,21 @@ pe__bundle_text(pcmk__output_t *out, va_list args)
         print_remote = replica->remote != NULL &&
                        !replica->remote->fns->is_filtered(replica->remote, only_rsc, print_everything);
 
-        if (is_set(options, pe_print_implicit) ||
+        if (pcmk_is_set(options, pe_print_implicit) ||
             (print_everything == FALSE && (print_ip || print_child || print_ctnr || print_remote))) {
             /* The text output messages used below require pe_print_implicit to
              * be set to do anything.
              */
-            unsigned int new_options = is_set(options, pe_print_implicit) ? options : options | pe_print_implicit;
+            unsigned int new_options = options;
 
+            if (!pcmk_is_set(options, pe_print_implicit)) {
+                new_options |= pe_print_implicit;
+            }
             PCMK__OUTPUT_LIST_HEADER(out, FALSE, rc, "Container bundle%s: %s [%s]%s%s",
                                      (bundle_data->nreplicas > 1)? " set" : "",
                                      rsc->id, bundle_data->image,
-                                     is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
-                                     is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
+                                     pcmk_is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
+                                     pcmk_is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
 
             if (pcmk__list_of_multiple(bundle_data->replicas)) {
                 out->list_item(out, NULL, "Replica[%d]", replica->offset);
@@ -1848,8 +1855,8 @@ pe__bundle_text(pcmk__output_t *out, va_list args)
             PCMK__OUTPUT_LIST_HEADER(out, FALSE, rc, "Container bundle%s: %s [%s]%s%s",
                                      (bundle_data->nreplicas > 1)? " set" : "",
                                      rsc->id, bundle_data->image,
-                                     is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
-                                     is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
+                                     pcmk_is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
+                                     pcmk_is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
 
             pe__bundle_replica_output_text(out, replica, pe__current_node(replica->container),
                                            options);
@@ -1912,8 +1919,8 @@ pe__print_bundle(pe_resource_t *rsc, const char *pre_text, long options,
     status_print("%sContainer bundle%s: %s [%s]%s%s\n",
                  pre_text, ((bundle_data->nreplicas > 1)? " set" : ""),
                  rsc->id, bundle_data->image,
-                 is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
-                 is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
+                 pcmk_is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
+                 pcmk_is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
     if (options & pe_print_html) {
         status_print("<br />\n<ul>\n");
     }
@@ -1928,7 +1935,7 @@ pe__print_bundle(pe_resource_t *rsc, const char *pre_text, long options,
             status_print("<li>");
         }
 
-        if (is_set(options, pe_print_implicit)) {
+        if (pcmk_is_set(options, pe_print_implicit)) {
             child_text = crm_strdup_printf("     %s", pre_text);
             if (pcmk__list_of_multiple(bundle_data->replicas)) {
                 status_print("  %sReplica[%d]\n", pre_text, replica->offset);

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -124,7 +124,7 @@ clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
     clone_data = calloc(1, sizeof(clone_variant_data_t));
     rsc->variant_opaque = clone_data;
 
-    if (is_set(rsc->flags, pe_rsc_promotable)) {
+    if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
         const char *promoted_max = NULL;
         const char *promoted_node_max = NULL;
 
@@ -340,7 +340,7 @@ bool is_set_recursive(pe_resource_t * rsc, long long flag, bool any)
     GListPtr gIter;
     bool all = !any;
 
-    if(is_set(rsc->flags, flag)) {
+    if (pcmk_is_set(rsc->flags, flag)) {
         if(any) {
             return TRUE;
         }
@@ -394,9 +394,9 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
 
     status_print("%sClone Set: %s [%s]%s%s%s",
                  pre_text ? pre_text : "", rsc->id, ID(clone_data->xml_obj_child),
-                 is_set(rsc->flags, pe_rsc_promotable) ? " (promotable)" : "",
-                 is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
-                 is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
+                 pcmk_is_set(rsc->flags, pe_rsc_promotable)? " (promotable)" : "",
+                 pcmk_is_set(rsc->flags, pe_rsc_unique)? " (unique)" : "",
+                 pcmk_is_set(rsc->flags, pe_rsc_managed)? "" : " (unmanaged)");
 
     if (options & pe_print_html) {
         status_print("\n<ul>\n");
@@ -414,15 +414,15 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
             print_full = TRUE;
         }
 
-        if (is_set(rsc->flags, pe_rsc_unique)) {
+        if (pcmk_is_set(rsc->flags, pe_rsc_unique)) {
             // Print individual instance when unique (except stopped orphans)
-            if (partially_active || is_not_set(rsc->flags, pe_rsc_orphan)) {
+            if (partially_active || !pcmk_is_set(rsc->flags, pe_rsc_orphan)) {
                 print_full = TRUE;
             }
 
         // Everything else in this block is for anonymous clones
 
-        } else if (is_set(options, pe_print_pending)
+        } else if (pcmk_is_set(options, pe_print_pending)
                    && (child_rsc->pending_task != NULL)
                    && strcmp(child_rsc->pending_task, "probe")) {
             // Print individual instance when non-probe action is pending
@@ -430,8 +430,8 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
 
         } else if (partially_active == FALSE) {
             // List stopped instances when requested (except orphans)
-            if (is_not_set(child_rsc->flags, pe_rsc_orphan)
-                && is_not_set(options, pe_print_clone_active)) {
+            if (!pcmk_is_set(child_rsc->flags, pe_rsc_orphan)
+                && !pcmk_is_set(options, pe_print_clone_active)) {
                 stopped_list = pcmk__add_word(stopped_list, child_rsc->id);
             }
 
@@ -506,7 +506,7 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
 	active_instances++;
     }
 
-    if (is_set(rsc->flags, pe_rsc_promotable)) {
+    if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
         enum rsc_role_e role = configured_role(rsc);
 
         if(role == RSC_ROLE_SLAVE) {
@@ -523,7 +523,7 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
     free(list_text);
     list_text = NULL;
 
-    if (is_not_set(options, pe_print_clone_active)) {
+    if (!pcmk_is_set(options, pe_print_clone_active)) {
         const char *state = "Stopped";
         enum rsc_role_e role = configured_role(rsc);
 
@@ -531,7 +531,7 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
             state = "Stopped (disabled)";
         }
 
-        if (is_not_set(rsc->flags, pe_rsc_unique)
+        if (!pcmk_is_set(rsc->flags, pe_rsc_unique)
             && (clone_data->clone_max > active_instances)) {
 
             GListPtr nIter;
@@ -659,9 +659,9 @@ pe__clone_html(pcmk__output_t *out, va_list args)
 
     out->begin_list(out, NULL, NULL, "Clone Set: %s [%s]%s%s%s",
                     rsc->id, ID(clone_data->xml_obj_child),
-                    is_set(rsc->flags, pe_rsc_promotable) ? " (promotable)" : "",
-                    is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
-                    is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
+                    pcmk_is_set(rsc->flags, pe_rsc_promotable) ? " (promotable)" : "",
+                    pcmk_is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
+                    pcmk_is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
     rc = pcmk_rc_ok;
 
     for (; gIter != NULL; gIter = gIter->next) {
@@ -681,15 +681,15 @@ pe__clone_html(pcmk__output_t *out, va_list args)
             print_full = TRUE;
         }
 
-        if (is_set(rsc->flags, pe_rsc_unique)) {
+        if (pcmk_is_set(rsc->flags, pe_rsc_unique)) {
             // Print individual instance when unique (except stopped orphans)
-            if (partially_active || is_not_set(rsc->flags, pe_rsc_orphan)) {
+            if (partially_active || !pcmk_is_set(rsc->flags, pe_rsc_orphan)) {
                 print_full = TRUE;
             }
 
         // Everything else in this block is for anonymous clones
 
-        } else if (is_set(options, pe_print_pending)
+        } else if (pcmk_is_set(options, pe_print_pending)
                    && (child_rsc->pending_task != NULL)
                    && strcmp(child_rsc->pending_task, "probe")) {
             // Print individual instance when non-probe action is pending
@@ -697,8 +697,8 @@ pe__clone_html(pcmk__output_t *out, va_list args)
 
         } else if (partially_active == FALSE) {
             // List stopped instances when requested (except orphans)
-            if (is_not_set(child_rsc->flags, pe_rsc_orphan)
-                && is_not_set(options, pe_print_clone_active)) {
+            if (!pcmk_is_set(child_rsc->flags, pe_rsc_orphan)
+                && !pcmk_is_set(options, pe_print_clone_active)) {
                 stopped_list = pcmk__add_word(stopped_list, child_rsc->id);
             }
 
@@ -750,7 +750,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
         }
     }
 
-    if (is_set(options, pe_print_clone_details)) {
+    if (pcmk_is_set(options, pe_print_clone_details)) {
         free(stopped_list);
         out->end_list(out);
         return pcmk_rc_ok;
@@ -790,7 +790,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
     }
 
     if (list_text != NULL) {
-        if (is_set(rsc->flags, pe_rsc_promotable)) {
+        if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
             enum rsc_role_e role = configured_role(rsc);
 
             if(role == RSC_ROLE_SLAVE) {
@@ -808,7 +808,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
         list_text = NULL;
     }
 
-    if (is_not_set(options, pe_print_clone_active)) {
+    if (!pcmk_is_set(options, pe_print_clone_active)) {
         const char *state = "Stopped";
         enum rsc_role_e role = configured_role(rsc);
 
@@ -816,7 +816,7 @@ pe__clone_html(pcmk__output_t *out, va_list args)
             state = "Stopped (disabled)";
         }
 
-        if (is_not_set(rsc->flags, pe_rsc_unique)
+        if (!pcmk_is_set(rsc->flags, pe_rsc_unique)
             && (clone_data->clone_max > active_instances)) {
 
             GListPtr nIter;
@@ -889,9 +889,9 @@ pe__clone_text(pcmk__output_t *out, va_list args)
 
     out->begin_list(out, NULL, NULL, "Clone Set: %s [%s]%s%s%s",
                     rsc->id, ID(clone_data->xml_obj_child),
-                    is_set(rsc->flags, pe_rsc_promotable) ? " (promotable)" : "",
-                    is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
-                    is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
+                    pcmk_is_set(rsc->flags, pe_rsc_promotable) ? " (promotable)" : "",
+                    pcmk_is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
+                    pcmk_is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)");
     rc = pcmk_rc_ok;
 
     for (; gIter != NULL; gIter = gIter->next) {
@@ -911,15 +911,15 @@ pe__clone_text(pcmk__output_t *out, va_list args)
             print_full = TRUE;
         }
 
-        if (is_set(rsc->flags, pe_rsc_unique)) {
+        if (pcmk_is_set(rsc->flags, pe_rsc_unique)) {
             // Print individual instance when unique (except stopped orphans)
-            if (partially_active || is_not_set(rsc->flags, pe_rsc_orphan)) {
+            if (partially_active || !pcmk_is_set(rsc->flags, pe_rsc_orphan)) {
                 print_full = TRUE;
             }
 
         // Everything else in this block is for anonymous clones
 
-        } else if (is_set(options, pe_print_pending)
+        } else if (pcmk_is_set(options, pe_print_pending)
                    && (child_rsc->pending_task != NULL)
                    && strcmp(child_rsc->pending_task, "probe")) {
             // Print individual instance when non-probe action is pending
@@ -927,8 +927,8 @@ pe__clone_text(pcmk__output_t *out, va_list args)
 
         } else if (partially_active == FALSE) {
             // List stopped instances when requested (except orphans)
-            if (is_not_set(child_rsc->flags, pe_rsc_orphan)
-                && is_not_set(options, pe_print_clone_active)) {
+            if (!pcmk_is_set(child_rsc->flags, pe_rsc_orphan)
+                && !pcmk_is_set(options, pe_print_clone_active)) {
                 stopped_list = pcmk__add_word(stopped_list, child_rsc->id);
             }
 
@@ -980,7 +980,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
         }
     }
 
-    if (is_set(options, pe_print_clone_details)) {
+    if (pcmk_is_set(options, pe_print_clone_details)) {
         free(stopped_list);
         out->end_list(out);
         return pcmk_rc_ok;
@@ -1020,7 +1020,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
     }
 
     if (list_text != NULL) {
-        if (is_set(rsc->flags, pe_rsc_promotable)) {
+        if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
             enum rsc_role_e role = configured_role(rsc);
 
             if(role == RSC_ROLE_SLAVE) {
@@ -1037,7 +1037,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
         list_text = NULL;
     }
 
-    if (is_not_set(options, pe_print_clone_active)) {
+    if (!pcmk_is_set(options, pe_print_clone_active)) {
         const char *state = "Stopped";
         enum rsc_role_e role = configured_role(rsc);
 
@@ -1045,7 +1045,7 @@ pe__clone_text(pcmk__output_t *out, va_list args)
             state = "Stopped (disabled)";
         }
 
-        if (is_not_set(rsc->flags, pe_rsc_unique)
+        if (!pcmk_is_set(rsc->flags, pe_rsc_unique)
             && (clone_data->clone_max > active_instances)) {
 
             GListPtr nIter;

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -604,15 +604,14 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
         if (!printed_header) {
             printed_header = TRUE;
 
-            rc = pe__name_and_nvpairs_xml(out, true, "clone", 7
-                     , "id", rsc->id
-                     , "multi_state", BOOL2STR(is_set(rsc->flags, pe_rsc_promotable))
-                     , "unique", BOOL2STR(is_set(rsc->flags, pe_rsc_unique))
-                     , "managed", BOOL2STR(is_set(rsc->flags, pe_rsc_managed))
-                     , "failed", BOOL2STR(is_set(rsc->flags, pe_rsc_failed))
-                     , "failure_ignored", BOOL2STR(is_set(rsc->flags, pe_rsc_failure_ignored))
-                     , "target_role", configured_role_str(rsc));
-
+            rc = pe__name_and_nvpairs_xml(out, true, "clone", 7,
+                    "id", rsc->id,
+                    "multi_state", pe__rsc_bool_str(rsc, pe_rsc_promotable),
+                    "unique", pe__rsc_bool_str(rsc, pe_rsc_unique),
+                    "managed", pe__rsc_bool_str(rsc, pe_rsc_managed),
+                    "failed", pe__rsc_bool_str(rsc, pe_rsc_failed),
+                    "failure_ignored", pe__rsc_bool_str(rsc, pe_rsc_failure_ignored),
+                    "target_role", configured_role_str(rsc));
             CRM_ASSERT(rc == pcmk_rc_ok);
         }
 

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -176,9 +176,9 @@ clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
     pe_rsc_trace(rsc, "\tClone max: %d", clone_data->clone_max);
     pe_rsc_trace(rsc, "\tClone node max: %d", clone_data->clone_node_max);
     pe_rsc_trace(rsc, "\tClone is unique: %s",
-                 is_set(rsc->flags, pe_rsc_unique) ? "true" : "false");
+                 pe__rsc_bool_str(rsc, pe_rsc_unique));
     pe_rsc_trace(rsc, "\tClone is promotable: %s",
-                 is_set(rsc->flags, pe_rsc_promotable) ? "true" : "false");
+                 pe__rsc_bool_str(rsc, pe_rsc_promotable));
 
     // Clones may contain a single group or primitive
     for (a_child = __xml_first_child_element(xml_obj); a_child != NULL;
@@ -209,7 +209,7 @@ clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
      * inherit when being unpacked, as well as in resource agents' environment.
      */
     add_hash_param(rsc->meta, XML_RSC_ATTR_UNIQUE,
-                   is_set(rsc->flags, pe_rsc_unique) ? XML_BOOLEAN_TRUE : XML_BOOLEAN_FALSE);
+                   pe__rsc_bool_str(rsc, pe_rsc_unique));
 
     if (clone_data->clone_max <= 0) {
         /* Create one child instance so that unpack_find_resource() will hook up
@@ -313,12 +313,13 @@ clone_print_xml(pe_resource_t * rsc, const char *pre_text, long options, void *p
 
     status_print("%s<clone ", pre_text);
     status_print("id=\"%s\" ", rsc->id);
-    status_print("multi_state=\"%s\" ", is_set(rsc->flags, pe_rsc_promotable)? "true" : "false");
-    status_print("unique=\"%s\" ", is_set(rsc->flags, pe_rsc_unique) ? "true" : "false");
-    status_print("managed=\"%s\" ", is_set(rsc->flags, pe_rsc_managed) ? "true" : "false");
-    status_print("failed=\"%s\" ", is_set(rsc->flags, pe_rsc_failed) ? "true" : "false");
+    status_print("multi_state=\"%s\" ",
+                 pe__rsc_bool_str(rsc, pe_rsc_promotable));
+    status_print("unique=\"%s\" ", pe__rsc_bool_str(rsc, pe_rsc_unique));
+    status_print("managed=\"%s\" ", pe__rsc_bool_str(rsc, pe_rsc_managed));
+    status_print("failed=\"%s\" ", pe__rsc_bool_str(rsc, pe_rsc_failed));
     status_print("failure_ignored=\"%s\" ",
-                 is_set(rsc->flags, pe_rsc_failure_ignored) ? "true" : "false");
+                 pe__rsc_bool_str(rsc, pe_rsc_failure_ignored));
     if (target_role) {
         status_print("target_role=\"%s\" ", target_role);
     }

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -178,7 +178,7 @@ rsc_fail_name(pe_resource_t *rsc)
 {
     const char *name = (rsc->clone_name? rsc->clone_name : rsc->id);
 
-    return is_set(rsc->flags, pe_rsc_unique)? strdup(name) : clone_strip(name);
+    return pcmk_is_set(rsc->flags, pe_rsc_unique)? strdup(name) : clone_strip(name);
 }
 
 /*!
@@ -239,10 +239,10 @@ generate_fail_regexes(pe_resource_t *rsc, pe_working_set_t *data_set,
     gboolean is_legacy = (compare_version(version, "3.0.13") < 0);
 
     generate_fail_regex(PCMK__FAIL_COUNT_PREFIX, rsc_name, is_legacy,
-                        is_set(rsc->flags, pe_rsc_unique), failcount_re);
+                        pcmk_is_set(rsc->flags, pe_rsc_unique), failcount_re);
 
     generate_fail_regex(PCMK__LAST_FAILURE_PREFIX, rsc_name, is_legacy,
-                        is_set(rsc->flags, pe_rsc_unique), lastfailure_re);
+                        pcmk_is_set(rsc->flags, pe_rsc_unique), lastfailure_re);
 
     free(rsc_name);
 }
@@ -287,7 +287,7 @@ pe_get_failcount(pe_node_t *node, pe_resource_t *rsc, time_t *last_failure,
     }
 
     /* If all failures have expired, ignore fail count */
-    if (is_set(flags, pe_fc_effective) && (failcount > 0) && (last > 0)
+    if (pcmk_is_set(flags, pe_fc_effective) && (failcount > 0) && (last > 0)
         && rsc->failure_timeout) {
 
         time_t now = get_effective_time(data_set);
@@ -309,7 +309,7 @@ pe_get_failcount(pe_node_t *node, pe_resource_t *rsc, time_t *last_failure,
      * container on the wrong node.
      */
 
-    if (is_set(flags, pe_fc_fillers) && rsc->fillers
+    if (pcmk_is_set(flags, pe_fc_fillers) && rsc->fillers
         && !pe_rsc_is_bundled(rsc)) {
 
         GListPtr gIter = NULL;

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -491,13 +491,13 @@ native_print_xml(pe_resource_t * rsc, const char *pre_text, long options, void *
     if (target_role) {
         status_print("target_role=\"%s\" ", target_role);
     }
-    status_print("active=\"%s\" ", rsc->fns->active(rsc, TRUE) ? "true" : "false");
-    status_print("orphaned=\"%s\" ", is_set(rsc->flags, pe_rsc_orphan) ? "true" : "false");
-    status_print("blocked=\"%s\" ", is_set(rsc->flags, pe_rsc_block) ? "true" : "false");
-    status_print("managed=\"%s\" ", is_set(rsc->flags, pe_rsc_managed) ? "true" : "false");
-    status_print("failed=\"%s\" ", is_set(rsc->flags, pe_rsc_failed) ? "true" : "false");
+    status_print("active=\"%s\" ", pcmk__btoa(rsc->fns->active(rsc, TRUE)));
+    status_print("orphaned=\"%s\" ", pe__rsc_bool_str(rsc, pe_rsc_orphan));
+    status_print("blocked=\"%s\" ", pe__rsc_bool_str(rsc, pe_rsc_block));
+    status_print("managed=\"%s\" ", pe__rsc_bool_str(rsc, pe_rsc_managed));
+    status_print("failed=\"%s\" ", pe__rsc_bool_str(rsc, pe_rsc_failed));
     status_print("failure_ignored=\"%s\" ",
-                 is_set(rsc->flags, pe_rsc_failure_ignored) ? "true" : "false");
+                 pe__rsc_bool_str(rsc, pe_rsc_failure_ignored));
     status_print("nodes_running_on=\"%d\" ", g_list_length(rsc->running_on));
 
     if (options & pe_print_pending) {
@@ -510,8 +510,8 @@ native_print_xml(pe_resource_t * rsc, const char *pre_text, long options, void *
 
     if (options & pe_print_dev) {
         status_print("provisional=\"%s\" ",
-                     is_set(rsc->flags, pe_rsc_provisional) ? "true" : "false");
-        status_print("runnable=\"%s\" ", is_set(rsc->flags, pe_rsc_runnable) ? "true" : "false");
+                     pe__rsc_bool_str(rsc, pe_rsc_provisional));
+        status_print("runnable=\"%s\" ", pe__rsc_bool_str(rsc, pe_rsc_runnable));
         status_print("priority=\"%f\" ", (double)rsc->priority);
         status_print("variant=\"%s\" ", crm_element_name(rsc->xml));
     }
@@ -529,7 +529,7 @@ native_print_xml(pe_resource_t * rsc, const char *pre_text, long options, void *
 
             status_print("%s    <node name=\"%s\" id=\"%s\" cached=\"%s\"/>\n", pre_text,
                          node->details->uname, node->details->id,
-                         node->details->online ? "false" : "true");
+                         pcmk__btoa(node->details->online == FALSE));
         }
         status_print("%s</resource>\n", pre_text);
     } else {

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -1058,6 +1058,11 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
     char *nodes_running_on = NULL;
     char *priority = NULL;
     int rc = pcmk_rc_no_output;
+    const char *target_role = NULL;
+
+    if (rsc->meta != NULL) {
+       target_role = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_TARGET_ROLE);
+    }
 
     CRM_ASSERT(rsc->variant == pe_native);
 
@@ -1072,23 +1077,23 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
     nodes_running_on = crm_itoa(g_list_length(rsc->running_on));
     priority = crm_ftoa(rsc->priority);
 
-    rc = pe__name_and_nvpairs_xml(out, true, "resource", 16
-                 , "id", rsc_printable_id(rsc)
-                 , "resource_agent", ra_name
-                 , "role", rsc_state
-                 , "target_role", (rsc->meta ? g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_TARGET_ROLE) : NULL)
-                 , "active", BOOL2STR(rsc->fns->active(rsc, TRUE))
-                 , "orphaned", BOOL2STR(is_set(rsc->flags, pe_rsc_orphan))
-                 , "blocked", BOOL2STR(is_set(rsc->flags, pe_rsc_block))
-                 , "managed", BOOL2STR(is_set(rsc->flags, pe_rsc_managed))
-                 , "failed", BOOL2STR(is_set(rsc->flags, pe_rsc_failed))
-                 , "failure_ignored", BOOL2STR(is_set(rsc->flags, pe_rsc_failure_ignored))
-                 , "nodes_running_on", nodes_running_on
-                 , "pending", (is_print_pending ? native_pending_task(rsc) : NULL)
-                 , "provisional", (is_print_dev ? BOOL2STR(is_set(rsc->flags, pe_rsc_provisional)) : NULL)
-                 , "runnable", (is_print_dev ? BOOL2STR(is_set(rsc->flags, pe_rsc_runnable)) : NULL)
-                 , "priority", (is_print_dev ? priority : NULL)
-                 , "variant", (is_print_dev ? crm_element_name(rsc->xml) : NULL));
+    rc = pe__name_and_nvpairs_xml(out, true, "resource", 16,
+             "id", rsc_printable_id(rsc),
+             "resource_agent", ra_name,
+             "role", rsc_state,
+             "target_role", target_role,
+             "active", pcmk__btoa(rsc->fns->active(rsc, TRUE)),
+             "orphaned", pe__rsc_bool_str(rsc, pe_rsc_orphan),
+             "blocked", pe__rsc_bool_str(rsc, pe_rsc_block),
+             "managed", pe__rsc_bool_str(rsc, pe_rsc_managed),
+             "failed", pe__rsc_bool_str(rsc, pe_rsc_failed),
+             "failure_ignored", pe__rsc_bool_str(rsc, pe_rsc_failure_ignored),
+             "nodes_running_on", nodes_running_on,
+             "pending", (is_print_pending? native_pending_task(rsc) : NULL),
+             "provisional", (is_print_dev? pe__rsc_bool_str(rsc, pe_rsc_provisional) : NULL),
+             "runnable", (is_print_dev? pe__rsc_bool_str(rsc, pe_rsc_runnable) : NULL),
+             "priority", (is_print_dev? priority : NULL),
+             "variant", (is_print_dev? crm_element_name(rsc->xml) : NULL));
     free(priority);
     free(nodes_running_on);
 
@@ -1100,10 +1105,10 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
         for (; gIter != NULL; gIter = gIter->next) {
             pe_node_t *node = (pe_node_t *) gIter->data;
 
-            rc = pe__name_and_nvpairs_xml(out, false, "node", 3
-                                          , "name", node->details->uname
-                                          , "id", node->details->id
-                                          , "cached", BOOL2STR(node->details->online));
+            rc = pe__name_and_nvpairs_xml(out, false, "node", 3,
+                     "name", node->details->uname,
+                     "id", node->details->id,
+                     "cached", pcmk__btoa(node->details->online));
             CRM_ASSERT(rc == pcmk_rc_ok);
         }
     }

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -263,7 +263,7 @@ pe__cluster_summary(pcmk__output_t *out, va_list args) {
 
     PCMK__OUTPUT_LIST_FOOTER(out, rc);
 
-    if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
+    if (pcmk_is_set(data_set->flags, pe_flag_maintenance_mode)) {
         out->message(out, "maint-mode");
         rc = pcmk_rc_ok;
     }
@@ -336,7 +336,7 @@ pe__cluster_summary_html(pcmk__output_t *out, va_list args) {
 
     PCMK__OUTPUT_LIST_FOOTER(out, rc);
 
-    if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
+    if (pcmk_is_set(data_set->flags, pe_flag_maintenance_mode)) {
         out->message(out, "maint-mode");
         rc = pcmk_rc_ok;
     }
@@ -703,10 +703,10 @@ pe__cluster_options_html(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
 
     out->list_item(out, NULL, "STONITH of failed nodes %s",
-                   is_set(data_set->flags, pe_flag_stonith_enabled) ? "enabled" : "disabled");
+                   pcmk_is_set(data_set->flags, pe_flag_stonith_enabled) ? "enabled" : "disabled");
 
     out->list_item(out, NULL, "Cluster is %s",
-                   is_set(data_set->flags, pe_flag_symmetric_cluster) ? "symmetric" : "asymmetric");
+                   pcmk_is_set(data_set->flags, pe_flag_symmetric_cluster) ? "symmetric" : "asymmetric");
 
     switch (data_set->no_quorum_policy) {
         case no_quorum_freeze:
@@ -731,7 +731,7 @@ pe__cluster_options_html(pcmk__output_t *out, va_list args) {
             break;
     }
 
-    if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
+    if (pcmk_is_set(data_set->flags, pe_flag_maintenance_mode)) {
         xmlNodePtr node = pcmk__output_create_xml_node(out, "li");
 
         pcmk_create_html_node(node, "span", NULL, NULL, "Resource management: ");
@@ -750,7 +750,7 @@ int
 pe__cluster_options_log(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
 
-    if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
+    if (pcmk_is_set(data_set->flags, pe_flag_maintenance_mode)) {
         out->info(out, "Resource management is DISABLED.  The cluster will not attempt to start, stop or recover services.");
         return pcmk_rc_ok;
     } else {
@@ -764,10 +764,10 @@ pe__cluster_options_text(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
 
     out->list_item(out, NULL, "STONITH of failed nodes %s",
-                   is_set(data_set->flags, pe_flag_stonith_enabled) ? "enabled" : "disabled");
+                   pcmk_is_set(data_set->flags, pe_flag_stonith_enabled) ? "enabled" : "disabled");
 
     out->list_item(out, NULL, "Cluster is %s",
-                   is_set(data_set->flags, pe_flag_symmetric_cluster) ? "symmetric" : "asymmetric");
+                   pcmk_is_set(data_set->flags, pe_flag_symmetric_cluster) ? "symmetric" : "asymmetric");
 
     switch (data_set->no_quorum_policy) {
         case no_quorum_freeze:
@@ -802,9 +802,9 @@ pe__cluster_options_xml(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
 
     xmlSetProp(node, (pcmkXmlStr) "stonith-enabled",
-               (pcmkXmlStr) pcmk__btoa(is_set(data_set->flags, pe_flag_stonith_enabled)));
+               (pcmkXmlStr) pcmk__btoa(pcmk_is_set(data_set->flags, pe_flag_stonith_enabled)));
     xmlSetProp(node, (pcmkXmlStr) "symmetric-cluster",
-               (pcmkXmlStr) pcmk__btoa(is_set(data_set->flags, pe_flag_symmetric_cluster)));
+               (pcmkXmlStr) pcmk__btoa(pcmk_is_set(data_set->flags, pe_flag_symmetric_cluster)));
 
     switch (data_set->no_quorum_policy) {
         case no_quorum_freeze:
@@ -829,7 +829,7 @@ pe__cluster_options_xml(pcmk__output_t *out, va_list args) {
     }
 
     xmlSetProp(node, (pcmkXmlStr) "maintenance-mode",
-               (pcmkXmlStr) pcmk__btoa(is_set(data_set->flags, pe_flag_maintenance_mode)));
+               (pcmkXmlStr) pcmk__btoa(pcmk_is_set(data_set->flags, pe_flag_maintenance_mode)));
 
     return pcmk_rc_ok;
 }

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -479,7 +479,7 @@ pe__ban_xml(pcmk__output_t *out, va_list args) {
     xmlSetProp(node, (pcmkXmlStr) "node", (pcmkXmlStr) pe_node->details->uname);
     xmlSetProp(node, (pcmkXmlStr) "weight", (pcmkXmlStr) weight_s);
     xmlSetProp(node, (pcmkXmlStr) "master_only",
-               (pcmkXmlStr) (location->role_filter == RSC_ROLE_MASTER ? "true" : "false"));
+               (pcmkXmlStr) pcmk__btoa(location->role_filter == RSC_ROLE_MASTER));
 
     free(weight_s);
     return pcmk_rc_ok;
@@ -679,7 +679,8 @@ pe__cluster_dc_xml(pcmk__output_t *out, va_list args) {
         xmlSetProp(node, (pcmkXmlStr) "version", (pcmkXmlStr) (dc_version_s ? dc_version_s : ""));
         xmlSetProp(node, (pcmkXmlStr) "name", (pcmkXmlStr) dc->details->uname);
         xmlSetProp(node, (pcmkXmlStr) "id", (pcmkXmlStr) dc->details->id);
-        xmlSetProp(node, (pcmkXmlStr) "with_quorum", (pcmkXmlStr) (crm_is_true(quorum) ? "true" : "false"));
+        xmlSetProp(node, (pcmkXmlStr) "with_quorum",
+                   (pcmkXmlStr) pcmk__btoa(crm_is_true(quorum)));
     } else {
         xmlSetProp(node, (pcmkXmlStr) "present", (pcmkXmlStr) "false");
     }
@@ -801,9 +802,9 @@ pe__cluster_options_xml(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
 
     xmlSetProp(node, (pcmkXmlStr) "stonith-enabled",
-               (pcmkXmlStr) (is_set(data_set->flags, pe_flag_stonith_enabled) ? "true" : "false"));
+               (pcmkXmlStr) pcmk__btoa(is_set(data_set->flags, pe_flag_stonith_enabled)));
     xmlSetProp(node, (pcmkXmlStr) "symmetric-cluster",
-               (pcmkXmlStr) (is_set(data_set->flags, pe_flag_symmetric_cluster) ? "true" : "false"));
+               (pcmkXmlStr) pcmk__btoa(is_set(data_set->flags, pe_flag_symmetric_cluster)));
 
     switch (data_set->no_quorum_policy) {
         case no_quorum_freeze:
@@ -828,7 +829,7 @@ pe__cluster_options_xml(pcmk__output_t *out, va_list args) {
     }
 
     xmlSetProp(node, (pcmkXmlStr) "maintenance-mode",
-               (pcmkXmlStr) (is_set(data_set->flags, pe_flag_maintenance_mode) ? "true" : "false"));
+               (pcmkXmlStr) pcmk__btoa(is_set(data_set->flags, pe_flag_maintenance_mode)));
 
     return pcmk_rc_ok;
 }
@@ -1167,15 +1168,15 @@ pe__node_xml(pcmk__output_t *out, va_list args) {
         pe__name_and_nvpairs_xml(out, true, "node", 13,
                                  "name", node->details->uname,
                                  "id", node->details->id,
-                                 "online", node->details->online ? "true" : "false",
-                                 "standby", node->details->standby ? "true" : "false",
-                                 "standby_onfail", node->details->standby_onfail ? "true" : "false",
-                                 "maintenance", node->details->maintenance ? "true" : "false",
-                                 "pending", node->details->pending ? "true" : "false",
-                                 "unclean", node->details->unclean ? "true" : "false",
-                                 "shutdown", node->details->shutdown ? "true" : "false",
-                                 "expected_up", node->details->expected_up ? "true" : "false",
-                                 "is_dc", node->details->is_dc ? "true" : "false",
+                                 "online", pcmk__btoa(node->details->online),
+                                 "standby", pcmk__btoa(node->details->standby),
+                                 "standby_onfail", pcmk__btoa(node->details->standby_onfail),
+                                 "maintenance", pcmk__btoa(node->details->maintenance),
+                                 "pending", pcmk__btoa(node->details->pending),
+                                 "unclean", pcmk__btoa(node->details->unclean),
+                                 "shutdown", pcmk__btoa(node->details->shutdown),
+                                 "expected_up", pcmk__btoa(node->details->expected_up),
+                                 "is_dc", pcmk__btoa(node->details->is_dc),
                                  "resources_running", length_s,
                                  "type", node_type);
 
@@ -1672,7 +1673,8 @@ pe__ticket_xml(pcmk__output_t *out, va_list args) {
     node = pcmk__output_create_xml_node(out, "ticket");
     xmlSetProp(node, (pcmkXmlStr) "id", (pcmkXmlStr) ticket->id);
     xmlSetProp(node, (pcmkXmlStr) "status", (pcmkXmlStr) (ticket->granted ? "granted" : "revoked"));
-    xmlSetProp(node, (pcmkXmlStr) "standby", (pcmkXmlStr) (ticket->standby ? "true" : "false"));
+    xmlSetProp(node, (pcmkXmlStr) "standby",
+               (pcmkXmlStr) pcmk__btoa(ticket->standby));
 
     if (ticket->last_granted > -1) {
         xmlSetProp(node, (pcmkXmlStr) "last-granted",

--- a/lib/pengine/remote.c
+++ b/lib/pengine/remote.c
@@ -83,7 +83,9 @@ pe_resource_t *
 pe__resource_contains_guest_node(const pe_working_set_t *data_set,
                                  const pe_resource_t *rsc)
 {
-    if (rsc && data_set && is_set(data_set->flags, pe_flag_have_remote_nodes)) {
+    if ((rsc != NULL) && (data_set != NULL)
+        && pcmk_is_set(data_set->flags, pe_flag_have_remote_nodes)) {
+
         for (GList *gIter = rsc->fillers; gIter != NULL; gIter = gIter->next) {
             pe_resource_t *filler = gIter->data;
 
@@ -125,7 +127,7 @@ pe_foreach_guest_node(const pe_working_set_t *data_set, const pe_node_t *host,
     GListPtr iter;
 
     CRM_CHECK(data_set && host && host->details && helper, return);
-    if (!is_set(data_set->flags, pe_flag_have_remote_nodes)) {
+    if (!pcmk_is_set(data_set->flags, pe_flag_have_remote_nodes)) {
         return;
     }
     for (iter = host->details->running_rsc; iter != NULL; iter = iter->next) {

--- a/lib/pengine/rules_alerts.c
+++ b/lib/pengine/rules_alerts.c
@@ -146,11 +146,11 @@ unpack_alert_filter(xmlNode *basenode, pcmk__alert_t *entry)
         entry->flags = flags;
         crm_debug("Alert %s receives events: attributes:%s%s%s%s",
                   entry->id,
-                  (is_set(flags, pcmk__alert_attribute)?
+                  (pcmk_is_set(flags, pcmk__alert_attribute)?
                    (entry->select_attribute_name? "some" : "all") : "none"),
-                  (is_set(flags, pcmk__alert_fencing)? " fencing" : ""),
-                  (is_set(flags, pcmk__alert_node)? " nodes" : ""),
-                  (is_set(flags, pcmk__alert_resource)? " resources" : ""));
+                  (pcmk_is_set(flags, pcmk__alert_fencing)? " fencing" : ""),
+                  (pcmk_is_set(flags, pcmk__alert_node)? " nodes" : ""),
+                  (pcmk_is_set(flags, pcmk__alert_resource)? " resources" : ""));
     }
 }
 

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -108,26 +108,26 @@ cluster_status(pe_working_set_t * data_set)
 
     unpack_config(config, data_set);
 
-   if (is_not_set(data_set->flags, pe_flag_quick_location)
-       && is_not_set(data_set->flags, pe_flag_have_quorum)
-       && data_set->no_quorum_policy != no_quorum_ignore) {
+   if (!pcmk_any_flags_set(data_set->flags,
+                           pe_flag_quick_location|pe_flag_have_quorum)
+       && (data_set->no_quorum_policy != no_quorum_ignore)) {
         crm_warn("Fencing and resource management disabled due to lack of quorum");
     }
 
     unpack_nodes(cib_nodes, data_set);
 
-    if(is_not_set(data_set->flags, pe_flag_quick_location)) {
+    if (!pcmk_is_set(data_set->flags, pe_flag_quick_location)) {
         unpack_remote_nodes(cib_resources, data_set);
     }
 
     unpack_resources(cib_resources, data_set);
     unpack_tags(cib_tags, data_set);
 
-    if(is_not_set(data_set->flags, pe_flag_quick_location)) {
+    if (!pcmk_is_set(data_set->flags, pe_flag_quick_location)) {
         unpack_status(cib_status, data_set);
     }
 
-    if (is_not_set(data_set->flags, pe_flag_no_counts)) {
+    if (!pcmk_is_set(data_set->flags, pe_flag_no_counts)) {
         for (GList *item = data_set->resources; item != NULL;
              item = item->next) {
             ((pe_resource_t *) (item->data))->fns->count(item->data);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -251,7 +251,7 @@ unpack_config(xmlNode * config, pe_working_set_t * data_set)
 
     set_config_flag(data_set, "stop-all-resources", pe_flag_stop_everything);
     crm_debug("Stop all active resources: %s",
-              is_set(data_set->flags, pe_flag_stop_everything) ? "true" : "false");
+              pcmk__btoa(is_set(data_set->flags, pe_flag_stop_everything)));
 
     set_config_flag(data_set, "symmetric-cluster", pe_flag_symmetric_cluster);
     if (is_set(data_set->flags, pe_flag_symmetric_cluster)) {
@@ -320,11 +320,11 @@ unpack_config(xmlNode * config, pe_working_set_t * data_set)
 
     set_config_flag(data_set, "remove-after-stop", pe_flag_remove_after_stop);
     crm_trace("Stopped resources are removed from the status section: %s",
-              is_set(data_set->flags, pe_flag_remove_after_stop) ? "true" : "false");
+              pcmk__btoa(is_set(data_set->flags, pe_flag_remove_after_stop)));
 
     set_config_flag(data_set, "maintenance-mode", pe_flag_maintenance_mode);
     crm_trace("Maintenance mode: %s",
-              is_set(data_set->flags, pe_flag_maintenance_mode) ? "true" : "false");
+              pcmk__btoa(is_set(data_set->flags, pe_flag_maintenance_mode)));
 
     set_config_flag(data_set, "start-failure-is-fatal", pe_flag_start_failure_fatal);
     crm_trace("Start failures are %s",
@@ -2990,7 +2990,7 @@ unpack_rsc_op_failure(pe_resource_t * rsc, pe_node_t * node, int rc, xmlNode * x
 
     pe_rsc_trace(rsc, "Resource %s: role=%s, unclean=%s, on_fail=%s, fail_role=%s",
                  rsc->id, role2text(rsc->role),
-                 node->details->unclean ? "true" : "false",
+                 pcmk__btoa(node->details->unclean),
                  fail2text(action->on_fail), role2text(action->fail_role));
 
     if (action->fail_role != RSC_ROLE_STARTED && rsc->next_role < action->fail_role) {

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -27,13 +27,23 @@
 
 CRM_TRACE_INIT_DATA(pe_status);
 
+/* This uses pcmk__set_flags_as()/pcmk__clear_flags_as() directly rather than
+ * use pe__set_working_set_flags()/pe__clear_working_set_flags() so that the
+ * flag is stringified more readably in log messages.
+ */
 #define set_config_flag(data_set, option, flag) do {                        \
         const char *scf_value = pe_pref((data_set)->config_hash, (option)); \
         if (scf_value != NULL) {                                            \
             if (crm_is_true(scf_value)) {                                   \
-                pe__set_working_set_flags((data_set), (flag));              \
+                (data_set)->flags = pcmk__set_flags_as(__func__, __LINE__,  \
+                                    LOG_TRACE, "Working set",               \
+                                    crm_system_name, (data_set)->flags,     \
+                                    (flag), #flag);                         \
             } else {                                                        \
-                pe__clear_working_set_flags((data_set), (flag));            \
+                (data_set)->flags = pcmk__clear_flags_as(__func__, __LINE__,\
+                                    LOG_TRACE, "Working set",               \
+                                    crm_system_name, (data_set)->flags,     \
+                                    (flag), #flag);                         \
             }                                                               \
         }                                                                   \
     } while(0)

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -186,7 +186,8 @@ resources_action_create(const char *name, const char *standard,
     }
     ra_caps = pcmk_get_ra_caps(standard);
 
-    if (is_set(ra_caps, pcmk_ra_cap_provider) && pcmk__str_empty(provider)) {
+    if (pcmk_is_set(ra_caps, pcmk_ra_cap_provider)
+        && pcmk__str_empty(provider)) {
         crm_err("Cannot create operation for %s without provider", name);
         goto return_error;
     }
@@ -216,17 +217,19 @@ resources_action_create(const char *name, const char *standard,
     op->flags = flags;
     op->id = pcmk__op_key(name, action, interval_ms);
 
-    if (is_set(ra_caps, pcmk_ra_cap_status) && pcmk__str_eq(action, "monitor", pcmk__str_casei)) {
+    if (pcmk_is_set(ra_caps, pcmk_ra_cap_status)
+        && pcmk__str_eq(action, "monitor", pcmk__str_casei)) {
+
         op->action = strdup("status");
     } else {
         op->action = strdup(action);
     }
 
-    if (is_set(ra_caps, pcmk_ra_cap_provider)) {
+    if (pcmk_is_set(ra_caps, pcmk_ra_cap_provider)) {
         op->provider = strdup(provider);
     }
 
-    if (is_set(ra_caps, pcmk_ra_cap_params)) {
+    if (pcmk_is_set(ra_caps, pcmk_ra_cap_params)) {
         op->params = params;
         params = NULL; // so we don't free them in this function
     }
@@ -756,7 +759,7 @@ services_action_async_fork_notify(svc_action_t * op,
         g_hash_table_replace(recurring_actions, op->id, op);
     }
 
-    if (is_not_set(op->flags, SVC_ACTION_NON_BLOCKED)
+    if (!pcmk_is_set(op->flags, SVC_ACTION_NON_BLOCKED)
         && op->rsc && is_op_blocked(op->rsc)) {
         blocked_ops = g_list_append(blocked_ops, op);
         return TRUE;
@@ -954,7 +957,7 @@ resources_list_standards(void)
 GList *
 resources_list_providers(const char *standard)
 {
-    if (is_set(pcmk_get_ra_caps(standard), pcmk_ra_cap_provider)) {
+    if (pcmk_is_set(pcmk_get_ra_caps(standard), pcmk_ra_cap_provider)) {
         return resources_os_list_ocf_providers();
     }
 
@@ -1040,7 +1043,7 @@ resources_agent_exists(const char *standard, const char *provider, const char *a
 
     rc = FALSE;
 
-    has_providers = is_set(pcmk_get_ra_caps(standard), pcmk_ra_cap_provider);
+    has_providers = pcmk_is_set(pcmk_get_ra_caps(standard), pcmk_ra_cap_provider);
     if (has_providers == TRUE && provider != NULL) {
         providers = resources_list_providers(standard);
         for (iter = providers; iter != NULL; iter = iter->next) {

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -923,7 +923,7 @@ services_os_action_execute(svc_action_t * op)
         return FALSE;
     }
 
-    if (is_set(pcmk_get_ra_caps(op->standard), pcmk_ra_cap_stdin)) {
+    if (pcmk_is_set(pcmk_get_ra_caps(op->standard), pcmk_ra_cap_stdin)) {
         if (pipe(stdin_fd) < 0) {
             rc = errno;
 

--- a/maint/mocked/based-notifyfenced.c
+++ b/maint/mocked/based-notifyfenced.c
@@ -63,8 +63,8 @@ mock_based_cib_notify_send_one(pcmk__client_t *client, xmlNode *xml)
 
     type = crm_element_value(update.msg, F_SUBTYPE);
     CRM_LOG_ASSERT(type != NULL);
-    if (is_set(client->options, cib_notify_diff)
-            && pcmk__str_eq(type, T_CIB_DIFF_NOTIFY, pcmk__str_casei)) {
+    if (pcmk_is_set(client->options, cib_notify_diff)
+        && pcmk__str_eq(type, T_CIB_DIFF_NOTIFY, pcmk__str_casei)) {
 
         if (pcmk__ipc_send_iov(client, update.iov,
                                crm_ipc_server_event) != pcmk_rc_ok) {

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -779,15 +779,17 @@ cib_connect(gboolean full)
         need_pass = FALSE;
     }
 
-    if (is_set(options.mon_ops, mon_op_fence_connect) && st == NULL) {
+    if (pcmk_is_set(options.mon_ops, mon_op_fence_connect) && (st == NULL)) {
         st = stonith_api_new();
     }
 
-    if (is_set(options.mon_ops, mon_op_fence_connect) && st != NULL && st->state == stonith_disconnected) {
+    if (pcmk_is_set(options.mon_ops, mon_op_fence_connect)
+        && (st != NULL) && (st->state == stonith_disconnected)) {
+
         rc = st->cmds->connect(st, crm_system_name, NULL);
         if (rc == pcmk_ok) {
             crm_trace("Setting up stonith callbacks");
-            if (is_set(options.mon_ops, mon_op_watch_fencing)) {
+            if (pcmk_is_set(options.mon_ops, mon_op_watch_fencing)) {
                 st->cmds->register_notification(st, T_STONITH_NOTIFY_DISCONNECT,
                                                 mon_st_callback_event);
                 st->cmds->register_notification(st, T_STONITH_NOTIFY_FENCE, mon_st_callback_event);
@@ -884,7 +886,7 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
 
         switch (c) {
             case 'm':
-                if (is_not_set(show, mon_show_fencing_all)) {
+                if (!pcmk_is_set(show, mon_show_fencing_all)) {
                     options.mon_ops |= mon_op_fence_history;
                     options.mon_ops |= mon_op_fence_connect;
                     if (st == NULL) {
@@ -892,8 +894,10 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
                     }
                 }
 
-                if (is_set(show, mon_show_fence_failed) || is_set(show, mon_show_fence_pending) ||
-                    is_set(show, mon_show_fence_worked)) {
+                if (pcmk_any_flags_set(show,
+                                       mon_show_fence_failed
+                                       |mon_show_fence_pending
+                                       |mon_show_fence_worked)) {
                     show &= ~mon_show_fencing_all;
                 } else {
                     show |= mon_show_fencing_all;
@@ -911,7 +915,7 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
                 break;
             case 'o':
                 show ^= mon_show_operations;
-                if (is_not_set(show, mon_show_operations)) {
+                if (!pcmk_is_set(show, mon_show_operations)) {
                     options.mon_ops &= ~mon_op_print_timing;
                 }
                 break;
@@ -923,7 +927,7 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
                 break;
             case 't':
                 options.mon_ops ^= mon_op_print_timing;
-                if (is_set(options.mon_ops, mon_op_print_timing)) {
+                if (pcmk_is_set(options.mon_ops, mon_op_print_timing)) {
                     show |= mon_show_operations;
                 }
                 break;
@@ -935,8 +939,11 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
                 break;
             case 'D':
                 /* If any header is shown, clear them all, otherwise set them all */
-                if (is_set(show, mon_show_stack) || is_set(show, mon_show_dc) ||
-                    is_set(show, mon_show_times) || is_set(show, mon_show_counts)) {
+                if (pcmk_any_flags_set(show,
+                                       mon_show_stack
+                                       |mon_show_dc
+                                       |mon_show_times
+                                       |mon_show_counts)) {
                     show &= ~mon_show_summary;
                 } else {
                     show |= mon_show_summary;
@@ -963,19 +970,19 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
         blank_screen();
 
         out->info(out, "%s", "Display option change mode\n");
-        print_option_help(out, 'c', is_set(show, mon_show_tickets));
-        print_option_help(out, 'f', is_set(show, mon_show_failcounts));
-        print_option_help(out, 'n', is_set(options.mon_ops, mon_op_group_by_node));
-        print_option_help(out, 'o', is_set(show, mon_show_operations));
-        print_option_help(out, 'r', is_set(options.mon_ops, mon_op_inactive_resources));
-        print_option_help(out, 't', is_set(options.mon_ops, mon_op_print_timing));
-        print_option_help(out, 'A', is_set(show, mon_show_attributes));
-        print_option_help(out, 'L', is_set(show,mon_show_bans));
-        print_option_help(out, 'D', is_not_set(show, mon_show_summary));
-        print_option_help(out, 'R', is_set(options.mon_ops, mon_op_print_clone_detail));
-        print_option_help(out, 'b', is_set(options.mon_ops, mon_op_print_brief));
-        print_option_help(out, 'j', is_set(options.mon_ops, mon_op_print_pending));
-        print_option_help(out, 'm', is_set(show, mon_show_fencing_all));
+        print_option_help(out, 'c', pcmk_is_set(show, mon_show_tickets));
+        print_option_help(out, 'f', pcmk_is_set(show, mon_show_failcounts));
+        print_option_help(out, 'n', pcmk_is_set(options.mon_ops, mon_op_group_by_node));
+        print_option_help(out, 'o', pcmk_is_set(show, mon_show_operations));
+        print_option_help(out, 'r', pcmk_is_set(options.mon_ops, mon_op_inactive_resources));
+        print_option_help(out, 't', pcmk_is_set(options.mon_ops, mon_op_print_timing));
+        print_option_help(out, 'A', pcmk_is_set(show, mon_show_attributes));
+        print_option_help(out, 'L', pcmk_is_set(show,mon_show_bans));
+        print_option_help(out, 'D', !pcmk_is_set(show, mon_show_summary));
+        print_option_help(out, 'R', pcmk_is_set(options.mon_ops, mon_op_print_clone_detail));
+        print_option_help(out, 'b', pcmk_is_set(options.mon_ops, mon_op_print_brief));
+        print_option_help(out, 'j', pcmk_is_set(options.mon_ops, mon_op_print_pending));
+        print_option_help(out, 'm', pcmk_is_set(show, mon_show_fencing_all));
         out->info(out, "%s", "\nToggle fields via field letter, type any other key to return");
     }
 
@@ -1124,7 +1131,7 @@ reconcile_output_format(pcmk__common_args_t *args) {
         args->output_ty = strdup("xml");
         output_format = mon_output_xml;
         options.mon_ops |= mon_op_one_shot;
-    } else if (is_set(options.mon_ops, mon_op_one_shot)) {
+    } else if (pcmk_is_set(options.mon_ops, mon_op_one_shot)) {
         if (args->output_ty != NULL) {
             free(args->output_ty);
         }
@@ -1196,7 +1203,7 @@ main(int argc, char **argv)
             include_exclude_cb("--exclude", "times", NULL, NULL);
         }
 
-        if (is_set(options.mon_ops, mon_op_watch_fencing)) {
+        if (pcmk_is_set(options.mon_ops, mon_op_watch_fencing)) {
             fence_history_cb("--fence-history", "0", NULL, NULL);
             options.mon_ops |= mon_op_fence_connect;
         }
@@ -1240,7 +1247,7 @@ main(int argc, char **argv)
             }
         }
 
-        if (is_set(options.mon_ops, mon_op_one_shot)) {
+        if (pcmk_is_set(options.mon_ops, mon_op_one_shot)) {
             if (output_format == mon_output_console) {
                 output_format = mon_output_plain;
             }
@@ -1363,12 +1370,12 @@ main(int argc, char **argv)
     if (cib) {
 
         do {
-            if (is_not_set(options.mon_ops, mon_op_one_shot)) {
+            if (!pcmk_is_set(options.mon_ops, mon_op_one_shot)) {
                 print_as(output_format ,"Waiting until cluster is available on this node ...\n");
             }
-            rc = cib_connect(is_not_set(options.mon_ops, mon_op_one_shot));
+            rc = cib_connect(!pcmk_is_set(options.mon_ops, mon_op_one_shot));
 
-            if (is_set(options.mon_ops, mon_op_one_shot)) {
+            if (pcmk_is_set(options.mon_ops, mon_op_one_shot)) {
                 break;
 
             } else if (rc != pcmk_ok) {
@@ -1403,7 +1410,7 @@ main(int argc, char **argv)
         return clean_up(crm_errno2exit(rc));
     }
 
-    if (is_set(options.mon_ops, mon_op_one_shot)) {
+    if (pcmk_is_set(options.mon_ops, mon_op_one_shot)) {
         return clean_up(CRM_EX_OK);
     }
 
@@ -1482,7 +1489,7 @@ print_simple_status(pcmk__output_t *out, pe_working_set_t * data_set,
         }
     }
 
-    if (is_set(mon_ops, mon_op_has_warnings)) {
+    if (pcmk_is_set(mon_ops, mon_op_has_warnings)) {
         out->info(out, "CLUSTER WARN:%s%s%s",
                   no_dc ? " No DC" : "",
                   no_dc && offline ? "," : "",
@@ -1937,7 +1944,7 @@ mon_refresh_display(gpointer user_data)
 
     /* get the stonith-history if there is evidence we need it
      */
-    while (is_set(options.mon_ops, mon_op_fence_history)) {
+    while (pcmk_is_set(options.mon_ops, mon_op_fence_history)) {
         if (st != NULL) {
             history_rc = st->cmds->history(st, st_opt_sync_call, NULL, &stonith_history, 120);
 
@@ -1946,7 +1953,9 @@ mon_refresh_display(gpointer user_data)
                 mon_cib_connection_destroy_error(NULL);
             } else {
                 stonith_history = stonith__sort_history(stonith_history);
-                if (is_not_set(options.mon_ops, mon_op_fence_full_history) && output_format != mon_output_xml) {
+                if (!pcmk_is_set(options.mon_ops, mon_op_fence_full_history)
+                    && (output_format != mon_output_xml)) {
+
                     stonith_history = reduce_stonith_history(stonith_history);
                 }
                 break; /* all other cases are errors */
@@ -1971,7 +1980,7 @@ mon_refresh_display(gpointer user_data)
     /* Unpack constraints if any section will need them
      * (tickets may be referenced in constraints but not granted yet,
      * and bans need negative location constraints) */
-    if (is_set(show, mon_show_bans) || is_set(show, mon_show_tickets)) {
+    if (pcmk_is_set(show, mon_show_bans) || pcmk_is_set(show, mon_show_tickets)) {
         xmlNode *cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS,
                                                    mon_data_set->input);
         unpack_constraints(cib_constraints, mon_data_set);
@@ -1999,7 +2008,7 @@ mon_refresh_display(gpointer user_data)
 
         case mon_output_monitor:
             print_simple_status(out, mon_data_set, stonith_history, options.mon_ops);
-            if (is_set(options.mon_ops, mon_op_has_warnings)) {
+            if (pcmk_is_set(options.mon_ops, mon_op_has_warnings)) {
                 clean_up(MON_STATUS_WARN);
                 return FALSE;
             }

--- a/tools/crm_mon_runtime.c
+++ b/tools/crm_mon_runtime.c
@@ -90,16 +90,16 @@ get_resource_display_options(unsigned int mon_ops)
 {
     int print_opts = 0;
 
-    if (is_set(mon_ops, mon_op_print_pending)) {
+    if (pcmk_is_set(mon_ops, mon_op_print_pending)) {
         print_opts |= pe_print_pending;
     }
-    if (is_set(mon_ops, mon_op_print_clone_detail)) {
+    if (pcmk_is_set(mon_ops, mon_op_print_clone_detail)) {
         print_opts |= pe_print_clone_details|pe_print_implicit;
     }
-    if (is_not_set(mon_ops, mon_op_inactive_resources)) {
+    if (!pcmk_is_set(mon_ops, mon_op_inactive_resources)) {
         print_opts |= pe_print_clone_active;
     }
-    if (is_set(mon_ops, mon_op_print_brief)) {
+    if (pcmk_is_set(mon_ops, mon_op_print_brief)) {
         print_opts |= pe_print_brief;
     }
     return print_opts;

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -768,7 +768,7 @@ ban_or_move(pe_resource_t *rsc, crm_exit_t *exit_code)
         rc = cli_resource_ban(options.rsc_id, current->details->uname, NULL,
                               cib_conn, options.cib_options, options.promoted_role_only);
 
-    } else if (is_set(rsc->flags, pe_rsc_promotable)) {
+    } else if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
         int count = 0;
         GListPtr iter = NULL;
 

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -111,7 +111,7 @@ cli_resource_print_list(pe_working_set_t * data_set, bool raw)
     for (lpc = data_set->resources; lpc != NULL; lpc = lpc->next) {
         pe_resource_t *rsc = (pe_resource_t *) lpc->data;
 
-        if (is_set(rsc->flags, pe_rsc_orphan)
+        if (pcmk_is_set(rsc->flags, pe_rsc_orphan)
             && rsc->fns->active(rsc, TRUE) == FALSE) {
             continue;
         }
@@ -211,7 +211,7 @@ cli_resource_print_colocation(pe_resource_t * rsc, bool dependents, bool recursi
         list = rsc->rsc_cons_lhs;
     }
 
-    if (is_set(rsc->flags, pe_rsc_allocating)) {
+    if (pcmk_is_set(rsc->flags, pe_rsc_allocating)) {
         /* Break colocation loops */
         printf("loop %s\n", rsc->id);
         free(prefix);
@@ -229,7 +229,7 @@ cli_resource_print_colocation(pe_resource_t * rsc, bool dependents, bool recursi
             peer = cons->rsc_lh;
         }
 
-        if (is_set(peer->flags, pe_rsc_allocating)) {
+        if (pcmk_is_set(peer->flags, pe_rsc_allocating)) {
             if (dependents == FALSE) {
                 fprintf(stdout, "%s%-*s (id=%s - loop)\n", prefix, 80 - (4 * offset), peer->id,
                         cons->id);

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -490,7 +490,7 @@ print_cluster_status(pe_working_set_t * data_set, long options)
     for (gIter = data_set->resources; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *rsc = (pe_resource_t *) gIter->data;
 
-        if (is_set(rsc->flags, pe_rsc_orphan)
+        if (pcmk_is_set(rsc->flags, pe_rsc_orphan)
             && rsc->role == RSC_ROLE_STOPPED) {
             continue;
         }
@@ -510,7 +510,7 @@ create_action_name(pe_action_t *action)
 
     if (action->node) {
         action_host = action->node->details->uname;
-    } else if (is_not_set(action->flags, pe_action_pseudo)) {
+    } else if (!pcmk_is_set(action->flags, pe_action_pseudo)) {
         action_host = "<none>";
     }
 
@@ -600,22 +600,23 @@ create_dotfile(pe_working_set_t * data_set, const char *dot_file, gboolean all_a
 
         crm_trace("Action %d: %s %s %p", action->id, action_name, action->uuid, action);
 
-        if (is_set(action->flags, pe_action_pseudo)) {
+        if (pcmk_is_set(action->flags, pe_action_pseudo)) {
             font = "orange";
         }
 
-        if (is_set(action->flags, pe_action_dumped)) {
+        if (pcmk_is_set(action->flags, pe_action_dumped)) {
             style = "bold";
             color = "green";
 
-        } else if (action->rsc != NULL && is_not_set(action->rsc->flags, pe_rsc_managed)) {
+        } else if ((action->rsc != NULL)
+                   && !pcmk_is_set(action->rsc->flags, pe_rsc_managed)) {
             color = "red";
             font = "purple";
             if (all_actions == FALSE) {
                 goto do_not_write;
             }
 
-        } else if (is_set(action->flags, pe_action_optional)) {
+        } else if (pcmk_is_set(action->flags, pe_action_optional)) {
             color = "blue";
             if (all_actions == FALSE) {
                 goto do_not_write;
@@ -623,8 +624,7 @@ create_dotfile(pe_working_set_t * data_set, const char *dot_file, gboolean all_a
 
         } else {
             color = "red";
-            CRM_CHECK(is_set(action->flags, pe_action_runnable) == FALSE,;
-                );
+            CRM_CHECK(!pcmk_is_set(action->flags, pe_action_runnable), ;);
         }
 
         pe__set_action_flags(action, pe_action_dumped);
@@ -652,13 +652,13 @@ create_dotfile(pe_working_set_t * data_set, const char *dot_file, gboolean all_a
             if (before->state == pe_link_dumped) {
                 optional = FALSE;
                 style = "bold";
-            } else if (is_set(action->flags, pe_action_pseudo)
+            } else if (pcmk_is_set(action->flags, pe_action_pseudo)
                        && (before->type & pe_order_stonith_stop)) {
                 continue;
             } else if (before->type == pe_order_none) {
                 continue;
-            } else if (is_set(before->action->flags, pe_action_dumped)
-                       && is_set(action->flags, pe_action_dumped)
+            } else if (pcmk_is_set(before->action->flags, pe_action_dumped)
+                       && pcmk_is_set(action->flags, pe_action_dumped)
                        && before->type != pe_order_load) {
                 optional = FALSE;
             }
@@ -977,7 +977,7 @@ main(int argc, char **argv)
     if (quiet == FALSE) {
         int opts = options.print_pending ? pe_print_pending : 0;
 
-        if (is_set(data_set->flags, pe_flag_maintenance_mode)) {
+        if (pcmk_is_set(data_set->flags, pe_flag_maintenance_mode)) {
             quiet_log("\n              *** Resource management is DISABLED ***");
             quiet_log("\n  The cluster will not attempt to start, stop or recover services");
             quiet_log("\n");


### PR DESCRIPTION
This more or less is an extension of my previous pull request #2134 that refactored flag setting/clearing functions, to now cover flag testing functions, but this one is almost entirely search-and-replace renames.

  is_set() -> pcmk_is_set() or pcmk_all_flags_set()
  is_not_set() -> !pcmk_is_set() or !pcmk_all_flags_set()
  is_set_any() -> pcmk_any_flags_set()

Additionally there is a new function pcmk__btoa() that takes a boolean and returns "true" or "false" (string literals), and there is one more commit along the lines of the previous flag functions PR to further improve log messages.