### PR TITLE
Low: libcib: Cleanup at signoff.Fix(CLBZ#5457)

### DIFF
--- a/include/crm/cib.h
+++ b/include/crm/cib.h
@@ -43,6 +43,7 @@ cib_t *cib_new_no_shadow(void);
 char *get_shadow_file(const char *name);
 cib_t *cib_shadow_new(const char *name);
 
+void cib_free_notify(cib_t *cib);
 void cib_free_callbacks(cib_t *cib);
 void cib_delete(cib_t * cib);
 

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -397,14 +397,10 @@ cib_new_variant(void)
     return new_cib;
 }
 
-/*!
- * \brief Free all callbacks for a CIB connection
- *
- * \param[in] cib  CIB connection to clean up
- */
-void
-cib_free_callbacks(cib_t *cib)
+void 
+cib_free_notify(cib_t *cib)
 {
+
     if (cib) {
         GList *list = cib->notify_list;
 
@@ -416,6 +412,17 @@ cib_free_callbacks(cib_t *cib)
         }
         cib->notify_list = NULL;
     }
+}
+/*!
+ * \brief Free all callbacks for a CIB connection
+ *
+ * \param[in] cib  CIB connection to clean up
+ */
+void
+cib_free_callbacks(cib_t *cib)
+{
+    cib_free_notify(cib);
+
     destroy_op_callback_table();
 }
 

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -250,6 +250,9 @@ cib_native_signoff(cib_t * cib)
 
     crm_debug("Disconnecting from the CIB manager");
 
+    cib_free_notify(cib);
+    remove_cib_op_callback(0, TRUE);
+
     if (native->source != NULL) {
         /* Attached to mainloop */
         mainloop_del_ipc_client(native->source);


### PR DESCRIPTION
Hi All,

This is the fix proposed in Bugzilla below.
 - https://bugs.clusterlabs.org/show_bug.cgi?id=5457

Clean up the callback table and notification table at the time of cib_native_signoff().




Best Regards,
Hideo Yamauchi.