### PR TITLE
Minor improvements to failed actions in status display

### DIFF
--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -62,9 +62,13 @@ typedef enum {
     pcmk_show_rscs_by_node  = 1 << 6,
     pcmk_show_pending       = 1 << 7,
     pcmk_show_rsc_only      = 1 << 8,
+    pcmk_show_failed_detail = 1 << 9,
 } pcmk_show_opt_e;
 
-#define pcmk_show_details           (pcmk_show_clone_detail | pcmk_show_node_id | pcmk_show_implicit_rscs)
+#define pcmk_show_details   (pcmk_show_clone_detail     \
+                             | pcmk_show_node_id        \
+                             | pcmk_show_implicit_rscs  \
+                             | pcmk_show_failed_detail)
 
 #ifdef __cplusplus
 }

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1504,7 +1504,7 @@ pcmk__cluster_status_text(pcmk__output_t *out, va_list args)
         && xml_has_children(data_set->failed)) {
 
         CHECK_RC(rc, out->message(out, "failed-action-list", data_set, unames,
-                                  resources, rc == pcmk_rc_ok));
+                                  resources, show_opts, rc == pcmk_rc_ok));
     }
 
     /* Print failed stonith actions */
@@ -1622,7 +1622,7 @@ cluster_status_xml(pcmk__output_t *out, va_list args)
         && xml_has_children(data_set->failed)) {
 
         out->message(out, "failed-action-list", data_set, unames, resources,
-                     FALSE);
+                     show_opts, FALSE);
     }
 
     /* Print stonith history */
@@ -1695,7 +1695,7 @@ cluster_status_html(pcmk__output_t *out, va_list args)
         && xml_has_children(data_set->failed)) {
 
         out->message(out, "failed-action-list", data_set, unames, resources,
-                     FALSE);
+                     show_opts, FALSE);
     }
 
     /* Print failed stonith actions */

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -210,9 +210,6 @@ failed_action_string(xmlNodePtr xml_op, gboolean print_detail)
     if (pcmk__str_empty(node_name)) {
         node_name = "unknown node";
     }
-    if (pcmk__str_empty(exit_reason)) {
-        exit_reason = "none";
-    }
     if (pcmk__str_empty(exit_status)) {
         exit_status = "unknown exit status";
     }
@@ -222,12 +219,14 @@ failed_action_string(xmlNodePtr xml_op, gboolean print_detail)
 
     str = g_string_sized_new(strlen(op_key) + strlen(node_name)
                              + strlen(exit_status) + strlen(call_id)
-                             + strlen(lrm_status) + strlen(exit_reason) + 50);
+                             + strlen(lrm_status) + 50); // rough estimate
 
-    g_string_printf(str, "%s on %s '%s' (%d): call=%s, status=%s, "
-                         "exitreason='%s'",
-                    op_key, node_name, exit_status, rc, call_id,
-                    lrm_status, exit_reason);
+    g_string_printf(str, "%s on %s '%s' (%d): call=%s, status=%s",
+                    op_key, node_name, exit_status, rc, call_id, lrm_status);
+
+    if (!pcmk__str_empty(exit_reason)) {
+        g_string_append_printf(str, ", exitreason='%s'", exit_reason);
+    }
 
     if (crm_element_value_epoch(xml_op, XML_RSC_OP_LAST_CHANGE,
                                 &last_change) == pcmk_ok) {

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -224,33 +224,31 @@ failed_action_string(xmlNodePtr xml_op, gboolean print_detail)
                              + strlen(exit_status) + strlen(call_id)
                              + strlen(lrm_status) + strlen(exit_reason) + 50);
 
+    g_string_printf(str, "%s on %s '%s' (%d): call=%s, status=%s, "
+                         "exitreason='%s'",
+                    op_key, node_name, exit_status, rc, call_id,
+                    lrm_status, exit_reason);
+
     if (crm_element_value_epoch(xml_op, XML_RSC_OP_LAST_CHANGE,
                                 &last_change) == pcmk_ok) {
         crm_time_t *crm_when = crm_time_new(NULL);
         char *time_s = NULL;
 
         crm_time_set_timet(crm_when, &last_change);
-        time_s = crm_time_as_string(crm_when, crm_time_log_date | crm_time_log_timeofday | crm_time_log_with_timezone);
-
-        if (pcmk__str_empty(queue_time)) {
-            queue_time = "unknown ";
-        }
-        if (pcmk__str_empty(exec_time)) {
-            exec_time = "unknown ";
-        }
-        g_string_printf(str, "%s on %s '%s' (%d): call=%s, status='%s', "
-                        "exitreason='%s', " XML_RSC_OP_LAST_CHANGE
-                        "='%s', queued=%sms, exec=%sms",
-                        op_key, node_name, exit_status, rc, call_id,
-                        lrm_status, exit_reason, time_s, queue_time,
-                        exec_time);
-
+        time_s = crm_time_as_string(crm_when,
+                                    crm_time_log_date
+                                    |crm_time_log_timeofday
+                                    |crm_time_log_with_timezone);
+        g_string_append_printf(str, ", " XML_RSC_OP_LAST_CHANGE "='%s'",
+                               time_s);
         crm_time_free(crm_when);
         free(time_s);
-    } else {
-        g_string_printf(str, "%s on %s '%s' (%d): call=%s, status=%s, exitreason='%s'",
-                        op_key, node_name, exit_status, rc, call_id,
-                        lrm_status, exit_reason);
+    }
+    if (!pcmk__str_empty(queue_time)) {
+        g_string_append_printf(str, ", queued=%sms", queue_time);
+    }
+    if (!pcmk__str_empty(exec_time)) {
+        g_string_append_printf(str, ", exec=%sms", exec_time);
     }
     return str;
 }

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -191,7 +191,8 @@ failed_action_string(xmlNodePtr xml_op, gboolean print_detail)
 
     const char *exit_status = NULL;
     const char *lrm_status = NULL;
-    time_t last_change = 0;
+    const char *last_change_str = NULL;
+    time_t last_change_epoch = 0;
     GString *str = NULL;
 
     pcmk__scan_min_int(crm_element_value(xml_op, XML_LRM_ATTR_RC), &rc, 0);
@@ -229,19 +230,12 @@ failed_action_string(xmlNodePtr xml_op, gboolean print_detail)
     }
 
     if (crm_element_value_epoch(xml_op, XML_RSC_OP_LAST_CHANGE,
-                                &last_change) == pcmk_ok) {
-        crm_time_t *crm_when = crm_time_new(NULL);
-        char *time_s = NULL;
-
-        crm_time_set_timet(crm_when, &last_change);
-        time_s = crm_time_as_string(crm_when,
-                                    crm_time_log_date
-                                    |crm_time_log_timeofday
-                                    |crm_time_log_with_timezone);
-        g_string_append_printf(str, ", " XML_RSC_OP_LAST_CHANGE "='%s'",
-                               time_s);
-        crm_time_free(crm_when);
-        free(time_s);
+                                &last_change_epoch) == pcmk_ok) {
+        last_change_str = pcmk__epoch2str(&last_change_epoch);
+        if (last_change_str != NULL) {
+            g_string_append_printf(str, ", " XML_RSC_OP_LAST_CHANGE "='%s'",
+                                   last_change_str);
+        }
     }
     if (!pcmk__str_empty(queue_time)) {
         g_string_append_printf(str, ", queued=%sms", queue_time);

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -176,7 +176,8 @@ append_dump_text(gpointer key, gpointer value, gpointer user_data)
 }
 
 static char *
-failed_action_string(xmlNodePtr xml_op) {
+failed_action_string(xmlNodePtr xml_op, gboolean print_detail)
+{
     const char *op_key = crm_element_value(xml_op, XML_LRM_ATTR_TASK_KEY);
     int rc;
     int status;
@@ -1159,22 +1160,26 @@ cluster_times_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("failed-action", "xmlNodePtr")
+PCMK__OUTPUT_ARGS("failed-action", "xmlNodePtr", "unsigned int")
 static int
-failed_action_text(pcmk__output_t *out, va_list args) {
+failed_action_text(pcmk__output_t *out, va_list args)
+{
     xmlNodePtr xml_op = va_arg(args, xmlNodePtr);
+    unsigned int show_opts = va_arg(args, unsigned int);
 
-    char *s = failed_action_string(xml_op);
+    gboolean show_detail = pcmk_is_set(show_opts, pcmk_show_failed_detail);
+    char *s = failed_action_string(xml_op, show_detail);
 
     out->list_item(out, NULL, "%s", s);
     free(s);
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("failed-action", "xmlNodePtr")
+PCMK__OUTPUT_ARGS("failed-action", "xmlNodePtr", "unsigned int")
 static int
 failed_action_xml(pcmk__output_t *out, va_list args) {
     xmlNodePtr xml_op = va_arg(args, xmlNodePtr);
+    unsigned int show_opts G_GNUC_UNUSED = va_arg(args, unsigned int);
 
     const char *op_key = crm_element_value(xml_op, XML_LRM_ATTR_TASK_KEY);
     int rc;
@@ -1233,12 +1238,13 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
 }
 
 PCMK__OUTPUT_ARGS("failed-action-list", "pe_working_set_t *", "GList *",
-                  "GList *", "gboolean")
+                  "GList *", "unsigned int", "gboolean")
 static int
 failed_action_list(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
+    unsigned int show_opts = va_arg(args, gboolean);
     gboolean print_spacer = va_arg(args, gboolean);
 
     xmlNode *xml_op = NULL;
@@ -1272,7 +1278,7 @@ failed_action_list(pcmk__output_t *out, va_list args) {
         free(rsc);
 
         PCMK__OUTPUT_LIST_HEADER(out, print_spacer, rc, "Failed Resource Actions");
-        out->message(out, "failed-action", xml_op);
+        out->message(out, "failed-action", xml_op, show_opts);
     }
 
     PCMK__OUTPUT_LIST_FOOTER(out, rc);

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -417,7 +417,7 @@ print_cluster_status(pe_working_set_t * data_set, unsigned int show_opts)
                           0, show_opts, rc == pcmk_rc_ok);
 
         out->message(out, "failed-action-list", data_set, all, all,
-                     rc == pcmk_rc_ok);
+                     0, rc == pcmk_rc_ok);
     }
 
     g_list_free(all);


### PR DESCRIPTION
This is the start of a project to improve the display of failed actions in status output (crm_mon/crm_simulate). The changes at this point are minimal. An example of the previous output:

    * rsc1_monitor_10000 on dhcp180 'not running' (7): call=16, status='complete', exitreason='none', last-rc-change='2016-03-30 08:46:11 -05:00', queued=0ms, exec=0ms

would now become:

    * rsc1_monitor_10000 on dhcp180 'not running' (7): call=16, status=complete, last-rc-change='Wed Mar 30 08:46:11 2016', queued=0ms, exec=0ms

Note that exitreason='none' has been dropped (it will now only be shown if it is available, never 'none'), and the date/time format is now consistent with other date/time displays (such as the Last updated/Last changed fields). Additionally, the queued/exec times will only be shown now when available.

(Side note: we should probably add some failed actions to the crm_mon regression test ...)