### PR TITLE
Refactoring to prepare for improved failure messages

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2049,6 +2049,7 @@ AC_CONFIG_FILES(Makefile                                            \
                 lib/common/tests/agents/Makefile                    \
                 lib/common/tests/cmdline/Makefile                   \
                 lib/common/tests/flags/Makefile                     \
+                lib/common/tests/iso8601/Makefile                   \
                 lib/common/tests/operations/Makefile                \
                 lib/common/tests/results/Makefile                   \
                 lib/common/tests/strings/Makefile                   \

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -77,7 +77,7 @@ fail_pending_op(gpointer key, gpointer value, gpointer user_data)
     event.timeout = 0;
     event.interval_ms = op->interval_ms;
     event.rc = PCMK_OCF_UNKNOWN_ERROR;
-    event.op_status = PCMK_LRM_OP_NOT_CONNECTED;
+    event.op_status = PCMK_EXEC_NOT_CONNECTED;
     event.t_run = (unsigned int) op->start_time;
     event.t_rcchange = (unsigned int) op->start_time;
 

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -426,7 +426,7 @@ enum crmd_fsa_input {
 
 #  define R_IN_RECOVERY     0x80000000ULL
 
-#define CRM_DIRECT_NACK_RC (99) // Deprecated (see PCMK_LRM_OP_INVALID)
+#define CRM_DIRECT_NACK_RC (99) // Deprecated (see PCMK_EXEC_INVALID)
 
 enum crmd_fsa_cause {
     C_UNKNOWN = 0,

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -472,7 +472,7 @@ monitor_timeout_cb(gpointer data)
     crm_info("Timed out waiting for remote poke response from %s%s",
              cmd->rsc_id, (lrm_state? "" : " (no LRM state)"));
     cmd->monitor_timeout_id = 0;
-    cmd->op_status = PCMK_LRM_OP_TIMEOUT;
+    cmd->op_status = PCMK_EXEC_TIMEOUT;
     cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
 
     if (lrm_state && lrm_state->remote_ra_data) {
@@ -510,7 +510,7 @@ synthesize_lrmd_success(lrm_state_t *lrm_state, const char *rsc_id, const char *
     op.rsc_id = rsc_id;
     op.op_type = op_type;
     op.rc = PCMK_OCF_OK;
-    op.op_status = PCMK_LRM_OP_DONE;
+    op.op_status = PCMK_EXEC_DONE;
     op.t_run = (unsigned int) time(NULL);
     op.t_rcchange = op.t_run;
     op.call_id = generate_callid();
@@ -530,7 +530,7 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
               (op->op_type? op->op_type : ""), (op->op_type? " " : ""),
               lrmd_event_type2str(op->type), op->remote_nodename,
               services_ocf_exitcode_str(op->rc), op->rc,
-              services_lrm_status_str(op->op_status), op->op_status);
+              pcmk_exec_status_str(op->op_status), op->op_status);
 
     lrm_state = lrm_state_find(op->remote_nodename);
     if (!lrm_state || !lrm_state->remote_ra_data) {
@@ -607,7 +607,7 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
 
             if (op->connection_rc == -ENOKEY) {
                 // Hard error, don't retry
-                cmd->op_status = PCMK_LRM_OP_ERROR;
+                cmd->op_status = PCMK_EXEC_ERROR;
                 cmd->rc = PCMK_OCF_INVALID_PARAM;
                 cmd->exit_reason = strdup("Authentication key not readable");
 
@@ -619,14 +619,14 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
             } else {
                 crm_trace("can't reschedule start, remaining timeout too small %d",
                           cmd->remaining_timeout);
-                cmd->op_status = PCMK_LRM_OP_TIMEOUT;
+                cmd->op_status = PCMK_EXEC_TIMEOUT;
                 cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
             }
 
         } else {
             lrm_state_reset_tables(lrm_state, TRUE);
             cmd->rc = PCMK_OCF_OK;
-            cmd->op_status = PCMK_LRM_OP_DONE;
+            cmd->op_status = PCMK_EXEC_DONE;
             ra_data->active = TRUE;
         }
 
@@ -646,7 +646,7 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
          * only fail if the send fails, or the response times out. */
         if (!cmd->reported_success) {
             cmd->rc = PCMK_OCF_OK;
-            cmd->op_status = PCMK_LRM_OP_DONE;
+            cmd->op_status = PCMK_EXEC_DONE;
             report_remote_ra_result(cmd);
             cmd->reported_success = 1;
         }
@@ -665,7 +665,7 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
     } else if (op->type == lrmd_event_disconnect && pcmk__str_eq(cmd->action, "monitor", pcmk__str_casei)) {
         if (ra_data->active == TRUE && (cmd->cancel == FALSE)) {
             cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
-            cmd->op_status = PCMK_LRM_OP_ERROR;
+            cmd->op_status = PCMK_EXEC_ERROR;
             report_remote_ra_result(cmd);
             crm_err("Remote connection to %s unexpectedly dropped during monitor",
                     lrm_state->node_name);
@@ -722,8 +722,7 @@ handle_remote_ra_stop(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd)
 
     if (cmd) {
         cmd->rc = PCMK_OCF_OK;
-        cmd->op_status = PCMK_LRM_OP_DONE;
-
+        cmd->op_status = PCMK_EXEC_DONE;
         report_remote_ra_result(cmd);
     }
 }
@@ -754,7 +753,7 @@ handle_remote_ra_start(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd, int timeo
                                           timeout_used);
     if (rc != pcmk_rc_ok) {
         cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
-        cmd->op_status = PCMK_LRM_OP_ERROR;
+        cmd->op_status = PCMK_EXEC_ERROR;
     }
     return rc;
 }
@@ -802,11 +801,11 @@ handle_remote_ra_exec(gpointer user_data)
                 rc = lrm_state_poke_connection(lrm_state);
                 if (rc < 0) {
                     cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
-                    cmd->op_status = PCMK_LRM_OP_ERROR;
+                    cmd->op_status = PCMK_EXEC_ERROR;
                 }
             } else {
                 rc = -1;
-                cmd->op_status = PCMK_LRM_OP_DONE;
+                cmd->op_status = PCMK_EXEC_DONE;
                 cmd->rc = PCMK_OCF_NOT_RUNNING;
             }
 
@@ -838,7 +837,7 @@ handle_remote_ra_exec(gpointer user_data)
         } else if (!strcmp(cmd->action, "migrate_to")) {
             ra_data->migrate_status = expect_takeover;
             cmd->rc = PCMK_OCF_OK;
-            cmd->op_status = PCMK_LRM_OP_DONE;
+            cmd->op_status = PCMK_EXEC_DONE;
             report_remote_ra_result(cmd);
         } else if (pcmk__str_any_of(cmd->action, CRMD_ACTION_RELOAD,
                                     CRMD_ACTION_RELOAD_AGENT, NULL))  {
@@ -852,7 +851,7 @@ handle_remote_ra_exec(gpointer user_data)
              * so this would work for that purpose as well.
              */
             cmd->rc = PCMK_OCF_OK;
-            cmd->op_status = PCMK_LRM_OP_DONE;
+            cmd->op_status = PCMK_EXEC_DONE;
             report_remote_ra_result(cmd);
         }
 
@@ -959,7 +958,7 @@ fail_all_monitor_cmds(GList * list)
         cmd = gIter->data;
 
         cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
-        cmd->op_status = PCMK_LRM_OP_ERROR;
+        cmd->op_status = PCMK_EXEC_ERROR;
         crm_trace("Pre-emptively failing %s %s (interval=%u, %s)",
                   cmd->action, cmd->rsc_id, cmd->interval_ms, cmd->userdata);
         report_remote_ra_result(cmd);

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -241,7 +241,7 @@ controld_record_action_timeout(crm_action_t *action)
      * to distinguish those situations, but perhaps PCMK_OCF_TIMEOUT would be
      * preferable anyway.
      */
-    op = pcmk__event_from_graph_action(NULL, action, PCMK_LRM_OP_TIMEOUT,
+    op = pcmk__event_from_graph_action(NULL, action, PCMK_EXEC_TIMEOUT,
                                        PCMK_OCF_UNKNOWN_ERROR);
     op->call_id = -1;
     op->user_data = pcmk__transition_key(transition_graph->id, action->id,

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -357,7 +357,7 @@ process_graph_event(xmlNode *event, const char *event_node)
     }
 
     crm_element_value_int(event, XML_LRM_ATTR_OPSTATUS, &status);
-    if (status == PCMK_LRM_OP_PENDING) {
+    if (status == PCMK_EXEC_PENDING) {
         return;
     }
 
@@ -398,7 +398,7 @@ process_graph_event(xmlNode *event, const char *event_node)
              * scheduled in.
              */
 
-            if (status == PCMK_LRM_OP_CANCELLED) {
+            if (status == PCMK_EXEC_CANCELLED) {
                 confirm_cancel_action(id, get_node_id(event));
                 goto bail;
             }
@@ -464,11 +464,11 @@ process_graph_event(xmlNode *event, const char *event_node)
         uname = "unknown node";
     }
 
-    if (status == PCMK_LRM_OP_INVALID) {
+    if (status == PCMK_EXEC_INVALID) {
         // We couldn't attempt the action
         crm_info("Transition %d action %d (%s on %s): %s",
                  transition_num, action_num, id, uname,
-                 services_lrm_status_str(status));
+                 pcmk_exec_status_str(status));
 
     } else if (desc && update_failcount(event, event_node, rc, target_rc,
                                         (transition_num == -1), FALSE)) {

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -25,7 +25,7 @@ void process_graph_event(xmlNode *event, const char *event_node);
 /* utils */
 crm_action_t *controld_get_action(int id);
 extern gboolean stop_te_timer(crm_action_timer_t * timer);
-extern const char *get_rsc_state(const char *task, enum op_status status);
+const char *get_rsc_state(const char *task, enum pcmk_exec_status status);
 
 /* unpack */
 extern gboolean process_te_message(xmlNode * msg, xmlNode * xml_data);

--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -169,8 +169,8 @@ test_exit(crm_exit_t exit_code)
              lrmd_event_type2str(event->type),                          \
              event->rsc_id,                                             \
              event->op_type ? event->op_type : "none",                  \
-             services_ocf_exitcode_str(event->rc),                              \
-             services_lrm_status_str(event->op_status));                \
+             services_ocf_exitcode_str(event->rc),                      \
+             pcmk_exec_status_str(event->op_status));                   \
     crm_info("%s", event_buf_v0);
 
 static void
@@ -196,7 +196,8 @@ read_events(lrmd_event_data_t * event)
             print_result(printf("API-CALL SUCCESSFUL for 'exec'\n"));
         } else {
             print_result(printf("API-CALL FAILURE for 'exec', rc:%d lrmd_op_status:%s\n",
-                                event->rc, services_lrm_status_str(event->op_status)));
+                                event->rc,
+                                pcmk_exec_status_str(event->op_status)));
             test_exit(CRM_EX_ERROR);
         }
 

--- a/include/crm/Makefile.am
+++ b/include/crm/Makefile.am
@@ -14,7 +14,8 @@ headerdir=$(pkgincludedir)/crm
 header_HEADERS		= cib.h cluster.h compatibility.h crm.h \
 			  lrmd.h msg_xml.h services.h stonith-ng.h \
 			  crm_compat.h		\
-			  msg_xml_compat.h
+			  msg_xml_compat.h	\
+			  services_compat.h
 
 noinst_HEADERS		= lrmd_internal.h services_internal.h
 

--- a/include/crm/common/Makefile.am
+++ b/include/crm/common/Makefile.am
@@ -22,4 +22,5 @@ noinst_HEADERS = internal.h alerts_internal.h \
 		 iso8601_internal.h remote_internal.h xml_internal.h \
 		 ipc_internal.h output_internal.h cmdline_internal.h	\
 		 curses_internal.h attrd_internal.h options_internal.h	\
+		 results_internal.h	\
 		 strings_internal.h lists_internal.h logging_internal.h

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -23,6 +23,7 @@
 #include <crm/common/util.h>    // crm_strdup_printf()
 #include <crm/common/logging.h>  // do_crm_log_unlikely(), etc.
 #include <crm/common/mainloop.h> // mainloop_io_t, struct ipc_client_callbacks
+#include <crm/common/results_internal.h>
 #include <crm/common/strings_internal.h>
 
 /* This says whether the current application is a Pacemaker daemon or not,
@@ -284,14 +285,6 @@ pcmk__realloc(void *ptr, size_t size)
     return new_ptr;
 }
 
-
-/* Error domains for use with g_set_error (from results.c) */
-
-GQuark pcmk__rc_error_quark(void);
-GQuark pcmk__exitc_error_quark(void);
-
-#define PCMK__RC_ERROR       pcmk__rc_error_quark()
-#define PCMK__EXITC_ERROR    pcmk__exitc_error_quark()
 
 static inline char *
 pcmk__getpid_s(void)

--- a/include/crm/common/iso8601_internal.h
+++ b/include/crm/common/iso8601_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the Pacemaker project contributors
+ * Copyright 2015-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -25,6 +25,7 @@ pcmk__time_hr_t *pcmk__time_hr_new(const char *date_time);
 void pcmk__time_hr_free(pcmk__time_hr_t *hr_dt);
 char *pcmk__time_format_hr(const char *format, pcmk__time_hr_t *hr_dt);
 const char *pcmk__epoch2str(time_t *when);
+const char *pcmk__readable_interval(guint interval_ms);
 
 struct pcmk__time_us {
     int years;

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -53,10 +53,11 @@ extern "C" {
  * alternative interpretations. The legacy interpration is that the absolute
  * value of the return code is either a system error number or a custom
  * pcmk_err_* number. This is less than ideal because system error numbers are
- * constrained only to the positive int range, so there's the possibility
- * (though not noticed in the wild) that system errors and custom errors could
- * collide. The new intepretation is that negative values are from the pcmk_rc_e
- * enum, and positive values are system error numbers. Both use 0 for success.
+ * constrained only to the positive int range, so there's the possibility that
+ * system errors and custom errors could collide (which did in fact happen
+ * already on one architecture). The new intepretation is that negative values
+ * are from the pcmk_rc_e enum, and positive values are system error numbers.
+ * Both use 0 for success.
  *
  * For system error codes, see:
  * - /usr/include/asm-generic/errno.h
@@ -84,8 +85,8 @@ extern "C" {
 #  define pcmk_err_already              215
 /* On HPPA 215 is ENOSYM (Unknown error 215), which hopefully never happens. */
 #ifdef __hppa__
-#  define pcmk_err_bad_nvpair           250	/* 216 is ENOTSOCK */
-#  define pcmk_err_unknown_format       252	/* 217 is EDESTADDRREQ */
+#  define pcmk_err_bad_nvpair           250 /* 216 is ENOTSOCK */
+#  define pcmk_err_unknown_format       252 /* 217 is EDESTADDRREQ */
 #else
 #  define pcmk_err_bad_nvpair           216
 #  define pcmk_err_unknown_format       217
@@ -144,36 +145,39 @@ enum pcmk_rc_e {
     // Positive values reserved for system error numbers
 };
 
-/* Uniform exit codes
- * Everything is mapped to its OCF equivalent so that Pacemaker only deals with one set of codes
+
+/*!
+ * \enum ocf_exitcode
+ * \brief Exit status codes for resource agents
+ *
+ * The OCF Resource Agent API standard enumerates the possible exit status codes
+ * that agents should return. Pacemaker adds some more to cover problems with
+ * executing the agent, and to use a single set of codes for all agent types.
  */
 enum ocf_exitcode {
-    PCMK_OCF_OK                   = 0,
-    PCMK_OCF_UNKNOWN_ERROR        = 1,
-    PCMK_OCF_INVALID_PARAM        = 2,
-    PCMK_OCF_UNIMPLEMENT_FEATURE  = 3,
-    PCMK_OCF_INSUFFICIENT_PRIV    = 4,
-    PCMK_OCF_NOT_INSTALLED        = 5,
-    PCMK_OCF_NOT_CONFIGURED       = 6,
-    PCMK_OCF_NOT_RUNNING          = 7,  /* End of overlap with LSB */
-    PCMK_OCF_RUNNING_PROMOTED     = 8,
-    PCMK_OCF_FAILED_PROMOTED      = 9,
+    PCMK_OCF_OK                   = 0,   //!< Success
+    PCMK_OCF_UNKNOWN_ERROR        = 1,   //!< Unspecified error
+    PCMK_OCF_INVALID_PARAM        = 2,   //!< Parameter invalid (in local context)
+    PCMK_OCF_UNIMPLEMENT_FEATURE  = 3,   //!< Requested action not implemented
+    PCMK_OCF_INSUFFICIENT_PRIV    = 4,   //!< Insufficient privileges
+    PCMK_OCF_NOT_INSTALLED        = 5,   //!< Dependencies not available locally
+    PCMK_OCF_NOT_CONFIGURED       = 6,   //!< Parameter invalid (inherently)
+    PCMK_OCF_NOT_RUNNING          = 7,   //!< Service safely stopped
+    PCMK_OCF_RUNNING_PROMOTED     = 8,   //!< Service active and promoted
+    PCMK_OCF_FAILED_PROMOTED      = 9,   //!< Service failed and possibly in promoted role
+    PCMK_OCF_DEGRADED             = 190, //!< Service active but more likely to fail soon
+    PCMK_OCF_DEGRADED_PROMOTED    = 191, //!< Service promoted but more likely to fail soon
 
-
-    /* 150-199	reserved for application use */
-    PCMK_OCF_CONNECTION_DIED = 189, // Deprecated (see PCMK_LRM_OP_NOT_CONNECTED)
-
-    PCMK_OCF_DEGRADED           = 190, // Resource active but more likely to fail soon
-    PCMK_OCF_DEGRADED_PROMOTED  = 191, // Resource promoted but more likely to fail soon
-
-    PCMK_OCF_EXEC_ERROR    = 192, /* Generic problem invoking the agent */
-    PCMK_OCF_UNKNOWN       = 193, /* State of the service is unknown - used for recording in-flight operations */
-    PCMK_OCF_SIGNAL        = 194,
-    PCMK_OCF_NOT_SUPPORTED = 195,
-    PCMK_OCF_PENDING       = 196,
-    PCMK_OCF_CANCELLED     = 197,
-    PCMK_OCF_TIMEOUT       = 198,
-    PCMK_OCF_OTHER_ERROR   = 199, /* Keep the same codes as PCMK_LSB */
+    // Pacemaker extensions
+    PCMK_OCF_CONNECTION_DIED      = 189, //!< \deprecated See PCMK_LRM_OP_NOT_CONNECTED
+    PCMK_OCF_EXEC_ERROR           = 192, //!< Error executing the agent
+    PCMK_OCF_UNKNOWN              = 193, //!< Action is pending
+    PCMK_OCF_SIGNAL               = 194, //!< Agent terminated due to signal
+    PCMK_OCF_NOT_SUPPORTED        = 195, //!< \deprecated (Unused)
+    PCMK_OCF_PENDING              = 196, //!< Multi-stage execution in progress
+    PCMK_OCF_CANCELLED            = 197, //!< \deprecated (Unused)
+    PCMK_OCF_TIMEOUT              = 198, //!< Action did not complete in time
+    PCMK_OCF_OTHER_ERROR          = 199, //!< \deprecated (Unused)
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use PCMK_OCF_RUNNING_PROMOTED instead
@@ -187,8 +191,9 @@ enum ocf_exitcode {
 #endif
 };
 
-/*
- * Exit status codes
+/*!
+ * \enum crm_exit_e
+ * \brief Exit status codes for tools and daemons
  *
  * We want well-specified (i.e. OS-invariant) exit status codes for our daemons
  * and applications so they can be relied on by callers. (Function return codes
@@ -214,53 +219,53 @@ enum ocf_exitcode {
  */
 typedef enum crm_exit_e {
     // Common convention
-    CRM_EX_OK                   =   0,
-    CRM_EX_ERROR                =   1,
+    CRM_EX_OK                   =   0, //!< Success
+    CRM_EX_ERROR                =   1, //!< Unspecified error
 
     // LSB + OCF
-    CRM_EX_INVALID_PARAM        =   2,
-    CRM_EX_UNIMPLEMENT_FEATURE  =   3,
-    CRM_EX_INSUFFICIENT_PRIV    =   4,
-    CRM_EX_NOT_INSTALLED        =   5,
-    CRM_EX_NOT_CONFIGURED       =   6,
-    CRM_EX_NOT_RUNNING          =   7,
+    CRM_EX_INVALID_PARAM        =   2, //!< Parameter invalid (in local context)
+    CRM_EX_UNIMPLEMENT_FEATURE  =   3, //!< Requested action not implemented
+    CRM_EX_INSUFFICIENT_PRIV    =   4, //!< Insufficient privileges
+    CRM_EX_NOT_INSTALLED        =   5, //!< Dependencies not available locally
+    CRM_EX_NOT_CONFIGURED       =   6, //!< Parameter invalid (inherently)
+    CRM_EX_NOT_RUNNING          =   7, //!< Service safely stopped
 
     // sysexits.h
-    CRM_EX_USAGE                =  64, // command line usage error
-    CRM_EX_DATAERR              =  65, // user-supplied data incorrect
-    CRM_EX_NOINPUT              =  66, // input file not available
-    CRM_EX_NOUSER               =  67, // user does not exist
-    CRM_EX_NOHOST               =  68, // host unknown
-    CRM_EX_UNAVAILABLE          =  69, // needed service unavailable
-    CRM_EX_SOFTWARE             =  70, // internal software bug
-    CRM_EX_OSERR                =  71, // external (OS/environmental) problem
-    CRM_EX_OSFILE               =  72, // system file not usable
-    CRM_EX_CANTCREAT            =  73, // file couldn't be created
-    CRM_EX_IOERR                =  74, // file I/O error
-    CRM_EX_TEMPFAIL             =  75, // try again
-    CRM_EX_PROTOCOL             =  76, // protocol violated
-    CRM_EX_NOPERM               =  77, // non-file permission issue
-    CRM_EX_CONFIG               =  78, // misconfiguration
+    CRM_EX_USAGE                =  64, //!< Command line usage error
+    CRM_EX_DATAERR              =  65, //!< User-supplied data incorrect
+    CRM_EX_NOINPUT              =  66, //!< Input file not available
+    CRM_EX_NOUSER               =  67, //!< User does not exist
+    CRM_EX_NOHOST               =  68, //!< Host unknown
+    CRM_EX_UNAVAILABLE          =  69, //!< Needed service unavailable
+    CRM_EX_SOFTWARE             =  70, //!< Internal software bug
+    CRM_EX_OSERR                =  71, //!< External (OS/environmental) problem
+    CRM_EX_OSFILE               =  72, //!< System file not usable
+    CRM_EX_CANTCREAT            =  73, //!< File couldn't be created
+    CRM_EX_IOERR                =  74, //!< File I/O error
+    CRM_EX_TEMPFAIL             =  75, //!< Try again
+    CRM_EX_PROTOCOL             =  76, //!< Protocol violated
+    CRM_EX_NOPERM               =  77, //!< Non-file permission issue
+    CRM_EX_CONFIG               =  78, //!< Misconfiguration
 
     // Custom
-    CRM_EX_FATAL                = 100, // do not respawn
-    CRM_EX_PANIC                = 101, // panic the local host
-    CRM_EX_DISCONNECT           = 102, // lost connection to something
-    CRM_EX_OLD                  = 103, // update older than existing config
-    CRM_EX_DIGEST               = 104, // digest comparison failed
-    CRM_EX_NOSUCH               = 105, // requested item does not exist
-    CRM_EX_QUORUM               = 106, // local partition does not have quorum
-    CRM_EX_UNSAFE               = 107, // requires --force or new conditions
-    CRM_EX_EXISTS               = 108, // requested item already exists
-    CRM_EX_MULTIPLE             = 109, // requested item has multiple matches
-    CRM_EX_EXPIRED              = 110, // requested item has expired
-    CRM_EX_NOT_YET_IN_EFFECT    = 111, // requested item is not in effect
-    CRM_EX_INDETERMINATE        = 112, // could not determine status
-    CRM_EX_UNSATISFIED          = 113, // requested item does not satisfy constraints
+    CRM_EX_FATAL                = 100, //!< Do not respawn
+    CRM_EX_PANIC                = 101, //!< Panic the local host
+    CRM_EX_DISCONNECT           = 102, //!< Lost connection to something
+    CRM_EX_OLD                  = 103, //!< Update older than existing config
+    CRM_EX_DIGEST               = 104, //!< Digest comparison failed
+    CRM_EX_NOSUCH               = 105, //!< Requested item does not exist
+    CRM_EX_QUORUM               = 106, //!< Local partition does not have quorum
+    CRM_EX_UNSAFE               = 107, //!< Requires --force or new conditions
+    CRM_EX_EXISTS               = 108, //!< Requested item already exists
+    CRM_EX_MULTIPLE             = 109, //!< Requested item has multiple matches
+    CRM_EX_EXPIRED              = 110, //!< Requested item has expired
+    CRM_EX_NOT_YET_IN_EFFECT    = 111, //!< Requested item is not in effect
+    CRM_EX_INDETERMINATE        = 112, //!< Could not determine status
+    CRM_EX_UNSATISFIED          = 113, //!< Requested item does not satisfy constraints
 
     // Other
-    CRM_EX_TIMEOUT              = 124, // convention from timeout(1)
-    CRM_EX_MAX                  = 255, // ensure crm_exit_t can hold this
+    CRM_EX_TIMEOUT              = 124, //!< Convention from timeout(1)
+    CRM_EX_MAX                  = 255, //!< Ensure crm_exit_t can hold this
 } crm_exit_t;
 
 const char *pcmk_rc_name(int rc);

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -303,6 +303,25 @@ const char *crm_exit_name(crm_exit_t exit_code);
 const char *crm_exit_str(crm_exit_t exit_code);
 _Noreturn crm_exit_t crm_exit(crm_exit_t rc);
 
+static inline const char *
+pcmk_exec_status_str(enum pcmk_exec_status status)
+{
+    switch (status) {
+        case PCMK_EXEC_PENDING:         return "pending";
+        case PCMK_EXEC_DONE:            return "complete";
+        case PCMK_EXEC_CANCELLED:       return "Cancelled";
+        case PCMK_EXEC_TIMEOUT:         return "Timed Out";
+        case PCMK_EXEC_NOT_SUPPORTED:   return "NOT SUPPORTED";
+        case PCMK_EXEC_ERROR:           return "Error";
+        case PCMK_EXEC_ERROR_HARD:      return "Hard error";
+        case PCMK_EXEC_ERROR_FATAL:     return "Fatal error";
+        case PCMK_EXEC_NOT_INSTALLED:   return "Not installed";
+        case PCMK_EXEC_NOT_CONNECTED:   return "No executor connection";
+        case PCMK_EXEC_INVALID:         return "Cannot execute now";
+        default:                        return "UNKNOWN!";
+    }
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -169,7 +169,7 @@ enum ocf_exitcode {
     PCMK_OCF_DEGRADED_PROMOTED    = 191, //!< Service promoted but more likely to fail soon
 
     // Pacemaker extensions
-    PCMK_OCF_CONNECTION_DIED      = 189, //!< \deprecated See PCMK_LRM_OP_NOT_CONNECTED
+    PCMK_OCF_CONNECTION_DIED      = 189, //!< \deprecated See PCMK_EXEC_NOT_CONNECTED
     PCMK_OCF_EXEC_ERROR           = 192, //!< Error executing the agent
     PCMK_OCF_UNKNOWN              = 193, //!< Action is pending
     PCMK_OCF_SIGNAL               = 194, //!< Agent terminated due to signal
@@ -267,6 +267,28 @@ typedef enum crm_exit_e {
     CRM_EX_TIMEOUT              = 124, //!< Convention from timeout(1)
     CRM_EX_MAX                  = 255, //!< Ensure crm_exit_t can hold this
 } crm_exit_t;
+
+/*!
+ * \enum pcmk_exec_status
+ * \brief Execution status
+ *
+ * These codes are used to specify the result of the attempt to execute an
+ * agent, rather than the agent's result itself.
+ */
+enum pcmk_exec_status {
+    PCMK_EXEC_UNKNOWN = -2,     //!< Used only to initialize variables
+    PCMK_EXEC_PENDING = -1,     //!< Action is in progress
+    PCMK_EXEC_DONE,             //!< Action completed, result is known
+    PCMK_EXEC_CANCELLED,        //!< Action was cancelled
+    PCMK_EXEC_TIMEOUT,          //!< Action did not complete in time
+    PCMK_EXEC_NOT_SUPPORTED,    //!< Agent does not implement requested action
+    PCMK_EXEC_ERROR,            //!< Execution failed, may be retried
+    PCMK_EXEC_ERROR_HARD,       //!< Execution failed, do not retry on node
+    PCMK_EXEC_ERROR_FATAL,      //!< Execution failed, do not retry anywhere
+    PCMK_EXEC_NOT_INSTALLED,    //!< Agent or dependency not available locally
+    PCMK_EXEC_NOT_CONNECTED,    //!< No connection to executor
+    PCMK_EXEC_INVALID,          //!< Action cannot be attempted (e.g. shutdown)
+};
 
 const char *pcmk_rc_name(int rc);
 const char *pcmk_rc_str(int rc);

--- a/include/crm/common/results_internal.h
+++ b/include/crm/common/results_internal.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020-2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__COMMON_RESULTS_INTERNAL__H
+#define PCMK__COMMON_RESULTS_INTERNAL__H
+
+#include <glib.h>               // GQuark
+
+/* Error domains for use with g_set_error */
+
+GQuark pcmk__rc_error_quark(void);
+GQuark pcmk__exitc_error_quark(void);
+
+#define PCMK__RC_ERROR       pcmk__rc_error_quark()
+#define PCMK__EXITC_ERROR    pcmk__exitc_error_quark()
+
+#endif // PCMK__COMMON_RESULTS_INTERNAL__H

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -64,7 +64,7 @@ extern "C" {
  * >=3.0.9:  DC will send its own shutdown request to all peers
  *           XML v2 patchsets are created by default
  * >=3.0.13: Fail counts include operation name and interval
- * >=3.2.0:  DC supports PCMK_LRM_OP_INVALID and PCMK_LRM_OP_NOT_CONNECTED
+ * >=3.2.0:  DC supports PCMK_EXEC_INVALID and PCMK_EXEC_NOT_CONNECTED
  */
 #  define CRM_FEATURE_SET		"3.11.0"
 

--- a/include/crm/services.h
+++ b/include/crm/services.h
@@ -83,21 +83,6 @@ enum lsb_status_exitcode {
     PCMK_LSB_STATUS_INSUFFICIENT_PRIV  = 151,
 };
 
-enum op_status {
-    PCMK_LRM_OP_UNKNOWN = -2,
-    PCMK_LRM_OP_PENDING = -1,
-    PCMK_LRM_OP_DONE,
-    PCMK_LRM_OP_CANCELLED,
-    PCMK_LRM_OP_TIMEOUT,
-    PCMK_LRM_OP_NOTSUPPORTED,
-    PCMK_LRM_OP_ERROR,
-    PCMK_LRM_OP_ERROR_HARD,
-    PCMK_LRM_OP_ERROR_FATAL,
-    PCMK_LRM_OP_NOT_INSTALLED,
-    PCMK_LRM_OP_NOT_CONNECTED,
-    PCMK_LRM_OP_INVALID,
-};
-
 enum nagios_exitcode {
     NAGIOS_STATE_OK        = 0,
     NAGIOS_STATE_WARNING   = 1,
@@ -391,6 +376,10 @@ gboolean services_alert_async(svc_action_t *action,
         }
         return PCMK_OCF_UNKNOWN_ERROR;
     }
+
+#if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+#include <crm/services_compat.h>
+#endif
 
 #  ifdef __cplusplus
 }

--- a/include/crm/services.h
+++ b/include/crm/services.h
@@ -283,22 +283,6 @@ svc_action_t *services_alert_create(const char *id, const char *exec,
 gboolean services_alert_async(svc_action_t *action,
                               void (*cb)(svc_action_t *op));
 
-    static inline const char *services_lrm_status_str(enum op_status status) {
-        switch (status) {
-            case PCMK_LRM_OP_PENDING:
-                return "pending";
-                case PCMK_LRM_OP_DONE:return "complete";
-                case PCMK_LRM_OP_CANCELLED:return "Cancelled";
-                case PCMK_LRM_OP_TIMEOUT:return "Timed Out";
-                case PCMK_LRM_OP_NOTSUPPORTED:return "NOT SUPPORTED";
-                case PCMK_LRM_OP_ERROR:return "Error";
-                case PCMK_LRM_OP_NOT_INSTALLED:return "Not installed";
-                case PCMK_LRM_OP_NOT_CONNECTED:return "No executor connection";
-                case PCMK_LRM_OP_INVALID:return "Cannot execute now";
-                default:return "UNKNOWN!";
-        }
-    }
-
     static inline const char *services_ocf_exitcode_str(enum ocf_exitcode code) {
         switch (code) {
             case PCMK_OCF_OK:

--- a/include/crm/services_compat.h
+++ b/include/crm/services_compat.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2010-2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__SERVICES_COMPAT__H
+#  define PCMK__SERVICES_COMPAT__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \file
+ * \brief Deprecated services API
+ * \ingroup core
+ * \deprecated Do not include this header directly. The service APIs in this
+ *             header, and the header itself, will be removed in a future
+ *             release.
+ */
+
+#include <crm/common/results.h>
+
+//! \deprecated Use enum pcmk_exec_status instead
+enum op_status {
+    PCMK_LRM_OP_UNKNOWN = PCMK_EXEC_UNKNOWN,
+    PCMK_LRM_OP_PENDING = PCMK_EXEC_PENDING,
+    PCMK_LRM_OP_DONE = PCMK_EXEC_DONE,
+    PCMK_LRM_OP_CANCELLED = PCMK_EXEC_CANCELLED,
+    PCMK_LRM_OP_TIMEOUT = PCMK_EXEC_TIMEOUT,
+    PCMK_LRM_OP_NOTSUPPORTED = PCMK_EXEC_NOT_SUPPORTED,
+    PCMK_LRM_OP_ERROR = PCMK_EXEC_ERROR,
+    PCMK_LRM_OP_ERROR_HARD = PCMK_EXEC_ERROR_HARD,
+    PCMK_LRM_OP_ERROR_FATAL = PCMK_EXEC_ERROR_FATAL,
+    PCMK_LRM_OP_NOT_INSTALLED = PCMK_EXEC_NOT_INSTALLED,
+    PCMK_LRM_OP_NOT_CONNECTED = PCMK_EXEC_NOT_CONNECTED,
+    PCMK_LRM_OP_INVALID = PCMK_EXEC_INVALID,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/crm/services_compat.h
+++ b/include/crm/services_compat.h
@@ -41,6 +41,13 @@ enum op_status {
     PCMK_LRM_OP_INVALID = PCMK_EXEC_INVALID,
 };
 
+//! \deprecated Use pcmk_exec_status_str() instead
+static inline const char *
+services_lrm_status_str(enum op_status status)
+{
+    return pcmk_exec_status_str(status);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1734,3 +1734,61 @@ pcmk__epoch2str(time_t *when)
         return pcmk__trim(since_epoch);
     }
 }
+
+/*!
+ * \internal
+ * \brief Given a millisecond interval, return a log-friendly string
+ *
+ * \param[in] interval_ms  Interval in milliseconds
+ *
+ * \return Readable version of \p interval_ms
+ *
+ * \note The return value is a pointer to static memory that will be
+ *       overwritten by later calls to this function.
+ */
+const char *
+pcmk__readable_interval(guint interval_ms)
+{
+#define MS_IN_S (1000)
+#define MS_IN_M (MS_IN_S * 60)
+#define MS_IN_H (MS_IN_M * 60)
+#define MS_IN_D (MS_IN_H * 24)
+#define MAXSTR sizeof("..d..h..m..s...ms")
+    static char str[MAXSTR] = { '\0', };
+    int offset = 0;
+
+    if (interval_ms > MS_IN_D) {
+        offset += snprintf(str + offset, MAXSTR - offset, "%ud",
+                           interval_ms / MS_IN_D);
+        interval_ms -= (interval_ms / MS_IN_D) * MS_IN_D;
+    }
+    if (interval_ms > MS_IN_H) {
+        offset += snprintf(str + offset, MAXSTR - offset, "%uh",
+                           interval_ms / MS_IN_H);
+        interval_ms -= (interval_ms / MS_IN_H) * MS_IN_H;
+    }
+    if (interval_ms > MS_IN_M) {
+        offset += snprintf(str + offset, MAXSTR - offset, "%um",
+                           interval_ms / MS_IN_M);
+        interval_ms -= (interval_ms / MS_IN_M) * MS_IN_M;
+    }
+
+    // Ns, N.NNNs, or NNNms
+    if (interval_ms > MS_IN_S) {
+        offset += snprintf(str + offset, MAXSTR - offset, "%u",
+                           interval_ms / MS_IN_S);
+        interval_ms -= (interval_ms / MS_IN_S) * MS_IN_S;
+        if (interval_ms > 0) {
+            offset += snprintf(str + offset, MAXSTR - offset, ".%03u",
+                               interval_ms);
+        }
+        (void) snprintf(str + offset, MAXSTR - offset, "s");
+
+    } else if (interval_ms > 0) {
+        (void) snprintf(str + offset, MAXSTR - offset, "%ums", interval_ms);
+
+    } else if (str[0] == '\0') {
+        strcpy(str, "0s");
+    }
+    return str;
+}

--- a/lib/common/operations.c
+++ b/lib/common/operations.c
@@ -437,15 +437,15 @@ gboolean
 did_rsc_op_fail(lrmd_event_data_t * op, int target_rc)
 {
     switch (op->op_status) {
-        case PCMK_LRM_OP_CANCELLED:
-        case PCMK_LRM_OP_PENDING:
+        case PCMK_EXEC_CANCELLED:
+        case PCMK_EXEC_PENDING:
             return FALSE;
 
-        case PCMK_LRM_OP_NOTSUPPORTED:
-        case PCMK_LRM_OP_TIMEOUT:
-        case PCMK_LRM_OP_ERROR:
-        case PCMK_LRM_OP_NOT_CONNECTED:
-        case PCMK_LRM_OP_INVALID:
+        case PCMK_EXEC_NOT_SUPPORTED:
+        case PCMK_EXEC_TIMEOUT:
+        case PCMK_EXEC_ERROR:
+        case PCMK_EXEC_NOT_CONNECTED:
+        case PCMK_EXEC_INVALID:
             return TRUE;
 
         default:

--- a/lib/common/tests/Makefile.am
+++ b/lib/common/tests/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = agents cmdline flags operations strings utils xpath results
+SUBDIRS = agents cmdline flags iso8601 operations results strings utils xpath

--- a/lib/common/tests/iso8601/Makefile.am
+++ b/lib/common/tests/iso8601/Makefile.am
@@ -1,0 +1,29 @@
+#
+# Copyright 2020-2021 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+#
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
+LDADD = $(top_builddir)/lib/common/libcrmcommon.la
+
+include $(top_srcdir)/mk/glib-tap.mk
+
+# Add each test program here.  Each test should be written as a little standalone
+# program using the glib unit testing functions.  See the documentation for more
+# information.
+#
+# https://developer.gnome.org/glib/unstable/glib-Testing.html
+#
+# Add "_test" to the end of all test program names to simplify .gitignore.
+test_programs = pcmk__readable_interval_test
+
+# If any extra data needs to be added to the source distribution, add it to the
+# following list.
+dist_test_data =
+
+# If any extra data needs to be used by tests but should not be added to the
+# source distribution, add it to the following list.
+test_data =

--- a/lib/common/tests/iso8601/pcmk__readable_interval_test.c
+++ b/lib/common/tests/iso8601/pcmk__readable_interval_test.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <limits.h>
+
+#include <crm/common/iso8601_internal.h>
+
+static void
+readable_interval(void)
+{
+    g_assert_cmpint(strcmp(pcmk__readable_interval(0), "0s"), ==, 0);
+    g_assert_cmpint(strcmp(pcmk__readable_interval(30000), "30s"), ==, 0);
+    g_assert_cmpint(strcmp(pcmk__readable_interval(150000), "2m30s"), ==, 0);
+    g_assert_cmpint(strcmp(pcmk__readable_interval(3333), "3.333s"), ==, 0);
+    g_assert_cmpint(strcmp(pcmk__readable_interval(UINT_MAX), "49d17h2m47.295s"), ==, 0);
+}
+
+int
+main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/common/utils/pcmk__readable_interval/readable_interval",
+                    readable_interval);
+    return g_test_run();
+}

--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -378,7 +378,7 @@ lrmd_send_resource_alert(lrmd_t *lrmd, GList *alert_list,
     /* Reoccurring operations do not set exec_time, so on timeout, set it
      * to the operation timeout since that's closer to the actual value.
      */
-    if (op->op_status == PCMK_LRM_OP_TIMEOUT && op->exec_time == 0) {
+    if ((op->op_status == PCMK_EXEC_TIMEOUT) && (op->exec_time == 0)) {
         params = alert_key2param_int(params, PCMK__alert_key_exec_time,
                                      op->timeout);
     } else {
@@ -386,12 +386,12 @@ lrmd_send_resource_alert(lrmd_t *lrmd, GList *alert_list,
                                      op->exec_time);
     }
 
-    if (op->op_status == PCMK_LRM_OP_DONE) {
+    if (op->op_status == PCMK_EXEC_DONE) {
         params = alert_key2param(params, PCMK__alert_key_desc,
                                  services_ocf_exitcode_str(op->rc));
     } else {
         params = alert_key2param(params, PCMK__alert_key_desc,
-                                 services_lrm_status_str(op->op_status));
+                                 pcmk_exec_status_str(op->op_status));
     }
 
     rc = exec_alert_list(lrmd, alert_list, pcmk__alert_resource, NULL, params);

--- a/lib/pacemaker/pcmk_sched_transition.c
+++ b/lib/pacemaker/pcmk_sched_transition.c
@@ -122,7 +122,7 @@ create_op(xmlNode *cib_resource, const char *task, guint interval_ms,
 
     op = lrmd_new_event(ID(cib_resource), task, interval_ms);
     op->rc = outcome;
-    op->op_status = 0;
+    op->op_status = PCMK_EXEC_DONE;
     op->params = NULL;          /* TODO: Fill me in */
     op->t_run = (unsigned int) time(NULL);
     op->t_rcchange = op->t_run;
@@ -682,7 +682,8 @@ exec_rsc_action(crm_graph_t * graph, crm_action_t * action)
         return FALSE;
     }
 
-    op = pcmk__event_from_graph_action(cib_resource, action, 0, target_outcome);
+    op = pcmk__event_from_graph_action(cib_resource, action, PCMK_EXEC_DONE,
+                                       target_outcome);
 
     out->message(out, "inject-rsc-action", resource, op->op_type, node, op->interval_ms);
 

--- a/lib/pacemaker/pcmk_sched_utils.c
+++ b/lib/pacemaker/pcmk_sched_utils.c
@@ -618,8 +618,8 @@ pcmk__create_history_xml(xmlNode *parent, lrmd_event_data_t *op,
 
     CRM_CHECK(op != NULL, return NULL);
     do_crm_log(level, "%s: Updating resource %s after %s op %s (interval=%u)",
-               origin, op->rsc_id, op->op_type, services_lrm_status_str(op->op_status),
-               op->interval_ms);
+               origin, op->rsc_id, op->op_type,
+               pcmk_exec_status_str(op->op_status), op->interval_ms);
 
     crm_trace("DC version: %s", caller_version);
 
@@ -636,7 +636,7 @@ pcmk__create_history_xml(xmlNode *parent, lrmd_event_data_t *op,
      */
     if (pcmk__str_any_of(task, CRMD_ACTION_RELOAD, CRMD_ACTION_RELOAD_AGENT,
                          NULL)) {
-        if (op->op_status == PCMK_LRM_OP_DONE) {
+        if (op->op_status == PCMK_EXEC_DONE) {
             task = CRMD_ACTION_START;
         } else {
             task = CRMD_ACTION_STATUS;
@@ -652,13 +652,13 @@ pcmk__create_history_xml(xmlNode *parent, lrmd_event_data_t *op,
         CRM_LOG_ASSERT(n_task != NULL);
         op_id = pcmk__notify_key(op->rsc_id, n_type, n_task);
 
-        if (op->op_status != PCMK_LRM_OP_PENDING) {
+        if (op->op_status != PCMK_EXEC_PENDING) {
             /* Ignore notify errors.
              *
              * @TODO It might be better to keep the correct result here, and
              * ignore it in process_graph_event().
              */
-            op->op_status = PCMK_LRM_OP_DONE;
+            op->op_status = PCMK_EXEC_DONE;
             op->rc = 0;
         }
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1138,7 +1138,7 @@ failed_action_default(pcmk__output_t *out, va_list args)
 
     pcmk__scan_min_int(crm_element_value(xml_op, XML_LRM_ATTR_OPSTATUS),
                        &status, 0);
-    lrm_status = services_lrm_status_str(status);
+    lrm_status = pcmk_exec_status_str(status);
 
     if (pcmk__str_empty(op_key)) {
         op_key = ID(xml_op);
@@ -1216,7 +1216,7 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
                                         "exitreason", crm_str(reason_s),
                                         "exitcode", rc_s,
                                         "call", crm_element_value(xml_op, XML_LRM_ATTR_CALLID),
-                                        "status", services_lrm_status_str(status),
+                                        "status", pcmk_exec_status_str(status),
                                         NULL);
     free(rc_s);
 
@@ -1646,7 +1646,7 @@ node_and_op(pcmk__output_t *out, va_list args) {
                    crm_element_value(xml_op, XML_LRM_ATTR_CALLID),
                    crm_element_value(xml_op, XML_LRM_ATTR_RC),
                    last_change_str ? last_change_str : "",
-                   services_lrm_status_str(status));
+                   pcmk_exec_status_str(status));
 
     g_free(node_str);
     free(last_change_str);
@@ -1673,7 +1673,7 @@ node_and_op_xml(pcmk__output_t *out, va_list args) {
                                         "node", crm_element_value(xml_op, XML_ATTR_UNAME),
                                         "call", crm_element_value(xml_op, XML_LRM_ATTR_CALLID),
                                         "rc", crm_element_value(xml_op, XML_LRM_ATTR_RC),
-                                        "status", services_lrm_status_str(status),
+                                        "status", pcmk_exec_status_str(status),
                                         NULL);
 
     rsc = pe_find_resource(data_set->resources, op_rsc);

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -639,7 +639,7 @@ services_action_cancel(const char *name, const char *action, guint interval_ms)
     // except without calling handle_blocked_ops()
 
     // Report operation as cancelled
-    op->status = PCMK_LRM_OP_CANCELLED;
+    op->status = PCMK_EXEC_CANCELLED;
     if (op->opaque->callback) {
         op->opaque->callback(op);
     }
@@ -859,7 +859,7 @@ handle_blocked_ops(void)
         executed_ops = g_list_append(executed_ops, op);
         res = action_exec_helper(op);
         if (res == FALSE) {
-            op->status = PCMK_LRM_OP_ERROR;
+            op->status = PCMK_EXEC_ERROR;
             /* this can cause this function to be called recursively
              * which is why we have processing_blocked_ops static variable */
             operation_finalize(op);

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -498,7 +498,7 @@ operation_finalize(svc_action_t * op)
 
     if (op->interval_ms) {
         if (op->cancel) {
-            op->status = PCMK_LRM_OP_CANCELLED;
+            op->status = PCMK_EXEC_CANCELLED;
             cancel_recurring_action(op);
         } else {
             recurring = 1;
@@ -594,12 +594,12 @@ operation_finished(mainloop_child_t * p, pid_t pid, int core, int signo, int exi
 
     if (signo == 0) {
         crm_debug("%s[%d] exited with status %d", op->id, op->pid, exitcode);
-        op->status = PCMK_LRM_OP_DONE;
+        op->status = PCMK_EXEC_DONE;
         op->rc = exitcode;
 
     } else if (mainloop_child_timeout(p)) {
         crm_warn("%s[%d] timed out after %dms", op->id, op->pid, op->timeout);
-        op->status = PCMK_LRM_OP_TIMEOUT;
+        op->status = PCMK_EXEC_TIMEOUT;
         op->rc = PCMK_OCF_TIMEOUT;
 
     } else if (op->cancel) {
@@ -608,13 +608,13 @@ operation_finished(mainloop_child_t * p, pid_t pid, int core, int signo, int exi
          */
         crm_info("%s[%d] terminated with signal: %s " CRM_XS " (%d)",
                  op->id, op->pid, strsignal(signo), signo);
-        op->status = PCMK_LRM_OP_CANCELLED;
+        op->status = PCMK_EXEC_CANCELLED;
         op->rc = PCMK_OCF_OK;
 
     } else {
         crm_warn("%s[%d] terminated with signal: %s " CRM_XS " (%d)",
                  op->id, op->pid, strsignal(signo), signo);
-        op->status = PCMK_LRM_OP_ERROR;
+        op->status = PCMK_EXEC_ERROR;
         op->rc = PCMK_OCF_SIGNAL;
     }
 
@@ -664,16 +664,16 @@ services__handle_exec_error(svc_action_t * op, int error)
         case EINVAL:   /* Invalid executable format */
         case ENOEXEC:  /* Invalid executable format */
             op->rc = rc_not_installed;
-            op->status = PCMK_LRM_OP_NOT_INSTALLED;
+            op->status = PCMK_EXEC_NOT_INSTALLED;
             break;
         case EACCES:   /* permission denied (various errors) */
         case EPERM:    /* permission denied (various errors) */
             op->rc = rc_insufficient_priv;
-            op->status = PCMK_LRM_OP_ERROR;
+            op->status = PCMK_EXEC_ERROR;
             break;
         default:
             op->rc = rc_exec_error;
-            op->status = PCMK_LRM_OP_ERROR;
+            op->status = PCMK_EXEC_ERROR;
     }
 }
 
@@ -831,12 +831,12 @@ action_synced_wait(svc_action_t *op, struct sigchld_data_s *data)
         op->rc = PCMK_OCF_UNKNOWN_ERROR;
 
         if (op->timeout > 0 && timeout <= 0) {
-            op->status = PCMK_LRM_OP_TIMEOUT;
+            op->status = PCMK_EXEC_TIMEOUT;
             crm_warn("%s[%d] timed out after %dms",
                      op->id, op->pid, op->timeout);
 
         } else {
-            op->status = PCMK_LRM_OP_ERROR;
+            op->status = PCMK_EXEC_ERROR;
         }
 
         /* If only child hasn't been successfully waited for, yet.
@@ -851,14 +851,14 @@ action_synced_wait(svc_action_t *op, struct sigchld_data_s *data)
         }
 
     } else if (WIFEXITED(status)) {
-        op->status = PCMK_LRM_OP_DONE;
+        op->status = PCMK_EXEC_DONE;
         op->rc = WEXITSTATUS(status);
         crm_info("%s[%d] exited with status %d", op->id, op->pid, op->rc);
 
     } else if (WIFSIGNALED(status)) {
         int signo = WTERMSIG(status);
 
-        op->status = PCMK_LRM_OP_ERROR;
+        op->status = PCMK_EXEC_ERROR;
         crm_err("%s[%d] terminated with signal: %s " CRM_XS " (%d)",
                 op->id, op->pid, strsignal(signo), signo);
     }

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -244,7 +244,7 @@ systemd_mask_error(svc_action_t *op, const char *error)
         } else {
             crm_trace("Mapping %s failure for %s: unknown services are not installed", op->action, op->rsc);
             op->rc = PCMK_OCF_NOT_INSTALLED;
-            op->status = PCMK_LRM_OP_NOT_INSTALLED;
+            op->status = PCMK_EXEC_NOT_INSTALLED;
             return FALSE;
         }
     }

--- a/lib/services/upstart.c
+++ b/lib/services/upstart.c
@@ -349,7 +349,7 @@ upstart_mask_error(svc_action_t *op, const char *error)
         } else if(pcmk__str_eq(op->action, "start", pcmk__str_casei)) {
             crm_trace("Mapping %s failure for %s: unknown services are not installed", op->action, op->rsc);
             op->rc = PCMK_OCF_NOT_INSTALLED;
-            op->status = PCMK_LRM_OP_NOT_INSTALLED;
+            op->status = PCMK_EXEC_NOT_INSTALLED;
         }
         return TRUE;
 
@@ -443,7 +443,7 @@ upstart_job_exec(svc_action_t * op)
 
         } else {
             op->rc = PCMK_OCF_NOT_INSTALLED;
-            op->status = PCMK_LRM_OP_NOT_INSTALLED;
+            op->status = PCMK_EXEC_NOT_INSTALLED;
         }
         goto cleanup;
     }

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1881,18 +1881,18 @@ handle_rsc_op(xmlNode * xml, const char *node_id)
 
     /* look up where we expected it to be? */
     desc = pcmk_strerror(pcmk_ok);
-    if (status == PCMK_LRM_OP_DONE && target_rc == rc) {
+    if ((status == PCMK_EXEC_DONE) && (target_rc == rc)) {
         crm_notice("%s of %s on %s completed: %s", task, rsc, node, desc);
         if (rc == PCMK_OCF_NOT_RUNNING) {
             notify = FALSE;
         }
 
-    } else if (status == PCMK_LRM_OP_DONE) {
+    } else if (status == PCMK_EXEC_DONE) {
         desc = services_ocf_exitcode_str(rc);
         crm_warn("%s of %s on %s failed: %s", task, rsc, node, desc);
 
     } else {
-        desc = services_lrm_status_str(status);
+        desc = pcmk_exec_status_str(status);
         crm_warn("%s of %s on %s failed: %s", task, rsc, node, desc);
     }
 

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -159,7 +159,7 @@ agent_status_default(pcmk__output_t *out, va_list args) {
     const char *type = va_arg(args, const char *);
     int rc = va_arg(args, int);
 
-    if (status == PCMK_LRM_OP_DONE) {
+    if (status == PCMK_EXEC_DONE) {
         out->info(out, "Operation %s%s%s (%s%s%s:%s) returned: '%s' (%d)",
                   action, name ? " for " : "", name ? name : "",
                   class, provider ? ":" : "", provider ? provider : "", type,
@@ -168,7 +168,7 @@ agent_status_default(pcmk__output_t *out, va_list args) {
         out->err(out, "Operation %s%s%s (%s%s%s:%s) failed: '%s' (%d)",
                  action, name ? " for " : "", name ? name : "",
                  class, provider ? ":" : "", provider ? provider : "", type,
-                 services_lrm_status_str(status), status);
+                 pcmk_exec_status_str(status), status);
     }
 
     return pcmk_rc_ok;


### PR DESCRIPTION
This mainly adds a not-yet-used function for more friendly output of intervals, and replaces libcrmservice's enum op_status with a new enum pcmk_exec_status in libcrmcommon.