### PR TITLE
Clarify pointer argument usage in libcrmcommon

### DIFF
--- a/doc/sphinx/Pacemaker_Development/c.rst
+++ b/doc/sphinx/Pacemaker_Development/c.rst
@@ -216,6 +216,14 @@ Simple example of an internal function with a Doxygen comment block:
       return strlen(s) + 1;
    }
 
+Function arguments are marked as ``[in]`` for input only, ``[out]`` for output
+only, or ``[in,out]`` for both input and output. ``[in,out]`` should be used
+for struct pointer arguments if *any* data reachable by the pointer might
+change. For example, if the struct contains a ``GHashTable *`` member, a
+doxygen block for a function that inserts data into the hash table should mark
+the struct pointer argument as ``[in,out]`` even if the struct members
+themselves are not changed.
+
 
 Public API Deprecation
 ______________________

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -89,7 +89,7 @@ pcmk__xe_set_bool_attr(xmlNodePtr node, const char *name, bool value);
  *         the value "true", False in all other cases
  */
 bool
-pcmk__xe_attr_is_true(xmlNodePtr node, const char *name);
+pcmk__xe_attr_is_true(const xmlNode *node, const char *name);
 
 /*!
  * \internal
@@ -107,7 +107,7 @@ pcmk__xe_attr_is_true(xmlNodePtr node, const char *name);
  * \note \p value only has any meaning if the return value is pcmk_rc_ok.
  */
 int
-pcmk__xe_get_bool_attr(xmlNodePtr node, const char *name, bool *value);
+pcmk__xe_get_bool_attr(const xmlNode *node, const char *name, bool *value);
 
 
 /* internal procfs utilities (from procfs.c) */

--- a/include/crm/common/ipc.h
+++ b/include/crm/common/ipc.h
@@ -37,7 +37,7 @@ extern "C" {
 #define create_reply(request, xml_response_data)    \
     create_reply_adv(request, xml_response_data, __func__)
 
-xmlNode *create_reply_adv(xmlNode *request, xmlNode *xml_response_data,
+xmlNode *create_reply_adv(const xmlNode *request, xmlNode *xml_response_data,
                           const char *origin);
 
 #define create_request(task, xml_data, host_to, sys_to, sys_from, uuid_from) \

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -220,9 +220,9 @@ void pcmk__foreach_ipc_client(GHFunc func, gpointer user_data);
 
 void pcmk__client_cleanup(void);
 
-pcmk__client_t *pcmk__find_client(qb_ipcs_connection_t *c);
+pcmk__client_t *pcmk__find_client(const qb_ipcs_connection_t *c);
 pcmk__client_t *pcmk__find_client_by_id(const char *id);
-const char *pcmk__client_name(pcmk__client_t *c);
+const char *pcmk__client_name(const pcmk__client_t *c);
 const char *pcmk__client_type_str(uint64_t client_type);
 
 pcmk__client_t *pcmk__new_unauth_client(void *key);

--- a/include/crm/common/logging.h
+++ b/include/crm/common/logging.h
@@ -131,8 +131,9 @@ void crm_enable_stderr(int enable);
 
 gboolean crm_is_callsite_active(struct qb_log_callsite *cs, uint8_t level, uint32_t tags);
 
-void log_data_element(int log_level, const char *file, const char *function, int line,
-                      const char *prefix, xmlNode * data, int depth, gboolean formatted);
+void log_data_element(int log_level, const char *file, const char *function,
+                      int line, const char *prefix, const xmlNode *data,
+                      int depth, gboolean formatted);
 
 /* returns the old value */
 unsigned int set_crm_log_level(unsigned int level);

--- a/include/crm/common/nvpair.h
+++ b/include/crm/common/nvpair.h
@@ -43,7 +43,7 @@ void hash2nvpair(gpointer key, gpointer value, gpointer user_data);
 void hash2field(gpointer key, gpointer value, gpointer user_data);
 void hash2metafield(gpointer key, gpointer value, gpointer user_data);
 void hash2smartfield(gpointer key, gpointer value, gpointer user_data);
-GHashTable *xml2list(xmlNode *parent);
+GHashTable *xml2list(const xmlNode *parent);
 
 const char *crm_xml_add(xmlNode *node, const char *name, const char *value);
 const char *crm_xml_replace(xmlNode *node, const char *name, const char *value);

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -156,7 +156,8 @@ gboolean can_prune_leaf(xmlNode * xml_node);
 /*
  * Searching & Modifying
  */
-xmlNode *find_xml_node(xmlNode * cib, const char *node_path, gboolean must_find);
+xmlNode *find_xml_node(const xmlNode *root, const char *search_path,
+                       gboolean must_find);
 
 void xml_remove_prop(xmlNode * obj, const char *name);
 

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -287,7 +287,7 @@ void xml_calculate_significant_changes(xmlNode *old_xml, xmlNode *new_xml);
 void xml_accept_changes(xmlNode * xml);
 void xml_log_changes(uint8_t level, const char *function, xmlNode *xml);
 void xml_log_patchset(uint8_t level, const char *function, xmlNode *xml);
-bool xml_patch_versions(xmlNode *patchset, int add[3], int del[3]);
+bool xml_patch_versions(const xmlNode *patchset, int add[3], int del[3]);
 
 xmlNode *xml_create_patchset(
     int format, xmlNode *source, xmlNode *target, bool *config, bool manage_version);

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -50,7 +50,7 @@ extern "C" {
 typedef const xmlChar *pcmkXmlStr;
 
 gboolean add_message_xml(xmlNode * msg, const char *field, xmlNode * xml);
-xmlNode *get_message_xml(xmlNode * msg, const char *field);
+xmlNode *get_message_xml(const xmlNode *msg, const char *field);
 
 xmlDoc *getDocPtr(xmlNode * node);
 

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -296,7 +296,7 @@ int xml_apply_patchset(xmlNode *xml, xmlNode *patchset, bool check_version);
 void patchset_process_digest(xmlNode *patch, xmlNode *source, xmlNode *target, bool with_digest);
 
 void save_xml_to_file(xmlNode * xml, const char *desc, const char *filename);
-char *xml_get_path(xmlNode *xml);
+char *xml_get_path(const xmlNode *xml);
 
 char * crm_xml_escape(const char *text);
 void crm_xml_sanitize_id(char *id);

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -68,7 +68,7 @@ G_GNUC_INTERNAL
 bool pcmk__tracking_xml_changes(xmlNode *xml, bool lazy);
 
 G_GNUC_INTERNAL
-int pcmk__element_xpath(const char *prefix, xmlNode *xml, char *buffer,
+int pcmk__element_xpath(const char *prefix, const xmlNode *xml, char *buffer,
                         int offset, size_t buffer_size);
 
 G_GNUC_INTERNAL

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -82,7 +82,7 @@ xmlNode *pcmk__xml_match(xmlNode *haystack, xmlNode *needle, bool exact);
 
 G_GNUC_INTERNAL
 void pcmk__xe_log(int log_level, const char *file, const char *function,
-                  int line, const char *prefix, xmlNode *data, int depth,
+                  int line, const char *prefix, const xmlNode *data, int depth,
                   int options);
 
 G_GNUC_INTERNAL

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -56,7 +56,7 @@ pcmk__foreach_ipc_client(GHFunc func, gpointer user_data)
 }
 
 pcmk__client_t *
-pcmk__find_client(qb_ipcs_connection_t *c)
+pcmk__find_client(const qb_ipcs_connection_t *c)
 {
     if (client_connections) {
         return g_hash_table_lookup(client_connections, c);
@@ -95,7 +95,7 @@ pcmk__find_client_by_id(const char *id)
  * \note This is intended to be used in format strings like "client %s".
  */
 const char *
-pcmk__client_name(pcmk__client_t *c)
+pcmk__client_name(const pcmk__client_t *c)
 {
     if (c == NULL) {
         return "(unspecified)";

--- a/lib/common/messages.c
+++ b/lib/common/messages.c
@@ -151,11 +151,9 @@ create_reply_adv(xmlNode *original_request, xmlNode *xml_response_data,
 }
 
 xmlNode *
-get_message_xml(xmlNode *msg, const char *field)
+get_message_xml(const xmlNode *msg, const char *field)
 {
-    xmlNode *tmp = first_named_child(msg, field);
-
-    return pcmk__xml_first_child(tmp);
+    return pcmk__xml_first_child(first_named_child(msg, field));
 }
 
 gboolean

--- a/lib/common/messages.c
+++ b/lib/common/messages.c
@@ -99,7 +99,7 @@ create_request_adv(const char *task, xmlNode * msg_data,
  * \note The caller is responsible for freeing the result using free_xml().
  */
 xmlNode *
-create_reply_adv(xmlNode *original_request, xmlNode *xml_response_data,
+create_reply_adv(const xmlNode *original_request, xmlNode *xml_response_data,
                  const char *origin)
 {
     xmlNode *reply = NULL;

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -945,7 +945,8 @@ pcmk__xe_set_bool_attr(xmlNodePtr node, const char *name, bool value)
 }
 
 int
-pcmk__xe_get_bool_attr(xmlNodePtr node, const char *name, bool *value) {
+pcmk__xe_get_bool_attr(const xmlNode *node, const char *name, bool *value)
+{
     const char *xml_value = NULL;
     int ret, rc;
 
@@ -971,7 +972,7 @@ pcmk__xe_get_bool_attr(xmlNodePtr node, const char *name, bool *value) {
 }
 
 bool
-pcmk__xe_attr_is_true(xmlNodePtr node, const char *name)
+pcmk__xe_attr_is_true(const xmlNode *node, const char *name)
 {
     bool value = false;
     int rc;

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -893,7 +893,7 @@ hash2nvpair(gpointer key, gpointer value, gpointer user_data)
  *       \c g_hash_table_destroy().
  */
 GHashTable *
-xml2list(xmlNode *parent)
+xml2list(const xmlNode *parent)
 {
     xmlNode *child = NULL;
     xmlAttrPtr pIter = NULL;

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -768,7 +768,7 @@ process_v1_additions(xmlNode *parent, xmlNode *target, xmlNode *patch)
  * \return TRUE if format is valid, FALSE if invalid
  */
 static bool
-find_patch_xml_node(xmlNode *patchset, int format, bool added,
+find_patch_xml_node(const xmlNode *patchset, int format, bool added,
                     xmlNode **patch_node)
 {
     xmlNode *cib_node;
@@ -798,7 +798,7 @@ find_patch_xml_node(xmlNode *patchset, int format, bool added,
 
 // Get CIB versions used for additions and deletions in a patchset
 bool
-xml_patch_versions(xmlNode *patchset, int add[3], int del[3])
+xml_patch_versions(const xmlNode *patchset, int add[3], int del[3])
 {
     int lpc = 0;
     int format = 1;

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1572,7 +1572,7 @@ pcmk__xe_log(int log_level, const char *file, const char *function, int line,
 // Log XML portions that have been marked as changed
 static void
 log_xml_changes(int log_level, const char *file, const char *function, int line,
-                const char *prefix, xmlNode *data, int depth, int options)
+                const char *prefix, const xmlNode *data, int depth, int options)
 {
     xml_private_t *p;
     char *prefix_m = NULL;
@@ -1671,8 +1671,9 @@ log_xml_changes(int log_level, const char *file, const char *function, int line,
 }
 
 void
-log_data_element(int log_level, const char *file, const char *function, int line,
-                 const char *prefix, xmlNode * data, int depth, int options)
+log_data_element(int log_level, const char *file, const char *function,
+                 int line, const char *prefix, const xmlNode *data, int depth,
+                 int options)
 {
     xmlNode *a_child = NULL;
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -442,7 +442,7 @@ xml_accept_changes(xmlNode * xml)
 }
 
 xmlNode *
-find_xml_node(xmlNode * root, const char *search_path, gboolean must_find)
+find_xml_node(const xmlNode *root, const char *search_path, gboolean must_find)
 {
     xmlNode *a_child = NULL;
     const char *name = "NULL";

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1470,7 +1470,7 @@ dump_xml_attr(xmlAttrPtr attr, int options, char **buffer, int *offset, int *max
 // Log an XML element (and any children) in a formatted way
 void
 pcmk__xe_log(int log_level, const char *file, const char *function, int line,
-             const char *prefix, xmlNode *data, int depth, int options)
+             const char *prefix, const xmlNode *data, int depth, int options)
 {
     int max = 0;
     int offset = 0;

--- a/lib/common/xpath.c
+++ b/lib/common/xpath.c
@@ -267,7 +267,7 @@ get_xpath_object(const char *xpath, xmlNode * xml_obj, int error_level)
 }
 
 int
-pcmk__element_xpath(const char *prefix, xmlNode *xml, char *buffer,
+pcmk__element_xpath(const char *prefix, const xmlNode *xml, char *buffer,
                     int offset, size_t buffer_size)
 {
     const char *id = ID(xml);
@@ -289,7 +289,7 @@ pcmk__element_xpath(const char *prefix, xmlNode *xml, char *buffer,
 }
 
 char *
-xml_get_path(xmlNode *xml)
+xml_get_path(const xmlNode *xml)
 {
     int offset = 0;
     char buffer[PCMK__BUFFER_SIZE];


### PR DESCRIPTION
Now that we've decided on a convention for doxygen documentation of pointer arguments, update some functions in libcrmcommon. Change doxygen comments from in to in,out where appropriate, and change pointer arguments to const where appropriate. This is not comprehensive but takes care of functions that will be needed to update daemons similarly.