### PR TITLE
Fix: crm_mon: try to connect CIB while pacemakerd shutting down

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1031,6 +1031,10 @@ pacemakerd_status(void)
                             case pcmk_pacemakerd_state_running:
                                 rc = pcmk_rc_ok;
                                 break;
+                            case pcmk_pacemakerd_state_shutting_down:
+                                /* try our luck maybe CIB is still accessible */
+                                rc = pcmk_rc_ok;
+                                break;
                             default:
                                 break;
                         }


### PR DESCRIPTION
we need to do this in all output modes (xml specifically)