### PR TITLE
Best practices for libpacemaker

### DIFF
--- a/cts/lab/CTStests.py
+++ b/cts/lab/CTStests.py
@@ -1703,7 +1703,7 @@ class Reattach(CTSTest):
         pats = []
         # Conveniently, the scheduler will display this message when disabling
         # management, even if fencing is not enabled, so we can rely on it.
-        managed = self.create_watch(["Delaying fencing operations"], 60)
+        managed = self.create_watch(["No fencing will be done"], 60)
         managed.setwatch()
 
         self._set_unmanaged(node)

--- a/cts/lab/ClusterManager.py
+++ b/cts/lab/ClusterManager.py
@@ -1,7 +1,7 @@
 """ ClusterManager class for Pacemaker's Cluster Test Suite (CTS)
 """
 
-__copyright__ = """Copyright 2000-2021 the Pacemaker project contributors.
+__copyright__ = """Copyright 2000-2022 the Pacemaker project contributors.
 Certain portions by Huang Zhen <zhenhltc@cn.ibm.com> are copyright 2004
 International Business Machines. The version control history for this file
 may have further details."""
@@ -946,7 +946,7 @@ class ClusterManager(UserDict):
 #                    "A new node joined the cluster",
 
 #                    "WARN: determine_online_status: Node .* is unclean",
-#                    "Scheduling Node .* for STONITH",
+#                    "Scheduling node .* for fencing",
 #                    "Executing .* fencing operation",
 #                    "tengine_stonith_callback: .*result=0",
 #                    "Processing I_NODE_JOIN:.* cause=C_HA_MESSAGE",
@@ -980,7 +980,7 @@ class ClusterManager(UserDict):
         controld = Process(self, "pacemaker-controld", triggersreboot=self.fastfail,
                     pats = [
 #                    "WARN: determine_online_status: Node .* is unclean",
-#                    "Scheduling Node .* for STONITH",
+#                    "Scheduling node .* for fencing",
 #                    "Executing .* fencing operation",
 #                    "tengine_stonith_callback: .*result=0",
                     "State transition .* S_IDLE",

--- a/cts/lab/patterns.py
+++ b/cts/lab/patterns.py
@@ -250,7 +250,7 @@ class crm_corosync(BasePatterns):
             r"pacemaker-based.*:\s*(crit|error):.*Lost connection to cluster layer",
             r"pacemaker-controld.*:\s*(crit|error):.*Lost connection to (cluster layer|the CIB manager)",
             r"pacemaker-fenced.*:\s*(crit|error):.*Lost connection to (cluster layer|the CIB manager)",
-            r"schedulerd.*Scheduling Node .* for STONITH",
+            r"schedulerd.*Scheduling node .* for fencing",
             r"pacemaker-controld.*:\s*Peer .* was terminated \(.*\) by .* on behalf of .*:\s*OK",
         ]
 
@@ -296,7 +296,7 @@ class crm_corosync(BasePatterns):
 
         self.components["pacemaker-controld"] = [
 #                    "WARN: determine_online_status: Node .* is unclean",
-#                    "Scheduling Node .* for STONITH",
+#                    "Scheduling node .* for fencing",
 # Only if the node wasn't the DC:  "State transition S_IDLE",
                     "State transition .* -> S_IDLE",
                     ]

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -58,8 +58,6 @@ struct rsc_ticket_s {
     int role_lh;
 };
 
-extern gboolean stage6(pe_working_set_t * data_set);
-
 void pcmk__unpack_constraints(pe_working_set_t *data_set);
 
 extern void add_maintenance_update(pe_working_set_t *data_set);

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -58,7 +58,6 @@ struct rsc_ticket_s {
     int role_lh;
 };
 
-extern gboolean stage5(pe_working_set_t * data_set);
 extern gboolean stage6(pe_working_set_t * data_set);
 
 void pcmk__unpack_constraints(pe_working_set_t *data_set);

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -193,7 +193,7 @@ G_GNUC_INTERNAL
 void pcmk__apply_orderings(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-void pcmk__order_after_all(pe_action_t *after, GList *list);
+void pcmk__order_after_each(pe_action_t *after, GList *list);
 
 
 /*!

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -169,6 +169,9 @@ G_GNUC_INTERNAL
 void pcmk__block_colocated_starts(pe_action_t *action,
                                   pe_working_set_t *data_set);
 
+
+// Ordering constraints (pcmk_sched_ordering.c)
+
 G_GNUC_INTERNAL
 void pcmk__new_ordering(pe_resource_t *lh_rsc, char *lh_task,
                         pe_action_t *lh_action, pe_resource_t *rh_rsc,
@@ -188,6 +191,10 @@ void pcmk__order_stops_before_shutdown(pe_node_t *node,
 
 G_GNUC_INTERNAL
 void pcmk__apply_orderings(pe_working_set_t *data_set);
+
+G_GNUC_INTERNAL
+void pcmk__order_after_all(pe_action_t *after, GList *list);
+
 
 /*!
  * \internal

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -465,11 +465,6 @@ stage6(pe_working_set_t * data_set)
     GList *stonith_ops = NULL;
     GList *shutdown_ops = NULL;
 
-    /* Remote ordering constraints need to happen prior to calculating fencing
-     * because it is one more place we can mark nodes as needing fencing.
-     */
-    pcmk__order_remote_connection_actions(data_set);
-
     crm_trace("Processing fencing and shutdown cases");
     if (!any_managed_resources(data_set)) {
         crm_notice("Delaying fencing operations until there are resources to manage");
@@ -741,6 +736,11 @@ pcmk__schedule_actions(xmlNode *cib, unsigned long long flags,
 
     allocate_resources(data_set);
     schedule_resource_actions(data_set);
+
+    /* Remote ordering constraints need to happen prior to calculating fencing
+     * because it is one more place we can mark nodes as needing fencing.
+     */
+    pcmk__order_remote_connection_actions(data_set);
 
     crm_trace("Processing fencing and shutdown cases");
     stage6(data_set);

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -774,7 +774,6 @@ pcmk__schedule_actions(xmlNode *cib, unsigned long long flags,
 
     pcmk__create_internal_constraints(data_set);
     pcmk__handle_rsc_config_changes(data_set);
-
     allocate_resources(data_set);
     schedule_resource_actions(data_set);
 
@@ -784,12 +783,10 @@ pcmk__schedule_actions(xmlNode *cib, unsigned long long flags,
     pcmk__order_remote_connection_actions(data_set);
 
     schedule_fencing_and_shutdowns(data_set);
-
     pcmk__apply_orderings(data_set);
     log_all_actions(data_set);
-
-    crm_trace("Create transition graph");
     pcmk__create_graph(data_set);
+
     if (get_crm_log_level() == LOG_TRACE) {
         log_unrunnable_actions(data_set);
     }

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -410,40 +410,45 @@ schedule_resource_actions(pe_working_set_t *data_set)
     }
 }
 
-static gboolean
-is_managed(const pe_resource_t * rsc)
+/*!
+ * \internal
+ * \brief Check whether a resource or any of its descendants are managed
+ *
+ * \param[in] rsc  Resource to check
+ *
+ * \return true if resource or any descendent is managed, otherwise false
+ */
+static bool
+is_managed(const pe_resource_t *rsc)
 {
-    GList *gIter = rsc->children;
-
     if (pcmk_is_set(rsc->flags, pe_rsc_managed)) {
-        return TRUE;
+        return true;
     }
-
-    for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
-
-        if (is_managed(child_rsc)) {
-            return TRUE;
+    for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
+        if (is_managed((pe_resource_t *) iter->data)) {
+            return true;
         }
     }
-
-    return FALSE;
+    return false;
 }
 
-static gboolean
-any_managed_resources(pe_working_set_t * data_set)
+/*!
+ * \internal
+ * \brief Check whether any resources in the cluster are managed
+ *
+ * \param[in] data_set  Cluster working set
+ *
+ * \return true if any resource is managed, otherwise false
+ */
+static bool
+any_managed_resources(pe_working_set_t *data_set)
 {
-
-    GList *gIter = data_set->resources;
-
-    for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) gIter->data;
-
-        if (is_managed(rsc)) {
-            return TRUE;
+    for (GList *iter = data_set->resources; iter != NULL; iter = iter->next) {
+        if (is_managed((pe_resource_t *) iter->data)) {
+            return true;
         }
     }
-    return FALSE;
+    return false;
 }
 
 /*
@@ -466,7 +471,7 @@ stage6(pe_working_set_t * data_set)
     pcmk__order_remote_connection_actions(data_set);
 
     crm_trace("Processing fencing and shutdown cases");
-    if (any_managed_resources(data_set) == FALSE) {
+    if (!any_managed_resources(data_set)) {
         crm_notice("Delaying fencing operations until there are resources to manage");
         need_stonith = FALSE;
     }

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -615,7 +615,7 @@ schedule_fencing_and_shutdowns(pe_working_set_t *data_set)
          * a graph loop.
          */
         if (pcmk__str_eq(dc_down->task, CRM_OP_SHUTDOWN, pcmk__str_none)) {
-            pcmk__order_after_all(dc_down, shutdown_ops);
+            pcmk__order_after_each(dc_down, shutdown_ops);
         }
 
         // Order any non-DC fencing before any DC fencing or shutdown
@@ -624,7 +624,7 @@ schedule_fencing_and_shutdowns(pe_working_set_t *data_set)
             /* With concurrent fencing, order each non-DC fencing action
              * separately before any DC fencing or shutdown.
              */
-            pcmk__order_after_all(dc_down, fencing_ops);
+            pcmk__order_after_each(dc_down, fencing_ops);
         } else if (fencing_ops != NULL) {
             /* Without concurrent fencing, the non-DC fencing actions are
              * already ordered relative to each other, so we just need to order

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -525,7 +525,7 @@ schedule_fencing(pe_node_t *node, pe_working_set_t *data_set)
     pe_action_t *fencing = pe_fence_op(node, NULL, FALSE, "node is unclean",
                                        FALSE, data_set);
 
-    pe_warn("Scheduling Node %s for STONITH", node->details->uname);
+    pe_warn("Scheduling node %s for fencing", node->details->uname);
     pcmk__order_vs_fence(fencing, data_set);
     return fencing;
 }
@@ -547,7 +547,7 @@ schedule_fencing_and_shutdowns(pe_working_set_t *data_set)
 
     crm_trace("Scheduling fencing and shutdowns as needed");
     if (!have_managed) {
-        crm_notice("Delaying fencing operations until there are resources to manage");
+        crm_notice("No fencing will be done until there are resources to manage");
     }
 
     // Check each node for whether it needs fencing or shutdown
@@ -589,18 +589,20 @@ schedule_fencing_and_shutdowns(pe_working_set_t *data_set)
 
         if ((fencing == NULL) && node->details->unclean) {
             integrity_lost = true;
-            pe_warn("Node %s is unclean!", node->details->uname);
+            pe_warn("Node %s is unclean but cannot be fenced",
+                    node->details->uname);
         }
     }
 
     if (integrity_lost) {
         if (!pcmk_is_set(data_set->flags, pe_flag_stonith_enabled)) {
-            pe_warn("YOUR RESOURCES ARE NOW LIKELY COMPROMISED");
-            pe_err("ENABLE STONITH TO KEEP YOUR RESOURCES SAFE");
+            pe_warn("Resource functionality and data integrity cannot be "
+                    "guaranteed (configure, enable, and test fencing to "
+                    "correct this)");
 
         } else if (!pcmk_is_set(data_set->flags, pe_flag_have_quorum)) {
-            crm_notice("Cannot fence unclean nodes until quorum is"
-                       " attained (or no-quorum-policy is set to ignore)");
+            crm_notice("Unclean nodes will not be fenced until quorum is "
+                       "attained or no-quorum-policy is set to ignore");
         }
     }
 

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1539,4 +1539,27 @@ pcmk__apply_orderings(pe_working_set_t *data_set)
                    (GFunc) pcmk__update_action_for_orderings, data_set);
 
     pcmk__disable_invalid_orderings(data_set);
+}
+
+/*!
+ * \internal
+ * \brief Order a given action after each action in a given list
+ *
+ * \param[in] after   "After" action
+ * \param[in] list    List of "before" actions
+ */
+void
+pcmk__order_after_all(pe_action_t *after, GList *list)
+{
+    const char *after_desc = (after->task == NULL)? after->uuid : after->task;
+
+    for (GList *iter = list; iter != NULL; iter = iter->next) {
+        pe_action_t *before = (pe_action_t *) iter->data;
+        const char *before_desc = before->task? before->task : before->uuid;
+
+        crm_debug("Ordering %s on %s before %s on %s",
+                  before_desc, crm_str(before->node->details->uname),
+                  after_desc, crm_str(after->node->details->uname));
+        order_actions(before, after, pe_order_optional);
+    }
 }

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -1549,7 +1549,7 @@ pcmk__apply_orderings(pe_working_set_t *data_set)
  * \param[in] list    List of "before" actions
  */
 void
-pcmk__order_after_all(pe_action_t *after, GList *list)
+pcmk__order_after_each(pe_action_t *after, GList *list)
 {
     const char *after_desc = (after->task == NULL)? after->uuid : after->task;
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -2211,9 +2211,10 @@ pe_fence_op(pe_node_t * node, const char *op, bool optional, const char *reason,
              * At least add `priority-fencing-delay` field as an indicator. */
         && (priority_delay
 
-            /* Re-calculate priority delay for the suitable case when
-             * pe_fence_op() is called again by stage6() after node priority has
-             * been actually calculated with native_add_running() */
+            /* The priority delay needs to be recalculated if this function has
+             * been called by schedule_fencing_and_shutdowns() after node
+             * priority has already been calculated by native_add_running().
+             */
             || g_hash_table_lookup(stonith_op->meta,
                                    XML_CONFIG_ATTR_PRIORITY_FENCING_DELAY) != NULL)) {
 


### PR DESCRIPTION
This continues the project to bring libpacemaker up to current development guidelines, finishing the functions in pcmk_sched_allocate.c. This finally abandons the "stageN" terminology for the scheduler.