### PR TITLE
Continue best practices for libpacemaker

### DIFF
--- a/cts/lab/patterns.py
+++ b/cts/lab/patterns.py
@@ -245,7 +245,7 @@ class crm_corosync(BasePatterns):
             # However, if the CIB manager loses its connection first,
             # it's possible for another daemon to lose that connection and
             # exit before losing the cluster connection.
-            r"pacemakerd.*:\s*(crit|error):.*Lost connection to cluster layer",
+            r"pacemakerd.*:\s*warning:.*Lost connection to cluster layer",
             r"pacemaker-attrd.*:\s*(crit|error):.*Lost connection to (cluster layer|the CIB manager)",
             r"pacemaker-based.*:\s*(crit|error):.*Lost connection to cluster layer",
             r"pacemaker-controld.*:\s*(crit|error):.*Lost connection to (cluster layer|the CIB manager)",

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -82,6 +82,14 @@ struct resource_alloc_functions_s {
      */
     void (*add_utilization)(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                             GList *all_rscs, GHashTable *utilization);
+
+    /*!
+     * \internal
+     * \brief Apply a shutdown lock for a resource, if appropriate
+     *
+     * \param[in] rsc       Resource to check for shutdown lock
+     */
+    void (*shutdown_lock)(pe_resource_t *rsc);
 };
 
 GHashTable *pcmk__native_merge_weights(pe_resource_t *rsc, const char *rhs,
@@ -112,6 +120,7 @@ extern void native_append_meta(pe_resource_t * rsc, xmlNode * xml);
 void pcmk__primitive_add_utilization(pe_resource_t *rsc,
                                      pe_resource_t *orig_rsc, GList *all_rscs,
                                      GHashTable *utilization);
+void pcmk__primitive_shutdown_lock(pe_resource_t *rsc);
 
 pe_node_t *pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *preferred,
                                 pe_working_set_t *data_set);
@@ -129,6 +138,7 @@ extern void group_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
 extern void group_append_meta(pe_resource_t * rsc, xmlNode * xml);
 void pcmk__group_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                  GList *all_rscs, GHashTable *utilization);
+void pcmk__group_shutdown_lock(pe_resource_t *rsc);
 
 pe_node_t *pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *preferred,
                                  pe_working_set_t *data_set);
@@ -154,6 +164,7 @@ void pcmk__bundle_expand(pe_resource_t *rsc, pe_working_set_t *data_set);
 void pcmk__bundle_append_meta(pe_resource_t *rsc, xmlNode *xml);
 void pcmk__bundle_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                   GList *all_rscs, GHashTable *utilization);
+void pcmk__bundle_shutdown_lock(pe_resource_t *rsc);
 
 pe_node_t *pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *preferred,
                                 pe_working_set_t *data_set);
@@ -173,6 +184,7 @@ extern gboolean clone_create_probe(pe_resource_t * rsc, pe_node_t * node, pe_act
 extern void clone_append_meta(pe_resource_t * rsc, xmlNode * xml);
 void pcmk__clone_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                  GList *all_rscs, GHashTable *utilization);
+void pcmk__clone_shutdown_lock(pe_resource_t *rsc);
 
 void pcmk__add_promotion_scores(pe_resource_t *rsc);
 pe_node_t *pcmk__set_instance_roles(pe_resource_t *rsc,

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -58,7 +58,6 @@ struct rsc_ticket_s {
     int role_lh;
 };
 
-extern gboolean stage2(pe_working_set_t * data_set);
 extern gboolean stage5(pe_working_set_t * data_set);
 extern gboolean stage6(pe_working_set_t * data_set);
 

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -380,7 +380,11 @@ G_GNUC_INTERNAL
 void pcmk__ban_insufficient_capacity(pe_resource_t *rsc, pe_node_t **prefer,
                                      pe_working_set_t *data_set);
 
-G_GNUC_INTERNAL void pcmk__create_utilization_constraints(pe_resource_t *rsc,
-                                                          GList *allowed_nodes);
+G_GNUC_INTERNAL
+void pcmk__create_utilization_constraints(pe_resource_t *rsc,
+                                          GList *allowed_nodes);
+
+G_GNUC_INTERNAL
+void pcmk__show_node_capacities(const char *desc, pe_working_set_t *data_set);
 
 #endif // PCMK__LIBPACEMAKER_PRIVATE__H

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -215,110 +215,6 @@ apply_stickiness(pe_resource_t *rsc, pe_working_set_t *data_set)
                       rsc->cluster);
 }
 
-/*!
- * \internal
- * \brief Get epoch time of node's shutdown attribute (or now if none)
- *
- * \param[in] node      Node to check
- * \param[in] data_set  Cluster working set
- *
- * \return Epoch time corresponding to shutdown attribute if set or now if not
- */
-static time_t
-shutdown_time(pe_node_t *node, pe_working_set_t *data_set)
-{
-    const char *shutdown = pe_node_attribute_raw(node, XML_CIB_ATTR_SHUTDOWN);
-    time_t result = 0;
-
-    if (shutdown != NULL) {
-        long long result_ll;
-
-        if (pcmk__scan_ll(shutdown, &result_ll, 0LL) == pcmk_rc_ok) {
-            result = (time_t) result_ll;
-        }
-    }
-    return (result == 0)? get_effective_time(data_set) : result;
-}
-
-static void
-apply_shutdown_lock(pe_resource_t *rsc, pe_working_set_t *data_set)
-{
-    const char *class;
-
-    // Only primitives and (uncloned) groups may be locked
-    if (rsc->variant == pe_group) {
-        g_list_foreach(rsc->children, (GFunc) apply_shutdown_lock, data_set);
-    }
-    if (rsc->variant != pe_native) {
-        return;
-    }
-
-    // Fence devices and remote connections can't be locked
-    class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
-    if (pcmk__str_eq(class, PCMK_RESOURCE_CLASS_STONITH, pcmk__str_null_matches)
-        || pe__resource_is_remote_conn(rsc, data_set)) {
-        return;
-    }
-
-    if (rsc->lock_node != NULL) {
-        // The lock was obtained from resource history
-
-        if (rsc->running_on != NULL) {
-            /* The resource was started elsewhere even though it is now
-             * considered locked. This shouldn't be possible, but as a
-             * failsafe, we don't want to disturb the resource now.
-             */
-            pe_rsc_info(rsc,
-                        "Cancelling shutdown lock because %s is already active",
-                        rsc->id);
-            pe__clear_resource_history(rsc, rsc->lock_node, data_set);
-            rsc->lock_node = NULL;
-            rsc->lock_time = 0;
-        }
-
-    // Only a resource active on exactly one node can be locked
-    } else if (pcmk__list_of_1(rsc->running_on)) {
-        pe_node_t *node = rsc->running_on->data;
-
-        if (node->details->shutdown) {
-            if (node->details->unclean) {
-                pe_rsc_debug(rsc, "Not locking %s to unclean %s for shutdown",
-                             rsc->id, node->details->uname);
-            } else {
-                rsc->lock_node = node;
-                rsc->lock_time = shutdown_time(node, data_set);
-            }
-        }
-    }
-
-    if (rsc->lock_node == NULL) {
-        // No lock needed
-        return;
-    }
-
-    if (data_set->shutdown_lock > 0) {
-        time_t lock_expiration = rsc->lock_time + data_set->shutdown_lock;
-
-        pe_rsc_info(rsc, "Locking %s to %s due to shutdown (expires @%lld)",
-                    rsc->id, rsc->lock_node->details->uname,
-                    (long long) lock_expiration);
-        pe__update_recheck_time(++lock_expiration, data_set);
-    } else {
-        pe_rsc_info(rsc, "Locking %s to %s due to shutdown",
-                    rsc->id, rsc->lock_node->details->uname);
-    }
-
-    // If resource is locked to one node, ban it from all other nodes
-    for (GList *item = data_set->nodes; item != NULL; item = item->next) {
-        pe_node_t *node = item->data;
-
-        if (strcmp(node->details->uname, rsc->lock_node->details->uname)) {
-            resource_location(rsc, node, -CRM_SCORE_INFINITY,
-                              XML_CONFIG_ATTR_SHUTDOWN_LOCK, data_set);
-        }
-    }
-}
-
 /*
  * \internal
  * \brief Stage 2 of cluster status: apply node-specific criteria
@@ -332,7 +228,11 @@ stage2(pe_working_set_t * data_set)
     GList *gIter = NULL;
 
     if (pcmk_is_set(data_set->flags, pe_flag_shutdown_lock)) {
-        g_list_foreach(data_set->resources, (GFunc) apply_shutdown_lock, data_set);
+        for (gIter = data_set->resources; gIter != NULL; gIter = gIter->next) {
+            pe_resource_t *rsc = (pe_resource_t *) gIter->data;
+
+            rsc->cmds->shutdown_lock(rsc);
+        }
     }
 
     if (!pcmk_is_set(data_set->flags, pe_flag_no_compat)) {

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -374,34 +374,19 @@ clear_failcounts_if_orphaned(pe_resource_t *rsc, pe_working_set_t *data_set)
 gboolean
 stage5(pe_working_set_t * data_set)
 {
-    pcmk__output_t *out = data_set->priv;
     GList *gIter = NULL;
 
     if (!pcmk__str_eq(data_set->placement_strategy, "default", pcmk__str_casei)) {
         pcmk__sort_resources(data_set);
     }
 
-    gIter = data_set->nodes;
-    for (; gIter != NULL; gIter = gIter->next) {
-        pe_node_t *node = (pe_node_t *) gIter->data;
-
-        if (pcmk_is_set(data_set->flags, pe_flag_show_utilization)) {
-            out->message(out, "node-capacity", node, "Original");
-        }
-    }
+    pcmk__show_node_capacities("Original", data_set);
 
     /* Take (next) highest resource, assign it and create its actions */
 
     allocate_resources(data_set);
 
-    gIter = data_set->nodes;
-    for (; gIter != NULL; gIter = gIter->next) {
-        pe_node_t *node = (pe_node_t *) gIter->data;
-
-        if (pcmk_is_set(data_set->flags, pe_flag_show_utilization)) {
-            out->message(out, "node-capacity", node, "Remaining");
-        }
-    }
+    pcmk__show_node_capacities("Remaining", data_set);
 
     // Process deferred action checks
     pe__foreach_param_check(data_set, check_params);

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -384,8 +384,6 @@ stage5(pe_working_set_t * data_set)
 {
     GList *gIter = NULL;
 
-    allocate_resources(data_set);
-
     // Process deferred action checks
     pe__foreach_param_check(data_set, check_params);
     pe__free_param_checks(data_set);
@@ -736,7 +734,8 @@ pcmk__schedule_actions(xmlNode *cib, unsigned long long flags,
     pcmk__create_internal_constraints(data_set);
     pcmk__handle_rsc_config_changes(data_set);
 
-    crm_trace("Allocate resources");
+    allocate_resources(data_set);
+
     stage5(data_set);
 
     crm_trace("Processing fencing and shutdown cases");

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -248,7 +248,8 @@ apply_shutdown_lock(pe_resource_t *rsc, pe_working_set_t *data_set)
     // Only primitives and (uncloned) groups may be locked
     if (rsc->variant == pe_group) {
         g_list_foreach(rsc->children, (GFunc) apply_shutdown_lock, data_set);
-    } else if (rsc->variant != pe_native) {
+    }
+    if (rsc->variant != pe_native) {
         return;
     }
 

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -215,20 +215,29 @@ apply_stickiness(pe_resource_t *rsc, pe_working_set_t *data_set)
                       rsc->cluster);
 }
 
+/*!
+ * \internal
+ * \brief Get epoch time of node's shutdown attribute (or now if none)
+ *
+ * \param[in] node      Node to check
+ * \param[in] data_set  Cluster working set
+ *
+ * \return Epoch time corresponding to shutdown attribute if set or now if not
+ */
 static time_t
 shutdown_time(pe_node_t *node, pe_working_set_t *data_set)
 {
     const char *shutdown = pe_node_attribute_raw(node, XML_CIB_ATTR_SHUTDOWN);
     time_t result = 0;
 
-    if (shutdown) {
+    if (shutdown != NULL) {
         long long result_ll;
 
         if (pcmk__scan_ll(shutdown, &result_ll, 0LL) == pcmk_rc_ok) {
             result = (time_t) result_ll;
         }
     }
-    return result? result : get_effective_time(data_set);
+    return (result == 0)? get_effective_time(data_set) : result;
 }
 
 static void

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -301,6 +301,12 @@ allocate_resources(pe_working_set_t *data_set)
     GList *iter = NULL;
 
     crm_trace("Allocating resources to nodes");
+
+    if (!pcmk__str_eq(data_set->placement_strategy, "default", pcmk__str_casei)) {
+        pcmk__sort_resources(data_set);
+    }
+    pcmk__show_node_capacities("Original", data_set);
+
     if (pcmk_is_set(data_set->flags, pe_flag_have_remote_nodes)) {
         /* Allocate remote connection resources first (which will also allocate
          * any colocation dependencies). If the connection is migrating, always
@@ -328,6 +334,8 @@ allocate_resources(pe_working_set_t *data_set)
             rsc->cmds->allocate(rsc, NULL, data_set);
         }
     }
+
+    pcmk__show_node_capacities("Remaining", data_set);
 }
 
 /*!
@@ -376,17 +384,7 @@ stage5(pe_working_set_t * data_set)
 {
     GList *gIter = NULL;
 
-    if (!pcmk__str_eq(data_set->placement_strategy, "default", pcmk__str_casei)) {
-        pcmk__sort_resources(data_set);
-    }
-
-    pcmk__show_node_capacities("Original", data_set);
-
-    /* Take (next) highest resource, assign it and create its actions */
-
     allocate_resources(data_set);
-
-    pcmk__show_node_capacities("Remaining", data_set);
 
     // Process deferred action checks
     pe__foreach_param_check(data_set, check_params);

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -224,13 +224,13 @@ apply_stickiness(pe_resource_t *rsc, pe_working_set_t *data_set)
 static void
 apply_shutdown_locks(pe_working_set_t *data_set)
 {
-    if (pcmk_is_set(data_set->flags, pe_flag_shutdown_lock)) {
-        for (GList *iter = data_set->resources; iter != NULL;
-             iter = iter->next) {
-            pe_resource_t *rsc = (pe_resource_t *) iter->data;
+    if (!pcmk_is_set(data_set->flags, pe_flag_shutdown_lock)) {
+        return;
+    }
+    for (GList *iter = data_set->resources; iter != NULL; iter = iter->next) {
+        pe_resource_t *rsc = (pe_resource_t *) iter->data;
 
-            rsc->cmds->shutdown_lock(rsc);
-        }
+        rsc->cmds->shutdown_lock(rsc);
     }
 }
 

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -1119,3 +1119,10 @@ pcmk__bundle_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                                   all_rscs, utilization);
     }
 }
+
+// Bundle implementation of resource_alloc_functions_t:shutdown_lock()
+void
+pcmk__bundle_shutdown_lock(pe_resource_t *rsc)
+{
+    return; // Bundles currently don't support shutdown locks
+}

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -1560,3 +1560,10 @@ pcmk__clone_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
         child->cmds->add_utilization(child, orig_rsc, all_rscs, utilization);
     }
 }
+
+// Clone implementation of resource_alloc_functions_t:shutdown_lock()
+void
+pcmk__clone_shutdown_lock(pe_resource_t *rsc)
+{
+    return; // Clones currently don't support shutdown locks
+}

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -681,3 +681,14 @@ pcmk__group_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
         }
     }
 }
+
+// Group implementation of resource_alloc_functions_t:shutdown_lock()
+void
+pcmk__group_shutdown_lock(pe_resource_t *rsc)
+{
+    for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
+        pe_resource_t *child = (pe_resource_t *) iter->data;
+
+        child->cmds->shutdown_lock(child);
+    }
+}

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -31,6 +31,7 @@ static resource_alloc_functions_t allocation_methods[] = {
         native_expand,
         native_append_meta,
         pcmk__primitive_add_utilization,
+        pcmk__primitive_shutdown_lock,
     },
     {
         pcmk__group_merge_weights,
@@ -48,6 +49,7 @@ static resource_alloc_functions_t allocation_methods[] = {
         group_expand,
         group_append_meta,
         pcmk__group_add_utilization,
+        pcmk__group_shutdown_lock,
     },
     {
         pcmk__native_merge_weights,
@@ -65,6 +67,7 @@ static resource_alloc_functions_t allocation_methods[] = {
         clone_expand,
         clone_append_meta,
         pcmk__clone_add_utilization,
+        pcmk__clone_shutdown_lock,
     },
     {
         pcmk__native_merge_weights,
@@ -82,6 +85,7 @@ static resource_alloc_functions_t allocation_methods[] = {
         pcmk__bundle_expand,
         pcmk__bundle_append_meta,
         pcmk__bundle_add_utilization,
+        pcmk__bundle_shutdown_lock,
     }
 };
 

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -441,3 +441,23 @@ pcmk__create_utilization_constraints(pe_resource_t *rsc, GList *allowed_nodes)
                            pe_order_load, rsc->cluster);
     }
 }
+
+/*!
+ * \internal
+ * \brief Output node capacities if enabled
+ *
+ * \param[in] desc      Prefix for output
+ * \param[in] data_set  Cluster working set
+ */
+void
+pcmk__show_node_capacities(const char *desc, pe_working_set_t *data_set)
+{
+    if (pcmk_is_set(data_set->flags, pe_flag_show_utilization)) {
+        for (GList *iter = data_set->nodes; iter != NULL; iter = iter->next) {
+            pe_node_t *node = (pe_node_t *) iter->data;
+            pcmk__output_t *out = data_set->priv;
+
+            out->message(out, "node-capacity", node, desc);
+        }
+    }
+}

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -452,12 +452,13 @@ pcmk__create_utilization_constraints(pe_resource_t *rsc, GList *allowed_nodes)
 void
 pcmk__show_node_capacities(const char *desc, pe_working_set_t *data_set)
 {
-    if (pcmk_is_set(data_set->flags, pe_flag_show_utilization)) {
-        for (GList *iter = data_set->nodes; iter != NULL; iter = iter->next) {
-            pe_node_t *node = (pe_node_t *) iter->data;
-            pcmk__output_t *out = data_set->priv;
+    if (!pcmk_is_set(data_set->flags, pe_flag_show_utilization)) {
+        return;
+    }
+    for (GList *iter = data_set->nodes; iter != NULL; iter = iter->next) {
+        pe_node_t *node = (pe_node_t *) iter->data;
+        pcmk__output_t *out = data_set->priv;
 
-            out->message(out, "node-capacity", node, desc);
-        }
+        out->message(out, "node-capacity", node, desc);
     }
 }


### PR DESCRIPTION
This continues the project to bring libpacemaker up to current development guidelines, focusing on functions before "stage 5" in pcmk_sched_allocate.c