### PR TITLE
Fix: crm_mon: detect when run on remote-node

### DIFF
--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -1287,11 +1287,7 @@ main(int argc, char **argv)
 
     // Don't build CRM_RSCTMP_DIR, pacemaker-execd will do it
 
-    ipcs = mainloop_add_ipc_server(CRM_SYSTEM_MCP, QB_IPC_NATIVE, &mcp_ipc_callbacks);
-    if (ipcs == NULL) {
-        crm_err("Couldn't start IPC server");
-        crm_exit(CRM_EX_OSERR);
-    }
+    pcmk__serve_pacemakerd_ipc(&ipcs, &mcp_ipc_callbacks);
 
 #ifdef SUPPORT_COROSYNC
     /* Allows us to block shutdown */

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -221,6 +221,8 @@ void pcmk__serve_attrd_ipc(qb_ipcs_service_t **ipcs,
                            struct qb_ipcs_service_handlers *cb);
 void pcmk__serve_fenced_ipc(qb_ipcs_service_t **ipcs,
                             struct qb_ipcs_service_handlers *cb);
+void pcmk__serve_pacemakerd_ipc(qb_ipcs_service_t **ipcs,
+                                struct qb_ipcs_service_handlers *cb);
 qb_ipcs_service_t *pcmk__serve_controld_ipc(struct qb_ipcs_service_handlers *cb);
 
 void pcmk__serve_based_ipc(qb_ipcs_service_t **ipcs_ro,

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -922,6 +922,32 @@ pcmk__serve_fenced_ipc(qb_ipcs_service_t **ipcs,
 }
 
 /*!
+ * \internal
+ * \brief Add an IPC server to the main loop for the pacemakerd API
+ *
+ * \param[in] cb  IPC callbacks
+ *
+ * \note This function exits with CRM_EX_OSERR if unable to create the servers.
+ */
+void
+pcmk__serve_pacemakerd_ipc(qb_ipcs_service_t **ipcs,
+                       struct qb_ipcs_service_handlers *cb)
+{
+    *ipcs = mainloop_add_ipc_server(CRM_SYSTEM_MCP, QB_IPC_NATIVE, cb);
+
+    if (*ipcs == NULL) {
+        crm_err("Couldn't start pacemakerd IPC server");
+        crm_warn("Verify pacemaker and pacemaker_remote are not both enabled.");
+        /* sub-daemons are observed by pacemakerd. Thus we exit CRM_EX_FATAL
+         * if we want to prevent pacemakerd from restarting them.
+         * With pacemakerd we leave the exit-code shown to e.g. systemd
+         * to what it was prior to moving the code here from pacemakerd.c
+         */
+        crm_exit(CRM_EX_OSERR);
+    }
+}
+
+/*!
  * \brief Check whether string represents a client name used by cluster daemons
  *
  * \param[in] name  String to check


### PR DESCRIPTION
Looks like a clean solution so far.
We had EREMOTEIO already that can be used to notify that there is pacemaker-remoted but the api doesn't support proxying.
Have to check if I can make the proxy-callback NULL but accept.