### PR TITLE
Mid: libstonithd: "(a later attempt succeeded)" does not appear in history if fencing fails and succeeds at the same time.

### DIFF
--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2539,7 +2539,7 @@ stonith__later_succeeded(stonith_history_t *event, stonith_history_t *top_histor
             pcmk__str_eq(event->target, prev_hp->target, pcmk__str_casei) &&
             pcmk__str_eq(event->action, prev_hp->action, pcmk__str_casei) &&
             pcmk__str_eq(event->delegate, prev_hp->delegate, pcmk__str_casei) &&
-            (event->completed < prev_hp->completed)) {
+            (event->completed <= prev_hp->completed)) {
             ret = TRUE;
             break;
         }
@@ -2565,7 +2565,7 @@ stonith__sort_history(stonith_history_t *history)
         tmp = hp->next;
         if ((hp->state == st_done) || (hp->state == st_failed)) {
             /* sort into new */
-            if ((!new) || (hp->completed > new->completed)) {
+            if ((!new) || (hp->completed >= new->completed)) {
                 hp->next = new;
                 new = hp;
             } else {


### PR DESCRIPTION
Hi All,

In very rare cases, if the fencing operation of the off action fails just before the timeout, the next fencing may succeed at exactly the same time.
This is the case, for example, if the fencing times out while checking the off state, even if the off action is successful.
If the next fencing is an off action, it will succeed immediately because it is already in the off state.

```
(snip)
Migration Summary:

Failed Fencing Actions:
  * reboot of rh83-02 failed: delegate=rh83-02, client=test, origin=rh83-01, completed='2021-07-27 13:21:26 +09:00' 
  * reboot of rh83-02 failed: delegate=rh83-02, client=test, origin=rh83-01, completed='2021-07-27 xx:xx:xx +09:00' (a later attempt succeeded)
  * reboot of rh83-02 failed: delegate=rh83-02, client=test, origin=rh83-01, completed='2021-07-27 xx:xx:xx +09:00' (a later attempt succeeded)
  * reboot of rh83-02 failed: delegate=rh83-02, client=test, origin=rh83-01, completed='2021-07-27 xx:xx:xx +09:00' (a later attempt succeeded)

Fencing History:
  * reboot of rh83-02 successful: delegate=rh83-02, client=test, origin=rh83-01, completed='2021-07-27 13:21:26 +09:00'

```

This fix improves the problem where crm_mon does not show "(a later attempt succeeded)".

 - I think the best fix should change op-> completed to milliseconds(Change from time() to gettimeofday() etc.), but I've kept it to a minimum, considering the impact on the data structure. 

Best Regards,
Hideo Yamauchi.