### PR TITLE
Fix: controller: handle remote connection start timeouts correctly

### DIFF
--- a/cts/lab/patterns.py
+++ b/cts/lab/patterns.py
@@ -220,6 +220,7 @@ class crm_corosync(BasePatterns):
         
         self.components["corosync-ignore"] = [
             r"Could not connect to Corosync CFG: CS_ERR_LIBRARY",
+            r"error:.*Connection to the CPG API failed: Library error",
             r"\[[0-9]+\] exited with status [0-9]+ \(",
             r"\[[0-9]+\] terminated with signal 15",
             r"pacemaker-based.*error:.*Corosync connection lost",

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -413,7 +413,7 @@ retry_start_cmd_cb(gpointer data)
     lrm_state_t *lrm_state = data;
     remote_ra_data_t *ra_data = lrm_state->remote_ra_data;
     remote_ra_cmd_t *cmd = NULL;
-    int rc = pcmk_rc_error;
+    int rc = ETIME;
 
     if (!ra_data || !ra_data->cur_cmd) {
         return FALSE;
@@ -426,6 +426,10 @@ retry_start_cmd_cb(gpointer data)
 
     if (cmd->remaining_timeout > 0) {
         rc = handle_remote_ra_start(lrm_state, cmd, cmd->remaining_timeout);
+    } else {
+        pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
+                         PCMK_EXEC_TIMEOUT,
+                         "Not enough time remains to retry remote connection");
     }
 
     if (rc != pcmk_rc_ok) {


### PR DESCRIPTION
16346686 (2.1.2-rc1) introduced a regression in the handling of
remote connection start timeouts.

It simplified setting failures for handle_remote_ra_start(), but overlooked the
case in retry_start_cmd_cb() where handle_remote_ra_start() is not called
because there is not enough time remaining.

Before that commit, the timeout would get PCMK_OCF_UNKNOWN_ERROR and
PCMK_EXEC_ERROR as the result. Now, fix the regression, and change that to
PCMK_EXEC_TIMEOUT with a suitable exit reason.