### PR TITLE
Improve various input validation

### DIFF
--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -381,114 +381,12 @@ cib_process_replace_svr(const char *op, int options, const char *section, xmlNod
     return rc;
 }
 
-static int
-delete_cib_object(xmlNode * parent, xmlNode * delete_spec)
-{
-    const char *object_name = NULL;
-    const char *object_id = NULL;
-    xmlNode *equiv_node = NULL;
-    int result = pcmk_ok;
-
-    if (delete_spec != NULL) {
-        object_name = crm_element_name(delete_spec);
-    }
-    object_id = crm_element_value(delete_spec, XML_ATTR_ID);
-
-    crm_trace("Processing: <%s id='%s'>",
-              pcmk__s(object_name, "<null>"), pcmk__s(object_id, "<null>"));
-
-    if (delete_spec == NULL) {
-        result = -EINVAL;
-
-    } else if (parent == NULL) {
-        result = -EINVAL;
-
-    } else if (object_id == NULL) {
-        /*  placeholder object */
-        equiv_node = find_xml_node(parent, object_name, FALSE);
-
-    } else {
-        equiv_node = pcmk__xe_match(parent, object_name, XML_ATTR_ID,
-                                    object_id);
-    }
-
-    if (result != pcmk_ok) {
-        ;                       /* nothing */
-
-    } else if (equiv_node == NULL) {
-        result = pcmk_ok;
-
-    } else if (xml_has_children(delete_spec) == FALSE) {
-        /*  only leaves are deleted */
-        crm_debug("Removing leaf: <%s id='%s'>",
-                  pcmk__s(object_name, "<null>"), pcmk__s(object_id, "<null>"));
-        free_xml(equiv_node);
-        equiv_node = NULL;
-
-    } else {
-        xmlNode *child = NULL;
-
-        for (child = pcmk__xml_first_child(delete_spec); child != NULL;
-             child = pcmk__xml_next(child)) {
-            int tmp_result = delete_cib_object(equiv_node, child);
-
-            /*  only the first error is likely to be interesting */
-            if (tmp_result != pcmk_ok && result == pcmk_ok) {
-                result = tmp_result;
-            }
-        }
-    }
-
-    return result;
-}
-
 int
 cib_process_delete_absolute(const char *op, int options, const char *section, xmlNode * req,
                             xmlNode * input, xmlNode * existing_cib, xmlNode ** result_cib,
                             xmlNode ** answer)
 {
-    xmlNode *failed = NULL;
-    int result = pcmk_ok;
-    xmlNode *update_section = NULL;
-
-    crm_trace("Processing '%s' event for section '%s'",
-              op, pcmk__s(section, "<null>"));
-    if (pcmk__str_eq(XML_CIB_TAG_SECTION_ALL, section, pcmk__str_casei)) {
-        section = NULL;
-
-    } else if (pcmk__str_eq(XML_TAG_CIB, section, pcmk__str_casei)) {
-        section = NULL;
-
-    } else if (pcmk__str_eq(crm_element_name(input), XML_TAG_CIB, pcmk__str_casei)) {
-        section = NULL;
-    }
-
-    CRM_CHECK(strcasecmp(CIB_OP_DELETE, op) == 0, return -EINVAL);
-
-    if (input == NULL) {
-        crm_err("Cannot perform modification with no data");
-        return -EINVAL;
-    }
-
-    failed = create_xml_node(NULL, XML_TAG_FAILED);
-
-    update_section = pcmk_find_cib_element(*result_cib, section);
-    result = delete_cib_object(update_section, input);
-    update_results(failed, input, op, result);
-
-    if ((result == pcmk_ok) && xml_has_children(failed)) {
-        result = -EINVAL;
-    }
-
-    if (result != pcmk_ok) {
-        crm_log_xml_err(failed, "CIB Update failures");
-        *answer = failed;
-
-    } else {
-        free_xml(failed);
-    }
-
-    return result;
+    return -EINVAL;
 }
 
 int

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -1199,9 +1199,11 @@ handle_shutdown_request(xmlNode * stored_msg)
 static void
 send_msg_via_ipc(xmlNode * msg, const char *sys)
 {
-    pcmk__client_t *client_channel = pcmk__find_client_by_id(sys);
+    pcmk__client_t *client_channel = NULL;
 
     CRM_CHECK(sys != NULL, return);
+
+    client_channel = pcmk__find_client_by_id(sys);
 
     if (crm_element_value(msg, F_CRM_HOST_FROM) == NULL) {
         crm_xml_add(msg, F_CRM_HOST_FROM, fsa_our_uname);

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -348,18 +348,17 @@ relay_message(xmlNode * msg, gboolean originated_locally)
         return TRUE;
 
     } else if (pcmk__str_eq(task, CRM_OP_HELLO, pcmk__str_casei)) {
-        /* quietly ignore */
         crm_trace("No routing needed for hello message %s", ref);
         return TRUE;
 
     } else if (!pcmk__str_eq(type, T_CRM, pcmk__str_casei)) {
-        crm_warn("Cannot route message %s: Type is '%s' not '" T_CRM "'",
-                 ref, (type? type : "missing"));
+        crm_warn("Received invalid message %s: type '%s' not '" T_CRM "'",
+                 ref, pcmk__s(type, ""));
         crm_log_xml_warn(msg, "[bad message type]");
         return TRUE;
 
     } else if (sys_to == NULL) {
-        crm_warn("Cannot route message %s: No subsystem specified", ref);
+        crm_warn("Received invalid message %s: no subsystem", ref);
         crm_log_xml_warn(msg, "[no subsystem]");
         return TRUE;
     }
@@ -1202,6 +1201,8 @@ send_msg_via_ipc(xmlNode * msg, const char *sys)
 {
     pcmk__client_t *client_channel = pcmk__find_client_by_id(sys);
 
+    CRM_CHECK(sys != NULL, return);
+
     if (crm_element_value(msg, F_CRM_HOST_FROM) == NULL) {
         crm_xml_add(msg, F_CRM_HOST_FROM, fsa_our_uname);
     }
@@ -1210,12 +1211,12 @@ send_msg_via_ipc(xmlNode * msg, const char *sys)
         /* Transient clients such as crmadmin */
         pcmk__ipc_send_xml(client_channel, 0, msg, crm_ipc_server_event);
 
-    } else if (sys != NULL && strcmp(sys, CRM_SYSTEM_TENGINE) == 0) {
+    } else if (pcmk__str_eq(sys, CRM_SYSTEM_TENGINE, pcmk__str_none)) {
         xmlNode *data = get_message_xml(msg, F_CRM_DATA);
 
         process_te_message(msg, data);
 
-    } else if (sys != NULL && strcmp(sys, CRM_SYSTEM_LRMD) == 0) {
+    } else if (pcmk__str_eq(sys, CRM_SYSTEM_LRMD, pcmk__str_none)) {
         fsa_data_t fsa_data;
         ha_msg_input_t fsa_input;
 
@@ -1232,12 +1233,11 @@ send_msg_via_ipc(xmlNode * msg, const char *sys)
 
         do_lrm_invoke(A_LRM_INVOKE, C_IPC_MESSAGE, fsa_state, I_MESSAGE, &fsa_data);
 
-    } else if (sys != NULL && crmd_is_proxy_session(sys)) {
+    } else if (crmd_is_proxy_session(sys)) {
         crmd_proxy_send(sys, msg);
 
     } else {
-        crm_debug("Ignoring message for unknown subsystem %s",
-                  pcmk__s(sys, "<null>"));
+        crm_info("Received invalid request: unknown subsystem '%s'", sys);
     }
 }
 

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -1197,9 +1197,6 @@ handle_shutdown_request(xmlNode * stored_msg)
     return I_NULL;
 }
 
-/* msg is deleted by the time this returns */
-extern gboolean process_te_message(xmlNode * msg, xmlNode * xml_data);
-
 static void
 send_msg_via_ipc(xmlNode * msg, const char *sys)
 {

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -563,60 +563,58 @@ te_update_diff(const char *event, xmlNode * msg)
     }
 }
 
-gboolean
+void
 process_te_message(xmlNode * msg, xmlNode * xml_data)
 {
-    const char *from = crm_element_value(msg, F_ORIG);
-    const char *sys_to = crm_element_value(msg, F_CRM_SYS_TO);
-    const char *sys_from = crm_element_value(msg, F_CRM_SYS_FROM);
-    const char *ref = crm_element_value(msg, F_CRM_REFERENCE);
-    const char *op = crm_element_value(msg, F_CRM_TASK);
-    const char *type = crm_element_value(msg, F_CRM_MSG_TYPE);
+    const char *value = NULL;
+    xmlXPathObject *xpathObj = NULL;
 
-    crm_trace("Processing %s (%s) message", op, ref);
-    crm_log_xml_trace(msg, "ipc");
+    CRM_CHECK(msg != NULL, return);
 
-    if (op == NULL) {
-        /* error */
-
-    } else if (sys_to == NULL || strcasecmp(sys_to, CRM_SYSTEM_TENGINE) != 0) {
-        crm_trace("Bad sys-to: %s", pcmk__s(sys_to, "missing"));
-        return FALSE;
-
-    } else if (pcmk__str_eq(op, CRM_OP_INVOKE_LRM, pcmk__str_casei)
-               && pcmk__str_eq(sys_from, CRM_SYSTEM_LRMD, pcmk__str_casei)
-/* 		  && pcmk__str_eq(type, XML_ATTR_RESPONSE, pcmk__str_casei) */
-        ) {
-        xmlXPathObject *xpathObj = NULL;
-
-        crm_log_xml_trace(msg, "Processing (N)ACK");
-        crm_debug("Processing (N)ACK %s from %s", crm_element_value(msg, F_CRM_REFERENCE), from);
-
-        xpathObj = xpath_search(xml_data, "//" XML_LRM_TAG_RSC_OP);
-        if (numXpathResults(xpathObj)) {
-            int lpc = 0, max = numXpathResults(xpathObj);
-
-            for (lpc = 0; lpc < max; lpc++) {
-                xmlNode *rsc_op = getXpathResult(xpathObj, lpc);
-                const char *node = get_node_id(rsc_op);
-
-                process_graph_event(rsc_op, node);
-            }
-            freeXpathObject(xpathObj);
-
-        } else {
-            crm_log_xml_err(msg, "Invalid (N)ACK");
-            freeXpathObject(xpathObj);
-            return FALSE;
-        }
-
-    } else {
-        crm_err("Unknown command: %s::%s from %s", type, op, sys_from);
+    // Transition requests must specify transition engine as subsystem
+    value = crm_element_value(msg, F_CRM_SYS_TO);
+    if (pcmk__str_empty(value)
+        || !pcmk__str_eq(value, CRM_SYSTEM_TENGINE, pcmk__str_none)) {
+        crm_info("Received invalid transition request: subsystem '%s' not '"
+                 CRM_SYSTEM_TENGINE "'", pcmk__s(value, ""));
+        return;
     }
 
-    crm_trace("finished processing message");
+    // Only the lrm_invoke command is supported as a transition request
+    value = crm_element_value(msg, F_CRM_TASK);
+    if (!pcmk__str_eq(value, CRM_OP_INVOKE_LRM, pcmk__str_none)) {
+        crm_info("Received invalid transition request: command '%s' not '"
+                 CRM_OP_INVOKE_LRM "'", pcmk__s(value, ""));
+        return;
+    }
 
-    return TRUE;
+    // Transition requests must be marked as coming from the executor
+    value = crm_element_value(msg, F_CRM_SYS_FROM);
+    if (!pcmk__str_eq(value, CRM_SYSTEM_LRMD, pcmk__str_none)) {
+        crm_info("Received invalid transition request: from '%s' not '"
+                 CRM_SYSTEM_LRMD "'", pcmk__s(value, ""));
+        return;
+    }
+
+    crm_debug("Processing transition request with ref='%s' origin='%s'",
+              pcmk__s(crm_element_value(msg, F_CRM_REFERENCE), ""),
+              pcmk__s(crm_element_value(msg, F_ORIG), ""));
+
+    xpathObj = xpath_search(xml_data, "//" XML_LRM_TAG_RSC_OP);
+    if (numXpathResults(xpathObj)) {
+        int lpc = 0, max = numXpathResults(xpathObj);
+
+        for (lpc = 0; lpc < max; lpc++) {
+            xmlNode *rsc_op = getXpathResult(xpathObj, lpc);
+            const char *node = get_node_id(rsc_op);
+
+            process_graph_event(rsc_op, node);
+        }
+        freeXpathObject(xpathObj);
+    } else {
+        crm_err("Received transition request with no results (bug?)");
+        freeXpathObject(xpathObj);
+    }
 }
 
 void

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -568,6 +568,7 @@ process_te_message(xmlNode * msg, xmlNode * xml_data)
 {
     const char *value = NULL;
     xmlXPathObject *xpathObj = NULL;
+    int nmatches = 0;
 
     CRM_CHECK(msg != NULL, return);
 
@@ -601,20 +602,18 @@ process_te_message(xmlNode * msg, xmlNode * xml_data)
               pcmk__s(crm_element_value(msg, F_ORIG), ""));
 
     xpathObj = xpath_search(xml_data, "//" XML_LRM_TAG_RSC_OP);
-    if (numXpathResults(xpathObj)) {
-        int lpc = 0, max = numXpathResults(xpathObj);
-
-        for (lpc = 0; lpc < max; lpc++) {
+    nmatches = numXpathResults(xpathObj);
+    if (nmatches == 0) {
+        crm_err("Received transition request with no results (bug?)");
+    } else {
+        for (int lpc = 0; lpc < nmatches; lpc++) {
             xmlNode *rsc_op = getXpathResult(xpathObj, lpc);
             const char *node = get_node_id(rsc_op);
 
             process_graph_event(rsc_op, node);
         }
-        freeXpathObject(xpathObj);
-    } else {
-        crm_err("Received transition request with no results (bug?)");
-        freeXpathObject(xpathObj);
     }
+    freeXpathObject(xpathObj);
 }
 
 void

--- a/daemons/controld/controld_transition.c
+++ b/daemons/controld/controld_transition.c
@@ -158,9 +158,11 @@ do_te_invoke(long long action,
             return;
         }
 
-        if (fsa_pe_ref == NULL || !pcmk__str_eq(fsa_pe_ref, ref, pcmk__str_casei)) {
-            crm_info("Transition is redundant: %s vs. %s",
-                     pcmk__s(fsa_pe_ref, "<null>"), pcmk__s(ref, "<null>"));
+        if ((fsa_pe_ref == NULL)
+            || !pcmk__str_eq(fsa_pe_ref, ref, pcmk__str_none)) {
+            crm_info("Transition is redundant: %s expected but %s received",
+                     pcmk__s(fsa_pe_ref, "no reference"),
+                     pcmk__s(ref, "no reference"));
             abort_transition(INFINITY, pcmk__graph_restart,
                              "Transition Redundant", NULL);
         }

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -27,8 +27,7 @@ pcmk__graph_action_t *controld_get_action(int id);
 gboolean stop_te_timer(pcmk__graph_action_t *action);
 const char *get_rsc_state(const char *task, enum pcmk_exec_status status);
 
-/* unpack */
-extern gboolean process_te_message(xmlNode * msg, xmlNode * xml_data);
+void process_te_message(xmlNode *msg, xmlNode *xml_data);
 
 extern pcmk__graph_t *transition_graph;
 extern crm_trigger_t *transition_trigger;

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -3388,14 +3388,11 @@ handle_cache_request(pcmk__request_t *request)
 static xmlNode *
 handle_unknown_request(pcmk__request_t *request)
 {
-    const char *op = crm_element_value(request->xml, F_STONITH_OPERATION);
-
     crm_err("Unknown IPC request %s from %s %s",
-            op, pcmk__request_origin_type(request),
+            request->op, pcmk__request_origin_type(request),
             pcmk__request_origin(request));
     pcmk__format_result(&request->result, CRM_EX_PROTOCOL, PCMK_EXEC_INVALID,
-                        "Unknown IPC request type '%s' (bug?)",
-                        pcmk__s(op, "<null>"));
+                        "Unknown IPC request type '%s' (bug?)", request->op);
     return fenced_construct_reply(request->xml, NULL, &request->result);
 }
 

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1662,7 +1662,7 @@ fenced_register_level(xmlNode *msg, char **desc, pcmk__action_result_t *result)
     stonith_key_value_t *dIter = NULL;
     stonith_key_value_t *devices = NULL;
 
-    CRM_CHECK(result != NULL, return);
+    CRM_CHECK((msg != NULL) && (result != NULL), return);
 
     level = unpack_level_request(msg, &mode, &target, &id, desc);
     if (level == NULL) {
@@ -1670,15 +1670,25 @@ fenced_register_level(xmlNode *msg, char **desc, pcmk__action_result_t *result)
         return;
     }
 
+    // Ensure an ID was given (even the client API adds an ID)
+    if (pcmk__str_empty(ID(level))) {
+        crm_warn("Ignoring registration for topology level without ID");
+        free(target);
+        crm_log_xml_trace(level, "Bad level");
+        pcmk__format_result(result, CRM_EX_INVALID_PARAM, PCMK_EXEC_INVALID,
+                            "Topology level is invalid without ID");
+        return;
+    }
+
     // Ensure a valid target was specified
     if (mode == fenced_target_by_unknown) {
         crm_warn("Ignoring registration for topology level '%s' "
-                 "without valid target", pcmk__s(ID(level), "<null>"));
+                 "without valid target", ID(level));
         free(target);
         crm_log_xml_trace(level, "Bad level");
         pcmk__format_result(result, CRM_EX_INVALID_PARAM, PCMK_EXEC_INVALID,
                             "Invalid target for topology level '%s'",
-                            pcmk__s(ID(level), "<null>"));
+                            ID(level));
         return;
     }
 
@@ -1692,8 +1702,8 @@ fenced_register_level(xmlNode *msg, char **desc, pcmk__action_result_t *result)
                             "Invalid level number '%s' for topology level '%s'",
                             pcmk__s(crm_element_value(level,
                                                       XML_ATTR_STONITH_INDEX),
-                                    "<null>"),
-                            pcmk__s(ID(level), "<null>"));
+                                    ""),
+                            ID(level));
         return;
     }
 
@@ -1780,11 +1790,13 @@ fenced_unregister_level(xmlNode *msg, char **desc,
         free(target);
         crm_log_xml_trace(level, "Bad level");
         pcmk__format_result(result, CRM_EX_INVALID_PARAM, PCMK_EXEC_INVALID,
-                            "Invalid level number '%s' for topology level '%s'",
+                            "Invalid level number '%s' for topology level %s",
                             pcmk__s(crm_element_value(level,
                                                       XML_ATTR_STONITH_INDEX),
                                     "<null>"),
-                            pcmk__s(ID(level), "<null>"));
+
+                            // Client API doesn't add ID to unregistration XML
+                            pcmk__s(ID(level), ""));
         return;
     }
 

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -3022,7 +3022,7 @@ is_privileged(pcmk__client_t *c, const char *op)
         return true;
     } else {
         crm_warn("Rejecting IPC request '%s' from unprivileged client %s",
-                 pcmk__s(op, "<null>"), pcmk__client_name(c));
+                 pcmk__s(op, ""), pcmk__client_name(c));
         return false;
     }
 }

--- a/daemons/pacemakerd/pcmkd_messages.c
+++ b/daemons/pacemakerd/pcmkd_messages.c
@@ -165,7 +165,12 @@ pcmk_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
     }
 
     task = crm_element_value(msg, F_CRM_TASK);
-    if (pcmk__str_eq(task, CRM_OP_QUIT, pcmk__str_none)) {
+    if (pcmk__str_empty(task)) {
+        crm_debug("IPC command from client %s is missing task",
+                  pcmk__client_name(c));
+        pcmk__ipc_send_ack(c, id, flags, "ack", NULL, CRM_EX_INVALID_PARAM);
+
+    } else if (pcmk__str_eq(task, CRM_OP_QUIT, pcmk__str_none)) {
         pcmk__ipc_send_ack(c, id, flags, "ack", NULL, CRM_EX_INDETERMINATE);
         pcmk_handle_shutdown_request(c, msg, id, flags);
 
@@ -180,7 +185,7 @@ pcmk_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
 
     } else {
         crm_debug("Unrecognized IPC command '%s' from client %s",
-                  pcmk__s(task, "(unspecified)"), pcmk__client_name(c));
+                  task, pcmk__client_name(c));
         pcmk__ipc_send_ack(c, id, flags, "ack", NULL, CRM_EX_INVALID_PARAM);
     }
 

--- a/daemons/pacemakerd/pcmkd_messages.c
+++ b/daemons/pacemakerd/pcmkd_messages.c
@@ -28,9 +28,9 @@ pcmk_handle_ping_request(pcmk__client_t *c, xmlNode *msg, uint32_t id)
     const char *from = crm_element_value(msg, F_CRM_SYS_FROM);
 
     /* Pinged for status */
-    crm_trace("Pinged from %s.%s",
-              pcmk__s(crm_element_value(msg, F_CRM_ORIGIN), "unknown"),
-              from?from:"unknown");
+    crm_trace("Pinged from " F_CRM_SYS_FROM "='%s' " F_CRM_ORIGIN "='%s'",
+              pcmk__s(from, ""),
+              pcmk__s(crm_element_value(msg, F_CRM_ORIGIN), ""));
     ping = create_xml_node(NULL, XML_CRM_TAG_PING);
     value = crm_element_value(msg, F_CRM_SYS_TO);
     crm_xml_add(ping, XML_PING_ATTR_SYSFROM, value);

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -197,8 +197,8 @@ process_pe_message(xmlNode *msg, xmlNode *xml_data, pcmk__client_t *sender)
 
     } else if (pcmk__str_empty(sys_to)
                || !pcmk__str_eq(sys_to, CRM_SYSTEM_PENGINE, pcmk__str_none)) {
-        crm_info("Ignoring invalid IPC message: to '%s' not " CRM_SYSTEM_PENGINE,
-                 pcmk__s(sys_to, ""));
+        crm_info("Ignoring invalid IPC message: to '%s' not "
+                 CRM_SYSTEM_PENGINE, pcmk__s(sys_to, ""));
 
     } else if (pcmk__str_eq(op, CRM_OP_PECALC, pcmk__str_none)) {
         handle_pecalc_op(msg, xml_data, sender);

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -113,8 +113,11 @@ typedef struct cib_api_operations_s {
     int (*remove) (cib_t *cib, const char *section, xmlNode *data,
                    int call_options);
     int (*erase) (cib_t *cib, xmlNode **output_data, int call_options);
+
+    //! \deprecated This method does nothing and should not be called
     int (*delete_absolute) (cib_t *cib, const char *section, xmlNode *data,
                             int call_options);
+
     int (*quit) (cib_t *cib, int call_options);
     int (*register_notification) (cib_t *cib, const char *callback,
                                   int enabled);

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -399,8 +399,9 @@ update_cib_object(xmlNode * parent, xmlNode * update)
     CRM_CHECK(object_name != NULL, return -EINVAL);
 
     object_id = ID(update);
-    crm_trace("Processing update for <%s%s%s>", object_name,
-              ((object_id == NULL)? "" : " id="), pcmk__s(object_id, ""));
+    crm_trace("Processing update for <%s%s%s%s>", object_name,
+              ((object_id == NULL)? "" : " id='"), pcmk__s(object_id, ""),
+              ((object_id == NULL)? "" : "'"));
 
     if (object_id == NULL) {
         /*  placeholder object */
@@ -414,8 +415,9 @@ update_cib_object(xmlNode * parent, xmlNode * update)
         target = create_xml_node(parent, object_name);
     }
 
-    crm_trace("Found node <%s%s%s> to update", object_name,
-              ((object_id == NULL)? "" : " id="), pcmk__s(object_id, ""));
+    crm_trace("Found node <%s%s%s%s> to update", object_name,
+              ((object_id == NULL)? "" : " id='"), pcmk__s(object_id, ""),
+              ((object_id == NULL)? "" : "'"));
 
     replace = crm_element_value(update, XML_CIB_ATTR_REPLACE);
     if (replace != NULL) {
@@ -453,22 +455,27 @@ update_cib_object(xmlNode * parent, xmlNode * update)
 
     copy_in_properties(target, update);
 
-    crm_trace("Processing children of <%s%s%s>", object_name,
-              ((object_id == NULL)? "" : " id="), pcmk__s(object_id, ""));
+    crm_trace("Processing children of <%s%s%s%s>", object_name,
+              ((object_id == NULL)? "" : " id='"), pcmk__s(object_id, ""),
+              ((object_id == NULL)? "" : "'"));
 
     for (a_child = pcmk__xml_first_child(update); a_child != NULL;
          a_child = pcmk__xml_next(a_child)) {
         int tmp_result = 0;
 
-        crm_trace("Updating child <%s%s%s>", crm_element_name(a_child),
-                  ((ID(a_child) == NULL)? "" : " id="),
-                  pcmk__s(ID(a_child), ""));
+        crm_trace("Updating child <%s%s%s%s>", crm_element_name(a_child),
+                  ((ID(a_child) == NULL)? "" : " id='"),
+                  pcmk__s(ID(a_child), ""), ((ID(a_child) == NULL)? "" : "'"));
 
         tmp_result = update_cib_object(target, a_child);
 
         /*  only the first error is likely to be interesting */
         if (tmp_result != pcmk_ok) {
-            crm_err("Error updating child <%s id=%s>", crm_element_name(a_child), ID(a_child));
+            crm_err("Error updating child <%s%s%s%s>",
+                    crm_element_name(a_child),
+                    ((ID(a_child) == NULL)? "" : " id='"),
+                    pcmk__s(ID(a_child), ""),
+                    ((ID(a_child) == NULL)? "" : "'"));
 
             if (result == pcmk_ok) {
                 result = tmp_result;
@@ -476,8 +483,9 @@ update_cib_object(xmlNode * parent, xmlNode * update)
         }
     }
 
-    crm_trace("Finished handling update for <%s%s%s>", object_name,
-              ((object_id == NULL)? "" : " id="), pcmk__s(object_id, ""));
+    crm_trace("Finished handling update for <%s%s%s%s>", object_name,
+              ((object_id == NULL)? "" : " id='"), pcmk__s(object_id, ""),
+              ((object_id == NULL)? "" : "'"));
 
     return result;
 }
@@ -500,8 +508,9 @@ add_cib_object(xmlNode * parent, xmlNode * new_obj)
 
     object_id = ID(new_obj);
 
-    crm_trace("Processing creation of <%s%s%s>", object_name,
-              ((object_id == NULL)? "" : " id="), pcmk__s(object_id, ""));
+    crm_trace("Processing creation of <%s%s%s%s>", object_name,
+              ((object_id == NULL)? "" : " id='"), pcmk__s(object_id, ""),
+              ((object_id == NULL)? "" : "'"));
 
     if (object_id == NULL) {
         equiv_node = find_xml_node(parent, object_name, FALSE);

--- a/lib/common/ipc_controld.c
+++ b/lib/common/ipc_controld.c
@@ -361,9 +361,10 @@ pcmk_controld_api_reprobe(pcmk_ipc_api_t *api, const char *target_node,
     if (router_node == NULL) {
         router_node = target_node;
     }
-    crm_debug("Sending %s IPC request to reprobe %s via %s",
-              pcmk_ipc_name(api, true), pcmk__s(target_node, "unknown node"),
-              pcmk__s(router_node, "unknown node"));
+    crm_debug("Sending %s IPC request to reprobe %s%s%s",
+              pcmk_ipc_name(api, true), pcmk__s(target_node, "local node"),
+              ((router_node == target_node)? "" : " via "),
+              pcmk__s(router_node, ""));
     msg_data = create_reprobe_message_data(target_node, router_node);
     request = create_controller_request(api, CRM_OP_REPROBE, router_node,
                                         msg_data);

--- a/lib/common/ipc_controld.c
+++ b/lib/common/ipc_controld.c
@@ -361,10 +361,9 @@ pcmk_controld_api_reprobe(pcmk_ipc_api_t *api, const char *target_node,
     if (router_node == NULL) {
         router_node = target_node;
     }
-    crm_debug("Sending %s IPC request to reprobe %s%s%s",
+    crm_debug("Sending %s IPC request to reprobe %s via %s",
               pcmk_ipc_name(api, true), pcmk__s(target_node, "local node"),
-              ((router_node == target_node)? "" : " via "),
-              pcmk__s(router_node, ""));
+              pcmk__s(router_node, "local node"));
     msg_data = create_reprobe_message_data(target_node, router_node);
     request = create_controller_request(api, CRM_OP_REPROBE, router_node,
                                         msg_data);

--- a/lib/common/ipc_schedulerd.c
+++ b/lib/common/ipc_schedulerd.c
@@ -89,15 +89,16 @@ dispatch(pcmk_ipc_api_t *api, xmlNode *reply)
     }
 
     value = crm_element_value(reply, F_CRM_MSG_TYPE);
-    if ((value == NULL) || (strcmp(value, XML_ATTR_RESPONSE))) {
-        crm_debug("Unrecognizable schedulerd message: invalid message type '%s'",
-                  pcmk__s(value, "(missing)"));
+    if (!pcmk__str_eq(value, XML_ATTR_RESPONSE, pcmk__str_none)) {
+        crm_info("Unrecognizable message from schedulerd: "
+                  "message type '%s' not '" XML_ATTR_RESPONSE "'",
+                  pcmk__s(value, ""));
         status = CRM_EX_PROTOCOL;
         goto done;
     }
 
-    if (crm_element_value(reply, XML_ATTR_REFERENCE) == NULL) {
-        crm_debug("Unrecognizable schedulerd message: no reference");
+    if (pcmk__str_empty(crm_element_value(reply, XML_ATTR_REFERENCE))) {
+        crm_info("Unrecognizable message from schedulerd: no reference");
         status = CRM_EX_PROTOCOL;
         goto done;
     }
@@ -112,8 +113,8 @@ dispatch(pcmk_ipc_api_t *api, xmlNode *reply)
         reply_data.data.graph.input = crm_element_value(reply, F_CRM_TGRAPH_INPUT);
         reply_data.data.graph.tgraph = msg_data;
     } else {
-        crm_debug("Unrecognizable pacemakerd message: '%s'",
-                  pcmk__s(value, "(missing)"));
+        crm_info("Unrecognizable message from schedulerd: "
+                  "unknown command '%s'", pcmk__s(value, ""));
         status = CRM_EX_PROTOCOL;
         goto done;
     }

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -69,11 +69,11 @@ pcmk__find_client(qb_ipcs_connection_t *c)
 pcmk__client_t *
 pcmk__find_client_by_id(const char *id)
 {
-    gpointer key;
-    pcmk__client_t *client;
-    GHashTableIter iter;
+    if ((client_connections != NULL) && (id != NULL)) {
+        gpointer key;
+        pcmk__client_t *client = NULL;
+        GHashTableIter iter;
 
-    if (client_connections && id) {
         g_hash_table_iter_init(&iter, client_connections);
         while (g_hash_table_iter_next(&iter, &key, (gpointer *) & client)) {
             if (strcmp(client->id, id) == 0) {
@@ -81,8 +81,7 @@ pcmk__find_client_by_id(const char *id)
             }
         }
     }
-
-    crm_trace("No client found with id=%s", id);
+    crm_trace("No client found with id='%s'", pcmk__s(id, ""));
     return NULL;
 }
 

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -322,7 +322,7 @@ set_result_from_method_error(svc_action_t *op, const DBusError *error)
     }
 
     crm_info("DBus request for %s of systemd unit %s%s%s failed: %s",
-             op->action, op->agent, pcmk__s(op->rsc, "(unspecified)"),
+             op->action, op->agent,
              ((op->rsc == NULL)? "" : " for resource "), pcmk__s(op->rsc, ""),
              error->message);
 }

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -321,8 +321,9 @@ set_result_from_method_error(svc_action_t *op, const DBusError *error)
                                "systemd unit %s not found", op->agent);
     }
 
-    crm_info("DBus request for %s of systemd unit %s for resource %s failed: %s",
+    crm_info("DBus request for %s of systemd unit %s%s%s failed: %s",
              op->action, op->agent, pcmk__s(op->rsc, "(unspecified)"),
+             ((op->rsc == NULL)? "" : " for resource "), pcmk__s(op->rsc, ""),
              error->message);
 }
 
@@ -977,8 +978,9 @@ invoke_unit_by_path(svc_action_t *op, const char *unit)
         return;
     }
 
-    crm_trace("Calling %s for unit path %s named %s",
-              method, unit, pcmk__s(op->rsc, "with unknown name"));
+    crm_trace("Calling %s for unit path %s%s%s",
+              method, unit,
+              ((op->rsc == NULL)? "" : " for resource "), pcmk__s(op->rsc, ""));
 
     msg = systemd_new_method(method);
     CRM_ASSERT(msg != NULL);
@@ -1066,9 +1068,9 @@ services__execute_systemd(svc_action_t *op)
         goto done;
     }
 
-    crm_debug("Performing %ssynchronous %s op on systemd unit %s named %s",
+    crm_debug("Performing %ssynchronous %s op on systemd unit %s%s%s",
               (op->synchronous? "" : "a"), op->action, op->agent,
-              pcmk__s(op->rsc, "with unknown name"));
+              ((op->rsc == NULL)? "" : " for resource "), pcmk__s(op->rsc, ""));
 
     if (pcmk__str_eq(op->action, "meta-data", pcmk__str_casei)) {
         op->stdout_data = systemd_unit_metadata(op->agent, op->timeout);


### PR DESCRIPTION
The replacement of crm_str() with pcmk__s() opened the door to a more in-depth look at how we validate various bits of input. This aims to improve all of that, especially log messages.