### PR TITLE
Test: libcrmcommon: Mock snprintf() and add tests

### DIFF
--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -110,7 +110,8 @@ libcrmcommon_test_la_LDFLAGS	= $(libcrmcommon_la_LDFLAGS) -rpath $(libdir) $(LDF
 # disable all builtins.  Older versions of GCC (at least, on RHEL7) will still emit
 # replacement code for strdup (and possibly other functions) unless -fno-inline is
 # also added.
-libcrmcommon_test_la_CFLAGS	= $(libcrmcommon_la_CFLAGS) -DPCMK__UNIT_TESTING -fno-builtin -fno-inline
+libcrmcommon_test_la_CFLAGS	= $(libcrmcommon_la_CFLAGS) -DPCMK__UNIT_TESTING
+libcrmcommon_test_la_CFLAGS	+= -fno-builtin -fno-inline -U_FORTIFY_SOURCE
 # If -fno-builtin is used, -lm also needs to be added.  See the comment at
 # BUILD_PROFILING above.
 libcrmcommon_test_la_LIBADD	= $(libcrmcommon_la_LIBADD) -lcmocka -lm

--- a/lib/common/mock_private.h
+++ b/lib/common/mock_private.h
@@ -66,6 +66,18 @@ ssize_t __real_readlink(const char *restrict path, char *restrict buf,
 ssize_t __wrap_readlink(const char *restrict path, char *restrict buf,
                         size_t bufsize);
 
+extern bool pcmk__mock_snprintf;
+int pcmk__wrap_vsnprintf_helper(char *restrict str, size_t size,
+                                const char *restrict format, va_list ap);
+int __real_snprintf(char *restrict str, size_t size,
+                    const char *restrict format, ...);
+int __wrap_snprintf(char *restrict str, size_t size,
+                    const char *restrict format, ...);
+int __real___snprintfieee128(char *restrict str, size_t size,
+                               const char *restrict format, ...);
+int __wrap___snprintfieee128(char *restrict str, size_t size,
+                               const char *restrict format, ...);
+
 extern bool pcmk__mock_strdup;
 char *__real_strdup(const char *s);
 char *__wrap_strdup(const char *s);

--- a/lib/common/tests/options/pcmk__env_option_test.c
+++ b/lib/common/tests/options/pcmk__env_option_test.c
@@ -25,6 +25,23 @@ empty_input_string(void **state)
 }
 
 static void
+snprintf_error(void **state)
+{
+    pcmk__mock_getenv = true;
+    pcmk__mock_snprintf = true;
+
+    // getenv() not called
+    expect_any(pcmk__wrap_vsnprintf_helper, str);
+    expect_value(pcmk__wrap_vsnprintf_helper, size, NAME_MAX);
+    expect_string(pcmk__wrap_vsnprintf_helper, format, "%s%s");
+    will_return(pcmk__wrap_vsnprintf_helper, EOVERFLOW);
+    assert_null(pcmk__env_option("env_var"));
+
+    pcmk__mock_getenv = false;
+    pcmk__mock_snprintf = false;
+}
+
+static void
 input_too_long_for_both(void **state)
 {
     /* pcmk__env_option() prepends "PCMK_" before lookup. If the option name is
@@ -130,6 +147,7 @@ main(int argc, char **argv)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(empty_input_string),
+        cmocka_unit_test(snprintf_error),
         cmocka_unit_test(input_too_long_for_both),
         cmocka_unit_test(input_too_long_for_pcmk),
         cmocka_unit_test(value_not_found),

--- a/lib/common/tests/options/pcmk__set_env_option_test.c
+++ b/lib/common/tests/options/pcmk__set_env_option_test.c
@@ -37,6 +37,23 @@ bad_input_string(void **state)
 }
 
 static void
+snprintf_error(void **state)
+{
+    pcmk__mock_setenv = true;
+    pcmk__mock_snprintf = true;
+
+    // setenv() not called
+    expect_any(pcmk__wrap_vsnprintf_helper, str);
+    expect_value(pcmk__wrap_vsnprintf_helper, size, NAME_MAX);
+    expect_string(pcmk__wrap_vsnprintf_helper, format, "%s%s");
+    will_return(pcmk__wrap_vsnprintf_helper, EOVERFLOW);
+    pcmk__env_option("env_var");
+
+    pcmk__mock_setenv = false;
+    pcmk__mock_snprintf = false;
+}
+
+static void
 input_too_long_for_both(void **state)
 {
     /* pcmk__set_env_option() wants to set "PCMK_<option>" and "HA_<option>". If
@@ -151,6 +168,7 @@ main(int argc, char **argv)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(bad_input_string),
+        cmocka_unit_test(snprintf_error),
         cmocka_unit_test(input_too_long_for_both),
         cmocka_unit_test(input_too_long_for_pcmk),
         cmocka_unit_test(valid_inputs_set),

--- a/mk/tap.mk
+++ b/mk/tap.mk
@@ -25,6 +25,8 @@ WRAPPED = calloc		\
 	  readlink		\
 	  setenv		\
 	  setgrent		\
+	  snprintf		\
+	  __snprintfieee128		\
 	  strdup 		\
 	  uname			\
 	  unsetenv


### PR DESCRIPTION
Some systems (currently F36 ppc64le) now support a IEEE 128-bit floating-point data type. On such systems, `snprintf()` gets replaced by `__snprintfieee128()` (a.k.a., `___ieee128_snprintf()`).
  * https://fedoraproject.org/wiki/Changes/PPC64LE_Float128_Transition

Mocking `snprintf()` must take this into account. By the time the linker wraps `snprintf()`, it has already been replaced by `__snprintfieee128()` on affected systems. So there needs to be a `__wrap_X()` function defined for both variants. However, they should behave in exactly the same way, and the unit testing code shouldn't have to be aware of which one is in use.

A solution is to define two identical `__wrap_X()` functions and have each of them call a helper, `pcmk__wrap_vsnprintf_helper()`. It's named this way because it must convert the received variadic arguments into a `va_list` and then pass it to `vsnprintf()`. Additionally, if we ever mock `vsnprintf()`, we'll want to use the same `pcmk__wrap_vsnprintf_helper()` function with the two `vsnprintf()` `__wrap_X()` functions.

This same pattern lends itself to other `Xprintf()` functions, if we ever need to mock them.

---

Also add a new test for each of `pcmk__env_option()` and `pcmk__set_env_option()`.

---

The one thing that makes me nervous here is that we may run into other such "quiet replacements" in the future, where `snprintf()` (or another function that we mock!) gets replaced by something else before the wrapping happens at link time. I'm not sure there's  a general solution to this that doesn't run the risk of unwanted side effects, so we may just need to keep an eye out for them and address them if and when tests fail.

Another possible solution might be the one used in libqb here: https://github.com/ClusterLabs/libqb/pull/231/commits/f610b1b

I wanted to try to stick with our `--wrap` approach for consistency if possible.