### PR TITLE
Drop redundant pe_working_set_t arguments from libpacemaker functions

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -402,48 +402,48 @@ extern pe_action_t *custom_action(pe_resource_t * rsc, char *key, const char *ta
 #  define delete_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_DELETE, 0)
 #  define delete_action(rsc, node, optional) custom_action(		\
 		rsc, delete_key(rsc), CRMD_ACTION_DELETE, node,		\
-		optional, TRUE, data_set);
+		optional, TRUE, rsc->cluster);
 
 #  define stopped_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_STOPPED, 0)
 #  define stopped_action(rsc, node, optional) custom_action(		\
 		rsc, stopped_key(rsc), CRMD_ACTION_STOPPED, node,	\
-		optional, TRUE, data_set);
+		optional, TRUE, rsc->cluster);
 
 #  define stop_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_STOP, 0)
 #  define stop_action(rsc, node, optional) custom_action(			\
 		rsc, stop_key(rsc), CRMD_ACTION_STOP, node,		\
-		optional, TRUE, data_set);
+		optional, TRUE, rsc->cluster);
 
 #  define reload_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_RELOAD_AGENT, 0)
 #  define start_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_START, 0)
 #  define start_action(rsc, node, optional) custom_action(		\
 		rsc, start_key(rsc), CRMD_ACTION_START, node,		\
-		optional, TRUE, data_set)
+		optional, TRUE, rsc->cluster)
 
 #  define started_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_STARTED, 0)
 #  define started_action(rsc, node, optional) custom_action(		\
 		rsc, started_key(rsc), CRMD_ACTION_STARTED, node,	\
-		optional, TRUE, data_set)
+		optional, TRUE, rsc->cluster)
 
 #  define promote_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_PROMOTE, 0)
 #  define promote_action(rsc, node, optional) custom_action(		\
 		rsc, promote_key(rsc), CRMD_ACTION_PROMOTE, node,	\
-		optional, TRUE, data_set)
+		optional, TRUE, rsc->cluster)
 
 #  define promoted_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_PROMOTED, 0)
 #  define promoted_action(rsc, node, optional) custom_action(		\
 		rsc, promoted_key(rsc), CRMD_ACTION_PROMOTED, node,	\
-		optional, TRUE, data_set)
+		optional, TRUE, rsc->cluster)
 
 #  define demote_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_DEMOTE, 0)
 #  define demote_action(rsc, node, optional) custom_action(		\
 		rsc, demote_key(rsc), CRMD_ACTION_DEMOTE, node,		\
-		optional, TRUE, data_set)
+		optional, TRUE, rsc->cluster)
 
 #  define demoted_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_DEMOTED, 0)
 #  define demoted_action(rsc, node, optional) custom_action(		\
 		rsc, demoted_key(rsc), CRMD_ACTION_DEMOTED, node,	\
-		optional, TRUE, data_set)
+		optional, TRUE, rsc->cluster)
 
 extern int pe_get_configured_timeout(pe_resource_t *rsc, const char *action,
                                      pe_working_set_t *data_set);

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -95,6 +95,7 @@ enum pe_graph_flags pcmk__multi_update_actions(pe_action_t *first,
                                                pe_working_set_t *data_set);
 
 void pcmk__log_transition_summary(const char *filename);
-void clone_create_pseudo_actions(
-    pe_resource_t * rsc, GList *children, notify_data_t **start_notify, notify_data_t **stop_notify,  pe_working_set_t * data_set);
+void clone_create_pseudo_actions(pe_resource_t *rsc, GList *children,
+                                 notify_data_t **start_notify,
+                                 notify_data_t **stop_notify);
 #endif

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -21,7 +21,7 @@
 
 pe_node_t *pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *prefer);
 void native_create_actions(pe_resource_t *rsc);
-extern void native_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set);
+void native_internal_constraints(pe_resource_t *rsc);
 extern enum pe_action_flags native_action_flags(pe_action_t * action, pe_node_t * node);
 
 void native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
@@ -36,7 +36,7 @@ void pcmk__primitive_shutdown_lock(pe_resource_t *rsc);
 
 pe_node_t *pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer);
 void group_create_actions(pe_resource_t *rsc);
-extern void group_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set);
+void group_internal_constraints(pe_resource_t *rsc);
 extern enum pe_action_flags group_action_flags(pe_action_t * action, pe_node_t * node);
 void group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern void group_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
@@ -49,8 +49,7 @@ pe_node_t *pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *prefer);
 void pcmk__bundle_create_actions(pe_resource_t *rsc);
 gboolean pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node,
                                    pe_action_t *complete, gboolean force);
-void pcmk__bundle_internal_constraints(pe_resource_t *rsc,
-                                       pe_working_set_t *data_set);
+void pcmk__bundle_internal_constraints(pe_resource_t *rsc);
 void pcmk__bundle_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 enum pe_action_flags pcmk__bundle_action_flags(pe_action_t *action,
                                                pe_node_t *node);
@@ -62,7 +61,7 @@ void pcmk__bundle_shutdown_lock(pe_resource_t *rsc);
 
 pe_node_t *pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *prefer);
 void clone_create_actions(pe_resource_t *rsc);
-extern void clone_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set);
+void clone_internal_constraints(pe_resource_t *rsc);
 void clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern enum pe_action_flags clone_action_flags(pe_action_t * action, pe_node_t * node);
 extern void clone_expand(pe_resource_t * rsc, pe_working_set_t * data_set);

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -25,7 +25,7 @@ void native_internal_constraints(pe_resource_t *rsc);
 extern enum pe_action_flags native_action_flags(pe_action_t * action, pe_node_t * node);
 
 void native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
-extern void native_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
+void native_expand(pe_resource_t *rsc);
 gboolean native_create_probe(pe_resource_t *rsc, pe_node_t *node,
                              pe_action_t *complete, gboolean force);
 extern void native_append_meta(pe_resource_t * rsc, xmlNode * xml);
@@ -39,7 +39,7 @@ void group_create_actions(pe_resource_t *rsc);
 void group_internal_constraints(pe_resource_t *rsc);
 extern enum pe_action_flags group_action_flags(pe_action_t * action, pe_node_t * node);
 void group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
-extern void group_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
+void group_expand(pe_resource_t *rsc);
 extern void group_append_meta(pe_resource_t * rsc, xmlNode * xml);
 void pcmk__group_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                  GList *all_rscs, GHashTable *utilization);
@@ -53,7 +53,7 @@ void pcmk__bundle_internal_constraints(pe_resource_t *rsc);
 void pcmk__bundle_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 enum pe_action_flags pcmk__bundle_action_flags(pe_action_t *action,
                                                pe_node_t *node);
-void pcmk__bundle_expand(pe_resource_t *rsc, pe_working_set_t *data_set);
+void pcmk__bundle_expand(pe_resource_t *rsc);
 void pcmk__bundle_append_meta(pe_resource_t *rsc, xmlNode *xml);
 void pcmk__bundle_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                   GList *all_rscs, GHashTable *utilization);
@@ -64,7 +64,7 @@ void clone_create_actions(pe_resource_t *rsc);
 void clone_internal_constraints(pe_resource_t *rsc);
 void clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern enum pe_action_flags clone_action_flags(pe_action_t * action, pe_node_t * node);
-extern void clone_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
+void clone_expand(pe_resource_t *rsc);
 gboolean clone_create_probe(pe_resource_t *rsc, pe_node_t *node,
                             pe_action_t *complete, gboolean force);
 extern void clone_append_meta(pe_resource_t * rsc, xmlNode * xml);

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -20,7 +20,7 @@
 #  include <pcmki/pcmki_scheduler.h>
 
 pe_node_t *pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *prefer);
-extern void native_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set);
+void native_create_actions(pe_resource_t *rsc);
 extern void native_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set);
 extern enum pe_action_flags native_action_flags(pe_action_t * action, pe_node_t * node);
 
@@ -35,7 +35,7 @@ void pcmk__primitive_add_utilization(pe_resource_t *rsc,
 void pcmk__primitive_shutdown_lock(pe_resource_t *rsc);
 
 pe_node_t *pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer);
-extern void group_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set);
+void group_create_actions(pe_resource_t *rsc);
 extern void group_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set);
 extern enum pe_action_flags group_action_flags(pe_action_t * action, pe_node_t * node);
 void group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
@@ -46,8 +46,7 @@ void pcmk__group_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
 void pcmk__group_shutdown_lock(pe_resource_t *rsc);
 
 pe_node_t *pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *prefer);
-void pcmk__bundle_create_actions(pe_resource_t *rsc,
-                                 pe_working_set_t *data_set);
+void pcmk__bundle_create_actions(pe_resource_t *rsc);
 gboolean pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node,
                                    pe_action_t *complete, gboolean force,
                                    pe_working_set_t *data_set);
@@ -63,7 +62,7 @@ void pcmk__bundle_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
 void pcmk__bundle_shutdown_lock(pe_resource_t *rsc);
 
 pe_node_t *pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *prefer);
-extern void clone_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set);
+void clone_create_actions(pe_resource_t *rsc);
 extern void clone_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set);
 void clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern enum pe_action_flags clone_action_flags(pe_action_t * action, pe_node_t * node);

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -19,8 +19,7 @@
 #  include <crm/common/xml.h>
 #  include <pcmki/pcmki_scheduler.h>
 
-pe_node_t *pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *preferred,
-                                 pe_working_set_t *data_set);
+pe_node_t *pcmk__native_allocate(pe_resource_t *rsc, pe_node_t *prefer);
 extern void native_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set);
 extern void native_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set);
 extern enum pe_action_flags native_action_flags(pe_action_t * action, pe_node_t * node);
@@ -35,8 +34,7 @@ void pcmk__primitive_add_utilization(pe_resource_t *rsc,
                                      GHashTable *utilization);
 void pcmk__primitive_shutdown_lock(pe_resource_t *rsc);
 
-pe_node_t *pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *preferred,
-                                pe_working_set_t *data_set);
+pe_node_t *pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer);
 extern void group_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set);
 extern void group_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set);
 extern enum pe_action_flags group_action_flags(pe_action_t * action, pe_node_t * node);
@@ -47,8 +45,7 @@ void pcmk__group_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                  GList *all_rscs, GHashTable *utilization);
 void pcmk__group_shutdown_lock(pe_resource_t *rsc);
 
-pe_node_t *pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *preferred,
-                                 pe_working_set_t *data_set);
+pe_node_t *pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *prefer);
 void pcmk__bundle_create_actions(pe_resource_t *rsc,
                                  pe_working_set_t *data_set);
 gboolean pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node,
@@ -65,8 +62,7 @@ void pcmk__bundle_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                   GList *all_rscs, GHashTable *utilization);
 void pcmk__bundle_shutdown_lock(pe_resource_t *rsc);
 
-pe_node_t *pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *preferred,
-                                pe_working_set_t *data_set);
+pe_node_t *pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *prefer);
 extern void clone_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set);
 extern void clone_internal_constraints(pe_resource_t * rsc, pe_working_set_t * data_set);
 void clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -26,8 +26,8 @@ extern enum pe_action_flags native_action_flags(pe_action_t * action, pe_node_t 
 
 void native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern void native_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
-extern gboolean native_create_probe(pe_resource_t * rsc, pe_node_t * node, pe_action_t * complete,
-                                    gboolean force, pe_working_set_t * data_set);
+gboolean native_create_probe(pe_resource_t *rsc, pe_node_t *node,
+                             pe_action_t *complete, gboolean force);
 extern void native_append_meta(pe_resource_t * rsc, xmlNode * xml);
 void pcmk__primitive_add_utilization(pe_resource_t *rsc,
                                      pe_resource_t *orig_rsc, GList *all_rscs,
@@ -48,8 +48,7 @@ void pcmk__group_shutdown_lock(pe_resource_t *rsc);
 pe_node_t *pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *prefer);
 void pcmk__bundle_create_actions(pe_resource_t *rsc);
 gboolean pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node,
-                                   pe_action_t *complete, gboolean force,
-                                   pe_working_set_t *data_set);
+                                   pe_action_t *complete, gboolean force);
 void pcmk__bundle_internal_constraints(pe_resource_t *rsc,
                                        pe_working_set_t *data_set);
 void pcmk__bundle_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
@@ -67,8 +66,8 @@ extern void clone_internal_constraints(pe_resource_t * rsc, pe_working_set_t * d
 void clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern enum pe_action_flags clone_action_flags(pe_action_t * action, pe_node_t * node);
 extern void clone_expand(pe_resource_t * rsc, pe_working_set_t * data_set);
-extern gboolean clone_create_probe(pe_resource_t * rsc, pe_node_t * node, pe_action_t * complete,
-                                   gboolean force, pe_working_set_t * data_set);
+gboolean clone_create_probe(pe_resource_t *rsc, pe_node_t *node,
+                            pe_action_t *complete, gboolean force);
 extern void clone_append_meta(pe_resource_t * rsc, xmlNode * xml);
 void pcmk__clone_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                  GList *all_rscs, GHashTable *utilization);

--- a/include/pcmki/pcmki_sched_utils.h
+++ b/include/pcmki/pcmki_sched_utils.h
@@ -26,8 +26,7 @@ GList *pcmk__copy_node_list(const GList *list, bool reset);
 
 pe_resource_t *find_compatible_child(pe_resource_t *local_child,
                                      pe_resource_t *rsc, enum rsc_role_e filter,
-                                     gboolean current,
-                                     pe_working_set_t *data_set);
+                                     gboolean current);
 pe_resource_t *find_compatible_child_by_node(pe_resource_t * local_child, pe_node_t * local_node, pe_resource_t * rsc,
                                              enum rsc_role_e filter, gboolean current);
 gboolean is_child_compatible(pe_resource_t *child_rsc, pe_node_t * local_node, enum rsc_role_e filter, gboolean current);

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -527,8 +527,7 @@ G_GNUC_INTERNAL
 GHashTable *pcmk__copy_node_table(GHashTable *nodes);
 
 G_GNUC_INTERNAL
-GList *pcmk__sort_nodes(GList *nodes, pe_node_t *active_node,
-                        pe_working_set_t *data_set);
+GList *pcmk__sort_nodes(GList *nodes, pe_node_t *active_node);
 
 G_GNUC_INTERNAL
 void pcmk__apply_node_health(pe_working_set_t *data_set);

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -33,7 +33,7 @@ enum pcmk__coloc_select {
 
 // Resource allocation methods
 struct resource_alloc_functions_s {
-    pe_node_t *(*allocate) (pe_resource_t *, pe_node_t *, pe_working_set_t *);
+    pe_node_t *(*allocate)(pe_resource_t *rsc, pe_node_t *prefer);
     void (*create_actions) (pe_resource_t *, pe_working_set_t *);
     gboolean(*create_probe) (pe_resource_t *, pe_node_t *, pe_action_t *, gboolean, pe_working_set_t *);
     void (*internal_constraints) (pe_resource_t *, pe_working_set_t *);

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -190,8 +190,7 @@ void pcmk__order_vs_fence(pe_action_t *stonith_op, pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
 void pcmk__order_vs_unfence(pe_resource_t *rsc, pe_node_t *node,
-                            pe_action_t *action, enum pe_ordering order,
-                            pe_working_set_t *data_set);
+                            pe_action_t *action, enum pe_ordering order);
 
 G_GNUC_INTERNAL
 void pcmk__fence_guest(pe_node_t *node);

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -108,7 +108,7 @@ struct resource_alloc_functions_s {
                                            pe_working_set_t *data_set);
     void (*output_actions)(pe_resource_t *rsc);
 
-    void (*expand) (pe_resource_t *, pe_working_set_t *);
+    void (*expand)(pe_resource_t *rsc);
     void (*append_meta) (pe_resource_t * rsc, xmlNode * xml);
 
     /*!

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -376,7 +376,7 @@ void pcmk__order_after_each(pe_action_t *after, GList *list);
                        pcmk__op_key((then_rsc)->id, (then_task), 0),        \
                        NULL, (flags), (first_rsc)->cluster)
 
-#define pcmk__order_starts(rsc1, rsc2, type, data_set)       \
+#define pcmk__order_starts(rsc1, rsc2, type)                 \
     pcmk__order_resource_actions((rsc1), CRMD_ACTION_START,  \
                                  (rsc2), CRMD_ACTION_START, (type))
 

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -367,22 +367,22 @@ void pcmk__order_after_each(pe_action_t *after, GList *list);
  * \param[in] flags       Bitmask of enum pe_ordering flags
  * \param[in] data_set    Cluster working set to add ordering to
  */
-#define pcmk__order_resource_actions(first_rsc, first_task, \
-                                     then_rsc, then_task, flags, data_set)  \
+#define pcmk__order_resource_actions(first_rsc, first_task,                 \
+                                     then_rsc, then_task, flags)            \
     pcmk__new_ordering((first_rsc),                                         \
                        pcmk__op_key((first_rsc)->id, (first_task), 0),      \
                        NULL,                                                \
                        (then_rsc),                                          \
                        pcmk__op_key((then_rsc)->id, (then_task), 0),        \
-                       NULL, (flags), (data_set))
+                       NULL, (flags), (first_rsc)->cluster)
 
 #define pcmk__order_starts(rsc1, rsc2, type, data_set)       \
     pcmk__order_resource_actions((rsc1), CRMD_ACTION_START,  \
-                                 (rsc2), CRMD_ACTION_START, (type), (data_set))
+                                 (rsc2), CRMD_ACTION_START, (type))
 
 #define pcmk__order_stops(rsc1, rsc2, type, data_set)        \
     pcmk__order_resource_actions((rsc1), CRMD_ACTION_STOP,   \
-                                 (rsc2), CRMD_ACTION_STOP, (type), (data_set))
+                                 (rsc2), CRMD_ACTION_STOP, (type))
 
 
 // Ticket constraints (pcmk_sched_tickets.c)

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -347,8 +347,7 @@ void pcmk__disable_invalid_orderings(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
 void pcmk__order_stops_before_shutdown(pe_node_t *node,
-                                       pe_action_t *shutdown_op,
-                                       pe_working_set_t *data_set);
+                                       pe_action_t *shutdown_op);
 
 G_GNUC_INTERNAL
 void pcmk__apply_orderings(pe_working_set_t *data_set);

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -34,7 +34,7 @@ enum pcmk__coloc_select {
 // Resource allocation methods
 struct resource_alloc_functions_s {
     pe_node_t *(*allocate)(pe_resource_t *rsc, pe_node_t *prefer);
-    void (*create_actions) (pe_resource_t *, pe_working_set_t *);
+    void (*create_actions)(pe_resource_t *rsc);
     gboolean(*create_probe) (pe_resource_t *, pe_node_t *, pe_action_t *, gboolean, pe_working_set_t *);
     void (*internal_constraints) (pe_resource_t *, pe_working_set_t *);
 

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -380,7 +380,7 @@ void pcmk__order_after_each(pe_action_t *after, GList *list);
     pcmk__order_resource_actions((rsc1), CRMD_ACTION_START,  \
                                  (rsc2), CRMD_ACTION_START, (type))
 
-#define pcmk__order_stops(rsc1, rsc2, type, data_set)        \
+#define pcmk__order_stops(rsc1, rsc2, type)                  \
     pcmk__order_resource_actions((rsc1), CRMD_ACTION_STOP,   \
                                  (rsc2), CRMD_ACTION_STOP, (type))
 

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -37,7 +37,7 @@ struct resource_alloc_functions_s {
     void (*create_actions)(pe_resource_t *rsc);
     gboolean (*create_probe)(pe_resource_t *rsc, pe_node_t *node,
                              pe_action_t *complete, gboolean force);
-    void (*internal_constraints) (pe_resource_t *, pe_working_set_t *);
+    void (*internal_constraints)(pe_resource_t *rsc);
 
     /*!
      * \internal

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -35,7 +35,8 @@ enum pcmk__coloc_select {
 struct resource_alloc_functions_s {
     pe_node_t *(*allocate)(pe_resource_t *rsc, pe_node_t *prefer);
     void (*create_actions)(pe_resource_t *rsc);
-    gboolean(*create_probe) (pe_resource_t *, pe_node_t *, pe_action_t *, gboolean, pe_working_set_t *);
+    gboolean (*create_probe)(pe_resource_t *rsc, pe_node_t *node,
+                             pe_action_t *complete, gboolean force);
     void (*internal_constraints) (pe_resource_t *, pe_working_set_t *);
 
     /*!

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -1050,7 +1050,7 @@ pcmk__create_graph(pe_working_set_t *data_set)
         pe_resource_t *rsc = (pe_resource_t *) iter->data;
 
         pe_rsc_trace(rsc, "Processing actions for %s", rsc->id);
-        rsc->cmds->expand(rsc, data_set);
+        rsc->cmds->expand(rsc);
     }
 
     // Add pseudo-action for list of nodes with maintenance state update

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -817,8 +817,7 @@ pcmk__new_shutdown_action(pe_node_t *node)
     shutdown_op = custom_action(NULL, shutdown_id, CRM_OP_SHUTDOWN, node, FALSE,
                                 TRUE, node->details->data_set);
 
-    pcmk__order_stops_before_shutdown(node, shutdown_op,
-                                      node->details->data_set);
+    pcmk__order_stops_before_shutdown(node, shutdown_op);
     add_hash_param(shutdown_op->meta, XML_ATTR_TE_NOWAIT, XML_BOOLEAN_TRUE);
     return shutdown_op;
 }

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -405,7 +405,7 @@ schedule_resource_actions(pe_working_set_t *data_set)
     for (GList *iter = data_set->resources; iter != NULL; iter = iter->next) {
         pe_resource_t *rsc = (pe_resource_t *) iter->data;
 
-        rsc->cmds->create_actions(rsc, data_set);
+        rsc->cmds->create_actions(rsc);
     }
 }
 

--- a/lib/pacemaker/pcmk_sched_allocate.c
+++ b/lib/pacemaker/pcmk_sched_allocate.c
@@ -318,8 +318,7 @@ allocate_resources(pe_working_set_t *data_set)
             if (rsc->is_remote_node) {
                 pe_rsc_trace(rsc, "Allocating remote connection resource '%s'",
                              rsc->id);
-                rsc->cmds->allocate(rsc, rsc->partial_migration_target,
-                                    data_set);
+                rsc->cmds->allocate(rsc, rsc->partial_migration_target);
             }
         }
     }
@@ -331,7 +330,7 @@ allocate_resources(pe_working_set_t *data_set)
         if (!rsc->is_remote_node) {
             pe_rsc_trace(rsc, "Allocating %s resource '%s'",
                          crm_element_name(rsc->xml), rsc->id);
-            rsc->cmds->allocate(rsc, NULL, data_set);
+            rsc->cmds->allocate(rsc, NULL);
         }
     }
 

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -653,7 +653,7 @@ multi_update_interleave_actions(pe_action_t *first, pe_action_t *then,
         pe_resource_t *first_child = find_compatible_child(then_child,
                                                            first->rsc,
                                                            RSC_ROLE_UNKNOWN,
-                                                           current, data_set);
+                                                           current);
         if (first_child == NULL && current) {
             crm_trace("Ignore");
 

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -966,8 +966,7 @@ pcmk__bundle_expand(pe_resource_t *rsc, pe_working_set_t * data_set)
 
 gboolean
 pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node,
-                          pe_action_t *complete, gboolean force,
-                          pe_working_set_t * data_set)
+                          pe_action_t *complete, gboolean force)
 {
     bool any_created = FALSE;
     pe__bundle_variant_data_t *bundle_data = NULL;
@@ -982,18 +981,17 @@ pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node,
         CRM_ASSERT(replica);
         if (replica->ip) {
             any_created |= replica->ip->cmds->create_probe(replica->ip, node,
-                                                           complete, force,
-                                                           data_set);
+                                                           complete, force);
         }
         if (replica->child && (node->details == replica->node->details)) {
             any_created |= replica->child->cmds->create_probe(replica->child,
                                                               node, complete,
-                                                              force, data_set);
+                                                              force);
         }
         if (replica->container) {
             bool created = replica->container->cmds->create_probe(replica->container,
                                                                   node, complete,
-                                                                  force, data_set);
+                                                                  force);
 
             if(created) {
                 any_created = TRUE;
@@ -1024,15 +1022,14 @@ pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node,
                                            pcmk__op_key(other->container->id, RSC_START, 0),
                                            NULL,
                                            pe_order_optional|pe_order_same_node,
-                                           data_set);
+                                           rsc->cluster);
                     }
                 }
             }
         }
         if (replica->container && replica->remote
             && replica->remote->cmds->create_probe(replica->remote, node,
-                                                   complete, force,
-                                                   data_set)) {
+                                                   complete, force)) {
 
             /* Do not probe the remote resource until we know where the
              * container is running. This is required for REMOTE_CONTAINER_HACK
@@ -1051,7 +1048,7 @@ pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node,
                 pcmk__new_ordering(replica->container,
                                    pcmk__op_key(replica->container->id, RSC_START, 0),
                                    NULL, replica->remote, NULL, probe,
-                                   pe_order_probe, data_set);
+                                   pe_order_probe, rsc->cluster);
             }
         }
     }

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -188,7 +188,7 @@ pcmk__bundle_create_actions(pe_resource_t *rsc)
         }
     }
 
-    clone_create_pseudo_actions(rsc, containers, NULL, NULL,  rsc->cluster);
+    clone_create_pseudo_actions(rsc, containers, NULL, NULL);
 
     if (bundle_data->child) {
         bundle_data->child->cmds->create_actions(bundle_data->child);

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -255,10 +255,10 @@ pcmk__bundle_internal_constraints(pe_resource_t *rsc)
 
         if (replica->child) {
             pcmk__order_stops(rsc, replica->child,
-                              pe_order_implies_first_printed, rsc->cluster);
+                              pe_order_implies_first_printed);
         }
         pcmk__order_stops(rsc, replica->container,
-                          pe_order_implies_first_printed, rsc->cluster);
+                          pe_order_implies_first_printed);
         pcmk__order_resource_actions(replica->container, RSC_START, rsc,
                                      RSC_STARTED,
                                      pe_order_implies_then_printed);
@@ -273,8 +273,7 @@ pcmk__bundle_internal_constraints(pe_resource_t *rsc)
             pcmk__order_starts(replica->ip, replica->container,
                                pe_order_runnable_left|pe_order_preserve);
             pcmk__order_stops(replica->container, replica->ip,
-                              pe_order_implies_first|pe_order_preserve,
-                              rsc->cluster);
+                              pe_order_implies_first|pe_order_preserve);
 
             pcmk__new_colocation("ip-with-docker", NULL, INFINITY, replica->ip,
                                  replica->container, NULL, NULL, true,

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -890,7 +890,7 @@ pcmk__bundle_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
 }
 
 void
-pcmk__bundle_expand(pe_resource_t *rsc, pe_working_set_t * data_set)
+pcmk__bundle_expand(pe_resource_t *rsc)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
 
@@ -899,7 +899,7 @@ pcmk__bundle_expand(pe_resource_t *rsc, pe_working_set_t * data_set)
     get_bundle_variant_data(bundle_data, rsc);
 
     if (bundle_data->child) {
-        bundle_data->child->cmds->expand(bundle_data->child, data_set);
+        bundle_data->child->cmds->expand(bundle_data->child);
     }
 
     for (GList *gIter = bundle_data->replicas; gIter != NULL;
@@ -908,7 +908,7 @@ pcmk__bundle_expand(pe_resource_t *rsc, pe_working_set_t * data_set)
 
         CRM_ASSERT(replica);
         if (replica->remote && replica->container
-            && pe__bundle_needs_remote_name(replica->remote, data_set)) {
+            && pe__bundle_needs_remote_name(replica->remote, rsc->cluster)) {
 
             /* REMOTE_CONTAINER_HACK: Allow remote nodes to run containers that
              * run pacemaker-remoted inside, without needing a separate IP for
@@ -922,7 +922,7 @@ pcmk__bundle_expand(pe_resource_t *rsc, pe_working_set_t * data_set)
 
             // Replace the value in replica->remote->xml (if appropriate)
             calculated_addr = pe__add_bundle_remote_name(replica->remote,
-                                                         data_set,
+                                                         rsc->cluster,
                                                          nvpair, "value");
             if (calculated_addr) {
                 /* Since this is for the bundle as a resource, and not any
@@ -932,7 +932,7 @@ pcmk__bundle_expand(pe_resource_t *rsc, pe_working_set_t * data_set)
                  * parameters.
                  */
                 GHashTable *params = pe_rsc_params(replica->remote,
-                                                   NULL, data_set);
+                                                   NULL, rsc->cluster);
 
                 g_hash_table_replace(params,
                                      strdup(XML_RSC_ATTR_REMOTE_RA_ADDR),
@@ -950,13 +950,13 @@ pcmk__bundle_expand(pe_resource_t *rsc, pe_working_set_t * data_set)
             }
         }
         if (replica->ip) {
-            replica->ip->cmds->expand(replica->ip, data_set);
+            replica->ip->cmds->expand(replica->ip);
         }
         if (replica->container) {
-            replica->container->cmds->expand(replica->container, data_set);
+            replica->container->cmds->expand(replica->container);
         }
         if (replica->remote) {
-            replica->remote->cmds->expand(replica->remote, data_set);
+            replica->remote->cmds->expand(replica->remote);
         }
     }
 }

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -220,30 +220,24 @@ pcmk__bundle_internal_constraints(pe_resource_t *rsc)
 
     if (bundle_data->child) {
         pcmk__order_resource_actions(rsc, RSC_START, bundle_data->child,
-                                     RSC_START, pe_order_implies_first_printed,
-                                     rsc->cluster);
+                                     RSC_START, pe_order_implies_first_printed);
         pcmk__order_resource_actions(rsc, RSC_STOP, bundle_data->child,
-                                     RSC_STOP, pe_order_implies_first_printed,
-                                     rsc->cluster);
+                                     RSC_STOP, pe_order_implies_first_printed);
 
         if (bundle_data->child->children) {
             pcmk__order_resource_actions(bundle_data->child, RSC_STARTED, rsc,
                                          RSC_STARTED,
-                                         pe_order_implies_then_printed,
-                                         rsc->cluster);
+                                         pe_order_implies_then_printed);
             pcmk__order_resource_actions(bundle_data->child, RSC_STOPPED, rsc,
                                          RSC_STOPPED,
-                                         pe_order_implies_then_printed,
-                                         rsc->cluster);
+                                         pe_order_implies_then_printed);
         } else {
             pcmk__order_resource_actions(bundle_data->child, RSC_START, rsc,
                                          RSC_STARTED,
-                                         pe_order_implies_then_printed,
-                                         rsc->cluster);
+                                         pe_order_implies_then_printed);
             pcmk__order_resource_actions(bundle_data->child, RSC_STOP, rsc,
                                          RSC_STOPPED,
-                                         pe_order_implies_then_printed,
-                                         rsc->cluster);
+                                         pe_order_implies_then_printed);
         }
     }
 
@@ -267,11 +261,11 @@ pcmk__bundle_internal_constraints(pe_resource_t *rsc)
         pcmk__order_stops(rsc, replica->container,
                           pe_order_implies_first_printed, rsc->cluster);
         pcmk__order_resource_actions(replica->container, RSC_START, rsc,
-                                     RSC_STARTED, pe_order_implies_then_printed,
-                                     rsc->cluster);
+                                     RSC_STARTED,
+                                     pe_order_implies_then_printed);
         pcmk__order_resource_actions(replica->container, RSC_STOP, rsc,
-                                     RSC_STOPPED, pe_order_implies_then_printed,
-                                     rsc->cluster);
+                                     RSC_STOPPED,
+                                     pe_order_implies_then_printed);
 
         if (replica->ip) {
             replica->ip->cmds->internal_constraints(replica->ip);
@@ -314,26 +308,22 @@ pcmk__bundle_internal_constraints(pe_resource_t *rsc)
             /* child demoted before global demoted */
             pcmk__order_resource_actions(bundle_data->child, RSC_DEMOTED, rsc,
                                          RSC_DEMOTED,
-                                         pe_order_implies_then_printed,
-                                         rsc->cluster);
+                                         pe_order_implies_then_printed);
 
             /* global demote before child demote */
             pcmk__order_resource_actions(rsc, RSC_DEMOTE, bundle_data->child,
                                          RSC_DEMOTE,
-                                         pe_order_implies_first_printed,
-                                         rsc->cluster);
+                                         pe_order_implies_first_printed);
 
             /* child promoted before global promoted */
             pcmk__order_resource_actions(bundle_data->child, RSC_PROMOTED, rsc,
                                          RSC_PROMOTED,
-                                         pe_order_implies_then_printed,
-                                         rsc->cluster);
+                                         pe_order_implies_then_printed);
 
             /* global promote before child promote */
             pcmk__order_resource_actions(rsc, RSC_PROMOTE, bundle_data->child,
                                          RSC_PROMOTE,
-                                         pe_order_implies_first_printed,
-                                         rsc->cluster);
+                                         pe_order_implies_first_printed);
         }
     }
 }

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -162,7 +162,7 @@ pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *prefer)
 
 
 void
-pcmk__bundle_create_actions(pe_resource_t *rsc, pe_working_set_t *data_set)
+pcmk__bundle_create_actions(pe_resource_t *rsc)
 {
     pe_action_t *action = NULL;
     GList *containers = NULL;
@@ -178,21 +178,20 @@ pcmk__bundle_create_actions(pe_resource_t *rsc, pe_working_set_t *data_set)
 
         CRM_ASSERT(replica);
         if (replica->ip) {
-            replica->ip->cmds->create_actions(replica->ip, data_set);
+            replica->ip->cmds->create_actions(replica->ip);
         }
         if (replica->container) {
-            replica->container->cmds->create_actions(replica->container,
-                                                     data_set);
+            replica->container->cmds->create_actions(replica->container);
         }
         if (replica->remote) {
-            replica->remote->cmds->create_actions(replica->remote, data_set);
+            replica->remote->cmds->create_actions(replica->remote);
         }
     }
 
-    clone_create_pseudo_actions(rsc, containers, NULL, NULL,  data_set);
+    clone_create_pseudo_actions(rsc, containers, NULL, NULL,  rsc->cluster);
 
     if (bundle_data->child) {
-        bundle_data->child->cmds->create_actions(bundle_data->child, data_set);
+        bundle_data->child->cmds->create_actions(bundle_data->child);
 
         if (pcmk_is_set(bundle_data->child->flags, pe_rsc_promotable)) {
             /* promote */

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -251,8 +251,7 @@ pcmk__bundle_internal_constraints(pe_resource_t *rsc)
         replica->container->cmds->internal_constraints(replica->container);
 
         pcmk__order_starts(rsc, replica->container,
-                           pe_order_runnable_left|pe_order_implies_first_printed,
-                           rsc->cluster);
+                           pe_order_runnable_left|pe_order_implies_first_printed);
 
         if (replica->child) {
             pcmk__order_stops(rsc, replica->child,
@@ -272,8 +271,7 @@ pcmk__bundle_internal_constraints(pe_resource_t *rsc)
 
             // Start IP then container
             pcmk__order_starts(replica->ip, replica->container,
-                               pe_order_runnable_left|pe_order_preserve,
-                               rsc->cluster);
+                               pe_order_runnable_left|pe_order_preserve);
             pcmk__order_stops(replica->container, replica->ip,
                               pe_order_implies_first|pe_order_preserve,
                               rsc->cluster);

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -79,7 +79,7 @@ pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *prefer)
                           rsc, __func__, rsc->allowed_nodes, rsc->cluster);
 
     nodes = g_hash_table_get_values(rsc->allowed_nodes);
-    nodes = pcmk__sort_nodes(nodes, NULL, rsc->cluster);
+    nodes = pcmk__sort_nodes(nodes, NULL);
     containers = g_list_sort(containers, pcmk__cmp_instance);
     distribute_children(rsc, containers, nodes, bundle_data->nreplicas,
                         bundle_data->nreplicas_per_host, rsc->cluster);
@@ -383,7 +383,7 @@ compatible_replica(pe_resource_t *rsc_lh, pe_resource_t *rsc,
     }
 
     scratch = g_hash_table_get_values(rsc_lh->allowed_nodes);
-    scratch = pcmk__sort_nodes(scratch, NULL, data_set);
+    scratch = pcmk__sort_nodes(scratch, NULL);
 
     for (GList *gIter = scratch; gIter != NULL; gIter = gIter->next) {
         pe_node_t *node = (pe_node_t *) gIter->data;

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -481,7 +481,7 @@ clone_create_actions(pe_resource_t *rsc)
 
     pe_rsc_debug(rsc, "Creating actions for clone %s", rsc->id);
     clone_create_pseudo_actions(rsc, rsc->children, &clone_data->start_notify,
-                                &clone_data->stop_notify, rsc->cluster);
+                                &clone_data->stop_notify);
     child_ordering_constraints(rsc, rsc->cluster);
 
     if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
@@ -490,8 +490,9 @@ clone_create_actions(pe_resource_t *rsc)
 }
 
 void
-clone_create_pseudo_actions(
-    pe_resource_t * rsc, GList *children, notify_data_t **start_notify, notify_data_t **stop_notify,  pe_working_set_t * data_set)
+clone_create_pseudo_actions(pe_resource_t *rsc, GList *children,
+                            notify_data_t **start_notify,
+                            notify_data_t **stop_notify)
 {
     gboolean child_active = FALSE;
     gboolean child_starting = FALSE;

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -587,13 +587,11 @@ clone_internal_constraints(pe_resource_t *rsc)
         child_rsc->cmds->internal_constraints(child_rsc);
 
         pcmk__order_starts(rsc, child_rsc,
-                           pe_order_runnable_left|pe_order_implies_first_printed,
-                           rsc->cluster);
+                           pe_order_runnable_left|pe_order_implies_first_printed);
         pcmk__order_resource_actions(child_rsc, RSC_START, rsc, RSC_STARTED,
                                      pe_order_implies_then_printed);
         if (ordered && (last_rsc != NULL)) {
-            pcmk__order_starts(last_rsc, child_rsc, pe_order_optional,
-                               rsc->cluster);
+            pcmk__order_starts(last_rsc, child_rsc, pe_order_optional);
         }
 
         pcmk__order_stops(rsc, child_rsc, pe_order_implies_first_printed,

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -564,17 +564,17 @@ clone_internal_constraints(pe_resource_t *rsc)
 
     pe_rsc_trace(rsc, "Internal constraints for %s", rsc->id);
     pcmk__order_resource_actions(rsc, RSC_STOPPED, rsc, RSC_START,
-                                 pe_order_optional, rsc->cluster);
+                                 pe_order_optional);
     pcmk__order_resource_actions(rsc, RSC_START, rsc, RSC_STARTED,
-                                 pe_order_runnable_left, rsc->cluster);
+                                 pe_order_runnable_left);
     pcmk__order_resource_actions(rsc, RSC_STOP, rsc, RSC_STOPPED,
-                                 pe_order_runnable_left, rsc->cluster);
+                                 pe_order_runnable_left);
 
     if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
         pcmk__order_resource_actions(rsc, RSC_DEMOTED, rsc, RSC_STOP,
-                                     pe_order_optional, rsc->cluster);
+                                     pe_order_optional);
         pcmk__order_resource_actions(rsc, RSC_STARTED, rsc, RSC_PROMOTE,
-                                     pe_order_runnable_left, rsc->cluster);
+                                     pe_order_runnable_left);
     }
 
     if (ordered) {
@@ -590,8 +590,7 @@ clone_internal_constraints(pe_resource_t *rsc)
                            pe_order_runnable_left|pe_order_implies_first_printed,
                            rsc->cluster);
         pcmk__order_resource_actions(child_rsc, RSC_START, rsc, RSC_STARTED,
-                                     pe_order_implies_then_printed,
-                                     rsc->cluster);
+                                     pe_order_implies_then_printed);
         if (ordered && (last_rsc != NULL)) {
             pcmk__order_starts(last_rsc, child_rsc, pe_order_optional,
                                rsc->cluster);
@@ -600,8 +599,7 @@ clone_internal_constraints(pe_resource_t *rsc)
         pcmk__order_stops(rsc, child_rsc, pe_order_implies_first_printed,
                           rsc->cluster);
         pcmk__order_resource_actions(child_rsc, RSC_STOP, rsc, RSC_STOPPED,
-                                     pe_order_implies_then_printed,
-                                     rsc->cluster);
+                                     pe_order_implies_then_printed);
         if (ordered && (last_rsc != NULL)) {
             pcmk__order_stops(child_rsc, last_rsc, pe_order_optional,
                               rsc->cluster);

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -473,15 +473,16 @@ child_ordering_constraints(pe_resource_t * rsc, pe_working_set_t * data_set)
 }
 
 void
-clone_create_actions(pe_resource_t *rsc, pe_working_set_t *data_set)
+clone_create_actions(pe_resource_t *rsc)
 {
     clone_variant_data_t *clone_data = NULL;
 
     get_clone_variant_data(clone_data, rsc);
 
     pe_rsc_debug(rsc, "Creating actions for clone %s", rsc->id);
-    clone_create_pseudo_actions(rsc, rsc->children, &clone_data->start_notify, &clone_data->stop_notify,data_set);
-    child_ordering_constraints(rsc, data_set);
+    clone_create_pseudo_actions(rsc, rsc->children, &clone_data->start_notify,
+                                &clone_data->stop_notify, rsc->cluster);
+    child_ordering_constraints(rsc, rsc->cluster);
 
     if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
         pcmk__create_promotable_actions(rsc);
@@ -510,7 +511,7 @@ clone_create_pseudo_actions(
         gboolean starting = FALSE;
         gboolean stopping = FALSE;
 
-        child_rsc->cmds->create_actions(child_rsc, data_set);
+        child_rsc->cmds->create_actions(child_rsc);
         clone_update_pseudo_status(child_rsc, &stopping, &starting, &child_active);
         if (stopping && starting) {
             allow_dependent_migrations = FALSE;

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -332,7 +332,7 @@ pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *prefer)
                           rsc, __func__, rsc->allowed_nodes, rsc->cluster);
 
     nodes = g_hash_table_get_values(rsc->allowed_nodes);
-    nodes = pcmk__sort_nodes(nodes, NULL, rsc->cluster);
+    nodes = pcmk__sort_nodes(nodes, NULL);
     rsc->children = g_list_sort(rsc->children, pcmk__cmp_instance);
     distribute_children(rsc, rsc->children, nodes, clone_data->clone_max,
                         clone_data->clone_node_max, rsc->cluster);
@@ -659,7 +659,7 @@ find_compatible_child(pe_resource_t *local_child, pe_resource_t *rsc,
     }
 
     scratch = g_hash_table_get_values(local_child->allowed_nodes);
-    scratch = pcmk__sort_nodes(scratch, NULL, data_set);
+    scratch = pcmk__sort_nodes(scratch, NULL);
 
     gIter = scratch;
     for (; gIter != NULL; gIter = gIter->next) {

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -594,13 +594,11 @@ clone_internal_constraints(pe_resource_t *rsc)
             pcmk__order_starts(last_rsc, child_rsc, pe_order_optional);
         }
 
-        pcmk__order_stops(rsc, child_rsc, pe_order_implies_first_printed,
-                          rsc->cluster);
+        pcmk__order_stops(rsc, child_rsc, pe_order_implies_first_printed);
         pcmk__order_resource_actions(child_rsc, RSC_STOP, rsc, RSC_STOPPED,
                                      pe_order_implies_then_printed);
         if (ordered && (last_rsc != NULL)) {
-            pcmk__order_stops(child_rsc, last_rsc, pe_order_optional,
-                              rsc->cluster);
+            pcmk__order_stops(child_rsc, last_rsc, pe_order_optional);
         }
 
         last_rsc = child_rsc;

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -646,8 +646,7 @@ is_child_compatible(pe_resource_t *child_rsc, pe_node_t * local_node, enum rsc_r
 
 pe_resource_t *
 find_compatible_child(pe_resource_t *local_child, pe_resource_t *rsc,
-                      enum rsc_role_e filter, gboolean current,
-                      pe_working_set_t *data_set)
+                      enum rsc_role_e filter, gboolean current)
 {
     pe_resource_t *pair = NULL;
     GList *gIter = NULL;
@@ -765,8 +764,7 @@ pcmk__clone_apply_coloc_score(pe_resource_t *dependent, pe_resource_t *primary,
         pe_resource_t *primary_instance = NULL;
 
         primary_instance = find_compatible_child(dependent, primary,
-                                                 RSC_ROLE_UNKNOWN, FALSE,
-                                                 dependent->cluster);
+                                                 RSC_ROLE_UNKNOWN, FALSE);
         if (primary_instance != NULL) {
             pe_rsc_debug(primary, "Pairing %s with %s",
                          dependent->id, primary_instance->id);

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -1013,8 +1013,7 @@ probe_unique_clone(pe_resource_t *rsc, pe_node_t *node, pe_action_t *complete,
 
         pe_resource_t *child = (pe_resource_t *) child_iter->data;
 
-        any_created |= child->cmds->create_probe(child, node, complete, force,
-                                                 data_set);
+        any_created |= child->cmds->create_probe(child, node, complete, force);
     }
     return any_created;
 }
@@ -1050,12 +1049,12 @@ probe_anonymous_clone(pe_resource_t *rsc, pe_node_t *node,
         child = rsc->children->data;
     }
     CRM_ASSERT(child);
-    return child->cmds->create_probe(child, node, complete, force, data_set);
+    return child->cmds->create_probe(child, node, complete, force);
 }
 
 gboolean
 clone_create_probe(pe_resource_t * rsc, pe_node_t * node, pe_action_t * complete,
-                   gboolean force, pe_working_set_t * data_set)
+                   gboolean force)
 {
     gboolean any_created = FALSE;
 
@@ -1085,10 +1084,11 @@ clone_create_probe(pe_resource_t * rsc, pe_node_t * node, pe_action_t * complete
     }
 
     if (pcmk_is_set(rsc->flags, pe_rsc_unique)) {
-        any_created = probe_unique_clone(rsc, node, complete, force, data_set);
+        any_created = probe_unique_clone(rsc, node, complete, force,
+                                         rsc->cluster);
     } else {
         any_created = probe_anonymous_clone(rsc, node, complete, force,
-                                            data_set);
+                                            rsc->cluster);
     }
     return any_created;
 }

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -925,7 +925,7 @@ clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
 }
 
 void
-clone_expand(pe_resource_t * rsc, pe_working_set_t * data_set)
+clone_expand(pe_resource_t *rsc)
 {
     GList *gIter = NULL;
     clone_variant_data_t *clone_data = NULL;
@@ -945,10 +945,10 @@ clone_expand(pe_resource_t * rsc, pe_working_set_t * data_set)
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
-        child_rsc->cmds->expand(child_rsc, data_set);
+        child_rsc->cmds->expand(child_rsc);
     }
 
-    native_expand(rsc, data_set);
+    native_expand(rsc);
 
     /* The notifications are in the graph now, we can destroy the notify_data */
     pe__free_notification_data(clone_data->demote_notify);

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -174,7 +174,7 @@ anti_colocation_order(pe_resource_t *first_rsc, int first_role,
 
             pcmk__order_resource_actions(first_rsc, first_tasks[first_lpc],
                                          then_rsc, then_tasks[then_lpc],
-                                         pe_order_anti_colocation, data_set);
+                                         pe_order_anti_colocation);
         }
     }
 }

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -415,6 +415,6 @@ pcmk__create_internal_constraints(pe_working_set_t *data_set)
     for (GList *iter = data_set->resources; iter != NULL; iter = iter->next) {
         pe_resource_t *rsc = (pe_resource_t *) iter->data;
 
-        rsc->cmds->internal_constraints(rsc, data_set);
+        rsc->cmds->internal_constraints(rsc);
     }
 }

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -287,7 +287,7 @@ group_internal_constraints(pe_resource_t *rsc)
 
         pcmk__order_starts(rsc, child_rsc, pe_order_implies_first_printed);
         pcmk__order_stops(rsc, child_rsc,
-                          stop|pe_order_implies_first_printed, rsc->cluster);
+                          stop|pe_order_implies_first_printed);
 
         pcmk__order_resource_actions(child_rsc, RSC_STOP, rsc, RSC_STOPPED,
                                      stopped);
@@ -306,7 +306,7 @@ group_internal_constraints(pe_resource_t *rsc)
         } else if (last_rsc != NULL) {
             pcmk__order_starts(last_rsc, child_rsc, start);
             pcmk__order_stops(child_rsc, last_rsc,
-                              pe_order_optional|pe_order_restart, rsc->cluster);
+                              pe_order_optional|pe_order_restart);
 
             if (pcmk_is_set(top->flags, pe_rsc_promotable)) {
                 pcmk__order_resource_actions(last_rsc, RSC_PROMOTE, child_rsc,
@@ -330,8 +330,7 @@ group_internal_constraints(pe_resource_t *rsc)
             if (group_data->ordered
                 && last_rsc
                 && last_rsc->running_on == NULL && last_active && last_active->running_on) {
-                pcmk__order_stops(child_rsc, last_active, pe_order_optional,
-                                  rsc->cluster);
+                pcmk__order_stops(child_rsc, last_active, pe_order_optional);
             }
             last_active = child_rsc;
         }
@@ -343,7 +342,7 @@ group_internal_constraints(pe_resource_t *rsc)
         int stop_stop_flags = pe_order_implies_then;
         int stop_stopped_flags = pe_order_optional;
 
-        pcmk__order_stops(rsc, last_rsc, stop_stop_flags, rsc->cluster);
+        pcmk__order_stops(rsc, last_rsc, stop_stop_flags);
         pcmk__order_resource_actions(last_rsc, RSC_STOP, rsc, RSC_STOPPED,
                                      stop_stopped_flags);
 

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -240,11 +240,11 @@ group_internal_constraints(pe_resource_t *rsc)
     get_group_variant_data(group_data, rsc);
 
     pcmk__order_resource_actions(rsc, RSC_STOPPED, rsc, RSC_START,
-                                 pe_order_optional, rsc->cluster);
+                                 pe_order_optional);
     pcmk__order_resource_actions(rsc, RSC_START, rsc, RSC_STARTED,
-                                 pe_order_runnable_left, rsc->cluster);
+                                 pe_order_runnable_left);
     pcmk__order_resource_actions(rsc, RSC_STOP, rsc, RSC_STOPPED,
-                                 pe_order_runnable_left, rsc->cluster);
+                                 pe_order_runnable_left);
 
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
@@ -271,19 +271,17 @@ group_internal_constraints(pe_resource_t *rsc)
 
         if (pcmk_is_set(top->flags, pe_rsc_promotable)) {
             pcmk__order_resource_actions(rsc, RSC_DEMOTE, child_rsc, RSC_DEMOTE,
-                                         stop|pe_order_implies_first_printed,
-                                         rsc->cluster);
+                                         stop|pe_order_implies_first_printed);
 
             pcmk__order_resource_actions(child_rsc, RSC_DEMOTE, rsc,
-                                         RSC_DEMOTED, stopped, rsc->cluster);
+                                         RSC_DEMOTED, stopped);
 
             pcmk__order_resource_actions(child_rsc, RSC_PROMOTE, rsc,
-                                         RSC_PROMOTED, started, rsc->cluster);
+                                         RSC_PROMOTED, started);
 
             pcmk__order_resource_actions(rsc, RSC_PROMOTE, child_rsc,
                                          RSC_PROMOTE,
-                                         pe_order_implies_first_printed,
-                                         rsc->cluster);
+                                         pe_order_implies_first_printed);
 
         }
 
@@ -293,9 +291,9 @@ group_internal_constraints(pe_resource_t *rsc)
                           stop|pe_order_implies_first_printed, rsc->cluster);
 
         pcmk__order_resource_actions(child_rsc, RSC_STOP, rsc, RSC_STOPPED,
-                                     stopped, rsc->cluster);
+                                     stopped);
         pcmk__order_resource_actions(child_rsc, RSC_START, rsc, RSC_STARTED,
-                                     started, rsc->cluster);
+                                     started);
 
         if (group_data->ordered == FALSE) {
             pcmk__order_starts(rsc, child_rsc,
@@ -304,8 +302,7 @@ group_internal_constraints(pe_resource_t *rsc)
             if (pcmk_is_set(top->flags, pe_rsc_promotable)) {
                 pcmk__order_resource_actions(rsc, RSC_PROMOTE, child_rsc,
                                              RSC_PROMOTE,
-                                             start|pe_order_implies_first_printed,
-                                             rsc->cluster);
+                                             start|pe_order_implies_first_printed);
             }
 
         } else if (last_rsc != NULL) {
@@ -315,18 +312,16 @@ group_internal_constraints(pe_resource_t *rsc)
 
             if (pcmk_is_set(top->flags, pe_rsc_promotable)) {
                 pcmk__order_resource_actions(last_rsc, RSC_PROMOTE, child_rsc,
-                                             RSC_PROMOTE, start, rsc->cluster);
+                                             RSC_PROMOTE, start);
                 pcmk__order_resource_actions(child_rsc, RSC_DEMOTE, last_rsc,
-                                             RSC_DEMOTE, pe_order_optional,
-                                             rsc->cluster);
+                                             RSC_DEMOTE, pe_order_optional);
             }
 
         } else {
             pcmk__order_starts(rsc, child_rsc, pe_order_none, rsc->cluster);
             if (pcmk_is_set(top->flags, pe_rsc_promotable)) {
                 pcmk__order_resource_actions(rsc, RSC_PROMOTE, child_rsc,
-                                             RSC_PROMOTE, pe_order_none,
-                                             rsc->cluster);
+                                             RSC_PROMOTE, pe_order_none);
             }
         }
 
@@ -352,13 +347,13 @@ group_internal_constraints(pe_resource_t *rsc)
 
         pcmk__order_stops(rsc, last_rsc, stop_stop_flags, rsc->cluster);
         pcmk__order_resource_actions(last_rsc, RSC_STOP, rsc, RSC_STOPPED,
-                                     stop_stopped_flags, rsc->cluster);
+                                     stop_stopped_flags);
 
         if (pcmk_is_set(top->flags, pe_rsc_promotable)) {
             pcmk__order_resource_actions(rsc, RSC_DEMOTE, last_rsc, RSC_DEMOTE,
-                                         stop_stop_flags, rsc->cluster);
+                                         stop_stop_flags);
             pcmk__order_resource_actions(last_rsc, RSC_DEMOTE, rsc, RSC_DEMOTED,
-                                         stop_stopped_flags, rsc->cluster);
+                                         stop_stopped_flags);
         }
     }
 }

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -559,17 +559,17 @@ group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
 }
 
 void
-group_expand(pe_resource_t * rsc, pe_working_set_t * data_set)
+group_expand(pe_resource_t *rsc)
 {
     CRM_CHECK(rsc != NULL, return);
 
     pe_rsc_trace(rsc, "Processing actions from %s", rsc->id);
-    native_expand(rsc, data_set);
+    native_expand(rsc);
 
     for (GList *gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
-        child_rsc->cmds->expand(child_rsc, data_set);
+        child_rsc->cmds->expand(child_rsc);
     }
 }
 

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -138,7 +138,7 @@ pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer)
 void group_update_pseudo_status(pe_resource_t * parent, pe_resource_t * child);
 
 void
-group_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set)
+group_create_actions(pe_resource_t *rsc)
 {
     pe_action_t *op = NULL;
     const char *value = NULL;
@@ -149,7 +149,7 @@ group_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set)
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
-        child_rsc->cmds->create_actions(child_rsc, data_set);
+        child_rsc->cmds->create_actions(child_rsc);
         group_update_pseudo_status(rsc, child_rsc);
     }
 
@@ -157,28 +157,36 @@ group_create_actions(pe_resource_t * rsc, pe_working_set_t * data_set)
     pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
 
     op = custom_action(rsc, started_key(rsc),
-                       RSC_STARTED, NULL, TRUE /* !group_data->child_starting */ , TRUE, data_set);
+                       RSC_STARTED, NULL,
+                       TRUE /* !group_data->child_starting */ ,
+                       TRUE, rsc->cluster);
     pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
 
     op = stop_action(rsc, NULL, TRUE /* !group_data->child_stopping */ );
     pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
 
     op = custom_action(rsc, stopped_key(rsc),
-                       RSC_STOPPED, NULL, TRUE /* !group_data->child_stopping */ , TRUE, data_set);
+                       RSC_STOPPED, NULL,
+                       TRUE /* !group_data->child_stopping */ ,
+                       TRUE, rsc->cluster);
     pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
 
     value = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_PROMOTABLE);
     if (crm_is_true(value)) {
-        op = custom_action(rsc, demote_key(rsc), RSC_DEMOTE, NULL, TRUE, TRUE, data_set);
+        op = custom_action(rsc, demote_key(rsc), RSC_DEMOTE, NULL, TRUE, TRUE,
+                           rsc->cluster);
         pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
 
-        op = custom_action(rsc, demoted_key(rsc), RSC_DEMOTED, NULL, TRUE, TRUE, data_set);
+        op = custom_action(rsc, demoted_key(rsc), RSC_DEMOTED, NULL, TRUE, TRUE,
+                           rsc->cluster);
         pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
 
-        op = custom_action(rsc, promote_key(rsc), RSC_PROMOTE, NULL, TRUE, TRUE, data_set);
+        op = custom_action(rsc, promote_key(rsc), RSC_PROMOTE, NULL, TRUE, TRUE,
+                           rsc->cluster);
         pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
 
-        op = custom_action(rsc, promoted_key(rsc), RSC_PROMOTED, NULL, TRUE, TRUE, data_set);
+        op = custom_action(rsc, promoted_key(rsc), RSC_PROMOTED, NULL, TRUE,
+                           TRUE, rsc->cluster);
         pe__set_action_flags(op, pe_action_pseudo|pe_action_runnable);
     }
 }

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -82,8 +82,7 @@ expand_group_colocations(pe_resource_t *rsc)
 }
 
 pe_node_t *
-pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer,
-                     pe_working_set_t *data_set)
+pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer)
 {
     pe_node_t *node = NULL;
     pe_node_t *group_node = NULL;
@@ -111,8 +110,8 @@ pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer,
 
     expand_group_colocations(rsc);
 
-    pe__show_node_weights(!pcmk_is_set(data_set->flags, pe_flag_show_scores),
-                          rsc, __func__, rsc->allowed_nodes, data_set);
+    pe__show_node_weights(!pcmk_is_set(rsc->cluster->flags, pe_flag_show_scores),
+                          rsc, __func__, rsc->allowed_nodes, rsc->cluster);
 
     gIter = rsc->children;
     for (; gIter != NULL; gIter = gIter->next) {
@@ -120,7 +119,7 @@ pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer,
 
         pe_rsc_trace(rsc, "Allocating group %s member %s",
                      rsc->id, child_rsc->id);
-        node = child_rsc->cmds->allocate(child_rsc, prefer, data_set);
+        node = child_rsc->cmds->allocate(child_rsc, prefer);
         if (group_node == NULL) {
             group_node = node;
         }

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -285,8 +285,7 @@ group_internal_constraints(pe_resource_t *rsc)
 
         }
 
-        pcmk__order_starts(rsc, child_rsc, pe_order_implies_first_printed,
-                           rsc->cluster);
+        pcmk__order_starts(rsc, child_rsc, pe_order_implies_first_printed);
         pcmk__order_stops(rsc, child_rsc,
                           stop|pe_order_implies_first_printed, rsc->cluster);
 
@@ -297,8 +296,7 @@ group_internal_constraints(pe_resource_t *rsc)
 
         if (group_data->ordered == FALSE) {
             pcmk__order_starts(rsc, child_rsc,
-                               start|pe_order_implies_first_printed,
-                               rsc->cluster);
+                               start|pe_order_implies_first_printed);
             if (pcmk_is_set(top->flags, pe_rsc_promotable)) {
                 pcmk__order_resource_actions(rsc, RSC_PROMOTE, child_rsc,
                                              RSC_PROMOTE,
@@ -306,7 +304,7 @@ group_internal_constraints(pe_resource_t *rsc)
             }
 
         } else if (last_rsc != NULL) {
-            pcmk__order_starts(last_rsc, child_rsc, start, rsc->cluster);
+            pcmk__order_starts(last_rsc, child_rsc, start);
             pcmk__order_stops(child_rsc, last_rsc,
                               pe_order_optional|pe_order_restart, rsc->cluster);
 
@@ -318,7 +316,7 @@ group_internal_constraints(pe_resource_t *rsc)
             }
 
         } else {
-            pcmk__order_starts(rsc, child_rsc, pe_order_none, rsc->cluster);
+            pcmk__order_starts(rsc, child_rsc, pe_order_none);
             if (pcmk_is_set(top->flags, pe_rsc_promotable)) {
                 pcmk__order_resource_actions(rsc, RSC_PROMOTE, child_rsc,
                                              RSC_PROMOTE, pe_order_none);

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -1707,7 +1707,7 @@ native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
 }
 
 void
-native_expand(pe_resource_t * rsc, pe_working_set_t * data_set)
+native_expand(pe_resource_t *rsc)
 {
     GList *gIter = NULL;
 
@@ -1718,13 +1718,13 @@ native_expand(pe_resource_t * rsc, pe_working_set_t * data_set)
         pe_action_t *action = (pe_action_t *) gIter->data;
 
         crm_trace("processing action %d for rsc=%s", action->id, rsc->id);
-        pcmk__add_action_to_graph(action, data_set);
+        pcmk__add_action_to_graph(action, rsc->cluster);
     }
 
     for (gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
-        child_rsc->cmds->expand(child_rsc, data_set);
+        child_rsc->cmds->expand(child_rsc);
     }
 }
 

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -1339,8 +1339,7 @@ native_internal_constraints(pe_resource_t *rsc)
              * transition and avoid the unnecessary recovery.
              */
             pcmk__order_resource_actions(rsc->container, RSC_STATUS, rsc,
-                                         RSC_STOP, pe_order_optional,
-                                         rsc->cluster);
+                                         RSC_STOP, pe_order_optional);
 
         /* A user can specify that a resource must start on a Pacemaker Remote
          * node by explicitly configuring it with the container=NODENAME
@@ -1983,12 +1982,10 @@ DeleteRsc(pe_resource_t * rsc, pe_node_t * node, gboolean optional, pe_working_s
     delete_action(rsc, node, optional);
 
     pcmk__order_resource_actions(rsc, RSC_STOP, rsc, RSC_DELETE,
-                                 optional? pe_order_implies_then : pe_order_optional,
-                                 data_set);
+                                 optional? pe_order_implies_then : pe_order_optional);
 
     pcmk__order_resource_actions(rsc, RSC_DELETE, rsc, RSC_START,
-                                 optional? pe_order_implies_then : pe_order_optional,
-                                 data_set);
+                                 optional? pe_order_implies_then : pe_order_optional);
 
     return TRUE;
 }

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -1843,7 +1843,7 @@ StartRsc(pe_resource_t * rsc, pe_node_t * next, gboolean optional, pe_working_se
                  ((next == NULL)? 0 : next->weight));
     start = start_action(rsc, next, TRUE);
 
-    pcmk__order_vs_unfence(rsc, next, start, pe_order_implies_then, data_set);
+    pcmk__order_vs_unfence(rsc, next, start, pe_order_implies_then);
 
     if (pcmk_is_set(start->flags, pe_action_runnable) && !optional) {
         pe__clear_action_flags(start, pe_action_optional);
@@ -2168,7 +2168,7 @@ native_create_probe(pe_resource_t * rsc, pe_node_t * node, pe_action_t * complet
     probe = custom_action(rsc, key, RSC_STATUS, node, FALSE, TRUE, rsc->cluster);
     pe__clear_action_flags(probe, pe_action_optional);
 
-    pcmk__order_vs_unfence(rsc, node, probe, pe_order_optional, rsc->cluster);
+    pcmk__order_vs_unfence(rsc, node, probe, pe_order_optional);
 
     /*
      * We need to know if it's running_on (not just known_on) this node

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -98,7 +98,7 @@ native_choose_node(pe_resource_t * rsc, pe_node_t * prefer, pe_working_set_t * d
     }
     if (length > 0) {
         nodes = g_hash_table_get_values(rsc->allowed_nodes);
-        nodes = pcmk__sort_nodes(nodes, pe__current_node(rsc), data_set);
+        nodes = pcmk__sort_nodes(nodes, pe__current_node(rsc));
 
         // First node in sorted list has the best score
         best = g_list_nth_data(nodes, 0);

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -1276,13 +1276,13 @@ pcmk__disable_invalid_orderings(pe_working_set_t *data_set)
  *
  * \param[in] node         Node being shut down
  * \param[in] shutdown_op  Shutdown action for node
- * \param[in] data_set     Cluster working set
  */
 void
-pcmk__order_stops_before_shutdown(pe_node_t *node, pe_action_t *shutdown_op,
-                                  pe_working_set_t *data_set)
+pcmk__order_stops_before_shutdown(pe_node_t *node, pe_action_t *shutdown_op)
 {
-    for (GList *iter = data_set->actions; iter != NULL; iter = iter->next) {
+    for (GList *iter = node->details->data_set->actions;
+         iter != NULL; iter = iter->next) {
+
         pe_action_t *action = (pe_action_t *) iter->data;
 
         // Only stops on the node shutting down are relevant
@@ -1327,7 +1327,8 @@ pcmk__order_stops_before_shutdown(pe_node_t *node, pe_action_t *shutdown_op,
         pe__clear_action_flags(action, pe_action_optional);
         pcmk__new_ordering(action->rsc, NULL, action, NULL,
                            strdup(CRM_OP_SHUTDOWN), shutdown_op,
-                           pe_order_optional|pe_order_runnable_left, data_set);
+                           pe_order_optional|pe_order_runnable_left,
+                           node->details->data_set);
     }
 }
 

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -404,7 +404,7 @@ inverse_ordering(const char *id, enum pe_order_kind kind,
 
         handle_restart_type(rsc_then, kind, pe_order_implies_first, flags);
         pcmk__order_resource_actions(rsc_then, action_then, rsc_first,
-                                     action_first, flags, data_set);
+                                     action_first, flags);
     }
 }
 
@@ -473,7 +473,7 @@ unpack_simple_rsc_order(xmlNode *xml_obj, pe_working_set_t *data_set)
                            cons_weight, min_required_before, data_set);
     } else {
         pcmk__order_resource_actions(rsc_first, action_first, rsc_then,
-                                     action_then, cons_weight, data_set);
+                                     action_then, cons_weight);
     }
 
     if (symmetry == ordering_symmetric) {
@@ -813,7 +813,7 @@ unpack_order_set(xmlNode *set, enum pe_order_kind parent_kind,
         } else if (sequential) {
             if (last != NULL) {
                 pcmk__order_resource_actions(last, action, resource, action,
-                                             flags, data_set);
+                                             flags);
             }
             last = resource;
         }
@@ -838,7 +838,7 @@ unpack_order_set(xmlNode *set, enum pe_order_kind parent_kind,
         if (sequential) {
             if (last != NULL) {
                 pcmk__order_resource_actions(resource, action, last, action,
-                                             flags, data_set);
+                                             flags);
             }
             last = resource;
         }
@@ -992,8 +992,7 @@ order_rsc_sets(const char *id, xmlNode *set1, xmlNode *set2,
     }
 
     if ((rsc_1 != NULL) && (rsc_2 != NULL)) {
-        pcmk__order_resource_actions(rsc_1, action_1, rsc_2, action_2, flags,
-                                     data_set);
+        pcmk__order_resource_actions(rsc_1, action_1, rsc_2, action_2, flags);
 
     } else if (rsc_1 != NULL) {
         for (xml_rsc = first_named_child(set2, XML_TAG_RESOURCE_REF);
@@ -1001,7 +1000,7 @@ order_rsc_sets(const char *id, xmlNode *set1, xmlNode *set2,
 
             EXPAND_CONSTRAINT_IDREF(id, rsc_2, ID(xml_rsc));
             pcmk__order_resource_actions(rsc_1, action_1, rsc_2, action_2,
-                                         flags, data_set);
+                                         flags);
         }
 
     } else if (rsc_2 != NULL) {
@@ -1010,7 +1009,7 @@ order_rsc_sets(const char *id, xmlNode *set1, xmlNode *set2,
 
             EXPAND_CONSTRAINT_IDREF(id, rsc_1, ID(xml_rsc));
             pcmk__order_resource_actions(rsc_1, action_1, rsc_2, action_2,
-                                         flags, data_set);
+                                         flags);
         }
 
     } else {
@@ -1024,7 +1023,7 @@ order_rsc_sets(const char *id, xmlNode *set1, xmlNode *set2,
 
                 EXPAND_CONSTRAINT_IDREF(id, rsc_2, ID(xml_rsc_2));
                 pcmk__order_resource_actions(rsc_1, action_1, rsc_2,
-                                             action_2, flags, data_set);
+                                             action_2, flags);
             }
         }
     }
@@ -1584,23 +1583,23 @@ pcmk__promotable_restart_ordering(pe_resource_t *rsc)
 {
     // Order start and promote after all instances are stopped
     pcmk__order_resource_actions(rsc, RSC_STOPPED, rsc, RSC_START,
-                                 pe_order_optional, rsc->cluster);
+                                 pe_order_optional);
     pcmk__order_resource_actions(rsc, RSC_STOPPED, rsc, RSC_PROMOTE,
-                                 pe_order_optional, rsc->cluster);
+                                 pe_order_optional);
 
     // Order stop, start, and promote after all instances are demoted
     pcmk__order_resource_actions(rsc, RSC_DEMOTED, rsc, RSC_STOP,
-                                 pe_order_optional, rsc->cluster);
+                                 pe_order_optional);
     pcmk__order_resource_actions(rsc, RSC_DEMOTED, rsc, RSC_START,
-                                 pe_order_optional, rsc->cluster);
+                                 pe_order_optional);
     pcmk__order_resource_actions(rsc, RSC_DEMOTED, rsc, RSC_PROMOTE,
-                                 pe_order_optional, rsc->cluster);
+                                 pe_order_optional);
 
     // Order promote after all instances are started
     pcmk__order_resource_actions(rsc, RSC_STARTED, rsc, RSC_PROMOTE,
-                                 pe_order_optional, rsc->cluster);
+                                 pe_order_optional);
 
     // Order demote after all instances are demoted
     pcmk__order_resource_actions(rsc, RSC_DEMOTE, rsc, RSC_DEMOTED,
-                                 pe_order_optional, rsc->cluster);
+                                 pe_order_optional);
 }

--- a/lib/pacemaker/pcmk_sched_probes.c
+++ b/lib/pacemaker/pcmk_sched_probes.c
@@ -557,7 +557,7 @@ pcmk__schedule_probes(pe_working_set_t *data_set)
              rsc_iter = rsc_iter->next) {
             pe_resource_t *rsc = (pe_resource_t *) rsc_iter->data;
 
-            rsc->cmds->create_probe(rsc, node, NULL, FALSE, data_set);
+            rsc->cmds->create_probe(rsc, node, NULL, FALSE);
         }
     }
 }

--- a/lib/pacemaker/pcmk_sched_probes.c
+++ b/lib/pacemaker/pcmk_sched_probes.c
@@ -259,7 +259,7 @@ add_restart_orderings_for_probe(pe_action_t *probe, pe_action_t *after,
             compatible_rsc = find_compatible_child(probe->rsc,
                                                    after->rsc,
                                                    RSC_ROLE_UNKNOWN,
-                                                   FALSE, data_set);
+                                                   FALSE);
         }
     }
 

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -1052,7 +1052,7 @@ create_promotable_instance_actions(pe_resource_t *clone,
     for (GList *iter = clone->children; iter != NULL; iter = iter->next) {
         pe_resource_t *instance = (pe_resource_t *) iter->data;
 
-        instance->cmds->create_actions(instance, clone->cluster);
+        instance->cmds->create_actions(instance);
         check_for_role_change(instance, any_demoting, any_promoting);
     }
 }

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -1242,8 +1242,7 @@ pcmk__update_promotable_dependent_priority(pe_resource_t *primary,
 
     // Look for a primary instance where dependent will be
     primary_instance = find_compatible_child(dependent, primary,
-                                             colocation->primary_role, FALSE,
-                                             primary->cluster);
+                                             colocation->primary_role, FALSE);
 
     if (primary_instance != NULL) {
         // Add primary instance's priority to dependent's

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -28,14 +28,14 @@ order_instance_promotion(pe_resource_t *clone, pe_resource_t *child,
 {
     // "Promote clone" -> promote instance -> "clone promoted"
     pcmk__order_resource_actions(clone, RSC_PROMOTE, child, RSC_PROMOTE,
-                                 pe_order_optional, clone->cluster);
+                                 pe_order_optional);
     pcmk__order_resource_actions(child, RSC_PROMOTE, clone, RSC_PROMOTED,
-                                 pe_order_optional, clone->cluster);
+                                 pe_order_optional);
 
     // If clone is ordered, order this instance relative to last
     if ((last != NULL) && pe__clone_is_ordered(clone)) {
         pcmk__order_resource_actions(last, RSC_PROMOTE, child, RSC_PROMOTE,
-                                     pe_order_optional, clone->cluster);
+                                     pe_order_optional);
     }
 }
 
@@ -53,15 +53,14 @@ order_instance_demotion(pe_resource_t *clone, pe_resource_t *child,
 {
     // "Demote clone" -> demote instance -> "clone demoted"
     pcmk__order_resource_actions(clone, RSC_DEMOTE, child, RSC_DEMOTE,
-                                 pe_order_implies_first_printed,
-                                 clone->cluster);
+                                 pe_order_implies_first_printed);
     pcmk__order_resource_actions(child, RSC_DEMOTE, clone, RSC_DEMOTED,
-                                 pe_order_implies_then_printed, clone->cluster);
+                                 pe_order_implies_then_printed);
 
     // If clone is ordered, order this instance relative to last
     if ((last != NULL) && pe__clone_is_ordered(clone)) {
         pcmk__order_resource_actions(child, RSC_DEMOTE, last, RSC_DEMOTE,
-                                     pe_order_optional, clone->cluster);
+                                     pe_order_optional);
     }
 }
 
@@ -1118,7 +1117,7 @@ pcmk__order_promotable_instances(pe_resource_t *clone)
         // Demote before promote
         pcmk__order_resource_actions(instance, RSC_DEMOTE,
                                      instance, RSC_PROMOTE,
-                                     pe_order_optional, instance->cluster);
+                                     pe_order_optional);
 
         order_instance_promotion(clone, instance, previous);
         order_instance_demotion(clone, instance, previous);

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -698,7 +698,7 @@ pcmk__sort_resources(pe_working_set_t *data_set)
 {
     GList *nodes = g_list_copy(data_set->nodes);
 
-    nodes = pcmk__sort_nodes(nodes, NULL, data_set);
+    nodes = pcmk__sort_nodes(nodes, NULL);
     data_set->resources = g_list_sort_with_data(data_set->resources,
                                                 cmp_resources, nodes);
     g_list_free(nodes);


### PR DESCRIPTION
This focuses on exposed functions (some static functions still could be changed)