### PR TITLE
Mid: fenced: DC node fencing is unconditionally relayed.

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2963,7 +2963,7 @@ check_alternate_host(const char *target)
     const char *alternate_host = NULL;
 
     crm_trace("Checking if we (%s) can fence %s", stonith_our_uname, target);
-    if (find_topology_for_host(target) && pcmk__str_eq(target, stonith_our_uname, pcmk__str_casei)) {
+    if (pcmk__str_eq(target, stonith_our_uname, pcmk__str_casei)) {
         GHashTableIter gIter;
         crm_node_t *entry = NULL;
 


### PR DESCRIPTION
Hi All,

This fix improves escalation fencing failures in multi-node configurations when there is no topology.
Fencing from DC resource failure is performed by RELAY regardless of the presence or absence of topology.

In addition to this fix, there is code that is no longer needed due to this change, but we will first publicize this fix.

Best Regards,
Hideo Yamauchi.