### PR TITLE
Fix: liblrmd: Limit node name addition to proxied attrd update commands

### DIFF
--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -628,6 +628,11 @@ attrd_peer_message(crm_node_t *peer, xmlNode *xml)
             /* Synchronize if there is an attribute held only by own node that Writer does not have. */
             attrd_current_only_attribute_update(peer, xml);
         }
+
+    } else if (pcmk__str_eq(op, PCMK__ATTRD_CMD_FLUSH, pcmk__str_casei)) {
+        /* Ignore. The flush command was removed in 2.0.0 but may be
+         * received from peers running older versions.
+         */
     }
 }
 

--- a/lib/lrmd/proxy_common.c
+++ b/lib/lrmd/proxy_common.c
@@ -259,7 +259,11 @@ remote_proxy_cb(lrmd_t *lrmd, const char *node_name, xmlNode *msg)
 
             if (pcmk__str_eq(type, T_ATTRD, pcmk__str_casei)
                 && crm_element_value(request,
-                                     PCMK__XA_ATTR_NODE_NAME) == NULL) {
+                                     PCMK__XA_ATTR_NODE_NAME) == NULL
+                && pcmk__str_any_of(crm_element_value(request, PCMK__XA_TASK),
+                                    PCMK__ATTRD_CMD_UPDATE,
+                                    PCMK__ATTRD_CMD_UPDATE_BOTH,
+                                    PCMK__ATTRD_CMD_UPDATE_DELAY, NULL)) {
                 crm_xml_add(request, PCMK__XA_ATTR_NODE_NAME, proxy->node_name);
             }
 


### PR DESCRIPTION
remote_proxy_cb() currently adds the remote node's name as
PCMK__XA_ATTR_NODE_NAME if that attribute is not explicitly set. This is
necessary for attrd update commands. For those, lack of an explicit node
name means to use the local node. Since requests are proxied to full
nodes, the node hosting the remote resource would be incorrectly treated
as the "local node", causing the attribute to be updated for the wrong
node.

However, for other commands, this is not the case. Lack of an explicit
node name can mean "all nodes" (as for CLEAR_FAILURE and QUERY), or a
node name may be ignored (as for REFRESH). In these cases (the
non-update commands), we don't want to add a node name automatically if
it's not explicitly set.

Resolves: RHBZ#1907726