### PR TITLE
[WIP] Fix: crm_mon: try to connect CIB while pacemakerd shutting down

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1014,6 +1014,8 @@ pacemakerd_status(void)
                                 break;
                             case pcmk_pacemakerd_state_shutting_down:
                                 out->info(out,"Pacemaker daemons shutting down ...");
+                                /* try our luck maybe CIB is still accessible */
+                                rc = pcmk_rc_ok;
                                 break;
                             case pcmk_pacemakerd_state_shutdown_complete:
                                 /* assuming pacemakerd doesn't dispatch any pings after entering


### PR DESCRIPTION
actually while resources are evacuated from the node. But atm
there is no clean and easy way to tell when this is done or if
pacemakerd is just shutting down leftover daemons. So try to
connect anyway.

This showed up to be an issue - introduced by checking for
pacemakerd in full up & running state - when resources are
using crm_mon in their stop-operation.
Maybe don't merge this right away.
I've opened this PR with the simplest solution to just handle
the state where pacemakerd is sequentially shutting down
the subdaemons exactly like as if it was fully up and running.
So we can discuss here.
Alternative might be introduction of an additional state so
that when querying the state of pacemakerd the caller can
know that it is actually still trying to get down all resources
on the node before starting to shutdown all the subdaemons.