### PR TITLE
[1.1] Fix: fencer: broadcast returned fencing operations and update outdated pending ones in the history

### DIFF
--- a/fencing/history.c
+++ b/fencing/history.c
@@ -359,7 +359,18 @@ stonith_merge_in_history_list(GHashTable *history)
             g_hash_table_lookup(stonith_remote_op_list, op->id);
 
         if (stored_op) {
-            continue; /* skip over existant - state-merging migh be desirable */
+            if (stored_op->state != st_failed
+                && stored_op->state != st_done
+                && (op->state == st_failed || op->state == st_done)) {
+                    crm_debug("Updating outdated pending operation %.8s "
+                              "(state=%d) according to the one (state=%d) from "
+                              "remote peer history",
+                              op->id, stored_op->state,
+                              op->state);
+
+            } else {
+                continue; // Skip existent
+            }
         }
 
         updated = TRUE;

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -164,4 +164,18 @@ int stonith__rhcs_validate(stonith_t *st, int call_options, const char *target,
                            const char *agent, GHashTable *params, const char *host_arg,
                            int timeout, char **output, char **error_output);
 
+/*!
+ * \internal
+ * \brief Is a fencing operation in pending state?
+ *
+ * \param[in] state     State as enum op_state value
+ *
+ * \return A boolean
+ */
+static inline bool
+stonith__op_state_pending(enum op_state state)
+{
+    return state != st_failed && state != st_done;
+}
+
 #endif


### PR DESCRIPTION
Backports of https://github.com/ClusterLabs/pacemaker/pull/2297 and https://github.com/ClusterLabs/pacemaker/pull/2304 for 1.1 branch.

If a fencer had a pending fencing operation in the history but somehow
was not reachable when the fencing operation returned, the pending
operation would remain outdated and get stuck in the history.

The solution here is to broadcast returned fencing operations and update
outdated pending ones in the history.