### PR TITLE
Track full result including exit reasons throughout fencer API

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -3216,7 +3216,7 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
                              PCMK_EXEC_INVALID,
                              "Unprivileged users must add level via CIB");
         }
-        do_stonith_notify_level(op, pcmk_rc2legacy(stonith__result2rc(&result)), device_id);
+        fenced_send_level_notification(op, &result, device_id);
         free(device_id);
 
     } else if (pcmk__str_eq(op, STONITH_OP_LEVEL_DEL, pcmk__str_none)) {
@@ -3229,7 +3229,7 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
                              PCMK_EXEC_INVALID,
                              "Unprivileged users must delete level via CIB");
         }
-        do_stonith_notify_level(op, pcmk_rc2legacy(stonith__result2rc(&result)), device_id);
+        fenced_send_level_notification(op, &result, device_id);
 
     } else if(pcmk__str_eq(op, CRM_OP_RM_NODE_CACHE, pcmk__str_casei)) {
         int node_id = 0;

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1636,6 +1636,16 @@ fenced_register_level(xmlNode *msg, char **desc, pcmk__action_result_t *result)
         *desc = crm_strdup_printf("%s[%d]", target, id);
     }
 
+    // Ensure a valid target was specified
+    if ((mode < 0) || (mode > 2)) {
+        crm_warn("Ignoring topology level registration without valid target");
+        free(target);
+        crm_log_xml_warn(level, "Bad level");
+        pcmk__set_result(result, CRM_EX_INVALID_PARAM, PCMK_EXEC_INVALID,
+                         "Invalid topology level target");
+        return;
+    }
+
     // Ensure level ID is in allowed range
     if ((id <= 0) || (id >= ST_LEVEL_MAX)) {
         crm_warn("Ignoring topology registration for %s with invalid level %d",
@@ -1643,7 +1653,7 @@ fenced_register_level(xmlNode *msg, char **desc, pcmk__action_result_t *result)
         free(target);
         crm_log_xml_warn(level, "Bad level");
         pcmk__set_result(result, CRM_EX_INVALID_PARAM, PCMK_EXEC_INVALID,
-                         "Invalid topology level");
+                         "Invalid topology level number");
         return;
     }
 

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -3190,7 +3190,7 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
                              PCMK_EXEC_INVALID,
                              "Unprivileged users must register device via CIB");
         }
-        do_stonith_notify_device(op, pcmk_rc2legacy(stonith__result2rc(&result)), device_id);
+        fenced_send_device_notification(op, &result, device_id);
 
     } else if (pcmk__str_eq(op, STONITH_OP_DEVICE_DEL, pcmk__str_none)) {
         xmlNode *dev = get_xpath_object("//" F_STONITH_DEVICE, request, LOG_ERR);
@@ -3204,7 +3204,7 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
                              PCMK_EXEC_INVALID,
                              "Unprivileged users must delete device via CIB");
         }
-        do_stonith_notify_device(op, pcmk_rc2legacy(stonith__result2rc(&result)), device_id);
+        fenced_send_device_notification(op, &result, device_id);
 
     } else if (pcmk__str_eq(op, STONITH_OP_LEVEL_ADD, pcmk__str_none)) {
         char *device_id = NULL;

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2489,8 +2489,8 @@ send_async_reply(async_command_t *cmd, const pcmk__action_result_t *result,
         crm_xml_add(notify_data, F_STONITH_REMOTE_OP_ID, cmd->remote_op_id);
         crm_xml_add(notify_data, F_STONITH_ORIGIN, cmd->client);
 
-        do_stonith_notify(T_STONITH_NOTIFY_FENCE, pcmk_rc2legacy(stonith__result2rc(result)), notify_data);
-        do_stonith_notify(T_STONITH_NOTIFY_HISTORY, pcmk_ok, NULL);
+        fenced_send_notification(T_STONITH_NOTIFY_FENCE, result, notify_data);
+        fenced_send_notification(T_STONITH_NOTIFY_HISTORY, NULL, NULL);
     }
 }
 

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2415,9 +2415,8 @@ send_async_reply(async_command_t *cmd, const pcmk__action_result_t *result,
     if (stand_alone) {
         /* Do notification with a clean data object */
         xmlNode *notify_data = create_xml_node(NULL, T_STONITH_NOTIFY_FENCE);
-        int rc = pcmk_rc2legacy(stonith__result2rc(result));
 
-        crm_xml_add_int(notify_data, F_STONITH_RC, rc);
+        stonith__xe_set_result(notify_data, result);
         crm_xml_add(notify_data, F_STONITH_TARGET, cmd->victim);
         crm_xml_add(notify_data, F_STONITH_OPERATION, cmd->op);
         crm_xml_add(notify_data, F_STONITH_DELEGATE, "localhost");
@@ -2425,7 +2424,7 @@ send_async_reply(async_command_t *cmd, const pcmk__action_result_t *result,
         crm_xml_add(notify_data, F_STONITH_REMOTE_OP_ID, cmd->remote_op_id);
         crm_xml_add(notify_data, F_STONITH_ORIGIN, cmd->client);
 
-        do_stonith_notify(T_STONITH_NOTIFY_FENCE, rc, notify_data);
+        do_stonith_notify(T_STONITH_NOTIFY_FENCE, pcmk_rc2legacy(stonith__result2rc(result)), notify_data);
         do_stonith_notify(T_STONITH_NOTIFY_HISTORY, pcmk_ok, NULL);
     }
 }
@@ -2728,9 +2727,8 @@ construct_async_reply(async_command_t *cmd, const pcmk__action_result_t *result)
     crm_xml_add(reply, F_STONITH_ORIGIN, cmd->origin);
     crm_xml_add_int(reply, F_STONITH_CALLID, cmd->id);
     crm_xml_add_int(reply, F_STONITH_CALLOPTS, cmd->options);
-    crm_xml_add_int(reply, F_STONITH_RC,
-                    pcmk_rc2legacy(stonith__result2rc(result)));
-    crm_xml_add(reply, F_STONITH_OUTPUT, result->action_stdout);
+
+    stonith__xe_set_result(reply, result);
     return reply;
 }
 

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -100,7 +100,7 @@ stonith_fence_history_cleanup(const char *target,
         g_hash_table_foreach_remove(stonith_remote_op_list,
                              stonith_remove_history_entry,
                              (gpointer) target);
-        do_stonith_notify(T_STONITH_NOTIFY_HISTORY, pcmk_ok, NULL);
+        fenced_send_notification(T_STONITH_NOTIFY_HISTORY, NULL, NULL);
     }
 }
 
@@ -402,7 +402,7 @@ stonith_local_history_diff_and_merge(GHashTable *remote_history,
 
     if (updated) {
         stonith_fence_history_trim();
-        do_stonith_notify(T_STONITH_NOTIFY_HISTORY, pcmk_ok, NULL);
+        fenced_send_notification(T_STONITH_NOTIFY_HISTORY, NULL, NULL);
     }
 
     if (cnt == 0) {
@@ -473,7 +473,7 @@ stonith_fence_history(xmlNode *msg, xmlNode **output,
            is done so send a notification for anything
            that smells like history-sync
          */
-        do_stonith_notify(T_STONITH_NOTIFY_HISTORY_SYNCED, pcmk_ok, NULL);
+        fenced_send_notification(T_STONITH_NOTIFY_HISTORY_SYNCED, NULL, NULL);
         if (crm_element_value(msg, F_STONITH_CALLID)) {
             /* this is coming from the stonith-API
             *

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -374,7 +374,7 @@ stonith_local_history_diff_and_merge(GHashTable *remote_history,
                 set_fencing_completed(op);
                 /* use -EHOSTUNREACH to not introduce a new return-code that might
                    trigger unexpected results at other places and to prevent
-                   remote_op_done from setting the delegate if not present
+                   finalize_op from setting the delegate if not present
                 */
                 stonith_bcast_result_to_peers(op, -EHOSTUNREACH, FALSE);
             }

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -415,7 +415,14 @@ handle_local_reply_and_notify(remote_fencing_op_t * op, xmlNode * data, int rc)
     crm_xml_add(data, F_STONITH_TARGET, op->target);
     crm_xml_add(data, F_STONITH_OPERATION, op->action);
 
-    reply = stonith_construct_reply(op->request, NULL, data, rc);
+    {
+        pcmk__action_result_t result = PCMK__UNKNOWN_RESULT;
+
+        pcmk__set_result(&result,
+                         ((rc == pcmk_ok)? CRM_EX_OK : CRM_EX_ERROR),
+                         stonith__legacy2status(rc), NULL);
+        reply = fenced_construct_reply(op->request, data, &result);
+    }
     crm_xml_add(reply, F_STONITH_DELEGATE, op->delegate);
 
     /* Send fencing OP reply to local client that initiated fencing */

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -616,7 +616,9 @@ remote_op_timeout_one(gpointer userdata)
 
     crm_notice("Peer's '%s' action targeting %s for client %s timed out " CRM_XS
                " id=%.8s", op->action, op->target, op->client_name, op->id);
-    pcmk__set_result(&result, CRM_EX_ERROR, PCMK_EXEC_TIMEOUT, NULL);
+    pcmk__set_result(&result, CRM_EX_ERROR, PCMK_EXEC_TIMEOUT,
+                     "Peer did not send fence result within timeout");
+
 
     // Try another device, if appropriate
     request_peer_fencing(op, NULL, &result);

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -656,7 +656,7 @@ remote_op_timeout_one(gpointer userdata)
     crm_notice("Peer's '%s' action targeting %s for client %s timed out " CRM_XS
                " id=%.8s", op->action, op->target, op->client_name, op->id);
     pcmk__set_result(&result, CRM_EX_ERROR, PCMK_EXEC_TIMEOUT,
-                     "Peer did not send fence result within timeout");
+                     "Peer did not return fence result within timeout");
 
 
     // Try another device, if appropriate

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -442,8 +442,8 @@ handle_local_reply_and_notify(remote_fencing_op_t *op, xmlNode *data,
     do_local_reply(reply, op->client_id, op->call_options & st_opt_sync_call, FALSE);
 
     /* bcast to all local clients that the fencing operation happend */
-    do_stonith_notify(T_STONITH_NOTIFY_FENCE, pcmk_rc2legacy(stonith__result2rc(result)), notify_data);
-    do_stonith_notify(T_STONITH_NOTIFY_HISTORY, pcmk_ok, NULL);
+    fenced_send_notification(T_STONITH_NOTIFY_FENCE, result, notify_data);
+    fenced_send_notification(T_STONITH_NOTIFY_HISTORY, NULL, NULL);
 
     /* mark this op as having notify's already sent */
     op->notify_sent = TRUE;
@@ -1211,7 +1211,7 @@ create_remote_stonith_op(const char *client, xmlNode * request, gboolean peer)
 
     if (op->state != st_duplicate) {
         /* kick history readers */
-        do_stonith_notify(T_STONITH_NOTIFY_HISTORY, pcmk_ok, NULL);
+        fenced_send_notification(T_STONITH_NOTIFY_HISTORY, NULL, NULL);
     }
 
     /* safe to trim as long as that doesn't touch pending ops */

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -394,10 +394,21 @@ do_stonith_notify_config(const char *op, int rc,
     free_xml(notify_data);
 }
 
+/*!
+ * \internal
+ * \brief Send notifications for a device change to subscribed clients
+ *
+ * \param[in] op      Notification type (STONITH_OP_DEVICE_ADD or
+ *                    STONITH_OP_DEVICE_DEL)
+ * \param[in] result  Operation result
+ * \param[in] desc    ID of device that changed
+ */
 void
-do_stonith_notify_device(const char *op, int rc, const char *desc)
+fenced_send_device_notification(const char *op,
+                                const pcmk__action_result_t *result,
+                                const char *desc)
 {
-    do_stonith_notify_config(op, rc, desc, g_hash_table_size(device_list));
+    do_stonith_notify_config(op, pcmk_rc2legacy(stonith__result2rc(result)), desc, g_hash_table_size(device_list));
 }
 
 void

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -409,17 +409,18 @@ do_stonith_notify_level(const char *op, int rc, const char *desc)
 static void
 topology_remove_helper(const char *node, int level)
 {
-    int rc;
     char *desc = NULL;
+    pcmk__action_result_t result = PCMK__UNKNOWN_RESULT;
     xmlNode *data = create_xml_node(NULL, XML_TAG_FENCING_LEVEL);
 
     crm_xml_add(data, F_STONITH_ORIGIN, __func__);
     crm_xml_add_int(data, XML_ATTR_STONITH_INDEX, level);
     crm_xml_add(data, XML_ATTR_STONITH_TARGET, node);
 
-    rc = stonith_level_remove(data, &desc);
-    do_stonith_notify_level(STONITH_OP_LEVEL_DEL, rc, desc);
-
+    fenced_unregister_level(data, &desc, &result);
+    do_stonith_notify_level(STONITH_OP_LEVEL_DEL,
+                            pcmk_rc2legacy(stonith__result2rc(&result)), desc);
+    pcmk__reset_result(&result);
     free_xml(data);
     free(desc);
 }

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -452,8 +452,8 @@ remove_cib_device(xmlXPathObjectPtr xpathObj)
 static void
 handle_topology_change(xmlNode *match, bool remove) 
 {
-    int rc;
     char *desc = NULL;
+    pcmk__action_result_t result = PCMK__UNKNOWN_RESULT;
 
     CRM_CHECK(match != NULL, return);
     crm_trace("Updating %s", ID(match));
@@ -467,9 +467,10 @@ handle_topology_change(xmlNode *match, bool remove)
         free(key);
     }
 
-    rc = stonith_level_register(match, &desc);
-    do_stonith_notify_level(STONITH_OP_LEVEL_ADD, rc, desc);
-
+    fenced_register_level(match, &desc, &result);
+    do_stonith_notify_level(STONITH_OP_LEVEL_ADD,
+                            pcmk_rc2legacy(stonith__result2rc(&result)), desc);
+    pcmk__reset_result(&result);
     free(desc);
 }
 

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -411,10 +411,21 @@ fenced_send_device_notification(const char *op,
     do_stonith_notify_config(op, pcmk_rc2legacy(stonith__result2rc(result)), desc, g_hash_table_size(device_list));
 }
 
+/*!
+ * \internal
+ * \brief Send notifications for a topology level change to subscribed clients
+ *
+ * \param[in] op      Notification type (STONITH_OP_LEVEL_ADD or
+ *                    STONITH_OP_LEVEL_DEL)
+ * \param[in] result  Operation result
+ * \param[in] desc    String representation of level (<target>[<level_index>])
+ */
 void
-do_stonith_notify_level(const char *op, int rc, const char *desc)
+fenced_send_level_notification(const char *op,
+                               const pcmk__action_result_t *result,
+                               const char *desc)
 {
-    do_stonith_notify_config(op, rc, desc, g_hash_table_size(topology));
+    do_stonith_notify_config(op, pcmk_rc2legacy(stonith__result2rc(result)), desc, g_hash_table_size(topology));
 }
 
 static void
@@ -429,8 +440,7 @@ topology_remove_helper(const char *node, int level)
     crm_xml_add(data, XML_ATTR_STONITH_TARGET, node);
 
     fenced_unregister_level(data, &desc, &result);
-    do_stonith_notify_level(STONITH_OP_LEVEL_DEL,
-                            pcmk_rc2legacy(stonith__result2rc(&result)), desc);
+    fenced_send_level_notification(STONITH_OP_LEVEL_DEL, &result, desc);
     pcmk__reset_result(&result);
     free_xml(data);
     free(desc);
@@ -480,8 +490,7 @@ handle_topology_change(xmlNode *match, bool remove)
     }
 
     fenced_register_level(match, &desc, &result);
-    do_stonith_notify_level(STONITH_OP_LEVEL_ADD,
-                            pcmk_rc2legacy(stonith__result2rc(&result)), desc);
+    fenced_send_level_notification(STONITH_OP_LEVEL_ADD, &result, desc);
     pcmk__reset_result(&result);
     free(desc);
 }

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -233,7 +233,9 @@ void do_stonith_notify(const char *type, int result, xmlNode *data);
 void fenced_send_device_notification(const char *op,
                                      const pcmk__action_result_t *result,
                                      const char *desc);
-void do_stonith_notify_level(const char *op, int rc, const char *desc);
+void fenced_send_level_notification(const char *op,
+                                    const pcmk__action_result_t *result,
+                                    const char *desc);
 
 remote_fencing_op_t *initiate_remote_stonith_op(pcmk__client_t *client,
                                                 xmlNode *request,

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -230,7 +230,9 @@ void
  do_stonith_async_timeout_update(const char *client, const char *call_id, int timeout);
 
 void do_stonith_notify(const char *type, int result, xmlNode *data);
-void do_stonith_notify_device(const char *op, int rc, const char *desc);
+void fenced_send_device_notification(const char *op,
+                                     const pcmk__action_result_t *result,
+                                     const char *desc);
 void do_stonith_notify_level(const char *op, int rc, const char *desc);
 
 remote_fencing_op_t *initiate_remote_stonith_op(pcmk__client_t *client,

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -153,13 +153,8 @@ typedef struct remote_fencing_op_s {
 
 } remote_fencing_op_t;
 
-/*!
- * \internal
- * \brief Broadcast the result of an operation to the peers.
- * \param op, Operation whose result should be broadcast
- * \param rc, Result of the operation
- */
-void stonith_bcast_result_to_peers(remote_fencing_op_t * op, int rc, gboolean op_merged);
+void fenced_broadcast_op_result(remote_fencing_op_t *op,
+                                pcmk__action_result_t *result, bool op_merged);
 
 // Fencer-specific client flags
 enum st_client_flags {

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -229,7 +229,9 @@ xmlNode *fenced_construct_reply(xmlNode *request, xmlNode *data,
 void
  do_stonith_async_timeout_update(const char *client, const char *call_id, int timeout);
 
-void do_stonith_notify(const char *type, int result, xmlNode *data);
+void fenced_send_notification(const char *type,
+                              const pcmk__action_result_t *result,
+                              xmlNode *data);
 void fenced_send_device_notification(const char *op,
                                      const pcmk__action_result_t *result,
                                      const char *desc);

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -228,8 +228,8 @@ stonith_topology_t *find_topology_for_host(const char *host);
 void do_local_reply(xmlNode * notify_src, const char *client_id, gboolean sync_reply,
                            gboolean from_peer);
 
-xmlNode *stonith_construct_reply(xmlNode * request, const char *output, xmlNode * data,
-                                        int rc);
+xmlNode *fenced_construct_reply(xmlNode *request, xmlNode *data,
+                                pcmk__action_result_t *result);
 
 void
  do_stonith_async_timeout_update(const char *client, const char *call_id, int timeout);

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -220,8 +220,8 @@ char *stonith_level_key(xmlNode * msg, int mode);
 int stonith_level_kind(xmlNode * msg);
 void fenced_register_level(xmlNode *msg, char **desc,
                            pcmk__action_result_t *result);
-
-int stonith_level_remove(xmlNode * msg, char **desc);
+void fenced_unregister_level(xmlNode *msg, char **desc,
+                             pcmk__action_result_t *result);
 
 stonith_topology_t *find_topology_for_host(const char *host);
 

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -218,7 +218,8 @@ void stonith_device_remove(const char *id, bool from_cib);
 
 char *stonith_level_key(xmlNode * msg, int mode);
 int stonith_level_kind(xmlNode * msg);
-int stonith_level_register(xmlNode * msg, char **desc);
+void fenced_register_level(xmlNode *msg, char **desc,
+                           pcmk__action_result_t *result);
 
 int stonith_level_remove(xmlNode * msg, char **desc);
 

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -325,6 +325,7 @@ stonith__result2rc(const pcmk__action_result_t *result)
          */
         case PCMK_EXEC_INVALID:
             switch (result->exit_status) {
+                case CRM_EX_INVALID_PARAM:      return EINVAL;
                 case CRM_EX_INSUFFICIENT_PRIV:  return EACCES;
                 case CRM_EX_PROTOCOL:           return EPROTO;
 


### PR DESCRIPTION
An earlier PR made the fencer track the full result of fence actions, including exit reasons. This extends that to the entire fencer IPC/CPG API.

The fencing client library provides results both as callbacks (to the requester of fencing) and as notifications (to all clients who registered for them). The ultimate goal is to provide the full result in both places, which would require the fencer to track and pass the full result for a bunch of API request types. It made more sense to convert the entire API to use full results, both for consistency and to move away from legacy return codes in general. (Custom legacy return codes can conflict with system errnos, and system errnos are not guaranteed to have the same meaning from node to node.)