### PR TITLE
Test: cts-fencing, cts-exec: optimize fencing and exec regression testing via appropriate synchronization with daemons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,9 @@ script:
 - sudo make install-exec-local || true
 - make
 - make check
-- ./cts/cts-regression -V cli scheduler exec
+- ./cts/cts-cli -V
+- ./cts/cts-scheduler -V
+- sudo ./cts/cts-exec -V --force-wait
 - test $MAINT_EXTRA -eq 0 ||
   { { echo 'looking for presence of control characters...';
       { git ls-files

--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -159,6 +159,7 @@ class Test(object):
         self.name = name
         self.description = description
         self.cmds = []
+        self.logpath = "/tmp/pacemaker-execd-regression.log"
 
         if tls:
             self.daemon_location = "pacemaker-remoted"
@@ -216,10 +217,21 @@ class Test(object):
         if self.verbose:
             additional_args = additional_args + " -V"
 
-        self.execd_process = subprocess.Popen(shlex.split("%s %s -l /tmp/pacemaker-execd-regression.log"
-                                                         % (self.daemon_location, additional_args)))
+        self.execd_process = subprocess.Popen(shlex.split("%s %s -l %s"
+                                                         % (self.daemon_location, additional_args, self.logpath)))
 
-        time.sleep(1)
+        logfile = None
+
+        while True:
+            time.sleep(0.1)
+
+            if logfile == None and os.path.exists(self.logpath):
+                logfile = io.open(self.logpath, 'rt', encoding = "ISO-8859-1")
+
+            if logfile != None:
+                for line in logfile.readlines():
+                    if "successfully started" in line:
+                        return
 
     def clean_environment(self):
         """ Clean up the host after running a test """
@@ -230,10 +242,10 @@ class Test(object):
 
             if self.verbose:
                 print("Daemon output")
-                logfile = io.open('/tmp/pacemaker-execd-regression.log', 'rt', errors='replace')
+                logfile = io.open(self.logpath, 'rt', errors='replace')
                 for line in logfile:
                     print(line.strip().encode('utf-8', 'replace'))
-            os.remove('/tmp/pacemaker-execd-regression.log')
+            os.remove(self.logpath)
 
         if self.stonith_process:
             self.stonith_process.terminate()

--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -155,7 +155,7 @@ class OutputFoundError(TestError):
 class Test(object):
     """ Executor for a single pacemaker-execd regression test """
 
-    def __init__(self, name, description, verbose=0, tls=0):
+    def __init__(self, name, description, verbose=0, tls=0, timeout=2):
         self.name = name
         self.description = description
         self.cmds = []
@@ -169,6 +169,7 @@ class Test(object):
         self.test_tool_location = "cts-exec-helper"
         self.verbose = verbose
         self.tls = tls
+        self.timeout = timeout
 
         self.result_txt = ""
         self.cmd_tool_output = ""
@@ -222,6 +223,9 @@ class Test(object):
 
         logfile = None
 
+        init_time = time.time()
+        update_time = init_time
+
         while True:
             time.sleep(0.1)
 
@@ -232,6 +236,19 @@ class Test(object):
                 for line in logfile.readlines():
                     if "successfully started" in line:
                         return
+
+            now = time.time()
+
+            if self.timeout > 0 and (now - init_time) >= self.timeout:
+                print("\tDaemon %s doesn't seem to have been initialized within %fs."
+                      "\n\tConsider specifying a longer '--timeout' value."
+                       %(self.daemon_location, self.timeout))
+                return
+
+            if (now - update_time) >= 5:
+                print("\tWaiting for %s to be initialized: %fs ..."
+                      %(self.daemon_location, now - init_time))
+                update_time = now
 
     def clean_environment(self):
         """ Clean up the host after running a test """
@@ -382,10 +399,11 @@ class Test(object):
 class Tests(object):
     """ Collection of all pacemaker-execd regression tests """
 
-    def __init__(self, verbose=0, tls=0):
+    def __init__(self, verbose=0, tls=0, timeout=2):
         self.tests = []
         self.verbose = verbose
         self.tls = tls
+        self.timeout = timeout
         self.rsc_classes = output_from_command("crm_resource --list-standards")
         self.rsc_classes = self.rsc_classes[:-1] # Strip trailing empty line
         self.installed_files = []
@@ -491,7 +509,7 @@ class Tests(object):
     def new_test(self, name, description):
         """ Create a named test """
 
-        test = Test(name, description, self.verbose, self.tls)
+        test = Test(name, description, self.verbose, self.tls, self.timeout)
         self.tests.append(test)
         return test
 
@@ -1143,6 +1161,7 @@ class TestOptions(object):
         self.options['run-only'] = ""
         self.options['run-only-pattern'] = ""
         self.options['verbose'] = 0
+        self.options['timeout'] = 2
         self.options['invalid-arg'] = ""
         self.options['show-usage'] = 0
         self.options['pacemaker-remote'] = 0
@@ -1162,6 +1181,8 @@ class TestOptions(object):
                 self.options['list-tests'] = 1
             elif args[i] == "-V" or args[i] == "--verbose":
                 self.options['verbose'] = 1
+            elif args[i] == "-t" or args[i] == "--timeout":
+                self.options['timeout'] = float(args[i+1])
             elif args[i] == "-R" or args[i] == "--pacemaker-remote":
                 self.options['pacemaker-remote'] = 1
             elif args[i] == "-r" or args[i] == "--run-only":
@@ -1181,6 +1202,9 @@ class TestOptions(object):
         print("\t [--list-tests | -l]                  Print out all registered tests.")
         print("\t [--run-only | -r 'testname']         Run a specific test")
         print("\t [--verbose | -V]                     Verbose output")
+        print("\t [--timeout | -t 'floating point number']"
+              "\n\t\tUp to how many seconds each test case waits for the daemon to be initialized."
+              "\n\t\tDefaults to 2. The value 0 means no limit.")
         print("\t [--pacemaker-remote | -R             Test pacemaker-remoted binary instead of pacemaker-execd")
         print("\t [--run-only-pattern | -p 'string']   Run only tests containing the string value")
         print("\n\tExample: Run only the test 'start_stop'")
@@ -1197,7 +1221,8 @@ def main(argv):
     opts = TestOptions()
     opts.build_options(argv)
 
-    tests = Tests(opts.options['verbose'], opts.options['pacemaker-remote'])
+    tests = Tests(opts.options['verbose'], opts.options['pacemaker-remote'],
+                  opts.options['timeout'])
 
     tests.build_generic_tests()
     tests.build_multi_rsc_tests()

--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -155,7 +155,7 @@ class OutputFoundError(TestError):
 class Test(object):
     """ Executor for a single pacemaker-execd regression test """
 
-    def __init__(self, name, description, verbose=0, tls=0, timeout=2):
+    def __init__(self, name, description, verbose=0, tls=0, timeout=2, force_wait=0):
         self.name = name
         self.description = description
         self.cmds = []
@@ -170,6 +170,7 @@ class Test(object):
         self.verbose = verbose
         self.tls = tls
         self.timeout = timeout
+        self.force_wait = force_wait
 
         self.result_txt = ""
         self.cmd_tool_output = ""
@@ -229,10 +230,11 @@ class Test(object):
         while True:
             time.sleep(0.1)
 
-            if logfile == None and os.path.exists(self.logpath):
+            if self.force_wait == 0 and logfile == None \
+               and os.path.exists(self.logpath):
                 logfile = io.open(self.logpath, 'rt', encoding = "ISO-8859-1")
 
-            if logfile != None:
+            if self.force_wait == 0 and logfile != None:
                 for line in logfile.readlines():
                     if "successfully started" in line:
                         return
@@ -240,13 +242,14 @@ class Test(object):
             now = time.time()
 
             if self.timeout > 0 and (now - init_time) >= self.timeout:
-                print("\tDaemon %s doesn't seem to have been initialized within %fs."
-                      "\n\tConsider specifying a longer '--timeout' value."
-                       %(self.daemon_location, self.timeout))
+                if self.force_wait == 0:
+                    print("\tDaemon %s doesn't seem to have been initialized within %fs."
+                          "\n\tConsider specifying a longer '--timeout' value."
+                          %(self.daemon_location, self.timeout))
                 return
 
-            if (now - update_time) >= 5:
-                print("\tWaiting for %s to be initialized: %fs ..."
+            if self.verbose and (now - update_time) >= 5:
+                print("Waiting for %s to be initialized: %fs ..."
                       %(self.daemon_location, now - init_time))
                 update_time = now
 
@@ -399,11 +402,12 @@ class Test(object):
 class Tests(object):
     """ Collection of all pacemaker-execd regression tests """
 
-    def __init__(self, verbose=0, tls=0, timeout=2):
+    def __init__(self, verbose=0, tls=0, timeout=2, force_wait=0):
         self.tests = []
         self.verbose = verbose
         self.tls = tls
         self.timeout = timeout
+        self.force_wait = force_wait
         self.rsc_classes = output_from_command("crm_resource --list-standards")
         self.rsc_classes = self.rsc_classes[:-1] # Strip trailing empty line
         self.installed_files = []
@@ -509,7 +513,7 @@ class Tests(object):
     def new_test(self, name, description):
         """ Create a named test """
 
-        test = Test(name, description, self.verbose, self.tls, self.timeout)
+        test = Test(name, description, self.verbose, self.tls, self.timeout, self.force_wait)
         self.tests.append(test)
         return test
 
@@ -1162,6 +1166,7 @@ class TestOptions(object):
         self.options['run-only-pattern'] = ""
         self.options['verbose'] = 0
         self.options['timeout'] = 2
+        self.options['force-wait'] = 0
         self.options['invalid-arg'] = ""
         self.options['show-usage'] = 0
         self.options['pacemaker-remote'] = 0
@@ -1183,6 +1188,8 @@ class TestOptions(object):
                 self.options['verbose'] = 1
             elif args[i] == "-t" or args[i] == "--timeout":
                 self.options['timeout'] = float(args[i+1])
+            elif args[i] == "-w" or args[i] == "--force-wait":
+                self.options['force-wait'] = 1
             elif args[i] == "-R" or args[i] == "--pacemaker-remote":
                 self.options['pacemaker-remote'] = 1
             elif args[i] == "-r" or args[i] == "--run-only":
@@ -1205,6 +1212,8 @@ class TestOptions(object):
         print("\t [--timeout | -t 'floating point number']"
               "\n\t\tUp to how many seconds each test case waits for the daemon to be initialized."
               "\n\t\tDefaults to 2. The value 0 means no limit.")
+        print("\t [--force-wait | -w]"
+              "\n\t\tEach test case waits the default/specified --timeout for the daemon without tracking the log.")
         print("\t [--pacemaker-remote | -R             Test pacemaker-remoted binary instead of pacemaker-execd")
         print("\t [--run-only-pattern | -p 'string']   Run only tests containing the string value")
         print("\n\tExample: Run only the test 'start_stop'")
@@ -1222,7 +1231,7 @@ def main(argv):
     opts.build_options(argv)
 
     tests = Tests(opts.options['verbose'], opts.options['pacemaker-remote'],
-                  opts.options['timeout'])
+                  opts.options['timeout'], opts.options['force-wait'])
 
     tests.build_generic_tests()
     tests.build_multi_rsc_tests()

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -227,11 +227,12 @@ class XmlValidationError(TestError):
 class Test(object):
     """ Executor for a single test """
 
-    def __init__(self, name, description, verbose=0, with_cpg=0):
+    def __init__(self, name, description, verbose=0, with_cpg=0, timeout=2):
         self.name = name
         self.description = description
         self.cmds = []
         self.verbose = verbose
+        self.timeout = timeout
         self.logpath = "/tmp/stonith-regression.log"
 
         self.result_txt = ""
@@ -287,6 +288,9 @@ class Test(object):
 
         logfile = None
 
+        init_time = time.time()
+        update_time = init_time
+
         while True:
             time.sleep(0.1)
 
@@ -297,6 +301,19 @@ class Test(object):
                 for line in logfile.readlines():
                     if "successfully started" in line:
                         return
+
+            now = time.time()
+
+            if self.timeout > 0 and (now - init_time) >= self.timeout:
+                print("\tDaemon pacemaker-fenced doesn't seem to have been initialized within %fs."
+                      "\n\tConsider specifying a longer '--timeout' value."
+                      %(self.timeout))
+                return
+
+            if (now - update_time) >= 5:
+                print("\tWaiting for pacemaker-fenced to be initialized: %fs ..."
+                      %(now - init_time))
+                update_time = now
 
     def clean_environment(self):
         """ Clean up the host after executing a test """
@@ -521,15 +538,16 @@ class Test(object):
 class Tests(object):
     """ Collection of all fencing regression tests """
 
-    def __init__(self, verbose=0):
+    def __init__(self, verbose=0, timeout=2):
         self.tests = []
         self.verbose = verbose
+        self.timeout = timeout
         self.autogen_corosync_cfg = not os.path.exists("/etc/corosync/corosync.conf")
 
     def new_test(self, name, description, with_cpg=0):
         """ Create a named test """
 
-        test = Test(name, description, self.verbose, with_cpg)
+        test = Test(name, description, self.verbose, with_cpg, self.timeout)
         self.tests.append(test)
         return test
 
@@ -1460,6 +1478,7 @@ class TestOptions(object):
         self.options['run-only'] = ""
         self.options['run-only-pattern'] = ""
         self.options['verbose'] = 0
+        self.options['timeout'] = 2
         self.options['invalid-arg'] = ""
         self.options['cpg-only'] = 0
         self.options['no-cpg'] = 0
@@ -1480,6 +1499,8 @@ class TestOptions(object):
                 self.options['list-tests'] = 1
             elif args[i] == "-V" or args[i] == "--verbose":
                 self.options['verbose'] = 1
+            elif args[i] == "-t" or args[i] == "--timeout":
+                self.options['timeout'] = float(args[i+1])
             elif args[i] == "-n" or args[i] == "--no-cpg":
                 self.options['no-cpg'] = 1
             elif args[i] == "-c" or args[i] == "--cpg-only":
@@ -1503,6 +1524,9 @@ class TestOptions(object):
         print("\t [--no-cpg | -n]                      Only run tests that do not require corosync")
         print("\t [--run-only | -r 'testname']         Run a specific test")
         print("\t [--verbose | -V]                     Verbose output")
+        print("\t [--timeout | -t 'floating point number']"
+              "\n\t\tUp to how many seconds each test case waits for the daemon to be initialized."
+              "\n\t\tDefaults to 2. The value 0 means no limit.")
         print("\t [--run-only-pattern | -p 'string']   Run only tests containing the string value")
         print("\n\tExample: Run only the test 'start_stop'")
         print("\t\t " + sys.argv[0] + " --run-only start_stop")
@@ -1520,7 +1544,7 @@ def main(argv):
 
     use_corosync = 1
 
-    tests = Tests(opts.options['verbose'])
+    tests = Tests(opts.options['verbose'], opts.options['timeout'])
     tests.build_standalone_tests()
     tests.build_custom_timeout_tests()
     tests.build_api_sanity_tests()

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -227,12 +227,13 @@ class XmlValidationError(TestError):
 class Test(object):
     """ Executor for a single test """
 
-    def __init__(self, name, description, verbose=0, with_cpg=0, timeout=2):
+    def __init__(self, name, description, verbose=0, with_cpg=0, timeout=2, force_wait=0):
         self.name = name
         self.description = description
         self.cmds = []
         self.verbose = verbose
         self.timeout = timeout
+        self.force_wait = force_wait
         self.logpath = "/tmp/stonith-regression.log"
 
         self.result_txt = ""
@@ -294,10 +295,11 @@ class Test(object):
         while True:
             time.sleep(0.1)
 
-            if logfile == None and os.path.exists(self.logpath):
+            if self.force_wait == 0 and logfile == None \
+               and os.path.exists(self.logpath):
                 logfile = io.open(self.logpath, 'rt', encoding = "ISO-8859-1")
 
-            if logfile != None:
+            if self.force_wait == 0 and logfile != None:
                 for line in logfile.readlines():
                     if "successfully started" in line:
                         return
@@ -305,13 +307,14 @@ class Test(object):
             now = time.time()
 
             if self.timeout > 0 and (now - init_time) >= self.timeout:
-                print("\tDaemon pacemaker-fenced doesn't seem to have been initialized within %fs."
-                      "\n\tConsider specifying a longer '--timeout' value."
-                      %(self.timeout))
+                if self.force_wait == 0:
+                    print("\tDaemon pacemaker-fenced doesn't seem to have been initialized within %fs."
+                          "\n\tConsider specifying a longer '--timeout' value."
+                          %(self.timeout))
                 return
 
-            if (now - update_time) >= 5:
-                print("\tWaiting for pacemaker-fenced to be initialized: %fs ..."
+            if self.verbose and (now - update_time) >= 5:
+                print("Waiting for pacemaker-fenced to be initialized: %fs ..."
                       %(now - init_time))
                 update_time = now
 
@@ -538,16 +541,17 @@ class Test(object):
 class Tests(object):
     """ Collection of all fencing regression tests """
 
-    def __init__(self, verbose=0, timeout=2):
+    def __init__(self, verbose=0, timeout=2, force_wait=0):
         self.tests = []
         self.verbose = verbose
         self.timeout = timeout
+        self.force_wait = force_wait
         self.autogen_corosync_cfg = not os.path.exists("/etc/corosync/corosync.conf")
 
     def new_test(self, name, description, with_cpg=0):
         """ Create a named test """
 
-        test = Test(name, description, self.verbose, with_cpg, self.timeout)
+        test = Test(name, description, self.verbose, with_cpg, self.timeout, self.force_wait)
         self.tests.append(test)
         return test
 
@@ -1479,6 +1483,7 @@ class TestOptions(object):
         self.options['run-only-pattern'] = ""
         self.options['verbose'] = 0
         self.options['timeout'] = 2
+        self.options['force-wait'] = 0
         self.options['invalid-arg'] = ""
         self.options['cpg-only'] = 0
         self.options['no-cpg'] = 0
@@ -1501,6 +1506,8 @@ class TestOptions(object):
                 self.options['verbose'] = 1
             elif args[i] == "-t" or args[i] == "--timeout":
                 self.options['timeout'] = float(args[i+1])
+            elif args[i] == "-w" or args[i] == "--force-wait":
+                self.options['force-wait'] = 1
             elif args[i] == "-n" or args[i] == "--no-cpg":
                 self.options['no-cpg'] = 1
             elif args[i] == "-c" or args[i] == "--cpg-only":
@@ -1527,6 +1534,8 @@ class TestOptions(object):
         print("\t [--timeout | -t 'floating point number']"
               "\n\t\tUp to how many seconds each test case waits for the daemon to be initialized."
               "\n\t\tDefaults to 2. The value 0 means no limit.")
+        print("\t [--force-wait | -w]"
+              "\n\t\tEach test case waits the default/specified --timeout for the daemon without tracking the log.")
         print("\t [--run-only-pattern | -p 'string']   Run only tests containing the string value")
         print("\n\tExample: Run only the test 'start_stop'")
         print("\t\t " + sys.argv[0] + " --run-only start_stop")
@@ -1544,7 +1553,8 @@ def main(argv):
 
     use_corosync = 1
 
-    tests = Tests(opts.options['verbose'], opts.options['timeout'])
+    tests = Tests(opts.options['verbose'], opts.options['timeout'],
+                  opts.options['force-wait'])
     tests.build_standalone_tests()
     tests.build_custom_timeout_tests()
     tests.build_api_sanity_tests()

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -232,6 +232,7 @@ class Test(object):
         self.description = description
         self.cmds = []
         self.verbose = verbose
+        self.logpath = "/tmp/stonith-regression.log"
 
         self.result_txt = ""
         self.cmd_tool_output = ""
@@ -278,13 +279,24 @@ class Test(object):
             self.stonith_options = self.stonith_options + " -V"
             print("Starting pacemaker-fenced with %s" % self.stonith_options)
 
-        if os.path.exists("/tmp/stonith-regression.log"):
-            os.remove('/tmp/stonith-regression.log')
+        if os.path.exists(self.logpath):
+            os.remove(self.logpath)
 
-        cmd = "pacemaker-fenced %s -l /tmp/stonith-regression.log" % self.stonith_options
+        cmd = "pacemaker-fenced %s -l %s" % (self.stonith_options, self.logpath)
         self.stonith_process = subprocess.Popen(shlex.split(cmd))
 
-        time.sleep(1)
+        logfile = None
+
+        while True:
+            time.sleep(0.1)
+
+            if logfile == None and os.path.exists(self.logpath):
+                logfile = io.open(self.logpath, 'rt', encoding = "ISO-8859-1")
+
+            if logfile != None:
+                for line in logfile.readlines():
+                    if "successfully started" in line:
+                        return
 
     def clean_environment(self):
         """ Clean up the host after executing a test """
@@ -310,7 +322,7 @@ class Test(object):
         # makes fenced output any kind of 8 bit value - while still interesting
         # for debugging and we'd still like the regression-test to go over the
         # full set of test-cases
-        logfile = io.open('/tmp/stonith-regression.log', 'rt', encoding = "ISO-8859-1")
+        logfile = io.open(self.logpath, 'rt', encoding = "ISO-8859-1")
         for line in logfile.readlines():
             self.stonith_output = self.stonith_output + line
 
@@ -318,7 +330,7 @@ class Test(object):
             print("Daemon Output Start")
             print(self.stonith_output)
             print("Daemon Output End")
-        os.remove('/tmp/stonith-regression.log')
+        os.remove(self.logpath)
 
     def add_stonith_log_pattern(self, pattern):
         """ Add a log pattern to expect from this test """


### PR DESCRIPTION
Previously for each test case, it would sleep for 1s waiting for the daemon to be initialized and ready for accepting connections. It would accumulate and become expensive given that there are dozens of test cases.

With this commit, rather than sleeping for 1s, it tracks the log and starts each test case whenever the daemon is shown being ready. So that it will save significant time in total for the whole testing with an average system (for my case, reduced from around 2m40s to 1m40s for cts-fencing, from around 7m15s to 6m35s for cts-exec).

On the other hand, for a system with poor performance, this solution also prevents test failures that are due to impatience (1s sleep might not be sufficient).