### PR TITLE
Low: scheduler: Output the clone header if there are no instances.

### DIFF
--- a/cts/scheduler/summary/clone-max-zero.summary
+++ b/cts/scheduler/summary/clone-max-zero.summary
@@ -42,6 +42,7 @@ Revised Cluster Status:
 
   * Full List of Resources:
     * fencing	(stonith:external/ssh):	 Started c001n11
+    * Clone Set: dlm-clone [dlm]:
     * Clone Set: o2cb-clone [o2cb]:
       * Stopped: [ c001n11 c001n12 ]
     * Clone Set: clone-drbd0 [drbd0]:

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -932,6 +932,15 @@ pe__clone_default(pcmk__output_t *out, va_list args)
             out->list_item(out, NULL, "%s: [ %s ]", state, stopped_list);
             free(stopped_list);
             stopped_list_len = 0;
+
+        /* If there are no instances of this clone (perhaps because there are no
+         * nodes configured), simply output the clone header by itself.  This can
+         * come up in PCS testing.
+         */
+        } else if (active_instances == 0) {
+            clone_header(out, &rc, rsc, clone_data);
+            PCMK__OUTPUT_LIST_FOOTER(out, rc);
+            return rc;
         }
     }
 


### PR DESCRIPTION
In the corner case where there's no nodes (and therefore no instances of
a clone resource running anywhere), we still want to output the header.
This can occur in PCS testing.

Regression in 2.1.0 caused by f99d9eecb.