### PR TITLE
Get lib/common/strings.c very close to 100% test coverage

### DIFF
--- a/lib/common/tests/cmdline/pcmk__cmdline_preproc_test.c
+++ b/lib/common/tests/cmdline/pcmk__cmdline_preproc_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the Pacemaker project contributors
+ * Copyright 2020-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -31,8 +31,8 @@ empty_input(void **state) {
 
 static void
 no_specials(void **state) {
-    const char *argv[] = { "-a", "-b", "-c", "-d", NULL };
-    const gchar *expected[] = { "-a", "-b", "-c", "-d", NULL };
+    const char *argv[] = { "-a", "-b", "-c", "-d", "-1", NULL };
+    const gchar *expected[] = { "-a", "-b", "-c", "-d", "-1", NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, NULL);
     LISTS_EQ(processed, expected);

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -30,6 +30,7 @@ check_PROGRAMS = \
 		pcmk__str_any_of_test		\
 		pcmk__str_in_list_test		\
 		pcmk__strcmp_test 			\
+		pcmk__strkey_table_test 	\
 		pcmk__trim_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -31,6 +31,7 @@ check_PROGRAMS = \
 		pcmk__str_in_list_test		\
 		pcmk__strcmp_test 			\
 		pcmk__strkey_table_test 	\
+		pcmk__strikey_table_test 	\
 		pcmk__trim_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -23,6 +23,7 @@ check_PROGRAMS = \
 		pcmk__ends_with_test 		\
 		pcmk__parse_ll_range_test	\
 		pcmk__scan_double_test		\
+		pcmk__scan_min_int_test		\
 		pcmk__scan_port_test		\
 		pcmk__starts_with_test 		\
 		pcmk__str_any_of_test		\

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -21,6 +21,7 @@ check_PROGRAMS = \
 		pcmk__btoa_test			\
 		pcmk__char_in_any_str_test	\
 		pcmk__ends_with_test 		\
+		pcmk__guint_from_hash_test	\
 		pcmk__numeric_strcasecmp_test \
 		pcmk__parse_ll_range_test	\
 		pcmk__scan_double_test		\

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -20,6 +20,7 @@ check_PROGRAMS = \
 		pcmk__add_word_test		\
 		pcmk__btoa_test			\
 		pcmk__char_in_any_str_test	\
+		pcmk__compress_test	\
 		pcmk__ends_with_test 		\
 		pcmk__guint_from_hash_test	\
 		pcmk__numeric_strcasecmp_test \

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -29,6 +29,7 @@ check_PROGRAMS = \
 		pcmk__starts_with_test 		\
 		pcmk__str_any_of_test		\
 		pcmk__str_in_list_test		\
+		pcmk__str_table_dup_test	\
 		pcmk__strcmp_test 			\
 		pcmk__strkey_table_test 	\
 		pcmk__strikey_table_test 	\

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2021 the Pacemaker project contributors
+# Copyright 2020-2022 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -23,6 +23,7 @@ check_PROGRAMS = \
 		pcmk__ends_with_test 		\
 		pcmk__parse_ll_range_test	\
 		pcmk__scan_double_test		\
+		pcmk__scan_port_test		\
 		pcmk__starts_with_test 		\
 		pcmk__str_any_of_test		\
 		pcmk__str_in_list_test		\

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -21,6 +21,7 @@ check_PROGRAMS = \
 		pcmk__btoa_test			\
 		pcmk__char_in_any_str_test	\
 		pcmk__ends_with_test 		\
+		pcmk__numeric_strcasecmp_test \
 		pcmk__parse_ll_range_test	\
 		pcmk__scan_double_test		\
 		pcmk__scan_min_int_test		\

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -27,6 +27,7 @@ check_PROGRAMS = \
 		pcmk__starts_with_test 		\
 		pcmk__str_any_of_test		\
 		pcmk__str_in_list_test		\
-		pcmk__strcmp_test
+		pcmk__strcmp_test 			\
+		pcmk__trim_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/strings/pcmk__compress_test.c
+++ b/lib/common/tests/strings/pcmk__compress_test.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#define SIMPLE_DATA "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+const char *SIMPLE_COMPRESSED = "BZh41AY&SYO\x1ai";
+
+static void
+simple_compress(void **state)
+{
+    char *result = calloc(1024, sizeof(char));
+    unsigned int len;
+
+    assert_int_equal(pcmk__compress(SIMPLE_DATA, 40, 0, &result, &len), pcmk_rc_ok);
+    assert_memory_equal(result, SIMPLE_COMPRESSED, 13);
+}
+
+static void
+max_too_small(void **state)
+{
+    char *result = calloc(1024, sizeof(char));
+    unsigned int len;
+
+    assert_int_equal(pcmk__compress(SIMPLE_DATA, 40, 10, &result, &len), pcmk_rc_error);
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(simple_compress),
+        cmocka_unit_test(max_too_small),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/strings/pcmk__guint_from_hash_test.c
+++ b/lib/common/tests/strings/pcmk__guint_from_hash_test.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <glib.h>
+
+static void
+null_args(void **state)
+{
+    GHashTable *tbl = pcmk__strkey_table(free, free);
+    guint result;
+
+    assert_int_equal(pcmk__guint_from_hash(NULL, "abc", 123, &result), EINVAL);
+    assert_int_equal(pcmk__guint_from_hash(tbl, NULL, 123, &result), EINVAL);
+
+    g_hash_table_destroy(tbl);
+}
+
+static void
+missing_key(void **state)
+{
+    GHashTable *tbl = pcmk__strkey_table(free, free);
+    guint result;
+
+    assert_int_equal(pcmk__guint_from_hash(tbl, "abc", 123, &result), pcmk_rc_ok);
+    assert_int_equal(result, 123);
+
+    g_hash_table_destroy(tbl);
+}
+
+static void
+standard_usage(void **state)
+{
+    GHashTable *tbl = pcmk__strkey_table(free, free);
+    guint result;
+
+    g_hash_table_insert(tbl, strdup("abc"), strdup("123"));
+
+    assert_int_equal(pcmk__guint_from_hash(tbl, "abc", 456, &result), pcmk_rc_ok);
+    assert_int_equal(result, 123);
+
+    g_hash_table_destroy(tbl);
+}
+
+static void
+conversion_errors(void **state)
+{
+    GHashTable *tbl = pcmk__strkey_table(free, free);
+    guint result;
+
+    g_hash_table_insert(tbl, strdup("negative"), strdup("-3"));
+    g_hash_table_insert(tbl, strdup("toobig"), strdup("20000000000000000"));
+
+    assert_int_equal(pcmk__guint_from_hash(tbl, "negative", 456, &result), ERANGE);
+    assert_int_equal(result, 456);
+
+    assert_int_equal(pcmk__guint_from_hash(tbl, "toobig", 456, &result), ERANGE);
+    assert_int_equal(result, 456);
+
+    g_hash_table_destroy(tbl);
+}
+
+int main(int argc, char **argv) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(null_args),
+        cmocka_unit_test(missing_key),
+        cmocka_unit_test(standard_usage),
+        cmocka_unit_test(conversion_errors),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/strings/pcmk__numeric_strcasecmp_test.c
+++ b/lib/common/tests/strings/pcmk__numeric_strcasecmp_test.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+static void
+no_numbers(void **state)
+{
+    /* All comparisons are done case-insensitively. */
+    assert_int_equal(pcmk__numeric_strcasecmp("abcd", "efgh"), -1);
+    assert_int_equal(pcmk__numeric_strcasecmp("abcd", "abcd"), 0);
+    assert_int_equal(pcmk__numeric_strcasecmp("efgh", "abcd"), 1);
+
+    assert_int_equal(pcmk__numeric_strcasecmp("AbCd", "eFgH"), -1);
+    assert_int_equal(pcmk__numeric_strcasecmp("ABCD", "abcd"), 0);
+    assert_int_equal(pcmk__numeric_strcasecmp("EFgh", "ABcd"), 1);
+}
+
+static void
+trailing_numbers(void **state)
+{
+    assert_int_equal(pcmk__numeric_strcasecmp("node1", "node2"), -1);
+    assert_int_equal(pcmk__numeric_strcasecmp("node1", "node1"), 0);
+    assert_int_equal(pcmk__numeric_strcasecmp("node2", "node1"), 1);
+
+    assert_int_equal(pcmk__numeric_strcasecmp("node1", "node10"), -1);
+    assert_int_equal(pcmk__numeric_strcasecmp("node10", "node10"), 0);
+    assert_int_equal(pcmk__numeric_strcasecmp("node10", "node1"), 1);
+
+    assert_int_equal(pcmk__numeric_strcasecmp("node10", "remotenode9"), -1);
+    assert_int_equal(pcmk__numeric_strcasecmp("remotenode9", "node10"), 1);
+
+    /* Longer numbers sort higher than shorter numbers. */
+    assert_int_equal(pcmk__numeric_strcasecmp("node001", "node1"), 1);
+    assert_int_equal(pcmk__numeric_strcasecmp("node1", "node001"), -1);
+}
+
+static void
+middle_numbers(void **state)
+{
+    assert_int_equal(pcmk__numeric_strcasecmp("node1abc", "node1def"), -1);
+    assert_int_equal(pcmk__numeric_strcasecmp("node1def", "node1abc"), 1);
+
+    assert_int_equal(pcmk__numeric_strcasecmp("node1abc", "node2abc"), -1);
+    assert_int_equal(pcmk__numeric_strcasecmp("node2abc", "node1abc"), 1);
+}
+
+static void
+unequal_lengths(void **state)
+{
+    assert_int_equal(pcmk__numeric_strcasecmp("node-ab", "node-abc"), -1);
+    assert_int_equal(pcmk__numeric_strcasecmp("node-abc", "node-ab"), 1);
+
+    assert_int_equal(pcmk__numeric_strcasecmp("node1ab", "node1abc"), -1);
+    assert_int_equal(pcmk__numeric_strcasecmp("node1abc", "node1ab"), 1);
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(no_numbers),
+        cmocka_unit_test(trailing_numbers),
+        cmocka_unit_test(middle_numbers),
+        cmocka_unit_test(unequal_lengths),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/strings/pcmk__parse_ll_range_test.c
+++ b/lib/common/tests/strings/pcmk__parse_ll_range_test.c
@@ -72,6 +72,8 @@ range_start_and_end(void **state)
     assert_int_equal(pcmk__parse_ll_range("2000-2020", &start, &end), pcmk_rc_ok);
     assert_int_equal(start, 2000);
     assert_int_equal(end, 2020);
+
+    assert_int_equal(pcmk__parse_ll_range("2000-2020-2030", &start, &end), pcmk_rc_unknown_format);
 }
 
 static void
@@ -88,6 +90,15 @@ garbage(void **state)
     assert_int_equal(end, PCMK__PARSE_INT_DEFAULT);
 }
 
+static void
+strtoll_errors(void **state)
+{
+    long long start, end;
+
+    assert_int_equal(pcmk__parse_ll_range("20000000000000000000-", &start, &end), pcmk_rc_unknown_format);
+    assert_int_equal(pcmk__parse_ll_range("100-20000000000000000000", &start, &end), pcmk_rc_unknown_format);
+}
+
 int main(int argc, char **argv)
 {
     const struct CMUnitTest tests[] = {
@@ -97,6 +108,7 @@ int main(int argc, char **argv)
         cmocka_unit_test(no_range_end),
         cmocka_unit_test(no_range_start),
         cmocka_unit_test(range_start_and_end),
+        cmocka_unit_test(strtoll_errors),
 
         cmocka_unit_test(garbage),
     };

--- a/lib/common/tests/strings/pcmk__scan_double_test.c
+++ b/lib/common/tests/strings/pcmk__scan_double_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -73,9 +73,11 @@ static void
 trailing_chars(void **state)
 {
     double result;
+    char *end_text;
 
-    assert_int_equal(pcmk__scan_double("2.0asdf", &result, NULL, NULL), pcmk_rc_ok);
+    assert_int_equal(pcmk__scan_double("2.0asdf", &result, NULL, &end_text), pcmk_rc_ok);
     assert_float_equal(result, 2.0, DBL_EPSILON);
+    assert_string_equal(end_text, "asdf");
 }
 
 static void

--- a/lib/common/tests/strings/pcmk__scan_min_int_test.c
+++ b/lib/common/tests/strings/pcmk__scan_min_int_test.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+static void
+empty_input_string(void **state)
+{
+    int result;
+
+    assert_int_equal(pcmk__scan_min_int("", &result, 1), EINVAL);
+    assert_int_equal(result, 1);
+
+    assert_int_equal(pcmk__scan_min_int(NULL, &result, 1), pcmk_rc_ok);
+    assert_int_equal(result, 1);
+}
+
+static void
+input_below_minimum(void **state)
+{
+    int result;
+
+    assert_int_equal(pcmk__scan_min_int("100", &result, 1024), pcmk_rc_ok);
+    assert_int_equal(result, 1024);
+}
+
+static void
+input_above_maximum(void **state)
+{
+    int result;
+
+    assert_int_equal(pcmk__scan_min_int("20000000000000000", &result, 100), EOVERFLOW);
+    assert_int_equal(result, INT_MAX);
+}
+
+static void
+input_just_right(void **state)
+{
+    int result;
+
+    assert_int_equal(pcmk__scan_min_int("1024", &result, 1024), pcmk_rc_ok);
+    assert_int_equal(result, 1024);
+
+    assert_int_equal(pcmk__scan_min_int("2048", &result, 1024), pcmk_rc_ok);
+    assert_int_equal(result, 2048);
+}
+
+int main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(empty_input_string),
+        cmocka_unit_test(input_below_minimum),
+        cmocka_unit_test(input_above_maximum),
+        cmocka_unit_test(input_just_right),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}
+

--- a/lib/common/tests/strings/pcmk__scan_port_test.c
+++ b/lib/common/tests/strings/pcmk__scan_port_test.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+static void
+empty_input_string(void **state)
+{
+    int result;
+
+    assert_int_equal(pcmk__scan_port("", &result), EINVAL);
+    assert_int_equal(result, -1);
+}
+
+static void
+bad_input_string(void **state)
+{
+    int result;
+
+    assert_int_equal(pcmk__scan_port("abc", &result), EINVAL);
+    assert_int_equal(result, -1);
+}
+
+static void
+out_of_range(void **state)
+{
+    int result;
+
+    assert_int_equal(pcmk__scan_port("-1", &result), pcmk_rc_before_range);
+    assert_int_equal(result, -1);
+    assert_int_equal(pcmk__scan_port("65536",  &result), pcmk_rc_after_range);
+    assert_int_equal(result, -1);
+}
+
+static void
+typical_case(void **state)
+{
+    int result;
+
+    assert_int_equal(pcmk__scan_port("0", &result), pcmk_rc_ok);
+    assert_int_equal(result, 0);
+
+    assert_int_equal(pcmk__scan_port("80", &result), pcmk_rc_ok);
+    assert_int_equal(result, 80);
+}
+
+int main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(empty_input_string),
+        cmocka_unit_test(bad_input_string),
+        cmocka_unit_test(out_of_range),
+        cmocka_unit_test(typical_case),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}
+

--- a/lib/common/tests/strings/pcmk__str_table_dup_test.c
+++ b/lib/common/tests/strings/pcmk__str_table_dup_test.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <glib.h>
+
+static void
+null_input_table(void **state)
+{
+    assert_null(pcmk__str_table_dup(NULL));
+}
+
+static void
+empty_input_table(void **state)
+{
+    GHashTable *tbl = pcmk__strkey_table(free, free);
+    GHashTable *copy = NULL;
+
+    copy = pcmk__str_table_dup(tbl);
+    assert_int_equal(g_hash_table_size(copy), 0);
+
+    g_hash_table_destroy(tbl);
+    g_hash_table_destroy(copy);
+}
+
+static void
+regular_input_table(void **state)
+{
+    GHashTable *tbl = pcmk__strkey_table(free, free);
+    GHashTable *copy = NULL;
+
+    g_hash_table_insert(tbl, strdup("abc"), strdup("123"));
+    g_hash_table_insert(tbl, strdup("def"), strdup("456"));
+    g_hash_table_insert(tbl, strdup("ghi"), strdup("789"));
+
+    copy = pcmk__str_table_dup(tbl);
+    assert_int_equal(g_hash_table_size(copy), 3);
+
+    assert_string_equal(g_hash_table_lookup(tbl, "abc"), "123");
+    assert_string_equal(g_hash_table_lookup(tbl, "def"), "456");
+    assert_string_equal(g_hash_table_lookup(tbl, "ghi"), "789");
+
+    g_hash_table_destroy(tbl);
+    g_hash_table_destroy(copy);
+}
+
+int main(int argc, char **argv) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(null_input_table),
+        cmocka_unit_test(empty_input_table),
+        cmocka_unit_test(regular_input_table),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/strings/pcmk__strikey_table_test.c
+++ b/lib/common/tests/strings/pcmk__strikey_table_test.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <glib.h>
+
+static void
+store_strs(void **state)
+{
+    GHashTable *tbl = NULL;
+
+    tbl = pcmk__strikey_table(free, free);
+    assert_non_null(tbl);
+
+    assert_true(g_hash_table_insert(tbl, strdup("key-abc"), strdup("val-abc")));
+    assert_int_equal(g_hash_table_size(tbl), 1);
+    assert_string_equal(g_hash_table_lookup(tbl, "key-abc"), "val-abc");
+
+    assert_false(g_hash_table_insert(tbl, strdup("key-abc"), strdup("val-def")));
+    assert_int_equal(g_hash_table_size(tbl), 1);
+    assert_string_equal(g_hash_table_lookup(tbl, "key-abc"), "val-def");
+
+    assert_false(g_hash_table_insert(tbl, strdup("key-ABC"), strdup("val-ABC")));
+    assert_int_equal(g_hash_table_size(tbl), 1);
+    assert_string_equal(g_hash_table_lookup(tbl, "key-ABC"), "val-ABC");
+
+    g_hash_table_destroy(tbl);
+}
+
+int main(int argc, char **argv) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(store_strs),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/strings/pcmk__strkey_table_test.c
+++ b/lib/common/tests/strings/pcmk__strkey_table_test.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <glib.h>
+
+static void
+store_strs(void **state)
+{
+    GHashTable *tbl = NULL;
+
+    tbl = pcmk__strkey_table(free, free);
+    assert_non_null(tbl);
+
+    assert_true(g_hash_table_insert(tbl, strdup("key-abc"), strdup("val-abc")));
+    assert_int_equal(g_hash_table_size(tbl), 1);
+    assert_string_equal(g_hash_table_lookup(tbl, "key-abc"), "val-abc");
+
+    assert_false(g_hash_table_insert(tbl, strdup("key-abc"), strdup("val-def")));
+    assert_int_equal(g_hash_table_size(tbl), 1);
+    assert_string_equal(g_hash_table_lookup(tbl, "key-abc"), "val-def");
+
+    assert_true(g_hash_table_insert(tbl, strdup("key-ABC"), strdup("val-abc")));
+    assert_int_equal(g_hash_table_size(tbl), 2);
+    assert_string_equal(g_hash_table_lookup(tbl, "key-ABC"), "val-abc");
+
+    g_hash_table_destroy(tbl);
+}
+
+int main(int argc, char **argv) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(store_strs),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/strings/pcmk__trim_test.c
+++ b/lib/common/tests/strings/pcmk__trim_test.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <string.h>
+
+static void
+empty_input(void **state)
+{
+    char *s = strdup("");
+
+    assert_null(pcmk__trim(NULL));
+    assert_string_equal(pcmk__trim(s), "");
+
+    free(s);
+}
+
+static void
+leading_newline(void **state)
+{
+    char *s = strdup("\nabcd");
+
+    assert_string_equal(pcmk__trim(s), "\nabcd");
+    free(s);
+}
+
+static void
+middle_newline(void **state)
+{
+    char *s = strdup("ab\ncd");
+
+    assert_string_equal(pcmk__trim(s), "ab\ncd");
+    free(s);
+}
+
+static void
+trailing_newline(void **state)
+{
+    char *s = strdup("abcd\n\n");
+
+    assert_string_equal(pcmk__trim(s), "abcd");
+    free(s);
+
+    s = strdup("abcd\n ");
+    assert_string_equal(pcmk__trim(s), "abcd\n ");
+    free(s);
+}
+
+static void
+other_whitespace(void **state)
+{
+    char *s = strdup("  ab\t\ncd  \t");
+
+    assert_string_equal(pcmk__trim(s), "  ab\t\ncd  \t");
+    free(s);
+}
+
+int main(int argc, char **argv) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(empty_input),
+        cmocka_unit_test(leading_newline),
+        cmocka_unit_test(middle_newline),
+        cmocka_unit_test(trailing_newline),
+        cmocka_unit_test(other_whitespace),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Note that these tests could do a lot more, but I did not worry about trying to pass NULL in for a lot of parameters and seeing what happens.  It's obvious from looking at most of them that they do not handle NULL arguments in a lot of cases and we're not worried about that at the moment.

After applying these patches, the only parts left without code coverage are:

In scan_ll:
```
      58         147 :         } else if (errno != 0) {
      59           0 :             rc = errno;
      60           0 :             local_result = default_value;
      61           0 :             crm_warn("Could not parse integer from '%s' (using %lld instead): "
      62             :                      "%s", text, default_value, pcmk_rc_str(rc));
```
I'm not sure we can ever hit this, at least not with glibc.

In pcmk__scan_double:
```
     264           3 :                 if (strchr("0.eE", *p) == NULL) {
     265           0 :                     rc = pcmk_rc_underflow;
     266           0 :                     crm_debug("Floating-point value parsed from '%s' would "
     267             :                               "underflow (using %g instead)", text, *result);
     268           0 :                     break;
     269             :                 }
```
I don't understand what combination of factors would let us get to this point.

In pcmk__guint_from_hash:
```
     320           3 :     rc = pcmk__scan_ll(value, &value_ll, 0LL);
     321           3 :     if (rc != pcmk_rc_ok) {
     322           0 :         return rc;
     323             :     }
```
I just can't seem to pass it any bad data that would cause this to happen.