### PR TITLE
Set fail-count and last-failure atomically

### DIFF
--- a/daemons/controld/controld_attrd.c
+++ b/daemons/controld/controld_attrd.c
@@ -137,6 +137,13 @@ update_attrd(const char *host, const char *name, const char *value,
 }
 
 void
+update_attrd_list(GList *attrs, uint32_t opts)
+{
+    pcmk__attrd_api_update_list(attrd_api, attrs, NULL, NULL, NULL,
+                                opts | pcmk__node_attr_value);
+}
+
+void
 update_attrd_remote_node_removed(const char *host, const char *user_name)
 {
     crm_trace("Asking attribute manager to purge Pacemaker Remote node %s",

--- a/daemons/controld/controld_attrd.c
+++ b/daemons/controld/controld_attrd.c
@@ -104,66 +104,23 @@ update_attrd_helper(const char *host, const char *name, const char *value,
         }
     }
 
-    for (int attempt = 1; attempt <= 4; ++attempt) {
-        rc = pcmk_rc_ok;
-
-        // If we're not already connected, try to connect
-        if (!pcmk_ipc_is_connected(attrd_api)) {
-            if (attempt == 1) {
-                // Start with a clean slate
-                pcmk_disconnect_ipc(attrd_api);
-            }
-
-            // Connect without a main loop, and with no callback either.
-            // We don't use any commands that expect a reply.
-            rc = pcmk_connect_ipc(attrd_api, pcmk_ipc_dispatch_sync);
-
-            crm_debug("Attribute manager connection attempt %d of 4: %s (%d)",
-                      attempt, pcmk_rc_str(rc), rc);
-        }
-
-        if (rc == pcmk_rc_ok) {
-            switch (command) {
-                case cmd_clear:
-                    /* name/value is really resource/operation */
-                    rc = pcmk__attrd_api_clear_failures(attrd_api, host, name,
-                                                        value, interval_spec,
-                                                        user_name, attrd_opts);
-                    break;
-
-                case cmd_update:
-                    rc = pcmk__attrd_api_update(attrd_api, host, name, value,
-                                                NULL, NULL, user_name,
-                                                attrd_opts | pcmk__node_attr_value);
-                    break;
-
-                case cmd_purge:
-                    rc = pcmk__attrd_api_purge(attrd_api, host);
-                    break;
-            }
-
-            crm_debug("Attribute manager request attempt %d of 4: %s (%d)",
-                      attempt, pcmk_rc_str(rc), rc);
-        }
-
-        if (rc == pcmk_rc_ok) {
-            // Success, we're done
+    switch (command) {
+        case cmd_clear:
+            /* name/value is really resource/operation */
+            rc = pcmk__attrd_api_clear_failures(attrd_api, host, name,
+                                                value, interval_spec,
+                                                user_name, attrd_opts);
             break;
 
-        } else if ((rc != EAGAIN) && (rc != EALREADY)) {
-            /* EAGAIN or EALREADY indicates a temporary block, so just try
-             * again. Otherwise, close the connection for a clean slate.
-             */
-            pcmk_disconnect_ipc(attrd_api);
-        }
+        case cmd_update:
+            rc = pcmk__attrd_api_update(attrd_api, host, name, value,
+                                        NULL, NULL, user_name,
+                                        attrd_opts | pcmk__node_attr_value);
+            break;
 
-        /* @TODO If the attribute manager remains unavailable the entire time,
-         * this function takes more than 6 seconds. Maybe set a timer for
-         * retries, to let the main loop do other work.
-         */
-        if (attempt < 4) {
-            sleep(attempt);
-        }
+        case cmd_purge:
+            rc = pcmk__attrd_api_purge(attrd_api, host);
+            break;
     }
 
     if (rc != pcmk_rc_ok) {

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -84,6 +84,7 @@ void populate_cib_nodes(enum node_update_flags flags, const char *source);
 void crm_update_quorum(gboolean quorum, gboolean force_update);
 void controld_close_attrd_ipc(void);
 void update_attrd(const char *host, const char *name, const char *value, const char *user_name, gboolean is_remote_node);
+void update_attrd_list(GList *attrs, uint32_t opts);
 void update_attrd_remote_node_removed(const char *host, const char *user_name);
 void update_attrd_clear_failures(const char *host, const char *rsc,
                                  const char *op, const char *interval_spec,

--- a/include/crm/common/ipc_attrd_internal.h
+++ b/include/crm/common/ipc_attrd_internal.h
@@ -50,14 +50,19 @@ typedef struct {
  * \internal
  * \brief Send a request to pacemaker-attrd to clear resource failure
  *
- * \param[in] api           Connection to pacemaker-attrd (or NULL to use
- *                          a temporary new connection)
+ * \param[in] api           pacemaker-attrd IPC object
  * \param[in] node          Affect only this node (or NULL for all nodes)
  * \param[in] resource      Name of resource to clear (or NULL for all)
  * \param[in] operation     Name of operation to clear (or NULL for all)
  * \param[in] interval_spec If operation is not NULL, its interval
  * \param[in] user_name     ACL user to pass to pacemaker-attrd
  * \param[in] options       Bitmask of pcmk__node_attr_opts
+ *
+ * \note If \p api is NULL, a new temporary connection will be created
+ *       just for this operation and destroyed afterwards.  If \p api is
+ *       not NULL but is not yet connected to pacemaker-attrd, the object
+ *       will be connected for this operation and left connected afterwards.
+ *       This allows for reusing an IPC connection.
  *
  * \return Standard Pacemaker return code
  */
@@ -86,9 +91,14 @@ int pcmk__attrd_api_delete(pcmk_ipc_api_t *api, const char *node, const char *na
  * \internal
  * \brief Purge a node from pacemaker-attrd
  *
- * \param[in] api           Connection to pacemaker-attrd (or NULL to use
- *                          a temporary new connection)
+ * \param[in] api           pacemaker-attrd IPC object
  * \param[in] node          Node to remove
+ *
+ * \note If \p api is NULL, a new temporary connection will be created
+ *       just for this operation and destroyed afterwards.  If \p api is
+ *       not NULL but is not yet connected to pacemaker-attrd, the object
+ *       will be connected for this operation and left connected afterwards.
+ *       This allows for reusing an IPC connection.
  *
  * \return Standard Pacemaker return code
  */
@@ -113,9 +123,14 @@ int pcmk__attrd_api_query(pcmk_ipc_api_t *api, const char *node, const char *nam
  * \internal
  * \brief Tell pacemaker-attrd to update the CIB with current values
  *
- * \param[in] api           Connection to pacemaker-attrd (or NULL to use
- *                          a temporary new connection)
+ * \param[in] api           pacemaker-attrd IPC object
  * \param[in] node          Affect only this node (or NULL for all nodes)
+ *
+ * \note If \p api is NULL, a new temporary connection will be created
+ *       just for this operation and destroyed afterwards.  If \p api is
+ *       not NULL but is not yet connected to pacemaker-attrd, the object
+ *       will be connected for this operation and left connected afterwards.
+ *       This allows for reusing an IPC connection.
  *
  * \return Standard Pacemaker return code
  */
@@ -125,8 +140,7 @@ int pcmk__attrd_api_refresh(pcmk_ipc_api_t *api, const char *node);
  * \internal
  * \brief Update an attribute's value, time to wait, or both
  *
- * \param[in] api           Connection to pacemaker-attrd (or NULL to use
- *                          a temporary new connection)
+ * \param[in] api           pacemaker-attrd IPC object
  * \param[in] node          Affect only this node (or NULL for current node)
  * \param[in] name          Attribute name
  * \param[in] value         The attribute's new value, or NULL to unset
@@ -134,6 +148,12 @@ int pcmk__attrd_api_refresh(pcmk_ipc_api_t *api, const char *node);
  * \param[in] set           ID of attribute set to use (or NULL to choose first)
  * \param[in] user_name     ACL user to pass to pacemaker-attrd
  * \param[in] options       Bitmask of pcmk__node_attr_opts
+ *
+ * \note If \p api is NULL, a new temporary connection will be created
+ *       just for this operation and destroyed afterwards.  If \p api is
+ *       not NULL but is not yet connected to pacemaker-attrd, the object
+ *       will be connected for this operation and left connected afterwards.
+ *       This allows for reusing an IPC connection.
  *
  * \return Standard Pacemaker return code
  */
@@ -145,19 +165,24 @@ int pcmk__attrd_api_update(pcmk_ipc_api_t *api, const char *node, const char *na
  * \internal
  * \brief Like pcmk__attrd_api_update, but for multiple attributes at once
  *
- * \param[in] api           Connection to pacemaker-attrd (or NULL to use
- *                          a temporary new connection)
+ * \param[in] api           pacemaker-attrd IPC object
  * \param[in] attrs         A list of pcmk__attr_query_pair_t structs
  * \param[in] dampen        The new time to wait value, or NULL to unset
  * \param[in] set           ID of attribute set to use (or NULL to choose first)
  * \param[in] user_name     ACL user to pass to pacemaker-attrd
  * \param[in] options       Bitmask of pcmk__node_attr_opts
  *
- * \return Standard Pacemaker return code
+ * \note If \p api is NULL, a new temporary connection will be created
+ *       just for this operation and destroyed afterwards.  If \p api is
+ *       not NULL but is not yet connected to pacemaker-attrd, the object
+ *       will be connected for this operation and left connected afterwards.
+ *       This allows for reusing an IPC connection.
  *
  * \note Not all attrd versions support setting multiple attributes at once.
  *       For those servers that do not, this function will fall back to just
  *       sending a separate IPC request for each attribute.
+ *
+ * \return Standard Pacemaker return code
  */
 int pcmk__attrd_api_update_list(pcmk_ipc_api_t *api, GList *attrs,
                                 const char *dampen, const char *set,

--- a/lib/common/ipc_attrd.c
+++ b/lib/common/ipc_attrd.c
@@ -232,6 +232,10 @@ pcmk__attrd_api_clear_failures(pcmk_ipc_api_t *api, const char *node,
 
         rc = connect_and_send_attrd_request(api, request);
         destroy_api(api);
+
+    } else if (!pcmk_ipc_is_connected(api)) {
+        rc = connect_and_send_attrd_request(api, request);
+
     } else {
         rc = send_attrd_request(api, request);
     }
@@ -301,6 +305,10 @@ pcmk__attrd_api_purge(pcmk_ipc_api_t *api, const char *node)
 
         rc = connect_and_send_attrd_request(api, request);
         destroy_api(api);
+
+    } else if (!pcmk_ipc_is_connected(api)) {
+        rc = connect_and_send_attrd_request(api, request);
+
     } else {
         rc = send_attrd_request(api, request);
     }
@@ -376,6 +384,10 @@ pcmk__attrd_api_refresh(pcmk_ipc_api_t *api, const char *node)
 
         rc = connect_and_send_attrd_request(api, request);
         destroy_api(api);
+
+    } else if (!pcmk_ipc_is_connected(api)) {
+        rc = connect_and_send_attrd_request(api, request);
+
     } else {
         rc = send_attrd_request(api, request);
     }
@@ -453,6 +465,10 @@ pcmk__attrd_api_update(pcmk_ipc_api_t *api, const char *node, const char *name,
 
         rc = connect_and_send_attrd_request(api, request);
         destroy_api(api);
+
+    } else if (!pcmk_ipc_is_connected(api)) {
+        rc = connect_and_send_attrd_request(api, request);
+
     } else {
         rc = send_attrd_request(api, request);
     }


### PR DESCRIPTION
I don't think the first two patches are strictly necessary, but it seems nice to keep a persistent connection and reduce the setup/teardown duplication.