### PR TITLE
Try to speed up parse_op_key

### DIFF
--- a/lib/common/operations.c
+++ b/lib/common/operations.c
@@ -183,6 +183,10 @@ try_migrate_notify_match(const char *key, char **rsc_id, char **op_type, guint *
 gboolean
 parse_op_key(const char *key, char **rsc_id, char **op_type, guint *interval_ms)
 {
+    char *underbar1 = NULL;
+    char *underbar2 = NULL;
+    char *underbar3 = NULL;
+
     // Initialize output variables in case of early return
     if (rsc_id) {
         *rsc_id = NULL;
@@ -198,11 +202,25 @@ parse_op_key(const char *key, char **rsc_id, char **op_type, guint *interval_ms)
 
     CRM_CHECK(key && *key, return FALSE);
 
-    if (!try_migrate_notify_match(key, rsc_id, op_type, interval_ms)) {
-        return try_basic_match(key, rsc_id, op_type, interval_ms);
+    underbar1 = strchr(key, '_');
+    if (!underbar1) {
+        return FALSE;
     }
 
-    return TRUE;
+    underbar2 = strchr(underbar1+1, '_');
+    if (!underbar2) {
+        return FALSE;
+    }
+
+    underbar3 = strchr(underbar2+1, '_');
+
+    if (!underbar3) {
+        return try_basic_match(key, rsc_id, op_type, interval_ms);
+    } else if (try_migrate_notify_match(key, rsc_id, op_type, interval_ms)) {
+        return TRUE;
+    } else {
+        return try_basic_match(key, rsc_id, op_type, interval_ms);
+    }
 }
 
 char *

--- a/lib/common/operations.c
+++ b/lib/common/operations.c
@@ -138,7 +138,7 @@ try_migrate_notify_match(const char *key, char **rsc_id, char **op_type, guint *
 {
     int rc = 0;
     size_t nmatch = 8;
-    regmatch_t *pmatch = NULL;
+    regmatch_t pmatch[nmatch];
 
     if (notify_migrate_re == NULL) {
         // cppcheck-suppress memleak
@@ -148,11 +148,8 @@ try_migrate_notify_match(const char *key, char **rsc_id, char **op_type, guint *
         CRM_ASSERT(rc == 0);
     }
 
-    pmatch = calloc(nmatch, sizeof(regmatch_t));
-
     rc = regexec(notify_migrate_re, key, nmatch, pmatch, 0);
     if (rc == REG_NOMATCH) {
-        free(pmatch);
         return FALSE;
     }
 
@@ -176,12 +173,10 @@ try_migrate_notify_match(const char *key, char **rsc_id, char **op_type, guint *
                 *op_type = NULL;
             }
 
-            free(pmatch);
             return FALSE;
         }
     }
 
-    free(pmatch);
     return TRUE;
 }
 


### PR DESCRIPTION
The new parse_op_key is a fair bit slower than the old version, but has the distinct advantage of understanding all the op key formats I know about.  These four patches take various steps to try to speed it up.  On the whole it's faster but still not at the level of the previous version.  Before these changes:

```
$ tools/pcmk_simtimes ~/crm_simulate.2.0.4.out ~/crm_simulate.master.out -s 0.1 -p 5
notify-1                                 2.12s vs 2.26s (+0.14s =  +6.60%)
notify-2                                 2.12s vs 2.25s (+0.13s =  +6.13%)
migrate-stop-start-complex               2.01s vs 2.13s (+0.12s =  +5.97%)
a-demote-then-b-migrate                  3.74s vs 3.93s (+0.19s =  +5.08%)
bug-5059                                 7.85s vs 8.25s (+0.40s =  +5.10%)
novell-239079                            1.81s vs 1.92s (+0.11s =  +6.08%)
group-dependents                         12.19s vs 13.01s (+0.82s =  +6.73%)
novell-239087                            1.24s vs 1.35s (+0.11s =  +8.87%)
load-stopped-loop                        105.08s vs 115.08s (+10.00s =  +9.52%)
load-stopped-loop-2                      12.42s vs 13.23s (+0.81s =  +6.52%)
interleave-stop                          5.32s vs 5.63s (+0.31s =  +5.83%)
interleave-pseudo-stop                   5.29s vs 5.60s (+0.31s =  +5.86%)
coloc-slave-anti                         3.67s vs 3.91s (+0.24s =  +6.54%)
probe-0                                  2.39s vs 2.57s (+0.18s =  +7.53%)
master-2                                 4.86s vs 5.16s (+0.30s =  +6.17%)
bug-1685                                 2.55s vs 2.70s (+0.15s =  +5.88%)
bug-lf-1852                              2.51s vs 2.68s (+0.17s =  +6.77%)
bundle-order-startup-clone               6.38s vs 6.70s (+0.32s =  +5.02%)
not-reschedule-unneeded-monitor          3.79s vs 4.00s (+0.21s =  +5.54%)
master-allow-start                       1.17s vs 1.31s (+0.14s = +11.97%)
params-6                                 139.50s vs 147.89s (+8.39s =  +6.01%)
order-serialize-set                      3.78s vs 4.15s (+0.37s =  +9.79%)
bug-lf-2358                              5.10s vs 5.57s (+0.47s =  +9.22%)
migrate-stop-complex                     1.88s vs 1.98s (+0.10s =  +5.32%)
asymmetric                               1.86s vs 2.02s (+0.16s =  +8.60%)
novell-251689                            3.69s vs 4.01s (+0.32s =  +8.67%)
bug-cl-5213                              1.52s vs 1.65s (+0.13s =  +8.55%)
bug-lf-2317                              2.82s vs 2.99s (+0.17s =  +6.03%)
master-demote                            6.13s vs 6.52s (+0.39s =  +6.36%)
bug-5007-masterslave_colocation          1.41s vs 1.56s (+0.15s = +10.64%)
colocation_constraint_stops_master       2.25s vs 2.39s (+0.14s =  +6.22%)
master-notify                            2.74s vs 2.94s (+0.20s =  +7.30%)
colocated-utilization-clone              2.94s vs 3.11s (+0.17s =  +5.78%)
a-promote-then-b-migrate                 2.59s vs 2.77s (+0.18s =  +6.95%)
master-ordering                          5.34s vs 5.69s (+0.35s =  +6.55%)
migrate-partial-4                        18.88s vs 20.08s (+1.20s =  +6.36%)
bug-lf-2361                              2.55s vs 2.69s (+0.14s =  +5.49%)
novell-252693-2                          6.14s vs 6.53s (+0.39s =  +6.35%)
novell-252693-3                          6.68s vs 7.09s (+0.41s =  +6.14%)
order-serialize                          3.63s vs 3.86s (+0.23s =  +6.34%)
novell-252693                            5.63s vs 5.99s (+0.36s =  +6.39%)
colo_master_w_native                     3.26s vs 3.45s (+0.19s =  +5.83%)
master-dependent-ban                     3.22s vs 3.41s (+0.19s =  +5.90%)
colo_slave_w_native                      3.37s vs 3.56s (+0.19s =  +5.64%)
coloc-clone-stays-active                 33.92s vs 36.43s (+2.51s =  +7.40%)
interleave-restart                       7.85s vs 8.27s (+0.42s =  +5.35%)
master_monitor_restart                   1.03s vs 1.14s (+0.11s = +10.68%)
master-12                                1.87s vs 2.03s (+0.16s =  +8.56%)
bug-1765                                 3.49s vs 3.76s (+0.27s =  +7.74%)
colocation_constraint_stops_slave        1.53s vs 1.64s (+0.11s =  +7.19%)
order_constraint_stops_master            2.52s vs 2.66s (+0.14s =  +5.56%)
migration-ping-pong                      1.68s vs 1.79s (+0.11s =  +6.55%)
```

And then after these changes:
```
$ tools/pcmk_simtimes ~/crm_simulate.2.0.4.out ~/crm_simulate.after.out -s 0.1 -p 5
notify-1                                 2.12s vs 2.24s (+0.12s =  +5.66%)
notify-2                                 2.12s vs 2.25s (+0.13s =  +6.13%)
group-dependents                         12.19s vs 12.97s (+0.78s =  +6.40%)
novell-239087                            1.24s vs 1.34s (+0.10s =  +8.06%)
load-stopped-loop                        105.08s vs 112.17s (+7.09s =  +6.75%)
load-stopped-loop-2                      12.42s vs 13.08s (+0.66s =  +5.31%)
probe-0                                  2.39s vs 2.53s (+0.14s =  +5.86%)
bug-1685                                 2.55s vs 2.69s (+0.14s =  +5.49%)
bug-lf-1852                              2.51s vs 2.64s (+0.13s =  +5.18%)
master-allow-start                       1.17s vs 1.32s (+0.15s = +12.82%)
order-serialize-set                      3.78s vs 4.10s (+0.32s =  +8.47%)
bug-lf-2358                              5.10s vs 5.59s (+0.49s =  +9.61%)
asymmetric                               1.86s vs 2.00s (+0.14s =  +7.53%)
novell-251689                            3.69s vs 3.93s (+0.24s =  +6.50%)
bug-cl-5213                              1.52s vs 1.62s (+0.10s =  +6.58%)
bug-lf-2317                              2.82s vs 3.00s (+0.18s =  +6.38%)
master-demote                            6.13s vs 6.49s (+0.36s =  +5.87%)
master-13                                4.41s vs 4.67s (+0.26s =  +5.90%)
bug-5007-masterslave_colocation          1.41s vs 1.52s (+0.11s =  +7.80%)
colocation_constraint_stops_master       2.25s vs 2.38s (+0.13s =  +5.78%)
master-notify                            2.74s vs 2.90s (+0.16s =  +5.84%)
a-promote-then-b-migrate                 2.59s vs 2.74s (+0.15s =  +5.79%)
master-ordering                          5.34s vs 5.65s (+0.31s =  +5.81%)
order-serialize                          3.63s vs 3.82s (+0.19s =  +5.23%)
colo_master_w_native                     3.26s vs 3.43s (+0.17s =  +5.21%)
master-dependent-ban                     3.22s vs 3.40s (+0.18s =  +5.59%)
colo_slave_w_native                      3.37s vs 3.55s (+0.18s =  +5.34%)
master_monitor_restart                   1.03s vs 1.15s (+0.12s = +11.65%)
master-12                                1.87s vs 2.02s (+0.15s =  +8.02%)
bug-1765                                 3.49s vs 3.69s (+0.20s =  +5.73%)
order_constraint_stops_master            2.52s vs 2.66s (+0.14s =  +5.56%)
migration-ping-pong                      1.68s vs 1.79s (+0.11s =  +6.55%)
```