### PR TITLE
Build: gettext-devel is now required.

### DIFF
--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -302,6 +302,7 @@ BuildRequires: %{pkgname_bzip2_devel}
 BuildRequires: pkgconfig(dbus-1)
 BuildRequires: %{pkgname_docbook_xsl}
 BuildRequires: %{pkgname_gnutls_devel}
+BuildRequires: gettext-devel
 BuildRequires: help2man
 BuildRequires: ncurses-devel
 BuildRequires: pam-devel


### PR DESCRIPTION
There doesn't appear to be a way to conditionalize this.  autogen.sh
calls autoreconf, which applies a fairly simplistic test to see if
gettext is in use or not.