### PR TITLE
Fix: libpe_status,tools: work with -D_TIME_BITS=64

### DIFF
--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -2565,7 +2565,7 @@ resource_history_text(pcmk__output_t *out, va_list args) {
     const char *rsc_id = va_arg(args, const char *);
     bool all = va_arg(args, int);
     int failcount = va_arg(args, int);
-    time_t last_failure = va_arg(args, int);
+    time_t last_failure = va_arg(args, time_t);
     bool as_header = va_arg(args, int);
 
     char *buf = resource_history_string(rsc, rsc_id, all, failcount, last_failure);
@@ -2587,7 +2587,7 @@ resource_history_xml(pcmk__output_t *out, va_list args) {
     const char *rsc_id = va_arg(args, const char *);
     bool all = va_arg(args, int);
     int failcount = va_arg(args, int);
-    time_t last_failure = va_arg(args, int);
+    time_t last_failure = va_arg(args, time_t);
     bool as_header = va_arg(args, int);
 
     xmlNodePtr node = pcmk__output_xml_create_parent(out, "resource_history",

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1736,7 +1736,7 @@ wait_till_stable(pcmk__output_t *out, int timeout_ms, cib_t * cib)
         /* Abort if timeout is reached */
         time_diff = expire_time - time(NULL);
         if (time_diff > 0) {
-            crm_info("Waiting up to %ld seconds for cluster actions to complete", time_diff);
+            crm_info("Waiting up to %lld seconds for cluster actions to complete", (long long) time_diff);
         } else {
             print_pending_actions(out, data_set->actions);
             pe_free_working_set(data_set);


### PR DESCRIPTION
Fix "time_t val = va_arg(args, int);" which bombs out on 32bit

When using -D_TIME_BITS=64 and without this patch, "make check" fails. Particulary, "cts/cts-cli -t crm_mon" will fail.