### PR TITLE
Fix a couple more error codes in crm_resource

### DIFF
--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1376,6 +1376,12 @@ show_metadata(pcmk__output_t *out, const char *agent_spec)
         if (metadata) {
             out->output_xml(out, "metadata", metadata);
         } else {
+            /* We were given a validly formatted spec, but it doesn't necessarily
+             * match up with anything that exists.  Use ENXIO as the return code
+             * here because that maps to an exit code of CRM_EX_NOSUCH, which
+             * probably is the most common reason to get here.
+             */
+            rc = ENXIO;
             g_set_error(&error, PCMK__RC_ERROR, rc,
                         "Metadata query for %s failed: %s",
                         agent_spec, pcmk_rc_str(rc));

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -157,7 +157,7 @@ find_resource_attr(pcmk__output_t *out, cib_t * the_cib, const char *attr,
     if (xml_has_children(xml_search)) {
         xmlNode *child = NULL;
 
-        rc = EINVAL;
+        rc = ENOTUNIQ;
         out->info(out, "Multiple attributes match name=%s", attr_name);
 
         for (child = pcmk__xml_first_child(xml_search); child != NULL;


### PR DESCRIPTION
The point of this is to avoid EINVAL where possible.  That value maps to CRM_EX_SOFTWARE, which means the user will see an "internal software bug" message.  Often times, this is incorrect.  This PR is narrowly focused to just catch a couple cases that are pretty obvious.  There are likely more of them lurking out there.