### PR TITLE
cluster: Use most up-to-date corosync API calls

### DIFF
--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -256,7 +256,7 @@ mcp_read_config(void)
 
     // There can be only one possibility
     do {
-        rc = cmap_initialize(&local_handle);
+        rc = cmap_initialize_map(&local_handle, CMAP_MAP_ICMAP);
         if (rc != CS_OK) {
             retries++;
             crm_info("Could not connect to Corosync CMAP: %s (retrying in %ds) "


### PR DESCRIPTION
While the current API calls used by pacemaker are still supported
in corosync, this change makes things more future-proof and easier
to incorporate new features as needed.