### PR TITLE
Best practices for primitive-related functions in libpacemaker

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -4966,26 +4966,26 @@ Original: cluster02 capacity:
 Original: httpd-bundle-0 capacity:
 Original: httpd-bundle-1 capacity:
 Original: httpd-bundle-2 capacity:
-pcmk__assign_primitive: ping:0 utilization on cluster02:
-pcmk__assign_primitive: ping:1 utilization on cluster01:
-pcmk__assign_primitive: Fencing utilization on cluster01:
-pcmk__assign_primitive: dummy utilization on cluster02:
-pcmk__assign_primitive: httpd-bundle-docker-0 utilization on cluster01:
-pcmk__assign_primitive: httpd-bundle-docker-1 utilization on cluster02:
-pcmk__assign_primitive: httpd-bundle-ip-192.168.122.131 utilization on cluster01:
-pcmk__assign_primitive: httpd-bundle-0 utilization on cluster01:
-pcmk__assign_primitive: httpd:0 utilization on httpd-bundle-0:
-pcmk__assign_primitive: httpd-bundle-ip-192.168.122.132 utilization on cluster02:
-pcmk__assign_primitive: httpd-bundle-1 utilization on cluster02:
-pcmk__assign_primitive: httpd:1 utilization on httpd-bundle-1:
-pcmk__assign_primitive: httpd-bundle-2 utilization on cluster01:
-pcmk__assign_primitive: httpd:2 utilization on httpd-bundle-2:
-pcmk__assign_primitive: Public-IP utilization on cluster02:
-pcmk__assign_primitive: Email utilization on cluster02:
-pcmk__assign_primitive: mysql-proxy:0 utilization on cluster02:
-pcmk__assign_primitive: mysql-proxy:1 utilization on cluster01:
-pcmk__assign_primitive: promotable-rsc:0 utilization on cluster02:
-pcmk__assign_primitive: promotable-rsc:1 utilization on cluster01:
+pcmk__finalize_assignment: ping:0 utilization on cluster02:
+pcmk__finalize_assignment: ping:1 utilization on cluster01:
+pcmk__finalize_assignment: Fencing utilization on cluster01:
+pcmk__finalize_assignment: dummy utilization on cluster02:
+pcmk__finalize_assignment: httpd-bundle-docker-0 utilization on cluster01:
+pcmk__finalize_assignment: httpd-bundle-docker-1 utilization on cluster02:
+pcmk__finalize_assignment: httpd-bundle-ip-192.168.122.131 utilization on cluster01:
+pcmk__finalize_assignment: httpd-bundle-0 utilization on cluster01:
+pcmk__finalize_assignment: httpd:0 utilization on httpd-bundle-0:
+pcmk__finalize_assignment: httpd-bundle-ip-192.168.122.132 utilization on cluster02:
+pcmk__finalize_assignment: httpd-bundle-1 utilization on cluster02:
+pcmk__finalize_assignment: httpd:1 utilization on httpd-bundle-1:
+pcmk__finalize_assignment: httpd-bundle-2 utilization on cluster01:
+pcmk__finalize_assignment: httpd:2 utilization on httpd-bundle-2:
+pcmk__finalize_assignment: Public-IP utilization on cluster02:
+pcmk__finalize_assignment: Email utilization on cluster02:
+pcmk__finalize_assignment: mysql-proxy:0 utilization on cluster02:
+pcmk__finalize_assignment: mysql-proxy:1 utilization on cluster01:
+pcmk__finalize_assignment: promotable-rsc:0 utilization on cluster02:
+pcmk__finalize_assignment: promotable-rsc:1 utilization on cluster01:
 Remaining: cluster01 capacity:
 Remaining: cluster02 capacity:
 Remaining: httpd-bundle-0 capacity:

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -431,8 +431,8 @@ pe_action_t *custom_action(pe_resource_t *rsc, char *key, const char *task,
 extern int pe_get_configured_timeout(pe_resource_t *rsc, const char *action,
                                      pe_working_set_t *data_set);
 
-extern pe_action_t *find_first_action(GList *input, const char *uuid, const char *task,
-                                      pe_node_t * on_node);
+pe_action_t *find_first_action(const GList *input, const char *uuid,
+                               const char *task, const pe_node_t *on_node);
 extern enum action_tasks get_complex_task(pe_resource_t * rsc, const char *name,
                                           gboolean allow_non_atomic);
 

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -19,7 +19,6 @@
 #  include <crm/common/xml.h>
 #  include <pcmki/pcmki_scheduler.h>
 
-void native_create_actions(pe_resource_t *rsc);
 void native_internal_constraints(pe_resource_t *rsc);
 extern enum pe_action_flags native_action_flags(pe_action_t * action, pe_node_t * node);
 

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -19,7 +19,8 @@
 #  include <crm/common/xml.h>
 #  include <pcmki/pcmki_scheduler.h>
 
-extern enum pe_action_flags native_action_flags(pe_action_t * action, pe_node_t * node);
+enum pe_action_flags native_action_flags(pe_action_t *action,
+                                         const pe_node_t *node);
 
 void native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern void native_append_meta(pe_resource_t * rsc, xmlNode * xml);
@@ -31,7 +32,8 @@ void pcmk__primitive_shutdown_lock(pe_resource_t *rsc);
 pe_node_t *pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer);
 void group_create_actions(pe_resource_t *rsc);
 void group_internal_constraints(pe_resource_t *rsc);
-extern enum pe_action_flags group_action_flags(pe_action_t * action, pe_node_t * node);
+enum pe_action_flags group_action_flags(pe_action_t *action,
+                                        const pe_node_t *node);
 void group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern void group_append_meta(pe_resource_t * rsc, xmlNode * xml);
 void pcmk__group_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
@@ -44,7 +46,7 @@ bool pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node);
 void pcmk__bundle_internal_constraints(pe_resource_t *rsc);
 void pcmk__bundle_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 enum pe_action_flags pcmk__bundle_action_flags(pe_action_t *action,
-                                               pe_node_t *node);
+                                               const pe_node_t *node);
 void pcmk__bundle_expand(pe_resource_t *rsc);
 void pcmk__bundle_append_meta(pe_resource_t *rsc, xmlNode *xml);
 void pcmk__bundle_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
@@ -55,7 +57,8 @@ pe_node_t *pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *prefer);
 void clone_create_actions(pe_resource_t *rsc);
 void clone_internal_constraints(pe_resource_t *rsc);
 void clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
-extern enum pe_action_flags clone_action_flags(pe_action_t * action, pe_node_t * node);
+enum pe_action_flags clone_action_flags(pe_action_t *action,
+                                        const pe_node_t *node);
 void clone_expand(pe_resource_t *rsc);
 bool clone_create_probe(pe_resource_t *rsc, pe_node_t *node);
 extern void clone_append_meta(pe_resource_t * rsc, xmlNode * xml);

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -19,7 +19,6 @@
 #  include <crm/common/xml.h>
 #  include <pcmki/pcmki_scheduler.h>
 
-void native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern void native_append_meta(pe_resource_t * rsc, xmlNode * xml);
 void pcmk__primitive_add_utilization(pe_resource_t *rsc,
                                      pe_resource_t *orig_rsc, GList *all_rscs,

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -19,9 +19,6 @@
 #  include <crm/common/xml.h>
 #  include <pcmki/pcmki_scheduler.h>
 
-enum pe_action_flags native_action_flags(pe_action_t *action,
-                                         const pe_node_t *node);
-
 void native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern void native_append_meta(pe_resource_t * rsc, xmlNode * xml);
 void pcmk__primitive_add_utilization(pe_resource_t *rsc,

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -19,7 +19,6 @@
 #  include <crm/common/xml.h>
 #  include <pcmki/pcmki_scheduler.h>
 
-void native_internal_constraints(pe_resource_t *rsc);
 extern enum pe_action_flags native_action_flags(pe_action_t * action, pe_node_t * node);
 
 void native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);

--- a/include/pcmki/pcmki_sched_utils.h
+++ b/include/pcmki/pcmki_sched_utils.h
@@ -30,7 +30,8 @@ pe_resource_t *find_compatible_child(pe_resource_t *local_child,
 pe_resource_t *find_compatible_child_by_node(pe_resource_t * local_child, pe_node_t * local_node, pe_resource_t * rsc,
                                              enum rsc_role_e filter, gboolean current);
 gboolean is_child_compatible(pe_resource_t *child_rsc, pe_node_t * local_node, enum rsc_role_e filter, gboolean current);
-enum pe_action_flags summary_action_flags(pe_action_t * action, GList *children, pe_node_t * node);
+enum pe_action_flags summary_action_flags(pe_action_t *action, GList *children,
+                                          const pe_node_t *node);
 enum action_tasks clone_child_action(pe_action_t * action);
 int copies_per_node(pe_resource_t * rsc);
 

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -84,6 +84,12 @@ struct resource_alloc_functions_s {
      */
     bool (*create_probe)(pe_resource_t *rsc, pe_node_t *node);
 
+    /*!
+     * \internal
+     * \brief Create implicit constraints needed for a resource
+     *
+     * \param[in,out] rsc  Resource to create implicit constraints for
+     */
     void (*internal_constraints)(pe_resource_t *rsc);
 
     /*!
@@ -549,6 +555,9 @@ pe_node_t *pcmk__primitive_assign(pe_resource_t *rsc, pe_node_t *prefer);
 
 G_GNUC_INTERNAL
 void pcmk__primitive_create_actions(pe_resource_t *rsc);
+
+G_GNUC_INTERNAL
+void pcmk__primitive_internal_constraints(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
 void pcmk__primitive_apply_coloc_score(pe_resource_t *dependent,

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -65,6 +65,12 @@ struct resource_alloc_functions_s {
      */
     pe_node_t *(*assign)(pe_resource_t *rsc, pe_node_t *prefer);
 
+    /*!
+     * \internal
+     * \brief Create all actions needed for a given resource
+     *
+     * \param[in,out] rsc  Resource to create actions for
+     */
     void (*create_actions)(pe_resource_t *rsc);
 
     /*!
@@ -540,6 +546,9 @@ void pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, pe_action_t *action);
 
 G_GNUC_INTERNAL
 pe_node_t *pcmk__primitive_assign(pe_resource_t *rsc, pe_node_t *prefer);
+
+G_GNUC_INTERNAL
+void pcmk__primitive_create_actions(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
 void pcmk__primitive_apply_coloc_score(pe_resource_t *dependent,

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -698,7 +698,8 @@ G_GNUC_INTERNAL
 void pcmk__output_resource_actions(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
-bool pcmk__assign_primitive(pe_resource_t *rsc, pe_node_t *chosen, bool force);
+bool pcmk__finalize_assignment(pe_resource_t *rsc, pe_node_t *chosen,
+                               bool force);
 
 G_GNUC_INTERNAL
 bool pcmk__assign_resource(pe_resource_t *rsc, pe_node_t *node, bool force);

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -153,7 +153,20 @@ struct resource_alloc_functions_s {
 
     void (*rsc_location) (pe_resource_t *, pe__location_t *);
 
-    enum pe_action_flags (*action_flags) (pe_action_t *, pe_node_t *);
+    /*!
+     * \internal
+     * \brief Return action flags for a given resource action
+     *
+     * \param[in,out] action  Action to get flags for
+     * \param[in]     node    If not NULL, limit effects to this node
+     *
+     * \return Flags appropriate to \p action on \p node
+     * \note For primitives, this will be the same as action->flags regardless
+     *       of node. For collective resources, the flags can differ due to
+     *       multiple instances possibly being involved.
+     */
+    enum pe_action_flags (*action_flags)(pe_action_t *action,
+                                         const pe_node_t *node);
 
     /*!
      * \internal

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -362,7 +362,7 @@ G_GNUC_INTERNAL
 void pcmk__apply_locations(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-void pcmk__apply_location(pe__location_t *constraint, pe_resource_t *rsc);
+void pcmk__apply_location(pe_resource_t *rsc, pe__location_t *constraint);
 
 
 // Colocation constraints (pcmk_sched_colocation.c)

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -151,7 +151,14 @@ struct resource_alloc_functions_s {
     GList *(*colocated_resources)(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                   GList *colocated_rscs);
 
-    void (*rsc_location) (pe_resource_t *, pe__location_t *);
+    /*!
+     * \internal
+     * \brief Apply a location constraint to a resource's allowed node scores
+     *
+     * \param[in,out] rsc       Resource to apply constraint to
+     * \param[in,out] location  Location constraint to apply
+     */
+    void (*apply_location)(pe_resource_t *rsc, pe__location_t *location);
 
     /*!
      * \internal

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -573,6 +573,10 @@ G_GNUC_INTERNAL
 void pcmk__primitive_internal_constraints(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
+enum pe_action_flags pcmk__primitive_action_flags(pe_action_t *action,
+                                                  const pe_node_t *node);
+
+G_GNUC_INTERNAL
 void pcmk__primitive_apply_coloc_score(pe_resource_t *dependent,
                                        pe_resource_t *primary,
                                        pcmk__colocation_t *colocation,

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -895,18 +895,19 @@ pcmk__bundle_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
         pe__bundle_replica_t *replica = gIter->data;
 
         if (replica->container) {
-            replica->container->cmds->rsc_location(replica->container,
-                                                   constraint);
+            replica->container->cmds->apply_location(replica->container,
+                                                     constraint);
         }
         if (replica->ip) {
-            replica->ip->cmds->rsc_location(replica->ip, constraint);
+            replica->ip->cmds->apply_location(replica->ip, constraint);
         }
     }
 
     if (bundle_data->child
         && ((constraint->role_filter == RSC_ROLE_UNPROMOTED)
             || (constraint->role_filter == RSC_ROLE_PROMOTED))) {
-        bundle_data->child->cmds->rsc_location(bundle_data->child, constraint);
+        bundle_data->child->cmds->apply_location(bundle_data->child,
+                                                 constraint);
         bundle_data->child->rsc_location = g_list_prepend(bundle_data->child->rsc_location,
                                                           constraint);
     }

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -540,7 +540,7 @@ pcmk__bundle_apply_coloc_score(pe_resource_t *dependent, pe_resource_t *primary,
 }
 
 enum pe_action_flags
-pcmk__bundle_action_flags(pe_action_t *action, pe_node_t *node)
+pcmk__bundle_action_flags(pe_action_t *action, const pe_node_t *node)
 {
     GList *containers = NULL;
     enum pe_action_flags flags = 0;

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -888,7 +888,7 @@ pcmk__bundle_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
     pe__bundle_variant_data_t *bundle_data = NULL;
     get_bundle_variant_data(bundle_data, rsc);
 
-    pcmk__apply_location(constraint, rsc);
+    pcmk__apply_location(rsc, constraint);
 
     for (GList *gIter = bundle_data->replicas; gIter != NULL;
          gIter = gIter->next) {

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -918,7 +918,7 @@ clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
 
     pe_rsc_trace(rsc, "Processing location constraint %s for %s", constraint->id, rsc->id);
 
-    pcmk__apply_location(constraint, rsc);
+    pcmk__apply_location(rsc, constraint);
 
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -923,7 +923,7 @@ clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
-        child_rsc->cmds->rsc_location(child_rsc, constraint);
+        child_rsc->cmds->apply_location(child_rsc, constraint);
     }
 }
 

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -861,7 +861,8 @@ clone_child_action(pe_action_t * action)
     } while (0)
 
 enum pe_action_flags
-summary_action_flags(pe_action_t * action, GList *children, pe_node_t * node)
+summary_action_flags(pe_action_t *action, GList *children,
+                     const pe_node_t *node)
 {
     GList *gIter = NULL;
     gboolean any_runnable = FALSE;
@@ -905,7 +906,7 @@ summary_action_flags(pe_action_t * action, GList *children, pe_node_t * node)
 }
 
 enum pe_action_flags
-clone_action_flags(pe_action_t * action, pe_node_t * node)
+clone_action_flags(pe_action_t *action, const pe_node_t *node)
 {
     return summary_action_flags(action, action->rsc->children, node);
 }

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -460,7 +460,7 @@ for_primary:
 }
 
 enum pe_action_flags
-group_action_flags(pe_action_t * action, pe_node_t * node)
+group_action_flags(pe_action_t *action, const pe_node_t *node)
 {
     GList *gIter = NULL;
     enum pe_action_flags flags = (pe_action_optional | pe_action_runnable | pe_action_pseudo);

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -565,7 +565,7 @@ group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
 
     pe_rsc_debug(rsc, "Processing rsc_location %s for %s", constraint->id, rsc->id);
 
-    pcmk__apply_location(constraint, rsc);
+    pcmk__apply_location(rsc, constraint);
 
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -570,7 +570,7 @@ group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
     for (; gIter != NULL; gIter = gIter->next) {
         pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
 
-        child_rsc->cmds->rsc_location(child_rsc, constraint);
+        child_rsc->cmds->apply_location(child_rsc, constraint);
         if (group_data->colocated && reset_scores) {
             reset_scores = FALSE;
             constraint->node_list_rh = zero;

--- a/lib/pacemaker/pcmk_sched_location.c
+++ b/lib/pacemaker/pcmk_sched_location.c
@@ -605,45 +605,48 @@ pcmk__apply_locations(pe_working_set_t *data_set)
          iter != NULL; iter = iter->next) {
         pe__location_t *location = iter->data;
 
-        location->rsc_lh->cmds->rsc_location(location->rsc_lh, location);
+        location->rsc_lh->cmds->apply_location(location->rsc_lh, location);
     }
 }
 
 /*!
  * \internal
- * \brief Apply a location constraint to a resource's allowed node weights
+ * \brief Apply a location constraint to a resource's allowed node scores
  *
- * \param[in] rsc         Resource to apply constraint to
- * \param[in] constraint  Location constraint to apply
+ * \param[in,out] rsc         Resource to apply constraint to
+ * \param[in,out] location    Location constraint to apply
+ *
+ * \note This does not consider the resource's children, so the resource's
+ *       apply_location() method should be used instead in most cases.
  */
 void
-pcmk__apply_location(pe_resource_t *rsc, pe__location_t *constraint)
+pcmk__apply_location(pe_resource_t *rsc, pe__location_t *location)
 {
     bool need_role = false;
 
-    CRM_CHECK((constraint != NULL) && (rsc != NULL), return);
+    CRM_CHECK((rsc != NULL) && (location != NULL), return);
 
     // If a role was specified, ensure constraint is applicable
-    need_role = (constraint->role_filter > RSC_ROLE_UNKNOWN);
-    if (need_role && (constraint->role_filter != rsc->next_role)) {
+    need_role = (location->role_filter > RSC_ROLE_UNKNOWN);
+    if (need_role && (location->role_filter != rsc->next_role)) {
         pe_rsc_trace(rsc,
                      "Not applying %s to %s because role will be %s not %s",
-                     constraint->id, rsc->id, role2text(rsc->next_role),
-                     role2text(constraint->role_filter));
+                     location->id, rsc->id, role2text(rsc->next_role),
+                     role2text(location->role_filter));
         return;
     }
 
-    if (constraint->node_list_rh == NULL) {
+    if (location->node_list_rh == NULL) {
         pe_rsc_trace(rsc, "Not applying %s to %s because no nodes match",
-                     constraint->id, rsc->id);
+                     location->id, rsc->id);
         return;
     }
 
-    pe_rsc_trace(rsc, "Applying %s%s%s to %s", constraint->id,
+    pe_rsc_trace(rsc, "Applying %s%s%s to %s", location->id,
                  (need_role? " for role " : ""),
-                 (need_role? role2text(constraint->role_filter) : ""), rsc->id);
+                 (need_role? role2text(location->role_filter) : ""), rsc->id);
 
-    for (GList *gIter = constraint->node_list_rh; gIter != NULL;
+    for (GList *gIter = location->node_list_rh; gIter != NULL;
          gIter = gIter->next) {
 
         pe_node_t *node = (pe_node_t *) gIter->data;
@@ -665,12 +668,12 @@ pcmk__apply_location(pe_resource_t *rsc, pe__location_t *constraint)
                                                      node->weight);
         }
 
-        if (weighted_node->rsc_discover_mode < constraint->discover_mode) {
-            if (constraint->discover_mode == pe_discover_exclusive) {
+        if (weighted_node->rsc_discover_mode < location->discover_mode) {
+            if (location->discover_mode == pe_discover_exclusive) {
                 rsc->exclusive_discover = TRUE;
             }
             /* exclusive > never > always... always is default */
-            weighted_node->rsc_discover_mode = constraint->discover_mode;
+            weighted_node->rsc_discover_mode = location->discover_mode;
         }
     }
 }

--- a/lib/pacemaker/pcmk_sched_location.c
+++ b/lib/pacemaker/pcmk_sched_location.c
@@ -613,11 +613,11 @@ pcmk__apply_locations(pe_working_set_t *data_set)
  * \internal
  * \brief Apply a location constraint to a resource's allowed node weights
  *
- * \param[in] constraint  Location constraint to apply
  * \param[in] rsc         Resource to apply constraint to
+ * \param[in] constraint  Location constraint to apply
  */
 void
-pcmk__apply_location(pe__location_t *constraint, pe_resource_t *rsc)
+pcmk__apply_location(pe_resource_t *rsc, pe__location_t *constraint)
 {
     bool need_role = false;
 

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -196,7 +196,7 @@ assign_best_node(pe_resource_t *rsc, pe_node_t *prefer)
                      pe__node_name(chosen), rsc->id, g_list_length(nodes));
     }
 
-    result = pcmk__assign_primitive(rsc, chosen, false);
+    result = pcmk__finalize_assignment(rsc, chosen, false);
     g_list_free(nodes);
     return result;
 }
@@ -395,11 +395,11 @@ pcmk__primitive_assign(pe_resource_t *rsc, pe_node_t *prefer)
         }
         pe_rsc_info(rsc, "Unmanaged resource %s assigned to %s: %s", rsc->id,
                     (assign_to? assign_to->details->uname : "no node"), reason);
-        pcmk__assign_primitive(rsc, assign_to, true);
+        pcmk__finalize_assignment(rsc, assign_to, true);
 
     } else if (pcmk_is_set(rsc->cluster->flags, pe_flag_stop_everything)) {
         pe_rsc_debug(rsc, "Forcing %s to stop: stop-all-resources", rsc->id);
-        pcmk__assign_primitive(rsc, NULL, true);
+        pcmk__finalize_assignment(rsc, NULL, true);
 
     } else if (pcmk_is_set(rsc->flags, pe_rsc_provisional)
                && assign_best_node(rsc, prefer)) {

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -1030,12 +1030,6 @@ pcmk__primitive_action_flags(pe_action_t *action, const pe_node_t *node)
     return action->flags;
 }
 
-void
-native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
-{
-    pcmk__apply_location(rsc, constraint);
-}
-
 /*!
  * \internal
  * \brief Check whether a node is a multiply active resource's expected node

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -1033,7 +1033,7 @@ pcmk__primitive_action_flags(pe_action_t *action, const pe_node_t *node)
 void
 native_rsc_location(pe_resource_t *rsc, pe__location_t *constraint)
 {
-    pcmk__apply_location(constraint, rsc);
+    pcmk__apply_location(rsc, constraint);
 }
 
 /*!

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -718,14 +718,21 @@ pcmk__primitive_create_actions(pe_resource_t *rsc)
     }
 }
 
+/*!
+ * \internal
+ * \brief Ban a resource from any allowed nodes that are Pacemaker Remote nodes
+ *
+ * \param[in] rsc  Resource to check
+ */
 static void
-rsc_avoids_remote_nodes(pe_resource_t *rsc)
+rsc_avoids_remote_nodes(const pe_resource_t *rsc)
 {
     GHashTableIter iter;
     pe_node_t *node = NULL;
+
     g_hash_table_iter_init(&iter, rsc->allowed_nodes);
-    while (g_hash_table_iter_next(&iter, NULL, (void **)&node)) {
-        if (node->details->remote_rsc) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
+        if (node->details->remote_rsc != NULL) {
             node->weight = -INFINITY;
         }
     }

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -1014,9 +1014,19 @@ pcmk__primitive_apply_coloc_score(pe_resource_t *dependent,
     }
 }
 
+/*!
+ * \internal
+ * \brief Return action flags for a given primitive resource action
+ *
+ * \param[in,out] action  Action to get flags for
+ * \param[in]     node    If not NULL, limit effects to this node
+ *
+ * \return Flags appropriate to \p action on \p node
+ */
 enum pe_action_flags
-native_action_flags(pe_action_t *action, const pe_node_t *node)
+pcmk__primitive_action_flags(pe_action_t *action, const pe_node_t *node)
 {
+    CRM_ASSERT(action != NULL);
     return action->flags;
 }
 

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -430,17 +430,16 @@ pcmk__primitive_assign(pe_resource_t *rsc, pe_node_t *prefer)
  * \internal
  * \brief Schedule actions to bring resource down and back to current role
  *
- * \param[in] rsc           Resource to restart
- * \param[in] current       Node that resource should be brought down on
- * \param[in] chosen        Node that resource should be brought up on
- * \param[in] need_stop     Whether the resource must be stopped
- * \param[in] need_promote  Whether the resource must be promoted
+ * \param[in,out] rsc           Resource to restart
+ * \param[in]     current       Node that resource should be brought down on
+ * \param[in]     need_stop     Whether the resource must be stopped
+ * \param[in]     need_promote  Whether the resource must be promoted
  *
  * \return Role that resource would have after scheduled actions are taken
  */
 static void
 schedule_restart_actions(pe_resource_t *rsc, pe_node_t *current,
-                         pe_node_t *chosen, bool need_stop, bool need_promote)
+                         bool need_stop, bool need_promote)
 {
     enum rsc_role_e role = rsc->role;
     enum rsc_role_e next_role;
@@ -471,7 +470,8 @@ schedule_restart_actions(pe_resource_t *rsc, pe_node_t *current,
         pe_rsc_trace(rsc, "Creating %s action to take %s up from %s to %s",
                      (required? "required" : "optional"), rsc->id,
                      role2text(role), role2text(next_role));
-        if (!rsc_action_matrix[role][next_role](rsc, chosen, !required)) {
+        if (!rsc_action_matrix[role][next_role](rsc, rsc->allocated_to,
+                                                !required)) {
             break;
         }
         role = next_role;
@@ -705,8 +705,7 @@ pcmk__primitive_create_actions(pe_resource_t *rsc)
     }
 
     // Create any actions needed to bring resource down and back up to same role
-    schedule_restart_actions(rsc, current, rsc->allocated_to, need_stop,
-                             need_promote);
+    schedule_restart_actions(rsc, current, need_stop, need_promote);
 
     // Create any actions needed to take resource from this role to the next
     schedule_role_transition_actions(rsc);

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -1018,7 +1018,7 @@ pcmk__primitive_apply_coloc_score(pe_resource_t *dependent,
  * \brief Return action flags for a given primitive resource action
  *
  * \param[in,out] action  Action to get flags for
- * \param[in]     node    If not NULL, limit effects to this node
+ * \param[in]     node    If not NULL, limit effects to this node (ignored)
  *
  * \return Flags appropriate to \p action on \p node
  */

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -1015,7 +1015,7 @@ pcmk__primitive_apply_coloc_score(pe_resource_t *dependent,
 }
 
 enum pe_action_flags
-native_action_flags(pe_action_t * action, pe_node_t * node)
+native_action_flags(pe_action_t *action, const pe_node_t *node)
 {
     return action->flags;
 }

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -22,7 +22,7 @@ static resource_alloc_functions_t allocation_methods[] = {
         pcmk__primitive_assign,
         pcmk__primitive_create_actions,
         pcmk__probe_rsc_on_node,
-        native_internal_constraints,
+        pcmk__primitive_internal_constraints,
         pcmk__primitive_apply_coloc_score,
         pcmk__add_colocated_node_scores,
         pcmk__colocated_resources,

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -26,7 +26,7 @@ static resource_alloc_functions_t allocation_methods[] = {
         pcmk__primitive_apply_coloc_score,
         pcmk__add_colocated_node_scores,
         pcmk__colocated_resources,
-        native_rsc_location,
+        pcmk__apply_location,
         pcmk__primitive_action_flags,
         pcmk__update_ordered_actions,
         pcmk__output_resource_actions,

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -20,7 +20,7 @@
 static resource_alloc_functions_t allocation_methods[] = {
     {
         pcmk__primitive_assign,
-        native_create_actions,
+        pcmk__primitive_create_actions,
         pcmk__probe_rsc_on_node,
         native_internal_constraints,
         pcmk__primitive_apply_coloc_score,
@@ -295,9 +295,8 @@ pcmk__output_resource_actions(pe_resource_t *rsc)
     if (rsc->running_on) {
         current = pe__current_node(rsc);
         if (rsc->role == RSC_ROLE_STOPPED) {
-            /*
-             * This can occur when resources are being recovered
-             * We fiddle with the current role in native_create_actions()
+            /* This can occur when resources are being recovered because
+             * the current role can change in pcmk__primitive_create_actions()
              */
             rsc->role = RSC_ROLE_STARTED;
         }

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -27,7 +27,7 @@ static resource_alloc_functions_t allocation_methods[] = {
         pcmk__add_colocated_node_scores,
         pcmk__colocated_resources,
         native_rsc_location,
-        native_action_flags,
+        pcmk__primitive_action_flags,
         pcmk__update_ordered_actions,
         pcmk__output_resource_actions,
         pcmk__add_rsc_actions_to_graph,

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -332,7 +332,7 @@ pcmk__output_resource_actions(pe_resource_t *rsc)
  *       actions created for the resource.
  */
 bool
-pcmk__assign_primitive(pe_resource_t *rsc, pe_node_t *chosen, bool force)
+pcmk__finalize_assignment(pe_resource_t *rsc, pe_node_t *chosen, bool force)
 {
     pcmk__output_t *out = rsc->cluster->priv;
 
@@ -438,7 +438,7 @@ pcmk__assign_resource(pe_resource_t *rsc, pe_node_t *node, bool force)
         if (rsc->allocated_to != NULL) {
             changed = true;
         }
-        pcmk__assign_primitive(rsc, node, force);
+        pcmk__finalize_assignment(rsc, node, force);
 
     } else {
         for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -1387,14 +1387,24 @@ get_complex_task(pe_resource_t * rsc, const char *name, gboolean allow_non_atomi
     return task;
 }
 
+/*!
+ * \internal
+ * \brief Find first matching action in a list
+ *
+ * \param[in] input    List of actions to search
+ * \param[in] uuid     If not NULL, action must have this UUID
+ * \param[in] task     If not NULL, action must have this action name
+ * \param[in] on_node  If not NULL, action must be on this node
+ *
+ * \return First action in list that matches criteria, or NULL if none
+ */
 pe_action_t *
-find_first_action(GList *input, const char *uuid, const char *task, pe_node_t * on_node)
+find_first_action(const GList *input, const char *uuid, const char *task,
+                  const pe_node_t *on_node)
 {
-    GList *gIter = NULL;
-
     CRM_CHECK(uuid || task, return NULL);
 
-    for (gIter = input; gIter != NULL; gIter = gIter->next) {
+    for (const GList *gIter = input; gIter != NULL; gIter = gIter->next) {
         pe_action_t *action = (pe_action_t *) gIter->data;
 
         if (uuid != NULL && !pcmk__str_eq(uuid, action->uuid, pcmk__str_casei)) {


### PR DESCRIPTION
This continues the project to bring libpacemaker up to current guidelines, focusing on some of the primitive methods.