### PR TITLE
Mid: based controld: Suppresses unnecessary Election execution.(2)

### DIFF
--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -234,7 +234,7 @@ attach_cib_generation(xmlNode * msg, const char *field, xmlNode * a_cib)
 }
 
 void
-cib_replace_notify(const char *origin, xmlNode * update, int result, xmlNode * diff)
+cib_replace_notify(const char *origin, xmlNode * update, int result, xmlNode * diff, int change_section)
 {
     xmlNode *replace_msg = NULL;
 
@@ -271,6 +271,7 @@ cib_replace_notify(const char *origin, xmlNode * update, int result, xmlNode * d
     crm_xml_add(replace_msg, F_SUBTYPE, T_CIB_REPLACE_NOTIFY);
     crm_xml_add(replace_msg, F_CIB_OPERATION, CIB_OP_REPLACE);
     crm_xml_add_int(replace_msg, F_CIB_RC, result);
+    crm_xml_add_int(replace_msg, F_CIB_CHANGE_SECTION, change_section);
     attach_cib_generation(replace_msg, "cib-replace-generation", update);
 
     crm_log_xml_trace(replace_msg, "CIB Replaced");

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -148,7 +148,7 @@ void cib_diff_notify(int options, const char *client, const char *call_id,
                      const char *op, xmlNode *update, int result,
                      xmlNode *old_cib);
 void cib_replace_notify(const char *origin, xmlNode *update, int result,
-                        xmlNode *diff);
+                        xmlNode *diff, int change_section);
 
 static inline const char *
 cib_config_lookup(const char *opt)

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -31,6 +31,8 @@ do_cib_updated(const char *event, xmlNode * msg)
 void
 do_cib_replaced(const char *event, xmlNode * msg)
 {
+    int change_section = cib_change_section_nodes | cib_change_section_status;
+
     crm_debug("Updating the CIB after a replace: DC=%s", pcmk__btoa(AM_I_DC));
     if (AM_I_DC == FALSE) {
         return;
@@ -43,7 +45,11 @@ do_cib_replaced(const char *event, xmlNode * msg)
 
     /* start the join process again so we get everyone's LRM status */
     populate_cib_nodes(node_update_quick|node_update_all, __func__);
-    register_fsa_input(C_FSA_INTERNAL, I_ELECTION, NULL);
+
+    crm_element_value_int(msg, F_CIB_CHANGE_SECTION, &change_section);
+    if (change_section & (cib_change_section_nodes | cib_change_section_status)) {
+        register_fsa_input(C_FSA_INTERNAL, I_ELECTION, NULL);
+    }
 }
 
 void

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -67,6 +67,13 @@ enum cib_call_options {
     cib_force_diff      = 0x10000000
 };
 
+enum cib_change_section_info {
+    cib_change_section_none     = 0x00000000,
+    cib_change_section_nodes    = 0x00000001,
+    cib_change_section_alerts   = 0x00000002,
+    cib_change_section_status   = 0x00000004
+};
+
 typedef struct cib_s cib_t;
 
 typedef struct cib_api_operations_s {

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -58,6 +58,7 @@
 #  define F_CIB_LOCAL_NOTIFY_ID	"cib_local_notify_id"
 #  define F_CIB_PING_ID         "cib_ping_id"
 #  define F_CIB_SCHEMA_MAX      "cib_schema_max"
+#  define F_CIB_CHANGE_SECTION  "cib_change_section"
 
 #  define T_CIB			"cib"
 #  define T_CIB_NOTIFY		"cib_notify"


### PR DESCRIPTION
Hi Ken,
Hi All,

This PR is a modified version of the next PR.
 - https://github.com/ClusterLabs/pacemaker/pull/2550

After further consideration, I added a section change to the CIB replacement notification.
This avoids unnecessary Elections.

Best Regards,
Hideo Yamauchi.