### PR TITLE
Refactor: various: Use g_free() with gchar *

### DIFF
--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -661,14 +661,14 @@ static pcmk__cluster_option_t controller_options[] = {
 void
 crmd_metadata(void)
 {
-    char *s = pcmk__format_option_metadata("pacemaker-controld",
-                                           "Pacemaker controller options",
-                                           "Cluster options used by Pacemaker's "
-                                               "controller",
-                                           controller_options,
-                                           PCMK__NELEM(controller_options));
+    const char *desc_short = "Pacemaker controller options";
+    const char *desc_long = "Cluster options used by Pacemaker's controller";
+
+    gchar *s = pcmk__format_option_metadata("pacemaker-controld", desc_short,
+                                            desc_long, controller_options,
+                                            PCMK__NELEM(controller_options));
     printf("%s", s);
-    free(s);
+    g_free(s);
 }
 
 static const char *

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -1562,14 +1562,17 @@ static pcmk__cluster_option_t fencer_options[] = {
 void
 fencer_metadata(void)
 {
-    char *s = pcmk__format_option_metadata("pacemaker-fenced",
-                                            "Instance attributes available for all \"stonith\"-class resources",
-                                            "Instance attributes available for all \"stonith\"-class resources"
-                                                "and used by Pacemaker's fence daemon, formerly known as stonithd",
-                                           fencer_options,
-                                           PCMK__NELEM(fencer_options));
+    const char *desc_short = "Instance attributes available for all "
+                             "\"stonith\"-class resources";
+    const char *desc_long = "Instance attributes available for all \"stonith\"-"
+                            "class resources and used by Pacemaker's fence "
+                            "daemon, formerly known as stonithd";
+
+    gchar *s = pcmk__format_option_metadata("pacemaker-fenced", desc_short,
+                                            desc_long, fencer_options,
+                                            PCMK__NELEM(fencer_options));
     printf("%s", s);
-    free(s);
+    g_free(s);
 }
 
 /*

--- a/include/crm/common/options_internal.h
+++ b/include/crm/common/options_internal.h
@@ -97,9 +97,10 @@ const char *pcmk__cluster_option(GHashTable *options,
                                  pcmk__cluster_option_t *option_list, int len,
                                  const char *name);
 
-char *pcmk__format_option_metadata(const char *name, const char *desc_short,
-                                   const char *desc_long,
-                                   pcmk__cluster_option_t *option_list, int len);
+gchar *pcmk__format_option_metadata(const char *name, const char *desc_short,
+                                    const char *desc_long,
+                                    pcmk__cluster_option_t *option_list,
+                                    int len);
 
 void pcmk__validate_cluster_options(GHashTable *options,
                                     pcmk__cluster_option_t *option_list,

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -572,13 +572,15 @@ static pcmk__cluster_option_t cib_opts[] = {
 void
 cib_metadata(void)
 {
-    char *s = pcmk__format_option_metadata("pacemaker-based",
-                                           "Cluster Information Base manager options",
-                                           "Cluster options used by Pacemaker's "
-                                               "Cluster Information Base manager",
-                                           cib_opts, PCMK__NELEM(cib_opts));
+    const char *desc_short = "Cluster Information Base manager options";
+    const char *desc_long = "Cluster options used by Pacemaker's Cluster "
+                            "Information Base manager";
+
+    gchar *s = pcmk__format_option_metadata("pacemaker-based", desc_short,
+                                            desc_long, cib_opts,
+                                            PCMK__NELEM(cib_opts));
     printf("%s", s);
-    free(s);
+    g_free(s);
 }
 
 void

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -165,7 +165,6 @@ gchar *
 pcmk__quote_cmdline(gchar **argv)
 {
     GString *gs = NULL;
-    gchar *retval = NULL;
 
     if (argv == NULL || argv[0] == NULL) {
         return NULL;
@@ -209,9 +208,7 @@ pcmk__quote_cmdline(gchar **argv)
         }
     }
 
-    retval = gs->str;
-    g_string_free(gs, FALSE);
-    return retval;
+    return g_string_free(gs, FALSE);
 }
 
 gchar **

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -630,12 +630,11 @@ add_desc(GString *s, const char *tag, const char *desc, const char *values, cons
     free(escaped_en);
 }
 
-char *
+gchar *
 pcmk__format_option_metadata(const char *name, const char *desc_short,
                              const char *desc_long,
                              pcmk__cluster_option_t *option_list, int len)
 {
-    char *retval;
     /* big enough to hold "pacemaker-schedulerd metadata" output */
     GString *s = g_string_sized_new(13000);
     int lpc = 0;
@@ -700,9 +699,7 @@ pcmk__format_option_metadata(const char *name, const char *desc_short,
     }
     g_string_append_printf(s, "  </parameters>\n</resource-agent>\n");
 
-    retval = s->str;
-    g_string_free(s, FALSE);
-    return retval;
+    return g_string_free(s, FALSE);
 }
 
 void

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -75,7 +75,6 @@ stonith__history_description(stonith_history_t *history, bool full_history,
                              const char *later_succeeded, uint32_t show_opts)
 {
     GString *str = g_string_sized_new(256); // Generous starting size
-    char *retval = NULL;
     char *completed_time = NULL;
 
     if ((history->state == st_failed) || (history->state == st_done)) {
@@ -142,10 +141,8 @@ stonith__history_description(stonith_history_t *history, bool full_history,
                                later_succeeded);
     }
 
-    retval = str->str;
-    g_string_free(str, FALSE);
     free(completed_time);
-    return retval;
+    return g_string_free(str, FALSE);
 }
 
 PCMK__OUTPUT_ARGS("failed-fencing-list", "stonith_history_t *", "GList *",

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -287,12 +287,14 @@ static pcmk__cluster_option_t pe_opts[] = {
 void
 pe_metadata(pcmk__output_t *out)
 {
-    char *s = pcmk__format_option_metadata("pacemaker-schedulerd",
-                                           "Pacemaker scheduler options",
-                                           "Cluster options used by Pacemaker's scheduler",
-                                           pe_opts, PCMK__NELEM(pe_opts));
+    const char *desc_short = "Pacemaker scheduler options";
+    const char *desc_long = "Cluster options used by Pacemaker's scheduler";
+
+    gchar *s = pcmk__format_option_metadata("pacemaker-schedulerd", desc_short,
+                                            desc_long, pe_opts,
+                                            PCMK__NELEM(pe_opts));
     out->output_xml(out, "metadata", s);
-    free(s);
+    g_free(s);
 }
 
 void

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -547,7 +547,6 @@ pcmk__native_output_string(pe_resource_t *rsc, const char *name, pe_node_t *node
     const char *class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
     const char *provider = NULL;
     const char *kind = crm_element_value(rsc->xml, XML_ATTR_TYPE);
-    gchar *retval = NULL;
     GString *outstr = NULL;
     bool have_flags = false;
 
@@ -678,9 +677,7 @@ pcmk__native_output_string(pe_resource_t *rsc, const char *name, pe_node_t *node
         }
     }
 
-    retval = outstr->str;
-    g_string_free(outstr, FALSE);
-    return retval;
+    return g_string_free(outstr, FALSE);
 }
 
 int


### PR DESCRIPTION
And use shortcut `return g_string_free(str, FALSE)` instead of assigning to a temporary variable and returning that.

In practice `g_free()` (vs. `free()`) shouldn't be required if GLib >= 2.46 is used, but it's a best practice and we only require GLib >= 2.42.