### PR TITLE
Log: pcmk__pid_active: Lower the log level when readlink() is EACCES

### DIFF
--- a/lib/common/pid.c
+++ b/lib/common/pid.c
@@ -73,8 +73,13 @@ pcmk__pid_active(pid_t pid, const char *daemon)
         rc = readlink(proc_path, exe_path, sizeof(exe_path) - 1);
         if (rc < 0) {
             if (last_asked_pid != pid) {
-                crm_err("Could not read from %s: %s " CRM_XS " errno=%d",
-                        proc_path, strerror(errno), errno);
+                if (errno == EACCES) {
+                    crm_info("Could not read from %s: %s " CRM_XS " errno=%d",
+                             proc_path, strerror(errno), errno);
+                } else {
+                    crm_err("Could not read from %s: %s " CRM_XS " errno=%d",
+                            proc_path, strerror(errno), errno);
+                }
                 last_asked_pid = pid;
             }
             if ((errno == EACCES) && checked_through_kill) {


### PR DESCRIPTION
In an environment where SBD is enabled, the following **error** message is always output at the time of DC election.
It is not a problem that readlink() of pacemaker-controld (non-root) fails because it targets sbd (root),
but the log level should be lowered to **info** because it will confuse users.
```
# grep grep pacemaker-controld /var/log/pacemaker/pacemaker.log
 :
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (crm_timer_popped)        info: Election Trigger just popped | input=I_DC_TIMEOUT time=20000ms
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (do_log)  warning: Input I_DC_TIMEOUT received in state S_PENDING from crm_timer_popped
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (do_state_transition)     info: State transition S_PENDING -> S_ELECTION | input=I_DC_TIMEOUT cause=C_TIMER_POPPED origin=crm_timer_popped
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (election_check)  info: election-DC won by local node
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (do_log)  info: Input I_ELECTION_DC received in state S_ELECTION from election_win_cb
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (do_state_transition)     notice: State transition S_ELECTION -> S_INTEGRATION | input=I_ELECTION_DC cause=C_FSA_INTERNAL origin=election_win_cb
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (do_te_control)   info: Registering TE UUID: fd11c4d6-a106-4333-8d7d-1cb6934f76f8
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (set_graph_functions)     info: Setting custom graph functions

May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (pcmk__pid_active)        error: Could not read from /proc/755896/exe: Permission denied | errno=13

May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (do_dc_takeover)  info: Taking over DC status for this partition
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (join_make_offer)         info: Making join-1 offers based on membership event 80189
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (join_make_offer)         info: Sending join-1 offer to rhel83-1
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (join_make_offer)         info: Sending join-1 offer to rhel83-2
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (do_dc_join_offer_all)    info: Waiting on join-1 requests from 2 outstanding nodes
May 12 18:30:07 rhel83-1 pacemaker-controld  [756142] (update_dc)       info: Set DC to rhel83-1 (3.10.0)
 :
#
# ps -ef | grep -e pacemaker -e sbd
root      755896       1  0 18:27 ?        00:00:00 sbd: inquisitor
root      755898  755896  0 18:27 ?        00:00:00 sbd: watcher: /dev/vdb5 - slot: 1 - uuid: 79bf5a1b-8010-4cc5-ae1d-15cf84ea85ad
root      755899  755896  0 18:27 ?        00:00:00 sbd: watcher: Pacemaker
root      755900  755896  0 18:27 ?        00:00:00 sbd: watcher: Cluster
root      756136       1  0 18:29 ?        00:00:00 /usr/sbin/pacemakerd -f
haclust+  756137  756136  0 18:29 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-based
root      756138  756136  0 18:29 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-fenced
root      756139  756136  0 18:29 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-execd
haclust+  756140  756136  0 18:29 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-attrd
haclust+  756141  756136  0 18:29 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-schedulerd
haclust+  756142  756136  0 18:29 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-controld
#
```