### PR TITLE
Show exit reasons in crm_resource --force-*

### DIFF
--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -277,6 +277,8 @@ pcmk__xe_set_propv(xmlNodePtr node, va_list pairs);
  *
  * \param[in,out] node XML node to add properties to
  * \param[in]     ...  NULL-terminated list of name/value pairs
+ *
+ * \note A NULL name terminates the arguments; a NULL value will be skipped.
  */
 void
 pcmk__xe_set_props(xmlNodePtr node, ...)

--- a/include/crm/services_internal.h
+++ b/include/crm/services_internal.h
@@ -41,6 +41,10 @@ svc_action_t *services__create_resource_action(const char *name, const char *sta
 
 const char *services__exit_reason(svc_action_t *action);
 
+void services__set_result(svc_action_t *action, int agent_status,
+                          enum pcmk_exec_status exec_status,
+                          const char *exit_reason);
+
 #  ifdef __cplusplus
 }
 #  endif

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -2955,11 +2955,9 @@ pcmk__xe_set_propv(xmlNodePtr node, va_list pairs)
         }
 
         value = va_arg(pairs, const char *);
-        if (value == NULL) {
-            return;
+        if (value != NULL) {
+            crm_xml_add(node, name, value);
         }
-
-        crm_xml_add(node, name, value);
     }
 }
 

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -27,6 +27,7 @@
 #include "crm/crm.h"
 #include "crm/common/mainloop.h"
 #include "crm/services.h"
+#include "crm/services_internal.h"
 
 #include "services_private.h"
 

--- a/lib/services/services_private.h
+++ b/lib/services/services_private.h
@@ -89,11 +89,6 @@ void services_untrack_op(svc_action_t *op);
 G_GNUC_INTERNAL
 gboolean is_op_blocked(const char *rsc);
 
-G_GNUC_INTERNAL
-void services__set_result(svc_action_t *action, int agent_status,
-                          enum pcmk_exec_status exec_status,
-                          const char *exit_reason);
-
 #if SUPPORT_DBUS
 G_GNUC_INTERNAL
 void services_set_op_pending(svc_action_t *op, DBusPendingCall *pending);

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -10,6 +10,7 @@
 #include <crm_internal.h>
 #include <crm/crm.h>
 #include <crm/services.h>
+#include <crm/services_internal.h>
 #include <crm/common/mainloop.h>
 
 #include <sys/stat.h>

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -148,7 +148,7 @@ attribute_list_default(pcmk__output_t *out, va_list args) {
 }
 
 PCMK__OUTPUT_ARGS("agent-status", "int", "const char *", "const char *", "const char *",
-                  "const char *", "const char *", "int")
+                  "const char *", "const char *", "int", "const char *")
 static int
 agent_status_default(pcmk__output_t *out, va_list args) {
     int status = va_arg(args, int);
@@ -158,41 +158,65 @@ agent_status_default(pcmk__output_t *out, va_list args) {
     const char *provider = va_arg(args, const char *);
     const char *type = va_arg(args, const char *);
     int rc = va_arg(args, int);
+    const char *exit_reason = va_arg(args, const char *);
 
     if (status == PCMK_EXEC_DONE) {
-        out->info(out, "Operation %s%s%s (%s%s%s:%s) returned: '%s' (%d)",
-                  action, name ? " for " : "", name ? name : "",
-                  class, provider ? ":" : "", provider ? provider : "", type,
-                  services_ocf_exitcode_str(rc), rc);
+        /* Operation <action> [for <resource>] (<class>[:<provider>]:<agent>)
+         * returned <exit-code> (<exit-description>[: <exit-reason>])
+         */
+        out->info(out, "Operation %s%s%s (%s%s%s:%s) returned %d (%s%s%s)",
+                  action,
+                  ((name == NULL)? "" : " for "), ((name == NULL)? "" : name),
+                  class,
+                  ((provider == NULL)? "" : ":"),
+                  ((provider == NULL)? "" : provider),
+                  type, rc, services_ocf_exitcode_str(rc),
+                  ((exit_reason == NULL)? "" : ": "),
+                  ((exit_reason == NULL)? "" : exit_reason));
     } else {
-        out->err(out, "Operation %s%s%s (%s%s%s:%s) failed: '%s' (%d)",
-                 action, name ? " for " : "", name ? name : "",
-                 class, provider ? ":" : "", provider ? provider : "", type,
-                 pcmk_exec_status_str(status), status);
+        /* Operation <action> [for <resource>] (<class>[:<provider>]:<agent>)
+         * could not be executed (<execution-status>[: <exit-reason>])
+         */
+        out->err(out,
+                 "Operation %s%s%s (%s%s%s:%s) could not be executed (%s%s%s)",
+                 action,
+                 ((name == NULL)? "" : " for "), ((name == NULL)? "" : name),
+                 class,
+                 ((provider == NULL)? "" : ":"),
+                 ((provider == NULL)? "" : provider),
+                 type, pcmk_exec_status_str(status),
+                 ((exit_reason == NULL)? "" : ": "),
+                 ((exit_reason == NULL)? "" : exit_reason));
     }
 
     return pcmk_rc_ok;
 }
 
 PCMK__OUTPUT_ARGS("agent-status", "int", "const char *", "const char *", "const char *",
-                  "const char *", "const char *", "int")
+                  "const char *", "const char *", "int", "const char *")
 static int
 agent_status_xml(pcmk__output_t *out, va_list args) {
-    int status G_GNUC_UNUSED = va_arg(args, int);
+    int status = va_arg(args, int);
     const char *action G_GNUC_UNUSED = va_arg(args, const char *);
     const char *name G_GNUC_UNUSED = va_arg(args, const char *);
     const char *class G_GNUC_UNUSED = va_arg(args, const char *);
     const char *provider G_GNUC_UNUSED = va_arg(args, const char *);
     const char *type G_GNUC_UNUSED = va_arg(args, const char *);
     int rc = va_arg(args, int);
+    const char *exit_reason = va_arg(args, const char *);
 
-    char *status_str = pcmk__itoa(rc);
+    char *exit_str = pcmk__itoa(rc);
+    char *status_str = pcmk__itoa(status);
 
     pcmk__output_create_xml_node(out, "agent-status",
-                                 "code", status_str,
+                                 "code", exit_str,
                                  "message", services_ocf_exitcode_str(rc),
+                                 "execution_code", status_str,
+                                 "execution_message", pcmk_exec_status_str(status),
+                                 "reason", exit_reason,
                                  NULL);
 
+    free(exit_str);
     free(status_str);
 
     return pcmk_rc_ok;
@@ -290,7 +314,7 @@ property_list_text(pcmk__output_t *out, va_list args) {
 
 PCMK__OUTPUT_ARGS("resource-agent-action", "int", "const char *", "const char *",
                   "const char *", "const char *", "const char *", "GHashTable *",
-                  "int", "int", "char *", "char *")
+                  "int", "int", "const char *", "char *", "char *")
 static int
 resource_agent_action_default(pcmk__output_t *out, va_list args) {
     int verbose = va_arg(args, int);
@@ -303,6 +327,7 @@ resource_agent_action_default(pcmk__output_t *out, va_list args) {
     GHashTable *overrides = va_arg(args, GHashTable *);
     int rc = va_arg(args, int);
     int status = va_arg(args, int);
+    const char *exit_reason = va_arg(args, const char *);
     char *stdout_data = va_arg(args, char *);
     char *stderr_data = va_arg(args, char *);
 
@@ -322,7 +347,7 @@ resource_agent_action_default(pcmk__output_t *out, va_list args) {
     }
 
     out->message(out, "agent-status", status, action, rsc_name, class, provider,
-                 type, rc);
+                 type, rc, exit_reason);
 
     /* hide output for validate-all if not in verbose */
     if (verbose == 0 && pcmk__str_eq(action, "validate-all", pcmk__str_casei)) {
@@ -348,7 +373,7 @@ resource_agent_action_default(pcmk__output_t *out, va_list args) {
 
 PCMK__OUTPUT_ARGS("resource-agent-action", "int", "const char *", "const char *",
                   "const char *", "const char *", "const char *", "GHashTable *",
-                  "int", "int", "char *", "char *")
+                  "int", "int", "const char *", "char *", "char *")
 static int
 resource_agent_action_xml(pcmk__output_t *out, va_list args) {
     int verbose G_GNUC_UNUSED = va_arg(args, int);
@@ -361,6 +386,7 @@ resource_agent_action_xml(pcmk__output_t *out, va_list args) {
     GHashTable *overrides = va_arg(args, GHashTable *);
     int rc = va_arg(args, int);
     int status = va_arg(args, int);
+    const char *exit_reason = va_arg(args, const char *);
     char *stdout_data = va_arg(args, char *);
     char *stderr_data = va_arg(args, char *);
 
@@ -394,7 +420,7 @@ resource_agent_action_xml(pcmk__output_t *out, va_list args) {
     }
 
     out->message(out, "agent-status", status, action, rsc_name, class, provider,
-                 type, rc);
+                 type, rc, exit_reason);
 
     if (stdout_data || stderr_data) {
         xmlNodePtr doc = NULL;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1765,7 +1765,7 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
                                  int timeout_ms, int resource_verbose, gboolean force,
                                  int check_level)
 {
-    const char *class = NULL;
+    const char *class = rsc_class;
     const char *action = get_action(rsc_action);
     crm_exit_t exit_code = CRM_EX_OK;
     svc_action_t *op = NULL;
@@ -1789,16 +1789,13 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
         return CRM_EX_OSERR;
     }
 
-    class = !pcmk__str_eq(rsc_class, PCMK_RESOURCE_CLASS_SERVICE, pcmk__str_casei) ?
-                rsc_class : resources_find_service_class(rsc_type);
-    if (pcmk__str_eq(class, PCMK_RESOURCE_CLASS_STONITH, pcmk__str_casei)) {
-        out->err(out, "Sorry, the %s option doesn't support %s resources yet",
-                 rsc_action, class);
-        crm_exit(CRM_EX_UNIMPLEMENT_FEATURE);
-    } else if (pcmk__strcase_any_of(class, PCMK_RESOURCE_CLASS_SYSTEMD,
-                PCMK_RESOURCE_CLASS_UPSTART, PCMK_RESOURCE_CLASS_NAGIOS, NULL)) {
+    if (pcmk__str_eq(rsc_class, PCMK_RESOURCE_CLASS_SERVICE, pcmk__str_casei)) {
+        class = resources_find_service_class(rsc_type);
+    }
+    if (!pcmk__strcase_any_of(class, PCMK_RESOURCE_CLASS_OCF,
+                              PCMK_RESOURCE_CLASS_LSB, NULL)) {
         out->err(out, "Sorry, the %s option doesn't support %s resources",
-                 rsc_action, class);
+                 rsc_action, ((class == NULL)? "unresolvable service" : class));
         crm_exit(CRM_EX_UNIMPLEMENT_FEATURE);
     }
 

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1809,21 +1809,17 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
         crm_exit(op->rc);
     }
 
-    if (services_action_sync(op)) {
-        exit_code = op->rc;
+    services_action_sync(op);
+    exit_code = op->rc;
 
-        /* Lookup exit code based on rc for LSB resources */
-        if (pcmk__str_eq(class, PCMK_RESOURCE_CLASS_LSB, pcmk__str_casei) &&
-              pcmk__str_eq(rsc_action, "force-check", pcmk__str_casei)) {
+    // Map LSB status results to OCF results for consistent reporting to user
+    if (pcmk__str_eq(class, PCMK_RESOURCE_CLASS_LSB, pcmk__str_casei)
+        && pcmk__str_eq(rsc_action, "force-check", pcmk__str_casei)) {
 
-            /* A simple cast is sufficient because services_get_ocf_exitcode()
-             * will only return OCF codes that overlap with crm_exit_t.
-             */
-            exit_code = (crm_exit_t) services_get_ocf_exitcode(action,
-                                                               exit_code);
-        }
-    } else {
-        exit_code = op->rc == 0 ? CRM_EX_ERROR : op->rc;
+        /* A simple cast is sufficient because services_get_ocf_exitcode()
+         * will only return OCF codes that overlap with crm_exit_t.
+         */
+        exit_code = (crm_exit_t) services_get_ocf_exitcode(action, exit_code);
     }
 
     out->message(out, "resource-agent-action", resource_verbose, rsc_class,

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1822,14 +1822,13 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
             exit_code = (crm_exit_t) services_get_ocf_exitcode(action,
                                                                exit_code);
         }
-
-        out->message(out, "resource-agent-action", resource_verbose, rsc_class,
-                     rsc_prov, rsc_type, rsc_name, rsc_action, override_hash,
-                     exit_code, op->status, op->stdout_data, op->stderr_data);
     } else {
         exit_code = op->rc == 0 ? CRM_EX_ERROR : op->rc;
     }
 
+    out->message(out, "resource-agent-action", resource_verbose, rsc_class,
+                 rsc_prov, rsc_type, rsc_name, rsc_action, override_hash,
+                 exit_code, op->status, op->stdout_data, op->stderr_data);
     services_action_free(op);
     return exit_code;
 }

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1794,16 +1794,13 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
     }
     if (!pcmk__strcase_any_of(class, PCMK_RESOURCE_CLASS_OCF,
                               PCMK_RESOURCE_CLASS_LSB, NULL)) {
-        out->err(out, "Sorry, the %s option doesn't support %s resources",
-                 rsc_action, ((class == NULL)? "unresolvable service" : class));
-        crm_exit(CRM_EX_UNIMPLEMENT_FEATURE);
+        services__set_result(op, CRM_EX_UNIMPLEMENT_FEATURE, PCMK_EXEC_ERROR,
+                             "Manual execution of this standard is unsupported");
     }
 
     if (op->rc != PCMK_OCF_UNKNOWN) {
-        out->err(out, "Operation %s for %s (%s%s%s:%s) failed: %s",
-                 action, rsc_name, rsc_class, (rsc_prov? ":" : ""),
-                 (rsc_prov? rsc_prov : ""), rsc_type, crm_exit_str(op->rc));
-        crm_exit(op->rc);
+        exit_code = op->rc;
+        goto done;
     }
 
     services_action_sync(op);
@@ -1819,6 +1816,7 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
         exit_code = (crm_exit_t) services_get_ocf_exitcode(action, exit_code);
     }
 
+done:
     out->message(out, "resource-agent-action", resource_verbose, rsc_class,
                  rsc_prov, rsc_type, rsc_name, rsc_action, override_hash,
                  exit_code, op->status, op->stdout_data, op->stderr_data);

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1819,7 +1819,8 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
 done:
     out->message(out, "resource-agent-action", resource_verbose, rsc_class,
                  rsc_prov, rsc_type, rsc_name, rsc_action, override_hash,
-                 exit_code, op->status, op->stdout_data, op->stderr_data);
+                 exit_code, op->status, services__exit_reason(op),
+                 op->stdout_data, op->stderr_data);
     services_action_free(op);
     return exit_code;
 }

--- a/xml/api/crm_resource-2.14.rng
+++ b/xml/api/crm_resource-2.14.rng
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crm-resource"/>
+    </start>
+
+    <define name="element-crm-resource">
+        <choice>
+            <ref name="agents-list" />
+            <ref name="alternatives-list" />
+            <ref name="constraints-list" />
+            <externalRef href="generic-list-2.4.rng"/>
+            <element name="metadata"> <text/> </element>
+            <ref name="locate-list" />
+            <ref name="operations-list" />
+            <ref name="providers-list" />
+            <ref name="reasons-list" />
+            <ref name="resource-check" />
+            <ref name="resource-config" />
+            <ref name="resources-list" />
+            <ref name="resource-agent-action" />
+        </choice>
+    </define>
+
+    <define name="agents-list">
+        <element name="agents">
+            <attribute name="standard"> <text/> </attribute>
+            <optional>
+                <attribute name="provider"> <text/> </attribute>
+            </optional>
+            <zeroOrMore>
+                <element name="agent"> <text/> </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="alternatives-list">
+        <element name="providers">
+            <attribute name="for"> <text/> </attribute>
+            <zeroOrMore>
+                <element name="provider"> <text/> </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="constraints-list">
+        <element name="constraints">
+            <interleave>
+                <zeroOrMore>
+                    <ref name="rsc-location" />
+                </zeroOrMore>
+                <zeroOrMore>
+                    <ref name="rsc-colocation" />
+                </zeroOrMore>
+            </interleave>
+        </element>
+    </define>
+
+    <define name="locate-list">
+        <element name="nodes">
+            <attribute name="resource"> <text/> </attribute>
+            <zeroOrMore>
+                <element name="node">
+                    <optional>
+                        <attribute name="state"><value>promoted</value></attribute>
+                    </optional>
+                    <text/>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="rsc-location">
+        <element name="rsc_location">
+            <attribute name="node"> <text/> </attribute>
+            <attribute name="rsc"> <text/> </attribute>
+            <attribute name="id"> <text/> </attribute>
+            <externalRef href="../score.rng"/>
+        </element>
+    </define>
+
+    <define name="operations-list">
+        <element name="operations">
+            <oneOrMore>
+                <ref name="element-operation-list" />
+            </oneOrMore>
+        </element>
+    </define>
+
+    <define name="providers-list">
+        <element name="providers">
+            <attribute name="standard"> <value>ocf</value> </attribute>
+            <optional>
+                <attribute name="agent"> <text/> </attribute>
+            </optional>
+            <zeroOrMore>
+                <element name="provider"> <text/> </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="reasons-list">
+        <choice>
+            <ref name="no-resource-or-uname"/>
+            <ref name="resource-and-uname"/>
+            <ref name="no-resource-but-uname"/>
+            <ref name="resource-but-no-uname"/>
+        </choice>
+    </define>
+
+    <define name="no-resource-or-uname">
+        <element name="reason">
+            <element name="resources">
+                <zeroOrMore>
+                    <element name="resource">
+                        <attribute name="id"> <text/> </attribute>
+                        <attribute name="running"> <data type="boolean"/> </attribute>
+                        <ref name="resource-check"/>
+                    </element>
+                </zeroOrMore>
+            </element>
+        </element>
+    </define>
+
+    <define name="resource-and-uname">
+        <element name="reason">
+            <attribute name="running_on"> <text/> </attribute>
+            <ref name="resource-check"/>
+        </element>
+    </define>
+
+    <define name="no-resource-but-uname">
+        <element name="reason">
+            <element name="resources">
+                <zeroOrMore>
+                    <element name="resource">
+                        <attribute name="id"> <text/> </attribute>
+                        <attribute name="running"> <data type="boolean"/> </attribute>
+                        <attribute name="host"> <text/> </attribute>
+                        <ref name="resource-check"/>
+                    </element>
+                </zeroOrMore>
+            </element>
+        </element>
+    </define>
+
+    <define name="resource-but-no-uname">
+        <element name="reason">
+            <attribute name="running"> <data type="boolean"/> </attribute>
+            <ref name="resource-check"/>
+        </element>
+    </define>
+
+    <define name="resource-config">
+        <element name="resource_config">
+            <externalRef href="resources-2.4.rng" />
+            <element name="xml"> <text/> </element>
+        </element>
+    </define>
+
+    <define name="resource-check">
+        <element name="check">
+            <attribute name="id"> <text/> </attribute>
+            <optional>
+                <choice>
+                    <attribute name="remain_stopped"><value>true</value></attribute>
+                    <attribute name="promotable"><value>false</value></attribute>
+                </choice>
+            </optional>
+            <optional>
+                <attribute name="unmanaged"><value>true</value></attribute>
+            </optional>
+            <optional>
+                <attribute name="locked-to"> <text/> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="resources-list">
+        <element name="resources">
+            <zeroOrMore>
+                <externalRef href="resources-2.4.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="rsc-colocation">
+        <element name="rsc_colocation">
+            <attribute name="id"> <text/> </attribute>
+            <attribute name="rsc"> <text/> </attribute>
+            <attribute name="with-rsc"> <text/> </attribute>
+            <externalRef href="../score.rng"/>
+            <optional>
+                <attribute name="node-attribute"> <text/> </attribute>
+            </optional>
+            <optional>
+                <attribute name="rsc-role">
+                    <ref name="attribute-roles"/>
+                </attribute>
+            </optional>
+            <optional>
+                <attribute name="with-rsc-role">
+                    <ref name="attribute-roles"/>
+                </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="element-operation-list">
+        <element name="operation">
+            <optional>
+                <group>
+                    <attribute name="rsc"> <text/> </attribute>
+                    <attribute name="agent"> <text/> </attribute>
+                </group>
+            </optional>
+            <attribute name="op"> <text/> </attribute>
+            <attribute name="node"> <text/> </attribute>
+            <attribute name="call"> <data type="integer" /> </attribute>
+            <attribute name="rc"> <data type="nonNegativeInteger" /> </attribute>
+            <optional>
+                <attribute name="last-rc-change"> <text/> </attribute>
+                <attribute name="exec-time"> <data type="nonNegativeInteger" /> </attribute>
+            </optional>
+            <attribute name="status"> <text/> </attribute>
+        </element>
+    </define>
+
+    <define name="resource-agent-action">
+        <element name="resource-agent-action">
+            <attribute name="action"> <text/> </attribute>
+            <optional>
+                <attribute name="rsc"> <text/> </attribute>
+            </optional>
+            <attribute name="class"> <text/> </attribute>
+            <attribute name="type"> <text/> </attribute>
+            <optional>
+                <attribute name="provider"> <text/> </attribute>
+            </optional>
+            <optional>
+                <ref name="overrides-list"/>
+            </optional>
+            <ref name="agent-status"/>
+            <optional>
+                <choice>
+                    <element name="command">
+                        <text />
+                    </element>
+                    <externalRef href="command-output-1.0.rng"/>
+                </choice>
+            </optional>
+        </element>
+    </define>
+
+    <define name="overrides-list">
+        <element name="overrides">
+            <zeroOrMore>
+                <element name="override">
+                    <optional>
+                        <attribute name="rsc"> <text/> </attribute>
+                    </optional>
+                    <attribute name="name"> <text/> </attribute>
+                    <attribute name="value"> <text/> </attribute>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="agent-status">
+        <element name="agent-status">
+            <attribute name="code"> <data type="integer" /> </attribute>
+            <optional>
+                <attribute name="message"> <text/> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="attribute-roles">
+        <choice>
+            <value>Stopped</value>
+            <value>Started</value>
+            <value>Master</value>
+            <value>Slave</value>
+        </choice>
+    </define>
+</grammar>

--- a/xml/api/crm_resource-2.14.rng
+++ b/xml/api/crm_resource-2.14.rng
@@ -274,6 +274,15 @@
             <optional>
                 <attribute name="message"> <text/> </attribute>
             </optional>
+            <optional>
+                <attribute name="execution_code"> <data type="integer" /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="execution_message"> <text/> </attribute>
+            </optional>
+            <optional>
+                <attribute name="reason"> <text/> </attribute>
+            </optional>
         </element>
     </define>
 


### PR DESCRIPTION
Previously, the crm_resource --force-* options would output the result of the action, but it did not show any exit reason set (whether by the agent itself or internally). Now that the services library manages the exit reason, we can easily show it.