### PR TITLE
Doc: Clusters from Scratch: Improve DRBD walkthrough

### DIFF
--- a/doc/sphinx/Clusters_from_Scratch/active-active.rst
+++ b/doc/sphinx/Clusters_from_Scratch/active-active.rst
@@ -142,7 +142,7 @@ Now we can create a new GFS2 filesystem on the DRBD device.
 
 .. code-block:: console
 
-    [root@pcmk-2 ~]# mkfs.gfs2 -p lock_dlm -j 2 -t mycluster:web /dev/drbd1
+    [root@pcmk-1 ~]# mkfs.gfs2 -p lock_dlm -j 2 -t mycluster:web /dev/drbd1
     It appears to contain an existing filesystem (xfs)
     This will destroy any data on /dev/drbd1
     Are you sure you want to proceed? [y/n] y

--- a/doc/sphinx/Clusters_from_Scratch/active-active.rst
+++ b/doc/sphinx/Clusters_from_Scratch/active-active.rst
@@ -82,7 +82,8 @@ Activate our new configuration, and see how the cluster responds:
       Resource: WebData (class=ocf provider=linbit type=drbd)
        Attributes: drbd_resource=wwwdata
        Operations: demote interval=0s timeout=90 (WebData-demote-interval-0s)
-                   monitor interval=60s (WebData-monitor-interval-60s)
+                   monitor interval=29s role=Promoted (WebData-monitor-interval-29s)
+                   monitor interval=31s role=Unpromoted (WebData-monitor-interval-31s)
                    notify interval=0s timeout=90 (WebData-notify-interval-0s)
                    promote interval=0s timeout=90 (WebData-promote-interval-0s)
                    reload interval=0s timeout=30 (WebData-reload-interval-0s)

--- a/doc/sphinx/Clusters_from_Scratch/ap-configuration.rst
+++ b/doc/sphinx/Clusters_from_Scratch/ap-configuration.rst
@@ -102,7 +102,8 @@ Final Cluster Configuration
       Resource: WebData (class=ocf provider=linbit type=drbd)
        Attributes: drbd_resource=wwwdata
        Operations: demote interval=0s timeout=90 (WebData-demote-interval-0s)
-                   monitor interval=60s (WebData-monitor-interval-60s)
+                   monitor interval=29s role=Promoted (WebData-monitor-interval-29s)
+                   monitor interval=31s role=Unpromoted (WebData-monitor-interval-31s)
                    notify interval=0s timeout=90 (WebData-notify-interval-0s)
                    promote interval=0s timeout=90 (WebData-promote-interval-0s)
                    reload interval=0s timeout=30 (WebData-reload-interval-0s)
@@ -281,7 +282,8 @@ will tell the ``drbd`` agent when its peer changes state.
       Resource: WebData (class=ocf provider=linbit type=drbd)
        Attributes: drbd_resource=wwwdata
        Operations: demote interval=0s timeout=90 (WebData-demote-interval-0s)
-                   monitor interval=60s (WebData-monitor-interval-60s)
+                   monitor interval=29s role=Promoted (WebData-monitor-interval-29s)
+                   monitor interval=31s role=Unpromoted (WebData-monitor-interval-31s)
                    notify interval=0s timeout=90 (WebData-notify-interval-0s)
                    promote interval=0s timeout=90 (WebData-promote-interval-0s)
                    reload interval=0s timeout=30 (WebData-reload-interval-0s)


### PR DESCRIPTION
* Remove `syncer` section, which was made obsolete in DRBD 8.4. Move `verify-alg` to `net` section.
  * Ref: https://linbit.com/drbd-user-guide/drbd-guide-9_0-en/#s-recent-changes-config-syncer.
* Use new-style configuration instead of legacy 8.4-style. These changes aren't necessary but seem like best practices (although the user guide itself becomes inconsistent later, reverting to what it calls the old style at times).
  * Use `device minor 1` instead of device `/dev/drbd1`.
  * Move `protocol C` to the `net` section where it belongs.
  * Assign explicit an `node-id` to each node.
  * Use a `connection` section instead of specifying addresses in `on
    <host>` sections.
  * Quote strings.
  * Ref: https://linbit.com/drbd-user-guide/drbd-guide-9_0-en/#s-drbdconf-example, especially Listings 2 and 4 and the bullet points beneath.
* Integrate with Pacemaker fencing.
  * Use `fencing resource-and-stonith`.
  * Use handlers for `fence-peer` and `unfence-peer`.
    * Note: The DRBD user guide instructs to use the handler `outdate-peer /sbin/kill-other-node.sh`. But that script does not exist, and the DRBD source code comments say `outdate-peer` was replaced by `fence-peer` years ago. I'm using the settings from the `fencing resource-only` description. The `crm-fence-peer.9.sh` script seems to have at least been designed to work with `fencing resource-and-stonith`.
* Add promoted/unpromoted monitor ops.

The commits before "Correct node for mkfs.gfs2" are part of #2786. I expect that one to be merged first.

Part of T492.