### PR TITLE
Low: libcrmcommon: Use G_GNUC_PRINTF instead of the __printf__ attrib…

### DIFF
--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -46,7 +46,7 @@ gboolean crm_is_true(const char *s);
 int crm_str_to_boolean(const char *s, int *ret);
 long long crm_get_msec(const char *input);
 char * crm_strip_trailing_newline(char *str);
-char *crm_strdup_printf(char const *format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));
+char *crm_strdup_printf(char const *format, ...) G_GNUC_PRINTF(1, 2);
 
 guint crm_parse_interval_spec(const char *input);
 int char2score(const char *score);

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -285,8 +285,7 @@ char *xml_get_path(xmlNode *xml);
 
 char * crm_xml_escape(const char *text);
 void crm_xml_sanitize_id(char *id);
-void crm_xml_set_id(xmlNode *xml, const char *format, ...)
-    __attribute__ ((__format__ (__printf__, 2, 3)));
+void crm_xml_set_id(xmlNode *xml, const char *format, ...) G_GNUC_PRINTF(2, 3);
 
 /*!
  * \brief xmlNode destructor which can be used in glib collections

--- a/lib/fencing/st_lha.c
+++ b/lib/fencing/st_lha.c
@@ -148,7 +148,7 @@ strdup_null(const char *val)
 }
 
 static void
-stonith_plugin(int priority, const char *fmt, ...) __attribute__((__format__ (__printf__, 2, 3)));
+stonith_plugin(int priority, const char *fmt, ...) G_GNUC_PRINTF(2, 3);
 
 static void
 stonith_plugin(int priority, const char *format, ...)


### PR DESCRIPTION
…ute.

The result is the same, but we're using the macro everywhere else except
for these three places, so we might as well be consistent.