### PR TITLE
Med: tools: Fix a segfault when calling "crm_simulate -U".

### DIFF
--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1801,7 +1801,7 @@ node_capacity_xml(pcmk__output_t *out, va_list args)
                                                        "node", node->details->uname,
                                                        "comment", comment,
                                                        NULL);
-    g_hash_table_foreach(node->details->utilization, add_dump_node, &xml_node);
+    g_hash_table_foreach(node->details->utilization, add_dump_node, xml_node);
 
     return pcmk_rc_ok;
 }
@@ -2553,7 +2553,7 @@ resource_util_xml(pcmk__output_t *out, va_list args)
                                                        "node", node->details->uname,
                                                        "function", fn,
                                                        NULL);
-    g_hash_table_foreach(rsc->utilization, add_dump_node, &xml_node);
+    g_hash_table_foreach(rsc->utilization, add_dump_node, xml_node);
 
     return pcmk_rc_ok;
 }


### PR DESCRIPTION
The argument to add_dump_node is an xmlNodePtr.  Adding an ampersand at
these two locations means we are passing it an xmlNodePtr *, which
results in segfaults when referencing.