### PR TITLE
Update rule schema and documentation to match actual behavior

### DIFF
--- a/cts/cli/regression.upgrade.exp
+++ b/cts/cli/regression.upgrade.exp
@@ -94,8 +94,11 @@ update_validation 	debug: Configuration valid for schema: pacemaker-3.7
 update_validation 	debug: pacemaker-3.7-style configuration is also valid for pacemaker-3.8
 update_validation 	debug: Testing 'pacemaker-3.8' validation (22 of X)
 update_validation 	debug: Configuration valid for schema: pacemaker-3.8
-update_validation 	trace: Stopping at pacemaker-3.8
-update_validation 	info: Transformed the configuration from pacemaker-2.10 to pacemaker-3.8
+update_validation 	debug: pacemaker-3.8-style configuration is also valid for pacemaker-3.9
+update_validation 	debug: Testing 'pacemaker-3.9' validation (23 of X)
+update_validation 	debug: Configuration valid for schema: pacemaker-3.9
+update_validation 	trace: Stopping at pacemaker-3.9
+update_validation 	info: Transformed the configuration from pacemaker-2.10 to pacemaker-3.9
 =#=#=#= Current cib after: Upgrade to latest CIB schema (trigger 2.10.xsl + the wrapping) =#=#=#=
 <cib epoch="2" num_updates="0" admin_epoch="1">
   <configuration>

--- a/cts/cli/regression.validity.exp
+++ b/cts/cli/regression.validity.exp
@@ -125,7 +125,11 @@ update_validation 	debug: Testing 'pacemaker-3.8' validation (22 of X)
 element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
 element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 update_validation 	trace: pacemaker-3.8 validation failed
-Cannot upgrade configuration (claiming schema pacemaker-1.2) to at least pacemaker-3.0 because it does not validate with any schema from pacemaker-1.2 to pacemaker-3.8
+update_validation 	debug: Testing 'pacemaker-3.9' validation (23 of X)
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+update_validation 	trace: pacemaker-3.9 validation failed
+Cannot upgrade configuration (claiming schema pacemaker-1.2) to at least pacemaker-3.0 because it does not validate with any schema from pacemaker-1.2 to pacemaker-3.9
 =#=#=#= End test: Run crm_simulate with invalid CIB (enum violation) - Invalid configuration (78) =#=#=#=
 * Passed: crm_simulate   - Run crm_simulate with invalid CIB (enum violation)
 =#=#=#= Begin test: Try to make resulting CIB invalid (unrecognized validate-with) =#=#=#=
@@ -233,7 +237,10 @@ update_validation 	trace: pacemaker-3.7 validation failed
 update_validation 	debug: Testing 'pacemaker-3.8' validation (22 of X)
 element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 update_validation 	trace: pacemaker-3.8 validation failed
-Cannot upgrade configuration (claiming schema pacemaker-9999.0) to at least pacemaker-3.0 because it does not validate with any schema from unknown to pacemaker-3.8
+update_validation 	debug: Testing 'pacemaker-3.9' validation (23 of X)
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+update_validation 	trace: pacemaker-3.9 validation failed
+Cannot upgrade configuration (claiming schema pacemaker-9999.0) to at least pacemaker-3.0 because it does not validate with any schema from unknown to pacemaker-3.9
 =#=#=#= End test: Run crm_simulate with invalid CIB (unrecognized validate-with) - Invalid configuration (78) =#=#=#=
 * Passed: crm_simulate   - Run crm_simulate with invalid CIB (unrecognized validate-with)
 =#=#=#= Begin test: Try to make resulting CIB invalid, but possibly recoverable (valid with X.Y+1) =#=#=#=
@@ -336,8 +343,11 @@ update_validation 	debug: Configuration valid for schema: pacemaker-3.7
 update_validation 	debug: pacemaker-3.7-style configuration is also valid for pacemaker-3.8
 update_validation 	debug: Testing 'pacemaker-3.8' validation (22 of X)
 update_validation 	debug: Configuration valid for schema: pacemaker-3.8
-update_validation 	trace: Stopping at pacemaker-3.8
-update_validation 	info: Transformed the configuration from pacemaker-1.2 to pacemaker-3.8
+update_validation 	debug: pacemaker-3.8-style configuration is also valid for pacemaker-3.9
+update_validation 	debug: Testing 'pacemaker-3.9' validation (23 of X)
+update_validation 	debug: Configuration valid for schema: pacemaker-3.9
+update_validation 	trace: Stopping at pacemaker-3.9
+update_validation 	info: Transformed the configuration from pacemaker-1.2 to pacemaker-3.9
 unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
 unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
@@ -449,6 +459,8 @@ element rsc_order: Relax-NG validity error : Invalid attribute first-action for 
 element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
 element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 =#=#=#= Current cib after: Make resulting CIB invalid, and without validate-with attribute =#=#=#=
 <cib epoch="41" num_updates="0" admin_epoch="0" validate-with="none">
   <configuration>
@@ -468,6 +480,8 @@ element rsc_order: Relax-NG validity error : Element constraints has extra conte
 * Passed: cibadmin       - Make resulting CIB invalid, and without validate-with attribute
 =#=#=#= Begin test: Run crm_simulate with invalid CIB, also without validate-with attribute =#=#=#=
 Schema validation of configuration is disabled (enabling is encouraged and prevents common misconfigurations)
+validity.bad.xml:10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+validity.bad.xml:10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 validity.bad.xml:10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
 validity.bad.xml:10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 validity.bad.xml:10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order

--- a/doc/sphinx/Pacemaker_Explained/rules.rst
+++ b/doc/sphinx/Pacemaker_Explained/rules.rst
@@ -282,7 +282,8 @@ A ``date_expression`` element may optionally contain a ``date_spec`` or
    |               |   ``start`` (if specified) and before either ``end`` (if  |
    |               |   specified) or ``start`` plus the value of the           |
    |               |   ``duration`` element (if one is contained in the        |
-   |               |   ``date_expression``)                                    |
+   |               |   ``date_expression``). If both ``end`` and ``duration``  |
+   |               |   are specified, ``duration`` is ignored.                 |
    |               | * ``date_spec:`` True if the current date/time matches    |
    |               |   the specification given in the contained ``date_spec``  |
    |               |   element (described below)                               |
@@ -314,6 +315,16 @@ supplied is ignored.
    |               |    pair: id; date_spec                                    |
    |               |                                                           |
    |               | A unique name for this element (required)                 |
+   +---------------+-----------------------------------------------------------+
+   | seconds       | .. index::                                                |
+   |               |    pair: seconds; date_spec                               |
+   |               |                                                           |
+   |               | Allowed values: 0-59                                      |
+   +---------------+-----------------------------------------------------------+
+   | minutes       | .. index::                                                |
+   |               |    pair: minutes; date_spec                               |
+   |               |                                                           |
+   |               | Allowed values: 0-59                                      |
    +---------------+-----------------------------------------------------------+
    | hours         | .. index::                                                |
    |               |    pair: hours; date_spec                                 |
@@ -427,6 +438,11 @@ containing a single number. Any attribute not supplied is ignored.
    |               |    pair: hours; duration                                  |
    |               |                                                           |
    |               | This many hours will be added to the total duration       |
+   +---------------+-----------------------------------------------------------+
+   | days          | .. index::                                                |
+   |               |    pair: days; duration                                   |
+   |               |                                                           |
+   |               | This many days will be added to the total duration        |
    +---------------+-----------------------------------------------------------+
    | weeks         | .. index::                                                |
    |               |    pair: weeks; duration                                  |

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -344,6 +344,7 @@ extern "C" {
 
 #  define XML_TAG_EXPRESSION		"expression"
 #  define PCMK_XE_DATE_EXPRESSION	"date_expression"
+#  define PCMK_XE_OP_EXPRESSION		"op_expression"
 #  define XML_EXPR_ATTR_ATTRIBUTE	"attribute"
 #  define XML_EXPR_ATTR_OPERATION	"operation"
 #  define XML_EXPR_ATTR_VALUE		"value"

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -345,6 +345,7 @@ extern "C" {
 #  define XML_TAG_EXPRESSION		"expression"
 #  define PCMK_XE_DATE_EXPRESSION	"date_expression"
 #  define PCMK_XE_OP_EXPRESSION		"op_expression"
+#  define PCMK_XE_RSC_EXPRESSION	"rsc_expression"
 #  define XML_EXPR_ATTR_ATTRIBUTE	"attribute"
 #  define XML_EXPR_ATTR_OPERATION	"operation"
 #  define XML_EXPR_ATTR_VALUE		"value"

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -343,6 +343,7 @@ extern "C" {
 #  define XML_RULE_ATTR_BOOLEAN_OP	"boolean-op"
 
 #  define XML_TAG_EXPRESSION		"expression"
+#  define PCMK_XE_DATE_EXPRESSION	"date_expression"
 #  define XML_EXPR_ATTR_ATTRIBUTE	"attribute"
 #  define XML_EXPR_ATTR_OPERATION	"operation"
 #  define XML_EXPR_ATTR_VALUE		"value"

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -110,29 +110,29 @@ find_expression_type(xmlNode * expr)
     attr = crm_element_value(expr, XML_EXPR_ATTR_ATTRIBUTE);
     tag = crm_element_name(expr);
 
-    if (pcmk__str_eq(tag, PCMK_XE_DATE_EXPRESSION, pcmk__str_casei)) {
+    if (pcmk__str_eq(tag, PCMK_XE_DATE_EXPRESSION, pcmk__str_none)) {
         return time_expr;
 
-    } else if (pcmk__str_eq(tag, PCMK_XE_RSC_EXPRESSION, pcmk__str_casei)) {
+    } else if (pcmk__str_eq(tag, PCMK_XE_RSC_EXPRESSION, pcmk__str_none)) {
         return rsc_expr;
 
-    } else if (pcmk__str_eq(tag, PCMK_XE_OP_EXPRESSION, pcmk__str_casei)) {
+    } else if (pcmk__str_eq(tag, PCMK_XE_OP_EXPRESSION, pcmk__str_none)) {
         return op_expr;
 
-    } else if (pcmk__str_eq(tag, XML_TAG_RULE, pcmk__str_casei)) {
+    } else if (pcmk__str_eq(tag, XML_TAG_RULE, pcmk__str_none)) {
         return nested_rule;
 
-    } else if (!pcmk__str_eq(tag, XML_TAG_EXPRESSION, pcmk__str_casei)) {
+    } else if (!pcmk__str_eq(tag, XML_TAG_EXPRESSION, pcmk__str_none)) {
         return not_expr;
 
-    } else if (pcmk__strcase_any_of(attr, CRM_ATTR_UNAME, CRM_ATTR_KIND, CRM_ATTR_ID, NULL)) {
+    } else if (pcmk__str_any_of(attr, CRM_ATTR_UNAME, CRM_ATTR_KIND, CRM_ATTR_ID, NULL)) {
         return loc_expr;
 
-    } else if (pcmk__str_eq(attr, CRM_ATTR_ROLE, pcmk__str_casei)) {
+    } else if (pcmk__str_eq(attr, CRM_ATTR_ROLE, pcmk__str_none)) {
         return role_expr;
 
 #if ENABLE_VERSIONED_ATTRS
-    } else if (pcmk__str_eq(attr, CRM_ATTR_RA_VERSION, pcmk__str_casei)) {
+    } else if (pcmk__str_eq(attr, CRM_ATTR_RA_VERSION, pcmk__str_none)) {
         return version_expr;
 #endif
     }

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -110,19 +110,19 @@ find_expression_type(xmlNode * expr)
     attr = crm_element_value(expr, XML_EXPR_ATTR_ATTRIBUTE);
     tag = crm_element_name(expr);
 
-    if (pcmk__str_eq(tag, "date_expression", pcmk__str_casei)) {
+    if (pcmk__str_eq(tag, PCMK_XE_DATE_EXPRESSION, pcmk__str_casei)) {
         return time_expr;
 
-    } else if (pcmk__str_eq(tag, "rsc_expression", pcmk__str_casei)) {
+    } else if (pcmk__str_eq(tag, PCMK_XE_RSC_EXPRESSION, pcmk__str_casei)) {
         return rsc_expr;
 
-    } else if (pcmk__str_eq(tag, "op_expression", pcmk__str_casei)) {
+    } else if (pcmk__str_eq(tag, PCMK_XE_OP_EXPRESSION, pcmk__str_casei)) {
         return op_expr;
 
     } else if (pcmk__str_eq(tag, XML_TAG_RULE, pcmk__str_casei)) {
         return nested_rule;
 
-    } else if (!pcmk__str_eq(tag, "expression", pcmk__str_casei)) {
+    } else if (!pcmk__str_eq(tag, XML_TAG_EXPRESSION, pcmk__str_casei)) {
         return not_expr;
 
     } else if (pcmk__strcase_any_of(attr, CRM_ATTR_UNAME, CRM_ATTR_KIND, CRM_ATTR_ID, NULL)) {

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -288,9 +288,7 @@ update_field(crm_time_t *t, xmlNode *xml, const char *attr,
 crm_time_t *
 pe_parse_xml_duration(crm_time_t * start, xmlNode * duration_spec)
 {
-    crm_time_t *end = crm_time_new_undefined();
-
-    crm_time_set(end, start);
+    crm_time_t *end = pcmk_copy_time(start);
 
     update_field(end, duration_spec, "years", crm_time_add_years);
     update_field(end, duration_spec, "months", crm_time_add_months);

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -222,7 +222,7 @@ pacemaker-%.rng: $(CIB_build_copies) best-match.sh Makefile.am
 	$(AM_V_SCHEMA)echo '</grammar>' >> $@
 
 # Dynamically generated CIB schema listing all pacemaker versions
-versions.rng: Makefile.am
+versions.rng: pacemaker-$(CIB_max).rng Makefile.am
 	$(AM_V_at)echo '<?xml version="1.0" encoding="UTF-8"?>' > $@
 	$(AM_V_at)echo '<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">' >> $@
 	$(AM_V_at)echo '  <start>' >> $@

--- a/xml/README.md
+++ b/xml/README.md
@@ -122,12 +122,13 @@ itself, allowing for more sophistication down the road.
 3. Modify `${base}-${X}.${Y}.rng` as required.
 4. If required, add an XSLT file, and update `xslt\_SCRIPTS` in `xml/Makefile.am`.
 5. Commit.
-6. Run `make -C xml clean; make -C xml` to rebuild the schemas in the local 
+6. Run `make -C xml clean; make -C xml` to rebuild the schemas in the local
+6. Run `make -C xml clean; make -C xml` to rebuild the schemas in the local
    source directory.
 7. The CIB validity and upgrade regression tests will break after the schema is
    updated. Run `cts/cts-cli -s` to make the expected outputs reflect the
    changes made so far, and run `git diff` to ensure that these changes look
-   sane. Finally, commit the changes. 
+   sane. Finally, commit the changes.
 8. Similarly, with the new major version `${X}`, it's advisable to refresh
    scheduler tests at some point. See the instructions in `cts/README.md`.
 

--- a/xml/README.md
+++ b/xml/README.md
@@ -117,26 +117,26 @@ itself, allowing for more sophistication down the road.
 1. Copy the most recent version of `${base}-*.rng` to `${base}-${X}.${Y}.rng`,
    such that the new file name increments the highest number of any schema file,
    not just the file being edited.
-1. Commit the copy, e.g. `"Low: xml: clone ${base} schema in preparation for
+2. Commit the copy, e.g. `"Low: xml: clone ${base} schema in preparation for
    changes"`. This way, the actual change will be obvious in the commit history.
-1. Modify `${base}-${X}.${Y}.rng` as required.
-1. If required, add an XSLT file, and update `xslt\_SCRIPTS` in `xml/Makefile.am`.
-1. Commit
-1. `make -C xml clean; make -C xml all` to rebuild the schemas in the local
+3. Modify `${base}-${X}.${Y}.rng` as required.
+4. If required, add an XSLT file, and update `xslt\_SCRIPTS` in `xml/Makefile.am`.
+5. Commit.
+6. Run `make -C xml clean; make -C xml` to rebuild the schemas in the local 
    source directory.
-1. The CIB validity regression tests will break after the schema is updated.
-   Run `cts/cts-cli -s` to make the referential outcomes reflect the transient
-   changes made so far, `git diff` to ensure the these changes look sane, then
-   commit them.
-1. Similarly, with the new major version `${X}`, it's advisable to refresh
-   scheduler tests at some point, see the instructions in `cts/README.md`.
+7. The CIB validity and upgrade regression tests will break after the schema is
+   updated. Run `cts/cts-cli -s` to make the expected outputs reflect the
+   changes made so far, and run `git diff` to ensure that these changes look
+   sane. Finally, commit the changes. 
+8. Similarly, with the new major version `${X}`, it's advisable to refresh
+   scheduler tests at some point. See the instructions in `cts/README.md`.
 
 ## Using a New Schema
 
 New features will not be available until the cluster administrator:
 
 1. Updates all the nodes
-1. Runs the equivalent of `cibadmin --upgrade --force`
+2. Runs the equivalent of `cibadmin --upgrade --force`
 
 ## Random Notes
 

--- a/xml/alerts-3.9.rng
+++ b/xml/alerts-3.9.rng
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" 
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+      <ref name="element-alerts"/>
+  </start>
+
+  <define name="element-alerts">
+    <optional>
+    <element name="alerts">
+      <zeroOrMore>
+        <element name="alert">
+          <attribute name="id"><data type="ID"/></attribute>
+          <optional>
+            <attribute name="description"><text/></attribute>
+          </optional>
+          <!-- path to the script called for alert -->
+          <attribute name="path"><text/></attribute>
+          <interleave>
+            <ref name="element-alert-extra"/>
+            <optional>
+              <element name="select">
+                <interleave>
+                  <optional>
+                    <element name="select_attributes">
+                      <zeroOrMore>
+                        <element name="attribute">
+                          <attribute name="id"><data type="ID"/></attribute>
+                          <attribute name="name"><text/></attribute>
+                        </element>
+                      </zeroOrMore>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name="select_fencing">
+                      <empty/>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name="select_nodes">
+                      <empty/>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name="select_resources">
+                      <empty/>
+                    </element>
+                  </optional>
+                </interleave>
+              </element>
+            </optional>
+            <zeroOrMore>
+              <element name="recipient">
+                <attribute name="id"><data type="ID"/></attribute>
+                <optional>
+                  <attribute name="description"><text/></attribute>
+                </optional>
+                <attribute name="value"><text/></attribute>
+                <ref name="element-alert-extra"/>
+              </element>
+            </zeroOrMore>
+          </interleave>
+        </element>
+      </zeroOrMore>
+    </element>
+    </optional>
+  </define>
+
+  <define name="element-alert-extra">
+      <zeroOrMore>
+        <choice>
+          <element name="meta_attributes">
+            <externalRef href="nvset-3.9.rng"/>
+          </element>
+          <element name="instance_attributes">
+            <externalRef href="nvset-3.9.rng"/>
+          </element>
+        </choice>
+      </zeroOrMore>
+  </define>
+
+</grammar>

--- a/xml/constraints-3.9.rng
+++ b/xml/constraints-3.9.rng
@@ -43,7 +43,13 @@
           <attribute name="node"><text/></attribute>
         </group>
         <oneOrMore>
-          <externalRef href="rule-3.9.rng"/>
+          <grammar>
+            <include href="rule-3.9.rng">
+              <start>
+                <ref name="element-rule-location"/>
+              </start>
+            </include>
+          </grammar>
         </oneOrMore>
       </choice>
       <optional>
@@ -253,7 +259,13 @@
   <define name="element-lifetime">
     <element name="lifetime">
       <oneOrMore>
-        <externalRef href="rule-3.9.rng"/>
+        <grammar>
+          <include href="rule-3.9.rng">
+            <start>
+              <ref name="element-rule-location"/>
+            </start>
+          </include>
+        </grammar>
       </oneOrMore>
     </element>
   </define>

--- a/xml/constraints-3.9.rng
+++ b/xml/constraints-3.9.rng
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar xmlns="http://relaxng.org/ns/structure/1.0" 
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <start>
       <ref name="element-constraints"/>
@@ -88,7 +88,12 @@
             </attribute>
           </optional>
           <optional>
-            <externalRef href="score.rng"/>
+            <choice>
+              <externalRef href="score.rng"/>
+              <attribute name="kind">
+                <ref name="order-types"/>
+              </attribute>
+             </choice>
           </optional>
           <oneOrMore>
             <element name="resource_ref">
@@ -105,6 +110,9 @@
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
         <externalRef href="score.rng"/>
+      </optional>
+      <optional>
+        <attribute name="influence"><text/></attribute>
       </optional>
       <optional>
         <ref name="element-lifetime"/>
@@ -128,12 +136,6 @@
             <attribute name="with-rsc-role">
               <ref name="attribute-roles"/>
             </attribute>
-          </optional>
-          <optional>
-            <attribute name="rsc-instance"><data type="integer"/></attribute>
-          </optional>
-          <optional>
-            <attribute name="with-rsc-instance"><data type="integer"/></attribute>
           </optional>
         </group>
       </choice>
@@ -177,17 +179,11 @@
               <ref name="attribute-actions"/>
             </attribute>
           </optional>
-          <optional>
-            <attribute name="first-instance"><data type="integer"/></attribute>
-          </optional>
-          <optional>
-            <attribute name="then-instance"><data type="integer"/></attribute>
-          </optional>
         </group>
       </choice>
     </element>
   </define>
- 
+
   <define name="element-rsc_ticket">
     <element name="rsc_ticket">
       <attribute name="id"><data type="ID"/></attribute>
@@ -234,7 +230,7 @@
       <value>stop</value>
     </choice>
   </define>
-      
+
   <define name="attribute-roles">
     <choice>
       <value>Stopped</value>
@@ -261,5 +257,5 @@
       </oneOrMore>
     </element>
   </define>
-  
+
 </grammar>

--- a/xml/constraints-next.rng
+++ b/xml/constraints-next.rng
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar xmlns="http://relaxng.org/ns/structure/1.0" 
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <start>
       <ref name="element-constraints"/>
@@ -43,7 +43,13 @@
           <attribute name="node"><text/></attribute>
         </group>
         <oneOrMore>
-          <externalRef href="rule-3.9.rng"/>
+          <grammar>
+            <include href="rule-3.9.rng">
+              <start>
+                <ref name="element-rule-location"/>
+              </start>
+            </include>
+          </grammar>
         </oneOrMore>
       </choice>
       <optional>
@@ -88,7 +94,12 @@
             </attribute>
           </optional>
           <optional>
-            <externalRef href="score.rng"/>
+            <choice>
+              <externalRef href="score.rng"/>
+              <attribute name="kind">
+                <ref name="order-types"/>
+              </attribute>
+             </choice>
           </optional>
           <oneOrMore>
             <element name="resource_ref">
@@ -105,6 +116,9 @@
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
         <externalRef href="score.rng"/>
+      </optional>
+      <optional>
+        <attribute name="influence"><text/></attribute>
       </optional>
       <optional>
         <ref name="element-lifetime"/>
@@ -187,7 +201,7 @@
       </choice>
     </element>
   </define>
- 
+
   <define name="element-rsc_ticket">
     <element name="rsc_ticket">
       <attribute name="id"><data type="ID"/></attribute>
@@ -234,7 +248,7 @@
       <value>stop</value>
     </choice>
   </define>
-      
+
   <define name="attribute-roles">
     <choice>
       <value>Stopped</value>
@@ -257,9 +271,15 @@
   <define name="element-lifetime">
     <element name="lifetime">
       <oneOrMore>
-        <externalRef href="rule-3.9.rng"/>
+        <grammar>
+          <include href="rule-3.9.rng">
+            <start>
+              <ref name="element-rule-location"/>
+            </start>
+          </include>
+        </grammar>
       </oneOrMore>
     </element>
   </define>
-  
+
 </grammar>

--- a/xml/nodes-3.9.rng
+++ b/xml/nodes-3.9.rng
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+      <ref name="element-nodes"/>
+  </start>
+
+  <define name="element-nodes">
+    <element name="nodes">
+      <zeroOrMore>
+        <element name="node">
+          <attribute name="id"><text/></attribute>
+          <attribute name="uname"><text/></attribute>
+          <optional>
+            <attribute name="type">
+              <choice>
+                <value>member</value>
+                <value>ping</value>
+                <value>remote</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="description"><text/></attribute>
+          </optional>
+          <optional>
+            <externalRef href="score.rng"/>
+          </optional>
+          <zeroOrMore>
+            <choice>
+              <element name="instance_attributes">
+                <externalRef href="nvset-3.9.rng"/>
+              </element>
+              <element name="utilization">
+                <externalRef href="nvset-3.9.rng"/>
+              </element>
+            </choice>
+          </zeroOrMore>
+        </element>
+      </zeroOrMore>
+    </element>
+  </define>
+
+</grammar>

--- a/xml/nvset-3.9.rng
+++ b/xml/nvset-3.9.rng
@@ -27,6 +27,11 @@
     </optional>
   </define>
 
+  <!-- Allow easy redefinition in parent grammars -->
+  <define name="element-nvset.rule">
+    <externalRef href="rule-3.9.rng"/>
+  </define>
+
   <define name="element-nvset">
    <choice>
    <attribute name="id-ref"><data type="IDREF"/></attribute>
@@ -34,7 +39,7 @@
     <attribute name="id"><data type="ID"/></attribute>
     <interleave>
       <optional>
-        <externalRef href="rule-3.9.rng"/>
+        <ref name="element-nvset.rule"/>
       </optional>
         <zeroOrMore>
           <element name="nvpair">

--- a/xml/nvset-3.9.rng
+++ b/xml/nvset-3.9.rng
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- just as nvset-2.9.rng, but allows for instantiated @name restrictions -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" 
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <ref name="element-nvset"/>
+  </start>
+
+  <!-- nvpair/@name:
+       * generic string by default, parent grammar may want to prohibit
+         enumerated names -->
+  <define name="element-nvset.name">
+    <attribute name="name">
+      <text/>
+    </attribute>
+  </define>
+
+  <!-- nvpair/@name:
+       * defer element-nvset.name grammar item
+       nvpair/@value:
+       generic string by default, parent grammar may want to restrict
+       enumerated pairs (i.e. related to @name) at once -->
+  <define name="element-nvset.name-value">
+    <ref name="element-nvset.name"/>
+    <optional>
+      <attribute name="value"><text/></attribute>
+    </optional>
+  </define>
+
+  <define name="element-nvset">
+   <choice>
+   <attribute name="id-ref"><data type="IDREF"/></attribute>
+   <group>
+    <attribute name="id"><data type="ID"/></attribute>
+    <interleave>
+      <optional>
+        <externalRef href="rule-3.9.rng"/>
+      </optional>
+        <zeroOrMore>
+          <element name="nvpair">
+            <choice>
+              <group>
+                <attribute name="id-ref"><data type="IDREF"/></attribute>
+                <optional>
+                  <attribute name="name"><text/></attribute>
+                </optional>
+              </group>
+              <group>
+                <attribute name="id"><data type="ID"/></attribute>
+                <ref name="element-nvset.name-value"/>
+              </group>
+            </choice>
+          </element>
+        </zeroOrMore>
+      <optional>
+        <externalRef href="score.rng"/>
+      </optional>
+    </interleave>
+   </group>
+   </choice>
+  </define>
+
+</grammar>

--- a/xml/options-3.9.rng
+++ b/xml/options-3.9.rng
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <ref name="options"/>
+  </start>
+
+  <!--
+   see upgrade-2.10.xsl
+   - cibtr:table for="cluster-properties"
+   -->
+  <define name="cluster_property_set.nvpair.name-value-unsupported">
+    <choice>
+      <group>
+        <attribute name="name">
+          <value type="string">cluster-infrastructure</value>
+        </attribute>
+        <attribute name="value">
+          <data type="string">
+            <except>
+              <choice>
+                <value>heartbeat</value>
+                <value>openais</value>
+                <value>classic openais</value>
+                <value>classic openais (with plugin)</value>
+                <value>cman</value>
+              </choice>
+            </except>
+          </data>
+        </attribute>
+      </group>
+      <group>
+        <attribute name="name">
+          <data type="string">
+            <except>
+              <choice>
+                <value>cluster-infrastructure</value>
+                <value>cluster_recheck_interval</value>
+                <value>dc_deadtime</value>
+                <value>default-action-timeout</value>
+                <value>default_action_timeout</value>
+                <value>default-migration-threshold</value>
+                <value>default_migration_threshold</value>
+                <value>default-resource-failure-stickiness</value>
+                <value>default_resource_failure_stickiness</value>
+                <value>default-resource-stickiness</value>
+                <value>default_resource_stickiness</value>
+                <value>election_timeout</value>
+                <value>expected-quorum-votes</value>
+                <value>is-managed-default</value>
+                <value>is_managed_default</value>
+                <value>no_quorum_policy</value>
+                <value>notification-agent</value>
+                <value>notification-recipient</value>
+                <value>remove_after_stop</value>
+                <value>shutdown_escalation</value>
+                <value>startup_fencing</value>
+                <value>stonith_action</value>
+                <value>stonith_enabled</value>
+                <value>stop_orphan_actions</value>
+                <value>stop_orphan_resources</value>
+                <value>symmetric_cluster</value>
+                <value>transition_idle_timeout</value>
+              </choice>
+            </except>
+          </data>
+        </attribute>
+        <optional>
+          <attribute name="value"><text/></attribute>
+        </optional>
+      </group>
+    </choice>
+  </define>
+
+  <define name="options">
+    <interleave>
+      <element name="crm_config">
+        <zeroOrMore>
+          <element name="cluster_property_set">
+            <grammar>
+              <include href="nvset-3.9.rng">
+                <define name="element-nvset.name-value">
+                  <parentRef name="cluster_property_set.nvpair.name-value-unsupported"/>
+                </define>
+              </include>
+            </grammar>
+          </element>
+        </zeroOrMore>
+      </element>
+      <optional>
+        <element name="rsc_defaults">
+          <zeroOrMore>
+            <element name="meta_attributes">
+              <externalRef href="nvset-3.9.rng"/>
+            </element>
+          </zeroOrMore>
+        </element>
+      </optional>
+      <optional>
+        <element name="op_defaults">
+          <zeroOrMore>
+            <element name="meta_attributes">
+              <externalRef href="nvset-3.9.rng"/>
+            </element>
+          </zeroOrMore>
+        </element>
+      </optional>
+    </interleave>
+  </define>
+
+</grammar>

--- a/xml/options-3.9.rng
+++ b/xml/options-3.9.rng
@@ -6,6 +6,16 @@
   </start>
 
   <!--
+   Include rule definitions so that we can override element-nvset.rule based on
+   context
+   -->
+  <include href="rule-3.9.rng">
+    <start combine="choice">
+      <notAllowed/>
+    </start>
+  </include>
+
+  <!--
    see upgrade-2.10.xsl
    - cibtr:table for="cluster-properties"
    -->
@@ -91,7 +101,13 @@
         <element name="rsc_defaults">
           <zeroOrMore>
             <element name="meta_attributes">
-              <externalRef href="nvset-3.9.rng"/>
+              <grammar>
+                <include href="nvset-3.9.rng">
+                  <define name="element-nvset.rule">
+                    <parentRef name="element-rule-rsc_defaults"/>
+                  </define>
+                </include>
+              </grammar>
             </element>
           </zeroOrMore>
         </element>

--- a/xml/options-3.9.rng
+++ b/xml/options-3.9.rng
@@ -116,7 +116,13 @@
         <element name="op_defaults">
           <zeroOrMore>
             <element name="meta_attributes">
-              <externalRef href="nvset-3.9.rng"/>
+              <grammar>
+                <include href="nvset-3.9.rng">
+                  <define name="element-nvset.rule">
+                    <parentRef name="element-rule-op_defaults"/>
+                  </define>
+                </include>
+              </grammar>
             </element>
           </zeroOrMore>
         </element>

--- a/xml/resources-3.9.rng
+++ b/xml/resources-3.9.rng
@@ -1,0 +1,428 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <ref name="element-resources"/>
+  </start>
+
+  <define name="element-resources">
+    <element name="resources">
+      <zeroOrMore>
+        <choice>
+          <ref name="element-primitive"/>
+          <ref name="element-template"/>
+          <ref name="element-group"/>
+          <ref name="element-clone"/>
+          <ref name="element-master"/>
+          <ref name="element-bundle"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <!--
+   see upgrade-2.10.xsl
+   - cibtr:table for="resource-meta-attributes"
+   -->
+  <define name="primitive-template.meta_attributes.nvpair.name-unsupported">
+    <attribute name="name">
+      <data type="string">
+        <except>
+          <choice>
+            <value>isolation</value>
+            <value>isolation-host</value>
+            <value>isolation-instance</value>
+            <value>isolation-wrapper</value>
+          </choice>
+        </except>
+      </data>
+    </attribute>
+  </define>
+
+  <define name="element-resource-extra.primitive-template">
+    <zeroOrMore>
+      <choice>
+        <element name="meta_attributes">
+          <grammar>
+            <include href="nvset-3.9.rng">
+              <define name="element-nvset.name">
+                <parentRef name="primitive-template.meta_attributes.nvpair.name-unsupported"/>
+              </define>
+            </include>
+          </grammar>
+        </element>
+        <element name="instance_attributes">
+          <externalRef href="nvset-3.9.rng"/>
+        </element>
+      </choice>
+    </zeroOrMore>
+  </define>
+
+  <define name="element-primitive">
+    <element name="primitive">
+      <interleave>
+        <attribute name="id"><data type="ID"/></attribute>
+        <choice>
+          <group>
+            <ref name="element-resource-class"/>
+            <attribute name="type"><text/></attribute>
+          </group>
+          <attribute name="template"><data type="IDREF"/></attribute>
+        </choice>
+        <optional>
+          <attribute name="description"><text/></attribute>
+        </optional>
+        <ref name="element-resource-extra.primitive-template"/>
+        <ref name="element-operations"/>
+        <zeroOrMore>
+          <element name="utilization">
+            <externalRef href="nvset-3.9.rng"/>
+          </element>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+
+  <define name="element-template">
+    <element name="template">
+      <interleave>
+        <attribute name="id"><data type="ID"/></attribute>
+        <ref name="element-resource-class"/>
+        <attribute name="type"><text/></attribute>
+        <optional>
+          <attribute name="description"><text/></attribute>
+        </optional>
+        <ref name="element-resource-extra.primitive-template"/>
+        <ref name="element-operations"/>
+        <zeroOrMore>
+          <element name="utilization">
+            <externalRef href="nvset-3.9.rng"/>
+          </element>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+
+  <define name="element-bundle">
+    <element name="bundle">
+      <interleave>
+        <attribute name="id"><data type="ID"/></attribute>
+        <optional>
+          <attribute name="description"><text/></attribute>
+        </optional>
+        <ref name="element-resource-extra"/>
+        <choice>
+          <element name="docker">
+            <attribute name="image"><text/></attribute>
+            <optional>
+              <attribute name="replicas"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="replicas-per-host"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <choice>
+                <attribute name="masters"><data type="integer"/></attribute>
+                <attribute name="promoted-max"><data type="integer"/></attribute>
+              </choice>
+            </optional>
+            <optional>
+              <attribute name="run-command"> <text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="network"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="options"><text/></attribute>
+            </optional>
+          </element>
+          <element name="rkt">
+            <attribute name="image"><text/></attribute>
+            <optional>
+              <attribute name="replicas"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="replicas-per-host"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <choice>
+                <attribute name="masters"><data type="integer"/></attribute>
+                <attribute name="promoted-max"><data type="integer"/></attribute>
+              </choice>
+            </optional>
+            <optional>
+              <attribute name="run-command"> <text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="network"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="options"><text/></attribute>
+            </optional>
+          </element>
+          <element name="podman">
+            <attribute name="image"><text/></attribute>
+            <optional>
+              <attribute name="replicas"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="replicas-per-host"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <choice>
+                <attribute name="masters"><data type="integer"/></attribute>
+                <attribute name="promoted-max"><data type="integer"/></attribute>
+              </choice>
+            </optional>
+            <optional>
+              <attribute name="run-command"> <text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="network"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="options"><text/></attribute>
+            </optional>
+          </element>
+        </choice>
+        <optional>
+          <element name="network">
+            <optional>
+              <attribute name="ip-range-start"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="control-port"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="host-interface"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="host-netmask"><data type="integer"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="add-host"><data type="boolean"/></attribute>
+            </optional>
+            <zeroOrMore>
+              <element name="port-mapping">
+                <attribute name="id"><data type="ID"/></attribute>
+                <choice>
+                  <group>
+                    <attribute name="port"><data type="integer"/></attribute>
+                    <optional>
+                      <attribute name="internal-port"><data type="integer"/></attribute>
+                    </optional>
+                  </group>
+                  <attribute name="range">
+                    <data type="string">
+                      <param name="pattern">([0-9\-]+)</param>
+                    </data>
+                  </attribute>
+                </choice>
+              </element>
+            </zeroOrMore>
+          </element>
+        </optional>
+        <optional>
+          <element name="storage">
+            <zeroOrMore>
+              <element name="storage-mapping">
+                <attribute name="id"><data type="ID"/></attribute>
+                <choice>
+                  <attribute name="source-dir"><text/></attribute>
+                  <attribute name="source-dir-root"><text/></attribute>
+                </choice>
+                <attribute name="target-dir"><text/></attribute>
+                <optional>
+                  <attribute name="options"><text/></attribute>
+                </optional>
+              </element>
+            </zeroOrMore>
+          </element>
+        </optional>
+        <optional>
+          <ref name="element-primitive"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+
+  <define name="element-group">
+    <element name="group">
+      <attribute name="id"><data type="ID"/></attribute>
+      <optional>
+        <attribute name="description"><text/></attribute>
+      </optional>
+      <interleave>
+        <ref name="element-resource-extra"/>
+        <oneOrMore>
+          <ref name="element-primitive"/>
+        </oneOrMore>
+      </interleave>
+    </element>
+  </define>
+
+  <define name="element-clone">
+    <element name="clone">
+      <attribute name="id"><data type="ID"/></attribute>
+      <optional>
+        <attribute name="description"><text/></attribute>
+      </optional>
+      <interleave>
+        <ref name="element-resource-extra"/>
+        <choice>
+          <ref name="element-primitive"/>
+          <ref name="element-group"/>
+        </choice>
+      </interleave>
+    </element>
+  </define>
+
+  <define name="element-master">
+    <element name="master">
+      <attribute name="id"><data type="ID"/></attribute>
+      <optional>
+        <attribute name="description"><text/></attribute>
+      </optional>
+      <interleave>
+        <ref name="element-resource-extra"/>
+        <choice>
+          <ref name="element-primitive"/>
+          <ref name="element-group"/>
+        </choice>
+      </interleave>
+    </element>
+  </define>
+
+  <define name="element-resource-extra">
+    <zeroOrMore>
+      <choice>
+        <element name="meta_attributes">
+          <externalRef href="nvset-3.9.rng"/>
+        </element>
+        <element name="instance_attributes">
+          <externalRef href="nvset-3.9.rng"/>
+        </element>
+      </choice>
+    </zeroOrMore>
+  </define>
+
+  <!--
+   see upgrade-2.10.xsl
+   - cibtr:table for="resources-operation"
+   -->
+  <define name="op.meta_attributes.nvpair.name-unsupported">
+    <attribute name="name">
+      <data type="string">
+        <except>
+          <choice>
+            <value>requires</value>
+          </choice>
+        </except>
+      </data>
+    </attribute>
+  </define>
+
+  <define name="element-resource-extra.op">
+    <zeroOrMore>
+      <choice>
+        <element name="meta_attributes">
+          <grammar>
+            <include href="nvset-3.9.rng">
+              <define name="element-nvset.name">
+                <parentRef name="op.meta_attributes.nvpair.name-unsupported"/>
+              </define>
+            </include>
+          </grammar>
+        </element>
+        <element name="instance_attributes">
+          <externalRef href="nvset-3.9.rng"/>
+        </element>
+      </choice>
+    </zeroOrMore>
+  </define>
+
+  <define name="element-operations">
+    <optional>
+      <element name="operations">
+        <optional>
+          <attribute name="id"><data type="ID"/></attribute>
+        </optional>
+        <optional>
+          <attribute name="id-ref"><data type="IDREF"/></attribute>
+        </optional>
+        <zeroOrMore>
+          <element name="op">
+            <attribute name="id"><data type="ID"/></attribute>
+            <attribute name="name"><text/></attribute>
+            <attribute name="interval"><text/></attribute>
+            <optional>
+              <attribute name="description"><text/></attribute>
+            </optional>
+            <optional>
+              <choice>
+                <attribute name="start-delay"><text/></attribute>
+                <attribute name="interval-origin"><text/></attribute>
+              </choice>
+            </optional>
+            <optional>
+              <attribute name="timeout"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="enabled"><data type="boolean"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="record-pending"><data type="boolean"/></attribute>
+            </optional>
+            <optional>
+              <attribute name="role">
+                <choice>
+                  <value>Stopped</value>
+                  <value>Started</value>
+                  <value>Promoted</value>
+                  <value>Unpromoted</value>
+                  <value>Slave</value>
+                  <value>Master</value>
+                </choice>
+              </attribute>
+            </optional>
+            <optional>
+              <attribute name="on-fail">
+                <choice>
+                  <value>ignore</value>
+                  <value>block</value>
+                  <value>demote</value>
+                  <value>stop</value>
+                  <value>restart</value>
+                  <value>standby</value>
+                  <value>fence</value>
+                  <value>restart-container</value>
+                </choice>
+              </attribute>
+            </optional>
+            <ref name="element-resource-extra.op"/>
+          </element>
+        </zeroOrMore>
+      </element>
+    </optional>
+  </define>
+
+  <define name="element-resource-class">
+    <choice>
+      <group>
+        <attribute name="class"><value>ocf</value></attribute>
+        <attribute name="provider"><text/></attribute>
+      </group>
+      <attribute name="class">
+        <choice>
+          <value>lsb</value>
+          <value>heartbeat</value>
+          <value>stonith</value>
+          <value>upstart</value>
+          <value>service</value>
+          <value>systemd</value>
+          <value>nagios</value>
+        </choice>
+      </attribute>
+    </choice>
+  </define>
+</grammar>

--- a/xml/rule-3.9.rng
+++ b/xml/rule-3.9.rng
@@ -146,16 +146,7 @@
     <element name="duration">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <attribute name="hours"><text/></attribute>
-      </optional>
-      <optional>
-        <attribute name="monthdays"><text/></attribute>
-      </optional>
-      <optional>
-        <attribute name="weekdays"><text/></attribute>
-      </optional>
-      <optional>
-        <attribute name="yearsdays"><text/></attribute>
+        <attribute name="years"><text/></attribute>
       </optional>
       <optional>
         <attribute name="months"><text/></attribute>
@@ -164,7 +155,18 @@
         <attribute name="weeks"><text/></attribute>
       </optional>
       <optional>
-        <attribute name="years"><text/></attribute>
+        <attribute name="hours"><text/></attribute>
+      </optional>
+
+      <!-- @COMPAT: The below attributes are invalid for duration -->
+      <optional>
+        <attribute name="monthdays"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="weekdays"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="yearsdays"><text/></attribute>
       </optional>
       <optional>
         <attribute name="weekyears"><text/></attribute>
@@ -179,31 +181,33 @@
     <element name="date_spec">
       <attribute name="id"><data type="ID"/></attribute>
       <optional>
-        <attribute name="hours"><text/></attribute>
-      </optional>
-      <optional>
-        <attribute name="monthdays"><text/></attribute>
-      </optional>
-      <optional>
-        <attribute name="weekdays"><text/></attribute>
-      </optional>
-      <optional>
-        <attribute name="yearsdays"><text/></attribute>
+        <attribute name="years"><text/></attribute>
       </optional>
       <optional>
         <attribute name="months"><text/></attribute>
       </optional>
       <optional>
-        <attribute name="weeks"><text/></attribute>
+        <attribute name="monthdays"><text/></attribute>
       </optional>
       <optional>
-        <attribute name="years"><text/></attribute>
+        <attribute name="hours"><text/></attribute>
       </optional>
       <optional>
         <attribute name="weekyears"><text/></attribute>
       </optional>
       <optional>
+        <attribute name="weeks"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="weekdays"><text/></attribute>
+      </optional>
+      <optional>
         <attribute name="moon"><text/></attribute>
+      </optional>
+
+      <!-- @COMPAT: The below attributes are invalid for date_spec -->
+      <optional>
+        <attribute name="yearsdays"><text/></attribute>
       </optional>
     </element>
   </define>

--- a/xml/rule-3.9.rng
+++ b/xml/rule-3.9.rng
@@ -155,7 +155,16 @@
         <attribute name="weeks"><text/></attribute>
       </optional>
       <optional>
+        <attribute name="days"><text/></attribute>
+      </optional>
+      <optional>
         <attribute name="hours"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="minutes"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="seconds"><text/></attribute>
       </optional>
 
       <!-- @COMPAT: The below attributes are invalid for duration -->
@@ -191,6 +200,15 @@
       </optional>
       <optional>
         <attribute name="hours"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="minutes"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="seconds"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="yeardays"><text/></attribute>
       </optional>
       <optional>
         <attribute name="weekyears"><text/></attribute>

--- a/xml/rule-3.9.rng
+++ b/xml/rule-3.9.rng
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" 
+         xmlns:ann="http://relaxng.org/ns/compatibility/annotations/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+      <ref name="element-rule"/>
+  </start>
+
+  <define name="element-rule">
+    <element name="rule">
+     <choice>
+     <attribute name="id-ref"><data type="IDREF"/></attribute>
+     <group>
+      <attribute name="id"><data type="ID"/></attribute>
+      <choice>
+        <externalRef href="score.rng"/>
+        <attribute name="score-attribute"><text/></attribute>
+      </choice>
+      <optional>
+        <attribute name="boolean-op">
+          <choice>
+            <value>or</value>
+            <value>and</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="role"><text/></attribute>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <element name="expression">
+            <attribute name="id"><data type="ID"/></attribute>
+            <attribute name="attribute"><text/></attribute>
+            <attribute name="operation">
+              <choice>
+                <value>lt</value>
+                <value>gt</value>
+                <value>lte</value>
+                <value>gte</value>
+                <value>eq</value>
+                <value>ne</value>
+                <value>defined</value>
+                <value>not_defined</value>
+              </choice>
+            </attribute>
+            <optional>
+              <attribute name="value"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="type" ann:defaultValue="string">
+                <choice>
+                  <value>string</value>
+                  <value>integer</value>
+                  <value>number</value>
+                  <value>version</value>
+                </choice>
+              </attribute>
+            </optional>
+            <optional>
+              <attribute name="value-source" ann:defaultValue="literal">
+                <choice>
+                  <value>literal</value>
+                  <value>param</value>
+                  <value>meta</value>
+                </choice>
+              </attribute>
+            </optional>
+          </element>
+          <element name="date_expression">
+            <attribute name="id"><data type="ID"/></attribute>
+            <choice>
+              <group>
+                <attribute name="operation"><value>in_range</value></attribute>
+                <choice>
+                  <group>
+                    <optional>
+                      <attribute name="start"><text/></attribute>
+                    </optional>
+                    <attribute name="end"><text/></attribute>
+                  </group>
+                  <group>
+                    <attribute name="start"><text/></attribute>
+                    <element name="duration">
+                      <ref name="date-common"/>
+                    </element>
+                  </group>
+                </choice>
+              </group>
+              <group>
+                <attribute name="operation"><value>gt</value></attribute>
+                <attribute name="start"><text/></attribute>
+              </group>
+              <group>
+                <attribute name="operation"><value>lt</value></attribute>
+                <choice>
+                  <attribute name="end"><text/></attribute>
+                </choice>
+              </group>
+              <group>
+                <attribute name="operation"><value>date_spec</value></attribute>
+                <element name="date_spec">
+                  <ref name="date-common"/>
+                </element> 
+              </group>
+            </choice>
+          </element> 
+          <element name="rsc_expression">
+            <attribute name="id"><data type="ID"/></attribute>
+            <optional>
+              <attribute name="class"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="provider"><text/></attribute>
+            </optional>
+            <optional>
+              <attribute name="type"><text/></attribute>
+            </optional>
+          </element>
+          <element name="op_expression">
+            <attribute name="id"><data type="ID"/></attribute>
+            <attribute name="name"><text/></attribute>
+            <optional>
+              <attribute name="interval"><text/></attribute>
+            </optional>
+          </element>
+          <ref name="element-rule"/>
+        </choice>
+      </oneOrMore>
+     </group>
+     </choice>
+    </element>
+  </define>
+
+  <define name="date-common">
+    <attribute name="id"><data type="ID"/></attribute>
+    <optional>
+      <attribute name="hours"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="monthdays"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="weekdays"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="yearsdays"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="months"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="weeks"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="years"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="weekyears"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="moon"><text/></attribute>
+    </optional>
+  </define>
+
+</grammar>

--- a/xml/rule-3.9.rng
+++ b/xml/rule-3.9.rng
@@ -6,73 +6,104 @@
       <ref name="element-rule"/>
   </start>
 
+  <!--
+   The COMPAT comments below mark items that are invalid in their given context
+   and should be removed at a compatibility break.
+   -->
+
+  <!--
+   A rule element that doesn't match any of the special cases defined below
+   -->
   <define name="element-rule">
     <element name="rule">
       <choice>
         <attribute name="id-ref"><data type="IDREF"/></attribute>
         <group>
-          <attribute name="id"><data type="ID"/></attribute>
+          <ref name="rule-common"/>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="element-rule"/>
+
+              <!--
+               @COMPAT: The below expression types are invalid for element-rule
+               -->
+              <ref name="rsc_expression"/>
+              <ref name="op_expression"/>
+            </choice>
+          </oneOrMore>
+
+          <!--
+           @COMPAT: The below score attributes are invalid for element-rule
+           -->
           <optional>
             <choice>
               <externalRef href="score.rng"/>
               <attribute name="score-attribute"><text/></attribute>
             </choice>
           </optional>
-          <optional>
-            <attribute name="boolean-op">
-              <choice>
-                <value>or</value>
-                <value>and</value>
-              </choice>
-            </attribute>
-          </optional>
-          <optional>
-            <attribute name="role"><text/></attribute>
-          </optional>
-          <oneOrMore>
-            <choice>
-              <ref name="expression"/>
-              <ref name="date_expression"/>
-              <ref name="rsc_expression"/>
-              <ref name="op_expression"/>
-              <ref name="element-rule"/>
-            </choice>
-          </oneOrMore>
         </group>
       </choice>
     </element>
   </define>
 
+  <!-- A rule element in a location constraint -->
+  <define name="element-rule-location">
+    <element name="rule">
+      <choice>
+        <attribute name="id-ref"><data type="IDREF"/></attribute>
+        <group>
+          <ref name="rule-common"/>
+          <oneOrMore>
+            <choice>
+              <ref name="expression-location"/>
+              <ref name="date_expression"/>
+              <ref name="element-rule-location"/>
+
+              <!--
+               @COMPAT: The below expression types are invalid for
+               element-rule-location
+               -->
+              <ref name="rsc_expression"/>
+              <ref name="op_expression"/>
+            </choice>
+          </oneOrMore>
+          <optional>
+            <choice>
+              <externalRef href="score.rng"/>
+              <attribute name="score-attribute"><text/></attribute>
+            </choice>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+
+  <!-- Attributes that are common to all rule elements -->
+  <define name="rule-common">
+    <attribute name="id"><data type="ID"/></attribute>
+    <optional>
+      <attribute name="boolean-op">
+        <choice>
+          <value>or</value>
+          <value>and</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="role"><text/></attribute>
+    </optional>
+  </define>
+
   <!-- A node attribute expression -->
   <define name="expression">
     <element name="expression">
-      <attribute name="id"><data type="ID"/></attribute>
-      <attribute name="attribute"><text/></attribute>
-      <attribute name="operation">
-        <choice>
-          <value>lt</value>
-          <value>gt</value>
-          <value>lte</value>
-          <value>gte</value>
-          <value>eq</value>
-          <value>ne</value>
-          <value>defined</value>
-          <value>not_defined</value>
-        </choice>
-      </attribute>
-      <optional>
-        <attribute name="value"><text/></attribute>
-      </optional>
-      <optional>
-        <attribute name="type" ann:defaultValue="string">
-          <choice>
-            <value>string</value>
-            <value>integer</value>
-            <value>number</value>
-            <value>version</value>
-          </choice>
-        </attribute>
-      </optional>
+      <ref name="expression-common"/>
+
+      <!--
+       @COMPAT: The value-source attribute is invalid for expression
+       -->
       <optional>
         <attribute name="value-source" ann:defaultValue="literal">
           <choice>
@@ -83,6 +114,53 @@
         </attribute>
       </optional>
     </element>
+  </define>
+
+  <!-- A node attribute expression in a location constraint -->
+  <define name="expression-location">
+    <element name="expression">
+      <ref name="expression-common"/>
+      <optional>
+        <attribute name="value-source" ann:defaultValue="literal">
+          <choice>
+            <value>literal</value>
+            <value>param</value>
+            <value>meta</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+
+  <!-- Attributes that are common to all <expression> elements -->
+  <define name="expression-common">
+    <attribute name="id"><data type="ID"/></attribute>
+    <attribute name="attribute"><text/></attribute>
+    <attribute name="operation">
+      <choice>
+        <value>lt</value>
+        <value>gt</value>
+        <value>lte</value>
+        <value>gte</value>
+        <value>eq</value>
+        <value>ne</value>
+        <value>defined</value>
+        <value>not_defined</value>
+      </choice>
+    </attribute>
+    <optional>
+      <attribute name="value"><text/></attribute>
+    </optional>
+    <optional>
+      <attribute name="type" ann:defaultValue="string">
+        <choice>
+          <value>string</value>
+          <value>integer</value>
+          <value>number</value>
+          <value>version</value>
+        </choice>
+      </attribute>
+    </optional>
   </define>
 
   <define name="date_expression">

--- a/xml/rule-3.9.rng
+++ b/xml/rule-3.9.rng
@@ -12,10 +12,12 @@
         <attribute name="id-ref"><data type="IDREF"/></attribute>
         <group>
           <attribute name="id"><data type="ID"/></attribute>
-          <choice>
-            <externalRef href="score.rng"/>
-            <attribute name="score-attribute"><text/></attribute>
-          </choice>
+          <optional>
+            <choice>
+              <externalRef href="score.rng"/>
+              <attribute name="score-attribute"><text/></attribute>
+            </choice>
+          </optional>
           <optional>
             <attribute name="boolean-op">
               <choice>

--- a/xml/rule-3.9.rng
+++ b/xml/rule-3.9.rng
@@ -80,6 +80,43 @@
     </element>
   </define>
 
+  <!-- A rule element in a rsc_defaults element -->
+  <define name="element-rule-rsc_defaults">
+    <element name="rule">
+      <choice>
+        <attribute name="id-ref"><data type="IDREF"/></attribute>
+        <group>
+          <ref name="rule-common"/>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rsc_expression"/>
+              <ref name="element-rule-rsc_defaults"/>
+
+              <!--
+               @COMPAT: The below expression type is invalid for
+               element-rule-rsc_defaults
+               -->
+              <ref name="op_expression"/>
+            </choice>
+          </oneOrMore>
+
+          <!--
+           @COMPAT: The below score attributes are invalid for
+           element-rule-rsc_defaults
+           -->
+          <optional>
+            <choice>
+              <externalRef href="score.rng"/>
+              <attribute name="score-attribute"><text/></attribute>
+            </choice>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+
   <!-- Attributes that are common to all rule elements -->
   <define name="rule-common">
     <attribute name="id"><data type="ID"/></attribute>

--- a/xml/rule-3.9.rng
+++ b/xml/rule-3.9.rng
@@ -8,127 +8,144 @@
 
   <define name="element-rule">
     <element name="rule">
-     <choice>
-     <attribute name="id-ref"><data type="IDREF"/></attribute>
-     <group>
-      <attribute name="id"><data type="ID"/></attribute>
       <choice>
-        <externalRef href="score.rng"/>
-        <attribute name="score-attribute"><text/></attribute>
-      </choice>
-      <optional>
-        <attribute name="boolean-op">
+        <attribute name="id-ref"><data type="IDREF"/></attribute>
+        <group>
+          <attribute name="id"><data type="ID"/></attribute>
           <choice>
-            <value>or</value>
-            <value>and</value>
+            <externalRef href="score.rng"/>
+            <attribute name="score-attribute"><text/></attribute>
+          </choice>
+          <optional>
+            <attribute name="boolean-op">
+              <choice>
+                <value>or</value>
+                <value>and</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="role"><text/></attribute>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rsc_expression"/>
+              <ref name="op_expression"/>
+              <ref name="element-rule"/>
+            </choice>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+
+  <!-- A node attribute expression -->
+  <define name="expression">
+    <element name="expression">
+      <attribute name="id"><data type="ID"/></attribute>
+      <attribute name="attribute"><text/></attribute>
+      <attribute name="operation">
+        <choice>
+          <value>lt</value>
+          <value>gt</value>
+          <value>lte</value>
+          <value>gte</value>
+          <value>eq</value>
+          <value>ne</value>
+          <value>defined</value>
+          <value>not_defined</value>
+        </choice>
+      </attribute>
+      <optional>
+        <attribute name="value"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="type" ann:defaultValue="string">
+          <choice>
+            <value>string</value>
+            <value>integer</value>
+            <value>number</value>
+            <value>version</value>
           </choice>
         </attribute>
       </optional>
       <optional>
-        <attribute name="role"><text/></attribute>
+        <attribute name="value-source" ann:defaultValue="literal">
+          <choice>
+            <value>literal</value>
+            <value>param</value>
+            <value>meta</value>
+          </choice>
+        </attribute>
       </optional>
-      <oneOrMore>
-        <choice>
-          <element name="expression">
-            <attribute name="id"><data type="ID"/></attribute>
-            <attribute name="attribute"><text/></attribute>
-            <attribute name="operation">
-              <choice>
-                <value>lt</value>
-                <value>gt</value>
-                <value>lte</value>
-                <value>gte</value>
-                <value>eq</value>
-                <value>ne</value>
-                <value>defined</value>
-                <value>not_defined</value>
-              </choice>
-            </attribute>
-            <optional>
-              <attribute name="value"><text/></attribute>
-            </optional>
-            <optional>
-              <attribute name="type" ann:defaultValue="string">
-                <choice>
-                  <value>string</value>
-                  <value>integer</value>
-                  <value>number</value>
-                  <value>version</value>
-                </choice>
-              </attribute>
-            </optional>
-            <optional>
-              <attribute name="value-source" ann:defaultValue="literal">
-                <choice>
-                  <value>literal</value>
-                  <value>param</value>
-                  <value>meta</value>
-                </choice>
-              </attribute>
-            </optional>
-          </element>
-          <element name="date_expression">
-            <attribute name="id"><data type="ID"/></attribute>
-            <choice>
-              <group>
-                <attribute name="operation"><value>in_range</value></attribute>
-                <choice>
-                  <group>
-                    <optional>
-                      <attribute name="start"><text/></attribute>
-                    </optional>
-                    <attribute name="end"><text/></attribute>
-                  </group>
-                  <group>
-                    <attribute name="start"><text/></attribute>
-                    <element name="duration">
-                      <ref name="date-common"/>
-                    </element>
-                  </group>
-                </choice>
-              </group>
-              <group>
-                <attribute name="operation"><value>gt</value></attribute>
+    </element>
+  </define>
+
+  <define name="date_expression">
+    <element name="date_expression">
+      <attribute name="id"><data type="ID"/></attribute>
+      <choice>
+        <group>
+          <attribute name="operation"><value>in_range</value></attribute>
+          <choice>
+            <group>
+              <optional>
                 <attribute name="start"><text/></attribute>
-              </group>
-              <group>
-                <attribute name="operation"><value>lt</value></attribute>
-                <choice>
-                  <attribute name="end"><text/></attribute>
-                </choice>
-              </group>
-              <group>
-                <attribute name="operation"><value>date_spec</value></attribute>
-                <element name="date_spec">
-                  <ref name="date-common"/>
-                </element> 
-              </group>
-            </choice>
+              </optional>
+              <attribute name="end"><text/></attribute>
+            </group>
+            <group>
+              <attribute name="start"><text/></attribute>
+              <element name="duration">
+                <ref name="date-common"/>
+              </element>
+            </group>
+          </choice>
+        </group>
+        <group>
+          <attribute name="operation"><value>gt</value></attribute>
+          <attribute name="start"><text/></attribute>
+        </group>
+        <group>
+          <attribute name="operation"><value>lt</value></attribute>
+          <choice>
+            <attribute name="end"><text/></attribute>
+          </choice>
+        </group>
+        <group>
+          <attribute name="operation"><value>date_spec</value></attribute>
+          <element name="date_spec">
+            <ref name="date-common"/>
           </element> 
-          <element name="rsc_expression">
-            <attribute name="id"><data type="ID"/></attribute>
-            <optional>
-              <attribute name="class"><text/></attribute>
-            </optional>
-            <optional>
-              <attribute name="provider"><text/></attribute>
-            </optional>
-            <optional>
-              <attribute name="type"><text/></attribute>
-            </optional>
-          </element>
-          <element name="op_expression">
-            <attribute name="id"><data type="ID"/></attribute>
-            <attribute name="name"><text/></attribute>
-            <optional>
-              <attribute name="interval"><text/></attribute>
-            </optional>
-          </element>
-          <ref name="element-rule"/>
-        </choice>
-      </oneOrMore>
-     </group>
-     </choice>
+        </group>
+      </choice>
+    </element> 
+  </define>
+
+  <define name="rsc_expression">
+    <element name="rsc_expression">
+      <attribute name="id"><data type="ID"/></attribute>
+      <optional>
+        <attribute name="class"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="provider"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="type"><text/></attribute>
+      </optional>
+    </element>
+  </define>
+
+  <define name="op_expression">
+    <element name="op_expression">
+      <attribute name="id"><data type="ID"/></attribute>
+      <attribute name="name"><text/></attribute>
+      <optional>
+        <attribute name="interval"><text/></attribute>
+      </optional>
     </element>
   </define>
 

--- a/xml/rule-3.9.rng
+++ b/xml/rule-3.9.rng
@@ -117,6 +117,38 @@
     </element>
   </define>
 
+  <!-- A rule element in an op_defaults element -->
+  <define name="element-rule-op_defaults">
+    <element name="rule">
+      <choice>
+        <attribute name="id-ref"><data type="IDREF"/></attribute>
+        <group>
+          <ref name="rule-common"/>
+          <oneOrMore>
+            <choice>
+              <ref name="expression"/>
+              <ref name="date_expression"/>
+              <ref name="rsc_expression"/>
+              <ref name="op_expression"/>
+              <ref name="element-rule-op_defaults"/>
+            </choice>
+          </oneOrMore>
+
+          <!--
+           @COMPAT: The below score attributes are invalid for
+           element-rule-op_defaults
+           -->
+          <optional>
+            <choice>
+              <externalRef href="score.rng"/>
+              <attribute name="score-attribute"><text/></attribute>
+            </choice>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+
   <!-- Attributes that are common to all rule elements -->
   <define name="rule-common">
     <attribute name="id"><data type="ID"/></attribute>

--- a/xml/rule-3.9.rng
+++ b/xml/rule-3.9.rng
@@ -98,9 +98,7 @@
             </group>
             <group>
               <attribute name="start"><text/></attribute>
-              <element name="duration">
-                <ref name="date-common"/>
-              </element>
+              <ref name="duration"/>
             </group>
           </choice>
         </group>
@@ -116,9 +114,7 @@
         </group>
         <group>
           <attribute name="operation"><value>date_spec</value></attribute>
-          <element name="date_spec">
-            <ref name="date-common"/>
-          </element> 
+          <ref name="date_spec"/>
         </group>
       </choice>
     </element> 
@@ -149,35 +145,70 @@
     </element>
   </define>
 
-  <define name="date-common">
-    <attribute name="id"><data type="ID"/></attribute>
-    <optional>
-      <attribute name="hours"><text/></attribute>
-    </optional>
-    <optional>
-      <attribute name="monthdays"><text/></attribute>
-    </optional>
-    <optional>
-      <attribute name="weekdays"><text/></attribute>
-    </optional>
-    <optional>
-      <attribute name="yearsdays"><text/></attribute>
-    </optional>
-    <optional>
-      <attribute name="months"><text/></attribute>
-    </optional>
-    <optional>
-      <attribute name="weeks"><text/></attribute>
-    </optional>
-    <optional>
-      <attribute name="years"><text/></attribute>
-    </optional>
-    <optional>
-      <attribute name="weekyears"><text/></attribute>
-    </optional>
-    <optional>
-      <attribute name="moon"><text/></attribute>
-    </optional>
+  <define name="duration">
+    <element name="duration">
+      <attribute name="id"><data type="ID"/></attribute>
+      <optional>
+        <attribute name="hours"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="monthdays"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="weekdays"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="yearsdays"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="months"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="weeks"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="years"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="weekyears"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="moon"><text/></attribute>
+      </optional>
+    </element>
+  </define>
+
+  <define name="date_spec">
+    <element name="date_spec">
+      <attribute name="id"><data type="ID"/></attribute>
+      <optional>
+        <attribute name="hours"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="monthdays"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="weekdays"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="yearsdays"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="months"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="weeks"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="years"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="weekyears"><text/></attribute>
+      </optional>
+      <optional>
+        <attribute name="moon"><text/></attribute>
+      </optional>
+    </element>
   </define>
 
 </grammar>

--- a/xml/rule-3.9.rng
+++ b/xml/rule-3.9.rng
@@ -90,17 +90,16 @@
         <group>
           <attribute name="operation"><value>in_range</value></attribute>
           <choice>
-            <group>
-              <optional>
-                <attribute name="start"><text/></attribute>
-              </optional>
-              <attribute name="end"><text/></attribute>
-            </group>
+            <attribute name="start"><text/></attribute>
+            <attribute name="end"><text/></attribute>
             <group>
               <attribute name="start"><text/></attribute>
-              <ref name="duration"/>
+              <attribute name="end"><text/></attribute>
             </group>
           </choice>
+          <optional>
+            <ref name="duration"/>
+          </optional>
         </group>
         <group>
           <attribute name="operation"><value>gt</value></attribute>
@@ -108,9 +107,7 @@
         </group>
         <group>
           <attribute name="operation"><value>lt</value></attribute>
-          <choice>
-            <attribute name="end"><text/></attribute>
-          </choice>
+          <attribute name="end"><text/></attribute>
         </group>
         <group>
           <attribute name="operation"><value>date_spec</value></attribute>


### PR DESCRIPTION
`rules.c` allows several elements in `duration` and `date_spec` that the rule schema currently does not allow. The main point of this PR is to update the schema to allow everything that the rules parser allows. Summary of changes:
* Refactor the code in very minor ways (mostly name substitutions)
* Automatically rebuild `versions.rng` on a schema bump... or technically, on any schema change, as we do with the `pacemaker-x.y.rng` schemas.
* Create a separate definition for each rule expression type for readability and ease of maintenance.
* Split `duration` and `date_spec` into separate definitions, mark as deprecated the options that are invalid but must be kept for compatibility, and add valid options that are missing.
* Make the choice between `score` and `score-attribute` optional... it looks as if these have been required the whole time, even though they're valid only in location constraints.
* Create separate definitions for rules in location constraints (`element-rule-location`), rules in `rsc_defaults` elements (`element-rule-rsc_defaults`), rules in `op_defaults` elements (`element-rule-op_defaults`), and rules elsewhere (`element-rule`). For now, these must all have the same contents. If new valid options are added, they can go only where needed. Invalid options can be removed where appropriate at a compatibility break.
* Update the schemas that include rules so that they include the appropriate type of rule based on context. This will ease the transition in the future when we remove invalid options.
* Update the Pacemaker Explained doc with regard to `duration` and `date_spec`.

More info in [T196](https://projects.clusterlabs.org/T196).

Closes T196