### PR TITLE
Fix: include: Bump CRM_FEATURE_SET to 3.7.2.

### DIFF
--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -51,7 +51,7 @@ extern "C" {
  * >=3.0.13: Fail counts include operation name and interval
  * >=3.2.0:  DC supports PCMK_LRM_OP_INVALID and PCMK_LRM_OP_NOT_CONNECTED
  */
-#  define CRM_FEATURE_SET		"3.7.1"
+#  define CRM_FEATURE_SET		"3.7.2"
 
 #  define EOS		'\0'
 #  define DIMOF(a)	((int) (sizeof(a)/sizeof(a[0])) )


### PR DESCRIPTION
This is being bumped due to the addition of the --output-as= and
--output-to= arguments to crm_verify for formatted output.  In addition,
there are various minor differences in the crm_resource text output.  It
is hoped that over time, these differences won't matter as much because
consumers can use the XML output instead.