### PR TITLE
Fix: iso8601: prevent sec overrun before adding as long long

### DIFF
--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -321,7 +321,7 @@ crm_time_get_seconds(crm_time_t * dt)
     }
 
     for (lpc = 1; lpc < utc->years; lpc++) {
-        int dmax = year_days(lpc);
+        long long dmax = year_days(lpc);
 
         in_seconds += DAY_SECONDS * dmax;
     }
@@ -334,11 +334,11 @@ crm_time_get_seconds(crm_time_t * dt)
      * for anyone that tries to use a month in this way.
      */
     if (utc->months > 0) {
-        in_seconds += DAY_SECONDS * 30 * utc->months;
+        in_seconds += DAY_SECONDS * 30 * (long long) (utc->months);
     }
 
     if (utc->days > 0) {
-        in_seconds += DAY_SECONDS * (utc->days - 1);
+        in_seconds += DAY_SECONDS * (long long) (utc->days - 1);
     }
     in_seconds += utc->seconds;
 


### PR DESCRIPTION
The first one (years) is actually a false positive as coverity is just not looking deep enough into year_days.
In theory it would of course be possible that sbdy specifies a span long enough that seconds would exceed int in days or months.