### PR TITLE
Display fixes for unmanaged resources on offline nodes

### DIFF
--- a/cts/Makefile.am
+++ b/cts/Makefile.am
@@ -30,6 +30,7 @@ dist_cli_DATA	= cli/constraints.xml \
 		  cli/crm_diff_new.xml		\
 		  cli/crm_diff_old.xml		\
 		  cli/crm_mon.xml		\
+		  cli/crm_mon-unmanaged.xml	\
 		  cli/crm_mon-partial.xml	\
 		  cli/crm_resource_digests.xml	\
 		  cli/regression.acls.exp	\

--- a/cts/cli/crm_mon-unmanaged.xml
+++ b/cts/cli/crm_mon-unmanaged.xml
@@ -1,4 +1,4 @@
-<cib crm_feature_set="3.3.0" validate-with="pacemaker-3.3" epoch="1" num_updates="49" admin_epoch="1" cib-last-written="Tue May  5 12:04:36 2020" update-origin="cluster01" update-client="crmd" update-user="hacluster" have-quorum="1" dc-uuid="2">
+<cib crm_feature_set="3.3.0" validate-with="pacemaker-3.3" epoch="1" num_updates="56" admin_epoch="1" cib-last-written="Tue May  5 12:04:36 2020" update-origin="cluster01" update-client="crmd" update-user="hacluster" have-quorum="1" dc-uuid="2">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -22,6 +22,14 @@
       </primitive>
       <primitive class="ocf" id="rsc1" provider="pacemaker" type="Dummy"/>
       <primitive class="ocf" id="rsc2" provider="pacemaker" type="Dummy"/>
+      <group id="exim-group">
+        <primitive id="Public-IP" class="ocf" type="IPaddr" provider="heartbeat">
+          <instance_attributes id="params-public-ip">
+            <nvpair id="public-ip-addr" name="ip" value="192.168.1.1"/>
+          </instance_attributes>
+        </primitive>
+        <primitive id="Email" class="lsb" type="exim"/>
+      </group>
     </resources>
     <constraints/>
   </configuration>
@@ -32,13 +40,19 @@
           <lrm_resource id="Fencing" class="stonith" type="fence_xvm">
             <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" last-rc-change="1623265189" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
             <lrm_rsc_op id="Fencing_monitor_60000" operation_key="Fencing_monitor_60000" operation="monitor" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="60000" last-rc-change="1623265189" exec-time="0" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd"/>
-            <lrm_rsc_op id="Fencing_cancel_60000" operation_key="Fencing_cancel_60000" operation="cancel" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="6:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;6:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="6" rc-code="0" op-status="0" interval="60000" last-rc-change="1623267736" exec-time="0" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd"/>
+            <lrm_rsc_op id="Fencing_cancel_60000" operation_key="Fencing_cancel_60000" operation="cancel" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="10:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;10:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="10" rc-code="0" op-status="0" interval="60000" last-rc-change="1623269878" exec-time="0" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd"/>
           </lrm_resource>
           <lrm_resource id="rsc1" class="ocf" provider="pacemaker" type="Dummy">
             <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" last-rc-change="1623265189" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
           </lrm_resource>
           <lrm_resource id="rsc2" class="ocf" provider="pacemaker" type="Dummy">
             <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" last-rc-change="1623265464" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="Public-IP" class="ocf" provider="heartbeat" type="IPaddr">
+            <lrm_rsc_op id="Public-IP_last_0" operation_key="Public-IP_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="0" op-status="0" interval="0" last-rc-change="1623269525" exec-time="0" queue-time="0" op-digest="3bb21cd55b79809a3ae69333a8981fd4"/>
+          </lrm_resource>
+          <lrm_resource id="Email" class="lsb" type="exim">
+            <lrm_rsc_op id="Email_last_0" operation_key="Email_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" last-rc-change="1623269878" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
           </lrm_resource>
         </lrm_resources>
       </lrm>
@@ -48,6 +62,9 @@
         <lrm_resources>
           <lrm_resource id="rsc2" class="ocf" provider="pacemaker" type="Dummy">
             <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" last-rc-change="1623265189" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="Email" class="lsb" type="exim">
+            <lrm_rsc_op id="Email_last_0" operation_key="Email_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="0" op-status="0" interval="0" last-rc-change="1623269525" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
           </lrm_resource>
         </lrm_resources>
       </lrm>

--- a/cts/cli/crm_mon-unmanaged.xml
+++ b/cts/cli/crm_mon-unmanaged.xml
@@ -1,4 +1,4 @@
-<cib crm_feature_set="3.3.0" validate-with="pacemaker-3.3" epoch="1" num_updates="56" admin_epoch="1" cib-last-written="Tue May  5 12:04:36 2020" update-origin="cluster01" update-client="crmd" update-user="hacluster" have-quorum="1" dc-uuid="2">
+<cib crm_feature_set="3.3.0" validate-with="pacemaker-3.3" epoch="1" num_updates="59" admin_epoch="1" cib-last-written="Tue May  5 12:04:36 2020" update-origin="cluster01" update-client="crmd" update-user="hacluster" have-quorum="1" dc-uuid="2">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -30,6 +30,20 @@
         </primitive>
         <primitive id="Email" class="lsb" type="exim"/>
       </group>
+      <clone id="ping-clone">
+        <primitive class="ocf" id="ping" provider="pacemaker" type="ping">
+          <instance_attributes id="ping-instance_attributes">
+            <nvpair id="ping-instance_attributes-dampen" name="dampen" value="5s"/>
+            <nvpair id="ping-instance_attributes-host_list" name="host_list" value="192.168.122.1"/>
+            <nvpair id="ping-instance_attributes-multiplier" name="multiplier" value="1000"/>
+          </instance_attributes>
+          <operations>
+            <op id="ping-monitor-interval-10s" interval="10s" name="monitor" timeout="60s"/>
+            <op id="ping-start-interval-0s" interval="0s" name="start" timeout="60s"/>
+            <op id="ping-stop-interval-0s" interval="0s" name="stop" timeout="20s"/>
+          </operations>
+        </primitive>
+      </clone>
     </resources>
     <constraints/>
   </configuration>
@@ -40,7 +54,7 @@
           <lrm_resource id="Fencing" class="stonith" type="fence_xvm">
             <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" last-rc-change="1623265189" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
             <lrm_rsc_op id="Fencing_monitor_60000" operation_key="Fencing_monitor_60000" operation="monitor" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="60000" last-rc-change="1623265189" exec-time="0" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd"/>
-            <lrm_rsc_op id="Fencing_cancel_60000" operation_key="Fencing_cancel_60000" operation="cancel" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="10:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;10:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="10" rc-code="0" op-status="0" interval="60000" last-rc-change="1623269878" exec-time="0" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd"/>
+            <lrm_rsc_op id="Fencing_cancel_60000" operation_key="Fencing_cancel_60000" operation="cancel" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="12:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;12:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="12" rc-code="0" op-status="0" interval="60000" last-rc-change="1623270930" exec-time="0" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd"/>
           </lrm_resource>
           <lrm_resource id="rsc1" class="ocf" provider="pacemaker" type="Dummy">
             <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" last-rc-change="1623265189" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
@@ -54,6 +68,9 @@
           <lrm_resource id="Email" class="lsb" type="exim">
             <lrm_rsc_op id="Email_last_0" operation_key="Email_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" last-rc-change="1623269878" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
           </lrm_resource>
+          <lrm_resource id="ping" class="ocf" provider="pacemaker" type="ping">
+            <lrm_rsc_op id="ping_last_0" operation_key="ping_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="0" op-status="0" interval="0" last-rc-change="1623270930" exec-time="0" queue-time="0" op-digest="769dd6f95f1494d416ae9dc690960e17"/>
+          </lrm_resource>
         </lrm_resources>
       </lrm>
     </node_state>
@@ -65,6 +82,9 @@
           </lrm_resource>
           <lrm_resource id="Email" class="lsb" type="exim">
             <lrm_rsc_op id="Email_last_0" operation_key="Email_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="0" op-status="0" interval="0" last-rc-change="1623269525" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="ping" class="ocf" provider="pacemaker" type="ping">
+            <lrm_rsc_op id="ping_last_0" operation_key="ping_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="0" op-status="0" interval="0" last-rc-change="1623270930" exec-time="0" queue-time="0" op-digest="769dd6f95f1494d416ae9dc690960e17"/>
           </lrm_resource>
         </lrm_resources>
       </lrm>

--- a/cts/cli/crm_mon-unmanaged.xml
+++ b/cts/cli/crm_mon-unmanaged.xml
@@ -1,0 +1,56 @@
+<cib crm_feature_set="3.3.0" validate-with="pacemaker-3.3" epoch="1" num_updates="49" admin_epoch="1" cib-last-written="Tue May  5 12:04:36 2020" update-origin="cluster01" update-client="crmd" update-user="hacluster" have-quorum="1" dc-uuid="2">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-have-watchdog" name="have-watchdog" value="false"/>
+        <nvpair id="cib-bootstrap-options-dc-version" name="dc-version" value="2.0.4-1.e97f9675f.git.el7-e97f9675f"/>
+        <nvpair id="cib-bootstrap-options-cluster-infrastructure" name="cluster-infrastructure" value="corosync"/>
+        <nvpair id="cib-bootstrap-options-cluster-name" name="cluster-name" value="test-cluster"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+        <nvpair id="cib-bootstrap-options-maintenance-mode" name="maintenance-mode" value="true"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="1" uname="cluster01"/>
+      <node id="2" uname="cluster02"/>
+    </nodes>
+    <resources>
+      <primitive class="stonith" id="Fencing" type="fence_xvm">
+        <operations>
+          <op id="Fencing-monitor-interval-60s" interval="60s" name="monitor"/>
+        </operations>
+      </primitive>
+      <primitive class="ocf" id="rsc1" provider="pacemaker" type="Dummy"/>
+      <primitive class="ocf" id="rsc2" provider="pacemaker" type="Dummy"/>
+    </resources>
+    <constraints/>
+  </configuration>
+  <status>
+    <node_state id="1" uname="cluster01" in_ccm="true" crmd="online" crm-debug-origin="post_cache_update" join="member" expected="member">
+      <lrm id="1">
+        <lrm_resources>
+          <lrm_resource id="Fencing" class="stonith" type="fence_xvm">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" last-rc-change="1623265189" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="Fencing_monitor_60000" operation_key="Fencing_monitor_60000" operation="monitor" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="60000" last-rc-change="1623265189" exec-time="0" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd"/>
+            <lrm_rsc_op id="Fencing_cancel_60000" operation_key="Fencing_cancel_60000" operation="cancel" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="6:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;6:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="6" rc-code="0" op-status="0" interval="60000" last-rc-change="1623267736" exec-time="0" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd"/>
+          </lrm_resource>
+          <lrm_resource id="rsc1" class="ocf" provider="pacemaker" type="Dummy">
+            <lrm_rsc_op id="rsc1_last_0" operation_key="rsc1_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" last-rc-change="1623265189" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="rsc2" class="ocf" provider="pacemaker" type="Dummy">
+            <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" last-rc-change="1623265464" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state id="2" uname="cluster02" in_ccm="false" crmd="offline" crm-debug-origin="post_cache_update" join="down" expected="down">
+      <lrm id="2">
+        <lrm_resources>
+          <lrm_resource id="rsc2" class="ocf" provider="pacemaker" type="Dummy">
+            <lrm_rsc_op id="rsc2_last_0" operation_key="rsc2_start_0" operation="start" crm-debug-origin="crm_simulate" crm_feature_set="3.10.2" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" last-rc-change="1623265189" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+  </status>
+</cib>

--- a/cts/cli/regression.crm_mon.exp
+++ b/cts/cli/regression.crm_mon.exp
@@ -3878,7 +3878,7 @@ Cluster Summary:
   * Last updated:
   * Last change:
   * 2 nodes configured
-  * 5 resource instances configured
+  * 7 resource instances configured
 
               *** Resource management is DISABLED ***
   The cluster will not attempt to start, stop or recover services
@@ -3894,6 +3894,9 @@ Active Resources:
   * Resource Group: exim-group (unmanaged):
     * Public-IP	(ocf:heartbeat:IPaddr):	 Started cluster01 (unmanaged)
     * Email	(lsb:exim):	 Started cluster02 (unmanaged)
+  * Clone Set: ping-clone [ping] (unmanaged):
+    * ping	(ocf:pacemaker:ping):	 Started cluster01 (unmanaged)
+    * ping	(ocf:pacemaker:ping):	 Started cluster02 (unmanaged)
 =#=#=#= End test: Text output of active resources on unmanaged nodes - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of active resources on unmanaged nodes
 =#=#=#= Begin test: Brief text output, with unmanaged nodes =#=#=#=
@@ -3903,7 +3906,7 @@ Cluster Summary:
   * Last updated:
   * Last change:
   * 2 nodes configured
-  * 5 resource instances configured
+  * 7 resource instances configured
 
               *** Resource management is DISABLED ***
   The cluster will not attempt to start, stop or recover services
@@ -3919,6 +3922,9 @@ Active Resources:
   * Resource Group: exim-group (unmanaged):
     * 1/1	(lsb:exim):	Active cluster02
     * 1/1	(ocf:heartbeat:IPaddr):	Active cluster01
+  * Clone Set: ping-clone [ping] (unmanaged):
+    * ping	(ocf:pacemaker:ping):	 Started cluster01 (unmanaged)
+    * ping	(ocf:pacemaker:ping):	 Started cluster02 (unmanaged)
 =#=#=#= End test: Brief text output, with unmanaged nodes - OK (0) =#=#=#=
 * Passed: crm_mon        - Brief text output, with unmanaged nodes
 =#=#=#= Begin test: XML output of active resources on unmanaged nodes =#=#=#=
@@ -3929,12 +3935,12 @@ Active Resources:
     <last_update time=""/>
     <last_change time=""/>
     <nodes_configured number="2"/>
-    <resources_configured number="5" disabled="0" blocked="0"/>
+    <resources_configured number="7" disabled="0" blocked="0"/>
     <cluster_options stonith-enabled="true" symmetric-cluster="true" no-quorum-policy="stop" maintenance-mode="true" stop-all-resources="false"/>
   </summary>
   <nodes>
-    <node name="cluster01" id="1" online="true" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="false" resources_running="3" type="member"/>
-    <node name="cluster02" id="2" online="false" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="false" is_dc="true" resources_running="2" type="member"/>
+    <node name="cluster01" id="1" online="true" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="false" resources_running="4" type="member"/>
+    <node name="cluster02" id="2" online="false" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="false" is_dc="true" resources_running="3" type="member"/>
   </nodes>
   <resources>
     <resource id="Fencing" resource_agent="stonith:fence_xvm" role="Started" active="true" orphaned="false" blocked="false" managed="false" failed="false" failure_ignored="false" nodes_running_on="1">
@@ -3954,18 +3960,29 @@ Active Resources:
         <node name="cluster02" id="2" cached="false"/>
       </resource>
     </group>
+    <clone id="ping-clone" multi_state="false" unique="false" managed="false" disabled="false" failed="false" failure_ignored="false">
+      <resource id="ping" resource_agent="ocf:pacemaker:ping" role="Started" active="true" orphaned="false" blocked="false" managed="false" failed="false" failure_ignored="false" nodes_running_on="1">
+        <node name="cluster01" id="1" cached="true"/>
+      </resource>
+      <resource id="ping" resource_agent="ocf:pacemaker:ping" role="Started" active="false" orphaned="false" blocked="false" managed="false" failed="false" failure_ignored="false" nodes_running_on="1">
+        <node name="cluster02" id="2" cached="false"/>
+      </resource>
+    </clone>
   </resources>
   <node_history>
     <node name="cluster01">
       <resource_history id="Fencing" orphan="false" migration-threshold="1000000">
         <operation_history call="2" task="start" rc="0" rc_text="ok" exec-time="0ms" queue-time="0ms"/>
         <operation_history call="3" task="monitor" rc="0" rc_text="ok" interval="60000ms" exec-time="0ms" queue-time="0ms"/>
-        <operation_history call="10" task="cancel" rc="0" rc_text="ok" interval="60000ms" exec-time="0ms" queue-time="0ms"/>
+        <operation_history call="12" task="cancel" rc="0" rc_text="ok" interval="60000ms" exec-time="0ms" queue-time="0ms"/>
       </resource_history>
       <resource_history id="rsc1" orphan="false" migration-threshold="1000000">
         <operation_history call="2" task="start" rc="0" rc_text="ok" exec-time="0ms" queue-time="0ms"/>
       </resource_history>
       <resource_history id="Public-IP" orphan="false" migration-threshold="1000000">
+        <operation_history call="1" task="start" rc="0" rc_text="ok" exec-time="0ms" queue-time="0ms"/>
+      </resource_history>
+      <resource_history id="ping" orphan="false" migration-threshold="1000000">
         <operation_history call="1" task="start" rc="0" rc_text="ok" exec-time="0ms" queue-time="0ms"/>
       </resource_history>
     </node>
@@ -3981,7 +3998,7 @@ Cluster Summary:
   * Last updated:
   * Last change:
   * 2 nodes configured
-  * 5 resource instances configured
+  * 7 resource instances configured
 
               *** Resource management is DISABLED ***
   The cluster will not attempt to start, stop or recover services
@@ -3991,11 +4008,13 @@ Node List:
     * Resources:
       * 1	(ocf:heartbeat:IPaddr):	Active 
       * 1	(ocf:pacemaker:Dummy):	Active 
+      * 1	(ocf:pacemaker:ping):	Active 
       * 1	(stonith:fence_xvm):	Active 
   * Node cluster02: OFFLINE:
     * Resources:
       * 1	(lsb:exim):	Active 
       * 1	(ocf:pacemaker:Dummy):	Active 
+      * 1	(ocf:pacemaker:ping):	Active 
 =#=#=#= End test: Brief text output grouped by node, with unmanaged nodes - OK (0) =#=#=#=
 * Passed: crm_mon        - Brief text output grouped by node, with unmanaged nodes
 =#=#=#= Begin test: Text output of all resources with maintenance-mode enabled =#=#=#=

--- a/cts/cli/regression.crm_mon.exp
+++ b/cts/cli/regression.crm_mon.exp
@@ -4022,6 +4022,8 @@ Full List of Resources:
   * Fencing	(stonith:fence_xvm):	 Started cluster01 (unmanaged)
   * dummy	(ocf:pacemaker:Dummy):	 Started cluster02 (unmanaged)
   * Clone Set: inactive-clone [inactive-dhcpd] (unmanaged) (disabled):
+    * inactive-dhcpd	(lsb:dhcpd):	 Stopped (disabled, unmanaged)
+    * inactive-dhcpd	(lsb:dhcpd):	 Stopped (disabled, unmanaged)
     * Stopped (disabled): [ cluster01 cluster02 ]
   * Resource Group: inactive-group (unmanaged) (disabled):
     * inactive-dummy-1	(ocf:pacemaker:Dummy):	 Stopped (disabled, unmanaged)
@@ -4038,8 +4040,17 @@ Full List of Resources:
       * mysql-proxy	(lsb:mysql-proxy):	 Started cluster02 (unmanaged)
     * Resource Group: mysql-group:1 (unmanaged):
       * mysql-proxy	(lsb:mysql-proxy):	 Started cluster01 (unmanaged)
+    * Resource Group: mysql-group:2 (unmanaged):
+      * mysql-proxy	(lsb:mysql-proxy):	 Stopped (unmanaged)
+    * Resource Group: mysql-group:3 (unmanaged):
+      * mysql-proxy	(lsb:mysql-proxy):	 Stopped (unmanaged)
+    * Resource Group: mysql-group:4 (unmanaged):
+      * mysql-proxy	(lsb:mysql-proxy):	 Stopped (unmanaged)
   * Clone Set: promotable-clone [promotable-rsc] (promotable) (unmanaged):
     * promotable-rsc	(ocf:pacemaker:Stateful):	 Promoted cluster02 (unmanaged)
     * promotable-rsc	(ocf:pacemaker:Stateful):	 Unpromoted cluster01 (unmanaged)
+    * promotable-rsc	(ocf:pacemaker:Stateful):	 Stopped (unmanaged)
+    * promotable-rsc	(ocf:pacemaker:Stateful):	 Stopped (unmanaged)
+    * promotable-rsc	(ocf:pacemaker:Stateful):	 Stopped (unmanaged)
 =#=#=#= End test: Text output of all resources with maintenance-mode enabled - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of all resources with maintenance-mode enabled

--- a/cts/cli/regression.crm_mon.exp
+++ b/cts/cli/regression.crm_mon.exp
@@ -3878,7 +3878,7 @@ Cluster Summary:
   * Last updated:
   * Last change:
   * 2 nodes configured
-  * 3 resource instances configured
+  * 5 resource instances configured
 
               *** Resource management is DISABLED ***
   The cluster will not attempt to start, stop or recover services
@@ -3891,6 +3891,9 @@ Active Resources:
   * Fencing	(stonith:fence_xvm):	 Started cluster01 (unmanaged)
   * rsc1	(ocf:pacemaker:Dummy):	 Started cluster01 (unmanaged)
   * rsc2	(ocf:pacemaker:Dummy):	 Started cluster02 (unmanaged)
+  * Resource Group: exim-group (unmanaged):
+    * Public-IP	(ocf:heartbeat:IPaddr):	 Started cluster01 (unmanaged)
+    * Email	(lsb:exim):	 Started cluster02 (unmanaged)
 =#=#=#= End test: Text output of active resources on unmanaged nodes - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of active resources on unmanaged nodes
 =#=#=#= Begin test: Brief text output, with unmanaged nodes =#=#=#=
@@ -3900,7 +3903,7 @@ Cluster Summary:
   * Last updated:
   * Last change:
   * 2 nodes configured
-  * 3 resource instances configured
+  * 5 resource instances configured
 
               *** Resource management is DISABLED ***
   The cluster will not attempt to start, stop or recover services
@@ -3913,6 +3916,9 @@ Active Resources:
   * 1	(ocf:pacemaker:Dummy):	Active cluster02
   * 1	(ocf:pacemaker:Dummy):	Active cluster01
   * 1	(stonith:fence_xvm):	Active cluster01
+  * Resource Group: exim-group (unmanaged):
+    * 1/1	(lsb:exim):	Active cluster02
+    * 1/1	(ocf:heartbeat:IPaddr):	Active cluster01
 =#=#=#= End test: Brief text output, with unmanaged nodes - OK (0) =#=#=#=
 * Passed: crm_mon        - Brief text output, with unmanaged nodes
 =#=#=#= Begin test: XML output of active resources on unmanaged nodes =#=#=#=
@@ -3923,12 +3929,12 @@ Active Resources:
     <last_update time=""/>
     <last_change time=""/>
     <nodes_configured number="2"/>
-    <resources_configured number="3" disabled="0" blocked="0"/>
+    <resources_configured number="5" disabled="0" blocked="0"/>
     <cluster_options stonith-enabled="true" symmetric-cluster="true" no-quorum-policy="stop" maintenance-mode="true" stop-all-resources="false"/>
   </summary>
   <nodes>
-    <node name="cluster01" id="1" online="true" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="false" resources_running="2" type="member"/>
-    <node name="cluster02" id="2" online="false" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="false" is_dc="true" resources_running="1" type="member"/>
+    <node name="cluster01" id="1" online="true" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="false" resources_running="3" type="member"/>
+    <node name="cluster02" id="2" online="false" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="false" is_dc="true" resources_running="2" type="member"/>
   </nodes>
   <resources>
     <resource id="Fencing" resource_agent="stonith:fence_xvm" role="Started" active="true" orphaned="false" blocked="false" managed="false" failed="false" failure_ignored="false" nodes_running_on="1">
@@ -3940,16 +3946,27 @@ Active Resources:
     <resource id="rsc2" resource_agent="ocf:pacemaker:Dummy" role="Started" active="false" orphaned="false" blocked="false" managed="false" failed="false" failure_ignored="false" nodes_running_on="1">
       <node name="cluster02" id="2" cached="false"/>
     </resource>
+    <group id="exim-group" number_resources="2" managed="false" disabled="false">
+      <resource id="Public-IP" resource_agent="ocf:heartbeat:IPaddr" role="Started" active="true" orphaned="false" blocked="false" managed="false" failed="false" failure_ignored="false" nodes_running_on="1">
+        <node name="cluster01" id="1" cached="true"/>
+      </resource>
+      <resource id="Email" resource_agent="lsb:exim" role="Started" active="false" orphaned="false" blocked="false" managed="false" failed="false" failure_ignored="false" nodes_running_on="1">
+        <node name="cluster02" id="2" cached="false"/>
+      </resource>
+    </group>
   </resources>
   <node_history>
     <node name="cluster01">
       <resource_history id="Fencing" orphan="false" migration-threshold="1000000">
         <operation_history call="2" task="start" rc="0" rc_text="ok" exec-time="0ms" queue-time="0ms"/>
         <operation_history call="3" task="monitor" rc="0" rc_text="ok" interval="60000ms" exec-time="0ms" queue-time="0ms"/>
-        <operation_history call="4" task="cancel" rc="0" rc_text="ok" interval="60000ms" exec-time="0ms" queue-time="0ms"/>
+        <operation_history call="10" task="cancel" rc="0" rc_text="ok" interval="60000ms" exec-time="0ms" queue-time="0ms"/>
       </resource_history>
       <resource_history id="rsc1" orphan="false" migration-threshold="1000000">
         <operation_history call="2" task="start" rc="0" rc_text="ok" exec-time="0ms" queue-time="0ms"/>
+      </resource_history>
+      <resource_history id="Public-IP" orphan="false" migration-threshold="1000000">
+        <operation_history call="1" task="start" rc="0" rc_text="ok" exec-time="0ms" queue-time="0ms"/>
       </resource_history>
     </node>
   </node_history>
@@ -3964,7 +3981,7 @@ Cluster Summary:
   * Last updated:
   * Last change:
   * 2 nodes configured
-  * 3 resource instances configured
+  * 5 resource instances configured
 
               *** Resource management is DISABLED ***
   The cluster will not attempt to start, stop or recover services
@@ -3972,10 +3989,12 @@ Cluster Summary:
 Node List:
   * Node cluster01: online:
     * Resources:
+      * 1	(ocf:heartbeat:IPaddr):	Active 
       * 1	(ocf:pacemaker:Dummy):	Active 
       * 1	(stonith:fence_xvm):	Active 
   * Node cluster02: OFFLINE:
     * Resources:
+      * 1	(lsb:exim):	Active 
       * 1	(ocf:pacemaker:Dummy):	Active 
 =#=#=#= End test: Brief text output grouped by node, with unmanaged nodes - OK (0) =#=#=#=
 * Passed: crm_mon        - Brief text output grouped by node, with unmanaged nodes

--- a/cts/cli/regression.crm_mon.exp
+++ b/cts/cli/regression.crm_mon.exp
@@ -3871,6 +3871,114 @@ Full List of Resources:
 </pacemaker-result>
 =#=#=#= End test: Text output of partially active resources, filtered by node - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of partially active resources, filtered by node
+=#=#=#= Begin test: Text output of active resources on unmanaged nodes =#=#=#=
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: cluster02 (version) - partition with quorum
+  * Last updated:
+  * Last change:
+  * 2 nodes configured
+  * 3 resource instances configured
+
+              *** Resource management is DISABLED ***
+  The cluster will not attempt to start, stop or recover services
+
+Node List:
+  * Online: [ cluster01 ]
+  * OFFLINE: [ cluster02 ]
+
+Active Resources:
+  * Fencing	(stonith:fence_xvm):	 Started cluster01 (unmanaged)
+  * rsc1	(ocf:pacemaker:Dummy):	 Started cluster01 (unmanaged)
+  * rsc2	(ocf:pacemaker:Dummy):	 Started cluster02 (unmanaged)
+=#=#=#= End test: Text output of active resources on unmanaged nodes - OK (0) =#=#=#=
+* Passed: crm_mon        - Text output of active resources on unmanaged nodes
+=#=#=#= Begin test: Brief text output, with unmanaged nodes =#=#=#=
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: cluster02 (version) - partition with quorum
+  * Last updated:
+  * Last change:
+  * 2 nodes configured
+  * 3 resource instances configured
+
+              *** Resource management is DISABLED ***
+  The cluster will not attempt to start, stop or recover services
+
+Node List:
+  * Online: [ cluster01 ]
+  * OFFLINE: [ cluster02 ]
+
+Active Resources:
+  * 1	(ocf:pacemaker:Dummy):	Active cluster02
+  * 1	(ocf:pacemaker:Dummy):	Active cluster01
+  * 1	(stonith:fence_xvm):	Active cluster01
+=#=#=#= End test: Brief text output, with unmanaged nodes - OK (0) =#=#=#=
+* Passed: crm_mon        - Brief text output, with unmanaged nodes
+=#=#=#= Begin test: XML output of active resources on unmanaged nodes =#=#=#=
+<pacemaker-result api-version="X" request="crm_mon -1 --output-as=xml">
+  <summary>
+    <stack type="corosync"/>
+    <current_dc present="true" version="" with_quorum="true"/>
+    <last_update time=""/>
+    <last_change time=""/>
+    <nodes_configured number="2"/>
+    <resources_configured number="3" disabled="0" blocked="0"/>
+    <cluster_options stonith-enabled="true" symmetric-cluster="true" no-quorum-policy="stop" maintenance-mode="true" stop-all-resources="false"/>
+  </summary>
+  <nodes>
+    <node name="cluster01" id="1" online="true" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="false" resources_running="2" type="member"/>
+    <node name="cluster02" id="2" online="false" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="false" is_dc="true" resources_running="1" type="member"/>
+  </nodes>
+  <resources>
+    <resource id="Fencing" resource_agent="stonith:fence_xvm" role="Started" active="true" orphaned="false" blocked="false" managed="false" failed="false" failure_ignored="false" nodes_running_on="1">
+      <node name="cluster01" id="1" cached="true"/>
+    </resource>
+    <resource id="rsc1" resource_agent="ocf:pacemaker:Dummy" role="Started" active="true" orphaned="false" blocked="false" managed="false" failed="false" failure_ignored="false" nodes_running_on="1">
+      <node name="cluster01" id="1" cached="true"/>
+    </resource>
+    <resource id="rsc2" resource_agent="ocf:pacemaker:Dummy" role="Started" active="false" orphaned="false" blocked="false" managed="false" failed="false" failure_ignored="false" nodes_running_on="1">
+      <node name="cluster02" id="2" cached="false"/>
+    </resource>
+  </resources>
+  <node_history>
+    <node name="cluster01">
+      <resource_history id="Fencing" orphan="false" migration-threshold="1000000">
+        <operation_history call="2" task="start" rc="0" rc_text="ok" exec-time="0ms" queue-time="0ms"/>
+        <operation_history call="3" task="monitor" rc="0" rc_text="ok" interval="60000ms" exec-time="0ms" queue-time="0ms"/>
+        <operation_history call="4" task="cancel" rc="0" rc_text="ok" interval="60000ms" exec-time="0ms" queue-time="0ms"/>
+      </resource_history>
+      <resource_history id="rsc1" orphan="false" migration-threshold="1000000">
+        <operation_history call="2" task="start" rc="0" rc_text="ok" exec-time="0ms" queue-time="0ms"/>
+      </resource_history>
+    </node>
+  </node_history>
+  <status code="0" message="OK"/>
+</pacemaker-result>
+=#=#=#= End test: XML output of active resources on unmanaged nodes - OK (0) =#=#=#=
+* Passed: crm_mon        - XML output of active resources on unmanaged nodes
+=#=#=#= Begin test: Brief text output grouped by node, with unmanaged nodes =#=#=#=
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: cluster02 (version) - partition with quorum
+  * Last updated:
+  * Last change:
+  * 2 nodes configured
+  * 3 resource instances configured
+
+              *** Resource management is DISABLED ***
+  The cluster will not attempt to start, stop or recover services
+
+Node List:
+  * Node cluster01: online:
+    * Resources:
+      * 1	(ocf:pacemaker:Dummy):	Active 
+      * 1	(stonith:fence_xvm):	Active 
+  * Node cluster02: OFFLINE:
+    * Resources:
+      * 1	(ocf:pacemaker:Dummy):	Active 
+=#=#=#= End test: Brief text output grouped by node, with unmanaged nodes - OK (0) =#=#=#=
+* Passed: crm_mon        - Brief text output grouped by node, with unmanaged nodes
 =#=#=#= Begin test: Text output of all resources with maintenance-mode enabled =#=#=#=
 Cluster Summary:
   * Stack: corosync

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -419,6 +419,28 @@ function test_crm_mon() {
 
     unset CIB_file
 
+    export CIB_file="$test_home/cli/crm_mon-unmanaged.xml"
+
+    desc="Text output of active resources on unmanaged nodes"
+    cmd="crm_mon -1"
+    test_assert $CRM_EX_OK 0
+
+    desc="Brief text output, with unmanaged nodes"
+    cmd="crm_mon -1 --brief"
+    test_assert $CRM_EX_OK 0
+
+    # XML does not have a brief output option
+
+    desc="XML output of active resources on unmanaged nodes"
+    cmd="crm_mon -1 --output-as=xml"
+    test_assert $CRM_EX_OK 0
+
+    desc="Brief text output grouped by node, with unmanaged nodes"
+    cmd="crm_mon -1 --group-by-node --brief"
+    test_assert $CRM_EX_OK 0
+
+    unset CIB_file
+
     export CIB_file=$(mktemp ${TMPDIR:-/tmp}/cts-cli.crm_mon.xml.XXXXXXXXXX)
     sed -e '/maintenance-mode/ s/false/true/' "$test_home/cli/crm_mon.xml" > $CIB_file
 

--- a/cts/scheduler/summary/promoted-unmanaged-monitor.summary
+++ b/cts/scheduler/summary/promoted-unmanaged-monitor.summary
@@ -4,6 +4,10 @@ Current cluster status:
 
   * Full List of Resources:
     * Clone Set: Fencing [FencingChild] (unmanaged):
+      * FencingChild	(stonith:fence_xvm):	 Stopped (unmanaged)
+      * FencingChild	(stonith:fence_xvm):	 Stopped (unmanaged)
+      * FencingChild	(stonith:fence_xvm):	 Stopped (unmanaged)
+      * FencingChild	(stonith:fence_xvm):	 Stopped (unmanaged)
       * Stopped: [ pcmk-1 pcmk-2 pcmk-3 pcmk-4 ]
     * Resource Group: group-1 (unmanaged):
       * r192.168.122.112	(ocf:heartbeat:IPaddr):	 Started pcmk-3 (unmanaged)
@@ -24,6 +28,7 @@ Current cluster status:
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-2 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Promoted pcmk-3 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-4 (unmanaged)
+      * stateful-1	(ocf:pacemaker:Stateful):	 Stopped (unmanaged)
       * Stopped: [ pcmk-1 ]
 
 Transition Summary:
@@ -46,6 +51,10 @@ Revised Cluster Status:
 
   * Full List of Resources:
     * Clone Set: Fencing [FencingChild] (unmanaged):
+      * FencingChild	(stonith:fence_xvm):	 Stopped (unmanaged)
+      * FencingChild	(stonith:fence_xvm):	 Stopped (unmanaged)
+      * FencingChild	(stonith:fence_xvm):	 Stopped (unmanaged)
+      * FencingChild	(stonith:fence_xvm):	 Stopped (unmanaged)
       * Stopped: [ pcmk-1 pcmk-2 pcmk-3 pcmk-4 ]
     * Resource Group: group-1 (unmanaged):
       * r192.168.122.112	(ocf:heartbeat:IPaddr):	 Started pcmk-3 (unmanaged)
@@ -66,4 +75,5 @@ Revised Cluster Status:
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-2 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Promoted pcmk-3 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-4 (unmanaged)
+      * stateful-1	(ocf:pacemaker:Stateful):	 Stopped (unmanaged)
       * Stopped: [ pcmk-1 ]

--- a/cts/scheduler/summary/unmanaged-promoted.summary
+++ b/cts/scheduler/summary/unmanaged-promoted.summary
@@ -5,6 +5,8 @@ Current cluster status:
 
   * Full List of Resources:
     * Clone Set: Fencing [FencingChild] (unmanaged):
+      * FencingChild	(stonith:fence_xvm):	 Started pcmk-3 (unmanaged)
+      * FencingChild	(stonith:fence_xvm):	 Started pcmk-4 (unmanaged)
       * FencingChild	(stonith:fence_xvm):	 Started pcmk-2 (unmanaged)
       * FencingChild	(stonith:fence_xvm):	 Started pcmk-1 (unmanaged)
       * Stopped: [ pcmk-3 pcmk-4 ]
@@ -19,10 +21,14 @@ Current cluster status:
     * lsb-dummy	(lsb:/usr/share/pacemaker/tests/cts/LSBDummy):	 Started pcmk-2 (unmanaged)
     * migrator	(ocf:pacemaker:Dummy):	 Started pcmk-4 (unmanaged)
     * Clone Set: Connectivity [ping-1] (unmanaged):
+      * ping-1	(ocf:pacemaker:ping):	 Started pcmk-3 (unmanaged)
+      * ping-1	(ocf:pacemaker:ping):	 Started pcmk-4 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-2 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-1 (unmanaged)
       * Stopped: [ pcmk-3 pcmk-4 ]
     * Clone Set: master-1 [stateful-1] (promotable) (unmanaged):
+      * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-3 (unmanaged)
+      * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-4 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Promoted pcmk-2 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-1 (unmanaged)
       * Stopped: [ pcmk-3 pcmk-4 ]
@@ -40,6 +46,8 @@ Revised Cluster Status:
 
   * Full List of Resources:
     * Clone Set: Fencing [FencingChild] (unmanaged):
+      * FencingChild	(stonith:fence_xvm):	 Started pcmk-3 (unmanaged)
+      * FencingChild	(stonith:fence_xvm):	 Started pcmk-4 (unmanaged)
       * FencingChild	(stonith:fence_xvm):	 Started pcmk-2 (unmanaged)
       * FencingChild	(stonith:fence_xvm):	 Started pcmk-1 (unmanaged)
       * Stopped: [ pcmk-3 pcmk-4 ]
@@ -54,10 +62,14 @@ Revised Cluster Status:
     * lsb-dummy	(lsb:/usr/share/pacemaker/tests/cts/LSBDummy):	 Started pcmk-2 (unmanaged)
     * migrator	(ocf:pacemaker:Dummy):	 Started pcmk-4 (unmanaged)
     * Clone Set: Connectivity [ping-1] (unmanaged):
+      * ping-1	(ocf:pacemaker:ping):	 Started pcmk-3 (unmanaged)
+      * ping-1	(ocf:pacemaker:ping):	 Started pcmk-4 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-2 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-1 (unmanaged)
       * Stopped: [ pcmk-3 pcmk-4 ]
     * Clone Set: master-1 [stateful-1] (promotable) (unmanaged):
+      * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-3 (unmanaged)
+      * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-4 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Promoted pcmk-2 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-1 (unmanaged)
       * Stopped: [ pcmk-3 pcmk-4 ]

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -975,7 +975,8 @@ pe__clone_text(pcmk__output_t *out, va_list args)
             // Print individual instance when non-probe action is pending
             print_full = TRUE;
 
-        } else if (partially_active == FALSE) {
+        } else if (partially_active == FALSE
+                   && pcmk_is_set(child_rsc->flags, pe_rsc_managed)) {
             // List stopped instances when requested (except orphans)
             if (!pcmk_is_set(child_rsc->flags, pe_rsc_orphan)
                 && pcmk_is_set(show_opts, pcmk_show_inactive_rscs)) {

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -1147,7 +1147,8 @@ get_rscs_brief(GList *rsc_list, GHashTable * rsc_table, GHashTable * active_tabl
                 pe_node_t *node = (pe_node_t *) gIter2->data;
                 GHashTable *node_table = NULL;
 
-                if (node->details->unclean == FALSE && node->details->online == FALSE) {
+                if (node->details->unclean == FALSE && node->details->online == FALSE &&
+                    pcmk_is_set(rsc->flags, pe_rsc_managed)) {
                     continue;
                 }
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -2386,7 +2386,13 @@ resource_list(pcmk__output_t *out, va_list args)
         /* Skip resources that aren't at least partially active,
          * unless we're displaying inactive resources
          */
-        } else if (!partially_active && !pcmk_is_set(show_opts, pcmk_show_inactive_rscs)) {
+        /* Skip resources that aren't at least partially active, unless
+         * we're displaying inactive resources or the resource is on an
+         * unmanaged node.  The latter should be shown without having to
+         * request inactive resources.
+         */
+        } else if (pcmk_is_set(rsc->flags, pe_rsc_managed) && !partially_active &&
+                   !pcmk_is_set(show_opts, pcmk_show_inactive_rscs)) {
             continue;
 
         } else if (partially_active && !pe__rsc_running_on_any_node_in_list(rsc, only_node)) {


### PR DESCRIPTION
The primitive and group resources look good following these patches.  Clone resources I am much less sure about, especially the regression test changes in 418fd6b.  For the most part, the extra resources displayed duplicate the Stopped lists.  I think I can get rid of those lists in these cases, but I'm not sure what the right direction to go is here.

I also still need to do some more checking for other places where these resources could be a problem.  There's not tons of spots, and a lot of them I've already ruled out, but it's worth going back through again.