### PR TITLE
Mid: based controld: Suppresses unnecessary Election execution.(3)

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1209,6 +1209,7 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     char *current_nodes_digest = NULL;
     char *current_alerts_digest = NULL;
     char *current_status_digest = NULL;
+    int change_section = cib_change_section_nodes | cib_change_section_alerts | cib_change_section_status;
 
     CRM_ASSERT(cib_status == pcmk_ok);
 
@@ -1330,9 +1331,6 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
             char *result_nodes_digest = NULL;
             char *result_alerts_digest = NULL;
             char *result_status_digest = NULL;
-            gboolean change_node_digest = TRUE;
-            gboolean change_alert_digest = TRUE;
-            gboolean change_status_digest= TRUE;
 
             /* Calculate the hash value of the changed section. */
             result_nodes_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_NODES, result_cib);
@@ -1341,16 +1339,16 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
             crm_trace("result-digest %s:%s:%s", result_nodes_digest, result_alerts_digest, result_status_digest);
 
             if (pcmk__str_eq(current_nodes_digest, result_nodes_digest, pcmk__str_none)) {
-                change_node_digest = FALSE;
+                change_section = change_section ^ cib_change_section_nodes;
             }
             if (pcmk__str_eq(current_alerts_digest, result_alerts_digest, pcmk__str_none)) {
-                change_alert_digest = FALSE;
+                change_section = change_section ^ cib_change_section_alerts;
             }
             if (pcmk__str_eq(current_status_digest, result_status_digest, pcmk__str_none)) {
-                change_status_digest = FALSE;
+                change_section = change_section ^ cib_change_section_status;
             }
 
-            if (change_node_digest || change_alert_digest || change_status_digest) {
+            if (change_section) {
                 send_r_notify = TRUE;
             }
             
@@ -1395,7 +1393,7 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     if (send_r_notify) {
         const char *origin = crm_element_value(request, F_ORIG);
 
-        cib_replace_notify(origin, the_cib, rc, *cib_diff);
+        cib_replace_notify(origin, the_cib, rc, *cib_diff, change_section);
     }
 
     xml_log_patchset(LOG_TRACE, "cib:diff", *cib_diff);

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -234,7 +234,7 @@ attach_cib_generation(xmlNode * msg, const char *field, xmlNode * a_cib)
 }
 
 void
-cib_replace_notify(const char *origin, xmlNode * update, int result, xmlNode * diff)
+cib_replace_notify(const char *origin, xmlNode * update, int result, xmlNode * diff, int change_section)
 {
     xmlNode *replace_msg = NULL;
 
@@ -271,6 +271,7 @@ cib_replace_notify(const char *origin, xmlNode * update, int result, xmlNode * d
     crm_xml_add(replace_msg, F_SUBTYPE, T_CIB_REPLACE_NOTIFY);
     crm_xml_add(replace_msg, F_CIB_OPERATION, CIB_OP_REPLACE);
     crm_xml_add_int(replace_msg, F_CIB_RC, result);
+    crm_xml_add_int(replace_msg, F_CIB_CHANGE_SECTION, change_section);
     attach_cib_generation(replace_msg, "cib-replace-generation", update);
 
     crm_log_xml_trace(replace_msg, "CIB Replaced");

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -148,7 +148,7 @@ void cib_diff_notify(int options, const char *client, const char *call_id,
                      const char *op, xmlNode *update, int result,
                      xmlNode *old_cib);
 void cib_replace_notify(const char *origin, xmlNode *update, int result,
-                        xmlNode *diff);
+                        xmlNode *diff, int change_section);
 
 static inline const char *
 cib_config_lookup(const char *opt)

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -31,6 +31,8 @@ do_cib_updated(const char *event, xmlNode * msg)
 void
 do_cib_replaced(const char *event, xmlNode * msg)
 {
+    int change_section = cib_change_section_nodes | cib_change_section_status;
+
     crm_debug("Updating the CIB after a replace: DC=%s", pcmk__btoa(AM_I_DC));
     if (AM_I_DC == FALSE) {
         return;
@@ -41,9 +43,13 @@ do_cib_replaced(const char *event, xmlNode * msg)
         return;
     }
 
-    /* start the join process again so we get everyone's LRM status */
-    populate_cib_nodes(node_update_quick|node_update_all, __func__);
-    register_fsa_input(C_FSA_INTERNAL, I_ELECTION, NULL);
+    crm_element_value_int(msg, F_CIB_CHANGE_SECTION, &change_section);
+    if (change_section & (cib_change_section_nodes | cib_change_section_status)) {
+        /* start the join process again so we get everyone's LRM status */
+        populate_cib_nodes(node_update_quick|node_update_all, __func__);
+
+        register_fsa_input(C_FSA_INTERNAL, I_ELECTION, NULL);
+    }
 }
 
 void

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -58,6 +58,7 @@
 #  define F_CIB_LOCAL_NOTIFY_ID	"cib_local_notify_id"
 #  define F_CIB_PING_ID         "cib_ping_id"
 #  define F_CIB_SCHEMA_MAX      "cib_schema_max"
+#  define F_CIB_CHANGE_SECTION  "cib_change_section"
 
 #  define T_CIB			"cib"
 #  define T_CIB_NOTIFY		"cib_notify"
@@ -66,6 +67,14 @@
 #  define T_CIB_POST_NOTIFY	"cib_post_notify"
 #  define T_CIB_UPDATE_CONFIRM	"cib_update_confirmation"
 #  define T_CIB_REPLACE_NOTIFY	"cib_refresh_notify"
+
+enum cib_change_section_info {
+    cib_change_section_none     = 0x00000000,
+    cib_change_section_nodes    = 0x00000001,
+    cib_change_section_alerts   = 0x00000002,
+    cib_change_section_status   = 0x00000004
+};
+
 
 gboolean cib_diff_version_details(xmlNode * diff, int *admin_epoch, int *epoch, int *updates,
                                   int *_admin_epoch, int *_epoch, int *_updates);


### PR DESCRIPTION
Hi Ken,
Hi All,

This PR is a modified version of the next PR.
 - https://github.com/ClusterLabs/pacemaker/pull/2565
 
After further consideration, I added a section change to the CIB replacement notification.
This avoids unnecessary Elections.

To Ken : I decided to include populate_cib_nodes () in this PR and move it to the if block.

Best Regards,
Hideo Yamauchi.