### PR TITLE
Refactor: libs, tools: Add a cib__clean_up_connection function.

### DIFF
--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -215,10 +215,8 @@ attrd_cib_disconnect()
 {
     CRM_CHECK(the_cib != NULL, return);
     the_cib->cmds->del_notify_callback(the_cib, T_CIB_REPLACE_NOTIFY, attrd_cib_replaced_cb);
-    the_cib->cmds->del_notify_callback(the_cib, T_CIB_DIFF_NOTIFY, attrd_cib_updated_cb); 
-    the_cib->cmds->signoff(the_cib);
-    cib_delete(the_cib);
-    the_cib = NULL;
+    the_cib->cmds->del_notify_callback(the_cib, T_CIB_DIFF_NOTIFY, attrd_cib_updated_cb);
+    cib__clean_up_connection(&the_cib);
 }
 
 void

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the Pacemaker project contributors
+ * Copyright 2013-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -194,9 +194,7 @@ attrd_cib_connect(int max_retry)
     return pcmk_ok;
 
   cleanup:
-    the_cib->cmds->signoff(the_cib);
-    cib_delete(the_cib);
-    the_cib = NULL;
+    cib__clean_up_connection(&the_cib);
     return -ENOTCONN;
 }
 

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -238,5 +238,7 @@ cib_callback_client_t* cib__lookup_id (int call_id);
  * \return A standard Pacemaker return code
  */
 int cib__signon_query(cib_t **cib, xmlNode **cib_object);
+
+int cib__clean_up_connection(cib_t **cib);
 
 #endif

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -1,6 +1,6 @@
 /*
  * Original copyright 2004 International Business Machines
- * Later changes copyright 2008-2021 the Pacemaker project contributors
+ * Later changes copyright 2008-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -736,9 +736,7 @@ cib__signon_query(cib_t **cib, xmlNode **cib_object)
     }
 
     if (cib == NULL) {
-        cib_conn->cmds->signoff(cib_conn);
-        cib_delete(cib_conn);
-        cib_conn = NULL;
+        cib__clean_up_connection(&cib_conn);
     }
 
     if (cib_object == NULL) {
@@ -746,6 +744,21 @@ cib__signon_query(cib_t **cib, xmlNode **cib_object)
     } else {
         return rc;
     }
+}
+
+int
+cib__clean_up_connection(cib_t **cib)
+{
+    int rc;
+
+    if (*cib == NULL) {
+        return pcmk_rc_ok;
+    }
+
+    rc = (*cib)->cmds->signoff(*cib);
+    cib_delete(*cib);
+    *cib = NULL;
+    return pcmk_legacy2rc(rc);
 }
 
 // Deprecated functions kept only for backward API compatibility

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -938,10 +938,7 @@ pcmk__simulate(pe_working_set_t *data_set, pcmk__output_t *out,
                          true);
 
 simulate_done:
-    if (cib) {
-        cib->cmds->signoff(cib);
-        cib_delete(cib);
-    }
+    cib__clean_up_connection(&cib);
     return rc;
 }
 

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -698,11 +698,10 @@ main(int argc, char **argv)
     crm_trace("%s exiting normally", crm_system_name);
 
     free_xml(input);
-    rc = the_cib->cmds->signoff(the_cib);
+    rc = cib__clean_up_connection(&the_cib);
     if (exit_code == CRM_EX_OK) {
-        exit_code = crm_errno2exit(rc);
+        exit_code = pcmk_rc2exitc(rc);
     }
-    cib_delete(the_cib);
 
     crm_exit(exit_code);
 }

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -515,10 +515,7 @@ done:
     free(options.set_type);
     g_free(options.type);
 
-    if (the_cib) {
-        the_cib->cmds->signoff(the_cib);
-        cib_delete(the_cib);
-    }
+    cib__clean_up_connection(&the_cib);
 
     pcmk__output_and_clear_error(error, NULL);
     return crm_exit(exit_code);

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -20,6 +20,7 @@
 #include <crm/common/mainloop.h>
 #include <crm/msg_xml.h>
 #include <crm/cib.h>
+#include <crm/cib/internal.h>
 #include <crm/common/ipc_controld.h>
 #include <crm/common/attrd_internal.h>
 
@@ -363,8 +364,7 @@ cib_remove_node(long id, const char *name)
                 name, id, pcmk_strerror(rc));
     }
 
-    cib->cmds->signoff(cib);
-    cib_delete(cib);
+    cib__clean_up_connection(&cib);
     return rc;
 }
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -206,8 +206,7 @@ bye(crm_exit_t ec)
         cib_t *save_cib_conn = cib_conn;
 
         cib_conn = NULL; // Ensure we can't free this twice
-        save_cib_conn->cmds->signoff(save_cib_conn);
-        cib_delete(save_cib_conn);
+        cib__clean_up_connection(&save_cib_conn);
     }
     if (controld_api != NULL) {
         pcmk_ipc_api_t *save_controld_api = controld_api;

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the Pacemaker project contributors
+ * Copyright 2012-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -27,6 +27,7 @@
 #include <crm/common/ipc.h>
 
 #include <crm/cib.h>
+#include <crm/cib/internal.h>
 #include <crm/pengine/rules.h>
 #include <crm/pengine/status.h>
 
@@ -1066,10 +1067,7 @@ main(int argc, char **argv)
     pe_free_working_set(data_set);
     data_set = NULL;
 
-    if (cib_conn != NULL) {
-        cib_conn->cmds->signoff(cib_conn);
-        cib_delete(cib_conn);
-    }
+    cib__clean_up_connection(&cib_conn);
 
     if (rc == -pcmk_err_no_quorum) {
         CMD_ERR("Use --force to ignore quorum");


### PR DESCRIPTION
We have this same pattern all over the place, so reduce it to a single
common function.  This is kept distinct from cib_delete in case you want
to keep the signoff cib_free_callbacks actions separate.