### PR TITLE
crm_rule improvements

### DIFF
--- a/cts/cli/regression.rules.exp
+++ b/cts/cli/regression.rules.exp
@@ -3,15 +3,15 @@ Setting up shadow instance
 A new shadow instance was created.  To begin using it paste the following into your shell:
   CIB_shadow=cts-cli ; export CIB_shadow
 =#=#=#= Begin test: Try to check a rule that doesn't exist =#=#=#=
-unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
-unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
-unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
-No rule found with ID=blahblah
-Error checking rule: No such device or address
+crm_rule: No rule found with ID=blahblah
 =#=#=#= Current cib after: Try to check a rule that doesn't exist =#=#=#=
-<cib epoch="9" num_updates="0" admin_epoch="0">
+<cib epoch="10" num_updates="0" admin_epoch="0">
   <configuration>
-    <crm_config/>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="false"/>
+      </cluster_property_set>
+    </crm_config>
     <nodes/>
     <resources>
       <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
@@ -65,565 +65,69 @@ Error checking rule: No such device or address
 </cib>
 =#=#=#= End test: Try to check a rule that doesn't exist - No such object (105) =#=#=#=
 * Passed: crm_rule       - Try to check a rule that doesn't exist
+=#=#=#= Begin test: Try to check a rule that doesn't exist, with XML output =#=#=#=
+<pacemaker-result api-version="X" request="crm_rule -c -r blahblah --output-as=xml">
+  <status code="105" message="No such object">
+    <errors>
+      <error>crm_rule: No rule found with ID=blahblah</error>
+    </errors>
+  </status>
+</pacemaker-result>
+=#=#=#= End test: Try to check a rule that doesn't exist, with XML output - No such object (105) =#=#=#=
+* Passed: crm_rule       - Try to check a rule that doesn't exist, with XML output
 =#=#=#= Begin test: Try to check a rule that has too many date_expressions =#=#=#=
-unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
-unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
-unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
-Can't check rule cli-rule-too-many-date-expressions because it does not have exactly one date_expression
-Error checking rule: Operation not supported
-=#=#=#= Current cib after: Try to check a rule that has too many date_expressions =#=#=#=
-<cib epoch="9" num_updates="0" admin_epoch="0">
-  <configuration>
-    <crm_config/>
-    <nodes/>
-    <resources>
-      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
-    </resources>
-    <constraints>
-      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
-        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
-          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
-          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-no-date_expression" rsc="dummy">
-        <rule id="cli-no-date_expression-rule" score="INFINITY">
-          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
-        </rule>
-      </rsc_location>
-    </constraints>
-  </configuration>
-  <status/>
-</cib>
+crm_rule: Can't check rule cli-rule-too-many-date-expressions because it does not have exactly one date_expression
 =#=#=#= End test: Try to check a rule that has too many date_expressions - Unimplemented (3) =#=#=#=
 * Passed: crm_rule       - Try to check a rule that has too many date_expressions
 =#=#=#= Begin test: Verify basic rule is expired =#=#=#=
-unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
-unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
-unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
 Rule cli-prefer-rule-dummy-expired is expired
-=#=#=#= Current cib after: Verify basic rule is expired =#=#=#=
-<cib epoch="9" num_updates="0" admin_epoch="0">
-  <configuration>
-    <crm_config/>
-    <nodes/>
-    <resources>
-      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
-    </resources>
-    <constraints>
-      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
-        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
-          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
-          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-no-date_expression" rsc="dummy">
-        <rule id="cli-no-date_expression-rule" score="INFINITY">
-          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
-        </rule>
-      </rsc_location>
-    </constraints>
-  </configuration>
-  <status/>
-</cib>
 =#=#=#= End test: Verify basic rule is expired - Requested item has expired (110) =#=#=#=
 * Passed: crm_rule       - Verify basic rule is expired
+=#=#=#= Begin test: Verify basic rule is expired, with XML output =#=#=#=
+<pacemaker-result api-version="X" request="crm_rule -c -r cli-prefer-rule-dummy-expired --output-as=xml">
+  <rule-check rule-id="cli-prefer-rule-dummy-expired" rc="110"/>
+  <status code="110" message="Requested item has expired"/>
+</pacemaker-result>
+=#=#=#= End test: Verify basic rule is expired, with XML output - Requested item has expired (110) =#=#=#=
+* Passed: crm_rule       - Verify basic rule is expired, with XML output
 =#=#=#= Begin test: Verify basic rule worked in the past =#=#=#=
-unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
-unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
-unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
 Rule cli-prefer-rule-dummy-expired is still in effect
-=#=#=#= Current cib after: Verify basic rule worked in the past =#=#=#=
-<cib epoch="9" num_updates="0" admin_epoch="0">
-  <configuration>
-    <crm_config/>
-    <nodes/>
-    <resources>
-      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
-    </resources>
-    <constraints>
-      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
-        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
-          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
-          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-no-date_expression" rsc="dummy">
-        <rule id="cli-no-date_expression-rule" score="INFINITY">
-          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
-        </rule>
-      </rsc_location>
-    </constraints>
-  </configuration>
-  <status/>
-</cib>
 =#=#=#= End test: Verify basic rule worked in the past - OK (0) =#=#=#=
 * Passed: crm_rule       - Verify basic rule worked in the past
 =#=#=#= Begin test: Verify basic rule is not yet in effect =#=#=#=
-unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
-unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
-unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
 Rule cli-prefer-rule-dummy-not-yet has not yet taken effect
-=#=#=#= Current cib after: Verify basic rule is not yet in effect =#=#=#=
-<cib epoch="9" num_updates="0" admin_epoch="0">
-  <configuration>
-    <crm_config/>
-    <nodes/>
-    <resources>
-      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
-    </resources>
-    <constraints>
-      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
-        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
-          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
-          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-no-date_expression" rsc="dummy">
-        <rule id="cli-no-date_expression-rule" score="INFINITY">
-          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
-        </rule>
-      </rsc_location>
-    </constraints>
-  </configuration>
-  <status/>
-</cib>
 =#=#=#= End test: Verify basic rule is not yet in effect - Requested item is not yet in effect (111) =#=#=#=
 * Passed: crm_rule       - Verify basic rule is not yet in effect
 =#=#=#= Begin test: Verify date_spec rule with years has expired =#=#=#=
-unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
-unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
-unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
 Rule cli-prefer-rule-dummy-date_spec-only-years is expired
-=#=#=#= Current cib after: Verify date_spec rule with years has expired =#=#=#=
-<cib epoch="9" num_updates="0" admin_epoch="0">
-  <configuration>
-    <crm_config/>
-    <nodes/>
-    <resources>
-      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
-    </resources>
-    <constraints>
-      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
-        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
-          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
-          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-no-date_expression" rsc="dummy">
-        <rule id="cli-no-date_expression-rule" score="INFINITY">
-          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
-        </rule>
-      </rsc_location>
-    </constraints>
-  </configuration>
-  <status/>
-</cib>
 =#=#=#= End test: Verify date_spec rule with years has expired - Requested item has expired (110) =#=#=#=
 * Passed: crm_rule       - Verify date_spec rule with years has expired
+=#=#=#= Begin test: Verify multiple rules at once =#=#=#=
+Rule cli-prefer-rule-dummy-not-yet has not yet taken effect
+Rule cli-prefer-rule-dummy-date_spec-only-years is expired
+=#=#=#= End test: Verify multiple rules at once - Requested item has expired (110) =#=#=#=
+* Passed: crm_rule       - Verify multiple rules at once
+=#=#=#= Begin test: Verify multiple rules at once, with XML output =#=#=#=
+<pacemaker-result api-version="X" request="crm_rule -c -r cli-prefer-rule-dummy-not-yet -r cli-prefer-rule-dummy-date_spec-only-years --output-as=xml">
+  <rule-check rule-id="cli-prefer-rule-dummy-not-yet" rc="111"/>
+  <rule-check rule-id="cli-prefer-rule-dummy-date_spec-only-years" rc="110"/>
+  <status code="110" message="Requested item has expired"/>
+</pacemaker-result>
+=#=#=#= End test: Verify multiple rules at once, with XML output - Requested item has expired (110) =#=#=#=
+* Passed: crm_rule       - Verify multiple rules at once, with XML output
 =#=#=#= Begin test: Verify date_spec rule with years is in effect =#=#=#=
-unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
-unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
-unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
 Rule cli-prefer-rule-dummy-date_spec-only-years satisfies conditions
-=#=#=#= Current cib after: Verify date_spec rule with years is in effect =#=#=#=
-<cib epoch="9" num_updates="0" admin_epoch="0">
-  <configuration>
-    <crm_config/>
-    <nodes/>
-    <resources>
-      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
-    </resources>
-    <constraints>
-      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
-        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
-          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
-          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-no-date_expression" rsc="dummy">
-        <rule id="cli-no-date_expression-rule" score="INFINITY">
-          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
-        </rule>
-      </rsc_location>
-    </constraints>
-  </configuration>
-  <status/>
-</cib>
 =#=#=#= End test: Verify date_spec rule with years is in effect - OK (0) =#=#=#=
 * Passed: crm_rule       - Verify date_spec rule with years is in effect
 =#=#=#= Begin test: Try to check a rule whose date_spec does not contain years= =#=#=#=
-unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
-unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
-unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
-Rule either must not use date_spec, or use date_spec with years= but not moon=
-Error checking rule: No such device or address
-=#=#=#= Current cib after: Try to check a rule whose date_spec does not contain years= =#=#=#=
-<cib epoch="9" num_updates="0" admin_epoch="0">
-  <configuration>
-    <crm_config/>
-    <nodes/>
-    <resources>
-      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
-    </resources>
-    <constraints>
-      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
-        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
-          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
-          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-no-date_expression" rsc="dummy">
-        <rule id="cli-no-date_expression-rule" score="INFINITY">
-          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
-        </rule>
-      </rsc_location>
-    </constraints>
-  </configuration>
-  <status/>
-</cib>
+crm_rule: Rule either must not use date_spec, or use date_spec with years= but not moon=
 =#=#=#= End test: Try to check a rule whose date_spec does not contain years= - No such object (105) =#=#=#=
 * Passed: crm_rule       - Try to check a rule whose date_spec does not contain years=
 =#=#=#= Begin test: Try to check a rule whose date_spec contains years= and moon= =#=#=#=
-unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
-unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
-unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
-Rule either must not use date_spec, or use date_spec with years= but not moon=
-Error checking rule: No such device or address
-=#=#=#= Current cib after: Try to check a rule whose date_spec contains years= and moon= =#=#=#=
-<cib epoch="9" num_updates="0" admin_epoch="0">
-  <configuration>
-    <crm_config/>
-    <nodes/>
-    <resources>
-      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
-    </resources>
-    <constraints>
-      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
-        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
-          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
-          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-no-date_expression" rsc="dummy">
-        <rule id="cli-no-date_expression-rule" score="INFINITY">
-          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
-        </rule>
-      </rsc_location>
-    </constraints>
-  </configuration>
-  <status/>
-</cib>
+crm_rule: Rule either must not use date_spec, or use date_spec with years= but not moon=
 =#=#=#= End test: Try to check a rule whose date_spec contains years= and moon= - No such object (105) =#=#=#=
 * Passed: crm_rule       - Try to check a rule whose date_spec contains years= and moon=
 =#=#=#= Begin test: Try to check a rule with no date_expression =#=#=#=
-unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
-unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
-unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
-Can't check rule cli-no-date_expression-rule because it does not have exactly one date_expression
-Error checking rule: Operation not supported
-=#=#=#= Current cib after: Try to check a rule with no date_expression =#=#=#=
-<cib epoch="9" num_updates="0" admin_epoch="0">
-  <configuration>
-    <crm_config/>
-    <nodes/>
-    <resources>
-      <primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy"/>
-    </resources>
-    <constraints>
-      <rsc_location id="cli-too-many-date-expressions" rsc="dummy">
-        <rule id="cli-rule-too-many-date-expressions" score="INFINITY" boolean-op="or">
-          <date_expression id="cli-date-expression-1" operation="gt" start=""/>
-          <date_expression id="cli-date-expression-2" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-expired" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-expired" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-expired" operation="lt" end=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-not-yet" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-not-yet" score="INFINITY">
-          <date_expression id="cli-prefer-lifetime-end-dummy-not-yet" operation="gt" start=""/>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-only-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-only-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-only-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-only-years-spec" years="2019"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-without-years" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-without-years" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-without-years-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-without-years-spec" hours="20" months="1,3,5,7"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-prefer-dummy-date_spec-years-moon" rsc="dummy">
-        <rule id="cli-prefer-rule-dummy-date_spec-years-moon" score="INFINITY">
-          <date_expression id="cli-prefer-dummy-date_spec-years-moon-expr" operation="date_spec">
-            <date_spec id="cli-prefer-dummy-date_spec-years-moon-spec" years="2019" moon="1"/>
-          </date_expression>
-        </rule>
-      </rsc_location>
-      <rsc_location id="cli-no-date_expression" rsc="dummy">
-        <rule id="cli-no-date_expression-rule" score="INFINITY">
-          <expression id="ban-apache-expr" attribute="#uname" operation="eq" value="node3"/>
-        </rule>
-      </rsc_location>
-    </constraints>
-  </configuration>
-  <status/>
-</cib>
+crm_rule: Can't check rule cli-no-date_expression-rule because it does not have exactly one date_expression
 =#=#=#= End test: Try to check a rule with no date_expression - Unimplemented (3) =#=#=#=
 * Passed: crm_rule       - Try to check a rule with no date_expression

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -4702,7 +4702,7 @@ Transition Summary:
   * Move       Public-IP                           ( cluster02 -> cluster01 )
   * Move       Email                               ( cluster02 -> cluster01 )
   * Stop       mysql-proxy:0                       (              cluster02 )  due to node availability
-  * Stop       promotable-rsc:0                    (       Promoted cluster02 )  due to node availability
+  * Stop       promotable-rsc:0                    (     Promoted cluster02 )  due to node availability
 
 Executing Cluster Transition:
   * Pseudo action:   httpd-bundle-1_stop_0

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1758,6 +1758,14 @@ EOF
     cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-only-years"
     test_assert $CRM_EX_EXPIRED
 
+    desc="Verify multiple rules at once"
+    cmd="crm_rule -c -r cli-prefer-rule-dummy-not-yet -r cli-prefer-rule-dummy-date_spec-only-years"
+    test_assert $CRM_EX_EXPIRED
+
+    desc="Verify multiple rules at once, with XML output"
+    cmd="crm_rule -c -r cli-prefer-rule-dummy-not-yet -r cli-prefer-rule-dummy-date_spec-only-years --output-as=xml"
+    test_assert $CRM_EX_EXPIRED
+
     desc="Verify date_spec rule with years is in effect"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-only-years -d 20190201"
     test_assert $CRM_EX_OK

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1627,7 +1627,8 @@ test_rules() {
 
     create_shadow_cib
 
-    cibadmin -C -o resources   --xml-text '<primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy" />'
+    cibadmin -C -o crm_config --xml-text '<cluster_property_set id="cib-bootstrap-options"><nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="false"/></cluster_property_set>'
+    cibadmin -C -o resources --xml-text '<primitive class="ocf" id="dummy" provider="heartbeat" type="Dummy" />'
 
     TMPXML=$(mktemp ${TMPDIR:-/tmp}/cts-cli.tools.xml.XXXXXXXXXX)
     cat <<EOF > "$TMPXML"

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1733,55 +1733,55 @@ EOF
 
     desc="Try to check a rule that doesn't exist, with XML output"
     cmd="crm_rule -c -r blahblah --output-as=xml"
-    test_assert $CRM_EX_NOSUCH
+    test_assert $CRM_EX_NOSUCH 0
 
     desc="Try to check a rule that has too many date_expressions"
     cmd="crm_rule -c -r cli-rule-too-many-date-expressions"
-    test_assert $CRM_EX_UNIMPLEMENT_FEATURE
+    test_assert $CRM_EX_UNIMPLEMENT_FEATURE 0
 
     desc="Verify basic rule is expired"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-expired"
-    test_assert $CRM_EX_EXPIRED
+    test_assert $CRM_EX_EXPIRED 0
 
     desc="Verify basic rule is expired, with XML output"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-expired --output-as=xml"
-    test_assert $CRM_EX_EXPIRED
+    test_assert $CRM_EX_EXPIRED 0
 
     desc="Verify basic rule worked in the past"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-expired -d 20180101"
-    test_assert $CRM_EX_OK
+    test_assert $CRM_EX_OK 0
 
     desc="Verify basic rule is not yet in effect"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-not-yet"
-    test_assert $CRM_EX_NOT_YET_IN_EFFECT
+    test_assert $CRM_EX_NOT_YET_IN_EFFECT 0
 
     desc="Verify date_spec rule with years has expired"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-only-years"
-    test_assert $CRM_EX_EXPIRED
+    test_assert $CRM_EX_EXPIRED 0
 
     desc="Verify multiple rules at once"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-not-yet -r cli-prefer-rule-dummy-date_spec-only-years"
-    test_assert $CRM_EX_EXPIRED
+    test_assert $CRM_EX_EXPIRED 0
 
     desc="Verify multiple rules at once, with XML output"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-not-yet -r cli-prefer-rule-dummy-date_spec-only-years --output-as=xml"
-    test_assert $CRM_EX_EXPIRED
+    test_assert $CRM_EX_EXPIRED 0
 
     desc="Verify date_spec rule with years is in effect"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-only-years -d 20190201"
-    test_assert $CRM_EX_OK
+    test_assert $CRM_EX_OK 0
 
     desc="Try to check a rule whose date_spec does not contain years="
     cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-without-years"
-    test_assert $CRM_EX_NOSUCH
+    test_assert $CRM_EX_NOSUCH 0
 
     desc="Try to check a rule whose date_spec contains years= and moon="
     cmd="crm_rule -c -r cli-prefer-rule-dummy-date_spec-years-moon"
-    test_assert $CRM_EX_NOSUCH
+    test_assert $CRM_EX_NOSUCH 0
 
     desc="Try to check a rule with no date_expression"
     cmd="crm_rule -c -r cli-no-date_expression-rule"
-    test_assert $CRM_EX_UNIMPLEMENT_FEATURE
+    test_assert $CRM_EX_UNIMPLEMENT_FEATURE 0
 
     unset CIB_shadow_dir
 }

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1730,12 +1730,20 @@ EOF
     cmd="crm_rule -c -r blahblah"
     test_assert $CRM_EX_NOSUCH
 
+    desc="Try to check a rule that doesn't exist, with XML output"
+    cmd="crm_rule -c -r blahblah --output-as=xml"
+    test_assert $CRM_EX_NOSUCH
+
     desc="Try to check a rule that has too many date_expressions"
     cmd="crm_rule -c -r cli-rule-too-many-date-expressions"
     test_assert $CRM_EX_UNIMPLEMENT_FEATURE
 
     desc="Verify basic rule is expired"
     cmd="crm_rule -c -r cli-prefer-rule-dummy-expired"
+    test_assert $CRM_EX_EXPIRED
+
+    desc="Verify basic rule is expired, with XML output"
+    cmd="crm_rule -c -r cli-prefer-rule-dummy-expired --output-as=xml"
     test_assert $CRM_EX_EXPIRED
 
     desc="Verify basic rule worked in the past"

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the Pacemaker project contributors
+ * Copyright 2019-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -28,7 +28,7 @@ extern "C" {
  */
 
 
-#  define PCMK__API_VERSION "2.15"
+#  define PCMK__API_VERSION "2.16"
 
 #if defined(PCMK__WITH_ATTRIBUTE_OUTPUT_ARGS)
 #  define PCMK__OUTPUT_ARGS(ARGS...) __attribute__((output_args(ARGS)))

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -66,7 +66,7 @@ extern "C" {
  * >=3.0.13: Fail counts include operation name and interval
  * >=3.2.0:  DC supports PCMK_EXEC_INVALID and PCMK_EXEC_NOT_CONNECTED
  */
-#  define CRM_FEATURE_SET		"3.13.1"
+#  define CRM_FEATURE_SET		"3.13.2"
 
 /* Pacemaker's CPG protocols use fixed-width binary fields for the sender and
  * recipient of a CPG message. This imposes an arbitrary limit on cluster node

--- a/tools/crm_rule.c
+++ b/tools/crm_rule.c
@@ -264,12 +264,7 @@ static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
 
-    const char *description = "This tool is currently experimental.\n"
-                              "The interface, behavior, and output may change "
-                              "with any version of Pacemaker.";
-
     context = pcmk__build_arg_context(args, "text (default), xml", group, NULL);
-    g_option_context_set_description(context, description);
 
     pcmk__add_arg_group(context, "modes", "Modes (mutually exclusive):",
                         "Show modes of operation", mode_entries);

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -56,6 +56,7 @@ version_pairs_last = $(wordlist \
 API_request_base	= command-output	\
 			  crm_mon		\
 			  crm_resource		\
+			  crm_rule \
 			  crm_simulate		\
 			  crmadmin		\
 			  digests		\

--- a/xml/api/crm_rule-2.16.rng
+++ b/xml/api/crm_rule-2.16.rng
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crm_rule"/>
+    </start>
+
+    <define name="element-crm_rule">
+        <zeroOrMore>
+            <ref name="element-rule-check" />
+        </zeroOrMore>
+    </define>
+
+    <define name="element-rule-check">
+        <element name="rule-check">
+            <attribute name="rule-id"> <text /> </attribute>
+            <attribute name="rc"> <data type="nonNegativeInteger" /> </attribute>
+        </element>
+    </define>
+</grammar>


### PR DESCRIPTION
The hidden purpose of this PR is that after this, and then doing another one for crm_ticket (which needs to be converted to using glib for args first, ugh) then we can get rid of include/pcmki/pcmki_error.h.  And getting rid of entire source files is very appealing.

Note that the conversion away from CMD_ERR here means that errors will only be printed to the screen.  They will not also get logged with crm_warn.  For crm_rule at least, I am fine with that.  I'm sure I just copied and pasted that from somewhere else.