### PR TITLE
Support "sync-crash" option with PCMK_panic_action

### DIFF
--- a/etc/sysconfig/pacemaker
+++ b/etc/sysconfig/pacemaker
@@ -79,11 +79,11 @@
 
 # Pacemaker will panic its host under certain conditions. If this is set to
 # "crash", Pacemaker will trigger a kernel crash (which is useful if you want a
-# kernel dump to investigate). If "sync-reboot" is set, execute sync() before
-# host reboot (this leaves information about the crashed daemon in the log
-# file, but note that there is a possibility that the sync() call may not
-# return). For any other value, Pacemaker will trigger a host reboot. The
-# default is unset.
+# kernel dump to investigate). If "sync-reboot" or "sync-crash" is set, execute
+# sync() before host reboot or kernel crash (this leaves information about the
+# crashed daemon in the log file, but note that there is a possibility that the
+# sync() call may not return). For any other value, Pacemaker will trigger a
+# host reboot. The default is unset.
 # PCMK_panic_action=crash
 
 #==#==# Pacemaker Remote

--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -95,6 +95,9 @@ panic_local(void)
 
     if (pcmk__str_eq("crash", getenv("PCMK_panic_action"), pcmk__str_casei)) {
         sysrq_trigger('c');
+    } else if (pcmk__str_eq("sync-crash", getenv("PCMK_panic_action"), pcmk__str_casei)) {
+        sync();
+        sysrq_trigger('c');
     } else {
         if (pcmk__str_eq("sync-reboot", getenv("PCMK_panic_action"), pcmk__str_casei)) {
             sync();


### PR DESCRIPTION
This is a supplement to https://github.com/ClusterLabs/pacemaker/pull/2344.
I think some users want both log and kernel dump, but what about?