### PR TITLE
Modernize pacemaker-schedulerd

### DIFF
--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -183,7 +183,7 @@ crmd_exit(crm_exit_t exit_code)
     }
 
     controld_close_attrd_ipc();
-    pe_subsystem_free();
+    controld_shutdown_schedulerd_ipc();
     controld_disconnect_fencer(TRUE);
 
     if ((exit_code == CRM_EX_OK) && (crmd_mainloop == NULL)) {

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -86,6 +86,7 @@ fail_pending_op(gpointer key, gpointer value, gpointer user_data)
     event.params = op->params;
 
     process_lrm_event(lrm_state, &event, op, NULL);
+    lrmd__reset_result(&event);
     return TRUE;
 }
 

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -270,17 +270,12 @@ controld_stop_sched_timer(void)
  * \internal
  * \brief Set the scheduler request currently being waited on
  *
- * \param[in] msg  Request to expect reply to (or NULL for none)
+ * \param[in] ref  Request to expect reply to (or NULL for none)
  */
 void
-controld_expect_sched_reply(xmlNode *msg)
+controld_expect_sched_reply(char *ref)
 {
-    char *ref = NULL;
-
-    if (msg) {
-        ref = crm_element_value_copy(msg, XML_ATTR_REFERENCE);
-        CRM_ASSERT(ref != NULL);
-
+    if (ref) {
         if (controld_sched_timer == NULL) {
             controld_sched_timer = mainloop_timer_add("scheduler_reply_timer",
                                                       SCHED_TIMEOUT_MS, FALSE,
@@ -472,7 +467,10 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
                 pcmk_strerror(rc), rc);
         register_fsa_error_adv(C_FSA_INTERNAL, I_ERROR, NULL, NULL, __func__);
     } else {
-        controld_expect_sched_reply(cmd);
+        char *ref = crm_element_value_copy(cmd, XML_ATTR_REFERENCE);
+
+        CRM_ASSERT(ref != NULL);
+        controld_expect_sched_reply(ref);
         crm_debug("Invoking the scheduler: query=%d, ref=%s, seq=%llu, quorate=%d",
                   fsa_pe_query, fsa_pe_ref, crm_peer_seq, fsa_has_quorum);
     }

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -17,10 +17,12 @@
 #include <crm/crm.h>
 #include <crm/msg_xml.h>
 #include <crm/common/xml_internal.h>
+#include <crm/common/ipc.h>
+#include <crm/common/ipc_schedulerd.h>
 
 #include <pacemaker-controld.h>
 
-static mainloop_io_t *pe_subsystem = NULL;
+static pcmk_ipc_api_t *schedulerd_api = NULL;
 
 /*!
  * \internal
@@ -30,10 +32,11 @@ void
 pe_subsystem_free(void)
 {
     controld_clear_fsa_input_flags(R_PE_REQUIRED);
-    if (pe_subsystem) {
+    if (schedulerd_api) {
         controld_expect_sched_reply(NULL);
-        mainloop_del_ipc_client(pe_subsystem);
-        pe_subsystem = NULL;
+        pcmk_disconnect_ipc(schedulerd_api);
+        pcmk_free_ipc_api(schedulerd_api);
+        schedulerd_api = NULL;
         controld_clear_fsa_input_flags(R_PE_CONNECTED);
     }
 }
@@ -80,7 +83,7 @@ save_cib_contents(xmlNode *msg, int call_id, int rc, xmlNode *output,
  * \param[in] user_data  Ignored
  */
 static void
-pe_ipc_destroy(gpointer user_data)
+pe_ipc_destroy(void)
 {
     // If we aren't connected to the scheduler, we can't expect a reply
     controld_expect_sched_reply(NULL);
@@ -110,92 +113,103 @@ pe_ipc_destroy(gpointer user_data)
     }
 
     controld_clear_fsa_input_flags(R_PE_CONNECTED);
-    pe_subsystem = NULL;
     mainloop_set_trigger(fsa_source);
     return;
 }
 
-/*!
- * \internal
- * \brief Handle message from scheduler connection
- *
- * \param[in] buffer    XML message (will be freed)
- * \param[in] length    Ignored
- * \param[in] userdata  Ignored
- *
- * \return 0
- */
-static int
-pe_ipc_dispatch(const char *buffer, ssize_t length, gpointer userdata)
+static void
+handle_reply(pcmk_schedulerd_api_reply_t *reply)
 {
-    xmlNode *msg = string2xml(buffer);
+    const char *msg_ref = NULL;
 
-    if (msg) {
-        route_message(C_IPC_MESSAGE, msg);
+    if (!AM_I_DC) {
+        return;
     }
-    free_xml(msg);
-    return 0;
+
+    msg_ref = reply->data.graph.reference;
+
+    if (msg_ref == NULL) {
+        crm_err("%s - Ignoring calculation with no reference", CRM_OP_PECALC);
+
+    } else if (pcmk__str_eq(msg_ref, fsa_pe_ref, pcmk__str_none)) {
+        ha_msg_input_t fsa_input;
+        xmlNode *crm_data_node;
+
+        controld_stop_sched_timer();
+
+        /* do_te_invoke (which will eventually process the fsa_input we are constructing
+         * here) requires that fsa_input.xml be non-NULL.  That will only happen if
+         * copy_ha_msg_input (which is called by register_fsa_input_adv) sees the
+         * fsa_input.msg that it is expecting. The scheduler's IPC dispatch function
+         * gave us the values we need, we just need to put them into XML.
+         *
+         * The name of the top level element here is irrelevant.  Nothing checks it.
+         */
+        fsa_input.msg = create_xml_node(NULL, "dummy-reply");
+        crm_xml_add(fsa_input.msg, XML_ATTR_REFERENCE, msg_ref);
+        crm_xml_add(fsa_input.msg, F_CRM_TGRAPH_INPUT, reply->data.graph.input);
+
+        crm_data_node = create_xml_node(fsa_input.msg, F_CRM_DATA);
+        add_node_copy(crm_data_node, reply->data.graph.tgraph);
+        register_fsa_input_later(C_IPC_MESSAGE, I_PE_SUCCESS, &fsa_input);
+
+        free_xml(fsa_input.msg);
+
+    } else {
+        crm_info("%s calculation %s is obsolete", CRM_OP_PECALC, msg_ref);
+    }
 }
 
-/*!
- * \internal
- * \brief Make new connection to scheduler
- *
- * \return TRUE on success, FALSE otherwise
- */
+static void
+scheduler_event_callback(pcmk_ipc_api_t *api, enum pcmk_ipc_event event_type,
+                         crm_exit_t status, void *event_data, void *user_data)
+{
+    pcmk_schedulerd_api_reply_t *reply = event_data;
+
+    switch (event_type) {
+        case pcmk_ipc_event_disconnect:
+            pe_ipc_destroy();
+            break;
+
+        case pcmk_ipc_event_reply:
+            handle_reply(reply);
+            break;
+
+        default:
+            break;
+    }
+}
+
 static bool
 pe_subsystem_new(void)
 {
-    struct ipc_client_callbacks pe_callbacks = {
-        .dispatch = pe_ipc_dispatch,
-        .destroy = pe_ipc_destroy
-    };
-    static bool retry_one = TRUE;
+    int rc;
 
     controld_set_fsa_input_flags(R_PE_REQUIRED);
-retry:
-    pe_subsystem = mainloop_add_ipc_client(CRM_SYSTEM_PENGINE,
-                                           G_PRIORITY_DEFAULT,
-                                           5 * 1024 * 1024 /* 5MB */,
-                                           NULL, &pe_callbacks);
-    if (pe_subsystem == NULL) {
-        crm_debug("Could not connect to scheduler : %s(%d)", pcmk_rc_str(errno), errno);
-        if (errno == EAGAIN && retry_one) {
-            /* In rare cases, a SIGTERM may be received and the connection may fail when the cluster shuts down. */
-            /* At this time, the connection will be retried only once. */
-            crm_debug("Scheduler connection attempt.");
-            retry_one = FALSE;
-            goto retry;
-        }
-        return FALSE;
+
+    if (schedulerd_api != NULL) {
+        pcmk_free_ipc_api(schedulerd_api);
+        schedulerd_api = NULL;
     }
+
+    rc = pcmk_new_ipc_api(&schedulerd_api, pcmk_ipc_schedulerd);
+
+    if (rc != pcmk_rc_ok) {
+        crm_err("Error connecting to the scheduler: %s", pcmk_rc_str(rc));
+        return false;
+    }
+
+    pcmk_register_ipc_callback(schedulerd_api, scheduler_event_callback, NULL);
+    rc = pcmk_connect_ipc(schedulerd_api, pcmk_ipc_dispatch_main);
+    if (rc != pcmk_rc_ok) {
+        crm_err("Error connecting to the scheduler: %s", pcmk_rc_str(rc));
+        pcmk_free_ipc_api(schedulerd_api);
+        schedulerd_api = NULL;
+        return false;
+    }
+
     controld_set_fsa_input_flags(R_PE_CONNECTED);
-    return TRUE;
-}
-
-/*!
- * \internal
- * \brief Send an XML message to the scheduler
- *
- * \param[in] cmd  XML message to send
- *
- * \return pcmk_ok on success, -errno otherwise
- */
-static int
-pe_subsystem_send(xmlNode *cmd)
-{
-    if (pe_subsystem) {
-        int sent = crm_ipc_send(mainloop_get_ipc_client(pe_subsystem), cmd,
-                                0, 0, NULL);
-
-        if (sent == 0) {
-            sent = -ENODATA;
-        } else if (sent > 0) {
-            sent = pcmk_ok;
-        }
-        return sent;
-    }
-    return -ENOTCONN;
+    return true;
 }
 
 static void do_pe_invoke_callback(xmlNode *msg, int call_id, int rc,
@@ -412,7 +426,7 @@ force_local_option(xmlNode *xml, const char *attr_name, const char *attr_value)
 static void
 do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *user_data)
 {
-    xmlNode *cmd = NULL;
+    char *ref = NULL;
     pid_t watchdog = pcmk__locate_sbd();
 
     if (rc != pcmk_ok) {
@@ -459,20 +473,20 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
         crm_xml_add_int(output, XML_ATTR_QUORUM_PANIC, 1);
     }
 
-    cmd = create_request(CRM_OP_PECALC, output, NULL, CRM_SYSTEM_PENGINE, CRM_SYSTEM_DC, NULL);
+    if (schedulerd_api) {
+        rc = pcmk_rc2legacy(pcmk_schedulerd_api_graph(schedulerd_api, output, &ref));
+    } else {
+        rc = -ENOTCONN;
+    }
 
-    rc = pe_subsystem_send(cmd);
     if (rc < 0) {
         crm_err("Could not contact the scheduler: %s " CRM_XS " rc=%d",
                 pcmk_strerror(rc), rc);
         register_fsa_error_adv(C_FSA_INTERNAL, I_ERROR, NULL, NULL, __func__);
     } else {
-        char *ref = crm_element_value_copy(cmd, XML_ATTR_REFERENCE);
-
         CRM_ASSERT(ref != NULL);
         controld_expect_sched_reply(ref);
         crm_debug("Invoking the scheduler: query=%d, ref=%s, seq=%llu, quorate=%d",
                   fsa_pe_query, fsa_pe_ref, crm_peer_seq, fsa_has_quorum);
     }
-    free_xml(cmd);
 }

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -71,7 +71,7 @@ _Noreturn void crmd_fast_exit(crm_exit_t exit_code);
 void pe_subsystem_free(void);
 void controld_stop_sched_timer(void);
 void controld_free_sched_timer(void);
-void controld_expect_sched_reply(xmlNode *msg);
+void controld_expect_sched_reply(char *ref);
 
 void fsa_dump_actions(uint64_t action, const char *text);
 void fsa_dump_inputs(int log_level, const char *text, long long input_register);

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -68,7 +68,7 @@ enum node_update_flags {
 
 crm_exit_t crmd_exit(crm_exit_t exit_code);
 _Noreturn void crmd_fast_exit(crm_exit_t exit_code);
-void pe_subsystem_free(void);
+void controld_shutdown_schedulerd_ipc(void);
 void controld_stop_sched_timer(void);
 void controld_free_sched_timer(void);
 void controld_expect_sched_reply(char *ref);

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -1665,9 +1665,9 @@ main(int argc, char **argv)
     free(cluster);
     pe_free_working_set(fenced_data_set);
 
-    pcmk__unregister_formats();
     out->finish(out, CRM_EX_OK, true, NULL);
     pcmk__output_free(out);
+    pcmk__unregister_formats();
 
     crm_exit(CRM_EX_OK);
 }

--- a/daemons/schedulerd/Makefile.am
+++ b/daemons/schedulerd/Makefile.am
@@ -24,6 +24,8 @@ endif
 
 ## SOURCES
 
+noinst_HEADERS 	= pacemaker-schedulerd.h
+
 pacemaker_schedulerd_CFLAGS	= $(CFLAGS_HARDENED_EXE)
 pacemaker_schedulerd_LDFLAGS	= $(LDFLAGS_HARDENED_EXE)
 pacemaker_schedulerd_LDADD	= $(top_builddir)/lib/common/libcrmcommon.la \
@@ -31,6 +33,7 @@ pacemaker_schedulerd_LDADD	= $(top_builddir)/lib/common/libcrmcommon.la \
 							  $(top_builddir)/lib/pacemaker/libpacemaker.la
 # libcib for get_object_root()
 pacemaker_schedulerd_SOURCES	= pacemaker-schedulerd.c
+pacemaker_schedulerd_SOURCES	+= schedulerd_messages.c
 
 install-exec-local:
 	$(INSTALL) -d -m 750 $(DESTDIR)/$(PE_STATE_DIR)

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -418,12 +418,12 @@ pengine_shutdown(int nsig)
         sched_data_set = NULL;
     }
 
-    pcmk__unregister_formats();
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);
         pcmk__output_free(out);
         out = NULL;
     }
 
+    pcmk__unregister_formats();
     crm_exit(exit_code);
 }

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -22,13 +22,18 @@
 
 #include <libxml/parser.h>
 
+#include <crm/common/cmdline_internal.h>
 #include <crm/common/ipc_internal.h>
 #include <crm/common/mainloop.h>
 #include <crm/pengine/internal.h>
 #include <pacemaker-internal.h>
 #include <crm/msg_xml.h>
 
-#define OPTARGS	"hVc"
+#define SUMMARY "pacemaker-schedulerd - daemon for calculating a Pacemaker cluster's response to events"
+
+struct {
+    gchar **remainder;
+} options;
 
 static GMainLoop *mainloop = NULL;
 static qb_ipcs_service_t *ipcs = NULL;
@@ -296,68 +301,64 @@ struct qb_ipcs_service_handlers ipc_callbacks = {
     .connection_destroyed = pe_ipc_destroy
 };
 
-static pcmk__cli_option_t long_options[] = {
-    // long option, argument type, storage, short option, description, flags
-    {
-        "help", no_argument, NULL, '?',
-        "\tThis text", pcmk__option_default
-    },
-    {
-        "verbose", no_argument, NULL, 'V',
-        "\tIncrease debug output", pcmk__option_default
-    },
-    { 0, 0, 0, 0 }
-};
+static GOptionContext *
+build_arg_context(pcmk__common_args_t *args) {
+    GOptionContext *context = NULL;
+
+    GOptionEntry extra_prog_entries[] = {
+        { G_OPTION_REMAINING, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING_ARRAY, &options.remainder,
+          NULL,
+          NULL },
+
+        { NULL }
+    };
+
+    context = pcmk__build_arg_context(args, NULL, NULL, NULL);
+    pcmk__add_main_args(context, extra_prog_entries);
+    return context;
+}
 
 int
 main(int argc, char **argv)
 {
-    int flag;
-    int index = 0;
-    int argerr = 0;
-
     int rc = pcmk_rc_ok;
 
     GError *error = NULL;
 
-    crm_log_preinit(NULL, argc, argv);
-    pcmk__set_cli_options(NULL, "[options]", long_options,
-                          "daemon for calculating a Pacemaker cluster's "
-                          "response to events");
+    pcmk__common_args_t *args = pcmk__new_common_args(SUMMARY);
+    gchar **processed_args = pcmk__cmdline_preproc(argv, NULL);
+    GOptionContext *context = build_arg_context(args);
 
+    crm_log_preinit(NULL, argc, argv);
     mainloop_add_signal(SIGTERM, pengine_shutdown);
 
-    while (1) {
-        flag = pcmk__next_cli_option(argc, argv, &index, NULL);
-        if (flag == -1)
-            break;
-
-        switch (flag) {
-            case 'V':
-                crm_bump_log_level(argc, argv);
-                break;
-            case 'h':          /* Help message */
-                pcmk__cli_help('?', CRM_EX_OK);
-                break;
-            default:
-                ++argerr;
-                break;
-        }
-    }
-
-    if (argc - optind == 1 && pcmk__str_eq("metadata", argv[optind], pcmk__str_casei)) {
-        pe_metadata();
+    if (!g_option_context_parse_strv(context, &processed_args, &error)) {
+        exit_code = CRM_EX_USAGE;
         goto done;
     }
 
-    if (optind > argc) {
-        ++argerr;
+    if (options.remainder) {
+        if (g_strv_length(options.remainder) == 1 &&
+            pcmk__str_eq("metadata", options.remainder[0], pcmk__str_casei)) {
+            pe_metadata();
+            goto done;
+        } else {
+            exit_code = CRM_EX_USAGE;
+            g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+                        "Unsupported extra command line parameters");
+            goto done;
+        }
     }
 
-    if (argerr) {
-        pcmk__cli_help('?', CRM_EX_USAGE);
+    if (args->version) {
+        g_strfreev(options.remainder);
+        g_strfreev(processed_args);
+        pcmk__free_arg_context(context);
+        /* FIXME:  When pacemaker-schedulerd is converted to use formatted output, this can go. */
+        pcmk__cli_help('v', CRM_EX_USAGE);
     }
 
+    pcmk__cli_init_logging("pacemaker-schedulerd", args->verbosity);
     crm_log_init(NULL, LOG_INFO, TRUE, FALSE, argc, argv, FALSE);
     crm_notice("Starting Pacemaker scheduler");
 
@@ -396,6 +397,10 @@ main(int argc, char **argv)
     g_main_loop_run(mainloop);
 
 done:
+    g_strfreev(options.remainder);
+    g_strfreev(processed_args);
+    pcmk__free_arg_context(context);
+
     pcmk__output_and_clear_error(error, NULL);
     pengine_shutdown(0);
 }

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -125,9 +125,10 @@ main(int argc, char **argv)
         goto done;
     }
 
-    ipcs = mainloop_add_ipc_server(CRM_SYSTEM_PENGINE, QB_IPC_SHM, &ipc_callbacks);
+    ipcs = pcmk__serve_schedulerd_ipc(&ipc_callbacks);
     if (ipcs == NULL) {
-        crm_err("Failed to create IPC server: shutting down and inhibiting respawn");
+        g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+                    "Failed to create pacemaker-schedulerd server: exiting and inhibiting respawn");
         exit_code = CRM_EX_FATAL;
         goto done;
     }
@@ -158,6 +159,7 @@ void
 pengine_shutdown(int nsig)
 {
     if (ipcs != NULL) {
+        crm_trace("Closing IPC server");
         mainloop_del_ipc_server(ipcs);
         ipcs = NULL;
     }

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -12,22 +12,17 @@
 #include <crm/crm.h>
 #include <stdio.h>
 #include <stdbool.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 #include <stdlib.h>
 #include <errno.h>
-#include <fcntl.h>
-
-#include <libxml/parser.h>
 
 #include <crm/common/cmdline_internal.h>
 #include <crm/common/ipc_internal.h>
 #include <crm/common/mainloop.h>
 #include <crm/pengine/internal.h>
 #include <pacemaker-internal.h>
-#include <crm/msg_xml.h>
+
+#include "pacemaker-schedulerd.h"
 
 #define SUMMARY "pacemaker-schedulerd - daemon for calculating a Pacemaker cluster's response to events"
 
@@ -35,11 +30,12 @@ struct {
     gchar **remainder;
 } options;
 
+pe_working_set_t *sched_data_set = NULL;
+pcmk__output_t *logger_out = NULL;
+pcmk__output_t *out = NULL;
+
 static GMainLoop *mainloop = NULL;
 static qb_ipcs_service_t *ipcs = NULL;
-static pe_working_set_t *sched_data_set = NULL;
-static pcmk__output_t *logger_out = NULL;
-static pcmk__output_t *out = NULL;
 static crm_exit_t exit_code = CRM_EX_OK;
 
 pcmk__supported_format_t formats[] = {
@@ -50,257 +46,6 @@ pcmk__supported_format_t formats[] = {
 };
 
 void pengine_shutdown(int nsig);
-
-static void
-init_working_set(void)
-{
-    crm_config_error = FALSE;
-    crm_config_warning = FALSE;
-
-    was_processing_error = FALSE;
-    was_processing_warning = FALSE;
-
-    if (sched_data_set == NULL) {
-        sched_data_set = pe_new_working_set();
-        CRM_ASSERT(sched_data_set != NULL);
-        pe__set_working_set_flags(sched_data_set,
-                                  pe_flag_no_counts|pe_flag_no_compat);
-        pe__set_working_set_flags(sched_data_set,
-                                  pe_flag_show_utilization);
-        sched_data_set->priv = logger_out;
-    } else {
-        pe_reset_working_set(sched_data_set);
-    }
-}
-
-static void
-handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
-{
-    static struct series_s {
-        const char *name;
-        const char *param;
-
-        /* Maximum number of inputs of this kind to save to disk.
-         * If -1, save all; if 0, save none.
-         */
-        int wrap;
-    } series[] = {
-        { "pe-error", "pe-error-series-max", -1 },
-        { "pe-warn",  "pe-warn-series-max",  5000 },
-        { "pe-input", "pe-input-series-max", 4000 },
-    };
-    static char *last_digest = NULL;
-    static char *filename = NULL;
-
-    unsigned int seq;
-    int series_id = 0;
-    int series_wrap = 0;
-    char *digest = NULL;
-    const char *value = NULL;
-    time_t execution_date = time(NULL);
-    xmlNode *converted = NULL;
-    xmlNode *reply = NULL;
-    bool is_repoke = false;
-    bool process = true;
-
-    init_working_set();
-
-    digest = calculate_xml_versioned_digest(xml_data, FALSE, FALSE,
-                                            CRM_FEATURE_SET);
-    converted = copy_xml(xml_data);
-    if (!cli_config_update(&converted, NULL, TRUE)) {
-        sched_data_set->graph = create_xml_node(NULL, XML_TAG_GRAPH);
-        crm_xml_add_int(sched_data_set->graph, "transition_id", 0);
-        crm_xml_add_int(sched_data_set->graph, "cluster-delay", 0);
-        process = false;
-        free(digest);
-
-    } else if (pcmk__str_eq(digest, last_digest, pcmk__str_casei)) {
-        is_repoke = true;
-        free(digest);
-
-    } else {
-        free(last_digest);
-        last_digest = digest;
-    }
-
-    if (process) {
-        pcmk__schedule_actions(sched_data_set, converted, NULL);
-    }
-
-    // Get appropriate index into series[] array
-    if (was_processing_error) {
-        series_id = 0;
-    } else if (was_processing_warning) {
-        series_id = 1;
-    } else {
-        series_id = 2;
-    }
-
-    value = pe_pref(sched_data_set->config_hash, series[series_id].param);
-    if ((value == NULL)
-        || (pcmk__scan_min_int(value, &series_wrap, -1) != pcmk_rc_ok)) {
-        series_wrap = series[series_id].wrap;
-    }
-
-    if (pcmk__read_series_sequence(PE_STATE_DIR, series[series_id].name,
-                                   &seq) != pcmk_rc_ok) {
-        // @TODO maybe handle errors better ...
-        seq = 0;
-    }
-    crm_trace("Series %s: wrap=%d, seq=%u, pref=%s",
-              series[series_id].name, series_wrap, seq, value);
-
-    sched_data_set->input = NULL;
-    reply = create_reply(msg, sched_data_set->graph);
-    CRM_ASSERT(reply != NULL);
-
-    if (series_wrap == 0) { // Don't save any inputs of this kind
-        free(filename);
-        filename = NULL;
-
-    } else if (!is_repoke) { // Input changed, save to disk
-        free(filename);
-        filename = pcmk__series_filename(PE_STATE_DIR,
-                                         series[series_id].name, seq, true);
-    }
-
-    crm_xml_add(reply, F_CRM_TGRAPH_INPUT, filename);
-    crm_xml_add_int(reply, "graph-errors", was_processing_error);
-    crm_xml_add_int(reply, "graph-warnings", was_processing_warning);
-    crm_xml_add_int(reply, "config-errors", crm_config_error);
-    crm_xml_add_int(reply, "config-warnings", crm_config_warning);
-
-    if (pcmk__ipc_send_xml(sender, 0, reply,
-                           crm_ipc_server_event) != pcmk_rc_ok) {
-        int graph_file_fd = 0;
-        char *graph_file = NULL;
-        umask(S_IWGRP | S_IWOTH | S_IROTH);
-
-        graph_file = crm_strdup_printf("%s/pengine.graph.XXXXXX",
-                                       PE_STATE_DIR);
-        graph_file_fd = mkstemp(graph_file);
-
-        crm_err("Couldn't send transition graph to peer, writing to %s instead",
-                graph_file);
-
-        crm_xml_add(reply, F_CRM_TGRAPH, graph_file);
-        write_xml_fd(sched_data_set->graph, graph_file, graph_file_fd, FALSE);
-
-        free(graph_file);
-        free_xml(first_named_child(reply, F_CRM_DATA));
-        CRM_ASSERT(pcmk__ipc_send_xml(sender, 0, reply,
-                                      crm_ipc_server_event) == pcmk_rc_ok);
-    }
-
-    free_xml(reply);
-    pcmk__log_transition_summary(filename);
-
-    if (series_wrap == 0) {
-        crm_debug("Not saving input to disk (disabled by configuration)");
-
-    } else if (is_repoke) {
-        crm_info("Input has not changed since last time, not saving to disk");
-
-    } else {
-        unlink(filename);
-        crm_xml_add_ll(xml_data, "execution-date", (long long) execution_date);
-        write_xml_file(xml_data, filename, TRUE);
-        pcmk__write_series_sequence(PE_STATE_DIR, series[series_id].name,
-                                    ++seq, series_wrap);
-    }
-
-    free_xml(converted);
-}
-
-static gboolean
-process_pe_message(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
-{
-    const char *sys_to = crm_element_value(msg, F_CRM_SYS_TO);
-    const char *op = crm_element_value(msg, F_CRM_TASK);
-    const char *ref = crm_element_value(msg, F_CRM_REFERENCE);
-
-    crm_trace("Processing %s op (ref=%s)...", op, ref);
-
-    if (op == NULL) {
-        /* error */
-
-    } else if (strcasecmp(op, CRM_OP_HELLO) == 0) {
-        /* ignore */
-
-    } else if (pcmk__str_eq(crm_element_value(msg, F_CRM_MSG_TYPE), XML_ATTR_RESPONSE, pcmk__str_casei)) {
-        /* ignore */
-
-    } else if (sys_to == NULL || strcasecmp(sys_to, CRM_SYSTEM_PENGINE) != 0) {
-        crm_trace("Bad sys-to %s", crm_str(sys_to));
-        return FALSE;
-
-    } else if (strcasecmp(op, CRM_OP_PECALC) == 0) {
-        handle_pecalc_op(msg, xml_data, sender);
-    }
-
-    return TRUE;
-}
-
-static int32_t
-pe_ipc_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid)
-{
-    crm_trace("Connection %p", c);
-    if (pcmk__new_client(c, uid, gid) == NULL) {
-        return -EIO;
-    }
-    return 0;
-}
-
-gboolean process_pe_message(xmlNode *msg, xmlNode *xml_data,
-                            pcmk__client_t *sender);
-
-static int32_t
-pe_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
-{
-    uint32_t id = 0;
-    uint32_t flags = 0;
-    pcmk__client_t *c = pcmk__find_client(qbc);
-    xmlNode *msg = pcmk__client_data2xml(c, data, &id, &flags);
-
-    pcmk__ipc_send_ack(c, id, flags, "ack", CRM_EX_INDETERMINATE);
-    if (msg != NULL) {
-        xmlNode *data_xml = get_message_xml(msg, F_CRM_DATA);
-
-        process_pe_message(msg, data_xml, c);
-        free_xml(msg);
-    }
-    return 0;
-}
-
-/* Error code means? */
-static int32_t
-pe_ipc_closed(qb_ipcs_connection_t * c)
-{
-    pcmk__client_t *client = pcmk__find_client(c);
-
-    if (client == NULL) {
-        return 0;
-    }
-    crm_trace("Connection %p", c);
-    pcmk__free_client(client);
-    return 0;
-}
-
-static void
-pe_ipc_destroy(qb_ipcs_connection_t * c)
-{
-    crm_trace("Connection %p", c);
-    pe_ipc_closed(c);
-}
-
-struct qb_ipcs_service_handlers ipc_callbacks = {
-    .connection_accept = pe_ipc_accept,
-    .connection_created = NULL,
-    .msg_process = pe_ipc_dispatch,
-    .connection_closed = pe_ipc_closed,
-    .connection_destroyed = pe_ipc_destroy
-};
 
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {

--- a/daemons/schedulerd/pacemaker-schedulerd.h
+++ b/daemons/schedulerd/pacemaker-schedulerd.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2004-2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__PACEMAKER_SCHEDULERD__H
+#define PCMK__PACEMAKER_SCHEDULERD__H
+
+#include <crm_internal.h>
+#include <crm/pengine/pe_types.h>
+
+extern pe_working_set_t *sched_data_set;
+extern pcmk__output_t *logger_out;
+extern pcmk__output_t *out;
+extern struct qb_ipcs_service_handlers ipc_callbacks;
+
+#endif

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2004-2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/msg_xml.h>
+#include <pacemaker-internal.h>
+
+#include <stdbool.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "pacemaker-schedulerd.h"
+
+static void
+init_working_set(void)
+{
+    crm_config_error = FALSE;
+    crm_config_warning = FALSE;
+
+    was_processing_error = FALSE;
+    was_processing_warning = FALSE;
+
+    if (sched_data_set == NULL) {
+        sched_data_set = pe_new_working_set();
+        CRM_ASSERT(sched_data_set != NULL);
+        pe__set_working_set_flags(sched_data_set,
+                                  pe_flag_no_counts|pe_flag_no_compat);
+        pe__set_working_set_flags(sched_data_set,
+                                  pe_flag_show_utilization);
+        sched_data_set->priv = logger_out;
+    } else {
+        pe_reset_working_set(sched_data_set);
+    }
+}
+
+static void
+handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
+{
+    static struct series_s {
+        const char *name;
+        const char *param;
+
+        /* Maximum number of inputs of this kind to save to disk.
+         * If -1, save all; if 0, save none.
+         */
+        int wrap;
+    } series[] = {
+        { "pe-error", "pe-error-series-max", -1 },
+        { "pe-warn",  "pe-warn-series-max",  5000 },
+        { "pe-input", "pe-input-series-max", 4000 },
+    };
+    static char *last_digest = NULL;
+    static char *filename = NULL;
+
+    unsigned int seq;
+    int series_id = 0;
+    int series_wrap = 0;
+    char *digest = NULL;
+    const char *value = NULL;
+    time_t execution_date = time(NULL);
+    xmlNode *converted = NULL;
+    xmlNode *reply = NULL;
+    bool is_repoke = false;
+    bool process = true;
+
+    init_working_set();
+
+    digest = calculate_xml_versioned_digest(xml_data, FALSE, FALSE,
+                                            CRM_FEATURE_SET);
+    converted = copy_xml(xml_data);
+    if (!cli_config_update(&converted, NULL, TRUE)) {
+        sched_data_set->graph = create_xml_node(NULL, XML_TAG_GRAPH);
+        crm_xml_add_int(sched_data_set->graph, "transition_id", 0);
+        crm_xml_add_int(sched_data_set->graph, "cluster-delay", 0);
+        process = false;
+        free(digest);
+
+    } else if (pcmk__str_eq(digest, last_digest, pcmk__str_casei)) {
+        is_repoke = true;
+        free(digest);
+
+    } else {
+        free(last_digest);
+        last_digest = digest;
+    }
+
+    if (process) {
+        pcmk__schedule_actions(sched_data_set, converted, NULL);
+    }
+
+    // Get appropriate index into series[] array
+    if (was_processing_error) {
+        series_id = 0;
+    } else if (was_processing_warning) {
+        series_id = 1;
+    } else {
+        series_id = 2;
+    }
+
+    value = pe_pref(sched_data_set->config_hash, series[series_id].param);
+    if ((value == NULL)
+        || (pcmk__scan_min_int(value, &series_wrap, -1) != pcmk_rc_ok)) {
+        series_wrap = series[series_id].wrap;
+    }
+
+    if (pcmk__read_series_sequence(PE_STATE_DIR, series[series_id].name,
+                                   &seq) != pcmk_rc_ok) {
+        // @TODO maybe handle errors better ...
+        seq = 0;
+    }
+    crm_trace("Series %s: wrap=%d, seq=%u, pref=%s",
+              series[series_id].name, series_wrap, seq, value);
+
+    sched_data_set->input = NULL;
+    reply = create_reply(msg, sched_data_set->graph);
+    CRM_ASSERT(reply != NULL);
+
+    if (series_wrap == 0) { // Don't save any inputs of this kind
+        free(filename);
+        filename = NULL;
+
+    } else if (!is_repoke) { // Input changed, save to disk
+        free(filename);
+        filename = pcmk__series_filename(PE_STATE_DIR,
+                                         series[series_id].name, seq, true);
+    }
+
+    crm_xml_add(reply, F_CRM_TGRAPH_INPUT, filename);
+    crm_xml_add_int(reply, "graph-errors", was_processing_error);
+    crm_xml_add_int(reply, "graph-warnings", was_processing_warning);
+    crm_xml_add_int(reply, "config-errors", crm_config_error);
+    crm_xml_add_int(reply, "config-warnings", crm_config_warning);
+
+    if (pcmk__ipc_send_xml(sender, 0, reply,
+                           crm_ipc_server_event) != pcmk_rc_ok) {
+        int graph_file_fd = 0;
+        char *graph_file = NULL;
+        umask(S_IWGRP | S_IWOTH | S_IROTH);
+
+        graph_file = crm_strdup_printf("%s/pengine.graph.XXXXXX",
+                                       PE_STATE_DIR);
+        graph_file_fd = mkstemp(graph_file);
+
+        crm_err("Couldn't send transition graph to peer, writing to %s instead",
+                graph_file);
+
+        crm_xml_add(reply, F_CRM_TGRAPH, graph_file);
+        write_xml_fd(sched_data_set->graph, graph_file, graph_file_fd, FALSE);
+
+        free(graph_file);
+        free_xml(first_named_child(reply, F_CRM_DATA));
+        CRM_ASSERT(pcmk__ipc_send_xml(sender, 0, reply,
+                                      crm_ipc_server_event) == pcmk_rc_ok);
+    }
+
+    free_xml(reply);
+    pcmk__log_transition_summary(filename);
+
+    if (series_wrap == 0) {
+        crm_debug("Not saving input to disk (disabled by configuration)");
+
+    } else if (is_repoke) {
+        crm_info("Input has not changed since last time, not saving to disk");
+
+    } else {
+        unlink(filename);
+        crm_xml_add_ll(xml_data, "execution-date", (long long) execution_date);
+        write_xml_file(xml_data, filename, TRUE);
+        pcmk__write_series_sequence(PE_STATE_DIR, series[series_id].name,
+                                    ++seq, series_wrap);
+    }
+
+    free_xml(converted);
+}
+
+static gboolean
+process_pe_message(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
+{
+    const char *sys_to = crm_element_value(msg, F_CRM_SYS_TO);
+    const char *op = crm_element_value(msg, F_CRM_TASK);
+    const char *ref = crm_element_value(msg, F_CRM_REFERENCE);
+
+    crm_trace("Processing %s op (ref=%s)...", op, ref);
+
+    if (op == NULL) {
+        /* error */
+
+    } else if (strcasecmp(op, CRM_OP_HELLO) == 0) {
+        /* ignore */
+
+    } else if (pcmk__str_eq(crm_element_value(msg, F_CRM_MSG_TYPE), XML_ATTR_RESPONSE, pcmk__str_casei)) {
+        /* ignore */
+
+    } else if (sys_to == NULL || strcasecmp(sys_to, CRM_SYSTEM_PENGINE) != 0) {
+        crm_trace("Bad sys-to %s", crm_str(sys_to));
+        return FALSE;
+
+    } else if (strcasecmp(op, CRM_OP_PECALC) == 0) {
+        handle_pecalc_op(msg, xml_data, sender);
+    }
+
+    return TRUE;
+}
+
+static int32_t
+pe_ipc_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid)
+{
+    crm_trace("Connection %p", c);
+    if (pcmk__new_client(c, uid, gid) == NULL) {
+        return -EIO;
+    }
+    return 0;
+}
+
+static int32_t
+pe_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
+{
+    uint32_t id = 0;
+    uint32_t flags = 0;
+    pcmk__client_t *c = pcmk__find_client(qbc);
+    xmlNode *msg = pcmk__client_data2xml(c, data, &id, &flags);
+
+    pcmk__ipc_send_ack(c, id, flags, "ack", CRM_EX_INDETERMINATE);
+    if (msg != NULL) {
+        xmlNode *data_xml = get_message_xml(msg, F_CRM_DATA);
+
+        process_pe_message(msg, data_xml, c);
+        free_xml(msg);
+    }
+    return 0;
+}
+
+/* Error code means? */
+static int32_t
+pe_ipc_closed(qb_ipcs_connection_t * c)
+{
+    pcmk__client_t *client = pcmk__find_client(c);
+
+    if (client == NULL) {
+        return 0;
+    }
+    crm_trace("Connection %p", c);
+    pcmk__free_client(client);
+    return 0;
+}
+
+static void
+pe_ipc_destroy(qb_ipcs_connection_t * c)
+{
+    crm_trace("Connection %p", c);
+    pe_ipc_closed(c);
+}
+
+struct qb_ipcs_service_handlers ipc_callbacks = {
+    .connection_accept = pe_ipc_accept,
+    .connection_created = NULL,
+    .msg_process = pe_ipc_dispatch,
+    .connection_closed = pe_ipc_closed,
+    .connection_destroyed = pe_ipc_destroy
+};

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -181,7 +181,7 @@ handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
     free_xml(converted);
 }
 
-static gboolean
+static void
 process_pe_message(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
 {
     const char *sys_to = crm_element_value(msg, F_CRM_SYS_TO);
@@ -201,13 +201,10 @@ process_pe_message(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
 
     } else if (sys_to == NULL || strcasecmp(sys_to, CRM_SYSTEM_PENGINE) != 0) {
         crm_trace("Bad sys-to %s", crm_str(sys_to));
-        return FALSE;
 
     } else if (strcasecmp(op, CRM_OP_PECALC) == 0) {
         handle_pecalc_op(msg, xml_data, sender);
     }
-
-    return TRUE;
 }
 
 static int32_t

--- a/include/crm/common/Makefile.am
+++ b/include/crm/common/Makefile.am
@@ -12,7 +12,8 @@ MAINTAINERCLEANFILES = Makefile.in
 headerdir=$(pkgincludedir)/crm/common
 
 header_HEADERS = xml.h ipc.h util.h iso8601.h mainloop.h logging.h results.h \
-		 nvpair.h acl.h agents.h ipc_controld.h ipc_pacemakerd.h output.h \
+		 nvpair.h acl.h agents.h ipc_controld.h ipc_pacemakerd.h ipc_schedulerd.h \
+		 output.h \
 		 agents_compat.h	\
 		 logging_compat.h	\
 		 mainloop_compat.h	\

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -239,6 +239,12 @@ void pcmk__stop_based_ipc(qb_ipcs_service_t *ipcs_ro,
         qb_ipcs_service_t *ipcs_rw,
         qb_ipcs_service_t *ipcs_shm);
 
+static inline const char *
+pcmk__ipc_sys_name(const char *ipc_name, const char *fallback)
+{
+    return ipc_name ? ipc_name : ((crm_system_name ? crm_system_name : fallback));
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -226,6 +226,7 @@ void pcmk__serve_fenced_ipc(qb_ipcs_service_t **ipcs,
                             struct qb_ipcs_service_handlers *cb);
 void pcmk__serve_pacemakerd_ipc(qb_ipcs_service_t **ipcs,
                                 struct qb_ipcs_service_handlers *cb);
+qb_ipcs_service_t *pcmk__serve_schedulerd_ipc(struct qb_ipcs_service_handlers *cb);
 qb_ipcs_service_t *pcmk__serve_controld_ipc(struct qb_ipcs_service_handlers *cb);
 
 void pcmk__serve_based_ipc(qb_ipcs_service_t **ipcs_ro,

--- a/include/crm/common/ipc_schedulerd.h
+++ b/include/crm/common/ipc_schedulerd.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__IPC_SCHEDULERD__H
+#  define PCMK__IPC_SCHEDULERD__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \file
+ * \brief IPC commands for Schedulerd
+ *
+ * \ingroup core
+ */
+
+#include <crm/common/ipc.h>  // pcmk_ipc_api_t
+
+//! Possible types of schedulerd replies
+enum pcmk_schedulerd_api_reply {
+    pcmk_schedulerd_reply_unknown,
+    pcmk_schedulerd_reply_graph,
+};
+
+/*!
+ * Schedulerd reply passed to event callback
+ */
+typedef struct {
+    enum pcmk_schedulerd_api_reply reply_type;
+
+    union {
+        // pcmk__schedulerd_reply_graph
+        struct {
+            xmlNode *tgraph;
+            const char *reference;
+            const char *input;
+        } graph;
+    } data;
+} pcmk_schedulerd_api_reply_t;
+
+/*!
+ * \brief Make an IPC request to the scheduler for the transition graph
+ *
+ * \param[in]  api IPC API connection
+ * \param[in]  cib The CIB to create a transition graph for
+ * \param[out] ref The reference ID a response will have
+ *
+ * \return Standard Pacemaker return code
+ */
+int pcmk_schedulerd_api_graph(pcmk_ipc_api_t *api, xmlNode *cib, char **ref);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PCMK__IPC_SCHEDULERD__H

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -66,6 +66,7 @@ libcrmcommon_la_SOURCES	+= ipc_client.c
 libcrmcommon_la_SOURCES	+= ipc_common.c
 libcrmcommon_la_SOURCES	+= ipc_controld.c
 libcrmcommon_la_SOURCES	+= ipc_pacemakerd.c
+libcrmcommon_la_SOURCES 	+= ipc_schedulerd.c
 libcrmcommon_la_SOURCES	+= ipc_server.c
 libcrmcommon_la_SOURCES	+= iso8601.c
 libcrmcommon_la_SOURCES	+= lists.c

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -264,6 +264,9 @@ pcmk__ipc_methods_t *pcmk__controld_api_methods(void);
 G_GNUC_INTERNAL
 pcmk__ipc_methods_t *pcmk__pacemakerd_api_methods(void);
 
+G_GNUC_INTERNAL
+pcmk__ipc_methods_t *pcmk__schedulerd_api_methods(void);
+
 
 /*
  * Logging

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -41,7 +41,7 @@
  *
  * \note The caller is responsible for freeing *api using pcmk_free_ipc_api().
  * \note This is intended to supersede crm_ipc_new() but currently only
- *       supports the controller & pacemakerd IPC API.
+ *       supports the controller, pacemakerd, and schedulerd IPC API.
  */
 int
 pcmk_new_ipc_api(pcmk_ipc_api_t **api, enum pcmk_ipc_server server)
@@ -88,6 +88,7 @@ pcmk_new_ipc_api(pcmk_ipc_api_t **api, enum pcmk_ipc_server server)
             break;
 
         case pcmk_ipc_schedulerd:
+            (*api)->cmds = pcmk__schedulerd_api_methods();
             // @TODO max_size could vary by client, maybe take as argument?
             (*api)->ipc_size_max = 5 * 1024 * 1024; // 5MB
             break;
@@ -263,7 +264,7 @@ pcmk_ipc_name(pcmk_ipc_api_t *api, bool for_log)
             return for_log? "launcher" : CRM_SYSTEM_MCP;
 
         case pcmk_ipc_schedulerd:
-            return for_log? "scheduler" : NULL /* CRM_SYSTEM_PENGINE */;
+            return for_log? "scheduler" : CRM_SYSTEM_PENGINE;
 
         default:
             return for_log? "Pacemaker" : NULL;

--- a/lib/common/ipc_pacemakerd.c
+++ b/lib/common/ipc_pacemakerd.c
@@ -220,8 +220,8 @@ do_pacemakerd_api_call(pcmk_ipc_api_t *api, const char *ipc_name, const char *ta
     CRM_ASSERT(private != NULL);
 
     cmd = create_request(task, NULL, NULL, CRM_SYSTEM_MCP,
-        ipc_name?ipc_name:((crm_system_name? crm_system_name : "client")),
-        private->client_uuid);
+                         pcmk__ipc_sys_name(ipc_name, "client"),
+                         private->client_uuid);
 
     if (cmd) {
         rc = pcmk__send_ipc_request(api, cmd);

--- a/lib/common/ipc_pacemakerd.c
+++ b/lib/common/ipc_pacemakerd.c
@@ -215,7 +215,10 @@ do_pacemakerd_api_call(pcmk_ipc_api_t *api, const char *ipc_name, const char *ta
     xmlNode *cmd;
     int rc;
 
-    CRM_CHECK(api != NULL, return -EINVAL);
+    if (api == NULL) {
+        return EINVAL;
+    }
+
     private = api->api_data;
     CRM_ASSERT(private != NULL);
 
@@ -226,9 +229,8 @@ do_pacemakerd_api_call(pcmk_ipc_api_t *api, const char *ipc_name, const char *ta
     if (cmd) {
         rc = pcmk__send_ipc_request(api, cmd);
         if (rc != pcmk_rc_ok) {
-            crm_debug("Couldn't ping pacemakerd: %s rc=%d",
-                pcmk_rc_str(rc), rc);
-            rc = ECOMM;
+            crm_debug("Couldn't send request to pacemakerd: %s rc=%d",
+                      pcmk_rc_str(rc), rc);
         }
         free_xml(cmd);
     } else {

--- a/lib/common/ipc_schedulerd.c
+++ b/lib/common/ipc_schedulerd.c
@@ -143,8 +143,8 @@ do_schedulerd_api_call(pcmk_ipc_api_t *api, const char *task, xmlNode *cib, char
     xmlNode *cmd = NULL;
     int rc;
 
-    if (api == NULL) {
-        return EINVAL;
+    if (!pcmk_ipc_is_connected(api)) {
+        return ENOTCONN;
     }
 
     private = api->api_data;

--- a/lib/common/ipc_schedulerd.c
+++ b/lib/common/ipc_schedulerd.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdlib.h>
+#include <time.h>
+
+#include <crm/crm.h>
+#include <crm/msg_xml.h>
+#include <crm/common/xml.h>
+#include <crm/common/ipc.h>
+#include <crm/common/ipc_internal.h>
+#include <crm/common/ipc_schedulerd.h>
+#include "crmcommon_private.h"
+
+typedef struct schedulerd_api_private_s {
+    char *client_uuid;
+} schedulerd_api_private_t;
+
+// \return Standard Pacemaker return code
+static int
+new_data(pcmk_ipc_api_t *api)
+{
+    struct schedulerd_api_private_s *private = NULL;
+
+    api->api_data = calloc(1, sizeof(struct schedulerd_api_private_s));
+
+    if (api->api_data == NULL) {
+        return errno;
+    }
+
+    private = api->api_data;
+    /* See comments in ipc_pacemakerd.c. */
+    private->client_uuid = pcmk__getpid_s();
+
+    return pcmk_rc_ok;
+}
+
+static void
+free_data(void *data)
+{
+    free(((struct schedulerd_api_private_s *) data)->client_uuid);
+    free(data);
+}
+
+// \return Standard Pacemaker return code
+static int
+post_connect(pcmk_ipc_api_t *api)
+{
+    if (api->api_data == NULL) {
+        return EINVAL;
+    }
+
+    return pcmk_rc_ok;
+}
+
+static bool
+reply_expected(pcmk_ipc_api_t *api, xmlNode *request)
+{
+    const char *command = crm_element_value(request, F_CRM_TASK);
+
+    if (command == NULL) {
+        return false;
+    }
+
+    // We only need to handle commands that functions in this file can send
+    return pcmk__str_any_of(command, CRM_OP_PECALC, NULL);
+}
+
+static void
+dispatch(pcmk_ipc_api_t *api, xmlNode *reply)
+{
+    crm_exit_t status = CRM_EX_OK;
+    xmlNode *msg_data = NULL;
+    pcmk_schedulerd_api_reply_t reply_data = {
+        pcmk_schedulerd_reply_unknown
+    };
+    const char *value = NULL;
+
+    if (pcmk__str_eq((const char *) reply->name, "ack", pcmk__str_casei)) {
+        return;
+    }
+
+    value = crm_element_value(reply, F_CRM_MSG_TYPE);
+    if ((value == NULL) || (strcmp(value, XML_ATTR_RESPONSE))) {
+        crm_debug("Unrecognizable schedulerd message: invalid message type '%s'",
+                  crm_str(value));
+        status = CRM_EX_PROTOCOL;
+        goto done;
+    }
+
+    if (crm_element_value(reply, XML_ATTR_REFERENCE) == NULL) {
+        crm_debug("Unrecognizable schedulerd message: no reference");
+        status = CRM_EX_PROTOCOL;
+        goto done;
+    }
+
+    // Parse useful info from reply
+    msg_data = get_message_xml(reply, F_CRM_DATA);
+    value = crm_element_value(reply, F_CRM_TASK);
+
+    if (pcmk__str_eq(value, CRM_OP_PECALC, pcmk__str_none)) {
+        reply_data.reply_type = pcmk_schedulerd_reply_graph;
+        reply_data.data.graph.reference = crm_element_value(reply, XML_ATTR_REFERENCE);
+        reply_data.data.graph.input = crm_element_value(reply, F_CRM_TGRAPH_INPUT);
+        reply_data.data.graph.tgraph = msg_data;
+    } else {
+        crm_debug("Unrecognizable pacemakerd message: '%s'", crm_str(value));
+        status = CRM_EX_PROTOCOL;
+        goto done;
+    }
+
+done:
+    pcmk__call_ipc_callback(api, pcmk_ipc_event_reply, status, &reply_data);
+}
+
+pcmk__ipc_methods_t *
+pcmk__schedulerd_api_methods()
+{
+    pcmk__ipc_methods_t *cmds = calloc(1, sizeof(pcmk__ipc_methods_t));
+
+    if (cmds != NULL) {
+        cmds->new_data = new_data;
+        cmds->free_data = free_data;
+        cmds->post_connect = post_connect;
+        cmds->reply_expected = reply_expected;
+        cmds->dispatch = dispatch;
+    }
+    return cmds;
+}
+
+static int
+do_schedulerd_api_call(pcmk_ipc_api_t *api, const char *task, xmlNode *cib, char **ref)
+{
+    schedulerd_api_private_t *private;
+    xmlNode *cmd = NULL;
+    int rc;
+
+    if (api == NULL) {
+        return EINVAL;
+    }
+
+    private = api->api_data;
+    CRM_ASSERT(private != NULL);
+
+    cmd = create_request(task, cib, NULL, CRM_SYSTEM_PENGINE,
+                         crm_system_name? crm_system_name : "client",
+                         private->client_uuid);
+
+    if (cmd) {
+        rc = pcmk__send_ipc_request(api, cmd);
+        if (rc != pcmk_rc_ok) {
+            crm_debug("Couldn't send request to schedulerd: %s rc=%d",
+                      pcmk_rc_str(rc), rc);
+        }
+
+        *ref = strdup(crm_element_value(cmd, F_CRM_REFERENCE));
+        free_xml(cmd);
+    } else {
+        rc = ENOMSG;
+    }
+
+    return rc;
+}
+
+int
+pcmk_schedulerd_api_graph(pcmk_ipc_api_t *api, xmlNode *cib, char **ref)
+{
+    return do_schedulerd_api_call(api, CRM_OP_PECALC, cib, ref);
+}

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -945,6 +945,20 @@ pcmk__serve_pacemakerd_ipc(qb_ipcs_service_t **ipcs,
 }
 
 /*!
+ * \internal
+ * \brief Add an IPC server to the main loop for the pacemaker-schedulerd API
+ *
+ * \param[in] cb IPC callbacks
+ *
+ * \note This function exits fatally if unable to create the servers.
+ */
+qb_ipcs_service_t *
+pcmk__serve_schedulerd_ipc(struct qb_ipcs_service_handlers *cb)
+{
+    return mainloop_add_ipc_server(CRM_SYSTEM_PENGINE, QB_IPC_NATIVE, cb);
+}
+
+/*!
  * \brief Check whether string represents a client name used by cluster daemons
  *
  * \param[in] name  String to check


### PR DESCRIPTION
This patch set does three things:

* Convert pacemaker-schedulerd to use glib for its command line handling.
* Rearrange how pacemaker-schedulerd uses formatted output.
* Convert pacemaker-schedulerd to use the new IPC API mechanism.