### PR TITLE
Use const arguments in iso8601.c when appropriate

### DIFF
--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -83,7 +83,8 @@ int crm_time_compare(crm_time_t * dt, crm_time_t * rhs);
 int crm_time_get_timeofday(const crm_time_t *dt, uint32_t *h, uint32_t *m,
                            uint32_t *s);
 int crm_time_get_timezone(const crm_time_t *dt, uint32_t *h, uint32_t *m);
-int crm_time_get_gregorian(crm_time_t * dt, uint32_t * y, uint32_t * m, uint32_t * d);
+int crm_time_get_gregorian(const crm_time_t *dt, uint32_t *y, uint32_t *m,
+                           uint32_t *d);
 int crm_time_get_ordinal(crm_time_t * dt, uint32_t * y, uint32_t * d);
 int crm_time_get_isoweek(crm_time_t * dt, uint32_t * y, uint32_t * w, uint32_t * d);
 

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -80,7 +80,7 @@ crm_time_t *crm_time_calculate_duration(const crm_time_t *dt,
 crm_time_period_t *crm_time_parse_period(const char *period_str);
 void crm_time_free_period(crm_time_period_t *period);
 
-int crm_time_compare(crm_time_t * dt, crm_time_t * rhs);
+int crm_time_compare(const crm_time_t *a, const crm_time_t *b);
 
 int crm_time_get_timeofday(const crm_time_t *dt, uint32_t *h, uint32_t *m,
                            uint32_t *s);

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -80,7 +80,8 @@ void crm_time_free_period(crm_time_period_t *period);
 
 int crm_time_compare(crm_time_t * dt, crm_time_t * rhs);
 
-int crm_time_get_timeofday(crm_time_t * dt, uint32_t * h, uint32_t * m, uint32_t * s);
+int crm_time_get_timeofday(const crm_time_t *dt, uint32_t *h, uint32_t *m,
+                           uint32_t *s);
 int crm_time_get_timezone(crm_time_t * dt, uint32_t * h, uint32_t * m);
 int crm_time_get_gregorian(crm_time_t * dt, uint32_t * y, uint32_t * m, uint32_t * d);
 int crm_time_get_ordinal(crm_time_t * dt, uint32_t * y, uint32_t * d);

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -103,7 +103,7 @@ void crm_time_set_timet(crm_time_t *target, const time_t *source);
 /* Returns a new time object */
 crm_time_t *pcmk_copy_time(const crm_time_t *source);
 crm_time_t *crm_time_add(const crm_time_t *dt, const crm_time_t *value);
-crm_time_t *crm_time_subtract(crm_time_t * dt, crm_time_t * value);
+crm_time_t *crm_time_subtract(const crm_time_t *dt, const crm_time_t *value);
 
 /* All crm_time_add_... functions support negative values */
 void crm_time_add_seconds(crm_time_t * dt, int value);

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -85,7 +85,7 @@ int crm_time_get_timeofday(const crm_time_t *dt, uint32_t *h, uint32_t *m,
 int crm_time_get_timezone(const crm_time_t *dt, uint32_t *h, uint32_t *m);
 int crm_time_get_gregorian(const crm_time_t *dt, uint32_t *y, uint32_t *m,
                            uint32_t *d);
-int crm_time_get_ordinal(crm_time_t * dt, uint32_t * y, uint32_t * d);
+int crm_time_get_ordinal(const crm_time_t *dt, uint32_t *y, uint32_t *d);
 int crm_time_get_isoweek(crm_time_t * dt, uint32_t * y, uint32_t * w, uint32_t * d);
 
 /* Time in seconds since 0000-01-01 00:00:00Z */

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -96,7 +96,7 @@ long long crm_time_get_seconds(const crm_time_t *dt);
 /* Time in seconds since 1970-01-01 00:00:00Z */
 long long crm_time_get_seconds_since_epoch(const crm_time_t *dt);
 
-void crm_time_set(crm_time_t * target, crm_time_t * source);
+void crm_time_set(crm_time_t *target, const crm_time_t *source);
 void crm_time_set_timet(crm_time_t * target, time_t * source);
 
 /* Returns a new time object */

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -55,13 +55,14 @@ crm_time_t *crm_time_new_undefined(void);
 void crm_time_free(crm_time_t * dt);
 
 bool crm_time_is_defined(const crm_time_t *t);
-char *crm_time_as_string(crm_time_t * dt, int flags);
+char *crm_time_as_string(const crm_time_t *dt, int flags);
 
 #define crm_time_log(level, prefix, dt, flags)  \
     crm_time_log_alias(level, __FILE__, __func__, __LINE__, prefix, dt, flags)
 
-void crm_time_log_alias(int log_level, const char *file, const char *function, int line,
-                        const char *prefix, crm_time_t * date_time, int flags);
+void crm_time_log_alias(int log_level, const char *file, const char *function,
+                        int line, const char *prefix,
+                        const crm_time_t *date_time, int flags);
 
 #  define crm_time_log_date          0x001
 #  define crm_time_log_timeofday     0x002
@@ -90,10 +91,10 @@ int crm_time_get_isoweek(const crm_time_t *dt, uint32_t *y, uint32_t *w,
                          uint32_t * d);
 
 /* Time in seconds since 0000-01-01 00:00:00Z */
-long long int crm_time_get_seconds(crm_time_t * dt);
+long long crm_time_get_seconds(const crm_time_t *dt);
 
 /* Time in seconds since 1970-01-01 00:00:00Z */
-long long int crm_time_get_seconds_since_epoch(crm_time_t * dt);
+long long crm_time_get_seconds_since_epoch(const crm_time_t *dt);
 
 void crm_time_set(crm_time_t * target, crm_time_t * source);
 void crm_time_set_timet(crm_time_t * target, time_t * source);

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -120,7 +120,7 @@ int crm_time_weeks_in_year(int year);
 int crm_time_days_in_month(int month, int year);
 
 bool crm_time_leapyear(int year);
-bool crm_time_check(crm_time_t * dt);
+bool crm_time_check(const crm_time_t *dt);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -82,7 +82,7 @@ int crm_time_compare(crm_time_t * dt, crm_time_t * rhs);
 
 int crm_time_get_timeofday(const crm_time_t *dt, uint32_t *h, uint32_t *m,
                            uint32_t *s);
-int crm_time_get_timezone(crm_time_t * dt, uint32_t * h, uint32_t * m);
+int crm_time_get_timezone(const crm_time_t *dt, uint32_t *h, uint32_t *m);
 int crm_time_get_gregorian(crm_time_t * dt, uint32_t * y, uint32_t * m, uint32_t * d);
 int crm_time_get_ordinal(crm_time_t * dt, uint32_t * y, uint32_t * d);
 int crm_time_get_isoweek(crm_time_t * dt, uint32_t * y, uint32_t * w, uint32_t * d);

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -86,7 +86,8 @@ int crm_time_get_timezone(const crm_time_t *dt, uint32_t *h, uint32_t *m);
 int crm_time_get_gregorian(const crm_time_t *dt, uint32_t *y, uint32_t *m,
                            uint32_t *d);
 int crm_time_get_ordinal(const crm_time_t *dt, uint32_t *y, uint32_t *d);
-int crm_time_get_isoweek(crm_time_t * dt, uint32_t * y, uint32_t * w, uint32_t * d);
+int crm_time_get_isoweek(const crm_time_t *dt, uint32_t *y, uint32_t *w,
+                         uint32_t * d);
 
 /* Time in seconds since 0000-01-01 00:00:00Z */
 long long int crm_time_get_seconds(crm_time_t * dt);

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -97,7 +97,7 @@ long long crm_time_get_seconds(const crm_time_t *dt);
 long long crm_time_get_seconds_since_epoch(const crm_time_t *dt);
 
 void crm_time_set(crm_time_t *target, const crm_time_t *source);
-void crm_time_set_timet(crm_time_t * target, time_t * source);
+void crm_time_set_timet(crm_time_t *target, const time_t *source);
 
 /* Returns a new time object */
 crm_time_t *pcmk_copy_time(crm_time_t *source);

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -75,7 +75,8 @@ void crm_time_log_alias(int log_level, const char *file, const char *function,
 #  define crm_time_epoch             0x200
 
 crm_time_t *crm_time_parse_duration(const char *duration_str);
-crm_time_t *crm_time_calculate_duration(crm_time_t * dt, crm_time_t * value);
+crm_time_t *crm_time_calculate_duration(const crm_time_t *dt,
+                                        const crm_time_t *value);
 crm_time_period_t *crm_time_parse_period(const char *period_str);
 void crm_time_free_period(crm_time_period_t *period);
 

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -100,7 +100,7 @@ void crm_time_set(crm_time_t *target, const crm_time_t *source);
 void crm_time_set_timet(crm_time_t *target, const time_t *source);
 
 /* Returns a new time object */
-crm_time_t *pcmk_copy_time(crm_time_t *source);
+crm_time_t *pcmk_copy_time(const crm_time_t *source);
 crm_time_t *crm_time_add(crm_time_t * dt, crm_time_t * value);
 crm_time_t *crm_time_subtract(crm_time_t * dt, crm_time_t * value);
 

--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -101,7 +101,7 @@ void crm_time_set_timet(crm_time_t *target, const time_t *source);
 
 /* Returns a new time object */
 crm_time_t *pcmk_copy_time(const crm_time_t *source);
-crm_time_t *crm_time_add(crm_time_t * dt, crm_time_t * value);
+crm_time_t *crm_time_add(const crm_time_t *dt, const crm_time_t *value);
 crm_time_t *crm_time_subtract(crm_time_t * dt, crm_time_t * value);
 
 /* All crm_time_add_... functions support negative values */

--- a/include/crm/common/iso8601_internal.h
+++ b/include/crm/common/iso8601_internal.h
@@ -17,13 +17,14 @@
 
 typedef struct pcmk__time_us pcmk__time_hr_t;
 
-pcmk__time_hr_t *pcmk__time_hr_convert(pcmk__time_hr_t *target, crm_time_t *dt);
-void pcmk__time_set_hr_dt(crm_time_t *target, pcmk__time_hr_t *hr_dt);
+pcmk__time_hr_t *pcmk__time_hr_convert(pcmk__time_hr_t *target,
+                                       const crm_time_t *dt);
+void pcmk__time_set_hr_dt(crm_time_t *target, const pcmk__time_hr_t *hr_dt);
 pcmk__time_hr_t *pcmk__time_hr_now(time_t *epoch);
 pcmk__time_hr_t *pcmk__time_hr_new(const char *date_time);
 void pcmk__time_hr_free(pcmk__time_hr_t *hr_dt);
-char *pcmk__time_format_hr(const char *format, pcmk__time_hr_t *hr_dt);
-const char *pcmk__epoch2str(time_t *when);
+char *pcmk__time_format_hr(const char *format, const pcmk__time_hr_t *hr_dt);
+const char *pcmk__epoch2str(const time_t *when);
 const char *pcmk__readable_interval(guint interval_ms);
 
 struct pcmk__time_us {

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1271,7 +1271,7 @@ pcmk_copy_time(const crm_time_t *source)
 }
 
 crm_time_t *
-crm_time_add(crm_time_t * dt, crm_time_t * value)
+crm_time_add(const crm_time_t *dt, const crm_time_t *value)
 {
     crm_time_t *utc = NULL;
     crm_time_t *answer = NULL;

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1299,7 +1299,7 @@ crm_time_add(const crm_time_t *dt, const crm_time_t *value)
 }
 
 crm_time_t *
-crm_time_calculate_duration(crm_time_t * dt, crm_time_t * value)
+crm_time_calculate_duration(const crm_time_t *dt, const crm_time_t *value)
 {
     crm_time_t *utc = NULL;
     crm_time_t *answer = NULL;

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -59,7 +59,7 @@ struct crm_time_s {
 static crm_time_t *parse_date(const char *date_str);
 
 static crm_time_t *
-crm_get_utc_time(crm_time_t *dt)
+crm_get_utc_time(const crm_time_t *dt)
 {
     crm_time_t *utc = NULL;
 
@@ -248,8 +248,9 @@ get_ordinal_days(uint32_t y, uint32_t m, uint32_t d)
 }
 
 void
-crm_time_log_alias(int log_level, const char *file, const char *function, int line,
-                   const char *prefix, crm_time_t * date_time, int flags)
+crm_time_log_alias(int log_level, const char *file, const char *function,
+                   int line, const char *prefix, const crm_time_t *date_time,
+                   int flags)
 {
     char *date_s = crm_time_as_string(date_time, flags);
 
@@ -305,7 +306,7 @@ crm_time_get_timezone(const crm_time_t *dt, uint32_t *h, uint32_t *m)
 }
 
 long long
-crm_time_get_seconds(crm_time_t * dt)
+crm_time_get_seconds(const crm_time_t *dt)
 {
     int lpc;
     crm_time_t *utc = NULL;
@@ -348,7 +349,7 @@ crm_time_get_seconds(crm_time_t * dt)
 
 #define EPOCH_SECONDS 62135596800ULL    /* Calculated using crm_time_get_seconds() */
 long long
-crm_time_get_seconds_since_epoch(crm_time_t * dt)
+crm_time_get_seconds_since_epoch(const crm_time_t *dt)
 {
     return (dt == NULL)? 0 : (crm_time_get_seconds(dt) - EPOCH_SECONDS);
 }
@@ -452,7 +453,7 @@ crm_time_get_isoweek(const crm_time_t *dt, uint32_t *y, uint32_t *w,
 #define DATE_MAX 128
 
 static void
-crm_duration_as_string(crm_time_t *dt, char *result)
+crm_duration_as_string(const crm_time_t *dt, char *result)
 {
     size_t offset = 0;
 
@@ -496,9 +497,9 @@ crm_duration_as_string(crm_time_t *dt, char *result)
 }
 
 char *
-crm_time_as_string(crm_time_t * date_time, int flags)
+crm_time_as_string(const crm_time_t *date_time, int flags)
 {
-    crm_time_t *dt = NULL;
+    const crm_time_t *dt = NULL;
     crm_time_t *utc = NULL;
     char result[DATE_MAX] = { '\0', };
     char *result_copy = NULL;

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -288,7 +288,7 @@ crm_time_get_sec(int sec, uint32_t *h, uint32_t *m, uint32_t *s)
 }
 
 int
-crm_time_get_timeofday(crm_time_t *dt, uint32_t *h, uint32_t *m,
+crm_time_get_timeofday(const crm_time_t *dt, uint32_t *h, uint32_t *m,
                        uint32_t *s)
 {
     crm_time_get_sec(dt->seconds, h, m, s);

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1529,7 +1529,7 @@ crm_time_add_years(crm_time_t * a_time, int extra)
 }
 
 static void
-ha_get_tm_time( struct tm *target, crm_time_t *source)
+ha_get_tm_time(struct tm *target, const crm_time_t *source)
 {
     *target = (struct tm) {
         .tm_year = source->years - 1900,
@@ -1557,7 +1557,7 @@ ha_get_tm_time( struct tm *target, crm_time_t *source)
  */
 
 pcmk__time_hr_t *
-pcmk__time_hr_convert(pcmk__time_hr_t *target, crm_time_t *dt)
+pcmk__time_hr_convert(pcmk__time_hr_t *target, const crm_time_t *dt)
 {
     pcmk__time_hr_t *hr_dt = NULL;
 
@@ -1578,7 +1578,7 @@ pcmk__time_hr_convert(pcmk__time_hr_t *target, crm_time_t *dt)
 }
 
 void
-pcmk__time_set_hr_dt(crm_time_t *target, pcmk__time_hr_t *hr_dt)
+pcmk__time_set_hr_dt(crm_time_t *target, const pcmk__time_hr_t *hr_dt)
 {
     CRM_ASSERT((hr_dt) && (target));
     *target = (crm_time_t) {
@@ -1642,7 +1642,7 @@ pcmk__time_hr_free(pcmk__time_hr_t * hr_dt)
 }
 
 char *
-pcmk__time_format_hr(const char *format, pcmk__time_hr_t * hr_dt)
+pcmk__time_format_hr(const char *format, const pcmk__time_hr_t *hr_dt)
 {
     const char *mark_s;
     int max = 128, scanned_pos = 0, printed_pos = 0, fmt_pos = 0,
@@ -1726,7 +1726,7 @@ pcmk__time_format_hr(const char *format, pcmk__time_hr_t * hr_dt)
  *       functions.
  */
 const char *
-pcmk__epoch2str(time_t *when)
+pcmk__epoch2str(const time_t *when)
 {
     char *since_epoch = NULL;
 

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -387,7 +387,7 @@ crm_time_get_gregorian(const crm_time_t *dt, uint32_t *y, uint32_t *m,
 }
 
 int
-crm_time_get_ordinal(crm_time_t *dt, uint32_t *y, uint32_t *d)
+crm_time_get_ordinal(const crm_time_t *dt, uint32_t *y, uint32_t *d)
 {
     *y = dt->years;
     *d = dt->days;

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1364,10 +1364,10 @@ crm_time_subtract(const crm_time_t *dt, const crm_time_t *value)
  *
  * \param[in] dt  Date/time object to check
  *
- * \return TRUE if years, days, and seconds are sensible, FALSE otherwise
+ * \return \c true if years, days, and seconds are sensible, \c false otherwise
  */
 bool
-crm_time_check(crm_time_t * dt)
+crm_time_check(const crm_time_t *dt)
 {
     return (dt != NULL)
            && (dt->days > 0) && (dt->days <= year_days(dt->years))

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -264,9 +264,9 @@ crm_time_log_alias(int log_level, const char *file, const char *function, int li
 }
 
 static void
-crm_time_get_sec(int sec, uint * h, uint * m, uint * s)
+crm_time_get_sec(int sec, uint32_t *h, uint32_t *m, uint32_t *s)
 {
-    uint hours, minutes, seconds;
+    uint32_t hours, minutes, seconds;
 
     if (sec < 0) {
         seconds = 0 - sec;
@@ -288,16 +288,17 @@ crm_time_get_sec(int sec, uint * h, uint * m, uint * s)
 }
 
 int
-crm_time_get_timeofday(crm_time_t * dt, uint * h, uint * m, uint * s)
+crm_time_get_timeofday(crm_time_t *dt, uint32_t *h, uint32_t *m,
+                       uint32_t *s)
 {
     crm_time_get_sec(dt->seconds, h, m, s);
     return TRUE;
 }
 
 int
-crm_time_get_timezone(crm_time_t * dt, uint * h, uint * m)
+crm_time_get_timezone(crm_time_t *dt, uint32_t *h, uint32_t *m)
 {
-    uint s;
+    uint32_t s;
 
     crm_time_get_sec(dt->seconds, h, m, &s);
     return TRUE;
@@ -353,7 +354,7 @@ crm_time_get_seconds_since_epoch(crm_time_t * dt)
 }
 
 int
-crm_time_get_gregorian(crm_time_t * dt, uint * y, uint * m, uint * d)
+crm_time_get_gregorian(crm_time_t *dt, uint32_t *y, uint32_t *m, uint32_t *d)
 {
     int months = 0;
     int days = dt->days;
@@ -385,7 +386,7 @@ crm_time_get_gregorian(crm_time_t * dt, uint * y, uint * m, uint * d)
 }
 
 int
-crm_time_get_ordinal(crm_time_t * dt, uint * y, uint * d)
+crm_time_get_ordinal(crm_time_t *dt, uint32_t *y, uint32_t *d)
 {
     *y = dt->years;
     *d = dt->days;
@@ -393,7 +394,7 @@ crm_time_get_ordinal(crm_time_t * dt, uint * y, uint * d)
 }
 
 int
-crm_time_get_isoweek(crm_time_t * dt, uint * y, uint * w, uint * d)
+crm_time_get_isoweek(crm_time_t * dt, uint32_t *y, uint32_t *w, uint32_t *d)
 {
     /*
      * Monday 29 December 2008 is written "2009-W01-1"
@@ -471,7 +472,7 @@ crm_duration_as_string(crm_time_t *dt, char *result)
         offset += snprintf(result + offset, DATE_MAX - offset, "%d second%s",
                            dt->seconds, pcmk__plural_s(dt->seconds));
     } else if (dt->seconds) {
-        uint h = 0, m = 0, s = 0;
+        uint32_t h = 0, m = 0, s = 0;
 
         offset += snprintf(result + offset, DATE_MAX - offset, "%d seconds (",
                            dt->seconds);
@@ -538,7 +539,7 @@ crm_time_as_string(crm_time_t * date_time, int flags)
 
     if (flags & crm_time_log_date) {
         if (flags & crm_time_weeks) { // YYYY-WW-D
-            uint y, w, d;
+            uint32_t y, w, d;
 
             if (crm_time_get_isoweek(dt, &y, &w, &d)) {
                 offset += snprintf(result + offset, DATE_MAX - offset,
@@ -546,7 +547,7 @@ crm_time_as_string(crm_time_t * date_time, int flags)
             }
 
         } else if (flags & crm_time_ordinal) { // YYYY-DDD
-            uint y, d;
+            uint32_t y, d;
 
             if (crm_time_get_ordinal(dt, &y, &d)) {
                 offset += snprintf(result + offset, DATE_MAX - offset,
@@ -554,7 +555,7 @@ crm_time_as_string(crm_time_t * date_time, int flags)
             }
 
         } else { // YYYY-MM-DD
-            uint y, m, d;
+            uint32_t y, m, d;
 
             if (crm_time_get_gregorian(dt, &y, &m, &d)) {
                 offset += snprintf(result + offset, DATE_MAX - offset,
@@ -564,7 +565,7 @@ crm_time_as_string(crm_time_t * date_time, int flags)
     }
 
     if (flags & crm_time_log_timeofday) {
-        uint h = 0, m = 0, s = 0;
+        uint32_t h = 0, m = 0, s = 0;
 
         if (offset > 0) {
             offset += snprintf(result + offset, DATE_MAX - offset, " ");
@@ -608,9 +609,9 @@ static bool
 crm_time_parse_sec(const char *time_str, int *result)
 {
     int rc;
-    uint hour = 0;
-    uint minute = 0;
-    uint second = 0;
+    uint32_t hour = 0;
+    uint32_t minute = 0;
+    uint32_t second = 0;
 
     *result = 0;
 
@@ -713,7 +714,7 @@ crm_time_parse_offset(const char *offset_str, int *offset)
 static bool
 crm_time_parse(const char *time_str, crm_time_t *a_time)
 {
-    uint h, m, s;
+    uint32_t h, m, s;
     char *offset_s = NULL;
 
     tzset();

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -395,7 +395,8 @@ crm_time_get_ordinal(const crm_time_t *dt, uint32_t *y, uint32_t *d)
 }
 
 int
-crm_time_get_isoweek(crm_time_t * dt, uint32_t *y, uint32_t *w, uint32_t *d)
+crm_time_get_isoweek(const crm_time_t *dt, uint32_t *y, uint32_t *w,
+                     uint32_t *d)
 {
     /*
      * Monday 29 December 2008 is written "2009-W01-1"

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1388,7 +1388,7 @@ crm_time_check(const crm_time_t *dt)
     }
 
 int
-crm_time_compare(crm_time_t *a, crm_time_t *b)
+crm_time_compare(const crm_time_t *a, const crm_time_t *b)
 {
     int rc = 0;
     crm_time_t *t1 = crm_get_utc_time(a);

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1193,7 +1193,7 @@ crm_time_free_period(crm_time_period_t *period)
 }
 
 void
-crm_time_set(crm_time_t * target, crm_time_t * source)
+crm_time_set(crm_time_t *target, const crm_time_t *source)
 {
     crm_trace("target=%p, source=%p", target, source);
 

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -296,7 +296,7 @@ crm_time_get_timeofday(const crm_time_t *dt, uint32_t *h, uint32_t *m,
 }
 
 int
-crm_time_get_timezone(crm_time_t *dt, uint32_t *h, uint32_t *m)
+crm_time_get_timezone(const crm_time_t *dt, uint32_t *h, uint32_t *m)
 {
     uint32_t s;
 

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1262,7 +1262,7 @@ crm_time_set_timet(crm_time_t *target, const time_t *source)
 }
 
 crm_time_t *
-pcmk_copy_time(crm_time_t *source)
+pcmk_copy_time(const crm_time_t *source)
 {
     crm_time_t *target = crm_time_new_undefined();
 

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1333,7 +1333,7 @@ crm_time_calculate_duration(const crm_time_t *dt, const crm_time_t *value)
 }
 
 crm_time_t *
-crm_time_subtract(crm_time_t * dt, crm_time_t * value)
+crm_time_subtract(const crm_time_t *dt, const crm_time_t *value)
 {
     crm_time_t *utc = NULL;
     crm_time_t *answer = NULL;

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -354,7 +354,8 @@ crm_time_get_seconds_since_epoch(crm_time_t * dt)
 }
 
 int
-crm_time_get_gregorian(crm_time_t *dt, uint32_t *y, uint32_t *m, uint32_t *d)
+crm_time_get_gregorian(const crm_time_t *dt, uint32_t *y, uint32_t *m,
+                       uint32_t *d)
 {
     int months = 0;
     int days = dt->days;

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1212,7 +1212,7 @@ crm_time_set(crm_time_t *target, const crm_time_t *source)
 }
 
 static void
-ha_set_tm_time(crm_time_t * target, struct tm *source)
+ha_set_tm_time(crm_time_t *target, const struct tm *source)
 {
     int h_offset = 0;
     int m_offset = 0;
@@ -1256,7 +1256,7 @@ ha_set_tm_time(crm_time_t * target, struct tm *source)
 }
 
 void
-crm_time_set_timet(crm_time_t * target, time_t * source)
+crm_time_set_timet(crm_time_t *target, const time_t *source)
 {
     ha_set_tm_time(target, localtime(source));
 }


### PR DESCRIPTION
Little bit of cleanup. No point getting deep into the weeds in iso8601.c, noting https://projects.clusterlabs.org/T432.

Note that the changes from `uint` to `uint32_t` in the very first commit are to be consistent with what we already advertise in the public API header.