### PR TITLE
Refactor: libpe_status: Bring two functions up to current guidelines

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2126,6 +2126,7 @@ AC_CONFIG_FILES(Makefile                                            \
                 lib/pengine/tests/rules/Makefile                    \
                 lib/pengine/tests/status/Makefile                   \
                 lib/pengine/tests/unpack/Makefile                   \
+                lib/pengine/tests/utils/Makefile                    \
                 lib/services/Makefile                               \
                 maint/Makefile                                      \
                 po/Makefile.in                                      \

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -378,8 +378,6 @@ void pe__show_node_weights_as(const char *file, const char *function,
         pe__show_node_weights_as(__FILE__, __func__, __LINE__,      \
                                  (level), (rsc), (text), (nodes), (data_set))
 
-extern gint sort_rsc_priority(gconstpointer a, gconstpointer b);
-
 extern xmlNode *find_rsc_op_entry(pe_resource_t * rsc, const char *key);
 
 extern pe_action_t *custom_action(pe_resource_t * rsc, char *key, const char *task, pe_node_t * on_node,

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -482,7 +482,7 @@ pe_base_name_eq(pe_resource_t *rsc, const char *id)
 
 int pe__target_rc_from_xml(xmlNode *xml_op);
 
-gint sort_node_uname(gconstpointer a, gconstpointer b);
+gint pe__cmp_node_name(gconstpointer a, gconstpointer b);
 bool is_set_recursive(pe_resource_t * rsc, long long flag, bool any);
 
 enum rsc_digest_cmp_val {

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -1020,6 +1020,8 @@ pcmk__char_in_any_str(int ch, ...)
 int
 pcmk__numeric_strcasecmp(const char *s1, const char *s2)
 {
+    CRM_ASSERT((s1 != NULL) && (s2 != NULL));
+
     while (*s1 && *s2) {
         if (isdigit(*s1) && isdigit(*s2)) {
             // If node names contain a number, sort numerically

--- a/lib/common/tests/strings/pcmk__numeric_strcasecmp_test.c
+++ b/lib/common/tests/strings/pcmk__numeric_strcasecmp_test.c
@@ -12,6 +12,14 @@
 #include <crm/common/unittest_internal.h>
 
 static void
+null_ptr(void **state)
+{
+    pcmk__assert_asserts(pcmk__numeric_strcasecmp(NULL, NULL));
+    pcmk__assert_asserts(pcmk__numeric_strcasecmp("a", NULL));
+    pcmk__assert_asserts(pcmk__numeric_strcasecmp(NULL, "a"));
+}
+
+static void
 no_numbers(void **state)
 {
     /* All comparisons are done case-insensitively. */
@@ -64,6 +72,7 @@ unequal_lengths(void **state)
 }
 
 PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(null_ptr),
                 cmocka_unit_test(no_numbers),
                 cmocka_unit_test(trailing_numbers),
                 cmocka_unit_test(middle_numbers),

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -1205,7 +1205,7 @@ allowed_nodes_as_list(pe_resource_t *rsc, pe_working_set_t *data_set)
     }
 
     if (!pcmk__is_daemon) {
-        allowed_nodes = g_list_sort(allowed_nodes, sort_node_uname);
+        allowed_nodes = g_list_sort(allowed_nodes, pe__cmp_node_name);
     }
 
     return allowed_nodes;

--- a/lib/pengine/Makefile.am
+++ b/lib/pengine/Makefile.am
@@ -66,13 +66,15 @@ include $(top_srcdir)/mk/tap.mk
 libpe_rules_test_la_SOURCES = $(libpe_rules_la_SOURCES)
 libpe_rules_test_la_LDFLAGS = $(libpe_rules_la_LDFLAGS) -rpath $(libdir) $(LDFLAGS_WRAP)
 # See comments on libcrmcommon_test_la in lib/common/Makefile.am regarding these flags.
-libpe_rules_test_la_CFLAGS = $(libpe_rules_la_CFLAGS) -fno-builtin -fno-inline
+libpe_rules_test_la_CFLAGS = $(libpe_rules_la_CFLAGS) -DPCMK__UNIT_TESTING \
+			     -fno-builtin -fno-inline
 libpe_rules_test_la_LIBADD = $(top_builddir)/lib/common/libcrmcommon_test.la -lcmocka -lm
 
 libpe_status_test_la_SOURCES = $(libpe_status_la_SOURCES)
 libpe_status_test_la_LDFLAGS = $(libpe_status_la_LDFLAGS) -rpath $(libdir) $(LDFLAGS_WRAP)
 # See comments on libcrmcommon_test_la in lib/common/Makefile.am regarding these flags.
-libpe_status_test_la_CFLAGS = $(libpe_status_la_CFLAGS) -fno-builtin -fno-inline
+libpe_status_test_la_CFLAGS = $(libpe_status_la_CFLAGS) -DPCMK__UNIT_TESTING \
+			      -fno-builtin -fno-inline
 libpe_status_test_la_LIBADD = $(top_builddir)/lib/common/libcrmcommon_test.la -lcmocka -lm
 
 clean-generic:

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -636,7 +636,7 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
     }
 
     /* Promoted */
-    promoted_list = g_list_sort(promoted_list, sort_node_uname);
+    promoted_list = g_list_sort(promoted_list, pe__cmp_node_name);
     for (gIter = promoted_list; gIter; gIter = gIter->next) {
         pe_node_t *host = gIter->data;
 
@@ -652,7 +652,7 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
     list_text_len = 0;
 
     /* Started/Unpromoted */
-    started_list = g_list_sort(started_list, sort_node_uname);
+    started_list = g_list_sort(started_list, pe__cmp_node_name);
     for (gIter = started_list; gIter; gIter = gIter->next) {
         pe_node_t *host = gIter->data;
 
@@ -707,7 +707,7 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
                 list = g_hash_table_get_values(rsc->known_on);
             }
 
-            list = g_list_sort(list, sort_node_uname);
+            list = g_list_sort(list, pe__cmp_node_name);
             for (nIter = list; nIter != NULL; nIter = nIter->next) {
                 pe_node_t *node = (pe_node_t *)nIter->data;
 
@@ -922,7 +922,7 @@ pe__clone_default(pcmk__output_t *out, va_list args)
     }
 
     /* Promoted */
-    promoted_list = g_list_sort(promoted_list, sort_node_uname);
+    promoted_list = g_list_sort(promoted_list, pe__cmp_node_name);
     for (gIter = promoted_list; gIter; gIter = gIter->next) {
         pe_node_t *host = gIter->data;
 
@@ -946,7 +946,7 @@ pe__clone_default(pcmk__output_t *out, va_list args)
     }
 
     /* Started/Unpromoted */
-    started_list = g_list_sort(started_list, sort_node_uname);
+    started_list = g_list_sort(started_list, pe__cmp_node_name);
     for (gIter = started_list; gIter; gIter = gIter->next) {
         pe_node_t *host = gIter->data;
 
@@ -1003,7 +1003,7 @@ pe__clone_default(pcmk__output_t *out, va_list args)
                 list = g_hash_table_get_values(rsc->known_on);
             }
 
-            list = g_list_sort(list, sort_node_uname);
+            list = g_list_sort(list, pe__cmp_node_name);
             for (nIter = list; nIter != NULL; nIter = nIter->next) {
                 pe_node_t *node = (pe_node_t *)nIter->data;
 

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -729,7 +729,7 @@ add_notif_keys(pe_resource_t *rsc, notify_data_t *n_data)
          * regression test output (while avoiding the performance hit
          * for the live cluster).
          */
-        nodes = g_list_sort(nodes, sort_node_uname);
+        nodes = g_list_sort(nodes, pe__cmp_node_name);
     }
     get_node_names(nodes, &node_list, NULL);
     add_notify_env_free(n_data, "notify_available_uname", node_list);

--- a/lib/pengine/pe_status_private.h
+++ b/lib/pengine/pe_status_private.h
@@ -38,6 +38,9 @@ void pe__force_anon(const char *standard, pe_resource_t *rsc, const char *rid,
                     pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
+gint pe__cmp_rsc_priority(gconstpointer a, gconstpointer b);
+
+G_GNUC_INTERNAL
 gboolean unpack_remote_nodes(xmlNode *xml_resources, pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL

--- a/lib/pengine/pe_status_private.h
+++ b/lib/pengine/pe_status_private.h
@@ -14,6 +14,11 @@
  * declared with G_GNUC_INTERNAL for efficiency.
  */
 
+#if defined(PCMK__UNIT_TESTING)
+#undef G_GNUC_INTERNAL
+#define G_GNUC_INTERNAL
+#endif
+
 #  define status_print(fmt, args...)           \
    if(options & pe_print_html) {           \
        FILE *stream = print_data;      \

--- a/lib/pengine/tests/Makefile.am
+++ b/lib/pengine/tests/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = rules native status unpack
+SUBDIRS = rules native status unpack utils

--- a/lib/pengine/tests/utils/Makefile.am
+++ b/lib/pengine/tests/utils/Makefile.am
@@ -1,0 +1,18 @@
+#
+# Copyright 2022 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+#
+
+include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
+
+LDADD += $(top_builddir)/lib/pengine/libpe_status_test.la
+
+# Add "_test" to the end of all test program names to simplify .gitignore.
+check_PROGRAMS = pe__cmp_node_name_test
+
+TESTS = $(check_PROGRAMS)

--- a/lib/pengine/tests/utils/Makefile.am
+++ b/lib/pengine/tests/utils/Makefile.am
@@ -10,9 +10,12 @@
 include $(top_srcdir)/mk/tap.mk
 include $(top_srcdir)/mk/unittest.mk
 
+AM_CPPFLAGS += -I$(top_srcdir)/lib/pengine
 LDADD += $(top_builddir)/lib/pengine/libpe_status_test.la
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
-check_PROGRAMS = pe__cmp_node_name_test
+check_PROGRAMS = \
+		 pe__cmp_node_name_test \
+		 pe__cmp_rsc_priority_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/pengine/tests/utils/pe__cmp_node_name_test.c
+++ b/lib/pengine/tests/utils/pe__cmp_node_name_test.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/pengine/internal.h>
+
+struct pe_node_shared_s node1_details;
+struct pe_node_shared_s node2_details;
+
+pe_node_t node1 = {.details = &node1_details};
+pe_node_t node2 = {.details = &node2_details};
+
+static void
+nodes_equal(void **state)
+{
+    assert_int_equal(pe__cmp_node_name(NULL, NULL), 0);
+
+    node1.details->uname = "node10";
+    node2.details->uname = "node10";
+    assert_int_equal(pe__cmp_node_name(&node1, &node2), 0);
+}
+
+static void
+node1_first(void **state)
+{
+    assert_int_equal(pe__cmp_node_name(NULL, &node2), -1);
+
+    // The heavy testing is done in pcmk__numeric_strcasecmp()'s unit tests
+    node1.details->uname = "node9";
+    node2.details->uname = "node10";
+    assert_int_equal(pe__cmp_node_name(&node1, &node2), -1);
+}
+
+static void
+node2_first(void **state)
+{
+    assert_int_equal(pe__cmp_node_name(&node1, NULL), 1);
+
+    node1.details->uname = "node10";
+    node2.details->uname = "node9";
+    assert_int_equal(pe__cmp_node_name(&node1, &node2), 1);
+}
+
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(nodes_equal),
+                cmocka_unit_test(node1_first),
+                cmocka_unit_test(node2_first))

--- a/lib/pengine/tests/utils/pe__cmp_rsc_priority_test.c
+++ b/lib/pengine/tests/utils/pe__cmp_rsc_priority_test.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/pengine/internal.h>
+
+#include "pe_status_private.h"
+
+pe_resource_t rsc1;
+pe_resource_t rsc2;
+
+static void
+rscs_equal(void **state)
+{
+    rsc1.priority = 0;
+    rsc2.priority = 0;
+    assert_int_equal(pe__cmp_rsc_priority(NULL, NULL), 0);
+    assert_int_equal(pe__cmp_rsc_priority(&rsc1, &rsc2), 0);
+}
+
+static void
+rsc1_first(void **state)
+{
+    rsc1.priority = 1;
+    rsc2.priority = 0;
+    assert_int_equal(pe__cmp_rsc_priority(&rsc1, NULL), -1);
+    assert_int_equal(pe__cmp_rsc_priority(&rsc1, &rsc2), -1);
+}
+
+static void
+rsc2_first(void **state)
+{
+    rsc1.priority = 0;
+    rsc2.priority = 1;
+    assert_int_equal(pe__cmp_rsc_priority(NULL, &rsc2), 1);
+    assert_int_equal(pe__cmp_rsc_priority(&rsc1, &rsc2), 1);
+}
+
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(rscs_equal),
+                cmocka_unit_test(rsc1_first),
+                cmocka_unit_test(rsc2_first))

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -810,7 +810,8 @@ unpack_resources(xmlNode * xml_resources, pe_working_set_t * data_set)
         link_rsc2remotenode(data_set, rsc);
     }
 
-    data_set->resources = g_list_sort(data_set->resources, sort_rsc_priority);
+    data_set->resources = g_list_sort(data_set->resources,
+                                      pe__cmp_rsc_priority);
     if (pcmk_is_set(data_set->flags, pe_flag_quick_location)) {
         /* Ignore */
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -447,7 +447,8 @@ pe_create_node(const char *id, const char *uname, const char *type,
     new_node->details->digest_cache = pcmk__strkey_table(free,
                                                           pe__free_digests);
 
-    data_set->nodes = g_list_insert_sorted(data_set->nodes, new_node, sort_node_uname);
+    data_set->nodes = g_list_insert_sorted(data_set->nodes, new_node,
+                                           pe__cmp_node_name);
     return new_node;
 }
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -159,8 +159,23 @@ pe__node_list2table(GList *list)
     return result;
 }
 
+/*!
+ * \internal
+ * \brief Compare two nodes by name, with numeric portions sorted numerically
+ *
+ * Sort two node names case-insensitively like strcasecmp(), but with any
+ * numeric portions of the name sorted numerically. For example, "node10" will
+ * sort higher than "node9" but lower than "remotenode9".
+ *
+ * \param[in] a  First node to compare (must not be \c NULL)
+ * \param[in] b  Second node to compare (must not be \c NULL)
+ *
+ * \retval -1 \c a comes before \c b
+ * \retval  0 \c a and \c b are equal
+ * \retval  1 \c a comes after \c b
+ */
 gint
-sort_node_uname(gconstpointer a, gconstpointer b)
+pe__cmp_node_name(gconstpointer a, gconstpointer b)
 {
     return pcmk__numeric_strcasecmp(((const pe_node_t *) a)->details->uname,
                                     ((const pe_node_t *) b)->details->uname);
@@ -181,7 +196,8 @@ pe__output_node_weights(pe_resource_t *rsc, const char *comment,
     pcmk__output_t *out = data_set->priv;
 
     // Sort the nodes so the output is consistent for regression tests
-    GList *list = g_list_sort(g_hash_table_get_values(nodes), sort_node_uname);
+    GList *list = g_list_sort(g_hash_table_get_values(nodes),
+                              pe__cmp_node_name);
 
     for (GList *gIter = list; gIter != NULL; gIter = gIter->next) {
         pe_node_t *node = (pe_node_t *) gIter->data;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -17,6 +17,8 @@
 #include <crm/pengine/rules.h>
 #include <crm/pengine/internal.h>
 
+#include "pe_status_private.h"
+
 extern bool pcmk__is_daemon;
 
 void print_str_str(gpointer key, gpointer value, gpointer user_data);
@@ -290,8 +292,22 @@ pe__show_node_weights_as(const char *file, const char *function, int line,
     }
 }
 
+/*!
+ * \internal
+ * \brief Compare two resources by priority
+ *
+ * \param[in] a  First resource to compare (can be \c NULL)
+ * \param[in] b  Second resource to compare (can be \c NULL)
+ *
+ * \retval -1 \c a->priority > \c b->priority (or \c b is \c NULL and \c a is
+ *            not)
+ * \retval  0 \c a->priority == \c b->priority (or both \c a and \c b are
+ *            \c NULL)
+ * \retval  1 \c a->priority < \c b->priority (or \c a is \c NULL and \c b is
+ *            not)
+ */
 gint
-sort_rsc_priority(gconstpointer a, gconstpointer b)
+pe__cmp_rsc_priority(gconstpointer a, gconstpointer b)
 {
     const pe_resource_t *resource1 = (const pe_resource_t *)a;
     const pe_resource_t *resource2 = (const pe_resource_t *)b;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -169,18 +169,33 @@ pe__node_list2table(GList *list)
  * numeric portions of the name sorted numerically. For example, "node10" will
  * sort higher than "node9" but lower than "remotenode9".
  *
- * \param[in] a  First node to compare (must not be \c NULL)
- * \param[in] b  Second node to compare (must not be \c NULL)
+ * \param[in] a  First node to compare (can be \c NULL)
+ * \param[in] b  Second node to compare (can be \c NULL)
  *
- * \retval -1 \c a comes before \c b
- * \retval  0 \c a and \c b are equal
- * \retval  1 \c a comes after \c b
+ * \retval -1 \c a comes before \c b (or \c a is \c NULL and \c b is not)
+ * \retval  0 \c a and \c b are equal (or both are \c NULL)
+ * \retval  1 \c a comes after \c b (or \c b is \c NULL and \c a is not)
  */
 gint
 pe__cmp_node_name(gconstpointer a, gconstpointer b)
 {
-    return pcmk__numeric_strcasecmp(((const pe_node_t *) a)->details->uname,
-                                    ((const pe_node_t *) b)->details->uname);
+    const pe_node_t *node1 = (const pe_node_t *) a;
+    const pe_node_t *node2 = (const pe_node_t *) b;
+
+    if ((node1 == NULL) && (node2 == NULL)) {
+        return 0;
+    }
+
+    if (node1 == NULL) {
+        return -1;
+    }
+
+    if (node2 == NULL) {
+        return 1;
+    }
+
+    return pcmk__numeric_strcasecmp(node1->details->uname,
+                                    node2->details->uname);
 }
 
 /*!


### PR DESCRIPTION
* Prepend `pe__` to `sort_node_uname()` and `sort_rsc_priority()` and add doc comment blocks and unit tests.
* Make `pe__sort_rsc_priority()` library-private.
* Update `pe__sort_node_uname()` to handle `NULL` values.
* Add a `NULL` check to `pcmk__numeric_strcasecmp()`.

Closes T534