### PR TITLE
Overhaul parsing of integers

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -309,8 +309,17 @@ process_ping_reply(xmlNode *reply)
     const char *seq_s = crm_element_value(pong, F_CIB_PING_ID);
     const char *digest = crm_element_value(pong, XML_ATTR_DIGEST);
 
-    if (seq_s) {
-        seq = (uint64_t) crm_parse_ll(seq_s, NULL);
+    if (seq_s == NULL) {
+        crm_debug("Ignoring ping reply with no " F_CIB_PING_ID);
+        return;
+
+    } else {
+        long long seq_ll;
+
+        if (pcmk__scan_ll(seq_s, &seq_ll, 0LL) != pcmk_rc_ok) {
+            return;
+        }
+        seq = (uint64_t) seq_ll;
     }
 
     if(digest == NULL) {

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -353,21 +353,18 @@ startCib(const char *filename)
 
     if (activateCibXml(cib, TRUE, "start") == 0) {
         int port = 0;
-        const char *port_s = NULL;
 
         active = TRUE;
 
         cib_read_config(config_hash, cib);
 
-        port_s = crm_element_value(cib, "remote-tls-port");
-        if (port_s) {
-            port = crm_parse_int(port_s, "0");
+        pcmk__scan_port(crm_element_value(cib, "remote-tls-port"), &port);
+        if (port >= 0) {
             remote_tls_fd = init_remote_listener(port, TRUE);
         }
 
-        port_s = crm_element_value(cib, "remote-clear-port");
-        if (port_s) {
-            port = crm_parse_int(port_s, "0");
+        pcmk__scan_port(crm_element_value(cib, "remote-clear-port"), &port);
+        if (port >= 0) {
             remote_fd = init_remote_listener(port, FALSE);
         }
     }

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1615,7 +1615,7 @@ static bool do_lrm_cancel(ha_msg_input_t *input, lrm_state_t *lrm_state,
 
     crm_debug("Scheduler requested op %s (call=%s) be cancelled",
               op_key, (call_id? call_id : "NA"));
-    call = crm_parse_int(call_id, "0");
+    pcmk__scan_min_int(call_id, &call, 0);
     if (call == 0) {
         // Normal case when the scheduler cancels a recurring op
         in_progress = cancel_op_key(lrm_state, rsc, op_key, TRUE);
@@ -1870,9 +1870,9 @@ resolve_versioned_parameters(lrm_state_t *lrm_state, const char *rsc_id,
             g_hash_table_replace(params, crm_meta_name(key), strdup(value));
 
             if (pcmk__str_eq(key, XML_ATTR_TIMEOUT, pcmk__str_casei)) {
-                op->timeout = crm_parse_int(value, "0");
+                pcmk__scan_min_int(value, &op->timeout, 0);
             } else if (pcmk__str_eq(key, XML_OP_ATTR_START_DELAY, pcmk__str_casei)) {
-                op->start_delay = crm_parse_int(value, "0");
+                pcmk__scan_min_int(value, &op->start_delay, 0);
             }
         }
         g_hash_table_destroy(hash);
@@ -1934,10 +1934,10 @@ construct_op(lrm_state_t *lrm_state, xmlNode *rsc_op, const char *rsc_id,
     g_hash_table_remove(params, CRM_META "_op_target_rc");
 
     op_delay = crm_meta_value(params, XML_OP_ATTR_START_DELAY);
-    op->start_delay = crm_parse_int(op_delay, "0");
+    pcmk__scan_min_int(op_delay, &op->start_delay, 0);
 
     op_timeout = crm_meta_value(params, XML_ATTR_TIMEOUT);
-    op->timeout = crm_parse_int(op_timeout, "0");
+    pcmk__scan_min_int(op_timeout, &op->timeout, 0);
 
     if (pcmk__guint_from_hash(params, CRM_META "_" XML_LRM_ATTR_INTERVAL_MS, 0,
                               &(op->interval_ms)) != pcmk_rc_ok) {

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -812,13 +812,14 @@ fence_with_delay(const char *target, const char *type, const char *delay)
 {
     uint32_t options = st_opt_none; // Group of enum stonith_call_options
     int timeout_sec = (int) (transition_graph->stonith_timeout / 1000);
+    int delay_i;
 
     if (crmd_join_phase_count(crm_join_confirmed) == 1) {
         stonith__set_call_options(options, target, st_opt_allow_suicide);
     }
+    pcmk__scan_min_int(delay, &delay_i, 0);
     return stonith_api->cmds->fence_with_delay(stonith_api, options, target,
-                                               type, timeout_sec, 0,
-                                               crm_atoi(delay, "0"));
+                                               type, timeout_sec, 0, delay_i);
 }
 
 gboolean

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -34,14 +34,12 @@ static bool fence_reaction_panic = FALSE;
 static unsigned long int stonith_max_attempts = 10;
 static GHashTable *stonith_failures = NULL;
 
-// crmd_opts defines default for stonith-max-attempts, so value is never NULL
 void
 update_stonith_max_attempts(const char *value)
 {
-    if (pcmk__str_eq(value, CRM_INFINITY_S, pcmk__str_casei)) {
-       stonith_max_attempts = CRM_SCORE_INFINITY;
-    } else {
-       stonith_max_attempts = (unsigned long int) crm_parse_ll(value, NULL);
+    stonith_max_attempts = char2score(value);
+    if (stonith_max_attempts < 1UL) {
+        stonith_max_attempts = 10UL;
     }
 }
 

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -270,8 +270,11 @@ compare_int_fields(xmlNode * left, xmlNode * right, const char *field)
     const char *elem_l = crm_element_value(left, field);
     const char *elem_r = crm_element_value(right, field);
 
-    long long int_elem_l = elem_l? crm_parse_ll(elem_l, NULL) : -1;
-    long long int_elem_r = elem_r? crm_parse_ll(elem_r, NULL) : -1;
+    long long int_elem_l;
+    long long int_elem_r;
+
+    pcmk__scan_ll(elem_l, &int_elem_l, -1LL);
+    pcmk__scan_ll(elem_r, &int_elem_r, -1LL);
 
     if (int_elem_l < int_elem_r) {
         return -1;

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -479,21 +479,16 @@ authorize_version(xmlNode *message_data, const char *field,
                   const char *client_name, const char *ref, const char *uuid)
 {
     const char *version = crm_element_value(message_data, field);
+    long long version_num;
 
-    if (pcmk__str_empty(version)) {
-        crm_warn("IPC hello from %s rejected: No protocol %s",
+    if ((pcmk__scan_ll(version, &version_num, -1LL) != pcmk_rc_ok)
+        || (version_num < 0LL)) {
+
+        crm_warn("Rejected IPC hello from %s: '%s' is not a valid protocol %s "
                  CRM_XS " ref=%s uuid=%s",
-                 client_name, field, (ref? ref : "none"), uuid);
+                 client_name, ((version == NULL)? "" : version),
+                 field, (ref? ref : "none"), uuid);
         return false;
-    } else {
-        int version_num = crm_parse_int(version, NULL);
-
-        if (version_num < 0) {
-            crm_warn("IPC hello from %s rejected: Protocol %s '%s' "
-                     "not recognized", CRM_XS " ref=%s uuid=%s",
-                     client_name, field, version, (ref? ref : "none"), uuid);
-            return false;
-        }
     }
     return true;
 }

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the Pacemaker project contributors
+ * Copyright 2013-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1269,11 +1269,12 @@ remote_ra_process_maintenance_nodes(xmlNode *xml)
             cnt++;
             if (lrm_state && lrm_state->remote_ra_data &&
                 ((remote_ra_data_t *) lrm_state->remote_ra_data)->active) {
-                cnt_remote++;
-                remote_ra_maintenance(lrm_state,
-                                        crm_atoi(crm_element_value(node,
-                                            XML_NODE_IS_MAINTENANCE), "0"));
+                int is_maint;
 
+                cnt_remote++;
+                pcmk__scan_min_int(crm_element_value(node, XML_NODE_IS_MAINTENANCE),
+                                   &is_maint, 0);
+                remote_ra_maintenance(lrm_state, is_maint);
             }
         }
         crm_trace("Action holds %d nodes (%d remotes found) "

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -76,12 +76,11 @@ te_pseudo_action(crm_graph_t * graph, crm_action_t * pseudo)
 static int
 get_target_rc(crm_action_t * action)
 {
-    const char *target_rc_s = crm_meta_value(action->params, XML_ATTR_TE_TARGET_RC);
+    int exit_status;
 
-    if (target_rc_s != NULL) {
-        return crm_parse_int(target_rc_s, "0");
-    }
-    return 0;
+    pcmk__scan_min_int(crm_meta_value(action->params, XML_ATTR_TE_TARGET_RC),
+                       &exit_status, 0);
+    return exit_status;
 }
 
 static gboolean

--- a/daemons/controld/controld_throttle.c
+++ b/daemons/controld/controld_throttle.c
@@ -405,14 +405,14 @@ throttle_set_load_target(float target)
 void
 throttle_update_job_max(const char *preference)
 {
-    long long max = -1;
+    long long max = 0LL;
     const char *env_limit = getenv("PCMK_node_action_limit");
 
     if (env_limit != NULL) {
         preference = env_limit; // Per-node override
     }
-    if (preference) {
-        max = crm_parse_ll(preference, NULL);
+    if (preference != NULL) {
+        pcmk__scan_ll(preference, &max, 0LL);
     }
     if (max > 0) {
         throttle_job_max = (int) max;

--- a/daemons/controld/controld_utils.c
+++ b/daemons/controld/controld_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -774,11 +774,8 @@ cib_op_timeout()
     if (env_timeout == -1) {
         const char *env = getenv("PCMK_cib_timeout");
 
-        if (env) {
-            env_timeout = crm_parse_int(env, "0");
-        }
-        env_timeout = QB_MAX(env_timeout, MIN_CIB_OP_TIMEOUT);
-        crm_trace("Minimum CIB op timeout: %us (environment: %s)",
+        pcmk__scan_min_int(env, &env_timeout, MIN_CIB_OP_TIMEOUT);
+        crm_trace("Minimum CIB op timeout: %ds (environment: %s)",
                   env_timeout, (env? env : "none"));
     }
 

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2399,10 +2399,11 @@ stonith_fence(xmlNode * msg)
         const char *host = crm_element_value(dev, F_STONITH_TARGET);
 
         if (cmd->options & st_opt_cs_nodeid) {
-            int nodeid = crm_atoi(host, NULL);
-            crm_node_t *node = pcmk__search_known_node_cache(nodeid, NULL,
-                                                             CRM_GET_PEER_ANY);
+            int nodeid;
+            crm_node_t *node;
 
+            pcmk__scan_min_int(host, &nodeid, 0);
+            node = pcmk__search_known_node_cache(nodeid, NULL, CRM_GET_PEER_ANY);
             if (node) {
                 host = node->uname;
             }

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -273,14 +273,11 @@ get_action_limit(stonith_device_t * device)
     int action_limit = 1;
 
     value = g_hash_table_lookup(device->params, PCMK_STONITH_ACTION_LIMIT);
-    if (value) {
-       action_limit = crm_parse_int(value, "1");
-       if (action_limit == 0) {
-           /* pcmk_action_limit should not be 0. Enforce it to be 1. */
-           action_limit = 1;
-       }
+    if ((value == NULL)
+        || (pcmk__scan_min_int(value, &action_limit, INT_MIN) != pcmk_rc_ok)
+        || (action_limit == 0)) {
+        action_limit = 1;
     }
-
     return action_limit;
 }
 

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2020 the Pacemaker project contributors
+ * Copyright 2009-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -440,10 +440,11 @@ stonith_fence_history(xmlNode *msg, xmlNode **output,
     if (dev) {
         target = crm_element_value(dev, F_STONITH_TARGET);
         if (target && (options & st_opt_cs_nodeid)) {
-            int nodeid = crm_atoi(target, NULL);
-            crm_node_t *node = pcmk__search_known_node_cache(nodeid, NULL,
-                                                             CRM_GET_PEER_ANY);
+            int nodeid;
+            crm_node_t *node;
 
+            pcmk__scan_min_int(target, &nodeid, 0);
+            node = pcmk__search_known_node_cache(nodeid, NULL, CRM_GET_PEER_ANY);
             if (node) {
                 target = node->uname;
             }

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1082,9 +1082,11 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
               pcmk__plural_alt(op->replies_expected, "reply", "replies"));
 
     if (op->call_options & st_opt_cs_nodeid) {
-        int nodeid = crm_atoi(op->target, NULL);
-        crm_node_t *node = pcmk__search_known_node_cache(nodeid, NULL,
-                                                         CRM_GET_PEER_ANY);
+        int nodeid;
+        crm_node_t *node;
+
+        pcmk__scan_min_int(op->target, &nodeid, 0);
+        node = pcmk__search_known_node_cache(nodeid, NULL, CRM_GET_PEER_ANY);
 
         /* Ensure the conversion only happens once */
         stonith__clear_call_options(op->call_options, op->id, st_opt_cs_nodeid);

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -155,10 +155,6 @@ process_pe_message(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
             if (errno != 0) {
                 series_wrap = series[series_id].wrap;
             }
-
-        } else {
-            pcmk__config_warn("No value specified for cluster preference: %s",
-                              series[series_id].param);
         }
 
         if (pcmk__read_series_sequence(PE_STATE_DIR, series[series_id].name,

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -130,13 +130,10 @@ handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
         series_id = 2;
     }
 
-    series_wrap = series[series_id].wrap;
     value = pe_pref(sched_data_set->config_hash, series[series_id].param);
-    if (value != NULL) {
-        series_wrap = (int) crm_parse_ll(value, NULL);
-        if (errno != 0) {
-            series_wrap = series[series_id].wrap;
-        }
+    if ((value == NULL)
+        || (pcmk__scan_min_int(value, &series_wrap, -1) != pcmk_rc_ok)) {
+        series_wrap = series[series_id].wrap;
     }
 
     if (pcmk__read_series_sequence(PE_STATE_DIR, series[series_id].name,

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -369,21 +369,24 @@ main(int argc, char **argv)
     mainloop = g_main_loop_new(NULL, FALSE);
     crm_notice("Pacemaker scheduler successfully started and accepting connections");
     g_main_loop_run(mainloop);
-
-    pe_free_working_set(sched_data_set);
-    crm_info("Exiting %s", crm_system_name);
-
-    pcmk__unregister_formats();
-    out->finish(out, CRM_EX_OK, true, NULL);
-    pcmk__output_free(out);
-
-    crm_exit(CRM_EX_OK);
+    pengine_shutdown(0);
 }
 
 void
 pengine_shutdown(int nsig)
 {
     mainloop_del_ipc_server(ipcs);
+    ipcs = NULL;
+
     pe_free_working_set(sched_data_set);
+    sched_data_set = NULL;
+
+    pcmk__unregister_formats();
+    if (out != NULL) {
+        out->finish(out, CRM_EX_OK, true, NULL);
+        pcmk__output_free(out);
+        out = NULL;
+    }
+
     crm_exit(CRM_EX_OK);
 }

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -42,19 +42,14 @@ pcmk__supported_format_t formats[] = {
     { NULL, NULL, NULL }
 };
 
-#define get_series() 	was_processing_error?1:was_processing_warning?2:3
-
-typedef struct series_s {
+static struct series_s {
     const char *name;
     const char *param;
     int wrap;
-} series_t;
-
-series_t series[] = {
-    {"pe-unknown", "_do_not_match_anything_", -1},
-    {"pe-error", "pe-error-series-max", -1},
-    {"pe-warn", "pe-warn-series-max", 200},
-    {"pe-input", "pe-input-series-max", 400},
+} series[] = {
+    { "pe-error", "pe-error-series-max", -1 },
+    { "pe-warn",  "pe-warn-series-max",  5000 },
+    { "pe-input", "pe-input-series-max", 4000 },
 };
 
 void pengine_shutdown(int nsig);
@@ -143,7 +138,15 @@ process_pe_message(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
             pcmk__schedule_actions(sched_data_set, converted, NULL);
         }
 
-        series_id = get_series();
+        // Get appropriate index into series[] array
+        if (was_processing_error) {
+            series_id = 0;
+        } else if (was_processing_warning) {
+            series_id = 1;
+        } else {
+            series_id = 2;
+        }
+
         series_wrap = series[series_id].wrap;
         value = pe_pref(sched_data_set->config_hash, series[series_id].param);
 

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -40,6 +40,7 @@ void pcmk__add_separated_word(char **list, size_t *len, const char *word,
 int pcmk__compress(const char *data, unsigned int length, unsigned int max,
                    char **result, unsigned int *result_len);
 
+int pcmk__scan_ll(const char *text, long long *result, long long default_value);
 int pcmk__parse_ll_range(const char *srcstring, long long *start, long long *end);
 
 GHashTable *pcmk__strkey_table(GDestroyNotify key_destroy_func,

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -41,6 +41,7 @@ int pcmk__compress(const char *data, unsigned int length, unsigned int max,
                    char **result, unsigned int *result_len);
 
 int pcmk__scan_ll(const char *text, long long *result, long long default_value);
+int pcmk__scan_port(const char *text, int *port);
 int pcmk__parse_ll_range(const char *srcstring, long long *start, long long *end);
 
 GHashTable *pcmk__strkey_table(GDestroyNotify key_destroy_func,

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -41,6 +41,7 @@ int pcmk__compress(const char *data, unsigned int length, unsigned int max,
                    char **result, unsigned int *result_len);
 
 int pcmk__scan_ll(const char *text, long long *result, long long default_value);
+int pcmk__scan_min_int(const char *text, int *result, int minimum);
 int pcmk__scan_port(const char *text, int *port);
 int pcmk__parse_ll_range(const char *srcstring, long long *start, long long *end);
 

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -45,7 +45,6 @@ int crm_default_remote_port(void);
 gboolean crm_is_true(const char *s);
 int crm_str_to_boolean(const char *s, int *ret);
 long long crm_parse_ll(const char *text, const char *default_text);
-int crm_parse_int(const char *text, const char *default_text);
 long long crm_get_msec(const char *input);
 char * crm_strip_trailing_newline(char *str);
 char *crm_strdup_printf(char const *format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -69,8 +69,6 @@ crm_ttoa(time_t epoch_time)
     return crm_strdup_printf("%lld", (long long) epoch_time);
 }
 
-#  define crm_atoi(text, default_text) crm_parse_int(text, default_text)
-
 /* public I/O functions (from io.c) */
 void crm_build_path(const char *path_c, mode_t mode);
 

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -44,7 +44,6 @@ int crm_default_remote_port(void);
 /* public string functions (from strings.c) */
 gboolean crm_is_true(const char *s);
 int crm_str_to_boolean(const char *s, int *ret);
-long long crm_parse_ll(const char *text, const char *default_text);
 long long crm_get_msec(const char *input);
 char * crm_strip_trailing_newline(char *str);
 char *crm_strdup_printf(char const *format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -70,6 +70,9 @@ char *pcmk_format_nvpair(const char *name, const char *value,
 char *pcmk_format_named_time(const char *name, time_t epoch_time);
 
 //! \deprecated Use strtoll() instead
+long long crm_parse_ll(const char *text, const char *default_text);
+
+//! \deprecated Use strtoll() instead
 int crm_parse_int(const char *text, const char *default_text);
 
 //! \deprecated Use strtoll() instead

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -70,6 +70,9 @@ char *pcmk_format_nvpair(const char *name, const char *value,
 char *pcmk_format_named_time(const char *name, time_t epoch_time);
 
 //! \deprecated Use strtoll() instead
+int crm_parse_int(const char *text, const char *default_text);
+
+//! \deprecated Use strtoll() instead
 #  define crm_atoi(text, default_text) crm_parse_int(text, default_text)
 
 //! \deprecated Use g_str_hash() instead

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -69,6 +69,9 @@ char *pcmk_format_nvpair(const char *name, const char *value,
 //! \deprecated Use a standard printf()-style function instead
 char *pcmk_format_named_time(const char *name, time_t epoch_time);
 
+//! \deprecated Use strtoll() instead
+#  define crm_atoi(text, default_text) crm_parse_int(text, default_text)
+
 //! \deprecated Use g_str_hash() instead
 guint g_str_hash_traditional(gconstpointer v);
 

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -56,7 +56,7 @@ extern "C" {
  * The feature set also affects the processing of old saved CIBs (such as for
  * many scheduler regression tests).
  *
- * Particular feature points currently used by pacemaker:
+ * Particular feature points currently tested by Pacemaker code:
  *
  * >2.1:     Operation updates include timing data
  * >=3.0.5:  XML v2 digests are created
@@ -66,7 +66,7 @@ extern "C" {
  * >=3.0.13: Fail counts include operation name and interval
  * >=3.2.0:  DC supports PCMK_LRM_OP_INVALID and PCMK_LRM_OP_NOT_CONNECTED
  */
-#  define CRM_FEATURE_SET		"3.7.4"
+#  define CRM_FEATURE_SET		"3.8.0"
 
 #  ifndef MAX_NAME
 #    define MAX_NAME	256

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -292,6 +292,7 @@ cib_t *
 cib_new(void)
 {
     const char *value = getenv("CIB_shadow");
+    int port;
 
     if (value && value[0] != 0) {
         return cib_shadow_new(value);
@@ -305,10 +306,16 @@ cib_new(void)
     value = getenv("CIB_port");
     if (value) {
         gboolean encrypted = TRUE;
-        int port = crm_parse_int(value, NULL);
         const char *server = getenv("CIB_server");
         const char *user = getenv("CIB_user");
         const char *pass = getenv("CIB_passwd");
+
+        /* We don't ensure port is valid (>= 0) because cib_new() currently
+         * can't return NULL in practice, and introducing a NULL return here
+         * could cause core dumps that would previously just cause signon()
+         * failures.
+         */
+        pcmk__scan_port(value, &port);
 
         value = getenv("CIB_encrypted");
         if (value && crm_is_true(value) == FALSE) {

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -244,14 +244,15 @@ crm_peer_uname(const char *uuid)
 
 #if SUPPORT_COROSYNC
     if (is_corosync_cluster()) {
-        uint32_t id = (uint32_t) crm_parse_ll(uuid, NULL);
+        long long id;
 
-        if (id != 0) {
-            node = pcmk__search_cluster_node_cache(id, NULL);
-        } else {
-            crm_err("Invalid node id: %s", uuid);
+        if ((pcmk__scan_ll(uuid, &id, 0LL) != pcmk_rc_ok)
+            || (id < 1LL) || (id > UINT32_MAX))  {
+            crm_err("Invalid Corosync node ID '%s'", uuid);
+            return NULL;
         }
 
+        node = pcmk__search_cluster_node_cache((uint32_t) id, NULL);
         if (node != NULL) {
             crm_info("Setting uuid for node %s[%u] to %s",
                      node->uname, node->id, uuid);

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -350,22 +350,21 @@ pcmk__free_client(pcmk__client_t *c)
  * \param[in,out] client     Client to modify
  * \param[in]     qmax       New threshold (as non-NULL string)
  *
- * \return TRUE if change was allowed, FALSE otherwise
+ * \return true if change was allowed, false otherwise
  */
 bool
 pcmk__set_client_queue_max(pcmk__client_t *client, const char *qmax)
 {
     if (pcmk_is_set(client->flags, pcmk__client_privileged)) {
-        long long qmax_int;
+        long long qmax_ll;
 
-        errno = 0;
-        qmax_int = crm_parse_ll(qmax, NULL);
-        if ((errno == 0) && (qmax_int > 0)) {
-            client->queue_max = (unsigned int) qmax_int;
-            return TRUE;
+        if ((pcmk__scan_ll(qmax, &qmax_ll, 0LL) == pcmk_rc_ok)
+            && (qmax_ll > 0LL) && (qmax_ll <= UINT_MAX)) {
+            client->queue_max = (unsigned int) qmax_ll;
+            return true;
         }
     }
-    return FALSE;
+    return false;
 }
 
 int

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -597,12 +597,9 @@ crm_element_value_ll(const xmlNode *data, const char *name, long long *dest)
 
     CRM_CHECK(dest != NULL, return -1);
     value = crm_element_value(data, name);
-    if (value) {
-        errno = 0;
-        *dest = crm_parse_ll(value, NULL);
-        if (errno == 0) {
-            return 0;
-        }
+    if ((value != NULL)
+        && (pcmk__scan_ll(value, dest, PCMK__PARSE_INT_DEFAULT) == pcmk_rc_ok)) {
+        return 0;
     }
     return -1;
 }
@@ -626,18 +623,11 @@ crm_element_value_ms(const xmlNode *data, const char *name, guint *dest)
 
     CRM_CHECK(dest != NULL, return -1);
     *dest = 0;
-
     value = crm_element_value(data, name);
-    if (value == NULL) {
-        return pcmk_ok;
-    }
-
-    errno = 0;
-    value_ll = crm_parse_ll(value, NULL);
-    if ((errno != 0) || (value_ll < 0) || (value_ll > G_MAXUINT)) {
+    if ((pcmk__scan_ll(value, &value_ll, 0LL) != pcmk_rc_ok)
+        || (value_ll < 0) || (value_ll > G_MAXUINT)) {
         return -1;
     }
-
     *dest = (guint) value_ll;
     return pcmk_ok;
 }

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -570,9 +570,13 @@ crm_element_value_int(const xmlNode *data, const char *name, int *dest)
     CRM_CHECK(dest != NULL, return -1);
     value = crm_element_value(data, name);
     if (value) {
-        errno = 0;
-        *dest = crm_parse_int(value, NULL);
-        if (errno == 0) {
+        long long value_ll;
+
+        if ((pcmk__scan_ll(value, &value_ll, 0LL) != pcmk_rc_ok)
+            || (value_ll < INT_MIN) || (value_ll > INT_MAX)) {
+            *dest = PCMK__PARSE_INT_DEFAULT;
+        } else {
+            *dest = (int) value_ll;
             return 0;
         }
     }

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -390,16 +390,16 @@ pcmk__valid_number(const char *value)
         return true;
     }
 
-    errno = 0;
-    crm_parse_ll(value, NULL);
-    return errno == 0;
+    return pcmk__scan_ll(value, NULL, 0LL) == pcmk_rc_ok;
 }
 
 bool
 pcmk__valid_positive_number(const char *value)
 {
-    return pcmk_str_is_infinity(value) ||
-           (crm_parse_ll(value, NULL) > 0);
+    long long num = 0LL;
+
+    return pcmk_str_is_infinity(value)
+           || ((pcmk__scan_ll(value, &num, 0LL) == pcmk_rc_ok) && (num > 0));
 }
 
 bool

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2020 the Pacemaker project contributors
+ * Copyright 2008-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -165,41 +165,32 @@ pcmk__tls_client_handshake(pcmk__remote_t *remote, int timeout_ms)
 static void
 set_minimum_dh_bits(gnutls_session_t *session)
 {
-    const char *dh_min_bits_s = getenv("PCMK_dh_min_bits");
+    int dh_min_bits;
 
-    if (dh_min_bits_s) {
-        int dh_min_bits = crm_parse_int(dh_min_bits_s, "0");
+    pcmk__scan_min_int(getenv("PCMK_dh_min_bits"), &dh_min_bits, 0);
 
-        /* This function is deprecated since GnuTLS 3.1.7, in favor of letting
-         * the priority string imply the DH requirements, but this is the only
-         * way to give the user control over compatibility with older servers.
-         */
-        if (dh_min_bits > 0) {
-            crm_info("Requiring server use a Diffie-Hellman prime of at least %d bits",
-                     dh_min_bits);
-            gnutls_dh_set_prime_bits(*session, dh_min_bits);
-        }
+    /* This function is deprecated since GnuTLS 3.1.7, in favor of letting
+     * the priority string imply the DH requirements, but this is the only
+     * way to give the user control over compatibility with older servers.
+     */
+    if (dh_min_bits > 0) {
+        crm_info("Requiring server use a Diffie-Hellman prime of at least %d bits",
+                 dh_min_bits);
+        gnutls_dh_set_prime_bits(*session, dh_min_bits);
     }
 }
 
 static unsigned int
 get_bound_dh_bits(unsigned int dh_bits)
 {
-    const char *dh_min_bits_s = getenv("PCMK_dh_min_bits");
-    const char *dh_max_bits_s = getenv("PCMK_dh_max_bits");
-    int dh_min_bits = 0;
-    int dh_max_bits = 0;
+    int dh_min_bits;
+    int dh_max_bits;
 
-    if (dh_min_bits_s) {
-        dh_min_bits = crm_parse_int(dh_min_bits_s, "0");
-    }
-    if (dh_max_bits_s) {
-        dh_max_bits = crm_parse_int(dh_max_bits_s, "0");
-        if ((dh_min_bits > 0) && (dh_max_bits > 0)
-            && (dh_max_bits < dh_min_bits)) {
-            crm_warn("Ignoring PCMK_dh_max_bits because it is less than PCMK_dh_min_bits");
-            dh_max_bits = 0;
-        }
+    pcmk__scan_min_int(getenv("PCMK_dh_min_bits"), &dh_min_bits, 0);
+    pcmk__scan_min_int(getenv("PCMK_dh_max_bits"), &dh_max_bits, 0);
+    if ((dh_max_bits > 0) && (dh_max_bits < dh_min_bits)) {
+        crm_warn("Ignoring PCMK_dh_max_bits less than PCMK_dh_min_bits");
+        dh_max_bits = 0;
     }
     if ((dh_min_bits > 0) && (dh_bits < dh_min_bits)) {
         return dh_min_bits;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -203,41 +203,6 @@ crm_parse_ll(const char *text, const char *default_text)
 }
 
 /*!
- * \brief Parse an integer value from a string
- *
- * \param[in] text          The string to parse
- * \param[in] default_text  Default string to parse if text is NULL
- *
- * \return Parsed value on success, INT_MIN or INT_MAX (and set errno to
- *         ERANGE) if parsed value is out of integer range, otherwise
- *         PCMK__PARSE_INT_DEFAULT (and set errno)
- */
-int
-crm_parse_int(const char *text, const char *default_text)
-{
-    long long result = crm_parse_ll(text, default_text);
-
-    if (result < INT_MIN) {
-        // If errno is ERANGE, crm_parse_ll() has already logged a message
-        if (errno != ERANGE) {
-            crm_err("Conversion of %s was clipped: %lld", text, result);
-            errno = ERANGE;
-        }
-        return INT_MIN;
-
-    } else if (result > INT_MAX) {
-        // If errno is ERANGE, crm_parse_ll() has already logged a message
-        if (errno != ERANGE) {
-            crm_err("Conversion of %s was clipped: %lld", text, result);
-            errno = ERANGE;
-        }
-        return INT_MAX;
-    }
-
-    return (int) result;
-}
-
-/*!
  * \internal
  * \brief Scan a double-precision floating-point value from a string
  *
@@ -1281,6 +1246,31 @@ GHashTable *
 crm_str_table_dup(GHashTable *old_table)
 {
     return pcmk__str_table_dup(old_table);
+}
+
+int
+crm_parse_int(const char *text, const char *default_text)
+{
+    long long result = crm_parse_ll(text, default_text);
+
+    if (result < INT_MIN) {
+        // If errno is ERANGE, crm_parse_ll() has already logged a message
+        if (errno != ERANGE) {
+            crm_err("Conversion of %s was clipped: %lld", text, result);
+            errno = ERANGE;
+        }
+        return INT_MIN;
+
+    } else if (result > INT_MAX) {
+        // If errno is ERANGE, crm_parse_ll() has already logged a message
+        if (errno != ERANGE) {
+            crm_err("Conversion of %s was clipped: %lld", text, result);
+            errno = ERANGE;
+        }
+        return INT_MAX;
+    }
+
+    return (int) result;
 }
 
 // End deprecated API

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -28,9 +28,11 @@
  * \internal
  * \brief Scan a long long integer from a string
  *
- * \param[in]  text      String to scan
- * \param[out] result    If not NULL, where to store scanned value
- * \param[out] end_text  If not NULL, where to store pointer to just after value
+ * \param[in]  text           String to scan
+ * \param[out] result         If not NULL, where to store scanned value
+ * \param[in]  default_value  Value to use if text is NULL or invalid
+ * \param[out] end_text       If not NULL, where to store pointer to first
+ *                            non-integer character
  *
  * \return Standard Pacemaker return code (\c pcmk_rc_ok on success,
  *         \c EINVAL on failed string conversion due to invalid input,
@@ -38,9 +40,10 @@
  * \note Sets \c errno on error
  */
 static int
-scan_ll(const char *text, long long *result, char **end_text)
+scan_ll(const char *text, long long *result, long long default_value,
+        char **end_text)
 {
-    long long local_result = PCMK__PARSE_INT_DEFAULT;
+    long long local_result = default_value;
     char *local_end_text = NULL;
     int rc = pcmk_rc_ok;
 
@@ -49,20 +52,20 @@ scan_ll(const char *text, long long *result, char **end_text)
         local_result = strtoll(text, &local_end_text, 10);
         if (errno == ERANGE) {
             rc = EOVERFLOW;
-            crm_warn("Integer parsed from %s was clipped to %lld",
+            crm_warn("Integer parsed from '%s' was clipped to %lld",
                      text, local_result);
 
         } else if (errno != 0) {
             rc = errno;
-            local_result = PCMK__PARSE_INT_DEFAULT;
-            crm_warn("Could not parse integer from %s (using %d instead): %s",
-                    text, PCMK__PARSE_INT_DEFAULT, pcmk_rc_str(rc));
+            local_result = default_value;
+            crm_warn("Could not parse integer from '%s' (using %lld instead): "
+                     "%s", text, default_value, pcmk_rc_str(rc));
 
         } else if (local_end_text == text) {
             rc = EINVAL;
-            local_result = PCMK__PARSE_INT_DEFAULT;
-            crm_warn("Could not parse integer from %s (using %d instead): "
-                    "No digits found", text, PCMK__PARSE_INT_DEFAULT);
+            local_result = default_value;
+            crm_warn("Could not parse integer from '%s' (using %lld instead): "
+                    "No digits found", text, default_value);
         }
 
         if ((end_text == NULL) && !pcmk__str_empty(local_end_text)) {
@@ -73,6 +76,34 @@ scan_ll(const char *text, long long *result, char **end_text)
     }
     if (end_text != NULL) {
         *end_text = local_end_text;
+    }
+    if (result != NULL) {
+        *result = local_result;
+    }
+    return rc;
+}
+
+/*!
+ * \internal
+ * \brief Scan a long long integer value from a string
+ *
+ * \param[in]  text           The string to scan (may be NULL)
+ * \param[out] result         Where to store result (or NULL to ignore)
+ * \param[in]  default_value  Value to use if text is NULL or invalid
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+pcmk__scan_ll(const char *text, long long *result, long long default_value)
+{
+    long long local_result = default_value;
+    int rc = pcmk_rc_ok;
+
+    if (text != NULL) {
+        rc = scan_ll(text, &local_result, default_value, NULL);
+        if (rc != pcmk_rc_ok) {
+            local_result = default_value;
+        }
     }
     if (result != NULL) {
         *result = local_result;
@@ -102,7 +133,7 @@ crm_parse_ll(const char *text, const char *default_text)
             return PCMK__PARSE_INT_DEFAULT;
         }
     }
-    scan_ll(text, &result, NULL);
+    scan_ll(text, &result, PCMK__PARSE_INT_DEFAULT, NULL);
     return result;
 }
 
@@ -278,22 +309,24 @@ pcmk__guint_from_hash(GHashTable *table, const char *key, guint default_val,
 {
     const char *value;
     long long value_ll;
+    int rc = pcmk_rc_ok;
 
     CRM_CHECK((table != NULL) && (key != NULL), return EINVAL);
 
+    if (result != NULL) {
+        *result = default_val;
+    }
+
     value = g_hash_table_lookup(table, key);
     if (value == NULL) {
-        if (result != NULL) {
-            *result = default_val;
-        }
         return pcmk_rc_ok;
     }
 
-    errno = 0;
-    value_ll = crm_parse_ll(value, NULL);
-    if (errno != 0) {
-        return errno; // Message already logged
+    rc = pcmk__scan_ll(value, &value_ll, 0LL);
+    if (rc != pcmk_rc_ok) {
+        return rc;
     }
+
     if ((value_ll < 0) || (value_ll > G_MAXUINT)) {
         crm_warn("Could not parse non-negative integer from %s", value);
         return ERANGE;
@@ -364,7 +397,7 @@ crm_get_msec(const char *input)
         return PCMK__PARSE_INT_DEFAULT;
     }
 
-    scan_ll(num_start, &msec, &end_text);
+    scan_ll(num_start, &msec, PCMK__PARSE_INT_DEFAULT, &end_text);
     if (msec > (LLONG_MAX / multiplier)) {
         // Arithmetics overflow while multiplier/divisor mutually exclusive
         return LLONG_MAX;
@@ -782,7 +815,7 @@ pcmk__parse_ll_range(const char *srcstring, long long *start, long long *end)
      * no beginning or garbage.
      * */
     if (*srcstring == '-') {
-        int rc = scan_ll(srcstring+1, end, &remainder);
+        int rc = scan_ll(srcstring+1, end, PCMK__PARSE_INT_DEFAULT, &remainder);
 
         if (rc != pcmk_rc_ok || *remainder != '\0') {
             return pcmk_rc_unknown_format;
@@ -791,14 +824,16 @@ pcmk__parse_ll_range(const char *srcstring, long long *start, long long *end)
         }
     }
 
-    if (scan_ll(srcstring, start, &remainder) != pcmk_rc_ok) {
+    if (scan_ll(srcstring, start, PCMK__PARSE_INT_DEFAULT,
+                &remainder) != pcmk_rc_ok) {
         return pcmk_rc_unknown_format;
     }
 
     if (*remainder && *remainder == '-') {
         if (*(remainder+1)) {
             char *more_remainder = NULL;
-            int rc = scan_ll(remainder+1, end, &more_remainder);
+            int rc = scan_ll(remainder+1, end, PCMK__PARSE_INT_DEFAULT,
+                             &more_remainder);
 
             if (rc != pcmk_rc_ok || *more_remainder != '\0') {
                 return pcmk_rc_unknown_format;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -113,6 +113,42 @@ pcmk__scan_ll(const char *text, long long *result, long long default_value)
 
 /*!
  * \internal
+ * \brief Scan an integer value from a string, constrained to a minimum
+ *
+ * \param[in]  text           The string to scan (may be NULL)
+ * \param[out] result         Where to store result (or NULL to ignore)
+ * \param[in]  minimum        Value to use as default and minimum
+ *
+ * \return Standard Pacemaker return code
+ * \note If the value is larger than the maximum integer, EOVERFLOW will be
+ *       returned and \p result will be set to the maximum integer.
+ */
+int
+pcmk__scan_min_int(const char *text, int *result, int minimum)
+{
+    int rc;
+    long long result_ll;
+
+    rc = pcmk__scan_ll(text, &result_ll, (long long) minimum);
+
+    if (result_ll < (long long) minimum) {
+        crm_warn("Clipped '%s' to minimum acceptable value %d", text, minimum);
+        result_ll = (long long) minimum;
+
+    } else if (result_ll > INT_MAX) {
+        crm_warn("Clipped '%s' to maximum integer %d", text, INT_MAX);
+        result_ll = (long long) INT_MAX;
+        rc = EOVERFLOW;
+    }
+
+    if (result != NULL) {
+        *result = (int) result_ll;
+    }
+    return rc;
+}
+
+/*!
+ * \internal
  * \brief Scan a TCP port number from a string
  *
  * \param[in]  text  The string to scan

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -177,32 +177,6 @@ pcmk__scan_port(const char *text, int *port)
 }
 
 /*!
- * \brief Parse a long long integer value from a string
- *
- * \param[in] text          The string to parse
- * \param[in] default_text  Default string to parse if text is NULL
- *
- * \return Parsed value on success, PCMK__PARSE_INT_DEFAULT (and set
- *         errno) on error
- */
-long long
-crm_parse_ll(const char *text, const char *default_text)
-{
-    long long result;
-
-    if (text == NULL) {
-        text = default_text;
-        if (text == NULL) {
-            crm_err("No default conversion value supplied");
-            errno = EINVAL;
-            return PCMK__PARSE_INT_DEFAULT;
-        }
-    }
-    scan_ll(text, &result, PCMK__PARSE_INT_DEFAULT, NULL);
-    return result;
-}
-
-/*!
  * \internal
  * \brief Scan a double-precision floating-point value from a string
  *
@@ -1246,6 +1220,23 @@ GHashTable *
 crm_str_table_dup(GHashTable *old_table)
 {
     return pcmk__str_table_dup(old_table);
+}
+
+long long
+crm_parse_ll(const char *text, const char *default_text)
+{
+    long long result;
+
+    if (text == NULL) {
+        text = default_text;
+        if (text == NULL) {
+            crm_err("No default conversion value supplied");
+            errno = EINVAL;
+            return PCMK__PARSE_INT_DEFAULT;
+        }
+    }
+    scan_ll(text, &result, PCMK__PARSE_INT_DEFAULT, NULL);
+    return result;
 }
 
 int

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -112,6 +112,35 @@ pcmk__scan_ll(const char *text, long long *result, long long default_value)
 }
 
 /*!
+ * \internal
+ * \brief Scan a TCP port number from a string
+ *
+ * \param[in]  text  The string to scan
+ * \param[out] port  Where to store result (or NULL to ignore)
+ *
+ * \return Standard Pacemaker return code
+ * \note \p port will be -1 if \p text is NULL or invalid
+ */
+int
+pcmk__scan_port(const char *text, int *port)
+{
+    long long port_ll;
+    int rc = pcmk__scan_ll(text, &port_ll, -1LL);
+
+    if ((text != NULL) && (rc == pcmk_rc_ok) // wasn't default or invalid
+        && ((port_ll < 0LL) || (port_ll > 65535LL))) {
+        crm_warn("Ignoring port specification '%s' "
+                 "not in valid range (0-65535)", text);
+        rc = (port_ll < 0LL)? pcmk_rc_before_range : pcmk_rc_after_range;
+        port_ll = -1LL;
+    }
+    if (port != NULL) {
+        *port = (int) port_ll;
+    }
+    return rc;
+}
+
+/*!
  * \brief Parse a long long integer value from a string
  *
  * \param[in] text          The string to parse

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -80,12 +80,17 @@ char2score(const char *score)
         score_f = pcmk__score_green;
 
     } else {
-        score_f = crm_parse_int(score, NULL);
-        if (score_f > 0 && score_f > CRM_SCORE_INFINITY) {
+        long long score_ll;
+
+        pcmk__scan_ll(score, &score_ll, 0LL);
+        if (score_ll > CRM_SCORE_INFINITY) {
             score_f = CRM_SCORE_INFINITY;
 
-        } else if (score_f < 0 && score_f < -CRM_SCORE_INFINITY) {
+        } else if (score_ll < -CRM_SCORE_INFINITY) {
             score_f = -CRM_SCORE_INFINITY;
+
+        } else {
+            score_f = (int) score_ll;
         }
     }
 

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -840,7 +840,8 @@ apply_system_health(pe_working_set_t * data_set)
          * Defaults are provided by the pe_prefs table
          * Also, custom health "base score" can be used
          */
-        base_health = crm_parse_int(pe_pref(data_set->config_hash, "node-health-base"), "0");
+        base_health = char2score(pe_pref(data_set->config_hash,
+                                         "node-health-base"));
 
     } else if (pcmk__str_eq(health_strategy, "custom", pcmk__str_casei)) {
 

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -2916,16 +2916,22 @@ void
 pcmk__log_transition_summary(const char *filename)
 {
     if (was_processing_error) {
-        crm_err("Calculated transition %d (with errors), saving inputs in %s",
-                transition_id, filename);
+        crm_err("Calculated transition %d (with errors)%s%s",
+                transition_id,
+                (filename == NULL)? "" : ", saving inputs in ",
+                (filename == NULL)? "" : filename);
 
     } else if (was_processing_warning) {
-        crm_warn("Calculated transition %d (with warnings), saving inputs in %s",
-                 transition_id, filename);
+        crm_warn("Calculated transition %d (with warnings)%s%s",
+                 transition_id,
+                 (filename == NULL)? "" : ", saving inputs in ",
+                 (filename == NULL)? "" : filename);
 
     } else {
-        crm_notice("Calculated transition %d, saving inputs in %s",
-                   transition_id, filename);
+        crm_notice("Calculated transition %d%s%s",
+                   transition_id,
+                   (filename == NULL)? "" : ", saving inputs in ",
+                   (filename == NULL)? "" : filename);
     }
     if (pcmk__config_error) {
         crm_notice("Configuration errors found during scheduler processing,"

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -981,10 +981,10 @@ shutdown_time(pe_node_t *node, pe_working_set_t *data_set)
     time_t result = 0;
 
     if (shutdown) {
-        errno = 0;
-        result = (time_t) crm_parse_ll(shutdown, NULL);
-        if (errno != 0) {
-            result = 0;
+        long long result_ll;
+
+        if (pcmk__scan_ll(shutdown, &result_ll, 0LL) == pcmk_rc_ok) {
+            result = (time_t) result_ll;
         }
     }
     return result? result : get_effective_time(data_set);
@@ -2940,6 +2940,7 @@ stage8(pe_working_set_t * data_set)
 {
     GList *gIter = NULL;
     const char *value = NULL;
+    long long limit = 0LL;
 
     transition_id++;
     crm_trace("Creating transition graph %d.", transition_id);
@@ -2966,7 +2967,7 @@ stage8(pe_working_set_t * data_set)
     crm_xml_add_int(data_set->graph, "transition_id", transition_id);
 
     value = pe_pref(data_set->config_hash, "migration-limit");
-    if (crm_parse_ll(value, NULL) > 0) {
+    if ((pcmk__scan_ll(value, &limit, 0LL) == pcmk_rc_ok) && (limit > 0)) {
         crm_xml_add(data_set->graph, "migration-limit", value);
     }
 

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -459,7 +459,16 @@ int copies_per_node(pe_resource_t * rsc)
         case pe_clone:
             {
                 const char *max_clones_node = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_INCARNATION_NODEMAX);
-                return crm_parse_int(max_clones_node, "1");
+
+                if (max_clones_node == NULL) {
+                    return 1;
+
+                } else {
+                    int max_i;
+
+                    pcmk__scan_min_int(max_clones_node, &max_i, 0);
+                    return max_i;
+                }
             }
         case pe_container:
             {

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -434,7 +434,7 @@ unpack_simple_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
         const char *require_all_s = crm_element_value(xml_obj, "require-all");
 
         if (min_clones_s) {
-            min_required_before = crm_parse_int(min_clones_s, "0");
+            pcmk__scan_min_int(min_clones_s, &min_required_before, 0);
 
         } else if (require_all_s) {
             pe_warn_once(pe_wo_require_all,

--- a/lib/pacemaker/pcmk_sched_transition.c
+++ b/lib/pacemaker/pcmk_sched_transition.c
@@ -665,9 +665,7 @@ exec_rsc_action(crm_graph_t * graph, crm_action_t * action)
     rtype = crm_element_value(action_rsc, XML_ATTR_TYPE);
     rprovider = crm_element_value(action_rsc, XML_AGENT_ATTR_PROVIDER);
 
-    if (target_rc_s != NULL) {
-        target_outcome = crm_parse_int(target_rc_s, "0");
-    }
+    pcmk__scan_min_int(target_rc_s, &target_outcome, 0);
 
     CRM_ASSERT(fake_cib->cmds->query(fake_cib, NULL, NULL, cib_sync_call | cib_scope_local) ==
                pcmk_ok);

--- a/lib/pacemaker/pcmk_trans_unpack.c
+++ b/lib/pacemaker/pcmk_trans_unpack.c
@@ -219,8 +219,13 @@ unpack_graph(xmlNode * xml_graph, const char *reference)
             new_graph->stonith_timeout = crm_parse_interval_spec(time);
         }
 
+        // Use 0 (dynamic limit) as default/invalid, -1 (no limit) as minimum
         t_id = crm_element_value(xml_graph, "batch-limit");
-        new_graph->batch_limit = crm_parse_int(t_id, "0");
+        if ((t_id == NULL)
+            || (pcmk__scan_min_int(t_id, &(new_graph->batch_limit),
+                                   -1) != pcmk_rc_ok)) {
+            new_graph->batch_limit = 0;
+        }
 
         t_id = crm_element_value(xml_graph, "migration-limit");
         pcmk__scan_min_int(t_id, &(new_graph->migration_limit), -1);

--- a/lib/pacemaker/pcmk_trans_utils.c
+++ b/lib/pacemaker/pcmk_trans_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -22,10 +22,11 @@ pseudo_action_dummy(crm_graph_t * graph, crm_action_t * action)
     static int fail = -1;
 
     if (fail < 0) {
-        char *fail_s = getenv("PE_fail");
+        long long fail_ll;
 
-        if (fail_s) {
-            fail = (int) crm_parse_ll(fail_s, NULL);
+        if ((pcmk__scan_ll(getenv("PE_fail"), &fail_ll, 0LL) == pcmk_rc_ok)
+            && (fail_ll > 0LL) && (fail_ll <= INT_MAX)) {
+            fail = (int) fail_ll;
         } else {
             fail = 0;
         }

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -152,7 +152,12 @@ clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
     // Implied by calloc()
     /* clone_data->xml_obj_child = NULL; */
 
-    clone_data->clone_node_max = crm_parse_int(max_clones_node, "1");
+    // Use 1 as default but 0 for minimum and invalid
+    if (max_clones_node == NULL) {
+        clone_data->clone_node_max = 1;
+    } else {
+        pcmk__scan_min_int(max_clones_node, &(clone_data->clone_node_max), 0);
+    }
 
     if (max_clones) {
         clone_data->clone_max = crm_parse_int(max_clones, "1");

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -159,14 +159,13 @@ clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
         pcmk__scan_min_int(max_clones_node, &(clone_data->clone_node_max), 0);
     }
 
-    if (max_clones) {
-        clone_data->clone_max = crm_parse_int(max_clones, "1");
-
-    } else if (pcmk__list_of_multiple(data_set->nodes)) {
-        clone_data->clone_max = g_list_length(data_set->nodes);
-
+    /* Use number of nodes (but always at least 1, which is handy for crm_verify
+     * for a CIB without nodes) as default, but 0 for minimum and invalid
+     */
+    if (max_clones == NULL) {
+        clone_data->clone_max = QB_MAX(1, g_list_length(data_set->nodes));
     } else {
-        clone_data->clone_max = 1;      /* Handy during crm_verify */
+        pcmk__scan_min_int(max_clones, &(clone_data->clone_max), 0);
     }
 
     clone_data->ordered = crm_is_true(ordered);

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -145,8 +145,20 @@ clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
                                                     XML_RSC_ATTR_MASTER_NODEMAX);
         }
 
-        clone_data->promoted_max = crm_parse_int(promoted_max, "1");
-        clone_data->promoted_node_max = crm_parse_int(promoted_node_max, "1");
+        // Use 1 as default but 0 for minimum and invalid
+        if (promoted_max == NULL) {
+            clone_data->promoted_max = 1;
+        } else {
+            pcmk__scan_min_int(promoted_max, &(clone_data->promoted_max), 0);
+        }
+
+        // Use 1 as default but 0 for minimum and invalid
+        if (promoted_node_max == NULL) {
+            clone_data->promoted_node_max = 1;
+        } else {
+            pcmk__scan_min_int(promoted_node_max,
+                               &(clone_data->promoted_node_max), 0);
+        }
     }
 
     // Implied by calloc()

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -598,7 +598,7 @@ common_unpack(xmlNode * xml_obj, pe_resource_t ** rsc,
     (*rsc)->failure_timeout = 0;
 
     value = g_hash_table_lookup((*rsc)->meta, XML_CIB_ATTR_PRIORITY);
-    (*rsc)->priority = crm_parse_int(value, "0");
+    (*rsc)->priority = char2score(value);
 
     value = g_hash_table_lookup((*rsc)->meta, XML_RSC_ATTR_CRITICAL);
     if ((value == NULL) || crm_is_true(value)) {

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2020 the Pacemaker project contributors
+ * Copyright 2008-2021 the Pacemaker project contributors
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -266,7 +266,11 @@ pe_get_failcount(pe_node_t *node, pe_resource_t *rsc, time_t *last_failure,
         if (regexec(&failcount_re, key, 0, NULL, 0) == 0) {
             failcount = pe__add_scores(failcount, char2score(value));
         } else if (regexec(&lastfailure_re, key, 0, NULL, 0) == 0) {
-            last = QB_MAX(last, (time_t) crm_parse_ll(value, NULL));
+            long long last_ll;
+
+            if (pcmk__scan_ll(value, &last_ll, 0LL) == pcmk_rc_ok) {
+                last = (time_t) QB_MAX(last, last_ll);
+            }
         }
     }
 

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -162,9 +162,8 @@ calculate_main_digest(op_digest_cache_t *data, pe_resource_t *rsc,
         if (interval_s != NULL) {
             long long value_ll;
 
-            errno = 0;
-            value_ll = crm_parse_ll(interval_s, NULL);
-            if ((errno == 0) && (value_ll >= 0) && (value_ll <= G_MAXUINT)) {
+            if ((pcmk__scan_ll(interval_s, &value_ll, 0LL) == pcmk_rc_ok)
+                && (value_ll >= 0) && (value_ll <= G_MAXUINT)) {
                 *interval_ms = (guint) value_ll;
             }
         }

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -910,13 +910,13 @@ compare_attr_expr_vals(const char *l_val, const char *r_val, const char *type,
             cmp = strcasecmp(l_val, r_val);
 
         } else if (pcmk__str_eq(type, "integer", pcmk__str_casei)) {
-            long long l_val_num = crm_parse_ll(l_val, NULL);
-            int rc1 = errno;
+            long long l_val_num;
+            int rc1 = pcmk__scan_ll(l_val, &l_val_num, 0LL);
 
-            long long r_val_num = crm_parse_ll(r_val, NULL);
-            int rc2 = errno;
+            long long r_val_num;
+            int rc2 = pcmk__scan_ll(r_val, &r_val_num, 0LL);
 
-            if (rc1 == 0 && rc2 == 0) {
+            if ((rc1 == pcmk_rc_ok) && (rc2 == pcmk_rc_ok)) {
                 if (l_val_num < r_val_num) {
                     cmp = -1;
                 } else if (l_val_num > r_val_num) {

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -273,29 +273,32 @@ pe_cron_range_satisfied(crm_time_t * now, xmlNode * cron_spec)
     return pcmk_rc_ok;
 }
 
-#define update_field(xml_field, time_fn)			\
-    value = crm_element_value(duration_spec, xml_field);	\
-    if(value != NULL) {						\
-	int value_i = crm_parse_int(value, "0");		\
-	time_fn(end, value_i);					\
+static void
+update_field(crm_time_t *t, xmlNode *xml, const char *attr,
+            void (*time_fn)(crm_time_t *, int))
+{
+    long long value;
+
+    if ((pcmk__scan_ll(crm_element_value(xml, attr), &value, 0LL) == pcmk_rc_ok)
+        && (value != 0LL) && (value >= INT_MIN) && (value <= INT_MAX)) {
+        time_fn(t, (int) value);
     }
+}
 
 crm_time_t *
 pe_parse_xml_duration(crm_time_t * start, xmlNode * duration_spec)
 {
-    crm_time_t *end = NULL;
-    const char *value = NULL;
+    crm_time_t *end = crm_time_new_undefined();
 
-    end = crm_time_new(NULL);
     crm_time_set(end, start);
 
-    update_field("years", crm_time_add_years);
-    update_field("months", crm_time_add_months);
-    update_field("weeks", crm_time_add_weeks);
-    update_field("days", crm_time_add_days);
-    update_field("hours", crm_time_add_hours);
-    update_field("minutes", crm_time_add_minutes);
-    update_field("seconds", crm_time_add_seconds);
+    update_field(end, duration_spec, "years", crm_time_add_years);
+    update_field(end, duration_spec, "months", crm_time_add_months);
+    update_field(end, duration_spec, "weeks", crm_time_add_weeks);
+    update_field(end, duration_spec, "days", crm_time_add_days);
+    update_field(end, duration_spec, "hours", crm_time_add_hours);
+    update_field(end, duration_spec, "minutes", crm_time_add_minutes);
+    update_field(end, duration_spec, "seconds", crm_time_add_seconds);
 
     return end;
 }

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -919,7 +919,10 @@ unpack_ticket_state(xmlNode * xml_ticket, pe_working_set_t * data_set)
 
     last_granted = g_hash_table_lookup(ticket->state, "last-granted");
     if (last_granted) {
-        ticket->last_granted = crm_parse_int(last_granted, 0);
+        long long last_granted_ll;
+
+        pcmk__scan_ll(last_granted, &last_granted_ll, 0LL);
+        ticket->last_granted = (time_t) last_granted_ll;
     }
 
     standby = g_hash_table_lookup(ticket->state, "standby");

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -973,8 +973,8 @@ unpack_handle_remote_attrs(pe_node_t *this_node, xmlNode *state, pe_working_set_
     }
     crm_trace("Processing remote node id=%s, uname=%s", this_node->details->id, this_node->details->uname);
 
-    this_node->details->remote_maintenance =
-        crm_atoi(crm_element_value(state, XML_NODE_IS_MAINTENANCE), "0");
+    pcmk__scan_min_int(crm_element_value(state, XML_NODE_IS_MAINTENANCE),
+                       &(this_node->details->remote_maintenance), 0);
 
     rsc = this_node->details->remote_rsc;
     if (this_node->details->remote_requires_reset == FALSE) {
@@ -1099,9 +1099,8 @@ unpack_node_state(xmlNode *state, pe_working_set_t *data_set)
          * do need to mark whether the node has been fenced, as this plays a
          * role during unpacking cluster node resource state.
          */
-        const char *is_fenced = crm_element_value(state, XML_NODE_IS_FENCED);
-
-        this_node->details->remote_was_fenced = crm_atoi(is_fenced, "0");
+        pcmk__scan_min_int(crm_element_value(state, XML_NODE_IS_FENCED),
+                           &(this_node->details->remote_was_fenced), 0);
         return;
     }
 

--- a/tools/crm_error.c
+++ b/tools/crm_error.c
@@ -136,7 +136,7 @@ main(int argc, char **argv)
 
         /* Skip #1 because that's the program name. */
         for (lpc = 1; processed_args[lpc] != NULL; lpc++) {
-            rc = crm_atoi(processed_args[lpc], NULL);
+            pcmk__scan_min_int(processed_args[lpc], &rc, INT_MIN);
             get_strings(rc, &name, &desc);
             if (options.with_name) {
                 printf("%s - %s\n", name, desc);

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -386,7 +386,11 @@ as_xml_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError *
 
 static gboolean
 fence_history_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    interactive_fence_level = crm_atoi(optarg, "2");
+    if (optarg == NULL) {
+        interactive_fence_level = 2;
+    } else {
+        pcmk__scan_min_int(optarg, &interactive_fence_level, 0);
+    }
 
     switch (interactive_fence_level) {
         case 3:

--- a/tools/crm_mon_print.c
+++ b/tools/crm_mon_print.c
@@ -156,7 +156,9 @@ get_operation_list(xmlNode *rsc_entry) {
         const char *interval_ms_s = crm_element_value(rsc_op,
                                                       XML_LRM_ATTR_INTERVAL_MS);
         const char *op_rc = crm_element_value(rsc_op, XML_LRM_ATTR_RC);
-        int op_rc_i = crm_parse_int(op_rc, "0");
+        int op_rc_i;
+
+        pcmk__scan_min_int(op_rc, &op_rc_i, 0);
 
         /* Display 0-interval monitors as "probe" */
         if (pcmk__str_eq(task, CRMD_ACTION_STATUS, pcmk__str_casei)
@@ -205,7 +207,9 @@ print_rsc_history(pe_working_set_t *data_set, pe_node_t *node, xmlNode *rsc_entr
         const char *interval_ms_s = crm_element_value(xml_op,
                                                       XML_LRM_ATTR_INTERVAL_MS);
         const char *op_rc = crm_element_value(xml_op, XML_LRM_ATTR_RC);
-        int op_rc_i = crm_parse_int(op_rc, "0");
+        int op_rc_i;
+
+        pcmk__scan_min_int(op_rc, &op_rc_i, 0);
 
         /* Display 0-interval monitors as "probe" */
         if (pcmk__str_eq(task, CRMD_ACTION_STATUS, pcmk__str_casei)

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -113,7 +113,7 @@ command_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError 
 gboolean
 name_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
     options.command = 'N';
-    options.nodeid = crm_parse_int(optarg, NULL);
+    pcmk__scan_min_int(optarg, &(options.nodeid), 0);
     return TRUE;
 }
 

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1207,11 +1207,16 @@ max_delay_for_resource(pe_working_set_t * data_set, pe_resource_t *rsc)
         char *key = crm_strdup_printf("%s_%s_0", rsc->id, RSC_STOP);
         pe_action_t *stop = custom_action(rsc, key, RSC_STOP, NULL, TRUE, FALSE, data_set);
         const char *value = g_hash_table_lookup(stop->meta, XML_ATTR_TIMEOUT);
+        long long result_ll;
 
-        max_delay = value? (int) crm_parse_ll(value, NULL) : -1;
+        if ((pcmk__scan_ll(value, &result_ll, -1LL) == pcmk_rc_ok)
+            && (result_ll >= 0) && (result_ll <= INT_MAX)) {
+            max_delay = (int) result_ll;
+        } else {
+            max_delay = -1;
+        }
         pe_free_action(stop);
     }
-
 
     return max_delay;
 }

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -97,7 +97,10 @@ print_ticket(pe_ticket_t * ticket, gboolean raw, gboolean details)
             }
             fprintf(stdout, "%s=", name);
             if (pcmk__str_any_of(name, "last-granted", "expires", NULL)) {
-                print_date(crm_parse_int(value, 0));
+                long long time_ll;
+
+                pcmk__scan_ll(value, &time_ll, 0);
+                print_date((time_t) time_ll);
             } else {
                 fprintf(stdout, "%s", value);
             }


### PR DESCRIPTION
Preparing to deprecate integer parsing functions from Pacemaker's public C API, I realized we had a lot of places with insufficient handling of invalid or out-of-bounds values. This is an attempt to get all that in order.

* The first commit is the biggest (most of the rest are trivial or small). Callers provided the existing crm_parse_ll() with a string default to parse when the given value is NULL. If no default were given, it would use -1 as the default. However when the given value is invalid (e.g. PCMK_node_action_limit="foo"), it would always use -1, not the default if given. This commit uses a new pcmk__scan_ll() function that takes a long long value as a default instead of a string default that gets parsed to a long long (and which parsing could theoretically fail in itself), and it uses that value for invalid text as well as NULL text. At the same time, for callers that cast the long long result to a smaller type, this commit does bounds-checking.
* A couple of Y2038 issues in status displays are fixed.
* Certain configuration items (stonith-max-attempts, node-health-base, remote-tls-port, remote-clear-port, clone-node-max, clone-min, promoted-max, promoted-node-max, batch-limit, pcmk_action_limit, and resource priorities) are now constrained to meaningful ranges.
* crm_parse_int() in most cases is replaced by a new pcmk__scan_min_int(), which takes a value that is used as both the default and a minimum, since most of our uses fit that pattern.
* Invalid duration fields in rules are now treated as 0 (i.e. have no effect) rather than -1 (i.e. subtract one whatever from the duration).

The feature set is bumped to ensure cluster handling of invalid/out-of-range configuration values doesn't flip back and forth when different nodes become DC.