### PR TITLE
Low: fencer: assume unknown status from older fencers' history replies

### DIFF
--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -705,7 +705,6 @@ stonith_api_history(stonith_t * stonith, int call_options, const char *node,
             stonith_history_t *kvp;
             long long completed;
             long long completed_nsec = 0L;
-            pcmk__action_result_t result = PCMK__UNKNOWN_RESULT;
 
             kvp = calloc(1, sizeof(stonith_history_t));
             kvp->target = crm_element_value_copy(op, F_STONITH_TARGET);
@@ -718,11 +717,8 @@ stonith_api_history(stonith_t * stonith, int call_options, const char *node,
             crm_element_value_ll(op, F_STONITH_DATE_NSEC, &completed_nsec);
             kvp->completed_nsec = completed_nsec;
             crm_element_value_int(op, F_STONITH_STATE, &kvp->state);
-
-            stonith__xe_get_result(op, &result);
-            kvp->exit_reason = result.exit_reason;
-            result.exit_reason = NULL;
-            pcmk__reset_result(&result);
+            kvp->exit_reason = crm_element_value_copy(op,
+                                                      XML_LRM_ATTR_EXIT_REASON);
 
             if (last) {
                 last->next = kvp;


### PR DESCRIPTION
be0a0b652c added and retrieved fencing results from fencing history entries'
XML. However stonith__xe_get_result() would log an error and set an error
status if no result is set, as is the case with older fencers. So, avoid that
function, and instead parse the results directly. Since a legacy rc was never
added by any version, we don't have to look for one.