### PR TITLE
Feature: daemons: Convert pacemakerd to formatted output.

### DIFF
--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -296,8 +296,11 @@ main(int argc, char **argv)
 
     pcmk__set_env_option("mcp", "true");
 
-    pcmk__cli_init_logging("pacemakerd", args->verbosity);
-    crm_log_init(NULL, LOG_INFO, TRUE, FALSE, argc, argv, FALSE);
+    if (options.shutdown) {
+        pcmk__cli_init_logging("pacemakerd", args->verbosity);
+    } else {
+        crm_log_init(NULL, LOG_INFO, TRUE, FALSE, argc, argv, FALSE);
+    }
 
     crm_debug("Checking for existing Pacemaker instance");
 

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -66,7 +66,7 @@ extern "C" {
  * >=3.0.13: Fail counts include operation name and interval
  * >=3.2.0:  DC supports PCMK_LRM_OP_INVALID and PCMK_LRM_OP_NOT_CONNECTED
  */
-#  define CRM_FEATURE_SET		"3.10.0"
+#  define CRM_FEATURE_SET		"3.10.1"
 
 /* Pacemaker's CPG protocols use fixed-width binary fields for the sender and
  * recipient of a CPG message. This imposes an arbitrary limit on cluster node

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -56,6 +56,7 @@ API_request_base	= command-output	\
 			  crm_simulate		\
 			  crmadmin		\
 			  digests		\
+			  pacemakerd 		\
 			  stonith_admin		\
 			  version
 

--- a/xml/api/pacemakerd-2.10.rng
+++ b/xml/api/pacemakerd-2.10.rng
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-pacemakerd"/>
+    </start>
+
+    <define name="element-pacemakerd">
+        <element name="pacemakerd">
+            <attribute name="version"> <text /> </attribute>
+            <attribute name="build"> <text /> </attribute>
+            <attribute name="feature_set"> <text /> </attribute>
+
+            <optional>
+                <ref name="feature-list" />
+            </optional>
+        </element>
+    </define>
+
+    <define name="feature-list">
+        <element name="features">
+            <oneOrMore>
+                <element name="feature"> <text/> </element>
+            </oneOrMore>
+        </element>
+    </define>
+</grammar>


### PR DESCRIPTION
The main purpose of this is to finish getting pacemakerd moved off the
existing command line handling code (pcmk__cli_help in particular) so
that code can eventually be deprecated or removed.  pacemakerd itself
does fairly little printing.