### PR TITLE
Use g_list_foreach where possible

### DIFF
--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -769,7 +769,6 @@ static void cib_device_update(pe_resource_t *rsc, pe_working_set_t *data_set)
 static void
 cib_devices_update(void)
 {
-    GList *gIter = NULL;
     GHashTableIter iter;
     stonith_device_t *device = NULL;
 
@@ -799,10 +798,7 @@ cib_devices_update(void)
      */
     g_list_free_full(stonith_watchdog_targets, free);
     stonith_watchdog_targets = NULL;
-
-    for (gIter = fenced_data_set->resources; gIter != NULL; gIter = gIter->next) {
-        cib_device_update(gIter->data, fenced_data_set);
-    }
+    g_list_foreach(fenced_data_set->resources, (GFunc) cib_device_update, fenced_data_set);
 
     g_hash_table_iter_init(&iter, device_list);
     while (g_hash_table_iter_next(&iter, NULL, (void **)&device)) {

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -1304,12 +1304,7 @@ clone_expand(pe_resource_t * rsc, pe_working_set_t * data_set)
 
     get_clone_variant_data(clone_data, rsc);
 
-    gIter = rsc->actions;
-    for (; gIter != NULL; gIter = gIter->next) {
-        pe_action_t *op = (pe_action_t *) gIter->data;
-
-        rsc->cmds->action_flags(op, NULL);
-    }
+    g_list_foreach(rsc->actions, (GFunc) rsc->cmds->action_flags, NULL);
 
     if (clone_data->start_notify) {
         collect_notification_data(rsc, TRUE, TRUE, clone_data->start_notify);

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -2394,13 +2394,7 @@ LogActions(pe_resource_t * rsc, pe_working_set_t * data_set)
     }
 
     if (rsc->children) {
-        GList *gIter = NULL;
-
-        for (gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
-
-            LogActions(child_rsc, data_set);
-        }
+        g_list_foreach(rsc->children, (GFunc) LogActions, data_set);
         return;
     }
 

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -640,19 +640,13 @@ set_role_unpromoted(pe_resource_t *rsc, bool current)
 }
 
 static void
-set_role_promoted(pe_resource_t *rsc)
+set_role_promoted(pe_resource_t *rsc, gpointer user_data)
 {
-    GList *gIter = rsc->children;
-
     if (rsc->next_role == RSC_ROLE_UNKNOWN) {
         pe__set_next_role(rsc, RSC_ROLE_PROMOTED, "promoted instance");
     }
 
-    for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
-
-        set_role_promoted(child_rsc);
-    }
+    g_list_foreach(rsc->children, (GFunc) set_role_promoted, NULL);
 }
 
 pe_node_t *
@@ -798,7 +792,7 @@ pcmk__set_instance_roles(pe_resource_t *rsc, pe_working_set_t *data_set)
         chosen->count++;
         pe_rsc_info(rsc, "Promoting %s (%s %s)",
                     child_rsc->id, role2text(child_rsc->role), chosen->details->uname);
-        set_role_promoted(child_rsc);
+        set_role_promoted(child_rsc, NULL);
         promoted++;
     }
 

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -684,11 +684,7 @@ disallow_node(pe_resource_t *rsc, const char *uname)
         ((pe_node_t *) match)->rsc_discover_mode = pe_discover_never;
     }
     if (rsc->children) {
-        GList *child;
-
-        for (child = rsc->children; child != NULL; child = child->next) {
-            disallow_node((pe_resource_t *) (child->data), uname);
-        }
+        g_list_foreach(rsc->children, (GFunc) disallow_node, (gpointer) uname);
     }
 }
 
@@ -699,7 +695,6 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
 {
     if (replica->child && valid_network(data)) {
         GHashTableIter gIter;
-        GList *rsc_iter = NULL;
         pe_node_t *node = NULL;
         xmlNode *xml_remote = NULL;
         char *id = crm_strdup_printf("%s-%d", data->prefix, replica->offset);
@@ -775,9 +770,7 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
          * @TODO Possible alternative: ensure bundles are unpacked before other
          * resources, so the weight is correct before any copies are made.
          */
-        for (rsc_iter = data_set->resources; rsc_iter; rsc_iter = rsc_iter->next) {
-            disallow_node((pe_resource_t *) (rsc_iter->data), uname);
-        }
+        g_list_foreach(data_set->resources, (GFunc) disallow_node, (gpointer) uname);
 
         replica->node = pe__copy_node(node);
         replica->node->weight = 500;

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -184,14 +184,11 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
 }
 
 static void
-recursive_clear_unique(pe_resource_t *rsc)
+recursive_clear_unique(pe_resource_t *rsc, gpointer user_data)
 {
     pe__clear_resource_flags(rsc, pe_rsc_unique);
     add_hash_param(rsc->meta, XML_RSC_ATTR_UNIQUE, XML_BOOLEAN_FALSE);
-
-    for (GList *child = rsc->children; child != NULL; child = child->next) {
-        recursive_clear_unique((pe_resource_t *) child->data);
-    }
+    g_list_foreach(rsc->children, (GFunc) recursive_clear_unique, NULL);
 }
 
 gboolean
@@ -223,8 +220,8 @@ native_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
          * correct). We have to clear this resource explicitly because it isn't
          * hooked into the parent's children yet.
          */
-        recursive_clear_unique(parent);
-        recursive_clear_unique(rsc);
+        recursive_clear_unique(parent, NULL);
+        recursive_clear_unique(rsc, NULL);
     }
     if (!pcmk_is_set(ra_caps, pcmk_ra_cap_promotable)
         && pcmk_is_set(parent->flags, pe_rsc_promotable)) {

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -600,13 +600,7 @@ setup_container(pe_resource_t * rsc, pe_working_set_t * data_set)
     const char *container_id = NULL;
 
     if (rsc->children) {
-        GList *gIter = rsc->children;
-
-        for (; gIter != NULL; gIter = gIter->next) {
-            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
-
-            setup_container(child_rsc, data_set);
-        }
+        g_list_foreach(rsc->children, (GFunc) setup_container, data_set);
         return;
     }
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1870,14 +1870,7 @@ main(int argc, char **argv)
 
         case cmd_cts:
             rc = pcmk_rc_ok;
-
-            for (GList *lpc = data_set->resources; lpc != NULL;
-                 lpc = lpc->next) {
-
-                rsc = (pe_resource_t *) lpc->data;
-                cli_resource_print_cts(out, rsc);
-            }
-
+            g_list_foreach(data_set->resources, (GFunc) cli_resource_print_cts, out);
             cli_resource_print_cts_constraints(data_set);
             break;
 

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -56,7 +56,6 @@ int cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, int cib_optio
 
 /* print */
 void cli_resource_print_cts(pe_resource_t * rsc, pcmk__output_t *out);
-void cli_resource_print_raw(pcmk__output_t *out, pe_resource_t * rsc);
 void cli_resource_print_cts_constraints(pe_working_set_t * data_set);
 
 int cli_resource_print(pe_resource_t *rsc, pe_working_set_t *data_set, bool expanded);

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -55,7 +55,7 @@ int cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, int cib_optio
                                    const char *rsc, const char *node, gboolean promoted_role_only);
 
 /* print */
-void cli_resource_print_cts(pcmk__output_t *out, pe_resource_t * rsc);
+void cli_resource_print_cts(pe_resource_t * rsc, pcmk__output_t *out);
 void cli_resource_print_raw(pcmk__output_t *out, pe_resource_t * rsc);
 void cli_resource_print_cts_constraints(pe_working_set_t * data_set);
 

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -1087,18 +1087,11 @@ main(int argc, char **argv)
         }
 
         if (!out->is_quiet(out)) {
-            GList *gIter = NULL;
-
             PCMK__OUTPUT_SPACER_IF(out, printed == pcmk_rc_ok);
             out->begin_list(out, NULL, NULL, "Transition Summary");
 
             LogNodeActions(data_set);
-            for (gIter = data_set->resources; gIter != NULL; gIter = gIter->next) {
-                pe_resource_t *rsc = (pe_resource_t *) gIter->data;
-
-                LogActions(rsc, data_set);
-            }
-
+            g_list_foreach(data_set->resources, (GFunc) LogActions, data_set);
             out->end_list(out);
             printed = pcmk_rc_ok;
         }


### PR DESCRIPTION
But, note all the caveats in the first patch.  I could go through and work on some of those to convert more for loops.  An additional idea I had was to add something to call out->message() for each item in a list.  That comes up in a fair number of places.

I have not tested timings for any of this, but I don't think there should be any serious performance hit.  g_list_foreach is a single function call that contains a while loop and a call of the given function for each element.  So, the difference should be the addition of a single function call.