### PR TITLE
Mid: fenced: Skipping devices that don't support the on action.(Fix:CLBZ#5495)

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -938,6 +938,8 @@ read_action_metadata(stonith_device_t *device)
             if (pcmk__xe_attr_is_true(match, "automatic") || pcmk__xe_attr_is_true(match, "required")) {
                 device->automatic_unfencing = TRUE;
             }
+            stonith__set_device_flags(device->flags, device->id,
+                                      st_device_supports_on);
         }
 
         if (action && pcmk__xe_attr_is_true(match, "on_target")) {
@@ -2353,6 +2355,7 @@ stonith_query_capable_device_cb(GList * devices, void *user_data)
         crm_xml_add(dev, "namespace", device->namespace);
         crm_xml_add(dev, "agent", device->agent);
         crm_xml_add_int(dev, F_STONITH_DEVICE_VERIFIED, device->verified);
+        crm_xml_add_int(dev, F_STONITH_DEVICE_SUPPORT_FLAGS, device->flags);
 
         /* If the originating fencer wants to reboot the node, and we have a
          * capable device that doesn't support "reboot", remap to "off" instead.

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -23,6 +23,7 @@ enum st_device_flags
     st_device_supports_reboot = 0x0004,
     st_device_supports_parameter_plug = 0x0008,
     st_device_supports_parameter_port = 0x0010,
+    st_device_supports_on = 0x0020,
 };
 
 #define stonith__set_device_flags(device_flags, device_id, flags_to_set) do { \
@@ -132,6 +133,7 @@ void stonith__device_parameter_flags(uint32_t *device_flags,
 #  define F_STONITH_NOTIFY_ACTIVATE   "st_notify_activate"
 #  define F_STONITH_NOTIFY_DEACTIVATE "st_notify_deactivate"
 #  define F_STONITH_DELEGATE      "st_delegate"
+#  define F_STONITH_DEVICE_SUPPORT_FLAGS "st_support_flags"
 /*! The node initiating the stonith operation.  If an operation
  * is relayed, this is the last node the operation lands on. When
  * in standalone mode, origin is the client's id that originated the


### PR DESCRIPTION
Hi All,

Fix for the issue reported in CLBZ#5945 below.
 - https://bugs.clusterlabs.org/show_bug.cgi?id=5495

In the unfencing action, skip execution for devices that do not support the on action set in topology.

Best Regards,
Hideo Yamauchi.