### PR TITLE
High: xml: Revert to correct schema for alerts-3.5

### DIFF
--- a/xml/alerts-3.5.rng
+++ b/xml/alerts-3.5.rng
@@ -16,17 +16,50 @@
           </optional>
           <!-- path to the script called for alert -->
           <attribute name="path"><text/></attribute>
-          <ref name="element-alert-extra"/>
-          <zeroOrMore>
-            <element name="recipient">
-              <attribute name="id"><data type="ID"/></attribute>
-              <optional>
-                <attribute name="description"><text/></attribute>
-              </optional>
-              <attribute name="value"><text/></attribute>
-              <ref name="element-alert-extra"/>
-            </element>
-          </zeroOrMore>
+          <interleave>
+            <ref name="element-alert-extra"/>
+            <optional>
+              <element name="select">
+                <interleave>
+                  <optional>
+                    <element name="select_attributes">
+                      <zeroOrMore>
+                        <element name="attribute">
+                          <attribute name="id"><data type="ID"/></attribute>
+                          <attribute name="name"><text/></attribute>
+                        </element>
+                      </zeroOrMore>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name="select_fencing">
+                      <empty/>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name="select_nodes">
+                      <empty/>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name="select_resources">
+                      <empty/>
+                    </element>
+                  </optional>
+                </interleave>
+              </element>
+            </optional>
+            <zeroOrMore>
+              <element name="recipient">
+                <attribute name="id"><data type="ID"/></attribute>
+                <optional>
+                  <attribute name="description"><text/></attribute>
+                </optional>
+                <attribute name="value"><text/></attribute>
+                <ref name="element-alert-extra"/>
+              </element>
+            </zeroOrMore>
+          </interleave>
         </element>
       </zeroOrMore>
     </element>


### PR DESCRIPTION
Commit bd451763 mistakenly used alert-2.9 instead of alerts-2.10 as the
basis for alerts-3.5. This corrects that mistake.

Signed-off-by: Reid Wahl <nrwahl@protonmail.com>