### PR TITLE
Best practices for transition graph types

### DIFF
--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -295,7 +295,8 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                 crm_update_peer_join(__func__, node, crm_join_none);
                 check_join_state(fsa_state, __func__);
             }
-            abort_transition(INFINITY, tg_restart, "Node failure", NULL);
+            abort_transition(INFINITY, pcmk__graph_restart, "Node failure",
+                             NULL);
             fail_incompletable_actions(transition_graph, node->uuid);
 
         } else {
@@ -311,7 +312,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
 
             /* Trigger resource placement on newly integrated nodes */
             if (appeared) {
-                abort_transition(INFINITY, tg_restart,
+                abort_transition(INFINITY, pcmk__graph_restart,
                                  "Pacemaker Remote node integrated", NULL);
             }
         }

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -244,7 +244,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
         xmlNode *update = NULL;
         int flags = node_update_peer;
         int alive = node_alive(node);
-        crm_action_t *down = match_down_event(node->uuid);
+        pcmk__graph_action_t *down = match_down_event(node->uuid);
 
         crm_trace("Alive=%d, appeared=%d, down=%d",
                   alive, appeared, (down? down->id : -1));

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -169,7 +169,8 @@ cib_fencing_updated(xmlNode *msg, int call_id, int rc, xmlNode *output,
 }
 
 static void
-send_stonith_update(crm_action_t *action, const char *target, const char *uuid)
+send_stonith_update(pcmk__graph_action_t *action, const char *target,
+                    const char *uuid)
 {
     int rc = pcmk_ok;
     crm_node_t *peer = NULL;
@@ -378,7 +379,7 @@ fail_incompletable_stonith(crm_graph_t *graph)
         }
 
         for (lpc2 = synapse->actions; lpc2 != NULL; lpc2 = lpc2->next) {
-            crm_action_t *action = (crm_action_t *) lpc2->data;
+            pcmk__graph_action_t *action = (pcmk__graph_action_t *) lpc2->data;
 
             if ((action->type != pcmk__cluster_graph_action)
                 || pcmk_is_set(action->flags, pcmk__graph_action_confirmed)) {
@@ -738,7 +739,7 @@ tengine_stonith_callback(stonith_t *stonith, stonith_callback_data_t *data)
     char *uuid = NULL;
     int stonith_id = -1;
     int transition_id = -1;
-    crm_action_t *action = NULL;
+    pcmk__graph_action_t *action = NULL;
     const char *target = NULL;
 
     if ((data == NULL) || (data->userdata == NULL)) {
@@ -894,7 +895,7 @@ fence_with_delay(const char *target, const char *type, const char *delay)
 }
 
 gboolean
-te_fence_node(crm_graph_t *graph, crm_action_t *action)
+te_fence_node(crm_graph_t *graph, pcmk__graph_action_t *action)
 {
     int rc = 0;
     const char *id = NULL;

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -380,7 +380,8 @@ fail_incompletable_stonith(crm_graph_t *graph)
         for (lpc2 = synapse->actions; lpc2 != NULL; lpc2 = lpc2->next) {
             crm_action_t *action = (crm_action_t *) lpc2->data;
 
-            if (action->type != action_type_crm || pcmk_is_set(action->flags, pcmk__graph_action_confirmed)) {
+            if ((action->type != pcmk__cluster_graph_action)
+                || pcmk_is_set(action->flags, pcmk__graph_action_confirmed)) {
                 continue;
             }
 

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -388,7 +388,7 @@ fail_incompletable_stonith(pcmk__graph_t *graph)
 
             task = crm_element_value(action->xml, XML_LRM_ATTR_TASK);
             if (task && pcmk__str_eq(task, CRM_OP_FENCE, pcmk__str_casei)) {
-                crm__set_graph_action_flags(action, pcmk__graph_action_failed);
+                pcmk__set_graph_action_flags(action, pcmk__graph_action_failed);
                 last_action = action->xml;
                 pcmk__update_graph(graph, action);
                 crm_notice("Failing action %d (%s): fencer terminated",
@@ -830,7 +830,8 @@ tengine_stonith_callback(stonith_t *stonith, stonith_callback_data_t *data)
 
             } else if (!(pcmk_is_set(action->flags, pcmk__graph_action_sent_update))) {
                 send_stonith_update(action, target, uuid);
-                crm__set_graph_action_flags(action, pcmk__graph_action_sent_update);
+                pcmk__set_graph_action_flags(action,
+                                             pcmk__graph_action_sent_update);
             }
         }
         st_fail_count_reset(target);
@@ -847,7 +848,7 @@ tengine_stonith_callback(stonith_t *stonith, stonith_callback_data_t *data)
                 reason = pcmk_exec_status_str(status);
             }
         }
-        crm__set_graph_action_flags(action, pcmk__graph_action_failed);
+        pcmk__set_graph_action_flags(action, pcmk__graph_action_failed);
 
         /* If no fence devices were available, there's no use in immediately
          * checking again, so don't start a new transition in that case.

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -372,7 +372,7 @@ fail_incompletable_stonith(pcmk__graph_t *graph)
 
     for (lpc = graph->synapses; lpc != NULL; lpc = lpc->next) {
         GList *lpc2 = NULL;
-        synapse_t *synapse = (synapse_t *) lpc->data;
+        pcmk__graph_synapse_t *synapse = (pcmk__graph_synapse_t *) lpc->data;
 
         if (pcmk_is_set(synapse->flags, pcmk__synapse_confirmed)) {
             continue;

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -895,8 +895,18 @@ fence_with_delay(const char *target, const char *type, const char *delay)
                                                type, timeout_sec, 0, delay_i);
 }
 
-gboolean
-te_fence_node(pcmk__graph_t *graph, pcmk__graph_action_t *action)
+/*!
+ * \internal
+ * \brief Execute a fencing action from a transition graph
+ *
+ * \param[in] graph   Transition graph being executed
+ * \param[in] action  Fencing action to execute
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+controld_execute_fence_action(pcmk__graph_t *graph,
+                              pcmk__graph_action_t *action)
 {
     int rc = 0;
     const char *id = NULL;
@@ -919,7 +929,7 @@ te_fence_node(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 
     if (invalid_action) {
         crm_log_xml_warn(action->xml, "BadAction");
-        return FALSE;
+        return EPROTO;
     }
 
     priority_delay = crm_meta_value(action->params, XML_CONFIG_ATTR_PRIORITY_FENCING_DELAY);
@@ -940,8 +950,7 @@ te_fence_node(pcmk__graph_t *graph, pcmk__graph_action_t *action)
                                          (int) (transition_graph->stonith_timeout / 1000),
                                          st_opt_timeout_updates, transition_key,
                                          "tengine_stonith_callback", tengine_stonith_callback);
-
-    return TRUE;
+    return pcmk_rc_ok;
 }
 
 bool

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -791,7 +791,7 @@ tengine_stonith_callback(stonith_t *stonith, stonith_callback_data_t *data)
         goto bail;
     }
 
-    stop_te_timer(action->timer);
+    stop_te_timer(action);
     if (stonith__exit_status(data) == CRM_EX_OK) {
         const char *uuid = crm_element_value(action->xml, XML_LRM_ATTR_TARGET_UUID);
         const char *op = crm_meta_value(action->params, "stonith_action");

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -360,7 +360,7 @@ static crm_trigger_t *stonith_reconnect = NULL;
 static char *te_client_id = NULL;
 
 static gboolean
-fail_incompletable_stonith(crm_graph_t *graph)
+fail_incompletable_stonith(pcmk__graph_t *graph)
 {
     GList *lpc = NULL;
     const char *task = NULL;
@@ -895,7 +895,7 @@ fence_with_delay(const char *target, const char *type, const char *delay)
 }
 
 gboolean
-te_fence_node(crm_graph_t *graph, pcmk__graph_action_t *action)
+te_fence_node(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     int rc = 0;
     const char *id = NULL;

--- a/daemons/controld/controld_fencing.h
+++ b/daemons/controld/controld_fencing.h
@@ -11,7 +11,7 @@
 #  define CONTROLD_FENCING__H
 
 #include <stdbool.h>                // bool
-#include <pacemaker-internal.h>     // crm_graph_t, crm_action_t
+#include <pacemaker-internal.h>     // crm_graph_t, pcmk__graph_action_t
 
 // reaction to notification of local node being fenced
 void set_fence_reaction(const char *reaction_s);
@@ -23,7 +23,7 @@ void update_stonith_max_attempts(const char* value);
 // stonith API client
 void controld_trigger_fencer_connect(void);
 void controld_disconnect_fencer(bool destroy);
-gboolean te_fence_node(crm_graph_t *graph, crm_action_t *action);
+gboolean te_fence_node(crm_graph_t *graph, pcmk__graph_action_t *action);
 bool controld_verify_stonith_watchdog_timeout(const char *value);
 
 // stonith cleanup list

--- a/daemons/controld/controld_fencing.h
+++ b/daemons/controld/controld_fencing.h
@@ -23,7 +23,8 @@ void update_stonith_max_attempts(const char* value);
 // stonith API client
 void controld_trigger_fencer_connect(void);
 void controld_disconnect_fencer(bool destroy);
-gboolean te_fence_node(pcmk__graph_t *graph, pcmk__graph_action_t *action);
+int controld_execute_fence_action(pcmk__graph_t *graph,
+                                  pcmk__graph_action_t *action);
 bool controld_verify_stonith_watchdog_timeout(const char *value);
 
 // stonith cleanup list

--- a/daemons/controld/controld_fencing.h
+++ b/daemons/controld/controld_fencing.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -11,7 +11,7 @@
 #  define CONTROLD_FENCING__H
 
 #include <stdbool.h>                // bool
-#include <pacemaker-internal.h>     // crm_graph_t, pcmk__graph_action_t
+#include <pacemaker-internal.h>     // pcmk__graph_t, pcmk__graph_action_t
 
 // reaction to notification of local node being fenced
 void set_fence_reaction(const char *reaction_s);
@@ -23,7 +23,7 @@ void update_stonith_max_attempts(const char* value);
 // stonith API client
 void controld_trigger_fencer_connect(void);
 void controld_disconnect_fencer(bool destroy);
-gboolean te_fence_node(crm_graph_t *graph, pcmk__graph_action_t *action);
+gboolean te_fence_node(pcmk__graph_t *graph, pcmk__graph_action_t *action);
 bool controld_verify_stonith_watchdog_timeout(const char *value);
 
 // stonith cleanup list

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -255,7 +255,7 @@ do_dc_join_offer_one(long long action,
     /* This was a genuine join request; cancel any existing transition and
      * invoke the scheduler.
      */
-    abort_transition(INFINITY, tg_restart, "Node join", NULL);
+    abort_transition(INFINITY, pcmk__graph_restart, "Node join", NULL);
 
     count = crmd_join_phase_count(crm_join_welcomed);
     crm_info("Waiting on join-%d requests from %d outstanding node%s",

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -430,9 +430,11 @@ crm_update_quorum(gboolean quorum, gboolean force_update)
              * nodes are joining around the same time, so the one that brings us
              * to quorum doesn't cause all the remaining ones to be fenced.
              */
-            abort_after_delay(INFINITY, tg_restart, "Quorum gained", 5000);
+            abort_after_delay(INFINITY, pcmk__graph_restart, "Quorum gained",
+                              5000);
         } else {
-            abort_transition(INFINITY, tg_restart, "Quorum lost", NULL);
+            abort_transition(INFINITY, pcmk__graph_restart, "Quorum lost",
+                             NULL);
         }
     }
     fsa_has_quorum = quorum;

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -1018,7 +1018,7 @@ handle_request(xmlNode *stored_msg, enum crmd_fsa_cause cause)
     } else if (strcmp(op, CRM_OP_THROTTLE) == 0) {
         throttle_update(stored_msg);
         if (AM_I_DC && transition_graph != NULL) {
-            if (transition_graph->complete == FALSE) {
+            if (!transition_graph->complete) {
                 crm_debug("The throttle changed. Trigger a graph.");
                 trigger_graph();
             }

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -641,7 +641,7 @@ pcmk__graph_functions_t te_graph_fns = {
     execute_pseudo_action,
     execute_rsc_action,
     execute_cluster_action,
-    te_fence_node,
+    controld_execute_fence_action,
     te_should_perform_action,
 };
 

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -28,13 +28,9 @@ static void te_update_job_count(crm_action_t * action, int offset);
 static void
 te_start_action_timer(crm_graph_t * graph, crm_action_t * action)
 {
-    action->timer = calloc(1, sizeof(crm_action_timer_t));
-    action->timer->timeout = action->timeout;
-    action->timer->action = action;
-    action->timer->source_id = g_timeout_add(action->timer->timeout + graph->network_delay,
-                                             action_timer_callback, (void *)action->timer);
-
-    CRM_ASSERT(action->timer->source_id != 0);
+    action->timer = g_timeout_add(action->timeout + graph->network_delay,
+                                  action_timer_callback, (void *) action);
+    CRM_ASSERT(action->timer != 0);
 }
 
 static gboolean

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -151,7 +151,7 @@ execute_cluster_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     if (is_local && pcmk__str_eq(task, CRM_OP_SHUTDOWN, pcmk__str_casei)) {
         /* defer until everything else completes */
         crm_info("crm-event (%s) is a local shutdown", pcmk__s(id, "<null>"));
-        graph->completion_action = tg_shutdown;
+        graph->completion_action = pcmk__graph_shutdown;
         graph->abort_reason = "local shutdown";
         te_action_confirmed(action, graph);
         return pcmk_rc_ok;
@@ -675,20 +675,20 @@ notify_crmd(pcmk__graph_t *graph)
     CRM_CHECK(graph->complete, graph->complete = true);
 
     switch (graph->completion_action) {
-        case tg_stop:
+        case pcmk__graph_wait:
             type = "stop";
             if (fsa_state == S_TRANSITION_ENGINE) {
                 event = I_TE_SUCCESS;
             }
             break;
-        case tg_done:
+        case pcmk__graph_done:
             type = "done";
             if (fsa_state == S_TRANSITION_ENGINE) {
                 event = I_TE_SUCCESS;
             }
             break;
 
-        case tg_restart:
+        case pcmk__graph_restart:
             type = "restart";
             if (fsa_state == S_TRANSITION_ENGINE) {
                 if (transition_timer->period_ms > 0) {
@@ -704,7 +704,7 @@ notify_crmd(pcmk__graph_t *graph)
             }
             break;
 
-        case tg_shutdown:
+        case pcmk__graph_shutdown:
             type = "shutdown";
             if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
                 event = I_STOP;
@@ -719,7 +719,7 @@ notify_crmd(pcmk__graph_t *graph)
               pcmk__s(graph->abort_reason, "unspecified reason"));
 
     graph->abort_reason = NULL;
-    graph->completion_action = tg_done;
+    graph->completion_action = pcmk__graph_done;
     controld_clear_fsa_input_flags(R_IN_TRANSITION);
 
     if (event != I_NULL) {

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -611,7 +611,7 @@ te_action_confirmed(pcmk__graph_action_t *action, pcmk__graph_t *graph)
 }
 
 
-crm_graph_functions_t te_graph_fns = {
+pcmk__graph_functions_t te_graph_fns = {
     te_pseudo_action,
     te_rsc_command,
     te_crm_command,

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -487,7 +487,7 @@ te_update_job_count(crm_action_t * action, int offset)
     const char *task = crm_element_value(action->xml, XML_LRM_ATTR_TASK);
     const char *target = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
 
-    if (action->type != action_type_rsc || target == NULL) {
+    if ((action->type != pcmk__rsc_graph_action) || (target == NULL)) {
         /* No limit on these */
         return;
     }
@@ -563,7 +563,7 @@ te_should_perform_action(crm_graph_t * graph, crm_action_t * action)
     const char *target = NULL;
     const char *task = crm_element_value(action->xml, XML_LRM_ATTR_TASK);
 
-    if (action->type != action_type_rsc) {
+    if (action->type != pcmk__rsc_graph_action) {
         /* No limit on these */
         return TRUE;
     }
@@ -600,7 +600,7 @@ void
 te_action_confirmed(crm_action_t *action, crm_graph_t *graph)
 {
     if (!pcmk_is_set(action->flags, pcmk__graph_action_confirmed)) {
-        if ((action->type == action_type_rsc)
+        if ((action->type == pcmk__rsc_graph_action)
             && (crm_element_value(action->xml, XML_LRM_ATTR_TARGET) != NULL)) {
             te_update_job_count(action, -1);
         }

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -33,8 +33,17 @@ te_start_action_timer(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     CRM_ASSERT(action->timer != 0);
 }
 
-static gboolean
-te_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *pseudo)
+/*!
+ * \internal
+ * \brief Execute a graph pseudo-action
+ *
+ * \param[in] graph   Transition graph being executed
+ * \param[in] pseudo  Pseudo-action to execute
+ *
+ * \return Standard Pacemaker return code
+ */
+static int
+execute_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *pseudo)
 {
     const char *task = crm_element_value(pseudo->xml, XML_LRM_ATTR_TASK);
 
@@ -66,7 +75,7 @@ te_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *pseudo)
     crm_debug("Pseudo-action %d (%s) fired and confirmed", pseudo->id,
               crm_element_value(pseudo->xml, XML_LRM_ATTR_TASK_KEY));
     te_action_confirmed(pseudo, graph);
-    return TRUE;
+    return pcmk_rc_ok;
 }
 
 static int
@@ -613,7 +622,7 @@ te_action_confirmed(pcmk__graph_action_t *action, pcmk__graph_t *graph)
 
 
 pcmk__graph_functions_t te_graph_fns = {
-    te_pseudo_action,
+    execute_pseudo_action,
     te_rsc_command,
     te_crm_command,
     te_fence_node,

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -283,7 +283,7 @@ controld_record_action_event(pcmk__graph_action_t *action,
 
     crm_trace("Sent CIB update (call ID %d) for synthesized event of action %d (%s on %s)",
               rc, action->id, task_uuid, target);
-    crm__set_graph_action_flags(action, pcmk__graph_action_sent_update);
+    pcmk__set_graph_action_flags(action, pcmk__graph_action_sent_update);
 }
 
 void
@@ -330,7 +330,7 @@ te_rsc_command(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     CRM_ASSERT(action != NULL);
     CRM_ASSERT(action->xml != NULL);
 
-    crm__clear_graph_action_flags(action, pcmk__graph_action_executed);
+    pcmk__clear_graph_action_flags(action, pcmk__graph_action_executed);
     on_node = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
 
     if (pcmk__str_empty(on_node)) {
@@ -394,17 +394,18 @@ te_rsc_command(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     free(counter);
     free_xml(cmd);
 
-    crm__set_graph_action_flags(action, pcmk__graph_action_executed);
+    pcmk__set_graph_action_flags(action, pcmk__graph_action_executed);
 
     if (rc == FALSE) {
         crm_err("Action %d failed: send", action->id);
         return FALSE;
 
     } else if (no_wait) {
+        /* Just mark confirmed. Don't bump the job count only to immediately
+         * decrement it.
+         */
         crm_info("Action %d confirmed - no wait", action->id);
-        crm__set_graph_action_flags(action, pcmk__graph_action_confirmed); /* Just mark confirmed.
-                                   * Don't bump the job count only to immediately decrement it
-                                   */
+        pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);
         pcmk__update_graph(transition_graph, action);
         trigger_graph();
 
@@ -602,7 +603,7 @@ te_action_confirmed(pcmk__graph_action_t *action, pcmk__graph_t *graph)
             && (crm_element_value(action->xml, XML_LRM_ATTR_TARGET) != NULL)) {
             te_update_job_count(action, -1);
         }
-        crm__set_graph_action_flags(action, pcmk__graph_action_confirmed);
+        pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);
     }
     if (graph) {
         pcmk__update_graph(graph, action);

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -22,11 +22,11 @@
 
 char *te_uuid = NULL;
 GHashTable *te_targets = NULL;
-void send_rsc_command(crm_action_t * action);
-static void te_update_job_count(crm_action_t * action, int offset);
+void send_rsc_command(pcmk__graph_action_t *action);
+static void te_update_job_count(pcmk__graph_action_t *action, int offset);
 
 static void
-te_start_action_timer(crm_graph_t * graph, crm_action_t * action)
+te_start_action_timer(crm_graph_t * graph, pcmk__graph_action_t *action)
 {
     action->timer = g_timeout_add(action->timeout + graph->network_delay,
                                   action_timer_callback, (void *) action);
@@ -34,7 +34,7 @@ te_start_action_timer(crm_graph_t * graph, crm_action_t * action)
 }
 
 static gboolean
-te_pseudo_action(crm_graph_t * graph, crm_action_t * pseudo)
+te_pseudo_action(crm_graph_t * graph, pcmk__graph_action_t *pseudo)
 {
     const char *task = crm_element_value(pseudo->xml, XML_LRM_ATTR_TASK);
 
@@ -70,7 +70,7 @@ te_pseudo_action(crm_graph_t * graph, crm_action_t * pseudo)
 }
 
 static int
-get_target_rc(crm_action_t * action)
+get_target_rc(pcmk__graph_action_t *action)
 {
     int exit_status;
 
@@ -80,7 +80,7 @@ get_target_rc(crm_action_t * action)
 }
 
 static gboolean
-te_crm_command(crm_graph_t * graph, crm_action_t * action)
+te_crm_command(crm_graph_t * graph, pcmk__graph_action_t *action)
 {
     char *counter = NULL;
     xmlNode *cmd = NULL;
@@ -191,7 +191,7 @@ te_crm_command(crm_graph_t * graph, crm_action_t * action)
  *       lrmd_free_event().
  */
 static lrmd_event_data_t *
-synthesize_timeout_event(crm_action_t *action, int target_rc)
+synthesize_timeout_event(pcmk__graph_action_t *action, int target_rc)
 {
     lrmd_event_data_t *op = NULL;
     const char *target = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
@@ -222,7 +222,8 @@ synthesize_timeout_event(crm_action_t *action, int target_rc)
 }
 
 static void
-controld_record_action_event(crm_action_t *action, lrmd_event_data_t *op)
+controld_record_action_event(pcmk__graph_action_t *action,
+                             lrmd_event_data_t *op)
 {
     xmlNode *state = NULL;
     xmlNode *rsc = NULL;
@@ -286,7 +287,7 @@ controld_record_action_event(crm_action_t *action, lrmd_event_data_t *op)
 }
 
 void
-controld_record_action_timeout(crm_action_t *action)
+controld_record_action_timeout(pcmk__graph_action_t *action)
 {
     lrmd_event_data_t *op = NULL;
 
@@ -304,7 +305,7 @@ controld_record_action_timeout(crm_action_t *action)
 }
 
 static gboolean
-te_rsc_command(crm_graph_t * graph, crm_action_t * action)
+te_rsc_command(crm_graph_t * graph, pcmk__graph_action_t *action)
 {
     /* never overwrite stop actions in the CIB with
      *   anything other than completed results
@@ -478,7 +479,7 @@ te_update_job_count_on(const char *target, int offset, bool migrate)
 }
 
 static void
-te_update_job_count(crm_action_t * action, int offset)
+te_update_job_count(pcmk__graph_action_t *action, int offset)
 {
     const char *task = crm_element_value(action->xml, XML_LRM_ATTR_TASK);
     const char *target = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
@@ -511,7 +512,8 @@ te_update_job_count(crm_action_t * action, int offset)
 }
 
 static gboolean
-te_should_perform_action_on(crm_graph_t * graph, crm_action_t * action, const char *target)
+te_should_perform_action_on(crm_graph_t * graph, pcmk__graph_action_t *action,
+                            const char *target)
 {
     int limit = 0;
     struct te_peer_s *r = NULL;
@@ -554,7 +556,7 @@ te_should_perform_action_on(crm_graph_t * graph, crm_action_t * action, const ch
 }
 
 static gboolean
-te_should_perform_action(crm_graph_t * graph, crm_action_t * action)
+te_should_perform_action(crm_graph_t * graph, pcmk__graph_action_t *action)
 {
     const char *target = NULL;
     const char *task = crm_element_value(action->xml, XML_LRM_ATTR_TASK);
@@ -593,7 +595,7 @@ te_should_perform_action(crm_graph_t * graph, crm_action_t * action)
  * \param[in] graph   Update and trigger this graph (if non-NULL)
  */
 void
-te_action_confirmed(crm_action_t *action, crm_graph_t *graph)
+te_action_confirmed(pcmk__graph_action_t *action, crm_graph_t *graph)
 {
     if (!pcmk_is_set(action->flags, pcmk__graph_action_confirmed)) {
         if ((action->type == pcmk__rsc_graph_action)

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -628,7 +628,7 @@ notify_crmd(pcmk__graph_t *graph)
 
     crm_debug("Processing transition completion in state %s", fsa_state2string(fsa_state));
 
-    CRM_CHECK(graph->complete, graph->complete = TRUE);
+    CRM_CHECK(graph->complete, graph->complete = true);
 
     switch (graph->completion_action) {
         case tg_stop:

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -26,7 +26,7 @@ void send_rsc_command(pcmk__graph_action_t *action);
 static void te_update_job_count(pcmk__graph_action_t *action, int offset);
 
 static void
-te_start_action_timer(crm_graph_t * graph, pcmk__graph_action_t *action)
+te_start_action_timer(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     action->timer = g_timeout_add(action->timeout + graph->network_delay,
                                   action_timer_callback, (void *) action);
@@ -34,7 +34,7 @@ te_start_action_timer(crm_graph_t * graph, pcmk__graph_action_t *action)
 }
 
 static gboolean
-te_pseudo_action(crm_graph_t * graph, pcmk__graph_action_t *pseudo)
+te_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *pseudo)
 {
     const char *task = crm_element_value(pseudo->xml, XML_LRM_ATTR_TASK);
 
@@ -80,7 +80,7 @@ get_target_rc(pcmk__graph_action_t *action)
 }
 
 static gboolean
-te_crm_command(crm_graph_t * graph, pcmk__graph_action_t *action)
+te_crm_command(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     char *counter = NULL;
     xmlNode *cmd = NULL;
@@ -305,7 +305,7 @@ controld_record_action_timeout(pcmk__graph_action_t *action)
 }
 
 static gboolean
-te_rsc_command(crm_graph_t * graph, pcmk__graph_action_t *action)
+te_rsc_command(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     /* never overwrite stop actions in the CIB with
      *   anything other than completed results
@@ -512,7 +512,7 @@ te_update_job_count(pcmk__graph_action_t *action, int offset)
 }
 
 static gboolean
-te_should_perform_action_on(crm_graph_t * graph, pcmk__graph_action_t *action,
+te_should_perform_action_on(pcmk__graph_t *graph, pcmk__graph_action_t *action,
                             const char *target)
 {
     int limit = 0;
@@ -556,7 +556,7 @@ te_should_perform_action_on(crm_graph_t * graph, pcmk__graph_action_t *action,
 }
 
 static gboolean
-te_should_perform_action(crm_graph_t * graph, pcmk__graph_action_t *action)
+te_should_perform_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     const char *target = NULL;
     const char *task = crm_element_value(action->xml, XML_LRM_ATTR_TASK);
@@ -595,7 +595,7 @@ te_should_perform_action(crm_graph_t * graph, pcmk__graph_action_t *action)
  * \param[in] graph   Update and trigger this graph (if non-NULL)
  */
 void
-te_action_confirmed(pcmk__graph_action_t *action, crm_graph_t *graph)
+te_action_confirmed(pcmk__graph_action_t *action, pcmk__graph_t *graph)
 {
     if (!pcmk_is_set(action->flags, pcmk__graph_action_confirmed)) {
         if ((action->type == pcmk__rsc_graph_action)
@@ -620,7 +620,7 @@ crm_graph_functions_t te_graph_fns = {
 };
 
 void
-notify_crmd(crm_graph_t * graph)
+notify_crmd(pcmk__graph_t *graph)
 {
     const char *type = "unknown";
     enum crmd_fsa_input event = I_NULL;

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -170,7 +170,7 @@ te_update_diff_v1(const char *event, xmlNode *diff)
         if (numXpathResults(op_match) == 0) {
             /* Prevent false positives by matching cancelations too */
             const char *node = get_node_id(match);
-            crm_action_t *cancelled = get_cancel_action(op_id, node);
+            pcmk__graph_action_t *cancelled = get_cancel_action(op_id, node);
 
             if (cancelled == NULL) {
                 crm_debug("No match for deleted action %s (%s on %s)", rsc_op_xpath, op_id,
@@ -283,7 +283,7 @@ abort_unless_down(const char *xpath, const char *op, xmlNode *change,
                   const char *reason)
 {
     char *node_uuid = NULL;
-    crm_action_t *down = NULL;
+    pcmk__graph_action_t *down = NULL;
 
     if(!pcmk__str_eq(op, "delete", pcmk__str_casei)) {
         abort_transition(INFINITY, tg_restart, reason, change);
@@ -630,14 +630,13 @@ cib_action_updated(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
 gboolean
 action_timer_callback(gpointer data)
 {
-    crm_action_t *action = NULL;
+    pcmk__graph_action_t *action = (pcmk__graph_action_t *) data;
     const char *task = NULL;
     const char *on_node = NULL;
     const char *via_node = NULL;
 
     CRM_CHECK(data != NULL, return FALSE);
 
-    action = (crm_action_t *) data;
     stop_te_timer(action);
 
     task = crm_element_value(action->xml, XML_LRM_ATTR_TASK);

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -658,7 +658,7 @@ action_timer_callback(gpointer data)
                 action->timeout + transition_graph->network_delay);
         pcmk__log_graph_action(LOG_ERR, action);
 
-        crm__set_graph_action_flags(action, pcmk__graph_action_failed);
+        pcmk__set_graph_action_flags(action, pcmk__graph_action_failed);
 
         te_action_confirmed(action, transition_graph);
         abort_transition(INFINITY, tg_restart, "Action lost", NULL);

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -529,8 +529,7 @@ te_update_diff(const char *event, xmlNode * msg)
                && fsa_state != S_IDLE
                && fsa_state != S_TRANSITION_ENGINE
                && fsa_state != S_POLICY_ENGINE) {
-        crm_trace("Filter state=%s, complete=%d", fsa_state2string(fsa_state),
-                  transition_graph->complete);
+        crm_trace("Filter state=%s (complete)", fsa_state2string(fsa_state));
         return;
     }
 

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -667,7 +667,7 @@ action_timer_callback(gpointer data)
         abort_transition(INFINITY, tg_restart, "Action lost", NULL);
 
         // Record timeout in the CIB if appropriate
-        if ((timer->action->type == action_type_rsc)
+        if ((timer->action->type == pcmk__rsc_graph_action)
             && controld_action_is_recordable(task)) {
             controld_record_action_timeout(timer->action);
         }

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -23,7 +23,7 @@ void te_update_confirm(const char *event, xmlNode * msg);
 
 extern char *te_uuid;
 gboolean shuttingdown = FALSE;
-crm_graph_t *transition_graph;
+pcmk__graph_t *transition_graph;
 crm_trigger_t *transition_trigger = NULL;
 
 /* #define RSC_OP_TEMPLATE "//"XML_TAG_DIFF_ADDED"//"XML_TAG_CIB"//"XML_CIB_TAG_STATE"[@uname='%s']"//"XML_LRM_TAG_RSC_OP"[@id='%s]" */

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -69,7 +69,7 @@ fail_incompletable_actions(pcmk__graph_t *graph, const char *down_node)
             }
 
             if (pcmk__str_eq(target_uuid, down_node, pcmk__str_casei) || pcmk__str_eq(router_uuid, down_node, pcmk__str_casei)) {
-                crm__set_graph_action_flags(action, pcmk__graph_action_failed);
+                pcmk__set_graph_action_flags(action, pcmk__graph_action_failed);
                 pcmk__set_synapse_flags(synapse, pcmk__synapse_failed);
                 last_action = action->xml;
                 stop_te_timer(action);
@@ -444,7 +444,7 @@ process_graph_event(xmlNode *event, const char *event_node)
                 ignore_failures = TRUE;
 
             } else if (rc != target_rc) {
-                crm__set_graph_action_flags(action, pcmk__graph_action_failed);
+                pcmk__set_graph_action_flags(action, pcmk__graph_action_failed);
             }
 
             stop_te_timer(action);

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -72,7 +72,7 @@ fail_incompletable_actions(crm_graph_t * graph, const char *down_node)
                 crm__set_graph_action_flags(action, pcmk__graph_action_failed);
                 pcmk__set_synapse_flags(synapse, pcmk__synapse_failed);
                 last_action = action->xml;
-                stop_te_timer(action->timer);
+                stop_te_timer(action);
                 pcmk__update_graph(graph, action);
 
                 if (pcmk_is_set(synapse->flags, pcmk__synapse_executed)) {
@@ -268,7 +268,7 @@ confirm_cancel_action(const char *id, const char *node_id)
     op_key = crm_element_value(cancel->xml, XML_LRM_ATTR_TASK_KEY);
     node_name = crm_element_value(cancel->xml, XML_LRM_ATTR_TARGET);
 
-    stop_te_timer(cancel->timer);
+    stop_te_timer(cancel);
     te_action_confirmed(cancel, transition_graph);
 
     crm_info("Cancellation of %s on %s confirmed (action %d)",
@@ -447,7 +447,7 @@ process_graph_event(xmlNode *event, const char *event_node)
                 crm__set_graph_action_flags(action, pcmk__graph_action_failed);
             }
 
-            stop_te_timer(action->timer);
+            stop_te_timer(action);
             te_action_confirmed(action, transition_graph);
 
             if (pcmk_is_set(action->flags, pcmk__graph_action_failed)) {

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -387,7 +387,7 @@ process_graph_event(xmlNode *event, const char *event_node)
         abort_transition(INFINITY, tg_restart, "Foreign event", event);
 
     } else if ((transition_graph->id != transition_num)
-               || (transition_graph->complete)) {
+               || transition_graph->complete) {
 
         // Action is not from currently active transition
 

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -37,7 +37,7 @@ fail_incompletable_actions(pcmk__graph_t *graph, const char *down_node)
 
     gIter = graph->synapses;
     for (; gIter != NULL; gIter = gIter->next) {
-        synapse_t *synapse = (synapse_t *) gIter->data;
+        pcmk__graph_synapse_t *synapse = (pcmk__graph_synapse_t *) gIter->data;
 
         if (pcmk_any_flags_set(synapse->flags, pcmk__synapse_confirmed|pcmk__synapse_failed)) {
             /* We've already been here */
@@ -201,7 +201,7 @@ pcmk__graph_action_t *
 controld_get_action(int id)
 {
     for (GList *item = transition_graph->synapses; item; item = item->next) {
-        synapse_t *synapse = (synapse_t *) item->data;
+        pcmk__graph_synapse_t *synapse = (pcmk__graph_synapse_t *) item->data;
 
         for (GList *item2 = synapse->actions; item2; item2 = item2->next) {
             pcmk__graph_action_t *action = (pcmk__graph_action_t *) item2->data;
@@ -222,7 +222,7 @@ get_cancel_action(const char *id, const char *node)
 
     gIter = transition_graph->synapses;
     for (; gIter != NULL; gIter = gIter->next) {
-        synapse_t *synapse = (synapse_t *) gIter->data;
+        pcmk__graph_synapse_t *synapse = (pcmk__graph_synapse_t *) gIter->data;
 
         gIter2 = synapse->actions;
         for (; gIter2 != NULL; gIter2 = gIter2->next) {
@@ -300,7 +300,7 @@ match_down_event(const char *target)
          gIter != NULL && match == NULL;
          gIter = gIter->next) {
 
-        for (gIter2 = ((synapse_t*)gIter->data)->actions;
+        for (gIter2 = ((pcmk__graph_synapse_t * ) gIter->data)->actions;
              gIter2 != NULL && match == NULL;
              gIter2 = gIter2->next) {
 

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -21,7 +21,7 @@ char *failed_stop_offset = NULL;
 char *failed_start_offset = NULL;
 
 gboolean
-fail_incompletable_actions(crm_graph_t * graph, const char *down_node)
+fail_incompletable_actions(pcmk__graph_t *graph, const char *down_node)
 {
     const char *target_uuid = NULL;
     const char *router = NULL;

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -88,7 +88,8 @@ fail_incompletable_actions(pcmk__graph_t *graph, const char *down_node)
 
     if (last_action != NULL) {
         crm_info("Node %s shutdown resulted in un-runnable actions", down_node);
-        abort_transition(INFINITY, tg_restart, "Node failure", last_action);
+        abort_transition(INFINITY, pcmk__graph_restart, "Node failure",
+                         last_action);
         return TRUE;
     }
 
@@ -373,18 +374,19 @@ process_graph_event(xmlNode *event, const char *event_node)
         // decode_transition_key() already logged the bad key
         crm_err("Can't process action %s result: Incompatible versions? "
                 CRM_XS " call-id=%d", id, callid);
-        abort_transition(INFINITY, tg_restart, "Bad event", event);
+        abort_transition(INFINITY, pcmk__graph_restart, "Bad event", event);
         return;
     }
 
     if (transition_num == -1) {
         // E.g. crm_resource --fail
         desc = "initiated outside of the cluster";
-        abort_transition(INFINITY, tg_restart, "Unexpected event", event);
+        abort_transition(INFINITY, pcmk__graph_restart, "Unexpected event",
+                         event);
 
     } else if ((action_num < 0) || !pcmk__str_eq(update_te_uuid, te_uuid, pcmk__str_none)) {
         desc = "initiated by a different DC";
-        abort_transition(INFINITY, tg_restart, "Foreign event", event);
+        abort_transition(INFINITY, pcmk__graph_restart, "Foreign event", event);
 
     } else if ((transition_graph->id != transition_num)
                || transition_graph->complete) {
@@ -405,15 +407,16 @@ process_graph_event(xmlNode *event, const char *event_node)
             }
 
             desc = "arrived after initial scheduling";
-            abort_transition(INFINITY, tg_restart, "Change in recurring result",
-                             event);
+            abort_transition(INFINITY, pcmk__graph_restart,
+                             "Change in recurring result", event);
 
         } else if (transition_graph->id != transition_num) {
             desc = "arrived really late";
-            abort_transition(INFINITY, tg_restart, "Old event", event);
+            abort_transition(INFINITY, pcmk__graph_restart, "Old event", event);
         } else {
             desc = "arrived late";
-            abort_transition(INFINITY, tg_restart, "Inactive graph", event);
+            abort_transition(INFINITY, pcmk__graph_restart, "Inactive graph",
+                             event);
         }
 
     } else {
@@ -423,7 +426,8 @@ process_graph_event(xmlNode *event, const char *event_node)
         if (action == NULL) {
             // Should never happen
             desc = "unknown";
-            abort_transition(INFINITY, tg_restart, "Unknown event", event);
+            abort_transition(INFINITY, pcmk__graph_restart, "Unknown event",
+                             event);
 
         } else if (pcmk_is_set(action->flags, pcmk__graph_action_confirmed)) {
             /* Nothing further needs to be done if the action has already been
@@ -451,8 +455,8 @@ process_graph_event(xmlNode *event, const char *event_node)
             te_action_confirmed(action, transition_graph);
 
             if (pcmk_is_set(action->flags, pcmk__graph_action_failed)) {
-                abort_transition(action->synapse->priority + 1, tg_restart,
-                                 "Event failed", event);
+                abort_transition(action->synapse->priority + 1,
+                                 pcmk__graph_restart, "Event failed", event);
             }
         }
     }

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -48,9 +48,10 @@ fail_incompletable_actions(crm_graph_t * graph, const char *down_node)
         for (; gIter2 != NULL; gIter2 = gIter2->next) {
             crm_action_t *action = (crm_action_t *) gIter2->data;
 
-            if (action->type == action_type_pseudo || pcmk_is_set(action->flags, pcmk__graph_action_confirmed)) {
+            if ((action->type == pcmk__pseudo_graph_action)
+                || pcmk_is_set(action->flags, pcmk__graph_action_confirmed)) {
                 continue;
-            } else if (action->type == action_type_crm) {
+            } else if (action->type == pcmk__cluster_graph_action) {
                 const char *task = crm_element_value(action->xml, XML_LRM_ATTR_TASK);
 
                 if (pcmk__str_eq(task, CRM_OP_FENCE, pcmk__str_casei)) {

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -46,7 +46,7 @@ fail_incompletable_actions(crm_graph_t * graph, const char *down_node)
 
         gIter2 = synapse->actions;
         for (; gIter2 != NULL; gIter2 = gIter2->next) {
-            crm_action_t *action = (crm_action_t *) gIter2->data;
+            pcmk__graph_action_t *action = (pcmk__graph_action_t *) gIter2->data;
 
             if ((action->type == pcmk__pseudo_graph_action)
                 || pcmk_is_set(action->flags, pcmk__graph_action_confirmed)) {
@@ -197,14 +197,14 @@ update_failcount(xmlNode * event, const char *event_node_uuid, int rc,
     return TRUE;
 }
 
-crm_action_t *
+pcmk__graph_action_t *
 controld_get_action(int id)
 {
     for (GList *item = transition_graph->synapses; item; item = item->next) {
         synapse_t *synapse = (synapse_t *) item->data;
 
         for (GList *item2 = synapse->actions; item2; item2 = item2->next) {
-            crm_action_t *action = (crm_action_t *) item2->data;
+            pcmk__graph_action_t *action = (pcmk__graph_action_t *) item2->data;
 
             if (action->id == id) {
                 return action;
@@ -214,7 +214,7 @@ controld_get_action(int id)
     return NULL;
 }
 
-crm_action_t *
+pcmk__graph_action_t *
 get_cancel_action(const char *id, const char *node)
 {
     GList *gIter = NULL;
@@ -228,7 +228,7 @@ get_cancel_action(const char *id, const char *node)
         for (; gIter2 != NULL; gIter2 = gIter2->next) {
             const char *task = NULL;
             const char *target = NULL;
-            crm_action_t *action = (crm_action_t *) gIter2->data;
+            pcmk__graph_action_t *action = (pcmk__graph_action_t *) gIter2->data;
 
             task = crm_element_value(action->xml, XML_LRM_ATTR_TASK);
             if (!pcmk__str_eq(CRMD_ACTION_CANCEL, task, pcmk__str_casei)) {
@@ -260,7 +260,7 @@ confirm_cancel_action(const char *id, const char *node_id)
 {
     const char *op_key = NULL;
     const char *node_name = NULL;
-    crm_action_t *cancel = get_cancel_action(id, node_id);
+    pcmk__graph_action_t *cancel = get_cancel_action(id, node_id);
 
     if (cancel == NULL) {
         return FALSE;
@@ -287,10 +287,10 @@ confirm_cancel_action(const char *id, const char *node_id)
  *
  * \return Matching event if found, NULL otherwise
  */
-crm_action_t *
+pcmk__graph_action_t *
 match_down_event(const char *target)
 {
-    crm_action_t *match = NULL;
+    pcmk__graph_action_t *match = NULL;
     xmlXPathObjectPtr xpath_ret = NULL;
     GList *gIter, *gIter2;
 
@@ -304,7 +304,7 @@ match_down_event(const char *target)
              gIter2 != NULL && match == NULL;
              gIter2 = gIter2->next) {
 
-            match = (crm_action_t*)gIter2->data;
+            match = (pcmk__graph_action_t *) gIter2->data;
             if (pcmk_is_set(match->flags, pcmk__graph_action_executed)) {
                 xpath_ret = xpath_search(match->xml, xpath);
                 if (numXpathResults(xpath_ret) < 1) {
@@ -418,7 +418,7 @@ process_graph_event(xmlNode *event, const char *event_node)
 
     } else {
         // Event is result of an action from currently active transition
-        crm_action_t *action = controld_get_action(action_num);
+        pcmk__graph_action_t *action = controld_get_action(action_num);
 
         if (action == NULL) {
             // Should never happen

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -96,7 +96,7 @@ static struct abort_timer_s {
     bool aborted;
     guint id;
     int priority;
-    enum transition_action action;
+    enum pcmk__graph_next action;
     const char *text;
 } abort_timer = { 0, };
 
@@ -118,7 +118,7 @@ abort_timer_popped(gpointer data)
  * \param[in] abort_text  Must be literal string
  */
 void
-abort_after_delay(int abort_priority, enum transition_action abort_action,
+abort_after_delay(int abort_priority, enum pcmk__graph_next abort_action,
                   const char *abort_text, guint delay_ms)
 {
     if (abort_timer.id) {
@@ -133,24 +133,20 @@ abort_after_delay(int abort_priority, enum transition_action abort_action,
 }
 
 static const char *
-abort2text(enum transition_action abort_action)
+abort2text(enum pcmk__graph_next abort_action)
 {
     switch (abort_action) {
-        case tg_done:
-            return "done";
-        case tg_stop:
-            return "stop";
-        case tg_restart:
-            return "restart";
-        case tg_shutdown:
-            return "shutdown";
+        case pcmk__graph_done:      return "done";
+        case pcmk__graph_wait:      return "stop";
+        case pcmk__graph_restart:   return "restart";
+        case pcmk__graph_shutdown:  return "shutdown";
     }
     return "unknown";
 }
 
 static bool
 update_abort_priority(pcmk__graph_t *graph, int priority,
-                      enum transition_action action, const char *abort_reason)
+                      enum pcmk__graph_next action, const char *abort_reason)
 {
     bool change = FALSE;
 
@@ -179,7 +175,7 @@ update_abort_priority(pcmk__graph_t *graph, int priority,
 }
 
 void
-abort_transition_graph(int abort_priority, enum transition_action abort_action,
+abort_transition_graph(int abort_priority, enum pcmk__graph_next abort_action,
                        const char *abort_text, xmlNode * reason, const char *fn, int line)
 {
     int add[] = { 0, 0, 0 };

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -15,15 +15,15 @@
 #include <pacemaker-controld.h>
 
 gboolean
-stop_te_timer(crm_action_timer_t * timer)
+stop_te_timer(crm_action_t *action)
 {
-    if (timer == NULL) {
+    if (action == NULL) {
         return FALSE;
     }
-    if (timer->source_id != 0) {
+    if (action->timer != 0) {
         crm_trace("Stopping action timer");
-        g_source_remove(timer->source_id);
-        timer->source_id = 0;
+        g_source_remove(action->timer);
+        action->timer = 0;
     } else {
         crm_trace("Action timer was already stopped");
         return FALSE;

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -55,23 +55,23 @@ te_graph_trigger(gpointer user_data)
     }
 
     if (!transition_graph->complete) {
-        enum transition_status graph_rc;
+        enum pcmk__graph_status graph_rc;
         int limit = transition_graph->batch_limit;
 
         transition_graph->batch_limit = throttle_get_total_job_limit(limit);
         graph_rc = pcmk__execute_graph(transition_graph);
         transition_graph->batch_limit = limit; /* Restore the configured value */
 
-        if (graph_rc == transition_active) {
+        if (graph_rc == pcmk__graph_active) {
             crm_trace("Transition not yet complete");
             return TRUE;
 
-        } else if (graph_rc == transition_pending) {
+        } else if (graph_rc == pcmk__graph_pending) {
             crm_trace("Transition not yet complete - no actions fired");
             return TRUE;
         }
 
-        if (graph_rc != transition_complete) {
+        if (graph_rc != pcmk__graph_complete) {
             crm_warn("Transition failed: %s",
                      pcmk__graph_status2text(graph_rc));
             pcmk__log_graph(LOG_NOTICE, transition_graph);

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -15,7 +15,7 @@
 #include <pacemaker-controld.h>
 
 gboolean
-stop_te_timer(crm_action_t *action)
+stop_te_timer(pcmk__graph_action_t *action)
 {
     if (action == NULL) {
         return FALSE;

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -54,7 +54,7 @@ te_graph_trigger(gpointer user_data)
             break;
     }
 
-    if (transition_graph->complete == FALSE) {
+    if (!transition_graph->complete) {
         enum transition_status graph_rc;
         int limit = transition_graph->batch_limit;
 
@@ -79,7 +79,7 @@ te_graph_trigger(gpointer user_data)
     }
 
     crm_debug("Transition %d is now complete", transition_graph->id);
-    transition_graph->complete = TRUE;
+    transition_graph->complete = true;
     notify_crmd(transition_graph);
 
     return TRUE;
@@ -198,8 +198,9 @@ abort_transition_graph(int abort_priority, enum transition_action abort_action,
         case S_ILLEGAL:
         case S_STOPPING:
         case S_TERMINATE:
-            crm_info("Abort %s suppressed: state=%s (complete=%d)",
-                     abort_text, fsa_state2string(fsa_state), transition_graph->complete);
+            crm_info("Abort %s suppressed: state=%s (%scomplete)",
+                     abort_text, fsa_state2string(fsa_state),
+                     (transition_graph->complete? "" : "in"));
             return;
         default:
             break;
@@ -208,7 +209,7 @@ abort_transition_graph(int abort_priority, enum transition_action abort_action,
     abort_timer.aborted = TRUE;
     controld_expect_sched_reply(NULL);
 
-    if (transition_graph->complete == FALSE) {
+    if (!transition_graph->complete) {
         if(update_abort_priority(transition_graph, abort_priority, abort_action, abort_text)) {
             level = LOG_NOTICE;
         }

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -149,7 +149,7 @@ abort2text(enum transition_action abort_action)
 }
 
 static bool
-update_abort_priority(crm_graph_t *graph, int priority,
+update_abort_priority(pcmk__graph_t *graph, int priority,
                       enum transition_action action, const char *abort_reason)
 {
     bool change = FALSE;

--- a/daemons/controld/controld_transition.c
+++ b/daemons/controld/controld_transition.c
@@ -22,10 +22,10 @@ global_cib_callback(const xmlNode * msg, int callid, int rc, xmlNode * output)
 {
 }
 
-static crm_graph_t *
+static pcmk__graph_t *
 create_blank_graph(void)
 {
-    crm_graph_t *a_graph = pcmk__unpack_graph(NULL, NULL);
+    pcmk__graph_t *a_graph = pcmk__unpack_graph(NULL, NULL);
 
     a_graph->complete = TRUE;
     a_graph->abort_reason = "DC Takeover";

--- a/daemons/controld/controld_transition.c
+++ b/daemons/controld/controld_transition.c
@@ -27,7 +27,7 @@ create_blank_graph(void)
 {
     pcmk__graph_t *a_graph = pcmk__unpack_graph(NULL, NULL);
 
-    a_graph->complete = TRUE;
+    a_graph->complete = true;
     a_graph->abort_reason = "DC Takeover";
     a_graph->completion_action = tg_restart;
     return a_graph;
@@ -127,13 +127,13 @@ do_te_invoke(long long action,
         crm_debug("Cancelling the transition: %s",
                   transition_graph->complete ? "inactive" : "active");
         abort_transition(INFINITY, tg_restart, "Peer Cancelled", NULL);
-        if (transition_graph->complete == FALSE) {
+        if (!transition_graph->complete) {
             crmd_fsa_stall(FALSE);
         }
 
     } else if (action & A_TE_HALT) {
         abort_transition(INFINITY, tg_stop, "Peer Halt", NULL);
-        if (transition_graph->complete == FALSE) {
+        if (!transition_graph->complete) {
             crmd_fsa_stall(FALSE);
         }
 
@@ -151,7 +151,7 @@ do_te_invoke(long long action,
             return;
         }
 
-        if (transition_graph->complete == FALSE) {
+        if (!transition_graph->complete) {
             crm_info("Another transition is already active");
             abort_transition(INFINITY, tg_restart, "Transition Active", NULL);
             return;

--- a/daemons/controld/controld_transition.c
+++ b/daemons/controld/controld_transition.c
@@ -15,7 +15,7 @@
 
 #include <pacemaker-controld.h>
 
-extern crm_graph_functions_t te_graph_fns;
+extern pcmk__graph_functions_t te_graph_fns;
 
 static void
 global_cib_callback(const xmlNode * msg, int callid, int rc, xmlNode * output)

--- a/daemons/controld/controld_transition.c
+++ b/daemons/controld/controld_transition.c
@@ -29,7 +29,7 @@ create_blank_graph(void)
 
     a_graph->complete = true;
     a_graph->abort_reason = "DC Takeover";
-    a_graph->completion_action = tg_restart;
+    a_graph->completion_action = pcmk__graph_restart;
     return a_graph;
 }
 
@@ -126,13 +126,13 @@ do_te_invoke(long long action,
     if (action & A_TE_CANCEL) {
         crm_debug("Cancelling the transition: %s",
                   transition_graph->complete ? "inactive" : "active");
-        abort_transition(INFINITY, tg_restart, "Peer Cancelled", NULL);
+        abort_transition(INFINITY, pcmk__graph_restart, "Peer Cancelled", NULL);
         if (!transition_graph->complete) {
             crmd_fsa_stall(FALSE);
         }
 
     } else if (action & A_TE_HALT) {
-        abort_transition(INFINITY, tg_stop, "Peer Halt", NULL);
+        abort_transition(INFINITY, pcmk__graph_wait, "Peer Halt", NULL);
         if (!transition_graph->complete) {
             crmd_fsa_stall(FALSE);
         }
@@ -153,14 +153,16 @@ do_te_invoke(long long action,
 
         if (!transition_graph->complete) {
             crm_info("Another transition is already active");
-            abort_transition(INFINITY, tg_restart, "Transition Active", NULL);
+            abort_transition(INFINITY, pcmk__graph_restart, "Transition Active",
+                             NULL);
             return;
         }
 
         if (fsa_pe_ref == NULL || !pcmk__str_eq(fsa_pe_ref, ref, pcmk__str_casei)) {
             crm_info("Transition is redundant: %s vs. %s",
                      pcmk__s(fsa_pe_ref, "<null>"), pcmk__s(ref, "<null>"));
-            abort_transition(INFINITY, tg_restart, "Transition Redundant", NULL);
+            abort_transition(INFINITY, pcmk__graph_restart,
+                             "Transition Redundant", NULL);
         }
 
         graph_data = input->xml;

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -19,7 +19,7 @@ pcmk__graph_action_t *get_cancel_action(const char *id, const char *node);
 bool confirm_cancel_action(const char *id, const char *node_id);
 
 void controld_record_action_timeout(pcmk__graph_action_t *action);
-extern gboolean fail_incompletable_actions(crm_graph_t * graph, const char *down_node);
+gboolean fail_incompletable_actions(pcmk__graph_t *graph, const char *down_node);
 void process_graph_event(xmlNode *event, const char *event_node);
 
 /* utils */
@@ -30,12 +30,12 @@ const char *get_rsc_state(const char *task, enum pcmk_exec_status status);
 /* unpack */
 extern gboolean process_te_message(xmlNode * msg, xmlNode * xml_data);
 
-extern crm_graph_t *transition_graph;
+extern pcmk__graph_t *transition_graph;
 extern crm_trigger_t *transition_trigger;
 
 extern char *te_uuid;
 
-extern void notify_crmd(crm_graph_t * graph);
+void notify_crmd(pcmk__graph_t * graph);
 
 void cib_action_updated(xmlNode *msg, int call_id, int rc, xmlNode *output,
                         void *user_data);
@@ -59,7 +59,7 @@ extern crm_trigger_t *transition_trigger;
 extern char *failed_stop_offset;
 extern char *failed_start_offset;
 
-void te_action_confirmed(pcmk__graph_action_t *action, crm_graph_t *graph);
+void te_action_confirmed(pcmk__graph_action_t *action, pcmk__graph_t *graph);
 void te_reset_job_counts(void);
 
 #endif

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -14,17 +14,17 @@
 #  include <pacemaker-internal.h>
 
 /* tengine */
-extern crm_action_t *match_down_event(const char *target);
-extern crm_action_t *get_cancel_action(const char *id, const char *node);
+pcmk__graph_action_t *match_down_event(const char *target);
+pcmk__graph_action_t *get_cancel_action(const char *id, const char *node);
 bool confirm_cancel_action(const char *id, const char *node_id);
 
-void controld_record_action_timeout(crm_action_t *action);
+void controld_record_action_timeout(pcmk__graph_action_t *action);
 extern gboolean fail_incompletable_actions(crm_graph_t * graph, const char *down_node);
 void process_graph_event(xmlNode *event, const char *event_node);
 
 /* utils */
-crm_action_t *controld_get_action(int id);
-gboolean stop_te_timer(crm_action_t *action);
+pcmk__graph_action_t *controld_get_action(int id);
+gboolean stop_te_timer(pcmk__graph_action_t *action);
 const char *get_rsc_state(const char *task, enum pcmk_exec_status status);
 
 /* unpack */
@@ -59,7 +59,7 @@ extern crm_trigger_t *transition_trigger;
 extern char *failed_stop_offset;
 extern char *failed_start_offset;
 
-void te_action_confirmed(crm_action_t *action, crm_graph_t *graph);
+void te_action_confirmed(pcmk__graph_action_t *action, crm_graph_t *graph);
 void te_reset_job_counts(void);
 
 #endif

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -44,11 +44,12 @@ gboolean te_graph_trigger(gpointer user_data);
 void te_update_diff(const char *event, xmlNode *msg);
 
 extern void trigger_graph_processing(const char *fn, int line);
-void abort_after_delay(int abort_priority, enum transition_action abort_action,
+void abort_after_delay(int abort_priority, enum pcmk__graph_next abort_action,
                        const char *abort_text, guint delay_ms);
-extern void abort_transition_graph(int abort_priority, enum transition_action abort_action,
-                                   const char *abort_text, xmlNode * reason, const char *fn,
-                                   int line);
+void abort_transition_graph(int abort_priority,
+                            enum pcmk__graph_next abort_action,
+                            const char *abort_text, xmlNode *reason,
+                            const char *fn, int line);
 
 #  define trigger_graph()	trigger_graph_processing(__func__, __LINE__)
 #  define abort_transition(pri, action, text, reason)			\

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -24,7 +24,7 @@ void process_graph_event(xmlNode *event, const char *event_node);
 
 /* utils */
 crm_action_t *controld_get_action(int id);
-extern gboolean stop_te_timer(crm_action_timer_t * timer);
+gboolean stop_te_timer(crm_action_t *action);
 const char *get_rsc_state(const char *task, enum pcmk_exec_status status);
 
 /* unpack */

--- a/include/pcmki/pcmki_sched_utils.h
+++ b/include/pcmki/pcmki_sched_utils.h
@@ -39,6 +39,4 @@ xmlNode *pcmk__create_history_xml(xmlNode *parent, lrmd_event_data_t *event,
                                  const char *caller_version, int target_rc,
                                  const char *node, const char *origin);
 
-#  define LOAD_STOPPED "load_stopped"
-
 #endif

--- a/include/pcmki/pcmki_sched_utils.h
+++ b/include/pcmki/pcmki_sched_utils.h
@@ -22,10 +22,6 @@
 #include <pacemaker.h>
 
 /* Constraint helper functions */
-pcmk__colocation_t *invert_constraint(pcmk__colocation_t *constraint);
-
-pe__location_t *copy_constraint(pe__location_t *constraint);
-
 GList *pcmk__copy_node_list(const GList *list, bool reset);
 
 pe_resource_t *find_compatible_child(pe_resource_t *local_child,

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -45,30 +45,4 @@ void pcmk__unpack_constraints(pe_working_set_t *data_set);
 void pcmk__schedule_actions(xmlNode *cib, unsigned long long flags,
                             pe_working_set_t *data_set);
 
-/*!
- * \internal
- * \brief Check whether colocation's left-hand preferences should be considered
- *
- * \param[in] colocation  Colocation constraint
- * \param[in] rsc         Right-hand instance (normally this will be
- *                        colocation->primary, which NULL will be treated as,
- *                        but for clones or bundles with multiple instances
- *                        this can be a particular instance)
- *
- * \return true if colocation influence should be effective, otherwise false
- */
-static inline bool
-pcmk__colocation_has_influence(const pcmk__colocation_t *colocation,
-                               const pe_resource_t *rsc)
-{
-    if (rsc == NULL) {
-        rsc = colocation->primary;
-    }
-
-    /* The left hand of a colocation influences the right hand's location
-     * if the influence option is true, or the right hand is not yet active.
-     */
-    return colocation->influence || (rsc->running_on == NULL);
-}
-
 #endif

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -10,8 +10,6 @@
 #ifndef PCMK__PCMKI_PCMKI_SCHEDULER__H
 #  define PCMK__PCMKI_PCMKI_SCHEDULER__H
 
-typedef struct rsc_ticket_s rsc_ticket_t;
-
 #  include <glib.h>
 #  include <crm/crm.h>
 #  include <crm/common/iso8601.h>
@@ -41,22 +39,6 @@ typedef struct {
     int score;
     bool influence; // Whether dependent influences active primary placement
 } pcmk__colocation_t;
-
-enum loss_ticket_policy_e {
-    loss_ticket_stop,
-    loss_ticket_demote,
-    loss_ticket_fence,
-    loss_ticket_freeze
-};
-
-struct rsc_ticket_s {
-    const char *id;
-    pe_resource_t *rsc_lh;
-    pe_ticket_t *ticket;
-    enum loss_ticket_policy_e loss_policy;
-
-    int role_lh;
-};
 
 void pcmk__unpack_constraints(pe_working_set_t *data_set);
 

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -64,8 +64,6 @@ extern void add_maintenance_update(pe_working_set_t *data_set);
 void pcmk__schedule_actions(xmlNode *cib, unsigned long long flags,
                             pe_working_set_t *data_set);
 
-extern const char *transition_idle_timeout;
-
 /*!
  * \internal
  * \brief Check whether colocation's left-hand preferences should be considered

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -42,7 +42,6 @@ typedef struct {
 
 void pcmk__unpack_constraints(pe_working_set_t *data_set);
 
-extern void add_maintenance_update(pe_working_set_t *data_set);
 void pcmk__schedule_actions(xmlNode *cib, unsigned long long flags,
                             pe_working_set_t *data_set);
 

--- a/include/pcmki/pcmki_simulate.h
+++ b/include/pcmki/pcmki_simulate.h
@@ -46,9 +46,9 @@ void pcmk__profile_dir(const char *dir, long long repeat, pe_working_set_t *data
  *
  * \return Transition status after simulated execution
  */
-enum transition_status pcmk__simulate_transition(pe_working_set_t *data_set,
-                                                 cib_t *cib,
-                                                 GList *op_fail_list);
+enum pcmk__graph_status pcmk__simulate_transition(pe_working_set_t *data_set,
+                                                  cib_t *cib,
+                                                  GList *op_fail_list);
 
 /**
  * \internal

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -40,8 +40,8 @@ typedef struct synapse_s {
 
     uint32_t flags; // Group of pcmk__synapse_flags
 
-    GList *actions;           /* crm_action_t* */
-    GList *inputs;            /* crm_action_t* */
+    GList *actions;           /* pcmk__graph_action_t* */
+    GList *inputs;            /* pcmk__graph_action_t* */
 } synapse_t;
 
 const char *synapse_state_str(synapse_t *synapse);
@@ -81,7 +81,7 @@ typedef struct crm_action_s {
 
     xmlNode *xml;
 
-} crm_action_t;
+} pcmk__graph_action_t;
 
 #define crm__set_graph_action_flags(action, flags_to_set) do {             \
         (action)->flags = pcmk__set_flags_as(__func__, __LINE__,      \
@@ -133,11 +133,11 @@ struct crm_graph_s {
 };
 
 typedef struct crm_graph_functions_s {
-    gboolean(*pseudo) (crm_graph_t * graph, crm_action_t * action);
-    gboolean(*rsc) (crm_graph_t * graph, crm_action_t * action);
-    gboolean(*crmd) (crm_graph_t * graph, crm_action_t * action);
-    gboolean(*stonith) (crm_graph_t * graph, crm_action_t * action);
-    gboolean(*allowed) (crm_graph_t * graph, crm_action_t * action);
+    gboolean (*pseudo) (crm_graph_t * graph, pcmk__graph_action_t *action);
+    gboolean (*rsc) (crm_graph_t * graph, pcmk__graph_action_t *action);
+    gboolean (*crmd) (crm_graph_t * graph, pcmk__graph_action_t *action);
+    gboolean (*stonith) (crm_graph_t * graph, pcmk__graph_action_t *action);
+    gboolean (*allowed) (crm_graph_t * graph, pcmk__graph_action_t *action);
 } crm_graph_functions_t;
 
 enum transition_status {
@@ -150,13 +150,13 @@ enum transition_status {
 void pcmk__set_graph_functions(crm_graph_functions_t *fns);
 crm_graph_t *pcmk__unpack_graph(xmlNode *xml_graph, const char *reference);
 enum transition_status pcmk__execute_graph(crm_graph_t *graph);
-void pcmk__update_graph(crm_graph_t *graph, crm_action_t *action);
+void pcmk__update_graph(crm_graph_t *graph, pcmk__graph_action_t *action);
 void pcmk__free_graph(crm_graph_t *graph);
 const char *pcmk__graph_status2text(enum transition_status state);
 void pcmk__log_graph(unsigned int log_level, crm_graph_t *graph);
-void pcmk__log_graph_action(int log_level, crm_action_t *action);
+void pcmk__log_graph_action(int log_level, pcmk__graph_action_t *action);
 lrmd_event_data_t *pcmk__event_from_graph_action(xmlNode *resource,
-                                                 crm_action_t *action,
+                                                 pcmk__graph_action_t *action,
                                                  int status, int rc,
                                                  const char *exit_reason);
 

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -137,19 +137,19 @@ typedef struct {
     bool (*allowed) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
 } pcmk__graph_functions_t;
 
-enum transition_status {
-    transition_active,
-    transition_pending,         /* active but no actions performed this time */
-    transition_complete,
-    transition_terminated,
+enum pcmk__graph_status {
+    pcmk__graph_active,     // Some actions have been performed
+    pcmk__graph_pending,    // No actions performed yet
+    pcmk__graph_complete,
+    pcmk__graph_terminated,
 };
 
 void pcmk__set_graph_functions(pcmk__graph_functions_t *fns);
 pcmk__graph_t *pcmk__unpack_graph(xmlNode *xml_graph, const char *reference);
-enum transition_status pcmk__execute_graph(pcmk__graph_t *graph);
+enum pcmk__graph_status pcmk__execute_graph(pcmk__graph_t *graph);
 void pcmk__update_graph(pcmk__graph_t *graph, pcmk__graph_action_t *action);
 void pcmk__free_graph(pcmk__graph_t *graph);
-const char *pcmk__graph_status2text(enum transition_status state);
+const char *pcmk__graph_status2text(enum pcmk__graph_status state);
 void pcmk__log_graph(unsigned int log_level, pcmk__graph_t *graph);
 void pcmk__log_graph_action(int log_level, pcmk__graph_action_t *action);
 lrmd_event_data_t *pcmk__event_from_graph_action(xmlNode *resource,

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -79,14 +79,14 @@ typedef struct {
 
 } pcmk__graph_action_t;
 
-#define crm__set_graph_action_flags(action, flags_to_set) do {             \
+#define pcmk__set_graph_action_flags(action, flags_to_set) do {       \
         (action)->flags = pcmk__set_flags_as(__func__, __LINE__,      \
             LOG_TRACE,                                                \
             "Action", "action",                                       \
             (action)->flags, (flags_to_set), #flags_to_set);          \
     } while (0)
 
-#define crm__clear_graph_action_flags(action, flags_to_clear) do {         \
+#define pcmk__clear_graph_action_flags(action, flags_to_clear) do {   \
         (action)->flags = pcmk__clear_flags_as(__func__, __LINE__,    \
             LOG_TRACE,                                                \
             "Action", "action",                                       \

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -134,7 +134,7 @@ typedef struct {
     int (*rsc) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     int (*cluster) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     int (*fence) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
-    gboolean (*allowed) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
+    bool (*allowed) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
 } pcmk__graph_functions_t;
 
 enum transition_status {

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -25,7 +25,6 @@ enum pcmk__graph_action_type {
     pcmk__cluster_graph_action,
 };
 
-typedef struct te_timer_s crm_action_timer_t;
 typedef struct crm_graph_s crm_graph_t;
 
 enum pcmk__synapse_flags {
@@ -72,11 +71,10 @@ enum pcmk__graph_action_flags {
 typedef struct crm_action_s {
     int id;
     int timeout;
+    int timer;
     guint interval_ms;
     GHashTable *params;
     enum pcmk__graph_action_type type;
-
-    crm_action_timer_t *timer;
     synapse_t *synapse;
 
     uint32_t flags; // Group of pcmk__graph_action_flags
@@ -98,12 +96,6 @@ typedef struct crm_action_s {
             "Action", "action",                                       \
             (action)->flags, (flags_to_clear), #flags_to_clear);      \
     } while (0)
-
-struct te_timer_s {
-    int source_id;
-    int timeout;
-    crm_action_t *action;
-};
 
 /* order matters here */
 enum transition_action {

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -42,8 +42,6 @@ typedef struct {
     GList *inputs;            /* pcmk__graph_action_t* */
 } pcmk__graph_synapse_t;
 
-const char *synapse_state_str(pcmk__graph_synapse_t *synapse);
-
 #define pcmk__set_synapse_flags(synapse, flags_to_set) do {             \
         (synapse)->flags = pcmk__set_flags_as(__func__, __LINE__,       \
             LOG_TRACE,                                                  \

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -93,12 +93,13 @@ typedef struct {
             (action)->flags, (flags_to_clear), #flags_to_clear);      \
     } while (0)
 
-/* order matters here */
-enum transition_action {
-    tg_done,
-    tg_stop,
-    tg_restart,
-    tg_shutdown,
+// What to do after finished processing a transition graph
+enum pcmk__graph_next {
+    // Order matters: lowest priority to highest
+    pcmk__graph_done,       // Transition complete, nothing further needed
+    pcmk__graph_wait,       // Transition interrupted, wait for further changes
+    pcmk__graph_restart,    // Transition interrupted, start a new one
+    pcmk__graph_shutdown,   // Transition interrupted, local shutdown needed
 };
 
 typedef struct {
@@ -108,7 +109,7 @@ typedef struct {
 
     bool complete;
     const char *abort_reason;
-    enum transition_action completion_action;
+    enum pcmk__graph_next completion_action;
 
     int num_actions;
     int num_synapses;

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -133,7 +133,7 @@ typedef struct {
     int (*pseudo) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     int (*rsc) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     int (*cluster) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
-    gboolean (*stonith) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
+    int (*fence) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*allowed) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
 } pcmk__graph_functions_t;
 

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -32,7 +32,7 @@ enum pcmk__synapse_flags {
     pcmk__synapse_confirmed   = (1 << 3),
 };
 
-typedef struct synapse_s {
+typedef struct {
     int id;
     int priority;
 
@@ -40,9 +40,9 @@ typedef struct synapse_s {
 
     GList *actions;           /* pcmk__graph_action_t* */
     GList *inputs;            /* pcmk__graph_action_t* */
-} synapse_t;
+} pcmk__graph_synapse_t;
 
-const char *synapse_state_str(synapse_t *synapse);
+const char *synapse_state_str(pcmk__graph_synapse_t *synapse);
 
 #define pcmk__set_synapse_flags(synapse, flags_to_set) do {             \
         (synapse)->flags = pcmk__set_flags_as(__func__, __LINE__,       \
@@ -73,7 +73,7 @@ typedef struct {
     guint interval_ms;
     GHashTable *params;
     enum pcmk__graph_action_type type;
-    synapse_t *synapse;
+    pcmk__graph_synapse_t *synapse;
 
     uint32_t flags; // Group of pcmk__graph_action_flags
 
@@ -125,7 +125,7 @@ typedef struct {
     int completed;
     int incomplete;
 
-    GList *synapses;          /* synapse_t* */
+    GList *synapses;          /* pcmk__graph_synapse_t* */
 
     int migration_limit;
 } pcmk__graph_t;

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -129,13 +129,13 @@ typedef struct {
 } pcmk__graph_t;
 
 
-typedef struct crm_graph_functions_s {
+typedef struct {
     gboolean (*pseudo) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*rsc) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*crmd) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*stonith) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*allowed) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
-} crm_graph_functions_t;
+} pcmk__graph_functions_t;
 
 enum transition_status {
     transition_active,
@@ -144,7 +144,7 @@ enum transition_status {
     transition_terminated,
 };
 
-void pcmk__set_graph_functions(crm_graph_functions_t *fns);
+void pcmk__set_graph_functions(pcmk__graph_functions_t *fns);
 pcmk__graph_t *pcmk__unpack_graph(xmlNode *xml_graph, const char *reference);
 enum transition_status pcmk__execute_graph(pcmk__graph_t *graph);
 void pcmk__update_graph(pcmk__graph_t *graph, pcmk__graph_action_t *action);

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -106,7 +106,7 @@ typedef struct {
     char *source;
     int abort_priority;
 
-    gboolean complete;
+    bool complete;
     const char *abort_reason;
     enum transition_action completion_action;
 

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -19,11 +19,11 @@
 extern "C" {
 #endif
 
-typedef enum {
-    action_type_pseudo,
-    action_type_rsc,
-    action_type_crm
-} action_type_e;
+enum pcmk__graph_action_type {
+    pcmk__pseudo_graph_action,
+    pcmk__rsc_graph_action,
+    pcmk__cluster_graph_action,
+};
 
 typedef struct te_timer_s crm_action_timer_t;
 typedef struct crm_graph_s crm_graph_t;
@@ -74,7 +74,7 @@ typedef struct crm_action_s {
     int timeout;
     guint interval_ms;
     GHashTable *params;
-    action_type_e type;
+    enum pcmk__graph_action_type type;
 
     crm_action_timer_t *timer;
     synapse_t *synapse;

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -132,7 +132,7 @@ typedef struct {
 typedef struct {
     int (*pseudo) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     int (*rsc) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
-    gboolean (*crmd) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
+    int (*cluster) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*stonith) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*allowed) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
 } pcmk__graph_functions_t;

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -131,7 +131,7 @@ typedef struct {
 
 typedef struct {
     int (*pseudo) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
-    gboolean (*rsc) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
+    int (*rsc) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*crmd) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*stonith) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*allowed) (pcmk__graph_t *graph, pcmk__graph_action_t *action);

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -85,8 +85,6 @@ typedef struct crm_action_s {
 
 } crm_action_t;
 
-const char *action_state_str(crm_action_t *action);
-
 #define crm__set_graph_action_flags(action, flags_to_set) do {             \
         (action)->flags = pcmk__set_flags_as(__func__, __LINE__,      \
             LOG_TRACE,                                                \
@@ -154,10 +152,7 @@ enum transition_status {
     transition_active,
     transition_pending,         /* active but no actions performed this time */
     transition_complete,
-    transition_stopped,
     transition_terminated,
-    transition_action_failed,
-    transition_failed,
 };
 
 void pcmk__set_graph_functions(crm_graph_functions_t *fns);

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -130,7 +130,7 @@ typedef struct {
 
 
 typedef struct {
-    gboolean (*pseudo) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
+    int (*pseudo) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*rsc) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*crmd) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
     gboolean (*stonith) (pcmk__graph_t *graph, pcmk__graph_action_t *action);

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -25,8 +25,6 @@ enum pcmk__graph_action_type {
     pcmk__cluster_graph_action,
 };
 
-typedef struct crm_graph_s crm_graph_t;
-
 enum pcmk__synapse_flags {
     pcmk__synapse_ready       = (1 << 0),
     pcmk__synapse_failed      = (1 << 1),
@@ -68,7 +66,7 @@ enum pcmk__graph_action_flags {
     pcmk__graph_action_can_fail      = (1 << 4),     //! \deprecated Will be removed in a future release
 };
 
-typedef struct crm_action_s {
+typedef struct {
     int id;
     int timeout;
     int timer;
@@ -105,7 +103,7 @@ enum transition_action {
     tg_shutdown,
 };
 
-struct crm_graph_s {
+typedef struct {
     int id;
     char *source;
     int abort_priority;
@@ -130,14 +128,15 @@ struct crm_graph_s {
     GList *synapses;          /* synapse_t* */
 
     int migration_limit;
-};
+} pcmk__graph_t;
+
 
 typedef struct crm_graph_functions_s {
-    gboolean (*pseudo) (crm_graph_t * graph, pcmk__graph_action_t *action);
-    gboolean (*rsc) (crm_graph_t * graph, pcmk__graph_action_t *action);
-    gboolean (*crmd) (crm_graph_t * graph, pcmk__graph_action_t *action);
-    gboolean (*stonith) (crm_graph_t * graph, pcmk__graph_action_t *action);
-    gboolean (*allowed) (crm_graph_t * graph, pcmk__graph_action_t *action);
+    gboolean (*pseudo) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
+    gboolean (*rsc) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
+    gboolean (*crmd) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
+    gboolean (*stonith) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
+    gboolean (*allowed) (pcmk__graph_t *graph, pcmk__graph_action_t *action);
 } crm_graph_functions_t;
 
 enum transition_status {
@@ -148,12 +147,12 @@ enum transition_status {
 };
 
 void pcmk__set_graph_functions(crm_graph_functions_t *fns);
-crm_graph_t *pcmk__unpack_graph(xmlNode *xml_graph, const char *reference);
-enum transition_status pcmk__execute_graph(crm_graph_t *graph);
-void pcmk__update_graph(crm_graph_t *graph, pcmk__graph_action_t *action);
-void pcmk__free_graph(crm_graph_t *graph);
+pcmk__graph_t *pcmk__unpack_graph(xmlNode *xml_graph, const char *reference);
+enum transition_status pcmk__execute_graph(pcmk__graph_t *graph);
+void pcmk__update_graph(pcmk__graph_t *graph, pcmk__graph_action_t *action);
+void pcmk__free_graph(pcmk__graph_t *graph);
 const char *pcmk__graph_status2text(enum transition_status state);
-void pcmk__log_graph(unsigned int log_level, crm_graph_t *graph);
+void pcmk__log_graph(unsigned int log_level, pcmk__graph_t *graph);
 void pcmk__log_graph_action(int log_level, pcmk__graph_action_t *action);
 lrmd_event_data_t *pcmk__event_from_graph_action(xmlNode *resource,
                                                  pcmk__graph_action_t *action,

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -169,6 +169,32 @@ G_GNUC_INTERNAL
 void pcmk__block_colocated_starts(pe_action_t *action,
                                   pe_working_set_t *data_set);
 
+/*!
+ * \internal
+ * \brief Check whether colocation's left-hand preferences should be considered
+ *
+ * \param[in] colocation  Colocation constraint
+ * \param[in] rsc         Right-hand instance (normally this will be
+ *                        colocation->primary, which NULL will be treated as,
+ *                        but for clones or bundles with multiple instances
+ *                        this can be a particular instance)
+ *
+ * \return true if colocation influence should be effective, otherwise false
+ */
+static inline bool
+pcmk__colocation_has_influence(const pcmk__colocation_t *colocation,
+                               const pe_resource_t *rsc)
+{
+    if (rsc == NULL) {
+        rsc = colocation->primary;
+    }
+
+    /* The left hand of a colocation influences the right hand's location
+     * if the influence option is true, or the right hand is not yet active.
+     */
+    return colocation->influence || (rsc->running_on == NULL);
+}
+
 
 // Ordering constraints (pcmk_sched_ordering.c)
 

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -226,6 +226,9 @@ G_GNUC_INTERNAL
 void pcmk__unpack_rsc_ticket(xmlNode *xml_obj, pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
+void pcmk__require_promotion_tickets(pe_resource_t *rsc);
+
+G_GNUC_INTERNAL
 bool pcmk__is_failed_remote_node(pe_node_t *node);
 
 G_GNUC_INTERNAL

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -108,7 +108,7 @@ update_synapse_confirmed(synapse_t *synapse, int action_id)
  * \param[in]     action  Action that completed
  */
 void
-pcmk__update_graph(crm_graph_t *graph, pcmk__graph_action_t *action)
+pcmk__update_graph(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     for (GList *lpc = graph->synapses; lpc != NULL; lpc = lpc->next) {
         synapse_t *synapse = (synapse_t *) lpc->data;
@@ -165,7 +165,7 @@ pcmk__set_graph_functions(crm_graph_functions_t *fns)
  * \return true if synapse is ready, false otherwise
  */
 static bool
-should_fire_synapse(crm_graph_t *graph, synapse_t *synapse)
+should_fire_synapse(pcmk__graph_t *graph, synapse_t *synapse)
 {
     GList *lpc = NULL;
 
@@ -224,7 +224,7 @@ should_fire_synapse(crm_graph_t *graph, synapse_t *synapse)
  * \return Standard Pacemaker return code
  */
 static int
-initiate_action(crm_graph_t *graph, pcmk__graph_action_t *action)
+initiate_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     const char *id = ID(action->xml);
 
@@ -269,7 +269,7 @@ initiate_action(crm_graph_t *graph, pcmk__graph_action_t *action)
  * \return Standard Pacemaker return value
  */
 static int
-fire_synapse(crm_graph_t *graph, synapse_t *synapse)
+fire_synapse(pcmk__graph_t *graph, synapse_t *synapse)
 {
     pcmk__set_synapse_flags(synapse, pcmk__synapse_executed);
     for (GList *lpc = synapse->actions; lpc != NULL; lpc = lpc->next) {
@@ -298,7 +298,7 @@ fire_synapse(crm_graph_t *graph, synapse_t *synapse)
  *                PE_fail environment variable being set to the action ID)
  */
 static gboolean
-pseudo_action_dummy(crm_graph_t * graph, pcmk__graph_action_t *action)
+pseudo_action_dummy(pcmk__graph_t * graph, pcmk__graph_action_t *action)
 {
     static int fail = -1;
 
@@ -341,7 +341,7 @@ static crm_graph_functions_t default_fns = {
  * \return Status of transition after execution
  */
 enum transition_status
-pcmk__execute_graph(crm_graph_t *graph)
+pcmk__execute_graph(pcmk__graph_t *graph)
 {
     GList *lpc = NULL;
     int log_level = LOG_DEBUG;
@@ -557,7 +557,7 @@ unpack_action(synapse_t *parent, xmlNode *xml_action)
  * \return Newly allocated synapse on success, or NULL otherwise
  */
 static synapse_t *
-unpack_synapse(crm_graph_t *new_graph, xmlNode *xml_synapse)
+unpack_synapse(pcmk__graph_t *new_graph, xmlNode *xml_synapse)
 {
     const char *value = NULL;
     xmlNode *action_set = NULL;
@@ -659,14 +659,14 @@ unpack_synapse(crm_graph_t *new_graph, xmlNode *xml_synapse)
            ...
          </transition_graph>
  */
-crm_graph_t *
+pcmk__graph_t *
 pcmk__unpack_graph(xmlNode *xml_graph, const char *reference)
 {
-    crm_graph_t *new_graph = NULL;
+    pcmk__graph_t *new_graph = NULL;
     const char *t_id = NULL;
     const char *time = NULL;
 
-    new_graph = calloc(1, sizeof(crm_graph_t));
+    new_graph = calloc(1, sizeof(pcmk__graph_t));
     if (new_graph == NULL) {
         return NULL;
     }
@@ -783,7 +783,7 @@ free_graph_synapse(gpointer user_data)
  * \param[in] graph  Transition graph to free
  */
 void
-pcmk__free_graph(crm_graph_t *graph)
+pcmk__free_graph(pcmk__graph_t *graph)
 {
     if (graph != NULL) {
         g_list_free_full(graph->synapses, free_graph_synapse);

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -150,7 +150,7 @@ pcmk__set_graph_functions(pcmk__graph_functions_t *fns)
 
     CRM_ASSERT(graph_fns != NULL);
     CRM_ASSERT(graph_fns->rsc != NULL);
-    CRM_ASSERT(graph_fns->crmd != NULL);
+    CRM_ASSERT(graph_fns->cluster != NULL);
     CRM_ASSERT(graph_fns->pseudo != NULL);
     CRM_ASSERT(graph_fns->stonith != NULL);
 }
@@ -249,8 +249,8 @@ initiate_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
                           action->id, id);
                 return graph_fns->stonith(graph, action)? pcmk_rc_ok : pcmk_rc_error;
             }
-            crm_trace("Executing control action %d (%s)", action->id, id);
-            return graph_fns->crmd(graph, action)? pcmk_rc_ok : pcmk_rc_error;
+            crm_trace("Executing cluster action %d (%s)", action->id, id);
+            return graph_fns->cluster(graph, action);
 
         default:
             crm_err("Unsupported graph action type <%s id='%s'> (bug?)",

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -134,7 +134,7 @@ pcmk__update_graph(pcmk__graph_t *graph, pcmk__graph_action_t *action)
  * registers execution functions for each action type, which will be stored
  * here.
  */
-static crm_graph_functions_t *graph_fns = NULL;
+static pcmk__graph_functions_t *graph_fns = NULL;
 
 /*!
  * \internal
@@ -143,7 +143,7 @@ static crm_graph_functions_t *graph_fns = NULL;
  * \param[in]  Execution functions to use
  */
 void
-pcmk__set_graph_functions(crm_graph_functions_t *fns)
+pcmk__set_graph_functions(pcmk__graph_functions_t *fns)
 {
     crm_debug("Setting custom functions for executing transition graphs");
     graph_fns = fns;
@@ -325,7 +325,7 @@ pseudo_action_dummy(pcmk__graph_t * graph, pcmk__graph_action_t *action)
     return TRUE;
 }
 
-static crm_graph_functions_t default_fns = {
+static pcmk__graph_functions_t default_fns = {
     pseudo_action_dummy,
     pseudo_action_dummy,
     pseudo_action_dummy,

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -344,19 +344,19 @@ static pcmk__graph_functions_t default_fns = {
  *
  * \return Status of transition after execution
  */
-enum transition_status
+enum pcmk__graph_status
 pcmk__execute_graph(pcmk__graph_t *graph)
 {
     GList *lpc = NULL;
     int log_level = LOG_DEBUG;
-    enum transition_status pass_result = transition_active;
+    enum pcmk__graph_status pass_result = pcmk__graph_active;
     const char *status = "In progress";
 
     if (graph_fns == NULL) {
         graph_fns = &default_fns;
     }
     if (graph == NULL) {
-        return transition_complete;
+        return pcmk__graph_complete;
     }
 
     graph->fired = 0;
@@ -422,22 +422,22 @@ pcmk__execute_graph(pcmk__graph_t *graph)
 
         if ((graph->incomplete != 0) && (graph->abort_priority <= 0)) {
             log_level = LOG_WARNING;
-            pass_result = transition_terminated;
+            pass_result = pcmk__graph_terminated;
             status = "Terminated";
 
         } else if (graph->skipped != 0) {
             log_level = LOG_NOTICE;
-            pass_result = transition_complete;
+            pass_result = pcmk__graph_complete;
             status = "Stopped";
 
         } else {
             log_level = LOG_NOTICE;
-            pass_result = transition_complete;
+            pass_result = pcmk__graph_complete;
             status = "Complete";
         }
 
     } else if (graph->fired == 0) {
-        pass_result = transition_pending;
+        pass_result = pcmk__graph_pending;
     }
 
     do_crm_log(log_level,

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -416,7 +416,7 @@ pcmk__execute_graph(pcmk__graph_t *graph)
     }
 
     if ((graph->pending == 0) && (graph->fired == 0)) {
-        graph->complete = TRUE;
+        graph->complete = true;
 
         if ((graph->incomplete != 0) && (graph->abort_priority <= 0)) {
             log_level = LOG_WARNING;

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -747,15 +747,14 @@ free_graph_action(gpointer user_data)
 {
     crm_action_t *action = user_data;
 
-    if ((action->timer != NULL) && (action->timer->source_id != 0)) {
+    if (action->timer != 0) {
         crm_warn("Cancelling timer for graph action %d", action->id);
-        g_source_remove(action->timer->source_id);
+        g_source_remove(action->timer);
     }
     if (action->params != NULL) {
         g_hash_table_destroy(action->params);
     }
     free_xml(action->xml);
-    free(action->timer);
     free(action);
 }
 

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -236,7 +236,7 @@ initiate_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     switch (action->type) {
         case pcmk__pseudo_graph_action:
             crm_trace("Executing pseudo-action %d (%s)", action->id, id);
-            return graph_fns->pseudo(graph, action)? pcmk_rc_ok : pcmk_rc_error;
+            return graph_fns->pseudo(graph, action);
 
         case pcmk__rsc_graph_action:
             crm_trace("Executing resource action %d (%s)", action->id, id);
@@ -293,13 +293,13 @@ fire_synapse(pcmk__graph_t *graph, pcmk__graph_synapse_t *synapse)
  * \brief Dummy graph method that can be used with simulations
  *
  * \param[in] graph   Transition graph containing action
- * \param[in] action  Action to be initiated
+ * \param[in] action  Graph action to be initiated
  *
- * \retval TRUE   Action initiation was (simulated to be) successful
- * \retval FALSE  Action initiation was (simulated to be) failed (due to the
- *                PE_fail environment variable being set to the action ID)
+ * \return Standard Pacemaker return code
+ * \note If the PE_fail environment variable is set to the action ID,
+ *       then the graph action will be marked as failed.
  */
-static gboolean
+static int
 pseudo_action_dummy(pcmk__graph_t * graph, pcmk__graph_action_t *action)
 {
     static int fail = -1;
@@ -324,7 +324,7 @@ pseudo_action_dummy(pcmk__graph_t * graph, pcmk__graph_action_t *action)
     }
     pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);
     pcmk__update_graph(graph, action);
-    return TRUE;
+    return pcmk_rc_ok;
 }
 
 static pcmk__graph_functions_t default_fns = {

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -685,7 +685,7 @@ pcmk__unpack_graph(xmlNode *xml_graph, const char *reference)
     new_graph->abort_priority = 0;
     new_graph->network_delay = 0;
     new_graph->stonith_timeout = 0;
-    new_graph->completion_action = tg_done;
+    new_graph->completion_action = pcmk__graph_done;
 
     // Parse top-level attributes from <transition_graph>
     if (xml_graph != NULL) {

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -240,7 +240,7 @@ initiate_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 
         case pcmk__rsc_graph_action:
             crm_trace("Executing resource action %d (%s)", action->id, id);
-            return graph_fns->rsc(graph, action)? pcmk_rc_ok : pcmk_rc_error;
+            return graph_fns->rsc(graph, action);
 
         case pcmk__cluster_graph_action:
             if (pcmk__str_eq(crm_element_value(action->xml, XML_LRM_ATTR_TASK),

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -54,7 +54,7 @@ update_synapse_ready(pcmk__graph_synapse_t *synapse, int action_id)
         if (prereq->id == action_id) {
             crm_trace("Confirming input %d of synapse %d",
                       action_id, synapse->id);
-            crm__set_graph_action_flags(prereq, pcmk__graph_action_confirmed);
+            pcmk__set_graph_action_flags(prereq, pcmk__graph_action_confirmed);
 
         } else if (!(pcmk_is_set(prereq->flags, pcmk__graph_action_confirmed))) {
             pcmk__clear_synapse_flags(synapse, pcmk__synapse_ready);
@@ -85,7 +85,7 @@ update_synapse_confirmed(pcmk__graph_synapse_t *synapse, int action_id)
         if (action->id == action_id) {
             crm_trace("Confirmed action %d of synapse %d",
                       action_id, synapse->id);
-            crm__set_graph_action_flags(action, pcmk__graph_action_confirmed);
+            pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);
 
         } else if (all_confirmed && !(pcmk_is_set(action->flags, pcmk__graph_action_confirmed))) {
             all_confirmed = false;
@@ -232,7 +232,7 @@ initiate_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     CRM_CHECK(!pcmk_is_set(action->flags, pcmk__graph_action_executed),
               return pcmk_rc_already);
 
-    crm__set_graph_action_flags(action, pcmk__graph_action_executed);
+    pcmk__set_graph_action_flags(action, pcmk__graph_action_executed);
     switch (action->type) {
         case pcmk__pseudo_graph_action:
             crm_trace("Executing pseudo-action %d (%s)", action->id, id);
@@ -279,7 +279,9 @@ fire_synapse(pcmk__graph_t *graph, pcmk__graph_synapse_t *synapse)
             crm_err("Failed initiating <%s id=%d> in synapse %d",
                     crm_element_name(action->xml), action->id, synapse->id);
             pcmk__set_synapse_flags(synapse, pcmk__synapse_confirmed);
-            crm__set_graph_action_flags(action, pcmk__graph_action_confirmed | pcmk__graph_action_failed);
+            pcmk__set_graph_action_flags(action,
+                                         pcmk__graph_action_confirmed
+                                         |pcmk__graph_action_failed);
             return pcmk_rc_error;
         }
     }
@@ -315,12 +317,12 @@ pseudo_action_dummy(pcmk__graph_t * graph, pcmk__graph_action_t *action)
 
     if (action->id == fail) {
         crm_err("Dummy event handler: pretending action %d failed", action->id);
-        crm__set_graph_action_flags(action, pcmk__graph_action_failed);
+        pcmk__set_graph_action_flags(action, pcmk__graph_action_failed);
         graph->abort_priority = INFINITY;
     } else {
         crm_trace("Dummy event handler: action %d initiated", action->id);
     }
-    crm__set_graph_action_flags(action, pcmk__graph_action_confirmed);
+    pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);
     pcmk__update_graph(graph, action);
     return TRUE;
 }
@@ -529,9 +531,9 @@ unpack_action(pcmk__graph_synapse_t *parent, xmlNode *xml_action)
         gboolean can_fail = FALSE;
         crm_str_to_boolean(value, &can_fail);
         if (can_fail) {
-            crm__set_graph_action_flags(action, pcmk__graph_action_can_fail);
+            pcmk__set_graph_action_flags(action, pcmk__graph_action_can_fail);
         } else {
-            crm__clear_graph_action_flags(action, pcmk__graph_action_can_fail);
+            pcmk__clear_graph_action_flags(action, pcmk__graph_action_can_fail);
         }
 
 #ifndef PCMK__COMPAT_2_0

--- a/lib/pacemaker/pcmk_graph_logging.c
+++ b/lib/pacemaker/pcmk_graph_logging.c
@@ -16,23 +16,23 @@
 
 /*!
  * \internal
- * \brief Return text equivalent of an enum transition_status for logging
+ * \brief Return text equivalent of an enum pcmk__graph_status for logging
  *
  * \param[in] state  Transition status
  *
  * \return Human-readable text equivalent of \p state
  */
 const char *
-pcmk__graph_status2text(enum transition_status state)
+pcmk__graph_status2text(enum pcmk__graph_status state)
 {
     switch (state) {
-        case transition_active:
+        case pcmk__graph_active:
             return "active";
-        case transition_pending:
+        case pcmk__graph_pending:
             return "pending";
-        case transition_complete:
+        case pcmk__graph_complete:
             return "complete";
-        case transition_terminated:
+        case pcmk__graph_terminated:
             return "terminated";
     }
     return "unknown";

--- a/lib/pacemaker/pcmk_graph_logging.c
+++ b/lib/pacemaker/pcmk_graph_logging.c
@@ -32,14 +32,8 @@ pcmk__graph_status2text(enum transition_status state)
             return "pending";
         case transition_complete:
             return "complete";
-        case transition_stopped:
-            return "stopped";
         case transition_terminated:
             return "terminated";
-        case transition_action_failed:
-            return "failed (action)";
-        case transition_failed:
-            return "failed";
     }
     return "unknown";
 }

--- a/lib/pacemaker/pcmk_graph_logging.c
+++ b/lib/pacemaker/pcmk_graph_logging.c
@@ -61,7 +61,7 @@ actiontype2text(enum pcmk__graph_action_type type)
  *
  * \return Transition graph action corresponding to \p id, or NULL if none
  */
-static crm_action_t *
+static pcmk__graph_action_t *
 find_graph_action_by_id(crm_graph_t *graph, int id)
 {
     if (graph == NULL) {
@@ -74,7 +74,7 @@ find_graph_action_by_id(crm_graph_t *graph, int id)
         for (GList *aIter = synapse->actions; aIter != NULL;
              aIter = aIter->next) {
 
-            crm_action_t *action = (crm_action_t *) aIter->data;
+            pcmk__graph_action_t *action = (pcmk__graph_action_t *) aIter->data;
 
             if (action->id == id) {
                 return action;
@@ -110,7 +110,7 @@ synapse_pending_inputs(crm_graph_t *graph, synapse_t *synapse)
     size_t pending_len = 0;
 
     for (GList *lpc = synapse->inputs; lpc != NULL; lpc = lpc->next) {
-        crm_action_t *input = (crm_action_t *) lpc->data;
+        pcmk__graph_action_t *input = (pcmk__graph_action_t *) lpc->data;
 
         if (pcmk_is_set(input->flags, pcmk__graph_action_failed)) {
             pcmk__add_word(&pending, &pending_len, ID(input->xml));
@@ -135,7 +135,7 @@ log_unresolved_inputs(unsigned int log_level, crm_graph_t *graph,
                       synapse_t *synapse)
 {
     for (GList *lpc = synapse->inputs; lpc != NULL; lpc = lpc->next) {
-        crm_action_t *input = (crm_action_t *) lpc->data;
+        pcmk__graph_action_t *input = (pcmk__graph_action_t *) lpc->data;
         const char *key = crm_element_value(input->xml, XML_LRM_ATTR_TASK_KEY);
         const char *host = crm_element_value(input->xml, XML_LRM_ATTR_TARGET);
 
@@ -150,7 +150,7 @@ log_unresolved_inputs(unsigned int log_level, crm_graph_t *graph,
 
 static void
 log_synapse_action(unsigned int log_level, synapse_t *synapse,
-                   crm_action_t *action, const char *pending_inputs)
+                   pcmk__graph_action_t *action, const char *pending_inputs)
 {
     const char *key = crm_element_value(action->xml, XML_LRM_ATTR_TASK_KEY);
     const char *host = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
@@ -174,8 +174,8 @@ log_synapse(unsigned int log_level, crm_graph_t *graph, synapse_t *synapse)
         pending = synapse_pending_inputs(graph, synapse);
     }
     for (GList *lpc = synapse->actions; lpc != NULL; lpc = lpc->next) {
-        log_synapse_action(log_level, synapse, (crm_action_t *) lpc->data,
-                           pending);
+        log_synapse_action(log_level, synapse,
+                           (pcmk__graph_action_t *) lpc->data, pending);
     }
     free(pending);
     if (!pcmk_is_set(synapse->flags, pcmk__synapse_executed)) {
@@ -184,7 +184,7 @@ log_synapse(unsigned int log_level, crm_graph_t *graph, synapse_t *synapse)
 }
 
 void
-pcmk__log_graph_action(int log_level, crm_action_t *action)
+pcmk__log_graph_action(int log_level, pcmk__graph_action_t *action)
 {
     log_synapse(log_level, NULL, action->synapse);
 }

--- a/lib/pacemaker/pcmk_graph_logging.c
+++ b/lib/pacemaker/pcmk_graph_logging.c
@@ -84,7 +84,7 @@ find_graph_action_by_id(pcmk__graph_t *graph, int id)
     return NULL;
 }
 
-const char *
+static const char *
 synapse_state_str(pcmk__graph_synapse_t *synapse)
 {
     if (pcmk_is_set(synapse->flags, pcmk__synapse_failed)) {

--- a/lib/pacemaker/pcmk_graph_logging.c
+++ b/lib/pacemaker/pcmk_graph_logging.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -39,14 +39,14 @@ pcmk__graph_status2text(enum transition_status state)
 }
 
 static const char *
-actiontype2text(action_type_e type)
+actiontype2text(enum pcmk__graph_action_type type)
 {
     switch (type) {
-        case action_type_pseudo:
+        case pcmk__pseudo_graph_action:
             return "pseudo";
-        case action_type_rsc:
+        case pcmk__rsc_graph_action:
             return "resource";
-        case action_type_crm:
+        case pcmk__cluster_graph_action:
             return "cluster";
     }
     return "invalid";

--- a/lib/pacemaker/pcmk_graph_logging.c
+++ b/lib/pacemaker/pcmk_graph_logging.c
@@ -62,7 +62,7 @@ actiontype2text(enum pcmk__graph_action_type type)
  * \return Transition graph action corresponding to \p id, or NULL if none
  */
 static pcmk__graph_action_t *
-find_graph_action_by_id(crm_graph_t *graph, int id)
+find_graph_action_by_id(pcmk__graph_t *graph, int id)
 {
     if (graph == NULL) {
         return NULL;
@@ -104,7 +104,7 @@ synapse_state_str(synapse_t *synapse)
 
 // List action IDs of inputs in graph that haven't completed successfully
 static char *
-synapse_pending_inputs(crm_graph_t *graph, synapse_t *synapse)
+synapse_pending_inputs(pcmk__graph_t *graph, synapse_t *synapse)
 {
     char *pending = NULL;
     size_t pending_len = 0;
@@ -131,7 +131,7 @@ synapse_pending_inputs(crm_graph_t *graph, synapse_t *synapse)
 
 // Log synapse inputs that aren't in graph
 static void
-log_unresolved_inputs(unsigned int log_level, crm_graph_t *graph,
+log_unresolved_inputs(unsigned int log_level, pcmk__graph_t *graph,
                       synapse_t *synapse)
 {
     for (GList *lpc = synapse->inputs; lpc != NULL; lpc = lpc->next) {
@@ -166,7 +166,7 @@ log_synapse_action(unsigned int log_level, synapse_t *synapse,
 }
 
 static void
-log_synapse(unsigned int log_level, crm_graph_t *graph, synapse_t *synapse)
+log_synapse(unsigned int log_level, pcmk__graph_t *graph, synapse_t *synapse)
 {
     char *pending = NULL;
 
@@ -190,7 +190,7 @@ pcmk__log_graph_action(int log_level, pcmk__graph_action_t *action)
 }
 
 void
-pcmk__log_graph(unsigned int log_level, crm_graph_t *graph)
+pcmk__log_graph(unsigned int log_level, pcmk__graph_t *graph)
 {
     if ((graph == NULL) || (graph->num_actions == 0)) {
         if (log_level == LOG_TRACE) {

--- a/lib/pacemaker/pcmk_graph_logging.c
+++ b/lib/pacemaker/pcmk_graph_logging.c
@@ -69,7 +69,7 @@ find_graph_action_by_id(pcmk__graph_t *graph, int id)
     }
 
     for (GList *sIter = graph->synapses; sIter != NULL; sIter = sIter->next) {
-        synapse_t *synapse = (synapse_t *) sIter->data;
+        pcmk__graph_synapse_t *synapse = (pcmk__graph_synapse_t *) sIter->data;
 
         for (GList *aIter = synapse->actions; aIter != NULL;
              aIter = aIter->next) {
@@ -85,7 +85,7 @@ find_graph_action_by_id(pcmk__graph_t *graph, int id)
 }
 
 const char *
-synapse_state_str(synapse_t *synapse)
+synapse_state_str(pcmk__graph_synapse_t *synapse)
 {
     if (pcmk_is_set(synapse->flags, pcmk__synapse_failed)) {
         return "Failed";
@@ -104,7 +104,7 @@ synapse_state_str(synapse_t *synapse)
 
 // List action IDs of inputs in graph that haven't completed successfully
 static char *
-synapse_pending_inputs(pcmk__graph_t *graph, synapse_t *synapse)
+synapse_pending_inputs(pcmk__graph_t *graph, pcmk__graph_synapse_t *synapse)
 {
     char *pending = NULL;
     size_t pending_len = 0;
@@ -132,7 +132,7 @@ synapse_pending_inputs(pcmk__graph_t *graph, synapse_t *synapse)
 // Log synapse inputs that aren't in graph
 static void
 log_unresolved_inputs(unsigned int log_level, pcmk__graph_t *graph,
-                      synapse_t *synapse)
+                      pcmk__graph_synapse_t *synapse)
 {
     for (GList *lpc = synapse->inputs; lpc != NULL; lpc = lpc->next) {
         pcmk__graph_action_t *input = (pcmk__graph_action_t *) lpc->data;
@@ -149,7 +149,7 @@ log_unresolved_inputs(unsigned int log_level, pcmk__graph_t *graph,
 }
 
 static void
-log_synapse_action(unsigned int log_level, synapse_t *synapse,
+log_synapse_action(unsigned int log_level, pcmk__graph_synapse_t *synapse,
                    pcmk__graph_action_t *action, const char *pending_inputs)
 {
     const char *key = crm_element_value(action->xml, XML_LRM_ATTR_TASK_KEY);
@@ -166,7 +166,8 @@ log_synapse_action(unsigned int log_level, synapse_t *synapse,
 }
 
 static void
-log_synapse(unsigned int log_level, pcmk__graph_t *graph, synapse_t *synapse)
+log_synapse(unsigned int log_level, pcmk__graph_t *graph,
+            pcmk__graph_synapse_t *synapse)
 {
     char *pending = NULL;
 
@@ -205,6 +206,6 @@ pcmk__log_graph(unsigned int log_level, pcmk__graph_t *graph)
                graph->batch_limit, graph->network_delay);
 
     for (GList *lpc = graph->synapses; lpc != NULL; lpc = lpc->next) {
-        log_synapse(log_level, graph, (synapse_t *) lpc->data);
+        log_synapse(log_level, graph, (pcmk__graph_synapse_t *) lpc->data);
     }
 }

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -110,7 +110,7 @@ add_maintenance_nodes(xmlNode *xml, const pe_working_set_t *data_set)
  *
  * \param[in,out] data_set  Working set for cluster
  */
-void
+static void
 add_maintenance_update(pe_working_set_t *data_set)
 {
     pe_action_t *action = NULL;

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -377,15 +377,8 @@ promotion_order(pe_resource_t *rsc, pe_working_set_t *data_set)
         }
     }
 
-    gIter = rsc->rsc_tickets;
-    for (; gIter != NULL; gIter = gIter->next) {
-        rsc_ticket_t *rsc_ticket = (rsc_ticket_t *) gIter->data;
-
-        if ((rsc_ticket->role_lh == RSC_ROLE_PROMOTED)
-            && (rsc_ticket->ticket->granted == FALSE || rsc_ticket->ticket->standby)) {
-            resource_location(rsc, NULL, -INFINITY, "__stateful_without_ticket__", data_set);
-        }
-    }
+    // Ban resource from all nodes if it needs a ticket but doesn't have it
+    pcmk__require_promotion_tickets(rsc);
 
     pe__show_node_weights(true, rsc, "After", rsc->allowed_nodes, data_set);
 

--- a/lib/pacemaker/pcmk_sched_tickets.c
+++ b/lib/pacemaker/pcmk_sched_tickets.c
@@ -18,6 +18,21 @@
 
 #include "libpacemaker_private.h"
 
+enum loss_ticket_policy {
+    loss_ticket_stop,
+    loss_ticket_demote,
+    loss_ticket_fence,
+    loss_ticket_freeze
+};
+
+typedef struct {
+    const char *id;
+    pe_resource_t *rsc_lh;
+    pe_ticket_t *ticket;
+    enum loss_ticket_policy loss_policy;
+    int role_lh;
+} rsc_ticket_t;
+
 /*!
  * \brief Check whether a ticket constraint matches a resource by role
  *

--- a/lib/pacemaker/pcmk_sched_tickets.c
+++ b/lib/pacemaker/pcmk_sched_tickets.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -482,5 +482,28 @@ pcmk__unpack_rsc_ticket(xmlNode *xml_obj, pe_working_set_t *data_set)
 
     if (!any_sets) {
         unpack_simple_rsc_ticket(xml_obj, data_set);
+    }
+}
+
+/*!
+ * \internal
+ * \brief Ban resource from a node if it doesn't have a promotion ticket
+ *
+ * If a resource has tickets for the promoted role, and the ticket is either not
+ * granted or set to standby, then ban the resource from all nodes.
+ *
+ * \param[in] rsc  Resource to check
+ */
+void
+pcmk__require_promotion_tickets(pe_resource_t *rsc)
+{
+    for (GList *item = rsc->rsc_tickets; item != NULL; item = item->next) {
+        rsc_ticket_t *rsc_ticket = (rsc_ticket_t *) item->data;
+
+        if ((rsc_ticket->role_lh == RSC_ROLE_PROMOTED)
+            && (!rsc_ticket->ticket->granted || rsc_ticket->ticket->standby)) {
+            resource_location(rsc, NULL, -INFINITY,
+                              "__stateful_without_ticket__", rsc->cluster);
+        }
     }
 }

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -13,6 +13,9 @@
 
 #include "libpacemaker_private.h"
 
+// Name for a pseudo-op to use in ordering constraints for utilization
+#define LOAD_STOPPED "load_stopped"
+
 /*!
  * \internal
  * \brief Get integer utilization from a string

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -464,7 +464,7 @@ set_effective_date(pe_working_set_t *data_set, bool print_original,
  * \return TRUE
  */
 static gboolean
-simulate_pseudo_action(crm_graph_t *graph, crm_action_t *action)
+simulate_pseudo_action(crm_graph_t *graph, pcmk__graph_action_t *action)
 {
     const char *node = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
     const char *task = crm_element_value(action->xml, XML_LRM_ATTR_TASK_KEY);
@@ -486,7 +486,7 @@ simulate_pseudo_action(crm_graph_t *graph, crm_action_t *action)
  * \return TRUE if action is validly specified, otherwise FALSE
  */
 static gboolean
-simulate_resource_action(crm_graph_t *graph, crm_action_t *action)
+simulate_resource_action(crm_graph_t *graph, pcmk__graph_action_t *action)
 {
     int rc;
     lrmd_event_data_t *op = NULL;
@@ -655,7 +655,7 @@ simulate_resource_action(crm_graph_t *graph, crm_action_t *action)
  * \return TRUE
  */
 static gboolean
-simulate_cluster_action(crm_graph_t *graph, crm_action_t *action)
+simulate_cluster_action(crm_graph_t *graph, pcmk__graph_action_t *action)
 {
     const char *node = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
     const char *task = crm_element_value(action->xml, XML_LRM_ATTR_TASK);
@@ -677,7 +677,7 @@ simulate_cluster_action(crm_graph_t *graph, crm_action_t *action)
  * \return TRUE
  */
 static gboolean
-simulate_fencing_action(crm_graph_t *graph, crm_action_t *action)
+simulate_fencing_action(crm_graph_t *graph, pcmk__graph_action_t *action)
 {
     const char *op = crm_meta_value(action->params, "stonith_action");
     char *target = crm_element_value_copy(action->xml, XML_LRM_ATTR_TARGET);

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -718,12 +718,12 @@ simulate_fencing_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     return pcmk_rc_ok;
 }
 
-enum transition_status
+enum pcmk__graph_status
 pcmk__simulate_transition(pe_working_set_t *data_set, cib_t *cib,
                           GList *op_fail_list)
 {
     pcmk__graph_t *transition = NULL;
-    enum transition_status graph_rc;
+    enum pcmk__graph_status graph_rc;
 
     pcmk__graph_functions_t simulation_fns = {
         simulate_pseudo_action,
@@ -748,10 +748,10 @@ pcmk__simulate_transition(pe_working_set_t *data_set, cib_t *cib,
     fake_resource_list = data_set->resources;
     do {
         graph_rc = pcmk__execute_graph(transition);
-    } while (graph_rc == transition_active);
+    } while (graph_rc == pcmk__graph_active);
     fake_resource_list = NULL;
 
-    if (graph_rc != transition_complete) {
+    if (graph_rc != pcmk__graph_complete) {
         out->err(out, "Transition failed: %s",
                  pcmk__graph_status2text(graph_rc));
         pcmk__log_graph(LOG_ERR, transition);
@@ -932,7 +932,7 @@ pcmk__simulate(pe_working_set_t *data_set, pcmk__output_t *out,
 
     PCMK__OUTPUT_SPACER_IF(out, printed == pcmk_rc_ok);
     if (pcmk__simulate_transition(data_set, cib,
-                                  injections->op_fail) != transition_complete) {
+                                  injections->op_fail) != pcmk__graph_complete) {
         rc = pcmk_rc_invalid_transition;
     }
 

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -483,9 +483,9 @@ simulate_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
  * \param[in] graph   Graph to update with resource action result
  * \param[in] action  Resource action to simulate executing
  *
- * \return TRUE if action is validly specified, otherwise FALSE
+ * \return Standard Pacemaker return code
  */
-static gboolean
+static int
 simulate_resource_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     int rc;
@@ -519,7 +519,7 @@ simulate_resource_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     if (action_rsc == NULL) { // Shouldn't be possible
         crm_log_xml_err(action->xml, "Bad");
         free(node);
-        return FALSE;
+        return EPROTO;
     }
 
     /* A resource might be known by different names in the configuration and in
@@ -531,7 +531,7 @@ simulate_resource_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     if (resource_config_name == NULL) { // Shouldn't be possible
         crm_log_xml_err(action->xml, "No ID");
         free(node);
-        return FALSE;
+        return EPROTO;
     }
     resource = resource_config_name;
     if (pe_find_resource(fake_resource_list, resource) == NULL) {
@@ -575,7 +575,7 @@ simulate_resource_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
                 action->id, resource);
         free(node);
         free_xml(cib_node);
-        return FALSE;
+        return EINVAL;
     }
 
     // Simulate and display an executor event for the action result
@@ -642,7 +642,7 @@ simulate_resource_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     free_xml(cib_node);
     pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);
     pcmk__update_graph(graph, action);
-    return TRUE;
+    return pcmk_rc_ok;
 }
 
 /*!

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -461,9 +461,9 @@ set_effective_date(pe_working_set_t *data_set, bool print_original,
  * \param[in] graph   Graph to update with pseudo-action result
  * \param[in] action  Pseudo-action to simulate executing
  *
- * \return TRUE
+ * \return Standard Pacemaker return code
  */
-static gboolean
+static int
 simulate_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     const char *node = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
@@ -473,7 +473,7 @@ simulate_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     out->message(out, "inject-pseudo-action", node, task);
 
     pcmk__update_graph(graph, action);
-    return TRUE;
+    return pcmk_rc_ok;
 }
 
 /*!

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -469,7 +469,7 @@ simulate_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     const char *node = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
     const char *task = crm_element_value(action->xml, XML_LRM_ATTR_TASK_KEY);
 
-    crm__set_graph_action_flags(action, pcmk__graph_action_confirmed);
+    pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);
     out->message(out, "inject-pseudo-action", node, task);
 
     pcmk__update_graph(graph, action);
@@ -624,7 +624,7 @@ simulate_resource_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 
         out->info(out, "Pretending action %d failed with rc=%d",
                   action->id, op->rc);
-        crm__set_graph_action_flags(action, pcmk__graph_action_failed);
+        pcmk__set_graph_action_flags(action, pcmk__graph_action_failed);
         graph->abort_priority = INFINITY;
         pcmk__inject_failcount(out, cib_node, match_name, op->op_type,
                                op->interval_ms, op->rc);
@@ -640,7 +640,7 @@ simulate_resource_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
   done:
     free(node);
     free_xml(cib_node);
-    crm__set_graph_action_flags(action, pcmk__graph_action_confirmed);
+    pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);
     pcmk__update_graph(graph, action);
     return TRUE;
 }
@@ -661,7 +661,7 @@ simulate_cluster_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     const char *task = crm_element_value(action->xml, XML_LRM_ATTR_TASK);
     xmlNode *rsc = first_named_child(action->xml, XML_CIB_TAG_RESOURCE);
 
-    crm__set_graph_action_flags(action, pcmk__graph_action_confirmed);
+    pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);
     out->message(out, "inject-cluster-action", node, task, rsc);
     pcmk__update_graph(graph, action);
     return TRUE;
@@ -712,7 +712,7 @@ simulate_fencing_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
         free_xml(cib_node);
     }
 
-    crm__set_graph_action_flags(action, pcmk__graph_action_confirmed);
+    pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);
     pcmk__update_graph(graph, action);
     free(target);
     return TRUE;

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -464,7 +464,7 @@ set_effective_date(pe_working_set_t *data_set, bool print_original,
  * \return TRUE
  */
 static gboolean
-simulate_pseudo_action(crm_graph_t *graph, pcmk__graph_action_t *action)
+simulate_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     const char *node = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
     const char *task = crm_element_value(action->xml, XML_LRM_ATTR_TASK_KEY);
@@ -486,7 +486,7 @@ simulate_pseudo_action(crm_graph_t *graph, pcmk__graph_action_t *action)
  * \return TRUE if action is validly specified, otherwise FALSE
  */
 static gboolean
-simulate_resource_action(crm_graph_t *graph, pcmk__graph_action_t *action)
+simulate_resource_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     int rc;
     lrmd_event_data_t *op = NULL;
@@ -655,7 +655,7 @@ simulate_resource_action(crm_graph_t *graph, pcmk__graph_action_t *action)
  * \return TRUE
  */
 static gboolean
-simulate_cluster_action(crm_graph_t *graph, pcmk__graph_action_t *action)
+simulate_cluster_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     const char *node = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
     const char *task = crm_element_value(action->xml, XML_LRM_ATTR_TASK);
@@ -677,7 +677,7 @@ simulate_cluster_action(crm_graph_t *graph, pcmk__graph_action_t *action)
  * \return TRUE
  */
 static gboolean
-simulate_fencing_action(crm_graph_t *graph, pcmk__graph_action_t *action)
+simulate_fencing_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     const char *op = crm_meta_value(action->params, "stonith_action");
     char *target = crm_element_value_copy(action->xml, XML_LRM_ATTR_TARGET);
@@ -722,7 +722,7 @@ enum transition_status
 pcmk__simulate_transition(pe_working_set_t *data_set, cib_t *cib,
                           GList *op_fail_list)
 {
-    crm_graph_t *transition = NULL;
+    pcmk__graph_t *transition = NULL;
     enum transition_status graph_rc;
 
     crm_graph_functions_t simulation_fns = {

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -674,9 +674,9 @@ simulate_cluster_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
  * \param[in] graph   Graph to update with action result
  * \param[in] action  Fencing action to simulate
  *
- * \return TRUE
+ * \return Standard Pacemaker return code
  */
-static gboolean
+static int
 simulate_fencing_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     const char *op = crm_meta_value(action->params, "stonith_action");
@@ -715,7 +715,7 @@ simulate_fencing_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);
     pcmk__update_graph(graph, action);
     free(target);
-    return TRUE;
+    return pcmk_rc_ok;
 }
 
 enum transition_status

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -725,7 +725,7 @@ pcmk__simulate_transition(pe_working_set_t *data_set, cib_t *cib,
     pcmk__graph_t *transition = NULL;
     enum transition_status graph_rc;
 
-    crm_graph_functions_t simulation_fns = {
+    pcmk__graph_functions_t simulation_fns = {
         simulate_pseudo_action,
         simulate_resource_action,
         simulate_cluster_action,

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -652,9 +652,9 @@ simulate_resource_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
  * \param[in] graph   Graph to update with action result
  * \param[in] action  Cluster action to simulate
  *
- * \return TRUE
+ * \return Standard Pacemaker return code
  */
-static gboolean
+static int
 simulate_cluster_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 {
     const char *node = crm_element_value(action->xml, XML_LRM_ATTR_TARGET);
@@ -664,7 +664,7 @@ simulate_cluster_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);
     out->message(out, "inject-cluster-action", node, task, rsc);
     pcmk__update_graph(graph, action);
-    return TRUE;
+    return pcmk_rc_ok;
 }
 
 /*!


### PR DESCRIPTION
This continues bringing libpacemaker up to current development guidelines. This one focuses mainly on the transition graph types and is mostly renames.