### PR TITLE
Fix a few minor issues

### DIFF
--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -52,7 +52,7 @@ cib_prepare_common(xmlNode * root, const char *section)
 
     /* grab the section specified for the command */
     if (section != NULL && data != NULL && pcmk__str_eq(crm_element_name(data), XML_TAG_CIB, pcmk__str_none)) {
-        data = get_object_root(section, data);
+        data = pcmk_find_cib_element(data, section);
     }
 
     /* crm_log_xml_trace(root, "cib:input"); */

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -469,7 +469,7 @@ cib_process_delete_absolute(const char *op, int options, const char *section, xm
 
     failed = create_xml_node(NULL, XML_TAG_FAILED);
 
-    update_section = get_object_root(section, *result_cib);
+    update_section = pcmk_find_cib_element(*result_cib, section);
     result = delete_cib_object(update_section, input);
     update_results(failed, input, op, result);
 

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -367,12 +367,19 @@ force_local_option(xmlNode *xml, const char *attr_name, const char *attr_value)
 {
     int max = 0;
     int lpc = 0;
+    const char *xpath_base = NULL;
     char *xpath_string = NULL;
     xmlXPathObjectPtr xpathObj = NULL;
 
-    xpath_string = crm_strdup_printf("%.128s//%s//nvpair[@name='%.128s']",
-                                     get_object_path(XML_CIB_TAG_CRMCONFIG),
-                                     XML_CIB_TAG_PROPSET, attr_name);
+    xpath_base = pcmk_cib_xpath_for(XML_CIB_TAG_CRMCONFIG);
+    if (xpath_base == NULL) {
+        crm_err(XML_CIB_TAG_CRMCONFIG " CIB element not known (bug?)");
+        return;
+    }
+
+    xpath_string = crm_strdup_printf("%s//%s//nvpair[@name='%s']",
+                                     xpath_base, XML_CIB_TAG_PROPSET,
+                                     attr_name);
     xpathObj = xpath_search(xml, xpath_string);
     max = numXpathResults(xpathObj);
     free(xpath_string);

--- a/extra/resources/Dummy
+++ b/extra/resources/Dummy
@@ -58,8 +58,7 @@
 meta_data() {
     cat <<END
 <?xml version="1.0"?>
-<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="Dummy" version="2.0">
+<resource-agent name="Dummy" version="2.1">
 <version>1.1</version>
 
 <longdesc lang="en">

--- a/extra/resources/HealthIOWait
+++ b/extra/resources/HealthIOWait
@@ -25,8 +25,7 @@
 meta_data() {
         cat <<END
 <?xml version="1.0"?>
-<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="HealthIOWait" version="1.1">
+<resource-agent name="HealthIOWait" version="1.2">
 <version>1.1</version>
 
 <longdesc lang="en">

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -39,8 +39,7 @@ SCORE_PROMOTED=10
 meta_data() {
     cat <<END
 <?xml version="1.0"?>
-<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="Stateful" version="1.1">
+<resource-agent name="Stateful" version="1.2">
 <version>1.1</version>
 
 <longdesc lang="en">

--- a/extra/resources/Stateful
+++ b/extra/resources/Stateful
@@ -57,7 +57,7 @@ Location to store the resource state in
 <content type="string" default="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state" />
 </parameter>
 
-<parameter name="envfile" reloadable="true">
+<parameter name="envfile" reloadable="1">
 <longdesc lang="en">
 If this is set, the environment will be dumped to this file for every call.
 </longdesc>
@@ -65,7 +65,7 @@ If this is set, the environment will be dumped to this file for every call.
 <content type="string" default="" />
 </parameter>
 
-<parameter name="notify_delay" reloadable="true">
+<parameter name="notify_delay" reloadable="1">
 <longdesc lang="en">
 The notify action will sleep for this many seconds before returning,
 to simulate a long-running notify.

--- a/extra/resources/attribute
+++ b/extra/resources/attribute
@@ -57,8 +57,7 @@ END
 meta_data() {
     cat <<END
 <?xml version="1.0"?>
-<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="attribute" version="1.1">
+<resource-agent name="attribute" version="1.2">
   <version>1.1</version>
   <shortdesc lang="en">Manages a node attribute</shortdesc>
   <longdesc lang="en">

--- a/extra/resources/ping
+++ b/extra/resources/ping
@@ -36,8 +36,7 @@
 meta_data() {
      cat <<END
 <?xml version="1.0"?>
-<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="ping" version="1.1">
+<resource-agent name="ping" version="1.2">
 <version>1.1</version>
 
 <longdesc lang="en">

--- a/extra/resources/remote
+++ b/extra/resources/remote
@@ -24,8 +24,7 @@
 meta_data() {
     cat <<END
 <?xml version="1.0"?>
-<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="remote" version="1.0">
+<resource-agent name="remote" version="1.1">
   <version>1.1</version>
   <shortdesc lang="en">Pacemaker Remote connection</shortdesc>
   <parameters>

--- a/include/crm/cib/Makefile.am
+++ b/include/crm/cib/Makefile.am
@@ -11,4 +11,6 @@ MAINTAINERCLEANFILES	= Makefile.in
 headerdir=$(pkgincludedir)/crm/cib
 
 noinst_HEADERS		= internal.h
-header_HEADERS		= util.h cib_types.h
+header_HEADERS		= cib_types.h	\
+			  util.h	\
+			  util_compat.h

--- a/include/crm/cib/util.h
+++ b/include/crm/cib/util.h
@@ -19,7 +19,6 @@ extern "C" {
 #endif
 
 /* Utility functions */
-const char *get_object_path(const char *object_type);
 xmlNode *create_cib_fragment_adv(xmlNode * update, const char *section, const char *source);
 
 xmlNode *createEmptyCib(int cib_epoch);

--- a/include/crm/cib/util.h
+++ b/include/crm/cib/util.h
@@ -20,7 +20,6 @@ extern "C" {
 
 /* Utility functions */
 const char *get_object_path(const char *object_type);
-const char *get_object_parent(const char *object_type);
 xmlNode *create_cib_fragment_adv(xmlNode * update, const char *section, const char *source);
 
 xmlNode *createEmptyCib(int cib_epoch);

--- a/include/crm/cib/util.h
+++ b/include/crm/cib/util.h
@@ -21,7 +21,6 @@ extern "C" {
 /* Utility functions */
 const char *get_object_path(const char *object_type);
 const char *get_object_parent(const char *object_type);
-xmlNode *get_object_root(const char *object_type, xmlNode * the_root);
 xmlNode *create_cib_fragment_adv(xmlNode * update, const char *section, const char *source);
 
 xmlNode *createEmptyCib(int cib_epoch);
@@ -67,6 +66,10 @@ const char *cib_pref(GHashTable * options, const char *name);
 
 int cib_apply_patch_event(xmlNode *event, xmlNode *input, xmlNode **output,
                           int level);
+
+#if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+#include <crm/cib/util_compat.h>
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/crm/cib/util_compat.h
+++ b/include/crm/cib/util_compat.h
@@ -23,6 +23,9 @@ extern "C" {
  *             release.
  */
 
+//! \deprecated Use pcmk_cib_xpath_for() instead
+const char *get_object_path(const char *object_type);
+
 //! \deprecated Use pcmk_cib_parent_name_for() instead
 const char *get_object_parent(const char *object_type);
 

--- a/include/crm/cib/util_compat.h
+++ b/include/crm/cib/util_compat.h
@@ -23,6 +23,9 @@ extern "C" {
  *             release.
  */
 
+//! \deprecated Use pcmk_cib_parent_name_for() instead
+const char *get_object_parent(const char *object_type);
+
 //! \deprecated Use pcmk_cib_xpath_for() instead
 xmlNode *get_object_root(const char *object_type, xmlNode *the_root);
 

--- a/include/crm/cib/util_compat.h
+++ b/include/crm/cib/util_compat.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__CIB_UTIL_COMPAT__H
+#  define PCMK__CIB_UTIL_COMPAT__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \file
+ * \brief Deprecated Pacemaker configuration utilities
+ * \ingroup cib
+ * \deprecated Do not include this header directly. The utilities in this
+ *             header, and the header itself, will be removed in a future
+ *             release.
+ */
+
+//! \deprecated Use pcmk_cib_xpath_for() instead
+xmlNode *get_object_root(const char *object_type, xmlNode *the_root);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PCMK__CIB_UTIL_COMPAT__H

--- a/include/crm/common/Makefile.am
+++ b/include/crm/common/Makefile.am
@@ -15,6 +15,7 @@ header_HEADERS = xml.h ipc.h util.h iso8601.h mainloop.h logging.h results.h \
 		 nvpair.h acl.h agents.h ipc_controld.h ipc_pacemakerd.h ipc_schedulerd.h \
 		 output.h \
 		 agents_compat.h	\
+		 cib.h			\
 		 logging_compat.h	\
 		 mainloop_compat.h	\
 		 util_compat.h		\

--- a/include/crm/common/cib.h
+++ b/include/crm/common/cib.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__COMMON_CIB__H
+#  define PCMK__COMMON_CIB__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char *pcmk_cib_xpath_for(const char *element_name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PCMK__COMMON_CIB__H

--- a/include/crm/common/cib.h
+++ b/include/crm/common/cib.h
@@ -15,6 +15,7 @@ extern "C" {
 #endif
 
 const char *pcmk_cib_xpath_for(const char *element_name);
+const char *pcmk_cib_parent_name_for(const char *element_name);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/cib.h
+++ b/include/crm/common/cib.h
@@ -14,8 +14,11 @@
 extern "C" {
 #endif
 
+#include <libxml/tree.h>    // xmlNode
+
 const char *pcmk_cib_xpath_for(const char *element_name);
 const char *pcmk_cib_parent_name_for(const char *element_name);
+xmlNode *pcmk_find_cib_element(xmlNode *cib, const char *element_name);
 
 #ifdef __cplusplus
 }

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -216,6 +216,7 @@ extern char *crm_system_name;
 #  define RSC_METADATA	CRMD_ACTION_METADATA
 /* *INDENT-ON* */
 
+#  include <crm/common/cib.h>
 #  include <crm/common/logging.h>
 #  include <crm/common/util.h>
 

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -53,6 +53,7 @@ find_nvpair_attr_delegate(cib_t * the_cib, const char *attr, const char *section
     int offset = 0;
     int rc = pcmk_ok;
 
+    const char *xpath_base = NULL;
     char *xpath_string = NULL;
     xmlNode *xml_search = NULL;
     const char *set_type = NULL;
@@ -85,13 +86,18 @@ find_nvpair_attr_delegate(cib_t * the_cib, const char *attr, const char *section
         return -EINVAL;
     }
 
+    xpath_base = pcmk_cib_xpath_for(section);
+    if (xpath_base == NULL) {
+        crm_warn("%s CIB section not known", section);
+        return -ENOMSG;
+    }
+
     xpath_string = calloc(1, XPATH_MAX);
     if (xpath_string == NULL) {
         crm_perror(LOG_CRIT, "Could not create xpath");
         return -ENOMEM;
     }
-
-    attr_snprintf(xpath_string, offset, XPATH_MAX, "%.128s", get_object_path(section));
+    attr_snprintf(xpath_string, offset, XPATH_MAX, "%s", xpath_base);
 
     if (pcmk__str_eq(node_type, XML_CIB_TAG_TICKETS, pcmk__str_casei)) {
         attr_snprintf(xpath_string, offset, XPATH_MAX, "//%s", node_type);

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -852,7 +852,7 @@ cib_file_perform_op_delegate(cib_t * cib, const char *op, const char *host, cons
 
     /* Mirror the logic in cib_prepare_common() */
     if (section != NULL && data != NULL && pcmk__str_eq(crm_element_name(data), XML_TAG_CIB, pcmk__str_none)) {
-        data = get_object_root(section, data);
+        data = pcmk_find_cib_element(data, section);
     }
 
     rc = cib_perform_op(op, call_options, fn, query,

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -47,7 +47,7 @@ cib_process_query(const char *op, int options, const char *section, xmlNode * re
         section = NULL;
     }
 
-    obj_root = get_object_root(section, existing_cib);
+    obj_root = pcmk_find_cib_element(existing_cib, section);
 
     if (obj_root == NULL) {
         result = -ENXIO;
@@ -265,7 +265,7 @@ cib_process_replace(const char *op, int options, const char *section, xmlNode * 
         xmlNode *obj_root = NULL;
         gboolean ok = TRUE;
 
-        obj_root = get_object_root(section, *result_cib);
+        obj_root = pcmk_find_cib_element(*result_cib, section);
         ok = replace_xml_child(NULL, obj_root, input, FALSE);
         if (ok == FALSE) {
             crm_trace("No matching object to replace");
@@ -294,7 +294,7 @@ cib_process_delete(const char *op, int options, const char *section, xmlNode * r
         return -EINVAL;
     }
 
-    obj_root = get_object_root(section, *result_cib);
+    obj_root = pcmk_find_cib_element(*result_cib, section);
     if(pcmk__str_eq(crm_element_name(input), section, pcmk__str_casei)) {
         xmlNode *child = NULL;
         for (child = pcmk__xml_first_child(input); child;
@@ -329,7 +329,7 @@ cib_process_modify(const char *op, int options, const char *section, xmlNode * r
         return -EINVAL;
     }
 
-    obj_root = get_object_root(section, *result_cib);
+    obj_root = pcmk_find_cib_element(*result_cib, section);
     if (obj_root == NULL) {
         xmlNode *tmp_section = NULL;
         const char *path = pcmk_cib_parent_name_for(section);
@@ -342,7 +342,7 @@ cib_process_modify(const char *op, int options, const char *section, xmlNode * r
         cib_process_xpath(CIB_OP_CREATE, 0, path, NULL, tmp_section, NULL, result_cib, answer);
         free_xml(tmp_section);
 
-        obj_root = get_object_root(section, *result_cib);
+        obj_root = pcmk_find_cib_element(*result_cib, section);
     }
 
     CRM_CHECK(obj_root != NULL, return -EINVAL);
@@ -548,7 +548,7 @@ cib_process_create(const char *op, int options, const char *section, xmlNode * r
 
     failed = create_xml_node(NULL, XML_TAG_FAILED);
 
-    update_section = get_object_root(section, *result_cib);
+    update_section = pcmk_find_cib_element(*result_cib, section);
     if (pcmk__str_eq(crm_element_name(input), section, pcmk__str_casei)) {
         xmlNode *a_child = NULL;
 

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -332,7 +332,7 @@ cib_process_modify(const char *op, int options, const char *section, xmlNode * r
     obj_root = get_object_root(section, *result_cib);
     if (obj_root == NULL) {
         xmlNode *tmp_section = NULL;
-        const char *path = get_object_parent(section);
+        const char *path = pcmk_cib_parent_name_for(section);
 
         if (path == NULL) {
             return -EINVAL;

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -141,18 +141,6 @@ get_object_parent(const char *object_type)
     return NULL;
 }
 
-xmlNode *
-get_object_root(const char *object_type, xmlNode * the_root)
-{
-    const char *xpath = get_object_path(object_type);
-
-    if (xpath == NULL) {
-        return the_root;        /* or return NULL? */
-    }
-
-    return get_xpath_object(xpath, the_root, LOG_TRACE);
-}
-
 /*!
  * \brief Create XML for a new (empty) CIB
  *
@@ -823,3 +811,17 @@ cib__signon_query(cib_t **cib, xmlNode **cib_object)
         return rc;
     }
 }
+
+// Deprecated functions kept only for backward API compatibility
+// LCOV_EXCL_START
+
+#include <crm/cib/util_compat.h>
+
+xmlNode *
+get_object_root(const char *object_type, xmlNode *the_root)
+{
+    return pcmk_find_cib_element(the_root, object_type);
+}
+
+// LCOV_EXCL_END
+// End deprecated API

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -127,20 +127,6 @@ get_object_path(const char *object_type)
     return NULL;
 }
 
-const char *
-get_object_parent(const char *object_type)
-{
-    int lpc = 0;
-    int max = PCMK__NELEM(known_paths);
-
-    for (; lpc < max; lpc++) {
-        if (pcmk__str_eq(object_type, known_paths[lpc].name, pcmk__str_casei)) {
-            return known_paths[lpc].parent;
-        }
-    }
-    return NULL;
-}
-
 /*!
  * \brief Create XML for a new (empty) CIB
  *
@@ -816,6 +802,12 @@ cib__signon_query(cib_t **cib, xmlNode **cib_object)
 // LCOV_EXCL_START
 
 #include <crm/cib/util_compat.h>
+
+const char *
+get_object_parent(const char *object_type)
+{
+    return pcmk_cib_parent_name_for(object_type);
+}
 
 xmlNode *
 get_object_root(const char *object_type, xmlNode *the_root)

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -24,37 +24,6 @@
 #include <crm/common/xml_internal.h>
 #include <crm/pengine/rules.h>
 
-struct config_root_s {
-    const char *name;
-    const char *parent;
-    const char *path;
-};
-
- /*
-  * "//crm_config" will also work in place of "/cib/configuration/crm_config"
-  * The / prefix means find starting from the root, whereas the // prefix means
-  * find anywhere and risks multiple matches
-  */
-/* *INDENT-OFF* */
-static struct config_root_s known_paths[] = {
-    { NULL,                         NULL,                 "//cib" },
-    { XML_TAG_CIB,                  NULL,                 "//cib" },
-    { XML_CIB_TAG_STATUS,           "/cib",               "//cib/status" },
-    { XML_CIB_TAG_CONFIGURATION,    "/cib",               "//cib/configuration" },
-    { XML_CIB_TAG_CRMCONFIG,        "/cib/configuration", "//cib/configuration/crm_config" },
-    { XML_CIB_TAG_NODES,            "/cib/configuration", "//cib/configuration/nodes" },
-    { XML_CIB_TAG_RESOURCES,        "/cib/configuration", "//cib/configuration/resources" },
-    { XML_CIB_TAG_CONSTRAINTS,      "/cib/configuration", "//cib/configuration/constraints" },
-    { XML_CIB_TAG_OPCONFIG,         "/cib/configuration", "//cib/configuration/op_defaults" },
-    { XML_CIB_TAG_RSCCONFIG,        "/cib/configuration", "//cib/configuration/rsc_defaults" },
-    { XML_CIB_TAG_ACLS,             "/cib/configuration", "//cib/configuration/acls" },
-    { XML_TAG_FENCING_TOPOLOGY,     "/cib/configuration", "//cib/configuration/fencing-topology" },
-    { XML_CIB_TAG_TAGS,             "/cib/configuration", "//cib/configuration/tags" },
-    { XML_CIB_TAG_ALERTS,           "/cib/configuration", "//cib/configuration/alerts" },
-    { XML_CIB_TAG_SECTION_ALL,      NULL,                 "//cib" },
-};
-/* *INDENT-ON* */
-
 xmlNode *
 cib_get_generation(cib_t * cib)
 {
@@ -106,25 +75,6 @@ cib_diff_version_details(xmlNode * diff, int *admin_epoch, int *epoch, int *upda
     *_updates = del[2];
 
     return TRUE;
-}
-
-/*
- * The caller should never free the return value
- */
-
-const char *
-get_object_path(const char *object_type)
-{
-    int lpc = 0;
-    int max = PCMK__NELEM(known_paths);
-
-    for (; lpc < max; lpc++) {
-        if ((object_type == NULL && known_paths[lpc].name == NULL)
-            || pcmk__str_eq(object_type, known_paths[lpc].name, pcmk__str_casei)) {
-            return known_paths[lpc].path;
-        }
-    }
-    return NULL;
 }
 
 /*!
@@ -802,6 +752,12 @@ cib__signon_query(cib_t **cib, xmlNode **cib_object)
 // LCOV_EXCL_START
 
 #include <crm/cib/util_compat.h>
+
+const char *
+get_object_path(const char *object_type)
+{
+    return pcmk_cib_xpath_for(object_type);
+}
 
 const char *
 get_object_parent(const char *object_type)

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -681,7 +681,7 @@ cib_read_config(GHashTable * options, xmlNode * current_cib)
 
     g_hash_table_remove_all(options);
 
-    config = get_object_root(XML_CIB_TAG_CRMCONFIG, current_cib);
+    config = pcmk_find_cib_element(current_cib, XML_CIB_TAG_CRMCONFIG);
     if (config) {
         pe_unpack_nvpairs(current_cib, config, XML_CIB_TAG_PROPSET, NULL,
                           options, CIB_OPTIONS_FIRST, TRUE, now, NULL);

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -56,6 +56,7 @@ libcrmcommon_la_SOURCES	+= acl.c
 libcrmcommon_la_SOURCES	+= agents.c
 libcrmcommon_la_SOURCES	+= alerts.c
 libcrmcommon_la_SOURCES	+= attrd_client.c
+libcrmcommon_la_SOURCES	+= cib.c
 if BUILD_CIBSECRETS
 libcrmcommon_la_SOURCES	+= cib_secrets.c
 endif

--- a/lib/common/cib.c
+++ b/lib/common/cib.c
@@ -26,11 +26,7 @@ static struct {
     const char *path;   // XPath to find this CIB element
 } cib_sections[] = {
     {
-        NULL,
-        NULL,
-        "//" XML_TAG_CIB
-    },
-    {
+        // This first entry is also the default if a NULL is compared
         XML_TAG_CIB,
         NULL,
         "//" XML_TAG_CIB
@@ -114,9 +110,9 @@ const char *
 pcmk_cib_xpath_for(const char *element_name)
 {
     for (int lpc = 0; lpc < PCMK__NELEM(cib_sections); lpc++) {
-        if (((element_name == NULL) && (cib_sections[lpc].name == NULL))
-            || pcmk__str_eq(element_name, cib_sections[lpc].name,
-                            pcmk__str_none)) {
+        // A NULL element_name will match the first entry
+        if (pcmk__str_eq(element_name, cib_sections[lpc].name,
+                         pcmk__str_null_matches)) {
             return cib_sections[lpc].path;
         }
     }
@@ -128,15 +124,16 @@ pcmk_cib_xpath_for(const char *element_name)
  *
  * \param[in] element_name  Name of CIB element
  *
- * \return Parent element of \p element_name (or NULL if unknown)
+ * \return Parent element of \p element_name (or NULL if none or unknown)
  * \note The return value is constant and should not be freed.
  */
 const char *
 pcmk_cib_parent_name_for(const char *element_name)
 {
     for (int lpc = 0; lpc < PCMK__NELEM(cib_sections); lpc++) {
+        // A NULL element_name will match the first entry
         if (pcmk__str_eq(element_name, cib_sections[lpc].name,
-                         pcmk__str_none)) {
+                         pcmk__str_null_matches)) {
             return cib_sections[lpc].parent;
         }
     }

--- a/lib/common/cib.c
+++ b/lib/common/cib.c
@@ -11,6 +11,7 @@
 #include <crm_internal.h>
 
 #include <stdio.h>
+#include <libxml/tree.h>    // xmlNode
 
 #include <crm/msg_xml.h>
 
@@ -140,4 +141,19 @@ pcmk_cib_parent_name_for(const char *element_name)
         }
     }
     return NULL;
+}
+
+/*!
+ * \brief Find an element in the CIB
+ *
+ * \param[in] cib           Top-level CIB XML to search
+ * \param[in] element_name  Name of CIB element to search for
+ *
+ * \return XML element in \p cib corresponding to \p element_name
+ *         (or \p cib itself if element is unknown or not found)
+ */
+xmlNode *
+pcmk_find_cib_element(xmlNode *cib, const char *element_name)
+{
+    return get_xpath_object(pcmk_cib_xpath_for(element_name), cib, LOG_TRACE);
 }

--- a/lib/common/cib.c
+++ b/lib/common/cib.c
@@ -121,3 +121,23 @@ pcmk_cib_xpath_for(const char *element_name)
     }
     return NULL;
 }
+
+/*!
+ * \brief Get the parent element name of a given CIB element name
+ *
+ * \param[in] element_name  Name of CIB element
+ *
+ * \return Parent element of \p element_name (or NULL if unknown)
+ * \note The return value is constant and should not be freed.
+ */
+const char *
+pcmk_cib_parent_name_for(const char *element_name)
+{
+    for (int lpc = 0; lpc < PCMK__NELEM(cib_sections); lpc++) {
+        if (pcmk__str_eq(element_name, cib_sections[lpc].name,
+                         pcmk__str_none)) {
+            return cib_sections[lpc].parent;
+        }
+    }
+    return NULL;
+}

--- a/lib/common/cib.c
+++ b/lib/common/cib.c
@@ -1,0 +1,123 @@
+/*
+ * Original copyright 2004 International Business Machines
+ * Later changes copyright 2008-2021 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdio.h>
+
+#include <crm/msg_xml.h>
+
+/*
+ * Functions to help find particular sections of the CIB
+ */
+
+// Map CIB element names to their parent elements and XPath searches
+static struct {
+    const char *name;   // Name of this CIB element
+    const char *parent; // CIB element that this element is a child of
+    const char *path;   // XPath to find this CIB element
+} cib_sections[] = {
+    {
+        NULL,
+        NULL,
+        "//" XML_TAG_CIB
+    },
+    {
+        XML_TAG_CIB,
+        NULL,
+        "//" XML_TAG_CIB
+    },
+    {
+        XML_CIB_TAG_STATUS,
+        "/" XML_TAG_CIB,
+        "//" XML_TAG_CIB "/" XML_CIB_TAG_STATUS
+    },
+    {
+        XML_CIB_TAG_CONFIGURATION,
+        "/" XML_TAG_CIB,
+        "//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION
+    },
+    {
+        XML_CIB_TAG_CRMCONFIG,
+        "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION,
+        "//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_CRMCONFIG
+    },
+    {
+        XML_CIB_TAG_NODES,
+        "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION,
+        "//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_NODES
+    },
+    {
+        XML_CIB_TAG_RESOURCES,
+        "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION,
+        "//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_RESOURCES
+    },
+    {
+        XML_CIB_TAG_CONSTRAINTS,
+        "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION,
+        "//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_CONSTRAINTS
+    },
+    {
+        XML_CIB_TAG_OPCONFIG,
+        "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION,
+        "//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_OPCONFIG
+    },
+    {
+        XML_CIB_TAG_RSCCONFIG,
+        "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION,
+        "//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_RSCCONFIG
+    },
+    {
+        XML_CIB_TAG_ACLS,
+        "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION,
+        "//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_ACLS
+    },
+    {
+        XML_TAG_FENCING_TOPOLOGY,
+        "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION,
+        "//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_TAG_FENCING_TOPOLOGY
+    },
+    {
+        XML_CIB_TAG_TAGS,
+        "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION,
+        "//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_TAGS
+    },
+    {
+        XML_CIB_TAG_ALERTS,
+        "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION,
+        "//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_ALERTS
+    },
+    {
+        XML_CIB_TAG_SECTION_ALL,
+        NULL,
+        "//" XML_TAG_CIB
+    },
+};
+
+/*!
+ * \brief Get the XPath needed to find a specified CIB element name
+ *
+ * \param[in] element_name  Name of CIB element
+ *
+ * \return XPath for finding \p element_name in CIB XML (or NULL if unknown)
+ * \note The return value is constant and should not be freed.
+ */
+const char *
+pcmk_cib_xpath_for(const char *element_name)
+{
+    for (int lpc = 0; lpc < PCMK__NELEM(cib_sections); lpc++) {
+        if (((element_name == NULL) && (cib_sections[lpc].name == NULL))
+            || pcmk__str_eq(element_name, cib_sections[lpc].name,
+                            pcmk__str_none)) {
+            return cib_sections[lpc].path;
+        }
+    }
+    return NULL;
+}

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -243,6 +243,8 @@ stonith_action_create(const char *agent,
     stonith_action_t *action;
 
     action = calloc(1, sizeof(stonith_action_t));
+    CRM_ASSERT(action != NULL);
+
     action->args = make_args(agent, _action, victim, victim_nodeid,
                              device_args, port_map, host_arg);
     crm_debug("Preparing '%s' action for %s using agent %s",

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -2332,7 +2332,9 @@ lrmd_api_delete(lrmd_t * lrmd)
         return;
     }
     if (lrmd->cmds != NULL) { // Never NULL, but make static analysis happy
-        lrmd->cmds->disconnect(lrmd); // No-op if already disconnected
+        if (lrmd->cmds->disconnect != NULL) { // Also never really NULL
+            lrmd->cmds->disconnect(lrmd); // No-op if already disconnected
+        }
         free(lrmd->cmds);
     }
     if (lrmd->lrmd_private != NULL) {

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -506,8 +506,8 @@ check_actions(pe_working_set_t * data_set)
     const char *id = NULL;
     pe_node_t *node = NULL;
     xmlNode *lrm_rscs = NULL;
-    xmlNode *status = get_object_root(XML_CIB_TAG_STATUS, data_set->input);
-
+    xmlNode *status = pcmk_find_cib_element(data_set->input,
+                                            XML_CIB_TAG_STATUS);
     xmlNode *node_state = NULL;
 
     for (node_state = pcmk__xe_first_child(status); node_state != NULL;

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -55,8 +55,8 @@ evaluate_lifetime(xmlNode *lifetime, pe_working_set_t *data_set)
 void
 pcmk__unpack_constraints(pe_working_set_t *data_set)
 {
-    xmlNode *xml_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS,
-                                               data_set->input);
+    xmlNode *xml_constraints = pcmk_find_cib_element(data_set->input,
+                                                     XML_CIB_TAG_CONSTRAINTS);
 
     for (xmlNode *xml_obj = pcmk__xe_first_child(xml_constraints);
          xml_obj != NULL; xml_obj = pcmk__xe_next(xml_obj)) {

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -258,7 +258,7 @@ pcmk__profile_file(const char *xml_file, long long repeat, pe_working_set_t *dat
     cib_object = filename2xml(xml_file);
     start = clock();
 
-    if (get_object_root(XML_CIB_TAG_STATUS, cib_object) == NULL) {
+    if (pcmk_find_cib_element(cib_object, XML_CIB_TAG_STATUS) == NULL) {
         create_xml_node(cib_object, XML_CIB_TAG_STATUS);
     }
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -2202,7 +2202,8 @@ node_summary(pcmk__output_t *out, va_list args) {
     gboolean print_spacer = va_arg(args, gboolean);
 
     xmlNode *node_state = NULL;
-    xmlNode *cib_status = get_object_root(XML_CIB_TAG_STATUS, data_set->input);
+    xmlNode *cib_status = pcmk_find_cib_element(data_set->input,
+                                                XML_CIB_TAG_STATUS);
     int rc = pcmk_rc_no_output;
 
     if (xmlChildElementCount(cib_status) == 0) {

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1135,6 +1135,7 @@ failed_action_friendly(pcmk__output_t *out, xmlNodePtr xml_op,
         task = strdup("unknown action");
         interval_ms = 0;
     }
+    CRM_ASSERT((rsc_id != NULL) && (task != NULL));
 
     str = g_string_sized_new(strlen(rsc_id) + strlen(task) + strlen(node_name)
                              + 100); // reasonable starting size

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -23,7 +23,6 @@
 
 extern bool pcmk__is_daemon;
 
-extern xmlNode *get_object_root(const char *object_type, xmlNode * the_root);
 void print_str_str(gpointer key, gpointer value, gpointer user_data);
 gboolean ghash_free_str_str(gpointer key, gpointer value, gpointer user_data);
 static void unpack_operation(pe_action_t * action, xmlNode * xml_obj, pe_resource_t * container,

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2021 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -714,7 +714,7 @@ do_work(xmlNode * input, int call_options, xmlNode ** output)
     the_cib->call_timeout = message_timeout_ms;
     if (strcasecmp(CIB_OP_REPLACE, cib_action) == 0
         && pcmk__str_eq(crm_element_name(input), XML_TAG_CIB, pcmk__str_casei)) {
-        xmlNode *status = get_object_root(XML_CIB_TAG_STATUS, input);
+        xmlNode *status = pcmk_find_cib_element(input, XML_CIB_TAG_STATUS);
 
         if (status == NULL) {
             create_xml_node(input, XML_CIB_TAG_STATUS);

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -318,7 +318,7 @@ build_constraint_list(xmlNode *root)
     xmlXPathObjectPtr xpathObj = NULL;
     int ndx = 0;
 
-    cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS, root);
+    cib_constraints = pcmk_find_cib_element(root, XML_CIB_TAG_CONSTRAINTS);
     xpathObj = xpath_search(cib_constraints, "//" XML_CONS_TAG_RSC_LOCATION);
 
     for (ndx = 0; ndx < numXpathResults(xpathObj); ndx++) {

--- a/tools/crm_resource_ban.c
+++ b/tools/crm_resource_ban.c
@@ -424,7 +424,7 @@ cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, int cib_options,
     int i;
     int rc = pcmk_rc_ok;
 
-    cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS, root);
+    cib_constraints = pcmk_find_cib_element(root, XML_CIB_TAG_CONSTRAINTS);
     xpathObj = xpath_search(cib_constraints, "//" XML_CONS_TAG_RSC_LOCATION);
 
     for (i = 0; i < numXpathResults(xpathObj); i++) {

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -20,7 +20,8 @@ cli_resource_print_cts_constraints(pe_working_set_t * data_set)
     pcmk__output_t *out = data_set->priv;
     xmlNode *xml_obj = NULL;
     xmlNode *lifetime = NULL;
-    xmlNode *cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS, data_set->input);
+    xmlNode *cib_constraints = pcmk_find_cib_element(data_set->input,
+                                                     XML_CIB_TAG_CONSTRAINTS);
 
     for (xml_obj = pcmk__xe_first_child(cib_constraints); xml_obj != NULL;
          xml_obj = pcmk__xe_next(xml_obj)) {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -110,6 +110,7 @@ find_resource_attr(pcmk__output_t *out, cib_t * the_cib, const char *attr,
     int rc = pcmk_rc_ok;
     xmlNode *xml_search = NULL;
     char *xpath_string = NULL;
+    const char *xpath_base = NULL;
 
     if(value) {
         *value = NULL;
@@ -119,9 +120,15 @@ find_resource_attr(pcmk__output_t *out, cib_t * the_cib, const char *attr,
         return ENOTCONN;
     }
 
+    xpath_base = pcmk_cib_xpath_for(XML_CIB_TAG_RESOURCES);
+    if (xpath_base == NULL) {
+        crm_err(XML_CIB_TAG_RESOURCES " CIB element not known (bug?)");
+        return ENOMSG;
+    }
+
     xpath_string = calloc(1, XPATH_MAX);
-    offset +=
-        snprintf(xpath_string + offset, XPATH_MAX - offset, "%s", get_object_path("resources"));
+    offset += snprintf(xpath_string + offset, XPATH_MAX - offset, "%s",
+                       xpath_base);
 
     offset += snprintf(xpath_string + offset, XPATH_MAX - offset, "//*[@id=\"%s\"]", rsc);
 

--- a/tools/crm_rule.c
+++ b/tools/crm_rule.c
@@ -113,7 +113,8 @@ crm_rule_check(pe_working_set_t *data_set, const char *rule_id, crm_time_t *effe
     int max = 0;
 
     /* Rules are under the constraints node in the XML, so first find that. */
-    cib_constraints = get_object_root(XML_CIB_TAG_CONSTRAINTS, data_set->input);
+    cib_constraints = pcmk_find_cib_element(data_set->input,
+                                            XML_CIB_TAG_CONSTRAINTS);
 
     /* Get all rules matching the given ID which are also simple enough for us to check.
      * For the moment, these rules must only have a single date_expression child and:

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -388,7 +388,7 @@ setup_input(const char *input, const char *output, GError **error)
         cib_object = filename2xml(input);
     }
 
-    if (get_object_root(XML_CIB_TAG_STATUS, cib_object) == NULL) {
+    if (pcmk_find_cib_element(cib_object, XML_CIB_TAG_STATUS) == NULL) {
         create_xml_node(cib_object, XML_CIB_TAG_STATUS);
     }
 

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -188,14 +188,20 @@ find_ticket_constraints(cib_t * the_cib, const char *ticket_id, xmlNode ** ticke
     xmlNode *xml_search = NULL;
 
     char *xpath_string = NULL;
+    const char *xpath_base = NULL;
 
     CRM_ASSERT(ticket_cons_xml != NULL);
     *ticket_cons_xml = NULL;
 
+    xpath_base = pcmk_cib_xpath_for(XML_CIB_TAG_CONSTRAINTS);
+    if (xpath_base == NULL) {
+        crm_err(XML_CIB_TAG_CONSTRAINTS " CIB element not known (bug?)");
+        return -ENOMSG;
+    }
+
     xpath_string = calloc(1, XPATH_MAX);
-    offset +=
-        snprintf(xpath_string + offset, XPATH_MAX - offset, "%s/%s",
-                 get_object_path(XML_CIB_TAG_CONSTRAINTS), XML_CONS_TAG_RSC_TICKET);
+    offset += snprintf(xpath_string + offset, XPATH_MAX - offset, "%s/%s",
+                       xpath_base, XML_CONS_TAG_RSC_TICKET);
 
     if (ticket_id) {
         offset += snprintf(xpath_string + offset, XPATH_MAX - offset, "[@ticket=\"%s\"]",

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -198,7 +198,7 @@ main(int argc, char **argv)
         write_xml_file(cib_object, options.cib_save, FALSE);
     }
 
-    status = get_object_root(XML_CIB_TAG_STATUS, cib_object);
+    status = pcmk_find_cib_element(cib_object, XML_CIB_TAG_STATUS);
     if (status == NULL) {
         create_xml_node(cib_object, XML_CIB_TAG_STATUS);
     }


### PR DESCRIPTION
This is a collection of 3 unrelated fixes, including 2 regressions introduced in the 2.1.0 release.

Most of the commits fix CLBZ#5488 (a circular library dependency introduced by cd617199a3 in the 2.1.0 release).

A couple more fix RHBZ#2027370 (incorrect ocf:pacemaker:Stateful meta-data syntax introduced by 7024398 in the 2.1.0 release).

The last few try to make static analysis complain less.