### PR TITLE
Refactor: libpe_status: Bring common_unpack() up to current guidelines

### DIFF
--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -108,6 +108,7 @@ enum pcmk_rc_e {
     /* When adding new values, use consecutively lower numbers, update the array
      * in lib/common/results.c, and test with crm_error.
      */
+    pcmk_rc_unpack_error        = -1032,
     pcmk_rc_invalid_transition  = -1031,
     pcmk_rc_graph_error         = -1030,
     pcmk_rc_dot_error           = -1029,

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -309,8 +309,6 @@ enum rsc_role_e pe__bundle_resource_state(const pe_resource_t *rsc,
 void pe__count_common(pe_resource_t *rsc);
 void pe__count_bundle(pe_resource_t *rsc);
 
-gboolean common_unpack(xmlNode * xml_obj, pe_resource_t ** rsc, pe_resource_t * parent,
-                       pe_working_set_t * data_set);
 void common_free(pe_resource_t * rsc);
 
 pe_node_t *pe__copy_node(const pe_node_t *this_node);

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -195,6 +195,10 @@ static struct pcmk__rc_info {
       "Cluster simulation produced invalid transition",
       -pcmk_err_generic,
     },
+    { "pcmk_rc_unpack_error",
+      "Unable to parse CIB XML",
+      -pcmk_err_generic,
+    },
 };
 
 #define PCMK__N_RC (sizeof(pcmk__rcs) / sizeof(struct pcmk__rc_info))
@@ -582,6 +586,7 @@ pcmk_rc2exitc(int rc)
 
         case pcmk_rc_schema_validation:
         case pcmk_rc_transform_failed:
+        case pcmk_rc_unpack_error:
             return CRM_EX_CONFIG;
 
         case pcmk_rc_bad_nvpair:

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -588,13 +588,13 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
 
     *expanded_xml = NULL;
 
-    CRM_CHECK(xml_obj != NULL, return pcmk_rc_schema_validation);
+    CRM_CHECK(xml_obj != NULL, return EINVAL);
 
     id = ID(xml_obj);
     if (id == NULL) {
         pcmk__config_err("Ignoring <%s> constraint without " XML_ATTR_ID,
                          crm_element_name(xml_obj));
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     // Check whether there are any resource sets with template or tag references
@@ -614,14 +614,14 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
                                      &dependent_tag)) {
         pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
                          "valid resource or tag", id, dependent_id);
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     if (!pcmk__valid_resource_or_tag(data_set, primary_id, &primary,
                                      &primary_tag)) {
         pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
                          "valid resource or tag", id, primary_id);
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     if ((dependent != NULL) && (primary != NULL)) {
@@ -633,7 +633,7 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
         // A colocation constraint between two templates/tags makes no sense
         pcmk__config_err("Ignoring constraint '%s' because two templates or "
                          "tags cannot be colocated", id);
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     dependent_role = crm_element_value(xml_obj, XML_COLOC_ATTR_SOURCE_ROLE);
@@ -646,7 +646,7 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
                           true, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     if (dependent_set != NULL) {
@@ -663,7 +663,7 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
                           true, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     if (primary_set != NULL) {

--- a/lib/pacemaker/pcmk_sched_location.c
+++ b/lib/pacemaker/pcmk_sched_location.c
@@ -376,13 +376,13 @@ unpack_location_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
 
     *expanded_xml = NULL;
 
-    CRM_CHECK(xml_obj != NULL, return pcmk_rc_schema_validation);
+    CRM_CHECK(xml_obj != NULL, return EINVAL);
 
     id = ID(xml_obj);
     if (id == NULL) {
         pcmk__config_err("Ignoring <%s> constraint without " XML_ATTR_ID,
                          crm_element_name(xml_obj));
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     // Check whether there are any resource sets with template or tag references
@@ -400,7 +400,7 @@ unpack_location_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
     if (!pcmk__valid_resource_or_tag(data_set, rsc_id, &rsc, &tag)) {
         pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
                          "valid resource or tag", id, rsc_id);
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
 
     } else if (rsc != NULL) {
         // No template is referenced
@@ -416,7 +416,7 @@ unpack_location_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
                           false, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     if (rsc_set != NULL) {
@@ -446,14 +446,14 @@ unpack_location_set(xmlNode *location, xmlNode *set, pe_working_set_t *data_set)
     const char *role;
     const char *local_score;
 
-    CRM_CHECK(set != NULL, return pcmk_rc_schema_validation);
+    CRM_CHECK(set != NULL, return EINVAL);
 
     set_id = ID(set);
     if (set_id == NULL) {
         pcmk__config_err("Ignoring " XML_CONS_TAG_RSC_SET " without "
                          XML_ATTR_ID " in constraint '%s'",
                          pcmk__s(ID(location), "(missing ID)"));
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     role = crm_element_value(set, "role");
@@ -467,7 +467,7 @@ unpack_location_set(xmlNode *location, xmlNode *set, pe_working_set_t *data_set)
         if (resource == NULL) {
             pcmk__config_err("%s: No resource found for %s",
                              set_id, ID(xml_rsc));
-            return pcmk_rc_schema_validation;
+            return pcmk_rc_unpack_error;
         }
 
         unpack_rsc_location(location, resource, role, local_score, data_set,

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -32,7 +32,7 @@ enum ordering_symmetry {
         __rsc = pcmk__find_constraint_resource(data_set->resources, __name);    \
         if (__rsc == NULL) {                                                    \
             pcmk__config_err("%s: No resource found for %s", __set, __name);    \
-            return pcmk_rc_schema_validation;                                   \
+            return pcmk_rc_unpack_error;                                        \
         }                                                                       \
     } while (0)
 
@@ -1040,7 +1040,7 @@ order_rsc_sets(const char *id, xmlNode *set1, xmlNode *set2,
  * \param[in]  data_set      Cluster working set
  *
  * \return Standard Pacemaker return code (specifically, pcmk_rc_ok on success,
- *         and pcmk_rc_schema_validation on invalid configuration)
+ *         and pcmk_rc_unpack_error on invalid configuration)
  */
 static int
 unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
@@ -1077,13 +1077,13 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
                                      &tag_first)) {
         pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
                          "valid resource or tag", ID(xml_obj), id_first);
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     if (!pcmk__valid_resource_or_tag(data_set, id_then, &rsc_then, &tag_then)) {
         pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
                          "valid resource or tag", ID(xml_obj), id_then);
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     if ((rsc_first != NULL) && (rsc_then != NULL)) {
@@ -1101,7 +1101,7 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
                           true, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     if (rsc_set_first != NULL) {
@@ -1118,7 +1118,7 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
                           true, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     if (rsc_set_then != NULL) {

--- a/lib/pacemaker/pcmk_sched_tickets.c
+++ b/lib/pacemaker/pcmk_sched_tickets.c
@@ -251,7 +251,7 @@ unpack_rsc_ticket_set(xmlNode *set, pe_ticket_t *ticket,
     if (set_id == NULL) {
         pcmk__config_err("Ignoring <" XML_CONS_TAG_RSC_SET "> without "
                          XML_ATTR_ID);
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     role = crm_element_value(set, "role");
@@ -266,7 +266,7 @@ unpack_rsc_ticket_set(xmlNode *set, pe_ticket_t *ticket,
         if (resource == NULL) {
             pcmk__config_err("%s: No resource found for %s",
                              set_id, ID(xml_rsc));
-            return pcmk_rc_schema_validation;
+            return pcmk_rc_unpack_error;
         }
         pe_rsc_trace(resource, "Resource '%s' depends on ticket '%s'",
                      resource->id, ticket->id);
@@ -373,7 +373,7 @@ unpack_rsc_ticket_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
     if (id == NULL) {
         pcmk__config_err("Ignoring <%s> constraint without " XML_ATTR_ID,
                          crm_element_name(xml_obj));
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     // Check whether there are any resource sets with template or tag references
@@ -391,7 +391,7 @@ unpack_rsc_ticket_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
     if (!pcmk__valid_resource_or_tag(data_set, rsc_id, &rsc, &tag)) {
         pcmk__config_err("Ignoring constraint '%s' because '%s' is not a "
                          "valid resource or tag", id, rsc_id);
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
 
     } else if (rsc != NULL) {
         // No template or tag is referenced
@@ -407,7 +407,7 @@ unpack_rsc_ticket_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
                           false, data_set)) {
         free_xml(*expanded_xml);
         *expanded_xml = NULL;
-        return pcmk_rc_schema_validation;
+        return pcmk_rc_unpack_error;
     }
 
     if (rsc_set != NULL) {

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -161,7 +161,8 @@ create_ip_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
 
         // TODO: Other ops? Timeouts and intervals from underlying resource?
 
-        if (!pe__unpack_resource(xml_ip, &replica->ip, parent, data_set)) {
+        if (pe__unpack_resource(xml_ip, &replica->ip, parent,
+                                data_set) != pcmk_rc_ok) {
             return FALSE;
         }
 
@@ -327,8 +328,8 @@ create_docker_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
         crm_create_op_xml(xml_obj, ID(xml_container), "monitor", "60s", NULL);
 
         // TODO: Other ops? Timeouts and intervals from underlying resource?
-        if (!pe__unpack_resource(xml_container, &replica->container, parent,
-                                 data_set)) {
+        if (pe__unpack_resource(xml_container, &replica->container, parent,
+                                data_set) != pcmk_rc_ok) {
             return FALSE;
         }
         parent->children = g_list_append(parent->children, replica->container);
@@ -494,8 +495,8 @@ create_podman_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
         crm_create_op_xml(xml_obj, ID(xml_container), "monitor", "60s", NULL);
 
         // TODO: Other ops? Timeouts and intervals from underlying resource?
-        if (!pe__unpack_resource(xml_container, &replica->container, parent,
-                                 data_set)) {
+        if (pe__unpack_resource(xml_container, &replica->container, parent,
+                                data_set) != pcmk_rc_ok) {
             return FALSE;
         }
         parent->children = g_list_append(parent->children, replica->container);
@@ -664,8 +665,8 @@ create_rkt_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
 
         // TODO: Other ops? Timeouts and intervals from underlying resource?
 
-        if (!pe__unpack_resource(xml_container, &replica->container, parent,
-                                 data_set)) {
+        if (pe__unpack_resource(xml_container, &replica->container, parent,
+                                data_set) != pcmk_rc_ok) {
             return FALSE;
         }
         parent->children = g_list_append(parent->children, replica->container);
@@ -795,8 +796,8 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
             g_hash_table_insert(replica->child->parent->allowed_nodes,
                                 (gpointer) replica->node->details->id, copy);
         }
-        if (!pe__unpack_resource(xml_remote, &replica->remote, parent,
-                                 data_set)) {
+        if (pe__unpack_resource(xml_remote, &replica->remote, parent,
+                                data_set) != pcmk_rc_ok) {
             return FALSE;
         }
 
@@ -1197,7 +1198,7 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
         char *buffer = NULL;
 
         if (pe__unpack_resource(xml_resource, &new_rsc, rsc,
-                                data_set) == FALSE) {
+                                data_set) != pcmk_rc_ok) {
             pe_err("Failed unpacking resource %s", ID(rsc->xml));
             if (new_rsc != NULL && new_rsc->fns != NULL) {
                 new_rsc->fns->free(new_rsc);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -161,7 +161,7 @@ create_ip_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
 
         // TODO: Other ops? Timeouts and intervals from underlying resource?
 
-        if (!common_unpack(xml_ip, &replica->ip, parent, data_set)) {
+        if (!pe__unpack_resource(xml_ip, &replica->ip, parent, data_set)) {
             return FALSE;
         }
 
@@ -327,7 +327,8 @@ create_docker_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
         crm_create_op_xml(xml_obj, ID(xml_container), "monitor", "60s", NULL);
 
         // TODO: Other ops? Timeouts and intervals from underlying resource?
-        if (!common_unpack(xml_container, &replica->container, parent, data_set)) {
+        if (!pe__unpack_resource(xml_container, &replica->container, parent,
+                                 data_set)) {
             return FALSE;
         }
         parent->children = g_list_append(parent->children, replica->container);
@@ -493,8 +494,8 @@ create_podman_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
         crm_create_op_xml(xml_obj, ID(xml_container), "monitor", "60s", NULL);
 
         // TODO: Other ops? Timeouts and intervals from underlying resource?
-        if (!common_unpack(xml_container, &replica->container, parent,
-                           data_set)) {
+        if (!pe__unpack_resource(xml_container, &replica->container, parent,
+                                 data_set)) {
             return FALSE;
         }
         parent->children = g_list_append(parent->children, replica->container);
@@ -663,7 +664,8 @@ create_rkt_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
 
         // TODO: Other ops? Timeouts and intervals from underlying resource?
 
-        if (!common_unpack(xml_container, &replica->container, parent, data_set)) {
+        if (!pe__unpack_resource(xml_container, &replica->container, parent,
+                                 data_set)) {
             return FALSE;
         }
         parent->children = g_list_append(parent->children, replica->container);
@@ -762,7 +764,7 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
          *
          * Worse, that means that the node may have been utilized while
          * unpacking other resources, without our weight correction. The most
-         * likely place for this to happen is when common_unpack() calls
+         * likely place for this to happen is when pe__unpack_resource() calls
          * resource_location() to set a default score in symmetric clusters.
          * This adds a node *copy* to each resource's allowed nodes, and these
          * copies will have the wrong weight.
@@ -793,7 +795,8 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
             g_hash_table_insert(replica->child->parent->allowed_nodes,
                                 (gpointer) replica->node->details->id, copy);
         }
-        if (!common_unpack(xml_remote, &replica->remote, parent, data_set)) {
+        if (!pe__unpack_resource(xml_remote, &replica->remote, parent,
+                                 data_set)) {
             return FALSE;
         }
 
@@ -1193,7 +1196,8 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
         int offset = 0, max = 1024;
         char *buffer = NULL;
 
-        if (common_unpack(xml_resource, &new_rsc, rsc, data_set) == FALSE) {
+        if (pe__unpack_resource(xml_resource, &new_rsc, rsc,
+                                data_set) == FALSE) {
             pe_err("Failed unpacking resource %s", ID(rsc->xml));
             if (new_rsc != NULL && new_rsc->fns != NULL) {
                 new_rsc->fns->free(new_rsc);

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -210,7 +210,7 @@ pe__create_clone_child(pe_resource_t *rsc, pe_working_set_t *data_set)
 
     crm_xml_add(child_copy, XML_RSC_ATTR_INCARNATION, inc_num);
 
-    if (common_unpack(child_copy, &child_rsc, rsc, data_set) == FALSE) {
+    if (pe__unpack_resource(child_copy, &child_rsc, rsc, data_set) == FALSE) {
         pe_err("Failed unpacking resource %s", crm_element_value(child_copy, XML_ATTR_ID));
         child_rsc = NULL;
         goto bail;

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -210,7 +210,8 @@ pe__create_clone_child(pe_resource_t *rsc, pe_working_set_t *data_set)
 
     crm_xml_add(child_copy, XML_RSC_ATTR_INCARNATION, inc_num);
 
-    if (pe__unpack_resource(child_copy, &child_rsc, rsc, data_set) == FALSE) {
+    if (pe__unpack_resource(child_copy, &child_rsc, rsc,
+                            data_set) != pcmk_rc_ok) {
         pe_err("Failed unpacking resource %s", crm_element_value(child_copy, XML_ATTR_ID));
         child_rsc = NULL;
         goto bail;

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -570,6 +570,20 @@ unpack_requires(pe_resource_t *rsc, const char *value, bool is_default)
                  (is_default? " (default)" : ""));
 }
 
+/*!
+ * \internal
+ * \brief Unpack configuration XML for a given resource
+ *
+ * Unpack the XML object containing a resource's configuration into a new
+ * \c pe_resource_t object.
+ *
+ * \param[in]     xml_obj   XML node containing the resource's configuration
+ * \param[out]    rsc       Where to store the unpacked resource information
+ * \param[in]     parent    Resource's parent, if any
+ * \param[in,out] data_set  Cluster working set
+ *
+ * \return Standard Pacemaker return code
+ */
 int
 pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
                     pe_resource_t *parent, pe_working_set_t *data_set)

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -14,6 +14,8 @@
 #include <crm/msg_xml.h>
 #include <crm/common/xml_internal.h>
 
+#include "pe_status_private.h"
+
 void populate_hash(xmlNode * nvpair_list, GHashTable * hash, const char **attrs, int attrs_length);
 
 resource_object_functions_t resource_class_functions[] = {
@@ -569,8 +571,8 @@ unpack_requires(pe_resource_t *rsc, const char *value, bool is_default)
 }
 
 gboolean
-common_unpack(xmlNode * xml_obj, pe_resource_t ** rsc,
-              pe_resource_t * parent, pe_working_set_t * data_set)
+pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
+                    pe_resource_t *parent, pe_working_set_t *data_set)
 {
     xmlNode *expanded_xml = NULL;
     xmlNode *ops = NULL;

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -579,9 +579,9 @@ pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
     const char *value = NULL;
     const char *rclass = NULL; /* Look for this after any templates have been expanded */
     const char *id = crm_element_value(xml_obj, XML_ATTR_ID);
-    bool guest_node = FALSE;
-    bool remote_node = FALSE;
-    bool has_versioned_params = FALSE;
+    bool guest_node = false;
+    bool remote_node = false;
+    bool has_versioned_params = false;
 
     pe_rule_eval_data_t rule_data = {
         .node_hash = NULL,
@@ -695,9 +695,9 @@ pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
     if (xml_contains_remote_node((*rsc)->xml)) {
         (*rsc)->is_remote_node = TRUE;
         if (g_hash_table_lookup((*rsc)->meta, XML_RSC_ATTR_CONTAINER)) {
-            guest_node = TRUE;
+            guest_node = true;
         } else {
-            remote_node = TRUE;
+            remote_node = true;
         }
     }
 

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -134,7 +134,7 @@ group_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
 
             crm_xml_add(xml_native_rsc, XML_RSC_ATTR_INCARNATION, clone_id);
             if (pe__unpack_resource(xml_native_rsc, &new_rsc, rsc,
-                                    data_set) == FALSE) {
+                                    data_set) != pcmk_rc_ok) {
                 pe_err("Failed unpacking resource %s", crm_element_value(xml_obj, XML_ATTR_ID));
                 if (new_rsc != NULL && new_rsc->fns != NULL) {
                     new_rsc->fns->free(new_rsc);

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -133,7 +133,8 @@ group_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
             pe_resource_t *new_rsc = NULL;
 
             crm_xml_add(xml_native_rsc, XML_RSC_ATTR_INCARNATION, clone_id);
-            if (common_unpack(xml_native_rsc, &new_rsc, rsc, data_set) == FALSE) {
+            if (pe__unpack_resource(xml_native_rsc, &new_rsc, rsc,
+                                    data_set) == FALSE) {
                 pe_err("Failed unpacking resource %s", crm_element_value(xml_obj, XML_ATTR_ID));
                 if (new_rsc != NULL && new_rsc->fns != NULL) {
                     new_rsc->fns->free(new_rsc);

--- a/lib/pengine/pe_status_private.h
+++ b/lib/pengine/pe_status_private.h
@@ -46,6 +46,10 @@ G_GNUC_INTERNAL
 gint pe__cmp_rsc_priority(gconstpointer a, gconstpointer b);
 
 G_GNUC_INTERNAL
+gboolean pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
+                             pe_resource_t *parent, pe_working_set_t *data_set);
+
+G_GNUC_INTERNAL
 gboolean unpack_remote_nodes(xmlNode *xml_resources, pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -789,7 +789,8 @@ unpack_resources(xmlNode * xml_resources, pe_working_set_t * data_set)
         }
 
         crm_trace("Unpacking <%s id='%s'>", crm_element_name(xml_obj), id);
-        if (pe__unpack_resource(xml_obj, &new_rsc, NULL, data_set)
+        if ((pe__unpack_resource(xml_obj, &new_rsc, NULL,
+                                 data_set) == pcmk_rc_ok)
             && (new_rsc != NULL)) {
 
             data_set->resources = g_list_append(data_set->resources, new_rsc);
@@ -1690,7 +1691,7 @@ create_fake_resource(const char *rsc_id, xmlNode * rsc_entry, pe_working_set_t *
     crm_xml_add(xml_rsc, XML_ATTR_ID, rsc_id);
     crm_log_xml_debug(xml_rsc, "Orphan resource");
 
-    if (!pe__unpack_resource(xml_rsc, &rsc, NULL, data_set)) {
+    if (pe__unpack_resource(xml_rsc, &rsc, NULL, data_set) != pcmk_rc_ok) {
         return NULL;
     }
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -756,7 +756,7 @@ destroy_tag(gpointer data)
  * \return TRUE
  *
  * \note unpack_remote_nodes() MUST be called before this, so that the nodes can
- *       be used when common_unpack() calls resource_location()
+ *       be used when pe__unpack_resource() calls resource_location()
  */
 gboolean
 unpack_resources(xmlNode * xml_resources, pe_working_set_t * data_set)
@@ -789,7 +789,9 @@ unpack_resources(xmlNode * xml_resources, pe_working_set_t * data_set)
         }
 
         crm_trace("Unpacking <%s id='%s'>", crm_element_name(xml_obj), id);
-        if (common_unpack(xml_obj, &new_rsc, NULL, data_set) && (new_rsc != NULL)) {
+        if (pe__unpack_resource(xml_obj, &new_rsc, NULL, data_set)
+            && (new_rsc != NULL)) {
+
             data_set->resources = g_list_append(data_set->resources, new_rsc);
             pe_rsc_trace(new_rsc, "Added resource %s", new_rsc->id);
 
@@ -1688,7 +1690,7 @@ create_fake_resource(const char *rsc_id, xmlNode * rsc_entry, pe_working_set_t *
     crm_xml_add(xml_rsc, XML_ATTR_ID, rsc_id);
     crm_log_xml_debug(xml_rsc, "Orphan resource");
 
-    if (!common_unpack(xml_rsc, &rsc, NULL, data_set)) {
+    if (!pe__unpack_resource(xml_rsc, &rsc, NULL, data_set)) {
         return NULL;
     }
 


### PR DESCRIPTION
* Rename to `pe__unpack_resource()` and make library-private
* Use `true`/`false` instead of `TRUE`/`FALSE` with its `bool` variables
* Return a standard Pacemaker return code (currently only `pcmk_rc_ok` or `pcmk_rc_error`, since no others seemed to fit)
* Add a Doxygen comment block

Closes T540