### PR TITLE
Mid: based: Avoiding Broken pipe when shutdown.(Fix CLBZ:#5434) 

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -393,8 +393,16 @@ do_local_notify(xmlNode * notify_src, const char *client_id,
         }
 
     } else {
-        crm_trace("Sending event %d to %s %s",
+        if (!pcmk_any_flags_set(client_obj->flags, cib_notify_diff | cib_notify_replace | cib_notify_confirm | cib_notify_pre | cib_notify_post) &&
+            pcmk_is_set(client_obj->flags, cib_is_daemon)) {
+            /* Skip notifications to local daemons whose flags have been cleared. */
+            crm_trace("Skipping sending event %d to %s %s",
                   call_id, client_obj->name, from_peer ? "(originator of delegated request)" : "");
+            return;
+        } else {
+            crm_trace("Sending event %d to %s %s",
+                  call_id, client_obj->name, from_peer ? "(originator of delegated request)" : "");
+        }
     }
 
     switch (PCMK__CLIENT_TYPE(client_obj)) {


### PR DESCRIPTION
Hi All,

This fix is a continuation of the previous PR.
 - https://github.com/ClusterLabs/pacemaker/pull/2173

Avoid the "Broken pipe" error that occurs in do_local_notify() when the cluster is stopped.

```
Sep 24 18:36:39 rh80-test01 pacemaker-based     [3078897] (qb_ipcs_event_sendv)         warning: new_event_notification (/dev/shm/qb-3078897-3078902-12-alHOtg/qb): Broken pipe (32)
Sep 24 18:36:39 rh80-test01 pacemaker-based     [3078897] (do_local_notify)     warning: Asynchronous reply to crmd failed: Broken pipe | rc=32
```

But...These fixes reduce the frequency of "Broken pipes", but not 100% due to different processes.

Best Regards,
Hideo Yamauchi.
