### PR TITLE
Fix: libcib: cib__signon_query(): NULL-check correct pointer

### DIFF
--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -719,6 +719,8 @@ cib__signon_query(cib_t **cib, xmlNode **cib_object)
     int rc = pcmk_rc_ok;
     cib_t *cib_conn = NULL;
 
+    CRM_ASSERT(cib_object != NULL);
+
     if (cib == NULL) {
         cib_conn = cib_new();
     } else {
@@ -742,11 +744,10 @@ cib__signon_query(cib_t **cib, xmlNode **cib_object)
         cib__clean_up_connection(&cib_conn);
     }
 
-    if (cib_object == NULL) {
+    if (*cib_object == NULL) {
         return pcmk_rc_no_input;
-    } else {
-        return rc;
     }
+    return rc;
 }
 
 int


### PR DESCRIPTION
`cib_object` is not `NULL`-checked until the very end. It should be checked at the beginning to ensure we have a destination to store the CIB. Also as a result, `*cib_object` is never `NULL`-checked. We need to check it at the end to determine our return code.