### PR TITLE
Fix: fencing: clear all stonith devices before reregister

### DIFF
--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -765,6 +765,10 @@ update_cib_stonith_devices_v2(const char *event, xmlNode * msg)
     }
 
     if(needs_update) {
+        if (g_hash_table_size(device_list)) {
+            free_device_list();
+            init_device_list();
+        }
         crm_info("Updating device list from CIB: %s", reason);
         cib_devices_update();
     } else {


### PR DESCRIPTION
Changing stonith device does not update the list in pacemaker-fenced correctly and uses the unconfigured stonith device.
 * changed ```fence-virsh``` to ```fence_ipmilan```, but ```fence-virsh``` executes reboot...
```
# pcs cluster setup my_cluster node-1 addr=192.168.101.141 addr=192.168.102.141 node-2 addr=192.168.101.142 addr=192.168.102.142 --force
# pcs cluster start --all
# pcs cluster cib-push cib-1.xml
# pcs status --full
Cluster name: my_cluster
Cluster Summary:
  * Stack: corosync
  * Current DC: node-2 (2) (version 2.0.5-c67665496) - partition with quorum
  * Last updated: Fri Dec 25 15:06:37 2020
  * Last change:  Fri Dec 25 15:06:24 2020 by hacluster via crmd on node-2
  * 2 nodes configured
  * 3 resource instances configured

Node List:
  * Online: [ node-1 (1) node-2 (2) ]

Full List of Resources:
  * prmDummy1   (ocf::pacemaker:Dummy):  Started node-1
  * fence1-virsh        (stonith:fence_virsh):   Started node-2
  * fence2-virsh        (stonith:fence_virsh):   Started node-1

Migration Summary:

Tickets:

PCSD Status:
  node-1: Online
  node-2: Online

Daemon Status:
  corosync: active/disabled
  pacemaker: active/disabled
  pcsd: active/enabled

# pcs config
Cluster Name: my_cluster
Corosync Nodes:
 node-1 node-2
Pacemaker Nodes:
 node-1 node-2

Resources:
 Resource: prmDummy1 (class=ocf provider=pacemaker type=Dummy)
  Attributes: fake=fake_attr
  Operations: migrate_from interval=0s timeout=20s (prmDummy1-migrate_from-interval-0s)
              migrate_to interval=0s timeout=20s (prmDummy1-migrate_to-interval-0s)
              monitor interval=60s on-fail=fence (prmDummy1-monitor-interval-60s)
              reload interval=0s timeout=20s (prmDummy1-reload-interval-0s)
              start interval=0s timeout=20s (prmDummy1-start-interval-0s)
              stop interval=0s timeout=20s (prmDummy1-stop-interval-0s)

Stonith Devices:
 Resource: fence1-virsh (class=stonith type=fence_virsh)
  Attributes: identity_file=/root/.ssh/id_rsa ipaddr=192.168.122.1 pcmk_host_map=node-1:ab7abe54-7965-4afc-94e5-c40a89b7a1c5 username=root
  Operations: monitor interval=60s (fence1-virsh-monitor-interval-60s)
 Resource: fence2-virsh (class=stonith type=fence_virsh)
  Attributes: identity_file=/root/.ssh/id_rsa ipaddr=192.168.122.1 pcmk_host_map=node-2:1b37c92c-1626-40da-a990-3d082d540dc7 username=root
  Operations: monitor interval=60s (fence2-virsh-monitor-interval-60s)
Fencing Levels:

Location Constraints:
  Resource: fence1-virsh
    Disabled on:
      Node: node-1 (score:-INFINITY) (id:location-fence1-virsh-node-1--INFINITY)
  Resource: fence2-virsh
    Disabled on:
      Node: node-2 (score:-INFINITY) (id:location-fence2-virsh-node-2--INFINITY)
Ordering Constraints:
Colocation Constraints:
Ticket Constraints:

Alerts:
 No alerts defined

Resources Defaults:
  No defaults set
Operations Defaults:
  No defaults set

Cluster Properties:
 cluster-infrastructure: corosync
 cluster-name: my_cluster
 dc-version: 2.0.5-c67665496
 have-watchdog: false

Tags:
 No tags defined

Quorum:
  Options:


# pcs cluster cib-push cib-2.xml --config
# pcs status --full
Cluster name: my_cluster
Cluster Summary:
  * Stack: corosync
  * Current DC: node-2 (2) (version 2.0.5-c67665496) - partition with quorum
  * Last updated: Fri Dec 25 15:07:49 2020
  * Last change:  Fri Dec 25 15:07:32 2020 by hacluster via crmd on node-2
  * 2 nodes configured
  * 3 resource instances configured

Node List:
  * Online: [ node-1 (1) node-2 (2) ]

Full List of Resources:
  * prmDummy1   (ocf::pacemaker:Dummy):  Started node-1
  * fence1-ipmilan      (stonith:fence_ipmilan):         Started node-2
  * fence2-ipmilan      (stonith:fence_ipmilan):         Started node-1

Migration Summary:

Tickets:

PCSD Status:
  node-1: Online
  node-2: Online

Daemon Status:
  corosync: active/disabled
  pacemaker: active/disabled
  pcsd: active/enabled

# pcs config
Cluster Name: my_cluster
Corosync Nodes:
 node-1 node-2
Pacemaker Nodes:
 node-1 node-2

Resources:
 Resource: prmDummy1 (class=ocf provider=pacemaker type=Dummy)
  Operations: migrate_from interval=0s timeout=20s (prmDummy1-migrate_from-interval-0s)
              migrate_to interval=0s timeout=20s (prmDummy1-migrate_to-interval-0s)
              monitor interval=60s on-fail=fence (prmDummy1-monitor-interval-60s)
              reload interval=0s timeout=20s (prmDummy1-reload-interval-0s)
              start interval=0s timeout=20s (prmDummy1-start-interval-0s)
              stop interval=0s timeout=20s (prmDummy1-stop-interval-0s)

Stonith Devices:
 Resource: fence1-ipmilan (class=stonith type=fence_ipmilan)
  Attributes: delay=10 ip=192.168.122.89 lanplus=1 password=pacemakerpass pcmk_host_list=node-1 username=pacemaker
  Operations: monitor interval=60s (fence1-ipmilan-monitor-interval-60s)
 Resource: fence2-ipmilan (class=stonith type=fence_ipmilan)
  Attributes: ip=192.168.122.90 lanplus=1 password=pacemakerpass pcmk_host_list=node-2 username=pacemaker
  Operations: monitor interval=60s (fence2-ipmilan-monitor-interval-60s)
Fencing Levels:

Location Constraints:
  Resource: fence1-ipmilan
    Disabled on:
      Node: node-1 (score:-INFINITY) (id:location-fence1-ipmilan-node-1--INFINITY)
  Resource: fence2-ipmilan
    Disabled on:
      Node: node-2 (score:-INFINITY) (id:location-fence2-ipmilan-node-2--INFINITY)
Ordering Constraints:
Colocation Constraints:
Ticket Constraints:

Alerts:
 No alerts defined

Resources Defaults:
  No defaults set
Operations Defaults:
  No defaults set

Cluster Properties:
 cluster-infrastructure: corosync
 cluster-name: my_cluster
 dc-version: 2.0.5-c67665496
 have-watchdog: false

Tags:
 No tags defined

Quorum:
  Options:


# ssh node-1 rm -f /var/run/Dummy-prmDummy1.state
# pcs status --full
Cluster name: my_cluster
Cluster Summary:
  * Stack: corosync
  * Current DC: node-2 (2) (version 2.0.5-c67665496) - partition with quorum
  * Last updated: Fri Dec 25 15:10:09 2020
  * Last change:  Fri Dec 25 15:07:32 2020 by hacluster via crmd on node-2
  * 2 nodes configured
  * 3 resource instances configured

Node List:
  * Online: [ node-2 (2) ]
  * OFFLINE: [ node-1 (1) ]

Full List of Resources:
  * prmDummy1   (ocf::pacemaker:Dummy):  Started node-2
  * fence1-ipmilan      (stonith:fence_ipmilan):         Started node-2
  * fence2-ipmilan      (stonith:fence_ipmilan):         Stopped

Migration Summary:

Fencing History:
  * reboot of node-1 successful: delegate=node-2, client=pacemaker-controld.22192, origin=node-2, completed='2020-12-25 15:09:44 +09:00'

Tickets:

PCSD Status:
  node-1: Offline
  node-2: Online

Daemon Status:
  corosync: active/disabled
  pacemaker: active/disabled
  pcsd: active/enabled

# grep fence1 /var/log/pacemaker/pacemaker.log
Dec 25 15:09:32 node-2 pacemaker-schedulerd[22191] (log_list_item)   info: fence1-ipmilan    (stonith:fence_ipmilan):         Started node-2
Dec 25 15:09:32 node-2 pacemaker-schedulerd[22191] (LogActions)      info: Leave   fence1-ipmilan    (Started node-2)
Dec 25 15:09:32 node-2 pacemaker-schedulerd[22191] (log_list_item)   info: fence1-ipmilan    (stonith:fence_ipmilan):         Started node-2
Dec 25 15:09:32 node-2 pacemaker-schedulerd[22191] (LogActions)      info: Leave   fence1-ipmilan    (Started node-2)
Dec 25 15:09:32 node-2 pacemaker-fenced    [22188] (can_fence_host_with_device)      notice: fence1-virsh is eligible to fence (reboot) node-1 (aka. 'ab7abe54-7965-4afc-94e5-c40a89b7a1c5'): static-list
Dec 25 15:09:32 node-2 pacemaker-fenced    [22188] (can_fence_host_with_device)      notice: fence1-ipmilan is eligible to fence (reboot) node-1: static-list
Dec 25 15:09:33 node-2 pacemaker-fenced    [22188] (can_fence_host_with_device)      notice: fence1-virsh is eligible to fence (reboot) node-1 (aka. 'ab7abe54-7965-4afc-94e5-c40a89b7a1c5'): static-list
Dec 25 15:09:33 node-2 pacemaker-fenced    [22188] (can_fence_host_with_device)      notice: fence1-ipmilan is eligible to fence (reboot) node-1: static-list
Dec 25 15:09:33 node-2 pacemaker-fenced    [22188] (schedule_stonith_command)        debug: Scheduling 'reboot' action targeting node-1 using fence1-virsh for remote peer node-2 with op id 3193648b and timeout 60s
Dec 25 15:09:33 node-2 pacemaker-fenced    [22188] (fork_cb)         debug: Operation 'reboot' [22524] targeting node-1 using fence1-virsh now running with 60s timeout
Dec 25 15:09:33 node-2 pacemaker-fenced    [22188] (schedule_stonith_command)        debug: Scheduling 'monitor' action using fence1-ipmilan for 9ee27d58-b83c-45c7-bcf8-f10ba937328e with timeout 20s
Dec 25 15:09:33 node-2 pacemaker-fenced    [22188] (fork_cb)         debug: Operation 'monitor' [22527] using fence1-ipmilan now running with 20s timeout
Dec 25 15:09:33 node-2 pacemaker-fenced    [22188] (st_child_done)   debug: Operation 'monitor' using fence1-ipmilan returned 0 (0 devices remaining)
Dec 25 15:09:33 node-2 pacemaker-fenced    [22188] (log_operation)   debug: Operation 'monitor' [22527] using fence1-ipmilan returned 0 (OK)
Dec 25 15:09:44 node-2 pacemaker-fenced    [22188] (st_child_done)   debug: Operation 'reboot' using fence1-virsh returned 0 (1 devices remaining)
Dec 25 15:09:44 node-2 pacemaker-fenced    [22188] (log_operation)   notice: Operation 'reboot' [22524] (call 3 from pacemaker-controld.22192) targeting node-1 using fence1-virsh returned 0 (OK)
Dec 25 15:09:44 node-2 pacemaker-fenced    [22188] (log_operation)   debug: fence1-virsh[22524] [ Success: Rebooted ]

```
 * cib-1.xml
```
<cib crm_feature_set="3.6.3" validate-with="pacemaker-3.5" epoch="6" num_updates="0" admin_epoch="0">
  <configuration>
    <crm_config/>
    <nodes/>
    <resources>
      <primitive class="ocf" id="prmDummy1" provider="pacemaker" type="Dummy">
        <instance_attributes id="prmDummy1-instance_attributes">
          <nvpair id="prmDummy1-instance_attributes-fake" name="fake" value="fake_attr"/>
        </instance_attributes>
        <operations>
          <op id="prmDummy1-migrate_from-interval-0s" interval="0s" name="migrate_from" timeout="20s"/>
          <op id="prmDummy1-migrate_to-interval-0s" interval="0s" name="migrate_to" timeout="20s"/>
          <op id="prmDummy1-monitor-interval-60s" interval="60s" name="monitor" on-fail="fence"/>
          <op id="prmDummy1-reload-interval-0s" interval="0s" name="reload" timeout="20s"/>
          <op id="prmDummy1-start-interval-0s" interval="0s" name="start" timeout="20s"/>
          <op id="prmDummy1-stop-interval-0s" interval="0s" name="stop" timeout="20s"/>
        </operations>
      </primitive>
      <primitive class="stonith" id="fence1-virsh" type="fence_virsh">
        <instance_attributes id="fence1-virsh-instance_attributes">
          <nvpair id="fence1-virsh-instance_attributes-identity_file" name="identity_file" value="/root/.ssh/id_rsa"/>
          <nvpair id="fence1-virsh-instance_attributes-ipaddr" name="ipaddr" value="192.168.122.1"/>
          <nvpair id="fence1-virsh-instance_attributes-pcmk_host_map" name="pcmk_host_map" value="node-1:ab7abe54-7965-4afc-94e5-c40a89b7a1c5"/>
          <nvpair id="fence1-virsh-instance_attributes-username" name="username" value="root"/>
        </instance_attributes>
        <operations>
          <op id="fence1-virsh-monitor-interval-60s" interval="60s" name="monitor"/>
        </operations>
      </primitive>
      <primitive class="stonith" id="fence2-virsh" type="fence_virsh">
        <instance_attributes id="fence2-virsh-instance_attributes">
          <nvpair id="fence2-virsh-instance_attributes-identity_file" name="identity_file" value="/root/.ssh/id_rsa"/>
          <nvpair id="fence2-virsh-instance_attributes-ipaddr" name="ipaddr" value="192.168.122.1"/>
          <nvpair id="fence2-virsh-instance_attributes-pcmk_host_map" name="pcmk_host_map" value="node-2:1b37c92c-1626-40da-a990-3d082d540dc7"/>
          <nvpair id="fence2-virsh-instance_attributes-username" name="username" value="root"/>
        </instance_attributes>
        <operations>
          <op id="fence2-virsh-monitor-interval-60s" interval="60s" name="monitor"/>
        </operations>
      </primitive>
    </resources>
    <constraints>
      <rsc_location id="location-fence1-virsh-node-1--INFINITY" node="node-1" rsc="fence1-virsh" score="-INFINITY"/>
      <rsc_location id="location-fence2-virsh-node-2--INFINITY" node="node-2" rsc="fence2-virsh" score="-INFINITY"/>
    </constraints>
  </configuration>
  <status/>
</cib>
```
 * cib-2.xml
```
<cib crm_feature_set="3.6.3" validate-with="pacemaker-3.5" epoch="6" num_updates="0" admin_epoch="0">
  <configuration>
    <crm_config/>
    <nodes/>
    <resources>
      <primitive class="ocf" id="prmDummy1" provider="pacemaker" type="Dummy">
        <operations>
          <op id="prmDummy1-migrate_from-interval-0s" interval="0s" name="migrate_from" timeout="20s"/>
          <op id="prmDummy1-migrate_to-interval-0s" interval="0s" name="migrate_to" timeout="20s"/>
          <op id="prmDummy1-monitor-interval-60s" interval="60s" name="monitor" on-fail="fence"/>
          <op id="prmDummy1-reload-interval-0s" interval="0s" name="reload" timeout="20s"/>
          <op id="prmDummy1-start-interval-0s" interval="0s" name="start" timeout="20s"/>
          <op id="prmDummy1-stop-interval-0s" interval="0s" name="stop" timeout="20s"/>
        </operations>
      </primitive>
      <primitive class="stonith" id="fence1-ipmilan" type="fence_ipmilan">
        <instance_attributes id="fence1-ipmilan-instance_attributes">
          <nvpair id="fence1-ipmilan-instance_attributes-delay" name="delay" value="10"/>
          <nvpair id="fence1-ipmilan-instance_attributes-ip" name="ip" value="192.168.122.89"/>
          <nvpair id="fence1-ipmilan-instance_attributes-lanplus" name="lanplus" value="1"/>
          <nvpair id="fence1-ipmilan-instance_attributes-password" name="password" value="pacemakerpass"/>
          <nvpair id="fence1-ipmilan-instance_attributes-pcmk_host_list" name="pcmk_host_list" value="node-1"/>
          <nvpair id="fence1-ipmilan-instance_attributes-username" name="username" value="pacemaker"/>
        </instance_attributes>
        <operations>
          <op id="fence1-ipmilan-monitor-interval-60s" interval="60s" name="monitor"/>
        </operations>
      </primitive>
      <primitive class="stonith" id="fence2-ipmilan" type="fence_ipmilan">
        <instance_attributes id="fence2-ipmilan-instance_attributes">
          <nvpair id="fence2-ipmilan-instance_attributes-ip" name="ip" value="192.168.122.90"/>
          <nvpair id="fence2-ipmilan-instance_attributes-lanplus" name="lanplus" value="1"/>
          <nvpair id="fence2-ipmilan-instance_attributes-password" name="password" value="pacemakerpass"/>
          <nvpair id="fence2-ipmilan-instance_attributes-pcmk_host_list" name="pcmk_host_list" value="node-2"/>
          <nvpair id="fence2-ipmilan-instance_attributes-username" name="username" value="pacemaker"/>
        </instance_attributes>
        <operations>
          <op id="fence2-ipmilan-monitor-interval-60s" interval="60s" name="monitor"/>
        </operations>
      </primitive>
    </resources>
    <constraints>
      <rsc_location id="location-fence1-ipmilan-node-1--INFINITY" node="node-1" rsc="fence1-ipmilan" score="-INFINITY"/>
      <rsc_location id="location-fence2-ipmilan-node-2--INFINITY" node="node-2" rsc="fence2-ipmilan" score="-INFINITY"/>
    </constraints>
  </configuration>
  <status/>
</cib>
```