### PR TITLE
corosync: Add cfg_trackstart/stop calls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1418,7 +1418,15 @@ AS_IF([test $SUPPORT_CS = no],
           CLUSTERLIBS="$CLUSTERLIBS $COROSYNC_LIBS"
           PC_NAME_CLUSTER="$PC_CLUSTER_NAME libcfg libcmap libcorosync_common libcpg libquorum"
           STACKS="$STACKS corosync-ge-2"
-      ])
+
+          dnl Shutdown tracking added (back) to corosync Jan 2021
+          saved_LIBS="$LIBS"
+          LIBS="$LIBS $COROSYNC_LIBS"
+          AC_CHECK_FUNCS(corosync_cfg_trackstart,
+          AC_DEFINE(HAVE_COROSYNC_CFG_TRACKSTART, 1,
+                         [Have corosync_cfg_trackstart function]))
+          LIBS="$saved_LIBS"
+     ])
 
 AC_DEFINE_UNQUOTED(SUPPORT_COROSYNC, $SUPPORT_CS,    Support the Corosync messaging and membership layer)
 AM_CONDITIONAL(BUILD_CS_SUPPORT, test $SUPPORT_CS = 1)


### PR DESCRIPTION
corosync shutdown tracking has been broken for ages (since the
trackstart/stop calls were removed in 2012), so pacemaker has not been
able to veto corosync shutdown requests.

The corosync_cfg_startstart/stop calls have now been re-added back to
corosync and with this patch, the pacemaker shutdown veto will
work again (provided shutdown is done as a REQUEST rather then
REGARDLESS or IMMEDIATE of course). There is a new flag (--force
added to corosync-cfgtool -H which uses REGARDLESS.

I'm not 100% sure that I've got the configure.ac correct. Though it does work, it might not be 'correct'.