### PR TITLE
Low: daemons: Free memory at the end of fail_pending_op.

### DIFF
--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -86,6 +86,7 @@ fail_pending_op(gpointer key, gpointer value, gpointer user_data)
     event.params = op->params;
 
     process_lrm_event(lrm_state, &event, op, NULL);
+    lrmd__reset_result(&event);
     return TRUE;
 }
 


### PR DESCRIPTION
The event structure contains memory allocated by strdup that needs to be
freed when this function is done.