### PR TITLE
Separate colocation-related functions into own source file

### DIFF
--- a/include/pcmki/pcmki_sched_utils.h
+++ b/include/pcmki/pcmki_sched_utils.h
@@ -29,11 +29,6 @@ pe__location_t *rsc2node_new(const char *id, pe_resource_t *rsc, int weight,
                              const char *discovery_mode, pe_node_t *node,
                              pe_working_set_t *data_set);
 
-void pcmk__new_colocation(const char *id, const char *node_attr, int score,
-                          pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
-                          const char *state_lh, const char *state_rh,
-                          bool influence, pe_working_set_t *data_set);
-
 GHashTable *pcmk__copy_node_table(GHashTable *nodes);
 GList *pcmk__copy_node_list(const GList *list, bool reset);
 GList *sort_nodes_by_weight(GList *nodes, pe_node_t *active_node,

--- a/lib/pacemaker/Makefile.am
+++ b/lib/pacemaker/Makefile.am
@@ -41,6 +41,7 @@ libpacemaker_la_SOURCES += pcmk_resource.c
 libpacemaker_la_SOURCES	+= pcmk_sched_allocate.c
 libpacemaker_la_SOURCES += pcmk_sched_bundle.c
 libpacemaker_la_SOURCES += pcmk_sched_clone.c
+libpacemaker_la_SOURCES += pcmk_sched_colocation.c
 libpacemaker_la_SOURCES += pcmk_sched_constraints.c
 libpacemaker_la_SOURCES += pcmk_sched_fencing.c
 libpacemaker_la_SOURCES += pcmk_sched_group.c

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -34,4 +34,28 @@ G_GNUC_INTERNAL
 bool pcmk__is_unfence_device(const pe_resource_t *rsc,
                              const pe_working_set_t *data_set);
 
+G_GNUC_INTERNAL
+pe_resource_t *pcmk__find_constraint_resource(GList *rsc_list, const char *id);
+
+G_GNUC_INTERNAL
+xmlNode *pcmk__expand_tags_in_sets(xmlNode *xml_obj,
+                                   pe_working_set_t *data_set);
+
+G_GNUC_INTERNAL
+gboolean pcmk__valid_resource_or_tag(pe_working_set_t *data_set, const char *id,
+                                     pe_resource_t **rsc, pe_tag_t **tag);
+
+G_GNUC_INTERNAL
+gboolean pcmk__tag_to_set(xmlNode *xml_obj, xmlNode **rsc_set, const char *attr,
+                          gboolean convert_rsc, pe_working_set_t *data_set);
+
+G_GNUC_INTERNAL
+void pcmk__unpack_colocation(xmlNode *xml_obj, pe_working_set_t *data_set);
+
+G_GNUC_INTERNAL
+void pcmk__new_colocation(const char *id, const char *node_attr, int score,
+                          pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
+                          const char *state_lh, const char *state_rh,
+                          bool influence, pe_working_set_t *data_set);
+
 #endif // PCMK__LIBPACEMAKER_PRIVATE__H

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -58,4 +58,8 @@ void pcmk__new_colocation(const char *id, const char *node_attr, int score,
                           const char *state_lh, const char *state_rh,
                           bool influence, pe_working_set_t *data_set);
 
+G_GNUC_INTERNAL
+void pcmk__block_colocated_starts(pe_action_t *action,
+                                  pe_working_set_t *data_set);
+
 #endif // PCMK__LIBPACEMAKER_PRIVATE__H

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -1759,9 +1759,6 @@ rsc_order_first(pe_resource_t *lh_rsc, pe__ordering_t *order,
     g_list_free(lh_actions);
 }
 
-extern void update_colo_start_chain(pe_action_t *action,
-                                    pe_working_set_t *data_set);
-
 static int
 is_recurring_action(pe_action_t *action)
 {
@@ -2676,7 +2673,8 @@ stage7(pe_working_set_t * data_set)
         }
     }
 
-    g_list_foreach(data_set->actions, (GFunc) update_colo_start_chain, data_set);
+    g_list_foreach(data_set->actions, (GFunc) pcmk__block_colocated_starts,
+                   data_set);
 
     crm_trace("Ordering probes");
     order_probes(data_set);

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -14,6 +14,8 @@
 #include <crm/msg_xml.h>
 #include <pacemaker-internal.h>
 
+#include "libpacemaker_private.h"
+
 #define PE__VARIANT_BUNDLE 1
 #include <lib/pengine/variant.h>
 

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -565,7 +565,7 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
 
     xmlNode *rsc_set_lh = NULL;
     xmlNode *rsc_set_rh = NULL;
-    gboolean any_sets = FALSE;
+    bool any_sets = false;
 
     *expanded_xml = NULL;
 
@@ -634,7 +634,7 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
             crm_xml_add(rsc_set_lh, "role", state_lh);
             xml_remove_prop(*expanded_xml, XML_COLOC_ATTR_SOURCE_ROLE);
         }
-        any_sets = TRUE;
+        any_sets = true;
     }
 
     // Convert template/tag reference in "with-rsc" into resource_set under constraint
@@ -651,7 +651,7 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
             crm_xml_add(rsc_set_rh, "role", state_rh);
             xml_remove_prop(*expanded_xml, XML_COLOC_ATTR_TARGET_ROLE);
         }
-        any_sets = TRUE;
+        any_sets = true;
     }
 
     if (any_sets) {

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -1,0 +1,728 @@
+/*
+ * Copyright 2004-2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdbool.h>
+#include <glib.h>
+
+#include <crm/crm.h>
+#include <crm/pengine/status.h>
+#include <pacemaker-internal.h>
+
+#include "libpacemaker_private.h"
+
+#define EXPAND_CONSTRAINT_IDREF(__set, __rsc, __name) do {                      \
+        __rsc = pcmk__find_constraint_resource(data_set->resources, __name);    \
+        if (__rsc == NULL) {                                                    \
+            pcmk__config_err("%s: No resource found for %s", __set, __name);    \
+            return FALSE;                                                       \
+        }                                                                       \
+    } while(0)
+
+static gint
+sort_cons_priority_lh(gconstpointer a, gconstpointer b)
+{
+    const pcmk__colocation_t *rsc_constraint1 = (const pcmk__colocation_t *) a;
+    const pcmk__colocation_t *rsc_constraint2 = (const pcmk__colocation_t *) b;
+
+    if (a == NULL) {
+        return 1;
+    }
+    if (b == NULL) {
+        return -1;
+    }
+
+    CRM_ASSERT(rsc_constraint1->rsc_lh != NULL);
+    CRM_ASSERT(rsc_constraint1->rsc_rh != NULL);
+
+    if (rsc_constraint1->rsc_lh->priority > rsc_constraint2->rsc_lh->priority) {
+        return -1;
+    }
+
+    if (rsc_constraint1->rsc_lh->priority < rsc_constraint2->rsc_lh->priority) {
+        return 1;
+    }
+
+    /* Process clones before primitives and groups */
+    if (rsc_constraint1->rsc_lh->variant > rsc_constraint2->rsc_lh->variant) {
+        return -1;
+    } else if (rsc_constraint1->rsc_lh->variant < rsc_constraint2->rsc_lh->variant) {
+        return 1;
+    }
+
+    /* @COMPAT scheduler <2.0.0: Process promotable clones before nonpromotable
+     * clones (probably unnecessary, but avoids having to update regression
+     * tests)
+     */
+    if (rsc_constraint1->rsc_lh->variant == pe_clone) {
+        if (pcmk_is_set(rsc_constraint1->rsc_lh->flags, pe_rsc_promotable)
+            && !pcmk_is_set(rsc_constraint2->rsc_lh->flags, pe_rsc_promotable)) {
+            return -1;
+        } else if (!pcmk_is_set(rsc_constraint1->rsc_lh->flags, pe_rsc_promotable)
+            && pcmk_is_set(rsc_constraint2->rsc_lh->flags, pe_rsc_promotable)) {
+            return 1;
+        }
+    }
+
+    return strcmp(rsc_constraint1->rsc_lh->id, rsc_constraint2->rsc_lh->id);
+}
+
+static gint
+sort_cons_priority_rh(gconstpointer a, gconstpointer b)
+{
+    const pcmk__colocation_t *rsc_constraint1 = (const pcmk__colocation_t *) a;
+    const pcmk__colocation_t *rsc_constraint2 = (const pcmk__colocation_t *) b;
+
+    if (a == NULL) {
+        return 1;
+    }
+    if (b == NULL) {
+        return -1;
+    }
+
+    CRM_ASSERT(rsc_constraint1->rsc_lh != NULL);
+    CRM_ASSERT(rsc_constraint1->rsc_rh != NULL);
+
+    if (rsc_constraint1->rsc_rh->priority > rsc_constraint2->rsc_rh->priority) {
+        return -1;
+    }
+
+    if (rsc_constraint1->rsc_rh->priority < rsc_constraint2->rsc_rh->priority) {
+        return 1;
+    }
+
+    /* Process clones before primitives and groups */
+    if (rsc_constraint1->rsc_rh->variant > rsc_constraint2->rsc_rh->variant) {
+        return -1;
+    } else if (rsc_constraint1->rsc_rh->variant < rsc_constraint2->rsc_rh->variant) {
+        return 1;
+    }
+
+    /* @COMPAT scheduler <2.0.0: Process promotable clones before nonpromotable
+     * clones (probably unnecessary, but avoids having to update regression
+     * tests)
+     */
+    if (rsc_constraint1->rsc_rh->variant == pe_clone) {
+        if (pcmk_is_set(rsc_constraint1->rsc_rh->flags, pe_rsc_promotable)
+            && !pcmk_is_set(rsc_constraint2->rsc_rh->flags, pe_rsc_promotable)) {
+            return -1;
+        } else if (!pcmk_is_set(rsc_constraint1->rsc_rh->flags, pe_rsc_promotable)
+            && pcmk_is_set(rsc_constraint2->rsc_rh->flags, pe_rsc_promotable)) {
+            return 1;
+        }
+    }
+
+    return strcmp(rsc_constraint1->rsc_rh->id, rsc_constraint2->rsc_rh->id);
+}
+
+/*!
+ * \internal
+ * \brief Add orderings necessary for an anti-colocation constraint
+ */
+static void
+anti_colocation_order(pe_resource_t *first_rsc, int first_role,
+                      pe_resource_t *then_rsc, int then_role,
+                      pe_working_set_t *data_set)
+{
+    const char *first_tasks[] = { NULL, NULL };
+    const char *then_tasks[] = { NULL, NULL };
+
+    /* Actions to make first_rsc lose first_role */
+    if (first_role == RSC_ROLE_PROMOTED) {
+        first_tasks[0] = CRMD_ACTION_DEMOTE;
+
+    } else {
+        first_tasks[0] = CRMD_ACTION_STOP;
+
+        if (first_role == RSC_ROLE_UNPROMOTED) {
+            first_tasks[1] = CRMD_ACTION_PROMOTE;
+        }
+    }
+
+    /* Actions to make then_rsc gain then_role */
+    if (then_role == RSC_ROLE_PROMOTED) {
+        then_tasks[0] = CRMD_ACTION_PROMOTE;
+
+    } else {
+        then_tasks[0] = CRMD_ACTION_START;
+
+        if (then_role == RSC_ROLE_UNPROMOTED) {
+            then_tasks[1] = CRMD_ACTION_DEMOTE;
+        }
+    }
+
+    for (int first_lpc = 0;
+         (first_lpc <= 1) && (first_tasks[first_lpc] != NULL); first_lpc++) {
+
+        for (int then_lpc = 0;
+             (then_lpc <= 1) && (then_tasks[then_lpc] != NULL); then_lpc++) {
+
+            new_rsc_order(first_rsc, first_tasks[first_lpc], then_rsc, then_tasks[then_lpc],
+                          pe_order_anti_colocation, data_set);
+        }
+    }
+}
+
+/*!
+ * \internal
+ * \brief Add a new colocation constraint to a cluster working set
+ *
+ * \param[in] id         XML ID for this constraint
+ * \param[in] node_attr  Colocate by this attribute (or NULL for #uname)
+ * \param[in] score      Constraint score
+ * \param[in] rsc_lh     Resource to be colocated
+ * \param[in] rsc_rh     Resource to colocate \p rsc_lh with
+ * \param[in] state_lh   Current role of \p rsc_lh
+ * \param[in] state_rh   Current role of \p rsc_rh
+ * \param[in] influence  Whether colocation constraint has influence
+ * \param[in] data_set   Cluster working set to add constraint to
+ */
+void
+pcmk__new_colocation(const char *id, const char *node_attr, int score,
+                     pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
+                     const char *state_lh, const char *state_rh,
+                     bool influence, pe_working_set_t *data_set)
+{
+    pcmk__colocation_t *new_con = NULL;
+
+    if (score == 0) {
+        crm_trace("Ignoring colocation '%s' because score is 0", id);
+        return;
+    }
+    if ((rsc_lh == NULL) || (rsc_rh == NULL)) {
+        pcmk__config_err("Ignoring colocation '%s' because resource "
+                         "does not exist", id);
+        return;
+    }
+
+    new_con = calloc(1, sizeof(pcmk__colocation_t));
+    if (new_con == NULL) {
+        return;
+    }
+
+    if (pcmk__str_eq(state_lh, RSC_ROLE_STARTED_S,
+                     pcmk__str_null_matches|pcmk__str_casei)) {
+        state_lh = RSC_ROLE_UNKNOWN_S;
+    }
+
+    if (pcmk__str_eq(state_rh, RSC_ROLE_STARTED_S,
+                     pcmk__str_null_matches|pcmk__str_casei)) {
+        state_rh = RSC_ROLE_UNKNOWN_S;
+    }
+
+    new_con->id = id;
+    new_con->rsc_lh = rsc_lh;
+    new_con->rsc_rh = rsc_rh;
+    new_con->score = score;
+    new_con->role_lh = text2role(state_lh);
+    new_con->role_rh = text2role(state_rh);
+    new_con->node_attribute = node_attr;
+    new_con->influence = influence;
+
+    if (node_attr == NULL) {
+        node_attr = CRM_ATTR_UNAME;
+    }
+
+    pe_rsc_trace(rsc_lh, "%s ==> %s (%s %d)",
+                 rsc_lh->id, rsc_rh->id, node_attr, score);
+
+    rsc_lh->rsc_cons = g_list_insert_sorted(rsc_lh->rsc_cons, new_con,
+                                            sort_cons_priority_rh);
+
+    rsc_rh->rsc_cons_lhs = g_list_insert_sorted(rsc_rh->rsc_cons_lhs, new_con,
+                                                sort_cons_priority_lh);
+
+    data_set->colocation_constraints = g_list_append(data_set->colocation_constraints,
+                                                     new_con);
+
+    if (score <= -INFINITY) {
+        anti_colocation_order(rsc_lh, new_con->role_lh, rsc_rh,
+                              new_con->role_rh, data_set);
+        anti_colocation_order(rsc_rh, new_con->role_rh, rsc_lh,
+                              new_con->role_lh, data_set);
+    }
+}
+
+/*!
+ * \internal
+ * \brief Return the boolean influence corresponding to configuration
+ *
+ * \param[in] coloc_id     Colocation XML ID (for error logging)
+ * \param[in] rsc          Resource involved in constraint (for default)
+ * \param[in] influence_s  String value of influence option
+ *
+ * \return true if string evaluates true, false if string evaluates false,
+ *         or value of resource's critical option if string is NULL or invalid
+ */
+static bool
+unpack_influence(const char *coloc_id, const pe_resource_t *rsc,
+                 const char *influence_s)
+{
+    if (influence_s != NULL) {
+        int influence_i = 0;
+
+        if (crm_str_to_boolean(influence_s, &influence_i) < 0) {
+            pcmk__config_err("Constraint '%s' has invalid value for "
+                             XML_COLOC_ATTR_INFLUENCE " (using default)",
+                             coloc_id);
+        } else {
+            return (influence_i != 0);
+        }
+    }
+    return pcmk_is_set(rsc->flags, pe_rsc_critical);
+}
+
+static gboolean
+unpack_colocation_set(xmlNode *set, int score, const char *coloc_id,
+                      const char *influence_s, pe_working_set_t *data_set)
+{
+    xmlNode *xml_rsc = NULL;
+    pe_resource_t *with = NULL;
+    pe_resource_t *resource = NULL;
+    const char *set_id = ID(set);
+    const char *role = crm_element_value(set, "role");
+    const char *sequential = crm_element_value(set, "sequential");
+    const char *ordering = crm_element_value(set, "ordering");
+    int local_score = score;
+
+    const char *score_s = crm_element_value(set, XML_RULE_ATTR_SCORE);
+
+    if (score_s) {
+        local_score = char2score(score_s);
+    }
+    if (local_score == 0) {
+        crm_trace("Ignoring colocation '%s' for set '%s' because score is 0",
+                  coloc_id, set_id);
+        return TRUE;
+    }
+
+    if (ordering == NULL) {
+        ordering = "group";
+    }
+
+    if ((sequential != NULL) && !crm_is_true(sequential)) {
+        return TRUE;
+
+    } else if ((local_score > 0)
+               && pcmk__str_eq(ordering, "group", pcmk__str_casei)) {
+        for (xml_rsc = first_named_child(set, XML_TAG_RESOURCE_REF);
+             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
+
+            EXPAND_CONSTRAINT_IDREF(set_id, resource, ID(xml_rsc));
+            if (with != NULL) {
+                pe_rsc_trace(resource, "Colocating %s with %s", resource->id, with->id);
+                pcmk__new_colocation(set_id, NULL, local_score, resource,
+                                     with, role, role,
+                                     unpack_influence(coloc_id, resource,
+                                                      influence_s), data_set);
+            }
+            with = resource;
+        }
+
+    } else if (local_score > 0) {
+        pe_resource_t *last = NULL;
+
+        for (xml_rsc = first_named_child(set, XML_TAG_RESOURCE_REF);
+             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
+
+            EXPAND_CONSTRAINT_IDREF(set_id, resource, ID(xml_rsc));
+            if (last != NULL) {
+                pe_rsc_trace(resource, "Colocating %s with %s",
+                             last->id, resource->id);
+                pcmk__new_colocation(set_id, NULL, local_score, last,
+                                     resource, role, role,
+                                     unpack_influence(coloc_id, last,
+                                                      influence_s), data_set);
+            }
+
+            last = resource;
+        }
+
+    } else {
+        /* Anti-colocating with every prior resource is
+         * the only way to ensure the intuitive result
+         * (i.e. that no one in the set can run with anyone else in the set)
+         */
+
+        for (xml_rsc = first_named_child(set, XML_TAG_RESOURCE_REF);
+             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
+
+            xmlNode *xml_rsc_with = NULL;
+            bool influence = true;
+
+            EXPAND_CONSTRAINT_IDREF(set_id, resource, ID(xml_rsc));
+            influence = unpack_influence(coloc_id, resource, influence_s);
+
+            for (xml_rsc_with = first_named_child(set, XML_TAG_RESOURCE_REF);
+                 xml_rsc_with != NULL;
+                 xml_rsc_with = crm_next_same_xml(xml_rsc_with)) {
+
+                if (pcmk__str_eq(resource->id, ID(xml_rsc_with),
+                                 pcmk__str_casei)) {
+                    break;
+                }
+                EXPAND_CONSTRAINT_IDREF(set_id, with, ID(xml_rsc_with));
+                pe_rsc_trace(resource, "Anti-Colocating %s with %s", resource->id,
+                             with->id);
+                pcmk__new_colocation(set_id, NULL, local_score,
+                                     resource, with, role, role,
+                                     influence, data_set);
+            }
+        }
+    }
+
+    return TRUE;
+}
+
+static gboolean
+colocate_rsc_sets(const char *id, xmlNode *set1, xmlNode *set2, int score,
+                  const char *influence_s, pe_working_set_t *data_set)
+{
+    xmlNode *xml_rsc = NULL;
+    pe_resource_t *rsc_1 = NULL;
+    pe_resource_t *rsc_2 = NULL;
+
+    const char *role_1 = crm_element_value(set1, "role");
+    const char *role_2 = crm_element_value(set2, "role");
+
+    const char *sequential_1 = crm_element_value(set1, "sequential");
+    const char *sequential_2 = crm_element_value(set2, "sequential");
+
+    if (score == 0) {
+        crm_trace("Ignoring colocation '%s' between sets because score is 0",
+                  id);
+        return TRUE;
+    }
+    if ((sequential_1 == NULL) || crm_is_true(sequential_1)) {
+        // Get the first one
+        xml_rsc = first_named_child(set1, XML_TAG_RESOURCE_REF);
+        if (xml_rsc != NULL) {
+            EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
+        }
+    }
+
+    if ((sequential_2 == NULL) || crm_is_true(sequential_2)) {
+        // Get the last one
+        const char *rid = NULL;
+
+        for (xml_rsc = first_named_child(set2, XML_TAG_RESOURCE_REF);
+             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
+
+            rid = ID(xml_rsc);
+        }
+        EXPAND_CONSTRAINT_IDREF(id, rsc_2, rid);
+    }
+
+    if ((rsc_1 != NULL) && (rsc_2 != NULL)) {
+        pcmk__new_colocation(id, NULL, score, rsc_1, rsc_2, role_1, role_2,
+                             unpack_influence(id, rsc_1, influence_s),
+                             data_set);
+
+    } else if (rsc_1 != NULL) {
+        bool influence = unpack_influence(id, rsc_1, influence_s);
+
+        for (xml_rsc = first_named_child(set2, XML_TAG_RESOURCE_REF);
+             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
+
+            EXPAND_CONSTRAINT_IDREF(id, rsc_2, ID(xml_rsc));
+            pcmk__new_colocation(id, NULL, score, rsc_1, rsc_2, role_1,
+                                 role_2, influence, data_set);
+        }
+
+    } else if (rsc_2 != NULL) {
+        for (xml_rsc = first_named_child(set1, XML_TAG_RESOURCE_REF);
+             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
+
+            EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
+            pcmk__new_colocation(id, NULL, score, rsc_1, rsc_2, role_1,
+                                 role_2,
+                                 unpack_influence(id, rsc_1, influence_s),
+                                 data_set);
+        }
+
+    } else {
+        for (xml_rsc = first_named_child(set1, XML_TAG_RESOURCE_REF);
+             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
+
+            xmlNode *xml_rsc_2 = NULL;
+            bool influence = true;
+
+            EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
+            influence = unpack_influence(id, rsc_1, influence_s);
+
+            for (xml_rsc_2 = first_named_child(set2, XML_TAG_RESOURCE_REF);
+                 xml_rsc_2 != NULL;
+                 xml_rsc_2 = crm_next_same_xml(xml_rsc_2)) {
+
+                EXPAND_CONSTRAINT_IDREF(id, rsc_2, ID(xml_rsc_2));
+                pcmk__new_colocation(id, NULL, score, rsc_1, rsc_2,
+                                     role_1, role_2, influence,
+                                     data_set);
+            }
+        }
+    }
+
+    return TRUE;
+}
+
+static void
+unpack_simple_colocation(xmlNode *xml_obj, const char *id,
+                         const char *influence_s, pe_working_set_t *data_set)
+{
+    int score_i = 0;
+
+    const char *score = crm_element_value(xml_obj, XML_RULE_ATTR_SCORE);
+    const char *id_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE);
+    const char *id_rh = crm_element_value(xml_obj, XML_COLOC_ATTR_TARGET);
+    const char *state_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE_ROLE);
+    const char *state_rh = crm_element_value(xml_obj, XML_COLOC_ATTR_TARGET_ROLE);
+    const char *attr = crm_element_value(xml_obj, XML_COLOC_ATTR_NODE_ATTR);
+    const char *symmetrical = crm_element_value(xml_obj, XML_CONS_ATTR_SYMMETRICAL);
+
+    // experimental syntax from pacemaker-next (unlikely to be adopted as-is)
+    const char *instance_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE_INSTANCE);
+    const char *instance_rh = crm_element_value(xml_obj, XML_COLOC_ATTR_TARGET_INSTANCE);
+
+    pe_resource_t *rsc_lh = pcmk__find_constraint_resource(data_set->resources, id_lh);
+    pe_resource_t *rsc_rh = pcmk__find_constraint_resource(data_set->resources, id_rh);
+
+    if (rsc_lh == NULL) {
+        pcmk__config_err("Ignoring constraint '%s' because resource '%s' "
+                         "does not exist", id, id_lh);
+        return;
+
+    } else if (rsc_rh == NULL) {
+        pcmk__config_err("Ignoring constraint '%s' because resource '%s' "
+                         "does not exist", id, id_rh);
+        return;
+
+    } else if ((instance_lh != NULL) && !pe_rsc_is_clone(rsc_lh)) {
+        pcmk__config_err("Ignoring constraint '%s' because resource '%s' "
+                         "is not a clone but instance '%s' was requested",
+                         id, id_lh, instance_lh);
+        return;
+
+    } else if ((instance_rh != NULL) && !pe_rsc_is_clone(rsc_rh)) {
+        pcmk__config_err("Ignoring constraint '%s' because resource '%s' "
+                         "is not a clone but instance '%s' was requested",
+                         id, id_rh, instance_rh);
+        return;
+    }
+
+    if (instance_lh != NULL) {
+        rsc_lh = find_clone_instance(rsc_lh, instance_lh, data_set);
+        if (rsc_lh == NULL) {
+            pcmk__config_warn("Ignoring constraint '%s' because resource '%s' "
+                              "does not have an instance '%s'",
+                              id, id_lh, instance_lh);
+            return;
+        }
+    }
+
+    if (instance_rh != NULL) {
+        rsc_rh = find_clone_instance(rsc_rh, instance_rh, data_set);
+        if (rsc_rh == NULL) {
+            pcmk__config_warn("Ignoring constraint '%s' because resource '%s' "
+                              "does not have an instance '%s'",
+                              "'%s'", id, id_rh, instance_rh);
+            return;
+        }
+    }
+
+    if (crm_is_true(symmetrical)) {
+        pcmk__config_warn("The colocation constraint '"
+                          XML_CONS_ATTR_SYMMETRICAL
+                          "' attribute has been removed");
+    }
+
+    if (score) {
+        score_i = char2score(score);
+    }
+
+    pcmk__new_colocation(id, attr, score_i, rsc_lh, rsc_rh, state_lh, state_rh,
+                         unpack_influence(id, rsc_lh, influence_s), data_set);
+}
+
+static gboolean
+unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
+                       pe_working_set_t *data_set)
+{
+    const char *id = NULL;
+    const char *id_lh = NULL;
+    const char *id_rh = NULL;
+    const char *state_lh = NULL;
+    const char *state_rh = NULL;
+
+    pe_resource_t *rsc_lh = NULL;
+    pe_resource_t *rsc_rh = NULL;
+
+    pe_tag_t *tag_lh = NULL;
+    pe_tag_t *tag_rh = NULL;
+
+    xmlNode *rsc_set_lh = NULL;
+    xmlNode *rsc_set_rh = NULL;
+    gboolean any_sets = FALSE;
+
+    *expanded_xml = NULL;
+
+    CRM_CHECK(xml_obj != NULL, return FALSE);
+
+    id = ID(xml_obj);
+    if (id == NULL) {
+        pcmk__config_err("Ignoring <%s> constraint without " XML_ATTR_ID,
+                         crm_element_name(xml_obj));
+        return FALSE;
+    }
+
+    // Check whether there are any resource sets with template or tag references
+    *expanded_xml = pcmk__expand_tags_in_sets(xml_obj, data_set);
+    if (*expanded_xml != NULL) {
+        crm_log_xml_trace(*expanded_xml, "Expanded rsc_colocation");
+        return TRUE;
+    }
+
+    id_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE);
+    id_rh = crm_element_value(xml_obj, XML_COLOC_ATTR_TARGET);
+    if (id_lh == NULL || id_rh == NULL) {
+        return TRUE;
+    }
+
+    if (!pcmk__valid_resource_or_tag(data_set, id_lh, &rsc_lh, &tag_lh)) {
+        pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
+                         "valid resource or tag", id, id_lh);
+        return FALSE;
+    }
+
+    if (!pcmk__valid_resource_or_tag(data_set, id_rh, &rsc_rh, &tag_rh)) {
+        pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
+                         "valid resource or tag", id, id_rh);
+        return FALSE;
+    }
+
+    if (rsc_lh && rsc_rh) {
+        /* Neither side references any template/tag. */
+        return TRUE;
+    }
+
+    if (tag_lh && tag_rh) {
+        // A colocation constraint between two templates/tags makes no sense
+        pcmk__config_err("Ignoring constraint '%s' because two templates or "
+                         "tags cannot be colocated", id);
+        return FALSE;
+    }
+
+    state_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE_ROLE);
+    state_rh = crm_element_value(xml_obj, XML_COLOC_ATTR_TARGET_ROLE);
+
+    *expanded_xml = copy_xml(xml_obj);
+
+    // Convert template/tag reference in "rsc" into resource_set under constraint
+    if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_lh, XML_COLOC_ATTR_SOURCE,
+                          TRUE, data_set)) {
+        free_xml(*expanded_xml);
+        *expanded_xml = NULL;
+        return FALSE;
+    }
+
+    if (rsc_set_lh != NULL) {
+        if (state_lh != NULL) {
+            // Move "rsc-role" into converted resource_set as "role"
+            crm_xml_add(rsc_set_lh, "role", state_lh);
+            xml_remove_prop(*expanded_xml, XML_COLOC_ATTR_SOURCE_ROLE);
+        }
+        any_sets = TRUE;
+    }
+
+    // Convert template/tag reference in "with-rsc" into resource_set under constraint
+    if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_rh, XML_COLOC_ATTR_TARGET,
+                          TRUE, data_set)) {
+        free_xml(*expanded_xml);
+        *expanded_xml = NULL;
+        return FALSE;
+    }
+
+    if (rsc_set_rh != NULL) {
+        if (state_rh != NULL) {
+            // Move "with-rsc-role" into converted resource_set as "role"
+            crm_xml_add(rsc_set_rh, "role", state_rh);
+            xml_remove_prop(*expanded_xml, XML_COLOC_ATTR_TARGET_ROLE);
+        }
+        any_sets = TRUE;
+    }
+
+    if (any_sets) {
+        crm_log_xml_trace(*expanded_xml, "Expanded rsc_colocation");
+    } else {
+        free_xml(*expanded_xml);
+        *expanded_xml = NULL;
+    }
+
+    return TRUE;
+}
+
+/*!
+ * \internal
+ * \brief Parse a colocation constraint from XML into a cluster working set
+ *
+ * \param[in] xml_obj   Colocation constraint XML to unpack
+ * \param[in] data_set  Cluster working set to add constraint to
+ */
+void
+pcmk__unpack_colocation(xmlNode *xml_obj, pe_working_set_t *data_set)
+{
+    int score_i = 0;
+    xmlNode *set = NULL;
+    xmlNode *last = NULL;
+
+    xmlNode *orig_xml = NULL;
+    xmlNode *expanded_xml = NULL;
+
+    const char *id = crm_element_value(xml_obj, XML_ATTR_ID);
+    const char *score = crm_element_value(xml_obj, XML_RULE_ATTR_SCORE);
+    const char *influence_s = crm_element_value(xml_obj,
+                                                XML_COLOC_ATTR_INFLUENCE);
+
+    if (score) {
+        score_i = char2score(score);
+    }
+
+    if (!unpack_colocation_tags(xml_obj, &expanded_xml, data_set)) {
+        return;
+    }
+    if (expanded_xml) {
+        orig_xml = xml_obj;
+        xml_obj = expanded_xml;
+    }
+
+    for (set = first_named_child(xml_obj, XML_CONS_TAG_RSC_SET); set != NULL;
+         set = crm_next_same_xml(set)) {
+
+        set = expand_idref(set, data_set->input);
+        if ((set == NULL) // Configuration error, message already logged
+            || !unpack_colocation_set(set, score_i, id, influence_s, data_set)
+            || ((last != NULL) && !colocate_rsc_sets(id, last, set, score_i,
+                                                     influence_s, data_set))) {
+            if (expanded_xml != NULL) {
+                free_xml(expanded_xml);
+            }
+            return;
+        }
+        last = set;
+    }
+
+    if (expanded_xml) {
+        free_xml(expanded_xml);
+        xml_obj = orig_xml;
+    }
+
+    if (last == NULL) {
+        unpack_simple_colocation(xml_obj, id, influence_s, data_set);
+    }
+}

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -25,6 +25,7 @@
 #include <crm/pengine/internal.h>
 #include <crm/pengine/rules.h>
 #include <pacemaker-internal.h>
+#include "libpacemaker_private.h"
 
 enum pe_order_kind {
     pe_order_kind_optional,
@@ -39,7 +40,7 @@ enum ordering_symmetry {
 };
 
 #define EXPAND_CONSTRAINT_IDREF(__set, __rsc, __name) do {				\
-	__rsc = pe_find_constraint_resource(data_set->resources, __name);		\
+	__rsc = pcmk__find_constraint_resource(data_set->resources, __name);		\
 	if(__rsc == NULL) {						\
 	    pcmk__config_err("%s: No resource found for %s", __set, __name);    \
 	    return FALSE;						\
@@ -53,7 +54,6 @@ static pe__location_t *generate_location_rule(pe_resource_t *rsc,
                                               pe_working_set_t *data_set,
                                               pe_re_match_data_t *match_data);
 static void unpack_location(xmlNode *xml_obj, pe_working_set_t *data_set);
-static void unpack_rsc_colocation(xmlNode *xml_obj, pe_working_set_t *data_set);
 static void unpack_rsc_order(xmlNode *xml_obj, pe_working_set_t *data_set);
 static void unpack_rsc_ticket(xmlNode *xml_obj, pe_working_set_t *data_set);
 
@@ -107,7 +107,7 @@ unpack_constraints(xmlNode * xml_constraints, pe_working_set_t * data_set)
             unpack_rsc_order(xml_obj, data_set);
 
         } else if (pcmk__str_eq(XML_CONS_TAG_RSC_DEPEND, tag, pcmk__str_casei)) {
-            unpack_rsc_colocation(xml_obj, data_set);
+            pcmk__unpack_colocation(xml_obj, data_set);
 
         } else if (pcmk__str_eq(XML_CONS_TAG_RSC_LOCATION, tag, pcmk__str_casei)) {
             unpack_location(xml_obj, data_set);
@@ -194,8 +194,8 @@ get_ordering_type(xmlNode * xml_obj)
     return kind_e;
 }
 
-static pe_resource_t *
-pe_find_constraint_resource(GList *rsc_list, const char *id)
+pe_resource_t *
+pcmk__find_constraint_resource(GList *rsc_list, const char *id)
 {
     GList *rIter = NULL;
 
@@ -247,15 +247,15 @@ pe_find_constraint_tag(pe_working_set_t * data_set, const char * id, pe_tag_t **
     return rc;
 }
 
-static gboolean
-valid_resource_or_tag(pe_working_set_t * data_set, const char * id,
-                      pe_resource_t ** rsc, pe_tag_t ** tag)
+gboolean
+pcmk__valid_resource_or_tag(pe_working_set_t *data_set, const char *id,
+                            pe_resource_t **rsc, pe_tag_t **tag)
 {
     gboolean rc = FALSE;
 
     if (rsc) {
         *rsc = NULL;
-        *rsc = pe_find_constraint_resource(data_set->resources, id);
+        *rsc = pcmk__find_constraint_resource(data_set->resources, id);
         if (*rsc) {
             return TRUE;
         }
@@ -393,7 +393,7 @@ get_ordering_resource(xmlNode *xml, const char *resource_attr,
         return NULL;
     }
 
-    rsc = pe_find_constraint_resource(data_set->resources, rsc_id);
+    rsc = pcmk__find_constraint_resource(data_set->resources, rsc_id);
     if (rsc == NULL) {
         pcmk__config_err("Ignoring constraint '%s' because resource '%s' "
                          "does not exist", ID(xml), rsc_id);
@@ -650,8 +650,8 @@ unpack_simple_rsc_order(xmlNode * xml_obj, pe_working_set_t * data_set)
  * \return Equivalent XML with resource tags replaced (or NULL if none)
  * \note It is the caller's responsibility to free the result with free_xml().
  */
-static xmlNode *
-expand_tags_in_sets(xmlNode *xml_obj, pe_working_set_t *data_set)
+xmlNode *
+pcmk__expand_tags_in_sets(xmlNode *xml_obj, pe_working_set_t *data_set)
 {
     xmlNode *new_xml = NULL;
     bool any_refs = false;
@@ -675,7 +675,8 @@ expand_tags_in_sets(xmlNode *xml_obj, pe_working_set_t *data_set)
             pe_resource_t *rsc = NULL;
             pe_tag_t *tag = NULL;
 
-            if (!valid_resource_or_tag(data_set, ID(xml_rsc), &rsc, &tag)) {
+            if (!pcmk__valid_resource_or_tag(data_set, ID(xml_rsc), &rsc,
+                                             &tag)) {
                 pcmk__config_err("Ignoring resource sets for constraint '%s' "
                                  "because '%s' is not a valid resource or tag",
                                  ID(xml_obj), ID(xml_rsc));
@@ -757,9 +758,9 @@ expand_tags_in_sets(xmlNode *xml_obj, pe_working_set_t *data_set)
     return new_xml;
 }
 
-static gboolean
-tag_to_set(xmlNode * xml_obj, xmlNode ** rsc_set, const char * attr,
-                gboolean convert_rsc, pe_working_set_t * data_set)
+gboolean
+pcmk__tag_to_set(xmlNode *xml_obj, xmlNode **rsc_set, const char *attr,
+                 gboolean convert_rsc, pe_working_set_t *data_set)
 {
     const char *cons_id = NULL;
     const char *id = NULL;
@@ -783,7 +784,7 @@ tag_to_set(xmlNode * xml_obj, xmlNode ** rsc_set, const char * attr,
         return TRUE;
     }
 
-    if (valid_resource_or_tag(data_set, id, &rsc, &tag) == FALSE) {
+    if (!pcmk__valid_resource_or_tag(data_set, id, &rsc, &tag)) {
         pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
                          "valid resource or tag", cons_id, id);
         return FALSE;
@@ -843,7 +844,7 @@ unpack_simple_location(xmlNode *xml_obj, pe_working_set_t *data_set)
     const char *value = crm_element_value(xml_obj, XML_LOC_ATTR_SOURCE);
 
     if(value) {
-        pe_resource_t *rsc_lh = pe_find_constraint_resource(data_set->resources, value);
+        pe_resource_t *rsc_lh = pcmk__find_constraint_resource(data_set->resources, value);
 
         unpack_rsc_location(xml_obj, rsc_lh, NULL, NULL, data_set, NULL);
     }
@@ -1021,7 +1022,7 @@ unpack_location_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_
     }
 
     // Check whether there are any resource sets with template or tag references
-    *expanded_xml = expand_tags_in_sets(xml_obj, data_set);
+    *expanded_xml = pcmk__expand_tags_in_sets(xml_obj, data_set);
     if (*expanded_xml != NULL) {
         crm_log_xml_trace(*expanded_xml, "Expanded rsc_location");
         return TRUE;
@@ -1032,7 +1033,7 @@ unpack_location_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_
         return TRUE;
     }
 
-    if (valid_resource_or_tag(data_set, id_lh, &rsc_lh, &tag_lh) == FALSE) {
+    if (!pcmk__valid_resource_or_tag(data_set, id_lh, &rsc_lh, &tag_lh)) {
         pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
                          "valid resource or tag", id, id_lh);
         return FALSE;
@@ -1047,8 +1048,8 @@ unpack_location_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_
     *expanded_xml = copy_xml(xml_obj);
 
     /* Convert the template/tag reference in "rsc" into a resource_set under the rsc_location constraint. */
-    if (!tag_to_set(*expanded_xml, &rsc_set_lh, XML_LOC_ATTR_SOURCE, FALSE,
-                    data_set)) {
+    if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_lh, XML_LOC_ATTR_SOURCE,
+                          FALSE, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
         return FALSE;
@@ -1318,203 +1319,6 @@ generate_location_rule(pe_resource_t *rsc, xmlNode *rule_xml,
 
     crm_trace("%s: %d nodes matched", rule_id, g_list_length(location_rule->node_list_rh));
     return location_rule;
-}
-
-static gint
-sort_cons_priority_lh(gconstpointer a, gconstpointer b)
-{
-    const pcmk__colocation_t *rsc_constraint1 = (const pcmk__colocation_t *) a;
-    const pcmk__colocation_t *rsc_constraint2 = (const pcmk__colocation_t *) b;
-
-    if (a == NULL) {
-        return 1;
-    }
-    if (b == NULL) {
-        return -1;
-    }
-
-    CRM_ASSERT(rsc_constraint1->rsc_lh != NULL);
-    CRM_ASSERT(rsc_constraint1->rsc_rh != NULL);
-
-    if (rsc_constraint1->rsc_lh->priority > rsc_constraint2->rsc_lh->priority) {
-        return -1;
-    }
-
-    if (rsc_constraint1->rsc_lh->priority < rsc_constraint2->rsc_lh->priority) {
-        return 1;
-    }
-
-    /* Process clones before primitives and groups */
-    if (rsc_constraint1->rsc_lh->variant > rsc_constraint2->rsc_lh->variant) {
-        return -1;
-    } else if (rsc_constraint1->rsc_lh->variant < rsc_constraint2->rsc_lh->variant) {
-        return 1;
-    }
-
-    /* @COMPAT scheduler <2.0.0: Process promotable clones before nonpromotable
-     * clones (probably unnecessary, but avoids having to update regression
-     * tests)
-     */
-    if (rsc_constraint1->rsc_lh->variant == pe_clone) {
-        if (pcmk_is_set(rsc_constraint1->rsc_lh->flags, pe_rsc_promotable)
-            && !pcmk_is_set(rsc_constraint2->rsc_lh->flags, pe_rsc_promotable)) {
-            return -1;
-        } else if (!pcmk_is_set(rsc_constraint1->rsc_lh->flags, pe_rsc_promotable)
-            && pcmk_is_set(rsc_constraint2->rsc_lh->flags, pe_rsc_promotable)) {
-            return 1;
-        }
-    }
-
-    return strcmp(rsc_constraint1->rsc_lh->id, rsc_constraint2->rsc_lh->id);
-}
-
-static gint
-sort_cons_priority_rh(gconstpointer a, gconstpointer b)
-{
-    const pcmk__colocation_t *rsc_constraint1 = (const pcmk__colocation_t *) a;
-    const pcmk__colocation_t *rsc_constraint2 = (const pcmk__colocation_t *) b;
-
-    if (a == NULL) {
-        return 1;
-    }
-    if (b == NULL) {
-        return -1;
-    }
-
-    CRM_ASSERT(rsc_constraint1->rsc_lh != NULL);
-    CRM_ASSERT(rsc_constraint1->rsc_rh != NULL);
-
-    if (rsc_constraint1->rsc_rh->priority > rsc_constraint2->rsc_rh->priority) {
-        return -1;
-    }
-
-    if (rsc_constraint1->rsc_rh->priority < rsc_constraint2->rsc_rh->priority) {
-        return 1;
-    }
-
-    /* Process clones before primitives and groups */
-    if (rsc_constraint1->rsc_rh->variant > rsc_constraint2->rsc_rh->variant) {
-        return -1;
-    } else if (rsc_constraint1->rsc_rh->variant < rsc_constraint2->rsc_rh->variant) {
-        return 1;
-    }
-
-    /* @COMPAT scheduler <2.0.0: Process promotable clones before nonpromotable
-     * clones (probably unnecessary, but avoids having to update regression
-     * tests)
-     */
-    if (rsc_constraint1->rsc_rh->variant == pe_clone) {
-        if (pcmk_is_set(rsc_constraint1->rsc_rh->flags, pe_rsc_promotable)
-            && !pcmk_is_set(rsc_constraint2->rsc_rh->flags, pe_rsc_promotable)) {
-            return -1;
-        } else if (!pcmk_is_set(rsc_constraint1->rsc_rh->flags, pe_rsc_promotable)
-            && pcmk_is_set(rsc_constraint2->rsc_rh->flags, pe_rsc_promotable)) {
-            return 1;
-        }
-    }
-
-    return strcmp(rsc_constraint1->rsc_rh->id, rsc_constraint2->rsc_rh->id);
-}
-
-static void
-anti_colocation_order(pe_resource_t * first_rsc, int first_role,
-                      pe_resource_t * then_rsc, int then_role,
-                      pe_working_set_t * data_set)
-{
-    const char *first_tasks[] = { NULL, NULL };
-    const char *then_tasks[] = { NULL, NULL };
-    int first_lpc = 0;
-    int then_lpc = 0;
-
-    /* Actions to make first_rsc lose first_role */
-    if (first_role == RSC_ROLE_PROMOTED) {
-        first_tasks[0] = CRMD_ACTION_DEMOTE;
-
-    } else {
-        first_tasks[0] = CRMD_ACTION_STOP;
-
-        if (first_role == RSC_ROLE_UNPROMOTED) {
-            first_tasks[1] = CRMD_ACTION_PROMOTE;
-        }
-    }
-
-    /* Actions to make then_rsc gain then_role */
-    if (then_role == RSC_ROLE_PROMOTED) {
-        then_tasks[0] = CRMD_ACTION_PROMOTE;
-
-    } else {
-        then_tasks[0] = CRMD_ACTION_START;
-
-        if (then_role == RSC_ROLE_UNPROMOTED) {
-            then_tasks[1] = CRMD_ACTION_DEMOTE;
-        }
-    }
-
-    for (first_lpc = 0; first_lpc <= 1 && first_tasks[first_lpc] != NULL; first_lpc++) {
-        for (then_lpc = 0; then_lpc <= 1 && then_tasks[then_lpc] != NULL; then_lpc++) {
-            new_rsc_order(first_rsc, first_tasks[first_lpc], then_rsc, then_tasks[then_lpc],
-                          pe_order_anti_colocation, data_set);
-        }
-    }
-}
-
-void
-pcmk__new_colocation(const char *id, const char *node_attr, int score,
-                     pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
-                     const char *state_lh, const char *state_rh,
-                     bool influence, pe_working_set_t *data_set)
-{
-    pcmk__colocation_t *new_con = NULL;
-
-    if (score == 0) {
-        crm_trace("Ignoring colocation '%s' because score is 0", id);
-        return;
-    }
-    if ((rsc_lh == NULL) || (rsc_rh == NULL)) {
-        pcmk__config_err("Ignoring colocation '%s' because resource "
-                         "does not exist", id);
-        return;
-    }
-
-    new_con = calloc(1, sizeof(pcmk__colocation_t));
-    if (new_con == NULL) {
-        return;
-    }
-
-    if (pcmk__str_eq(state_lh, RSC_ROLE_STARTED_S, pcmk__str_null_matches | pcmk__str_casei)) {
-        state_lh = RSC_ROLE_UNKNOWN_S;
-    }
-
-    if (pcmk__str_eq(state_rh, RSC_ROLE_STARTED_S, pcmk__str_null_matches | pcmk__str_casei)) {
-        state_rh = RSC_ROLE_UNKNOWN_S;
-    }
-
-    new_con->id = id;
-    new_con->rsc_lh = rsc_lh;
-    new_con->rsc_rh = rsc_rh;
-    new_con->score = score;
-    new_con->role_lh = text2role(state_lh);
-    new_con->role_rh = text2role(state_rh);
-    new_con->node_attribute = node_attr;
-    new_con->influence = influence;
-
-    if (node_attr == NULL) {
-        node_attr = CRM_ATTR_UNAME;
-    }
-
-    pe_rsc_trace(rsc_lh, "%s ==> %s (%s %d)", rsc_lh->id, rsc_rh->id, node_attr, score);
-
-    rsc_lh->rsc_cons = g_list_insert_sorted(rsc_lh->rsc_cons, new_con, sort_cons_priority_rh);
-
-    rsc_rh->rsc_cons_lhs =
-        g_list_insert_sorted(rsc_rh->rsc_cons_lhs, new_con, sort_cons_priority_lh);
-
-    data_set->colocation_constraints = g_list_append(data_set->colocation_constraints, new_con);
-
-    if (score <= -INFINITY) {
-        anti_colocation_order(rsc_lh, new_con->role_lh, rsc_rh, new_con->role_rh, data_set);
-        anti_colocation_order(rsc_rh, new_con->role_rh, rsc_lh, new_con->role_lh, data_set);
-    }
 }
 
 /* LHS before RHS */
@@ -2051,7 +1855,7 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
     gboolean any_sets = FALSE;
 
     // Check whether there are any resource sets with template or tag references
-    *expanded_xml = expand_tags_in_sets(xml_obj, data_set);
+    *expanded_xml = pcmk__expand_tags_in_sets(xml_obj, data_set);
     if (*expanded_xml != NULL) {
         crm_log_xml_trace(*expanded_xml, "Expanded rsc_order");
         return pcmk_rc_ok;
@@ -2063,13 +1867,13 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
         return pcmk_rc_ok;
     }
 
-    if (valid_resource_or_tag(data_set, id_first, &rsc_first, &tag_first) == FALSE) {
+    if (!pcmk__valid_resource_or_tag(data_set, id_first, &rsc_first, &tag_first)) {
         pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
                          "valid resource or tag", ID(xml_obj), id_first);
         return pcmk_rc_schema_validation;
     }
 
-    if (valid_resource_or_tag(data_set, id_then, &rsc_then, &tag_then) == FALSE) {
+    if (!pcmk__valid_resource_or_tag(data_set, id_then, &rsc_then, &tag_then)) {
         pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
                          "valid resource or tag", ID(xml_obj), id_then);
         return pcmk_rc_schema_validation;
@@ -2086,8 +1890,8 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
     *expanded_xml = copy_xml(xml_obj);
 
     /* Convert the template/tag reference in "first" into a resource_set under the order constraint. */
-    if (!tag_to_set(*expanded_xml, &rsc_set_first, XML_ORDER_ATTR_FIRST, TRUE,
-                    data_set)) {
+    if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_first, XML_ORDER_ATTR_FIRST,
+                          TRUE, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
         return pcmk_rc_schema_validation;
@@ -2104,8 +1908,8 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
     }
 
     /* Convert the template/tag reference in "then" into a resource_set under the order constraint. */
-    if (!tag_to_set(*expanded_xml, &rsc_set_then, XML_ORDER_ATTR_THEN, TRUE,
-                    data_set)) {
+    if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_then, XML_ORDER_ATTR_THEN,
+                          TRUE, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
         return pcmk_rc_schema_validation;
@@ -2198,473 +2002,6 @@ unpack_rsc_order(xmlNode *xml_obj, pe_working_set_t *data_set)
     // If the constraint has no resource sets, unpack it as a simple ordering
     if (last == NULL) {
         unpack_simple_rsc_order(xml_obj, data_set);
-    }
-}
-
-/*!
- * \internal
- * \brief Return the boolean influence corresponding to configuration
- *
- * \param[in] coloc_id     Colocation XML ID (for error logging)
- * \param[in] rsc          Resource involved in constraint (for default)
- * \param[in] influence_s  String value of influence option
- *
- * \return true if string evaluates true, false if string evaluates false,
- *         or value of resource's critical option if string is NULL or invalid
- */
-static bool
-unpack_influence(const char *coloc_id, const pe_resource_t *rsc,
-                 const char *influence_s)
-{
-    if (influence_s != NULL) {
-        int influence_i = 0;
-
-        if (crm_str_to_boolean(influence_s, &influence_i) < 0) {
-            pcmk__config_err("Constraint '%s' has invalid value for "
-                             XML_COLOC_ATTR_INFLUENCE " (using default)",
-                             coloc_id);
-        } else {
-            return (influence_i == TRUE);
-        }
-    }
-    return pcmk_is_set(rsc->flags, pe_rsc_critical);
-}
-
-static gboolean
-unpack_colocation_set(xmlNode *set, int score, const char *coloc_id,
-                      const char *influence_s, pe_working_set_t *data_set)
-{
-    xmlNode *xml_rsc = NULL;
-    pe_resource_t *with = NULL;
-    pe_resource_t *resource = NULL;
-    const char *set_id = ID(set);
-    const char *role = crm_element_value(set, "role");
-    const char *sequential = crm_element_value(set, "sequential");
-    const char *ordering = crm_element_value(set, "ordering");
-    int local_score = score;
-
-    const char *score_s = crm_element_value(set, XML_RULE_ATTR_SCORE);
-
-    if (score_s) {
-        local_score = char2score(score_s);
-    }
-    if (local_score == 0) {
-        crm_trace("Ignoring colocation '%s' for set '%s' because score is 0",
-                  coloc_id, set_id);
-        return TRUE;
-    }
-
-    if(ordering == NULL) {
-        ordering = "group";
-    }
-
-    if (sequential != NULL && crm_is_true(sequential) == FALSE) {
-        return TRUE;
-
-    } else if ((local_score > 0)
-               && pcmk__str_eq(ordering, "group", pcmk__str_casei)) {
-        for (xml_rsc = first_named_child(set, XML_TAG_RESOURCE_REF);
-             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
-
-            EXPAND_CONSTRAINT_IDREF(set_id, resource, ID(xml_rsc));
-            if (with != NULL) {
-                pe_rsc_trace(resource, "Colocating %s with %s", resource->id, with->id);
-                pcmk__new_colocation(set_id, NULL, local_score, resource,
-                                     with, role, role,
-                                     unpack_influence(coloc_id, resource,
-                                                      influence_s),
-                                     data_set);
-            }
-            with = resource;
-        }
-    } else if (local_score > 0) {
-        pe_resource_t *last = NULL;
-        for (xml_rsc = first_named_child(set, XML_TAG_RESOURCE_REF);
-             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
-
-            EXPAND_CONSTRAINT_IDREF(set_id, resource, ID(xml_rsc));
-            if (last != NULL) {
-                pe_rsc_trace(resource, "Colocating %s with %s", last->id, resource->id);
-                pcmk__new_colocation(set_id, NULL, local_score, last,
-                                     resource, role, role,
-                                     unpack_influence(coloc_id, last,
-                                                      influence_s),
-                                     data_set);
-            }
-
-            last = resource;
-        }
-
-    } else {
-        /* Anti-colocating with every prior resource is
-         * the only way to ensure the intuitive result
-         * (i.e. that no one in the set can run with anyone else in the set)
-         */
-
-        for (xml_rsc = first_named_child(set, XML_TAG_RESOURCE_REF);
-             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
-
-            xmlNode *xml_rsc_with = NULL;
-            bool influence = true;
-
-            EXPAND_CONSTRAINT_IDREF(set_id, resource, ID(xml_rsc));
-            influence = unpack_influence(coloc_id, resource, influence_s);
-
-            for (xml_rsc_with = first_named_child(set, XML_TAG_RESOURCE_REF);
-                 xml_rsc_with != NULL;
-                 xml_rsc_with = crm_next_same_xml(xml_rsc_with)) {
-
-                if (pcmk__str_eq(resource->id, ID(xml_rsc_with), pcmk__str_casei)) {
-                    break;
-                }
-                EXPAND_CONSTRAINT_IDREF(set_id, with, ID(xml_rsc_with));
-                pe_rsc_trace(resource, "Anti-Colocating %s with %s", resource->id,
-                             with->id);
-                pcmk__new_colocation(set_id, NULL, local_score,
-                                     resource, with, role, role,
-                                     influence, data_set);
-            }
-        }
-    }
-
-    return TRUE;
-}
-
-static gboolean
-colocate_rsc_sets(const char *id, xmlNode * set1, xmlNode * set2, int score,
-                  const char *influence_s, pe_working_set_t *data_set)
-{
-    xmlNode *xml_rsc = NULL;
-    pe_resource_t *rsc_1 = NULL;
-    pe_resource_t *rsc_2 = NULL;
-
-    const char *role_1 = crm_element_value(set1, "role");
-    const char *role_2 = crm_element_value(set2, "role");
-
-    const char *sequential_1 = crm_element_value(set1, "sequential");
-    const char *sequential_2 = crm_element_value(set2, "sequential");
-
-    if (score == 0) {
-        crm_trace("Ignoring colocation '%s' between sets because score is 0",
-                  id);
-        return TRUE;
-    }
-    if (sequential_1 == NULL || crm_is_true(sequential_1)) {
-        /* get the first one */
-        xml_rsc = first_named_child(set1, XML_TAG_RESOURCE_REF);
-        if (xml_rsc != NULL) {
-            EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
-        }
-    }
-
-    if (sequential_2 == NULL || crm_is_true(sequential_2)) {
-        /* get the last one */
-        const char *rid = NULL;
-
-        for (xml_rsc = first_named_child(set2, XML_TAG_RESOURCE_REF);
-             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
-            rid = ID(xml_rsc);
-        }
-        EXPAND_CONSTRAINT_IDREF(id, rsc_2, rid);
-    }
-
-    if (rsc_1 != NULL && rsc_2 != NULL) {
-        pcmk__new_colocation(id, NULL, score, rsc_1, rsc_2, role_1, role_2,
-                             unpack_influence(id, rsc_1, influence_s),
-                             data_set);
-
-    } else if (rsc_1 != NULL) {
-        bool influence = unpack_influence(id, rsc_1, influence_s);
-
-        for (xml_rsc = first_named_child(set2, XML_TAG_RESOURCE_REF);
-             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
-
-            EXPAND_CONSTRAINT_IDREF(id, rsc_2, ID(xml_rsc));
-            pcmk__new_colocation(id, NULL, score, rsc_1, rsc_2, role_1,
-                                 role_2, influence, data_set);
-        }
-
-    } else if (rsc_2 != NULL) {
-        for (xml_rsc = first_named_child(set1, XML_TAG_RESOURCE_REF);
-             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
-
-            EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
-            pcmk__new_colocation(id, NULL, score, rsc_1, rsc_2, role_1,
-                                 role_2,
-                                 unpack_influence(id, rsc_1, influence_s),
-                                 data_set);
-        }
-
-    } else {
-        for (xml_rsc = first_named_child(set1, XML_TAG_RESOURCE_REF);
-             xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
-
-            xmlNode *xml_rsc_2 = NULL;
-            bool influence = true;
-
-            EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
-            influence = unpack_influence(id, rsc_1, influence_s);
-
-            for (xml_rsc_2 = first_named_child(set2, XML_TAG_RESOURCE_REF);
-                 xml_rsc_2 != NULL; xml_rsc_2 = crm_next_same_xml(xml_rsc_2)) {
-
-                EXPAND_CONSTRAINT_IDREF(id, rsc_2, ID(xml_rsc_2));
-                pcmk__new_colocation(id, NULL, score, rsc_1, rsc_2,
-                                     role_1, role_2, influence,
-                                     data_set);
-            }
-        }
-    }
-
-    return TRUE;
-}
-
-static void
-unpack_simple_colocation(xmlNode *xml_obj, const char *id,
-                         const char *influence_s, pe_working_set_t *data_set)
-{
-    int score_i = 0;
-
-    const char *score = crm_element_value(xml_obj, XML_RULE_ATTR_SCORE);
-    const char *id_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE);
-    const char *id_rh = crm_element_value(xml_obj, XML_COLOC_ATTR_TARGET);
-    const char *state_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE_ROLE);
-    const char *state_rh = crm_element_value(xml_obj, XML_COLOC_ATTR_TARGET_ROLE);
-    const char *attr = crm_element_value(xml_obj, XML_COLOC_ATTR_NODE_ATTR);
-    const char *symmetrical = crm_element_value(xml_obj, XML_CONS_ATTR_SYMMETRICAL);
-
-    // experimental syntax from pacemaker-next (unlikely to be adopted as-is)
-    const char *instance_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE_INSTANCE);
-    const char *instance_rh = crm_element_value(xml_obj, XML_COLOC_ATTR_TARGET_INSTANCE);
-
-    pe_resource_t *rsc_lh = pe_find_constraint_resource(data_set->resources, id_lh);
-    pe_resource_t *rsc_rh = pe_find_constraint_resource(data_set->resources, id_rh);
-
-    if (rsc_lh == NULL) {
-        pcmk__config_err("Ignoring constraint '%s' because resource '%s' "
-                         "does not exist", id, id_lh);
-        return;
-
-    } else if (rsc_rh == NULL) {
-        pcmk__config_err("Ignoring constraint '%s' because resource '%s' "
-                         "does not exist", id, id_rh);
-        return;
-
-    } else if (instance_lh && pe_rsc_is_clone(rsc_lh) == FALSE) {
-        pcmk__config_err("Ignoring constraint '%s' because resource '%s' "
-                         "is not a clone but instance '%s' was requested",
-                         id, id_lh, instance_lh);
-        return;
-
-    } else if (instance_rh && pe_rsc_is_clone(rsc_rh) == FALSE) {
-        pcmk__config_err("Ignoring constraint '%s' because resource '%s' "
-                         "is not a clone but instance '%s' was requested",
-                         id, id_rh, instance_rh);
-        return;
-    }
-
-    if (instance_lh) {
-        rsc_lh = find_clone_instance(rsc_lh, instance_lh, data_set);
-        if (rsc_lh == NULL) {
-            pcmk__config_warn("Ignoring constraint '%s' because resource '%s' "
-                              "does not have an instance '%s'",
-                              id, id_lh, instance_lh);
-            return;
-        }
-    }
-
-    if (instance_rh) {
-        rsc_rh = find_clone_instance(rsc_rh, instance_rh, data_set);
-        if (rsc_rh == NULL) {
-            pcmk__config_warn("Ignoring constraint '%s' because resource '%s' "
-                              "does not have an instance '%s'",
-                              "'%s'", id, id_rh, instance_rh);
-            return;
-        }
-    }
-
-    if (crm_is_true(symmetrical)) {
-        pcmk__config_warn("The colocation constraint '"
-                          XML_CONS_ATTR_SYMMETRICAL
-                          "' attribute has been removed");
-    }
-
-    if (score) {
-        score_i = char2score(score);
-    }
-
-    pcmk__new_colocation(id, attr, score_i, rsc_lh, rsc_rh, state_lh, state_rh,
-                         unpack_influence(id, rsc_lh, influence_s), data_set);
-}
-
-static gboolean
-unpack_colocation_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t * data_set)
-{
-    const char *id = NULL;
-    const char *id_lh = NULL;
-    const char *id_rh = NULL;
-    const char *state_lh = NULL;
-    const char *state_rh = NULL;
-
-    pe_resource_t *rsc_lh = NULL;
-    pe_resource_t *rsc_rh = NULL;
-
-    pe_tag_t *tag_lh = NULL;
-    pe_tag_t *tag_rh = NULL;
-
-    xmlNode *rsc_set_lh = NULL;
-    xmlNode *rsc_set_rh = NULL;
-    gboolean any_sets = FALSE;
-
-    *expanded_xml = NULL;
-
-    CRM_CHECK(xml_obj != NULL, return FALSE);
-
-    id = ID(xml_obj);
-    if (id == NULL) {
-        pcmk__config_err("Ignoring <%s> constraint without " XML_ATTR_ID,
-                         crm_element_name(xml_obj));
-        return FALSE;
-    }
-
-    // Check whether there are any resource sets with template or tag references
-    *expanded_xml = expand_tags_in_sets(xml_obj, data_set);
-    if (*expanded_xml != NULL) {
-        crm_log_xml_trace(*expanded_xml, "Expanded rsc_colocation");
-        return TRUE;
-    }
-
-    id_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE);
-    id_rh = crm_element_value(xml_obj, XML_COLOC_ATTR_TARGET);
-    if (id_lh == NULL || id_rh == NULL) {
-        return TRUE;
-    }
-
-    if (valid_resource_or_tag(data_set, id_lh, &rsc_lh, &tag_lh) == FALSE) {
-        pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
-                         "valid resource or tag", id, id_lh);
-        return FALSE;
-    }
-
-    if (valid_resource_or_tag(data_set, id_rh, &rsc_rh, &tag_rh) == FALSE) {
-        pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
-                         "valid resource or tag", id, id_rh);
-        return FALSE;
-    }
-
-    if (rsc_lh && rsc_rh) {
-        /* Neither side references any template/tag. */
-        return TRUE;
-    }
-
-    if (tag_lh && tag_rh) {
-        /* A colocation constraint between two templates/tags makes no sense. */
-        pcmk__config_err("Ignoring constraint '%s' because two templates or "
-                         "tags cannot be colocated", id);
-        return FALSE;
-    }
-
-    state_lh = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE_ROLE);
-    state_rh = crm_element_value(xml_obj, XML_COLOC_ATTR_TARGET_ROLE);
-
-    *expanded_xml = copy_xml(xml_obj);
-
-    /* Convert the template/tag reference in "rsc" into a resource_set under the colocation constraint. */
-    if (!tag_to_set(*expanded_xml, &rsc_set_lh, XML_COLOC_ATTR_SOURCE, TRUE,
-                    data_set)) {
-        free_xml(*expanded_xml);
-        *expanded_xml = NULL;
-        return FALSE;
-    }
-
-    if (rsc_set_lh) {
-        if (state_lh) {
-            /* A "rsc-role" is specified.
-               Move it into the converted resource_set as a "role"" attribute. */
-            crm_xml_add(rsc_set_lh, "role", state_lh);
-            xml_remove_prop(*expanded_xml, XML_COLOC_ATTR_SOURCE_ROLE);
-        }
-        any_sets = TRUE;
-    }
-
-    /* Convert the template/tag reference in "with-rsc" into a resource_set under the colocation constraint. */
-    if (!tag_to_set(*expanded_xml, &rsc_set_rh, XML_COLOC_ATTR_TARGET, TRUE,
-                    data_set)) {
-        free_xml(*expanded_xml);
-        *expanded_xml = NULL;
-        return FALSE;
-    }
-
-    if (rsc_set_rh) {
-        if (state_rh) {
-            /* A "with-rsc-role" is specified.
-               Move it into the converted resource_set as a "role"" attribute. */
-            crm_xml_add(rsc_set_rh, "role", state_rh);
-            xml_remove_prop(*expanded_xml, XML_COLOC_ATTR_TARGET_ROLE);
-        }
-        any_sets = TRUE;
-    }
-
-    if (any_sets) {
-        crm_log_xml_trace(*expanded_xml, "Expanded rsc_colocation");
-    } else {
-        free_xml(*expanded_xml);
-        *expanded_xml = NULL;
-    }
-
-    return TRUE;
-}
-
-static void
-unpack_rsc_colocation(xmlNode *xml_obj, pe_working_set_t *data_set)
-{
-    int score_i = 0;
-    xmlNode *set = NULL;
-    xmlNode *last = NULL;
-
-    xmlNode *orig_xml = NULL;
-    xmlNode *expanded_xml = NULL;
-
-    const char *id = crm_element_value(xml_obj, XML_ATTR_ID);
-    const char *score = crm_element_value(xml_obj, XML_RULE_ATTR_SCORE);
-    const char *influence_s = crm_element_value(xml_obj,
-                                                XML_COLOC_ATTR_INFLUENCE);
-
-    if (score) {
-        score_i = char2score(score);
-    }
-
-    if (!unpack_colocation_tags(xml_obj, &expanded_xml, data_set)) {
-        return;
-    }
-    if (expanded_xml) {
-        orig_xml = xml_obj;
-        xml_obj = expanded_xml;
-    }
-
-    for (set = first_named_child(xml_obj, XML_CONS_TAG_RSC_SET); set != NULL;
-         set = crm_next_same_xml(set)) {
-
-        set = expand_idref(set, data_set->input);
-        if ((set == NULL) // Configuration error, message already logged
-            || !unpack_colocation_set(set, score_i, id, influence_s, data_set)
-            || ((last != NULL) && !colocate_rsc_sets(id, last, set, score_i,
-                                                     influence_s, data_set))) {
-            if (expanded_xml != NULL) {
-                free_xml(expanded_xml);
-            }
-            return;
-        }
-        last = set;
-    }
-
-    if (expanded_xml) {
-        free_xml(expanded_xml);
-        xml_obj = orig_xml;
-    }
-
-    if (last == NULL) {
-        unpack_simple_colocation(xml_obj, id, influence_s, data_set);
     }
 }
 
@@ -2833,7 +2170,7 @@ unpack_simple_rsc_ticket(xmlNode * xml_obj, pe_working_set_t * data_set)
         pcmk__config_err("Ignoring constraint '%s' without resource", id);
         return;
     } else {
-        rsc_lh = pe_find_constraint_resource(data_set->resources, id_lh);
+        rsc_lh = pcmk__find_constraint_resource(data_set->resources, id_lh);
     }
 
     if (rsc_lh == NULL) {
@@ -2883,7 +2220,7 @@ unpack_rsc_ticket_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_se
     }
 
     // Check whether there are any resource sets with template or tag references
-    *expanded_xml = expand_tags_in_sets(xml_obj, data_set);
+    *expanded_xml = pcmk__expand_tags_in_sets(xml_obj, data_set);
     if (*expanded_xml != NULL) {
         crm_log_xml_trace(*expanded_xml, "Expanded rsc_ticket");
         return TRUE;
@@ -2894,7 +2231,7 @@ unpack_rsc_ticket_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_se
         return TRUE;
     }
 
-    if (valid_resource_or_tag(data_set, id_lh, &rsc_lh, &tag_lh) == FALSE) {
+    if (!pcmk__valid_resource_or_tag(data_set, id_lh, &rsc_lh, &tag_lh)) {
         pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
                          "valid resource or tag", id, id_lh);
         return FALSE;
@@ -2909,8 +2246,8 @@ unpack_rsc_ticket_tags(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_se
     *expanded_xml = copy_xml(xml_obj);
 
     /* Convert the template/tag reference in "rsc" into a resource_set under the rsc_ticket constraint. */
-    if (!tag_to_set(*expanded_xml, &rsc_set_lh, XML_COLOC_ATTR_SOURCE, FALSE,
-                    data_set)) {
+    if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_lh, XML_COLOC_ATTR_SOURCE,
+                          FALSE, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
         return FALSE;

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -15,6 +15,8 @@
 
 #include <pacemaker-internal.h>
 
+#include "libpacemaker_private.h"
+
 #define VARIANT_GROUP 1
 #include <lib/pengine/variant.h>
 

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -44,11 +44,12 @@ expand_group_colocations(pe_resource_t *rsc)
      * colocated with the previous one.
      *
      * However, there is a special case when a group has a mandatory colocation
-     * with a resource that can't start. In that case, update_colo_start_chain()
-     * will ensure that dependent resources in mandatory colocations (i.e. the
-     * first member for groups) can't start either. But if any group member is
-     * unmanaged and already started, the internal group colocations are no
-     * longer sufficient to make that apply to later members.
+     * with a resource that can't start. In that case,
+     * pcmk__block_colocated_starts() will ensure that dependent resources in
+     * mandatory colocations (i.e. the first member for groups) can't start
+     * either. But if any group member is unmanaged and already started, the
+     * internal group colocations are no longer sufficient to make that apply to
+     * later members.
      *
      * To handle that case, add mandatory colocations to each member after the
      * first.


### PR DESCRIPTION
As part of a general "best practices" project for libpacemaker, address the size of pcmk_sched_constraints.c by separating functions related to each type of constraint into their own files (starting with colocations in this PR), with pcmk_sched_constraints.c containing only generic functions that apply to any constraint type.

With this PR, pcmk_sched_constraints.c drops from just over 3,000 lines to less than 2,400, while the new pcmk_sched_colocation.c (which also gets a related function from pcmk_sched_graph.c) is just over 800.