### PR TITLE
Log: libcrmcommon: Warn instead of err in scan_ll()

### DIFF
--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -69,13 +69,13 @@ scan_ll(const char *text, long long *result, char **end_text)
         } else if (errno != 0) {
             rc = errno;
             local_result = PCMK__PARSE_INT_DEFAULT;
-            crm_err("Could not parse integer from %s (using %d instead): %s",
+            crm_warn("Could not parse integer from %s (using %d instead): %s",
                     text, PCMK__PARSE_INT_DEFAULT, pcmk_rc_str(rc));
 
         } else if (local_end_text == text) {
             rc = EINVAL;
             local_result = PCMK__PARSE_INT_DEFAULT;
-            crm_err("Could not parse integer from %s (using %d instead): "
+            crm_warn("Could not parse integer from %s (using %d instead): "
                     "No digits found", text, PCMK__PARSE_INT_DEFAULT);
         }
 


### PR DESCRIPTION
Logging at err level in the event of a parse failure makes scan_ll() too
chatty. Specifically, it causes `crm_node -q/-n` to always log a parse
failure to stderr when run within a bundle, where logging to stderr is
enabled by default via PCMK_stderr.

In the future we may want to drop to crm_debug() in scan_ll(). This will
require looking for particular callers where more visible error checking
is necessary, and logging at higher levels there.

Resolves: RHBZ#1874391

Signed-off-by: Reid Wahl <nrwahl@protonmail.com>