### PR TITLE
Doc: Pacemaker Explained: Remove group ordered meta attribute

### DIFF
--- a/doc/sphinx/Pacemaker_Explained/advanced-resources.rst
+++ b/doc/sphinx/Pacemaker_Explained/advanced-resources.rst
@@ -98,23 +98,6 @@ Groups inherit the ``priority``, ``target-role``, and ``is-managed`` properties
 from primitive resources. See :ref:`resource_options` for information about
 those properties.
    
-.. table:: **Group-specific configuration options**
-   :class: longtable
-   :widths: 1 1 3
-
-   +-------------------+-----------------+-------------------------------------------------------+
-   | Meta-Attribute    | Default         | Description                                           |
-   +===================+=================+=======================================================+
-   | ordered           | true            |  .. index::                                           |
-   |                   |                 |     single: group; option, ordered                    |
-   |                   |                 |     single: option; ordered (group)                   |
-   |                   |                 |     single: ordered; group option                     |
-   |                   |                 |                                                       |
-   |                   |                 | If **true**, group members will be started in the     |
-   |                   |                 | order they are listed in the configuration (and       |
-   |                   |                 | stopped in the reverse order).                        |
-   +-------------------+-----------------+-------------------------------------------------------+
-
 Group Instance Attributes
 _________________________
 


### PR DESCRIPTION
Deprecated by 82010e5e