### PR TITLE
Mid: fenced: Fencing escalation may not be performed if there is no topology.

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2135,9 +2135,13 @@ stonith_send_async_reply(async_command_t * cmd, const char *output, int rc, GPid
         crm_trace("Never broadcast '%s' replies", cmd->action);
 
     } else if (!stand_alone && pcmk__str_eq(cmd->origin, cmd->victim, pcmk__str_casei) && !pcmk__str_eq(cmd->action, "on", pcmk__str_casei)) {
-        crm_trace("Broadcast '%s' reply for %s", cmd->action, cmd->victim);
-        crm_xml_add(reply, F_SUBTYPE, "broadcast");
-        bcast = TRUE;
+        /* If the DC node is the starting point in the absence of topology and fencing the DC node, the fencing success will "Broadcast" to all nodes. */
+        /* A fencing failure replies to the DC node and escalate the fencing. */
+        if (rc == 0) {
+            crm_trace("Broadcast '%s' reply for %s", cmd->action, cmd->victim);
+            crm_xml_add(reply, F_SUBTYPE, "broadcast");
+            bcast = TRUE;
+        }
     }
 
     log_operation(cmd, rc, pid, NULL, output, (options & st_reply_opt_merged ? TRUE : FALSE));


### PR DESCRIPTION
Hi All,


Execution of fencing escalation consisting of N nodes without topology settings may fail.
Occurs when processed by "static-list".
If there is a topology, this problem does not apply because the processing is different.

Here are the successes and failures: The following example specifies pcmk_host_list.
The virtual environment is taken as an example below, but the same is true for the real environment.

Also, depending on the version of fence_agent, disable-timeout may be enabled, so it is necessary to disable disable-timeout for reproduction.


```
(snip)
pcs stonith create fence1-virsh fence_virsh \
    pcmk_reboot_action="reboot" pcmk_host_list="rh83-dev01" ip="192.168.3.253" username="root" password="xxxxx" \
    op start timeout=60s on-fail=restart \
    monitor timeout=60s interval=3600s on-fail=restart \
    stop timeout=60s on-fail=ignore

pcs stonith create fence2-virsh fence_virsh \
    pcmk_reboot_action="reboot" pcmk_host_list="rh83-dev02" ip="192.168.3.253" username="root" password="xxxxx" \
    op start timeout=60s on-fail=restart \
    monitor timeout=60s interval=3600s on-fail=restart \
    stop timeout=60s on-fail=ignore

pcs stonith create fence3-virsh fence_virsh \
    pcmk_reboot_action="reboot" pcmk_host_list="rh83-dev03" ip="192.168.3.253" username="root" password="xxxxx" \
    op start timeout=60s on-fail=restart \
    monitor timeout=60s interval=3600s on-fail=restart \
    stop timeout=60s on-fail=ignore
(snip)
pcs constraint location fence1-virsh avoids rh83-dev01
pcs constraint location fence2-virsh avoids rh83-dev02
pcs constraint location fence3-virsh avoids rh83-dev03
(snip)

```

Successful case.
Step1) Configure the cluster.
```
[root@rh83-dev01 ~]# crm_mon -rfA1
Cluster Summary:
  * Stack: corosync
  * Current DC: rh83-dev02 (version 2.1.0-f7da24cd0) - partition with quorum
  * Last updated: Mon Jun  7 09:02:54 2021
  * Last change:  Mon Jun  7 08:58:49 2021 by root via cibadmin on rh83-dev01
  * 3 nodes configured
  * 7 resource instances configured

Node List:
  * Online: [ rh83-dev01 rh83-dev02 rh83-dev03 ]

Full List of Resources:
  * fence1-virsh        (stonith:fence_virsh):   Started rh83-dev02
  * fence2-virsh        (stonith:fence_virsh):   Started rh83-dev01
  * fence3-virsh        (stonith:fence_virsh):   Started rh83-dev01
  * Resource Group: dummy-group:
    * dummy-1   (ocf:heartbeat:Dummy):   Started rh83-dev01
  * Clone Set: prmPing-clone [prmPing]:
    * Started: [ rh83-dev01 rh83-dev02 rh83-dev03 ]

Node Attributes:
  * Node: rh83-dev01:
    * default_ping_set                  : 1         
  * Node: rh83-dev02:
    * default_ping_set                  : 1         
  * Node: rh83-dev03:
    * default_ping_set                  : 1         

Migration Summary:
```

Step2) Blocks the fencing connection path for node 2, which preferentially fencing node 1.
```
[root@rh83-dev02 ~]# iptables -A INPUT -s 192.168.3.253 -j DROP;iptables -A OUTPUT -s 192.168.3.253 -j DROP
```

Step3) Causes a resource outage failure on node 1.

Step4) Fencing from node 2 will fail, but fencing from node 3 will be performed.

Step5) As a result, it fails over.
```
[root@rh83-dev02 ~]# crm_mon -rfA1
Cluster Summary:
  * Stack: corosync
  * Current DC: rh83-dev02 (version 2.1.0-f7da24cd0) - partition with quorum
  * Last updated: Mon Jun  7 09:05:35 2021
  * Last change:  Mon Jun  7 08:58:49 2021 by root via cibadmin on rh83-dev01
  * 3 nodes configured
  * 7 resource instances configured

Node List:
  * Online: [ rh83-dev02 rh83-dev03 ]
  * OFFLINE: [ rh83-dev01 ]

Full List of Resources:
  * fence1-virsh        (stonith:fence_virsh):   Started rh83-dev02
  * fence2-virsh        (stonith:fence_virsh):   Started rh83-dev03
  * fence3-virsh        (stonith:fence_virsh):   Stopped
  * Resource Group: dummy-group:
    * dummy-1   (ocf:heartbeat:Dummy):   Started rh83-dev02
  * Clone Set: prmPing-clone [prmPing]:
    * Started: [ rh83-dev02 rh83-dev03 ]
    * Stopped: [ rh83-dev01 ]

Node Attributes:
  * Node: rh83-dev02:
    * default_ping_set                  : 1         
  * Node: rh83-dev03:
    * default_ping_set                  : 1         

Migration Summary:
  * Node: rh83-dev02:
    * fence3-virsh: migration-threshold=1 fail-count=1000000 last-failure='Mon Jun  7 09:05:07 2021'

Failed Resource Actions:
  * fence3-virsh_start_0 on rh83-dev02 'error' (1): call=27, status='complete', exitreason='', last-rc-change='2021-06-07 09:04:56 +09:00', queued=0ms, exec=10353ms
```

Case of failure.
Step1) Configure the cluster.
```
[root@rh83-dev01 ~]# crm_mon -rfA1
Cluster Summary:
  * Stack: corosync
  * Current DC: rh83-dev01 (version 2.1.0-f7da24cd0) - partition with quorum
  * Last updated: Mon Jun  7 09:13:51 2021
  * Last change:  Mon Jun  7 09:13:42 2021 by root via cibadmin on rh83-dev01
  * 3 nodes configured
  * 7 resource instances configured

Node List:
  * Online: [ rh83-dev01 rh83-dev02 rh83-dev03 ]

Full List of Resources:
  * fence1-virsh        (stonith:fence_virsh):   Started rh83-dev02
  * fence2-virsh        (stonith:fence_virsh):   Started rh83-dev01
  * fence3-virsh        (stonith:fence_virsh):   Started rh83-dev01
  * Resource Group: dummy-group:
    * dummy-1   (ocf:heartbeat:Dummy):   Started rh83-dev01
  * Clone Set: prmPing-clone [prmPing]:
    * Started: [ rh83-dev01 rh83-dev02 rh83-dev03 ]

Node Attributes:
  * Node: rh83-dev01:
    * default_ping_set                  : 1         
  * Node: rh83-dev02:
    * default_ping_set                  : 1         
  * Node: rh83-dev03:
    * default_ping_set                  : 1         

Migration Summary:
```
Step2) Blocks the fencing connection path for node 2, which preferentially fencing node 1.
```
[root@rh83-dev02 ~]# iptables -A INPUT -s 192.168.3.253 -j DROP;iptables -A OUTPUT -s 192.168.3.253 -j DROP
```
Step3) Causes a resource outage failure on node 1.

Step4) Fencing from node 2 will fail, but fencing from node 3 will not be performed.

Step5) As a result, failover fails.
```

[root@rh83-dev01 ~]# crm_mon -rfA1m3
Cluster Summary:
  * Stack: corosync
  * Current DC: rh83-dev01 (version 2.1.0-f7da24cd0) - partition with quorum
  * Last updated: Mon Jun  7 09:16:20 2021
  * Last change:  Mon Jun  7 09:13:42 2021 by root via cibadmin on rh83-dev01
  * 3 nodes configured
  * 7 resource instances configured

Node List:
  * Node rh83-dev01: UNCLEAN (online)
  * Online: [ rh83-dev02 rh83-dev03 ]

Full List of Resources:
  * fence1-virsh        (stonith:fence_virsh):   Started rh83-dev02
  * fence2-virsh        (stonith:fence_virsh):   Started [ rh83-dev01 rh83-dev03 ]
  * fence3-virsh        (stonith:fence_virsh):   Started rh83-dev01
  * Resource Group: dummy-group:
    * dummy-1   (ocf:heartbeat:Dummy):   FAILED rh83-dev01
  * Clone Set: prmPing-clone [prmPing]:
    * Started: [ rh83-dev01 rh83-dev02 rh83-dev03 ]

Node Attributes:
  * Node: rh83-dev01:
    * default_ping_set                  : 1         
  * Node: rh83-dev02:
    * default_ping_set                  : 1         
  * Node: rh83-dev03:
    * default_ping_set                  : 1         

Migration Summary:
  * Node: rh83-dev01:
    * dummy-1: migration-threshold=1 fail-count=1000000 last-failure='Mon Jun  7 09:14:19 2021'
  * Node: rh83-dev02:
    * fence3-virsh: migration-threshold=1 fail-count=1000000 last-failure='Mon Jun  7 09:14:29 2021'

Failed Resource Actions:
  * dummy-1_stop_0 on rh83-dev01 'error' (1): call=32, status='complete', exitreason='', last-rc-change='2021-06-07 09:14:19 +09:00', queued=0ms, exec=9ms
  * fence3-virsh_start_0 on rh83-dev02 'error' (1): call=27, status='complete', exitreason='', last-rc-change='2021-06-07 09:14:19 +09:00', queued=0ms, exec=10351ms

Failed Fencing Actions:
  * reboot of rh83-dev01 failed: delegate=rh83-dev02, client=pacemaker-controld.4237, origin=rh83-dev01, completed='2021-06-07 09:16:12 +09:00' 
  * reboot of rh83-dev01 failed: delegate=rh83-dev02, client=pacemaker-controld.4237, origin=rh83-dev01, completed='2021-06-07 09:16:01 +09:00' 
  * reboot of rh83-dev01 failed: delegate=rh83-dev02, client=pacemaker-controld.4237, origin=rh83-dev01, completed='2021-06-07 09:15:50 +09:00' 
  * reboot of rh83-dev01 failed: delegate=rh83-dev02, client=pacemaker-controld.4237, origin=rh83-dev01, completed='2021-06-07 09:15:38 +09:00' 
  * reboot of rh83-dev01 failed: delegate=rh83-dev02, client=pacemaker-controld.4237, origin=rh83-dev01, completed='2021-06-07 09:15:27 +09:00' 
  * reboot of rh83-dev01 failed: delegate=rh83-dev02, client=pacemaker-controld.4237, origin=rh83-dev01, completed='2021-06-07 09:15:16 +09:00' 
  * reboot of rh83-dev01 failed: delegate=rh83-dev02, client=pacemaker-controld.4237, origin=rh83-dev01, completed='2021-06-07 09:15:04 +09:00' 
  * reboot of rh83-dev01 failed: delegate=rh83-dev02, client=pacemaker-controld.4237, origin=rh83-dev01, completed='2021-06-07 09:14:53 +09:00' 
  * reboot of rh83-dev01 failed: delegate=rh83-dev02, client=pacemaker-controld.4237, origin=rh83-dev01, completed='2021-06-07 09:14:41 +09:00' 
  * reboot of rh83-dev01 failed: delegate=rh83-dev02, client=pacemaker-controld.4237, origin=rh83-dev01, completed='2021-06-07 09:14:30 +09:00' 
```


If the failing node is a DC node and the first fencing fails, escalation fencing will not be directed.
Therefore, failover will fail.


The problem occurs when fencing occurs targeting DC nodes in the absence of topology.

In this case, the fencing failure should be sent back to the DC node, but it will be notified by "Broadcast".
Therefore, the DC node does not perform fencing escalation.

This fix solves this problem.

Best Regards,
Hideo Yamauchi.


