### PR TITLE
Fixes for starting/stopping daemons

### DIFF
--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -20,6 +20,7 @@ typedef struct pcmk_child_s {
     const char *uid;
     const char *command;
     const char *endpoint;  /* IPC server name */
+    bool needs_cluster;
 
     bool active_before_startup;
 } pcmk_child_t;

--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -21,7 +21,7 @@ typedef struct pcmk_child_s {
     const char *command;
     const char *endpoint;  /* IPC server name */
 
-    gboolean active_before_startup;
+    bool active_before_startup;
 } pcmk_child_t;
 
 #define SIZEOF(a)   (sizeof(a) / sizeof(a[0]))

--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -11,7 +11,6 @@
 
 #include <stdint.h>
 
-#define SIZEOF(a)   (sizeof(a) / sizeof(a[0]))
 #define MAX_RESPAWN		100
 
 extern GMainLoop *mainloop;

--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -11,20 +11,6 @@
 
 #include <stdint.h>
 
-typedef struct pcmk_child_s {
-    pid_t pid;
-    int start_seq;
-    int respawn_count;
-    bool respawn;
-    const char *name;
-    const char *uid;
-    const char *command;
-    const char *endpoint;  /* IPC server name */
-    bool needs_cluster;
-
-    bool active_before_startup;
-} pcmk_child_t;
-
 #define SIZEOF(a)   (sizeof(a) / sizeof(a[0]))
 #define MAX_RESPAWN		100
 

--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -15,7 +15,7 @@ typedef struct pcmk_child_s {
     pid_t pid;
     int start_seq;
     int respawn_count;
-    gboolean respawn;
+    bool respawn;
     const char *name;
     const char *uid;
     const char *command;

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -31,31 +31,37 @@
 
 static pcmk_child_t pcmk_children[] = {
     {
-        0, 0, 0, false, "none", NULL, NULL, NULL
+        0, 0, 0, false, "none", NULL, NULL, NULL, false
     },
     {
         0, 3, 0, true,  "pacemaker-execd", NULL,
-        CRM_DAEMON_DIR "/pacemaker-execd", CRM_SYSTEM_LRMD
+        CRM_DAEMON_DIR "/pacemaker-execd", CRM_SYSTEM_LRMD,
+        false
     },
     {
         0, 1, 0, true,  "pacemaker-based", CRM_DAEMON_USER,
-        CRM_DAEMON_DIR "/pacemaker-based", PCMK__SERVER_BASED_RO
+        CRM_DAEMON_DIR "/pacemaker-based", PCMK__SERVER_BASED_RO,
+        true
     },
     {
         0, 6, 0, true, "pacemaker-controld", CRM_DAEMON_USER,
-        CRM_DAEMON_DIR "/pacemaker-controld", CRM_SYSTEM_CRMD
+        CRM_DAEMON_DIR "/pacemaker-controld", CRM_SYSTEM_CRMD,
+        true
     },
     {
         0, 4, 0, true, "pacemaker-attrd", CRM_DAEMON_USER,
-        CRM_DAEMON_DIR "/pacemaker-attrd", T_ATTRD
+        CRM_DAEMON_DIR "/pacemaker-attrd", T_ATTRD,
+        false
     },
     {
         0, 5, 0, true, "pacemaker-schedulerd", CRM_DAEMON_USER,
-        CRM_DAEMON_DIR "/pacemaker-schedulerd", CRM_SYSTEM_PENGINE
+        CRM_DAEMON_DIR "/pacemaker-schedulerd", CRM_SYSTEM_PENGINE,
+        true
     },
     {
         0, 2, 0, true, "pacemaker-fenced", NULL,
-        CRM_DAEMON_DIR "/pacemaker-fenced", "stonith-ng"
+        CRM_DAEMON_DIR "/pacemaker-fenced", "stonith-ng",
+        true
     },
 };
 

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -117,7 +117,7 @@ check_active_before_startup_processes(gpointer user_data)
 {
     gboolean keep_tracking = FALSE;
 
-    for (int i = 0; i < SIZEOF(pcmk_children); i++) {
+    for (int i = 0; i < PCMK__NELEM(pcmk_children); i++) {
         if (!pcmk_children[i].active_before_startup) {
             /* we are already tracking it as a child process. */
             continue;
@@ -259,10 +259,10 @@ pcmk_process_exit(pcmk_child_t * child)
 static gboolean
 pcmk_shutdown_worker(gpointer user_data)
 {
-    static int phase = SIZEOF(pcmk_children) - 1;
+    static int phase = PCMK__NELEM(pcmk_children) - 1;
     static time_t next_log = 0;
 
-    if (phase == SIZEOF(pcmk_children) - 1) {
+    if (phase == PCMK__NELEM(pcmk_children) - 1) {
         crm_notice("Shutting down Pacemaker");
         pacemakerd_state = XML_PING_ATTR_PACEMAKERDSTATE_SHUTTINGDOWN;
     }
@@ -633,7 +633,7 @@ find_and_track_existing_processes(void)
 
     for (rounds = 1; rounds <= WAIT_TRIES; rounds++) {
         wait_in_progress = false;
-        for (i = 0; i < SIZEOF(pcmk_children); i++) {
+        for (i = 0; i < PCMK__NELEM(pcmk_children); i++) {
 
             if ((pcmk_children[i].endpoint == NULL)
                 || (pcmk_children[i].respawn_count < 0)) {
@@ -725,7 +725,7 @@ find_and_track_existing_processes(void)
         }
         pcmk__sleep_ms(250); // Wait a bit for changes to possibly happen
     }
-    for (i = 0; i < SIZEOF(pcmk_children); i++) {
+    for (i = 0; i < PCMK__NELEM(pcmk_children); i++) {
         pcmk_children[i].respawn_count = 0;  /* restore pristine state */
     }
 
@@ -740,7 +740,7 @@ gboolean
 init_children_processes(void *user_data)
 {
     /* start any children that have not been detected */
-    for (int i = 0; i < SIZEOF(pcmk_children); i++) {
+    for (int i = 0; i < PCMK__NELEM(pcmk_children); i++) {
         if (pcmk_children[i].pid != 0) {
             /* we are already tracking it */
             continue;

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -105,7 +105,7 @@ check_active_before_startup_processes(gpointer user_data)
 
     for (start_seq = 1; start_seq < max; start_seq++) {
         for (lpc = 0; lpc < max; lpc++) {
-            if (pcmk_children[lpc].active_before_startup == FALSE) {
+            if (!pcmk_children[lpc].active_before_startup) {
                 /* we are already tracking it as a child process. */
                 continue;
             } else if (start_seq != pcmk_children[lpc].start_seq) {
@@ -209,7 +209,7 @@ static void
 pcmk_process_exit(pcmk_child_t * child)
 {
     child->pid = 0;
-    child->active_before_startup = FALSE;
+    child->active_before_startup = false;
 
     child->respawn_count += 1;
     if (child->respawn_count > MAX_RESPAWN) {
@@ -233,7 +233,7 @@ pcmk_process_exit(pcmk_child_t * child)
                  " appears alright per %s IPC end-point",
                  child->name, child->endpoint);
         /* need to monitor how it evolves, and start new process if badly */
-        child->active_before_startup = TRUE;
+        child->active_before_startup = true;
         if (!global_keep_tracking) {
             global_keep_tracking = true;
             g_timeout_add_seconds(PCMK_PROCESS_CHECK_INTERVAL,
@@ -354,7 +354,7 @@ start_child(pcmk_child_t * child)
     const char *env_valgrind = getenv("PCMK_valgrind_enabled");
     const char *env_callgrind = getenv("PCMK_callgrind_enabled");
 
-    child->active_before_startup = FALSE;
+    child->active_before_startup = false;
 
     if (child->command == NULL) {
         crm_info("Nothing to do for child \"%s\"", child->name);
@@ -694,7 +694,7 @@ find_and_track_existing_processes(void)
                                (long long) PCMK__SPECIAL_PID_AS_0(
                                                pcmk_children[i].pid));
                     pcmk_children[i].respawn_count = -1;  /* 0~keep watching */
-                    pcmk_children[i].active_before_startup = TRUE;
+                    pcmk_children[i].active_before_startup = true;
                     tracking = true;
                     break;
                 case pcmk_rc_ipc_pid_only:

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -23,6 +23,20 @@
 #include <crm/cluster.h>
 #include <crm/msg_xml.h>
 
+typedef struct pcmk_child_s {
+    pid_t pid;
+    int start_seq;
+    int respawn_count;
+    bool respawn;
+    const char *name;
+    const char *uid;
+    const char *command;
+    const char *endpoint;  /* IPC server name */
+    bool needs_cluster;
+
+    bool active_before_startup;
+} pcmk_child_t;
+
 #define PCMK_PROCESS_CHECK_INTERVAL 5
 #define SHUTDOWN_ESCALATION_PERIOD 180000  /* 3m */
 

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -31,30 +31,30 @@
 
 static pcmk_child_t pcmk_children[] = {
     {
-        0, 0, 0, FALSE, "none", NULL, NULL, NULL
+        0, 0, 0, false, "none", NULL, NULL, NULL
     },
     {
-        0, 3, 0, TRUE,  "pacemaker-execd", NULL,
+        0, 3, 0, true,  "pacemaker-execd", NULL,
         CRM_DAEMON_DIR "/pacemaker-execd", CRM_SYSTEM_LRMD
     },
     {
-        0, 1, 0, TRUE,  "pacemaker-based", CRM_DAEMON_USER,
+        0, 1, 0, true,  "pacemaker-based", CRM_DAEMON_USER,
         CRM_DAEMON_DIR "/pacemaker-based", PCMK__SERVER_BASED_RO
     },
     {
-        0, 6, 0, TRUE, "pacemaker-controld", CRM_DAEMON_USER,
+        0, 6, 0, true, "pacemaker-controld", CRM_DAEMON_USER,
         CRM_DAEMON_DIR "/pacemaker-controld", CRM_SYSTEM_CRMD
     },
     {
-        0, 4, 0, TRUE, "pacemaker-attrd", CRM_DAEMON_USER,
+        0, 4, 0, true, "pacemaker-attrd", CRM_DAEMON_USER,
         CRM_DAEMON_DIR "/pacemaker-attrd", T_ATTRD
     },
     {
-        0, 5, 0, TRUE, "pacemaker-schedulerd", CRM_DAEMON_USER,
+        0, 5, 0, true, "pacemaker-schedulerd", CRM_DAEMON_USER,
         CRM_DAEMON_DIR "/pacemaker-schedulerd", CRM_SYSTEM_PENGINE
     },
     {
-        0, 2, 0, TRUE, "pacemaker-fenced", NULL,
+        0, 2, 0, true, "pacemaker-fenced", NULL,
         CRM_DAEMON_DIR "/pacemaker-fenced", "stonith-ng"
     },
 };
@@ -118,7 +118,7 @@ check_active_before_startup_processes(gpointer user_data)
                         break;
                     case pcmk_rc_ipc_unresponsive:
                     case pcmk_rc_ipc_pid_only: // This case: it was previously OK
-                        if (pcmk_children[lpc].respawn == TRUE) {
+                        if (pcmk_children[lpc].respawn) {
                             crm_err("%s[%lld] terminated%s", pcmk_children[lpc].name,
                                     (long long) PCMK__SPECIAL_PID_AS_0(pcmk_children[lpc].pid),
                                     (rc == pcmk_rc_ipc_pid_only)? " as IPC server" : "");
@@ -182,14 +182,14 @@ pcmk_child_exit(mainloop_child_t * p, pid_t pid, int core, int signo, int exitco
             case CRM_EX_FATAL:
                 crm_warn("Shutting cluster down because %s[%d] had fatal failure",
                          name, pid);
-                child->respawn = FALSE;
+                child->respawn = false;
                 fatal_error = TRUE;
                 pcmk_shutdown(SIGTERM);
                 break;
 
             case CRM_EX_PANIC:
                 crm_emerg("%s[%d] instructed the machine to reset", name, pid);
-                child->respawn = FALSE;
+                child->respawn = false;
                 fatal_error = TRUE;
                 pcmk__panic(__func__);
                 pcmk_shutdown(SIGTERM);
@@ -214,7 +214,7 @@ pcmk_process_exit(pcmk_child_t * child)
     child->respawn_count += 1;
     if (child->respawn_count > MAX_RESPAWN) {
         crm_err("Child respawn count exceeded by %s", child->name);
-        child->respawn = FALSE;
+        child->respawn = false;
     }
 
     if (shutdown_trigger) {
@@ -286,7 +286,7 @@ pcmk_shutdown_worker(gpointer user_data)
                                  child->command);
                     }
                     next_log = now + 30;
-                    child->respawn = FALSE;
+                    child->respawn = false;
                     stop_child(child, SIGTERM);
                     if (phase < pcmk_children[PCMK_CHILD_CONTROLD].start_seq) {
                         g_timeout_add(SHUTDOWN_ESCALATION_PERIOD,


### PR DESCRIPTION
The one thing not done in this patch set yet is dealing with the start_child return value.  If this returns FALSE, we should shut down previously started processes and quit.  However, I've not been able to make much progress on that.  First, a lot of our process shutdown code assumes the presence of a main loop which we will not have when daemons are first being started.

Second, processes may take some time to start and be ready to receive the shutdown signal.  In the time they are doing that, the main pacemakerd process may have already sent the signal.  This will get missed by the subdaemon and pacemakerd will be left spinning endlessly in pcmk_shutdown_worker, logging "Still waiting for %s to terminate".  I'm not sure what to do about this.