### PR TITLE
Build: libcrmcommon: export prefix and exec_prefix via pkg-config

### DIFF
--- a/lib/pacemaker.pc.in
+++ b/lib/pacemaker.pc.in
@@ -2,6 +2,8 @@ sub=crmcommon
 libdir=@libdir@
 includedir=@includedir@/@PACKAGE_TARNAME@
 
+prefix=@prefix@
+exec_prefix=@exec_prefix@
 daemon_group=@CRM_DAEMON_GROUP@
 daemon_user=@CRM_DAEMON_USER@
 daemondir=@CRM_DAEMON_DIR@


### PR DESCRIPTION
... so other packages can detect where pacemaker is, if installed in a
nonstandard location. This is useful mainly for CI purposes.