### PR TITLE
Add pacemaker(pacemaker-based) resource translatefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -72,6 +72,10 @@ DAEMON_R_DIRS	= $(CRM_CONFIG_DIR)	\
 DAEMON_RW_DIRS	= $(CRM_BUNDLE_DIR)	\
 		  $(CRM_LOG_DIR)
 
+install: install-recursive
+	msgfmt po/pacemaker.po -o /usr/share/locale/zh_CN/LC_MESSAGES/pacemaker.mo
+	msgfmt po/pacemaker_en.po -o /usr/share/locale/en_US/LC_MESSAGES/pacemaker.mo
+
 core:
 	@echo "Building only core components and tests: $(CORE)"
 	@for subdir in $(CORE); do \

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -94,6 +94,15 @@ main(int argc, char **argv)
     struct passwd *pwentry = NULL;
     crm_ipc_t *old_instance = NULL;
 
+    if( is_zh_language() ){
+         setlocale(LC_MESSAGES, "zh_CN.UTF-8");
+    }else{
+         setlocale(LC_MESSAGES, "en_US.UTF-8");
+    }
+    bindtextdomain(PACKAGE_NAME, PACKAGE_LOCALEDIR);
+    textdomain(PACKAGE_NAME);
+    bind_textdomain_codeset(PACKAGE_NAME, "UTF-8");
+
     crm_log_preinit(NULL, argc, argv);
     pcmk__set_cli_options(NULL, "[options]", long_options,
                           "daemon for managing the configuration "

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -43,6 +43,33 @@
 #  include <crm/common/xml_internal.h>
 #  include <crm/common/internal.h>
 
+#include <locale.h>
+#include <libintl.h>
+#define PACKAGE_NAME "pacemaker"
+#define PACKAGE_LOCALEDIR "/usr/share/locale/"
+#define _(x) gettext(x)
+
+static inline gboolean is_zh_language(void)
+{
+    FILE *fp = NULL;
+    char data[128] = {'0'};
+    char *p = NULL;
+    char* ret = NULL;
+    fp = fopen("/etc/locale.conf", "r");
+    if (fp == NULL){
+        return false;
+    }
+    ret = fgets(data, sizeof(data), fp);
+    if (ret == NULL){
+        return false;
+    }
+    p = strstr(data, "zh_CN");
+    if (p != NULL) {
+    	return true;
+    }
+    fclose(fp);
+    return false;
+}
 
 /*
  * XML attribute names used only by internal code

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -565,7 +565,7 @@ pcmk__print_option_metadata(const char *name, const char *version,
             "  <version>%s</version>\n"
             "  <longdesc lang=\"en\">%s</longdesc>\n"
             "  <shortdesc lang=\"en\">%s</shortdesc>\n"
-            "  <parameters>\n", name, version, desc_long, desc_short);
+            "  <parameters>\n", name, version, _(desc_long), _(desc_short));
 
     for (lpc = 0; lpc < len; lpc++) {
         if ((option_list[lpc].description_long == NULL)
@@ -578,14 +578,14 @@ pcmk__print_option_metadata(const char *name, const char *version,
                 "      <longdesc lang=\"en\">%s%s%s</longdesc>\n"
                 "    </parameter>\n",
                 option_list[lpc].name,
-                option_list[lpc].description_short,
+                _(option_list[lpc].description_short),
                 option_list[lpc].type,
                 option_list[lpc].default_value,
                 option_list[lpc].description_long?
-                    option_list[lpc].description_long :
-                    option_list[lpc].description_short,
-                (option_list[lpc].values? "  Allowed values: " : ""),
-                (option_list[lpc].values? option_list[lpc].values : ""));
+                    _(option_list[lpc].description_long) :
+                    _(option_list[lpc].description_short),
+                (option_list[lpc].values? _("  Allowed values: ") : ""),
+                (option_list[lpc].values? _(option_list[lpc].values) : ""));
     }
     fprintf(stdout, "  </parameters>\n</resource-agent>\n");
 }

--- a/po/pacemaker.po
+++ b/po/pacemaker.po
@@ -1,0 +1,65 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-12-11 15:59+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+
+#: lib/cib/cib_utils.c:619
+msgid "enable-acl"
+msgstr "启用ACL"
+
+#: lib/cib/cib_utils.c:621
+msgid "Enable Access Control Lists (ACLs) for the CIB"
+msgstr "为CIB启用访问控制列表(ACL)"
+
+#: lib/cib/cib_utils.c:625
+msgid "cluster-ipc-limit"
+msgstr "集群ipc限制"
+
+#: lib/cib/cib_utils.c:627
+msgid "Maximum IPC message backlog before disconnecting a cluster daemon"
+msgstr "断开集群守护程序之前的最大IPC消息积压"
+
+#: lib/cib/cib_utils.c:628
+msgid ""
+"Raise this if log has \"Evicting client\" messages for cluster daemon PIDs "
+"(a good value is the number of resources in the cluster multiplied by the "
+"number of nodes)."
+msgstr ""
+"如果日志中包含集群守护程序PID的“正在退出客户端”消息，请提高此值（这个值应该"
+"是集群中的资源数量乘以节点数量）"
+
+msgid ""
+"Zero disables polling, while positive values are an interval in seconds(unless other units are specified, for example \"5min\")"
+msgstr ""
+"设置为0将禁用轮询，设置为正数将是以秒为单位的时间间隔（除非使用了其他单位，比如\"5min\"表示5分钟）"
+
+msgid "Whether watchdog integration is enabled"
+msgstr "是否启用看门狗集成设置"
+
+msgid ""
+"    <longdesc lang=\"en\">Optional</longdesc>\n"
+msgstr "    <longdesc lang=\"zh\">选填</longdesc>\n"
+
+msgid "'%s' is not a valid agent specification"
+msgstr "'%s' 是一个无效的代理"
+
+msgid "Metadata query for %s failed: %s\n"
+msgstr "，查询%s的元数据失败: %s\n"
+
+msgid "No such device or address"
+msgstr "没有这种设备或地址"

--- a/po/pacemaker_en.po
+++ b/po/pacemaker_en.po
@@ -1,0 +1,67 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-12-11 15:59+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+
+#: lib/cib/cib_utils.c:619
+msgid "enable-acl"
+msgstr "enable-acl"
+
+#: lib/cib/cib_utils.c:621
+msgid "Enable Access Control Lists (ACLs) for the CIB"
+msgstr "Enable Access Control Lists (ACLs) for the CIB"
+
+#: lib/cib/cib_utils.c:625
+msgid "cluster-ipc-limit"
+msgstr "cluster-ipc-limit"
+
+#: lib/cib/cib_utils.c:627
+msgid "Maximum IPC message backlog before disconnecting a cluster daemon"
+msgstr "Maximum IPC message backlog before disconnecting a cluster daemon"
+
+#: lib/cib/cib_utils.c:628
+msgid ""
+"Raise this if log has \"Evicting client\" messages for cluster daemon PIDs "
+"(a good value is the number of resources in the cluster multiplied by the "
+"number of nodes)."
+msgstr ""
+"Raise this if log has \"Evicting client\" messages for cluster daemon PIDs "
+"(a good value is the number of resources in the cluster multiplied by the "
+"number of nodes)."
+
+msgid "Whether watchdog integration is enabled"
+msgstr "Whether watchdog integration is enabled"
+
+msgid ""
+"Zero disables polling, while positive values are an interval in seconds(unless other units are specified, for example \"5min\")"
+msgstr ""
+"Zero disables polling, while positive values are an interval in seconds(unless other units are specified, for example \"5min\")"
+
+msgid ""
+"    <longdesc lang=\"en\">Optional</longdesc>\n"
+msgstr ""
+"    <longdesc lang=\"en\">Optional</longdesc>\n"
+
+msgid "'%s' is not a valid agent specification"
+msgstr "'%s' is not a valid agent specification"
+
+msgid "Metadata query for %s failed: %s\n"
+msgstr ", Metadata query for %s failed: %s\n"
+
+msgid "No such device or address"
+msgstr "No such device or address"


### PR DESCRIPTION
In order to realize the support of Pacemaker for Chinese, the internationalization method was added, and the internationalization modification was gradually carried out based on Pacemaker -based.