### PR TITLE
Mid: controld,fenced,attrd: Unregister NOTIFY to avoid the occurrence of "Broken pipe" at the time of stop. (Fix CLBZ:#5434)

### DIFF
--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -81,22 +81,6 @@ attrd_cpg_destroy(gpointer unused)
 }
 
 static void
-attrd_cib_replaced_cb(const char *event, xmlNode * msg)
-{
-    if (attrd_shutting_down()) {
-        return;
-    }
-
-    if (attrd_election_won()) {
-        crm_notice("Updating all attributes after %s event", event);
-        write_attributes(TRUE, FALSE);
-    }
-
-    // Check for changes in alerts
-    mainloop_set_trigger(attrd_config_read);
-}
-
-static void
 attrd_cib_destroy_cb(gpointer user_data)
 {
     cib_t *conn = user_data;

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -63,6 +63,7 @@ extern crm_trigger_t *attrd_config_read;
 
 void attrd_lrmd_disconnect(void);
 gboolean attrd_read_options(gpointer user_data);
+void attrd_cib_replaced_cb(const char *event, xmlNode * msg);
 void attrd_cib_updated_cb(const char *event, xmlNode *msg);
 int attrd_send_attribute_alert(const char *node, int nodeid,
                                const char *attr, const char *value);

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -20,7 +20,7 @@
 
 int cib_retries = 0;
 
-static void
+void
 do_cib_updated(const char *event, xmlNode * msg)
 {
     if (pcmk__alert_in_patchset(msg, TRUE)) {
@@ -28,7 +28,7 @@ do_cib_updated(const char *event, xmlNode * msg)
     }
 }
 
-static void
+void
 do_cib_replaced(const char *event, xmlNode * msg)
 {
     crm_debug("Updating the CIB after a replace: DC=%s", pcmk__btoa(AM_I_DC));
@@ -66,6 +66,7 @@ do_cib_control(long long action,
         crm_info("Disconnecting from the CIB manager");
         controld_clear_fsa_input_flags(R_CIB_CONNECTED);
 
+        fsa_cib_conn->cmds->del_notify_callback(fsa_cib_conn, T_CIB_REPLACE_NOTIFY, do_cib_replaced);
         fsa_cib_conn->cmds->del_notify_callback(fsa_cib_conn, T_CIB_DIFF_NOTIFY, do_cib_updated);
 
         if (fsa_cib_conn->state != cib_disconnected) {

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -225,6 +225,8 @@ crmd_exit(crm_exit_t exit_code)
     /* Tear down the CIB manager connection, but don't free it yet -- it could
      * be used when we drain the mainloop later.
      */
+    fsa_cib_conn->cmds->del_notify_callback(fsa_cib_conn, T_CIB_REPLACE_NOTIFY, do_cib_replaced);
+    fsa_cib_conn->cmds->del_notify_callback(fsa_cib_conn, T_CIB_DIFF_NOTIFY, do_cib_updated);
     cib_free_callbacks(fsa_cib_conn);
     fsa_cib_conn->cmds->signoff(fsa_cib_conn);
 

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -26,6 +26,8 @@
 extern GMainLoop *crmd_mainloop;
 extern bool no_quorum_suicide_escalation;
 
+void do_cib_updated(const char *event, xmlNode * msg);
+void do_cib_replaced(const char *event, xmlNode * msg);
 void crmd_metadata(void);
 void controld_election_init(const char *uname);
 void controld_remove_voter(const char *uname);

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -1146,6 +1146,7 @@ static void
 stonith_cleanup(void)
 {
     if (cib_api) {
+        cib_api->cmds->del_notify_callback(cib_api, T_CIB_DIFF_NOTIFY, update_cib_cache_cb);
         cib_api->cmds->signoff(cib_api);
     }
 


### PR DESCRIPTION
Hi All,

This PR improves on the following issues:
 - https://bugs.clusterlabs.org/show_bug.cgi?id=5434

However, this does not mean that the "Broken Pipe" will not occur completely.

This PR can reduce the frequency of problems.

Best Regards,
Hideo Yamauchi.