### PR TITLE
Doc: Pacemaker Explained: Fix the node attributes expression table.

### DIFF
--- a/doc/Pacemaker_Explained/en-US/Ch-Rules.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Rules.txt
@@ -115,7 +115,6 @@ Expressions are rule conditions based on the values of node attributes.
  indexterm:[XML element,expression element,attribute attribute]
 
 |type
-|+string+
 |The default type for +lt+, +gt+, +lte+, and +gte+ operations is
  +number+ if either value contains a decimal point character, or
  +integer+ otherwise. The default type for all other operations is


### PR DESCRIPTION
39d78f36b23d8910afdafd955df0170e0102b7e7 left the previous default in
the table, meaning we had a row with four columns, which ended up
shifting everything over by a column.  This is now fixed, the the
default column is so narrow that it's a little hard to read.

It doesn't matter too much, because this is all going away in favor of
new documentation soon.