### PR TITLE
Set working set flags correctly

### DIFF
--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -53,6 +53,9 @@ static gboolean stonith_shutdown_flag = FALSE;
 static qb_ipcs_service_t *ipcs = NULL;
 static xmlNode *local_cib = NULL;
 static pe_working_set_t *fenced_data_set = NULL;
+static const unsigned long long data_set_flags = pe_flag_quick_location
+                                                 | pe_flag_no_compat
+                                                 | pe_flag_no_counts;
 
 static cib_t *cib_api = NULL;
 
@@ -822,10 +825,10 @@ cib_devices_update(void)
     fenced_data_set->input = local_cib;
     fenced_data_set->now = crm_time_new(NULL);
     fenced_data_set->localhost = stonith_our_uname;
-    pe__set_working_set_flags(fenced_data_set, pe_flag_quick_location);
+    pe__set_working_set_flags(fenced_data_set, data_set_flags);
 
     cluster_status(fenced_data_set);
-    pcmk__schedule_actions(NULL, fenced_data_set);
+    pcmk__schedule_actions(NULL, data_set_flags, fenced_data_set);
 
     g_hash_table_iter_init(&iter, device_list);
     while (g_hash_table_iter_next(&iter, NULL, (void **)&device)) {
@@ -1644,9 +1647,6 @@ main(int argc, char **argv)
 
     fenced_data_set = pe_new_working_set();
     CRM_ASSERT(fenced_data_set != NULL);
-    pe__set_working_set_flags(fenced_data_set,
-                              pe_flag_no_counts|pe_flag_no_compat);
-    pe__set_working_set_flags(fenced_data_set, pe_flag_show_utilization);
 
     cluster = calloc(1, sizeof(crm_cluster_t));
     CRM_ASSERT(cluster != NULL);

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -821,14 +821,12 @@ cib_devices_update(void)
              crm_element_value(local_cib, XML_ATTR_GENERATION),
              crm_element_value(local_cib, XML_ATTR_NUMUPDATES));
 
-    CRM_ASSERT(fenced_data_set != NULL);
-    fenced_data_set->input = local_cib;
-    fenced_data_set->now = crm_time_new(NULL);
+    if (fenced_data_set->now != NULL) {
+        crm_time_free(fenced_data_set->now);
+        fenced_data_set->now = NULL;
+    }
     fenced_data_set->localhost = stonith_our_uname;
-    pe__set_working_set_flags(fenced_data_set, data_set_flags);
-
-    cluster_status(fenced_data_set);
-    pcmk__schedule_actions(NULL, data_set_flags, fenced_data_set);
+    pcmk__schedule_actions(local_cib, data_set_flags, fenced_data_set);
 
     g_hash_table_iter_init(&iter, device_list);
     while (g_hash_table_iter_next(&iter, NULL, (void **)&device)) {

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -825,7 +825,7 @@ cib_devices_update(void)
     pe__set_working_set_flags(fenced_data_set, pe_flag_quick_location);
 
     cluster_status(fenced_data_set);
-    pcmk__schedule_actions(fenced_data_set, NULL, NULL);
+    pcmk__schedule_actions(fenced_data_set, NULL);
 
     g_hash_table_iter_init(&iter, device_list);
     while (g_hash_table_iter_next(&iter, NULL, (void **)&device)) {

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -825,7 +825,7 @@ cib_devices_update(void)
     pe__set_working_set_flags(fenced_data_set, pe_flag_quick_location);
 
     cluster_status(fenced_data_set);
-    pcmk__schedule_actions(fenced_data_set, NULL);
+    pcmk__schedule_actions(NULL, fenced_data_set);
 
     g_hash_table_iter_init(&iter, device_list);
     while (g_hash_table_iter_next(&iter, NULL, (void **)&device)) {

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -30,7 +30,6 @@ struct {
     gchar **remainder;
 } options;
 
-pe_working_set_t *sched_data_set = NULL;
 pcmk__output_t *logger_out = NULL;
 pcmk__output_t *out = NULL;
 
@@ -162,11 +161,6 @@ pengine_shutdown(int nsig)
         crm_trace("Closing IPC server");
         mainloop_del_ipc_server(ipcs);
         ipcs = NULL;
-    }
-
-    if (sched_data_set != NULL) {
-        pe_free_working_set(sched_data_set);
-        sched_data_set = NULL;
     }
 
     if (logger_out != NULL) {

--- a/daemons/schedulerd/pacemaker-schedulerd.h
+++ b/daemons/schedulerd/pacemaker-schedulerd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -13,7 +13,6 @@
 #include <crm_internal.h>
 #include <crm/pengine/pe_types.h>
 
-extern pe_working_set_t *sched_data_set;
 extern pcmk__output_t *logger_out;
 extern pcmk__output_t *out;
 extern struct qb_ipcs_service_handlers ipc_callbacks;

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -93,7 +93,10 @@ handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
     }
 
     if (process) {
-        pcmk__schedule_actions(converted, sched_data_set);
+        pcmk__schedule_actions(converted,
+                               pe_flag_no_counts
+                               |pe_flag_no_compat
+                               |pe_flag_show_utilization, sched_data_set);
     }
 
     // Get appropriate index into series[] array

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -93,7 +93,7 @@ handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
     }
 
     if (process) {
-        pcmk__schedule_actions(sched_data_set, converted);
+        pcmk__schedule_actions(converted, sched_data_set);
     }
 
     // Get appropriate index into series[] array

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -93,7 +93,7 @@ handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
     }
 
     if (process) {
-        pcmk__schedule_actions(sched_data_set, converted, NULL);
+        pcmk__schedule_actions(sched_data_set, converted);
     }
 
     // Get appropriate index into series[] array

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -19,26 +19,21 @@
 
 #include "pacemaker-schedulerd.h"
 
-static void
+static pe_working_set_t *
 init_working_set(void)
 {
+    pe_working_set_t *data_set = pe_new_working_set();
+
+    CRM_ASSERT(data_set != NULL);
+
     crm_config_error = FALSE;
     crm_config_warning = FALSE;
 
     was_processing_error = FALSE;
     was_processing_warning = FALSE;
 
-    if (sched_data_set == NULL) {
-        sched_data_set = pe_new_working_set();
-        CRM_ASSERT(sched_data_set != NULL);
-        pe__set_working_set_flags(sched_data_set,
-                                  pe_flag_no_counts|pe_flag_no_compat);
-        pe__set_working_set_flags(sched_data_set,
-                                  pe_flag_show_utilization);
-        sched_data_set->priv = logger_out;
-    } else {
-        pe_reset_working_set(sched_data_set);
-    }
+    data_set->priv = logger_out;
+    return data_set;
 }
 
 static void
@@ -70,16 +65,15 @@ handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
     xmlNode *reply = NULL;
     bool is_repoke = false;
     bool process = true;
-
-    init_working_set();
+    pe_working_set_t *data_set = init_working_set();
 
     digest = calculate_xml_versioned_digest(xml_data, FALSE, FALSE,
                                             CRM_FEATURE_SET);
     converted = copy_xml(xml_data);
     if (!cli_config_update(&converted, NULL, TRUE)) {
-        sched_data_set->graph = create_xml_node(NULL, XML_TAG_GRAPH);
-        crm_xml_add_int(sched_data_set->graph, "transition_id", 0);
-        crm_xml_add_int(sched_data_set->graph, "cluster-delay", 0);
+        data_set->graph = create_xml_node(NULL, XML_TAG_GRAPH);
+        crm_xml_add_int(data_set->graph, "transition_id", 0);
+        crm_xml_add_int(data_set->graph, "cluster-delay", 0);
         process = false;
         free(digest);
 
@@ -96,7 +90,7 @@ handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
         pcmk__schedule_actions(converted,
                                pe_flag_no_counts
                                |pe_flag_no_compat
-                               |pe_flag_show_utilization, sched_data_set);
+                               |pe_flag_show_utilization, data_set);
     }
 
     // Get appropriate index into series[] array
@@ -108,7 +102,7 @@ handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
         series_id = 2;
     }
 
-    value = pe_pref(sched_data_set->config_hash, series[series_id].param);
+    value = pe_pref(data_set->config_hash, series[series_id].param);
     if ((value == NULL)
         || (pcmk__scan_min_int(value, &series_wrap, -1) != pcmk_rc_ok)) {
         series_wrap = series[series_id].wrap;
@@ -122,8 +116,8 @@ handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
     crm_trace("Series %s: wrap=%d, seq=%u, pref=%s",
               series[series_id].name, series_wrap, seq, value);
 
-    sched_data_set->input = NULL;
-    reply = create_reply(msg, sched_data_set->graph);
+    data_set->input = NULL;
+    reply = create_reply(msg, data_set->graph);
     CRM_ASSERT(reply != NULL);
 
     if (series_wrap == 0) { // Don't save any inputs of this kind
@@ -156,7 +150,7 @@ handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
                 graph_file);
 
         crm_xml_add(reply, F_CRM_TGRAPH, graph_file);
-        write_xml_fd(sched_data_set->graph, graph_file, graph_file_fd, FALSE);
+        write_xml_fd(data_set->graph, graph_file, graph_file_fd, FALSE);
 
         free(graph_file);
         free_xml(first_named_child(reply, F_CRM_DATA));
@@ -182,6 +176,7 @@ handle_pecalc_op(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
     }
 
     free_xml(converted);
+    pe_free_working_set(data_set);
 }
 
 static void

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -133,6 +133,12 @@ enum pe_find {
 
 #  define pe_flag_show_scores           0x02000000ULL
 #  define pe_flag_show_utilization      0x04000000ULL
+
+/*!
+ * When scheduling, only unpack the CIB (including constraints), calculate
+ * as much cluster status as possible, and apply node health.
+ */
+#  define pe_flag_check_config          0x08000000ULL
 
 struct pe_working_set_s {
     xmlNode *input;

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -58,7 +58,6 @@ struct rsc_ticket_s {
     int role_lh;
 };
 
-extern gboolean stage0(pe_working_set_t * data_set);
 extern gboolean stage2(pe_working_set_t * data_set);
 extern gboolean stage5(pe_working_set_t * data_set);
 extern gboolean stage6(pe_working_set_t * data_set);

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -65,7 +65,8 @@ extern gboolean stage6(pe_working_set_t * data_set);
 void pcmk__unpack_constraints(pe_working_set_t *data_set);
 
 extern void add_maintenance_update(pe_working_set_t *data_set);
-void pcmk__schedule_actions(xmlNode *cib, pe_working_set_t *data_set);
+void pcmk__schedule_actions(xmlNode *cib, unsigned long long flags,
+                            pe_working_set_t *data_set);
 
 extern const char *transition_idle_timeout;
 

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -66,8 +66,7 @@ extern gboolean stage6(pe_working_set_t * data_set);
 void pcmk__unpack_constraints(pe_working_set_t *data_set);
 
 extern void add_maintenance_update(pe_working_set_t *data_set);
-xmlNode *pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input,
-                                crm_time_t *now);
+xmlNode *pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input);
 
 extern const char *transition_idle_timeout;
 

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -65,7 +65,7 @@ extern gboolean stage6(pe_working_set_t * data_set);
 void pcmk__unpack_constraints(pe_working_set_t *data_set);
 
 extern void add_maintenance_update(pe_working_set_t *data_set);
-xmlNode *pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input);
+void pcmk__schedule_actions(xmlNode *cib, pe_working_set_t *data_set);
 
 extern const char *transition_idle_timeout;
 

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -738,11 +738,9 @@ log_all_actions(pe_working_set_t *data_set)
  *
  * \param[in,out] data_set  Cluster working set
  * \param[in]     xml_input CIB XML to use as scheduler input
- * \param[in]     now       Time to use for rule evaluation (or NULL for now)
  */
 xmlNode *
-pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input,
-                       crm_time_t *now)
+pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input)
 {
     GList *gIter = NULL;
 
@@ -751,14 +749,9 @@ pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input,
     if (!pcmk_is_set(data_set->flags, pe_flag_have_status)) {
         set_working_set_defaults(data_set);
         data_set->input = xml_input;
-        data_set->now = now;
 
     } else {
         crm_trace("Already have status - reusing");
-    }
-
-    if (data_set->now == NULL) {
-        data_set->now = crm_time_new(NULL);
     }
 
     crm_trace("Calculate cluster status");

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -767,20 +767,20 @@ unpack_cib(xmlNode *cib, pe_working_set_t *data_set)
  * \internal
  * \brief Run the scheduler for a given CIB
  *
+ * \param[in]     cib       CIB XML to use as scheduler input
  * \param[in,out] data_set  Cluster working set
- * \param[in]     xml_input CIB XML to use as scheduler input
  */
-xmlNode *
-pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input)
+void
+pcmk__schedule_actions(xmlNode *cib, pe_working_set_t *data_set)
 {
-    unpack_cib(xml_input, data_set);
+    unpack_cib(cib, data_set);
     pcmk__set_allocation_methods(data_set);
     pcmk__apply_node_health(data_set);
     pcmk__unpack_constraints(data_set);
-
     if (pcmk_is_set(data_set->flags, pe_flag_check_config)) {
-        return data_set->graph;
+        return;
     }
+
     if (!pcmk_is_set(data_set->flags, pe_flag_quick_location) &&
          pcmk__is_daemon) {
         log_resource_details(data_set);
@@ -790,7 +790,7 @@ pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input)
     stage2(data_set);
 
     if (pcmk_is_set(data_set->flags, pe_flag_quick_location)) {
-        return NULL;
+        return;
     }
 
     pcmk__create_internal_constraints(data_set);
@@ -810,5 +810,4 @@ pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input)
     if (get_crm_log_level() == LOG_TRACE) {
         log_unrunnable_actions(data_set);
     }
-    return data_set->graph;
 }

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -756,6 +756,9 @@ pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input)
 
     crm_trace("Calculate cluster status");
     stage0(data_set);
+    if (pcmk_is_set(data_set->flags, pe_flag_check_config)) {
+        return data_set->graph;
+    }
     if (!pcmk_is_set(data_set->flags, pe_flag_quick_location) &&
          pcmk__is_daemon) {
         log_resource_details(data_set);

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -739,13 +739,15 @@ log_unrunnable_actions(pe_working_set_t *data_set)
  * \brief Unpack the CIB for scheduling
  *
  * \param[in] cib       CIB XML to unpack (may be NULL if previously unpacked)
+ * \param[in] flags     Working set flags to set in addition to defaults
  * \param[in] data_set  Cluster working set
  */
 static void
-unpack_cib(xmlNode *cib, pe_working_set_t *data_set)
+unpack_cib(xmlNode *cib, unsigned long long flags, pe_working_set_t *data_set)
 {
     if (pcmk_is_set(data_set->flags, pe_flag_have_status)) {
         crm_trace("Reusing previously calculated cluster status");
+        pe__set_working_set_flags(data_set, flags);
         return;
     }
 
@@ -759,6 +761,7 @@ unpack_cib(xmlNode *cib, pe_working_set_t *data_set)
      */
     set_working_set_defaults(data_set);
 
+    pe__set_working_set_flags(data_set, flags);
     data_set->input = cib;
     cluster_status(data_set); // Sets pe_flag_have_status
 }
@@ -768,12 +771,14 @@ unpack_cib(xmlNode *cib, pe_working_set_t *data_set)
  * \brief Run the scheduler for a given CIB
  *
  * \param[in]     cib       CIB XML to use as scheduler input
+ * \param[in]     flags     Working set flags to set in addition to defaults
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__schedule_actions(xmlNode *cib, pe_working_set_t *data_set)
+pcmk__schedule_actions(xmlNode *cib, unsigned long long flags,
+                       pe_working_set_t *data_set)
 {
-    unpack_cib(cib, data_set);
+    unpack_cib(cib, flags, data_set);
     pcmk__set_allocation_methods(data_set);
     pcmk__apply_node_health(data_set);
     pcmk__unpack_constraints(data_set);

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -343,6 +343,7 @@ stage2(pe_working_set_t * data_set)
                 data_set->max_valid_nodes++;
             }
         }
+        crm_trace("Online node count: %d", data_set->max_valid_nodes);
     }
 
     pcmk__apply_locations(data_set);

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -355,7 +355,7 @@ profile_file(const char *xml_file, long long repeat, pe_working_set_t *data_set,
 
         data_set->input = input;
         set_effective_date(data_set, false, use_date);
-        pcmk__schedule_actions(data_set, input);
+        pcmk__schedule_actions(input, data_set);
         pe_reset_working_set(data_set);
     }
 
@@ -872,7 +872,7 @@ pcmk__simulate(pe_working_set_t *data_set, pcmk__output_t *out,
             data_set->priv = logger_out;
         }
 
-        pcmk__schedule_actions(data_set, input);
+        pcmk__schedule_actions(input, data_set);
 
         if (logger_out == NULL) {
             out->end_list(out);

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -330,6 +330,7 @@ profile_file(const char *xml_file, long long repeat, pe_working_set_t *data_set,
     xmlNode *cib_object = NULL;
     clock_t start = 0;
     clock_t end;
+    unsigned long long data_set_flags = pe_flag_no_compat;
 
     CRM_ASSERT(out != NULL);
 
@@ -350,12 +351,19 @@ profile_file(const char *xml_file, long long repeat, pe_working_set_t *data_set,
         return;
     }
 
+    if (pcmk_is_set(data_set->flags, pe_flag_show_scores)) {
+        data_set_flags |= pe_flag_show_scores;
+    }
+    if (pcmk_is_set(data_set->flags, pe_flag_show_utilization)) {
+        data_set_flags |= pe_flag_show_utilization;
+    }
+
     for (int i = 0; i < repeat; ++i) {
         xmlNode *input = (repeat == 1)? cib_object : copy_xml(cib_object);
 
         data_set->input = input;
         set_effective_date(data_set, false, use_date);
-        pcmk__schedule_actions(input, data_set);
+        pcmk__schedule_actions(input, data_set_flags, data_set);
         pe_reset_working_set(data_set);
     }
 
@@ -845,6 +853,14 @@ pcmk__simulate(pe_working_set_t *data_set, pcmk__output_t *out,
 
     if (pcmk_any_flags_set(flags, pcmk_sim_process | pcmk_sim_simulate)) {
         pcmk__output_t *logger_out = NULL;
+        unsigned long long data_set_flags = pe_flag_no_compat;
+
+        if (pcmk_is_set(data_set->flags, pe_flag_show_scores)) {
+            data_set_flags |= pe_flag_show_scores;
+        }
+        if (pcmk_is_set(data_set->flags, pe_flag_show_utilization)) {
+            data_set_flags |= pe_flag_show_utilization;
+        }
 
         if (pcmk_all_flags_set(data_set->flags,
                                pe_flag_show_scores|pe_flag_show_utilization)) {
@@ -872,7 +888,7 @@ pcmk__simulate(pe_working_set_t *data_set, pcmk__output_t *out,
             data_set->priv = logger_out;
         }
 
-        pcmk__schedule_actions(input, data_set);
+        pcmk__schedule_actions(input, data_set_flags, data_set);
 
         if (logger_out == NULL) {
             out->end_list(out);

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -355,7 +355,7 @@ profile_file(const char *xml_file, long long repeat, pe_working_set_t *data_set,
 
         data_set->input = input;
         set_effective_date(data_set, false, use_date);
-        pcmk__schedule_actions(data_set, input, NULL);
+        pcmk__schedule_actions(data_set, input);
         pe_reset_working_set(data_set);
     }
 
@@ -844,7 +844,6 @@ pcmk__simulate(pe_working_set_t *data_set, pcmk__output_t *out,
     }
 
     if (pcmk_any_flags_set(flags, pcmk_sim_process | pcmk_sim_simulate)) {
-        crm_time_t *local_date = NULL;
         pcmk__output_t *logger_out = NULL;
 
         if (pcmk_all_flags_set(data_set->flags,
@@ -873,7 +872,7 @@ pcmk__simulate(pe_working_set_t *data_set, pcmk__output_t *out,
             data_set->priv = logger_out;
         }
 
-        pcmk__schedule_actions(data_set, input, local_date);
+        pcmk__schedule_actions(data_set, input);
 
         if (logger_out == NULL) {
             out->end_list(out);

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -70,21 +70,18 @@ pe_free_working_set(pe_working_set_t *data_set)
 gboolean
 cluster_status(pe_working_set_t * data_set)
 {
-    xmlNode *config = get_xpath_object("//"XML_CIB_TAG_CRMCONFIG, data_set->input, LOG_TRACE);
-    xmlNode *cib_nodes = get_xpath_object("//"XML_CIB_TAG_NODES, data_set->input, LOG_TRACE);
-    xmlNode *cib_resources = get_xpath_object("//"XML_CIB_TAG_RESOURCES, data_set->input, LOG_TRACE);
-    xmlNode *cib_status = get_xpath_object("//"XML_CIB_TAG_STATUS, data_set->input, LOG_TRACE);
-    xmlNode *cib_tags = get_xpath_object("//" XML_CIB_TAG_TAGS, data_set->input,
-                                         LOG_NEVER);
+    xmlNode *section = NULL;
+
+    if ((data_set == NULL) || (data_set->input == NULL)) {
+        return FALSE;
+    }
 
     crm_trace("Beginning unpack");
 
-    /* reset remaining global variables */
-    data_set->failed = create_xml_node(NULL, "failed-ops");
-
-    if (data_set->input == NULL) {
-        return FALSE;
+    if (data_set->failed != NULL) {
+        free_xml(data_set->failed);
     }
+    data_set->failed = create_xml_node(NULL, "failed-ops");
 
     if (data_set->now == NULL) {
         data_set->now = crm_time_new(NULL);
@@ -106,7 +103,9 @@ cluster_status(pe_working_set_t * data_set)
     data_set->rsc_defaults = get_xpath_object("//" XML_CIB_TAG_RSCCONFIG,
                                               data_set->input, LOG_NEVER);
 
-    unpack_config(config, data_set);
+    section = get_xpath_object("//" XML_CIB_TAG_CRMCONFIG, data_set->input,
+                               LOG_TRACE);
+    unpack_config(section, data_set);
 
    if (!pcmk_any_flags_set(data_set->flags,
                            pe_flag_quick_location|pe_flag_have_quorum)
@@ -114,17 +113,25 @@ cluster_status(pe_working_set_t * data_set)
         crm_warn("Fencing and resource management disabled due to lack of quorum");
     }
 
-    unpack_nodes(cib_nodes, data_set);
+    section = get_xpath_object("//" XML_CIB_TAG_NODES, data_set->input,
+                               LOG_TRACE);
+    unpack_nodes(section, data_set);
 
+    section = get_xpath_object("//" XML_CIB_TAG_RESOURCES, data_set->input,
+                               LOG_TRACE);
     if (!pcmk_is_set(data_set->flags, pe_flag_quick_location)) {
-        unpack_remote_nodes(cib_resources, data_set);
+        unpack_remote_nodes(section, data_set);
     }
+    unpack_resources(section, data_set);
 
-    unpack_resources(cib_resources, data_set);
-    unpack_tags(cib_tags, data_set);
+    section = get_xpath_object("//" XML_CIB_TAG_TAGS, data_set->input,
+                               LOG_NEVER);
+    unpack_tags(section, data_set);
 
     if (!pcmk_is_set(data_set->flags, pe_flag_quick_location)) {
-        unpack_status(cib_status, data_set);
+        section = get_xpath_object("//"XML_CIB_TAG_STATUS, data_set->input,
+                                   LOG_TRACE);
+        unpack_status(section, data_set);
     }
 
     if (!pcmk_is_set(data_set->flags, pe_flag_no_counts)) {

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -132,6 +132,9 @@ cluster_status(pe_working_set_t * data_set)
              item = item->next) {
             ((pe_resource_t *) (item->data))->fns->count(item->data);
         }
+        crm_trace("Cluster resource count: %d (%d disabled, %d blocked)",
+                  data_set->ninstances, data_set->disabled_resources,
+                  data_set->blocked_resources);
     }
 
     pe__set_working_set_flags(data_set, pe_flag_have_status);

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1164,7 +1164,7 @@ update_dataset(cib_t *cib, pe_working_set_t * data_set, bool simulate)
             goto done;
         }
 
-        pcmk__schedule_actions(data_set, data_set->input);
+        pcmk__schedule_actions(data_set->input, data_set);
 
         prev_quiet = out->is_quiet(out);
         out->quiet = true;
@@ -1652,7 +1652,7 @@ wait_till_stable(pcmk__output_t *out, int timeout_ms, cib_t * cib)
             pe_free_working_set(data_set);
             return rc;
         }
-        pcmk__schedule_actions(data_set, data_set->input);
+        pcmk__schedule_actions(data_set->input, data_set);
 
         if (!printed_version_warning) {
             /* If the DC has a different version than the local node, the two

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1164,7 +1164,7 @@ update_dataset(cib_t *cib, pe_working_set_t * data_set, bool simulate)
             goto done;
         }
 
-        pcmk__schedule_actions(data_set, data_set->input, NULL);
+        pcmk__schedule_actions(data_set, data_set->input);
 
         prev_quiet = out->is_quiet(out);
         out->quiet = true;
@@ -1652,7 +1652,7 @@ wait_till_stable(pcmk__output_t *out, int timeout_ms, cib_t * cib)
             pe_free_working_set(data_set);
             return rc;
         }
-        pcmk__schedule_actions(data_set, data_set->input, NULL);
+        pcmk__schedule_actions(data_set, data_set->input);
 
         if (!printed_version_warning) {
             /* If the DC has a different version than the local node, the two

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1131,6 +1131,7 @@ update_dataset(cib_t *cib, pe_working_set_t * data_set, bool simulate)
     pcmk__output_t *out = data_set->priv;
 
     pe_reset_working_set(data_set);
+    pe__set_working_set_flags(data_set, pe_flag_no_counts|pe_flag_no_compat);
     rc = update_working_set_from_cib(out, data_set, cib);
     if (rc != pcmk_rc_ok) {
         return rc;
@@ -1164,7 +1165,8 @@ update_dataset(cib_t *cib, pe_working_set_t * data_set, bool simulate)
             goto done;
         }
 
-        pcmk__schedule_actions(data_set->input, data_set);
+        pcmk__schedule_actions(data_set->input,
+                               pe_flag_no_counts|pe_flag_no_compat, data_set);
 
         prev_quiet = out->is_quiet(out);
         out->quiet = true;
@@ -1331,7 +1333,6 @@ cli_resource_restart(pcmk__output_t *out, pe_resource_t *rsc, const char *host,
     }
 
     data_set->priv = out;
-    pe__set_working_set_flags(data_set, pe_flag_no_counts|pe_flag_no_compat);
     rc = update_dataset(cib, data_set, FALSE);
 
     if(rc != pcmk_rc_ok) {
@@ -1628,7 +1629,6 @@ wait_till_stable(pcmk__output_t *out, int timeout_ms, cib_t * cib)
     if (data_set == NULL) {
         return ENOMEM;
     }
-    pe__set_working_set_flags(data_set, pe_flag_no_counts|pe_flag_no_compat);
 
     do {
 
@@ -1652,7 +1652,8 @@ wait_till_stable(pcmk__output_t *out, int timeout_ms, cib_t * cib)
             pe_free_working_set(data_set);
             return rc;
         }
-        pcmk__schedule_actions(data_set->input, data_set);
+        pcmk__schedule_actions(data_set->input,
+                               pe_flag_no_counts|pe_flag_no_compat, data_set);
 
         if (!printed_version_warning) {
             /* If the DC has a different version than the local node, the two

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -234,7 +234,7 @@ main(int argc, char **argv)
             // No status available, so do minimal checks
             pe__set_working_set_flags(data_set, pe_flag_check_config);
         }
-        pcmk__schedule_actions(data_set, cib_object);
+        pcmk__schedule_actions(cib_object, data_set);
     }
     pe_free_working_set(data_set);
 

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -229,7 +229,7 @@ main(int argc, char **argv)
     if (cib_object == NULL) {
     } else if (status != NULL || options.use_live_cib) {
         /* live queries will always have a status section and can do a full simulation */
-        pcmk__schedule_actions(data_set, cib_object, NULL);
+        pcmk__schedule_actions(data_set, cib_object);
 
     } else {
         data_set->now = crm_time_new(NULL);

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -221,7 +221,6 @@ main(int argc, char **argv)
         crm_perror(LOG_CRIT, "Unable to allocate working set");
         goto done;
     }
-    pe__set_working_set_flags(data_set, pe_flag_no_counts|pe_flag_no_compat);
     data_set->priv = out;
 
     /* Process the configuration to set crm_config_error/crm_config_warning.
@@ -230,11 +229,13 @@ main(int argc, char **argv)
      * example, action configuration), so we aren't necessarily checking those.
      */
     if (cib_object != NULL) {
+        unsigned long long flags = pe_flag_no_counts|pe_flag_no_compat;
+
         if ((status == NULL) && !options.use_live_cib) {
             // No status available, so do minimal checks
-            pe__set_working_set_flags(data_set, pe_flag_check_config);
+            flags |= pe_flag_check_config;
         }
-        pcmk__schedule_actions(cib_object, data_set);
+        pcmk__schedule_actions(cib_object, flags, data_set);
     }
     pe_free_working_set(data_set);
 

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -44,8 +44,6 @@ struct {
     gboolean xml_stdin;
     char *xml_string;
 } options;
-
-extern gboolean stage0(pe_working_set_t * data_set);
 
 static GOptionEntry data_entries[] = {
     { "live-check", 'L', 0, G_OPTION_ARG_NONE,
@@ -226,15 +224,17 @@ main(int argc, char **argv)
     pe__set_working_set_flags(data_set, pe_flag_no_counts|pe_flag_no_compat);
     data_set->priv = out;
 
-    if (cib_object == NULL) {
-    } else if (status != NULL || options.use_live_cib) {
-        /* live queries will always have a status section and can do a full simulation */
+    /* Process the configuration to set crm_config_error/crm_config_warning.
+     *
+     * @TODO Some parts of the configuration are unpacked only when needed (for
+     * example, action configuration), so we aren't necessarily checking those.
+     */
+    if (cib_object != NULL) {
+        if ((status == NULL) && !options.use_live_cib) {
+            // No status available, so do minimal checks
+            pe__set_working_set_flags(data_set, pe_flag_check_config);
+        }
         pcmk__schedule_actions(data_set, cib_object);
-
-    } else {
-        data_set->now = crm_time_new(NULL);
-        data_set->input = cib_object;
-        stage0(data_set);
     }
     pe_free_working_set(data_set);
 


### PR DESCRIPTION
While working on best practices for libpacemaker, I realized that pe_working_set_t flags were being ignored in some cases. This PR fixes that and includes related best-practices work on the affected functions.