### PR TITLE
libcib, libpe_status: Replace snprintf() with GString

### DIFF
--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -37,8 +37,8 @@ bool pcmk__starts_with(const char *str, const char *prefix);
 bool pcmk__ends_with(const char *s, const char *match);
 bool pcmk__ends_with_ext(const char *s, const char *match);
 char *pcmk__trim(char *str);
-void pcmk__add_separated_word(char **list, size_t *len, const char *word,
-                              const char *separator);
+void pcmk__add_separated_word(GString **list, size_t init_size,
+                              const char *word, const char *separator);
 int pcmk__compress(const char *data, unsigned int length, unsigned int max,
                    char **result, unsigned int *result_len);
 
@@ -151,9 +151,9 @@ pcmk__str_eq(const char *s1, const char *s2, uint32_t flags)
 
 // Like pcmk__add_separated_word() but using a space as separator
 static inline void
-pcmk__add_word(char **list, size_t *len, const char *word)
+pcmk__add_word(GString **list, size_t init_size, const char *word)
 {
-    return pcmk__add_separated_word(list, len, word, " ");
+    return pcmk__add_separated_word(list, init_size, word, " ");
 }
 
 /* Correctly displaying singular or plural is complicated; consider "1 node has"

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -255,9 +255,19 @@ gboolean group_active(pe_resource_t * rsc, gboolean all);
 gboolean clone_active(pe_resource_t * rsc, gboolean all);
 gboolean pe__bundle_active(pe_resource_t *rsc, gboolean all);
 
-void native_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data);
-void group_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data);
-void clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data);
+//! \deprecated This function will be removed in a future release
+void native_print(pe_resource_t *rsc, const char *pre_text, long options,
+                  void *print_data);
+
+//! \deprecated This function will be removed in a future release
+void group_print(pe_resource_t *rsc, const char *pre_text, long options,
+                 void *print_data);
+
+//! \deprecated This function will be removed in a future release
+void clone_print(pe_resource_t *rsc, const char *pre_text, long options,
+                 void *print_data);
+
+//! \deprecated This function will be removed in a future release
 void pe__print_bundle(pe_resource_t *rsc, const char *pre_text, long options,
                       void *print_data);
 
@@ -529,6 +539,7 @@ void pe__clear_resource_flags_on_all(pe_working_set_t *data_set, uint64_t flag);
 
 gboolean add_tag_ref(GHashTable * tags, const char * tag_name,  const char * obj_ref);
 
+//! \deprecated This function will be removed in a future release
 void print_rscs_brief(GList *rsc_list, const char * pre_text, long options,
                       void * print_data, gboolean print_all);
 int pe__rscs_brief_output(pcmk__output_t *out, GList *rsc_list, unsigned int options);
@@ -536,7 +547,10 @@ void pe_fence_node(pe_working_set_t * data_set, pe_node_t * node, const char *re
 
 pe_node_t *pe_create_node(const char *id, const char *uname, const char *type,
                           const char *score, pe_working_set_t * data_set);
-void common_print(pe_resource_t * rsc, const char *pre_text, const char *name, pe_node_t *node, long options, void *print_data);
+
+//! \deprecated This function will be removed in a future release
+void common_print(pe_resource_t *rsc, const char *pre_text, const char *name,
+                  pe_node_t *node, long options, void *print_data);
 int pe__common_output_text(pcmk__output_t *out, pe_resource_t * rsc, const char *name, pe_node_t *node, unsigned int options);
 int pe__common_output_html(pcmk__output_t *out, pe_resource_t * rsc, const char *name, pe_node_t *node, unsigned int options);
 pe_resource_t *pe__find_bundle_replica(const pe_resource_t *bundle,

--- a/lib/common/tests/strings/pcmk__add_word_test.c
+++ b/lib/common/tests/strings/pcmk__add_word_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the Pacemaker project contributors
+ * Copyright 2020-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,75 +14,74 @@
 static void
 add_words(void **state)
 {
-    char *list = NULL;
-    size_t list_len = 0;
+    GString *list = NULL;
 
-    pcmk__add_word(&list, &list_len, "hello");
-    pcmk__add_word(&list, &list_len, "world");
-    assert_int_equal(strcmp(list, "hello world"), 0);
-    free(list);
+    pcmk__add_word(&list, 16, "hello");
+    pcmk__add_word(&list, 16, "world");
+    assert_int_equal(strcmp((const char *) list->str, "hello world"), 0);
+    g_string_free(list, TRUE);
 }
 
 static void
 add_with_no_len(void **state)
 {
-    char *list = NULL;
+    GString *list = NULL;
 
-    pcmk__add_word(&list, NULL, "hello");
-    pcmk__add_word(&list, NULL, "world");
-    assert_int_equal(strcmp(list, "hello world"), 0);
-    free(list);
+    pcmk__add_word(&list, 0, "hello");
+    pcmk__add_word(&list, 0, "world");
+    assert_int_equal(strcmp((const char *) list->str, "hello world"), 0);
+    g_string_free(list, TRUE);
 }
 
 static void
 add_nothing(void **state)
 {
-    char *list = NULL;
+    GString *list = NULL;
 
-    pcmk__add_word(&list, NULL, "hello");
-    pcmk__add_word(&list, NULL, NULL);
-    pcmk__add_word(&list, NULL, "");
-    assert_int_equal(strcmp(list, "hello"), 0);
-    free(list);
+    pcmk__add_word(&list, 0, "hello");
+    pcmk__add_word(&list, 0, NULL);
+    pcmk__add_word(&list, 0, "");
+    assert_int_equal(strcmp((const char *) list->str, "hello"), 0);
+    g_string_free(list, TRUE);
 }
 
 static void
 add_with_null(void **state)
 {
-    char *list = NULL;
-    size_t list_len = 0;
+    GString *list = NULL;
 
-    pcmk__add_separated_word(&list, &list_len, "hello", NULL);
-    pcmk__add_separated_word(&list, &list_len, "world", NULL);
-    pcmk__add_separated_word(&list, &list_len, "I am a unit test", NULL);
-    assert_int_equal(strcmp(list, "hello world I am a unit test"), 0);
-    free(list);
+    pcmk__add_separated_word(&list, 32, "hello", NULL);
+    pcmk__add_separated_word(&list, 32, "world", NULL);
+    pcmk__add_separated_word(&list, 32, "I am a unit test", NULL);
+    assert_int_equal(strcmp((const char *) list->str,
+                            "hello world I am a unit test"), 0);
+    g_string_free(list, TRUE);
 }
 
 static void
 add_with_comma(void **state)
 {
-    char *list = NULL;
-    size_t list_len = 0;
+    GString *list = NULL;
 
-    pcmk__add_separated_word(&list, &list_len, "hello", ",");
-    pcmk__add_separated_word(&list, &list_len, "world", ",");
-    pcmk__add_separated_word(&list, &list_len, "I am a unit test", ",");
-    assert_int_equal(strcmp(list, "hello,world,I am a unit test"), 0);
-    free(list);
+    pcmk__add_separated_word(&list, 32, "hello", ",");
+    pcmk__add_separated_word(&list, 32, "world", ",");
+    pcmk__add_separated_word(&list, 32, "I am a unit test", ",");
+    assert_int_equal(strcmp((const char *) list->str,
+                            "hello,world,I am a unit test"), 0);
+    g_string_free(list, TRUE);
 }
 
 static void
 add_with_comma_and_space(void **state)
 {
-    char *list = NULL;
-    size_t list_len = 0;
+    GString *list = NULL;
 
-    pcmk__add_separated_word(&list, &list_len, "hello", ", ");
-    pcmk__add_separated_word(&list, &list_len, "world", ", ");
-    pcmk__add_separated_word(&list, &list_len, "I am a unit test", ", ");
-    assert_int_equal(strcmp(list, "hello, world, I am a unit test"), 0);
-    free(list);
+    pcmk__add_separated_word(&list, 32, "hello", ", ");
+    pcmk__add_separated_word(&list, 32, "world", ", ");
+    pcmk__add_separated_word(&list, 32, "I am a unit test", ", ");
+    assert_int_equal(strcmp((const char *) list->str,
+                            "hello, world, I am a unit test"), 0);
+    g_string_free(list, TRUE);
 }
 
 PCMK__UNIT_TEST(NULL, NULL,

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -416,8 +416,7 @@ create_level_registration_xml(const char *node, const char *pattern,
                               const char *attr, const char *value,
                               int level, const stonith_key_value_t *device_list)
 {
-    size_t len = 0;
-    char *list = NULL;
+    GString *list = NULL;
     xmlNode *data;
 
     CRM_CHECK(node || pattern || (attr && value), return NULL);
@@ -440,15 +439,14 @@ create_level_registration_xml(const char *node, const char *pattern,
         crm_xml_add(data, XML_ATTR_STONITH_TARGET_VALUE, value);
     }
 
-    // cppcheck seems not to understand the abort logic behind pcmk__realloc
-    // cppcheck-suppress memleak
     for (; device_list; device_list = device_list->next) {
-        pcmk__add_separated_word(&list, &len, device_list->value, ",");
+        pcmk__add_separated_word(&list, 1024, device_list->value, ",");
     }
 
-    crm_xml_add(data, XML_ATTR_STONITH_DEVICES, list);
-
-    free(list);
+    if (list != NULL) {
+        crm_xml_add(data, XML_ATTR_STONITH_DEVICES, (const char *) list->str);
+        g_string_free(list, TRUE);
+    }
     return data;
 }
 

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -50,12 +50,12 @@ next_ip(const char *last_ip)
     return crm_strdup_printf("%u.%u.%u.%u", oct1, oct2, oct3, oct4);
 }
 
-static int
+static void
 allocate_ip(pe__bundle_variant_data_t *data, pe__bundle_replica_t *replica,
-            char *buffer, int max)
+            GString *buffer)
 {
     if(data->ip_range_start == NULL) {
-        return 0;
+        return;
 
     } else if(data->ip_last) {
         replica->ipaddr = next_ip(data->ip_last);
@@ -69,18 +69,20 @@ allocate_ip(pe__bundle_variant_data_t *data, pe__bundle_replica_t *replica,
         case PE__CONTAINER_AGENT_DOCKER:
         case PE__CONTAINER_AGENT_PODMAN:
             if (data->add_host) {
-                return snprintf(buffer, max, " --add-host=%s-%d:%s",
-                                data->prefix, replica->offset,
-                                replica->ipaddr);
+                g_string_append_printf(buffer, " --add-host=%s-%d:%s",
+                                       data->prefix, replica->offset,
+                                       replica->ipaddr);
+                break;
             }
             // fall through
         case PE__CONTAINER_AGENT_RKT:
-            return snprintf(buffer, max, " --hosts-entry=%s=%s-%d",
-                            replica->ipaddr, data->prefix, replica->offset);
+            g_string_append_printf(buffer, " --hosts-entry=%s=%s-%d",
+                                   replica->ipaddr, data->prefix,
+                                   replica->offset);
+            break;
         default: // PE__CONTAINER_AGENT_UNKNOWN
             break;
     }
-    return 0;
 }
 
 static xmlNode *
@@ -176,11 +178,8 @@ create_docker_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
                        pe__bundle_replica_t *replica,
                        pe_working_set_t *data_set)
 {
-        int offset = 0, max = 4096;
-        char *buffer = calloc(1, max+1);
-
-        int doffset = 0, dmax = 1024;
-        char *dbuffer = calloc(1, dmax+1);
+        GString *buffer = g_string_sized_new(4096);
+        GString *dbuffer = g_string_sized_new(1024);
 
         char *id = NULL;
         xmlNode *xml_container = NULL;
@@ -201,7 +200,7 @@ create_docker_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
         crm_create_nvpair_xml(xml_obj, NULL, "force_kill", XML_BOOLEAN_FALSE);
         crm_create_nvpair_xml(xml_obj, NULL, "reuse", XML_BOOLEAN_FALSE);
 
-        offset += snprintf(buffer+offset, max-offset, " --restart=no");
+        g_string_append(buffer, " --restart=no");
 
         /* Set a container hostname only if we have an IP to map it to.
          * The user can set -h or --uts=host themselves if they want a nicer
@@ -209,25 +208,23 @@ create_docker_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
          * hostname to match the IP they bind to.
          */
         if (data->ip_range_start != NULL) {
-            offset += snprintf(buffer+offset, max-offset, " -h %s-%d",
-                               data->prefix, replica->offset);
+            g_string_append_printf(buffer, " -h %s-%d", data->prefix,
+                                   replica->offset);
         }
 
-        offset += snprintf(buffer+offset, max-offset, " -e PCMK_stderr=1");
+        g_string_append(buffer, " -e PCMK_stderr=1");
 
         if (data->container_network) {
-#if 0
-            offset += snprintf(buffer+offset, max-offset, " --link-local-ip=%s",
-                               replica->ipaddr);
-#endif
-            offset += snprintf(buffer+offset, max-offset, " --net=%s",
-                               data->container_network);
+            g_string_append_printf(buffer, " --net=%s",
+                                   data->container_network);
         }
 
         if(data->control_port) {
-            offset += snprintf(buffer+offset, max-offset, " -e PCMK_remote_port=%s", data->control_port);
+            g_string_append_printf(buffer, " -e PCMK_remote_port=%s",
+                                   data->control_port);
         } else {
-            offset += snprintf(buffer+offset, max-offset, " -e PCMK_remote_port=%d", DEFAULT_REMOTE_PORT);
+            g_string_append_printf(buffer, " -e PCMK_remote_port=%d",
+                                   DEFAULT_REMOTE_PORT);
         }
 
         for(GList *pIter = data->mounts; pIter != NULL; pIter = pIter->next) {
@@ -237,18 +234,20 @@ create_docker_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
                 char *source = crm_strdup_printf(
                     "%s/%s-%d", mount->source, data->prefix, replica->offset);
 
-                if(doffset > 0) {
-                    doffset += snprintf(dbuffer+doffset, dmax-doffset, ",");
+                if (dbuffer->len > 0) {
+                    g_string_append_c(dbuffer, ',');
                 }
-                doffset += snprintf(dbuffer+doffset, dmax-doffset, "%s", source);
-                offset += snprintf(buffer+offset, max-offset, " -v %s:%s", source, mount->target);
+                g_string_append(dbuffer, source);
+                g_string_append_printf(buffer, " -v %s:%s", source,
+                                       mount->target);
                 free(source);
 
             } else {
-                offset += snprintf(buffer+offset, max-offset, " -v %s:%s", mount->source, mount->target);
+                g_string_append_printf(buffer, " -v %s:%s", mount->source,
+                                       mount->target);
             }
             if(mount->options) {
-                offset += snprintf(buffer+offset, max-offset, ":%s", mount->options);
+                g_string_append_printf(buffer, ":%s", mount->options);
             }
         }
 
@@ -256,30 +255,30 @@ create_docker_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
             pe__bundle_port_t *port = pIter->data;
 
             if (replica->ipaddr) {
-                offset += snprintf(buffer+offset, max-offset, " -p %s:%s:%s",
-                                   replica->ipaddr, port->source,
-                                   port->target);
+                g_string_append_printf(buffer, " -p %s:%s:%s", replica->ipaddr,
+                                       port->source, port->target);
             } else if(!pcmk__str_eq(data->container_network, "host", pcmk__str_casei)) {
                 // No need to do port mapping if net=host
-                offset += snprintf(buffer+offset, max-offset, " -p %s:%s", port->source, port->target);
+                g_string_append_printf(buffer, " -p %s:%s", port->source,
+                                       port->target);
             }
         }
 
         if (data->launcher_options) {
-            offset += snprintf(buffer+offset, max-offset, " %s",
-                               data->launcher_options);
+            g_string_append_printf(buffer, " %s", data->launcher_options);
         }
 
         if (data->container_host_options) {
-            offset += snprintf(buffer + offset, max - offset, " %s",
-                               data->container_host_options);
+            g_string_append_printf(buffer, " %s", data->container_host_options);
         }
 
-        crm_create_nvpair_xml(xml_obj, NULL, "run_opts", buffer);
-        free(buffer);
+        crm_create_nvpair_xml(xml_obj, NULL, "run_opts",
+                              (const char *) buffer->str);
+        g_string_free(buffer, TRUE);
 
-        crm_create_nvpair_xml(xml_obj, NULL, "mount_points", dbuffer);
-        free(dbuffer);
+        crm_create_nvpair_xml(xml_obj, NULL, "mount_points",
+                              (const char *) dbuffer->str);
+        g_string_free(dbuffer, TRUE);
 
         if (replica->child) {
             if (data->container_command) {
@@ -341,11 +340,8 @@ create_podman_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
                        pe__bundle_replica_t *replica,
                        pe_working_set_t *data_set)
 {
-        int offset = 0, max = 4096;
-        char *buffer = calloc(1, max+1);
-
-        int doffset = 0, dmax = 1024;
-        char *dbuffer = calloc(1, dmax+1);
+        GString *buffer = g_string_sized_new(4096);
+        GString *dbuffer = g_string_sized_new(1024);
 
         char *id = NULL;
         xmlNode *xml_container = NULL;
@@ -366,35 +362,29 @@ create_podman_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
         crm_create_nvpair_xml(xml_obj, NULL, "force_kill", XML_BOOLEAN_FALSE);
         crm_create_nvpair_xml(xml_obj, NULL, "reuse", XML_BOOLEAN_FALSE);
 
-        // FIXME: (bandini 2018-08) podman has no restart policies
-        //offset += snprintf(buffer+offset, max-offset, " --restart=no");
-
         /* Set a container hostname only if we have an IP to map it to.
          * The user can set -h or --uts=host themselves if they want a nicer
          * name for logs, but this makes applications happy who need their
          * hostname to match the IP they bind to.
          */
         if (data->ip_range_start != NULL) {
-            offset += snprintf(buffer+offset, max-offset, " -h %s-%d",
-                               data->prefix, replica->offset);
+            g_string_append_printf(buffer, " -h %s-%d", data->prefix,
+                                   replica->offset);
         }
 
-        offset += snprintf(buffer+offset, max-offset, " -e PCMK_stderr=1");
+        g_string_append(buffer, " -e PCMK_stderr=1");
 
         if (data->container_network) {
-#if 0
-            // podman has no support for --link-local-ip
-            offset += snprintf(buffer+offset, max-offset, " --link-local-ip=%s",
-                               replica->ipaddr);
-#endif
-            offset += snprintf(buffer+offset, max-offset, " --net=%s",
-                               data->container_network);
+            g_string_append_printf(buffer, " --net=%s",
+                                   data->container_network);
         }
 
         if(data->control_port) {
-            offset += snprintf(buffer+offset, max-offset, " -e PCMK_remote_port=%s", data->control_port);
+            g_string_append_printf(buffer, " -e PCMK_remote_port=%s",
+                                   data->control_port);
         } else {
-            offset += snprintf(buffer+offset, max-offset, " -e PCMK_remote_port=%d", DEFAULT_REMOTE_PORT);
+            g_string_append_printf(buffer, " -e PCMK_remote_port=%d",
+                                   DEFAULT_REMOTE_PORT);
         }
 
         for(GList *pIter = data->mounts; pIter != NULL; pIter = pIter->next) {
@@ -404,18 +394,20 @@ create_podman_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
                 char *source = crm_strdup_printf(
                     "%s/%s-%d", mount->source, data->prefix, replica->offset);
 
-                if(doffset > 0) {
-                    doffset += snprintf(dbuffer+doffset, dmax-doffset, ",");
+                if (dbuffer->len > 0) {
+                    g_string_append_c(dbuffer, ',');
                 }
-                doffset += snprintf(dbuffer+doffset, dmax-doffset, "%s", source);
-                offset += snprintf(buffer+offset, max-offset, " -v %s:%s", source, mount->target);
+                g_string_append(dbuffer, source);
+                g_string_append_printf(buffer, " -v %s:%s", source,
+                                       mount->target);
                 free(source);
 
             } else {
-                offset += snprintf(buffer+offset, max-offset, " -v %s:%s", mount->source, mount->target);
+                g_string_append_printf(buffer, " -v %s:%s", mount->source,
+                                       mount->target);
             }
             if(mount->options) {
-                offset += snprintf(buffer+offset, max-offset, ":%s", mount->options);
+                g_string_append_printf(buffer, ":%s", mount->options);
             }
         }
 
@@ -423,30 +415,30 @@ create_podman_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
             pe__bundle_port_t *port = pIter->data;
 
             if (replica->ipaddr) {
-                offset += snprintf(buffer+offset, max-offset, " -p %s:%s:%s",
-                                   replica->ipaddr, port->source,
-                                   port->target);
+                g_string_append_printf(buffer, " -p %s:%s:%s", replica->ipaddr,
+                                       port->source, port->target);
             } else if(!pcmk__str_eq(data->container_network, "host", pcmk__str_casei)) {
                 // No need to do port mapping if net=host
-                offset += snprintf(buffer+offset, max-offset, " -p %s:%s", port->source, port->target);
+                g_string_append_printf(buffer, " -p %s:%s", port->source,
+                                       port->target);
             }
         }
 
         if (data->launcher_options) {
-            offset += snprintf(buffer+offset, max-offset, " %s",
-                               data->launcher_options);
+            g_string_append_printf(buffer, " %s", data->launcher_options);
         }
 
         if (data->container_host_options) {
-            offset += snprintf(buffer + offset, max - offset, " %s",
-                               data->container_host_options);
+            g_string_append_printf(buffer, " %s", data->container_host_options);
         }
 
-        crm_create_nvpair_xml(xml_obj, NULL, "run_opts", buffer);
-        free(buffer);
+        crm_create_nvpair_xml(xml_obj, NULL, "run_opts",
+                              (const char *) buffer->str);
+        g_string_free(buffer, TRUE);
 
-        crm_create_nvpair_xml(xml_obj, NULL, "mount_points", dbuffer);
-        free(dbuffer);
+        crm_create_nvpair_xml(xml_obj, NULL, "mount_points",
+                              (const char *) dbuffer->str);
+        g_string_free(dbuffer, TRUE);
 
         if (replica->child) {
             if (data->container_command) {
@@ -507,11 +499,8 @@ static bool
 create_rkt_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
                     pe__bundle_replica_t *replica, pe_working_set_t *data_set)
 {
-        int offset = 0, max = 4096;
-        char *buffer = calloc(1, max+1);
-
-        int doffset = 0, dmax = 1024;
-        char *dbuffer = calloc(1, dmax+1);
+        GString *buffer = g_string_sized_new(4096);
+        GString *dbuffer = g_string_sized_new(1024);
 
         char *id = NULL;
         xmlNode *xml_container = NULL;
@@ -540,25 +529,23 @@ create_rkt_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
          * hostname to match the IP they bind to.
          */
         if (data->ip_range_start != NULL) {
-            offset += snprintf(buffer+offset, max-offset, " --hostname=%s-%d",
-                               data->prefix, replica->offset);
+            g_string_append_printf(buffer, " --hostname=%s-%d", data->prefix,
+                                   replica->offset);
         }
 
-        offset += snprintf(buffer+offset, max-offset, " --environment=PCMK_stderr=1");
+        g_string_append(buffer, " --environment=PCMK_stderr=1");
 
         if (data->container_network) {
-#if 0
-            offset += snprintf(buffer+offset, max-offset, " --link-local-ip=%s",
-                               replica->ipaddr);
-#endif
-            offset += snprintf(buffer+offset, max-offset, " --net=%s",
-                               data->container_network);
+            g_string_append_printf(buffer, " --net=%s",
+                                   data->container_network);
         }
 
         if(data->control_port) {
-            offset += snprintf(buffer+offset, max-offset, " --environment=PCMK_remote_port=%s", data->control_port);
+            g_string_append_printf(buffer, " --environment=PCMK_remote_port=%s",
+                                   data->control_port);
         } else {
-            offset += snprintf(buffer+offset, max-offset, " --environment=PCMK_remote_port=%d", DEFAULT_REMOTE_PORT);
+            g_string_append_printf(buffer, " --environment=PCMK_remote_port=%d",
+                                   DEFAULT_REMOTE_PORT);
         }
 
         for(GList *pIter = data->mounts; pIter != NULL; pIter = pIter->next) {
@@ -568,23 +555,31 @@ create_rkt_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
                 char *source = crm_strdup_printf(
                     "%s/%s-%d", mount->source, data->prefix, replica->offset);
 
-                if(doffset > 0) {
-                    doffset += snprintf(dbuffer+doffset, dmax-doffset, ",");
+                if (dbuffer->len > 0) {
+                    g_string_append_c(dbuffer, ',');
                 }
-                doffset += snprintf(dbuffer+doffset, dmax-doffset, "%s", source);
-                offset += snprintf(buffer+offset, max-offset, " --volume vol%d,kind=host,source=%s", volid, source);
+                g_string_append(dbuffer, source);
+                g_string_append_printf(buffer,
+                                       " --volume vol%d,kind=host,source=%s",
+                                       volid, source);
                 if(mount->options) {
-                    offset += snprintf(buffer+offset, max-offset, ",%s", mount->options);
+                    g_string_append_printf(buffer, ",%s", mount->options);
                 }
-                offset += snprintf(buffer+offset, max-offset, " --mount volume=vol%d,target=%s", volid, mount->target);
+                g_string_append_printf(buffer,
+                                       " --mount volume=vol%d,target=%s",
+                                       volid, mount->target);
                 free(source);
 
             } else {
-                offset += snprintf(buffer+offset, max-offset, " --volume vol%d,kind=host,source=%s", volid, mount->source);
+                g_string_append_printf(buffer,
+                                       " --volume vol%d,kind=host,source=%s",
+                                       volid, mount->source);
                 if(mount->options) {
-                    offset += snprintf(buffer+offset, max-offset, ",%s", mount->options);
+                    g_string_append_printf(buffer, ",%s", mount->options);
                 }
-                offset += snprintf(buffer+offset, max-offset, " --mount volume=vol%d,target=%s", volid, mount->target);
+                g_string_append_printf(buffer,
+                                       " --mount volume=vol%d,target=%s",
+                                       volid, mount->target);
             }
             volid++;
         }
@@ -593,29 +588,29 @@ create_rkt_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
             pe__bundle_port_t *port = pIter->data;
 
             if (replica->ipaddr) {
-                offset += snprintf(buffer+offset, max-offset,
-                                   " --port=%s:%s:%s", port->target,
-                                   replica->ipaddr, port->source);
+                g_string_append_printf(buffer, " --port=%s:%s:%s", port->target,
+                                       replica->ipaddr, port->source);
             } else {
-                offset += snprintf(buffer+offset, max-offset, " --port=%s:%s", port->target, port->source);
+                g_string_append_printf(buffer, " --port=%s:%s", port->target,
+                                       port->source);
             }
         }
 
         if (data->launcher_options) {
-            offset += snprintf(buffer+offset, max-offset, " %s",
-                               data->launcher_options);
+            g_string_append_printf(buffer, " %s", data->launcher_options);
         }
 
         if (data->container_host_options) {
-            offset += snprintf(buffer + offset, max - offset, " %s",
-                               data->container_host_options);
+            g_string_append_printf(buffer, " %s", data->container_host_options);
         }
 
-        crm_create_nvpair_xml(xml_obj, NULL, "run_opts", buffer);
-        free(buffer);
+        crm_create_nvpair_xml(xml_obj, NULL, "run_opts",
+                              (const char *) buffer->str);
+        g_string_free(buffer, TRUE);
 
-        crm_create_nvpair_xml(xml_obj, NULL, "mount_points", dbuffer);
-        free(dbuffer);
+        crm_create_nvpair_xml(xml_obj, NULL, "mount_points",
+                              (const char *) dbuffer->str);
+        g_string_free(dbuffer, TRUE);
 
         if (replica->child) {
             if (data->container_command) {
@@ -1194,8 +1189,7 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
         pe_resource_t *new_rsc = NULL;
         pe__bundle_port_t *port = NULL;
 
-        int offset = 0, max = 1024;
-        char *buffer = NULL;
+        GString *buffer = NULL;
 
         if (pe__unpack_resource(xml_resource, &new_rsc, rsc,
                                 data_set) != pcmk_rc_ok) {
@@ -1254,7 +1248,7 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
         port->target = strdup(port->source);
         bundle_data->ports = g_list_append(bundle_data->ports, port);
 
-        buffer = calloc(1, max+1);
+        buffer = g_string_sized_new(1024);
         for (childIter = bundle_data->child->children; childIter != NULL;
              childIter = childIter->next) {
 
@@ -1269,14 +1263,14 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
                 pe__set_resource_flags(bundle_data->child, pe_rsc_notify);
             }
 
-            offset += allocate_ip(bundle_data, replica, buffer+offset,
-                                  max-offset);
+            allocate_ip(bundle_data, replica, buffer);
             bundle_data->replicas = g_list_append(bundle_data->replicas,
                                                   replica);
             bundle_data->attribute_target = g_hash_table_lookup(replica->child->meta,
                                                                 XML_RSC_ATTR_TARGET);
         }
-        bundle_data->container_host_options = buffer;
+        bundle_data->container_host_options = g_string_free(buffer, FALSE);
+
         if (bundle_data->attribute_target) {
             g_hash_table_replace(rsc->meta, strdup(XML_RSC_ATTR_TARGET),
                                  strdup(bundle_data->attribute_target));
@@ -1287,19 +1281,17 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
 
     } else {
         // Just a naked container, no pacemaker-remote
-        int offset = 0, max = 1024;
-        char *buffer = calloc(1, max+1);
+        GString *buffer = g_string_sized_new(1024);
 
         for (int lpc = 0; lpc < bundle_data->nreplicas; lpc++) {
             pe__bundle_replica_t *replica = calloc(1, sizeof(pe__bundle_replica_t));
 
             replica->offset = lpc;
-            offset += allocate_ip(bundle_data, replica, buffer+offset,
-                                  max-offset);
+            allocate_ip(bundle_data, replica, buffer);
             bundle_data->replicas = g_list_append(bundle_data->replicas,
                                                   replica);
         }
-        bundle_data->container_host_options = buffer;
+        bundle_data->container_host_options = g_string_free(buffer, FALSE);
     }
 
     for (GList *gIter = bundle_data->replicas; gIter != NULL;
@@ -1994,7 +1986,7 @@ pe__free_bundle(pe_resource_t *rsc)
     free(bundle_data->container_network);
     free(bundle_data->launcher_options);
     free(bundle_data->container_command);
-    free(bundle_data->container_host_options);
+    g_free(bundle_data->container_host_options);
 
     g_list_free_full(bundle_data->replicas,
                      (GDestroyNotify) free_bundle_replica);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1416,6 +1416,10 @@ pe__find_bundle_replica(const pe_resource_t *bundle, const pe_node_t *node)
     return NULL;
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 static void
 print_rsc_in_list(pe_resource_t *rsc, const char *pre_text, long options,
                   void *print_data)
@@ -1444,6 +1448,10 @@ container_agent_str(enum pe__container_agent t)
     return PE__CONTAINER_AGENT_UNKNOWN_S;
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 static void
 bundle_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
                  void *print_data)
@@ -1836,6 +1844,10 @@ pe__bundle_text(pcmk__output_t *out, va_list args)
     return rc;
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 static void
 print_bundle_replica(pe__bundle_replica_t *replica, const char *pre_text,
                      long options, void *print_data)
@@ -1866,6 +1878,10 @@ print_bundle_replica(pe__bundle_replica_t *replica, const char *pre_text,
     common_print(rsc, pre_text, buffer, node, options, print_data);
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 void
 pe__print_bundle(pe_resource_t *rsc, const char *pre_text, long options,
                  void *print_data)

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -404,6 +404,10 @@ clone_active(pe_resource_t * rsc, gboolean all)
     }
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 static void
 short_print(const char *list, const char *prefix, const char *type,
             const char *suffix, long options, void *print_data)
@@ -454,8 +458,13 @@ configured_role(pe_resource_t * rsc)
     return RSC_ROLE_UNKNOWN;
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 static void
-clone_print_xml(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
+clone_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
+                void *print_data)
 {
     char *child_text = crm_strdup_printf("%s    ", pre_text);
     const char *target_role = configured_role_str(rsc);
@@ -515,8 +524,13 @@ bool is_set_recursive(pe_resource_t * rsc, long long flag, bool any)
     return FALSE;
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 void
-clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
+clone_print(pe_resource_t *rsc, const char *pre_text, long options,
+            void *print_data)
 {
     GString *list_text = NULL;
     char *child_text = NULL;

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -100,14 +100,13 @@ nodes_with_status(GHashTable *table, const char *status)
     return retval;
 }
 
-static char *
-node_list_to_str(GList *list)
+static GString *
+node_list_to_str(const GList *list)
 {
-    char *retval = NULL;
-    size_t len = 0;
+    GString *retval = NULL;
 
-    for (GList *iter = list; iter != NULL; iter = iter->next) {
-        pcmk__add_word(&retval, &len, (char *) iter->data);
+    for (const GList *iter = list; iter != NULL; iter = iter->next) {
+        pcmk__add_word(&retval, 1024, (const char *) iter->data);
     }
 
     return retval;
@@ -116,30 +115,29 @@ node_list_to_str(GList *list)
 static void
 clone_header(pcmk__output_t *out, int *rc, pe_resource_t *rsc, clone_variant_data_t *clone_data)
 {
-    char *attrs = NULL;
-    size_t len = 0;
+    GString *attrs = NULL;
 
     if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
-        pcmk__add_separated_word(&attrs, &len, "promotable", ", ");
+        pcmk__add_separated_word(&attrs, 64, "promotable", ", ");
     }
 
     if (pcmk_is_set(rsc->flags, pe_rsc_unique)) {
-        pcmk__add_separated_word(&attrs, &len, "unique", ", ");
+        pcmk__add_separated_word(&attrs, 64, "unique", ", ");
     }
 
     if (!pcmk_is_set(rsc->flags, pe_rsc_managed)) {
-        pcmk__add_separated_word(&attrs, &len, "unmanaged", ", ");
+        pcmk__add_separated_word(&attrs, 64, "unmanaged", ", ");
     }
 
     if (pe__resource_is_disabled(rsc)) {
-        pcmk__add_separated_word(&attrs, &len, "disabled", ", ");
+        pcmk__add_separated_word(&attrs, 64, "disabled", ", ");
     }
 
-    if (attrs) {
+    if (attrs != NULL) {
         PCMK__OUTPUT_LIST_HEADER(out, FALSE, *rc, "Clone Set: %s [%s] (%s)",
-                             rsc->id, ID(clone_data->xml_obj_child),
-                                 attrs);
-        free(attrs);
+                                 rsc->id, ID(clone_data->xml_obj_child),
+                                 (const char *) attrs->str);
+        g_string_free(attrs, TRUE);
     } else {
         PCMK__OUTPUT_LIST_HEADER(out, FALSE, *rc, "Clone Set: %s [%s]",
                                  rsc->id, ID(clone_data->xml_obj_child))
@@ -407,13 +405,14 @@ clone_active(pe_resource_t * rsc, gboolean all)
 }
 
 static void
-short_print(char *list, const char *prefix, const char *type, const char *suffix, long options, void *print_data)
+short_print(const char *list, const char *prefix, const char *type,
+            const char *suffix, long options, void *print_data)
 {
     if(suffix == NULL) {
         suffix = "";
     }
 
-    if (list) {
+    if (!pcmk__str_empty(list)) {
         if (options & pe_print_html) {
             status_print("<li>");
         }
@@ -519,11 +518,9 @@ bool is_set_recursive(pe_resource_t * rsc, long long flag, bool any)
 void
 clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
 {
-    char *list_text = NULL;
+    GString *list_text = NULL;
     char *child_text = NULL;
-    char *stopped_list = NULL;
-    size_t list_text_len = 0;
-    size_t stopped_list_len = 0;
+    GString *stopped_list = NULL;
 
     GList *promoted_list = NULL;
     GList *started_list = NULL;
@@ -585,7 +582,8 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
             // List stopped instances when requested (except orphans)
             if (!pcmk_is_set(child_rsc->flags, pe_rsc_orphan)
                 && !pcmk_is_set(options, pe_print_clone_active)) {
-                pcmk__add_word(&stopped_list, &stopped_list_len, child_rsc->id);
+
+                pcmk__add_word(&stopped_list, 1024, child_rsc->id);
             }
 
         } else if (is_set_recursive(child_rsc, pe_rsc_orphan, TRUE)
@@ -641,46 +639,46 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
     for (gIter = promoted_list; gIter; gIter = gIter->next) {
         pe_node_t *host = gIter->data;
 
-        pcmk__add_word(&list_text, &list_text_len, host->details->uname);
-	active_instances++;
+        pcmk__add_word(&list_text, 1024, host->details->uname);
+        active_instances++;
     }
 
-    short_print(list_text, child_text, PROMOTED_INSTANCES, NULL, options,
-                print_data);
+    if (list_text != NULL) {
+        short_print((const char *) list_text->str, child_text,
+                    PROMOTED_INSTANCES, NULL, options, print_data);
+        g_string_truncate(list_text, 0);
+    }
     g_list_free(promoted_list);
-    free(list_text);
-    list_text = NULL;
-    list_text_len = 0;
 
     /* Started/Unpromoted */
     started_list = g_list_sort(started_list, pe__cmp_node_name);
     for (gIter = started_list; gIter; gIter = gIter->next) {
         pe_node_t *host = gIter->data;
 
-        pcmk__add_word(&list_text, &list_text_len, host->details->uname);
+        pcmk__add_word(&list_text, 1024, host->details->uname);
         active_instances++;
     }
 
-    if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
-        enum rsc_role_e role = configured_role(rsc);
+    if (list_text != NULL) {
+        if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
+            enum rsc_role_e role = configured_role(rsc);
 
-        if (role == RSC_ROLE_UNPROMOTED) {
-            short_print(list_text, child_text,
-                        UNPROMOTED_INSTANCES " (target-role)", NULL, options,
-                        print_data);
+            if (role == RSC_ROLE_UNPROMOTED) {
+                short_print((const char *) list_text->str, child_text,
+                            UNPROMOTED_INSTANCES " (target-role)", NULL,
+                            options, print_data);
+            } else {
+                short_print((const char *) list_text->str, child_text,
+                            UNPROMOTED_INSTANCES, NULL, options, print_data);
+            }
+
         } else {
-            short_print(list_text, child_text, UNPROMOTED_INSTANCES, NULL,
-                        options, print_data);
+            short_print((const char *) list_text->str, child_text, "Started",
+                        NULL, options, print_data);
         }
-
-    } else {
-        short_print(list_text, child_text, "Started", NULL, options, print_data);
     }
 
     g_list_free(started_list);
-    free(list_text);
-    list_text = NULL;
-    list_text_len = 0;
 
     if (!pcmk_is_set(options, pe_print_clone_active)) {
         const char *state = "Stopped";
@@ -697,9 +695,9 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
             GList *list = g_hash_table_get_values(rsc->allowed_nodes);
 
             /* Custom stopped list for non-unique clones */
-            free(stopped_list);
-            stopped_list = NULL;
-            stopped_list_len = 0;
+            if (stopped_list != NULL) {
+                g_string_truncate(stopped_list, 0);
+            }
 
             if (list == NULL) {
                 /* Clusters with symmetrical=false haven't calculated allowed_nodes yet
@@ -713,21 +711,29 @@ clone_print(pe_resource_t * rsc, const char *pre_text, long options, void *print
                 pe_node_t *node = (pe_node_t *)nIter->data;
 
                 if (pe_find_node(rsc->running_on, node->details->uname) == NULL) {
-                    pcmk__add_word(&stopped_list, &stopped_list_len,
-                                   node->details->uname);
+                    pcmk__add_word(&stopped_list, 1024, node->details->uname);
                 }
             }
             g_list_free(list);
         }
 
-        short_print(stopped_list, child_text, state, NULL, options, print_data);
-        free(stopped_list);
+        if (stopped_list != NULL) {
+            short_print((const char *) stopped_list->str, child_text, state,
+                        NULL, options, print_data);
+        }
     }
 
     if (options & pe_print_html) {
         status_print("</ul>\n");
     }
 
+    if (list_text != NULL) {
+        g_string_free(list_text, TRUE);
+    }
+
+    if (stopped_list != NULL) {
+        g_string_free(stopped_list, TRUE);
+    }
     free(child_text);
 }
 
@@ -804,8 +810,7 @@ pe__clone_default(pcmk__output_t *out, va_list args)
 
     GHashTable *stopped = NULL;
 
-    char *list_text = NULL;
-    size_t list_text_len = 0;
+    GString *list_text = NULL;
 
     GList *promoted_list = NULL;
     GList *started_list = NULL;
@@ -932,18 +937,17 @@ pe__clone_default(pcmk__output_t *out, va_list args)
             continue;
         }
 
-        pcmk__add_word(&list_text, &list_text_len, host->details->uname);
+        pcmk__add_word(&list_text, 1024, host->details->uname);
         active_instances++;
     }
     g_list_free(promoted_list);
 
-    if (list_text != NULL) {
+    if ((list_text != NULL) && (list_text->len > 0)) {
         clone_header(out, &rc, rsc, clone_data);
 
-        out->list_item(out, NULL, PROMOTED_INSTANCES ": [ %s ]", list_text);
-        free(list_text);
-        list_text = NULL;
-        list_text_len = 0;
+        out->list_item(out, NULL, PROMOTED_INSTANCES ": [ %s ]",
+                       (const char *) list_text->str);
+        g_string_truncate(list_text, 0);
     }
 
     /* Started/Unpromoted */
@@ -956,12 +960,12 @@ pe__clone_default(pcmk__output_t *out, va_list args)
             continue;
         }
 
-        pcmk__add_word(&list_text, &list_text_len, host->details->uname);
+        pcmk__add_word(&list_text, 1024, host->details->uname);
         active_instances++;
     }
     g_list_free(started_list);
 
-    if (list_text != NULL) {
+    if ((list_text != NULL) && (list_text->len > 0)) {
         clone_header(out, &rc, rsc, clone_data);
 
         if (pcmk_is_set(rsc->flags, pe_rsc_promotable)) {
@@ -970,18 +974,20 @@ pe__clone_default(pcmk__output_t *out, va_list args)
             if (role == RSC_ROLE_UNPROMOTED) {
                 out->list_item(out, NULL,
                                UNPROMOTED_INSTANCES " (target-role): [ %s ]",
-                               list_text);
+                               (const char *) list_text->str);
             } else {
                 out->list_item(out, NULL, UNPROMOTED_INSTANCES ": [ %s ]",
-                               list_text);
+                               (const char *) list_text->str);
             }
 
         } else {
-            out->list_item(out, NULL, "Started: [ %s ]", list_text);
+            out->list_item(out, NULL, "Started: [ %s ]",
+                           (const char *) list_text->str);
         }
-        free(list_text);
-        list_text = NULL;
-        list_text_len = 0;
+    }
+
+    if (list_text != NULL) {
+        g_string_free(list_text, TRUE);
     }
 
     if (pcmk_is_set(show_opts, pcmk_show_inactive_rscs)) {
@@ -1044,11 +1050,14 @@ pe__clone_default(pcmk__output_t *out, va_list args)
             for (GList *status_iter = list; status_iter != NULL; status_iter = status_iter->next) {
                 const char *status = status_iter->data;
                 GList *nodes = nodes_with_status(stopped, status);
-                char *str = node_list_to_str(nodes);
+                GString *nodes_str = node_list_to_str(nodes);
 
-                if (str != NULL) {
-                    out->list_item(out, NULL, "%s: [ %s ]", status, str);
-                    free(str);
+                if (nodes_str != NULL) {
+                    if (nodes_str->len > 0) {
+                        out->list_item(out, NULL, "%s: [ %s ]", status,
+                                       (const char *) nodes_str->str);
+                    }
+                    g_string_free(nodes_str, TRUE);
                 }
 
                 g_list_free(nodes);

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -205,8 +205,13 @@ group_active(pe_resource_t * rsc, gboolean all)
     return TRUE;
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 static void
-group_print_xml(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
+group_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
+                void *print_data)
 {
     GList *gIter = rsc->children;
     char *child_text = crm_strdup_printf("%s     ", pre_text);
@@ -225,8 +230,13 @@ group_print_xml(pe_resource_t * rsc, const char *pre_text, long options, void *p
     free(child_text);
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 void
-group_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
+group_print(pe_resource_t *rsc, const char *pre_text, long options,
+            void *print_data)
 {
     char *child_text = NULL;
     GList *gIter = rsc->children;

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -42,27 +42,26 @@ inactive_resources(pe_resource_t *rsc)
 static void
 group_header(pcmk__output_t *out, int *rc, pe_resource_t *rsc, int n_inactive, bool show_inactive)
 {
-    char *attrs = NULL;
-    size_t len = 0;
+    GString *attrs = NULL;
 
     if (n_inactive > 0 && !show_inactive) {
-        char *word = crm_strdup_printf("%d member%s inactive", n_inactive, pcmk__plural_s(n_inactive));
-        pcmk__add_separated_word(&attrs, &len, word, ", ");
-        free(word);
+        attrs = g_string_sized_new(64);
+        g_string_append_printf(attrs, "%d member%s inactive", n_inactive,
+                               pcmk__plural_s(n_inactive));
     }
 
     if (!pcmk_is_set(rsc->flags, pe_rsc_managed)) {
-        pcmk__add_separated_word(&attrs, &len, "unmanaged", ", ");
+        pcmk__add_separated_word(&attrs, 64, "unmanaged", ", ");
     }
 
     if (pe__resource_is_disabled(rsc)) {
-        pcmk__add_separated_word(&attrs, &len, "disabled", ", ");
+        pcmk__add_separated_word(&attrs, 64, "disabled", ", ");
     }
 
-    if (attrs) {
+    if (attrs != NULL) {
         PCMK__OUTPUT_LIST_HEADER(out, FALSE, *rc, "Resource Group: %s (%s)",
-                                 rsc->id, attrs);
-        free(attrs);
+                                 rsc->id, (const char *) attrs->str);
+        g_string_free(attrs, TRUE);
     } else {
         PCMK__OUTPUT_LIST_HEADER(out, FALSE, *rc, "Resource Group: %s", rsc->id);
     }

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -447,8 +447,13 @@ native_displayable_state(pe_resource_t *rsc, bool print_pending)
     return rsc_state;
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 static void
-native_print_xml(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
+native_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
+                 void *print_data)
 {
     const char *class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
     const char *prov = crm_element_value(rsc->xml, XML_AGENT_ATTR_PROVIDER);
@@ -770,8 +775,13 @@ pe__common_output_text(pcmk__output_t *out, pe_resource_t * rsc,
     return pcmk_rc_ok;
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 void
-common_print(pe_resource_t * rsc, const char *pre_text, const char *name, pe_node_t *node, long options, void *print_data)
+common_print(pe_resource_t *rsc, const char *pre_text, const char *name,
+             pe_node_t *node, long options, void *print_data)
 {
     const char *target_role = NULL;
 
@@ -885,8 +895,13 @@ common_print(pe_resource_t * rsc, const char *pre_text, const char *name, pe_nod
     }
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 void
-native_print(pe_resource_t * rsc, const char *pre_text, long options, void *print_data)
+native_print(pe_resource_t *rsc, const char *pre_text, long options,
+             void *print_data)
 {
     pe_node_t *node = NULL;
 
@@ -1193,6 +1208,10 @@ destroy_node_table(gpointer data)
     }
 }
 
+/*!
+ * \internal
+ * \deprecated This function will be removed in a future release
+ */
 void
 print_rscs_brief(GList *rsc_list, const char *pre_text, long options,
                  void *print_data, gboolean print_all)

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -2222,17 +2222,11 @@ node_list_text(pcmk__output_t *out, va_list args) {
     bool print_spacer = va_arg(args, int);
 
     /* space-separated lists of node names */
-    char *online_nodes = NULL;
-    char *online_remote_nodes = NULL;
-    char *online_guest_nodes = NULL;
-    char *offline_nodes = NULL;
-    char *offline_remote_nodes = NULL;
-
-    size_t online_nodes_len = 0;
-    size_t online_remote_nodes_len = 0;
-    size_t online_guest_nodes_len = 0;
-    size_t offline_nodes_len = 0;
-    size_t offline_remote_nodes_len = 0;
+    GString *online_nodes = NULL;
+    GString *online_remote_nodes = NULL;
+    GString *online_guest_nodes = NULL;
+    GString *offline_nodes = NULL;
+    GString *offline_remote_nodes = NULL;
 
     int rc = pcmk_rc_no_output;
 
@@ -2260,13 +2254,13 @@ node_list_text(pcmk__output_t *out, va_list args) {
         } else if (node->details->online) {
             // Display online node in a list
             if (pe__is_guest_node(node)) {
-                pcmk__add_word(&online_guest_nodes,
-                               &online_guest_nodes_len, node_name);
+                pcmk__add_word(&online_guest_nodes, 1024, node_name);
+
             } else if (pe__is_remote_node(node)) {
-                pcmk__add_word(&online_remote_nodes,
-                               &online_remote_nodes_len, node_name);
+                pcmk__add_word(&online_remote_nodes, 1024, node_name);
+
             } else {
-                pcmk__add_word(&online_nodes, &online_nodes_len, node_name);
+                pcmk__add_word(&online_nodes, 1024, node_name);
             }
             free(node_name);
             continue;
@@ -2274,13 +2268,13 @@ node_list_text(pcmk__output_t *out, va_list args) {
         } else {
             // Display offline node in a list
             if (pe__is_remote_node(node)) {
-                pcmk__add_word(&offline_remote_nodes,
-                               &offline_remote_nodes_len, node_name);
+                pcmk__add_word(&offline_remote_nodes, 1024, node_name);
+
             } else if (pe__is_guest_node(node)) {
                 /* ignore offline guest nodes */
+
             } else {
-                pcmk__add_word(&offline_nodes,
-                               &offline_nodes_len, node_name);
+                pcmk__add_word(&offline_nodes, 1024, node_name);
             }
             free(node_name);
             continue;
@@ -2292,25 +2286,30 @@ node_list_text(pcmk__output_t *out, va_list args) {
     }
 
     /* If we're not grouping by node, summarize nodes by status */
-    if (online_nodes) {
-        out->list_item(out, "Online", "[ %s ]", online_nodes);
-        free(online_nodes);
+    if (online_nodes != NULL) {
+        out->list_item(out, "Online", "[ %s ]",
+                       (const char *) online_nodes->str);
+        g_string_free(online_nodes, TRUE);
     }
-    if (offline_nodes) {
-        out->list_item(out, "OFFLINE", "[ %s ]", offline_nodes);
-        free(offline_nodes);
+    if (offline_nodes != NULL) {
+        out->list_item(out, "OFFLINE", "[ %s ]",
+                       (const char *) offline_nodes->str);
+        g_string_free(offline_nodes, TRUE);
     }
     if (online_remote_nodes) {
-        out->list_item(out, "RemoteOnline", "[ %s ]", online_remote_nodes);
-        free(online_remote_nodes);
+        out->list_item(out, "RemoteOnline", "[ %s ]",
+                       (const char *) online_remote_nodes->str);
+        g_string_free(online_remote_nodes, TRUE);
     }
     if (offline_remote_nodes) {
-        out->list_item(out, "RemoteOFFLINE", "[ %s ]", offline_remote_nodes);
-        free(offline_remote_nodes);
+        out->list_item(out, "RemoteOFFLINE", "[ %s ]",
+                       (const char *) offline_remote_nodes->str);
+        g_string_free(offline_remote_nodes, TRUE);
     }
-    if (online_guest_nodes) {
-        out->list_item(out, "GuestOnline", "[ %s ]", online_guest_nodes);
-        free(online_guest_nodes);
+    if (online_guest_nodes != NULL) {
+        out->list_item(out, "GuestOnline", "[ %s ]",
+                       (const char *) online_guest_nodes->str);
+        g_string_free(online_guest_nodes, TRUE);
     }
 
     PCMK__OUTPUT_LIST_FOOTER(out, rc);

--- a/lib/pengine/pe_status_private.h
+++ b/lib/pengine/pe_status_private.h
@@ -19,6 +19,10 @@
 #define G_GNUC_INTERNAL
 #endif
 
+/*!
+ * \internal
+ * \deprecated This macro will be removed in a future release
+ */
 #  define status_print(fmt, args...)           \
    if(options & pe_print_html) {           \
        FILE *stream = print_data;      \

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2582,43 +2582,41 @@ set_node_score(gpointer key, gpointer value, gpointer user_data)
     node->weight = *score;
 }
 
-#define STATUS_PATH_MAX 1024
 static xmlNode *
 find_lrm_op(const char *resource, const char *op, const char *node, const char *source,
             int target_rc, pe_working_set_t *data_set)
 {
-    int offset = 0;
-    char xpath[STATUS_PATH_MAX];
+    GString *xpath = NULL;
     xmlNode *xml = NULL;
 
     CRM_CHECK((resource != NULL) && (op != NULL) && (node != NULL),
               return NULL);
 
-    offset += snprintf(xpath + offset, STATUS_PATH_MAX - offset, "//node_state[@uname='%s']", node);
-    offset +=
-        snprintf(xpath + offset, STATUS_PATH_MAX - offset, "//" XML_LRM_TAG_RESOURCE "[@id='%s']",
-                 resource);
+    xpath = g_string_sized_new(256);
+    g_string_append_printf(xpath,
+                           "//" XML_CIB_TAG_STATE "[@" XML_ATTR_UNAME "='%s']"
+                           "//" XML_LRM_TAG_RESOURCE "[@" XML_ATTR_ID "='%s']"
+                           "/" XML_LRM_TAG_RSC_OP
+                           "[@" XML_LRM_ATTR_TASK "='%s'",
+                           node, resource, op);
 
     /* Need to check against transition_magic too? */
     if ((source != NULL) && (strcmp(op, CRMD_ACTION_MIGRATE) == 0)) {
-        offset +=
-            snprintf(xpath + offset, STATUS_PATH_MAX - offset,
-                     "/" XML_LRM_TAG_RSC_OP "[@operation='%s' and @migrate_target='%s']", op,
-                     source);
+        g_string_append_printf(xpath,
+                               "and @" XML_LRM_ATTR_MIGRATE_TARGET "='%s']",
+                               source);
 
     } else if ((source != NULL) && (strcmp(op, CRMD_ACTION_MIGRATED) == 0)) {
-        offset +=
-            snprintf(xpath + offset, STATUS_PATH_MAX - offset,
-                     "/" XML_LRM_TAG_RSC_OP "[@operation='%s' and @migrate_source='%s']", op,
-                     source);
+        g_string_append_printf(xpath,
+                               "and @" XML_LRM_ATTR_MIGRATE_SOURCE "='%s']",
+                               source);
     } else {
-        offset +=
-            snprintf(xpath + offset, STATUS_PATH_MAX - offset,
-                     "/" XML_LRM_TAG_RSC_OP "[@operation='%s']", op);
+        g_string_append_c(xpath, ']');
     }
 
-    CRM_LOG_ASSERT(offset > 0);
-    xml = get_xpath_object(xpath, data_set->input, LOG_DEBUG);
+    xml = get_xpath_object((const char *) xpath->str, data_set->input,
+                           LOG_DEBUG);
+    g_string_free(xpath, TRUE);
 
     if (xml && target_rc >= 0) {
         int rc = PCMK_OCF_UNKNOWN_ERROR;
@@ -2637,21 +2635,21 @@ static xmlNode *
 find_lrm_resource(const char *rsc_id, const char *node_name,
                   pe_working_set_t *data_set)
 {
-    int offset = 0;
-    char xpath[STATUS_PATH_MAX];
+    GString *xpath = NULL;
     xmlNode *xml = NULL;
 
     CRM_CHECK((rsc_id != NULL) && (node_name != NULL), return NULL);
 
-    offset += snprintf(xpath + offset, STATUS_PATH_MAX - offset,
-                       "//node_state[@uname='%s']", node_name);
-    offset +=
-        snprintf(xpath + offset, STATUS_PATH_MAX - offset,
-                 "//" XML_LRM_TAG_RESOURCE "[@id='%s']", rsc_id);
+    xpath = g_string_sized_new(256);
+    g_string_append_printf(xpath,
+                           "//" XML_CIB_TAG_STATE "[@" XML_ATTR_UNAME "='%s']"
+                           "//" XML_LRM_TAG_RESOURCE "[@" XML_ATTR_ID "='%s']",
+                           node_name, rsc_id);
 
-    CRM_LOG_ASSERT(offset > 0);
-    xml = get_xpath_object(xpath, data_set->input, LOG_DEBUG);
+    xml = get_xpath_object((const char *) xpath->str, data_set->input,
+                           LOG_DEBUG);
 
+    g_string_free(xpath, TRUE);
     return xml;
 }
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2591,18 +2591,22 @@ find_lrm_op(const char *resource, const char *op, const char *node, const char *
     char xpath[STATUS_PATH_MAX];
     xmlNode *xml = NULL;
 
+    CRM_CHECK((resource != NULL) && (op != NULL) && (node != NULL),
+              return NULL);
+
     offset += snprintf(xpath + offset, STATUS_PATH_MAX - offset, "//node_state[@uname='%s']", node);
     offset +=
         snprintf(xpath + offset, STATUS_PATH_MAX - offset, "//" XML_LRM_TAG_RESOURCE "[@id='%s']",
                  resource);
 
     /* Need to check against transition_magic too? */
-    if (source && pcmk__str_eq(op, CRMD_ACTION_MIGRATE, pcmk__str_casei)) {
+    if ((source != NULL) && (strcmp(op, CRMD_ACTION_MIGRATE) == 0)) {
         offset +=
             snprintf(xpath + offset, STATUS_PATH_MAX - offset,
                      "/" XML_LRM_TAG_RSC_OP "[@operation='%s' and @migrate_target='%s']", op,
                      source);
-    } else if (source && pcmk__str_eq(op, CRMD_ACTION_MIGRATED, pcmk__str_casei)) {
+
+    } else if ((source != NULL) && (strcmp(op, CRMD_ACTION_MIGRATED) == 0)) {
         offset +=
             snprintf(xpath + offset, STATUS_PATH_MAX - offset,
                      "/" XML_LRM_TAG_RSC_OP "[@operation='%s' and @migrate_source='%s']", op,
@@ -2636,6 +2640,8 @@ find_lrm_resource(const char *rsc_id, const char *node_name,
     int offset = 0;
     char xpath[STATUS_PATH_MAX];
     xmlNode *xml = NULL;
+
+    CRM_CHECK((rsc_id != NULL) && (node_name != NULL), return NULL);
 
     offset += snprintf(xpath + offset, STATUS_PATH_MAX - offset,
                        "//node_state[@uname='%s']", node_name);

--- a/lib/pengine/variant.h
+++ b/lib/pengine/variant.h
@@ -92,7 +92,7 @@ typedef struct pe__bundle_variant_data_s {
         char *container_network;
         char *ip_range_start;
         gboolean add_host;
-        char *container_host_options;
+        gchar *container_host_options;
         char *container_command;
         char *launcher_options;
         const char *attribute_target;


### PR DESCRIPTION
Skip the output functions in `bundle.c` for now: `pe__bundle_replica_output_html()`, `pe__bundle_replica_output_text()`, and `print_bundle_replica()`. Since we ultimately pass to `fprintf()`, it might make sense to use `LINE_MAX` as a size limit... not entirely sure. We can come back to those later if we want.

Some performance test results after each successive change, relative to the commits in https://github.com/ClusterLabs/pacemaker/pull/2857:
```
# tools/pcmk_simtimes -S percent /tmp/before_1000.txt /tmp/after_unpack_1000.txt | tail -1
Averages: +0.01s  +0.50%
# tools/pcmk_simtimes -s 0.1 -S percent /tmp/before_1000.txt /tmp/after_unpack_1000.txt | tail -1
Averages: +0.08s  +0.52%
# tools/pcmk_simtimes -s 0.1 -p 3 -S percent /tmp/before_1000.txt /tmp/after_unpack_1000.txt | tail -1
Averages: +0.04s  -0.16%

# tools/pcmk_simtimes -S percent /tmp/before_1000.txt /tmp/after_bundle_1000.txt | tail -1
Averages: +0.02s  +0.58%
# tools/pcmk_simtimes -s 0.1 -S percent /tmp/before_1000.txt /tmp/after_bundle_1000.txt | tail -1
Averages: +0.15s  +0.63%
# tools/pcmk_simtimes -s 0.1 -p 3 -S percent /tmp/before_1000.txt /tmp/after_bundle_1000.txt | tail -1
<empty>

# tools/pcmk_simtimes -S percent /tmp/before_1000.txt /tmp/after_pe_actions_1000.txt | tail -1
Averages: +0.02s  +0.65%
# tools/pcmk_simtimes -s 0.1 -S percent /tmp/before_1000.txt /tmp/after_pe_actions_1000.txt | tail -1
Averages: +0.21s  +0.37%
# tools/pcmk_simtimes -s 0.1 -p 3 -S percent /tmp/before_1000.txt /tmp/after_pe_actions_1000.txt | tail -1
Averages: -0.13s  -4.69%

# tools/pcmk_simtimes -S percent /tmp/before_1000.txt /tmp/after_cib_attrs_1000.txt | tail -1
Averages: +0.01s  +0.58%
# tools/pcmk_simtimes -s 0.1 -S percent /tmp/before_1000.txt /tmp/after_cib_attrs_1000.txt | tail -1
Averages: +0.08s  +0.47%
# tools/pcmk_simtimes -s 0.1 -p 3 -S percent /tmp/before_1000.txt /tmp/after_cib_attrs_1000.txt | tail -1
Averages: -0.14s  -5.34%
```