### PR TITLE
Call sync() before calling sysrq_trigger(b) in panic_local()

### DIFF
--- a/etc/sysconfig/pacemaker
+++ b/etc/sysconfig/pacemaker
@@ -79,8 +79,11 @@
 
 # Pacemaker will panic its host under certain conditions. If this is set to
 # "crash", Pacemaker will trigger a kernel crash (which is useful if you want a
-# kernel dump to investigate). For any other value, Pacemaker will trigger a
-# host reboot. The default is unset.
+# kernel dump to investigate). If "sync-reboot" is set, execute sync() before
+# host reboot (this leaves information about the crashed daemon in the log
+# file, but note that there is a possibility that the sync() call may not
+# return). For any other value, Pacemaker will trigger a host reboot. The
+# default is unset.
 # PCMK_panic_action=crash
 
 #==#==# Pacemaker Remote

--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -96,7 +96,9 @@ panic_local(void)
     if (pcmk__str_eq("crash", getenv("PCMK_panic_action"), pcmk__str_casei)) {
         sysrq_trigger('c');
     } else {
-        sync();
+        if (pcmk__str_eq("sync-reboot", getenv("PCMK_panic_action"), pcmk__str_casei)) {
+            sync();
+        }
         sysrq_trigger('b');
     }
     /* reboot(RB_HALT_SYSTEM); rc = errno; */

--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -96,6 +96,7 @@ panic_local(void)
     if (pcmk__str_eq("crash", getenv("PCMK_panic_action"), pcmk__str_casei)) {
         sysrq_trigger('c');
     } else {
+        sync();
         sysrq_trigger('b');
     }
     /* reboot(RB_HALT_SYSTEM); rc = errno; */


### PR DESCRIPTION
If a pacemaker sub-process terminates unexpectedly in an environment where fail_fast=yes is set, no message will be left in pacemaker.log indicating the cause.
(We do not use fail_fast=no because there is a problem [1] that the attributes will remain missing if controld or attrd unexpectedly terminates.)
I am aware of the risk [2], but sbd executed via panic_sbd() calls sync() [3] before sysrq_trigger('b').

[1] https://github.com/ClusterLabs/pacemaker/pull/1699
[2] https://github.com/ClusterLabs/pacemaker/pull/874#issuecomment-171069747
[3] https://github.com/ClusterLabs/sbd/blob/v1.4.2/src/sbd-common.c#L958