### PR TITLE
ipc_client: Use libqb to get auth data for ipcc connections

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,18 @@ gl_EARLY
 gl_SET_CRYPTO_CHECK_DEFAULT([no])
 gl_INIT
 
+# --enable-new-dtags: Use RUNPATH instead of RPATH.
+# It is necessary to have this done before libtool does linker detection.
+# See also: https://github.com/kronosnet/kronosnet/issues/107
+AX_CHECK_LINK_FLAG([-Wl,--enable-new-dtags],
+                  [AM_LDFLAGS=-Wl,--enable-new-dtags],
+                  [AC_MSG_ERROR(["Linker support for --enable-new-dtags is required"])])
+AC_SUBST([AM_LDFLAGS])
+
+saved_LDFLAGS="$LDFLAGS"
+LDFLAGS="$AM_LDFLAGS $LDFLAGS"
 LT_INIT([dlopen])
+LDFLAGS="$saved_LDFLAGS"
 LTDL_INIT([convenience])
 
 AC_TYPE_SIZE_T
@@ -581,8 +592,6 @@ dnl So keep this section to a bare minimum; regard as a "necessary evil".
 case "$host_os" in
     *bsd*)
         AC_DEFINE_UNQUOTED(ON_BSD, 1, Compiling for BSD platform)
-        LIBS="-L/usr/local/lib"
-        CPPFLAGS="$CPPFLAGS -I/usr/local/include"
         INIT_EXT=".sh"
         ;;
     *solaris*)
@@ -1179,8 +1188,10 @@ PKG_CHECK_MODULES(libqb, libqb >= 0.13)
 CPPFLAGS="$libqb_CFLAGS $CPPFLAGS"
 LIBS="$libqb_LIBS $LIBS"
 
-dnl libqb 0.14.0+ (2012-06)
-AC_CHECK_LIB(qb, qb_ipcs_connection_auth_set)
+dnl libqb 2.02+ (2020-10)
+AC_CHECK_FUNCS(qb_ipcc_auth_get,
+               AC_DEFINE(HAVE_IPCC_AUTH_GET, 1,
+                         [Have qb_ipcc_auth_get function]))
 
 PCMK_FEATURES="$PCMK_FEATURES libqb-logging libqb-ipc"
 
@@ -1487,8 +1498,8 @@ else
     PKG_CHECK_MODULES(quorum, libquorum) dnl Fatal
     PKG_CHECK_MODULES(libcorosync_common, libcorosync_common) dnl Fatal
 
-    CFLAGS="$CFLAGS $libqb_FLAGS $cpg_FLAGS $cfg_FLAGS $cmap_CFLAGS $quorum_CFLAGS $libcorosync_common_CFLAGS"
-    COROSYNC_LIBS="$COROSYNC_LIBS $libqb_LIBS $cpg_LIBS $cfg_LIBS $cmap_LIBS $quorum_LIBS $libcorosync_common_LIBS"
+    CFLAGS="$CFLAGS $libqb_CFLAGS $cpg_CFLAGS $cfg_CFLAGS $cmap_CFLAGS $quorum_CFLAGS $libcorosync_common_CFLAGS"
+    COROSYNC_LIBS="$COROSYNC_LIBS $cpg_LIBS $cfg_LIBS $cmap_LIBS $quorum_LIBS $libcorosync_common_LIBS"
     CLUSTERLIBS="$CLUSTERLIBS $COROSYNC_LIBS"
     PC_NAME_CLUSTER="$PC_CLUSTER_NAME libcfg libcmap libcorosync_common libcpg libquorum"
     STACKS="$STACKS corosync-native"
@@ -1541,11 +1552,7 @@ if test $SUPPORT_ACL = no; then
 else
     AC_MSG_RESULT($SUPPORT_ACL)
 
-    SUPPORT_ACL=1
-    AC_CHECK_LIB(qb, qb_ipcs_connection_auth_set)
-    if test $ac_cv_lib_qb_qb_ipcs_connection_auth_set != yes; then
-        SUPPORT_ACL=0
-    fi
+    AC_CHECK_FUNCS(qb_ipcs_connection_auth_set, SUPPORT_ACL=1, SUPPORT_ACL=0)
 
     if test $SUPPORT_ACL = 0; then
         if test $missingisfatal = 0; then

--- a/include/crm/common/ipc.h
+++ b/include/crm/common/ipc.h
@@ -180,7 +180,7 @@ const char *crm_ipc_name(crm_ipc_t * client);
 unsigned int crm_ipc_default_buffer_size(void);
 
 /*!
- * \brief Check the authenticity of the IPC socket peer process
+ * \brief Check the authenticity of the IPC socket peer process (legacy)
  *
  * If everything goes well, peer's authenticity is verified by the means
  * of comparing against provided referential UID and GID (either satisfies),

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -285,4 +285,43 @@ pcmk__ipc_methods_t *pcmk__pacemakerd_api_methods(void);
 G_GNUC_INTERNAL
 extern bool pcmk__is_daemon;
 
+/*!
+ * \brief Check the authenticity of the IPC socket peer process
+ *
+ * If everything goes well, peer's authenticity is verified by the means
+ * of comparing against provided referential UID and GID (either satisfies),
+ * and the result of this check can be deduced from the return value.
+ * As an exception, detected UID of 0 ("root") satisfies arbitrary
+ * provided referential daemon's credentials.
+ *
+ * \param[in]  qb_ipc  libqb client connection if available
+ * \param[in]  sock    IPC related, connected Unix socket to check peer of
+ * \param[in]  refuid  referential UID to check against
+ * \param[in]  refgid  referential GID to check against
+ * \param[out] gotpid  to optionally store obtained PID of the peer
+ *                     (not available on FreeBSD, special value of 1
+ *                     used instead, and the caller is required to
+ *                     special case this value respectively)
+ * \param[out] gotuid  to optionally store obtained UID of the peer
+ * \param[out] gotgid  to optionally store obtained GID of the peer
+ *
+ * \return Standard Pacemaker return code
+ *         ie: 0 if it the connection is authentic
+ *         pcmk_rc_ipc_unauthorized if the connection is not authentic,
+ *         standard errors.
+ *
+ * \note While this function is tolerant on what constitutes authorized
+ *       IPC daemon process (its effective user matches UID=0 or \p refuid,
+ *       or at least its group matches \p refgid), either or both (in case
+ *       of UID=0) mismatches on the expected credentials of such peer
+ *       process \e shall be investigated at the caller when value of 1
+ *       gets returned there, since higher-than-expected privileges in
+ *       respect to the expected/intended credentials possibly violate
+ *       the least privilege principle and may pose an additional risk
+ *       (i.e. such accidental inconsistency shall be eventually fixed).
+ */
+int pcmk__crm_ipc_is_authentic_process(qb_ipcc_connection_t *qb_ipc, int sock, uid_t refuid, gid_t refgid,
+                                       pid_t *gotpid, uid_t *gotuid, gid_t *gotgid);
+
+
 #endif  // CRMCOMMON_PRIVATE__H

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -819,9 +819,9 @@ crm_ipc_connect(crm_ipc_t * client)
         return FALSE;
     }
 
-    if (!(rv = crm_ipc_is_authentic_process(client->pfd.fd, cl_uid, cl_gid,
-                                            &found_pid, &found_uid,
-                                            &found_gid))) {
+    if ((rv = pcmk__crm_ipc_is_authentic_process(client->ipc, client->pfd.fd, cl_uid, cl_gid,
+                                                  &found_pid, &found_uid,
+                                                  &found_gid)) == pcmk_rc_ipc_unauthorized) {
         crm_err("Daemon (IPC %s) is not authentic:"
                 " process %lld (uid: %lld, gid: %lld)",
                 client->name,  (long long) PCMK__SPECIAL_PID_AS_0(found_pid),
@@ -830,12 +830,15 @@ crm_ipc_connect(crm_ipc_t * client)
         errno = ECONNABORTED;
         return FALSE;
 
-    } else if (rv < 0) {
-        errno = -rv;
+    } else if (rv != pcmk_rc_ok) {
         crm_perror(LOG_ERR, "Could not verify authenticity of daemon (IPC %s)",
                    client->name);
         crm_ipc_close(client);
-        errno = -rv;
+        if (rv > 0) {
+            errno = rv;
+        } else {
+            rv = ENOTCONN;
+        }
         return FALSE;
     }
 
@@ -1291,14 +1294,23 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
 }
 
 int
-crm_ipc_is_authentic_process(int sock, uid_t refuid, gid_t refgid,
-                             pid_t *gotpid, uid_t *gotuid, gid_t *gotgid) {
+pcmk__crm_ipc_is_authentic_process(qb_ipcc_connection_t *qb_ipc, int sock, uid_t refuid, gid_t refgid,
+                                   pid_t *gotpid, uid_t *gotuid, gid_t *gotgid)
+{
     int ret = 0;
     pid_t found_pid = 0; uid_t found_uid = 0; gid_t found_gid = 0;
 #if defined(US_AUTH_PEERCRED_UCRED)
     struct ucred ucred;
     socklen_t ucred_len = sizeof(ucred);
+#endif
 
+#ifdef HAVE_QB_IPCC_AUTH_GET
+    if (qb_ipc && !qb_ipcc_auth_get(qb_ipc, &found_pid, &found_uid, &found_gid)) {
+        goto do_checks;
+    }
+#endif
+
+#if defined(US_AUTH_PEERCRED_UCRED)
     if (!getsockopt(sock, SOL_SOCKET, SO_PEERCRED,
                     &ucred, &ucred_len)
                 && ucred_len == sizeof(ucred)) {
@@ -1335,6 +1347,9 @@ crm_ipc_is_authentic_process(int sock, uid_t refuid, gid_t refgid,
     errno = 0;
     if (0) {
 #endif
+#ifdef HAVE_QB_IPCC_AUTH_GET
+    do_checks:
+#endif
         if (gotpid != NULL) {
             *gotpid = found_pid;
         }
@@ -1344,12 +1359,32 @@ crm_ipc_is_authentic_process(int sock, uid_t refuid, gid_t refgid,
         if (gotgid != NULL) {
             *gotgid = found_gid;
         }
-        ret = (found_uid == 0 || found_uid == refuid || found_gid == refgid);
+        if (found_uid == 0 || found_uid == refuid || found_gid == refgid) {
+		ret = 0;
+        } else {
+                ret = pcmk_rc_ipc_unauthorized;
+        }
     } else {
-        ret = (errno > 0) ? -errno : -pcmk_err_generic;
+        ret = (errno > 0) ? errno : pcmk_rc_error;
     }
-
     return ret;
+}
+
+int
+crm_ipc_is_authentic_process(int sock, uid_t refuid, gid_t refgid,
+                             pid_t *gotpid, uid_t *gotuid, gid_t *gotgid)
+{
+    int ret  = pcmk__crm_ipc_is_authentic_process(NULL, sock, refuid, refgid,
+                                                  gotpid, gotuid, gotgid);
+
+    /* The old function had some very odd return codes*/
+    if (ret == 0) {
+        return 1;
+    } else if (ret == pcmk_rc_ipc_unauthorized) {
+        return 0;
+    } else {
+        return pcmk_rc2legacy(ret);
+    }
 }
 
 int
@@ -1379,10 +1414,19 @@ pcmk__ipc_is_authentic_process_active(const char *name, uid_t refuid,
         goto bail;
     }
 
-    auth_rc = crm_ipc_is_authentic_process(fd, refuid, refgid, &found_pid,
-                                           &found_uid, &found_gid);
-    if (auth_rc < 0) {
-        rc = pcmk_legacy2rc(auth_rc);
+    auth_rc = pcmk__crm_ipc_is_authentic_process(c, fd, refuid, refgid, &found_pid,
+                                                 &found_uid, &found_gid);
+    if (auth_rc == pcmk_rc_ipc_unauthorized) {
+        crm_err("Daemon (IPC %s) effectively blocked with unauthorized"
+                " process %lld (uid: %lld, gid: %lld)",
+                name, (long long) PCMK__SPECIAL_PID_AS_0(found_pid),
+                (long long) found_uid, (long long) found_gid);
+        rc = pcmk_rc_ipc_unauthorized;
+        goto bail;
+    }
+
+    if (auth_rc != pcmk_rc_ok) {
+        rc = auth_rc;
         crm_err("Could not get peer credentials from %s IPC: %s "
                 CRM_XS " rc=%d", name, pcmk_rc_str(rc), rc);
         goto bail;
@@ -1390,15 +1434,6 @@ pcmk__ipc_is_authentic_process_active(const char *name, uid_t refuid,
 
     if (gotpid != NULL) {
         *gotpid = found_pid;
-    }
-
-    if (auth_rc == 0) {
-        crm_err("Daemon (IPC %s) effectively blocked with unauthorized"
-                " process %lld (uid: %lld, gid: %lld)",
-                name, (long long) PCMK__SPECIAL_PID_AS_0(found_pid),
-                (long long) found_uid, (long long) found_gid);
-        rc = pcmk_rc_ipc_unauthorized;
-        goto bail;
     }
 
     rc = pcmk_rc_ok;

--- a/m4/ax_check_link_flag.m4
+++ b/m4/ax_check_link_flag.m4
@@ -1,0 +1,74 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_LINK_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the linker or gives an error.
+#   (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_LINK_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,COMPILE}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 5
+
+AC_DEFUN([AX_CHECK_LINK_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_ldflags_$4_$1])dnl
+AC_CACHE_CHECK([whether the linker accepts $1], CACHEVAR, [
+  ax_check_save_flags=$LDFLAGS
+  LDFLAGS="$LDFLAGS $4 $1"
+  AC_LINK_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  LDFLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_LINK_FLAGS


### PR DESCRIPTION
When using libqb in SOCKET mode it uses DGRAM connections
that don't support SO_PEERCRED, so we can't use that to authenticate
the daemons. However, libqb does keep this information so we can
use the (newly created) API call to get it.

This requires a new call, that breaks the API of crm_ipc_is_authentic_process
so we wrap the new call in that one to maintain compatibility with
external users.

This does not work if corosync is using SOCKET connections (set
in corosync.conf) as it does not expose the libqb ipcc object
we need to pass into libqb.

Also this uncovered a bug in the linker options we were using
that caused breakage on FreeBSD, so fix that too.