### PR TITLE
Mid: based: Makes the replace notification a comparison base for the hash value of the section.

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1164,6 +1164,23 @@ cib_process_request(xmlNode *request, gboolean privileged,
     return;
 }
 
+static char *
+calculate_section_digest(const char *xpath, xmlNode * xml_obj)
+{
+    xmlNode *xml_section = NULL;
+
+    if (xml_obj == NULL) {
+        return NULL;
+    }
+
+    xml_section = get_xpath_object(xpath, xml_obj, LOG_TRACE);
+    if (xml_section == NULL) {
+        return NULL;
+    }
+    return calculate_xml_versioned_digest(xml_section, FALSE, TRUE, CRM_FEATURE_SET); 
+
+}
+
 static int
 cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gboolean privileged)
 {
@@ -1188,6 +1205,15 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     gboolean manage_counters = TRUE;
 
     static mainloop_timer_t *digest_timer = NULL;
+
+    char *current_config_digest = NULL;
+    char *current_nodes_digest = NULL;
+    char *current_alerts_digest = NULL;
+    char *current_status_digest = NULL;
+    char *result_config_digest = NULL;
+    char *result_nodes_digest = NULL;
+    char *result_alerts_digest = NULL;
+    char *result_status_digest = NULL;
 
     CRM_ASSERT(cib_status == pcmk_ok);
 
@@ -1254,6 +1280,15 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
             cib__clear_call_options(call_options, "call", cib_zero_copy);
         }
 
+        /* Calculate the hash value of the section before the change. */
+        if (pcmk__str_eq(CIB_OP_REPLACE, op, pcmk__str_none)) {
+            current_config_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION, current_cib);
+            current_nodes_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_NODES, current_cib);
+            current_alerts_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_ALERTS, current_cib);
+            current_status_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_STATUS, current_cib);
+            crm_trace("current-digest %s:%s:%s:%s", current_config_digest, current_nodes_digest, current_alerts_digest, current_status_digest);
+        }
+
         /* result_cib must not be modified after cib_perform_op() returns */
         rc = cib_perform_op(op, call_options, cib_op_func(call_type), FALSE,
                             section, request, input, manage_counters, &config_changed,
@@ -1298,21 +1333,39 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
         }
 
         if (pcmk__str_eq(CIB_OP_REPLACE, op, pcmk__str_none)) {
-            if (section == NULL) {
-                send_r_notify = TRUE;
+            gboolean change_config = TRUE;
+            gboolean change_node = TRUE;
+            gboolean change_alert = TRUE;
+            gboolean change_status= TRUE;
 
-            } else if (pcmk__str_eq(section, XML_TAG_CIB, pcmk__str_casei)) {
-                send_r_notify = TRUE;
+            /* Calculate the hash value of the changed section. */
+            result_config_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION, result_cib);
+            result_nodes_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_NODES, result_cib);
+            result_alerts_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_ALERTS, result_cib);
+            result_status_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_STATUS, result_cib);
+            crm_trace("result-digest %s:%s:%s:%s", result_config_digest, result_nodes_digest, result_alerts_digest, result_status_digest);
 
-            } else if (pcmk__str_eq(section, XML_CIB_TAG_NODES, pcmk__str_casei)) {
-                send_r_notify = TRUE;
+            if (pcmk__str_eq(current_config_digest, result_config_digest, pcmk__str_casei)) {
+                change_config = FALSE;
+            }
+            if (pcmk__str_eq(current_nodes_digest, result_nodes_digest, pcmk__str_casei)) {
+                change_node = FALSE;
+            }
+            if (pcmk__str_eq(current_alerts_digest, result_alerts_digest, pcmk__str_casei)) {
+                change_alert = FALSE;
+            }
+            if (pcmk__str_eq(current_status_digest, result_status_digest, pcmk__str_casei)) {
+                change_status = FALSE;
+            }
 
-            } else if (pcmk__str_eq(section, XML_CIB_TAG_STATUS, pcmk__str_casei)) {
-                send_r_notify = TRUE;
-
-            } else if (pcmk__str_eq(section, XML_CIB_TAG_CONFIGURATION, pcmk__str_casei)) {
+            if (change_config || change_node || change_alert || change_status) {
                 send_r_notify = TRUE;
             }
+            
+            free(result_config_digest);
+            free(result_nodes_digest);
+            free(result_alerts_digest);
+            free(result_status_digest);
 
         } else if (pcmk__str_eq(CIB_OP_ERASE, op, pcmk__str_none)) {
             send_r_notify = TRUE;
@@ -1385,6 +1438,11 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     if (call_type >= 0) {
         cib_op_cleanup(call_type, call_options, &input, &output);
     }
+
+    free(current_config_digest);
+    free(current_nodes_digest);
+    free(current_alerts_digest);
+    free(current_status_digest);
 
     crm_trace("done");
     return rc;


### PR DESCRIPTION
Hi Ken,
Hi All,

This amendment was discussed in the next PR.
 - https://github.com/ClusterLabs/pacemaker/pull/2550

With this fix, the result of the replace process of cib is changed to be judged by the hash value of the section of cib before and after the change.

This fix also resolves an issue where attrd is not currently notified of changes in the alert section.

Best Regards,
Hideo Yamauchi.
