### PR TITLE
Feature: support debugging of timed out resource agents

### DIFF
--- a/etc/sysconfig/pacemaker
+++ b/etc/sysconfig/pacemaker
@@ -58,6 +58,15 @@
 # as for PCMK_debug above.
 # PCMK_blackbox=no
 
+# Debug a RA (resource agent) that is about to be terminated due to timeout.
+# This should point to an executable or script that you wish to run just before the
+# RA hierarchy spawned from pacemaker-execd is killed. The script should run in as short a time
+# as possible because its execution will block pacemaker-execd whilst it runs. It
+# only runs prior to a timeout.  You will need to restart the cluster to enable this the first time.
+# Simply rename the script or make it non-executable if you don't need it to run any more, no
+# need to reconfigure here or restart pacemaker once it has been initially enabled.
+# PCMK_timedoutRA=/root/debugRA.sh
+
 #==#==# Advanced use only
 
 # By default, nodes will join the cluster in an online state when they first

--- a/extra/debugRA.sh
+++ b/extra/debugRA.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+
+### main script
+
+pid=$1
+
+logdir=/root
+now=$(date '+%Y%m%d_%H%M%S')
+log=$logdir/ra-debug_${now}.log
+
+exec > $log
+exec 2>&1
+
+echo "Started: $(date '+%s.%N')"
+echo "Passed pid $pid"
+
+ps -o uid,ruid,pid,ppid,pgid,sess,state,tty,psr,pcpu,etimes,cputime,wchan,args  -He
+
+for p in $(pgrep -g $pid)
+do
+         echo "======================"
+         echo "Getting user stack for pid $p $(</proc/$p/comm)"
+         gstack $p
+         echo "Getting kernel stack for pid $p"
+         cat /proc/$p/stack
+done
+
+echo "Finished: $(date '+%s.%N')"
+exit 0
+


### PR DESCRIPTION

This is a supportability/debug feature request to help with diagnosing unexpected RA (resource agent) timeouts. Cases involving RA timeouts are one of our most commonly reported problems. Unfortunately there is no easy way to troubleshoot these especially if they are not readily repeatable/reproducible.  This changeset adds functionality in to pacemaker such that a configurable external program/script can be executed just before pacemaker terminates the RA monitor hierarchy.  The sample debugRA.sh script gathers ps information along with user/kernel stack-traces of all the processes in the hierarchy in the hope that it will give clues as to why the RA did not complete in the allotted time.  Being an external script means that it is easily customised to perform other data gathering steps.

Pacemaker Alerts were considered and tested, however these are not synchronised to the termination of the RA process hierarchy so that by the time they run the problem processes have already disappeared.

The changes were actually tested in SLES15.1 with pacemaker-2.0.1 with a modified version of the ip(1) command (employed by Ipaddr2 RA). The modification permits a user injectable delay which will invoke the timeout function to execute.



Test Results

```
B4609009D:~ # ll -rt ra-d*
-rw-r----- 1 root root  95816 Apr 26 11:36 ra-debug_20210426_113614.log
-rw-r----- 1 root root 104251 Apr 26 12:03 ra-debug_20210426_120314.log
-rw-r----- 1 root root 104251 Apr 27 05:11 ra-debug_20210427_051100.log
B4609009D:~ #


B4609009D:~ # cat ra-deb*
Started: 1619451374.146883177
Passed pid 5710
   UID  RUID   PID  PPID  PGID  SESS S TT       PSR %CPU ELAPSED WCHAN  COMMAND
     0     0     2     0     0     0 S ?          7  0.0  347070 -      [kthreadd]
     0     0     4     2     0     0 S ?          0  0.0  347070 -        [kworker/0:0H]
     0     0     7     2     0     0 S ?          0  0.0  347070 -        [mm_percpu_wq]
........

     0     0 69500     1 69500 69500 S ?         16  0.3   10472 SyS_ep   corosync
     0     0 69506     1 69506 69506 S ?         62  0.0   10471 SyS_po   /usr/sbin/pacemakerd -f
    90    90 69507 69506 69507 69507 S ?         19  0.0   10471 SyS_po     /usr/lib/pacemaker/pacemaker-based
     0     0 69508 69506 69508 69508 S ?         12  0.0   10471 SyS_po     /usr/lib/pacemaker/pacemaker-fenced
     0     0 69509 69506 69509 69509 S ?         58  0.0   10471 -          /usr/lib/pacemaker/pacemaker-execd
     0     0  5710 69509  5710 69509 S ?         46  0.0      20 -            /bin/sh /usr/lib/ocf/resource.d/heartbeat/IPaddr2 monitor
     0     0  5722  5710  5710 69509 S ?         65  0.0      20 -              /bin/sh /usr/lib/ocf/resource.d/heartbeat/IPaddr2 monitor
     0     0  5725  5722  5710 69509 S ?          1  0.0      20 -                /bin/sh /usr/lib/ocf/resource.d/heartbeat/IPaddr2 monitor
     0     0  5726  5725  5710 69509 S ?         59  0.0      20 -                  ip -o -f inet route list match 192.168.1.5/24 scope link
     0     0  5727  5725  5710 69509 S ?         61  0.0      20 -                  awk BEGIN{best=0} /\// { mask=$1; sub(".*/", "", mask); if( int(mask)>=best ) { best=int(mask); best_ln=$0; } } END{print best_ln}
     0     0  5887 69509 69509 69509 S ?         15  0.0       0 -            /bin/sh /root/debugRA.sh 5710
     0     0  5890  5887 69509 69509 R ?         60  300       0 -              ps -o uid,ruid,pid,ppid,pgid,sess,state,tty,psr,pcpu,etimes,wchan,args -He
    90    90 69510 69506 69510 69510 S ?         44  0.0   10471 SyS_po     /usr/lib/pacemaker/pacemaker-attrd
    90    90 69511 69506 69511 69511 S ?         74  0.0   10471 SyS_po     /usr/lib/pacemaker/pacemaker-schedulerd
    90    90 69512 69506 69512 69512 S ?         48  0.0   10471 SyS_po     /usr/lib/pacemaker/pacemaker-controld
======================
Getting user stack for pid 5710 IPaddr2
#0  0x00007f5d935e6c61 in read () from /lib64/libc.so.6
#1  0x000055f7d7c599d5 in zread ()
#2  0x000055f7d7c472e1 in command_substitute ()
#3  0x000055f7d7c3f1c8 in ?? ()
#4  0x000055f7d7c41867 in ?? ()
#5  0x000055f7d7c409b4 in ?? ()
#6  0x000055f7d7c2c7a5 in ?? ()
#7  0x000055f7d7c2b3bd in execute_command_internal ()

.........

======================
Getting user stack for pid 5726 ip
#0  0x00007fbda12710c1 in nanosleep () from /lib64/libc.so.6
#1  0x00007fbda1270ffa in sleep () from /lib64/libc.so.6
#2  0x0000000000415085 in iproute_list_flush_or_save (argc=<optimized out>, argc@entry=4, argv=<optimized out>, argv@entry=0x7ffe90b38d68, action=action@entry=0) at iproute.c:1481
#3  0x000000000041590b in do_iproute (argc=5, argv=0x7ffe90b38d60) at iproute.c:2008
#4  0x0000000000409f4c in do_cmd (argv0=0x7ffe90b399e3 "route", argc=6, argv=0x7ffe90b38d58) at ip.c:115
#5  0x0000000000409a15 in main (argc=7, argv=0x7ffe90b38d50) at ip.c:305
Getting kernel stack for pid 5726
[<ffffffff86003ae4>] do_syscall_64+0x74/0x150
[<ffffffff8680009a>] entry_SYSCALL_64_after_hwframe+0x3d/0xa2
[<ffffffffffffffff>] 0xffffffffffffffff
======================
Getting user stack for pid 5727 awk
#0  0x00007feaca6fdc61 in read () from /lib64/libc.so.6
#1  0x000055a9cf35506e in ?? ()
#2  0x000055a9cf355968 in ?? ()
#3  0x000055a9cf342e6e in ?? ()
#4  0x000055a9cf3108a0 in ?? ()
#5  0x00007feaca634f8a in __libc_start_main () from /lib64/libc.so.6
#6  0x000055a9cf310bfa in ?? ()
Getting kernel stack for pid 5727
[<ffffffff8626241c>] pipe_wait+0x5c/0x90
[<ffffffff86262a9c>] pipe_read+0x20c/0x2e0
[<ffffffff86257cdb>] __vfs_read+0xdb/0x140
[<ffffffff86259069>] vfs_read+0x89/0x130
[<ffffffff8625a612>] SyS_read+0x42/0x90
[<ffffffff86003ae4>] do_syscall_64+0x74/0x150
[<ffffffff8680009a>] entry_SYSCALL_64_after_hwframe+0x3d/0xa2
[<ffffffffffffffff>] 0xffffffffffffffff
Finished: 1619451374.994192164
B4609009D:~ #
```



Keep the run time short, less than a second here:

```
B4609009D:~ # grep -e Star -e Fini ra-debug_20210426_113614.log
Started: 1619451374.146883177
Finished: 1619451374.994192164
B4609009D:~ #

```

