### PR TITLE
Fix regressions in stonith_admin --validate

### DIFF
--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -528,10 +528,9 @@ validate_agent_xml(pcmk__output_t *out, va_list args) {
     char *error_output = va_arg(args, char *);
     int rc = va_arg(args, int);
 
-    xmlNodePtr node = pcmk__output_create_xml_node(out, "validate",
-                                                   "agent", agent,
-                                                   "valid", pcmk__btoa(rc),
-                                                   NULL);
+    xmlNodePtr node = pcmk__output_create_xml_node(
+        out, "validate", "agent", agent, "valid", pcmk__btoa(rc == pcmk_ok),
+        NULL);
 
     if (device != NULL) {
         crm_xml_add(node, "device", device);

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -130,15 +130,14 @@ stonith__rhcs_get_metadata(const char *agent, int timeout, xmlNode **metadata)
     stonith_action_t *action = stonith_action_create(agent, "metadata", NULL, 0,
                                                      5, NULL, NULL, NULL);
     int rc = stonith__execute(action);
+    result = stonith__action_result(action);
 
-    if (rc < 0) {
+    if (rc < 0 && result == NULL) {
         crm_warn("Could not execute metadata action for %s: %s "
                  CRM_XS " rc=%d", agent, pcmk_strerror(rc), rc);
         stonith__destroy_action(action);
         return rc;
     }
-
-    result = stonith__action_result(action);
 
     if (result->execution_status != PCMK_EXEC_DONE) {
         crm_warn("Could not execute metadata action for %s: %s",
@@ -262,6 +261,7 @@ stonith__rhcs_validate(stonith_t *st, int call_options, const char *target,
     int remaining_timeout = timeout;
     xmlNode *metadata = NULL;
     stonith_action_t *action = NULL;
+    pcmk__action_result_t *result = NULL;
 
     if (host_arg == NULL) {
         time_t start_time = time(NULL);
@@ -298,9 +298,9 @@ stonith__rhcs_validate(stonith_t *st, int call_options, const char *target,
                                    NULL, host_arg);
 
     rc = stonith__execute(action);
-    if (rc == pcmk_ok) {
-        pcmk__action_result_t *result = stonith__action_result(action);
+    result = stonith__action_result(action);
 
+    if (result != NULL) {
         rc = pcmk_rc2legacy(stonith__result2rc(result));
 
         // Take ownership of output so stonith__destroy_action() doesn't free it


### PR DESCRIPTION
If the fence agent returns a failure, the XML output does not include the stdout/stderr from the fence agent. The "valid" attribute is also set to the wrong boolean.

Regressions were introduced in https://github.com/ClusterLabs/pacemaker/commit/91a2b2e417d0d3b4ed310b5003879b8d0e2fc831 and https://github.com/ClusterLabs/pacemaker/commit/b441925e2da6b938db0674b98783d1dfb3d2a096.

Example:
```
<pacemaker-result api-version="2.20" request="stonith_admin --output-as=xml --validate --agent fence_apc">
  <validate agent="fence_apc" valid="true">
    <command code="-103"/>
  </validate>
  <status code="102" message="Not connected"/>
</pacemaker-result>
# echo $?
102
```

Before regressions (and after fix):
```
<pacemaker-result api-version="2.2" request="stonith_admin --output-as=xml --validate --agent fence_apc">
  <validate agent="fence_apc" valid="false">
    <command code="-201">
      <output source="stderr">2022-06-29 17:29:05,499 ERROR: Failed: You have to set login name

2022-06-29 17:29:05,500 ERROR: Failed: You have to enter fence address

2022-06-29 17:29:05,500 ERROR: Failed: You have to enter password, password script or identity file

2022-06-29 17:29:05,500 ERROR: validate-all failed

2022-06-29 17:29:05,500 ERROR: Please use '-h' for usage

</output>
    </command>
  </validate>
  <status code="1" message="Error occurred"/>
</pacemaker-result>
```

Resolves: RHBZ#2102292