### PR TITLE
Preparation for 2.1.0-rc2 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ script:
 - make check
 - ./cts/cts-cli -V
 - ./cts/cts-scheduler -V
-- sudo ./cts/cts-exec -V --force-wait
+- if [ "$TRAVIS_ARCH" != "ppc64le" ]; then sudo ./cts/cts-exec -V --force-wait; fi
 - test $MAINT_EXTRA -eq 0 ||
   { { echo 'looking for presence of control characters...';
       { git ls-files

--- a/configure.ac
+++ b/configure.ac
@@ -328,6 +328,21 @@ AC_DEFINE_UNQUOTED([PCMK__CONCURRENT_FENCING_DEFAULT],
                    ["$with_concurrent_fencing_default"],
                    [Default value for concurrent-fencing cluster option])
 
+AC_ARG_WITH([sbd-sync-default],
+    [AS_HELP_STRING([--with-sbd-sync-default], m4_normalize([
+        default value used by sbd if SBD_SYNC_RESOURCE_STARTUP
+        environment variable is not set @<:@false@:>@]))],
+)
+AS_CASE([$with_sbd_sync_default],
+        [""], [with_sbd_sync_default=false],
+        [false], [],
+        [true], [PCMK_FEATURES="$PCMK_FEATURES default-sbd-sync"],
+        [AC_MSG_ERROR([Invalid value "$with_sbd_sync_default" for --with-sbd-sync-default])]
+)
+AC_DEFINE_UNQUOTED([PCMK__SBD_SYNC_DEFAULT],
+                   [$with_sbd_sync_default],
+                   [Default value for SBD_SYNC_RESOURCE_STARTUP environment variable])
+
 AC_ARG_WITH([resource-stickiness-default],
     [AS_HELP_STRING([--with-resource-stickiness-default],
         [If positive, value to add to new CIBs as explicit resource default for resource-stickiness @<:@0@:>@])],

--- a/configure.ac
+++ b/configure.ac
@@ -226,8 +226,8 @@ dnl --enable-* options: compatibility
 
 AC_ARG_ENABLE([compat-2.0],
     [AS_HELP_STRING([--enable-compat-2.0], m4_normalize([
-	preserve certain output as it was in 2.0; this option will be
-	available only for the lifetime of the 2.1 series @<:@no@:>@]))]
+        preserve certain output as it was in 2.0; this option will be
+        available only for the lifetime of the 2.1 series @<:@no@:>@]))]
 )
 yes_no_try "$enable_compat_2_0" "no"
 enable_compat_2_0=$?
@@ -286,8 +286,8 @@ AC_ARG_WITH([daemon-group],
 BUG_URL=""
 AC_ARG_WITH([bug-url],
     [AS_HELP_STRING([--with-bug-url=DIR], m4_normalize([
-	address where users should submit bug reports
-	@<:@https://bugs.clusterlabs.org/enter_bug.cgi?product=Pacemaker@:>@]))],
+        address where users should submit bug reports
+        @<:@https://bugs.clusterlabs.org/enter_bug.cgi?product=Pacemaker@:>@]))],
     [ BUG_URL="$withval" ]
 )
 
@@ -319,7 +319,7 @@ AC_ARG_WITH([concurrent-fencing-default],
         [default value for concurrent-fencing cluster option @<:@false@:>@])],
 )
 AS_CASE([$with_concurrent_fencing_default],
-	[""], [with_concurrent_fencing_default="false"],
+        [""], [with_concurrent_fencing_default="false"],
         [false], [],
         [true], [PCMK_FEATURES="$PCMK_FEATURES default-concurrent-fencing"],
         [AC_MSG_ERROR([Invalid value "$with_concurrent_fencing_default" for --with-concurrent-fencing-default])]
@@ -448,12 +448,12 @@ AC_DEFINE_UNQUOTED([OCF_ROOT_DIR], ["$OCF_ROOT_DIR"],
                    [OCF root directory for resource agents and libraries])
 
 PKG_CHECK_VAR([OCF_RA_PATH], [resource-agents], [ocfrapath], [],
-	      [OCF_RA_PATH="$OCF_ROOT_DIR/resource.d"])
+              [OCF_RA_PATH="$OCF_ROOT_DIR/resource.d"])
 AC_ARG_WITH([ocfrapath],
     [AS_HELP_STRING([--with-ocfrapath=DIR], m4_normalize([
         OCF resource agent directories (colon-separated) to search
         @<:@value from resource-agents package if available otherwise
-	OCFDIR/resource.d@:>@]))],
+        OCFDIR/resource.d@:>@]))],
     [ OCF_RA_PATH="$withval" ]
 )
 AC_SUBST(OCF_RA_PATH)
@@ -618,7 +618,7 @@ if [ test "x${runstatedir}" = "x" ]; then
 fi
 eval runstatedir="$(eval echo ${runstatedir})"
 AC_DEFINE_UNQUOTED([PCMK_RUN_DIR], ["$runstatedir"],
-		   [Location for modifiable per-process data])
+                   [Location for modifiable per-process data])
 AC_SUBST(runstatedir)
 
 eval INITDIR="${INITDIR}"
@@ -733,7 +733,7 @@ esac
 
 AC_SUBST(INIT_EXT)
 AC_DEFINE_UNQUOTED([SUPPORT_PROCFS], [$PROCFS],
-		   [Define to 1 if procfs is supported])
+                   [Define to 1 if procfs is supported])
 
 case "$host_cpu" in
     ppc64|powerpc64)
@@ -934,9 +934,9 @@ PKG_CHECK_MODULES([UUID], [uuid],
 
 AC_CHECK_FUNCS([sched_setscheduler])
 if test "$ac_cv_func_sched_setscheduler" != yes; then
-	PC_LIBS_RT=""
+        PC_LIBS_RT=""
 else
-	PC_LIBS_RT="-lrt"
+        PC_LIBS_RT="-lrt"
 fi
 AC_SUBST(PC_LIBS_RT)
 
@@ -1304,7 +1304,7 @@ AC_SUBST(CRM_DAEMON_DIR)
 
 CRM_STATE_DIR="${runstatedir}/crm"
 AC_DEFINE_UNQUOTED([CRM_STATE_DIR], ["$CRM_STATE_DIR"],
-		   [Where to keep state files and sockets])
+                   [Where to keep state files and sockets])
 AC_SUBST(CRM_STATE_DIR)
 
 CRM_RSCTMP_DIR="${runstatedir}/resource-agents"
@@ -1339,15 +1339,15 @@ AC_SUBST(BUILD_VERSION)
 
 HAVE_dbus=1
 PKG_CHECK_MODULES([DBUS], [dbus-1],
-		  [CPPFLAGS="${CPPFLAGS} ${DBUS_CFLAGS}"],
-		  [HAVE_dbus=0])
+                  [CPPFLAGS="${CPPFLAGS} ${DBUS_CFLAGS}"],
+                  [HAVE_dbus=0])
 AC_DEFINE_UNQUOTED(SUPPORT_DBUS, $HAVE_dbus, Support dbus)
 AM_CONDITIONAL(BUILD_DBUS, test $HAVE_dbus = 1)
 AC_CHECK_TYPES([DBusBasicValue],,,[[#include <dbus/dbus.h>]])
 if test $HAVE_dbus = 0; then
-	PC_NAME_DBUS=""
+        PC_NAME_DBUS=""
 else
-	PC_NAME_DBUS="dbus-1"
+        PC_NAME_DBUS="dbus-1"
 fi
 AC_SUBST(PC_NAME_DBUS)
 

--- a/cts/lab/CTStests.py
+++ b/cts/lab/CTStests.py
@@ -3082,6 +3082,16 @@ class RemoteMigrate(RemoteDriver):
 
         return self.success()
 
+    def is_applicable(self):
+        if not RemoteDriver.is_applicable(self):
+            return 0
+        # This test requires at least three nodes: one to convert to a
+        # remote node, one to host the connection originally, and one
+        # to migrate the connection to.
+        if len(self.Env["nodes"]) < 3:
+            return 0
+        return 1
+
 AllTestClasses.append(RemoteMigrate)
 
 
@@ -3116,6 +3126,16 @@ class RemoteRscFailure(RemoteDriver):
 
         ignore_pats.extend(RemoteDriver.errorstoignore(self))
         return ignore_pats
+
+    def is_applicable(self):
+        if not RemoteDriver.is_applicable(self):
+            return 0
+        # This test requires at least three nodes: one to convert to a
+        # remote node, one to host the connection originally, and one
+        # to migrate the connection to.
+        if len(self.Env["nodes"]) < 3:
+            return 0
+        return 1
 
 AllTestClasses.append(RemoteRscFailure)
 

--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -247,8 +247,6 @@ pcmk__get_sbd_timeout(void)
     return sbd_timeout;
 }
 
-#define PCMK__SBD_SYNC_DEFAULT false
-
 bool
 pcmk__get_sbd_sync_resource_startup(void)
 {

--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -247,19 +247,29 @@ pcmk__get_sbd_timeout(void)
     return sbd_timeout;
 }
 
+#define PCMK__SBD_SYNC_DEFAULT false
+
 bool
 pcmk__get_sbd_sync_resource_startup(void)
 {
-    static bool sync_resource_startup = false;
+    static int sync_resource_startup = PCMK__SBD_SYNC_DEFAULT;
     static bool checked_sync_resource_startup = false;
 
     if (!checked_sync_resource_startup) {
-        sync_resource_startup =
-            crm_is_true(getenv("SBD_SYNC_RESOURCE_STARTUP"));
+        const char *sync_env = getenv("SBD_SYNC_RESOURCE_STARTUP");
+
+        if (sync_env == NULL) {
+            crm_trace("Defaulting to %sstart-up synchronization with sbd",
+                      (PCMK__SBD_SYNC_DEFAULT? "" : "no "));
+
+        } else if (crm_str_to_boolean(sync_env, &sync_resource_startup) < 0) {
+            crm_warn("Defaulting to %sstart-up synchronization with sbd "
+                     "because environment value '%s' is invalid",
+                     (PCMK__SBD_SYNC_DEFAULT? "" : "no "), sync_env);
+        }
         checked_sync_resource_startup = true;
     }
-
-    return sync_resource_startup;
+    return sync_resource_startup != 0;
 }
 
 long

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -59,6 +59,19 @@
 %bcond_without doc
 %endif
 
+## Add option to default to start-up synchronization with SBD.
+##
+## If enabled, SBD *MUST* be built to default similarly, otherwise data
+## corruption could occur. Building both Pacemaker and SBD to default
+## to synchronization improves safety, without requiring higher-level tools
+## to be aware of the setting or requiring users to modify configurations
+## after upgrading to versions that support synchronization.
+%if 0%{?rhel} && 0%{?rhel} > 8
+%bcond_without sbd_sync
+%else
+%bcond_with sbd_sync
+%endif
+
 ## Add option to prefix package version with "0."
 ## (so later "official" packages will be considered updates)
 %bcond_with pre_release
@@ -478,6 +491,7 @@ export LDFLAGS_HARDENED_LIB="%{?_hardening_ldflags}"
         %{?with_profiling:     --with-profiling}                                \
         %{?with_coverage:      --with-coverage}                                 \
         %{?with_cibsecrets:    --with-cibsecrets}                               \
+        %{?with_sbd_sync:      --with-sbd-sync-default="true"}                  \
         %{?gnutls_priorities:  --with-gnutls-priorities="%{gnutls_priorities}"} \
         %{?bug_url:            --with-bug-url=%{bug_url}}                       \
         %{?concurrent_fencing}                                                  \


### PR DESCRIPTION
This combines two unrelated items, a new build-time option to specify the default for sbd start-up synchronization, and a workaround for a Corosync bug. We should be ready to release 2.1.0-rc2 after this.