### PR TITLE
Fix: tools: crm_mon --daemonize should update when disconnected

### DIFF
--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -28,7 +28,7 @@ extern "C" {
  */
 
 
-#  define PCMK__API_VERSION "2.25"
+#  define PCMK__API_VERSION "2.26"
 
 #if defined(PCMK__WITH_ATTRIBUTE_OUTPUT_ARGS)
 #  define PCMK__OUTPUT_ARGS(ARGS...) __attribute__((output_args(ARGS)))

--- a/include/pcmki/pcmki_status.h
+++ b/include/pcmki/pcmki_status.h
@@ -40,6 +40,7 @@ int pcmk__output_simple_status(pcmk__output_t *out, pe_working_set_t *data_set);
 
 int pcmk__output_cluster_status(pcmk__output_t *out, stonith_t *stonith,
                                 cib_t *cib, xmlNode *current_cib,
+                                enum pcmk_pacemakerd_state pcmkd_state,
                                 enum pcmk__fence_history fence_history,
                                 uint32_t show, uint32_t show_opts,
                                 const char *only_node, const char *only_rsc,

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -771,7 +771,7 @@ done:
         cib__clean_up_connection(&cib_conn);
     }
 
-    if (*cib_object == NULL) {
+    if ((rc == pcmk_rc_ok) && (*cib_object == NULL)) {
         return pcmk_rc_no_input;
     }
     return rc;

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1655,13 +1655,16 @@ inject_rsc_action_xml(pcmk__output_t *out, va_list args)
         retcode = pcmk_rc_ok;       \
     }
 
-PCMK__OUTPUT_ARGS("cluster-status", "pe_working_set_t *", "crm_exit_t", "stonith_history_t *",
-                  "enum pcmk__fence_history", "uint32_t", "uint32_t", "const char *", "GList *",
-                  "GList *")
+PCMK__OUTPUT_ARGS("cluster-status", "pe_working_set_t *",
+                  "enum pcmk_pacemakerd_state", "crm_exit_t",
+                  "stonith_history_t *", "enum pcmk__fence_history", "uint32_t",
+                  "uint32_t", "const char *", "GList *", "GList *")
 int
 pcmk__cluster_status_text(pcmk__output_t *out, va_list args)
 {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    enum pcmk_pacemakerd_state pcmkd_state =
+        (enum pcmk_pacemakerd_state) va_arg(args, int);
     crm_exit_t history_rc = va_arg(args, crm_exit_t);
     stonith_history_t *stonith_history = va_arg(args, stonith_history_t *);
     enum pcmk__fence_history fence_history = va_arg(args, int);
@@ -1674,7 +1677,7 @@ pcmk__cluster_status_text(pcmk__output_t *out, va_list args)
     int rc = pcmk_rc_no_output;
     bool already_printed_failure = false;
 
-    CHECK_RC(rc, out->message(out, "cluster-summary", data_set,
+    CHECK_RC(rc, out->message(out, "cluster-summary", data_set, pcmkd_state,
                               section_opts, show_opts));
 
     if (pcmk_is_set(section_opts, pcmk_section_nodes) && unames) {
@@ -1778,13 +1781,16 @@ pcmk__cluster_status_text(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("cluster-status", "pe_working_set_t *", "crm_exit_t", "stonith_history_t *",
-                  "enum pcmk__fence_history", "uint32_t", "uint32_t", "const char *", "GList *",
-                  "GList *")
+PCMK__OUTPUT_ARGS("cluster-status", "pe_working_set_t *",
+                  "enum pcmk_pacemakerd_state", "crm_exit_t",
+                  "stonith_history_t *", "enum pcmk__fence_history", "uint32_t",
+                  "uint32_t", "const char *", "GList *", "GList *")
 static int
 cluster_status_xml(pcmk__output_t *out, va_list args)
 {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    enum pcmk_pacemakerd_state pcmkd_state =
+        (enum pcmk_pacemakerd_state) va_arg(args, int);
     crm_exit_t history_rc = va_arg(args, crm_exit_t);
     stonith_history_t *stonith_history = va_arg(args, stonith_history_t *);
     enum pcmk__fence_history fence_history = va_arg(args, int);
@@ -1794,7 +1800,8 @@ cluster_status_xml(pcmk__output_t *out, va_list args)
     GList *unames = va_arg(args, GList *);
     GList *resources = va_arg(args, GList *);
 
-    out->message(out, "cluster-summary", data_set, section_opts, show_opts);
+    out->message(out, "cluster-summary", data_set, pcmkd_state, section_opts,
+                 show_opts);
 
     /*** NODES ***/
     if (pcmk_is_set(section_opts, pcmk_section_nodes)) {
@@ -1854,13 +1861,16 @@ cluster_status_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("cluster-status", "pe_working_set_t *", "crm_exit_t", "stonith_history_t *",
-                  "enum pcmk__fence_history", "uint32_t", "uint32_t", "const char *", "GList *",
-                  "GList *")
+PCMK__OUTPUT_ARGS("cluster-status", "pe_working_set_t *",
+                  "enum pcmk_pacemakerd_state", "crm_exit_t",
+                  "stonith_history_t *", "enum pcmk__fence_history", "uint32_t",
+                  "uint32_t", "const char *", "GList *", "GList *")
 static int
 cluster_status_html(pcmk__output_t *out, va_list args)
 {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    enum pcmk_pacemakerd_state pcmkd_state =
+        (enum pcmk_pacemakerd_state) va_arg(args, int);
     crm_exit_t history_rc = va_arg(args, crm_exit_t);
     stonith_history_t *stonith_history = va_arg(args, stonith_history_t *);
     enum pcmk__fence_history fence_history = va_arg(args, int);
@@ -1871,7 +1881,8 @@ cluster_status_html(pcmk__output_t *out, va_list args)
     GList *resources = va_arg(args, GList *);
     bool already_printed_failure = false;
 
-    out->message(out, "cluster-summary", data_set, section_opts, show_opts);
+    out->message(out, "cluster-summary", data_set, pcmkd_state, section_opts,
+                 show_opts);
 
     /*** NODE LIST ***/
     if (pcmk_is_set(section_opts, pcmk_section_nodes) && unames) {

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -647,8 +647,8 @@ health_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
-                  "long long")
+PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *",
+                  "enum pcmk_pacemakerd_state", "const char *", "long long")
 static int
 pacemakerd_health(pcmk__output_t *out, va_list args)
 {
@@ -688,8 +688,8 @@ pacemakerd_health(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
-                  "long long")
+PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *",
+                  "enum pcmk_pacemakerd_state", "const char *", "long long")
 static int
 pacemakerd_health_html(pcmk__output_t *out, va_list args)
 {
@@ -731,8 +731,8 @@ pacemakerd_health_html(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
-                  "long long")
+PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *",
+                  "enum pcmk_pacemakerd_state", "const char *", "long long")
 static int
 pacemakerd_health_text(pcmk__output_t *out, va_list args)
 {
@@ -753,8 +753,8 @@ pacemakerd_health_text(pcmk__output_t *out, va_list args)
     }
 }
 
-PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
-                  "long long")
+PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *",
+                  "enum pcmk_pacemakerd_state", "const char *", "long long")
 static int
 pacemakerd_health_xml(pcmk__output_t *out, va_list args)
 {

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -775,7 +775,7 @@ pacemakerd_health_xml(pcmk__output_t *out, va_list args)
     }
 
     if (state_s == NULL) {
-        state_s = pcmk__pcmkd_state_enum2friendly(state);
+        state_s = pcmk_pacemakerd_api_daemon_state_enum2text(state);
     }
 
     if (last_updated != 0) {

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -148,8 +148,9 @@ print_cluster_status(pe_working_set_t *data_set, uint32_t show_opts,
 
     PCMK__OUTPUT_SPACER_IF(out, print_spacer);
     out->begin_list(out, NULL, NULL, "%s", title);
-    out->message(out, "cluster-status", data_set, stonith_rc, NULL, false,
-                 section_opts, show_opts, NULL, all, all);
+    out->message(out, "cluster-status",
+                 data_set, pcmk_pacemakerd_state_invalid, stonith_rc, NULL,
+                 false, section_opts, show_opts, NULL, all, all);
     out->end_list(out);
 
     g_list_free(all);

--- a/lib/pacemaker/pcmk_status.c
+++ b/lib/pacemaker/pcmk_status.c
@@ -48,6 +48,7 @@ fencing_connect(void)
  * \param[in,out] stonith              Fencer connection
  * \param[in,out] cib                  CIB connection
  * \param[in]     current_cib          Current CIB XML
+ * \param[in]     pcmkd_state          \p pacemakerd state
  * \param[in]     fence_history        How much of the fencing history to output
  * \param[in]     show                 Group of \p pcmk_section_e flags
  * \param[in]     show_opts            Group of \p pcmk_show_opt_e flags
@@ -68,7 +69,9 @@ fencing_connect(void)
  */
 int
 pcmk__output_cluster_status(pcmk__output_t *out, stonith_t *stonith, cib_t *cib,
-                            xmlNode *current_cib, enum pcmk__fence_history fence_history,
+                            xmlNode *current_cib,
+                            enum pcmk_pacemakerd_state pcmkd_state,
+                            enum pcmk__fence_history fence_history,
                             uint32_t show, uint32_t show_opts,
                             const char *only_node, const char *only_rsc,
                             const char *neg_location_prefix, bool simple_output)
@@ -122,7 +125,8 @@ pcmk__output_cluster_status(pcmk__output_t *out, stonith_t *stonith, cib_t *cib,
     if (simple_output) {
         rc = pcmk__output_simple_status(out, data_set);
     } else {
-        out->message(out, "cluster-status", data_set, pcmk_rc2exitc(history_rc),
+        out->message(out, "cluster-status",
+                     data_set, pcmkd_state, pcmk_rc2exitc(history_rc),
                      stonith_history, fence_history, show, show_opts,
                      neg_location_prefix, unames, resources);
     }
@@ -214,7 +218,7 @@ pcmk__status(pcmk__output_t *out, cib_t *cib,
     xmlNode *current_cib = NULL;
     int rc = pcmk_rc_ok;
     stonith_t *stonith = NULL;
-    enum pcmk_pacemakerd_state state = pcmk_pacemakerd_state_invalid;
+    enum pcmk_pacemakerd_state pcmkd_state = pcmk_pacemakerd_state_invalid;
     time_t last_updated = 0;
 
     if (cib == NULL) {
@@ -223,14 +227,14 @@ pcmk__status(pcmk__output_t *out, cib_t *cib,
 
     if (cib->variant == cib_native) {
         rc = pcmk__pacemakerd_status(out, crm_system_name, timeout_ms, false,
-                                     &state);
+                                     &pcmkd_state);
         if (rc != pcmk_rc_ok) {
             return rc;
         }
 
         last_updated = time(NULL);
 
-        switch (state) {
+        switch (pcmkd_state) {
             case pcmk_pacemakerd_state_running:
             case pcmk_pacemakerd_state_shutting_down:
             case pcmk_pacemakerd_state_remote:
@@ -241,7 +245,7 @@ pcmk__status(pcmk__output_t *out, cib_t *cib,
             default:
                 // Fencer and CIB are definitely unavailable
                 out->message(out, "pacemakerd-health",
-                             NULL, state, NULL, last_updated);
+                             NULL, pcmkd_state, NULL, last_updated);
                 return rc;
         }
 
@@ -252,18 +256,18 @@ pcmk__status(pcmk__output_t *out, cib_t *cib,
 
     rc = cib__signon_query(out, &cib, &current_cib);
     if (rc != pcmk_rc_ok) {
-        if (state != pcmk_pacemakerd_state_invalid) {
-            // If we got this far, invalid means we didn't query the pcmkd state
+        if (pcmkd_state != pcmk_pacemakerd_state_invalid) {
+            // Invalid at this point means we didn't query the pcmkd state
             out->message(out, "pacemakerd-health",
-                         NULL, state, NULL, last_updated);
+                         NULL, pcmkd_state, NULL, last_updated);
         }
         goto done;
     }
 
     rc = pcmk__output_cluster_status(out, stonith, cib, current_cib,
-                                     fence_history, show, show_opts, only_node,
-                                     only_rsc, neg_location_prefix,
-                                     simple_output);
+                                     pcmkd_state, fence_history, show,
+                                     show_opts, only_node, only_rsc,
+                                     neg_location_prefix, simple_output);
     if (rc != pcmk_rc_ok) {
         out->err(out, "Error outputting status info from the fencer or CIB");
     }

--- a/lib/pacemaker/pcmk_status.c
+++ b/lib/pacemaker/pcmk_status.c
@@ -215,6 +215,7 @@ pcmk__status(pcmk__output_t *out, cib_t *cib,
     int rc = pcmk_rc_ok;
     stonith_t *stonith = NULL;
     enum pcmk_pacemakerd_state state = pcmk_pacemakerd_state_invalid;
+    time_t last_updated = 0;
 
     if (cib == NULL) {
         return ENOTCONN;
@@ -227,6 +228,8 @@ pcmk__status(pcmk__output_t *out, cib_t *cib,
             return rc;
         }
 
+        last_updated = time(NULL);
+
         switch (state) {
             case pcmk_pacemakerd_state_running:
             case pcmk_pacemakerd_state_shutting_down:
@@ -238,7 +241,7 @@ pcmk__status(pcmk__output_t *out, cib_t *cib,
             default:
                 // Fencer and CIB are definitely unavailable
                 out->message(out, "pacemakerd-health",
-                             NULL, state, NULL, time(NULL));
+                             NULL, state, NULL, last_updated);
                 return rc;
         }
 
@@ -252,7 +255,7 @@ pcmk__status(pcmk__output_t *out, cib_t *cib,
         if (state != pcmk_pacemakerd_state_invalid) {
             // If we got this far, invalid means we didn't query the pcmkd state
             out->message(out, "pacemakerd-health",
-                         NULL, state, NULL, time(NULL));
+                         NULL, state, NULL, last_updated);
         }
         goto done;
     }

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -789,9 +789,6 @@ setup_cib_connection(void)
             out->err(out,
                      "Notification setup not supported, won't be "
                      "able to reconnect after failure");
-            if (output_format == mon_output_console) {
-                sleep(2);
-            }
             rc = pcmk_rc_ok;
         }
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1105,7 +1105,8 @@ detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_dat
         if (!config_mode)
             goto refresh;
 
-        blank_screen();
+        clear();
+        refresh();
 
         curses_formatted_printf(out, "%s", "Display option change mode\n");
         print_option_help(out, 'c', pcmk_is_set(show, pcmk_section_tickets));
@@ -1133,7 +1134,7 @@ refresh:
 
     return TRUE;
 }
-#endif
+#endif  // CURSES_ENABLED
 
 // Basically crm_signal_handler(SIGCHLD, SIG_IGN) plus the SA_NOCLDWAIT flag
 static void

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -136,7 +136,7 @@ static void crm_diff_update(const char *event, xmlNode * msg);
 static void clean_up_on_connection_failure(int rc);
 static int mon_refresh_display(gpointer user_data);
 static int setup_cib_connection(void);
-static int fencing_connect(void);
+static int setup_fencer_connection(void);
 static int setup_api_connections(void);
 static void mon_st_callback_event(stonith_t * st, stonith_event_t * e);
 static void mon_st_callback_display(stonith_t * st, stonith_event_t * e);
@@ -736,7 +736,7 @@ mon_winresize(int nsig)
 #endif
 
 static int
-fencing_connect(void)
+setup_fencer_connection(void)
 {
     int rc = pcmk_ok;
 
@@ -885,7 +885,7 @@ setup_api_connections(void)
                 return ENOTCONN;
         }
 
-        fencing_connect();
+        setup_fencer_connection();
     }
 
     rc = setup_cib_connection();
@@ -1909,8 +1909,8 @@ mon_refresh_display(gpointer user_data)
     return G_SOURCE_CONTINUE;
 }
 
-/* This function is called for fencing events (see fencing_connect for which ones) when
- * --watch-fencing is used on the command line.
+/* This function is called for fencing events (see setup_fencer_connection() for
+ * which ones) when --watch-fencing is used on the command line
  */
 static void
 mon_st_callback_event(stonith_t * st, stonith_event_t * e)
@@ -1960,7 +1960,7 @@ refresh_after_event(gboolean data_updated, gboolean enforce)
      * fatal give it a retry here
      * not getting here if cib-reconnection is already on the way
      */
-    fencing_connect();
+    setup_fencer_connection();
 
     if (enforce ||
         ((now - last_refresh) > (options.reconnect_ms / 1000)) ||
@@ -1974,8 +1974,8 @@ refresh_after_event(gboolean data_updated, gboolean enforce)
     }
 }
 
-/* This function is called for fencing events (see fencing_connect for which ones) when
- * --watch-fencing is NOT used on the command line.
+/* This function is called for fencing events (see setup_fencer_connection() for
+ * which ones) when --watch-fencing is NOT used on the command line
  */
 static void
 mon_st_callback_display(stonith_t * st, stonith_event_t * e)

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -55,8 +55,6 @@ typedef enum mon_output_format_e {
     mon_output_cgi
 } mon_output_format_t;
 
-void blank_screen(void);
-
 void crm_mon_register_messages(pcmk__output_t *out);
 
 #if CURSES_ENABLED

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -445,7 +445,8 @@ cluster_maint_mode_console(pcmk__output_t *out, va_list args) {
     }
 }
 
-PCMK__OUTPUT_ARGS("cluster-status", "pe_working_set_t *", "crm_exit_t",
+PCMK__OUTPUT_ARGS("cluster-status", "pe_working_set_t *",
+                  "enum pcmk_pacemakerd_state", "crm_exit_t",
                   "stonith_history_t *", "enum pcmk__fence_history", "uint32_t",
                   "uint32_t", "const char *", "GList *", "GList *")
 static int

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -452,7 +452,7 @@ static int
 cluster_status_console(pcmk__output_t *out, va_list args) {
     int rc = pcmk_rc_no_output;
 
-    blank_screen();
+    clear();
     rc = pcmk__cluster_status_text(out, args);
     refresh();
     return rc;
@@ -492,20 +492,5 @@ void
 crm_mon_register_messages(pcmk__output_t *out) {
 #if CURSES_ENABLED
     pcmk__register_messages(out, fmt_functions);
-#endif
-}
-
-void
-blank_screen(void)
-{
-#if CURSES_ENABLED
-    int lpc = 0;
-
-    for (lpc = 0; lpc < LINES; lpc++) {
-        move(lpc, 0);
-        clrtoeol();
-    }
-    move(0, 0);
-    refresh();
 #endif
 }

--- a/xml/api/crm_mon-2.26.rng
+++ b/xml/api/crm_mon-2.26.rng
@@ -7,36 +7,52 @@
     </start>
 
     <define name="element-crm-mon">
-        <optional>
-            <externalRef href="pacemakerd-health-2.25.rng" />
-        </optional>
-        <optional>
-            <ref name="element-summary" />
-        </optional>
-        <optional>
-            <ref name="nodes-list" />
-        </optional>
-        <optional>
-            <ref name="resources-list" />
-        </optional>
-        <optional>
-            <ref name="node-attributes-list" />
-        </optional>
-        <optional>
-            <externalRef href="node-history-2.12.rng"/>
-        </optional>
-        <optional>
-            <ref name="failures-list" />
-        </optional>
-        <optional>
-            <ref name="fence-event-list" />
-        </optional>
-        <optional>
-            <ref name="tickets-list" />
-        </optional>
-        <optional>
-            <ref name="bans-list" />
-        </optional>
+        <choice>
+            <ref name="element-crm-mon-disconnected" />
+            <group>
+                <optional>
+                    <externalRef href="pacemakerd-health-2.25.rng" />
+                </optional>
+                <optional>
+                    <ref name="element-summary" />
+                </optional>
+                <optional>
+                    <ref name="nodes-list" />
+                </optional>
+                <optional>
+                    <ref name="resources-list" />
+                </optional>
+                <optional>
+                    <ref name="node-attributes-list" />
+                </optional>
+                <optional>
+                    <externalRef href="node-history-2.12.rng"/>
+                </optional>
+                <optional>
+                    <ref name="failures-list" />
+                </optional>
+                <optional>
+                    <ref name="fence-event-list" />
+                </optional>
+                <optional>
+                    <ref name="tickets-list" />
+                </optional>
+                <optional>
+                    <ref name="bans-list" />
+                </optional>
+            </group>
+        </choice>
+    </define>
+
+    <define name="element-crm-mon-disconnected">
+        <element name="crm-mon-disconnected">
+            <optional>
+                <attribute name="description"> <text /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="pacemakerd-state"> <text /> </attribute>
+            </optional>
+        </element>
     </define>
 
     <define name="element-summary">
@@ -44,6 +60,11 @@
             <optional>
                 <element name="stack">
                     <attribute name="type"> <text /> </attribute>
+                    <optional>
+                        <attribute name="pacemakerd-state">
+                            <text />
+                        </attribute>
+                    </optional>
                 </element>
             </optional>
             <optional>

--- a/xml/api/crm_mon-2.26.rng
+++ b/xml/api/crm_mon-2.26.rng
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crm-mon"/>
+    </start>
+
+    <define name="element-crm-mon">
+        <optional>
+            <externalRef href="pacemakerd-health-2.25.rng" />
+        </optional>
+        <optional>
+            <ref name="element-summary" />
+        </optional>
+        <optional>
+            <ref name="nodes-list" />
+        </optional>
+        <optional>
+            <ref name="resources-list" />
+        </optional>
+        <optional>
+            <ref name="node-attributes-list" />
+        </optional>
+        <optional>
+            <externalRef href="node-history-2.12.rng"/>
+        </optional>
+        <optional>
+            <ref name="failures-list" />
+        </optional>
+        <optional>
+            <ref name="fence-event-list" />
+        </optional>
+        <optional>
+            <ref name="tickets-list" />
+        </optional>
+        <optional>
+            <ref name="bans-list" />
+        </optional>
+    </define>
+
+    <define name="element-summary">
+        <element name="summary">
+            <optional>
+                <element name="stack">
+                    <attribute name="type"> <text /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="current_dc">
+                    <attribute name="present"> <data type="boolean" /> </attribute>
+                    <optional>
+                        <group>
+                            <attribute name="version"> <text /> </attribute>
+                            <attribute name="name"> <text /> </attribute>
+                            <attribute name="id"> <text /> </attribute>
+                            <attribute name="with_quorum"> <data type="boolean" /> </attribute>
+                        </group>
+                    </optional>
+                    <optional>
+                        <attribute name="mixed_version"> <data type="boolean" /> </attribute>
+                    </optional>
+                </element>
+            </optional>
+            <optional>
+                <element name="last_update">
+                    <attribute name="time"> <text /> </attribute>
+                </element>
+                <element name="last_change">
+                    <attribute name="time"> <text /> </attribute>
+                    <attribute name="user"> <text /> </attribute>
+                    <attribute name="client"> <text /> </attribute>
+                    <attribute name="origin"> <text /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="nodes_configured">
+                    <attribute name="number"> <data type="nonNegativeInteger" /> </attribute>
+                </element>
+                <element name="resources_configured">
+                    <attribute name="number"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="disabled"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="blocked"> <data type="nonNegativeInteger" /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="cluster_options">
+                    <attribute name="stonith-enabled"> <data type="boolean" /> </attribute>
+                    <attribute name="symmetric-cluster"> <data type="boolean" /> </attribute>
+                    <attribute name="no-quorum-policy"> <text /> </attribute>
+                    <attribute name="maintenance-mode"> <data type="boolean" /> </attribute>
+                    <attribute name="stop-all-resources"> <data type="boolean" /> </attribute>
+                    <attribute name="stonith-timeout-ms"> <data type="integer" /> </attribute>
+                    <attribute name="priority-fencing-delay-ms"> <data type="integer" /> </attribute>
+                </element>
+            </optional>
+        </element>
+    </define>
+
+    <define name="resources-list">
+        <element name="resources">
+            <zeroOrMore>
+                <externalRef href="resources-2.24.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="nodes-list">
+        <element name="nodes">
+            <zeroOrMore>
+                <externalRef href="nodes-2.24.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="node-attributes-list">
+        <element name="node_attributes">
+            <zeroOrMore>
+                <externalRef href="node-attrs-2.8.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="failures-list">
+        <element name="failures">
+            <zeroOrMore>
+                <externalRef href="failure-2.8.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="fence-event-list">
+        <element name="fence_history">
+            <optional>
+                <attribute name="status"> <data type="integer" /> </attribute>
+            </optional>
+            <zeroOrMore>
+                <externalRef href="fence-event-2.15.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="tickets-list">
+        <element name="tickets">
+            <zeroOrMore>
+                <ref name="element-ticket" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="bans-list">
+        <element name="bans">
+            <zeroOrMore>
+                <ref name="element-ban" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="element-ticket">
+        <element name="ticket">
+            <attribute name="id"> <text /> </attribute>
+            <attribute name="status">
+                <choice>
+                    <value>granted</value>
+                    <value>revoked</value>
+                </choice>
+            </attribute>
+            <attribute name="standby"> <data type="boolean" /> </attribute>
+            <optional>
+                <attribute name="last-granted"> <text /> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="element-ban">
+        <element name="ban">
+            <attribute name="id"> <text /> </attribute>
+            <attribute name="resource"> <text /> </attribute>
+            <attribute name="node"> <text /> </attribute>
+            <attribute name="weight"> <data type="integer" /> </attribute>
+            <attribute name="promoted-only"> <data type="boolean" /> </attribute>
+            <!-- DEPRECATED: master_only is a duplicate of promoted-only that is
+                 provided solely for API backward compatibility. It will be
+                 removed in a future release. Check promoted-only instead.
+              -->
+            <attribute name="master_only"> <data type="boolean" /> </attribute>
+        </element>
+    </define>
+</grammar>


### PR DESCRIPTION
With `crm_mon --daemonize`, the output will continue to show the last known status after the cluster is stopped on the local node. It should go back to something like `"Cluster is not available"`.

Likewise, messages like `"Reconnecting..."` should not go to the daemonized output. The output file (or external handler) should receive only the cluster status. So we print those messages only if `output_format` is `mon_output_console` (or if we're in one-shot mode, where applicable). Normally those messages don't get printed to the daemonized output anyway because we don't flush the buffer, but theoretically they could get printed if the buffer fills up.

It's questionable whether we want to print `"Cluster is not available"` when we're in interactive mode or only in daemonized mode. For now, we'll do daemonized-only. Interactive (console) mode already gets the `"Connection to cluster daemons terminated"` message, which is quickly replaced by `"Reconnecting..."`.

External agents are notified via traps rather than via output, so we can ignore them.

Closes T15