### PR TITLE
Show some internal errors as exit reason in failed action displays

### DIFF
--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1721,13 +1721,7 @@ do_lrm_delete(ha_msg_input_t *input, lrm_state_t *lrm_state,
         /* These are resource clean-ups, not actions, so no exit reason is
          * needed.
          */
-        if (cib_rc == EACCES) {
-            lrmd__set_result(op, PCMK_OCF_INSUFFICIENT_PRIV, PCMK_EXEC_ERROR,
-                             NULL);
-        } else {
-            lrmd__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
-                             NULL);
-        }
+        lrmd__set_result(op, pcmk_rc2ocf(cib_rc), PCMK_EXEC_ERROR, NULL);
         controld_ack_event_directly(from_host, from_sys, NULL, op, rsc->id);
         lrmd_free_event(op);
         return;

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1962,7 +1962,7 @@ construct_op(lrm_state_t *lrm_state, xmlNode *rsc_op, const char *rsc_id,
     op->type = lrmd_event_exec_complete;
     op->timeout = 0;
     op->start_delay = 0;
-    lrmd__set_result(op, -1, PCMK_EXEC_PENDING, NULL);
+    lrmd__set_result(op, PCMK_OCF_UNKNOWN, PCMK_EXEC_PENDING, NULL);
 
     if (rsc_op == NULL) {
         CRM_LOG_ASSERT(pcmk__str_eq(CRMD_ACTION_STOP, operation, pcmk__str_casei));
@@ -2363,7 +2363,7 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc,
 
         if ((op->interval_ms > 0)
             && (op->start_delay > START_DELAY_THRESHOLD)) {
-            int target_rc = 0;
+            int target_rc = PCMK_OCF_OK;
 
             crm_info("Faking confirmation of %s: execution postponed for over 5 minutes", op_id);
             decode_transition_key(op->user_data, NULL, NULL, NULL, &target_rc);

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -77,7 +77,7 @@ fail_pending_op(gpointer key, gpointer value, gpointer user_data)
     event.timeout = 0;
     event.interval_ms = op->interval_ms;
     lrmd__set_result(&event, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_NOT_CONNECTED,
-                     NULL);
+                     "Action was pending when executor connection was dropped");
     event.t_run = (unsigned int) op->start_time;
     event.t_rcchange = (unsigned int) op->start_time;
 

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -76,8 +76,8 @@ fail_pending_op(gpointer key, gpointer value, gpointer user_data)
     event.user_data = op->user_data;
     event.timeout = 0;
     event.interval_ms = op->interval_ms;
-    event.rc = PCMK_OCF_UNKNOWN_ERROR;
-    event.op_status = PCMK_EXEC_NOT_CONNECTED;
+    lrmd__set_result(&event, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_NOT_CONNECTED,
+                     NULL);
     event.t_run = (unsigned int) op->start_time;
     event.t_rcchange = (unsigned int) op->start_time;
 

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -362,7 +362,7 @@ report_remote_ra_result(remote_ra_cmd_t * cmd)
     op.t_run = (unsigned int) cmd->start_time;
     op.t_rcchange = (unsigned int) cmd->start_time;
 
-    lrmd__set_result(&op, cmd->result.exit_status, cmd->result.exec_status,
+    lrmd__set_result(&op, cmd->result.exit_status, cmd->result.execution_status,
                      cmd->result.exit_reason);
 
     if (cmd->reported_success && (cmd->result.exit_status != PCMK_OCF_OK)) {

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -31,7 +31,6 @@ typedef struct remote_ra_cmd_s {
     char *action;
     /*! some string the client wants us to give it back */
     char *userdata;
-    char *exit_reason;          // descriptive text on error
     /*! start delay in ms */
     int start_delay;
     /*! timer id used for start delay. */
@@ -48,9 +47,7 @@ typedef struct remote_ra_cmd_s {
     int takeover_timeout_id;
     /*! action parameters */
     lrmd_key_value_t *params;
-    /*! executed rc */
-    int rc;
-    int op_status;
+    pcmk__action_result_t result;
     int call_id;
     time_t start_time;
     gboolean cancel;
@@ -113,7 +110,7 @@ free_cmd(gpointer user_data)
     free(cmd->rsc_id);
     free(cmd->action);
     free(cmd->userdata);
-    free(cmd->exit_reason);
+    pcmk__reset_result(&(cmd->result));
     lrmd_key_value_freeall(cmd->params);
     free(cmd);
 }
@@ -299,7 +296,7 @@ static void
 check_remote_node_state(remote_ra_cmd_t *cmd)
 {
     /* Only successful actions can change node state */
-    if (cmd->rc != PCMK_OCF_OK) {
+    if (cmd->result.exit_status != PCMK_OCF_OK) {
         return;
     }
 
@@ -359,14 +356,19 @@ report_remote_ra_result(remote_ra_cmd_t * cmd)
     op.rsc_id = cmd->rsc_id;
     op.op_type = cmd->action;
     op.user_data = cmd->userdata;
-    op.exit_reason = cmd->exit_reason;
     op.timeout = cmd->timeout;
     op.interval_ms = cmd->interval_ms;
-    op.rc = cmd->rc;
-    op.op_status = cmd->op_status;
     op.t_run = (unsigned int) cmd->start_time;
     op.t_rcchange = (unsigned int) cmd->start_time;
-    if (cmd->reported_success && cmd->rc != PCMK_OCF_OK) {
+
+    /* Since op's lifetime is just this function, which doesn't free cmd,
+     * point to the exit reason directly rather than copy it.
+     */
+    op.rc = cmd->result.exit_status;
+    op.op_status = cmd->result.exec_status;
+    op.exit_reason = cmd->result.exit_reason;
+
+    if (cmd->reported_success && (cmd->result.exit_status != PCMK_OCF_OK)) {
         op.t_rcchange = (unsigned int) time(NULL);
         /* This edge case will likely never ever occur, but if it does the
          * result is that a failure will not be processed correctly. This is only
@@ -472,8 +474,8 @@ monitor_timeout_cb(gpointer data)
     crm_info("Timed out waiting for remote poke response from %s%s",
              cmd->rsc_id, (lrm_state? "" : " (no LRM state)"));
     cmd->monitor_timeout_id = 0;
-    cmd->op_status = PCMK_EXEC_TIMEOUT;
-    cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
+    pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_TIMEOUT,
+                     NULL);
 
     if (lrm_state && lrm_state->remote_ra_data) {
         remote_ra_data_t *ra_data = lrm_state->remote_ra_data;
@@ -607,9 +609,9 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
 
             if (op->connection_rc == -ENOKEY) {
                 // Hard error, don't retry
-                cmd->op_status = PCMK_EXEC_ERROR;
-                cmd->rc = PCMK_OCF_INVALID_PARAM;
-                cmd->exit_reason = strdup("Authentication key not readable");
+                pcmk__set_result(&(cmd->result), PCMK_OCF_INVALID_PARAM,
+                                 PCMK_EXEC_ERROR,
+                                 "Authentication key not readable");
 
             } else if (cmd->remaining_timeout > 3000) {
                 crm_trace("rescheduling start, remaining timeout %d", cmd->remaining_timeout);
@@ -619,14 +621,13 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
             } else {
                 crm_trace("can't reschedule start, remaining timeout too small %d",
                           cmd->remaining_timeout);
-                cmd->op_status = PCMK_EXEC_TIMEOUT;
-                cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
+                pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
+                                 PCMK_EXEC_TIMEOUT, NULL);
             }
 
         } else {
             lrm_state_reset_tables(lrm_state, TRUE);
-            cmd->rc = PCMK_OCF_OK;
-            cmd->op_status = PCMK_EXEC_DONE;
+            pcmk__set_result(&(cmd->result), PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
             ra_data->active = TRUE;
         }
 
@@ -645,8 +646,7 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
          * For this function, if we get the poke pack, it is always a success. Pokes
          * only fail if the send fails, or the response times out. */
         if (!cmd->reported_success) {
-            cmd->rc = PCMK_OCF_OK;
-            cmd->op_status = PCMK_EXEC_DONE;
+            pcmk__set_result(&(cmd->result), PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
             report_remote_ra_result(cmd);
             cmd->reported_success = 1;
         }
@@ -664,8 +664,8 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
 
     } else if (op->type == lrmd_event_disconnect && pcmk__str_eq(cmd->action, "monitor", pcmk__str_casei)) {
         if (ra_data->active == TRUE && (cmd->cancel == FALSE)) {
-            cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
-            cmd->op_status = PCMK_EXEC_ERROR;
+            pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
+                             PCMK_EXEC_ERROR, NULL);
             report_remote_ra_result(cmd);
             crm_err("Remote connection to %s unexpectedly dropped during monitor",
                     lrm_state->node_name);
@@ -721,8 +721,7 @@ handle_remote_ra_stop(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd)
     ra_data->cur_cmd = NULL;
 
     if (cmd) {
-        cmd->rc = PCMK_OCF_OK;
-        cmd->op_status = PCMK_EXEC_DONE;
+        pcmk__set_result(&(cmd->result), PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
         report_remote_ra_result(cmd);
     }
 }
@@ -752,9 +751,8 @@ handle_remote_ra_start(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd, int timeo
     rc = controld_connect_remote_executor(lrm_state, server, port,
                                           timeout_used);
     if (rc != pcmk_rc_ok) {
-        cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
-        cmd->op_status = PCMK_EXEC_ERROR;
-        cmd->exit_reason = strdup(pcmk_rc_str(rc));
+        pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
+                         PCMK_EXEC_ERROR, pcmk_rc_str(rc));
     }
     return rc;
 }
@@ -801,13 +799,13 @@ handle_remote_ra_exec(gpointer user_data)
             if (lrm_state_is_connected(lrm_state) == TRUE) {
                 rc = lrm_state_poke_connection(lrm_state);
                 if (rc < 0) {
-                    cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
-                    cmd->op_status = PCMK_EXEC_ERROR;
+                    pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
+                                     PCMK_EXEC_ERROR, NULL);
                 }
             } else {
                 rc = -1;
-                cmd->op_status = PCMK_EXEC_DONE;
-                cmd->rc = PCMK_OCF_NOT_RUNNING;
+                pcmk__set_result(&(cmd->result), PCMK_OCF_NOT_RUNNING,
+                                 PCMK_EXEC_DONE, NULL);
             }
 
             if (rc == 0) {
@@ -837,8 +835,7 @@ handle_remote_ra_exec(gpointer user_data)
 
         } else if (!strcmp(cmd->action, "migrate_to")) {
             ra_data->migrate_status = expect_takeover;
-            cmd->rc = PCMK_OCF_OK;
-            cmd->op_status = PCMK_EXEC_DONE;
+            pcmk__set_result(&(cmd->result), PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
             report_remote_ra_result(cmd);
         } else if (pcmk__str_any_of(cmd->action, CRMD_ACTION_RELOAD,
                                     CRMD_ACTION_RELOAD_AGENT, NULL))  {
@@ -851,8 +848,7 @@ handle_remote_ra_exec(gpointer user_data)
              * of "reload-agent". An OCF 1.1 "reload" would be a no-op anyway,
              * so this would work for that purpose as well.
              */
-            cmd->rc = PCMK_OCF_OK;
-            cmd->op_status = PCMK_EXEC_DONE;
+            pcmk__set_result(&(cmd->result), PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
             report_remote_ra_result(cmd);
         }
 
@@ -958,8 +954,8 @@ fail_all_monitor_cmds(GList * list)
     for (gIter = rm_list; gIter != NULL; gIter = gIter->next) {
         cmd = gIter->data;
 
-        cmd->rc = PCMK_OCF_UNKNOWN_ERROR;
-        cmd->op_status = PCMK_EXEC_ERROR;
+        pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
+                         PCMK_EXEC_ERROR, NULL);
         crm_trace("Pre-emptively failing %s %s (interval=%u, %s)",
                   cmd->action, cmd->rsc_id, cmd->interval_ms, cmd->userdata);
         report_remote_ra_result(cmd);

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -236,13 +236,9 @@ controld_record_action_timeout(crm_action_t *action)
      * that will be reported via the usual callback. This timeout means that we
      * didn't hear from the executor or the controller that relayed the action
      * to the executor.
-     *
-     * @TODO Using PCMK_OCF_UNKNOWN_ERROR instead of PCMK_OCF_TIMEOUT is one way
-     * to distinguish those situations, but perhaps PCMK_OCF_TIMEOUT would be
-     * preferable anyway.
      */
     op = pcmk__event_from_graph_action(NULL, action, PCMK_EXEC_TIMEOUT,
-                                       PCMK_OCF_UNKNOWN_ERROR);
+                                       PCMK_OCF_TIMEOUT);
     op->call_id = -1;
     op->user_data = pcmk__transition_key(transition_graph->id, action->id,
                                          target_rc, te_uuid);

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -238,7 +238,9 @@ controld_record_action_timeout(crm_action_t *action)
      * to the executor.
      */
     op = pcmk__event_from_graph_action(NULL, action, PCMK_EXEC_TIMEOUT,
-                                       PCMK_OCF_TIMEOUT);
+                                       PCMK_OCF_TIMEOUT,
+                                       "Cluster communication timeout "
+                                       "(no response from executor)");
     op->call_id = -1;
     op->user_data = pcmk__transition_key(transition_graph->id, action->id,
                                          target_rc, te_uuid);

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1396,7 +1396,7 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
         goto exec_done;
     }
 
-    if (action->rc != 0) {
+    if (action->rc != PCMK_OCF_OK) {
         pcmk__set_result(&(cmd->result), action->rc, action->status, NULL);
         services_action_free(action);
         goto exec_done;

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -41,8 +41,6 @@ typedef struct lrmd_cmd_s {
     int timeout_orig;
 
     int call_id;
-    int exec_rc;
-    int lrmd_op_status;
 
     int call_opts;
     /* Timer ids, must be removed on cmd destruction. */
@@ -58,9 +56,9 @@ typedef struct lrmd_cmd_s {
     char *rsc_id;
     char *action;
     char *real_action;
-    char *exit_reason;
-    char *output;
     char *userdata_str;
+
+    pcmk__action_result_t result;
 
     /* We can track operation queue time and run time, to be saved with the CIB
      * resource history (and displayed in cluster status). We need
@@ -218,12 +216,13 @@ log_finished(lrmd_cmd_t * cmd, int exec_time, int queue_time)
     do_crm_log(log_level, "%s %s (call %d%s%s) exited with status %d"
                " (execution time %dms, queue time %dms)",
                cmd->rsc_id, cmd->action, cmd->call_id,
-               (cmd->last_pid? ", PID " : ""), pid_str, cmd->exec_rc,
-               exec_time, queue_time);
+               (cmd->last_pid? ", PID " : ""), pid_str,
+               cmd->result.exit_status, exec_time, queue_time);
 #else
     do_crm_log(log_level, "%s %s (call %d%s%s) exited with status %d",
                cmd->rsc_id, cmd->action, cmd->call_id,
-               (cmd->last_pid? ", PID " : ""), pid_str, cmd->exec_rc);
+               (cmd->last_pid? ", PID " : ""), pid_str,
+               cmd->result.exit_status);
 #endif
 }
 
@@ -329,13 +328,12 @@ free_lrmd_cmd(lrmd_cmd_t * cmd)
     if (cmd->params) {
         g_hash_table_destroy(cmd->params);
     }
+    pcmk__reset_result(&(cmd->result));
     free(cmd->origin);
     free(cmd->action);
     free(cmd->real_action);
     free(cmd->userdata_str);
     free(cmd->rsc_id);
-    free(cmd->output);
-    free(cmd->exit_reason);
     free(cmd->client_id);
     free(cmd);
 }
@@ -435,7 +433,7 @@ merge_recurring_duplicate(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
      */
     if (pcmk__str_eq(rsc->class, PCMK_RESOURCE_CLASS_STONITH,
                      pcmk__str_casei)
-        && (dup->lrmd_op_status == PCMK_EXEC_CANCELLED)) {
+        && (dup->result.exec_status == PCMK_EXEC_CANCELLED)) {
         return false;
     }
 
@@ -578,8 +576,8 @@ send_cmd_complete_notify(lrmd_cmd_t * cmd)
      * the option to only send notifies on result changes is set. Check to see
      * if the last result is the same as the new one. If so, suppress this update */
     if (cmd->first_notify_sent && (cmd->call_opts & lrmd_opt_notify_changes_only)) {
-        if (cmd->last_notify_rc == cmd->exec_rc &&
-            cmd->last_notify_op_status == cmd->lrmd_op_status) {
+        if ((cmd->last_notify_rc == cmd->result.exit_status) &&
+            (cmd->last_notify_op_status == cmd->result.exec_status)) {
 
             /* only send changes */
             return;
@@ -588,8 +586,8 @@ send_cmd_complete_notify(lrmd_cmd_t * cmd)
     }
 
     cmd->first_notify_sent = true;
-    cmd->last_notify_rc = cmd->exec_rc;
-    cmd->last_notify_op_status = cmd->lrmd_op_status;
+    cmd->last_notify_rc = cmd->result.exit_status;
+    cmd->last_notify_op_status = cmd->result.exec_status;
 
     notify = create_xml_node(NULL, T_LRMD_NOTIFY);
 
@@ -597,8 +595,8 @@ send_cmd_complete_notify(lrmd_cmd_t * cmd)
     crm_xml_add_int(notify, F_LRMD_TIMEOUT, cmd->timeout);
     crm_xml_add_ms(notify, F_LRMD_RSC_INTERVAL, cmd->interval_ms);
     crm_xml_add_int(notify, F_LRMD_RSC_START_DELAY, cmd->start_delay);
-    crm_xml_add_int(notify, F_LRMD_EXEC_RC, cmd->exec_rc);
-    crm_xml_add_int(notify, F_LRMD_OP_STATUS, cmd->lrmd_op_status);
+    crm_xml_add_int(notify, F_LRMD_EXEC_RC, cmd->result.exit_status);
+    crm_xml_add_int(notify, F_LRMD_OP_STATUS, cmd->result.exec_status);
     crm_xml_add_int(notify, F_LRMD_CALLID, cmd->call_id);
     crm_xml_add_int(notify, F_LRMD_RSC_DELETED, cmd->rsc_deleted);
 
@@ -619,8 +617,14 @@ send_cmd_complete_notify(lrmd_cmd_t * cmd)
         crm_xml_add(notify, F_LRMD_RSC_ACTION, cmd->action);
     }
     crm_xml_add(notify, F_LRMD_RSC_USERDATA_STR, cmd->userdata_str);
-    crm_xml_add(notify, F_LRMD_RSC_OUTPUT, cmd->output);
-    crm_xml_add(notify, F_LRMD_RSC_EXIT_REASON, cmd->exit_reason);
+    crm_xml_add(notify, F_LRMD_RSC_EXIT_REASON, cmd->result.exit_reason);
+
+    if (cmd->result.action_stderr != NULL) {
+        crm_xml_add(notify, F_LRMD_RSC_OUTPUT, cmd->result.action_stderr);
+
+    } else if (cmd->result.action_stdout != NULL) {
+        crm_xml_add(notify, F_LRMD_RSC_OUTPUT, cmd->result.action_stdout);
+    }
 
     if (cmd->params) {
         char *key = NULL;
@@ -675,17 +679,15 @@ send_generic_notify(int rc, xmlNode * request)
 static void
 cmd_reset(lrmd_cmd_t * cmd)
 {
-    cmd->lrmd_op_status = 0;
     cmd->last_pid = 0;
 #ifdef PCMK__TIME_USE_CGT
     memset(&cmd->t_run, 0, sizeof(cmd->t_run));
     memset(&cmd->t_queue, 0, sizeof(cmd->t_queue));
 #endif
     cmd->epoch_last_run = 0;
-    free(cmd->exit_reason);
-    cmd->exit_reason = NULL;
-    free(cmd->output);
-    cmd->output = NULL;
+
+    pcmk__reset_result(&(cmd->result));
+    cmd->result.exec_status = PCMK_EXEC_DONE;
 }
 
 static void
@@ -708,7 +710,9 @@ cmd_finalize(lrmd_cmd_t * cmd, lrmd_rsc_t * rsc)
 
     send_cmd_complete_notify(cmd);
 
-    if (cmd->interval_ms && (cmd->lrmd_op_status == PCMK_EXEC_CANCELLED)) {
+    if ((cmd->interval_ms != 0)
+        && (cmd->result.exec_status == PCMK_EXEC_CANCELLED)) {
+
         if (rsc) {
             rsc->recurring_ops = g_list_remove(rsc->recurring_ops, cmd);
             rsc->pending_ops = g_list_remove(rsc->pending_ops, cmd);
@@ -931,14 +935,14 @@ action_complete(svc_action_t * action)
     }
 
 #ifdef PCMK__TIME_USE_CGT
-    if (cmd->exec_rc != action->rc) {
+    if (cmd->result.exit_status != action->rc) {
         cmd->epoch_rcchange = time(NULL);
     }
 #endif
 
     cmd->last_pid = action->pid;
-    cmd->exec_rc = action_get_uniform_rc(action);
-    cmd->lrmd_op_status = action->status;
+    pcmk__set_result(&(cmd->result), action_get_uniform_rc(action),
+                     action->status, NULL);
     rsc = cmd->rsc_id ? g_hash_table_lookup(rsc_list, cmd->rsc_id) : NULL;
 
 #ifdef PCMK__TIME_USE_CGT
@@ -949,7 +953,7 @@ action_complete(svc_action_t * action)
     }
 
     if (pcmk__str_eq(rclass, PCMK_RESOURCE_CLASS_SYSTEMD, pcmk__str_casei)) {
-        if ((cmd->exec_rc == PCMK_OCF_OK)
+        if ((cmd->result.exit_status == PCMK_OCF_OK)
             && pcmk__strcase_any_of(cmd->action, "start", "stop", NULL)) {
             /* systemd returns from start and stop actions after the action
              * begins, not after it completes. We have to jump through a few
@@ -962,11 +966,11 @@ action_complete(svc_action_t * action)
 
         } else if (cmd->real_action != NULL) {
             // This is follow-up monitor to check whether start/stop completed
-            if ((cmd->lrmd_op_status == PCMK_EXEC_DONE)
-                && (cmd->exec_rc == PCMK_OCF_PENDING)) {
+            if ((cmd->result.exec_status == PCMK_EXEC_DONE)
+                && (cmd->result.exit_status == PCMK_OCF_PENDING)) {
                 goagain = true;
 
-            } else if ((cmd->exec_rc == PCMK_OCF_OK)
+            } else if ((cmd->result.exit_status == PCMK_OCF_OK)
                        && pcmk__str_eq(cmd->real_action, "stop", pcmk__str_casei)) {
                 goagain = true;
 
@@ -977,18 +981,18 @@ action_complete(svc_action_t * action)
                 crm_debug("%s systemd %s is now complete (elapsed=%dms, "
                           "remaining=%dms): %s (%d)",
                           cmd->rsc_id, cmd->real_action, time_sum, timeout_left,
-                          services_ocf_exitcode_str(cmd->exec_rc),
-                          cmd->exec_rc);
+                          services_ocf_exitcode_str(cmd->result.exit_status),
+                          cmd->result.exit_status);
                 cmd_original_times(cmd);
 
                 // Monitors may return "not running", but start/stop shouldn't
-                if ((cmd->lrmd_op_status == PCMK_EXEC_DONE)
-                    && (cmd->exec_rc == PCMK_OCF_NOT_RUNNING)) {
+                if ((cmd->result.exec_status == PCMK_EXEC_DONE)
+                    && (cmd->result.exit_status == PCMK_OCF_NOT_RUNNING)) {
 
                     if (pcmk__str_eq(cmd->real_action, "start", pcmk__str_casei)) {
-                        cmd->exec_rc = PCMK_OCF_UNKNOWN_ERROR;
+                        cmd->result.exit_status = PCMK_OCF_UNKNOWN_ERROR;
                     } else if (pcmk__str_eq(cmd->real_action, "stop", pcmk__str_casei)) {
-                        cmd->exec_rc = PCMK_OCF_OK;
+                        cmd->result.exit_status = PCMK_OCF_OK;
                     }
                 }
             }
@@ -999,11 +1003,12 @@ action_complete(svc_action_t * action)
 #if SUPPORT_NAGIOS
     if (rsc && pcmk__str_eq(rsc->class, PCMK_RESOURCE_CLASS_NAGIOS, pcmk__str_casei)) {
         if (action_matches(cmd, "monitor", 0)
-            && (cmd->exec_rc == PCMK_OCF_OK)) {
+            && (cmd->result.exit_status == PCMK_OCF_OK)) {
             /* Successfully executed --version for the nagios plugin */
-            cmd->exec_rc = PCMK_OCF_NOT_RUNNING;
+            cmd->result.exit_status = PCMK_OCF_NOT_RUNNING;
 
-        } else if (pcmk__str_eq(cmd->action, "start", pcmk__str_casei) && cmd->exec_rc != PCMK_OCF_OK) {
+        } else if (pcmk__str_eq(cmd->action, "start", pcmk__str_casei)
+                   && (cmd->result.exit_status != PCMK_OCF_OK)) {
 #ifdef PCMK__TIME_USE_CGT
             goagain = true;
 #endif
@@ -1026,17 +1031,20 @@ action_complete(svc_action_t * action)
             cmd->start_delay = delay;
             cmd->timeout = timeout_left;
 
-            if(cmd->exec_rc == PCMK_OCF_OK) {
+            if (cmd->result.exit_status == PCMK_OCF_OK) {
                 crm_debug("%s %s may still be in progress: re-scheduling (elapsed=%dms, remaining=%dms, start_delay=%dms)",
                           cmd->rsc_id, cmd->real_action, time_sum, timeout_left, delay);
 
-            } else if(cmd->exec_rc == PCMK_OCF_PENDING) {
+            } else if (cmd->result.exit_status == PCMK_OCF_PENDING) {
                 crm_info("%s %s is still in progress: re-scheduling (elapsed=%dms, remaining=%dms, start_delay=%dms)",
                          cmd->rsc_id, cmd->action, time_sum, timeout_left, delay);
 
             } else {
                 crm_notice("%s %s failed '%s' (%d): re-scheduling (elapsed=%dms, remaining=%dms, start_delay=%dms)",
-                           cmd->rsc_id, cmd->action, services_ocf_exitcode_str(cmd->exec_rc), cmd->exec_rc, time_sum, timeout_left, delay);
+                           cmd->rsc_id, cmd->action,
+                           services_ocf_exitcode_str(cmd->result.exit_status),
+                           cmd->result.exit_status, time_sum, timeout_left,
+                           delay);
             }
 
             cmd_reset(cmd);
@@ -1050,20 +1058,20 @@ action_complete(svc_action_t * action)
 
         } else {
             crm_notice("Giving up on %s %s (rc=%d): timeout (elapsed=%dms, remaining=%dms)",
-                       cmd->rsc_id, cmd->real_action?cmd->real_action:cmd->action, cmd->exec_rc, time_sum, timeout_left);
-            cmd->lrmd_op_status = PCMK_EXEC_TIMEOUT;
-            cmd->exec_rc = PCMK_OCF_TIMEOUT;
+                       cmd->rsc_id,
+                       (cmd->real_action? cmd->real_action : cmd->action),
+                       cmd->result.exit_status, time_sum, timeout_left);
+            pcmk__set_result(&(cmd->result), PCMK_OCF_TIMEOUT,
+                             PCMK_EXEC_TIMEOUT, NULL);
             cmd_original_times(cmd);
         }
     }
 #endif
 
+    pcmk__set_result_output(&(cmd->result),
+                            action->stdout_data, action->stderr_data);
     if (action->stderr_data) {
-        cmd->output = strdup(action->stderr_data);
-        cmd->exit_reason = parse_exit_reason(action->stderr_data);
-
-    } else if (action->stdout_data) {
-        cmd->output = strdup(action->stdout_data);
+        cmd->result.exit_reason = parse_exit_reason(action->stderr_data);
     }
 
     cmd_finalize(cmd, rsc);
@@ -1125,18 +1133,18 @@ stonith_action_complete(lrmd_cmd_t * cmd, int rc)
     // This can be NULL if resource was removed before command completed
     lrmd_rsc_t *rsc = g_hash_table_lookup(rsc_list, cmd->rsc_id);
 
-    cmd->exec_rc = stonith2uniform_rc(cmd->action, rc);
+    cmd->result.exit_status = stonith2uniform_rc(cmd->action, rc);
 
     /* This function may be called with status already set to cancelled, if a
      * pending action was aborted. Otherwise, we need to determine status from
      * the fencer return code.
      */
-    if (cmd->lrmd_op_status != PCMK_EXEC_CANCELLED) {
-        cmd->lrmd_op_status = stonith_rc2status(cmd->action, cmd->interval_ms,
-                                                rc);
+    if (cmd->result.exec_status != PCMK_EXEC_CANCELLED) {
+        cmd->result.exec_status = stonith_rc2status(cmd->action,
+                                                    cmd->interval_ms, rc);
 
         // Certain successful actions change the known state of the resource
-        if (rsc && (cmd->exec_rc == PCMK_OCF_OK)) {
+        if ((rsc != NULL) && (cmd->result.exit_status == PCMK_OCF_OK)) {
             if (pcmk__str_eq(cmd->action, "start", pcmk__str_casei)) {
                 rsc->st_probe_rc = pcmk_ok; // maps to PCMK_OCF_OK
             } else if (pcmk__str_eq(cmd->action, "stop", pcmk__str_casei)) {
@@ -1155,7 +1163,7 @@ stonith_action_complete(lrmd_cmd_t * cmd, int rc)
      * not be removed from recurring_ops by cmd_finalize().
      */
     if (rsc && (cmd->interval_ms > 0)
-        && (cmd->lrmd_op_status != PCMK_EXEC_CANCELLED)) {
+        && (cmd->result.exec_status != PCMK_EXEC_CANCELLED)) {
         start_recurring_timer(cmd);
     }
 
@@ -1368,7 +1376,7 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
     if (pcmk__str_eq(rsc->class, PCMK_RESOURCE_CLASS_NAGIOS, pcmk__str_casei)
         && pcmk__str_eq(cmd->action, "stop", pcmk__str_casei)) {
 
-        cmd->exec_rc = PCMK_OCF_OK;
+        cmd->result.exit_status = PCMK_OCF_OK;
         goto exec_done;
     }
 #endif
@@ -1383,14 +1391,13 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
 
     if (!action) {
         crm_err("Failed to create action, action:%s on resource %s", cmd->action, rsc->rsc_id);
-        cmd->exec_rc = PCMK_OCF_UNKNOWN_ERROR;
-        cmd->lrmd_op_status = PCMK_EXEC_ERROR;
+        pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
+                         PCMK_EXEC_ERROR, NULL);
         goto exec_done;
     }
 
     if (action->rc != 0) {
-        cmd->exec_rc = action->rc;
-        cmd->lrmd_op_status = action->status;
+        pcmk__set_result(&(cmd->result), action->rc, action->status, NULL);
         services_action_free(action);
         goto exec_done;
     }
@@ -1407,12 +1414,10 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
         return TRUE;
     }
 
-    cmd->exec_rc = action->rc;
-    if (action->status != PCMK_EXEC_DONE) {
-        cmd->lrmd_op_status = action->status;
-    } else {
-        cmd->lrmd_op_status = PCMK_EXEC_ERROR;
+    if (action->status == PCMK_EXEC_DONE) {
+        action->status = PCMK_EXEC_ERROR;
     }
+    pcmk__set_result(&(cmd->result), action->rc, action->status, NULL);
     services_action_free(action);
     action = NULL;
 
@@ -1493,7 +1498,7 @@ free_rsc(gpointer data)
         lrmd_cmd_t *cmd = gIter->data;
 
         /* command was never executed */
-        cmd->lrmd_op_status = PCMK_EXEC_CANCELLED;
+        cmd->result.exec_status = PCMK_EXEC_CANCELLED;
         cmd_finalize(cmd, NULL);
 
         gIter = next;
@@ -1507,7 +1512,7 @@ free_rsc(gpointer data)
         lrmd_cmd_t *cmd = gIter->data;
 
         if (is_stonith) {
-            cmd->lrmd_op_status = PCMK_EXEC_CANCELLED;
+            cmd->result.exec_status = PCMK_EXEC_CANCELLED;
             /* If a stonith command is in-flight, just mark it as cancelled;
              * it is not safe to finalize/free the cmd until the stonith api
              * says it has either completed or timed out.
@@ -1709,7 +1714,7 @@ cancel_op(const char *rsc_id, const char *action, guint interval_ms)
         lrmd_cmd_t *cmd = gIter->data;
 
         if (action_matches(cmd, action, interval_ms)) {
-            cmd->lrmd_op_status = PCMK_EXEC_CANCELLED;
+            cmd->result.exec_status = PCMK_EXEC_CANCELLED;
             cmd_finalize(cmd, rsc);
             return pcmk_ok;
         }
@@ -1722,7 +1727,7 @@ cancel_op(const char *rsc_id, const char *action, guint interval_ms)
             lrmd_cmd_t *cmd = gIter->data;
 
             if (action_matches(cmd, action, interval_ms)) {
-                cmd->lrmd_op_status = PCMK_EXEC_CANCELLED;
+                cmd->result.exec_status = PCMK_EXEC_CANCELLED;
                 if (rsc->active != cmd) {
                     cmd_finalize(cmd, rsc);
                 }

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1062,7 +1062,9 @@ action_complete(svc_action_t * action)
                        (cmd->real_action? cmd->real_action : cmd->action),
                        cmd->result.exit_status, time_sum, timeout_left);
             pcmk__set_result(&(cmd->result), PCMK_OCF_TIMEOUT,
-                             PCMK_EXEC_TIMEOUT, NULL);
+                             PCMK_EXEC_TIMEOUT,
+                             "Investigate reason for timeout, and adjust "
+                             "configured operation timeout if necessary");
             cmd_original_times(cmd);
         }
     }
@@ -1390,9 +1392,10 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
                                      params_copy, cmd->service_flags);
 
     if (!action) {
+        // Invalid arguments (which would be a bug) or out-of-memory
         crm_err("Failed to create action, action:%s on resource %s", cmd->action, rsc->rsc_id);
         pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
-                         PCMK_EXEC_ERROR, NULL);
+                         PCMK_EXEC_ERROR, "Internal Pacemaker error");
         goto exec_done;
     }
 

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1422,9 +1422,15 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
         return TRUE;
     }
 
+    /* Asynchronous execution could not be initiated. services_action_async()
+     * should have already set an appropriate execution status, but as a
+     * fail-safe for cases where we've neglected to do so, make sure this is
+     * considered an execution error.
+     */
     if (action->status == PCMK_EXEC_DONE) {
         action->status = PCMK_EXEC_ERROR;
     }
+
     pcmk__set_result(&(cmd->result), action->rc, action->status, NULL);
     services_action_free(action);
     action = NULL;

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1155,6 +1155,11 @@ stonith_action_complete(lrmd_cmd_t * cmd, int rc)
         }
     }
 
+    // Give the user more detail than an OCF code
+    if (rc != -pcmk_err_generic) {
+        cmd->result.exit_reason = strdup(pcmk_strerror(rc));
+    }
+
     /* The recurring timer should not be running at this point in any case, but
      * as a failsafe, stop it if it is.
      */

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -516,7 +516,11 @@ remote_op_done(remote_fencing_op_t * op, xmlNode * data, int rc, int dup)
         goto remote_op_done_cleanup;
     }
 
-    if (op->delegate == NULL) {
+    if (data == NULL) {
+        data = create_xml_node(NULL, "remote-op");
+        local_data = data;
+
+    } else if (op->delegate == NULL) {
         switch (rc) {
             case -ENODEV:
             case -EHOSTUNREACH:
@@ -525,11 +529,6 @@ remote_op_done(remote_fencing_op_t * op, xmlNode * data, int rc, int dup)
                 op->delegate = delegate_from_xml(data);
                 break;
         }
-    }
-
-    if (data == NULL) {
-        data = create_xml_node(NULL, "remote-op");
-        local_data = data;
     }
 
     if(dup) {

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -296,6 +296,7 @@ enum pcmk_exec_status {
 const char *pcmk_rc_name(int rc);
 const char *pcmk_rc_str(int rc);
 crm_exit_t pcmk_rc2exitc(int rc);
+enum ocf_exitcode pcmk_rc2ocf(int rc);
 int pcmk_rc2legacy(int rc);
 int pcmk_legacy2rc(int legacy_rc);
 const char *pcmk_strerror(int rc);

--- a/include/crm/common/results_internal.h
+++ b/include/crm/common/results_internal.h
@@ -23,11 +23,11 @@ GQuark pcmk__exitc_error_quark(void);
 /* Action results */
 
 typedef struct {
-    int exit_status;                    // Child exit status
-    enum pcmk_exec_status exec_status;  // Execution status
-    char *exit_reason;                  // Brief, human-friendly explanation
-    char *action_stdout;                // Action output
-    char *action_stderr;                // Action error output
+    int exit_status;        // Child exit status
+    enum pcmk_exec_status execution_status; // Execution status
+    char *exit_reason;      // Brief, human-friendly explanation
+    char *action_stdout;    // Action output
+    char *action_stderr;    // Action error output
 } pcmk__action_result_t;
 
 void pcmk__set_result(pcmk__action_result_t *result, int exit_status,

--- a/include/crm/common/results_internal.h
+++ b/include/crm/common/results_internal.h
@@ -20,4 +20,24 @@ GQuark pcmk__exitc_error_quark(void);
 #define PCMK__RC_ERROR       pcmk__rc_error_quark()
 #define PCMK__EXITC_ERROR    pcmk__exitc_error_quark()
 
+/* Action results */
+
+typedef struct {
+    int exit_status;                    // Child exit status
+    enum pcmk_exec_status exec_status;  // Execution status
+    char *exit_reason;                  // Brief, human-friendly explanation
+    char *action_stdout;                // Action output
+    char *action_stderr;                // Action error output
+} pcmk__action_result_t;
+
+void pcmk__set_result(pcmk__action_result_t *result, int exit_status,
+                      enum pcmk_exec_status exec_status,
+                      const char *exit_reason);
+
+void pcmk__set_result_output(pcmk__action_result_t *result,
+                             const char *action_stdout,
+                             const char *action_stderr);
+
+void pcmk__reset_result(pcmk__action_result_t *result);
+
 #endif // PCMK__COMMON_RESULTS_INTERNAL__H

--- a/include/crm/common/results_internal.h
+++ b/include/crm/common/results_internal.h
@@ -35,8 +35,7 @@ void pcmk__set_result(pcmk__action_result_t *result, int exit_status,
                       const char *exit_reason);
 
 void pcmk__set_result_output(pcmk__action_result_t *result,
-                             const char *action_stdout,
-                             const char *action_stderr);
+                             const char *out, const char *err);
 
 void pcmk__reset_result(pcmk__action_result_t *result);
 

--- a/include/crm/lrmd_internal.h
+++ b/include/crm/lrmd_internal.h
@@ -35,6 +35,11 @@ int lrmd_send_resource_alert(lrmd_t *lrmd, GList *alert_list,
 int lrmd__remote_send_xml(pcmk__remote_t *session, xmlNode *msg, uint32_t id,
                           const char *msg_type);
 
+void lrmd__set_result(lrmd_event_data_t *event, enum ocf_exitcode rc,
+                      int op_status, const char *exit_reason);
+
+void lrmd__reset_result(lrmd_event_data_t *event);
+
 /* Shared functions for IPC proxy back end */
 
 typedef struct remote_proxy_s {

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -131,7 +131,8 @@ void pcmk__log_graph(unsigned int log_level, crm_graph_t *graph);
 void pcmk__log_graph_action(int log_level, crm_action_t *action);
 lrmd_event_data_t *pcmk__event_from_graph_action(xmlNode *resource,
                                                  crm_action_t *action,
-                                                 int status, int rc);
+                                                 int status, int rc,
+                                                 const char *exit_reason);
 
 #ifdef __cplusplus
 }

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -817,7 +817,7 @@ pcmk__set_result(pcmk__action_result_t *result, int exit_status,
     }
 
     result->exit_status = exit_status;
-    result->exec_status = exec_status;
+    result->execution_status = exec_status;
 
     if (!pcmk__str_eq(result->exit_reason, exit_reason, pcmk__str_none)) {
         free(result->exit_reason);

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -830,30 +830,22 @@ pcmk__set_result(pcmk__action_result_t *result, int exit_status,
  * \brief Set the output of an action
  *
  * \param[out] result         Action result to set output for
- * \param[in]  action_stdout  Action output to copy
- * \param[in]  action_stderr  Action error output to copy
+ * \param[in]  out            Action output to copy
+ * \param[in]  err            Action error output to copy
  */
 void
 pcmk__set_result_output(pcmk__action_result_t *result,
-                        const char *action_stdout, const char *action_stderr)
+                        const char *out, const char *err)
 {
     if (result == NULL) {
         return;
     }
 
     free(result->action_stdout);
-    if (action_stdout == NULL) {
-        result->action_stdout = NULL;
-    } else {
-        result->action_stdout = strdup(action_stdout);
-    }
+    result->action_stdout = (out == NULL)? NULL : strdup(out);
 
     free(result->action_stderr);
-    if (action_stderr == NULL) {
-        result->action_stderr = NULL;
-    } else {
-        result->action_stderr = strdup(action_stderr);
-    }
+    result->action_stderr = (err == NULL)? NULL : strdup(err);
 }
 
 /*!

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -734,6 +734,38 @@ pcmk_rc2exitc(int rc)
     }
 }
 
+/*!
+ * \brief Map a function return code to the most similar OCF exit code
+ *
+ * \param[in] rc  Function return code
+ *
+ * \return Most similar OCF exit code
+ */
+enum ocf_exitcode
+pcmk_rc2ocf(int rc)
+{
+    switch (rc) {
+        case pcmk_rc_ok:
+            return PCMK_OCF_OK;
+
+        case pcmk_rc_bad_nvpair:
+            return PCMK_OCF_INVALID_PARAM;
+
+        case EACCES:
+            return PCMK_OCF_INSUFFICIENT_PRIV;
+
+        case ENOTSUP:
+#if EOPNOTSUPP != ENOTSUP
+        case EOPNOTSUPP:
+#endif
+            return PCMK_OCF_UNIMPLEMENT_FEATURE;
+
+        default:
+            return PCMK_OCF_UNKNOWN_ERROR;
+    }
+}
+
+
 // Other functions
 
 const char *

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -794,3 +794,87 @@ crm_exit(crm_exit_t rc)
 
     exit(rc);
 }
+
+/*
+ * External action results
+ */
+
+/*!
+ * \internal
+ * \brief Set the result of an action
+ *
+ * \param[out] result        Where to set action result
+ * \param[in]  exit_status   OCF exit status to set
+ * \param[in]  exec_status   Execution status to set
+ * \param[in]  exit_reason   Human-friendly description of event to set
+ */
+void
+pcmk__set_result(pcmk__action_result_t *result, int exit_status,
+                 enum pcmk_exec_status exec_status, const char *exit_reason)
+{
+    if (result == NULL) {
+        return;
+    }
+
+    result->exit_status = exit_status;
+    result->exec_status = exec_status;
+
+    if (!pcmk__str_eq(result->exit_reason, exit_reason, pcmk__str_none)) {
+        free(result->exit_reason);
+        result->exit_reason = (exit_reason == NULL)? NULL : strdup(exit_reason);
+    }
+}
+
+/*!
+ * \internal
+ * \brief Set the output of an action
+ *
+ * \param[out] result         Action result to set output for
+ * \param[in]  action_stdout  Action output to copy
+ * \param[in]  action_stderr  Action error output to copy
+ */
+void
+pcmk__set_result_output(pcmk__action_result_t *result,
+                        const char *action_stdout, const char *action_stderr)
+{
+    if (result == NULL) {
+        return;
+    }
+
+    free(result->action_stdout);
+    if (action_stdout == NULL) {
+        result->action_stdout = NULL;
+    } else {
+        result->action_stdout = strdup(action_stdout);
+    }
+
+    free(result->action_stderr);
+    if (action_stderr == NULL) {
+        result->action_stderr = NULL;
+    } else {
+        result->action_stderr = strdup(action_stderr);
+    }
+}
+
+/*!
+ * \internal
+ * \brief Clear a result's exit reason, output, and error output
+ *
+ * \param[in] result  Result to reset
+ */
+void
+pcmk__reset_result(pcmk__action_result_t *result)
+{
+    if (result == NULL) {
+        return;
+    }
+
+    free(result->exit_reason);
+    result->exit_reason = NULL;
+
+    free(result->action_stdout);
+    result->action_stdout = NULL;
+
+    free(result->action_stderr);
+    result->action_stderr = NULL;
+}

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -878,7 +878,6 @@ lrmd_send_command(lrmd_t *lrmd, const char *op, xmlNode *data,
 
     if (rc < 0) {
         crm_perror(LOG_ERR, "Couldn't perform %s operation (timeout=%d): %d", op, timeout, rc);
-        rc = -ECOMM;
         goto done;
 
     } else if(op_reply == NULL) {

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -248,9 +248,8 @@ lrmd_free_event(lrmd_event_data_t *event)
     free((void *) event->rsc_id);
     free((void *) event->op_type);
     free((void *) event->user_data);
-    free((void *) event->output);
-    free((void *) event->exit_reason);
     free((void *) event->remote_nodename);
+    lrmd__reset_result(event);
     if (event->params != NULL) {
         g_hash_table_destroy(event->params);
     }
@@ -305,9 +304,11 @@ lrmd_dispatch_internal(lrmd_t * lrmd, xmlNode * msg)
 
         event.op_type = crm_element_value(msg, F_LRMD_RSC_ACTION);
         event.user_data = crm_element_value(msg, F_LRMD_RSC_USERDATA_STR);
+        event.type = lrmd_event_exec_complete;
+
+        // No need to duplicate the memory, so don't use setter functions
         event.output = crm_element_value(msg, F_LRMD_RSC_OUTPUT);
         event.exit_reason = crm_element_value(msg, F_LRMD_RSC_EXIT_REASON);
-        event.type = lrmd_event_exec_complete;
 
         event.params = xml2list(msg);
     } else if (pcmk__str_eq(type, LRMD_OP_NEW_CLIENT, pcmk__str_none)) {
@@ -2344,4 +2345,50 @@ lrmd_api_delete(lrmd_t * lrmd)
 
     free(lrmd->lrmd_private);
     free(lrmd);
+}
+
+/*!
+ * \internal
+ * \brief Set the result of an executor event
+ *
+ * \param[in,out] event        Executor event to set
+ * \param[in]     rc           OCF exit status of event
+ * \param[in]     op_status    Executor status of event
+ * \param[in]     exit_reason  Human-friendly description of event
+ */
+void
+lrmd__set_result(lrmd_event_data_t *event, enum ocf_exitcode rc, int op_status,
+                 const char *exit_reason)
+{
+    if (event == NULL) {
+        return;
+    }
+
+    event->rc = rc;
+    event->op_status = op_status;
+
+    if (!pcmk__str_eq(event->exit_reason, exit_reason, pcmk__str_none)) {
+        free((void *) event->exit_reason);
+        event->exit_reason = (exit_reason == NULL)? NULL : strdup(exit_reason);
+    }
+}
+
+/*!
+ * \internal
+ * \brief Clear an executor event's exit reason, output, and error output
+ *
+ * \param[in] event  Executor event to reset
+ */
+void
+lrmd__reset_result(lrmd_event_data_t *event)
+{
+    if (event == NULL) {
+        return;
+    }
+
+    free((void *) event->exit_reason);
+    event->exit_reason = NULL;
+
+    free((void *) event->output);
+    event->output = NULL;
 }

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -16,6 +16,7 @@
 #include <crm/msg_xml.h>
 #include <crm/common/xml.h>
 #include <crm/common/xml_internal.h>
+#include <crm/lrmd_internal.h>
 #include <pacemaker-internal.h>
 
 
@@ -818,8 +819,7 @@ pcmk__event_from_graph_action(xmlNode *resource, crm_action_t *action,
     op = lrmd_new_event(ID(action_resource),
                         crm_element_value(action->xml, XML_LRM_ATTR_TASK),
                         action->interval_ms);
-    op->rc = rc;
-    op->op_status = status;
+    lrmd__set_result(op, rc, status, NULL);
     op->t_run = time(NULL);
     op->t_rcchange = op->t_run;
     op->params = pcmk__strkey_table(free, free);

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -792,16 +792,17 @@ pcmk__free_graph(crm_graph_t *graph)
  * \internal
  * \brief Synthesize an executor event from a graph action
  *
- * \param[in] resource  If not NULL, use greater call ID than in this XML
- * \param[in] action    Graph action
- * \param[in] status    What to use as event execution status
- * \param[in] rc        What to use as event exit status
+ * \param[in] resource     If not NULL, use greater call ID than in this XML
+ * \param[in] action       Graph action
+ * \param[in] status       What to use as event execution status
+ * \param[in] rc           What to use as event exit status
+ * \param[in] exit_reason  What to use as event exit reason
  *
  * \return Newly allocated executor event on success, or NULL otherwise
  */
 lrmd_event_data_t *
 pcmk__event_from_graph_action(xmlNode *resource, crm_action_t *action,
-                              int status, int rc)
+                              int status, int rc, const char *exit_reason)
 {
     lrmd_event_data_t *op = NULL;
     GHashTableIter iter;
@@ -819,7 +820,7 @@ pcmk__event_from_graph_action(xmlNode *resource, crm_action_t *action,
     op = lrmd_new_event(ID(action_resource),
                         crm_element_value(action->xml, XML_LRM_ATTR_TASK),
                         action->interval_ms);
-    lrmd__set_result(op, rc, status, NULL);
+    lrmd__set_result(op, rc, status, exit_reason);
     op->t_run = time(NULL);
     op->t_rcchange = op->t_run;
     op->params = pcmk__strkey_table(free, free);

--- a/lib/pacemaker/pcmk_sched_transition.c
+++ b/lib/pacemaker/pcmk_sched_transition.c
@@ -24,6 +24,7 @@
 #include <crm/common/util.h>
 #include <crm/common/iso8601.h>
 #include <crm/common/xml_internal.h>
+#include <crm/lrmd_internal.h>
 #include <crm/pengine/status.h>
 #include <pacemaker-internal.h>
 
@@ -121,8 +122,7 @@ create_op(xmlNode *cib_resource, const char *task, guint interval_ms,
     xmlNode *xop = NULL;
 
     op = lrmd_new_event(ID(cib_resource), task, interval_ms);
-    op->rc = outcome;
-    op->op_status = PCMK_EXEC_DONE;
+    lrmd__set_result(op, outcome, PCMK_EXEC_DONE, NULL);
     op->params = NULL;          /* TODO: Fill me in */
     op->t_run = (unsigned int) time(NULL);
     op->t_rcchange = op->t_run;

--- a/lib/pacemaker/pcmk_sched_transition.c
+++ b/lib/pacemaker/pcmk_sched_transition.c
@@ -680,7 +680,7 @@ exec_rsc_action(crm_graph_t * graph, crm_action_t * action)
     }
 
     op = pcmk__event_from_graph_action(cib_resource, action, PCMK_EXEC_DONE,
-                                       target_outcome);
+                                       target_outcome, "User-injected result");
 
     out->message(out, "inject-rsc-action", resource, op->op_type, node, op->interval_ms);
 

--- a/lib/pacemaker/pcmk_sched_transition.c
+++ b/lib/pacemaker/pcmk_sched_transition.c
@@ -524,7 +524,7 @@ modify_configuration(pe_working_set_t * data_set, cib_t *cib, pcmk_injections_t 
         char *spec = (char *)gIter->data;
 
         int rc = 0;
-        int outcome = 0;
+        int outcome = PCMK_OCF_OK;
         guint interval_ms = 0;
 
         char *key = NULL;
@@ -609,7 +609,7 @@ exec_rsc_action(crm_graph_t * graph, crm_action_t * action)
     int rc = 0;
     GList *gIter = NULL;
     lrmd_event_data_t *op = NULL;
-    int target_outcome = 0;
+    int target_outcome = PCMK_OCF_OK;
 
     const char *rtype = NULL;
     const char *rclass = NULL;

--- a/lib/pacemaker/pcmk_sched_transition.c
+++ b/lib/pacemaker/pcmk_sched_transition.c
@@ -122,7 +122,7 @@ create_op(xmlNode *cib_resource, const char *task, guint interval_ms,
     xmlNode *xop = NULL;
 
     op = lrmd_new_event(ID(cib_resource), task, interval_ms);
-    lrmd__set_result(op, outcome, PCMK_EXEC_DONE, NULL);
+    lrmd__set_result(op, outcome, PCMK_EXEC_DONE, "Simulated action result");
     op->params = NULL;          /* TODO: Fill me in */
     op->t_run = (unsigned int) time(NULL);
     op->t_rcchange = op->t_run;

--- a/lib/pacemaker/pcmk_sched_utils.c
+++ b/lib/pacemaker/pcmk_sched_utils.c
@@ -613,7 +613,7 @@ pcmk__create_history_xml(xmlNode *parent, lrmd_event_data_t *op,
              * @TODO It might be better to keep the correct result here, and
              * ignore it in process_graph_event().
              */
-            lrmd__set_result(op, 0, PCMK_EXEC_DONE, NULL);
+            lrmd__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
         }
 
     } else if (did_rsc_op_fail(op, target_rc)) {

--- a/lib/pacemaker/pcmk_sched_utils.c
+++ b/lib/pacemaker/pcmk_sched_utils.c
@@ -11,6 +11,7 @@
 #include <crm/msg_xml.h>
 #include <crm/lrmd.h>       // lrmd_event_data_t
 #include <crm/common/xml_internal.h>
+#include <crm/lrmd_internal.h>
 #include <pacemaker-internal.h>
 #include <pacemaker.h>
 #include "libpacemaker_private.h"
@@ -612,8 +613,7 @@ pcmk__create_history_xml(xmlNode *parent, lrmd_event_data_t *op,
              * @TODO It might be better to keep the correct result here, and
              * ignore it in process_graph_event().
              */
-            op->op_status = PCMK_EXEC_DONE;
-            op->rc = 0;
+            lrmd__set_result(op, 0, PCMK_EXEC_DONE, NULL);
         }
 
     } else if (did_rsc_op_fail(op, target_rc)) {

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1163,7 +1163,7 @@ failed_action_default(pcmk__output_t *out, va_list args)
                              + strlen(exit_status) + strlen(call_id)
                              + strlen(lrm_status) + 50); // rough estimate
 
-    g_string_printf(str, "%s on %s '%s' (%d): call=%s, status=%s",
+    g_string_printf(str, "%s on %s '%s' (%d): call=%s, status='%s'",
                     op_key, node_name, exit_status, rc, call_id, lrm_status);
 
     if (!pcmk__str_empty(exit_reason)) {


### PR DESCRIPTION
The result of a forked process consists of an execution status (i.e. whether we could successfully execute the action), the process's exit status, and a human-friendly exit reason for status displays.

Formerly, the exit reason would only be set by OCF resource agents. Now, we also set it for some internal errors.