### PR TITLE
Low: tools: Always output to the HTML dest file.

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -2000,7 +2000,7 @@ mon_refresh_display(gpointer user_data)
         fence_history = pcmk__fence_history_reduced;
      }
 
-    if (options.daemonize) {
+    if (out->dest != stdout) {
         out->reset(out);
     }
 
@@ -2017,7 +2017,7 @@ mon_refresh_display(gpointer user_data)
         return G_SOURCE_REMOVE;
     }
 
-    if (options.daemonize) {
+    if (out->dest != stdout) {
         out->finish(out, CRM_EX_OK, true, NULL);
     }
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1287,6 +1287,10 @@ reconcile_output_format(pcmk__common_args_t *args) {
     } else if (options.one_shot) {
         pcmk__str_update(&args->output_ty, "text");
         output_format = mon_output_plain;
+    } else if (!options.daemonize && args->output_dest != NULL) {
+        options.one_shot = TRUE;
+        pcmk__str_update(&args->output_ty, "text");
+        output_format = mon_output_plain;
     } else {
         /* Neither old nor new arguments were given, so set the default. */
         pcmk__str_update(&args->output_ty, "console");


### PR DESCRIPTION
Previously, if you did --output-as=html --output-to= and backgrounded
the crm_mon process, it would not print anything to the destination file
until crm_mon exited.  However, if you added --daemonize, it would
output immediately.  This patch just makes the background behavior the
same as the daemonize behavior.

See: clbz#5492