### PR TITLE
Use execution status instead of exit status when appropriate

### DIFF
--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -966,8 +966,7 @@ action_complete(svc_action_t * action)
 
         } else if (cmd->real_action != NULL) {
             // This is follow-up monitor to check whether start/stop completed
-            if ((cmd->result.execution_status == PCMK_EXEC_DONE)
-                && (cmd->result.exit_status == PCMK_OCF_PENDING)) {
+            if (cmd->result.execution_status == PCMK_EXEC_PENDING) {
                 goagain = true;
 
             } else if ((cmd->result.exit_status == PCMK_OCF_OK)
@@ -1035,7 +1034,7 @@ action_complete(svc_action_t * action)
                 crm_debug("%s %s may still be in progress: re-scheduling (elapsed=%dms, remaining=%dms, start_delay=%dms)",
                           cmd->rsc_id, cmd->real_action, time_sum, timeout_left, delay);
 
-            } else if (cmd->result.exit_status == PCMK_OCF_PENDING) {
+            } else if (cmd->result.execution_status == PCMK_EXEC_PENDING) {
                 crm_info("%s %s is still in progress: re-scheduling (elapsed=%dms, remaining=%dms, start_delay=%dms)",
                          cmd->rsc_id, cmd->action, time_sum, timeout_left, delay);
 

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -173,7 +173,6 @@ enum ocf_exitcode {
 
     // Pacemaker extensions
     PCMK_OCF_CONNECTION_DIED      = 189, //!< \deprecated See PCMK_EXEC_NOT_CONNECTED
-    PCMK_OCF_EXEC_ERROR           = 192, //!< Error executing the agent
     PCMK_OCF_UNKNOWN              = 193, //!< Action is pending
     PCMK_OCF_SIGNAL               = 194, //!< Agent terminated due to signal
     PCMK_OCF_PENDING              = 196, //!< Multi-stage execution in progress
@@ -181,6 +180,7 @@ enum ocf_exitcode {
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     // Former Pacemaker extensions
+    PCMK_OCF_EXEC_ERROR           = 192, //!< \deprecated (Unused)
     PCMK_OCF_NOT_SUPPORTED        = 195, //!< \deprecated (Unused)
     PCMK_OCF_CANCELLED            = 197, //!< \deprecated (Unused)
     PCMK_OCF_OTHER_ERROR          = 199, //!< \deprecated (Unused)

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -176,13 +176,15 @@ enum ocf_exitcode {
     PCMK_OCF_EXEC_ERROR           = 192, //!< Error executing the agent
     PCMK_OCF_UNKNOWN              = 193, //!< Action is pending
     PCMK_OCF_SIGNAL               = 194, //!< Agent terminated due to signal
-    PCMK_OCF_NOT_SUPPORTED        = 195, //!< \deprecated (Unused)
     PCMK_OCF_PENDING              = 196, //!< Multi-stage execution in progress
-    PCMK_OCF_CANCELLED            = 197, //!< \deprecated (Unused)
     PCMK_OCF_TIMEOUT              = 198, //!< Action did not complete in time
-    PCMK_OCF_OTHER_ERROR          = 199, //!< \deprecated (Unused)
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+    // Former Pacemaker extensions
+    PCMK_OCF_NOT_SUPPORTED        = 195, //!< \deprecated (Unused)
+    PCMK_OCF_CANCELLED            = 197, //!< \deprecated (Unused)
+    PCMK_OCF_OTHER_ERROR          = 199, //!< \deprecated (Unused)
+
     //! \deprecated Use PCMK_OCF_RUNNING_PROMOTED instead
     PCMK_OCF_RUNNING_MASTER     = PCMK_OCF_RUNNING_PROMOTED,
 

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -207,7 +207,7 @@ enum ocf_exitcode {
  * OSes we don't support -- for example, OpenVMS considers 1 success!).
  *
  * For init scripts, the LSB gives meaning to 0-7, and sets aside 150-199 for
- * application use. OCF adds 8-9 and 189-199.
+ * application use. OCF adds 8-9 and 190-191.
  *
  * sysexits.h was an attempt to give additional meanings, but never really
  * caught on. It uses 0 and 64-78.
@@ -268,6 +268,16 @@ typedef enum crm_exit_e {
 
     // Other
     CRM_EX_TIMEOUT              = 124, //!< Convention from timeout(1)
+
+    /* Anything above 128 overlaps with some shells' use of these values for
+     * "interrupted by signal N", and so may be unreliable when detected by
+     * shell scripts.
+     */
+
+    // OCF Resource Agent API 1.1
+    CRM_EX_DEGRADED             = 190, //!< Service active but more likely to fail soon
+    CRM_EX_DEGRADED_PROMOTED    = 191, //!< Service promoted but more likely to fail soon
+
     CRM_EX_MAX                  = 255, //!< Ensure crm_exit_t can hold this
 } crm_exit_t;
 

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -154,8 +154,9 @@ enum pcmk_rc_e {
  * \brief Exit status codes for resource agents
  *
  * The OCF Resource Agent API standard enumerates the possible exit status codes
- * that agents should return. Pacemaker adds some more to cover problems with
- * executing the agent, and to use a single set of codes for all agent types.
+ * that agents should return. Besides being used with OCF agents, these values
+ * are also used by the executor as a universal status for all agent standards;
+ * actual results are mapped to these before returning them to clients.
  */
 enum ocf_exitcode {
     PCMK_OCF_OK                   = 0,   //!< Success
@@ -171,7 +172,21 @@ enum ocf_exitcode {
     PCMK_OCF_DEGRADED             = 190, //!< Service active but more likely to fail soon
     PCMK_OCF_DEGRADED_PROMOTED    = 191, //!< Service promoted but more likely to fail soon
 
-    // Pacemaker extensions
+    /* The rest are Pacemaker extensions, not in the OCF standard. The executor
+     * returns PCMK_OCF_TIMEOUT for agent timeouts, and the controller records
+     * PCMK_OCF_UNKNOWN for pending actions, and PCMK_OCF_TIMEOUT for executor
+     * communication timeouts. PCMK_OCF_CONNECTION_DIED is used only with older
+     * DCs that don't support PCMK_EXEC_NOT_CONNECTED.
+     *
+     * @TODO These should be deprecated, and existing execution status codes
+     * (enum pcmk_exec_status) should be relied on for these instead
+     * (PCMK_EXEC_PENDING for the purposes of PCMK_OCF_UNKNOWN, and
+     * PCMK_EXEC_TIMEOUT for PCMK_OCF_TIMEOUT). It might be worthwhile to keep
+     * PCMK_OCF_UNKNOWN as an invalid value for initializing new action objects.
+     * However, backward compatibility must be considered (processing old saved
+     * CIB files, rolling upgrades with older DCs, older Pacemaker Remote nodes
+     * or connection hosts, and older bundles).
+     */
     PCMK_OCF_CONNECTION_DIED      = 189, //!< \deprecated See PCMK_EXEC_NOT_CONNECTED
     PCMK_OCF_UNKNOWN              = 193, //!< Action is pending
     PCMK_OCF_TIMEOUT              = 198, //!< Action did not complete in time

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -174,7 +174,6 @@ enum ocf_exitcode {
     // Pacemaker extensions
     PCMK_OCF_CONNECTION_DIED      = 189, //!< \deprecated See PCMK_EXEC_NOT_CONNECTED
     PCMK_OCF_UNKNOWN              = 193, //!< Action is pending
-    PCMK_OCF_PENDING              = 196, //!< Multi-stage execution in progress
     PCMK_OCF_TIMEOUT              = 198, //!< Action did not complete in time
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
@@ -182,6 +181,7 @@ enum ocf_exitcode {
     PCMK_OCF_EXEC_ERROR           = 192, //!< \deprecated (Unused)
     PCMK_OCF_SIGNAL               = 194, //!< \deprecated (Unused)
     PCMK_OCF_NOT_SUPPORTED        = 195, //!< \deprecated (Unused)
+    PCMK_OCF_PENDING              = 196, //!< \deprecated (Unused)
     PCMK_OCF_CANCELLED            = 197, //!< \deprecated (Unused)
     PCMK_OCF_OTHER_ERROR          = 199, //!< \deprecated (Unused)
 

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -174,13 +174,13 @@ enum ocf_exitcode {
     // Pacemaker extensions
     PCMK_OCF_CONNECTION_DIED      = 189, //!< \deprecated See PCMK_EXEC_NOT_CONNECTED
     PCMK_OCF_UNKNOWN              = 193, //!< Action is pending
-    PCMK_OCF_SIGNAL               = 194, //!< Agent terminated due to signal
     PCMK_OCF_PENDING              = 196, //!< Multi-stage execution in progress
     PCMK_OCF_TIMEOUT              = 198, //!< Action did not complete in time
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     // Former Pacemaker extensions
     PCMK_OCF_EXEC_ERROR           = 192, //!< \deprecated (Unused)
+    PCMK_OCF_SIGNAL               = 194, //!< \deprecated (Unused)
     PCMK_OCF_NOT_SUPPORTED        = 195, //!< \deprecated (Unused)
     PCMK_OCF_CANCELLED            = 197, //!< \deprecated (Unused)
     PCMK_OCF_OTHER_ERROR          = 199, //!< \deprecated (Unused)

--- a/include/crm/services.h
+++ b/include/crm/services.h
@@ -305,8 +305,6 @@ gboolean services_alert_async(svc_action_t *action,
                 return "promoted";
             case PCMK_OCF_FAILED_PROMOTED:
                 return "promoted (failed)";
-            case PCMK_OCF_PENDING:
-                return "OCF_PENDING";
             case PCMK_OCF_TIMEOUT:
                 return "OCF_TIMEOUT";
             case PCMK_OCF_DEGRADED:
@@ -323,6 +321,8 @@ gboolean services_alert_async(svc_action_t *action,
                 return "other error (DEPRECATED STATUS)";
             case PCMK_OCF_SIGNAL:
                 return "interrupted by signal (DEPRECATED STATUS)";
+            case PCMK_OCF_PENDING:
+                return "pending (DEPRECATED STATUS)";
 #endif
             default:
                 return "unknown";

--- a/include/crm/services.h
+++ b/include/crm/services.h
@@ -307,20 +307,23 @@ gboolean services_alert_async(svc_action_t *action,
                 return "promoted (failed)";
             case PCMK_OCF_SIGNAL:
                 return "OCF_SIGNAL";
-            case PCMK_OCF_NOT_SUPPORTED:
-                return "OCF_NOT_SUPPORTED";
             case PCMK_OCF_PENDING:
                 return "OCF_PENDING";
-            case PCMK_OCF_CANCELLED:
-                return "OCF_CANCELLED";
             case PCMK_OCF_TIMEOUT:
                 return "OCF_TIMEOUT";
-            case PCMK_OCF_OTHER_ERROR:
-                return "OCF_OTHER_ERROR";
             case PCMK_OCF_DEGRADED:
                 return "OCF_DEGRADED";
             case PCMK_OCF_DEGRADED_PROMOTED:
                 return "promoted (degraded)";
+
+#if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+            case PCMK_OCF_NOT_SUPPORTED:
+                return "action not supported (DEPRECATED)";
+            case PCMK_OCF_CANCELLED:
+                return "action cancelled (DEPRECATED)";
+            case PCMK_OCF_OTHER_ERROR:
+                return "other error (DEPRECATED)";
+#endif
             default:
                 return "unknown";
         }

--- a/include/crm/services.h
+++ b/include/crm/services.h
@@ -305,8 +305,6 @@ gboolean services_alert_async(svc_action_t *action,
                 return "promoted";
             case PCMK_OCF_FAILED_PROMOTED:
                 return "promoted (failed)";
-            case PCMK_OCF_SIGNAL:
-                return "OCF_SIGNAL";
             case PCMK_OCF_PENDING:
                 return "OCF_PENDING";
             case PCMK_OCF_TIMEOUT:
@@ -318,11 +316,13 @@ gboolean services_alert_async(svc_action_t *action,
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
             case PCMK_OCF_NOT_SUPPORTED:
-                return "action not supported (DEPRECATED)";
+                return "not supported (DEPRECATED STATUS)";
             case PCMK_OCF_CANCELLED:
-                return "action cancelled (DEPRECATED)";
+                return "cancelled (DEPRECATED STATUS)";
             case PCMK_OCF_OTHER_ERROR:
-                return "other error (DEPRECATED)";
+                return "other error (DEPRECATED STATUS)";
+            case PCMK_OCF_SIGNAL:
+                return "interrupted by signal (DEPRECATED STATUS)";
 #endif
             default:
                 return "unknown";

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -529,6 +529,8 @@ crm_exit_name(crm_exit_t exit_code)
         case CRM_EX_UNSATISFIED: return "CRM_EX_UNSATISFIED";
         case CRM_EX_OLD: return "CRM_EX_OLD";
         case CRM_EX_TIMEOUT: return "CRM_EX_TIMEOUT";
+        case CRM_EX_DEGRADED: return "CRM_EX_DEGRADED";
+        case CRM_EX_DEGRADED_PROMOTED: return "CRM_EX_DEGRADED_PROMOTED";
         case CRM_EX_MAX: return "CRM_EX_UNKNOWN";
     }
     return "CRM_EX_UNKNOWN";
@@ -576,6 +578,8 @@ crm_exit_str(crm_exit_t exit_code)
         case CRM_EX_UNSATISFIED: return "Not applicable under current conditions";
         case CRM_EX_OLD: return "Update was older than existing configuration";
         case CRM_EX_TIMEOUT: return "Timeout occurred";
+        case CRM_EX_DEGRADED: return "Service is active but might fail soon";
+        case CRM_EX_DEGRADED_PROMOTED: return "Service is promoted but might fail soon";
         case CRM_EX_MAX: return "Error occurred";
     }
     if ((exit_code > 128) && (exit_code < CRM_EX_MAX)) {

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -752,14 +752,14 @@ static int
 svc_action_to_errno(svc_action_t *svc_action) {
     int rv = pcmk_ok;
 
-    if (svc_action->rc > 0) {
-        /* Try to provide a useful error code based on the fence agent's
-            * error output.
-            */
-        if (svc_action->rc == PCMK_OCF_TIMEOUT) {
+    if (svc_action->status == PCMK_EXEC_TIMEOUT) {
             rv = -ETIME;
 
-        } else if (svc_action->stderr_data == NULL) {
+    } else if (svc_action->rc != PCMK_OCF_OK) {
+        /* Try to provide a useful error code based on the fence agent's
+         * error output.
+         */
+        if (svc_action->stderr_data == NULL) {
             rv = -ENODATA;
 
         } else if (strstr(svc_action->stderr_data, "imed out")) {

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -648,13 +648,13 @@ services__handle_exec_error(svc_action_t * op, int error)
     } else if (pcmk__str_eq(op->standard, PCMK_RESOURCE_CLASS_NAGIOS, pcmk__str_casei)) {
         rc_not_installed = NAGIOS_NOT_INSTALLED;
         rc_insufficient_priv = NAGIOS_INSUFFICIENT_PRIV;
-        rc_exec_error = PCMK_OCF_EXEC_ERROR;
+        rc_exec_error = PCMK_OCF_UNKNOWN_ERROR;
 #endif
 
     } else {
         rc_not_installed = PCMK_OCF_NOT_INSTALLED;
         rc_insufficient_priv = PCMK_OCF_INSUFFICIENT_PRIV;
-        rc_exec_error = PCMK_OCF_EXEC_ERROR;
+        rc_exec_error = PCMK_OCF_UNKNOWN_ERROR;
     }
 
     switch (error) {   /* see execve(2), stat(2) and fork(2) */

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -615,7 +615,7 @@ operation_finished(mainloop_child_t * p, pid_t pid, int core, int signo, int exi
         crm_warn("%s[%d] terminated with signal: %s " CRM_XS " (%d)",
                  op->id, op->pid, strsignal(signo), signo);
         op->status = PCMK_EXEC_ERROR;
-        op->rc = PCMK_OCF_SIGNAL;
+        op->rc = PCMK_OCF_UNKNOWN_ERROR;
     }
 
     log_op_output(op);

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -710,9 +710,11 @@ systemd_unit_check(const char *name, const char *state, void *userdata)
     } else if (g_strcmp0(state, "reloading") == 0) {
         op->rc = PCMK_OCF_OK;
     } else if (g_strcmp0(state, "activating") == 0) {
-        op->rc = PCMK_OCF_PENDING;
+        op->rc = PCMK_OCF_UNKNOWN;
+        op->status = PCMK_EXEC_PENDING;
     } else if (g_strcmp0(state, "deactivating") == 0) {
-        op->rc = PCMK_OCF_PENDING;
+        op->rc = PCMK_OCF_UNKNOWN;
+        op->status = PCMK_EXEC_PENDING;
     } else {
         op->rc = PCMK_OCF_NOT_RUNNING;
     }

--- a/lib/services/upstart.c
+++ b/lib/services/upstart.c
@@ -1,6 +1,9 @@
 /*
- * Copyright (C) 2010 Senko Rasic <senko.rasic@dobarkod.hr>
- * Copyright (c) 2010 Ante Karamatic <ivoks@init.hr>
+ * Original copyright 2010 Senko Rasic <senko.rasic@dobarkod.hr>
+ *                         and Ante Karamatic <ivoks@init.hr>
+ * Later changes copyright 2012-2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -300,8 +303,6 @@ upstart_job_check(const char *name, const char *state, void *userdata)
 
     if (state && g_strcmp0(state, "running") == 0) {
         op->rc = PCMK_OCF_OK;
-    /* } else if (g_strcmp0(state, "activating") == 0) { */
-    /*     op->rc = PCMK_OCF_PENDING; */
     } else {
         op->rc = PCMK_OCF_NOT_RUNNING;
     }


### PR DESCRIPTION
Pacemaker defines a number of exit codes as extensions to the OCF exit codes, however most of them are more logically execution statuses. Use execution statuses where appropriate and deprecate extended codes no longer used.