### PR TITLE
strings.c: don't expect strcmp() return one-byte values

### DIFF
--- a/doc/sphinx/Pacemaker_Development/helpers.rst
+++ b/doc/sphinx/Pacemaker_Development/helpers.rst
@@ -333,8 +333,8 @@ expression matching:
        const char *s1 = "abcd";
        const char *s2 = "ABCD";
 
-       assert_int_equal(pcmk__strcmp(NULL, "a..d", pcmk__str_regex), 1);
-       assert_int_equal(pcmk__strcmp(s1, NULL, pcmk__str_regex), 1);
+       assert_true(pcmk__strcmp(NULL, "a..d", pcmk__str_regex) < 0);
+       assert_true(pcmk__strcmp(s1, NULL, pcmk__str_regex) > 0);
        assert_int_equal(pcmk__strcmp(s1, "a..d", pcmk__str_regex), 0);
    }
 

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -1090,10 +1090,10 @@ pcmk__numeric_strcasecmp(const char *s1, const char *s2)
  *                  match if pcmk__str_regex is set
  * \param[in] flags A bitfield of pcmk__str_flags to modify operation
  *
- * \retval -1 \p s1 is NULL or comes before \p s2
+ * \retval  negative \p s1 is NULL or comes before \p s2
  * \retval  0 \p s1 and \p s2 are equal, or \p s1 is found in \p s2 if
  *            pcmk__str_regex is set
- * \retval  1 \p s2 is NULL or \p s1 comes after \p s2, or if \p s2
+ * \retval  positive \p s2 is NULL or \p s1 comes after \p s2, or \p s2
  *            is an invalid regular expression, or \p s1 was not found
  *            in \p s2 if pcmk__str_regex is set.
  */

--- a/lib/common/tests/strings/pcmk__strcmp_test.c
+++ b/lib/common/tests/strings/pcmk__strcmp_test.c
@@ -34,9 +34,9 @@ one_is_null(void **state) {
     assert_int_equal(pcmk__strcmp(s1, NULL, pcmk__str_null_matches), 0);
     assert_true(pcmk__str_eq(s1, NULL, pcmk__str_null_matches));
     assert_int_equal(pcmk__strcmp(NULL, s1, pcmk__str_null_matches), 0);
-    assert_in_range(pcmk__strcmp(s1, NULL, pcmk__str_none), 1, 255);
+    assert_true(pcmk__strcmp(s1, NULL, pcmk__str_none) > 0);
     assert_false(pcmk__str_eq(s1, NULL, pcmk__str_none));
-    assert_in_range(pcmk__strcmp(NULL, s1, pcmk__str_none), -255, -1);
+    assert_true(pcmk__strcmp(NULL, s1, pcmk__str_none) < 0);
 }
 
 static void
@@ -44,9 +44,9 @@ case_matters(void **state) {
     const char *s1 = "abcd";
     const char *s2 = "ABCD";
 
-    assert_in_range(pcmk__strcmp(s1, s2, pcmk__str_none), 1, 255);
+    assert_true(pcmk__strcmp(s1, s2, pcmk__str_none) > 0);
     assert_false(pcmk__str_eq(s1, s2, pcmk__str_none));
-    assert_in_range(pcmk__strcmp(s2, s1, pcmk__str_none), -255, -1);
+    assert_true(pcmk__strcmp(s2, s1, pcmk__str_none) < 0);
 }
 
 static void
@@ -63,8 +63,8 @@ regex(void **state) {
     const char *s1 = "abcd";
     const char *s2 = "ABCD";
 
-    assert_int_equal(pcmk__strcmp(NULL, "a..d", pcmk__str_regex), 1);
-    assert_int_equal(pcmk__strcmp(s1, NULL, pcmk__str_regex), 1);
+    assert_true(pcmk__strcmp(NULL, "a..d", pcmk__str_regex) > 0);
+    assert_true(pcmk__strcmp(s1, NULL, pcmk__str_regex) > 0);
     assert_int_equal(pcmk__strcmp(s1, "a..d", pcmk__str_regex), 0);
     assert_true(pcmk__str_eq(s1, "a..d", pcmk__str_regex));
     assert_int_not_equal(pcmk__strcmp(s1, "xxyy", pcmk__str_regex), 0);
@@ -73,7 +73,7 @@ regex(void **state) {
     assert_true(pcmk__str_eq(s2, "a..d", pcmk__str_regex|pcmk__str_casei));
     assert_int_not_equal(pcmk__strcmp(s2, "a..d", pcmk__str_regex), 0);
     assert_false(pcmk__str_eq(s2, "a..d", pcmk__str_regex));
-    assert_int_equal(pcmk__strcmp(s2, "*ab", pcmk__str_regex), 1);
+    assert_true(pcmk__strcmp(s2, "*ab", pcmk__str_regex) > 0);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Affects documentation and some tests only (revealed on 32-bit
PowerPC).