### PR TITLE
Mid: controld: Avoiding Broken pipe when shutdown.(Fix CLBZ:#5434)

### DIFF
--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -70,7 +70,8 @@ do_cib_control(long long action,
         fsa_cib_conn->cmds->del_notify_callback(fsa_cib_conn, T_CIB_DIFF_NOTIFY, do_cib_updated);
 
         if (fsa_cib_conn->state != cib_disconnected) {
-            fsa_cib_conn->cmds->set_slave(fsa_cib_conn, cib_scope_local);
+            /* Does not require a set_slave() reply to sign out from based. */
+            fsa_cib_conn->cmds->set_slave(fsa_cib_conn, cib_scope_local | cib_discard_reply);
             fsa_cib_conn->cmds->signoff(fsa_cib_conn);
         }
         crm_notice("Disconnected from the CIB manager");

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -260,7 +260,8 @@ do_dc_release(long long action,
             crm_update_peer_expected(__func__, node, CRMD_JOINSTATE_DOWN);
             update = create_node_state_update(node, node_update_expected, NULL,
                                               __func__);
-            fsa_cib_anon_update(XML_CIB_TAG_STATUS, update);
+            /* Don't need a based response because controld will stop. */
+            fsa_cib_anon_update_discard_reply(XML_CIB_TAG_STATUS, update);
             free_xml(update);
         }
         register_fsa_input(C_FSA_INTERNAL, I_RELEASE_SUCCESS, NULL);

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -40,6 +40,17 @@ fsa_cib_anon_update(const char *section, xmlNode *data) {
     }
 }
 
+static inline void
+fsa_cib_anon_update_discard_reply(const char *section, xmlNode *data) {
+    if (fsa_cib_conn == NULL) {
+        crm_err("No CIB connection available");
+    } else {
+        int opts = cib_scope_local | cib_quorum_override | cib_can_create | cib_discard_reply;
+
+        fsa_cib_conn->cmds->modify(fsa_cib_conn, section, data, opts);
+    }
+}
+
 extern gboolean fsa_has_quorum;
 extern bool controld_shutdown_lock_enabled;
 extern int last_peer_update;


### PR DESCRIPTION
Hi All,

This fix is a continuation of the previous PR.
 - https://github.com/ClusterLabs/pacemaker/pull/2173
 - https://github.com/ClusterLabs/pacemaker/pull/2177

But...These fixes reduce the frequency of "Broken pipes", but not 100% due to different processes.
(I will continue to consider fixing other "Broken pipe" occurrences.)

Best Regards,
Hideo Yamauchi.

