### PR TITLE
Improve failure messages

### DIFF
--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the Pacemaker project contributors
+ * Copyright 2013-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -773,9 +773,7 @@ attrd_lookup_or_create_value(GHashTable *values, const char *host, xmlNode *xml)
         v = calloc(1, sizeof(attribute_value_t));
         CRM_ASSERT(v != NULL);
 
-        v->nodename = strdup(host);
-        CRM_ASSERT(v->nodename != NULL);
-
+        pcmk__str_update(&v->nodename, host);
         v->is_remote = is_remote;
         g_hash_table_replace(values, v->nodename, v);
     }
@@ -941,8 +939,7 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
     } else if (!pcmk__str_eq(v->current, value, pcmk__str_casei)) {
         crm_notice("Setting %s[%s]: %s -> %s " CRM_XS " from %s",
                    attr, host, v->current? v->current : "(unset)", value? value : "(unset)", peer->uname);
-        free(v->current);
-        v->current = (value? strdup(value) : NULL);
+        pcmk__str_update(&v->current, value);
         a->changed = TRUE;
 
         if (pcmk__str_eq(host, attrd_cluster->uname, pcmk__str_casei)
@@ -1230,10 +1227,7 @@ set_alert_attribute_value(GHashTable *t, attribute_value_t *v)
 
     a_v->nodeid = v->nodeid;
     a_v->nodename = strdup(v->nodename);
-
-    if (v->current != NULL) {
-        a_v->current = strdup(v->current);
-    }
+    pcmk__str_update(&a_v->current, v->current);
 
     g_hash_table_replace(t, a_v->nodename, a_v);
 }

--- a/daemons/attrd/attrd_elections.c
+++ b/daemons/attrd/attrd_elections.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the Pacemaker project contributors
+ * Copyright 2013-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -81,8 +81,7 @@ attrd_handle_election_op(const crm_node_t *peer, xmlNode *xml)
              * Approximate a test for that case as best as possible.
              */
             if ((peer_writer == NULL) || (previous != election_lost)) {
-                free(peer_writer);
-                peer_writer = strdup(peer->uname);
+                pcmk__str_update(&peer_writer, peer->uname);
                 crm_debug("Election lost, presuming %s is writer for now",
                           peer_writer);
             }
@@ -114,8 +113,7 @@ attrd_check_for_new_writer(const crm_node_t *peer, const xmlNode *xml)
         } else if (!pcmk__str_eq(peer->uname, peer_writer, pcmk__str_casei)) {
             crm_notice("Recorded new attribute writer: %s (was %s)",
                        peer->uname, (peer_writer? peer_writer : "unset"));
-            free(peer_writer);
-            peer_writer = strdup(peer->uname);
+            pcmk__str_update(&peer_writer, peer->uname);
         }
     }
     return (peer_state == election_won);
@@ -126,8 +124,7 @@ attrd_declare_winner()
 {
     crm_notice("Recorded local node as attribute writer (was %s)",
                (peer_writer? peer_writer : "unset"));
-    free(peer_writer);
-    peer_writer = strdup(attrd_cluster->uname);
+    pcmk__str_update(&peer_writer, attrd_cluster->uname);
 }
 
 void

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -186,11 +186,7 @@ update_history_cache(lrm_state_t * lrm_state, lrmd_rsc_info_t * rsc, lrmd_event_
         entry->rsc.id = entry->id;
         entry->rsc.type = strdup(rsc->type);
         entry->rsc.standard = strdup(rsc->standard);
-        if (rsc->provider) {
-            entry->rsc.provider = strdup(rsc->provider);
-        } else {
-            entry->rsc.provider = NULL;
-        }
+        pcmk__str_update(&entry->rsc.provider, rsc->provider);
 
     } else if (entry == NULL) {
         crm_info("Resource %s no longer exists, not updating cache", op->rsc_id);
@@ -2364,7 +2360,7 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc,
         pending->op_key = strdup(op_id);
         pending->rsc_id = strdup(rsc->id);
         pending->start_time = time(NULL);
-        pending->user_data = op->user_data? strdup(op->user_data) : NULL;
+        pcmk__str_update(&pending->user_data, op->user_data);
         if (crm_element_value_epoch(msg, XML_CONFIG_ATTR_SHUTDOWN_LOCK,
                                     &(pending->lock_time)) != pcmk_ok) {
             pending->lock_time = 0;

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -373,10 +373,9 @@ do_dc_join_filter_offer(long long action,
         crm_log_xml_debug(max_generation_xml, "Old max generation");
         crm_log_xml_debug(generation, "New max generation");
 
-        free(max_generation_from);
-        free_xml(max_generation_xml);
+        pcmk__str_update(&max_generation_from, join_from);
 
-        max_generation_from = strdup(join_from);
+        free_xml(max_generation_xml);
         max_generation_xml = copy_xml(join_ack->xml);
 
     } else {

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the Pacemaker project contributors
+ * Copyright 2013-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -627,9 +627,10 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
             } else {
                 crm_trace("can't reschedule start, remaining timeout too small %d",
                           cmd->remaining_timeout);
-                pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
-                                 PCMK_EXEC_TIMEOUT,
-                                 pcmk_strerror(op->connection_rc));
+                pcmk__format_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
+                                    PCMK_EXEC_TIMEOUT,
+                                    "%s without enough time to retry",
+                                    pcmk_strerror(op->connection_rc));
             }
 
         } else {
@@ -760,8 +761,10 @@ handle_remote_ra_start(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd, int timeo
     rc = controld_connect_remote_executor(lrm_state, server, port,
                                           timeout_used);
     if (rc != pcmk_rc_ok) {
-        pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
-                         PCMK_EXEC_ERROR, pcmk_rc_str(rc));
+        pcmk__format_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
+                            PCMK_EXEC_ERROR,
+                            "Could not connect to Pacemaker Remote node %s: %s",
+                            lrm_state->node_name, pcmk_rc_str(rc));
     }
     return rc;
 }

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -613,11 +613,12 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
         if (op->connection_rc < 0) {
             update_remaining_timeout(cmd);
 
-            if (op->connection_rc == -ENOKEY) {
+            if ((op->connection_rc == -ENOKEY)
+                || (op->connection_rc == -EKEYREJECTED)) {
                 // Hard error, don't retry
                 pcmk__set_result(&(cmd->result), PCMK_OCF_INVALID_PARAM,
                                  PCMK_EXEC_ERROR,
-                                 "Authentication key not readable");
+                                 pcmk_strerror(op->connection_rc));
 
             } else if (cmd->remaining_timeout > 3000) {
                 crm_trace("rescheduling start, remaining timeout %d", cmd->remaining_timeout);

--- a/daemons/controld/controld_utils.c
+++ b/daemons/controld/controld_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -724,17 +724,9 @@ update_dc(xmlNode * msg)
         }
     }
 
-    free(fsa_our_dc_version);
-    fsa_our_dc_version = NULL;
-
     fsa_our_dc = NULL;          /* Free'd as last_dc */
-
-    if (welcome_from != NULL) {
-        fsa_our_dc = strdup(welcome_from);
-    }
-    if (dc_version != NULL) {
-        fsa_our_dc_version = strdup(dc_version);
-    }
+    pcmk__str_update(&fsa_our_dc, welcome_from);
+    pcmk__str_update(&fsa_our_dc_version, dc_version);
 
     if (pcmk__str_eq(fsa_our_dc, last_dc, pcmk__str_casei)) {
         /* do nothing */

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1097,7 +1097,7 @@ schedule_internal_command(const char *origin,
     cmd->default_timeout = timeout ? timeout : 60;
     cmd->timeout = cmd->default_timeout;
     cmd->action = strdup(action);
-    cmd->victim = victim ? strdup(victim) : NULL;
+    pcmk__str_update(&cmd->victim, victim);
     cmd->device = strdup(device->id);
     cmd->origin = strdup(origin);
     cmd->client = strdup(crm_system_name);
@@ -2109,8 +2109,8 @@ get_capable_devices(const char *host, const char *action, int timeout, bool suic
         return;
     }
 
-    search->host = host ? strdup(host) : NULL;
-    search->action = action ? strdup(action) : NULL;
+    pcmk__str_update(&search->host, host);
+    pcmk__str_update(&search->action, action);
     search->per_device_timeout = timeout;
     search->allow_suicide = suicide;
     search->callback = callback;
@@ -2357,10 +2357,10 @@ stonith_query(xmlNode * msg, const char *remote_peer, const char *client_id, int
 
     pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
     query->reply = fenced_construct_reply(msg, NULL, &result);
-    query->remote_peer = remote_peer ? strdup(remote_peer) : NULL;
-    query->client_id = client_id ? strdup(client_id) : NULL;
-    query->target = target ? strdup(target) : NULL;
-    query->action = action ? strdup(action) : NULL;
+    pcmk__str_update(&query->remote_peer, remote_peer);
+    pcmk__str_update(&query->client_id, client_id);
+    pcmk__str_update(&query->target, target);
+    pcmk__str_update(&query->action, action);
     query->call_options = call_options;
 
     get_capable_devices(target, action, timeout,

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2021 the Pacemaker project contributors
+ * Copyright 2009-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -72,6 +72,7 @@ static void search_devices_record_result(struct device_search_s *search, const c
 
 static int get_agent_metadata(const char *agent, xmlNode **metadata);
 static void read_action_metadata(stonith_device_t *device);
+static int stonith_level_kind(xmlNode *level);
 
 typedef struct async_command_s {
 
@@ -1529,7 +1530,8 @@ char *stonith_level_key(xmlNode *level, int mode)
     }
 }
 
-int stonith_level_kind(xmlNode * level)
+static int
+stonith_level_kind(xmlNode *level)
 {
     int mode = 0;
     const char *target = crm_element_value(level, XML_ATTR_STONITH_TARGET);

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -829,8 +829,8 @@ topology_matches(const stonith_topology_t *tp, const char *node)
     regex_t r_patt;
 
     CRM_CHECK(node && tp && tp->target, return FALSE);
-    switch(tp->kind) {
-        case 2:
+    switch (tp->kind) {
+        case fenced_target_by_attribute:
             /* This level targets by attribute, so tp->target is a NAME=VALUE pair
              * of a permanent attribute applied to targeted nodes. The test below
              * relies on the locally cached copy of the CIB, so if fencing needs to
@@ -842,11 +842,11 @@ topology_matches(const stonith_topology_t *tp, const char *node)
                 return TRUE;
             }
             break;
-        case 1:
-            /* This level targets by name, so tp->target is a regular expression
-             * matching names of nodes to be targeted.
-             */
 
+        case fenced_target_by_pattern:
+            /* This level targets node names matching a pattern, so tp->target
+             * (and tp->target_pattern) is a regular expression.
+             */
             if (regcomp(&r_patt, tp->target_pattern, REG_EXTENDED|REG_NOSUB)) {
                 crm_info("Bad regex '%s' for fencing level", tp->target);
             } else {
@@ -859,9 +859,13 @@ topology_matches(const stonith_topology_t *tp, const char *node)
                 }
             }
             break;
-        case 0:
+
+        case fenced_target_by_name:
             crm_trace("Testing %s against %s", node, tp->target);
             return pcmk__str_eq(tp->target, node, pcmk__str_casei);
+
+        default:
+            break;
     }
     crm_trace("No match for %s with %s", node, tp->target);
     return FALSE;

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -476,9 +476,7 @@ finalize_op_duplicates(remote_fencing_op_t *op, xmlNode *data)
                       other->client_name, other->originator,
                       pcmk_exec_status_str(op->result.execution_status),
                       other->id);
-            pcmk__set_result(&other->result, op->result.exit_status,
-                             op->result.execution_status,
-                             op->result.exit_reason);
+            pcmk__copy_result(&op->result, &other->result);
             finalize_op(other, data, true);
 
         } else {

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -502,7 +502,7 @@ handle_topology_change(xmlNode *match, bool remove)
 
     if(remove) {
         int index = 0;
-        char *key = stonith_level_key(match, -1);
+        char *key = stonith_level_key(match, fenced_target_by_unknown);
 
         crm_element_value_int(match, XML_ATTR_STONITH_INDEX, &index);
         topology_remove_helper(key, index);
@@ -527,7 +527,7 @@ remove_fencing_topology(xmlXPathObjectPtr xpathObj)
         if (match && crm_element_value(match, XML_DIFF_MARKER)) {
             /* Deletion */
             int index = 0;
-            char *target = stonith_level_key(match, -1);
+            char *target = stonith_level_key(match, fenced_target_by_unknown);
 
             crm_element_value_int(match, XML_ATTR_STONITH_INDEX, &index);
             if (target == NULL) {

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -167,6 +167,14 @@ enum st_client_flags {
     st_callback_notify_history_synced = (UINT64_C(1) << 6)
 };
 
+// How the user specified the target of a topology level
+enum fenced_target_by {
+    fenced_target_by_unknown = -1,  // Invalid or not yet parsed
+    fenced_target_by_name,          // By target name
+    fenced_target_by_pattern,       // By a pattern matching target names
+    fenced_target_by_attribute,     // By a node attribute/value on target
+};
+
 /*
  * Complex fencing requirements are specified via fencing topologies.
  * A topology consists of levels; each level is a list of fencing devices.
@@ -182,7 +190,7 @@ enum st_client_flags {
  * Topology levels start from 1, so levels[0] is unused and always NULL.
  */
 typedef struct stonith_topology_s {
-    int kind;
+    enum fenced_target_by kind; // How target was specified
 
     /*! Node name regex or attribute name=value for which topology applies */
     char *target;

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -213,7 +213,6 @@ int stonith_device_register(xmlNode * msg, const char **desc, gboolean from_cib)
 void stonith_device_remove(const char *id, bool from_cib);
 
 char *stonith_level_key(xmlNode * msg, int mode);
-int stonith_level_kind(xmlNode * msg);
 void fenced_register_level(xmlNode *msg, char **desc,
                            pcmk__action_result_t *result);
 void fenced_unregister_level(xmlNode *msg, char **desc,

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 the Pacemaker project contributors
+ * Copyright 2010-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -253,11 +253,7 @@ get_config_opt(uint64_t unused, cmap_handle_t object_handle, const char *key, ch
     cs_repeat(retries, 5, rc = cmap_get_string(object_handle, key, value));
     if (rc != CS_OK) {
         crm_trace("Search for %s failed %d, defaulting to %s", key, rc, fallback);
-        if (fallback) {
-            *value = strdup(fallback);
-        } else {
-            *value = NULL;
-        }
+        pcmk__str_update(value, fallback);
     }
     crm_trace("%s: %s", key, *value);
     return rc;

--- a/include/crm/common/results_internal.h
+++ b/include/crm/common/results_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the Pacemaker project contributors
+ * Copyright 2020-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -48,6 +48,10 @@ typedef struct {
 void pcmk__set_result(pcmk__action_result_t *result, int exit_status,
                       enum pcmk_exec_status exec_status,
                       const char *exit_reason);
+
+void pcmk__format_result(pcmk__action_result_t *result, int exit_status,
+                         enum pcmk_exec_status exec_status,
+                         const char *format, ...) G_GNUC_PRINTF(4, 5);
 
 void pcmk__set_result_output(pcmk__action_result_t *result,
                              char *out, char *err);

--- a/include/crm/common/results_internal.h
+++ b/include/crm/common/results_internal.h
@@ -54,6 +54,8 @@ void pcmk__set_result_output(pcmk__action_result_t *result,
 
 void pcmk__reset_result(pcmk__action_result_t *result);
 
+void pcmk__copy_result(pcmk__action_result_t *src, pcmk__action_result_t *dst);
+
 /*!
  * \internal
  * \brief Check whether a result is OK

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the Pacemaker project contributors
+ * Copyright 2015-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -126,6 +126,7 @@ bool pcmk__char_in_any_str(int ch, ...) G_GNUC_NULL_TERMINATED;
 
 int pcmk__strcmp(const char *s1, const char *s2, uint32_t flags);
 int pcmk__numeric_strcasecmp(const char *s1, const char *s2);
+void pcmk__str_update(char **str, const char *value);
 
 static inline bool
 pcmk__str_eq(const char *s1, const char *s2, uint32_t flags)

--- a/include/crm/services.h
+++ b/include/crm/services.h
@@ -43,6 +43,7 @@ extern "C" {
 #define PCMK_RESOURCE_CLASS_UPSTART "upstart"
 #define PCMK_RESOURCE_CLASS_NAGIOS  "nagios"
 #define PCMK_RESOURCE_CLASS_STONITH "stonith"
+#define PCMK_RESOURCE_CLASS_ALERT   "alert"
 
 /* This is the string passed in the OCF_EXIT_REASON_PREFIX environment variable.
  * The stderr output that occurs after this prefix is encountered is considered

--- a/include/crm/services_internal.h
+++ b/include/crm/services_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 the Pacemaker project contributors
+ * Copyright 2010-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -46,6 +46,10 @@ char *services__grab_stderr(svc_action_t *action);
 void services__set_result(svc_action_t *action, int agent_status,
                           enum pcmk_exec_status exec_status,
                           const char *exit_reason);
+
+void services__format_result(svc_action_t *action, int agent_status,
+                             enum pcmk_exec_status exec_status,
+                             const char *format, ...) G_GNUC_PRINTF(4, 5);
 
 #  ifdef __cplusplus
 }

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -158,11 +158,7 @@ find_nvpair_attr_delegate(cib_t * the_cib, const char *attr, const char *section
         }
 
     } else {
-        const char *tmp = crm_element_value(xml_search, attr);
-
-        if (tmp) {
-            *value = strdup(tmp);
-        }
+        pcmk__str_update(value, crm_element_value(xml_search, attr));
     }
 
   done:

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the Pacemaker project contributors
+ * Copyright 2008-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -121,17 +121,9 @@ cib_remote_new(const char *server, const char *user, const char *passwd, int por
     cib->variant = cib_remote;
     cib->variant_opaque = private;
 
-    if (server) {
-        private->server = strdup(server);
-    }
-
-    if (user) {
-        private->user = strdup(user);
-    }
-
-    if (passwd) {
-        private->passwd = strdup(passwd);
-    }
+    pcmk__str_update(&private->server, server);
+    pcmk__str_update(&private->user, user);
+    pcmk__str_update(&private->passwd, passwd);
 
     private->port = port;
     private->encrypted = encrypted;

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -303,8 +303,7 @@ pcmk__unpack_acl(xmlNode *source, xmlNode *target, const char *user)
         xmlNode *acls = get_xpath_object("//" XML_CIB_TAG_ACLS,
                                          source, LOG_NEVER);
 
-        free(p->user);
-        p->user = strdup(user);
+        pcmk__str_update(&p->user, user);
 
         if (acls) {
             xmlNode *child = NULL;

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the Pacemaker project contributors
+ * Copyright 2015-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -137,12 +137,8 @@ pcmk__dup_alert(pcmk__alert_t *entry)
     new_entry->timeout = entry->timeout;
     new_entry->flags = entry->flags;
     new_entry->envvars = pcmk__str_table_dup(entry->envvars);
-    if (entry->tstamp_format) {
-        new_entry->tstamp_format = strdup(entry->tstamp_format);
-    }
-    if (entry->recipient) {
-        new_entry->recipient = strdup(entry->recipient);
-    }
+    pcmk__str_update(&new_entry->tstamp_format, entry->tstamp_format);
+    pcmk__str_update(&new_entry->recipient, entry->recipient);
     if (entry->select_attribute_name) {
         new_entry->select_attribute_name = g_strdupv(entry->select_attribute_name);
     }

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -1272,7 +1272,7 @@ mainloop_child_add_with_flags(pid_t pid, int timeout, const char *desc, void *pr
                    void (*callback) (mainloop_child_t * p, pid_t pid, int core, int signo, int exitcode))
 {
     static bool need_init = TRUE;
-    mainloop_child_t *child = g_new(mainloop_child_t, 1);
+    mainloop_child_t *child = calloc(1, sizeof(mainloop_child_t));
 
     child->pid = pid;
     child->timerid = 0;

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -1280,10 +1280,7 @@ mainloop_child_add_with_flags(pid_t pid, int timeout, const char *desc, void *pr
     child->privatedata = privatedata;
     child->callback = callback;
     child->flags = flags;
-
-    if(desc) {
-        child->desc = strdup(desc);
-    }
+    pcmk__str_update(&child->desc, desc);
 
     if (timeout) {
         child->timerid = g_timeout_add(timeout, child_timeout_callback, child);

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -53,8 +53,8 @@ pcmk__new_nvpair(const char *name, const char *value)
     nvpair = calloc(1, sizeof(pcmk_nvpair_t));
     CRM_ASSERT(nvpair);
 
-    nvpair->name = strdup(name);
-    nvpair->value = value? strdup(value) : NULL;
+    pcmk__str_update(&nvpair->name, name);
+    pcmk__str_update(&nvpair->value, value);
     return nvpair;
 }
 
@@ -726,11 +726,8 @@ char *
 crm_element_value_copy(const xmlNode *data, const char *name)
 {
     char *value_copy = NULL;
-    const char *value = crm_element_value(data, name);
 
-    if (value != NULL) {
-        value_copy = strdup(value);
-    }
+    pcmk__str_update(&value_copy, crm_element_value(data, name));
     return value_copy;
 }
 

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the Pacemaker project contributors
+ * Copyright 2019-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -187,8 +187,8 @@ text_begin_list(pcmk__output_t *out, const char *singular_noun, const char *plur
 
     new_list = calloc(1, sizeof(text_list_data_t));
     new_list->len = 0;
-    new_list->singular_noun = singular_noun == NULL ? NULL : strdup(singular_noun);
-    new_list->plural_noun = plural_noun == NULL ? NULL : strdup(plural_noun);
+    pcmk__str_update(&new_list->singular_noun, singular_noun);
+    pcmk__str_update(&new_list->plural_noun, plural_noun);
 
     g_queue_push_tail(priv->parent_q, new_list);
 }

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -926,9 +926,7 @@ pcmk__reset_result(pcmk__action_result_t *result)
 void
 pcmk__copy_result(pcmk__action_result_t *src, pcmk__action_result_t *dst)
 {
-    if ((src == NULL) || (dst == NULL)) {
-        return;
-    }
+    CRM_CHECK((src != NULL) && (dst != NULL), return);
     dst->exit_status = src->exit_status;
     dst->execution_status = src->execution_status;
     pcmk__str_update(&src->exit_reason, dst->exit_reason);

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -931,31 +931,7 @@ pcmk__copy_result(pcmk__action_result_t *src, pcmk__action_result_t *dst)
     }
     dst->exit_status = src->exit_status;
     dst->execution_status = src->execution_status;
-
-    if (!pcmk__str_eq(src->exit_reason, dst->exit_reason, pcmk__str_none)) {
-        free(dst->exit_reason);
-        if (src->exit_reason == NULL) {
-            dst->exit_reason = NULL;
-        } else {
-            dst->exit_reason = strdup(src->exit_reason);
-        }
-    }
-
-    if (!pcmk__str_eq(src->action_stdout, dst->action_stdout, pcmk__str_none)) {
-        free(dst->action_stdout);
-        if (src->action_stdout == NULL) {
-            dst->action_stdout = NULL;
-        } else {
-            dst->action_stdout = strdup(src->action_stdout);
-        }
-    }
-
-    if (!pcmk__str_eq(src->action_stderr, dst->action_stderr, pcmk__str_none)) {
-        free(dst->action_stderr);
-        if (src->action_stderr == NULL) {
-            dst->action_stderr = NULL;
-        } else {
-            dst->action_stderr = strdup(src->action_stderr);
-        }
-    }
+    pcmk__str_update(&src->exit_reason, dst->exit_reason);
+    pcmk__str_update(&src->action_stdout, dst->action_stdout);
+    pcmk__str_update(&src->action_stderr, dst->action_stderr);
 }

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -876,3 +876,47 @@ pcmk__reset_result(pcmk__action_result_t *result)
     free(result->action_stderr);
     result->action_stderr = NULL;
 }
+
+/*!
+ * \internal
+ * \brief Copy the result of an action
+ *
+ * \param[in]  src  Result to copy
+ * \param[out] dst  Where to copy \p src to
+ */
+void
+pcmk__copy_result(pcmk__action_result_t *src, pcmk__action_result_t *dst)
+{
+    if ((src == NULL) || (dst == NULL)) {
+        return;
+    }
+    dst->exit_status = src->exit_status;
+    dst->execution_status = src->execution_status;
+
+    if (!pcmk__str_eq(src->exit_reason, dst->exit_reason, pcmk__str_none)) {
+        free(dst->exit_reason);
+        if (src->exit_reason == NULL) {
+            dst->exit_reason = NULL;
+        } else {
+            dst->exit_reason = strdup(src->exit_reason);
+        }
+    }
+
+    if (!pcmk__str_eq(src->action_stdout, dst->action_stdout, pcmk__str_none)) {
+        free(dst->action_stdout);
+        if (src->action_stdout == NULL) {
+            dst->action_stdout = NULL;
+        } else {
+            dst->action_stdout = strdup(src->action_stdout);
+        }
+    }
+
+    if (!pcmk__str_eq(src->action_stderr, dst->action_stderr, pcmk__str_none)) {
+        free(dst->action_stderr);
+        if (src->action_stderr == NULL) {
+            dst->action_stderr = NULL;
+        } else {
+            dst->action_stderr = strdup(src->action_stderr);
+        }
+    }
+}

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -825,6 +825,45 @@ pcmk__set_result(pcmk__action_result_t *result, int exit_status,
         free(result->exit_reason);
         result->exit_reason = (exit_reason == NULL)? NULL : strdup(exit_reason);
     }
+}
+
+
+/*!
+ * \internal
+ * \brief Set the result of an action, with a formatted exit reason
+ *
+ * \param[out] result        Where to set action result
+ * \param[in]  exit_status   OCF exit status to set
+ * \param[in]  exec_status   Execution status to set
+ * \param[in]  format        printf-style format for a human-friendly
+ *                           description of reason for result
+ * \param[in]  ...           arguments for \p format
+ */
+G_GNUC_PRINTF(4, 5)
+void
+pcmk__format_result(pcmk__action_result_t *result, int exit_status,
+                    enum pcmk_exec_status exec_status,
+                    const char *format, ...)
+{
+    va_list ap;
+    int len = 0;
+    char *reason = NULL;
+
+    if (result == NULL) {
+        return;
+    }
+
+    result->exit_status = exit_status;
+    result->execution_status = exec_status;
+
+    if (format != NULL) {
+        va_start(ap, format);
+        len = vasprintf(&reason, format, ap);
+        CRM_ASSERT(len > 0);
+        va_end(ap);
+    }
+    free(result->exit_reason);
+    result->exit_reason = reason;
 }
 
 /*!

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1168,6 +1168,33 @@ pcmk__strcmp(const char *s1, const char *s2, uint32_t flags)
         return strcasecmp(s1, s2);
     } else {
         return strcmp(s1, s2);
+    }
+}
+
+/*!
+ * \internal
+ * \brief Update a dynamically allocated string with a new value
+ *
+ * Given a dynamically allocated string and a new value for it, if the string
+ * is different from the new value, free the string and replace it with either a
+ * newly allocated duplicate of the value or NULL as appropriate.
+ *
+ * \param[in] str    Pointer to dynamically allocated string
+ * \param[in] value  New value to duplicate (or NULL)
+ *
+ * \note The caller remains responsibile for freeing \p *str.
+ */
+void
+pcmk__str_update(char **str, const char *value)
+{
+    if ((str != NULL) && !pcmk__str_eq(*str, value, pcmk__str_none)) {
+        free(*str);
+        if (value == NULL) {
+            *str = NULL;
+        } else {
+            *str = strdup(value);
+            CRM_ASSERT(*str != NULL);
+        }
     }
 }
 

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -32,6 +32,7 @@ check_PROGRAMS = \
 		pcmk__str_any_of_test		\
 		pcmk__str_in_list_test		\
 		pcmk__str_table_dup_test	\
+		pcmk__str_update_test		\
 		pcmk__strcmp_test 			\
 		pcmk__strkey_table_test 	\
 		pcmk__strikey_table_test 	\

--- a/lib/common/tests/strings/pcmk__str_update_test.c
+++ b/lib/common/tests/strings/pcmk__str_update_test.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+static void
+update_null(void **state) {
+    char *str = NULL;
+
+    // These just make sure they don't crash
+    pcmk__str_update(NULL, NULL);
+    pcmk__str_update(NULL, "value");
+
+    // Update an already NULL string to NULL
+    pcmk__str_update(&str, NULL);
+    assert_null(str);
+
+    // Update an already allocated string to NULL
+    str = strdup("hello");
+    pcmk__str_update(&str, NULL);
+    assert_null(str);
+}
+
+static void
+update_same(void **state) {
+    char *str = NULL;
+    char *saved = NULL;
+
+    str = strdup("hello");
+    saved = str;
+    pcmk__str_update(&str, "hello");
+    assert_ptr_equal(saved, str); // No free and reallocation
+    free(str);
+}
+
+static void
+update_different(void **state) {
+    char *str = NULL;
+
+    str = strdup("hello");
+    pcmk__str_update(&str, "world");
+    assert_string_equal(str, "world");
+    free(str);
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(update_null),
+        cmocka_unit_test(update_same),
+        cmocka_unit_test(update_different),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -618,12 +618,11 @@ internal_stonith_action_execute(stonith_action_t * action)
     }
 
     if (action->async) {
-        /* async */
-        if (services_action_async_fork_notify(svc_action,
+        // We never create a recurring action, so this should always return TRUE
+        CRM_LOG_ASSERT(services_action_async_fork_notify(svc_action,
                                               &stonith_action_async_done,
-                                              &stonith_action_async_forked)) {
-            return pcmk_ok;
-        }
+                                              &stonith_action_async_forked));
+        return pcmk_ok;
 
     } else if (services_action_sync(svc_action)) { // sync success
         rc = pcmk_ok;

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -251,9 +251,7 @@ stonith_action_create(const char *agent,
               _action, (victim? victim : "no target"), agent);
     action->agent = strdup(agent);
     action->action = strdup(_action);
-    if (victim) {
-        action->victim = strdup(victim);
-    }
+    pcmk__str_update(&action->victim, victim);
     action->timeout = action->remaining_timeout = timeout;
     action->max_retries = FAILURE_MAX_RETRIES;
 

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1870,12 +1870,8 @@ stonith_key_value_add(stonith_key_value_t * head, const char *key, const char *v
     stonith_key_value_t *p, *end;
 
     p = calloc(1, sizeof(stonith_key_value_t));
-    if (key) {
-        p->key = strdup(key);
-    }
-    if (value) {
-        p->value = strdup(value);
-    }
+    pcmk__str_update(&p->key, key);
+    pcmk__str_update(&p->value, value);
 
     end = head;
     while (end && end->next) {

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -29,6 +29,7 @@
 
 CRM_TRACE_INIT_DATA(stonith);
 
+// Used as stonith_t:st_private
 typedef struct stonith_private_s {
     char *token;
     crm_ipc_t *ipc;
@@ -41,6 +42,11 @@ typedef struct stonith_private_s {
     void (*op_callback) (stonith_t * st, stonith_callback_data_t * data);
 
 } stonith_private_t;
+
+// Used as stonith_event_t:opaque
+struct event_private {
+    pcmk__action_result_t result;
+};
 
 typedef struct stonith_notify_client_s {
     const char *event;
@@ -1380,21 +1386,25 @@ get_event_data_xml(xmlNode *msg, const char *ntype)
  </notify>
 */
 static stonith_event_t *
-xml_to_event(xmlNode *msg, pcmk__action_result_t *result)
+xml_to_event(xmlNode *msg)
 {
     stonith_event_t *event = calloc(1, sizeof(stonith_event_t));
     const char *ntype = crm_element_value(msg, F_SUBTYPE);
+    struct event_private *event_private = NULL;
 
-    CRM_ASSERT((event != NULL) && (result != NULL));
+    CRM_ASSERT(event != NULL);
+
+    event->opaque = calloc(1, sizeof(struct event_private));
+    CRM_ASSERT(event->opaque != NULL);
+    event_private = (struct event_private *) event->opaque;
 
     crm_log_xml_trace(msg, "stonith_notify");
 
     // All notification types have the operation result
-    event->opaque = result;
-    stonith__xe_get_result(msg, result);
+    stonith__xe_get_result(msg, &event_private->result);
 
     // @COMPAT The API originally provided the result as a legacy return code
-    event->result = pcmk_rc2legacy(stonith__result2rc(result));
+    event->result = pcmk_rc2legacy(stonith__result2rc(&event_private->result));
 
     // Fence notifications have additional information
     if (pcmk__str_eq(ntype, T_STONITH_NOTIFY_FENCE, pcmk__str_casei)) {
@@ -1421,6 +1431,8 @@ xml_to_event(xmlNode *msg, pcmk__action_result_t *result)
 static void
 event_free(stonith_event_t * event)
 {
+    struct event_private *event_private = event->opaque;
+
     free(event->id);
     free(event->type);
     free(event->message);
@@ -1431,7 +1443,8 @@ event_free(stonith_event_t * event)
     free(event->executioner);
     free(event->device);
     free(event->client_origin);
-    pcmk__reset_result((pcmk__action_result_t *) (event->opaque));
+    pcmk__reset_result(&event_private->result);
+    free(event->opaque);
     free(event);
 }
 
@@ -1442,7 +1455,6 @@ stonith_send_notification(gpointer data, gpointer user_data)
     stonith_notify_client_t *entry = data;
     stonith_event_t *st_event = NULL;
     const char *event = NULL;
-    pcmk__action_result_t result = PCMK__UNKNOWN_RESULT;
 
     if (blob->xml == NULL) {
         crm_warn("Skipping callback - NULL message");
@@ -1468,7 +1480,7 @@ stonith_send_notification(gpointer data, gpointer user_data)
         return;
     }
 
-    st_event = xml_to_event(blob->xml, &result);
+    st_event = xml_to_event(blob->xml);
 
     crm_trace("Invoking callback for %p/%s event...", entry, event);
     entry->notify(blob->stonith, st_event);
@@ -2422,8 +2434,11 @@ stonith__event_exit_status(stonith_event_t *event)
 {
     if ((event == NULL) || (event->opaque == NULL)) {
         return CRM_EX_ERROR;
+    } else {
+        struct event_private *event_private = event->opaque;
+
+        return event_private->result.exit_status;
     }
-    return ((pcmk__action_result_t *) event->opaque)->exit_status;
 }
 
 /*!
@@ -2439,8 +2454,11 @@ stonith__event_execution_status(stonith_event_t *event)
 {
     if ((event == NULL) || (event->opaque == NULL)) {
         return PCMK_EXEC_UNKNOWN;
+    } else {
+        struct event_private *event_private = event->opaque;
+
+        return event_private->result.execution_status;
     }
-    return ((pcmk__action_result_t *) event->opaque)->execution_status;
 }
 
 /*!
@@ -2456,8 +2474,11 @@ stonith__event_exit_reason(stonith_event_t *event)
 {
     if ((event == NULL) || (event->opaque == NULL)) {
         return NULL;
+    } else {
+        struct event_private *event_private = event->opaque;
+
+        return event_private->result.exit_reason;
     }
-    return ((pcmk__action_result_t *) event->opaque)->exit_reason;
 }
 
 /*!

--- a/lib/fencing/st_lha.c
+++ b/lib/fencing/st_lha.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -142,15 +142,6 @@ stonith__list_lha_agents(stonith_key_value_t **devices)
     return count;
 }
 
-static inline char *
-strdup_null(const char *val)
-{
-    if (val) {
-        return strdup(val);
-    }
-    return NULL;
-}
-
 static void
 stonith_plugin(int priority, const char *fmt, ...) G_GNUC_PRINTF(2, 3);
 
@@ -213,19 +204,22 @@ stonith__lha_metadata(const char *agent, int timeout, char **output)
         stonith_obj = (*st_new_fn) (agent);
         if (stonith_obj) {
             (*st_log_fn) (stonith_obj, (PILLogFun) & stonith_plugin);
-            meta_longdesc = strdup_null((*st_info_fn) (stonith_obj, ST_DEVICEDESCR));
+            pcmk__str_update(&meta_longdesc,
+                             (*st_info_fn) (stonith_obj, ST_DEVICEDESCR));
             if (meta_longdesc == NULL) {
                 crm_warn("no long description in %s's metadata.", agent);
                 meta_longdesc = strdup(no_parameter_info);
             }
 
-            meta_shortdesc = strdup_null((*st_info_fn) (stonith_obj, ST_DEVICEID));
+            pcmk__str_update(&meta_shortdesc,
+                             (*st_info_fn) (stonith_obj, ST_DEVICEID));
             if (meta_shortdesc == NULL) {
                 crm_warn("no short description in %s's metadata.", agent);
                 meta_shortdesc = strdup(no_parameter_info);
             }
 
-            meta_param = strdup_null((*st_info_fn) (stonith_obj, ST_CONF_XML));
+            pcmk__str_update(&meta_param,
+                             (*st_info_fn) (stonith_obj, ST_CONF_XML));
             if (meta_param == NULL) {
                 crm_warn("no list of parameters in %s's metadata.", agent);
                 meta_param = strdup(no_parameter_info);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the Pacemaker project contributors
+ * Copyright 2012-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -197,14 +197,8 @@ lrmd_new_event(const char *rsc_id, const char *task, guint interval_ms)
     lrmd_event_data_t *event = calloc(1, sizeof(lrmd_event_data_t));
 
     CRM_ASSERT(event != NULL);
-    if (rsc_id != NULL) {
-        event->rsc_id = strdup(rsc_id);
-        CRM_ASSERT(event->rsc_id != NULL);
-    }
-    if (task != NULL) {
-        event->op_type = strdup(task);
-        CRM_ASSERT(event->op_type != NULL);
-    }
+    pcmk__str_update((char **) &event->rsc_id, rsc_id);
+    pcmk__str_update((char **) &event->op_type, task);
     event->interval_ms = interval_ms;
     return event;
 }
@@ -216,18 +210,26 @@ lrmd_copy_event(lrmd_event_data_t * event)
 
     copy = calloc(1, sizeof(lrmd_event_data_t));
 
-    /* This will get all the int values.
-     * we just have to be careful not to leave any
-     * dangling pointers to strings. */
-    memcpy(copy, event, sizeof(lrmd_event_data_t));
-
-    copy->rsc_id = event->rsc_id ? strdup(event->rsc_id) : NULL;
-    copy->op_type = event->op_type ? strdup(event->op_type) : NULL;
-    copy->user_data = event->user_data ? strdup(event->user_data) : NULL;
-    copy->output = event->output ? strdup(event->output) : NULL;
-    copy->exit_reason = event->exit_reason ? strdup(event->exit_reason) : NULL;
-    copy->remote_nodename = event->remote_nodename ? strdup(event->remote_nodename) : NULL;
+    copy->type = event->type;
+    pcmk__str_update((char **) &copy->rsc_id, event->rsc_id);
+    pcmk__str_update((char **) &copy->op_type, event->op_type);
+    pcmk__str_update((char **) &copy->user_data, event->user_data);
+    copy->call_id = event->call_id;
+    copy->timeout = event->timeout;
+    copy->interval_ms = event->interval_ms;
+    copy->start_delay = event->start_delay;
+    copy->rsc_deleted = event->rsc_deleted;
+    copy->rc = event->rc;
+    copy->op_status = event->op_status;
+    pcmk__str_update((char **) &copy->output, event->output);
+    copy->t_run = event->t_run;
+    copy->t_rcchange = event->t_rcchange;
+    copy->exec_time = event->exec_time;
+    copy->queue_time = event->queue_time;
+    copy->connection_rc = event->connection_rc;
     copy->params = pcmk__str_table_dup(event->params);
+    pcmk__str_update((char **) &copy->remote_nodename, event->remote_nodename);
+    pcmk__str_update((char **) &copy->exit_reason, event->exit_reason);
 
     return copy;
 }
@@ -1723,22 +1725,10 @@ lrmd_new_rsc_info(const char *rsc_id, const char *standard,
     lrmd_rsc_info_t *rsc_info = calloc(1, sizeof(lrmd_rsc_info_t));
 
     CRM_ASSERT(rsc_info);
-    if (rsc_id) {
-        rsc_info->id = strdup(rsc_id);
-        CRM_ASSERT(rsc_info->id);
-    }
-    if (standard) {
-        rsc_info->standard = strdup(standard);
-        CRM_ASSERT(rsc_info->standard);
-    }
-    if (provider) {
-        rsc_info->provider = strdup(provider);
-        CRM_ASSERT(rsc_info->provider);
-    }
-    if (type) {
-        rsc_info->type = strdup(type);
-        CRM_ASSERT(rsc_info->type);
-    }
+    pcmk__str_update(&rsc_info->id, rsc_id);
+    pcmk__str_update(&rsc_info->standard, standard);
+    pcmk__str_update(&rsc_info->provider, provider);
+    pcmk__str_update(&rsc_info->type, type);
     return rsc_info;
 }
 
@@ -2372,11 +2362,7 @@ lrmd__set_result(lrmd_event_data_t *event, enum ocf_exitcode rc, int op_status,
 
     event->rc = rc;
     event->op_status = op_status;
-
-    if (!pcmk__str_eq(event->exit_reason, exit_reason, pcmk__str_none)) {
-        free((void *) event->exit_reason);
-        event->exit_reason = (exit_reason == NULL)? NULL : strdup(exit_reason);
-    }
+    pcmk__str_update((char **) &event->exit_reason, exit_reason);
 }
 
 /*!

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -809,11 +809,8 @@ pcmk__new_cancel_action(pe_resource_t *rsc, const char *task, guint interval_ms,
     cancel_op = custom_action(rsc, key, RSC_CANCEL, node, FALSE, TRUE,
                               rsc->cluster);
 
-    free(cancel_op->task);
-    cancel_op->task = strdup(RSC_CANCEL);
-
-    free(cancel_op->cancel_task);
-    cancel_op->cancel_task = strdup(task);
+    pcmk__str_update(&cancel_op->task, RSC_CANCEL);
+    pcmk__str_update(&cancel_op->cancel_task, task);
 
     interval_ms_s = crm_strdup_printf("%u", interval_ms);
     add_hash_param(cancel_op->meta, XML_LRM_ATTR_TASK, task);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -887,11 +887,10 @@ mount_add(pe__bundle_variant_data_t *bundle_data, const char *source,
 {
     pe__bundle_mount_t *mount = calloc(1, sizeof(pe__bundle_mount_t));
 
+    CRM_ASSERT(mount != NULL);
     mount->source = strdup(source);
     mount->target = strdup(target);
-    if (options) {
-        mount->options = strdup(options);
-    }
+    pcmk__str_update(&mount->options, options);
     mount->flags = flags;
     bundle_data->mounts = g_list_append(bundle_data->mounts, mount);
 }

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -337,9 +337,7 @@ native_parameter(pe_resource_t * rsc, pe_node_t * node, gboolean create, const c
         /* try meta attributes instead */
         value = g_hash_table_lookup(rsc->meta, name);
     }
-    if (value != NULL) {
-        value_copy = strdup(value);
-    }
+    pcmk__str_update(&value_copy, value);
     return value_copy;
 }
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1137,8 +1137,7 @@ failed_action_friendly(pcmk__output_t *out, xmlNodePtr xml_op,
     }
     CRM_ASSERT((rsc_id != NULL) && (task != NULL));
 
-    str = g_string_sized_new(strlen(rsc_id) + strlen(task) + strlen(node_name)
-                             + 100); // reasonable starting size
+    str = g_string_sized_new(256); // Should be sufficient for most messages
 
     g_string_printf(str, "%s ", rsc_id);
 
@@ -1152,14 +1151,19 @@ failed_action_friendly(pcmk__output_t *out, xmlNodePtr xml_op,
     if (status == PCMK_EXEC_DONE) {
         g_string_append_printf(str, " returned '%s'",
                                services_ocf_exitcode_str(rc));
+        if (!pcmk__str_empty(exit_reason)) {
+            g_string_append_printf(str, " (%s)", exit_reason);
+        }
+
     } else {
-        g_string_append_printf(str, " could not be executed (%s)",
+        g_string_append_printf(str, " could not be executed (%s",
                                pcmk_exec_status_str(status));
+        if (!pcmk__str_empty(exit_reason)) {
+            g_string_append_printf(str, ": %s", exit_reason);
+        }
+        g_string_append(str, ")");
     }
 
-    if (!pcmk__str_empty(exit_reason)) {
-        g_string_append_printf(str, " because '%s'", exit_reason);
-    }
 
     if (crm_element_value_epoch(xml_op, XML_RSC_OP_LAST_CHANGE,
                                 &last_change_epoch) == pcmk_ok) {

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1909,8 +1909,7 @@ unpack_find_resource(pe_working_set_t * data_set, pe_node_t * node, const char *
     if (rsc && !pcmk__str_eq(rsc_id, rsc->id, pcmk__str_casei)
         && !pcmk__str_eq(rsc_id, rsc->clone_name, pcmk__str_casei)) {
 
-        free(rsc->clone_name);
-        rsc->clone_name = strdup(rsc_id);
+        pcmk__str_update(&rsc->clone_name, rsc_id);
         pe_rsc_debug(rsc, "Internally renamed %s on %s to %s%s",
                      rsc_id, node->details->uname, rsc->id,
                      (pcmk_is_set(rsc->flags, pe_rsc_orphan)? " (ORPHAN)" : ""));

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -2350,7 +2350,6 @@ void pe_action_set_reason(pe_action_t *action, const char *reason, bool overwrit
     if (action->reason != NULL && overwrite) {
         pe_rsc_trace(action->rsc, "Changing %s reason from '%s' to '%s'",
                      action->uuid, action->reason, crm_str(reason));
-        free(action->reason);
     } else if (action->reason == NULL) {
         pe_rsc_trace(action->rsc, "Set %s reason to '%s'",
                      action->uuid, crm_str(reason));
@@ -2359,11 +2358,7 @@ void pe_action_set_reason(pe_action_t *action, const char *reason, bool overwrit
         return;
     }
 
-    if (reason != NULL) {
-        action->reason = strdup(reason);
-    } else {
-        action->reason = NULL;
-    }
+    pcmk__str_update(&action->reason, reason);
 }
 
 /*!

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -415,8 +415,11 @@ services_alert_create(const char *id, const char *exec, int timeout,
 {
     svc_action_t *action = services_action_create_generic(exec, NULL);
 
-    action->timeout = timeout;
     action->id = strdup(id);
+    action->standard = strdup(PCMK_RESOURCE_CLASS_ALERT);
+    CRM_ASSERT((action->id != NULL) && (action->standard != NULL));
+
+    action->timeout = timeout;
     action->params = params;
     action->sequence = sequence;
     action->cb_data = cb_data;

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -1287,6 +1287,43 @@ services__set_result(svc_action_t *action, int agent_status,
 
 /*!
  * \internal
+ * \brief Set the result of an action, with a formatted exit reason
+ *
+ * \param[out] action        Where to set action result
+ * \param[in]  agent_status  Exit status to set
+ * \param[in]  exec_status   Execution status to set
+ * \param[in]  format        printf-style format for a human-friendly
+ *                           description of reason for result
+ * \param[in]  ...           arguments for \p format
+ */
+void
+services__format_result(svc_action_t *action, int agent_status,
+                        enum pcmk_exec_status exec_status,
+                        const char *format, ...)
+{
+    va_list ap;
+    int len = 0;
+    char *reason = NULL;
+
+    if (action == NULL) {
+        return;
+    }
+
+    action->rc = agent_status;
+    action->status = exec_status;
+
+    if (format != NULL) {
+        va_start(ap, format);
+        len = vasprintf(&reason, format, ap);
+        CRM_ASSERT(len > 0);
+        va_end(ap);
+    }
+    free(action->opaque->exit_reason);
+    action->opaque->exit_reason = reason;
+}
+
+/*!
+ * \internal
  * \brief Set the result of an action to cancelled
  *
  * \param[out] action        Where to set action result

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 the Pacemaker project contributors
+ * Copyright 2010-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -863,17 +863,19 @@ services_action_async_fork_notify(svc_action_t * op,
                                   void (*action_callback) (svc_action_t *),
                                   void (*action_fork_callback) (svc_action_t *))
 {
+    CRM_CHECK(op != NULL, return TRUE);
+
     op->synchronous = false;
-    if (action_callback) {
+    if (action_callback != NULL) {
         op->opaque->callback = action_callback;
     }
-    if (action_fork_callback) {
+    if (action_fork_callback != NULL) {
         op->opaque->fork_callback = action_fork_callback;
     }
 
     if (op->interval_ms > 0) {
         init_recurring_actions();
-        if (handle_duplicate_recurring(op) == TRUE) {
+        if (handle_duplicate_recurring(op)) {
             /* entry rescheduled, dup freed */
             /* exit early */
             return TRUE;

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -1342,6 +1342,30 @@ services__set_cancelled(svc_action_t *action)
 
 /*!
  * \internal
+ * \brief Get a readable description of what an action is for
+ *
+ * \param[in] action  Action to check
+ *
+ * \return Readable name for the kind of \p action
+ */
+const char *
+services__action_kind(svc_action_t *action)
+{
+    if ((action == NULL) || (action->standard == NULL)) {
+        return "Process";
+    } else if (pcmk__str_eq(action->standard, PCMK_RESOURCE_CLASS_STONITH,
+                            pcmk__str_none)) {
+        return "Fence agent";
+    } else if (pcmk__str_eq(action->standard, PCMK_RESOURCE_CLASS_ALERT,
+                            pcmk__str_none)) {
+        return "Alert agent";
+    } else {
+        return "Resource agent";
+    }
+}
+
+/*!
+ * \internal
  * \brief Get the exit reason of an action
  *
  * \param[in] action  Action to check

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -454,7 +454,9 @@ services_action_user(svc_action_t *op, const char *user)
  * \return TRUE if the library will free action, FALSE otherwise
  *
  * \note If this function returns FALSE, it is the caller's responsibility to
- *       free the action with services_action_free().
+ *       free the action with services_action_free(). However, unless someone
+ *       intentionally creates a recurring alert action, this will never return
+ *       FALSE.
  */
 gboolean
 services_alert_async(svc_action_t *action, void (*cb)(svc_action_t *op))

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -679,11 +679,14 @@ async_action_complete(mainloop_child_t *p, pid_t pid, int core, int signo,
     } else if (mainloop_child_timeout(p)) {
         const char *reason = NULL;
 
-        if (op->rsc != NULL) {
-            reason = "Resource agent did not complete in time";
-        } else if (pcmk__str_eq(op->standard, PCMK_RESOURCE_CLASS_STONITH,
-                                pcmk__str_none)) {
+        if (pcmk__str_eq(op->standard, PCMK_RESOURCE_CLASS_STONITH,
+                         pcmk__str_none)) {
             reason = "Fence agent did not complete in time";
+        } else if (pcmk__str_eq(op->standard, PCMK_RESOURCE_CLASS_ALERT,
+                                pcmk__str_none)) {
+            reason = "Alert agent did not complete in time";
+        } else if (op->standard != NULL) {
+            reason = "Resource agent did not complete in time";
         } else {
             reason = "Process did not complete in time";
         }

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -677,22 +677,23 @@ async_action_complete(mainloop_child_t *p, pid_t pid, int core, int signo,
         parse_exit_reason_from_stderr(op);
 
     } else if (mainloop_child_timeout(p)) {
-        const char *reason = NULL;
+        const char *what = NULL;
 
         if (pcmk__str_eq(op->standard, PCMK_RESOURCE_CLASS_STONITH,
                          pcmk__str_none)) {
-            reason = "Fence agent did not complete in time";
+            what = "Fence agent";
         } else if (pcmk__str_eq(op->standard, PCMK_RESOURCE_CLASS_ALERT,
                                 pcmk__str_none)) {
-            reason = "Alert agent did not complete in time";
+            what = "Alert agent";
         } else if (op->standard != NULL) {
-            reason = "Resource agent did not complete in time";
+            what = "Resource agent";
         } else {
-            reason = "Process did not complete in time";
+            what = "Process";
         }
         crm_info("%s[%d] timed out after %dms", op->id, op->pid, op->timeout);
-        services__set_result(op, services__generic_error(op), PCMK_EXEC_TIMEOUT,
-                             reason);
+        services__format_result(op, services__generic_error(op),
+                                PCMK_EXEC_TIMEOUT,
+                                "%s did not complete in time", what);
 
     } else if (op->cancel) {
         /* If an in-flight recurring operation was killed because it was

--- a/lib/services/services_private.h
+++ b/lib/services/services_private.h
@@ -45,6 +45,9 @@ struct svc_action_private_s {
 };
 
 G_GNUC_INTERNAL
+const char *services__action_kind(svc_action_t *action);
+
+G_GNUC_INTERNAL
 GList *services_os_get_single_directory_list(const char *root, gboolean files,
                                              gboolean executable);
 

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the Pacemaker project contributors
+ * Copyright 2012-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1033,8 +1033,8 @@ systemd_timeout_callback(gpointer p)
  * \retval EBUSY          Recurring operation could not be initiated
  * \retval pcmk_rc_error  Synchronous action failed
  * \retval pcmk_rc_ok     Synchronous action succeeded, or asynchronous action
- *                        should not be freed (because it already was or is
- *                        pending)
+ *                        should not be freed (because it's pending or because
+ *                        it failed to execute and was already freed)
  *
  * \note If the return value for an asynchronous action is not pcmk_rc_ok, the
  *       caller is responsible for freeing the action.

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -316,8 +316,9 @@ set_result_from_method_error(svc_action_t *op, const DBusError *error)
             return;
         }
 
-        services__set_result(op, PCMK_OCF_NOT_INSTALLED,
-                             PCMK_EXEC_NOT_INSTALLED, "systemd unit not found");
+        services__format_result(op, PCMK_OCF_NOT_INSTALLED,
+                               PCMK_EXEC_NOT_INSTALLED,
+                               "systemd unit %s not found", op->agent);
     }
 
     crm_info("DBus request for %s of systemd unit %s for resource %s failed: %s",
@@ -372,8 +373,9 @@ execute_after_loadunit(DBusMessage *reply, svc_action_t *op)
             invoke_unit_by_path(op, path);
 
         } else if (!(op->synchronous)) {
-            services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
-                                 "No DBus object found for systemd unit");
+            services__format_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                                    "No DBus object found for systemd unit %s",
+                                    op->agent);
             services__finalize_async_op(op);
         }
     }
@@ -939,8 +941,9 @@ invoke_unit_by_path(svc_action_t *op, const char *unit)
             free(state);
 
         } else if (pending == NULL) { // Could not get ActiveState property
-            services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
-                                 "Could not get unit state from DBus");
+            services__format_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                                    "Could not get state for unit %s from DBus",
+                                    op->agent);
             services__finalize_async_op(op);
 
         } else {
@@ -960,8 +963,10 @@ invoke_unit_by_path(svc_action_t *op, const char *unit)
         method = "RestartUnit";
 
     } else {
-        services__set_result(op, PCMK_OCF_UNIMPLEMENT_FEATURE, PCMK_EXEC_ERROR,
-                             "Action not implemented for systemd resources");
+        services__format_result(op, PCMK_OCF_UNIMPLEMENT_FEATURE,
+                                PCMK_EXEC_ERROR,
+                                "Action %s not implemented "
+                                "for systemd resources", crm_str(op->action));
         if (!(op->synchronous)) {
             services__finalize_async_op(op);
         }
@@ -1017,8 +1022,9 @@ systemd_timeout_callback(gpointer p)
     op->opaque->timerid = 0;
     crm_info("%s action for systemd unit %s named '%s' timed out",
              op->action, op->agent, op->rsc);
-    services__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_TIMEOUT,
-                         "Systemd unit action did not complete in time");
+    services__format_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_TIMEOUT,
+                            "%s action for systemd unit %s "
+                            "did not complete in time", op->action, op->agent);
     services__finalize_async_op(op);
     return FALSE;
 }

--- a/lib/services/upstart.c
+++ b/lib/services/upstart.c
@@ -1,7 +1,7 @@
 /*
  * Original copyright 2010 Senko Rasic <senko.rasic@dobarkod.hr>
  *                         and Ante Karamatic <ivoks@init.hr>
- * Later changes copyright 2012-2021 the Pacemaker project contributors
+ * Later changes copyright 2012-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -503,8 +503,8 @@ job_method_complete(DBusPendingCall *pending, void *user_data)
  * \retval EBUSY          Recurring operation could not be initiated
  * \retval pcmk_rc_error  Synchronous action failed
  * \retval pcmk_rc_ok     Synchronous action succeeded, or asynchronous action
- *                        should not be freed (because it already was or is
- *                        pending)
+ *                        should not be freed (because it's pending or because
+ *                        it failed to execute and was already freed)
  *
  * \note If the return value for an asynchronous action is not pcmk_rc_ok, the
  *       caller is responsible for freeing the action.

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -156,12 +156,6 @@ static int do_update(char command, const char *attr_node, const char *attr_name,
     free(attr_section); \
     free(attr_set);
 
-#define set_option(option_var) \
-    if (option_var) { \
-        free(option_var); \
-    } \
-    option_var = strdup(optarg);
-
 int
 main(int argc, char **argv)
 {
@@ -204,20 +198,20 @@ main(int argc, char **argv)
                 pcmk__cli_help(flag, CRM_EX_OK);
                 break;
             case 'n':
-                set_option(attr_name);
+                pcmk__str_update(&attr_name, optarg);
                 break;
             case 's':
-                set_option(attr_set);
+                pcmk__str_update(&attr_set, optarg);
                 break;
             case 'd':
-                set_option(attr_dampen);
+                pcmk__str_update(&attr_dampen, optarg);
                 break;
             case 'l':
             case 'S':
-                set_option(attr_section);
+                pcmk__str_update(&attr_section, optarg);
                 break;
             case 'N':
-                set_option(attr_node);
+                pcmk__str_update(&attr_node, optarg);
                 break;
             case 'A':
                 query_all = TRUE;

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -20,7 +20,7 @@ static int command_options = 0;
 static int request_id = 0;
 static int bump_log_num = 0;
 
-static const char *host = NULL;
+static char *host = NULL;
 static const char *cib_user = NULL;
 static const char *cib_action = NULL;
 static const char *obj_type = NULL;
@@ -514,7 +514,7 @@ main(int argc, char **argv)
                 break;
             case 'N':
             case 'h':
-                host = strdup(optarg);
+                pcmk__str_update(&host, optarg);
                 break;
             case 'l':
                 cib__set_call_options(command_options, crm_system_name,
@@ -703,6 +703,7 @@ main(int argc, char **argv)
         exit_code = pcmk_rc2exitc(rc);
     }
 
+    free(host);
     crm_exit(exit_code);
 }
 

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -98,12 +98,7 @@ promotion_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErro
 static gboolean
 update_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
     options.command = 'v';
-
-    if (options.attr_value) {
-        free(options.attr_value);
-    }
-
-    options.attr_value = strdup(optarg);
+    pcmk__str_update(&options.attr_value, optarg);
     return TRUE;
 }
 

--- a/tools/crm_diff.c
+++ b/tools/crm_diff.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2021 the Pacemaker project contributors
+ * Copyright 2005-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -85,36 +85,21 @@ static GOptionEntry addl_entries[] = {
 gboolean
 new_string_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
     options.raw_2 = TRUE;
-
-    if (options.xml_file_2 != NULL) {
-        free(options.xml_file_2);
-    }
-
-    options.xml_file_2 = strdup(optarg);
+    pcmk__str_update(&options.xml_file_2, optarg);
     return TRUE;
 }
 
 gboolean
 original_string_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
     options.raw_1 = TRUE;
-
-    if (options.xml_file_1 != NULL) {
-        free(options.xml_file_1);
-    }
-
-    options.xml_file_1 = strdup(optarg);
+    pcmk__str_update(&options.xml_file_1, optarg);
     return TRUE;
 }
 
 gboolean
 patch_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
     options.apply = TRUE;
-
-    if (options.xml_file_2 != NULL) {
-        free(options.xml_file_2);
-    }
-
-    options.xml_file_2 = strdup(optarg);
+    pcmk__str_update(&options.xml_file_2, optarg);
     return TRUE;
 }
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -329,11 +329,7 @@ include_exclude_cb(const gchar *option_name, const gchar *optarg, gpointer data,
 
 static gboolean
 as_cgi_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    if (args->output_ty != NULL) {
-        free(args->output_ty);
-    }
-
-    args->output_ty = strdup("html");
+    pcmk__str_update(&args->output_ty, "html");
     output_format = mon_output_cgi;
     options.one_shot = TRUE;
     return TRUE;
@@ -341,20 +337,8 @@ as_cgi_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError *
 
 static gboolean
 as_html_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    if (args->output_ty != NULL) {
-        free(args->output_ty);
-    }
-
-    if (args->output_dest != NULL) {
-        free(args->output_dest);
-        args->output_dest = NULL;
-    }
-
-    if (optarg != NULL) {
-        args->output_dest = strdup(optarg);
-    }
-
-    args->output_ty = strdup("html");
+    pcmk__str_update(&args->output_dest, optarg);
+    pcmk__str_update(&args->output_ty, "html");
     output_format = mon_output_html;
     umask(S_IWGRP | S_IWOTH);
     return TRUE;
@@ -362,11 +346,7 @@ as_html_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError 
 
 static gboolean
 as_simple_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    if (args->output_ty != NULL) {
-        free(args->output_ty);
-    }
-
-    args->output_ty = strdup("text");
+    pcmk__str_update(&args->output_ty, "text");
     output_format = mon_output_monitor;
     options.one_shot = TRUE;
     return TRUE;
@@ -374,11 +354,7 @@ as_simple_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErro
 
 static gboolean
 as_xml_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    if (args->output_ty != NULL) {
-        free(args->output_ty);
-    }
-
-    args->output_ty = strdup("xml");
+    pcmk__str_update(&args->output_ty, "xml");
     output_format = mon_output_legacy_xml;
     return TRUE;
 }
@@ -1299,35 +1275,20 @@ reconcile_output_format(pcmk__common_args_t *args) {
     if (pcmk__str_eq(args->output_ty, "html", pcmk__str_casei)) {
         char *dest = NULL;
 
-        if (args->output_dest != NULL) {
-            dest = strdup(args->output_dest);
-        }
-
+        pcmk__str_update(&dest, args->output_dest);
         retval = as_html_cb("h", dest, NULL, &err);
         free(dest);
     } else if (pcmk__str_eq(args->output_ty, "text", pcmk__str_casei)) {
         retval = no_curses_cb("N", NULL, NULL, &err);
     } else if (pcmk__str_eq(args->output_ty, "xml", pcmk__str_casei)) {
-        if (args->output_ty != NULL) {
-            free(args->output_ty);
-        }
-
-        args->output_ty = strdup("xml");
+        pcmk__str_update(&args->output_ty, "xml");
         output_format = mon_output_xml;
     } else if (options.one_shot) {
-        if (args->output_ty != NULL) {
-            free(args->output_ty);
-        }
-
-        args->output_ty = strdup("text");
+        pcmk__str_update(&args->output_ty, "text");
         output_format = mon_output_plain;
     } else {
         /* Neither old nor new arguments were given, so set the default. */
-        if (args->output_ty != NULL) {
-            free(args->output_ty);
-        }
-
-        args->output_ty = strdup("console");
+        pcmk__str_update(&args->output_ty, "console");
         output_format = mon_output_console;
     }
 

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -203,8 +203,8 @@ curses_begin_list(pcmk__output_t *out, const char *singular_noun, const char *pl
 
     new_list = calloc(1, sizeof(curses_list_data_t));
     new_list->len = 0;
-    new_list->singular_noun = singular_noun == NULL ? NULL : strdup(singular_noun);
-    new_list->plural_noun = plural_noun == NULL ? NULL : strdup(plural_noun);
+    pcmk__str_update(&new_list->singular_noun, singular_noun);
+    pcmk__str_update(&new_list->plural_noun, plural_noun);
 
     g_queue_push_tail(priv->parent_q, new_list);
 }

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -128,7 +128,7 @@ remove_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError *
 
     options.command = 'R';
     options.dangerous_cmd = TRUE;
-    options.target_uname = strdup(optarg);
+    pcmk__str_update(&options.target_uname, optarg);
     return TRUE;
 }
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -632,15 +632,9 @@ agent_provider_cb(const gchar *option_name, const gchar *optarg, gpointer data, 
     options.require_resource = FALSE;
 
     if (pcmk__str_eq(option_name, "--provider", pcmk__str_casei)) {
-        if (options.v_provider) {
-           free(options.v_provider);
-        }
-        options.v_provider = strdup(optarg);
+        pcmk__str_update(&options.v_provider, optarg);
     } else {
-        if (options.v_agent) {
-           free(options.v_agent);
-        }
-        options.v_agent = strdup(optarg);
+        pcmk__str_update(&options.v_agent, optarg);
     }
 
     return TRUE;
@@ -659,12 +653,7 @@ attr_set_type_cb(const gchar *option_name, const gchar *optarg, gpointer data, G
 
 gboolean
 class_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
-    if (options.v_class != NULL) {
-        free(options.v_class);
-    }
-
-    options.v_class = strdup(optarg);
-
+    pcmk__str_update(&options.v_class, optarg);
     options.cmdline_config = TRUE;
     options.require_resource = FALSE;
     return TRUE;
@@ -707,13 +696,7 @@ get_agent_spec(const gchar *optarg)
     options.require_cib = FALSE;
     options.require_dataset = FALSE;
     options.require_resource = FALSE;
-    if (options.agent_spec != NULL) {
-        free(options.agent_spec);
-        options.agent_spec = NULL;
-    }
-    if (optarg != NULL) {
-        options.agent_spec = strdup(optarg);
-    }
+    pcmk__str_update(&options.agent_spec, optarg);
 }
 
 gboolean
@@ -827,11 +810,7 @@ get_param_prop_cb(const gchar *option_name, const gchar *optarg, gpointer data, 
         SET_COMMAND(cmd_get_property);
     }
 
-    if (options.prop_name) {
-        free(options.prop_name);
-    }
-
-    options.prop_name = strdup(optarg);
+    pcmk__str_update(&options.prop_name, optarg);
     options.find_flags = pe_find_renamed|pe_find_any;
     return TRUE;
 }
@@ -862,11 +841,7 @@ set_delete_param_cb(const gchar *option_name, const gchar *optarg, gpointer data
         SET_COMMAND(cmd_delete_param);
     }
 
-    if (options.prop_name) {
-        free(options.prop_name);
-    }
-
-    options.prop_name = strdup(optarg);
+    pcmk__str_update(&options.prop_name, optarg);
     options.find_flags = pe_find_renamed|pe_find_any;
     return TRUE;
 }
@@ -874,12 +849,7 @@ set_delete_param_cb(const gchar *option_name, const gchar *optarg, gpointer data
 gboolean
 set_prop_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
     options.require_dataset = FALSE;
-
-    if (options.prop_name) {
-        free(options.prop_name);
-    }
-
-    options.prop_name = strdup(optarg);
+    pcmk__str_update(&options.prop_name, optarg);
     SET_COMMAND(cmd_set_property);
     options.find_flags = pe_find_renamed|pe_find_any;
     return TRUE;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1805,8 +1805,9 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
     }
     if (!pcmk__strcase_any_of(class, PCMK_RESOURCE_CLASS_OCF,
                               PCMK_RESOURCE_CLASS_LSB, NULL)) {
-        services__set_result(op, CRM_EX_UNIMPLEMENT_FEATURE, PCMK_EXEC_ERROR,
-                             "Manual execution of this standard is unsupported");
+        services__format_result(op, CRM_EX_UNIMPLEMENT_FEATURE, PCMK_EXEC_ERROR,
+                                "Manual execution of the %s standard "
+                                "is unsupported", crm_str(class));
     }
 
     if (op->rc != PCMK_OCF_UNKNOWN) {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -177,11 +177,7 @@ find_resource_attr(pcmk__output_t *out, cib_t * the_cib, const char *attr,
         out->spacer(out);
 
     } else if(value) {
-        const char *tmp = crm_element_value(xml_search, attr);
-
-        if (tmp) {
-            *value = strdup(tmp);
-        }
+        pcmk__str_update(value, crm_element_value(xml_search, attr));
     }
 
   done:

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -305,15 +305,13 @@ main(int argc, char **argv)
             case 's':
             case 'r':
                 command = flag;
-                free(shadow);
-                shadow = strdup(optarg);
+                pcmk__str_update(&shadow, optarg);
                 break;
             case 'C':
             case 'D':
                 command = flag;
                 dangerous_cmd = TRUE;
-                free(shadow);
-                shadow = strdup(optarg);
+                pcmk__str_update(&shadow, optarg);
                 break;
             case 'V':
                 command_options = command_options | cib_verbose;

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -146,33 +146,21 @@ process_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError 
 
 static gboolean
 quorum_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
-    if (options.injections->quorum) {
-        free(options.injections->quorum);
-    }
-
-    options.injections->quorum = strdup(optarg);
+    pcmk__str_update(&options.injections->quorum, optarg);
     return TRUE;
 }
 
 static gboolean
 save_dotfile_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
-    if (options.dot_file) {
-        free(options.dot_file);
-    }
-
     options.flags |= pcmk_sim_process;
-    options.dot_file = strdup(optarg);
+    pcmk__str_update(&options.dot_file, optarg);
     return TRUE;
 }
 
 static gboolean
 save_graph_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
-    if (options.graph_file) {
-        free(options.graph_file);
-    }
-
     options.flags |= pcmk_sim_process;
-    options.graph_file = strdup(optarg);
+    pcmk__str_update(&options.graph_file, optarg);
     return TRUE;
 }
 
@@ -220,32 +208,20 @@ utilization_cb(const gchar *option_name, const gchar *optarg, gpointer data, GEr
 
 static gboolean
 watchdog_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
-    if (options.injections->watchdog) {
-        free(options.injections->watchdog);
-    }
-
-    options.injections->watchdog = strdup(optarg);
+    pcmk__str_update(&options.injections->watchdog, optarg);
     return TRUE;
 }
 
 static gboolean
 xml_file_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
-    if (options.xml_file) {
-        free(options.xml_file);
-    }
-
-    options.xml_file = strdup(optarg);
+    pcmk__str_update(&options.xml_file, optarg);
     options.flags |= pcmk_sim_sanitized;
     return TRUE;
 }
 
 static gboolean
 xml_pipe_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
-    if (options.xml_file) {
-        free(options.xml_file);
-    }
-
-    options.xml_file = strdup("-");
+    pcmk__str_update(&options.xml_file, "-");
     options.flags |= pcmk_sim_sanitized;
     return TRUE;
 }

--- a/tools/crmadmin.c
+++ b/tools/crmadmin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -124,13 +124,7 @@ command_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError 
         return TRUE;
     }
 
-    if (optarg) {
-        if (options.optarg != NULL) {
-            free(options.optarg);
-        }
-        options.optarg = strdup(optarg);
-    }
-
+    pcmk__str_update(&options.optarg, optarg);
     return TRUE;
 }
 


### PR DESCRIPTION
This is a follow-up to the project adding exit reasons for internal failures, with a variety of semi-related changes. The biggest change is making the exit reason functions take printf-style arguments, for better messages.