### PR TITLE
Low: daemons: Fix a bug processing child XML messages in attrd.

### DIFF
--- a/daemons/attrd/attrd_commands.c
+++ b/daemons/attrd/attrd_commands.c
@@ -271,7 +271,7 @@ attrd_client_update(xmlNode *xml)
              */
             for (xmlNode *child = first_named_child(xml, XML_ATTR_OP); child != NULL;
                  child = crm_next_same_xml(child)) {
-                attrd_client_update(xml);
+                attrd_client_update(child);
             }
         }
 


### PR DESCRIPTION
Before, we were just calling attrd_client_update again on the whole
top-level node.  The intention here is that we would pass each child to
attrd_client_update in turn.  This has probably not turned up yet
because it requires a cluster with mixed versions of attrd, in addition
to only happening when messages between daemons are sent.  Normal
command line tool usage will not run into this.

This was introduced by 2e9b5ef562.