### PR TITLE
Test: Check for expected arguments in mocked functions

### DIFF
--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -291,4 +291,10 @@ int pcmk__crm_ipc_is_authentic_process(qb_ipcc_connection_t *qb_ipc, int sock, u
                                        pid_t *gotpid, uid_t *gotuid, gid_t *gotgid);
 
 
+/*
+ * Utils
+ */
+#define PCMK__PW_BUFFER_LEN 500
+
+
 #endif  // CRMCOMMON_PRIVATE__H

--- a/lib/common/mock.c
+++ b/lib/common/mock.c
@@ -338,8 +338,11 @@ __wrap_strdup(const char *s)
  * If pcmk__mock_uname is set to true, later calls to uname() must be preceded
  * by:
  *
+ *     expect_*(__wrap_uname, buf[, ...]);
  *     will_return(__wrap_uname, return_value);
  *     will_return(__wrap_uname, node_name_for_buf_parameter_to_uname);
+ *
+ * expect_* functions: https://api.cmocka.org/group__cmocka__param.html
  */
 
 bool pcmk__mock_uname = false;
@@ -348,8 +351,12 @@ int
 __wrap_uname(struct utsname *buf)
 {
     if (pcmk__mock_uname) {
-        int retval = mock_type(int);
-        char *result = mock_ptr_type(char *);
+        int retval = 0;
+        char *result = NULL;
+
+        check_expected_ptr(buf);
+        retval = mock_type(int);
+        result = mock_ptr_type(char *);
 
         if (result != NULL) {
             strcpy(buf->nodename, result);

--- a/lib/common/mock.c
+++ b/lib/common/mock.c
@@ -272,8 +272,13 @@ __wrap_getpwnam_r(const char *name, struct passwd *pwd, char *buf,
  * If pcmk__mock_readlink is set to true, later calls to readlink() must be
  * preceded by:
  *
+ *     expect_*(__wrap_readlink, path[, ...]);
+ *     expect_*(__wrap_readlink, buf[, ...]);
+ *     expect_*(__wrap_readlink, bufsize[, ...]);
  *     will_return(__wrap_readlink, errno_to_set);
  *     will_return(__wrap_readlink, link_contents);
+ *
+ * expect_* functions: https://api.cmocka.org/group__cmocka__param.html
  *
  * The mocked function will return 0 if errno_to_set is 0, and -1 otherwise.
  */
@@ -287,6 +292,9 @@ __wrap_readlink(const char *restrict path, char *restrict buf,
     if (pcmk__mock_readlink) {
         const char *contents = NULL;
 
+        check_expected_ptr(path);
+        check_expected_ptr(buf);
+        check_expected(bufsize);
         errno = mock_type(int);
         contents = mock_ptr_type(const char *);
 

--- a/lib/common/mock.c
+++ b/lib/common/mock.c
@@ -73,7 +73,10 @@ __wrap_calloc(size_t nmemb, size_t size)
  * If pcmk__mock_getenv is set to true, later calls to getenv() must be preceded
  * by:
  *
+ *     expect_*(__wrap_getenv, name[, ...]);
  *     will_return(__wrap_getenv, return_value);
+ *
+ * expect_* functions: https://api.cmocka.org/group__cmocka__param.html
  */
 
 bool pcmk__mock_getenv = false;
@@ -81,7 +84,11 @@ bool pcmk__mock_getenv = false;
 char *
 __wrap_getenv(const char *name)
 {
-    return pcmk__mock_getenv? mock_ptr_type(char *) : __real_getenv(name);
+    if (!pcmk__mock_getenv) {
+        return __real_getenv(name);
+    }
+    check_expected_ptr(name);
+    return mock_ptr_type(char *);
 }
 
 

--- a/lib/common/mock.c
+++ b/lib/common/mock.c
@@ -201,7 +201,11 @@ __wrap_endgrent(void) {
  * If pcmk__mock_fopen is set to true, later calls to fopen() must be
  * preceded by:
  *
+ *     expect_*(__wrap_fopen, pathname[, ...]);
+ *     expect_*(__wrap_fopen, mode[, ...]);
  *     will_return(__wrap_fopen, errno_to_set);
+ *
+ * expect_* functions: https://api.cmocka.org/group__cmocka__param.html
  */
 
 bool pcmk__mock_fopen = false;
@@ -210,6 +214,8 @@ FILE *
 __wrap_fopen(const char *pathname, const char *mode)
 {
     if (pcmk__mock_fopen) {
+        check_expected_ptr(pathname);
+        check_expected_ptr(mode);
         errno = mock_type(int);
 
         if (errno != 0) {

--- a/lib/common/mock.c
+++ b/lib/common/mock.c
@@ -313,7 +313,11 @@ __wrap_readlink(const char *restrict path, char *restrict buf,
 /* strdup()
  *
  * If pcmk__mock_strdup is set to true, later calls to strdup() will return
- * NULL.
+ * NULL and must be preceded by:
+ *
+ *     expect_*(__wrap_strdup, s[, ...]);
+ *
+ * expect_* functions: https://api.cmocka.org/group__cmocka__param.html
  */
 
 bool pcmk__mock_strdup = false;
@@ -321,7 +325,11 @@ bool pcmk__mock_strdup = false;
 char *
 __wrap_strdup(const char *s)
 {
-    return pcmk__mock_strdup? NULL : __real_strdup(s);
+    if (!pcmk__mock_strdup) {
+        return __real_strdup(s);
+    }
+    check_expected_ptr(s);
+    return NULL;
 }
 
 

--- a/lib/common/mock.c
+++ b/lib/common/mock.c
@@ -52,11 +52,15 @@
  */
 
 // LCOV_EXCL_START
-
 /* calloc()
  *
- * If pcmk__mock_calloc is set to true, later calls to malloc() will return
- * NULL.
+ * If pcmk__mock_calloc is set to true, later calls to calloc() will return
+ * NULL and must be preceded by:
+ *
+ *     expect_*(__wrap_calloc, nmemb[, ...]);
+ *     expect_*(__wrap_calloc, size[, ...]);
+ *
+ * expect_* functions: https://api.cmocka.org/group__cmocka__param.html
  */
 
 bool pcmk__mock_calloc = false;
@@ -64,7 +68,12 @@ bool pcmk__mock_calloc = false;
 void *
 __wrap_calloc(size_t nmemb, size_t size)
 {
-    return pcmk__mock_calloc? NULL : __real_calloc(nmemb, size);
+    if (!pcmk__mock_calloc) {
+        return __real_calloc(nmemb, size);
+    }
+    check_expected(nmemb);
+    check_expected(size);
+    return NULL;
 }
 
 

--- a/lib/common/mock.c
+++ b/lib/common/mock.c
@@ -235,8 +235,15 @@ __wrap_fopen(const char *pathname, const char *mode)
  * If pcmk__mock_getpwnam_r is set to true, later calls to getpwnam_r() must be
  * preceded by:
  *
+ *     expect_*(__wrap_getpwnam_r, name[, ...]);
+ *     expect_*(__wrap_getpwnam_r, pwd[, ...]);
+ *     expect_*(__wrap_getpwnam_r, buf[, ...]);
+ *     expect_*(__wrap_getpwnam_r, buflen[, ...]);
+ *     expect_*(__wrap_getpwnam_r, result[, ...]);
  *     will_return(__wrap_getpwnam_r, return_value);
  *     will_return(__wrap_getpwnam_r, ptr_to_result_struct);
+ *
+ * expect_* functions: https://api.cmocka.org/group__cmocka__param.html
  */
 
 bool pcmk__mock_getpwnam_r = false;
@@ -248,6 +255,11 @@ __wrap_getpwnam_r(const char *name, struct passwd *pwd, char *buf,
     if (pcmk__mock_getpwnam_r) {
         int retval = mock_type(int);
 
+        check_expected_ptr(name);
+        check_expected_ptr(pwd);
+        check_expected_ptr(buf);
+        check_expected(buflen);
+        check_expected_ptr(result);
         *result = mock_ptr_type(struct passwd *);
         return retval;
 

--- a/lib/common/tests/io/pcmk__full_path_test.c
+++ b/lib/common/tests/io/pcmk__full_path_test.c
@@ -19,9 +19,14 @@ function_asserts(void **state)
     pcmk__assert_asserts(pcmk__full_path(NULL, "/dir"));
     pcmk__assert_asserts(pcmk__full_path("file", NULL));
 
-    pcmk__mock_strdup = true;       // strdup() will return NULL
-    pcmk__assert_asserts(pcmk__full_path("/full/path", "/dir"));
-    pcmk__mock_strdup = false;      // Use real strdup()
+    pcmk__assert_asserts(
+        {
+            pcmk__mock_strdup = true;   // strdup() will return NULL
+            expect_string(__wrap_strdup, s, "/full/path");
+            pcmk__full_path("/full/path", "/dir");
+            pcmk__mock_strdup = false;  // Use real strdup()
+        }
+    );
 }
 
 static void

--- a/lib/common/tests/io/pcmk__get_tmpdir_test.c
+++ b/lib/common/tests/io/pcmk__get_tmpdir_test.c
@@ -20,14 +20,17 @@ getenv_returns_invalid(void **state)
 
     pcmk__mock_getenv = true;
 
+    expect_string(__wrap_getenv, name, "TMPDIR");
     will_return(__wrap_getenv, NULL);                   // getenv("TMPDIR") return value
     result = pcmk__get_tmpdir();
     assert_string_equal(result, "/tmp");
 
+    expect_string(__wrap_getenv, name, "TMPDIR");
     will_return(__wrap_getenv, "");                     // getenv("TMPDIR") return value
     result = pcmk__get_tmpdir();
     assert_string_equal(result, "/tmp");
 
+    expect_string(__wrap_getenv, name, "TMPDIR");
     will_return(__wrap_getenv, "subpath");              // getenv("TMPDIR") return value
     result = pcmk__get_tmpdir();
     assert_string_equal(result, "/tmp");
@@ -42,14 +45,17 @@ getenv_returns_valid(void **state)
 
     pcmk__mock_getenv = true;
 
+    expect_string(__wrap_getenv, name, "TMPDIR");
     will_return(__wrap_getenv, "/var/tmp");             // getenv("TMPDIR") return value
     result = pcmk__get_tmpdir();
     assert_string_equal(result, "/var/tmp");
 
+    expect_string(__wrap_getenv, name, "TMPDIR");
     will_return(__wrap_getenv, "/");                    // getenv("TMPDIR") return value
     result = pcmk__get_tmpdir();
     assert_string_equal(result, "/");
 
+    expect_string(__wrap_getenv, name, "TMPDIR");
     will_return(__wrap_getenv, "/tmp/abcd.1234");       // getenv("TMPDIR") return value
     result = pcmk__get_tmpdir();
     assert_string_equal(result, "/tmp/abcd.1234");

--- a/lib/common/tests/output/pcmk__output_new_test.c
+++ b/lib/common/tests/output/pcmk__output_new_test.c
@@ -83,6 +83,8 @@ create_fails(void **state) {
 
     pcmk__mock_calloc = true;   // calloc() will return NULL
 
+    expect_value(__wrap_calloc, nmemb, 1);
+    expect_value(__wrap_calloc, size, sizeof(pcmk__output_t));
     assert_int_equal(pcmk__output_new(&out, "text", NULL, NULL), ENOMEM);
 
     pcmk__mock_calloc = false;  // Use real calloc()

--- a/lib/common/tests/output/pcmk__output_new_test.c
+++ b/lib/common/tests/output/pcmk__output_new_test.c
@@ -95,6 +95,8 @@ fopen_fails(void **state) {
     pcmk__output_t *out = NULL;
 
     pcmk__mock_fopen = true;
+    expect_string(__wrap_fopen, pathname, "destfile");
+    expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, EPERM);
 
     assert_int_equal(pcmk__output_new(&out, "text", "destfile", NULL), EPERM);

--- a/lib/common/tests/procfs/pcmk__procfs_has_pids_false_test.c
+++ b/lib/common/tests/procfs/pcmk__procfs_has_pids_false_test.c
@@ -22,8 +22,16 @@
 static void
 no_pids(void **state)
 {
+    char path[PATH_MAX];
+
+    snprintf(path, PATH_MAX, "/proc/%u/exe", getpid());
+
     // Set readlink() errno and link contents (for /proc/PID/exe)
     pcmk__mock_readlink = true;
+
+    expect_string(__wrap_readlink, path, path);
+    expect_any(__wrap_readlink, buf);
+    expect_value(__wrap_readlink, bufsize, PATH_MAX - 1);
     will_return(__wrap_readlink, ENOENT);
     will_return(__wrap_readlink, NULL);
 

--- a/lib/common/tests/procfs/pcmk__procfs_has_pids_true_test.c
+++ b/lib/common/tests/procfs/pcmk__procfs_has_pids_true_test.c
@@ -22,8 +22,16 @@
 static void
 has_pids(void **state)
 {
+    char path[PATH_MAX];
+
+    snprintf(path, PATH_MAX, "/proc/%u/exe", getpid());
+
     // Set readlink() errno and link contents (for /proc/PID/exe)
     pcmk__mock_readlink = true;
+
+    expect_string(__wrap_readlink, path, path);
+    expect_any(__wrap_readlink, buf);
+    expect_value(__wrap_readlink, bufsize, PATH_MAX - 1);
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, "/ok");
 

--- a/lib/common/tests/procfs/pcmk__procfs_pid2path_test.c
+++ b/lib/common/tests/procfs/pcmk__procfs_pid2path_test.c
@@ -26,6 +26,10 @@ no_exe_file(void **state)
 
     // Set readlink() errno and link contents
     pcmk__mock_readlink = true;
+
+    expect_string(__wrap_readlink, path, "/proc/1000/exe");
+    expect_value(__wrap_readlink, buf, path);
+    expect_value(__wrap_readlink, bufsize, sizeof(path) - 1);
     will_return(__wrap_readlink, ENOENT);
     will_return(__wrap_readlink, NULL);
 
@@ -41,6 +45,10 @@ contents_too_long(void **state)
 
     // Set readlink() errno and link contents
     pcmk__mock_readlink = true;
+
+    expect_string(__wrap_readlink, path, "/proc/1000/exe");
+    expect_value(__wrap_readlink, buf, path);
+    expect_value(__wrap_readlink, bufsize, sizeof(path) - 1);
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, "/more/than/10/characters");
 
@@ -57,6 +65,10 @@ contents_ok(void **state)
 
     // Set readlink() errno and link contents
     pcmk__mock_readlink = true;
+
+    expect_string(__wrap_readlink, path, "/proc/1000/exe");
+    expect_value(__wrap_readlink, buf, path);
+    expect_value(__wrap_readlink, bufsize, sizeof(path) - 1);
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, "/ok");
 

--- a/lib/common/tests/strings/pcmk__compress_test.c
+++ b/lib/common/tests/strings/pcmk__compress_test.c
@@ -41,9 +41,15 @@ calloc_fails(void **state) {
     char *result = calloc(1024, sizeof(char));
     unsigned int len;
 
-    pcmk__mock_calloc = true;   // calloc() will return NULL
-    pcmk__assert_asserts(pcmk__compress(SIMPLE_DATA, 40, 0, &result, &len));
-    pcmk__mock_calloc = false;  // Use the real calloc()
+    pcmk__assert_asserts(
+        {
+            pcmk__mock_calloc = true;   // calloc() will return NULL
+            expect_value(__wrap_calloc, nmemb, (size_t) ((40 * 1.01) + 601));
+            expect_value(__wrap_calloc, size, sizeof(char));
+            pcmk__compress(SIMPLE_DATA, 40, 0, &result, &len);
+            pcmk__mock_calloc = false;  // Use the real calloc()
+        }
+    );
 }
 
 int

--- a/lib/common/tests/strings/pcmk__str_update_test.c
+++ b/lib/common/tests/strings/pcmk__str_update_test.c
@@ -59,9 +59,14 @@ strdup_fails(void **state) {
 
     str = strdup("hello");
 
-    pcmk__mock_strdup = true;       // strdup() will return NULL
-    pcmk__assert_asserts(pcmk__str_update(&str, "world"));
-    pcmk__mock_strdup = false;      // Use the real strdup()
+    pcmk__assert_asserts(
+        {
+            pcmk__mock_strdup = true;   // strdup() will return NULL
+            expect_string(__wrap_strdup, s, "world");
+            pcmk__str_update(&str, "world");
+            pcmk__mock_strdup = false;  // Use the real strdup()
+        }
+    );
 
     free(str);
 }

--- a/lib/common/tests/utils/crm_user_lookup_test.c
+++ b/lib/common/tests/utils/crm_user_lookup_test.c
@@ -24,6 +24,8 @@ calloc_fails(void **state)
 
     pcmk__mock_calloc = true;   // calloc() will return NULL
 
+    expect_value(__wrap_calloc, nmemb, 1);
+    expect_value(__wrap_calloc, size, PCMK__PW_BUFFER_LEN);
     assert_int_equal(crm_user_lookup("hauser", &uid, &gid), -ENOMEM);
 
     pcmk__mock_calloc = false;  // Use real calloc()

--- a/lib/common/tests/utils/crm_user_lookup_test.c
+++ b/lib/common/tests/utils/crm_user_lookup_test.c
@@ -11,6 +11,7 @@
 
 #include <crm/common/unittest_internal.h>
 
+#include "crmcommon_private.h"
 #include "mock_private.h"
 
 #include <pwd.h>
@@ -39,6 +40,12 @@ getpwnam_r_fails(void **state)
 
     // Set getpwnam_r() return value and result parameter
     pcmk__mock_getpwnam_r = true;
+
+    expect_string(__wrap_getpwnam_r, name, "hauser");
+    expect_any(__wrap_getpwnam_r, pwd);
+    expect_any(__wrap_getpwnam_r, buf);
+    expect_value(__wrap_getpwnam_r, buflen, PCMK__PW_BUFFER_LEN);
+    expect_any(__wrap_getpwnam_r, result);
     will_return(__wrap_getpwnam_r, EIO);
     will_return(__wrap_getpwnam_r, NULL);
 
@@ -55,6 +62,12 @@ no_matching_pwent(void **state)
 
     // Set getpwnam_r() return value and result parameter
     pcmk__mock_getpwnam_r = true;
+
+    expect_string(__wrap_getpwnam_r, name, "hauser");
+    expect_any(__wrap_getpwnam_r, pwd);
+    expect_any(__wrap_getpwnam_r, buf);
+    expect_value(__wrap_getpwnam_r, buflen, PCMK__PW_BUFFER_LEN);
+    expect_any(__wrap_getpwnam_r, result);
     will_return(__wrap_getpwnam_r, 0);
     will_return(__wrap_getpwnam_r, NULL);
 
@@ -78,6 +91,12 @@ entry_found(void **state)
 
     // Set getpwnam_r() return value and result parameter
     pcmk__mock_getpwnam_r = true;
+
+    expect_string(__wrap_getpwnam_r, name, "hauser");
+    expect_any(__wrap_getpwnam_r, pwd);
+    expect_any(__wrap_getpwnam_r, buf);
+    expect_value(__wrap_getpwnam_r, buflen, PCMK__PW_BUFFER_LEN);
+    expect_any(__wrap_getpwnam_r, result);
     will_return(__wrap_getpwnam_r, 0);
     will_return(__wrap_getpwnam_r, &returned_ent);
 
@@ -86,6 +105,11 @@ entry_found(void **state)
     /* Test getpwnam_r returning a valid passwd entry, and we do pass uid and gid. */
 
     // Set getpwnam_r() return value and result parameter
+    expect_string(__wrap_getpwnam_r, name, "hauser");
+    expect_any(__wrap_getpwnam_r, pwd);
+    expect_any(__wrap_getpwnam_r, buf);
+    expect_value(__wrap_getpwnam_r, buflen, PCMK__PW_BUFFER_LEN);
+    expect_any(__wrap_getpwnam_r, result);
     will_return(__wrap_getpwnam_r, 0);
     will_return(__wrap_getpwnam_r, &returned_ent);
 

--- a/lib/common/tests/utils/pcmk_daemon_user_test.c
+++ b/lib/common/tests/utils/pcmk_daemon_user_test.c
@@ -11,6 +11,7 @@
 
 #include <crm/common/unittest_internal.h>
 
+#include "crmcommon_private.h"
 #include "mock_private.h"
 
 #include <pwd.h>
@@ -24,6 +25,12 @@ no_matching_pwent(void **state)
 
     // Set getpwnam_r() return value and result parameter
     pcmk__mock_getpwnam_r = true;
+
+    expect_string(__wrap_getpwnam_r, name, "hacluster");
+    expect_any(__wrap_getpwnam_r, pwd);
+    expect_any(__wrap_getpwnam_r, buf);
+    expect_value(__wrap_getpwnam_r, buflen, PCMK__PW_BUFFER_LEN);
+    expect_any(__wrap_getpwnam_r, result);
     will_return(__wrap_getpwnam_r, ENOENT);
     will_return(__wrap_getpwnam_r, NULL);
 
@@ -47,6 +54,12 @@ entry_found(void **state)
 
     // Set getpwnam_r() return value and result parameter
     pcmk__mock_getpwnam_r = true;
+
+    expect_string(__wrap_getpwnam_r, name, "hacluster");
+    expect_any(__wrap_getpwnam_r, pwd);
+    expect_any(__wrap_getpwnam_r, buf);
+    expect_value(__wrap_getpwnam_r, buflen, PCMK__PW_BUFFER_LEN);
+    expect_any(__wrap_getpwnam_r, result);
     will_return(__wrap_getpwnam_r, 0);
     will_return(__wrap_getpwnam_r, &returned_ent);
 

--- a/lib/common/tests/utils/pcmk_hostname_test.c
+++ b/lib/common/tests/utils/pcmk_hostname_test.c
@@ -22,6 +22,8 @@ uname_succeeded_test(void **state)
 
     // Set uname() return value and buf parameter node name
     pcmk__mock_uname = true;
+
+    expect_any(__wrap_uname, buf);
     will_return(__wrap_uname, 0);
     will_return(__wrap_uname, "somename");
 
@@ -39,6 +41,8 @@ uname_failed_test(void **state)
 {
     // Set uname() return value and buf parameter node name
     pcmk__mock_uname = true;
+
+    expect_any(__wrap_uname, buf);
     will_return(__wrap_uname, -1);
     will_return(__wrap_uname, NULL);
 

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -44,10 +44,6 @@
 
 #include "crmcommon_private.h"
 
-#ifndef PW_BUFFER_LEN
-#  define PW_BUFFER_LEN		500
-#endif
-
 CRM_TRACE_INIT_DATA(common);
 
 gboolean crm_config_error = FALSE;
@@ -94,12 +90,12 @@ crm_user_lookup(const char *name, uid_t * uid, gid_t * gid)
     struct passwd pwd;
     struct passwd *pwentry = NULL;
 
-    buffer = calloc(1, PW_BUFFER_LEN);
+    buffer = calloc(1, PCMK__PW_BUFFER_LEN);
     if (buffer == NULL) {
         return -ENOMEM;
     }
 
-    rc = getpwnam_r(name, &pwd, buffer, PW_BUFFER_LEN, &pwentry);
+    rc = getpwnam_r(name, &pwd, buffer, PCMK__PW_BUFFER_LEN, &pwentry);
     if (pwentry) {
         if (uid) {
             *uid = pwentry->pw_uid;

--- a/lib/pengine/tests/status/pe_new_working_set_test.c
+++ b/lib/pengine/tests/status/pe_new_working_set_test.c
@@ -18,6 +18,8 @@ static void
 calloc_fails(void **state) {
     pcmk__mock_calloc = true;   // calloc() will return NULL
 
+    expect_value(__wrap_calloc, nmemb, 1);
+    expect_value(__wrap_calloc, size, sizeof(pe_working_set_t));
     assert_null(pe_new_working_set());
 
     pcmk__mock_calloc = false;  // Use real calloc()


### PR DESCRIPTION
Check that mocked functions receive the expected arguments.

Any time we're unsure what the argument will be (for example, when it's an object that's created by the called function and we pass its address to the mocked function), we can use `expect_any(<function>, <parameter_name>)`.

We also clarify that `pcmk__assert_asserts()` accepts a statement in general and isn't limited to an expression. We need that in order to use `expect_*()` macros alongside `pcmk__assert_asserts()`.

More info: https://api.cmocka.org/group__cmocka__param.html