### PR TITLE
Fix: daemons: Resource reordering doesn't cause transition abort

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1210,7 +1210,9 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     char *current_nodes_digest = NULL;
     char *current_alerts_digest = NULL;
     char *current_status_digest = NULL;
-    int change_section = cib_change_section_nodes | cib_change_section_alerts | cib_change_section_status;
+    uint32_t change_section = cib_change_section_nodes
+                              |cib_change_section_alerts
+                              |cib_change_section_status;
 
     CRM_ASSERT(cib_status == pcmk_ok);
 

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1340,17 +1340,34 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
             result_status_digest = calculate_section_digest("//" XML_TAG_CIB "/" XML_CIB_TAG_STATUS, result_cib);
             crm_trace("result-digest %s:%s:%s", result_nodes_digest, result_alerts_digest, result_status_digest);
 
-            if (pcmk__str_eq(current_nodes_digest, result_nodes_digest, pcmk__str_none)) {
-                change_section = change_section ^ cib_change_section_nodes;
-            }
-            if (pcmk__str_eq(current_alerts_digest, result_alerts_digest, pcmk__str_none)) {
-                change_section = change_section ^ cib_change_section_alerts;
-            }
-            if (pcmk__str_eq(current_status_digest, result_status_digest, pcmk__str_none)) {
-                change_section = change_section ^ cib_change_section_status;
+            if (pcmk__str_eq(current_nodes_digest, result_nodes_digest,
+                             pcmk__str_none)) {
+                change_section =
+                    pcmk__clear_flags_as(__func__, __LINE__, LOG_TRACE,
+                                         "CIB change section",
+                                         "change_section", change_section,
+                                         cib_change_section_nodes, "nodes");
             }
 
-            if (change_section) {
+            if (pcmk__str_eq(current_alerts_digest, result_alerts_digest,
+                             pcmk__str_none)) {
+                change_section =
+                    pcmk__clear_flags_as(__func__, __LINE__, LOG_TRACE,
+                                         "CIB change section",
+                                         "change_section", change_section,
+                                         cib_change_section_alerts, "alerts");
+            }
+
+            if (pcmk__str_eq(current_status_digest, result_status_digest,
+                             pcmk__str_none)) {
+                change_section =
+                    pcmk__clear_flags_as(__func__, __LINE__, LOG_TRACE,
+                                         "CIB change section",
+                                         "change_section", change_section,
+                                         cib_change_section_status, "status");
+            }
+
+            if (change_section != cib_change_section_none) {
                 send_r_notify = TRUE;
             }
             

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -234,7 +234,8 @@ attach_cib_generation(xmlNode * msg, const char *field, xmlNode * a_cib)
 }
 
 void
-cib_replace_notify(const char *origin, xmlNode * update, int result, xmlNode * diff, int change_section)
+cib_replace_notify(const char *origin, xmlNode *update, int result,
+                   xmlNode *diff, uint32_t change_section)
 {
     xmlNode *replace_msg = NULL;
 
@@ -273,7 +274,8 @@ cib_replace_notify(const char *origin, xmlNode * update, int result, xmlNode * d
     crm_xml_add(replace_msg, F_SUBTYPE, T_CIB_REPLACE_NOTIFY);
     crm_xml_add(replace_msg, F_CIB_OPERATION, PCMK__CIB_REQUEST_REPLACE);
     crm_xml_add_int(replace_msg, F_CIB_RC, result);
-    crm_xml_add_int(replace_msg, F_CIB_CHANGE_SECTION, change_section);
+    crm_xml_add_ll(replace_msg, F_CIB_CHANGE_SECTION,
+                   (long long) change_section);
     attach_cib_generation(replace_msg, "cib-replace-generation", update);
 
     crm_log_xml_trace(replace_msg, "CIB Replaced");

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -146,7 +146,7 @@ void cib_diff_notify(int options, const char *client, const char *call_id,
                      const char *op, xmlNode *update, int result,
                      xmlNode *old_cib);
 void cib_replace_notify(const char *origin, xmlNode *update, int result,
-                        xmlNode *diff, int change_section);
+                        xmlNode *diff, uint32_t change_section);
 
 static inline const char *
 cib_config_lookup(const char *opt)

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -53,7 +53,9 @@ do_cib_replaced(const char *event, xmlNode * msg)
         change_section = (uint32_t) value;
     }
 
-    if (change_section & (cib_change_section_nodes | cib_change_section_status)) {
+    if (pcmk_any_flags_set(change_section, cib_change_section_nodes
+                                           |cib_change_section_status)) {
+
         /* start the join process again so we get everyone's LRM status */
         populate_cib_nodes(node_update_quick|node_update_all, __func__);
 

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -419,7 +419,13 @@ te_update_diff_v2(xmlNode *diff)
             crm_trace("Ignoring %s change for version field", op);
             continue;
 
-        } else if (strcmp(op, "move") == 0) {
+        } else if ((strcmp(op, "move") == 0)
+                   && (strstr(xpath,
+                              "/" XML_TAG_CIB "/" XML_CIB_TAG_CONFIGURATION
+                              "/" XML_CIB_TAG_RESOURCES) == NULL)) {
+            /* We still need to consider moves within the resources section,
+             * since they affect placement order.
+             */
             crm_trace("Ignoring move change at %s", xpath);
             continue;
         }
@@ -434,7 +440,7 @@ te_update_diff_v2(xmlNode *diff)
                 match = match->children;
             }
 
-        } else if (strcmp(op, "delete") != 0) {
+        } else if (!pcmk__str_any_of(op, "delete", "move", NULL)) {
             crm_warn("Ignoring malformed CIB update (%s operation on %s is unrecognized)",
                      op, xpath);
             continue;

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -458,13 +458,14 @@ te_update_diff_v2(xmlNode *diff)
             break; // Won't be packaged with operation results we may be waiting for
 
         } else if (strstr(xpath, "/" XML_CIB_TAG_TICKETS)
-                   || pcmk__str_eq(name, XML_CIB_TAG_TICKETS, pcmk__str_casei)) {
+                   || pcmk__str_eq(name, XML_CIB_TAG_TICKETS, pcmk__str_none)) {
             abort_transition(INFINITY, pcmk__graph_restart,
                              "Ticket attribute change", change);
             break; // Won't be packaged with operation results we may be waiting for
 
         } else if (strstr(xpath, "/" XML_TAG_TRANSIENT_NODEATTRS "[")
-                   || pcmk__str_eq(name, XML_TAG_TRANSIENT_NODEATTRS, pcmk__str_casei)) {
+                   || pcmk__str_eq(name, XML_TAG_TRANSIENT_NODEATTRS,
+                                   pcmk__str_none)) {
             abort_unless_down(xpath, op, change, "Transient attribute change");
             break; // Won't be packaged with operation results we may be waiting for
 

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -71,11 +71,16 @@
 #  define T_CIB_UPDATE_CONFIRM	"cib_update_confirmation"
 #  define T_CIB_REPLACE_NOTIFY	"cib_refresh_notify"
 
+/*!
+ * \internal
+ * \enum cib_change_section_info
+ * \brief Flags to indicate which sections of the CIB have changed
+ */
 enum cib_change_section_info {
-    cib_change_section_none     = 0x00000000,
-    cib_change_section_nodes    = 0x00000001,
-    cib_change_section_alerts   = 0x00000002,
-    cib_change_section_status   = 0x00000004
+    cib_change_section_none     = 0,        //!< No sections have changed
+    cib_change_section_nodes    = (1 << 0), //!< The nodes section has changed
+    cib_change_section_alerts   = (1 << 1), //!< The alerts section has changed
+    cib_change_section_status   = (1 << 2), //!< The status section has changed
 };
 
 


### PR DESCRIPTION
This fixes a regression introduced by 41d0a1af and set up by 45e5e82a. A reordering of the resources in the configuration section of the CIB no longer causes a transition abort.

However, the order of resources in the configuration affects their order of placement, and thus a configuration reordering can require resources to change nodes. In that case, the moves will not be initiated until the next natural transition (up to the value of cluster-recheck-interval).

Closes T549