### PR TITLE
Improve error handling around crm_mon's daemonize mode

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1494,8 +1494,10 @@ main(int argc, char **argv)
             }
 
         } else if (options.daemonize) {
-            if (pcmk__str_eq(args->output_dest, "-", pcmk__str_null_matches | pcmk__str_casei) && !options.external_agent) {
-                g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_USAGE, "--daemonize requires at least one of --output-to and --external-agent");
+            if (pcmk__str_eq(args->output_dest, "-", pcmk__str_null_matches|pcmk__str_casei) &&
+                !options.external_agent) {
+                g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_USAGE,
+                            "--daemonize requires at least one of --output-to and --external-agent");
                 return clean_up(CRM_EX_USAGE);
             }
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1542,20 +1542,12 @@ main(int argc, char **argv)
 
         crm_enable_stderr(FALSE);
 
-        if (cib) {
-            /* to be on the safe side don't have cib-object around
-             * when we are forking
-             */
-            cib_delete(cib);
-            cib = NULL;
-            pcmk__daemonize(crm_system_name, options.pid_file);
-            cib = cib_new();
-            if (cib == NULL) {
-                exit_on_invalid_cib();
-            }
-            /* otherwise assume we've got the same cib-object we've just destroyed
-             * in our parent
-             */
+        cib_delete(cib);
+        cib = NULL;
+        pcmk__daemonize(crm_system_name, options.pid_file);
+        cib = cib_new();
+        if (cib == NULL) {
+            exit_on_invalid_cib();
         }
     }
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1388,6 +1388,10 @@ one_shot(void)
 static void
 exit_on_invalid_cib(void)
 {
+    if (cib != NULL) {
+        return;
+    }
+
     // Shouldn't really be possible
     g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_ERROR, "Invalid CIB source");
     clean_up(CRM_EX_ERROR);
@@ -1452,39 +1456,36 @@ main(int argc, char **argv)
          */
         cib = cib_new();
 
-        if (cib == NULL) {
-            exit_on_invalid_cib();
-        } else {
-            switch (cib->variant) {
+        exit_on_invalid_cib();
 
-                case cib_native:
-                    /* cib & fencing - everything available */
-                    use_cib_native = TRUE;
-                    break;
+        switch (cib->variant) {
+            case cib_native:
+                /* cib & fencing - everything available */
+                use_cib_native = TRUE;
+                break;
 
-                case cib_file:
-                    /* Don't try to connect to fencing as we
-                     * either don't have a running cluster or
-                     * the fencing-information would possibly
-                     * not match the cib data from a file.
-                     * As we don't expect cib-updates coming
-                     * in enforce one-shot. */
-                    fence_history_cb("--fence-history", "0", NULL, NULL);
-                    options.one_shot = TRUE;
-                    break;
+            case cib_file:
+                /* Don't try to connect to fencing as we
+                 * either don't have a running cluster or
+                 * the fencing-information would possibly
+                 * not match the cib data from a file.
+                 * As we don't expect cib-updates coming
+                 * in enforce one-shot. */
+                fence_history_cb("--fence-history", "0", NULL, NULL);
+                options.one_shot = TRUE;
+                break;
 
-                case cib_remote:
-                    /* updates coming in but no fencing */
-                    fence_history_cb("--fence-history", "0", NULL, NULL);
-                    break;
+            case cib_remote:
+                /* updates coming in but no fencing */
+                fence_history_cb("--fence-history", "0", NULL, NULL);
+                break;
 
-                case cib_undefined:
-                case cib_database:
-                default:
-                    /* something is odd */
-                    exit_on_invalid_cib();
-                    break;
-            }
+            case cib_undefined:
+            case cib_database:
+            default:
+                /* something is odd */
+                exit_on_invalid_cib();
+                break;
         }
 
         if (options.one_shot) {
@@ -1546,9 +1547,7 @@ main(int argc, char **argv)
         cib = NULL;
         pcmk__daemonize(crm_system_name, options.pid_file);
         cib = cib_new();
-        if (cib == NULL) {
-            exit_on_invalid_cib();
-        }
+        exit_on_invalid_cib();
     }
 
     show = default_includes(output_format);


### PR DESCRIPTION
The basic problem here is that if you run `crm_mon -d --output-to foo`, it creates a foo file and puts nothing in it because the output format is none.  Tell the user they need to specify an output format.