### PR TITLE
Fix various crm_mon problems

### DIFF
--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -11,6 +11,7 @@
 #  define CIB_INTERNAL__H
 #  include <crm/cib.h>
 #  include <crm/common/ipc_internal.h>
+#  include <crm/common/output_internal.h>
 
 #  define CIB_OP_SLAVE	"cib_slave"
 #  define CIB_OP_SLAVEALL	"cib_slave_all"
@@ -211,5 +212,7 @@ int cib_file_read_and_verify(const char *filename, const char *sigfile,
                              xmlNode **root);
 int cib_file_write_with_digest(xmlNode *cib_root, const char *cib_dirname,
                                const char *cib_filename);
+
+void cib__set_output(cib_t *cib, pcmk__output_t *out);
 
 #endif

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -480,6 +480,24 @@ struct pcmk__output_s {
      *
      */
     void (*progress) (pcmk__output_t *out, bool end);
+
+    /*!
+     * \internal
+     * \brief Prompt the user for input.  Not all formatters will do this.
+     *
+     * \note This function is part of pcmk__output_t, but unlike all other
+     *       function it does not take that as an argument.  In general, a
+     *       prompt will go directly to the screen and therefore bypass any
+     *       need to use the formatted output code to decide where and how
+     *       to display.
+     *
+     * \param[in]  prompt The prompt to display.  This is required.
+     * \param[in]  echo   If true, echo the user's input to the screen.  Set
+     *                    to false for password entry.
+     * \param[out] dest   Where to store the user's response.  This is
+     *                    required.
+     */
+    void (*prompt) (const char *prompt, bool echo, char **dest);
 };
 
 /*!
@@ -628,6 +646,18 @@ pcmk__indented_printf(pcmk__output_t *out, const char *format, ...) G_GNUC_PRINT
  */
 void
 pcmk__indented_vprintf(pcmk__output_t *out, const char *format, va_list args) G_GNUC_PRINTF(2, 0);
+
+/*!
+ * \internal
+ * \brief Prompt the user for input.
+ *
+ * \param[in]  prompt The prompt to display
+ * \param[in]  echo   If true, echo the user's input to the screen.  Set
+ *                    to false for password entry.
+ * \param[out] dest   Where to store the user's response.
+ */
+void
+pcmk__text_prompt(const char *prompt, bool echo, char **dest);
 
 /*!
  * \internal

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -463,11 +463,23 @@ struct pcmk__output_s {
 
     /*!
      * \internal
-     * \brief Output a spacer.  Not all formatter will do this.
+     * \brief Output a spacer.  Not all formatters will do this.
      *
      * \param[in] out The output functions structure.
      */
     void (*spacer) (pcmk__output_t *out);
+
+    /*!
+     * \internal
+     * \brief Output a progress indicator.  This is likely only useful for
+     *        plain text, console based formatters.
+     *
+     * \param[in] out The output functions structure.
+     * \param[in] end If true, output a newline afterwards.  This should
+     *                only be used the last time this function is called.
+     *
+     */
+    void (*progress) (pcmk__output_t *out, bool end);
 };
 
 /*!

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -183,6 +183,7 @@ html_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy
     }
 
     g_slist_free_full(extra_headers, (GDestroyNotify) xmlFreeNode);
+    extra_headers = NULL;
 }
 
 static void

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the Pacemaker project contributors
+ * Copyright 2019-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -375,6 +375,11 @@ html_spacer(pcmk__output_t *out) {
     pcmk__output_create_xml_node(out, "br", NULL);
 }
 
+static void
+html_progress(pcmk__output_t *out, bool end) {
+    /* This function intentially left blank */
+}
+
 pcmk__output_t *
 pcmk__mk_html_output(char **argv) {
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
@@ -407,6 +412,7 @@ pcmk__mk_html_output(char **argv) {
 
     retval->is_quiet = html_is_quiet;
     retval->spacer = html_spacer;
+    retval->progress = html_progress;
 
     return retval;
 }

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -413,6 +413,7 @@ pcmk__mk_html_output(char **argv) {
     retval->is_quiet = html_is_quiet;
     retval->spacer = html_spacer;
     retval->progress = html_progress;
+    retval->prompt = pcmk__text_prompt;
 
     return retval;
 }

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -115,10 +115,17 @@ add_error_node(gpointer data, gpointer user_data) {
 }
 
 static void
-finish_reset_common(pcmk__output_t *out, crm_exit_t exit_status, bool print) {
+html_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_dest) {
     private_data_t *priv = out->priv;
     htmlNodePtr head_node = NULL;
     htmlNodePtr charset_node = NULL;
+
+    /* If root is NULL, html_init failed and we are being called from pcmk__output_free
+     * in the pcmk__output_new path.
+     */
+    if (priv == NULL || priv->root == NULL) {
+        return;
+    }
 
     if (cgi_output && print) {
         fprintf(out->dest, "Content-Type: text/html\n\n");
@@ -170,20 +177,6 @@ finish_reset_common(pcmk__output_t *out, crm_exit_t exit_status, bool print) {
     if (print) {
         htmlDocDump(out->dest, priv->root->doc);
     }
-}
-
-static void
-html_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_dest) {
-    private_data_t *priv = out->priv;
-
-    /* If root is NULL, html_init failed and we are being called from pcmk__output_free
-     * in the pcmk__output_new path.
-     */
-    if (priv == NULL || priv->root == NULL) {
-        return;
-    }
-
-    finish_reset_common(out, exit_status, print);
 
     if (copy_dest != NULL) {
         *copy_dest = copy_xml(priv->root);
@@ -198,10 +191,6 @@ html_reset(pcmk__output_t *out) {
 
     out->dest = freopen(NULL, "w", out->dest);
     CRM_ASSERT(out->dest != NULL);
-
-    if (out->priv != NULL) {
-        finish_reset_common(out, CRM_EX_OK, true);
-    }
 
     html_free_priv(out);
     html_init(out);

--- a/lib/common/output_log.c
+++ b/lib/common/output_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the Pacemaker project contributors
+ * Copyright 2019-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -231,6 +231,11 @@ log_spacer(pcmk__output_t *out) {
     /* This function intentionally left blank */
 }
 
+static void
+log_progress(pcmk__output_t *out, bool end) {
+    /* This function intentionally left blank */
+}
+
 pcmk__output_t *
 pcmk__mk_log_output(char **argv) {
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
@@ -262,6 +267,7 @@ pcmk__mk_log_output(char **argv) {
 
     retval->is_quiet = log_is_quiet;
     retval->spacer = log_spacer;
+    retval->progress = log_progress;
 
     return retval;
 }

--- a/lib/common/output_log.c
+++ b/lib/common/output_log.c
@@ -236,6 +236,11 @@ log_progress(pcmk__output_t *out, bool end) {
     /* This function intentionally left blank */
 }
 
+static void
+log_prompt(const char *prompt, bool echo, char **dest) {
+    /* This function intentionally left blank */
+}
+
 pcmk__output_t *
 pcmk__mk_log_output(char **argv) {
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
@@ -268,6 +273,7 @@ pcmk__mk_log_output(char **argv) {
     retval->is_quiet = log_is_quiet;
     retval->spacer = log_spacer;
     retval->progress = log_progress;
+    retval->prompt = log_prompt;
 
     return retval;
 }

--- a/lib/common/output_none.c
+++ b/lib/common/output_none.c
@@ -105,6 +105,11 @@ none_progress(pcmk__output_t *out, bool end) {
     /* This function intentionally left blank */
 }
 
+static void
+none_prompt(const char *prompt, bool echo, char **dest) {
+    /* This function intentionally left blank */
+}
+
 pcmk__output_t *
 pcmk__mk_none_output(char **argv) {
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
@@ -138,6 +143,7 @@ pcmk__mk_none_output(char **argv) {
     retval->is_quiet = none_is_quiet;
     retval->spacer = none_spacer;
     retval->progress = none_progress;
+    retval->prompt = none_prompt;
 
     return retval;
 }

--- a/lib/common/output_none.c
+++ b/lib/common/output_none.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the Pacemaker project contributors
+ * Copyright 2019-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -95,6 +95,16 @@ none_is_quiet(pcmk__output_t *out) {
     return out->quiet;
 }
 
+static void
+none_spacer(pcmk__output_t *out) {
+    /* This function intentionally left blank */
+}
+
+static void
+none_progress(pcmk__output_t *out, bool end) {
+    /* This function intentionally left blank */
+}
+
 pcmk__output_t *
 pcmk__mk_none_output(char **argv) {
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
@@ -126,6 +136,8 @@ pcmk__mk_none_output(char **argv) {
     retval->end_list = none_end_list;
 
     retval->is_quiet = none_is_quiet;
+    retval->spacer = none_spacer;
+    retval->progress = none_progress;
 
     return retval;
 }

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -70,14 +70,17 @@ text_init(pcmk__output_t *out) {
 
 static void
 text_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_dest) {
-    /* This function intentionally left blank */
+    fflush(out->dest);
 }
 
 static void
 text_reset(pcmk__output_t *out) {
     CRM_ASSERT(out != NULL);
 
-    out->dest = freopen(NULL, "w", out->dest);
+    if (out->dest != stdout) {
+        out->dest = freopen(NULL, "w", out->dest);
+    }
+
     CRM_ASSERT(out->dest != NULL);
 
     text_free_priv(out);

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the Pacemaker project contributors
+ * Copyright 2019-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -249,6 +249,17 @@ text_spacer(pcmk__output_t *out) {
     fprintf(out->dest, "\n");
 }
 
+static void
+text_progress(pcmk__output_t *out, bool end) {
+    if (out->dest == stdout) {
+        fprintf(out->dest, ".");
+
+        if (end) {
+            fprintf(out->dest, "\n");
+        }
+    }
+}
+
 pcmk__output_t *
 pcmk__mk_text_output(char **argv) {
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
@@ -281,6 +292,7 @@ pcmk__mk_text_output(char **argv) {
 
     retval->is_quiet = text_is_quiet;
     retval->spacer = text_spacer;
+    retval->progress = text_progress;
 
     return retval;
 }

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -421,6 +421,7 @@ pcmk__mk_xml_output(char **argv) {
     retval->is_quiet = xml_is_quiet;
     retval->spacer = xml_spacer;
     retval->progress = xml_progress;
+    retval->prompt = pcmk__text_prompt;
 
     return retval;
 }

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the Pacemaker project contributors
+ * Copyright 2019-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -383,6 +383,11 @@ xml_spacer(pcmk__output_t *out) {
     /* This function intentionally left blank */
 }
 
+static void
+xml_progress(pcmk__output_t *out, bool end) {
+    /* This function intentionally left blank */
+}
+
 pcmk__output_t *
 pcmk__mk_xml_output(char **argv) {
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
@@ -415,6 +420,7 @@ pcmk__mk_xml_output(char **argv) {
 
     retval->is_quiet = xml_is_quiet;
     retval->spacer = xml_spacer;
+    retval->progress = xml_progress;
 
     return retval;
 }

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -172,6 +172,7 @@ finish_reset_common(pcmk__output_t *out, crm_exit_t exit_status, bool print) {
     if (print) {
         char *buf = dump_xml_formatted_with_text(priv->root);
         fprintf(out->dest, "%s", buf);
+        fflush(out->dest);
         free(buf);
     }
 }

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -686,7 +686,7 @@ reconnect_after_timeout(gpointer data)
     }
 #endif
 
-    print_as(output_format, "Reconnecting...\n");
+    out->info(out, "Reconnecting...");
     if (pacemakerd_status() == pcmk_rc_ok) {
         fencing_connect();
         if (cib_connect(TRUE) == pcmk_rc_ok) {
@@ -826,7 +826,7 @@ cib_connect(gboolean full)
 #if CURSES_ENABLED
     /* just show this if refresh is gonna remove all traces */
     if (output_format == mon_output_console) {
-        print_as(output_format ,"Waiting for CIB ...\n");
+        out->info(out,"Waiting for CIB ...");
     }
 #endif
 
@@ -837,7 +837,7 @@ cib_connect(gboolean full)
         rc = pcmk_legacy2rc(cib->cmds->set_connection_dnotify(cib,
             mon_cib_connection_destroy));
         if (rc == EPROTONOSUPPORT) {
-            print_as(output_format,
+            out->err(out,
                      "Notification setup not supported, won't be "
                      "able to reconnect after failure");
             if (output_format == mon_output_console) {
@@ -987,19 +987,19 @@ pacemakerd_status(void)
                                 rc = pcmk_rc_ok;
                                 break;
                             case pcmk_pacemakerd_state_starting_daemons:
-                                print_as(output_format ,"Pacemaker daemons starting ...\n");
+                                out->info(out,"Pacemaker daemons starting ...");
                                 break;
                             case pcmk_pacemakerd_state_wait_for_ping:
-                                print_as(output_format ,"Waiting for startup-trigger from SBD ...\n");
+                                out->info(out,"Waiting for startup-trigger from SBD ...");
                                 break;
                             case pcmk_pacemakerd_state_shutting_down:
-                                print_as(output_format ,"Pacemaker daemons shutting down ...\n");
+                                out->info(out,"Pacemaker daemons shutting down ...");
                                 break;
                             case pcmk_pacemakerd_state_shutdown_complete:
                                 /* assuming pacemakerd doesn't dispatch any pings after entering
                                 * that state unless it is waiting for SBD
                                 */
-                                print_as(output_format ,"Pacemaker daemons shut down - reporting to SBD ...\n");
+                                out->info(out,"Pacemaker daemons shut down - reporting to SBD ...");
                                 break;
                             default:
                                 break;
@@ -1022,8 +1022,8 @@ pacemakerd_status(void)
 #if CURSES_ENABLED
             /* just show this if refresh is gonna remove all traces */
             if (output_format == mon_output_console) {
-                print_as(output_format ,
-                    "Running on remote-node waiting to be connected by cluster ...\n");
+                out->info(out,
+                    "Running on remote-node waiting to be connected by cluster ...");
             }
 #endif
             break;
@@ -1616,7 +1616,7 @@ main(int argc, char **argv)
     }
 
     do {
-        print_as(output_format ,"Waiting until cluster is available on this node ...\n");
+        out->info(out,"Waiting until cluster is available on this node ...");
 
         rc = pacemakerd_status();
         if (rc == pcmk_rc_ok) {
@@ -2082,7 +2082,7 @@ crm_diff_update(const char *event, xmlNode * msg)
 
     if (current_cib == NULL) {
         if(!stale) {
-            print_as(output_format, "--- Stale data ---");
+            out->info(out, "--- Stale data ---");
         }
         stale = TRUE;
         return;

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -886,7 +886,7 @@ set_fencing_options(int level)
             break;
 
         default:
-            level = 0;
+            interactive_fence_level = 0;
             options.mon_ops &= ~(mon_op_fence_history | mon_op_fence_connect);
             show &= ~mon_show_fencing_all;
             break;

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -2056,7 +2056,7 @@ crm_diff_update(const char *event, xmlNode * msg)
     gboolean cib_updated = FALSE;
     xmlNode *diff = get_message_xml(msg, F_CIB_UPDATE_RESULT);
 
-    print_dot(output_format);
+    out->progress(out, false);
 
     if (current_cib != NULL) {
         rc = xml_apply_patchset(current_cib, diff, TRUE);
@@ -2311,7 +2311,7 @@ mon_st_callback_display(stonith_t * st, stonith_event_t * e)
         /* disconnect cib as well and have everything reconnect */
         mon_cib_connection_destroy(NULL);
     } else {
-        print_dot(output_format);
+        out->progress(out, false);
         refresh_after_event(TRUE, FALSE);
     }
 }

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -19,18 +19,6 @@
                      "shutdown", "terminate", "standby", "probe_complete", \
                      "#", NULL }
 
-#if CURSES_ENABLED
-#  define print_as(output_format, fmt, args...) if (output_format == mon_output_console) { \
-	printw(fmt, ##args);				\
-	clrtoeol();					\
-	refresh();					\
-    } else {						\
-	fprintf(stdout, fmt, ##args);			\
-    }
-#else
-#  define print_as(output_format, fmt, args...) fprintf(stdout, fmt, ##args);
-#endif
-
 typedef enum mon_output_format_e {
     mon_output_unset,
     mon_output_none,

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -20,18 +20,6 @@
                      "#", NULL }
 
 #if CURSES_ENABLED
-#  define print_dot(output_format) if (output_format == mon_output_console) { \
-	printw(".");				\
-	clrtoeol();				\
-	refresh();				\
-    } else {					\
-	fprintf(stdout, ".");			\
-    }
-#else
-#  define print_dot(output_format) fprintf(stdout, ".");
-#endif
-
-#if CURSES_ENABLED
 #  define print_as(output_format, fmt, args...) if (output_format == mon_output_console) { \
 	printw(fmt, ##args);				\
 	clrtoeol();					\

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the Pacemaker project contributors
+ * Copyright 2019-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -252,6 +252,15 @@ curses_spacer(pcmk__output_t *out) {
     addch('\n');
 }
 
+static void
+curses_progress(pcmk__output_t *out, bool end) {
+    if (end) {
+        printw(".\n");
+    } else {
+        addch('.');
+    }
+}
+
 pcmk__output_t *
 crm_mon_mk_curses_output(char **argv) {
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
@@ -284,6 +293,7 @@ crm_mon_mk_curses_output(char **argv) {
 
     retval->is_quiet = curses_is_quiet;
     retval->spacer = curses_spacer;
+    retval->progress = curses_progress;
 
     return retval;
 }


### PR DESCRIPTION
This fixes most things that came up in #2284 except for functionalizing the connection code.  Additionally, this will need to be rebased once #2286 is merged because it touches the same areas.  And finally, I've been unable to actually test the remote CIB functionality.  crm_mon connects to the cluster node, but the following pam errors prevent me from authenticating:

```
Feb 03 09:30:11 cluster01 pacemaker-based     [58028] (cib_remote_listen)       debug: New clear-text connection from 192.168.122.1
Feb 03 09:30:11 cluster01 pacemaker-based     [58028] (cib_remote_listen)       info: Remote CIB client pending authentication | 0x5586db36e120 id: d92f42e9-4b96-4764-9aeb-e6a4fc14120d
Feb 03 09:30:11 cluster01 pacemaker-based     [58028] (cib_remote_auth)         info: Login:    <cib_command op="authenticate" user="clumens" password="*****" hidden="password"/>
Feb 03 09:30:13 cluster01 pacemaker-based     [58028] (authenticate_user)       error: Authentication failed for clumens: Authentication failure (7)
Feb 03 09:30:13 cluster01 pacemaker-based     [58028] (cib_remote_auth)         error: PAM auth failed
```

And then looking at /var/log/secure, I see:

```
Feb  3 09:30:11 cluster01 unix_chkpwd[60458]: check pass; user unknown
Feb  3 09:30:11 cluster01 unix_chkpwd[60459]: check pass; user unknown
Feb  3 09:30:11 cluster01 unix_chkpwd[60459]: password check failed for user (clumens)
Feb  3 09:30:11 cluster01 pacemaker-based[58028]: pam_unix(login:auth): authentication failure; logname= uid=189 euid=189 tty= ruser= rhost=  user=clumens
```