### PR TITLE
High: tools: Add the -q option back to attrd_updater.

### DIFF
--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -49,6 +49,7 @@ struct {
     char *attr_value;
     int attr_options;
     gboolean query_all;
+    gboolean quiet;
 } options = {
     .attr_options = pcmk__node_attr_none,
     .command = 'Q',
@@ -177,6 +178,10 @@ static GOptionEntry addl_entries[] = {
 };
 
 static GOptionEntry deprecated_entries[] = {
+    { "quiet", 'q', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &options.quiet,
+      NULL,
+      NULL },
+
     { "update", 'v', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_CALLBACK, command_cb,
       NULL,
       NULL },


### PR DESCRIPTION
This option is deprecated and unused, but should still be recognized.

Regression in 2.1.3 introduced by ef0e8a5f63.

Fixes T526
See rhbz#2110452