### PR TITLE
Test: cts-regression: Remove .dot.pe files

### DIFF
--- a/cts/cts-scheduler.in
+++ b/cts/cts-scheduler.in
@@ -1526,6 +1526,7 @@ class CtsScheduler(object):
             did_fail = True
 
         remove_files([ output_filename,
+                       dot_output_filename,
                        score_output_filename,
                        summary_output_filename])
 


### PR DESCRIPTION
Remove .dot.pe files as part of cleanup after a regression test.
Currently we clean up the .out, .scores.pe, and .summary.pe files.

Closes [T495](https://projects.clusterlabs.org/T495).