### PR TITLE
Add exit reasons for internal libcrmservice errors

### DIFF
--- a/daemons/execd/execd_alerts.c
+++ b/daemons/execd/execd_alerts.c
@@ -122,6 +122,11 @@ process_lrmd_alert_exec(pcmk__client_t *client, uint32_t id, xmlNode *request)
 
     action = services_alert_create(alert_id, alert_path, alert_timeout, params,
                                    alert_sequence_no, cb_data);
+    if (action->rc != PCMK_OCF_UNKNOWN) {
+        rc = -E2BIG;
+        goto err;
+    }
+
     rc = services_action_user(action, CRM_DAEMON_USER);
     if (rc < 0) {
         goto err;

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -937,7 +937,7 @@ action_complete(svc_action_t * action)
 
     cmd->last_pid = action->pid;
     pcmk__set_result(&(cmd->result), action_get_uniform_rc(action),
-                     action->status, NULL);
+                     action->status, services__exit_reason(action));
     rsc = cmd->rsc_id ? g_hash_table_lookup(rsc_list, cmd->rsc_id) : NULL;
 
 #ifdef PCMK__TIME_USE_CGT
@@ -1399,7 +1399,8 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
     }
 
     if (action->rc != PCMK_OCF_UNKNOWN) {
-        pcmk__set_result(&(cmd->result), action->rc, action->status, NULL);
+        pcmk__set_result(&(cmd->result), action->rc, action->status,
+                         services__exit_reason(action));
         services_action_free(action);
         goto exec_done;
     }
@@ -1414,7 +1415,8 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
         return TRUE;
     }
 
-    pcmk__set_result(&(cmd->result), action->rc, action->status, NULL);
+    pcmk__set_result(&(cmd->result), action->rc, action->status,
+                     services__exit_reason(action));
     services_action_free(action);
     action = NULL;
 

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1349,11 +1349,9 @@ lrmd_rsc_execute_service_lib(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
                                      cmd->interval_ms, cmd->timeout,
                                      params_copy, cmd->service_flags);
 
-    if (!action) {
-        // Invalid arguments (which would be a bug) or out-of-memory
-        crm_err("Failed to create action, action:%s on resource %s", cmd->action, rsc->rsc_id);
+    if (action == NULL) {
         pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
-                         PCMK_EXEC_ERROR, "Internal Pacemaker error");
+                         PCMK_EXEC_ERROR, strerror(ENOMEM));
         goto exec_done;
     }
 

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -30,8 +30,6 @@
 
 #include "pacemaker-execd.h"
 
-#define EXIT_REASON_MAX_LEN 128
-
 GHashTable *rsc_list = NULL;
 
 typedef struct lrmd_cmd_s {
@@ -860,41 +858,6 @@ notify_of_new_client(pcmk__client_t *new_client)
     free_xml(data.notify);
 }
 
-static char *
-parse_exit_reason(const char *output)
-{
-    const char *cur = NULL;
-    const char *last = NULL;
-    static int cookie_len = 0;
-    char *eol = NULL;
-    size_t reason_len = EXIT_REASON_MAX_LEN;
-
-    if (output == NULL) {
-        return NULL;
-    }
-
-    if (!cookie_len) {
-        cookie_len = strlen(PCMK_OCF_REASON_PREFIX);
-    }
-
-    cur = strstr(output, PCMK_OCF_REASON_PREFIX);
-    for (; cur != NULL; cur = strstr(cur, PCMK_OCF_REASON_PREFIX)) {
-        /* skip over the cookie delimiter string */
-        cur += cookie_len;
-        last = cur;
-    }
-    if (last == NULL) {
-        return NULL;
-    }
-
-    // Truncate everything after a new line, and limit reason string size
-    eol = strchr(last, '\n');
-    if (eol) {
-        reason_len = QB_MIN(reason_len, eol - last);
-    }
-    return strndup(last, reason_len);
-}
-
 void
 client_disconnect_cleanup(const char *client_id)
 {
@@ -1066,10 +1029,6 @@ action_complete(svc_action_t * action)
 
     pcmk__set_result_output(&(cmd->result),
                             action->stdout_data, action->stderr_data);
-    if (action->stderr_data) {
-        cmd->result.exit_reason = parse_exit_reason(action->stderr_data);
-    }
-
     cmd_finalize(cmd, rsc);
 }
 

--- a/include/crm/services_internal.h
+++ b/include/crm/services_internal.h
@@ -39,6 +39,8 @@ svc_action_t *services__create_resource_action(const char *name, const char *sta
                                       int timeout /* ms */, GHashTable *params,
                                       enum svc_action_flags flags);
 
+const char *services__exit_reason(svc_action_t *action);
+
 #  ifdef __cplusplus
 }
 #  endif

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -854,6 +854,12 @@ internal_stonith_action_execute(stonith_action_t * action)
                                basename(action->agent));
     svc_action = services_action_create_generic(buffer, NULL);
     free(buffer);
+
+    if (svc_action->rc != PCMK_OCF_UNKNOWN) {
+        services_action_free(svc_action);
+        return -E2BIG;
+    }
+
     svc_action->timeout = 1000 * action->remaining_timeout;
     svc_action->standard = strdup(PCMK_RESOURCE_CLASS_STONITH);
     svc_action->id = crm_strdup_printf("%s_%s_%d", basename(action->agent),

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -573,6 +573,7 @@ services_action_free(svc_action_t * op)
         free(op->opaque->args[i]);
     }
 
+    free(op->opaque->exit_reason);
     free(op->opaque);
     free(op->rsc);
     free(op->action);
@@ -1210,4 +1211,45 @@ done:
     g_list_free(standards);
     g_list_free(providers);
     return rc;
+}
+
+/*!
+ * \internal
+ * \brief Set the result of an action
+ *
+ * \param[out] action        Where to set action result
+ * \param[in]  agent_status  Exit status to set
+ * \param[in]  exec_status   Execution status to set
+ * \param[in]  reason        Human-friendly description of event to set
+ */
+void
+services__set_result(svc_action_t *action, int agent_status,
+                     enum pcmk_exec_status exec_status, const char *reason)
+{
+    if (action == NULL) {
+        return;
+    }
+
+    action->rc = agent_status;
+    action->status = exec_status;
+
+    if (!pcmk__str_eq(action->opaque->exit_reason, reason,
+                      pcmk__str_none)) {
+        free(action->opaque->exit_reason);
+        action->opaque->exit_reason = (reason == NULL)? NULL : strdup(reason);
+    }
+}
+
+/*!
+ * \internal
+ * \brief Get the exit reason of an action
+ *
+ * \param[in] action  Action to check
+ *
+ * \return Action's exit reason (or NULL if none)
+ */
+const char *
+services__exit_reason(svc_action_t *action)
+{
+    return action->opaque->exit_reason;
 }

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -169,8 +169,7 @@ new_action(void)
     }
 
     // Initialize result
-    op->rc = PCMK_OCF_UNKNOWN;
-    op->status = PCMK_EXEC_UNKNOWN;
+    services__set_result(op, PCMK_OCF_UNKNOWN, PCMK_EXEC_UNKNOWN, NULL);
     return op;
 }
 
@@ -263,8 +262,9 @@ services__create_resource_action(const char *name, const char *standard,
         if (pcmk__str_empty(OCF_RA_PATH)) {
             crm_err("Cannot execute OCF actions because resource agent path "
                     "was not configured in this build");
-            op->rc = PCMK_OCF_UNKNOWN_ERROR;
-            op->status = PCMK_EXEC_ERROR_HARD;
+            services__set_result(op, PCMK_OCF_UNKNOWN_ERROR,
+                                 PCMK_EXEC_ERROR_HARD,
+                                 NULL);
             return op;
         }
 
@@ -672,7 +672,7 @@ services_action_cancel(const char *name, const char *action, guint interval_ms)
      */
 
     // Report operation as cancelled
-    op->status = PCMK_EXEC_CANCELLED;
+    services__set_result(op, op->rc, PCMK_EXEC_CANCELLED, NULL);
     if (op->opaque->callback) {
         op->opaque->callback(op);
     }
@@ -932,16 +932,16 @@ execute_metadata_action(svc_action_t *op)
 
     if (op->agent == NULL) {
         crm_err("meta-data requested without specifying agent");
-        op->rc = services__generic_error(op);
-        op->status = PCMK_EXEC_ERROR_FATAL;
+        services__set_result(op, services__generic_error(op),
+                             PCMK_EXEC_ERROR_FATAL, NULL);
         return EINVAL;
     }
 
     if (class == NULL) {
         crm_err("meta-data requested for agent %s without specifying class",
                 op->agent);
-        op->rc = services__generic_error(op);
-        op->status = PCMK_EXEC_ERROR_FATAL;
+        services__set_result(op, services__generic_error(op),
+                             PCMK_EXEC_ERROR_FATAL, NULL);
         return EINVAL;
     }
 
@@ -951,8 +951,8 @@ execute_metadata_action(svc_action_t *op)
     if (class == NULL) {
         crm_err("meta-data requested for %s, but could not determine class",
                 op->agent);
-        op->rc = services__generic_error(op);
-        op->status = PCMK_EXEC_ERROR_HARD;
+        services__set_result(op, services__generic_error(op),
+                             PCMK_EXEC_ERROR_HARD, NULL);
         return EINVAL;
     }
 

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -264,7 +264,7 @@ services__create_resource_action(const char *name, const char *standard,
                     "was not configured in this build");
             services__set_result(op, PCMK_OCF_UNKNOWN_ERROR,
                                  PCMK_EXEC_ERROR_HARD,
-                                 NULL);
+                                 "No OCF agent path configured in build");
             return op;
         }
 
@@ -933,7 +933,7 @@ execute_metadata_action(svc_action_t *op)
     if (op->agent == NULL) {
         crm_err("meta-data requested without specifying agent");
         services__set_result(op, services__generic_error(op),
-                             PCMK_EXEC_ERROR_FATAL, NULL);
+                             PCMK_EXEC_ERROR_FATAL, "Agent not specified");
         return EINVAL;
     }
 
@@ -941,7 +941,8 @@ execute_metadata_action(svc_action_t *op)
         crm_err("meta-data requested for agent %s without specifying class",
                 op->agent);
         services__set_result(op, services__generic_error(op),
-                             PCMK_EXEC_ERROR_FATAL, NULL);
+                             PCMK_EXEC_ERROR_FATAL,
+                             "Agent standard not specified");
         return EINVAL;
     }
 
@@ -952,7 +953,8 @@ execute_metadata_action(svc_action_t *op)
         crm_err("meta-data requested for %s, but could not determine class",
                 op->agent);
         services__set_result(op, services__generic_error(op),
-                             PCMK_EXEC_ERROR_HARD, NULL);
+                             PCMK_EXEC_ERROR_HARD,
+                             "Agent standard could not be determined");
         return EINVAL;
     }
 

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -406,13 +406,20 @@ services__create_resource_action(const char *name, const char *standard,
             GHashTableIter iter;
             char *key = NULL;
             char *value = NULL;
-            int index = 1;
-            static int args_size = sizeof(op->opaque->args) / sizeof(char *);
+            int index = 1; // 0 is already set to executable name
 
             g_hash_table_iter_init(&iter, op->params);
 
-            while (g_hash_table_iter_next(&iter, (gpointer *) & key, (gpointer *) & value) &&
-                   index <= args_size - 3) {
+            while (g_hash_table_iter_next(&iter, (gpointer *) & key, (gpointer *) & value)) {
+
+                if (index > (PCMK__NELEM(op->opaque->args) - 2)) {
+                    crm_info("Cannot prepare %s action for %s: Too many parameters",
+                             action, name);
+                    services__set_result(op, NAGIOS_STATE_UNKNOWN,
+                                         PCMK_EXEC_ERROR_HARD,
+                                         "Too many parameters");
+                    break;
+                }
 
                 if (pcmk__str_eq(key, XML_ATTR_CRM_VERSION, pcmk__str_casei) || strstr(key, CRM_META "_")) {
                     continue;

--- a/lib/services/services_private.h
+++ b/lib/services/services_private.h
@@ -21,6 +21,7 @@
 #define MAX_ARGC        255
 struct svc_action_private_s {
     char *exec;
+    char *exit_reason;
     char *args[MAX_ARGC];
 
     uid_t uid;
@@ -87,6 +88,11 @@ void services_untrack_op(svc_action_t *op);
 
 G_GNUC_INTERNAL
 gboolean is_op_blocked(const char *rsc);
+
+G_GNUC_INTERNAL
+void services__set_result(svc_action_t *action, int agent_status,
+                          enum pcmk_exec_status exec_status,
+                          const char *exit_reason);
 
 #if SUPPORT_DBUS
 G_GNUC_INTERNAL

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -238,8 +238,7 @@ systemd_daemon_reload(int timeout)
 static void
 set_result_from_method_error(svc_action_t *op, const DBusError *error)
 {
-    op->rc = PCMK_OCF_UNKNOWN_ERROR;
-    op->status = PCMK_EXEC_ERROR;
+    services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR, NULL);
 
     if (strstr(error->name, "org.freedesktop.systemd1.InvalidName")
         || strstr(error->name, "org.freedesktop.systemd1.LoadFailed")
@@ -249,13 +248,12 @@ set_result_from_method_error(svc_action_t *op, const DBusError *error)
             crm_trace("Masking systemd stop failure (%s) for %s "
                       "because unknown service can be considered stopped",
                       error->name, crm_str(op->rsc));
-            op->rc = PCMK_OCF_OK;
-            op->status = PCMK_EXEC_DONE;
+            services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
             return;
         }
 
-        op->rc = PCMK_OCF_NOT_INSTALLED;
-        op->status = PCMK_EXEC_NOT_INSTALLED;
+        services__set_result(op, PCMK_OCF_NOT_INSTALLED,
+                             PCMK_EXEC_NOT_INSTALLED, NULL);
     }
 
     crm_err("DBus request for %s of systemd unit %s for resource %s failed: %s",
@@ -290,8 +288,8 @@ execute_after_loadunit(DBusMessage *reply, svc_action_t *op)
     } else if (!pcmk_dbus_type_check(reply, NULL, DBUS_TYPE_OBJECT_PATH,
                                      __func__, __LINE__)) {
         if (op != NULL) {
-            op->rc = PCMK_OCF_UNKNOWN_ERROR;
-            op->status = PCMK_EXEC_ERROR;
+            services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                                 NULL);
             crm_err("Could not load systemd unit %s for %s: "
                     "DBus reply has unexpected type", op->agent, op->id);
         } else {
@@ -310,8 +308,8 @@ execute_after_loadunit(DBusMessage *reply, svc_action_t *op)
             invoke_unit_by_path(op, path);
 
         } else if (!(op->synchronous)) {
-            op->rc = PCMK_OCF_UNKNOWN_ERROR;
-            op->status = PCMK_EXEC_ERROR;
+            services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                                 NULL);
             services__finalize_async_op(op);
         }
     }
@@ -375,8 +373,8 @@ invoke_unit_by_name(const char *arg_name, svc_action_t *op, char **path)
 
     if (!systemd_init()) {
         if (op != NULL) {
-            op->rc = PCMK_OCF_UNKNOWN_ERROR;
-            op->status = PCMK_EXEC_ERROR;
+            services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                                 NULL);
         }
         return ENOTCONN;
     }
@@ -429,15 +427,14 @@ invoke_unit_by_name(const char *arg_name, svc_action_t *op, char **path)
     // For asynchronous ops, initiate the LoadUnit call and return
     pending = systemd_send(msg, loadunit_completed, op, op->timeout);
     if (pending == NULL) {
-        op->rc = PCMK_OCF_UNKNOWN_ERROR;
-        op->status = PCMK_EXEC_ERROR;
+        services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                             NULL);
         dbus_message_unref(msg);
         return ECOMM;
     }
 
     // LoadUnit was successfully initiated
-    op->rc = PCMK_OCF_UNKNOWN;
-    op->status = PCMK_EXEC_PENDING;
+    services__set_result(op, PCMK_OCF_UNKNOWN, PCMK_EXEC_PENDING, NULL);
     services_set_op_pending(op, pending);
     dbus_message_unref(msg);
     return pcmk_rc_ok;
@@ -657,8 +654,7 @@ process_unit_method_reply(DBusMessage *reply, svc_action_t *op)
                                      __func__, __LINE__)) {
         crm_warn("DBus request for %s of %s succeeded but "
                  "return type was unexpected", op->action, crm_str(op->rsc));
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
 
     } else {
         const char *path = NULL;
@@ -668,8 +664,7 @@ process_unit_method_reply(DBusMessage *reply, svc_action_t *op)
                               DBUS_TYPE_INVALID);
         crm_debug("DBus request for %s of %s using %s succeeded",
                   op->action, crm_str(op->rsc), path);
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
     }
 }
 
@@ -825,24 +820,19 @@ parse_status_result(const char *name, const char *state, void *userdata)
               crm_str(op->rsc), name, crm_str(state));
 
     if (pcmk__str_eq(state, "active", pcmk__str_none)) {
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
 
     } else if (pcmk__str_eq(state, "reloading", pcmk__str_none)) {
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
 
     } else if (pcmk__str_eq(state, "activating", pcmk__str_none)) {
-        op->rc = PCMK_OCF_UNKNOWN;
-        op->status = PCMK_EXEC_PENDING;
+        services__set_result(op, PCMK_OCF_UNKNOWN, PCMK_EXEC_PENDING, NULL);
 
     } else if (pcmk__str_eq(state, "deactivating", pcmk__str_none)) {
-        op->rc = PCMK_OCF_UNKNOWN;
-        op->status = PCMK_EXEC_PENDING;
+        services__set_result(op, PCMK_OCF_UNKNOWN, PCMK_EXEC_PENDING, NULL);
 
     } else {
-        op->rc = PCMK_OCF_NOT_RUNNING;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_NOT_RUNNING, PCMK_EXEC_DONE, NULL);
     }
 
     if (!(op->synchronous)) {
@@ -878,8 +868,8 @@ invoke_unit_by_path(svc_action_t *op, const char *unit)
             free(state);
 
         } else if (pending == NULL) { // Could not get ActiveState property
-            op->rc = PCMK_OCF_UNKNOWN_ERROR;
-            op->status = PCMK_EXEC_ERROR;
+            services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                                 NULL);
             services__finalize_async_op(op);
 
         } else {
@@ -899,8 +889,8 @@ invoke_unit_by_path(svc_action_t *op, const char *unit)
         method = "RestartUnit";
 
     } else {
-        op->rc = PCMK_OCF_UNIMPLEMENT_FEATURE;
-        op->status = PCMK_EXEC_ERROR;
+        services__set_result(op, PCMK_OCF_UNIMPLEMENT_FEATURE, PCMK_EXEC_ERROR,
+                             NULL);
         if (!(op->synchronous)) {
             services__finalize_async_op(op);
         }
@@ -938,8 +928,8 @@ invoke_unit_by_path(svc_action_t *op, const char *unit)
 
         dbus_message_unref(msg);
         if (pending == NULL) {
-            op->rc = PCMK_OCF_UNKNOWN_ERROR;
-            op->status = PCMK_EXEC_ERROR;
+            services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                                 NULL);
             services__finalize_async_op(op);
 
         } else {
@@ -955,8 +945,7 @@ systemd_timeout_callback(gpointer p)
 
     op->opaque->timerid = 0;
     crm_warn("%s operation on systemd unit %s named '%s' timed out", op->action, op->agent, op->rsc);
-    op->rc = PCMK_OCF_UNKNOWN_ERROR;
-    op->status = PCMK_EXEC_TIMEOUT;
+    services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_TIMEOUT, NULL);
     services__finalize_async_op(op);
     return FALSE;
 }
@@ -983,14 +972,14 @@ services__execute_systemd(svc_action_t *op)
     CRM_ASSERT(op != NULL);
 
     if ((op->action == NULL) || (op->agent == NULL)) {
-        op->rc = PCMK_OCF_NOT_CONFIGURED;
-        op->status = PCMK_EXEC_ERROR_FATAL;
+        services__set_result(op, PCMK_OCF_NOT_CONFIGURED, PCMK_EXEC_ERROR_FATAL,
+                             NULL);
         goto done;
     }
 
     if (!systemd_init()) {
-        op->rc = PCMK_OCF_UNKNOWN_ERROR;
-        op->status = PCMK_EXEC_ERROR;
+        services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                             NULL);
         goto done;
     }
 
@@ -1000,16 +989,14 @@ services__execute_systemd(svc_action_t *op)
 
     if (pcmk__str_eq(op->action, "meta-data", pcmk__str_casei)) {
         op->stdout_data = systemd_unit_metadata(op->agent, op->timeout);
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
         goto done;
     }
 
     /* invoke_unit_by_name() should always override these values, which are here
      * just as a fail-safe in case there are any code paths that neglect to
      */
-    op->rc = PCMK_OCF_UNKNOWN_ERROR;
-    op->status = PCMK_EXEC_ERROR;
+    services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR, NULL);
 
     if (invoke_unit_by_name(op->agent, op, NULL) == pcmk_rc_ok) {
         op->opaque->timerid = g_timeout_add(op->timeout + 5000,

--- a/lib/services/upstart.c
+++ b/lib/services/upstart.c
@@ -326,11 +326,9 @@ parse_status_result(const char *name, const char *state, void *userdata)
     svc_action_t *op = userdata;
 
     if (pcmk__str_eq(state, "running", pcmk__str_none)) {
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
     } else {
-        op->rc = PCMK_OCF_NOT_RUNNING;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_NOT_RUNNING, PCMK_EXEC_DONE, NULL);
     }
 
     if (!(op->synchronous)) {
@@ -376,8 +374,7 @@ upstart_job_metadata(const char *name)
 static void
 set_result_from_method_error(svc_action_t *op, const DBusError *error)
 {
-    op->rc = PCMK_OCF_UNKNOWN_ERROR;
-    op->status = PCMK_EXEC_ERROR;
+    services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR, NULL);
 
     if (strstr(error->name, UPSTART_06_API ".Error.UnknownInstance")) {
 
@@ -385,21 +382,19 @@ set_result_from_method_error(svc_action_t *op, const DBusError *error)
             crm_trace("Masking stop failure (%s) for %s "
                       "because unknown service can be considered stopped",
                       error->name, crm_str(op->rsc));
-            op->rc = PCMK_OCF_OK;
-            op->status = PCMK_EXEC_DONE;
+            services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
             return;
         }
 
-        op->rc = PCMK_OCF_NOT_INSTALLED;
-        op->status = PCMK_EXEC_NOT_INSTALLED;
+        services__set_result(op, PCMK_OCF_NOT_INSTALLED,
+                             PCMK_EXEC_NOT_INSTALLED, NULL);
 
     } else if (pcmk__str_eq(op->action, "start", pcmk__str_casei)
                && strstr(error->name, UPSTART_06_API ".Error.AlreadyStarted")) {
         crm_trace("Masking start failure (%s) for %s "
                   "because already started resource is OK",
                   error->name, crm_str(op->rsc));
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
         return;
     }
 
@@ -435,15 +430,13 @@ job_method_complete(DBusPendingCall *pending, void *user_data)
     } else if (pcmk__str_eq(op->action, "stop", pcmk__str_none)) {
         // Call has no return value
         crm_debug("DBus request for stop of %s succeeded", crm_str(op->rsc));
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
 
     } else if (!pcmk_dbus_type_check(reply, NULL, DBUS_TYPE_OBJECT_PATH,
                                      __func__, __LINE__)) {
         crm_warn("DBus request for %s of %s succeeded but "
                  "return type was unexpected", op->action, crm_str(op->rsc));
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
 
     } else {
         const char *path = NULL;
@@ -452,8 +445,7 @@ job_method_complete(DBusPendingCall *pending, void *user_data)
                               DBUS_TYPE_INVALID);
         crm_debug("DBus request for %s of %s using %s succeeded",
                   op->action, crm_str(op->rsc), path);
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
     }
 
     // The call is no longer pending
@@ -499,31 +491,29 @@ services__execute_upstart(svc_action_t *op)
     CRM_ASSERT(op != NULL);
 
     if ((op->action == NULL) || (op->agent == NULL)) {
-        op->rc = PCMK_OCF_NOT_CONFIGURED;
-        op->status = PCMK_EXEC_ERROR_FATAL;
+        services__set_result(op, PCMK_OCF_NOT_CONFIGURED, PCMK_EXEC_ERROR_FATAL,
+                             NULL);
         goto cleanup;
     }
 
     if (!upstart_init()) {
-        op->rc = PCMK_OCF_UNKNOWN_ERROR;
-        op->status = PCMK_EXEC_ERROR;
+        services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                             NULL);
         goto cleanup;
     }
 
     if (pcmk__str_eq(op->action, "meta-data", pcmk__str_casei)) {
         op->stdout_data = upstart_job_metadata(op->agent);
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
         goto cleanup;
     }
 
     if (!object_path_for_job(op->agent, &job, op->timeout)) {
         if (pcmk__str_eq(action, "stop", pcmk__str_none)) {
-            op->rc = PCMK_OCF_OK;
-            op->status = PCMK_EXEC_DONE;
+            services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
         } else {
-            op->rc = PCMK_OCF_NOT_INSTALLED;
-            op->status = PCMK_EXEC_NOT_INSTALLED;
+            services__set_result(op, PCMK_OCF_NOT_INSTALLED,
+                                 PCMK_EXEC_NOT_INSTALLED, NULL);
         }
         goto cleanup;
     }
@@ -540,8 +530,7 @@ services__execute_upstart(svc_action_t *op)
         char *state = NULL;
         char *path = get_first_instance(job, op->timeout);
 
-        op->rc = PCMK_OCF_NOT_RUNNING;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_NOT_RUNNING, PCMK_EXEC_DONE, NULL);
         if (path == NULL) {
             goto cleanup;
         }
@@ -558,8 +547,8 @@ services__execute_upstart(svc_action_t *op)
             free(state);
 
         } else if (pending == NULL) {
-            op->rc = PCMK_OCF_UNKNOWN_ERROR;
-            op->status = PCMK_EXEC_ERROR;
+            services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                                 NULL);
 
         } else { // Successfully initiated async op
             free(job);
@@ -580,14 +569,14 @@ services__execute_upstart(svc_action_t *op)
         action = "Restart";
 
     } else {
-        op->rc = PCMK_OCF_UNIMPLEMENT_FEATURE;
-        op->status = PCMK_EXEC_ERROR_HARD;
+        services__set_result(op, PCMK_OCF_UNIMPLEMENT_FEATURE,
+                             PCMK_EXEC_ERROR_HARD, NULL);
         goto cleanup;
     }
 
     // Initialize rc/status in case called functions don't set them
-    op->rc = PCMK_OCF_UNKNOWN_ERROR;
-    op->status = PCMK_EXEC_DONE;
+    services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_DONE,
+                         NULL);
 
     crm_debug("Calling %s for %s on %s", action, crm_str(op->rsc), job);
 
@@ -614,8 +603,8 @@ services__execute_upstart(svc_action_t *op)
                                                   op->timeout);
 
         if (pending == NULL) {
-            op->rc = PCMK_OCF_UNKNOWN_ERROR;
-            op->status = PCMK_EXEC_ERROR;
+            services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                                 NULL);
             goto cleanup;
 
         } else { // Successfully initiated async op
@@ -637,14 +626,12 @@ services__execute_upstart(svc_action_t *op)
 
     } else if (pcmk__str_eq(op->action, "stop", pcmk__str_none)) {
         // DBus call does not return a value
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
 
     } else if (!pcmk_dbus_type_check(reply, NULL, DBUS_TYPE_OBJECT_PATH,
                                      __func__, __LINE__)) {
         crm_warn("Call to %s passed but return type was unexpected", op->action);
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
 
     } else {
         const char *path = NULL;
@@ -652,8 +639,7 @@ services__execute_upstart(svc_action_t *op)
         dbus_message_get_args(reply, NULL, DBUS_TYPE_OBJECT_PATH, &path,
                               DBUS_TYPE_INVALID);
         crm_info("Call to %s passed: %s", op->action, path);
-        op->rc = PCMK_OCF_OK;
-        op->status = PCMK_EXEC_DONE;
+        services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
     }
 
 cleanup:


### PR DESCRIPTION
This adds an exit reason to svc_action_t's private data, moves OCF exit reason parsing from the executor to libcrmservice, and sets an exit reason for internal libcrmservice errors. This allows better status messages for failed actions, for easier troubleshooting.