### PR TITLE
Build: rpm: Fix python2 vs. python3 problems on SuSE.

### DIFF
--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -192,10 +192,15 @@
 %define python_site %{?python2_sitelib}%{!?python2_sitelib:%(
   %{python_path} -c 'from distutils.sysconfig import get_python_lib as gpl; print(gpl(1))' 2>/dev/null)}
 %else
+%if %{defined python_version}
+%global python_name python%(echo %{python_version} | cut -d'.' -f1)
+%define python_path %{?__python}%{!?__python:/usr/bin/%{python_name}}
+%else
 %global python_name python
 %global python_path %{?__python}%{!?__python:/usr/bin/python%{?python_pkgversion}}
+%endif
 %define python_site %{?python_sitelib}%{!?python_sitelib:%(
-  python -c 'from distutils.sysconfig import get_python_lib as gpl; print(gpl(1))' 2>/dev/null)}
+  %{python_name} -c 'from distutils.sysconfig import get_python_lib as gpl; print(gpl(1))' 2>/dev/null)}
 %endif
 %endif
 


### PR DESCRIPTION
Package builds on SuSE Tumbleweed are failing because the spec file
installs compiled CTS python files into /usr/bin/python2.X, but then
tries to package up files in /usr/bin/python3.X.

The problem here is that python_sitelib is already defined on SuSE, so
our attempts at setting it will never happen.  Thus, we end up with
%{python}=python (which is actually python2), and
%{python_sitelib}=/usr/lib/python3.X.

As a fix, we can set %{python}=python3 if the %{python_version} macro is
set.  Fedora really doesn't want us using this (and will fail if it is
used), but this piece of code should never be run on Fedora anyway.
This is the last ditch effort to set these variables.