### PR TITLE
Mid: fenced: Set the delegate correctly when fencing fails.

### DIFF
--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1626,17 +1626,17 @@ call_remote_stonith(remote_fencing_op_t * op, st_query_result_t * peer)
         }
 
         if (op->state == st_query) {
-           crm_info("No peers (out of %d) have devices capable of fencing "
-                    "(%s) %s for client %s " CRM_XS " state=%d",
-                    op->replies, op->action, op->target, op->client_name,
-                    op->state);
+            crm_info("No peers (out of %d) have devices capable of fencing "
+                     "(%s) %s for client %s " CRM_XS " state=%d",
+                     op->replies, op->action, op->target, op->client_name,
+                     op->state);
 
             rc = -ENODEV;
         } else {
-           crm_info("No peers (out of %d) are capable of fencing (%s) %s "
-                    "for client %s " CRM_XS " state=%d",
-                    op->replies, op->action, op->target, op->client_name,
-                    op->state);
+            crm_info("No peers (out of %d) are capable of fencing (%s) %s "
+                     "for client %s " CRM_XS " state=%d",
+                     op->replies, op->action, op->target, op->client_name,
+                     op->state);
         }
 
         op->state = st_failed;


### PR DESCRIPTION
Hi All,

After a fencing failure due to a node failure, the fencing history of crm_mon may not be displayed correctly even if the fencing re-execution is successful.

The following is an example of a problem with a cluster using fence_vmware_rest.
Fencing goes through the vCenter server at 192.168.28.25.

Step1) Build a cluster.

```
[root@rh80-test01 ~]# crm_mon -rfA1m3
Cluster Summary:
  * Stack: corosync
  * Current DC: rh80-test01 (version 2.0.4-73f6f5c5f2) - partition with quorum
  * Last updated: Thu Sep 10 12:48:48 2020
  * Last change:  Thu Sep 10 12:47:04 2020 by root via cibadmin on rh80-test01
  * 2 nodes configured
  * 9 resource instances configured

Node List:
  * Online: [ rh80-test01 rh80-test02 ]

Full List of Resources:
  * Resource Group: pgsql-group:
    * filesystem1       (ocf::heartbeat:Dummy):  Started rh80-test02
    * filesystem2       (ocf::heartbeat:Dummy):  Started rh80-test02
    * filesystem3       (ocf::heartbeat:Dummy):  Started rh80-test02
    * ipaddr    (ocf::heartbeat:Dummy):  Started rh80-test02
    * pgsql     (ocf::heartbeat:Dummy):  Started rh80-test02
  * fence1-vmware-rest  (stonith:fence_vmware_rest):     Started rh80-test02
  * fence2-vmware-rest  (stonith:fence_vmware_rest):     Started rh80-test01
  * Clone Set: ping-clone [ping]:
    * Started: [ rh80-test01 rh80-test02 ]

Node Attributes:
  * Node: rh80-test01:
    * ping-status                       : 1         
  * Node: rh80-test02:
    * ping-status                       : 1         

Migration Summary:
```

Step2) Set fencing to fail in advance.

```
[root@rh80-test02 ~]# iptables -A INPUT -s 192.168.28.25 -j DROP
```

Step3) Reboot the DC node to perform fencing.

```
[root@rh80-test01 ~]# reboot -nf
```

Step4) All fencing will fail.

```
[root@rh80-test02 ~]# crm_mon -rfA1m3
Cluster Summary:
  * Stack: corosync
  * Current DC: rh80-test02 (version 2.0.4-73f6f5c5f2) - partition with quorum
  * Last updated: Thu Sep 10 12:59:32 2020
  * Last change:  Thu Sep 10 12:47:04 2020 by root via cibadmin on rh80-test01
  * 2 nodes configured
  * 9 resource instances configured

Node List:
  * Node rh80-test01: UNCLEAN (offline)
  * Online: [ rh80-test02 ]

Full List of Resources:
  * Resource Group: pgsql-group:
    * filesystem1       (ocf::heartbeat:Dummy):  Started rh80-test02
    * filesystem2       (ocf::heartbeat:Dummy):  Started rh80-test02
    * filesystem3       (ocf::heartbeat:Dummy):  Started rh80-test02
    * ipaddr    (ocf::heartbeat:Dummy):  Started rh80-test02
    * pgsql     (ocf::heartbeat:Dummy):  Started rh80-test02
  * fence1-vmware-rest  (stonith:fence_vmware_rest):     Started rh80-test02
  * fence2-vmware-rest  (stonith:fence_vmware_rest):     Started rh80-test01 (UNCLEAN)
  * Clone Set: ping-clone [ping]:
    * ping      (ocf::pacemaker:ping):   Started rh80-test01 (UNCLEAN)
    * Started: [ rh80-test02 ]

Node Attributes:
  * Node: rh80-test02:
    * ping-status                       : 1         

Migration Summary:

Failed Fencing Actions:
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:55:04 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:54:30 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:53:57 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:53:23 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:52:50 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:52:16 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:51:43 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:51:09 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:50:36 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:50:02 +09:00' 
```

Step5) Reset the settings for successful fencing.

```
[root@rh80-test02 ~]# iptables -F
```

Step6) After the recheck-timer has passed, the fencing is successful, but the fencing history does not show success.
 * But...."(A later attempt succeeded)" is not added.

```
[root@rh80-test02 ~]# crm_mon -rfA1m3
Cluster Summary:
  * Stack: corosync
  * Current DC: rh80-test02 (version 2.0.4-73f6f5c5f2) - partition with quorum
  * Last updated: Thu Sep 10 13:19:16 2020
  * Last change:  Thu Sep 10 12:47:04 2020 by root via cibadmin on rh80-test01
  * 2 nodes configured
  * 9 resource instances configured

Node List:
  * Online: [ rh80-test02 ]
  * OFFLINE: [ rh80-test01 ]

Full List of Resources:
  * Resource Group: pgsql-group:
    * filesystem1       (ocf::heartbeat:Dummy):  Started rh80-test02
    * filesystem2       (ocf::heartbeat:Dummy):  Started rh80-test02
    * filesystem3       (ocf::heartbeat:Dummy):  Started rh80-test02
    * ipaddr    (ocf::heartbeat:Dummy):  Started rh80-test02
    * pgsql     (ocf::heartbeat:Dummy):  Started rh80-test02
  * fence1-vmware-rest  (stonith:fence_vmware_rest):     Started rh80-test02
  * fence2-vmware-rest  (stonith:fence_vmware_rest):     Stopped
  * Clone Set: ping-clone [ping]:
    * Started: [ rh80-test02 ]
    * Stopped: [ rh80-test01 ]

Node Attributes:
  * Node: rh80-test02:
    * ping-status                       : 1         

Migration Summary:

Failed Fencing Actions:
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:55:04 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:54:30 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:53:57 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:53:23 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:52:50 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:52:16 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:51:43 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:51:09 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:50:36 +09:00' 
  * reboot of rh80-test01 failed: delegate=, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 12:50:02 +09:00' 

Fencing History:
  * reboot of rh80-test01 successful: delegate=rh80-test02, client=pacemaker-controld.147271, origin=rh80-test02, completed='2020-09-10 13:10:21 +09:00'
```


The problem is that call_remote_stonith() doesn't handle the fencing failure error code correctly in the absence of topology.
For this reason, the delegate is not set and is not treated as completed after fencing is complete.
 * This issue does not occur in fenced processing when the fencing topology is set.

This fix does not affect the -EHOSTUNREAC notification used by stonith_merge_in_history_list().
This is because the notification by stonith_merge_in_history_list() does not pass this process because it is notified to the node by "broadcast".


Best Regards,
Hideo Yamauchi.