### PR TITLE
Replace g_string_append_printf() with new pcmk__g_strcat() function

### DIFF
--- a/cts/Makefile.am
+++ b/cts/Makefile.am
@@ -36,6 +36,7 @@ dist_cli_DATA	= cli/constraints.xml 				\
 		  cli/crm_resource_digests.xml			\
 		  cli/regression.acls.exp			\
 		  cli/regression.crm_mon.exp			\
+		  cli/regression.daemons.exp			\
 		  cli/regression.dates.exp			\
 		  cli/regression.error_codes.exp		\
 		  cli/regression.feature_set.exp		\

--- a/cts/cli/regression.daemons.exp
+++ b/cts/cli/regression.daemons.exp
@@ -1,0 +1,441 @@
+=#=#=#= Begin test: Get CIB manager metadata =#=#=#=
+<?xml version=""?>
+<resource-agent name="pacemaker-based" version="">
+  <version>1.1</version>
+  <longdesc lang="en">Cluster options used by Pacemaker&apos;s Cluster Information Base manager</longdesc>
+  <shortdesc lang="en">Cluster Information Base manager options</shortdesc>
+  <parameters>
+    <parameter name="enable-acl">
+      <longdesc lang="en">Enable Access Control Lists (ACLs) for the CIB</longdesc>
+      <shortdesc lang="en">Enable Access Control Lists (ACLs) for the CIB</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="cluster-ipc-limit">
+      <longdesc lang="en">Raise this if log has &quot;Evicting client&quot; messages for cluster daemon PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).</longdesc>
+      <shortdesc lang="en">Maximum IPC message backlog before disconnecting a cluster daemon</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+  </parameters>
+</resource-agent>
+=#=#=#= End test: Get CIB manager metadata - OK (0) =#=#=#=
+* Passed: pacemaker-based - Get CIB manager metadata
+=#=#=#= Begin test: Get controller metadata =#=#=#=
+<?xml version=""?>
+<resource-agent name="pacemaker-controld" version="">
+  <version>1.1</version>
+  <longdesc lang="en">Cluster options used by Pacemaker&apos;s controller</longdesc>
+  <shortdesc lang="en">Pacemaker controller options</shortdesc>
+  <parameters>
+    <parameter name="dc-version">
+      <longdesc lang="en">Includes a hash which identifies the exact changeset the code was built from. Used for diagnostic purposes.</longdesc>
+      <shortdesc lang="en">Pacemaker version on cluster node elected Designated Controller (DC)</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="cluster-infrastructure">
+      <longdesc lang="en">Used for informational and diagnostic purposes.</longdesc>
+      <shortdesc lang="en">The messaging stack on which Pacemaker is currently running</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="cluster-name">
+      <longdesc lang="en">This optional value is mostly for users&apos; convenience as desired in administration, but may also be used in Pacemaker configuration rules via the #cluster-name node attribute, and by higher-level tools and resource agents.</longdesc>
+      <shortdesc lang="en">An arbitrary name for the cluster</shortdesc>
+      <content type="string"/>
+    </parameter>
+    <parameter name="dc-deadtime">
+      <longdesc lang="en">The optimal value will depend on the speed and load of your network and the type of switches used.</longdesc>
+      <shortdesc lang="en">How long to wait for a response from other nodes during start-up</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="cluster-recheck-interval">
+      <longdesc lang="en">Pacemaker is primarily event-driven, and looks ahead to know when to recheck cluster state for failure timeouts and most time-based rules. However, it will also recheck the cluster after this amount of inactivity, to evaluate rules with date specifications and serve as a fail-safe for certain types of scheduler bugs.  Allowed values: Zero disables polling, while positive values are an interval in seconds(unless other units are specified, for example "5min")</longdesc>
+      <shortdesc lang="en">Polling interval to recheck cluster state and evaluate rules with date specifications</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="load-threshold">
+      <longdesc lang="en">The cluster will slow down its recovery process when the amount of system resources used (currently CPU) approaches this limit</longdesc>
+      <shortdesc lang="en">Maximum amount of system load that should be used by cluster nodes</shortdesc>
+      <content type="percentage" default=""/>
+    </parameter>
+    <parameter name="node-action-limit">
+      <longdesc lang="en">Maximum number of jobs that can be scheduled per node (defaults to 2x cores)</longdesc>
+      <shortdesc lang="en">Maximum number of jobs that can be scheduled per node (defaults to 2x cores)</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="fence-reaction">
+      <longdesc lang="en">A cluster node may receive notification of its own fencing if fencing is misconfigured, or if fabric fencing is in use that doesn&apos;t cut cluster communication. Allowed values are &quot;stop&quot; to attempt to immediately stop Pacemaker and stay stopped, or &quot;panic&quot; to attempt to immediately reboot the local node, falling back to stop on failure.</longdesc>
+      <shortdesc lang="en">How a cluster node should react if notified of its own fencing</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="election-timeout">
+      <longdesc lang="en">Declare an election failed if it is not decided within this much time. If you need to adjust this value, it probably indicates the presence of a bug.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only ***</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="shutdown-escalation">
+      <longdesc lang="en">Exit immediately if shutdown does not complete within this much time. If you need to adjust this value, it probably indicates the presence of a bug.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only ***</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="join-integration-timeout">
+      <longdesc lang="en">If you need to adjust this value, it probably indicates the presence of a bug.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only ***</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="join-finalization-timeout">
+      <longdesc lang="en">If you need to adjust this value, it probably indicates the presence of a bug.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only ***</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="transition-delay">
+      <longdesc lang="en">Delay cluster recovery for this much time to allow for additional events to occur. Useful if your configuration is sensitive to the order in which ping updates arrive.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** Enabling this option will slow down cluster recovery under all conditions</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="stonith-watchdog-timeout">
+      <longdesc lang="en">If this is set to a positive value, lost nodes are assumed to self-fence using watchdog-based SBD within this much time. This does not require a fencing resource to be explicitly configured, though a fence_watchdog resource can be configured, to limit use to specific nodes. If this is set to 0 (the default), the cluster will never assume watchdog-based self-fencing. If this is set to a negative value, the cluster will use twice the local value of the `SBD_WATCHDOG_TIMEOUT` environment variable if that is positive, or otherwise treat this as 0. WARNING: When used, this timeout must be larger than `SBD_WATCHDOG_TIMEOUT` on all nodes that use watchdog-based SBD, and Pacemaker will refuse to start on any of those nodes where this is not true for the local value or SBD is not active. When this is set to a negative value, `SBD_WATCHDOG_TIMEOUT` must be set to the same value on all nodes that use SBD, otherwise data corruption or loss could occur.</longdesc>
+      <shortdesc lang="en">How long before nodes can be assumed to be safely down when watchdog-based self-fencing via SBD is in use</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="stonith-max-attempts">
+      <longdesc lang="en">How many times fencing can fail before it will no longer be immediately re-attempted on a target</longdesc>
+      <shortdesc lang="en">How many times fencing can fail before it will no longer be immediately re-attempted on a target</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="no-quorum-policy">
+      <longdesc lang="en">What to do when the cluster does not have quorum  Allowed values: stop, freeze, ignore, demote, suicide</longdesc>
+      <shortdesc lang="en">What to do when the cluster does not have quorum</shortdesc>
+      <content type="select" default="">
+        <option value="stop" />
+        <option value="freeze" />
+        <option value="ignore" />
+        <option value="demote" />
+        <option value="suicide" />
+      </content>
+    </parameter>
+    <parameter name="shutdown-lock">
+      <longdesc lang="en">When true, resources active on a node when it is cleanly shut down are kept &quot;locked&quot; to that node (not allowed to run elsewhere) until they start again on that node after it rejoins (or for at most shutdown-lock-limit, if set). Stonith resources and Pacemaker Remote connections are never locked. Clone and bundle instances and the promoted role of promotable clones are currently never locked, though support could be added in a future release.</longdesc>
+      <shortdesc lang="en">Whether to lock resources to a cleanly shut down node</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+  </parameters>
+</resource-agent>
+=#=#=#= End test: Get controller metadata - OK (0) =#=#=#=
+* Passed: pacemaker-controld - Get controller metadata
+=#=#=#= Begin test: Get fencer metadata =#=#=#=
+<?xml version=""?>
+<resource-agent name="pacemaker-fenced" version="">
+  <version>1.1</version>
+  <longdesc lang="en">Instance attributes available for all &quot;stonith&quot;-class resources and used by Pacemaker&apos;s fence daemon, formerly known as stonithd</longdesc>
+  <shortdesc lang="en">Instance attributes available for all &quot;stonith&quot;-class resources</shortdesc>
+  <parameters>
+    <parameter name="pcmk_host_argument">
+      <longdesc lang="en">some devices do not support the standard &apos;port&apos; parameter or may provide additional ones. Use this to specify an alternate, device-specific, parameter that should indicate the machine to be fenced. A value of none can be used to tell the cluster not to supply any additional parameters.</longdesc>
+      <shortdesc lang="en">Advanced use only: An alternate parameter to supply instead of &apos;port&apos;</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="pcmk_host_map">
+      <longdesc lang="en">Eg. node1:1;node2:2,3 would tell the cluster to use port 1 for node1 and ports 2 and 3 for node2</longdesc>
+      <shortdesc lang="en">A mapping of host names to ports numbers for devices that do not support host names.</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="pcmk_host_list">
+      <longdesc lang="en">A list of machines controlled by this device (Optional unless pcmk_host_list=static-list)</longdesc>
+      <shortdesc lang="en">Eg. node1,node2,node3</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="pcmk_host_check">
+      <longdesc lang="en">Allowed values: dynamic-list (query the device via the &apos;list&apos; command), static-list (check the pcmk_host_list attribute), status (query the device via the &apos;status&apos; command), none (assume every device can fence every machine)</longdesc>
+      <shortdesc lang="en">How to determine which machines are controlled by the device.</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="pcmk_delay_max">
+      <longdesc lang="en">Enable a delay of no more than the time specified before executing fencing actions. Pacemaker derives the overall delay by taking the value of pcmk_delay_base and adding a random delay value such that the sum is kept below this maximum.</longdesc>
+      <shortdesc lang="en">Enable a base delay for fencing actions and specify base delay value.</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="pcmk_delay_base">
+      <longdesc lang="en">This enables a static delay for fencing actions, which can help avoid &quot;death matches&quot; where two nodes try to fence each other at the same time. If pcmk_delay_max  is also used, a random delay will be added such that the total delay is kept below that value.This can be set to a single time value to apply to any node targeted by this device (useful if a separate device is configured for each target), or to a node map (for example, &quot;node1:1s;node2:5&quot;) to set a different value per target.</longdesc>
+      <shortdesc lang="en">Enable a base delay for fencing actions and specify base delay value.</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="pcmk_action_limit">
+      <longdesc lang="en">Cluster property concurrent-fencing=true needs to be configured first.Then use this to specify the maximum number of actions can be performed in parallel on this device. -1 is unlimited.</longdesc>
+      <shortdesc lang="en">The maximum number of actions can be performed in parallel on this device</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="pcmk_reboot_action">
+      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones.\nUse this to specify an alternate, device-specific, command that implements the &apos;reboot&apos; action.</longdesc>
+      <shortdesc lang="en">Advanced use only: An alternate command to run instead of &apos;reboot&apos;</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="pcmk_reboot_timeout">
+      <longdesc lang="en">Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for &apos;reboot&apos; actions.</longdesc>
+      <shortdesc lang="en">Advanced use only: Specify an alternate timeout to use for reboot actions instead of stonith-timeout</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="pcmk_reboot_retries">
+      <longdesc lang="en">Some devices do not support multiple connections. Operations may &apos;fail&apos; if the device is busy with another task so Pacemaker will automatically retry the operation,      if there is time remaining. Use this option to alter the number of times Pacemaker retries &apos;reboot&apos; actions before giving up.</longdesc>
+      <shortdesc lang="en">Advanced use only: The maximum number of times to retry the &apos;reboot&apos; command within the timeout period</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="pcmk_off_action">
+      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the &apos;off&apos; action.</longdesc>
+      <shortdesc lang="en">Advanced use only: An alternate command to run instead of &apos;off&apos;</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="pcmk_off_timeout">
+      <longdesc lang="en">Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for &apos;off&apos; actions.</longdesc>
+      <shortdesc lang="en">Advanced use only: Specify an alternate timeout to use for off actions instead of stonith-timeout</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="pcmk_off_retries">
+      <longdesc lang="en">Some devices do not support multiple connections. Operations may &apos;fail&apos; if the device is busy with another task so Pacemaker will automatically retry the operation,      if there is time remaining. Use this option to alter the number of times Pacemaker retries &apos;off&apos; actions before giving up.</longdesc>
+      <shortdesc lang="en">Advanced use only: The maximum number of times to retry the &apos;off&apos; command within the timeout period</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="pcmk_on_action">
+      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the &apos;on&apos; action.</longdesc>
+      <shortdesc lang="en">Advanced use only: An alternate command to run instead of &apos;on&apos;</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="pcmk_on_timeout">
+      <longdesc lang="en">Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for &apos;on&apos; actions.</longdesc>
+      <shortdesc lang="en">Advanced use only: Specify an alternate timeout to use for on actions instead of stonith-timeout</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="pcmk_on_retries">
+      <longdesc lang="en">Some devices do not support multiple connections. Operations may &apos;fail&apos; if the device is busy with another task so Pacemaker will automatically retry the operation,      if there is time remaining. Use this option to alter the number of times Pacemaker retries &apos;on&apos; actions before giving up.</longdesc>
+      <shortdesc lang="en">Advanced use only: The maximum number of times to retry the &apos;on&apos; command within the timeout period</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="pcmk_list_action">
+      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the &apos;list&apos; action.</longdesc>
+      <shortdesc lang="en">Advanced use only: An alternate command to run instead of &apos;list&apos;</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="pcmk_list_timeout">
+      <longdesc lang="en">Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for &apos;list&apos; actions.</longdesc>
+      <shortdesc lang="en">Advanced use only: Specify an alternate timeout to use for list actions instead of stonith-timeout</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="pcmk_list_retries">
+      <longdesc lang="en">Some devices do not support multiple connections. Operations may &apos;fail&apos; if the device is busy with another task so Pacemaker will automatically retry the operation,      if there is time remaining. Use this option to alter the number of times Pacemaker retries &apos;list&apos; actions before giving up.</longdesc>
+      <shortdesc lang="en">Advanced use only: The maximum number of times to retry the &apos;list&apos; command within the timeout period</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="pcmk_monitor_action">
+      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the &apos;monitor&apos; action.</longdesc>
+      <shortdesc lang="en">Advanced use only: An alternate command to run instead of &apos;monitor&apos;</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="pcmk_monitor_timeout">
+      <longdesc lang="en">Some devices need much more/less time to complete than normal.\nUse this to specify an alternate, device-specific, timeout for &apos;monitor&apos; actions.</longdesc>
+      <shortdesc lang="en">Advanced use only: Specify an alternate timeout to use for monitor actions instead of stonith-timeout</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="pcmk_monitor_retries">
+      <longdesc lang="en">Some devices do not support multiple connections. Operations may &apos;fail&apos; if the device is busy with another task so Pacemaker will automatically retry the operation,      if there is time remaining. Use this option to alter the number of times Pacemaker retries &apos;monitor&apos; actions before giving up.</longdesc>
+      <shortdesc lang="en">Advanced use only: The maximum number of times to retry the &apos;monitor&apos; command within the timeout period</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="pcmk_status_action">
+      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the &apos;status&apos; action.</longdesc>
+      <shortdesc lang="en">Advanced use only: An alternate command to run instead of &apos;status&apos;</shortdesc>
+      <content type="string" default=""/>
+    </parameter>
+    <parameter name="pcmk_status_timeout">
+      <longdesc lang="en">Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for &apos;status&apos; actions.</longdesc>
+      <shortdesc lang="en">Advanced use only: Specify an alternate timeout to use for status actions instead of stonith-timeout</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="pcmk_status_retries">
+      <longdesc lang="en">Some devices do not support multiple connections. Operations may &apos;fail&apos; if the device is busy with another task so Pacemaker will automatically retry the operation,      if there is time remaining. Use this option to alter the number of times Pacemaker retries &apos;status&apos; actions before giving up.</longdesc>
+      <shortdesc lang="en">Advanced use only: The maximum number of times to retry the &apos;status&apos; command within the timeout period</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+  </parameters>
+</resource-agent>
+=#=#=#= End test: Get fencer metadata - OK (0) =#=#=#=
+* Passed: pacemaker-fenced - Get fencer metadata
+=#=#=#= Begin test: Get scheduler metadata =#=#=#=
+<?xml version=""?>
+<resource-agent name="pacemaker-schedulerd" version="">
+  <version>1.1</version>
+  <longdesc lang="en">Cluster options used by Pacemaker&apos;s scheduler</longdesc>
+  <shortdesc lang="en">Pacemaker scheduler options</shortdesc>
+  <parameters>
+    <parameter name="no-quorum-policy">
+      <longdesc lang="en">What to do when the cluster does not have quorum  Allowed values: stop, freeze, ignore, demote, suicide</longdesc>
+      <shortdesc lang="en">What to do when the cluster does not have quorum</shortdesc>
+      <content type="select" default="">
+        <option value="stop" />
+        <option value="freeze" />
+        <option value="ignore" />
+        <option value="demote" />
+        <option value="suicide" />
+      </content>
+    </parameter>
+    <parameter name="symmetric-cluster">
+      <longdesc lang="en">Whether resources can run on any node by default</longdesc>
+      <shortdesc lang="en">Whether resources can run on any node by default</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="maintenance-mode">
+      <longdesc lang="en">Whether the cluster should refrain from monitoring, starting, and stopping resources</longdesc>
+      <shortdesc lang="en">Whether the cluster should refrain from monitoring, starting, and stopping resources</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="start-failure-is-fatal">
+      <longdesc lang="en">When true, the cluster will immediately ban a resource from a node if it fails to start there. When false, the cluster will instead check the resource&apos;s fail count against its migration-threshold.</longdesc>
+      <shortdesc lang="en">Whether a start failure should prevent a resource from being recovered on the same node</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="enable-startup-probes">
+      <longdesc lang="en">Whether the cluster should check for active resources during start-up</longdesc>
+      <shortdesc lang="en">Whether the cluster should check for active resources during start-up</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="shutdown-lock">
+      <longdesc lang="en">When true, resources active on a node when it is cleanly shut down are kept &quot;locked&quot; to that node (not allowed to run elsewhere) until they start again on that node after it rejoins (or for at most shutdown-lock-limit, if set). Stonith resources and Pacemaker Remote connections are never locked. Clone and bundle instances and the promoted role of promotable clones are currently never locked, though support could be added in a future release.</longdesc>
+      <shortdesc lang="en">Whether to lock resources to a cleanly shut down node</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="shutdown-lock-limit">
+      <longdesc lang="en">If shutdown-lock is true and this is set to a nonzero time duration, shutdown locks will expire after this much time has passed since the shutdown was initiated, even if the node has not rejoined.</longdesc>
+      <shortdesc lang="en">Do not lock resources to a cleanly shut down node longer than this</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="stonith-enabled">
+      <longdesc lang="en">If false, unresponsive nodes are immediately assumed to be harmless, and resources that were active on them may be recovered elsewhere. This can result in a &quot;split-brain&quot; situation, potentially leading to data loss and/or service unavailability.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** Whether nodes may be fenced as part of recovery</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="stonith-action">
+      <longdesc lang="en">Action to send to fence device when a node needs to be fenced (&quot;poweroff&quot; is a deprecated alias for &quot;off&quot;)  Allowed values: reboot, off, poweroff</longdesc>
+      <shortdesc lang="en">Action to send to fence device when a node needs to be fenced (&quot;poweroff&quot; is a deprecated alias for &quot;off&quot;)</shortdesc>
+      <content type="select" default="">
+        <option value="reboot" />
+        <option value="off" />
+        <option value="poweroff" />
+      </content>
+    </parameter>
+    <parameter name="stonith-timeout">
+      <longdesc lang="en">This value is not used by Pacemaker, but is kept for backward compatibility, and certain legacy fence agents might use it.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** Unused by Pacemaker</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="have-watchdog">
+      <longdesc lang="en">This is set automatically by the cluster according to whether SBD is detected to be in use. User-configured values are ignored. The value `true` is meaningful if diskless SBD is used and `stonith-watchdog-timeout` is nonzero. In that case, if fencing is required, watchdog-based self-fencing will be performed via SBD without requiring a fencing resource explicitly configured.</longdesc>
+      <shortdesc lang="en">Whether watchdog integration is enabled</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="concurrent-fencing">
+      <longdesc lang="en">Allow performing fencing operations in parallel</longdesc>
+      <shortdesc lang="en">Allow performing fencing operations in parallel</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="startup-fencing">
+      <longdesc lang="en">Setting this to false may lead to a &quot;split-brain&quot; situation,potentially leading to data loss and/or service unavailability.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** Whether to fence unseen nodes at start-up</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="priority-fencing-delay">
+      <longdesc lang="en">Apply specified delay for the fencings that are targeting the lost nodes with the highest total resource priority in case we don&apos;t have the majority of the nodes in our cluster partition, so that the more significant nodes potentially win any fencing match, which is especially meaningful under split-brain of 2-node cluster. A promoted resource instance takes the base priority + 1 on calculation if the base priority is not 0. Any static/random delays that are introduced by `pcmk_delay_base/max` configured for the corresponding fencing resources will be added to this delay. This delay should be significantly greater than, safely twice, the maximum `pcmk_delay_base/max`. By default, priority fencing delay is disabled.</longdesc>
+      <shortdesc lang="en">Apply fencing delay targeting the lost nodes with the highest total resource priority</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="cluster-delay">
+      <longdesc lang="en">The node elected Designated Controller (DC) will consider an action failed if it does not get a response from the node executing the action within this time (after considering the action&apos;s own timeout). The &quot;correct&quot; value will depend on the speed and load of your network and cluster nodes.</longdesc>
+      <shortdesc lang="en">Maximum time for node-to-node communication</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
+    <parameter name="batch-limit">
+      <longdesc lang="en">The &quot;correct&quot; value will depend on the speed and load of your network and cluster nodes. If set to 0, the cluster will impose a dynamically calculated limit when any node has a high load.</longdesc>
+      <shortdesc lang="en">Maximum number of jobs that the cluster may execute in parallel across all nodes</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="migration-limit">
+      <longdesc lang="en">The number of live migration actions that the cluster is allowed to execute in parallel on a node (-1 means no limit)</longdesc>
+      <shortdesc lang="en">The number of live migration actions that the cluster is allowed to execute in parallel on a node (-1 means no limit)</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="stop-all-resources">
+      <longdesc lang="en">Whether the cluster should stop all active resources</longdesc>
+      <shortdesc lang="en">Whether the cluster should stop all active resources</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="stop-orphan-resources">
+      <longdesc lang="en">Whether to stop resources that were removed from the configuration</longdesc>
+      <shortdesc lang="en">Whether to stop resources that were removed from the configuration</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="stop-orphan-actions">
+      <longdesc lang="en">Whether to cancel recurring actions removed from the configuration</longdesc>
+      <shortdesc lang="en">Whether to cancel recurring actions removed from the configuration</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="remove-after-stop">
+      <longdesc lang="en">Values other than default are poorly tested and potentially dangerous. This option will be removed in a future release.</longdesc>
+      <shortdesc lang="en">*** Deprecated *** Whether to remove stopped resources from the executor</shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="pe-error-series-max">
+      <longdesc lang="en">Zero to disable, -1 to store unlimited.</longdesc>
+      <shortdesc lang="en">The number of scheduler inputs resulting in errors to save</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="pe-warn-series-max">
+      <longdesc lang="en">Zero to disable, -1 to store unlimited.</longdesc>
+      <shortdesc lang="en">The number of scheduler inputs resulting in warnings to save</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="pe-input-series-max">
+      <longdesc lang="en">Zero to disable, -1 to store unlimited.</longdesc>
+      <shortdesc lang="en">The number of scheduler inputs without errors or warnings to save</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="node-health-strategy">
+      <longdesc lang="en">Requires external entities to create node attributes (named with the prefix &quot;#health&quot;) with values &quot;red&quot;, &quot;yellow&quot;, or &quot;green&quot;.  Allowed values: none, migrate-on-red, only-green, progressive, custom</longdesc>
+      <shortdesc lang="en">How cluster should react to node health attributes</shortdesc>
+      <content type="select" default="">
+        <option value="none" />
+        <option value="migrate-on-red" />
+        <option value="only-green" />
+        <option value="progressive" />
+        <option value="custom" />
+      </content>
+    </parameter>
+    <parameter name="node-health-base">
+      <longdesc lang="en">Only used when node-health-strategy is set to progressive.</longdesc>
+      <shortdesc lang="en">Base health score assigned to a node</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="node-health-green">
+      <longdesc lang="en">Only used when node-health-strategy is set to custom or progressive.</longdesc>
+      <shortdesc lang="en">The score to use for a node health attribute whose value is &quot;green&quot;</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="node-health-yellow">
+      <longdesc lang="en">Only used when node-health-strategy is set to custom or progressive.</longdesc>
+      <shortdesc lang="en">The score to use for a node health attribute whose value is &quot;yellow&quot;</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="node-health-red">
+      <longdesc lang="en">Only used when node-health-strategy is set to custom or progressive.</longdesc>
+      <shortdesc lang="en">The score to use for a node health attribute whose value is &quot;red&quot;</shortdesc>
+      <content type="integer" default=""/>
+    </parameter>
+    <parameter name="placement-strategy">
+      <longdesc lang="en">How the cluster should allocate resources to nodes  Allowed values: default, utilization, minimal, balanced</longdesc>
+      <shortdesc lang="en">How the cluster should allocate resources to nodes</shortdesc>
+      <content type="select" default="">
+        <option value="default" />
+        <option value="utilization" />
+        <option value="minimal" />
+        <option value="balanced" />
+      </content>
+    </parameter>
+  </parameters>
+</resource-agent>
+=#=#=#= End test: Get scheduler metadata - OK (0) =#=#=#=
+* Passed: pacemaker-schedulerd - Get scheduler metadata

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -2429,8 +2429,8 @@ for t in $tests; do
         -e 's/(version .*)/(version)/' \
         -e 's/last_update time=\".*\"/last_update time=\"\"/' \
         -e 's/last_change time=\".*\"/last_change time=\"\"/' \
-        -e 's/ api-version=\".*\" / api-version=\"X\" /' \
-        -e 's/ version="[^"]*" / version="" /' \
+        -e 's/ api-version="[^"]*"/ api-version="X"/' \
+        -e 's/ version="[^"]*"/ version=""/' \
         -e 's/request=\".*\(crm_[a-zA-Z0-9]*\)/request=\"\1/' \
         -e 's/crm_feature_set="[^"]*" //'\
         -e 's/validate-with="[^"]*" //'\

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -23,8 +23,8 @@ Options:
  --help          Display this text, then exit
  -V, --verbose   Display any differences from expected output
  -t 'TEST [...]' Run only specified tests
-                 (default: 'dates error_codes tools crm_mon acls validity
-                            upgrade rules feature_set').
+                 (default: 'daemons dates error_codes tools crm_mon acls
+                            validity upgrade rules feature_set').
                  Other tests: agents (must be run in an installed environment).
  -p DIR          Look for executables in DIR (may be specified multiple times)
  -v, --valgrind  Run all commands under valgrind
@@ -43,7 +43,8 @@ shadow_dir=$(mktemp -d ${TMPDIR:-/tmp}/cts-cli.shadow.XXXXXXXXXX)
 num_errors=0
 num_passed=0
 verbose=0
-tests="dates error_codes tools crm_mon acls validity upgrade rules feature_set"
+tests="daemons dates error_codes tools crm_mon acls validity upgrade rules "
+tests="$tests feature_set"
 do_save=0
 XMLLINT_CMD=
 VALGRIND_CMD=
@@ -224,6 +225,24 @@ function test_agents() {
 
     unset OCF_RESKEY_op_sleep
     export OCF_RESKEY_op_sleep
+}
+
+function test_daemons() {
+    desc="Get CIB manager metadata"
+    cmd="pacemaker-based metadata"
+    test_assert $CRM_EX_OK 0
+
+    desc="Get controller metadata"
+    cmd="pacemaker-controld metadata"
+    test_assert $CRM_EX_OK 0
+
+    desc="Get fencer metadata"
+    cmd="pacemaker-fenced metadata"
+    test_assert $CRM_EX_OK 0
+
+    desc="Get scheduler metadata"
+    cmd="pacemaker-schedulerd metadata"
+    test_assert $CRM_EX_OK 0
 }
 
 function test_crm_mon() {
@@ -2375,6 +2394,7 @@ done
 for t in $tests; do
     case "$t" in
         agents) ;;
+        daemons) ;;
         dates) ;;
         error_codes) ;;
         tools) ;;
@@ -2402,8 +2422,15 @@ fi
 # Check whether we're running from source directory
 SRCDIR=$(dirname $test_home)
 if [ -x "$SRCDIR/tools/crm_simulate" ]; then
-    export PATH="$SRCDIR/tools:$PATH"
-    echo "Using local binaries from: $SRCDIR/tools"
+    path_dirs="$SRCDIR/tools"
+    for daemon in based controld fenced schedulerd; do
+        if [ -x "$SRCDIR/daemons/$daemon/pacemaker-${daemon}" ]; then
+            path_dirs="$path_dirs:$SRCDIR/daemons/$daemon"
+        fi
+    done
+    export PATH="$path_dirs:$PATH"
+
+    echo "Using local binaries from: ${path_dirs//:/ }"
 
     if [ -x "$SRCDIR/xml" ]; then
         export PCMK_schema_directory="$SRCDIR/xml"
@@ -2430,6 +2457,7 @@ for t in $tests; do
         -e 's/last_update time=\".*\"/last_update time=\"\"/' \
         -e 's/last_change time=\".*\"/last_change time=\"\"/' \
         -e 's/ api-version="[^"]*"/ api-version="X"/' \
+        -e 's/ default="[^"]*"/ default=""/' \
         -e 's/ version="[^"]*"/ version=""/' \
         -e 's/request=\".*\(crm_[a-zA-Z0-9]*\)/request=\"\1/' \
         -e 's/crm_feature_set="[^"]*" //'\

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -649,12 +649,21 @@ static pcmk__cluster_option_t controller_options[] = {
 
     // Already documented in libpe_status (other values must be kept identical)
     {
-        "no-quorum-policy", NULL, "select", "stop, freeze, ignore, demote, suicide",
-        "stop", pcmk__valid_quorum, NULL, NULL
+        "no-quorum-policy", NULL, "select",
+        "stop, freeze, ignore, demote, suicide", "stop", pcmk__valid_quorum,
+        "What to do when the cluster does not have quorum", NULL
     },
     {
         XML_CONFIG_ATTR_SHUTDOWN_LOCK, NULL, "boolean", NULL,
-        "false", pcmk__valid_boolean, NULL, NULL
+        "false", pcmk__valid_boolean,
+        "Whether to lock resources to a cleanly shut down node",
+        "When true, resources active on a node when it is cleanly shut down "
+            "are kept \"locked\" to that node (not allowed to run elsewhere) "
+            "until they start again on that node after it rejoins (or for at "
+            "most shutdown-lock-limit, if set). Stonith resources and "
+            "Pacemaker Remote connections are never locked. Clone and bundle "
+            "instances and the promoted role of promotable clones are currently"
+            " never locked, though support could be added in a future release."
     },
 };
 

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -142,6 +142,7 @@ bool pcmk__char_in_any_str(int ch, ...) G_GNUC_NULL_TERMINATED;
 int pcmk__strcmp(const char *s1, const char *s2, uint32_t flags);
 int pcmk__numeric_strcasecmp(const char *s1, const char *s2);
 void pcmk__str_update(char **str, const char *value);
+void pcmk__g_strcat(GString *buffer, ...) G_GNUC_NULL_TERMINATED;
 
 static inline bool
 pcmk__str_eq(const char *s1, const char *s2, uint32_t flags)

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -87,18 +87,18 @@ create_acl(xmlNode *xml, GList *acls, enum xml_private_flags mode)
 
         if ((ref != NULL) && (attr != NULL)) {
             // NOTE: schema currently does not allow this
-            g_string_append_printf(buf, "//%s[@" XML_ATTR_ID "='%s' and @%s]",
-                                   pcmk__s(tag, "*"), ref, attr);
+            pcmk__g_strcat(buf, "//", pcmk__s(tag, "*"), "[@" XML_ATTR_ID "='",
+                           ref, "' and @", attr, "]", NULL);
 
         } else if (ref != NULL) {
-            g_string_append_printf(buf, "//%s[@" XML_ATTR_ID "='%s']",
-                                   pcmk__s(tag, "*"), ref);
+            pcmk__g_strcat(buf, "//", pcmk__s(tag, "*"), "[@" XML_ATTR_ID "='",
+                           ref, "']", NULL);
 
         } else if (attr != NULL) {
-            g_string_append_printf(buf, "//%s[@%s]", pcmk__s(tag, "*"), attr);
+            pcmk__g_strcat(buf, "//", pcmk__s(tag, "*"), "[@", attr, "]", NULL);
 
         } else {
-            g_string_append_printf(buf, "//%s", pcmk__s(tag, "*"));
+            pcmk__g_strcat(buf, "//", pcmk__s(tag, "*"), NULL);
         }
 
         acl->xpath = strdup((const char *) buf->str);
@@ -668,7 +668,7 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
             pcmk__log_else(LOG_TRACE, return false);
             xpath = pcmk__element_xpath(xml);
             if (name != NULL) {
-                g_string_append_printf(xpath, "[@%s]", name);
+                pcmk__g_strcat(xpath, "[@", name, "]", NULL);
             }
 
             qb_log_from_external_source(__func__, __FILE__,
@@ -704,7 +704,7 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
                 pcmk__log_else(LOG_TRACE, return false);
                 xpath = pcmk__element_xpath(xml);
                 if (name != NULL) {
-                    g_string_append_printf(xpath, "[@%s]", name);
+                    pcmk__g_strcat(xpath, "[@", name, "]", NULL);
                 }
 
                 qb_log_from_external_source(__func__, __FILE__,
@@ -724,7 +724,7 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
         pcmk__log_else(LOG_TRACE, return false);
         xpath = pcmk__element_xpath(xml);
         if (name != NULL) {
-            g_string_append_printf(xpath, "[@%s]", name);
+            pcmk__g_strcat(xpath, "[@", name, "]", NULL);
         }
 
         qb_log_from_external_source(__func__, __FILE__,

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -174,15 +174,15 @@ pcmk__quote_cmdline(gchar **argv)
 
     for (int i = 0; argv[i] != NULL; i++) {
         if (i > 0) {
-            g_string_append(gs, " ");
+            g_string_append_c(gs, ' ');
         }
 
         if (strchr(argv[i], ' ') == NULL) {
             /* The arg does not contain a space. */
-            g_string_append_printf(gs, "%s", argv[i]);
+            g_string_append(gs, argv[i]);
         } else if (strchr(argv[i], '\'') == NULL) {
             /* The arg contains a space, but not a single quote. */
-            g_string_append_printf(gs, "'%s'", argv[i]);
+            pcmk__g_strcat(gs, "'", argv[i], "'", NULL);
         } else {
             /* The arg contains both a space and a single quote, which needs to
              * be replaced with an escaped version.  We do this instead of counting
@@ -203,7 +203,7 @@ pcmk__quote_cmdline(gchar **argv)
              * It's simplest to just escape with a backslash.
              */
             gchar *repl = string_replace(argv[i], "'", "\\\'");
-            g_string_append_printf(gs, "'%s'", repl);
+            pcmk__g_strcat(gs, "'", repl, "'", NULL);
             g_free(repl);
         }
     }

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -602,13 +602,12 @@ add_desc(GString *s, const char *tag, const char *desc, const char *values,
     if (spaces != NULL) {
         g_string_append(s, spaces);
     }
-    g_string_append_printf(s, "<%s lang=\"en\">%s",
-                           tag, escaped_en);
+    pcmk__g_strcat(s, "<", tag, " lang=\"en\">", escaped_en, NULL);
 
     if (values != NULL) {
-        g_string_append_printf(s, "  Allowed values: %s", values);
+        pcmk__g_strcat(s, "  Allowed values: ", values, NULL);
     }
-    g_string_append_printf(s, "</%s>\n", tag);
+    pcmk__g_strcat(s, "</", tag, ">\n", NULL);
 
 #ifdef ENABLE_NLS
     {
@@ -624,14 +623,13 @@ add_desc(GString *s, const char *tag, const char *desc, const char *values,
             if (spaces != NULL) {
                 g_string_append(s, spaces);
             }
-            g_string_append_printf(s, "<%s lang=\"%s\">%s",
-                                   tag, locale, localized);
+            pcmk__g_strcat(s, "<", tag, " lang=\"", locale, "\">", localized,
+                           NULL);
 
             if (values != NULL) {
-                g_string_append_printf(s, "%s%s", _("  Allowed values: "),
-                                       _(values));
+                pcmk__g_strcat(s, _("  Allowed values: "), _(values), NULL);
             }
-            g_string_append_printf(s, "</%s>\n", tag);
+            pcmk__g_strcat(s, "</", tag, ">\n", NULL);
         }
         free(localized);
     }
@@ -647,19 +645,19 @@ pcmk__format_option_metadata(const char *name, const char *desc_short,
 {
     /* big enough to hold "pacemaker-schedulerd metadata" output */
     GString *s = g_string_sized_new(13000);
-    int lpc = 0;
 
-    g_string_append_printf(s, "<?xml version=\"1.0\"?>"
-                              "<resource-agent name=\"%s\">\n"
-                              "  <version>%s</version>\n",
-                              name, PCMK_OCF_VERSION);
+    pcmk__g_strcat(s,
+                   "<?xml version=\"1.0\"?>\n"
+                   "<resource-agent name=\"", name, "\" "
+                                   "version=\"" PACEMAKER_VERSION "\">\n"
+                   "  <version>" PCMK_OCF_VERSION "</version>\n", NULL);
 
     add_desc(s, "longdesc", desc_long, NULL, "  ");
     add_desc(s, "shortdesc", desc_short, NULL, "  ");
 
     g_string_append(s, "  <parameters>\n");
 
-    for (lpc = 0; lpc < len; lpc++) {
+    for (int lpc = 0; lpc < len; lpc++) {
         const char *opt_name = option_list[lpc].name;
         const char *opt_type = option_list[lpc].type;
         const char *opt_values = option_list[lpc].values;
@@ -679,14 +677,14 @@ pcmk__format_option_metadata(const char *name, const char *desc_short,
         // The standard requires a parameter type
         CRM_ASSERT(opt_type != NULL);
 
-        g_string_append_printf(s, "    <parameter name=\"%s\">\n", opt_name);
+        pcmk__g_strcat(s, "    <parameter name=\"", opt_name, "\">\n", NULL);
 
         add_desc(s, "longdesc", opt_desc_long, opt_values, "      ");
         add_desc(s, "shortdesc", opt_desc_short, NULL, "      ");
 
-        g_string_append_printf(s, "      <content type=\"%s\"", opt_type);
+        pcmk__g_strcat(s, "      <content type=\"", opt_type, "\"", NULL);
         if (opt_default != NULL) {
-            g_string_append_printf(s, " default=\"%s\"", opt_default);
+            pcmk__g_strcat(s, " default=\"", opt_default, "\"", NULL);
         }
 
         if ((opt_values != NULL) && (strcmp(opt_type, "select") == 0)) {
@@ -697,7 +695,8 @@ pcmk__format_option_metadata(const char *name, const char *desc_short,
             g_string_append(s, ">\n");
 
             while (ptr != NULL) {
-                g_string_append_printf(s, "        <option value=\"%s\" />\n", ptr);
+                pcmk__g_strcat(s, "        <option value=\"", ptr, "\" />\n",
+                               NULL);
                 ptr = strtok(NULL, delim);
             }
             g_string_append_printf(s, "      </content>\n");
@@ -707,9 +706,9 @@ pcmk__format_option_metadata(const char *name, const char *desc_short,
             g_string_append(s, "/>\n");
         }
 
-        g_string_append_printf(s, "    </parameter>\n");
+        g_string_append(s, "    </parameter>\n");
     }
-    g_string_append_printf(s, "  </parameters>\n</resource-agent>\n");
+    g_string_append(s, "  </parameters>\n</resource-agent>\n");
 
     return g_string_free(s, FALSE);
 }

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -539,8 +539,8 @@ xml_log_patchset(uint8_t log_level, const char *function, xmlNode *patchset)
 
             } else if (strcmp(op, "modify") == 0) {
                 xmlNode *clist = first_named_child(change, XML_DIFF_LIST);
-                GString *buffer_set = g_string_sized_new(256);
-                GString *buffer_unset = g_string_sized_new(256);
+                GString *buffer_set = NULL;
+                GString *buffer_unset = NULL;
 
                 for (child = pcmk__xml_first_child(clist); child != NULL;
                      child = pcmk__xml_next(child)) {
@@ -548,34 +548,33 @@ xml_log_patchset(uint8_t log_level, const char *function, xmlNode *patchset)
 
                     op = crm_element_value(child, XML_DIFF_OP);
                     if (op == NULL) {
-                    } else if (strcmp(op, "set") == 0) {
+                        continue;
+                    }
+
+		    if (strcmp(op, "set") == 0) {
                         const char *value = crm_element_value(child, "value");
 
-                        if (buffer_set->len > 0) {
-                            g_string_append(buffer_set, ", ");
-                        }
-                        g_string_append_printf(buffer_set, "@%s=%s", name, value);
+                        pcmk__add_separated_word(&buffer_set, 256, "@", ", ");
+                        pcmk__g_strcat(buffer_set, name, "=", value, NULL);
 
                     } else if (strcmp(op, "unset") == 0) {
-                        if (buffer_unset->len > 0) {
-                            g_string_append(buffer_unset, ", ");
-                        }
-                        g_string_append_printf(buffer_unset, "@%s", name);
+                        pcmk__add_separated_word(&buffer_unset, 256, "@", ", ");
+                        g_string_append(buffer_unset, name);
                     }
                 }
 
-                if (buffer_set->len > 0) {
+                if (buffer_set != NULL) {
                     do_crm_log_alias(log_level, __FILE__, function, __LINE__,
                                      "+  %s:  %s", xpath,
                                      (const char *) buffer_set->str);
+                    g_string_free(buffer_set, TRUE);
                 }
-                if (buffer_unset->len > 0) {
+                if (buffer_unset != NULL) {
                     do_crm_log_alias(log_level, __FILE__, function, __LINE__,
                                      "-- %s:  %s", xpath,
                                      (const char *) buffer_unset->str);
+                    g_string_free(buffer_unset, TRUE);
                 }
-                g_string_free(buffer_set, TRUE);
-                g_string_free(buffer_unset, TRUE);
 
             } else if (strcmp(op, "delete") == 0) {
                 int position = -1;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -1200,6 +1200,35 @@ pcmk__str_update(char **str, const char *value)
     }
 }
 
+/*!
+ * \internal
+ * \brief Append a list of strings to a destination \p GString
+ *
+ * \param[in,out] buffer  Where to append the strings (must not be \p NULL)
+ * \param[in]     ...     A <tt>NULL</tt>-terminated list of strings
+ *
+ * \note This tends to be more efficient than a single call to
+ *       \p g_string_append_printf().
+ */
+void
+pcmk__g_strcat(GString *buffer, ...)
+{
+    va_list ap;
+
+    CRM_ASSERT(buffer != NULL);
+    va_start(ap, buffer);
+
+    while (true) {
+        const char *ele = va_arg(ap, const char *);
+
+        if (ele == NULL) {
+            break;
+        }
+        g_string_append(buffer, ele);
+    }
+    va_end(ap);
+}
+
 // Deprecated functions kept only for backward API compatibility
 // LCOV_EXCL_START
 

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -20,6 +20,7 @@ check_PROGRAMS = \
 		pcmk__char_in_any_str_test	\
 		pcmk__compress_test	\
 		pcmk__ends_with_test 		\
+		pcmk__g_strcat_test		\
 		pcmk__guint_from_hash_test	\
 		pcmk__numeric_strcasecmp_test \
 		pcmk__parse_ll_range_test	\

--- a/lib/common/tests/strings/pcmk__g_strcat_test.c
+++ b/lib/common/tests/strings/pcmk__g_strcat_test.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020-2022 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+
+static void
+add_to_null(void **state)
+{
+    pcmk__assert_asserts(pcmk__g_strcat(NULL, NULL));
+    pcmk__assert_asserts(pcmk__g_strcat(NULL, "hello", NULL));
+}
+
+static void
+add_nothing(void **state)
+{
+    GString *buf = g_string_new(NULL);
+
+    // Start with empty string
+    pcmk__g_strcat(buf, NULL);
+    assert_string_equal((const char *) buf->str, "");
+
+    pcmk__g_strcat(buf, "", NULL);
+    assert_string_equal((const char *) buf->str, "");
+
+    // Start with populated string
+    g_string_append(buf, "hello");
+    pcmk__g_strcat(buf, NULL);
+    assert_string_equal((const char *) buf->str, "hello");
+
+    pcmk__g_strcat(buf, "", NULL);
+    assert_string_equal((const char *) buf->str, "hello");
+    g_string_free(buf, TRUE);
+}
+
+static void
+add_words(void **state)
+{
+    GString *buf = g_string_new(NULL);
+
+    // Verify a call with multiple words
+    pcmk__g_strcat(buf, "hello", " ", NULL);
+    assert_string_equal((const char *) buf->str, "hello ");
+
+    // Verify that a second call doesn't overwrite the first one
+    pcmk__g_strcat(buf, "world", NULL);
+    assert_string_equal((const char *) buf->str, "hello world");
+    g_string_free(buf, TRUE);
+}
+
+static void
+stop_early(void **state)
+{
+    GString *buf = g_string_new(NULL);
+
+    // NULL anywhere after buf in the arg list should cause a return
+    pcmk__g_strcat(buf, "hello", NULL, " world", NULL);
+    assert_string_equal((const char *) buf->str, "hello");
+    g_string_free(buf, TRUE);
+}
+
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(add_to_null),
+                cmocka_unit_test(add_nothing),
+                cmocka_unit_test(add_words),
+                cmocka_unit_test(stop_early))

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1471,8 +1471,8 @@ dump_xml_attr(const xmlAttr *attr, int options, GString *buffer)
 
     p_name = (const char *) attr->name;
     p_value = crm_xml_escape((const char *)attr->children->content);
-    g_string_append_printf(buffer, " %s=\"%s\"", p_name,
-                           pcmk__s(p_value, "<null>"));
+    pcmk__g_strcat(buffer, " ", p_name, "=\"", pcmk__s(p_value, "<null>"), "\"",
+                   NULL);
 
     free(p_value);
 }
@@ -1504,11 +1504,11 @@ log_xml_node_and_children(GString *buffer, int log_level, const char *file,
         insert_prefix(options, buffer, depth);
 
         if (data->type == XML_COMMENT_NODE) {
-            g_string_append_printf(buffer, "<!--%s-->",
-                                   (const gchar *) data->content);
+            pcmk__g_strcat(buffer, "<!--", (const char *) data->content, "-->",
+                           NULL);
 
         } else {
-            g_string_append_printf(buffer, "<%s", name);
+            pcmk__g_strcat(buffer, "<", name, NULL);
 
             hidden = crm_element_value(data, "hidden");
             for (xmlAttrPtr a = pcmk__xe_first_attr(data); a != NULL;
@@ -1534,8 +1534,8 @@ log_xml_node_and_children(GString *buffer, int log_level, const char *file,
                     p_copy = crm_xml_escape(p_value);
                 }
 
-                g_string_append_printf(buffer, " %s=\"%s\"", p_name,
-                                       pcmk__s(p_copy, "<null>"));
+                pcmk__g_strcat(buffer, " ", p_name, "=\"",
+                               pcmk__s(p_copy, "<null>"), "\"", NULL);
                 free(p_copy);
             }
 
@@ -1575,7 +1575,7 @@ log_xml_node_and_children(GString *buffer, int log_level, const char *file,
         g_string_truncate(buffer, 0);
 
         insert_prefix(options, buffer, depth);
-        g_string_append_printf(buffer, "</%s>", name);
+        pcmk__g_strcat(buffer, "</", name, ">", NULL);
 
         do_crm_log_alias(log_level, file, function, line, "%s %s", prefix,
                          (const char *) buffer->str);
@@ -1810,7 +1810,7 @@ dump_xml_element(const xmlNode *data, int options, GString *buffer, int depth)
     CRM_ASSERT(name != NULL);
 
     insert_prefix(options, buffer, depth);
-    g_string_append_printf(buffer, "<%s", name);
+    pcmk__g_strcat(buffer, "<", name, NULL);
 
     if (options & xml_log_option_filtered) {
         dump_filtered_xml(data, options, buffer);
@@ -1841,7 +1841,7 @@ dump_xml_element(const xmlNode *data, int options, GString *buffer, int depth)
         }
 
         insert_prefix(options, buffer, depth);
-        g_string_append_printf(buffer, "</%s>", name);
+        pcmk__g_strcat(buffer, "</", name, ">", NULL);
 
         if (pcmk_is_set(options, xml_log_option_formatted)) {
             g_string_append_c(buffer, '\n');
@@ -1896,8 +1896,8 @@ dump_xml_cdata(const xmlNode *data, int options, GString *buffer, int depth)
     }
 
     insert_prefix(options, buffer, depth);
-    g_string_append_printf(buffer, "<![CDATA[%s]]>",
-                           (const gchar *) data->content);
+    pcmk__g_strcat(buffer, "<![CDATA[", (const char *) data->content, "]]>",
+                   NULL);
 
     if (pcmk_is_set(options, xml_log_option_formatted)) {
         g_string_append_c(buffer, '\n');
@@ -1924,7 +1924,7 @@ dump_xml_comment(const xmlNode *data, int options, GString *buffer, int depth)
     }
 
     insert_prefix(options, buffer, depth);
-    g_string_append_printf(buffer, "<!--%s-->", (const gchar *) data->content);
+    pcmk__g_strcat(buffer, "<!--", (const char *) data->content, "-->", NULL);
 
     if (pcmk_is_set(options, xml_log_option_formatted)) {
         g_string_append_c(buffer, '\n');

--- a/lib/common/xpath.c
+++ b/lib/common/xpath.c
@@ -300,12 +300,12 @@ pcmk__element_xpath(const xmlNode *xml)
     } else if (parent->parent == NULL) {
         g_string_append(xpath, TYPE(xml));
     } else {
-        g_string_append_printf(xpath, "/%s", TYPE(xml));
+        pcmk__g_strcat(xpath, "/", TYPE(xml), NULL);
     }
 
     id = ID(xml);
     if (id != NULL) {
-        g_string_append_printf(xpath, "[@" XML_ATTR_ID "='%s']", id);
+        pcmk__g_strcat(xpath, "[@" XML_ATTR_ID "='", id, "']", NULL);
     }
 
     return xpath;


### PR DESCRIPTION
This PR depends on #2879 and includes some overlapping commits. It introduces a new function `pcmk__g_strcat()` that's intended to replace `g_string_append_printf()` when the only interpolated objects are strings (i.e., when there are no integers (`%d`), pointers (`%p`), etc., to be appended to the string). This yields a performance improvement, with `crm_simulate` times decreasing or staying the same for almost every test input in `cts/scheduler/xml`.

Results below are compared to the "Use GString in pcmk__add_separated_word() commit", since it's assumed that that commit will be merged first via #2879.
```
# tools/pcmk_simtimes -S percent /tmp/after_pcmk__add_word_1000.txt /tmp/after_pcmk__g_strcat_1000.txt | tail -1
Averages: -0.11s  -2.62%
# tools/pcmk_simtimes -s 0.1 -S percent /tmp/after_pcmk__add_word_1000.txt /tmp/after_pcmk__g_strcat_1000.txt | tail -1
Averages: -0.40s  -3.48%
# tools/pcmk_simtimes -s 0.1 -p 3 -S percent /tmp/after_pcmk__add_word_1000.txt /tmp/after_pcmk__g_strcat_1000.txt | tail -1
Averages: -0.47s  -4.48%
```