### PR TITLE
Low: libcrmcommon: Fix an IPC-related memory leak.

### DIFF
--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -571,6 +571,7 @@ pcmk_disconnect_ipc(pcmk_ipc_api_t *api)
                 // This should always be the case already, but to be safe
                 api->free_on_disconnect = false;
 
+                crm_ipc_close(ipc);
                 crm_ipc_destroy(ipc);
                 ipc_post_disconnect(api);
             }


### PR DESCRIPTION
"crm_attribute -t status -u ..." connects to the attribute daemon using
the sync method.  The call chain for this is send_attrd_update ->
pcmk__attrd_api_update -> connect_and_send_attrd_request ->
pcmk_connect_ipc -> connect_without_main_loop -> crm_ipc_connect.  In
that function, a libqb connection is allocated with qb_ipcc_connect.

In order to avoid leaking memory, that connection needs to be freed with
qb_ipcc_disconnect, which happens in crm_ipc_close.

However, nothing in pcmk__attrd_api_update calls that.  That function
calls destroy_api, which in turn calls pcmk_disconnect_ipc, which seems
like the logical place to free the libqb connection.  Unfortunately, all
it does in the sync case is free the crm_ipc_t that holds the libqb
connection.

So, add a call to crm_ipc_close there to take care of that.  This
probably hits all other ways you can run crm_attribute and probably
attrd_updater as well.  It seems likely that it hits any user of the
sync IPC API.

This can also happen in the mainloop case.  To reproduce, simply enable
valgrind for pacemaker-controld, start the cluster, wait for everything
to be up, and then shut the cluster down.  The valgrind results should
show a leak with a similar origin to the description above.  This patch
looks like it fixes that case, too.