### PR TITLE
Fix: tests: Use g_assert_true, g_assert_false, and g_assert_null.

### DIFF
--- a/include/portability.h
+++ b/include/portability.h
@@ -85,6 +85,12 @@ g_list_free_full(GList * list, GDestroyNotify free_func)
 }
 #  endif
 
+#  if !GLIB_CHECK_VERSION(2,38,0)
+#    define g_assert_true(expr) g_assert_cmpint((expr), ==, TRUE)
+#    define g_assert_false(expr) g_assert_cmpint((expr), !=, TRUE)
+#    define g_assert_null(expr)  g_assert_cmpint((expr) == NULL, ==, TRUE)
+#  endif
+
 #  if SUPPORT_DBUS
 #    ifndef HAVE_DBUSBASICVALUE
 #      include <stdint.h>

--- a/lib/common/tests/agents/pcmk_stonith_param_test.c
+++ b/lib/common/tests/agents/pcmk_stonith_param_test.c
@@ -15,22 +15,22 @@
 static void
 is_stonith_param(void)
 {
-    g_assert_cmpint(pcmk_stonith_param(NULL), ==, false);
-    g_assert_cmpint(pcmk_stonith_param(""), ==, false);
-    g_assert_cmpint(pcmk_stonith_param("unrecognized"), ==, false);
-    g_assert_cmpint(pcmk_stonith_param("pcmk_unrecognized"), ==, false);
-    g_assert_cmpint(pcmk_stonith_param("x" PCMK_STONITH_ACTION_LIMIT), ==, false);
-    g_assert_cmpint(pcmk_stonith_param(PCMK_STONITH_ACTION_LIMIT "x"), ==, false);
+    g_assert_false(pcmk_stonith_param(NULL));
+    g_assert_false(pcmk_stonith_param(""));
+    g_assert_false(pcmk_stonith_param("unrecognized"));
+    g_assert_false(pcmk_stonith_param("pcmk_unrecognized"));
+    g_assert_false(pcmk_stonith_param("x" PCMK_STONITH_ACTION_LIMIT));
+    g_assert_false(pcmk_stonith_param(PCMK_STONITH_ACTION_LIMIT "x"));
 
-    g_assert_cmpint(pcmk_stonith_param(PCMK_STONITH_ACTION_LIMIT), ==, true);
-    g_assert_cmpint(pcmk_stonith_param(PCMK_STONITH_DELAY_BASE), ==, true);
-    g_assert_cmpint(pcmk_stonith_param(PCMK_STONITH_DELAY_MAX), ==, true);
-    g_assert_cmpint(pcmk_stonith_param(PCMK_STONITH_HOST_ARGUMENT), ==, true);
-    g_assert_cmpint(pcmk_stonith_param(PCMK_STONITH_HOST_CHECK), ==, true);
-    g_assert_cmpint(pcmk_stonith_param(PCMK_STONITH_HOST_LIST), ==, true);
-    g_assert_cmpint(pcmk_stonith_param(PCMK_STONITH_HOST_MAP), ==, true);
-    g_assert_cmpint(pcmk_stonith_param(PCMK_STONITH_PROVIDES), ==, true);
-    g_assert_cmpint(pcmk_stonith_param(PCMK_STONITH_STONITH_TIMEOUT), ==, true);
+    g_assert_true(pcmk_stonith_param(PCMK_STONITH_ACTION_LIMIT));
+    g_assert_true(pcmk_stonith_param(PCMK_STONITH_DELAY_BASE));
+    g_assert_true(pcmk_stonith_param(PCMK_STONITH_DELAY_MAX));
+    g_assert_true(pcmk_stonith_param(PCMK_STONITH_HOST_ARGUMENT));
+    g_assert_true(pcmk_stonith_param(PCMK_STONITH_HOST_CHECK));
+    g_assert_true(pcmk_stonith_param(PCMK_STONITH_HOST_LIST));
+    g_assert_true(pcmk_stonith_param(PCMK_STONITH_HOST_MAP));
+    g_assert_true(pcmk_stonith_param(PCMK_STONITH_PROVIDES));
+    g_assert_true(pcmk_stonith_param(PCMK_STONITH_STONITH_TIMEOUT));
 }
 
 static void
@@ -39,10 +39,10 @@ is_stonith_action_param(void)
     /* Currently, the function accepts any string not containing underbars as
      * the action name, so we do not need to verify particular action names.
      */
-    g_assert_cmpint(pcmk_stonith_param("pcmk_on_unrecognized"), ==, false);
-    g_assert_cmpint(pcmk_stonith_param("pcmk_on_action"), ==, true);
-    g_assert_cmpint(pcmk_stonith_param("pcmk_on_timeout"), ==, true);
-    g_assert_cmpint(pcmk_stonith_param("pcmk_on_retries"), ==, true);
+    g_assert_false(pcmk_stonith_param("pcmk_on_unrecognized"));
+    g_assert_true(pcmk_stonith_param("pcmk_on_action"));
+    g_assert_true(pcmk_stonith_param("pcmk_on_timeout"));
+    g_assert_true(pcmk_stonith_param("pcmk_on_retries"));
 }
 
 int

--- a/lib/common/tests/cmdline/pcmk__cmdline_preproc_test.c
+++ b/lib/common/tests/cmdline/pcmk__cmdline_preproc_test.c
@@ -19,7 +19,7 @@
 
 static void
 empty_input(void) {
-    g_assert_cmpint(pcmk__cmdline_preproc(NULL, "") == NULL, ==, TRUE);
+    g_assert_null(pcmk__cmdline_preproc(NULL, ""));
 }
 
 static void

--- a/lib/common/tests/flags/pcmk_all_flags_set_test.c
+++ b/lib/common/tests/flags/pcmk_all_flags_set_test.c
@@ -13,19 +13,19 @@
 
 static void
 all_set(void) {
-    g_assert_cmpint(pcmk_all_flags_set(0x000, 0x003), ==, false);
-    g_assert_cmpint(pcmk_all_flags_set(0x00f, 0x003), ==, true);
-    g_assert_cmpint(pcmk_all_flags_set(0x00f, 0x010), ==, false);
-    g_assert_cmpint(pcmk_all_flags_set(0x00f, 0x011), ==, false);
-    g_assert_cmpint(pcmk_all_flags_set(0x000, 0x000), ==, true);
-    g_assert_cmpint(pcmk_all_flags_set(0x00f, 0x000), ==, true);
+    g_assert_false(pcmk_all_flags_set(0x000, 0x003));
+    g_assert_true(pcmk_all_flags_set(0x00f, 0x003));
+    g_assert_false(pcmk_all_flags_set(0x00f, 0x010));
+    g_assert_false(pcmk_all_flags_set(0x00f, 0x011));
+    g_assert_true(pcmk_all_flags_set(0x000, 0x000));
+    g_assert_true(pcmk_all_flags_set(0x00f, 0x000));
 }
 
 static void
 one_is_set(void) {
     // pcmk_is_set() is a simple macro alias for pcmk_all_flags_set()
-    g_assert_cmpint(pcmk_is_set(0x00f, 0x001), ==, true);
-    g_assert_cmpint(pcmk_is_set(0x00f, 0x010), ==, false);
+    g_assert_true(pcmk_is_set(0x00f, 0x001));
+    g_assert_false(pcmk_is_set(0x00f, 0x010));
 }
 
 int

--- a/lib/common/tests/flags/pcmk_any_flags_set_test.c
+++ b/lib/common/tests/flags/pcmk_any_flags_set_test.c
@@ -13,13 +13,13 @@
 
 static void
 any_set(void) {
-    g_assert_cmpint(pcmk_any_flags_set(0x000, 0x000), ==, false);
-    g_assert_cmpint(pcmk_any_flags_set(0x000, 0x001), ==, false);
-    g_assert_cmpint(pcmk_any_flags_set(0x00f, 0x001), ==, true);
-    g_assert_cmpint(pcmk_any_flags_set(0x00f, 0x010), ==, false);
-    g_assert_cmpint(pcmk_any_flags_set(0x00f, 0x011), ==, true);
-    g_assert_cmpint(pcmk_any_flags_set(0x000, 0x000), ==, false);
-    g_assert_cmpint(pcmk_any_flags_set(0x00f, 0x000), ==, false);
+    g_assert_false(pcmk_any_flags_set(0x000, 0x000));
+    g_assert_false(pcmk_any_flags_set(0x000, 0x001));
+    g_assert_true(pcmk_any_flags_set(0x00f, 0x001));
+    g_assert_false(pcmk_any_flags_set(0x00f, 0x010));
+    g_assert_true(pcmk_any_flags_set(0x00f, 0x011));
+    g_assert_false(pcmk_any_flags_set(0x000, 0x000));
+    g_assert_false(pcmk_any_flags_set(0x00f, 0x000));
 }
 
 int

--- a/lib/common/tests/operations/parse_op_key_test.c
+++ b/lib/common/tests/operations/parse_op_key_test.c
@@ -10,7 +10,7 @@ basic(void)
     char *ty = NULL;
     guint ms = 0;
 
-    g_assert_cmpint(parse_op_key("Fencing_monitor_60000", &rsc, &ty, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("Fencing_monitor_60000", &rsc, &ty, &ms));
     g_assert_cmpstr(rsc, ==, "Fencing");
     g_assert_cmpstr(ty, ==, "monitor");
     g_assert_cmpint(ms, ==, 60000);
@@ -25,14 +25,14 @@ colon_in_rsc(void)
     char *ty = NULL;
     guint ms = 0;
 
-    g_assert_cmpint(parse_op_key("ClusterIP:0_start_0", &rsc, &ty, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("ClusterIP:0_start_0", &rsc, &ty, &ms));
     g_assert_cmpstr(rsc, ==, "ClusterIP:0");
     g_assert_cmpstr(ty, ==, "start");
     g_assert_cmpint(ms, ==, 0);
     free(rsc);
     free(ty);
 
-    g_assert_cmpint(parse_op_key("imagestoreclone:1_post_notify_stop_0", &rsc, &ty, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("imagestoreclone:1_post_notify_stop_0", &rsc, &ty, &ms));
     g_assert_cmpstr(rsc, ==, "imagestoreclone:1");
     g_assert_cmpstr(ty, ==, "post_notify_stop");
     g_assert_cmpint(ms, ==, 0);
@@ -47,14 +47,14 @@ dashes_in_rsc(void)
     char *ty = NULL;
     guint ms = 0;
 
-    g_assert_cmpint(parse_op_key("httpd-bundle-0_monitor_30000", &rsc, &ty, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("httpd-bundle-0_monitor_30000", &rsc, &ty, &ms));
     g_assert_cmpstr(rsc, ==, "httpd-bundle-0");
     g_assert_cmpstr(ty, ==, "monitor");
     g_assert_cmpint(ms, ==, 30000);
     free(rsc);
     free(ty);
 
-    g_assert_cmpint(parse_op_key("httpd-bundle-ip-192.168.122.132_start_0", &rsc, &ty, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("httpd-bundle-ip-192.168.122.132_start_0", &rsc, &ty, &ms));
     g_assert_cmpstr(rsc, ==, "httpd-bundle-ip-192.168.122.132");
     g_assert_cmpstr(ty, ==, "start");
     g_assert_cmpint(ms, ==, 0);
@@ -69,21 +69,21 @@ migrate_to_from(void)
     char *ty = NULL;
     guint ms = 0;
 
-    g_assert_cmpint(parse_op_key("vm_migrate_from_0", &rsc, &ty, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("vm_migrate_from_0", &rsc, &ty, &ms));
     g_assert_cmpstr(rsc, ==, "vm");
     g_assert_cmpstr(ty, ==, "migrate_from");
     g_assert_cmpint(ms, ==, 0);
     free(rsc);
     free(ty);
 
-    g_assert_cmpint(parse_op_key("vm_migrate_to_0", &rsc, &ty, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("vm_migrate_to_0", &rsc, &ty, &ms));
     g_assert_cmpstr(rsc, ==, "vm");
     g_assert_cmpstr(ty, ==, "migrate_to");
     g_assert_cmpint(ms, ==, 0);
     free(rsc);
     free(ty);
 
-    g_assert_cmpint(parse_op_key("vm_idcc_devel_migrate_to_0", &rsc, &ty, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("vm_idcc_devel_migrate_to_0", &rsc, &ty, &ms));
     g_assert_cmpstr(rsc, ==, "vm_idcc_devel");
     g_assert_cmpstr(ty, ==, "migrate_to");
     g_assert_cmpint(ms, ==, 0);
@@ -98,21 +98,21 @@ pre_post(void)
     char *ty = NULL;
     guint ms = 0;
 
-    g_assert_cmpint(parse_op_key("rsc_drbd_7788:1_post_notify_start_0", &rsc, &ty, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("rsc_drbd_7788:1_post_notify_start_0", &rsc, &ty, &ms));
     g_assert_cmpstr(rsc, ==, "rsc_drbd_7788:1");
     g_assert_cmpstr(ty, ==, "post_notify_start");
     g_assert_cmpint(ms, ==, 0);
     free(rsc);
     free(ty);
 
-    g_assert_cmpint(parse_op_key("rabbitmq-bundle-clone_pre_notify_stop_0", &rsc, &ty, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("rabbitmq-bundle-clone_pre_notify_stop_0", &rsc, &ty, &ms));
     g_assert_cmpstr(rsc, ==, "rabbitmq-bundle-clone");
     g_assert_cmpstr(ty, ==, "pre_notify_stop");
     g_assert_cmpint(ms, ==, 0);
     free(rsc);
     free(ty);
 
-    g_assert_cmpint(parse_op_key("post_notify_start_0", &rsc, &ty, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("post_notify_start_0", &rsc, &ty, &ms));
     g_assert_cmpstr(rsc, ==, "post_notify");
     g_assert_cmpstr(ty, ==, "start");
     g_assert_cmpint(ms, ==, 0);
@@ -126,7 +126,7 @@ skip_rsc(void)
     char *ty = NULL;
     guint ms = 0;
 
-    g_assert_cmpint(parse_op_key("Fencing_monitor_60000", NULL, &ty, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("Fencing_monitor_60000", NULL, &ty, &ms));
     g_assert_cmpstr(ty, ==, "monitor");
     g_assert_cmpint(ms, ==, 60000);
     free(ty);
@@ -138,7 +138,7 @@ skip_ty(void)
     char *rsc = NULL;
     guint ms = 0;
 
-    g_assert_cmpint(parse_op_key("Fencing_monitor_60000", &rsc, NULL, &ms), ==, TRUE);
+    g_assert_true(parse_op_key("Fencing_monitor_60000", &rsc, NULL, &ms));
     g_assert_cmpstr(rsc, ==, "Fencing");
     g_assert_cmpint(ms, ==, 60000);
     free(rsc);
@@ -150,7 +150,7 @@ skip_ms(void)
     char *rsc = NULL;
     char *ty = NULL;
 
-    g_assert_cmpint(parse_op_key("Fencing_monitor_60000", &rsc, &ty, NULL), ==, TRUE);
+    g_assert_true(parse_op_key("Fencing_monitor_60000", &rsc, &ty, NULL));
     g_assert_cmpstr(rsc, ==, "Fencing");
     g_assert_cmpstr(ty, ==, "monitor");
     free(rsc);
@@ -164,14 +164,14 @@ empty_input(void)
     char *ty = NULL;
     guint ms = 0;
 
-    g_assert_cmpint(parse_op_key("", &rsc, &ty, &ms), ==, FALSE);
-    g_assert_cmpint(rsc == NULL, ==, TRUE);
-    g_assert_cmpint(ty == NULL, ==, TRUE);
+    g_assert_false(parse_op_key("", &rsc, &ty, &ms));
+    g_assert_null(rsc);
+    g_assert_null(ty);
     g_assert_cmpint(ms, ==, 0);
 
-    g_assert_cmpint(parse_op_key(NULL, &rsc, &ty, &ms), ==, FALSE);
-    g_assert_cmpint(rsc == NULL, ==, TRUE);
-    g_assert_cmpint(ty == NULL, ==, TRUE);
+    g_assert_false(parse_op_key(NULL, &rsc, &ty, &ms));
+    g_assert_null(rsc);
+    g_assert_null(ty);
     g_assert_cmpint(ms, ==, 0);
 }
 
@@ -182,19 +182,19 @@ malformed_input(void)
     char *ty = NULL;
     guint ms = 0;
 
-    g_assert_cmpint(parse_op_key("httpd-bundle-0", &rsc, &ty, &ms), ==, FALSE);
-    g_assert_cmpint(rsc == NULL, ==, TRUE);
-    g_assert_cmpint(ty == NULL, ==, TRUE);
+    g_assert_false(parse_op_key("httpd-bundle-0", &rsc, &ty, &ms));
+    g_assert_null(rsc);
+    g_assert_null(ty);
     g_assert_cmpint(ms, ==, 0);
 
-    g_assert_cmpint(parse_op_key("httpd-bundle-0_monitor", &rsc, &ty, &ms), ==, FALSE);
-    g_assert_cmpint(rsc == NULL, ==, TRUE);
-    g_assert_cmpint(ty == NULL, ==, TRUE);
+    g_assert_false(parse_op_key("httpd-bundle-0_monitor", &rsc, &ty, &ms));
+    g_assert_null(rsc);
+    g_assert_null(ty);
     g_assert_cmpint(ms, ==, 0);
 
-    g_assert_cmpint(parse_op_key("httpd-bundle-0_30000", &rsc, &ty, &ms), ==, FALSE);
-    g_assert_cmpint(rsc == NULL, ==, TRUE);
-    g_assert_cmpint(ty == NULL, ==, TRUE);
+    g_assert_false(parse_op_key("httpd-bundle-0_30000", &rsc, &ty, &ms));
+    g_assert_null(rsc);
+    g_assert_null(ty);
     g_assert_cmpint(ms, ==, 0);
 }
 

--- a/lib/common/tests/strings/pcmk__char_in_any_str_test.c
+++ b/lib/common/tests/strings/pcmk__char_in_any_str_test.c
@@ -7,29 +7,29 @@
 static void
 empty_list(void)
 {
-    g_assert_cmpint(pcmk__char_in_any_str('x', NULL), ==, false);
-    g_assert_cmpint(pcmk__char_in_any_str('\0', NULL), ==, false);
+    g_assert_false(pcmk__char_in_any_str('x', NULL));
+    g_assert_false(pcmk__char_in_any_str('\0', NULL));
 }
 
 static void
 null_char(void)
 {
-    g_assert_cmpint(pcmk__char_in_any_str('\0', "xxx", "yyy", NULL), ==, true);
-    g_assert_cmpint(pcmk__char_in_any_str('\0', "", NULL), ==, true);
+    g_assert_true(pcmk__char_in_any_str('\0', "xxx", "yyy", NULL));
+    g_assert_true(pcmk__char_in_any_str('\0', "", NULL));
 }
 
 static void
 in_list(void)
 {
-    g_assert_cmpint(pcmk__char_in_any_str('x', "aaa", "bbb", "xxx", NULL), ==, true);
+    g_assert_true(pcmk__char_in_any_str('x', "aaa", "bbb", "xxx", NULL));
 }
 
 static void
 not_in_list(void)
 {
-    g_assert_cmpint(pcmk__char_in_any_str('x', "aaa", "bbb", NULL), ==, false);
-    g_assert_cmpint(pcmk__char_in_any_str('A', "aaa", "bbb", NULL), ==, false);
-    g_assert_cmpint(pcmk__char_in_any_str('x', "", NULL), ==, false);
+    g_assert_false(pcmk__char_in_any_str('x', "aaa", "bbb", NULL));
+    g_assert_false(pcmk__char_in_any_str('A', "aaa", "bbb", NULL));
+    g_assert_false(pcmk__char_in_any_str('x', "", NULL));
 }
 
 int main(int argc, char **argv)

--- a/lib/common/tests/strings/pcmk__str_any_of_test.c
+++ b/lib/common/tests/strings/pcmk__str_any_of_test.c
@@ -6,32 +6,32 @@
 
 static void
 empty_input_list(void) {
-    g_assert_cmpint(pcmk__strcase_any_of("xxx", NULL), ==, false);
-    g_assert_cmpint(pcmk__str_any_of("xxx", NULL), ==, false);
-    g_assert_cmpint(pcmk__strcase_any_of("", NULL), ==, false);
-    g_assert_cmpint(pcmk__str_any_of("", NULL), ==, false);
+    g_assert_false(pcmk__strcase_any_of("xxx", NULL));
+    g_assert_false(pcmk__str_any_of("xxx", NULL));
+    g_assert_false(pcmk__strcase_any_of("", NULL));
+    g_assert_false(pcmk__str_any_of("", NULL));
 }
 
 static void
 empty_string(void) {
-    g_assert_cmpint(pcmk__strcase_any_of("", "xxx", "yyy", NULL), ==, false);
-    g_assert_cmpint(pcmk__str_any_of("", "xxx", "yyy", NULL), ==, false);
-    g_assert_cmpint(pcmk__strcase_any_of(NULL, "xxx", "yyy", NULL), ==, false);
-    g_assert_cmpint(pcmk__str_any_of(NULL, "xxx", "yyy", NULL), ==, false);
+    g_assert_false(pcmk__strcase_any_of("", "xxx", "yyy", NULL));
+    g_assert_false(pcmk__str_any_of("", "xxx", "yyy", NULL));
+    g_assert_false(pcmk__strcase_any_of(NULL, "xxx", "yyy", NULL));
+    g_assert_false(pcmk__str_any_of(NULL, "xxx", "yyy", NULL));
 }
 
 static void
 in_list(void) {
-    g_assert_cmpint(pcmk__strcase_any_of("xxx", "aaa", "bbb", "xxx", NULL), ==, true);
-    g_assert_cmpint(pcmk__str_any_of("xxx", "aaa", "bbb", "xxx", NULL), ==, true);
-    g_assert_cmpint(pcmk__strcase_any_of("XXX", "aaa", "bbb", "xxx", NULL), ==, true);
+    g_assert_true(pcmk__strcase_any_of("xxx", "aaa", "bbb", "xxx", NULL));
+    g_assert_true(pcmk__str_any_of("xxx", "aaa", "bbb", "xxx", NULL));
+    g_assert_true(pcmk__strcase_any_of("XXX", "aaa", "bbb", "xxx", NULL));
 }
 
 static void
 not_in_list(void) {
-    g_assert_cmpint(pcmk__strcase_any_of("xxx", "aaa", "bbb", NULL), ==, false);
-    g_assert_cmpint(pcmk__str_any_of("xxx", "aaa", "bbb", NULL), ==, false);
-    g_assert_cmpint(pcmk__str_any_of("AAA", "aaa", "bbb", NULL), ==, false);
+    g_assert_false(pcmk__strcase_any_of("xxx", "aaa", "bbb", NULL));
+    g_assert_false(pcmk__str_any_of("xxx", "aaa", "bbb", NULL));
+    g_assert_false(pcmk__str_any_of("AAA", "aaa", "bbb", NULL));
 }
 
 int main(int argc, char **argv)

--- a/lib/common/tests/strings/pcmk__strcmp_test.c
+++ b/lib/common/tests/strings/pcmk__strcmp_test.c
@@ -10,9 +10,9 @@ same_pointer(void) {
     const char *s2 = "wxyz";
 
     g_assert_cmpint(pcmk__strcmp(s1, s1, pcmk__str_none), ==, 0);
-    g_assert_cmpint(pcmk__str_eq(s1, s1, pcmk__str_none), ==, true);
+    g_assert_true(pcmk__str_eq(s1, s1, pcmk__str_none));
     g_assert_cmpint(pcmk__strcmp(s1, s2, pcmk__str_none), !=, 0);
-    g_assert_cmpint(pcmk__str_eq(s1, s2, pcmk__str_none), ==, false);
+    g_assert_false(pcmk__str_eq(s1, s2, pcmk__str_none));
     g_assert_cmpint(pcmk__strcmp(NULL, NULL, pcmk__str_none), ==, 0);
 }
 
@@ -21,10 +21,10 @@ one_is_null(void) {
     const char *s1 = "abcd";
 
     g_assert_cmpint(pcmk__strcmp(s1, NULL, pcmk__str_null_matches), ==, 0);
-    g_assert_cmpint(pcmk__str_eq(s1, NULL, pcmk__str_null_matches), ==, true);
+    g_assert_true(pcmk__str_eq(s1, NULL, pcmk__str_null_matches));
     g_assert_cmpint(pcmk__strcmp(NULL, s1, pcmk__str_null_matches), ==, 0);
     g_assert_cmpint(pcmk__strcmp(s1, NULL, pcmk__str_none), >, 0);
-    g_assert_cmpint(pcmk__str_eq(s1, NULL, pcmk__str_none), ==, false);
+    g_assert_false(pcmk__str_eq(s1, NULL, pcmk__str_none));
     g_assert_cmpint(pcmk__strcmp(NULL, s1, pcmk__str_none), <, 0);
 }
 
@@ -34,7 +34,7 @@ case_matters(void) {
     const char *s2 = "ABCD";
 
     g_assert_cmpint(pcmk__strcmp(s1, s2, pcmk__str_none), >, 0);
-    g_assert_cmpint(pcmk__str_eq(s1, s2, pcmk__str_none), ==, false);
+    g_assert_false(pcmk__str_eq(s1, s2, pcmk__str_none));
     g_assert_cmpint(pcmk__strcmp(s2, s1, pcmk__str_none), <, 0);
 }
 
@@ -44,7 +44,7 @@ case_insensitive(void) {
     const char *s2 = "ABCD";
 
     g_assert_cmpint(pcmk__strcmp(s1, s2, pcmk__str_casei), ==, 0);
-    g_assert_cmpint(pcmk__str_eq(s1, s2, pcmk__str_casei), ==, true);
+    g_assert_true(pcmk__str_eq(s1, s2, pcmk__str_casei));
 }
 
 static void
@@ -55,13 +55,13 @@ regex(void) {
     g_assert_cmpint(pcmk__strcmp(NULL, "a..d", pcmk__str_regex), ==, 1);
     g_assert_cmpint(pcmk__strcmp(s1, NULL, pcmk__str_regex), ==, 1);
     g_assert_cmpint(pcmk__strcmp(s1, "a..d", pcmk__str_regex), ==, 0);
-    g_assert_cmpint(pcmk__str_eq(s1, "a..d", pcmk__str_regex), ==, true);
+    g_assert_true(pcmk__str_eq(s1, "a..d", pcmk__str_regex));
     g_assert_cmpint(pcmk__strcmp(s1, "xxyy", pcmk__str_regex), !=, 0);
-    g_assert_cmpint(pcmk__str_eq(s1, "xxyy", pcmk__str_regex), ==, false);
+    g_assert_false(pcmk__str_eq(s1, "xxyy", pcmk__str_regex));
     g_assert_cmpint(pcmk__strcmp(s2, "a..d", pcmk__str_regex|pcmk__str_casei), ==, 0);
-    g_assert_cmpint(pcmk__str_eq(s2, "a..d", pcmk__str_regex|pcmk__str_casei), ==, true);
+    g_assert_true(pcmk__str_eq(s2, "a..d", pcmk__str_regex|pcmk__str_casei));
     g_assert_cmpint(pcmk__strcmp(s2, "a..d", pcmk__str_regex), !=, 0);
-    g_assert_cmpint(pcmk__str_eq(s2, "a..d", pcmk__str_regex), ==, false);
+    g_assert_false(pcmk__str_eq(s2, "a..d", pcmk__str_regex));
     g_assert_cmpint(pcmk__strcmp(s2, "*ab", pcmk__str_regex), ==, 1);
 }
 

--- a/lib/common/tests/utils/pcmk_str_is_infinity_test.c
+++ b/lib/common/tests/utils/pcmk_str_is_infinity_test.c
@@ -7,39 +7,39 @@
 static void
 uppercase_str_passes(void)
 {
-    g_assert_cmpint(pcmk_str_is_infinity("INFINITY"), ==, true);
-    g_assert_cmpint(pcmk_str_is_infinity("+INFINITY"), ==, true);
+    g_assert_true(pcmk_str_is_infinity("INFINITY"));
+    g_assert_true(pcmk_str_is_infinity("+INFINITY"));
 }
 
 static void
 mixed_case_str_fails(void)
 {
-    g_assert_cmpint(pcmk_str_is_infinity("infinity"), ==, false);
-    g_assert_cmpint(pcmk_str_is_infinity("+infinity"), ==, false);
-    g_assert_cmpint(pcmk_str_is_infinity("Infinity"), ==, false);
-    g_assert_cmpint(pcmk_str_is_infinity("+Infinity"), ==, false);
+    g_assert_false(pcmk_str_is_infinity("infinity"));
+    g_assert_false(pcmk_str_is_infinity("+infinity"));
+    g_assert_false(pcmk_str_is_infinity("Infinity"));
+    g_assert_false(pcmk_str_is_infinity("+Infinity"));
 }
 
 static void
 added_whitespace_fails(void)
 {
-    g_assert_cmpint(pcmk_str_is_infinity(" INFINITY"), ==, false);
-    g_assert_cmpint(pcmk_str_is_infinity("INFINITY "), ==, false);
-    g_assert_cmpint(pcmk_str_is_infinity(" INFINITY "), ==, false);
-    g_assert_cmpint(pcmk_str_is_infinity("+ INFINITY"), ==, false);
+    g_assert_false(pcmk_str_is_infinity(" INFINITY"));
+    g_assert_false(pcmk_str_is_infinity("INFINITY "));
+    g_assert_false(pcmk_str_is_infinity(" INFINITY "));
+    g_assert_false(pcmk_str_is_infinity("+ INFINITY"));
 }
 
 static void
 empty_str_fails(void)
 {
-    g_assert_cmpint(pcmk_str_is_infinity(NULL), ==, false);
-    g_assert_cmpint(pcmk_str_is_infinity(""), ==, false);
+    g_assert_false(pcmk_str_is_infinity(NULL));
+    g_assert_false(pcmk_str_is_infinity(""));
 }
 
 static void
 minus_infinity_fails(void)
 {
-    g_assert_cmpint(pcmk_str_is_infinity("-INFINITY"), ==, false);
+    g_assert_false(pcmk_str_is_infinity("-INFINITY"));
 }
 
 int main(int argc, char **argv)

--- a/lib/common/tests/utils/pcmk_str_is_minus_infinity_test.c
+++ b/lib/common/tests/utils/pcmk_str_is_minus_infinity_test.c
@@ -7,36 +7,36 @@
 static void
 uppercase_str_passes(void)
 {
-    g_assert_cmpint(pcmk_str_is_minus_infinity("-INFINITY"), ==, true);
+    g_assert_true(pcmk_str_is_minus_infinity("-INFINITY"));
 }
 
 static void
 mixed_case_str_fails(void)
 {
-    g_assert_cmpint(pcmk_str_is_minus_infinity("-infinity"), ==, false);
-    g_assert_cmpint(pcmk_str_is_minus_infinity("-Infinity"), ==, false);
+    g_assert_false(pcmk_str_is_minus_infinity("-infinity"));
+    g_assert_false(pcmk_str_is_minus_infinity("-Infinity"));
 }
 
 static void
 added_whitespace_fails(void)
 {
-    g_assert_cmpint(pcmk_str_is_minus_infinity(" -INFINITY"), ==, false);
-    g_assert_cmpint(pcmk_str_is_minus_infinity("-INFINITY "), ==, false);
-    g_assert_cmpint(pcmk_str_is_minus_infinity(" -INFINITY "), ==, false);
-    g_assert_cmpint(pcmk_str_is_minus_infinity("- INFINITY"), ==, false);
+    g_assert_false(pcmk_str_is_minus_infinity(" -INFINITY"));
+    g_assert_false(pcmk_str_is_minus_infinity("-INFINITY "));
+    g_assert_false(pcmk_str_is_minus_infinity(" -INFINITY "));
+    g_assert_false(pcmk_str_is_minus_infinity("- INFINITY"));
 }
 
 static void
 empty_str_fails(void)
 {
-    g_assert_cmpint(pcmk_str_is_minus_infinity(NULL), ==, false);
-    g_assert_cmpint(pcmk_str_is_minus_infinity(""), ==, false);
+    g_assert_false(pcmk_str_is_minus_infinity(NULL));
+    g_assert_false(pcmk_str_is_minus_infinity(""));
 }
 
 static void
 infinity_fails(void)
 {
-    g_assert_cmpint(pcmk_str_is_minus_infinity("INFINITY"), ==, false);
+    g_assert_false(pcmk_str_is_minus_infinity("INFINITY"));
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
These macros were defined in glib 2.38, which we can't use and it seems
like we won't be able to use it any time soon.  Luckily, it's easy
enough to define these in terms of other glib assertion macros in the
case we're on an older system.  That's basically what we were already
doing.  Now we'll only be doing it some of the time instead of all of
the time.