### PR TITLE
Fix: fencing: Don't set stonith action to pending if fork fails

### DIFF
--- a/include/crm/services.h
+++ b/include/crm/services.h
@@ -292,8 +292,10 @@ gboolean services_action_kick(const char *name, const char *action,
  * \param[in] action_callback       Function to call when the action completes
  * \param[in] action_fork_callback  Function to call after action process forks
  *
- * \return TRUE if execution was successfully initiated, FALSE otherwise (in
- *              which case the callback will not be called)
+ * \return TRUE if the action should not be freed by the caller (e.g., if
+ *         execution was initiated successfully, if execution failed to initiate
+ *         and the action has already been freed, or if the action is blocked);
+ *         FALSE otherwise
  */
     gboolean services_action_async_fork_notify(svc_action_t * op,
         void (*action_callback) (svc_action_t *),

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -550,6 +550,9 @@ stonith_action_async_forked(svc_action_t *svc_action)
         (action->fork_cb) (svc_action->pid, action->userdata);
     }
 
+    pcmk__set_result(&(action->result), PCMK_OCF_UNKNOWN, PCMK_EXEC_PENDING,
+                     NULL);
+
     crm_trace("Child process %d performing action '%s' successfully forked",
               action->pid, action->action);
 }
@@ -619,8 +622,6 @@ internal_stonith_action_execute(stonith_action_t * action)
         if (services_action_async_fork_notify(svc_action,
                                               &stonith_action_async_done,
                                               &stonith_action_async_forked)) {
-            pcmk__set_result(&(action->result), PCMK_OCF_UNKNOWN,
-                             PCMK_EXEC_PENDING, NULL);
             return pcmk_ok;
         }
 

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -800,8 +800,8 @@ handle_duplicate_recurring(svc_action_t * op)
  * \retval EBUSY          Recurring operation could not be initiated
  * \retval pcmk_rc_error  Synchronous action failed
  * \retval pcmk_rc_ok     Synchronous action succeeded, or asynchronous action
- *                        should not be freed (because it already was or is
- *                        pending)
+ *                        should not be freed (because it's pending or because
+ *                        it failed to execute and was already freed)
  *
  * \note If the return value for an asynchronous action is not pcmk_rc_ok, the
  *       caller is responsible for freeing the action.

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -1140,8 +1140,8 @@ wait_for_sync_result(svc_action_t *op, struct sigchld_data_s *data)
  * \retval EBUSY          Recurring operation could not be initiated
  * \retval pcmk_rc_error  Synchronous action failed
  * \retval pcmk_rc_ok     Synchronous action succeeded, or asynchronous action
- *                        should not be freed (because it already was or is
- *                        pending)
+ *                        should not be freed (because it's pending or because
+ *                        it failed to execute and was already freed)
  *
  * \note If the return value for an asynchronous action is not pcmk_rc_ok, the
  *       caller is responsible for freeing the action.


### PR DESCRIPTION
Currently, we set a stonith action to pending if
`services_action_async_fork_notify()` returns true. However, "true" means
that the `svc_action` should not be freed. This might be because the
`svc_action` forked successfully and is pending, or it might be because
the `svc_action` has already been freed.

In the case of stonith actions, if we fail to fork, the `stonith_action_t`
object stored in `svc_action->cb_data` gets freed by the done callback,
and `services_action_async_fork_notify()` returns true. If we try to set
the action to pending, it causes a segfault.

This commit moves the "set to pending" step to the
`stonith_action_async_forked()` callback. We avoid the segfault and only
set it to pending if it's actually pending.

A slight difference in ordering was required to achieve this. Now, the
action gets set to pending immediately before being added to the
mainloop, instead of immediately after.