### PR TITLE
Display exit reasons for fence device start/stop/monitor failures

### DIFF
--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -993,7 +993,6 @@ stonith_action_complete(lrmd_cmd_t *cmd, int exit_status,
         switch (execution_status) {
             case PCMK_EXEC_NOT_CONNECTED:
             case PCMK_EXEC_INVALID:
-            case PCMK_EXEC_NO_SECRETS:
                 execution_status = PCMK_EXEC_ERROR;
                 break;
 

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1262,7 +1262,10 @@ lrmd_rsc_execute_stonith(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
         return;
 
     } else if (stonith_api == NULL) {
-        rc = -ENOTCONN;
+        stonith_action_complete(cmd, PCMK_OCF_UNKNOWN_ERROR,
+                                PCMK_EXEC_NOT_CONNECTED,
+                                "No connection to fencer");
+        return;
 
     } else if (pcmk__str_eq(cmd->action, "start", pcmk__str_casei)) {
         rc = execd_stonith_start(stonith_api, rsc, cmd);

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the Pacemaker project contributors
+ * Copyright 2012-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1297,7 +1297,7 @@ lrmd_rsc_execute_stonith(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
     stonith_action_complete(cmd,
                             ((rc == pcmk_ok)? CRM_EX_OK : CRM_EX_ERROR),
                             stonith__legacy2status(rc),
-                            rc == -pcmk_err_generic? NULL : pcmk_strerror(rc));
+                            ((rc == -pcmk_err_generic)? NULL : pcmk_strerror(rc)));
 }
 
 static int

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1275,6 +1275,12 @@ lrmd_rsc_execute_stonith(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
 
     } else if (pcmk__str_eq(cmd->action, "monitor", pcmk__str_casei)) {
         do_monitor = TRUE;
+
+    } else {
+        stonith_action_complete(cmd, PCMK_OCF_UNIMPLEMENT_FEATURE,
+                                PCMK_EXEC_ERROR,
+                                "Invalid fence device action (bug?)");
+        return;
     }
 
     if (do_monitor) {

--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -41,7 +41,14 @@ typedef struct lrmd_rsc_s {
      * that have been handed off from the pending ops list. */
     GList *recurring_ops;
 
-    int st_probe_rc; // What value should be returned for a probe if stonith
+    /* If this resource is a fence device, probes are handled internally by the
+     * executor, and this value indicates the result that should currently be
+     * returned for probes. It should be one of:
+     * PCMK_EXEC_DONE (to indicate "running"),
+     * PCMK_EXEC_NO_FENCE_DEVICE ("not running"), or
+     * PCMK_EXEC_NOT_CONNECTED ("unknown because fencer connection was lost").
+     */
+    enum pcmk_exec_status fence_probe_result;
 
     crm_trigger_t *work;
 } lrmd_rsc_t;

--- a/daemons/fenced/cts-fence-helper.c
+++ b/daemons/fenced/cts-fence-helper.c
@@ -34,22 +34,11 @@
 static GMainLoop *mainloop = NULL;
 static crm_trigger_t *trig = NULL;
 static int mainloop_iter = 0;
-static int callback_rc = 0;
+static pcmk__action_result_t result = PCMK__UNKNOWN_RESULT;
+
 typedef void (*mainloop_test_iteration_cb) (int check_event);
 
 #define MAINLOOP_DEFAULT_TIMEOUT 2
-
-#define mainloop_test_done(pass) \
-    if (pass) { \
-        crm_info("SUCCESS - %s", __func__); \
-        mainloop_iter++;   \
-        mainloop_set_trigger(trig);  \
-    } else { \
-        crm_err("FAILURE = %s async_callback %d", __func__, callback_rc); \
-        crm_exit(CRM_EX_ERROR); \
-    } \
-    callback_rc = 0; \
-
 
 enum test_modes {
     test_standard = 0,  // test using a specific developer environment
@@ -92,6 +81,23 @@ static struct pollfd pollfd;
 static const int st_opts = st_opt_sync_call;
 static int expected_notifications = 0;
 static int verbose = 0;
+
+static void
+mainloop_test_done(const char *origin, bool pass)
+{
+    if (pass) {
+        crm_info("SUCCESS - %s", origin);
+        mainloop_iter++;
+        mainloop_set_trigger(trig);
+        result.execution_status = PCMK_EXEC_UNKNOWN;
+        result.exit_status = CRM_EX_OK;
+    } else {
+        crm_err("FAILURE - %s (%d: %s)", origin, result.exit_status,
+                pcmk_exec_status_str(result.execution_status));
+        crm_exit(CRM_EX_ERROR);
+    }
+}
+
 
 static void
 dispatch_helper(int timeout)
@@ -385,7 +391,9 @@ static void
 static void
 mainloop_callback(stonith_t * stonith, stonith_callback_data_t * data)
 {
-    callback_rc = data->rc;
+    pcmk__set_result(&result, stonith__exit_status(data),
+                     stonith__execution_status(data),
+                     stonith__exit_reason(data));
     iterate_mainloop_tests(TRUE);
 }
 
@@ -404,18 +412,14 @@ test_async_fence_pass(int check_event)
     int rc = 0;
 
     if (check_event) {
-        if (callback_rc != 0) {
-            mainloop_test_done(FALSE);
-        } else {
-            mainloop_test_done(TRUE);
-        }
+        mainloop_test_done(__func__, (result.exit_status == CRM_EX_OK));
         return;
     }
 
     rc = st->cmds->fence(st, 0, "true_1_node1", "off", MAINLOOP_DEFAULT_TIMEOUT, 0);
     if (rc < 0) {
         crm_err("fence failed with rc %d", rc);
-        mainloop_test_done(FALSE);
+        mainloop_test_done(__func__, false);
     }
     register_callback_helper(rc);
     /* wait for event */
@@ -431,15 +435,15 @@ test_async_fence_custom_timeout(int check_event)
     if (check_event) {
         uint32_t diff = (time(NULL) - begin);
 
-        if (callback_rc != -ETIME) {
-            mainloop_test_done(FALSE);
+        if (result.execution_status != PCMK_EXEC_TIMEOUT) {
+            mainloop_test_done(__func__, false);
         } else if (diff < CUSTOM_TIMEOUT_ADDITION + MAINLOOP_DEFAULT_TIMEOUT) {
             crm_err
                 ("Custom timeout test failed, callback expiration should be updated to %d, actual timeout was %d",
                  CUSTOM_TIMEOUT_ADDITION + MAINLOOP_DEFAULT_TIMEOUT, diff);
-            mainloop_test_done(FALSE);
+            mainloop_test_done(__func__, false);
         } else {
-            mainloop_test_done(TRUE);
+            mainloop_test_done(__func__, true);
         }
         return;
     }
@@ -448,7 +452,7 @@ test_async_fence_custom_timeout(int check_event)
     rc = st->cmds->fence(st, 0, "custom_timeout_node1", "off", MAINLOOP_DEFAULT_TIMEOUT, 0);
     if (rc < 0) {
         crm_err("fence failed with rc %d", rc);
-        mainloop_test_done(FALSE);
+        mainloop_test_done(__func__, false);
     }
     register_callback_helper(rc);
     /* wait for event */
@@ -460,18 +464,15 @@ test_async_fence_timeout(int check_event)
     int rc = 0;
 
     if (check_event) {
-        if (callback_rc != -ENODEV) {
-            mainloop_test_done(FALSE);
-        } else {
-            mainloop_test_done(TRUE);
-        }
+        mainloop_test_done(__func__,
+                           (result.execution_status == PCMK_EXEC_NO_FENCE_DEVICE));
         return;
     }
 
     rc = st->cmds->fence(st, 0, "false_1_node2", "off", MAINLOOP_DEFAULT_TIMEOUT, 0);
     if (rc < 0) {
         crm_err("fence failed with rc %d", rc);
-        mainloop_test_done(FALSE);
+        mainloop_test_done(__func__, false);
     }
     register_callback_helper(rc);
     /* wait for event */
@@ -483,18 +484,14 @@ test_async_monitor(int check_event)
     int rc = 0;
 
     if (check_event) {
-        if (callback_rc) {
-            mainloop_test_done(FALSE);
-        } else {
-            mainloop_test_done(TRUE);
-        }
+        mainloop_test_done(__func__, (result.exit_status == CRM_EX_OK));
         return;
     }
 
     rc = st->cmds->monitor(st, 0, "false_1", MAINLOOP_DEFAULT_TIMEOUT);
     if (rc < 0) {
         crm_err("monitor failed with rc %d", rc);
-        mainloop_test_done(FALSE);
+        mainloop_test_done(__func__, false);
     }
 
     register_callback_helper(rc);
@@ -531,7 +528,7 @@ test_register_async_devices(int check_event)
                               params);
     stonith_key_value_freeall(params, 1, 1);
 
-    mainloop_test_done(TRUE);
+    mainloop_test_done(__func__, true);
 }
 
 static void
@@ -540,11 +537,11 @@ try_mainloop_connect(int check_event)
     int rc = stonith_api_connect_retry(st, crm_system_name, 10);
 
     if (rc == pcmk_ok) {
-        mainloop_test_done(TRUE);
+        mainloop_test_done(__func__, true);
         return;
     }
     crm_err("API CONNECTION FAILURE");
-    mainloop_test_done(FALSE);
+    mainloop_test_done(__func__, false);
 }
 
 static void

--- a/daemons/fenced/cts-fence-helper.c
+++ b/daemons/fenced/cts-fence-helper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2021 the Pacemaker project contributors
+ * Copyright 2009-2022 the Pacemaker project contributors
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -89,7 +89,7 @@ mainloop_test_done(const char *origin, bool pass)
         crm_info("SUCCESS - %s", origin);
         mainloop_iter++;
         mainloop_set_trigger(trig);
-        result.execution_status = PCMK_EXEC_UNKNOWN;
+        result.execution_status = PCMK_EXEC_DONE;
         result.exit_status = CRM_EX_OK;
     } else {
         crm_err("FAILURE - %s (%d: %s)", origin, result.exit_status,

--- a/daemons/fenced/cts-fence-helper.c
+++ b/daemons/fenced/cts-fence-helper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2020 the Pacemaker project contributors
+ * Copyright 2009-2021 the Pacemaker project contributors
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -132,7 +132,10 @@ st_callback(stonith_t * st, stonith_event_t * e)
 static void
 st_global_callback(stonith_t * stonith, stonith_callback_data_t * data)
 {
-    crm_notice("Call id %d completed with rc %d", data->call_id, data->rc);
+    crm_notice("Call %d exited %d: %s (%s)",
+               data->call_id, stonith__exit_status(data),
+               stonith__execution_status(data),
+               crm_str(stonith__exit_reason(data)));
 }
 
 static void

--- a/doc/sphinx/Pacemaker_Development/components.rst
+++ b/doc/sphinx/Pacemaker_Development/components.rst
@@ -106,7 +106,7 @@ or messaging layer callback, which calls:
       the number of active peers), and if this is the last expected reply,
       calls
 
-      * ``call_remote_stonith()``, which calculates the timeout and sends
+      * ``request_peer_fencing()``, which calculates the timeout and sends
         ``STONITH_OP_FENCE`` request(s) to carry out the fencing. If the target
 	node has a fencing "topology" (which allows specifications such as
 	"this node can be fenced either with device A, or devices B and C in
@@ -156,7 +156,7 @@ returns, and calls
   * done callback (``st_child_done()``), which calls ``schedule_stonith_command()``
     for a new device if there are further required actions to execute or if the
     original action failed, then builds and sends an XML reply to the original
-    fencer (via ``stonith_send_async_reply()``), then checks whether any
+    fencer (via ``send_async_reply()``), then checks whether any
     pending actions are the same as the one just executed and merges them if so.
 
 Fencing replies
@@ -169,18 +169,18 @@ messaging layer callback, which calls:
 
   * ``handle_reply()``, which calls
 
-    * ``process_remote_stonith_exec()``, which calls either
-      ``call_remote_stonith()`` (to retry a failed operation, or try the next
-       device in a topology is appropriate, which issues a new
+    * ``fenced_process_fencing_reply()``, which calls either
+      ``request_peer_fencing()`` (to retry a failed operation, or try the next
+      device in a topology is appropriate, which issues a new
       ``STONITH_OP_FENCE`` request, proceeding as before) or
-      ``remote_op_done()`` (if the operation is definitively failed or
+      ``finalize_op()`` (if the operation is definitively failed or
       successful).
 
-      * remote_op_done() broadcasts the result to all peers.
+      * ``finalize_op()`` broadcasts the result to all peers.
 
 Finally, all peers receive the broadcast result and call
 
-* ``remote_op_done()``, which sends the result to all local clients.
+* ``finalize_op()``, which sends the result to all local clients.
 
 
 .. index::

--- a/doc/sphinx/Pacemaker_Development/components.rst
+++ b/doc/sphinx/Pacemaker_Development/components.rst
@@ -184,6 +184,21 @@ Finally, all peers receive the broadcast result and call
 
 
 .. index::
+   single: fence history
+
+Fencing History
+_______________
+
+The fencer keeps a running history of all fencing operations. The bulk of the
+relevant code is in `fenced_history.c` and ensures the history is synchronized
+across all nodes even if a node leaves and rejoins the cluster.
+
+In libstonithd, this information is represented by `stonith_history_t` and is
+queryable by the `stonith_api_operations_t:history()` method. `crm_mon` and
+`stonith_admin` use this API to display the history.
+
+
+.. index::
    single: scheduler
    single: pacemaker-schedulerd
    single: libpe_status

--- a/doc/sphinx/Pacemaker_Development/components.rst
+++ b/doc/sphinx/Pacemaker_Development/components.rst
@@ -171,7 +171,7 @@ messaging layer callback, which calls:
 
     * ``fenced_process_fencing_reply()``, which calls either
       ``request_peer_fencing()`` (to retry a failed operation, or try the next
-      device in a topology is appropriate, which issues a new
+      device in a topology if appropriate, which issues a new
       ``STONITH_OP_FENCE`` request, proceeding as before) or
       ``finalize_op()`` (if the operation is definitively failed or
       successful).

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -66,7 +66,7 @@ extern "C" {
  * >=3.0.13: Fail counts include operation name and interval
  * >=3.2.0:  DC supports PCMK_EXEC_INVALID and PCMK_EXEC_NOT_CONNECTED
  */
-#  define CRM_FEATURE_SET		"3.12.0"
+#  define CRM_FEATURE_SET		"3.13.0"
 
 /* Pacemaker's CPG protocols use fixed-width binary fields for the sender and
  * recipient of a CPG message. This imposes an arbitrary limit on cluster node

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -187,6 +187,9 @@ bool stonith__event_state_eq(stonith_history_t *history, void *user_data);
 bool stonith__event_state_neq(stonith_history_t *history, void *user_data);
 
 int stonith__legacy2status(int rc);
+int stonith__exit_status(stonith_callback_data_t *data);
+int stonith__execution_status(stonith_callback_data_t *data);
+const char *stonith__exit_reason(stonith_callback_data_t *data);
 
 /*!
  * \internal

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -926,9 +926,11 @@ invoke_registered_callbacks(stonith_t *stonith, xmlNode *msg, int call_id)
                                      cb_info->user_data, cb_info->callback);
 
     } else if ((private->op_callback == NULL) && !pcmk__result_ok(&result)) {
-        crm_warn("Fencing action without registered callback failed: %d (%s)",
+        crm_warn("Fencing action without registered callback failed: %d (%s%s%s)",
                  result.exit_status,
-                 pcmk_exec_status_str(result.execution_status));
+                 pcmk_exec_status_str(result.execution_status),
+                 ((result.exit_reason == NULL)? "" : ": "),
+                 ((result.exit_reason == NULL)? "" : result.exit_reason));
         crm_log_xml_debug(msg, "Failed fence update");
     }
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -3879,9 +3879,6 @@ unpack_rsc_op(pe_resource_t *rsc, pe_node_t *node, xmlNode *xml_op,
         case PCMK_EXEC_INVALID:
             break; // Not done, do error handling
 
-        /* These should only be possible in fence action results, not operation
-         * history, but have some handling in place as a fail-safe.
-         */
         case PCMK_EXEC_NO_FENCE_DEVICE:
         case PCMK_EXEC_NO_SECRETS:
             status = PCMK_EXEC_ERROR_HARD;


### PR DESCRIPTION
This continues the long project to track exit reasons throughout the fencing code. Previous PRs handled the server side; the client side has three relevant pieces:

* Fencing action callbacks (stonith_callback_data_t)
* Fencing event notifications (stonith_event_t)
* Fencing history (stonith_history_t)

This PR addresses the first of those, which is the result data passed to the client that requested a fencing action. The most visible effect is that the executor can now get the exit reason from the fencing library and pass it to executor clients, which means that exit reasons can now be displayed for internal failures of fence device start, stop, and monitor actions.