### PR TITLE
Mid: based controld: Suppresses unnecessary Election execution.

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1186,6 +1186,7 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     gboolean global_update = FALSE;
     gboolean config_changed = FALSE;
     gboolean manage_counters = TRUE;
+    gboolean needs_election = TRUE;
 
     static mainloop_timer_t *digest_timer = NULL;
 
@@ -1312,6 +1313,7 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
 
             } else if (pcmk__str_eq(section, XML_CIB_TAG_CONFIGURATION, pcmk__str_casei)) {
                 send_r_notify = TRUE;
+                needs_election = FALSE;
             }
 
         } else if (pcmk__str_eq(CIB_OP_ERASE, op, pcmk__str_none)) {
@@ -1351,7 +1353,7 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     if (send_r_notify) {
         const char *origin = crm_element_value(request, F_ORIG);
 
-        cib_replace_notify(origin, the_cib, rc, *cib_diff);
+        cib_replace_notify(origin, the_cib, rc, *cib_diff, needs_election);
     }
 
     xml_log_patchset(LOG_TRACE, "cib:diff", *cib_diff);

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -234,7 +234,7 @@ attach_cib_generation(xmlNode * msg, const char *field, xmlNode * a_cib)
 }
 
 void
-cib_replace_notify(const char *origin, xmlNode * update, int result, xmlNode * diff)
+cib_replace_notify(const char *origin, xmlNode * update, int result, xmlNode * diff, gboolean needs_election)
 {
     xmlNode *replace_msg = NULL;
 
@@ -271,6 +271,7 @@ cib_replace_notify(const char *origin, xmlNode * update, int result, xmlNode * d
     crm_xml_add(replace_msg, F_SUBTYPE, T_CIB_REPLACE_NOTIFY);
     crm_xml_add(replace_msg, F_CIB_OPERATION, CIB_OP_REPLACE);
     crm_xml_add_int(replace_msg, F_CIB_RC, result);
+    crm_xml_add_boolean(replace_msg, F_CIB_NEEDS_ELECTION, needs_election);
     attach_cib_generation(replace_msg, "cib-replace-generation", update);
 
     crm_log_xml_trace(replace_msg, "CIB Replaced");

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -148,7 +148,7 @@ void cib_diff_notify(int options, const char *client, const char *call_id,
                      const char *op, xmlNode *update, int result,
                      xmlNode *old_cib);
 void cib_replace_notify(const char *origin, xmlNode *update, int result,
-                        xmlNode *diff);
+                        xmlNode *diff, gboolean needs_notify);
 
 static inline const char *
 cib_config_lookup(const char *opt)

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -43,7 +43,10 @@ do_cib_replaced(const char *event, xmlNode * msg)
 
     /* start the join process again so we get everyone's LRM status */
     populate_cib_nodes(node_update_quick|node_update_all, __func__);
-    register_fsa_input(C_FSA_INTERNAL, I_ELECTION, NULL);
+
+    if (crm_is_true(crm_element_value(msg, F_CIB_NEEDS_ELECTION))) {
+        register_fsa_input(C_FSA_INTERNAL, I_ELECTION, NULL);
+    }
 }
 
 void

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -58,6 +58,7 @@
 #  define F_CIB_LOCAL_NOTIFY_ID	"cib_local_notify_id"
 #  define F_CIB_PING_ID         "cib_ping_id"
 #  define F_CIB_SCHEMA_MAX      "cib_schema_max"
+#  define F_CIB_NEEDS_ELECTION  "cib_needs_election"
 
 #  define T_CIB			"cib"
 #  define T_CIB_NOTIFY		"cib_notify"


### PR DESCRIPTION
Hi All,

The following fix resolved one issue.
  - https://github.com/ClusterLabs/pacemaker/commit/7ddc27ca0877cbabde75f571354003e63108f8ea

However, as a result of this fix, unnecessary DC node elections will occur with each cib change.

For example, unnecessary elections occur in the following cases.
case 1) When the cluster is put into or released from maintenance mode.
case 2) When resource monitoring is disabled or enabled.
case 3) etc...

This fix eliminates unnecessary DC node elections.

Best Regards,
Hideo Yamauchi.