### PR TITLE
Low: libpe_status: Don't output an extraneous header under crm_mon -b.

### DIFF
--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -2414,7 +2414,7 @@ resource_list(pcmk__output_t *out, va_list args)
         print_resource_header(out, group_by_node, inactive_resources);
         printed_header = true;
 
-        pe__rscs_brief_output(out, rscs, print_opts, inactive_resources);
+        rc = pe__rscs_brief_output(out, rscs, print_opts, inactive_resources);
         g_list_free(rscs);
     }
 


### PR DESCRIPTION
It looks like this only happens for brief output when there are only
primitive resources in the cluster.  In that case, the summary header
was getting added as a list item under the rest of the resources.