### PR TITLE
Refactor: libstonithd: Allow removing all registered callbacks at once.

### DIFF
--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -424,9 +424,7 @@ tengine_stonith_connection_destroy(stonith_t *st, stonith_event_t *e)
         if (stonith_api->state != stonith_disconnected) {
             stonith_api->cmds->disconnect(st);
         }
-        stonith_api->cmds->remove_notification(stonith_api, T_STONITH_NOTIFY_DISCONNECT);
-        stonith_api->cmds->remove_notification(stonith_api, T_STONITH_NOTIFY_FENCE);
-        stonith_api->cmds->remove_notification(stonith_api, T_STONITH_NOTIFY_HISTORY_SYNCED);
+        stonith_api->cmds->remove_notification(stonith_api, NULL);
     }
 
     if (AM_I_DC) {
@@ -701,9 +699,7 @@ controld_disconnect_fencer(bool destroy)
         if (stonith_api->state != stonith_disconnected) {
             stonith_api->cmds->disconnect(stonith_api);
         }
-        stonith_api->cmds->remove_notification(stonith_api, T_STONITH_NOTIFY_DISCONNECT);
-        stonith_api->cmds->remove_notification(stonith_api, T_STONITH_NOTIFY_FENCE);
-        stonith_api->cmds->remove_notification(stonith_api, T_STONITH_NOTIFY_HISTORY_SYNCED);
+        stonith_api->cmds->remove_notification(stonith_api, NULL);
     }
     if (destroy) {
         if (stonith_api) {

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -298,6 +298,16 @@ typedef struct stonith_api_operations_s
     int (*register_notification)(
         stonith_t *st, const char *event,
         void (*notify)(stonith_t *st, stonith_event_t *e));
+
+    /*!
+     * \brief Remove a previously registered notification for \c event, or all
+     *        notifications if NULL.
+     *
+     * \param[in] st     Fencer connection to use
+     * \param[in] event  The event to remove notifications for (may be NULL).
+     *
+     * \return Legacy Pacemaker return code
+     */
     int (*remove_notification)(stonith_t *st, const char *event);
 
     /*!

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -2322,9 +2322,7 @@ clean_up_fencing_connection(void)
     }
 
     if (st->state != stonith_disconnected) {
-        st->cmds->remove_notification(st, T_STONITH_NOTIFY_DISCONNECT);
-        st->cmds->remove_notification(st, T_STONITH_NOTIFY_FENCE);
-        st->cmds->remove_notification(st, T_STONITH_NOTIFY_HISTORY);
+        st->cmds->remove_notification(st, NULL);
         st->cmds->disconnect(st);
     }
 


### PR DESCRIPTION
If stonith_api_del_notification is given NULL for its second argument,
just remove every notification from the list.