### PR TITLE
Show exit reasons in failed fence action display

### DIFF
--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2021 the Pacemaker project contributors
+ * Copyright 2009-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -359,8 +359,6 @@ stonith_local_history_diff_and_merge(GHashTable *remote_history,
     }
 
     if (remote_history) {
-        pcmk__action_result_t result = PCMK__UNKNOWN_RESULT;
-
         init_stonith_remote_op_hash_table(&stonith_remote_op_list);
 
         updated |= g_hash_table_size(remote_history);
@@ -378,10 +376,10 @@ stonith_local_history_diff_and_merge(GHashTable *remote_history,
                 /* CRM_EX_EXPIRED + PCMK_EXEC_INVALID prevents finalize_op()
                  * from setting a delegate
                  */
-                pcmk__set_result(&result, CRM_EX_EXPIRED, PCMK_EXEC_INVALID,
+                pcmk__set_result(&op->result, CRM_EX_EXPIRED, PCMK_EXEC_INVALID,
                                  "Initiated by earlier fencer "
                                  "process and presumed failed");
-                fenced_broadcast_op_result(op, &result, false);
+                fenced_broadcast_op_result(op, false);
             }
 
             g_hash_table_iter_steal(&iter);
@@ -396,7 +394,6 @@ stonith_local_history_diff_and_merge(GHashTable *remote_history,
              */
         }
 
-        pcmk__reset_result(&result);
         g_hash_table_destroy(remote_history); /* remove what is left */
     }
 

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -257,6 +257,7 @@ stonith_xml_history_to_list(xmlNode *history)
         op->completed_nsec = completed_nsec;
         crm_element_value_int(xml_op, F_STONITH_STATE, &state);
         op->state = (enum op_state) state;
+        stonith__xe_get_result(xml_op, &op->result);
 
         g_hash_table_replace(rv, id, op);
         CRM_LOG_ASSERT(g_hash_table_lookup(rv, id) != NULL);
@@ -355,6 +356,7 @@ stonith_local_history_diff_and_merge(GHashTable *remote_history,
                 crm_xml_add_ll(entry, F_STONITH_DATE, op->completed);
                 crm_xml_add_ll(entry, F_STONITH_DATE_NSEC, op->completed_nsec);
                 crm_xml_add_int(entry, F_STONITH_STATE, op->state);
+                stonith__xe_set_result(entry, &op->result);
             }
     }
 

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -390,16 +390,14 @@ fencing_result2xml(remote_fencing_op_t *op, pcmk__action_result_t *result)
  * \brief Broadcast a fence result notification to all CPG peers
  *
  * \param[in] op         Fencer operation that completed
- * \param[in] result     Full operation result
  * \param[in] op_merged  Whether this operation is a duplicate of another
  */
 void
-fenced_broadcast_op_result(remote_fencing_op_t *op,
-                           pcmk__action_result_t *result, bool op_merged)
+fenced_broadcast_op_result(remote_fencing_op_t *op, bool op_merged)
 {
     static int count = 0;
     xmlNode *bcast = create_xml_node(NULL, T_STONITH_REPLY);
-    xmlNode *notify_data = fencing_result2xml(op, result);
+    xmlNode *notify_data = fencing_result2xml(op, &op->result);
 
     count++;
     crm_trace("Broadcasting result to peers");
@@ -581,7 +579,7 @@ finalize_op(remote_fencing_op_t *op, xmlNode *data, bool dup)
     subt = crm_element_value(data, F_SUBTYPE);
     if (!dup && !pcmk__str_eq(subt, "broadcast", pcmk__str_casei)) {
         /* Defer notification until the bcast message arrives */
-        fenced_broadcast_op_result(op, &op->result, op_merged);
+        fenced_broadcast_op_result(op, op_merged);
         free_xml(local_data);
         return;
     }

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -260,6 +260,8 @@ free_remote_op(gpointer data)
     }
     g_list_free_full(op->automatic_list, free);
     g_list_free(op->duplicates);
+
+    pcmk__reset_result(&op->result);
     free(op);
 }
 

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -2219,6 +2219,7 @@ fenced_process_fencing_reply(xmlNode *msg)
         return;
     }
 
+    pcmk__reset_result(&op->result);
     op->result = result; // The operation takes ownership of the result
 
     if (op->devices && device && !pcmk__str_eq(op->devices->data, device, pcmk__str_casei)) {

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -362,13 +362,12 @@ undo_op_remap(remote_fencing_op_t *op)
  * \brief Create notification data XML for a fencing operation result
  *
  * \param[in] op      Fencer operation that completed
- * \param[in] result  Full operation result
  *
  * \return Newly created XML to add as notification data
  * \note The caller is responsible for freeing the result.
  */
 static xmlNode *
-fencing_result2xml(remote_fencing_op_t *op, pcmk__action_result_t *result)
+fencing_result2xml(remote_fencing_op_t *op)
 {
     xmlNode *notify_data = create_xml_node(NULL, T_STONITH_NOTIFY_FENCE);
 
@@ -381,7 +380,7 @@ fencing_result2xml(remote_fencing_op_t *op, pcmk__action_result_t *result)
     crm_xml_add(notify_data, F_STONITH_CLIENTID, op->client_id);
     crm_xml_add(notify_data, F_STONITH_CLIENTNAME, op->client_name);
 
-    stonith__xe_set_result(notify_data, result);
+    stonith__xe_set_result(notify_data, &op->result);
     return notify_data;
 }
 
@@ -397,7 +396,7 @@ fenced_broadcast_op_result(remote_fencing_op_t *op, bool op_merged)
 {
     static int count = 0;
     xmlNode *bcast = create_xml_node(NULL, T_STONITH_REPLY);
-    xmlNode *notify_data = fencing_result2xml(op, &op->result);
+    xmlNode *notify_data = fencing_result2xml(op);
 
     count++;
     crm_trace("Broadcasting result to peers");
@@ -448,7 +447,7 @@ handle_local_reply_and_notify(remote_fencing_op_t *op, xmlNode *data)
     do_local_reply(reply, op->client_id, op->call_options & st_opt_sync_call, FALSE);
 
     /* bcast to all local clients that the fencing operation happend */
-    notify_data = fencing_result2xml(op, &op->result);
+    notify_data = fencing_result2xml(op);
     fenced_send_notification(T_STONITH_NOTIFY_FENCE, &op->result, notify_data);
     free_xml(notify_data);
     fenced_send_notification(T_STONITH_NOTIFY_HISTORY, NULL, NULL);

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -468,11 +468,9 @@ handle_local_reply_and_notify(remote_fencing_op_t *op, xmlNode *data,
  *
  * \param[in] op         Fencer operation that completed
  * \param[in] data       Top-level XML to add notification to
- * \param[in] result     Full operation result
  */
 static void
-finalize_op_duplicates(remote_fencing_op_t *op, xmlNode *data,
-                       pcmk__action_result_t *result)
+finalize_op_duplicates(remote_fencing_op_t *op, xmlNode *data)
 {
     for (GList *iter = op->duplicates; iter != NULL; iter = iter->next) {
         remote_fencing_op_t *other = iter->data;
@@ -482,10 +480,11 @@ finalize_op_duplicates(remote_fencing_op_t *op, xmlNode *data,
             crm_debug("Performing duplicate notification for %s@%s: %s "
                       CRM_XS " id=%.8s",
                       other->client_name, other->originator,
-                      pcmk_exec_status_str(result->execution_status),
+                      pcmk_exec_status_str(op->result.execution_status),
                       other->id);
-            pcmk__set_result(&other->result, result->exit_status,
-                             result->execution_status, result->exit_reason);
+            pcmk__set_result(&other->result, op->result.exit_status,
+                             op->result.execution_status,
+                             op->result.exit_reason);
             finalize_op(other, data, true);
 
         } else {
@@ -606,7 +605,7 @@ finalize_op(remote_fencing_op_t *op, xmlNode *data, bool dup)
     handle_local_reply_and_notify(op, data, &op->result);
 
     if (!dup) {
-        finalize_op_duplicates(op, data, &op->result);
+        finalize_op_duplicates(op, data);
     }
 
     /* Free non-essential parts of the record

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -155,8 +155,7 @@ typedef struct remote_fencing_op_s {
     pcmk__action_result_t result;
 } remote_fencing_op_t;
 
-void fenced_broadcast_op_result(remote_fencing_op_t *op,
-                                pcmk__action_result_t *result, bool op_merged);
+void fenced_broadcast_op_result(remote_fencing_op_t *op, bool op_merged);
 
 // Fencer-specific client flags
 enum st_client_flags {

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2021 the Pacemaker project contributors
+ * Copyright 2009-2022 the Pacemaker project contributors
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -151,6 +151,8 @@ typedef struct remote_fencing_op_s {
     /*! The point at which the remote operation completed(nsec) */
     long long completed_nsec;
 
+    /*! The (potentially intermediate) result of the operation */
+    pcmk__action_result_t result;
 } remote_fencing_op_t;
 
 void fenced_broadcast_op_result(remote_fencing_op_t *op,

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -27,7 +27,7 @@ extern "C" {
 #  include <glib.h>
 #  include <crm/common/results.h>
 
-#  define PCMK__API_VERSION "2.14"
+#  define PCMK__API_VERSION "2.15"
 
 #if defined(PCMK__WITH_ATTRIBUTE_OUTPUT_ARGS)
 #  define PCMK__OUTPUT_ARGS(ARGS...) __attribute__((output_args(ARGS)))

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -111,6 +111,7 @@ typedef struct stonith_history_s {
     time_t completed;
     struct stonith_history_s *next;
     long completed_nsec;
+    char *exit_reason;
 } stonith_history_t;
 
 typedef struct stonith_s stonith_t;

--- a/lib/fencing/Makefile.am
+++ b/lib/fencing/Makefile.am
@@ -2,7 +2,7 @@
 # Original Author: Sun Jiang Dong <sunjd@cn.ibm.com>
 # Copyright 2004 International Business Machines
 #
-# with later changes copyright 2004-2021 the Pacemaker project contributors.
+# with later changes copyright 2004-2022 the Pacemaker project contributors.
 # The version control history for this file may have further details.
 #
 # This source code is licensed under the GNU General Public License version 2
@@ -14,7 +14,7 @@ noinst_HEADERS		= fencing_private.h
 
 lib_LTLIBRARIES		= libstonithd.la
 
-libstonithd_la_LDFLAGS	= -version-info 33:0:7
+libstonithd_la_LDFLAGS	= -version-info 34:0:8
 
 libstonithd_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 libstonithd_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -698,6 +698,7 @@ stonith_api_history(stonith_t * stonith, int call_options, const char *node,
             stonith_history_t *kvp;
             long long completed;
             long long completed_nsec = 0L;
+            pcmk__action_result_t result = PCMK__UNKNOWN_RESULT;
 
             kvp = calloc(1, sizeof(stonith_history_t));
             kvp->target = crm_element_value_copy(op, F_STONITH_TARGET);
@@ -710,6 +711,11 @@ stonith_api_history(stonith_t * stonith, int call_options, const char *node,
             crm_element_value_ll(op, F_STONITH_DATE_NSEC, &completed_nsec);
             kvp->completed_nsec = completed_nsec;
             crm_element_value_int(op, F_STONITH_STATE, &kvp->state);
+
+            stonith__xe_get_result(op, &result);
+            kvp->exit_reason = result.exit_reason;
+            result.exit_reason = NULL;
+            pcmk__reset_result(&result);
 
             if (last) {
                 last->next = kvp;

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -735,6 +735,7 @@ void stonith_history_free(stonith_history_t *history)
         free(hp->origin);
         free(hp->delegate);
         free(hp->client);
+        free(hp->exit_reason);
     }
 }
 

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the Pacemaker project contributors
+ * Copyright 2019-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -11,6 +11,7 @@
 #include <stdarg.h>
 
 #include <crm/stonith-ng.h>
+#include <crm/msg_xml.h>
 #include <crm/common/iso8601.h>
 #include <crm/common/util.h>
 #include <crm/common/xml.h>
@@ -263,8 +264,12 @@ stonith_event_html(pcmk__output_t *out, va_list args) {
             char *failed_s = time_t_string(event->completed);
 
             out->list_item(out, "failed-stonith-event",
-                           "%s of %s failed : delegate=%s, client=%s, origin=%s, %s='%s' %s",
+                           "%s of %s failed%s%s%s: "
+                           "delegate=%s, client=%s, origin=%s, %s='%s' %s",
                            stonith_action_str(event->action), event->target,
+                           (event->exit_reason == NULL)? "" : " (",
+                           (event->exit_reason == NULL)? "" : event->exit_reason,
+                           (event->exit_reason == NULL)? "" : ")",
                            event->delegate ? event->delegate : "",
                            event->client, event->origin,
                            full_history ? "completed" : "last-failed",
@@ -296,8 +301,13 @@ stonith_event_text(pcmk__output_t *out, va_list args) {
 
     switch (event->state) {
         case st_failed:
-            pcmk__indented_printf(out, "%s of %s failed: delegate=%s, client=%s, origin=%s, %s='%s' %s\n",
+            pcmk__indented_printf(out,
+                                  "%s of %s failed%s%s%s: "
+                                  "delegate=%s, client=%s, origin=%s, %s='%s' %s\n",
                                   stonith_action_str(event->action), event->target,
+                                  (event->exit_reason == NULL)? "" : " (",
+                                  (event->exit_reason == NULL)? "" : event->exit_reason,
+                                  (event->exit_reason == NULL)? "" : ")",
                                   event->delegate ? event->delegate : "",
                                   event->client, event->origin,
                                   full_history ? "completed" : "last-failed", buf,
@@ -341,7 +351,9 @@ stonith_event_xml(pcmk__output_t *out, va_list args) {
 
     switch (event->state) {
         case st_failed:
-            crm_xml_add(node, "status", "failed");
+            pcmk__xe_set_props(node, "status", "failed",
+                               XML_LRM_ATTR_EXIT_REASON, event->exit_reason,
+                               NULL);
             break;
 
         case st_done:

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the Pacemaker project contributors
+ * Copyright 2019-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -463,8 +463,13 @@ stonith_event_console(pcmk__output_t *out, va_list args) {
 
     switch (event->state) {
         case st_failed:
-            curses_indented_printf(out, "%s of %s failed: delegate=%s, client=%s, origin=%s, %s='%s'%s\n",
+            curses_indented_printf(out,
+                                   "%s of %s failed%s%s%s: "
+                                   "delegate=%s, client=%s, origin=%s, %s='%s' %s\n",
                                    stonith_action_str(event->action), event->target,
+                                   (event->exit_reason == NULL)? "" : " (",
+                                   (event->exit_reason == NULL)? "" : event->exit_reason,
+                                   (event->exit_reason == NULL)? "" : ")",
                                    event->delegate ? event->delegate : "",
                                    event->client, event->origin,
                                    full_history ? "completed" : "last-failed", buf,

--- a/xml/api/fence-event-2.15.rng
+++ b/xml/api/fence-event-2.15.rng
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="fencing-history-event"/>
+    </start>
+
+    <define name="fencing-history-event">
+        <element name="fence_event">
+            <attribute name="status">
+                <choice>
+                    <value>failed</value>
+                    <value>success</value>
+                    <value>pending</value>
+                </choice>
+            </attribute>
+            <optional>
+                <attribute name="extended-status"> <text /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="delegate"> <text /> </attribute>
+            </optional>
+            <attribute name="action"> <text /> </attribute>
+            <attribute name="target"> <text /> </attribute>
+            <attribute name="client"> <text /> </attribute>
+            <attribute name="origin"> <text /> </attribute>
+            <optional>
+                <attribute name="completed"> <text /> </attribute>
+            </optional>
+        </element>
+    </define>
+</grammar>

--- a/xml/api/fence-event-2.15.rng
+++ b/xml/api/fence-event-2.15.rng
@@ -19,6 +19,9 @@
                 <attribute name="extended-status"> <text /> </attribute>
             </optional>
             <optional>
+                <attribute name="exit-reason"> <text /> </attribute>
+            </optional>
+            <optional>
                 <attribute name="delegate"> <text /> </attribute>
             </optional>
             <attribute name="action"> <text /> </attribute>


### PR DESCRIPTION
This is the final PR in the long project to show exit reasons in status displays for actions that failed due to internal Pacemaker errors. It adds the full result to the fencer's remote_fencing_op_t so it can be tracked in the fence history, and adds the exit reason to the stonith_history_t type, allowing crm_mon to display it in the failed fencing actions section.