### PR TITLE
Help attribute manager learn node "remoteness" more quickly

### DIFF
--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -972,6 +972,7 @@ attrd_election_cb(gpointer user_data)
     return FALSE;
 }
 
+#define state_text(state) ((state)? (const char *)(state) : "in unknown state")
 
 void
 attrd_peer_change_cb(enum crm_status_type kind, crm_node_t *peer, const void *data)
@@ -981,15 +982,23 @@ attrd_peer_change_cb(enum crm_status_type kind, crm_node_t *peer, const void *da
 
     switch (kind) {
         case crm_status_uname:
+            crm_debug("%s node %s is now %s",
+                      (is_remote? "Remote" : "Cluster"),
+                      peer->uname, state_text(peer->state));
             break;
 
         case crm_status_processes:
             if (!pcmk_is_set(peer->processes, crm_get_cluster_proc())) {
                 gone = true;
             }
+            crm_debug("Node %s is %s a peer",
+                      peer->uname, (gone? "no longer" : "now"));
             break;
 
         case crm_status_nstate:
+            crm_debug("%s node %s is now %s (was %s)",
+                      (is_remote? "Remote" : "Cluster"),
+                      peer->uname, state_text(peer->state), state_text(data));
             if (pcmk__str_eq(peer->state, CRM_NODE_MEMBER, pcmk__str_casei)) {
                 /* If we're the writer, send new peers a list of all attributes
                  * (unless it's a remote node, which doesn't run its own attrd)

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -43,8 +43,9 @@
  *     1       1.1.15   PCMK__ATTRD_CMD_UPDATE_BOTH,
  *                      PCMK__ATTRD_CMD_UPDATE_DELAY
  *     2       1.1.17   PCMK__ATTRD_CMD_CLEAR_FAILURE
+ *     3       2.1.1    PCMK__ATTRD_CMD_SYNC_RESPONSE indicates remote nodes
  */
-#define ATTRD_PROTOCOL_VERSION "2"
+#define ATTRD_PROTOCOL_VERSION "3"
 
 int last_cib_op_done = 0;
 GHashTable *attributes = NULL;
@@ -149,6 +150,9 @@ add_attribute_value_xml(xmlNode *parent, attribute_t *a, attribute_value_t *v,
     crm_xml_add(xml, PCMK__XA_ATTR_NODE_NAME, v->nodename);
     if (v->nodeid > 0) {
         crm_xml_add_int(xml, PCMK__XA_ATTR_NODE_ID, v->nodeid);
+    }
+    if (v->is_remote != 0) {
+        crm_xml_add_int(xml, PCMK__XA_ATTR_IS_REMOTE, 1);
     }
     crm_xml_add(xml, PCMK__XA_ATTR_VALUE, v->current);
     crm_xml_add_int(xml, PCMK__XA_ATTR_DAMPENING, a->timeout_ms / 1000);

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -136,7 +136,9 @@ build_attribute_xml(
     crm_xml_add(xml, PCMK__XA_ATTR_UUID, uuid);
     crm_xml_add(xml, PCMK__XA_ATTR_USER, user);
     crm_xml_add(xml, PCMK__XA_ATTR_NODE_NAME, peer);
-    crm_xml_add_int(xml, PCMK__XA_ATTR_NODE_ID, peerid);
+    if (peerid > 0) {
+        crm_xml_add_int(xml, PCMK__XA_ATTR_NODE_ID, peerid);
+    }
     crm_xml_add(xml, PCMK__XA_ATTR_VALUE, value);
     crm_xml_add_int(xml, PCMK__XA_ATTR_DAMPENING, timeout_ms/1000);
     crm_xml_add_int(xml, PCMK__XA_ATTR_IS_PRIVATE, is_private);
@@ -937,7 +939,7 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
     /* If this is a cluster node whose node ID we are learning, remember it */
     if ((v->nodeid == 0) && (v->is_remote == FALSE)
         && (crm_element_value_int(xml, PCMK__XA_ATTR_NODE_ID,
-                                  (int*)&v->nodeid) == 0)) {
+                                  (int*)&v->nodeid) == 0) && (v->nodeid > 0)) {
 
         crm_node_t *known_peer = crm_get_peer(v->nodeid, host);
 

--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -1009,6 +1009,10 @@ attrd_peer_change_cb(enum crm_status_type kind, crm_node_t *peer, const void *da
     // Remove votes from cluster nodes that leave, in case election in progress
     if (gone && !is_remote) {
         attrd_remove_voter(peer);
+
+    // Ensure remote nodes that come up are in the remote node cache
+    } else if (!gone && is_remote) {
+        cache_remote_node(peer->uname);
     }
 }
 


### PR DESCRIPTION
pacemaker-attrd can write out a remote node's attributes to the CIB only if the node is in its remote peer cache. Unlike the controller, pacemaker-attrd does not manage the remote peer cache via parsing the CIB; instead, it adds nodes to the cache after certain events, the most important being the controller setting the probed attribute when a remote node comes up.

If the cluster restarts on a cluster node, it will get a copy of all current attributes via a sync request to other nodes. However, it will not know that remote nodes are remote, and if the remote nodes are already up, it won't easily learn it. If the node later becomes DC, its scheduler will not see the remote nodes' attributes. If the cluster includes unfencing, this can lead to an unfencing loop.

The main solution is to indicate a node's "remoteness" in replies to the sync request. That way, the cluster node can learn existing remote nodes' "remoteness" as soon as it rejoins the cluster. There are a few other (less important) places where we can pass along the information as well.