### PR TITLE
Test: cts-lab: Remove docker, phd, and the RemotePrimitives class

### DIFF
--- a/cts/lab/CTS.py
+++ b/cts/lab/CTS.py
@@ -108,9 +108,6 @@ class NodeStatus(object):
 
     def IsNodeBooted(self, node):
         '''Return TRUE if the given node is booted (responds to pings)'''
-        if self.Env["docker"]:
-            return RemoteFactory().getInstance()("localhost", "docker inspect --format {{.State.Running}} %s | grep -q true" % node, silent=True) == 0
-
         return RemoteFactory().getInstance()("localhost", "ping -nq -c1 -w1 %s" % node, silent=True) == 0
 
     def IsSshdUp(self, node):

--- a/cts/lab/CTStests.py
+++ b/cts/lab/CTStests.py
@@ -66,7 +66,6 @@ class CTSTest(object):
         self.passed = 1
         self.is_loop = 0
         self.is_unsafe = 0
-        self.is_docker_unsafe = 0
         self.is_experimental = 0
         self.is_container = 0
         self.is_valgrind = 0
@@ -212,8 +211,6 @@ class CTSTest(object):
         elif self.is_valgrind and not self.Env["valgrind-tests"]:
             return 0
         elif self.is_experimental and not self.Env["experimental-tests"]:
-            return 0
-        elif self.is_docker_unsafe and self.Env["docker"]:
             return 0
         elif self.is_container and not self.Env["container-tests"]:
             return 0
@@ -1337,8 +1334,6 @@ class ComponentFail(CTSTest):
     def __init__(self, cm):
         CTSTest.__init__(self,cm)
         self.name = "ComponentFail"
-        # TODO make this work correctly in docker.
-        self.is_docker_unsafe = 1
         self.startall = SimulStartLite(cm)
         self.complist = cm.Components()
         self.patterns = []
@@ -2477,7 +2472,6 @@ class RemoteLXC(CTSTest):
         self.startall = SimulStartLite(cm)
         self.num_containers = 2
         self.is_container = 1
-        self.is_docker_unsafe = 1
         self.failed = 0
         self.fail_string = ""
 
@@ -2579,7 +2573,6 @@ class RemoteDriver(CTSTest):
     def __init__(self, cm):
         CTSTest.__init__(self,cm)
         self.name = self.__class__.__name__
-        self.is_docker_unsafe = 1
         self.start = StartTest(cm)
         self.startall = SimulStartLite(cm)
         self.stop = StopTest(cm)

--- a/cts/lab/environment.py
+++ b/cts/lab/environment.py
@@ -50,7 +50,6 @@ class Environment(object):
         self["loop-tests"] = 1
         self["scenario"] = "random"
         self["stats"] = 0
-        self["docker"] = 0
         self["continue"] = 0
 
         self.RandomGen = random.Random()
@@ -123,9 +122,7 @@ class Environment(object):
                 # GoodThing(tm).
                 try:
                     n = node.strip()
-                    if self.data["docker"] == 0:
-                        socket.gethostbyname_ex(n)
-
+                    socket.gethostbyname_ex(n)
                     self.Nodes.append(n) 
                 except:
                     self.logger.log(node+" not found in DNS... aborting")
@@ -154,10 +151,7 @@ class Environment(object):
             return "unknown"
 
         elif self.data["Stack"] == "corosync 2+":
-            if self["docker"]:
-                return "crm-corosync-docker"
-            else:
-                return "crm-corosync"
+            return "crm-corosync"
 
         else:
             LogFactory().log("Unknown stack: "+self["stack"])
@@ -320,9 +314,6 @@ class Environment(object):
             elif args[i] == "--qarsh":
                 RemoteFactory().enable_qarsh()
 
-            elif args[i] == "--docker":
-                self["docker"] = 1
-                RemoteFactory().enable_docker()
             elif args[i] == "--yes" or args[i] == "-y":
                 self["continue"] = 1
             elif args[i] == "--stonith" or args[i] == "--fencing":
@@ -331,15 +322,9 @@ class Environment(object):
                     self["DoFencing"]=1
                 elif args[i+1] == "0" or args[i+1] == "no":
                     self["DoFencing"]=0
-                elif args[i+1] == "phd":
-                    self["DoStonith"]=1
-                    self["stonith-type"] = "fence_phd_kvm"
                 elif args[i+1] == "rhcs" or args[i+1] == "xvm" or args[i+1] == "virt":
                     self["DoStonith"]=1
                     self["stonith-type"] = "fence_xvm"
-                elif args[i+1] == "docker":
-                    self["DoStonith"]=1
-                    self["stonith-type"] = "fence_docker_cts"
                 elif args[i+1] == "scsi":
                     self["DoStonith"]=1
                     self["stonith-type"] = "fence_scsi"
@@ -630,7 +615,6 @@ class Environment(object):
         print("\t [--container-tests]          include pacemaker_remote tests that run in lxc container resources")
         print("\t [--oprofile 'node list']     list of cluster nodes to run oprofile on]")
         print("\t [--qarsh]                    use the QARSH backdoor to access nodes instead of SSH")
-        print("\t [--docker]                   Indicates nodes are docker nodes.")
         print("\t [--seed random_seed]")
         print("\t [--set option=value]")
         print("\t [--yes | -y]                 continue to run cts when there is an interaction whether to continue running pacemaker-cts")

--- a/cts/lab/patterns.py
+++ b/cts/lab/patterns.py
@@ -339,19 +339,6 @@ class crm_corosync(BasePatterns):
         self.components["pacemaker-fenced-ignore"].extend(self.components["common-ignore"])
 
 
-class crm_corosync_docker(crm_corosync):
-    '''
-    Patterns for Corosync version 2 cluster manager class
-    '''
-    def __init__(self, name):
-        crm_corosync.__init__(self, name)
-
-        self.commands.update({
-            "StartCmd"       : "pcmk_start",
-            "StopCmd"        : "pcmk_stop",
-        })
-
-
 class PatternSelector(object):
 
     def __init__(self, name=None):
@@ -362,8 +349,6 @@ class PatternSelector(object):
             crm_corosync("crm-corosync")
         elif name == "crm-corosync":
             crm_corosync(name)
-        elif name == "crm-corosync-docker":
-            crm_corosync_docker(name)
 
     def get_variant(self, variant):
         if variant in patternvariants:

--- a/cts/lab/remote.py
+++ b/cts/lab/remote.py
@@ -269,12 +269,6 @@ class RemoteFactory(object):
     def new(self, silent=False):
         return RemoteExec(RemoteFactory.rsh, silent)
 
-    def enable_docker(self):
-        print("Using DOCKER backend for connections to cluster nodes")
-
-        RemoteFactory.rsh.Command = "/usr/libexec/phd/docker/phd_docker_remote_cmd "
-        RemoteFactory.rsh.CpCommand = "/usr/libexec/phd/docker/phd_docker_cp"
-
     def enable_qarsh(self):
         # http://nstraz.wordpress.com/2008/12/03/introducing-qarsh/
         print("Using QARSH for connections to cluster nodes")

--- a/cts/lab/remote.py
+++ b/cts/lab/remote.py
@@ -106,21 +106,6 @@ class AsyncRemoteCmd(Thread):
         if self.delegate:
             self.delegate.async_complete(self.proc.pid, self.proc.returncode, outLines, errLines)
 
-class RemotePrimitives(object):
-    def __init__(self, Command=None, CpCommand=None):
-        if CpCommand:
-            self.CpCommand = CpCommand
-        else:
-            #        -B: batch mode, -q: no stats (quiet)
-            self.CpCommand = "scp -B -q"
-
-        if Command:
-            self.Command = Command
-        else:
-            #   -n: no stdin, -x: no X11,
-            #   -o ServerAliveInterval=5 disconnect after 3*5s if the server stops responding
-            self.Command = "ssh -l root -n -x -o ServerAliveInterval=5 -o ConnectTimeout=10 -o TCPKeepAlive=yes -o ServerAliveCountMax=3 "
-
 class RemoteExec(object):
     '''This is an abstract remote execution class.  It runs a command on another
        machine - somehow.  The somehow is up to us.  This particular
@@ -128,8 +113,9 @@ class RemoteExec(object):
        Most of the work is done by fork/exec of ssh or scp.
     '''
 
-    def __init__(self, rsh, silent=False):
-        self.rsh = rsh
+    def __init__(self, command, cp_command, silent=False):
+        self.command = command
+        self.cp_command = cp_command
         self.silent = silent
         self.logger = LogFactory()
 
@@ -154,7 +140,7 @@ class RemoteExec(object):
         if sysname == None or sysname.lower() == self.OurNode or sysname == "localhost":
             ret = command
         else:
-            ret = self.rsh.Command + " " + sysname + " '" + self._fixcmd(command) + "'"
+            ret = self.command + " " + sysname + " '" + self._fixcmd(command) + "'"
         #print ("About to run %s\n" % ret)
         return ret
 
@@ -238,7 +224,7 @@ class RemoteExec(object):
 
     def cp(self, source, target, silent=False):
         '''Perform a remote copy'''
-        cpstring = self.rsh.CpCommand  + " \'" + source + "\'"  + " \'" + target + "\'"
+        cpstring = self.cp_command  + " \'" + source + "\'"  + " \'" + target + "\'"
         rc = os.system(cpstring)
         if trace_rsh:
             silent = False
@@ -258,21 +244,33 @@ class RemoteExec(object):
 
 class RemoteFactory(object):
     # Class variables
-    rsh = RemotePrimitives()
+
+    # -n: no stdin, -x: no X11,
+    # -o ServerAliveInterval=5: disconnect after 3*5s if the server
+    # stops responding
+    command = ("ssh -l root -n -x -o ServerAliveInterval=5 "
+               "-o ConnectTimeout=10 -o TCPKeepAlive=yes "
+               "-o ServerAliveCountMax=3 ")
+
+    # -B: batch mode, -q: no stats (quiet)
+    cp_command = "scp -B -q"
+
     instance = None
 
     def getInstance(self):
         if not RemoteFactory.instance:
-            RemoteFactory.instance = RemoteExec(RemoteFactory.rsh, False)
+            RemoteFactory.instance = RemoteExec(RemoteFactory.command,
+                                                RemoteFactory.cp_command,
+                                                False)
         return RemoteFactory.instance
 
     def new(self, silent=False):
-        return RemoteExec(RemoteFactory.rsh, silent)
+        return RemoteExec(RemoteFactory.command, RemoteFactory.cp_command,
+                          silent)
 
     def enable_qarsh(self):
         # http://nstraz.wordpress.com/2008/12/03/introducing-qarsh/
         print("Using QARSH for connections to cluster nodes")
 
-        RemoteFactory.rsh.Command = "qarsh -t 300 -l root"
-        RemoteFactory.rsh.CpCommand = "qacp -q"
-
+        RemoteFactory.command = "qarsh -t 300 -l root"
+        RemoteFactory.cp_command = "qacp -q"


### PR DESCRIPTION
Per T499, phd was a tool for spinning up test clusters, but it hasn't been maintained in years and isn't worth bringing up to date. All the docker stuff in the cts lab was related to phd, so remove it.

Drop the `RemotePrimitives` class since it doesn't do much or really simplify anything. It acts like a two-member struct that gets created once.

Closes T499.