### PR TITLE
Low: tools: If there are no nodes, don't add an extra blank line.

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -335,7 +335,6 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ node1 ]
-
 =#=#=#= Current cib after: Create node1 and bring it online =#=#=#=
 <cib epoch="9" num_updates="2" admin_epoch="0">
   <configuration>

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1475,9 +1475,8 @@ pcmk__cluster_status_text(pcmk__output_t *out, va_list args)
                               section_opts, show_opts));
 
     if (pcmk_is_set(section_opts, pcmk_section_nodes) && unames) {
-        PCMK__OUTPUT_SPACER_IF(out, rc == pcmk_rc_ok);
         CHECK_RC(rc, out->message(out, "node-list", data_set->nodes, unames,
-                                  resources, show_opts));
+                                  resources, show_opts, rc == pcmk_rc_ok));
     }
 
     /* Print resources section, if needed */
@@ -1591,7 +1590,8 @@ cluster_status_xml(pcmk__output_t *out, va_list args)
 
     /*** NODES ***/
     if (pcmk_is_set(section_opts, pcmk_section_nodes)) {
-        out->message(out, "node-list", data_set->nodes, unames, resources, show_opts);
+        out->message(out, "node-list", data_set->nodes, unames, resources,
+                     show_opts, FALSE);
     }
 
     /* Print resources section, if needed */
@@ -1666,7 +1666,8 @@ cluster_status_html(pcmk__output_t *out, va_list args)
 
     /*** NODE LIST ***/
     if (pcmk_is_set(section_opts, pcmk_section_nodes) && unames) {
-        out->message(out, "node-list", data_set->nodes, unames, resources, show_opts);
+        out->message(out, "node-list", data_set->nodes, unames, resources,
+                     show_opts, FALSE);
     }
 
     /* Print resources section, if needed */

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1886,13 +1886,14 @@ node_history_list(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("node-list", "GList *", "GList *", "GList *", "unsigned int")
+PCMK__OUTPUT_ARGS("node-list", "GList *", "GList *", "GList *", "unsigned int", "gboolean")
 static int
 node_list_html(pcmk__output_t *out, va_list args) {
     GList *nodes = va_arg(args, GList *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
     unsigned int show_opts = va_arg(args, unsigned int);
+    gboolean print_spacer G_GNUC_UNUSED = va_arg(args, gboolean);
 
     int rc = pcmk_rc_no_output;
 
@@ -1912,13 +1913,14 @@ node_list_html(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("node-list", "GList *", "GList *", "GList *", "unsigned int")
+PCMK__OUTPUT_ARGS("node-list", "GList *", "GList *", "GList *", "unsigned int", "gboolean")
 static int
 node_list_text(pcmk__output_t *out, va_list args) {
     GList *nodes = va_arg(args, GList *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
     unsigned int show_opts = va_arg(args, unsigned int);
+    gboolean print_spacer = va_arg(args, gboolean);
 
     /* space-separated lists of node names */
     char *online_nodes = NULL;
@@ -1945,7 +1947,7 @@ node_list_text(pcmk__output_t *out, va_list args) {
             continue;
         }
 
-        PCMK__OUTPUT_LIST_HEADER(out, FALSE, rc, "Node List");
+        PCMK__OUTPUT_LIST_HEADER(out, print_spacer == TRUE, rc, "Node List");
 
         /* Get node mode */
         if (node->details->unclean) {
@@ -2047,13 +2049,14 @@ node_list_text(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("node-list", "GList *", "GList *", "GList *", "unsigned int")
+PCMK__OUTPUT_ARGS("node-list", "GList *", "GList *", "GList *", "unsigned int", "gboolean")
 static int
 node_list_xml(pcmk__output_t *out, va_list args) {
     GList *nodes = va_arg(args, GList *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
     unsigned int show_opts = va_arg(args, unsigned int);
+    gboolean print_spacer G_GNUC_UNUSED = va_arg(args, gboolean);
 
     out->begin_list(out, NULL, NULL, "nodes");
     for (GList *gIter = nodes; gIter != NULL; gIter = gIter->next) {

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -403,10 +403,9 @@ print_cluster_status(pe_working_set_t * data_set, unsigned int show_opts)
 
     all = g_list_prepend(all, (gpointer) "*");
 
-    rc = out->message(out, "node-list", data_set->nodes, all, all, show_opts);
-    PCMK__OUTPUT_SPACER_IF(out, rc == pcmk_rc_ok);
+    rc = out->message(out, "node-list", data_set->nodes, all, all, show_opts, FALSE);
     rc = out->message(out, "resource-list", data_set, show_opts | pcmk_show_inactive_rscs,
-                      FALSE, all, all, FALSE);
+                      FALSE, all, all, rc == pcmk_rc_ok);
 
     if (options.show_attrs) {
         rc = out->message(out, "node-attribute-list", data_set,


### PR DESCRIPTION
This typically should only come up if --exclude=nodes is passed to
crm_mon, but it's possible someone might run crm_mon against a CIB with
no nodes.  In this case, do not output an extra blank line between the
cluster status section and the resource list section.