### PR TITLE
Mid: fenced: Fencing escalation may not be performed if there is no topology.

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2507,6 +2507,20 @@ send_async_reply(async_command_t *cmd, const pcmk__action_result_t *result,
                   cmd->action, cmd->victim);
         crm_xml_add(reply, F_SUBTYPE, "broadcast");
         crm_xml_add(reply, F_STONITH_OPERATION, T_STONITH_NOTIFY);
+
+        if (result->exit_status != CRM_EX_OK) {
+            remote_fencing_op_t *op = NULL;
+
+            op = calloc(1, sizeof(remote_fencing_op_t));
+            CRM_ASSERT(op != NULL);
+            /* Get the failed time. */
+            set_fencing_completed(op);
+            crm_xml_add_int(reply, F_STONITH_TIMEOUT, cmd->timeout);
+            crm_xml_add_ll(reply, F_STONITH_DATE, op->completed);
+            crm_xml_add_ll(reply, F_STONITH_DATE_NSEC, op->completed_nsec);
+
+            free(op);
+        }
         send_cluster_message(NULL, crm_msg_stonith_ng, reply, FALSE);
     } else {
         // Reply only to the originator

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -1262,6 +1262,7 @@ stonith_cleanup(void)
     crm_peer_destroy();
     pcmk__client_cleanup();
     free_stonith_remote_op_list();
+    free_check_async_reply_list();
     free_topology_list();
     free_device_list();
     free_metadata_cache();

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -203,11 +203,22 @@ typedef struct stonith_topology_s {
 
 } stonith_topology_t;
 
+typedef struct check_async_reply {
+    char *remote_op_id;
+    xmlNode *msg;
+    time_t completed;
+    long long completed_nsec;
+    int timeout; /* seconds */
+    guint timer;
+
+} check_async_reply_t;
+
 void init_device_list(void);
 void free_device_list(void);
 void init_topology_list(void);
 void free_topology_list(void);
 void free_stonith_remote_op_list(void);
+void free_check_async_reply_list(void);
 void init_stonith_remote_op_hash_table(GHashTable **table);
 void free_metadata_cache(void);
 void fenced_unregister_handlers(void);
@@ -288,3 +299,4 @@ extern long stonith_watchdog_timeout_ms;
 extern GList *stonith_watchdog_targets;
 
 extern GHashTable *stonith_remote_op_list;
+extern GHashTable *check_async_reply_list;

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -147,6 +147,7 @@ void stonith__device_parameter_flags(uint32_t *device_flags,
 #  define F_STONITH_DEVICE        "st_device_id"
 #  define F_STONITH_ACTION        "st_device_action"
 #  define F_STONITH_MERGED        "st_op_merged"
+# define F_STONITH_SET_COMPLETED "st_op_set_completed"
 
 #  define T_STONITH_NG        "stonith-ng"
 #  define T_STONITH_REPLY     "st-reply"


### PR DESCRIPTION
Hi All,

I was very late.
This fix is a modified version of the following WIP PR.
 - https://github.com/ClusterLabs/pacemaker/pull/2401
 
In response to previous comments, we have changed the process significantly.
The original problem is that the fencing escalation of the DC node fails in the absence of topology.

 * Broadcast failure to notify you of fencing failures.
 * Nodes other than the DC node that received this fencing failure will track subsequent escalation fencing with a timer to prevent it from floating in pending.
 * The failure time will always skip the set in finalize_op to save the time of failure.


What I thought about writing this fix was that, as I received a comment before, it may be better to relay to another node and fencing even if there is no topology.

Best Regards,
Hideo Yamauchi.