### PR TITLE
Low: fenced: Correctly log the total fencing timeout.

### DIFF
--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1689,14 +1689,12 @@ request_peer_fencing(remote_fencing_op_t *op, peer_device_info_t *peer)
     }
 
     if (!op->op_timer_total) {
-        int total_timeout = get_op_total_timeout(op, peer);
-
-        op->total_timeout = TIMEOUT_MULTIPLY_FACTOR * total_timeout;
+        op->total_timeout = TIMEOUT_MULTIPLY_FACTOR * get_op_total_timeout(op, peer);
         op->op_timer_total = g_timeout_add(1000 * op->total_timeout, remote_op_timeout, op);
         report_timeout_period(op, op->total_timeout);
         crm_info("Total timeout set to %d for peer's fencing targeting %s for %s"
                  CRM_XS "id=%.8s",
-                 total_timeout, op->target, op->client_name, op->id);
+                 op->total_timeout, op->target, op->client_name, op->id);
     }
 
     if (pcmk_is_set(op->call_options, st_opt_topology) && op->devices) {


### PR DESCRIPTION
Hi All,

Actually, a longer timeout is used than the timeout output in the next log.

```
Apr 25 12:41:59.270 rh85-dev03 pacemaker-fenced    [55863] (request_peer_fencing)       info: Total timeout set to 60 for peer's fencing targeting rh85-dev01 for pacemaker-controld.55867|id=8930a249
```

The correct timeout should be logged to avoid confusion when tracking the log.
```
Apr 25 12:52:07.542 rh85-dev02 pacemaker-fenced    [131676] (request_peer_fencing)      info: Total timeout set to 72 for peer's fencing targeting rh85-dev01 for pacemaker-controld.131680|id=722d4435
```

Best Regards,
Hideo Yamauchi.
