### PR TITLE
Execute metadata asynchronously in controller

### DIFF
--- a/cts/lab/CTStests.py
+++ b/cts/lab/CTStests.py
@@ -1,7 +1,7 @@
 """ Test-specific classes for Pacemaker's Cluster Test Suite (CTS)
 """
 
-__copyright__ = "Copyright 2000-2021 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2022 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 #
@@ -1222,7 +1222,7 @@ class MaintenanceMode(CTSTest):
         '''Return list of errors which should be ignored'''
         return [
             r"Updating failcount for %s" % self.rid,
-            r"schedulerd.*: Recover %s\s*\(.*\)" % self.rid,
+            r"schedulerd.*: Recover\s+%s\s+\(.*\)" % self.rid,
             r"Unknown operation: fail",
             self.templates["Pat:RscOpOK"] % (self.action, self.rid),
             r"(ERROR|error).*: Action %s_%s_%d .* initiated outside of a transition" % (self.rid, self.action, self.interval),
@@ -1321,7 +1321,7 @@ class ResourceRecover(CTSTest):
         '''Return list of errors which should be ignored'''
         return [
             r"Updating failcount for %s" % self.rid,
-            r"schedulerd.*: Recover (%s|%s)\s*\(.*\)" % (self.rid, self.rid_alt),
+            r"schedulerd.*: Recover\s+(%s|%s)\s+\(.*\)" % (self.rid, self.rid_alt),
             r"Unknown operation: fail",
             self.templates["Pat:RscOpOK"] % (self.action, self.rid),
             r"(ERROR|error).*: Action %s_%s_%d .* initiated outside of a transition" % (self.rid, self.action, self.interval),
@@ -2553,7 +2553,7 @@ class RemoteLXC(CTSTest):
         '''Return list of errors which should be ignored'''
         return [
             r"Updating failcount for ping",
-            r"schedulerd.*: Recover (ping|lxc-ms|container)\s*\(.*\)",
+            r"schedulerd.*: Recover\s+(ping|lxc-ms|container)\s+\(.*\)",
             # The orphaned lxc-ms resource causes an expected transition error
             # that is a result of the scheduler not having knowledge that the
             # promotable resource used to be a clone. As a result, it looks like that 
@@ -3047,7 +3047,7 @@ class RemoteStonithd(RemoteDriver):
             r"Software caused connection abort",
             r"pacemaker-controld.*:\s+error.*: Operation remote-.*_monitor",
             r"pacemaker-controld.*:\s+error.*: Result of monitor operation for remote-.*",
-            r"schedulerd.*:\s+Recover remote-.*\s*\(.*\)",
+            r"schedulerd.*:\s+Recover\s+remote-.*\s+\(.*\)",
             r"error: Result of monitor operation for .* on remote-.*: Internal communication failure",
         ]
 
@@ -3113,7 +3113,7 @@ class RemoteRscFailure(RemoteDriver):
 
     def errorstoignore(self):
         ignore_pats = [
-            r"schedulerd.*: Recover remote-rsc\s*\(.*\)",
+            r"schedulerd.*: Recover\s+remote-rsc\s+\(.*\)",
             r"Dummy.*: No process state file found",
         ]
 

--- a/cts/lab/patterns.py
+++ b/cts/lab/patterns.py
@@ -270,7 +270,7 @@ class crm_corosync(BasePatterns):
         ]
         self.components["pacemaker-based-ignore"] = [
             r"pacemaker-execd.*Connection to (fencer|stonith-ng).* (closed|failed|lost)",
-            r"pacemaker-controld.*:\s+Result of .* operation for Fencing.*Error (Lost connection to fencer)",
+            r"pacemaker-controld.*:\s+Result of .* operation for Fencing.*Error \(Lost connection to fencer\)",
             r"pacemaker-controld.*:Could not connect to attrd: Connection refused",
             # This is overbroad, but we don't have a way to say that only
             # certain transition errors are acceptable (if the fencer respawns,
@@ -325,7 +325,7 @@ class crm_corosync(BasePatterns):
             r"(error|warning):.*Connection to (fencer|stonith-ng).* (closed|failed|lost)",
             r"crit:.*Fencing daemon connection failed",
             r"error:.*Fencer connection failed \(will retry\)",
-            r"pacemaker-controld.*:\s+Result of .* operation for Fencing.*Error (Lost connection to fencer)",
+            r"pacemaker-controld.*:\s+Result of .* operation for Fencing.*Error \(Lost connection to fencer\)",
             # This is overbroad, but we don't have a way to say that only
             # certain transition errors are acceptable (if the fencer respawns,
             # fence devices may appear multiply active). We have to rely on

--- a/cts/lab/patterns.py
+++ b/cts/lab/patterns.py
@@ -66,7 +66,7 @@ class BasePatterns(object):
 
             "Pat:Fencing_start"   : r"Requesting peer fencing .* targeting %s",
             "Pat:Fencing_ok"      : r"pacemaker-fenced.*:\s*Operation .* targeting %s by .* for .*@.*: OK",
-            "Pat:Fencing_recover" : r"pacemaker-schedulerd.*: Recover %s",
+            "Pat:Fencing_recover" : r"pacemaker-schedulerd.*: Recover\s+%s",
             "Pat:Fencing_active"  : r"stonith resource .* is active on 2 nodes (attempting recovery)",
             "Pat:Fencing_probe"   : r"pacemaker-controld.* Result of probe operation for %s on .*: Error",
 
@@ -179,7 +179,7 @@ class crm_corosync(BasePatterns):
             r"Parameters to .* action changed:",
             r"Parameters to .* changed",
             r"pacemakerd.*\[[0-9]+\] terminated( with signal| as IPC server|$)",
-            r"pacemaker-schedulerd.*Recover .*\(.* -\> .*\)",
+            r"pacemaker-schedulerd.*Recover\s+.*\(.* -\> .*\)",
             r"rsyslogd.* imuxsock lost .* messages from pid .* due to rate-limiting",
             r"Peer is not part of our cluster",
             r"We appear to be in an election loop",

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -694,18 +694,8 @@ build_operation_update(xmlNode * parent, const lrmd_rsc_info_t *rsc,
 
     target_rc = rsc_op_expected_rc(op);
 
-    /* there is a small risk in formerly mixed clusters that it will
-     * be sub-optimal.
-     *
-     * however with our upgrade policy, the update we send should
-     * still be completely supported anyway
-     */
     caller_version = g_hash_table_lookup(op->params, XML_ATTR_CRM_VERSION);
-    CRM_LOG_ASSERT(caller_version != NULL);
-
-    if(caller_version == NULL) {
-        caller_version = CRM_FEATURE_SET;
-    }
+    CRM_CHECK(caller_version != NULL, caller_version = CRM_FEATURE_SET);
 
     xml_op = pcmk__create_history_xml(parent, op, caller_version, target_rc,
                                       fsa_our_uname, src);

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -2205,6 +2205,17 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc, xmlNode *msg,
         crm_log_xml_err(msg, "Missing transition number");
     }
 
+    if (lrm_state == NULL) {
+        // This shouldn't be possible, but provide a failsafe just in case
+        crm_err("Cannot execute %s of %s: No executor connection "
+                CRM_XS " transition_key=%s",
+                operation, rsc->id, pcmk__s(transition, ""));
+        synthesize_lrmd_failure(NULL, msg, PCMK_EXEC_INVALID,
+                                PCMK_OCF_UNKNOWN_ERROR,
+                                "No executor connection");
+        return;
+    }
+
     if (pcmk__str_any_of(operation, CRMD_ACTION_RELOAD,
                          CRMD_ACTION_RELOAD_AGENT, NULL)) {
         /* Pre-2.1.0 DCs will schedule reload actions only, and 2.1.0+ DCs

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -812,16 +812,16 @@ build_active_RAs(lrm_state_t * lrm_state, xmlNode * rsc_list)
 }
 
 xmlNode *
-controld_query_executor_state(const char *node_name)
+controld_query_executor_state(void)
 {
     xmlNode *xml_state = NULL;
     xmlNode *xml_data = NULL;
     xmlNode *rsc_list = NULL;
     crm_node_t *peer = NULL;
-    lrm_state_t *lrm_state = lrm_state_find(node_name);
+    lrm_state_t *lrm_state = lrm_state_find(fsa_our_uname);
 
     if (!lrm_state) {
-        crm_err("Could not find executor state for node %s", node_name);
+        crm_err("Could not find executor state for node %s", fsa_our_uname);
         return NULL;
     }
 

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1569,20 +1569,6 @@ fail_lrm_resource(xmlNode *xml, lrm_state_t *lrm_state, const char *user_name,
 }
 
 static void
-handle_query_op(xmlNode *msg, lrm_state_t *lrm_state)
-{
-    xmlNode *data = do_lrm_query_internal(lrm_state, node_update_all);
-    xmlNode *reply = create_reply(msg, data);
-
-    if (relay_message(reply, TRUE) == FALSE) {
-        crm_err("Unable to route reply");
-        crm_log_xml_err(reply, "reply");
-    }
-    free_xml(reply);
-    free_xml(data);
-}
-
-static void
 handle_reprobe_op(lrm_state_t *lrm_state, const char *from_sys,
                   const char *from_host, const char *user_name,
                   gboolean is_remote_node)
@@ -1786,9 +1772,6 @@ do_lrm_invoke(long long action,
          * resource history to the CIB. Just ignore it.
          */
         crm_notice("Ignoring refresh request from Pacemaker Remote 1.1.9 node");
-
-    } else if (pcmk__str_eq(crm_op, CRM_OP_LRM_QUERY, pcmk__str_none)) {
-        handle_query_op(input->msg, lrm_state);
 
     // @COMPAT DCs <1.1.14 in a rolling upgrade might schedule this op
     } else if (pcmk__str_eq(operation, CRM_OP_PROBED, pcmk__str_none)) {

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -827,19 +827,26 @@ build_active_RAs(lrm_state_t * lrm_state, xmlNode * rsc_list)
     return FALSE;
 }
 
-static xmlNode *
-do_lrm_query_internal(lrm_state_t *lrm_state, int update_flags)
+xmlNode *
+controld_query_executor_state(const char *node_name)
 {
     xmlNode *xml_state = NULL;
     xmlNode *xml_data = NULL;
     xmlNode *rsc_list = NULL;
     crm_node_t *peer = NULL;
+    lrm_state_t *lrm_state = lrm_state_find(node_name);
+
+    if (!lrm_state) {
+        crm_err("Could not find executor state for node %s", node_name);
+        return NULL;
+    }
 
     peer = crm_get_peer_full(0, lrm_state->node_name, CRM_GET_PEER_ANY);
     CRM_CHECK(peer != NULL, return NULL);
 
-    xml_state = create_node_state_update(peer, update_flags, NULL,
-                                         __func__);
+    xml_state = create_node_state_update(peer,
+                                         node_update_cluster|node_update_peer,
+                                         NULL, __func__);
     if (xml_state == NULL) {
         return NULL;
     }
@@ -854,19 +861,6 @@ do_lrm_query_internal(lrm_state_t *lrm_state, int update_flags)
     crm_log_xml_trace(xml_state, "Current executor state");
 
     return xml_state;
-}
-
-xmlNode *
-controld_query_executor_state(const char *node_name)
-{
-    lrm_state_t *lrm_state = lrm_state_find(node_name);
-
-    if (!lrm_state) {
-        crm_err("Could not find executor state for node %s", node_name);
-        return NULL;
-    }
-    return do_lrm_query_internal(lrm_state,
-                                 node_update_cluster|node_update_peer);
 }
 
 /*!

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -2878,7 +2878,7 @@ process_lrm_event(lrm_state_t *lrm_state, lrmd_event_data_t *op,
         } else if (rsc && (op->rc == PCMK_OCF_OK)) {
             char *metadata = unescape_newlines(op->output);
 
-            metadata_cache_update(lrm_state->metadata_cache, rsc, metadata);
+            controld_cache_metadata(lrm_state->metadata_cache, rsc, metadata);
             free(metadata);
         }
     }

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1903,6 +1903,11 @@ do_lrm_invoke(long long action,
                 struct metadata_cb_data *data = NULL;
 
                 data = new_metadata_cb_data(rsc, input->xml);
+                crm_info("Retrieving metadata for %s (%s%s%s:%s) asynchronously",
+                         rsc->id, rsc->standard,
+                         ((rsc->provider == NULL)? "" : ":"),
+                         ((rsc->provider == NULL)? "" : rsc->provider),
+                         rsc->type);
                 (void) lrmd__metadata_async(rsc, metadata_complete,
                                             (void *) data);
             } else {

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -518,7 +518,7 @@ extern gboolean ever_had_quorum;
 // These should be moved elsewhere
 void do_update_cib_nodes(gboolean overwrite, const char *caller);
 int crmd_cib_smart_opt(void);
-xmlNode *controld_query_executor_state(const char *node_name);
+xmlNode *controld_query_executor_state(void);
 
 const char *fsa_input2string(enum crmd_fsa_input input);
 const char *fsa_state2string(enum crmd_fsa_state state);

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -272,7 +272,7 @@ do_cl_join_finalize_respond(long long action,
                  FALSE);
 
     /* send our status section to the DC */
-    tmp1 = controld_query_executor_state(fsa_our_uname);
+    tmp1 = controld_query_executor_state();
     if (tmp1 != NULL) {
         xmlNode *reply = create_request(CRM_OP_JOIN_CONFIRM, tmp1, fsa_our_dc,
                                         CRM_SYSTEM_DC, CRM_SYSTEM_CRMD, NULL);

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -591,7 +591,7 @@ do_dc_join_ack(long long action,
     }
     controld_delete_node_state(join_from, section, cib_scope_local);
     if (pcmk__str_eq(join_from, fsa_our_uname, pcmk__str_casei)) {
-        xmlNode *now_dc_lrmd_state = controld_query_executor_state(fsa_our_uname);
+        xmlNode *now_dc_lrmd_state = controld_query_executor_state();
 
         if (now_dc_lrmd_state != NULL) {
             fsa_cib_update(XML_CIB_TAG_STATUS, now_dc_lrmd_state,

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -1064,7 +1064,7 @@ handle_request(xmlNode *stored_msg, enum crmd_fsa_cause cause)
         return handle_lrm_delete(stored_msg);
 
     } else if ((strcmp(op, CRM_OP_LRM_FAIL) == 0)
-               || (strcmp(op, CRM_OP_LRM_REFRESH) == 0)
+               || (strcmp(op, CRM_OP_LRM_REFRESH) == 0) // @COMPAT
                || (strcmp(op, CRM_OP_REPROBE) == 0)) {
 
         crm_xml_add(stored_msg, F_CRM_SYS_TO, CRM_SYSTEM_LRMD);

--- a/daemons/controld/controld_metadata.c
+++ b/daemons/controld/controld_metadata.c
@@ -348,6 +348,11 @@ controld_get_rsc_metadata(lrm_state_t *lrm_state, const lrmd_rsc_info_t *rsc,
             free(key);
         }
         if (metadata != NULL) {
+            crm_debug("Retrieved metadata for %s (%s%s%s:%s) from cache",
+                      rsc->id, rsc->standard,
+                      ((rsc->provider == NULL)? "" : ":"),
+                      ((rsc->provider == NULL)? "" : rsc->provider),
+                      rsc->type);
             return metadata;
         }
     }
@@ -370,6 +375,11 @@ controld_get_rsc_metadata(lrm_state_t *lrm_state, const lrmd_rsc_info_t *rsc,
      * means that if the metadata action tries to contact the controller,
      * everything will hang until the timeout).
      */
+    crm_debug("Retrieving metadata for %s (%s%s%s:%s) synchronously",
+              rsc->id, rsc->standard,
+              ((rsc->provider == NULL)? "" : ":"),
+              ((rsc->provider == NULL)? "" : rsc->provider),
+              rsc->type);
     rc = lrm_state_get_metadata(lrm_state, rsc->standard, rsc->provider,
                                 rsc->type, &metadata_str, 0);
     if (rc != pcmk_ok) {

--- a/daemons/controld/controld_metadata.h
+++ b/daemons/controld/controld_metadata.h
@@ -73,9 +73,9 @@ void metadata_cache_free(GHashTable *mdc);
 void metadata_cache_reset(GHashTable *mdc);
 void metadata_cache_fini(void);
 
-struct ra_metadata_s *metadata_cache_update(GHashTable *mdc,
-                                            const lrmd_rsc_info_t *rsc,
-                                            const char *metadata_str);
+struct ra_metadata_s *controld_cache_metadata(GHashTable *mdc,
+                                              const lrmd_rsc_info_t *rsc,
+                                              const char *metadata_str);
 struct ra_metadata_s *controld_get_rsc_metadata(lrm_state_t *lrm_state,
                                                 const lrmd_rsc_info_t *rsc,
                                                 uint32_t source);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -550,8 +550,8 @@ stonith_device_execute(stonith_device_t * device)
     /* for async exec, exec_rc is negative for early error exit
        otherwise handling of success/errors is done via callbacks */
     cmd->activating_on = device;
-    exec_rc = stonith_action_execute_async(action, (void *)cmd,
-                                           cmd->done_cb, fork_cb);
+    exec_rc = stonith__execute_async(action, (void *)cmd, cmd->done_cb,
+                                     fork_cb);
     if (exec_rc < 0) {
         cmd->activating_on = NULL;
         cmd->done_cb(0, stonith__action_result(action), cmd);

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -146,7 +146,7 @@ extern char *crm_system_name;
 #  define CRM_OP_REGISTER		"register"
 #  define CRM_OP_IPC_FWD		"ipc_fwd"
 #  define CRM_OP_INVOKE_LRM	"lrm_invoke"
-#  define CRM_OP_LRM_REFRESH	"lrm_refresh" /* Deprecated */
+#  define CRM_OP_LRM_REFRESH "lrm_refresh" //!< Deprecated since 1.1.10
 #  define CRM_OP_LRM_QUERY	"lrm_query"
 #  define CRM_OP_LRM_DELETE	"lrm_delete"
 #  define CRM_OP_LRM_FAIL		"lrm_fail"

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -147,7 +147,6 @@ extern char *crm_system_name;
 #  define CRM_OP_IPC_FWD		"ipc_fwd"
 #  define CRM_OP_INVOKE_LRM	"lrm_invoke"
 #  define CRM_OP_LRM_REFRESH "lrm_refresh" //!< Deprecated since 1.1.10
-#  define CRM_OP_LRM_QUERY	"lrm_query"
 #  define CRM_OP_LRM_DELETE	"lrm_delete"
 #  define CRM_OP_LRM_FAIL		"lrm_fail"
 #  define CRM_OP_PROBED		"probe_complete"

--- a/include/crm/crm_compat.h
+++ b/include/crm/crm_compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -30,6 +30,9 @@ extern "C" {
 
 //! \deprecated This defined constant will be removed in a future release
 #define MAX_IPC_DELAY 120
+
+//! \deprecated This defined constant will be removed in a future release
+#define CRM_OP_LRM_QUERY "lrm_query"
 
 //!@{
 //! \deprecated This macro will be removed in a future release

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -52,10 +52,10 @@ struct stonith_action_s;
 typedef struct stonith_action_s stonith_action_t;
 
 stonith_action_t *stonith__action_create(const char *agent,
-                                         const char *_action,
+                                         const char *action_name,
                                          const char *target,
                                          uint32_t target_nodeid,
-                                         int timeout,
+                                         int timeout_sec,
                                          GHashTable *device_args,
                                          GHashTable *port_map,
                                          const char *host_arg);

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -72,6 +72,12 @@ int stonith__execute_async(stonith_action_t *action, void *userdata,
                                          void *user_data),
                            void (*fork_cb) (int pid, void *user_data));
 
+int stonith__metadata_async(const char *agent, int timeout_sec,
+                            void (*callback)(int pid,
+                                             const pcmk__action_result_t *result,
+                                             void *user_data),
+                            void *user_data);
+
 xmlNode *create_level_registration_xml(const char *node, const char *pattern,
                                        const char *attr, const char *value,
                                        int level,

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -66,13 +66,11 @@ void stonith__xe_set_result(xmlNode *xml, const pcmk__action_result_t *result);
 void stonith__xe_get_result(xmlNode *xml, pcmk__action_result_t *result);
 xmlNode *stonith__find_xe_with_result(xmlNode *xml);
 
-int
-stonith_action_execute_async(stonith_action_t * action,
-                             void *userdata,
-                             void (*done) (int pid,
-                                           const pcmk__action_result_t *result,
-                                           void *user_data),
-                             void (*fork_cb) (int pid, void *user_data));
+int stonith__execute_async(stonith_action_t *action, void *userdata,
+                           void (*done) (int pid,
+                                         const pcmk__action_result_t *result,
+                                         void *user_data),
+                           void (*fork_cb) (int pid, void *user_data));
 
 xmlNode *create_level_registration_xml(const char *node, const char *pattern,
                                        const char *attr, const char *value,

--- a/include/crm/lrmd_internal.h
+++ b/include/crm/lrmd_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the Pacemaker project contributors
+ * Copyright 2015-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -17,7 +17,7 @@
 #include <crm/common/mainloop.h>        // mainloop_io_t, ipc_client_callbacks
 #include <crm/common/output_internal.h> // pcmk__output_t
 #include <crm/common/remote_internal.h> // pcmk__remote_t
-#include <crm/lrmd.h>                   // lrmd_t, lrmd_event_data_t
+#include <crm/lrmd.h>           // lrmd_t, lrmd_event_data_t, lrmd_rsc_info_t
 
 int lrmd__new(lrmd_t **api, const char *nodename, const char *server, int port);
 
@@ -34,6 +34,12 @@ int lrmd_send_resource_alert(lrmd_t *lrmd, GList *alert_list,
 
 int lrmd__remote_send_xml(pcmk__remote_t *session, xmlNode *msg, uint32_t id,
                           const char *msg_type);
+
+int lrmd__metadata_async(lrmd_rsc_info_t *rsc,
+                         void (*callback)(int pid,
+                                          const pcmk__action_result_t *result,
+                                          void *user_data),
+                         void *user_data);
 
 void lrmd__set_result(lrmd_event_data_t *event, enum ocf_exitcode rc,
                       int op_status, const char *exit_reason);

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -206,14 +206,21 @@ typedef struct stonith_api_operations_s
         stonith_t *st, int options, const char *node, int level, stonith_key_value_t *device_list);
 
     /*!
-     * \brief Get the metadata documentation for a resource.
+     * \brief Retrieve a fence agent's metadata
      *
-     * \note Value is returned in output.  Output must be freed when set.
+     * \param[in,out] stonith       Fencer connection
+     * \param[in]     call_options  Group of enum stonith_call_options
+     *                              (currently ignored)
+     * \param[in]     agent         Fence agent to query
+     * \param[in]     namespace     Namespace of fence agent to query (optional)
+     * \param[out]    output        Where to store metadata
+     * \param[in]     timeout_sec   Error if not complete within this time
      *
      * \return Legacy Pacemaker return code
+     * \note The caller is responsible for freeing *output using free().
      */
-    int (*metadata)(stonith_t *st, int options,
-            const char *device, const char *provider, char **output, int timeout);
+    int (*metadata)(stonith_t *stonith, int call_options, const char *agent,
+                    const char *namespace, char **output, int timeout_sec);
 
     /*!
      * \brief Retrieve a list of installed stonith agents

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -744,6 +744,8 @@ pcmk_rc2exitc(int rc)
         case pcmk_rc_multiple:
             return CRM_EX_MULTIPLE;
 
+        case ENODEV:
+        case ENOENT:
         case ENXIO:
         case pcmk_rc_node_unknown:
         case pcmk_rc_unknown_format:

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -668,12 +668,11 @@ internal_stonith_action_execute(stonith_action_t * action)
  * \return pcmk_ok if ownership of action has been taken, -errno otherwise
  */
 int
-stonith_action_execute_async(stonith_action_t * action,
-                             void *userdata,
-                             void (*done) (int pid,
-                                           const pcmk__action_result_t *result,
-                                           void *user_data),
-                             void (*fork_cb) (int pid, void *user_data))
+stonith__execute_async(stonith_action_t * action, void *userdata,
+                       void (*done) (int pid,
+                                     const pcmk__action_result_t *result,
+                                     void *user_data),
+                       void (*fork_cb) (int pid, void *user_data))
 {
     if (!action) {
         return -EINVAL;

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -9,6 +9,7 @@
 
 #include <crm_internal.h>
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -31,7 +32,7 @@ struct stonith_action_s {
     char *action;
     GHashTable *args;
     int timeout;
-    int async;
+    bool async;
     void *userdata;
     void (*done_cb) (int pid, const pcmk__action_result_t *result,
                      void *user_data);
@@ -681,7 +682,7 @@ stonith_action_execute_async(stonith_action_t * action,
     action->userdata = userdata;
     action->done_cb = done;
     action->fork_cb = fork_cb;
-    action->async = 1;
+    action->async = true;
 
     return internal_stonith_action_execute(action);
 }

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -502,10 +502,11 @@ stonith_api_device_list(stonith_t * stonith, int call_options, const char *names
     return count;
 }
 
+// See stonith_api_operations_t:metadata() documentation
 static int
-stonith_api_device_metadata(stonith_t * stonith, int call_options, const char *agent,
-                            const char *namespace, char **output,
-                            int timeout_sec)
+stonith_api_device_metadata(stonith_t *stonith, int call_options,
+                            const char *agent, const char *namespace,
+                            char **output, int timeout_sec)
 {
     /* By executing meta-data directly, we can get it from stonith_admin when
      * the cluster is not running, which is important for higher-level tools.

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -2489,7 +2489,7 @@ stonith__metadata_async(const char *agent, int timeout_sec,
         default:
             {
                 pcmk__action_result_t result = {
-                    .exit_status = CRM_EX_ERROR,
+                    .exit_status = CRM_EX_NOSUCH,
                     .execution_status = PCMK_EXEC_ERROR_HARD,
                     .exit_reason = crm_strdup_printf("No such agent '%s'",
                                                      agent),

--- a/lib/fencing/st_rhcs.c
+++ b/lib/fencing/st_rhcs.c
@@ -112,25 +112,24 @@ stonith_rhcs_parameter_not_required(xmlNode *metadata, const char *parameter)
 }
 
 /*!
- * \brief Execute RHCS-compatible agent's meta-data action
+ * \brief Execute RHCS-compatible agent's metadata action
  *
- * \param[in]  agent    Agent to execute
- * \param[in]  timeout  Action timeout
- * \param[out] metadata Where to store output xmlNode (or NULL to ignore)
- *
- * \todo timeout is currently ignored; shouldn't we use it?
+ * \param[in]  agent        Agent to execute
+ * \param[in]  timeout_sec  Action timeout
+ * \param[out] metadata     Where to store output xmlNode (or NULL to ignore)
  */
 static int
-stonith__rhcs_get_metadata(const char *agent, int timeout, xmlNode **metadata)
+stonith__rhcs_get_metadata(const char *agent, int timeout_sec,
+                           xmlNode **metadata)
 {
     xmlNode *xml = NULL;
     xmlNode *actions = NULL;
     xmlXPathObject *xpathObj = NULL;
-    pcmk__action_result_t *result = NULL;
     stonith_action_t *action = stonith__action_create(agent, "metadata", NULL,
-                                                      0, 5, NULL, NULL, NULL);
+                                                      0, timeout_sec, NULL,
+                                                      NULL, NULL);
     int rc = stonith__execute(action);
-    result = stonith__action_result(action);
+    pcmk__action_result_t *result = stonith__action_result(action);
 
     if (result == NULL) {
         if (rc < 0) {
@@ -208,21 +207,19 @@ stonith__rhcs_get_metadata(const char *agent, int timeout, xmlNode **metadata)
 }
 
 /*!
- * \brief Execute RHCS-compatible agent's meta-data action
+ * \brief Retrieve metadata for RHCS-compatible fence agent
  *
- * \param[in]  agent    Agent to execute
- * \param[in]  timeout  Action timeout
- * \param[out] output   Where to store action output (or NULL to ignore)
- *
- * \todo timeout is currently ignored; shouldn't we use it?
+ * \param[in]  agent        Agent to execute
+ * \param[in]  timeout_sec  Action timeout
+ * \param[out] output       Where to store action output (or NULL to ignore)
  */
 int
-stonith__rhcs_metadata(const char *agent, int timeout, char **output)
+stonith__rhcs_metadata(const char *agent, int timeout_sec, char **output)
 {
     char *buffer = NULL;
     xmlNode *xml = NULL;
 
-    int rc = stonith__rhcs_get_metadata(agent, timeout, &xml);
+    int rc = stonith__rhcs_get_metadata(agent, timeout_sec, &xml);
 
     if (rc != pcmk_ok) {
         free_xml(xml);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -2402,7 +2402,8 @@ lrmd__metadata_async(lrmd_rsc_info_t *rsc,
     CRM_CHECK(callback != NULL, return EINVAL);
 
     if ((rsc == NULL) || (rsc->standard == NULL) || (rsc->type == NULL)) {
-        pcmk__set_result(&result, PCMK_OCF_NOT_CONFIGURED, PCMK_EXEC_ERROR,
+        pcmk__set_result(&result, PCMK_OCF_NOT_CONFIGURED,
+                         PCMK_EXEC_ERROR_FATAL,
                          "Invalid resource specification");
         callback(0, &result, user_data);
         pcmk__reset_result(&result);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -2416,11 +2416,11 @@ lrmd__metadata_async(lrmd_rsc_info_t *rsc,
                                        callback, user_data);
     }
 
-    action = services__create_resource_action(rsc->type, rsc->standard,
-                                              rsc->provider, rsc->type,
-                                              CRMD_ACTION_METADATA, 0,
-                                              CRMD_METADATA_CALL_TIMEOUT, NULL,
-                                              0);
+    action = services__create_resource_action(pcmk__s(rsc->id, rsc->type),
+                                              rsc->standard, rsc->provider,
+                                              rsc->type, CRMD_ACTION_METADATA,
+                                              0, CRMD_METADATA_CALL_TIMEOUT,
+                                              NULL, 0);
     if (action == NULL) {
         pcmk__set_result(&result, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
                          "Out of memory");

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -2343,6 +2343,121 @@ lrmd_api_delete(lrmd_t * lrmd)
     free(lrmd);
 }
 
+struct metadata_cb {
+     void (*callback)(int pid, const pcmk__action_result_t *result,
+                      void *user_data);
+     void *user_data;
+};
+
+/*!
+ * \internal
+ * \brief Process asynchronous metadata completion
+ *
+ * \param[in] action  Metadata action that completed
+ */
+static void
+metadata_complete(svc_action_t *action)
+{
+    struct metadata_cb *metadata_cb = (struct metadata_cb *) action->cb_data;
+    pcmk__action_result_t result = PCMK__UNKNOWN_RESULT;
+
+    pcmk__set_result(&result, action->rc, action->status,
+                     services__exit_reason(action));
+    pcmk__set_result_output(&result, action->stdout_data, action->stderr_data);
+
+    metadata_cb->callback(0, &result, metadata_cb->user_data);
+    result.action_stdout = NULL; // Prevent free, because action owns it
+    result.action_stderr = NULL; // Prevent free, because action owns it
+    pcmk__reset_result(&result);
+    free(metadata_cb);
+}
+
+/*!
+ * \internal
+ * \brief Retrieve agent metadata asynchronously
+ *
+ * \param[in] rsc        Resource agent specification
+ * \param[in] callback   Function to call with result (this will always be
+ *                       called, whether by this function directly or later via
+ *                       the main loop, and on success the metadata will be in
+ *                       its result argument's action_stdout)
+ * \param[in] user_data  User data to pass to callback
+ *
+ * \return Standard Pacemaker return code
+ * \note This function is not a lrmd_api_operations_t method because it does not
+ *       need an lrmd_t object and does not go through the executor, but
+ *       executes the agent directly.
+ */
+int
+lrmd__metadata_async(lrmd_rsc_info_t *rsc,
+                     void (*callback)(int pid,
+                                      const pcmk__action_result_t *result,
+                                      void *user_data),
+                     void *user_data)
+{
+    svc_action_t *action = NULL;
+    struct metadata_cb *metadata_cb = NULL;
+    pcmk__action_result_t result = PCMK__UNKNOWN_RESULT;
+
+    CRM_CHECK(callback != NULL, return EINVAL);
+
+    if ((rsc == NULL) || (rsc->standard == NULL) || (rsc->type == NULL)) {
+        pcmk__set_result(&result, PCMK_OCF_NOT_CONFIGURED, PCMK_EXEC_ERROR,
+                         "Invalid resource specification");
+        callback(0, &result, user_data);
+        pcmk__reset_result(&result);
+        return EINVAL;
+    }
+
+    if (strcmp(rsc->standard, PCMK_RESOURCE_CLASS_STONITH) == 0) {
+        return stonith__metadata_async(rsc->type,
+                                       CRMD_METADATA_CALL_TIMEOUT / 1000,
+                                       callback, user_data);
+    }
+
+    action = services__create_resource_action(rsc->type, rsc->standard,
+                                              rsc->provider, rsc->type,
+                                              CRMD_ACTION_METADATA, 0,
+                                              CRMD_METADATA_CALL_TIMEOUT, NULL,
+                                              0);
+    if (action == NULL) {
+        pcmk__set_result(&result, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                         "Out of memory");
+        callback(0, &result, user_data);
+        pcmk__reset_result(&result);
+        return ENOMEM;
+    }
+    if (action->rc != PCMK_OCF_UNKNOWN) {
+        pcmk__set_result(&result, action->rc, action->status,
+                         services__exit_reason(action));
+        callback(0, &result, user_data);
+        pcmk__reset_result(&result);
+        services_action_free(action);
+        return EINVAL;
+    }
+
+    action->cb_data = calloc(1, sizeof(struct metadata_cb));
+    if (action->cb_data == NULL) {
+        services_action_free(action);
+        pcmk__set_result(&result, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_ERROR,
+                         "Out of memory");
+        callback(0, &result, user_data);
+        pcmk__reset_result(&result);
+        return ENOMEM;
+    }
+
+    metadata_cb = (struct metadata_cb *) action->cb_data;
+    metadata_cb->callback = callback;
+    metadata_cb->user_data = user_data;
+    if (!services_action_async(action, metadata_complete)) {
+        services_action_free(action);
+        return pcmk_rc_error; // @TODO Derive from action->rc and ->status
+    }
+
+    // The services library has taken responsibility for action
+    return pcmk_rc_ok;
+}
+
 /*!
  * \internal
  * \brief Set the result of an executor event

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -446,8 +446,7 @@ create_graph_action(xmlNode *parent, pe_action_t *action, bool skip_details,
 
     } else if (pcmk__str_any_of(action->task,
                                 CRM_OP_SHUTDOWN,
-                                CRM_OP_CLEAR_FAILCOUNT,
-                                CRM_OP_LRM_REFRESH, NULL)) {
+                                CRM_OP_CLEAR_FAILCOUNT, NULL)) {
         action_xml = create_xml_node(parent, XML_GRAPH_TAG_CRM_EVENT);
 
     } else if (pcmk__str_eq(action->task, CRM_OP_LRM_DELETE, pcmk__str_none)) {

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -384,8 +384,6 @@ text2task(const char *task)
         return no_action;
     } else if (pcmk__str_eq(task, CRMD_ACTION_STATUS, pcmk__str_casei)) {
         return no_action;
-    } else if (pcmk__str_eq(task, CRM_OP_LRM_REFRESH, pcmk__str_casei)) {
-        return no_action;
     } else if (pcmk__str_eq(task, CRMD_ACTION_MIGRATE, pcmk__str_casei)) {
         return no_action;
     } else if (pcmk__str_eq(task, CRMD_ACTION_MIGRATED, pcmk__str_casei)) {


### PR DESCRIPTION
A longstanding problem has been that the controller executes resource agent metadata actions synchronously. Among the problems with that, it blocks the controller, and if the agent's metadata action attempts to contact the controller, everything hangs until the timeout.

This switches it to asynchronous execution. This is not a comprehensive solution, because there are code paths to getting metadata that could still end up in the synchronous block, but this addresses the most important use case, scheduled resource actions including probe, start, etc. In practice this should mean that metadata is cached before any of the other paths need it.