### PR TITLE
Various refactorings around XML bools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2119,6 +2119,7 @@ AC_CONFIG_FILES(Makefile                                            \
                 lib/common/tests/flags/Makefile                     \
                 lib/common/tests/io/Makefile                        \
                 lib/common/tests/iso8601/Makefile                   \
+                lib/common/tests/nvpair/Makefile                    \
                 lib/common/tests/operations/Makefile                \
                 lib/common/tests/results/Makefile                   \
                 lib/common/tests/strings/Makefile                   \

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -90,14 +90,12 @@ static int
 cib_prepare_diff(xmlNode * request, xmlNode ** data, const char **section)
 {
     xmlNode *input_fragment = NULL;
-    const char *update = crm_element_value(request, F_CIB_GLOBAL_UPDATE);
 
     *data = NULL;
     *section = NULL;
 
-    if (crm_is_true(update)) {
+    if (pcmk__xe_attr_is_true(request, F_CIB_GLOBAL_UPDATE)) {
         input_fragment = get_message_xml(request, F_CIB_UPDATE_DIFF);
-
     } else {
         input_fragment = get_message_xml(request, F_CIB_CALLDATA);
     }

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -522,7 +522,7 @@ sync_our_cib(xmlNode * request, gboolean all)
 
     crm_xml_add(replace_request, F_CIB_OPERATION, CIB_OP_REPLACE);
     crm_xml_add(replace_request, "original_" F_CIB_OPERATION, op);
-    crm_xml_add(replace_request, F_CIB_GLOBAL_UPDATE, XML_BOOLEAN_TRUE);
+    pcmk__xe_set_bool_attr(replace_request, F_CIB_GLOBAL_UPDATE, true);
 
     crm_xml_add(replace_request, XML_ATTR_CRM_VERSION, CRM_FEATURE_SET);
     digest = calculate_xml_versioned_digest(the_cib, FALSE, TRUE, CRM_FEATURE_SET);

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -2476,7 +2476,7 @@ do_update_resource(const char *node_name, lrmd_rsc_info_t *rsc,
     } else {
         /* remote nodes uuid and uname are equal */
         uuid = node_name;
-        crm_xml_add(iter, XML_NODE_IS_REMOTE, "true");
+        pcmk__xe_set_bool_attr(iter, XML_NODE_IS_REMOTE, true);
     }
 
     CRM_LOG_ASSERT(uuid != NULL);

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -34,7 +34,7 @@ extern ha_msg_input_t *copy_ha_msg_input(ha_msg_input_t * orig);
 static void
 update_dc_expected(xmlNode *msg)
 {
-    if (fsa_our_dc && crm_is_true(crm_element_value(msg, F_CRM_DC_LEAVING))) {
+    if (fsa_our_dc && pcmk__xe_attr_is_true(msg, F_CRM_DC_LEAVING)) {
         crm_node_t *dc_node = crm_get_peer(0, fsa_our_dc);
 
         pcmk__update_peer_expected(__func__, dc_node, CRMD_JOINSTATE_DOWN);
@@ -229,7 +229,6 @@ do_cl_join_finalize_respond(long long action,
 
     int join_id = -1;
     const char *op = crm_element_value(input->msg, F_CRM_TASK);
-    const char *ack_nack = crm_element_value(input->msg, CRM_OP_JOIN_ACKNAK);
     const char *welcome_from = crm_element_value(input->msg, F_CRM_HOST_FROM);
 
     if (!pcmk__str_eq(op, CRM_OP_JOIN_ACKNAK, pcmk__str_casei)) {
@@ -238,7 +237,7 @@ do_cl_join_finalize_respond(long long action,
     }
 
     /* calculate if it was an ack or a nack */
-    if (crm_is_true(ack_nack)) {
+    if (pcmk__xe_attr_is_true(input->msg, CRM_OP_JOIN_ACKNAK)) {
         was_nack = FALSE;
     }
 

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -109,8 +109,8 @@ create_dc_message(const char *join_op, const char *host_to)
     /* Add a field specifying whether the DC is shutting down. This keeps the
      * joining node from fencing the old DC if it becomes the new DC.
      */
-    crm_xml_add_boolean(msg, F_CRM_DC_LEAVING,
-                        pcmk_is_set(fsa_input_register, R_SHUTDOWN));
+    pcmk__xe_set_bool_attr(msg, F_CRM_DC_LEAVING,
+                           pcmk_is_set(fsa_input_register, R_SHUTDOWN));
     return msg;
 }
 
@@ -656,7 +656,7 @@ finalize_join_for(gpointer key, gpointer value, gpointer user_data)
     crm_debug("Acknowledging join-%d request from %s",
               current_join_id, join_to);
     acknak = create_dc_message(CRM_OP_JOIN_ACKNAK, join_to);
-    crm_xml_add(acknak, CRM_OP_JOIN_ACKNAK, XML_BOOLEAN_TRUE);
+    pcmk__xe_set_bool_attr(acknak, CRM_OP_JOIN_ACKNAK, true);
     crm_update_peer_join(__func__, join_node, crm_join_finalized);
     pcmk__update_peer_expected(__func__, join_node, CRMD_JOINSTATE_MEMBER);
 

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -138,7 +138,7 @@ create_node_state_update(crm_node_t *node, int flags, xmlNode *parent,
     node_state = create_xml_node(parent, XML_CIB_TAG_STATE);
 
     if (pcmk_is_set(node->flags, crm_remote_node)) {
-        crm_xml_add(node_state, XML_NODE_IS_REMOTE, XML_BOOLEAN_TRUE);
+        pcmk__xe_set_bool_attr(node_state, XML_NODE_IS_REMOTE, true);
     }
 
     set_uuid(node_state, XML_ATTR_UUID, node);
@@ -152,8 +152,8 @@ create_node_state_update(crm_node_t *node, int flags, xmlNode *parent,
     crm_xml_add(node_state, XML_ATTR_UNAME, node->uname);
 
     if ((flags & node_update_cluster) && node->state) {
-        crm_xml_add_boolean(node_state, XML_NODE_IN_CLUSTER,
-                            pcmk__str_eq(node->state, CRM_NODE_MEMBER, pcmk__str_casei));
+        pcmk__xe_set_bool_attr(node_state, XML_NODE_IN_CLUSTER,
+                               pcmk__str_eq(node->state, CRM_NODE_MEMBER, pcmk__str_casei));
     }
 
     if (!pcmk_is_set(node->flags, crm_remote_node)) {

--- a/daemons/controld/controld_metadata.c
+++ b/daemons/controld/controld_metadata.c
@@ -145,7 +145,6 @@ static struct ra_param_s *
 ra_param_from_xml(xmlNode *param_xml)
 {
     const char *param_name = crm_element_value(param_xml, "name");
-    const char *value;
     struct ra_param_s *p;
 
     p = calloc(1, sizeof(struct ra_param_s));
@@ -161,18 +160,15 @@ ra_param_from_xml(xmlNode *param_xml)
         return NULL;
     }
 
-    value = crm_element_value(param_xml, "reloadable");
-    if (crm_is_true(value)) {
+    if (pcmk__xe_attr_is_true(param_xml, "reloadable")) {
         controld_set_ra_param_flags(p, ra_param_reloadable);
     }
 
-    value = crm_element_value(param_xml, "unique");
-    if (crm_is_true(value)) {
+    if (pcmk__xe_attr_is_true(param_xml, "unique")) {
         controld_set_ra_param_flags(p, ra_param_unique);
     }
 
-    value = crm_element_value(param_xml, "private");
-    if (crm_is_true(value)) {
+    if (pcmk__xe_attr_is_true(param_xml, "private")) {
         controld_set_ra_param_flags(p, ra_param_private);
     }
     return p;

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -89,13 +89,9 @@ te_update_diff_v1(const char *event, xmlNode *diff)
     for (lpc = 0; lpc < max; lpc++) {
         xmlNode *attr = getXpathResult(xpathObj, lpc);
         const char *name = crm_element_value(attr, XML_NVPAIR_ATTR_NAME);
-        const char *value = NULL;
 
-        if (pcmk__str_eq(CRM_OP_PROBED, name, pcmk__str_casei)) {
-            value = crm_element_value(attr, XML_NVPAIR_ATTR_VALUE);
-        }
-
-        if (crm_is_true(value) == FALSE) {
+        if (pcmk__str_eq(CRM_OP_PROBED, name, pcmk__str_casei) &&
+            !pcmk__xe_attr_is_true(attr, XML_NVPAIR_ATTR_VALUE)) {
             abort_transition(INFINITY, tg_restart, "Transient attribute: update", attr);
             crm_log_xml_trace(attr, "Abort");
             goto bail;

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1472,7 +1472,6 @@ process_lrmd_signon(pcmk__client_t *client, xmlNode *request, int call_id,
                     xmlNode **reply)
 {
     int rc = pcmk_ok;
-    const char *is_ipc_provider = crm_element_value(request, F_LRMD_IS_IPC_PROVIDER);
     const char *protocol_version = crm_element_value(request, F_LRMD_PROTOCOL_VERSION);
 
     if (compare_version(protocol_version, LRMD_MIN_PROTOCOL_VERSION) < 0) {
@@ -1481,7 +1480,7 @@ process_lrmd_signon(pcmk__client_t *client, xmlNode *request, int call_id,
         rc = -EPROTO;
     }
 
-    if (crm_is_true(is_ipc_provider)) {
+    if (pcmk__xe_attr_is_true(request, F_LRMD_IS_IPC_PROVIDER)) {
 #ifdef PCMK__COMPILE_REMOTE
         if ((client->remote != NULL) && client->remote->tls_handshake_complete) {
             // This is a remote connection from a cluster node's controller

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -499,15 +499,12 @@ stonith_fence_history(xmlNode *msg, xmlNode **output,
             * otherwise broadcast what we have on top
             * marking as differential and merge in afterwards
             */
-            if (!history ||
-                !crm_is_true(crm_element_value(history,
-                                               F_STONITH_DIFFERENTIAL))) {
+            if (!history || !pcmk__xe_attr_is_true(history, F_STONITH_DIFFERENTIAL)) {
                 out_history =
                     stonith_local_history_diff_and_merge(received_history, TRUE, NULL);
                 if (out_history) {
                     crm_trace("Broadcasting history-diff to peers");
-                    crm_xml_add(out_history, F_STONITH_DIFFERENTIAL,
-                                XML_BOOLEAN_TRUE);
+                    pcmk__xe_set_bool_attr(out_history, F_STONITH_DIFFERENTIAL, true);
                     stonith_send_broadcast_history(out_history,
                         st_opt_broadcast | st_opt_discard_reply,
                         NULL);

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -387,7 +387,7 @@ stonith_bcast_result_to_peers(remote_fencing_op_t * op, int rc, gboolean op_merg
     crm_xml_add_int(bcast, "count", count);
 
     if (op_merged) {
-        crm_xml_add(bcast, F_STONITH_MERGED, "true");
+        pcmk__xe_set_bool_attr(bcast, F_STONITH_MERGED, true);
     }
 
     add_message_xml(bcast, F_STONITH_CALLDATA, notify_data);
@@ -1836,7 +1836,7 @@ parse_action_specific(xmlNode *xml, const char *peer, const char *device,
     /* If a reboot is remapped to off+on, it's possible that a node is allowed
      * to perform one action but not another.
      */
-    if (crm_is_true(crm_element_value(xml, F_STONITH_ACTION_DISALLOWED))) {
+    if (pcmk__xe_attr_is_true(xml, F_STONITH_ACTION_DISALLOWED)) {
         props->disallowed[phase] = TRUE;
         crm_trace("Peer %s is disallowed from executing %s for device %s",
                   peer, action, device);

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -126,6 +126,48 @@ char *pcmk__format_nvpair(const char *name, const char *value,
                           const char *units);
 char *pcmk__format_named_time(const char *name, time_t epoch_time);
 
+/*!
+ * \internal
+ * \brief Add a boolean attribute to an XML node.
+ *
+ * \param[in,out] node  XML node to add attributes to
+ * \param[in]     name  XML attribute to create
+ * \param[in]     value Value to give to the attribute
+ */
+void
+pcmk__xe_set_bool_attr(xmlNodePtr node, const char *name, bool value);
+
+/*!
+ * \internal
+ * \brief Extract a boolean attribute's value from an XML element
+ *
+ * \param[in] node XML node to get attribute from
+ * \param[in] name XML attribute to get
+ *
+ * \return True if the given \p name is an attribute on \p node and has
+ *         the value "true", False in all other cases
+ */
+bool
+pcmk__xe_attr_is_true(xmlNodePtr node, const char *name);
+
+/*!
+ * \internal
+ * \brief Extract a boolean attribute's value from an XML element, with
+ *        error checking
+ *
+ * \param[in]  node  XML node to get attribute from
+ * \param[in]  name  XML attribute to get
+ * \param[out] value Destination for the value of the attribute
+ *
+ * \return EINVAL if \p name or \p value are NULL, ENODATA if \p node is
+ *         NULL or the attribute does not exist, pcmk_rc_unknown_format
+ *         if the attribute is not a boolean, and pcmk_rc_ok otherwise.
+ *
+ * \note \p value only has any meaning if the return value is pcmk_rc_ok.
+ */
+int
+pcmk__xe_get_bool_attr(xmlNodePtr node, const char *name, bool *value);
+
 
 /* internal procfs utilities (from procfs.c) */
 

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -442,7 +442,7 @@ get_uuid_from_result(xmlNode *result, char **uuid, int *is_remote)
         /* Result is <node_state> tag from <status> section */
 
         parsed_uuid = crm_element_value(result, XML_ATTR_UNAME);
-        if (crm_is_true(crm_element_value(result, XML_NODE_IS_REMOTE))) {
+        if (pcmk__xe_attr_is_true(result, XML_NODE_IS_REMOTE)) {
             parsed_is_remote = TRUE;
         }
     }

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -165,15 +165,13 @@ crm_remote_peer_cache_remove(const char *node_name)
 static const char *
 remote_state_from_cib(xmlNode *node_state)
 {
-    const char *status;
+    bool status = false;
 
-    status = crm_element_value(node_state, XML_NODE_IN_CLUSTER);
-    if (status && !crm_is_true(status)) {
-        status = CRM_NODE_LOST;
+    if (pcmk__xe_get_bool_attr(node_state, XML_NODE_IN_CLUSTER, &status) == pcmk_rc_ok && !status) {
+        return CRM_NODE_LOST;
     } else {
-        status = CRM_NODE_MEMBER;
+        return CRM_NODE_MEMBER;
     }
-    return status;
 }
 
 /* user data for looping through remote node xpath searches */

--- a/lib/common/ipc_controld.c
+++ b/lib/common/ipc_controld.c
@@ -89,8 +89,6 @@ post_connect(pcmk_ipc_api_t *api)
     return rc;
 }
 
-#define xml_true(xml, field) crm_is_true(crm_element_value(xml, field))
-
 static void
 set_node_info_data(pcmk_controld_api_reply_t *data, xmlNode *msg_data)
 {
@@ -98,8 +96,8 @@ set_node_info_data(pcmk_controld_api_reply_t *data, xmlNode *msg_data)
     if (msg_data == NULL) {
         return;
     }
-    data->data.node_info.have_quorum = xml_true(msg_data, XML_ATTR_HAVE_QUORUM);
-    data->data.node_info.is_remote = xml_true(msg_data, XML_NODE_IS_REMOTE);
+    data->data.node_info.have_quorum = pcmk__xe_attr_is_true(msg_data, XML_ATTR_HAVE_QUORUM);
+    data->data.node_info.is_remote = pcmk__xe_attr_is_true(msg_data, XML_NODE_IS_REMOTE);
     crm_element_value_int(msg_data, XML_ATTR_ID, &(data->data.node_info.id));
     data->data.node_info.uuid = crm_element_value(msg_data, XML_ATTR_UUID);
     data->data.node_info.uname = crm_element_value(msg_data, XML_ATTR_UNAME);

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -953,6 +953,48 @@ xml2list(xmlNode *parent)
     return nvpair_hash;
 }
 
+void
+pcmk__xe_set_bool_attr(xmlNodePtr node, const char *name, bool value)
+{
+    crm_xml_add(node, name, value ? XML_BOOLEAN_TRUE : XML_BOOLEAN_FALSE);
+}
+
+int
+pcmk__xe_get_bool_attr(xmlNodePtr node, const char *name, bool *value) {
+    const char *xml_value = NULL;
+    int ret, rc;
+
+    if (node == NULL) {
+        return ENODATA;
+    } else if (name == NULL || value == NULL) {
+        return EINVAL;
+    }
+
+    xml_value = crm_element_value(node, name);
+
+    if (xml_value == NULL) {
+        return ENODATA;
+    }
+
+    rc = crm_str_to_boolean(xml_value, &ret);
+    if (rc == 1) {
+        *value = ret;
+        return pcmk_rc_ok;
+    } else {
+        return pcmk_rc_unknown_format;
+    }
+}
+
+bool
+pcmk__xe_attr_is_true(xmlNodePtr node, const char *name)
+{
+    bool value = false;
+    int rc;
+
+    rc = pcmk__xe_get_bool_attr(node, name, &value);
+    return rc == pcmk_rc_ok && value == true;
+}
+
 // Deprecated functions kept only for backward API compatibility
 // LCOV_EXCL_START
 

--- a/lib/common/tests/Makefile.am
+++ b/lib/common/tests/Makefile.am
@@ -13,6 +13,7 @@ SUBDIRS = \
 	flags		\
 	io		\
 	iso8601		\
+	nvpair 		\
 	operations	\
 	results		\
 	strings		\

--- a/lib/common/tests/nvpair/Makefile.am
+++ b/lib/common/tests/nvpair/Makefile.am
@@ -1,0 +1,19 @@
+#
+# Copyright 2021 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+#
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
+LDADD = $(top_builddir)/lib/common/libcrmcommon.la -lcmocka
+
+include $(top_srcdir)/mk/tap.mk
+
+# Add "_test" to the end of all test program names to simplify .gitignore.
+check_PROGRAMS =	pcmk__xe_attr_is_true_test \
+					pcmk__xe_get_bool_attr_test \
+					pcmk__xe_set_bool_attr_test
+
+TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/nvpair/pcmk__xe_attr_is_true_test.c
+++ b/lib/common/tests/nvpair/pcmk__xe_attr_is_true_test.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+#include <crm/common/xml_internal.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+static void
+empty_input(void **state)
+{
+    xmlNode *node = string2xml("<node/>");
+
+    assert_false(pcmk__xe_attr_is_true(NULL, NULL));
+    assert_false(pcmk__xe_attr_is_true(NULL, "whatever"));
+    assert_false(pcmk__xe_attr_is_true(node, NULL));
+
+    free_xml(node);
+}
+
+static void
+attr_missing(void **state)
+{
+    xmlNode *node = string2xml("<node a=\"true\" b=\"false\"/>");
+
+    assert_false(pcmk__xe_attr_is_true(node, "c"));
+    free_xml(node);
+}
+
+static void
+attr_present(void **state)
+{
+    xmlNode *node = string2xml("<node a=\"true\" b=\"false\"/>");
+
+    assert_true(pcmk__xe_attr_is_true(node, "a"));
+    assert_false(pcmk__xe_attr_is_true(node, "b"));
+
+    free_xml(node);
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(empty_input),
+        cmocka_unit_test(attr_missing),
+        cmocka_unit_test(attr_present),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/nvpair/pcmk__xe_get_bool_attr_test.c
+++ b/lib/common/tests/nvpair/pcmk__xe_get_bool_attr_test.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include "crm/common/results.h"
+#include <crm_internal.h>
+#include <crm/common/xml_internal.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+static void
+empty_input(void **state)
+{
+    xmlNode *node = string2xml("<node/>");
+    bool value;
+
+    assert_int_equal(pcmk__xe_get_bool_attr(NULL, NULL, &value), ENODATA);
+    assert_int_equal(pcmk__xe_get_bool_attr(NULL, "whatever", &value), ENODATA);
+    assert_int_equal(pcmk__xe_get_bool_attr(node, NULL, &value), EINVAL);
+    assert_int_equal(pcmk__xe_get_bool_attr(node, "whatever", NULL), EINVAL);
+
+    free_xml(node);
+}
+
+static void
+attr_missing(void **state)
+{
+    xmlNode *node = string2xml("<node a=\"true\" b=\"false\"/>");
+    bool value;
+
+    assert_int_equal(pcmk__xe_get_bool_attr(node, "c", &value), ENODATA);
+    free_xml(node);
+}
+
+static void
+attr_present(void **state)
+{
+    xmlNode *node = string2xml("<node a=\"true\" b=\"false\" c=\"blah\"/>");
+    bool value;
+
+    value = false;
+    assert_int_equal(pcmk__xe_get_bool_attr(node, "a", &value), pcmk_rc_ok);
+    assert_true(value);
+    value = true;
+    assert_int_equal(pcmk__xe_get_bool_attr(node, "b", &value), pcmk_rc_ok);
+    assert_false(value);
+    assert_int_equal(pcmk__xe_get_bool_attr(node, "c", &value), pcmk_rc_unknown_format);
+
+    free_xml(node);
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(empty_input),
+        cmocka_unit_test(attr_missing),
+        cmocka_unit_test(attr_present),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/nvpair/pcmk__xe_set_bool_attr_test.c
+++ b/lib/common/tests/nvpair/pcmk__xe_set_bool_attr_test.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+#include <crm/common/xml_internal.h>
+#include <crm/msg_xml.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+static void
+set_attr(void **state)
+{
+    xmlNode *node = string2xml("<node/>");
+
+    pcmk__xe_set_bool_attr(node, "a", true);
+    pcmk__xe_set_bool_attr(node, "b", false);
+
+    assert_string_equal(crm_element_value(node, "a"), XML_BOOLEAN_TRUE);
+    assert_string_equal(crm_element_value(node, "b"), XML_BOOLEAN_FALSE);
+
+    free_xml(node);
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(set_attr),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -962,7 +962,7 @@ lrmd_handshake(lrmd_t * lrmd, const char *name)
 
     /* advertise that we are a proxy provider */
     if (native->proxy_callback) {
-        crm_xml_add(hello, F_LRMD_IS_IPC_PROVIDER, "true");
+        pcmk__xe_set_bool_attr(hello, F_LRMD_IS_IPC_PROVIDER, true);
     }
 
     rc = lrmd_send_xml(lrmd, hello, -1, &reply);

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -342,7 +342,7 @@ rsc_action_item_xml(pcmk__output_t *out, va_list args)
         crm_xml_add(xml, "reason", source->reason);
 
     } else if (!pcmk_is_set(action->flags, pe_action_runnable)) {
-        crm_xml_add(xml, "blocked", "true");
+        pcmk__xe_set_bool_attr(xml, "blocked", true);
 
     }
 

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -377,7 +377,7 @@ pcmk__tag_to_set(xmlNode *xml_obj, xmlNode **rsc_set, const char *attr,
         }
 
         /* Set sequential="false" for the resource_set */
-        crm_xml_add(*rsc_set, "sequential", XML_BOOLEAN_FALSE);
+        pcmk__xe_set_bool_attr(*rsc_set, "sequential", false);
 
     } else if ((rsc != NULL) && convert_rsc) {
         /* Even a regular resource is referenced by "attr", convert it into a resource_set.

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -2437,7 +2437,7 @@ resource_history_xml(pcmk__output_t *out, va_list args) {
                                                      NULL);
 
     if (rsc == NULL) {
-        crm_xml_add(node, "orphan", "true");
+        pcmk__xe_set_bool_attr(node, "orphan", true);
     } else if (all || failcount || last_failure > 0) {
         char *migration_s = pcmk__itoa(rsc->migration_threshold);
 

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -76,7 +76,6 @@ cluster_status(pe_working_set_t * data_set)
     xmlNode *cib_status = get_xpath_object("//"XML_CIB_TAG_STATUS, data_set->input, LOG_TRACE);
     xmlNode *cib_tags = get_xpath_object("//" XML_CIB_TAG_TAGS, data_set->input,
                                          LOG_NEVER);
-    const char *value = crm_element_value(data_set->input, XML_ATTR_HAVE_QUORUM);
 
     crm_trace("Beginning unpack");
 
@@ -96,7 +95,7 @@ cluster_status(pe_working_set_t * data_set)
                                                    XML_ATTR_DC_UUID);
     }
 
-    if (crm_is_true(value)) {
+    if (pcmk__xe_attr_is_true(data_set->input, XML_ATTR_HAVE_QUORUM)) {
         pe__set_working_set_flags(data_set, pe_flag_have_quorum);
     } else {
         pe__clear_working_set_flags(data_set, pe_flag_have_quorum);

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -778,7 +778,6 @@ unpack_operation_on_fail(pe_action_t * action)
     const char *role = NULL;
     const char *on_fail = NULL;
     const char *interval_spec = NULL;
-    const char *enabled = NULL;
     const char *value = g_hash_table_lookup(action->meta, XML_OP_ATTR_ON_FAIL);
 
     if (pcmk__str_eq(action->task, CRMD_ACTION_STOP, pcmk__str_casei)
@@ -798,6 +797,7 @@ unpack_operation_on_fail(pe_action_t * action)
         for (operation = pcmk__xe_first_child(action->rsc->ops_xml);
              (operation != NULL) && (value == NULL);
              operation = pcmk__xe_next(operation)) {
+            bool enabled = false;
 
             if (!pcmk__str_eq((const char *)operation->name, "op", pcmk__str_none)) {
                 continue;
@@ -805,11 +805,10 @@ unpack_operation_on_fail(pe_action_t * action)
             name = crm_element_value(operation, "name");
             role = crm_element_value(operation, "role");
             on_fail = crm_element_value(operation, XML_OP_ATTR_ON_FAIL);
-            enabled = crm_element_value(operation, "enabled");
             interval_spec = crm_element_value(operation, XML_LRM_ATTR_INTERVAL);
             if (!on_fail) {
                 continue;
-            } else if (enabled && !crm_is_true(enabled)) {
+            } else if (pcmk__xe_get_bool_attr(operation, "enabled", &enabled) == pcmk_rc_ok && !enabled) {
                 continue;
             } else if (!pcmk__str_eq(name, "monitor", pcmk__str_casei)
                        || !pcmk__strcase_any_of(role, RSC_ROLE_PROMOTED_S,
@@ -854,7 +853,6 @@ find_min_interval_mon(pe_resource_t * rsc, gboolean include_disabled)
     guint interval_ms = 0;
     guint min_interval_ms = G_MAXUINT;
     const char *name = NULL;
-    const char *value = NULL;
     const char *interval_spec = NULL;
     xmlNode *op = NULL;
     xmlNode *operation = NULL;
@@ -864,10 +862,12 @@ find_min_interval_mon(pe_resource_t * rsc, gboolean include_disabled)
          operation = pcmk__xe_next(operation)) {
 
         if (pcmk__str_eq((const char *)operation->name, "op", pcmk__str_none)) {
+            bool enabled = false;
+
             name = crm_element_value(operation, "name");
             interval_spec = crm_element_value(operation, XML_LRM_ATTR_INTERVAL);
-            value = crm_element_value(operation, "enabled");
-            if (!include_disabled && value && crm_is_true(value) == FALSE) {
+            if (!include_disabled && pcmk__xe_get_bool_attr(operation, "enabled", &enabled) == pcmk_rc_ok &&
+                !enabled) {
                 continue;
             }
 
@@ -1375,7 +1375,6 @@ find_rsc_op_entry_helper(pe_resource_t * rsc, const char *key, gboolean include_
     gboolean do_retry = TRUE;
     char *local_key = NULL;
     const char *name = NULL;
-    const char *value = NULL;
     const char *interval_spec = NULL;
     char *match_key = NULL;
     xmlNode *op = NULL;
@@ -1386,10 +1385,12 @@ find_rsc_op_entry_helper(pe_resource_t * rsc, const char *key, gboolean include_
          operation = pcmk__xe_next(operation)) {
 
         if (pcmk__str_eq((const char *)operation->name, "op", pcmk__str_none)) {
+            bool enabled = false;
+
             name = crm_element_value(operation, "name");
             interval_spec = crm_element_value(operation, XML_LRM_ATTR_INTERVAL);
-            value = crm_element_value(operation, "enabled");
-            if (!include_disabled && value && crm_is_true(value) == FALSE) {
+            if (!include_disabled && pcmk__xe_get_bool_attr(operation, "enabled", &enabled) == pcmk_rc_ok &&
+                !enabled) {
                 continue;
             }
 

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -494,15 +494,15 @@ resource_check_list_xml(pcmk__output_t *out, va_list args) {
                                                    NULL);
 
     if (pcmk_is_set(checks->flags, rsc_remain_stopped)) {
-        crm_xml_add(node, "remain_stopped", "true");
+        pcmk__xe_set_bool_attr(node, "remain_stopped", true);
     }
 
     if (pcmk_is_set(checks->flags, rsc_unpromotable)) {
-        crm_xml_add(node, "promotable", "false");
+        pcmk__xe_set_bool_attr(node, "promotable", false);
     }
 
     if (pcmk_is_set(checks->flags, rsc_unmanaged)) {
-        crm_xml_add(node, "unmanaged", "true");
+        pcmk__xe_set_bool_attr(node, "unmanaged", true);
     }
 
     if (checks->lock_node) {


### PR DESCRIPTION
Note that there's still several complicated places where these new functions cannot be used, most notably in lib/pacemaker/pcmk_sched_ordering.c (search for crm_is_true).  Additionally, while working on this PR I discovered we do actually have a function to set booleans - crm_xml_add_boolean.  However, it was only used in five places, all of which were in the control daemon.

Another thing I encountered while working on this PR is a bunch of crm_xml_add blocks that could all be replaced with a single call to pcmk__xe_set_props (which would just call crm_xml_add eventually but would be nicer looking code).  I could make that change pretty quickly and add to this PR, or do it separately, or just put it on a todo list forever.