### PR TITLE
Recover from corosync crashes

### DIFF
--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -32,3 +32,4 @@ void pcmk_shutdown(int nsig);
 void pcmk_handle_ping_request(pcmk__client_t *c, xmlNode *msg, uint32_t id);
 void pcmk_handle_shutdown_request(pcmk__client_t *c, xmlNode *msg, uint32_t id, uint32_t flags);
 void pcmkd_shutdown_corosync(void);
+bool pcmkd_corosync_connected(void);

--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -28,6 +28,7 @@ gboolean cluster_connect_cfg(void);
 void cluster_disconnect_cfg(void);
 int find_and_track_existing_processes(void);
 gboolean init_children_processes(void *user_data);
+void restart_cluster_subdaemons(void);
 void pcmk_shutdown(int nsig);
 void pcmk_handle_ping_request(pcmk__client_t *c, xmlNode *msg, uint32_t id);
 void pcmk_handle_shutdown_request(pcmk__client_t *c, xmlNode *msg, uint32_t id, uint32_t flags);

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -221,6 +221,25 @@ pcmkd_shutdown_corosync(void)
     }
 }
 
+bool
+pcmkd_corosync_connected(void)
+{
+    cpg_handle_t local_handle = 0;
+    cpg_model_v1_data_t cpg_model_info = {CPG_MODEL_V1, NULL, NULL, NULL, 0};
+    int fd = -1;
+
+    if (cpg_model_initialize(&local_handle, CPG_MODEL_V1, (cpg_model_data_t *) &cpg_model_info, NULL) != CS_OK) {
+        return false;
+    }
+
+    if (cpg_fd_get(local_handle, &fd) != CS_OK) {
+        return false;
+    }
+
+    cpg_finalize(local_handle);
+
+    return true;
+}
 
 /* =::=::=::= Configuration =::=::=::= */
 static int

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -83,6 +83,7 @@ cluster_reconnect_cb(gpointer data)
         reconnect_timer = NULL;
         crm_notice("Cluster reconnect succeeded");
         mcp_read_config();
+        restart_cluster_subdaemons();
         return G_SOURCE_REMOVE;
     } else {
         crm_info("Cluster reconnect failed"

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -82,6 +82,8 @@ cluster_reconnect_cb(gpointer data)
         mainloop_timer_del(reconnect_timer);
         reconnect_timer = NULL;
         crm_notice("Cluster reconnect succeeded");
+        mcp_read_config();
+        return G_SOURCE_REMOVE;
     } else {
         crm_info("Cluster reconnect failed"
                  "(connection will be reattempted once per second)");
@@ -90,7 +92,7 @@ cluster_reconnect_cb(gpointer data)
      * In theory this will continue forever. In practice the CIB connection from
      * attrd will timeout and shut down Pacemaker when it gets bored.
      */
-    return TRUE;
+    return G_SOURCE_CONTINUE;
 }
 
 

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -33,6 +33,8 @@ typedef struct pcmk_child_s {
     const char *endpoint;  /* IPC server name */
     bool needs_cluster;
 
+    /* Anything below here will be dynamically initialized */
+    bool needs_retry;
     bool active_before_startup;
 } pcmk_child_t;
 
@@ -261,6 +263,13 @@ pcmk_process_exit(pcmk_child_t * child)
         }
 
     } else {
+        if (child->needs_cluster && !pcmkd_cluster_connected()) {
+            crm_notice("Skipping cluster-based subdaemon %s until cluster returns",
+                       child->name);
+            child->needs_retry = true;
+            return;
+        }
+
         crm_notice("Respawning failed child process: %s", child->name);
         start_child(child);
     }
@@ -777,6 +786,21 @@ pcmk_shutdown(int nsig)
         shutdown_trigger = mainloop_add_trigger(G_PRIORITY_HIGH, pcmk_shutdown_worker, NULL);
     }
     mainloop_set_trigger(shutdown_trigger);
+}
+
+void
+restart_cluster_subdaemons(void)
+{
+    for (int i = 0; i < PCMK__NELEM(pcmk_children); i++) {
+        if (!pcmk_children[i].needs_retry || pcmk_children[i].pid != 0) {
+            continue;
+        }
+
+        crm_notice("Respawning cluster-based subdaemon: %s", pcmk_children[i].name);
+        if (start_child(&pcmk_children[i])) {
+            pcmk_children[i].needs_retry = false;
+        }
+    }
 }
 
 static gboolean

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -61,12 +61,12 @@ static pcmk_child_t pcmk_children[] = {
     {
         0, 0, true, "pacemaker-attrd", CRM_DAEMON_USER,
         CRM_DAEMON_DIR "/pacemaker-attrd", T_ATTRD,
-        false
+        true
     },
     {
         0, 0, true, "pacemaker-schedulerd", CRM_DAEMON_USER,
         CRM_DAEMON_DIR "/pacemaker-schedulerd", CRM_SYSTEM_PENGINE,
-        true
+        false
     },
     {
         0, 0, true, "pacemaker-controld", CRM_DAEMON_USER,

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -112,6 +112,16 @@ static void pcmk_process_exit(pcmk_child_t * child);
 static gboolean pcmk_shutdown_worker(gpointer user_data);
 static gboolean stop_child(pcmk_child_t * child, int signal);
 
+static bool
+pcmkd_cluster_connected()
+{
+#if SUPPORT_COROSYNC
+    return pcmkd_corosync_connected();
+#else
+    return true;
+#endif
+}
+
 static gboolean
 check_active_before_startup_processes(gpointer user_data)
 {


### PR DESCRIPTION
This builds on top of #2526 to finish adding support for respawning subdaemons when corosync returns.