### PR TITLE
Show exit reasons for stonith_admin fencing failures

### DIFF
--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -177,27 +177,27 @@ int pcmk_list_nodes(xmlNodePtr *xml, char *node_types);
 #ifdef BUILD_PUBLIC_LIBPACEMAKER
 
 /*!
- * \brief Perform a STONITH action.
+ * \brief Ask the cluster to perform fencing
  *
- * \param[in] st        A connection to the STONITH API.
- * \param[in] target    The node receiving the action.
- * \param[in] action    The action to perform.
+ * \param[in] st        A connection to the fencer API
+ * \param[in] target    The node that should be fenced
+ * \param[in] action    The fencing action (on, off, reboot) to perform
  * \param[in] name      Who requested the fence action?
- * \param[in] timeout   How long to wait for the operation to complete (in ms).
+ * \param[in] timeout   How long to wait for the operation to complete (in ms)
  * \param[in] tolerance If a successful action for \p target happened within
  *                      this many ms, return 0 without performing the action
- *                      again.
+ *                      again
  * \param[in] delay     Apply a fencing delay. Value -1 means disable also any
- *                      static/random fencing delays from pcmk_delay_base/max.
+ *                      static/random fencing delays from pcmk_delay_base/max
  * \param[out] reason   If not NULL, where to put descriptive failure reason
  *
  * \return Standard Pacemaker return code
  * \note If \p reason is not NULL, the caller is responsible for freeing its
  *       returned value.
  */
-int pcmk_fence_action(stonith_t *st, const char *target, const char *action,
-                      const char *name, unsigned int timeout, unsigned int tolerance,
-                      int delay, char **reason);
+int pcmk_request_fencing(stonith_t *st, const char *target, const char *action,
+                         const char *name, unsigned int timeout,
+                         unsigned int tolerance, int delay, char **reason);
 
 /*!
  * \brief List the fencing operations that have occurred for a specific node.

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -187,8 +187,10 @@ int pcmk_list_nodes(xmlNodePtr *xml, char *node_types);
  * \param[in] tolerance If a successful action for \p target happened within
  *                      this many ms, return 0 without performing the action
  *                      again
- * \param[in] delay     Apply a fencing delay. Value -1 means disable also any
- *                      static/random fencing delays from pcmk_delay_base/max
+ * \param[in] delay     Apply this delay (in milliseconds) before initiating the
+ *                      fencing action (a value of -1 applies no delay and also
+ *                      disables any fencing delay from pcmk_delay_base and
+ *                      pcmk_delay_max)
  * \param[out] reason   If not NULL, where to put descriptive failure reason
  *
  * \return Standard Pacemaker return code

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -189,12 +189,15 @@ int pcmk_list_nodes(xmlNodePtr *xml, char *node_types);
  *                      again.
  * \param[in] delay     Apply a fencing delay. Value -1 means disable also any
  *                      static/random fencing delays from pcmk_delay_base/max.
+ * \param[out] reason   If not NULL, where to put descriptive failure reason
  *
  * \return Standard Pacemaker return code
+ * \note If \p reason is not NULL, the caller is responsible for freeing its
+ *       returned value.
  */
 int pcmk_fence_action(stonith_t *st, const char *target, const char *action,
                       const char *name, unsigned int timeout, unsigned int tolerance,
-                      int delay);
+                      int delay, char **reason);
 
 /*!
  * \brief List the fencing operations that have occurred for a specific node.

--- a/include/pcmki/pcmki_fence.h
+++ b/include/pcmki/pcmki_fence.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the Pacemaker project contributors
+ * Copyright 2019-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -22,17 +22,20 @@
  * \param[in] target    The node that should be fenced
  * \param[in] action    The fencing action (on, off, reboot) to perform
  * \param[in] name      Who requested the fence action?
- * \param[in] timeout   How long to wait for the operation to complete (in ms).
+ * \param[in] timeout   How long to wait for the operation to complete (in ms)
  * \param[in] tolerance If a successful action for \p target happened within
- *                      this many ms, return 0 without performing the action
- *                      again.
- * \param[in] delay     Apply a fencing delay. Value -1 means disable also any
- *                      static/random fencing delays from pcmk_delay_base/max
+ *                      this many milliseconds, return success without
+ *                      performing the action again
+ * \param[in] delay     Apply this delay (in milliseconds) before initiating the
+ *                      fencing action (a value of -1 applies no delay and also
+ *                      disables any fencing delay from pcmk_delay_base and
+ *                      pcmk_delay_max)
  * \param[out] reason   If not NULL, where to put descriptive failure reason
  *
  * \return Standard Pacemaker return code
  * \note If \p reason is not NULL, the caller is responsible for freeing its
  *       returned value.
+ * \todo delay is eventually used with g_timeout_add() and should be guint
  */
 int pcmk__request_fencing(stonith_t *st, const char *target, const char *action,
                           const char *name, unsigned int timeout,

--- a/include/pcmki/pcmki_fence.h
+++ b/include/pcmki/pcmki_fence.h
@@ -28,12 +28,15 @@
  *                      again.
  * \param[in] delay     Apply a fencing delay. Value -1 means disable also any
  *                      static/random fencing delays from pcmk_delay_base/max
+ * \param[out] reason   If not NULL, where to put descriptive failure reason
  *
  * \return Standard Pacemaker return code
+ * \note If \p reason is not NULL, the caller is responsible for freeing its
+ *       returned value.
  */
 int pcmk__fence_action(stonith_t *st, const char *target, const char *action,
                        const char *name, unsigned int timeout, unsigned int tolerance,
-                       int delay);
+                       int delay, char **reason);
 
 /*!
  * \brief List the fencing operations that have occurred for a specific node.

--- a/include/pcmki/pcmki_fence.h
+++ b/include/pcmki/pcmki_fence.h
@@ -13,14 +13,14 @@
 #  include <crm/common/output_internal.h>
 
 /*!
- * \brief Perform a STONITH action.
+ * \brief Ask the cluster to perform fencing
  *
- * \note This is the internal version of pcmk_fence_action().  External users
+ * \note This is the internal version of pcmk_request_fencing(). External users
  *       of the pacemaker API should use that function instead.
  *
- * \param[in] st        A connection to the STONITH API.
- * \param[in] target    The node receiving the action.
- * \param[in] action    The action to perform.
+ * \param[in] st        A connection to the fencer API
+ * \param[in] target    The node that should be fenced
+ * \param[in] action    The fencing action (on, off, reboot) to perform
  * \param[in] name      Who requested the fence action?
  * \param[in] timeout   How long to wait for the operation to complete (in ms).
  * \param[in] tolerance If a successful action for \p target happened within
@@ -34,9 +34,9 @@
  * \note If \p reason is not NULL, the caller is responsible for freeing its
  *       returned value.
  */
-int pcmk__fence_action(stonith_t *st, const char *target, const char *action,
-                       const char *name, unsigned int timeout, unsigned int tolerance,
-                       int delay, char **reason);
+int pcmk__request_fencing(stonith_t *st, const char *target, const char *action,
+                          const char *name, unsigned int timeout,
+                          unsigned int tolerance, int delay, char **reason);
 
 /*!
  * \brief List the fencing operations that have occurred for a specific node.

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2021 the Pacemaker project contributors
+ * Copyright 2009-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -77,7 +77,7 @@ static void
 notify_callback(stonith_t * st, stonith_event_t * e)
 {
     if (pcmk__str_eq(async_fence_data.target, e->target, pcmk__str_casei)
-        && pcmk__str_eq(async_fence_data.action, e->action, pcmk__str_casei)) {
+        && pcmk__str_eq(async_fence_data.action, e->action, pcmk__str_none)) {
 
         pcmk__set_result(&async_fence_data.result,
                          stonith__event_exit_status(e),
@@ -549,7 +549,7 @@ pcmk__reduce_fence_history(stonith_history_t *history)
             if ((hp->state == st_done) || (hp->state == st_failed)) {
                 /* action not in progress */
                 if (pcmk__str_eq(hp->target, np->target, pcmk__str_casei) &&
-                    pcmk__str_eq(hp->action, np->action, pcmk__str_casei) &&
+                    pcmk__str_eq(hp->action, np->action, pcmk__str_none) &&
                     (hp->state == np->state) &&
                     ((hp->state == st_done) ||
                      pcmk__str_eq(hp->delegate, np->delegate, pcmk__str_casei))) {

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -137,9 +137,9 @@ async_fence_helper(gpointer user_data)
 }
 
 int
-pcmk__fence_action(stonith_t *st, const char *target, const char *action,
-                   const char *name, unsigned int timeout, unsigned int tolerance,
-                   int delay, char **reason)
+pcmk__request_fencing(stonith_t *st, const char *target, const char *action,
+                      const char *name, unsigned int timeout,
+                      unsigned int tolerance, int delay, char **reason)
 {
     crm_trigger_t *trig;
 
@@ -169,12 +169,12 @@ pcmk__fence_action(stonith_t *st, const char *target, const char *action,
 
 #ifdef BUILD_PUBLIC_LIBPACEMAKER
 int
-pcmk_fence_action(stonith_t *st, const char *target, const char *action,
-                  const char *name, unsigned int timeout, unsigned int tolerance,
-                  int delay, char **reason)
+pcmk_request_fencing(stonith_t *st, const char *target, const char *action,
+                     const char *name, unsigned int timeout,
+                     unsigned int tolerance, int delay, char **reason)
 {
-    return pcmk__fence_action(st, target, action, name, timeout, tolerance,
-                              delay, reason);
+    return pcmk__request_fencing(st, target, action, name, timeout, tolerance,
+                                 delay, reason);
 }
 #endif
 

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -141,6 +141,7 @@ pcmk__request_fencing(stonith_t *st, const char *target, const char *action,
                       unsigned int tolerance, int delay, char **reason)
 {
     crm_trigger_t *trig;
+    int rc = pcmk_rc_ok;
 
     async_fence_data.st = st;
     async_fence_data.name = strdup(name);
@@ -160,10 +161,14 @@ pcmk__request_fencing(stonith_t *st, const char *target, const char *action,
 
     free(async_fence_data.name);
 
-    if ((reason != NULL) && (async_fence_data.result.exit_reason != NULL)) {
-        *reason = strdup(async_fence_data.result.exit_reason);
+    if (reason != NULL) {
+        // Give the caller ownership of the exit reason
+        *reason = async_fence_data.result.exit_reason;
+        async_fence_data.result.exit_reason = NULL;
     }
-    return stonith__result2rc(&async_fence_data.result);
+    rc = stonith__result2rc(&async_fence_data.result);
+    pcmk__reset_result(&async_fence_data.result);
+    return rc;
 }
 
 #ifdef BUILD_PUBLIC_LIBPACEMAKER

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -104,10 +104,9 @@ async_fence_helper(gpointer user_data)
     int rc = stonith_api_connect_retry(st, async_fence_data.name, 10);
 
     if (rc != pcmk_ok) {
-        fprintf(stderr, "Could not connect to fencer: %s\n", pcmk_strerror(rc));
         g_main_loop_quit(mainloop);
         pcmk__set_result(&async_fence_data.result, CRM_EX_ERROR,
-                         PCMK_EXEC_NOT_CONNECTED, NULL);
+                         PCMK_EXEC_NOT_CONNECTED, pcmk_strerror(rc));
         return TRUE;
     }
 

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -139,7 +139,7 @@ async_fence_helper(gpointer user_data)
 int
 pcmk__fence_action(stonith_t *st, const char *target, const char *action,
                    const char *name, unsigned int timeout, unsigned int tolerance,
-                   int delay)
+                   int delay, char **reason)
 {
     crm_trigger_t *trig;
 
@@ -161,6 +161,9 @@ pcmk__fence_action(stonith_t *st, const char *target, const char *action,
 
     free(async_fence_data.name);
 
+    if ((reason != NULL) && (async_fence_data.result.exit_reason != NULL)) {
+        *reason = strdup(async_fence_data.result.exit_reason);
+    }
     return stonith__result2rc(&async_fence_data.result);
 }
 
@@ -168,9 +171,10 @@ pcmk__fence_action(stonith_t *st, const char *target, const char *action,
 int
 pcmk_fence_action(stonith_t *st, const char *target, const char *action,
                   const char *name, unsigned int timeout, unsigned int tolerance,
-                  int delay)
+                  int delay, char **reason)
 {
-    return pcmk__fence_action(st, target, action, name, timeout, tolerance, delay);
+    return pcmk__fence_action(st, target, action, name, timeout, tolerance,
+                              delay, reason);
 }
 #endif
 

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -570,18 +570,24 @@ main(int argc, char **argv)
             break;
 
         case 'B':
-            rc = pcmk__fence_action(st, target, "reboot", name, options.timeout*1000,
-                                    options.tolerance*1000, options.delay, NULL);
+            rc = pcmk__request_fencing(st, target, "reboot", name,
+                                       options.timeout * 1000,
+                                       options.tolerance * 1000,
+                                       options.delay, NULL);
             break;
 
         case 'F':
-            rc = pcmk__fence_action(st, target, "off", name, options.timeout*1000,
-                                    options.tolerance*1000, options.delay, NULL);
+            rc = pcmk__request_fencing(st, target, "off", name,
+                                       options.timeout * 1000,
+                                       options.tolerance * 1000,
+                                       options.delay, NULL);
             break;
 
         case 'U':
-            rc = pcmk__fence_action(st, target, "on", name, options.timeout*1000,
-                                    options.tolerance*1000, options.delay, NULL);
+            rc = pcmk__request_fencing(st, target, "on", name,
+                                       options.timeout * 1000,
+                                       options.tolerance * 1000,
+                                       options.delay, NULL);
             break;
 
         case 'h':

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -331,6 +331,18 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     return context;
 }
 
+// \return Standard Pacemaker return code
+static int
+request_fencing(stonith_t *st, const char *target, const char *command)
+{
+    int rc = pcmk__request_fencing(st, target, command, crm_system_name,
+                                       options.timeout * 1000,
+                                       options.tolerance * 1000,
+                                       options.delay, NULL);
+
+    return rc;
+}
+
 int
 main(int argc, char **argv)
 {
@@ -568,24 +580,15 @@ main(int argc, char **argv)
             break;
 
         case 'B':
-            rc = pcmk__request_fencing(st, target, "reboot", crm_system_name,
-                                       options.timeout * 1000,
-                                       options.tolerance * 1000,
-                                       options.delay, NULL);
+            rc = request_fencing(st, target, "reboot");
             break;
 
         case 'F':
-            rc = pcmk__request_fencing(st, target, "off", crm_system_name,
-                                       options.timeout * 1000,
-                                       options.tolerance * 1000,
-                                       options.delay, NULL);
+            rc = request_fencing(st, target, "off");
             break;
 
         case 'U':
-            rc = pcmk__request_fencing(st, target, "on", crm_system_name,
-                                       options.timeout * 1000,
-                                       options.tolerance * 1000,
-                                       options.delay, NULL);
+            rc = request_fencing(st, target, "on");
             break;
 
         case 'h':

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -571,17 +571,17 @@ main(int argc, char **argv)
 
         case 'B':
             rc = pcmk__fence_action(st, target, "reboot", name, options.timeout*1000,
-                                    options.tolerance*1000, options.delay);
+                                    options.tolerance*1000, options.delay, NULL);
             break;
 
         case 'F':
             rc = pcmk__fence_action(st, target, "off", name, options.timeout*1000,
-                                    options.tolerance*1000, options.delay);
+                                    options.tolerance*1000, options.delay, NULL);
             break;
 
         case 'U':
             rc = pcmk__fence_action(st, target, "on", name, options.timeout*1000,
-                                    options.tolerance*1000, options.delay);
+                                    options.tolerance*1000, options.delay, NULL);
             break;
 
         case 'h':

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -360,8 +360,6 @@ main(int argc, char **argv)
 
     pcmk__cli_init_logging("stonith_admin", args->verbosity);
 
-    name = strdup(crm_system_name);
-
     rc = pcmk__output_new(&out, args->output_ty, args->output_dest, argv);
     if (rc != pcmk_rc_ok) {
         exit_code = CRM_EX_ERROR;
@@ -496,7 +494,7 @@ main(int argc, char **argv)
     if (st == NULL) {
         rc = -ENOMEM;
     } else if (!no_connect) {
-        rc = st->cmds->connect(st, name, NULL);
+        rc = st->cmds->connect(st, crm_system_name, NULL);
     }
     if (rc < 0) {
         out->err(out, "Could not connect to fencer: %s", pcmk_strerror(rc));
@@ -570,21 +568,21 @@ main(int argc, char **argv)
             break;
 
         case 'B':
-            rc = pcmk__request_fencing(st, target, "reboot", name,
+            rc = pcmk__request_fencing(st, target, "reboot", crm_system_name,
                                        options.timeout * 1000,
                                        options.tolerance * 1000,
                                        options.delay, NULL);
             break;
 
         case 'F':
-            rc = pcmk__request_fencing(st, target, "off", name,
+            rc = pcmk__request_fencing(st, target, "off", crm_system_name,
                                        options.timeout * 1000,
                                        options.tolerance * 1000,
                                        options.delay, NULL);
             break;
 
         case 'U':
-            rc = pcmk__request_fencing(st, target, "on", name,
+            rc = pcmk__request_fencing(st, target, "on", crm_system_name,
                                        options.timeout * 1000,
                                        options.tolerance * 1000,
                                        options.delay, NULL);
@@ -619,7 +617,6 @@ main(int argc, char **argv)
         out->finish(out, exit_code, true, NULL);
         pcmk__output_free(out);
     }
-    free(name);
     stonith_key_value_freeall(options.params, 1, 1);
 
     if (st != NULL) {

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -337,10 +337,10 @@ request_fencing(stonith_t *st, const char *target, const char *command,
                 GError **error)
 {
     char *reason = NULL;
-    int rc = pcmk__request_fencing(st, target, command, crm_system_name,
-                                       options.timeout * 1000,
-                                       options.tolerance * 1000,
-                                       options.delay, &reason);
+    int rc = pcmk__request_fencing(st, target, command, name,
+                                   options.timeout * 1000,
+                                   options.tolerance * 1000,
+                                   options.delay, &reason);
 
     if (rc != pcmk_rc_ok) {
         const char *rc_str = pcmk_rc_str(rc);
@@ -391,6 +391,10 @@ main(int argc, char **argv)
     }
 
     pcmk__cli_init_logging("stonith_admin", args->verbosity);
+
+    if (name == NULL) {
+        name = strdup(crm_system_name);
+    }
 
     rc = pcmk__output_new(&out, args->output_ty, args->output_dest, argv);
     if (rc != pcmk_rc_ok) {
@@ -526,7 +530,7 @@ main(int argc, char **argv)
     if (st == NULL) {
         rc = -ENOMEM;
     } else if (!no_connect) {
-        rc = st->cmds->connect(st, crm_system_name, NULL);
+        rc = st->cmds->connect(st, name, NULL);
     }
     if (rc < 0) {
         out->err(out, "Could not connect to fencer: %s", pcmk_strerror(rc));
@@ -640,6 +644,7 @@ main(int argc, char **argv)
         out->finish(out, exit_code, true, NULL);
         pcmk__output_free(out);
     }
+    free(name);
     stonith_key_value_freeall(options.params, 1, 1);
 
     if (st != NULL) {


### PR DESCRIPTION
Now that stonith_event_t has an exit reason, add it as well to libpacemaker's high-level fencing API used by stonith_admin, and have stonith_admin display an error message if a fencing action fails.

The high-level fencing API has not been exposed publicly yet, so we don't have to worry about backward compatibility.