### PR TITLE
[1.1] Log: libpe_status: downgrade the message about the meaning of `have-watchdog=true` to info

### DIFF
--- a/crmd/control.c
+++ b/crmd/control.c
@@ -965,9 +965,22 @@ pe_cluster_option crmd_opts[] = {
           "Delay cluster recovery for the configured interval to allow for additional/related events to occur.\n"
           "Useful if your configuration is sensitive to the order in which ping updates arrive."
         },
-	{ "stonith-watchdog-timeout", NULL, "time", NULL, NULL, &check_sbd_timeout,
-	  "How long to wait before we can assume nodes are safely down", NULL
-        },
+	{ "stonith-watchdog-timeout", NULL, "time", NULL, "0", &check_sbd_timeout,
+        "How long to wait before we can assume nodes are safely down "
+            "when watchdog-based self-fencing via SBD is in use",
+        "If positive, along with `have-watchdog=true` automatically set by the "
+            "cluster, when fencing is required, watchdog-based self-fencing "
+            "will be performed via SBD without requiring a fencing resource "
+            "explicitly configured. "
+            "If `stonith-watchdog-timeout` is set to a positive value, unseen "
+            "nodes are assumed to self-fence within this much time. +WARNING:+ "
+            "It must be ensured that this value is larger than the "
+            "`SBD_WATCHDOG_TIMEOUT` environment variable on all nodes. "
+            "Pacemaker verifies the settings individually on all nodes and "
+            "prevents startup or shuts down if configured wrongly on the fly. "
+            "It's strongly recommended that `SBD_WATCHDOG_TIMEOUT` is set to "
+            "the same value on all nodes. "
+       },
         { "stonith-max-attempts",NULL,"integer",NULL,"10",&check_positive_number,
           "How many times stonith can fail before it will no longer be attempted on a target"
         },   

--- a/doc/Pacemaker_Explained/en-US/Ch-Options.txt
+++ b/doc/Pacemaker_Explained/en-US/Ch-Options.txt
@@ -235,6 +235,22 @@ indexterm:[Cluster,Option,stonith-max-attempts]
 How many times fencing can fail for a target before the cluster will no longer
 immediately re-attempt it. '(since 1.1.17)'
 
+| stonith-watchdog-timeout | 0 |
+indexterm:[stonith-watchdog-timeout,Cluster Option]
+indexterm:[Cluster,Option,stonith-watchdog-timeout]
+If positive, along with `have-watchdog=true` automatically set by the
+cluster, when fencing is required, watchdog-based self-fencing
+will be performed via SBD without requiring a fencing resource
+explicitly configured.
+If `stonith-watchdog-timeout` is set to a positive value, unseen
+nodes are assumed to self-fence within this much time. +WARNING:+
+It must be ensured that this value is larger than the
+`SBD_WATCHDOG_TIMEOUT` environment variable on all nodes.
+Pacemaker verifies the settings individually on all nodes and
+prevents startup or shuts down if configured wrongly on the fly.
+It's strongly recommended that `SBD_WATCHDOG_TIMEOUT` is set to
+the same value on all nodes.
+
 | concurrent-fencing | FALSE |
 indexterm:[concurrent-fencing,Cluster Option]
 indexterm:[Cluster,Option,concurrent-fencing]

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -110,7 +110,14 @@ pe_cluster_option pe_opts[] = {
 	{ "stonith-timeout", NULL, "time", NULL, "60s", &check_timer,
 	  "How long to wait for the STONITH action (reboot,on,off) to complete", NULL },
 	{ XML_ATTR_HAVE_WATCHDOG, NULL, "boolean", NULL, "false", &check_boolean,
-	  "Enable watchdog integration", "Set automatically by the cluster if SBD is detected.  User configured values are ignored." },
+        "Whether watchdog integration is enabled",
+        "This is set automatically by the cluster according to whether SBD "
+            "is detected to be in use. User-configured values are ignored. "
+            "The value `true` is meaningful if diskless SBD is used and "
+            "`stonith-watchdog-timeout` is positive. In that case, if fencing "
+            "is required, watchdog-based self-fencing will be performed via "
+            "SBD without requiring a fencing resource explicitly configured."
+      },
 	{ "concurrent-fencing", NULL, "boolean", NULL,
 #ifdef DEFAULT_CONCURRENT_FENCING_TRUE
       "true",

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -196,7 +196,8 @@ unpack_config(xmlNode * config, pe_working_set_t * data_set)
 
     value = pe_pref(data_set->config_hash, XML_ATTR_HAVE_WATCHDOG);
     if (value && crm_is_true(value)) {
-        crm_notice("Watchdog will be used via SBD if fencing is required");
+        crm_info("Watchdog-based self-fencing will be performed via SBD if "
+                 "fencing is required and stonith-watchdog-timeout is positive");
         set_bit(data_set->flags, pe_flag_have_stonith_resource);
     }
 


### PR DESCRIPTION
Backport of https://github.com/ClusterLabs/pacemaker/pull/2142 for 1.1 branch.

I realize it'd be better to have these clarification/documentation for 1.1 branch as well, especially given that the handling of a negative value of `stonith-watchdog-timeout` is different here. In this case with a negative value, rather than an appropriate timeout automatically being calculated, watchdog-based self-fencing is disabled.