### PR TITLE
Fix: libcrmcommon: Correctly handle case-sensitive ids of xml objects…

### DIFF
--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -2614,10 +2614,10 @@ update_xml_child(xmlNode * child, xmlNode * to_update)
     CRM_CHECK(child != NULL, return FALSE);
     CRM_CHECK(to_update != NULL, return FALSE);
 
-    if (!pcmk__str_eq(crm_element_name(to_update), crm_element_name(child), pcmk__str_casei)) {
+    if (!pcmk__str_eq(crm_element_name(to_update), crm_element_name(child), pcmk__str_none)) {
         can_update = FALSE;
 
-    } else if (!pcmk__str_eq(ID(to_update), ID(child), pcmk__str_casei)) {
+    } else if (!pcmk__str_eq(ID(to_update), ID(child), pcmk__str_none)) {
         can_update = FALSE;
 
     } else if (can_update) {


### PR DESCRIPTION
A Fix to correctly handle case-sensitive ids of xml objects when changing values.
For example.
Adding two cluster properties with lower-case and capital names like so :

```
crm_attribute --type crm_config --name foo --update bar
crm_attribute --type crm_config --name FOO --update aaa

```
 But if we try to change the value of the attribute FOO, we will get something like this.

`crm_attribute --type crm_config --name FOO --update bbb`
Error setting FOO=bbb (section=crm_config, set=<null>): Update does not conform to the configured schema
Error performing operation: Update does not conform to the configured schema


