### PR TITLE
Clean up DBus code

### DIFF
--- a/lib/services/dbus.c
+++ b/lib/services/dbus.c
@@ -524,7 +524,7 @@ pcmk_dbus_type_check(DBusMessage *msg, DBusMessageIter *field, int expected,
     }
 
     if (field == NULL) {
-        do_crm_log_alias(LOG_ERR, __FILE__, function, line,
+        do_crm_log_alias(LOG_INFO, __FILE__, function, line,
                          "DBus reply has empty parameter list (expected '%c')",
                          expected);
         return FALSE;
@@ -538,7 +538,7 @@ pcmk_dbus_type_check(DBusMessage *msg, DBusMessageIter *field, int expected,
 
         dbus_message_iter_init(msg, &args);
         sig = dbus_message_iter_get_signature(&args);
-        do_crm_log_alias(LOG_ERR, __FILE__, function, line,
+        do_crm_log_alias(LOG_INFO, __FILE__, function, line,
                          "DBus reply has unexpected type "
                          "(expected '%c' not '%c' in '%s')",
                          expected, dtype, sig);

--- a/lib/services/dbus.c
+++ b/lib/services/dbus.c
@@ -746,6 +746,7 @@ pcmk_dbus_get_property(DBusConnection *connection, const char *target,
     if (query_data == NULL) {
         crm_crit("DBus query of %s for %s properties failed: Out of memory",
                  target, obj);
+        dbus_message_unref(msg);
         return NULL;
     }
 

--- a/lib/services/pcmk-dbus.h
+++ b/lib/services/pcmk-dbus.h
@@ -1,5 +1,7 @@
 /*
- * Copyright (C) 2014-2016 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2014-2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -16,9 +18,6 @@
 
 G_GNUC_INTERNAL
 DBusConnection *pcmk_dbus_connect(void);
-
-G_GNUC_INTERNAL
-void pcmk_dbus_connection_setup_with_select(DBusConnection *c);
 
 G_GNUC_INTERNAL
 void pcmk_dbus_disconnect(DBusConnection *connection);

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -265,7 +265,12 @@ systemd_loadunit_result(DBusMessage *reply, svc_action_t * op)
         }
         dbus_error_free(&error);
 
-    } else if(pcmk_dbus_type_check(reply, NULL, DBUS_TYPE_OBJECT_PATH, __func__, __LINE__)) {
+    } else if (!pcmk_dbus_type_check(reply, NULL, DBUS_TYPE_OBJECT_PATH,
+                                     __func__, __LINE__)) {
+        crm_err("Could not load systemd unit %s for %s: "
+                "systemd reply has unexpected type", op->agent, op->id);
+
+    } else {
         dbus_message_get_args (reply, NULL,
                                DBUS_TYPE_OBJECT_PATH, &path,
                                DBUS_TYPE_INVALID);
@@ -431,13 +436,13 @@ systemd_unit_listall(void)
         char *basename = NULL;
 
         if(!pcmk_dbus_type_check(reply, &unit, DBUS_TYPE_STRUCT, __func__, __LINE__)) {
-            crm_debug("ListUnitFiles reply has unexpected type");
+            crm_warn("Skipping systemd reply argument with unexpected type");
             continue;
         }
 
         dbus_message_iter_recurse(&unit, &elem);
         if(!pcmk_dbus_type_check(reply, &elem, DBUS_TYPE_STRING, __func__, __LINE__)) {
-            crm_debug("ListUnitFiles reply does not contain a string");
+            crm_warn("Skipping systemd reply argument with no string");
             continue;
         }
 

--- a/lib/services/upstart.c
+++ b/lib/services/upstart.c
@@ -199,6 +199,7 @@ upstart_job_listall(void)
         char *path = NULL;
 
         if(!pcmk_dbus_type_check(reply, &unit, DBUS_TYPE_OBJECT_PATH, __func__, __LINE__)) {
+            crm_warn("Skipping Upstart reply argument with unexpected type");
             continue;
         }
 


### PR DESCRIPTION
This is what happens when you pull on a thread in Pacemaker.

The latest coverity version reported a potential use-before-initialization error in Pacemaker's DBus code, and it wasn't obvious at first whether it was a true error or a false positive. It turned out to be a false positive, but in order to figure that out ...

"Let me add some comments as I figure out what these functions do ..."
"If I'm going to test this, I need better log messages ..."
"This code with the false positive is really inefficient, I should refactor it ..."

Hopefully now it's cleaner. :) I tested with all the regression tests, CTS, and specific-testing of nonexistent systemd units and some test-only modifications to ask for invalid or undefined properties.