### PR TITLE
Fix: fencer: get current time correctly

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2746,19 +2746,14 @@ bool fencing_peer_active(crm_node_t *peer)
     return FALSE;
 }
 
-void set_fencing_completed(remote_fencing_op_t * op)
+void
+set_fencing_completed(remote_fencing_op_t *op)
 {
-#ifdef CLOCK_MONOTONIC
     struct timespec tv;
 
-    clock_gettime(CLOCK_MONOTONIC, &tv);
-
+    qb_util_timespec_from_epoch_get(&tv);
     op->completed = tv.tv_sec;
     op->completed_nsec = tv.tv_nsec;
-#else
-    op->completed = time(NULL);
-    op->completed_nsec = 0L;
-#endif
 }
 
 /*!


### PR DESCRIPTION
f52bc8e1ce (2.1.2) introduced a regression by using CLOCK_MONOTONIC to get the
current time. Use CLOCK_REALTIME instead.