### PR TITLE
Refactor: various: Remove U64T(S), U32T, and X32T print/scanf specs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -791,41 +791,6 @@ AS_CASE(["$host_cpu"],
                     ])
         ])
 
-# C99 doesn't guarantee uint64_t type and related format specifiers, but
-# prerequisites, corosync + libqb, use that widely, so the target platforms
-# are already pre-constrained to those "64bit-clean" (doesn't imply native
-# bit width) and hence we deliberately refrain from artificial surrogates
-# (sans manipulation through cached values).
-AC_CACHE_VAL(
-    [pcmk_cv_decl_inttypes],
-    [
-        AC_CHECK_DECLS(
-            [PRIu64, PRIu32, PRIx32,
-             SCNu64],
-            [pcmk_cv_decl_inttypes="PRIu64 PRIu32 PRIx32 SCNu64"],
-            [
-                # test shall only react on "no" cached result & error out respectively
-                AS_IF([test "x$ac_cv_have_decl_PRIu64" = x"no"],
-                      [AC_MSG_ERROR([lack of inttypes.h based specifier serving uint64_t (PRIu64)])],
-                      [test "x$ac_cv_have_decl_PRIu32" = x"no"],
-                      [AC_MSG_ERROR([lack of inttypes.h based specifier serving uint32_t (PRIu32)])],
-                      [test "x$ac_cv_have_decl_PRIx32" = x"no"],
-                      [AC_MSG_ERROR([lack of inttypes.h based hexa specifier serving uint32_t (PRIx32)])],
-                      [test "x$ac_cv_have_decl_SCNu64" = x"no"],
-                      [AC_MSG_ERROR([lack of inttypes.h based specifier gathering uint64_t (SCNu64)])])
-            ],
-            [[#include <inttypes.h>]]
-        )
-    ]
-)
-(
-    set $pcmk_cv_decl_inttypes
-    AC_DEFINE_UNQUOTED([U64T],  [$1], [Correct format specifier for U64T])
-    AC_DEFINE_UNQUOTED([U32T],  [$2], [Correct format specifier for U32T])
-    AC_DEFINE_UNQUOTED([X32T],  [$3], [Correct format specifier for X32T])
-    AC_DEFINE_UNQUOTED([U64TS], [$4], [Correct format specifier for U64TS])
-)
-
 dnl ===============================================
 dnl Program Paths
 dnl ===============================================

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -18,7 +18,7 @@
 #include <stdint.h>     // uint32_t, uint64_t, UINT64_C()
 #include <errno.h>
 #include <fcntl.h>
-#include <inttypes.h>  /* U64T ~ PRIu64 */
+#include <inttypes.h>   // PRIu64
 
 #include <crm/crm.h>
 #include <crm/cib.h>
@@ -284,7 +284,7 @@ cib_digester_cb(gpointer data)
         free(ping_digest);
         ping_digest = NULL;
         ping_modified_since = FALSE;
-        snprintf(buffer, 32, "%" U64T, ping_seq);
+        snprintf(buffer, 32, "%" PRIu64, ping_seq);
         crm_trace("Requesting peer digests (%s)", buffer);
 
         crm_xml_add(ping, F_TYPE, "cib");

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -13,7 +13,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
-#include <inttypes.h>  /* U64T ~ PRIu64 */
+#include <inttypes.h>   // PRIu64
 
 #include <bzlib.h>
 
@@ -274,16 +274,16 @@ quorum_notification_cb(quorum_handle_t handle, uint32_t quorate,
 
     if (quorate != crm_have_quorum) {
         if (quorate) {
-            crm_notice("Quorum acquired " CRM_XS " membership=%" U64T " members=%lu",
+            crm_notice("Quorum acquired " CRM_XS " membership=%" PRIu64 " members=%lu",
                        ring_id, (long unsigned int)view_list_entries);
         } else {
-            crm_warn("Quorum lost " CRM_XS " membership=%" U64T " members=%lu",
+            crm_warn("Quorum lost " CRM_XS " membership=%" PRIu64 " members=%lu",
                      ring_id, (long unsigned int)view_list_entries);
         }
         crm_have_quorum = quorate;
 
     } else {
-        crm_info("Quorum %s " CRM_XS " membership=%" U64T " members=%lu",
+        crm_info("Quorum %s " CRM_XS " membership=%" PRIu64 " members=%lu",
                  (quorate? "retained" : "still lost"), ring_id,
                  (long unsigned int)view_list_entries);
     }

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -23,7 +23,7 @@
 #include <netdb.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <inttypes.h>  /* X32T ~ PRIx32 */
+#include <inttypes.h>   // PRIx32
 
 #include <glib.h>
 #include <bzlib.h>
@@ -106,8 +106,8 @@ localized_remote_header(pcmk__remote_t *remote)
 
         CRM_LOG_ASSERT(endian == ENDIAN_LOCAL);
         if(endian != ENDIAN_LOCAL) {
-            crm_err("Invalid message detected, endian mismatch: %" X32T
-                    " is neither %" X32T " nor the swab'd %" X32T,
+            crm_err("Invalid message detected, endian mismatch: %" PRIx32
+                    " is neither %" PRIx32 " nor the swab'd %" PRIx32,
                     ENDIAN_LOCAL, header->endian, endian);
             return NULL;
         }


### PR DESCRIPTION
There are custom constants called U64T, X32T, etc. in configure.ac. They're intended to do the same job as the fixed-width format specifiers (PRIu64, SCNu64, etc.) that are specified in the C standard. The basic idea is that the C99 standard doesn't guarantee the existence of exact-width integer types.

However, Pacemaker already relies on fixed-width types and has for some time. There's no longer any reason to keep these.