### PR TITLE
Best practices for RecurringOp()

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -376,7 +376,7 @@ void pe__show_node_weights_as(const char *file, const char *function,
         pe__show_node_weights_as(__FILE__, __func__, __LINE__,      \
                                  (level), (rsc), (text), (nodes), (data_set))
 
-extern xmlNode *find_rsc_op_entry(pe_resource_t * rsc, const char *key);
+xmlNode *find_rsc_op_entry(const pe_resource_t *rsc, const char *key);
 
 extern pe_action_t *custom_action(pe_resource_t * rsc, char *key, const char *task, pe_node_t * on_node,
                                   gboolean optional, gboolean foo, pe_working_set_t * data_set);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -378,8 +378,9 @@ void pe__show_node_weights_as(const char *file, const char *function,
 
 xmlNode *find_rsc_op_entry(const pe_resource_t *rsc, const char *key);
 
-extern pe_action_t *custom_action(pe_resource_t * rsc, char *key, const char *task, pe_node_t * on_node,
-                                  gboolean optional, gboolean foo, pe_working_set_t * data_set);
+pe_action_t *custom_action(pe_resource_t *rsc, char *key, const char *task,
+                           const pe_node_t *on_node, gboolean optional,
+                           gboolean foo, pe_working_set_t *data_set);
 
 #  define delete_key(rsc) pcmk__op_key(rsc->id, CRMD_ACTION_DELETE, 0)
 #  define delete_action(rsc, node, optional) custom_action(		\

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -226,7 +226,7 @@ void pcmk__log_action(const char *pre_text, pe_action_t *action, bool details);
 
 G_GNUC_INTERNAL
 pe_action_t *pcmk__new_cancel_action(pe_resource_t *rsc, const char *name,
-                                     guint interval_ms, pe_node_t *node);
+                                     guint interval_ms, const pe_node_t *node);
 
 G_GNUC_INTERNAL
 pe_action_t *pcmk__new_shutdown_action(pe_node_t *node);

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -1057,7 +1057,7 @@ pcmk__log_action(const char *pre_text, pe_action_t *action, bool details)
  */
 pe_action_t *
 pcmk__new_cancel_action(pe_resource_t *rsc, const char *task, guint interval_ms,
-                        pe_node_t *node)
+                        const pe_node_t *node)
 {
     pe_action_t *cancel_op = NULL;
     char *key = NULL;

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -492,10 +492,28 @@ is_op_dup(const pe_resource_t *rsc, const char *name, guint interval_ms)
     return false;
 }
 
+/*!
+ * \internal
+ * \brief Check whether an action name is one that can be recurring
+ *
+ * \param[in] name  Action name to check
+ *
+ * \return true if \p name is an action known to be unsuitable as a recurring
+ *         operation, otherwise false
+ *
+ * \note Pacemaker's current philosophy is to allow users to configure recurring
+ *       operations except for a short list of actions known not to be suitable
+ *       for that (as opposed to allowing only actions known to be suitable,
+ *       which includes only monitor). Among other things, this approach allows
+ *       users to define their own custom operations and make them recurring,
+ *       though that use case is not well tested.
+ */
 static bool
 op_cannot_recur(const char *name)
 {
-    return pcmk__strcase_any_of(name, RSC_STOP, RSC_START, RSC_DEMOTE, RSC_PROMOTE, NULL);
+    return pcmk__str_any_of(name, RSC_STOP, RSC_START, RSC_DEMOTE, RSC_PROMOTE,
+                            CRMD_ACTION_RELOAD_AGENT, CRMD_ACTION_MIGRATE,
+                            CRMD_ACTION_MIGRATED, NULL);
 }
 
 static void

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -435,6 +435,21 @@ pcmk__primitive_assign(pe_resource_t *rsc, pe_node_t *prefer)
     return rsc->allocated_to;
 }
 
+/*!
+ * \internal
+ * \brief Parse an interval from XML
+ *
+ * \param[in] xml  XML containing an interval attribute
+ *
+ * \return Interval parsed from XML (or 0 as default)
+ */
+static guint
+xe_interval(const xmlNode *xml)
+{
+    return crm_parse_interval_spec(crm_element_value(xml,
+                                                     XML_LRM_ATTR_INTERVAL));
+}
+
 static gboolean
 is_op_dup(pe_resource_t *rsc, const char *name, guint interval_ms)
 {
@@ -442,7 +457,6 @@ is_op_dup(pe_resource_t *rsc, const char *name, guint interval_ms)
     const char *id = NULL;
     const char *value = NULL;
     xmlNode *operation = NULL;
-    guint interval2_ms = 0;
 
     CRM_ASSERT(rsc);
     for (operation = pcmk__xe_first_child(rsc->ops_xml); operation != NULL;
@@ -454,9 +468,7 @@ is_op_dup(pe_resource_t *rsc, const char *name, guint interval_ms)
                 continue;
             }
 
-            value = crm_element_value(operation, XML_LRM_ATTR_INTERVAL);
-            interval2_ms = crm_parse_interval_spec(value);
-            if (interval_ms != interval2_ms) {
+            if (xe_interval(operation) != interval_ms) {
                 continue;
             }
 
@@ -488,10 +500,9 @@ RecurringOp(pe_resource_t * rsc, pe_action_t * start, pe_node_t * node,
     char *key = NULL;
     const char *name = NULL;
     const char *role = NULL;
-    const char *interval_spec = NULL;
     const char *node_uname = node? node->details->uname : "n/a";
 
-    guint interval_ms = 0;
+    guint interval_ms = xe_interval(operation);
     pe_action_t *mon = NULL;
     gboolean is_optional = TRUE;
     GList *possible_matches = NULL;
@@ -504,8 +515,6 @@ RecurringOp(pe_resource_t * rsc, pe_action_t * start, pe_node_t * node,
         return;
     }
 
-    interval_spec = crm_element_value(operation, XML_LRM_ATTR_INTERVAL);
-    interval_ms = crm_parse_interval_spec(interval_spec);
     if (interval_ms == 0) {
         return;
     }
@@ -682,10 +691,9 @@ RecurringOp_Stopped(pe_resource_t * rsc, pe_action_t * start, pe_node_t * node,
     char *key = NULL;
     const char *name = NULL;
     const char *role = NULL;
-    const char *interval_spec = NULL;
     const char *node_uname = node? node->details->uname : "n/a";
 
-    guint interval_ms = 0;
+    guint interval_ms = xe_interval(operation);
     GList *possible_matches = NULL;
     GList *gIter = NULL;
 
@@ -695,8 +703,6 @@ RecurringOp_Stopped(pe_resource_t * rsc, pe_action_t * start, pe_node_t * node,
         return;
     }
 
-    interval_spec = crm_element_value(operation, XML_LRM_ATTR_INTERVAL);
-    interval_ms = crm_parse_interval_spec(interval_spec);
     if (interval_ms == 0) {
         return;
     }

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -579,8 +579,6 @@ RecurringOp(pe_resource_t * rsc, pe_action_t * start, pe_node_t * node,
     gboolean is_optional = TRUE;
     GList *possible_matches = NULL;
 
-    CRM_ASSERT(rsc);
-
     /* Only process for the operations without role="Stopped" */
     role = crm_element_value(operation, "role");
     if (role && text2role(role) == RSC_ROLE_STOPPED) {
@@ -596,15 +594,10 @@ RecurringOp(pe_resource_t * rsc, pe_action_t * start, pe_node_t * node,
     pe_rsc_trace(rsc, "Creating recurring action %s for %s in role %s on %s",
                  ID(operation), rsc->id, role2text(rsc->next_role), node_uname);
 
-    if (start != NULL) {
-        pe_rsc_trace(rsc, "Marking %s %s due to %s", key,
-                     pcmk_is_set(start->flags, pe_action_optional)? "optional" : "mandatory",
-                     start->uuid);
-        is_optional = (rsc->cmds->action_flags(start, NULL) & pe_action_optional);
-    } else {
-        pe_rsc_trace(rsc, "Marking %s optional", key);
-        is_optional = TRUE;
-    }
+    pe_rsc_trace(rsc, "Marking %s %s due to %s", key,
+                 pcmk_is_set(start->flags, pe_action_optional)? "optional" : "mandatory",
+                 start->uuid);
+    is_optional = (rsc->cmds->action_flags(start, NULL) & pe_action_optional);
 
     /* start a monitor for an already active resource */
     possible_matches = find_actions_exact(rsc->actions, key, node);
@@ -678,7 +671,7 @@ RecurringOp(pe_resource_t * rsc, pe_action_t * start, pe_node_t * node,
         pe_rsc_trace(rsc, "%s\t   %s (optional)", node_uname, mon->uuid);
     }
 
-    if ((start == NULL) || !pcmk_is_set(start->flags, pe_action_runnable)) {
+    if (!pcmk_is_set(start->flags, pe_action_runnable)) {
         pe_rsc_debug(rsc, "%s\t   %s (cancelled : start un-runnable)",
                      node_uname, mon->uuid);
         pe__clear_action_flags(mon, pe_action_runnable);

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -51,7 +51,7 @@ lookup_singleton(pe_working_set_t *data_set, const char *action_uuid)
  * \return Existing action that matches arguments (or NULL if none)
  */
 static pe_action_t *
-find_existing_action(const char *key, pe_resource_t *rsc, pe_node_t *node,
+find_existing_action(const char *key, pe_resource_t *rsc, const pe_node_t *node,
                      pe_working_set_t *data_set)
 {
     GList *matches = NULL;
@@ -164,8 +164,9 @@ find_rsc_op_entry(const pe_resource_t *rsc, const char *key)
  *       responsibility to free the return value with pe_free_action().
  */
 static pe_action_t *
-new_action(char *key, const char *task, pe_resource_t *rsc, pe_node_t *node,
-           bool optional, bool for_graph, pe_working_set_t *data_set)
+new_action(char *key, const char *task, pe_resource_t *rsc,
+           const pe_node_t *node, bool optional, bool for_graph,
+           pe_working_set_t *data_set)
 {
     pe_action_t *action = calloc(1, sizeof(pe_action_t));
 
@@ -1042,7 +1043,7 @@ unpack_operation(pe_action_t * action, xmlNode * xml_obj, pe_resource_t * contai
  */
 pe_action_t *
 custom_action(pe_resource_t *rsc, char *key, const char *task,
-              pe_node_t *on_node, gboolean optional, gboolean save_action,
+              const pe_node_t *on_node, gboolean optional, gboolean save_action,
               pe_working_set_t *data_set)
 {
     pe_action_t *action = NULL;

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -73,7 +73,8 @@ find_existing_action(const char *key, pe_resource_t *rsc, pe_node_t *node,
 }
 
 static xmlNode *
-find_rsc_op_entry_helper(pe_resource_t * rsc, const char *key, gboolean include_disabled)
+find_rsc_op_entry_helper(const pe_resource_t *rsc, const char *key,
+                         gboolean include_disabled)
 {
     guint interval_ms = 0;
     gboolean do_retry = TRUE;
@@ -141,7 +142,7 @@ find_rsc_op_entry_helper(pe_resource_t * rsc, const char *key, gboolean include_
 }
 
 xmlNode *
-find_rsc_op_entry(pe_resource_t * rsc, const char *key)
+find_rsc_op_entry(const pe_resource_t *rsc, const char *key)
 {
     return find_rsc_op_entry_helper(rsc, key, FALSE);
 }


### PR DESCRIPTION
This continues bringing libpacemaker up to current guidelines, focusing on RecurringOp() and the static functions it calls.