### PR TITLE
Best practices for generic constraint functions in libpacemaker

### DIFF
--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -74,7 +74,7 @@ extern gboolean stage5(pe_working_set_t * data_set);
 extern gboolean stage6(pe_working_set_t * data_set);
 extern gboolean stage8(pe_working_set_t * data_set);
 
-extern gboolean unpack_constraints(xmlNode * xml_constraints, pe_working_set_t * data_set);
+void pcmk__unpack_constraints(pe_working_set_t *data_set);
 
 extern void graph_element_from_action(pe_action_t * action, pe_working_set_t * data_set);
 extern void add_maintenance_update(pe_working_set_t *data_set);

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -68,7 +68,6 @@ struct rsc_ticket_s {
 extern gboolean stage0(pe_working_set_t * data_set);
 extern gboolean probe_resources(pe_working_set_t * data_set);
 extern gboolean stage2(pe_working_set_t * data_set);
-extern gboolean stage3(pe_working_set_t * data_set);
 extern gboolean stage4(pe_working_set_t * data_set);
 extern gboolean stage5(pe_working_set_t * data_set);
 extern gboolean stage6(pe_working_set_t * data_set);

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -54,6 +54,9 @@ bool pcmk__tag_to_set(xmlNode *xml_obj, xmlNode **rsc_set, const char *attr,
                       bool convert_rsc, pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
+void pcmk__create_internal_constraints(pe_working_set_t *data_set);
+
+G_GNUC_INTERNAL
 void pcmk__unpack_location(xmlNode *xml_obj, pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -50,8 +50,8 @@ bool pcmk__valid_resource_or_tag(pe_working_set_t *data_set, const char *id,
                                  pe_resource_t **rsc, pe_tag_t **tag);
 
 G_GNUC_INTERNAL
-gboolean pcmk__tag_to_set(xmlNode *xml_obj, xmlNode **rsc_set, const char *attr,
-                          gboolean convert_rsc, pe_working_set_t *data_set);
+bool pcmk__tag_to_set(xmlNode *xml_obj, xmlNode **rsc_set, const char *attr,
+                      bool convert_rsc, pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
 void pcmk__unpack_location(xmlNode *xml_obj, pe_working_set_t *data_set);

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -46,8 +46,8 @@ xmlNode *pcmk__expand_tags_in_sets(xmlNode *xml_obj,
                                    pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-gboolean pcmk__valid_resource_or_tag(pe_working_set_t *data_set, const char *id,
-                                     pe_resource_t **rsc, pe_tag_t **tag);
+bool pcmk__valid_resource_or_tag(pe_working_set_t *data_set, const char *id,
+                                 pe_resource_t **rsc, pe_tag_t **tag);
 
 G_GNUC_INTERNAL
 gboolean pcmk__tag_to_set(xmlNode *xml_obj, xmlNode **rsc_set, const char *attr,

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -540,10 +540,7 @@ stacks_and_constraints(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
     gboolean recursive = va_arg(args, gboolean);
 
-    xmlNodePtr cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS,
-                                                 data_set->input);
-
-    unpack_constraints(cib_constraints, data_set);
+    pcmk__unpack_constraints(data_set);
 
     // Constraints apply to group/clone, not member/instance
     rsc = uber_parent(rsc);
@@ -565,10 +562,7 @@ stacks_and_constraints_xml(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
     gboolean recursive = va_arg(args, gboolean);
 
-    xmlNodePtr cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS,
-                                                 data_set->input);
-
-    unpack_constraints(cib_constraints, data_set);
+    pcmk__unpack_constraints(data_set);
 
     // Constraints apply to group/clone, not member/instance
     rsc = uber_parent(rsc);

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -815,8 +815,6 @@ apply_system_health(pe_working_set_t * data_set)
 gboolean
 stage0(pe_working_set_t * data_set)
 {
-    xmlNode *cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS, data_set->input);
-
     if (data_set->input == NULL) {
         return FALSE;
     }
@@ -828,7 +826,7 @@ stage0(pe_working_set_t * data_set)
 
     set_alloc_actions(data_set);
     apply_system_health(data_set);
-    unpack_constraints(cib_constraints, data_set);
+    pcmk__unpack_constraints(data_set);
 
     return TRUE;
 }

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -1037,24 +1037,6 @@ stage2(pe_working_set_t * data_set)
 }
 
 /*
- * Create internal resource constraints before allocation
- */
-gboolean
-stage3(pe_working_set_t * data_set)
-{
-
-    GList *gIter = data_set->resources;
-
-    for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) gIter->data;
-
-        rsc->cmds->internal_constraints(rsc, data_set);
-    }
-
-    return TRUE;
-}
-
-/*
  * Check for orphaned or redefined actions
  */
 gboolean

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -623,7 +623,7 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
 
     // Convert template/tag reference in "rsc" into resource_set under constraint
     if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_lh, XML_COLOC_ATTR_SOURCE,
-                          TRUE, data_set)) {
+                          true, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
         return pcmk_rc_schema_validation;
@@ -640,7 +640,7 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
 
     // Convert template/tag reference in "with-rsc" into resource_set under constraint
     if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_rh, XML_COLOC_ATTR_TARGET,
-                          TRUE, data_set)) {
+                          true, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
         return pcmk_rc_schema_validation;

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -401,3 +401,20 @@ pcmk__tag_to_set(xmlNode *xml_obj, xmlNode **rsc_set, const char *attr,
 
     return true;
 }
+
+/*!
+ * \internal
+ * \brief Create constraints inherent to resource types
+ *
+ * \param[in,out] data_set  Cluster working set
+ */
+void
+pcmk__create_internal_constraints(pe_working_set_t *data_set)
+{
+    crm_trace("Create internal constraints");
+    for (GList *iter = data_set->resources; iter != NULL; iter = iter->next) {
+        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+
+        rsc->cmds->internal_constraints(rsc, data_set);
+    }
+}

--- a/lib/pacemaker/pcmk_sched_location.c
+++ b/lib/pacemaker/pcmk_sched_location.c
@@ -413,7 +413,7 @@ unpack_location_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
 
     // Convert template/tag reference in "rsc" into resource_set under constraint
     if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_lh, XML_LOC_ATTR_SOURCE,
-                          FALSE, data_set)) {
+                          false, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
         return pcmk_rc_schema_validation;

--- a/lib/pacemaker/pcmk_sched_messages.c
+++ b/lib/pacemaker/pcmk_sched_messages.c
@@ -122,8 +122,7 @@ pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input,
         return NULL;
     }
 
-    crm_trace("Create internal constraints");
-    stage3(data_set);
+    pcmk__create_internal_constraints(data_set);
 
     crm_trace("Check actions");
     stage4(data_set);

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -1088,7 +1088,7 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
 
     // Convert template/tag reference in "first" into resource_set under constraint
     if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_first, XML_ORDER_ATTR_FIRST,
-                          TRUE, data_set)) {
+                          true, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
         return pcmk_rc_schema_validation;
@@ -1105,7 +1105,7 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
 
     // Convert template/tag reference in "then" into resource_set under constraint
     if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_then, XML_ORDER_ATTR_THEN,
-                          TRUE, data_set)) {
+                          true, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
         return pcmk_rc_schema_validation;

--- a/lib/pacemaker/pcmk_sched_tickets.c
+++ b/lib/pacemaker/pcmk_sched_tickets.c
@@ -388,7 +388,7 @@ unpack_rsc_ticket_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
 
     // Convert template/tag reference in "rsc" into resource_set under rsc_ticket
     if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_lh, XML_COLOC_ATTR_SOURCE,
-                          FALSE, data_set)) {
+                          false, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
         return pcmk_rc_schema_validation;

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -2163,9 +2163,7 @@ mon_refresh_display(gpointer user_data)
      * (tickets may be referenced in constraints but not granted yet,
      * and bans need negative location constraints) */
     if (pcmk_is_set(show, pcmk_section_bans) || pcmk_is_set(show, pcmk_section_tickets)) {
-        xmlNode *cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS,
-                                                   mon_data_set->input);
-        unpack_constraints(cib_constraints, mon_data_set);
+        pcmk__unpack_constraints(mon_data_set);
     }
 
     if (options.daemonize) {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -399,11 +399,8 @@ cli_resource_update_attribute(pe_resource_t *rsc, const char *requested_name,
             GList *lpc = NULL;
 
             if(need_init) {
-                xmlNode *cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS, data_set->input);
-
                 need_init = FALSE;
-                unpack_constraints(cib_constraints, data_set);
-
+                pcmk__unpack_constraints(data_set);
                 pe__clear_resource_flags_on_all(data_set, pe_rsc_allocating);
             }
 

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -712,7 +712,6 @@ main(int argc, char **argv)
 {
     pe_working_set_t *data_set = NULL;
     xmlNode *cib_xml_copy = NULL;
-    xmlNode *cib_constraints = NULL;
 
     cib_t *cib_conn = NULL;
     crm_exit_t exit_code = CRM_EX_OK;
@@ -893,8 +892,7 @@ main(int argc, char **argv)
 
     /* For recording the tickets that are referenced in rsc_ticket constraints
      * but have never been granted yet. */
-    cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS, data_set->input);
-    unpack_constraints(cib_constraints, data_set);
+    pcmk__unpack_constraints(data_set);
 
     if (ticket_cmd == 'l' || ticket_cmd == 'L' || ticket_cmd == 'w') {
         gboolean raw = FALSE;


### PR DESCRIPTION
After splitting all constraint-type-specific APIs into their own source files, pcmk_sched_constraints.c contains only APIs related to constraints in general. Bring those to current guidelines regarding naming and commenting.