### PR TITLE
Rename internal libcib symbols for IPC request types

### DIFF
--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -315,8 +315,9 @@ attrd_write_attribute(attribute_t *a, bool ignore_delay)
     if (cib_updates) {
         crm_log_xml_trace(xml_top, __func__);
 
-        a->update = cib_internal_op(the_cib, CIB_OP_MODIFY, NULL, XML_CIB_TAG_STATUS, xml_top, NULL,
-                                    flags, a->user);
+        a->update = cib_internal_op(the_cib, PCMK__CIB_REQUEST_MODIFY, NULL,
+                                    XML_CIB_TAG_STATUS, xml_top, NULL, flags,
+                                    a->user);
 
         crm_info("Sent CIB request %d with %d change%s for %s (id %s, set %s)",
                  a->update, cib_updates, pcmk__plural_s(cib_updates),

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -532,7 +532,8 @@ parse_local_options_v2(pcmk__client_t *cib_client, int call_type,
                        gboolean *process, gboolean *needs_forward)
 {
     if (cib_op_modifies(call_type)) {
-        if (pcmk__strcase_any_of(op, CIB_OP_MASTER, CIB_OP_SLAVE, NULL)) {
+        if (pcmk__str_any_of(op, CIB_OP_MASTER,
+                             PCMK__CIB_REQUEST_SECONDARY, NULL)) {
             /* Always handle these locally */
             *process = TRUE;
             *needs_reply = FALSE;

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -704,7 +704,7 @@ parse_peer_options_v2(int call_type, xmlNode * request,
 
     gboolean is_reply = pcmk__str_eq(reply_to, cib_our_uname, pcmk__str_casei);
 
-    if(pcmk__str_eq(op, CIB_OP_REPLACE, pcmk__str_casei)) {
+    if (pcmk__str_eq(op, PCMK__CIB_REQUEST_REPLACE, pcmk__str_none)) {
         /* sync_our_cib() sets F_CIB_ISREPLY */
         if (reply_to) {
             delegated = reply_to;
@@ -1276,7 +1276,7 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
         }
 
         /* Calculate the hash value of the section before the change. */
-        if (pcmk__str_eq(CIB_OP_REPLACE, op, pcmk__str_none)) {
+        if (pcmk__str_eq(PCMK__CIB_REQUEST_REPLACE, op, pcmk__str_none)) {
             current_nodes_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_NODES, current_cib);
             current_alerts_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION "/" XML_CIB_TAG_ALERTS, current_cib);
             current_status_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_STATUS, current_cib);
@@ -1305,7 +1305,7 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
         /* Always write to disk for replace ops,
          * this also negates the need to detect ordering changes
          */
-        if (pcmk__str_eq(CIB_OP_REPLACE, op, pcmk__str_none)) {
+        if (pcmk__str_eq(PCMK__CIB_REQUEST_REPLACE, op, pcmk__str_none)) {
             config_changed = TRUE;
         }
     }
@@ -1326,7 +1326,7 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
             cib_read_config(config_hash, result_cib);
         }
 
-        if (pcmk__str_eq(CIB_OP_REPLACE, op, pcmk__str_none)) {
+        if (pcmk__str_eq(PCMK__CIB_REQUEST_REPLACE, op, pcmk__str_none)) {
             char *result_nodes_digest = NULL;
             char *result_alerts_digest = NULL;
             char *result_status_digest = NULL;

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1355,7 +1355,7 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
             free(result_alerts_digest);
             free(result_status_digest);
 
-        } else if (pcmk__str_eq(CIB_OP_ERASE, op, pcmk__str_none)) {
+        } else if (pcmk__str_eq(PCMK__CIB_REQUEST_ERASE, op, pcmk__str_none)) {
             send_r_notify = TRUE;
         }
 

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -711,7 +711,9 @@ parse_peer_options_v2(int call_type, xmlNode * request,
         }
         goto skip_is_reply;
 
-    } else if(pcmk__str_eq(op, CIB_OP_SYNC, pcmk__str_casei)) {
+    } else if (pcmk__str_eq(op, PCMK__CIB_REQUEST_SYNC_TO_ALL,
+                            pcmk__str_none)) {
+        // Nothing to do
 
     } else if (is_reply && pcmk__str_eq(op, CRM_OP_PING, pcmk__str_casei)) {
         process_ping_reply(request);

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -621,7 +621,7 @@ parse_peer_options_v1(int call_type, xmlNode * request,
 
     op = crm_element_value(request, F_CIB_OPERATION);
     crm_trace("Processing %s request sent by %s", op, originator);
-    if (pcmk__str_eq(op, "cib_shutdown_req", pcmk__str_casei)) {
+    if (pcmk__str_eq(op, PCMK__CIB_REQUEST_SHUTDOWN, pcmk__str_none)) {
         /* Always process these */
         *local_notify = FALSE;
         if (reply_to == NULL || is_reply) {
@@ -673,7 +673,7 @@ parse_peer_options_v1(int call_type, xmlNode * request,
         /* this is for the master instance and we're not it */
         crm_trace("Ignoring reply for primary instance");
 
-    } else if (pcmk__str_eq(op, "cib_shutdown_req", pcmk__str_casei)) {
+    } else if (pcmk__str_eq(op, PCMK__CIB_REQUEST_SHUTDOWN, pcmk__str_none)) {
         if (reply_to != NULL) {
             crm_debug("Processing %s from %s", op, originator);
             *needs_reply = FALSE;
@@ -765,7 +765,7 @@ parse_peer_options_v2(int call_type, xmlNode * request,
         crm_trace("Ignoring legacy %s reply sent from %s to local clients", op, originator);
         return FALSE;
 
-    } else if (pcmk__str_eq(op, "cib_shutdown_req", pcmk__str_casei)) {
+    } else if (pcmk__str_eq(op, PCMK__CIB_REQUEST_SHUTDOWN, pcmk__str_none)) {
         /* Legacy handling */
         crm_debug("Legacy handling of %s message from %s", op, originator);
         *local_notify = FALSE;
@@ -1571,7 +1571,7 @@ initiate_exit(void)
 
     leaving = create_xml_node(NULL, "exit-notification");
     crm_xml_add(leaving, F_TYPE, "cib");
-    crm_xml_add(leaving, F_CIB_OPERATION, "cib_shutdown_req");
+    crm_xml_add(leaving, F_CIB_OPERATION, PCMK__CIB_REQUEST_SHUTDOWN);
 
     send_cluster_message(NULL, crm_msg_cib, leaving, TRUE);
     free_xml(leaving);

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -893,7 +893,7 @@ send_peer_reply(xmlNode * msg, xmlNode * result_diff, const char *originator, gb
 
         crm_xml_add(msg, F_CIB_ISREPLY, originator);
         pcmk__xe_set_bool_attr(msg, F_CIB_GLOBAL_UPDATE, true);
-        crm_xml_add(msg, F_CIB_OPERATION, CIB_OP_APPLY_DIFF);
+        crm_xml_add(msg, F_CIB_OPERATION, PCMK__CIB_REQUEST_APPLY_PATCH);
         crm_xml_add(msg, F_CIB_USER, CRM_DAEMON_USER);
 
         if (format == 1) {

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -719,12 +719,12 @@ parse_peer_options_v2(int call_type, xmlNode * request,
         process_ping_reply(request);
         return FALSE;
 
-    } else if (pcmk__str_eq(op, CIB_OP_UPGRADE, pcmk__str_casei)) {
+    } else if (pcmk__str_eq(op, PCMK__CIB_REQUEST_UPGRADE, pcmk__str_none)) {
         /* Only the DC (node with the oldest software) should process
          * this operation if F_CIB_SCHEMA_MAX is unset
          *
          * If the DC is happy it will then send out another
-         * CIB_OP_UPGRADE which will tell all nodes to do the actual
+         * PCMK__CIB_REQUEST_UPGRADE which will tell all nodes to do the actual
          * upgrade.
          *
          * Except this time F_CIB_SCHEMA_MAX will be set which puts a

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -532,7 +532,7 @@ parse_local_options_v2(pcmk__client_t *cib_client, int call_type,
                        gboolean *process, gboolean *needs_forward)
 {
     if (cib_op_modifies(call_type)) {
-        if (pcmk__str_any_of(op, CIB_OP_MASTER,
+        if (pcmk__str_any_of(op, PCMK__CIB_REQUEST_PRIMARY,
                              PCMK__CIB_REQUEST_SECONDARY, NULL)) {
             /* Always handle these locally */
             *process = TRUE;

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1004,7 +1004,7 @@ cib_process_request(xmlNode *request, gboolean privileged,
         const char *section = crm_element_value(request, F_CIB_SECTION);
         int log_level = LOG_INFO;
 
-        if (pcmk__str_eq(op, CRM_OP_NOOP, pcmk__str_casei)) {
+        if (pcmk__str_eq(op, PCMK__CIB_REQUEST_NOOP, pcmk__str_none)) {
             log_level = LOG_DEBUG;
         }
 

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -206,7 +206,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_sync, cib_cleanup_none, cib_process_sync_one
     },
     {
-        CIB_OP_MASTER, TRUE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_PRIMARY, TRUE, TRUE, FALSE,
         cib_prepare_data, cib_cleanup_data, cib_process_readwrite
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -194,7 +194,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_none, cib_cleanup_output, cib_process_upgrade_server
     },
     {
-        CIB_OP_SLAVE, FALSE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_SECONDARY, FALSE, TRUE, FALSE,
         cib_prepare_none, cib_cleanup_none, cib_process_readwrite
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the Pacemaker project contributors
+ * Copyright 2008-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -141,26 +141,86 @@ cib_cleanup_none(int options, xmlNode ** data, xmlNode ** output)
 
 static cib_operation_t cib_server_ops[] = {
     // Booleans are modifies_cib, needs_privileges, needs_quorum
-    {NULL,             FALSE, FALSE, FALSE, cib_prepare_none, cib_cleanup_none,   cib_process_default},
-    {CIB_OP_QUERY,     FALSE, FALSE, FALSE, cib_prepare_none, cib_cleanup_query,  cib_process_query},
-    {CIB_OP_MODIFY,    TRUE,  TRUE,  TRUE,  cib_prepare_data, cib_cleanup_data,   cib_process_modify},
-    {CIB_OP_APPLY_DIFF,TRUE,  TRUE,  TRUE,  cib_prepare_diff, cib_cleanup_data,   cib_server_process_diff},
-    {CIB_OP_REPLACE,   TRUE,  TRUE,  TRUE,  cib_prepare_data, cib_cleanup_data,   cib_process_replace_svr},
-    {CIB_OP_CREATE,    TRUE,  TRUE,  TRUE,  cib_prepare_data, cib_cleanup_data,   cib_process_create},
-    {CIB_OP_DELETE,    TRUE,  TRUE,  TRUE,  cib_prepare_data, cib_cleanup_data,   cib_process_delete},
-    {CIB_OP_SYNC,      FALSE, TRUE,  FALSE, cib_prepare_sync, cib_cleanup_none,   cib_process_sync},
-    {CIB_OP_BUMP,      TRUE,  TRUE,  TRUE,  cib_prepare_none, cib_cleanup_output, cib_process_bump},
-    {CIB_OP_ERASE,     TRUE,  TRUE,  TRUE,  cib_prepare_none, cib_cleanup_output, cib_process_erase},
-    {CRM_OP_NOOP,      FALSE, FALSE, FALSE, cib_prepare_none, cib_cleanup_none,   cib_process_default},
-    {CIB_OP_DELETE_ALT,TRUE,  TRUE,  TRUE,  cib_prepare_data, cib_cleanup_data,   cib_process_delete_absolute},
-    {CIB_OP_UPGRADE,   TRUE,  TRUE,  TRUE,  cib_prepare_none, cib_cleanup_output, cib_process_upgrade_server},
-    {CIB_OP_SLAVE,     FALSE, TRUE,  FALSE, cib_prepare_none, cib_cleanup_none,   cib_process_readwrite},
-    {CIB_OP_SLAVEALL,  FALSE, TRUE,  FALSE, cib_prepare_none, cib_cleanup_none,   cib_process_readwrite},
-    {CIB_OP_SYNC_ONE,  FALSE, TRUE,  FALSE, cib_prepare_sync, cib_cleanup_none,   cib_process_sync_one},
-    {CIB_OP_MASTER,    TRUE,  TRUE,  FALSE, cib_prepare_data, cib_cleanup_data,   cib_process_readwrite},
-    {CIB_OP_ISMASTER,  FALSE, TRUE,  FALSE, cib_prepare_none, cib_cleanup_none,   cib_process_readwrite},
-    {"cib_shutdown_req",FALSE, TRUE, FALSE, cib_prepare_sync, cib_cleanup_none,   cib_process_shutdown_req},
-    {CRM_OP_PING,      FALSE, FALSE, FALSE, cib_prepare_none, cib_cleanup_output, cib_process_ping},
+    {
+        NULL, FALSE, FALSE, FALSE,
+        cib_prepare_none, cib_cleanup_none, cib_process_default
+    },
+    {
+        CIB_OP_QUERY, FALSE, FALSE, FALSE,
+        cib_prepare_none, cib_cleanup_query, cib_process_query
+    },
+    {
+        CIB_OP_MODIFY, TRUE, TRUE, TRUE,
+        cib_prepare_data, cib_cleanup_data, cib_process_modify
+    },
+    {
+        CIB_OP_APPLY_DIFF, TRUE, TRUE, TRUE,
+        cib_prepare_diff, cib_cleanup_data, cib_server_process_diff
+    },
+    {
+        CIB_OP_REPLACE, TRUE, TRUE, TRUE,
+        cib_prepare_data, cib_cleanup_data, cib_process_replace_svr
+    },
+    {
+        CIB_OP_CREATE, TRUE, TRUE, TRUE,
+        cib_prepare_data, cib_cleanup_data, cib_process_create
+    },
+    {
+        CIB_OP_DELETE, TRUE, TRUE, TRUE,
+        cib_prepare_data, cib_cleanup_data, cib_process_delete
+    },
+    {
+        CIB_OP_SYNC, FALSE, TRUE, FALSE,
+        cib_prepare_sync, cib_cleanup_none, cib_process_sync
+    },
+    {
+        CIB_OP_BUMP, TRUE, TRUE, TRUE,
+        cib_prepare_none, cib_cleanup_output, cib_process_bump
+    },
+    {
+        CIB_OP_ERASE, TRUE, TRUE, TRUE,
+        cib_prepare_none, cib_cleanup_output, cib_process_erase
+    },
+    {
+        CRM_OP_NOOP, FALSE, FALSE, FALSE,
+        cib_prepare_none, cib_cleanup_none, cib_process_default
+    },
+    {
+        CIB_OP_DELETE_ALT, TRUE, TRUE, TRUE,
+        cib_prepare_data, cib_cleanup_data, cib_process_delete_absolute
+    },
+    {
+        CIB_OP_UPGRADE, TRUE, TRUE, TRUE,
+        cib_prepare_none, cib_cleanup_output, cib_process_upgrade_server
+    },
+    {
+        CIB_OP_SLAVE, FALSE, TRUE, FALSE,
+        cib_prepare_none, cib_cleanup_none, cib_process_readwrite
+    },
+    {
+        CIB_OP_SLAVEALL, FALSE, TRUE, FALSE,
+        cib_prepare_none, cib_cleanup_none, cib_process_readwrite
+    },
+    {
+        CIB_OP_SYNC_ONE, FALSE, TRUE, FALSE,
+        cib_prepare_sync, cib_cleanup_none, cib_process_sync_one
+    },
+    {
+        CIB_OP_MASTER, TRUE, TRUE, FALSE,
+        cib_prepare_data, cib_cleanup_data, cib_process_readwrite
+    },
+    {
+        CIB_OP_ISMASTER, FALSE, TRUE, FALSE,
+        cib_prepare_none, cib_cleanup_none, cib_process_readwrite
+    },
+    {
+        "cib_shutdown_req", FALSE, TRUE, FALSE,
+        cib_prepare_sync, cib_cleanup_none, cib_process_shutdown_req
+    },
+    {
+        CRM_OP_PING, FALSE, FALSE, FALSE,
+        cib_prepare_none, cib_cleanup_output, cib_process_ping
+    },
 };
 
 int

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -198,7 +198,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_none, cib_cleanup_none, cib_process_readwrite
     },
     {
-        CIB_OP_SLAVEALL, FALSE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_ALL_SECONDARY, FALSE, TRUE, FALSE,
         cib_prepare_none, cib_cleanup_none, cib_process_readwrite
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -214,7 +214,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_none, cib_cleanup_none, cib_process_readwrite
     },
     {
-        "cib_shutdown_req", FALSE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_SHUTDOWN, FALSE, TRUE, FALSE,
         cib_prepare_sync, cib_cleanup_none, cib_process_shutdown_req
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -166,7 +166,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_data, cib_cleanup_data, cib_process_create
     },
     {
-        CIB_OP_DELETE, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_DELETE, TRUE, TRUE, TRUE,
         cib_prepare_data, cib_cleanup_data, cib_process_delete
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -210,7 +210,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_data, cib_cleanup_data, cib_process_readwrite
     },
     {
-        CIB_OP_ISMASTER, FALSE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_IS_PRIMARY, FALSE, TRUE, FALSE,
         cib_prepare_none, cib_cleanup_none, cib_process_readwrite
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -158,7 +158,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_diff, cib_cleanup_data, cib_server_process_diff
     },
     {
-        CIB_OP_REPLACE, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_REPLACE, TRUE, TRUE, TRUE,
         cib_prepare_data, cib_cleanup_data, cib_process_replace_svr
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -170,7 +170,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_data, cib_cleanup_data, cib_process_delete
     },
     {
-        CIB_OP_SYNC, FALSE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_SYNC_TO_ALL, FALSE, TRUE, FALSE,
         cib_prepare_sync, cib_cleanup_none, cib_process_sync
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -178,7 +178,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_none, cib_cleanup_output, cib_process_bump
     },
     {
-        CIB_OP_ERASE, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_ERASE, TRUE, TRUE, TRUE,
         cib_prepare_none, cib_cleanup_output, cib_process_erase
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -146,7 +146,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_none, cib_cleanup_none, cib_process_default
     },
     {
-        CIB_OP_QUERY, FALSE, FALSE, FALSE,
+        PCMK__CIB_REQUEST_QUERY, FALSE, FALSE, FALSE,
         cib_prepare_none, cib_cleanup_query, cib_process_query
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -186,7 +186,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_none, cib_cleanup_none, cib_process_default
     },
     {
-        CIB_OP_DELETE_ALT, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_ABS_DELETE, TRUE, TRUE, TRUE,
         cib_prepare_data, cib_cleanup_data, cib_process_delete_absolute
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -182,7 +182,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_none, cib_cleanup_output, cib_process_erase
     },
     {
-        CRM_OP_NOOP, FALSE, FALSE, FALSE,
+        PCMK__CIB_REQUEST_NOOP, FALSE, FALSE, FALSE,
         cib_prepare_none, cib_cleanup_none, cib_process_default
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -190,7 +190,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_data, cib_cleanup_data, cib_process_delete_absolute
     },
     {
-        CIB_OP_UPGRADE, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_UPGRADE, TRUE, TRUE, TRUE,
         cib_prepare_none, cib_cleanup_output, cib_process_upgrade_server
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -150,7 +150,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_none, cib_cleanup_query, cib_process_query
     },
     {
-        CIB_OP_MODIFY, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_MODIFY, TRUE, TRUE, TRUE,
         cib_prepare_data, cib_cleanup_data, cib_process_modify
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -174,7 +174,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_sync, cib_cleanup_none, cib_process_sync
     },
     {
-        CIB_OP_BUMP, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_BUMP, TRUE, TRUE, TRUE,
         cib_prepare_none, cib_cleanup_output, cib_process_bump
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -154,7 +154,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_data, cib_cleanup_data, cib_process_modify
     },
     {
-        CIB_OP_APPLY_DIFF, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_APPLY_PATCH, TRUE, TRUE, TRUE,
         cib_prepare_diff, cib_cleanup_data, cib_server_process_diff
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -162,7 +162,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_data, cib_cleanup_data, cib_process_replace_svr
     },
     {
-        CIB_OP_CREATE, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_CREATE, TRUE, TRUE, TRUE,
         cib_prepare_data, cib_cleanup_data, cib_process_create
     },
     {

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -202,7 +202,7 @@ static cib_operation_t cib_server_ops[] = {
         cib_prepare_none, cib_cleanup_none, cib_process_readwrite
     },
     {
-        CIB_OP_SYNC_ONE, FALSE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_SYNC_TO_ONE, FALSE, TRUE, FALSE,
         cib_prepare_sync, cib_cleanup_none, cib_process_sync_one
     },
     {

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -105,7 +105,7 @@ cib_process_readwrite(const char *op, int options, const char *section, xmlNode 
 
     crm_trace("Processing \"%s\" event", op);
 
-    if (pcmk__str_eq(op, CIB_OP_ISMASTER, pcmk__str_casei)) {
+    if (pcmk__str_eq(op, PCMK__CIB_REQUEST_IS_PRIMARY, pcmk__str_none)) {
         if (cib_is_master == TRUE) {
             result = pcmk_ok;
         } else {

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -144,7 +144,7 @@ send_sync_request(const char *host)
     sync_in_progress = 1;
 
     crm_xml_add(sync_me, F_TYPE, "cib");
-    crm_xml_add(sync_me, F_CIB_OPERATION, CIB_OP_SYNC_ONE);
+    crm_xml_add(sync_me, F_CIB_OPERATION, PCMK__CIB_REQUEST_SYNC_TO_ONE);
     crm_xml_add(sync_me, F_CIB_DELEGATED, cib_our_uname);
 
     send_cluster_message(host ? crm_get_peer(0, host) : NULL, crm_msg_cib, sync_me, FALSE);

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -423,7 +423,7 @@ sync_our_cib(xmlNode * request, gboolean all)
         xml_remove_prop(replace_request, F_CIB_HOST);
     }
 
-    crm_xml_add(replace_request, F_CIB_OPERATION, CIB_OP_REPLACE);
+    crm_xml_add(replace_request, F_CIB_OPERATION, PCMK__CIB_REQUEST_REPLACE);
     crm_xml_add(replace_request, "original_" F_CIB_OPERATION, op);
     pcmk__xe_set_bool_attr(replace_request, F_CIB_GLOBAL_UPDATE, true);
 

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -114,7 +114,7 @@ cib_process_readwrite(const char *op, int options, const char *section, xmlNode 
         return result;
     }
 
-    if (pcmk__str_eq(op, CIB_OP_MASTER, pcmk__str_casei)) {
+    if (pcmk__str_eq(op, PCMK__CIB_REQUEST_PRIMARY, pcmk__str_none)) {
         if (cib_is_master == FALSE) {
             crm_info("We are now in R/W mode");
             cib_is_master = TRUE;

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -246,7 +246,7 @@ cib_process_upgrade_server(const char *op, int options, const char *section, xml
             crm_notice("Upgrade request from %s verified", host);
 
             crm_xml_add(up, F_TYPE, "cib");
-            crm_xml_add(up, F_CIB_OPERATION, CIB_OP_UPGRADE);
+            crm_xml_add(up, F_CIB_OPERATION, PCMK__CIB_REQUEST_UPGRADE);
             crm_xml_add(up, F_CIB_SCHEMA_MAX, get_schema_name(new_version));
             crm_xml_add(up, F_CIB_DELEGATED, host);
             crm_xml_add(up, F_CIB_CLIENTID, client_id);
@@ -279,7 +279,7 @@ cib_process_upgrade_server(const char *op, int options, const char *section, xml
                 xmlNode *up = create_xml_node(NULL, __func__);
 
                 crm_xml_add(up, F_TYPE, "cib");
-                crm_xml_add(up, F_CIB_OPERATION, CIB_OP_UPGRADE);
+                crm_xml_add(up, F_CIB_OPERATION, PCMK__CIB_REQUEST_UPGRADE);
                 crm_xml_add(up, F_CIB_DELEGATED, host);
                 crm_xml_add(up, F_CIB_ISREPLY, host);
                 crm_xml_add(up, F_CIB_CLIENTID, client_id);

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -86,10 +86,7 @@ cib_process_default(const char *op, int options, const char *section, xmlNode * 
         result = -EINVAL;
         crm_err("No operation specified");
 
-    } else if (strcasecmp(CRM_OP_NOOP, op) == 0) {
-        ;
-
-    } else {
+    } else if (strcmp(PCMK__CIB_REQUEST_NOOP, op) != 0) {
         result = -EPROTONOSUPPORT;
         crm_err("Action [%s] is not supported by the CIB manager", op);
     }

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -271,7 +271,7 @@ cib_replace_notify(const char *origin, xmlNode * update, int result, xmlNode * d
     replace_msg = create_xml_node(NULL, "notify-replace");
     crm_xml_add(replace_msg, F_TYPE, T_CIB_NOTIFY);
     crm_xml_add(replace_msg, F_SUBTYPE, T_CIB_REPLACE_NOTIFY);
-    crm_xml_add(replace_msg, F_CIB_OPERATION, CIB_OP_REPLACE);
+    crm_xml_add(replace_msg, F_CIB_OPERATION, PCMK__CIB_REQUEST_REPLACE);
     crm_xml_add_int(replace_msg, F_CIB_RC, result);
     crm_xml_add_int(replace_msg, F_CIB_CHANGE_SECTION, change_section);
     attach_cib_generation(replace_msg, "cib-replace-generation", update);

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -319,8 +319,8 @@ controld_delete_resource_history(const char *rsc_id, const char *node,
 
     // Ask CIB to delete the entry
     xpath = crm_strdup_printf(XPATH_RESOURCE_HISTORY, node, rsc_id);
-    rc = cib_internal_op(fsa_cib_conn, CIB_OP_DELETE, NULL, xpath, NULL,
-                         NULL, call_options|cib_xpath, user_name);
+    rc = cib_internal_op(fsa_cib_conn, PCMK__CIB_REQUEST_DELETE, NULL, xpath,
+                         NULL, NULL, call_options|cib_xpath, user_name);
 
     if (rc < 0) {
         rc = pcmk_legacy2rc(rc);

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -12,7 +12,7 @@
 
 #  include <crm/crm.h>
 #  include <crm/common/xml.h>
-#  include <crm/cib/internal.h>     // CIB_OP_MODIFY
+#  include <crm/cib/internal.h>     // PCMK__CIB_REQUEST_MODIFY
 #  include <controld_fsa.h>         // fsa_cib_conn
 #  include <controld_alerts.h>
 
@@ -22,7 +22,7 @@
 #  define fsa_cib_update(section, data, options, call_id, user_name)	\
 	if(fsa_cib_conn != NULL) {					\
 	    call_id = cib_internal_op(                                  \
-		fsa_cib_conn, CIB_OP_MODIFY, NULL, section, data,	\
+        fsa_cib_conn, PCMK__CIB_REQUEST_MODIFY, NULL, section, data,    \
 		NULL, options, user_name);				\
 									\
 	} else {							\

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -27,7 +27,7 @@
 #define PCMK__CIB_REQUEST_DELETE        "cib_delete"
 #define PCMK__CIB_REQUEST_ERASE         "cib_erase"
 #define PCMK__CIB_REQUEST_REPLACE       "cib_replace"
-#  define CIB_OP_APPLY_DIFF "cib_apply_diff"
+#define PCMK__CIB_REQUEST_APPLY_PATCH   "cib_apply_diff"
 #  define CIB_OP_UPGRADE    "cib_upgrade"
 #  define CIB_OP_DELETE_ALT	"cib_delete_alt"
 

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -29,7 +29,7 @@
 #define PCMK__CIB_REQUEST_REPLACE       "cib_replace"
 #define PCMK__CIB_REQUEST_APPLY_PATCH   "cib_apply_diff"
 #define PCMK__CIB_REQUEST_UPGRADE       "cib_upgrade"
-#  define CIB_OP_DELETE_ALT	"cib_delete_alt"
+#define PCMK__CIB_REQUEST_ABS_DELETE    "cib_delete_alt"
 
 #  define F_CIB_CLIENTID  "cib_clientid"
 #  define F_CIB_CALLOPTS  "cib_callopt"
@@ -189,7 +189,7 @@ int cib_process_upgrade(const char *op, int options, const char *section, xmlNod
  * \internal
  * \brief Query or modify a CIB
  *
- * \param[in]     op            CIB_OP_* operation to be performed
+ * \param[in]     op            PCMK__CIB_REQUEST_* operation to be performed
  * \param[in]     options       Flag set of \c cib_call_options
  * \param[in]     section       XPath to query or modify
  * \param[in]     req           unused

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -28,7 +28,7 @@
 #define PCMK__CIB_REQUEST_ERASE         "cib_erase"
 #define PCMK__CIB_REQUEST_REPLACE       "cib_replace"
 #define PCMK__CIB_REQUEST_APPLY_PATCH   "cib_apply_diff"
-#  define CIB_OP_UPGRADE    "cib_upgrade"
+#define PCMK__CIB_REQUEST_UPGRADE       "cib_upgrade"
 #  define CIB_OP_DELETE_ALT	"cib_delete_alt"
 
 #  define F_CIB_CLIENTID  "cib_clientid"

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -31,6 +31,7 @@
 #define PCMK__CIB_REQUEST_UPGRADE       "cib_upgrade"
 #define PCMK__CIB_REQUEST_ABS_DELETE    "cib_delete_alt"
 #define PCMK__CIB_REQUEST_NOOP          "noop"
+#define PCMK__CIB_REQUEST_SHUTDOWN      "cib_shutdown_req"
 
 #  define F_CIB_CLIENTID  "cib_clientid"
 #  define F_CIB_CALLOPTS  "cib_callopt"

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -15,7 +15,7 @@
 
 // Request types for CIB manager IPC/CPG
 #define PCMK__CIB_REQUEST_SECONDARY     "cib_slave"
-#  define CIB_OP_SLAVEALL	"cib_slave_all"
+#define PCMK__CIB_REQUEST_ALL_SECONDARY "cib_slave_all"
 #  define CIB_OP_MASTER	"cib_master"
 #  define CIB_OP_SYNC	"cib_sync"
 #  define CIB_OP_SYNC_ONE	"cib_sync_one"

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -21,7 +21,7 @@
 #define PCMK__CIB_REQUEST_SYNC_TO_ONE   "cib_sync_one"
 #define PCMK__CIB_REQUEST_IS_PRIMARY    "cib_ismaster"
 #define PCMK__CIB_REQUEST_BUMP          "cib_bump"
-#  define CIB_OP_QUERY	"cib_query"
+#define PCMK__CIB_REQUEST_QUERY         "cib_query"
 #  define CIB_OP_CREATE	"cib_create"
 #  define CIB_OP_MODIFY	"cib_modify"
 #  define CIB_OP_DELETE	"cib_delete"
@@ -196,11 +196,11 @@ int cib_process_upgrade(const char *op, int options, const char *section, xmlNod
  * \param[in]     input         Portion of CIB to modify (used with
  *                              CIB_OP_CREATE, CIB_OP_MODIFY, and
  *                              CIB_OP_REPLACE)
- * \param[in]     existing_cib  Input CIB (used with CIB_OP_QUERY)
+ * \param[in]     existing_cib  Input CIB (used with PCMK__CIB_REQUEST_QUERY)
  * \param[in,out] result_cib    CIB copy to make changes in (used with
  *                              CIB_OP_CREATE, CIB_OP_MODIFY, CIB_OP_DELETE, and
  *                              CIB_OP_REPLACE)
- * \param[out]    answer        Query result (used with CIB_OP_QUERY)
+ * \param[out]    answer        Query result (used with PCMK__CIB_REQUEST_QUERY)
  *
  * \return Legacy Pacemaker return code
  */

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -25,7 +25,7 @@
 #define PCMK__CIB_REQUEST_CREATE        "cib_create"
 #define PCMK__CIB_REQUEST_MODIFY        "cib_modify"
 #define PCMK__CIB_REQUEST_DELETE        "cib_delete"
-#  define CIB_OP_ERASE	"cib_erase"
+#define PCMK__CIB_REQUEST_ERASE         "cib_erase"
 #  define CIB_OP_REPLACE	"cib_replace"
 #  define CIB_OP_APPLY_DIFF "cib_apply_diff"
 #  define CIB_OP_UPGRADE    "cib_upgrade"

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -18,7 +18,7 @@
 #define PCMK__CIB_REQUEST_ALL_SECONDARY "cib_slave_all"
 #define PCMK__CIB_REQUEST_PRIMARY       "cib_master"
 #define PCMK__CIB_REQUEST_SYNC_TO_ALL   "cib_sync"
-#  define CIB_OP_SYNC_ONE	"cib_sync_one"
+#define PCMK__CIB_REQUEST_SYNC_TO_ONE   "cib_sync_one"
 #  define CIB_OP_ISMASTER	"cib_ismaster"
 #  define CIB_OP_BUMP	"cib_bump"
 #  define CIB_OP_QUERY	"cib_query"

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -13,7 +13,8 @@
 #  include <crm/common/ipc_internal.h>
 #  include <crm/common/output_internal.h>
 
-#  define CIB_OP_SLAVE	"cib_slave"
+// Request types for CIB manager IPC/CPG
+#define PCMK__CIB_REQUEST_SECONDARY     "cib_slave"
 #  define CIB_OP_SLAVEALL	"cib_slave_all"
 #  define CIB_OP_MASTER	"cib_master"
 #  define CIB_OP_SYNC	"cib_sync"

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -24,7 +24,7 @@
 #define PCMK__CIB_REQUEST_QUERY         "cib_query"
 #define PCMK__CIB_REQUEST_CREATE        "cib_create"
 #define PCMK__CIB_REQUEST_MODIFY        "cib_modify"
-#  define CIB_OP_DELETE	"cib_delete"
+#define PCMK__CIB_REQUEST_DELETE        "cib_delete"
 #  define CIB_OP_ERASE	"cib_erase"
 #  define CIB_OP_REPLACE	"cib_replace"
 #  define CIB_OP_APPLY_DIFF "cib_apply_diff"
@@ -201,7 +201,7 @@ int cib_process_upgrade(const char *op, int options, const char *section, xmlNod
  * \param[in,out] result_cib    CIB copy to make changes in (used with
  *                              PCMK__CIB_REQUEST_CREATE,
  *                              PCMK__CIB_REQUEST_MODIFY,
- *                              CIB_OP_DELETE, and CIB_OP_REPLACE)
+ *                              PCMK__CIB_REQUEST_DELETE, and CIB_OP_REPLACE)
  * \param[out]    answer        Query result (used with PCMK__CIB_REQUEST_QUERY)
  *
  * \return Legacy Pacemaker return code

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -30,6 +30,7 @@
 #define PCMK__CIB_REQUEST_APPLY_PATCH   "cib_apply_diff"
 #define PCMK__CIB_REQUEST_UPGRADE       "cib_upgrade"
 #define PCMK__CIB_REQUEST_ABS_DELETE    "cib_delete_alt"
+#define PCMK__CIB_REQUEST_NOOP          "noop"
 
 #  define F_CIB_CLIENTID  "cib_clientid"
 #  define F_CIB_CALLOPTS  "cib_callopt"

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -16,7 +16,7 @@
 // Request types for CIB manager IPC/CPG
 #define PCMK__CIB_REQUEST_SECONDARY     "cib_slave"
 #define PCMK__CIB_REQUEST_ALL_SECONDARY "cib_slave_all"
-#  define CIB_OP_MASTER	"cib_master"
+#define PCMK__CIB_REQUEST_PRIMARY       "cib_master"
 #  define CIB_OP_SYNC	"cib_sync"
 #  define CIB_OP_SYNC_ONE	"cib_sync_one"
 #  define CIB_OP_ISMASTER	"cib_ismaster"

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -23,7 +23,7 @@
 #define PCMK__CIB_REQUEST_BUMP          "cib_bump"
 #define PCMK__CIB_REQUEST_QUERY         "cib_query"
 #define PCMK__CIB_REQUEST_CREATE        "cib_create"
-#  define CIB_OP_MODIFY	"cib_modify"
+#define PCMK__CIB_REQUEST_MODIFY        "cib_modify"
 #  define CIB_OP_DELETE	"cib_delete"
 #  define CIB_OP_ERASE	"cib_erase"
 #  define CIB_OP_REPLACE	"cib_replace"
@@ -194,11 +194,13 @@ int cib_process_upgrade(const char *op, int options, const char *section, xmlNod
  * \param[in]     section       XPath to query or modify
  * \param[in]     req           unused
  * \param[in]     input         Portion of CIB to modify (used with
- *                              PCMK__CIB_REQUEST_CREATE, CIB_OP_MODIFY, and
+ *                              PCMK__CIB_REQUEST_CREATE,
+ *                              PCMK__CIB_REQUEST_MODIFY, and
  *                              CIB_OP_REPLACE)
  * \param[in]     existing_cib  Input CIB (used with PCMK__CIB_REQUEST_QUERY)
  * \param[in,out] result_cib    CIB copy to make changes in (used with
- *                              PCMK__CIB_REQUEST_CREATE, CIB_OP_MODIFY,
+ *                              PCMK__CIB_REQUEST_CREATE,
+ *                              PCMK__CIB_REQUEST_MODIFY,
  *                              CIB_OP_DELETE, and CIB_OP_REPLACE)
  * \param[out]    answer        Query result (used with PCMK__CIB_REQUEST_QUERY)
  *

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -17,7 +17,7 @@
 #define PCMK__CIB_REQUEST_SECONDARY     "cib_slave"
 #define PCMK__CIB_REQUEST_ALL_SECONDARY "cib_slave_all"
 #define PCMK__CIB_REQUEST_PRIMARY       "cib_master"
-#  define CIB_OP_SYNC	"cib_sync"
+#define PCMK__CIB_REQUEST_SYNC_TO_ALL   "cib_sync"
 #  define CIB_OP_SYNC_ONE	"cib_sync_one"
 #  define CIB_OP_ISMASTER	"cib_ismaster"
 #  define CIB_OP_BUMP	"cib_bump"

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -22,7 +22,7 @@
 #define PCMK__CIB_REQUEST_IS_PRIMARY    "cib_ismaster"
 #define PCMK__CIB_REQUEST_BUMP          "cib_bump"
 #define PCMK__CIB_REQUEST_QUERY         "cib_query"
-#  define CIB_OP_CREATE	"cib_create"
+#define PCMK__CIB_REQUEST_CREATE        "cib_create"
 #  define CIB_OP_MODIFY	"cib_modify"
 #  define CIB_OP_DELETE	"cib_delete"
 #  define CIB_OP_ERASE	"cib_erase"
@@ -194,12 +194,12 @@ int cib_process_upgrade(const char *op, int options, const char *section, xmlNod
  * \param[in]     section       XPath to query or modify
  * \param[in]     req           unused
  * \param[in]     input         Portion of CIB to modify (used with
- *                              CIB_OP_CREATE, CIB_OP_MODIFY, and
+ *                              PCMK__CIB_REQUEST_CREATE, CIB_OP_MODIFY, and
  *                              CIB_OP_REPLACE)
  * \param[in]     existing_cib  Input CIB (used with PCMK__CIB_REQUEST_QUERY)
  * \param[in,out] result_cib    CIB copy to make changes in (used with
- *                              CIB_OP_CREATE, CIB_OP_MODIFY, CIB_OP_DELETE, and
- *                              CIB_OP_REPLACE)
+ *                              PCMK__CIB_REQUEST_CREATE, CIB_OP_MODIFY,
+ *                              CIB_OP_DELETE, and CIB_OP_REPLACE)
  * \param[out]    answer        Query result (used with PCMK__CIB_REQUEST_QUERY)
  *
  * \return Legacy Pacemaker return code

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -19,7 +19,7 @@
 #define PCMK__CIB_REQUEST_PRIMARY       "cib_master"
 #define PCMK__CIB_REQUEST_SYNC_TO_ALL   "cib_sync"
 #define PCMK__CIB_REQUEST_SYNC_TO_ONE   "cib_sync_one"
-#  define CIB_OP_ISMASTER	"cib_ismaster"
+#define PCMK__CIB_REQUEST_IS_PRIMARY    "cib_ismaster"
 #  define CIB_OP_BUMP	"cib_bump"
 #  define CIB_OP_QUERY	"cib_query"
 #  define CIB_OP_CREATE	"cib_create"

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -26,7 +26,7 @@
 #define PCMK__CIB_REQUEST_MODIFY        "cib_modify"
 #define PCMK__CIB_REQUEST_DELETE        "cib_delete"
 #define PCMK__CIB_REQUEST_ERASE         "cib_erase"
-#  define CIB_OP_REPLACE	"cib_replace"
+#define PCMK__CIB_REQUEST_REPLACE       "cib_replace"
 #  define CIB_OP_APPLY_DIFF "cib_apply_diff"
 #  define CIB_OP_UPGRADE    "cib_upgrade"
 #  define CIB_OP_DELETE_ALT	"cib_delete_alt"
@@ -196,12 +196,13 @@ int cib_process_upgrade(const char *op, int options, const char *section, xmlNod
  * \param[in]     input         Portion of CIB to modify (used with
  *                              PCMK__CIB_REQUEST_CREATE,
  *                              PCMK__CIB_REQUEST_MODIFY, and
- *                              CIB_OP_REPLACE)
+ *                              PCMK__CIB_REQUEST_REPLACE)
  * \param[in]     existing_cib  Input CIB (used with PCMK__CIB_REQUEST_QUERY)
  * \param[in,out] result_cib    CIB copy to make changes in (used with
  *                              PCMK__CIB_REQUEST_CREATE,
  *                              PCMK__CIB_REQUEST_MODIFY,
- *                              PCMK__CIB_REQUEST_DELETE, and CIB_OP_REPLACE)
+ *                              PCMK__CIB_REQUEST_DELETE, and
+ *                              PCMK__CIB_REQUEST_REPLACE)
  * \param[out]    answer        Query result (used with PCMK__CIB_REQUEST_QUERY)
  *
  * \return Legacy Pacemaker return code

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -20,7 +20,7 @@
 #define PCMK__CIB_REQUEST_SYNC_TO_ALL   "cib_sync"
 #define PCMK__CIB_REQUEST_SYNC_TO_ONE   "cib_sync_one"
 #define PCMK__CIB_REQUEST_IS_PRIMARY    "cib_ismaster"
-#  define CIB_OP_BUMP	"cib_bump"
+#define PCMK__CIB_REQUEST_BUMP          "cib_bump"
 #  define CIB_OP_QUERY	"cib_query"
 #  define CIB_OP_CREATE	"cib_create"
 #  define CIB_OP_MODIFY	"cib_modify"

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -337,8 +337,8 @@ cib__update_node_attr(pcmk__output_t *out, cib_t *cib, int call_options, const c
     }
 
     crm_log_xml_trace(xml_top, "update_attr");
-    rc = cib_internal_op(cib, CIB_OP_MODIFY, NULL, section, xml_top, NULL,
-                         call_options | cib_quorum_override, user_name);
+    rc = cib_internal_op(cib, PCMK__CIB_REQUEST_MODIFY, NULL, section, xml_top,
+                         NULL, call_options|cib_quorum_override, user_name);
     if (rc < 0) {
         rc = pcmk_legacy2rc(rc);
 

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -413,8 +413,8 @@ cib__delete_node_attr(pcmk__output_t *out, cib_t *cib, int options, const char *
 
     xml_obj = crm_create_nvpair_xml(NULL, attr_id, attr_name, attr_value);
 
-    rc = cib_internal_op(cib, CIB_OP_DELETE, NULL, section, xml_obj, NULL,
-                         options | cib_quorum_override, user_name);
+    rc = cib_internal_op(cib, PCMK__CIB_REQUEST_DELETE, NULL, section, xml_obj,
+                         NULL, options|cib_quorum_override, user_name);
     if (rc < 0) {
         rc = pcmk_legacy2rc(rc);
     } else {

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -144,8 +144,9 @@ find_attr(cib_t *cib, const char *section, const char *node_uuid,
 
     CRM_LOG_ASSERT(offset > 0);
 
-    rc = cib_internal_op(cib, CIB_OP_QUERY, NULL, xpath_string, NULL, &xml_search,
-                         cib_sync_call | cib_scope_local | cib_xpath, user_name);
+    rc = cib_internal_op(cib, PCMK__CIB_REQUEST_QUERY, NULL, xpath_string, NULL,
+                         &xml_search, cib_sync_call|cib_scope_local| cib_xpath,
+                         user_name);
     if (rc < 0) {
         rc = pcmk_legacy2rc(rc);
         crm_trace("Query failed for attribute %s (section=%s, node=%s, set=%s, xpath=%s): %s",
@@ -653,8 +654,9 @@ query_node_uuid(cib_t * the_cib, const char *uname, char **uuid, int *is_remote_
     }
 
     xpath_string = crm_strdup_printf(XPATH_NODE, host_lowercase, host_lowercase, host_lowercase, host_lowercase);
-    if (cib_internal_op(the_cib, CIB_OP_QUERY, NULL, xpath_string, NULL,
-                        &xml_search, cib_sync_call|cib_scope_local|cib_xpath,
+    if (cib_internal_op(the_cib, PCMK__CIB_REQUEST_QUERY, NULL, xpath_string,
+                        NULL, &xml_search,
+                        cib_sync_call|cib_scope_local|cib_xpath,
                         NULL) == pcmk_ok) {
         rc = get_uuid_from_result(xml_search, uuid, is_remote_node);
     } else {

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -147,14 +147,16 @@ static int
 cib_client_modify(cib_t * cib, const char *section, xmlNode * data, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_MODIFY, NULL, section, data, NULL, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_MODIFY, NULL, section, data,
+                           NULL, call_options, NULL);
 }
 
 static int
 cib_client_update(cib_t * cib, const char *section, xmlNode * data, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_MODIFY, NULL, section, data, NULL, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_MODIFY, NULL, section, data,
+                           NULL, call_options, NULL);
 }
 
 static int

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -180,7 +180,8 @@ static int
 cib_client_delete_absolute(cib_t * cib, const char *section, xmlNode * data, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_DELETE_ALT, NULL, section, data, NULL, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_ABS_DELETE, NULL, section,
+                           data, NULL, call_options, NULL);
 }
 
 static int

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -163,7 +163,8 @@ static int
 cib_client_replace(cib_t * cib, const char *section, xmlNode * data, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_REPLACE, NULL, section, data, NULL, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_REPLACE, NULL, section, data,
+                           NULL, call_options, NULL);
 }
 
 static int

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -86,7 +86,8 @@ static int
 cib_client_set_slave(cib_t * cib, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_SLAVE, NULL, NULL, NULL, NULL, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_SECONDARY, NULL, NULL, NULL,
+                           NULL, call_options, NULL);
 }
 
 static int

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -129,7 +129,8 @@ static int
 cib_client_sync_from(cib_t * cib, const char *host, const char *section, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_SYNC, host, section, NULL, NULL, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_SYNC_TO_ALL, host, section,
+                           NULL, NULL, call_options, NULL);
 }
 
 static int

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -101,8 +101,8 @@ cib_client_set_master(cib_t * cib, int call_options)
 {
     op_common(cib);
     crm_trace("Adding cib_scope_local to options");
-    return cib_internal_op(cib, CIB_OP_MASTER, NULL, NULL, NULL, NULL,
-                           call_options | cib_scope_local, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_PRIMARY, NULL, NULL, NULL,
+                           NULL, call_options|cib_scope_local, NULL);
 }
 
 static int

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -78,8 +78,8 @@ static int
 cib_client_is_master(cib_t * cib)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_ISMASTER, NULL, NULL, NULL, NULL,
-                           cib_scope_local | cib_sync_call, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_IS_PRIMARY, NULL, NULL, NULL,
+                           NULL, cib_scope_local|cib_sync_call, NULL);
 }
 
 static int

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -109,7 +109,8 @@ static int
 cib_client_bump_epoch(cib_t * cib, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_BUMP, NULL, NULL, NULL, NULL, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_BUMP, NULL, NULL, NULL, NULL,
+                           call_options, NULL);
 }
 
 static int

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -170,7 +170,8 @@ static int
 cib_client_delete(cib_t * cib, const char *section, xmlNode * data, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_DELETE, NULL, section, data, NULL, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_DELETE, NULL, section, data,
+                           NULL, call_options, NULL);
 }
 
 static int

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -71,7 +71,8 @@ cib_client_query_from(cib_t * cib, const char *host, const char *section,
                       xmlNode ** output_data, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_QUERY, host, section, NULL, output_data, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_QUERY, host, section, NULL,
+                           output_data, call_options, NULL);
 }
 
 static int

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -185,7 +185,8 @@ static int
 cib_client_erase(cib_t * cib, xmlNode ** output_data, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_ERASE, NULL, NULL, NULL, output_data, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_ERASE, NULL, NULL, NULL,
+                           output_data, call_options, NULL);
 }
 
 static void

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -139,7 +139,8 @@ static int
 cib_client_create(cib_t * cib, const char *section, xmlNode * data, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_CREATE, NULL, section, data, NULL, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_CREATE, NULL, section, data,
+                           NULL, call_options, NULL);
 }
 
 static int

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -50,7 +50,8 @@ static int
 cib_client_noop(cib_t * cib, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CRM_OP_NOOP, NULL, NULL, NULL, NULL, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_NOOP, NULL, NULL, NULL, NULL,
+                           call_options, NULL);
 }
 
 static int

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -118,7 +118,8 @@ static int
 cib_client_upgrade(cib_t * cib, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CIB_OP_UPGRADE, NULL, NULL, NULL, NULL, call_options, NULL);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_UPGRADE, NULL, NULL, NULL,
+                           NULL, call_options, NULL);
 }
 
 static int

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -780,7 +780,7 @@ static struct cib_func_entry cib_file_ops[] = {
     { PCMK__CIB_REQUEST_MODIFY,     FALSE,  cib_process_modify},
     {CIB_OP_APPLY_DIFF, FALSE, cib_process_diff},
     { PCMK__CIB_REQUEST_BUMP,       FALSE,  cib_process_bump },
-    {CIB_OP_REPLACE,    FALSE, cib_process_replace},
+    { PCMK__CIB_REQUEST_REPLACE,    FALSE,  cib_process_replace},
     { PCMK__CIB_REQUEST_CREATE,     FALSE,  cib_process_create },
     { PCMK__CIB_REQUEST_DELETE,     FALSE,  cib_process_delete},
     { PCMK__CIB_REQUEST_ERASE,      FALSE,  cib_process_erase},

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -777,7 +777,7 @@ struct cib_func_entry {
 /* *INDENT-OFF* */
 static struct cib_func_entry cib_file_ops[] = {
     { PCMK__CIB_REQUEST_QUERY,      TRUE,   cib_process_query},
-    {CIB_OP_MODIFY,     FALSE, cib_process_modify},
+    { PCMK__CIB_REQUEST_MODIFY,     FALSE,  cib_process_modify},
     {CIB_OP_APPLY_DIFF, FALSE, cib_process_diff},
     { PCMK__CIB_REQUEST_BUMP,       FALSE,  cib_process_bump },
     {CIB_OP_REPLACE,    FALSE, cib_process_replace},

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -782,7 +782,7 @@ static struct cib_func_entry cib_file_ops[] = {
     { PCMK__CIB_REQUEST_BUMP,       FALSE,  cib_process_bump },
     {CIB_OP_REPLACE,    FALSE, cib_process_replace},
     { PCMK__CIB_REQUEST_CREATE,     FALSE,  cib_process_create },
-    {CIB_OP_DELETE,     FALSE, cib_process_delete},
+    { PCMK__CIB_REQUEST_DELETE,     FALSE,  cib_process_delete},
     {CIB_OP_ERASE,      FALSE, cib_process_erase},
     {CIB_OP_UPGRADE,    FALSE, cib_process_upgrade},
 };

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -783,7 +783,7 @@ static struct cib_func_entry cib_file_ops[] = {
     {CIB_OP_REPLACE,    FALSE, cib_process_replace},
     { PCMK__CIB_REQUEST_CREATE,     FALSE,  cib_process_create },
     { PCMK__CIB_REQUEST_DELETE,     FALSE,  cib_process_delete},
-    {CIB_OP_ERASE,      FALSE, cib_process_erase},
+    { PCMK__CIB_REQUEST_ERASE,      FALSE,  cib_process_erase},
     {CIB_OP_UPGRADE,    FALSE, cib_process_upgrade},
 };
 /* *INDENT-ON* */

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -781,7 +781,7 @@ static struct cib_func_entry cib_file_ops[] = {
     {CIB_OP_APPLY_DIFF, FALSE, cib_process_diff},
     { PCMK__CIB_REQUEST_BUMP,       FALSE,  cib_process_bump },
     {CIB_OP_REPLACE,    FALSE, cib_process_replace},
-    {CIB_OP_CREATE,     FALSE, cib_process_create},
+    { PCMK__CIB_REQUEST_CREATE,     FALSE,  cib_process_create },
     {CIB_OP_DELETE,     FALSE, cib_process_delete},
     {CIB_OP_ERASE,      FALSE, cib_process_erase},
     {CIB_OP_UPGRADE,    FALSE, cib_process_upgrade},

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -778,7 +778,7 @@ struct cib_func_entry {
 static struct cib_func_entry cib_file_ops[] = {
     { PCMK__CIB_REQUEST_QUERY,      TRUE,   cib_process_query},
     { PCMK__CIB_REQUEST_MODIFY,     FALSE,  cib_process_modify},
-    {CIB_OP_APPLY_DIFF, FALSE, cib_process_diff},
+    { PCMK__CIB_REQUEST_APPLY_PATCH,FALSE,  cib_process_diff},
     { PCMK__CIB_REQUEST_BUMP,       FALSE,  cib_process_bump },
     { PCMK__CIB_REQUEST_REPLACE,    FALSE,  cib_process_replace},
     { PCMK__CIB_REQUEST_CREATE,     FALSE,  cib_process_create },

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -1,6 +1,6 @@
 /*
  * Original copyright 2004 International Business Machines
- * Later changes copyright 2008-2021 the Pacemaker project contributors
+ * Later changes copyright 2008-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -779,7 +779,7 @@ static struct cib_func_entry cib_file_ops[] = {
     {CIB_OP_QUERY,      TRUE,  cib_process_query},
     {CIB_OP_MODIFY,     FALSE, cib_process_modify},
     {CIB_OP_APPLY_DIFF, FALSE, cib_process_diff},
-    {CIB_OP_BUMP,       FALSE, cib_process_bump},
+    { PCMK__CIB_REQUEST_BUMP,       FALSE,  cib_process_bump },
     {CIB_OP_REPLACE,    FALSE, cib_process_replace},
     {CIB_OP_CREATE,     FALSE, cib_process_create},
     {CIB_OP_DELETE,     FALSE, cib_process_delete},

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -776,7 +776,7 @@ struct cib_func_entry {
 
 /* *INDENT-OFF* */
 static struct cib_func_entry cib_file_ops[] = {
-    {CIB_OP_QUERY,      TRUE,  cib_process_query},
+    { PCMK__CIB_REQUEST_QUERY,      TRUE,   cib_process_query},
     {CIB_OP_MODIFY,     FALSE, cib_process_modify},
     {CIB_OP_APPLY_DIFF, FALSE, cib_process_diff},
     { PCMK__CIB_REQUEST_BUMP,       FALSE,  cib_process_bump },

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -784,7 +784,7 @@ static struct cib_func_entry cib_file_ops[] = {
     { PCMK__CIB_REQUEST_CREATE,     FALSE,  cib_process_create },
     { PCMK__CIB_REQUEST_DELETE,     FALSE,  cib_process_delete},
     { PCMK__CIB_REQUEST_ERASE,      FALSE,  cib_process_erase},
-    {CIB_OP_UPGRADE,    FALSE, cib_process_upgrade},
+    { PCMK__CIB_REQUEST_UPGRADE,    FALSE,  cib_process_upgrade},
 };
 /* *INDENT-ON* */
 

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2004 International Business Machines
- * Later changes copyright 2004-2021 the Pacemaker project contributors
+ * Later changes copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -434,7 +434,7 @@ cib_native_perform_op_delegate(cib_t * cib, const char *op, const char *host, co
             break;
 
         default:
-            if (!pcmk__str_eq(op, CIB_OP_QUERY, pcmk__str_casei)) {
+            if (!pcmk__str_eq(op, PCMK__CIB_REQUEST_QUERY, pcmk__str_none)) {
                 crm_warn("Call failed: %s", pcmk_strerror(rc));
             }
     }

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -751,7 +751,7 @@ cib_process_xpath(const char *op, int options, const char *section, xmlNode * re
                 break;
             }
 
-        } else if (pcmk__str_eq(op, CIB_OP_MODIFY, pcmk__str_casei)) {
+        } else if (pcmk__str_eq(op, PCMK__CIB_REQUEST_MODIFY, pcmk__str_none)) {
             if (update_xml_child(match, input) == FALSE) {
                 rc = -ENXIO;
             } else if ((options & cib_multiple) == 0) {

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -812,7 +812,8 @@ cib_process_xpath(const char *op, int options, const char *section, xmlNode * re
                 *answer = match;
             }
 
-        } else if (pcmk__str_eq(op, CIB_OP_REPLACE, pcmk__str_casei)) {
+        } else if (pcmk__str_eq(op, PCMK__CIB_REQUEST_REPLACE,
+                                pcmk__str_none)) {
             xmlNode *parent = match->parent;
 
             free_xml(match);

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -343,7 +343,8 @@ cib_process_modify(const char *op, int options, const char *section, xmlNode * r
         }
 
         tmp_section = create_xml_node(NULL, section);
-        cib_process_xpath(CIB_OP_CREATE, 0, path, NULL, tmp_section, NULL, result_cib, answer);
+        cib_process_xpath(PCMK__CIB_REQUEST_CREATE, 0, path, NULL, tmp_section,
+                          NULL, result_cib, answer);
         free_xml(tmp_section);
 
         obj_root = pcmk_find_cib_element(*result_cib, section);
@@ -550,7 +551,7 @@ cib_process_create(const char *op, int options, const char *section, xmlNode * r
         section = NULL;
     }
 
-    CRM_CHECK(strcasecmp(CIB_OP_CREATE, op) == 0, return -EINVAL);
+    CRM_CHECK(strcmp(op, PCMK__CIB_REQUEST_CREATE) == 0, return -EINVAL);
 
     if (input == NULL) {
         crm_err("Cannot perform modification with no data");
@@ -757,7 +758,7 @@ cib_process_xpath(const char *op, int options, const char *section, xmlNode * re
                 break;
             }
 
-        } else if (pcmk__str_eq(op, CIB_OP_CREATE, pcmk__str_casei)) {
+        } else if (pcmk__str_eq(op, PCMK__CIB_REQUEST_CREATE, pcmk__str_none)) {
             add_node_copy(match, input);
             break;
 

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -709,7 +709,8 @@ cib_process_xpath(const char *op, int options, const char *section, xmlNode * re
 
     max = numXpathResults(xpathObj);
 
-    if (max < 1 && pcmk__str_eq(op, CIB_OP_DELETE, pcmk__str_casei)) {
+    if ((max < 1)
+        && pcmk__str_eq(op, PCMK__CIB_REQUEST_DELETE, pcmk__str_none)) {
         crm_debug("%s was already removed", section);
 
     } else if (max < 1) {
@@ -722,7 +723,8 @@ cib_process_xpath(const char *op, int options, const char *section, xmlNode * re
         }
     }
 
-    if (pcmk__str_eq(op, CIB_OP_DELETE, pcmk__str_casei) && (options & cib_multiple)) {
+    if (pcmk_is_set(options, cib_multiple)
+        && pcmk__str_eq(op, PCMK__CIB_REQUEST_DELETE, pcmk__str_none)) {
         dedupXpathResults(xpathObj);
     }
 
@@ -738,7 +740,7 @@ cib_process_xpath(const char *op, int options, const char *section, xmlNode * re
         crm_debug("Processing %s op for %s with %s", op, section, path);
         free(path);
 
-        if (pcmk__str_eq(op, CIB_OP_DELETE, pcmk__str_casei)) {
+        if (pcmk__str_eq(op, PCMK__CIB_REQUEST_DELETE, pcmk__str_none)) {
             if (match == *result_cib) {
                 /* Attempting to delete the whole "/cib" */
                 crm_warn("Cannot perform %s for %s: The xpath is addressing the whole /cib", op, section);

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -694,7 +694,7 @@ cib_process_xpath(const char *op, int options, const char *section, xmlNode * re
     int lpc = 0;
     int max = 0;
     int rc = pcmk_ok;
-    gboolean is_query = pcmk__str_eq(op, CIB_OP_QUERY, pcmk__str_casei);
+    bool is_query = pcmk__str_eq(op, PCMK__CIB_REQUEST_QUERY, pcmk__str_none);
 
     xmlXPathObjectPtr xpathObj = NULL;
 
@@ -761,7 +761,7 @@ cib_process_xpath(const char *op, int options, const char *section, xmlNode * re
             add_node_copy(match, input);
             break;
 
-        } else if (pcmk__str_eq(op, CIB_OP_QUERY, pcmk__str_casei)) {
+        } else if (pcmk__str_eq(op, PCMK__CIB_REQUEST_QUERY, pcmk__str_none)) {
 
             if (options & cib_no_children) {
                 const char *tag = TYPE(match);

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -476,7 +476,7 @@ main(int argc, char **argv)
                 dangerous_cmd = TRUE;
                 break;
             case 'E':
-                cib_action = CIB_OP_ERASE;
+                cib_action = PCMK__CIB_REQUEST_ERASE;
                 dangerous_cmd = TRUE;
                 break;
             case 'S':

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -516,7 +516,7 @@ main(int argc, char **argv)
                 cib_action = PCMK__CIB_REQUEST_MODIFY;
                 break;
             case 'R':
-                cib_action = CIB_OP_REPLACE;
+                cib_action = PCMK__CIB_REQUEST_REPLACE;
                 break;
             case 'C':
                 cib_action = PCMK__CIB_REQUEST_CREATE;
@@ -845,7 +845,7 @@ do_work(xmlNode * input, int call_options, xmlNode ** output)
 {
     /* construct the request */
     the_cib->call_timeout = message_timeout_ms;
-    if (strcasecmp(CIB_OP_REPLACE, cib_action) == 0
+    if ((strcmp(cib_action, PCMK__CIB_REQUEST_REPLACE) == 0)
         && pcmk__str_eq(crm_element_name(input), XML_TAG_CIB, pcmk__str_casei)) {
         xmlNode *status = pcmk_find_cib_element(input, XML_CIB_TAG_STATUS);
 

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -539,7 +539,7 @@ main(int argc, char **argv)
                                       cib_no_children);
                 break;
             case 'B':
-                cib_action = CIB_OP_BUMP;
+                cib_action = PCMK__CIB_REQUEST_BUMP;
                 crm_log_args(argc, argv);
                 break;
             case 'V':

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -513,7 +513,7 @@ main(int argc, char **argv)
                 cib_user = optarg;
                 break;
             case 'M':
-                cib_action = CIB_OP_MODIFY;
+                cib_action = PCMK__CIB_REQUEST_MODIFY;
                 break;
             case 'R':
                 cib_action = CIB_OP_REPLACE;

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -504,7 +504,7 @@ main(int argc, char **argv)
                 command_options |= cib_sync_call;
                 break;
             case 'Q':
-                cib_action = CIB_OP_QUERY;
+                cib_action = PCMK__CIB_REQUEST_QUERY;
                 break;
             case 'P':
                 cib_action = CIB_OP_APPLY_DIFF;
@@ -895,7 +895,8 @@ cibadmin_op_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void 
         fprintf(stderr, "Call %s failed: %s\n", cib_action, pcmk_rc_str(rc));
         print_xml_output(output);
 
-    } else if (pcmk__str_eq(cib_action, CIB_OP_QUERY, pcmk__str_casei) && output == NULL) {
+    } else if (pcmk__str_eq(cib_action, PCMK__CIB_REQUEST_QUERY, pcmk__str_none)
+               && (output == NULL)) {
         crm_err("Query returned no output");
         crm_log_xml_err(msg, "no output");
 

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -522,7 +522,7 @@ main(int argc, char **argv)
                 cib_action = PCMK__CIB_REQUEST_CREATE;
                 break;
             case 'D':
-                cib_action = CIB_OP_DELETE;
+                cib_action = PCMK__CIB_REQUEST_DELETE;
                 break;
             case '5':
                 cib_action = "md5-sum";
@@ -579,7 +579,7 @@ main(int argc, char **argv)
                                       cib_scope_local);
                 break;
             case 'd':
-                cib_action = CIB_OP_DELETE;
+                cib_action = PCMK__CIB_REQUEST_DELETE;
                 cib__set_call_options(command_options, crm_system_name,
                                       cib_multiple);
                 dangerous_cmd = TRUE;

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -507,7 +507,7 @@ main(int argc, char **argv)
                 cib_action = PCMK__CIB_REQUEST_QUERY;
                 break;
             case 'P':
-                cib_action = CIB_OP_APPLY_DIFF;
+                cib_action = PCMK__CIB_REQUEST_APPLY_PATCH;
                 break;
             case 'U':
                 cib_user = optarg;

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -472,7 +472,7 @@ main(int argc, char **argv)
                                       cib_xpath_address);
                 break;
             case 'u':
-                cib_action = CIB_OP_UPGRADE;
+                cib_action = PCMK__CIB_REQUEST_UPGRADE;
                 dangerous_cmd = TRUE;
                 break;
             case 'E':
@@ -757,7 +757,8 @@ main(int argc, char **argv)
         g_main_loop_run(mainloop);
 
     } else if ((rc == -pcmk_err_schema_unchanged)
-               && pcmk__str_eq(cib_action, CIB_OP_UPGRADE, pcmk__str_none)) {
+               && pcmk__str_eq(cib_action, PCMK__CIB_REQUEST_UPGRADE,
+                               pcmk__str_none)) {
         report_schema_unchanged();
 
     } else if (rc < 0) {
@@ -766,7 +767,8 @@ main(int argc, char **argv)
         fprintf(stderr, "Call failed: %s\n", pcmk_rc_str(rc));
 
         if (rc == pcmk_rc_schema_validation) {
-            if (pcmk__str_eq(cib_action, CIB_OP_UPGRADE, pcmk__str_none)) {
+            if (pcmk__str_eq(cib_action, PCMK__CIB_REQUEST_UPGRADE,
+                             pcmk__str_none)) {
                 xmlNode *obj = NULL;
                 int version = 0;
 

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -519,7 +519,7 @@ main(int argc, char **argv)
                 cib_action = CIB_OP_REPLACE;
                 break;
             case 'C':
-                cib_action = CIB_OP_CREATE;
+                cib_action = PCMK__CIB_REQUEST_CREATE;
                 break;
             case 'D':
                 cib_action = CIB_OP_DELETE;


### PR DESCRIPTION
... for consistency with current guidelines, and to move away from deprecated terminology. Also, compare them case-sensitively.