### PR TITLE
Fix crm_resource --validate validation

### DIFF
--- a/cts/cli/regression.agents.exp
+++ b/cts/cli/regression.agents.exp
@@ -1,0 +1,33 @@
+=#=#=#= Begin test: Validate a valid resource configuration =#=#=#=
+Operation validate (ocf:pacemaker:Dummy) returned 0 (ok)
+=#=#=#= End test: Validate a valid resource configuration - OK (0) =#=#=#=
+* Passed: crm_resource   - Validate a valid resource configuration
+=#=#=#= Begin test: Validate a valid resource configuration (XML) =#=#=#=
+<pacemaker-result api-version="X" request="crm_resource --validate --class ocf --provider pacemaker --agent Dummy --output-as=xml">
+  <resource-agent-action action="validate" class="ocf" type="Dummy" provider="pacemaker">
+    <overrides/>
+    <agent-status code="0" message="ok" execution_code="0" execution_message="complete"/>
+  </resource-agent-action>
+  <status code="0" message="OK"/>
+</pacemaker-result>
+=#=#=#= End test: Validate a valid resource configuration (XML) - OK (0) =#=#=#=
+* Passed: crm_resource   - Validate a valid resource configuration (XML)
+=#=#=#= Begin test: Validate an invalid resource configuration =#=#=#=
+crm_resource: Error performing operation: Not configured
+Operation validate (ocf:pacemaker:Dummy) returned 6 (not configured)
+=#=#=#= End test: Validate an invalid resource configuration - Not configured (6) =#=#=#=
+* Passed: crm_resource   - Validate an invalid resource configuration
+=#=#=#= Begin test: Validate an invalid resource configuration (XML) =#=#=#=
+<pacemaker-result api-version="X" request="crm_resource --validate --class ocf --provider pacemaker --agent Dummy --output-as=xml">
+  <resource-agent-action action="validate" class="ocf" type="Dummy" provider="pacemaker">
+    <overrides/>
+    <agent-status code="6" message="not configured" execution_code="0" execution_message="complete"/>
+  </resource-agent-action>
+  <status code="6" message="Not configured">
+    <errors>
+      <error>crm_resource: Error performing operation: Not configured</error>
+    </errors>
+  </status>
+</pacemaker-result>
+=#=#=#= End test: Validate an invalid resource configuration (XML) - Not configured (6) =#=#=#=
+* Passed: crm_resource   - Validate an invalid resource configuration (XML)

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -62,6 +62,7 @@ CRM_EX_ERROR=1
 CRM_EX_INVALID_PARAM=2
 CRM_EX_UNIMPLEMENT_FEATURE=3
 CRM_EX_INSUFFICIENT_PRIV=4
+CRM_EX_NOT_CONFIGURED=6
 CRM_EX_USAGE=64
 CRM_EX_DATAERR=65
 CRM_EX_CONFIG=78
@@ -179,7 +180,29 @@ function test_assert_validate() {
 # Tests that depend on resource agents and must be run in an installed
 # environment
 function test_agents() {
-    :
+    desc="Validate a valid resource configuration"
+    cmd="crm_resource --validate --class ocf --provider pacemaker --agent Dummy"
+    test_assert $CRM_EX_OK 0
+
+    desc="Validate a valid resource configuration (XML)"
+    cmd="crm_resource --validate --class ocf --provider pacemaker --agent Dummy"
+    cmd="$cmd --output-as=xml"
+    test_assert_validate $CRM_EX_OK 0
+
+    # Make the Dummy configuration invalid (op_sleep can't be a generic string)
+    export OCF_RESKEY_op_sleep=asdf
+
+    desc="Validate an invalid resource configuration"
+    cmd="crm_resource --validate --class ocf --provider pacemaker --agent Dummy"
+    test_assert $CRM_EX_NOT_CONFIGURED 0
+
+    desc="Validate an invalid resource configuration (XML)"
+    cmd="crm_resource --validate --class ocf --provider pacemaker --agent Dummy"
+    cmd="$cmd --output-as=xml"
+    test_assert_validate $CRM_EX_NOT_CONFIGURED 0
+
+    unset OCF_RESKEY_op_sleep
+    export OCF_RESKEY_op_sleep
 }
 
 function test_crm_mon() {

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -22,7 +22,8 @@ USAGE_TEXT="Usage: cts-cli [<options>]
 Options:
  --help          Display this text, then exit
  -V, --verbose   Display any differences from expected output
- -t 'TEST [...]' Run only specified tests (default: 'dates tools crm_mon acls validity upgrade rules feature_set')
+ -t 'TEST [...]' Run only specified tests (default: 'dates tools crm_mon acls validity upgrade rules feature_set').
+                 Other tests: agents (must be run in an installed environment).
  -p DIR          Look for executables in DIR (may be specified multiple times)
  -v, --valgrind  Run all commands under valgrind
  -s              Save actual output as expected output"
@@ -173,6 +174,12 @@ function test_assert() {
 
 function test_assert_validate() {
     _test_assert $1 1 $2
+}
+
+# Tests that depend on resource agents and must be run in an installed
+# environment
+function test_agents() {
+    :
 }
 
 function test_crm_mon() {
@@ -2110,6 +2117,7 @@ done
 
 for t in $tests; do
     case "$t" in
+        agents) ;;
         dates) ;;
         tools) ;;
         acls) ;;

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -28,7 +28,7 @@ extern "C" {
  */
 
 
-#  define PCMK__API_VERSION "2.22"
+#  define PCMK__API_VERSION "2.23"
 
 #if defined(PCMK__WITH_ATTRIBUTE_OUTPUT_ARGS)
 #  define PCMK__OUTPUT_ARGS(ARGS...) __attribute__((output_args(ARGS)))

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -69,7 +69,17 @@ API_request_base	= command-output	\
 CIB_cfg_base		= options nodes resources constraints fencing acls tags alerts
 
 # Names of all schemas (including top level and those included by others)
-API_base		= $(API_request_base) fence-event failure generic-list item node-attrs node-history nodes resources status
+API_base		= $(API_request_base)	\
+			  failure		\
+			  fence-event 		\
+			  generic-list		\
+			  item			\
+			  node-attrs		\
+			  node-history		\
+			  nodes			\
+			  resources		\
+			  status		\
+			  subprocess-output
 CIB_base		= cib $(CIB_cfg_base) status score rule nvset
 
 # Static schema files and transforms (only CIB has transforms)

--- a/xml/api/command-output-2.23.rng
+++ b/xml/api/command-output-2.23.rng
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="command-output" />
+    </start>
+
+    <define name="command-output">
+        <element name="command">
+            <attribute name="code"> <data type="integer" /> </attribute>
+            <optional>
+                <element name="output">
+                    <attribute name="source"><value>stdout</value></attribute>
+                    <text />
+                </element>
+            </optional>
+            <optional>
+                <element name="output">
+                    <attribute name="source"><value>stderr</value></attribute>
+                    <text />
+                </element>
+            </optional>
+        </element>
+    </define>
+</grammar>

--- a/xml/api/command-output-2.23.rng
+++ b/xml/api/command-output-2.23.rng
@@ -8,19 +8,7 @@
 
     <define name="command-output">
         <element name="command">
-            <attribute name="code"> <data type="integer" /> </attribute>
-            <optional>
-                <element name="output">
-                    <attribute name="source"><value>stdout</value></attribute>
-                    <text />
-                </element>
-            </optional>
-            <optional>
-                <element name="output">
-                    <attribute name="source"><value>stderr</value></attribute>
-                    <text />
-                </element>
-            </optional>
+            <externalRef href="subprocess-output-2.23.rng" />
         </element>
     </define>
 </grammar>

--- a/xml/api/crm_resource-2.23.rng
+++ b/xml/api/crm_resource-2.23.rng
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crm-resource"/>
+    </start>
+
+    <define name="element-crm-resource">
+        <choice>
+            <ref name="agents-list" />
+            <ref name="alternatives-list" />
+            <ref name="constraints-list" />
+            <externalRef href="generic-list-2.4.rng"/>
+            <element name="metadata"> <text/> </element>
+            <ref name="locate-list" />
+            <ref name="operations-list" />
+            <ref name="providers-list" />
+            <ref name="reasons-list" />
+            <ref name="resource-check" />
+            <ref name="resource-config" />
+            <ref name="resources-list" />
+            <ref name="resource-agent-action" />
+        </choice>
+    </define>
+
+    <define name="agents-list">
+        <element name="agents">
+            <attribute name="standard"> <text/> </attribute>
+            <optional>
+                <attribute name="provider"> <text/> </attribute>
+            </optional>
+            <zeroOrMore>
+                <element name="agent"> <text/> </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="alternatives-list">
+        <element name="providers">
+            <attribute name="for"> <text/> </attribute>
+            <zeroOrMore>
+                <element name="provider"> <text/> </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="constraints-list">
+        <element name="constraints">
+            <interleave>
+                <zeroOrMore>
+                    <ref name="rsc-location" />
+                </zeroOrMore>
+                <zeroOrMore>
+                    <ref name="rsc-colocation" />
+                </zeroOrMore>
+            </interleave>
+        </element>
+    </define>
+
+    <define name="locate-list">
+        <element name="nodes">
+            <attribute name="resource"> <text/> </attribute>
+            <zeroOrMore>
+                <element name="node">
+                    <optional>
+                        <attribute name="state"><value>promoted</value></attribute>
+                    </optional>
+                    <text/>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="rsc-location">
+        <element name="rsc_location">
+            <attribute name="node"> <text/> </attribute>
+            <attribute name="rsc"> <text/> </attribute>
+            <attribute name="id"> <text/> </attribute>
+            <externalRef href="../score.rng"/>
+        </element>
+    </define>
+
+    <define name="operations-list">
+        <element name="operations">
+            <oneOrMore>
+                <ref name="element-operation-list" />
+            </oneOrMore>
+        </element>
+    </define>
+
+    <define name="providers-list">
+        <element name="providers">
+            <attribute name="standard"> <value>ocf</value> </attribute>
+            <optional>
+                <attribute name="agent"> <text/> </attribute>
+            </optional>
+            <zeroOrMore>
+                <element name="provider"> <text/> </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="reasons-list">
+        <element name="reason">
+            <!-- set only when resource and node are both specified -->
+            <optional>
+                <attribute name="running_on"> <text/> </attribute>
+            </optional>
+
+            <!-- set only when only a resource is specified -->
+            <optional>
+                <attribute name="running"> <data type="boolean"/> </attribute>
+            </optional>
+
+            <choice>
+                <ref name="reasons-with-no-resource"/>
+                <ref name="resource-check"/>
+            </choice>
+        </element>
+    </define>
+
+    <define name="reasons-with-no-resource">
+        <element name="resources">
+            <zeroOrMore>
+                <element name="resource">
+                    <attribute name="id"> <text/> </attribute>
+                    <attribute name="running"> <data type="boolean"/> </attribute>
+                    <optional>
+                        <attribute name="host"> <text/> </attribute>
+                    </optional>
+                    <ref name="resource-check"/>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="resource-config">
+        <element name="resource_config">
+            <externalRef href="resources-2.4.rng" />
+            <element name="xml"> <text/> </element>
+        </element>
+    </define>
+
+    <define name="resource-check">
+        <element name="check">
+            <attribute name="id"> <text/> </attribute>
+            <optional>
+                <choice>
+                    <attribute name="remain_stopped"><value>true</value></attribute>
+                    <attribute name="promotable"><value>false</value></attribute>
+                </choice>
+            </optional>
+            <optional>
+                <attribute name="unmanaged"><value>true</value></attribute>
+            </optional>
+            <optional>
+                <attribute name="locked-to"> <text/> </attribute>
+            </optional>
+            <optional>
+                <attribute name="unhealthy"><value>true</value></attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="resources-list">
+        <element name="resources">
+            <zeroOrMore>
+                <externalRef href="resources-2.4.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="rsc-colocation">
+        <element name="rsc_colocation">
+            <attribute name="id"> <text/> </attribute>
+            <attribute name="rsc"> <text/> </attribute>
+            <attribute name="with-rsc"> <text/> </attribute>
+            <externalRef href="../score.rng"/>
+            <optional>
+                <attribute name="node-attribute"> <text/> </attribute>
+            </optional>
+            <optional>
+                <attribute name="rsc-role">
+                    <ref name="attribute-roles"/>
+                </attribute>
+            </optional>
+            <optional>
+                <attribute name="with-rsc-role">
+                    <ref name="attribute-roles"/>
+                </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="element-operation-list">
+        <element name="operation">
+            <optional>
+                <group>
+                    <attribute name="rsc"> <text/> </attribute>
+                    <attribute name="agent"> <text/> </attribute>
+                </group>
+            </optional>
+            <attribute name="op"> <text/> </attribute>
+            <attribute name="node"> <text/> </attribute>
+            <attribute name="call"> <data type="integer" /> </attribute>
+            <attribute name="rc"> <data type="nonNegativeInteger" /> </attribute>
+            <optional>
+                <attribute name="last-rc-change"> <text/> </attribute>
+                <attribute name="exec-time"> <data type="nonNegativeInteger" /> </attribute>
+            </optional>
+            <attribute name="status"> <text/> </attribute>
+        </element>
+    </define>
+
+    <define name="resource-agent-action">
+        <element name="resource-agent-action">
+            <attribute name="action"> <text/> </attribute>
+            <optional>
+                <attribute name="rsc"> <text/> </attribute>
+            </optional>
+            <attribute name="class"> <text/> </attribute>
+            <attribute name="type"> <text/> </attribute>
+            <optional>
+                <attribute name="provider"> <text/> </attribute>
+            </optional>
+            <optional>
+                <ref name="overrides-list"/>
+            </optional>
+            <ref name="agent-status"/>
+            <optional>
+                <choice>
+                    <element name="command">
+                        <text />
+                    </element>
+                    <externalRef href="command-output-1.0.rng"/>
+                </choice>
+            </optional>
+        </element>
+    </define>
+
+    <define name="overrides-list">
+        <element name="overrides">
+            <zeroOrMore>
+                <element name="override">
+                    <optional>
+                        <attribute name="rsc"> <text/> </attribute>
+                    </optional>
+                    <attribute name="name"> <text/> </attribute>
+                    <attribute name="value"> <text/> </attribute>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="agent-status">
+        <element name="agent-status">
+            <attribute name="code"> <data type="integer" /> </attribute>
+            <optional>
+                <attribute name="message"> <text/> </attribute>
+            </optional>
+            <optional>
+                <attribute name="execution_code"> <data type="integer" /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="execution_message"> <text/> </attribute>
+            </optional>
+            <optional>
+                <attribute name="reason"> <text/> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="attribute-roles">
+        <choice>
+            <value>Stopped</value>
+            <value>Started</value>
+            <value>Promoted</value>
+            <value>Unpromoted</value>
+
+            <!-- These synonyms for Promoted/Unpromoted are allowed for
+                 backward compatibility with output from older Pacemaker
+                 versions that used them -->
+            <value>Master</value>
+            <value>Slave</value>
+        </choice>
+    </define>
+</grammar>

--- a/xml/api/crm_resource-2.23.rng
+++ b/xml/api/crm_resource-2.23.rng
@@ -229,12 +229,12 @@
             </optional>
             <ref name="agent-status"/>
             <optional>
-                <choice>
-                    <element name="command">
+                <element name="command">
+                    <choice>
                         <text />
-                    </element>
-                    <externalRef href="command-output-1.0.rng"/>
-                </choice>
+                        <externalRef href="subprocess-output-2.23.rng"/>
+                    </choice>
+                </element>
             </optional>
         </element>
     </define>

--- a/xml/api/stonith_admin-2.23.rng
+++ b/xml/api/stonith_admin-2.23.rng
@@ -45,7 +45,7 @@
             <attribute name="agent"> <text /> </attribute>
             <attribute name="valid"> <data type="boolean" /> </attribute>
             <optional>
-                <externalRef href="command-output-1.0.rng" />
+                <externalRef href="command-output-2.23.rng" />
             </optional>
         </element>
     </define>

--- a/xml/api/stonith_admin-2.23.rng
+++ b/xml/api/stonith_admin-2.23.rng
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-stonith-admin"/>
+    </start>
+
+    <define name="element-stonith-admin">
+        <choice>
+            <ref name="stonith-admin-list" />
+            <ref name="element-last-fenced" />
+            <ref name="element-validation" />
+            <element name="metadata"> <text /> </element>
+        </choice>
+    </define>
+
+    <define name="stonith-admin-list">
+        <optional>
+            <element name="list">
+                <attribute name="name"> <text /> </attribute>
+                <attribute name="count"> <data type="nonNegativeInteger" /> </attribute>
+                <choice>
+                    <empty/>
+                    <oneOrMore>
+                        <externalRef href="item-1.1.rng"/>
+                    </oneOrMore>
+                    <oneOrMore>
+                        <externalRef href="fence-event-2.15.rng"/>
+                    </oneOrMore>
+                </choice>
+            </element>
+        </optional>
+    </define>
+
+    <define name="element-last-fenced">
+        <element name="last-fenced">
+            <attribute name="target"> <text /> </attribute>
+            <attribute name="when"> <text /> </attribute>
+        </element>
+    </define>
+
+    <define name="element-validation">
+        <element name="validate">
+            <attribute name="agent"> <text /> </attribute>
+            <attribute name="valid"> <data type="boolean" /> </attribute>
+            <optional>
+                <externalRef href="command-output-1.0.rng" />
+            </optional>
+        </element>
+    </define>
+</grammar>

--- a/xml/api/subprocess-output-2.23.rng
+++ b/xml/api/subprocess-output-2.23.rng
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="subprocess-output" />
+    </start>
+
+    <define name="subprocess-output">
+        <attribute name="code"> <data type="integer" /> </attribute>
+        <optional>
+            <element name="output">
+                <attribute name="source"><value>stdout</value></attribute>
+                <text />
+            </element>
+        </optional>
+        <optional>
+            <element name="output">
+                <attribute name="source"><value>stderr</value></attribute>
+                <text />
+            </element>
+        </optional>
+    </define>
+</grammar>


### PR DESCRIPTION
In case of an error, the output of `crm_resource --validate` fails to validate (if validate-all does not output XML). This is because if a
`<choice>` contains two elements with the same name in a RelaxNG schema, only the first occurrence is honored and the rest are ignored. (This does not seem to be documented clearly; it's a conclusion based on experimentation.)

A solution is to create just one `<element>` that contains a `<choice>` (instead of a `<choice>` that contains two `<element>`s).

Closes RHBZ#2123727