### PR TITLE
Fix: tools: Don't display crm_resource error messages twice.

### DIFF
--- a/cts/cli/regression.acls.exp
+++ b/cts/cli/regression.acls.exp
@@ -742,15 +742,15 @@ Call failed: Permission denied
 =#=#=#= End test: root: Create a resource - OK (0) =#=#=#=
 * Passed: cibadmin       - root: Create a resource
 =#=#=#= Begin test: l33t-haxor: Create a resource meta attribute =#=#=#=
-Error performing operation: Permission denied
+crm_resource: Error performing operation: Permission denied
 =#=#=#= End test: l33t-haxor: Create a resource meta attribute - Insufficient privileges (4) =#=#=#=
 * Passed: crm_resource   - l33t-haxor: Create a resource meta attribute
 =#=#=#= Begin test: l33t-haxor: Query a resource meta attribute =#=#=#=
-Error performing operation: Permission denied
+crm_resource: Error performing operation: Permission denied
 =#=#=#= End test: l33t-haxor: Query a resource meta attribute - Insufficient privileges (4) =#=#=#=
 * Passed: crm_resource   - l33t-haxor: Query a resource meta attribute
 =#=#=#= Begin test: l33t-haxor: Remove a resource meta attribute =#=#=#=
-Error performing operation: Permission denied
+crm_resource: Error performing operation: Permission denied
 =#=#=#= End test: l33t-haxor: Remove a resource meta attribute - Insufficient privileges (4) =#=#=#=
 * Passed: crm_resource   - l33t-haxor: Remove a resource meta attribute
 =#=#=#= Begin test: niceguy: Create a resource meta attribute =#=#=#=
@@ -2769,15 +2769,15 @@ Call failed: Permission denied
 =#=#=#= End test: root: Create a resource - OK (0) =#=#=#=
 * Passed: cibadmin       - root: Create a resource
 =#=#=#= Begin test: l33t-haxor: Create a resource meta attribute =#=#=#=
-Error performing operation: Permission denied
+crm_resource: Error performing operation: Permission denied
 =#=#=#= End test: l33t-haxor: Create a resource meta attribute - Insufficient privileges (4) =#=#=#=
 * Passed: crm_resource   - l33t-haxor: Create a resource meta attribute
 =#=#=#= Begin test: l33t-haxor: Query a resource meta attribute =#=#=#=
-Error performing operation: Permission denied
+crm_resource: Error performing operation: Permission denied
 =#=#=#= End test: l33t-haxor: Query a resource meta attribute - Insufficient privileges (4) =#=#=#=
 * Passed: crm_resource   - l33t-haxor: Query a resource meta attribute
 =#=#=#= Begin test: l33t-haxor: Remove a resource meta attribute =#=#=#=
-Error performing operation: Permission denied
+crm_resource: Error performing operation: Permission denied
 =#=#=#= End test: l33t-haxor: Remove a resource meta attribute - Insufficient privileges (4) =#=#=#=
 * Passed: crm_resource   - l33t-haxor: Remove a resource meta attribute
 =#=#=#= Begin test: niceguy: Create a resource meta attribute =#=#=#=

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -982,7 +982,7 @@ xml:
 =#=#=#= End test: Show XML configuration of resource - OK (0) =#=#=#=
 * Passed: crm_resource   - Show XML configuration of resource
 =#=#=#= Begin test: Require a destination when migrating a resource that is stopped =#=#=#=
-Resource 'dummy' not moved: active in 0 locations.
+crm_resource: Resource 'dummy' not moved: active in 0 locations.
 To prevent 'dummy' from running on a specific location, specify a node.
 Error performing operation: Invalid argument
 =#=#=#= Current cib after: Require a destination when migrating a resource that is stopped =#=#=#=
@@ -1024,7 +1024,7 @@ Error performing operation: Invalid argument
 =#=#=#= End test: Require a destination when migrating a resource that is stopped - Incorrect usage (64) =#=#=#=
 * Passed: crm_resource   - Require a destination when migrating a resource that is stopped
 =#=#=#= Begin test: Don't support migration to non-existent locations =#=#=#=
-Error performing operation: Node not found
+crm_resource: Error performing operation: Node not found
 =#=#=#= Current cib after: Don't support migration to non-existent locations =#=#=#=
 <cib epoch="19" num_updates="0" admin_epoch="1">
   <configuration>
@@ -1177,7 +1177,7 @@ Online: [ node1 ]
 =#=#=#= End test: Bring resources online - OK (0) =#=#=#=
 * Passed: crm_simulate   - Bring resources online
 =#=#=#= Begin test: Try to move a resource to its existing location =#=#=#=
-Error performing operation: Already in requested state
+crm_resource: Error performing operation: Already in requested state
 =#=#=#= Current cib after: Try to move a resource to its existing location =#=#=#=
 <cib epoch="20" num_updates="4" admin_epoch="1">
   <configuration>
@@ -1758,7 +1758,7 @@ true
 =#=#=#= End test: Delete ticket standby state - OK (0) =#=#=#=
 * Passed: crm_ticket     - Delete ticket standby state
 =#=#=#= Begin test: Ban a resource on unknown node =#=#=#=
-Error performing operation: Node not found
+crm_resource: Error performing operation: Node not found
 =#=#=#= Current cib after: Ban a resource on unknown node =#=#=#=
 <cib epoch="22" num_updates="5" admin_epoch="1">
   <configuration>

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1620,6 +1620,7 @@ for t in $tests; do
         -e 's/ end=\"[0-9][-+: 0-9]*Z*\"/ end=\"\"/' \
         -e 's/ start=\"[0-9][-+: 0-9]*Z*\"/ start=\"\"/' \
         -e 's/^Error checking rule: Device not configured/Error checking rule: No such device or address/' \
+        -e 's/^lt-//' \
         "$TMPFILE" > "${TMPFILE}.$$"
     mv -- "${TMPFILE}.$$" "$TMPFILE"
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -171,7 +171,7 @@ static crm_exit_t
 bye(crm_exit_t ec)
 {
     if (error != NULL) {
-        fprintf(stderr, "%s\n", error->message);
+        fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
         g_clear_error(&error);
     }
 
@@ -1512,7 +1512,6 @@ main(int argc, char **argv)
     processed_args = pcmk__cmdline_preproc(argv, "GINSTdginpstuv");
 
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
-        fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
         exit_code = CRM_EX_USAGE;
         goto done;
     }


### PR DESCRIPTION
Also, add the program name to any error prints that happen.  This brings
it in line with what crm_mon is doing.