### PR TITLE
Escape special XML characters in agent descriptions

### DIFF
--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -557,10 +557,15 @@ pcmk__format_option_metadata(const char *name, const char *desc_short,
                              const char *desc_long,
                              pcmk__cluster_option_t *option_list, int len)
 {
+    char *escaped_long = NULL;
+    char *escaped_short = NULL;
     char *retval;
     /* big enough to hold "pacemaker-schedulerd metadata" output */
     GString *s = g_string_sized_new(13000);
     int lpc = 0;
+
+    escaped_long = crm_xml_escape(desc_long);
+    escaped_short = crm_xml_escape(desc_short);
 
     g_string_append_printf(s, "<?xml version=\"1.0\"?>"
                               "<!DOCTYPE resource-agent SYSTEM \"ra-api-1.dtd\">\n"
@@ -569,7 +574,9 @@ pcmk__format_option_metadata(const char *name, const char *desc_short,
                               "  <longdesc lang=\"en\">%s</longdesc>\n"
                               "  <shortdesc lang=\"en\">%s</shortdesc>\n"
                               "  <parameters>\n",
-                              name, PCMK_OCF_VERSION, desc_long, desc_short);
+                              name, PCMK_OCF_VERSION, escaped_long, escaped_short);
+    free(escaped_long);
+    free(escaped_short);
 
     for (lpc = 0; lpc < len; lpc++) {
         if ((option_list[lpc].description_long == NULL)
@@ -577,16 +584,21 @@ pcmk__format_option_metadata(const char *name, const char *desc_short,
             continue;
         }
 
+        escaped_long = crm_xml_escape(option_list[lpc].description_long?
+                                         option_list[lpc].description_long :
+                                          option_list[lpc].description_short);
+        escaped_short = crm_xml_escape(option_list[lpc].description_short);
+
         g_string_append_printf(s, "    <parameter name=\"%s\">\n"
                                   "      <longdesc lang=\"en\">%s%s%s</longdesc>\n"
                                   "      <shortdesc lang=\"en\">%s</shortdesc>\n",
                                   option_list[lpc].name,
-                                  option_list[lpc].description_long?
-                                     option_list[lpc].description_long :
-                                      option_list[lpc].description_short,
+                                  escaped_long,
                                   (option_list[lpc].values? "  Allowed values: " : ""),
                                   (option_list[lpc].values? option_list[lpc].values : ""),
-                                  option_list[lpc].description_short);
+                                  escaped_short);
+        free(escaped_long);
+        free(escaped_short);
 
         if (option_list[lpc].values && !strcmp(option_list[lpc].type, "select")) {
             char *str = strdup(option_list[lpc].values);

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -664,6 +664,8 @@ systemd_unit_metadata(const char *name, int timeout)
     char *desc = NULL;
     char *path = NULL;
 
+    char *escaped = NULL;
+
     if (invoke_unit_by_name(name, NULL, &path) == pcmk_rc_ok) {
         /* TODO: Worth a making blocking call for? Probably not. Possibly if cached. */
         desc = systemd_get_property(path, "Description", NULL, NULL, NULL,
@@ -672,9 +674,12 @@ systemd_unit_metadata(const char *name, int timeout)
         desc = crm_strdup_printf("Systemd unit file for %s", name);
     }
 
-    meta = crm_strdup_printf(METADATA_FORMAT, name, desc, name);
+    escaped = crm_xml_escape(desc);
+
+    meta = crm_strdup_printf(METADATA_FORMAT, name, escaped, name);
     free(desc);
     free(path);
+    free(escaped);
     return meta;
 }
 


### PR DESCRIPTION
Note that I have not yet been able to test this because I don't have the proper OS version installed, but it looks obviously correct to me.