### PR TITLE
Refactor: pacemaker-schedulerd: Constants for graph/config errors/warnings

### DIFF
--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -147,10 +147,10 @@ handle_pecalc_request(pcmk__request_t *request)
     }
 
     crm_xml_add(reply, F_CRM_TGRAPH_INPUT, filename);
-    crm_xml_add_int(reply, "graph-errors", was_processing_error);
-    crm_xml_add_int(reply, "graph-warnings", was_processing_warning);
-    crm_xml_add_int(reply, "config-errors", crm_config_error);
-    crm_xml_add_int(reply, "config-warnings", crm_config_warning);
+    crm_xml_add_int(reply, PCMK__XA_GRAPH_ERRORS, was_processing_error);
+    crm_xml_add_int(reply, PCMK__XA_GRAPH_WARNINGS, was_processing_warning);
+    crm_xml_add_int(reply, PCMK__XA_CONFIG_ERRORS, crm_config_error);
+    crm_xml_add_int(reply, PCMK__XA_CONFIG_WARNINGS, crm_config_warning);
 
     pcmk__log_transition_summary(filename);
 

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -76,6 +76,10 @@
 #define PCMK__XA_ATTR_VALUE             "attr_value"
 #define PCMK__XA_ATTR_VERSION           "attr_version"
 #define PCMK__XA_ATTR_WRITER            "attr_writer"
+#define PCMK__XA_CONFIG_ERRORS          "config-errors"
+#define PCMK__XA_CONFIG_WARNINGS        "config-warnings"
+#define PCMK__XA_GRAPH_ERRORS           "graph-errors"
+#define PCMK__XA_GRAPH_WARNINGS         "graph-warnings"
 #define PCMK__XA_MODE                   "mode"
 #define PCMK__XA_TASK                   "task"
 


### PR DESCRIPTION
Define new string constants and use them instead of string literals

Closes T541