### PR TITLE
High: tools: Fix the -v option to attrd_updater.

### DIFF
--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -56,7 +56,7 @@ command_cb (const gchar *option_name, const gchar *optarg, gpointer data, GError
         options.command = 'Q';
     } else if (pcmk__str_any_of(option_name, "--refresh", "-R", NULL)) {
         options.command = 'R';
-    } else if (pcmk__str_any_of(option_name, "--update", "-U", NULL)) {
+    } else if (pcmk__str_any_of(option_name, "--update", "-U", "-v", NULL)) {
         options.command = 'U';
     }
 
@@ -150,7 +150,7 @@ static GOptionEntry addl_entries[] = {
 };
 
 static GOptionEntry deprecated_entries[] = {
-    { NULL, 'v', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_CALLBACK, command_cb,
+    { "update", 'v', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_CALLBACK, command_cb,
       NULL,
       NULL },
 


### PR DESCRIPTION
Two things were going wrong here:

(1) The "-v" option needs to be recognized by the command_cb function.

(2) All options must have a long name, so duplicate the "update" name.
Without a long name, the leading NULL is seen as the terminator for the
entire entry array and neither that entry nor any after it will be added
to the program.

Fixes T195.