### PR TITLE
Feature: resources: update HealthSMART agent for OCF 1.1

### DIFF
--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -251,33 +251,31 @@ HealthSMART_monitor() {
 
     if [ -f "${OCF_RESKEY_state}" ]; then
 
-        # Check overall S.M.A.R.T. status
-        for DRIVE in $DRIVES; do
+        for ndx in ${!DRIVES[*]}; do
+            DRIVE=${DRIVES[$ndx]}
+
             if [ -n "${OCF_RESKEY_devices}" ]; then
-                for DEVICE in ${OCF_RESKEY_devices}; do
-                    "${OCF_RESKEY_smartctl}" -d "$DEVICE" -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
-                    if [ $? -ne 0 ]; then
-                        attrd_updater -n "#health-smart" -U "red" -d "5s"
-                        return $OCF_SUCCESS
-                    fi
-                done
+                DEVICE=${DEVICES[$ndx]}
+
+                # Check overall S.M.A.R.T. status
+                "${OCF_RESKEY_smartctl}" -d "${DEVICE}" -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
+                if [ $? -ne 0 ]; then
+                    attrd_updater -n "#health-smart" -U "red" -d "5s"
+                    return $OCF_SUCCESS
+                fi
+
+                # Check drive temperature(s)
+                check_temperature "$("${OCF_RESKEY_smartctl}" -d "${DEVICE}" -A "${DRIVE}" | awk '/^194/ { print $10 }')"
+                if [ $? -ne 0 ]; then
+                    return $OCF_SUCCESS
+                fi
             else
                 "${OCF_RESKEY_smartctl}" -H "${DRIVE}" | grep -q "SMART overall-health self-assessment test result: PASSED"
                 if [ $? -ne 0 ]; then
                     attrd_updater -n "#health-smart" -U "red" -d "5s"
                     return $OCF_SUCCESS
                 fi
-            fi
 
-            # Check drive temperature(s)
-            if [ -n "${OCF_RESKEY_devices}" ]; then
-                for DEVICE in ${OCF_RESKEY_devices}; do
-                    check_temperature "$("${OCF_RESKEY_smartctl}" -d "$DEVICE" -A "${DRIVE}" | awk '/^194/ { print $10 }')"
-                    if [ $? -ne 0 ]; then
-                        return $OCF_SUCCESS
-                    fi
-                done
-            else
                 check_temperature "$("${OCF_RESKEY_smartctl}" -A "${DRIVE}" | awk '/^194/ { print $10 }')"
                 if [ $? -ne 0 ]; then
                     return $OCF_SUCCESS

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -33,6 +33,7 @@
 : ${OCF_RESKEY_devices:=""}
 : ${OCF_RESKEY_state:=""}
 : ${OCF_RESKEY_smartctl:="/usr/sbin/smartctl"}
+: ${OCF_RESKEY_dampen:="5s"}
 
 # Turn these into arrays so we can iterate them later.
 DRIVES=(${OCF_RESKEY_drives})
@@ -110,6 +111,14 @@ The path to the smartctl program, used for querying device health.
 <contest type="string" default="/usr/sbin/smartctl"/>
 </parameter>
 
+<parameter name="dampen" reloadable="1">
+<longdesc lang="en">
+The time to wait (dampening) for further changes to occur
+</longdesc>
+<shortdesc lang="en">Dampening interval</shortdesc>
+<content type="integer" default="5s"/>
+</parameter>
+
 </parameters>
 
 <actions>
@@ -130,25 +139,25 @@ check_temperature() {
 
     if [ $1 -lt ${lower_red_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} too cold: ${1} C"
-        attrd_updater -n "#health-smart" -U "red" -d "5s"
+        attrd_updater -n "#health-smart" -U "red" -d "${OCF_RESKEY_dampen}"
         return 1
     fi
 
     if [ $1 -gt ${upper_red_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} too hot: ${1} C"
-        attrd_updater -n "#health-smart" -U "red" -d "5s"
+        attrd_updater -n "#health-smart" -U "red" -d "${OCF_RESKEY_dampen}"
         return 1
     fi
 
     if [ $1 -lt ${lower_yellow_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} quite cold: ${1} C"
-        attrd_updater -n "#health-smart" -U "yellow" -d "5s"
+        attrd_updater -n "#health-smart" -U "yellow" -d "${OCF_RESKEY_dampen}"
         return 1
     fi
 
     if [ $1 -gt ${upper_yellow_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} quite hot: ${1} C"
-        attrd_updater -n "#health-smart" -U "yellow" -d "5s"
+        attrd_updater -n "#health-smart" -U "yellow" -d "${OCF_RESKEY_dampen}"
         return 1
     fi
 }
@@ -231,7 +240,7 @@ HealthSMART_start() {
 }
 
 HealthSMART_stop() {
-    attrd_updater -D -n "#health-smart" -d "5s"
+    attrd_updater -D -n "#health-smart" -d "${OCF_RESKEY_dampen}"
 
     rm "${OCF_RESKEY_state}"
 
@@ -261,7 +270,7 @@ HealthSMART_monitor() {
                 # Check overall S.M.A.R.T. status
                 "${OCF_RESKEY_smartctl}" -d "${DEVICE}" -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
                 if [ $? -ne 0 ]; then
-                    attrd_updater -n "#health-smart" -U "red" -d "5s"
+                    attrd_updater -n "#health-smart" -U "red" -d "${OCF_RESKEY_dampen}"
                     return $OCF_SUCCESS
                 fi
 
@@ -273,7 +282,7 @@ HealthSMART_monitor() {
             else
                 "${OCF_RESKEY_smartctl}" -H "${DRIVE}" | grep -q "SMART overall-health self-assessment test result: PASSED"
                 if [ $? -ne 0 ]; then
-                    attrd_updater -n "#health-smart" -U "red" -d "5s"
+                    attrd_updater -n "#health-smart" -U "red" -d "${OCF_RESKEY_dampen}"
                     return $OCF_SUCCESS
                 fi
 
@@ -284,7 +293,7 @@ HealthSMART_monitor() {
             fi
         done
 
-        attrd_updater -n "#health-smart" -U "green" -d "5s"
+        attrd_updater -n "#health-smart" -U "green" -d "${OCF_RESKEY_dampen}"
         return $OCF_SUCCESS
     fi
 

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -162,6 +162,27 @@ check_temperature() {
     fi
 }
 
+common_checks() {
+    # Each item in $OCF_RESKEY_drives must have a corresponding item in
+    # $OCF_RESKEY_devices with the device type.  Alternately,
+    # $OCF_RESKEY_devices can be empty.
+    drives_len=${#DRIVES[@]}
+    devices_len=${#DEVICES[@]}
+
+    if [ "${drives_len}" -ne "${devices_len}" ] && [ "${devices_len}" -gt 0 ]; then
+        ocf_log err "OCF_RESKEY_devices must be empty or the same length as OCF_RESKEY_drives."
+        exit $OCF_ERR_ARGS
+    fi
+
+    # Each item in $OCF_RESKEY_drives must look like a device node.
+    for d in "${DRIVES[@]}"; do
+        if [[ "$d" != /dev/* ]]; then
+            ocf_log err "Device in OCF_RESKEY_devices does not look like a device node: $d"
+            exit $OCF_ERR_ARGS
+        fi
+    done
+}
+
 
 init_smart() {
     #Set temperature defaults
@@ -184,23 +205,6 @@ init_smart() {
         upper_red_limit=${OCF_RESKEY_temp_upper_limit}
     fi
     upper_yellow_limit=$((${upper_red_limit}-${yellow_threshold}))
-
-    #Test for presence of smartctl
-    if [ ! -x "${OCF_RESKEY_smartctl}" ] ; then
-        ocf_log err "${OCF_RESKEY_smartctl} not installed."
-        exit $OCF_ERR_INSTALLED
-    fi
-
-    # Each item in $OCF_RESKEY_drives must have a corresponding item in
-    # $OCF_RESKEY_devices with the device type.  Alternately,
-    # $OCF_RESKEY_devices can be empty.  First, check that this is the case.
-    drives_len=${#DRIVES[@]}
-    devices_len=${#DEVICES[@]}
-
-    if [ "${drives_len}" -ne "${devices_len}" ] && [ "${devices_len}" -gt 0 ]; then
-        ocf_log err "OCF_RESKEY_devices must be empty or the same length as OCF_RESKEY_drives."
-        exit $OCF_ERR_ARGS
-    fi
 
     for ndx in ${!DRIVES[*]}; do
         DRIVE=${DRIVES[$ndx]}
@@ -252,6 +256,10 @@ HealthSMART_stop() {
 }
 
 HealthSMART_monitor() {
+    common_checks
+
+    # Test for presence of smartctl
+    check_binary smartctl
 
     init_smart
 
@@ -302,8 +310,13 @@ HealthSMART_monitor() {
 }
 
 HealthSMART_validate() {
+    common_checks
+
     # Host-specific checks
     if [ "$OCF_CHECK_LEVEL" = "10" ]; then
+        # Test for presence of smartctl
+        check_binary smartctl
+
         init_smart
 
         # Is the state directory writable?

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -29,10 +29,14 @@
 : ${OCF_RESKEY_temp_warning:=""}
 : ${OCF_RESKEY_temp_lower_limit:=""}
 : ${OCF_RESKEY_temp_upper_limit:=""}
-: ${OCF_RESKEY_drives:=""}
+: ${OCF_RESKEY_drives:="/dev/sda"}
 : ${OCF_RESKEY_devices:=""}
 : ${OCF_RESKEY_state:=""}
 : ${OCF_RESKEY_smartctl:="/usr/sbin/smartctl"}
+
+# Turn these into arrays so we can iterate them later.
+DRIVES=(${OCF_RESKEY_drives})
+DEVICES=(${OCF_RESKEY_devices})
 
 #######################################################################
 
@@ -171,28 +175,34 @@ init_smart() {
     fi
     upper_yellow_limit=$((${upper_red_limit}-${yellow_threshold}))
 
-    #Set disk defaults
-    if [ -z "${OCF_RESKEY_drives}" ] ; then
-        DRIVES="/dev/sda"
-    else
-        DRIVES=${OCF_RESKEY_drives}
-    fi
-
     #Test for presence of smartctl
     if [ ! -x "${OCF_RESKEY_smartctl}" ] ; then
         ocf_log err "${OCF_RESKEY_smartctl} not installed."
         exit $OCF_ERR_INSTALLED
     fi
 
-    for DRIVE in $DRIVES; do
+    # Each item in $OCF_RESKEY_drives must have a corresponding item in
+    # $OCF_RESKEY_devices with the device type.  Alternately,
+    # $OCF_RESKEY_devices can be empty.  First, check that this is the case.
+    drives_len=${#DRIVES[@]}
+    devices_len=${#DEVICES[@]}
+
+    if [ "${drives_len}" -ne "${devices_len}" ] && [ "${devices_len}" -gt 0 ]; then
+        ocf_log err "OCF_RESKEY_devices must be empty or the same length as OCF_RESKEY_drives."
+        exit $OCF_ERR_ARGS
+    fi
+
+    for ndx in ${!DRIVES[*]}; do
+        DRIVE=${DRIVES[$ndx]}
+
         if [ -n "${OCF_RESKEY_devices}" ]; then
-            for DEVICE in ${OCF_RESKEY_devices}; do
-                "${OCF_RESKEY_smartctl}" -d "$DEVICE" -i "${DRIVE}" | grep -q "SMART support is: Enabled"
-                if [ $? -ne 0 ] ; then
-                    ocf_log err "S.M.A.R.T. not enabled for drive "${DRIVE}
-                    exit $OCF_ERR_INSTALLED
-                fi
-            done
+            DEVICE=${DEVICES[$ndx]}
+
+            "${OCF_RESKEY_smartctl}" -d "${DEVICE}" -i "${DRIVE}" | grep -q "SMART support is: Enabled"
+            if [ $? -ne 0 ] ; then
+                ocf_log err "S.M.A.R.T. not enabled for drive "${DRIVE}
+                exit $OCF_ERR_INSTALLED
+            fi
         else
             "${OCF_RESKEY_smartctl}" -i "${DRIVE}" | grep -q "SMART support is: Enabled"
             if [ $? -ne 0 ] ; then

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -22,8 +22,6 @@
 : ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
 . "${OCF_FUNCTIONS}"
 : ${__OCF_ACTION:="$1"}
-#
-SMARTCTL=/usr/sbin/smartctl
 
 # Explicitly list all environment variables used, to make static analysis happy
 : ${OCF_RESKEY_CRM_meta_interval:=0}
@@ -34,6 +32,7 @@ SMARTCTL=/usr/sbin/smartctl
 : ${OCF_RESKEY_drives:=""}
 : ${OCF_RESKEY_devices:=""}
 : ${OCF_RESKEY_state:=""}
+: ${OCF_RESKEY_smartctl:="/usr/sbin/smartctl"}
 
 #######################################################################
 
@@ -97,6 +96,14 @@ Number of deg C below/above the upper/lower temp limits at which point the statu
 </longdesc>
 <shortdesc lang="en">Deg C below/above the upper limits for yellow smart attribute</shortdesc>
 <content type="string" default="5"/>
+</parameter>
+
+<parameter name="smartctl">
+<longdesc lang="en">
+The path to the smartctl program, used for querying device health.
+</longdesc>
+<shortdesc lang="en">The path to the smartctl program</shortdesc>
+<contest type="string" default="/usr/sbin/smartctl"/>
 </parameter>
 
 </parameters>
@@ -172,22 +179,22 @@ init_smart() {
     fi
 
     #Test for presence of smartctl
-    if [ ! -x "$SMARTCTL" ] ; then
-        ocf_log err "${SMARTCTL} not installed."
+    if [ ! -x "${OCF_RESKEY_smartctl}" ] ; then
+        ocf_log err "${OCF_RESKEY_smartctl} not installed."
         exit $OCF_ERR_INSTALLED
     fi
 
     for DRIVE in $DRIVES; do
         if [ -n "${OCF_RESKEY_devices}" ]; then
             for DEVICE in ${OCF_RESKEY_devices}; do
-                "$SMARTCTL" -d "$DEVICE" -i "${DRIVE}" | grep -q "SMART support is: Enabled"
+                "${OCF_RESKEY_smartctl}" -d "$DEVICE" -i "${DRIVE}" | grep -q "SMART support is: Enabled"
                 if [ $? -ne 0 ] ; then
                     ocf_log err "S.M.A.R.T. not enabled for drive "${DRIVE}
                     exit $OCF_ERR_INSTALLED
                 fi
             done
         else
-            "$SMARTCTL" -i "${DRIVE}" | grep -q "SMART support is: Enabled"
+            "${OCF_RESKEY_smartctl}" -i "${DRIVE}" | grep -q "SMART support is: Enabled"
             if [ $? -ne 0 ] ; then
                 ocf_log err "S.M.A.R.T. not enabled for drive "${DRIVE}
                 exit $OCF_ERR_INSTALLED
@@ -234,14 +241,14 @@ HealthSMART_monitor() {
         for DRIVE in $DRIVES; do
             if [ -n "${OCF_RESKEY_devices}" ]; then
                 for DEVICE in ${OCF_RESKEY_devices}; do
-                    "$SMARTCTL" -d "$DEVICE" -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
+                    "${OCF_RESKEY_smartctl}" -d "$DEVICE" -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
                     if [ $? -ne 0 ]; then
                         attrd_updater -n "#health-smart" -U "red" -d "5s"
                         return $OCF_SUCCESS
                     fi
                 done
             else
-                "$SMARTCTL" -H "${DRIVE}" | grep -q "SMART overall-health self-assessment test result: PASSED"
+                "${OCF_RESKEY_smartctl}" -H "${DRIVE}" | grep -q "SMART overall-health self-assessment test result: PASSED"
                 if [ $? -ne 0 ]; then
                     attrd_updater -n "#health-smart" -U "red" -d "5s"
                     return $OCF_SUCCESS
@@ -251,13 +258,13 @@ HealthSMART_monitor() {
             # Check drive temperature(s)
             if [ -n "${OCF_RESKEY_devices}" ]; then
                 for DEVICE in ${OCF_RESKEY_devices}; do
-                    check_temperature "$("$SMARTCTL" -d "$DEVICE" -A "${DRIVE}" | awk '/^194/ { print $10 }')"
+                    check_temperature "$("${OCF_RESKEY_smartctl}" -d "$DEVICE" -A "${DRIVE}" | awk '/^194/ { print $10 }')"
                     if [ $? -ne 0 ]; then
                         return $OCF_SUCCESS
                     fi
                 done
             else
-                check_temperature "$("$SMARTCTL" -A "${DRIVE}" | awk '/^194/ { print $10 }')"
+                check_temperature "$("${OCF_RESKEY_smartctl}" -A "${DRIVE}" | awk '/^194/ { print $10 }')"
                 if [ $? -ne 0 ]; then
                     return $OCF_SUCCESS
                 fi

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -61,7 +61,7 @@ Location to store the resource state in.
 <content type="string" default="${HA_VARRUN%%/}/HealthSMART-${OCF_RESOURCE_INSTANCE}.state" />
 </parameter>
 
-<parameter name="drives">
+<parameter name="drives" reloadable="1">
 <longdesc lang="en">
 The drive(s) to check as a SPACE separated list. Enter the full path to the device, e.g. "/dev/sda".
 </longdesc>
@@ -69,7 +69,7 @@ The drive(s) to check as a SPACE separated list. Enter the full path to the devi
 <content type="string" default="/dev/sda" />
 </parameter>
 
-<parameter name="devices">
+<parameter name="devices" reloadable="1">
 <longdesc lang="en">
 The device type(s) to assume for the drive(s) being tested as a SPACE separated list.
 </longdesc>
@@ -77,7 +77,7 @@ The device type(s) to assume for the drive(s) being tested as a SPACE separated 
 <content type="string" />
 </parameter>
 
-<parameter name="temp_lower_limit">
+<parameter name="temp_lower_limit" reloadable="1">
 <longdesc lang="en">
 Lower limit of the temperature in deg C of the drive(s). Below this limit the status will be red.
 </longdesc>
@@ -85,7 +85,7 @@ Lower limit of the temperature in deg C of the drive(s). Below this limit the st
 <content type="string" default="0"/>
 </parameter>
 
-<parameter name="temp_upper_limit">
+<parameter name="temp_upper_limit" reloadable="1">
 <longdesc lang="en">
 Upper limit of the temperature if deg C of the drives(s). If the drive reports
 a temperature higher than this value the status of #health-smart will be red.
@@ -94,7 +94,7 @@ a temperature higher than this value the status of #health-smart will be red.
 <content type="string" default="60"/>
 </parameter>
 
-<parameter name="temp_warning">
+<parameter name="temp_warning" reloadable="1">
 <longdesc lang="en">
 Number of deg C below/above the upper/lower temp limits at which point the status of #health-smart will change to yellow.
 </longdesc>
@@ -102,7 +102,7 @@ Number of deg C below/above the upper/lower temp limits at which point the statu
 <content type="string" default="5"/>
 </parameter>
 
-<parameter name="smartctl">
+<parameter name="smartctl" reloadable="1">
 <longdesc lang="en">
 The path to the smartctl program, used for querying device health.
 </longdesc>
@@ -118,6 +118,7 @@ The path to the smartctl program, used for querying device health.
 <action name="monitor"      timeout="10s" interval="10s" start-delay="0s" />
 <action name="meta-data"    timeout="5s" />
 <action name="validate-all"   timeout="10s" />
+<action name="reload-agent"   timeout="20s" />
 </actions>
 </resource-agent>
 END
@@ -215,7 +216,7 @@ init_smart() {
 
 HealthSMART_usage() {
     cat <<END
-usage: $0 {start|stop|monitor|validate-all|meta-data}
+usage: $0 {start|stop|monitor|validate-all|meta-data|reload-agent}
 
 Expects to have a fully populated OCF RA-compliant environment set.
 END
@@ -308,6 +309,10 @@ HealthSMART_validate() {
     return $OCF_SUCCESS
 }
 
+HealthSMART_reload_agent() {
+    return $OCF_SUCCESS
+}
+
 
 if [ -z "$OCF_RESKEY_state" ]; then
     if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
@@ -325,6 +330,7 @@ case "$__OCF_ACTION" in
     stop)         HealthSMART_stop;;
     monitor)      HealthSMART_monitor;;
     validate-all) HealthSMART_validate;;
+    reload-agent) HealthSMART_reload_agent;;
     meta-data)
         meta_data
         exit $OCF_SUCCESS

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -220,11 +220,15 @@ HealthSMART_start() {
 }
 
 HealthSMART_stop() {
-    HealthSMART_monitor
-    if [ $? -eq $OCF_SUCCESS ]; then
-        rm "${OCF_RESKEY_state}"
+    attrd_updater -D -n "#health-smart" -d "5s"
+
+    rm "${OCF_RESKEY_state}"
+
+    if [ $? -eq 0 ]; then
+        return $OCF_SUCCESS
+    else
+        return $OCF_ERR_GENERIC
     fi
-    return $OCF_SUCCESS
 }
 
 HealthSMART_monitor() {

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -24,7 +24,6 @@
 : ${__OCF_ACTION:="$1"}
 #
 SMARTCTL=/usr/sbin/smartctl
-ATTRDUP=/usr/sbin/attrd_updater
 
 # Explicitly list all environment variables used, to make static analysis happy
 : ${OCF_RESKEY_CRM_meta_interval:=0}
@@ -119,25 +118,25 @@ check_temperature() {
 
     if [ $1 -lt ${lower_red_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} too cold: ${1} C"
-        "$ATTRDUP" -n "#health-smart" -U "red" -d "5s"
+        attrd_updater -n "#health-smart" -U "red" -d "5s"
         return 1
     fi
 
     if [ $1 -gt ${upper_red_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} too hot: ${1} C"
-        "$ATTRDUP" -n "#health-smart" -U "red" -d "5s"
+        attrd_updater -n "#health-smart" -U "red" -d "5s"
         return 1
     fi
 
     if [ $1 -lt ${lower_yellow_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} quite cold: ${1} C"
-        "$ATTRDUP" -n "#health-smart" -U "yellow" -d "5s"
+        attrd_updater -n "#health-smart" -U "yellow" -d "5s"
         return 1
     fi
 
     if [ $1 -gt ${upper_yellow_limit} ] ; then
         ocf_log info "Drive ${DRIVE} ${DEVICE} quite hot: ${1} C"
-        "$ATTRDUP" -n "#health-smart" -U "yellow" -d "5s"
+        attrd_updater -n "#health-smart" -U "yellow" -d "5s"
         return 1
     fi
 }
@@ -237,14 +236,14 @@ HealthSMART_monitor() {
                 for DEVICE in ${OCF_RESKEY_devices}; do
                     "$SMARTCTL" -d "$DEVICE" -H ${DRIVE} | grep -q "SMART overall-health self-assessment test result: PASSED"
                     if [ $? -ne 0 ]; then
-                        "$ATTRDUP" -n "#health-smart" -U "red" -d "5s"
+                        attrd_updater -n "#health-smart" -U "red" -d "5s"
                         return $OCF_SUCCESS
                     fi
                 done
             else
                 "$SMARTCTL" -H "${DRIVE}" | grep -q "SMART overall-health self-assessment test result: PASSED"
                 if [ $? -ne 0 ]; then
-                    "$ATTRDUP" -n "#health-smart" -U "red" -d "5s"
+                    attrd_updater -n "#health-smart" -U "red" -d "5s"
                     return $OCF_SUCCESS
                 fi
             fi
@@ -265,7 +264,7 @@ HealthSMART_monitor() {
             fi
         done
 
-        "$ATTRDUP" -n "#health-smart" -U "green" -d "5s"
+        attrd_updater -n "#health-smart" -U "green" -d "5s"
         return $OCF_SUCCESS
     fi
 
@@ -274,11 +273,10 @@ HealthSMART_monitor() {
 }
 
 HealthSMART_validate() {
-
-    init_smart
-
     # Host-specific checks
     if [ "$OCF_CHECK_LEVEL" = "10" ]; then
+        init_smart
+
         # Is the state directory writable?
         state_dir=$(dirname "$OCF_RESKEY_state")
         touch "$state_dir/$$"

--- a/extra/resources/HealthSMART.in
+++ b/extra/resources/HealthSMART.in
@@ -2,7 +2,7 @@
 #
 # ocf:pacemaker:HealthSMART resource agent
 #
-# Copyright 2009-2021 the Pacemaker project contributors
+# Copyright 2009-2022 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -41,9 +41,8 @@ ATTRDUP=/usr/sbin/attrd_updater
 meta_data() {
     cat <<END
 <?xml version="1.0"?>
-<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="HealthSMART" version="0.1">
-<version>1.0</version>
+<resource-agent name="HealthSMART" version="1.0">
+<version>1.1</version>
 
 <longdesc lang="en">
 System health agent that checks the S.M.A.R.T. status of the given drives and
@@ -52,7 +51,7 @@ updates the #health-smart attribute.
 <shortdesc lang="en">SMART health status</shortdesc>
 
 <parameters>
-<parameter name="state" unique="1">
+<parameter name="state" unique-group="state">
 <longdesc lang="en">
 Location to store the resource state in.
 </longdesc>
@@ -60,7 +59,7 @@ Location to store the resource state in.
 <content type="string" default="${HA_VARRUN%%/}/HealthSMART-${OCF_RESOURCE_INSTANCE}.state" />
 </parameter>
 
-<parameter name="drives" unique="0">
+<parameter name="drives">
 <longdesc lang="en">
 The drive(s) to check as a SPACE separated list. Enter the full path to the device, e.g. "/dev/sda".
 </longdesc>
@@ -68,7 +67,7 @@ The drive(s) to check as a SPACE separated list. Enter the full path to the devi
 <content type="string" default="/dev/sda" />
 </parameter>
 
-<parameter name="devices" unique="0">
+<parameter name="devices">
 <longdesc lang="en">
 The device type(s) to assume for the drive(s) being tested as a SPACE separated list.
 </longdesc>
@@ -76,7 +75,7 @@ The device type(s) to assume for the drive(s) being tested as a SPACE separated 
 <content type="string" />
 </parameter>
 
-<parameter name="temp_lower_limit" unique="0">
+<parameter name="temp_lower_limit">
 <longdesc lang="en">
 Lower limit of the temperature in deg C of the drive(s). Below this limit the status will be red.
 </longdesc>
@@ -84,7 +83,7 @@ Lower limit of the temperature in deg C of the drive(s). Below this limit the st
 <content type="string" default="0"/>
 </parameter>
 
-<parameter name="temp_upper_limit" unique="0">
+<parameter name="temp_upper_limit">
 <longdesc lang="en">
 Upper limit of the temperature if deg C of the drives(s). If the drive reports
 a temperature higher than this value the status of #health-smart will be red.
@@ -93,7 +92,7 @@ a temperature higher than this value the status of #health-smart will be red.
 <content type="string" default="60"/>
 </parameter>
 
-<parameter name="temp_warning" unique="0">
+<parameter name="temp_warning">
 <longdesc lang="en">
 Number of deg C below/above the upper/lower temp limits at which point the status of #health-smart will change to yellow.
 </longdesc>
@@ -278,13 +277,16 @@ HealthSMART_validate() {
 
     init_smart
 
-    # Is the state directory writable?
-    state_dir=$(dirname "$OCF_RESKEY_state")
-    touch "$state_dir/$$"
-    if [ $? -ne 0 ]; then
-        return $OCF_ERR_ARGS
+    # Host-specific checks
+    if [ "$OCF_CHECK_LEVEL" = "10" ]; then
+        # Is the state directory writable?
+        state_dir=$(dirname "$OCF_RESKEY_state")
+        touch "$state_dir/$$"
+        if [ $? -ne 0 ]; then
+            return $OCF_ERR_ARGS
+        fi
+        rm "$state_dir/$$"
     fi
-    rm "$state_dir/$$"
 
     return $OCF_SUCCESS
 }


### PR DESCRIPTION
* The HealthSMART agent is now marked as version 1.0.
* Update the unique= attributes on parameters.
* The state directory check will only be run if OCF_CHECK_LEVEL=10.

Fixes T52.