### PR TITLE
Ensure libcrmservice always explicitly sets rc and status

### DIFF
--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -684,7 +684,7 @@ class Tests(object):
                      '-l "NEW_EVENT event_type:register rsc_id:test_rsc action:none rc:ok op_status:complete"')
         test.add_cmd('-c exec -r test_rsc -a start -k monitor_delay -v 30 ' +
                      '-t 1000 -w') # -t must be less than self.action_timeout
-        test.add_cmd('-l "NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:OCF_TIMEOUT op_status:Timed Out" '
+        test.add_cmd('-l "NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:start rc:error op_status:Timed Out" '
                      + self.action_timeout)
         test.add_cmd("-c exec -r test_rsc -a stop " + self.action_timeout +
                      "-l \"NEW_EVENT event_type:exec_complete rsc_id:test_rsc action:stop rc:ok op_status:complete\" ")

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -238,7 +238,7 @@ controld_record_action_timeout(crm_action_t *action)
      * to the executor.
      */
     op = pcmk__event_from_graph_action(NULL, action, PCMK_EXEC_TIMEOUT,
-                                       PCMK_OCF_TIMEOUT,
+                                       PCMK_OCF_UNKNOWN_ERROR,
                                        "Cluster communication timeout "
                                        "(no response from executor)");
     op->call_id = -1;

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1398,7 +1398,7 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
         goto exec_done;
     }
 
-    if (action->rc != PCMK_OCF_OK) {
+    if (action->rc != PCMK_OCF_UNKNOWN) {
         pcmk__set_result(&(cmd->result), action->rc, action->status, NULL);
         services_action_free(action);
         goto exec_done;

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -770,11 +770,6 @@ stonith2uniform_rc(const char *action, int rc)
             rc = PCMK_OCF_UNIMPLEMENT_FEATURE;
             break;
 
-        case -ETIME:
-        case -ETIMEDOUT:
-            rc = PCMK_OCF_TIMEOUT;
-            break;
-
         default:
             rc = PCMK_OCF_UNKNOWN_ERROR;
             break;
@@ -1060,7 +1055,7 @@ action_complete(svc_action_t * action)
                        cmd->rsc_id,
                        (cmd->real_action? cmd->real_action : cmd->action),
                        cmd->result.exit_status, time_sum, timeout_left);
-            pcmk__set_result(&(cmd->result), PCMK_OCF_TIMEOUT,
+            pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
                              PCMK_EXEC_TIMEOUT,
                              "Investigate reason for timeout, and adjust "
                              "configured operation timeout if necessary");

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1406,23 +1406,12 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
 
     action->cb_data = cmd;
 
-    /* 'cmd' may not be valid after this point if
-     * services_action_async() returned TRUE
-     *
-     * Upstart and systemd both synchronously determine monitor/status
-     * results and call action_complete (which may free 'cmd') if necessary.
-     */
     if (services_action_async(action, action_complete)) {
+        /* When services_action_async() returns TRUE, the callback might have
+         * been called -- in this case action_complete(), which might free cmd,
+         * so cmd cannot be used here.
+         */
         return TRUE;
-    }
-
-    /* Asynchronous execution could not be initiated. services_action_async()
-     * should have already set an appropriate execution status, but as a
-     * fail-safe for cases where we've neglected to do so, make sure this is
-     * considered an execution error.
-     */
-    if (action->status == PCMK_EXEC_DONE) {
-        action->status = PCMK_EXEC_ERROR;
     }
 
     pcmk__set_result(&(cmd->result), action->rc, action->status, NULL);

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -172,24 +172,20 @@ enum ocf_exitcode {
     PCMK_OCF_DEGRADED             = 190, //!< Service active but more likely to fail soon
     PCMK_OCF_DEGRADED_PROMOTED    = 191, //!< Service promoted but more likely to fail soon
 
-    /* The rest are Pacemaker extensions, not in the OCF standard. The executor
-     * returns PCMK_OCF_TIMEOUT for agent timeouts, and the controller records
-     * PCMK_OCF_UNKNOWN for pending actions, and PCMK_OCF_TIMEOUT for executor
-     * communication timeouts. PCMK_OCF_CONNECTION_DIED is used only with older
-     * DCs that don't support PCMK_EXEC_NOT_CONNECTED.
+    /* These two are Pacemaker extensions, not in the OCF standard. The
+     * controller records PCMK_OCF_UNKNOWN for pending actions.
+     * PCMK_OCF_CONNECTION_DIED is used only with older DCs that don't support
+     * PCMK_EXEC_NOT_CONNECTED.
      *
-     * @TODO These should be deprecated, and existing execution status codes
-     * (enum pcmk_exec_status) should be relied on for these instead
-     * (PCMK_EXEC_PENDING for the purposes of PCMK_OCF_UNKNOWN, and
-     * PCMK_EXEC_TIMEOUT for PCMK_OCF_TIMEOUT). It might be worthwhile to keep
-     * PCMK_OCF_UNKNOWN as an invalid value for initializing new action objects.
-     * However, backward compatibility must be considered (processing old saved
-     * CIB files, rolling upgrades with older DCs, older Pacemaker Remote nodes
-     * or connection hosts, and older bundles).
+     * @TODO PCMK_OCF_UNKNOWN should be deprecated, and an execution status of
+     * PCMK_EXEC_PENDING relied on instead (though it might be worthwhile to
+     * keep PCMK_OCF_UNKNOWN as an invalid value for initializing new action
+     * objects). However, backward compatibility must be considered (processing
+     * old saved CIB files, rolling upgrades with older DCs, older
+     * Pacemaker Remote nodes or connection hosts, and older bundles).
      */
     PCMK_OCF_CONNECTION_DIED      = 189, //!< \deprecated See PCMK_EXEC_NOT_CONNECTED
     PCMK_OCF_UNKNOWN              = 193, //!< Action is pending
-    PCMK_OCF_TIMEOUT              = 198, //!< Action did not complete in time
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     // Former Pacemaker extensions
@@ -198,6 +194,7 @@ enum ocf_exitcode {
     PCMK_OCF_NOT_SUPPORTED        = 195, //!< \deprecated (Unused)
     PCMK_OCF_PENDING              = 196, //!< \deprecated (Unused)
     PCMK_OCF_CANCELLED            = 197, //!< \deprecated (Unused)
+    PCMK_OCF_TIMEOUT              = 198, //!< \deprecated (Unused)
     PCMK_OCF_OTHER_ERROR          = 199, //!< \deprecated (Unused)
 
     //! \deprecated Use PCMK_OCF_RUNNING_PROMOTED instead

--- a/include/crm/services.h
+++ b/include/crm/services.h
@@ -331,8 +331,6 @@ gboolean services_alert_async(svc_action_t *action,
                 return "promoted";
             case PCMK_OCF_FAILED_PROMOTED:
                 return "promoted (failed)";
-            case PCMK_OCF_TIMEOUT:
-                return "OCF_TIMEOUT";
             case PCMK_OCF_DEGRADED:
                 return "OCF_DEGRADED";
             case PCMK_OCF_DEGRADED_PROMOTED:
@@ -349,6 +347,8 @@ gboolean services_alert_async(svc_action_t *action,
                 return "interrupted by signal (DEPRECATED STATUS)";
             case PCMK_OCF_PENDING:
                 return "pending (DEPRECATED STATUS)";
+            case PCMK_OCF_TIMEOUT:
+                return "timeout (DEPRECATED STATUS)";
 #endif
             default:
                 return "unknown";

--- a/include/crm/services_internal.h
+++ b/include/crm/services_internal.h
@@ -26,7 +26,8 @@ extern "C" {
  * \param[in] timeout     Consider action failed if it does not complete in this many milliseconds
  * \param[in] params      Action parameters
  *
- * \return newly allocated action instance
+ * \return NULL if not enough memory, otherwise newly allocated action instance
+ *         (if its rc member is not PCMK_OCF_UNKNOWN, the action is invalid)
  *
  * \post After the call, 'params' is owned, and later free'd by the svc_action_t result
  * \note The caller is responsible for freeing the return value using

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1969,7 +1969,7 @@ lrmd_api_get_metadata_params(lrmd_t *lrmd, const char *standard,
     if (action == NULL) {
         return -ENOMEM;
     }
-    if (action->rc != PCMK_OCF_OK) {
+    if (action->rc != PCMK_OCF_UNKNOWN) {
         services_action_free(action);
         return -EINVAL;
     }

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -606,7 +606,7 @@ services_action_cancel(const char *name, const char *action, guint interval_ms)
     /* If the op has a PID, it's an in-flight child process, so kill it.
      *
      * Whether the kill succeeds or fails, the main loop will send the op to
-     * operation_finished() (and thus services__finalize_async_op()) when the
+     * async_action_complete() (and thus services__finalize_async_op()) when the
      * process goes away.
      */
     if (op->pid != 0) {

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -866,7 +866,6 @@ handle_blocked_ops(void)
         }
         executed_ops = g_list_append(executed_ops, op);
         if (execute_action(op) != pcmk_rc_ok) {
-            op->status = PCMK_EXEC_ERROR;
             /* this can cause this function to be called recursively
              * which is why we have processing_blocked_ops static variable */
             services__finalize_async_op(op);

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -149,7 +149,7 @@ expand_resource_class(const char *rsc, const char *standard, const char *agent)
 
 /*!
  * \internal
- * \brief Create an uninitialized svc_action_t instance
+ * \brief Create a simple svc_action_t instance
  *
  * \return Newly allocated instance (or NULL if not enough memory)
  */
@@ -168,6 +168,9 @@ new_action(void)
         return NULL;
     }
 
+    // Initialize result
+    op->rc = PCMK_OCF_UNKNOWN;
+    op->status = PCMK_EXEC_UNKNOWN;
     return op;
 }
 
@@ -370,6 +373,10 @@ resources_action_create(const char *name, const char *standard,
         services_action_free(op);
         return NULL;
     } else {
+        // Preserve public API backward compatibility
+        op->rc = PCMK_OCF_OK;
+        op->status = PCMK_EXEC_DONE;
+
         return op;
     }
 }

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -1044,7 +1044,7 @@ services__execute_file(svc_action_t *op)
         close_pipe(stdout_fd);
         close_pipe(stderr_fd);
         sigchld_cleanup(&data);
-        op->rc = PCMK_OCF_UNKNOWN_ERROR;
+        op->rc = services__generic_error(op);
         op->status = PCMK_EXEC_ERROR;
         goto done;
     }

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -665,7 +665,7 @@ services__generic_error(svc_action_t *op)
 
 #if SUPPORT_NAGIOS
     if (pcmk__str_eq(op->standard, PCMK_RESOURCE_CLASS_NAGIOS, pcmk__str_casei)) {
-        return PCMK_OCF_UNKNOWN_ERROR;
+        return NAGIOS_STATE_UNKNOWN;
     }
 #endif
 

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -629,7 +629,7 @@ async_action_complete(mainloop_child_t *p, pid_t pid, int core, int signo,
     } else if (mainloop_child_timeout(p)) {
         crm_warn("%s[%d] timed out after %dms", op->id, op->pid, op->timeout);
         op->status = PCMK_EXEC_TIMEOUT;
-        op->rc = PCMK_OCF_TIMEOUT;
+        op->rc = services__generic_error(op);
 
     } else if (op->cancel) {
         /* If an in-flight recurring operation was killed because it was

--- a/lib/services/services_private.h
+++ b/lib/services/services_private.h
@@ -68,6 +68,15 @@ G_GNUC_INTERNAL
 int services__finalize_async_op(svc_action_t *op);
 
 G_GNUC_INTERNAL
+int services__generic_error(svc_action_t *op);
+
+G_GNUC_INTERNAL
+int services__not_installed_error(svc_action_t *op);
+
+G_GNUC_INTERNAL
+int services__authorization_error(svc_action_t *op);
+
+G_GNUC_INTERNAL
 void services__handle_exec_error(svc_action_t * op, int error);
 
 G_GNUC_INTERNAL

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1742,7 +1742,7 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
     op = services__create_resource_action(rsc_name? rsc_name : "test",
                                           rsc_class, rsc_prov, rsc_type, action,
                                           0, timeout_ms, params, 0);
-    if ((op == NULL) || (op->rc != PCMK_OCF_OK)) {
+    if ((op == NULL) || (op->rc != PCMK_OCF_UNKNOWN)) {
         const char *reason = NULL;
 
         if (op == NULL) {


### PR DESCRIPTION
This is the last in a series of PRs. Previous ones ensured rc and status were set for systemd and upstart actions; this one covers file-based actions (generic actions, alerts, and ocf, lsb, and nagios resource actions), along with related clean-ups. There is also one systemd-related fix for a longstanding (and unnoticed) issue.