### PR TITLE
Convert attrd_updater to use formatted output

### DIFF
--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -28,7 +28,7 @@ extern "C" {
  */
 
 
-#  define PCMK__API_VERSION "2.17"
+#  define PCMK__API_VERSION "2.18"
 
 #if defined(PCMK__WITH_ATTRIBUTE_OUTPUT_ARGS)
 #  define PCMK__OUTPUT_ARGS(ARGS...) __attribute__((output_args(ARGS)))

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -66,7 +66,7 @@ extern "C" {
  * >=3.0.13: Fail counts include operation name and interval
  * >=3.2.0:  DC supports PCMK_EXEC_INVALID and PCMK_EXEC_NOT_CONNECTED
  */
-#  define CRM_FEATURE_SET		"3.13.3"
+#  define CRM_FEATURE_SET		"3.13.4"
 
 /* Pacemaker's CPG protocols use fixed-width binary fields for the sender and
  * recipient of a CPG message. This imposes an arbitrary limit on cluster node

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1789,7 +1789,63 @@ cluster_status_html(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
+PCMK__OUTPUT_ARGS("attribute", "char *", "char *", "char *")
+static int
+attribute_default(pcmk__output_t *out, va_list args)
+{
+    char *type = va_arg(args, char *);
+    char *attr_id = va_arg(args, char *);
+    char *attr_name = va_arg(args, char *);
+    char *read_value = va_arg(args, char *);
+
+    if (out->quiet) {
+        pcmk__formatted_printf(out, "%s\n", read_value);
+    } else {
+        out->info(out, "%s%s %s%s %s%s value=%s",
+                  type ? "scope=" : "", type ? type : "",
+                  attr_id ? "id=" : "", attr_id ? attr_id : "",
+                  attr_name ? "name=" : "", attr_name ? attr_name : "",
+                  read_value ? read_value : "(null)");
+    }
+
+    return pcmk_rc_ok;
+}
+
+PCMK__OUTPUT_ARGS("attribute", "char *", "char *", "char *")
+static int
+attribute_xml(pcmk__output_t *out, va_list args)
+{
+    char *type = va_arg(args, char *);
+    char *attr_id = va_arg(args, char *);
+    char *attr_name = va_arg(args, char *);
+    char *read_value = va_arg(args, char *);
+
+    xmlNodePtr node = NULL;
+
+    node = pcmk__output_create_xml_node(out, "attribute", NULL);
+
+    if (type) {
+        crm_xml_add(node, "scope", type);
+    }
+
+    if (attr_id) {
+        crm_xml_add(node, "id", attr_id);
+    }
+
+    if (attr_name) {
+        crm_xml_add(node, "name", attr_name);
+    }
+
+    if (read_value) {
+        crm_xml_add(node, "value", read_value);
+    }
+
+    return pcmk_rc_ok;
+}
+
 static pcmk__message_entry_t fmt_functions[] = {
+    { "attribute", "default", attribute_default },
+    { "attribute", "xml", attribute_xml },
     { "cluster-status", "default", pcmk__cluster_status_text },
     { "cluster-status", "html", cluster_status_html },
     { "cluster-status", "xml", cluster_status_xml },

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1801,17 +1801,17 @@ attribute_default(pcmk__output_t *out, va_list args)
 
     GString *s = g_string_sized_new(50);
 
-    if (scope) {
+    if (!pcmk__str_empty(scope)) {
         g_string_append_printf(s, "scope=\"%s\" ", scope);
     }
 
-    if (instance) {
+    if (!pcmk__str_empty(instance)) {
         g_string_append_printf(s, "id=\"%s\" ", instance);
     }
 
     g_string_append_printf(s, "name=\"%s\" ", name);
 
-    if (host) {
+    if (!pcmk__str_empty(host)) {
         g_string_append_printf(s, "host=\"%s\" ", host);
     }
 
@@ -1840,15 +1840,15 @@ attribute_xml(pcmk__output_t *out, va_list args)
                                         "value", value ? value : "",
                                         NULL);
 
-    if (scope) {
+    if (!pcmk__str_empty(scope)) {
         crm_xml_add(node, "scope", scope);
     }
 
-    if (instance) {
+    if (!pcmk__str_empty(instance)) {
         crm_xml_add(node, "id", instance);
     }
 
-    if (host) {
+    if (!pcmk__str_empty(host)) {
         crm_xml_add(node, "host", host);
     }
 

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1793,19 +1793,19 @@ PCMK__OUTPUT_ARGS("attribute", "char *", "char *", "char *")
 static int
 attribute_default(pcmk__output_t *out, va_list args)
 {
-    char *type = va_arg(args, char *);
-    char *attr_id = va_arg(args, char *);
-    char *attr_name = va_arg(args, char *);
-    char *read_value = va_arg(args, char *);
+    char *scope = va_arg(args, char *);
+    char *instance = va_arg(args, char *);
+    char *name = va_arg(args, char *);
+    char *value = va_arg(args, char *);
 
     if (out->quiet) {
-        pcmk__formatted_printf(out, "%s\n", read_value);
+        pcmk__formatted_printf(out, "%s\n", value);
     } else {
         out->info(out, "%s%s %s%s %s%s value=%s",
-                  type ? "scope=" : "", type ? type : "",
-                  attr_id ? "id=" : "", attr_id ? attr_id : "",
-                  attr_name ? "name=" : "", attr_name ? attr_name : "",
-                  read_value ? read_value : "(null)");
+                  scope ? "scope=" : "", scope ? scope : "",
+                  instance ? "id=" : "", instance ? instance : "",
+                  name ? "name=" : "", name ? name : "",
+                  value ? value : "(null)");
     }
 
     return pcmk_rc_ok;
@@ -1815,29 +1815,29 @@ PCMK__OUTPUT_ARGS("attribute", "char *", "char *", "char *")
 static int
 attribute_xml(pcmk__output_t *out, va_list args)
 {
-    char *type = va_arg(args, char *);
-    char *attr_id = va_arg(args, char *);
-    char *attr_name = va_arg(args, char *);
-    char *read_value = va_arg(args, char *);
+    char *scope = va_arg(args, char *);
+    char *instance = va_arg(args, char *);
+    char *name = va_arg(args, char *);
+    char *value = va_arg(args, char *);
 
     xmlNodePtr node = NULL;
 
     node = pcmk__output_create_xml_node(out, "attribute", NULL);
 
-    if (type) {
-        crm_xml_add(node, "scope", type);
+    if (scope) {
+        crm_xml_add(node, "scope", scope);
     }
 
-    if (attr_id) {
-        crm_xml_add(node, "id", attr_id);
+    if (instance) {
+        crm_xml_add(node, "id", instance);
     }
 
-    if (attr_name) {
-        crm_xml_add(node, "name", attr_name);
+    if (name) {
+        crm_xml_add(node, "name", name);
     }
 
-    if (read_value) {
-        crm_xml_add(node, "value", read_value);
+    if (value) {
+        crm_xml_add(node, "value", value);
     }
 
     return pcmk_rc_ok;

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1789,7 +1789,7 @@ cluster_status_html(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("attribute", "char *", "char *", "char *")
+PCMK__OUTPUT_ARGS("attribute", "char *", "char *", "char *", "char *")
 static int
 attribute_default(pcmk__output_t *out, va_list args)
 {
@@ -1797,21 +1797,33 @@ attribute_default(pcmk__output_t *out, va_list args)
     char *instance = va_arg(args, char *);
     char *name = va_arg(args, char *);
     char *value = va_arg(args, char *);
+    char *host = va_arg(args, char *);
 
-    if (out->quiet) {
-        pcmk__formatted_printf(out, "%s\n", value);
-    } else {
-        out->info(out, "%s%s %s%s %s%s value=%s",
-                  scope ? "scope=" : "", scope ? scope : "",
-                  instance ? "id=" : "", instance ? instance : "",
-                  name ? "name=" : "", name ? name : "",
-                  value ? value : "(null)");
+    GString *s = g_string_sized_new(50);
+
+    if (scope) {
+        g_string_append_printf(s, "scope=\"%s\" ", scope);
     }
+
+    if (instance) {
+        g_string_append_printf(s, "id=\"%s\" ", instance);
+    }
+
+    g_string_append_printf(s, "name=\"%s\" ", name);
+
+    if (host) {
+        g_string_append_printf(s, "host=\"%s\" ", host);
+    }
+
+    g_string_append_printf(s, "value=\"%s\"", value ? value : "");
+
+    out->info(out, "%s", s->str);
+    g_string_free(s, TRUE);
 
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("attribute", "char *", "char *", "char *")
+PCMK__OUTPUT_ARGS("attribute", "char *", "char *", "char *", "char *")
 static int
 attribute_xml(pcmk__output_t *out, va_list args)
 {
@@ -1819,10 +1831,14 @@ attribute_xml(pcmk__output_t *out, va_list args)
     char *instance = va_arg(args, char *);
     char *name = va_arg(args, char *);
     char *value = va_arg(args, char *);
+    char *host = va_arg(args, char *);
 
     xmlNodePtr node = NULL;
 
-    node = pcmk__output_create_xml_node(out, "attribute", NULL);
+    node = pcmk__output_create_xml_node(out, "attribute",
+                                        "name", name,
+                                        "value", value ? value : "",
+                                        NULL);
 
     if (scope) {
         crm_xml_add(node, "scope", scope);
@@ -1832,12 +1848,8 @@ attribute_xml(pcmk__output_t *out, va_list args)
         crm_xml_add(node, "id", instance);
     }
 
-    if (name) {
-        crm_xml_add(node, "name", name);
-    }
-
-    if (value) {
-        crm_xml_add(node, "value", value);
+    if (host) {
+        crm_xml_add(node, "host", host);
     }
 
     return pcmk_rc_ok;

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -144,7 +144,8 @@ iso8601_SOURCES		= iso8601.c
 iso8601_LDADD		= $(top_builddir)/lib/common/libcrmcommon.la
 
 attrd_updater_SOURCES	= attrd_updater.c
-attrd_updater_LDADD	= $(top_builddir)/lib/common/libcrmcommon.la
+attrd_updater_LDADD	= $(top_builddir)/lib/pacemaker/libpacemaker.la	\
+			  $(top_builddir)/lib/common/libcrmcommon.la
 
 crm_ticket_SOURCES	= crm_ticket.c
 crm_ticket_LDADD	= $(top_builddir)/lib/pengine/libpe_rules.la	\

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -117,6 +117,7 @@ crm_verify_LDADD	= $(top_builddir)/lib/pengine/libpe_status.la 	\
 
 crm_attribute_SOURCES	= crm_attribute.c
 crm_attribute_LDADD	= $(top_builddir)/lib/cluster/libcrmcluster.la	\
+			  $(top_builddir)/lib/pacemaker/libpacemaker.la	\
 			  $(top_builddir)/lib/cib/libcib.la		\
 			  $(top_builddir)/lib/common/libcrmcommon.la
 

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -20,12 +20,20 @@
 #include <crm/crm.h>
 #include <crm/msg_xml.h>
 #include <crm/common/cmdline_internal.h>
+#include <crm/common/output_internal.h>
 #include <crm/common/xml_internal.h>
 #include <crm/common/ipc.h>
 
 #include <crm/common/attrd_internal.h>
 
 #define SUMMARY "query and update Pacemaker node attributes"
+
+static pcmk__supported_format_t formats[] = {
+    PCMK__SUPPORTED_FORMAT_NONE,
+    PCMK__SUPPORTED_FORMAT_TEXT,
+    PCMK__SUPPORTED_FORMAT_XML,
+    { NULL, NULL, NULL }
+};
 
 GError *error = NULL;
 
@@ -167,10 +175,10 @@ static int do_update(char command, const char *attr_node, const char *attr_name,
                      const char *attr_set, const char *attr_dampen, int attr_options);
 
 static GOptionContext *
-build_arg_context(pcmk__common_args_t *args) {
+build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
 
-    context = pcmk__build_arg_context(args, NULL, NULL, NULL);
+    context = pcmk__build_arg_context(args, "text (default), xml", group, NULL);
 
     pcmk__add_arg_group(context, "required", "Required Arguments:",
                         "Show required arguments", required_entries);
@@ -187,12 +195,17 @@ build_arg_context(pcmk__common_args_t *args) {
 int
 main(int argc, char **argv)
 {
+    int rc = pcmk_rc_ok;
     crm_exit_t exit_code = CRM_EX_OK;
 
+    pcmk__output_t *out = NULL;
+
+    GOptionGroup *output_group = NULL;
     pcmk__common_args_t *args = pcmk__new_common_args(SUMMARY);
-    GOptionContext *context = build_arg_context(args);
+    GOptionContext *context = build_arg_context(args, &output_group);
     gchar **processed_args = pcmk__cmdline_preproc(argv, "dlnsvBNUS");
 
+    pcmk__register_formats(output_group, formats);
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
         exit_code = CRM_EX_USAGE;
         goto done;
@@ -200,9 +213,17 @@ main(int argc, char **argv)
 
     pcmk__cli_init_logging("attrd_updater", args->verbosity);
 
+    rc = pcmk__output_new(&out, args->output_ty, args->output_dest, argv);
+    if (rc != pcmk_rc_ok) {
+        exit_code = CRM_EX_ERROR;
+        g_set_error(&error, PCMK__EXITC_ERROR, exit_code, "Error creating output format %s: %s",
+                    args->output_ty, pcmk_rc_str(rc));
+        goto done;
+    }
+
     if (args->version) {
-        /* FIXME:  When attrd_updater is converted to use formatted output, this can go. */
-        pcmk__cli_help('v', CRM_EX_OK);
+        out->version(out, false);
+        goto done;
     }
 
     if (options.command != 'R' && options.attr_name == NULL) {
@@ -239,7 +260,12 @@ done:
     g_free(options.attr_set);
     free(options.attr_value);
 
-    pcmk__output_and_clear_error(error, NULL);
+    pcmk__output_and_clear_error(error, out);
+
+    if (out != NULL) {
+        out->finish(out, exit_code, true, NULL);
+        pcmk__output_free(out);
+    }
 
     crm_exit(exit_code);
 }

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -35,76 +35,17 @@
 #include <crm/common/output_internal.h>
 #include <sys/utsname.h>
 
+#include <pcmki/pcmki_output.h>
+
 #define SUMMARY "crm_attribute - query and update Pacemaker cluster options and node attributes"
 
 crm_exit_t exit_code = CRM_EX_OK;
 uint64_t cib_opts = cib_sync_call;
 
-PCMK__OUTPUT_ARGS("attribute", "char *", "char *", "char *")
-static int
-attribute_default(pcmk__output_t *out, va_list args)
-{
-    char *type = va_arg(args, char *);
-    char *attr_id = va_arg(args, char *);
-    char *attr_name = va_arg(args, char *);
-    char *read_value = va_arg(args, char *);
-
-    if (out->quiet) {
-        pcmk__formatted_printf(out, "%s\n", read_value);
-    } else {
-        out->info(out, "%s%s %s%s %s%s value=%s",
-                  type ? "scope=" : "", type ? type : "",
-                  attr_id ? "id=" : "", attr_id ? attr_id : "",
-                  attr_name ? "name=" : "", attr_name ? attr_name : "",
-                  read_value ? read_value : "(null)");
-    }
-
-    return pcmk_rc_ok;
-}
-
-PCMK__OUTPUT_ARGS("attribute", "char *", "char *", "char *")
-static int
-attribute_xml(pcmk__output_t *out, va_list args)
-{
-    char *type = va_arg(args, char *);
-    char *attr_id = va_arg(args, char *);
-    char *attr_name = va_arg(args, char *);
-    char *read_value = va_arg(args, char *);
-
-    xmlNodePtr node = NULL;
-
-    node = pcmk__output_create_xml_node(out, "attribute", NULL);
-
-    if (type) {
-        crm_xml_add(node, "scope", type);
-    }
-
-    if (attr_id) {
-        crm_xml_add(node, "id", attr_id);
-    }
-
-    if (attr_name) {
-        crm_xml_add(node, "name", attr_name);
-    }
-
-    if (read_value) {
-        crm_xml_add(node, "value", read_value);
-    }
-
-    return pcmk_rc_ok;
-}
-
 static pcmk__supported_format_t formats[] = {
     PCMK__SUPPORTED_FORMAT_NONE,
     PCMK__SUPPORTED_FORMAT_TEXT,
     PCMK__SUPPORTED_FORMAT_XML,
-    { NULL, NULL, NULL }
-};
-
-static pcmk__message_entry_t fmt_functions[] = {
-    { "attribute", "default", attribute_default },
-    { "attribute", "xml", attribute_xml },
-
     { NULL, NULL, NULL }
 };
 
@@ -395,7 +336,7 @@ main(int argc, char **argv)
         goto done;
     }
 
-    pcmk__register_messages(out, fmt_functions);
+    pcmk__register_lib_messages(out);
 
     if (args->version) {
         out->version(out, false);

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -42,10 +42,39 @@
 crm_exit_t exit_code = CRM_EX_OK;
 uint64_t cib_opts = cib_sync_call;
 
+PCMK__OUTPUT_ARGS("attribute", "char *", "char *", "char *", "char *")
+static int
+attribute_text(pcmk__output_t *out, va_list args)
+{
+    char *scope = va_arg(args, char *);
+    char *instance = va_arg(args, char *);
+    char *name = va_arg(args, char *);
+    char *value = va_arg(args, char *);
+    char *host G_GNUC_UNUSED = va_arg(args, char *);
+
+    if (out->quiet) {
+        pcmk__formatted_printf(out, "%s\n", value);
+    } else {
+        out->info(out, "%s%s %s%s %s%s value=%s",
+                  scope ? "scope=" : "", scope ? scope : "",
+                  instance ? "id=" : "", instance ? instance : "",
+                  name ? "name=" : "", name ? name : "",
+                  value ? value : "(null)");
+    }
+
+    return pcmk_rc_ok;
+}
+
 static pcmk__supported_format_t formats[] = {
     PCMK__SUPPORTED_FORMAT_NONE,
     PCMK__SUPPORTED_FORMAT_TEXT,
     PCMK__SUPPORTED_FORMAT_XML,
+    { NULL, NULL, NULL }
+};
+
+static pcmk__message_entry_t fmt_functions[] = {
+    { "attribute", "text", attribute_text },
+
     { NULL, NULL, NULL }
 };
 
@@ -337,6 +366,7 @@ main(int argc, char **argv)
     }
 
     pcmk__register_lib_messages(out);
+    pcmk__register_messages(out, fmt_functions);
 
     if (args->version) {
         out->version(out, false);

--- a/xml/api/crm_attribute-2.18.rng
+++ b/xml/api/crm_attribute-2.18.rng
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crm_attribute"/>
+    </start>
+
+    <define name="element-crm_attribute">
+        <choice>
+            <ref name="element-attribute" />
+        </choice>
+    </define>
+
+    <define name="element-attribute">
+        <element name="attribute">
+            <optional>
+                <attribute name="scope"> <text /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="id"> <text /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="name"> <text /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="value"> <text /> </attribute>
+            </optional>
+        </element>
+    </define>
+</grammar>

--- a/xml/api/crm_attribute-2.18.rng
+++ b/xml/api/crm_attribute-2.18.rng
@@ -8,7 +8,9 @@
 
     <define name="element-crm_attribute">
         <choice>
-            <ref name="element-attribute" />
+            <zeroOrMore>
+                <ref name="element-attribute" />
+            </zeroOrMore>
         </choice>
     </define>
 
@@ -20,11 +22,10 @@
             <optional>
                 <attribute name="id"> <text /> </attribute>
             </optional>
+            <attribute name="name"> <text /> </attribute>
+            <attribute name="value"> <text /> </attribute>
             <optional>
-                <attribute name="name"> <text /> </attribute>
-            </optional>
-            <optional>
-                <attribute name="value"> <text /> </attribute>
+                <attribute name="host"> <text /> </attribute>
             </optional>
         </element>
     </define>


### PR DESCRIPTION
This also condenses the number of places where we have an attribute output message a little bit.  attrd_updater and crm_attribute use the same XML message.  crm_attribute uses its own text message because it has a special output format.  The intention is that the attrd_updater text message will become the single version in the future.

Also, perhaps it's worth making a new schema file specifically for the attribute element since it exists identically in two places.  Only the wrappings are different (see attrd_updater schema vs. crm_attribute schema).