### PR TITLE
Purge remote node attribute when the node is up.

### DIFF
--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -192,6 +192,9 @@ remote_node_up(const char *node_name)
     if (controld_shutdown_lock_enabled) {
         section = controld_section_all_unlocked;
     }
+    /* Purge node from attrd's memory */
+    update_attrd_remote_node_removed(node_name, NULL);
+
     controld_delete_node_state(node_name, section, call_opt);
 
     /* Clear node's probed attribute */
@@ -1086,7 +1089,7 @@ handle_dup:
         recurring_helper(cmd);
     }
 
-    return cmd;  
+    return cmd;
 }
 
 int


### PR DESCRIPTION
When a remote node is up again after being killed, cleans the attrd's cache for the node. This is necessary to ensure that the CIB and the attrd cache will match. Otherwise, when the node is up the cache will be populated with the values from other nodes (e.g. transient attributes) and the attributes will be clean from the CIB. Causing a discrepancy among these data sources.

How to reproduce the issue:

0. Setup a cluster with 3 nodes. In the third node add two remote nodes. In this example, let's call the remote nodes as `ionian` and `aeolian`.
1.  On the DC node (make sure it is either node1 or node2), check that we don't have any transient node attributes defined for the remote nodes:
`cibadmin --query | python3 -c 'import sys; import xml.etree.ElementTree as ET; tree=ET.parse(sys.stdin); [ET.dump(e) for e in tree.getroot().findall("./status/node_state/transient_attributes") if "ionian" in e.attrib["id"] or "aeolian" in e.attrib["id"]]'`
2. On node3, set an arbitrary transient node attribute for ionian:
`nsenter -a -t $(systemctl show pacemaker_remote@ionian.service --property=ExecMainPID | cut -f2 -d=) crm_attribute --lifetime forever -l reboot -N ionian -n foo -v bar`

3. On the DC node, check that the attribute appears in the CIB:
`cibadmin --query | python3 -c 'import sys; import xml.etree.ElementTree as ET; tree=ET.parse(sys.stdin); [ET.dump(e) for e in tree.getroot().findall("./status/node_state/transient_attributes") if "ionian" in e.attrib["id"] or "aeolian" in e.attrib["id"]]'`

4. Kill corosync and pacemaker on node3:
```
systemctl kill corosync
systemctl kill pacemaker
systemctl stop corosync
systemctl stop pacemaker
```

5. On the DC, check that the value is still in CIB:
`cibadmin --query | python3 -c 'import sys; import xml.etree.ElementTree as ET; tree=ET.parse(sys.stdin); [ET.dump(e) for e in tree.getroot().findall("./status/node_state/transient_attributes") if "ionian" in e.attrib["id"] or "aeolian" in e.attrib["id"]]'`

6. Put a shutdown attribute for aeolian on the DC node:
`crm_attribute --lifetime forever -l reboot -N aeolian -n shutdown -v $(($(date +%s) - 180))`

7. Start corosync and pacemaker on node3
`systemctl start corosync pacemaker`

8. At this point, the values that are being set previously will disappear from CIB. We can check that on the DC node:
`cibadmin --query | python3 -c 'import sys; import xml.etree.ElementTree as ET; tree=ET.parse(sys.stdin); [ET.dump(e) for e in tree.getroot().findall("./status/node_state/transient_attributes") if "ionian" in e.attrib["id"] or "aeolian" in e.attrib["id"]]'`

9. However, when we started Pacemaker on node3 node, the pacemaker-attrd component learnt and stored those previous attributes in its cache. 
Let's try to set the same node attribute again for ionian on node3:
`nsenter -a -t $(systemctl show pacemaker_remote@ionian.service --property=ExecMainPID | cut -f2 -d=) crm_attribute --lifetime forever -l reboot -N ionian -n foo -v bar`

10. The attribute update won't reach the CIB, because pacemaker-attrd thinks it is already being set. 
We can confirm that by checking CIB on the first node:
`cibadmin --query | python3 -c 'import sys; import xml.etree.ElementTree as ET; tree=ET.parse(sys.stdin); [ET.dump(e) for e in tree.getroot().findall("./status/node_state/transient_attributes") if "ionian" in e.attrib["id"] or "aeolian" in e.attrib["id"]]'`

11. This inconsistency can be seen when we try to query the value with different tools (on node3):
According to the implementation, the crm_attribute goes directly to CIB when it comes to querying an attribute:
```
nsenter -a -t $(systemctl show pacemaker_remote@ionian.service --property=ExecMainPID | cut -f2 -d=) crm_attribute --lifetime forever -l reboot -N ionian -n foo -G
scope=status  name=foo value=(null)
Error performing operation: No such device or address
```
Meanwhile, attrd_updater uses the cache:
```
nsenter -a -t $(systemctl show pacemaker_remote@ionian.service --property=ExecMainPID | cut -f2 -d=) attrd_updater -n foo -Q
name="foo" host="ionian" value="bar"
```