### PR TITLE
remote: Shutdown if tls goes down while waiting for shutdown all-clear

### DIFF
--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -56,7 +56,7 @@ typedef struct lrmd_rsc_s {
 #  ifdef HAVE_GNUTLS_GNUTLS_H
 // in remoted_tls.c
 int lrmd_init_remote_tls_server(void);
-void lrmd_tls_server_destroy(void);
+void execd_stop_tls_server(void);
 #  endif
 
 int lrmd_server_send_reply(pcmk__client_t *client, uint32_t id, xmlNode *reply);
@@ -105,5 +105,6 @@ void remoted_spawn_pidone(int argc, char **argv, char **envp);
 int process_lrmd_alert_exec(pcmk__client_t *client, uint32_t id,
                             xmlNode *request);
 void lrmd_drain_alerts(GMainLoop *mloop);
+void execd_exit_if_shutting_down(void);
 
 #endif // PACEMAKER_EXECD__H


### PR DESCRIPTION
[CC: I might have missed something important here, but it was in the "easy" pile of jobs on Phabricator]

When pacemaker-remoted wants to exit, it informs its connection host (if connected),
receives an ack, then waits for an all-clear message before exiting.

If the remote connection drops after sending the shutdown request and
receiving the ack, pacemaker-remoted will continue waiting for the
all-clear even though it can never arrive.

We now exit immediately with an exit status in that case.

fixes: T361