### PR TITLE
Support newer OS/software versions

### DIFF
--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -12,6 +12,7 @@ import sys
 import subprocess
 import shlex
 import shutil
+import tempfile
 import time
 
 # Where to find test binaries
@@ -138,17 +139,19 @@ class OutputFoundError(TestError):
 class Test(object):
     """ Executor for a single pacemaker-execd regression test """
 
-    def __init__(self, name, description, verbose=0, tls=0, timeout=2, force_wait=0):
+    def __init__(self, name, description, verbose=0, tls=0, timeout=2,
+                 force_wait=0, logdir="/tmp"):
+
         self.name = name
         self.description = description
         self.cmds = []
-        self.logpath = "/tmp/pacemaker-execd-regression.log"
 
         if tls:
             self.daemon_location = "pacemaker-remoted"
         else:
             self.daemon_location = "pacemaker-execd"
 
+        self.logpath = os.path.join(logdir, self.daemon_location + ".log")
         self.test_tool_location = "cts-exec-helper"
         self.verbose = verbose
         self.tls = tls
@@ -248,7 +251,6 @@ class Test(object):
                 logfile = io.open(self.logpath, 'rt', errors='replace')
                 for line in logfile:
                     print(line.strip().encode('utf-8', 'replace'))
-            os.remove(self.logpath)
 
         if self.stonith_process:
             self.stonith_process.terminate()
@@ -385,12 +387,15 @@ class Test(object):
 class Tests(object):
     """ Collection of all pacemaker-execd regression tests """
 
-    def __init__(self, verbose=0, tls=0, timeout=2, force_wait=0):
+    def __init__(self, verbose=0, tls=0, timeout=2, force_wait=0,
+                 logdir="/tmp"):
+
         self.tests = []
         self.verbose = verbose
         self.tls = tls
         self.timeout = timeout
         self.force_wait = force_wait
+        self.logdir = logdir
         self.rsc_classes = output_from_command("crm_resource --list-standards")
         self.rsc_classes = self.rsc_classes[:-1] # Strip trailing empty line
         self.installed_files = []
@@ -496,7 +501,8 @@ class Tests(object):
     def new_test(self, name, description):
         """ Create a named test """
 
-        test = Test(name, description, self.verbose, self.tls, self.timeout, self.force_wait)
+        test = Test(name, description, self.verbose, self.tls, self.timeout,
+                    self.force_wait, self.logdir)
         self.tests.append(test)
         return test
 
@@ -1219,35 +1225,39 @@ def main(argv):
     opts = TestOptions()
     opts.build_options(argv)
 
-    tests = Tests(opts.options['verbose'], opts.options['pacemaker-remote'],
-                  opts.options['timeout'], opts.options['force-wait'])
+    # Create a temporary directory for log files (the directory will
+    # automatically be erased when done)
+    with tempfile.TemporaryDirectory(prefix="cts-exec-") as logdir:
+        tests = Tests(opts.options['verbose'], opts.options['pacemaker-remote'],
+                      opts.options['timeout'], opts.options['force-wait'],
+                      logdir)
 
-    tests.build_generic_tests()
-    tests.build_multi_rsc_tests()
-    tests.build_negative_tests()
-    tests.build_custom_tests()
-    tests.build_stress_tests()
+        tests.build_generic_tests()
+        tests.build_multi_rsc_tests()
+        tests.build_negative_tests()
+        tests.build_custom_tests()
+        tests.build_stress_tests()
 
-    tests.setup_test_environment()
+        tests.setup_test_environment()
 
-    print("Starting ...")
+        print("Starting ...")
 
-    if opts.options['list-tests']:
-        tests.print_list()
-    elif opts.options['show-usage']:
-        opts.show_usage()
-    elif opts.options['run-only-pattern'] != "":
-        tests.run_tests_matching(opts.options['run-only-pattern'])
-        tests.print_results()
-    elif opts.options['run-only'] != "":
-        tests.run_single(opts.options['run-only'])
-        tests.print_results()
-    else:
-        tests.run_tests()
-        tests.print_results()
+        if opts.options['list-tests']:
+            tests.print_list()
+        elif opts.options['show-usage']:
+            opts.show_usage()
+        elif opts.options['run-only-pattern'] != "":
+            tests.run_tests_matching(opts.options['run-only-pattern'])
+            tests.print_results()
+        elif opts.options['run-only'] != "":
+            tests.run_single(opts.options['run-only'])
+            tests.print_results()
+        else:
+            tests.run_tests()
+            tests.print_results()
 
-    tests.cleanup_test_environment()
-    tests.exit()
+        tests.cleanup_test_environment()
+        tests.exit()
 
 
 if __name__ == "__main__":

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -2,7 +2,7 @@
 """ Regression tests for Pacemaker's fencer
 """
 
-__copyright__ = "Copyright 2012-2020 the Pacemaker project contributors"
+__copyright__ = "Copyright 2012-2021 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import io
@@ -212,14 +212,15 @@ class XmlValidationError(TestError):
 class Test(object):
     """ Executor for a single test """
 
-    def __init__(self, name, description, verbose=0, with_cpg=0, timeout=2, force_wait=0):
+    def __init__(self, name, description, verbose=0, with_cpg=0, timeout=2,
+                 force_wait=0, logdir="/tmp"):
         self.name = name
         self.description = description
         self.cmds = []
         self.verbose = verbose
         self.timeout = timeout
         self.force_wait = force_wait
-        self.logpath = "/tmp/stonith-regression.log"
+        self.logpath = os.path.join(logdir, "pacemaker-fenced.log")
 
         self.result_txt = ""
         self.cmd_tool_output = ""
@@ -335,7 +336,6 @@ class Test(object):
             print("Daemon Output Start")
             print(self.stonith_output)
             print("Daemon Output End")
-        os.remove(self.logpath)
 
     def add_stonith_log_pattern(self, pattern):
         """ Add a log pattern to expect from this test """
@@ -526,17 +526,19 @@ class Test(object):
 class Tests(object):
     """ Collection of all fencing regression tests """
 
-    def __init__(self, verbose=0, timeout=2, force_wait=0):
+    def __init__(self, verbose=0, timeout=2, force_wait=0, logdir="/tmp"):
         self.tests = []
         self.verbose = verbose
         self.timeout = timeout
         self.force_wait = force_wait
+        self.logdir = logdir
         self.autogen_corosync_cfg = not os.path.exists("/etc/corosync/corosync.conf")
 
     def new_test(self, name, description, with_cpg=0):
         """ Create a named test """
 
-        test = Test(name, description, self.verbose, with_cpg, self.timeout, self.force_wait)
+        test = Test(name, description, self.verbose, with_cpg, self.timeout,
+                    self.force_wait, self.logdir)
         self.tests.append(test)
         return test
 
@@ -1426,11 +1428,9 @@ class Tests(object):
 
         if use_corosync:
             if self.autogen_corosync_cfg:
-                (handle, self.autogen_corosync_log) = tempfile.mkstemp(prefix="cts-fencing-",
-                                                                       suffix=".corosync.log")
-                os.close(handle)
+                logname = os.path.join(self.logdir, "corosync.log")
                 corosync_cfg = io.open("/etc/corosync/corosync.conf", "w")
-                corosync_cfg.write(AUTOGEN_COROSYNC_TEMPLATE % (localname(), self.autogen_corosync_log))
+                corosync_cfg.write(AUTOGEN_COROSYNC_TEMPLATE % (localname(), logname))
                 corosync_cfg.close()
 
             ### make sure we are in control ###
@@ -1448,11 +1448,10 @@ class Tests(object):
             if self.autogen_corosync_cfg:
                 if self.verbose:
                     print("Corosync output")
-                    logfile = io.open(self.autogen_corosync_log, 'rt')
+                    logfile = io.open(os.path.join(self.logdir, "corosync.log"), 'rt')
                     for line in logfile.readlines():
                         print(line.strip())
                     logfile.close()
-                os.remove(self.autogen_corosync_log)
                 os.remove("/etc/corosync/corosync.conf")
 
         subprocess.call(["cts-support", "uninstall"])
@@ -1538,49 +1537,52 @@ def main(argv):
 
     use_corosync = 1
 
-    tests = Tests(opts.options['verbose'], opts.options['timeout'],
-                  opts.options['force-wait'])
-    tests.build_standalone_tests()
-    tests.build_custom_timeout_tests()
-    tests.build_api_sanity_tests()
-    tests.build_fence_merge_tests()
-    tests.build_fence_no_merge_tests()
-    tests.build_unfence_tests()
-    tests.build_unfence_on_target_tests()
-    tests.build_nodeid_tests()
-    tests.build_remap_tests()
+    # Create a temporary directory for log files (the directory and its
+    # contents will automatically be erased when done)
+    with tempfile.TemporaryDirectory(prefix="cts-fencing-") as logdir:
+        tests = Tests(opts.options['verbose'], opts.options['timeout'],
+                      opts.options['force-wait'], logdir)
+        tests.build_standalone_tests()
+        tests.build_custom_timeout_tests()
+        tests.build_api_sanity_tests()
+        tests.build_fence_merge_tests()
+        tests.build_fence_no_merge_tests()
+        tests.build_unfence_tests()
+        tests.build_unfence_on_target_tests()
+        tests.build_nodeid_tests()
+        tests.build_remap_tests()
 
-    if opts.options['list-tests']:
-        tests.print_list()
-        sys.exit(CrmExit.OK)
-    elif opts.options['show-usage']:
-        opts.show_usage()
-        sys.exit(CrmExit.OK)
+        if opts.options['list-tests']:
+            tests.print_list()
+            sys.exit(CrmExit.OK)
+        elif opts.options['show-usage']:
+            opts.show_usage()
+            sys.exit(CrmExit.OK)
 
-    print("Starting ...")
+        print("Starting ...")
 
-    if opts.options['no-cpg']:
-        use_corosync = 0
+        if opts.options['no-cpg']:
+            use_corosync = 0
 
-    tests.setup_environment(use_corosync)
+        tests.setup_environment(use_corosync)
 
-    if opts.options['run-only-pattern'] != "":
-        tests.run_tests_matching(opts.options['run-only-pattern'])
-        tests.print_results()
-    elif opts.options['run-only'] != "":
-        tests.run_single(opts.options['run-only'])
-        tests.print_results()
-    elif opts.options['no-cpg']:
-        tests.run_no_cpg()
-        tests.print_results()
-    elif opts.options['cpg-only']:
-        tests.run_cpg_only()
-        tests.print_results()
-    else:
-        tests.run_tests()
-        tests.print_results()
+        if opts.options['run-only-pattern'] != "":
+            tests.run_tests_matching(opts.options['run-only-pattern'])
+            tests.print_results()
+        elif opts.options['run-only'] != "":
+            tests.run_single(opts.options['run-only'])
+            tests.print_results()
+        elif opts.options['no-cpg']:
+            tests.run_no_cpg()
+            tests.print_results()
+        elif opts.options['cpg-only']:
+            tests.run_cpg_only()
+            tests.print_results()
+        else:
+            tests.run_tests()
+            tests.print_results()
 
-    tests.cleanup_environment(use_corosync)
+        tests.cleanup_environment(use_corosync)
     tests.exit()
 
 

--- a/cts/lab/watcher.py
+++ b/cts/lab/watcher.py
@@ -299,7 +299,7 @@ class LogWatcher(RemoteExec):
 
         for t in pending:
             t.join(60.0)
-            if t.isAlive():
+            if t.is_alive():
                 self.logger.log("%s: Aborting after 20s waiting for %s logging commands" % (self.name, repr(t)))
                 return
 

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -440,7 +440,17 @@ main(int argc, char **argv, char **envp)
 
         switch (flag) {
             case 'l':
-                pcmk__add_logfile(optarg);
+                {
+                    int rc = pcmk__add_logfile(optarg);
+
+                    if (rc != pcmk_rc_ok) {
+                        /* Logging has not yet been initialized, so stderr is
+                         * the only way to get information out
+                         */
+                        fprintf(stderr, "Logging to %s is disabled: %s\n",
+                                optarg, pcmk_rc_str(rc));
+                    }
+                }
                 break;
             case 'p':
                 setenv("PCMK_remote_port", optarg, 1);

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -440,7 +440,7 @@ main(int argc, char **argv, char **envp)
 
         switch (flag) {
             case 'l':
-                crm_add_logfile(optarg);
+                pcmk__add_logfile(optarg);
                 break;
             case 'p':
                 setenv("PCMK_remote_port", optarg, 1);

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -1349,7 +1349,7 @@ main(int argc, char **argv)
                 crm_bump_log_level(argc, argv);
                 break;
             case 'l':
-                crm_add_logfile(optarg);
+                pcmk__add_logfile(optarg);
                 break;
             case 's':
                 stand_alone = TRUE;

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -1349,7 +1349,17 @@ main(int argc, char **argv)
                 crm_bump_log_level(argc, argv);
                 break;
             case 'l':
-                pcmk__add_logfile(optarg);
+                {
+                    int rc = pcmk__add_logfile(optarg);
+
+                    if (rc != pcmk_rc_ok) {
+                        /* Logging has not yet been initialized, so stderr is
+                         * the only way to get information out
+                         */
+                        fprintf(stderr, "Logging to %s is disabled: %s\n",
+                                optarg, pcmk_rc_str(rc));
+                    }
+                }
                 break;
             case 's':
                 stand_alone = TRUE;

--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -25,7 +25,7 @@
 gboolean mcp_read_config(void);
 
 gboolean cluster_connect_cfg(void);
-gboolean cluster_disconnect_cfg(void);
+void cluster_disconnect_cfg(void);
 void pcmkd_shutdown_corosync(void);
 
 void pcmk_shutdown(int nsig);

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -90,7 +90,7 @@ cfg_connection_destroy(gpointer user_data)
     mainloop_timer_start(reconnect_timer);
 }
 
-gboolean
+void
 cluster_disconnect_cfg(void)
 {
     if (cfg_handle) {
@@ -107,8 +107,6 @@ cluster_disconnect_cfg(void)
         mainloop_timer_del(reconnect_timer);
         reconnect_timer = NULL;
     }
-    pcmk_shutdown(SIGTERM);
-    return TRUE;
 }
 
 #define cs_repeat(counter, max, code) do {		\

--- a/include/crm/common/logging.h
+++ b/include/crm/common/logging.h
@@ -117,8 +117,6 @@ void crm_log_output_fn(const char *file, const char *function, int line, int lev
 #define crm_log_output(level, prefix, output)   \
     crm_log_output_fn(__FILE__, __func__, __LINE__, level, prefix, output)
 
-gboolean crm_add_logfile(const char *filename);
-
 void crm_bump_log_level(int argc, char **argv);
 
 void crm_enable_stderr(int enable);

--- a/include/crm/common/logging_compat.h
+++ b/include/crm/common/logging_compat.h
@@ -48,6 +48,9 @@ extern "C" {
 //! \deprecated Do not use Pacemaker for general-purpose logging
 gboolean crm_log_cli_init(const char *entity);
 
+//! \deprecated Do not use Pacemaker for general-purpose logging
+gboolean crm_add_logfile(const char *filename);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/logging_internal.h
+++ b/include/crm/common/logging_internal.h
@@ -75,6 +75,8 @@ extern "C" {
  */
 void pcmk__cli_init_logging(const char *name, unsigned int verbosity);
 
+int pcmk__add_logfile(const char *filename);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -177,10 +177,135 @@ set_format_string(int method, const char *daemon)
 
 #define DEFAULT_LOG_FILE CRM_LOG_DIR "/pacemaker.log"
 
+static bool
+logfile_disabled(const char *filename)
+{
+    return pcmk__str_eq(filename, "none", pcmk__str_casei|pcmk__str_null_matches)
+           || pcmk__str_eq(filename, "/dev/null", pcmk__str_none);
+}
+
+/*!
+ * \internal
+ * \brief Fix log file ownership if group is wrong or doesn't have access
+ *
+ * \param[in] filename  Log file name (for logging only)
+ * \param[in] logfd     Log file descriptor
+ *
+ * \return Standard Pacemaker return code
+ */
+static int
+chown_logfile(const char *filename, int logfd)
+{
+    uid_t pcmk_uid = 0;
+    gid_t pcmk_gid = 0;
+    struct stat st;
+
+    // Get the log file's current ownership and permissions
+    if (fstat(logfd, &st) < 0) {
+        return errno;
+    }
+
+    // Any other errors don't prevent file from being used as log
+
+    if (pcmk_daemon_user(&pcmk_uid, &pcmk_gid) != pcmk_ok) {
+        return pcmk_rc_ok;
+    }
+    if ((st.st_gid == pcmk_gid)
+        && ((st.st_mode & S_IRWXG) == (S_IRGRP|S_IWGRP))) {
+        return pcmk_rc_ok;
+    }
+    if (fchown(logfd, pcmk_uid, pcmk_gid) < 0) {
+        crm_warn("Couldn't change '%s' ownership to user %s gid %d: %s",
+             filename, CRM_DAEMON_USER, pcmk_gid, strerror(errno));
+    }
+    return pcmk_rc_ok;
+}
+
+// Reset log file permissions (using environment variable if set)
+static void
+chmod_logfile(const char *filename, int logfd)
+{
+    const char *modestr = getenv("PCMK_logfile_mode");
+    mode_t filemode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
+
+    if (modestr != NULL) {
+        long filemode_l = strtol(modestr, NULL, 8);
+
+        if ((filemode_l != LONG_MIN) && (filemode_l != LONG_MAX)) {
+            filemode = (mode_t) filemode_l;
+        }
+    }
+    if ((filemode != 0) && (fchmod(logfd, filemode) < 0)) {
+        crm_warn("Couldn't change '%s' mode to %04o: %s",
+                 filename, filemode, strerror(errno));
+    }
+}
+
+// If we're root, correct a log file's permissions if needed
+static int
+set_logfile_permissions(const char *filename, FILE *logfile)
+{
+    if (geteuid() == 0) {
+        int logfd = fileno(logfile);
+        int rc = chown_logfile(filename, logfd);
+
+        if (rc != pcmk_rc_ok) {
+            return rc;
+        }
+        chmod_logfile(filename, logfd);
+    }
+    return pcmk_rc_ok;
+}
+
+// Enable libqb logging to a new log file
+static void
+enable_logfile(int fd)
+{
+    qb_log_ctl(fd, QB_LOG_CONF_ENABLED, QB_TRUE);
+#if 0
+    qb_log_ctl(fd, QB_LOG_CONF_FILE_SYNC, 1); // Turn on synchronous writes
+#endif
+
+#ifdef HAVE_qb_log_conf_QB_LOG_CONF_MAX_LINE_LEN
+    // Longer than default, for logging long XML lines
+    qb_log_ctl(fd, QB_LOG_CONF_MAX_LINE_LEN, 800);
+#endif
+
+    crm_update_callsites();
+}
+
+static inline void
+disable_logfile(int fd)
+{
+    qb_log_ctl(fd, QB_LOG_CONF_ENABLED, QB_FALSE);
+}
+
+static void
+setenv_logfile(const char *filename)
+{
+    // Some resource agents will log only if environment variable is set
+    if (pcmk__env_option("logfile") == NULL) {
+        pcmk__set_env_option("logfile", filename);
+    }
+}
+
+/*!
+ * \brief Add a file to be used as a Pacemaker detail log
+ *
+ * \param[in] filename  Name of log file to use
+ *
+ * \return TRUE if log could be used, FALSE otherwise
+ */
 gboolean
 crm_add_logfile(const char *filename)
 {
+    /* No log messages from this function will be logged to the new log!
+     * If another target such as syslog has already been added, the messages
+     * should show up there.
+     */
+
     int fd = 0;
+    int rc = pcmk_rc_ok;
     FILE *logfile = NULL;
     bool is_default = false;
 
@@ -193,22 +318,17 @@ crm_add_logfile(const char *filename)
     }
 
     // If the user doesn't want logging, we're done
-    if ((filename == NULL)
-        || pcmk__str_eq(filename, "none", pcmk__str_casei)
-        || pcmk__str_eq(filename, "/dev/null", pcmk__str_none)) {
+    if (logfile_disabled(filename)) {
         return FALSE;
     }
 
     // If the caller wants the default and we already have it, we're done
-    if (pcmk__str_eq(filename, DEFAULT_LOG_FILE, pcmk__str_none)) {
-        is_default = TRUE;
-    }
+    is_default = pcmk__str_eq(filename, DEFAULT_LOG_FILE, pcmk__str_none);
     if (is_default && (default_fd >= 0)) {
         return TRUE;
     }
 
     // Check whether we have write access to the file
-    errno = 0;
     logfile = fopen(filename, "a");
     if (logfile == NULL) {
         crm_warn("Logging to '%s' is disabled: %s " CRM_XS " uid=%u gid=%u",
@@ -216,46 +336,12 @@ crm_add_logfile(const char *filename)
         return FALSE;
     }
 
-    // If we're root, correct the file permissions if needed
-    if (geteuid() == 0) {
-        struct stat st;
-        uid_t pcmk_uid = 0;
-        gid_t pcmk_gid = 0;
-        int logfd = fileno(logfile);
-        const char *modestr;
-        mode_t filemode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
-
-        // Get the log file's current ownership and permissions
-        if (fstat(logfd, &st) < 0) {
-            crm_warn("Logging to '%s' is disabled: %s " CRM_XS " fstat",
-                     filename, strerror(errno));
-            fclose(logfile);
-            return FALSE;
-        }
-
-        // Fix ownership if group is wrong or doesn't have read/write access
-        if ((pcmk_daemon_user(&pcmk_uid, &pcmk_gid) == pcmk_ok)
-            && ((st.st_gid != pcmk_gid)
-                || ((st.st_mode & S_IRWXG) != (S_IRGRP|S_IWGRP)))) {
-            if (fchown(logfd, pcmk_uid, pcmk_gid) < 0) {
-                crm_warn("Couldn't change '%s' ownership to user %s gid %d: %s",
-                         filename, CRM_DAEMON_USER, pcmk_gid, strerror(errno));
-            }
-        }
-
-        // Reset the permissions (using environment variable if set)
-        modestr = getenv("PCMK_logfile_mode");
-        if (modestr) {
-            long filemode_l = strtol(modestr, NULL, 8);
-
-            if ((filemode_l != LONG_MIN) && (filemode_l != LONG_MAX)) {
-                filemode = (mode_t) filemode_l;
-            }
-        }
-        if ((filemode != 0) && (fchmod(logfd, filemode) < 0)) {
-            crm_warn("Couldn't change '%s' mode to %04o: %s",
-                     filename, filemode, strerror(errno));
-        }
+    rc = set_logfile_permissions(filename, logfile);
+    if (rc != pcmk_rc_ok) {
+        crm_warn("Logging to '%s' is disabled: %s " CRM_XS " permissions",
+                 filename, strerror(rc));
+        fclose(logfile);
+        return FALSE;
     }
 
     // Close and reopen as libqb logging target
@@ -269,33 +355,16 @@ crm_add_logfile(const char *filename)
 
     if (is_default) {
         default_fd = fd;
-
-        // Some resource agents will log only if environment variable is set
-        if (pcmk__env_option("logfile") == NULL) {
-            pcmk__set_env_option("logfile", filename);
-        }
+        setenv_logfile(filename);
 
     } else if (default_fd >= 0) {
         crm_notice("Switching logging to %s", filename);
-        qb_log_ctl(default_fd, QB_LOG_CONF_ENABLED, QB_FALSE);
+        disable_logfile(default_fd);
     }
 
-    // This message can show up in other targets (syslog, etc.)
     crm_notice("Additional logging available in %s", filename);
-
-    // Enable logging to the new log file
-    qb_log_ctl(fd, QB_LOG_CONF_ENABLED, QB_TRUE);
-    /* qb_log_ctl(fd, QB_LOG_CONF_FILE_SYNC, 1);  Turn on synchronous writes */
-
-#ifdef HAVE_qb_log_conf_QB_LOG_CONF_MAX_LINE_LEN
-    // Longer than default, for logging long XML lines
-    qb_log_ctl(fd, QB_LOG_CONF_MAX_LINE_LEN, 800);
-#endif
-
-    /* Enable callsites */
-    crm_update_callsites();
+    enable_logfile(fd);
     have_logfile = true;
-
     return TRUE;
 }
 

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -199,6 +199,7 @@ chown_logfile(const char *filename, int logfd)
     uid_t pcmk_uid = 0;
     gid_t pcmk_gid = 0;
     struct stat st;
+    int rc;
 
     // Get the log file's current ownership and permissions
     if (fstat(logfd, &st) < 0) {
@@ -207,7 +208,11 @@ chown_logfile(const char *filename, int logfd)
 
     // Any other errors don't prevent file from being used as log
 
-    if (pcmk_daemon_user(&pcmk_uid, &pcmk_gid) != pcmk_ok) {
+    rc = pcmk_daemon_user(&pcmk_uid, &pcmk_gid);
+    if (rc != pcmk_ok) {
+        rc = pcmk_legacy2rc(rc);
+        crm_warn("Not changing '%s' ownership because user information "
+                 "unavailable: %s", filename, pcmk_rc_str(rc));
         return pcmk_rc_ok;
     }
     if ((st.st_gid == pcmk_gid)

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -171,7 +171,7 @@ pcmk_daemon_user(uid_t *uid, gid_t *gid)
     static uid_t daemon_uid;
     static gid_t daemon_gid;
     static bool found = false;
-    int rc = pcmk_err_generic;
+    int rc = pcmk_ok;
 
     if (!found) {
         rc = crm_user_lookup(CRM_DAEMON_USER, &daemon_uid, &daemon_gid);

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -19,6 +19,9 @@
 ## GitHub entity that distributes source (for ease of using a fork)
 %global github_owner ClusterLabs
 
+## Where bug reports should be submitted
+## Leave bug_url undefined to use ClusterLabs default, others define it here
+
 ## Upstream pacemaker version, and its package version (specversion
 ## can be incremented to build packages reliably considered "newer"
 ## than previously built packages with the same pcmkversion)
@@ -475,6 +478,7 @@ export LDFLAGS_HARDENED_LIB="%{?_hardening_ldflags}"
         %{?with_coverage:      --with-coverage}                                 \
         %{?with_cibsecrets:    --with-cibsecrets}                               \
         %{?gnutls_priorities:  --with-gnutls-priorities="%{gnutls_priorities}"} \
+        %{?bug_url:            --with-bug-url=%{bug_url}}                       \
         %{?concurrent_fencing}                                                  \
         %{?resource_stickiness}                                                 \
         %{?compat20}                                                            \

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -247,8 +247,8 @@ Requires:      %{python_path}
 BuildRequires: %{python_name}-devel
 
 # Pacemaker requires a minimum libqb functionality
-Requires:      libqb >= 0.13.0
-BuildRequires: libqb-devel >= 0.13.0
+Requires:      libqb >= 0.17.0
+BuildRequires: libqb-devel >= 0.17.0
 
 # Basics required for the build (even if usually satisfied through other BRs)
 BuildRequires: coreutils findutils grep sed

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -50,9 +50,13 @@
 ## Add option to create binaries with coverage analysis
 %bcond_with coverage
 
-## Add option to skip generating documentation
+## Add option to skip (or enable, on RHEL) generating documentation
 ## (the build tools aren't available everywhere)
+%if 0%{?rhel}
+%bcond_with doc
+%else
 %bcond_without doc
+%endif
 
 ## Add option to prefix package version with "0."
 ## (so later "official" packages will be considered updates)
@@ -64,9 +68,12 @@
 ## Add option to turn off hardening of libraries and daemon executables
 %bcond_without hardening
 
-## Add option to enable links for legacy daemon names
+## Add option to enable (or disable, on RHEL 8) links for legacy daemon names
+%if 0%{?rhel} && 0%{?rhel} <= 8
+%bcond_without legacy_links
+%else
 %bcond_with legacy_links
-
+%endif
 
 # Define globals for convenient use later
 
@@ -156,7 +163,7 @@
 ## Distro-specific configuration choices
 
 ### Use 2.0-style output when other distro packages don't support current output
-%if ( 0%{?fedora} && 0%{?fedora} <= 34 ) || ( 0%{?rhel} && 0%{?rhel} <= 8 )
+%if 0%{?fedora} || ( 0%{?rhel} && 0%{?rhel} <= 8 )
 %global compat20 --enable-compat-2.0
 %endif
 

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -30,6 +30,7 @@
 
 ## Upstream commit (full commit ID, abbreviated commit ID, or tag) to build
 %global commit HEAD
+
 ## Since git v2.11, the extent of abbreviation is autoscaled by default
 ## (used to be constant of 7), so we need to convey it for non-tags, too.
 %global commit_abbrev 7
@@ -259,11 +260,12 @@ BuildRequires: %{python_name}-devel
 Requires:      libqb >= 0.17.0
 BuildRequires: libqb-devel >= 0.17.0
 
-# Basics required for the build (even if usually satisfied through other BRs)
+# Required basic build tools
 BuildRequires: coreutils findutils grep sed
+BuildRequires: autoconf automake gcc make pkgconfig
+BuildRequires: libtool %{?pkgname_libtool_devel}
 
 # Required for core functionality
-BuildRequires: automake autoconf gcc libtool pkgconfig %{?pkgname_libtool_devel}
 BuildRequires: pkgconfig(glib-2.0) >= 2.42
 BuildRequires: libxml2-devel libxslt-devel libuuid-devel
 BuildRequires: %{pkgname_bzip2_devel}
@@ -284,7 +286,7 @@ BuildRequires: %{pkgname_glue_libs}-devel
 %endif
 
 %if %{with doc}
-BuildRequires: inkscape asciidoc %{python_name}-sphinx
+BuildRequires: asciidoc inkscape %{python_name}-sphinx
 %endif
 
 Provides:      pcmk-cluster-manager = %{version}-%{release}
@@ -308,8 +310,8 @@ when related resources fail and can be configured to periodically check
 resource health.
 
 Available rpmbuild rebuild options:
-  --with(out) : cibsecrets coverage doc stonithd hardening pre_release
-                profiling upstart_job
+  --with(out) : cibsecrets coverage doc hardening pre_release profiling stonithd
+                upstart_job
 
 %package cli
 License:       GPLv2+ and LGPLv2+
@@ -368,7 +370,7 @@ License:       GPLv2+ and LGPLv2+
 # initscript is Revised BSD
 License:       GPLv2+ and LGPLv2+ and BSD
 %endif
-Summary:       Pacemaker remote daemon for non-cluster nodes
+Summary:       Pacemaker remote executor daemon for non-cluster nodes
 Requires:      %{pkgname_pcmk_libs}%{?_isa} = %{version}-%{release}
 Requires:      %{name}-cli = %{version}-%{release}
 Requires:      resource-agents
@@ -393,7 +395,7 @@ License:       GPLv2+ and LGPLv2+
 Summary:       Pacemaker development package
 Requires:      %{pkgname_pcmk_libs}%{?_isa} = %{version}-%{release}
 Requires:      %{name}-cluster-libs%{?_isa} = %{version}-%{release}
-Requires:      libuuid-devel%{?_isa} %{?pkgname_libtool_devel_arch}
+Requires:      %{?pkgname_libtool_devel_arch} libuuid-devel%{?_isa}
 Requires:      libxml2-devel%{?_isa} libxslt-devel%{?_isa}
 Requires:      %{pkgname_bzip2_devel}%{?_isa} glib2-devel%{?_isa}
 Requires:      libqb-devel%{?_isa}

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -225,7 +225,6 @@ License:       GPLv2+ and LGPLv2+
 License:       GPLv2+ and LGPLv2+ and BSD
 %endif
 Url:           https://www.clusterlabs.org/
-Group:         System Environment/Daemons
 
 # Example: https://codeload.github.com/ClusterLabs/pacemaker/tar.gz/e91769e
 # will download pacemaker-e91769e.tar.gz
@@ -308,7 +307,6 @@ Available rpmbuild rebuild options:
 %package cli
 License:       GPLv2+ and LGPLv2+
 Summary:       Command line tools for controlling Pacemaker clusters
-Group:         System Environment/Daemons
 Requires:      %{pkgname_pcmk_libs}%{?_isa} = %{version}-%{release}
 %if 0%{?supports_recommends}
 Recommends:    pcmk-cluster-manager = %{version}-%{release}
@@ -332,7 +330,6 @@ be part of the cluster.
 %package -n %{pkgname_pcmk_libs}
 License:       GPLv2+ and LGPLv2+
 Summary:       Core Pacemaker libraries
-Group:         System Environment/Daemons
 Requires(pre): %{pkgname_shadow_utils}
 Requires:      %{name}-schemas = %{version}-%{release}
 # sbd 1.4.0+ supports the libpe_status API for pe_working_set_t
@@ -348,7 +345,6 @@ nodes and those just running the CLI tools.
 %package cluster-libs
 License:       GPLv2+ and LGPLv2+
 Summary:       Cluster Libraries used by Pacemaker
-Group:         System Environment/Daemons
 Requires:      %{pkgname_pcmk_libs}%{?_isa} = %{version}-%{release}
 
 %description cluster-libs
@@ -366,7 +362,6 @@ License:       GPLv2+ and LGPLv2+
 License:       GPLv2+ and LGPLv2+ and BSD
 %endif
 Summary:       Pacemaker remote daemon for non-cluster nodes
-Group:         System Environment/Daemons
 Requires:      %{pkgname_pcmk_libs}%{?_isa} = %{version}-%{release}
 Requires:      %{name}-cli = %{version}-%{release}
 Requires:      resource-agents
@@ -389,7 +384,6 @@ nodes not running the full corosync/cluster stack.
 %package -n %{pkgname_pcmk_libs}-devel
 License:       GPLv2+ and LGPLv2+
 Summary:       Pacemaker development package
-Group:         Development/Libraries
 Requires:      %{pkgname_pcmk_libs}%{?_isa} = %{version}-%{release}
 Requires:      %{name}-cluster-libs%{?_isa} = %{version}-%{release}
 Requires:      libuuid-devel%{?_isa} %{?pkgname_libtool_devel_arch}
@@ -408,7 +402,6 @@ for developing tools for Pacemaker.
 %package       cts
 License:       GPLv2+ and LGPLv2+
 Summary:       Test framework for cluster-related technologies like Pacemaker
-Group:         System Environment/Daemons
 Requires:      %{python_path}
 Requires:      %{pkgname_pcmk_libs} = %{version}-%{release}
 Requires:      %{name}-cli = %{version}-%{release}
@@ -429,7 +422,6 @@ Test framework for cluster-related technologies like Pacemaker
 %package       doc
 License:       CC-BY-SA-4.0
 Summary:       Documentation for Pacemaker
-Group:         Documentation
 BuildArch:     noarch
 
 %description   doc


### PR DESCRIPTION
This addresses issues found when trying to build and run 2.1.0-rc1 on RHEL 9 beta hosts, which have newer versions of software (e.g. Python 3.9), Linux kernel (e.g. having "protected_regular" enabled), etc.