### PR TITLE
Low: tests: Use mock_ptr_type instead of mock_type...

### DIFF
--- a/lib/common/tests/io/pcmk__get_tmpdir_test.c
+++ b/lib/common/tests/io/pcmk__get_tmpdir_test.c
@@ -30,7 +30,7 @@ __wrap_getenv(const char *name)
      * the mocked version is only called in that time.
      */
     if (use_mocked) {
-        return mock_type(char *);
+        return mock_ptr_type(char *);
     } else {
         return __real_getenv(name);
     }

--- a/lib/common/tests/utils/pcmk_hostname_test.c
+++ b/lib/common/tests/utils/pcmk_hostname_test.c
@@ -26,7 +26,7 @@ __wrap_uname(struct utsname *buf)
     int retval = mock_type(int);
 
     if (retval == 0) {
-        strcpy(buf->nodename, mock_type(char *));
+        strcpy(buf->nodename, mock_ptr_type(char *));
     }
 
     return retval;


### PR DESCRIPTION
...when returning a char *.  This appears to matter only on certain
platforms.