### PR TITLE
Improve crm_mon output when guest node's container and remote resource are on different nodes

### DIFF
--- a/cts/cli/crm_mon-T180.xml
+++ b/cts/cli/crm_mon-T180.xml
@@ -1,0 +1,160 @@
+<cib crm_feature_set="3.0.14" validate-with="pacemaker-2.10" epoch="9" num_updates="17" admin_epoch="0" cib-last-written="Thu Dec  6 13:23:17 2018" update-origin="cent7-host1" update-client="crm_resource" update-user="root" have-quorum="1" dc-uuid="3232262829">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-have-watchdog" name="have-watchdog" value="false"/>
+        <nvpair id="cib-bootstrap-options-dc-version" name="dc-version" value="1.1.19-c3c624ea3d"/>
+        <nvpair id="cib-bootstrap-options-cluster-infrastructure" name="cluster-infrastructure" value="corosync"/>
+        <nvpair name="no-quorum-policy" value="ignore" id="cib-bootstrap-options-no-quorum-policy"/>
+        <nvpair name="stonith-enabled" value="false" id="cib-bootstrap-options-stonith-enabled"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="3232262828" uname="cent7-host1">
+        <instance_attributes id="nodes-3232262828">
+          <nvpair id="nodes-3232262828-standby" name="standby" value="off"/>
+        </instance_attributes>
+      </node>
+      <node id="3232262829" uname="cent7-host2"/>
+    </nodes>
+    <resources>
+      <group id="group1">
+        <primitive id="dummy1" class="ocf" provider="pacemaker" type="Dummy">
+          <operations>
+            <op name="start" interval="0s" timeout="60s" on-fail="restart" id="dummy-start-0s"/>
+            <op name="monitor" interval="10s" timeout="60s" on-fail="restart" id="dummy-monitor-10s"/>
+            <op name="stop" interval="0s" timeout="60s" on-fail="block" id="dummy-stop-0s"/>
+          </operations>
+        </primitive>
+      </group>
+      <group id="group2">
+        <primitive id="dummy2" class="ocf" provider="pacemaker" type="Dummy">
+          <operations>
+            <op name="start" interval="0s" timeout="60s" on-fail="restart" id="dummy2-start-0s"/>
+            <op name="monitor" interval="10s" timeout="60s" on-fail="restart" id="dummy2-monitor-10s"/>
+            <op name="stop" interval="0s" timeout="60s" on-fail="block" id="dummy2-stop-0s"/>
+          </operations>
+        </primitive>
+      </group>
+      <bundle id="httpd-bundle1">
+        <docker image="pcmktest:http" replicas="1" replicas-per-host="1" options="--log-driver=journald"/>
+        <network ip-range-start="192.168.20.188" host-interface="ens192" host-netmask="24">
+          <port-mapping id="httpd-port" port="80"/>
+        </network>
+        <storage>
+          <storage-mapping id="httpd-root1" source-dir-root="/var/local/containers" target-dir="/var/www/html" options="rw"/>
+          <storage-mapping id="httpd-logs1" source-dir-root="/var/log/pacemaker/bundles" target-dir="/etc/httpd/logs" options="rw"/>
+        </storage>
+        <primitive class="ocf" id="httpd1" provider="heartbeat" type="apache"/>
+      </bundle>
+      <bundle id="httpd-bundle2">
+        <docker image="pcmktest:http" replicas="1" replicas-per-host="1" options="--log-driver=journald"/>
+        <network ip-range-start="192.168.20.190" host-interface="ens192" host-netmask="24">
+          <port-mapping id="httpd-port2" port="80"/>
+        </network>
+        <storage>
+          <storage-mapping id="httpd-root2" source-dir-root="/var/local/containers" target-dir="/var/www/html" options="rw"/>
+          <storage-mapping id="httpd-logs2" source-dir-root="/var/log/pacemaker/bundles" target-dir="/etc/httpd/logs" options="rw"/>
+        </storage>
+        <primitive class="ocf" id="httpd2" provider="heartbeat" type="apache"/>
+      </bundle>
+    </resources>
+    <constraints/>
+    <rsc_defaults/>
+  </configuration>
+  <status>
+    <node_state id="3232262828" uname="cent7-host1" in_ccm="true" crmd="online" crm-debug-origin="do_update_resource" join="member" expected="member">
+      <lrm id="3232262828">
+        <lrm_resources>
+          <lrm_resource id="dummy1" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="dummy1_last_0" operation_key="dummy1_start_0" operation="start" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="11:7:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;11:7:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="40" rc-code="0" op-status="0" interval="0" last-run="1544070156" last-rc-change="1544070156" exec-time="24" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="dummy1_monitor_10000" operation_key="dummy1_monitor_10000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="12:7:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;12:7:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="41" rc-code="0" op-status="0" interval="10000" last-rc-change="1544070156" exec-time="20" queue-time="0" op-digest="873ed4f07792aa8ff18f3254244675ea" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="dummy2" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="dummy2_last_0" operation_key="dummy2_monitor_0" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="3:1:7:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:7;3:1:7:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="9" rc-code="7" op-status="0" interval="0" last-run="1544070006" last-rc-change="1544070006" exec-time="107" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle1-ip-192.168.20.188" type="IPaddr2" class="ocf" provider="heartbeat">
+            <lrm_rsc_op id="httpd-bundle1-ip-192.168.20.188_last_0" operation_key="httpd-bundle1-ip-192.168.20.188_start_0" operation="start" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="24:7:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;24:7:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="42" rc-code="0" op-status="0" interval="0" last-run="1544070170" last-rc-change="1544070170" exec-time="148" queue-time="1" op-digest="bed932c9e12e6a9f54826c22f0c0c741"/>
+            <lrm_rsc_op id="httpd-bundle1-ip-192.168.20.188_monitor_60000" operation_key="httpd-bundle1-ip-192.168.20.188_monitor_60000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="25:7:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;25:7:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="43" rc-code="0" op-status="0" interval="60000" last-rc-change="1544070170" exec-time="144" queue-time="0" op-digest="bfe7247114ffd09887005fb41035f1c7"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle1-docker-0" type="docker" class="ocf" provider="heartbeat">
+            <lrm_rsc_op id="httpd-bundle1-docker-0_last_0" operation_key="httpd-bundle1-docker-0_start_0" operation="start" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="26:11:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;26:11:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="48" rc-code="0" op-status="0" interval="0" last-run="1544070230" last-rc-change="1544070230" exec-time="983" queue-time="0" op-digest="c78f50451e7c5c013663cbf35f043d7b"/>
+            <lrm_rsc_op id="httpd-bundle1-docker-0_monitor_60000" operation_key="httpd-bundle1-docker-0_monitor_60000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="3:11:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;3:11:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="49" rc-code="0" op-status="0" interval="60000" last-rc-change="1544070231" exec-time="322" queue-time="0" op-digest="9f30b5a64540743a9e5bcd85abdc7c24"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle2-docker-0" type="docker" class="ocf" provider="heartbeat">
+            <lrm_rsc_op id="httpd-bundle2-docker-0_last_0" operation_key="httpd-bundle2-docker-0_monitor_0" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="8:1:7:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:7;8:1:7:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="25" rc-code="7" op-status="0" interval="0" last-run="1544070006" last-rc-change="1544070006" exec-time="88" queue-time="0" op-digest="18027dfd1c76ba580428a1095647d39d"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle2-ip-192.168.20.190" type="IPaddr2" class="ocf" provider="heartbeat">
+            <lrm_rsc_op id="httpd-bundle2-ip-192.168.20.190_last_0" operation_key="httpd-bundle2-ip-192.168.20.190_monitor_0" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="7:1:7:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:7;7:1:7:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="21" rc-code="7" op-status="0" interval="0" last-run="1544070006" last-rc-change="1544070006" exec-time="156" queue-time="0" op-digest="b15750595f38793008d791dfb905caf4"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle1-0" type="remote" class="ocf" provider="pacemaker" container="httpd-bundle1-docker-0">
+            <lrm_rsc_op id="httpd-bundle1-0_last_0" operation_key="httpd-bundle1-0_stop_0" operation="stop" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="27:11:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;27:11:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="10" rc-code="0" op-status="0" interval="0" last-run="1544070229" last-rc-change="1544070229" exec-time="0" queue-time="0" op-digest="a307ec40ef4478a192b587881f6932c1" op-force-restart=" server " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="httpd-bundle1-0_monitor_60000" operation_key="httpd-bundle1-0_monitor_60000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="28:8:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;28:8:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="9" rc-code="0" op-status="0" interval="60000" last-rc-change="1544070171" exec-time="0" queue-time="0" op-digest="b826e10b6e1fbc3900415f9940a1d315"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle2-0" type="remote" class="ocf" provider="pacemaker" container="httpd-bundle2-docker-0">
+            <lrm_rsc_op id="httpd-bundle2-0_last_0" operation_key="httpd-bundle2-0_monitor_0" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="9:1:7:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:7;9:1:7:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="2" rc-code="7" op-status="0" interval="0" last-run="1544070007" last-rc-change="1544070007" exec-time="0" queue-time="0" op-digest="e238d81edc240b99ad2c3a41afb4a69a" op-force-restart=" server " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state id="3232262829" uname="cent7-host2" in_ccm="true" crmd="online" crm-debug-origin="do_update_resource" join="member" expected="member">
+      <lrm id="3232262829">
+        <lrm_resources>
+          <lrm_resource id="dummy2" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="dummy2_last_0" operation_key="dummy2_start_0" operation="start" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="24:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;24:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="18" rc-code="0" op-status="0" interval="0" last-run="1544070005" last-rc-change="1544070005" exec-time="92" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="dummy2_monitor_10000" operation_key="dummy2_monitor_10000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="25:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;25:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="27" rc-code="0" op-status="0" interval="10000" last-rc-change="1544070005" exec-time="51" queue-time="0" op-digest="873ed4f07792aa8ff18f3254244675ea" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="dummy1" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="dummy1_last_0" operation_key="dummy1_stop_0" operation="stop" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="10:7:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;10:7:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="41" rc-code="0" op-status="0" interval="0" last-run="1544070155" last-rc-change="1544070155" exec-time="58" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="dummy1_monitor_10000" operation_key="dummy1_monitor_10000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="12:3:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;12:3:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="35" rc-code="0" op-status="0" interval="10000" last-rc-change="1544070076" exec-time="41" queue-time="0" op-digest="873ed4f07792aa8ff18f3254244675ea" op-secure-params=" passwd " op-secure-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle1-docker-0" type="docker" class="ocf" provider="heartbeat">
+            <lrm_rsc_op id="httpd-bundle1-docker-0_last_0" operation_key="httpd-bundle1-docker-0_stop_0" operation="stop" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="8:11:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;8:11:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="46" rc-code="0" op-status="0" interval="0" last-run="1544070229" last-rc-change="1544070229" exec-time="195" queue-time="1" op-digest="c78f50451e7c5c013663cbf35f043d7b"/>
+            <lrm_rsc_op id="httpd-bundle1-docker-0_monitor_60000" operation_key="httpd-bundle1-docker-0_monitor_60000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="28:3:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;28:3:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="39" rc-code="0" op-status="0" interval="60000" last-rc-change="1544070091" exec-time="237" queue-time="0" op-digest="9f30b5a64540743a9e5bcd85abdc7c24"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle1-ip-192.168.20.188" type="IPaddr2" class="ocf" provider="heartbeat">
+            <lrm_rsc_op id="httpd-bundle1-ip-192.168.20.188_last_0" operation_key="httpd-bundle1-ip-192.168.20.188_stop_0" operation="stop" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="23:7:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;23:7:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="45" rc-code="0" op-status="0" interval="0" last-run="1544070169" last-rc-change="1544070169" exec-time="115" queue-time="1" op-digest="bed932c9e12e6a9f54826c22f0c0c741"/>
+            <lrm_rsc_op id="httpd-bundle1-ip-192.168.20.188_monitor_60000" operation_key="httpd-bundle1-ip-192.168.20.188_monitor_60000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="25:3:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;25:3:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="37" rc-code="0" op-status="0" interval="60000" last-rc-change="1544070090" exec-time="136" queue-time="0" op-digest="bfe7247114ffd09887005fb41035f1c7"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle2-ip-192.168.20.190" type="IPaddr2" class="ocf" provider="heartbeat">
+            <lrm_rsc_op id="httpd-bundle2-ip-192.168.20.190_last_0" operation_key="httpd-bundle2-ip-192.168.20.190_start_0" operation="start" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="45:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;45:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="28" rc-code="0" op-status="0" interval="0" last-run="1544070005" last-rc-change="1544070005" exec-time="83" queue-time="0" op-digest="b15750595f38793008d791dfb905caf4"/>
+            <lrm_rsc_op id="httpd-bundle2-ip-192.168.20.190_monitor_60000" operation_key="httpd-bundle2-ip-192.168.20.190_monitor_60000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="46:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;46:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="29" rc-code="0" op-status="0" interval="60000" last-rc-change="1544070005" exec-time="66" queue-time="0" op-digest="d66b395d765aa54ef26f683efa1d0e11"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle2-docker-0" type="docker" class="ocf" provider="heartbeat">
+            <lrm_rsc_op id="httpd-bundle2-docker-0_last_0" operation_key="httpd-bundle2-docker-0_start_0" operation="start" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="47:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;47:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="30" rc-code="0" op-status="0" interval="0" last-run="1544070005" last-rc-change="1544070005" exec-time="916" queue-time="0" op-digest="18027dfd1c76ba580428a1095647d39d"/>
+            <lrm_rsc_op id="httpd-bundle2-docker-0_monitor_60000" operation_key="httpd-bundle2-docker-0_monitor_60000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="48:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;48:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="32" rc-code="0" op-status="0" interval="60000" last-rc-change="1544070006" exec-time="285" queue-time="0" op-digest="1fe1e584f801bf9c9b66ca380a2dad83"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle1-0" type="remote" class="ocf" provider="pacemaker" container="httpd-bundle1-docker-0">
+            <lrm_rsc_op id="httpd-bundle1-0_last_0" operation_key="httpd-bundle1-0_start_0" operation="start" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="28:11:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;28:11:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="6" rc-code="0" op-status="0" interval="0" last-run="1544070231" last-rc-change="1544070231" exec-time="0" queue-time="0" op-digest="a307ec40ef4478a192b587881f6932c1" op-force-restart=" server " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="httpd-bundle1-0_monitor_60000" operation_key="httpd-bundle1-0_monitor_60000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="28:12:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;28:12:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="7" rc-code="0" op-status="0" interval="60000" last-rc-change="1544070232" exec-time="0" queue-time="0" op-digest="b826e10b6e1fbc3900415f9940a1d315"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle2-0" type="remote" class="ocf" provider="pacemaker" container="httpd-bundle2-docker-0">
+            <lrm_rsc_op id="httpd-bundle2-0_last_0" operation_key="httpd-bundle2-0_start_0" operation="start" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="49:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;49:1:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="3" rc-code="0" op-status="0" interval="0" last-run="1544070006" last-rc-change="1544070006" exec-time="0" queue-time="0" op-digest="e238d81edc240b99ad2c3a41afb4a69a" op-force-restart=" server " op-restart-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="httpd-bundle2-0_monitor_60000" operation_key="httpd-bundle2-0_monitor_60000" operation="monitor" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="44:2:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;44:2:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="4" rc-code="0" op-status="0" interval="60000" last-rc-change="1544070007" exec-time="0" queue-time="0" op-digest="3043b179543a9a9b16c91fae06f3922d"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+      <transient_attributes id="3232262829">
+          <instance_attributes id="status-3232262829"/>
+      </transient_attributes>
+    </node_state>
+    <node_state remote_node="true" id="httpd-bundle1-0" uname="httpd-bundle1-0" in_ccm="true" crm-debug-origin="do_update_resource" node_fenced="0">
+      <lrm id="httpd-bundle1-0">
+        <lrm_resources>
+          <lrm_resource id="httpd1" type="apache" class="ocf" provider="heartbeat">
+            <lrm_rsc_op id="httpd1_last_0" operation_key="httpd1_start_0" operation="start" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="33:12:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;33:12:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host1" call-id="8" rc-code="0" op-status="0" interval="0" last-run="1544070233" last-rc-change="1544070233" exec-time="1116" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state remote_node="true" id="httpd-bundle2-0" uname="httpd-bundle2-0" in_ccm="true" crm-debug-origin="do_update_resource" node_fenced="0">
+      <lrm id="httpd-bundle2-0">
+        <lrm_resources>
+          <lrm_resource id="httpd2" type="apache" class="ocf" provider="heartbeat">
+            <lrm_rsc_op id="httpd2_last_0" operation_key="httpd2_start_0" operation="start" crm-debug-origin="do_update_resource" crm_feature_set="3.0.14" transition-key="49:2:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" transition-magic="0:0;49:2:0:173a0661-aaa2-4c3d-a9a3-2e9342720d2d" exit-reason="" on_node="cent7-host2" call-id="8" rc-code="0" op-status="0" interval="0" last-run="1544070008" last-rc-change="1544070008" exec-time="1022" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+  </status>
+</cib>

--- a/cts/cli/regression.crm_mon.exp
+++ b/cts/cli/regression.crm_mon.exp
@@ -9,7 +9,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * Clone Set: ping-clone [ping]:
@@ -488,7 +488,7 @@ Active Resources:
 =#=#=#= Begin test: Text output with only the node section =#=#=#=
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 =#=#=#= End test: Text output with only the node section - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output with only the node section
 =#=#=#= Begin test: Complete text output =#=#=#=
@@ -502,7 +502,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * Clone Set: ping-clone [ping]:
@@ -582,10 +582,10 @@ Operations:
     * httpd-bundle-0: migration-threshold=1000000:
       * (2) start
       * (3) monitor: interval="30000ms"
-  * Node: httpd-bundle-0@cluster01:
+  * Node: httpd-bundle-0:
     * httpd: migration-threshold=1000000:
       * (1) start
-  * Node: httpd-bundle-1@cluster02:
+  * Node: httpd-bundle-1:
     * httpd: migration-threshold=1000000:
       * (1) start
 
@@ -728,7 +728,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * 1	(ocf:pacemaker:Dummy):	Active cluster02
@@ -808,10 +808,10 @@ Operations:
     * httpd-bundle-0: migration-threshold=1000000:
       * (2) start
       * (3) monitor: interval="30000ms"
-  * Node: httpd-bundle-0@cluster01:
+  * Node: httpd-bundle-0:
     * httpd: migration-threshold=1000000:
       * (1) start
-  * Node: httpd-bundle-1@cluster02:
+  * Node: httpd-bundle-1:
     * httpd: migration-threshold=1000000:
       * (1) start
 
@@ -847,13 +847,13 @@ Node List:
       * promotable-rsc	(ocf:pacemaker:Stateful):	 Promoted
       * httpd-bundle-ip-192.168.122.132	(ocf:heartbeat:IPaddr2):	 Started
       * httpd-bundle-docker-1	(ocf:heartbeat:docker):	 Started
-  * GuestNode httpd-bundle-0@cluster01: online:
+  * GuestNode httpd-bundle-0: online:
     * Resources:
       * httpd	(ocf:heartbeat:apache):	 Started
-  * GuestNode httpd-bundle-1@cluster02: online:
+  * GuestNode httpd-bundle-1: online:
     * Resources:
       * httpd	(ocf:heartbeat:apache):	 Started
-  * GuestNode httpd-bundle-2@: OFFLINE:
+  * GuestNode httpd-bundle-2: OFFLINE:
     * Resources:
 
 Node Attributes:
@@ -916,10 +916,10 @@ Operations:
     * httpd-bundle-0: migration-threshold=1000000:
       * (2) start
       * (3) monitor: interval="30000ms"
-  * Node: httpd-bundle-0@cluster01:
+  * Node: httpd-bundle-0:
     * httpd: migration-threshold=1000000:
       * (1) start
-  * Node: httpd-bundle-1@cluster02:
+  * Node: httpd-bundle-1:
     * httpd: migration-threshold=1000000:
       * (1) start
 
@@ -957,10 +957,10 @@ Node List:
       * 1	(ocf:pacemaker:Stateful):	Active 
       * 1	(ocf:pacemaker:ping):	Active 
       * 1	(ocf:pacemaker:remote):	Active 
-  * GuestNode httpd-bundle-0@cluster01: online:
+  * GuestNode httpd-bundle-0: online:
     * Resources:
       * 1	(ocf:heartbeat:apache):	Active 
-  * GuestNode httpd-bundle-1@cluster02: online:
+  * GuestNode httpd-bundle-1: online:
     * Resources:
       * 1	(ocf:heartbeat:apache):	Active 
 
@@ -1024,10 +1024,10 @@ Operations:
     * httpd-bundle-0: migration-threshold=1000000:
       * (2) start
       * (3) monitor: interval="30000ms"
-  * Node: httpd-bundle-0@cluster01:
+  * Node: httpd-bundle-0:
     * httpd: migration-threshold=1000000:
       * (1) start
-  * Node: httpd-bundle-1@cluster02:
+  * Node: httpd-bundle-1:
     * httpd: migration-threshold=1000000:
       * (1) start
 
@@ -1687,7 +1687,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * Fencing	(stonith:fence_xvm):	 Started cluster01
@@ -1803,7 +1803,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Full List of Resources:
   * Clone Set: ping-clone [ping]:
@@ -1873,7 +1873,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * Fencing	(stonith:fence_xvm):	 Started cluster01
@@ -1947,7 +1947,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * Resource Group: exim-group:
@@ -2031,7 +2031,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * Resource Group: exim-group:
@@ -2106,7 +2106,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * Clone Set: ping-clone [ping]:
@@ -2196,7 +2196,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * Clone Set: ping-clone [ping]:
@@ -2376,7 +2376,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * No active resources
@@ -2426,7 +2426,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Full List of Resources:
   * Clone Set: inactive-clone [inactive-dhcpd] (disabled):
@@ -2447,7 +2447,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Full List of Resources:
   * Container bundle set: httpd-bundle [pcmk:http]:
@@ -2576,7 +2576,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Full List of Resources:
   * Container bundle set: httpd-bundle [pcmk:http]:
@@ -2675,7 +2675,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Full List of Resources:
   * Container bundle set: httpd-bundle [pcmk:http]:
@@ -2772,7 +2772,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Full List of Resources:
   * Container bundle set: httpd-bundle [pcmk:http]:
@@ -2871,7 +2871,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Full List of Resources:
   * Container bundle set: httpd-bundle [pcmk:http]:
@@ -3822,7 +3822,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster02 httpd-bundle-1@cluster01 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * Resource Group: partially-active-group (2 members inactive):
@@ -3843,7 +3843,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster02 httpd-bundle-1@cluster01 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Full List of Resources:
   * Resource Group: partially-active-group:
@@ -3866,7 +3866,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster02 httpd-bundle-1@cluster01 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * Resource Group: partially-active-group (2 members inactive):
@@ -4213,8 +4213,8 @@ Cluster Summary:
   The cluster will not attempt to start, stop or recover services
 
 Node List:
-  * GuestNode httpd-bundle-0@cluster01: maintenance
-  * GuestNode httpd-bundle-1@cluster02: maintenance
+  * GuestNode httpd-bundle-0: maintenance
+  * GuestNode httpd-bundle-1: maintenance
   * Online: [ cluster01 cluster02 ]
 
 Full List of Resources:
@@ -4256,7 +4256,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cent7-host1 cent7-host2 ]
-  * GuestOnline: [ httpd-bundle1-0@cent7-host1 httpd-bundle2-0@cent7-host2 ]
+  * GuestOnline: [ httpd-bundle1-0 httpd-bundle2-0 ]
 
 Active Resources:
   * Resource Group: group1:

--- a/cts/cli/regression.crm_mon.exp
+++ b/cts/cli/regression.crm_mon.exp
@@ -4256,7 +4256,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cent7-host1 cent7-host2 ]
-  * GuestOnline: [ httpd-bundle1-0@cent7-host2 httpd-bundle2-0@cent7-host2 ]
+  * GuestOnline: [ httpd-bundle1-0@cent7-host1 httpd-bundle2-0@cent7-host2 ]
 
 Active Resources:
   * Resource Group: group1:
@@ -4281,7 +4281,7 @@ Cluster Summary:
 Node List:
   * Node cent7-host1 (3232262828): online, feature set <3.15.1
   * Node cent7-host2 (3232262829): online, feature set <3.15.1
-  * GuestNode httpd-bundle1-0@cent7-host2: online
+  * GuestNode httpd-bundle1-0@cent7-host1: online
   * GuestNode httpd-bundle2-0@cent7-host2: online
 
 Active Resources:

--- a/cts/cli/regression.crm_mon.exp
+++ b/cts/cli/regression.crm_mon.exp
@@ -4245,3 +4245,59 @@ Full List of Resources:
     * promotable-rsc	(ocf:pacemaker:Stateful):	 Unpromoted cluster01 (unmanaged)
 =#=#=#= End test: Text output of all resources with maintenance-mode enabled - OK (0) =#=#=#=
 * Passed: crm_mon        - Text output of all resources with maintenance-mode enabled
+=#=#=#= Begin test: Text output of guest node's container on different node from its remote resource =#=#=#=
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: cent7-host2 (version) - partition with quorum
+  * Last updated:
+  * Last change:
+  * 4 nodes configured
+  * 10 resource instances configured
+
+Node List:
+  * Online: [ cent7-host1 cent7-host2 ]
+  * GuestOnline: [ httpd-bundle1-0@cent7-host2 httpd-bundle2-0@cent7-host2 ]
+
+Active Resources:
+  * Resource Group: group1:
+    * dummy1	(ocf:pacemaker:Dummy):	 Started cent7-host1
+  * Resource Group: group2:
+    * dummy2	(ocf:pacemaker:Dummy):	 Started cent7-host2
+  * Container bundle: httpd-bundle1 [pcmktest:http]:
+    * httpd-bundle1-0 (192.168.20.188)	(ocf:heartbeat:apache):	 Started cent7-host1
+  * Container bundle: httpd-bundle2 [pcmktest:http]:
+    * httpd-bundle2-0 (192.168.20.190)	(ocf:heartbeat:apache):	 Started cent7-host2
+=#=#=#= End test: Text output of guest node's container on different node from its remote resource - OK (0) =#=#=#=
+* Passed: crm_mon        - Text output of guest node's container on different node from its remote resource
+=#=#=#= Begin test: Complete text output of guest node's container on different node from its remote resource =#=#=#=
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: cent7-host2 (3232262829) (version) - partition with quorum
+  * Last updated:
+  * Last change:
+  * 4 nodes configured
+  * 10 resource instances configured
+
+Node List:
+  * Node cent7-host1 (3232262828): online, feature set <3.15.1
+  * Node cent7-host2 (3232262829): online, feature set <3.15.1
+  * GuestNode httpd-bundle1-0@cent7-host2: online
+  * GuestNode httpd-bundle2-0@cent7-host2: online
+
+Active Resources:
+  * Resource Group: group1:
+    * dummy1	(ocf:pacemaker:Dummy):	 Started cent7-host1
+  * Resource Group: group2:
+    * dummy2	(ocf:pacemaker:Dummy):	 Started cent7-host2
+  * Container bundle: httpd-bundle1 [pcmktest:http]:
+      * httpd-bundle1-ip-192.168.20.188	(ocf:heartbeat:IPaddr2):	 Started cent7-host1
+      * httpd1	(ocf:heartbeat:apache):	 Started httpd-bundle1-0
+      * httpd-bundle1-docker-0	(ocf:heartbeat:docker):	 Started cent7-host1
+      * httpd-bundle1-0	(ocf:pacemaker:remote):	 Started cent7-host2
+  * Container bundle: httpd-bundle2 [pcmktest:http]:
+      * httpd-bundle2-ip-192.168.20.190	(ocf:heartbeat:IPaddr2):	 Started cent7-host2
+      * httpd2	(ocf:heartbeat:apache):	 Started httpd-bundle2-0
+      * httpd-bundle2-docker-0	(ocf:heartbeat:docker):	 Started cent7-host2
+      * httpd-bundle2-0	(ocf:pacemaker:remote):	 Started cent7-host2
+=#=#=#= End test: Complete text output of guest node's container on different node from its remote resource - OK (0) =#=#=#=
+* Passed: crm_mon        - Complete text output of guest node's container on different node from its remote resource

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -4943,7 +4943,7 @@ export overcloud-rabbit-2=overcloud-rabbit-2
 4 of 32 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
 [ cluster01 cluster02 ]
-[ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+[ httpd-bundle-0 httpd-bundle-1 ]
 
 Started: [ cluster01 cluster02 ]
 Fencing	(stonith:fence_xvm):	 Started cluster01
@@ -5002,7 +5002,7 @@ Start      httpd:2            ( httpd-bundle-2 )  due to unrunnable httpd-bundle
 Current cluster status:
   * Node List:
     * Online: [ cluster01 cluster02 ]
-    * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+    * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
   * Full List of Resources:
     * Clone Set: ping-clone [ping]:
@@ -5054,7 +5054,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ cluster01 cluster02 ]
-    * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+    * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
   * Full List of Resources:
     * Clone Set: ping-clone [ping]:
@@ -5086,7 +5086,7 @@ Revised Cluster Status:
 Current cluster status:
   * Node List:
     * Online: [ cluster01 cluster02 ]
-    * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+    * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
   * Full List of Resources:
     * Clone Set: ping-clone [ping]:
@@ -5140,7 +5140,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ cluster02 ]
     * OFFLINE: [ cluster01 ]
-    * GuestOnline: [ httpd-bundle-1@cluster02 ]
+    * GuestOnline: [ httpd-bundle-1 ]
 
   * Full List of Resources:
     * Clone Set: ping-clone [ping]:
@@ -5174,7 +5174,7 @@ Revised Cluster Status:
 Current cluster status:
   * Node List:
     * Online: [ cluster01 cluster02 ]
-    * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+    * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
   * Full List of Resources:
     * Clone Set: ping-clone [ping]:
@@ -5261,7 +5261,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ cluster01 ]
     * OFFLINE: [ cluster02 ]
-    * GuestOnline: [ httpd-bundle-0@cluster01 ]
+    * GuestOnline: [ httpd-bundle-0 ]
 
   * Full List of Resources:
     * Clone Set: ping-clone [ping]:
@@ -5462,7 +5462,7 @@ Cluster Summary:
 
 Node List:
   * Online: [ cluster01 cluster02 ]
-  * GuestOnline: [ httpd-bundle-0@cluster01 httpd-bundle-1@cluster02 ]
+  * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
 Active Resources:
   * Clone Set: ping-clone [ping]:

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -548,6 +548,20 @@ function test_crm_mon() {
 
     rm -r "$CIB_file"
     unset CIB_file
+
+    export CIB_file="$test_home/cli/crm_mon-T180.xml"
+
+    desc="Text output of guest node's container on different node from its"
+    desc="$desc remote resource"
+    cmd="crm_mon -1"
+    test_assert $CRM_EX_OK 0
+
+    desc="Complete text output of guest node's container on different node from"
+    desc="$desc its remote resource"
+    cmd="crm_mon -1 --show-detail"
+    test_assert $CRM_EX_OK 0
+
+    unset CIB_file
 }
 
 function test_error_codes() {

--- a/cts/scheduler/summary/bug-cl-5247.summary
+++ b/cts/scheduler/summary/bug-cl-5247.summary
@@ -2,7 +2,7 @@ Using the original execution date of: 2015-08-12 02:53:40Z
 Current cluster status:
   * Node List:
     * Online: [ bl460g8n3 bl460g8n4 ]
-    * GuestOnline: [ pgsr01@bl460g8n3 ]
+    * GuestOnline: [ pgsr01 ]
 
   * Full List of Resources:
     * prmDB1	(ocf:heartbeat:VirtualDomain):	 Started bl460g8n3
@@ -70,7 +70,7 @@ Using the original execution date of: 2015-08-12 02:53:40Z
 Revised Cluster Status:
   * Node List:
     * Online: [ bl460g8n3 bl460g8n4 ]
-    * GuestOnline: [ pgsr01@bl460g8n3 ]
+    * GuestOnline: [ pgsr01 ]
 
   * Full List of Resources:
     * prmDB1	(ocf:heartbeat:VirtualDomain):	 Started bl460g8n3

--- a/cts/scheduler/summary/bug-rh-1097457.summary
+++ b/cts/scheduler/summary/bug-rh-1097457.summary
@@ -3,7 +3,7 @@
 Current cluster status:
   * Node List:
     * Online: [ lama2 lama3 ]
-    * GuestOnline: [ lamaVM1@lama2 lamaVM2@lama3 lamaVM3@lama3 ]
+    * GuestOnline: [ lamaVM1 lamaVM2 lamaVM3 ]
 
   * Full List of Resources:
     * restofencelama2	(stonith:fence_ipmilan):	 Started lama3
@@ -95,7 +95,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ lama2 lama3 ]
-    * GuestOnline: [ lamaVM1@lama2 lamaVM2@lama3 lamaVM3@lama3 ]
+    * GuestOnline: [ lamaVM1 lamaVM2 lamaVM3 ]
 
   * Full List of Resources:
     * restofencelama2	(stonith:fence_ipmilan):	 Started lama3

--- a/cts/scheduler/summary/bundle-connection-with-container.summary
+++ b/cts/scheduler/summary/bundle-connection-with-container.summary
@@ -4,7 +4,7 @@ Current cluster status:
     * Online: [ rhel8-1 rhel8-3 rhel8-4 rhel8-5 ]
     * OFFLINE: [ rhel8-2 ]
     * RemoteOnline: [ remote-rhel8-2 ]
-    * GuestOnline: [ httpd-bundle-1@rhel8-3 httpd-bundle-2@rhel8-1 ]
+    * GuestOnline: [ httpd-bundle-1 httpd-bundle-2 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel8-3
@@ -49,7 +49,7 @@ Revised Cluster Status:
     * Online: [ rhel8-1 rhel8-3 rhel8-4 rhel8-5 ]
     * OFFLINE: [ rhel8-2 ]
     * RemoteOnline: [ remote-rhel8-2 ]
-    * GuestOnline: [ httpd-bundle-0@rhel8-1 httpd-bundle-1@rhel8-3 httpd-bundle-2@rhel8-1 ]
+    * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 httpd-bundle-2 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel8-3

--- a/cts/scheduler/summary/bundle-nested-colocation.summary
+++ b/cts/scheduler/summary/bundle-nested-colocation.summary
@@ -90,7 +90,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ overcloud-controller-0 overcloud-controller-1 overcloud-controller-2 overcloud-galera-0 overcloud-galera-1 overcloud-galera-2 ]
     * RemoteOnline: [ overcloud-rabbit-0 overcloud-rabbit-1 overcloud-rabbit-2 ]
-    * GuestOnline: [ rabbitmq-bundle-0@overcloud-controller-0 rabbitmq-bundle-1@overcloud-controller-1 rabbitmq-bundle-2@overcloud-controller-2 ]
+    * GuestOnline: [ rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 ]
 
   * Full List of Resources:
     * overcloud-rabbit-0	(ocf:pacemaker:remote):	 Started overcloud-controller-0

--- a/cts/scheduler/summary/bundle-order-fencing.summary
+++ b/cts/scheduler/summary/bundle-order-fencing.summary
@@ -3,7 +3,7 @@ Current cluster status:
   * Node List:
     * Node controller-0: UNCLEAN (offline)
     * Online: [ controller-1 controller-2 ]
-    * GuestOnline: [ galera-bundle-1@controller-1 galera-bundle-2@controller-2 rabbitmq-bundle-1@controller-1 rabbitmq-bundle-2@controller-2 redis-bundle-1@controller-1 redis-bundle-2@controller-2 ]
+    * GuestOnline: [ galera-bundle-1 galera-bundle-2 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * Container bundle set: rabbitmq-bundle [192.168.24.1:8787/rhosp12/openstack-rabbitmq-docker:pcmklatest]:
@@ -189,7 +189,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ controller-1 controller-2 ]
     * OFFLINE: [ controller-0 ]
-    * GuestOnline: [ galera-bundle-1@controller-1 galera-bundle-2@controller-2 rabbitmq-bundle-1@controller-1 rabbitmq-bundle-2@controller-2 redis-bundle-1@controller-1 redis-bundle-2@controller-2 ]
+    * GuestOnline: [ galera-bundle-1 galera-bundle-2 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * Container bundle set: rabbitmq-bundle [192.168.24.1:8787/rhosp12/openstack-rabbitmq-docker:pcmklatest]:

--- a/cts/scheduler/summary/bundle-order-partial-start-2.summary
+++ b/cts/scheduler/summary/bundle-order-partial-start-2.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ undercloud ]
-    * GuestOnline: [ galera-bundle-0@undercloud rabbitmq-bundle-0@undercloud redis-bundle-0@undercloud ]
+    * GuestOnline: [ galera-bundle-0 rabbitmq-bundle-0 redis-bundle-0 ]
 
   * Full List of Resources:
     * Container bundle: rabbitmq-bundle [192.168.24.1:8787/tripleoupstream/centos-binary-rabbitmq:latest]:
@@ -79,7 +79,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ undercloud ]
-    * GuestOnline: [ galera-bundle-0@undercloud rabbitmq-bundle-0@undercloud redis-bundle-0@undercloud ]
+    * GuestOnline: [ galera-bundle-0 rabbitmq-bundle-0 redis-bundle-0 ]
 
   * Full List of Resources:
     * Container bundle: rabbitmq-bundle [192.168.24.1:8787/tripleoupstream/centos-binary-rabbitmq:latest]:

--- a/cts/scheduler/summary/bundle-order-partial-start.summary
+++ b/cts/scheduler/summary/bundle-order-partial-start.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ undercloud ]
-    * GuestOnline: [ rabbitmq-bundle-0@undercloud redis-bundle-0@undercloud ]
+    * GuestOnline: [ rabbitmq-bundle-0 redis-bundle-0 ]
 
   * Full List of Resources:
     * Container bundle: rabbitmq-bundle [192.168.24.1:8787/tripleoupstream/centos-binary-rabbitmq:latest]:
@@ -76,7 +76,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ undercloud ]
-    * GuestOnline: [ galera-bundle-0@undercloud rabbitmq-bundle-0@undercloud redis-bundle-0@undercloud ]
+    * GuestOnline: [ galera-bundle-0 rabbitmq-bundle-0 redis-bundle-0 ]
 
   * Full List of Resources:
     * Container bundle: rabbitmq-bundle [192.168.24.1:8787/tripleoupstream/centos-binary-rabbitmq:latest]:

--- a/cts/scheduler/summary/bundle-order-partial-stop.summary
+++ b/cts/scheduler/summary/bundle-order-partial-stop.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ undercloud ]
-    * GuestOnline: [ galera-bundle-0@undercloud rabbitmq-bundle-0@undercloud redis-bundle-0@undercloud ]
+    * GuestOnline: [ galera-bundle-0 rabbitmq-bundle-0 redis-bundle-0 ]
 
   * Full List of Resources:
     * Container bundle: rabbitmq-bundle [192.168.24.1:8787/tripleoupstream/centos-binary-rabbitmq:latest]:

--- a/cts/scheduler/summary/bundle-order-startup-clone-2.summary
+++ b/cts/scheduler/summary/bundle-order-startup-clone-2.summary
@@ -193,7 +193,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ metal-1 metal-2 metal-3 ]
     * RemoteOFFLINE: [ rabbitmq-bundle-0 ]
-    * GuestOnline: [ galera-bundle-0@metal-1 galera-bundle-1@metal-2 galera-bundle-2@metal-3 redis-bundle-0@metal-1 redis-bundle-1@metal-2 redis-bundle-2@metal-3 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * Clone Set: storage-clone [storage]:

--- a/cts/scheduler/summary/bundle-order-startup-clone.summary
+++ b/cts/scheduler/summary/bundle-order-startup-clone.summary
@@ -66,7 +66,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ metal-1 metal-2 metal-3 ]
     * RemoteOFFLINE: [ rabbitmq-bundle-0 ]
-    * GuestOnline: [ redis-bundle-0@metal-2 ]
+    * GuestOnline: [ redis-bundle-0 ]
 
   * Full List of Resources:
     * Clone Set: storage-clone [storage]:

--- a/cts/scheduler/summary/bundle-order-startup.summary
+++ b/cts/scheduler/summary/bundle-order-startup.summary
@@ -120,7 +120,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ undercloud ]
-    * GuestOnline: [ galera-bundle-0@undercloud rabbitmq-bundle-0@undercloud redis-bundle-0@undercloud ]
+    * GuestOnline: [ galera-bundle-0 rabbitmq-bundle-0 redis-bundle-0 ]
 
   * Full List of Resources:
     * Container bundle: rabbitmq-bundle [192.168.24.1:8787/tripleoupstream/centos-binary-rabbitmq:latest]:

--- a/cts/scheduler/summary/bundle-order-stop-clone.summary
+++ b/cts/scheduler/summary/bundle-order-stop-clone.summary
@@ -2,7 +2,7 @@ Current cluster status:
   * Node List:
     * Online: [ metal-1 metal-2 metal-3 ]
     * RemoteOFFLINE: [ rabbitmq-bundle-0 ]
-    * GuestOnline: [ galera-bundle-0@metal-1 galera-bundle-1@metal-2 galera-bundle-2@metal-3 redis-bundle-0@metal-1 redis-bundle-1@metal-2 redis-bundle-2@metal-3 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * Clone Set: storage-clone [storage]:
@@ -68,7 +68,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ metal-1 metal-2 metal-3 ]
     * RemoteOFFLINE: [ rabbitmq-bundle-0 ]
-    * GuestOnline: [ galera-bundle-1@metal-2 galera-bundle-2@metal-3 redis-bundle-0@metal-1 redis-bundle-1@metal-2 redis-bundle-2@metal-3 ]
+    * GuestOnline: [ galera-bundle-1 galera-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * Clone Set: storage-clone [storage]:

--- a/cts/scheduler/summary/bundle-order-stop-on-remote.summary
+++ b/cts/scheduler/summary/bundle-order-stop-on-remote.summary
@@ -4,7 +4,7 @@ Current cluster status:
     * RemoteNode database-2: UNCLEAN (offline)
     * Online: [ controller-0 controller-1 controller-2 ]
     * RemoteOnline: [ database-1 messaging-0 messaging-1 messaging-2 ]
-    * GuestOnline: [ galera-bundle-1@controller-2 rabbitmq-bundle-0@controller-2 rabbitmq-bundle-1@controller-2 rabbitmq-bundle-2@controller-2 redis-bundle-0@controller-0 redis-bundle-2@controller-2 ]
+    * GuestOnline: [ galera-bundle-1 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-2 ]
 
   * Full List of Resources:
     * database-0	(ocf:pacemaker:remote):	 Stopped
@@ -181,7 +181,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ controller-0 controller-1 controller-2 ]
     * RemoteOnline: [ database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
-    * GuestOnline: [ galera-bundle-0@controller-0 galera-bundle-1@controller-2 galera-bundle-2@controller-1 rabbitmq-bundle-0@controller-2 rabbitmq-bundle-1@controller-2 rabbitmq-bundle-2@controller-2 redis-bundle-0@controller-0 redis-bundle-1@controller-1 redis-bundle-2@controller-2 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * database-0	(ocf:pacemaker:remote):	 Started controller-0

--- a/cts/scheduler/summary/bundle-order-stop.summary
+++ b/cts/scheduler/summary/bundle-order-stop.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ undercloud ]
-    * GuestOnline: [ galera-bundle-0@undercloud rabbitmq-bundle-0@undercloud redis-bundle-0@undercloud ]
+    * GuestOnline: [ galera-bundle-0 rabbitmq-bundle-0 redis-bundle-0 ]
 
   * Full List of Resources:
     * Container bundle: rabbitmq-bundle [192.168.24.1:8787/tripleoupstream/centos-binary-rabbitmq:latest]:

--- a/cts/scheduler/summary/bundle-probe-order-2.summary
+++ b/cts/scheduler/summary/bundle-probe-order-2.summary
@@ -1,7 +1,7 @@
 Using the original execution date of: 2017-10-12 07:31:57Z
 Current cluster status:
   * Node List:
-    * GuestNode galera-bundle-0@centos2: maintenance
+    * GuestNode galera-bundle-0: maintenance
     * Online: [ centos1 centos2 centos3 ]
 
   * Full List of Resources:
@@ -24,7 +24,7 @@ Using the original execution date of: 2017-10-12 07:31:57Z
 
 Revised Cluster Status:
   * Node List:
-    * GuestNode galera-bundle-0@centos2: maintenance
+    * GuestNode galera-bundle-0: maintenance
     * Online: [ centos1 centos2 centos3 ]
 
   * Full List of Resources:

--- a/cts/scheduler/summary/bundle-probe-remotes.summary
+++ b/cts/scheduler/summary/bundle-probe-remotes.summary
@@ -153,7 +153,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ c09-h05-r630 c09-h06-r630 c09-h07-r630 ]
     * RemoteOnline: [ c09-h08-r630 c09-h09-r630 c09-h10-r630 ]
-    * GuestOnline: [ scale1-bundle-0@c09-h05-r630 scale1-bundle-1@c09-h06-r630 scale1-bundle-2@c09-h07-r630 scale1-bundle-3@c09-h05-r630 scale1-bundle-4@c09-h06-r630 scale1-bundle-5@c09-h07-r630 ]
+    * GuestOnline: [ scale1-bundle-0 scale1-bundle-1 scale1-bundle-2 scale1-bundle-3 scale1-bundle-4 scale1-bundle-5 ]
 
   * Full List of Resources:
     * c09-h08-r630	(ocf:pacemaker:remote):	 Started c09-h05-r630

--- a/cts/scheduler/summary/bundle-replicas-change.summary
+++ b/cts/scheduler/summary/bundle-replicas-change.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ rh74-test ]
-    * GuestOnline: [ httpd-bundle-0@rh74-test ]
+    * GuestOnline: [ httpd-bundle-0 ]
 
   * Full List of Resources:
     * Container bundle set: httpd-bundle [pcmktest:http] (unique):
@@ -68,7 +68,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ rh74-test ]
-    * GuestOnline: [ httpd-bundle-0@rh74-test httpd-bundle-1@rh74-test httpd-bundle-2@rh74-test ]
+    * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 httpd-bundle-2 ]
 
   * Full List of Resources:
     * Container bundle set: httpd-bundle [pcmktest:http] (unique):

--- a/cts/scheduler/summary/cancel-behind-moving-remote.summary
+++ b/cts/scheduler/summary/cancel-behind-moving-remote.summary
@@ -4,7 +4,7 @@ Current cluster status:
     * Online: [ controller-0 controller-1 controller-2 database-0 database-1 database-2 messaging-0 messaging-2 ]
     * OFFLINE: [ messaging-1 ]
     * RemoteOnline: [ compute-0 compute-1 ]
-    * GuestOnline: [ galera-bundle-0@database-0 galera-bundle-1@database-1 galera-bundle-2@database-2 ovn-dbs-bundle-1@controller-2 ovn-dbs-bundle-2@controller-1 rabbitmq-bundle-0@messaging-0 rabbitmq-bundle-2@messaging-2 redis-bundle-0@controller-2 redis-bundle-1@controller-0 redis-bundle-2@controller-1 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 ovn-dbs-bundle-1 ovn-dbs-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * compute-0	(ocf:pacemaker:remote):	 Started controller-1
@@ -159,7 +159,7 @@ Revised Cluster Status:
     * Online: [ controller-0 controller-1 controller-2 database-0 database-1 database-2 messaging-0 messaging-2 ]
     * OFFLINE: [ messaging-1 ]
     * RemoteOnline: [ compute-0 compute-1 ]
-    * GuestOnline: [ galera-bundle-0@database-0 galera-bundle-1@database-1 galera-bundle-2@database-2 ovn-dbs-bundle-0@controller-2 ovn-dbs-bundle-1@controller-0 ovn-dbs-bundle-2@controller-1 rabbitmq-bundle-0@messaging-0 rabbitmq-bundle-2@messaging-2 redis-bundle-0@controller-2 redis-bundle-1@controller-0 redis-bundle-2@controller-1 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 ovn-dbs-bundle-0 ovn-dbs-bundle-1 ovn-dbs-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * compute-0	(ocf:pacemaker:remote):	 Started controller-1

--- a/cts/scheduler/summary/clbz5007-promotable-colocation.summary
+++ b/cts/scheduler/summary/clbz5007-promotable-colocation.summary
@@ -11,7 +11,7 @@ Current cluster status:
 
 Transition Summary:
   * Move       UNPROMOTED_IP     ( fc16-builder -> fc16-builder2 )
-  * Move       PROMOTED_IP     ( fc16-builder2 -> fc16-builder )
+  * Move       PROMOTED_IP       ( fc16-builder2 -> fc16-builder )
 
 Executing Cluster Transition:
   * Resource action: UNPROMOTED_IP   stop on fc16-builder

--- a/cts/scheduler/summary/colocation-influence.summary
+++ b/cts/scheduler/summary/colocation-influence.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 rhel7-5 ]
-    * GuestOnline: [ bundle10-0@rhel7-2 bundle10-1@rhel7-3 bundle11-0@rhel7-1 ]
+    * GuestOnline: [ bundle10-0 bundle10-1 bundle11-0 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel7-1
@@ -117,7 +117,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 rhel7-5 ]
-    * GuestOnline: [ bundle10-0@rhel7-2 bundle10-1@rhel7-3 bundle11-0@rhel7-1 ]
+    * GuestOnline: [ bundle10-0 bundle10-1 bundle11-0 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel7-1

--- a/cts/scheduler/summary/container-is-remote-node.summary
+++ b/cts/scheduler/summary/container-is-remote-node.summary
@@ -3,7 +3,7 @@
 Current cluster status:
   * Node List:
     * Online: [ lama2 lama3 ]
-    * GuestOnline: [ RNVM1@lama2 ]
+    * GuestOnline: [ RNVM1 ]
 
   * Full List of Resources:
     * restofencelama2	(stonith:fence_ipmilan):	 Started lama3
@@ -36,7 +36,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ lama2 lama3 ]
-    * GuestOnline: [ RNVM1@lama2 ]
+    * GuestOnline: [ RNVM1 ]
 
   * Full List of Resources:
     * restofencelama2	(stonith:fence_ipmilan):	 Started lama3

--- a/cts/scheduler/summary/guest-host-not-fenceable.summary
+++ b/cts/scheduler/summary/guest-host-not-fenceable.summary
@@ -4,7 +4,7 @@ Current cluster status:
     * Node node2: UNCLEAN (offline)
     * Node node3: UNCLEAN (offline)
     * Online: [ node1 ]
-    * GuestOnline: [ galera-bundle-0@node1 rabbitmq-bundle-0@node1 ]
+    * GuestOnline: [ galera-bundle-0 rabbitmq-bundle-0 ]
 
   * Full List of Resources:
     * Container bundle set: rabbitmq-bundle [192.168.122.139:8787/rhosp13/openstack-rabbitmq:pcmklatest]:

--- a/cts/scheduler/summary/guest-node-cleanup.summary
+++ b/cts/scheduler/summary/guest-node-cleanup.summary
@@ -2,7 +2,7 @@ Using the original execution date of: 2018-10-15 16:02:04Z
 Current cluster status:
   * Node List:
     * Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 rhel7-5 ]
-    * GuestOnline: [ lxc2@rhel7-1 ]
+    * GuestOnline: [ lxc2 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel7-2
@@ -43,7 +43,7 @@ Using the original execution date of: 2018-10-15 16:02:04Z
 Revised Cluster Status:
   * Node List:
     * Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 rhel7-5 ]
-    * GuestOnline: [ lxc1@rhel7-1 lxc2@rhel7-1 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel7-2

--- a/cts/scheduler/summary/guest-node-host-dies.summary
+++ b/cts/scheduler/summary/guest-node-host-dies.summary
@@ -70,7 +70,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ rhel7-2 rhel7-3 rhel7-4 rhel7-5 ]
     * OFFLINE: [ rhel7-1 ]
-    * GuestOnline: [ lxc1@rhel7-2 lxc2@rhel7-3 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel7-4

--- a/cts/scheduler/summary/nested-remote-recovery.summary
+++ b/cts/scheduler/summary/nested-remote-recovery.summary
@@ -3,7 +3,7 @@ Current cluster status:
   * Node List:
     * Online: [ controller-0 controller-1 controller-2 ]
     * RemoteOnline: [ database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
-    * GuestOnline: [ galera-bundle-1@controller-1 galera-bundle-2@controller-2 rabbitmq-bundle-0@controller-2 rabbitmq-bundle-1@controller-1 rabbitmq-bundle-2@controller-1 redis-bundle-0@controller-0 redis-bundle-1@controller-1 redis-bundle-2@controller-2 ]
+    * GuestOnline: [ galera-bundle-1 galera-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * database-0	(ocf:pacemaker:remote):	 Started controller-0
@@ -87,7 +87,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ controller-0 controller-1 controller-2 ]
     * RemoteOnline: [ database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
-    * GuestOnline: [ galera-bundle-0@controller-0 galera-bundle-1@controller-1 galera-bundle-2@controller-2 rabbitmq-bundle-0@controller-2 rabbitmq-bundle-1@controller-1 rabbitmq-bundle-2@controller-1 redis-bundle-0@controller-0 redis-bundle-1@controller-1 redis-bundle-2@controller-2 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * database-0	(ocf:pacemaker:remote):	 Started controller-0

--- a/cts/scheduler/summary/no-promote-on-unrunnable-guest.summary
+++ b/cts/scheduler/summary/no-promote-on-unrunnable-guest.summary
@@ -2,7 +2,7 @@ Using the original execution date of: 2020-05-14 10:49:31Z
 Current cluster status:
   * Node List:
     * Online: [ controller-0 controller-1 controller-2 ]
-    * GuestOnline: [ galera-bundle-0@controller-0 galera-bundle-1@controller-1 galera-bundle-2@controller-2 ovn-dbs-bundle-0@controller-0 ovn-dbs-bundle-1@controller-1 ovn-dbs-bundle-2@controller-2 rabbitmq-bundle-0@controller-0 rabbitmq-bundle-1@controller-1 rabbitmq-bundle-2@controller-2 redis-bundle-0@controller-0 redis-bundle-1@controller-1 redis-bundle-2@controller-2 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 ovn-dbs-bundle-0 ovn-dbs-bundle-1 ovn-dbs-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * Container bundle set: galera-bundle [cluster.common.tag/rhosp16-openstack-mariadb:pcmklatest]:
@@ -77,7 +77,7 @@ Using the original execution date of: 2020-05-14 10:49:31Z
 Revised Cluster Status:
   * Node List:
     * Online: [ controller-0 controller-1 controller-2 ]
-    * GuestOnline: [ galera-bundle-0@controller-0 galera-bundle-1@controller-1 galera-bundle-2@controller-2 ovn-dbs-bundle-1@controller-1 ovn-dbs-bundle-2@controller-2 rabbitmq-bundle-0@controller-0 rabbitmq-bundle-1@controller-1 rabbitmq-bundle-2@controller-2 redis-bundle-0@controller-0 redis-bundle-1@controller-1 redis-bundle-2@controller-2 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 ovn-dbs-bundle-1 ovn-dbs-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * Container bundle set: galera-bundle [cluster.common.tag/rhosp16-openstack-mariadb:pcmklatest]:

--- a/cts/scheduler/summary/notifs-for-unrunnable.summary
+++ b/cts/scheduler/summary/notifs-for-unrunnable.summary
@@ -3,7 +3,7 @@ Current cluster status:
   * Node List:
     * Online: [ controller-1 controller-2 ]
     * OFFLINE: [ controller-0 ]
-    * GuestOnline: [ galera-bundle-1@controller-1 galera-bundle-2@controller-2 rabbitmq-bundle-1@controller-1 rabbitmq-bundle-2@controller-2 redis-bundle-1@controller-1 redis-bundle-2@controller-2 ]
+    * GuestOnline: [ galera-bundle-1 galera-bundle-2 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * Container bundle set: rabbitmq-bundle [192.168.24.1:8787/rhosp12/openstack-rabbitmq:pcmklatest]:
@@ -68,7 +68,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ controller-1 controller-2 ]
     * OFFLINE: [ controller-0 ]
-    * GuestOnline: [ galera-bundle-1@controller-1 galera-bundle-2@controller-2 rabbitmq-bundle-1@controller-1 rabbitmq-bundle-2@controller-2 redis-bundle-1@controller-1 redis-bundle-2@controller-2 ]
+    * GuestOnline: [ galera-bundle-1 galera-bundle-2 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * Container bundle set: rabbitmq-bundle [192.168.24.1:8787/rhosp12/openstack-rabbitmq:pcmklatest]:

--- a/cts/scheduler/summary/notify-behind-stopping-remote.summary
+++ b/cts/scheduler/summary/notify-behind-stopping-remote.summary
@@ -2,7 +2,7 @@ Using the original execution date of: 2018-11-22 20:36:07Z
 Current cluster status:
   * Node List:
     * Online: [ ra1 ra2 ra3 ]
-    * GuestOnline: [ redis-bundle-0@ra1 redis-bundle-1@ra2 redis-bundle-2@ra3 ]
+    * GuestOnline: [ redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * Container bundle set: redis-bundle [docker.io/tripleoqueens/centos-binary-redis:current-tripleo-rdo]:
@@ -55,7 +55,7 @@ Using the original execution date of: 2018-11-22 20:36:07Z
 Revised Cluster Status:
   * Node List:
     * Online: [ ra1 ra2 ra3 ]
-    * GuestOnline: [ redis-bundle-0@ra1 redis-bundle-2@ra3 ]
+    * GuestOnline: [ redis-bundle-0 redis-bundle-2 ]
 
   * Full List of Resources:
     * Container bundle set: redis-bundle [docker.io/tripleoqueens/centos-binary-redis:current-tripleo-rdo]:

--- a/cts/scheduler/summary/on_fail_demote1.summary
+++ b/cts/scheduler/summary/on_fail_demote1.summary
@@ -3,7 +3,7 @@ Current cluster status:
   * Node List:
     * Online: [ rhel7-1 rhel7-3 rhel7-4 rhel7-5 ]
     * RemoteOnline: [ remote-rhel7-2 ]
-    * GuestOnline: [ lxc1@rhel7-3 lxc2@rhel7-3 stateful-bundle-0@rhel7-5 stateful-bundle-1@rhel7-1 stateful-bundle-2@rhel7-4 ]
+    * GuestOnline: [ lxc1 lxc2 stateful-bundle-0 stateful-bundle-1 stateful-bundle-2 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel7-4
@@ -66,7 +66,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ rhel7-1 rhel7-3 rhel7-4 rhel7-5 ]
     * RemoteOnline: [ remote-rhel7-2 ]
-    * GuestOnline: [ lxc1@rhel7-3 lxc2@rhel7-3 stateful-bundle-0@rhel7-5 stateful-bundle-1@rhel7-1 stateful-bundle-2@rhel7-4 ]
+    * GuestOnline: [ lxc1 lxc2 stateful-bundle-0 stateful-bundle-1 stateful-bundle-2 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel7-4

--- a/cts/scheduler/summary/on_fail_demote4.summary
+++ b/cts/scheduler/summary/on_fail_demote4.summary
@@ -4,7 +4,7 @@ Current cluster status:
     * RemoteNode remote-rhel7-2: UNCLEAN (offline)
     * Node rhel7-4: UNCLEAN (offline)
     * Online: [ rhel7-1 rhel7-3 rhel7-5 ]
-    * GuestOnline: [ lxc1@rhel7-3 stateful-bundle-1@rhel7-1 ]
+    * GuestOnline: [ lxc1 stateful-bundle-1 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel7-4 (UNCLEAN)
@@ -165,7 +165,7 @@ Revised Cluster Status:
     * Online: [ rhel7-1 rhel7-3 rhel7-5 ]
     * OFFLINE: [ rhel7-4 ]
     * RemoteOnline: [ remote-rhel7-2 ]
-    * GuestOnline: [ lxc1@rhel7-3 lxc2@rhel7-3 stateful-bundle-0@rhel7-5 stateful-bundle-1@rhel7-1 stateful-bundle-2@rhel7-3 ]
+    * GuestOnline: [ lxc1 lxc2 stateful-bundle-0 stateful-bundle-1 stateful-bundle-2 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel7-5

--- a/cts/scheduler/summary/order-expired-failure.summary
+++ b/cts/scheduler/summary/order-expired-failure.summary
@@ -4,7 +4,7 @@ Current cluster status:
     * RemoteNode overcloud-novacompute-1: UNCLEAN (offline)
     * Online: [ controller-0 controller-1 controller-2 ]
     * RemoteOnline: [ overcloud-novacompute-0 ]
-    * GuestOnline: [ galera-bundle-0@controller-2 galera-bundle-1@controller-0 galera-bundle-2@controller-1 rabbitmq-bundle-0@controller-2 rabbitmq-bundle-1@controller-0 rabbitmq-bundle-2@controller-1 redis-bundle-0@controller-2 redis-bundle-1@controller-0 redis-bundle-2@controller-1 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * overcloud-novacompute-0	(ocf:pacemaker:remote):	 Started controller-0
@@ -71,7 +71,7 @@ Revised Cluster Status:
     * RemoteNode overcloud-novacompute-1: UNCLEAN (offline)
     * Online: [ controller-0 controller-1 controller-2 ]
     * RemoteOnline: [ overcloud-novacompute-0 ]
-    * GuestOnline: [ galera-bundle-0@controller-2 galera-bundle-1@controller-0 galera-bundle-2@controller-1 rabbitmq-bundle-0@controller-2 rabbitmq-bundle-1@controller-0 rabbitmq-bundle-2@controller-1 redis-bundle-0@controller-2 redis-bundle-1@controller-0 redis-bundle-2@controller-1 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * overcloud-novacompute-0	(ocf:pacemaker:remote):	 Started controller-0

--- a/cts/scheduler/summary/priority-fencing-delay.summary
+++ b/cts/scheduler/summary/priority-fencing-delay.summary
@@ -2,7 +2,7 @@ Current cluster status:
   * Node List:
     * Node kiff-01: UNCLEAN (offline)
     * Online: [ kiff-02 ]
-    * GuestOnline: [ lxc-01_kiff-02@kiff-02 lxc-02_kiff-02@kiff-02 ]
+    * GuestOnline: [ lxc-01_kiff-02 lxc-02_kiff-02 ]
 
   * Full List of Resources:
     * vm-fs	(ocf:heartbeat:Filesystem):	 FAILED lxc-01_kiff-01
@@ -83,7 +83,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ kiff-02 ]
     * OFFLINE: [ kiff-01 ]
-    * GuestOnline: [ lxc-01_kiff-01@kiff-02 lxc-01_kiff-02@kiff-02 lxc-02_kiff-01@kiff-02 lxc-02_kiff-02@kiff-02 ]
+    * GuestOnline: [ lxc-01_kiff-01 lxc-01_kiff-02 lxc-02_kiff-01 lxc-02_kiff-02 ]
 
   * Full List of Resources:
     * vm-fs	(ocf:heartbeat:Filesystem):	 Started lxc-01_kiff-01

--- a/cts/scheduler/summary/remote-connection-shutdown.summary
+++ b/cts/scheduler/summary/remote-connection-shutdown.summary
@@ -3,7 +3,7 @@ Current cluster status:
   * Node List:
     * Online: [ controller-0 controller-1 controller-2 database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
     * RemoteOnline: [ compute-0 compute-1 ]
-    * GuestOnline: [ galera-bundle-0@database-0 galera-bundle-1@database-1 galera-bundle-2@database-2 ovn-dbs-bundle-0@controller-2 ovn-dbs-bundle-1@controller-0 ovn-dbs-bundle-2@controller-1 rabbitmq-bundle-0@messaging-0 rabbitmq-bundle-1@messaging-1 rabbitmq-bundle-2@messaging-2 redis-bundle-0@controller-2 redis-bundle-1@controller-0 redis-bundle-2@controller-1 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 ovn-dbs-bundle-0 ovn-dbs-bundle-1 ovn-dbs-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * compute-0	(ocf:pacemaker:remote):	 Started controller-0
@@ -55,54 +55,54 @@ Current cluster status:
       * openstack-cinder-volume-podman-0	(ocf:heartbeat:podman):	 Started controller-0
 
 Transition Summary:
- * Stop       compute-0                            (               controller-0 )   due to node availability
- * Start      stonith-fence_compute-fence-nova     (                 database-0 )  
- * Stop       compute-unfence-trigger:0            (                  compute-0 )   due to node availability
- * Move       nova-evacuate                        (   database-0 -> database-1 )  
- * Move       stonith-fence_ipmilan-52540033df9c   (   database-1 -> database-2 )  
- * Move       stonith-fence_ipmilan-5254001f5f3c   (  database-2 -> messaging-0 )  
- * Move       stonith-fence_ipmilan-5254003f88b4   ( messaging-0 -> messaging-1 )  
- * Move       stonith-fence_ipmilan-5254007b7920   ( messaging-1 -> messaging-2 )  
- * Move       stonith-fence_ipmilan-525400ffc780   (  messaging-2 -> database-0 )  
- * Move       stonith-fence_ipmilan-5254009cb549   (   database-0 -> database-1 )  
+  * Stop       compute-0                            (               controller-0 )  due to node availability
+  * Start      stonith-fence_compute-fence-nova     (                 database-0 )
+  * Stop       compute-unfence-trigger:0            (                  compute-0 )  due to node availability
+  * Move       nova-evacuate                        (   database-0 -> database-1 )
+  * Move       stonith-fence_ipmilan-52540033df9c   (   database-1 -> database-2 )
+  * Move       stonith-fence_ipmilan-5254001f5f3c   (  database-2 -> messaging-0 )
+  * Move       stonith-fence_ipmilan-5254003f88b4   ( messaging-0 -> messaging-1 )
+  * Move       stonith-fence_ipmilan-5254007b7920   ( messaging-1 -> messaging-2 )
+  * Move       stonith-fence_ipmilan-525400ffc780   (  messaging-2 -> database-0 )
+  * Move       stonith-fence_ipmilan-5254009cb549   (   database-0 -> database-1 )
 
 Executing Cluster Transition:
- * Resource action: stonith-fence_compute-fence-nova start on database-0
- * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on messaging-2
- * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on messaging-0
- * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on messaging-1
- * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on controller-2
- * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on controller-1
- * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on controller-0
- * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on database-2
- * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on database-1
- * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on database-0
- * Pseudo action:   compute-unfence-trigger-clone_stop_0
- * Resource action: nova-evacuate   stop on database-0
- * Resource action: stonith-fence_ipmilan-52540033df9c stop on database-1
- * Resource action: stonith-fence_ipmilan-5254001f5f3c stop on database-2
- * Resource action: stonith-fence_ipmilan-5254003f88b4 stop on messaging-0
- * Resource action: stonith-fence_ipmilan-5254007b7920 stop on messaging-1
- * Resource action: stonith-fence_ipmilan-525400ffc780 stop on messaging-2
- * Resource action: stonith-fence_ipmilan-5254009cb549 stop on database-0
- * Resource action: stonith-fence_compute-fence-nova monitor=60000 on database-0
- * Resource action: compute-unfence-trigger stop on compute-0
- * Pseudo action:   compute-unfence-trigger-clone_stopped_0
- * Resource action: nova-evacuate   start on database-1
- * Resource action: stonith-fence_ipmilan-52540033df9c start on database-2
- * Resource action: stonith-fence_ipmilan-5254001f5f3c start on messaging-0
- * Resource action: stonith-fence_ipmilan-5254003f88b4 start on messaging-1
- * Resource action: stonith-fence_ipmilan-5254007b7920 start on messaging-2
- * Resource action: stonith-fence_ipmilan-525400ffc780 start on database-0
- * Resource action: stonith-fence_ipmilan-5254009cb549 start on database-1
- * Resource action: compute-0       stop on controller-0
- * Resource action: nova-evacuate   monitor=10000 on database-1
- * Resource action: stonith-fence_ipmilan-52540033df9c monitor=60000 on database-2
- * Resource action: stonith-fence_ipmilan-5254001f5f3c monitor=60000 on messaging-0
- * Resource action: stonith-fence_ipmilan-5254003f88b4 monitor=60000 on messaging-1
- * Resource action: stonith-fence_ipmilan-5254007b7920 monitor=60000 on messaging-2
- * Resource action: stonith-fence_ipmilan-525400ffc780 monitor=60000 on database-0
- * Resource action: stonith-fence_ipmilan-5254009cb549 monitor=60000 on database-1
+  * Resource action: stonith-fence_compute-fence-nova start on database-0
+  * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on messaging-2
+  * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on messaging-0
+  * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on messaging-1
+  * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on controller-2
+  * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on controller-1
+  * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on controller-0
+  * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on database-2
+  * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on database-1
+  * Cluster action:  clear_failcount for stonith-fence_compute-fence-nova on database-0
+  * Pseudo action:   compute-unfence-trigger-clone_stop_0
+  * Resource action: nova-evacuate   stop on database-0
+  * Resource action: stonith-fence_ipmilan-52540033df9c stop on database-1
+  * Resource action: stonith-fence_ipmilan-5254001f5f3c stop on database-2
+  * Resource action: stonith-fence_ipmilan-5254003f88b4 stop on messaging-0
+  * Resource action: stonith-fence_ipmilan-5254007b7920 stop on messaging-1
+  * Resource action: stonith-fence_ipmilan-525400ffc780 stop on messaging-2
+  * Resource action: stonith-fence_ipmilan-5254009cb549 stop on database-0
+  * Resource action: stonith-fence_compute-fence-nova monitor=60000 on database-0
+  * Resource action: compute-unfence-trigger stop on compute-0
+  * Pseudo action:   compute-unfence-trigger-clone_stopped_0
+  * Resource action: nova-evacuate   start on database-1
+  * Resource action: stonith-fence_ipmilan-52540033df9c start on database-2
+  * Resource action: stonith-fence_ipmilan-5254001f5f3c start on messaging-0
+  * Resource action: stonith-fence_ipmilan-5254003f88b4 start on messaging-1
+  * Resource action: stonith-fence_ipmilan-5254007b7920 start on messaging-2
+  * Resource action: stonith-fence_ipmilan-525400ffc780 start on database-0
+  * Resource action: stonith-fence_ipmilan-5254009cb549 start on database-1
+  * Resource action: compute-0       stop on controller-0
+  * Resource action: nova-evacuate   monitor=10000 on database-1
+  * Resource action: stonith-fence_ipmilan-52540033df9c monitor=60000 on database-2
+  * Resource action: stonith-fence_ipmilan-5254001f5f3c monitor=60000 on messaging-0
+  * Resource action: stonith-fence_ipmilan-5254003f88b4 monitor=60000 on messaging-1
+  * Resource action: stonith-fence_ipmilan-5254007b7920 monitor=60000 on messaging-2
+  * Resource action: stonith-fence_ipmilan-525400ffc780 monitor=60000 on database-0
+  * Resource action: stonith-fence_ipmilan-5254009cb549 monitor=60000 on database-1
 Using the original execution date of: 2020-11-17 07:03:16Z
 
 Revised Cluster Status:
@@ -110,7 +110,7 @@ Revised Cluster Status:
     * Online: [ controller-0 controller-1 controller-2 database-0 database-1 database-2 messaging-0 messaging-1 messaging-2 ]
     * RemoteOnline: [ compute-1 ]
     * RemoteOFFLINE: [ compute-0 ]
-    * GuestOnline: [ galera-bundle-0@database-0 galera-bundle-1@database-1 galera-bundle-2@database-2 ovn-dbs-bundle-0@controller-2 ovn-dbs-bundle-1@controller-0 ovn-dbs-bundle-2@controller-1 rabbitmq-bundle-0@messaging-0 rabbitmq-bundle-1@messaging-1 rabbitmq-bundle-2@messaging-2 redis-bundle-0@controller-2 redis-bundle-1@controller-0 redis-bundle-2@controller-1 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 ovn-dbs-bundle-0 ovn-dbs-bundle-1 ovn-dbs-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * compute-0	(ocf:pacemaker:remote):	 Stopped

--- a/cts/scheduler/summary/remote-fence-unclean-3.summary
+++ b/cts/scheduler/summary/remote-fence-unclean-3.summary
@@ -2,7 +2,7 @@ Current cluster status:
   * Node List:
     * Online: [ overcloud-controller-0 overcloud-controller-1 overcloud-controller-2 ]
     * RemoteOFFLINE: [ overcloud-novacompute-0 ]
-    * GuestOnline: [ galera-bundle-0@overcloud-controller-0 galera-bundle-1@overcloud-controller-1 galera-bundle-2@overcloud-controller-2 rabbitmq-bundle-0@overcloud-controller-0 rabbitmq-bundle-1@overcloud-controller-1 rabbitmq-bundle-2@overcloud-controller-2 redis-bundle-0@overcloud-controller-0 redis-bundle-1@overcloud-controller-1 redis-bundle-2@overcloud-controller-2 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * fence1	(stonith:fence_xvm):	 Stopped
@@ -70,7 +70,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ overcloud-controller-0 overcloud-controller-1 overcloud-controller-2 ]
     * RemoteOFFLINE: [ overcloud-novacompute-0 ]
-    * GuestOnline: [ galera-bundle-0@overcloud-controller-0 galera-bundle-1@overcloud-controller-1 galera-bundle-2@overcloud-controller-2 rabbitmq-bundle-0@overcloud-controller-0 rabbitmq-bundle-1@overcloud-controller-1 rabbitmq-bundle-2@overcloud-controller-2 redis-bundle-0@overcloud-controller-0 redis-bundle-1@overcloud-controller-1 redis-bundle-2@overcloud-controller-2 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * fence1	(stonith:fence_xvm):	 Started overcloud-controller-0

--- a/cts/scheduler/summary/route-remote-notify.summary
+++ b/cts/scheduler/summary/route-remote-notify.summary
@@ -2,7 +2,7 @@ Using the original execution date of: 2018-10-31 11:51:32Z
 Current cluster status:
   * Node List:
     * Online: [ controller-0 controller-1 controller-2 ]
-    * GuestOnline: [ rabbitmq-bundle-0@controller-0 rabbitmq-bundle-1@controller-1 rabbitmq-bundle-2@controller-2 ]
+    * GuestOnline: [ rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 ]
 
   * Full List of Resources:
     * Container bundle set: rabbitmq-bundle [192.168.24.1:8787/rhosp13/openstack-rabbitmq:pcmklatest]:
@@ -77,7 +77,7 @@ Using the original execution date of: 2018-10-31 11:51:32Z
 Revised Cluster Status:
   * Node List:
     * Online: [ controller-0 controller-1 controller-2 ]
-    * GuestOnline: [ rabbitmq-bundle-1@controller-1 rabbitmq-bundle-2@controller-2 ]
+    * GuestOnline: [ rabbitmq-bundle-1 rabbitmq-bundle-2 ]
 
   * Full List of Resources:
     * Container bundle set: rabbitmq-bundle [192.168.24.1:8787/rhosp13/openstack-rabbitmq:pcmklatest]:

--- a/cts/scheduler/summary/utilization-complex.summary
+++ b/cts/scheduler/summary/utilization-complex.summary
@@ -2,7 +2,7 @@ Using the original execution date of: 2022-01-05 22:04:47Z
 Current cluster status:
   * Node List:
     * Online: [ rhel8-1 rhel8-2 rhel8-3 rhel8-4 rhel8-5 ]
-    * GuestOnline: [ httpd-bundle-0@rhel8-2 ]
+    * GuestOnline: [ httpd-bundle-0 ]
 
   * Full List of Resources:
     * dummy3	(ocf:pacemaker:Dummy):	 Started rhel8-1
@@ -121,7 +121,7 @@ Using the original execution date of: 2022-01-05 22:04:47Z
 Revised Cluster Status:
   * Node List:
     * Online: [ rhel8-1 rhel8-2 rhel8-3 rhel8-4 rhel8-5 ]
-    * GuestOnline: [ httpd-bundle-0@rhel8-5 ]
+    * GuestOnline: [ httpd-bundle-0 ]
 
   * Full List of Resources:
     * dummy3	(ocf:pacemaker:Dummy):	 Stopped

--- a/cts/scheduler/summary/whitebox-asymmetric.summary
+++ b/cts/scheduler/summary/whitebox-asymmetric.summary
@@ -30,7 +30,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ 18builder ]
-    * GuestOnline: [ 18node2@18builder ]
+    * GuestOnline: [ 18node2 ]
 
   * Full List of Resources:
     * fence_false	(stonith:fence_false):	 Stopped

--- a/cts/scheduler/summary/whitebox-fail1.summary
+++ b/cts/scheduler/summary/whitebox-fail1.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc2@18node2 ]
+    * GuestOnline: [ lxc2 ]
 
   * Full List of Resources:
     * container1	(ocf:heartbeat:VirtualDomain):	 FAILED 18node2
@@ -45,7 +45,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc1@18node2 lxc2@18node2 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * container1	(ocf:heartbeat:VirtualDomain):	 Started 18node2

--- a/cts/scheduler/summary/whitebox-fail2.summary
+++ b/cts/scheduler/summary/whitebox-fail2.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc2@18node2 ]
+    * GuestOnline: [ lxc2 ]
 
   * Full List of Resources:
     * container1	(ocf:heartbeat:VirtualDomain):	 FAILED 18node2
@@ -45,7 +45,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc1@18node2 lxc2@18node2 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * container1	(ocf:heartbeat:VirtualDomain):	 Started 18node2

--- a/cts/scheduler/summary/whitebox-fail3.summary
+++ b/cts/scheduler/summary/whitebox-fail3.summary
@@ -39,7 +39,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ dvossel-laptop2 ]
-    * GuestOnline: [ 18builder@dvossel-laptop2 ]
+    * GuestOnline: [ 18builder ]
 
   * Full List of Resources:
     * vm	(ocf:heartbeat:VirtualDomain):	 Started dvossel-laptop2

--- a/cts/scheduler/summary/whitebox-imply-stop-on-fence.summary
+++ b/cts/scheduler/summary/whitebox-imply-stop-on-fence.summary
@@ -2,7 +2,7 @@ Current cluster status:
   * Node List:
     * Node kiff-01: UNCLEAN (offline)
     * Online: [ kiff-02 ]
-    * GuestOnline: [ lxc-01_kiff-02@kiff-02 lxc-02_kiff-02@kiff-02 ]
+    * GuestOnline: [ lxc-01_kiff-02 lxc-02_kiff-02 ]
 
   * Full List of Resources:
     * fence-kiff-01	(stonith:fence_ipmilan):	 Started kiff-02
@@ -83,7 +83,7 @@ Revised Cluster Status:
   * Node List:
     * Online: [ kiff-02 ]
     * OFFLINE: [ kiff-01 ]
-    * GuestOnline: [ lxc-01_kiff-01@kiff-02 lxc-01_kiff-02@kiff-02 lxc-02_kiff-01@kiff-02 lxc-02_kiff-02@kiff-02 ]
+    * GuestOnline: [ lxc-01_kiff-01 lxc-01_kiff-02 lxc-02_kiff-01 lxc-02_kiff-02 ]
 
   * Full List of Resources:
     * fence-kiff-01	(stonith:fence_ipmilan):	 Started kiff-02

--- a/cts/scheduler/summary/whitebox-migrate1.summary
+++ b/cts/scheduler/summary/whitebox-migrate1.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ rhel7-node2 rhel7-node3 ]
-    * GuestOnline: [ rhel7-node1@rhel7-node2 ]
+    * GuestOnline: [ rhel7-node1 ]
 
   * Full List of Resources:
     * shooter1	(stonith:fence_xvm):	 Started rhel7-node3
@@ -42,7 +42,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ rhel7-node2 rhel7-node3 ]
-    * GuestOnline: [ rhel7-node1@rhel7-node3 ]
+    * GuestOnline: [ rhel7-node1 ]
 
   * Full List of Resources:
     * shooter1	(stonith:fence_xvm):	 Started rhel7-node2

--- a/cts/scheduler/summary/whitebox-move.summary
+++ b/cts/scheduler/summary/whitebox-move.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc1@18node1 lxc2@18node2 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * container1	(ocf:heartbeat:VirtualDomain):	 Started 18node1
@@ -38,7 +38,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc1@18node2 lxc2@18node2 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * container1	(ocf:heartbeat:VirtualDomain):	 Started 18node2

--- a/cts/scheduler/summary/whitebox-ms-ordering-move.summary
+++ b/cts/scheduler/summary/whitebox-ms-ordering-move.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 rhel7-5 ]
-    * GuestOnline: [ lxc1@rhel7-1 lxc2@rhel7-1 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel7-3
@@ -77,7 +77,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ rhel7-1 rhel7-2 rhel7-3 rhel7-4 rhel7-5 ]
-    * GuestOnline: [ lxc1@rhel7-2 lxc2@rhel7-1 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started rhel7-3

--- a/cts/scheduler/summary/whitebox-ms-ordering.summary
+++ b/cts/scheduler/summary/whitebox-ms-ordering.summary
@@ -62,7 +62,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc1@18node1 lxc2@18node1 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * shooter	(stonith:fence_xvm):	 Started 18node2

--- a/cts/scheduler/summary/whitebox-nested-group.summary
+++ b/cts/scheduler/summary/whitebox-nested-group.summary
@@ -86,7 +86,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ c7auto1 c7auto2 c7auto3 ]
-    * GuestOnline: [ c7auto4@c7auto1 ]
+    * GuestOnline: [ c7auto4 ]
 
   * Full List of Resources:
     * shooter	(stonith:fence_phd_kvm):	 Started c7auto2

--- a/cts/scheduler/summary/whitebox-orphan-ms.summary
+++ b/cts/scheduler/summary/whitebox-orphan-ms.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc1@18node1 lxc2@18node1 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * Fencing	(stonith:fence_xvm):	 Started 18node2

--- a/cts/scheduler/summary/whitebox-orphaned.summary
+++ b/cts/scheduler/summary/whitebox-orphaned.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc1@18node2 lxc2@18node2 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * container2	(ocf:heartbeat:VirtualDomain):	 Started 18node2
@@ -46,7 +46,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc2@18node2 ]
+    * GuestOnline: [ lxc2 ]
 
   * Full List of Resources:
     * container2	(ocf:heartbeat:VirtualDomain):	 Started 18node2

--- a/cts/scheduler/summary/whitebox-start.summary
+++ b/cts/scheduler/summary/whitebox-start.summary
@@ -1,7 +1,7 @@
 Current cluster status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc2@18node2 ]
+    * GuestOnline: [ lxc2 ]
 
   * Full List of Resources:
     * container1	(ocf:heartbeat:VirtualDomain):	 Stopped
@@ -42,7 +42,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc1@18node1 lxc2@18node2 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * container1	(ocf:heartbeat:VirtualDomain):	 Started 18node1

--- a/cts/scheduler/summary/whitebox-stop.summary
+++ b/cts/scheduler/summary/whitebox-stop.summary
@@ -3,7 +3,7 @@
 Current cluster status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc1@18node2 lxc2@18node2 ]
+    * GuestOnline: [ lxc1 lxc2 ]
 
   * Full List of Resources:
     * container1	(ocf:heartbeat:VirtualDomain):	 Started 18node2 (disabled)
@@ -38,7 +38,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ 18node1 18node2 18node3 ]
-    * GuestOnline: [ lxc2@18node2 ]
+    * GuestOnline: [ lxc2 ]
 
   * Full List of Resources:
     * container1	(ocf:heartbeat:VirtualDomain):	 Stopped (disabled)

--- a/cts/scheduler/summary/whitebox-unexpectedly-running.summary
+++ b/cts/scheduler/summary/whitebox-unexpectedly-running.summary
@@ -28,7 +28,7 @@ Executing Cluster Transition:
 Revised Cluster Status:
   * Node List:
     * Online: [ 18builder ]
-    * GuestOnline: [ remote1@18builder remote2@18builder ]
+    * GuestOnline: [ remote1 remote2 ]
 
   * Full List of Resources:
     * FAKE	(ocf:pacemaker:Dummy):	 Started 18builder

--- a/cts/scheduler/summary/year-2038.summary
+++ b/cts/scheduler/summary/year-2038.summary
@@ -4,7 +4,7 @@ Current cluster status:
     * RemoteNode overcloud-novacompute-1: UNCLEAN (offline)
     * Online: [ controller-0 controller-1 controller-2 ]
     * RemoteOnline: [ overcloud-novacompute-0 ]
-    * GuestOnline: [ galera-bundle-0@controller-2 galera-bundle-1@controller-0 galera-bundle-2@controller-1 rabbitmq-bundle-0@controller-2 rabbitmq-bundle-1@controller-0 rabbitmq-bundle-2@controller-1 redis-bundle-0@controller-2 redis-bundle-1@controller-0 redis-bundle-2@controller-1 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * overcloud-novacompute-0	(ocf:pacemaker:remote):	 Started controller-0
@@ -71,7 +71,7 @@ Revised Cluster Status:
     * RemoteNode overcloud-novacompute-1: UNCLEAN (offline)
     * Online: [ controller-0 controller-1 controller-2 ]
     * RemoteOnline: [ overcloud-novacompute-0 ]
-    * GuestOnline: [ galera-bundle-0@controller-2 galera-bundle-1@controller-0 galera-bundle-2@controller-1 rabbitmq-bundle-0@controller-2 rabbitmq-bundle-1@controller-0 rabbitmq-bundle-2@controller-1 redis-bundle-0@controller-2 redis-bundle-1@controller-0 redis-bundle-2@controller-1 ]
+    * GuestOnline: [ galera-bundle-0 galera-bundle-1 galera-bundle-2 rabbitmq-bundle-0 rabbitmq-bundle-1 rabbitmq-bundle-2 redis-bundle-0 redis-bundle-1 redis-bundle-2 ]
 
   * Full List of Resources:
     * overcloud-novacompute-0	(ocf:pacemaker:remote):	 Started controller-0

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -499,7 +499,8 @@ pe__node_display_name(pe_node_t *node, bool print_detail)
 
     /* Host is displayed only if this is a guest node */
     if (pe__is_guest_node(node)) {
-        pe_node_t *host_node = pe__current_node(node->details->remote_rsc);
+        const pe_resource_t *container = node->details->remote_rsc->container;
+        const pe_node_t *host_node = pe__current_node(container);
 
         if (host_node && host_node->details) {
             node_host = host_node->details->uname;

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -497,8 +497,8 @@ pe__node_display_name(pe_node_t *node, bool print_detail)
 
     CRM_ASSERT((node != NULL) && (node->details != NULL) && (node->details->uname != NULL));
 
-    /* Host is displayed only if this is a guest node */
-    if (pe__is_guest_node(node)) {
+    /* Host is displayed only if this is a guest node and detail is requested */
+    if (print_detail && pe__is_guest_node(node)) {
         const pe_resource_t *container = node->details->remote_rsc->container;
         const pe_node_t *host_node = pe__current_node(container);
 


### PR DESCRIPTION
In this situation, currently the GuestOnline line shows `<guest node>@<connection's node>`. It should show `<guest node>` when `--show-detail` is not set, and `<guest node>@<container's node>` when `--show-detail` is set.

Closes T180
Closes CLBZ#5373

