### PR TITLE
Added support for ppc64le build on Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,16 @@ matrix:
   include:
     - compiler: gcc
       env:      MAINT_EXTRA=1
+      arch:     amd64
     - compiler: clang
       env:      MAINT_EXTRA=0
+      arch:     amd64
+    - compiler: gcc
+      env:      MAINT_EXTRA=1
+      arch:     ppc64le 
+    - compiler: gcc 
+      env:      MAINT_EXTRA=0
+      arch:     ppc64le 
 
 cache:
   directories:
@@ -22,8 +30,8 @@ cache:
 
 # sudo add-apt-repository ppa:hotot-team
 before_install:
- - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty main"
- - sudo apt-get update -qq
+- if [ "$TRAVIS_ARCH" == "ppc64le" ]; then sudo add-apt-repository "deb http://ports.ubuntu.com/ubuntu-ports/ trusty main"; sudo apt-get update -qq; fi
+- if [ "$TRAVIS_ARCH" == "amd64" ]; then sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty main"; sudo apt-get update -qq; fi
 
 # To switch to Travis-CI's containerized (non-sudo) architecture,
 # all our dependencies need to be on Travis's whitelist:
@@ -101,3 +109,4 @@ branches:
     - master
     - "1.1"
     - "2.0"
+    - ppc64le

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,8 @@ matrix:
       env:      MAINT_EXTRA=0
       arch:     amd64
     - compiler: gcc
-      env:      MAINT_EXTRA=1
-      arch:     ppc64le 
-    - compiler: gcc 
       env:      MAINT_EXTRA=0
-      arch:     ppc64le 
+      arch:     ppc64le  
 
 cache:
   directories:
@@ -109,4 +106,3 @@ branches:
     - master
     - "1.1"
     - "2.0"
-    - ppc64le


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjay-cpu/pacemaker/builds/182614899 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!