### PR TITLE
Med: libcrmcommon: Wait for ACKs from the attrd refresh command.

### DIFF
--- a/lib/common/ipc_attrd.c
+++ b/lib/common/ipc_attrd.c
@@ -48,9 +48,13 @@ reply_expected(pcmk_ipc_api_t *api, xmlNode *request)
 {
     const char *command = crm_element_value(request, PCMK__XA_TASK);
 
-    return pcmk__str_any_of(command, PCMK__ATTRD_CMD_UPDATE,
-                            PCMK__ATTRD_CMD_UPDATE_BOTH, PCMK__ATTRD_CMD_UPDATE_DELAY,
-                            PCMK__ATTRD_CMD_QUERY, NULL);
+    return pcmk__str_any_of(command,
+                            PCMK__ATTRD_CMD_QUERY,
+                            PCMK__ATTRD_CMD_REFRESH,
+                            PCMK__ATTRD_CMD_UPDATE,
+                            PCMK__ATTRD_CMD_UPDATE_BOTH,
+                            PCMK__ATTRD_CMD_UPDATE_DELAY,
+                            NULL);
 }
 
 static bool


### PR DESCRIPTION
The commit message for 494cbdd3be616a9dbbdd3151c4f49e169b2be1d6 is
relevant here, too.  This basically extends that commit to wait for ACKs
for the refresh command.  Without this, it doesn't appear that anything
ever happens on the server side.