### PR TITLE
Test: cts-fencing, cts-exec: Bail out if daemon is running

### DIFF
--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -102,6 +102,27 @@ def output_from_command(command):
     return output.split("\n")
 
 
+def killall(process_names=[], terminate=False):
+    """ Kill all instances of every process in a list """
+
+    if not process_names:
+        return
+
+    procs = []
+    for proc in psutil.process_iter(["name"]):
+        if proc.info["name"] in process_names:
+            procs.append(proc)
+
+    if terminate:
+        for proc in procs:
+            proc.terminate()
+        gone, alive = psutil.wait_procs(procs, timeout=3)
+        procs = alive
+
+    for proc in procs:
+        proc.kill()
+
+
 def is_proc_running(process_name):
     """ Check whether a process with a given name is running """
 
@@ -120,7 +141,6 @@ def exit_if_proc_running(process_name):
         sys.exit(CrmExit.ERROR)
 
 
-def main(argv):
 class TestError(Exception):
     """ Base class for exceptions in this module """
     pass
@@ -213,9 +233,15 @@ class Test(object):
         """ Prepare the host for running a test """
 
         ### make sure we are in full control here ###
-        cmd = shlex.split("killall -q -9 pacemaker-fenced lt-pacemaker-fenced pacemaker-execd lt-pacemaker-execd cts-exec-helper lt-cts-exec-helper pacemaker-remoted")
-        test = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        test.wait()
+        killall([
+            "pacemaker-fenced",
+            "lt-pacemaker-fenced",
+            "pacemaker-execd",
+            "lt-pacemaker-execd",
+            "cts-exec-helper",
+            "lt-cts-exec-helper",
+            "pacemaker-remoted",
+        ])
 
         additional_args = ""
 

--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -7,6 +7,7 @@ __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT AN
 
 import io
 import os
+import psutil
 import stat
 import sys
 import subprocess
@@ -99,6 +100,15 @@ def output_from_command(command):
     test.wait()
     output = test.communicate()[0].decode(sys.stdout.encoding)
     return output.split("\n")
+
+
+def is_proc_running(process_name):
+    """ Check whether a process with a given name is running """
+
+    for proc in psutil.process_iter(["name"]):
+        if proc.info["name"] == process_name:
+            return True
+    return False
 
 
 class TestError(Exception):
@@ -1237,6 +1247,16 @@ def main(argv):
     if opts.options['show-usage']:
         show_usage()
         sys.exit(CrmExit.OK)
+
+    if opts.options['pacemaker-remote']:
+        daemon_name = "pacemaker-remoted"
+    else:
+        daemon_name = "pacemaker-execd"
+
+    if is_proc_running(daemon_name):
+        print("Error: %s is already running!" % daemon_name)
+        print("Run %s only when the cluster is stopped." % sys.argv[0])
+        sys.exit(CrmExit.ERROR)
 
     # Create a temporary directory for log files (the directory will
     # automatically be erased when done)

--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -111,6 +111,16 @@ def is_proc_running(process_name):
     return False
 
 
+def exit_if_proc_running(process_name):
+    """ Exit with error if a given process is running """
+
+    if is_proc_running(process_name):
+        print("Error: %s is already running!" % process_name)
+        print("Run %s only when the cluster is stopped." % sys.argv[0])
+        sys.exit(CrmExit.ERROR)
+
+
+def main(argv):
 class TestError(Exception):
     """ Base class for exceptions in this module """
     pass
@@ -1253,10 +1263,7 @@ def main(argv):
     else:
         daemon_name = "pacemaker-execd"
 
-    if is_proc_running(daemon_name):
-        print("Error: %s is already running!" % daemon_name)
-        print("Run %s only when the cluster is stopped." % sys.argv[0])
-        sys.exit(CrmExit.ERROR)
+    exit_if_proc_running(daemon_name)
 
     # Create a temporary directory for log files (the directory will
     # automatically be erased when done)

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -161,12 +161,25 @@ def localname():
     return our_uname
 
 
-def killall(process):
-    """ Kill all instances of a process """
+def killall(process_names=[], terminate=False):
+    """ Kill all instances of every process in a list """
 
-    cmd = shlex.split("killall -9 -q %s" % process)
-    test = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-    test.wait()
+    if not process_names:
+        return
+
+    procs = []
+    for proc in psutil.process_iter(["name"]):
+        if proc.info["name"] in process_names:
+            procs.append(proc)
+
+    if terminate:
+        for proc in procs:
+            proc.terminate()
+        gone, alive = psutil.wait_procs(procs, timeout=3)
+        procs = alive
+
+    for proc in procs:
+        proc.kill()
 
 
 def is_proc_running(process_name):
@@ -285,8 +298,7 @@ class Test(object):
         """ Prepare the host for executing a test """
 
         # Make sure we are in full control
-        killall("pacemakerd")
-        killall("pacemaker-fenced")
+        killall(["pacemakerd", "pacemaker-fenced"])
 
         if self.verbose:
             self.stonith_options = self.stonith_options + " -V"
@@ -1494,7 +1506,7 @@ class Tests(object):
                 corosync_cfg.close()
 
             ### make sure we are in control ###
-            killall("corosync")
+            killall(["corosync"])
             self.start_corosync()
 
         subprocess.call(["cts-support", "install"])
@@ -1503,7 +1515,7 @@ class Tests(object):
         """ Clean up the host after executing desired tests """
 
         if use_corosync:
-            killall("corosync")
+            killall(["corosync"])
 
             if self.autogen_corosync_cfg:
                 if self.verbose:

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -178,6 +178,15 @@ def is_proc_running(process_name):
     return False
 
 
+def exit_if_proc_running(process_name):
+    """ Exit with error if a given process is running """
+
+    if is_proc_running(process_name):
+        print("Error: %s is already running!" % process_name)
+        print("Run %s only when the cluster is stopped." % sys.argv[0])
+        sys.exit(CrmExit.ERROR)
+
+
 class TestError(Exception):
     """ Base class for exceptions in this module """
     pass
@@ -1581,11 +1590,6 @@ class TestOptions(object):
 def main(argv):
     """ Run fencing regression tests as specified by arguments """
 
-    if is_proc_running("pacemaker-fenced"):
-        print("Error: pacemaker-fenced is already running!")
-        print("Run %s only when the cluster is stopped." % sys.argv[0])
-        sys.exit(CrmExit.ERROR)
-        
     update_path()
 
     # Ensure all command output is in portable locale for comparison
@@ -1594,7 +1598,11 @@ def main(argv):
     opts = TestOptions()
     opts.build_options(argv)
 
-    use_corosync = 1
+    exit_if_proc_running("pacemaker-fenced")
+
+    use_corosync = not opts.options['no-cpg']
+    if use_corosync:
+        exit_if_proc_running("corosync")
 
     # Create a temporary directory for log files (the directory and its
     # contents will automatically be erased when done)
@@ -1622,9 +1630,6 @@ def main(argv):
             sys.exit(CrmExit.OK)
 
         print("Starting ...")
-
-        if opts.options['no-cpg']:
-            use_corosync = 0
 
         tests.setup_environment(use_corosync)
 

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -7,6 +7,7 @@ __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT AN
 
 import io
 import os
+import psutil
 import re
 import sys
 import subprocess
@@ -166,6 +167,15 @@ def killall(process):
     cmd = shlex.split("killall -9 -q %s" % process)
     test = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     test.wait()
+
+
+def is_proc_running(process_name):
+    """ Check whether a process with a given name is running """
+
+    for proc in psutil.process_iter(["name"]):
+        if proc.info["name"] == process_name:
+            return True
+    return False
 
 
 class TestError(Exception):
@@ -1571,6 +1581,11 @@ class TestOptions(object):
 def main(argv):
     """ Run fencing regression tests as specified by arguments """
 
+    if is_proc_running("pacemaker-fenced"):
+        print("Error: pacemaker-fenced is already running!")
+        print("Run %s only when the cluster is stopped." % sys.argv[0])
+        sys.exit(CrmExit.ERROR)
+        
     update_path()
 
     # Ensure all command output is in portable locale for comparison

--- a/rpm/pacemaker.spec.in
+++ b/rpm/pacemaker.spec.in
@@ -463,6 +463,7 @@ Requires:      %{pkgname_pcmk_libs} = %{version}-%{release}
 Requires:      %{name}-cli = %{version}-%{release}
 Requires:      %{pkgname_procps}
 Requires:      psmisc
+Requires:      %{python_name}-psutil
 BuildArch:     noarch
 
 # systemd Python bindings are a separate package in some distros


### PR DESCRIPTION
If `pacemaker-fenced` is already running when cts-fencing starts, `cts-fencing` will kill the existing fencer. Instead of allowing this to happen, we should bail out and tell the user to stop the cluster.

Likewise for `pacemaker-execd` (or `pacemaker-remoted`, if the `-R` option is used) and `cts-exec`.

Closes: [T496](https://projects.clusterlabs.org/T496)
Closes: [T497](https://projects.clusterlabs.org/T497)