### PR TITLE
Test: cts-cli: Fix cts-cli crm_mon failures in RPM-installed envs

### DIFF
--- a/cts/Makefile.am
+++ b/cts/Makefile.am
@@ -31,6 +31,7 @@ dist_cli_DATA	= cli/constraints.xml 				\
 		  cli/crm_mon.xml				\
 		  cli/crm_mon-feature_set.xml			\
 		  cli/crm_mon-partial.xml			\
+		  cli/crm_mon-T180.xml				\
 		  cli/crm_mon-unmanaged.xml			\
 		  cli/crm_resource_digests.xml			\
 		  cli/regression.acls.exp			\


### PR DESCRIPTION
The recently added crm_mon-T180.xml file was not added to dist_cli_DATA.