### PR TITLE
Add log level variables when alert mechanism departs

### DIFF
--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -34,6 +34,7 @@ typedef struct {
     char *path;
     char *tstamp_format;
     char *recipient;
+    char *alert_log_level;
     char **select_attribute_name;
     GHashTable *envvars;
     int timeout;
@@ -61,10 +62,11 @@ enum pcmk__alert_keys_e {
     PCMK__alert_key_timestamp_usec,
     PCMK__alert_key_exec_time,
     PCMK__alert_key_select_kind,
-    PCMK__alert_key_select_attribute_name
+    PCMK__alert_key_select_attribute_name,
+    PCMK__alert_log_level
 };
 
-#define PCMK__ALERT_INTERNAL_KEY_MAX 19
+#define PCMK__ALERT_INTERNAL_KEY_MAX 23
 #define PCMK__ALERT_NODE_SEQUENCE "CRM_alert_node_sequence"
 
 extern const char *pcmk__alert_keys[PCMK__ALERT_INTERNAL_KEY_MAX][3];

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -77,6 +77,9 @@ const char *pcmk__alert_keys[PCMK__ALERT_INTERNAL_KEY_MAX][3] =
     },
     [PCMK__alert_key_exec_time] = {
         "CRM_notify_exec_time",         "CRM_alert_exec_time",          NULL
+    },
+    [PCMK__alert_log_level] = {
+        "CRM_notify_log_level",         "CRM_alert_log_level",          NULL
     }
 };
 

--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -164,6 +164,15 @@ exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum pcmk__alert_flags kind,
         crm_info("Sending %s alert via %s to %s",
                  kind_s, entry->id, entry->recipient);
 
+        copy_params = alert_envvar2params(copy_params, entry);
+
+        for (head = copy_params; head != NULL; head = head->next) {
+            crm_info("Show CRM %s = %s",head->key, head->value);
+            if (strcmp(head->key, "alert_log_level") == 0) {
+                copy_params = alert_key2param(copy_params, PCMK__alert_log_level, head->value);
+            }
+        }
+
         /* Make a copy of the parameters, because each alert will be unique */
         for (head = params; head != NULL; head = head->next) {
             copy_params = lrmd_key_value_add(copy_params, head->key, head->value);


### PR DESCRIPTION
Cluster alert mechanism to add alert log level parameter, you can get this parameter when calling alert script, email content can be added according to this parameter to get the same level of logs in the cluster, do so at the same time need to add log level parameters in the interface related to the creation of alert in pcs