### PR TITLE
Test: cppcheck: Run cppcheck against certain defines.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -416,11 +416,14 @@ CLANG_checkers =
 # --enable={warning,style,performance,portability,information,all}
 # --inconclusive --std=posix
 CPPCHECK_ARGS ?=
+BASE_CPPCHECK_ARGS = -I include --max-configs=30 --library=posix --library=gnu \
+					 --library=gtk $(GLIB_CFLAGS) -D__GNUC__ --inline-suppr -q
+cppcheck-all:
+	cppcheck $(CPPCHECK_ARGS) $(BASE_CPPCHECK_ARGS) -DBUILD_PUBLIC_LIBPACEMAKER \
+		-DDEFAULT_CONCURRENT_FENCING_TRUE replace lib daemons tools
+
 cppcheck:
-	cppcheck $(CPPCHECK_ARGS) -I include --max-configs=30	\
-		--library=posix --library=gnu --library=gtk	\
-		$(GLIB_CFLAGS) -D__GNUC__			\
-		--inline-suppr -q replace lib daemons tools
+	cppcheck $(CPPCHECK_ARGS) $(BASE_CPPCHECK_ARGS) replace lib daemons tools
 
 clang:
 	test -e $(CLANG_analyzer)


### PR DESCRIPTION
First, run it with nothing defined.  Then, iterate over a list of
defines that change major portions of compilation.  We want to make sure
the build succeeds with these various things defined or not.

Note that ENABLE_VERSIONED_ATTRS is not included at the moment.  This
seems to be less well supported, so it's not yet worth testing.