### PR TITLE
Unit testing for much of lib/common/output.c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2098,6 +2098,7 @@ AC_CONFIG_FILES(Makefile                                            \
                 lib/common/tests/lists/Makefile                     \
                 lib/common/tests/nvpair/Makefile                    \
                 lib/common/tests/operations/Makefile                \
+                lib/common/tests/output/Makefile                    \
                 lib/common/tests/procfs/Makefile                    \
                 lib/common/tests/results/Makefile                   \
                 lib/common/tests/scores/Makefile                    \

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -567,7 +567,7 @@ int pcmk__output_new(pcmk__output_t **out, const char *fmt_name,
  * \param[in]     options Format-specific command line options.  These will be
  *                        added to the context.  This argument can also be NULL.
  *
- * \return 0 on success or an error code on error.
+ * \return Standard Pacemaker return code
  */
 int
 pcmk__register_format(GOptionGroup *group, const char *name,

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -862,6 +862,13 @@ int pcmk__xml_output_new(pcmk__output_t **out, xmlNodePtr *xml);
 void pcmk__xml_output_finish(pcmk__output_t *out, xmlNodePtr *xml);
 int pcmk__log_output_new(pcmk__output_t **out);
 
+#if defined(PCMK__UNIT_TESTING)
+/* If we are building libcrmcommon_test.a, add this accessor function so we can
+ * inspect the internal formatters hash table.
+ */
+GHashTable *pcmk__output_formatters(void);
+#endif
+
 #define PCMK__OUTPUT_SPACER_IF(out_obj, cond)   \
     if (cond) {                                 \
         out->spacer(out);                       \

--- a/lib/common/mock.c
+++ b/lib/common/mock.c
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <setjmp.h>
@@ -175,6 +176,34 @@ void
 __wrap_endgrent(void) {
     if (!pcmk__mock_grent) {
         __real_endgrent();
+    }
+}
+
+
+/* fopen()
+ *
+ * If pcmk__mock_fopen is set to true, later calls to fopen() must be
+ * preceded by:
+ *
+ *     will_return(__wrap_fopen, errno_to_set);
+ */
+
+bool pcmk__mock_fopen = false;
+
+FILE *
+__wrap_fopen(const char *pathname, const char *mode)
+{
+    if (pcmk__mock_fopen) {
+        errno = mock_type(int);
+
+        if (errno != 0) {
+            return NULL;
+        } else {
+            return __real_fopen(pathname, mode);
+        }
+
+    } else {
+        return __real_fopen(pathname, mode);
     }
 }
 

--- a/lib/common/mock_private.h
+++ b/lib/common/mock_private.h
@@ -12,6 +12,7 @@
 
 #include <pwd.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
@@ -24,6 +25,10 @@
 extern bool pcmk__mock_calloc;
 void *__real_calloc(size_t nmemb, size_t size);
 void *__wrap_calloc(size_t nmemb, size_t size);
+
+extern bool pcmk__mock_fopen;
+FILE *__real_fopen(const char *pathname, const char *mode);
+FILE *__wrap_fopen(const char *pathname, const char *mode);
 
 extern bool pcmk__mock_getenv;
 char *__real_getenv(const char *name);

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -39,9 +39,7 @@ pcmk__output_new(pcmk__output_t **out, const char *fmt_name, const char *filenam
                  char **argv) {
     pcmk__output_factory_t create = NULL;
 
-    if (formatters == NULL) {
-        return EINVAL;
-    }
+    CRM_ASSERT(formatters != NULL && out != NULL);
 
     /* If no name was given, just try "text".  It's up to each tool to register
      * what it supports so this also may not be valid.

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -127,6 +127,8 @@ pcmk__call_message(pcmk__output_t *out, const char *message_id, ...) {
     int rc = pcmk_rc_ok;
     pcmk__message_fn_t fn;
 
+    CRM_ASSERT(out != NULL && !pcmk__str_empty(message_id));
+
     fn = g_hash_table_lookup(out->messages, message_id);
     if (fn == NULL) {
         crm_debug("Called unknown output message '%s' for format '%s'",

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -24,6 +24,10 @@ pcmk__output_formatters(void) {
 
 void
 pcmk__output_free(pcmk__output_t *out) {
+    if (out == NULL) {
+        return;
+    }
+
     out->free_priv(out);
 
     if (out->messages != NULL) {

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -117,6 +117,7 @@ void
 pcmk__unregister_formats() {
     if (formatters != NULL) {
         g_hash_table_destroy(formatters);
+        formatters = NULL;
     }
 }
 

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -64,6 +64,8 @@ pcmk__output_new(pcmk__output_t **out, const char *fmt_name, const char *filenam
     } else {
         (*out)->dest = fopen(filename, "w");
         if ((*out)->dest == NULL) {
+            pcmk__output_free(*out);
+            *out = NULL;
             return errno;
         }
     }

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -144,6 +144,8 @@ pcmk__call_message(pcmk__output_t *out, const char *message_id, ...) {
 void
 pcmk__register_message(pcmk__output_t *out, const char *message_id,
                        pcmk__message_fn_t fn) {
+    CRM_ASSERT(out != NULL && !pcmk__str_empty(message_id) && fn != NULL);
+
     g_hash_table_replace(out->messages, strdup(message_id), fn);
 }
 

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -86,9 +86,7 @@ pcmk__output_new(pcmk__output_t **out, const char *fmt_name, const char *filenam
 int
 pcmk__register_format(GOptionGroup *group, const char *name,
                       pcmk__output_factory_t create, GOptionEntry *options) {
-    if (create == NULL) {
-        return -EINVAL;
-    }
+    CRM_ASSERT(create != NULL && !pcmk__str_empty(name));
 
     if (formatters == NULL) {
         formatters = pcmk__strkey_table(free, NULL);

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -15,6 +15,13 @@
 
 static GHashTable *formatters = NULL;
 
+#if defined(PCMK__UNIT_TESTING)
+GHashTable *
+pcmk__output_formatters(void) {
+    return formatters;
+}
+#endif
+
 void
 pcmk__output_free(pcmk__output_t *out) {
     out->free_priv(out);

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -30,7 +30,7 @@ pcmk__output_free(pcmk__output_t *out) {
 int
 pcmk__output_new(pcmk__output_t **out, const char *fmt_name, const char *filename,
                  char **argv) {
-    pcmk__output_factory_t create = NULL;;
+    pcmk__output_factory_t create = NULL;
 
     if (formatters == NULL) {
         return EINVAL;

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -92,7 +92,7 @@ pcmk__register_format(GOptionGroup *group, const char *name,
     }
 
     g_hash_table_insert(formatters, strdup(name), create);
-    return 0;
+    return pcmk_rc_ok;
 }
 
 void

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -73,11 +73,13 @@ typedef struct private_data_s {
 
 static void
 html_free_priv(pcmk__output_t *out) {
-    private_data_t *priv = out->priv;
+    private_data_t *priv = NULL;
 
-    if (priv == NULL) {
+    if (out == NULL || out->priv == NULL) {
         return;
     }
+
+    priv = out->priv;
 
     xmlFreeNode(priv->root);
     g_queue_free(priv->parent_q);
@@ -89,6 +91,8 @@ html_free_priv(pcmk__output_t *out) {
 static bool
 html_init(pcmk__output_t *out) {
     private_data_t *priv = NULL;
+
+    CRM_ASSERT(out != NULL);
 
     /* If html_init was previously called on this output struct, just return. */
     if (out->priv != NULL) {
@@ -125,9 +129,13 @@ add_error_node(gpointer data, gpointer user_data) {
 
 static void
 html_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_dest) {
-    private_data_t *priv = out->priv;
+    private_data_t *priv = NULL;
     htmlNodePtr head_node = NULL;
     htmlNodePtr charset_node = NULL;
+
+    CRM_ASSERT(out != NULL);
+
+    priv = out->priv;
 
     /* If root is NULL, html_init failed and we are being called from pcmk__output_free
      * in the pcmk__output_new path.
@@ -208,7 +216,7 @@ html_reset(pcmk__output_t *out) {
 
 static void
 html_subprocess_output(pcmk__output_t *out, int exit_status,
-                      const char *proc_stdout, const char *proc_stderr) {
+                       const char *proc_stdout, const char *proc_stderr) {
     char *rc_buf = NULL;
 
     CRM_ASSERT(out != NULL);
@@ -423,7 +431,7 @@ pcmk__mk_html_output(char **argv) {
 
 xmlNodePtr
 pcmk__output_create_html_node(pcmk__output_t *out, const char *element_name, const char *id,
-                       const char *class_name, const char *text) {
+                              const char *class_name, const char *text) {
     htmlNodePtr node = NULL;
 
     CRM_ASSERT(out != NULL);

--- a/lib/common/output_log.c
+++ b/lib/common/output_log.c
@@ -33,11 +33,13 @@ log_subprocess_output(pcmk__output_t *out, int exit_status,
 
 static void
 log_free_priv(pcmk__output_t *out) {
-    private_data_t *priv = out->priv;
+    private_data_t *priv = NULL;
 
-    if (priv == NULL) {
+    if (out == NULL || out->priv == NULL) {
         return;
     }
+
+    priv = out->priv;
 
     g_queue_free(priv->prefixes);
     free(priv);
@@ -47,6 +49,8 @@ log_free_priv(pcmk__output_t *out) {
 static bool
 log_init(pcmk__output_t *out) {
     private_data_t *priv = NULL;
+
+    CRM_ASSERT(out != NULL);
 
     /* If log_init was previously called on this output struct, just return. */
     if (out->priv != NULL) {

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -37,11 +37,13 @@ typedef struct private_data_s {
 
 static void
 text_free_priv(pcmk__output_t *out) {
-    private_data_t *priv = out->priv;
+    private_data_t *priv = NULL;
 
-    if (priv == NULL) {
+    if (out == NULL || out->priv == NULL) {
         return;
     }
+
+    priv = out->priv;
 
     g_queue_free(priv->parent_q);
     free(priv);
@@ -51,6 +53,8 @@ text_free_priv(pcmk__output_t *out) {
 static bool
 text_init(pcmk__output_t *out) {
     private_data_t *priv = NULL;
+
+    CRM_ASSERT(out != NULL);
 
     /* If text_init was previously called on this output struct, just return. */
     if (out->priv != NULL) {
@@ -70,6 +74,7 @@ text_init(pcmk__output_t *out) {
 
 static void
 text_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_dest) {
+    CRM_ASSERT(out != NULL && out->dest != NULL);
     fflush(out->dest);
 }
 
@@ -103,7 +108,7 @@ text_subprocess_output(pcmk__output_t *out, int exit_status,
 
 static void
 text_version(pcmk__output_t *out, bool extended) {
-    CRM_ASSERT(out != NULL);
+    CRM_ASSERT(out != NULL && out->dest != NULL);
 
     if (extended) {
         fprintf(out->dest, "Pacemaker %s (Build: %s): %s\n", PACEMAKER_VERSION, BUILD_VERSION, CRM_FEATURES);

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -82,11 +82,13 @@ typedef struct private_data_s {
 
 static void
 xml_free_priv(pcmk__output_t *out) {
-    private_data_t *priv = out->priv;
+    private_data_t *priv = NULL;
 
-    if (priv == NULL) {
+    if (out == NULL || out->priv == NULL) {
         return;
     }
+
+    priv = out->priv;
 
     free_xml(priv->root);
     g_queue_free(priv->parent_q);
@@ -98,6 +100,8 @@ xml_free_priv(pcmk__output_t *out) {
 static bool
 xml_init(pcmk__output_t *out) {
     private_data_t *priv = NULL;
+
+    CRM_ASSERT(out != NULL);
 
     /* If xml_init was previously called on this output struct, just return. */
     if (out->priv != NULL) {

--- a/lib/common/tests/Makefile.am
+++ b/lib/common/tests/Makefile.am
@@ -18,6 +18,7 @@ SUBDIRS = \
 	lists		\
 	nvpair 		\
 	operations	\
+	output 		\
 	procfs		\
 	results		\
 	scores		\

--- a/lib/common/tests/output/Makefile.am
+++ b/lib/common/tests/output/Makefile.am
@@ -19,6 +19,7 @@ include $(top_srcdir)/mk/tap.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS =	pcmk__call_message_test \
+					pcmk__output_free_test \
 					pcmk__output_new_test \
 					pcmk__register_format_test \
 					pcmk__register_formats_test \

--- a/lib/common/tests/output/Makefile.am
+++ b/lib/common/tests/output/Makefile.am
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2022 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+#
+
+AM_CPPFLAGS = -I$(top_srcdir)/include		\
+	      -I$(top_builddir)/include		\
+	      -I$(top_srcdir)/lib/common
+LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
+		-lcmocka
+AM_CFLAGS = -DPCMK__UNIT_TESTING
+AM_LDFLAGS = $(LDFLAGS_WRAP)
+
+include $(top_srcdir)/mk/tap.mk
+
+# Add "_test" to the end of all test program names to simplify .gitignore.
+check_PROGRAMS =	pcmk__register_format_test
+
+TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/output/Makefile.am
+++ b/lib/common/tests/output/Makefile.am
@@ -19,6 +19,7 @@ include $(top_srcdir)/mk/tap.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS =	pcmk__register_format_test \
-					pcmk__register_formats_test
+					pcmk__register_formats_test \
+					pcmk__unregister_formats_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/output/Makefile.am
+++ b/lib/common/tests/output/Makefile.am
@@ -18,7 +18,8 @@ AM_LDFLAGS = $(LDFLAGS_WRAP)
 include $(top_srcdir)/mk/tap.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
-check_PROGRAMS =	pcmk__output_new_test \
+check_PROGRAMS =	pcmk__call_message_test \
+					pcmk__output_new_test \
 					pcmk__register_format_test \
 					pcmk__register_formats_test \
 					pcmk__register_message_test \

--- a/lib/common/tests/output/Makefile.am
+++ b/lib/common/tests/output/Makefile.am
@@ -21,6 +21,7 @@ include $(top_srcdir)/mk/tap.mk
 check_PROGRAMS =	pcmk__output_new_test \
 					pcmk__register_format_test \
 					pcmk__register_formats_test \
+					pcmk__register_message_test \
 					pcmk__unregister_formats_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/output/Makefile.am
+++ b/lib/common/tests/output/Makefile.am
@@ -18,7 +18,8 @@ AM_LDFLAGS = $(LDFLAGS_WRAP)
 include $(top_srcdir)/mk/tap.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
-check_PROGRAMS =	pcmk__register_format_test \
+check_PROGRAMS =	pcmk__output_new_test \
+					pcmk__register_format_test \
 					pcmk__register_formats_test \
 					pcmk__unregister_formats_test
 

--- a/lib/common/tests/output/Makefile.am
+++ b/lib/common/tests/output/Makefile.am
@@ -18,6 +18,7 @@ AM_LDFLAGS = $(LDFLAGS_WRAP)
 include $(top_srcdir)/mk/tap.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
-check_PROGRAMS =	pcmk__register_format_test
+check_PROGRAMS =	pcmk__register_format_test \
+					pcmk__register_formats_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/output/Makefile.am
+++ b/lib/common/tests/output/Makefile.am
@@ -22,6 +22,7 @@ check_PROGRAMS =	pcmk__output_new_test \
 					pcmk__register_format_test \
 					pcmk__register_formats_test \
 					pcmk__register_message_test \
+					pcmk__register_messages_test \
 					pcmk__unregister_formats_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/output/Makefile.am
+++ b/lib/common/tests/output/Makefile.am
@@ -19,6 +19,7 @@ include $(top_srcdir)/mk/tap.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS =	pcmk__call_message_test \
+					pcmk__output_and_clear_error_test \
 					pcmk__output_free_test \
 					pcmk__output_new_test \
 					pcmk__register_format_test \

--- a/lib/common/tests/output/pcmk__call_message_test.c
+++ b/lib/common/tests/output/pcmk__call_message_test.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/common/output_internal.h>
+
+static int
+default_message_fn(pcmk__output_t *out, va_list args) {
+    function_called();
+    return pcmk_rc_ok;
+}
+
+static int
+failed_message_fn(pcmk__output_t *out, va_list args) {
+    function_called();
+    return pcmk_rc_no_output;
+}
+
+static int
+message_fn_1(pcmk__output_t *out, va_list args) {
+    function_called();
+    return pcmk_rc_ok;
+}
+
+static int
+message_fn_2(pcmk__output_t *out, va_list args) {
+    function_called();
+    return pcmk_rc_ok;
+}
+
+static bool
+fake_text_init(pcmk__output_t *out) {
+    return true;
+}
+
+static void
+fake_text_free_priv(pcmk__output_t *out) {
+    /* This function intentionally left blank */
+}
+
+static pcmk__output_t *
+mk_fake_text_output(char **argv) {
+    pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
+
+    if (retval == NULL) {
+        return NULL;
+    }
+
+    retval->fmt_name = "text";
+    retval->init = fake_text_init;
+    retval->free_priv = fake_text_free_priv;
+
+    retval->register_message = pcmk__register_message;
+    retval->message = pcmk__call_message;
+
+    return retval;
+}
+
+static int
+setup(void **state) {
+    pcmk__register_format(NULL, "text", mk_fake_text_output, NULL);
+    return 0;
+}
+
+static int
+teardown(void **state) {
+    pcmk__unregister_formats();
+    return 0;
+}
+
+static void
+no_such_message(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+
+    assert_int_equal(out->message(out, "fake"), EINVAL);
+    pcmk__assert_asserts(out->message(out, ""));
+    pcmk__assert_asserts(out->message(out, NULL));
+
+    pcmk__output_free(out);
+}
+
+static void
+message_return_value(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__message_entry_t entries[] = {
+        { "msg1", "text", message_fn_1 },
+        { "msg2", "text", message_fn_2 },
+        { "fail", "text", failed_message_fn },
+        { NULL },
+    };
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+    pcmk__register_messages(out, entries);
+
+    expect_function_call(message_fn_1);
+    assert_int_equal(out->message(out, "msg1"), pcmk_rc_ok);
+    expect_function_call(message_fn_2);
+    assert_int_equal(out->message(out, "msg2"), pcmk_rc_ok);
+    expect_function_call(failed_message_fn);
+    assert_int_equal(out->message(out, "fail"), pcmk_rc_no_output);
+
+    pcmk__output_free(out);
+}
+
+static void
+wrong_format(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__message_entry_t entries[] = {
+        { "msg1", "xml", message_fn_1 },
+        { NULL },
+    };
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+    pcmk__register_messages(out, entries);
+
+    assert_int_equal(out->message(out, "msg1"), EINVAL);
+
+    pcmk__output_free(out);
+}
+
+static void
+default_called(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__message_entry_t entries[] = {
+        { "msg1", "default", default_message_fn },
+        { "msg1", "xml", message_fn_1 },
+        { NULL },
+    };
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+    pcmk__register_messages(out, entries);
+
+    expect_function_call(default_message_fn);
+    assert_int_equal(out->message(out, "msg1"), pcmk_rc_ok);
+
+    pcmk__output_free(out);
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(no_such_message, setup, teardown),
+        cmocka_unit_test_setup_teardown(message_return_value, setup, teardown),
+        cmocka_unit_test_setup_teardown(wrong_format, setup, teardown),
+        cmocka_unit_test_setup_teardown(default_called, setup, teardown),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/output/pcmk__output_and_clear_error_test.c
+++ b/lib/common/tests/output/pcmk__output_and_clear_error_test.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/common/output_internal.h>
+
+#include <glib.h>
+
+static bool
+fake_text_init(pcmk__output_t *out) {
+    return true;
+}
+
+static void
+fake_text_free_priv(pcmk__output_t *out) {
+    /* This function intentionally left blank */
+}
+
+G_GNUC_PRINTF(2, 3)
+static void
+fake_text_err(pcmk__output_t *out, const char *format, ...) {
+    function_called();
+}
+
+static pcmk__output_t *
+mk_fake_text_output(char **argv) {
+    pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
+
+    if (retval == NULL) {
+        return NULL;
+    }
+
+    retval->fmt_name = "text";
+    retval->init = fake_text_init;
+    retval->free_priv = fake_text_free_priv;
+
+    retval->register_message = pcmk__register_message;
+    retval->message = pcmk__call_message;
+
+    retval->err = fake_text_err;
+
+    return retval;
+}
+
+static int
+setup(void **state) {
+    pcmk__register_format(NULL, "text", mk_fake_text_output, NULL);
+    return 0;
+}
+
+static int
+teardown(void **state) {
+    pcmk__unregister_formats();
+    return 0;
+}
+
+static void
+standard_usage(void **state) {
+    GError *error = NULL;
+    pcmk__output_t *out = NULL;
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+    g_set_error(&error, PCMK__RC_ERROR, pcmk_rc_bad_nvpair,
+                "some error message");
+
+    expect_function_call(fake_text_err);
+    pcmk__output_and_clear_error(error, out);
+
+    pcmk__output_free(out);
+    assert_null(error->message);
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(standard_usage, setup, teardown),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/output/pcmk__output_free_test.c
+++ b/lib/common/tests/output/pcmk__output_free_test.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/common/output_internal.h>
+
+static int
+null_message_fn(pcmk__output_t *out, va_list args) {
+    return pcmk_rc_ok;
+}
+
+static bool
+fake_text_init(pcmk__output_t *out) {
+    return true;
+}
+
+static void
+fake_text_free_priv(pcmk__output_t *out) {
+    function_called();
+    /* This function intentionally left blank */
+}
+
+static pcmk__output_t *
+mk_fake_text_output(char **argv) {
+    pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
+
+    if (retval == NULL) {
+        return NULL;
+    }
+
+    retval->fmt_name = "text";
+    retval->init = fake_text_init;
+    retval->free_priv = fake_text_free_priv;
+
+    retval->register_message = pcmk__register_message;
+    retval->message = pcmk__call_message;
+
+    return retval;
+}
+
+static int
+setup(void **state) {
+    pcmk__register_format(NULL, "text", mk_fake_text_output, NULL);
+    return 0;
+}
+
+static int
+teardown(void **state) {
+    pcmk__unregister_formats();
+    return 0;
+}
+
+static void
+no_messages(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+
+    expect_function_call(fake_text_free_priv);
+    pcmk__output_free(out);
+}
+
+static void
+messages(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+    pcmk__register_message(out, "fake", null_message_fn);
+
+    expect_function_call(fake_text_free_priv);
+    pcmk__output_free(out);
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(no_messages, setup, teardown),
+        cmocka_unit_test_setup_teardown(messages, setup, teardown),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/output/pcmk__output_new_test.c
+++ b/lib/common/tests/output/pcmk__output_new_test.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/common/output_internal.h>
+
+#include "mock_private.h"
+
+static bool init_succeeds = true;
+
+static bool
+fake_text_init(pcmk__output_t *out) {
+    return init_succeeds;
+}
+
+static void
+fake_text_free_priv(pcmk__output_t *out) {
+    /* This function intentionally left blank */
+}
+
+/* "text" is the default for pcmk__output_new. */
+static pcmk__output_t *
+mk_fake_text_output(char **argv) {
+    pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
+
+    if (retval == NULL) {
+        return NULL;
+    }
+
+    retval->fmt_name = "text";
+    retval->init = fake_text_init;
+    retval->free_priv = fake_text_free_priv;
+
+    retval->register_message = pcmk__register_message;
+    retval->message = pcmk__call_message;
+
+    return retval;
+}
+
+static int
+setup(void **state) {
+    pcmk__register_format(NULL, "text", mk_fake_text_output, NULL);
+    return 0;
+}
+
+static int
+teardown(void **state) {
+    pcmk__unregister_formats();
+    return 0;
+}
+
+static void
+empty_formatters(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__assert_asserts(pcmk__output_new(&out, "fake", NULL, NULL));
+}
+
+static void
+invalid_params(void **state) {
+    /* This must be called with the setup/teardown functions so formatters is not NULL. */
+    pcmk__assert_asserts(pcmk__output_new(NULL, "fake", NULL, NULL));
+}
+
+static void
+no_such_format(void **state) {
+    pcmk__output_t *out = NULL;
+
+    assert_int_equal(pcmk__output_new(&out, "fake", NULL, NULL), pcmk_rc_unknown_format);
+}
+
+static void
+create_fails(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__mock_calloc = true;   // calloc() will return NULL
+
+    assert_int_equal(pcmk__output_new(&out, "text", NULL, NULL), ENOMEM);
+
+    pcmk__mock_calloc = false;  // Use real calloc()
+}
+
+static void
+fopen_fails(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__mock_fopen = true;
+    will_return(__wrap_fopen, EPERM);
+
+    assert_int_equal(pcmk__output_new(&out, "text", "destfile", NULL), EPERM);
+
+    pcmk__mock_fopen = false;
+}
+
+static void
+init_fails(void **state) {
+    pcmk__output_t *out = NULL;
+
+    init_succeeds = false;
+    assert_int_equal(pcmk__output_new(&out, "text", NULL, NULL), ENOMEM);
+    init_succeeds = true;
+}
+
+static void
+everything_succeeds(void **state) {
+    pcmk__output_t *out = NULL;
+
+    assert_int_equal(pcmk__output_new(&out, "text", NULL, NULL), pcmk_rc_ok);
+    assert_string_equal(out->fmt_name, "text");
+    assert_ptr_equal(out->dest, stdout);
+    assert_false(out->quiet);
+    assert_non_null(out->messages);
+    assert_string_equal(getenv("OCF_OUTPUT_FORMAT"), "text");
+
+    pcmk__output_free(out);
+}
+
+static void
+no_fmt_name_given(void **state) {
+    pcmk__output_t *out = NULL;
+
+    assert_int_equal(pcmk__output_new(&out, NULL, NULL, NULL), pcmk_rc_ok);
+    assert_string_equal(out->fmt_name, "text");
+
+    pcmk__output_free(out);
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(empty_formatters),
+        cmocka_unit_test_setup_teardown(invalid_params, setup, teardown),
+        cmocka_unit_test_setup_teardown(no_such_format, setup, teardown),
+        cmocka_unit_test_setup_teardown(create_fails, setup, teardown),
+        cmocka_unit_test_setup_teardown(init_fails, setup, teardown),
+        cmocka_unit_test_setup_teardown(fopen_fails, setup, teardown),
+        cmocka_unit_test_setup_teardown(everything_succeeds, setup, teardown),
+        cmocka_unit_test_setup_teardown(no_fmt_name_given, setup, teardown),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/output/pcmk__register_format_test.c
+++ b/lib/common/tests/output/pcmk__register_format_test.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/common/output_internal.h>
+
+static pcmk__output_t *
+null_create_fn(char **argv) {
+    return NULL;
+}
+
+static pcmk__output_t *
+null_create_fn_2(char **argv) {
+    return NULL;
+}
+
+static void
+invalid_params(void **state) {
+    pcmk__assert_asserts(pcmk__register_format(NULL, "fake", NULL, NULL));
+    pcmk__assert_asserts(pcmk__register_format(NULL, "", null_create_fn, NULL));
+    pcmk__assert_asserts(pcmk__register_format(NULL, NULL, null_create_fn, NULL));
+}
+
+static void
+add_format(void **state) {
+    GHashTable *formatters = NULL;
+    gpointer value;
+
+    /* For starters, there should be no formatters defined. */
+    assert_null(pcmk__output_formatters());
+
+    /* Add a fake formatter and check that it's the only item in the hash table. */
+    assert_int_equal(pcmk__register_format(NULL, "fake", null_create_fn, NULL), pcmk_rc_ok);
+    formatters = pcmk__output_formatters();
+    assert_int_equal(g_hash_table_size(formatters), 1);
+
+    value = g_hash_table_lookup(formatters, "fake");
+    assert_ptr_equal(value, null_create_fn);
+
+    /* Add a second fake formatter which should overwrite the first one, leaving
+     * only one item in the hash table but pointing at the new function.
+     */
+    assert_int_equal(pcmk__register_format(NULL, "fake", null_create_fn_2, NULL), pcmk_rc_ok);
+    formatters = pcmk__output_formatters();
+    assert_int_equal(g_hash_table_size(formatters), 1);
+
+    value = g_hash_table_lookup(formatters, "fake");
+    assert_ptr_equal(value, null_create_fn_2);
+
+    pcmk__unregister_formats();
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(invalid_params),
+        cmocka_unit_test(add_format),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/output/pcmk__register_formats_test.c
+++ b/lib/common/tests/output/pcmk__register_formats_test.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/common/output_internal.h>
+
+static pcmk__output_t *
+null_create_fn(char **argv) {
+    return NULL;
+}
+
+static pcmk__output_t *
+null_create_fn_2(char **argv) {
+    return NULL;
+}
+
+static void
+no_formats(void **state) {
+    pcmk__register_formats(NULL, NULL);
+    assert_null(pcmk__output_formatters());
+}
+
+static void
+invalid_entries(void **state) {
+    /* Here, we can only test that an empty name won't be added.  A NULL name is
+     * the marker for the end of the format table.
+     */
+    pcmk__supported_format_t formats[] = {
+        { "", null_create_fn, NULL },
+        { NULL },
+    };
+
+    pcmk__assert_asserts(pcmk__register_formats(NULL, formats));
+}
+
+static void
+valid_entries(void **state) {
+    GHashTable *formatters = NULL;
+
+    pcmk__supported_format_t formats[] = {
+        { "fmt1", null_create_fn, NULL },
+        { "fmt2", null_create_fn_2, NULL },
+        { NULL },
+    };
+
+    pcmk__register_formats(NULL, formats);
+
+    formatters = pcmk__output_formatters();
+    assert_int_equal(g_hash_table_size(formatters), 2);
+    assert_ptr_equal(g_hash_table_lookup(formatters, "fmt1"), null_create_fn);
+    assert_ptr_equal(g_hash_table_lookup(formatters, "fmt2"), null_create_fn_2);
+
+    pcmk__unregister_formats();
+}
+
+static void
+duplicate_keys(void **state) {
+    GHashTable *formatters = NULL;
+
+    pcmk__supported_format_t formats[] = {
+        { "fmt1", null_create_fn, NULL },
+        { "fmt1", null_create_fn_2, NULL },
+        { NULL },
+    };
+
+    pcmk__register_formats(NULL, formats);
+
+    formatters = pcmk__output_formatters();
+    assert_int_equal(g_hash_table_size(formatters), 1);
+    assert_ptr_equal(g_hash_table_lookup(formatters, "fmt1"), null_create_fn_2);
+
+    pcmk__unregister_formats();
+}
+
+static void
+duplicate_values(void **state) {
+    GHashTable *formatters = NULL;
+
+    pcmk__supported_format_t formats[] = {
+        { "fmt1", null_create_fn, NULL },
+        { "fmt2", null_create_fn, NULL },
+        { NULL },
+    };
+
+    pcmk__register_formats(NULL, formats);
+
+    formatters = pcmk__output_formatters();
+    assert_int_equal(g_hash_table_size(formatters), 2);
+    assert_ptr_equal(g_hash_table_lookup(formatters, "fmt1"), null_create_fn);
+    assert_ptr_equal(g_hash_table_lookup(formatters, "fmt2"), null_create_fn);
+
+    pcmk__unregister_formats();
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(no_formats),
+        cmocka_unit_test(invalid_entries),
+        cmocka_unit_test(valid_entries),
+        cmocka_unit_test(duplicate_keys),
+        cmocka_unit_test(duplicate_values),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/output/pcmk__register_message_test.c
+++ b/lib/common/tests/output/pcmk__register_message_test.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/common/output_internal.h>
+
+static int
+null_message_fn(pcmk__output_t *out, va_list args) {
+    return pcmk_rc_ok;
+}
+
+static int
+null_message_fn_2(pcmk__output_t *out, va_list args) {
+    return pcmk_rc_ok;
+}
+
+static bool
+fake_text_init(pcmk__output_t *out) {
+    return true;
+}
+
+static void
+fake_text_free_priv(pcmk__output_t *out) {
+    /* This function intentionally left blank */
+}
+
+static pcmk__output_t *
+mk_fake_text_output(char **argv) {
+    pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
+
+    if (retval == NULL) {
+        return NULL;
+    }
+
+    retval->fmt_name = "text";
+    retval->init = fake_text_init;
+    retval->free_priv = fake_text_free_priv;
+
+    retval->register_message = pcmk__register_message;
+    retval->message = pcmk__call_message;
+
+    return retval;
+}
+
+static int
+setup(void **state) {
+    pcmk__register_format(NULL, "text", mk_fake_text_output, NULL);
+    return 0;
+}
+
+static int
+teardown(void **state) {
+    pcmk__unregister_formats();
+    return 0;
+}
+
+static void
+null_params(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+
+    pcmk__assert_asserts(pcmk__register_message(NULL, "fake", null_message_fn));
+    pcmk__assert_asserts(pcmk__register_message(out, NULL, null_message_fn));
+    pcmk__assert_asserts(pcmk__register_message(out, "", null_message_fn));
+    pcmk__assert_asserts(pcmk__register_message(out, "fake", NULL));
+
+    pcmk__output_free(out);
+}
+
+static void
+add_message(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+
+    /* For starters, there should be no messages defined. */
+    assert_int_equal(g_hash_table_size(out->messages), 0);
+
+    /* Add a fake function and check that it's the only item in the hash table. */
+    pcmk__register_message(out, "fake", null_message_fn);
+    assert_int_equal(g_hash_table_size(out->messages), 1);
+    assert_ptr_equal(g_hash_table_lookup(out->messages, "fake"), null_message_fn);
+
+    /* Add a second fake function which should overwrite the first one, leaving
+     * only one item in the hash table but pointing at the new function.
+     */
+    pcmk__register_message(out, "fake", null_message_fn_2);
+    assert_int_equal(g_hash_table_size(out->messages), 1);
+    assert_ptr_equal(g_hash_table_lookup(out->messages, "fake"), null_message_fn_2);
+
+    pcmk__output_free(out);
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(null_params, setup, teardown),
+        cmocka_unit_test_setup_teardown(add_message, setup, teardown),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/output/pcmk__register_messages_test.c
+++ b/lib/common/tests/output/pcmk__register_messages_test.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/common/output_internal.h>
+
+static int
+null_message_fn(pcmk__output_t *out, va_list args) {
+    return pcmk_rc_ok;
+}
+
+static int
+null_message_fn_2(pcmk__output_t *out, va_list args) {
+    return pcmk_rc_ok;
+}
+
+static bool
+fake_text_init(pcmk__output_t *out) {
+    return true;
+}
+
+static void
+fake_text_free_priv(pcmk__output_t *out) {
+    /* This function intentionally left blank */
+}
+
+static pcmk__output_t *
+mk_fake_text_output(char **argv) {
+    pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
+
+    if (retval == NULL) {
+        return NULL;
+    }
+
+    retval->fmt_name = "text";
+    retval->init = fake_text_init;
+    retval->free_priv = fake_text_free_priv;
+
+    retval->register_message = pcmk__register_message;
+    retval->message = pcmk__call_message;
+
+    return retval;
+}
+
+static int
+setup(void **state) {
+    pcmk__register_format(NULL, "text", mk_fake_text_output, NULL);
+    return 0;
+}
+
+static int
+teardown(void **state) {
+    pcmk__unregister_formats();
+    return 0;
+}
+
+static void
+invalid_entries(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__message_entry_t entries[] = {
+        /* We can't test a NULL message_id here because that's the marker for
+         * the end of the table.
+         */
+        { "", "", null_message_fn },
+        { "", NULL, null_message_fn },
+        { "", "text", NULL },
+        { NULL },
+    };
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+
+    pcmk__assert_asserts(pcmk__register_messages(out, entries));
+    assert_int_equal(g_hash_table_size(out->messages), 0);
+
+    pcmk__output_free(out);
+}
+
+static void
+valid_entries(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__message_entry_t entries[] = {
+        { "msg1", "text", null_message_fn },
+        { "msg2", "text", null_message_fn_2 },
+        { NULL },
+    };
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+
+    pcmk__register_messages(out, entries);
+    assert_int_equal(g_hash_table_size(out->messages), 2);
+    assert_ptr_equal(g_hash_table_lookup(out->messages, "msg1"), null_message_fn);
+    assert_ptr_equal(g_hash_table_lookup(out->messages, "msg2"), null_message_fn_2);
+
+    pcmk__output_free(out);
+}
+
+static void
+duplicate_message_ids(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__message_entry_t entries[] = {
+        { "msg1", "text", null_message_fn },
+        { "msg1", "text", null_message_fn_2 },
+        { NULL },
+    };
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+
+    pcmk__register_messages(out, entries);
+    assert_int_equal(g_hash_table_size(out->messages), 1);
+    assert_ptr_equal(g_hash_table_lookup(out->messages, "msg1"), null_message_fn_2);
+
+    pcmk__output_free(out);
+}
+
+static void
+duplicate_functions(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__message_entry_t entries[] = {
+        { "msg1", "text", null_message_fn },
+        { "msg2", "text", null_message_fn },
+        { NULL },
+    };
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+
+    pcmk__register_messages(out, entries);
+    assert_int_equal(g_hash_table_size(out->messages), 2);
+    assert_ptr_equal(g_hash_table_lookup(out->messages, "msg1"), null_message_fn);
+    assert_ptr_equal(g_hash_table_lookup(out->messages, "msg2"), null_message_fn);
+
+    pcmk__output_free(out);
+}
+
+static void
+default_handler(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__message_entry_t entries[] = {
+        { "msg1", "default", null_message_fn },
+        { NULL },
+    };
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+
+    pcmk__register_messages(out, entries);
+    assert_int_equal(g_hash_table_size(out->messages), 1);
+    assert_ptr_equal(g_hash_table_lookup(out->messages, "msg1"), null_message_fn);
+
+    pcmk__output_free(out);
+}
+
+static void
+override_default_handler(void **state) {
+    pcmk__output_t *out = NULL;
+
+    pcmk__message_entry_t entries[] = {
+        { "msg1", "default", null_message_fn },
+        { "msg1", "text", null_message_fn_2 },
+        { NULL },
+    };
+
+    pcmk__output_new(&out, "text", NULL, NULL);
+
+    pcmk__register_messages(out, entries);
+    assert_int_equal(g_hash_table_size(out->messages), 1);
+    assert_ptr_equal(g_hash_table_lookup(out->messages, "msg1"), null_message_fn_2);
+
+    pcmk__output_free(out);
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(invalid_entries, setup, teardown),
+        cmocka_unit_test_setup_teardown(valid_entries, setup, teardown),
+        cmocka_unit_test_setup_teardown(duplicate_message_ids, setup, teardown),
+        cmocka_unit_test_setup_teardown(duplicate_functions, setup, teardown),
+        cmocka_unit_test_setup_teardown(default_handler, setup, teardown),
+        cmocka_unit_test_setup_teardown(override_default_handler, setup, teardown),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/common/tests/output/pcmk__unregister_formats_test.c
+++ b/lib/common/tests/output/pcmk__unregister_formats_test.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/common/output_internal.h>
+
+static pcmk__output_t *
+null_create_fn(char **argv) {
+    return NULL;
+}
+
+static void
+invalid_params(void **state) {
+    /* This is basically just here to make sure that calling pcmk__unregister_formats
+     * with formatters=NULL doesn't segfault.
+     */
+    pcmk__unregister_formats();
+    assert_null(pcmk__output_formatters());
+}
+
+static void
+non_null_formatters(void **state) {
+    pcmk__register_format(NULL, "fake", null_create_fn, NULL);
+
+    pcmk__unregister_formats();
+    assert_null(pcmk__output_formatters());
+}
+
+int
+main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(invalid_params),
+        cmocka_unit_test(non_null_formatters),
+    };
+
+    cmocka_set_message_output(CM_OUTPUT_TAP);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/mk/tap.mk
+++ b/mk/tap.mk
@@ -17,6 +17,7 @@ CLEANFILES = *.log *.trs
 
 WRAPPED = calloc		\
 	  endgrent		\
+	  fopen 		\
 	  getenv		\
 	  getpid		\
 	  getgrent		\

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -40,11 +40,13 @@ typedef struct private_data_s {
 
 static void
 curses_free_priv(pcmk__output_t *out) {
-    private_data_t *priv = out->priv;
+    private_data_t *priv = NULL;
 
-    if (priv == NULL) {
+    if (out == NULL || out->priv == NULL) {
         return;
     }
+
+    priv = out->priv;
 
     g_queue_free(priv->parent_q);
     free(priv);
@@ -54,6 +56,8 @@ curses_free_priv(pcmk__output_t *out) {
 static bool
 curses_init(pcmk__output_t *out) {
     private_data_t *priv = NULL;
+
+    CRM_ASSERT(out != NULL);
 
     /* If curses_init was previously called on this output struct, just return. */
     if (out->priv != NULL) {
@@ -296,8 +300,7 @@ curses_prompt(const char *prompt, bool do_echo, char **dest)
 {
     int rc = OK;
 
-    CRM_ASSERT(prompt != NULL);
-    CRM_ASSERT(dest != NULL);
+    CRM_ASSERT(prompt != NULL && dest != NULL);
 
     /* This is backwards from the text version of this function on purpose.  We
      * disable echo by default in curses_init, so we need to enable it here if
@@ -394,9 +397,11 @@ G_GNUC_PRINTF(2, 0)
 void
 curses_indented_vprintf(pcmk__output_t *out, const char *format, va_list args) {
     int level = 0;
-    private_data_t *priv = out->priv;
+    private_data_t *priv = NULL;
 
-    CRM_ASSERT(priv != NULL);
+    CRM_ASSERT(out != NULL && out->priv != NULL);
+
+    priv = out->priv;
 
     level = g_queue_get_length(priv->parent_q);
 


### PR DESCRIPTION
NOTE - this PR is so huge because it's based on top of #2798 and #2793.  Once those are merged, I'll rebase this one and it'll shrink a lot.  For now, just start looking at [a507738](https://github.com/ClusterLabs/pacemaker/pull/2800/commits/a507738e2fc73148f9fced5e7d0f22ef9a2c180a) ("Assert in more output-related functions").

This tests everything except the last three functions that are wrappers around specific output formatters.  I want to test the output_*.c files before adding tests for those.

I'm also seeing a lot of duplication in tests/*/Makefile.am - I think AM_CPPFLAGS, LDADD, AM_CFLAGS, and AM_LDFLAGS are identical across files now.  So maybe that's a place to do some code reduction in the next round. 