### PR TITLE
Best practices for some code related to promotable clones

### DIFF
--- a/cts/cts-scheduler.in
+++ b/cts/cts-scheduler.in
@@ -1011,6 +1011,7 @@ TESTS = [
         [ "remote-reconnect-delay", "Waiting for remote reconnect interval to expire" ],
         [ "remote-connection-unrecoverable",
           "Remote connection host must be fenced, with connection unrecoverable" ],
+        [ "remote-connection-shutdown", "Remote connection shutdown" ],
         [ "cancel-behind-moving-remote",
           "Route recurring monitor cancellations through original node of a moving remote connection" ],
     ],

--- a/cts/scheduler/scores/bug-5059.scores
+++ b/cts/scheduler/scores/bug-5059.scores
@@ -1,6 +1,6 @@
 
-g_stateful:0 promotion score on gluster01.h: 4
-g_stateful:1 promotion score on gluster02.h: 4
+g_stateful:0 promotion score on gluster01.h: 5
+g_stateful:1 promotion score on gluster02.h: 5
 g_stateful:2 promotion score on none: 0
 pcmk__clone_allocate: c_dummy allocation score on gluster01.h: 0
 pcmk__clone_allocate: c_dummy allocation score on gluster02.h: 0

--- a/cts/scheduler/scores/remote-connection-shutdown.scores
+++ b/cts/scheduler/scores/remote-connection-shutdown.scores
@@ -1,31 +1,4 @@
-Allocation scores:
-Only 'private' parameters to nova-evacuate_monitor_10000 on database-0 changed: 0:0;259:1420:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to nova-evacuate_start_0 on database-0 changed: 0:0;258:1420:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_compute-fence-nova for unfencing compute-0 changed
-Only 'private' parameters to stonith-fence_compute-fence-nova for unfencing compute-1 changed
-Only 'private' parameters to stonith-fence_ipmilan-5254001f5f3c_monitor_60000 on database-2 changed: 0:0;265:1422:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254001f5f3c_start_0 on database-2 changed: 0:0;263:1422:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-52540033df9c_monitor_60000 on database-1 changed: 0:0;263:1420:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-52540033df9c_start_0 on database-1 changed: 0:0;261:1420:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254003f88b4_monitor_60000 on messaging-0 changed: 0:0;269:1422:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254003f88b4_start_0 on messaging-0 changed: 0:0;267:1422:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400642894_monitor_60000 on messaging-2 changed: 0:0;274:1424:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400642894_start_0 on messaging-2 changed: 0:0;272:1424:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254007b7920_monitor_60000 on messaging-1 changed: 0:0;273:1422:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254007b7920_start_0 on messaging-1 changed: 0:0;271:1422:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254009cb549_monitor_60000 on database-0 changed: 0:0;323:1375:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254009cb549_start_0 on database-0 changed: 0:0;322:1375:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400bb150b_monitor_60000 on messaging-0 changed: 0:0;325:70:0:40f880e4-b328-4380-9703-47856390a1e0
-Only 'private' parameters to stonith-fence_ipmilan-525400bb150b_start_0 on messaging-0 changed: 0:0;324:70:0:40f880e4-b328-4380-9703-47856390a1e0
-Only 'private' parameters to stonith-fence_ipmilan-525400d5382b_monitor_60000 on database-2 changed: 0:0;320:1374:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400d5382b_start_0 on database-2 changed: 0:0;319:1374:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400dc0f81_monitor_60000 on database-1 changed: 0:0;331:1380:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400dc0f81_start_0 on database-1 changed: 0:0;330:1380:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400e10267_monitor_60000 on messaging-1 changed: 0:0;326:1318:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400e10267_start_0 on messaging-1 changed: 0:0;320:1317:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400ffc780_monitor_60000 on messaging-2 changed: 0:0;323:50:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400ffc780_start_0 on messaging-2 changed: 0:0;321:49:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Using the original execution date of: 2020-11-17 07:03:16Z
+
 galera:0 promotion score on galera-bundle-0: 100
 galera:1 promotion score on galera-bundle-1: 100
 galera:2 promotion score on galera-bundle-2: 100

--- a/cts/scheduler/summary/remote-connection-shutdown.summary
+++ b/cts/scheduler/summary/remote-connection-shutdown.summary
@@ -1,84 +1,59 @@
 Using the original execution date of: 2020-11-17 07:03:16Z
-
 Current cluster status:
-Online: [ controller-0 controller-1 controller-2 database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
-RemoteOnline: [ compute-0 compute-1 ]
-GuestOnline: [ galera-bundle-0:galera-bundle-podman-0 galera-bundle-1:galera-bundle-podman-1 galera-bundle-2:galera-bundle-podman-2 ovn-dbs-bundle-0:ovn-dbs-bundle-podman-0 ovn-dbs-bundle-1:ovn-dbs-bundle-podman-1 ovn-dbs-bundle-2:ovn-dbs-bundle-podman-2 rabbitmq-bundle-0:rabbitmq-bundle-podman-0 rabbitmq-bundle-1:rabbitmq-bundle-podman-1 rabbitmq-bundle-2:rabbitmq-bundle-podman-2 redis-bundle-0:redis-bundle-podman-0 redis-bundle-1:redis-bundle-podman-1 redis-bundle-2:redis-bundle-podman-2 ]
+  * Node List:
+    * Online: [ controller-0 controller-1 controller-2 database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
+    * RemoteOnline: [ compute-0 compute-1 ]
+    * GuestOnline: [ galera-bundle-0@database-0 galera-bundle-1@database-1 galera-bundle-2@database-2 ovn-dbs-bundle-0@controller-2 ovn-dbs-bundle-1@controller-0 ovn-dbs-bundle-2@controller-1 rabbitmq-bundle-0@messaging-0 rabbitmq-bundle-1@messaging-1 rabbitmq-bundle-2@messaging-2 redis-bundle-0@controller-2 redis-bundle-1@controller-0 redis-bundle-2@controller-1 ]
 
- compute-0	(ocf::pacemaker:remote):	 Started controller-0
- compute-1	(ocf::pacemaker:remote):	 Started controller-1
- Container bundle set: galera-bundle [cluster.common.tag/mariadb:pcmklatest]
-   galera-bundle-0	(ocf::heartbeat:galera):	 Master database-0
-   galera-bundle-1	(ocf::heartbeat:galera):	 Master database-1
-   galera-bundle-2	(ocf::heartbeat:galera):	 Master database-2
- Container bundle set: rabbitmq-bundle [cluster.common.tag/rabbitmq:pcmklatest]
-   rabbitmq-bundle-0	(ocf::heartbeat:rabbitmq-cluster):	 Started messaging-0
-   rabbitmq-bundle-1	(ocf::heartbeat:rabbitmq-cluster):	 Started messaging-1
-   rabbitmq-bundle-2	(ocf::heartbeat:rabbitmq-cluster):	 Started messaging-2
- Container bundle set: redis-bundle [cluster.common.tag/redis:pcmklatest]
-   redis-bundle-0	(ocf::heartbeat:redis):	 Master controller-2
-   redis-bundle-1	(ocf::heartbeat:redis):	 Slave controller-0
-   redis-bundle-2	(ocf::heartbeat:redis):	 Slave controller-1
- ip-192.168.24.150	(ocf::heartbeat:IPaddr2):	 Started controller-2
- ip-10.0.0.150	(ocf::heartbeat:IPaddr2):	 Started controller-0
- ip-172.17.1.151	(ocf::heartbeat:IPaddr2):	 Started controller-1
- ip-172.17.1.150	(ocf::heartbeat:IPaddr2):	 Started controller-2
- ip-172.17.3.150	(ocf::heartbeat:IPaddr2):	 Started controller-0
- ip-172.17.4.150	(ocf::heartbeat:IPaddr2):	 Started controller-1
- Container bundle set: haproxy-bundle [cluster.common.tag/haproxy:pcmklatest]
-   haproxy-bundle-podman-0	(ocf::heartbeat:podman):	 Started controller-2
-   haproxy-bundle-podman-1	(ocf::heartbeat:podman):	 Started controller-0
-   haproxy-bundle-podman-2	(ocf::heartbeat:podman):	 Started controller-1
- Container bundle set: ovn-dbs-bundle [cluster.common.tag/ovn-northd:pcmklatest]
-   ovn-dbs-bundle-0	(ocf::ovn:ovndb-servers):	 Master controller-2
-   ovn-dbs-bundle-1	(ocf::ovn:ovndb-servers):	 Slave controller-0
-   ovn-dbs-bundle-2	(ocf::ovn:ovndb-servers):	 Slave controller-1
- ip-172.17.1.57	(ocf::heartbeat:IPaddr2):	 Started controller-2
- stonith-fence_compute-fence-nova	(stonith:fence_compute):	 Stopped
- Clone Set: compute-unfence-trigger-clone [compute-unfence-trigger]
-     Started: [ compute-0 compute-1 ]
-     Stopped: [ controller-0 controller-1 controller-2 database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
- nova-evacuate	(ocf::openstack:NovaEvacuate):	 Started database-0
- stonith-fence_ipmilan-52540033df9c	(stonith:fence_ipmilan):	 Started database-1
- stonith-fence_ipmilan-5254001f5f3c	(stonith:fence_ipmilan):	 Started database-2
- stonith-fence_ipmilan-5254003f88b4	(stonith:fence_ipmilan):	 Started messaging-0
- stonith-fence_ipmilan-5254007b7920	(stonith:fence_ipmilan):	 Started messaging-1
- stonith-fence_ipmilan-525400642894	(stonith:fence_ipmilan):	 Started messaging-2
- stonith-fence_ipmilan-525400d5382b	(stonith:fence_ipmilan):	 Started database-2
- stonith-fence_ipmilan-525400bb150b	(stonith:fence_ipmilan):	 Started messaging-0
- stonith-fence_ipmilan-525400ffc780	(stonith:fence_ipmilan):	 Started messaging-2
- stonith-fence_ipmilan-5254009cb549	(stonith:fence_ipmilan):	 Started database-0
- stonith-fence_ipmilan-525400e10267	(stonith:fence_ipmilan):	 Started messaging-1
- stonith-fence_ipmilan-525400dc0f81	(stonith:fence_ipmilan):	 Started database-1
- Container bundle: openstack-cinder-volume [cluster.common.tag/cinder-volume:pcmklatest]
-   openstack-cinder-volume-podman-0	(ocf::heartbeat:podman):	 Started controller-0
+  * Full List of Resources:
+    * compute-0	(ocf:pacemaker:remote):	 Started controller-0
+    * compute-1	(ocf:pacemaker:remote):	 Started controller-1
+    * Container bundle set: galera-bundle [cluster.common.tag/mariadb:pcmklatest]:
+      * galera-bundle-0	(ocf:heartbeat:galera):	 Promoted database-0
+      * galera-bundle-1	(ocf:heartbeat:galera):	 Promoted database-1
+      * galera-bundle-2	(ocf:heartbeat:galera):	 Promoted database-2
+    * Container bundle set: rabbitmq-bundle [cluster.common.tag/rabbitmq:pcmklatest]:
+      * rabbitmq-bundle-0	(ocf:heartbeat:rabbitmq-cluster):	 Started messaging-0
+      * rabbitmq-bundle-1	(ocf:heartbeat:rabbitmq-cluster):	 Started messaging-1
+      * rabbitmq-bundle-2	(ocf:heartbeat:rabbitmq-cluster):	 Started messaging-2
+    * Container bundle set: redis-bundle [cluster.common.tag/redis:pcmklatest]:
+      * redis-bundle-0	(ocf:heartbeat:redis):	 Promoted controller-2
+      * redis-bundle-1	(ocf:heartbeat:redis):	 Unpromoted controller-0
+      * redis-bundle-2	(ocf:heartbeat:redis):	 Unpromoted controller-1
+    * ip-192.168.24.150	(ocf:heartbeat:IPaddr2):	 Started controller-2
+    * ip-10.0.0.150	(ocf:heartbeat:IPaddr2):	 Started controller-0
+    * ip-172.17.1.151	(ocf:heartbeat:IPaddr2):	 Started controller-1
+    * ip-172.17.1.150	(ocf:heartbeat:IPaddr2):	 Started controller-2
+    * ip-172.17.3.150	(ocf:heartbeat:IPaddr2):	 Started controller-0
+    * ip-172.17.4.150	(ocf:heartbeat:IPaddr2):	 Started controller-1
+    * Container bundle set: haproxy-bundle [cluster.common.tag/haproxy:pcmklatest]:
+      * haproxy-bundle-podman-0	(ocf:heartbeat:podman):	 Started controller-2
+      * haproxy-bundle-podman-1	(ocf:heartbeat:podman):	 Started controller-0
+      * haproxy-bundle-podman-2	(ocf:heartbeat:podman):	 Started controller-1
+    * Container bundle set: ovn-dbs-bundle [cluster.common.tag/ovn-northd:pcmklatest]:
+      * ovn-dbs-bundle-0	(ocf:ovn:ovndb-servers):	 Promoted controller-2
+      * ovn-dbs-bundle-1	(ocf:ovn:ovndb-servers):	 Unpromoted controller-0
+      * ovn-dbs-bundle-2	(ocf:ovn:ovndb-servers):	 Unpromoted controller-1
+    * ip-172.17.1.57	(ocf:heartbeat:IPaddr2):	 Started controller-2
+    * stonith-fence_compute-fence-nova	(stonith:fence_compute):	 Stopped
+    * Clone Set: compute-unfence-trigger-clone [compute-unfence-trigger]:
+      * Started: [ compute-0 compute-1 ]
+      * Stopped: [ controller-0 controller-1 controller-2 database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
+    * nova-evacuate	(ocf:openstack:NovaEvacuate):	 Started database-0
+    * stonith-fence_ipmilan-52540033df9c	(stonith:fence_ipmilan):	 Started database-1
+    * stonith-fence_ipmilan-5254001f5f3c	(stonith:fence_ipmilan):	 Started database-2
+    * stonith-fence_ipmilan-5254003f88b4	(stonith:fence_ipmilan):	 Started messaging-0
+    * stonith-fence_ipmilan-5254007b7920	(stonith:fence_ipmilan):	 Started messaging-1
+    * stonith-fence_ipmilan-525400642894	(stonith:fence_ipmilan):	 Started messaging-2
+    * stonith-fence_ipmilan-525400d5382b	(stonith:fence_ipmilan):	 Started database-2
+    * stonith-fence_ipmilan-525400bb150b	(stonith:fence_ipmilan):	 Started messaging-0
+    * stonith-fence_ipmilan-525400ffc780	(stonith:fence_ipmilan):	 Started messaging-2
+    * stonith-fence_ipmilan-5254009cb549	(stonith:fence_ipmilan):	 Started database-0
+    * stonith-fence_ipmilan-525400e10267	(stonith:fence_ipmilan):	 Started messaging-1
+    * stonith-fence_ipmilan-525400dc0f81	(stonith:fence_ipmilan):	 Started database-1
+    * Container bundle: openstack-cinder-volume [cluster.common.tag/cinder-volume:pcmklatest]:
+      * openstack-cinder-volume-podman-0	(ocf:heartbeat:podman):	 Started controller-0
 
-Only 'private' parameters to stonith-fence_compute-fence-nova for unfencing compute-0 changed
-Only 'private' parameters to stonith-fence_compute-fence-nova for unfencing compute-1 changed
-Only 'private' parameters to stonith-fence_ipmilan-5254009cb549_start_0 on database-0 changed: 0:0;322:1375:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254009cb549_monitor_60000 on database-0 changed: 0:0;323:1375:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to nova-evacuate_start_0 on database-0 changed: 0:0;258:1420:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to nova-evacuate_monitor_10000 on database-0 changed: 0:0;259:1420:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400dc0f81_start_0 on database-1 changed: 0:0;330:1380:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400dc0f81_monitor_60000 on database-1 changed: 0:0;331:1380:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-52540033df9c_start_0 on database-1 changed: 0:0;261:1420:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-52540033df9c_monitor_60000 on database-1 changed: 0:0;263:1420:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400d5382b_start_0 on database-2 changed: 0:0;319:1374:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400d5382b_monitor_60000 on database-2 changed: 0:0;320:1374:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254001f5f3c_start_0 on database-2 changed: 0:0;263:1422:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254001f5f3c_monitor_60000 on database-2 changed: 0:0;265:1422:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400e10267_start_0 on messaging-1 changed: 0:0;320:1317:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400e10267_monitor_60000 on messaging-1 changed: 0:0;326:1318:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254007b7920_start_0 on messaging-1 changed: 0:0;271:1422:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254007b7920_monitor_60000 on messaging-1 changed: 0:0;273:1422:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400bb150b_start_0 on messaging-0 changed: 0:0;324:70:0:40f880e4-b328-4380-9703-47856390a1e0
-Only 'private' parameters to stonith-fence_ipmilan-525400bb150b_monitor_60000 on messaging-0 changed: 0:0;325:70:0:40f880e4-b328-4380-9703-47856390a1e0
-Only 'private' parameters to stonith-fence_ipmilan-5254003f88b4_start_0 on messaging-0 changed: 0:0;267:1422:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-5254003f88b4_monitor_60000 on messaging-0 changed: 0:0;269:1422:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400642894_start_0 on messaging-2 changed: 0:0;272:1424:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400642894_monitor_60000 on messaging-2 changed: 0:0;274:1424:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400ffc780_start_0 on messaging-2 changed: 0:0;321:49:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
-Only 'private' parameters to stonith-fence_ipmilan-525400ffc780_monitor_60000 on messaging-2 changed: 0:0;323:50:0:51c2f6fa-d5ae-4ae7-b8df-b121f8ea9269
 Transition Summary:
  * Stop       compute-0                            (               controller-0 )   due to node availability
  * Start      stonith-fence_compute-fence-nova     (                 database-0 )  
@@ -91,7 +66,7 @@ Transition Summary:
  * Move       stonith-fence_ipmilan-525400ffc780   (  messaging-2 -> database-0 )  
  * Move       stonith-fence_ipmilan-5254009cb549   (   database-0 -> database-1 )  
 
-Executing cluster transition:
+Executing Cluster Transition:
  * Resource action: stonith-fence_compute-fence-nova start on database-0
  * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on messaging-2
  * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on messaging-0
@@ -130,57 +105,58 @@ Executing cluster transition:
  * Resource action: stonith-fence_ipmilan-5254009cb549 monitor=60000 on database-1
 Using the original execution date of: 2020-11-17 07:03:16Z
 
-Revised cluster status:
-Online: [ controller-0 controller-1 controller-2 database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
-RemoteOnline: [ compute-1 ]
-RemoteOFFLINE: [ compute-0 ]
-GuestOnline: [ galera-bundle-0:galera-bundle-podman-0 galera-bundle-1:galera-bundle-podman-1 galera-bundle-2:galera-bundle-podman-2 ovn-dbs-bundle-0:ovn-dbs-bundle-podman-0 ovn-dbs-bundle-1:ovn-dbs-bundle-podman-1 ovn-dbs-bundle-2:ovn-dbs-bundle-podman-2 rabbitmq-bundle-0:rabbitmq-bundle-podman-0 rabbitmq-bundle-1:rabbitmq-bundle-podman-1 rabbitmq-bundle-2:rabbitmq-bundle-podman-2 redis-bundle-0:redis-bundle-podman-0 redis-bundle-1:redis-bundle-podman-1 redis-bundle-2:redis-bundle-podman-2 ]
+Revised Cluster Status:
+  * Node List:
+    * Online: [ controller-0 controller-1 controller-2 database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
+    * RemoteOnline: [ compute-1 ]
+    * RemoteOFFLINE: [ compute-0 ]
+    * GuestOnline: [ galera-bundle-0@database-0 galera-bundle-1@database-1 galera-bundle-2@database-2 ovn-dbs-bundle-0@controller-2 ovn-dbs-bundle-1@controller-0 ovn-dbs-bundle-2@controller-1 rabbitmq-bundle-0@messaging-0 rabbitmq-bundle-1@messaging-1 rabbitmq-bundle-2@messaging-2 redis-bundle-0@controller-2 redis-bundle-1@controller-0 redis-bundle-2@controller-1 ]
 
- compute-0	(ocf::pacemaker:remote):	 Stopped
- compute-1	(ocf::pacemaker:remote):	 Started controller-1
- Container bundle set: galera-bundle [cluster.common.tag/mariadb:pcmklatest]
-   galera-bundle-0	(ocf::heartbeat:galera):	 Master database-0
-   galera-bundle-1	(ocf::heartbeat:galera):	 Master database-1
-   galera-bundle-2	(ocf::heartbeat:galera):	 Master database-2
- Container bundle set: rabbitmq-bundle [cluster.common.tag/rabbitmq:pcmklatest]
-   rabbitmq-bundle-0	(ocf::heartbeat:rabbitmq-cluster):	 Started messaging-0
-   rabbitmq-bundle-1	(ocf::heartbeat:rabbitmq-cluster):	 Started messaging-1
-   rabbitmq-bundle-2	(ocf::heartbeat:rabbitmq-cluster):	 Started messaging-2
- Container bundle set: redis-bundle [cluster.common.tag/redis:pcmklatest]
-   redis-bundle-0	(ocf::heartbeat:redis):	 Master controller-2
-   redis-bundle-1	(ocf::heartbeat:redis):	 Slave controller-0
-   redis-bundle-2	(ocf::heartbeat:redis):	 Slave controller-1
- ip-192.168.24.150	(ocf::heartbeat:IPaddr2):	 Started controller-2
- ip-10.0.0.150	(ocf::heartbeat:IPaddr2):	 Started controller-0
- ip-172.17.1.151	(ocf::heartbeat:IPaddr2):	 Started controller-1
- ip-172.17.1.150	(ocf::heartbeat:IPaddr2):	 Started controller-2
- ip-172.17.3.150	(ocf::heartbeat:IPaddr2):	 Started controller-0
- ip-172.17.4.150	(ocf::heartbeat:IPaddr2):	 Started controller-1
- Container bundle set: haproxy-bundle [cluster.common.tag/haproxy:pcmklatest]
-   haproxy-bundle-podman-0	(ocf::heartbeat:podman):	 Started controller-2
-   haproxy-bundle-podman-1	(ocf::heartbeat:podman):	 Started controller-0
-   haproxy-bundle-podman-2	(ocf::heartbeat:podman):	 Started controller-1
- Container bundle set: ovn-dbs-bundle [cluster.common.tag/ovn-northd:pcmklatest]
-   ovn-dbs-bundle-0	(ocf::ovn:ovndb-servers):	 Master controller-2
-   ovn-dbs-bundle-1	(ocf::ovn:ovndb-servers):	 Slave controller-0
-   ovn-dbs-bundle-2	(ocf::ovn:ovndb-servers):	 Slave controller-1
- ip-172.17.1.57	(ocf::heartbeat:IPaddr2):	 Started controller-2
- stonith-fence_compute-fence-nova	(stonith:fence_compute):	 Started database-0
- Clone Set: compute-unfence-trigger-clone [compute-unfence-trigger]
-     Started: [ compute-1 ]
-     Stopped: [ compute-0 controller-0 controller-1 controller-2 database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
- nova-evacuate	(ocf::openstack:NovaEvacuate):	 Started database-1
- stonith-fence_ipmilan-52540033df9c	(stonith:fence_ipmilan):	 Started database-2
- stonith-fence_ipmilan-5254001f5f3c	(stonith:fence_ipmilan):	 Started messaging-0
- stonith-fence_ipmilan-5254003f88b4	(stonith:fence_ipmilan):	 Started messaging-1
- stonith-fence_ipmilan-5254007b7920	(stonith:fence_ipmilan):	 Started messaging-2
- stonith-fence_ipmilan-525400642894	(stonith:fence_ipmilan):	 Started messaging-2
- stonith-fence_ipmilan-525400d5382b	(stonith:fence_ipmilan):	 Started database-2
- stonith-fence_ipmilan-525400bb150b	(stonith:fence_ipmilan):	 Started messaging-0
- stonith-fence_ipmilan-525400ffc780	(stonith:fence_ipmilan):	 Started database-0
- stonith-fence_ipmilan-5254009cb549	(stonith:fence_ipmilan):	 Started database-1
- stonith-fence_ipmilan-525400e10267	(stonith:fence_ipmilan):	 Started messaging-1
- stonith-fence_ipmilan-525400dc0f81	(stonith:fence_ipmilan):	 Started database-1
- Container bundle: openstack-cinder-volume [cluster.common.tag/cinder-volume:pcmklatest]
-   openstack-cinder-volume-podman-0	(ocf::heartbeat:podman):	 Started controller-0
-
+  * Full List of Resources:
+    * compute-0	(ocf:pacemaker:remote):	 Stopped
+    * compute-1	(ocf:pacemaker:remote):	 Started controller-1
+    * Container bundle set: galera-bundle [cluster.common.tag/mariadb:pcmklatest]:
+      * galera-bundle-0	(ocf:heartbeat:galera):	 Promoted database-0
+      * galera-bundle-1	(ocf:heartbeat:galera):	 Promoted database-1
+      * galera-bundle-2	(ocf:heartbeat:galera):	 Promoted database-2
+    * Container bundle set: rabbitmq-bundle [cluster.common.tag/rabbitmq:pcmklatest]:
+      * rabbitmq-bundle-0	(ocf:heartbeat:rabbitmq-cluster):	 Started messaging-0
+      * rabbitmq-bundle-1	(ocf:heartbeat:rabbitmq-cluster):	 Started messaging-1
+      * rabbitmq-bundle-2	(ocf:heartbeat:rabbitmq-cluster):	 Started messaging-2
+    * Container bundle set: redis-bundle [cluster.common.tag/redis:pcmklatest]:
+      * redis-bundle-0	(ocf:heartbeat:redis):	 Promoted controller-2
+      * redis-bundle-1	(ocf:heartbeat:redis):	 Unpromoted controller-0
+      * redis-bundle-2	(ocf:heartbeat:redis):	 Unpromoted controller-1
+    * ip-192.168.24.150	(ocf:heartbeat:IPaddr2):	 Started controller-2
+    * ip-10.0.0.150	(ocf:heartbeat:IPaddr2):	 Started controller-0
+    * ip-172.17.1.151	(ocf:heartbeat:IPaddr2):	 Started controller-1
+    * ip-172.17.1.150	(ocf:heartbeat:IPaddr2):	 Started controller-2
+    * ip-172.17.3.150	(ocf:heartbeat:IPaddr2):	 Started controller-0
+    * ip-172.17.4.150	(ocf:heartbeat:IPaddr2):	 Started controller-1
+    * Container bundle set: haproxy-bundle [cluster.common.tag/haproxy:pcmklatest]:
+      * haproxy-bundle-podman-0	(ocf:heartbeat:podman):	 Started controller-2
+      * haproxy-bundle-podman-1	(ocf:heartbeat:podman):	 Started controller-0
+      * haproxy-bundle-podman-2	(ocf:heartbeat:podman):	 Started controller-1
+    * Container bundle set: ovn-dbs-bundle [cluster.common.tag/ovn-northd:pcmklatest]:
+      * ovn-dbs-bundle-0	(ocf:ovn:ovndb-servers):	 Promoted controller-2
+      * ovn-dbs-bundle-1	(ocf:ovn:ovndb-servers):	 Unpromoted controller-0
+      * ovn-dbs-bundle-2	(ocf:ovn:ovndb-servers):	 Unpromoted controller-1
+    * ip-172.17.1.57	(ocf:heartbeat:IPaddr2):	 Started controller-2
+    * stonith-fence_compute-fence-nova	(stonith:fence_compute):	 Started database-0
+    * Clone Set: compute-unfence-trigger-clone [compute-unfence-trigger]:
+      * Started: [ compute-1 ]
+      * Stopped: [ compute-0 controller-0 controller-1 controller-2 database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
+    * nova-evacuate	(ocf:openstack:NovaEvacuate):	 Started database-1
+    * stonith-fence_ipmilan-52540033df9c	(stonith:fence_ipmilan):	 Started database-2
+    * stonith-fence_ipmilan-5254001f5f3c	(stonith:fence_ipmilan):	 Started messaging-0
+    * stonith-fence_ipmilan-5254003f88b4	(stonith:fence_ipmilan):	 Started messaging-1
+    * stonith-fence_ipmilan-5254007b7920	(stonith:fence_ipmilan):	 Started messaging-2
+    * stonith-fence_ipmilan-525400642894	(stonith:fence_ipmilan):	 Started messaging-2
+    * stonith-fence_ipmilan-525400d5382b	(stonith:fence_ipmilan):	 Started database-2
+    * stonith-fence_ipmilan-525400bb150b	(stonith:fence_ipmilan):	 Started messaging-0
+    * stonith-fence_ipmilan-525400ffc780	(stonith:fence_ipmilan):	 Started database-0
+    * stonith-fence_ipmilan-5254009cb549	(stonith:fence_ipmilan):	 Started database-1
+    * stonith-fence_ipmilan-525400e10267	(stonith:fence_ipmilan):	 Started messaging-1
+    * stonith-fence_ipmilan-525400dc0f81	(stonith:fence_ipmilan):	 Started database-1
+    * Container bundle: openstack-cinder-volume [cluster.common.tag/cinder-volume:pcmklatest]:
+      * openstack-cinder-volume-podman-0	(ocf:heartbeat:podman):	 Started controller-0

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -127,7 +127,7 @@ G_GNUC_INTERNAL
 void pcmk__apply_location(pe__location_t *constraint, pe_resource_t *rsc);
 
 
-// Colocation constraints
+// Colocation constraints (pcmk_sched_colocation.c)
 
 enum pcmk__coloc_affects {
     pcmk__coloc_affects_nothing = 0,
@@ -150,6 +150,11 @@ G_GNUC_INTERNAL
 void pcmk__apply_coloc_to_priority(pe_resource_t *dependent,
                                    pe_resource_t *primary,
                                    pcmk__colocation_t *constraint);
+
+G_GNUC_INTERNAL
+void pcmk__apply_colocation(pcmk__colocation_t *colocation,
+                            pe_resource_t *rsc1, pe_resource_t *rsc2,
+                            uint32_t flags);
 
 G_GNUC_INTERNAL
 void pcmk__unpack_colocation(xmlNode *xml_obj, pe_working_set_t *data_set);

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -317,13 +317,10 @@ pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *prefer,
     for (GList *gIter = rsc->rsc_cons_lhs; gIter != NULL; gIter = gIter->next) {
         pcmk__colocation_t *constraint = (pcmk__colocation_t *) gIter->data;
 
-        if (!pcmk__colocation_has_influence(constraint, NULL)) {
-            continue;
+        if (pcmk__colocation_has_influence(constraint, NULL)) {
+            pcmk__apply_colocation(constraint, rsc, constraint->dependent,
+                                   pe_weights_rollback|pe_weights_positive);
         }
-        rsc->allowed_nodes = constraint->dependent->cmds->merge_weights(
-            constraint->dependent, rsc->id, rsc->allowed_nodes,
-            constraint->node_attribute, (float)constraint->score / INFINITY,
-            (pe_weights_rollback | pe_weights_positive));
     }
 
     pe__show_node_weights(!pcmk_is_set(data_set->flags, pe_flag_show_scores),

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -1063,3 +1063,25 @@ pcmk__apply_coloc_to_priority(pe_resource_t *dependent, pe_resource_t *primary,
     dependent->priority = pcmk__add_scores(score_multiplier * constraint->score,
                                            dependent->priority);
 }
+
+/*!
+ * \internal
+ * \brief Apply a colocation constraint to allowed nodes' weights
+ *
+ * \param[in] colocation   Colocation constraint to apply
+ * \param[in] rsc1         Resource whose allowed nodes should be updated
+ * \param[in] rsc2         Resource whose preferences should be added
+ * \param[in] flags        Flags (enum pe_weights) to apply when adding scores
+ */
+void
+pcmk__apply_colocation(pcmk__colocation_t *colocation, pe_resource_t *rsc1,
+                       pe_resource_t *rsc2, uint32_t flags)
+{
+    CRM_ASSERT((colocation != NULL) && (rsc1 != NULL) && (rsc2 != NULL));
+
+    rsc1->allowed_nodes = rsc2->cmds->merge_weights(rsc2, rsc1->id,
+                                                    rsc1->allowed_nodes,
+                                                    colocation->node_attribute,
+                                                    colocation->score / (float) INFINITY,
+                                                    flags);
+}

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -554,10 +554,8 @@ pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *prefer,
         pe_rsc_trace(rsc, "Merging score of '%s' constraint (%s with %s)",
                      constraint->id, constraint->dependent->id,
                      constraint->primary->id);
-        rsc->allowed_nodes = constraint->dependent->cmds->merge_weights(
-            constraint->dependent, rsc->id, rsc->allowed_nodes,
-            constraint->node_attribute, constraint->score / (float) INFINITY,
-            pe_weights_rollback);
+        pcmk__apply_colocation(constraint, rsc, constraint->dependent,
+                               pe_weights_rollback);
     }
 
     if (rsc->next_role == RSC_ROLE_STOPPED) {

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -614,17 +614,28 @@ check_allowed:
     return false;
 }
 
+/*!
+ * \internal
+ * \brief Get the value of a promotion score node attribute
+ *
+ * \param[in] rsc   Promotable clone instance to get promotion score for
+ * \param[in] node  Node to get promotion score for
+ * \param[in] name  Resource name to use in promotion score attribute name
+ *
+ * \return Value of promotion score node attribute for \p rsc on \p node
+ */
 static const char *
-lookup_promotion_score(pe_resource_t *rsc, const pe_node_t *node, const char *name)
+promotion_attr_value(pe_resource_t *rsc, const pe_node_t *node,
+                     const char *name)
 {
+    char *attr_name = NULL;
     const char *attr_value = NULL;
 
-    if (node && name) {
-        char *attr_name = pcmk_promotion_score_name(name);
+    CRM_CHECK((rsc != NULL) && (node != NULL) && (name != NULL), return NULL);
 
-        attr_value = pe_node_attribute_calculated(node, attr_name, rsc);
-        free(attr_name);
-    }
+    attr_name = pcmk_promotion_score_name(name);
+    attr_value = pe_node_attribute_calculated(node, attr_name, rsc);
+    free(attr_name);
     return attr_value;
 }
 
@@ -664,7 +675,7 @@ promotion_score(pe_resource_t *rsc, const pe_node_t *node, int not_set_value)
         name = rsc->clone_name;
     }
 
-    attr_value = lookup_promotion_score(rsc, node, name);
+    attr_value = promotion_attr_value(rsc, node, name);
     pe_rsc_trace(rsc, "Promotion score for %s on %s = %s",
                  name, node->details->uname, pcmk__s(attr_value, "(unset)"));
 
@@ -675,7 +686,7 @@ promotion_score(pe_resource_t *rsc, const pe_node_t *node, int not_set_value)
          */
         name = clone_strip(rsc->id);
         if (strcmp(rsc->id, name)) {
-            attr_value = lookup_promotion_score(rsc, node, name);
+            attr_value = promotion_attr_value(rsc, node, name);
             pe_rsc_trace(rsc, "Stripped promotion score for %s on %s = %s",
                          name, node->details->uname,
                          pcmk__s(attr_value, "(unset)"));

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -366,10 +366,8 @@ promotion_order(pe_resource_t *rsc, pe_working_set_t *data_set)
             pe_rsc_trace(rsc, "RHS: %s with %s: %d",
                          constraint->dependent->id, constraint->primary->id,
                          constraint->score);
-            rsc->allowed_nodes = constraint->primary->cmds->merge_weights(
-                constraint->primary, rsc->id, rsc->allowed_nodes,
-                constraint->node_attribute,
-                constraint->score / (float) INFINITY, flags);
+            pcmk__apply_colocation(constraint, rsc, constraint->primary,
+                                   flags);
         }
     }
 
@@ -388,11 +386,8 @@ promotion_order(pe_resource_t *rsc, pe_working_set_t *data_set)
             pe_rsc_trace(rsc, "LHS: %s with %s: %d",
                          constraint->dependent->id, constraint->primary->id,
                          constraint->score);
-            rsc->allowed_nodes = constraint->dependent->cmds->merge_weights(
-                constraint->dependent, rsc->id, rsc->allowed_nodes,
-                constraint->node_attribute,
-                constraint->score / (float) INFINITY,
-                pe_weights_rollback|pe_weights_positive);
+            pcmk__apply_colocation(constraint, rsc, constraint->dependent,
+                                   pe_weights_rollback|pe_weights_positive);
         }
     }
 


### PR DESCRIPTION
This continues the unending project to bring libpacemaker up to current development guidelines, focusing on some of pcmk_sched_promotable.c. One bug that was discovered in the process is fixed.

This also enables a scheduler regression test that was added more than a year ago but not enabled.