### PR TITLE
Improve liblrmd return codes and log messages

### DIFF
--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -453,7 +453,7 @@ remote_config_check(xmlNode * msg, int call_id, int rc, xmlNode * output, void *
                           config_hash, CIB_OPTIONS_FIRST, FALSE, now, NULL);
 
         /* Now send it to the remote peer */
-        remote_proxy_check(lrmd, config_hash);
+        lrmd__validate_remote_settings(lrmd, config_hash);
 
         g_hash_table_destroy(config_hash);
         crm_time_free(now);

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -210,7 +210,7 @@ lrmd_server_send_reply(pcmk__client_t *client, uint32_t id, xmlNode *reply)
             return pcmk__ipc_send_xml(client, id, reply, FALSE);
 #ifdef PCMK__COMPILE_REMOTE
         case pcmk__client_tls:
-            return lrmd_tls_send_msg(client->remote, reply, id, "reply");
+            return lrmd__remote_send_xml(client->remote, reply, id, "reply");
 #endif
         default:
             crm_err("Could not send reply: unknown type for client %s "
@@ -238,7 +238,7 @@ lrmd_server_send_notify(pcmk__client_t *client, xmlNode *msg)
                 crm_trace("Could not notify remote client: disconnected");
                 return ENOTCONN;
             } else {
-                return lrmd_tls_send_msg(client->remote, msg, 0, "notify");
+                return lrmd__remote_send_xml(client->remote, msg, 0, "notify");
             }
 #endif
         default:

--- a/include/crm/common/mainloop.h
+++ b/include/crm/common/mainloop.h
@@ -71,8 +71,23 @@ void mainloop_timer_del(mainloop_timer_t *t);
 #  include <qb/qbipcs.h>
 
 struct ipc_client_callbacks {
+    /*!
+     * \brief Dispatch function for an IPC connection used as mainloop source
+     *
+     * \param[in] buffer    Message read from IPC connection
+     * \param[in] length    Number of bytes in \p buffer
+     * \param[in] userdata  User data passed when creating mainloop source
+     *
+     * \return Negative value to remove source, anything else to keep it
+     */
     int (*dispatch) (const char *buffer, ssize_t length, gpointer userdata);
-    void (*destroy) (gpointer);
+
+    /*!
+     * \brief Destroy function for mainloop IPC connection client data
+     *
+     * \param[in] userdata  User data passed when creating mainloop source
+     */
+    void (*destroy) (gpointer userdata);
 };
 
 qb_ipcs_service_t *mainloop_add_ipc_server(const char *name, enum qb_ipc_type type,
@@ -112,7 +127,20 @@ void mainloop_del_ipc_client(mainloop_io_t * client);
 crm_ipc_t *mainloop_get_ipc_client(mainloop_io_t * client);
 
 struct mainloop_fd_callbacks {
+    /*!
+     * \brief Dispatch function for mainloop file descriptor with data ready
+     *
+     * \param[in] userdata  User data passed when creating mainloop source
+     *
+     * \return Negative value to remove source, anything else to keep it
+     */
     int (*dispatch) (gpointer userdata);
+
+    /*!
+     * \brief Destroy function for mainloop file descriptor client data
+     *
+     * \param[in] userdata  User data passed when creating mainloop source
+     */
     void (*destroy) (gpointer userdata);
 };
 

--- a/include/crm/lrmd_internal.h
+++ b/include/crm/lrmd_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the Pacemaker project contributors
+ * Copyright 2015-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -30,8 +30,8 @@ int lrmd_send_fencing_alert(lrmd_t *lrmd, GList *alert_list,
 int lrmd_send_resource_alert(lrmd_t *lrmd, GList *alert_list,
                              const char *node, lrmd_event_data_t *op);
 
-int lrmd_tls_send_msg(pcmk__remote_t *session, xmlNode *msg, uint32_t id,
-                      const char *msg_type);
+int lrmd__remote_send_xml(pcmk__remote_t *session, xmlNode *msg, uint32_t id,
+                          const char *msg_type);
 
 /* Shared functions for IPC proxy back end */
 

--- a/include/crm/lrmd_internal.h
+++ b/include/crm/lrmd_internal.h
@@ -69,4 +69,8 @@ void remote_proxy_relay_response(remote_proxy_t *proxy, xmlNode *msg,
 
 void lrmd__register_messages(pcmk__output_t *out);
 
+#ifdef HAVE_GNUTLS_GNUTLS_H
+int lrmd__init_remote_key(gnutls_datum_t *key);
+#endif
+
 #endif

--- a/include/crm/lrmd_internal.h
+++ b/include/crm/lrmd_internal.h
@@ -53,7 +53,7 @@ remote_proxy_t *remote_proxy_new(lrmd_t *lrmd,
                                  const char *node_name, const char *session_id,
                                  const char *channel);
 
-int  remote_proxy_check(lrmd_t *lrmd, GHashTable *hash);
+int lrmd__validate_remote_settings(lrmd_t *lrmd, GHashTable *hash);
 void remote_proxy_cb(lrmd_t *lrmd, const char *node_name, xmlNode *msg);
 void remote_proxy_ack_shutdown(lrmd_t *lrmd);
 void remote_proxy_nack_shutdown(lrmd_t *lrmd);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -923,10 +923,11 @@ lrmd_api_poke_connection(lrmd_t * lrmd)
     return rc < 0 ? rc : pcmk_ok;
 }
 
+// \return Standard Pacemaker return code
 int
-remote_proxy_check(lrmd_t * lrmd, GHashTable *hash)
+lrmd__validate_remote_settings(lrmd_t *lrmd, GHashTable *hash)
 {
-    int rc;
+    int rc = pcmk_rc_ok;
     const char *value;
     lrmd_private_t *native = lrmd->lrmd_private;
     xmlNode *data = create_xml_node(NULL, F_LRMD_OPERATION);
@@ -939,8 +940,7 @@ remote_proxy_check(lrmd_t * lrmd, GHashTable *hash)
     rc = lrmd_send_command(lrmd, LRMD_OP_CHECK, data, NULL, 0, 0,
                            (native->type == pcmk__client_ipc));
     free_xml(data);
-
-    return rc < 0 ? rc : pcmk_ok;
+    return (rc < 0)? pcmk_legacy2rc(rc) : pcmk_rc_ok;
 }
 
 static int

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1193,7 +1193,13 @@ get_remote_key(const char *location, gnutls_datum_t *key)
 int
 lrmd__init_remote_key(gnutls_datum_t *key)
 {
-    const char *env_location = getenv("PCMK_authkey_location");
+    static const char *env_location = NULL;
+    static bool need_env = true;
+
+    if (need_env) {
+        env_location = getenv("PCMK_authkey_location");
+        need_env = false;
+    }
 
     if (env_location != NULL) {
         int rc = get_remote_key(env_location, key);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -348,16 +348,12 @@ lrmd_free_xml(gpointer userdata)
     free_xml((xmlNode *) userdata);
 }
 
-static int
-lrmd_tls_connected(lrmd_t * lrmd)
+static bool
+remote_executor_connected(lrmd_t * lrmd)
 {
     lrmd_private_t *native = lrmd->lrmd_private;
 
-    if (native->remote->tls_session) {
-        return TRUE;
-    }
-
-    return FALSE;
+    return (native->remote->tls_session != NULL);
 }
 
 static int
@@ -368,7 +364,7 @@ lrmd_tls_dispatch(gpointer userdata)
     xmlNode *xml = NULL;
     int rc = pcmk_rc_ok;
 
-    if (lrmd_tls_connected(lrmd) == FALSE) {
+    if (!remote_executor_connected(lrmd)) {
         crm_trace("TLS dispatch triggered after disconnect");
         return 0;
     }
@@ -718,7 +714,7 @@ lrmd_tls_send_recv(lrmd_t * lrmd, xmlNode * msg, int timeout, xmlNode ** reply)
     int disconnected = 0;
     xmlNode *xml = NULL;
 
-    if (lrmd_tls_connected(lrmd) == FALSE) {
+    if (!remote_executor_connected(lrmd)) {
         return -1;
     }
 
@@ -810,7 +806,7 @@ lrmd_api_is_connected(lrmd_t * lrmd)
             return crm_ipc_connected(native->ipc);
 #ifdef HAVE_GNUTLS_GNUTLS_H
         case pcmk__client_tls:
-            return lrmd_tls_connected(lrmd);
+            return remote_executor_connected(lrmd);
 #endif
         default:
             crm_err("Unsupported connection type: %d", native->type);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -465,10 +465,10 @@ lrmd_poll(lrmd_t * lrmd, int timeout)
             }
 #endif
         default:
-            crm_err("Unsupported connection type: %d", native->type);
+            crm_err("Unsupported executor connection type (bug?): %d",
+                    native->type);
+            return -EPROTONOSUPPORT;
     }
-
-    return 0;
 }
 
 /* Not used with mainloop */
@@ -496,7 +496,8 @@ lrmd_dispatch(lrmd_t * lrmd)
             break;
 #endif
         default:
-            crm_err("Unsupported connection type: %d", private->type);
+            crm_err("Unsupported executor connection type (bug?): %d",
+                    private->type);
     }
 
     if (lrmd_api_is_connected(lrmd) == FALSE) {
@@ -748,7 +749,7 @@ lrmd_tls_send_recv(lrmd_t * lrmd, xmlNode * msg, int timeout, xmlNode ** reply)
 static int
 lrmd_send_xml(lrmd_t * lrmd, xmlNode * msg, int timeout, xmlNode ** reply)
 {
-    int rc = -1;
+    int rc = pcmk_ok;
     lrmd_private_t *native = lrmd->lrmd_private;
 
     switch (native->type) {
@@ -761,7 +762,9 @@ lrmd_send_xml(lrmd_t * lrmd, xmlNode * msg, int timeout, xmlNode ** reply)
             break;
 #endif
         default:
-            crm_err("Unsupported connection type: %d", native->type);
+            crm_err("Unsupported executor connection type (bug?): %d",
+                    native->type);
+            rc = -EPROTONOSUPPORT;
     }
 
     return rc;
@@ -770,7 +773,7 @@ lrmd_send_xml(lrmd_t * lrmd, xmlNode * msg, int timeout, xmlNode ** reply)
 static int
 lrmd_send_xml_no_reply(lrmd_t * lrmd, xmlNode * msg)
 {
-    int rc = -1;
+    int rc = pcmk_ok;
     lrmd_private_t *native = lrmd->lrmd_private;
 
     switch (native->type) {
@@ -790,7 +793,9 @@ lrmd_send_xml_no_reply(lrmd_t * lrmd, xmlNode * msg)
             break;
 #endif
         default:
-            crm_err("Unsupported connection type: %d", native->type);
+            crm_err("Unsupported executor connection type (bug?): %d",
+                    native->type);
+            rc = -EPROTONOSUPPORT;
     }
 
     return rc;
@@ -809,10 +814,10 @@ lrmd_api_is_connected(lrmd_t * lrmd)
             return remote_executor_connected(lrmd);
 #endif
         default:
-            crm_err("Unsupported connection type: %d", native->type);
+            crm_err("Unsupported executor connection type (bug?): %d",
+                    native->type);
+            return 0;
     }
-
-    return 0;
 }
 
 /*!
@@ -1376,7 +1381,9 @@ lrmd_api_connect(lrmd_t * lrmd, const char *name, int *fd)
             break;
 #endif
         default:
-            crm_err("Unsupported connection type: %d", native->type);
+            crm_err("Unsupported executor connection type (bug?): %d",
+                    native->type);
+            rc = -EPROTONOSUPPORT;
     }
 
     if (rc == pcmk_ok) {
@@ -1389,10 +1396,10 @@ lrmd_api_connect(lrmd_t * lrmd, const char *name, int *fd)
 static int
 lrmd_api_connect_async(lrmd_t * lrmd, const char *name, int timeout)
 {
-    int rc = 0;
+    int rc = pcmk_ok;
     lrmd_private_t *native = lrmd->lrmd_private;
 
-    CRM_CHECK(native && native->callback, return -1);
+    CRM_CHECK(native && native->callback, return -EINVAL);
 
     switch (native->type) {
         case pcmk__client_ipc:
@@ -1413,7 +1420,9 @@ lrmd_api_connect_async(lrmd_t * lrmd, const char *name, int timeout)
             break;
 #endif
         default:
-            crm_err("Unsupported connection type: %d", native->type);
+            crm_err("Unsupported executor connection type (bug?): %d",
+                    native->type);
+            rc = -EPROTONOSUPPORT;
     }
 
     return rc;
@@ -1479,6 +1488,7 @@ static int
 lrmd_api_disconnect(lrmd_t * lrmd)
 {
     lrmd_private_t *native = lrmd->lrmd_private;
+    int rc = pcmk_ok;
 
     crm_info("Disconnecting %s %s executor connection",
              pcmk__client_type_str(native->type),
@@ -1493,7 +1503,9 @@ lrmd_api_disconnect(lrmd_t * lrmd)
             break;
 #endif
         default:
-            crm_err("Unsupported connection type: %d", native->type);
+            crm_err("Unsupported executor connection type (bug?): %d",
+                    native->type);
+            rc = -EPROTONOSUPPORT;
     }
 
     free(native->token);
@@ -1501,7 +1513,7 @@ lrmd_api_disconnect(lrmd_t * lrmd)
 
     free(native->peer_version);
     native->peer_version = NULL;
-    return 0;
+    return rc;
 }
 
 static int

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -727,7 +727,7 @@ lrmd_tls_send_recv(lrmd_t * lrmd, xmlNode * msg, int timeout, xmlNode ** reply)
     xmlNode *xml = NULL;
 
     if (!remote_executor_connected(lrmd)) {
-        return -1;
+        return -ENOTCONN;
     }
 
     rc = send_remote_message(lrmd, msg);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1309,7 +1309,7 @@ lrmd_tls_connect_async(lrmd_t * lrmd, int timeout /*ms */ )
         crm_warn("Pacemaker Remote connection to %s:%s failed: %s "
                  CRM_XS " rc=%d",
                  native->server, native->port, pcmk_rc_str(rc), rc);
-        return -1;
+        return pcmk_rc2legacy(rc);
     }
     native->async_timer = timer_id;
     return pcmk_ok;

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -232,21 +232,25 @@ lrmd_copy_event(lrmd_event_data_t * event)
     return copy;
 }
 
+/*!
+ * \brief Free an executor event
+ *
+ * \param[in]  Executor event object to free
+ */
 void
-lrmd_free_event(lrmd_event_data_t * event)
+lrmd_free_event(lrmd_event_data_t *event)
 {
-    if (!event) {
+    if (event == NULL) {
         return;
     }
-
-    /* free gives me grief if i try to cast */
-    free((char *)event->rsc_id);
-    free((char *)event->op_type);
-    free((char *)event->user_data);
-    free((char *)event->output);
-    free((char *)event->exit_reason);
-    free((char *)event->remote_nodename);
-    if (event->params) {
+    // @TODO Why are these const char *?
+    free((void *) event->rsc_id);
+    free((void *) event->op_type);
+    free((void *) event->user_data);
+    free((void *) event->output);
+    free((void *) event->exit_reason);
+    free((void *) event->remote_nodename);
+    if (event->params != NULL) {
         g_hash_table_destroy(event->params);
     }
     free(event);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -600,8 +600,8 @@ lrmd_tls_connection_destroy(gpointer userdata)
 
 // \return Standard Pacemaker return code
 int
-lrmd_tls_send_msg(pcmk__remote_t *session, xmlNode *msg, uint32_t id,
-                  const char *msg_type)
+lrmd__remote_send_xml(pcmk__remote_t *session, xmlNode *msg, uint32_t id,
+                      const char *msg_type)
 {
     crm_xml_add_int(msg, F_LRMD_REMOTE_MSG_ID, id);
     crm_xml_add(msg, F_LRMD_REMOTE_MSG_TYPE, msg_type);
@@ -708,7 +708,8 @@ lrmd_tls_send(lrmd_t * lrmd, xmlNode * msg)
         global_remote_msg_id = 1;
     }
 
-    rc = lrmd_tls_send_msg(native->remote, msg, global_remote_msg_id, "request");
+    rc = lrmd__remote_send_xml(native->remote, msg, global_remote_msg_id,
+                               "request");
     if (rc != pcmk_rc_ok) {
         crm_err("Disconnecting because TLS message could not be sent to "
                 "Pacemaker Remote: %s", pcmk_rc_str(rc));

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1990,21 +1990,20 @@ lrmd_api_list_agents(lrmd_t * lrmd, lrmd_list_t ** resources, const char *class,
     return rc;
 }
 
-static int
+static bool
 does_provider_have_agent(const char *agent, const char *provider, const char *class)
 {
-    int found = 0;
+    bool found = false;
     GList *agents = NULL;
     GList *gIter2 = NULL;
 
     agents = resources_list_agents(class, provider);
     for (gIter2 = agents; gIter2 != NULL; gIter2 = gIter2->next) {
         if (pcmk__str_eq(agent, gIter2->data, pcmk__str_casei)) {
-            found = 1;
+            found = true;
         }
     }
     g_list_free_full(agents, free);
-
     return found;
 }
 


### PR DESCRIPTION
This is a spin-off of a project to improve failure messages in status displays. While working on that, I found that liblrmd could return values that would be misinterpreted, leading to nonsensical log messages. This PR cleans up the return codes from all the functions in lrmd_client.c, and improves comments and log messages.

This is a bit questionable for 2.1 since it has a lot of refactoring, but the incorrect codes/messages could be considered bugs, and I'd like to fix them for 2.1.0.