### PR TITLE
Clarify pointer arguments in library APIs

### DIFF
--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -145,8 +145,8 @@ typedef struct cib_api_operations_s {
     /*!
      * \brief Set the local CIB manager as the cluster's primary instance
      *
-     * \param[in] cib           CIB connection
-     * \param[in] call_options  Group of enum cib_call_options flags
+     * \param[in,out] cib           CIB connection
+     * \param[in]     call_options  Group of enum cib_call_options flags
      *
      * \return Legacy Pacemaker return code (in particular, pcmk_ok on success)
      */
@@ -155,8 +155,8 @@ typedef struct cib_api_operations_s {
     /*!
      * \brief Set the local CIB manager as a secondary instance
      *
-     * \param[in] cib           CIB connection
-     * \param[in] call_options  Group of enum cib_call_options flags
+     * \param[in,out] cib           CIB connection
+     * \param[in]     call_options  Group of enum cib_call_options flags
      *
      * \return Legacy Pacemaker return code (in particular, pcmk_ok on success)
      */

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -204,7 +204,7 @@ int cib_process_upgrade(const char *op, int options, const char *section, xmlNod
  *                              PCMK__CIB_REQUEST_CREATE,
  *                              PCMK__CIB_REQUEST_MODIFY, and
  *                              PCMK__CIB_REQUEST_REPLACE)
- * \param[in]     existing_cib  Input CIB (used with PCMK__CIB_REQUEST_QUERY)
+ * \param[in,out] existing_cib  Input CIB (used with PCMK__CIB_REQUEST_QUERY)
  * \param[in,out] result_cib    CIB copy to make changes in (used with
  *                              PCMK__CIB_REQUEST_CREATE,
  *                              PCMK__CIB_REQUEST_MODIFY,
@@ -214,9 +214,9 @@ int cib_process_upgrade(const char *op, int options, const char *section, xmlNod
  *
  * \return Legacy Pacemaker return code
  */
-int cib_process_xpath(const char *op, int options, const char *section, xmlNode * req,
-                      xmlNode * input, xmlNode * existing_cib, xmlNode ** result_cib,
-                      xmlNode ** answer);
+int cib_process_xpath(const char *op, int options, const char *section,
+                      const xmlNode *req, xmlNode *input, xmlNode *existing_cib,
+                      xmlNode **result_cib, xmlNode ** answer);
 
 gboolean cib_config_changed(xmlNode * last, xmlNode * next, xmlNode ** diff);
 gboolean update_results(xmlNode * failed, xmlNode * target, const char *operation, int return_code);

--- a/include/crm/common/cmdline_internal.h
+++ b/include/crm/common/cmdline_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the Pacemaker project contributors
+ * Copyright 2019-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -84,7 +84,7 @@ pcmk__free_arg_context(GOptionContext *context);
  *
  * \note This is simply a convenience wrapper to reduce duplication
  */
-void pcmk__add_main_args(GOptionContext *context, GOptionEntry entries[]);
+void pcmk__add_main_args(GOptionContext *context, const GOptionEntry entries[]);
 
 /*!
  * \internal
@@ -100,7 +100,7 @@ void pcmk__add_main_args(GOptionContext *context, GOptionEntry entries[]);
  */
 void pcmk__add_arg_group(GOptionContext *context, const char *name,
                          const char *header, const char *desc,
-                         GOptionEntry entries[]);
+                         const GOptionEntry entries[]);
 
 /*!
  * \internal
@@ -111,8 +111,7 @@ void pcmk__add_arg_group(GOptionContext *context, const char *name,
  * as surrounding arguments containing spaces with quotes and escaping any
  * single quotes in the string.
  *
- * \param[in] argv The command line, typically as returned from
- *                 pcmk__cmdline_preproc.
+ * \param[in,out] argv  Command line (typically from pcmk__cmdline_preproc())
  */
 gchar *pcmk__quote_cmdline(gchar **argv);
 
@@ -156,7 +155,7 @@ gchar *pcmk__quote_cmdline(gchar **argv);
  *                    These letters will all have pre-processing applied.
  */
 gchar **
-pcmk__cmdline_preproc(char **argv, const char *special);
+pcmk__cmdline_preproc(char *const *argv, const char *special);
 
 /*!
  * \internal

--- a/include/crm/common/ipc.h
+++ b/include/crm/common/ipc.h
@@ -97,11 +97,11 @@ typedef struct pcmk_ipc_api_s pcmk_ipc_api_t;
 /*!
  * \brief Callback function type for Pacemaker daemon IPC APIs
  *
- * \param[in] api         IPC API connection
- * \param[in] event_type  The type of event that occurred
- * \param[in] status      Event status
- * \param[in] event_data  Event-specific data
- * \param[in] user_data   Caller data provided when callback was registered
+ * \param[in,out] api         IPC API connection
+ * \param[in]     event_type  The type of event that occurred
+ * \param[in]     status      Event status
+ * \param[in,out] event_data  Event-specific data
+ * \param[in,out] user_data   Caller data provided when callback was registered
  *
  * \note For connection and disconnection events, event_data may be NULL (for
  *       local IPC) or the name of the connected node (for remote IPC, for

--- a/include/crm/common/ipc_attrd_internal.h
+++ b/include/crm/common/ipc_attrd_internal.h
@@ -50,13 +50,13 @@ typedef struct {
  * \internal
  * \brief Send a request to pacemaker-attrd to clear resource failure
  *
- * \param[in] api           pacemaker-attrd IPC object
- * \param[in] node          Affect only this node (or NULL for all nodes)
- * \param[in] resource      Name of resource to clear (or NULL for all)
- * \param[in] operation     Name of operation to clear (or NULL for all)
- * \param[in] interval_spec If operation is not NULL, its interval
- * \param[in] user_name     ACL user to pass to pacemaker-attrd
- * \param[in] options       Bitmask of pcmk__node_attr_opts
+ * \param[in,out] api           pacemaker-attrd IPC object
+ * \param[in]     node          Affect only this node (or NULL for all nodes)
+ * \param[in]     resource      Name of resource to clear (or NULL for all)
+ * \param[in]     operation     Name of operation to clear (or NULL for all)
+ * \param[in]     interval_spec If operation is not NULL, its interval
+ * \param[in]     user_name     ACL user to pass to pacemaker-attrd
+ * \param[in]     options       Bitmask of pcmk__node_attr_opts
  *
  * \note If \p api is NULL, a new temporary connection will be created
  *       just for this operation and destroyed afterwards.  If \p api is
@@ -76,11 +76,11 @@ int pcmk__attrd_api_clear_failures(pcmk_ipc_api_t *api, const char *node,
  *
  * \brief Delete a previously set attribute by setting its value to NULL
  *
- * \param[in] api           Connection to pacemaker-attrd (or NULL to use
- *                          a temporary new connection)
- * \param[in] node          Delete attribute for this node (or NULL for current node)
- * \param[in] name          Attribute name
- * \param[in] options       Bitmask of pcmk__node_attr_opts
+ * \param[in,out] api      Connection to pacemaker-attrd (or NULL to use
+ *                         a temporary new connection)
+ * \param[in]     node     Delete attribute for this node (or NULL for local)
+ * \param[in]     name     Attribute name
+ * \param[in]     options  Bitmask of pcmk__node_attr_opts
  *
  * \return Standard Pacemaker return code
  */
@@ -91,8 +91,8 @@ int pcmk__attrd_api_delete(pcmk_ipc_api_t *api, const char *node, const char *na
  * \internal
  * \brief Purge a node from pacemaker-attrd
  *
- * \param[in] api           pacemaker-attrd IPC object
- * \param[in] node          Node to remove
+ * \param[in,out] api           pacemaker-attrd IPC object
+ * \param[in]     node          Node to remove
  *
  * \note If \p api is NULL, a new temporary connection will be created
  *       just for this operation and destroyed afterwards.  If \p api is
@@ -108,11 +108,11 @@ int pcmk__attrd_api_purge(pcmk_ipc_api_t *api, const char *node);
  * \internal
  * \brief Get the value of an attribute from pacemaker-attrd
  *
- * \param[in] api           Connection to pacemaker-attrd
- * \param[in] node          Look up the attribute for this node
- *                          (or NULL for all nodes)
- * \param[in] name          Attribute name
- * \param[in] options       Bitmask of pcmk__node_attr_opts
+ * \param[in,out] api           Connection to pacemaker-attrd
+ * \param[in]     node          Look up the attribute for this node
+ *                              (or NULL for all nodes)
+ * \param[in]     name          Attribute name
+ * \param[in]     options       Bitmask of pcmk__node_attr_opts
  *
  * \return Standard Pacemaker return code
  */
@@ -123,8 +123,8 @@ int pcmk__attrd_api_query(pcmk_ipc_api_t *api, const char *node, const char *nam
  * \internal
  * \brief Tell pacemaker-attrd to update the CIB with current values
  *
- * \param[in] api           pacemaker-attrd IPC object
- * \param[in] node          Affect only this node (or NULL for all nodes)
+ * \param[in,out] api   pacemaker-attrd IPC object
+ * \param[in]     node  Affect only this node (or NULL for all nodes)
  *
  * \note If \p api is NULL, a new temporary connection will be created
  *       just for this operation and destroyed afterwards.  If \p api is
@@ -140,14 +140,14 @@ int pcmk__attrd_api_refresh(pcmk_ipc_api_t *api, const char *node);
  * \internal
  * \brief Update an attribute's value, time to wait, or both
  *
- * \param[in] api           pacemaker-attrd IPC object
- * \param[in] node          Affect only this node (or NULL for current node)
- * \param[in] name          Attribute name
- * \param[in] value         The attribute's new value, or NULL to unset
- * \param[in] dampen        The new time to wait value, or NULL to unset
- * \param[in] set           ID of attribute set to use (or NULL to choose first)
- * \param[in] user_name     ACL user to pass to pacemaker-attrd
- * \param[in] options       Bitmask of pcmk__node_attr_opts
+ * \param[in,out] api        pacemaker-attrd IPC object
+ * \param[in]     node       Affect only this node (or NULL for current node)
+ * \param[in]     name       Attribute name
+ * \param[in]     value      The attribute's new value, or NULL to unset
+ * \param[in]     dampen     The new time to wait value, or NULL to unset
+ * \param[in]     set        ID of attribute set to use (or NULL for first)
+ * \param[in]     user_name  ACL user to pass to pacemaker-attrd
+ * \param[in]     options    Bitmask of pcmk__node_attr_opts
  *
  * \note If \p api is NULL, a new temporary connection will be created
  *       just for this operation and destroyed afterwards.  If \p api is
@@ -165,12 +165,12 @@ int pcmk__attrd_api_update(pcmk_ipc_api_t *api, const char *node, const char *na
  * \internal
  * \brief Like pcmk__attrd_api_update, but for multiple attributes at once
  *
- * \param[in] api           pacemaker-attrd IPC object
- * \param[in] attrs         A list of pcmk__attr_query_pair_t structs
- * \param[in] dampen        The new time to wait value, or NULL to unset
- * \param[in] set           ID of attribute set to use (or NULL to choose first)
- * \param[in] user_name     ACL user to pass to pacemaker-attrd
- * \param[in] options       Bitmask of pcmk__node_attr_opts
+ * \param[in,out] api        pacemaker-attrd IPC object
+ * \param[in,out] attrs      A list of pcmk__attr_query_pair_t structs
+ * \param[in]     dampen     The new time to wait value, or NULL to unset
+ * \param[in]     set        ID of attribute set to use (or NULL for first)
+ * \param[in]     user_name  ACL user to pass to pacemaker-attrd
+ * \param[in]     options    Bitmask of pcmk__node_attr_opts
  *
  * \note If \p api is NULL, a new temporary connection will be created
  *       just for this operation and destroyed afterwards.  If \p api is

--- a/include/crm/common/ipc_schedulerd.h
+++ b/include/crm/common/ipc_schedulerd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the Pacemaker project contributors
+ * Copyright 2021-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -49,9 +49,9 @@ typedef struct {
 /*!
  * \brief Make an IPC request to the scheduler for the transition graph
  *
- * \param[in]  api IPC API connection
- * \param[in]  cib The CIB to create a transition graph for
- * \param[out] ref The reference ID a response will have
+ * \param[in,out] api  IPC API connection
+ * \param[in]     cib  The CIB to create a transition graph for
+ * \param[out]    ref  The reference ID a response will have
  *
  * \return Standard Pacemaker return code
  */

--- a/include/crm/common/lists_internal.h
+++ b/include/crm/common/lists_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the Pacemaker project contributors
+ * Copyright 2020-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -26,7 +26,8 @@ extern "C" {
  *
  * \return Newly allocated list
  */
-GList* pcmk__subtract_lists(GList *from, GList *items, GCompareFunc cmp);
+GList *pcmk__subtract_lists(GList *from, const GList *items,
+                            GCompareFunc cmp);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/logging.h
+++ b/include/crm/common/logging.h
@@ -113,7 +113,7 @@ void crm_log_deinit(void);
  * \param[in] argc    The number of command line parameters
  * \param[in] argv    The command line parameter values
  */
-void crm_log_preinit(const char *entity, int argc, char **argv);
+void crm_log_preinit(const char *entity, int argc, char *const *argv);
 gboolean crm_log_init(const char *entity, uint8_t level, gboolean daemon,
                       gboolean to_stderr, int argc, char **argv, gboolean quiet);
 

--- a/include/crm/common/mainloop.h
+++ b/include/crm/common/mainloop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2021 the Pacemaker project contributors
+ * Copyright 2009-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -86,7 +86,7 @@ struct ipc_client_callbacks {
     /*!
      * \brief Destroy function for mainloop IPC connection client data
      *
-     * \param[in] userdata  User data passed when creating mainloop source
+     * \param[in,out] userdata  User data passed when creating mainloop source
      */
     void (*destroy) (gpointer userdata);
 };
@@ -131,7 +131,7 @@ struct mainloop_fd_callbacks {
     /*!
      * \brief Dispatch function for mainloop file descriptor with data ready
      *
-     * \param[in] userdata  User data passed when creating mainloop source
+     * \param[in,out] userdata  User data passed when creating mainloop source
      *
      * \return Negative value to remove source, anything else to keep it
      */
@@ -140,7 +140,7 @@ struct mainloop_fd_callbacks {
     /*!
      * \brief Destroy function for mainloop file descriptor client data
      *
-     * \param[in] userdata  User data passed when creating mainloop source
+     * \param[in,out] userdata  User data passed when creating mainloop source
      */
     void (*destroy) (gpointer userdata);
 };

--- a/include/crm/common/messages_internal.h
+++ b/include/crm/common/messages_internal.h
@@ -87,7 +87,7 @@ void pcmk__reset_request(pcmk__request_t *request);
  *         if unknown
  */
 static inline const char *
-pcmk__request_origin_type(pcmk__request_t *request)
+pcmk__request_origin_type(const pcmk__request_t *request)
 {
     if ((request != NULL) && (request->ipc_client != NULL)) {
         return "client";
@@ -108,7 +108,7 @@ pcmk__request_origin_type(pcmk__request_t *request)
  *         "(unspecified)" if unknown
  */
 static inline const char *
-pcmk__request_origin(pcmk__request_t *request)
+pcmk__request_origin(const pcmk__request_t *request)
 {
     if ((request != NULL) && (request->ipc_client != NULL)) {
         return pcmk__client_name(request->ipc_client);

--- a/include/crm/common/nvpair.h
+++ b/include/crm/common/nvpair.h
@@ -73,7 +73,7 @@ char *crm_element_value_copy(const xmlNode *data, const char *name);
  * \return Pointer to copied value (from source)
  */
 static inline const char *
-crm_copy_xml_element(xmlNode *obj1, xmlNode *obj2, const char *element)
+crm_copy_xml_element(const xmlNode *obj1, xmlNode *obj2, const char *element)
 {
     const char *value = crm_element_value(obj1, element);
 

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -61,6 +61,9 @@ typedef pcmk__output_t * (*pcmk__output_factory_t)(char **argv);
  * In general, however, 0 should be returned on success and a positive value
  * on error.
  *
+ * \param[in,out] out   Output object to use to display message
+ * \param[in,out] args  Message-specific arguments needed
+ *
  * \note These functions must not call va_start or va_end - that is done
  *       automatically before the custom formatting function is called.
  */
@@ -468,7 +471,7 @@ struct pcmk__output_s {
      * \note This takes into account both the \p quiet value as well as the
      *       current formatter.
      *
-     * \param[in] out The output functions structure.
+     * \param[in,out] out The output functions structure.
      *
      * \return true if output should be supressed, false otherwise.
      */
@@ -478,7 +481,7 @@ struct pcmk__output_s {
      * \internal
      * \brief Output a spacer.  Not all formatters will do this.
      *
-     * \param[in] out The output functions structure.
+     * \param[in,out] out The output functions structure.
      */
     void (*spacer) (pcmk__output_t *out);
 
@@ -487,9 +490,9 @@ struct pcmk__output_s {
      * \brief Output a progress indicator.  This is likely only useful for
      *        plain text, console based formatters.
      *
-     * \param[in] out The output functions structure.
-     * \param[in] end If true, output a newline afterwards.  This should
-     *                only be used the last time this function is called.
+     * \param[in,out] out  The output functions structure
+     * \param[in]     end  If true, output a newline afterwards (this should
+     *                     only be used the last time this function is called)
      *
      */
     void (*progress) (pcmk__output_t *out, bool end);
@@ -577,7 +580,8 @@ int pcmk__output_new(pcmk__output_t **out, const char *fmt_name,
  */
 int
 pcmk__register_format(GOptionGroup *group, const char *name,
-                      pcmk__output_factory_t create, GOptionEntry *options);
+                      pcmk__output_factory_t create,
+                      const GOptionEntry *options);
 
 /*!
  * \internal
@@ -591,7 +595,8 @@ pcmk__register_format(GOptionGroup *group, const char *name,
  *
  */
 void
-pcmk__register_formats(GOptionGroup *group, pcmk__supported_format_t *table);
+pcmk__register_formats(GOptionGroup *group,
+                       const pcmk__supported_format_t *table);
 
 /*!
  * \internal
@@ -628,7 +633,8 @@ pcmk__register_message(pcmk__output_t *out, const char *message_id,
  *                      all be registered.  This array must be NULL-terminated.
  */
 void
-pcmk__register_messages(pcmk__output_t *out, pcmk__message_entry_t *table);
+pcmk__register_messages(pcmk__output_t *out,
+                        const pcmk__message_entry_t *table);
 
 /* Functions that are useful for implementing custom message formatters */
 
@@ -788,11 +794,11 @@ pcmk__output_create_xml_text_node(pcmk__output_t *out, const char *name, const c
  * other formatting functions will have their nodes added as children of this new
  * parent.
  *
- * \param[in,out] out  The output functions structure.
- * \param[in]     node The node to be added/
+ * \param[in,out] out     The output functions structure
+ * \param[in]     parent  XML node to add
  */
 void
-pcmk__output_xml_push_parent(pcmk__output_t *out, xmlNodePtr node);
+pcmk__output_xml_push_parent(pcmk__output_t *out, xmlNodePtr parent);
 
 /*!
  * \internal
@@ -870,7 +876,7 @@ G_GNUC_NULL_TERMINATED;
  *
  * \param[in,out] error A GError object potentially containing some error.
  *                      If NULL, do nothing.
- * \param[in]     out   The output functions structure.  If NULL, any errors
+ * \param[in,out] out   The output functions structure.  If NULL, any errors
  *                      will simply be printed to stderr.
  */
 void pcmk__output_and_clear_error(GError *error, pcmk__output_t *out);

--- a/include/crm/common/remote_internal.h
+++ b/include/crm/common/remote_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the Pacemaker project contributors
+ * Copyright 2008-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -37,8 +37,8 @@ int pcmk__read_handshake_data(pcmk__client_t *client);
  * \internal
  * \brief Perform client TLS handshake after establishing TCP socket
  *
- * \param[in] remote      Newly established remote connection
- * \param[in] timeout_ms  Abort if entire handshake is not complete within this
+ * \param[in,out] remote      Newly established remote connection
+ * \param[in]     timeout_ms  Abort if handshake is not complete within this
  *
  * \return Standard Pacemaker return code
  */

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -122,8 +122,8 @@ pcmk__intkey_table_lookup(GHashTable *hash_table, int key)
  * \internal
  * \brief Remove a key/value from a hash table with integer keys
  *
- * \param[in] hash_table  Table to modify
- * \param[in] key         Integer key of entry to remove
+ * \param[in,out] hash_table  Table to modify
+ * \param[in]     key         Integer key of entry to remove
  *
  * \return Whether \p key was found and removed from \p hash_table
  */

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -301,11 +301,6 @@ char * crm_xml_escape(const char *text);
 void crm_xml_sanitize_id(char *id);
 void crm_xml_set_id(xmlNode *xml, const char *format, ...) G_GNUC_PRINTF(2, 3);
 
-/*!
- * \brief xmlNode destructor which can be used in glib collections
- */
-void crm_destroy_xml(gpointer data);
-
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
 #include <crm/common/xml_compat.h>
 #endif

--- a/include/crm/common/xml_compat.h
+++ b/include/crm/common/xml_compat.h
@@ -39,6 +39,9 @@ char *xml_get_path(const xmlNode *xml);
 //!  \deprecated Use xml_apply_patchset() instead
 gboolean apply_xml_diff(xmlNode *old_xml, xmlNode *diff, xmlNode **new_xml);
 
+//! \deprecated Do not use (will be removed in a future release)
+void crm_destroy_xml(gpointer data);
+
 //!  \deprecated Use crm_xml_add() with "true" or "false" instead
 static inline const char *
 crm_xml_add_boolean(xmlNode *node, const char *name, gboolean value)

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -268,6 +268,9 @@ pcmk__xe_next(const xmlNode *child)
  * \internal
  * \brief Like pcmk__xe_set_props, but takes a va_list instead of
  *        arguments directly.
+ *
+ * \param[in,out] node   XML to add attributes to
+ * \param[in]     pairs  NULL-terminated list of name/value pairs to add
  */
 void
 pcmk__xe_set_propv(xmlNodePtr node, va_list pairs);

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -81,12 +81,12 @@ int stonith__metadata_async(const char *agent, int timeout_sec,
 xmlNode *create_level_registration_xml(const char *node, const char *pattern,
                                        const char *attr, const char *value,
                                        int level,
-                                       stonith_key_value_t *device_list);
+                                       const stonith_key_value_t *device_list);
 
 xmlNode *create_device_registration_xml(const char *id,
                                         enum stonith_namespace namespace,
                                         const char *agent,
-                                        stonith_key_value_t *params,
+                                        const stonith_key_value_t *params,
                                         const char *rsc_provides);
 
 void stonith__register_messages(pcmk__output_t *out);

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -150,12 +150,19 @@ typedef struct stonith_callback_data_s {
 typedef struct stonith_api_operations_s
 {
     /*!
-     * \brief Destroy the stonith api structure.
+     * \brief Destroy a fencer connection
+     *
+     * \param[in,out] st  Fencer connection to destroy
      */
     int (*free) (stonith_t *st);
 
     /*!
-     * \brief Connect to the local stonith daemon.
+     * \brief Connect to the local fencer
+     *
+     * \param[in,out] st          Fencer connection to connect
+     * \param[in]     name        Client name to use
+     * \param[out]    stonith_fd  If NULL, use a main loop, otherwise
+     *                            store IPC file descriptor here
      *
      * \return Legacy Pacemaker return code
      */
@@ -164,6 +171,8 @@ typedef struct stonith_api_operations_s
     /*!
      * \brief Disconnect from the local stonith daemon.
      *
+     * \param[in,out] st  Fencer connection to disconnect
+     *
      * \return Legacy Pacemaker return code
      */
     int (*disconnect)(stonith_t *st);
@@ -171,11 +180,14 @@ typedef struct stonith_api_operations_s
     /*!
      * \brief Unregister a fence device with the local fencer
      *
+     * \param[in,out] st       Fencer connection to disconnect
+     * \param[in]     options  Group of enum stonith_call_options
+     * \param[in]     name     ID of fence device to unregister
+     *
      * \return pcmk_ok (if synchronous) or positive call ID (if asynchronous)
      *         on success, otherwise a negative legacy Pacemaker return code
      */
-    int (*remove_device)(
-        stonith_t *st, int options, const char *name);
+    int (*remove_device)(stonith_t *st, int options, const char *name);
 
     /*!
      * \brief Register a fence device with the local fencer
@@ -200,11 +212,16 @@ typedef struct stonith_api_operations_s
     /*!
      * \brief Unregister a fencing level for specified node with local fencer
      *
+     * \param[in,out] st       Fencer connection to use
+     * \param[in]     options  Group of enum stonith_call_options
+     * \param[in]     node     Target node to unregister level for
+     * \param[in]     level    Topology level number to unregister
+     *
      * \return pcmk_ok (if synchronous) or positive call ID (if asynchronous)
      *         on success, otherwise a negative legacy Pacemaker return code
      */
-    int (*remove_level)(
-        stonith_t *st, int options, const char *node, int level);
+    int (*remove_level)(stonith_t *st, int options, const char *node,
+                        int level);
 
     /*!
      * \brief Register a fencing level for specified node with local fencer
@@ -228,7 +245,10 @@ typedef struct stonith_api_operations_s
      * \param[in]     call_options  Group of enum stonith_call_options
      *                              (currently ignored)
      * \param[in]     agent         Fence agent to query
-     * \param[in]     namespace     Namespace of fence agent to query (optional)
+     * \param[in]     namespace     Type of fence agent to search for ("redhat"
+     *                              or "stonith-ng" for RHCS-style, "internal"
+     *                              for Pacemaker-internal devices, "heartbeat"
+     *                              for LHA-style, or "any" or NULL for any)
      * \param[out]    output        Where to store metadata
      * \param[in]     timeout_sec   Error if not complete within this time
      *
@@ -239,144 +259,210 @@ typedef struct stonith_api_operations_s
                     const char *namespace, char **output, int timeout_sec);
 
     /*!
-     * \brief Retrieve a list of installed stonith agents
+     * \brief Retrieve a list of installed fence agents
      *
-     * \note if provider is not provided, all known agents will be returned
-     * \note list must be freed using stonith_key_value_freeall()
-     * \note call_options parameter is not used, it is reserved for future use.
+     * \param[in,out] stonith       Fencer connection to use
+     * \param[in]     call_options  Group of enum stonith_call_options
+     *                              (currently ignored)
+     * \param[in]     namespace     Type of fence agents to list ("redhat"
+     *                              or "stonith-ng" for RHCS-style, "internal" for
+     *                              Pacemaker-internal devices, "heartbeat" for
+     *                              LHA-style, or "any" or NULL for all)
+     * \param[out]    devices       Where to store agent list
+     * \param[in]     timeout       Error if unable to complete within this
+     *                              (currently ignored)
      *
      * \return Number of items in list on success, or negative errno otherwise
+     * \note The caller is responsible for freeing the returned list with
+     *       stonith_key_value_freeall().
      */
-    int (*list_agents)(stonith_t *stonith, int call_options, const char *provider,
-            stonith_key_value_t **devices, int timeout);
+    int (*list_agents)(stonith_t *stonith, int call_options,
+                       const char *namespace, stonith_key_value_t **devices,
+                       int timeout);
 
     /*!
-     * \brief Retrieve string listing hosts and port assignments from a local stonith device.
+     * \brief Get the output of a fence device's list action
+     *
+     * \param[in,out] stonith       Fencer connection to use
+     * \param[in]     call_options  Group of enum stonith_call_options
+     * \param[in]     id            Fence device ID to run list for
+     * \param[out]    list_info     Where to store list output
+     * \param[in]     timeout       Error if unable to complete within this
      *
      * \return pcmk_ok (if synchronous) or positive call ID (if asynchronous)
      *         on success, otherwise a negative legacy Pacemaker return code
      */
-    int (*list)(stonith_t *st, int options, const char *id, char **list_output, int timeout);
+    int (*list)(stonith_t *stonith, int call_options, const char *id,
+                char **list_info, int timeout);
 
     /*!
-     * \brief Check to see if a local stonith device is reachable
+     * \brief Check whether a fence device is reachable by monitor action
+     *
+     * \param[in,out] stonith       Fencer connection to use
+     * \param[in]     call_options  Group of enum stonith_call_options
+     * \param[in]     id            Fence device ID to run monitor for
+     * \param[in]     timeout       Error if unable to complete within this
      *
      * \return pcmk_ok (if synchronous) or positive call ID (if asynchronous)
      *         on success, otherwise a negative legacy Pacemaker return code
      */
-    int (*monitor)(stonith_t *st, int options, const char *id, int timeout);
+    int (*monitor)(stonith_t *stonith, int call_options, const char *id,
+                   int timeout);
 
     /*!
-     * \brief Check to see if a local stonith device's port is reachable
+     * \brief Check whether a fence device target is reachable by status action
+     *
+     * \param[in,out] stonith       Fencer connection to use
+     * \param[in]     call_options  Group of enum stonith_call_options
+     * \param[in]     id            Fence device ID to run status for
+     * \param[in]     port          Fence target to run status for
+     * \param[in]     timeout       Error if unable to complete within this
      *
      * \return pcmk_ok (if synchronous) or positive call ID (if asynchronous)
      *         on success, otherwise a negative legacy Pacemaker return code
      */
-    int (*status)(stonith_t *st, int options, const char *id, const char *port, int timeout);
+    int (*status)(stonith_t *stonith, int call_options, const char *id,
+                  const char *port, int timeout);
 
     /*!
-     * \brief Retrieve a list of registered stonith devices.
+     * \brief List registered fence devices
+     *
+     * \param[in,out] stonith       Fencer connection to use
+     * \param[in]     call_options  Group of enum stonith_call_options
+     * \param[in]     target        Fence target to run status for
+     * \param[out]    devices       Where to store list of fence devices
+     * \param[in]     timeout       Error if unable to complete within this
      *
      * \note If node is provided, only devices that can fence the node id
      *       will be returned.
      *
      * \return Number of items in list on success, or negative errno otherwise
      */
-    int (*query)(stonith_t *st, int options, const char *node,
-            stonith_key_value_t **devices, int timeout);
+    int (*query)(stonith_t *stonith, int call_options, const char *target,
+                 stonith_key_value_t **devices, int timeout);
 
     /*!
-     * \brief Issue a fencing action against a node.
+     * \brief Request that a target get fenced
      *
-     * \note Possible actions are, 'on', 'off', and 'reboot'.
-     *
-     * \param st, stonith connection
-     * \param options, call options
-     * \param node, The target node to fence
-     * \param action, The fencing action to take
-     * \param timeout, The default per device timeout to use with each device
-     *                 capable of fencing the target.
+     * \param[in,out] stonith       Fencer connection to use
+     * \param[in]     call_options  Group of enum stonith_call_options
+     * \param[in]     node          Fence target
+     * \param[in]     action        "on", "off", or "reboot"
+     * \param[in]     timeout       Default per-device timeout to use with
+     *                              each executed device
+     * \param[in]     tolerance     Accept result of identical fence action
+     *                              completed within this time
      *
      * \return pcmk_ok (if synchronous) or positive call ID (if asynchronous)
      *         on success, otherwise a negative legacy Pacemaker return code
      */
-    int (*fence)(stonith_t *st, int options, const char *node, const char *action,
-                 int timeout, int tolerance);
+    int (*fence)(stonith_t *stonith, int call_options, const char *node,
+                 const char *action, int timeout, int tolerance);
 
     /*!
-     * \brief Manually confirm that a node is down.
+     * \brief Manually confirm that a node has been fenced
+     *
+     * \param[in,out] stonith       Fencer connection to use
+     * \param[in]     call_options  Group of enum stonith_call_options
+     * \param[in]     target        Fence target
      *
      * \return pcmk_ok (if synchronous) or positive call ID (if asynchronous)
      *         on success, otherwise a negative legacy Pacemaker return code
      */
-    int (*confirm)(stonith_t *st, int options, const char *node);
+    int (*confirm)(stonith_t *stonith, int call_options, const char *target);
 
     /*!
-     * \brief Retrieve a list of fencing operations that have occurred for a specific node.
+     * \brief List fencing actions that have occurred for a target
+     *
+     * \param[in,out] stonith       Fencer connection to use
+     * \param[in]     call_options  Group of enum stonith_call_options
+     * \param[in]     node          Fence target
+     * \param[out]    history       Where to store list of fencing actions
+     * \param[in]     timeout       Error if unable to complete within this
      *
      * \return Legacy Pacemaker return code
      */
-    int (*history)(stonith_t *st, int options, const char *node, stonith_history_t **output, int timeout);
-
-    int (*register_notification)(
-        stonith_t *st, const char *event,
-        void (*notify)(stonith_t *st, stonith_event_t *e));
+    int (*history)(stonith_t *stonith, int call_options, const char *node,
+                   stonith_history_t **history, int timeout);
 
     /*!
-     * \brief Remove a previously registered notification for \c event, or all
-     *        notifications if NULL.
+     * \brief Register a callback for fence notifications
      *
-     * \param[in] st     Fencer connection to use
-     * \param[in] event  The event to remove notifications for (may be NULL).
+     * \param[in,out] stonith       Fencer connection to use
+     * \param[in]     event         Event to register for
+     * \param[in]     callback      Callback to register
      *
      * \return Legacy Pacemaker return code
      */
-    int (*remove_notification)(stonith_t *st, const char *event);
+    int (*register_notification)(stonith_t *stonith, const char *event,
+                                 void (*callback)(stonith_t *st,
+                                                  stonith_event_t *e));
 
     /*!
-     * \brief Register a callback to receive the result of an asynchronous call
+     * \brief Unregister callbacks for fence notifications
      *
-     * \param[in] call_id        The call ID to register callback for
-     * \param[in] timeout        Default time to wait until callback expires
-     * \param[in] options        Bitmask of \c stonith_call_options (respects
-     *                           \c st_opt_timeout_updates and
-     *                           \c st_opt_report_only_success)
-     * \param[in] userdata       Pointer that will be given to callback
-     * \param[in] callback_name  Unique name to identify callback
-     * \param[in] callback       The callback function to register
+     * \param[in,out] stonith  Fencer connection to use
+     * \param[in]     event    Event to unregister callbacks for (NULL for all)
      *
-     * \return \c TRUE on success, \c FALSE if call_id is negative, -errno otherwise
+     * \return Legacy Pacemaker return code
      */
-    int (*register_callback)(stonith_t *st,
-        int call_id,
-        int timeout,
-        int options,
-        void *userdata,
-        const char *callback_name,
-        void (*callback)(stonith_t *st, stonith_callback_data_t *data));
+    int (*remove_notification)(stonith_t *stonith, const char *event);
 
     /*!
-     * \brief Remove a registered callback for a given call id
+     * \brief Register a callback for an asynchronous fencing result
+     *
+     * \param[in,out] stonith        Fencer connection to use
+     * \param[in]     call_id        Call ID to register callback for
+     * \param[in]     timeout        Error if result not received in this time
+     * \param[in]     options        Group of enum stonith_call_options
+     *                               (respects \c st_opt_timeout_updates and
+     *                               \c st_opt_report_only_success)
+     * \param[in,out] user_data      Pointer to pass to callback
+     * \param[in]     callback_name  Unique identifier for callback
+     * \param[in]     callback       Callback to register (may be called
+     *                               immediately if \p call_id indicates error)
+     *
+     * \return \c TRUE on success, \c FALSE if call_id indicates error,
+     *         or -EINVAL if \p stonith is not valid
+     */
+    int (*register_callback)(stonith_t *stonith, int call_id, int timeout,
+                             int options, void *user_data,
+                             const char *callback_name,
+                             void (*callback)(stonith_t *st,
+                                              stonith_callback_data_t *data));
+
+    /*!
+     * \brief Unregister callbacks for asynchronous fencing results
+     *
+     * \param[in,out] stonith        Fencer connection to use
+     * \param[in]     call_id        If \p all_callbacks is false, call ID
+     *                               to unregister callback for
+     * \param[in]     all_callbacks  If true, unregister all callbacks
      *
      * \return pcmk_ok
      */
-    int (*remove_callback)(stonith_t *st, int call_id, bool all_callbacks);
+    int (*remove_callback)(stonith_t *stonith, int call_id, bool all_callbacks);
 
     /*!
      * \brief Unregister fencing level for specified node, pattern or attribute
      *
-     * \param[in] st      Fencer connection to use
-     * \param[in] options Bitmask of stonith_call_options to pass to the fencer
-     * \param[in] node    If not NULL, target level by this node name
-     * \param[in] pattern If not NULL, target by node name using this regex
-     * \param[in] attr    If not NULL, target by this node attribute
-     * \param[in] value   If not NULL, target by this node attribute value
-     * \param[in] level   Index number of level to remove
+     * \param[in,out] st       Fencer connection to use
+     * \param[in]     options  Group of enum stonith_call_options
+     * \param[in]     node     If not NULL, unregister level targeting this node
+     * \param[in]     pattern  If not NULL, unregister level targeting nodes
+     *                         whose names match this regular expression
+     * \param[in]     attr     If this and \p value are not NULL, unregister
+     *                         level targeting nodes with this node attribute
+     *                         set to \p value
+     * \param[in]     value    If this and \p attr are not NULL, unregister
+     *                         level targeting nodes with node attribute \p attr
+     *                         set to this
+     * \param[in]     level    Topology level number to remove
      *
      * \return pcmk_ok (if synchronous) or positive call ID (if asynchronous)
      *         on success, otherwise a negative legacy Pacemaker return code
-     *
-     * \note The caller should set only one of node, pattern or attr/value.
+     * \note The caller should set only one of \p node, \p pattern, or \p attr
+     *       and \p value.
      */
     int (*remove_level_full)(stonith_t *st, int options,
                              const char *node, const char *pattern,
@@ -436,24 +522,26 @@ typedef struct stonith_api_operations_s
                     char **output, char **error_output);
 
     /*!
-     * \brief Issue a fencing action against a node with requested fencing delay.
+     * \brief Request delayed fencing of a target
      *
-     * \note Possible actions are, 'on', 'off', and 'reboot'.
-     *
-     * \param st, stonith connection
-     * \param options, call options
-     * \param node, The target node to fence
-     * \param action, The fencing action to take
-     * \param timeout, The default per device timeout to use with each device
-     *                 capable of fencing the target.
-     * \param delay, Apply a fencing delay. Value -1 means disable also any
-     *               static/random fencing delays from pcmk_delay_base/max
+     * \param[in,out] stonith       Fencer connection to use
+     * \param[in]     call_options  Group of enum stonith_call_options
+     * \param[in]     node          Fence target
+     * \param[in]     action        "on", "off", or "reboot"
+     * \param[in]     timeout       Default per-device timeout to use with
+     *                              each executed device
+     * \param[in]     tolerance     Accept result of identical fence action
+     *                              completed within this time
+     * \param[in]     delay         Execute fencing after this delay (-1
+     *                              disables any delay from pcmk_delay_base
+     *                              and pcmk_delay_max)
      *
      * \return pcmk_ok (if synchronous) or positive call ID (if asynchronous)
      *         on success, otherwise a negative legacy Pacemaker return code
      */
-    int (*fence_with_delay)(stonith_t *st, int options, const char *node, const char *action,
-                            int timeout, int tolerance, int delay);
+    int (*fence_with_delay)(stonith_t *stonith, int call_options,
+                            const char *node, const char *action, int timeout,
+                            int tolerance, int delay);
 
 } stonith_api_operations_t;
 
@@ -595,9 +683,9 @@ stonith_api_time_helper(uint32_t nodeid, bool in_progress)
 bool stonith_agent_exists(const char *agent, int timeout);
 
 /*!
- * \brief Turn stonith action into a more readable string.
+ * \brief Turn fence action into a more readable string
  *
- * \param action Stonith action
+ * \param[in] action  Fence action
  */
 const char *stonith_action_str(const char *action);
 

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -180,12 +180,22 @@ typedef struct stonith_api_operations_s
     /*!
      * \brief Register a fence device with the local fencer
      *
+     * \param[in,out] st         Fencer connection to use
+     * \param[in]     options    Group of enum stonith_call_options
+     * \param[in]     id         ID of fence device to register
+     * \param[in]     namespace  Type of fence agent to search for ("redhat"
+     *                           or "stonith-ng" for RHCS-style, "internal" for
+     *                           Pacemaker-internal devices, "heartbeat" for
+     *                           LHA-style, or "any" or NULL for any)
+     * \param[in]     agent      Name of fence agent for device
+     * \param[in]     params     Fence agent parameters for device
+     *
      * \return pcmk_ok (if synchronous) or positive call ID (if asynchronous)
      *         on success, otherwise a negative legacy Pacemaker return code
      */
-    int (*register_device)(
-        stonith_t *st, int options, const char *id,
-        const char *provider, const char *agent, stonith_key_value_t *params);
+    int (*register_device)(stonith_t *st, int options, const char *id,
+                           const char *namespace, const char *agent,
+                           const stonith_key_value_t *params);
 
     /*!
      * \brief Unregister a fencing level for specified node with local fencer

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -385,14 +385,20 @@ typedef struct stonith_api_operations_s
     /*!
      * \brief Register fencing level for specified node, pattern or attribute
      *
-     * \param[in] st          Fencer connection to use
-     * \param[in] options     Bitmask of stonith_call_options to pass to fencer
-     * \param[in] node        If not NULL, target level by this node name
-     * \param[in] pattern     If not NULL, target by node name using this regex
-     * \param[in] attr        If not NULL, target by this node attribute
-     * \param[in] value       If not NULL, target by this node attribute value
-     * \param[in] level       Index number of level to add
-     * \param[in] device_list Devices to use in level
+     * \param[in,out] st           Fencer connection to use
+     * \param[in]     options      Group of enum stonith_call_options
+     * \param[in]     node         If not NULL, register level targeting this
+     *                             node by name
+     * \param[in]     pattern      If not NULL, register level targeting nodes
+     *                             whose names match this regular expression
+     * \param[in]     attr         If this and \p value are not NULL, register
+     *                             level targeting nodes with this node
+     *                             attribute set to \p value
+     * \param[in]     value        If this and \p attr are not NULL, register
+     *                             level targeting nodes with node attribute
+     *                             \p attr set to this
+     * \param[in]     level        Topology level number to remove
+     * \param[in]     device_list  Devices to use in level
      *
      * \return pcmk_ok (if synchronous) or positive call ID (if asynchronous)
      *         on success, otherwise a negative legacy Pacemaker return code
@@ -401,8 +407,8 @@ typedef struct stonith_api_operations_s
      */
     int (*register_level_full)(stonith_t *st, int options,
                                const char *node, const char *pattern,
-                               const char *attr, const char *value,
-                               int level, stonith_key_value_t *device_list);
+                               const char *attr, const char *value, int level,
+                               const stonith_key_value_t *device_list);
 
     /*!
      * \brief Validate an arbitrary stonith device configuration

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -413,25 +413,27 @@ typedef struct stonith_api_operations_s
     /*!
      * \brief Validate an arbitrary stonith device configuration
      *
-     * \param[in]  st            Stonithd connection to use
-     * \param[in]  call_options  Bitmask of stonith_call_options to use with fencer
-     * \param[in]  rsc_id        ID used to replace CIB secrets in params
-     * \param[in]  namespace_s   Namespace of fence agent to validate (optional)
-     * \param[in]  agent         Fence agent to validate
-     * \param[in]  params        Configuration parameters to pass to fence agent
-     * \param[in]  timeout       Fail if no response within this many seconds
-     * \param[out] output        If non-NULL, where to store any agent output
-     * \param[out] error_output  If non-NULL, where to store agent error output
+     * \param[in,out] st            Fencer connection to use
+     * \param[in]     call_options  Group of enum stonith_call_options
+     * \param[in]     rsc_id        ID used to replace CIB secrets in \p params
+     * \param[in]     namespace_s   Type of fence agent to validate ("redhat"
+     *                              or "stonith-ng" for RHCS-style, "internal"
+     *                              for Pacemaker-internal devices, "heartbeat"
+     *                              for LHA-style, or "any" or NULL for any)
+     * \param[in]     agent         Fence agent to validate
+     * \param[in]     params        Configuration parameters to pass to agent
+     * \param[in]     timeout       Fail if no response within this many seconds
+     * \param[out]    output        If non-NULL, where to store any agent output
+     * \param[out]    error_output  If non-NULL, where to store agent error output
      *
      * \return pcmk_ok if validation succeeds, -errno otherwise
-     *
      * \note If pcmk_ok is returned, the caller is responsible for freeing
-     *       the output (if requested).
+     *       the output (if requested) with free().
      */
     int (*validate)(stonith_t *st, int call_options, const char *rsc_id,
                     const char *namespace_s, const char *agent,
-                    stonith_key_value_t *params, int timeout, char **output,
-                    char **error_output);
+                    const stonith_key_value_t *params, int timeout,
+                    char **output, char **error_output);
 
     /*!
      * \brief Issue a fencing action against a node with requested fencing delay.

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -209,11 +209,17 @@ typedef struct stonith_api_operations_s
     /*!
      * \brief Register a fencing level for specified node with local fencer
      *
+     * \param[in,out] st           Fencer connection to use
+     * \param[in]     options      Group of enum stonith_call_options
+     * \param[in]     node         Target node to register level for
+     * \param[in]     level        Topology level number to register
+     * \param[in]     device_list  Devices to register in level
+     *
      * \return pcmk_ok (if synchronous) or positive call ID (if asynchronous)
      *         on success, otherwise a negative legacy Pacemaker return code
      */
-    int (*register_level)(
-        stonith_t *st, int options, const char *node, int level, stonith_key_value_t *device_list);
+    int (*register_level)(stonith_t *st, int options, const char *node,
+                          int level, const stonith_key_value_t *device_list);
 
     /*!
      * \brief Retrieve a fence agent's metadata

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -689,8 +689,9 @@ cib_config_changed(xmlNode * last, xmlNode * next, xmlNode ** diff)
 }
 
 int
-cib_process_xpath(const char *op, int options, const char *section, xmlNode * req, xmlNode * input,
-                  xmlNode * existing_cib, xmlNode ** result_cib, xmlNode ** answer)
+cib_process_xpath(const char *op, int options, const char *section,
+                  const xmlNode *req, xmlNode *input, xmlNode *existing_cib,
+                  xmlNode **result_cib, xmlNode **answer)
 {
     int lpc = 0;
     int max = 0;

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the Pacemaker project contributors
+ * Copyright 2019-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -123,7 +123,7 @@ pcmk__free_arg_context(GOptionContext *context) {
 }
 
 void
-pcmk__add_main_args(GOptionContext *context, GOptionEntry entries[])
+pcmk__add_main_args(GOptionContext *context, const GOptionEntry entries[])
 {
     GOptionGroup *main_group = g_option_context_get_main_group(context);
 
@@ -133,7 +133,7 @@ pcmk__add_main_args(GOptionContext *context, GOptionEntry entries[])
 void
 pcmk__add_arg_group(GOptionContext *context, const char *name,
                     const char *header, const char *desc,
-                    GOptionEntry entries[])
+                    const GOptionEntry entries[])
 {
     GOptionGroup *group = NULL;
 
@@ -215,7 +215,7 @@ pcmk__quote_cmdline(gchar **argv)
 }
 
 gchar **
-pcmk__cmdline_preproc(char **argv, const char *special) {
+pcmk__cmdline_preproc(char *const *argv, const char *special) {
     GPtrArray *arr = NULL;
     bool saw_dash_dash = false;
     bool copy_option = false;
@@ -267,7 +267,7 @@ pcmk__cmdline_preproc(char **argv, const char *special) {
          */
         if (g_str_has_prefix(argv[i], "-") && !g_str_has_prefix(argv[i], "--")) {
             /* Skip over leading dash */
-            char *ch = argv[i]+1;
+            const char *ch = argv[i]+1;
 
             /* This looks like the start of a number, which means it is a negative
              * number.  It's probably the argument to the preceeding option, but

--- a/lib/common/lists.c
+++ b/lib/common/lists.c
@@ -11,11 +11,11 @@
 #include <crm/common/lists_internal.h>
 
 GList*
-pcmk__subtract_lists(GList *from, GList *items, GCompareFunc cmp)
+pcmk__subtract_lists(GList *from, const GList *items, GCompareFunc cmp)
 {
     GList *result = g_list_copy(from);
 
-    for (GList *item = items; item != NULL; item = item->next) {
+    for (const GList *item = items; item != NULL; item = item->next) {
         GList *match = g_list_find_custom(result, item->data, cmp);
 
         if (match != NULL) {

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -733,7 +733,7 @@ crm_priority2int(const char *name)
  * \param[in] argv    The command line parameter values
  */
 static void
-set_identity(const char *entity, int argc, char **argv)
+set_identity(const char *entity, int argc, char *const *argv)
 {
     if (crm_system_name != NULL) {
         return; // Already set, don't overwrite
@@ -762,7 +762,7 @@ set_identity(const char *entity, int argc, char **argv)
 }
 
 void
-crm_log_preinit(const char *entity, int argc, char **argv)
+crm_log_preinit(const char *entity, int argc, char *const *argv)
 {
     /* Configure libqb logging with nothing turned on */
 

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -89,7 +89,9 @@ pcmk__output_new(pcmk__output_t **out, const char *fmt_name, const char *filenam
 
 int
 pcmk__register_format(GOptionGroup *group, const char *name,
-                      pcmk__output_factory_t create, GOptionEntry *options) {
+                      pcmk__output_factory_t create,
+                      const GOptionEntry *options)
+{
     CRM_ASSERT(create != NULL && !pcmk__str_empty(name));
 
     if (formatters == NULL) {
@@ -105,14 +107,14 @@ pcmk__register_format(GOptionGroup *group, const char *name,
 }
 
 void
-pcmk__register_formats(GOptionGroup *group, pcmk__supported_format_t *formats) {
-    pcmk__supported_format_t *entry = NULL;
-
+pcmk__register_formats(GOptionGroup *group,
+                       const pcmk__supported_format_t *formats)
+{
     if (formats == NULL) {
         return;
     }
-
-    for (entry = formats; entry->name != NULL; entry++) {
+    for (const pcmk__supported_format_t *entry = formats; entry->name != NULL;
+         entry++) {
         pcmk__register_format(group, entry->name, entry->create, entry->options);
     }
 }
@@ -156,10 +158,10 @@ pcmk__register_message(pcmk__output_t *out, const char *message_id,
 }
 
 void
-pcmk__register_messages(pcmk__output_t *out, pcmk__message_entry_t *table) {
-    pcmk__message_entry_t *entry;
-
-    for (entry = table; entry->message_id != NULL; entry++) {
+pcmk__register_messages(pcmk__output_t *out, const pcmk__message_entry_t *table)
+{
+    for (const pcmk__message_entry_t *entry = table; entry->message_id != NULL;
+         entry++) {
         if (pcmk__strcase_any_of(entry->fmt_name, "default", out->fmt_name, NULL)) {
             pcmk__register_message(out, entry->message_id, entry->fn);
         }

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -2969,12 +2969,6 @@ expand_idref(xmlNode * input, xmlNode * top)
     return result;
 }
 
-void
-crm_destroy_xml(gpointer data)
-{
-    free_xml(data);
-}
-
 char *
 pcmk__xml_artefact_root(enum pcmk__xml_artefact_ns ns)
 {
@@ -3085,6 +3079,12 @@ find_entity(xmlNode *parent, const char *node_name, const char *id)
 {
     return pcmk__xe_match(parent, node_name,
                           ((id == NULL)? id : XML_ATTR_ID), id);
+}
+
+void
+crm_destroy_xml(gpointer data)
+{
+    free_xml(data);
 }
 
 // LCOV_EXCL_STOP

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -291,7 +291,8 @@ stonith_connection_destroy(gpointer user_data)
 
 xmlNode *
 create_device_registration_xml(const char *id, enum stonith_namespace namespace,
-                               const char *agent, stonith_key_value_t *params,
+                               const char *agent,
+                               const stonith_key_value_t *params,
                                const char *rsc_provides)
 {
     xmlNode *data = create_xml_node(NULL, F_STONITH_DEVICE);
@@ -325,9 +326,10 @@ create_device_registration_xml(const char *id, enum stonith_namespace namespace,
 }
 
 static int
-stonith_api_register_device(stonith_t * st, int call_options,
-                            const char *id, const char *namespace, const char *agent,
-                            stonith_key_value_t * params)
+stonith_api_register_device(stonith_t *st, int call_options,
+                            const char *id, const char *namespace,
+                            const char *agent,
+                            const stonith_key_value_t *params)
 {
     int rc = 0;
     xmlNode *data = NULL;
@@ -412,7 +414,7 @@ stonith_api_remove_level(stonith_t * st, int options, const char *node, int leve
 xmlNode *
 create_level_registration_xml(const char *node, const char *pattern,
                               const char *attr, const char *value,
-                              int level, stonith_key_value_t *device_list)
+                              int level, const stonith_key_value_t *device_list)
 {
     size_t len = 0;
     char *list = NULL;
@@ -451,10 +453,10 @@ create_level_registration_xml(const char *node, const char *pattern,
 }
 
 static int
-stonith_api_register_level_full(stonith_t * st, int options, const char *node,
-                                const char *pattern,
-                                const char *attr, const char *value,
-                                int level, stonith_key_value_t *device_list)
+stonith_api_register_level_full(stonith_t *st, int options, const char *node,
+                                const char *pattern, const char *attr,
+                                const char *value, int level,
+                                const stonith_key_value_t *device_list)
 {
     int rc = 0;
     xmlNode *data = create_level_registration_xml(node, pattern, attr, value,
@@ -469,7 +471,7 @@ stonith_api_register_level_full(stonith_t * st, int options, const char *node,
 
 static int
 stonith_api_register_level(stonith_t * st, int options, const char *node, int level,
-                           stonith_key_value_t * device_list)
+                           const stonith_key_value_t * device_list)
 {
     return stonith_api_register_level_full(st, options, node, NULL, NULL, NULL,
                                            level, device_list);
@@ -1716,7 +1718,7 @@ stonith_api_delete(stonith_t * stonith)
 static int
 stonith_api_validate(stonith_t *st, int call_options, const char *rsc_id,
                      const char *namespace_s, const char *agent,
-                     stonith_key_value_t *params, int timeout_sec,
+                     const stonith_key_value_t *params, int timeout_sec,
                      char **output, char **error_output)
 {
     /* Validation should be done directly via the agent, so we can get it from


### PR DESCRIPTION
This is not comprehensive but focuses on libcrmcommon, libcib, and libstonithd APIs with doxygen blocks under include/ and some functions called by them.