### PR TITLE
Raise minimum dependency versions (again)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
 
 | Version         | Fedora-based       | Suse-based         | Debian-based   |
 |:---------------:|:------------------:|:------------------:|:--------------:|
-| 1.11 or later   | automake           | automake           | automake       |
+| 1.13 or later   | automake           | automake           | automake       |
 | 2.64 or later   | autoconf           | autoconf           | autoconf       |
 |                 | libtool            | libtool            | libtool        |
 |                 | libtool-ltdl-devel |                    | libltdl-dev    |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@
 |                 | libtool            | libtool            | libtool        |
 |                 | libtool-ltdl-devel |                    | libltdl-dev    |
 |                 | libuuid-devel      | libuuid-devel      | uuid-dev       |
-|                 | pkgconfig          | pkgconfig          | pkg-config     |
+| 0.27 or later   | pkgconfig          | pkgconfig          | pkg-config     |
 | 2.42.0 or later | glib2-devel        | glib2-devel        | libglib2.0-dev |
 |                 | libxml2-devel      | libxml2-devel      | libxml2-dev    |
 |                 | libxslt-devel      | libxslt-devel      | libxslt-dev    |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@
 |                 | libxslt-devel      | libxslt-devel      | libxslt-dev    |
 |                 | bzip2-devel        | libbz2-devel       | libbz2-dev     |
 | 0.17.0 or later | libqb-devel        | libqb-devel        | libqb-dev      |
-| 3.2 or later    | python3            | python3            | python3        |
+| 3.4 or later    | python3            | python3            | python3        |
 
 Also: GNU make
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@
 |                 | libtool-ltdl-devel |                    | libltdl-dev    |
 |                 | libuuid-devel      | libuuid-devel      | uuid-dev       |
 |                 | pkgconfig          | pkgconfig          | pkg-config     |
-| 2.32.0 or later | glib2-devel        | glib2-devel        | libglib2.0-dev |
+| 2.42.0 or later | glib2-devel        | glib2-devel        | libglib2.0-dev |
 |                 | libxml2-devel      | libxml2-devel      | libxml2-dev    |
 |                 | libxslt-devel      | libxslt-devel      | libxslt-dev    |
 |                 | bzip2-devel        | libbz2-devel       | libbz2-dev     |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@
 |                 | libxml2-devel      | libxml2-devel      | libxml2-dev    |
 |                 | libxslt-devel      | libxslt-devel      | libxslt-dev    |
 |                 | bzip2-devel        | libbz2-devel       | libbz2-dev     |
-|                 | libqb-devel        | libqb-devel        | libqb-dev      |
+| 0.17.0 or later | libqb-devel        | libqb-devel        | libqb-dev      |
 | 3.2 or later    | python3            | python3            | python3        |
 
 Also: GNU make
@@ -36,7 +36,7 @@ Also: GNU make
 
 | Feature Enabled                                 | Version        | Fedora-based            | Suse-based              | Debian-based            |
 |:-----------------------------------------------:|:--------------:|:-----------------------:|:-----------------------:|:-----------------------:|
-| Pacemaker Remote and encrypted remote CIB admin | 2.1.7 or later | gnutls-devel            | libgnutls-devel         | libgnutls-dev           |
+| Pacemaker Remote and encrypted remote CIB admin | 2.12.0 or later| gnutls-devel            | libgnutls-devel         | libgnutls-dev           |
 | encrypted remote CIB admin                      |                | pam-devel               | pam-devel               | libpam0g-dev            |
 | interactive crm_mon                             |                | ncurses-devel           | ncurses-devel           | ncurses-dev             |
 | systemd support                                 |                | systemd-devel           | systemd-devel           | libsystemd-dev          |

--- a/configure.ac
+++ b/configure.ac
@@ -896,8 +896,8 @@ else
 fi
 AC_SUBST(PC_LIBS_RT)
 
-# Require glib 2.32.0 (2012-03) or later
-PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.32.0],
+# Require minimum glib version
+PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.42.0],
                   [CPPFLAGS="${CPPFLAGS} ${GLIB_CFLAGS}"
                    LIBS="${LIBS} ${GLIB_LIBS}"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -764,8 +764,8 @@ dnl when calling configure, for example: ./configure PYTHON=/usr/bin/python3.6
 dnl Ensure PYTHON is an absolute path
 AS_IF([test x"${PYTHON}" != x""], [AC_PATH_PROG([PYTHON], [$PYTHON])])
 
-dnl Pacemaker requires a minimum Python version of 3.2
-AM_PATH_PYTHON([3.2])
+dnl Require a minimum Python version
+AM_PATH_PYTHON([3.4])
 
 AC_PATH_PROGS([ASCIIDOC_CONV], [asciidoc asciidoctor])
 AC_PATH_PROG([HELP2MAN], [help2man])

--- a/configure.ac
+++ b/configure.ac
@@ -59,12 +59,11 @@ dnl   - Should not include HAVE_* defines
 dnl   - Safe to include anywhere
 AC_CONFIG_HEADERS([include/config.h include/crm_config.h])
 
-dnl 1.11:           minimum automake version required
+dnl 1.13:           minimum automake version required
 dnl foreign:        don't require GNU-standard top-level files
 dnl tar-ustar:      use (older) POSIX variant of generated tar rather than v7
-dnl silent-rules:   allow "--enable-silent-rules" (no-op in 1.13+)
 dnl subdir-objects: keep .o's with their .c's (no-op in 2.0+)
-AM_INIT_AUTOMAKE([1.11 foreign tar-ustar silent-rules subdir-objects])
+AM_INIT_AUTOMAKE([1.13 foreign tar-ustar subdir-objects])
 
 dnl Require pkg-config (with a minimum version)
 PKG_PROG_PKG_CONFIG(0.18)

--- a/configure.ac
+++ b/configure.ac
@@ -65,18 +65,11 @@ dnl tar-ustar:      use (older) POSIX variant of generated tar rather than v7
 dnl subdir-objects: keep .o's with their .c's (no-op in 2.0+)
 AM_INIT_AUTOMAKE([1.13 foreign tar-ustar subdir-objects])
 
-dnl Require pkg-config (with a minimum version)
-PKG_PROG_PKG_CONFIG(0.18)
+dnl Require minimum version of pkg-config
+PKG_PROG_PKG_CONFIG(0.27)
 AS_IF([test "x${PKG_CONFIG}" != x], [],
-      [AC_MSG_FAILURE([Could not find required build tool pkg-config (0.18 or later)])])
-dnl PKG_NOARCH_INSTALLDIR is not available prior to pkg-config 0.27 and
-dnl pkgconf 0.8.10 (uncomment next line to mimic that scenario)
-dnl m4_ifdef([PKG_NOARCH_INSTALLDIR], [m4_undefine([PKG_NOARCH_INSTALLDIR])])
-m4_ifndef([PKG_NOARCH_INSTALLDIR], [
-    AC_DEFUN([PKG_NOARCH_INSTALLDIR], [
-        AC_SUBST([noarch_pkgconfigdir], ['${datadir}/pkgconfig'])
-    ])
-])
+      [AC_MSG_FAILURE([Could not find required build tool pkg-config (0.27 or later)])])
+PKG_INSTALLDIR
 PKG_NOARCH_INSTALLDIR
 
 dnl Example 2.4. Silent Custom Rule to Generate a File

--- a/cts/CTStests.py
+++ b/cts/CTStests.py
@@ -2954,10 +2954,8 @@ class RemoteDriver(CTSTest):
         # create key locally
         (handle, keyfile) = tempfile.mkstemp(".cts")
         os.close(handle)
-        devnull = open(os.devnull, 'wb')
         subprocess.check_call(["dd", "if=/dev/urandom", "of=%s" % keyfile, "bs=4096", "count=1"],
-            stdout=devnull, stderr=devnull)
-        devnull.close()
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         # sync key throughout the cluster
         for node in self.Env["nodes"]:

--- a/cts/cts-scheduler.in
+++ b/cts/cts-scheduler.in
@@ -1269,11 +1269,10 @@ class CtsScheduler(object):
     def _compare_files(self, filename1, filename2):
         """ Add any file differences to failed results """
 
-        with io.open("/dev/null", "wt") as dev_null:
-            if diff(filename1, filename2, stdout=dev_null) != 0:
-                diff(filename1, filename2, stdout=self.failed_file, stderr=dev_null)
-                self.failed_file.write("\n");
-                return True
+        if diff(filename1, filename2, stdout=subprocess.DEVNULL) != 0:
+            diff(filename1, filename2, stdout=self.failed_file, stderr=subprocess.DEVNULL)
+            self.failed_file.write("\n");
+            return True
         return False
 
     def run_one(self, test_name, test_desc, test_args=[]):

--- a/doc/sphinx/Pacemaker_Development/python.rst
+++ b/doc/sphinx/Pacemaker_Development/python.rst
@@ -54,16 +54,10 @@ or "GNU Lesser General Public License version 2.1 or later (LGPLv2.1+)".
 Python Version Compatibility
 ############################
 
-Pacemaker targets compatibility with Python 3.2 and later.
+Pacemaker targets compatibility with Python 3.4 and later.
 
-Do not use features not available in all targeted Python versions. Some
-examples include:
-
-  * The ``u`` prefix for string literals
-  * The ``ipaddress`` module
-  * The ``subprocess.run()`` function
-  * The ``subprocess.DEVNULL`` constant
-  * ``subprocess`` module-specific exceptions
+Do not use features not available in all targeted Python versions. An
+example is the ``subprocess.run()`` function.
 
 
 .. index::

--- a/include/portability.h
+++ b/include/portability.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2020 the Pacemaker project contributors
+ * Copyright 2001-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -66,12 +66,6 @@ char *strndup(const char *str, size_t len);
 #  endif
 
 #  include <glib.h>
-
-#  if !GLIB_CHECK_VERSION(2,38,0)
-#    define g_assert_true(expr) g_assert_cmpint((expr), ==, TRUE)
-#    define g_assert_false(expr) g_assert_cmpint((expr), !=, TRUE)
-#    define g_assert_null(expr)  g_assert_cmpint((expr) == NULL, ==, TRUE)
-#  endif
 
 #  if SUPPORT_DBUS
 #    ifndef HAVE_DBUSBASICVALUE

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2003-2019 the Pacemaker project contributors
+# Copyright 2003-2021 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -10,25 +10,12 @@ MAINTAINERCLEANFILES    = Makefile.in
 
 LIBS			= cib lrmd service fencing cluster
 
-PC_FILES		= $(LIBS:%=pacemaker-%.pc)	\
+pkgconfig_DATA		= $(LIBS:%=pacemaker-%.pc)	\
 			  libpacemaker.pc		\
 			  pacemaker.pc			\
 			  pacemaker-pe_rules.pc		\
 			  pacemaker-pe_status.pc
 
-EXTRA_DIST		= $(PC_FILES:%=%.in)
-
-all-local: $(PC_FILES)
-
-install-exec-local: $(PC_FILES)
-	$(INSTALL) -d $(DESTDIR)/$(libdir)/pkgconfig
-	$(INSTALL) -m 644 $(PC_FILES) $(DESTDIR)/$(libdir)/pkgconfig
-
-uninstall-local:
-	-cd $(DESTDIR)/$(libdir)/pkgconfig && rm -f $(PC_FILES)
-	-rmdir $(DESTDIR)/$(libdir)/pkgconfig 2> /dev/null
-
-clean-local:
-	-rm -f $(PC_FILES)
+EXTRA_DIST		= $(pkgconfig_DATA:%=%.in)
 
 SUBDIRS	= gnu common pengine cib services fencing lrmd cluster pacemaker

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -33,10 +33,6 @@ AM_V_SCHEMA = $(am__v_SCHEMA_$(V))
 am__v_SCHEMA_0 = @echo "  SCHEMA   $@";
 am__v_SCHEMA_1 = 
 
-AM_V_PUB = $(am__v_PUB_$(V))
-am__v_PUB_0 = @echo "  PUB     $@: $(DOCBOOK_FORMATS)";
-am__v_PUB_1 = 
-
 AM_V_BOOK = $(am__v_BOOK_$(V))
 am__v_BOOK_0 = @echo "  BOOK    $(@:%/_build=%): $(BOOK_FORMATS)";
 am__v_BOOK_1 = 

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -10,9 +10,6 @@
 #
 # Some variables to help with silent rules
 # https://www.gnu.org/software/automake/manual/html_node/Automake-silent_002drules-Option.html
-#
-# We require a minimum automake version of 1.11, which includes AM_V_GEN and
-# AM_V_at, but AM_V_P is not available until 1.13.
 
 V ?= $(AM_DEFAULT_VERBOSITY)
 

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -236,7 +236,7 @@ BuildRequires: coreutils findutils grep sed
 
 # Required for core functionality
 BuildRequires: automake autoconf gcc libtool pkgconfig %{?pkgname_libtool_devel}
-BuildRequires: pkgconfig(glib-2.0) >= 2.32
+BuildRequires: pkgconfig(glib-2.0) >= 2.42
 BuildRequires: libxml2-devel libxslt-devel libuuid-devel
 BuildRequires: %{pkgname_bzip2_devel}
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -354,15 +354,15 @@ static GOptionEntry query_entries[] = {
       list_providers_cb,
       "List all available OCF providers",
       NULL },
-    { "list-agents", 0, 0, G_OPTION_ARG_CALLBACK,
+    { "list-agents", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK,
       list_agents_cb,
       "List all agents available for the named standard and/or provider",
       "STD/PROV" },
-    { "list-ocf-alternatives", 0, 0, G_OPTION_ARG_CALLBACK,
+    { "list-ocf-alternatives", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK,
       list_alternatives_cb,
       "List all available providers for the named OCF agent",
       "AGENT" },
-    { "show-metadata", 0, 0, G_OPTION_ARG_CALLBACK,
+    { "show-metadata", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK,
       metadata_cb,
       "Show the metadata for the named class:provider:agent",
       "SPEC" },
@@ -372,7 +372,7 @@ static GOptionEntry query_entries[] = {
     { "query-xml-raw", 'w', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, flag_cb,
       "Show XML configuration of resource (before any template expansion)",
       NULL },
-    { "get-parameter", 'g', 0, G_OPTION_ARG_CALLBACK, get_param_prop_cb,
+    { "get-parameter", 'g', G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, get_param_prop_cb,
       "Display named parameter for resource (use instance attribute\n"
       INDENT "unless --meta or --utilization is specified)",
       "PARAM" },
@@ -424,11 +424,11 @@ static GOptionEntry command_entries[] = {
       INDENT "numbered instance of a clone or bundled resource, the refresh\n"
       INDENT "applies to the whole collective resource unless --force is given.",
       NULL },
-    { "set-parameter", 'p', 0, G_OPTION_ARG_CALLBACK, set_delete_param_cb,
+    { "set-parameter", 'p', G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, set_delete_param_cb,
       "Set named parameter for resource (requires -v). Use instance\n"
       INDENT "attribute unless --meta or --utilization is specified.",
       "PARAM" },
-    { "delete-parameter", 'd', 0, G_OPTION_ARG_CALLBACK, set_delete_param_cb,
+    { "delete-parameter", 'd', G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, set_delete_param_cb,
       "Delete named parameter for resource. Use instance attribute\n"
       INDENT "unless --meta or --utilization is specified.",
       "PARAM" },
@@ -477,11 +477,11 @@ static GOptionEntry location_entries[] = {
       "Modifies the --clear argument to remove constraints with\n"
       INDENT "expired lifetimes.",
       NULL },
-    { "lifetime", 'u', 0, G_OPTION_ARG_STRING, &options.move_lifetime,
+    { "lifetime", 'u', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &options.move_lifetime,
       "Lifespan (as ISO 8601 duration) of created constraints (with\n"
       INDENT "-B, -M) see https://en.wikipedia.org/wiki/ISO_8601#Durations)",
       "TIMESPEC" },
-    { "master", 0, 0, G_OPTION_ARG_NONE, &options.promoted_role_only,
+    { "master", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &options.promoted_role_only,
       "Limit scope of command to Master role (with -B, -M, -U). For\n"
       INDENT "-B and -M the previous master may remain active in the Slave role.",
       NULL },
@@ -546,16 +546,16 @@ static GOptionEntry advanced_entries[] = {
 };
 
 static GOptionEntry addl_entries[] = {
-    { "node", 'N', 0, G_OPTION_ARG_STRING, &options.host_uname,
+    { "node", 'N', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &options.host_uname,
       "Node name",
       "NAME" },
-    { "recursive", 0, 0, G_OPTION_ARG_NONE, &options.recursive,
+    { "recursive", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &options.recursive,
       "Follow colocation chains when using --set-parameter",
       NULL },
-    { "resource-type", 't', 0, G_OPTION_ARG_STRING, &options.rsc_type,
+    { "resource-type", 't', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &options.rsc_type,
       "Resource XML element (primitive, group, etc.) (with -D)",
       "ELEMENT" },
-    { "parameter-value", 'v', 0, G_OPTION_ARG_STRING, &options.prop_value,
+    { "parameter-value", 'v', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &options.prop_value,
       "Value to use with -p",
       "PARAM" },
     { "meta", 'm', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, attr_set_type_cb,
@@ -566,40 +566,40 @@ static GOptionEntry addl_entries[] = {
       "Use resource utilization attribute instead of instance attribute\n"
       INDENT "(with -p, -g, -d)",
       NULL },
-    { "operation", 'n', 0, G_OPTION_ARG_STRING, &options.operation,
+    { "operation", 'n', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &options.operation,
       "Operation to clear instead of all (with -C -r)",
       "OPERATION" },
-    { "interval", 'I', 0, G_OPTION_ARG_STRING, &options.interval_spec,
+    { "interval", 'I', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &options.interval_spec,
       "Interval of operation to clear (default 0) (with -C -r -n)",
       "N" },
-    { "class", 0, 0, G_OPTION_ARG_CALLBACK, class_cb,
+    { "class", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, class_cb,
       "The standard the resource agent conforms to (for example, ocf).\n"
       INDENT "Use with --agent, --provider, --option, and --validate.",
       "CLASS" },
-    { "agent", 0, 0, G_OPTION_ARG_CALLBACK, agent_provider_cb,
+    { "agent", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, agent_provider_cb,
       "The agent to use (for example, IPaddr). Use with --class,\n"
       INDENT "--provider, --option, and --validate.",
       "AGENT" },
-    { "provider", 0, 0, G_OPTION_ARG_CALLBACK, agent_provider_cb,
+    { "provider", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, agent_provider_cb,
       "The vendor that supplies the resource agent (for example,\n"
       INDENT "heartbeat). Use with --class, --agent, --option, and --validate.",
       "PROVIDER" },
-    { "option", 0, 0, G_OPTION_ARG_CALLBACK, option_cb,
+    { "option", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, option_cb,
       "Specify a device configuration parameter as NAME=VALUE (may be\n"
       INDENT "specified multiple times). Use with --validate and without the\n"
       INDENT "-r option.",
       "PARAM" },
-    { "set-name", 's', 0, G_OPTION_ARG_STRING, &options.prop_set,
+    { "set-name", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &options.prop_set,
       "(Advanced) XML ID of attributes element to use (with -p, -d)",
       "ID" },
-    { "nvpair", 'i', 0, G_OPTION_ARG_STRING, &options.prop_id,
+    { "nvpair", 'i', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &options.prop_id,
       "(Advanced) XML ID of nvpair element to use (with -p, -d)",
       "ID" },
-    { "timeout", 'T', 0, G_OPTION_ARG_CALLBACK, timeout_cb,
+    { "timeout", 'T', G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, timeout_cb,
       "(Advanced) Abort if command does not finish in this time (with\n"
       INDENT "--restart, --wait, --force-*)",
       "N" },
-    { "force", 'f', 0, G_OPTION_ARG_NONE, &options.force,
+    { "force", 'f', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &options.force,
       "If making CIB changes, do so regardless of quorum. See help for\n"
       INDENT "individual commands for additional behavior.",
       NULL },
@@ -1440,13 +1440,13 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
 
     GOptionEntry extra_prog_entries[] = {
-        { "quiet", 'Q', 0, G_OPTION_ARG_NONE, &(args->quiet),
+        { "quiet", 'Q', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &(args->quiet),
           "Be less descriptive in output.",
           NULL },
-        { "resource", 'r', 0, G_OPTION_ARG_STRING, &options.rsc_id,
+        { "resource", 'r', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &options.rsc_id,
           "Resource ID",
           "ID" },
-        { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &options.remainder,
+        { G_OPTION_REMAINING, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING_ARRAY, &options.remainder,
           NULL,
           NULL },
 

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -64,7 +64,7 @@ static GOptionEntry data_entries[] = {
 };
 
 static GOptionEntry addl_entries[] = {
-    { "save-xml", 'S', 0, G_OPTION_ARG_FILENAME,
+    { "save-xml", 'S', G_OPTION_FLAG_NONE, G_OPTION_ARG_FILENAME,
       &options.cib_save, "Save verified XML to named file (most useful with -L)",
       "FILE" },
 


### PR DESCRIPTION
Previously, we did not have any CI platforms that could test our *oldest* supported dependencies. This meant that occasionally we would accidentally use some feature that wasn't supported in all versions, and would have to revert it once we stumbled across it. This was made worse by Pacemaker's ultra-long support window for old build environments -- typically around a decade, which is a leftover from the days before most distributions packaged Pacemaker and most users built their own.

Now, raise the minimum versions of dependencies to what's available in major Linux distribution releases from about 5 years ago (for example, Debian 8 "jessie", Ubuntu 15 "xenial", and RHEL 7.2). We can actually test these versions in CI, so we can ensure we support what we claim to.