### PR TITLE
Minor scheduler digest fixes and refactoring

### DIFF
--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -136,6 +136,10 @@ const char *pcmk__xe_add_last_written(xmlNode *xe);
 xmlNode *pcmk__xe_match(xmlNode *parent, const char *node_name,
                         const char *attr_n, const char *attr_v);
 
+void pcmk__xe_remove_matching_attrs(xmlNode *element,
+                                    bool (*match)(xmlAttrPtr, void *),
+                                    void *user_data);
+
 /*!
  * \internal
  * \brief Get the root directory to scan XML artefacts of given kind for

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -255,4 +255,18 @@ void
 pcmk__xe_set_props(xmlNodePtr node, ...)
 G_GNUC_NULL_TERMINATED;
 
+/*!
+ * \internal
+ * \brief Get first attribute of an XML element
+ *
+ * \param[in] xe  XML element to check
+ *
+ * \return First attribute of \p xe (or NULL if \p xe is NULL or has none)
+ */
+static inline xmlAttr *
+pcmk__xe_first_attr(const xmlNode *xe)
+{
+    return (xe == NULL)? NULL : xe->properties;
+}
+
 #endif // PCMK__XML_INTERNAL__H

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -503,7 +503,7 @@ typedef struct op_digest_cache_s {
 } op_digest_cache_t;
 
 op_digest_cache_t *pe__calculate_digests(pe_resource_t *rsc, const char *task,
-                                         const char *key, pe_node_t *node,
+                                         guint *interval_ms, pe_node_t *node,
                                          xmlNode *xml_op, GHashTable *overrides,
                                          bool calc_secure,
                                          pe_working_set_t *data_set);

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -141,12 +141,6 @@ void pcmk__mark_xml_attr_dirty(xmlAttr *a);
 G_GNUC_INTERNAL
 bool pcmk__xa_filterable(const char *name);
 
-static inline xmlAttr *
-pcmk__first_xml_attr(const xmlNode *xml)
-{
-    return xml? xml->properties : NULL;
-}
-
 static inline const char *
 pcmk__xml_attr_value(const xmlAttr *attr)
 {

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -163,7 +163,7 @@ pcmk_xml_attrs2nvpairs(xmlNode *xml)
 {
     GSList *result = NULL;
 
-    for (xmlAttrPtr iter = pcmk__first_xml_attr(xml); iter != NULL;
+    for (xmlAttrPtr iter = pcmk__xe_first_attr(xml); iter != NULL;
          iter = iter->next) {
 
         result = pcmk_prepend_nvpair(result,
@@ -925,7 +925,7 @@ xml2list(xmlNode *parent)
 
     crm_log_xml_trace(nvpair_list, "Unpacking");
 
-    for (pIter = pcmk__first_xml_attr(nvpair_list); pIter != NULL;
+    for (pIter = pcmk__xe_first_attr(nvpair_list); pIter != NULL;
          pIter = pIter->next) {
 
         const char *p_name = (const char *)pIter->name;

--- a/lib/common/operations.c
+++ b/lib/common/operations.c
@@ -362,14 +362,14 @@ decode_transition_key(const char *key, char **uuid, int *transition_id, int *act
     return TRUE;
 }
 
-#define CRM_META_LEN (sizeof(CRM_META) - 1)
+// String length of CRM_META"_"
+#define CRM_META_LEN sizeof(CRM_META)
 
 // Return true if a is an attribute that should be filtered
 static bool
 should_filter_for_digest(xmlAttrPtr a, void *user_data)
 {
-    // @TODO CRM_META check should be case-sensitive
-    return (strncasecmp((const char *) a->name, CRM_META, CRM_META_LEN) == 0)
+    return (strncmp((const char *) a->name, CRM_META "_", CRM_META_LEN) == 0)
            || pcmk__str_any_of((const char *) a->name,
                                XML_ATTR_ID,
                                XML_ATTR_CRM_VERSION,

--- a/lib/common/operations.c
+++ b/lib/common/operations.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -362,22 +362,22 @@ decode_transition_key(const char *key, char **uuid, int *transition_id, int *act
     return TRUE;
 }
 
-// String length of CRM_META"_"
-#define CRM_META_LEN sizeof(CRM_META)
-
 // Return true if a is an attribute that should be filtered
 static bool
 should_filter_for_digest(xmlAttrPtr a, void *user_data)
 {
-    return (strncmp((const char *) a->name, CRM_META "_", CRM_META_LEN) == 0)
-           || pcmk__str_any_of((const char *) a->name,
-                               XML_ATTR_ID,
-                               XML_ATTR_CRM_VERSION,
-                               XML_LRM_ATTR_OP_DIGEST,
-                               XML_LRM_ATTR_TARGET,
-                               XML_LRM_ATTR_TARGET_UUID,
-                               "pcmk_external_ip",
-                               NULL);
+    if (strncmp((const char *) a->name, CRM_META "_",
+                sizeof(CRM_META " ") - 1) == 0) {
+        return true;
+    }
+    return pcmk__str_any_of((const char *) a->name,
+                            XML_ATTR_ID,
+                            XML_ATTR_CRM_VERSION,
+                            XML_LRM_ATTR_OP_DIGEST,
+                            XML_LRM_ATTR_TARGET,
+                            XML_LRM_ATTR_TARGET_UUID,
+                            "pcmk_external_ip",
+                            NULL);
 }
 
 /*!

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -112,7 +112,7 @@ add_xml_changes_to_patchset(xmlNode *xml, xmlNode *patchset)
     }
 
     // Check each of the XML node's attributes for changes
-    for (pIter = pcmk__first_xml_attr(xml); pIter != NULL;
+    for (pIter = pcmk__xe_first_attr(xml); pIter != NULL;
          pIter = pIter->next) {
         xmlNode *attr = NULL;
 
@@ -156,7 +156,7 @@ add_xml_changes_to_patchset(xmlNode *xml, xmlNode *patchset)
         change = create_xml_node(change->parent, XML_DIFF_RESULT);
         result = create_xml_node(change, (const char *)xml->name);
 
-        for (pIter = pcmk__first_xml_attr(xml); pIter != NULL;
+        for (pIter = pcmk__xe_first_attr(xml); pIter != NULL;
              pIter = pIter->next) {
             p = pIter->_private;
             if (!pcmk_is_set(p->flags, xpf_deleted)) {
@@ -677,7 +677,7 @@ process_v1_removals(xmlNode *target, xmlNode *patch)
         return;
     }
 
-    for (xIter = pcmk__first_xml_attr(patch); xIter != NULL;
+    for (xIter = pcmk__xe_first_attr(patch); xIter != NULL;
          xIter = xIter->next) {
         const char *p_name = (const char *)xIter->name;
 
@@ -745,7 +745,7 @@ process_v1_additions(xmlNode *parent, xmlNode *target, xmlNode *patch)
               return);
     CRM_CHECK(pcmk__str_eq(ID(target), ID(patch), pcmk__str_casei), return);
 
-    for (xIter = pcmk__first_xml_attr(patch); xIter != NULL;
+    for (xIter = pcmk__xe_first_attr(patch); xIter != NULL;
          xIter = xIter->next) {
         const char *p_name = (const char *) xIter->name;
         const char *p_value = crm_element_value(patch, p_name);
@@ -1204,7 +1204,7 @@ apply_v2_patchset(xmlNode *xml, xmlNode *patchset)
             free_xml(match);
 
         } else if (strcmp(op, "modify") == 0) {
-            xmlAttr *pIter = pcmk__first_xml_attr(match);
+            xmlAttr *pIter = pcmk__xe_first_attr(match);
             xmlNode *attrs = NULL;
 
             attrs = pcmk__xml_first_child(first_named_child(change,
@@ -1220,7 +1220,7 @@ apply_v2_patchset(xmlNode *xml, xmlNode *patchset)
                 xml_remove_prop(match, name);
             }
 
-            for (pIter = pcmk__first_xml_attr(attrs); pIter != NULL;
+            for (pIter = pcmk__xe_first_attr(attrs); pIter != NULL;
                  pIter = pIter->next) {
                 const char *name = (const char *) pIter->name;
                 const char *value = crm_element_value(attrs, name);
@@ -1553,7 +1553,7 @@ subtract_xml_object(xmlNode *parent, xmlNode *left, xmlNode *right,
     } else if (full) {
         xmlAttrPtr pIter = NULL;
 
-        for (pIter = pcmk__first_xml_attr(left); pIter != NULL;
+        for (pIter = pcmk__xe_first_attr(left); pIter != NULL;
              pIter = pIter->next) {
             const char *p_name = (const char *)pIter->name;
             const char *p_value = pcmk__xml_attr_value(pIter);
@@ -1566,7 +1566,7 @@ subtract_xml_object(xmlNode *parent, xmlNode *left, xmlNode *right,
     }
 
     // Changes to name/value pairs
-    for (xIter = pcmk__first_xml_attr(left); xIter != NULL;
+    for (xIter = pcmk__xe_first_attr(left); xIter != NULL;
          xIter = xIter->next) {
         const char *prop_name = (const char *) xIter->name;
         xmlAttrPtr right_attr = NULL;
@@ -1594,7 +1594,7 @@ subtract_xml_object(xmlNode *parent, xmlNode *left, xmlNode *right,
             if (full) {
                 xmlAttrPtr pIter = NULL;
 
-                for (pIter = pcmk__first_xml_attr(left); pIter != NULL;
+                for (pIter = pcmk__xe_first_attr(left); pIter != NULL;
                      pIter = pIter->next) {
                     const char *p_name = (const char *) pIter->name;
                     const char *p_value = pcmk__xml_attr_value(pIter);
@@ -1624,7 +1624,7 @@ subtract_xml_object(xmlNode *parent, xmlNode *left, xmlNode *right,
 
                     crm_trace("Changes detected to %s in <%s id=%s>", prop_name,
                               crm_element_name(left), id);
-                    for (pIter = pcmk__first_xml_attr(left); pIter != NULL;
+                    for (pIter = pcmk__xe_first_attr(left); pIter != NULL;
                          pIter = pIter->next) {
                         const char *p_name = (const char *) pIter->name;
                         const char *p_value = pcmk__xml_attr_value(pIter);

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -279,15 +279,10 @@ xml_repair_v1_diff(xmlNode *last, xmlNode *next, xmlNode *local_diff,
         crm_xml_add(diff_child, vfields[lpc], value);
     }
 
-    if (next) {
-        xmlAttrPtr xIter = NULL;
+    for (xmlAttrPtr a = pcmk__xe_first_attr(next); a != NULL; a = a->next) {
+        const char *p_value = crm_element_value(next, (const char *) a->name);
 
-        for (xIter = next->properties; xIter; xIter = xIter->next) {
-            const char *p_name = (const char *) xIter->name;
-            const char *p_value = crm_element_value(next, p_name);
-
-            xmlSetProp(cib, (pcmkXmlStr) p_name, (pcmkXmlStr) p_value);
-        }
+        xmlSetProp(cib, a->name, (pcmkXmlStr) p_value);
     }
 
     crm_log_xml_explicit(local_diff, "Repaired-diff");

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -637,10 +637,13 @@ pcmk__xe_remove_matching_attrs(xmlNode *element,
         next = a->next; // Grab now because attribute might get removed
         if ((match == NULL) || match(a, user_data)) {
             if (!pcmk__check_acl(element, NULL, xpf_acl_write)) {
-                crm_trace("ACLs prevent removal of %s attribute from %s element",
+                crm_trace("ACLs prevent removal of attributes (%s and "
+                          "possibly others) from %s element",
                           (const char *) a->name, (const char *) element->name);
+                return; // ACLs apply to element, not particular attributes
+            }
 
-            } else if (pcmk__tracking_xml_changes(element, false)) {
+            if (pcmk__tracking_xml_changes(element, false)) {
                 // Leave (marked for removal) until after diff is calculated
                 set_parent_flag(element, xpf_dirty);
                 pcmk__set_xml_flags((xml_private_t *) a->_private, xpf_deleted);

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -337,7 +337,7 @@ accept_attr_deletions(xmlNode *xml)
     xml_private_t *p = xml->_private;
 
     p->flags = xpf_none;
-    pIter = pcmk__first_xml_attr(xml);
+    pIter = pcmk__xe_first_attr(xml);
 
     while (pIter != NULL) {
         const xmlChar *name = pIter->name;
@@ -528,11 +528,9 @@ copy_in_properties(xmlNode * target, xmlNode * src)
         crm_err("No node to copy properties into");
 
     } else {
-        xmlAttrPtr pIter = NULL;
-
-        for (pIter = pcmk__first_xml_attr(src); pIter != NULL; pIter = pIter->next) {
-            const char *p_name = (const char *)pIter->name;
-            const char *p_value = pcmk__xml_attr_value(pIter);
+        for (xmlAttrPtr a = pcmk__xe_first_attr(src); a != NULL; a = a->next) {
+            const char *p_name = (const char *) a->name;
+            const char *p_value = pcmk__xml_attr_value(a);
 
             expand_plus_plus(target, p_name, p_value);
         }
@@ -546,11 +544,10 @@ fix_plus_plus_recursive(xmlNode * target)
 {
     /* TODO: Remove recursion and use xpath searches for value++ */
     xmlNode *child = NULL;
-    xmlAttrPtr pIter = NULL;
 
-    for (pIter = pcmk__first_xml_attr(target); pIter != NULL; pIter = pIter->next) {
-        const char *p_name = (const char *)pIter->name;
-        const char *p_value = pcmk__xml_attr_value(pIter);
+    for (xmlAttrPtr a = pcmk__xe_first_attr(target); a != NULL; a = a->next) {
+        const char *p_name = (const char *) a->name;
+        const char *p_value = pcmk__xml_attr_value(a);
 
         expand_plus_plus(target, p_name, p_value);
     }
@@ -1429,7 +1426,6 @@ pcmk__xe_log(int log_level, const char *file, const char *function, int line,
     const char *hidden = NULL;
 
     xmlNode *child = NULL;
-    xmlAttrPtr pIter = NULL;
 
     if ((data == NULL) || (log_level == LOG_NEVER)) {
         return;
@@ -1449,10 +1445,12 @@ pcmk__xe_log(int log_level, const char *file, const char *function, int line,
             buffer_print(buffer, max, offset, "<%s", name);
 
             hidden = crm_element_value(data, "hidden");
-            for (pIter = pcmk__first_xml_attr(data); pIter != NULL; pIter = pIter->next) {
-                xml_private_t *p = pIter->_private;
-                const char *p_name = (const char *)pIter->name;
-                const char *p_value = pcmk__xml_attr_value(pIter);
+            for (xmlAttrPtr a = pcmk__xe_first_attr(data); a != NULL;
+                 a = a->next) {
+
+                xml_private_t *p = a->_private;
+                const char *p_name = (const char *) a->name;
+                const char *p_value = pcmk__xml_attr_value(a);
                 char *p_copy = NULL;
 
                 if (pcmk_is_set(p->flags, xpf_deleted)) {
@@ -1526,7 +1524,6 @@ log_xml_changes(int log_level, const char *file, const char *function, int line,
     xml_private_t *p;
     char *prefix_m = NULL;
     xmlNode *child = NULL;
-    xmlAttrPtr pIter = NULL;
 
     if ((data == NULL) || (log_level == LOG_NEVER)) {
         return;
@@ -1566,10 +1563,10 @@ log_xml_changes(int log_level, const char *file, const char *function, int line,
         pcmk__xe_log(log_level, file, function, line, flags, data, depth,
                      options|xml_log_option_open);
 
-        for (pIter = pcmk__first_xml_attr(data); pIter != NULL; pIter = pIter->next) {
-            const char *aname = (const char*)pIter->name;
+        for (xmlAttrPtr a = pcmk__xe_first_attr(data); a != NULL; a = a->next) {
+            const char *aname = (const char*) a->name;
 
-            p = pIter->_private;
+            p = a->_private;
             if (pcmk_is_set(p->flags, xpf_deleted)) {
                 const char *value = crm_element_value(data, aname);
                 flags = prefix_del;
@@ -1684,11 +1681,9 @@ log_data_element(int log_level, const char *file, const char *function, int line
 static void
 dump_filtered_xml(xmlNode * data, int options, char **buffer, int *offset, int *max)
 {
-    xmlAttrPtr xIter = NULL;
-
-    for (xIter = pcmk__first_xml_attr(data); xIter != NULL; xIter = xIter->next) {
-        if (!pcmk__xa_filterable((const char *) (xIter->name))) {
-            dump_xml_attr(xIter, options, buffer, offset, max);
+    for (xmlAttrPtr a = pcmk__xe_first_attr(data); a != NULL; a = a->next) {
+        if (!pcmk__xa_filterable((const char *) (a->name))) {
+            dump_xml_attr(a, options, buffer, offset, max);
         }
     }
 }
@@ -1722,10 +1717,8 @@ dump_xml_element(xmlNode * data, int options, char **buffer, int *offset, int *m
         dump_filtered_xml(data, options, buffer, offset, max);
 
     } else {
-        xmlAttrPtr xIter = NULL;
-
-        for (xIter = pcmk__first_xml_attr(data); xIter != NULL; xIter = xIter->next) {
-            dump_xml_attr(xIter, options, buffer, offset, max);
+        for (xmlAttrPtr a = pcmk__xe_first_attr(data); a != NULL; a = a->next) {
+            dump_xml_attr(a, options, buffer, offset, max);
         }
     }
 
@@ -2062,7 +2055,7 @@ save_xml_to_file(xmlNode * xml, const char *desc, const char *filename)
 static void
 set_attrs_flag(xmlNode *xml, enum xml_private_flags flag)
 {
-    for (xmlAttr *attr = pcmk__first_xml_attr(xml); attr; attr = attr->next) {
+    for (xmlAttr *attr = pcmk__xe_first_attr(xml); attr; attr = attr->next) {
         pcmk__set_xml_flags((xml_private_t *) (attr->_private), flag);
     }
 }
@@ -2152,7 +2145,7 @@ mark_attr_moved(xmlNode *new_xml, const char *element, xmlAttr *old_attr,
 static void
 xml_diff_old_attrs(xmlNode *old_xml, xmlNode *new_xml)
 {
-    xmlAttr *attr_iter = pcmk__first_xml_attr(old_xml);
+    xmlAttr *attr_iter = pcmk__xe_first_attr(old_xml);
 
     while (attr_iter != NULL) {
         xmlAttr *old_attr = attr_iter;
@@ -2194,7 +2187,7 @@ xml_diff_old_attrs(xmlNode *old_xml, xmlNode *new_xml)
 static void
 mark_created_attrs(xmlNode *new_xml)
 {
-    xmlAttr *attr_iter = pcmk__first_xml_attr(new_xml);
+    xmlAttr *attr_iter = pcmk__xe_first_attr(new_xml);
 
     while (attr_iter != NULL) {
         xmlAttr *new_attr = attr_iter;
@@ -2371,7 +2364,6 @@ gboolean
 can_prune_leaf(xmlNode * xml_node)
 {
     xmlNode *cIter = NULL;
-    xmlAttrPtr pIter = NULL;
     gboolean can_prune = TRUE;
     const char *name = crm_element_name(xml_node);
 
@@ -2380,8 +2372,8 @@ can_prune_leaf(xmlNode * xml_node)
         return FALSE;
     }
 
-    for (pIter = pcmk__first_xml_attr(xml_node); pIter != NULL; pIter = pIter->next) {
-        const char *p_name = (const char *)pIter->name;
+    for (xmlAttrPtr a = pcmk__xe_first_attr(xml_node); a != NULL; a = a->next) {
+        const char *p_name = (const char *) a->name;
 
         if (strcmp(p_name, XML_ATTR_ID) == 0) {
             continue;
@@ -2558,15 +2550,13 @@ pcmk__xml_update(xmlNode *parent, xmlNode *target, xmlNode *update,
 
     } else {
         /* No need for expand_plus_plus(), just raw speed */
-        xmlAttrPtr pIter = NULL;
-
-        for (pIter = pcmk__first_xml_attr(update); pIter != NULL; pIter = pIter->next) {
-            const char *p_name = (const char *)pIter->name;
-            const char *p_value = pcmk__xml_attr_value(pIter);
+        for (xmlAttrPtr a = pcmk__xe_first_attr(update); a != NULL;
+             a = a->next) {
+            const char *p_value = pcmk__xml_attr_value(a);
 
             /* Remove it first so the ordering of the update is preserved */
-            xmlUnsetProp(target, (pcmkXmlStr) p_name);
-            xmlSetProp(target, (pcmkXmlStr) p_name, (pcmkXmlStr) p_value);
+            xmlUnsetProp(target, a->name);
+            xmlSetProp(target, a->name, (pcmkXmlStr) p_value);
         }
     }
 
@@ -2681,11 +2671,10 @@ replace_xml_child(xmlNode * parent, xmlNode * child, xmlNode * update, gboolean 
         can_delete = FALSE;
     }
     if (can_delete && delete_only) {
-        xmlAttrPtr pIter = NULL;
-
-        for (pIter = pcmk__first_xml_attr(update); pIter != NULL; pIter = pIter->next) {
-            const char *p_name = (const char *)pIter->name;
-            const char *p_value = pcmk__xml_attr_value(pIter);
+        for (xmlAttrPtr a = pcmk__xe_first_attr(update); a != NULL;
+             a = a->next) {
+            const char *p_name = (const char *) a->name;
+            const char *p_value = pcmk__xml_attr_value(a);
 
             right_val = crm_element_value(child, p_name);
             if (!pcmk__str_eq(p_value, right_val, pcmk__str_casei)) {

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -159,15 +159,11 @@ get_meta_attributes(GHashTable * meta_hash, pe_resource_t * rsc,
         rule_data.node_hash = node->details->attrs;
     }
 
-    if (rsc->xml) {
-        xmlAttrPtr xIter = NULL;
+    for (xmlAttrPtr a = pcmk__xe_first_attr(rsc->xml); a != NULL; a = a->next) {
+        const char *prop_name = (const char *) a->name;
+        const char *prop_value = crm_element_value(rsc->xml, prop_name);
 
-        for (xIter = rsc->xml->properties; xIter; xIter = xIter->next) {
-            const char *prop_name = (const char *)xIter->name;
-            const char *prop_value = crm_element_value(rsc->xml, prop_name);
-
-            add_hash_param(meta_hash, prop_name, prop_value);
-        }
+        add_hash_param(meta_hash, prop_name, prop_value);
     }
 
     pe__unpack_dataset_nvpairs(rsc->xml, XML_TAG_META_SETS, &rule_data,

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -247,6 +247,17 @@ calculate_secure_digest(op_digest_cache_t *data, pe_resource_t *rsc,
                                        NULL);
     }
     pcmk__filter_op_for_digest(data->params_secure);
+
+    /* CRM_meta_timeout *should* be part of a digest for recurring operations.
+     * However, currently the controller does not add timeout to secure digests,
+     * because it only includes parameters declared by the resource agent.
+     * Remove any timeout that made it this far, to match.
+     *
+     * @TODO Update the controller to add the timeout (which will require
+     * bumping the feature set and checking that here).
+     */
+    xml_remove_prop(data->params_secure, CRM_META "_" XML_ATTR_TIMEOUT);
+
     data->digest_secure_calc = calculate_operation_digest(data->params_secure,
                                                           op_version);
 }

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -229,6 +229,7 @@ calculate_secure_digest(op_digest_cache_t *data, pe_resource_t *rsc,
         pcmk__xe_remove_matching_attrs(data->params_secure, is_fence_param,
                                        NULL);
     }
+    pcmk__filter_op_for_digest(data->params_secure);
     data->digest_secure_calc = calculate_operation_digest(data->params_secure,
                                                           op_version);
 }

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1039,7 +1039,10 @@ expand_value_source(const char *value, const char *value_source,
 {
     GHashTable *table = NULL;
 
-    if (pcmk__str_eq(value_source, "param", pcmk__str_casei)) {
+    if (pcmk__str_empty(value)) {
+        return NULL; // value_source is irrelevant
+
+    } else if (pcmk__str_eq(value_source, "param", pcmk__str_casei)) {
         table = match_data->params;
 
     } else if (pcmk__str_eq(value_source, "meta", pcmk__str_casei)) {
@@ -1049,7 +1052,7 @@ expand_value_source(const char *value, const char *value_source,
         return value;
     }
 
-    if ((table == NULL) || pcmk__str_empty(value)) {
+    if (table == NULL) {
         return NULL;
     }
     return (const char *) g_hash_table_lookup(table, value);


### PR DESCRIPTION
This is a follow-up to PR #2224.

The most interesting part is a new function pcmk__xe_remove_matching_attrs() which is a basically a "foreach remove" function for XML attributes, to reduce code duplication and enhance readability. It does not significantly affect scheduler timings.