### PR TITLE
Handle XML output from validate-all actions

### DIFF
--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -27,7 +27,7 @@ extern "C" {
 #  include <glib.h>
 #  include <crm/common/results.h>
 
-#  define PCMK__API_VERSION "2.9"
+#  define PCMK__API_VERSION "2.11"
 
 #if defined(PCMK__WITH_ATTRIBUTE_OUTPUT_ARGS)
 #  define PCMK__OUTPUT_ARGS(ARGS...) __attribute__((output_args(ARGS)))

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -71,6 +71,8 @@ pcmk__output_new(pcmk__output_t **out, const char *fmt_name, const char *filenam
         return ENOMEM;
     }
 
+    setenv("OCF_OUTPUT_FORMAT", (*out)->fmt_name, 1);
+
     return pcmk_rc_ok;
 }
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1840,7 +1840,7 @@ main(int argc, char **argv)
 
         case cmd_execute_agent:
             if (options.cmdline_config) {
-                exit_code = cli_resource_execute_from_params(out, "test",
+                exit_code = cli_resource_execute_from_params(out, NULL,
                     options.v_class, options.v_provider, options.v_agent,
                     "validate-all", options.cmdline_params,
                     options.override_params, options.timeout_ms,

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1643,6 +1643,7 @@ main(int argc, char **argv)
          * saves from having to write custom messages to build the lists around all these things
          */
         switch (options.rsc_cmd) {
+            case cmd_execute_agent:
             case cmd_list_resources:
             case cmd_query_xml:
             case cmd_query_raw_xml:

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -224,6 +224,43 @@ attribute_list_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
+PCMK__OUTPUT_ARGS("override", "const char *", "const char *", "const char *")
+static int
+override_default(pcmk__output_t *out, va_list args) {
+    const char *rsc_name = va_arg(args, const char *);
+    const char *name = va_arg(args, const char *);
+    const char *value = va_arg(args, const char *);
+
+    if (rsc_name == NULL) {
+        out->list_item(out, NULL, "Overriding the cluster configuration with '%s' = '%s'",
+                       name, value);
+    } else {
+        out->list_item(out, NULL, "Overriding the cluster configuration for '%s' with '%s' = '%s'",
+                       rsc_name, name, value);
+    }
+
+    return pcmk_rc_ok;
+}
+
+PCMK__OUTPUT_ARGS("override", "const char *", "const char *", "const char *")
+static int
+override_xml(pcmk__output_t *out, va_list args) {
+    const char *rsc_name = va_arg(args, const char *);
+    const char *name = va_arg(args, const char *);
+    const char *value = va_arg(args, const char *);
+
+    xmlNodePtr node = pcmk__output_create_xml_node(out, "override",
+                                                   "name", name,
+                                                   "value", value,
+                                                   NULL);
+
+    if (rsc_name != NULL) {
+        crm_xml_add(node, "rsc", rsc_name);
+    }
+
+    return pcmk_rc_ok;
+}
+
 PCMK__OUTPUT_ARGS("property-list", "pe_resource_t *", "char *")
 static int
 property_list_default(pcmk__output_t *out, va_list args) {
@@ -617,6 +654,8 @@ static pcmk__message_entry_t fmt_functions[] = {
     { "agent-status", "xml", agent_status_xml },
     { "attribute-list", "default", attribute_list_default },
     { "attribute-list", "text", attribute_list_text },
+    { "override", "default", override_default },
+    { "override", "xml", override_xml },
     { "property-list", "default", property_list_default },
     { "property-list", "text", property_list_text },
     { "resource-check-list", "default", resource_check_list_default },

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -152,6 +152,57 @@ attribute_list_default(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
+PCMK__OUTPUT_ARGS("agent-status", "int", "const char *", "const char *", "const char *",
+                  "const char *", "const char *", "int")
+static int
+agent_status_default(pcmk__output_t *out, va_list args) {
+    int status = va_arg(args, int);
+    const char *action = va_arg(args, const char *);
+    const char *name = va_arg(args, const char *);
+    const char *class = va_arg(args, const char *);
+    const char *provider = va_arg(args, const char *);
+    const char *type = va_arg(args, const char *);
+    int rc = va_arg(args, int);
+
+    if (status == PCMK_LRM_OP_DONE) {
+        out->info(out, "Operation %s%s%s (%s%s%s:%s) returned: '%s' (%d)",
+                  action, name ? " for " : "", name ? name : "",
+                  class, provider ? ":" : "", provider ? provider : "", type,
+                  services_ocf_exitcode_str(rc), rc);
+    } else {
+        out->err(out, "Operation %s%s%s (%s%s%s:%s) failed: '%s' (%d)",
+                 action, name ? " for " : "", name ? name : "",
+                 class, provider ? ":" : "", provider ? provider : "", type,
+                 services_lrm_status_str(status), status);
+    }
+
+    return pcmk_rc_ok;
+}
+
+PCMK__OUTPUT_ARGS("agent-status", "int", "const char *", "const char *", "const char *",
+                  "const char *", "const char *", "int")
+static int
+agent_status_xml(pcmk__output_t *out, va_list args) {
+    int status G_GNUC_UNUSED = va_arg(args, int);
+    const char *action G_GNUC_UNUSED = va_arg(args, const char *);
+    const char *name G_GNUC_UNUSED = va_arg(args, const char *);
+    const char *class G_GNUC_UNUSED = va_arg(args, const char *);
+    const char *provider G_GNUC_UNUSED = va_arg(args, const char *);
+    const char *type G_GNUC_UNUSED = va_arg(args, const char *);
+    int rc = va_arg(args, int);
+
+    char *status_str = pcmk__itoa(rc);
+
+    pcmk__output_create_xml_node(out, "agent-status",
+                                 "code", status_str,
+                                 "message", services_ocf_exitcode_str(rc),
+                                 NULL);
+
+    free(status_str);
+
+    return pcmk_rc_ok;
+}
+
 PCMK__OUTPUT_ARGS("attribute-list", "pe_resource_t *", "char *", "GHashTable *")
 static int
 attribute_list_text(pcmk__output_t *out, va_list args) {
@@ -562,6 +613,8 @@ resource_names(pcmk__output_t *out, va_list args) {
 }
 
 static pcmk__message_entry_t fmt_functions[] = {
+    { "agent-status", "default", agent_status_default },
+    { "agent-status", "xml", agent_status_xml },
     { "attribute-list", "default", attribute_list_default },
     { "attribute-list", "text", attribute_list_text },
     { "property-list", "default", property_list_default },

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1717,14 +1717,14 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
      */
     params_copy = pcmk__str_table_dup(params);
 
-    op = resources_action_create(rsc_name, rsc_class, rsc_prov, rsc_type, action, 0,
-                                 timeout_ms, params_copy, 0);
+    op = resources_action_create(rsc_name ? rsc_name : "test", rsc_class, rsc_prov,
+                                 rsc_type, action, 0, timeout_ms, params_copy, 0);
     if (op == NULL) {
         /* Re-run with stderr enabled so we can display a sane error message */
         crm_enable_stderr(TRUE);
         params_copy = pcmk__str_table_dup(params);
-        op = resources_action_create(rsc_name, rsc_class, rsc_prov, rsc_type, action, 0,
-                                     timeout_ms, params_copy, 0);
+        op = resources_action_create(rsc_name ? rsc_name : "test", rsc_class, rsc_prov,
+                                     rsc_type, action, 0, timeout_ms, params_copy, 0);
 
         /* Callers of cli_resource_execute expect that the params hash table will
          * be freed.  That function uses this one, so for that reason and for

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1765,28 +1765,13 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
     if (services_action_sync(op)) {
         exit_code = op->rc;
 
-        if (op->status == PCMK_LRM_OP_DONE) {
-            out->info(out, "Operation %s for %s (%s:%s:%s) returned: '%s' (%d)",
-                      action, rsc_name, rsc_class, rsc_prov ? rsc_prov : "", rsc_type,
-                      services_ocf_exitcode_str(op->rc), op->rc);
-        } else {
-            out->err(out, "Operation %s for %s (%s:%s:%s) failed: '%s' (%d)",
-                     action, rsc_name, rsc_class, rsc_prov ? rsc_prov : "", rsc_type,
-                     services_lrm_status_str(op->status), op->status);
-        }
-
-        /* hide output for validate-all if not in verbose */
-        if (resource_verbose == 0 && pcmk__str_eq(action, "validate-all", pcmk__str_casei))
-            goto done;
-
-        if (op->stdout_data || op->stderr_data) {
-            out->subprocess_output(out, op->rc, op->stdout_data, op->stderr_data);
-        }
+        out->message(out, "resource-agent-action", resource_verbose, rsc_class,
+                     rsc_prov, rsc_type, rsc_name, action, override_hash, op->rc,
+                     op->status, op->stdout_data, op->stderr_data);
     } else {
         exit_code = op->rc == 0 ? CRM_EX_ERROR : op->rc;
     }
 
-done:
     services_action_free(op);
     /* See comment above about why we free params here. */
     g_hash_table_destroy(params);

--- a/xml/api/crm_resource-2.11.rng
+++ b/xml/api/crm_resource-2.11.rng
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crm-resource"/>
+    </start>
+
+    <define name="element-crm-resource">
+        <choice>
+            <ref name="agents-list" />
+            <ref name="alternatives-list" />
+            <ref name="constraints-list" />
+            <externalRef href="generic-list-2.4.rng"/>
+            <element name="metadata"> <text/> </element>
+            <ref name="locate-list" />
+            <ref name="operations-list" />
+            <ref name="providers-list" />
+            <ref name="reasons-list" />
+            <ref name="resource-check" />
+            <ref name="resource-config" />
+            <ref name="resources-list" />
+        </choice>
+    </define>
+
+    <define name="agents-list">
+        <element name="agents">
+            <attribute name="standard"> <text/> </attribute>
+            <optional>
+                <attribute name="provider"> <text/> </attribute>
+            </optional>
+            <zeroOrMore>
+                <element name="agent"> <text/> </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="alternatives-list">
+        <element name="providers">
+            <attribute name="for"> <text/> </attribute>
+            <zeroOrMore>
+                <element name="provider"> <text/> </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="constraints-list">
+        <element name="constraints">
+            <interleave>
+                <zeroOrMore>
+                    <ref name="rsc-location" />
+                </zeroOrMore>
+                <zeroOrMore>
+                    <ref name="rsc-colocation" />
+                </zeroOrMore>
+            </interleave>
+        </element>
+    </define>
+
+    <define name="locate-list">
+        <element name="nodes">
+            <attribute name="resource"> <text/> </attribute>
+            <zeroOrMore>
+                <element name="node">
+                    <optional>
+                        <attribute name="state"><value>promoted</value></attribute>
+                    </optional>
+                    <text/>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="rsc-location">
+        <element name="rsc_location">
+            <attribute name="node"> <text/> </attribute>
+            <attribute name="rsc"> <text/> </attribute>
+            <attribute name="id"> <text/> </attribute>
+            <externalRef href="../score.rng"/>
+        </element>
+    </define>
+
+    <define name="operations-list">
+        <element name="operations">
+            <oneOrMore>
+                <ref name="element-operation-list" />
+            </oneOrMore>
+        </element>
+    </define>
+
+    <define name="providers-list">
+        <element name="providers">
+            <attribute name="standard"> <value>ocf</value> </attribute>
+            <optional>
+                <attribute name="agent"> <text/> </attribute>
+            </optional>
+            <zeroOrMore>
+                <element name="provider"> <text/> </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="reasons-list">
+        <choice>
+            <ref name="no-resource-or-uname"/>
+            <ref name="resource-and-uname"/>
+            <ref name="no-resource-but-uname"/>
+            <ref name="resource-but-no-uname"/>
+        </choice>
+    </define>
+
+    <define name="no-resource-or-uname">
+        <element name="reason">
+            <element name="resources">
+                <zeroOrMore>
+                    <element name="resource">
+                        <attribute name="id"> <text/> </attribute>
+                        <attribute name="running"> <data type="boolean"/> </attribute>
+                        <ref name="resource-check"/>
+                    </element>
+                </zeroOrMore>
+            </element>
+        </element>
+    </define>
+
+    <define name="resource-and-uname">
+        <element name="reason">
+            <attribute name="running_on"> <text/> </attribute>
+            <ref name="resource-check"/>
+        </element>
+    </define>
+
+    <define name="no-resource-but-uname">
+        <element name="reason">
+            <element name="resources">
+                <zeroOrMore>
+                    <element name="resource">
+                        <attribute name="id"> <text/> </attribute>
+                        <attribute name="running"> <data type="boolean"/> </attribute>
+                        <attribute name="host"> <text/> </attribute>
+                        <ref name="resource-check"/>
+                    </element>
+                </zeroOrMore>
+            </element>
+        </element>
+    </define>
+
+    <define name="resource-but-no-uname">
+        <element name="reason">
+            <attribute name="running"> <data type="boolean"/> </attribute>
+            <ref name="resource-check"/>
+        </element>
+    </define>
+
+    <define name="resource-config">
+        <element name="resource_config">
+            <externalRef href="resources-2.4.rng" />
+            <element name="xml"> <text/> </element>
+        </element>
+    </define>
+
+    <define name="resource-check">
+        <element name="check">
+            <attribute name="id"> <text/> </attribute>
+            <optional>
+                <choice>
+                    <attribute name="remain_stopped"><value>true</value></attribute>
+                    <attribute name="promotable"><value>false</value></attribute>
+                </choice>
+            </optional>
+            <optional>
+                <attribute name="unmanaged"><value>true</value></attribute>
+            </optional>
+            <optional>
+                <attribute name="locked-to"> <text/> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="resources-list">
+        <element name="resources">
+            <zeroOrMore>
+                <externalRef href="resources-2.4.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="rsc-colocation">
+        <element name="rsc_colocation">
+            <attribute name="id"> <text/> </attribute>
+            <attribute name="rsc"> <text/> </attribute>
+            <attribute name="with-rsc"> <text/> </attribute>
+            <externalRef href="../score.rng"/>
+            <optional>
+                <attribute name="node-attribute"> <text/> </attribute>
+            </optional>
+            <optional>
+                <attribute name="rsc-role">
+                    <ref name="attribute-roles"/>
+                </attribute>
+            </optional>
+            <optional>
+                <attribute name="with-rsc-role">
+                    <ref name="attribute-roles"/>
+                </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="element-operation-list">
+        <element name="operation">
+            <optional>
+                <group>
+                    <attribute name="rsc"> <text/> </attribute>
+                    <attribute name="agent"> <text/> </attribute>
+                </group>
+            </optional>
+            <attribute name="op"> <text/> </attribute>
+            <attribute name="node"> <text/> </attribute>
+            <attribute name="call"> <data type="integer" /> </attribute>
+            <attribute name="rc"> <data type="nonNegativeInteger" /> </attribute>
+            <optional>
+                <attribute name="last-rc-change"> <text/> </attribute>
+                <attribute name="exec-time"> <data type="nonNegativeInteger" /> </attribute>
+            </optional>
+            <attribute name="status"> <text/> </attribute>
+        </element>
+    </define>
+
+    <define name="attribute-roles">
+        <choice>
+            <value>Stopped</value>
+            <value>Started</value>
+            <value>Master</value>
+            <value>Slave</value>
+        </choice>
+    </define>
+</grammar>

--- a/xml/api/crm_resource-2.11.rng
+++ b/xml/api/crm_resource-2.11.rng
@@ -20,6 +20,7 @@
             <ref name="resource-check" />
             <ref name="resource-config" />
             <ref name="resources-list" />
+            <ref name="resource-agent-action" />
         </choice>
     </define>
 
@@ -224,6 +225,55 @@
                 <attribute name="exec-time"> <data type="nonNegativeInteger" /> </attribute>
             </optional>
             <attribute name="status"> <text/> </attribute>
+        </element>
+    </define>
+
+    <define name="resource-agent-action">
+        <element name="resource-agent-action">
+            <attribute name="action"> <text/> </attribute>
+            <optional>
+                <attribute name="rsc"> <text/> </attribute>
+            </optional>
+            <attribute name="class"> <text/> </attribute>
+            <attribute name="type"> <text/> </attribute>
+            <optional>
+                <attribute name="provider"> <text/> </attribute>
+            </optional>
+            <optional>
+                <ref name="overrides-list"/>
+            </optional>
+            <ref name="agent-status"/>
+            <optional>
+                <choice>
+                    <element name="command">
+                        <text />
+                    </element>
+                    <externalRef href="command-output-1.0.rng"/>
+                </choice>
+            </optional>
+        </element>
+    </define>
+
+    <define name="overrides-list">
+        <element name="overrides">
+            <zeroOrMore>
+                <element name="override">
+                    <optional>
+                        <attribute name="rsc"> <text/> </attribute>
+                    </optional>
+                    <attribute name="name"> <text/> </attribute>
+                    <attribute name="value"> <text/> </attribute>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="agent-status">
+        <element name="agent-status">
+            <attribute name="code"> <data type="integer" /> </attribute>
+            <optional>
+                <attribute name="message"> <text/> </attribute>
+            </optional>
         </element>
     </define>
 


### PR DESCRIPTION
The point of this is just to see if I'm on the right track.  It seems like almost all of the work for supporting XML validate-all output is in defining a schema for the resource agents to follow, and then adding support to the resource agents themselves.  There doesn't seem like much required out of crm_resource.

Here's an example of successful output:
```
# crm_resource --class ocf --provider pacemaker --agent Dummy --validate --output-as xml 
<pacemaker-result api-version="2.3" request="crm_resource --class ocf --provider pacemaker --agent Dummy --validate --output-as xml">
  <validate>
    <overrides/>
    <result status="0" action="validate-all" name="test" class="ocf" type="Dummy" provider="pacemaker"/>
    <command><![CDATA[<dummy><status>0</status></dummy>
]]></command>
  </validate>
  <status code="0" message="OK"/>
</pacemaker-result>
```

And then here's an example of output when there's a problem and XML isn't output:
```
# crm_resource --class ocf --provider pacemaker --agent Dummy --validate --output-as xml op_sleep=a
<pacemaker-result api-version="2.3" request="crm_resource --class ocf --provider pacemaker --agent Dummy --validate --output-as xml op_sleep=a">
  <validate>
    <overrides>
      <override rsc_name="test" name="op_sleep" value="a"/>
    </overrides>
    <result status="0" action="validate-all" name="test" class="ocf" type="Dummy" provider="pacemaker"/>
    <command code="6">
      <output source="stderr">DEBUG: test validate-all : 6
</output>
    </command>
  </validate>
  <status code="6" message="Not configured">
    <errors>
      <error>crm_resource: Error performing operation: OK</error>
    </errors>
  </status>
</pacemaker-result>
```