### PR TITLE
More tweaks to resource filtering and clone/group output

### DIFF
--- a/cts/cli/regression.crm_mon.exp
+++ b/cts/cli/regression.crm_mon.exp
@@ -3022,7 +3022,27 @@ Operations:
     <node name="httpd-bundle-2" id="httpd-bundle-2" online="false" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="false" is_dc="false" resources_running="0" type="remote" id_as_resource="httpd-bundle-docker-2"/>
   </nodes>
   <resources>
-    <clone id="mysql-clone-group" multi_state="false" unique="false" managed="true" disabled="false" failed="false" failure_ignored="false"/>
+    <clone id="mysql-clone-group" multi_state="false" unique="false" managed="true" disabled="false" failed="false" failure_ignored="false">
+      <group id="mysql-group:0" number_resources="1" managed="true" disabled="false">
+        <resource id="mysql-proxy" resource_agent="lsb:mysql-proxy" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1">
+          <node name="cluster02" id="2" cached="true"/>
+        </resource>
+      </group>
+      <group id="mysql-group:1" number_resources="1" managed="true" disabled="false">
+        <resource id="mysql-proxy" resource_agent="lsb:mysql-proxy" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1">
+          <node name="cluster01" id="1" cached="true"/>
+        </resource>
+      </group>
+      <group id="mysql-group:2" number_resources="1" managed="true" disabled="false">
+        <resource id="mysql-proxy" resource_agent="lsb:mysql-proxy" role="Stopped" active="false" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="0"/>
+      </group>
+      <group id="mysql-group:3" number_resources="1" managed="true" disabled="false">
+        <resource id="mysql-proxy" resource_agent="lsb:mysql-proxy" role="Stopped" active="false" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="0"/>
+      </group>
+      <group id="mysql-group:4" number_resources="1" managed="true" disabled="false">
+        <resource id="mysql-proxy" resource_agent="lsb:mysql-proxy" role="Stopped" active="false" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="0"/>
+      </group>
+    </clone>
   </resources>
   <node_attributes>
     <node name="cluster01">

--- a/cts/cli/regression.crm_mon.exp
+++ b/cts/cli/regression.crm_mon.exp
@@ -3942,9 +3942,9 @@ Full List of Resources:
     * ping	(ocf:pacemaker:ping):	 Started cluster01 (unmanaged)
   * Fencing	(stonith:fence_xvm):	 Started cluster01 (unmanaged)
   * dummy	(ocf:pacemaker:Dummy):	 Started cluster02 (unmanaged)
-  * Clone Set: inactive-clone [inactive-dhcpd] (unmanaged) (disabled):
+  * Clone Set: inactive-clone [inactive-dhcpd] (unmanaged, disabled):
     * Stopped (disabled): [ cluster01 cluster02 ]
-  * Resource Group: inactive-group (unmanaged) (disabled):
+  * Resource Group: inactive-group (unmanaged, disabled):
     * inactive-dummy-1	(ocf:pacemaker:Dummy):	 Stopped (disabled, unmanaged)
     * inactive-dummy-2	(ocf:pacemaker:Dummy):	 Stopped (disabled, unmanaged)
   * Container bundle set: httpd-bundle [pcmk:http] (unmanaged):
@@ -3959,7 +3959,7 @@ Full List of Resources:
       * mysql-proxy	(lsb:mysql-proxy):	 Started cluster02 (unmanaged)
     * Resource Group: mysql-group:1 (unmanaged):
       * mysql-proxy	(lsb:mysql-proxy):	 Started cluster01 (unmanaged)
-  * Clone Set: promotable-clone [promotable-rsc] (promotable) (unmanaged):
+  * Clone Set: promotable-clone [promotable-rsc] (promotable, unmanaged):
     * promotable-rsc	(ocf:pacemaker:Stateful):	 Promoted cluster02 (unmanaged)
     * promotable-rsc	(ocf:pacemaker:Stateful):	 Unpromoted cluster01 (unmanaged)
 =#=#=#= End test: Text output of all resources with maintenance-mode enabled - OK (0) =#=#=#=

--- a/cts/cli/regression.crm_mon.exp
+++ b/cts/cli/regression.crm_mon.exp
@@ -636,12 +636,6 @@ Active Resources:
       * mysql-proxy	(lsb:mysql-proxy):	 Started cluster02
     * Resource Group: mysql-group:1:
       * mysql-proxy	(lsb:mysql-proxy):	 Started cluster01
-    * Resource Group: mysql-group:2:
-      * mysql-proxy	(lsb:mysql-proxy):	 Stopped
-    * Resource Group: mysql-group:3:
-      * mysql-proxy	(lsb:mysql-proxy):	 Stopped
-    * Resource Group: mysql-group:4:
-      * mysql-proxy	(lsb:mysql-proxy):	 Stopped
   * Clone Set: promotable-clone [promotable-rsc] (promotable):
     * promotable-rsc	(ocf:pacemaker:Stateful):	 Promoted cluster02
     * promotable-rsc	(ocf:pacemaker:Stateful):	 Unpromoted cluster01
@@ -2990,12 +2984,6 @@ Active Resources:
       * mysql-proxy	(lsb:mysql-proxy):	 Started cluster02
     * Resource Group: mysql-group:1:
       * mysql-proxy	(lsb:mysql-proxy):	 Started cluster01
-    * Resource Group: mysql-group:2:
-      * mysql-proxy	(lsb:mysql-proxy):	 Stopped
-    * Resource Group: mysql-group:3:
-      * mysql-proxy	(lsb:mysql-proxy):	 Stopped
-    * Resource Group: mysql-group:4:
-      * mysql-proxy	(lsb:mysql-proxy):	 Stopped
 
 Node Attributes:
   * Node: cluster01 (1):
@@ -3082,12 +3070,6 @@ Active Resources:
       * mysql-proxy	(lsb:mysql-proxy):	 Started cluster02
     * Resource Group: mysql-group:1:
       * mysql-proxy	(lsb:mysql-proxy):	 Started cluster01
-    * Resource Group: mysql-group:2:
-      * mysql-proxy	(lsb:mysql-proxy):	 Stopped
-    * Resource Group: mysql-group:3:
-      * mysql-proxy	(lsb:mysql-proxy):	 Stopped
-    * Resource Group: mysql-group:4:
-      * mysql-proxy	(lsb:mysql-proxy):	 Stopped
 
 Node Attributes:
   * Node: cluster01 (1):
@@ -3284,12 +3266,6 @@ Active Resources:
       * mysql-proxy	(lsb:mysql-proxy):	 Started cluster02
     * Resource Group: mysql-group:1:
       * mysql-proxy	(lsb:mysql-proxy):	 Started cluster01
-    * Resource Group: mysql-group:2:
-      * mysql-proxy	(lsb:mysql-proxy):	 Stopped
-    * Resource Group: mysql-group:3:
-      * mysql-proxy	(lsb:mysql-proxy):	 Stopped
-    * Resource Group: mysql-group:4:
-      * mysql-proxy	(lsb:mysql-proxy):	 Stopped
 
 Node Attributes:
   * Node: cluster01 (1):
@@ -3489,7 +3465,6 @@ Active Resources:
     * httpd-bundle-1 (192.168.122.132)	(ocf:heartbeat:apache):	 Stopped cluster01
   * Resource Group: partially-active-group:
     * dummy-1	(ocf:pacemaker:Dummy):	 Started cluster02
-    * dummy-2	(ocf:pacemaker:Dummy):	 Stopped (disabled)
 =#=#=#= End test: Text output of partially active resources - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of partially active resources
 =#=#=#= Begin test: XML output of partially active resources =#=#=#=
@@ -3702,6 +3677,79 @@ Operations:
       * (1) start
 =#=#=#= End test: Complete brief text output, with inactive resources - OK (0) =#=#=#=
 * Passed: crm_mon        - Complete brief text output, with inactive resources
+=#=#=#= Begin test: Text output of partially active group =#=#=#=
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: cluster02 (version) - partition with quorum
+  * Last updated:
+  * Last change:
+  * 4 nodes configured
+  * 13 resource instances configured (1 DISABLED)
+
+Node List:
+  * Online: [ cluster01 cluster02 ]
+  * GuestOnline: [ httpd-bundle-0@cluster02 httpd-bundle-1@cluster01 ]
+
+Active Resources:
+  * Resource Group: partially-active-group:
+    * dummy-1	(ocf:pacemaker:Dummy):	 Started cluster02
+=#=#=#= End test: Text output of partially active group - OK (0) =#=#=#=
+* Passed: crm_mon        - Text output of partially active group
+=#=#=#= Begin test: Text output of partially active group, with inactive resources =#=#=#=
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: cluster02 (version) - partition with quorum
+  * Last updated:
+  * Last change:
+  * 4 nodes configured
+  * 13 resource instances configured (1 DISABLED)
+
+Node List:
+  * Online: [ cluster01 cluster02 ]
+  * GuestOnline: [ httpd-bundle-0@cluster02 httpd-bundle-1@cluster01 ]
+
+Full List of Resources:
+  * Resource Group: partially-active-group:
+    * dummy-1	(ocf:pacemaker:Dummy):	 Started cluster02
+    * dummy-2	(ocf:pacemaker:Dummy):	 Stopped (disabled)
+=#=#=#= End test: Text output of partially active group, with inactive resources - OK (0) =#=#=#=
+* Passed: crm_mon        - Text output of partially active group, with inactive resources
+=#=#=#= Begin test: Text output of active member of partially active group =#=#=#=
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: cluster02 (version) - partition with quorum
+  * Last updated:
+  * Last change:
+  * 4 nodes configured
+  * 13 resource instances configured (1 DISABLED)
+
+Node List:
+  * Online: [ cluster01 cluster02 ]
+  * GuestOnline: [ httpd-bundle-0@cluster02 httpd-bundle-1@cluster01 ]
+
+Active Resources:
+  * Resource Group: partially-active-group:
+    * dummy-1	(ocf:pacemaker:Dummy):	 Started cluster02
+=#=#=#= End test: Text output of active member of partially active group - OK (0) =#=#=#=
+* Passed: crm_mon        - Text output of active member of partially active group
+=#=#=#= Begin test: Text output of inactive member of partially active group =#=#=#=
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: cluster02 (version) - partition with quorum
+  * Last updated:
+  * Last change:
+  * 4 nodes configured
+  * 13 resource instances configured (1 DISABLED)
+
+Node List:
+  * Online: [ cluster01 cluster02 ]
+  * GuestOnline: [ httpd-bundle-0@cluster02 httpd-bundle-1@cluster01 ]
+
+Active Resources:
+  * Resource Group: partially-active-group:
+    * dummy-2	(ocf:pacemaker:Dummy):	 Stopped (disabled)
+=#=#=#= End test: Text output of inactive member of partially active group - OK (0) =#=#=#=
+* Passed: crm_mon        - Text output of inactive member of partially active group
 =#=#=#= Begin test: Complete brief text output grouped by node, with inactive resources =#=#=#=
 Cluster Summary:
   * Stack: corosync

--- a/cts/cli/regression.crm_mon.exp
+++ b/cts/cli/regression.crm_mon.exp
@@ -3463,7 +3463,7 @@ Active Resources:
   * Container bundle set: httpd-bundle [pcmk:http]:
     * httpd-bundle-0 (192.168.122.131)	(ocf:heartbeat:apache):	 Started cluster02
     * httpd-bundle-1 (192.168.122.132)	(ocf:heartbeat:apache):	 Stopped cluster01
-  * Resource Group: partially-active-group:
+  * Resource Group: partially-active-group (1 member inactive):
     * dummy-1	(ocf:pacemaker:Dummy):	 Started cluster02
 =#=#=#= End test: Text output of partially active resources - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of partially active resources
@@ -3691,7 +3691,7 @@ Node List:
   * GuestOnline: [ httpd-bundle-0@cluster02 httpd-bundle-1@cluster01 ]
 
 Active Resources:
-  * Resource Group: partially-active-group:
+  * Resource Group: partially-active-group (1 member inactive):
     * dummy-1	(ocf:pacemaker:Dummy):	 Started cluster02
 =#=#=#= End test: Text output of partially active group - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of partially active group
@@ -3728,7 +3728,7 @@ Node List:
   * GuestOnline: [ httpd-bundle-0@cluster02 httpd-bundle-1@cluster01 ]
 
 Active Resources:
-  * Resource Group: partially-active-group:
+  * Resource Group: partially-active-group (1 member inactive):
     * dummy-1	(ocf:pacemaker:Dummy):	 Started cluster02
 =#=#=#= End test: Text output of active member of partially active group - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of active member of partially active group
@@ -3746,7 +3746,7 @@ Node List:
   * GuestOnline: [ httpd-bundle-0@cluster02 httpd-bundle-1@cluster01 ]
 
 Active Resources:
-  * Resource Group: partially-active-group:
+  * Resource Group: partially-active-group (1 member inactive):
     * dummy-2	(ocf:pacemaker:Dummy):	 Stopped (disabled)
 =#=#=#= End test: Text output of inactive member of partially active group - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of inactive member of partially active group

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -439,6 +439,22 @@ function test_crm_mon() {
 
     # XML does not have a brief output option
 
+    desc="Text output of partially active group"
+    cmd="crm_mon -1 --resource=partially-active-group"
+    test_assert $CRM_EX_OK 0
+
+    desc="Text output of partially active group, with inactive resources"
+    cmd="crm_mon -1 --resource=partially-active-group -r"
+    test_assert $CRM_EX_OK 0
+
+    desc="Text output of active member of partially active group"
+    cmd="crm_mon -1 --resource=dummy-1"
+    test_assert $CRM_EX_OK 0
+
+    desc="Text output of inactive member of partially active group"
+    cmd="crm_mon -1 --resource=dummy-2"
+    test_assert $CRM_EX_OK 0
+
     desc="Complete brief text output grouped by node, with inactive resources"
     cmd="crm_mon -1 -r --include=all --group-by-node --brief"
     test_assert $CRM_EX_OK 0

--- a/cts/scheduler/summary/bug-1822.summary
+++ b/cts/scheduler/summary/bug-1822.summary
@@ -3,7 +3,7 @@ Current cluster status:
     * Online: [ process1a process2b ]
 
   * Full List of Resources:
-    * Clone Set: ms-sf [ms-sf_group] (promotable) (unique):
+    * Clone Set: ms-sf [ms-sf_group] (promotable, unique):
       * Resource Group: ms-sf_group:0:
         * master_slave_Stateful:0	(ocf:heartbeat:Dummy-statful):	 Unpromoted process2b
         * master_slave_procdctl:0	(ocf:heartbeat:procdctl):	 Stopped
@@ -35,7 +35,7 @@ Revised Cluster Status:
     * Online: [ process1a process2b ]
 
   * Full List of Resources:
-    * Clone Set: ms-sf [ms-sf_group] (promotable) (unique):
+    * Clone Set: ms-sf [ms-sf_group] (promotable, unique):
       * Resource Group: ms-sf_group:0:
         * master_slave_Stateful:0	(ocf:heartbeat:Dummy-statful):	 Unpromoted process2b
         * master_slave_procdctl:0	(ocf:heartbeat:procdctl):	 Stopped

--- a/cts/scheduler/summary/bug-5140-require-all-false.summary
+++ b/cts/scheduler/summary/bug-5140-require-all-false.summary
@@ -19,9 +19,9 @@ Current cluster status:
     * fs-xfs-1	(ocf:heartbeat:Filesystem):	 Stopped
     * Clone Set: fs2 [fs-ocfs-2]:
       * Stopped: [ hex-1 hex-2 hex-3 ]
-    * Clone Set: ms-r0 [drbd-r0] (promotable) (disabled):
+    * Clone Set: ms-r0 [drbd-r0] (promotable, disabled):
       * Stopped (disabled): [ hex-1 hex-2 hex-3 ]
-    * Clone Set: ms-r1 [drbd-r1] (promotable) (disabled):
+    * Clone Set: ms-r1 [drbd-r1] (promotable, disabled):
       * Stopped (disabled): [ hex-1 hex-2 hex-3 ]
     * Resource Group: md0-group:
       * md0	(ocf:heartbeat:Raid1):	 Stopped
@@ -64,9 +64,9 @@ Revised Cluster Status:
     * fs-xfs-1	(ocf:heartbeat:Filesystem):	 Stopped
     * Clone Set: fs2 [fs-ocfs-2]:
       * Stopped: [ hex-1 hex-2 hex-3 ]
-    * Clone Set: ms-r0 [drbd-r0] (promotable) (disabled):
+    * Clone Set: ms-r0 [drbd-r0] (promotable, disabled):
       * Stopped (disabled): [ hex-1 hex-2 hex-3 ]
-    * Clone Set: ms-r1 [drbd-r1] (promotable) (disabled):
+    * Clone Set: ms-r1 [drbd-r1] (promotable, disabled):
       * Stopped (disabled): [ hex-1 hex-2 hex-3 ]
     * Resource Group: md0-group:
       * md0	(ocf:heartbeat:Raid1):	 Stopped

--- a/cts/scheduler/summary/bug-lf-2358.summary
+++ b/cts/scheduler/summary/bug-lf-2358.summary
@@ -5,7 +5,7 @@ Current cluster status:
     * Online: [ alice.demo bob.demo ]
 
   * Full List of Resources:
-    * Clone Set: ms_drbd_nfsexport [res_drbd_nfsexport] (promotable) (disabled):
+    * Clone Set: ms_drbd_nfsexport [res_drbd_nfsexport] (promotable, disabled):
       * Stopped (disabled): [ alice.demo bob.demo ]
     * Resource Group: rg_nfs:
       * res_fs_nfsexport	(ocf:heartbeat:Filesystem):	 Stopped
@@ -46,7 +46,7 @@ Revised Cluster Status:
     * Online: [ alice.demo bob.demo ]
 
   * Full List of Resources:
-    * Clone Set: ms_drbd_nfsexport [res_drbd_nfsexport] (promotable) (disabled):
+    * Clone Set: ms_drbd_nfsexport [res_drbd_nfsexport] (promotable, disabled):
       * Stopped (disabled): [ alice.demo bob.demo ]
     * Resource Group: rg_nfs:
       * res_fs_nfsexport	(ocf:heartbeat:Filesystem):	 Stopped

--- a/cts/scheduler/summary/bug-pm-11.summary
+++ b/cts/scheduler/summary/bug-pm-11.summary
@@ -3,7 +3,7 @@ Current cluster status:
     * Online: [ node-a node-b ]
 
   * Full List of Resources:
-    * Clone Set: ms-sf [group] (promotable) (unique):
+    * Clone Set: ms-sf [group] (promotable, unique):
       * Resource Group: group:0:
         * stateful-1:0	(ocf:heartbeat:Stateful):	 Unpromoted node-b
         * stateful-2:0	(ocf:heartbeat:Stateful):	 Stopped
@@ -39,7 +39,7 @@ Revised Cluster Status:
     * Online: [ node-a node-b ]
 
   * Full List of Resources:
-    * Clone Set: ms-sf [group] (promotable) (unique):
+    * Clone Set: ms-sf [group] (promotable, unique):
       * Resource Group: group:0:
         * stateful-1:0	(ocf:heartbeat:Stateful):	 Unpromoted node-b
         * stateful-2:0	(ocf:heartbeat:Stateful):	 Unpromoted node-b

--- a/cts/scheduler/summary/bug-pm-12.summary
+++ b/cts/scheduler/summary/bug-pm-12.summary
@@ -3,7 +3,7 @@ Current cluster status:
     * Online: [ node-a node-b ]
 
   * Full List of Resources:
-    * Clone Set: ms-sf [group] (promotable) (unique):
+    * Clone Set: ms-sf [group] (promotable, unique):
       * Resource Group: group:0:
         * stateful-1:0	(ocf:heartbeat:Stateful):	 Unpromoted node-b
         * stateful-2:0	(ocf:heartbeat:Stateful):	 Unpromoted node-b
@@ -48,7 +48,7 @@ Revised Cluster Status:
     * Online: [ node-a node-b ]
 
   * Full List of Resources:
-    * Clone Set: ms-sf [group] (promotable) (unique):
+    * Clone Set: ms-sf [group] (promotable, unique):
       * Resource Group: group:0:
         * stateful-1:0	(ocf:heartbeat:Stateful):	 Unpromoted node-b
         * stateful-2:0	(ocf:heartbeat:Stateful):	 Unpromoted node-b

--- a/cts/scheduler/summary/clone-max-zero.summary
+++ b/cts/scheduler/summary/clone-max-zero.summary
@@ -42,7 +42,6 @@ Revised Cluster Status:
 
   * Full List of Resources:
     * fencing	(stonith:external/ssh):	 Started c001n11
-    * Clone Set: dlm-clone [dlm]:
     * Clone Set: o2cb-clone [o2cb]:
       * Stopped: [ c001n11 c001n12 ]
     * Clone Set: clone-drbd0 [drbd0]:

--- a/cts/scheduler/summary/group14.summary
+++ b/cts/scheduler/summary/group14.summary
@@ -19,7 +19,7 @@ Current cluster status:
     * rsc_c001n07	(ocf:heartbeat:IPaddr):	 Stopped
     * Clone Set: DoFencing [child_DoFencing]:
       * Stopped: [ c001n02 c001n03 c001n04 c001n05 c001n06 c001n07 ]
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:Stateful):	 Stopped
       * ocf_msdummy:1	(ocf:heartbeat:Stateful):	 Stopped
       * ocf_msdummy:2	(ocf:heartbeat:Stateful):	 Stopped
@@ -87,7 +87,7 @@ Revised Cluster Status:
     * Clone Set: DoFencing [child_DoFencing]:
       * Started: [ c001n06 c001n07 ]
       * Stopped: [ c001n02 c001n03 c001n04 c001n05 ]
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:Stateful):	 Stopped
       * ocf_msdummy:1	(ocf:heartbeat:Stateful):	 Stopped
       * ocf_msdummy:2	(ocf:heartbeat:Stateful):	 Stopped

--- a/cts/scheduler/summary/inc11.summary
+++ b/cts/scheduler/summary/inc11.summary
@@ -4,7 +4,7 @@ Current cluster status:
 
   * Full List of Resources:
     * simple-rsc	(ocf:heartbeat:apache):	 Stopped
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Stopped
       * child_rsc1:1	(ocf:heartbeat:apache):	 Stopped
 
@@ -38,6 +38,6 @@ Revised Cluster Status:
 
   * Full List of Resources:
     * simple-rsc	(ocf:heartbeat:apache):	 Started node2
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Unpromoted node1
       * child_rsc1:1	(ocf:heartbeat:apache):	 Promoted node2

--- a/cts/scheduler/summary/inc12.summary
+++ b/cts/scheduler/summary/inc12.summary
@@ -18,7 +18,7 @@ Current cluster status:
     * Clone Set: DoFencing [child_DoFencing]:
       * Started: [ c001n02 c001n04 c001n05 c001n06 c001n07 ]
       * Stopped: [ c001n03 ]
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:Stateful):	 Stopped
       * ocf_msdummy:1	(ocf:heartbeat:Stateful):	 Stopped
       * ocf_msdummy:2	(ocf:heartbeat:Stateful):	 Unpromoted c001n04
@@ -117,7 +117,7 @@ Revised Cluster Status:
     * rsc_c001n07	(ocf:heartbeat:IPaddr):	 Stopped
     * Clone Set: DoFencing [child_DoFencing]:
       * Stopped: [ c001n02 c001n03 c001n04 c001n05 c001n06 c001n07 ]
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:Stateful):	 Stopped
       * ocf_msdummy:1	(ocf:heartbeat:Stateful):	 Stopped
       * ocf_msdummy:2	(ocf:heartbeat:Stateful):	 Stopped

--- a/cts/scheduler/summary/managed-1.summary
+++ b/cts/scheduler/summary/managed-1.summary
@@ -12,7 +12,7 @@ Current cluster status:
     * rsc_c001n06	(ocf:heartbeat:IPaddr):	 Started c001n06
     * rsc_c001n07	(ocf:heartbeat:IPaddr):	 Started c001n07
     * rsc_c001n08	(ocf:heartbeat:IPaddr):	 Started c001n08
-    * Clone Set: DoFencing [child_DoFencing] (unique) (unmanaged):
+    * Clone Set: DoFencing [child_DoFencing] (unique, unmanaged):
       * child_DoFencing:0	(stonith:ssh):	 Started c001n02 (unmanaged)
       * child_DoFencing:1	(stonith:ssh):	 Started c001n03 (unmanaged)
       * child_DoFencing:2	(stonith:ssh):	 Started c001n04 (unmanaged)
@@ -121,7 +121,7 @@ Revised Cluster Status:
     * rsc_c001n06	(ocf:heartbeat:IPaddr):	 Started c001n06
     * rsc_c001n07	(ocf:heartbeat:IPaddr):	 Started c001n07
     * rsc_c001n08	(ocf:heartbeat:IPaddr):	 Started c001n08
-    * Clone Set: DoFencing [child_DoFencing] (unique) (unmanaged):
+    * Clone Set: DoFencing [child_DoFencing] (unique, unmanaged):
       * child_DoFencing:0	(stonith:ssh):	 Started c001n02 (unmanaged)
       * child_DoFencing:1	(stonith:ssh):	 Started c001n03 (unmanaged)
       * child_DoFencing:2	(stonith:ssh):	 Started c001n04 (unmanaged)

--- a/cts/scheduler/summary/managed-2.summary
+++ b/cts/scheduler/summary/managed-2.summary
@@ -12,7 +12,7 @@ Current cluster status:
     * rsc_c001n06	(ocf:heartbeat:IPaddr):	 Started c001n06
     * rsc_c001n07	(ocf:heartbeat:IPaddr):	 Started c001n07
     * rsc_c001n08	(ocf:heartbeat:IPaddr):	 Started c001n08
-    * Clone Set: DoFencing [child_DoFencing] (unique) (unmanaged):
+    * Clone Set: DoFencing [child_DoFencing] (unique, unmanaged):
       * child_DoFencing:0	(stonith:ssh):	 Stopped (unmanaged)
       * child_DoFencing:1	(stonith:ssh):	 Stopped (unmanaged)
       * child_DoFencing:2	(stonith:ssh):	 Stopped (unmanaged)
@@ -155,7 +155,7 @@ Revised Cluster Status:
     * rsc_c001n06	(ocf:heartbeat:IPaddr):	 Started c001n06
     * rsc_c001n07	(ocf:heartbeat:IPaddr):	 Started c001n07
     * rsc_c001n08	(ocf:heartbeat:IPaddr):	 Started c001n08
-    * Clone Set: DoFencing [child_DoFencing] (unique) (unmanaged):
+    * Clone Set: DoFencing [child_DoFencing] (unique, unmanaged):
       * child_DoFencing:0	(stonith:ssh):	 Stopped (unmanaged)
       * child_DoFencing:1	(stonith:ssh):	 Stopped (unmanaged)
       * child_DoFencing:2	(stonith:ssh):	 Stopped (unmanaged)

--- a/cts/scheduler/summary/promoted-0.summary
+++ b/cts/scheduler/summary/promoted-0.summary
@@ -3,7 +3,7 @@ Current cluster status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Stopped
       * child_rsc1:1	(ocf:heartbeat:apache):	 Stopped
       * child_rsc1:2	(ocf:heartbeat:apache):	 Stopped
@@ -39,7 +39,7 @@ Revised Cluster Status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Unpromoted node1
       * child_rsc1:1	(ocf:heartbeat:apache):	 Unpromoted node2
       * child_rsc1:2	(ocf:heartbeat:apache):	 Unpromoted node1

--- a/cts/scheduler/summary/promoted-1.summary
+++ b/cts/scheduler/summary/promoted-1.summary
@@ -3,7 +3,7 @@ Current cluster status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Stopped
       * child_rsc1:1	(ocf:heartbeat:apache):	 Stopped
       * child_rsc1:2	(ocf:heartbeat:apache):	 Stopped
@@ -42,7 +42,7 @@ Revised Cluster Status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Unpromoted node1
       * child_rsc1:1	(ocf:heartbeat:apache):	 Promoted node2
       * child_rsc1:2	(ocf:heartbeat:apache):	 Unpromoted node1

--- a/cts/scheduler/summary/promoted-10.summary
+++ b/cts/scheduler/summary/promoted-10.summary
@@ -3,7 +3,7 @@ Current cluster status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Stopped
       * child_rsc1:1	(ocf:heartbeat:apache):	 Stopped
       * child_rsc1:2	(ocf:heartbeat:apache):	 Stopped
@@ -67,7 +67,7 @@ Revised Cluster Status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Promoted node1
       * child_rsc1:1	(ocf:heartbeat:apache):	 Unpromoted node2
       * child_rsc1:2	(ocf:heartbeat:apache):	 Unpromoted node1

--- a/cts/scheduler/summary/promoted-11.summary
+++ b/cts/scheduler/summary/promoted-11.summary
@@ -4,7 +4,7 @@ Current cluster status:
 
   * Full List of Resources:
     * simple-rsc	(ocf:heartbeat:apache):	 Stopped
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Stopped
       * child_rsc1:1	(ocf:heartbeat:apache):	 Stopped
 
@@ -35,6 +35,6 @@ Revised Cluster Status:
 
   * Full List of Resources:
     * simple-rsc	(ocf:heartbeat:apache):	 Started node2
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Unpromoted node1
       * child_rsc1:1	(ocf:heartbeat:apache):	 Promoted node2

--- a/cts/scheduler/summary/promoted-12.summary
+++ b/cts/scheduler/summary/promoted-12.summary
@@ -6,7 +6,7 @@ Current cluster status:
     * Clone Set: ms-drbd0 [drbd0] (promotable):
       * Promoted: [ sel3 ]
       * Unpromoted: [ sel4 ]
-    * Clone Set: ms-sf [sf] (promotable) (unique):
+    * Clone Set: ms-sf [sf] (promotable, unique):
       * sf:0	(ocf:heartbeat:Stateful):	 Unpromoted sel3
       * sf:1	(ocf:heartbeat:Stateful):	 Unpromoted sel4
     * fs0	(ocf:heartbeat:Filesystem):	 Started sel3
@@ -27,7 +27,7 @@ Revised Cluster Status:
     * Clone Set: ms-drbd0 [drbd0] (promotable):
       * Promoted: [ sel3 ]
       * Unpromoted: [ sel4 ]
-    * Clone Set: ms-sf [sf] (promotable) (unique):
+    * Clone Set: ms-sf [sf] (promotable, unique):
       * sf:0	(ocf:heartbeat:Stateful):	 Promoted sel3
       * sf:1	(ocf:heartbeat:Stateful):	 Unpromoted sel4
     * fs0	(ocf:heartbeat:Filesystem):	 Started sel3

--- a/cts/scheduler/summary/promoted-2.summary
+++ b/cts/scheduler/summary/promoted-2.summary
@@ -3,7 +3,7 @@ Current cluster status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Stopped
       * child_rsc1:1	(ocf:heartbeat:apache):	 Stopped
       * child_rsc1:2	(ocf:heartbeat:apache):	 Stopped
@@ -63,7 +63,7 @@ Revised Cluster Status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Promoted node1
       * child_rsc1:1	(ocf:heartbeat:apache):	 Unpromoted node2
       * child_rsc1:2	(ocf:heartbeat:apache):	 Unpromoted node1

--- a/cts/scheduler/summary/promoted-3.summary
+++ b/cts/scheduler/summary/promoted-3.summary
@@ -3,7 +3,7 @@ Current cluster status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Stopped
       * child_rsc1:1	(ocf:heartbeat:apache):	 Stopped
       * child_rsc1:2	(ocf:heartbeat:apache):	 Stopped
@@ -42,7 +42,7 @@ Revised Cluster Status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Clone Set: rsc1 [child_rsc1] (promotable) (unique):
+    * Clone Set: rsc1 [child_rsc1] (promotable, unique):
       * child_rsc1:0	(ocf:heartbeat:apache):	 Unpromoted node1
       * child_rsc1:1	(ocf:heartbeat:apache):	 Promoted node2
       * child_rsc1:2	(ocf:heartbeat:apache):	 Unpromoted node1

--- a/cts/scheduler/summary/promoted-4.summary
+++ b/cts/scheduler/summary/promoted-4.summary
@@ -17,7 +17,7 @@ Current cluster status:
       * child_DoFencing:1	(stonith:ssh):	 Started c001n03
       * child_DoFencing:2	(stonith:ssh):	 Started c001n01
       * child_DoFencing:3	(stonith:ssh):	 Started c001n02
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n08
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n03
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n01
@@ -83,7 +83,7 @@ Revised Cluster Status:
       * child_DoFencing:1	(stonith:ssh):	 Started c001n03
       * child_DoFencing:2	(stonith:ssh):	 Started c001n01
       * child_DoFencing:3	(stonith:ssh):	 Started c001n02
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Promoted c001n08
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n03
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n01

--- a/cts/scheduler/summary/promoted-5.summary
+++ b/cts/scheduler/summary/promoted-5.summary
@@ -17,7 +17,7 @@ Current cluster status:
       * child_DoFencing:1	(stonith:ssh):	 Started c001n03
       * child_DoFencing:2	(stonith:ssh):	 Started c001n01
       * child_DoFencing:3	(stonith:ssh):	 Started c001n02
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Promoted c001n08
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n03
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n01
@@ -77,7 +77,7 @@ Revised Cluster Status:
       * child_DoFencing:1	(stonith:ssh):	 Started c001n03
       * child_DoFencing:2	(stonith:ssh):	 Started c001n01
       * child_DoFencing:3	(stonith:ssh):	 Started c001n02
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Promoted c001n08
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n03
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n01

--- a/cts/scheduler/summary/promoted-6.summary
+++ b/cts/scheduler/summary/promoted-6.summary
@@ -18,7 +18,7 @@ Current cluster status:
       * child_DoFencing:1	(stonith:ssh):	 Started c001n02
       * child_DoFencing:2	(stonith:ssh):	 Started c001n03
       * child_DoFencing:3	(stonith:ssh):	 Started c001n01
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Promoted c001n08
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n02
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n03
@@ -76,7 +76,7 @@ Revised Cluster Status:
       * child_DoFencing:1	(stonith:ssh):	 Started c001n02
       * child_DoFencing:2	(stonith:ssh):	 Started c001n03
       * child_DoFencing:3	(stonith:ssh):	 Started c001n01
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Promoted c001n08
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n02
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n03

--- a/cts/scheduler/summary/promoted-7.summary
+++ b/cts/scheduler/summary/promoted-7.summary
@@ -19,7 +19,7 @@ Current cluster status:
       * child_DoFencing:1	(stonith:ssh):	 Started c001n03
       * child_DoFencing:2	(stonith:ssh):	 Started c001n02
       * child_DoFencing:3	(stonith:ssh):	 Started c001n08
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Promoted c001n01 (UNCLEAN)
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n03
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n02
@@ -110,7 +110,7 @@ Revised Cluster Status:
       * child_DoFencing:1	(stonith:ssh):	 Started c001n03
       * child_DoFencing:2	(stonith:ssh):	 Started c001n02
       * child_DoFencing:3	(stonith:ssh):	 Started c001n08
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Stopped
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n03
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n02

--- a/cts/scheduler/summary/promoted-8.summary
+++ b/cts/scheduler/summary/promoted-8.summary
@@ -19,7 +19,7 @@ Current cluster status:
       * child_DoFencing:1	(stonith:ssh):	 Started c001n03
       * child_DoFencing:2	(stonith:ssh):	 Started c001n02
       * child_DoFencing:3	(stonith:ssh):	 Started c001n08
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Promoted c001n01 (UNCLEAN)
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n03
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n02
@@ -113,7 +113,7 @@ Revised Cluster Status:
       * child_DoFencing:1	(stonith:ssh):	 Started c001n03
       * child_DoFencing:2	(stonith:ssh):	 Started c001n02
       * child_DoFencing:3	(stonith:ssh):	 Started c001n08
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n03
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n03
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n02

--- a/cts/scheduler/summary/promoted-9.summary
+++ b/cts/scheduler/summary/promoted-9.summary
@@ -20,7 +20,7 @@ Current cluster status:
       * child_DoFencing:1	(stonith:ssh):	 Started ibm1
       * child_DoFencing:2	(stonith:ssh):	 Stopped
       * child_DoFencing:3	(stonith:ssh):	 Stopped
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib64/heartbeat/cts/OCFMSDummy):	 Stopped
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib64/heartbeat/cts/OCFMSDummy):	 Stopped
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib64/heartbeat/cts/OCFMSDummy):	 Stopped
@@ -89,7 +89,7 @@ Revised Cluster Status:
       * child_DoFencing:1	(stonith:ssh):	 Stopped
       * child_DoFencing:2	(stonith:ssh):	 Stopped
       * child_DoFencing:3	(stonith:ssh):	 Stopped
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib64/heartbeat/cts/OCFMSDummy):	 Stopped
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib64/heartbeat/cts/OCFMSDummy):	 Stopped
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib64/heartbeat/cts/OCFMSDummy):	 Stopped

--- a/cts/scheduler/summary/promoted-asymmetrical-order.summary
+++ b/cts/scheduler/summary/promoted-asymmetrical-order.summary
@@ -5,7 +5,7 @@ Current cluster status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Clone Set: ms1 [rsc1] (promotable) (disabled):
+    * Clone Set: ms1 [rsc1] (promotable, disabled):
       * Promoted: [ node1 ]
       * Unpromoted: [ node2 ]
     * Clone Set: ms2 [rsc2] (promotable):
@@ -30,7 +30,7 @@ Revised Cluster Status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Clone Set: ms1 [rsc1] (promotable) (disabled):
+    * Clone Set: ms1 [rsc1] (promotable, disabled):
       * Stopped (disabled): [ node1 node2 ]
     * Clone Set: ms2 [rsc2] (promotable):
       * Promoted: [ node2 ]

--- a/cts/scheduler/summary/promoted-failed-demote-2.summary
+++ b/cts/scheduler/summary/promoted-failed-demote-2.summary
@@ -3,7 +3,7 @@ Current cluster status:
     * Online: [ dl380g5a dl380g5b ]
 
   * Full List of Resources:
-    * Clone Set: ms-sf [group] (promotable) (unique):
+    * Clone Set: ms-sf [group] (promotable, unique):
       * Resource Group: group:0:
         * stateful-1:0	(ocf:heartbeat:Stateful):	 FAILED dl380g5b
         * stateful-2:0	(ocf:heartbeat:Stateful):	 Stopped
@@ -38,7 +38,7 @@ Revised Cluster Status:
     * Online: [ dl380g5a dl380g5b ]
 
   * Full List of Resources:
-    * Clone Set: ms-sf [group] (promotable) (unique):
+    * Clone Set: ms-sf [group] (promotable, unique):
       * Resource Group: group:0:
         * stateful-1:0	(ocf:heartbeat:Stateful):	 Stopped
         * stateful-2:0	(ocf:heartbeat:Stateful):	 Stopped

--- a/cts/scheduler/summary/promoted-failed-demote.summary
+++ b/cts/scheduler/summary/promoted-failed-demote.summary
@@ -3,7 +3,7 @@ Current cluster status:
     * Online: [ dl380g5a dl380g5b ]
 
   * Full List of Resources:
-    * Clone Set: ms-sf [group] (promotable) (unique):
+    * Clone Set: ms-sf [group] (promotable, unique):
       * Resource Group: group:0:
         * stateful-1:0	(ocf:heartbeat:Stateful):	 FAILED dl380g5b
         * stateful-2:0	(ocf:heartbeat:Stateful):	 Stopped
@@ -55,7 +55,7 @@ Revised Cluster Status:
     * Online: [ dl380g5a dl380g5b ]
 
   * Full List of Resources:
-    * Clone Set: ms-sf [group] (promotable) (unique):
+    * Clone Set: ms-sf [group] (promotable, unique):
       * Resource Group: group:0:
         * stateful-1:0	(ocf:heartbeat:Stateful):	 Stopped
         * stateful-2:0	(ocf:heartbeat:Stateful):	 Stopped

--- a/cts/scheduler/summary/promoted-group.summary
+++ b/cts/scheduler/summary/promoted-group.summary
@@ -5,7 +5,7 @@ Current cluster status:
   * Full List of Resources:
     * Resource Group: test:
       * resource_1	(ocf:heartbeat:IPaddr):	 Started rh44-1
-    * Clone Set: ms-sf [grp_ms_sf] (promotable) (unique):
+    * Clone Set: ms-sf [grp_ms_sf] (promotable, unique):
       * Resource Group: grp_ms_sf:0:
         * master_slave_Stateful:0	(ocf:heartbeat:Stateful):	 Unpromoted rh44-2
       * Resource Group: grp_ms_sf:1:
@@ -30,7 +30,7 @@ Revised Cluster Status:
   * Full List of Resources:
     * Resource Group: test:
       * resource_1	(ocf:heartbeat:IPaddr):	 Started rh44-1
-    * Clone Set: ms-sf [grp_ms_sf] (promotable) (unique):
+    * Clone Set: ms-sf [grp_ms_sf] (promotable, unique):
       * Resource Group: grp_ms_sf:0:
         * master_slave_Stateful:0	(ocf:heartbeat:Stateful):	 Unpromoted rh44-2
       * Resource Group: grp_ms_sf:1:

--- a/cts/scheduler/summary/promoted-reattach.summary
+++ b/cts/scheduler/summary/promoted-reattach.summary
@@ -3,7 +3,7 @@ Current cluster status:
     * Online: [ dktest1 dktest2 ]
 
   * Full List of Resources:
-    * Clone Set: ms-drbd1 [drbd1] (promotable) (unmanaged):
+    * Clone Set: ms-drbd1 [drbd1] (promotable, unmanaged):
       * drbd1	(ocf:heartbeat:drbd):	 Promoted dktest1 (unmanaged)
       * drbd1	(ocf:heartbeat:drbd):	 Unpromoted dktest2 (unmanaged)
     * Resource Group: apache (unmanaged):
@@ -25,7 +25,7 @@ Revised Cluster Status:
     * Online: [ dktest1 dktest2 ]
 
   * Full List of Resources:
-    * Clone Set: ms-drbd1 [drbd1] (promotable) (unmanaged):
+    * Clone Set: ms-drbd1 [drbd1] (promotable, unmanaged):
       * drbd1	(ocf:heartbeat:drbd):	 Promoted dktest1 (unmanaged)
       * drbd1	(ocf:heartbeat:drbd):	 Unpromoted dktest2 (unmanaged)
     * Resource Group: apache (unmanaged):

--- a/cts/scheduler/summary/promoted-unmanaged-monitor.summary
+++ b/cts/scheduler/summary/promoted-unmanaged-monitor.summary
@@ -20,7 +20,7 @@ Current cluster status:
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-3 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-4 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-1 (unmanaged)
-    * Clone Set: master-1 [stateful-1] (promotable) (unmanaged):
+    * Clone Set: master-1 [stateful-1] (promotable, unmanaged):
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-2 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Promoted pcmk-3 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-4 (unmanaged)
@@ -62,7 +62,7 @@ Revised Cluster Status:
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-3 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-4 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-1 (unmanaged)
-    * Clone Set: master-1 [stateful-1] (promotable) (unmanaged):
+    * Clone Set: master-1 [stateful-1] (promotable, unmanaged):
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-2 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Promoted pcmk-3 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-4 (unmanaged)

--- a/cts/scheduler/summary/rec-node-13.summary
+++ b/cts/scheduler/summary/rec-node-13.summary
@@ -20,7 +20,7 @@ Current cluster status:
     * rsc_c001n02	(ocf:heartbeat:IPaddr):	 Started c001n02
     * rsc_c001n07	(ocf:heartbeat:IPaddr):	 Started c001n07
     * rsc_c001n06	(ocf:heartbeat:IPaddr):	 Started c001n06
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Promoted c001n02
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Stopped
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Stopped
@@ -65,7 +65,7 @@ Revised Cluster Status:
     * rsc_c001n02	(ocf:heartbeat:IPaddr):	 Started c001n02
     * rsc_c001n07	(ocf:heartbeat:IPaddr):	 Started c001n07
     * rsc_c001n06	(ocf:heartbeat:IPaddr):	 Started c001n06
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Promoted c001n02
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Stopped
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Stopped

--- a/cts/scheduler/summary/rsc-maintenance.summary
+++ b/cts/scheduler/summary/rsc-maintenance.summary
@@ -5,7 +5,7 @@ Current cluster status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Resource Group: group1 (unmanaged) (disabled):
+    * Resource Group: group1 (unmanaged, disabled):
       * rsc1	(ocf:pacemaker:Dummy):	 Started node1 (disabled, unmanaged)
       * rsc2	(ocf:pacemaker:Dummy):	 Started node1 (disabled, unmanaged)
     * Resource Group: group2:
@@ -23,7 +23,7 @@ Revised Cluster Status:
     * Online: [ node1 node2 ]
 
   * Full List of Resources:
-    * Resource Group: group1 (unmanaged) (disabled):
+    * Resource Group: group1 (unmanaged, disabled):
       * rsc1	(ocf:pacemaker:Dummy):	 Started node1 (disabled, unmanaged)
       * rsc2	(ocf:pacemaker:Dummy):	 Started node1 (disabled, unmanaged)
     * Resource Group: group2:

--- a/cts/scheduler/summary/stonith-0.summary
+++ b/cts/scheduler/summary/stonith-0.summary
@@ -21,7 +21,7 @@ Current cluster status:
     * Clone Set: DoFencing [child_DoFencing]:
       * Started: [ c001n02 c001n04 c001n06 c001n07 c001n08 ]
       * Stopped: [ c001n03 c001n05 ]
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Promoted c001n02
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n02
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n07
@@ -94,7 +94,7 @@ Revised Cluster Status:
     * Clone Set: DoFencing [child_DoFencing]:
       * Started: [ c001n02 c001n04 c001n06 c001n07 c001n08 ]
       * Stopped: [ c001n03 c001n05 ]
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Promoted c001n02
       * ocf_msdummy:1	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n02
       * ocf_msdummy:2	(ocf:heartbeat:/usr/lib/heartbeat/cts/OCFMSDummy):	 Unpromoted c001n07

--- a/cts/scheduler/summary/stonith-1.summary
+++ b/cts/scheduler/summary/stonith-1.summary
@@ -18,7 +18,7 @@ Current cluster status:
       * child_DoFencing	(stonith:external/vmware):	 Started sles-3 (UNCLEAN)
       * Started: [ sles-1 sles-2 ]
       * Stopped: [ sles-4 ]
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:Stateful):	 Stopped
       * ocf_msdummy:1	(ocf:heartbeat:Stateful):	 Stopped
       * ocf_msdummy:2	(ocf:heartbeat:Stateful):	 Unpromoted sles-3 (UNCLEAN)
@@ -102,7 +102,7 @@ Revised Cluster Status:
     * Clone Set: DoFencing [child_DoFencing]:
       * Started: [ sles-1 sles-2 sles-4 ]
       * Stopped: [ sles-3 ]
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:Stateful):	 Unpromoted sles-4
       * ocf_msdummy:1	(ocf:heartbeat:Stateful):	 Unpromoted sles-1
       * ocf_msdummy:2	(ocf:heartbeat:Stateful):	 Unpromoted sles-2

--- a/cts/scheduler/summary/stonith-2.summary
+++ b/cts/scheduler/summary/stonith-2.summary
@@ -19,7 +19,7 @@ Current cluster status:
     * Clone Set: DoFencing [child_DoFencing]:
       * Started: [ sles-1 sles-2 sles-3 sles-4 sles-6 ]
       * Stopped: [ sles-5 ]
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:Stateful):	 Unpromoted sles-3
       * ocf_msdummy:1	(ocf:heartbeat:Stateful):	 Unpromoted sles-4
       * ocf_msdummy:2	(ocf:heartbeat:Stateful):	 Unpromoted sles-4
@@ -63,7 +63,7 @@ Revised Cluster Status:
     * Clone Set: DoFencing [child_DoFencing]:
       * Started: [ sles-1 sles-2 sles-3 sles-4 sles-6 ]
       * Stopped: [ sles-5 ]
-    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable) (unique):
+    * Clone Set: master_rsc_1 [ocf_msdummy] (promotable, unique):
       * ocf_msdummy:0	(ocf:heartbeat:Stateful):	 Unpromoted sles-3
       * ocf_msdummy:1	(ocf:heartbeat:Stateful):	 Unpromoted sles-4
       * ocf_msdummy:2	(ocf:heartbeat:Stateful):	 Unpromoted sles-4

--- a/cts/scheduler/summary/unmanaged-promoted.summary
+++ b/cts/scheduler/summary/unmanaged-promoted.summary
@@ -22,7 +22,7 @@ Current cluster status:
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-2 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-1 (unmanaged)
       * Stopped: [ pcmk-3 pcmk-4 ]
-    * Clone Set: master-1 [stateful-1] (promotable) (unmanaged):
+    * Clone Set: master-1 [stateful-1] (promotable, unmanaged):
       * stateful-1	(ocf:pacemaker:Stateful):	 Promoted pcmk-2 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-1 (unmanaged)
       * Stopped: [ pcmk-3 pcmk-4 ]
@@ -57,7 +57,7 @@ Revised Cluster Status:
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-2 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-1 (unmanaged)
       * Stopped: [ pcmk-3 pcmk-4 ]
-    * Clone Set: master-1 [stateful-1] (promotable) (unmanaged):
+    * Clone Set: master-1 [stateful-1] (promotable, unmanaged):
       * stateful-1	(ocf:pacemaker:Stateful):	 Promoted pcmk-2 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-1 (unmanaged)
       * Stopped: [ pcmk-3 pcmk-4 ]

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -649,6 +649,7 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
     GList *only_rsc = va_arg(args, GList *);
 
     GList *gIter = rsc->children;
+    GList *all = NULL;
     int rc = pcmk_rc_no_output;
     gboolean printed_header = FALSE;
     gboolean print_everything = TRUE;
@@ -659,6 +660,8 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
 
     print_everything = pcmk__str_in_list(only_rsc, rsc_printable_id(rsc), pcmk__str_none) ||
                        (strstr(rsc->id, ":") != NULL && pcmk__str_in_list(only_rsc, rsc->id, pcmk__str_none));
+
+    all = g_list_prepend(all, (gpointer) "*");
 
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
@@ -687,13 +690,14 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
         }
 
         out->message(out, crm_map_element_name(child_rsc->xml), show_opts,
-                     child_rsc, only_node, only_rsc);
+                     child_rsc, only_node, all);
     }
 
     if (printed_header) {
         pcmk__output_xml_pop_parent(out);
     }
 
+    g_list_free(all);
     return rc;
 }
 

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -31,12 +31,34 @@
 static void
 clone_header(pcmk__output_t *out, int *rc, pe_resource_t *rsc, clone_variant_data_t *clone_data)
 {
-    PCMK__OUTPUT_LIST_HEADER(out, FALSE, *rc, "Clone Set: %s [%s]%s%s%s%s",
+    char *attrs = NULL;
+    size_t len = 0;
+
+    if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
+        pcmk__add_separated_word(&attrs, &len, "promotable", ", ");
+    }
+
+    if (pcmk_is_set(rsc->flags, pe_rsc_unique)) {
+        pcmk__add_separated_word(&attrs, &len, "unique", ", ");
+    }
+
+    if (!pcmk_is_set(rsc->flags, pe_rsc_managed)) {
+        pcmk__add_separated_word(&attrs, &len, "unmanaged", ", ");
+    }
+
+    if (pe__resource_is_disabled(rsc)) {
+        pcmk__add_separated_word(&attrs, &len, "disabled", ", ");
+    }
+
+    if (attrs) {
+        PCMK__OUTPUT_LIST_HEADER(out, FALSE, *rc, "Clone Set: %s [%s] (%s)",
                              rsc->id, ID(clone_data->xml_obj_child),
-                             pcmk_is_set(rsc->flags, pe_rsc_promotable) ? " (promotable)" : "",
-                             pcmk_is_set(rsc->flags, pe_rsc_unique) ? " (unique)" : "",
-                             pcmk_is_set(rsc->flags, pe_rsc_managed) ? "" : " (unmanaged)",
-                             pe__resource_is_disabled(rsc) ? " (disabled)" : "");
+                                 attrs);
+        free(attrs);
+    } else {
+        PCMK__OUTPUT_LIST_HEADER(out, FALSE, *rc, "Clone Set: %s [%s]",
+                                 rsc->id, ID(clone_data->xml_obj_child))
+    }
 }
 
 void

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -20,6 +20,33 @@
 #define VARIANT_GROUP 1
 #include "./variant.h"
 
+static bool
+skip_child_rsc(pe_resource_t *rsc, pe_resource_t *child, gboolean parent_passes,
+               GList *only_rsc, unsigned int show_opts)
+{
+    bool star_list = pcmk__list_of_1(only_rsc) &&
+                     pcmk__str_eq("*", g_list_first(only_rsc)->data, pcmk__str_none);
+    bool child_filtered = child->fns->is_filtered(child, only_rsc, FALSE);
+    bool child_active = child->fns->active(child, FALSE);
+    bool show_inactive = pcmk_is_set(show_opts, pcmk_show_inactive_rscs);
+
+    /* If the resource is in only_rsc by name (so, ignoring "*") then allow
+     * it regardless of if it's active or not.
+     */
+    if (!star_list && !child_filtered) {
+        return false;
+
+    } else if (!child_filtered && (child_active || show_inactive)) {
+        return false;
+
+    } else if (parent_passes && (child_active || show_inactive)) {
+        return false;
+
+    }
+
+    return true;
+}
+
 gboolean
 group_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
 {
@@ -194,20 +221,19 @@ pe__group_xml(pcmk__output_t *out, va_list args)
     char *count = pcmk__itoa(g_list_length(gIter));
 
     int rc = pcmk_rc_no_output;
-    gboolean print_everything = TRUE;
+
+    gboolean parent_passes = pcmk__str_in_list(only_rsc, rsc_printable_id(rsc), pcmk__str_none) ||
+                             (strstr(rsc->id, ":") != NULL && pcmk__str_in_list(only_rsc, rsc->id, pcmk__str_none));
 
     if (rsc->fns->is_filtered(rsc, only_rsc, TRUE)) {
         free(count);
         return rc;
     }
 
-    print_everything = pcmk__str_in_list(only_rsc, rsc_printable_id(rsc), pcmk__str_none) ||
-                       (strstr(rsc->id, ":") != NULL && pcmk__str_in_list(only_rsc, rsc->id, pcmk__str_none));
-
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
-        if (child_rsc->fns->is_filtered(child_rsc, only_rsc, print_everything)) {
+        if (skip_child_rsc(rsc, child_rsc, parent_passes, only_rsc, show_opts)) {
             continue;
         }
 
@@ -242,14 +268,14 @@ pe__group_default(pcmk__output_t *out, va_list args)
     GList *only_rsc = va_arg(args, GList *);
 
     int rc = pcmk_rc_no_output;
-    gboolean print_everything = TRUE;
+
+
+    gboolean parent_passes = pcmk__str_in_list(only_rsc, rsc_printable_id(rsc), pcmk__str_none) ||
+                             (strstr(rsc->id, ":") != NULL && pcmk__str_in_list(only_rsc, rsc->id, pcmk__str_none));
 
     if (rsc->fns->is_filtered(rsc, only_rsc, TRUE)) {
         return rc;
     }
-
-    print_everything = pcmk__str_in_list(only_rsc, rsc_printable_id(rsc), pcmk__str_none) ||
-                       (strstr(rsc->id, ":") != NULL && pcmk__str_in_list(only_rsc, rsc->id, pcmk__str_none));
 
     if (pcmk_is_set(show_opts, pcmk_show_brief)) {
         GList *rscs = pe__filter_rsc_list(rsc->children, only_rsc);
@@ -269,7 +295,7 @@ pe__group_default(pcmk__output_t *out, va_list args)
         for (GList *gIter = rsc->children; gIter; gIter = gIter->next) {
             pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
-            if (child_rsc->fns->is_filtered(child_rsc, only_rsc, print_everything)) {
+            if (skip_child_rsc(rsc, child_rsc, parent_passes, only_rsc, show_opts)) {
                 continue;
             }
 

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -1341,7 +1341,7 @@ pe__native_is_filtered(pe_resource_t *rsc, GList *only_rsc, gboolean check_paren
     if (pcmk__str_in_list(only_rsc, rsc_printable_id(rsc), pcmk__str_none) ||
         pcmk__str_in_list(only_rsc, rsc->id, pcmk__str_none)) {
         return FALSE;
-    } else if (check_parent) {
+    } else if (check_parent && rsc->parent) {
         pe_resource_t *up = uber_parent(rsc);
 
         if (pe_rsc_is_bundled(rsc)) {


### PR DESCRIPTION
Same as #2423 except opened against 2.1.  I additionally renamed a variable in the first patch and simplified the rsc->parent check.