### PR TITLE
Mid: fenced: Skipping devices that don't support the on action.(Fix:CLBZ#5495)

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -61,6 +61,8 @@ struct device_search_s {
     void (*callback) (GList * devices, void *user_data);
     /* devices capable of performing requested action (or off if remapping) */
     GList *capable;
+    /* Whether to perform searches that support the action */
+    uint32_t support_action_only;
 };
 
 static gboolean stonith_device_dispatch(gpointer user_data);
@@ -935,6 +937,8 @@ read_action_metadata(stonith_device_t *device)
             if (pcmk__xe_attr_is_true(match, "automatic") || pcmk__xe_attr_is_true(match, "required")) {
                 device->automatic_unfencing = TRUE;
             }
+            stonith__set_device_flags(device->flags, device->id,
+                                      st_device_supports_on);
         }
 
         if (action && pcmk__xe_attr_is_true(match, "on_target")) {
@@ -1987,8 +1991,13 @@ static void
 search_devices_record_result(struct device_search_s *search, const char *device, gboolean can_fence)
 {
     search->replies_received++;
-
     if (can_fence && device) {
+        if (search->support_action_only != st_device_supports_none) {
+            stonith_device_t *dev = g_hash_table_lookup(device_list, device);
+            if (dev && !pcmk_is_set(dev->flags, search->support_action_only)) {
+                return;
+            }
+        }
         search->capable = g_list_append(search->capable, strdup(device));
     }
 
@@ -2167,7 +2176,7 @@ search_devices(gpointer key, gpointer value, gpointer user_data)
 #define DEFAULT_QUERY_TIMEOUT 20
 static void
 get_capable_devices(const char *host, const char *action, int timeout, bool suicide, void *user_data,
-                    void (*callback) (GList * devices, void *user_data))
+                    void (*callback) (GList * devices, void *user_data), uint32_t support_action_only)
 {
     struct device_search_s *search;
     guint ndevices = g_hash_table_size(device_list);
@@ -2191,6 +2200,7 @@ get_capable_devices(const char *host, const char *action, int timeout, bool suic
     search->allow_suicide = suicide;
     search->callback = callback;
     search->user_data = user_data;
+    search->support_action_only = support_action_only;
 
     /* We are guaranteed this many replies, even if a device is
      * unregistered while the search is in progress.
@@ -2350,6 +2360,7 @@ stonith_query_capable_device_cb(GList * devices, void *user_data)
         crm_xml_add(dev, "namespace", device->namespace);
         crm_xml_add(dev, "agent", device->agent);
         crm_xml_add_int(dev, F_STONITH_DEVICE_VERIFIED, device->verified);
+        crm_xml_add_int(dev, F_STONITH_DEVICE_SUPPORT_FLAGS, device->flags);
 
         /* If the originating fencer wants to reboot the node, and we have a
          * capable device that doesn't support "reboot", remap to "off" instead.
@@ -2825,7 +2836,8 @@ fence_locally(xmlNode *msg, pcmk__action_result_t *result)
 
         /* If we get to here, then self-fencing is implicitly allowed */
         get_capable_devices(host, cmd->action, cmd->default_timeout,
-                            TRUE, cmd, stonith_fence_get_devices_cb);
+                            TRUE, cmd, stonith_fence_get_devices_cb, 
+                            pcmk__str_eq(cmd->action, "on", pcmk__str_casei)? st_device_supports_on: st_device_supports_none);
     }
 
     pcmk__set_result(result, CRM_EX_OK, PCMK_EXEC_PENDING, NULL);
@@ -3165,7 +3177,7 @@ handle_query_request(pcmk__request_t *request)
     crm_element_value_int(request->xml, F_STONITH_TIMEOUT, &timeout);
     get_capable_devices(target, action, timeout,
                         pcmk_is_set(query->call_options, st_opt_allow_suicide),
-                        query, stonith_query_capable_device_cb);
+                        query, stonith_query_capable_device_cb, st_device_supports_none);
     return NULL;
 }
 

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -18,11 +18,13 @@
 
 enum st_device_flags
 {
+    st_device_supports_none   = 0x0000,
     st_device_supports_list   = 0x0001,
     st_device_supports_status = 0x0002,
     st_device_supports_reboot = 0x0004,
     st_device_supports_parameter_plug = 0x0008,
     st_device_supports_parameter_port = 0x0010,
+    st_device_supports_on = 0x0020,
 };
 
 #define stonith__set_device_flags(device_flags, device_id, flags_to_set) do { \
@@ -132,6 +134,7 @@ void stonith__device_parameter_flags(uint32_t *device_flags,
 #  define F_STONITH_NOTIFY_ACTIVATE   "st_notify_activate"
 #  define F_STONITH_NOTIFY_DEACTIVATE "st_notify_deactivate"
 #  define F_STONITH_DELEGATE      "st_delegate"
+#  define F_STONITH_DEVICE_SUPPORT_FLAGS "st_device_support_flags"
 /*! The node initiating the stonith operation.  If an operation
  * is relayed, this is the last node the operation lands on. When
  * in standalone mode, origin is the client's id that originated the


### PR DESCRIPTION
Hi Ken,
Hi All,

This fix is a revision of the following PR.
 - https://github.com/ClusterLabs/pacemaker/pull/2805

* Added device_support_flag to Query response.
* Added constants for on action support and no support
* Added check for on action in find_peer_device() if topology exists.
* Added a check if on action in count_peer_devices() if there is no topology.
* Query search does not check the on action, but checks the on action when searching when there is no topology.
  * This is because when there is a topology, it is checked when all the devices in the topology are available as a trigger for fencing.

Best Regards,
Hideo Yamauchi.