### PR TITLE
More build changes for 2.1.0

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2008-2019 the Pacemaker project contributors
+# Copyright 2008-2021 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -382,8 +382,9 @@ rc-changes:
 
 changes: summary
 	@printf "\n- Features added since $(LAST_RELEASE)\n"
-	@git log --pretty=format:'  +%s' --abbrev-commit $(LAST_RELEASE)..HEAD | grep -e Feature: | sed -e 's@Feature:@@' | sort -uf
-	@printf "\n- Changes since $(LAST_RELEASE)\n"
+	@git log --pretty=format:'  +%s' --no-merges --abbrev-commit $(LAST_RELEASE)..HEAD \
+		| grep -e Feature: | sed -e 's@Feature:@@' | sort -uf
+	@printf "\n- Fixes since $(LAST_RELEASE)\n"
 	@git log --pretty=format:'  +%s' --no-merges --abbrev-commit $(LAST_RELEASE)..HEAD \
 		| grep -e High: -e Fix: -e Bug | sed \
 			-e 's@\(Fix\|High\|Bug\):@@' \
@@ -393,6 +394,9 @@ changes: summary
 			-e 's@\(Fencing\|stonithd\|stonith\|pacemaker-fenced\|fenced\):@fencing:@' \
 			-e 's@\(PE\|pengine\|pacemaker-schedulerd\|schedulerd\):@scheduler:@' \
 		| sort -uf
+	@printf "\n- Public API changes since $(LAST_RELEASE)\n"
+	@git log --pretty=format:'%s' --no-merges --abbrev-commit $(LAST_RELEASE)..HEAD \
+		| sed -n -e 's/^ *API: */  + /p' | sort -uf
 
 authors:
 	git log $(LAST_RELEASE)..$(COMMIT) --format='%an' | sort -u

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -382,12 +382,11 @@ rc-changes:
 
 changes: summary
 	@printf "\n- Features added since $(LAST_RELEASE)\n"
-	@git log --pretty=format:'  +%s' --no-merges --abbrev-commit $(LAST_RELEASE)..HEAD \
-		| grep -e Feature: | sed -e 's@Feature:@@' | sort -uf
+	@git log --pretty=format:'%s' --no-merges --abbrev-commit $(LAST_RELEASE)..HEAD \
+		| sed -n -e 's/^ *Feature: */  + /p' | sort -uf
 	@printf "\n- Fixes since $(LAST_RELEASE)\n"
-	@git log --pretty=format:'  +%s' --no-merges --abbrev-commit $(LAST_RELEASE)..HEAD \
-		| grep -e High: -e Fix: -e Bug | sed \
-			-e 's@\(Fix\|High\|Bug\):@@' \
+	@git log --pretty=format:'%s' --no-merges --abbrev-commit $(LAST_RELEASE)..HEAD \
+		| sed -n -e 's/^ *\(Fix\|High\|Bug\): */  + /p' | sed			\
 			-e 's@\(cib\|pacemaker-based\|based\):@CIB:@' \
 			-e 's@\(crmd\|pacemaker-controld\|controld\):@controller:@' \
 			-e 's@\(lrmd\|pacemaker-execd\|execd\):@executor:@' \

--- a/configure.ac
+++ b/configure.ac
@@ -869,8 +869,7 @@ PKG_CHECK_MODULES(LIBXML2, [libxml-2.0],
                   [CPPFLAGS="${CPPFLAGS} ${LIBXML2_CFLAGS}"
                    LIBS="${LIBS} ${LIBXML2_LIBS}"])
 
-AC_CHECK_LIB([xslt], [xsltApplyStylesheet], [],
-             [AC_MSG_FAILURE([Could not find required C library libxslt])])
+REQUIRE_LIB([xslt], [xsltApplyStylesheet])
 
 dnl ========================================================================
 dnl Headers
@@ -983,8 +982,7 @@ dnl ========================================================================
 dnl   bzip2
 dnl ========================================================================
 REQUIRE_HEADER([bzlib.h])
-AC_CHECK_LIB([bz2], [BZ2_bzBuffToBuffCompress],,
-             [AC_MSG_FAILURE(Could not find required C library libbz2)])
+REQUIRE_LIB([bz2], [BZ2_bzBuffToBuffCompress])
 
 dnl ========================================================================
 dnl sighandler_t is missing from Illumos, Solaris11 systems
@@ -1539,17 +1537,17 @@ AS_IF([test -n "${SANITIZERS}"], [
             [asan|ASAN], [
                 SANITIZERS_CFLAGS="$SANITIZERS_CFLAGS -fsanitize=address"
                 SANITIZERS_LDFLAGS="$SANITIZERS_LDFLAGS -fsanitize=address -lasan"
-                AC_CHECK_LIB([asan],[main],,AC_MSG_ERROR([Unable to find libasan]))
+                REQUIRE_LIB([asan],[main])
             ],
             [ubsan|UBSAN], [
                 SANITIZERS_CFLAGS="$SANITIZERS_CFLAGS -fsanitize=undefined"
                 SANITIZERS_LDFLAGS="$SANITIZERS_LDFLAGS -fsanitize=undefined -lubsan"
-                AC_CHECK_LIB([ubsan],[main],,AC_MSG_ERROR([Unable to find libubsan]))
+                REQUIRE_LIB([ubsan],[main])
             ],
             [tsan|TSAN], [
                 SANITIZERS_CFLAGS="$SANITIZERS_CFLAGS -fsanitize=thread"
                 SANITIZERS_LDFLAGS="$SANITIZERS_LDFLAGS -fsanitize=thread -ltsan"
-                AC_CHECK_LIB([tsan],[main],,AC_MSG_ERROR([Unable to find libtsan]))
+                REQUIRE_LIB([tsan],[main])
             ])
   done
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -188,14 +188,7 @@ dnl ===============================================
 dnl Actual library checks come later, but pkg-config can be used here to grab
 dnl external values to use as defaults for configure options
 
-dnl --enable-* options
-
-AC_ARG_ENABLE([fatal-warnings],
-    [AS_HELP_STRING([--enable-fatal-warnings],
-        [enable pedantic and fatal warnings for gcc @<:@try@:>@])],
-)
-yes_no_try "$enable_fatal_warnings" "try"
-enable_fatal_warnings=$?
+dnl --enable-* options: build process
 
 AC_ARG_ENABLE([quiet],
     [AS_HELP_STRING([--enable-quiet],
@@ -204,12 +197,21 @@ AC_ARG_ENABLE([quiet],
 yes_no_try "$enable_quiet" "no"
 enable_quiet=$?
 
-AC_ARG_ENABLE([upstart],
-    [AS_HELP_STRING([--enable-upstart],
-        [enable support for managing resources via Upstart @<:@try@:>@])]
+AC_ARG_ENABLE([fatal-warnings],
+    [AS_HELP_STRING([--enable-fatal-warnings],
+        [enable pedantic and fatal warnings for gcc @<:@try@:>@])],
 )
-yes_no_try "$enable_upstart" "try"
-enable_upstart=$?
+yes_no_try "$enable_fatal_warnings" "try"
+enable_fatal_warnings=$?
+
+AC_ARG_ENABLE([hardening],
+    [AS_HELP_STRING([--enable-hardening],
+        [harden the resulting executables/libraries @<:@try@:>@])]
+)
+yes_no_try "$enable_hardening" "try"
+enable_hardening=$?
+
+dnl --enable-* options: features
 
 AC_ARG_ENABLE([systemd],
     [AS_HELP_STRING([--enable-systemd],
@@ -218,12 +220,14 @@ AC_ARG_ENABLE([systemd],
 yes_no_try "$enable_systemd" "try"
 enable_systemd=$?
 
-AC_ARG_ENABLE([hardening],
-    [AS_HELP_STRING([--enable-hardening],
-        [harden the resulting executables/libraries @<:@try@:>@])]
+AC_ARG_ENABLE([upstart],
+    [AS_HELP_STRING([--enable-upstart],
+        [enable support for managing resources via Upstart @<:@try@:>@])]
 )
-yes_no_try "$enable_hardening" "try"
-enable_hardening=$?
+yes_no_try "$enable_upstart" "try"
+enable_upstart=$?
+
+dnl --enable-* options: compatibility
 
 AC_ARG_ENABLE([compat-2.0],
     [AS_HELP_STRING([--enable-compat-2.0], m4_normalize([
@@ -251,8 +255,7 @@ yes_no_try "$enable_legacy_links" "no"
 enable_legacy_links=$?
 AM_CONDITIONAL([BUILD_LEGACY_LINKS], [test $enable_legacy_links -gt 0])
 
-
-dnl --with-* options
+dnl --with-* options: basic parameters
 
 AC_DEFUN([VERSION_ARG],
     [AC_ARG_WITH([version],
@@ -262,31 +265,29 @@ AC_DEFUN([VERSION_ARG],
 )
 VERSION_ARG(VERSION_NUMBER)
 
-AC_ARG_WITH([corosync],
-    [AS_HELP_STRING([--with-corosync],
-        [support the Corosync messaging and membership layer @<:@try@:>@])]
-)
-yes_no_try "$with_corosync" "try"
-with_corosync=$?
-
-AC_ARG_WITH([nagios],
-    [AS_HELP_STRING([--with-nagios],
-        [support nagios remote monitoring])]
-)
-yes_no_try "$with_nagios" "try"
-with_nagios=$?
-
-AC_ARG_WITH([nagios-plugin-dir],
-    [AS_HELP_STRING([--with-nagios-plugin-dir=DIR],
-        [directory for nagios plugins @<:@LIBEXECDIR/nagios/plugins@:>@])],
-    [ NAGIOS_PLUGIN_DIR="$withval" ]
+CRM_DAEMON_USER=""
+AC_ARG_WITH([daemon-user],
+    [AS_HELP_STRING([--with-daemon-user=USER],
+        [user to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@hacluster@:>@])],
+    [ CRM_DAEMON_USER="$withval" ]
 )
 
-AC_ARG_WITH([nagios-metadata-dir],
-    [AS_HELP_STRING([--with-nagios-metadata-dir=DIR],
-        [directory for nagios plugins metadata @<:@DATADIR/nagios/plugins-metadata@:>@])],
-    [ NAGIOS_METADATA_DIR="$withval" ]
+CRM_DAEMON_GROUP=""
+AC_ARG_WITH([daemon-group],
+    [AS_HELP_STRING([--with-daemon-group=GROUP],
+        [group to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@haclient@:>@])],
+    [ CRM_DAEMON_GROUP="$withval" ]
 )
+
+BUG_URL=""
+AC_ARG_WITH([bug-url],
+    [AS_HELP_STRING([--with-bug-url=DIR], m4_normalize([
+	address where users should submit bug reports
+	@<:@https://bugs.clusterlabs.org/enter_bug.cgi?product=Pacemaker@:>@]))],
+    [ BUG_URL="$withval" ]
+)
+
+dnl --with-* options: features
 
 AC_ARG_WITH([acl],
     [AS_HELP_STRING([--with-acl],
@@ -306,16 +307,41 @@ AC_ARG_WITH([gnutls],
     [AS_HELP_STRING([--with-gnutls],
         [support Pacemaker Remote and remote-tls-port using GnuTLS @<:@try@:>@])]
 )
-with_gnutls=$(yes_no_try "$with_gnutls" "try")
-AS_IF([test $with_gnutls -eq 3],
-      [AC_MSG_ERROR([Invalid value for --with-gnutls])]
-)
+yes_no_try "$with_gnutls" "try"
+with_gnutls=$?
 
 PCMK_GNUTLS_PRIORITIES="NORMAL"
 AC_ARG_WITH([gnutls-priorities],
     [AS_HELP_STRING([--with-gnutls-priorities],
         [default GnuTLS cipher priorities @<:@NORMAL@:>@])],
     [ test x"$withval" = x"no" || PCMK_GNUTLS_PRIORITIES="$withval" ]
+)
+
+AC_ARG_WITH([corosync],
+    [AS_HELP_STRING([--with-corosync],
+        [support the Corosync messaging and membership layer @<:@try@:>@])]
+)
+yes_no_try "$with_corosync" "try"
+with_corosync=$?
+
+AC_ARG_WITH([nagios],
+    [AS_HELP_STRING([--with-nagios], [support nagios resources])]
+)
+yes_no_try "$with_nagios" "try"
+with_nagios=$?
+
+dnl --with-* options: directory locations
+
+AC_ARG_WITH([nagios-plugin-dir],
+    [AS_HELP_STRING([--with-nagios-plugin-dir=DIR],
+        [directory for nagios plugins @<:@LIBEXECDIR/nagios/plugins@:>@])],
+    [ NAGIOS_PLUGIN_DIR="$withval" ]
+)
+
+AC_ARG_WITH([nagios-metadata-dir],
+    [AS_HELP_STRING([--with-nagios-metadata-dir=DIR],
+        [directory for nagios plugins metadata @<:@DATADIR/nagios/plugins-metadata@:>@])],
+    [ NAGIOS_METADATA_DIR="$withval" ]
 )
 
 INITDIR=""
@@ -332,32 +358,20 @@ AC_ARG_WITH([systemdsystemunitdir],
     [ systemdsystemunitdir="$withval" ]
 )
 
-AC_ARG_WITH([profiling],
-    [AS_HELP_STRING([--with-profiling],
-        [disable optimizations, for effective profiling @<:@no@:>@])]
-)
-yes_no_try "$with_profiling" "no"
-with_profiling=$?
-
-AC_ARG_WITH([coverage],
-    [AS_HELP_STRING([--with-coverage],
-        [disable optimizations, for effective profiling and coverage testing @<:@no@:>@])]
-)
-yes_no_try "$with_coverage" "no"
-with_coverage=$?
-
-BUG_URL=""
-AC_ARG_WITH([bug-url],
-    [AS_HELP_STRING([--with-bug-url=DIR],
-        [address where users should submit bug reports @<:@https://bugs.clusterlabs.org/enter_bug.cgi?product=Pacemaker@:>@])],
-    [ BUG_URL="$withval" ]
-)
-
 CONFIGDIR=""
 AC_ARG_WITH([configdir],
     [AS_HELP_STRING([--with-configdir=DIR],
         [directory for Pacemaker configuration file @<:@SYSCONFDIR/sysconfig@:>@])],
     [ CONFIGDIR="$withval" ]
+)
+
+dnl --runstatedir is available as of autoconf 2.70 (2020-12-08). When users
+dnl have an older version, they can use our --with-runstatedir.
+pcmk_runstatedir=""
+AC_ARG_WITH([runstatedir],
+    [AS_HELP_STRING([--with-runstatedir=DIR],
+        [modifiable per-process data @<:@LOCALSTATEDIR/run@:>@ (ignored if --runstatedir is available)])],
+    [ pcmk_runstatedir="$withval" ]
 )
 
 CRM_LOG_DIR=""
@@ -372,22 +386,6 @@ AC_ARG_WITH([bundledir],
     [AS_HELP_STRING([--with-bundledir=DIR],
         [directory for Pacemaker bundle logs @<:@LOCALSTATEDIR/log/pacemaker/bundles@:>@])],
     [ CRM_BUNDLE_DIR="$withval" ]
-)
-
-AC_ARG_WITH([sanitizers],
-  [AS_HELP_STRING([--with-sanitizers=...,...],
-    [enable SANitizer build, do *NOT* use for production. Only ASAN/UBSAN/TSAN are currently supported])],
-  [ SANITIZERS="$withval" ],
-  [ SANITIZERS="" ])
-
-
-dnl --runstatedir is available as of autoconf 2.70 (2020-12-08). When users
-dnl have an older version, they can use our --with-runstatedir.
-pcmk_runstatedir=""
-AC_ARG_WITH([runstatedir],
-    [AS_HELP_STRING([--with-runstatedir=DIR],
-        [modifiable per-process data @<:@LOCALSTATEDIR/run@:>@ (ignored if --runstatedir is available)])],
-    [ pcmk_runstatedir="$withval" ]
 )
 
 dnl Get default from resource-agents if possible. Otherwise, the default uses
@@ -421,19 +419,27 @@ AC_ARG_WITH([fence-bindir],
 )
 AC_SUBST(PCMK__FENCE_BINDIR)
 
-CRM_DAEMON_USER=""
-AC_ARG_WITH([daemon-user],
-    [AS_HELP_STRING([--with-daemon-user=USER],
-        [user to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@hacluster@:>@])],
-    [ CRM_DAEMON_USER="$withval" ]
-)
+dnl --with-* options: non-production testing
 
-CRM_DAEMON_GROUP=""
-AC_ARG_WITH([daemon-group],
-    [AS_HELP_STRING([--with-daemon-group=GROUP],
-        [group to run unprivileged Pacemaker daemons as (advanced option: changing this may break other cluster components unless similarly configured) @<:@haclient@:>@])],
-    [ CRM_DAEMON_GROUP="$withval" ]
+AC_ARG_WITH([profiling],
+    [AS_HELP_STRING([--with-profiling],
+        [disable optimizations, for effective profiling @<:@no@:>@])]
 )
+yes_no_try "$with_profiling" "no"
+with_profiling=$?
+
+AC_ARG_WITH([coverage],
+    [AS_HELP_STRING([--with-coverage],
+        [disable optimizations, for effective profiling and coverage testing @<:@no@:>@])]
+)
+yes_no_try "$with_coverage" "no"
+with_coverage=$?
+
+AC_ARG_WITH([sanitizers],
+  [AS_HELP_STRING([--with-sanitizers=...,...],
+    [enable SANitizer build, do *NOT* use for production. Only ASAN/UBSAN/TSAN are currently supported])],
+  [ SANITIZERS="$withval" ],
+  [ SANITIZERS="" ])
 
 
 dnl ===============================================

--- a/configure.ac
+++ b/configure.ac
@@ -257,13 +257,22 @@ AM_CONDITIONAL([BUILD_LEGACY_LINKS], [test $enable_legacy_links -gt 0])
 
 dnl --with-* options: basic parameters
 
+dnl This argument is defined via an M4 macro so default can be a variable
 AC_DEFUN([VERSION_ARG],
     [AC_ARG_WITH([version],
         [AS_HELP_STRING([--with-version=VERSION],
             [override package version @<:@$1@:>@])],
-        [ PACKAGE_VERSION="$withval" ])]
+        [ PACEMAKER_VERSION="$withval" ],
+        [ PACEMAKER_VERSION="$PACKAGE_VERSION" ])]
 )
 VERSION_ARG(VERSION_NUMBER)
+
+# Redefine PACKAGE_VERSION and VERSION according to PACEMAKER_VERSION in case
+# the user used --with-version. Unfortunately, this can only affect the
+# substitution variables and later uses in this file, not the config.h
+# constants, so we have to be careful to use only PACEMAKER_VERSION in C code.
+PACKAGE_VERSION=$PACEMAKER_VERSION
+VERSION=$PACEMAKER_VERSION
 
 CRM_DAEMON_USER=""
 AC_ARG_WITH([daemon-user],
@@ -460,12 +469,11 @@ dnl ===============================================
 dnl General Processing
 dnl ===============================================
 
-AC_DEFINE_UNQUOTED(PACEMAKER_VERSION, "$PACKAGE_VERSION",
-                   [Current pacemaker version])
+AC_DEFINE_UNQUOTED(PACEMAKER_VERSION, "$VERSION",
+                   [Version number of this Pacemaker build])
 
-PACKAGE_SERIES=`echo $PACKAGE_VERSION | awk -F. '{ print $1"."$2 }'`
+PACKAGE_SERIES=`echo $VERSION | awk -F. '{ print $1"."$2 }'`
 AC_SUBST(PACKAGE_SERIES)
-AC_SUBST(PACKAGE_VERSION)
 
 AC_PROG_LN_S
 AC_PROG_MKDIR_P

--- a/configure.ac
+++ b/configure.ac
@@ -162,13 +162,16 @@ cc_restore_flags() {
 }
 
 # yes_no_try $user_response $default
+DISABLED=0
+REQUIRED=1
+OPTIONAL=2
 yes_no_try() {
     local value
     AS_IF([test x"$1" = x""], [value="$2"], [value="$1"])
     AS_CASE(["`echo "$value" | tr '[A-Z]' '[a-z]'`"],
-            [0|no|false|disable], [return 0],
-            [1|yes|true|enable], [return 1],
-            [try|check], [return 2]
+            [0|no|false|disable], [return $DISABLED],
+            [1|yes|true|enable], [return $REQUIRED],
+            [try|check], [return $OPTIONAL]
     )
     AC_MSG_ERROR([Invalid option value "$value"])
 }
@@ -236,7 +239,7 @@ AC_ARG_ENABLE([compat-2.0],
 )
 yes_no_try "$enable_compat_2_0" "no"
 enable_compat_2_0=$?
-AS_IF([test $enable_compat_2_0 -gt 0],
+AS_IF([test $enable_compat_2_0 -ne $DISABLED],
       [
           AC_DEFINE_UNQUOTED([PCMK__COMPAT_2_0], [1],
                              [Keep certain output compatible with 2.0 release series])
@@ -253,7 +256,7 @@ AC_ARG_ENABLE([legacy-links],
 )
 yes_no_try "$enable_legacy_links" "no"
 enable_legacy_links=$?
-AM_CONDITIONAL([BUILD_LEGACY_LINKS], [test $enable_legacy_links -gt 0])
+AM_CONDITIONAL([BUILD_LEGACY_LINKS], [test $enable_legacy_links -ne $DISABLED])
 
 dnl --with-* options: basic parameters
 
@@ -472,16 +475,16 @@ AC_PROG_LN_S
 AC_PROG_MKDIR_P
 
 # Check for fatal warning support
-AS_IF([test $enable_fatal_warnings -gt 0 && test "$GCC" = "yes" && cc_supports_flag -Werror],
+AS_IF([test $enable_fatal_warnings -ne $DISABLED && test "$GCC" = "yes" && cc_supports_flag -Werror],
       [WERROR="-Werror"],
       [
           WERROR=""
           AS_CASE([$enable_fatal_warnings],
-                  [1], [AC_MSG_ERROR([Compiler does not support fatal warnings])],
-                  [2], [
-                           AC_MSG_NOTICE([Compiler does not support fatal warnings])
-                           enable_fatal_warnings=0
-                       ])
+                  [$REQUIRED], [AC_MSG_ERROR([Compiler does not support fatal warnings])],
+                  [$OPTIONAL], [
+                      AC_MSG_NOTICE([Compiler does not support fatal warnings])
+                      enable_fatal_warnings=$DISABLED
+                  ])
       ])
 
 AC_MSG_NOTICE([Sanitizing prefix: ${prefix}])
@@ -1143,18 +1146,18 @@ dnl    Profiling and GProf
 dnl ========================================================================
 
 CFLAGS_ORIG="$CFLAGS"
-AS_IF([test $with_coverage -gt 0],
+AS_IF([test $with_coverage -ne $DISABLED],
       [
-        with_profiling=1
+        with_profiling=$REQUIRED
         PCMK_FEATURES="$PCMK_FEATURES coverage"
         CFLAGS="$CFLAGS -fprofile-arcs -ftest-coverage"
         dnl During linking, make sure to specify -lgcov or -coverage
       ]
 )
 
-AS_IF([test $with_profiling -gt 0],
+AS_IF([test $with_profiling -ne $DISABLED],
       [
-          with_profiling=1
+          with_profiling=$REQUIRED
           PCMK_FEATURES="$PCMK_FEATURES profile"
 
           dnl Disable various compiler optimizations
@@ -1307,45 +1310,45 @@ fi
 AC_SUBST(PC_NAME_DBUS)
 
 AS_CASE([$enable_systemd],
-        [1], [
-                 AS_IF([test $HAVE_dbus = 0],
-                       [AC_MSG_FAILURE([Cannot support systemd resources without DBus])])
-                 AS_IF([test "$ac_cv_have_decl_CLOCK_MONOTONIC" = "no"],
-                       [AC_MSG_FAILURE([Cannot support systemd resources without monotonic clock])])
-                 AS_IF([check_systemdsystemunitdir], [],
-                       [AC_MSG_FAILURE([Cannot support systemd resources without systemdsystemunitdir])])
-             ],
-        [2], [
-                 AS_IF([test $HAVE_dbus = 0 \
-                        || test "$ac_cv_have_decl_CLOCK_MONOTONIC" = "no"],
-                       [enable_systemd=0],
-                       [
-                           AC_MSG_CHECKING([for systemd version (using dbus-send)])
-                           ret=$({ dbus-send --system --print-reply \
-                                       --dest=org.freedesktop.systemd1 \
-                                       /org/freedesktop/systemd1 \
-                                       org.freedesktop.DBus.Properties.Get \
-                                       string:org.freedesktop.systemd1.Manager \
-                                       string:Version 2>/dev/null \
-                                   || echo "version unavailable"; } | tail -n1)
-                           # sanitize output a bit (interested just in value, not type),
-                           # ret is intentionally unenquoted so as to normalize whitespace
-                           ret=$(echo ${ret} | cut -d' ' -f2-)
-                           AC_MSG_RESULT([${ret}])
-                           AS_IF([test "$ret" != "unavailable" \
-                                  || systemctl --version 2>/dev/null | grep -q systemd],
-                                 [
-                                     AS_IF([check_systemdsystemunitdir],
-                                           [enable_systemd=1],
-                                           [enable_systemd=0])
-                                 ],
-                                 [enable_systemd=0]
-                           )
-                       ])
-             ],
+        [$REQUIRED], [
+            AS_IF([test $HAVE_dbus = 0],
+                  [AC_MSG_FAILURE([Cannot support systemd resources without DBus])])
+            AS_IF([test "$ac_cv_have_decl_CLOCK_MONOTONIC" = "no"],
+                  [AC_MSG_FAILURE([Cannot support systemd resources without monotonic clock])])
+            AS_IF([check_systemdsystemunitdir], [],
+                  [AC_MSG_FAILURE([Cannot support systemd resources without systemdsystemunitdir])])
+        ],
+        [$OPTIONAL], [
+            AS_IF([test $HAVE_dbus = 0 \
+                   || test "$ac_cv_have_decl_CLOCK_MONOTONIC" = "no"],
+                  [enable_systemd=$DISABLED],
+                  [
+                      AC_MSG_CHECKING([for systemd version (using dbus-send)])
+                      ret=$({ dbus-send --system --print-reply \
+                                  --dest=org.freedesktop.systemd1 \
+                                  /org/freedesktop/systemd1 \
+                                  org.freedesktop.DBus.Properties.Get \
+                                  string:org.freedesktop.systemd1.Manager \
+                                  string:Version 2>/dev/null \
+                              || echo "version unavailable"; } | tail -n1)
+                      # sanitize output a bit (interested just in value, not type),
+                      # ret is intentionally unenquoted so as to normalize whitespace
+                      ret=$(echo ${ret} | cut -d' ' -f2-)
+                      AC_MSG_RESULT([${ret}])
+                      AS_IF([test "$ret" != "unavailable" \
+                             || systemctl --version 2>/dev/null | grep -q systemd],
+                            [
+                                AS_IF([check_systemdsystemunitdir],
+                                      [enable_systemd=$REQUIRED],
+                                      [enable_systemd=$DISABLED])
+                            ],
+                            [enable_systemd=$DISABLED]
+                      )
+                  ])
+        ],
 )
 AC_MSG_CHECKING([whether to enable support for managing resources via systemd])
-AS_IF([test $enable_systemd -eq 0], [AC_MSG_RESULT([no])],
+AS_IF([test $enable_systemd -eq $DISABLED], [AC_MSG_RESULT([no])],
       [
           AC_MSG_RESULT([yes])
           PCMK_FEATURES="$PCMK_FEATURES systemd"
@@ -1354,37 +1357,37 @@ AS_IF([test $enable_systemd -eq 0], [AC_MSG_RESULT([no])],
 AC_SUBST([systemdsystemunitdir])
 AC_DEFINE_UNQUOTED([SUPPORT_SYSTEMD], [$enable_systemd],
                    [Support systemd resources])
-AM_CONDITIONAL([BUILD_SYSTEMD], [test $enable_systemd = 1])
+AM_CONDITIONAL([BUILD_SYSTEMD], [test $enable_systemd = $REQUIRED])
 AC_SUBST(SUPPORT_SYSTEMD)
 
 AS_CASE([$enable_upstart],
-        [1], [
-                 AS_IF([test $HAVE_dbus = 0],
-                       [AC_MSG_FAILURE([Cannot support Upstart resources without DBus])])
-             ],
-        [2], [
-                 AS_IF([test $HAVE_dbus = 0], [enable_upstart=0],
-                       [
-                           AC_MSG_CHECKING([for Upstart version (using dbus-send)])
-                           ret=$({ dbus-send --system --print-reply \
-                                       --dest=com.ubuntu.Upstart \
-                                       /com/ubuntu/Upstart org.freedesktop.DBus.Properties.Get \
-                                       string:com.ubuntu.Upstart0_6 string:version 2>/dev/null \
-                                   || echo "version unavailable"; } | tail -n1)
-                           # sanitize output a bit (interested just in value, not type),
-                           # ret is intentionally unenquoted so as to normalize whitespace
-                           ret=$(echo ${ret} | cut -d' ' -f2-)
-                           AC_MSG_RESULT([${ret}])
-                           AS_IF([test "$ret" != "unavailable" \
-                                  || initctl --version 2>/dev/null | grep -q upstart],
-                                 [enable_upstart=1],
-                                 [enable_upstart=0]
-                           )
-                       ])
-             ],
+        [$REQUIRED], [
+            AS_IF([test $HAVE_dbus = 0],
+                  [AC_MSG_FAILURE([Cannot support Upstart resources without DBus])])
+        ],
+        [$OPTIONAL], [
+            AS_IF([test $HAVE_dbus = 0], [enable_upstart=$DISABLED],
+                  [
+                      AC_MSG_CHECKING([for Upstart version (using dbus-send)])
+                      ret=$({ dbus-send --system --print-reply \
+                                  --dest=com.ubuntu.Upstart \
+                                  /com/ubuntu/Upstart org.freedesktop.DBus.Properties.Get \
+                                  string:com.ubuntu.Upstart0_6 string:version 2>/dev/null \
+                              || echo "version unavailable"; } | tail -n1)
+                      # sanitize output a bit (interested just in value, not type),
+                      # ret is intentionally unenquoted so as to normalize whitespace
+                      ret=$(echo ${ret} | cut -d' ' -f2-)
+                      AC_MSG_RESULT([${ret}])
+                      AS_IF([test "$ret" != "unavailable" \
+                             || initctl --version 2>/dev/null | grep -q upstart],
+                            [enable_upstart=$REQUIRED],
+                            [enable_upstart=$DISABLED]
+                      )
+                  ])
+        ],
 )
 AC_MSG_CHECKING([whether to enable support for managing resources via Upstart])
-AS_IF([test $enable_upstart -eq 0], [AC_MSG_RESULT([no])],
+AS_IF([test $enable_upstart -eq $DISABLED], [AC_MSG_RESULT([no])],
       [
           AC_MSG_RESULT([yes])
           PCMK_FEATURES="$PCMK_FEATURES upstart"
@@ -1392,22 +1395,22 @@ AS_IF([test $enable_upstart -eq 0], [AC_MSG_RESULT([no])],
 )
 AC_DEFINE_UNQUOTED([SUPPORT_UPSTART], [$enable_upstart],
                    [Support Upstart resources])
-AM_CONDITIONAL([BUILD_UPSTART], [test $enable_upstart = 1])
+AM_CONDITIONAL([BUILD_UPSTART], [test $enable_upstart -eq $REQUIRED])
 AC_SUBST(SUPPORT_UPSTART)
 
 AS_CASE([$with_nagios],
-        [1], [
-                 AS_IF([test "$ac_cv_have_decl_CLOCK_MONOTONIC" = "no"],
-                       [AC_MSG_FAILURE([Cannot support nagios resources without monotonic clock])])
-             ],
-        [2], [
-                 AS_IF([test "$ac_cv_have_decl_CLOCK_MONOTONIC" = "no"],
-                       [with_nagios=0], [with_nagios=1])
-             ]
+        [$REQUIRED], [
+            AS_IF([test "$ac_cv_have_decl_CLOCK_MONOTONIC" = "no"],
+                  [AC_MSG_FAILURE([Cannot support nagios resources without monotonic clock])])
+        ],
+        [$OPTIONAL], [
+            AS_IF([test "$ac_cv_have_decl_CLOCK_MONOTONIC" = "no"],
+                  [with_nagios=$DISABLED], [with_nagios=$REQUIRED])
+        ]
 )
-AS_IF([test $with_nagios = 1], [PCMK_FEATURES="$PCMK_FEATURES nagios"])
+AS_IF([test $with_nagios -eq $REQUIRED], [PCMK_FEATURES="$PCMK_FEATURES nagios"])
 AC_DEFINE_UNQUOTED([SUPPORT_NAGIOS], [$with_nagios], [Support nagios plugins])
-AM_CONDITIONAL([BUILD_NAGIOS], [test $with_nagios = 1])
+AM_CONDITIONAL([BUILD_NAGIOS], [test $with_nagios -eq $REQUIRED])
 
 if test x"$NAGIOS_PLUGIN_DIR" = x""; then
     NAGIOS_PLUGIN_DIR="${libexecdir}/nagios/plugins"
@@ -1434,24 +1437,24 @@ dnl ========================================================================
 COROSYNC_LIBS=""
 
 AS_CASE([$with_corosync],
-        [1], [
-                 # These will be fatal if unavailable
-                 PKG_CHECK_MODULES([cpg], [libcpg])
-                 PKG_CHECK_MODULES([cfg], [libcfg])
-                 PKG_CHECK_MODULES([cmap], [libcmap])
-                 PKG_CHECK_MODULES([quorum], [libquorum])
-                 PKG_CHECK_MODULES([libcorosync_common], [libcorosync_common])
-             ]
-        [2], [
-                 PKG_CHECK_MODULES([cpg], [libcpg], [], [with_corosync=0])
-                 PKG_CHECK_MODULES([cfg], [libcfg], [], [with_corosync=0])
-                 PKG_CHECK_MODULES([cmap], [libcmap], [], [with_corosync=0])
-                 PKG_CHECK_MODULES([quorum], [libquorum], [], [with_corosync=0])
-                 PKG_CHECK_MODULES([libcorosync_common], [libcorosync_common], [], [with_corosync=0])
-                 AS_IF([test $with_corosync -gt 0], [with_corosync=1])
-             ]
+        [$REQUIRED], [
+            # These will be fatal if unavailable
+            PKG_CHECK_MODULES([cpg], [libcpg])
+            PKG_CHECK_MODULES([cfg], [libcfg])
+            PKG_CHECK_MODULES([cmap], [libcmap])
+            PKG_CHECK_MODULES([quorum], [libquorum])
+            PKG_CHECK_MODULES([libcorosync_common], [libcorosync_common])
+        ]
+        [$OPTIONAL], [
+            PKG_CHECK_MODULES([cpg], [libcpg], [], [with_corosync=$DISABLED])
+            PKG_CHECK_MODULES([cfg], [libcfg], [], [with_corosync=$DISABLED])
+            PKG_CHECK_MODULES([cmap], [libcmap], [], [with_corosync=$DISABLED])
+            PKG_CHECK_MODULES([quorum], [libquorum], [], [with_corosync=$DISABLED])
+            PKG_CHECK_MODULES([libcorosync_common], [libcorosync_common], [], [with_corosync=$DISABLED])
+            AS_IF([test $with_corosync -ne $DISABLED], [with_corosync=$REQUIRED])
+        ]
 )
-AS_IF([test $with_corosync -gt 0],
+AS_IF([test $with_corosync -ne $DISABLED],
       [
           AC_MSG_CHECKING([for Corosync 2 or later])
           AC_MSG_RESULT([yes])
@@ -1472,7 +1475,7 @@ AS_IF([test $with_corosync -gt 0],
 )
 AC_DEFINE_UNQUOTED([SUPPORT_COROSYNC], [$with_corosync],
                    [Support the Corosync messaging and membership layer])
-AM_CONDITIONAL([BUILD_CS_SUPPORT], [test $with_corosync -eq 1])
+AM_CONDITIONAL([BUILD_CS_SUPPORT], [test $with_corosync -eq $REQUIRED])
 AC_SUBST([SUPPORT_COROSYNC])
 
 dnl
@@ -1491,9 +1494,9 @@ dnl ========================================================================
 dnl    CIB secrets
 dnl ========================================================================
 
-AS_IF([test $with_cibsecrets -gt 0],
+AS_IF([test $with_cibsecrets -ne $DISABLED],
       [
-          with_cibsecrets=1
+          with_cibsecrets=$REQUIRED
           PCMK_FEATURES="$PCMK_FEATURES cibsecrets"
           LRM_CIBSECRETS_DIR="${localstatedir}/lib/pacemaker/lrm/secrets"
           AC_DEFINE_UNQUOTED([LRM_CIBSECRETS_DIR], ["$LRM_CIBSECRETS_DIR"],
@@ -1502,7 +1505,7 @@ AS_IF([test $with_cibsecrets -gt 0],
       ]
 )
 AC_DEFINE_UNQUOTED([SUPPORT_CIBSECRETS], [$with_cibsecrets], [Support CIB secrets])
-AM_CONDITIONAL([BUILD_CIBSECRETS], [test $with_cibsecrets -eq 1])
+AM_CONDITIONAL([BUILD_CIBSECRETS], [test $with_cibsecrets -eq $REQUIRED])
 
 dnl ========================================================================
 dnl    GnuTLS
@@ -1511,24 +1514,24 @@ dnl ========================================================================
 dnl Require GnuTLS >=2.12.0 (2011-03) for Pacemaker Remote support
 PC_NAME_GNUTLS=""
 AS_CASE([$with_gnutls],
-        [1], [
-                 REQUIRE_LIB([gnutls], [gnutls_sec_param_to_pk_bits])
-                 REQUIRE_HEADER([gnutls/gnutls.h])
-             ],
-        [2], [
-                 AC_CHECK_LIB([gnutls], [gnutls_sec_param_to_pk_bits],
-                              [], [with_gnutls=0])
-                 AC_CHECK_HEADERS([gnutls/gnutls.h], [], [with_gnutls=0])
-             ]
+        [$REQUIRED], [
+            REQUIRE_LIB([gnutls], [gnutls_sec_param_to_pk_bits])
+            REQUIRE_HEADER([gnutls/gnutls.h])
+        ],
+        [$OPTIONAL], [
+            AC_CHECK_LIB([gnutls], [gnutls_sec_param_to_pk_bits],
+                         [], [with_gnutls=$DISABLED])
+            AC_CHECK_HEADERS([gnutls/gnutls.h], [], [with_gnutls=$DISABLED])
+        ]
 )
-AS_IF([test $with_gnutls -gt 0],
+AS_IF([test $with_gnutls -ne $DISABLED],
       [
           PC_NAME_GNUTLS="gnutls"
           PCMK_FEATURES="$PCMK_FEATURES remote"
       ]
 )
 AC_SUBST([PC_NAME_GNUTLS])
-AM_CONDITIONAL([BUILD_REMOTE], [test $with_gnutls -gt 0])
+AM_CONDITIONAL([BUILD_REMOTE], [test $with_gnutls -ne $DISABLED])
 
 dnl ========================================================================
 dnl    System Health
@@ -1736,94 +1739,94 @@ dnl https://fedoraproject.org/wiki/Changes/Harden_All_Packages#Detailed_Harden_F
 dnl https://owasp.org/index.php/C-Based_Toolchain_Hardening#GCC.2FBinutils
 dnl
 
-AS_IF([test $enable_hardening -lt 2],
+AS_IF([test $enable_hardening -eq $OPTIONAL],
+      [
+          AS_IF([test "$(env | grep -Ec '^(C|LD)FLAGS_HARDENED_(EXE|LIB)=.')" = 0],
+                [enable_hardening=$REQUIRED],
+                [AC_MSG_NOTICE([Hardening: using custom flags from environment])]
+          )
+      ],
       [
           unset CFLAGS_HARDENED_EXE
           unset CFLAGS_HARDENED_LIB
           unset LDFLAGS_HARDENED_EXE
           unset LDFLAGS_HARDENED_LIB
-      ],
-      [
-          AS_IF([test "$(env | grep -Ec '^(C|LD)FLAGS_HARDENED_(EXE|LIB)=.')" = 0],
-                [enable_hardening=1],
-                [AC_MSG_NOTICE([Hardening: using custom flags from environment])]
-          )
       ]
 )
 AS_CASE([$enable_hardening],
-        [0], [AC_MSG_NOTICE([Hardening: explicitly disabled])],
-        [1], [
-                 CFLAGS_HARDENED_EXE=
-                 CFLAGS_HARDENED_LIB=
-                 LDFLAGS_HARDENED_EXE=
-                 LDFLAGS_HARDENED_LIB=
-                 relro=0
-                 pie=0
-                 bindnow=0
-                 # daemons incl. libs: partial RELRO
-                 flag="-Wl,-z,relro"
-                 CC_CHECK_LDFLAGS(["${flag}"],
-                                  [
-                                      LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}"
-                                      LDFLAGS_HARDENED_LIB="${LDFLAGS_HARDENED_LIB} ${flag}"
-                                      relro=1
-                                  ])
-                 # daemons: PIE for both CFLAGS and LDFLAGS
-                 AS_IF([cc_supports_flag -fPIE],
-                       [
-                           flag="-pie"
-                           CC_CHECK_LDFLAGS(["${flag}"],
-                                            [
-                                                CFLAGS_HARDENED_EXE="${CFLAGS_HARDENED_EXE} -fPIE"
-                                                LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}"
-                                                pie=1
-                                            ])
-                       ]
-                 )
-                 # daemons incl. libs: full RELRO if sensible + as-needed linking
-                 #                     so as to possibly mitigate startup performance
-                 #                     hit caused by excessive linking with unneeded
-                 #                     libraries
-                 AS_IF([test "${relro}" = 1 && test "${pie}" = 1],
-                       [
-                           flag="-Wl,-z,now"
-                           CC_CHECK_LDFLAGS(["${flag}"],
-                                            [
-                                                LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}"
-                                                LDFLAGS_HARDENED_LIB="${LDFLAGS_HARDENED_LIB} ${flag}"
-                                                bindnow=1
-                                            ])
-                       ]
-                 )
-                 AS_IF([test "${bindnow}" = 1],
-                       [
-                           flag="-Wl,--as-needed"
-                           CC_CHECK_LDFLAGS(["${flag}"],
-                                            [
-                                                LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}"
-                                                LDFLAGS_HARDENED_LIB="${LDFLAGS_HARDENED_LIB} ${flag}"
-                                            ])
-                       ])
-                 # universal: prefer strong > all > default stack protector if possible
-                 flag=
-                 AS_IF([cc_supports_flag -fstack-protector-strong],
-                       [flag="-fstack-protector-strong"],
-                       [cc_supports_flag -fstack-protector-all],
-                       [flag="-fstack-protector-all"],
-                       [cc_supports_flag -fstack-protector],
-                       [flag="-fstack-protector"]
-                 )
-                 AS_IF([test -n "${flag}"],
-                       [
-                           CC_EXTRAS="${CC_EXTRAS} ${flag}"
-                           stackprot=1
-                       ]
-                 )
-                 AS_IF([test "${relro}" = 1 || test "${pie}" = 1 || test "${stackprot}" = 1],
-                       [AC_MSG_NOTICE([Hardening: relro=${relro} pie=${pie} bindnow=${bindnow} stackprot=${flag}])],
-                       [AC_MSG_WARN([Hardening: no suitable features in the toolchain detected])]
-                 )
-             ],
+        [$DISABLED], [AC_MSG_NOTICE([Hardening: explicitly disabled])],
+        [$REQUIRED], [
+            CFLAGS_HARDENED_EXE=
+            CFLAGS_HARDENED_LIB=
+            LDFLAGS_HARDENED_EXE=
+            LDFLAGS_HARDENED_LIB=
+            relro=0
+            pie=0
+            bindnow=0
+            # daemons incl. libs: partial RELRO
+            flag="-Wl,-z,relro"
+            CC_CHECK_LDFLAGS(["${flag}"],
+                             [
+                                 LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}"
+                                 LDFLAGS_HARDENED_LIB="${LDFLAGS_HARDENED_LIB} ${flag}"
+                                 relro=1
+                             ])
+            # daemons: PIE for both CFLAGS and LDFLAGS
+            AS_IF([cc_supports_flag -fPIE],
+                  [
+                      flag="-pie"
+                      CC_CHECK_LDFLAGS(["${flag}"],
+                                       [
+                                           CFLAGS_HARDENED_EXE="${CFLAGS_HARDENED_EXE} -fPIE"
+                                           LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}"
+                                           pie=1
+                                       ])
+                  ]
+            )
+            # daemons incl. libs: full RELRO if sensible + as-needed linking
+            #                     so as to possibly mitigate startup performance
+            #                     hit caused by excessive linking with unneeded
+            #                     libraries
+            AS_IF([test "${relro}" = 1 && test "${pie}" = 1],
+                  [
+                      flag="-Wl,-z,now"
+                      CC_CHECK_LDFLAGS(["${flag}"],
+                                       [
+                                           LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}"
+                                           LDFLAGS_HARDENED_LIB="${LDFLAGS_HARDENED_LIB} ${flag}"
+                                           bindnow=1
+                                       ])
+                  ]
+            )
+            AS_IF([test "${bindnow}" = 1],
+                  [
+                      flag="-Wl,--as-needed"
+                      CC_CHECK_LDFLAGS(["${flag}"],
+                                       [
+                                           LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}"
+                                           LDFLAGS_HARDENED_LIB="${LDFLAGS_HARDENED_LIB} ${flag}"
+                                       ])
+                  ])
+            # universal: prefer strong > all > default stack protector if possible
+            flag=
+            AS_IF([cc_supports_flag -fstack-protector-strong],
+                  [flag="-fstack-protector-strong"],
+                  [cc_supports_flag -fstack-protector-all],
+                  [flag="-fstack-protector-all"],
+                  [cc_supports_flag -fstack-protector],
+                  [flag="-fstack-protector"]
+            )
+            AS_IF([test -n "${flag}"],
+                  [
+                      CC_EXTRAS="${CC_EXTRAS} ${flag}"
+                      stackprot=1
+                  ]
+            )
+            AS_IF([test "${relro}" = 1 || test "${pie}" = 1 || test "${stackprot}" = 1],
+                  [AC_MSG_NOTICE([Hardening: relro=${relro} pie=${pie} bindnow=${bindnow} stackprot=${flag}])],
+                  [AC_MSG_WARN([Hardening: no suitable features in the toolchain detected])]
+            )
+        ],
 )
 
 CFLAGS="$SANITIZERS_CFLAGS $CFLAGS $CC_EXTRAS"
@@ -1841,7 +1844,7 @@ dnl AC_*FUNCS() calls above from working.  In particular, -Werror will
 dnl *always* cause us troubles if we set it before here.
 dnl
 dnl
-AS_IF([test $enable_fatal_warnings -gt 0], [
+AS_IF([test $enable_fatal_warnings -ne $DISABLED], [
     AC_MSG_NOTICE([Enabling fatal compiler warnings])
     CFLAGS="$CFLAGS $WERROR"
 ])
@@ -1856,7 +1859,7 @@ AC_SUBST(LIBADD_DL)        dnl extra flags for dynamic linking libraries
 AC_SUBST(LOCALE)
 
 dnl Options for cleaning up the compiler output
-AS_IF([test $enable_quiet -gt 0],
+AS_IF([test $enable_quiet -ne $DISABLED],
       [
           AC_MSG_NOTICE([Suppressing make details])
           QUIET_LIBTOOL_OPTS="--silent"

--- a/configure.ac
+++ b/configure.ac
@@ -225,6 +225,21 @@ AC_ARG_ENABLE([hardening],
 yes_no_try "$enable_hardening" "try"
 enable_hardening=$?
 
+AC_ARG_ENABLE([compat-2.0],
+    [AS_HELP_STRING([--enable-compat-2.0], m4_normalize([
+	preserve certain output as it was in 2.0; this option will be
+	available only for the lifetime of the 2.1 series @<:@no@:>@]))]
+)
+yes_no_try "$enable_compat_2_0" "no"
+enable_compat_2_0=$?
+AS_IF([test $enable_compat_2_0 -gt 0],
+      [
+          AC_DEFINE_UNQUOTED([PCMK__COMPAT_2_0], [1],
+                             [Keep certain output compatible with 2.0 release series])
+          PCMK_FEATURES="$PCMK_FEATURES compat-2.0"
+      ]
+)
+
 # Add an option to create symlinks at the pre-2.0.0 daemon name locations, so
 # that users and tools can continue to invoke those names directly (e.g., for
 # meta-data). This option will be deprecated in a future release.

--- a/configure.ac
+++ b/configure.ac
@@ -298,13 +298,6 @@ AC_ARG_WITH([bug-url],
 
 dnl --with-* options: features
 
-AC_ARG_WITH([acl],
-    [AS_HELP_STRING([--with-acl],
-        [support CIB Access Control Lists @<:@yes@:>@])]
-)
-yes_no_try "$with_acl" "yes"
-with_acl=$?
-
 AC_ARG_WITH([cibsecrets],
     [AS_HELP_STRING([--with-cibsecrets],
         [support separate file for CIB secrets @<:@no@:>@])]
@@ -1493,19 +1486,6 @@ PCMK_FEATURES="${PCMK_FEATURES}${STACKS}"
 
 AC_SUBST(CLUSTERLIBS)
 AC_SUBST(PC_NAME_CLUSTER)
-
-dnl ========================================================================
-dnl    ACL
-dnl ========================================================================
-
-AS_IF([test $with_acl -gt 0],
-      [
-          with_acl=1
-          PCMK_FEATURES="$PCMK_FEATURES acls"
-      ]
-)
-AM_CONDITIONAL([ENABLE_ACL], [test $with_acl -eq 1])
-AC_DEFINE_UNQUOTED([ENABLE_ACL], [$with_acl], [Support CIB ACLs])
 
 dnl ========================================================================
 dnl    CIB secrets

--- a/configure.ac
+++ b/configure.ac
@@ -317,6 +317,20 @@ AC_ARG_WITH([gnutls-priorities],
     [ test x"$withval" = x"no" || PCMK_GNUTLS_PRIORITIES="$withval" ]
 )
 
+AC_ARG_WITH([concurrent-fencing-default],
+    [AS_HELP_STRING([--with-concurrent-fencing-default],
+        [default value for concurrent-fencing cluster option @<:@false@:>@])],
+)
+AS_CASE([$with_concurrent_fencing_default],
+	[""], [with_concurrent_fencing_default="false"],
+        [false], [],
+        [true], [PCMK_FEATURES="$PCMK_FEATURES default-concurrent-fencing"],
+        [AC_MSG_ERROR([Invalid value "$with_concurrent_fencing_default" for --with-concurrent-fencing-default])]
+)
+AC_DEFINE_UNQUOTED([PCMK__CONCURRENT_FENCING_DEFAULT],
+                   ["$with_concurrent_fencing_default"],
+                   [Default value for concurrent-fencing cluster option])
+
 AC_ARG_WITH([corosync],
     [AS_HELP_STRING([--with-corosync],
         [support the Corosync messaging and membership layer @<:@try@:>@])]

--- a/configure.ac
+++ b/configure.ac
@@ -1502,6 +1502,7 @@ AS_IF([test "$ac_cv_lib_gnutls_gnutls_sec_param_to_pk_bits" != ""], [
                      ],
                      [PC_NAME_GNUTLS=""])
     AC_SUBST(PC_NAME_GNUTLS)
+    AM_CONDITIONAL(BUILD_REMOTE, test "$PC_NAME_GNUTLS" != "")
 ])
 
 dnl ========================================================================

--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,15 @@ AC_ARG_WITH([cibsecrets],
 yes_no_try "$with_cibsecrets" "no"
 with_cibsecrets=$?
 
+AC_ARG_WITH([gnutls],
+    [AS_HELP_STRING([--with-gnutls],
+        [support Pacemaker Remote and remote-tls-port using GnuTLS @<:@try@:>@])]
+)
+with_gnutls=$(yes_no_try "$with_gnutls" "try")
+AS_IF([test $with_gnutls -eq 3],
+      [AC_MSG_ERROR([Invalid value for --with-gnutls])]
+)
+
 PCMK_GNUTLS_PRIORITIES="NORMAL"
 AC_ARG_WITH([gnutls-priorities],
     [AS_HELP_STRING([--with-gnutls-priorities],
@@ -1476,18 +1485,27 @@ dnl ========================================================================
 dnl    GnuTLS
 dnl ========================================================================
 
-dnl Require GnuTLS >=2.12.0 (2011-03) to support Pacemaker Remote
-AC_CHECK_LIB(gnutls, gnutls_sec_param_to_pk_bits)
-AS_IF([test "$ac_cv_lib_gnutls_gnutls_sec_param_to_pk_bits" != ""], [
-    AC_CHECK_HEADERS([gnutls/gnutls.h],
-                     [
-                         PC_NAME_GNUTLS="gnutls"
-                         PCMK_FEATURES="$PCMK_FEATURES remote"
-                     ],
-                     [PC_NAME_GNUTLS=""])
-    AC_SUBST(PC_NAME_GNUTLS)
-    AM_CONDITIONAL(BUILD_REMOTE, test "$PC_NAME_GNUTLS" != "")
-])
+dnl Require GnuTLS >=2.12.0 (2011-03) for Pacemaker Remote support
+PC_NAME_GNUTLS=""
+AS_CASE([$with_gnutls],
+        [1], [
+                 REQUIRE_LIB([gnutls], [gnutls_sec_param_to_pk_bits])
+                 REQUIRE_HEADER([gnutls/gnutls.h])
+             ],
+        [2], [
+                 AC_CHECK_LIB([gnutls], [gnutls_sec_param_to_pk_bits],
+                              [], [with_gnutls=0])
+                 AC_CHECK_HEADERS([gnutls/gnutls.h], [], [with_gnutls=0])
+             ]
+)
+AS_IF([test $with_gnutls -gt 0],
+      [
+          PC_NAME_GNUTLS="gnutls"
+          PCMK_FEATURES="$PCMK_FEATURES remote"
+      ]
+)
+AC_SUBST([PC_NAME_GNUTLS])
+AM_CONDITIONAL([BUILD_REMOTE], [test $with_gnutls -gt 0])
 
 dnl ========================================================================
 dnl    System Health

--- a/configure.ac
+++ b/configure.ac
@@ -1840,36 +1840,36 @@ AC_DEFINE_UNQUOTED(CRM_FEATURES, "$PCMK_FEATURES", Set of enabled features)
 AC_SUBST(PCMK_FEATURES)
 
 dnl Files we output that need to be executable
-AC_CONFIG_FILES([cts/CTSlab.py], [chmod +x cts/CTSlab.py])
-AC_CONFIG_FILES([cts/LSBDummy], [chmod +x cts/LSBDummy])
-AC_CONFIG_FILES([cts/OCFIPraTest.py], [chmod +x cts/OCFIPraTest.py])
-AC_CONFIG_FILES([cts/cluster_test], [chmod +x cts/cluster_test])
-AC_CONFIG_FILES([cts/cts], [chmod +x cts/cts])
-AC_CONFIG_FILES([cts/cts-cli], [chmod +x cts/cts-cli])
-AC_CONFIG_FILES([cts/cts-coverage], [chmod +x cts/cts-coverage])
-AC_CONFIG_FILES([cts/cts-exec], [chmod +x cts/cts-exec])
-AC_CONFIG_FILES([cts/cts-fencing], [chmod +x cts/cts-fencing])
-AC_CONFIG_FILES([cts/cts-log-watcher], [chmod +x cts/cts-log-watcher])
-AC_CONFIG_FILES([cts/cts-regression], [chmod +x cts/cts-regression])
-AC_CONFIG_FILES([cts/cts-scheduler], [chmod +x cts/cts-scheduler])
-AC_CONFIG_FILES([cts/cts-support], [chmod +x cts/cts-support])
-AC_CONFIG_FILES([cts/lxc_autogen.sh], [chmod +x cts/lxc_autogen.sh])
-AC_CONFIG_FILES([cts/benchmark/clubench], [chmod +x cts/benchmark/clubench])
-AC_CONFIG_FILES([cts/fence_dummy], [chmod +x cts/fence_dummy])
-AC_CONFIG_FILES([cts/pacemaker-cts-dummyd], [chmod +x cts/pacemaker-cts-dummyd])
-AC_CONFIG_FILES([daemons/fenced/fence_legacy], [chmod +x daemons/fenced/fence_legacy])
-AC_CONFIG_FILES([doc/abi-check], [chmod +x doc/abi-check])
-AC_CONFIG_FILES([extra/resources/ClusterMon],  [chmod +x extra/resources/ClusterMon])
-AC_CONFIG_FILES([extra/resources/HealthSMART], [chmod +x extra/resources/HealthSMART])
-AC_CONFIG_FILES([extra/resources/SysInfo],     [chmod +x extra/resources/SysInfo])
-AC_CONFIG_FILES([extra/resources/ifspeed],     [chmod +x extra/resources/ifspeed])
-AC_CONFIG_FILES([extra/resources/o2cb],        [chmod +x extra/resources/o2cb])
-AC_CONFIG_FILES([tools/crm_failcount], [chmod +x tools/crm_failcount])
-AC_CONFIG_FILES([tools/crm_master], [chmod +x tools/crm_master])
-AC_CONFIG_FILES([tools/crm_report], [chmod +x tools/crm_report])
-AC_CONFIG_FILES([tools/crm_standby], [chmod +x tools/crm_standby])
-AC_CONFIG_FILES([tools/cibsecret], [chmod +x tools/cibsecret])
-AC_CONFIG_FILES([tools/pcmk_simtimes], [chmod +x tools/pcmk_simtimes])
+CONFIG_FILES_EXEC([cts/CTSlab.py],
+                  [cts/LSBDummy],
+                  [cts/OCFIPraTest.py],
+                  [cts/cluster_test],
+                  [cts/cts],
+                  [cts/cts-cli],
+                  [cts/cts-coverage],
+                  [cts/cts-exec],
+                  [cts/cts-fencing],
+                  [cts/cts-log-watcher],
+                  [cts/cts-regression],
+                  [cts/cts-scheduler],
+                  [cts/cts-support],
+                  [cts/lxc_autogen.sh],
+                  [cts/benchmark/clubench],
+                  [cts/fence_dummy],
+                  [cts/pacemaker-cts-dummyd],
+                  [daemons/fenced/fence_legacy],
+                  [doc/abi-check],
+                  [extra/resources/ClusterMon],
+                  [extra/resources/HealthSMART],
+                  [extra/resources/SysInfo],
+                  [extra/resources/ifspeed],
+                  [extra/resources/o2cb],
+                  [tools/crm_failcount],
+                  [tools/crm_master],
+                  [tools/crm_report],
+                  [tools/crm_standby],
+                  [tools/cibsecret],
+                  [tools/pcmk_simtimes])
 
 dnl Other files we output
 AC_CONFIG_FILES(Makefile                                            \

--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,26 @@ cc_restore_flags() {
     CFLAGS=$ac_save_CFLAGS
 }
 
+# yes_no_try $user_response $default
+yes_no_try() {
+    local value
+    AS_IF([test x"$1" = x""], [value="$2"], [value="$1"])
+    AS_CASE(["`echo "$value" | tr '[A-Z]' '[a-z]'`"],
+            [0|no|false|disable], [return 0],
+            [1|yes|true|enable], [return 1],
+            [try|check], [return 2]
+    )
+    AC_MSG_ERROR([Invalid option value "$value"])
+}
+
+check_systemdsystemunitdir() {
+    AC_MSG_CHECKING([which system unit file directory to use])
+    PKG_CHECK_VAR([systemdsystemunitdir], [systemd], [systemdsystemunitdir])
+    AC_MSG_RESULT([${systemdsystemunitdir}])
+    test x"$systemdsystemunitdir" != x""
+    return $?
+}
+
 dnl ===============================================
 dnl Configure Options
 dnl ===============================================
@@ -172,47 +192,49 @@ dnl --enable-* options
 
 AC_ARG_ENABLE([fatal-warnings],
     [AS_HELP_STRING([--enable-fatal-warnings],
-        [enable pedantic and fatal warnings for gcc @<:@yes@:>@])],
+        [enable pedantic and fatal warnings for gcc @<:@try@:>@])],
 )
+yes_no_try "$enable_fatal_warnings" "try"
+enable_fatal_warnings=$?
 
 AC_ARG_ENABLE([quiet],
     [AS_HELP_STRING([--enable-quiet],
-        [suppress make output unless there is an error @<:@no@:>@])],
-    [],
-    [enable_quiet=no],
+        [suppress make output unless there is an error @<:@no@:>@])]
 )
+yes_no_try "$enable_quiet" "no"
+enable_quiet=$?
 
 AC_ARG_ENABLE([upstart],
     [AS_HELP_STRING([--enable-upstart],
-        [enable support for managing resources via Upstart @<:@try@:>@])],
-    [],
-    [enable_upstart=try],
+        [enable support for managing resources via Upstart @<:@try@:>@])]
 )
+yes_no_try "$enable_upstart" "try"
+enable_upstart=$?
 
 AC_ARG_ENABLE([systemd],
     [AS_HELP_STRING([--enable-systemd],
-        [enable support for managing resources via systemd @<:@try@:>@])],
-    [],
-    [enable_systemd=try],
+        [enable support for managing resources via systemd @<:@try@:>@])]
 )
+yes_no_try "$enable_systemd" "try"
+enable_systemd=$?
 
 AC_ARG_ENABLE([hardening],
     [AS_HELP_STRING([--enable-hardening],
-        [harden the resulting executables/libraries @<:@try@:>@])],
-    [ HARDENING="${enableval}" ],
-    [ HARDENING=try ],
+        [harden the resulting executables/libraries @<:@try@:>@])]
 )
+yes_no_try "$enable_hardening" "try"
+enable_hardening=$?
 
 # Add an option to create symlinks at the pre-2.0.0 daemon name locations, so
 # that users and tools can continue to invoke those names directly (e.g., for
 # meta-data). This option will be deprecated in a future release.
 AC_ARG_ENABLE([legacy-links],
     [AS_HELP_STRING([--enable-legacy-links],
-        [add symlinks for old daemon names @<:@no@:>@])],
-    [ LEGACY_LINKS="${enableval}" ],
-    [ LEGACY_LINKS=no ],
+        [add symlinks for old daemon names @<:@no@:>@])]
 )
-AM_CONDITIONAL(BUILD_LEGACY_LINKS, test "x${LEGACY_LINKS}" = "xyes")
+yes_no_try "$enable_legacy_links" "no"
+enable_legacy_links=$?
+AM_CONDITIONAL([BUILD_LEGACY_LINKS], [test $enable_legacy_links -gt 0])
 
 
 dnl --with-* options
@@ -227,17 +249,17 @@ VERSION_ARG(VERSION_NUMBER)
 
 AC_ARG_WITH([corosync],
     [AS_HELP_STRING([--with-corosync],
-        [support the Corosync messaging and membership layer])],
-    [ SUPPORT_CS=$withval ],
-    [ SUPPORT_CS=try ],
+        [support the Corosync messaging and membership layer @<:@try@:>@])]
 )
+yes_no_try "$with_corosync" "try"
+with_corosync=$?
 
 AC_ARG_WITH([nagios],
     [AS_HELP_STRING([--with-nagios],
-        [support nagios remote monitoring])],
-    [ SUPPORT_NAGIOS=$withval ],
-    [ SUPPORT_NAGIOS=try ],
+        [support nagios remote monitoring])]
 )
+yes_no_try "$with_nagios" "try"
+with_nagios=$?
 
 AC_ARG_WITH([nagios-plugin-dir],
     [AS_HELP_STRING([--with-nagios-plugin-dir=DIR],
@@ -253,17 +275,17 @@ AC_ARG_WITH([nagios-metadata-dir],
 
 AC_ARG_WITH([acl],
     [AS_HELP_STRING([--with-acl],
-        [support CIB ACL])],
-    [ SUPPORT_ACL=$withval ],
-    [ SUPPORT_ACL=yes ],
+        [support CIB Access Control Lists @<:@yes@:>@])]
 )
+yes_no_try "$with_acl" "yes"
+with_acl=$?
 
 AC_ARG_WITH([cibsecrets],
     [AS_HELP_STRING([--with-cibsecrets],
-        [support separate file for CIB secrets])],
-    [ SUPPORT_CIBSECRETS=$withval ],
-    [ SUPPORT_CIBSECRETS=no ],
+        [support separate file for CIB secrets @<:@no@:>@])]
 )
+yes_no_try "$with_cibsecrets" "no"
+with_cibsecrets=$?
 
 PCMK_GNUTLS_PRIORITIES="NORMAL"
 AC_ARG_WITH([gnutls-priorities],
@@ -286,18 +308,19 @@ AC_ARG_WITH([systemdsystemunitdir],
     [ systemdsystemunitdir="$withval" ]
 )
 
-SUPPORT_PROFILING=0
 AC_ARG_WITH([profiling],
     [AS_HELP_STRING([--with-profiling],
-        [disable optimizations for effective profiling])],
-    [ SUPPORT_PROFILING=$withval ]
+        [disable optimizations, for effective profiling @<:@no@:>@])]
 )
+yes_no_try "$with_profiling" "no"
+with_profiling=$?
 
 AC_ARG_WITH([coverage],
     [AS_HELP_STRING([--with-coverage],
-        [disable optimizations for effective profiling])],
-    [ SUPPORT_COVERAGE=$withval ]
+        [disable optimizations, for effective profiling and coverage testing @<:@no@:>@])]
 )
+yes_no_try "$with_coverage" "no"
+with_coverage=$?
 
 BUG_URL=""
 AC_ARG_WITH([bug-url],
@@ -403,17 +426,18 @@ AC_SUBST(PACKAGE_VERSION)
 AC_PROG_LN_S
 AC_PROG_MKDIR_P
 
-AS_IF([cc_supports_flag -Werror], [WERROR="-Werror"], [WERROR=""])
-
-# Normalize enable_fatal_warnings (defaulting to yes, when compiler supports it)
-if test "x${enable_fatal_warnings}" != "xno" ; then
-    if test "$GCC" = "yes" && test "x${WERROR}" != "x" ; then
-        enable_fatal_warnings=yes
-    else
-        AC_MSG_NOTICE([Compiler does not support fatal warnings])
-        enable_fatal_warnings=no
-    fi
-fi
+# Check for fatal warning support
+AS_IF([test $enable_fatal_warnings -gt 0 && test "$GCC" = "yes" && cc_supports_flag -Werror],
+      [WERROR="-Werror"],
+      [
+          WERROR=""
+          AS_CASE([$enable_fatal_warnings],
+                  [1], [AC_MSG_ERROR([Compiler does not support fatal warnings])],
+                  [2], [
+                           AC_MSG_NOTICE([Compiler does not support fatal warnings])
+                           enable_fatal_warnings=0
+                       ])
+      ])
 
 AC_MSG_NOTICE([Sanitizing prefix: ${prefix}])
 AS_IF([test "$prefix" = "NONE"],
@@ -856,8 +880,7 @@ dnl ========================================================================
 # enable fatal warnings for the build, then enable them for the header checks
 # as well, otherwise the build could fail even though the header check
 # succeeds. (We should probably be doing this in more places.)
-AS_IF([test "x${enable_fatal_warnings}" = xyes],
-      [cc_temp_flags "$CFLAGS $WERROR"])
+cc_temp_flags "$CFLAGS $WERROR"
 
 # Optional headers (inclusion of these should be conditional in C code)
 AC_CHECK_HEADERS([getopt.h])
@@ -902,7 +925,7 @@ REQUIRE_HEADER([unistd.h])
 REQUIRE_HEADER([libxml/xpath.h])
 REQUIRE_HEADER([libxslt/xslt.h])
 
-AS_IF([test "x${enable_fatal_warnings}" = xyes], [cc_restore_flags])
+cc_restore_flags
 
 AC_CHECK_FUNCS([uuid_unparse], [],
                [AC_MSG_FAILURE([Could not find required C function uuid_unparse()])])
@@ -1077,40 +1100,39 @@ dnl    Profiling and GProf
 dnl ========================================================================
 
 CFLAGS_ORIG="$CFLAGS"
-case $SUPPORT_COVERAGE in
-    1|yes|true)
-        SUPPORT_PROFILING=1
+AS_IF([test $with_coverage -gt 0],
+      [
+        with_profiling=1
         PCMK_FEATURES="$PCMK_FEATURES coverage"
         CFLAGS="$CFLAGS -fprofile-arcs -ftest-coverage"
         dnl During linking, make sure to specify -lgcov or -coverage
-        ;;
-esac
+      ]
+)
 
-case $SUPPORT_PROFILING in
-    1|yes|true)
-        SUPPORT_PROFILING=1
-
-        dnl Disable various compiler optimizations
-        CFLAGS="$CFLAGS -fno-omit-frame-pointer -fno-inline -fno-builtin "
-        dnl CFLAGS="$CFLAGS -fno-inline-functions -fno-default-inline -fno-inline-functions-called-once -fno-optimize-sibling-calls"
-
-        dnl Turn off optimization so tools can get accurate line numbers
-        CFLAGS=`echo $CFLAGS | sed -e 's/-O.\ //g' -e 's/-Wp,-D_FORTIFY_SOURCE=.\ //g' -e 's/-D_FORTIFY_SOURCE=.\ //g'`
-        CFLAGS="$CFLAGS -O0 -g3 -gdwarf-2"
-
-        dnl Update features
-        PCMK_FEATURES="$PCMK_FEATURES profile"
-        ;;
-     *)
-        SUPPORT_PROFILING=0
-        ;;
-esac
-AS_IF([test ${SUPPORT_PROFILING} -eq 0], [],
+AS_IF([test $with_profiling -gt 0],
       [
+          with_profiling=1
+          PCMK_FEATURES="$PCMK_FEATURES profile"
+
+          dnl Disable various compiler optimizations
+          CFLAGS="$CFLAGS -fno-omit-frame-pointer -fno-inline -fno-builtin"
+          dnl CFLAGS="$CFLAGS -fno-inline-functions"
+          dnl CFLAGS="$CFLAGS -fno-default-inline"
+          dnl CFLAGS="$CFLAGS -fno-inline-functions-called-once"
+          dnl CFLAGS="$CFLAGS -fno-optimize-sibling-calls"
+
+          dnl Turn off optimization so tools can get accurate line numbers
+          CFLAGS=`echo $CFLAGS | sed \
+                  -e 's/-O.\ //g' \
+                  -e 's/-Wp,-D_FORTIFY_SOURCE=.\ //g' \
+                  -e 's/-D_FORTIFY_SOURCE=.\ //g'`
+          CFLAGS="$CFLAGS -O0 -g3 -gdwarf-2"
+
           AC_MSG_NOTICE([CFLAGS before adding profiling options: $CFLAGS_ORIG])
           AC_MSG_NOTICE([CFLAGS after: $CFLAGS])
-      ])
-AC_DEFINE_UNQUOTED(SUPPORT_PROFILING, $SUPPORT_PROFILING, Support for profiling)
+      ]
+)
+AC_DEFINE_UNQUOTED([SUPPORT_PROFILING], [$with_profiling], [Support profiling])
 
 dnl ========================================================================
 dnl    Cluster infrastructure - LibQB
@@ -1241,128 +1263,108 @@ else
 fi
 AC_SUBST(PC_NAME_DBUS)
 
-if test "x${enable_systemd}" != xno; then
-    if test $HAVE_dbus = 0; then
-        if test "x${enable_systemd}" = xyes; then
-            AC_MSG_FAILURE([Cannot support systemd resources without DBus])
-        else
-            enable_systemd=no
-        fi
-    fi
-    if test $(echo "$CPPFLAGS" | grep -q PCMK_TIME_EMERGENCY_CGT) \
-            || test "x$ac_cv_have_decl_CLOCK_MONOTONIC" = xno; then
-        if test "x${enable_systemd}" = xyes; then
-            AC_MSG_FAILURE([Cannot support systemd resources without clock_gettime(CLOCK_MONOTONIC, ...)])
-        else
-            enable_systemd=no
-        fi
-    fi
-    if test "x${enable_systemd}" = xtry; then
-        AC_MSG_CHECKING([for systemd version (using dbus-send)])
-        ret=$({ dbus-send --system --print-reply \
-                    --dest=org.freedesktop.systemd1 \
-                    /org/freedesktop/systemd1 \
-                    org.freedesktop.DBus.Properties.Get \
-                    string:org.freedesktop.systemd1.Manager \
-                    string:Version 2>/dev/null \
-                || echo "version unavailable"; } | tail -n1)
-        # sanitize output a bit (interested just in value, not type),
-        # ret is intentionally unenquoted so as to normalize whitespace
-        ret=$(echo ${ret} | cut -d' ' -f2-)
-        AC_MSG_RESULT([${ret}])
-        if test "x${ret}" != xunavailable \
-           || systemctl --version 2>/dev/null | grep -q systemd; then
-            enable_systemd=yes
-        else
-            enable_systemd=no
-        fi
-    fi
-fi
-
+AS_CASE([$enable_systemd],
+        [1], [
+                 AS_IF([test $HAVE_dbus = 0],
+                       [AC_MSG_FAILURE([Cannot support systemd resources without DBus])])
+                 AS_IF([test "$ac_cv_have_decl_CLOCK_MONOTONIC" = "no"],
+                       [AC_MSG_FAILURE([Cannot support systemd resources without monotonic clock])])
+                 AS_IF([check_systemdsystemunitdir], [],
+                       [AC_MSG_FAILURE([Cannot support systemd resources without systemdsystemunitdir])])
+             ],
+        [2], [
+                 AS_IF([test $HAVE_dbus = 0 \
+                        || test "$ac_cv_have_decl_CLOCK_MONOTONIC" = "no"],
+                       [enable_systemd=0],
+                       [
+                           AC_MSG_CHECKING([for systemd version (using dbus-send)])
+                           ret=$({ dbus-send --system --print-reply \
+                                       --dest=org.freedesktop.systemd1 \
+                                       /org/freedesktop/systemd1 \
+                                       org.freedesktop.DBus.Properties.Get \
+                                       string:org.freedesktop.systemd1.Manager \
+                                       string:Version 2>/dev/null \
+                                   || echo "version unavailable"; } | tail -n1)
+                           # sanitize output a bit (interested just in value, not type),
+                           # ret is intentionally unenquoted so as to normalize whitespace
+                           ret=$(echo ${ret} | cut -d' ' -f2-)
+                           AC_MSG_RESULT([${ret}])
+                           AS_IF([test "$ret" != "unavailable" \
+                                  || systemctl --version 2>/dev/null | grep -q systemd],
+                                 [
+                                     AS_IF([check_systemdsystemunitdir],
+                                           [enable_systemd=1],
+                                           [enable_systemd=0])
+                                 ],
+                                 [enable_systemd=0]
+                           )
+                       ])
+             ],
+)
 AC_MSG_CHECKING([whether to enable support for managing resources via systemd])
-AC_MSG_RESULT([${enable_systemd}])
-HAVE_systemd=0
-AS_IF([test "x${enable_systemd}" = xyes], [
-    HAVE_systemd=1
-    PCMK_FEATURES="$PCMK_FEATURES systemd"
-
-    AC_MSG_CHECKING([which system unit file directory to use])
-    PKG_CHECK_VAR([systemdsystemunitdir], [systemd], [systemdsystemunitdir])
-    AC_MSG_RESULT([${systemdsystemunitdir}])
-    AS_IF([test "x${systemdsystemunitdir}" != x""], [],
-          [AC_MSG_FAILURE([Cannot enable systemd because systemdsystemunitdir is unknown])])
-])
+AS_IF([test $enable_systemd -eq 0], [AC_MSG_RESULT([no])],
+      [
+          AC_MSG_RESULT([yes])
+          PCMK_FEATURES="$PCMK_FEATURES systemd"
+      ]
+)
 AC_SUBST([systemdsystemunitdir])
-
-AC_DEFINE_UNQUOTED(SUPPORT_SYSTEMD, $HAVE_systemd, Support systemd based system services)
-AM_CONDITIONAL(BUILD_SYSTEMD, test $HAVE_systemd = 1)
+AC_DEFINE_UNQUOTED([SUPPORT_SYSTEMD], [$enable_systemd],
+                   [Support systemd resources])
+AM_CONDITIONAL([BUILD_SYSTEMD], [test $enable_systemd = 1])
 AC_SUBST(SUPPORT_SYSTEMD)
 
-if test "x${enable_upstart}" != xno; then
-    if test $HAVE_dbus = 0; then
-        if test "x${enable_upstart}" = xyes; then
-            AC_MSG_FAILURE([Cannot support Upstart resources without DBus])
-        else
-            enable_upstart=no
-        fi
-    fi
-    if test "x${enable_upstart}" = xtry; then
-        AC_MSG_CHECKING([for Upstart version (using dbus-send)])
-        ret=$({ dbus-send --system --print-reply --dest=com.ubuntu.Upstart \
-                    /com/ubuntu/Upstart org.freedesktop.DBus.Properties.Get \
-                    string:com.ubuntu.Upstart0_6 string:version 2>/dev/null \
-                || echo "version unavailable"; } | tail -n1)
-        # sanitize output a bit (interested just in value, not type),
-        # ret is intentionally unenquoted so as to normalize whitespace
-        ret=$(echo ${ret} | cut -d' ' -f2-)
-        AC_MSG_RESULT([${ret}])
-        if test "x${ret}" != xunavailable \
-           || initctl --version 2>/dev/null | grep -q upstart; then
-            enable_upstart=yes
-        else
-            enable_upstart=no
-        fi
-    fi
-fi
+AS_CASE([$enable_upstart],
+        [1], [
+                 AS_IF([test $HAVE_dbus = 0],
+                       [AC_MSG_FAILURE([Cannot support Upstart resources without DBus])])
+             ],
+        [2], [
+                 AS_IF([test $HAVE_dbus = 0], [enable_upstart=0],
+                       [
+                           AC_MSG_CHECKING([for Upstart version (using dbus-send)])
+                           ret=$({ dbus-send --system --print-reply \
+                                       --dest=com.ubuntu.Upstart \
+                                       /com/ubuntu/Upstart org.freedesktop.DBus.Properties.Get \
+                                       string:com.ubuntu.Upstart0_6 string:version 2>/dev/null \
+                                   || echo "version unavailable"; } | tail -n1)
+                           # sanitize output a bit (interested just in value, not type),
+                           # ret is intentionally unenquoted so as to normalize whitespace
+                           ret=$(echo ${ret} | cut -d' ' -f2-)
+                           AC_MSG_RESULT([${ret}])
+                           AS_IF([test "$ret" != "unavailable" \
+                                  || initctl --version 2>/dev/null | grep -q upstart],
+                                 [enable_upstart=1],
+                                 [enable_upstart=0]
+                           )
+                       ])
+             ],
+)
 AC_MSG_CHECKING([whether to enable support for managing resources via Upstart])
-AC_MSG_RESULT([${enable_upstart}])
-HAVE_upstart=0
-if test "x${enable_upstart}" = xyes; then
-    HAVE_upstart=1
-    PCMK_FEATURES="$PCMK_FEATURES upstart"
-fi
-
-AC_DEFINE_UNQUOTED(SUPPORT_UPSTART, $HAVE_upstart, Support upstart based system services)
-AM_CONDITIONAL(BUILD_UPSTART, test $HAVE_upstart = 1)
+AS_IF([test $enable_upstart -eq 0], [AC_MSG_RESULT([no])],
+      [
+          AC_MSG_RESULT([yes])
+          PCMK_FEATURES="$PCMK_FEATURES upstart"
+      ]
+)
+AC_DEFINE_UNQUOTED([SUPPORT_UPSTART], [$enable_upstart],
+                   [Support Upstart resources])
+AM_CONDITIONAL([BUILD_UPSTART], [test $enable_upstart = 1])
 AC_SUBST(SUPPORT_UPSTART)
 
-case $SUPPORT_NAGIOS in
-    1|yes|true)
-        if test $(echo "CPPFLAGS" | grep -q PCMK_TIME_EMERGENCY_CGT) \
-            || test "x$ac_cv_have_decl_CLOCK_MONOTONIC" = xno; then
-                AC_MSG_FAILURE([Cannot support nagios resources without clock_gettime(CLOCK_MONOTONIC, ...)])
-        fi
-        SUPPORT_NAGIOS=1
-        ;;
-    try)
-        if test $(echo "CPPFLAGS" | grep -q PCMK_TIME_EMERGENCY_CGT) \
-                || test "x$ac_cv_have_decl_CLOCK_MONOTONIC" = xno; then
-            SUPPORT_NAGIOS=0
-        else
-            SUPPORT_NAGIOS=1
-        fi
-        ;;
-    *)
-        SUPPORT_NAGIOS=0
-        ;;
-esac
-
-if test $SUPPORT_NAGIOS = 1; then
-    PCMK_FEATURES="$PCMK_FEATURES nagios"
-fi
-
-AC_DEFINE_UNQUOTED(SUPPORT_NAGIOS, $SUPPORT_NAGIOS, Support nagios plugins)
-AM_CONDITIONAL(BUILD_NAGIOS, test $SUPPORT_NAGIOS = 1)
+AS_CASE([$with_nagios],
+        [1], [
+                 AS_IF([test "$ac_cv_have_decl_CLOCK_MONOTONIC" = "no"],
+                       [AC_MSG_FAILURE([Cannot support nagios resources without monotonic clock])])
+             ],
+        [2], [
+                 AS_IF([test "$ac_cv_have_decl_CLOCK_MONOTONIC" = "no"],
+                       [with_nagios=0], [with_nagios=1])
+             ]
+)
+AS_IF([test $with_nagios = 1], [PCMK_FEATURES="$PCMK_FEATURES nagios"])
+AC_DEFINE_UNQUOTED([SUPPORT_NAGIOS], [$with_nagios], [Support nagios plugins])
+AM_CONDITIONAL([BUILD_NAGIOS], [test $with_nagios = 1])
 
 if test x"$NAGIOS_PLUGIN_DIR" = x""; then
     NAGIOS_PLUGIN_DIR="${libexecdir}/nagios/plugins"
@@ -1386,37 +1388,30 @@ dnl ========================================================================
 dnl    Cluster stack - Corosync
 dnl ========================================================================
 
-dnl Normalize the values
-case $SUPPORT_CS in
-    1|yes|true)
-        SUPPORT_CS=yes
-        missingisfatal=1
-        ;;
-    try)
-        missingisfatal=0
-        ;;
-    *)
-        SUPPORT_CS=no
-        ;;
-esac
-
-AC_MSG_CHECKING([for Corosync 2 or later])
 COROSYNC_LIBS=""
 
-AS_IF([test $SUPPORT_CS = no],
+AS_CASE([$with_corosync],
+        [1], [
+                 # These will be fatal if unavailable
+                 PKG_CHECK_MODULES([cpg], [libcpg])
+                 PKG_CHECK_MODULES([cfg], [libcfg])
+                 PKG_CHECK_MODULES([cmap], [libcmap])
+                 PKG_CHECK_MODULES([quorum], [libquorum])
+                 PKG_CHECK_MODULES([libcorosync_common], [libcorosync_common])
+             ]
+        [2], [
+                 PKG_CHECK_MODULES([cpg], [libcpg], [], [with_corosync=0])
+                 PKG_CHECK_MODULES([cfg], [libcfg], [], [with_corosync=0])
+                 PKG_CHECK_MODULES([cmap], [libcmap], [], [with_corosync=0])
+                 PKG_CHECK_MODULES([quorum], [libquorum], [], [with_corosync=0])
+                 PKG_CHECK_MODULES([libcorosync_common], [libcorosync_common], [], [with_corosync=0])
+                 AS_IF([test $with_corosync -gt 0], [with_corosync=1])
+             ]
+)
+AS_IF([test $with_corosync -gt 0],
       [
-          AC_MSG_RESULT([no (disabled)])
-          SUPPORT_CS=0
-      ],
-      [
-          AC_MSG_RESULT([$SUPPORT_CS])
-          SUPPORT_CS=1
-          PKG_CHECK_MODULES(cpg,    libcpg) dnl Fatal
-          PKG_CHECK_MODULES(cfg,    libcfg) dnl Fatal
-          PKG_CHECK_MODULES(cmap,   libcmap) dnl Fatal
-          PKG_CHECK_MODULES(quorum, libquorum) dnl Fatal
-          PKG_CHECK_MODULES(libcorosync_common, libcorosync_common) dnl Fatal
-
+          AC_MSG_CHECKING([for Corosync 2 or later])
+          AC_MSG_RESULT([yes])
           CFLAGS="$CFLAGS $libqb_CFLAGS $cpg_CFLAGS $cfg_CFLAGS $cmap_CFLAGS $quorum_CFLAGS $libcorosync_common_CFLAGS"
           COROSYNC_LIBS="$COROSYNC_LIBS $cpg_LIBS $cfg_LIBS $cmap_LIBS $quorum_LIBS $libcorosync_common_LIBS"
           CLUSTERLIBS="$CLUSTERLIBS $COROSYNC_LIBS"
@@ -1430,11 +1425,12 @@ AS_IF([test $SUPPORT_CS = no],
           AC_DEFINE(HAVE_COROSYNC_CFG_TRACKSTART, 1,
                          [Have corosync_cfg_trackstart function]))
           LIBS="$saved_LIBS"
-     ])
-
-AC_DEFINE_UNQUOTED(SUPPORT_COROSYNC, $SUPPORT_CS,    Support the Corosync messaging and membership layer)
-AM_CONDITIONAL(BUILD_CS_SUPPORT, test $SUPPORT_CS = 1)
-AC_SUBST(SUPPORT_COROSYNC)
+      ]
+)
+AC_DEFINE_UNQUOTED([SUPPORT_COROSYNC], [$with_corosync],
+                   [Support the Corosync messaging and membership layer])
+AM_CONDITIONAL([BUILD_CS_SUPPORT], [test $with_corosync -eq 1])
+AC_SUBST([SUPPORT_COROSYNC])
 
 dnl
 dnl    Cluster stack - Sanity
@@ -1452,41 +1448,31 @@ dnl ========================================================================
 dnl    ACL
 dnl ========================================================================
 
-case $SUPPORT_ACL in
-    1|yes|true|try)
-        SUPPORT_ACL=1
-        PCMK_FEATURES="$PCMK_FEATURES acls"
-        ;;
-    *)
-        SUPPORT_ACL=0
-        ;;
-esac
-AM_CONDITIONAL(ENABLE_ACL, test "$SUPPORT_ACL" = "1")
-AC_DEFINE_UNQUOTED(ENABLE_ACL, $SUPPORT_ACL, Build in support for CIB ACL)
+AS_IF([test $with_acl -gt 0],
+      [
+          with_acl=1
+          PCMK_FEATURES="$PCMK_FEATURES acls"
+      ]
+)
+AM_CONDITIONAL([ENABLE_ACL], [test $with_acl -eq 1])
+AC_DEFINE_UNQUOTED([ENABLE_ACL], [$with_acl], [Support CIB ACLs])
 
 dnl ========================================================================
 dnl    CIB secrets
 dnl ========================================================================
 
-case $SUPPORT_CIBSECRETS in
-    1|yes|true|try)
-        SUPPORT_CIBSECRETS=1
-        ;;
-    *)
-        SUPPORT_CIBSECRETS=0
-        ;;
-esac
-
-AC_DEFINE_UNQUOTED(SUPPORT_CIBSECRETS, $SUPPORT_CIBSECRETS, Support CIB secrets)
-AM_CONDITIONAL(BUILD_CIBSECRETS, test $SUPPORT_CIBSECRETS = 1)
-
-AS_IF([test $SUPPORT_CIBSECRETS = 1], [
-    PCMK_FEATURES="$PCMK_FEATURES cibsecrets"
-
-    LRM_CIBSECRETS_DIR="${localstatedir}/lib/pacemaker/lrm/secrets"
-    AC_DEFINE_UNQUOTED(LRM_CIBSECRETS_DIR,"$LRM_CIBSECRETS_DIR", Location for CIB secrets)
-    AC_SUBST(LRM_CIBSECRETS_DIR)
-])
+AS_IF([test $with_cibsecrets -gt 0],
+      [
+          with_cibsecrets=1
+          PCMK_FEATURES="$PCMK_FEATURES cibsecrets"
+          LRM_CIBSECRETS_DIR="${localstatedir}/lib/pacemaker/lrm/secrets"
+          AC_DEFINE_UNQUOTED([LRM_CIBSECRETS_DIR], ["$LRM_CIBSECRETS_DIR"],
+                             [Location for CIB secrets])
+          AC_SUBST([LRM_CIBSECRETS_DIR])
+      ]
+)
+AC_DEFINE_UNQUOTED([SUPPORT_CIBSECRETS], [$with_cibsecrets], [Support CIB secrets])
+AM_CONDITIONAL([BUILD_CIBSECRETS], [test $with_cibsecrets -eq 1])
 
 dnl ========================================================================
 dnl    GnuTLS
@@ -1711,84 +1697,95 @@ dnl https://fedoraproject.org/wiki/Changes/Harden_All_Packages#Detailed_Harden_F
 dnl https://owasp.org/index.php/C-Based_Toolchain_Hardening#GCC.2FBinutils
 dnl
 
-if test "x${HARDENING}" != "xtry"; then
-    unset CFLAGS_HARDENED_EXE
-    unset CFLAGS_HARDENED_LIB
-    unset LDFLAGS_HARDENED_EXE
-    unset LDFLAGS_HARDENED_LIB
-fi
-AS_IF([test "x${HARDENING}" = "xno"],
-      [AC_MSG_NOTICE([Hardening: explicitly disabled])],
-      [test "x${HARDENING}" = "xyes" || test "$(env | grep -Ec '^(C|LD)FLAGS_HARDENED_(EXE|LIB)=.')" = 0],
+AS_IF([test $enable_hardening -lt 2],
       [
-          dnl We'll figure out on our own...
-          CFLAGS_HARDENED_EXE=
-          CFLAGS_HARDENED_LIB=
-          LDFLAGS_HARDENED_EXE=
-          LDFLAGS_HARDENED_LIB=
-          relro=0
-          pie=0
-          bindnow=0
-          # daemons incl. libs: partial RELRO
-          flag="-Wl,-z,relro"
-          CC_CHECK_LDFLAGS(["${flag}"],
-                           [
-                               LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}";
-                               LDFLAGS_HARDENED_LIB="${LDFLAGS_HARDENED_LIB} ${flag}";
-                               relro=1
-                           ])
-          # daemons: PIE for both CFLAGS and LDFLAGS
-          AS_IF([cc_supports_flag -fPIE],
-                [
-                    flag="-pie"
-                    CC_CHECK_LDFLAGS(["${flag}"],
-                                     [
-                                         CFLAGS_HARDENED_EXE="${CFLAGS_HARDENED_EXE} -fPIE";
-                                         LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}";
-                                         pie=1
-                                     ])
-                ])
-          # daemons incl. libs: full RELRO if sensible + as-needed linking
-          #                     so as to possibly mitigate startup performance
-          #                     hit caused by excessive linking with unneeded
-          #                     libraries
-          AS_IF([test "${relro}" = 1 && test "${pie}" = 1],
-                [
-                    flag="-Wl,-z,now"
-                    CC_CHECK_LDFLAGS(["${flag}"],
-                                     [
-                                         LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}";
-                                         LDFLAGS_HARDENED_LIB="${LDFLAGS_HARDENED_LIB} ${flag}";
-                                         bindnow=1
-                                     ])
-                ])
-          AS_IF([test "${bindnow}" = 1],
-                [
-                    flag="-Wl,--as-needed"
-                    CC_CHECK_LDFLAGS(["${flag}"],
-                                     [
-                                         LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}";
-                                         LDFLAGS_HARDENED_LIB="${LDFLAGS_HARDENED_LIB} ${flag}"
-                                     ])
-                ])
-          # universal: prefer strong > all > default stack protector if possible
-          flag=
-          AS_IF([cc_supports_flag -fstack-protector-strong],
-                [flag="-fstack-protector-strong"],
-                [cc_supports_flag -fstack-protector-all],
-                [flag="-fstack-protector-all"],
-                [cc_supports_flag -fstack-protector],
-                [flag="-fstack-protector"])
-          AS_IF([test -n "${flag}"],
-                [
-                    CC_EXTRAS="${CC_EXTRAS} ${flag}"
-                    stackprot=1
-                ])
-          AS_IF([test "${relro}" = 1 || test "${pie}" = 1 || test "${stackprot}" = 1],
-                [AC_MSG_NOTICE([Hardening: relro=${relro} pie=${pie} bindnow=${bindnow} stackprot=${flag}])],
-                [AC_MSG_WARN([Hardening: no suitable features in the toolchain detected])])
+          unset CFLAGS_HARDENED_EXE
+          unset CFLAGS_HARDENED_LIB
+          unset LDFLAGS_HARDENED_EXE
+          unset LDFLAGS_HARDENED_LIB
       ],
-      [AC_MSG_NOTICE([Hardening: using custom flags])])
+      [
+          AS_IF([test "$(env | grep -Ec '^(C|LD)FLAGS_HARDENED_(EXE|LIB)=.')" = 0],
+                [enable_hardening=1],
+                [AC_MSG_NOTICE([Hardening: using custom flags from environment])]
+          )
+      ]
+)
+AS_CASE([$enable_hardening],
+        [0], [AC_MSG_NOTICE([Hardening: explicitly disabled])],
+        [1], [
+                 CFLAGS_HARDENED_EXE=
+                 CFLAGS_HARDENED_LIB=
+                 LDFLAGS_HARDENED_EXE=
+                 LDFLAGS_HARDENED_LIB=
+                 relro=0
+                 pie=0
+                 bindnow=0
+                 # daemons incl. libs: partial RELRO
+                 flag="-Wl,-z,relro"
+                 CC_CHECK_LDFLAGS(["${flag}"],
+                                  [
+                                      LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}"
+                                      LDFLAGS_HARDENED_LIB="${LDFLAGS_HARDENED_LIB} ${flag}"
+                                      relro=1
+                                  ])
+                 # daemons: PIE for both CFLAGS and LDFLAGS
+                 AS_IF([cc_supports_flag -fPIE],
+                       [
+                           flag="-pie"
+                           CC_CHECK_LDFLAGS(["${flag}"],
+                                            [
+                                                CFLAGS_HARDENED_EXE="${CFLAGS_HARDENED_EXE} -fPIE"
+                                                LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}"
+                                                pie=1
+                                            ])
+                       ]
+                 )
+                 # daemons incl. libs: full RELRO if sensible + as-needed linking
+                 #                     so as to possibly mitigate startup performance
+                 #                     hit caused by excessive linking with unneeded
+                 #                     libraries
+                 AS_IF([test "${relro}" = 1 && test "${pie}" = 1],
+                       [
+                           flag="-Wl,-z,now"
+                           CC_CHECK_LDFLAGS(["${flag}"],
+                                            [
+                                                LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}"
+                                                LDFLAGS_HARDENED_LIB="${LDFLAGS_HARDENED_LIB} ${flag}"
+                                                bindnow=1
+                                            ])
+                       ]
+                 )
+                 AS_IF([test "${bindnow}" = 1],
+                       [
+                           flag="-Wl,--as-needed"
+                           CC_CHECK_LDFLAGS(["${flag}"],
+                                            [
+                                                LDFLAGS_HARDENED_EXE="${LDFLAGS_HARDENED_EXE} ${flag}"
+                                                LDFLAGS_HARDENED_LIB="${LDFLAGS_HARDENED_LIB} ${flag}"
+                                            ])
+                       ])
+                 # universal: prefer strong > all > default stack protector if possible
+                 flag=
+                 AS_IF([cc_supports_flag -fstack-protector-strong],
+                       [flag="-fstack-protector-strong"],
+                       [cc_supports_flag -fstack-protector-all],
+                       [flag="-fstack-protector-all"],
+                       [cc_supports_flag -fstack-protector],
+                       [flag="-fstack-protector"]
+                 )
+                 AS_IF([test -n "${flag}"],
+                       [
+                           CC_EXTRAS="${CC_EXTRAS} ${flag}"
+                           stackprot=1
+                       ]
+                 )
+                 AS_IF([test "${relro}" = 1 || test "${pie}" = 1 || test "${stackprot}" = 1],
+                       [AC_MSG_NOTICE([Hardening: relro=${relro} pie=${pie} bindnow=${bindnow} stackprot=${flag}])],
+                       [AC_MSG_WARN([Hardening: no suitable features in the toolchain detected])]
+                 )
+             ],
+)
 
 CFLAGS="$SANITIZERS_CFLAGS $CFLAGS $CC_EXTRAS"
 LDFLAGS="$SANITIZERS_LDFLAGS $LDFLAGS"
@@ -1805,10 +1802,10 @@ dnl AC_*FUNCS() calls above from working.  In particular, -Werror will
 dnl *always* cause us troubles if we set it before here.
 dnl
 dnl
-if test "x${enable_fatal_warnings}" = xyes ; then
+AS_IF([test $enable_fatal_warnings -gt 0], [
     AC_MSG_NOTICE([Enabling fatal compiler warnings])
     CFLAGS="$CFLAGS $WERROR"
-fi
+])
 AC_SUBST(CFLAGS)
 
 dnl This is useful for use in Makefiles that need to remove one specific flag
@@ -1820,14 +1817,17 @@ AC_SUBST(LIBADD_DL)        dnl extra flags for dynamic linking libraries
 AC_SUBST(LOCALE)
 
 dnl Options for cleaning up the compiler output
-AC_MSG_CHECKING([whether to suppress make details])
-QUIET_LIBTOOL_OPTS=""
-QUIET_MAKE_OPTS=""
-if test "x${enable_quiet}" = "xyes"; then
-    QUIET_LIBTOOL_OPTS="--silent"
-    QUIET_MAKE_OPTS="-s"  # POSIX compliant
-fi
-AC_MSG_RESULT([${enable_quiet}])
+AS_IF([test $enable_quiet -gt 0],
+      [
+          AC_MSG_NOTICE([Suppressing make details])
+          QUIET_LIBTOOL_OPTS="--silent"
+          QUIET_MAKE_OPTS="-s"  # POSIX compliant
+      ],
+      [
+          QUIET_LIBTOOL_OPTS=""
+          QUIET_MAKE_OPTS=""
+      ]
+)
 
 dnl Put the above variables to use
 LIBTOOL="${LIBTOOL} --tag=CC \$(QUIET_LIBTOOL_OPTS)"

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1704,6 +1704,7 @@ for t in $tests; do
         -e 's/ start=\"[0-9][-+: 0-9]*Z*\"/ start=\"\"/' \
         -e 's/^Error checking rule: Device not configured/Error checking rule: No such device or address/' \
         -e 's/^lt-//' \
+        -e 's/ocf::/ocf:/' \
         "$TMPFILE" > "${TMPFILE}.$$"
     mv -- "${TMPFILE}.$$" "$TMPFILE"
 

--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -2,7 +2,7 @@
 """ Regression tests for Pacemaker's pacemaker-execd
 """
 
-__copyright__ = "Copyright 2012-2020 the Pacemaker project contributors"
+__copyright__ = "Copyright 2012-2021 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import io
@@ -20,6 +20,9 @@ BUILD_DIR = "@abs_top_builddir@"
 TEST_DIR = sys.path[0]
 
 SBIN_DIR = "@sbindir@"
+
+# Check whether Pacemaker Remote support was built
+REMOTE_ENABLED = "@PC_NAME_GNUTLS@" != ""
 
 # File permissions for executable scripts we create
 EXECMODE = stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
@@ -500,7 +503,8 @@ class Tests(object):
     def setup_test_environment(self):
         """ Prepare the host before executing any tests """
 
-        os.system("service pacemaker_remote stop")
+        if REMOTE_ENABLED:
+            os.system("service pacemaker_remote stop")
         self.cleanup_test_environment()
 
         if self.tls and not os.path.isfile("/etc/pacemaker/authkey"):
@@ -1171,7 +1175,11 @@ class TestOptions(object):
             elif args[i] == "-w" or args[i] == "--force-wait":
                 self.options['force-wait'] = 1
             elif args[i] == "-R" or args[i] == "--pacemaker-remote":
-                self.options['pacemaker-remote'] = 1
+                if REMOTE_ENABLED:
+                    self.options['pacemaker-remote'] = 1
+                else:
+                    print("ERROR: This build does not support Pacemaker Remote")
+                    sys.exit(CrmExit.USAGE)
             elif args[i] == "-r" or args[i] == "--run-only":
                 self.options['run-only'] = args[i+1]
                 skip = 1
@@ -1194,7 +1202,8 @@ class TestOptions(object):
               "\n\t\tDefaults to 2. The value 0 means no limit.")
         print("\t [--force-wait | -w]"
               "\n\t\tEach test case waits the default/specified --timeout for the daemon without tracking the log.")
-        print("\t [--pacemaker-remote | -R             Test pacemaker-remoted binary instead of pacemaker-execd")
+        if REMOTE_ENABLED:
+            print("\t [--pacemaker-remote | -R             Test pacemaker-remoted binary instead of pacemaker-execd")
         print("\t [--run-only-pattern | -p 'string']   Run only tests containing the string value")
         print("\n\tExample: Run only the test 'start_stop'")
         print("\t\t " + sys.argv[0] + " --run-only start_stop")

--- a/cts/cts-regression.in
+++ b/cts/cts-regression.in
@@ -4,13 +4,17 @@
 #
 # Convenience wrapper for running any of the Pacemaker regression tests
 #
-# Copyright 2012-2018 the Pacemaker project contributors
+# Copyright 2012-2021 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
+
+# Check whether Pacemaker Remote support was built
+[ -z "@PC_NAME_GNUTLS@" ]
+REMOTE_ENABLED=$?
 
 USAGE_TEXT="Usage: cts-regression [<options>] [<test> ...]
 Options:
@@ -21,8 +25,14 @@ Options:
 Tests (default tests are 'scheduler cli'):
  scheduler         Action scheduler
  cli               Command-line tools
- exec              Local resource agent executor
- pacemaker_remote  Resource agent executor in remote mode
+ exec              Local resource agent executor"
+
+if [ $REMOTE_ENABLED -eq 1 ]; then
+    USAGE_TEXT="$USAGE_TEXT
+ pacemaker_remote  Resource agent executor in remote mode"
+fi
+
+USAGE_TEXT="$USAGE_TEXT
  fencing           Fencer
  all               Synonym for 'scheduler cli exec fencing'"
 
@@ -188,9 +198,18 @@ while [ $# -gt 0 ] ; do
             valgrind="-v"
             shift
             ;;
-        scheduler|exec|pacemaker_remote|fencing|cli)
+        scheduler|exec|fencing|cli)
             add_test $1
             shift
+            ;;
+        pacemaker_remote)
+            if [ $REMOTE_ENABLED -eq 0 ]; then
+                error "Pacemaker Remote not supported by this build"
+                exit $CRM_EX_USAGE
+            else
+                add_test $1
+                shift
+            fi
             ;;
         all)
             add_test scheduler

--- a/cts/cts-scheduler.in
+++ b/cts/cts-scheduler.in
@@ -1326,7 +1326,15 @@ class CtsScheduler(object):
             # @TODO Why isn't test_args added here?
             test_cmd_full = test_cmd + [ '-x', input_filename, '-S' ]
         with io.open(summary_output_filename, "wt") as f:
-            subprocess.call(test_cmd_full, stdout=f, stderr=subprocess.STDOUT, env=os.environ)
+            simulation = subprocess.Popen(test_cmd_full, stdout=subprocess.PIPE,
+                                          stderr=subprocess.STDOUT,
+                                          env=os.environ)
+            # This makes diff happy regardless of PCMK__COMPAT_2_0
+            sed = subprocess.Popen(["sed", "-e", "s/ocf::/ocf:/g"],
+                                   stdin=simulation.stdout, stdout=f,
+                                   stderr=subprocess.STDOUT)
+            simulation.stdout.close()
+            sed.communicate()
         if self.args.run:
             cat(summary_output_filename)
 

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the Pacemaker project contributors
+ * Copyright 2013-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -155,10 +155,8 @@ create_attribute(xmlNode *xml)
 
     crm_element_value_int(xml, PCMK__XA_ATTR_IS_PRIVATE, &a->is_private);
 
-#if ENABLE_ACL
     a->user = crm_element_value_copy(xml, PCMK__XA_ATTR_USER);
     crm_trace("Performing all %s operations as user '%s'", a->id, a->user);
-#endif
 
     if(value) {
         dampen = crm_get_msec(value);

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the Pacemaker project contributors
+ * Copyright 2013-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -240,10 +240,8 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
         return 0;
     }
 
-#if ENABLE_ACL
     CRM_ASSERT(client->user != NULL);
     pcmk__update_acl_user(xml, PCMK__XA_ATTR_USER, client->user);
-#endif
 
     op = crm_element_value(xml, PCMK__XA_TASK);
 

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -259,10 +259,8 @@ cib_common_callback(qb_ipcs_connection_t * c, void *data, size_t size, gboolean 
     crm_xml_add(op_request, F_CIB_CLIENTID, cib_client->id);
     crm_xml_add(op_request, F_CIB_CLIENTNAME, cib_client->name);
 
-#if ENABLE_ACL
     CRM_LOG_ASSERT(cib_client->user != NULL);
     pcmk__update_acl_user(op_request, F_CIB_USER, cib_client->user);
-#endif
 
     cib_common_callback_worker(id, flags, op_request, cib_client, privileged);
     free_xml(op_request);

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -1,5 +1,7 @@
 /*
- * Copyright 2008-2018 Andrew Beekhof <andrew@beekhof.net>
+ * Copyright 2008-2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -224,9 +226,7 @@ cib_msg_copy(xmlNode * msg, gboolean with_data)
         F_CIB_CALLBACK_TOKEN,
         F_CIB_GLOBAL_UPDATE,
         F_CIB_CLIENTNAME,
-#if ENABLE_ACL
         F_CIB_USER,
-#endif
         F_CIB_NOTIFY_TYPE,
         F_CIB_NOTIFY_ACTIVATE
     };

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -445,9 +445,7 @@ cib_handle_remote_msg(pcmk__client_t *client, xmlNode *command)
     crm_xml_add(command, F_TYPE, T_CIB);
     crm_xml_add(command, F_CIB_CLIENTID, client->id);
     crm_xml_add(command, F_CIB_CLIENTNAME, client->name);
-#if ENABLE_ACL
     crm_xml_add(command, F_CIB_USER, client->user);
-#endif
 
     if (crm_element_value(command, F_CIB_CALLID) == NULL) {
         char *call_uuid = crm_generate_uuid();
@@ -511,10 +509,8 @@ cib_remote_msg(gpointer data)
     /* must pass auth before we will process anything else */
     if (client->remote->authenticated == FALSE) {
         xmlNode *reg;
-
-#if ENABLE_ACL
         const char *user = NULL;
-#endif
+
         command = pcmk__remote_message_xml(client->remote);
         if (cib_remote_auth(command) == FALSE) {
             free_xml(command);
@@ -527,12 +523,10 @@ cib_remote_msg(gpointer data)
         client->remote->auth_timeout = 0;
         client->name = crm_element_value_copy(command, "name");
 
-#if ENABLE_ACL
         user = crm_element_value(command, "user");
         if (user) {
             client->user = strdup(user);
         }
-#endif
 
         /* send ACK */
         reg = create_xml_node(NULL, "cib_result");

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -384,10 +384,8 @@ dispatch_controller_ipc(qb_ipcs_connection_t * c, void *data, size_t size)
     }
     pcmk__ipc_send_ack(client, id, flags, "ack", CRM_EX_INDETERMINATE);
 
-#if ENABLE_ACL
     CRM_ASSERT(client->user != NULL);
     pcmk__update_acl_user(msg, F_CRM_USER, client->user);
-#endif
 
     crm_xml_add(msg, F_CRM_SYS_FROM, client->id);
     if (controld_authorize_ipc_message(msg, client, NULL)) {

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the Pacemaker project contributors
+ * Copyright 2012-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -527,11 +527,9 @@ crmd_remote_proxy_cb(lrmd_t *lrmd, void *userdata, xmlNode *msg)
         xmlNode *request = get_message_xml(msg, F_LRMD_IPC_MSG);
 
         CRM_CHECK(request != NULL, return);
-#if ENABLE_ACL
         CRM_CHECK(lrm_state->node_name, return);
         crm_xml_add(request, XML_ACL_TAG_ROLE, "pacemaker-remote");
         pcmk__update_acl_user(request, F_LRMD_IPC_USER, lrm_state->node_name);
-#endif
 
         /* Pacemaker Remote nodes don't know their own names (as known to the
          * cluster). When getting a node info request with no name or ID, add

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -672,16 +672,12 @@ handle_lrm_delete(xmlNode *stored_msg)
         rsc_id = ID(rsc_xml);
         from_sys = crm_element_value(stored_msg, F_CRM_SYS_FROM);
         node = crm_element_value(msg_data, XML_LRM_ATTR_TARGET);
-#if ENABLE_ACL
         user_name = pcmk__update_acl_user(stored_msg, F_CRM_USER, NULL);
-#endif
         crm_debug("Handling " CRM_OP_LRM_DELETE " for %s on %s locally%s%s "
                   "(clearing CIB resource history only)", rsc_id, node,
                   (user_name? " for user " : ""), (user_name? user_name : ""));
-#if ENABLE_ACL
         rc = controld_delete_resource_history(rsc_id, node, user_name,
                                               cib_dryrun|cib_sync_call);
-#endif
         if (rc == pcmk_rc_ok) {
             rc = controld_delete_resource_history(rsc_id, node, user_name,
                                                   crmd_cib_smart_opt());

--- a/daemons/execd/Makefile.am
+++ b/daemons/execd/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2020 the Pacemaker project contributors
+# Copyright 2012-2021 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -13,14 +13,6 @@ halibdir		= $(CRM_DAEMON_DIR)
 
 halib_PROGRAMS		= pacemaker-execd cts-exec-helper
 
-initdir			= $(INITDIR)
-init_SCRIPTS		= pacemaker_remote
-sbin_PROGRAMS		= pacemaker-remoted
-
-if BUILD_SYSTEMD
-systemdsystemunit_DATA	= pacemaker_remote.service
-endif
-
 pacemaker_execd_CFLAGS		= $(CFLAGS_HARDENED_EXE)
 pacemaker_execd_LDFLAGS		= $(LDFLAGS_HARDENED_EXE)
 
@@ -30,7 +22,16 @@ pacemaker_execd_LDADD		= $(top_builddir)/lib/common/libcrmcommon.la \
 pacemaker_execd_SOURCES		= pacemaker-execd.c execd_commands.c \
 				  execd_alerts.c
 
-pacemaker_remoted_CPPFLAGS	= -DSUPPORT_REMOTE $(AM_CPPFLAGS)
+if BUILD_REMOTE
+initdir			= $(INITDIR)
+init_SCRIPTS		= pacemaker_remote
+sbin_PROGRAMS		= pacemaker-remoted
+if BUILD_SYSTEMD
+systemdsystemunit_DATA	= pacemaker_remote.service
+endif
+
+
+pacemaker_remoted_CPPFLAGS	= -DPCMK__COMPILE_REMOTE $(AM_CPPFLAGS)
 
 pacemaker_remoted_CFLAGS	= $(CFLAGS_HARDENED_EXE)
 pacemaker_remoted_LDFLAGS	= $(LDFLAGS_HARDENED_EXE)
@@ -39,6 +40,7 @@ pacemaker_remoted_LDADD		= $(pacemaker_execd_LDADD) \
 				  $(top_builddir)/lib/lrmd/liblrmd.la
 pacemaker_remoted_SOURCES	= $(pacemaker_execd_SOURCES) \
 				  remoted_tls.c remoted_pidone.c remoted_proxy.c
+endif
 
 cts_exec_helper_LDADD	= $(top_builddir)/lib/common/libcrmcommon.la    \
 			  $(top_builddir)/lib/lrmd/liblrmd.la		\
@@ -58,10 +60,14 @@ install-exec-hook:
 if BUILD_LEGACY_LINKS
 	cd $(DESTDIR)$(CRM_DAEMON_DIR) && rm -f lrmd && $(LN_S) pacemaker-execd lrmd
 endif
+if BUILD_REMOTE
 	cd $(DESTDIR)$(sbindir) && rm -f pacemaker_remoted && $(LN_S) pacemaker-remoted pacemaker_remoted
+endif
 
 uninstall-hook:
 if BUILD_LEGACY_LINKS
 	cd $(DESTDIR)$(CRM_DAEMON_DIR) && rm -f lrmd
 endif
+if BUILD_REMOTE
 	cd $(DESTDIR)$(sbindir) && rm -f pacemaker_remoted
+endif

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1852,15 +1852,11 @@ process_lrmd_message(pcmk__client_t *client, uint32_t id, xmlNode *request)
     int do_notify = 0;
     xmlNode *reply = NULL;
 
-#if ENABLE_ACL
     /* Certain IPC commands may be done only by privileged users (i.e. root or
-     * hacluster) when ACLs are enabled, because they would otherwise provide a
-     * means of bypassing ACLs.
+     * hacluster), because they would otherwise provide a means of bypassing
+     * ACLs.
      */
     bool allowed = pcmk_is_set(client->flags, pcmk__client_privileged);
-#else
-    bool allowed = true;
-#endif
 
     crm_trace("Processing %s operation from %s", op, client->id);
     crm_element_value_int(request, F_LRMD_CALLID, &call_id);

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the Pacemaker project contributors
+ * Copyright 2012-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1531,7 +1531,7 @@ process_lrmd_signon(pcmk__client_t *client, xmlNode *request, int call_id,
     }
 
     if (crm_is_true(is_ipc_provider)) {
-#ifdef SUPPORT_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
         if ((client->remote != NULL) && client->remote->tls_handshake_complete) {
             // This is a remote connection from a cluster node's controller
             ipc_proxy_add_provider(client);
@@ -1866,7 +1866,7 @@ process_lrmd_message(pcmk__client_t *client, uint32_t id, xmlNode *request)
     crm_element_value_int(request, F_LRMD_CALLID, &call_id);
 
     if (pcmk__str_eq(op, CRM_OP_IPC_FWD, pcmk__str_none)) {
-#ifdef SUPPORT_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
         if (allowed) {
             ipc_proxy_forward_client(client, request);
         } else {

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the Pacemaker project contributors
+ * Copyright 2012-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -24,16 +24,12 @@
 
 #include "pacemaker-execd.h"
 
-#if defined(HAVE_GNUTLS_GNUTLS_H) && defined(SUPPORT_REMOTE)
-#  define ENABLE_PCMK_REMOTE
-#endif
-
 static GMainLoop *mainloop = NULL;
 static qb_ipcs_service_t *ipcs = NULL;
 static stonith_t *stonith_api = NULL;
 int lrmd_call_id = 0;
 
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
 /* whether shutdown request has been sent */
 static sig_atomic_t shutting_down = FALSE;
 
@@ -161,7 +157,7 @@ lrmd_client_destroy(pcmk__client_t *client)
 {
     pcmk__free_client(client);
 
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
     /* If we were waiting to shut down, we can now safely do so
      * if there are no more proxied IPC providers
      */
@@ -182,7 +178,7 @@ lrmd_ipc_closed(qb_ipcs_connection_t * c)
 
     crm_trace("Connection %p", c);
     client_disconnect_cleanup(client->id);
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
     ipc_proxy_remove_provider(client);
 #endif
     lrmd_client_destroy(client);
@@ -212,7 +208,7 @@ lrmd_server_send_reply(pcmk__client_t *client, uint32_t id, xmlNode *reply)
     switch (PCMK__CLIENT_TYPE(client)) {
         case pcmk__client_ipc:
             return pcmk__ipc_send_xml(client, id, reply, FALSE);
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
         case pcmk__client_tls:
             return lrmd_tls_send_msg(client->remote, reply, id, "reply");
 #endif
@@ -236,7 +232,7 @@ lrmd_server_send_notify(pcmk__client_t *client, xmlNode *msg)
                 return ENOTCONN;
             }
             return pcmk__ipc_send_xml(client, 0, msg, crm_ipc_server_event);
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
         case pcmk__client_tls:
             if (client->remote == NULL) {
                 crm_trace("Could not notify remote client: disconnected");
@@ -275,7 +271,7 @@ lrmd_exit(gpointer data)
         mainloop_del_ipc_server(ipcs);
     }
 
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
     lrmd_tls_server_destroy();
     ipc_proxy_cleanup();
 #endif
@@ -300,7 +296,7 @@ lrmd_exit(gpointer data)
 static void
 lrmd_shutdown(int nsig)
 {
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
     pcmk__client_t *ipc_proxy = ipc_proxy_get_provider();
 
     /* If there are active proxied IPC providers, then we may be running
@@ -351,7 +347,7 @@ lrmd_shutdown(int nsig)
  */
 void handle_shutdown_ack()
 {
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
     if (shutting_down) {
         crm_info("Received shutdown ack");
         if (shutdown_ack_timer > 0) {
@@ -370,7 +366,7 @@ void handle_shutdown_ack()
  */
 void handle_shutdown_nack()
 {
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
     if (shutting_down) {
         crm_info("Received shutdown nack");
         if (shutdown_ack_timer > 0) {
@@ -401,7 +397,7 @@ static pcmk__cli_option_t long_options[] = {
         "logfile", required_argument, NULL, 'l',
         "\tSend logs to the additional named logfile", pcmk__option_default
     },
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
     {
         "port", required_argument, NULL, 'p',
         "\tPort to listen on", pcmk__option_default
@@ -410,7 +406,7 @@ static pcmk__cli_option_t long_options[] = {
     { 0, 0, 0, 0 }
 };
 
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
 #  define EXECD_TYPE "remote"
 #  define EXECD_NAME "pacemaker-remoted"
 #  define EXECD_DESC "resource agent executor daemon for Pacemaker Remote nodes"
@@ -428,7 +424,7 @@ main(int argc, char **argv, char **envp)
     int bump_log_num = 0;
     const char *option = NULL;
 
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
     // If necessary, create PID 1 now before any file descriptors are opened
     remoted_spawn_pidone(argc, argv, envp);
 #endif
@@ -501,7 +497,7 @@ main(int argc, char **argv, char **envp)
         crm_exit(CRM_EX_FATAL);
     }
 
-#ifdef ENABLE_PCMK_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
     if (lrmd_init_remote_tls_server() < 0) {
         crm_err("Failed to create TLS listener: shutting down and staying down");
         crm_exit(CRM_EX_FATAL);

--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the Pacemaker project contributors
+ * Copyright 2012-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -85,7 +85,7 @@ stonith_t *get_stonith_connection(void);
  */
 void stonith_connection_failed(void);
 
-#ifdef SUPPORT_REMOTE
+#ifdef PCMK__COMPILE_REMOTE
 void ipc_proxy_init(void);
 void ipc_proxy_cleanup(void);
 void ipc_proxy_add_provider(pcmk__client_t *client);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2020 the Pacemaker project contributors
+ * Copyright 2009-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -2595,18 +2595,14 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
     const char *op = crm_element_value(request, F_STONITH_OPERATION);
     const char *client_id = crm_element_value(request, F_STONITH_CLIENTID);
 
-#if ENABLE_ACL
     /* IPC commands related to fencing configuration may be done only by
-     * privileged users (i.e. root or hacluster) when ACLs are supported,
-     * because all other users should go through the CIB to have ACLs applied.
+     * privileged users (i.e. root or hacluster), because all other users should
+     * go through the CIB to have ACLs applied.
      *
      * If no client was given, this is a peer request, which is always allowed.
      */
     bool allowed = (client == NULL)
                    || pcmk_is_set(client->flags, pcmk__client_privileged);
-#else
-    bool allowed = true;
-#endif
 
     crm_element_value_int(request, F_STONITH_CALLOPTS, &call_options);
 

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 the Pacemaker project contributors
+ * Copyright 2010-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -571,17 +571,12 @@ pcmk_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
 
     task = crm_element_value(msg, F_CRM_TASK);
     if (pcmk__str_eq(task, CRM_OP_QUIT, pcmk__str_none)) {
-#if ENABLE_ACL
-        /* Only allow privileged users (i.e. root or hacluster)
-         * to shut down Pacemaker from the command line (or direct IPC).
-         *
-         * We only check when ACLs are enabled, because without them, any client
-         * with IPC access could shut down Pacemaker via the CIB anyway.
+        /* Only allow privileged users (i.e. root or hacluster) to shut down
+         * Pacemaker from the command line (or direct IPC), so that other users
+         * are forced to go through the CIB and have ACLs applied.
          */
         bool allowed = pcmk_is_set(c->flags, pcmk__client_privileged);
-#else
-        bool allowed = true;
-#endif
+
         if (allowed) {
             crm_notice("Shutting down in response to IPC request %s from %s",
                        crm_element_value(msg, F_CRM_REFERENCE),

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the Pacemaker project contributors
+ * Copyright 2015-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -31,15 +31,11 @@ char *pcmk__uid2username(uid_t uid);
 const char *pcmk__update_acl_user(xmlNode *request, const char *field,
                                   const char *peer_user);
 
-#if ENABLE_ACL
-#  include <string.h>
 static inline bool
 pcmk__is_privileged(const char *user)
 {
     return user && (!strcmp(user, CRM_DAEMON_USER) || !strcmp(user, "root"));
 }
-#endif
-
 
 #if SUPPORT_CIBSECRETS
 // Internal CIB utilities (from cib_secrets.c) */

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -1,6 +1,8 @@
 /*
  * Original copyright 2004 International Business Machines
- * Later changes copyright 2008-2020 the Pacemaker project contributors
+ * Later changes copyright 2008-2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -803,14 +805,9 @@ cib_file_perform_op_delegate(cib_t * cib, const char *op, const char *host, cons
     static int max_msg_types = DIMOF(cib_file_ops);
     cib_file_opaque_t *private = cib->variant_opaque;
 
-#if ENABLE_ACL
     crm_info("Handling %s operation for %s as %s",
              (op? op : "invalid"), (section? section : "entire CIB"),
              (user_name? user_name : "default user"));
-#else
-    crm_info("Handling %s operation for %s",
-             (op? op : "invalid"), (section? section : "entire CIB"));
-#endif
 
     cib__set_call_options(call_options, "file operation",
                           cib_no_mtime|cib_inhibit_bcast|cib_scope_local);
@@ -841,11 +838,9 @@ cib_file_perform_op_delegate(cib_t * cib, const char *op, const char *host, cons
 
     cib->call_id++;
     request = cib_create_op(cib->call_id, "dummy-token", op, host, section, data, call_options, user_name);
-#if ENABLE_ACL
     if(user_name) {
         crm_xml_add(request, XML_ACL_TAG_USER, user_name);
     }
-#endif
 
     /* Mirror the logic in cib_prepare_common() */
     if (section != NULL && data != NULL && pcmk__str_eq(crm_element_name(data), XML_TAG_CIB, pcmk__str_none)) {

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -1,6 +1,6 @@
 /*
  * Original copyright 2004 International Business Machines
- * Later changes copyright 2008-2020 the Pacemaker project contributors
+ * Later changes copyright 2008-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -187,7 +187,6 @@ cib_acl_enabled(xmlNode *xml, const char *user)
 {
     bool rc = FALSE;
 
-#if ENABLE_ACL
     if(pcmk_acl_required(user)) {
         const char *value = NULL;
         GHashTable *options = crm_str_table_new();
@@ -199,7 +198,6 @@ cib_acl_enabled(xmlNode *xml, const char *user)
     }
 
     crm_trace("CIB ACL is %s", rc ? "enabled" : "disabled");
-#endif
     return rc;
 }
 
@@ -457,9 +455,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
                 crm_xml_replace(scratch, XML_ATTR_UPDATE_ORIG, origin);
                 crm_xml_replace(scratch, XML_ATTR_UPDATE_CLIENT,
                                 crm_element_value(req, F_CIB_CLIENTNAME));
-#if ENABLE_ACL
                 crm_xml_replace(scratch, XML_ATTR_UPDATE_USER, crm_element_value(req, F_CIB_USER));
-#endif
             }
         }
     }
@@ -477,7 +473,6 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
   done:
 
     *result_cib = scratch;
-#if ENABLE_ACL
     if(rc != pcmk_ok && cib_acl_enabled(current_cib, user)) {
         if(xml_acl_filtered_copy(user, current_cib, scratch, result_cib)) {
             if (*result_cib == NULL) {
@@ -486,7 +481,6 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
             free_xml(scratch);
         }
     }
-#endif
 
     if(diff) {
         *diff = local_diff;
@@ -516,11 +510,9 @@ cib_create_op(int call_id, const char *token, const char *op, const char *host, 
     crm_xml_add(op_msg, F_CIB_HOST, host);
     crm_xml_add(op_msg, F_CIB_SECTION, section);
     crm_xml_add_int(op_msg, F_CIB_CALLID, call_id);
-#if ENABLE_ACL
     if (user_name) {
         crm_xml_add(op_msg, F_CIB_USER, user_name);
     }
-#endif
     crm_trace("Sending call options: %.8lx, %d", (long)call_options, call_options);
     crm_xml_add_int(op_msg, F_CIB_CALLOPTS, call_options);
 
@@ -715,11 +707,9 @@ cib_internal_op(cib_t * cib, const char *op, const char *host,
                      xmlNode ** output_data, int call_options, const char *user_name) =
         cib->delegate_fn;
 
-#if ENABLE_ACL
     if(user_name == NULL) {
         user_name = getenv("CIB_user");
     }
-#endif
 
     return delegate(cib, op, host, section, data, output_data, call_options, user_name);
 }

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2004-2020 the Pacemaker project contributors
+# Copyright 2004-2021 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -8,7 +8,7 @@
 #
 include $(top_srcdir)/mk/common.mk
 
-AM_CPPFLAGS		+= -I$(top_builddir)/lib/gnu -I$(top_srcdir)/lib/gnu -DPCMK_SCHEMAS_EMERGENCY_XSLT=0
+AM_CPPFLAGS		+= -I$(top_builddir)/lib/gnu -I$(top_srcdir)/lib/gnu
 
 MOSTLYCLEANFILES	= md5.c
 

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -287,7 +287,6 @@ pcmk__apply_acl(xmlNode *xml)
 void
 pcmk__unpack_acl(xmlNode *source, xmlNode *target, const char *user)
 {
-#if ENABLE_ACL
     xml_private_t *p = NULL;
 
     if ((target == NULL) || (target->doc == NULL)
@@ -326,7 +325,6 @@ pcmk__unpack_acl(xmlNode *source, xmlNode *target, const char *user)
             }
         }
     }
-#endif
 }
 
 static inline bool
@@ -604,7 +602,6 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
     CRM_ASSERT(xml->doc);
     CRM_ASSERT(xml->doc->_private);
 
-#if ENABLE_ACL
     if (pcmk__tracking_xml_changes(xml, false) && xml_acl_enabled(xml)) {
         int offset = 0;
         xmlNode *parent = xml;
@@ -659,7 +656,6 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
         pcmk__set_xml_doc_flag(xml, xpf_acl_denied);
         return false;
     }
-#endif
 
     return true;
 }
@@ -674,7 +670,6 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
 bool
 pcmk_acl_required(const char *user)
 {
-#if ENABLE_ACL
     if (pcmk__str_empty(user)) {
         crm_trace("ACLs not required because no user set");
         return false;
@@ -685,13 +680,8 @@ pcmk_acl_required(const char *user)
     }
     crm_trace("ACLs required for %s", user);
     return true;
-#else
-    crm_trace("ACLs not required because not supported by this build");
-    return false;
-#endif
 }
 
-#if ENABLE_ACL
 char *
 pcmk__uid2username(uid_t uid)
 {
@@ -791,4 +781,3 @@ pcmk__update_acl_user(xmlNode *request, const char *field,
 
     return requested_user;
 }
-#endif

--- a/lib/common/attrd_client.c
+++ b/lib/common/attrd_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2020 the Pacemaker project contributors
+ * Copyright 2011-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -34,9 +34,7 @@ create_attrd_op(const char *user_name)
 
     crm_xml_add(attrd_op, F_TYPE, T_ATTRD);
     crm_xml_add(attrd_op, F_ORIG, (crm_system_name? crm_system_name: "unknown"));
-#if ENABLE_ACL
     crm_xml_add(attrd_op, PCMK__XA_ATTR_USER, user_name);
-#endif
 
     return attrd_op;
 }

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -171,7 +171,6 @@ client_from_connection(qb_ipcs_connection_t *c, void *key, uid_t uid_client)
     }
 
     if (c) {
-#if ENABLE_ACL
         client->user = pcmk__uid2username(uid_client);
         if (client->user == NULL) {
             client->user = strdup("#unprivileged");
@@ -179,7 +178,6 @@ client_from_connection(qb_ipcs_connection_t *c, void *key, uid_t uid_client)
             crm_err("Unable to enforce ACLs for user ID %d, assuming unprivileged",
                     uid_client);
         }
-#endif
         client->ipcs = c;
         pcmk__set_client_flags(client, pcmk__client_ipc);
         client->pid = pcmk__client_pid(c);

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -107,7 +107,7 @@ xml_init(pcmk__output_t *out) {
 
     if (legacy_xml) {
         priv->root = create_xml_node(NULL, "crm_mon");
-        crm_xml_add(priv->root, "version", VERSION);
+        crm_xml_add(priv->root, "version", PACEMAKER_VERSION);
     } else {
         priv->root = create_xml_node(NULL, "pacemaker-result");
         crm_xml_add(priv->root, "api-version", PCMK__API_VERSION);

--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the Pacemaker project contributors
+ * Copyright 2015-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -136,7 +136,8 @@ exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum pcmk__alert_flags kind,
     char timestamp_usec[7];
 
     params = alert_key2param(params, PCMK__alert_key_kind, kind_s);
-    params = alert_key2param(params, PCMK__alert_key_version, VERSION);
+    params = alert_key2param(params, PCMK__alert_key_version,
+                             PACEMAKER_VERSION);
 
     for (GList *iter = g_list_first(alert_list); iter; iter = g_list_next(iter)) {
         pcmk__alert_t *entry = (pcmk__alert_t *)(iter->data);

--- a/lib/lrmd/proxy_common.c
+++ b/lib/lrmd/proxy_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the Pacemaker project contributors
+ * Copyright 2015-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -248,10 +248,8 @@ remote_proxy_cb(lrmd_t *lrmd, const char *node_name, xmlNode *msg)
         crm_element_value_int(msg, F_LRMD_IPC_MSG_FLAGS, &flags);
         crm_xml_add(request, XML_ACL_TAG_ROLE, "pacemaker-remote");
 
-#if ENABLE_ACL
         CRM_ASSERT(node_name);
         pcmk__update_acl_user(request, F_LRMD_IPC_USER, node_name);
-#endif
 
         if (pcmk_is_set(flags, crm_ipc_proxied)) {
             const char *type = crm_element_value(request, F_TYPE);

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -139,12 +139,7 @@ static pcmk__cluster_option_t pe_opts[] = {
     },
     {
         "concurrent-fencing", NULL, "boolean", NULL,
-#ifdef DEFAULT_CONCURRENT_FENCING_TRUE
-        "true",
-#else
-        "false",
-#endif
-        pcmk__valid_boolean,
+        PCMK__CONCURRENT_FENCING_DEFAULT, pcmk__valid_boolean,
         "Allow performing fencing operations in parallel",
         NULL
     },

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -365,18 +365,13 @@ set_working_set_defaults(pe_working_set_t * data_set)
 
     data_set->flags = 0x0ULL;
 
-#ifdef DEFAULT_CONCURRENT_FENCING_TRUE
-    pe__set_working_set_flags(data_set,
-                              pe_flag_stop_rsc_orphans
-                              |pe_flag_symmetric_cluster
-                              |pe_flag_stop_action_orphans
-                              |pe_flag_concurrent_fencing);
-#else
     pe__set_working_set_flags(data_set,
                               pe_flag_stop_rsc_orphans
                               |pe_flag_symmetric_cluster
                               |pe_flag_stop_action_orphans);
-#endif
+    if (!strcmp(PCMK__CONCURRENT_FENCING_DEFAULT, "true")) {
+        pe__set_working_set_flags(data_set, pe_flag_concurrent_fencing);
+    }
 }
 
 pe_resource_t *

--- a/m4/CONFIG_FILES_EXEC.m4
+++ b/m4/CONFIG_FILES_EXEC.m4
@@ -1,0 +1,24 @@
+#
+# Copyright 2021 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+
+# CONFIG_FILE_EXEC(FILE [...])
+#
+# Mark single FILE as configure-generated, and make it executable once created.
+#
+AC_DEFUN([CONFIG_FILE_EXEC], [AC_CONFIG_FILES([$1], [chmod +x "$1"])])
+
+# CONFIG_FILES_EXEC(FILE [...])
+#
+# Mark multiple FILEs as configure-generated, and make them executable.
+#
+AC_DEFUN([CONFIG_FILES_EXEC], [
+    m4_case([$#], [0], [],
+                  [1], [CONFIG_FILE_EXEC([$1])],
+                  [CONFIG_FILE_EXEC([$1])
+                   CONFIG_FILES_EXEC(m4_shift($@))])
+])

--- a/m4/REQUIRE_LIB.m4
+++ b/m4/REQUIRE_LIB.m4
@@ -1,0 +1,15 @@
+#
+# Copyright 2021 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+
+# REQUIRE_LIB(LIBRARY, FUNCTION)
+#
+# Error if a C library can't be found or doesn't contain a specified function
+#
+AC_DEFUN([REQUIRE_LIB], [
+    AC_CHECK_LIB([$1],[$2],,[AC_MSG_FAILURE([Unable to find required C library lib$1])])
+])

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -448,6 +448,10 @@ export LDFLAGS_HARDENED_LIB="%{?_hardening_ldflags}"
 
 ./autogen.sh
 
+%if 0%{?fedora} <= 34 || 0%{?rhel} <= 8
+%global compat20 --enable-compat-2.0
+%endif
+
 %{configure}                                                                    \
         PYTHON=%{python_path}                                                   \
         %{!?with_hardening:    --disable-hardening}                             \
@@ -456,6 +460,7 @@ export LDFLAGS_HARDENED_LIB="%{?_hardening_ldflags}"
         %{?with_coverage:      --with-coverage}                                 \
         %{?with_cibsecrets:    --with-cibsecrets}                               \
         %{?gnutls_priorities:  --with-gnutls-priorities="%{gnutls_priorities}"} \
+        %{?compat20}                                                            \
         --with-initdir=%{_initrddir}                                            \
         --with-runstatedir=%{_rundir}                                           \
         --localstatedir=%{_var}                                                 \

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -61,8 +61,8 @@
 ## Add option to turn off hardening of libraries and daemon executables
 %bcond_without hardening
 
-## Add option to disable links for legacy daemon names
-%bcond_without legacy_links
+## Add option to enable links for legacy daemon names
+%bcond_with legacy_links
 
 # Define globals for convenient use later
 
@@ -459,7 +459,7 @@ export LDFLAGS_HARDENED_LIB="%{?_hardening_ldflags}"
 %{configure}                                                                    \
         PYTHON=%{python_path}                                                   \
         %{!?with_hardening:    --disable-hardening}                             \
-        %{!?with_legacy_links: --disable-legacy-links}                          \
+        %{?with_legacy_links:  --enable-legacy-links}                           \
         %{?with_profiling:     --with-profiling}                                \
         %{?with_coverage:      --with-coverage}                                 \
         %{?with_cibsecrets:    --with-cibsecrets}                               \
@@ -674,9 +674,7 @@ exit 0
 %exclude %{_libexecdir}/pacemaker/cts-log-watcher
 %exclude %{_libexecdir}/pacemaker/cts-support
 %exclude %{_sbindir}/pacemaker-remoted
-%if %{with legacy_links}
 %exclude %{_sbindir}/pacemaker_remoted
-%endif
 %{_libexecdir}/pacemaker/*
 
 %{_sbindir}/crm_attribute
@@ -815,9 +813,7 @@ exit 0
 %endif
 
 %{_sbindir}/pacemaker-remoted
-%if %{with legacy_links}
 %{_sbindir}/pacemaker_remoted
-%endif
 %{_mandir}/man8/pacemaker-remoted.*
 %license licenses/GPLv2
 %doc COPYING

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -448,6 +448,10 @@ export LDFLAGS_HARDENED_LIB="%{?_hardening_ldflags}"
 
 ./autogen.sh
 
+%if 0%{?rhel} >= 7
+%global concurrent_fencing --with-concurrent-fencing-default=true
+%endif
+
 %if 0%{?fedora} <= 34 || 0%{?rhel} <= 8
 %global compat20 --enable-compat-2.0
 %endif
@@ -460,6 +464,7 @@ export LDFLAGS_HARDENED_LIB="%{?_hardening_ldflags}"
         %{?with_coverage:      --with-coverage}                                 \
         %{?with_cibsecrets:    --with-cibsecrets}                               \
         %{?gnutls_priorities:  --with-gnutls-priorities="%{gnutls_priorities}"} \
+        %{?concurrent_fencing}                                                  \
         %{?compat20}                                                            \
         --with-initdir=%{_initrddir}                                            \
         --with-runstatedir=%{_rundir}                                           \


### PR DESCRIPTION
This is a rather large set of changes, mostly to the configure script, such as adding, removing, or changing the defaults for configure options. One of the new options, --enable-compat-2.0, is intended to revert certain output changes made for 2.1.0 (currently including just the ocf::PROVIDER:agent change, but expected to include more later), to retain compatibility with tools that depend on the old output.