### PR TITLE
Clarify pointer arguments in some daemons

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -51,7 +51,7 @@ qb_ipcs_service_t *ipcs_shm = NULL;
 
 void send_cib_replace(const xmlNode * sync_request, const char *host);
 static void cib_process_request(xmlNode *request, gboolean privileged,
-                                pcmk__client_t *cib_client);
+                                const pcmk__client_t *cib_client);
 
 
 static int cib_process_command(xmlNode *request, xmlNode **reply,
@@ -483,7 +483,7 @@ queue_local_notify(xmlNode * notify_src, const char *client_id, gboolean sync_re
 }
 
 static void
-parse_local_options_v1(pcmk__client_t *cib_client, int call_type,
+parse_local_options_v1(const pcmk__client_t *cib_client, int call_type,
                        int call_options, const char *host, const char *op,
                        gboolean *local_notify, gboolean *needs_reply,
                        gboolean *process, gboolean *needs_forward)
@@ -526,7 +526,7 @@ parse_local_options_v1(pcmk__client_t *cib_client, int call_type,
 }
 
 static void
-parse_local_options_v2(pcmk__client_t *cib_client, int call_type,
+parse_local_options_v2(const pcmk__client_t *cib_client, int call_type,
                        int call_options, const char *host, const char *op,
                        gboolean *local_notify, gboolean *needs_reply,
                        gboolean *process, gboolean *needs_forward)
@@ -580,7 +580,7 @@ parse_local_options_v2(pcmk__client_t *cib_client, int call_type,
 }
 
 static void
-parse_local_options(pcmk__client_t *cib_client, int call_type,
+parse_local_options(const pcmk__client_t *cib_client, int call_type,
                     int call_options, const char *host, const char *op,
                     gboolean *local_notify, gboolean *needs_reply,
                     gboolean *process, gboolean *needs_forward)
@@ -835,7 +835,7 @@ parse_peer_options(int call_type, xmlNode * request,
 }
 
 static void
-forward_request(xmlNode * request, pcmk__client_t *cib_client, int call_options)
+forward_request(xmlNode *request, int call_options)
 {
     const char *op = crm_element_value(request, F_CIB_OPERATION);
     const char *host = crm_element_value(request, F_CIB_HOST);
@@ -919,14 +919,14 @@ send_peer_reply(xmlNode * msg, xmlNode * result_diff, const char *originator, gb
  * \internal
  * \brief Handle an IPC or CPG message containing a request
  *
- * \param[in] request            Request XML
+ * \param[in,out] request        Request XML
  * \param[in] privileged         Whether privileged commands may be run
  *                               (see cib_server_ops[] definition)
  * \param[in] cib_client         IPC client that sent request (or NULL if CPG)
  */
 static void
 cib_process_request(xmlNode *request, gboolean privileged,
-                    pcmk__client_t *cib_client)
+                    const pcmk__client_t *cib_client)
 {
     int call_type = 0;
     int call_options = 0;
@@ -1017,7 +1017,7 @@ cib_process_request(xmlNode *request, gboolean privileged,
                    originator ? originator : "local",
                    client_name, call_id);
 
-        forward_request(request, cib_client, call_options);
+        forward_request(request, call_options);
         return;
     }
 

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -219,7 +219,7 @@ stonith_fence_history_trim(void)
  * \return Fence-history as hash-table
  */
 static GHashTable *
-stonith_xml_history_to_list(xmlNode *history)
+stonith_xml_history_to_list(const xmlNode *history)
 {
     xmlNode *xml_op = NULL;
     GHashTable *rv = NULL;
@@ -289,17 +289,16 @@ stonith_xml_history_to_list(xmlNode *history)
  * \brief Craft xml difference between local fence-history and a history
  *        coming from remote, and merge the remote history into the local
  *
- * \param[in] remote_history    Fence-history as hash-table (may be NULL)
- * \param[in] add_id            If crafting the answer for an API
- *                              history-request there is no need for the id
- * \param[in] target            Optionally limit to certain fence-target
+ * \param[in,out] remote_history  Fence-history as hash-table (may be NULL)
+ * \param[in]     add_id          If crafting the answer for an API
+ *                                history-request there is no need for the id
+ * \param[in]     target          Optionally limit to certain fence-target
  *
  * \return The fence-history as xml
  */
 static xmlNode *
 stonith_local_history_diff_and_merge(GHashTable *remote_history,
-                           gboolean add_id,
-                           const char *target)
+                                     gboolean add_id, const char *target)
 {
     xmlNode *history = NULL;
     GHashTableIter iter;
@@ -448,14 +447,12 @@ stonith_local_history(gboolean add_id, const char *target)
 
 /*!
  * \internal
- * \brief Handle fence-history messages (either from API or coming in as
- *        broadcasts
+ * \brief Handle fence-history messages (from API or coming in as broadcasts)
  *
- * \param[in] msg       Request message
- * \param[in] output    In case of a request from the API used to craft
- *                      a reply from
- * \param[in] remote_peer
- * \param[in] options   call-options from the request
+ * \param[in,out] msg          Request XML
+ * \param[out]    output       Where to set local history, if requested
+ * \param[in]     remote_peer  If broadcast, peer that sent it
+ * \param[in]     options      Call options from the request
  */
 void
 stonith_fence_history(xmlNode *msg, xmlNode **output,

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -592,7 +592,7 @@ fencing_topology_init(void)
  * \return Pointer to node object if found, NULL otherwise
  */
 static pe_node_t *
-our_node_allowed_for(pe_resource_t *rsc)
+our_node_allowed_for(const pe_resource_t *rsc)
 {
     GHashTableIter iter;
     pe_node_t *node = NULL;
@@ -674,10 +674,11 @@ update_stonith_watchdog_timeout_ms(xmlNode *cib)
  * \brief If a resource or any of its children are STONITH devices, update their
  *        definitions given a cluster working set.
  *
- * \param[in] rsc       Resource to check
- * \param[in] data_set  Cluster working set with device information
+ * \param[in,out] rsc       Resource to check
+ * \param[in,out] data_set  Cluster working set with device information
  */
-static void cib_device_update(pe_resource_t *rsc, pe_working_set_t *data_set)
+static void
+cib_device_update(pe_resource_t *rsc, pe_working_set_t *data_set)
 {
     pe_node_t *node = NULL;
     const char *value = NULL;

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -157,7 +157,7 @@ typedef struct remote_fencing_op_s {
     pcmk__action_result_t result;
 } remote_fencing_op_t;
 
-void fenced_broadcast_op_result(remote_fencing_op_t *op, bool op_merged);
+void fenced_broadcast_op_result(const remote_fencing_op_t *op, bool op_merged);
 
 // Fencer-specific client flags
 enum st_client_flags {
@@ -223,7 +223,7 @@ int stonith_device_register(xmlNode *msg, gboolean from_cib);
 
 void stonith_device_remove(const char *id, bool from_cib);
 
-char *stonith_level_key(xmlNode * msg, int mode);
+char *stonith_level_key(const xmlNode *msg, int mode);
 void fenced_register_level(xmlNode *msg, char **desc,
                            pcmk__action_result_t *result);
 void fenced_unregister_level(xmlNode *msg, char **desc,
@@ -234,8 +234,8 @@ stonith_topology_t *find_topology_for_host(const char *host);
 void do_local_reply(xmlNode *notify_src, pcmk__client_t *client,
                     int call_options);
 
-xmlNode *fenced_construct_reply(xmlNode *request, xmlNode *data,
-                                pcmk__action_result_t *result);
+xmlNode *fenced_construct_reply(const xmlNode *request, xmlNode *data,
+                                const pcmk__action_result_t *result);
 
 void
  do_stonith_async_timeout_update(const char *client, const char *call_id, int timeout);
@@ -250,7 +250,7 @@ void fenced_send_level_notification(const char *op,
                                     const pcmk__action_result_t *result,
                                     const char *desc);
 
-remote_fencing_op_t *initiate_remote_stonith_op(pcmk__client_t *client,
+remote_fencing_op_t *initiate_remote_stonith_op(const pcmk__client_t *client,
                                                 xmlNode *request,
                                                 gboolean manual_ack);
 
@@ -269,7 +269,8 @@ bool fencing_peer_active(crm_node_t *peer);
 
 void set_fencing_completed(remote_fencing_op_t * op);
 
-int fenced_handle_manual_confirmation(pcmk__client_t *client, xmlNode *msg);
+int fenced_handle_manual_confirmation(const pcmk__client_t *client,
+                                      xmlNode *msg);
 
 gboolean node_has_attr(const char *node, const char *name, const char *value);
 

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -543,7 +543,7 @@ start_child(pcmk_child_t * child)
  * \internal
  * \brief Check the liveness of the child based on IPC name and PID if tracked
  *
- * \param[inout] child  Child tracked data
+ * \param[in,out] child  Child tracked data
  *
  * \return Standard Pacemaker return code
  *


### PR DESCRIPTION
Mark pointer arguments as const where appropriate, and ensure doxygen blocks use [in] or [in,out] as appropriate, in functions for pacemakerd, pacemaker-based, and pacemaker-fenced.

This is not comprehensive but focuses on functions that have doxygen blocks and some functions called by them.