### PR TITLE
Fix: fencer: get target-by-attribute working again

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1545,7 +1545,7 @@ unpack_level_kind(xmlNode *level)
     }
     if (!stand_alone /* if standalone, there's no attribute manager */
         && (crm_element_value(level, XML_ATTR_STONITH_TARGET_ATTRIBUTE) != NULL)
-        && (crm_element_value(level, XML_ATTR_STONITH_TARGET_VALUE) == NULL)) {
+        && (crm_element_value(level, XML_ATTR_STONITH_TARGET_VALUE) != NULL)) {
         return fenced_target_by_attribute;
     }
     return fenced_target_by_unknown;


### PR DESCRIPTION
Regression in 2.1.3 introduced by b09f16eb1

This was papered over by the separate regression in cts-lab introduced by 4a6d1879, which caused target-by-attribute to no longer be tested, and which was recently fixed by caf9a3bc.