### PR TITLE
Low: Fix maint-mode output on curses mode.

### DIFF
--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -410,6 +410,24 @@ curses_indented_printf(pcmk__output_t *out, const char *format, ...) {
     va_end(ap);
 }
 
+PCMK__OUTPUT_ARGS("maint-mode", "unsigned long long int")
+static int
+cluster_maint_mode_console(pcmk__output_t *out, va_list args) {
+    unsigned long long flags = va_arg(args, unsigned long long);
+
+    if (pcmk_is_set(flags, pe_flag_maintenance_mode)) {
+        curses_formatted_printf(out, "\n              *** Resource management is DISABLED ***\n");
+        curses_formatted_printf(out, "  The cluster will not attempt to start, stop or recover services\n");
+        return pcmk_rc_ok;
+    } else if (pcmk_is_set(flags, pe_flag_stop_everything)) {
+        curses_formatted_printf(out, "\n    *** Resource management is DISABLED ***\n");
+        curses_formatted_printf(out, "  The cluster will keep all resources stopped\n");
+        return pcmk_rc_ok;
+    } else {
+        return pcmk_rc_no_output;
+    }
+}
+
 PCMK__OUTPUT_ARGS("stonith-event", "stonith_history_t *", "gboolean", "gboolean")
 static int
 stonith_event_console(pcmk__output_t *out, va_list args) {
@@ -468,7 +486,7 @@ static pcmk__message_entry_t fmt_functions[] = {
     { "fencing-list", "console", stonith__history },
     { "full-fencing-list", "console", stonith__full_history },
     { "group", "console", pe__group_text },
-    { "maint-mode", "console", pe__cluster_maint_mode_text },
+    { "maint-mode", "console", cluster_maint_mode_console },
     { "node", "console", pe__node_text },
     { "node-attribute", "console", pe__node_attribute_text },
     { "node-list", "console", pe__node_list_text },


### PR DESCRIPTION
This was broken by 6233f2ffb429c889747d5d56fa0b679424562c0d, which
switched from the format-specific out->info function to the text-only
pcmk__formatted_printf function.  Remember that curses always needs to
use its own printing functions or the screen will look weird.