### PR TITLE
Doc: rsc-pattern indexing

### DIFF
--- a/doc/sphinx/Pacemaker_Explained/constraints.rst
+++ b/doc/sphinx/Pacemaker_Explained/constraints.rst
@@ -116,7 +116,7 @@ ___________________
    |                    |         | the pattern are selected. If the regular expression                                          |
    |                    |         | contains submatches, and the constraint is governed by                                       |
    |                    |         | a :ref:`rule <rules>`, the submatches can be                                                 |
-   |                    |         | referenced as **%0** through **%9** in the rule's                                            |
+   |                    |         | referenced as **%1** through **%9** in the rule's                                            |
    |                    |         | ``score-attribute`` or a rule expression's ``attribute``.                                    |
    |                    |         | A location constraint must either have a ``rsc``, have a                                     |
    |                    |         | ``rsc-pattern``, or contain at least one resource set.                                       |


### PR DESCRIPTION
The references for rsc-pattern are 1 indexed and not 0 indexed.

See https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_05_01

Signed-off-by: Nathaniel Clark <Nathaniel.Clark@misrule.us>