### PR TITLE
OCF: controld: Give warning when no-quorum-policy not set as freeze while using DLM

### DIFF
--- a/extra/resources/controld
+++ b/extra/resources/controld
@@ -173,6 +173,12 @@ controld_start() {
         return $OCF_ERR_CONFIGURED
     fi
 
+    # If no-quorum-policy not set, or not set as freeze, give a warning
+    crm_attribute --type=crm_config --name=no-quorum-policy --query|grep value=freeze >/dev/null 2>/dev/null
+    if [ $? -ne 0 ]; then
+        ocf_log warn "The DLM cluster best practice suggests to set the cluster property \"no-quorum-policy=freeze\""
+    fi
+
     "${OCF_RESKEY_daemon}" $OCF_RESKEY_args
 
     while true


### PR DESCRIPTION
When using DLM ra(controld), as both SLE HA and RHEL HA officially recommend no-quorum-policy=freeze(see [1] and [2]), 
considering customers easily forget to set this value, It will be helpful if controld can give a warning when starting

[1] https://documentation.suse.com/sle-ha/15-SP3/single-html/SLE-HA-administration/#sec-ha-config-basics-global-quorum

[2] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_high_availability_clusters/assembly_configuring-gfs2-in-a-cluster-configuring-and-managing-high-availability-clusters
