### PR TITLE
Improve fencing logs and code readability

### DIFF
--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the Pacemaker project contributors
+ * Copyright 2012-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -48,7 +48,7 @@ typedef struct lrmd_rsc_s {
      * PCMK_EXEC_NO_FENCE_DEVICE ("not running"), or
      * PCMK_EXEC_NOT_CONNECTED ("unknown because fencer connection was lost").
      */
-    enum pcmk_exec_status fence_probe_result;
+    pcmk__action_result_t fence_probe_result;
 
     crm_trigger_t *work;
 } lrmd_rsc_t;

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -3091,7 +3091,7 @@ handle_request(pcmk__request_t *request)
         flag_name = crm_element_value(request->xml, F_STONITH_NOTIFY_ACTIVATE);
         if (flag_name) {
             crm_debug("Enabling %s callbacks for client %s",
-                      flag_name, pcmk__client_name(request->client));
+                      flag_name, pcmk__request_origin(request));
             pcmk__set_client_flags(request->client, get_stonith_flag(flag_name));
         }
 
@@ -3099,7 +3099,7 @@ handle_request(pcmk__request_t *request)
                                       F_STONITH_NOTIFY_DEACTIVATE);
         if (flag_name) {
             crm_debug("Disabling %s callbacks for client %s",
-                      flag_name, pcmk__client_name(request->client));
+                      flag_name, pcmk__request_origin(request));
             pcmk__clear_client_flags(request->client,
                                      get_stonith_flag(flag_name));
         }
@@ -3114,7 +3114,7 @@ handle_request(pcmk__request_t *request)
         crm_notice("Received forwarded fencing request from "
                    "%s %s to fence (%s) peer %s",
                    pcmk__request_origin_type(request),
-                   ((request->client == NULL)? request->peer : pcmk__client_name(request->client)),
+                   pcmk__request_origin(request),
                    crm_element_value(dev, F_STONITH_ACTION),
                    crm_element_value(dev, F_STONITH_TARGET));
 
@@ -3158,7 +3158,7 @@ handle_request(pcmk__request_t *request)
                 int tolerance = 0;
 
                 crm_notice("Client %s wants to fence (%s) %s using %s",
-                           pcmk__client_name(request->client), action,
+                           pcmk__request_origin(request), action,
                            target, (device? device : "any device"));
                 crm_element_value_int(dev, F_STONITH_TOLERANCE, &tolerance);
                 if (stonith_check_fence_tolerance(tolerance, target, action)) {
@@ -3308,7 +3308,7 @@ handle_request(pcmk__request_t *request)
     } else {
         crm_err("Unknown IPC request %s from %s %s", op,
                 pcmk__request_origin_type(request),
-                ((request->client == NULL)? request->peer : pcmk__client_name(request->client)));
+                pcmk__request_origin(request));
         pcmk__format_result(&request->result,
                             CRM_EX_PROTOCOL, PCMK_EXEC_INVALID,
                             "Unknown IPC request type '%s' (bug?)",
@@ -3338,7 +3338,7 @@ done:
     reason = request->result.exit_reason;
     crm_debug("Processed %s request from %s %s: %s%s%s%s",
               op, pcmk__request_origin_type(request),
-              ((request->client == NULL)? request->peer : pcmk__client_name(request->client)),
+              pcmk__request_origin(request),
               pcmk_exec_status_str(request->result.execution_status),
               (reason == NULL)? "" : " (",
               (reason == NULL)? "" : reason,

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2921,7 +2921,7 @@ stonith_send_reply(xmlNode *reply, int call_options, const char *remote_peer,
 
     if (remote_peer == NULL) {
         do_local_reply(reply, client_id,
-                       pcmk_is_set(call_options, st_opt_sync_call), FALSE);
+                       pcmk_is_set(call_options, st_opt_sync_call));
     } else {
         send_cluster_message(crm_get_peer(0, remote_peer), crm_msg_stonith_ng,
                              reply, FALSE);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -3016,6 +3016,7 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
 
     const char *op = crm_element_value(request, F_STONITH_OPERATION);
     const char *client_id = crm_element_value(request, F_STONITH_CLIENTID);
+    const char *reason = NULL;
 
     crm_element_value_int(request, F_STONITH_CALLOPTS, &call_options);
 
@@ -3271,13 +3272,14 @@ done:
         free_xml(reply);
     }
 
+    reason = result.exit_reason;
     crm_debug("Processed %s request from %s %s: %s%s%s%s",
               op, ((client == NULL)? "peer" : "client"),
               ((client == NULL)? remote_peer : pcmk__client_name(client)),
               pcmk_exec_status_str(result.execution_status),
-              (result.exit_reason == NULL)? "" : " (",
-              (result.exit_reason == NULL)? "" : result.exit_reason,
-              (result.exit_reason == NULL)? "" : ")");
+              (reason == NULL)? "" : " (",
+              (reason == NULL)? "" : reason,
+              (reason == NULL)? "" : ")");
 
     free_xml(data);
     pcmk__reset_result(&result);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2920,8 +2920,7 @@ stonith_send_reply(xmlNode *reply, int call_options, const char *remote_peer,
               return);
 
     if (remote_peer == NULL) {
-        do_local_reply(reply, client_id,
-                       pcmk_is_set(call_options, st_opt_sync_call));
+        do_local_reply(reply, client_id, call_options);
     } else {
         send_cluster_message(crm_get_peer(0, remote_peer), crm_msg_stonith_ng,
                              reply, FALSE);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -3113,7 +3113,7 @@ handle_request(pcmk__request_t *request)
 
         crm_notice("Received forwarded fencing request from "
                    "%s %s to fence (%s) peer %s",
-                   ((request->client == NULL)? "peer" : "client"),
+                   pcmk__request_origin_type(request),
                    ((request->client == NULL)? request->peer : pcmk__client_name(request->client)),
                    crm_element_value(dev, F_STONITH_ACTION),
                    crm_element_value(dev, F_STONITH_TARGET));
@@ -3307,7 +3307,7 @@ handle_request(pcmk__request_t *request)
 
     } else {
         crm_err("Unknown IPC request %s from %s %s", op,
-                ((request->client == NULL)? "peer" : "client"),
+                pcmk__request_origin_type(request),
                 ((request->client == NULL)? request->peer : pcmk__client_name(request->client)));
         pcmk__format_result(&request->result,
                             CRM_EX_PROTOCOL, PCMK_EXEC_INVALID,
@@ -3337,7 +3337,7 @@ done:
 
     reason = request->result.exit_reason;
     crm_debug("Processed %s request from %s %s: %s%s%s%s",
-              op, ((request->client == NULL)? "peer" : "client"),
+              op, pcmk__request_origin_type(request),
               ((request->client == NULL)? request->peer : pcmk__client_name(request->client)),
               pcmk_exec_status_str(request->result.execution_status),
               (reason == NULL)? "" : " (",

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -3050,10 +3050,6 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
         CRM_ASSERT(client);
         crm_xml_add(reply, F_STONITH_OPERATION, CRM_OP_REGISTER);
         crm_xml_add(reply, F_STONITH_CLIENTID, client->id);
-        pcmk__ipc_send_xml(client, id, reply, flags);
-        client->request_id = 0;
-        free_xml(reply);
-        reply = NULL;
         pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
 
     } else if (pcmk__str_eq(op, STONITH_OP_EXEC, pcmk__str_none)) {
@@ -3295,7 +3291,16 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
 done:
     // Reply if result is known
     if (reply != NULL) {
-        stonith_send_reply(reply, call_options, remote_peer, client);
+        if (pcmk__str_any_of(op, CRM_OP_REGISTER, NULL) && (client != NULL)) {
+            /* These IPC-only commands must reuse the call options from the
+             * original request rather than the ones set by stonith_send_reply()
+             * -> do_local_reply().
+             */
+            pcmk__ipc_send_xml(client, id, reply, flags);
+            client->request_id = 0;
+        } else {
+            stonith_send_reply(reply, call_options, remote_peer, client);
+        }
         free_xml(reply);
     }
 

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -3096,7 +3096,7 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
             pcmk__clear_client_flags(client, get_stonith_flag(flag_name));
         }
 
-        pcmk__ipc_send_ack(client, id, flags, "ack", CRM_EX_OK);
+        reply = pcmk__ipc_create_ack(flags, "ack", CRM_EX_OK);
         pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
 
     } else if (pcmk__str_eq(op, STONITH_OP_RELAY, pcmk__str_none)) {
@@ -3291,7 +3291,8 @@ handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
 done:
     // Reply if result is known
     if (reply != NULL) {
-        if (pcmk__str_any_of(op, CRM_OP_REGISTER, NULL) && (client != NULL)) {
+        if (pcmk__str_any_of(op, CRM_OP_REGISTER, T_STONITH_NOTIFY, NULL)
+            && (client != NULL)) {
             /* These IPC-only commands must reuse the call options from the
              * original request rather than the ones set by stonith_send_reply()
              * -> do_local_reply().

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2920,7 +2920,13 @@ stonith_send_reply(xmlNode *reply, int call_options, const char *remote_peer,
               return);
 
     if (remote_peer == NULL) {
-        do_local_reply(reply, client_id, call_options);
+        pcmk__client_t *client = pcmk__find_client_by_id(client_id);
+
+        if (client == NULL) {
+            crm_trace("Skipping reply to %s: no longer a client", client_id);
+        } else {
+            do_local_reply(reply, client, call_options);
+        }
     } else {
         send_cluster_message(crm_get_peer(0, remote_peer), crm_msg_stonith_ng,
                              reply, FALSE);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -3027,293 +3027,322 @@ is_privileged(pcmk__client_t *c, const char *op)
 }
 
 static void
-handle_request(pcmk__client_t *client, uint32_t id, uint32_t flags,
-               xmlNode *request, const char *remote_peer)
+handle_request(pcmk__request_t *request)
 {
-    int call_options = st_opt_none;
     xmlNode *reply = NULL;
-    pcmk__action_result_t result = PCMK__UNKNOWN_RESULT;
-
-    const char *op = crm_element_value(request, F_STONITH_OPERATION);
-    const char *client_id = crm_element_value(request, F_STONITH_CLIENTID);
+    const char *op = NULL;
+    const char *client_id = NULL;
     const char *reason = NULL;
 
-    crm_element_value_int(request, F_STONITH_CALLOPTS, &call_options);
+    CRM_CHECK((request != NULL) && (request->xml != NULL), return);
 
-    if (pcmk_is_set(call_options, st_opt_sync_call) && (client != NULL)) {
-        CRM_ASSERT(client->request_id == id);
+    op = crm_element_value(request->xml, F_STONITH_OPERATION);
+    CRM_CHECK(op != NULL, return);
+
+    client_id = crm_element_value(request->xml, F_STONITH_CLIENTID);
+
+    if (pcmk_is_set(request->call_options, st_opt_sync_call)
+        && (request->client != NULL)) {
+        CRM_ASSERT(request->client->request_id == request->id);
     }
 
     if (pcmk__str_eq(op, CRM_OP_REGISTER, pcmk__str_none)) {
         reply = create_xml_node(NULL, "reply");
 
-        CRM_ASSERT(client);
+        CRM_ASSERT(request->client != NULL);
         crm_xml_add(reply, F_STONITH_OPERATION, CRM_OP_REGISTER);
-        crm_xml_add(reply, F_STONITH_CLIENTID, client->id);
-        pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
+        crm_xml_add(reply, F_STONITH_CLIENTID, request->client->id);
+        pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
 
     } else if (pcmk__str_eq(op, STONITH_OP_EXEC, pcmk__str_none)) {
-        execute_agent_action(request, &result);
-        if (result.execution_status != PCMK_EXEC_PENDING) {
-            reply = fenced_construct_reply(request, NULL, &result);
+        execute_agent_action(request->xml, &request->result);
+        if (request->result.execution_status != PCMK_EXEC_PENDING) {
+            reply = fenced_construct_reply(request->xml, NULL,
+                                           &request->result);
         }
 
     } else if (pcmk__str_eq(op, STONITH_OP_TIMEOUT_UPDATE, pcmk__str_none)) {
-        const char *call_id = crm_element_value(request, F_STONITH_CALLID);
-        const char *client_id = crm_element_value(request, F_STONITH_CLIENTID);
+        const char *call_id = crm_element_value(request->xml, F_STONITH_CALLID);
+        const char *client_id = crm_element_value(request->xml,
+                                                  F_STONITH_CLIENTID);
         int op_timeout = 0;
 
-        crm_element_value_int(request, F_STONITH_TIMEOUT, &op_timeout);
+        crm_element_value_int(request->xml, F_STONITH_TIMEOUT, &op_timeout);
         do_stonith_async_timeout_update(client_id, call_id, op_timeout);
-        pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
+        pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
 
     } else if (pcmk__str_eq(op, STONITH_OP_QUERY, pcmk__str_none)) {
-        if (remote_peer) {
-            create_remote_stonith_op(client_id, request, TRUE); /* Record it for the future notification */
+        if (request->peer != NULL) {
+            // Record it for the future notification
+            create_remote_stonith_op(client_id, request->xml, TRUE);
         }
 
         /* Delete the DC node RELAY operation. */
-        remove_relay_op(request);
+        remove_relay_op(request->xml);
 
-        stonith_query(request, remote_peer, client_id, call_options);
-        pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
+        stonith_query(request->xml, request->peer, client_id,
+                      request->call_options);
+        pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
 
     } else if (pcmk__str_eq(op, T_STONITH_NOTIFY, pcmk__str_none)) {
         const char *flag_name = NULL;
 
-        CRM_ASSERT(client);
-        flag_name = crm_element_value(request, F_STONITH_NOTIFY_ACTIVATE);
+        CRM_ASSERT(request->client);
+        flag_name = crm_element_value(request->xml, F_STONITH_NOTIFY_ACTIVATE);
         if (flag_name) {
             crm_debug("Enabling %s callbacks for client %s",
-                      flag_name, pcmk__client_name(client));
-            pcmk__set_client_flags(client, get_stonith_flag(flag_name));
+                      flag_name, pcmk__client_name(request->client));
+            pcmk__set_client_flags(request->client, get_stonith_flag(flag_name));
         }
 
-        flag_name = crm_element_value(request, F_STONITH_NOTIFY_DEACTIVATE);
+        flag_name = crm_element_value(request->xml,
+                                      F_STONITH_NOTIFY_DEACTIVATE);
         if (flag_name) {
             crm_debug("Disabling %s callbacks for client %s",
-                      flag_name, pcmk__client_name(client));
-            pcmk__clear_client_flags(client, get_stonith_flag(flag_name));
+                      flag_name, pcmk__client_name(request->client));
+            pcmk__clear_client_flags(request->client,
+                                     get_stonith_flag(flag_name));
         }
 
-        reply = pcmk__ipc_create_ack(flags, "ack", CRM_EX_OK);
-        pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
+        reply = pcmk__ipc_create_ack(request->flags, "ack", CRM_EX_OK);
+        pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
 
     } else if (pcmk__str_eq(op, STONITH_OP_RELAY, pcmk__str_none)) {
-        xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, request, LOG_TRACE);
+        xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, request->xml,
+                                        LOG_TRACE);
 
         crm_notice("Received forwarded fencing request from "
                    "%s %s to fence (%s) peer %s",
-                   ((client == NULL)? "peer" : "client"),
-                   ((client == NULL)? remote_peer : pcmk__client_name(client)),
+                   ((request->client == NULL)? "peer" : "client"),
+                   ((request->client == NULL)? request->peer : pcmk__client_name(request->client)),
                    crm_element_value(dev, F_STONITH_ACTION),
                    crm_element_value(dev, F_STONITH_TARGET));
 
-        if (initiate_remote_stonith_op(NULL, request, FALSE) == NULL) {
-            fenced_set_protocol_error(&result);
-            reply = fenced_construct_reply(request, NULL, &result);
+        if (initiate_remote_stonith_op(NULL, request->xml, FALSE) == NULL) {
+            fenced_set_protocol_error(&request->result);
+            reply = fenced_construct_reply(request->xml, NULL, &request->result);
         } else {
-            pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_PENDING, NULL);
+            pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_PENDING,
+                             NULL);
         }
 
     } else if (pcmk__str_eq(op, STONITH_OP_FENCE, pcmk__str_none)) {
-        if ((remote_peer != NULL) || stand_alone) {
-            fence_locally(request, &result);
+        if ((request->peer != NULL) || stand_alone) {
+            fence_locally(request->xml, &request->result);
 
-        } else if (pcmk_is_set(call_options, st_opt_manual_ack)) {
-            switch (fenced_handle_manual_confirmation(client, request)) {
+        } else if (pcmk_is_set(request->call_options, st_opt_manual_ack)) {
+            switch (fenced_handle_manual_confirmation(request->client,
+                                                      request->xml)) {
                 case pcmk_rc_ok:
-                    pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
+                    pcmk__set_result(&request->result, CRM_EX_OK,
+                                     PCMK_EXEC_DONE, NULL);
                     break;
                 case EINPROGRESS:
-                    pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_PENDING,
-                                     NULL);
+                    pcmk__set_result(&request->result, CRM_EX_OK,
+                                     PCMK_EXEC_PENDING, NULL);
                     break;
                 default:
-                    fenced_set_protocol_error(&result);
+                    fenced_set_protocol_error(&request->result);
                     break;
             }
 
         } else {
             const char *alternate_host = NULL;
-            xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET, request, LOG_TRACE);
+            xmlNode *dev = get_xpath_object("//@" F_STONITH_TARGET,
+                                            request->xml, LOG_TRACE);
             const char *target = crm_element_value(dev, F_STONITH_TARGET);
             const char *action = crm_element_value(dev, F_STONITH_ACTION);
             const char *device = crm_element_value(dev, F_STONITH_DEVICE);
 
-            if (client != NULL) {
+            if (request->client != NULL) {
                 int tolerance = 0;
 
                 crm_notice("Client %s wants to fence (%s) %s using %s",
-                           pcmk__client_name(client), action,
+                           pcmk__client_name(request->client), action,
                            target, (device? device : "any device"));
                 crm_element_value_int(dev, F_STONITH_TOLERANCE, &tolerance);
                 if (stonith_check_fence_tolerance(tolerance, target, action)) {
-                    pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
-                    reply = fenced_construct_reply(request, NULL, &result);
+                    pcmk__set_result(&request->result, CRM_EX_OK,
+                                     PCMK_EXEC_DONE, NULL);
+                    reply = fenced_construct_reply(request->xml, NULL,
+                                                   &request->result);
                     goto done;
                 }
 
             } else {
                 crm_notice("Peer %s wants to fence (%s) '%s' with device '%s'",
-                           remote_peer, action, target, device ? device : "(any)");
+                           request->peer, action, target,
+                           (device == NULL)? "(any)" : device);
             }
 
             alternate_host = check_alternate_host(target);
 
-            if (alternate_host && client) {
+            if (alternate_host && request->client) {
                 const char *client_id = NULL;
                 remote_fencing_op_t *op = NULL;
 
                 crm_notice("Forwarding self-fencing request to peer %s "
                            "due to topology", alternate_host);
 
-                if (client->id) {
-                    client_id = client->id;
+                if (request->client->id == 0) {
+                    client_id = crm_element_value(request->xml,
+                                                  F_STONITH_CLIENTID);
                 } else {
-                    client_id = crm_element_value(request, F_STONITH_CLIENTID);
+                    client_id = request->client->id;
                 }
 
                 /* Create an operation for RELAY and send the ID in the RELAY message. */
                 /* When a QUERY response is received, delete the RELAY operation to avoid the existence of duplicate operations. */
-                op = create_remote_stonith_op(client_id, request, FALSE);
+                op = create_remote_stonith_op(client_id, request->xml, FALSE);
 
-                crm_xml_add(request, F_STONITH_OPERATION, STONITH_OP_RELAY);
-                crm_xml_add(request, F_STONITH_CLIENTID, client->id);
-                crm_xml_add(request, F_STONITH_REMOTE_OP_ID, op->id);
-                send_cluster_message(crm_get_peer(0, alternate_host), crm_msg_stonith_ng, request,
-                                     FALSE);
-                pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_PENDING, NULL);
+                crm_xml_add(request->xml, F_STONITH_OPERATION,
+                            STONITH_OP_RELAY);
+                crm_xml_add(request->xml, F_STONITH_CLIENTID,
+                            request->client->id);
+                crm_xml_add(request->xml, F_STONITH_REMOTE_OP_ID, op->id);
+                send_cluster_message(crm_get_peer(0, alternate_host),
+                                     crm_msg_stonith_ng, request->xml, FALSE);
+                pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_PENDING,
+                                 NULL);
 
-            } else if (initiate_remote_stonith_op(client, request, FALSE) == NULL) {
-                fenced_set_protocol_error(&result);
+            } else if (initiate_remote_stonith_op(request->client, request->xml,
+                                                  FALSE) == NULL) {
+                fenced_set_protocol_error(&request->result);
 
             } else {
-                pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_PENDING, NULL);
+                pcmk__set_result(&request->result, CRM_EX_OK,
+                                 PCMK_EXEC_PENDING, NULL);
             }
         }
-        if (result.execution_status != PCMK_EXEC_PENDING) {
-            reply = fenced_construct_reply(request, NULL, &result);
+        if (request->result.execution_status != PCMK_EXEC_PENDING) {
+            reply = fenced_construct_reply(request->xml, NULL,
+                                           &request->result);
         }
 
     } else if (pcmk__str_eq(op, STONITH_OP_FENCE_HISTORY, pcmk__str_none)) {
         xmlNode *data = NULL;
 
-        stonith_fence_history(request, &data, remote_peer, call_options);
-        pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
-        if (!pcmk_is_set(call_options, st_opt_discard_reply)) {
+        stonith_fence_history(request->xml, &data, request->peer,
+                              request->call_options);
+        pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
+        if (!pcmk_is_set(request->call_options, st_opt_discard_reply)) {
             /* we don't expect answers to the broadcast
              * we might have sent out
              */
-            reply = fenced_construct_reply(request, data, &result);
+            reply = fenced_construct_reply(request->xml, data,
+                                           &request->result);
         }
         free_xml(data);
 
     } else if (pcmk__str_eq(op, STONITH_OP_DEVICE_ADD, pcmk__str_none)) {
         const char *device_id = NULL;
 
-        if (is_privileged(client, op)) {
-            int rc = stonith_device_register(request, &device_id, FALSE);
+        if (is_privileged(request->client, op)) {
+            int rc = stonith_device_register(request->xml, &device_id, FALSE);
 
-            pcmk__set_result(&result,
+            pcmk__set_result(&request->result,
                              ((rc == pcmk_ok)? CRM_EX_OK : CRM_EX_ERROR),
                              stonith__legacy2status(rc),
                              ((rc == pcmk_ok)? NULL : pcmk_strerror(rc)));
         } else {
-            pcmk__set_result(&result, CRM_EX_INSUFFICIENT_PRIV,
+            pcmk__set_result(&request->result, CRM_EX_INSUFFICIENT_PRIV,
                              PCMK_EXEC_INVALID,
                              "Unprivileged users must register device via CIB");
         }
-        fenced_send_device_notification(op, &result, device_id);
-        reply = fenced_construct_reply(request, NULL, &result);
+        fenced_send_device_notification(op, &request->result, device_id);
+        reply = fenced_construct_reply(request->xml, NULL, &request->result);
 
     } else if (pcmk__str_eq(op, STONITH_OP_DEVICE_DEL, pcmk__str_none)) {
-        xmlNode *dev = get_xpath_object("//" F_STONITH_DEVICE, request, LOG_ERR);
+        xmlNode *dev = get_xpath_object("//" F_STONITH_DEVICE, request->xml,
+                                        LOG_ERR);
         const char *device_id = crm_element_value(dev, XML_ATTR_ID);
 
-        if (is_privileged(client, op)) {
+        if (is_privileged(request->client, op)) {
             stonith_device_remove(device_id, false);
-            pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
+            pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE,
+                             NULL);
         } else {
-            pcmk__set_result(&result, CRM_EX_INSUFFICIENT_PRIV,
+            pcmk__set_result(&request->result, CRM_EX_INSUFFICIENT_PRIV,
                              PCMK_EXEC_INVALID,
                              "Unprivileged users must delete device via CIB");
         }
-        fenced_send_device_notification(op, &result, device_id);
-        reply = fenced_construct_reply(request, NULL, &result);
+        fenced_send_device_notification(op, &request->result, device_id);
+        reply = fenced_construct_reply(request->xml, NULL, &request->result);
 
     } else if (pcmk__str_eq(op, STONITH_OP_LEVEL_ADD, pcmk__str_none)) {
         char *device_id = NULL;
 
-        if (is_privileged(client, op)) {
-            fenced_register_level(request, &device_id, &result);
+        if (is_privileged(request->client, op)) {
+            fenced_register_level(request->xml, &device_id, &request->result);
         } else {
-            pcmk__set_result(&result, CRM_EX_INSUFFICIENT_PRIV,
+            pcmk__set_result(&request->result, CRM_EX_INSUFFICIENT_PRIV,
                              PCMK_EXEC_INVALID,
                              "Unprivileged users must add level via CIB");
         }
-        fenced_send_level_notification(op, &result, device_id);
+        fenced_send_level_notification(op, &request->result, device_id);
         free(device_id);
-        reply = fenced_construct_reply(request, NULL, &result);
+        reply = fenced_construct_reply(request->xml, NULL, &request->result);
 
     } else if (pcmk__str_eq(op, STONITH_OP_LEVEL_DEL, pcmk__str_none)) {
         char *device_id = NULL;
 
-        if (is_privileged(client, op)) {
-            fenced_unregister_level(request, &device_id, &result);
+        if (is_privileged(request->client, op)) {
+            fenced_unregister_level(request->xml, &device_id, &request->result);
         } else {
-            pcmk__set_result(&result, CRM_EX_INSUFFICIENT_PRIV,
+            pcmk__set_result(&request->result, CRM_EX_INSUFFICIENT_PRIV,
                              PCMK_EXEC_INVALID,
                              "Unprivileged users must delete level via CIB");
         }
-        fenced_send_level_notification(op, &result, device_id);
-        reply = fenced_construct_reply(request, NULL, &result);
+        fenced_send_level_notification(op, &request->result, device_id);
+        reply = fenced_construct_reply(request->xml, NULL, &request->result);
 
     } else if(pcmk__str_eq(op, CRM_OP_RM_NODE_CACHE, pcmk__str_casei)) {
         int node_id = 0;
         const char *name = NULL;
 
-        crm_element_value_int(request, XML_ATTR_ID, &node_id);
-        name = crm_element_value(request, XML_ATTR_UNAME);
+        crm_element_value_int(request->xml, XML_ATTR_ID, &node_id);
+        name = crm_element_value(request->xml, XML_ATTR_UNAME);
         reap_crm_member(node_id, name);
-        pcmk__set_result(&result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
+        pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
 
     } else {
         crm_err("Unknown IPC request %s from %s %s", op,
-                ((client == NULL)? "peer" : "client"),
-                ((client == NULL)? remote_peer : pcmk__client_name(client)));
-        pcmk__format_result(&result, CRM_EX_PROTOCOL, PCMK_EXEC_INVALID,
+                ((request->client == NULL)? "peer" : "client"),
+                ((request->client == NULL)? request->peer : pcmk__client_name(request->client)));
+        pcmk__format_result(&request->result,
+                            CRM_EX_PROTOCOL, PCMK_EXEC_INVALID,
                             "Unknown IPC request type '%s' (bug?)",
                             crm_str(op));
-        reply = fenced_construct_reply(request, NULL, &result);
+        reply = fenced_construct_reply(request->xml, NULL, &request->result);
     }
 
 done:
     // Reply if result is known
     if (reply != NULL) {
         if (pcmk__str_any_of(op, CRM_OP_REGISTER, T_STONITH_NOTIFY, NULL)
-            && (client != NULL)) {
+            && (request->client != NULL)) {
             /* These IPC-only commands must reuse the call options from the
              * original request rather than the ones set by stonith_send_reply()
              * -> do_local_reply().
              */
-            pcmk__ipc_send_xml(client, id, reply, flags);
-            client->request_id = 0;
+            pcmk__ipc_send_xml(request->client, request->id, reply,
+                               request->flags);
+            request->client->request_id = 0;
         } else {
-            stonith_send_reply(reply, call_options, remote_peer, client);
+            stonith_send_reply(reply, request->call_options,
+                               request->peer, request->client);
         }
         free_xml(reply);
     }
 
-    reason = result.exit_reason;
+    reason = request->result.exit_reason;
     crm_debug("Processed %s request from %s %s: %s%s%s%s",
-              op, ((client == NULL)? "peer" : "client"),
-              ((client == NULL)? remote_peer : pcmk__client_name(client)),
-              pcmk_exec_status_str(result.execution_status),
+              op, ((request->client == NULL)? "peer" : "client"),
+              ((request->client == NULL)? request->peer : pcmk__client_name(request->client)),
+              pcmk_exec_status_str(request->result.execution_status),
               (reason == NULL)? "" : " (",
               (reason == NULL)? "" : reason,
               (reason == NULL)? "" : ")");
-    pcmk__reset_result(&result);
 }
 
 static void
@@ -3373,6 +3402,17 @@ stonith_command(pcmk__client_t *client, uint32_t id, uint32_t flags,
     if (is_reply) {
         handle_reply(client, message, remote_peer);
     } else {
-        handle_request(client, id, flags, message, remote_peer);
+        pcmk__request_t request = {
+            .client = client,
+            .id = id,
+            .flags = flags,
+            .peer = remote_peer,
+            .xml = message,
+            .call_options = call_options,
+            .result = PCMK__UNKNOWN_RESULT,
+        };
+
+        handle_request(&request);
+        pcmk__reset_result(&request.result);
     }
 }

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -443,7 +443,7 @@ handle_local_reply_and_notify(remote_fencing_op_t *op, xmlNode *data)
     crm_xml_add(reply, F_STONITH_DELEGATE, op->delegate);
 
     /* Send fencing OP reply to local client that initiated fencing */
-    do_local_reply(reply, op->client_id, op->call_options & st_opt_sync_call, FALSE);
+    do_local_reply(reply, op->client_id, op->call_options & st_opt_sync_call);
 
     /* bcast to all local clients that the fencing operation happend */
     notify_data = fencing_result2xml(op);

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -2249,6 +2249,7 @@ fenced_process_fencing_reply(xmlNode *msg)
 
     if (pcmk_is_set(op->call_options, st_opt_topology)) {
         const char *device = NULL;
+        const char *reason = op->result.exit_reason;
 
         /* We own the op, and it is complete. broadcast the result to all nodes
          * and notify our local clients. */
@@ -2266,8 +2267,8 @@ fenced_process_fencing_reply(xmlNode *msg)
             crm_warn("Ignoring %s 'on' failure (%s%s%s) targeting %s "
                      "after successful 'off'",
                      device, pcmk_exec_status_str(op->result.execution_status),
-                     (op->result.exit_reason == NULL)? "" : ": ",
-                     (op->result.exit_reason == NULL)? "" : op->result.exit_reason,
+                     (reason == NULL)? "" : ": ",
+                     (reason == NULL)? "" : reason,
                      op->target);
             pcmk__set_result(&op->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
         } else {
@@ -2276,9 +2277,9 @@ fenced_process_fencing_reply(xmlNode *msg)
                        op->action, op->target, device, op->client_name,
                        op->originator,
                        pcmk_exec_status_str(op->result.execution_status),
-                       (op->result.exit_reason == NULL)? "" : " (",
-                       (op->result.exit_reason == NULL)? "" : op->result.exit_reason,
-                       (op->result.exit_reason == NULL)? "" : ")");
+                       (reason == NULL)? "" : " (",
+                       (reason == NULL)? "" : reason,
+                       (reason == NULL)? "" : ")");
         }
 
         if (pcmk__result_ok(&op->result)) {

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -428,6 +428,7 @@ handle_local_reply_and_notify(remote_fencing_op_t *op, xmlNode *data)
 {
     xmlNode *notify_data = NULL;
     xmlNode *reply = NULL;
+    pcmk__client_t *client = NULL;
 
     if (op->notify_sent == TRUE) {
         /* nothing to do */
@@ -443,7 +444,12 @@ handle_local_reply_and_notify(remote_fencing_op_t *op, xmlNode *data)
     crm_xml_add(reply, F_STONITH_DELEGATE, op->delegate);
 
     /* Send fencing OP reply to local client that initiated fencing */
-    do_local_reply(reply, op->client_id, op->call_options);
+    client = pcmk__find_client_by_id(op->client_id);
+    if (client == NULL) {
+        crm_trace("Skipping reply to %s: no longer a client", op->client_id);
+    } else {
+        do_local_reply(reply, client, op->call_options);
+    }
 
     /* bcast to all local clients that the fencing operation happend */
     notify_data = fencing_result2xml(op);

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -443,7 +443,7 @@ handle_local_reply_and_notify(remote_fencing_op_t *op, xmlNode *data)
     crm_xml_add(reply, F_STONITH_DELEGATE, op->delegate);
 
     /* Send fencing OP reply to local client that initiated fencing */
-    do_local_reply(reply, op->client_id, op->call_options & st_opt_sync_call);
+    do_local_reply(reply, op->client_id, op->call_options);
 
     /* bcast to all local clients that the fencing operation happend */
     notify_data = fencing_result2xml(op);

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -1286,6 +1286,7 @@ stonith_cleanup(void)
     free_topology_list();
     free_device_list();
     free_metadata_cache();
+    fenced_unregister_handlers();
 
     free(stonith_our_uname);
     stonith_our_uname = NULL;

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -226,46 +226,28 @@ stonith_peer_cs_destroy(gpointer user_data)
 #endif
 
 void
-do_local_reply(xmlNode *notify_src, const char *client_id, int call_options)
+do_local_reply(xmlNode *notify_src, pcmk__client_t *client, int call_options)
 {
     /* send callback to originating child */
-    pcmk__client_t *client_obj = NULL;
     int local_rc = pcmk_rc_ok;
+    int rid = 0;
+    uint32_t ipc_flags = crm_ipc_server_event;
 
-    crm_trace("Sending response");
-    client_obj = pcmk__find_client_by_id(client_id);
-
-    crm_trace("Sending callback to request originator");
-    if (client_obj == NULL) {
-        local_rc = EPROTO;
-        crm_trace("No client to sent the response to.  F_STONITH_CLIENTID not set.");
-
-    } else {
-        int rid = 0;
-        uint32_t ipc_flags = crm_ipc_server_event;
-
-        if (pcmk_is_set(call_options, st_opt_sync_call)) {
-            CRM_LOG_ASSERT(client_obj->request_id);
-
-            rid = client_obj->request_id;
-            client_obj->request_id = 0;
-            ipc_flags = crm_ipc_flags_none;
-
-            crm_trace("Sending response %d to client %s",
-                      rid, pcmk__client_name(client_obj));
-
-        } else {
-            crm_trace("Sending an event to client %s",
-                      pcmk__client_name(client_obj));
-        }
-
-        local_rc = pcmk__ipc_send_xml(client_obj, rid, notify_src, ipc_flags);
+    if (pcmk_is_set(call_options, st_opt_sync_call)) {
+        CRM_LOG_ASSERT(client->request_id);
+        rid = client->request_id;
+        client->request_id = 0;
+        ipc_flags = crm_ipc_flags_none;
     }
 
-    if ((local_rc != pcmk_rc_ok) && (client_obj != NULL)) {
+    local_rc = pcmk__ipc_send_xml(client, rid, notify_src, ipc_flags);
+    if (local_rc == pcmk_rc_ok) {
+        crm_trace("Sent response %d to client %s",
+                  rid, pcmk__client_name(client));
+    } else {
         crm_warn("%synchronous reply to client %s failed: %s",
                  (pcmk_is_set(call_options, st_opt_sync_call)? "S" : "As"),
-                 pcmk__client_name(client_obj), pcmk_rc_str(local_rc));
+                 pcmk__client_name(client), pcmk_rc_str(local_rc));
     }
 }
 

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -226,7 +226,7 @@ stonith_peer_cs_destroy(gpointer user_data)
 #endif
 
 void
-do_local_reply(xmlNode * notify_src, const char *client_id, gboolean sync_reply, gboolean from_peer)
+do_local_reply(xmlNode *notify_src, const char *client_id, gboolean sync_reply)
 {
     /* send callback to originating child */
     pcmk__client_t *client_obj = NULL;
@@ -249,14 +249,12 @@ do_local_reply(xmlNode * notify_src, const char *client_id, gboolean sync_reply,
             rid = client_obj->request_id;
             client_obj->request_id = 0;
 
-            crm_trace("Sending response %d to client %s%s",
-                      rid, pcmk__client_name(client_obj),
-                      (from_peer? " (originator of delegated request)" : ""));
+            crm_trace("Sending response %d to client %s",
+                      rid, pcmk__client_name(client_obj));
 
         } else {
-            crm_trace("Sending an event to client %s%s",
-                      pcmk__client_name(client_obj),
-                      (from_peer? " (originator of delegated request)" : ""));
+            crm_trace("Sending an event to client %s",
+                      pcmk__client_name(client_obj));
         }
 
         local_rc = pcmk__ipc_send_xml(client_obj, rid, notify_src,

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -228,7 +228,7 @@ void fenced_unregister_level(xmlNode *msg, char **desc,
 
 stonith_topology_t *find_topology_for_host(const char *host);
 
-void do_local_reply(xmlNode *notify_src, const char *client_id,
+void do_local_reply(xmlNode *notify_src, pcmk__client_t *client,
                     int call_options);
 
 xmlNode *fenced_construct_reply(xmlNode *request, xmlNode *data,

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -229,7 +229,7 @@ void fenced_unregister_level(xmlNode *msg, char **desc,
 stonith_topology_t *find_topology_for_host(const char *host);
 
 void do_local_reply(xmlNode *notify_src, const char *client_id,
-                    gboolean sync_reply);
+                    int call_options);
 
 xmlNode *fenced_construct_reply(xmlNode *request, xmlNode *data,
                                 pcmk__action_result_t *result);

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -228,8 +228,8 @@ void fenced_unregister_level(xmlNode *msg, char **desc,
 
 stonith_topology_t *find_topology_for_host(const char *host);
 
-void do_local_reply(xmlNode * notify_src, const char *client_id, gboolean sync_reply,
-                           gboolean from_peer);
+void do_local_reply(xmlNode *notify_src, const char *client_id,
+                    gboolean sync_reply);
 
 xmlNode *fenced_construct_reply(xmlNode *request, xmlNode *data,
                                 pcmk__action_result_t *result);

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -210,6 +210,7 @@ void free_topology_list(void);
 void free_stonith_remote_op_list(void);
 void init_stonith_remote_op_hash_table(GHashTable **table);
 void free_metadata_cache(void);
+void fenced_unregister_handlers(void);
 
 uint64_t get_stonith_flag(const char *name);
 

--- a/include/crm/common/Makefile.am
+++ b/include/crm/common/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2004-2021 the Pacemaker project contributors
+# Copyright 2004-2022 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -24,4 +24,5 @@ noinst_HEADERS = internal.h alerts_internal.h \
 		 iso8601_internal.h remote_internal.h xml_internal.h \
 		 ipc_internal.h output_internal.h cmdline_internal.h	\
 		 attrd_internal.h options_internal.h results_internal.h	\
-		 strings_internal.h lists_internal.h logging_internal.h
+		 strings_internal.h lists_internal.h logging_internal.h \
+		 messages_internal.h

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the Pacemaker project contributors
+ * Copyright 2015-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -25,6 +25,7 @@
 #include <crm/common/mainloop.h> // mainloop_io_t, struct ipc_client_callbacks
 #include <crm/common/iso8601_internal.h>
 #include <crm/common/results_internal.h>
+#include <crm/common/messages_internal.h>
 #include <crm/common/strings_internal.h>
 
 /* This says whether the current application is a Pacemaker daemon or not,
@@ -117,11 +118,6 @@ int pcmk__add_mainloop_ipc(crm_ipc_t *ipc, int priority, void *userdata,
                            struct ipc_client_callbacks *callbacks,
                            mainloop_io_t **source);
 guint pcmk__mainloop_timer_get_period(mainloop_timer_t *timer);
-
-
-/* internal messaging utilities (from messages.c) */
-
-const char *pcmk__message_name(const char *name);
 
 
 /* internal name/value utilities (from nvpair.c) */

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the Pacemaker project contributors
+ * Copyright 2013-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -202,6 +202,11 @@ pcmk__client_t *pcmk__new_client(qb_ipcs_connection_t *c, uid_t uid, gid_t gid);
 void pcmk__free_client(pcmk__client_t *c);
 void pcmk__drop_all_clients(qb_ipcs_service_t *s);
 bool pcmk__set_client_queue_max(pcmk__client_t *client, const char *qmax);
+
+xmlNode *pcmk__ipc_create_ack_as(const char *function, int line, uint32_t flags,
+                                 const char *tag, crm_exit_t status);
+#define pcmk__ipc_create_ack(flags, tag, st) \
+    pcmk__ipc_create_ack_as(__func__, __LINE__, (flags), (tag), (st))
 
 int pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
                           uint32_t request, uint32_t flags, const char *tag,

--- a/include/crm/common/messages_internal.h
+++ b/include/crm/common/messages_internal.h
@@ -33,4 +33,25 @@ typedef struct {
 
 const char *pcmk__message_name(const char *name);
 
+/*!
+ * \internal
+ * \brief Get a loggable description of a request's origin
+ *
+ * \param[in] request
+ *
+ * \return "peer" if request was via CPG, "client" if via IPC, or "originator"
+ *         if unknown
+ */
+static inline const char *
+pcmk__request_origin_type(pcmk__request_t *request)
+{
+    if ((request != NULL) && (request->client != NULL)) {
+        return "client";
+    } else if ((request != NULL) && (request->peer != NULL)) {
+        return "peer";
+    } else {
+        return "originator";
+    }
+}
+
 #endif // PCMK__CRM_COMMON_MESSAGES_INTERNAL__H

--- a/include/crm/common/messages_internal.h
+++ b/include/crm/common/messages_internal.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2018-2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__CRM_COMMON_MESSAGES_INTERNAL__H
+#define PCMK__CRM_COMMON_MESSAGES_INTERNAL__H
+
+const char *pcmk__message_name(const char *name);
+
+#endif // PCMK__CRM_COMMON_MESSAGES_INTERNAL__H

--- a/include/crm/common/messages_internal.h
+++ b/include/crm/common/messages_internal.h
@@ -18,9 +18,9 @@
 // Server request (whether from an IPC client or cluster peer)
 typedef struct {
     // If request is from an IPC client
-    pcmk__client_t *client;  // IPC client (NULL if not via IPC)
-    uint32_t id;             // IPC message ID
-    uint32_t flags;          // IPC message flags
+    pcmk__client_t *ipc_client;     // IPC client (NULL if not via IPC)
+    uint32_t ipc_id;                // IPC message ID
+    uint32_t ipc_flags;             // IPC message flags
 
     // If message is from a cluster peer
     const char *peer;       // Peer name (NULL if not via cluster)
@@ -54,7 +54,7 @@ xmlNode *pcmk__process_request(pcmk__request_t *request, const char *op,
 static inline const char *
 pcmk__request_origin_type(pcmk__request_t *request)
 {
-    if ((request != NULL) && (request->client != NULL)) {
+    if ((request != NULL) && (request->ipc_client != NULL)) {
         return "client";
     } else if ((request != NULL) && (request->peer != NULL)) {
         return "peer";
@@ -75,8 +75,8 @@ pcmk__request_origin_type(pcmk__request_t *request)
 static inline const char *
 pcmk__request_origin(pcmk__request_t *request)
 {
-    if ((request != NULL) && (request->client != NULL)) {
-        return pcmk__client_name(request->client);
+    if ((request != NULL) && (request->ipc_client != NULL)) {
+        return pcmk__client_name(request->ipc_client);
     } else if ((request != NULL) && (request->peer != NULL)) {
         return request->peer;
     } else {

--- a/include/crm/common/messages_internal.h
+++ b/include/crm/common/messages_internal.h
@@ -10,6 +10,27 @@
 #ifndef PCMK__CRM_COMMON_MESSAGES_INTERNAL__H
 #define PCMK__CRM_COMMON_MESSAGES_INTERNAL__H
 
+#include <stdint.h>                         // uint32_t
+#include <libxml/tree.h>                    // xmlNode
+#include <crm/common/ipc_internal.h>        // pcmk__client_t
+#include <crm/common/results_internal.h>    // pcmk__action_result_t
+
+// Server request (whether from an IPC client or cluster peer)
+typedef struct {
+    // If request is from an IPC client
+    pcmk__client_t *client;  // IPC client (NULL if not via IPC)
+    uint32_t id;             // IPC message ID
+    uint32_t flags;          // IPC message flags
+
+    // If message is from a cluster peer
+    const char *peer;       // Peer name (NULL if not via cluster)
+
+    // Common information regardless of origin
+    xmlNode *xml;                   // Request XML
+    int call_options;               // Call options set on request
+    pcmk__action_result_t result;   // Where to store operation result
+} pcmk__request_t;
+
 const char *pcmk__message_name(const char *name);
 
 #endif // PCMK__CRM_COMMON_MESSAGES_INTERNAL__H

--- a/include/crm/common/messages_internal.h
+++ b/include/crm/common/messages_internal.h
@@ -31,7 +31,16 @@ typedef struct {
     pcmk__action_result_t result;   // Where to store operation result
 } pcmk__request_t;
 
+// Type for mapping a server command to a handler
+typedef struct {
+    const char *command;
+    xmlNode *(*handler)(pcmk__request_t *request);
+} pcmk__server_command_t;
+
 const char *pcmk__message_name(const char *name);
+GHashTable *pcmk__register_handlers(pcmk__server_command_t handlers[]);
+xmlNode *pcmk__process_request(pcmk__request_t *request, const char *op,
+                               bool sync, GHashTable *handlers);
 
 /*!
  * \internal

--- a/include/crm/common/messages_internal.h
+++ b/include/crm/common/messages_internal.h
@@ -54,4 +54,25 @@ pcmk__request_origin_type(pcmk__request_t *request)
     }
 }
 
+/*!
+ * \internal
+ * \brief Get a loggable name for a request's origin
+ *
+ * \param[in] request
+ *
+ * \return Peer name if request was via CPG, client name if via IPC, or
+ *         "(unspecified)" if unknown
+ */
+static inline const char *
+pcmk__request_origin(pcmk__request_t *request)
+{
+    if ((request != NULL) && (request->client != NULL)) {
+        return pcmk__client_name(request->client);
+    } else if ((request != NULL) && (request->peer != NULL)) {
+        return request->peer;
+    } else {
+        return "(unspecified)";
+    }
+}
+
 #endif // PCMK__CRM_COMMON_MESSAGES_INTERNAL__H

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -771,13 +771,40 @@ pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request, xmlNode *message,
 
 /*!
  * \internal
+ * \brief Create an acknowledgement with a status code to send to a client
+ *
+ * \param[in] function  Calling function
+ * \param[in] line      Source file line within calling function
+ * \param[in] flags     IPC flags to use when sending
+ * \param[in] tag       Element name to use for acknowledgement
+ * \param[in] status    Exit status code to add to ack
+ *
+ * \return Newly created XML for ack
+ * \note The caller is responsible for freeing the return value with free_xml().
+ */
+xmlNode *
+pcmk__ipc_create_ack_as(const char *function, int line, uint32_t flags,
+                        const char *tag, crm_exit_t status)
+{
+    xmlNode *ack = NULL;
+
+    if (pcmk_is_set(flags, crm_ipc_client_response)) {
+        ack = create_xml_node(NULL, tag);
+        crm_xml_add(ack, "function", function);
+        crm_xml_add_int(ack, "line", line);
+        crm_xml_add_int(ack, "status", (int) status);
+    }
+    return ack;
+}
+
+/*!
+ * \internal
  * \brief Send an acknowledgement with a status code to a client
  *
  * \param[in] function  Calling function
  * \param[in] line      Source file line within calling function
  * \param[in] c         Client to send ack to
  * \param[in] request   Request ID being replied to
- * \param[in] status    Exit status code to add to ack
  * \param[in] flags     IPC flags to use when sending
  * \param[in] tag       Element name to use for acknowledgement
  * \param[in] status    Status code to send with acknowledgement
@@ -790,16 +817,12 @@ pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
                       crm_exit_t status)
 {
     int rc = pcmk_rc_ok;
+    xmlNode *ack = pcmk__ipc_create_ack_as(function, line, flags, tag, status);
 
-    if (pcmk_is_set(flags, crm_ipc_client_response)) {
-        xmlNode *ack = create_xml_node(NULL, tag);
-
+    if (ack != NULL) {
         crm_trace("Ack'ing IPC message from client %s as <%s status=%d>",
                   pcmk__client_name(c), tag, status);
         c->request_id = 0;
-        crm_xml_add(ack, "function", function);
-        crm_xml_add_int(ack, "line", line);
-        crm_xml_add_int(ack, "status", (int) status);
         rc = pcmk__ipc_send_xml(c, request, ack, flags);
         free_xml(ack);
     }

--- a/lib/common/messages.c
+++ b/lib/common/messages.c
@@ -263,8 +263,9 @@ pcmk__process_request(pcmk__request_t *request, const char *op,
     CRM_CHECK((request != NULL) && (op != NULL) && (handlers != NULL),
               return NULL);
 
-    if (sync && (request->client != NULL)) {
-        CRM_CHECK(request->client->request_id == request->id, return NULL);
+    if (sync && (request->ipc_client != NULL)) {
+        CRM_CHECK(request->ipc_client->request_id == request->ipc_id,
+                  return NULL);
     }
 
     handler = g_hash_table_lookup(handlers, op);

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -511,12 +511,7 @@ stonith_action_async_done(svc_action_t *svc_action)
     stonith_action_t *action = (stonith_action_t *) svc_action->cb_data;
 
     set_result_from_svc_action(action, svc_action);
-
     svc_action->params = NULL;
-
-    crm_debug("Child process %d performing action '%s' exited with rc %d",
-                action->pid, action->action, svc_action->rc);
-
     log_action(action, action->pid);
 
     if (!pcmk__result_ok(&(action->result))

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2492,8 +2492,17 @@ stonith__event_exit_reason(stonith_event_t *event)
 char *
 stonith__event_description(stonith_event_t *event)
 {
-    const char *reason;
+    const char *origin = event->client_origin;
+    const char *executioner = event->executioner;
+    const char *reason = stonith__event_exit_reason(event);
     const char *status;
+
+    if (origin == NULL) {
+        origin = "a client";
+    }
+    if (executioner == NULL) {
+        executioner = "the cluster";
+    }
 
     if (stonith__event_execution_status(event) != PCMK_EXEC_DONE) {
         status = pcmk_exec_status_str(stonith__event_execution_status(event));
@@ -2502,12 +2511,9 @@ stonith__event_description(stonith_event_t *event)
     } else {
         status = crm_exit_str(CRM_EX_OK);
     }
-    reason = stonith__event_exit_reason(event);
 
     return crm_strdup_printf("Operation %s of %s by %s for %s@%s: %s%s%s%s (ref=%s)",
-                             event->action, event->target,
-                             (event->executioner? event->executioner : "the cluster"),
-                             (event->client_origin? event->client_origin : "a client"),
+                             event->action, event->target, executioner, origin,
                              event->origin, status,
                              ((reason == NULL)? "" : " ("),
                              ((reason == NULL)? "" : reason),

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -467,7 +467,6 @@ pipe_in_single_parameter(gpointer key, gpointer value, gpointer user_data)
 static void
 pipe_in_action_stdin_parameters(const svc_action_t *op)
 {
-    crm_debug("sending args");
     if (op->params) {
         g_hash_table_foreach(op->params, pipe_in_single_parameter, (gpointer) op);
     }

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -344,6 +344,7 @@ request_fencing(stonith_t *st, const char *target, const char *command,
 
     if (rc != pcmk_rc_ok) {
         const char *rc_str = pcmk_rc_str(rc);
+        const char *what = (strcmp(command, "on") == 0)? "unfence" : "fence";
 
         // If reason is identical to return code string, don't display it twice
         if (pcmk__str_eq(rc_str, reason, pcmk__str_none)) {
@@ -352,9 +353,8 @@ request_fencing(stonith_t *st, const char *target, const char *command,
         }
 
         g_set_error(error, PCMK__RC_ERROR, rc,
-                    "Couldn't %sfence %s: %s%s%s%s",
-                    ((strcmp(command, "on") == 0)? "un" : ""),
-                    target, pcmk_rc_str(rc),
+                    "Couldn't %s %s: %s%s%s%s",
+                    what, target, rc_str,
                     ((reason == NULL)? "" : " ("),
                     ((reason == NULL)? "" : reason),
                     ((reason == NULL)? "" : ")"));


### PR DESCRIPTION
This is another follow-up addressing issues found during the project adding exit reasons for fencing actions. This improves some fencing logs, and refactors the code to make it simpler and easier to follow. Most significantly, it refactors server API processing as a hash table of function pointers rather than a long series of if-else blocks.