### PR TITLE
Low: tools: Set options.command when "attrd_updater -Y" is used.

### DIFF
--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -68,6 +68,8 @@ command_cb (const gchar *option_name, const gchar *optarg, gpointer data, GError
         options.command = 'R';
     } else if (pcmk__str_any_of(option_name, "--update", "-U", "-v", NULL)) {
         options.command = 'U';
+    } else if (pcmk__str_any_of(option_name, "--update-delay", "-Y", NULL)) {
+        options.command = 'Y';
     }
 
     return TRUE;


### PR DESCRIPTION
This corrects a bug introduced with
ef0e8a5f63ca0ded566de7edc3ac81f2b56003d5.