### PR TITLE
[WIP] Subdaemon heartbeat

### DIFF
--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -259,6 +259,8 @@ main(int argc, char **argv)
     pcmk_ipc_api_t *old_instance = NULL;
     qb_ipcs_service_t *ipcs = NULL;
 
+    subdaemon_check_progress = time(NULL);
+
     crm_log_preinit(NULL, argc, argv);
     mainloop_add_signal(SIGHUP, pcmk_ignore);
     mainloop_add_signal(SIGQUIT, pcmk_sigquit);

--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -21,6 +21,7 @@ extern unsigned int shutdown_complete_state_reported_to;
 extern gboolean shutdown_complete_state_reported_client_closed;
 extern crm_trigger_t *shutdown_trigger;
 extern crm_trigger_t *startup_trigger;
+extern time_t subdaemon_check_progress;
 
 gboolean mcp_read_config(void);
 

--- a/daemons/pacemakerd/pcmkd_messages.c
+++ b/daemons/pacemakerd/pcmkd_messages.c
@@ -25,7 +25,6 @@ pcmk_handle_ping_request(pcmk__client_t *c, xmlNode *msg, uint32_t id)
     const char *value = NULL;
     xmlNode *ping = NULL;
     xmlNode *reply = NULL;
-    time_t pinged = time(NULL);
     const char *from = crm_element_value(msg, F_CRM_SYS_FROM);
 
     /* Pinged for status */
@@ -36,7 +35,8 @@ pcmk_handle_ping_request(pcmk__client_t *c, xmlNode *msg, uint32_t id)
     value = crm_element_value(msg, F_CRM_SYS_TO);
     crm_xml_add(ping, XML_PING_ATTR_SYSFROM, value);
     crm_xml_add(ping, XML_PING_ATTR_PACEMAKERDSTATE, pacemakerd_state);
-    crm_xml_add_ll(ping, XML_ATTR_TSTAMP, (long long) pinged);
+    crm_xml_add_ll(ping, XML_ATTR_TSTAMP,
+                   (long long) subdaemon_check_progress);
     crm_xml_add(ping, XML_PING_ATTR_STATUS, "ok");
     reply = create_reply(msg, ping);
     free_xml(ping);

--- a/rpm/Makefile.am
+++ b/rpm/Makefile.am
@@ -114,18 +114,17 @@ distdir		= $(top_distdir)/rpm
 TARFILE		= $(abs_builddir)/../$(top_distdir).tar.gz
 
 export:
-	if [ -f "$(TARFILE)" ]; then							\
-	    echo "`date`: Using existing tarball: $(TARFILE)";				\
-	else										\
-	    cd $(abs_srcdir)/..;							\
-	    if [ -n "$(DIRTY_EXT)" ]; then 							\
-	        git commit -m "DO-NOT-PUSH" -a;						\
-	        git archive --prefix=$(top_distdir)/ -o "$(TARFILE)" HEAD^{tree};	\
-	        git reset --mixed HEAD^;						\
-	    else									\
-	        git archive --prefix=$(top_distdir)/ -o "$(TARFILE)" $(TAG)^{tree};	\
-	    fi;										\
-	    echo "`date`: Rebuilt $(TARFILE)";						\
+	cd $(abs_srcdir)/..;							\
+	if [ -n "$(DIRTY_EXT)" ]; then						\
+	    git commit -m "DO-NOT-PUSH" -a;					\
+	    git archive --prefix=$(top_distdir)/ -o "$(TARFILE)" HEAD^{tree};	\
+	    git reset --mixed HEAD^;						\
+	    echo "`date`: Rebuilt $(TARFILE)";					\
+	elif [ -f "$(TARFILE)" ]; then						\
+	    echo "`date`: Using existing tarball: $(TARFILE)";			\
+	else									\
+	    git archive --prefix=$(top_distdir)/ -o "$(TARFILE)" $(TAG)^{tree};	\
+	    echo "`date`: Rebuilt $(TARFILE)";					\
 	fi
 
 # Depend on spec-clean so the spec gets rebuilt every time


### PR DESCRIPTION
This depicts the basic idea of using tracking via ipc to detect basic liveness of subdaemons.

Idea is to still keep tracking subdaemons active even if they are children of pacemakerd where we
up to now were relying on signals sent to the parent if subdaemons are dying.
But just if they are dying and not if they are stalled via whatever might block their mainloop.
pacemakerd updates timestamps sent to sbd on every successful check of a subdaemon -
regardless if running happily or successfully recovered.
The tracking loop periodically fired up is broken up into single checks per timer-expiry in
the hope that this will keep reactivity of pacemakerd at a level so that liveness detection
from sbd won't trigger in case everything is running fine - even at default wd-timeout of 5s.
If we want pacemakerd to attempt subdaemon recovery wd-timeout has to be relaxed
so that ipc-connect timeouts don't trigger it.

Still requires testing as I've never seen a stalled subdaemon being recovered by pacemakerd yet.
Haven't tested without sbd so far and thus sbd always came first to shoot the node (already set
to 90s wd-timeout).
Special handling of subdaemons that are children of pacemakerd might make sense as well - 
might e.g. skip checking for a pid.
 
Build-fix sneaked in deals with the case of multiple times building from a dirty git.
Reusing an already built tar-file from a clean commit is safe as it has the commit in the name and that defines the content.
If we want to get that into 2.1.2 I can spawn it out and make a PR against 2.1.