### PR TITLE
[1.1] Fix: attrd: prevent leftover attributes of shutdown node in cib

### DIFF
--- a/attrd/attrd_common.c
+++ b/attrd/attrd_common.c
@@ -22,10 +22,43 @@
 
 cib_t *the_cib = NULL;
 
+static bool requesting_shutdown = FALSE;
 // volatile because attrd_shutdown() can be called for a signal
 static volatile bool shutting_down = FALSE;
 
 static GMainLoop *mloop = NULL;
+
+/*!
+ * \internal
+ * \brief  Set requesting_shutdown state
+ */
+void
+attrd_set_requesting_shutdown()
+{
+    requesting_shutdown = TRUE;
+}
+
+/*!
+ * \internal
+ * \brief  Clear requesting_shutdown state
+ */
+void
+attrd_clear_requesting_shutdown()
+{
+    requesting_shutdown = FALSE;
+}
+
+/*!
+ * \internal
+ * \brief Check whether we're currently requesting shutdown
+ *
+ * \return TRUE if requesting shutdown, FALSE otherwise
+ */
+gboolean
+attrd_requesting_shutdown()
+{
+    return requesting_shutdown;
+}
 
 /*!
  * \internal

--- a/attrd/attrd_common.c
+++ b/attrd/attrd_common.c
@@ -8,6 +8,7 @@
 #include <crm_internal.h>
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <errno.h>
 #include <glib.h>
 #include <regex.h>
@@ -21,7 +22,9 @@
 
 cib_t *the_cib = NULL;
 
-static gboolean shutting_down = FALSE;
+// volatile because attrd_shutdown() can be called for a signal
+static volatile bool shutting_down = FALSE;
+
 static GMainLoop *mloop = NULL;
 
 /*!
@@ -46,12 +49,25 @@ void
 attrd_shutdown(int nsig) {
     crm_info("Shutting down");
 
+    // Tell various functions not to do anthing
     shutting_down = TRUE;
 
-    if ((mloop != NULL) && g_main_is_running(mloop)) {
-        g_main_quit(mloop);
-    } else {
+    // Don't respond to signals while shutting down
+    mainloop_destroy_signal(SIGTERM);
+    mainloop_destroy_signal(SIGCHLD);
+    mainloop_destroy_signal(SIGPIPE);
+    mainloop_destroy_signal(SIGUSR1);
+    mainloop_destroy_signal(SIGUSR2);
+    mainloop_destroy_signal(SIGTRAP);
+
+    if ((mloop == NULL) || !g_main_loop_is_running(mloop)) {
+        /* If there's no main loop active, just exit. This should be possible
+         * only if we get SIGTERM in brief windows at start-up and shutdown.
+         */
         crm_exit(pcmk_ok);
+    } else {
+        g_main_loop_quit(mloop);
+        g_main_loop_unref(mloop);
     }
 }
 

--- a/attrd/attrd_common.h
+++ b/attrd/attrd_common.h
@@ -18,6 +18,9 @@ void attrd_run_mainloop(void);
 gboolean attrd_mainloop_running(void);
 void attrd_quit_mainloop(void);
 
+void attrd_set_requesting_shutdown(void);
+void attrd_clear_requesting_shutdown(void);
+gboolean attrd_requesting_shutdown(void);
 gboolean attrd_shutting_down(void);
 void attrd_shutdown(int nsig);
 void attrd_init_ipc(qb_ipcs_service_t **ipcs,

--- a/attrd/attrd_common_alerts.c
+++ b/attrd/attrd_common_alerts.c
@@ -140,7 +140,7 @@ attrd_read_options(gpointer user_data)
 void
 attrd_cib_updated_cb(const char *event, xmlNode * msg)
 {
-    if (crm_patchset_contains_alert(msg, FALSE)) {
+    if (!attrd_shutting_down() && crm_patchset_contains_alert(msg, FALSE)) {
         mainloop_set_trigger(attrd_config_read);
     }
 }

--- a/attrd/attrd_elections.c
+++ b/attrd/attrd_elections.c
@@ -32,7 +32,9 @@ void
 attrd_start_election_if_needed()
 {
     if ((peer_writer == NULL)
-        && (election_state(writer) != election_in_progress)) {
+        && (election_state(writer) != election_in_progress)
+        && !attrd_shutting_down()) {
+
         crm_info("Starting an election to determine the writer");
         election_vote(writer);
     }
@@ -51,7 +53,10 @@ attrd_handle_election_op(const crm_node_t *peer, xmlNode *xml)
     enum election_result previous = election_state(writer);
 
     crm_xml_add(xml, F_CRM_HOST_FROM, peer->uname);
-    rc = election_count_vote(writer, xml, TRUE);
+
+    // Don't become writer if we're shutting down
+    rc = election_count_vote(writer, xml, !attrd_shutting_down());
+
     switch(rc) {
         case election_start:
             crm_debug("Unsetting writer (was %s) and starting new election",

--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -890,6 +890,17 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
         v->current = (value? strdup(value) : NULL);
         a->changed = TRUE;
 
+        if (safe_str_eq(host, attrd_cluster->uname)
+            && crm_str_eq(attr, XML_CIB_ATTR_SHUTDOWN, TRUE)) {
+
+            if (value != NULL && safe_str_neq(value, "0")) {
+                attrd_set_requesting_shutdown();
+
+            } else {
+                attrd_clear_requesting_shutdown();
+            }
+        }
+
         // Write out new value or start dampening timer
         if (a->timeout_ms && a->timer) {
             crm_trace("Delayed write out (%dms) for %s", a->timeout_ms, attr);

--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -588,6 +588,14 @@ attrd_peer_message(crm_node_t *peer, xmlNode *xml)
         }
     }
 
+    if (attrd_shutting_down()) {
+        /* If we're shutting down, we want to continue responding to election
+         * ops as long as we're a cluster member (because our vote may be
+         * needed). Ignore all other messages.
+         */
+        return;
+    }
+
     peer_won = attrd_check_for_new_writer(peer, xml);
 
     if (safe_str_eq(op, ATTRD_OP_UPDATE) || safe_str_eq(op, ATTRD_OP_UPDATE_BOTH) || safe_str_eq(op, ATTRD_OP_UPDATE_DELAY)) {

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -94,8 +94,12 @@ attrd_cpg_destroy(gpointer unused)
 static void
 attrd_cib_replaced_cb(const char *event, xmlNode * msg)
 {
-    crm_notice("Updating all attributes after %s event", event);
+    if (attrd_shutting_down()) {
+        return;
+    }
+
     if (attrd_election_won()) {
+        crm_notice("Updating all attributes after %s event", event);
         write_attributes(TRUE, FALSE);
     }
 

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -94,7 +94,7 @@ attrd_cpg_destroy(gpointer unused)
 static void
 attrd_cib_replaced_cb(const char *event, xmlNode * msg)
 {
-    if (attrd_shutting_down()) {
+    if (attrd_requesting_shutdown() || attrd_shutting_down()) {
         return;
     }
 


### PR DESCRIPTION
Backport of https://github.com/ClusterLabs/pacemaker/commit/6ddb87f6a364bd5c3be651d0ede0ec1c8f48666c and https://github.com/ClusterLabs/pacemaker/pull/2174 for 1.1 branch.