### PR TITLE
Release 2.1.4-rc1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+* Fri Jun 03 2022 Ken Gaillot <kgaillot@redhat.com> Pacemaker-2.1.4-rc1
+- Changesets: 11
+- Diff: 8 files changed, 31 insertions(+), 11 deletions(-)
+
+- Fixes since Pacemaker-2.1.3
+  + fencing: get target-by-attribute working again (regression in 2.1.3)
+  + fencing: avoid use-after-free when processing self-fencing requests
+             with topology (regression in 2.1.3)
+  + fencing: avoid memory leaks when processing topology requests
+  + fencing: delegate shouldn't matter when checking equivalent fencing
+  + tools: fix CSS syntax error in crm_mon --output-as=html
+
 * Wed Jun 1 2022 Ken Gaillot <kgaillot@redhat.com> Pacemaker-2.1.3
 - Changesets: 814
 - Diff: 332 files changed, 23435 insertions(+), 12137 deletions(-)

--- a/cts/lab/CIB.py
+++ b/cts/lab/CIB.py
@@ -127,7 +127,7 @@ class CIB12(ConfigBase):
         (rc, output) = self.Factory.rsh(self.Factory.target,
             r"""awk -v RS="}" """
             r"""'/^(\s*nodelist\s*{)?\s*node\s*{.*(ring0_addr|name):\s*%s(\s+|$)/"""
-            r"""{gsub(/.*nodeid:\s*/,"");gsub(/\s+.*$/,"");print}'%s"""
+            r"""{gsub(/.*nodeid:\s*/,"");gsub(/\s+.*$/,"");print}' %s"""
             % (node_name, CTSvars.COROSYNC_CONF), None)
 
         if rc == 0 and len(output) == 1:

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1669,6 +1669,7 @@ fenced_register_level(xmlNode *msg, char **desc, pcmk__action_result_t *result)
         if (tp == NULL) {
             pcmk__set_result(result, CRM_EX_ERROR, PCMK_EXEC_ERROR,
                              strerror(ENOMEM));
+            free(target);
             return;
         }
         tp->kind = mode;
@@ -3326,6 +3327,7 @@ handle_level_delete_request(pcmk__request_t *request)
                          "Unprivileged users must delete level via CIB");
     }
     fenced_send_level_notification(op, &request->result, device_id);
+    free(device_id);
     return fenced_construct_reply(request->xml, NULL, &request->result);
 }
 

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1549,7 +1549,7 @@ unpack_level_kind(xmlNode *level)
     }
     if (!stand_alone /* if standalone, there's no attribute manager */
         && (crm_element_value(level, XML_ATTR_STONITH_TARGET_ATTRIBUTE) != NULL)
-        && (crm_element_value(level, XML_ATTR_STONITH_TARGET_VALUE) == NULL)) {
+        && (crm_element_value(level, XML_ATTR_STONITH_TARGET_VALUE) != NULL)) {
         return fenced_target_by_attribute;
     }
     return fenced_target_by_unknown;

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -3498,7 +3498,7 @@ stonith_command(pcmk__client_t *client, uint32_t id, uint32_t flags,
             .result         = PCMK__UNKNOWN_RESULT,
         };
 
-        request.op = crm_element_value(request.xml, F_STONITH_OPERATION);
+        request.op = crm_element_value_copy(request.xml, F_STONITH_OPERATION);
         CRM_CHECK(request.op != NULL, return);
 
         if (pcmk_is_set(request.call_options, st_opt_sync_call)) {
@@ -3506,6 +3506,6 @@ stonith_command(pcmk__client_t *client, uint32_t id, uint32_t flags,
         }
 
         handle_request(&request);
-        pcmk__reset_result(&request.result);
+        pcmk__reset_request(&request);
     }
 }

--- a/include/crm/common/messages_internal.h
+++ b/include/crm/common/messages_internal.h
@@ -50,11 +50,14 @@ typedef struct {
      * generically, but each daemon uses a different XML attribute for it,
      * so the daemon is responsible for populating this field.
      *
+     * This must be a copy of the XML field, and not just a pointer into xml,
+     * because handlers might modify the original XML.
+     *
      * @TODO Create a per-daemon struct with IPC handlers, IPC endpoints, etc.,
      * and the name of the XML attribute for IPC commands, then replace this
-     * with a convenience function to grab the command.
+     * with a convenience function to copy the command.
      */
-    const char *op;                 // IPC command from xml
+    char *op;                       // IPC command name
 } pcmk__request_t;
 
 #define pcmk__set_request_flags(request, flags_to_set) do {         \
@@ -72,6 +75,7 @@ typedef struct {
 const char *pcmk__message_name(const char *name);
 GHashTable *pcmk__register_handlers(pcmk__server_command_t handlers[]);
 xmlNode *pcmk__process_request(pcmk__request_t *request, GHashTable *handlers);
+void pcmk__reset_request(pcmk__request_t *request);
 
 /*!
  * \internal

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -31,7 +31,7 @@ SUBDIRS = . tests
 
 noinst_HEADERS		= crmcommon_private.h mock_private.h
 
-libcrmcommon_la_LDFLAGS	= -version-info 43:0:9
+libcrmcommon_la_LDFLAGS	= -version-info 43:1:9
 
 libcrmcommon_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 libcrmcommon_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)

--- a/lib/common/messages.c
+++ b/lib/common/messages.c
@@ -276,3 +276,18 @@ pcmk__process_request(pcmk__request_t *request, GHashTable *handlers)
 
     return (*handler)(request);
 }
+
+/*!
+ * \internal
+ * \brief Free memory used within a request (but not the request itself)
+ *
+ * \param[in] request  Request to reset
+ */
+void
+pcmk__reset_request(pcmk__request_t *request)
+{
+    free(request->op);
+    request->op = NULL;
+
+    pcmk__reset_result(&(request->result));
+}

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -33,7 +33,7 @@ static const char *stylesheet_default =
     ".rsc-multiple { color: orange }\n"
     ".rsc-ok { color: green }\n"
 
-    ".warning { color: red, font-weight: bold }";
+    ".warning { color: red; font-weight: bold }";
 
 static gboolean cgi_output = FALSE;
 static char *stylesheet_link = NULL;

--- a/lib/fencing/Makefile.am
+++ b/lib/fencing/Makefile.am
@@ -14,7 +14,7 @@ noinst_HEADERS		= fencing_private.h
 
 lib_LTLIBRARIES		= libstonithd.la
 
-libstonithd_la_LDFLAGS	= -version-info 34:0:8
+libstonithd_la_LDFLAGS	= -version-info 34:1:8
 
 libstonithd_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 libstonithd_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2203,8 +2203,7 @@ stonith__later_succeeded(stonith_history_t *event, stonith_history_t *top_histor
          if ((prev_hp->state == st_done) &&
             pcmk__str_eq(event->target, prev_hp->target, pcmk__str_casei) &&
             pcmk__str_eq(event->action, prev_hp->action, pcmk__str_casei) &&
-            pcmk__str_eq(event->delegate, prev_hp->delegate, pcmk__str_casei) &&
-            ((event->completed < prev_hp->completed) || 
+            ((event->completed < prev_hp->completed) ||
              ((event->completed == prev_hp->completed) && (event->completed_nsec < prev_hp->completed_nsec)))) {
             ret = TRUE;
             break;

--- a/m4/version.m4
+++ b/m4/version.m4
@@ -1,2 +1,2 @@
-m4_define([VERSION_NUMBER], [2.1.3])
+m4_define([VERSION_NUMBER], [2.1.4])
 m4_define([PCMK_URL], [https://ClusterLabs.org/pacemaker/])

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pacemaker 2\n"
 "Report-Msgid-Bugs-To: developers@clusterlabs.org\n"
-"POT-Creation-Date: 2022-04-08 10:34-0500\n"
+"POT-Creation-Date: 2022-06-03 09:28-0500\n"
 "PO-Revision-Date: 2021-11-08 11:04+0800\n"
 "Last-Translator: Vivi <developers@clusterlabs.org>\n"
 "Language-Team: CHINESE <wangluwei@uniontech.org>\n"
@@ -107,20 +107,20 @@ msgstr ""
 "如果日志中有针对集群守护程序PID的消息“Evicting client”，（则建议将值设为集群"
 "中的资源数量乘以节点数量）"
 
-#: lib/common/options.c:590
+#: lib/common/options.c:594
 msgid "  Allowed values: "
 msgstr ""
 
-#: lib/pengine/common.c:131
+#: lib/pengine/common.c:119
 msgid "Whether watchdog integration is enabled"
 msgstr "是否启用看门狗集成设置"
 
-#: tools/crm_resource.c:1388
+#: tools/crm_resource.c:1405
 #, fuzzy, c-format
 msgid "Metadata query for %s failed: %s"
 msgstr "，查询%s的元数据失败: %s\n"
 
-#: tools/crm_resource.c:1394
+#: tools/crm_resource.c:1411
 #, c-format
 msgid "'%s' is not a valid agent specification"
 msgstr "'%s' 是一个无效的代理"

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -299,7 +299,7 @@ start_mainloop(pcmk_ipc_api_t *capi)
     unsigned int count = pcmk_controld_api_replies_expected(capi);
 
     if (count > 0) {
-        out->info(out, "Waiting for %d %s from the controller",
+        out->info(out, "Waiting for %u %s from the controller",
                   count, pcmk__plural_alt(count, "reply", "replies"));
         exit_code = CRM_EX_DISCONNECT; // For unexpected disconnects
         mainloop = g_main_loop_new(NULL, FALSE);


### PR DESCRIPTION
The just-released 2.1.3 had two regressions, one that broke targeting fence devices by node attribute, and one that broke the CTS lab test for that feature, which is why it wasn't detected.

A handful of trivial other fixes from the main branch are also backported to form the basis of a 2.1.4-rc1 release.