### PR TITLE
Fix: libcrmcommon: Rewrite much of parse_op_key.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,6 +205,7 @@ pacemaker-[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]
 /lib/common/tests/flags/pcmk__set_flags_as
 /lib/common/tests/flags/pcmk_all_flags_set
 /lib/common/tests/flags/pcmk_any_flags_set
+/lib/common/tests/operations/parse_op_key
 /lib/common/tests/strings/pcmk__btoa
 /lib/common/tests/strings/pcmk__parse_ll_range
 /lib/common/tests/strings/pcmk__scan_double

--- a/configure.ac
+++ b/configure.ac
@@ -2007,6 +2007,7 @@ AC_CONFIG_FILES(Makefile                                            \
                 lib/common/Makefile                                 \
                 lib/common/tests/Makefile                           \
                 lib/common/tests/flags/Makefile                     \
+                lib/common/tests/operations/Makefile                \
                 lib/common/tests/strings/Makefile                   \
                 lib/common/tests/utils/Makefile                     \
                 lib/cluster/Makefile                                \

--- a/lib/common/tests/Makefile.am
+++ b/lib/common/tests/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = flags strings utils
+SUBDIRS = flags operations strings utils

--- a/lib/common/tests/operations/Makefile.am
+++ b/lib/common/tests/operations/Makefile.am
@@ -1,0 +1,19 @@
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
+LDADD = $(top_builddir)/lib/common/libcrmcommon.la
+
+include $(top_srcdir)/mk/glib-tap.mk
+
+# Add each test program here.  Each test should be written as a little standalone
+# program using the glib unit testing functions.  See the documentation for more
+# information.
+#
+# https://developer.gnome.org/glib/unstable/glib-Testing.html
+test_programs = parse_op_key
+
+# If any extra data needs to be added to the source distribution, add it to the
+# following list.
+dist_test_data =
+
+# If any extra data needs to be used by tests but should not be added to the
+# source distribution, add it to the following list.
+test_data =

--- a/lib/common/tests/operations/parse_op_key.c
+++ b/lib/common/tests/operations/parse_op_key.c
@@ -1,0 +1,218 @@
+#include <glib.h>
+
+#include <crm_internal.h>
+
+static void
+basic(void)
+{
+    char *rsc = NULL;
+    char *ty = NULL;
+    guint ms = 0;
+
+    g_assert_true(parse_op_key("Fencing_monitor_60000", &rsc, &ty, &ms));
+    g_assert_cmpstr(rsc, ==, "Fencing");
+    g_assert_cmpstr(ty, ==, "monitor");
+    g_assert_cmpint(ms, ==, 60000);
+    free(rsc);
+    free(ty);
+}
+
+static void
+colon_in_rsc(void)
+{
+    char *rsc = NULL;
+    char *ty = NULL;
+    guint ms = 0;
+
+    g_assert_true(parse_op_key("ClusterIP:0_start_0", &rsc, &ty, &ms));
+    g_assert_cmpstr(rsc, ==, "ClusterIP:0");
+    g_assert_cmpstr(ty, ==, "start");
+    g_assert_cmpint(ms, ==, 0);
+    free(rsc);
+    free(ty);
+
+    g_assert_true(parse_op_key("imagestoreclone:1_post_notify_stop_0", &rsc, &ty, &ms));
+    g_assert_cmpstr(rsc, ==, "imagestoreclone:1");
+    g_assert_cmpstr(ty, ==, "post_notify_stop");
+    g_assert_cmpint(ms, ==, 0);
+    free(rsc);
+    free(ty);
+}
+
+static void
+dashes_in_rsc(void)
+{
+    char *rsc = NULL;
+    char *ty = NULL;
+    guint ms = 0;
+
+    g_assert_true(parse_op_key("httpd-bundle-0_monitor_30000", &rsc, &ty, &ms));
+    g_assert_cmpstr(rsc, ==, "httpd-bundle-0");
+    g_assert_cmpstr(ty, ==, "monitor");
+    g_assert_cmpint(ms, ==, 30000);
+    free(rsc);
+    free(ty);
+
+    g_assert_true(parse_op_key("httpd-bundle-ip-192.168.122.132_start_0", &rsc, &ty, &ms));
+    g_assert_cmpstr(rsc, ==, "httpd-bundle-ip-192.168.122.132");
+    g_assert_cmpstr(ty, ==, "start");
+    g_assert_cmpint(ms, ==, 0);
+    free(rsc);
+    free(ty);
+}
+
+static void
+migrate_to_from(void)
+{
+    char *rsc = NULL;
+    char *ty = NULL;
+    guint ms = 0;
+
+    g_assert_true(parse_op_key("vm_migrate_from_0", &rsc, &ty, &ms));
+    g_assert_cmpstr(rsc, ==, "vm");
+    g_assert_cmpstr(ty, ==, "migrate_from");
+    g_assert_cmpint(ms, ==, 0);
+    free(rsc);
+    free(ty);
+
+    g_assert_true(parse_op_key("vm_migrate_to_0", &rsc, &ty, &ms));
+    g_assert_cmpstr(rsc, ==, "vm");
+    g_assert_cmpstr(ty, ==, "migrate_to");
+    g_assert_cmpint(ms, ==, 0);
+    free(rsc);
+    free(ty);
+
+    g_assert_true(parse_op_key("vm_idcc_devel_migrate_to_0", &rsc, &ty, &ms));
+    g_assert_cmpstr(rsc, ==, "vm_idcc_devel");
+    g_assert_cmpstr(ty, ==, "migrate_to");
+    g_assert_cmpint(ms, ==, 0);
+    free(rsc);
+    free(ty);
+}
+
+static void
+pre_post(void)
+{
+    char *rsc = NULL;
+    char *ty = NULL;
+    guint ms = 0;
+
+    g_assert_true(parse_op_key("rsc_drbd_7788:1_post_notify_start_0", &rsc, &ty, &ms));
+    g_assert_cmpstr(rsc, ==, "rsc_drbd_7788:1");
+    g_assert_cmpstr(ty, ==, "post_notify_start");
+    g_assert_cmpint(ms, ==, 0);
+    free(rsc);
+    free(ty);
+
+    g_assert_true(parse_op_key("rabbitmq-bundle-clone_pre_notify_stop_0", &rsc, &ty, &ms));
+    g_assert_cmpstr(rsc, ==, "rabbitmq-bundle-clone");
+    g_assert_cmpstr(ty, ==, "pre_notify_stop");
+    g_assert_cmpint(ms, ==, 0);
+    free(rsc);
+    free(ty);
+
+    g_assert_true(parse_op_key("post_notify_start_0", &rsc, &ty, &ms));
+    g_assert_cmpstr(rsc, ==, "post_notify");
+    g_assert_cmpstr(ty, ==, "start");
+    g_assert_cmpint(ms, ==, 0);
+    free(rsc);
+    free(ty);
+}
+
+static void
+skip_rsc(void)
+{
+    char *ty = NULL;
+    guint ms = 0;
+
+    g_assert_true(parse_op_key("Fencing_monitor_60000", NULL, &ty, &ms));
+    g_assert_cmpstr(ty, ==, "monitor");
+    g_assert_cmpint(ms, ==, 60000);
+    free(ty);
+}
+
+static void
+skip_ty(void)
+{
+    char *rsc = NULL;
+    guint ms = 0;
+
+    g_assert_true(parse_op_key("Fencing_monitor_60000", &rsc, NULL, &ms));
+    g_assert_cmpstr(rsc, ==, "Fencing");
+    g_assert_cmpint(ms, ==, 60000);
+    free(rsc);
+}
+
+static void
+skip_ms(void)
+{
+    char *rsc = NULL;
+    char *ty = NULL;
+
+    g_assert_true(parse_op_key("Fencing_monitor_60000", &rsc, &ty, NULL));
+    g_assert_cmpstr(rsc, ==, "Fencing");
+    g_assert_cmpstr(ty, ==, "monitor");
+    free(rsc);
+    free(ty);
+}
+
+static void
+empty_input(void)
+{
+    char *rsc = NULL;
+    char *ty = NULL;
+    guint ms = 0;
+
+    g_assert_false(parse_op_key("", &rsc, &ty, &ms));
+    g_assert_true(rsc == NULL);
+    g_assert_true(ty == NULL);
+    g_assert_cmpint(ms, ==, 0);
+
+    g_assert_false(parse_op_key(NULL, &rsc, &ty, &ms));
+    g_assert_true(rsc == NULL);
+    g_assert_true(ty == NULL);
+    g_assert_cmpint(ms, ==, 0);
+}
+
+static void
+malformed_input(void)
+{
+    char *rsc = NULL;
+    char *ty = NULL;
+    guint ms = 0;
+
+    g_assert_false(parse_op_key("httpd-bundle-0", &rsc, &ty, &ms));
+    g_assert(rsc == NULL);
+    g_assert(ty == NULL);
+    g_assert_cmpint(ms, ==, 0);
+
+    g_assert_false(parse_op_key("httpd-bundle-0_monitor", &rsc, &ty, &ms));
+    g_assert(rsc == NULL);
+    g_assert(ty == NULL);
+    g_assert_cmpint(ms, ==, 0);
+
+    g_assert_false(parse_op_key("httpd-bundle-0_30000", &rsc, &ty, &ms));
+    g_assert(rsc == NULL);
+    g_assert(ty == NULL);
+    g_assert_cmpint(ms, ==, 0);
+}
+
+int main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/common/utils/parse_op_key/basic", basic);
+    g_test_add_func("/common/utils/parse_op_key/colon_in_rsc", colon_in_rsc);
+    g_test_add_func("/common/utils/parse_op_key/dashes_in_rsc", dashes_in_rsc);
+    g_test_add_func("/common/utils/parse_op_key/migrate_to_from", migrate_to_from);
+    g_test_add_func("/common/utils/parse_op_key/pre_post", pre_post);
+
+    g_test_add_func("/common/utils/parse_op_key/skip_rsc", skip_rsc);
+    g_test_add_func("/common/utils/parse_op_key/skip_ty", skip_ty);
+    g_test_add_func("/common/utils/parse_op_key/skip_ms", skip_ms);
+
+    g_test_add_func("/common/utils/parse_op_key/empty_input", empty_input);
+    g_test_add_func("/common/utils/parse_op_key/malformed_input", malformed_input);
+
+    return g_test_run();
+}


### PR DESCRIPTION
This function has problems with most operation names that have an
underscore in them, like "migrate_to" or "migrate_from".  It parses
those as if the "migrate" is part of the resource name, and "to" or
"from" is the operation name.  It does appear to understand _post_notify
and _pre_notify operations, at least.

I've rewritten much of the function to also understand "migrate_to" and
"migrate_from".  I don't believe there are any other operation names
with an underscore in them, but it so it's easy enough to add to the
obvious block.  I can't think of any better way to handle these cases,
given that an underscore is both the separator character and can appear
anywhere in the op key.

I'm hoping the rewritten version is a little easier to follow.  I have
added a lot of comments to make it easier understand when it needs to be
debugged.  There are also test cases.

The new version should function the same as the old version.  In fact,
there are commented out test cases that ought to fail, but did not with
the old code so I have left them alone for the moment.