### PR TITLE
cluster: try to reconnect with corosync if it goes down

### DIFF
--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -409,7 +409,7 @@ main(int argc, char **argv)
      * This allows us to assume the CIB is connected whenever we process a
      * cluster or IPC message (which also avoids start-up race conditions).
      */
-    if (attrd_cib_connect(10) != pcmk_ok) {
+    if (attrd_cib_connect(30) != pcmk_ok) {
         attrd_exit_status = CRM_EX_FATAL;
         goto done;
     }

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -29,6 +29,7 @@
 #include <crm/common/ipc_internal.h>  /* PCMK__SPECIAL_PID* */
 
 static corosync_cfg_handle_t cfg_handle = 0;
+static mainloop_timer_t *reconnect_timer = NULL;
 
 /* =::=::=::= CFG - Shutdown stuff =::=::=::= */
 
@@ -59,13 +60,32 @@ pcmk_cfg_dispatch(gpointer user_data)
     return 0;
 }
 
+static gboolean
+cluster_reconnect_cb(gpointer data)
+{
+    if (cluster_connect_cfg()) {
+        mainloop_timer_stop(reconnect_timer);
+        mainloop_timer_del(reconnect_timer);
+        crm_warn("Cluster reconnect succeeded");
+    } else {
+        crm_warn("Cluster reconnect callback failed - retrying");
+    }
+    /*
+     * In theory this will continue forever. In practice the CIB connection from
+     * attrd will timeout and shut down Pacemaker when it gets bored.
+     */
+    return TRUE;
+}
+
+
 static void
 cfg_connection_destroy(gpointer user_data)
 {
     crm_err("Lost connection to Corosync");
     corosync_cfg_finalize(cfg_handle);
     cfg_handle = 0;
-    pcmk_shutdown(SIGTERM);
+    reconnect_timer = mainloop_timer_add("corosync reconnect", 1000, TRUE, cluster_reconnect_cb, NULL);
+    mainloop_timer_start(reconnect_timer);
 }
 
 gboolean


### PR DESCRIPTION
If the corosync cfg conection goes down, don't just quit, but
keep trying to reconnect.

In theory this could retry forever, but in practice the attrd->cib
connection times out. I've increased the timeout for this to give
corosync a little longer to start, but it's that timeout that
ultimately decides how long pacemaker will survive the loss of
corosync.

(In actual practice, of course, the node should be fenced!)