### PR TITLE
Track and log exit reasons in fencer

### DIFF
--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -886,7 +886,7 @@ class Tests(object):
             test.add_cmd("stonith_admin", "--output-as=xml -F node3 -t 20")
 
             test.add_stonith_log_pattern("Total timeout set to 40")
-            test.add_stonith_log_pattern("targeting node3 using false returned -201")
+            test.add_stonith_log_pattern("targeting node3 using false returned 1")
             test.add_stonith_log_pattern("targeting node3 using true returned 0")
 
         # test what happens when the first fencing level fails.
@@ -920,8 +920,8 @@ class Tests(object):
             test.add_cmd("stonith_admin", "--output-as=xml -F node3 -t 3")
 
             test.add_stonith_log_pattern("Total timeout set to 18")
-            test.add_stonith_log_pattern("targeting node3 using false1 returned -201")
-            test.add_stonith_log_pattern("targeting node3 using false2 returned -201")
+            test.add_stonith_log_pattern("targeting node3 using false1 returned 1")
+            test.add_stonith_log_pattern("targeting node3 using false2 returned 1")
             test.add_stonith_log_pattern("targeting node3 using true3 returned 0")
             test.add_stonith_log_pattern("targeting node3 using true4 returned 0")
 
@@ -987,7 +987,7 @@ class Tests(object):
             test.add_cmd("stonith_admin", "--output-as=xml -F node3 -t 20")
 
             test.add_stonith_log_pattern("Total timeout set to 8")
-            test.add_stonith_log_pattern("targeting node3 using false1 returned -201")
+            test.add_stonith_log_pattern("targeting node3 using false1 returned 1")
             test.add_stonith_neg_log_pattern("targeting node3 using false2 returned ")
             test.add_stonith_log_pattern("targeting node3 using true3 returned 0")
             test.add_stonith_log_pattern("targeting node3 using true4 returned 0")
@@ -1147,7 +1147,7 @@ class Tests(object):
                          "--output-as=xml -R true1 -a fence_dummy_no_reboot -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
             test.add_cmd("stonith_admin", "--output-as=xml -B node1 -t 5 -V")
             test.add_stonith_log_pattern("does not support reboot")
-            test.add_stonith_log_pattern("using true1 returned 0 (OK)")
+            test.add_stonith_log_pattern("using true1 returned 0")
 
         # make sure reboot is used when reboot action is advertised
         for test_type in test_types:
@@ -1158,7 +1158,7 @@ class Tests(object):
                          "--output-as=xml -R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
             test.add_cmd("stonith_admin", "--output-as=xml -B node1 -t 5 -V")
             test.add_stonith_neg_log_pattern("does not advertise support for 'reboot', performing 'off'")
-            test.add_stonith_log_pattern("using true1 returned 0 (OK)")
+            test.add_stonith_log_pattern("using true1 returned 0")
 
         # make sure requested fencing delay is applied only for the first device in the first level
         # make sure static delay from pcmk_delay_base is added
@@ -1240,8 +1240,8 @@ class Tests(object):
                      '--output-as=xml -R true2 -a fence_dummy_auto_unfence -o "mode=pass" -o "pcmk_host_list=%s"' % (our_uname))
         test.add_cmd("stonith_admin", "--output-as=xml -U %s -t 3" % (our_uname))
         # both devices should be executed
-        test.add_stonith_log_pattern("using true1 returned 0 (OK)")
-        test.add_stonith_log_pattern("using true2 returned 0 (OK)")
+        test.add_stonith_log_pattern("using true1 returned 0")
+        test.add_stonith_log_pattern("using true2 returned 0")
 
         ### verify unfencing using automatic unfencing fails if any of the required agents fail
         test = self.new_test("cpg_unfence_required_2",
@@ -1264,8 +1264,8 @@ class Tests(object):
         test.add_cmd("stonith_admin", "--output-as=xml -r %s -i 1 -v true1" % (our_uname))
         test.add_cmd("stonith_admin", "--output-as=xml -r %s -i 2 -v true2" % (our_uname))
         test.add_cmd("stonith_admin", "--output-as=xml -U %s -t 3" % (our_uname))
-        test.add_stonith_log_pattern("using true1 returned 0 (OK)")
-        test.add_stonith_log_pattern("using true2 returned 0 (OK)")
+        test.add_stonith_log_pattern("using true1 returned 0")
+        test.add_stonith_log_pattern("using true2 returned 0")
 
         ### verify unfencing using automatic devices with topology
         test = self.new_test("cpg_unfence_required_4",
@@ -1296,10 +1296,10 @@ class Tests(object):
         test.add_cmd("stonith_admin", "--output-as=xml -r %s -i 3 -v false4" % (our_uname))
         test.add_cmd("stonith_admin", "--output-as=xml -r %s -i 4 -v true4" % (our_uname))
         test.add_cmd("stonith_admin", "--output-as=xml -U %s -t 3" % (our_uname))
-        test.add_stonith_log_pattern("using true1 returned 0 (OK)")
-        test.add_stonith_log_pattern("using true2 returned 0 (OK)")
-        test.add_stonith_log_pattern("using true3 returned 0 (OK)")
-        test.add_stonith_log_pattern("using true4 returned 0 (OK)")
+        test.add_stonith_log_pattern("using true1 returned 0")
+        test.add_stonith_log_pattern("using true2 returned 0")
+        test.add_stonith_log_pattern("using true3 returned 0")
+        test.add_stonith_log_pattern("using true4 returned 0")
 
     def build_unfence_on_target_tests(self):
         """ Register tests that verify unfencing that runs on the target """

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -2684,16 +2684,15 @@ log_executor_event(lrmd_event_data_t *op, const char *op_key,
     do_crm_log(log_level, "%s", str->str);
     g_string_free(str, TRUE);
 
-    if (op->output != NULL) {
-        char *prefix = crm_strdup_printf("%s-" PCMK__OP_FMT ":%d", node_name,
+    /* The services library has already logged the output at info or debug
+     * level, so just raise to notice if it looks like a failure.
+     */
+    if ((op->output != NULL) && (op->rc != PCMK_OCF_OK)) {
+        char *prefix = crm_strdup_printf(PCMK__OP_FMT "@%s output",
                                          op->rsc_id, op->op_type,
-                                         op->interval_ms, op->call_id);
+                                         op->interval_ms, node_name);
 
-        if (op->rc) {
-            crm_log_output(LOG_NOTICE, prefix, op->output);
-        } else {
-            crm_log_output(LOG_DEBUG, prefix, op->output);
-        }
+        crm_log_output(LOG_NOTICE, prefix, op->output);
         free(prefix);
     }
 }

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -477,7 +477,7 @@ stonith_device_execute(stonith_device_t * device)
                     "because unable to load CIB secrets: %s",
                      device->id, pcmk_rc_str(exec_rc));
             report_internal_result(cmd, CRM_EX_ERROR, PCMK_EXEC_NO_SECRETS,
-                                   NULL);
+                                   "Failed to get CIB secrets");
             goto done;
         }
     }
@@ -641,7 +641,7 @@ free_device(gpointer data)
 
         crm_warn("Removal of device '%s' purged operation '%s'", device->id, cmd->action);
         report_internal_result(cmd, CRM_EX_ERROR, PCMK_EXEC_NO_FENCE_DEVICE,
-                               NULL);
+                               "Device was removed before action could be executed");
     }
     g_list_free(device->pending_ops);
 

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -996,7 +996,7 @@ stonith_manual_ack(xmlNode * msg, remote_fencing_op_t * op)
 
     remote_op_done(op, msg, pcmk_ok, FALSE);
 
-    /* Replies are sent via done_cb->stonith_send_async_reply()->do_local_reply() */
+    // Replies are sent via done_cb -> send_async_reply() -> do_local_reply()
     return -EINPROGRESS;
 }
 

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -58,8 +58,7 @@ stonith_action_t *stonith_action_create(const char *agent,
                                         GHashTable * port_map,
                                         const char * host_arg);
 void stonith__destroy_action(stonith_action_t *action);
-void stonith__action_result(stonith_action_t *action, int *rc, char **output,
-                            char **error_output);
+pcmk__action_result_t *stonith__action_result(stonith_action_t *action);
 int stonith__result2rc(const pcmk__action_result_t *result);
 
 int

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -64,7 +64,8 @@ int stonith__result2rc(const pcmk__action_result_t *result);
 int
 stonith_action_execute_async(stonith_action_t * action,
                              void *userdata,
-                             void (*done) (int pid, int rc, const char *output,
+                             void (*done) (int pid,
+                                           const pcmk__action_result_t *result,
                                            void *user_data),
                              void (*fork_cb) (int pid, void *user_data));
 

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -60,6 +60,7 @@ stonith_action_t *stonith_action_create(const char *agent,
 void stonith__destroy_action(stonith_action_t *action);
 void stonith__action_result(stonith_action_t *action, int *rc, char **output,
                             char **error_output);
+int stonith__result2rc(const pcmk__action_result_t *result);
 
 int
 stonith_action_execute_async(stonith_action_t * action,

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -46,7 +46,8 @@ struct stonith_action_s {
     int timeout;
     int async;
     void *userdata;
-    void (*done_cb) (int pid, int status, const char *output, void *user_data);
+    void (*done_cb) (int pid, const pcmk__action_result_t *result,
+                     void *user_data);
     void (*fork_cb) (int pid, void *user_data);
 
     svc_action_t *svc_action;
@@ -811,9 +812,7 @@ stonith_action_async_done(svc_action_t *svc_action)
     }
 
     if (action->done_cb) {
-        action->done_cb(action->pid,
-                        pcmk_rc2legacy(stonith__result2rc(&(action->result))),
-                        action->result.action_stdout, action->userdata);
+        action->done_cb(action->pid, &(action->result), action->userdata);
     }
 
     action->svc_action = NULL; // don't remove our caller
@@ -933,7 +932,8 @@ internal_stonith_action_execute(stonith_action_t * action)
 int
 stonith_action_execute_async(stonith_action_t * action,
                              void *userdata,
-                             void (*done) (int pid, int rc, const char *output,
+                             void (*done) (int pid,
+                                           const pcmk__action_result_t *result,
                                            void *user_data),
                              void (*fork_cb) (int pid, void *user_data))
 {

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -276,14 +276,9 @@ stonith__watchdog_fencing_enabled_for_node(const char *node)
 static void
 log_action(stonith_action_t *action, pid_t pid)
 {
-    if (action->result.action_stdout != NULL) {
-        /* Logging the whole string confuses syslog when the string is xml */
-        char *prefix = crm_strdup_printf("%s[%d] stdout:", action->agent, pid);
-
-        crm_log_output(LOG_TRACE, prefix, action->result.action_stdout);
-        free(prefix);
-    }
-
+    /* The services library has already logged the output at info or debug
+     * level, so just raise to warning for stderr.
+     */
     if (action->result.action_stderr != NULL) {
         /* Logging the whole string confuses syslog when the string is xml */
         char *prefix = crm_strdup_printf("%s[%d] stderr:", action->agent, pid);

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -670,40 +670,14 @@ stonith__destroy_action(stonith_action_t *action)
  * \internal
  * \brief Get the result of an executed stonith action
  *
- * \param[in,out] action        Executed action
- * \param[out]    rc            Where to store result code (or NULL)
- * \param[out]    output        Where to store standard output (or NULL)
- * \param[out]    error_output  Where to store standard error output (or NULL)
+ * \param[in] action  Executed action
  *
- * \note If output or error_output is not NULL, the caller is responsible for
- *       freeing the memory.
+ * \return Pointer to action's result (or NULL if \p action is NULL)
  */
-void
-stonith__action_result(stonith_action_t *action, int *rc, char **output,
-                       char **error_output)
+pcmk__action_result_t *
+stonith__action_result(stonith_action_t *action)
 {
-    if (rc) {
-        *rc = pcmk_ok;
-    }
-    if (output) {
-        *output = NULL;
-    }
-    if (error_output) {
-        *error_output = NULL;
-    }
-    if (action != NULL) {
-        if (rc) {
-            *rc = pcmk_rc2legacy(stonith__result2rc(&(action->result)));
-        }
-        if ((output != NULL) && (action->result.action_stdout != NULL)) {
-            *output = action->result.action_stdout;
-            action->result.action_stdout = NULL; // hand off ownership to caller
-        }
-        if ((error_output != NULL) && (action->result.action_stderr != NULL)) {
-            *error_output = action->result.action_stderr;
-            action->result.action_stderr = NULL; // hand off ownership to caller
-        }
-    }
+    return (action == NULL)? NULL : &(action->result);
 }
 
 #define FAILURE_MAX_RETRIES 2

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -207,7 +207,7 @@ static void
 set_result_from_svc_action(stonith_action_t *action, svc_action_t *svc_action)
 {
     pcmk__set_result(&(action->result), svc_action->rc, svc_action->status,
-                     NULL);
+                     services__exit_reason(svc_action));
     pcmk__set_result_output(&(action->result),
                             services__grab_stdout(svc_action),
                             services__grab_stderr(svc_action));
@@ -706,7 +706,7 @@ stonith_action_create(const char *agent,
     action->max_retries = FAILURE_MAX_RETRIES;
 
     pcmk__set_result(&(action->result), PCMK_OCF_UNKNOWN, PCMK_EXEC_UNKNOWN,
-                     NULL);
+                     "Initialization bug in fencing library");
 
     if (device_args) {
         char buffer[512];
@@ -849,7 +849,7 @@ internal_stonith_action_execute(stonith_action_t * action)
     if ((action->action == NULL) || (action->args == NULL)
         || (action->agent == NULL)) {
         pcmk__set_result(&(action->result), PCMK_OCF_UNKNOWN_ERROR,
-                         PCMK_EXEC_ERROR_FATAL, NULL);
+                         PCMK_EXEC_ERROR_FATAL, "Bug in fencing library");
         return -EINVAL;
     }
 

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -29,6 +29,7 @@
 #include <crm/msg_xml.h>
 #include <crm/common/xml.h>
 #include <crm/common/xml_internal.h>
+#include <crm/services_internal.h>
 
 #include <crm/common/mainloop.h>
 
@@ -57,9 +58,7 @@ struct stonith_action_s {
     int max_retries;
 
     int pid;
-    int rc;
-    char *output;
-    char *error;
+    pcmk__action_result_t result;
 };
 
 typedef struct stonith_private_s {
@@ -120,6 +119,7 @@ static void stonith_connection_destroy(gpointer user_data);
 static void stonith_send_notification(gpointer data, gpointer user_data);
 static int internal_stonith_action_execute(stonith_action_t * action);
 static void log_action(stonith_action_t *action, pid_t pid);
+static int result2rc(const pcmk__action_result_t *result);
 
 /*!
  * \brief Get agent namespace by name
@@ -196,6 +196,23 @@ stonith_get_namespace(const char *agent, const char *namespace_s)
     return st_namespace_invalid;
 }
 
+/*!
+ * \internal
+ * \brief Set an action's result based on services library result
+ *
+ * \param[in] action      Fence action to set result for
+ * \param[in] svc_action  Service action to get result from
+ */
+static void
+set_result_from_svc_action(stonith_action_t *action, svc_action_t *svc_action)
+{
+    pcmk__set_result(&(action->result), svc_action->rc, svc_action->status,
+                     NULL);
+    pcmk__set_result_output(&(action->result),
+                            services__grab_stdout(svc_action),
+                            services__grab_stderr(svc_action));
+}
+
 gboolean
 stonith__watchdog_fencing_enabled_for_node_api(stonith_t *st, const char *node)
 {
@@ -259,19 +276,19 @@ stonith__watchdog_fencing_enabled_for_node(const char *node)
 static void
 log_action(stonith_action_t *action, pid_t pid)
 {
-    if (action->output) {
+    if (action->result.action_stdout != NULL) {
         /* Logging the whole string confuses syslog when the string is xml */
         char *prefix = crm_strdup_printf("%s[%d] stdout:", action->agent, pid);
 
-        crm_log_output(LOG_TRACE, prefix, action->output);
+        crm_log_output(LOG_TRACE, prefix, action->result.action_stdout);
         free(prefix);
     }
 
-    if (action->error) {
+    if (action->result.action_stderr != NULL) {
         /* Logging the whole string confuses syslog when the string is xml */
         char *prefix = crm_strdup_printf("%s[%d] stderr:", action->agent, pid);
 
-        crm_log_output(LOG_WARNING, prefix, action->error);
+        crm_log_output(LOG_WARNING, prefix, action->result.action_stderr);
         free(prefix);
     }
 }
@@ -645,8 +662,7 @@ stonith__destroy_action(stonith_action_t *action)
         if (action->svc_action) {
             services_action_free(action->svc_action);
         }
-        free(action->output);
-        free(action->error);
+        pcmk__reset_result(&(action->result));
         free(action);
     }
 }
@@ -678,15 +694,15 @@ stonith__action_result(stonith_action_t *action, int *rc, char **output,
     }
     if (action != NULL) {
         if (rc) {
-            *rc = action->rc;
+            *rc = pcmk_rc2legacy(result2rc(&(action->result)));
         }
-        if (output && action->output) {
-            *output = action->output;
-            action->output = NULL; // hand off memory management to caller
+        if ((output != NULL) && (action->result.action_stdout != NULL)) {
+            *output = action->result.action_stdout;
+            action->result.action_stdout = NULL; // hand off ownership to caller
         }
-        if (error_output && action->error) {
-            *error_output = action->error;
-            action->error = NULL; // hand off memory management to caller
+        if ((error_output != NULL) && (action->result.action_stderr != NULL)) {
+            *error_output = action->result.action_stderr;
+            action->result.action_stderr = NULL; // hand off ownership to caller
         }
     }
 }
@@ -715,6 +731,9 @@ stonith_action_create(const char *agent,
     action->timeout = action->remaining_timeout = timeout;
     action->max_retries = FAILURE_MAX_RETRIES;
 
+    pcmk__set_result(&(action->result), PCMK_OCF_UNKNOWN, PCMK_EXEC_UNKNOWN,
+                     NULL);
+
     if (device_args) {
         char buffer[512];
         const char *value = NULL;
@@ -739,7 +758,8 @@ update_remaining_timeout(stonith_action_t * action)
         crm_info("Attempted to execute agent %s (%s) the maximum number of times (%d) allowed",
                  action->agent, action->action, action->max_retries);
         action->remaining_timeout = 0;
-    } else if ((action->rc != -ETIME) && diff < (action->timeout * 0.7)) {
+    } else if ((action->result.execution_status != PCMK_EXEC_TIMEOUT)
+               && (diff < (action->timeout * 0.7))) {
         /* only set remaining timeout period if there is 30%
          * or greater of the original timeout period left */
         action->remaining_timeout = action->timeout - diff;
@@ -750,31 +770,31 @@ update_remaining_timeout(stonith_action_t * action)
 }
 
 static int
-svc_action_to_errno(svc_action_t *svc_action) {
-    int rv = pcmk_ok;
+result2rc(const pcmk__action_result_t *result) {
+    int rc = pcmk_rc_ok;
 
-    if (svc_action->status == PCMK_EXEC_TIMEOUT) {
-            rv = -ETIME;
+    if (result->execution_status == PCMK_EXEC_TIMEOUT) {
+            rc = ETIME;
 
-    } else if (svc_action->rc != PCMK_OCF_OK) {
+    } else if (result->exit_status != CRM_EX_OK) {
         /* Try to provide a useful error code based on the fence agent's
          * error output.
          */
-        if (svc_action->stderr_data == NULL) {
-            rv = -ENODATA;
+        if (result->action_stderr == NULL) {
+            rc = ENODATA;
 
-        } else if (strstr(svc_action->stderr_data, "imed out")) {
+        } else if (strstr(result->action_stderr, "imed out")) {
             /* Some agents have their own internal timeouts */
-            rv = -ETIME;
+            rc = ETIME;
 
-        } else if (strstr(svc_action->stderr_data, "Unrecognised action")) {
-            rv = -EOPNOTSUPP;
+        } else if (strstr(result->action_stderr, "Unrecognised action")) {
+            rc = EOPNOTSUPP;
 
         } else {
-            rv = -pcmk_err_generic;
+            rc = pcmk_rc_error;
         }
     }
-    return rv;
+    return rc;
 }
 
 static void
@@ -782,11 +802,7 @@ stonith_action_async_done(svc_action_t *svc_action)
 {
     stonith_action_t *action = (stonith_action_t *) svc_action->cb_data;
 
-    action->rc = svc_action_to_errno(svc_action);
-    action->output = svc_action->stdout_data;
-    svc_action->stdout_data = NULL;
-    action->error = svc_action->stderr_data;
-    svc_action->stderr_data = NULL;
+    set_result_from_svc_action(action, svc_action);
 
     svc_action->params = NULL;
 
@@ -795,7 +811,9 @@ stonith_action_async_done(svc_action_t *svc_action)
 
     log_action(action, action->pid);
 
-    if (action->rc != pcmk_ok && update_remaining_timeout(action)) {
+    if ((action->result.exit_status != CRM_EX_OK)
+        && update_remaining_timeout(action)) {
+
         int rc = internal_stonith_action_execute(action);
         if (rc == pcmk_ok) {
             return;
@@ -803,7 +821,8 @@ stonith_action_async_done(svc_action_t *svc_action)
     }
 
     if (action->done_cb) {
-        action->done_cb(action->pid, action->rc, action->output, action->userdata);
+        action->done_cb(action->pid, pcmk_rc2legacy(result2rc(&(action->result))),
+                        action->result.action_stdout, action->userdata);
     }
 
     action->svc_action = NULL; // don't remove our caller
@@ -835,9 +854,13 @@ internal_stonith_action_execute(stonith_action_t * action)
     static int stonith_sequence = 0;
     char *buffer = NULL;
 
-    if ((action == NULL) || (action->action == NULL) || (action->args == NULL)
+    CRM_CHECK(action != NULL, return -EINVAL);
+
+    if ((action->action == NULL) || (action->args == NULL)
         || (action->agent == NULL)) {
-        return -EPROTO;
+        pcmk__set_result(&(action->result), PCMK_OCF_UNKNOWN_ERROR,
+                         PCMK_EXEC_ERROR_FATAL, NULL);
+        return -EINVAL;
     }
 
     if (!action->tries) {
@@ -857,6 +880,7 @@ internal_stonith_action_execute(stonith_action_t * action)
     free(buffer);
 
     if (svc_action->rc != PCMK_OCF_UNKNOWN) {
+        set_result_from_svc_action(action, svc_action);
         services_action_free(svc_action);
         return -E2BIG;
     }
@@ -877,10 +901,7 @@ internal_stonith_action_execute(stonith_action_t * action)
 
     /* keep retries from executing out of control and free previous results */
     if (is_retry) {
-        free(action->output);
-        action->output = NULL;
-        free(action->error);
-        action->error = NULL;
+        pcmk__reset_result(&(action->result));
         sleep(1);
     }
 
@@ -889,22 +910,19 @@ internal_stonith_action_execute(stonith_action_t * action)
         if (services_action_async_fork_notify(svc_action,
                                               &stonith_action_async_done,
                                               &stonith_action_async_forked)) {
+            pcmk__set_result(&(action->result), PCMK_OCF_UNKNOWN,
+                             PCMK_EXEC_PENDING, NULL);
             return pcmk_ok;
         }
 
     } else if (services_action_sync(svc_action)) { // sync success
         rc = pcmk_ok;
-        action->rc = svc_action_to_errno(svc_action);
-        action->output = svc_action->stdout_data;
-        svc_action->stdout_data = NULL;
-        action->error = svc_action->stderr_data;
-        svc_action->stderr_data = NULL;
 
     } else { // sync failure
-        action->rc = -ECONNABORTED;
-        rc = action->rc;
+        rc = -ECONNABORTED;
     }
 
+    set_result_from_svc_action(action, svc_action);
     svc_action->params = NULL;
     services_action_free(svc_action);
     return rc;

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -143,15 +143,17 @@ stonith__rhcs_get_metadata(const char *agent, int timeout, xmlNode **metadata)
     if (result->execution_status != PCMK_EXEC_DONE) {
         crm_warn("Could not execute metadata action for %s: %s",
                  agent, pcmk_exec_status_str(result->execution_status));
+        rc = pcmk_rc2legacy(stonith__result2rc(result));
         stonith__destroy_action(action);
-        return pcmk_rc2legacy(stonith__result2rc(result));
+        return rc;
     }
 
     if (result->exit_status != CRM_EX_OK) {
         crm_warn("Metadata action for %s returned error code %d",
                  agent, result->exit_status);
+        rc = pcmk_rc2legacy(stonith__result2rc(result));
         stonith__destroy_action(action);
-        return pcmk_rc2legacy(stonith__result2rc(result));
+        return rc;
     }
 
     if (result->action_stdout == NULL) {

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -319,13 +319,13 @@ services__create_resource_action(const char *name, const char *standard,
         rc = services__nagios_prepare(op);
 #endif
     } else {
-        crm_err("Unknown resource standard: %s", op->standard);
+        crm_info("Unknown resource standard: %s", op->standard);
         rc = ENOENT;
     }
 
     if (rc != pcmk_rc_ok) {
-        crm_err("Cannot prepare %s operation for %s: %s",
-                action, name, strerror(rc));
+        crm_info("Cannot prepare %s operation for %s: %s",
+                 action, name, strerror(rc));
         services__handle_exec_error(op, rc);
     }
     return op;
@@ -967,14 +967,14 @@ execute_metadata_action(svc_action_t *op)
     const char *class = op->standard;
 
     if (op->agent == NULL) {
-        crm_err("meta-data requested without specifying agent");
+        crm_info("Meta-data requested without specifying agent");
         services__set_result(op, services__generic_error(op),
                              PCMK_EXEC_ERROR_FATAL, "Agent not specified");
         return EINVAL;
     }
 
     if (class == NULL) {
-        crm_err("meta-data requested for agent %s without specifying class",
+        crm_info("Meta-data requested for agent %s without specifying class",
                 op->agent);
         services__set_result(op, services__generic_error(op),
                              PCMK_EXEC_ERROR_FATAL,
@@ -986,8 +986,8 @@ execute_metadata_action(svc_action_t *op)
         class = resources_find_service_class(op->agent);
     }
     if (class == NULL) {
-        crm_err("meta-data requested for %s, but could not determine class",
-                op->agent);
+        crm_info("Meta-data requested for %s, but could not determine class",
+                 op->agent);
         services__set_result(op, services__generic_error(op),
                              PCMK_EXEC_ERROR_HARD,
                              "Agent standard could not be determined");

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -232,7 +232,8 @@ systemd_daemon_reload_complete(DBusPendingCall *pending, void *user_data)
     }
 
     if (pcmk_dbus_find_error(pending, reply, &error)) {
-        crm_err("Could not issue systemd reload %d: %s", reload_count, error.message);
+        crm_warn("Could not issue systemd reload %d: %s",
+                 reload_count, error.message);
         dbus_error_free(&error);
 
     } else {
@@ -291,8 +292,8 @@ set_result_from_method_error(svc_action_t *op, const DBusError *error)
                              PCMK_EXEC_NOT_INSTALLED, "systemd unit not found");
     }
 
-    crm_err("DBus request for %s of systemd unit %s for resource %s failed: %s",
-            op->action, op->agent, crm_str(op->rsc), error->message);
+    crm_info("DBus request for %s of systemd unit %s for resource %s failed: %s",
+             op->action, op->agent, crm_str(op->rsc), error->message);
 }
 
 /*!
@@ -325,11 +326,11 @@ execute_after_loadunit(DBusMessage *reply, svc_action_t *op)
         if (op != NULL) {
             services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
                                  "systemd DBus method had unexpected reply");
-            crm_err("Could not load systemd unit %s for %s: "
-                    "DBus reply has unexpected type", op->agent, op->id);
+            crm_info("Could not load systemd unit %s for %s: "
+                     "DBus reply has unexpected type", op->agent, op->id);
         } else {
-            crm_err("Could not load systemd unit: "
-                    "DBus reply has unexpected type");
+            crm_info("Could not load systemd unit: "
+                     "DBus reply has unexpected type");
         }
 
     } else {
@@ -688,7 +689,7 @@ process_unit_method_reply(DBusMessage *reply, svc_action_t *op)
 
     } else if (!pcmk_dbus_type_check(reply, NULL, DBUS_TYPE_OBJECT_PATH,
                                      __func__, __LINE__)) {
-        crm_warn("DBus request for %s of %s succeeded but "
+        crm_info("DBus request for %s of %s succeeded but "
                  "return type was unexpected", op->action, crm_str(op->rsc));
         services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE,
                              "systemd DBus method had unexpected reply");
@@ -981,7 +982,8 @@ systemd_timeout_callback(gpointer p)
     svc_action_t * op = p;
 
     op->opaque->timerid = 0;
-    crm_warn("%s operation on systemd unit %s named '%s' timed out", op->action, op->agent, op->rsc);
+    crm_info("%s action for systemd unit %s named '%s' timed out",
+             op->action, op->agent, op->rsc);
     services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_TIMEOUT,
                          "Systemd action did not complete within specified timeout");
     services__finalize_async_op(op);

--- a/lib/services/upstart.c
+++ b/lib/services/upstart.c
@@ -308,21 +308,21 @@ get_first_instance(const gchar * job, int timeout)
     dbus_message_unref(msg);
 
     if (dbus_error_is_set(&error)) {
-        crm_err("Call to %s failed: %s", method, error.message);
+        crm_info("Call to %s failed: %s", method, error.message);
         dbus_error_free(&error);
         goto done;
 
     } else if(reply == NULL) {
-        crm_err("Call to %s failed: no reply", method);
+        crm_info("Call to %s failed: no reply", method);
         goto done;
 
     } else if (!dbus_message_iter_init(reply, &args)) {
-        crm_err("Call to %s failed: Message has no arguments", method);
+        crm_info("Call to %s failed: Message has no arguments", method);
         goto done;
     }
 
     if(!pcmk_dbus_type_check(reply, &args, DBUS_TYPE_ARRAY, __func__, __LINE__)) {
-        crm_err("Call to %s failed: Message has invalid arguments", method);
+        crm_info("Call to %s failed: Message has invalid arguments", method);
         goto done;
     }
 
@@ -432,8 +432,8 @@ set_result_from_method_error(svc_action_t *op, const DBusError *error)
         return;
     }
 
-    crm_err("DBus request for %s of Upstart job %s for resource %s failed: %s",
-            op->action, op->agent, crm_str(op->rsc), error->message);
+    crm_info("DBus request for %s of Upstart job %s for resource %s failed: %s",
+             op->action, op->agent, crm_str(op->rsc), error->message);
 }
 
 /*!
@@ -468,7 +468,7 @@ job_method_complete(DBusPendingCall *pending, void *user_data)
 
     } else if (!pcmk_dbus_type_check(reply, NULL, DBUS_TYPE_OBJECT_PATH,
                                      __func__, __LINE__)) {
-        crm_warn("DBus request for %s of %s succeeded but "
+        crm_info("DBus request for %s of %s succeeded but "
                  "return type was unexpected", op->action, crm_str(op->rsc));
         services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
 
@@ -667,7 +667,8 @@ services__execute_upstart(svc_action_t *op)
 
     } else if (!pcmk_dbus_type_check(reply, NULL, DBUS_TYPE_OBJECT_PATH,
                                      __func__, __LINE__)) {
-        crm_warn("Call to %s passed but return type was unexpected", op->action);
+        crm_info("Call to %s passed but return type was unexpected",
+                 op->action);
         services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
 
     } else {
@@ -675,7 +676,7 @@ services__execute_upstart(svc_action_t *op)
 
         dbus_message_get_args(reply, NULL, DBUS_TYPE_OBJECT_PATH, &path,
                               DBUS_TYPE_INVALID);
-        crm_info("Call to %s passed: %s", op->action, path);
+        crm_debug("Call to %s passed: %s", op->action, path);
         services__set_result(op, PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);
     }
 


### PR DESCRIPTION
The services library provides a full result consisting of exit status, execution status, exit reason, and process output. Previously, the fencer immediately converted this to a legacy Pacemaker return code, which was all that it tracked.

Now, the fencer preserves the full result as long as possible, converting to a legacy code only when needing to return it to clients/peers (for backward compatibility). Internally, it tracks the full result, allowing it to give better log messages, and better mappings to legacy codes.

Now that exit reasons are always logged by services library callers, we can lower the severity of services library log messages, to reduce log duplication seen by the user.

As of this pull request, clients/peers do not receive or use the full result, but that is planned for later.