### PR TITLE
Clarify pointer arguments in libcrmcommon

### DIFF
--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the Pacemaker project contributors
+ * Copyright 2015-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -69,7 +69,7 @@ enum pcmk__alert_keys_e {
 
 extern const char *pcmk__alert_keys[PCMK__ALERT_INTERNAL_KEY_MAX][3];
 
-pcmk__alert_t *pcmk__dup_alert(pcmk__alert_t *entry);
+pcmk__alert_t *pcmk__dup_alert(const pcmk__alert_t *entry);
 pcmk__alert_t *pcmk__alert_new(const char *id, const char *path);
 void pcmk__free_alert(pcmk__alert_t *entry);
 void pcmk__add_alert_key(GHashTable *table, enum pcmk__alert_keys_e name,

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -55,9 +55,9 @@ bool pcmk__verify_digest(xmlNode *input, const char *expected);
 /* internal main loop utilities (from mainloop.c) */
 
 int pcmk__add_mainloop_ipc(crm_ipc_t *ipc, int priority, void *userdata,
-                           struct ipc_client_callbacks *callbacks,
+                           const struct ipc_client_callbacks *callbacks,
                            mainloop_io_t **source);
-guint pcmk__mainloop_timer_get_period(mainloop_timer_t *timer);
+guint pcmk__mainloop_timer_get_period(const mainloop_timer_t *timer);
 
 
 /* internal node-related XML utilities (from nodes.c) */

--- a/include/crm/common/ipc.h
+++ b/include/crm/common/ipc.h
@@ -121,7 +121,7 @@ int pcmk_connect_ipc(pcmk_ipc_api_t *api, enum pcmk_ipc_dispatch dispatch_type);
 
 void pcmk_disconnect_ipc(pcmk_ipc_api_t *api);
 
-int pcmk_poll_ipc(pcmk_ipc_api_t *api, int timeout_ms);
+int pcmk_poll_ipc(const pcmk_ipc_api_t *api, int timeout_ms);
 
 void pcmk_dispatch_ipc(pcmk_ipc_api_t *api);
 

--- a/include/crm/common/ipc.h
+++ b/include/crm/common/ipc.h
@@ -128,7 +128,7 @@ void pcmk_dispatch_ipc(pcmk_ipc_api_t *api);
 void pcmk_register_ipc_callback(pcmk_ipc_api_t *api, pcmk_ipc_callback_t cb,
                                 void *user_data);
 
-const char *pcmk_ipc_name(pcmk_ipc_api_t *api, bool for_log);
+const char *pcmk_ipc_name(const pcmk_ipc_api_t *api, bool for_log);
 
 bool pcmk_ipc_is_connected(pcmk_ipc_api_t *api);
 

--- a/include/crm/common/ipc_controld.h
+++ b/include/crm/common/ipc_controld.h
@@ -102,7 +102,7 @@ int pcmk_controld_api_refresh(pcmk_ipc_api_t *api, const char *target_node,
                               bool cib_only);
 int pcmk_controld_api_ping(pcmk_ipc_api_t *api, const char *node_name);
 int pcmk_controld_api_list_nodes(pcmk_ipc_api_t *api);
-unsigned int pcmk_controld_api_replies_expected(pcmk_ipc_api_t *api);
+unsigned int pcmk_controld_api_replies_expected(const pcmk_ipc_api_t *api);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/logging.h
+++ b/include/crm/common/logging.h
@@ -100,7 +100,7 @@ enum xml_log_options
 
 void crm_enable_blackbox(int nsig);
 void crm_disable_blackbox(int nsig);
-void crm_write_blackbox(int nsig, struct qb_log_callsite *callsite);
+void crm_write_blackbox(int nsig, const struct qb_log_callsite *callsite);
 
 void crm_update_callsites(void);
 

--- a/include/crm/common/messages_internal.h
+++ b/include/crm/common/messages_internal.h
@@ -73,7 +73,7 @@ typedef struct {
 } pcmk__server_command_t;
 
 const char *pcmk__message_name(const char *name);
-GHashTable *pcmk__register_handlers(pcmk__server_command_t handlers[]);
+GHashTable *pcmk__register_handlers(const pcmk__server_command_t handlers[]);
 xmlNode *pcmk__process_request(pcmk__request_t *request, GHashTable *handlers);
 void pcmk__reset_request(pcmk__request_t *request);
 

--- a/include/crm/common/nvpair.h
+++ b/include/crm/common/nvpair.h
@@ -34,7 +34,7 @@ typedef struct pcmk_nvpair_s {
 GSList *pcmk_prepend_nvpair(GSList *nvpairs, const char *name, const char *value);
 void pcmk_free_nvpairs(GSList *nvpairs);
 GSList *pcmk_sort_nvpairs(GSList *list);
-GSList *pcmk_xml_attrs2nvpairs(xmlNode *xml);
+GSList *pcmk_xml_attrs2nvpairs(const xmlNode *xml);
 void pcmk_nvpairs2xml_attrs(GSList *list, xmlNode *xml);
 
 xmlNode *crm_create_nvpair_xml(xmlNode *parent, const char *id,

--- a/include/crm/common/options_internal.h
+++ b/include/crm/common/options_internal.h
@@ -58,7 +58,7 @@ typedef struct pcmk__cli_option_s {
 } pcmk__cli_option_t;
 
 void pcmk__set_cli_options(const char *short_options, const char *usage,
-                           pcmk__cli_option_t *long_options,
+                           const pcmk__cli_option_t *long_options,
                            const char *app_desc);
 int pcmk__next_cli_option(int argc, char **argv, int *index,
                           const char **longname);
@@ -94,8 +94,8 @@ typedef struct pcmk__cluster_option_s {
 } pcmk__cluster_option_t;
 
 const char *pcmk__cluster_option(GHashTable *options,
-                                 pcmk__cluster_option_t *option_list, int len,
-                                 const char *name);
+                                 const pcmk__cluster_option_t *option_list,
+                                 int len, const char *name);
 
 char *pcmk__format_option_metadata(const char *name, const char *desc_short,
                                    const char *desc_long,

--- a/include/crm/common/remote_internal.h
+++ b/include/crm/common/remote_internal.h
@@ -15,14 +15,14 @@
 typedef struct pcmk__remote_s pcmk__remote_t;
 
 int pcmk__remote_send_xml(pcmk__remote_t *remote, xmlNode *msg);
-int pcmk__remote_ready(pcmk__remote_t *remote, int timeout_ms);
+int pcmk__remote_ready(const pcmk__remote_t *remote, int timeout_ms);
 int pcmk__read_remote_message(pcmk__remote_t *remote, int timeout_ms);
 xmlNode *pcmk__remote_message_xml(pcmk__remote_t *remote);
 int pcmk__connect_remote(const char *host, int port, int timeout_ms,
                          int *timer_id, int *sock_fd, void *userdata,
                          void (*callback) (void *userdata, int rc, int sock));
 int pcmk__accept_remote_connection(int ssock, int *csock);
-void pcmk__sockaddr2str(void *sa, char *s);
+void pcmk__sockaddr2str(const void *sa, char *s);
 
 #  ifdef HAVE_GNUTLS_GNUTLS_H
 #    include <gnutls/gnutls.h>
@@ -31,7 +31,7 @@ gnutls_session_t *pcmk__new_tls_session(int csock, unsigned int conn_type,
                                         gnutls_credentials_type_t cred_type,
                                         void *credentials);
 int pcmk__init_tls_dh(gnutls_dh_params_t *dh_params);
-int pcmk__read_handshake_data(pcmk__client_t *client);
+int pcmk__read_handshake_data(const pcmk__client_t *client);
 
 /*!
  * \internal

--- a/include/crm/common/results_internal.h
+++ b/include/crm/common/results_internal.h
@@ -66,7 +66,8 @@ void pcmk__set_result_output(pcmk__action_result_t *result,
 
 void pcmk__reset_result(pcmk__action_result_t *result);
 
-void pcmk__copy_result(pcmk__action_result_t *src, pcmk__action_result_t *dst);
+void pcmk__copy_result(const pcmk__action_result_t *src,
+                       pcmk__action_result_t *dst);
 
 /*!
  * \internal

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -133,7 +133,7 @@ pcmk__intkey_table_remove(GHashTable *hash_table, int key)
     return g_hash_table_remove(hash_table, GINT_TO_POINTER(key));
 }
 
-gboolean pcmk__str_in_list(const gchar *s, GList *lst, uint32_t flags);
+gboolean pcmk__str_in_list(const gchar *s, const GList *lst, uint32_t flags);
 
 bool pcmk__strcase_any_of(const char *s, ...) G_GNUC_NULL_TERMINATED;
 bool pcmk__str_any_of(const char *s, ...) G_GNUC_NULL_TERMINATED;

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -130,7 +130,7 @@ pcmk__free_alert(pcmk__alert_t *entry)
  * \return Duplicate of alert entry
  */
 pcmk__alert_t *
-pcmk__dup_alert(pcmk__alert_t *entry)
+pcmk__dup_alert(const pcmk__alert_t *entry)
 {
     pcmk__alert_t *new_entry = pcmk__alert_new(entry->id, entry->path);
 

--- a/lib/common/attrs.c
+++ b/lib/common/attrs.c
@@ -22,6 +22,18 @@
 
 /*!
  * \internal
+ * \brief Get the node name that should be used to set node attributes
+ *
+ * If given NULL, "auto", or "localhost" as an argument, check the environment
+ * to detect the node name that should be used to set node attributes. (The
+ * caller might not know the correct name, for example if the target is part of
+ * a bundle with container-attribute-target set to "host".)
+ *
+ * \param[in] name  NULL, "auto" or "localhost" to check environment variables,
+ *                  or anything else to return NULL
+ *
+ * \return Node name that should be used for node attributes based on the
+ *         environment if known, otherwise NULL
  */
 const char *
 pcmk__node_attr_target(const char *name)

--- a/lib/common/cib.c
+++ b/lib/common/cib.c
@@ -143,8 +143,8 @@ pcmk_cib_parent_name_for(const char *element_name)
 /*!
  * \brief Find an element in the CIB
  *
- * \param[in] cib           Top-level CIB XML to search
- * \param[in] element_name  Name of CIB element to search for
+ * \param[in,out] cib           Top-level CIB XML to search
+ * \param[in]     element_name  Name of CIB element to search for
  *
  * \return XML element in \p cib corresponding to \p element_name
  *         (or \p cib itself if element is unknown or not found)

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -130,7 +130,7 @@ typedef struct pcmk__ipc_methods_s {
      * \internal
      * \brief Allocate any private data needed by daemon IPC
      *
-     * \param[in] api  IPC API connection
+     * \param[in,out] api  IPC API connection
      *
      * \return Standard Pacemaker return code
      */
@@ -140,7 +140,7 @@ typedef struct pcmk__ipc_methods_s {
      * \internal
      * \brief Free any private data used by daemon IPC
      *
-     * \param[in] api_data  Data allocated by new_data() method
+     * \param[in,out] api_data  Data allocated by new_data() method
      */
     void (*free_data)(void *api_data);
 
@@ -154,7 +154,7 @@ typedef struct pcmk__ipc_methods_s {
      * reply). Ideally this would be consistent across all daemons, but for now
      * this allows each to do its own authorization.
      *
-     * \param[in] api  IPC API connection
+     * \param[in,out] api  IPC API connection
      *
      * \return Standard Pacemaker return code
      */
@@ -164,8 +164,8 @@ typedef struct pcmk__ipc_methods_s {
      * \internal
      * \brief Check whether an IPC request results in a reply
      *
-     * \param[in] api      IPC API connection
-     * \param[in] request  IPC request XML
+     * \param[in,out] api      IPC API connection
+     * \param[in,out] request  IPC request XML
      *
      * \return true if request would result in an IPC reply, false otherwise
      */
@@ -175,8 +175,8 @@ typedef struct pcmk__ipc_methods_s {
      * \internal
      * \brief Perform daemon-specific handling of an IPC message
      *
-     * \param[in] api  IPC API connection
-     * \param[in] msg  Message read from IPC connection
+     * \param[in,out] api  IPC API connection
+     * \param[in,out] msg  Message read from IPC connection
      *
      * \return true if more IPC reply messages should be expected
      */
@@ -186,7 +186,7 @@ typedef struct pcmk__ipc_methods_s {
      * \internal
      * \brief Perform daemon-specific handling of an IPC disconnect
      *
-     * \param[in] api  IPC API connection
+     * \param[in,out] api  IPC API connection
      */
     void (*post_disconnect)(pcmk_ipc_api_t *api);
 } pcmk__ipc_methods_t;
@@ -279,8 +279,10 @@ pcmk__ipc_methods_t *pcmk__schedulerd_api_methods(void);
  *       the least privilege principle and may pose an additional risk
  *       (i.e. such accidental inconsistency shall be eventually fixed).
  */
-int pcmk__crm_ipc_is_authentic_process(qb_ipcc_connection_t *qb_ipc, int sock, uid_t refuid, gid_t refgid,
-                                       pid_t *gotpid, uid_t *gotuid, gid_t *gotgid);
+int pcmk__crm_ipc_is_authentic_process(qb_ipcc_connection_t *qb_ipc, int sock,
+                                       uid_t refuid, gid_t refgid,
+                                       pid_t *gotpid, uid_t *gotuid,
+                                       gid_t *gotgid);
 
 
 /*

--- a/lib/common/digest.c
+++ b/lib/common/digest.c
@@ -54,7 +54,7 @@ dump_xml_for_digest(xmlNodePtr xml)
  * \note Example return value: "c048eae664dba840e1d2060f00299e9d"
  */
 static char *
-calculate_xml_digest_v1(xmlNode * input, gboolean sort, gboolean ignored)
+calculate_xml_digest_v1(xmlNode *input, gboolean sort, gboolean ignored)
 {
     char *digest = NULL;
     GString *buffer = NULL;
@@ -89,7 +89,7 @@ calculate_xml_digest_v1(xmlNode * input, gboolean sort, gboolean ignored)
  * \return Newly allocated string containing digest
  */
 static char *
-calculate_xml_digest_v2(xmlNode * source, gboolean do_filter)
+calculate_xml_digest_v2(xmlNode *source, gboolean do_filter)
 {
     char *digest = NULL;
     GString *buffer = g_string_sized_new(1024);
@@ -131,7 +131,7 @@ calculate_xml_digest_v2(xmlNode * source, gboolean do_filter)
  * \return Newly allocated string containing digest
  */
 char *
-calculate_on_disk_digest(xmlNode * input)
+calculate_on_disk_digest(xmlNode *input)
 {
     /* Always use the v1 format for on-disk digests
      * a) it's a compatibility nightmare
@@ -144,8 +144,8 @@ calculate_on_disk_digest(xmlNode * input)
 /*!
  * \brief Calculate and return digest of XML operation
  *
- * \param[in] input Root of XML to digest
- * \param[in] version Not used
+ * \param[in] input    Root of XML to digest
+ * \param[in] version  Unused
  *
  * \return Newly allocated string containing digest
  */
@@ -159,16 +159,16 @@ calculate_operation_digest(xmlNode *input, const char *version)
 /*!
  * \brief Calculate and return digest of XML tree
  *
- * \param[in] input Root of XML to digest
- * \param[in] sort Whether to sort XML before calculating digest
- * \param[in] do_filter Whether to filter certain XML attributes
- * \param[in] version CRM feature set version (used to select v1/v2 digest)
+ * \param[in] input      Root of XML to digest
+ * \param[in] sort       Whether to sort XML before calculating digest
+ * \param[in] do_filter  Whether to filter certain XML attributes
+ * \param[in] version    CRM feature set version (used to select v1/v2 digest)
  *
  * \return Newly allocated string containing digest
  */
 char *
-calculate_xml_versioned_digest(xmlNode * input, gboolean sort, gboolean do_filter,
-                               const char *version)
+calculate_xml_versioned_digest(xmlNode *input, gboolean sort,
+                               gboolean do_filter, const char *version)
 {
     /*
      * @COMPAT digests (on-disk or in diffs/patchsets) created <1.1.4;

--- a/lib/common/io.c
+++ b/lib/common/io.c
@@ -226,9 +226,10 @@ pcmk__write_series_sequence(const char *directory, const char *series,
  * \internal
  * \brief Change the owner and group of a file series' .last file
  *
- * \param[in] dir  Directory that contains series
- * \param[in] uid  User ID of desired file owner
- * \param[in] gid  Group ID of desired file group
+ * \param[in] directory  Directory that contains series
+ * \param[in] series     Series to change
+ * \param[in] uid        User ID of desired file owner
+ * \param[in] gid        Group ID of desired file group
  *
  * \return Standard Pacemaker return code
  * \note The caller must have the appropriate privileges.

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -240,7 +240,7 @@ pcmk_free_ipc_api(pcmk_ipc_api_t *api)
  *         "Pacemaker" if for_log is true and NULL if for_log is false
  */
 const char *
-pcmk_ipc_name(pcmk_ipc_api_t *api, bool for_log)
+pcmk_ipc_name(const pcmk_ipc_api_t *api, bool for_log)
 {
     if (api == NULL) {
         return for_log? "Pacemaker" : NULL;

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -137,10 +137,10 @@ free_daemon_specific_data(pcmk_ipc_api_t *api)
  * \internal
  * \brief Call an IPC API event callback, if one is registed
  *
- * \param[in] api         IPC API connection
- * \param[in] event_type  The type of event that occurred
- * \param[in] status      Event status
- * \param[in] event_data  Event-specific data
+ * \param[in,out] api         IPC API connection
+ * \param[in]     event_type  The type of event that occurred
+ * \param[in]     status      Event status
+ * \param[in,out] event_data  Event-specific data
  */
 void
 pcmk__call_ipc_callback(pcmk_ipc_api_t *api, enum pcmk_ipc_event event_type,
@@ -155,7 +155,7 @@ pcmk__call_ipc_callback(pcmk_ipc_api_t *api, enum pcmk_ipc_event event_type,
  * \internal
  * \brief Clean up after an IPC disconnect
  *
- * \param[in]  user_data  IPC API connection that disconnected
+ * \param[in,out] user_data  IPC API connection that disconnected
  *
  * \note This function can be used as a main loop IPC destroy callback.
  */
@@ -196,7 +196,7 @@ ipc_post_disconnect(gpointer user_data)
 /*!
  * \brief Free the contents of an IPC API object
  *
- * \param[in] api  IPC API object to free
+ * \param[in,out] api  IPC API object to free
  */
 void
 pcmk_free_ipc_api(pcmk_ipc_api_t *api)
@@ -275,7 +275,7 @@ pcmk_ipc_name(const pcmk_ipc_api_t *api, bool for_log)
 /*!
  * \brief Check whether an IPC API connection is active
  *
- * \param[in] api  IPC API connection
+ * \param[in,out] api  IPC API connection
  *
  * \return true if IPC is connected, false otherwise
  */
@@ -293,7 +293,8 @@ pcmk_ipc_is_connected(pcmk_ipc_api_t *api)
  * method's responsibility to call the client's registered event callback, as
  * well as allocate and free any event data.
  *
- * \param[in] api  IPC API connection
+ * \param[in,out] api      IPC API connection
+ * \param[in,out] message  IPC reply XML to dispatch
  */
 static bool
 call_api_dispatch(pcmk_ipc_api_t *api, xmlNode *message)
@@ -310,8 +311,8 @@ call_api_dispatch(pcmk_ipc_api_t *api, xmlNode *message)
  * \internal
  * \brief Dispatch previously read IPC data
  *
- * \param[in] buffer Data read from IPC
- * \param[in] api    IPC object
+ * \param[in]     buffer  Data read from IPC
+ * \param[in,out] api     IPC object
  *
  * \return Standard Pacemaker return code.  In particular:
  *
@@ -354,9 +355,9 @@ dispatch_ipc_data(const char *buffer, pcmk_ipc_api_t *api)
  * \internal
  * \brief Dispatch data read from IPC source
  *
- * \param[in] buffer     Data read from IPC
- * \param[in] length     Number of bytes of data in buffer (ignored)
- * \param[in] user_data  IPC object
+ * \param[in]     buffer     Data read from IPC
+ * \param[in]     length     Number of bytes of data in buffer (ignored)
+ * \param[in,out] user_data  IPC object
  *
  * \return Always 0 (meaning connection is still required)
  *
@@ -391,7 +392,7 @@ dispatch_ipc_source_data(const char *buffer, ssize_t length, gpointer user_data)
  *       crm_ipc_get_fd(api->ipc), so the caller can call poll() themselves.
  */
 int
-pcmk_poll_ipc(pcmk_ipc_api_t *api, int timeout_ms)
+pcmk_poll_ipc(const pcmk_ipc_api_t *api, int timeout_ms)
 {
     int rc;
     struct pollfd pollfd = { 0, };
@@ -413,7 +414,7 @@ pcmk_poll_ipc(pcmk_ipc_api_t *api, int timeout_ms)
 /*!
  * \brief Dispatch available messages on an IPC connection (without main loop)
  *
- * \param[in]  api  IPC API connection
+ * \param[in,out] api  IPC API connection
  *
  * \return Standard Pacemaker return code
  *
@@ -476,8 +477,8 @@ connect_without_main_loop(pcmk_ipc_api_t *api)
 /*!
  * \brief Connect to a Pacemaker daemon via IPC
  *
- * \param[in]  api            IPC API instance
- * \param[out] dispatch_type  How IPC replies should be dispatched
+ * \param[in,out] api            IPC API instance
+ * \param[in]     dispatch_type  How IPC replies should be dispatched
  *
  * \return Standard Pacemaker return code
  */
@@ -532,7 +533,7 @@ pcmk_connect_ipc(pcmk_ipc_api_t *api, enum pcmk_ipc_dispatch dispatch_type)
 /*!
  * \brief Disconnect an IPC API instance
  *
- * \param[in]  api  IPC API connection
+ * \param[in,out] api  IPC API connection
  *
  * \return Standard Pacemaker return code
  *
@@ -582,9 +583,9 @@ pcmk_disconnect_ipc(pcmk_ipc_api_t *api)
 /*!
  * \brief Register a callback for IPC API events
  *
- * \param[in] api          IPC API connection
- * \param[in] callback     Callback to register
- * \param[in] userdata     Caller data to pass to callback
+ * \param[in,out] api       IPC API connection
+ * \param[in]     callback  Callback to register
+ * \param[in]     userdata  Caller data to pass to callback
  *
  * \note This function may be called multiple times to update the callback
  *       and/or user data. The caller remains responsible for freeing
@@ -606,8 +607,8 @@ pcmk_register_ipc_callback(pcmk_ipc_api_t *api, pcmk_ipc_callback_t cb,
  * \internal
  * \brief Send an XML request across an IPC API connection
  *
- * \param[in] api          IPC API connection
- * \param[in] request      XML request to send
+ * \param[in,out] api      IPC API connection
+ * \param[in,out] request  XML request to send
  *
  * \return Standard Pacemaker return code
  *
@@ -697,7 +698,7 @@ pcmk__send_ipc_request(pcmk_ipc_api_t *api, xmlNode *request)
  *       common syntax with all daemons if their version supports it.
  */
 static xmlNode *
-create_purge_node_request(pcmk_ipc_api_t *api, const char *node_name,
+create_purge_node_request(const pcmk_ipc_api_t *api, const char *node_name,
                           uint32_t nodeid)
 {
     xmlNode *request = NULL;
@@ -734,9 +735,9 @@ create_purge_node_request(pcmk_ipc_api_t *api, const char *node_name,
 /*!
  * \brief Ask a Pacemaker daemon to purge a node from its peer cache
  *
- * \param[in]  api        IPC API connection
- * \param[in]  node_name  If not NULL, name of node to purge
- * \param[in]  nodeid     If not 0, node ID of node to purge
+ * \param[in,out] api        IPC API connection
+ * \param[in]     node_name  If not NULL, name of node to purge
+ * \param[in]     nodeid     If not 0, node ID of node to purge
  *
  * \return Standard Pacemaker return code
  *
@@ -836,14 +837,14 @@ crm_ipc_new(const char *name, size_t max_size)
 /*!
  * \brief Establish an IPC connection to a Pacemaker component
  *
- * \param[in] client  Connection instance obtained from crm_ipc_new()
+ * \param[in,out] client  Connection instance obtained from crm_ipc_new()
  *
  * \return TRUE on success, FALSE otherwise (in which case errno will be set;
  *         specifically, in case of discovering the remote side is not
  *         authentic, its value is set to ECONNABORTED).
  */
 bool
-crm_ipc_connect(crm_ipc_t * client)
+crm_ipc_connect(crm_ipc_t *client)
 {
     uid_t cl_uid = 0;
     gid_t cl_gid = 0;
@@ -993,7 +994,7 @@ crm_ipc_connected(crm_ipc_t * client)
 /*!
  * \brief Check whether an IPC connection is ready to be read
  *
- * \param[in] client  Connection to check
+ * \param[in,out] client  Connection to check
  *
  * \return Positive value if ready to be read, 0 if not ready, -errno on error
  */
@@ -1194,12 +1195,12 @@ internal_ipc_get_reply(crm_ipc_t *client, int request_id, int ms_timeout,
 /*!
  * \brief Send an IPC XML message
  *
- * \param[in]  client      Connection to IPC server
- * \param[in]  message     XML message to send
- * \param[in]  flags       Bitmask of crm_ipc_flags
- * \param[in]  ms_timeout  Give up if not sent within this much time
- *                         (5 seconds if 0, or no timeout if negative)
- * \param[out] reply       Reply from server (or NULL if none)
+ * \param[in,out] client      Connection to IPC server
+ * \param[in,out] message     XML message to send
+ * \param[in]     flags       Bitmask of crm_ipc_flags
+ * \param[in]     ms_timeout  Give up if not sent within this much time
+ *                            (5 seconds if 0, or no timeout if negative)
+ * \param[out]    reply       Reply from server (or NULL if none)
  *
  * \return Negative errno on error, otherwise size of reply received in bytes
  *         if reply was needed, otherwise number of bytes sent

--- a/lib/common/ipc_controld.c
+++ b/lib/common/ipc_controld.c
@@ -583,7 +583,7 @@ pcmk_controld_api_refresh(pcmk_ipc_api_t *api, const char *target_node,
  * \return Number of replies expected
  */
 unsigned int
-pcmk_controld_api_replies_expected(pcmk_ipc_api_t *api)
+pcmk_controld_api_replies_expected(const pcmk_ipc_api_t *api)
 {
     struct controld_api_private_s *private = api->api_data;
 

--- a/lib/common/ipc_controld.c
+++ b/lib/common/ipc_controld.c
@@ -285,7 +285,7 @@ pcmk__controld_api_methods(void)
  * \return Newly allocated XML for request
  */
 static xmlNode *
-create_controller_request(pcmk_ipc_api_t *api, const char *op,
+create_controller_request(const pcmk_ipc_api_t *api, const char *op,
                           const char *node, xmlNode *msg_data)
 {
     struct controld_api_private_s *private = NULL;
@@ -340,9 +340,9 @@ create_reprobe_message_data(const char *target_node, const char *router_node)
 /*!
  * \brief Send a reprobe controller operation
  *
- * \param[in] api          Controller connection
- * \param[in] target_node  Name of node to reprobe
- * \param[in] router_node  Router node for host
+ * \param[in,out] api          Controller connection
+ * \param[in]     target_node  Name of node to reprobe
+ * \param[in]     router_node  Router node for host
  *
  * \return Standard Pacemaker return code
  * \note Event callback will get a reply of type pcmk_controld_reply_reprobe.
@@ -376,8 +376,8 @@ pcmk_controld_api_reprobe(pcmk_ipc_api_t *api, const char *target_node,
 /*!
  * \brief Send a "node info" controller operation
  *
- * \param[in] api          Controller connection
- * \param[in] nodeid       ID of node to get info for (or 0 for local node)
+ * \param[in,out] api     Controller connection
+ * \param[in]     nodeid  ID of node to get info for (or 0 for local node)
  *
  * \return Standard Pacemaker return code
  * \note Event callback will get a reply of type pcmk_controld_reply_info.
@@ -404,8 +404,8 @@ pcmk_controld_api_node_info(pcmk_ipc_api_t *api, uint32_t nodeid)
 /*!
  * \brief Ask the controller for status
  *
- * \param[in] api          Controller connection
- * \param[in] node_name    Name of node whose status is desired (or NULL for DC)
+ * \param[in,out] api        Controller connection
+ * \param[in]     node_name  Name of node whose status is desired (NULL for DC)
  *
  * \return Standard Pacemaker return code
  * \note Event callback will get a reply of type pcmk_controld_reply_ping.
@@ -428,7 +428,7 @@ pcmk_controld_api_ping(pcmk_ipc_api_t *api, const char *node_name)
 /*!
  * \brief Ask the controller for cluster information
  *
- * \param[in] api          Controller connection
+ * \param[in,out] api  Controller connection
  *
  * \return Standard Pacemaker return code
  * \note Event callback will get a reply of type pcmk_controld_reply_nodes.
@@ -513,14 +513,14 @@ controller_resource_op(pcmk_ipc_api_t *api, const char *op,
 /*!
  * \brief Ask the controller to fail a resource
  *
- * \param[in] api          Controller connection
- * \param[in] target_node  Name of node resource is on
- * \param[in] router_node  Router node for target
- * \param[in] rsc_id       ID of resource to fail
- * \param[in] rsc_long_id  Long ID of resource (if any)
- * \param[in] standard     Standard of resource
- * \param[in] provider     Provider of resource (if any)
- * \param[in] type         Type of resource to fail
+ * \param[in,out] api          Controller connection
+ * \param[in]     target_node  Name of node resource is on
+ * \param[in]     router_node  Router node for target
+ * \param[in]     rsc_id       ID of resource to fail
+ * \param[in]     rsc_long_id  Long ID of resource (if any)
+ * \param[in]     standard     Standard of resource
+ * \param[in]     provider     Provider of resource (if any)
+ * \param[in]     type         Type of resource to fail
  *
  * \return Standard Pacemaker return code
  * \note Event callback will get a reply of type pcmk_controld_reply_resource.
@@ -545,15 +545,15 @@ pcmk_controld_api_fail(pcmk_ipc_api_t *api,
 /*!
  * \brief Ask the controller to refresh a resource
  *
- * \param[in] api          Controller connection
- * \param[in] target_node  Name of node resource is on
- * \param[in] router_node  Router node for target
- * \param[in] rsc_id       ID of resource to refresh
- * \param[in] rsc_long_id  Long ID of resource (if any)
- * \param[in] standard     Standard of resource
- * \param[in] provider     Provider of resource (if any)
- * \param[in] type         Type of resource
- * \param[in] cib_only     If true, clean resource from CIB only
+ * \param[in,out] api          Controller connection
+ * \param[in]     target_node  Name of node resource is on
+ * \param[in]     router_node  Router node for target
+ * \param[in]     rsc_id       ID of resource to refresh
+ * \param[in]     rsc_long_id  Long ID of resource (if any)
+ * \param[in]     standard     Standard of resource
+ * \param[in]     provider     Provider of resource (if any)
+ * \param[in]     type         Type of resource
+ * \param[in]     cib_only     If true, clean resource from CIB only
  *
  * \return Standard Pacemaker return code
  * \note Event callback will get a reply of type pcmk_controld_reply_resource.

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -154,9 +154,9 @@ pcmk__drop_all_clients(qb_ipcs_service_t *service)
  * \internal
  * \brief Allocate a new pcmk__client_t object based on an IPC connection
  *
- * \param[in,out] c           IPC connection (NULL to allocate generic client)
- * \param[in]     key         Connection table key (NULL to use sane default)
- * \param[in]     uid_client  UID corresponding to c (ignored if c is NULL)
+ * \param[in] c           IPC connection (NULL to allocate generic client)
+ * \param[in] key         Connection table key (NULL to use sane default)
+ * \param[in] uid_client  UID corresponding to c (ignored if c is NULL)
  *
  * \return Pointer to new pcmk__client_t (or NULL on error)
  */

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -42,8 +42,8 @@ pcmk__ipc_client_count(void)
  * \internal
  * \brief Execute a function for each active IPC client connection
  *
- * \param[in] func       Function to call
- * \param[in] user_data  Pointer to pass to function
+ * \param[in]     func       Function to call
+ * \param[in,out] user_data  Pointer to pass to function
  *
  * \note The parameters are the same as for g_hash_table_foreach().
  */
@@ -154,9 +154,9 @@ pcmk__drop_all_clients(qb_ipcs_service_t *service)
  * \internal
  * \brief Allocate a new pcmk__client_t object based on an IPC connection
  *
- * \param[in] c           IPC connection (or NULL to allocate generic client)
- * \param[in] key         Connection table key (or NULL to use sane default)
- * \param[in] uid_client  UID corresponding to c (ignored if c is NULL)
+ * \param[in,out] c           IPC connection (NULL to allocate generic client)
+ * \param[in]     key         Connection table key (NULL to use sane default)
+ * \param[in]     uid_client  UID corresponding to c (ignored if c is NULL)
  *
  * \return Pointer to new pcmk__client_t (or NULL on error)
  */
@@ -274,7 +274,7 @@ pcmk__new_ipc_event(void)
 /*!
  * \brief Free an I/O vector created by pcmk__ipc_prepare_iov()
  *
- * \param[in] event  I/O vector to free
+ * \param[in,out] event  I/O vector to free
  */
 void
 pcmk_free_ipc_event(struct iovec *event)
@@ -381,10 +381,10 @@ pcmk__client_pid(qb_ipcs_connection_t *c)
  * \internal
  * \brief Retrieve message XML from data read from client IPC
  *
- * \param[in]  c       IPC client connection
- * \param[in]  data    Data read from client connection
- * \param[out] id      Where to store message ID from libqb header
- * \param[out] flags   Where to store flags from libqb header
+ * \param[in,out]  c       IPC client connection
+ * \param[in]      data    Data read from client connection
+ * \param[out]     id      Where to store message ID from libqb header
+ * \param[out]     flags   Where to store flags from libqb header
  *
  * \return Message XML on success, NULL otherwise
  */
@@ -476,7 +476,7 @@ delay_next_flush(pcmk__client_t *c, unsigned int queue_len)
  * \internal
  * \brief Send client any messages in its queue
  *
- * \param[in]  c  Client to flush
+ * \param[in,out] c  Client to flush
  *
  * \return Standard Pacemaker return value
  */
@@ -574,11 +574,11 @@ crm_ipcs_flush_events(pcmk__client_t *c)
  * \internal
  * \brief Create an I/O vector for sending an IPC XML message
  *
- * \param[in]  request        Identifier for libqb response header
- * \param[in]  message        XML message to send
- * \param[in]  max_send_size  If 0, default IPC buffer size is used
- * \param[out] result         Where to store prepared I/O vector
- * \param[out] bytes          Size of prepared data in bytes
+ * \param[in]     request        Identifier for libqb response header
+ * \param[in,out] message        XML message to send
+ * \param[in]     max_send_size  If 0, default IPC buffer size is used
+ * \param[out]    result         Where to store prepared I/O vector
+ * \param[out]    bytes          Size of prepared data in bytes
  *
  * \return Standard Pacemaker return code
  */
@@ -905,6 +905,7 @@ pcmk__serve_controld_ipc(struct qb_ipcs_service_handlers *cb)
  * \internal
  * \brief Add an IPC server to the main loop for the pacemaker-attrd API
  *
+ * \param[out] ipcs  Where to store newly created IPC server
  * \param[in] cb  IPC callbacks
  *
  * \note This function exits fatally if unable to create the servers.
@@ -926,7 +927,8 @@ pcmk__serve_attrd_ipc(qb_ipcs_service_t **ipcs,
  * \internal
  * \brief Add an IPC server to the main loop for the pacemaker-fenced API
  *
- * \param[in] cb  IPC callbacks
+ * \param[out] ipcs  Where to store newly created IPC server
+ * \param[in]  cb    IPC callbacks
  *
  * \note This function exits fatally if unable to create the servers.
  */
@@ -948,7 +950,8 @@ pcmk__serve_fenced_ipc(qb_ipcs_service_t **ipcs,
  * \internal
  * \brief Add an IPC server to the main loop for the pacemakerd API
  *
- * \param[in] cb  IPC callbacks
+ * \param[out] ipcs  Where to store newly created IPC server
+ * \param[in]  cb    IPC callbacks
  *
  * \note This function exits with CRM_EX_OSERR if unable to create the servers.
  */
@@ -974,8 +977,9 @@ pcmk__serve_pacemakerd_ipc(qb_ipcs_service_t **ipcs,
  * \internal
  * \brief Add an IPC server to the main loop for the pacemaker-schedulerd API
  *
- * \param[in] cb IPC callbacks
+ * \param[in] cb  IPC callbacks
  *
+ * \return Newly created IPC server
  * \note This function exits fatally if unable to create the servers.
  */
 qb_ipcs_service_t *

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1179,7 +1179,7 @@ error:
 /*!
  * \brief Free a dynamically allocated time period object
  *
- * \param[in] period  Time period to free
+ * \param[in,out] period  Time period to free
  */
 void
 crm_time_free_period(crm_time_period_t *period)
@@ -1414,8 +1414,8 @@ crm_time_compare(const crm_time_t *a, const crm_time_t *b)
 /*!
  * \brief Add a given number of seconds to a date/time or duration
  *
- * \param[in] a_time  Date/time or duration to add seconds to
- * \param[in] extra   Number of seconds to add
+ * \param[in,out] a_time  Date/time or duration to add seconds to
+ * \param[in]     extra   Number of seconds to add
  */
 void
 crm_time_add_seconds(crm_time_t *a_time, int extra)

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -471,7 +471,7 @@ crm_disable_blackbox(int nsig)
  * @TODO actually make this async-safe
  */
 void
-crm_write_blackbox(int nsig, struct qb_log_callsite *cs)
+crm_write_blackbox(int nsig, const struct qb_log_callsite *cs)
 {
     static volatile int counter = 1;
     static volatile time_t last = 0;

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -723,9 +723,9 @@ crm_priority2int(const char *name)
  * If the identifier crm_system_name is not already set, then it is set as follows:
  * - it is passed to the function via the "entity" parameter, or
  * - it is derived from the executable name
- * 
+ *
  * The identifier can be used in logs, IPC, and more.
- * 
+ *
  * This method also sets the PCMK_service environment variable.
  *
  * \param[in] entity  If not NULL, will be assigned to the identifier

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -97,14 +97,14 @@ crm_trigger_check(GSource * source)
  * \internal
  * \brief GSource dispatch function for crm_trigger_t
  *
- * \param[in] source    crm_trigger_t being dispatched
- * \param[in] callback  Callback passed at source creation
- * \param[in] userdata  User data passed at source creation
+ * \param[in] source        crm_trigger_t being dispatched
+ * \param[in] callback      Callback passed at source creation
+ * \param[in,out] userdata  User data passed at source creation
  *
  * \return G_SOURCE_REMOVE to remove source, G_SOURCE_CONTINUE to keep it
  */
 static gboolean
-crm_trigger_dispatch(GSource * source, GSourceFunc callback, gpointer userdata)
+crm_trigger_dispatch(GSource *source, GSourceFunc callback, gpointer userdata)
 {
     gboolean rc = G_SOURCE_CONTINUE;
     crm_trigger_t *trig = (crm_trigger_t *) source;
@@ -179,11 +179,13 @@ mainloop_trigger_complete(crm_trigger_t * trig)
  *                      trigger from the mainloop, -1 if the trigger should be
  *                      kept but the job is still running and not complete, and
  *                      1 if the trigger should be kept and the job is complete)
+ * \param[in] userdata  Pointer to pass to \p dispatch
  *
  * \return Newly allocated mainloop source for trigger
  */
 crm_trigger_t *
-mainloop_add_trigger(int priority, int (*dispatch) (gpointer user_data), gpointer userdata)
+mainloop_add_trigger(int priority, int (*dispatch) (gpointer user_data),
+                     gpointer userdata)
 {
     GSource *source = NULL;
 
@@ -249,7 +251,7 @@ static crm_signal_t *crm_signals[NSIG];
  * \param[in] userdata  (ignored)
  */
 static gboolean
-crm_signal_dispatch(GSource * source, GSourceFunc callback, gpointer userdata)
+crm_signal_dispatch(GSource *source, GSourceFunc callback, gpointer userdata)
 {
     crm_signal_t *sig = (crm_signal_t *) source;
 
@@ -744,7 +746,7 @@ struct mainloop_io_s {
  * \return G_SOURCE_REMOVE to remove source, G_SOURCE_CONTINUE to keep it
  */
 static gboolean
-mainloop_gio_callback(GIOChannel * gio, GIOCondition condition, gpointer data)
+mainloop_gio_callback(GIOChannel *gio, GIOCondition condition, gpointer data)
 {
     gboolean rc = G_SOURCE_CONTINUE;
     mainloop_io_t *client = data;
@@ -875,11 +877,11 @@ mainloop_gio_destroy(gpointer c)
 /*!
  * \brief Connect to IPC and add it as a main loop source
  *
- * \param[in]  ipc        IPC connection to add
- * \param[in]  priority   Event source priority to use for connection
- * \param[in]  userdata   Data to register with callbacks
- * \param[in]  callbacks  Dispatch and destroy callbacks for connection
- * \param[out] source     Newly allocated event source
+ * \param[in,out] ipc        IPC connection to add
+ * \param[in]     priority   Event source priority to use for connection
+ * \param[in]     userdata   Data to register with callbacks
+ * \param[in]     callbacks  Dispatch and destroy callbacks for connection
+ * \param[out]    source     Newly allocated event source
  *
  * \return Standard Pacemaker return code
  *
@@ -892,7 +894,7 @@ mainloop_gio_destroy(gpointer c)
  */
 int
 pcmk__add_mainloop_ipc(crm_ipc_t *ipc, int priority, void *userdata,
-                       struct ipc_client_callbacks *callbacks,
+                       const struct ipc_client_callbacks *callbacks,
                        mainloop_io_t **source)
 {
     CRM_CHECK((ipc != NULL) && (callbacks != NULL), return EINVAL);
@@ -924,7 +926,7 @@ pcmk__add_mainloop_ipc(crm_ipc_t *ipc, int priority, void *userdata,
  * \return Period in ms
  */
 guint
-pcmk__mainloop_timer_get_period(mainloop_timer_t *timer)
+pcmk__mainloop_timer_get_period(const mainloop_timer_t *timer)
 {
     if (timer) {
         return timer->period_ms;
@@ -1430,8 +1432,8 @@ drain_timeout_cb(gpointer user_data)
 /*!
  * \brief Drain some remaining main loop events then quit it
  *
- * \param[in] mloop  Main loop to drain and quit
- * \param[in] n      Drain up to this many pending events
+ * \param[in,out] mloop  Main loop to drain and quit
+ * \param[in]     n      Drain up to this many pending events
  */
 void
 pcmk_quit_main_loop(GMainLoop *mloop, unsigned int n)
@@ -1452,9 +1454,10 @@ pcmk_quit_main_loop(GMainLoop *mloop, unsigned int n)
 /*!
  * \brief Process main loop events while a certain condition is met
  *
- * \param[in] mloop     Main loop to process
- * \param[in] timer_ms  Don't process longer than this amount of time
- * \param[in] check     Function that returns TRUE if events should be processed
+ * \param[in,out] mloop     Main loop to process
+ * \param[in]     timer_ms  Don't process longer than this amount of time
+ * \param[in]     check     Function that returns true if events should be
+ *                          processed
  *
  * \note This function is intended to be called at shutdown if certain important
  *       events should not be missed. The caller would likely quit the main loop

--- a/lib/common/messages.c
+++ b/lib/common/messages.c
@@ -37,7 +37,7 @@
  * \note The caller is responsible for freeing the result using free_xml().
  */
 xmlNode *
-create_request_adv(const char *task, xmlNode * msg_data,
+create_request_adv(const char *task, xmlNode *msg_data,
                    const char *host_to, const char *sys_to,
                    const char *sys_from, const char *uuid_from,
                    const char *origin)
@@ -219,7 +219,7 @@ pcmk__message_name(const char *name)
  *       g_hash_table_destroy().
  */
 GHashTable *
-pcmk__register_handlers(pcmk__server_command_t *handlers)
+pcmk__register_handlers(const pcmk__server_command_t handlers[])
 {
     GHashTable *commands = g_hash_table_new(g_str_hash, g_str_equal);
 
@@ -242,8 +242,8 @@ pcmk__register_handlers(pcmk__server_command_t *handlers)
  * \internal
  * \brief Process an incoming request
  *
- * \param[in] request   Request to process
- * \param[in] handlers  Command table created by pcmk__register_handlers()
+ * \param[in,out] request   Request to process
+ * \param[in]     handlers  Command table created by pcmk__register_handlers()
  *
  * \return XML to send as reply (or NULL if no reply is needed)
  */
@@ -279,7 +279,7 @@ pcmk__process_request(pcmk__request_t *request, GHashTable *handlers)
  * \internal
  * \brief Free memory used within a request (but not the request itself)
  *
- * \param[in] request  Request to reset
+ * \param[in,out] request  Request to reset
  */
 void
 pcmk__reset_request(pcmk__request_t *request)

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -62,7 +62,7 @@ pcmk__new_nvpair(const char *name, const char *value)
  * \internal
  * \brief Free a name/value pair
  *
- * \param[in] nvpair  Name/value pair to free
+ * \param[in,out] nvpair  Name/value pair to free
  */
 static void
 pcmk__free_nvpair(gpointer data)
@@ -96,7 +96,7 @@ pcmk_prepend_nvpair(GSList *nvpairs, const char *name, const char *value)
 /*!
  * \brief Free a list of name/value pairs
  *
- * \param[in] list  List to free
+ * \param[in,out] list  List to free
  */
 void
 pcmk_free_nvpairs(GSList *nvpairs)
@@ -194,7 +194,7 @@ pcmk__nvpair_add_xml_attr(gpointer data, gpointer user_data)
 /*!
  * \brief Add XML attributes based on a list of name/value pairs
  *
- * \param[in]     list  List of name/value pairs
+ * \param[in,out] list  List of name/value pairs
  * \param[in,out] xml   XML node to add attributes to
  */
 void
@@ -543,9 +543,9 @@ crm_element_value(const xmlNode *data, const char *name)
  *
  * This is like \c crm_element_value() but getting the value as an integer.
  *
- * \param[in] data   XML node to check
- * \param[in] name   Attribute name to check
- * \param[in] dest   Where to store element value
+ * \param[in]  data  XML node to check
+ * \param[in]  name  Attribute name to check
+ * \param[out] dest  Where to store element value
  *
  * \return 0 on success, -1 otherwise
  */
@@ -575,9 +575,9 @@ crm_element_value_int(const xmlNode *data, const char *name, int *dest)
  *
  * This is like \c crm_element_value() but getting the value as a long long int.
  *
- * \param[in] data   XML node to check
- * \param[in] name   Attribute name to check
- * \param[in] dest   Where to store element value
+ * \param[in]  data  XML node to check
+ * \param[in]  name  Attribute name to check
+ * \param[out] dest  Where to store element value
  *
  * \return 0 on success, -1 otherwise
  */
@@ -728,9 +728,9 @@ crm_element_value_copy(const xmlNode *data, const char *name)
  * name starts with a digit, this will instead add a \<param name=NAME
  * value=VALUE/> child to the XML (for legacy compatibility with heartbeat).
  *
- * \param[in] key        Key of hash table entry
- * \param[in] value      Value of hash table entry
- * \param[in] user_data  XML node
+ * \param[in]     key        Key of hash table entry
+ * \param[in]     value      Value of hash table entry
+ * \param[in,out] user_data  XML node
  */
 void
 hash2smartfield(gpointer key, gpointer value, gpointer user_data)
@@ -762,9 +762,9 @@ hash2smartfield(gpointer key, gpointer value, gpointer user_data)
  * and value, with an XML node passed as user data, and adds an XML attribute
  * with the specified name and value if it does not already exist.
  *
- * \param[in] key        Key of hash table entry
- * \param[in] value      Value of hash table entry
- * \param[in] user_data  XML node
+ * \param[in]     key        Key of hash table entry
+ * \param[in]     value      Value of hash table entry
+ * \param[in,out] user_data  XML node
  */
 void
 hash2field(gpointer key, gpointer value, gpointer user_data)
@@ -790,9 +790,9 @@ hash2field(gpointer key, gpointer value, gpointer user_data)
  * with the meta-attribute version of the specified name and value if it does
  * not already exist and if the name does not appear to be cluster-internal.
  *
- * \param[in] key        Key of hash table entry
- * \param[in] value      Value of hash table entry
- * \param[in] user_data  XML node
+ * \param[in]     key        Key of hash table entry
+ * \param[in]     value      Value of hash table entry
+ * \param[in,out] user_data  XML node
  */
 void
 hash2metafield(gpointer key, gpointer value, gpointer user_data)
@@ -822,10 +822,10 @@ hash2metafield(gpointer key, gpointer value, gpointer user_data)
 /*!
  * \brief Create an XML name/value pair
  *
- * \param[in] parent  If not \c NULL, make new XML node a child of this one
- * \param[in] id      If not \c NULL, use this as ID (otherwise auto-generate)
- * \param[in] name    Name to use
- * \param[in] value   Value to use
+ * \param[in,out] parent  If not \c NULL, make new XML node a child of this one
+ * \param[in]     id      Set this as XML ID (or NULL to auto-generate)
+ * \param[in]     name    Name to use
+ * \param[in]     value   Value to use
  *
  * \return New XML object on success, \c NULL otherwise
  */
@@ -863,9 +863,9 @@ crm_create_nvpair_xml(xmlNode *parent, const char *id, const char *name,
  * and value, with an XML node passed as the user data, and adds an \c nvpair
  * XML element with the specified name and value.
  *
- * \param[in] key        Key of hash table entry
- * \param[in] value      Value of hash table entry
- * \param[in] user_data  XML node
+ * \param[in]     key        Key of hash table entry
+ * \param[in]     value      Value of hash table entry
+ * \param[in,out] user_data  XML node
  */
 void
 hash2nvpair(gpointer key, gpointer value, gpointer user_data)

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -158,7 +158,7 @@ pcmk_sort_nvpairs(GSList *list)
  *       \c pcmk_free_nvpairs().
  */
 GSList *
-pcmk_xml_attrs2nvpairs(xmlNode *xml)
+pcmk_xml_attrs2nvpairs(const xmlNode *xml)
 {
     GSList *result = NULL;
 

--- a/lib/common/operations.c
+++ b/lib/common/operations.c
@@ -462,11 +462,11 @@ did_rsc_op_fail(lrmd_event_data_t * op, int target_rc)
 /*!
  * \brief Create a CIB XML element for an operation
  *
- * \param[in] parent         If not NULL, make new XML node a child of this one
- * \param[in] prefix         Generate an ID using this prefix
- * \param[in] task           Operation task to set
- * \param[in] interval_spec  Operation interval to set
- * \param[in] timeout        If not NULL, operation timeout to set
+ * \param[in,out] parent         If not NULL, make new XML node a child of this
+ * \param[in]     prefix         Generate an ID using this prefix
+ * \param[in]     task           Operation task to set
+ * \param[in]     interval_spec  Operation interval to set
+ * \param[in]     timeout        If not NULL, operation timeout to set
  *
  * \return New XML object on success, NULL otherwise
  */

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -556,9 +556,9 @@ cluster_option_value(GHashTable *options, bool (*validate)(const char *),
  * \internal
  * \brief Get the value of a cluster option
  *
- * \param[in] options      Name/value pairs for configured options
- * \param[in] option_list  Possible cluster options
- * \param[in] name         (Primary) option name to look for
+ * \param[in,out] options      Name/value pairs for configured options
+ * \param[in]     option_list  Possible cluster options
+ * \param[in]     name         (Primary) option name to look for
  *
  * \return Option value
  */

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -31,7 +31,7 @@
  */
 
 static char *crm_short_options = NULL;
-static pcmk__cli_option_t *crm_long_options = NULL;
+static const pcmk__cli_option_t *crm_long_options = NULL;
 static const char *crm_app_description = NULL;
 static const char *crm_app_usage = NULL;
 
@@ -43,7 +43,7 @@ pcmk__cli_option_cleanup(void)
 }
 
 static struct option *
-create_long_opts(pcmk__cli_option_t *long_options)
+create_long_opts(const pcmk__cli_option_t *long_options)
 {
     struct option *long_opts = NULL;
 
@@ -103,7 +103,8 @@ create_long_opts(pcmk__cli_option_t *long_options)
  */
 void
 pcmk__set_cli_options(const char *short_options, const char *app_usage,
-                      pcmk__cli_option_t *long_options, const char *app_desc)
+                      const pcmk__cli_option_t *long_options,
+                      const char *app_desc)
 {
     if (short_options) {
         crm_short_options = strdup(short_options);
@@ -479,11 +480,11 @@ pcmk__valid_percentage(const char *value)
  * \internal
  * \brief Check a table of configured options for a particular option
  *
- * \param[in] options    Name/value pairs for configured options
- * \param[in] validate   If not NULL, validator function for option value
- * \param[in] name       Option name to look for
- * \param[in] old_name   Alternative option name to look for
- * \param[in] def_value  Default to use if option not configured
+ * \param[in,out] options    Name/value pairs for configured options
+ * \param[in]     validate   If not NULL, validator function for option value
+ * \param[in]     name       Option name to look for
+ * \param[in]     old_name   Alternative option name to look for
+ * \param[in]     def_value  Default to use if option not configured
  *
  * \return Option value (from supplied options table or default value)
  */
@@ -562,7 +563,8 @@ cluster_option_value(GHashTable *options, bool (*validate)(const char *),
  * \return Option value
  */
 const char *
-pcmk__cluster_option(GHashTable *options, pcmk__cluster_option_t *option_list,
+pcmk__cluster_option(GHashTable *options,
+                     const pcmk__cluster_option_t *option_list,
                      int len, const char *name)
 {
     const char *value = NULL;
@@ -584,13 +586,14 @@ pcmk__cluster_option(GHashTable *options, pcmk__cluster_option_t *option_list,
  * \internal
  * \brief Add a description element to a meta-data string
  *
- * \param[in] s       Meta-data string to add to
- * \param[in] tag     Name of element to add ("longdesc" or "shortdesc")
- * \param[in] desc    Textual description to add
- * \param[in] values  If not NULL, the allowed values for the parameter
+ * \param[in,out] s       Meta-data string to add to
+ * \param[in]     tag     Name of element to add ("longdesc" or "shortdesc")
+ * \param[in]     desc    Textual description to add
+ * \param[in]     values  If not NULL, the allowed values for the parameter
  */
 static void
-add_desc(GString *s, const char *tag, const char *desc, const char *values, const char *spaces)
+add_desc(GString *s, const char *tag, const char *desc, const char *values,
+         const char *spaces)
 {
     char *escaped_en = crm_xml_escape(desc);
 

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -217,7 +217,7 @@ pcmk__xml_output_new(pcmk__output_t **out, xmlNodePtr *xml) {
  * \brief  Finish and free an XML-only output object
  *
  * \param[in,out] out  Output object to free
- * \param[out]    xml  Where to store XML output
+ * \param[out]    xml  If not NULL, where to store XML output
  */
 void
 pcmk__xml_output_finish(pcmk__output_t *out, xmlNodePtr *xml) {

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -216,8 +216,8 @@ pcmk__xml_output_new(pcmk__output_t **out, xmlNodePtr *xml) {
  * \internal
  * \brief  Finish and free an XML-only output object
  *
- * \param[in]  out     Output object to free
- * \param[out] xml     Where to store XML output
+ * \param[in,out] out  Output object to free
+ * \param[out]    xml  Where to store XML output
  */
 void
 pcmk__xml_output_finish(pcmk__output_t *out, xmlNodePtr *xml) {

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -840,7 +840,7 @@ xml_patch_versions(const xmlNode *patchset, int add[3], int del[3])
  * \return Standard Pacemaker return code
  */
 static int
-xml_patch_version_check(xmlNode *xml, xmlNode *patchset, int format)
+xml_patch_version_check(const xmlNode *xml, const xmlNode *patchset, int format)
 {
     int lpc = 0;
     bool changed = FALSE;
@@ -916,7 +916,7 @@ xml_patch_version_check(xmlNode *xml, xmlNode *patchset, int format)
  * \return Standard Pacemaker return code
  */
 static int
-apply_v1_patchset(xmlNode *xml, xmlNode *patchset)
+apply_v1_patchset(xmlNode *xml, const xmlNode *patchset)
 {
     int rc = pcmk_rc_ok;
     int root_nodes_seen = 0;
@@ -971,8 +971,8 @@ apply_v1_patchset(xmlNode *xml, xmlNode *patchset)
 
 // Return first child matching element name and optionally id or position
 static xmlNode *
-first_matching_xml_child(xmlNode *parent, const char *name, const char *id,
-                         int position)
+first_matching_xml_child(const xmlNode *parent, const char *name,
+                         const char *id, int position)
 {
     xmlNode *cIter = NULL;
 
@@ -1014,7 +1014,7 @@ first_matching_xml_child(xmlNode *parent, const char *name, const char *id,
  *       i.e. the only allowed search predicate is [@id='XXX'].
  */
 static xmlNode *
-search_v2_xpath(xmlNode *top, const char *key, int target_position)
+search_v2_xpath(const xmlNode *top, const char *key, int target_position)
 {
     xmlNode *target = (xmlNode *) top->doc;
     const char *current = key;
@@ -1096,7 +1096,7 @@ search_v2_xpath(xmlNode *top, const char *key, int target_position)
 }
 
 typedef struct xml_change_obj_s {
-    xmlNode *change;
+    const xmlNode *change;
     xmlNode *match;
 } xml_change_obj_t;
 
@@ -1131,10 +1131,10 @@ sort_change_obj_by_position(gconstpointer a, gconstpointer b)
  * \return Standard Pacemaker return code
  */
 static int
-apply_v2_patchset(xmlNode *xml, xmlNode *patchset)
+apply_v2_patchset(xmlNode *xml, const xmlNode *patchset)
 {
     int rc = pcmk_rc_ok;
-    xmlNode *change = NULL;
+    const xmlNode *change = NULL;
     GList *change_objs = NULL;
     GList *gIter = NULL;
 

--- a/lib/common/procfs.c
+++ b/lib/common/procfs.c
@@ -37,7 +37,7 @@
  *       limit, but there isn't.
  */
 static int
-pcmk__procfs_process_info(struct dirent *entry, char *name, pid_t *pid)
+pcmk__procfs_process_info(const struct dirent *entry, char *name, pid_t *pid)
 {
     int fd, local_pid;
     FILE *file;

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -163,7 +163,7 @@ pcmk__tls_client_handshake(pcmk__remote_t *remote, int timeout_ms)
  * \param[in] session  TLS session to affect
  */
 static void
-set_minimum_dh_bits(gnutls_session_t *session)
+set_minimum_dh_bits(const gnutls_session_t *session)
 {
     int dh_min_bits;
 
@@ -342,7 +342,7 @@ error:
  *         if some data was successfully read but more data is needed)
  */
 int
-pcmk__read_handshake_data(pcmk__client_t *client)
+pcmk__read_handshake_data(const pcmk__client_t *client)
 {
     int rc = 0;
 
@@ -479,8 +479,8 @@ remote_send_iovs(pcmk__remote_t *remote, struct iovec *iov, int iovs)
  * \internal
  * \brief Send an XML message over a Pacemaker Remote connection
  *
- * \param[in] remote  Pacemaker Remote connection to use
- * \param[in] msg     XML to send
+ * \param[in,out] remote  Pacemaker Remote connection to use
+ * \param[in]     msg     XML to send
  *
  * \return Standard Pacemaker return code
  */
@@ -531,7 +531,7 @@ pcmk__remote_send_xml(pcmk__remote_t *remote, xmlNode *msg)
  * \internal
  * \brief Obtain the XML from the currently buffered remote connection message
  *
- * \param[in] remote  Remote connection possibly with message available
+ * \param[in,out] remote  Remote connection possibly with message available
  *
  * \return Newly allocated XML object corresponding to message data, or NULL
  * \note This effectively removes the message from the connection buffer.
@@ -600,7 +600,7 @@ pcmk__remote_message_xml(pcmk__remote_t *remote)
 }
 
 static int
-get_remote_socket(pcmk__remote_t *remote)
+get_remote_socket(const pcmk__remote_t *remote)
 {
 #ifdef HAVE_GNUTLS_GNUTLS_H
     if (remote->tls_session) {
@@ -630,7 +630,7 @@ get_remote_socket(pcmk__remote_t *remote)
  *         the specified timeout)
  */
 int
-pcmk__remote_ready(pcmk__remote_t *remote, int timeout_ms)
+pcmk__remote_ready(const pcmk__remote_t *remote, int timeout_ms)
 {
     struct pollfd fds = { 0, };
     int sock = 0;
@@ -673,7 +673,7 @@ pcmk__remote_ready(pcmk__remote_t *remote, int timeout_ms)
  * \internal
  * \brief Read bytes from non-blocking remote connection
  *
- * \param[in] remote  Remote connection to read
+ * \param[in,out] remote  Remote connection to read
  *
  * \return Standard Pacemaker return code (of particular interest, pcmk_rc_ok if
  *         a full message has been received, or EAGAIN for a partial message)
@@ -781,9 +781,9 @@ read_available_remote_data(pcmk__remote_t *remote)
  * \internal
  * \brief Read one message from a remote connection
  *
- * \param[in]  remote      Remote connection to read
- * \param[in]  timeout_ms  Fail if message not read in this many milliseconds
- *                         (10s will be used if 0, and 60s if negative)
+ * \param[in,out] remote      Remote connection to read
+ * \param[in]     timeout_ms  Fail if message not read in this many milliseconds
+ *                            (10s will be used if 0, and 60s if negative)
  *
  * \return Standard Pacemaker return code
  */
@@ -1163,16 +1163,17 @@ async_cleanup:
  *          as long as its sa_family member is set correctly.
  */
 void
-pcmk__sockaddr2str(void *sa, char *s)
+pcmk__sockaddr2str(const void *sa, char *s)
 {
-    switch (((struct sockaddr*)sa)->sa_family) {
+    switch (((const struct sockaddr *) sa)->sa_family) {
         case AF_INET:
-            inet_ntop(AF_INET, &(((struct sockaddr_in *)sa)->sin_addr),
+            inet_ntop(AF_INET, &(((const struct sockaddr_in *) sa)->sin_addr),
                       s, INET6_ADDRSTRLEN);
             break;
 
         case AF_INET6:
-            inet_ntop(AF_INET6, &(((struct sockaddr_in6 *)sa)->sin6_addr),
+            inet_ntop(AF_INET6,
+                      &(((const struct sockaddr_in6 *) sa)->sin6_addr),
                       s, INET6_ADDRSTRLEN);
             break;
 

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -1010,9 +1010,9 @@ pcmk__copy_result(pcmk__action_result_t *src, pcmk__action_result_t *dst)
     CRM_CHECK((src != NULL) && (dst != NULL), return);
     dst->exit_status = src->exit_status;
     dst->execution_status = src->execution_status;
-    pcmk__str_update(&src->exit_reason, dst->exit_reason);
-    pcmk__str_update(&src->action_stdout, dst->action_stdout);
-    pcmk__str_update(&src->action_stderr, dst->action_stderr);
+    pcmk__str_update(&dst->exit_reason, src->exit_reason);
+    pcmk__str_update(&dst->action_stdout, src->action_stdout);
+    pcmk__str_update(&dst->action_stderr, src->action_stderr);
 }
 
 // Deprecated functions kept only for backward API compatibility

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -978,7 +978,7 @@ pcmk__set_result_output(pcmk__action_result_t *result, char *out, char *err)
  * \internal
  * \brief Clear a result's exit reason, output, and error output
  *
- * \param[in] result  Result to reset
+ * \param[in,out] result  Result to reset
  */
 void
 pcmk__reset_result(pcmk__action_result_t *result)
@@ -1005,7 +1005,7 @@ pcmk__reset_result(pcmk__action_result_t *result)
  * \param[out] dst  Where to copy \p src to
  */
 void
-pcmk__copy_result(pcmk__action_result_t *src, pcmk__action_result_t *dst)
+pcmk__copy_result(const pcmk__action_result_t *src, pcmk__action_result_t *dst)
 {
     CRM_CHECK((src != NULL) && (dst != NULL), return);
     dst->exit_status = src->exit_status;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -300,10 +300,10 @@ pcmk__scan_double(const char *text, double *result, const char *default_text,
  * \internal
  * \brief Parse a guint from a string stored in a hash table
  *
- * \param[in]  table        Hash table to search
- * \param[in]  key          Hash table key to use to retrieve string
- * \param[in]  default_val  What to use if key has no entry in table
- * \param[out] result       If not NULL, where to store parsed integer
+ * \param[in,out] table        Hash table to search
+ * \param[in]     key          Hash table key to use to retrieve string
+ * \param[in]     default_val  What to use if key has no entry in table
+ * \param[out]    result       If not NULL, where to store parsed integer
  *
  * \return Standard Pacemaker return code
  */
@@ -448,7 +448,7 @@ crm_str_to_boolean(const char *s, int *ret)
  * \internal
  * \brief Replace any trailing newlines in a string with \0's
  *
- * \param[in] str  String to trim
+ * \param[in,out] str  String to trim
  *
  * \return \p str
  */
@@ -665,7 +665,7 @@ copy_str_table_entry(gpointer key, gpointer value, gpointer user_data)
  * \internal
  * \brief Copy a hash table that uses dynamically allocated strings
  *
- * \param[in] old_table  Hash table to duplicate
+ * \param[in,out] old_table  Hash table to duplicate
  *
  * \return New hash table with copies of everything in \p old_table
  * \note This assumes the hash table uses dynamically allocated strings -- that
@@ -876,16 +876,16 @@ pcmk__parse_ll_range(const char *srcstring, long long *start, long long *end)
  * \note No matter what input string or flags are provided, an empty
  *       list will always return FALSE.
  *
- * \param[in]  s     String to search for
- * \param[in]  lst   List to search
- * \param[in]  flags A bitfield of pcmk__str_flags to modify operation
+ * \param[in] s      String to search for
+ * \param[in] lst    List to search
+ * \param[in] flags  A bitfield of pcmk__str_flags to modify operation
  *
  * \return \c TRUE if \p s is in \p lst, or \c FALSE otherwise
  */
 gboolean
-pcmk__str_in_list(const gchar *s, GList *lst, uint32_t flags)
+pcmk__str_in_list(const gchar *s, const GList *lst, uint32_t flags)
 {
-    for (GList *ele = lst; ele != NULL; ele = ele->next) {
+    for (const GList *ele = lst; ele != NULL; ele = ele->next) {
         if (pcmk__str_eq(s, ele->data, flags)) {
             return TRUE;
         }
@@ -1184,8 +1184,8 @@ pcmk__strcmp(const char *s1, const char *s2, uint32_t flags)
  * is different from the new value, free the string and replace it with either a
  * newly allocated duplicate of the value or NULL as appropriate.
  *
- * \param[in] str    Pointer to dynamically allocated string
- * \param[in] value  New value to duplicate (or NULL)
+ * \param[in,out] str    Pointer to dynamically allocated string
+ * \param[in]     value  New value to duplicate (or NULL)
  *
  * \note The caller remains responsibile for freeing \p *str.
  */

--- a/lib/common/xpath.c
+++ b/lib/common/xpath.c
@@ -160,9 +160,9 @@ xpath_search(xmlNode * xml_top, const char *path)
 /*!
  * \brief Run a supplied function for each result of an xpath search
  *
- * \param[in] xml            XML to search
- * \param[in] xpath          XPath search string
- * \param[in] helper         Function to call for each result
+ * \param[in,out] xml        XML to search
+ * \param[in]     xpath      XPath search string
+ * \param[in]     helper     Function to call for each result
  * \param[in,out] user_data  Data to pass to supplied function
  *
  * \note The helper function will be passed the XML node of the result,


### PR DESCRIPTION
This is not comprehensive but focuses on functions with doxygen comments and some functions called by them. It also skips acl.c and xml.c for now since unrelated work in progress will change those significantly.