### PR TITLE
Mid: execd: Skips merging of canceled fencing monitors.(Fix:#CLBZ5393)

### DIFF
--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -411,6 +411,12 @@ merge_recurring_duplicate(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
         dup = gIter->data;
         if (pcmk__str_eq(cmd->action, dup->action, pcmk__str_casei)
             && (cmd->interval_ms == dup->interval_ms)) {
+            if (pcmk__str_eq(rsc->class, PCMK_RESOURCE_CLASS_STONITH, pcmk__str_casei)) {
+                if (dup->lrmd_op_status == PCMK_LRM_OP_CANCELLED) {
+                    /* Fencing monitors marked for cancellation will not be merged to respond to cancellation. */
+                    return FALSE;
+                }
+            }
             goto merge_dup;
         }
     }


### PR DESCRIPTION
Hi All,

This fix avoids fencing resource monitoring errors that can occur when a DC node is fenced.
It corresponds to the following bugzilla fix.

 - https://bugs.clusterlabs.org/show_bug.cgi?id=5393

Best Regards,
Hideo Yamauchi.