### PR TITLE
Reduce duplication in the unit tests

### DIFF
--- a/doc/sphinx/Pacemaker_Development/helpers.rst
+++ b/doc/sphinx/Pacemaker_Development/helpers.rst
@@ -468,6 +468,46 @@ At this point, you need to determine whether your test case is incorrect or
 whether the code being tested is incorrect.  Fix whichever is wrong and continue.
 
 
+Code Coverage
+#############
+
+Figuring out what needs unit tests written is the purpose of a code coverage tool.
+The Pacemaker build process uses ``lcov`` and special make targets to generate
+an HTML coverage report that can be inspected with any web browser.
+
+To start, you'll need to install the ``lcov`` package which is included in most
+distributions.  Next, reconfigure and rebuild the source tree:
+
+.. code-block:: none
+
+   $ ./configure --with-coverage
+   $ make
+
+Then simply run ``make coverage``.  This will do the same thing as ``make check``,
+but will generate a bunch of intermediate files as part of the compiler's output.
+Essentially, the coverage tools run all the unit tests and make a note if a given
+line if code is executed as a part of some test program.  This will include not
+just things run as part of the tests but anything in the setup and teardown
+functions as well.
+
+Afterwards, the HTML report will be in ``coverage/index.html``.  You can drill down
+into individual source files to see exactly which lines are covered and which are
+not, which makes it easy to target new unit tests.  Note that sometimes, it is
+impossible to achieve 100% coverage for a source file.  For instance, how do you
+test a function with a return type of void that simply returns on some condition?
+
+Note that Pacemaker's overall code coverage numbers are very low at the moment.
+One reason for this is the large amount of code in the ``daemons`` directory that
+will be very difficult to write unit tests for.  For now, it is best to focus
+efforts on increasing the coverage on individual libraries.
+
+Additionally, there is a ``coverage-cts`` target that does the same thing but
+instead of testing ``make check``, it tests ``cts/cts-cli``.  The idea behind this
+target is to see what parts of our command line tools are covered by our regression
+tests.  It is probably best to clean and rebuild the source tree when switching
+between these various targets.
+
+
 Debugging
 #########
 

--- a/doc/sphinx/Pacemaker_Development/helpers.rst
+++ b/doc/sphinx/Pacemaker_Development/helpers.rst
@@ -224,17 +224,14 @@ is no ``lib/common/tests/acls`` directory.
 
      check_PROGRAMS = pcmk_acl_required_test
 
-* Double check that ``-I$(top_srcdir)/lib/common`` is present in ``AM_CPPFLAGS``.
-
-* Double check the settings of variables at the top of ``Makefile.am``.  The
-  following block should be present:
+* Double check that ``$(top_srcdir)/mk/tap.mk`` and ``$(top_srcdir)/mk/unittest.mk``
+  are included in the ``Makefile.am``.  These files contain all the flags necessary
+  for most unit tests.  If necessary, individual settings can be overridden like so:
 
   .. code-block:: none
 
-     LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-             -lcmocka
-     AM_CFLAGS = -DPCMK__UNIT_TESTING
-     AM_LDFLAGS = $(LDFLAGS_WRAP)
+     AM_CPPFLAGS += -I$(top_srcdir)
+     LDADD += $(top_builddir)/lib/pengine/libpe_status_test.la
 
 * Follow the steps in `Testing a new function in an already testable source file`_
   to create the new ``pcmk_acl_required_test.c`` file.
@@ -321,14 +318,8 @@ here's the basic structure:
 
    /* Put your test functions here */
 
-   int
-   main(int argc, char **argv)
-   {
-       /* Register your test functions here */
-
-       cmocka_set_message_output(CM_OUTPUT_TAP);
-       return cmocka_run_group_tests(tests, NULL, NULL);
-   }
+   PCMK__UNIT_TEST(NULL, NULL,
+                   /* Register your test functions here */)
 
 Each test-specific function should test one aspect of the library function,
 though it can include many assertions if there are many ways of testing that
@@ -348,13 +339,17 @@ expression matching:
    }
 
 Each test-specific function must also be registered or it will not be called.
-This is done with ``cmocka_unit_test()`` in the ``main`` function:
+This is done with ``cmocka_unit_test()`` in the ``PCMK__UNIT_TEST`` macro:
 
 .. code-block:: c
 
-   const struct CMUnitTest tests[] = {
-       cmocka_unit_test(regex),
-   };
+   PCMK__UNIT_TEST(NULL, NULL,
+                   cmocka_unit_test(regex))
+
+Most unit tests do not require a setup and teardown function to be executed
+around the entire group of tests.  On occassion, this may be necessary.  Simply
+pass those functions in as the first two parameters to ``PCMK__UNIT_TEST``
+instead of using NULL.
 
 Assertions
 __________

--- a/include/crm/common/unittest_internal.h
+++ b/include/crm/common/unittest_internal.h
@@ -65,4 +65,20 @@
         } \
     } while (0);
 
+/* Generate the main function of most unit test files.  Typically, group_setup
+ * and group_teardown will be NULL.  The rest of the arguments are a list of
+ * calls to cmocka_unit_test or cmocka_unit_test_setup_teardown to run the
+ * individual unit tests.
+ */
+#define PCMK__UNIT_TEST(group_setup, group_teardown, ...) \
+int \
+main(int argc, char **argv) \
+{ \
+    const struct CMUnitTest t[] = { \
+        __VA_ARGS__ \
+    }; \
+    cmocka_set_message_output(CM_OUTPUT_TAP); \
+    return cmocka_run_group_tests(t, group_setup, group_teardown); \
+}
+
 #endif /* CRM_COMMON_UNITTEST_INTERNAL__H */

--- a/lib/common/tests/acl/Makefile.am
+++ b/lib/common/tests/acl/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 

--- a/lib/common/tests/acl/pcmk__is_user_in_group_test.c
+++ b/lib/common/tests/acl/pcmk__is_user_in_group_test.c
@@ -34,13 +34,5 @@ is_pcmk__is_user_in_group(void **state)
     pcmk__mock_grent = false;
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(is_pcmk__is_user_in_group)
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(is_pcmk__is_user_in_group))

--- a/lib/common/tests/acl/pcmk_acl_required_test.c
+++ b/lib/common/tests/acl/pcmk_acl_required_test.c
@@ -22,13 +22,5 @@ is_pcmk_acl_required(void **state)
     assert_false(pcmk_acl_required("root"));
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(is_pcmk_acl_required),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(is_pcmk_acl_required))

--- a/lib/common/tests/acl/xml_acl_denied_test.c
+++ b/lib/common/tests/acl/xml_acl_denied_test.c
@@ -56,14 +56,6 @@ is_xml_acl_denied_with_node(void **state)
     assert_true(xml_acl_denied(test_xml));
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(is_xml_acl_denied_without_node),
-        cmocka_unit_test(is_xml_acl_denied_with_node),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(is_xml_acl_denied_without_node),
+                cmocka_unit_test(is_xml_acl_denied_with_node))

--- a/lib/common/tests/acl/xml_acl_enabled_test.c
+++ b/lib/common/tests/acl/xml_acl_enabled_test.c
@@ -56,14 +56,6 @@ is_xml_acl_enabled_with_node(void **state)
     assert_true(xml_acl_enabled(test_xml));
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(is_xml_acl_enabled_without_node),
-        cmocka_unit_test(is_xml_acl_enabled_with_node),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(is_xml_acl_enabled_without_node),
+                cmocka_unit_test(is_xml_acl_enabled_with_node))

--- a/lib/common/tests/agents/Makefile.am
+++ b/lib/common/tests/agents/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = crm_generate_ra_key_test \

--- a/lib/common/tests/agents/crm_generate_ra_key_test.c
+++ b/lib/common/tests/agents/crm_generate_ra_key_test.c
@@ -42,15 +42,7 @@ no_params_null(void **state) {
     free(retval);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(all_params_null),
-        cmocka_unit_test(some_params_null),
-        cmocka_unit_test(no_params_null),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(all_params_null),
+                cmocka_unit_test(some_params_null),
+                cmocka_unit_test(no_params_null))

--- a/lib/common/tests/agents/crm_parse_agent_spec_test.c
+++ b/lib/common/tests/agents/crm_parse_agent_spec_test.c
@@ -78,18 +78,10 @@ get_systemd_values(void **state) {
     free(ty);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(all_params_null),
-        cmocka_unit_test(no_prov_or_type),
-        cmocka_unit_test(no_type),
-        cmocka_unit_test(get_std_and_ty),
-        cmocka_unit_test(get_all_values),
-        cmocka_unit_test(get_systemd_values),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(all_params_null),
+                cmocka_unit_test(no_prov_or_type),
+                cmocka_unit_test(no_type),
+                cmocka_unit_test(get_std_and_ty),
+                cmocka_unit_test(get_all_values),
+                cmocka_unit_test(get_systemd_values))

--- a/lib/common/tests/agents/pcmk__effective_rc_test.c
+++ b/lib/common/tests/agents/pcmk__effective_rc_test.c
@@ -32,13 +32,5 @@ pcmk__effective_rc_test(void **state) {
     assert_int_equal(INT_MIN, pcmk__effective_rc(INT_MIN));
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(pcmk__effective_rc_test),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(pcmk__effective_rc_test))

--- a/lib/common/tests/agents/pcmk_get_ra_caps_test.c
+++ b/lib/common/tests/agents/pcmk_get_ra_caps_test.c
@@ -55,17 +55,9 @@ unknown_standard(void **state) {
     assert_int_equal(pcmk_get_ra_caps(NULL), pcmk_ra_cap_none);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(ocf_standard),
-        cmocka_unit_test(stonith_standard),
-        cmocka_unit_test(service_standard),
-        cmocka_unit_test(nagios_standard),
-        cmocka_unit_test(unknown_standard),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(ocf_standard),
+                cmocka_unit_test(stonith_standard),
+                cmocka_unit_test(service_standard),
+                cmocka_unit_test(nagios_standard),
+                cmocka_unit_test(unknown_standard))

--- a/lib/common/tests/agents/pcmk_stonith_param_test.c
+++ b/lib/common/tests/agents/pcmk_stonith_param_test.c
@@ -45,14 +45,6 @@ is_stonith_action_param(void **state)
     assert_true(pcmk_stonith_param("pcmk_on_retries"));
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(is_stonith_param),
-        cmocka_unit_test(is_stonith_action_param),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(is_stonith_param),
+                cmocka_unit_test(is_stonith_action_param))

--- a/lib/common/tests/cmdline/Makefile.am
+++ b/lib/common/tests/cmdline/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = pcmk__cmdline_preproc_test \

--- a/lib/common/tests/cmdline/pcmk__cmdline_preproc_test.c
+++ b/lib/common/tests/cmdline/pcmk__cmdline_preproc_test.c
@@ -13,6 +13,7 @@
 #include <crm/common/cmdline_internal.h>
 
 #include <glib.h>
+#include <stdint.h>
 
 #define LISTS_EQ(a, b) { \
     assert_int_equal(g_strv_length((gchar **) (a)), g_strv_length((gchar **) (b))); \
@@ -140,24 +141,16 @@ string_arg_with_dash_3(void **state) {
     g_strfreev(processed);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input),
-        cmocka_unit_test(no_specials),
-        cmocka_unit_test(single_dash),
-        cmocka_unit_test(double_dash),
-        cmocka_unit_test(special_args),
-        cmocka_unit_test(special_arg_at_end),
-        cmocka_unit_test(long_arg),
-        cmocka_unit_test(negative_score),
-        cmocka_unit_test(negative_score_2),
-        cmocka_unit_test(string_arg_with_dash),
-        cmocka_unit_test(string_arg_with_dash_2),
-        cmocka_unit_test(string_arg_with_dash_3),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input),
+                cmocka_unit_test(no_specials),
+                cmocka_unit_test(single_dash),
+                cmocka_unit_test(double_dash),
+                cmocka_unit_test(special_args),
+                cmocka_unit_test(special_arg_at_end),
+                cmocka_unit_test(long_arg),
+                cmocka_unit_test(negative_score),
+                cmocka_unit_test(negative_score_2),
+                cmocka_unit_test(string_arg_with_dash),
+                cmocka_unit_test(string_arg_with_dash_2),
+                cmocka_unit_test(string_arg_with_dash_3))

--- a/lib/common/tests/cmdline/pcmk__quote_cmdline_test.c
+++ b/lib/common/tests/cmdline/pcmk__quote_cmdline_test.c
@@ -49,16 +49,8 @@ spaces_with_quote(void **state) {
     g_free(processed);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input),
-        cmocka_unit_test(no_spaces),
-        cmocka_unit_test(spaces_no_quote),
-        cmocka_unit_test(spaces_with_quote),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input),
+                cmocka_unit_test(no_spaces),
+                cmocka_unit_test(spaces_no_quote),
+                cmocka_unit_test(spaces_with_quote))

--- a/lib/common/tests/flags/Makefile.am
+++ b/lib/common/tests/flags/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = \

--- a/lib/common/tests/flags/pcmk__clear_flags_as_test.c
+++ b/lib/common/tests/flags/pcmk__clear_flags_as_test.c
@@ -35,15 +35,7 @@ clear_all(void **state) {
                                           "test", 0x0f0, 0xfff, NULL), 0x000);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(clear_none),
-        cmocka_unit_test(clear_some),
-        cmocka_unit_test(clear_all),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(clear_none),
+                cmocka_unit_test(clear_some),
+                cmocka_unit_test(clear_all))

--- a/lib/common/tests/flags/pcmk__set_flags_as_test.c
+++ b/lib/common/tests/flags/pcmk__set_flags_as_test.c
@@ -21,13 +21,5 @@ set_flags(void **state) {
                      "test", 0x0f0, 0xfff, NULL), 0xfff);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(set_flags),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(set_flags))

--- a/lib/common/tests/flags/pcmk_all_flags_set_test.c
+++ b/lib/common/tests/flags/pcmk_all_flags_set_test.c
@@ -28,14 +28,6 @@ one_is_set(void **state) {
     assert_false(pcmk_is_set(0x00f, 0x010));
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(all_set),
-        cmocka_unit_test(one_is_set),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(all_set),
+                cmocka_unit_test(one_is_set))

--- a/lib/common/tests/flags/pcmk_any_flags_set_test.c
+++ b/lib/common/tests/flags/pcmk_any_flags_set_test.c
@@ -22,13 +22,5 @@ any_set(void **state) {
     assert_false(pcmk_any_flags_set(0x00f, 0x000));
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(any_set),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(any_set))

--- a/lib/common/tests/health/Makefile.am
+++ b/lib/common/tests/health/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = pcmk__parse_health_strategy_test	\

--- a/lib/common/tests/health/pcmk__parse_health_strategy_test.c
+++ b/lib/common/tests/health/pcmk__parse_health_strategy_test.c
@@ -51,14 +51,6 @@ invalid(void **state) {
                      pcmk__health_strategy_none);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(valid),
-        cmocka_unit_test(invalid),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(valid),
+                cmocka_unit_test(invalid))

--- a/lib/common/tests/health/pcmk__validate_health_strategy_test.c
+++ b/lib/common/tests/health/pcmk__validate_health_strategy_test.c
@@ -33,13 +33,6 @@ invalid_strategy(void **state) {
     assert_false(pcmk__validate_health_strategy("customized"));
 }
 
-int
-main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(valid_strategy),
-        cmocka_unit_test(invalid_strategy),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(valid_strategy),
+                cmocka_unit_test(invalid_strategy))

--- a/lib/common/tests/io/Makefile.am
+++ b/lib/common/tests/io/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = \

--- a/lib/common/tests/io/pcmk__full_path_test.c
+++ b/lib/common/tests/io/pcmk__full_path_test.c
@@ -47,14 +47,6 @@ full_path(void **state)
     free(path);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(function_asserts),
-        cmocka_unit_test(full_path),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(function_asserts),
+                cmocka_unit_test(full_path))

--- a/lib/common/tests/io/pcmk__get_tmpdir_test.c
+++ b/lib/common/tests/io/pcmk__get_tmpdir_test.c
@@ -63,14 +63,6 @@ getenv_returns_valid(void **state)
     pcmk__mock_getenv = false;
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(getenv_returns_invalid),
-        cmocka_unit_test(getenv_returns_valid),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(getenv_returns_invalid),
+                cmocka_unit_test(getenv_returns_valid))

--- a/lib/common/tests/iso8601/Makefile.am
+++ b/lib/common/tests/iso8601/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = pcmk__readable_interval_test

--- a/lib/common/tests/iso8601/pcmk__readable_interval_test.c
+++ b/lib/common/tests/iso8601/pcmk__readable_interval_test.c
@@ -23,13 +23,5 @@ readable_interval(void **state)
     assert_string_equal(pcmk__readable_interval(UINT_MAX), "49d17h2m47.295s");
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(readable_interval),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(readable_interval))

--- a/lib/common/tests/lists/Makefile.am
+++ b/lib/common/tests/lists/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 

--- a/lib/common/tests/lists/pcmk__list_of_1_test.c
+++ b/lib/common/tests/lists/pcmk__list_of_1_test.c
@@ -39,15 +39,7 @@ longer_list(void **state) {
     g_list_free_full(lst, free);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_list),
-        cmocka_unit_test(singleton_list),
-        cmocka_unit_test(longer_list),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_list),
+                cmocka_unit_test(singleton_list),
+                cmocka_unit_test(longer_list))

--- a/lib/common/tests/lists/pcmk__list_of_multiple_test.c
+++ b/lib/common/tests/lists/pcmk__list_of_multiple_test.c
@@ -39,15 +39,7 @@ longer_list(void **state) {
     g_list_free_full(lst, free);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_list),
-        cmocka_unit_test(singleton_list),
-        cmocka_unit_test(longer_list),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_list),
+                cmocka_unit_test(singleton_list),
+                cmocka_unit_test(longer_list))

--- a/lib/common/tests/lists/pcmk__subtract_lists_test.c
+++ b/lib/common/tests/lists/pcmk__subtract_lists_test.c
@@ -136,17 +136,9 @@ remove_all_items(void **state)
     g_list_free_full(items, free);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(different_lists),
-        cmocka_unit_test(remove_first_item),
-        cmocka_unit_test(remove_middle_item),
-        cmocka_unit_test(remove_last_item),
-        cmocka_unit_test(remove_all_items),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(different_lists),
+                cmocka_unit_test(remove_first_item),
+                cmocka_unit_test(remove_middle_item),
+                cmocka_unit_test(remove_last_item),
+                cmocka_unit_test(remove_all_items))

--- a/lib/common/tests/nvpair/Makefile.am
+++ b/lib/common/tests/nvpair/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS =	pcmk__xe_attr_is_true_test \

--- a/lib/common/tests/nvpair/pcmk__xe_attr_is_true_test.c
+++ b/lib/common/tests/nvpair/pcmk__xe_attr_is_true_test.c
@@ -44,15 +44,7 @@ attr_present(void **state)
     free_xml(node);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input),
-        cmocka_unit_test(attr_missing),
-        cmocka_unit_test(attr_present),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input),
+                cmocka_unit_test(attr_missing),
+                cmocka_unit_test(attr_present))

--- a/lib/common/tests/nvpair/pcmk__xe_get_bool_attr_test.c
+++ b/lib/common/tests/nvpair/pcmk__xe_get_bool_attr_test.c
@@ -53,15 +53,7 @@ attr_present(void **state)
     free_xml(node);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input),
-        cmocka_unit_test(attr_missing),
-        cmocka_unit_test(attr_present),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input),
+                cmocka_unit_test(attr_missing),
+                cmocka_unit_test(attr_present))

--- a/lib/common/tests/nvpair/pcmk__xe_set_bool_attr_test.c
+++ b/lib/common/tests/nvpair/pcmk__xe_set_bool_attr_test.c
@@ -27,13 +27,5 @@ set_attr(void **state)
     free_xml(node);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(set_attr),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(set_attr))

--- a/lib/common/tests/operations/Makefile.am
+++ b/lib/common/tests/operations/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = copy_in_properties_test \

--- a/lib/common/tests/operations/copy_in_properties_test.c
+++ b/lib/common/tests/operations/copy_in_properties_test.c
@@ -56,14 +56,7 @@ copying_is_successful(void **state)
     assert_string_equal(xml_1_value, xml_2_value);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(target_is_NULL),
-        cmocka_unit_test(src_is_NULL),
-        cmocka_unit_test(copying_is_successful),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(target_is_NULL),
+                cmocka_unit_test(src_is_NULL),
+                cmocka_unit_test(copying_is_successful))

--- a/lib/common/tests/operations/expand_plus_plus_test.c
+++ b/lib/common/tests/operations/expand_plus_plus_test.c
@@ -234,30 +234,23 @@ assignment_result_is_too_large(void **state)
     assert_string_equal(new_value, "1000000");
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(value_is_name_plus_plus),
-        cmocka_unit_test(value_is_name_plus_equals_integer),
-        cmocka_unit_test(target_is_NULL),
-        cmocka_unit_test(name_is_NULL),
-        cmocka_unit_test(value_is_NULL),
-        cmocka_unit_test(value_is_wrong_name),
-        cmocka_unit_test(value_is_only_an_integer),
-        cmocka_unit_test(variable_is_initialized_to_be_NULL),
-        cmocka_unit_test(variable_is_initialized_to_be_non_numeric),
-        cmocka_unit_test(variable_is_initialized_to_be_non_numeric_2),
-        cmocka_unit_test(variable_is_initialized_to_be_numeric_and_decimal_point_containing),
-        cmocka_unit_test(variable_is_initialized_to_be_numeric_and_decimal_point_containing_2),
-        cmocka_unit_test(variable_is_initialized_to_be_numeric_and_decimal_point_containing_3),
-        cmocka_unit_test(value_is_non_numeric),
-        cmocka_unit_test(value_is_numeric_and_decimal_point_containing),
-        cmocka_unit_test(value_is_numeric_and_decimal_point_containing_2),
-        cmocka_unit_test(value_is_numeric_and_decimal_point_containing_3),
-        cmocka_unit_test(name_is_undefined),
-        cmocka_unit_test(assignment_result_is_too_large),        
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(value_is_name_plus_plus),
+                cmocka_unit_test(value_is_name_plus_equals_integer),
+                cmocka_unit_test(target_is_NULL),
+                cmocka_unit_test(name_is_NULL),
+                cmocka_unit_test(value_is_NULL),
+                cmocka_unit_test(value_is_wrong_name),
+                cmocka_unit_test(value_is_only_an_integer),
+                cmocka_unit_test(variable_is_initialized_to_be_NULL),
+                cmocka_unit_test(variable_is_initialized_to_be_non_numeric),
+                cmocka_unit_test(variable_is_initialized_to_be_non_numeric_2),
+                cmocka_unit_test(variable_is_initialized_to_be_numeric_and_decimal_point_containing),
+                cmocka_unit_test(variable_is_initialized_to_be_numeric_and_decimal_point_containing_2),
+                cmocka_unit_test(variable_is_initialized_to_be_numeric_and_decimal_point_containing_3),
+                cmocka_unit_test(value_is_non_numeric),
+                cmocka_unit_test(value_is_numeric_and_decimal_point_containing),
+                cmocka_unit_test(value_is_numeric_and_decimal_point_containing_2),
+                cmocka_unit_test(value_is_numeric_and_decimal_point_containing_3),
+                cmocka_unit_test(name_is_undefined),
+                cmocka_unit_test(assignment_result_is_too_large))

--- a/lib/common/tests/operations/fix_plus_plus_recursive_test.c
+++ b/lib/common/tests/operations/fix_plus_plus_recursive_test.c
@@ -43,12 +43,5 @@ element_nodes(void **state)
     assert_string_equal(new_value_grandchild, "2");
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(element_nodes),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(element_nodes))

--- a/lib/common/tests/operations/parse_op_key_test.c
+++ b/lib/common/tests/operations/parse_op_key_test.c
@@ -208,23 +208,14 @@ malformed_input(void **state)
     assert_int_equal(ms, 0);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(basic),
-        cmocka_unit_test(colon_in_rsc),
-        cmocka_unit_test(dashes_in_rsc),
-        cmocka_unit_test(migrate_to_from),
-        cmocka_unit_test(pre_post),
-
-        cmocka_unit_test(skip_rsc),
-        cmocka_unit_test(skip_ty),
-        cmocka_unit_test(skip_ms),
-
-        cmocka_unit_test(empty_input),
-        cmocka_unit_test(malformed_input),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(basic),
+                cmocka_unit_test(colon_in_rsc),
+                cmocka_unit_test(dashes_in_rsc),
+                cmocka_unit_test(migrate_to_from),
+                cmocka_unit_test(pre_post),
+                cmocka_unit_test(skip_rsc),
+                cmocka_unit_test(skip_ty),
+                cmocka_unit_test(skip_ms),
+                cmocka_unit_test(empty_input),
+                cmocka_unit_test(malformed_input))

--- a/lib/common/tests/operations/pcmk_is_probe_test.c
+++ b/lib/common/tests/operations/pcmk_is_probe_test.c
@@ -21,12 +21,5 @@ is_probe_test(void **state)
     assert_true(pcmk_is_probe("monitor", 0));
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(is_probe_test),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(is_probe_test))

--- a/lib/common/tests/operations/pcmk_xe_is_probe_test.c
+++ b/lib/common/tests/operations/pcmk_xe_is_probe_test.c
@@ -39,12 +39,5 @@ op_is_probe_test(void **state)
     free_xml(node);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(op_is_probe_test),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(op_is_probe_test))

--- a/lib/common/tests/operations/pcmk_xe_mask_probe_failure_test.c
+++ b/lib/common/tests/operations/pcmk_xe_mask_probe_failure_test.c
@@ -144,14 +144,7 @@ check_values_test(void **state) {
     free_xml(node);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(op_is_not_probe_test),
-        cmocka_unit_test(op_does_not_have_right_values_test),
-        cmocka_unit_test(check_values_test),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(op_is_not_probe_test),
+                cmocka_unit_test(op_does_not_have_right_values_test),
+                cmocka_unit_test(check_values_test))

--- a/lib/common/tests/options/Makefile.am
+++ b/lib/common/tests/options/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = \

--- a/lib/common/tests/options/pcmk__env_option_enabled_test.c
+++ b/lib/common/tests/options/pcmk__env_option_enabled_test.c
@@ -93,17 +93,9 @@ disabled_daemon_not_in_list(void **state)
     pcmk__mock_getenv = false;
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(disabled_null_value),
-        cmocka_unit_test(enabled_true_value),
-        cmocka_unit_test(disabled_false_value),
-        cmocka_unit_test(enabled_daemon_in_list),
-        cmocka_unit_test(disabled_daemon_not_in_list),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(disabled_null_value),
+                cmocka_unit_test(enabled_true_value),
+                cmocka_unit_test(disabled_false_value),
+                cmocka_unit_test(enabled_daemon_in_list),
+                cmocka_unit_test(disabled_daemon_not_in_list))

--- a/lib/common/tests/options/pcmk__env_option_test.c
+++ b/lib/common/tests/options/pcmk__env_option_test.c
@@ -125,18 +125,10 @@ value_found_ha(void **state)
     pcmk__mock_getenv = false;
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input_string),
-        cmocka_unit_test(input_too_long_for_both),
-        cmocka_unit_test(input_too_long_for_pcmk),
-        cmocka_unit_test(value_not_found),
-        cmocka_unit_test(value_found_pcmk),
-        cmocka_unit_test(value_found_ha),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input_string),
+                cmocka_unit_test(input_too_long_for_both),
+                cmocka_unit_test(input_too_long_for_pcmk),
+                cmocka_unit_test(value_not_found),
+                cmocka_unit_test(value_found_pcmk),
+                cmocka_unit_test(value_found_ha))

--- a/lib/common/tests/options/pcmk__set_env_option_test.c
+++ b/lib/common/tests/options/pcmk__set_env_option_test.c
@@ -146,17 +146,9 @@ valid_inputs_unset(void **state)
     pcmk__mock_unsetenv = false;
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(bad_input_string),
-        cmocka_unit_test(input_too_long_for_both),
-        cmocka_unit_test(input_too_long_for_pcmk),
-        cmocka_unit_test(valid_inputs_set),
-        cmocka_unit_test(valid_inputs_unset),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(bad_input_string),
+                cmocka_unit_test(input_too_long_for_both),
+                cmocka_unit_test(input_too_long_for_pcmk),
+                cmocka_unit_test(valid_inputs_set),
+                cmocka_unit_test(valid_inputs_unset))

--- a/lib/common/tests/output/Makefile.am
+++ b/lib/common/tests/output/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-		-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS =	pcmk__call_message_test \

--- a/lib/common/tests/output/pcmk__call_message_test.c
+++ b/lib/common/tests/output/pcmk__call_message_test.c
@@ -149,16 +149,8 @@ default_called(void **state) {
     pcmk__output_free(out);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(no_such_message, setup, teardown),
-        cmocka_unit_test_setup_teardown(message_return_value, setup, teardown),
-        cmocka_unit_test_setup_teardown(wrong_format, setup, teardown),
-        cmocka_unit_test_setup_teardown(default_called, setup, teardown),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test_setup_teardown(no_such_message, setup, teardown),
+                cmocka_unit_test_setup_teardown(message_return_value, setup, teardown),
+                cmocka_unit_test_setup_teardown(wrong_format, setup, teardown),
+                cmocka_unit_test_setup_teardown(default_called, setup, teardown))

--- a/lib/common/tests/output/pcmk__output_and_clear_error_test.c
+++ b/lib/common/tests/output/pcmk__output_and_clear_error_test.c
@@ -78,13 +78,5 @@ standard_usage(void **state) {
     assert_null(error->message);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(standard_usage, setup, teardown),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test_setup_teardown(standard_usage, setup, teardown))

--- a/lib/common/tests/output/pcmk__output_free_test.c
+++ b/lib/common/tests/output/pcmk__output_free_test.c
@@ -79,14 +79,6 @@ messages(void **state) {
     pcmk__output_free(out);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(no_messages, setup, teardown),
-        cmocka_unit_test_setup_teardown(messages, setup, teardown),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test_setup_teardown(no_messages, setup, teardown),
+                cmocka_unit_test_setup_teardown(messages, setup, teardown))

--- a/lib/common/tests/output/pcmk__output_new_test.c
+++ b/lib/common/tests/output/pcmk__output_new_test.c
@@ -137,20 +137,12 @@ no_fmt_name_given(void **state) {
     pcmk__output_free(out);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_formatters),
-        cmocka_unit_test_setup_teardown(invalid_params, setup, teardown),
-        cmocka_unit_test_setup_teardown(no_such_format, setup, teardown),
-        cmocka_unit_test_setup_teardown(create_fails, setup, teardown),
-        cmocka_unit_test_setup_teardown(init_fails, setup, teardown),
-        cmocka_unit_test_setup_teardown(fopen_fails, setup, teardown),
-        cmocka_unit_test_setup_teardown(everything_succeeds, setup, teardown),
-        cmocka_unit_test_setup_teardown(no_fmt_name_given, setup, teardown),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_formatters),
+                cmocka_unit_test_setup_teardown(invalid_params, setup, teardown),
+                cmocka_unit_test_setup_teardown(no_such_format, setup, teardown),
+                cmocka_unit_test_setup_teardown(create_fails, setup, teardown),
+                cmocka_unit_test_setup_teardown(init_fails, setup, teardown),
+                cmocka_unit_test_setup_teardown(fopen_fails, setup, teardown),
+                cmocka_unit_test_setup_teardown(everything_succeeds, setup, teardown),
+                cmocka_unit_test_setup_teardown(no_fmt_name_given, setup, teardown))

--- a/lib/common/tests/output/pcmk__register_format_test.c
+++ b/lib/common/tests/output/pcmk__register_format_test.c
@@ -58,14 +58,6 @@ add_format(void **state) {
     pcmk__unregister_formats();
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(invalid_params),
-        cmocka_unit_test(add_format),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(invalid_params),
+                cmocka_unit_test(add_format))

--- a/lib/common/tests/output/pcmk__register_formats_test.c
+++ b/lib/common/tests/output/pcmk__register_formats_test.c
@@ -100,17 +100,9 @@ duplicate_values(void **state) {
     pcmk__unregister_formats();
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(no_formats),
-        cmocka_unit_test(invalid_entries),
-        cmocka_unit_test(valid_entries),
-        cmocka_unit_test(duplicate_keys),
-        cmocka_unit_test(duplicate_values),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(no_formats),
+                cmocka_unit_test(invalid_entries),
+                cmocka_unit_test(valid_entries),
+                cmocka_unit_test(duplicate_keys),
+                cmocka_unit_test(duplicate_values))

--- a/lib/common/tests/output/pcmk__register_message_test.c
+++ b/lib/common/tests/output/pcmk__register_message_test.c
@@ -100,14 +100,6 @@ add_message(void **state) {
     pcmk__output_free(out);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(null_params, setup, teardown),
-        cmocka_unit_test_setup_teardown(add_message, setup, teardown),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test_setup_teardown(null_params, setup, teardown),
+                cmocka_unit_test_setup_teardown(add_message, setup, teardown))

--- a/lib/common/tests/output/pcmk__register_messages_test.c
+++ b/lib/common/tests/output/pcmk__register_messages_test.c
@@ -180,18 +180,10 @@ override_default_handler(void **state) {
     pcmk__output_free(out);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(invalid_entries, setup, teardown),
-        cmocka_unit_test_setup_teardown(valid_entries, setup, teardown),
-        cmocka_unit_test_setup_teardown(duplicate_message_ids, setup, teardown),
-        cmocka_unit_test_setup_teardown(duplicate_functions, setup, teardown),
-        cmocka_unit_test_setup_teardown(default_handler, setup, teardown),
-        cmocka_unit_test_setup_teardown(override_default_handler, setup, teardown),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test_setup_teardown(invalid_entries, setup, teardown),
+                cmocka_unit_test_setup_teardown(valid_entries, setup, teardown),
+                cmocka_unit_test_setup_teardown(duplicate_message_ids, setup, teardown),
+                cmocka_unit_test_setup_teardown(duplicate_functions, setup, teardown),
+                cmocka_unit_test_setup_teardown(default_handler, setup, teardown),
+                cmocka_unit_test_setup_teardown(override_default_handler, setup, teardown))

--- a/lib/common/tests/output/pcmk__unregister_formats_test.c
+++ b/lib/common/tests/output/pcmk__unregister_formats_test.c
@@ -34,14 +34,6 @@ non_null_formatters(void **state) {
     assert_null(pcmk__output_formatters());
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(invalid_params),
-        cmocka_unit_test(non_null_formatters),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(invalid_params),
+                cmocka_unit_test(non_null_formatters))

--- a/lib/common/tests/procfs/Makefile.am
+++ b/lib/common/tests/procfs/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = pcmk__procfs_has_pids_false_test	\

--- a/lib/common/tests/procfs/pcmk__procfs_has_pids_false_test.c
+++ b/lib/common/tests/procfs/pcmk__procfs_has_pids_false_test.c
@@ -42,14 +42,8 @@ no_pids(void **state)
 
 #endif // SUPPORT_PROCFS
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
+PCMK__UNIT_TEST(NULL, NULL,
 #if SUPPORT_PROCFS
-        cmocka_unit_test(no_pids),
+                cmocka_unit_test(no_pids)
 #endif
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+               )

--- a/lib/common/tests/procfs/pcmk__procfs_has_pids_true_test.c
+++ b/lib/common/tests/procfs/pcmk__procfs_has_pids_true_test.c
@@ -42,14 +42,8 @@ has_pids(void **state)
 
 #endif // SUPPORT_PROCFS
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
+PCMK__UNIT_TEST(NULL, NULL,
 #if SUPPORT_PROCFS
-        cmocka_unit_test(has_pids),
+                cmocka_unit_test(has_pids)
 #endif
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+               )

--- a/lib/common/tests/procfs/pcmk__procfs_pid2path_test.c
+++ b/lib/common/tests/procfs/pcmk__procfs_pid2path_test.c
@@ -81,16 +81,10 @@ contents_ok(void **state)
 
 #endif // SUPPORT_PROCFS
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
+PCMK__UNIT_TEST(NULL, NULL,
 #if SUPPORT_PROCFS
-        cmocka_unit_test(no_exe_file),
-        cmocka_unit_test(contents_too_long),
-        cmocka_unit_test(contents_ok),
+                cmocka_unit_test(no_exe_file),
+                cmocka_unit_test(contents_too_long),
+                cmocka_unit_test(contents_ok)
 #endif
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+               )

--- a/lib/common/tests/results/Makefile.am
+++ b/lib/common/tests/results/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS =	pcmk__results_test

--- a/lib/common/tests/results/pcmk__results_test.c
+++ b/lib/common/tests/results/pcmk__results_test.c
@@ -52,16 +52,10 @@ test_for_bz2_strerror(void **state) {
     assert_string_equal(bz2_strerror(BZ_STREAM_END), "Ok");
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_for_pcmk_rc_name),
-        cmocka_unit_test(test_for_pcmk_rc_str),
-        cmocka_unit_test(test_for_crm_exit_name),
-        cmocka_unit_test(test_for_crm_exit_str),
-        cmocka_unit_test(test_for_pcmk_rc2exitc),
-        cmocka_unit_test(test_for_bz2_strerror),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(test_for_pcmk_rc_name),
+                cmocka_unit_test(test_for_pcmk_rc_str),
+                cmocka_unit_test(test_for_crm_exit_name),
+                cmocka_unit_test(test_for_crm_exit_str),
+                cmocka_unit_test(test_for_pcmk_rc2exitc),
+                cmocka_unit_test(test_for_bz2_strerror))

--- a/lib/common/tests/scores/Makefile.am
+++ b/lib/common/tests/scores/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS =			\

--- a/lib/common/tests/scores/char2score_test.c
+++ b/lib/common/tests/scores/char2score_test.c
@@ -67,16 +67,9 @@ inside_limits(void **state)
     assert_int_equal(char2score("-1234"), -1234);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input),
-        cmocka_unit_test(bad_input),
-        cmocka_unit_test(special_values),
-        cmocka_unit_test(outside_limits),
-        cmocka_unit_test(inside_limits),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input),
+                cmocka_unit_test(bad_input),
+                cmocka_unit_test(special_values),
+                cmocka_unit_test(outside_limits),
+                cmocka_unit_test(inside_limits))

--- a/lib/common/tests/scores/pcmk__add_scores_test.c
+++ b/lib/common/tests/scores/pcmk__add_scores_test.c
@@ -65,17 +65,10 @@ result_finite(void **state)
     assert_int_equal(pcmk__add_scores(200, -50), 150);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(score1_minus_inf),
-        cmocka_unit_test(score2_minus_inf),
-        cmocka_unit_test(score1_pos_inf),
-        cmocka_unit_test(score2_pos_inf),
-        cmocka_unit_test(result_infinite),
-        cmocka_unit_test(result_finite),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(score1_minus_inf),
+                cmocka_unit_test(score2_minus_inf),
+                cmocka_unit_test(score1_pos_inf),
+                cmocka_unit_test(score2_pos_inf),
+                cmocka_unit_test(result_infinite),
+                cmocka_unit_test(result_finite))

--- a/lib/common/tests/scores/pcmk_readable_score_test.c
+++ b/lib/common/tests/scores/pcmk_readable_score_test.c
@@ -28,13 +28,6 @@ inside_limits(void **state)
     assert_string_equal(pcmk_readable_score(-1024), "-1024");
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(outside_limits),
-        cmocka_unit_test(inside_limits),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(outside_limits),
+                cmocka_unit_test(inside_limits))

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = \

--- a/lib/common/tests/strings/crm_get_msec_test.c
+++ b/lib/common/tests/strings/crm_get_msec_test.c
@@ -44,15 +44,7 @@ overflow(void **state) {
     assert_int_equal(crm_get_msec("9223372036854775807s"), LLONG_MAX);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(bad_input),
-        cmocka_unit_test(good_input),
-        cmocka_unit_test(overflow),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(bad_input),
+                cmocka_unit_test(good_input),
+                cmocka_unit_test(overflow))

--- a/lib/common/tests/strings/crm_is_true_test.c
+++ b/lib/common/tests/strings/crm_is_true_test.c
@@ -51,15 +51,7 @@ is_false(void **state) {
     assert_false(crm_is_true("100"));
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(bad_input),
-        cmocka_unit_test(is_true),
-        cmocka_unit_test(is_false),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(bad_input),
+                cmocka_unit_test(is_true),
+                cmocka_unit_test(is_false))

--- a/lib/common/tests/strings/crm_str_to_boolean_test.c
+++ b/lib/common/tests/strings/crm_str_to_boolean_test.c
@@ -84,17 +84,9 @@ is_not_false(void **state) {
     assert_int_equal(crm_str_to_boolean("000", NULL), -1);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(bad_input),
-        cmocka_unit_test(is_true),
-        cmocka_unit_test(is_not_true),
-        cmocka_unit_test(is_false),
-        cmocka_unit_test(is_not_false),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(bad_input),
+                cmocka_unit_test(is_true),
+                cmocka_unit_test(is_not_true),
+                cmocka_unit_test(is_false),
+                cmocka_unit_test(is_not_false))

--- a/lib/common/tests/strings/pcmk__add_word_test.c
+++ b/lib/common/tests/strings/pcmk__add_word_test.c
@@ -85,18 +85,10 @@ add_with_comma_and_space(void **state)
     free(list);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(add_words),
-        cmocka_unit_test(add_with_no_len),
-        cmocka_unit_test(add_nothing),
-        cmocka_unit_test(add_with_null),
-        cmocka_unit_test(add_with_comma),
-        cmocka_unit_test(add_with_comma_and_space),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(add_words),
+                cmocka_unit_test(add_with_no_len),
+                cmocka_unit_test(add_nothing),
+                cmocka_unit_test(add_with_null),
+                cmocka_unit_test(add_with_comma),
+                cmocka_unit_test(add_with_comma_and_space))

--- a/lib/common/tests/strings/pcmk__btoa_test.c
+++ b/lib/common/tests/strings/pcmk__btoa_test.c
@@ -18,13 +18,5 @@ btoa(void **state) {
     assert_string_equal(pcmk__btoa(1 == 0), "false");
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(btoa),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(btoa))

--- a/lib/common/tests/strings/pcmk__char_in_any_str_test.c
+++ b/lib/common/tests/strings/pcmk__char_in_any_str_test.c
@@ -39,16 +39,8 @@ not_in_list(void **state)
     assert_false(pcmk__char_in_any_str('x', "", NULL));
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_list),
-        cmocka_unit_test(null_char),
-        cmocka_unit_test(in_list),
-        cmocka_unit_test(not_in_list),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
-
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_list),
+                cmocka_unit_test(null_char),
+                cmocka_unit_test(in_list),
+                cmocka_unit_test(not_in_list))

--- a/lib/common/tests/strings/pcmk__compress_test.c
+++ b/lib/common/tests/strings/pcmk__compress_test.c
@@ -52,15 +52,7 @@ calloc_fails(void **state) {
     );
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(simple_compress),
-        cmocka_unit_test(max_too_small),
-        cmocka_unit_test(calloc_fails),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(simple_compress),
+                cmocka_unit_test(max_too_small),
+                cmocka_unit_test(calloc_fails))

--- a/lib/common/tests/strings/pcmk__ends_with_test.c
+++ b/lib/common/tests/strings/pcmk__ends_with_test.c
@@ -51,15 +51,7 @@ ends_with_ext(void **state) {
     assert_false(pcmk__ends_with_ext("ab.c", ".C"));
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(bad_input),
-        cmocka_unit_test(ends_with),
-        cmocka_unit_test(ends_with_ext),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(bad_input),
+                cmocka_unit_test(ends_with),
+                cmocka_unit_test(ends_with_ext))

--- a/lib/common/tests/strings/pcmk__guint_from_hash_test.c
+++ b/lib/common/tests/strings/pcmk__guint_from_hash_test.c
@@ -69,14 +69,8 @@ conversion_errors(void **state)
     g_hash_table_destroy(tbl);
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(null_args),
-        cmocka_unit_test(missing_key),
-        cmocka_unit_test(standard_usage),
-        cmocka_unit_test(conversion_errors),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(null_args),
+                cmocka_unit_test(missing_key),
+                cmocka_unit_test(standard_usage),
+                cmocka_unit_test(conversion_errors))

--- a/lib/common/tests/strings/pcmk__numeric_strcasecmp_test.c
+++ b/lib/common/tests/strings/pcmk__numeric_strcasecmp_test.c
@@ -63,16 +63,8 @@ unequal_lengths(void **state)
     assert_int_equal(pcmk__numeric_strcasecmp("node1abc", "node1ab"), 1);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(no_numbers),
-        cmocka_unit_test(trailing_numbers),
-        cmocka_unit_test(middle_numbers),
-        cmocka_unit_test(unequal_lengths),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(no_numbers),
+                cmocka_unit_test(trailing_numbers),
+                cmocka_unit_test(middle_numbers),
+                cmocka_unit_test(unequal_lengths))

--- a/lib/common/tests/strings/pcmk__parse_ll_range_test.c
+++ b/lib/common/tests/strings/pcmk__parse_ll_range_test.c
@@ -104,21 +104,13 @@ strtoll_errors(void **state)
     assert_int_equal(pcmk__parse_ll_range("100-20000000000000000000", &start, &end), pcmk_rc_unknown_format);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input_string),
-        cmocka_unit_test(null_input_variables),
-        cmocka_unit_test(missing_separator),
-        cmocka_unit_test(only_separator),
-        cmocka_unit_test(no_range_end),
-        cmocka_unit_test(no_range_start),
-        cmocka_unit_test(range_start_and_end),
-        cmocka_unit_test(strtoll_errors),
-
-        cmocka_unit_test(garbage),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input_string),
+                cmocka_unit_test(null_input_variables),
+                cmocka_unit_test(missing_separator),
+                cmocka_unit_test(only_separator),
+                cmocka_unit_test(no_range_end),
+                cmocka_unit_test(no_range_start),
+                cmocka_unit_test(range_start_and_end),
+                cmocka_unit_test(strtoll_errors),
+                cmocka_unit_test(garbage))

--- a/lib/common/tests/strings/pcmk__s_test.c
+++ b/lib/common/tests/strings/pcmk__s_test.c
@@ -24,14 +24,6 @@ s_is_not_null(void **state) {
     assert_string_equal(pcmk__s("something", "default"), "something");
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(s_is_null),
-        cmocka_unit_test(s_is_not_null),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(s_is_null),
+                cmocka_unit_test(s_is_not_null))

--- a/lib/common/tests/strings/pcmk__scan_double_test.c
+++ b/lib/common/tests/strings/pcmk__scan_double_test.c
@@ -148,22 +148,11 @@ double_underflow(void **state)
     assert_true(result >= -DBL_MIN);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        // Test for input string issues
-        cmocka_unit_test(empty_input_string),
-        cmocka_unit_test(bad_input_string),
-        cmocka_unit_test(trailing_chars),
-        cmocka_unit_test(no_result_variable),
-
-        // Test for numeric issues
-        cmocka_unit_test(typical_case),
-        cmocka_unit_test(double_overflow),
-        cmocka_unit_test(double_underflow),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
-
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input_string),
+                cmocka_unit_test(bad_input_string),
+                cmocka_unit_test(trailing_chars),
+                cmocka_unit_test(no_result_variable),
+                cmocka_unit_test(typical_case),
+                cmocka_unit_test(double_overflow),
+                cmocka_unit_test(double_underflow))

--- a/lib/common/tests/strings/pcmk__scan_min_int_test.c
+++ b/lib/common/tests/strings/pcmk__scan_min_int_test.c
@@ -53,16 +53,8 @@ input_just_right(void **state)
     assert_int_equal(result, 2048);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input_string),
-        cmocka_unit_test(input_below_minimum),
-        cmocka_unit_test(input_above_maximum),
-        cmocka_unit_test(input_just_right),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
-
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input_string),
+                cmocka_unit_test(input_below_minimum),
+                cmocka_unit_test(input_above_maximum),
+                cmocka_unit_test(input_just_right))

--- a/lib/common/tests/strings/pcmk__scan_port_test.c
+++ b/lib/common/tests/strings/pcmk__scan_port_test.c
@@ -52,16 +52,8 @@ typical_case(void **state)
     assert_int_equal(result, 80);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input_string),
-        cmocka_unit_test(bad_input_string),
-        cmocka_unit_test(out_of_range),
-        cmocka_unit_test(typical_case),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
-
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input_string),
+                cmocka_unit_test(bad_input_string),
+                cmocka_unit_test(out_of_range),
+                cmocka_unit_test(typical_case))

--- a/lib/common/tests/strings/pcmk__starts_with_test.c
+++ b/lib/common/tests/strings/pcmk__starts_with_test.c
@@ -30,14 +30,6 @@ starts_with(void **state) {
     assert_true(pcmk__starts_with("xyz", ""));
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(bad_input),
-        cmocka_unit_test(starts_with),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(bad_input),
+                cmocka_unit_test(starts_with))

--- a/lib/common/tests/strings/pcmk__str_any_of_test.c
+++ b/lib/common/tests/strings/pcmk__str_any_of_test.c
@@ -41,15 +41,8 @@ not_in_list(void **state) {
     assert_false(pcmk__str_any_of("AAA", "aaa", "bbb", NULL));
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input_list),
-        cmocka_unit_test(empty_string),
-        cmocka_unit_test(in_list),
-        cmocka_unit_test(not_in_list),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input_list),
+                cmocka_unit_test(empty_string),
+                cmocka_unit_test(in_list),
+                cmocka_unit_test(not_in_list))

--- a/lib/common/tests/strings/pcmk__str_in_list_test.c
+++ b/lib/common/tests/strings/pcmk__str_in_list_test.c
@@ -98,17 +98,10 @@ not_in_list(void **state) {
     g_list_free(list);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input_list),
-        cmocka_unit_test(empty_string),
-        cmocka_unit_test(star_matches),
-        cmocka_unit_test(star_doesnt_match),
-        cmocka_unit_test(in_list),
-        cmocka_unit_test(not_in_list),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input_list),
+                cmocka_unit_test(empty_string),
+                cmocka_unit_test(star_matches),
+                cmocka_unit_test(star_doesnt_match),
+                cmocka_unit_test(in_list),
+                cmocka_unit_test(not_in_list))

--- a/lib/common/tests/strings/pcmk__str_table_dup_test.c
+++ b/lib/common/tests/strings/pcmk__str_table_dup_test.c
@@ -53,13 +53,7 @@ regular_input_table(void **state)
     g_hash_table_destroy(copy);
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(null_input_table),
-        cmocka_unit_test(empty_input_table),
-        cmocka_unit_test(regular_input_table),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(null_input_table),
+                cmocka_unit_test(empty_input_table),
+                cmocka_unit_test(regular_input_table))

--- a/lib/common/tests/strings/pcmk__str_update_test.c
+++ b/lib/common/tests/strings/pcmk__str_update_test.c
@@ -71,16 +71,8 @@ strdup_fails(void **state) {
     free(str);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(update_null),
-        cmocka_unit_test(update_same),
-        cmocka_unit_test(update_different),
-        cmocka_unit_test(strdup_fails),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(update_null),
+                cmocka_unit_test(update_same),
+                cmocka_unit_test(update_different),
+                cmocka_unit_test(strdup_fails))

--- a/lib/common/tests/strings/pcmk__strcmp_test.c
+++ b/lib/common/tests/strings/pcmk__strcmp_test.c
@@ -72,15 +72,9 @@ regex(void **state) {
     assert_true(pcmk__strcmp(s2, "*ab", pcmk__str_regex) > 0);
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(same_pointer),
-        cmocka_unit_test(one_is_null),
-        cmocka_unit_test(case_matters),
-        cmocka_unit_test(case_insensitive),
-        cmocka_unit_test(regex),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(same_pointer),
+                cmocka_unit_test(one_is_null),
+                cmocka_unit_test(case_matters),
+                cmocka_unit_test(case_insensitive),
+                cmocka_unit_test(regex))

--- a/lib/common/tests/strings/pcmk__strikey_table_test.c
+++ b/lib/common/tests/strings/pcmk__strikey_table_test.c
@@ -36,11 +36,5 @@ store_strs(void **state)
     g_hash_table_destroy(tbl);
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(store_strs),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(store_strs))

--- a/lib/common/tests/strings/pcmk__strkey_table_test.c
+++ b/lib/common/tests/strings/pcmk__strkey_table_test.c
@@ -36,11 +36,5 @@ store_strs(void **state)
     g_hash_table_destroy(tbl);
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(store_strs),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(store_strs))

--- a/lib/common/tests/strings/pcmk__trim_test.c
+++ b/lib/common/tests/strings/pcmk__trim_test.c
@@ -64,15 +64,9 @@ other_whitespace(void **state)
     free(s);
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input),
-        cmocka_unit_test(leading_newline),
-        cmocka_unit_test(middle_newline),
-        cmocka_unit_test(trailing_newline),
-        cmocka_unit_test(other_whitespace),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input),
+                cmocka_unit_test(leading_newline),
+                cmocka_unit_test(middle_newline),
+                cmocka_unit_test(trailing_newline),
+                cmocka_unit_test(other_whitespace))

--- a/lib/common/tests/utils/Makefile.am
+++ b/lib/common/tests/utils/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS =				\

--- a/lib/common/tests/utils/compare_version_test.c
+++ b/lib/common/tests/utils/compare_version_test.c
@@ -48,15 +48,8 @@ shorter_versions(void **state)
     assert_int_equal(compare_version("1.0.1", "1.0"), 1);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_params),
-        cmocka_unit_test(equal_versions),
-        cmocka_unit_test(unequal_versions),
-        cmocka_unit_test(shorter_versions),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_params),
+                cmocka_unit_test(equal_versions),
+                cmocka_unit_test(unequal_versions),
+                cmocka_unit_test(shorter_versions))

--- a/lib/common/tests/utils/crm_meta_name_test.c
+++ b/lib/common/tests/utils/crm_meta_name_test.c
@@ -36,13 +36,6 @@ standard_usage(void **state)
     free(s);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_params),
-        cmocka_unit_test(standard_usage),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_params),
+                cmocka_unit_test(standard_usage))

--- a/lib/common/tests/utils/crm_meta_value_test.c
+++ b/lib/common/tests/utils/crm_meta_value_test.c
@@ -50,14 +50,7 @@ key_in_table(void **state)
     g_hash_table_destroy(tbl);
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_params),
-        cmocka_unit_test(key_not_in_table),
-        cmocka_unit_test(key_in_table),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_params),
+                cmocka_unit_test(key_not_in_table),
+                cmocka_unit_test(key_in_table))

--- a/lib/common/tests/utils/crm_user_lookup_test.c
+++ b/lib/common/tests/utils/crm_user_lookup_test.c
@@ -120,15 +120,8 @@ entry_found(void **state)
     pcmk__mock_getpwnam_r = false;
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(calloc_fails),
-        cmocka_unit_test(getpwnam_r_fails),
-        cmocka_unit_test(no_matching_pwent),
-        cmocka_unit_test(entry_found),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(calloc_fails),
+                cmocka_unit_test(getpwnam_r_fails),
+                cmocka_unit_test(no_matching_pwent),
+                cmocka_unit_test(entry_found))

--- a/lib/common/tests/utils/pcmk__getpid_s_test.c
+++ b/lib/common/tests/utils/pcmk__getpid_s_test.c
@@ -34,13 +34,5 @@ pcmk__getpid_s_test(void **state)
     pcmk__mock_getpid = false;
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(pcmk__getpid_s_test),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(pcmk__getpid_s_test))

--- a/lib/common/tests/utils/pcmk_daemon_user_test.c
+++ b/lib/common/tests/utils/pcmk_daemon_user_test.c
@@ -78,13 +78,6 @@ entry_found(void **state)
     pcmk__mock_getpwnam_r = false;
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(no_matching_pwent),
-        cmocka_unit_test(entry_found),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(no_matching_pwent),
+                cmocka_unit_test(entry_found))

--- a/lib/common/tests/utils/pcmk_hostname_test.c
+++ b/lib/common/tests/utils/pcmk_hostname_test.c
@@ -51,14 +51,6 @@ uname_failed_test(void **state)
     pcmk__mock_uname = false;
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(uname_succeeded_test),
-        cmocka_unit_test(uname_failed_test),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(uname_succeeded_test),
+                cmocka_unit_test(uname_failed_test))

--- a/lib/common/tests/utils/pcmk_str_is_infinity_test.c
+++ b/lib/common/tests/utils/pcmk_str_is_infinity_test.c
@@ -49,16 +49,9 @@ minus_infinity_fails(void **state)
     assert_false(pcmk_str_is_infinity("-INFINITY"));
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(uppercase_str_passes),
-        cmocka_unit_test(mixed_case_str_fails),
-        cmocka_unit_test(added_whitespace_fails),
-        cmocka_unit_test(empty_str_fails),
-        cmocka_unit_test(minus_infinity_fails),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(uppercase_str_passes),
+                cmocka_unit_test(mixed_case_str_fails),
+                cmocka_unit_test(added_whitespace_fails),
+                cmocka_unit_test(empty_str_fails),
+                cmocka_unit_test(minus_infinity_fails))

--- a/lib/common/tests/utils/pcmk_str_is_minus_infinity_test.c
+++ b/lib/common/tests/utils/pcmk_str_is_minus_infinity_test.c
@@ -46,16 +46,9 @@ infinity_fails(void **state)
     assert_false(pcmk_str_is_minus_infinity("INFINITY"));
 }
 
-int main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(uppercase_str_passes),
-        cmocka_unit_test(mixed_case_str_fails),
-        cmocka_unit_test(added_whitespace_fails),
-        cmocka_unit_test(empty_str_fails),
-        cmocka_unit_test(infinity_fails),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(uppercase_str_passes),
+                cmocka_unit_test(mixed_case_str_fails),
+                cmocka_unit_test(added_whitespace_fails),
+                cmocka_unit_test(empty_str_fails),
+                cmocka_unit_test(infinity_fails))

--- a/lib/common/tests/xpath/Makefile.am
+++ b/lib/common/tests/xpath/Makefile.am
@@ -7,15 +7,8 @@
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include		\
-	      -I$(top_builddir)/include		\
-	      -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-	-lcmocka
-AM_CFLAGS = -DPCMK__UNIT_TESTING
-AM_LDFLAGS = $(LDFLAGS_WRAP)
-
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS =	pcmk__xpath_node_id_test

--- a/lib/common/tests/xpath/pcmk__xpath_node_id_test.c
+++ b/lib/common/tests/xpath/pcmk__xpath_node_id_test.c
@@ -45,16 +45,8 @@ present(void **state) {
     free(s);
 }
 
-int
-main(int argc, char **argv)
-{
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_input),
-        cmocka_unit_test(no_quotes),
-        cmocka_unit_test(not_present),
-        cmocka_unit_test(present),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_input),
+                cmocka_unit_test(no_quotes),
+                cmocka_unit_test(not_present),
+                cmocka_unit_test(present))

--- a/lib/pengine/tests/native/Makefile.am
+++ b/lib/pengine/tests/native/Makefile.am
@@ -6,14 +6,12 @@
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include \
-			  -I$(top_builddir) -I$(top_srcdir)
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-		$(top_builddir)/lib/pengine/libpe_status_test.la \
-		-lcmocka
-AM_LDFLAGS = $(LDFLAGS_WRAP)
 
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
+
+AM_CPPFLAGS += -I$(top_srcdir)
+LDADD += $(top_builddir)/lib/pengine/libpe_status_test.la
 
 AM_TESTS_ENVIRONMENT += PCMK_CTS_CLI_DIR=$(top_srcdir)/cts/cli
 

--- a/lib/pengine/tests/native/native_find_rsc_test.c
+++ b/lib/pengine/tests/native/native_find_rsc_test.c
@@ -656,29 +656,22 @@ clone_group_member_rsc(void **state) {
     assert_ptr_equal(mysql_proxy, native_find_rsc(mysql_proxy, "mysql-proxy:0", cluster02, pe_find_current));
 }
 
-int main(int argc, char **argv) {
-    /* TODO: Add tests for finding on allocated node (passing a node without
-     * pe_find_current, after scheduling, for a resource that is starting/stopping/moving.
-     */
-
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(bad_args),
-        cmocka_unit_test(primitive_rsc),
-        cmocka_unit_test(group_rsc),
-        cmocka_unit_test(inactive_group_rsc),
-        cmocka_unit_test(group_member_rsc),
-        cmocka_unit_test(inactive_group_member_rsc),
-        cmocka_unit_test(clone_rsc),
-        cmocka_unit_test(inactive_clone_rsc),
-        cmocka_unit_test(clone_instance_rsc),
-        cmocka_unit_test(renamed_rsc),
-        cmocka_unit_test(bundle_rsc),
-        cmocka_unit_test(bundle_replica_rsc),
-        cmocka_unit_test(clone_group_rsc),
-        cmocka_unit_test(clone_group_instance_rsc),
-        cmocka_unit_test(clone_group_member_rsc),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, setup, teardown);
-}
+/* TODO: Add tests for finding on allocated node (passing a node without
+ * pe_find_current, after scheduling, for a resource that is starting/stopping/moving.
+ */
+PCMK__UNIT_TEST(setup, teardown,
+                cmocka_unit_test(bad_args),
+                cmocka_unit_test(primitive_rsc),
+                cmocka_unit_test(group_rsc),
+                cmocka_unit_test(inactive_group_rsc),
+                cmocka_unit_test(group_member_rsc),
+                cmocka_unit_test(inactive_group_member_rsc),
+                cmocka_unit_test(clone_rsc),
+                cmocka_unit_test(inactive_clone_rsc),
+                cmocka_unit_test(clone_instance_rsc),
+                cmocka_unit_test(renamed_rsc),
+                cmocka_unit_test(bundle_rsc),
+                cmocka_unit_test(bundle_replica_rsc),
+                cmocka_unit_test(clone_group_rsc),
+                cmocka_unit_test(clone_group_instance_rsc),
+                cmocka_unit_test(clone_group_member_rsc))

--- a/lib/pengine/tests/native/pe_base_name_eq_test.c
+++ b/lib/pengine/tests/native/pe_base_name_eq_test.c
@@ -141,15 +141,9 @@ bundle_rsc(void **state) {
     assert_false(pe_base_name_eq(httpd_bundle, "httpd-docker-0"));
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(bad_args),
-        cmocka_unit_test(primitive_rsc),
-        cmocka_unit_test(group_rsc),
-        cmocka_unit_test(clone_rsc),
-        cmocka_unit_test(bundle_rsc),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, setup, teardown);
-}
+PCMK__UNIT_TEST(setup, teardown,
+                cmocka_unit_test(bad_args),
+                cmocka_unit_test(primitive_rsc),
+                cmocka_unit_test(group_rsc),
+                cmocka_unit_test(clone_rsc),
+                cmocka_unit_test(bundle_rsc))

--- a/lib/pengine/tests/rules/Makefile.am
+++ b/lib/pengine/tests/rules/Makefile.am
@@ -6,13 +6,11 @@
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-		$(top_builddir)/lib/pengine/libpe_rules_test.la \
-		-lcmocka
-AM_LDFLAGS = $(LDFLAGS_WRAP)
 
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
+
+LDADD += $(top_builddir)/lib/pengine/libpe_rules_test.la
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = pe_cron_range_satisfied_test

--- a/lib/pengine/tests/rules/pe_cron_range_satisfied_test.c
+++ b/lib/pengine/tests/rules/pe_cron_range_satisfied_test.c
@@ -111,28 +111,20 @@ time_after_monthdays_range(void **state) {
     run_one_test("2001-06-10", "<date_spec id='spec' years='2001' months='6' monthdays='11-15'/>", pcmk_rc_before_range);
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(no_time_given),
-        cmocka_unit_test(any_time_satisfies_empty_spec),
-        cmocka_unit_test(time_satisfies_year_spec),
-        cmocka_unit_test(time_after_year_spec),
-        cmocka_unit_test(time_satisfies_year_range),
-        cmocka_unit_test(time_before_year_range),
-        cmocka_unit_test(time_after_year_range),
-        cmocka_unit_test(range_without_start_year_passes),
-        cmocka_unit_test(range_without_end_year_passes),
-
-        cmocka_unit_test(yeardays_satisfies),
-        cmocka_unit_test(time_after_yeardays_spec),
-        cmocka_unit_test(yeardays_feb_29_satisfies),
-
-        cmocka_unit_test(exact_ymd_satisfies),
-        cmocka_unit_test(range_in_month_satisfies),
-        cmocka_unit_test(exact_ymd_after_range),
-        cmocka_unit_test(time_after_monthdays_range),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(no_time_given),
+                cmocka_unit_test(any_time_satisfies_empty_spec),
+                cmocka_unit_test(time_satisfies_year_spec),
+                cmocka_unit_test(time_after_year_spec),
+                cmocka_unit_test(time_satisfies_year_range),
+                cmocka_unit_test(time_before_year_range),
+                cmocka_unit_test(time_after_year_range),
+                cmocka_unit_test(range_without_start_year_passes),
+                cmocka_unit_test(range_without_end_year_passes),
+                cmocka_unit_test(yeardays_satisfies),
+                cmocka_unit_test(time_after_yeardays_spec),
+                cmocka_unit_test(yeardays_feb_29_satisfies),
+                cmocka_unit_test(exact_ymd_satisfies),
+                cmocka_unit_test(range_in_month_satisfies),
+                cmocka_unit_test(exact_ymd_after_range),
+                cmocka_unit_test(time_after_monthdays_range))

--- a/lib/pengine/tests/status/Makefile.am
+++ b/lib/pengine/tests/status/Makefile.am
@@ -6,14 +6,11 @@
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
-AM_CPPFLAGS = -I$(top_srcdir)/include \
-			  -I$(top_builddir)/include \
-			  -I$(top_srcdir)/lib/common
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-		$(top_builddir)/lib/pengine/libpe_status_test.la
-AM_LDFLAGS = $(LDFLAGS_WRAP)
 
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
+
+LDADD += $(top_builddir)/lib/pengine/libpe_status_test.la
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = pe_find_node_any_test \

--- a/lib/pengine/tests/status/pe_find_node_any_test.c
+++ b/lib/pengine/tests/status/pe_find_node_any_test.c
@@ -57,12 +57,6 @@ non_null_list(void **state) {
     g_list_free(nodes);
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_list),
-        cmocka_unit_test(non_null_list),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_list),
+                cmocka_unit_test(non_null_list))

--- a/lib/pengine/tests/status/pe_find_node_id_test.c
+++ b/lib/pengine/tests/status/pe_find_node_id_test.c
@@ -46,12 +46,6 @@ non_null_list(void **state) {
     g_list_free(nodes);
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_list),
-        cmocka_unit_test(non_null_list),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_list),
+                cmocka_unit_test(non_null_list))

--- a/lib/pengine/tests/status/pe_find_node_test.c
+++ b/lib/pengine/tests/status/pe_find_node_test.c
@@ -46,12 +46,6 @@ non_null_list(void **state) {
     g_list_free(nodes);
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(empty_list),
-        cmocka_unit_test(non_null_list),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_list),
+                cmocka_unit_test(non_null_list))

--- a/lib/pengine/tests/status/pe_new_working_set_test.c
+++ b/lib/pengine/tests/status/pe_new_working_set_test.c
@@ -41,12 +41,6 @@ calloc_succeeds(void **state) {
     free(data_set);
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(calloc_fails),
-        cmocka_unit_test(calloc_succeeds),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(calloc_fails),
+                cmocka_unit_test(calloc_succeeds))

--- a/lib/pengine/tests/status/set_working_set_defaults_test.c
+++ b/lib/pengine/tests/status/set_working_set_defaults_test.c
@@ -42,11 +42,5 @@ check_defaults(void **state) {
     free(data_set);
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(check_defaults),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(check_defaults))

--- a/lib/pengine/tests/unpack/Makefile.am
+++ b/lib/pengine/tests/unpack/Makefile.am
@@ -6,13 +6,11 @@
 # This source code is licensed under the GNU General Public License version 2
 # or later (GPLv2+) WITHOUT ANY WARRANTY.
 #
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
-LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
-		$(top_builddir)/lib/pengine/libpe_status_test.la \
-		-lcmocka
-AM_LDFLAGS = $(LDFLAGS_WRAP)
 
 include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
+
+LDADD += $(top_builddir)/lib/pengine/libpe_status_test.la
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = pe_base_name_end_test

--- a/lib/pengine/tests/unpack/pe_base_name_end_test.c
+++ b/lib/pengine/tests/unpack/pe_base_name_end_test.c
@@ -30,13 +30,7 @@ has_suffix(void **state) {
     assert_string_equal(pe_base_name_end("rsc:100"), "c:100");
 }
 
-int main(int argc, char **argv) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(bad_args),
-        cmocka_unit_test(no_suffix),
-        cmocka_unit_test(has_suffix),
-    };
-
-    cmocka_set_message_output(CM_OUTPUT_TAP);
-    return cmocka_run_group_tests(tests, NULL, NULL);
-}
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(bad_args),
+                cmocka_unit_test(no_suffix),
+                cmocka_unit_test(has_suffix))

--- a/mk/unittest.mk
+++ b/mk/unittest.mk
@@ -1,0 +1,19 @@
+#
+# Copyright 2022 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+#
+
+AM_CPPFLAGS = -I$(top_builddir)/include		\
+	      -I$(top_srcdir)/include		\
+	      -I$(top_srcdir)/lib/common
+
+AM_CFLAGS = -DPCMK__UNIT_TESTING
+
+AM_LDFLAGS = $(LDFLAGS_WRAP)
+
+LDADD = $(top_builddir)/lib/common/libcrmcommon_test.la \
+	-lcmocka


### PR DESCRIPTION
This can be left until after other unit test PRs get merged.  I'll have to update it, but I don't want to keep blocking those other PRs with my changes.