### PR TITLE
controld: Calm down connect retries if pacemaker-fenced dies

### DIFF
--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -618,6 +618,16 @@ static gboolean
 te_connect_stonith(gpointer user_data)
 {
     int rc = pcmk_ok;
+    static time_t last_attempt = 0;
+    time_t now = time(NULL);
+
+    /* This callback can get called a LOT if, eg, pacemaker_fenced
+     * goes down, so be a bit more restrained trying to reconnect
+     */
+    if (user_data && now <= last_attempt) {
+        return TRUE;
+    }
+    last_attempt = now;
 
     if (stonith_api == NULL) {
         stonith_api = stonith_api_new();


### PR DESCRIPTION
The controller schedules mainloop fencer connection retries immediately, making it run a zillion times a second (if pacemaker-fenced is killed and respawns, for example).

Closes T449

Signed-Off-By: Christine Caulfield <ccaulfie@redhat.com>