### PR TITLE
Fix: tools: Display an error in crm_mon output when fencing is unavailable

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1449,14 +1449,12 @@ main(int argc, char **argv)
  * \brief Print one-line status suitable for use with monitoring software
  *
  * \param[in] data_set  Working set of CIB state
- * \param[in] history   List of stonith actions
  *
  * \note This function's output (and the return code when the program exits)
  *       should conform to https://www.monitoring-plugins.org/doc/guidelines.html
  */
 static void
-print_simple_status(pcmk__output_t *out, pe_working_set_t * data_set,
-                    mon_stonith_history_t *history, unsigned int mon_ops)
+print_simple_status(pcmk__output_t *out, pe_working_set_t * data_set, unsigned int mon_ops)
 {
     GListPtr gIter = NULL;
     int nodes_online = 0;
@@ -2012,7 +2010,7 @@ mon_refresh_display(gpointer user_data)
             break;
 
         case mon_output_monitor:
-            print_simple_status(out, mon_data_set, &history, options.mon_ops);
+            print_simple_status(out, mon_data_set, options.mon_ops);
             if (pcmk_is_set(options.mon_ops, mon_op_has_warnings)) {
                 clean_up(MON_STATUS_WARN);
                 return FALSE;

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -55,6 +55,15 @@ typedef enum mon_output_format_e {
     mon_output_cgi
 } mon_output_format_t;
 
+typedef struct {
+    bool is_error;
+
+    union {
+        stonith_history_t *history;
+        const char *error_msg;
+    } data;
+} mon_stonith_history_t;
+
 #define mon_show_stack          (1 << 0)
 #define mon_show_dc             (1 << 1)
 #define mon_show_times          (1 << 2)
@@ -95,15 +104,15 @@ typedef enum mon_output_format_e {
 #define mon_op_default              (mon_op_print_pending | mon_op_fence_history | mon_op_fence_connect)
 
 void print_status(pcmk__output_t *out, pe_working_set_t *data_set,
-                  stonith_history_t *stonith_history, unsigned int mon_ops,
+                  mon_stonith_history_t *history, unsigned int mon_ops,
                   unsigned int show, char *prefix, char *only_node,
                   char *only_rsc);
 void print_xml_status(pcmk__output_t *out, pe_working_set_t *data_set,
-                      crm_exit_t history_rc, stonith_history_t *stonith_history,
+                      crm_exit_t history_rc, mon_stonith_history_t *history,
                       unsigned int mon_ops, unsigned int show, char *prefix,
                       char *only_node, char *only_rsc);
 int print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
-                      stonith_history_t *stonith_history, unsigned int mon_ops,
+                      mon_stonith_history_t *history, unsigned int mon_ops,
                       unsigned int show, char *prefix, char *only_node,
                       char *only_rsc);
 

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -707,16 +707,21 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
     }
 
     /* Print failed stonith actions */
-    if (pcmk_is_set(show, mon_show_fence_failed)
-        && pcmk_is_set(mon_ops, mon_op_fence_history)) {
+    if (pcmk_is_set(show, mon_show_fence_failed) && pcmk_is_set(mon_ops, mon_op_fence_history)) {
+        if (history->is_error) {
+            PCMK__OUTPUT_SPACER_IF(out, rc == pcmk_rc_ok);
+            out->begin_list(out, NULL, NULL, "Failed Fencing Actions");
+            out->list_item(out, NULL, "%s", history->data.error_msg);
+            out->end_list(out);
+        } else {
+            stonith_history_t *hp = stonith__first_matching_event(history->data.history, stonith__event_state_eq,
+                                                                  GINT_TO_POINTER(st_failed));
 
-        stonith_history_t *hp = stonith__first_matching_event(history->data.history, stonith__event_state_eq,
-                                                              GINT_TO_POINTER(st_failed));
-
-        if (hp) {
-            CHECK_RC(rc, out->message(out, "failed-fencing-history", history->data.history, unames,
-                                      pcmk_is_set(mon_ops, mon_op_fence_full_history),
-                                      rc == pcmk_rc_ok));
+            if (hp) {
+                CHECK_RC(rc, out->message(out, "failed-fencing-history", history->data.history, unames,
+                                          pcmk_is_set(mon_ops, mon_op_fence_full_history),
+                                          rc == pcmk_rc_ok));
+            }
         }
     }
 
@@ -733,7 +738,12 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
 
     /* Print stonith history */
     if (pcmk_is_set(mon_ops, mon_op_fence_history)) {
-        if (pcmk_is_set(show, mon_show_fence_worked)) {
+        if (history->is_error) {
+            PCMK__OUTPUT_SPACER_IF(out, rc == pcmk_rc_ok);
+            out->begin_list(out, NULL, NULL, "Fencing History");
+            out->list_item(out, NULL, "%s", history->data.error_msg);
+            out->end_list(out);
+        } else if (pcmk_is_set(show, mon_show_fence_worked)) {
             stonith_history_t *hp = stonith__first_matching_event(history->data.history, stonith__event_state_neq,
                                                                   GINT_TO_POINTER(st_failed));
 
@@ -829,9 +839,7 @@ print_xml_status(pcmk__output_t *out, pe_working_set_t *data_set,
     }
 
     /* Print stonith history */
-    if (pcmk_is_set(show, mon_show_fencing_all)
-        && pcmk_is_set(mon_ops, mon_op_fence_history)) {
-
+    if (pcmk_is_set(show, mon_show_fencing_all) && pcmk_is_set(mon_ops, mon_op_fence_history)) {
         out->message(out, "full-fencing-history", history_rc, history->data.history,
                      unames, pcmk_is_set(mon_ops, mon_op_fence_full_history),
                      FALSE);
@@ -926,21 +934,29 @@ print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
     }
 
     /* Print failed stonith actions */
-    if (pcmk_is_set(show, mon_show_fence_failed)
-        && pcmk_is_set(mon_ops, mon_op_fence_history)) {
+    if (pcmk_is_set(show, mon_show_fence_failed) && pcmk_is_set(mon_ops, mon_op_fence_history)) {
+        if (history->is_error) {
+            out->begin_list(out, NULL, NULL, "Failed Fencing Actions");
+            out->list_item(out, NULL, "%s", history->data.error_msg);
+            out->end_list(out);
+        } else {
+            stonith_history_t *hp = stonith__first_matching_event(history->data.history, stonith__event_state_eq,
+                                                                  GINT_TO_POINTER(st_failed));
 
-        stonith_history_t *hp = stonith__first_matching_event(history->data.history, stonith__event_state_eq,
-                                                              GINT_TO_POINTER(st_failed));
-
-        if (hp) {
-            out->message(out, "failed-fencing-history", history->data.history, unames,
-                         pcmk_is_set(mon_ops, mon_op_fence_full_history), FALSE);
+            if (hp) {
+                out->message(out, "failed-fencing-history", history->data.history, unames,
+                             pcmk_is_set(mon_ops, mon_op_fence_full_history), FALSE);
+            }
         }
     }
 
     /* Print stonith history */
     if (pcmk_is_set(mon_ops, mon_op_fence_history)) {
-        if (pcmk_is_set(show, mon_show_fence_worked)) {
+        if (history->is_error) {
+            out->begin_list(out, NULL, NULL, "Fencing History");
+            out->list_item(out, NULL, "%s", history->data.error_msg);
+            out->end_list(out);
+        } else if (pcmk_is_set(show, mon_show_fence_worked)) {
             stonith_history_t *hp = stonith__first_matching_event(history->data.history, stonith__event_state_neq,
                                                                   GINT_TO_POINTER(st_failed));
 

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -636,14 +636,14 @@ print_failed_actions(pcmk__output_t *out, pe_working_set_t *data_set,
  *
  * \param[in] out             The output functions structure.
  * \param[in] data_set        Cluster state to display.
- * \param[in] stonith_history List of stonith actions.
+ * \param[in] history         List of stonith actions.
  * \param[in] mon_ops         Bitmask of mon_op_*.
  * \param[in] show            Bitmask of mon_show_*.
  * \param[in] prefix          ID prefix to filter results by.
  */
 void
 print_status(pcmk__output_t *out, pe_working_set_t *data_set,
-             stonith_history_t *stonith_history, unsigned int mon_ops,
+             mon_stonith_history_t *history, unsigned int mon_ops,
              unsigned int show, char *prefix, char *only_node, char *only_rsc)
 {
     GListPtr unames = NULL;
@@ -710,11 +710,11 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
     if (pcmk_is_set(show, mon_show_fence_failed)
         && pcmk_is_set(mon_ops, mon_op_fence_history)) {
 
-        stonith_history_t *hp = stonith__first_matching_event(stonith_history, stonith__event_state_eq,
+        stonith_history_t *hp = stonith__first_matching_event(history->data.history, stonith__event_state_eq,
                                                               GINT_TO_POINTER(st_failed));
 
         if (hp) {
-            CHECK_RC(rc, out->message(out, "failed-fencing-history", stonith_history, unames,
+            CHECK_RC(rc, out->message(out, "failed-fencing-history", history->data.history, unames,
                                       pcmk_is_set(mon_ops, mon_op_fence_full_history),
                                       rc == pcmk_rc_ok));
         }
@@ -734,7 +734,7 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
     /* Print stonith history */
     if (pcmk_is_set(mon_ops, mon_op_fence_history)) {
         if (pcmk_is_set(show, mon_show_fence_worked)) {
-            stonith_history_t *hp = stonith__first_matching_event(stonith_history, stonith__event_state_neq,
+            stonith_history_t *hp = stonith__first_matching_event(history->data.history, stonith__event_state_neq,
                                                                   GINT_TO_POINTER(st_failed));
 
             if (hp) {
@@ -743,7 +743,7 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
                                           rc == pcmk_rc_ok));
             }
         } else if (pcmk_is_set(show, mon_show_fence_pending)) {
-            stonith_history_t *hp = stonith__first_matching_event(stonith_history, stonith__event_state_pending, NULL);
+            stonith_history_t *hp = stonith__first_matching_event(history->data.history, stonith__event_state_pending, NULL);
 
             if (hp) {
                 CHECK_RC(rc, out->message(out, "pending-fencing-actions", hp, unames,
@@ -762,14 +762,14 @@ print_status(pcmk__output_t *out, pe_working_set_t *data_set,
  *
  * \param[in] out             The output functions structure.
  * \param[in] data_set        Cluster state to display.
- * \param[in] stonith_history List of stonith actions.
+ * \param[in] history         List of stonith actions.
  * \param[in] mon_ops         Bitmask of mon_op_*.
  * \param[in] show            Bitmask of mon_show_*.
  * \param[in] prefix          ID prefix to filter results by.
  */
 void
 print_xml_status(pcmk__output_t *out, pe_working_set_t *data_set,
-                 crm_exit_t history_rc, stonith_history_t *stonith_history,
+                 crm_exit_t history_rc, mon_stonith_history_t *history,
                  unsigned int mon_ops, unsigned int show, char *prefix,
                  char *only_node, char *only_rsc)
 {
@@ -832,7 +832,7 @@ print_xml_status(pcmk__output_t *out, pe_working_set_t *data_set,
     if (pcmk_is_set(show, mon_show_fencing_all)
         && pcmk_is_set(mon_ops, mon_op_fence_history)) {
 
-        out->message(out, "full-fencing-history", history_rc, stonith_history,
+        out->message(out, "full-fencing-history", history_rc, history->data.history,
                      unames, pcmk_is_set(mon_ops, mon_op_fence_full_history),
                      FALSE);
     }
@@ -857,14 +857,14 @@ print_xml_status(pcmk__output_t *out, pe_working_set_t *data_set,
  *
  * \param[in] out             The output functions structure.
  * \param[in] data_set        Cluster state to display.
- * \param[in] stonith_history List of stonith actions.
+ * \param[in] histor          List of stonith actions.
  * \param[in] mon_ops         Bitmask of mon_op_*.
  * \param[in] show            Bitmask of mon_show_*.
  * \param[in] prefix          ID prefix to filter results by.
  */
 int
 print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
-                  stonith_history_t *stonith_history, unsigned int mon_ops,
+                  mon_stonith_history_t *history, unsigned int mon_ops,
                   unsigned int show, char *prefix, char *only_node,
                   char *only_rsc)
 {
@@ -929,11 +929,11 @@ print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
     if (pcmk_is_set(show, mon_show_fence_failed)
         && pcmk_is_set(mon_ops, mon_op_fence_history)) {
 
-        stonith_history_t *hp = stonith__first_matching_event(stonith_history, stonith__event_state_eq,
+        stonith_history_t *hp = stonith__first_matching_event(history->data.history, stonith__event_state_eq,
                                                               GINT_TO_POINTER(st_failed));
 
         if (hp) {
-            out->message(out, "failed-fencing-history", stonith_history, unames,
+            out->message(out, "failed-fencing-history", history->data.history, unames,
                          pcmk_is_set(mon_ops, mon_op_fence_full_history), FALSE);
         }
     }
@@ -941,7 +941,7 @@ print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
     /* Print stonith history */
     if (pcmk_is_set(mon_ops, mon_op_fence_history)) {
         if (pcmk_is_set(show, mon_show_fence_worked)) {
-            stonith_history_t *hp = stonith__first_matching_event(stonith_history, stonith__event_state_neq,
+            stonith_history_t *hp = stonith__first_matching_event(history->data.history, stonith__event_state_neq,
                                                                   GINT_TO_POINTER(st_failed));
 
             if (hp) {
@@ -950,7 +950,7 @@ print_html_status(pcmk__output_t *out, pe_working_set_t *data_set,
                              FALSE);
             }
         } else if (pcmk_is_set(show, mon_show_fence_pending)) {
-            stonith_history_t *hp = stonith__first_matching_event(stonith_history, stonith__event_state_pending, NULL);
+            stonith_history_t *hp = stonith__first_matching_event(history->data.history, stonith__event_state_pending, NULL);
 
             if (hp) {
                 out->message(out, "pending-fencing-actions", hp, unames,


### PR DESCRIPTION
…able.

The exit code didn't match the fact that an error has occurred and that
errors are being printed to the screen.  crm_mon should return an error
code in this case.

See: rhbz#1880426