### PR TITLE
Mid: fenced: Added nanosecond field to operation completion data.

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2608,6 +2608,21 @@ bool fencing_peer_active(crm_node_t *peer)
     return FALSE;
 }
 
+void set_fencing_completed(remote_fencing_op_t * op)
+{
+#ifdef CLOCK_MONOTONIC
+    struct timespec tv;
+
+    clock_gettime(CLOCK_MONOTONIC, &tv);
+
+    op->completed = tv.tv_sec;
+    op->completed_nsec = tv.tv_nsec;
+#else
+    op->completed = time(NULL);
+    op->completed_nsec = 0L;
+#endif
+}
+
 /*!
  * \internal
  * \brief Determine if we need to use an alternate node to

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -490,7 +490,7 @@ remote_op_done(remote_fencing_op_t * op, xmlNode * data, int rc, int dup)
     xmlNode *local_data = NULL;
     gboolean op_merged = FALSE;
 
-    op->completed = time(NULL);
+    set_fencing_completed(op);
     clear_remote_op_timers(op);
     undo_op_remap(op);
 
@@ -976,7 +976,7 @@ stonith_manual_ack(xmlNode * msg, remote_fencing_op_t * op)
     xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, msg, LOG_ERR);
 
     op->state = st_done;
-    op->completed = time(NULL);
+    set_fencing_completed(op);
     op->delegate = strdup("a human");
 
     crm_notice("Injecting manual confirmation that %s is safely off/down",

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -155,6 +155,9 @@ typedef struct remote_fencing_op_s {
      * completes, the duplicate operations will be closed out as well. */
     GList *duplicates;
 
+    /*! The point at which the remote operation completed(nsec) */
+    long long completed_nsec;
+
 } remote_fencing_op_t;
 
 /*!
@@ -257,6 +260,8 @@ int stonith_fence_history(xmlNode *msg, xmlNode **output,
 void stonith_fence_history_trim(void);
 
 bool fencing_peer_active(crm_node_t *peer);
+
+void set_fencing_completed(remote_fencing_op_t * op);
 
 int stonith_manual_ack(xmlNode * msg, remote_fencing_op_t * op);
 

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -135,6 +135,7 @@ void stonith__device_parameter_flags(uint32_t *device_flags,
 #  define F_STONITH_ORIGIN        "st_origin"
 #  define F_STONITH_HISTORY_LIST  "st_history"
 #  define F_STONITH_DATE          "st_date"
+#  define F_STONITH_DATE_NSEC     "st_date_nsec"
 #  define F_STONITH_STATE         "st_state"
 #  define F_STONITH_ACTIVE        "st_active"
 #  define F_STONITH_DIFFERENTIAL  "st_differential"

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -110,6 +110,7 @@ typedef struct stonith_history_s {
     int state;
     time_t completed;
     struct stonith_history_s *next;
+    long completed_nsec;
 } stonith_history_t;
 
 typedef struct stonith_s stonith_t;


### PR DESCRIPTION
Hi All,

This is a revised version of the following revised PR.
 - https://github.com/ClusterLabs/pacemaker/pull/2444

Added a nanosec field to the fencing completion time to improve the fencing history display issue that fails and succeeds at exactly the same time.

This feature only works in environments that support CLOCK_MONOTONIC.

As for stonith_api_time (), I haven't modified it because I only need to know the latest time of st_done.

Also, the comparison of nanoseconds (stonith__later_succeeded () and stonith__sort_history ()) is based on the idea that the exact same nanoseconds will not occur.
If there is exactly the same nanosecond data, it may be better to output debug log etc.
(However, in this case, stonith__sort_history() have no control over the sort order.)

Best Regards,
Hideo Yamauchi.