### PR TITLE
Fix: scheduler: Remove pe_print_expanded_xml print option.

### DIFF
--- a/include/crm/pengine/common.h
+++ b/include/crm/pengine/common.h
@@ -120,8 +120,7 @@ enum pe_print_options {
     pe_print_pending        = (1 << 12),
     pe_print_clone_details  = (1 << 13),
     pe_print_clone_active   = (1 << 14), // Print clone instances only if active
-    pe_print_implicit       = (1 << 15), // Print implicitly created resources
-    pe_print_expanded_xml   = (1 << 16)
+    pe_print_implicit       = (1 << 15)  // Print implicitly created resources
 };
 
 const char *task2text(enum action_tasks task);


### PR DESCRIPTION
I had added this on the assumption that we would want to use the basic
resource formatted output messages for also printing out the XML config
of a resource.  However, we're going to go a different direction and
have the XML come from a separate output message.

So, this option can go away.  It was only ever in -rc1 so it's unlikely
anyone is using it.  I'm not simply reverting the patch that introduced
it because that patch also changed how all these pe_print_* options were
defined, and we'd like to keep that formatting.