### PR TITLE
[WIP] High: Change Query timeout calculation.

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1959,10 +1959,12 @@ get_capable_devices(const char *host, const char *action, int timeout, bool suic
               int device_timeout = get_action_timeout(device, 
                                                   pcmk__str_eq(check_type, "status", pcmk__str_casei)? "status" : "list", timeout);
               if (device_timeout > timeout) {
-                  crm_notice("Since the pcmk_xxxx_timeout parameter of %s is larger than stonith-timeout(%d), timeout may occur",
+                  crm_notice("Since the pcmk_%s_timeout parameter of %s is larger than stonith-timeout(%d), timeout may occur",
+                  pcmk__str_eq(check_type, "status", pcmk__str_casei)? "status" : "list",
                   device->id, timeout); 
               } else if (device_timeout < timeout && device_timeout < MIN_QUERY_TIMEOUT) {
-                  crm_notice("Since the pcmk_xxxx_timeout parameter of %s is larger than the minimum timeout(%d) of Query, timeout may occur",
+                  crm_notice("Since the pcmk_%s_timeout parameter of %s is larger than the minimum timeout(%d) of Query, timeout may occur",
+                  pcmk__str_eq(check_type, "status", pcmk__str_casei)? "status" : "list",
                   device->id, MIN_QUERY_TIMEOUT); 
               }
         }

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1963,7 +1963,7 @@ get_capable_devices(const char *host, const char *action, int timeout, bool suic
                   pcmk__str_eq(check_type, "status", pcmk__str_casei)? "status" : "list",
                   device->id, timeout); 
               } else if ((device_timeout < timeout) && (device_timeout < MIN_QUERY_TIMEOUT)) {
-                  crm_notice("Since the pcmk_%s_timeout parameter of %s is larger than the minimum timeout(%d) of Query, timeout may occur",
+                  crm_notice("Since the pcmk_%s_timeout parameter of %s is smaller than the minimum timeout(%d) of Query, timeout may occur",
                   pcmk__str_eq(check_type, "status", pcmk__str_casei)? "status" : "list",
                   device->id, MIN_QUERY_TIMEOUT); 
               }

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1962,7 +1962,7 @@ get_capable_devices(const char *host, const char *action, int timeout, bool suic
                   crm_notice("Since the pcmk_%s_timeout parameter of %s is larger than stonith-timeout(%d), timeout may occur",
                   pcmk__str_eq(check_type, "status", pcmk__str_casei)? "status" : "list",
                   device->id, timeout); 
-              } else if (device_timeout < timeout && device_timeout < MIN_QUERY_TIMEOUT) {
+              } else if ((device_timeout < timeout) && (device_timeout < MIN_QUERY_TIMEOUT)) {
                   crm_notice("Since the pcmk_%s_timeout parameter of %s is larger than the minimum timeout(%d) of Query, timeout may occur",
                   pcmk__str_eq(check_type, "status", pcmk__str_casei)? "status" : "list",
                   device->id, MIN_QUERY_TIMEOUT); 


### PR DESCRIPTION
Hi All,

This WIP will be the corresponding version of the next PR.
 - https://github.com/ClusterLabs/pacemaker/pull/2443

Change the current Query timeout calculation.

The output contents of the log and the check when timeout is small are provisional.
Please give us your opinion.

So far, there isn't a very good idea for checking the optimal small value.
It is tentatively taking over the check of the previous minimum value of 20s.

---

Stonith processing is divided into two phases.
The first is the Query phase, at which time controlld waits for processing based on the stonith-timeout.
Execution of fenced Query must be performed in pcmk_list_timeout/pcmk_status_timeout and stonith-timeout.
The second is the actual fencing phase, where contorld waits for an updated timeout for the total value of the agents being executed.
Therefore, pcmk_list_timeout / pcmk_status_timeout has no effect here.
The calculation of the timeout at this time is sufficient as it is.
It is calculated for each reboot / off / on operation.

In this PR, the calculation of the timeout of the first phase is changed.

Best Regards,
Hideo Yamauchi.