### PR TITLE
Log: controller: log an info instead of a warning for a stonith/shutdown that is unknown to the new DC

### DIFF
--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -289,8 +289,13 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
             }
 
         } else if (appeared == FALSE) {
-            crm_warn("Stonith/shutdown of node %s was not expected",
-                     node->uname);
+            if (transition_graph == NULL || transition_graph->id == -1) {
+                crm_info("Stonith/shutdown of node %s is unknown to the "
+                         "current DC", node->uname);
+            } else {
+                crm_warn("Stonith/shutdown of node %s was not expected",
+                         node->uname);
+            }
             if (!is_remote) {
                 crm_update_peer_join(__func__, node, crm_join_none);
                 check_join_state(fsa_state, __func__);


### PR DESCRIPTION
If it happens to be the old DC that has just shut down, the new DC may
bring up this warning anyway. Although the message is more from the new
DC's point of view purely regarding whether the event matches any
running cluster transition, but it's confusing to end users since the
shutdown was scheduled and should be "expected".

Fixes T454