### PR TITLE
Deprecate public API for hash table creation

### DIFF
--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -151,7 +151,7 @@ create_attribute(xmlNode *xml)
     a->id      = crm_element_value_copy(xml, PCMK__XA_ATTR_NAME);
     a->set     = crm_element_value_copy(xml, PCMK__XA_ATTR_SET);
     a->uuid    = crm_element_value_copy(xml, PCMK__XA_ATTR_UUID);
-    a->values = g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal, NULL, free_attribute_value);
+    a->values = pcmk__strikey_table(NULL, free_attribute_value);
 
     crm_element_value_int(xml, PCMK__XA_ATTR_IS_PRIVATE, &a->is_private);
 
@@ -1239,9 +1239,7 @@ write_attribute(attribute_t *a, bool ignore_delay)
     a->force_write = FALSE;    
 
     /* Make the table for the attribute trap */
-    alert_attribute_value = g_hash_table_new_full(crm_strcase_hash,
-                                                  crm_strcase_equal, NULL,
-                                                  free_attribute_value);
+    alert_attribute_value = pcmk__strikey_table(NULL, free_attribute_value);
 
     /* Iterate over each peer value of this attribute */
     g_hash_table_iter_init(&iter, a->values);

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -385,7 +385,7 @@ main(int argc, char **argv)
         old_instance = NULL;
     }
 
-    attributes = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free_attribute);
+    attributes = pcmk__strkey_table(NULL, free_attribute);
 
     /* Connect to the CIB before connecting to the cluster or listening for IPC.
      * This allows us to assume the CIB is connected whenever we process a

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -445,12 +445,12 @@ check_local_notify(int bcast_id)
         return;
     }
 
-    notify = g_hash_table_lookup(local_notify_queue, GINT_TO_POINTER(bcast_id));
+    notify = pcmk__intkey_table_lookup(local_notify_queue, bcast_id);
 
     if (notify) {
         do_local_notify(notify->notify_src, notify->client_id, notify->sync_reply,
                         notify->from_peer);
-        g_hash_table_remove(local_notify_queue, GINT_TO_POINTER(bcast_id));
+        pcmk__intkey_table_remove(local_notify_queue, bcast_id);
     }
 }
 
@@ -466,12 +466,9 @@ queue_local_notify(xmlNode * notify_src, const char *client_id, gboolean sync_re
     notify->from_peer = from_peer;
 
     if (!local_notify_queue) {
-        local_notify_queue = g_hash_table_new_full(g_direct_hash,
-                                                   g_direct_equal, NULL,
-                                                   local_notify_destroy_callback);
+        local_notify_queue = pcmk__intkey_table(local_notify_destroy_callback);
     }
-
-    g_hash_table_insert(local_notify_queue, GINT_TO_POINTER(cib_local_bcast_num), notify);
+    pcmk__intkey_table_insert(local_notify_queue, cib_local_bcast_num, notify);
     // cppcheck doesn't know notify will get freed when hash table is destroyed
     // cppcheck-suppress memleak
 }

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -174,7 +174,7 @@ cib_get_operation_id(const char *op, int *operation)
         int lpc = 0;
         int max_msg_types = PCMK__NELEM(cib_server_ops);
 
-        operation_hash = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free);
+        operation_hash = pcmk__strkey_table(NULL, free);
         for (lpc = 1; lpc < max_msg_types; lpc++) {
             int *value = malloc(sizeof(int));
 

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -315,7 +315,7 @@ cib_init(void)
 #endif
     }
 
-    config_hash = crm_str_table_new();
+    config_hash = pcmk__strkey_table(free, free);
 
     if (startCib("cib.xml") == FALSE) {
         crm_crit("Cannot start CIB... terminating");

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -714,7 +714,7 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     }
 
     crm_debug("Call %d : Parsing CIB options", call_id);
-    config_hash = crm_str_table_new();
+    config_hash = pcmk__strkey_table(free, free);
     pe_unpack_nvpairs(crmconfig, crmconfig, XML_CIB_TAG_PROPSET, NULL,
                       config_hash, CIB_OPTIONS_FIRST, FALSE, now, NULL);
 

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -230,7 +230,7 @@ update_history_cache(lrm_state_t * lrm_state, lrmd_rsc_info_t * rsc, lrmd_event_
             if (entry->stop_params) {
                 g_hash_table_destroy(entry->stop_params);
             }
-            entry->stop_params = crm_str_table_new();
+            entry->stop_params = pcmk__strkey_table(free, free);
 
             g_hash_table_foreach(op->params, copy_instance_keys, entry->stop_params);
         }
@@ -1922,7 +1922,7 @@ construct_op(lrm_state_t *lrm_state, xmlNode *rsc_op, const char *rsc_id,
          *   us down).
          * So we should put our version here.
          */
-        op->params = crm_str_table_new();
+        op->params = pcmk__strkey_table(free, free);
 
         g_hash_table_insert(op->params, strdup(XML_ATTR_CRM_VERSION), strdup(CRM_FEATURE_SET));
 
@@ -1984,7 +1984,7 @@ construct_op(lrm_state_t *lrm_state, xmlNode *rsc_op, const char *rsc_id,
         } else {
             /* Copy the cached parameter list so that we stop the resource
              * with the old attributes, not the new ones */
-            op->params = crm_str_table_new();
+            op->params = pcmk__strkey_table(free, free);
 
             g_hash_table_foreach(params, copy_meta_keys, op->params);
             g_hash_table_foreach(entry->stop_params, copy_instance_keys, op->params);

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -117,24 +117,14 @@ lrm_state_create(const char *node_name)
     }
 
     state->node_name = strdup(node_name);
-
-    state->rsc_info_cache = g_hash_table_new_full(crm_str_hash,
-                                                g_str_equal, NULL, free_rsc_info);
-
-    state->deletion_ops = g_hash_table_new_full(crm_str_hash, g_str_equal, free,
-                                                free_deletion_op);
-
-    state->pending_ops = g_hash_table_new_full(crm_str_hash, g_str_equal, free,
-                                               free_recurring_op);
-
-    state->resource_history = g_hash_table_new_full(crm_str_hash,
-                                                    g_str_equal, NULL, history_free);
-
+    state->rsc_info_cache = pcmk__strkey_table(NULL, free_rsc_info);
+    state->deletion_ops = pcmk__strkey_table(free, free_deletion_op);
+    state->pending_ops = pcmk__strkey_table(free, free_recurring_op);
+    state->resource_history = pcmk__strkey_table(NULL, history_free);
     state->metadata_cache = metadata_cache_new();
 
     g_hash_table_insert(lrm_state_table, (char *)state->node_name, state);
     return state;
-
 }
 
 void
@@ -457,7 +447,7 @@ remote_config_check(xmlNode * msg, int call_id, int rc, xmlNode * output, void *
     } else {
         lrmd_t * lrmd = (lrmd_t *)user_data;
         crm_time_t *now = crm_time_new(NULL);
-        GHashTable *config_hash = crm_str_table_new();
+        GHashTable *config_hash = pcmk__strkey_table(free, free);
 
         crm_debug("Call %d : Parsing CIB options", call_id);
 

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -217,14 +217,12 @@ lrm_state_init_local(void)
         return TRUE;
     }
 
-    lrm_state_table =
-        g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal, NULL, internal_lrm_state_destroy);
+    lrm_state_table = pcmk__strikey_table(NULL, internal_lrm_state_destroy);
     if (!lrm_state_table) {
         return FALSE;
     }
 
-    proxy_table =
-        g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal, NULL, remote_proxy_free);
+    proxy_table = pcmk__strikey_table(NULL, remote_proxy_free);
     if (!proxy_table) {
         g_hash_table_destroy(lrm_state_table);
         lrm_state_table = NULL;

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -134,7 +134,7 @@ st_fail_count_increment(const char *target)
     struct st_fail_rec *rec = NULL;
 
     if (stonith_failures == NULL) {
-        stonith_failures = crm_str_table_new();
+        stonith_failures = pcmk__strkey_table(free, free);
     }
 
     rec = g_hash_table_lookup(stonith_failures, target);

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -704,7 +704,7 @@ handle_lrm_delete(xmlNode *stored_msg)
             op = lrmd_new_event(rsc_id, CRMD_ACTION_DELETE, 0);
             op->type = lrmd_event_exec_complete;
             op->user_data = strdup(transition? transition : FAKE_TE_ID);
-            op->params = crm_str_table_new();
+            op->params = pcmk__strkey_table(free, free);
             g_hash_table_insert(op->params, strdup(XML_ATTR_CRM_VERSION),
                                 strdup(CRM_FEATURE_SET));
             controld_rc2event(op, rc);

--- a/daemons/controld/controld_metadata.c
+++ b/daemons/controld/controld_metadata.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the Pacemaker project contributors
+ * Copyright 2017-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -52,8 +52,7 @@ metadata_free(void *metadata)
 GHashTable *
 metadata_cache_new()
 {
-    return g_hash_table_new_full(crm_str_hash, g_str_equal, free,
-                                 metadata_free);
+    return pcmk__strkey_table(free, metadata_free);
 }
 
 void

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -382,7 +382,7 @@ report_remote_ra_result(remote_ra_cmd_t * cmd)
     if (cmd->params) {
         lrmd_key_value_t *tmp;
 
-        op.params = crm_str_table_new();
+        op.params = pcmk__strkey_table(free, free);
         for (tmp = cmd->params; tmp; tmp = tmp->next) {
             g_hash_table_insert(op.params, strdup(tmp->key), strdup(tmp->value));
         }

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -402,7 +402,7 @@ void te_reset_job_counts(void)
     struct te_peer_s *peer = NULL;
 
     if(te_targets == NULL) {
-        te_targets = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, te_peer_free);
+        te_targets = pcmk__strkey_table(NULL, te_peer_free);
     }
 
     g_hash_table_iter_init(&iter, te_targets);

--- a/daemons/controld/controld_throttle.c
+++ b/daemons/controld/controld_throttle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the Pacemaker project contributors
+ * Copyright 2013-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -426,8 +426,7 @@ void
 throttle_init(void)
 {
     if(throttle_records == NULL) {
-        throttle_records = g_hash_table_new_full(
-            crm_str_hash, g_str_equal, NULL, throttle_record_free);
+        throttle_records = pcmk__strkey_table(NULL, throttle_record_free);
         throttle_timer = mainloop_timer_add("throttle", 30 * 1000, TRUE, throttle_timer_cb, NULL);
     }
 

--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the Pacemaker project contributors
+ * Copyright 2012-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -483,7 +483,7 @@ generate_params(void)
     }
 
     params = pe_rsc_params(rsc, NULL, data_set);
-    meta = crm_str_table_new();
+    meta = pcmk__strkey_table(free, free);
 
     get_meta_attributes(meta, rsc, NULL, data_set);
 

--- a/daemons/execd/execd_alerts.c
+++ b/daemons/execd/execd_alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the Pacemaker project contributors
+ * Copyright 2016-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -28,17 +28,17 @@ static inline void
 add_inflight_alert(int call_id, int timeout)
 {
     if (inflight_alerts == NULL) {
-        inflight_alerts = g_hash_table_new(g_direct_hash, g_direct_equal);
+        inflight_alerts = pcmk__intkey_table(NULL);
     }
-    g_hash_table_insert(inflight_alerts, GINT_TO_POINTER(call_id),
-                        GINT_TO_POINTER(timeout));
+    pcmk__intkey_table_insert(inflight_alerts, call_id,
+                              GINT_TO_POINTER(timeout));
 }
 
 static inline void
 remove_inflight_alert(int call_id)
 {
     if (inflight_alerts != NULL) {
-        g_hash_table_remove(inflight_alerts, GINT_TO_POINTER(call_id));
+        pcmk__intkey_table_remove(inflight_alerts, call_id);
     }
 }
 

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1358,7 +1358,7 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
     }
 #endif
 
-    params_copy = crm_str_table_dup(cmd->params);
+    params_copy = pcmk__str_table_dup(cmd->params);
 
     action = resources_action_create(rsc->rsc_id, rsc->class, rsc->provider,
                                      rsc->type,

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -490,7 +490,7 @@ main(int argc, char **argv, char **envp)
     /* Used by RAs - Leave owned by root */
     crm_build_path(CRM_RSCTMP_DIR, 0755);
 
-    rsc_list = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free_rsc);
+    rsc_list = pcmk__strkey_table(NULL, free_rsc);
     ipcs = mainloop_add_ipc_server(CRM_SYSTEM_LRMD, QB_IPC_SHM, &lrmd_ipc_callbacks);
     if (ipcs == NULL) {
         crm_err("Failed to create IPC server: shutting down and inhibiting respawn");

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the Pacemaker project contributors
+ * Copyright 2012-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -431,7 +431,7 @@ ipc_proxy_remove_provider(pcmk__client_t *ipc_proxy)
 void
 ipc_proxy_init(void)
 {
-    ipc_clients = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, NULL);
+    ipc_clients = pcmk__strkey_table(NULL, NULL);
 
     pcmk__serve_based_ipc(&cib_ro, &cib_rw, &cib_shm, &cib_proxy_callbacks_ro,
                           &cib_proxy_callbacks_rw);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -618,8 +618,7 @@ void
 init_device_list(void)
 {
     if (device_list == NULL) {
-        device_list = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL,
-                                            free_device);
+        device_list = pcmk__strkey_table(NULL, free_device);
     }
 }
 
@@ -703,7 +702,7 @@ free_metadata_cache(void) {
 static void
 init_metadata_cache(void) {
     if (metadata_cache == NULL) {
-        metadata_cache = crm_str_table_new();
+        metadata_cache = pcmk__strkey_table(free, free);
     }
 }
 
@@ -1336,8 +1335,7 @@ void
 init_topology_list(void)
 {
     if (topology == NULL) {
-        topology = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL,
-                                         free_topology_entry);
+        topology = pcmk__strkey_table(NULL, free_topology_entry);
     }
 }
 

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -627,7 +627,7 @@ build_port_aliases(const char *hostmap, GList ** targets)
 {
     char *name = NULL;
     int last = 0, lpc = 0, max = 0, added = 0;
-    GHashTable *aliases = crm_strcase_table_new();
+    GHashTable *aliases = pcmk__strikey_table(free, free);
 
     if (hostmap == NULL) {
         return aliases;

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2020 the Pacemaker project contributors
+ * Copyright 2009-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -265,7 +265,7 @@ void
 init_stonith_remote_op_hash_table(GHashTable **table)
 {
     if (*table == NULL) {
-        *table = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free_remote_op);
+        *table = pcmk__strkey_table(NULL, free_remote_op);
     }
 }
 
@@ -1875,7 +1875,7 @@ add_result(remote_fencing_op_t *op, const char *host, int ndevices, xmlNode *xml
     // cppcheck-suppress memleak
     CRM_CHECK(result != NULL, return NULL);
     result->host = strdup(host);
-    result->devices = crm_str_table_new();
+    result->devices = pcmk__strkey_table(free, free);
 
     /* Each child element describes one capable device available to the peer */
     for (child = pcmk__xml_first_child(xml); child != NULL;

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the Pacemaker project contributors
+ * Copyright 2015-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -41,6 +41,10 @@ int pcmk__compress(const char *data, unsigned int length, unsigned int max,
                    char **result, unsigned int *result_len);
 
 int pcmk__parse_ll_range(const char *srcstring, long long *start, long long *end);
+
+GHashTable *pcmk__strkey_table(GDestroyNotify key_destroy_func,
+                               GDestroyNotify value_destroy_func);
+
 gboolean pcmk__str_in_list(GList *lst, const gchar *s);
 
 bool pcmk__strcase_any_of(const char *s, ...) G_GNUC_NULL_TERMINATED;

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -44,6 +44,8 @@ int pcmk__parse_ll_range(const char *srcstring, long long *start, long long *end
 
 GHashTable *pcmk__strkey_table(GDestroyNotify key_destroy_func,
                                GDestroyNotify value_destroy_func);
+GHashTable *pcmk__strikey_table(GDestroyNotify key_destroy_func,
+                                GDestroyNotify value_destroy_func);
 
 gboolean pcmk__str_in_list(GList *lst, const gchar *s);
 

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -46,6 +46,7 @@ GHashTable *pcmk__strkey_table(GDestroyNotify key_destroy_func,
                                GDestroyNotify value_destroy_func);
 GHashTable *pcmk__strikey_table(GDestroyNotify key_destroy_func,
                                 GDestroyNotify value_destroy_func);
+GHashTable *pcmk__str_table_dup(GHashTable *old_table);
 
 gboolean pcmk__str_in_list(GList *lst, const gchar *s);
 

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -48,6 +48,71 @@ GHashTable *pcmk__strikey_table(GDestroyNotify key_destroy_func,
                                 GDestroyNotify value_destroy_func);
 GHashTable *pcmk__str_table_dup(GHashTable *old_table);
 
+/*!
+ * \internal
+ * \brief Create a hash table with integer keys
+ *
+ * \param[in] value_destroy_func  Function to free a value
+ *
+ * \return Newly allocated hash table
+ * \note It is the caller's responsibility to free the result, using
+ *       g_hash_table_destroy().
+ */
+static inline GHashTable *
+pcmk__intkey_table(GDestroyNotify value_destroy_func)
+{
+    return g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL,
+                                 value_destroy_func);
+}
+
+/*!
+ * \internal
+ * \brief Insert a value into a hash table with integer keys
+ *
+ * \param[in,out] hash_table  Table to insert into
+ * \param[in]     key         Integer key to insert
+ * \param[in]     value       Value to insert
+ *
+ * \return Whether the key/value was already in the table
+ * \note This has the same semantics as g_hash_table_insert(). If the key
+ *       already exists in the table, the old value is freed and replaced.
+ */
+static inline gboolean
+pcmk__intkey_table_insert(GHashTable *hash_table, int key, gpointer value)
+{
+    return g_hash_table_insert(hash_table, GINT_TO_POINTER(key), value);
+}
+
+/*!
+ * \internal
+ * \brief Look up a value in a hash table with integer keys
+ *
+ * \param[in] hash_table  Table to check
+ * \param[in] key         Integer key to look for
+ *
+ * \return Value in table for \key (or NULL if not found)
+ */
+static inline gpointer
+pcmk__intkey_table_lookup(GHashTable *hash_table, int key)
+{
+    return g_hash_table_lookup(hash_table, GINT_TO_POINTER(key));
+}
+
+/*!
+ * \internal
+ * \brief Remove a key/value from a hash table with integer keys
+ *
+ * \param[in] hash_table  Table to modify
+ * \param[in] key         Integer key of entry to remove
+ *
+ * \return Whether \p key was found and removed from \p hash_table
+ */
+static inline gboolean
+pcmk__intkey_table_remove(GHashTable *hash_table, int key)
+{
+    return g_hash_table_remove(hash_table, GINT_TO_POINTER(key));
+}
+
 gboolean pcmk__str_in_list(GList *lst, const gchar *s);
 
 bool pcmk__strcase_any_of(const char *s, ...) G_GNUC_NULL_TERMINATED;

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -48,7 +48,6 @@ long long crm_parse_ll(const char *text, const char *default_text);
 int crm_parse_int(const char *text, const char *default_text);
 long long crm_get_msec(const char *input);
 char * crm_strip_trailing_newline(char *str);
-gboolean crm_strcase_equal(gconstpointer a, gconstpointer b);
 guint crm_strcase_hash(gconstpointer v);
 char *crm_strdup_printf(char const *format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));
 int pcmk_numeric_strcasecmp(const char *s1, const char *s2);

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -75,19 +75,6 @@ crm_ttoa(time_t epoch_time)
 }
 
 /*!
- * \brief Create hash table with dynamically allocated string keys/values
- *
- * \return Newly allocated hash table
- * \note It is the caller's responsibility to free the result, using
- *       g_hash_table_destroy().
- */
-static inline GHashTable *
-crm_str_table_new(void)
-{
-    return g_hash_table_new_full(crm_str_hash, g_str_equal, free, free);
-}
-
-/*!
  * \brief Create hash table with case-insensitive dynamically allocated string keys/values
  *
  * \return Newly allocated hash table

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -48,7 +48,6 @@ long long crm_parse_ll(const char *text, const char *default_text);
 int crm_parse_int(const char *text, const char *default_text);
 long long crm_get_msec(const char *input);
 char * crm_strip_trailing_newline(char *str);
-guint crm_strcase_hash(gconstpointer v);
 char *crm_strdup_printf(char const *format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));
 int pcmk_numeric_strcasecmp(const char *s1, const char *s2);
 

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -69,8 +69,6 @@ crm_ttoa(time_t epoch_time)
     return crm_strdup_printf("%lld", (long long) epoch_time);
 }
 
-GHashTable *crm_str_table_dup(GHashTable *old_table);
-
 #  define crm_atoi(text, default_text) crm_parse_int(text, default_text)
 
 /* public I/O functions (from io.c) */

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -50,7 +50,6 @@ long long crm_get_msec(const char *input);
 char * crm_strip_trailing_newline(char *str);
 gboolean crm_strcase_equal(gconstpointer a, gconstpointer b);
 guint crm_strcase_hash(gconstpointer v);
-guint g_str_hash_traditional(gconstpointer v);
 char *crm_strdup_printf(char const *format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));
 int pcmk_numeric_strcasecmp(const char *s1, const char *s2);
 

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -71,19 +71,6 @@ crm_ttoa(time_t epoch_time)
     return crm_strdup_printf("%lld", (long long) epoch_time);
 }
 
-/*!
- * \brief Create hash table with case-insensitive dynamically allocated string keys/values
- *
- * \return Newly allocated hash table
- * \note It is the caller's responsibility to free the result, using
- *       g_hash_table_destroy().
- */
-static inline GHashTable *
-crm_strcase_table_new(void)
-{
-    return g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal, free, free);
-}
-
 GHashTable *crm_str_table_dup(GHashTable *old_table);
 
 #  define crm_atoi(text, default_text) crm_parse_int(text, default_text)

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -54,8 +54,6 @@ guint g_str_hash_traditional(gconstpointer v);
 char *crm_strdup_printf(char const *format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));
 int pcmk_numeric_strcasecmp(const char *s1, const char *s2);
 
-#  define crm_str_hash g_str_hash_traditional
-
 static inline char *
 crm_itoa(int an_int)
 {

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -82,6 +82,14 @@ crm_str_table_new(void)
     return g_hash_table_new_full(crm_str_hash, g_str_equal, free, free);
 }
 
+//! \deprecated Use g_hash_table_new_full() instead
+static inline GHashTable *
+crm_strcase_table_new(void)
+{
+    return g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal,
+                                 free, free);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -96,6 +96,9 @@ crm_strcase_table_new(void)
                                  free, free);
 }
 
+//! \deprecated Do not use Pacemaker for generic hash table manipulation
+GHashTable *crm_str_table_dup(GHashTable *old_table);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -75,6 +75,9 @@ guint g_str_hash_traditional(gconstpointer v);
 //! \deprecated Use g_str_hash() instead
 #define crm_str_hash g_str_hash_traditional
 
+//! \deprecated Do not use Pacemaker for generic string comparison
+gboolean crm_strcase_equal(gconstpointer a, gconstpointer b);
+
 //! \deprecated Use g_hash_table_new_full() instead
 static inline GHashTable *
 crm_str_table_new(void)

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -69,6 +69,9 @@ char *pcmk_format_nvpair(const char *name, const char *value,
 //! \deprecated Use a standard printf()-style function instead
 char *pcmk_format_named_time(const char *name, time_t epoch_time);
 
+//! \deprecated Use g_str_hash() instead
+#define crm_str_hash g_str_hash_traditional
+
 //! \deprecated Use g_hash_table_new_full() instead
 static inline GHashTable *
 crm_str_table_new(void)

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -70,6 +70,9 @@ char *pcmk_format_nvpair(const char *name, const char *value,
 char *pcmk_format_named_time(const char *name, time_t epoch_time);
 
 //! \deprecated Use g_str_hash() instead
+guint g_str_hash_traditional(gconstpointer v);
+
+//! \deprecated Use g_str_hash() instead
 #define crm_str_hash g_str_hash_traditional
 
 //! \deprecated Use g_hash_table_new_full() instead

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -78,6 +78,9 @@ guint g_str_hash_traditional(gconstpointer v);
 //! \deprecated Do not use Pacemaker for generic string comparison
 gboolean crm_strcase_equal(gconstpointer a, gconstpointer b);
 
+//! \deprecated Do not use Pacemaker for generic string manipulation
+guint crm_strcase_hash(gconstpointer v);
+
 //! \deprecated Use g_hash_table_new_full() instead
 static inline GHashTable *
 crm_str_table_new(void)

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -69,6 +69,13 @@ char *pcmk_format_nvpair(const char *name, const char *value,
 //! \deprecated Use a standard printf()-style function instead
 char *pcmk_format_named_time(const char *name, time_t epoch_time);
 
+//! \deprecated Use g_hash_table_new_full() instead
+static inline GHashTable *
+crm_str_table_new(void)
+{
+    return g_hash_table_new_full(crm_str_hash, g_str_equal, free, free);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -641,7 +641,7 @@ cib_client_register_callback_full(cib_t *cib, int call_id, int timeout,
     }
 
     crm_trace("Adding callback %s for call %d", callback_name, call_id);
-    g_hash_table_insert(cib_op_callback_table, GINT_TO_POINTER(call_id), blob);
+    pcmk__intkey_table_insert(cib_op_callback_table, call_id, blob);
 
     return TRUE;
 }
@@ -651,10 +651,9 @@ remove_cib_op_callback(int call_id, gboolean all_callbacks)
 {
     if (all_callbacks) {
         destroy_op_callback_table();
-        cib_op_callback_table = g_hash_table_new_full(g_direct_hash, g_direct_equal,
-                                                      NULL, cib_destroy_op_callback);
+        cib_op_callback_table = pcmk__intkey_table(cib_destroy_op_callback);
     } else {
-        g_hash_table_remove(cib_op_callback_table, GINT_TO_POINTER(call_id));
+        pcmk__intkey_table_remove(cib_op_callback_table, call_id);
     }
 }
 

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -538,7 +538,7 @@ cib_native_callback(cib_t * cib, xmlNode * msg, int call_id, int rc)
         output = get_message_xml(msg, F_CIB_CALLDATA);
     }
 
-    blob = g_hash_table_lookup(cib_op_callback_table, GINT_TO_POINTER(call_id));
+    blob = pcmk__intkey_table_lookup(cib_op_callback_table, call_id);
     if (blob == NULL) {
         crm_trace("No callback found for call %d", call_id);
     }

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -189,7 +189,7 @@ cib_acl_enabled(xmlNode *xml, const char *user)
 
     if(pcmk_acl_required(user)) {
         const char *value = NULL;
-        GHashTable *options = crm_str_table_new();
+        GHashTable *options = pcmk__strkey_table(free, free);
 
         cib_read_config(options, xml);
         value = cib_pref(options, "enable-acl");

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -488,7 +488,7 @@ record_vote(election_t *e, struct vote *vote)
 
     CRM_ASSERT(e && vote && vote->from && vote->op);
     if (e->voted == NULL) {
-        e->voted = crm_str_table_new();
+        e->voted = pcmk__strkey_table(free, free);
     }
 
     voter_copy = strdup(vote->from);

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -401,17 +401,15 @@ void
 crm_peer_init(void)
 {
     if (crm_peer_cache == NULL) {
-        crm_peer_cache = g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal, free, destroy_crm_node);
+        crm_peer_cache = pcmk__strikey_table(free, destroy_crm_node);
     }
 
     if (crm_remote_peer_cache == NULL) {
-        crm_remote_peer_cache = g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal, NULL, destroy_crm_node);
+        crm_remote_peer_cache = pcmk__strikey_table(NULL, destroy_crm_node);
     }
 
     if (known_node_cache == NULL) {
-        known_node_cache = g_hash_table_new_full(crm_strcase_hash,
-                                                 crm_strcase_equal, free,
-                                                 destroy_crm_node);
+        known_node_cache = pcmk__strikey_table(free, destroy_crm_node);
     }
 }
 

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the Pacemaker project contributors
+ * Copyright 2015-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -136,7 +136,7 @@ pcmk__dup_alert(pcmk__alert_t *entry)
 
     new_entry->timeout = entry->timeout;
     new_entry->flags = entry->flags;
-    new_entry->envvars = crm_str_table_dup(entry->envvars);
+    new_entry->envvars = pcmk__str_table_dup(entry->envvars);
     if (entry->tstamp_format) {
         new_entry->tstamp_format = strdup(entry->tstamp_format);
     }

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -920,7 +920,7 @@ xml2list(xmlNode *parent)
     xmlNode *child = NULL;
     xmlAttrPtr pIter = NULL;
     xmlNode *nvpair_list = NULL;
-    GHashTable *nvpair_hash = crm_str_table_new();
+    GHashTable *nvpair_hash = pcmk__strkey_table(free, free);
 
     CRM_CHECK(parent != NULL, return nvpair_hash);
 

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -67,8 +67,7 @@ pcmk__output_new(pcmk__output_t **out, const char *fmt_name, const char *filenam
     }
 
     (*out)->quiet = false;
-
-    (*out)->messages = g_hash_table_new_full(crm_str_hash, g_str_equal, free, NULL);
+    (*out)->messages = pcmk__strkey_table(free, NULL);
 
     if ((*out)->init(*out) == false) {
         pcmk__output_free(*out);
@@ -86,7 +85,7 @@ pcmk__register_format(GOptionGroup *group, const char *name,
     }
 
     if (formatters == NULL) {
-        formatters = g_hash_table_new_full(crm_str_hash, g_str_equal, free, NULL);
+        formatters = pcmk__strkey_table(free, NULL);
     }
 
     if (options != NULL && group != NULL) {

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -588,6 +588,25 @@ crm_strcase_hash(gconstpointer v)
     return h;
 }
 
+/*!
+ * \internal
+ * \brief Create a hash table with case-insensitive strings as keys
+ *
+ * \param[in] key_destroy_func    Function to free a key
+ * \param[in] value_destroy_func  Function to free a value
+ *
+ * \return Newly allocated hash table
+ * \note It is the caller's responsibility to free the result, using
+ *       g_hash_table_destroy().
+ */
+GHashTable *
+pcmk__strikey_table(GDestroyNotify key_destroy_func,
+                    GDestroyNotify value_destroy_func)
+{
+    return g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal,
+                                 key_destroy_func, value_destroy_func);
+}
+
 static void
 copy_str_table_entry(gpointer key, gpointer value, gpointer user_data)
 {

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -576,8 +576,8 @@ pcmk__strcase_equal(gconstpointer a, gconstpointer b)
     return pcmk__str_eq((const char *)a, (const char *)b, pcmk__str_casei);
 }
 
-guint
-crm_strcase_hash(gconstpointer v)
+static guint
+pcmk__strcase_hash(gconstpointer v)
 {
     const signed char *p;
     guint32 h = 0;
@@ -603,7 +603,7 @@ GHashTable *
 pcmk__strikey_table(GDestroyNotify key_destroy_func,
                     GDestroyNotify value_destroy_func)
 {
-    return g_hash_table_new_full(crm_strcase_hash, pcmk__strcase_equal,
+    return g_hash_table_new_full(pcmk__strcase_hash, pcmk__strcase_equal,
                                  key_destroy_func, value_destroy_func);
 }
 
@@ -1159,6 +1159,12 @@ gboolean
 crm_strcase_equal(gconstpointer a, gconstpointer b)
 {
     return pcmk__strcase_equal(a, b);
+}
+
+guint
+crm_strcase_hash(gconstpointer v)
+{
+    return pcmk__strcase_hash(v);
 }
 
 // End deprecated API

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -615,8 +615,18 @@ copy_str_table_entry(gpointer key, gpointer value, gpointer user_data)
     }
 }
 
+/*!
+ * \internal
+ * \brief Copy a hash table that uses dynamically allocated strings
+ *
+ * \param[in] old_table  Hash table to duplicate
+ *
+ * \return New hash table with copies of everything in \p old_table
+ * \note This assumes the hash table uses dynamically allocated strings -- that
+ *       is, both the key and value free functions are free().
+ */
 GHashTable *
-crm_str_table_dup(GHashTable *old_table)
+pcmk__str_table_dup(GHashTable *old_table)
 {
     GHashTable *new_table = NULL;
 
@@ -1165,6 +1175,12 @@ guint
 crm_strcase_hash(gconstpointer v)
 {
     return pcmk__strcase_hash(v);
+}
+
+GHashTable *
+crm_str_table_dup(GHashTable *old_table)
+{
+    return pcmk__str_table_dup(old_table);
 }
 
 // End deprecated API

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -544,6 +544,25 @@ g_str_hash_traditional(gconstpointer v)
     return h;
 }
 
+/*!
+ * \internal
+ * \brief Create a hash table with case-sensitive strings as keys
+ *
+ * \param[in] key_destroy_func    Function to free a key
+ * \param[in] value_destroy_func  Function to free a value
+ *
+ * \return Newly allocated hash table
+ * \note It is the caller's responsibility to free the result, using
+ *       g_hash_table_destroy().
+ */
+GHashTable *
+pcmk__strkey_table(GDestroyNotify key_destroy_func,
+                   GDestroyNotify value_destroy_func)
+{
+    return g_hash_table_new_full(g_str_hash_traditional, g_str_equal,
+                                 key_destroy_func, value_destroy_func);
+}
+
 /* used with hash tables where case does not matter */
 gboolean
 crm_strcase_equal(gconstpointer a, gconstpointer b)
@@ -577,7 +596,7 @@ crm_str_table_dup(GHashTable *old_table)
     GHashTable *new_table = NULL;
 
     if (old_table) {
-        new_table = crm_str_table_new();
+        new_table = pcmk__strkey_table(free, free);
         g_hash_table_foreach(old_table, copy_str_table_entry, new_table);
     }
     return new_table;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -570,8 +570,8 @@ pcmk__strkey_table(GDestroyNotify key_destroy_func,
 }
 
 /* used with hash tables where case does not matter */
-gboolean
-crm_strcase_equal(gconstpointer a, gconstpointer b)
+static gboolean
+pcmk__strcase_equal(gconstpointer a, gconstpointer b)
 {
     return pcmk__str_eq((const char *)a, (const char *)b, pcmk__str_casei);
 }
@@ -603,7 +603,7 @@ GHashTable *
 pcmk__strikey_table(GDestroyNotify key_destroy_func,
                     GDestroyNotify value_destroy_func)
 {
-    return g_hash_table_new_full(crm_strcase_hash, crm_strcase_equal,
+    return g_hash_table_new_full(crm_strcase_hash, pcmk__strcase_equal,
                                  key_destroy_func, value_destroy_func);
 }
 
@@ -1153,6 +1153,12 @@ guint
 g_str_hash_traditional(gconstpointer v)
 {
     return pcmk__str_hash(v);
+}
+
+gboolean
+crm_strcase_equal(gconstpointer a, gconstpointer b)
+{
+    return pcmk__strcase_equal(a, b);
 }
 
 // End deprecated API

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -519,8 +519,14 @@ pcmk__ends_with_ext(const char *s, const char *match)
     return ends_with(s, match, true);
 }
 
-/*
- * This re-implements g_str_hash as it was prior to glib2-2.28:
+/*!
+ * \internal
+ * \brief Create a hash of a string suitable for use with GHashTable
+ *
+ * \param[in] v  String to hash
+ *
+ * \return A hash of \p v compatible with g_str_hash() before glib 2.28
+ * \note glib changed their hash implementation:
  *
  * https://gitlab.gnome.org/GNOME/glib/commit/354d655ba8a54b754cb5a3efb42767327775696c
  *
@@ -532,8 +538,8 @@ pcmk__ends_with_ext(const char *s, const char *match)
  * also appears to have some minor impact on the ordering of a few
  * pseudo_event IDs in the transition graph.
  */
-guint
-g_str_hash_traditional(gconstpointer v)
+static guint
+pcmk__str_hash(gconstpointer v)
 {
     const signed char *p;
     guint32 h = 0;
@@ -559,7 +565,7 @@ GHashTable *
 pcmk__strkey_table(GDestroyNotify key_destroy_func,
                    GDestroyNotify value_destroy_func)
 {
-    return g_hash_table_new_full(g_str_hash_traditional, g_str_equal,
+    return g_hash_table_new_full(pcmk__str_hash, g_str_equal,
                                  key_destroy_func, value_destroy_func);
 }
 
@@ -1122,6 +1128,12 @@ crm_itoa_stack(int an_int, char *buffer, size_t len)
         snprintf(buffer, len, "%d", an_int);
     }
     return buffer;
+}
+
+guint
+g_str_hash_traditional(gconstpointer v)
+{
+    return pcmk__str_hash(v);
 }
 
 // End deprecated API

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -487,7 +487,7 @@ make_args(const char *agent, const char *action, const char *victim,
 
     CRM_CHECK(action != NULL, return NULL);
 
-    arg_list = crm_str_table_new();
+    arg_list = pcmk__strkey_table(free, free);
 
     // Add action to arguments (using an alias if requested)
     if (device_args) {
@@ -2036,7 +2036,7 @@ stonith_api_validate(stonith_t *st, int call_options, const char *rsc_id,
     const char *target = "node1";
     const char *host_arg = NULL;
 
-    GHashTable *params_table = crm_str_table_new();
+    GHashTable *params_table = pcmk__strkey_table(free, free);
 
     // Convert parameter list to a hash table
     for (; params; params = params->next) {

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -226,7 +226,7 @@ lrmd_copy_event(lrmd_event_data_t * event)
     copy->output = event->output ? strdup(event->output) : NULL;
     copy->exit_reason = event->exit_reason ? strdup(event->exit_reason) : NULL;
     copy->remote_nodename = event->remote_nodename ? strdup(event->remote_nodename) : NULL;
-    copy->params = crm_str_table_dup(event->params);
+    copy->params = pcmk__str_table_dup(event->params);
 
     return copy;
 }

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the Pacemaker project contributors
+ * Copyright 2012-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1775,7 +1775,7 @@ lrmd_api_get_metadata_params(lrmd_t *lrmd, const char *standard,
         return stonith_get_metadata(provider, type, output);
     }
 
-    params_table = crm_str_table_new();
+    params_table = pcmk__strkey_table(free, free);
     for (const lrmd_key_value_t *param = params; param; param = param->next) {
         g_hash_table_insert(params_table, strdup(param->key), strdup(param->value));
     }

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -103,10 +103,8 @@ order_instance_by_colocation(const pe_resource_t *rsc1,
     pe_node_t *current_node2 = pe__current_node(rsc2);
     GList *list1 = NULL;
     GList *list2 = NULL;
-    GHashTable *hash1 =
-        g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free);
-    GHashTable *hash2 =
-        g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free);
+    GHashTable *hash1 = pcmk__strkey_table(NULL, free);
+    GHashTable *hash2 = pcmk__strkey_table(NULL, free);
 
     /* Clone instances must have parents */
     CRM_ASSERT(rsc1->parent != NULL);

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -3080,8 +3080,7 @@ unpack_rsc_ticket(xmlNode * xml_obj, pe_working_set_t * data_set)
     }
 
     if (data_set->tickets == NULL) {
-        data_set->tickets =
-            g_hash_table_new_full(crm_str_hash, g_str_equal, free, destroy_ticket);
+        data_set->tickets = pcmk__strkey_table(free, destroy_ticket);
     }
 
     if (ticket_str == NULL) {

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the Pacemaker project contributors
+ * Copyright 2014-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -237,7 +237,7 @@ sum_unallocated_utilization(pe_resource_t * rsc, GList *colocated_rscs)
 {
     GList *gIter = NULL;
     GList *all_rscs = NULL;
-    GHashTable *all_utilization = crm_str_table_new();
+    GHashTable *all_utilization = pcmk__strkey_table(free, free);
 
     all_rscs = g_list_copy(colocated_rscs);
     if (g_list_find(all_rscs, rsc) == FALSE) {

--- a/lib/pacemaker/pcmk_sched_utils.c
+++ b/lib/pacemaker/pcmk_sched_utils.c
@@ -102,7 +102,7 @@ pcmk__copy_node_table(GHashTable *nodes)
     if (nodes == NULL) {
         return NULL;
     }
-    new_table = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free);
+    new_table = pcmk__strkey_table(NULL, free);
     g_hash_table_iter_init(&iter, nodes);
     while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
         pe_node_t *new_node = pe__copy_node(node);

--- a/lib/pacemaker/pcmk_trans_unpack.c
+++ b/lib/pacemaker/pcmk_trans_unpack.c
@@ -320,8 +320,7 @@ convert_graph_action(xmlNode * resource, crm_action_t * action, int status, int 
     op->op_status = status;
     op->t_run = time(NULL);
     op->t_rcchange = op->t_run;
-
-    op->params = g_hash_table_new_full(crm_str_hash, g_str_equal, free, free);
+    op->params = pcmk__strkey_table(free, free);
 
     g_hash_table_iter_init(&iter, action->params);
     while (g_hash_table_iter_next(&iter, (void **)&name, (void **)&value)) {

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -786,9 +786,7 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
         if (replica->child->allowed_nodes != NULL) {
             g_hash_table_destroy(replica->child->allowed_nodes);
         }
-        replica->child->allowed_nodes = g_hash_table_new_full(crm_str_hash,
-                                                              g_str_equal,
-                                                              NULL, free);
+        replica->child->allowed_nodes = pcmk__strkey_table(NULL, free);
         g_hash_table_insert(replica->child->allowed_nodes,
                             (gpointer) replica->node->details->id,
                             pe__copy_node(replica->node));

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -472,9 +472,7 @@ pe_rsc_params(pe_resource_t *rsc, pe_node_t *node, pe_working_set_t *data_set)
 
     // Find the parameter table for given node
     if (rsc->parameter_cache == NULL) {
-        rsc->parameter_cache = g_hash_table_new_full(crm_strcase_hash,
-                                                     crm_strcase_equal, free,
-                                                     free_params_table);
+        rsc->parameter_cache = pcmk__strikey_table(free, free_params_table);
     } else {
         params_on_node = g_hash_table_lookup(rsc->parameter_cache, node_name);
     }

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -99,7 +99,7 @@ dup_attr(gpointer key, gpointer value, gpointer user_data)
 static void
 expand_parents_fixed_nvpairs(pe_resource_t * rsc, pe_rule_eval_data_t * rule_data, GHashTable * meta_hash, pe_working_set_t * data_set)
 {
-    GHashTable *parent_orig_meta = crm_str_table_new();
+    GHashTable *parent_orig_meta = pcmk__strkey_table(free, free);
     pe_resource_t *p = rsc->parent;
 
     if (p == NULL) {
@@ -334,9 +334,7 @@ unpack_template(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t * d
 
     if (template_ops && rsc_ops) {
         xmlNode *op = NULL;
-        GHashTable *rsc_ops_hash = g_hash_table_new_full(crm_str_hash,
-                                                         g_str_equal, free,
-                                                         NULL);
+        GHashTable *rsc_ops_hash = pcmk__strkey_table(free, NULL);
 
         for (op = pcmk__xe_first_child(rsc_ops); op != NULL;
              op = pcmk__xe_next(op)) {
@@ -483,7 +481,7 @@ pe_rsc_params(pe_resource_t *rsc, pe_node_t *node, pe_working_set_t *data_set)
 
     // If none exists yet, create one with parameters evaluated for node
     if (params_on_node == NULL) {
-        params_on_node = crm_str_table_new();
+        params_on_node = pcmk__strkey_table(free, free);
         get_rsc_attributes(params_on_node, rsc, node, data_set);
         g_hash_table_insert(rsc->parameter_cache, strdup(node_name),
                             params_on_node);
@@ -561,13 +559,9 @@ common_unpack(xmlNode * xml_obj, pe_resource_t ** rsc,
     (*rsc)->versioned_parameters = create_xml_node(NULL, XML_TAG_RSC_VER_ATTRS);
 #endif
 
-    (*rsc)->meta = crm_str_table_new();
-
-    (*rsc)->allowed_nodes =
-        g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free);
-
-    (*rsc)->known_on = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL,
-                                             free);
+    (*rsc)->meta = pcmk__strkey_table(free, free);
+    (*rsc)->allowed_nodes = pcmk__strkey_table(NULL, free);
+    (*rsc)->known_on = pcmk__strkey_table(NULL, free);
 
     value = crm_element_value((*rsc)->xml, XML_RSC_ATTR_INCARNATION);
     if (value) {
@@ -851,7 +845,7 @@ common_unpack(xmlNode * xml_obj, pe_resource_t ** rsc,
     pe_rsc_trace((*rsc), "\tAction notification: %s",
                  pcmk_is_set((*rsc)->flags, pe_rsc_notify)? "required" : "not required");
 
-    (*rsc)->utilization = crm_str_table_new();
+    (*rsc)->utilization = pcmk__strkey_table(free, free);
 
     pe__unpack_dataset_nvpairs((*rsc)->xml, XML_TAG_UTILIZATION, &rule_data,
                                (*rsc)->utilization, NULL, FALSE, data_set);

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -1162,7 +1162,7 @@ get_rscs_brief(GList *rsc_list, GHashTable * rsc_table, GHashTable * active_tabl
 
                 node_table = g_hash_table_lookup(active_table, node->details->uname);
                 if (node_table == NULL) {
-                    node_table = crm_str_table_new();
+                    node_table = pcmk__strkey_table(free, free);
                     g_hash_table_insert(active_table, strdup(node->details->uname), node_table);
                 }
 
@@ -1192,9 +1192,8 @@ void
 print_rscs_brief(GList *rsc_list, const char *pre_text, long options,
                  void *print_data, gboolean print_all)
 {
-    GHashTable *rsc_table = crm_str_table_new();
-    GHashTable *active_table = g_hash_table_new_full(crm_str_hash, g_str_equal,
-                                                     free, destroy_node_table);
+    GHashTable *rsc_table = pcmk__strkey_table(free, free);
+    GHashTable *active_table = pcmk__strkey_table(free, destroy_node_table);
     GHashTableIter hash_iter;
     char *type = NULL;
     int *rsc_counter = NULL;
@@ -1271,9 +1270,8 @@ print_rscs_brief(GList *rsc_list, const char *pre_text, long options,
 int
 pe__rscs_brief_output(pcmk__output_t *out, GList *rsc_list, long options, gboolean print_all)
 {
-    GHashTable *rsc_table = crm_str_table_new();
-    GHashTable *active_table = g_hash_table_new_full(crm_str_hash, g_str_equal,
-                                                     free, destroy_node_table);
+    GHashTable *rsc_table = pcmk__strkey_table(free, free);
+    GHashTable *active_table = pcmk__strkey_table(free, destroy_node_table);
     GList *sorted_rscs;
     int rc = pcmk_rc_no_output;
 

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -712,10 +712,10 @@ pe_expand_re_matches(const char *string, pe_re_match_data_t *match_data)
 GHashTable*
 pe_unpack_versioned_parameters(xmlNode *versioned_params, const char *ra_version)
 {
-    GHashTable *hash = crm_str_table_new();
+    GHashTable *hash = pcmk__strkey_table(free, free);
 
     if (versioned_params && ra_version) {
-        GHashTable *node_hash = crm_str_table_new();
+        GHashTable *node_hash = pcmk__strkey_table(free, free);
         xmlNode *attr_set = pcmk__xe_first_child(versioned_params);
 
         if (attr_set) {

--- a/lib/pengine/rules_alerts.c
+++ b/lib/pengine/rules_alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the Pacemaker project contributors
+ * Copyright 2015-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -19,7 +19,7 @@ static void
 get_meta_attrs_from_cib(xmlNode *basenode, pcmk__alert_t *entry,
                         guint *max_timeout)
 {
-    GHashTable *config_hash = crm_str_table_new();
+    GHashTable *config_hash = pcmk__strkey_table(free, free);
     crm_time_t *now = crm_time_new(NULL);
     const char *value = NULL;
 
@@ -75,7 +75,7 @@ get_envvars_from_cib(xmlNode *basenode, pcmk__alert_t *entry)
     }
 
     if (entry->envvars == NULL) {
-        entry->envvars = crm_str_table_new();
+        entry->envvars = pcmk__strkey_table(free, free);
     }
 
     for (child = first_named_child(child, XML_CIB_TAG_NVPAIR); child != NULL;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -198,7 +198,7 @@ gboolean
 unpack_config(xmlNode * config, pe_working_set_t * data_set)
 {
     const char *value = NULL;
-    GHashTable *config_hash = crm_str_table_new();
+    GHashTable *config_hash = pcmk__strkey_table(free, free);
 
     pe_rule_eval_data_t rule_data = {
         .node_hash = NULL,
@@ -426,7 +426,7 @@ pe_create_node(const char *id, const char *uname, const char *type,
         new_node->details->type = node_member;
     }
 
-    new_node->details->attrs = crm_str_table_new();
+    new_node->details->attrs = pcmk__strkey_table(free, free);
 
     if (pe__is_guest_or_remote_node(new_node)) {
         g_hash_table_insert(new_node->details->attrs, strdup(CRM_ATTR_KIND),
@@ -436,11 +436,9 @@ pe_create_node(const char *id, const char *uname, const char *type,
                             strdup("cluster"));
     }
 
-    new_node->details->utilization = crm_str_table_new();
-
-    new_node->details->digest_cache = g_hash_table_new_full(crm_str_hash,
-                                                            g_str_equal, free,
-                                                            pe__free_digests);
+    new_node->details->utilization = pcmk__strkey_table(free, free);
+    new_node->details->digest_cache = pcmk__strkey_table(free,
+                                                          pe__free_digests);
 
     data_set->nodes = g_list_insert_sorted(data_set->nodes, new_node, sort_node_uname);
     return new_node;
@@ -770,9 +768,7 @@ unpack_resources(xmlNode * xml_resources, pe_working_set_t * data_set)
     xmlNode *xml_obj = NULL;
     GList *gIter = NULL;
 
-    data_set->template_rsc_sets = g_hash_table_new_full(crm_str_hash,
-                                                        g_str_equal, free,
-                                                        destroy_tag);
+    data_set->template_rsc_sets = pcmk__strkey_table(free, destroy_tag);
 
     for (xml_obj = pcmk__xe_first_child(xml_resources); xml_obj != NULL;
          xml_obj = pcmk__xe_next(xml_obj)) {
@@ -832,8 +828,7 @@ unpack_tags(xmlNode * xml_tags, pe_working_set_t * data_set)
 {
     xmlNode *xml_tag = NULL;
 
-    data_set->tags = g_hash_table_new_full(crm_str_hash, g_str_equal, free,
-                                           destroy_tag);
+    data_set->tags = pcmk__strkey_table(free, destroy_tag);
 
     for (xml_tag = pcmk__xe_first_child(xml_tags); xml_tag != NULL;
          xml_tag = pcmk__xe_next(xml_tag)) {
@@ -1256,8 +1251,7 @@ unpack_status(xmlNode * status, pe_working_set_t * data_set)
     crm_trace("Beginning unpack");
 
     if (data_set->tickets == NULL) {
-        data_set->tickets = g_hash_table_new_full(crm_str_hash, g_str_equal,
-                                                  free, destroy_ticket);
+        data_set->tickets = pcmk__strkey_table(free, destroy_ticket);
     }
 
     for (state = pcmk__xe_first_child(status); state != NULL;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -203,7 +203,7 @@ pe__node_list2table(GList *list)
 {
     GHashTable *result = NULL;
 
-    result = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free);
+    result = pcmk__strkey_table(NULL, free);
     for (GList *gIter = list; gIter != NULL; gIter = gIter->next) {
         pe_node_t *new_node = pe__copy_node((pe_node_t *) gIter->data);
 
@@ -483,7 +483,7 @@ custom_action(pe_resource_t * rsc, char *key, const char *task,
     }
 
     if(data_set->singletons == NULL) {
-        data_set->singletons = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, NULL);
+        data_set->singletons = pcmk__strkey_table(NULL, NULL);
     }
 
     if (possible_matches != NULL) {
@@ -535,8 +535,8 @@ custom_action(pe_resource_t * rsc, char *key, const char *task,
             pe__clear_action_flags(action, pe_action_optional);
         }
 
-        action->extra = crm_str_table_new();
-        action->meta = crm_str_table_new();
+        action->extra = pcmk__strkey_table(free, free);
+        action->meta = pcmk__strkey_table(free, free);
 
         if (save_action) {
             data_set->actions = g_list_prepend(data_set->actions, action);
@@ -914,7 +914,7 @@ pe_get_configured_timeout(pe_resource_t *rsc, const char *action, pe_working_set
     }
 
     if (timeout_spec == NULL && data_set->op_defaults) {
-        action_meta = crm_str_table_new();
+        action_meta = pcmk__strkey_table(free, free);
         pe__unpack_dataset_nvpairs(data_set->op_defaults, XML_TAG_META_SETS,
                                    &rule_data, action_meta, NULL, FALSE, data_set);
         timeout_spec = g_hash_table_lookup(action_meta, XML_ATTR_TIMEOUT);
@@ -1926,9 +1926,7 @@ ticket_new(const char *ticket_id, pe_working_set_t * data_set)
     }
 
     if (data_set->tickets == NULL) {
-        data_set->tickets =
-            g_hash_table_new_full(crm_str_hash, g_str_equal, free,
-                                  destroy_ticket);
+        data_set->tickets = pcmk__strkey_table(free, destroy_ticket);
     }
 
     ticket = g_hash_table_lookup(data_set->tickets, ticket_id);
@@ -1946,7 +1944,7 @@ ticket_new(const char *ticket_id, pe_working_set_t * data_set)
         ticket->granted = FALSE;
         ticket->last_granted = -1;
         ticket->standby = FALSE;
-        ticket->state = crm_str_table_new();
+        ticket->state = pcmk__strkey_table(free, free);
 
         g_hash_table_insert(data_set->tickets, strdup(ticket->id), ticket);
     }

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 the Pacemaker project contributors
+ * Copyright 2010-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -90,8 +90,7 @@ static inline void
 init_recurring_actions(void)
 {
     if (recurring_actions == NULL) {
-        recurring_actions = g_hash_table_new_full(g_str_hash, g_str_equal, NULL,
-                                                  NULL);
+        recurring_actions = pcmk__strkey_table(NULL, NULL);
     }
 }
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -770,7 +770,7 @@ option_cb(const gchar *option_name, const gchar *optarg, gpointer data,
         return FALSE;
     }
     if (options.cmdline_params == NULL) {
-        options.cmdline_params = crm_str_table_new();
+        options.cmdline_params = pcmk__strkey_table(free, free);
     }
     g_hash_table_replace(options.cmdline_params, name, value);
     return TRUE;
@@ -898,7 +898,7 @@ validate_or_force_cb(const gchar *option_name, const gchar *optarg,
     options.operation = g_strdup(option_name + 2); // skip "--"
     options.find_flags = pe_find_renamed|pe_find_anon;
     if (options.override_params == NULL) {
-        options.override_params = crm_str_table_new();
+        options.override_params = pcmk__strkey_table(free, free);
     }
     return TRUE;
 }
@@ -919,7 +919,7 @@ digests_cb(const gchar *option_name, const gchar *optarg, gpointer data,
     SET_COMMAND(cmd_digests);
     options.find_flags = pe_find_renamed|pe_find_anon;
     if (options.override_params == NULL) {
-        options.override_params = crm_str_table_new();
+        options.override_params = pcmk__strkey_table(free, free);
     }
     options.require_node = TRUE;
     options.require_dataset = TRUE;
@@ -1429,7 +1429,7 @@ validate_cmdline_config(void)
     }
 
     if (options.cmdline_params == NULL) {
-        options.cmdline_params = crm_str_table_new();
+        options.cmdline_params = pcmk__strkey_table(free, free);
     }
     options.require_resource = FALSE;
     options.require_dataset = FALSE;
@@ -1957,11 +1957,11 @@ main(int argc, char **argv)
                 free_params = false;
 
             } else if (pcmk__str_eq(options.attr_set_type, XML_TAG_META_SETS, pcmk__str_casei)) {
-                params = crm_str_table_new();
+                params = pcmk__strkey_table(free, free);
                 get_meta_attributes(params, rsc, current, data_set);
 
             } else {
-                params = crm_str_table_new();
+                params = pcmk__strkey_table(free, free);
                 pe__unpack_dataset_nvpairs(rsc->xml, XML_TAG_UTILIZATION, NULL, params,
                                            NULL, FALSE, data_set);
             }

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1691,14 +1691,14 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
      * we'll make a copy here so that gets freed and the original remains for
      * reuse.
      */
-    params_copy = crm_str_table_dup(params);
+    params_copy = pcmk__str_table_dup(params);
 
     op = resources_action_create(rsc_name, rsc_class, rsc_prov, rsc_type, action, 0,
                                  timeout_ms, params_copy, 0);
     if (op == NULL) {
         /* Re-run with stderr enabled so we can display a sane error message */
         crm_enable_stderr(TRUE);
-        params_copy = crm_str_table_dup(params);
+        params_copy = pcmk__str_table_dup(params);
         op = resources_action_create(rsc_name, rsc_class, rsc_prov, rsc_type, action, 0,
                                      timeout_ms, params_copy, 0);
 

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -633,7 +633,7 @@ clear_rsc_failures(pcmk__output_t *out, pcmk_ipc_api_t *controld_api,
      * clean each resource only once (per node) regardless of how many failed
      * operations it has.
      */
-    rscs = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, NULL);
+    rscs = pcmk__strkey_table(NULL, NULL);
 
     // Normalize interval to milliseconds for comparison to history entry
     if (operation) {
@@ -937,7 +937,7 @@ generate_resource_params(pe_resource_t *rsc, pe_node_t *node,
     char *key = NULL;
     char *value = NULL;
 
-    combined = crm_str_table_new();
+    combined = pcmk__strkey_table(free, free);
 
     params = pe_rsc_params(rsc, node, data_set);
     if (params != NULL) {
@@ -947,7 +947,7 @@ generate_resource_params(pe_resource_t *rsc, pe_node_t *node,
         }
     }
 
-    meta = crm_str_table_new();
+    meta = pcmk__strkey_table(free, free);
     get_meta_attributes(meta, rsc, node, data_set);
     if (meta != NULL) {
         g_hash_table_iter_init(&iter, meta);

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -721,7 +721,7 @@ main(int argc, char **argv)
     guint modified = 0;
 
     GList *attr_delete = NULL;
-    GHashTable *attr_set = crm_str_table_new();
+    GHashTable *attr_set = pcmk__strkey_table(free, free);
 
     crm_log_init(NULL, LOG_CRIT, FALSE, FALSE, argc, argv, FALSE);
     pcmk__set_cli_options(NULL, "<query>|<command> [options]", long_options,


### PR DESCRIPTION
This is part of an ongoing project to deprecate generic parts of the public C API so the Pacemaker libraries focus on Pacemaker-specific APIs, giving us greater freedom to reimplement generic utilities as needed.