### PR TITLE
Deprecate more public API

### DIFF
--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -110,6 +110,8 @@ const char *pcmk__message_name(const char *name);
 /* internal name/value utilities (from nvpair.c) */
 
 int pcmk__scan_nvpair(const char *input, char **name, char **value);
+char *pcmk__format_nvpair(const char *name, const char *value,
+                          const char *units);
 
 
 /* internal procfs utilities (from procfs.c) */

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -107,6 +107,11 @@ guint pcmk__mainloop_timer_get_period(mainloop_timer_t *timer);
 const char *pcmk__message_name(const char *name);
 
 
+/* internal name/value utilities (from nvpair.c) */
+
+int pcmk__scan_nvpair(const char *input, char **name, char **value);
+
+
 /* internal procfs utilities (from procfs.c) */
 
 pid_t pcmk__procfs_pid_of(const char *name);

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -112,6 +112,7 @@ const char *pcmk__message_name(const char *name);
 int pcmk__scan_nvpair(const char *input, char **name, char **value);
 char *pcmk__format_nvpair(const char *name, const char *value,
                           const char *units);
+char *pcmk__format_named_time(const char *name, time_t epoch_time);
 
 
 /* internal procfs utilities (from procfs.c) */

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the Pacemaker project contributors
+ * Copyright 2013-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -39,6 +39,9 @@ extern "C" {
    is meant to carry "unset" meaning, and better not to bet on/conditionalize
    over signedness of pid_t */
 #define PCMK__SPECIAL_PID  1
+
+// Timeout (in seconds) to use for IPC client sends, reply waits, etc.
+#define PCMK__IPC_TIMEOUT 120
 
 #if defined(US_AUTH_GETPEEREID)
 /* on FreeBSD, we don't want to expose "non-yieldable PID" (leading to

--- a/include/crm/common/logging.h
+++ b/include/crm/common/logging.h
@@ -195,7 +195,7 @@ unsigned int get_crm_log_level(void);
     } while (0)
 
 #  define CRM_LOG_ASSERT(expr) do {					\
-        if(__unlikely((expr) == FALSE)) {				\
+        if (!(expr)) {                                                  \
             static struct qb_log_callsite *core_cs = NULL;              \
             if(core_cs == NULL) {                                       \
                 core_cs = qb_log_callsite_get(__func__, __FILE__,       \
@@ -211,7 +211,7 @@ unsigned int get_crm_log_level(void);
  * macro's do-while loop
  */
 #  define CRM_CHECK(expr, failure_action) do {				            \
-	    if (__unlikely((expr) == FALSE)) {				                \
+        if (!(expr)) {                                                  \
             static struct qb_log_callsite *core_cs = NULL;              \
             if (core_cs == NULL) {                                      \
                 core_cs = qb_log_callsite_get(__func__, __FILE__,       \

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the Pacemaker project contributors
+ * Copyright 2012-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -40,9 +40,9 @@ extern "C" {
 #endif
 
 #  define CRM_ASSERT(expr) do {                                              \
-        if(__unlikely((expr) == FALSE)) {                                    \
+        if (!(expr)) {                                                       \
             crm_abort(__FILE__, __func__, __LINE__, #expr, TRUE, FALSE);     \
-            abort(); /* Redundant but it makes static analyzers happy */     \
+            abort(); /* crm_abort() doesn't always abort! */                 \
         }                                                                    \
     } while(0)
 

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -38,9 +38,6 @@ extern "C" {
 #  define ONLINESTATUS  "online"  // Status of an online client
 #  define OFFLINESTATUS "offline" // Status of an offline client
 
-// public name/value pair functions (from nvpair.c)
-char *pcmk_format_named_time(const char *name, time_t epoch_time);
-
 /* public Pacemaker Remote functions (from remote.c) */
 int crm_default_remote_port(void);
 

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -39,7 +39,6 @@ extern "C" {
 #  define OFFLINESTATUS "offline" // Status of an offline client
 
 // public name/value pair functions (from nvpair.c)
-char *pcmk_format_nvpair(const char *name, const char *value, const char *units);
 char *pcmk_format_named_time(const char *name, time_t epoch_time);
 
 /* public Pacemaker Remote functions (from remote.c) */

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -39,7 +39,6 @@ extern "C" {
 #  define OFFLINESTATUS "offline" // Status of an offline client
 
 // public name/value pair functions (from nvpair.c)
-int pcmk_scan_nvpair(const char *input, char **name, char **value);
 char *pcmk_format_nvpair(const char *name, const char *value, const char *units);
 char *pcmk_format_named_time(const char *name, time_t epoch_time);
 

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -42,7 +42,6 @@ extern "C" {
 int crm_default_remote_port(void);
 
 /* public string functions (from strings.c) */
-char *crm_itoa_stack(int an_int, char *buf, size_t len);
 gboolean crm_is_true(const char *s);
 int crm_str_to_boolean(const char *s, int *ret);
 long long crm_parse_ll(const char *text, const char *default_text);

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -56,6 +56,9 @@ gboolean safe_str_neq(const char *a, const char *b);
 //! \deprecated Use strcasecmp() instead
 #define safe_str_eq(a, b) crm_str_eq(a, b, FALSE)
 
+//! \deprecated Use snprintf() instead
+char *crm_itoa_stack(int an_int, char *buf, size_t len);
+
 //! \deprecated Use sscanf() instead
 int pcmk_scan_nvpair(const char *input, char **name, char **value);
 

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -56,6 +56,9 @@ gboolean safe_str_neq(const char *a, const char *b);
 //! \deprecated Use strcasecmp() instead
 #define safe_str_eq(a, b) crm_str_eq(a, b, FALSE)
 
+//! \deprecated Use sscanf() instead
+int pcmk_scan_nvpair(const char *input, char **name, char **value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -59,6 +59,10 @@ gboolean safe_str_neq(const char *a, const char *b);
 //! \deprecated Use sscanf() instead
 int pcmk_scan_nvpair(const char *input, char **name, char **value);
 
+//! \deprecated Use a standard printf()-style function instead
+char *pcmk_format_nvpair(const char *name, const char *value,
+                         const char *units);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -63,6 +63,9 @@ int pcmk_scan_nvpair(const char *input, char **name, char **value);
 char *pcmk_format_nvpair(const char *name, const char *value,
                          const char *units);
 
+//! \deprecated Use a standard printf()-style function instead
+char *pcmk_format_named_time(const char *name, time_t epoch_time);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -72,14 +72,6 @@ extern "C" {
 #    define MAX_NAME	256
 #  endif
 
-#  ifndef __GNUC__
-#    define __builtin_expect(expr, result) (expr)
-#  endif
-
-/* Some handy macros used by the Linux kernel */
-#  define __likely(expr) __builtin_expect(expr, 1)
-#  define __unlikely(expr) __builtin_expect(expr, 0)
-
 #  define CRM_META			"CRM_meta"
 
 extern char *crm_system_name;

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -78,9 +78,6 @@ extern char *crm_system_name;
 
 /* *INDENT-OFF* */
 
-// Used for some internal IPC timeouts (maybe should be configurable option)
-#  define MAX_IPC_DELAY   120
-
 // How we represent "infinite" scores
 #  define CRM_SCORE_INFINITY    1000000
 #  define CRM_INFINITY_S        "INFINITY"

--- a/include/crm/crm_compat.h
+++ b/include/crm/crm_compat.h
@@ -26,6 +26,9 @@ extern "C" {
 //! \deprecated Use '\0' instead
 #define EOS '\0'
 
+//! \deprecated This defined constant will be removed in a future release
+#define MAX_IPC_DELAY 120
+
 //!@{
 //! \deprecated This macro will be removed in a future release
 

--- a/include/crm/crm_compat.h
+++ b/include/crm/crm_compat.h
@@ -26,8 +26,21 @@ extern "C" {
 //! \deprecated Use '\0' instead
 #define EOS '\0'
 
+//!@{
 //! \deprecated This macro will be removed in a future release
+
 #define DIMOF(a) ((int) (sizeof(a)/sizeof(a[0])))
+
+#  ifndef __GNUC__
+#    define __builtin_expect(expr, result) (expr)
+#  endif
+
+#define __likely(expr) __builtin_expect(expr, 1)
+
+#define __unlikely(expr) __builtin_expect(expr, 0)
+
+// This ends the doxygen deprecation comment
+//!@}
 
 //! \deprecated Use GList * instead
 typedef GList *GListPtr;

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2004 International Business Machines
- * Later changes copyright 2004-2020 the Pacemaker project contributors
+ * Later changes copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -155,7 +155,7 @@ cib_native_signon_raw(cib_t * cib, const char *name, enum cib_conn_type type, in
         .destroy = cib_native_destroy
     };
 
-    cib->call_timeout = MAX_IPC_DELAY;
+    cib->call_timeout = PCMK__IPC_TIMEOUT;
 
     if (type == cib_command) {
         cib->state = cib_connected_command;

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -278,9 +278,12 @@ pcmk__scan_nvpair(const char *input, char **name, char **value)
  * \param[in]     name  The name of the nvpair.
  * \param[in]     value The value of the nvpair.
  * \param[in]     units Optional units for the value, or NULL.
+ *
+ * \return Newly allocated string with name/value pair
  */
 char *
-pcmk_format_nvpair(const char *name, const char *value, const char *units) {
+pcmk__format_nvpair(const char *name, const char *value, const char *units)
+{
     return crm_strdup_printf("%s=\"%s%s\"", name, value, units ? units : "");
 }
 
@@ -288,7 +291,7 @@ pcmk_format_nvpair(const char *name, const char *value, const char *units) {
  * \internal
  * \brief Format a name/time pair.
  *
- * See pcmk_format_nvpair() for more details.
+ * See pcmk__format_nvpair() for more details.
  *
  * \note The caller is responsible for freeing the return value after use.
  *
@@ -962,6 +965,13 @@ int
 pcmk_scan_nvpair(const char *input, char **name, char **value)
 {
     return pcmk__scan_nvpair(input, name, value);
+}
+
+char *
+pcmk_format_nvpair(const char *name, const char *value,
+                   const char *units)
+{
+    return pcmk__format_nvpair(name, value, units);
 }
 
 // End deprecated API

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -297,9 +297,12 @@ pcmk__format_nvpair(const char *name, const char *value, const char *units)
  *
  * \param[in]     name       The name for the time.
  * \param[in]     epoch_time The time to format.
+ *
+ * \return Newly allocated string with name/value pair
  */
 char *
-pcmk_format_named_time(const char *name, time_t epoch_time) {
+pcmk__format_named_time(const char *name, time_t epoch_time)
+{
     const char *now_str = pcmk__epoch2str(&epoch_time);
 
     return crm_strdup_printf("%s=\"%s\"", name, now_str ? now_str : "");
@@ -972,6 +975,12 @@ pcmk_format_nvpair(const char *name, const char *value,
                    const char *units)
 {
     return pcmk__format_nvpair(name, value, units);
+}
+
+char *
+pcmk_format_named_time(const char *name, time_t epoch_time)
+{
+    return pcmk__format_named_time(name, epoch_time);
 }
 
 // End deprecated API

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -207,6 +207,7 @@ pcmk_nvpairs2xml_attrs(GSList *list, xmlNode *xml)
 // convenience function for name=value strings
 
 /*!
+ * \internal
  * \brief Extract the name and value from an input string formatted as "name=value".
  * If unable to extract them, they are returned as NULL.
  *
@@ -218,7 +219,7 @@ pcmk_nvpairs2xml_attrs(GSList *list, xmlNode *xml)
  *         and error code otherwise
  */
 int
-pcmk_scan_nvpair(const char *input, char **name, char **value)
+pcmk__scan_nvpair(const char *input, char **name, char **value)
 {
 #ifdef SSCANF_HAS_M
     *name = NULL;
@@ -952,3 +953,15 @@ xml2list(xmlNode *parent)
 
     return nvpair_hash;
 }
+
+// Deprecated functions kept only for backward API compatibility
+
+#include <crm/common/util_compat.h>
+
+int
+pcmk_scan_nvpair(const char *input, char **name, char **value)
+{
+    return pcmk__scan_nvpair(input, name, value);
+}
+
+// End deprecated API

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -24,16 +24,6 @@
 #include <bzlib.h>
 #include <sys/types.h>
 
-char *
-crm_itoa_stack(int an_int, char *buffer, size_t len)
-{
-    if (buffer != NULL) {
-        snprintf(buffer, len, "%d", an_int);
-    }
-
-    return buffer;
-}
-
 /*!
  * \internal
  * \brief Scan a long long integer from a string
@@ -1104,6 +1094,15 @@ crm_str_eq(const char *a, const char *b, gboolean use_case)
         return TRUE;
     }
     return FALSE;
+}
+
+char *
+crm_itoa_stack(int an_int, char *buffer, size_t len)
+{
+    if (buffer != NULL) {
+        snprintf(buffer, len, "%d", an_int);
+    }
+    return buffer;
 }
 
 // End deprecated API

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -95,14 +95,16 @@ char2score(const char *score)
 char *
 score2char_stack(int score, char *buf, size_t len)
 {
+    CRM_CHECK((buf != NULL) && (len >= sizeof(CRM_MINUS_INFINITY_S)),
+              return NULL);
+
     if (score >= CRM_SCORE_INFINITY) {
         strncpy(buf, CRM_INFINITY_S, 9);
     } else if (score <= -CRM_SCORE_INFINITY) {
         strncpy(buf, CRM_MINUS_INFINITY_S , 10);
     } else {
-        return crm_itoa_stack(score, buf, len);
+        snprintf(buf, len, "%d", score);
     }
-
     return buf;
 }
 

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1528,7 +1528,7 @@ stonith_api_signon(stonith_t * stonith, const char *name, int *stonith_fd)
 
             } else {
 #if HAVE_MSGFROMIPC_TIMEOUT
-                stonith->call_timeout = MAX_IPC_DELAY;
+                stonith->call_timeout = PCMK__IPC_TIMEOUT;
 #endif
                 crm_debug("Connection to fencer by %s succeeded (registration token: %s)",
                           display_name, native->token);

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -107,7 +107,8 @@ op_history_string(xmlNode *xml_op, const char *task, const char *interval_ms_s,
 
         if ((crm_element_value_epoch(xml_op, XML_RSC_OP_LAST_CHANGE, &epoch) == pcmk_ok)
             && (epoch > 0)) {
-            char *time = pcmk_format_named_time(XML_RSC_OP_LAST_CHANGE, epoch);
+            char *time = pcmk__format_named_time(XML_RSC_OP_LAST_CHANGE, epoch);
+
             last_change_str = crm_strdup_printf(" %s", time);
             free(time);
         }
@@ -1872,7 +1873,9 @@ ticket_html(pcmk__output_t *out, va_list args) {
     pe_ticket_t *ticket = va_arg(args, pe_ticket_t *);
 
     if (ticket->last_granted > -1) {
-        char *time = pcmk_format_named_time("last-granted", ticket->last_granted);
+        char *time = pcmk__format_named_time("last-granted",
+                                             ticket->last_granted);
+
         out->list_item(out, NULL, "%s:\t%s%s %s", ticket->id,
                        ticket->granted ? "granted" : "revoked",
                        ticket->standby ? " [standby]" : "",
@@ -1893,7 +1896,9 @@ pe__ticket_text(pcmk__output_t *out, va_list args) {
     pe_ticket_t *ticket = va_arg(args, pe_ticket_t *);
 
     if (ticket->last_granted > -1) {
-        char *time = pcmk_format_named_time("last-granted", ticket->last_granted);
+        char *time = pcmk__format_named_time("last-granted",
+                                             ticket->last_granted);
+
         out->list_item(out, ticket->id, "%s%s %s",
                        ticket->granted ? "granted" : "revoked",
                        ticket->standby ? " [standby]" : "",

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -91,7 +91,7 @@ op_history_string(xmlNode *xml_op, const char *task, const char *interval_ms_s,
     char *buf = NULL;
 
     if (interval_ms_s && !pcmk__str_eq(interval_ms_s, "0", pcmk__str_casei)) {
-        char *pair = pcmk_format_nvpair("interval", interval_ms_s, "ms");
+        char *pair = pcmk__format_nvpair("interval", interval_ms_s, "ms");
         interval_str = crm_strdup_printf(" %s", pair);
         free(pair);
     }
@@ -114,14 +114,14 @@ op_history_string(xmlNode *xml_op, const char *task, const char *interval_ms_s,
 
         value = crm_element_value(xml_op, XML_RSC_OP_T_EXEC);
         if (value) {
-            char *pair = pcmk_format_nvpair(XML_RSC_OP_T_EXEC, value, "ms");
+            char *pair = pcmk__format_nvpair(XML_RSC_OP_T_EXEC, value, "ms");
             exec_str = crm_strdup_printf(" %s", pair);
             free(pair);
         }
 
         value = crm_element_value(xml_op, XML_RSC_OP_T_QUEUE);
         if (value) {
-            char *pair = pcmk_format_nvpair(XML_RSC_OP_T_QUEUE, value, "ms");
+            char *pair = pcmk__format_nvpair(XML_RSC_OP_T_QUEUE, value, "ms");
             queue_str = crm_strdup_printf(" %s", pair);
             free(pair);
         }

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -766,7 +766,7 @@ option_cb(const gchar *option_name, const gchar *optarg, gpointer data,
     char *name = NULL;
     char *value = NULL;
 
-    if (pcmk_scan_nvpair(optarg, &name, &value) != 2) {
+    if (pcmk__scan_nvpair(optarg, &name, &value) != 2) {
         return FALSE;
     }
     if (options.cmdline_params == NULL) {

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -278,7 +278,7 @@ add_stonith_params(const gchar *option_name, const gchar *optarg, gpointer data,
 
     crm_info("Scanning: -o %s", optarg);
 
-    rc = pcmk_scan_nvpair(optarg, &name, &value);
+    rc = pcmk__scan_nvpair(optarg, &name, &value);
 
     if (rc != 2) {
         rc = pcmk_legacy2rc(rc);


### PR DESCRIPTION
This is mostly renaming some functions to internal equivalents and leaving the old names as deprecated wrappers.

The most interesting thing is dropping the use of __builtin_expect() (__likely()/__unlikely) compiler hinting.