### PR TITLE
Minor clean-up in libcrmservice

### DIFF
--- a/include/crm/services.h
+++ b/include/crm/services.h
@@ -190,14 +190,6 @@ typedef struct svc_action_s {
     GList *get_directory_list(const char *root, gboolean files, gboolean executable);
 
 /**
- * Get a list of services
- *
- * \return a list of services.  The list items are gchar *.  This list _must_
- *         be destroyed using g_list_free_full(list, free).
- */
-    GList *services_list(void);
-
-/**
  * \brief Get a list of providers
  *
  * \param[in] standard  list providers of this standard (e.g. ocf, lsb, etc.)
@@ -236,9 +228,6 @@ typedef struct svc_action_s {
  * \return A boolean
  */
     gboolean resources_agent_exists(const char *standard, const char *provider, const char *agent);
-
-svc_action_t *services_action_create(const char *name, const char *action,
-                                     guint interval_ms, int timeout /* ms */);
 
 /**
  * \brief Create a new resource action

--- a/include/crm/services_compat.h
+++ b/include/crm/services_compat.h
@@ -41,6 +41,13 @@ enum op_status {
     PCMK_LRM_OP_INVALID = PCMK_EXEC_INVALID,
 };
 
+//! \deprecated Use resources_action_create() instead
+svc_action_t *services_action_create(const char *name, const char *action,
+                                     guint interval_ms, int timeout);
+
+//! \deprecated Use resources_list_agents() instead
+GList *services_list(void);
+
 //! \deprecated Use pcmk_exec_status_str() instead
 static inline const char *
 services_lrm_status_str(enum op_status status)

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -423,7 +423,7 @@ services_alert_async(svc_action_t *action, void (*cb)(svc_action_t *op))
 {
     action->synchronous = false;
     action->opaque->callback = cb;
-    return services_os_action_execute(action);
+    return services__execute_file(action) == pcmk_rc_ok;
 }
 
 #if SUPPORT_DBUS
@@ -721,7 +721,7 @@ action_exec_helper(svc_action_t * op)
         return services__execute_systemd(op) == pcmk_rc_ok;
 #endif
     } else {
-        return services_os_action_execute(op);
+        return services__execute_file(op) == pcmk_rc_ok;
     }
     /* The 'op' has probably been freed if the execution functions return TRUE
        for the asynchronous 'op'. */

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -585,7 +585,7 @@ services_action_cancel(const char *name, const char *action, guint interval_ms)
         goto done;
     }
 
-    /* Tell operation_finalize() not to reschedule the operation */
+    // Tell services__finalize_async_op() not to reschedule the operation
     op->cancel = TRUE;
 
     /* Stop tracking it as a recurring operation, and stop its repeat timer */
@@ -594,8 +594,8 @@ services_action_cancel(const char *name, const char *action, guint interval_ms)
     /* If the op has a PID, it's an in-flight child process, so kill it.
      *
      * Whether the kill succeeds or fails, the main loop will send the op to
-     * operation_finished() (and thus operation_finalize()) when the process
-     * goes away.
+     * operation_finished() (and thus services__finalize_async_op()) when the
+     * process goes away.
      */
     if (op->pid != 0) {
         crm_info("Terminating in-flight op %s[%d] early because it was cancelled",
@@ -619,8 +619,9 @@ services_action_cancel(const char *name, const char *action, guint interval_ms)
     }
 #endif
 
-    // The rest of this is essentially equivalent to operation_finalize(),
-    // except without calling handle_blocked_ops()
+    /* The rest of this is essentially equivalent to
+     * services__finalize_async_op(), minus the handle_blocked_ops() call.
+     */
 
     // Report operation as cancelled
     op->status = PCMK_EXEC_CANCELLED;
@@ -846,7 +847,7 @@ handle_blocked_ops(void)
             op->status = PCMK_EXEC_ERROR;
             /* this can cause this function to be called recursively
              * which is why we have processing_blocked_ops static variable */
-            operation_finalize(op);
+            services__finalize_async_op(op);
         }
     }
 

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -713,7 +713,7 @@ action_exec_helper(svc_action_t * op)
     if (op->standard
         && (strcasecmp(op->standard, PCMK_RESOURCE_CLASS_UPSTART) == 0)) {
 #if SUPPORT_UPSTART
-        return upstart_job_exec(op);
+        return upstart_job_exec(op) == pcmk_rc_ok;
 #endif
     } else if (op->standard && strcasecmp(op->standard,
                                           PCMK_RESOURCE_CLASS_SYSTEMD) == 0) {

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -718,7 +718,7 @@ action_exec_helper(svc_action_t * op)
     } else if (op->standard && strcasecmp(op->standard,
                                           PCMK_RESOURCE_CLASS_SYSTEMD) == 0) {
 #if SUPPORT_SYSTEMD
-        return systemd_unit_exec(op);
+        return services__execute_systemd(op) == pcmk_rc_ok;
 #endif
     } else {
         return services_os_action_execute(op);

--- a/lib/services/services_lsb.c
+++ b/lib/services/services_lsb.c
@@ -259,11 +259,10 @@ services__lsb_agent_exists(const char *agent)
     return rc;
 }
 
-/* The remaining functions below are not used by the Pacemaker code base, and
- * are provided for API compatibility only.
- *
- * @TODO They should be removed or renamed.
- */
+// Deprecated functions kept only for backward API compatibility
+// LCOV_EXCL_START
+
+#include <crm/services_compat.h>
 
 svc_action_t *
 services_action_create(const char *name, const char *action,
@@ -279,3 +278,5 @@ services_list(void)
     return resources_list_agents(PCMK_RESOURCE_CLASS_LSB, NULL);
 }
 
+// LCOV_EXCL_STOP
+// End deprecated API

--- a/lib/services/services_private.h
+++ b/lib/services/services_private.h
@@ -47,7 +47,7 @@ G_GNUC_INTERNAL
 GList *services_os_get_directory_list(const char *root, gboolean files, gboolean executable);
 
 G_GNUC_INTERNAL
-gboolean services_os_action_execute(svc_action_t * op);
+int services__execute_file(svc_action_t *op);
 
 G_GNUC_INTERNAL
 GList *resources_os_list_ocf_providers(void);

--- a/lib/services/services_private.h
+++ b/lib/services/services_private.h
@@ -65,7 +65,7 @@ G_GNUC_INTERNAL
 gboolean recurring_action_timer(gpointer data);
 
 G_GNUC_INTERNAL
-gboolean operation_finalize(svc_action_t * op);
+int services__finalize_async_op(svc_action_t *op);
 
 G_GNUC_INTERNAL
 void services__handle_exec_error(svc_action_t * op, int error);

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -281,7 +281,7 @@ systemd_loadunit_result(DBusMessage *reply, svc_action_t * op)
             systemd_unit_exec_with_unit(op, path);
 
         } else if (op->synchronous == FALSE) {
-            operation_finalize(op);
+            services__finalize_async_op(op);
         }
     }
 
@@ -587,7 +587,7 @@ systemd_async_dispatch(DBusPendingCall *pending, void *user_data)
     CRM_LOG_ASSERT(pending == op->opaque->pending);
     services_set_op_pending(op, NULL);
     systemd_exec_result(reply, op);
-    operation_finalize(op);
+    services__finalize_async_op(op);
 
     if(reply) {
         dbus_message_unref(reply);
@@ -720,7 +720,7 @@ systemd_unit_check(const char *name, const char *state, void *userdata)
 
     if (op->synchronous == FALSE) {
         services_set_op_pending(op, NULL);
-        operation_finalize(op);
+        services__finalize_async_op(op);
     }
 }
 
@@ -750,7 +750,7 @@ systemd_unit_exec_with_unit(svc_action_t * op, const char *unit)
             return TRUE;
 
         } else {
-            return operation_finalize(op);
+            return services__finalize_async_op(op) == pcmk_rc_ok;
         }
 
     } else if (g_strcmp0(method, "start") == 0) {
@@ -795,7 +795,7 @@ systemd_unit_exec_with_unit(svc_action_t * op, const char *unit)
             return TRUE;
 
         } else {
-            return operation_finalize(op);
+            return services__finalize_async_op(op) == pcmk_rc_ok;
         }
 
     } else {
@@ -811,7 +811,7 @@ systemd_unit_exec_with_unit(svc_action_t * op, const char *unit)
 
   cleanup:
     if (op->synchronous == FALSE) {
-        return operation_finalize(op);
+        return services__finalize_async_op(op) == pcmk_rc_ok;
     }
 
     return op->rc == PCMK_OCF_OK;
@@ -824,8 +824,7 @@ systemd_timeout_callback(gpointer p)
 
     op->opaque->timerid = 0;
     crm_warn("%s operation on systemd unit %s named '%s' timed out", op->action, op->agent, op->rsc);
-    operation_finalize(op);
-
+    services__finalize_async_op(op);
     return FALSE;
 }
 
@@ -848,7 +847,7 @@ systemd_unit_exec(svc_action_t * op)
         op->rc = PCMK_OCF_OK;
 
         if (op->synchronous == FALSE) {
-            return operation_finalize(op);
+            return services__finalize_async_op(op) == pcmk_rc_ok;
         }
         return TRUE;
     }
@@ -863,7 +862,7 @@ systemd_unit_exec(svc_action_t * op)
             return TRUE;
 
         } else {
-            return operation_finalize(op);
+            return services__finalize_async_op(op) == pcmk_rc_ok;
         }
     }
 

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -570,8 +570,6 @@ systemd_exec_result(DBusMessage *reply, svc_action_t *op)
             op->rc = PCMK_OCF_OK;
         }
     }
-
-    operation_finalize(op);
 }
 
 static void
@@ -589,6 +587,7 @@ systemd_async_dispatch(DBusPendingCall *pending, void *user_data)
     CRM_LOG_ASSERT(pending == op->opaque->pending);
     services_set_op_pending(op, NULL);
     systemd_exec_result(reply, op);
+    operation_finalize(op);
 
     if(reply) {
         dbus_message_unref(reply);

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -828,43 +828,71 @@ systemd_timeout_callback(gpointer p)
     return FALSE;
 }
 
-/* For an asynchronous 'op', returns FALSE if 'op' should be free'd by the caller */
-/* For a synchronous 'op', returns FALSE if 'op' fails */
-gboolean
-systemd_unit_exec(svc_action_t * op)
+/*!
+ * \internal
+ * \brief Execute a systemd action
+ *
+ * \param[in] op  Action to execute
+ *
+ * \return Standard Pacemaker return code
+ * \retval EBUSY          Recurring operation could not be initiated
+ * \retval pcmk_rc_error  Synchronous action failed
+ * \retval pcmk_rc_ok     Synchronous action succeeded, or asynchronous action
+ *                        should not be freed (because it already was or is
+ *                        pending)
+ *
+ * \note If the return value for an asynchronous action is not pcmk_rc_ok, the
+ *       caller is responsible for freeing the action.
+ */
+int
+services__execute_systemd(svc_action_t *op)
 {
-    char *unit = NULL;
+    CRM_ASSERT(op != NULL);
 
-    CRM_ASSERT(op);
-    CRM_ASSERT(systemd_init());
-    op->rc = PCMK_OCF_UNKNOWN_ERROR;
+    if ((op->action == NULL) || (op->agent == NULL)) {
+        op->rc = PCMK_OCF_NOT_CONFIGURED;
+        op->status = PCMK_EXEC_ERROR_FATAL;
+        goto done;
+    }
+
+    if (!systemd_init()) {
+        op->rc = PCMK_OCF_UNKNOWN_ERROR;
+        op->status = PCMK_EXEC_ERROR;
+        goto done;
+    }
+
     crm_debug("Performing %ssynchronous %s op on systemd unit %s named '%s'",
-              op->synchronous ? "" : "a", op->action, op->agent, op->rsc);
+              (op->synchronous? "" : "a"), op->action, op->agent,
+              crm_str(op->rsc));
 
     if (pcmk__str_eq(op->action, "meta-data", pcmk__str_casei)) {
-        // @TODO Implement an async meta-data call in executor API
         op->stdout_data = systemd_unit_metadata(op->agent, op->timeout);
         op->rc = PCMK_OCF_OK;
-
-        if (op->synchronous == FALSE) {
-            return services__finalize_async_op(op) == pcmk_rc_ok;
-        }
-        return TRUE;
+        op->status = PCMK_EXEC_DONE;
+        goto done;
     }
 
-    unit = systemd_unit_by_name(op->agent, op);
-    free(unit);
+    // Initialize rc/status in case systemd_unit_by_name() doesn't set them
+    op->rc = PCMK_OCF_UNKNOWN_ERROR;
+    op->status = PCMK_EXEC_DONE;
 
-    if (op->synchronous == FALSE) {
-        if (op->opaque->pending) {
-            op->opaque->timerid = g_timeout_add(op->timeout + 5000, systemd_timeout_callback, op);
-            services_add_inflight_op(op);
-            return TRUE;
+    {
+        char *unit = systemd_unit_by_name(op->agent, op);
 
-        } else {
-            return services__finalize_async_op(op) == pcmk_rc_ok;
-        }
+        free(unit);
     }
 
-    return op->rc == PCMK_OCF_OK;
+    if (op->opaque->pending != NULL) { // Successfully initiated async op
+        op->opaque->timerid = g_timeout_add(op->timeout + 5000,
+                                            systemd_timeout_callback, op);
+        services_add_inflight_op(op);
+        return pcmk_rc_ok;
+    }
+
+done:
+    if (op->synchronous) {
+        return (op->rc == PCMK_OCF_OK)? pcmk_rc_ok : pcmk_rc_error;
+    } else {
+        return services__finalize_async_op(op);
+    }
 }

--- a/lib/services/systemd.h
+++ b/lib/services/systemd.h
@@ -14,7 +14,10 @@
 #  include "crm/services.h"
 
 G_GNUC_INTERNAL GList *systemd_unit_listall(void);
-G_GNUC_INTERNAL gboolean systemd_unit_exec(svc_action_t * op);
+
+G_GNUC_INTERNAL
+int services__execute_systemd(svc_action_t *op);
+
 G_GNUC_INTERNAL gboolean systemd_unit_exists(const gchar * name);
 G_GNUC_INTERNAL void systemd_cleanup(void);
 

--- a/lib/services/upstart.c
+++ b/lib/services/upstart.c
@@ -309,7 +309,7 @@ upstart_job_check(const char *name, const char *state, void *userdata)
 
     if (op->synchronous == FALSE) {
         services_set_op_pending(op, NULL);
-        operation_finalize(op);
+        services__finalize_async_op(op);
     }
 }
 
@@ -406,7 +406,7 @@ upstart_async_dispatch(DBusPendingCall *pending, void *user_data)
 
     CRM_LOG_ASSERT(pending == op->opaque->pending);
     services_set_op_pending(op, NULL);
-    operation_finalize(op);
+    services__finalize_async_op(op);
 
     if(reply) {
         dbus_message_unref(reply);
@@ -559,7 +559,7 @@ upstart_job_exec(svc_action_t * op)
     }
 
     if (op->synchronous == FALSE) {
-        return operation_finalize(op);
+        return services__finalize_async_op(op) == pcmk_rc_ok;
     }
     return op->rc == PCMK_OCF_OK;
 }

--- a/lib/services/upstart.h
+++ b/lib/services/upstart.h
@@ -15,7 +15,10 @@
 #  include "crm/services.h"
 
 G_GNUC_INTERNAL GList *upstart_job_listall(void);
-G_GNUC_INTERNAL gboolean upstart_job_exec(svc_action_t * op);
+
+G_GNUC_INTERNAL
+int services__execute_upstart(svc_action_t *op);
+
 G_GNUC_INTERNAL gboolean upstart_job_exists(const gchar * name);
 G_GNUC_INTERNAL void upstart_cleanup(void);
 


### PR DESCRIPTION
This is part of a larger project to ensure that libcrmservice always explicitly sets rc and status in svc_action_t results, rather than relying on the implicit defaults (PCMK_OCF_OK/PCMK_EXEC_DONE) or unconditionally overwriting them with error codes in the callers.