### PR TITLE
Best practices for libcrmcluster

### DIFF
--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -707,10 +707,8 @@ class PartialStart(CTSTest):
         if not ret:
             return self.failure("Setup failed")
 
-#   FIXME!  This should use the CM class to get the pattern
-#       then it would be applicable in general
         watchpats = []
-        watchpats.append("pacemaker-controld.*Connecting to cluster infrastructure")
+        watchpats.append("pacemaker-controld.*Connecting to .* cluster infrastructure")
         watch = self.create_watch(watchpats, self.Env["DeadTime"]+10)
         watch.setwatch()
 

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -199,7 +199,7 @@ attrd_client_peer_remove(pcmk__client_t *client, xmlNode *xml)
 
         crm_element_value_int(xml, PCMK__XA_ATTR_NODE_ID, &nodeid);
         if (nodeid > 0) {
-            crm_node_t *node = crm_find_peer(nodeid, NULL);
+            crm_node_t *node = pcmk__search_cluster_node_cache(nodeid, NULL);
             char *host_alloc = NULL;
 
             if (node && node->uname) {
@@ -709,7 +709,7 @@ attrd_lookup_or_create_value(GHashTable *values, const char *host, xmlNode *xml)
         /* If we previously assumed this node was an unseen cluster node,
          * remove its entry from the cluster peer cache.
          */
-        crm_node_t *dup = crm_find_peer(0, host);
+        crm_node_t *dup = pcmk__search_cluster_node_cache(0, host);
 
         if (dup && (dup->uuid == NULL)) {
             reap_crm_member(0, host);

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -269,7 +269,7 @@ cib_process_upgrade_server(const char *op, int options, const char *section, xml
 
         if (rc != pcmk_ok) {
             // Notify originating peer so it can notify its local clients
-            crm_node_t *origin = crm_find_peer(0, host);
+            crm_node_t *origin = pcmk__search_cluster_node_cache(0, host);
 
             crm_info("Rejecting upgrade request from %s: %s "
                      CRM_XS " rc=%d peer=%s", host, pcmk_strerror(rc), rc,

--- a/daemons/controld/controld_corosync.c
+++ b/daemons/controld/controld_corosync.c
@@ -99,7 +99,8 @@ crm_connect_corosync(crm_cluster_t * cluster)
         cluster->destroy = crmd_cs_destroy;
 
         if (crm_cluster_connect(cluster)) {
-            cluster_connect_quorum(crmd_quorum_callback, crmd_cs_destroy);
+            pcmk__corosync_quorum_connect(crmd_quorum_callback,
+                                          crmd_cs_destroy);
             return TRUE;
         }
     }

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -218,7 +218,7 @@ do_dc_takeover(long long action,
 
 #if SUPPORT_COROSYNC
     if (fsa_cluster_name == NULL && is_corosync_cluster()) {
-        char *cluster_name = corosync_cluster_name();
+        char *cluster_name = pcmk__corosync_cluster_name();
 
         if (cluster_name) {
             update_attr_delegate(fsa_cib_conn, cib_none, XML_CIB_TAG_CRMCONFIG, NULL, NULL, NULL, NULL,

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -257,7 +257,7 @@ do_dc_release(long long action,
             xmlNode *update = NULL;
             crm_node_t *node = crm_get_peer(0, fsa_our_uname);
 
-            crm_update_peer_expected(__func__, node, CRMD_JOINSTATE_DOWN);
+            pcmk__update_peer_expected(__func__, node, CRMD_JOINSTATE_DOWN);
             update = create_node_state_update(node, node_update_expected, NULL,
                                               __func__);
             /* Don't need a based response because controld will stop. */

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -511,7 +511,8 @@ tengine_stonith_notify(stonith_t *st, stonith_event_t *st_event)
                st_event->origin, st_event->id);
 
     if (st_event->result == pcmk_ok) {
-        crm_node_t *peer = crm_find_known_peer_full(0, st_event->target, CRM_GET_PEER_ANY);
+        crm_node_t *peer = pcmk__search_known_node_cache(0, st_event->target,
+                                                         CRM_GET_PEER_ANY);
         const char *uuid = NULL;
         gboolean we_are_executioner = pcmk__str_eq(st_event->executioner,
                                                    fsa_our_uname,

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -37,7 +37,7 @@ update_dc_expected(xmlNode *msg)
     if (fsa_our_dc && crm_is_true(crm_element_value(msg, F_CRM_DC_LEAVING))) {
         crm_node_t *dc_node = crm_get_peer(0, fsa_our_dc);
 
-        crm_update_peer_expected(__func__, dc_node, CRMD_JOINSTATE_DOWN);
+        pcmk__update_peer_expected(__func__, dc_node, CRMD_JOINSTATE_DOWN);
     }
 }
 

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -135,7 +135,7 @@ join_make_offer(gpointer key, gpointer value, gpointer user_data)
              *
              * I'm not happy about this either.
              */
-            crm_update_peer_expected(__func__, member, CRMD_JOINSTATE_DOWN);
+            pcmk__update_peer_expected(__func__, member, CRMD_JOINSTATE_DOWN);
         }
         return;
     }
@@ -383,10 +383,10 @@ do_dc_join_filter_offer(long long action,
 
     if (ack_nack_bool == FALSE) {
         crm_update_peer_join(__func__, join_node, crm_join_nack);
-        crm_update_peer_expected(__func__, join_node, CRMD_JOINSTATE_NACK);
+        pcmk__update_peer_expected(__func__, join_node, CRMD_JOINSTATE_NACK);
     } else {
         crm_update_peer_join(__func__, join_node, crm_join_integrated);
-        crm_update_peer_expected(__func__, join_node, CRMD_JOINSTATE_MEMBER);
+        pcmk__update_peer_expected(__func__, join_node, CRMD_JOINSTATE_MEMBER);
     }
 
     count = crmd_join_phase_count(crm_join_integrated);
@@ -645,7 +645,7 @@ finalize_join_for(gpointer key, gpointer value, gpointer user_data)
          *
          * All other NACKs (due to versions etc) should still be processed
          */
-        crm_update_peer_expected(__func__, join_node, CRMD_JOINSTATE_PENDING);
+        pcmk__update_peer_expected(__func__, join_node, CRMD_JOINSTATE_PENDING);
         return;
     }
 
@@ -655,7 +655,7 @@ finalize_join_for(gpointer key, gpointer value, gpointer user_data)
     acknak = create_dc_message(CRM_OP_JOIN_ACKNAK, join_to);
     crm_xml_add(acknak, CRM_OP_JOIN_ACKNAK, XML_BOOLEAN_TRUE);
     crm_update_peer_join(__func__, join_node, crm_join_finalized);
-    crm_update_peer_expected(__func__, join_node, CRMD_JOINSTATE_MEMBER);
+    pcmk__update_peer_expected(__func__, join_node, CRMD_JOINSTATE_MEMBER);
 
     send_cluster_message(crm_get_peer(0, join_to), crm_msg_crmd, acknak, TRUE);
     free_xml(acknak);

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -304,7 +304,7 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
 
 #if SUPPORT_COROSYNC
     if (!pcmk_is_set(flags, node_update_quick) && is_corosync_cluster()) {
-        from_hashtable = corosync_initialize_nodelist(node_list);
+        from_hashtable = pcmk__corosync_add_nodes(node_list);
     }
 #endif
 

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -304,7 +304,7 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
 
 #if SUPPORT_COROSYNC
     if (!pcmk_is_set(flags, node_update_quick) && is_corosync_cluster()) {
-        from_hashtable = corosync_initialize_nodelist(NULL, FALSE, node_list);
+        from_hashtable = corosync_initialize_nodelist(node_list);
     }
 #endif
 

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -456,7 +456,7 @@ relay_message(xmlNode * msg, gboolean originated_locally)
 #endif
 
         if (host_to) {
-            node_to = crm_find_peer(0, host_to);
+            node_to = pcmk__search_cluster_node_cache(0, host_to);
             if (node_to == NULL) {
                 crm_warn("Cannot route message %s: Unknown node %s",
                          ref, host_to);
@@ -739,9 +739,9 @@ handle_remote_state(xmlNode *msg)
     remote_peer = crm_remote_peer_get(remote_uname);
     CRM_CHECK(remote_peer, return I_NULL);
 
-    crm_update_peer_state(__func__, remote_peer,
-                          crm_is_true(remote_is_up)?
-                          CRM_NODE_MEMBER : CRM_NODE_LOST, 0);
+    pcmk__update_peer_state(__func__, remote_peer,
+                            crm_is_true(remote_is_up)? CRM_NODE_MEMBER : CRM_NODE_LOST,
+                            0);
     return I_NULL;
 }
 
@@ -856,7 +856,7 @@ handle_node_info_request(xmlNode *msg)
         value = fsa_our_uname;
     }
 
-    node = crm_find_peer_full(node_id, value, CRM_GET_PEER_ANY);
+    node = pcmk__search_node_caches(node_id, value, CRM_GET_PEER_ANY);
     if (node) {
         crm_xml_add_int(reply, XML_ATTR_ID, node->id);
         crm_xml_add(reply, XML_ATTR_UUID, node->uuid);
@@ -980,9 +980,9 @@ handle_request(xmlNode *stored_msg, enum crmd_fsa_cause cause)
 
     if (strcmp(op, CRM_OP_SHUTDOWN_REQ) == 0) {
         const char *from = crm_element_value(stored_msg, F_CRM_HOST_FROM);
-        crm_node_t *node = crm_find_peer(0, from);
+        crm_node_t *node = pcmk__search_cluster_node_cache(0, from);
 
-        crm_update_peer_expected(__func__, node, CRMD_JOINSTATE_DOWN);
+        pcmk__update_peer_expected(__func__, node, CRMD_JOINSTATE_DOWN);
         if(AM_I_DC == FALSE) {
             return I_NULL; /* Done */
         }

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -200,7 +200,7 @@ remote_node_up(const char *node_name)
     /* Ensure node is in the remote peer cache with member status */
     node = crm_remote_peer_get(node_name);
     CRM_CHECK(node != NULL, return);
-    crm_update_peer_state(__func__, node, CRM_NODE_MEMBER, 0);
+    pcmk__update_peer_state(__func__, node, CRM_NODE_MEMBER, 0);
 
     /* pacemaker_remote nodes don't participate in the membership layer,
      * so cluster nodes don't automatically get notified when they come and go.
@@ -271,7 +271,7 @@ remote_node_down(const char *node_name, const enum down_opts opts)
     /* Ensure node is in the remote peer cache with lost state */
     node = crm_remote_peer_get(node_name);
     CRM_CHECK(node != NULL, return);
-    crm_update_peer_state(__func__, node, CRM_NODE_LOST, 0);
+    pcmk__update_peer_state(__func__, node, CRM_NODE_LOST, 0);
 
     /* Notify DC */
     send_remote_state_message(node_name, FALSE);
@@ -314,7 +314,7 @@ check_remote_node_state(remote_ra_cmd_t *cmd)
         crm_node_t *node = crm_remote_peer_get(cmd->rsc_id);
 
         CRM_CHECK(node != NULL, return);
-        crm_update_peer_state(__func__, node, CRM_NODE_MEMBER, 0);
+        pcmk__update_peer_state(__func__, node, CRM_NODE_MEMBER, 0);
 
     } else if (pcmk__str_eq(cmd->action, "stop", pcmk__str_casei)) {
         lrm_state_t *lrm_state = lrm_state_find(cmd->rsc_id);

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -453,7 +453,7 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 
     /* Refresh the remote node cache and the known node cache when the
      * scheduler is invoked */
-    crm_peer_caches_refresh(output);
+    pcmk__refresh_node_caches_from_cib(output);
 
     crm_xml_add(output, XML_ATTR_DC_UUID, fsa_our_uuid);
     crm_xml_add_int(output, XML_ATTR_HAVE_QUORUM, fsa_has_quorum);

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -143,7 +143,8 @@ te_crm_command(crm_graph_t * graph, crm_action_t * action)
 
     } else if (pcmk__str_eq(task, CRM_OP_SHUTDOWN, pcmk__str_casei)) {
         crm_node_t *peer = crm_get_peer(0, router_node);
-        crm_update_peer_expected(__func__, peer, CRMD_JOINSTATE_DOWN);
+
+        pcmk__update_peer_expected(__func__, peer, CRMD_JOINSTATE_DOWN);
     }
 
     cmd = create_request(task, action->xml, router_node, CRM_SYSTEM_CRMD, CRM_SYSTEM_TENGINE, NULL);

--- a/daemons/controld/controld_utils.c
+++ b/daemons/controld/controld_utils.c
@@ -743,7 +743,7 @@ update_dc(xmlNode * msg)
         crm_node_t *dc_node = crm_get_peer(0, fsa_our_dc);
 
         crm_info("Set DC to %s (%s)", crm_str(fsa_our_dc), crm_str(fsa_our_dc_version));
-        crm_update_peer_expected(__func__, dc_node, CRMD_JOINSTATE_MEMBER);
+        pcmk__update_peer_expected(__func__, dc_node, CRMD_JOINSTATE_MEMBER);
 
     } else if (last_dc != NULL) {
         crm_info("Unset DC. Was %s", crm_str(last_dc));
@@ -756,11 +756,11 @@ update_dc(xmlNode * msg)
 void crmd_peer_down(crm_node_t *peer, bool full) 
 {
     if(full && peer->state == NULL) {
-        crm_update_peer_state(__func__, peer, CRM_NODE_LOST, 0);
+        pcmk__update_peer_state(__func__, peer, CRM_NODE_LOST, 0);
         crm_update_peer_proc(__func__, peer, crm_proc_none, NULL);
     }
     crm_update_peer_join(__func__, peer, crm_join_none);
-    crm_update_peer_expected(__func__, peer, CRMD_JOINSTATE_DOWN);
+    pcmk__update_peer_expected(__func__, peer, CRMD_JOINSTATE_DOWN);
 }
 
 #define MIN_CIB_OP_TIMEOUT (30)

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2365,7 +2365,8 @@ stonith_fence(xmlNode * msg)
 
         if (cmd->options & st_opt_cs_nodeid) {
             int nodeid = crm_atoi(host, NULL);
-            crm_node_t *node = crm_find_known_peer_full(nodeid, NULL, CRM_GET_PEER_ANY);
+            crm_node_t *node = pcmk__search_known_node_cache(nodeid, NULL,
+                                                             CRM_GET_PEER_ANY);
 
             if (node) {
                 host = node->uname;

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -409,7 +409,8 @@ stonith_fence_history(xmlNode *msg, xmlNode **output,
         target = crm_element_value(dev, F_STONITH_TARGET);
         if (target && (options & st_opt_cs_nodeid)) {
             int nodeid = crm_atoi(target, NULL);
-            crm_node_t *node = crm_find_known_peer_full(nodeid, NULL, CRM_GET_PEER_ANY);
+            crm_node_t *node = pcmk__search_known_node_cache(nodeid, NULL,
+                                                             CRM_GET_PEER_ANY);
 
             if (node) {
                 target = node->uname;

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1083,7 +1083,8 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
 
     if (op->call_options & st_opt_cs_nodeid) {
         int nodeid = crm_atoi(op->target, NULL);
-        crm_node_t *node = crm_find_known_peer_full(nodeid, NULL, CRM_GET_PEER_ANY);
+        crm_node_t *node = pcmk__search_known_node_cache(nodeid, NULL,
+                                                         CRM_GET_PEER_ANY);
 
         /* Ensure the conversion only happens once */
         stonith__clear_call_options(op->call_options, op->id, st_opt_cs_nodeid);

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -1051,7 +1051,7 @@ update_cib_cache_cb(const char *event, xmlNode * msg)
         stonith_enabled_saved = FALSE; /* Trigger a full refresh below */
     }
 
-    crm_peer_caches_refresh(local_cib);
+    pcmk__refresh_node_caches_from_cib(local_cib);
 
     stonith_enabled_xml = get_xpath_object("//nvpair[@name='stonith-enabled']",
                                            local_cib, LOG_NEVER);
@@ -1110,7 +1110,7 @@ init_cib_cache_cb(xmlNode * msg, int call_id, int rc, xmlNode * output, void *us
     have_cib_devices = TRUE;
     local_cib = copy_xml(output);
 
-    crm_peer_caches_refresh(local_cib);
+    pcmk__refresh_node_caches_from_cib(local_cib);
 
     fencing_topology_init();
     cib_devices_update();

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -61,7 +61,6 @@ static gboolean shutdown_complete_state_reported_client_closed = FALSE;
 
 typedef struct pcmk_child_s {
     pid_t pid;
-    long flag;
     int start_seq;
     int respawn_count;
     gboolean respawn;
@@ -78,38 +77,31 @@ typedef struct pcmk_child_s {
 
 static pcmk_child_t pcmk_children[] = {
     {
-        0, crm_proc_none,       0, 0, FALSE, "none",
-        NULL, NULL
+        0, 0, 0, FALSE, "none", NULL, NULL, NULL
     },
     {
-        0, crm_proc_execd,      3, 0, TRUE,  "pacemaker-execd",
-        NULL, CRM_DAEMON_DIR "/pacemaker-execd",
-        CRM_SYSTEM_LRMD
+        0, 3, 0, TRUE,  "pacemaker-execd", NULL,
+        CRM_DAEMON_DIR "/pacemaker-execd", CRM_SYSTEM_LRMD
     },
     {
-        0, crm_proc_based,      1, 0, TRUE,  "pacemaker-based",
-        CRM_DAEMON_USER, CRM_DAEMON_DIR "/pacemaker-based",
-        PCMK__SERVER_BASED_RO
+        0, 1, 0, TRUE,  "pacemaker-based", CRM_DAEMON_USER,
+        CRM_DAEMON_DIR "/pacemaker-based", PCMK__SERVER_BASED_RO
     },
     {
-        0, crm_proc_controld,   6, 0, TRUE, "pacemaker-controld",
-        CRM_DAEMON_USER, CRM_DAEMON_DIR "/pacemaker-controld",
-        CRM_SYSTEM_CRMD
+        0, 6, 0, TRUE, "pacemaker-controld", CRM_DAEMON_USER,
+        CRM_DAEMON_DIR "/pacemaker-controld", CRM_SYSTEM_CRMD
     },
     {
-        0, crm_proc_attrd,      4, 0, TRUE, "pacemaker-attrd",
-        CRM_DAEMON_USER, CRM_DAEMON_DIR "/pacemaker-attrd",
-        T_ATTRD
+        0, 4, 0, TRUE, "pacemaker-attrd", CRM_DAEMON_USER,
+        CRM_DAEMON_DIR "/pacemaker-attrd", T_ATTRD
     },
     {
-        0, crm_proc_schedulerd, 5, 0, TRUE, "pacemaker-schedulerd",
-        CRM_DAEMON_USER, CRM_DAEMON_DIR "/pacemaker-schedulerd",
-        CRM_SYSTEM_PENGINE
+        0, 5, 0, TRUE, "pacemaker-schedulerd", CRM_DAEMON_USER,
+        CRM_DAEMON_DIR "/pacemaker-schedulerd", CRM_SYSTEM_PENGINE
     },
     {
-        0, crm_proc_fenced,     2, 0, TRUE, "pacemaker-fenced",
-        NULL, CRM_DAEMON_DIR "/pacemaker-fenced",
-        "stonith-ng"
+        0, 2, 0, TRUE, "pacemaker-fenced", NULL,
+        CRM_DAEMON_DIR "/pacemaker-fenced", "stonith-ng"
     },
 };
 

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -296,7 +296,7 @@ mcp_read_config(void)
             rc = cmap_set_uint8(local_handle, key, 1);
             if (rc != CS_OK) {
                 crm_warn("Could not authorize group with Corosync: %s " CRM_XS
-                         " group=%u rc=%d", ais_error2text(rc), gid, rc);
+                         " group=%u rc=%d", pcmk__cs_err_str(rc), gid, rc);
             }
         }
     }

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2018 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -29,12 +29,10 @@ extern GHashTable *crm_peer_cache;
 extern GHashTable *crm_remote_peer_cache;
 extern unsigned long long crm_peer_seq;
 
-/* *INDENT-OFF* */
 #define CRM_NODE_LOST      "lost"
 #define CRM_NODE_MEMBER    "member"
 
-enum crm_join_phase
-{
+enum crm_join_phase {
     crm_join_nack       = -1,
     crm_join_none       = 0,
     crm_join_welcomed   = 1,
@@ -43,15 +41,13 @@ enum crm_join_phase
     crm_join_confirmed  = 4,
 };
 
-enum crm_node_flags
-{
+enum crm_node_flags {
     /* node is not a cluster node and should not be considered for cluster membership */
     crm_remote_node          = 0x0001,
 
     /* node's cache entry is dirty */
     crm_node_dirty           = 0x0010,
 };
-/* *INDENT-ON* */
 
 typedef struct crm_peer_node_s {
     char *uname;                // Node name as known to cluster
@@ -60,6 +56,11 @@ typedef struct crm_peer_node_s {
     uint64_t flags;             // Bitmask of crm_node_flags
     uint64_t last_seen;         // Only needed by cluster nodes
     uint32_t processes;         // @TODO most not needed, merge into flags
+
+    /* @TODO When we can break public API compatibility, we can make the rest of
+     * these members separate structs and use void *cluster_data and
+     * void *user_data here instead, to abstract the cluster layer further.
+     */
 
     // Currently only needed by corosync stack
     uint32_t id;                // Node ID
@@ -81,6 +82,10 @@ typedef struct crm_cluster_s {
     void (*destroy) (gpointer);
 
 #  if SUPPORT_COROSYNC
+    /* @TODO When we can break public API compatibility, make these members a
+     * separate struct and use void *cluster_data here instead, to abstract the
+     * cluster layer further.
+     */
     struct cpg_name group;
     cpg_callbacks_t cpg;
     cpg_handle_t cpg_handle;
@@ -88,10 +93,9 @@ typedef struct crm_cluster_s {
 
 } crm_cluster_t;
 
-gboolean crm_cluster_connect(crm_cluster_t * cluster);
-void crm_cluster_disconnect(crm_cluster_t * cluster);
+gboolean crm_cluster_connect(crm_cluster_t *cluster);
+void crm_cluster_disconnect(crm_cluster_t *cluster);
 
-/* *INDENT-OFF* */
 enum crm_ais_msg_class {
     crm_class_cluster = 0,
 };
@@ -115,11 +119,9 @@ enum crm_get_peer_flags {
     CRM_GET_PEER_REMOTE    = 0x0002,
     CRM_GET_PEER_ANY       = CRM_GET_PEER_CLUSTER|CRM_GET_PEER_REMOTE,
 };
-/* *INDENT-ON* */
 
-gboolean send_cluster_message(crm_node_t * node, enum crm_ais_msg_types service,
-                              xmlNode * data, gboolean ordered);
-
+gboolean send_cluster_message(crm_node_t *node, enum crm_ais_msg_types service,
+                              xmlNode *data, gboolean ordered);
 
 int crm_remote_peer_cache_size(void);
 
@@ -173,9 +175,7 @@ enum crm_ais_msg_types text2msg_type(const char *text);
 void crm_set_status_callback(void (*dispatch) (enum crm_status_type, crm_node_t *, const void *));
 void crm_set_autoreap(gboolean autoreap);
 
-/* *INDENT-OFF* */
-enum cluster_type_e
-{
+enum cluster_type_e {
     pcmk_cluster_unknown     = 0x0001,
     pcmk_cluster_invalid     = 0x0002,
     // 0x0004 was heartbeat
@@ -183,7 +183,6 @@ enum cluster_type_e
     pcmk_cluster_corosync    = 0x0020,
     // 0x0040 was corosync 1 with CMAN
 };
-/* *INDENT-ON* */
 
 enum cluster_type_e get_cluster_type(void);
 const char *name_for_cluster_type(enum cluster_type_e type);
@@ -193,6 +192,13 @@ gboolean is_corosync_cluster(void);
 const char *get_local_node_name(void);
 char *get_node_name(uint32_t nodeid);
 
+/*!
+ * \brief Get log-friendly string equivalent of a join phase
+ *
+ * \param[in] phase  Join phase
+ *
+ * \return Log-friendly string equivalent of \p phase
+ */
 static inline const char *
 crm_join_phase_str(enum crm_join_phase phase)
 {

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -139,8 +139,6 @@ crm_node_t *crm_get_peer(unsigned int id, const char *uname);
 guint crm_active_peers(void);
 gboolean crm_is_peer_active(const crm_node_t * node);
 guint reap_crm_member(uint32_t id, const char *name);
-int crm_terminate_member(int nodeid, const char *uname, void *unused);
-int crm_terminate_member_no_mainloop(int nodeid, const char *uname, int *connection);
 
 #  if SUPPORT_COROSYNC
 uint32_t get_local_nodeid(cpg_handle_t handle);
@@ -212,6 +210,16 @@ crm_join_phase_str(enum crm_join_phase phase)
     }
     return "invalid";
 }
+
+#ifndef PCMK__NO_COMPAT
+/* Everything here is deprecated and kept only for public API backward
+ * compatibility. It will be moved to compatibility.h in a future release.
+ */
+
+int crm_terminate_member(int nodeid, const char *uname, void *unused);
+int crm_terminate_member_no_mainloop(int nodeid, const char *uname,
+                                     int *connection);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -322,9 +322,9 @@ msg_type2text(enum crm_ais_msg_types type)
 
 gboolean send_cpg_iov(struct iovec * iov);
 
-char *corosync_cluster_name(void);
+char *pcmk__corosync_cluster_name(void);
 
-gboolean corosync_initialize_nodelist(xmlNode *xml_parent);
+bool pcmk__corosync_add_nodes(xmlNode *xml_parent);
 
 gboolean send_cluster_message_cs(xmlNode * msg, gboolean local,
                                  crm_node_t * node, enum crm_ais_msg_types dest);
@@ -339,9 +339,9 @@ void crm_update_peer_uname(crm_node_t *node, const char *uname);
 void crm_update_peer_expected(const char *source, crm_node_t * node, const char *expected);
 void crm_reap_unseen_nodes(uint64_t ring_id);
 
-gboolean cluster_connect_quorum(gboolean(*dispatch) (unsigned long long, gboolean),
-                                void (*destroy) (gpointer));
-
+void pcmk__corosync_quorum_connect(gboolean (*dispatch)(unsigned long long,
+                                                        gboolean),
+                                   void (*destroy) (gpointer));
 crm_node_t * crm_find_peer_full(unsigned int id, const char *uname, int flags);
 crm_node_t * crm_find_peer(unsigned int id, const char *uname);
 

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -353,8 +353,6 @@ void crm_reap_unseen_nodes(uint64_t ring_id);
 gboolean cluster_connect_quorum(gboolean(*dispatch) (unsigned long long, gboolean),
                                 void (*destroy) (gpointer));
 
-gboolean node_name_is_valid(const char *key, const char *name);
-
 crm_node_t * crm_find_peer_full(unsigned int id, const char *uname, int flags);
 crm_node_t * crm_find_peer(unsigned int id, const char *uname);
 

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -318,8 +318,6 @@ msg_type2text(enum crm_ais_msg_types type)
     return text;
 }
 
-gboolean check_message_sanity(const AIS_Message * msg, const char *data);
-
 #  if SUPPORT_COROSYNC
 
 gboolean send_cpg_iov(struct iovec * iov);

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -329,8 +329,6 @@ gboolean corosync_initialize_nodelist(void *cluster, gboolean force_member, xmlN
 
 gboolean send_cluster_message_cs(xmlNode * msg, gboolean local,
                                  crm_node_t * node, enum crm_ais_msg_types dest);
-
-gboolean init_cs_connection_once(crm_cluster_t * cluster);
 #  endif
 
 crm_node_t *crm_update_peer_proc(const char *source, crm_node_t * peer,

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -325,9 +325,6 @@ gboolean send_cpg_iov(struct iovec * iov);
 char *pcmk__corosync_cluster_name(void);
 
 bool pcmk__corosync_add_nodes(xmlNode *xml_parent);
-
-gboolean send_cluster_message_cs(xmlNode * msg, gboolean local,
-                                 crm_node_t * node, enum crm_ais_msg_types dest);
 #  endif
 
 crm_node_t *crm_update_peer_proc(const char *source, crm_node_t * peer,

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -48,131 +48,49 @@ crm_get_cluster_proc(void)
     return crm_proc_none;
 }
 
-/*
-typedef enum {
-   CS_OK = 1,
-   CS_ERR_LIBRARY = 2,
-   CS_ERR_VERSION = 3,
-   CS_ERR_INIT = 4,
-   CS_ERR_TIMEOUT = 5,
-   CS_ERR_TRY_AGAIN = 6,
-   CS_ERR_INVALID_PARAM = 7,
-   CS_ERR_NO_MEMORY = 8,
-   CS_ERR_BAD_HANDLE = 9,
-   CS_ERR_BUSY = 10,
-   CS_ERR_ACCESS = 11,
-   CS_ERR_NOT_EXIST = 12,
-   CS_ERR_NAME_TOO_LONG = 13,
-   CS_ERR_EXIST = 14,
-   CS_ERR_NO_SPACE = 15,
-   CS_ERR_INTERRUPT = 16,
-   CS_ERR_NAME_NOT_FOUND = 17,
-   CS_ERR_NO_RESOURCES = 18,
-   CS_ERR_NOT_SUPPORTED = 19,
-   CS_ERR_BAD_OPERATION = 20,
-   CS_ERR_FAILED_OPERATION = 21,
-   CS_ERR_MESSAGE_ERROR = 22,
-   CS_ERR_QUEUE_FULL = 23,
-   CS_ERR_QUEUE_NOT_AVAILABLE = 24,
-   CS_ERR_BAD_FLAGS = 25,
-   CS_ERR_TOO_BIG = 26,
-   CS_ERR_NO_SECTIONS = 27,
-   CS_ERR_CONTEXT_NOT_FOUND = 28,
-   CS_ERR_TOO_MANY_GROUPS = 30,
-   CS_ERR_SECURITY = 100
-} cs_error_t;
+/*!
+ * \internal
+ * \brief Get log-friendly string description of a Corosync return code
+ *
+ * \param[in] error  Corosync return code
+ *
+ * \return Log-friendly string description corresponding to \p error
  */
 static inline const char *
-ais_error2text(int error)
+pcmk__cs_err_str(int error)
 {
-    const char *text = "unknown";
-
 #  if SUPPORT_COROSYNC
     switch (error) {
-        case CS_OK:
-            text = "OK";
-            break;
-        case CS_ERR_LIBRARY:
-            text = "Library error";
-            break;
-        case CS_ERR_VERSION:
-            text = "Version error";
-            break;
-        case CS_ERR_INIT:
-            text = "Initialization error";
-            break;
-        case CS_ERR_TIMEOUT:
-            text = "Timeout";
-            break;
-        case CS_ERR_TRY_AGAIN:
-            text = "Try again";
-            break;
-        case CS_ERR_INVALID_PARAM:
-            text = "Invalid parameter";
-            break;
-        case CS_ERR_NO_MEMORY:
-            text = "No memory";
-            break;
-        case CS_ERR_BAD_HANDLE:
-            text = "Bad handle";
-            break;
-        case CS_ERR_BUSY:
-            text = "Busy";
-            break;
-        case CS_ERR_ACCESS:
-            text = "Access error";
-            break;
-        case CS_ERR_NOT_EXIST:
-            text = "Doesn't exist";
-            break;
-        case CS_ERR_NAME_TOO_LONG:
-            text = "Name too long";
-            break;
-        case CS_ERR_EXIST:
-            text = "Exists";
-            break;
-        case CS_ERR_NO_SPACE:
-            text = "No space";
-            break;
-        case CS_ERR_INTERRUPT:
-            text = "Interrupt";
-            break;
-        case CS_ERR_NAME_NOT_FOUND:
-            text = "Name not found";
-            break;
-        case CS_ERR_NO_RESOURCES:
-            text = "No resources";
-            break;
-        case CS_ERR_NOT_SUPPORTED:
-            text = "Not supported";
-            break;
-        case CS_ERR_BAD_OPERATION:
-            text = "Bad operation";
-            break;
-        case CS_ERR_FAILED_OPERATION:
-            text = "Failed operation";
-            break;
-        case CS_ERR_MESSAGE_ERROR:
-            text = "Message error";
-            break;
-        case CS_ERR_QUEUE_FULL:
-            text = "Queue full";
-            break;
-        case CS_ERR_QUEUE_NOT_AVAILABLE:
-            text = "Queue not available";
-            break;
-        case CS_ERR_BAD_FLAGS:
-            text = "Bad flags";
-            break;
-        case CS_ERR_TOO_BIG:
-            text = "Too big";
-            break;
-        case CS_ERR_NO_SECTIONS:
-            text = "No sections";
-            break;
+        case CS_OK:                         return "OK";
+        case CS_ERR_LIBRARY:                return "Library error";
+        case CS_ERR_VERSION:                return "Version error";
+        case CS_ERR_INIT:                   return "Initialization error";
+        case CS_ERR_TIMEOUT:                return "Timeout";
+        case CS_ERR_TRY_AGAIN:              return "Try again";
+        case CS_ERR_INVALID_PARAM:          return "Invalid parameter";
+        case CS_ERR_NO_MEMORY:              return "No memory";
+        case CS_ERR_BAD_HANDLE:             return "Bad handle";
+        case CS_ERR_BUSY:                   return "Busy";
+        case CS_ERR_ACCESS:                 return "Access error";
+        case CS_ERR_NOT_EXIST:              return "Doesn't exist";
+        case CS_ERR_NAME_TOO_LONG:          return "Name too long";
+        case CS_ERR_EXIST:                  return "Exists";
+        case CS_ERR_NO_SPACE:               return "No space";
+        case CS_ERR_INTERRUPT:              return "Interrupt";
+        case CS_ERR_NAME_NOT_FOUND:         return "Name not found";
+        case CS_ERR_NO_RESOURCES:           return "No resources";
+        case CS_ERR_NOT_SUPPORTED:          return "Not supported";
+        case CS_ERR_BAD_OPERATION:          return "Bad operation";
+        case CS_ERR_FAILED_OPERATION:       return "Failed operation";
+        case CS_ERR_MESSAGE_ERROR:          return "Message error";
+        case CS_ERR_QUEUE_FULL:             return "Queue full";
+        case CS_ERR_QUEUE_NOT_AVAILABLE:    return "Queue not available";
+        case CS_ERR_BAD_FLAGS:              return "Bad flags";
+        case CS_ERR_TOO_BIG:                return "Too big";
+        case CS_ERR_NO_SECTIONS:            return "No sections";
     }
 #  endif
-    return text;
+    return "Corosync error";
 }
 
 #  if SUPPORT_COROSYNC

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -323,7 +323,6 @@ msg_type2text(enum crm_ais_msg_types type)
 gboolean send_cpg_iov(struct iovec * iov);
 
 char *corosync_cluster_name(void);
-int corosync_cmap_has_config(const char *prefix);
 
 gboolean corosync_initialize_nodelist(void *cluster, gboolean force_member, xmlNode * xml_parent);
 

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -324,7 +324,7 @@ gboolean send_cpg_iov(struct iovec * iov);
 
 char *corosync_cluster_name(void);
 
-gboolean corosync_initialize_nodelist(void *cluster, gboolean force_member, xmlNode * xml_parent);
+gboolean corosync_initialize_nodelist(xmlNode *xml_parent);
 
 gboolean send_cluster_message_cs(xmlNode * msg, gboolean local,
                                  crm_node_t * node, enum crm_ais_msg_types dest);

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -10,6 +10,7 @@
 #ifndef CRM_CLUSTER_INTERNAL__H
 #  define CRM_CLUSTER_INTERNAL__H
 
+#  include <stdint.h>       // uint32_t, uint64_t
 #  include <crm/cluster.h>
 
 /* *INDENT-OFF* */
@@ -100,20 +101,22 @@ bool pcmk__corosync_add_nodes(xmlNode *xml_parent);
 
 crm_node_t *crm_update_peer_proc(const char *source, crm_node_t * peer,
                                  uint32_t flag, const char *status);
-crm_node_t *crm_update_peer_state(const char *source, crm_node_t * node,
-                                  const char *state, uint64_t membership);
+crm_node_t *pcmk__update_peer_state(const char *source, crm_node_t *node,
+                                    const char *state, uint64_t membership);
 
-void crm_update_peer_uname(crm_node_t *node, const char *uname);
-void crm_update_peer_expected(const char *source, crm_node_t * node, const char *expected);
-void crm_reap_unseen_nodes(uint64_t ring_id);
+void pcmk__update_peer_expected(const char *source, crm_node_t *node,
+                                const char *expected);
+void pcmk__reap_unseen_nodes(uint64_t ring_id);
 
 void pcmk__corosync_quorum_connect(gboolean (*dispatch)(unsigned long long,
                                                         gboolean),
                                    void (*destroy) (gpointer));
-crm_node_t * crm_find_peer_full(unsigned int id, const char *uname, int flags);
-crm_node_t * crm_find_peer(unsigned int id, const char *uname);
+crm_node_t *pcmk__search_node_caches(unsigned int id, const char *uname,
+                                     uint32_t flags);
+crm_node_t *pcmk__search_cluster_node_cache(unsigned int id, const char *uname);
 
-void crm_peer_caches_refresh(xmlNode *cib);
-crm_node_t *crm_find_known_peer_full(unsigned int id, const char *uname, int flags);
+void pcmk__refresh_node_caches_from_cib(xmlNode *cib);
+crm_node_t *pcmk__search_known_node_cache(unsigned int id, const char *uname,
+                                          uint32_t flags);
 
 #endif

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -12,21 +12,6 @@
 
 #  include <crm/cluster.h>
 
-#define pcmk__set_peer_flags(peer, flags_to_set) do {                         \
-        (peer)->flags = pcmk__set_flags_as(__func__, __LINE__, LOG_TRACE,     \
-                                           "Peer", (peer)->uname,             \
-                                           (peer)->flags, (flags_to_set),     \
-                                           #flags_to_set);                    \
-    } while (0)
-
-#define pcmk__clear_peer_flags(peer, flags_to_clear) do {                     \
-        (peer)->flags = pcmk__clear_flags_as(__func__, __LINE__,              \
-                                             LOG_TRACE,                       \
-                                             "Peer", (peer)->uname,           \
-                                             (peer)->flags, (flags_to_clear), \
-                                             #flags_to_clear);                \
-    } while (0)
-
 typedef struct crm_ais_host_s AIS_Host;
 typedef struct crm_ais_msg_s AIS_Message;
 

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -322,8 +322,6 @@ msg_type2text(enum crm_ais_msg_types type)
 
 gboolean send_cpg_iov(struct iovec * iov);
 
-char *get_corosync_uuid(crm_node_t *peer);
-char *corosync_node_name(uint64_t /*cmap_handle_t */ cmap_handle, uint32_t nodeid);
 char *corosync_cluster_name(void);
 int corosync_cmap_has_config(const char *prefix);
 
@@ -332,10 +330,6 @@ gboolean corosync_initialize_nodelist(void *cluster, gboolean force_member, xmlN
 gboolean send_cluster_message_cs(xmlNode * msg, gboolean local,
                                  crm_node_t * node, enum crm_ais_msg_types dest);
 
-enum cluster_type_e find_corosync_variant(void);
-
-void terminate_cs_connection(crm_cluster_t * cluster);
-gboolean init_cs_connection(crm_cluster_t * cluster);
 gboolean init_cs_connection_once(crm_cluster_t * cluster);
 #  endif
 

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -319,11 +319,7 @@ msg_type2text(enum crm_ais_msg_types type)
 }
 
 #  if SUPPORT_COROSYNC
-
-gboolean send_cpg_iov(struct iovec * iov);
-
 char *pcmk__corosync_cluster_name(void);
-
 bool pcmk__corosync_add_nodes(xmlNode *xml_parent);
 #  endif
 

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -12,46 +12,6 @@
 
 #  include <crm/cluster.h>
 
-typedef struct crm_ais_host_s AIS_Host;
-typedef struct crm_ais_msg_s AIS_Message;
-
-struct crm_ais_host_s {
-    uint32_t id;
-    uint32_t pid;
-    gboolean local;
-    enum crm_ais_msg_types type;
-    uint32_t size;
-    char uname[MAX_NAME];
-
-} __attribute__ ((packed));
-
-#if SUPPORT_COROSYNC
-#  include <qb/qbipc_common.h>
-#  include <corosync/corotypes.h>
-typedef struct qb_ipc_response_header cs_ipc_header_response_t;
-#else
-typedef struct {
-    int size __attribute__ ((aligned(8)));
-    int id __attribute__ ((aligned(8)));
-    int error __attribute__ ((aligned(8)));
-} __attribute__ ((aligned(8))) cs_ipc_header_response_t;
-#endif
-
-struct crm_ais_msg_s {
-    cs_ipc_header_response_t header __attribute__ ((aligned(8)));
-    uint32_t id;
-    gboolean is_compressed;
-
-    AIS_Host host;
-    AIS_Host sender;
-
-    uint32_t size;
-    uint32_t compressed_size;
-    /* 584 bytes */
-    char data[0];
-
-} __attribute__ ((packed));
-
 /* *INDENT-OFF* */
 enum crm_proc_flag {
     crm_proc_none       = 0x00000001,
@@ -121,20 +81,6 @@ peer2text(enum crm_proc_flag proc)
     }
     return text;
 }
-
-static inline const char *
-ais_dest(const AIS_Host *host)
-{
-    if (host->local) {
-        return "local";
-    } else if (host->size > 0) {
-        return host->uname;
-    } else {
-        return "<all>";
-    }
-}
-
-#  define ais_data_len(msg) (msg->is_compressed?msg->compressed_size:msg->size)
 
 /*
 typedef enum {
@@ -260,46 +206,6 @@ ais_error2text(int error)
             break;
     }
 #  endif
-    return text;
-}
-
-static inline const char *
-msg_type2text(enum crm_ais_msg_types type)
-{
-    const char *text = "unknown";
-
-    switch (type) {
-        case crm_msg_none:
-            text = "unknown";
-            break;
-        case crm_msg_ais:
-            text = "ais";
-            break;
-        case crm_msg_cib:
-            text = "cib";
-            break;
-        case crm_msg_crmd:
-            text = "crmd";
-            break;
-        case crm_msg_pe:
-            text = "pengine";
-            break;
-        case crm_msg_te:
-            text = "tengine";
-            break;
-        case crm_msg_lrmd:
-            text = "lrmd";
-            break;
-        case crm_msg_attrd:
-            text = "attrd";
-            break;
-        case crm_msg_stonithd:
-            text = "stonithd";
-            break;
-        case crm_msg_stonith_ng:
-            text = "stonith-ng";
-            break;
-    }
     return text;
 }
 

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -48,40 +48,6 @@ crm_get_cluster_proc(void)
     return crm_proc_none;
 }
 
-static inline const char *
-peer2text(enum crm_proc_flag proc)
-{
-    const char *text = "unknown";
-
-    switch (proc) {
-        case crm_proc_none:
-            text = "none";
-            break;
-        case crm_proc_based:
-            text = "pacemaker-based";
-            break;
-        case crm_proc_controld:
-            text = "pacemaker-controld";
-            break;
-        case crm_proc_schedulerd:
-            text = "pacemaker-schedulerd";
-            break;
-        case crm_proc_execd:
-            text = "pacemaker-execd";
-            break;
-        case crm_proc_attrd:
-            text = "pacemaker-attrd";
-            break;
-        case crm_proc_fenced:
-            text = "pacemaker-fenced";
-            break;
-        case crm_proc_cpg:
-            text = "corosync-cpg";
-            break;
-    }
-    return text;
-}
-
 /*
 typedef enum {
    CS_OK = 1,

--- a/lib/cluster/Makefile.am
+++ b/lib/cluster/Makefile.am
@@ -8,6 +8,8 @@
 #
 include $(top_srcdir)/mk/common.mk
 
+noinst_HEADERS	= crmcluster_private.h
+
 ## libraries
 lib_LTLIBRARIES	= libcrmcluster.la 
 

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -136,7 +136,7 @@ send_cluster_message(crm_node_t *node, enum crm_ais_msg_types service,
     switch (get_cluster_type()) {
         case pcmk_cluster_corosync:
 #if SUPPORT_COROSYNC
-            return send_cluster_message_cs(data, FALSE, node, service);
+            return pcmk__cpg_send_xml(data, node, service);
 #endif
             break;
         default:

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -247,7 +247,7 @@ crm_peer_uname(const char *uuid)
         uint32_t id = (uint32_t) crm_parse_ll(uuid, NULL);
 
         if (id != 0) {
-            node = crm_find_peer(id, NULL);
+            node = pcmk__search_cluster_node_cache(id, NULL);
         } else {
             crm_err("Invalid node id: %s", uuid);
         }

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -23,6 +23,7 @@
 
 #include <crm/common/ipc.h>
 #include <crm/cluster/internal.h>
+#include "crmcluster_private.h"
 
 CRM_TRACE_INIT_DATA(cluster);
 
@@ -49,7 +50,7 @@ crm_peer_uuid(crm_node_t *peer)
     switch (get_cluster_type()) {
         case pcmk_cluster_corosync:
 #if SUPPORT_COROSYNC
-            uuid = get_corosync_uuid(peer);
+            uuid = pcmk__corosync_uuid(peer);
 #endif
             break;
 
@@ -82,7 +83,7 @@ crm_cluster_connect(crm_cluster_t *cluster)
 #if SUPPORT_COROSYNC
             if (is_corosync_cluster()) {
                 crm_peer_init();
-                return init_cs_connection(cluster);
+                return pcmk__corosync_connect(cluster);
             }
 #endif
             break;
@@ -109,7 +110,7 @@ crm_cluster_disconnect(crm_cluster_t *cluster)
 #if SUPPORT_COROSYNC
             if (is_corosync_cluster()) {
                 crm_peer_destroy();
-                terminate_cs_connection(cluster);
+                pcmk__corosync_disconnect(cluster);
             }
 #endif
             break;
@@ -179,7 +180,7 @@ get_node_name(uint32_t nodeid)
     switch (stack) {
 #  if SUPPORT_COROSYNC
         case pcmk_cluster_corosync:
-            name = corosync_node_name(0, nodeid);
+            name = pcmk__corosync_name(0, nodeid);
             break;
 #  endif
 
@@ -323,7 +324,7 @@ get_cluster_type(void)
     /* If nothing is defined in the environment, try corosync (if supported) */
     if (cluster == NULL) {
         crm_debug("Testing with Corosync");
-        cluster_type = find_corosync_variant();
+        cluster_type = pcmk__corosync_detect();
         if (cluster_type != pcmk_cluster_unknown) {
             detected = true;
             goto done;

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -309,24 +309,3 @@ is_corosync_cluster(void)
 {
     return get_cluster_type() == pcmk_cluster_corosync;
 }
-
-gboolean
-node_name_is_valid(const char *key, const char *name)
-{
-    int octet;
-
-    if (name == NULL) {
-        crm_trace("%s is empty", key);
-        return FALSE;
-
-    } else if (sscanf(name, "%d.%d.%d.%d", &octet, &octet, &octet, &octet) == 4) {
-        crm_trace("%s contains an ipv4 address, ignoring: %s", key, name);
-        return FALSE;
-
-    } else if (strstr(name, ":") != NULL) {
-        crm_trace("%s contains an ipv6 address, ignoring: %s", key, name);
-        return FALSE;
-    }
-    crm_trace("%s is valid", key);
-    return TRUE;
-}

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -247,30 +247,8 @@ name_for_cluster_type(enum cluster_type_e type)
     return "invalid";
 }
 
-/* Do not expose these two */
-int set_cluster_type(enum cluster_type_e type);
 static enum cluster_type_e cluster_type = pcmk_cluster_unknown;
 
-int
-set_cluster_type(enum cluster_type_e type)
-{
-    if (cluster_type == pcmk_cluster_unknown) {
-        crm_info("Cluster type set to: %s", name_for_cluster_type(type));
-        cluster_type = type;
-        return 0;
-
-    } else if (cluster_type == type) {
-        return 0;
-
-    } else if (pcmk_cluster_unknown == type) {
-        cluster_type = type;
-        return 0;
-    }
-
-    crm_err("Cluster type already set to %s, ignoring %s",
-            name_for_cluster_type(cluster_type), name_for_cluster_type(type));
-    return -1;
-}
 enum cluster_type_e
 get_cluster_type(void)
 {

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -319,11 +319,11 @@ quorum_notification_cb(quorum_handle_t handle, uint32_t quorate,
         }
 
         /* Update the node state (including updating last_seen to ring_id) */
-        crm_update_peer_state(__func__, node, CRM_NODE_MEMBER, ring_id);
+        pcmk__update_peer_state(__func__, node, CRM_NODE_MEMBER, ring_id);
     }
 
     /* Remove any peer cache entries we didn't update */
-    crm_reap_unseen_nodes(ring_id);
+    pcmk__reap_unseen_nodes(ring_id);
 
     if (quorum_app_callback) {
         quorum_app_callback(ring_id, quorate);

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -496,7 +496,7 @@ pcmk__corosync_detect(void)
 
         default:
             crm_info("Failed to initialize the cmap API: %s (%d)",
-                     ais_error2text(rc), rc);
+                     pcmk__cs_err_str(rc), rc);
             return pcmk_cluster_unknown;
     }
 

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -365,7 +365,7 @@ cluster_connect_quorum(gboolean(*dispatch) (unsigned long long, gboolean),
 
     mainloop_add_fd("quorum", G_PRIORITY_HIGH, fd, dispatch, &quorum_fd_callbacks);
 
-    corosync_initialize_nodelist(NULL, FALSE, NULL);
+    corosync_initialize_nodelist(NULL);
 
   bail:
     if (rc != CS_OK) {
@@ -461,7 +461,7 @@ crm_is_corosync_peer_active(const crm_node_t * node)
 }
 
 gboolean
-corosync_initialize_nodelist(void *cluster, gboolean force_member, xmlNode * xml_parent)
+corosync_initialize_nodelist(xmlNode *xml_parent)
 {
     int lpc = 0;
     cs_error_t rc = CS_OK;
@@ -556,9 +556,6 @@ corosync_initialize_nodelist(void *cluster, gboolean force_member, xmlNode * xml
 
                 crm_xml_set_id(node, "%u", nodeid);
                 crm_xml_add(node, XML_ATTR_UNAME, name);
-                if (force_member) {
-                    crm_xml_add(node, XML_ATTR_TYPE, CRM_NODE_MEMBER);
-                }
             }
         }
 

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2020 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -51,6 +51,27 @@ get_corosync_uuid(crm_node_t *node)
         }
     }
     return NULL;
+}
+
+static bool
+node_name_is_valid(const char *key, const char *name)
+{
+    int octet;
+
+    if (name == NULL) {
+        crm_trace("%s is empty", key);
+        return false;
+
+    } else if (sscanf(name, "%d.%d.%d.%d", &octet, &octet, &octet, &octet) == 4) {
+        crm_trace("%s contains an IPv4 address (%s), ignoring", key, name);
+        return false;
+
+    } else if (strstr(name, ":") != NULL) {
+        crm_trace("%s contains an IPv6 address (%s), ignoring", key, name);
+        return false;
+    }
+    crm_trace("'%s: %s' is valid", key, name);
+    return true;
 }
 
 /*
@@ -147,7 +168,7 @@ corosync_node_name(uint64_t /*cmap_handle_t */ cmap_handle, uint32_t nodeid)
                 cmap_get_string(cmap_handle, key, &name);
                 crm_trace("%s = %s", key, name);
 
-                if (node_name_is_valid(key, name) == FALSE) {
+                if (!node_name_is_valid(key, name)) {
                     free(name);
                     name = NULL;
                 }

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -458,7 +458,7 @@ check_message_sanity(const AIS_Message * msg, const char *data)
     if (sane && ais_data_len(msg) != tmp_size) {
         crm_warn("Message payload size is incorrect: expected %d, got %d", ais_data_len(msg),
                  tmp_size);
-        sane = TRUE;
+        sane = FALSE;
     }
 
     if (sane && ais_data_len(msg) == 0) {

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -438,69 +438,6 @@ init_cs_connection_once(crm_cluster_t * cluster)
     return TRUE;
 }
 
-gboolean
-check_message_sanity(const AIS_Message * msg, const char *data)
-{
-    gboolean sane = TRUE;
-    int dest = msg->host.type;
-    int tmp_size = msg->header.size - sizeof(AIS_Message);
-
-    if (sane && msg->header.size == 0) {
-        crm_warn("Message with no size");
-        sane = FALSE;
-    }
-
-    if (sane && msg->header.error != CS_OK) {
-        crm_warn("Message header contains an error: %d", msg->header.error);
-        sane = FALSE;
-    }
-
-    if (sane && ais_data_len(msg) != tmp_size) {
-        crm_warn("Message payload size is incorrect: expected %d, got %d", ais_data_len(msg),
-                 tmp_size);
-        sane = FALSE;
-    }
-
-    if (sane && ais_data_len(msg) == 0) {
-        crm_warn("Message with no payload");
-        sane = FALSE;
-    }
-
-    if (sane && data && msg->is_compressed == FALSE) {
-        int str_size = strlen(data) + 1;
-
-        if (ais_data_len(msg) != str_size) {
-            int lpc = 0;
-
-            crm_warn("Message payload is corrupted: expected %d bytes, got %d",
-                     ais_data_len(msg), str_size);
-            sane = FALSE;
-            for (lpc = (str_size - 10); lpc < msg->size; lpc++) {
-                if (lpc < 0) {
-                    lpc = 0;
-                }
-                crm_debug("bad_data[%d]: %d / '%c'", lpc, data[lpc], data[lpc]);
-            }
-        }
-    }
-
-    if (sane == FALSE) {
-        crm_err("Invalid message %d: (dest=%s:%s, from=%s:%s.%u, compressed=%d, size=%d, total=%d)",
-                msg->id, ais_dest(&(msg->host)), msg_type2text(dest),
-                ais_dest(&(msg->sender)), msg_type2text(msg->sender.type),
-                msg->sender.pid, msg->is_compressed, ais_data_len(msg), msg->header.size);
-
-    } else {
-        crm_trace
-            ("Verified message %d: (dest=%s:%s, from=%s:%s.%u, compressed=%d, size=%d, total=%d)",
-             msg->id, ais_dest(&(msg->host)), msg_type2text(dest), ais_dest(&(msg->sender)),
-             msg_type2text(msg->sender.type), msg->sender.pid, msg->is_compressed,
-             ais_data_len(msg), msg->header.size);
-    }
-
-    return sane;
-}
-
 enum cluster_type_e
 find_corosync_variant(void)
 {

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -640,7 +640,8 @@ pcmk_cpg_membership(cpg_handle_t handle,
           cmp_member_list_nodeid);
 
     for (i = 0; i < left_list_entries; i++) {
-        crm_node_t *peer = crm_find_peer(left_list[i].nodeid, NULL);
+        crm_node_t *peer = pcmk__search_cluster_node_cache(left_list[i].nodeid,
+                                                           NULL);
         const struct cpg_address **rival = NULL;
 
         /* in CPG world, NODE:PROCESS-IN-MEMBERSHIP-OF-G is an 1:N relation
@@ -733,7 +734,7 @@ pcmk_cpg_membership(cpg_handle_t handle,
                 // If it persists for more than a minute, update the state
                 crm_warn("Node %u is member of group %s but was believed offline",
                          member_list[i].nodeid, groupName->value);
-                crm_update_peer_state(__func__, peer, CRM_NODE_MEMBER, 0);
+                pcmk__update_peer_state(__func__, peer, CRM_NODE_MEMBER, 0);
             }
         }
 

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -34,7 +34,6 @@
 cpg_handle_t pcmk_cpg_handle = 0; /* TODO: Remove, use cluster.cpg_handle */
 
 static bool cpg_evicted = FALSE;
-gboolean(*pcmk_cpg_dispatch_fn) (int kind, const char *from, const char *data) = NULL;
 
 #define cs_repeat(counter, max, code) do {		\
 	code;						\

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -169,7 +169,8 @@ get_local_nodeid(cpg_handle_t handle)
     }
 
     if (rc != CS_OK) {
-        crm_err("Could not get local node id from the CPG API: %s (%d)", ais_error2text(rc), rc);
+        crm_err("Could not get local node id from the CPG API: %s (%d)",
+                pcmk__cs_err_str(rc), rc);
     }
 
 bail:
@@ -253,10 +254,10 @@ crm_cs_flush(gpointer data)
     queue_len -= sent;
     if ((sent > 1) || (cs_message_queue != NULL)) {
         crm_info("Sent %u CPG messages  (%d remaining): %s (%d)",
-                 sent, queue_len, ais_error2text(rc), (int) rc);
+                 sent, queue_len, pcmk__cs_err_str(rc), (int) rc);
     } else {
         crm_trace("Sent %u CPG messages  (%d remaining): %s (%d)",
-                  sent, queue_len, ais_error2text(rc), (int) rc);
+                  sent, queue_len, pcmk__cs_err_str(rc), (int) rc);
     }
 
     if (cs_message_queue) {
@@ -285,7 +286,8 @@ pcmk_cpg_dispatch(gpointer user_data)
 
     rc = cpg_dispatch(cluster->cpg_handle, CS_DISPATCH_ONE);
     if (rc != CS_OK) {
-        crm_err("Connection to the CPG API failed: %s (%d)", ais_error2text(rc), rc);
+        crm_err("Connection to the CPG API failed: %s (%d)",
+                pcmk__cs_err_str(rc), rc);
         cpg_finalize(cluster->cpg_handle);
         cluster->cpg_handle = 0;
         return -1;

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -30,6 +30,7 @@
 #include <crm/msg_xml.h>
 
 #include <crm/common/ipc_internal.h>  /* PCMK__SPECIAL_PID* */
+#include "crmcluster_private.h"
 
 cpg_handle_t pcmk_cpg_handle = 0; /* TODO: Remove, use cluster.cpg_handle */
 
@@ -694,13 +695,13 @@ cluster_connect_cpg(crm_cluster_t *cluster)
 }
 
 gboolean
-send_cluster_message_cs(xmlNode * msg, gboolean local, crm_node_t * node, enum crm_ais_msg_types dest)
+pcmk__cpg_send_xml(xmlNode *msg, crm_node_t *node, enum crm_ais_msg_types dest)
 {
     gboolean rc = TRUE;
     char *data = NULL;
 
     data = dump_xml_unformatted(msg);
-    rc = send_cluster_text(crm_class_cluster, data, local, node, dest);
+    rc = send_cluster_text(crm_class_cluster, data, FALSE, node, dest);
     free(data);
     return rc;
 }

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -215,19 +215,6 @@ crm_cs_flush(gpointer data)
     return rc;
 }
 
-gboolean
-send_cpg_iov(struct iovec * iov)
-{
-    static unsigned int queued = 0;
-
-    queued++;
-    crm_trace("Queueing CPG message %u (%llu bytes)",
-              queued, (unsigned long long) iov->iov_len);
-    cs_message_queue = g_list_append(cs_message_queue, iov);
-    crm_cs_flush(&pcmk_cpg_handle);
-    return TRUE;
-}
-
 static int
 pcmk_cpg_dispatch(gpointer user_data)
 {
@@ -830,7 +817,8 @@ send_cluster_text(enum crm_ais_msg_class msg_class, const char *data,
     }
     free(target);
 
-    send_cpg_iov(iov);
+    cs_message_queue = g_list_append(cs_message_queue, iov);
+    crm_cs_flush(&pcmk_cpg_handle);
 
     return TRUE;
 }

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -248,6 +248,69 @@ pcmk_cpg_dispatch(gpointer user_data)
     return 0;
 }
 
+static gboolean
+check_message_sanity(const AIS_Message * msg, const char *data)
+{
+    gboolean sane = TRUE;
+    int dest = msg->host.type;
+    int tmp_size = msg->header.size - sizeof(AIS_Message);
+
+    if (sane && msg->header.size == 0) {
+        crm_warn("Message with no size");
+        sane = FALSE;
+    }
+
+    if (sane && msg->header.error != CS_OK) {
+        crm_warn("Message header contains an error: %d", msg->header.error);
+        sane = FALSE;
+    }
+
+    if (sane && ais_data_len(msg) != tmp_size) {
+        crm_warn("Message payload size is incorrect: expected %d, got %d", ais_data_len(msg),
+                 tmp_size);
+        sane = FALSE;
+    }
+
+    if (sane && ais_data_len(msg) == 0) {
+        crm_warn("Message with no payload");
+        sane = FALSE;
+    }
+
+    if (sane && data && msg->is_compressed == FALSE) {
+        int str_size = strlen(data) + 1;
+
+        if (ais_data_len(msg) != str_size) {
+            int lpc = 0;
+
+            crm_warn("Message payload is corrupted: expected %d bytes, got %d",
+                     ais_data_len(msg), str_size);
+            sane = FALSE;
+            for (lpc = (str_size - 10); lpc < msg->size; lpc++) {
+                if (lpc < 0) {
+                    lpc = 0;
+                }
+                crm_debug("bad_data[%d]: %d / '%c'", lpc, data[lpc], data[lpc]);
+            }
+        }
+    }
+
+    if (sane == FALSE) {
+        crm_err("Invalid message %d: (dest=%s:%s, from=%s:%s.%u, compressed=%d, size=%d, total=%d)",
+                msg->id, ais_dest(&(msg->host)), msg_type2text(dest),
+                ais_dest(&(msg->sender)), msg_type2text(msg->sender.type),
+                msg->sender.pid, msg->is_compressed, ais_data_len(msg), msg->header.size);
+
+    } else {
+        crm_trace
+            ("Verified message %d: (dest=%s:%s, from=%s:%s.%u, compressed=%d, size=%d, total=%d)",
+             msg->id, ais_dest(&(msg->host)), msg_type2text(dest), ais_dest(&(msg->sender)),
+             msg_type2text(msg->sender.type), msg->sender.pid, msg->is_compressed,
+             ais_data_len(msg), msg->header.size);
+    }
+
+    return sane;
+}
+
 char *
 pcmk_message_common_cs(cpg_handle_t handle, uint32_t nodeid, uint32_t pid, void *content,
                         uint32_t *kind, const char **from)

--- a/lib/cluster/crmcluster_private.h
+++ b/lib/cluster/crmcluster_private.h
@@ -40,4 +40,8 @@ gboolean pcmk__corosync_connect(crm_cluster_t *cluster);
 G_GNUC_INTERNAL
 void pcmk__corosync_disconnect(crm_cluster_t *cluster);
 
+G_GNUC_INTERNAL
+gboolean pcmk__cpg_send_xml(xmlNode *msg, crm_node_t *node,
+                            enum crm_ais_msg_types dest);
+
 #endif  // PCMK__CRMCLUSTER_PRIVATE__H

--- a/lib/cluster/crmcluster_private.h
+++ b/lib/cluster/crmcluster_private.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__CRMCLUSTER_PRIVATE__H
+#  define PCMK__CRMCLUSTER_PRIVATE__H
+
+/* This header is for the sole use of libcrmcluster, so that functions can be
+ * declared with G_GNUC_INTERNAL for efficiency.
+ */
+
+#include <stdint.h>                // uint32_t, uint64_t
+
+#include <glib.h>                  // G_GNUC_INTERNAL, gboolean
+#include <libxml/tree.h>           // xmlNode
+
+#include <crm/cluster.h>           // cluster_type_e, crm_node_t
+
+G_GNUC_INTERNAL
+enum cluster_type_e pcmk__corosync_detect(void);
+
+G_GNUC_INTERNAL
+char *pcmk__corosync_uuid(crm_node_t *peer);
+
+G_GNUC_INTERNAL
+char *pcmk__corosync_name(uint64_t /*cmap_handle_t */ cmap_handle,
+                          uint32_t nodeid);
+
+G_GNUC_INTERNAL
+gboolean pcmk__corosync_connect(crm_cluster_t *cluster);
+
+G_GNUC_INTERNAL
+void pcmk__corosync_disconnect(crm_cluster_t *cluster);
+
+#endif  // PCMK__CRMCLUSTER_PRIVATE__H

--- a/lib/cluster/crmcluster_private.h
+++ b/lib/cluster/crmcluster_private.h
@@ -25,6 +25,9 @@ G_GNUC_INTERNAL
 enum cluster_type_e pcmk__corosync_detect(void);
 
 G_GNUC_INTERNAL
+bool pcmk__corosync_has_nodelist(void);
+
+G_GNUC_INTERNAL
 char *pcmk__corosync_uuid(crm_node_t *peer);
 
 G_GNUC_INTERNAL

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -51,7 +51,13 @@ GHashTable *crm_peer_cache = NULL;
  */
 GHashTable *crm_remote_peer_cache = NULL;
 
-GHashTable *crm_known_peer_cache = NULL;
+/*
+ * The known node cache tracks cluster and remote nodes that have been seen in
+ * the CIB. It is useful mainly when a caller needs to know about a node that
+ * may no longer be in the membership, but doesn't want to add the node to the
+ * main peer cache tables.
+ */
+static GHashTable *known_node_cache = NULL;
 
 unsigned long long crm_peer_seq = 0;
 gboolean crm_have_quorum = FALSE;
@@ -74,6 +80,8 @@ static gboolean crm_autoreap  = TRUE;
                                              #flags_to_clear);                \
     } while (0)
 
+static void update_peer_uname(crm_node_t *node, const char *uname);
+
 int
 crm_remote_peer_cache_size(void)
 {
@@ -91,8 +99,8 @@ crm_remote_peer_cache_size(void)
  * \return Cache entry for node on success, NULL (and set errno) otherwise
  *
  * \note When creating a new entry, this will leave the node state undetermined,
- *       so the caller should also call crm_update_peer_state() if the state is
- *       known.
+ *       so the caller should also call pcmk__update_peer_state() if the state
+ *       is known.
  */
 crm_node_t *
 crm_remote_peer_get(const char *node_name)
@@ -130,7 +138,7 @@ crm_remote_peer_get(const char *node_name)
     crm_trace("added %s to remote cache", node_name);
 
     /* Update the entry's uname, ensuring peer status callbacks are called */
-    crm_update_peer_uname(node, node_name);
+    update_peer_uname(node, node_name);
     return node;
 }
 
@@ -203,14 +211,14 @@ remote_cache_refresh_helper(xmlNode *result, void *user_data)
         node = crm_remote_peer_get(remote);
         CRM_ASSERT(node);
         if (state) {
-            crm_update_peer_state(__func__, node, state, 0);
+            pcmk__update_peer_state(__func__, node, state, 0);
         }
 
     } else if (pcmk_is_set(node->flags, crm_node_dirty)) {
         /* Node is in cache and hasn't been updated already, so mark it clean */
         clear_peer_flags(node, crm_node_dirty);
         if (state) {
-            crm_update_peer_state(__func__, node, state, 0);
+            pcmk__update_peer_state(__func__, node, state, 0);
         }
     }
 }
@@ -369,7 +377,7 @@ reap_crm_member(uint32_t id, const char *name)
 }
 
 static void
-crm_count_peer(gpointer key, gpointer value, gpointer user_data)
+count_peer(gpointer key, gpointer value, gpointer user_data)
 {
     guint *count = user_data;
     crm_node_t *node = value;
@@ -385,7 +393,7 @@ crm_active_peers(void)
     guint count = 0;
 
     if (crm_peer_cache) {
-        g_hash_table_foreach(crm_peer_cache, crm_count_peer, &count);
+        g_hash_table_foreach(crm_peer_cache, count_peer, &count);
     }
     return count;
 }
@@ -415,8 +423,10 @@ crm_peer_init(void)
         crm_remote_peer_cache = g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal, NULL, destroy_crm_node);
     }
 
-    if (crm_known_peer_cache == NULL) {
-        crm_known_peer_cache = g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal, free, destroy_crm_node);
+    if (known_node_cache == NULL) {
+        known_node_cache = g_hash_table_new_full(crm_strcase_hash,
+                                                 crm_strcase_equal, free,
+                                                 destroy_crm_node);
     }
 }
 
@@ -435,15 +445,17 @@ crm_peer_destroy(void)
         crm_remote_peer_cache = NULL;
     }
 
-    if (crm_known_peer_cache != NULL) {
-        crm_trace("Destroying known peer cache with %d members", g_hash_table_size(crm_known_peer_cache));
-        g_hash_table_destroy(crm_known_peer_cache);
-        crm_known_peer_cache = NULL;
+    if (known_node_cache != NULL) {
+        crm_trace("Destroying known node cache with %d members",
+                  g_hash_table_size(known_node_cache));
+        g_hash_table_destroy(known_node_cache);
+        known_node_cache = NULL;
     }
 
 }
 
-void (*crm_status_callback) (enum crm_status_type, crm_node_t *, const void *) = NULL;
+static void (*peer_status_callback)(enum crm_status_type, crm_node_t *,
+                                    const void *) = NULL;
 
 /*!
  * \brief Set a client function that will be called after peer status changes
@@ -458,14 +470,14 @@ void (*crm_status_callback) (enum crm_status_type, crm_node_t *, const void *) =
 void
 crm_set_status_callback(void (*dispatch) (enum crm_status_type, crm_node_t *, const void *))
 {
-    crm_status_callback = dispatch;
+    peer_status_callback = dispatch;
 }
 
 /*!
  * \brief Tell the library whether to automatically reap lost nodes
  *
  * If TRUE (the default), calling crm_update_peer_proc() will also update the
- * peer state to CRM_NODE_MEMBER or CRM_NODE_LOST, and crm_update_peer_state()
+ * peer state to CRM_NODE_MEMBER or CRM_NODE_LOST, and pcmk__update_peer_state()
  * will reap peers whose state changes to anything other than CRM_NODE_MEMBER.
  * Callers should leave this enabled unless they plan to manage the cache
  * separately on their own.
@@ -478,7 +490,8 @@ crm_set_autoreap(gboolean autoreap)
     crm_autoreap = autoreap;
 }
 
-static void crm_dump_peer_hash(int level, const char *caller)
+static void
+dump_peer_hash(int level, const char *caller)
 {
     GHashTableIter iter;
     const char *id = NULL;
@@ -490,16 +503,24 @@ static void crm_dump_peer_hash(int level, const char *caller)
     }
 }
 
-static gboolean crm_hash_find_by_data(gpointer key, gpointer value, gpointer user_data)
+static gboolean
+hash_find_by_data(gpointer key, gpointer value, gpointer user_data)
 {
-    if(value == user_data) {
-        return TRUE;
-    }
-    return FALSE;
+    return value == user_data;
 }
 
+/*!
+ * \internal
+ * \brief Search caches for a node (cluster or Pacemaker Remote)
+ *
+ * \param[in] id     If not 0, cluster node ID to search for
+ * \param[in] uname  If not NULL, node name to search for
+ * \param[in] flags  Bitmask of enum crm_get_peer_flags
+ *
+ * \return Node cache entry if found, otherwise NULL
+ */
 crm_node_t *
-crm_find_peer_full(unsigned int id, const char *uname, int flags)
+pcmk__search_node_caches(unsigned int id, const char *uname, uint32_t flags)
 {
     crm_node_t *node = NULL;
 
@@ -507,16 +528,25 @@ crm_find_peer_full(unsigned int id, const char *uname, int flags)
 
     crm_peer_init();
 
-    if ((uname != NULL) && (flags & CRM_GET_PEER_REMOTE)) {
+    if ((uname != NULL) && pcmk_is_set(flags, CRM_GET_PEER_REMOTE)) {
         node = g_hash_table_lookup(crm_remote_peer_cache, uname);
     }
 
-    if (node == NULL && (flags & CRM_GET_PEER_CLUSTER)) {
-        node = crm_find_peer(id, uname);
+    if ((node == NULL) && pcmk_is_set(flags, CRM_GET_PEER_CLUSTER)) {
+        node = pcmk__search_cluster_node_cache(id, uname);
     }
     return node;
 }
 
+/*!
+ * \brief Get a node cache entry (cluster or Pacemaker Remote)
+ *
+ * \param[in] id     If not 0, cluster node ID to search for
+ * \param[in] uname  If not NULL, node name to search for
+ * \param[in] flags  Bitmask of enum crm_get_peer_flags
+ *
+ * \return (Possibly newly created) node cache entry
+ */
 crm_node_t *
 crm_get_peer_full(unsigned int id, const char *uname, int flags)
 {
@@ -526,18 +556,27 @@ crm_get_peer_full(unsigned int id, const char *uname, int flags)
 
     crm_peer_init();
 
-    if (flags & CRM_GET_PEER_REMOTE) {
+    if (pcmk_is_set(flags, CRM_GET_PEER_REMOTE)) {
         node = g_hash_table_lookup(crm_remote_peer_cache, uname);
     }
 
-    if (node == NULL && (flags & CRM_GET_PEER_CLUSTER)) {
+    if ((node == NULL) && pcmk_is_set(flags, CRM_GET_PEER_CLUSTER)) {
         node = crm_get_peer(id, uname);
     }
     return node;
 }
 
+/*!
+ * \internal
+ * \brief Search cluster node cache
+ *
+ * \param[in] id     If not 0, cluster node ID to search for
+ * \param[in] uname  If not NULL, node name to search for
+ *
+ * \return Cluster node cache entry if found, otherwise NULL
+ */
 crm_node_t *
-crm_find_peer(unsigned int id, const char *uname)
+pcmk__search_cluster_node_cache(unsigned int id, const char *uname)
 {
     GHashTableIter iter;
     crm_node_t *node = NULL;
@@ -579,7 +618,7 @@ crm_find_peer(unsigned int id, const char *uname)
         crm_trace("Only one: %p for %u/%s", by_name, id, uname);
 
         if(id && by_name->id) {
-            crm_dump_peer_hash(LOG_WARNING, __func__);
+            dump_peer_hash(LOG_WARNING, __func__);
             crm_crit("Node %u and %u share the same name '%s'",
                      id, by_name->id, uname);
             node = NULL; /* Create a new one */
@@ -592,7 +631,7 @@ crm_find_peer(unsigned int id, const char *uname)
         crm_trace("Only one: %p for %u/%s", by_id, id, uname);
 
         if(uname && by_id->uname) {
-            crm_dump_peer_hash(LOG_WARNING, __func__);
+            dump_peer_hash(LOG_WARNING, __func__);
             crm_crit("Node '%s' and '%s' share the same cluster nodeid %u: assuming '%s' is correct",
                      uname, by_id->uname, id, uname);
         }
@@ -600,11 +639,11 @@ crm_find_peer(unsigned int id, const char *uname)
     } else if(uname && by_id->uname) {
         if(pcmk__str_eq(uname, by_id->uname, pcmk__str_casei)) {
             crm_notice("Node '%s' has changed its ID from %u to %u", by_id->uname, by_name->id, by_id->id);
-            g_hash_table_foreach_remove(crm_peer_cache, crm_hash_find_by_data, by_name);
+            g_hash_table_foreach_remove(crm_peer_cache, hash_find_by_data, by_name);
 
         } else {
             crm_warn("Node '%s' and '%s' share the same cluster nodeid: %u %s", by_id->uname, by_name->uname, id, uname);
-            crm_dump_peer_hash(LOG_INFO, __func__);
+            dump_peer_hash(LOG_INFO, __func__);
             crm_abort(__FILE__, __func__, __LINE__, "member weirdness", TRUE,
                       TRUE);
         }
@@ -616,13 +655,13 @@ crm_find_peer(unsigned int id, const char *uname)
         /* Simple merge */
 
         /* Only corosync-based clusters use node IDs. The functions that call
-         * crm_update_peer_state() and crm_update_peer_proc() only know nodeid,
-         * so 'by_id' is authoritative when merging.
+         * pcmk__update_peer_state() and crm_update_peer_proc() only know
+         * nodeid, so 'by_id' is authoritative when merging.
          */
-        crm_dump_peer_hash(LOG_DEBUG, __func__);
+        dump_peer_hash(LOG_DEBUG, __func__);
 
         crm_info("Merging %p into %p", by_name, by_id);
-        g_hash_table_foreach_remove(crm_peer_cache, crm_hash_find_by_data, by_name);
+        g_hash_table_foreach_remove(crm_peer_cache, hash_find_by_data, by_name);
     }
 
     return node;
@@ -630,7 +669,7 @@ crm_find_peer(unsigned int id, const char *uname)
 
 #if SUPPORT_COROSYNC
 static guint
-crm_remove_conflicting_peer(crm_node_t *node)
+remove_conflicting_peer(crm_node_t *node)
 {
     int matches = 0;
     GHashTableIter iter;
@@ -667,6 +706,14 @@ crm_remove_conflicting_peer(crm_node_t *node)
 }
 #endif
 
+/*!
+ * \brief Get a cluster node cache entry
+ *
+ * \param[in] id     If not 0, cluster node ID to search for
+ * \param[in] uname  If not NULL, node name to search for
+ *
+ * \return (Possibly newly created) cluster node cache entry
+ */
 /* coverity[-alloc] Memory is referenced in one or both hashtables */
 crm_node_t *
 crm_get_peer(unsigned int id, const char *uname)
@@ -678,7 +725,7 @@ crm_get_peer(unsigned int id, const char *uname)
 
     crm_peer_init();
 
-    node = crm_find_peer(id, uname);
+    node = pcmk__search_cluster_node_cache(id, uname);
 
     /* if uname wasn't provided, and find_peer did not turn up a uname based on id.
      * we need to do a lookup of the node name using the id in the cluster membership. */
@@ -692,7 +739,7 @@ crm_get_peer(unsigned int id, const char *uname)
 
         /* try to turn up the node one more time now that we know the uname. */
         if (node == NULL) {
-            node = crm_find_peer(id, uname);
+            node = pcmk__search_cluster_node_cache(id, uname);
         }
     }
 
@@ -717,7 +764,7 @@ crm_get_peer(unsigned int id, const char *uname)
     }
 
     if (uname && (node->uname == NULL)) {
-        crm_update_peer_uname(node, uname);
+        update_peer_uname(node, uname);
     }
 
     if(node->uuid == NULL) {
@@ -747,8 +794,8 @@ crm_get_peer(unsigned int id, const char *uname)
  *       because in some cases it can remove conflicting cache entries,
  *       which would invalidate the iterator.
  */
-void
-crm_update_peer_uname(crm_node_t *node, const char *uname)
+static void
+update_peer_uname(crm_node_t *node, const char *uname)
 {
     CRM_CHECK(uname != NULL,
               crm_err("Bug: can't update node name without name"); return);
@@ -773,13 +820,13 @@ crm_update_peer_uname(crm_node_t *node, const char *uname)
     node->uname = strdup(uname);
     CRM_ASSERT(node->uname != NULL);
 
-    if (crm_status_callback) {
-        crm_status_callback(crm_status_uname, node, NULL);
+    if (peer_status_callback != NULL) {
+        peer_status_callback(crm_status_uname, node, NULL);
     }
 
 #if SUPPORT_COROSYNC
     if (is_corosync_cluster() && !pcmk_is_set(node->flags, crm_remote_node)) {
-        crm_remove_conflicting_peer(node);
+        remove_conflicting_peer(node);
     }
 #endif
 }
@@ -893,8 +940,8 @@ crm_update_peer_proc(const char *source, crm_node_t * node, uint32_t flag, const
         /* Call the client callback first, then update the peer state,
          * in case the node will be reaped
          */
-        if (crm_status_callback) {
-            crm_status_callback(crm_status_processes, node, &last);
+        if (peer_status_callback != NULL) {
+            peer_status_callback(crm_status_processes, node, &last);
         }
 
         /* The client callback shouldn't touch the peer caches,
@@ -912,7 +959,7 @@ crm_update_peer_proc(const char *source, crm_node_t * node, uint32_t flag, const
             } else {
                 peer_state = CRM_NODE_LOST;
             }
-            node = crm_update_peer_state(__func__, node, peer_state, 0);
+            node = pcmk__update_peer_state(__func__, node, peer_state, 0);
         }
     } else {
         crm_trace("%s: Node %s[%u] - %s is unchanged (%s)", source, node->uname, node->id,
@@ -921,8 +968,17 @@ crm_update_peer_proc(const char *source, crm_node_t * node, uint32_t flag, const
     return node;
 }
 
+/*!
+ * \internal
+ * \brief Update a cluster node cache entry's expected join state
+ *
+ * \param[in]     source    Caller's function name (for logging)
+ * \param[in,out] node      Node to update
+ * \param[in]     expected  Node's new join state
+ */
 void
-crm_update_peer_expected(const char *source, crm_node_t * node, const char *expected)
+pcmk__update_peer_expected(const char *source, crm_node_t *node,
+                           const char *expected)
 {
     char *last = NULL;
     gboolean changed = FALSE;
@@ -968,7 +1024,8 @@ crm_update_peer_expected(const char *source, crm_node_t * node, const char *expe
  *       within a peer cache iteration if the iterator is supplied.
  */
 static crm_node_t *
-crm_update_peer_state_iter(const char *source, crm_node_t * node, const char *state, uint64_t membership, GHashTableIter *iter)
+update_peer_state_iter(const char *source, crm_node_t *node, const char *state,
+                       uint64_t membership, GHashTableIter *iter)
 {
     gboolean is_member;
 
@@ -992,8 +1049,8 @@ crm_update_peer_state_iter(const char *source, crm_node_t * node, const char *st
         crm_notice("Node %s state is now %s " CRM_XS
                    " nodeid=%u previous=%s source=%s", node->uname, state,
                    node->id, (last? last : "unknown"), source);
-        if (crm_status_callback) {
-            crm_status_callback(crm_status_nstate, node, last);
+        if (peer_status_callback != NULL) {
+            peer_status_callback(crm_status_nstate, node, last);
         }
         free(last);
 
@@ -1036,9 +1093,10 @@ crm_update_peer_state_iter(const char *source, crm_node_t * node, const char *st
  *       otherwise reaping could invalidate the iterator.
  */
 crm_node_t *
-crm_update_peer_state(const char *source, crm_node_t * node, const char *state, uint64_t membership)
+pcmk__update_peer_state(const char *source, crm_node_t *node,
+                        const char *state, uint64_t membership)
 {
-    return crm_update_peer_state_iter(source, node, state, membership, NULL);
+    return update_peer_state_iter(source, node, state, membership, NULL);
 }
 
 /*!
@@ -1048,7 +1106,7 @@ crm_update_peer_state(const char *source, crm_node_t * node, const char *state, 
  * \param[in] membership  Membership ID of nodes to keep
  */
 void
-crm_reap_unseen_nodes(uint64_t membership)
+pcmk__reap_unseen_nodes(uint64_t membership)
 {
     GHashTableIter iter;
     crm_node_t *node = NULL;
@@ -1059,11 +1117,11 @@ crm_reap_unseen_nodes(uint64_t membership)
         if (node->last_seen != membership) {
             if (node->state) {
                 /*
-                 * Calling crm_update_peer_state_iter() allows us to
+                 * Calling update_peer_state_iter() allows us to
                  * remove the node from crm_peer_cache without
                  * invalidating our iterator
                  */
-                crm_update_peer_state_iter(__func__, node, CRM_NODE_LOST,
+                update_peer_state_iter(__func__, node, CRM_NODE_LOST,
                                            membership, &iter);
 
             } else {
@@ -1075,7 +1133,7 @@ crm_reap_unseen_nodes(uint64_t membership)
 }
 
 static crm_node_t *
-crm_find_known_peer(const char *id, const char *uname)
+find_known_node(const char *id, const char *uname)
 {
     GHashTableIter iter;
     crm_node_t *node = NULL;
@@ -1083,7 +1141,7 @@ crm_find_known_peer(const char *id, const char *uname)
     crm_node_t *by_name = NULL;
 
     if (uname) {
-        g_hash_table_iter_init(&iter, crm_known_peer_cache);
+        g_hash_table_iter_init(&iter, known_node_cache);
         while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
             if (node->uname && strcasecmp(node->uname, uname) == 0) {
                 crm_trace("Name match: %s = %p", node->uname, node);
@@ -1094,7 +1152,7 @@ crm_find_known_peer(const char *id, const char *uname)
     }
 
     if (id) {
-        g_hash_table_iter_init(&iter, crm_known_peer_cache);
+        g_hash_table_iter_init(&iter, known_node_cache);
         while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
             if(strcasecmp(node->uuid, id) == 0) {
                 crm_trace("ID match: %s= %p", id, node);
@@ -1153,14 +1211,14 @@ crm_find_known_peer(const char *id, const char *uname)
 }
 
 static void
-known_peer_cache_refresh_helper(xmlNode *xml_node, void *user_data)
+known_node_cache_refresh_helper(xmlNode *xml_node, void *user_data)
 {
     const char *id = crm_element_value(xml_node, XML_ATTR_ID);
     const char *uname = crm_element_value(xml_node, XML_ATTR_UNAME);
     crm_node_t * node =  NULL;
 
     CRM_CHECK(id != NULL && uname !=NULL, return);
-    node = crm_find_known_peer(id, uname);
+    node = find_known_node(id, uname);
 
     if (node == NULL) {
         char *uniqueid = crm_generate_uuid();
@@ -1174,7 +1232,7 @@ known_peer_cache_refresh_helper(xmlNode *xml_node, void *user_data)
         node->uuid = strdup(id);
         CRM_ASSERT(node->uuid != NULL);
 
-        g_hash_table_replace(crm_known_peer_cache, uniqueid, node);
+        g_hash_table_replace(known_node_cache, uniqueid, node);
 
     } else if (pcmk_is_set(node->flags, crm_node_dirty)) {
         if (!pcmk__str_eq(uname, node->uname, pcmk__str_casei)) {
@@ -1194,35 +1252,46 @@ known_peer_cache_refresh_helper(xmlNode *xml_node, void *user_data)
     "/" XML_CIB_TAG_NODE "[not(@type) or @type='member']"
 
 static void
-crm_known_peer_cache_refresh(xmlNode *cib)
+refresh_known_node_cache(xmlNode *cib)
 {
     crm_peer_init();
 
-    g_hash_table_foreach(crm_known_peer_cache, mark_dirty, NULL);
+    g_hash_table_foreach(known_node_cache, mark_dirty, NULL);
 
     crm_foreach_xpath_result(cib, XPATH_MEMBER_NODE_CONFIG,
-                             known_peer_cache_refresh_helper, NULL);
+                             known_node_cache_refresh_helper, NULL);
 
     /* Remove all old cache entries that weren't seen in the CIB */
-    g_hash_table_foreach_remove(crm_known_peer_cache, is_dirty, NULL);
+    g_hash_table_foreach_remove(known_node_cache, is_dirty, NULL);
 }
 
 void
-crm_peer_caches_refresh(xmlNode *cib)
+pcmk__refresh_node_caches_from_cib(xmlNode *cib)
 {
     crm_remote_peer_cache_refresh(cib);
-    crm_known_peer_cache_refresh(cib);
+    refresh_known_node_cache(cib);
 }
 
+/*!
+ * \internal
+ * \brief Search known node cache
+ *
+ * \param[in] id     If not 0, cluster node ID to search for
+ * \param[in] uname  If not NULL, node name to search for
+ * \param[in] flags  Bitmask of enum crm_get_peer_flags
+ *
+ * \return Known node cache entry if found, otherwise NULL
+ */
 crm_node_t *
-crm_find_known_peer_full(unsigned int id, const char *uname, int flags)
+pcmk__search_known_node_cache(unsigned int id, const char *uname,
+                              uint32_t flags)
 {
     crm_node_t *node = NULL;
     char *id_str = NULL;
 
     CRM_ASSERT(id > 0 || uname != NULL);
 
-    node = crm_find_peer_full(id, uname, flags);
+    node = pcmk__search_node_caches(id, uname, flags);
 
     if (node || !(flags & CRM_GET_PEER_CLUSTER)) {
         return node;
@@ -1232,7 +1301,7 @@ crm_find_known_peer_full(unsigned int id, const char *uname, int flags)
         id_str = crm_strdup_printf("%u", id);
     }
 
-    node = crm_find_known_peer(id_str, uname);
+    node = find_known_node(id_str, uname);
 
     free(id_str);
     return node;

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -57,6 +57,23 @@ unsigned long long crm_peer_seq = 0;
 gboolean crm_have_quorum = FALSE;
 static gboolean crm_autoreap  = TRUE;
 
+// Flag setting and clearing for crm_node_t:flags
+
+#define set_peer_flags(peer, flags_to_set) do {                               \
+        (peer)->flags = pcmk__set_flags_as(__func__, __LINE__, LOG_TRACE,     \
+                                           "Peer", (peer)->uname,             \
+                                           (peer)->flags, (flags_to_set),     \
+                                           #flags_to_set);                    \
+    } while (0)
+
+#define clear_peer_flags(peer, flags_to_clear) do {                           \
+        (peer)->flags = pcmk__clear_flags_as(__func__, __LINE__,              \
+                                             LOG_TRACE,                       \
+                                             "Peer", (peer)->uname,           \
+                                             (peer)->flags, (flags_to_clear), \
+                                             #flags_to_clear);                \
+    } while (0)
+
 int
 crm_remote_peer_cache_size(void)
 {
@@ -100,7 +117,7 @@ crm_remote_peer_get(const char *node_name)
     }
 
     /* Populate the essential information */
-    pcmk__set_peer_flags(node, crm_remote_node);
+    set_peer_flags(node, crm_remote_node);
     node->uuid = strdup(node_name);
     if (node->uuid == NULL) {
         free(node);
@@ -191,7 +208,7 @@ remote_cache_refresh_helper(xmlNode *result, void *user_data)
 
     } else if (pcmk_is_set(node->flags, crm_node_dirty)) {
         /* Node is in cache and hasn't been updated already, so mark it clean */
-        pcmk__clear_peer_flags(node, crm_node_dirty);
+        clear_peer_flags(node, crm_node_dirty);
         if (state) {
             crm_update_peer_state(__func__, node, state, 0);
         }
@@ -201,7 +218,7 @@ remote_cache_refresh_helper(xmlNode *result, void *user_data)
 static void
 mark_dirty(gpointer key, gpointer value, gpointer user_data)
 {
-    pcmk__set_peer_flags((crm_node_t *) value, crm_node_dirty);
+    set_peer_flags((crm_node_t *) value, crm_node_dirty);
 }
 
 static gboolean
@@ -1137,7 +1154,7 @@ known_peer_cache_refresh_helper(xmlNode *xml_node, void *user_data)
         }
 
         /* Node is in cache and hasn't been updated already, so mark it clean */
-        pcmk__clear_peer_flags(node, crm_node_dirty);
+        clear_peer_flags(node, crm_node_dirty);
     }
 
 }

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -786,6 +786,48 @@ crm_update_peer_uname(crm_node_t *node, const char *uname)
 
 /*!
  * \internal
+ * \brief Get log-friendly string equivalent of a process flag
+ *
+ * \param[in] proc  Process flag
+ *
+ * \return Log-friendly string equivalent of \p proc
+ */
+static inline const char *
+proc2text(enum crm_proc_flag proc)
+{
+    const char *text = "unknown";
+
+    switch (proc) {
+        case crm_proc_none:
+            text = "none";
+            break;
+        case crm_proc_based:
+            text = "pacemaker-based";
+            break;
+        case crm_proc_controld:
+            text = "pacemaker-controld";
+            break;
+        case crm_proc_schedulerd:
+            text = "pacemaker-schedulerd";
+            break;
+        case crm_proc_execd:
+            text = "pacemaker-execd";
+            break;
+        case crm_proc_attrd:
+            text = "pacemaker-attrd";
+            break;
+        case crm_proc_fenced:
+            text = "pacemaker-fenced";
+            break;
+        case crm_proc_cpg:
+            text = "corosync-cpg";
+            break;
+    }
+    return text;
+}
+
+/*!
+ * \internal
  * \brief Update a node's process information (and potentially state)
  *
  * \param[in] source      Caller's function name (for log messages)
@@ -807,7 +849,8 @@ crm_update_peer_proc(const char *source, crm_node_t * node, uint32_t flag, const
     gboolean changed = FALSE;
 
     CRM_CHECK(node != NULL, crm_err("%s: Could not set %s to %s for NULL",
-                                    source, peer2text(flag), status); return NULL);
+                                    source, proc2text(flag), status);
+                            return NULL);
 
     /* Pacemaker doesn't spawn processes on remote nodes */
     if (pcmk_is_set(node->flags, crm_remote_node)) {
@@ -844,7 +887,7 @@ crm_update_peer_proc(const char *source, crm_node_t * node, uint32_t flag, const
                      node->id);
         } else {
             crm_info("%s: Node %s[%u] - %s is now %s", source, node->uname, node->id,
-                     peer2text(flag), status);
+                     proc2text(flag), status);
         }
 
         /* Call the client callback first, then update the peer state,
@@ -873,7 +916,7 @@ crm_update_peer_proc(const char *source, crm_node_t * node, uint32_t flag, const
         }
     } else {
         crm_trace("%s: Node %s[%u] - %s is unchanged (%s)", source, node->uname, node->id,
-                  peer2text(flag), status);
+                  proc2text(flag), status);
     }
     return node;
 }

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -23,6 +23,7 @@
 #include <crm/cluster/internal.h>
 #include <crm/msg_xml.h>
 #include <crm/stonith-ng.h>
+#include "crmcluster_private.h"
 
 /* The peer cache remembers cluster nodes that have been seen.
  * This is managed mostly automatically by libcluster, based on
@@ -622,7 +623,7 @@ crm_remove_conflicting_peer(crm_node_t *node)
         return 0;
     }
 
-    if (corosync_cmap_has_config("nodelist") != 0) {
+    if (!pcmk__corosync_has_nodelist()) {
         return 0;
     }
 

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -1074,19 +1074,6 @@ crm_reap_unseen_nodes(uint64_t membership)
     }
 }
 
-int
-crm_terminate_member(int nodeid, const char *uname, void *unused)
-{
-    /* Always use the synchronous, non-mainloop version */
-    return stonith_api_kick(nodeid, uname, 120, TRUE);
-}
-
-int
-crm_terminate_member_no_mainloop(int nodeid, const char *uname, int *connection)
-{
-    return stonith_api_kick(nodeid, uname, 120, TRUE);
-}
-
 static crm_node_t *
 crm_find_known_peer(const char *id, const char *uname)
 {
@@ -1249,4 +1236,29 @@ crm_find_known_peer_full(unsigned int id, const char *uname, int flags)
 
     free(id_str);
     return node;
+}
+
+
+// Deprecated functions kept only for backward API compatibility
+
+int crm_terminate_member(int nodeid, const char *uname, void *unused);
+int crm_terminate_member_no_mainloop(int nodeid, const char *uname,
+                                     int *connection);
+/*!
+ * \deprecated Use stonith_api_kick() from libstonithd instead
+ */
+int
+crm_terminate_member(int nodeid, const char *uname, void *unused)
+{
+    /* Always use the synchronous, non-mainloop version */
+    return stonith_api_kick(nodeid, uname, 120, TRUE);
+}
+
+/*!
+ * \deprecated Use stonith_api_kick() from libstonithd instead
+ */
+int
+crm_terminate_member_no_mainloop(int nodeid, const char *uname, int *connection)
+{
+    return stonith_api_kick(nodeid, uname, 120, TRUE);
 }


### PR DESCRIPTION
This is part of the extended project to bring the Pacemaker code base into compliance with the current development guidelines, particularly around naming, function return values, and documentation. This covers all internal API in the libcrmcluster library, as well as public API other than what has to be kept for backward compatibility (function names/signatures etc.).