### PR TITLE
Low: fenced: Insufficient space on log.

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2703,7 +2703,7 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
         xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, request, LOG_TRACE);
 
         crm_notice("Received forwarded fencing request from "
-                   "%s%s to fence (%s) peer %s",
+                   "%s %s to fence (%s) peer %s",
                    ((client == NULL)? "peer" : "client"),
                    ((client == NULL)? remote_peer : pcmk__client_name(client)),
                    crm_element_value(dev, F_STONITH_ACTION),


### PR DESCRIPTION
Hi All,

There is not enough space in the log.

Old log.
```
Jun 23 15:20:36.198 rh83-dev02 pacemaker-fenced    [51976] (handle_request)     notice: Received forwarded fencing request from peerrh83-dev01 to fence (reboot) peer rh83-dev01
```

New log.
```
Jun 23 15:34:24.075 rh83-dev02 pacemaker-fenced    [103570] (handle_request)    notice: Received forwarded fencing request from peer rh83-dev01 to fence (reboot) peer rh83-dev01
```

Best Regards,
Hideo Yamauchi.