### PR TITLE
Mid: fenced: Exclude devices that have individually set pcmk_xxxx_timeout.

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1813,7 +1813,14 @@ get_capable_devices(const char *host, const char *action, int timeout, bool suic
     while (g_hash_table_iter_next(&gIter, (void **)&key, (void **)&device)) {
         check_type = target_list_type(device);
         if (pcmk__strcase_any_of(check_type, "status", "dynamic-list", NULL)) {
-            devices_needing_async_query++;
+            char buffer[64] = { 0, };
+            const char *value = NULL;
+
+            snprintf(buffer, sizeof(buffer), "pcmk_%s_timeout", pcmk__str_eq(check_type, "status", pcmk__str_casei)? "status" : "list"); 
+            value = g_hash_table_lookup(device->params, buffer);
+            if (!value) {
+                devices_needing_async_query++;
+            }
         }
     }
 


### PR DESCRIPTION
Hi All,

If pcmk_xxxx_timeout is set and the timeout calculation for asynchronous communication is processed, you will see a message that the timeout is insufficient.
This calculation and message is not needed if pcmk_xxxx_timeout is set individually.

This PR suppresses unnecessary calculations and log output.

---
But....We need to discuss a little more.
(To Ken: It was a little talked about in Bugzilla.)

In the next process, stonith-timeout is calculated by dividing by the number of devices. Is this really necessary?

```
daemon/fenced/fenced_commands,c
(snip)
#define DEFAULT_QUERY_TIMEOUT 20
(snip)
    /* If we have devices that require an async event in order to know what
     * nodes they can fence, we have to give the events a timeout. The total
     * query timeout is divided among those events. */
    if (devices_needing_async_query) {
        per_device_timeout = timeout / devices_needing_async_query;
        if (!per_device_timeout) {
            crm_err("Fencing timeout %ds is too low; using %ds, "
                    "but consider raising to at least %ds",
                    timeout, DEFAULT_QUERY_TIMEOUT,
                    DEFAULT_QUERY_TIMEOUT * devices_needing_async_query);
            per_device_timeout = DEFAULT_QUERY_TIMEOUT;
        } else if (per_device_timeout < DEFAULT_QUERY_TIMEOUT) {
            crm_notice("Fencing timeout %ds is low for the current "
                       "configuration; consider raising to at least %ds",
                       timeout, DEFAULT_QUERY_TIMEOUT * devices_needing_async_query);
        }
    }
(snip)
```

Also, if necessary, this log is very confusing to the user.

```
Fencing timeout XXXXs is low for the current configuration; consider raising to at least 9999s.
```

For example, the following log...
```
Fencing timeout XXXXs is low for the current configuration; consider raising to at least 9999s. (The value must be greater than the 99 number of devices running status/list multiplied by 20s.)
```


I think it is necessary to output the problematic calculation and the number of devices to the log.

What do you think?

---

Best Regards,
Hideo Yamauchi.