### PR TITLE
Check node health in crm_resource --why

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -888,8 +888,12 @@ Deleted 'dummy' option: id=dummy-meta_attributes-is-managed name=is-managed
 =#=#=#= End test: Create another resource meta attribute - OK (0) =#=#=#=
 * Passed: crm_resource   - Create another resource meta attribute
 =#=#=#= Begin test: Show why a resource is not running =#=#=#=
-Resource dummy is not running
-Configuration specifies 'dummy' should remain stopped
+<pacemaker-result api-version="X" request="crm_resource -Y -r dummy --output-as=xml">
+  <reason running="false">
+    <check id="dummy" remain_stopped="true"/>
+  </reason>
+  <status code="0" message="OK"/>
+</pacemaker-result>
 =#=#=#= End test: Show why a resource is not running - OK (0) =#=#=#=
 * Passed: crm_resource   - Show why a resource is not running
 =#=#=#= Begin test: Remove another resource meta attribute =#=#=#=

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -3406,13 +3406,14 @@ Removing constraint: cli-prefer-dummy
 </cib>
 =#=#=#= End test: Clear all implicit constraints for dummy - OK (0) =#=#=#=
 * Passed: crm_resource   - Clear all implicit constraints for dummy
-=#=#=#= Begin test: Delete a resource =#=#=#=
-=#=#=#= Current cib after: Delete a resource =#=#=#=
+=#=#=#= Begin test: Set a node health strategy =#=#=#=
+=#=#=#= Current cib after: Set a node health strategy =#=#=#=
 <cib epoch="55" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
         <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-node-health-strategy" name="node-health-strategy" value="migrate-on-red"/>
       </cluster_property_set>
       <cluster_property_set id="duplicate">
         <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
@@ -3426,6 +3427,113 @@ Removing constraint: cli-prefer-dummy
       </node>
       <node id="node2" uname="node2"/>
       <node id="node3" uname="node3"/>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+      <clone id="test-clone">
+        <primitive id="test-primitive" class="ocf" provider="pacemaker" type="Dummy">
+          <meta_attributes id="test-primitive-meta_attributes"/>
+        </primitive>
+        <meta_attributes id="test-clone-meta_attributes">
+          <nvpair id="test-clone-meta_attributes-is-managed" name="is-managed" value="true"/>
+        </meta_attributes>
+      </clone>
+    </resources>
+    <constraints/>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Set a node health strategy - OK (0) =#=#=#=
+* Passed: crm_attribute  - Set a node health strategy
+=#=#=#= Begin test: Set a node health attribute =#=#=#=
+=#=#=#= Current cib after: Set a node health attribute =#=#=#=
+<cib epoch="56" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-node-health-strategy" name="node-health-strategy" value="migrate-on-red"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+      </node>
+      <node id="node2" uname="node2"/>
+      <node id="node3" uname="node3">
+        <instance_attributes id="nodes-node3">
+          <nvpair id="nodes-node3-.health-cts-cli" name="#health-cts-cli" value="red"/>
+        </instance_attributes>
+      </node>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+      <clone id="test-clone">
+        <primitive id="test-primitive" class="ocf" provider="pacemaker" type="Dummy">
+          <meta_attributes id="test-primitive-meta_attributes"/>
+        </primitive>
+        <meta_attributes id="test-clone-meta_attributes">
+          <nvpair id="test-clone-meta_attributes-is-managed" name="is-managed" value="true"/>
+        </meta_attributes>
+      </clone>
+    </resources>
+    <constraints/>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Set a node health attribute - OK (0) =#=#=#=
+* Passed: crm_attribute  - Set a node health attribute
+=#=#=#= Begin test: Show why a resource is not running on an unhealthy node =#=#=#=
+<pacemaker-result api-version="X" request="crm_resource -N node3 -Y -r dummy --output-as=xml">
+  <reason>
+    <check id="dummy" unhealthy="true"/>
+  </reason>
+  <status code="0" message="OK"/>
+</pacemaker-result>
+=#=#=#= End test: Show why a resource is not running on an unhealthy node - OK (0) =#=#=#=
+* Passed: crm_resource   - Show why a resource is not running on an unhealthy node
+=#=#=#= Begin test: Delete a resource =#=#=#=
+=#=#=#= Current cib after: Delete a resource =#=#=#=
+<cib epoch="57" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+        <nvpair id="cib-bootstrap-options-node-health-strategy" name="node-health-strategy" value="migrate-on-red"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+      </node>
+      <node id="node2" uname="node2"/>
+      <node id="node3" uname="node3">
+        <instance_attributes id="nodes-node3">
+          <nvpair id="nodes-node3-.health-cts-cli" name="#health-cts-cli" value="red"/>
+        </instance_attributes>
+      </node>
     </nodes>
     <resources>
       <primitive id="Fence" class="stonith" type="fence_true"/>

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -883,6 +883,18 @@ function test_tools() {
     cmd="crm_resource -r dummy -U"
     test_assert $CRM_EX_OK
 
+    desc="Set a node health strategy"
+    cmd="crm_attribute -n node-health-strategy -v migrate-on-red"
+    test_assert $CRM_EX_OK
+
+    desc="Set a node health attribute"
+    cmd="crm_attribute -N node3 -n '#health-cts-cli' -v red"
+    test_assert $CRM_EX_OK
+
+    desc="Show why a resource is not running on an unhealthy node"
+    cmd="crm_resource -N node3 -Y -r dummy --output-as=xml"
+    test_assert_validate $CRM_EX_OK 0
+
     desc="Delete a resource"
     cmd="crm_resource -D -r dummy -t primitive"
     test_assert $CRM_EX_OK

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -657,8 +657,8 @@ function test_tools() {
     test_assert_validate $CRM_EX_OK 0
 
     desc="Show why a resource is not running"
-    cmd="crm_resource -Y -r dummy"
-    test_assert $CRM_EX_OK 0
+    cmd="crm_resource -Y -r dummy --output-as=xml"
+    test_assert_validate $CRM_EX_OK 0
 
     desc="Remove another resource meta attribute"
     cmd="crm_resource -r dummy --meta -d target-role --output-as=xml"

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -28,7 +28,7 @@ extern "C" {
  */
 
 
-#  define PCMK__API_VERSION "2.21"
+#  define PCMK__API_VERSION "2.22"
 
 #if defined(PCMK__WITH_ATTRIBUTE_OUTPUT_ARGS)
 #  define PCMK__OUTPUT_ARGS(ARGS...) __attribute__((output_args(ARGS)))

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1019,7 +1019,7 @@ cleanup(pcmk__output_t *out, pe_resource_t *rsc)
 
     if ((rc == pcmk_rc_ok) && !out->is_quiet(out)) {
         // Show any reasons why resource might stay stopped
-        cli_resource_check(out, cib_conn, rsc);
+        cli_resource_check(out, rsc);
     }
 
     if (rc == pcmk_rc_ok) {
@@ -1326,7 +1326,7 @@ refresh_resource(pcmk__output_t *out, pe_resource_t *rsc)
 
     if ((rc == pcmk_rc_ok) && !out->is_quiet(out)) {
         // Show any reasons why resource might stay stopped
-        cli_resource_check(out, cib_conn, rsc);
+        cli_resource_check(out, rsc);
     }
 
     if (rc == pcmk_rc_ok) {

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1004,7 +1004,7 @@ ban_or_move(pcmk__output_t *out, pe_resource_t *rsc, const char *move_lifetime)
 }
 
 static void
-cleanup(pcmk__output_t *out, pe_resource_t *rsc)
+cleanup(pcmk__output_t *out, pe_resource_t *rsc, pe_node_t *node)
 {
     int rc = pcmk_rc_ok;
 
@@ -1019,7 +1019,7 @@ cleanup(pcmk__output_t *out, pe_resource_t *rsc)
 
     if ((rc == pcmk_rc_ok) && !out->is_quiet(out)) {
         // Show any reasons why resource might stay stopped
-        cli_resource_check(out, rsc);
+        cli_resource_check(out, rsc, node);
     }
 
     if (rc == pcmk_rc_ok) {
@@ -1311,7 +1311,7 @@ refresh(pcmk__output_t *out)
 }
 
 static void
-refresh_resource(pcmk__output_t *out, pe_resource_t *rsc)
+refresh_resource(pcmk__output_t *out, pe_resource_t *rsc, pe_node_t *node)
 {
     int rc = pcmk_rc_ok;
 
@@ -1326,7 +1326,7 @@ refresh_resource(pcmk__output_t *out, pe_resource_t *rsc)
 
     if ((rc == pcmk_rc_ok) && !out->is_quiet(out)) {
         // Show any reasons why resource might stay stopped
-        cli_resource_check(out, rsc);
+        cli_resource_check(out, rsc, node);
     }
 
     if (rc == pcmk_rc_ok) {
@@ -2075,7 +2075,7 @@ main(int argc, char **argv)
                     start_mainloop(controld_api);
                 }
             } else {
-                cleanup(out, rsc);
+                cleanup(out, rsc, node);
             }
             break;
 
@@ -2083,7 +2083,7 @@ main(int argc, char **argv)
             if (rsc == NULL) {
                 rc = refresh(out);
             } else {
-                refresh_resource(out, rsc);
+                refresh_resource(out, rsc, node);
             }
             break;
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1941,7 +1941,7 @@ main(int argc, char **argv)
             if ((options.host_uname != NULL) && (node == NULL)) {
                 rc = pcmk_rc_node_unknown;
             } else {
-                rc = out->message(out, "resource-reasons-list", cib_conn,
+                rc = out->message(out, "resource-reasons-list",
                                   data_set->resources, rsc, node);
             }
             break;

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -68,7 +68,8 @@ int cli_resource_print_operations(const char *rsc_id, const char *host_uname,
                                   bool active, pe_working_set_t * data_set);
 
 /* runtime */
-int cli_resource_check(pcmk__output_t *out, pe_resource_t *rsc);
+int cli_resource_check(pcmk__output_t *out, pe_resource_t *rsc,
+                       pe_node_t *node);
 int cli_resource_fail(pcmk_ipc_api_t *controld_api, const char *host_uname,
                       const char *rsc_id, pe_working_set_t *data_set);
 GList *cli_resource_search(pe_resource_t *rsc, const char *requested_name,

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -37,6 +37,7 @@ enum resource_check_flags {
     rsc_unpromotable    = (1 << 1),
     rsc_unmanaged       = (1 << 2),
     rsc_locked          = (1 << 3),
+    rsc_node_health     = (1 << 4),
 };
 
 typedef struct resource_checks_s {

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -68,7 +68,7 @@ int cli_resource_print_operations(const char *rsc_id, const char *host_uname,
                                   bool active, pe_working_set_t * data_set);
 
 /* runtime */
-int cli_resource_check(pcmk__output_t *out, cib_t * cib, pe_resource_t *rsc);
+int cli_resource_check(pcmk__output_t *out, pe_resource_t *rsc);
 int cli_resource_fail(pcmk_ipc_api_t *controld_api, const char *host_uname,
                       const char *rsc_id, pe_working_set_t *data_set);
 GList *cli_resource_search(pe_resource_t *rsc, const char *requested_name,

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -8,6 +8,10 @@
  */
 
 #include <crm_internal.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+
 #include <crm/crm.h>
 
 #include <crm/msg_xml.h>
@@ -31,13 +35,14 @@ typedef struct node_info_s {
 enum resource_check_flags {
     rsc_remain_stopped  = (1 << 0),
     rsc_unpromotable    = (1 << 1),
-    rsc_unmanaged       = (1 << 2)
+    rsc_unmanaged       = (1 << 2),
+    rsc_locked          = (1 << 3),
 };
 
 typedef struct resource_checks_s {
-    pe_resource_t *rsc;
-    unsigned int flags;
-    const char *lock_node;
+    pe_resource_t *rsc;     // Resource being checked
+    uint32_t flags;         // Group of enum resource_check_flags
+    const char *lock_node;  // Node that resource is shutdown-locked to, if any
 } resource_checks_t;
 
 resource_checks_t *cli_check_resource(pe_resource_t *rsc, char *role_s, char *managed);

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -587,7 +587,7 @@ PCMK__OUTPUT_ARGS("resource-reasons-list", "cib_t *", "GList *", "pe_resource_t 
 static int
 resource_reasons_list_default(pcmk__output_t *out, va_list args)
 {
-    cib_t *cib_conn = va_arg(args, cib_t *);
+    cib_t *cib_conn G_GNUC_UNUSED = va_arg(args, cib_t *);
     GList *resources = va_arg(args, GList *);
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
     pe_node_t *node = va_arg(args, pe_node_t *);
@@ -610,7 +610,7 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
                 out->list_item(out, "reason", "Resource %s is running", rsc->id);
             }
 
-            cli_resource_check(out, cib_conn, rsc);
+            cli_resource_check(out, rsc);
             g_list_free(hosts);
             hosts = NULL;
         }
@@ -624,7 +624,7 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
                            rsc->id, host_uname);
         }
 
-        cli_resource_check(out, cib_conn, rsc);
+        cli_resource_check(out, rsc);
 
     } else if ((rsc == NULL) && (host_uname != NULL)) {
         const char* host_uname =  node->details->uname;
@@ -637,14 +637,14 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
             pe_resource_t *rsc = (pe_resource_t *) lpc->data;
             out->list_item(out, "reason", "Resource %s is running on host %s",
                            rsc->id, host_uname);
-            cli_resource_check(out, cib_conn, rsc);
+            cli_resource_check(out, rsc);
         }
 
         for(lpc = unactiveResources; lpc != NULL; lpc = lpc->next) {
             pe_resource_t *rsc = (pe_resource_t *) lpc->data;
             out->list_item(out, "reason", "Resource %s is assigned to host %s but not running",
                            rsc->id, host_uname);
-            cli_resource_check(out, cib_conn, rsc);
+            cli_resource_check(out, rsc);
         }
 
         g_list_free(allResources);
@@ -657,7 +657,7 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
         rsc->fns->location(rsc, &hosts, TRUE);
         out->list_item(out, "reason", "Resource %s is %srunning",
                        rsc->id, (hosts? "" : "not "));
-        cli_resource_check(out, cib_conn, rsc);
+        cli_resource_check(out, rsc);
         g_list_free(hosts);
     }
 
@@ -670,7 +670,7 @@ PCMK__OUTPUT_ARGS("resource-reasons-list", "cib_t *", "GList *", "pe_resource_t 
 static int
 resource_reasons_list_xml(pcmk__output_t *out, va_list args)
 {
-    cib_t *cib_conn = va_arg(args, cib_t *);
+    cib_t *cib_conn G_GNUC_UNUSED = va_arg(args, cib_t *);
     GList *resources = va_arg(args, GList *);
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
     pe_node_t *node = va_arg(args, pe_node_t *);
@@ -695,7 +695,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
                                            "running", pcmk__btoa(hosts != NULL),
                                            NULL);
 
-            cli_resource_check(out, cib_conn, rsc);
+            cli_resource_check(out, rsc);
             pcmk__output_xml_pop_parent(out);
             g_list_free(hosts);
             hosts = NULL;
@@ -708,7 +708,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
             crm_xml_add(xml_node, "running_on", host_uname);
         }
 
-        cli_resource_check(out, cib_conn, rsc);
+        cli_resource_check(out, rsc);
 
     } else if ((rsc == NULL) && (host_uname != NULL)) {
         const char* host_uname =  node->details->uname;
@@ -728,7 +728,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
                                            "host", host_uname,
                                            NULL);
 
-            cli_resource_check(out, cib_conn, rsc);
+            cli_resource_check(out, rsc);
             pcmk__output_xml_pop_parent(out);
         }
 
@@ -741,7 +741,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
                                            "host", host_uname,
                                            NULL);
 
-            cli_resource_check(out, cib_conn, rsc);
+            cli_resource_check(out, rsc);
             pcmk__output_xml_pop_parent(out);
         }
 
@@ -755,7 +755,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
 
         rsc->fns->location(rsc, &hosts, TRUE);
         crm_xml_add(xml_node, "running", pcmk__btoa(hosts != NULL));
-        cli_resource_check(out, cib_conn, rsc);
+        cli_resource_check(out, rsc);
         g_list_free(hosts);
     }
 

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -609,7 +609,7 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
                 out->list_item(out, "reason", "Resource %s is running", rsc->id);
             }
 
-            cli_resource_check(out, rsc);
+            cli_resource_check(out, rsc, NULL);
             g_list_free(hosts);
             hosts = NULL;
         }
@@ -623,7 +623,7 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
                            rsc->id, host_uname);
         }
 
-        cli_resource_check(out, rsc);
+        cli_resource_check(out, rsc, node);
 
     } else if ((rsc == NULL) && (host_uname != NULL)) {
         const char* host_uname =  node->details->uname;
@@ -636,14 +636,14 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
             pe_resource_t *rsc = (pe_resource_t *) lpc->data;
             out->list_item(out, "reason", "Resource %s is running on host %s",
                            rsc->id, host_uname);
-            cli_resource_check(out, rsc);
+            cli_resource_check(out, rsc, node);
         }
 
         for(lpc = unactiveResources; lpc != NULL; lpc = lpc->next) {
             pe_resource_t *rsc = (pe_resource_t *) lpc->data;
             out->list_item(out, "reason", "Resource %s is assigned to host %s but not running",
                            rsc->id, host_uname);
-            cli_resource_check(out, rsc);
+            cli_resource_check(out, rsc, node);
         }
 
         g_list_free(allResources);
@@ -656,7 +656,7 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
         rsc->fns->location(rsc, &hosts, TRUE);
         out->list_item(out, "reason", "Resource %s is %srunning",
                        rsc->id, (hosts? "" : "not "));
-        cli_resource_check(out, rsc);
+        cli_resource_check(out, rsc, NULL);
         g_list_free(hosts);
     }
 
@@ -693,7 +693,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
                                            "running", pcmk__btoa(hosts != NULL),
                                            NULL);
 
-            cli_resource_check(out, rsc);
+            cli_resource_check(out, rsc, NULL);
             pcmk__output_xml_pop_parent(out);
             g_list_free(hosts);
             hosts = NULL;
@@ -706,7 +706,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
             crm_xml_add(xml_node, "running_on", host_uname);
         }
 
-        cli_resource_check(out, rsc);
+        cli_resource_check(out, rsc, node);
 
     } else if ((rsc == NULL) && (host_uname != NULL)) {
         const char* host_uname =  node->details->uname;
@@ -726,7 +726,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
                                            "host", host_uname,
                                            NULL);
 
-            cli_resource_check(out, rsc);
+            cli_resource_check(out, rsc, node);
             pcmk__output_xml_pop_parent(out);
         }
 
@@ -739,7 +739,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
                                            "host", host_uname,
                                            NULL);
 
-            cli_resource_check(out, rsc);
+            cli_resource_check(out, rsc, node);
             pcmk__output_xml_pop_parent(out);
         }
 
@@ -753,7 +753,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
 
         rsc->fns->location(rsc, &hosts, TRUE);
         crm_xml_add(xml_node, "running", pcmk__btoa(hosts != NULL));
-        cli_resource_check(out, rsc);
+        cli_resource_check(out, rsc, NULL);
         g_list_free(hosts);
     }
 

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -477,6 +477,15 @@ resource_check_list_default(pcmk__output_t *out, va_list args) {
                        parent->id, checks->lock_node);
     }
 
+    if (pcmk_is_set(checks->flags, rsc_node_health)) {
+        out->list_item(out, "check",
+                       "'%s' cannot run on unhealthy nodes due to "
+                       PCMK__OPT_NODE_HEALTH_STRATEGY "='%s'",
+                       parent->id,
+                       pe_pref(checks->rsc->cluster->config_hash,
+                               PCMK__OPT_NODE_HEALTH_STRATEGY));
+    }
+
     out->end_list(out);
     return pcmk_rc_ok;
 }
@@ -506,6 +515,10 @@ resource_check_list_xml(pcmk__output_t *out, va_list args) {
 
     if (pcmk_is_set(checks->flags, rsc_locked)) {
         crm_xml_add(node, "locked-to", checks->lock_node);
+    }
+
+    if (pcmk_is_set(checks->flags, rsc_node_health)) {
+        pcmk__xe_set_bool_attr(node, "unhealthy", true);
     }
 
     return pcmk_rc_ok;

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -582,12 +582,11 @@ resource_search_list_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-reasons-list", "cib_t *", "GList *", "pe_resource_t *",
+PCMK__OUTPUT_ARGS("resource-reasons-list", "GList *", "pe_resource_t *",
                   "pe_node_t *")
 static int
 resource_reasons_list_default(pcmk__output_t *out, va_list args)
 {
-    cib_t *cib_conn G_GNUC_UNUSED = va_arg(args, cib_t *);
     GList *resources = va_arg(args, GList *);
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
     pe_node_t *node = va_arg(args, pe_node_t *);
@@ -665,12 +664,11 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-reasons-list", "cib_t *", "GList *", "pe_resource_t *",
+PCMK__OUTPUT_ARGS("resource-reasons-list", "GList *", "pe_resource_t *",
                   "pe_node_t *")
 static int
 resource_reasons_list_xml(pcmk__output_t *out, va_list args)
 {
-    cib_t *cib_conn G_GNUC_UNUSED = va_arg(args, cib_t *);
     GList *resources = va_arg(args, GList *);
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
     pe_node_t *node = va_arg(args, pe_node_t *);

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -895,21 +895,14 @@ check_role(resource_checks_t *checks)
 }
 
 static void
-check_managed(pcmk__output_t *out, cib_t *cib_conn, resource_checks_t *checks)
+check_managed(resource_checks_t *checks)
 {
-    char *managed_s = NULL;
-    pe_resource_t *parent = uber_parent(checks->rsc);
+    const char *managed_s = g_hash_table_lookup(checks->rsc->meta,
+                                                XML_RSC_ATTR_MANAGED);
 
-    find_resource_attr(out, cib_conn, XML_NVPAIR_ATTR_VALUE, parent->id,
-                       NULL, NULL, NULL, XML_RSC_ATTR_MANAGED, &managed_s);
-    if (managed_s == NULL) {
-        return;
-    }
-
-    if (!crm_is_true(managed_s)) {
+    if ((managed_s != NULL) && !crm_is_true(managed_s)) {
         checks->flags |= rsc_unmanaged;
     }
-    free(managed_s);
 }
 
 static void
@@ -927,7 +920,7 @@ cli_resource_check(pcmk__output_t *out, cib_t * cib_conn, pe_resource_t *rsc)
     resource_checks_t checks = { .rsc = rsc };
 
     check_role(&checks);
-    check_managed(out, cib_conn, &checks);
+    check_managed(&checks);
     check_locked(&checks);
 
     return out->message(out, "resource-check-list", &checks);

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -36,7 +36,8 @@ cli_check_resource(pe_resource_t *rsc, char *role_s, char *managed)
         rc->flags |= rsc_unmanaged;
     }
 
-    if (rsc->lock_node) {
+    if (rsc->lock_node != NULL) {
+        rc->flags |= rsc_locked;
         rc->lock_node = rsc->lock_node->details->uname;
     }
 
@@ -914,9 +915,7 @@ cli_resource_check(pcmk__output_t *out, cib_t * cib_conn, pe_resource_t *rsc)
 
     checks = cli_check_resource(rsc, role_s, managed);
 
-    if (checks->flags != 0 || checks->lock_node != NULL) {
-        rc = out->message(out, "resource-check-list", checks);
-    }
+    rc = out->message(out, "resource-check-list", checks);
 
     free(role_s);
     free(managed);

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -915,7 +915,7 @@ check_locked(resource_checks_t *checks)
 }
 
 int
-cli_resource_check(pcmk__output_t *out, pe_resource_t *rsc)
+cli_resource_check(pcmk__output_t *out, pe_resource_t *rsc, pe_node_t *node)
 {
     resource_checks_t checks = { .rsc = rsc };
 

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -915,7 +915,7 @@ check_locked(resource_checks_t *checks)
 }
 
 int
-cli_resource_check(pcmk__output_t *out, cib_t * cib_conn, pe_resource_t *rsc)
+cli_resource_check(pcmk__output_t *out, pe_resource_t *rsc)
 {
     resource_checks_t checks = { .rsc = rsc };
 

--- a/xml/api/crm_resource-2.22.rng
+++ b/xml/api/crm_resource-2.22.rng
@@ -157,6 +157,9 @@
             <optional>
                 <attribute name="locked-to"> <text/> </attribute>
             </optional>
+            <optional>
+                <attribute name="unhealthy"><value>true</value></attribute>
+            </optional>
         </element>
     </define>
 

--- a/xml/api/crm_resource-2.22.rng
+++ b/xml/api/crm_resource-2.22.rng
@@ -126,7 +126,9 @@
 
     <define name="resource-and-uname">
         <element name="reason">
-            <attribute name="running_on"> <text/> </attribute>
+            <optional>
+                <attribute name="running_on"> <text/> </attribute>
+            </optional>
             <ref name="resource-check"/>
         </element>
     </define>

--- a/xml/api/crm_resource-2.22.rng
+++ b/xml/api/crm_resource-2.22.rng
@@ -102,56 +102,36 @@
     </define>
 
     <define name="reasons-list">
-        <choice>
-            <ref name="no-resource-or-uname"/>
-            <ref name="resource-and-uname"/>
-            <ref name="no-resource-but-uname"/>
-            <ref name="resource-but-no-uname"/>
-        </choice>
-    </define>
-
-    <define name="no-resource-or-uname">
         <element name="reason">
-            <element name="resources">
-                <zeroOrMore>
-                    <element name="resource">
-                        <attribute name="id"> <text/> </attribute>
-                        <attribute name="running"> <data type="boolean"/> </attribute>
-                        <ref name="resource-check"/>
-                    </element>
-                </zeroOrMore>
-            </element>
-        </element>
-    </define>
-
-    <define name="resource-and-uname">
-        <element name="reason">
+            <!-- set only when resource and node are both specified -->
             <optional>
                 <attribute name="running_on"> <text/> </attribute>
             </optional>
-            <ref name="resource-check"/>
+
+            <!-- set only when only a resource is specified -->
+            <optional>
+                <attribute name="running"> <data type="boolean"/> </attribute>
+            </optional>
+
+            <choice>
+                <ref name="reasons-with-no-resource"/>
+                <ref name="resource-check"/>
+            </choice>
         </element>
     </define>
 
-    <define name="no-resource-but-uname">
-        <element name="reason">
-            <element name="resources">
-                <zeroOrMore>
-                    <element name="resource">
-                        <attribute name="id"> <text/> </attribute>
-                        <attribute name="running"> <data type="boolean"/> </attribute>
+    <define name="reasons-with-no-resource">
+        <element name="resources">
+            <zeroOrMore>
+                <element name="resource">
+                    <attribute name="id"> <text/> </attribute>
+                    <attribute name="running"> <data type="boolean"/> </attribute>
+                    <optional>
                         <attribute name="host"> <text/> </attribute>
-                        <ref name="resource-check"/>
-                    </element>
-                </zeroOrMore>
-            </element>
-        </element>
-    </define>
-
-    <define name="resource-but-no-uname">
-        <element name="reason">
-            <attribute name="running"> <data type="boolean"/> </attribute>
-            <ref name="resource-check"/>
+                    </optional>
+                    <ref name="resource-check"/>
+                </element>
+            </zeroOrMore>
         </element>
     </define>
 

--- a/xml/api/crm_resource-2.22.rng
+++ b/xml/api/crm_resource-2.22.rng
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crm-resource"/>
+    </start>
+
+    <define name="element-crm-resource">
+        <choice>
+            <ref name="agents-list" />
+            <ref name="alternatives-list" />
+            <ref name="constraints-list" />
+            <externalRef href="generic-list-2.4.rng"/>
+            <element name="metadata"> <text/> </element>
+            <ref name="locate-list" />
+            <ref name="operations-list" />
+            <ref name="providers-list" />
+            <ref name="reasons-list" />
+            <ref name="resource-check" />
+            <ref name="resource-config" />
+            <ref name="resources-list" />
+            <ref name="resource-agent-action" />
+        </choice>
+    </define>
+
+    <define name="agents-list">
+        <element name="agents">
+            <attribute name="standard"> <text/> </attribute>
+            <optional>
+                <attribute name="provider"> <text/> </attribute>
+            </optional>
+            <zeroOrMore>
+                <element name="agent"> <text/> </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="alternatives-list">
+        <element name="providers">
+            <attribute name="for"> <text/> </attribute>
+            <zeroOrMore>
+                <element name="provider"> <text/> </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="constraints-list">
+        <element name="constraints">
+            <interleave>
+                <zeroOrMore>
+                    <ref name="rsc-location" />
+                </zeroOrMore>
+                <zeroOrMore>
+                    <ref name="rsc-colocation" />
+                </zeroOrMore>
+            </interleave>
+        </element>
+    </define>
+
+    <define name="locate-list">
+        <element name="nodes">
+            <attribute name="resource"> <text/> </attribute>
+            <zeroOrMore>
+                <element name="node">
+                    <optional>
+                        <attribute name="state"><value>promoted</value></attribute>
+                    </optional>
+                    <text/>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="rsc-location">
+        <element name="rsc_location">
+            <attribute name="node"> <text/> </attribute>
+            <attribute name="rsc"> <text/> </attribute>
+            <attribute name="id"> <text/> </attribute>
+            <externalRef href="../score.rng"/>
+        </element>
+    </define>
+
+    <define name="operations-list">
+        <element name="operations">
+            <oneOrMore>
+                <ref name="element-operation-list" />
+            </oneOrMore>
+        </element>
+    </define>
+
+    <define name="providers-list">
+        <element name="providers">
+            <attribute name="standard"> <value>ocf</value> </attribute>
+            <optional>
+                <attribute name="agent"> <text/> </attribute>
+            </optional>
+            <zeroOrMore>
+                <element name="provider"> <text/> </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="reasons-list">
+        <choice>
+            <ref name="no-resource-or-uname"/>
+            <ref name="resource-and-uname"/>
+            <ref name="no-resource-but-uname"/>
+            <ref name="resource-but-no-uname"/>
+        </choice>
+    </define>
+
+    <define name="no-resource-or-uname">
+        <element name="reason">
+            <element name="resources">
+                <zeroOrMore>
+                    <element name="resource">
+                        <attribute name="id"> <text/> </attribute>
+                        <attribute name="running"> <data type="boolean"/> </attribute>
+                        <ref name="resource-check"/>
+                    </element>
+                </zeroOrMore>
+            </element>
+        </element>
+    </define>
+
+    <define name="resource-and-uname">
+        <element name="reason">
+            <attribute name="running_on"> <text/> </attribute>
+            <ref name="resource-check"/>
+        </element>
+    </define>
+
+    <define name="no-resource-but-uname">
+        <element name="reason">
+            <element name="resources">
+                <zeroOrMore>
+                    <element name="resource">
+                        <attribute name="id"> <text/> </attribute>
+                        <attribute name="running"> <data type="boolean"/> </attribute>
+                        <attribute name="host"> <text/> </attribute>
+                        <ref name="resource-check"/>
+                    </element>
+                </zeroOrMore>
+            </element>
+        </element>
+    </define>
+
+    <define name="resource-but-no-uname">
+        <element name="reason">
+            <attribute name="running"> <data type="boolean"/> </attribute>
+            <ref name="resource-check"/>
+        </element>
+    </define>
+
+    <define name="resource-config">
+        <element name="resource_config">
+            <externalRef href="resources-2.4.rng" />
+            <element name="xml"> <text/> </element>
+        </element>
+    </define>
+
+    <define name="resource-check">
+        <element name="check">
+            <attribute name="id"> <text/> </attribute>
+            <optional>
+                <choice>
+                    <attribute name="remain_stopped"><value>true</value></attribute>
+                    <attribute name="promotable"><value>false</value></attribute>
+                </choice>
+            </optional>
+            <optional>
+                <attribute name="unmanaged"><value>true</value></attribute>
+            </optional>
+            <optional>
+                <attribute name="locked-to"> <text/> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="resources-list">
+        <element name="resources">
+            <zeroOrMore>
+                <externalRef href="resources-2.4.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="rsc-colocation">
+        <element name="rsc_colocation">
+            <attribute name="id"> <text/> </attribute>
+            <attribute name="rsc"> <text/> </attribute>
+            <attribute name="with-rsc"> <text/> </attribute>
+            <externalRef href="../score.rng"/>
+            <optional>
+                <attribute name="node-attribute"> <text/> </attribute>
+            </optional>
+            <optional>
+                <attribute name="rsc-role">
+                    <ref name="attribute-roles"/>
+                </attribute>
+            </optional>
+            <optional>
+                <attribute name="with-rsc-role">
+                    <ref name="attribute-roles"/>
+                </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="element-operation-list">
+        <element name="operation">
+            <optional>
+                <group>
+                    <attribute name="rsc"> <text/> </attribute>
+                    <attribute name="agent"> <text/> </attribute>
+                </group>
+            </optional>
+            <attribute name="op"> <text/> </attribute>
+            <attribute name="node"> <text/> </attribute>
+            <attribute name="call"> <data type="integer" /> </attribute>
+            <attribute name="rc"> <data type="nonNegativeInteger" /> </attribute>
+            <optional>
+                <attribute name="last-rc-change"> <text/> </attribute>
+                <attribute name="exec-time"> <data type="nonNegativeInteger" /> </attribute>
+            </optional>
+            <attribute name="status"> <text/> </attribute>
+        </element>
+    </define>
+
+    <define name="resource-agent-action">
+        <element name="resource-agent-action">
+            <attribute name="action"> <text/> </attribute>
+            <optional>
+                <attribute name="rsc"> <text/> </attribute>
+            </optional>
+            <attribute name="class"> <text/> </attribute>
+            <attribute name="type"> <text/> </attribute>
+            <optional>
+                <attribute name="provider"> <text/> </attribute>
+            </optional>
+            <optional>
+                <ref name="overrides-list"/>
+            </optional>
+            <ref name="agent-status"/>
+            <optional>
+                <choice>
+                    <element name="command">
+                        <text />
+                    </element>
+                    <externalRef href="command-output-1.0.rng"/>
+                </choice>
+            </optional>
+        </element>
+    </define>
+
+    <define name="overrides-list">
+        <element name="overrides">
+            <zeroOrMore>
+                <element name="override">
+                    <optional>
+                        <attribute name="rsc"> <text/> </attribute>
+                    </optional>
+                    <attribute name="name"> <text/> </attribute>
+                    <attribute name="value"> <text/> </attribute>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="agent-status">
+        <element name="agent-status">
+            <attribute name="code"> <data type="integer" /> </attribute>
+            <optional>
+                <attribute name="message"> <text/> </attribute>
+            </optional>
+            <optional>
+                <attribute name="execution_code"> <data type="integer" /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="execution_message"> <text/> </attribute>
+            </optional>
+            <optional>
+                <attribute name="reason"> <text/> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="attribute-roles">
+        <choice>
+            <value>Stopped</value>
+            <value>Started</value>
+            <value>Promoted</value>
+            <value>Unpromoted</value>
+
+            <!-- These synonyms for Promoted/Unpromoted are allowed for
+                 backward compatibility with output from older Pacemaker
+                 versions that used them -->
+            <value>Master</value>
+            <value>Slave</value>
+        </choice>
+    </define>
+</grammar>


### PR DESCRIPTION
crm_resource --why gives a list of reasons why a resource may be stopped. The same check is also done at the end of crm_resource --cleanup and --refresh. These checks now include a check for whether the specified node is unhealthy (or all of the resource's allowed nodes are unhealthy, if no node is specified) and the node healthy strategy prevents the resource from running.