### PR TITLE
Yet Another GString PR

### DIFF
--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -2696,37 +2696,38 @@ log_executor_event(const lrmd_event_data_t *op, const char *op_key,
     int log_level = LOG_ERR;
     GString *str = g_string_sized_new(100); // reasonable starting size
 
-    g_string_printf(str, "Result of %s operation for %s",
-                    crm_action_str(op->op_type, op->interval_ms), op->rsc_id);
+    pcmk__g_strcat(str,
+                   "Result of ", crm_action_str(op->op_type, op->interval_ms),
+                   " operation for ", op->rsc_id, NULL);
 
     if (node_name != NULL) {
-        g_string_append_printf(str, " on %s", node_name);
+        pcmk__g_strcat(str, " on ", node_name, NULL);
     }
 
     switch (op->op_status) {
         case PCMK_EXEC_DONE:
             log_level = LOG_NOTICE;
-            g_string_append_printf(str, ": %s",
-                                   services_ocf_exitcode_str(op->rc));
+            pcmk__g_strcat(str, ": ", services_ocf_exitcode_str(op->rc), NULL);
             break;
 
         case PCMK_EXEC_TIMEOUT:
-            g_string_append_printf(str, ": %s after %s",
-                                   pcmk_exec_status_str(op->op_status),
-                                   pcmk__readable_interval(op->timeout));
+            pcmk__g_strcat(str,
+                           ": ", pcmk_exec_status_str(op->op_status), " after ",
+                           pcmk__readable_interval(op->timeout), NULL);
             break;
 
         case PCMK_EXEC_CANCELLED:
             log_level = LOG_INFO;
             // Fall through
         default:
-            g_string_append_printf(str, ": %s",
-                                   pcmk_exec_status_str(op->op_status));
+            pcmk__g_strcat(str, ": ", pcmk_exec_status_str(op->op_status),
+                           NULL);
     }
 
     if ((op->exit_reason != NULL)
         && ((op->op_status != PCMK_EXEC_DONE) || (op->rc != PCMK_OCF_OK))) {
-        g_string_append_printf(str, " (%s)", op->exit_reason);
+
+        pcmk__g_strcat(str, " (", op->exit_reason, ")", NULL);
     }
 
     g_string_append(str, " " CRM_XS);

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -26,8 +26,8 @@ gboolean shuttingdown = FALSE;
 pcmk__graph_t *transition_graph;
 crm_trigger_t *transition_trigger = NULL;
 
-/* #define RSC_OP_TEMPLATE "//"XML_TAG_DIFF_ADDED"//"XML_TAG_CIB"//"XML_CIB_TAG_STATE"[@uname='%s']"//"XML_LRM_TAG_RSC_OP"[@id='%s]" */
-#define RSC_OP_TEMPLATE "//"XML_TAG_DIFF_ADDED"//"XML_TAG_CIB"//"XML_LRM_TAG_RSC_OP"[@id='%s']"
+#define RSC_OP_PREFIX "//" XML_TAG_DIFF_ADDED "//" XML_TAG_CIB \
+                      "//" XML_LRM_TAG_RSC_OP "[@" XML_ATTR_ID "='"
 
 // An explicit shutdown-lock of 0 means the lock has been cleared
 static bool
@@ -45,6 +45,7 @@ te_update_diff_v1(const char *event, xmlNode *diff)
 {
     int lpc, max;
     xmlXPathObject *xpathObj = NULL;
+    GString *rsc_op_xpath = NULL;
 
     CRM_CHECK(diff != NULL, return);
 
@@ -156,9 +157,7 @@ te_update_diff_v1(const char *event, xmlNode *diff)
     xpathObj = xpath_search(diff, "//" XML_TAG_DIFF_REMOVED "//" XML_LRM_TAG_RSC_OP);
     max = numXpathResults(xpathObj);
     for (lpc = 0; lpc < max; lpc++) {
-        int path_max = 0;
         const char *op_id = NULL;
-        char *rsc_op_xpath = NULL;
         xmlXPathObject *op_match = NULL;
         xmlNode *match = getXpathResult(xpathObj, lpc);
 
@@ -167,23 +166,25 @@ te_update_diff_v1(const char *event, xmlNode *diff)
 
         op_id = ID(match);
 
-        path_max = strlen(RSC_OP_TEMPLATE) + strlen(op_id) + 1;
-        rsc_op_xpath = calloc(1, path_max);
-        snprintf(rsc_op_xpath, path_max, RSC_OP_TEMPLATE, op_id);
+        if (rsc_op_xpath == NULL) {
+            rsc_op_xpath = g_string_new(RSC_OP_PREFIX);
+        } else {
+            g_string_truncate(rsc_op_xpath, sizeof(RSC_OP_PREFIX) - 1);
+        }
+        pcmk__g_strcat(rsc_op_xpath, op_id, "']", NULL);
 
-        op_match = xpath_search(diff, rsc_op_xpath);
+        op_match = xpath_search(diff, (const char *) rsc_op_xpath->str);
         if (numXpathResults(op_match) == 0) {
             /* Prevent false positives by matching cancelations too */
             const char *node = get_node_id(match);
             pcmk__graph_action_t *cancelled = get_cancel_action(op_id, node);
 
             if (cancelled == NULL) {
-                crm_debug("No match for deleted action %s (%s on %s)", rsc_op_xpath, op_id,
-                          node);
+                crm_debug("No match for deleted action %s (%s on %s)",
+                          (const char *) rsc_op_xpath->str, op_id, node);
                 abort_transition(INFINITY, pcmk__graph_restart,
                                  "Resource op removal", match);
                 freeXpathObject(op_match);
-                free(rsc_op_xpath);
                 goto bail;
 
             } else {
@@ -193,11 +194,13 @@ te_update_diff_v1(const char *event, xmlNode *diff)
         }
 
         freeXpathObject(op_match);
-        free(rsc_op_xpath);
     }
 
   bail:
     freeXpathObject(xpathObj);
+    if (rsc_op_xpath != NULL) {
+        g_string_free(rsc_op_xpath, TRUE);
+    }
 }
 
 static void

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -217,8 +217,8 @@ log_finished(const lrmd_cmd_t *cmd, int exec_time_ms, int queue_time_ms)
         log_level = LOG_DEBUG;
     }
 
-    g_string_printf(str, "%s %s (call %d",
-                    cmd->rsc_id, cmd->action, cmd->call_id);
+    g_string_append_printf(str, "%s %s (call %d",
+                           cmd->rsc_id, cmd->action, cmd->call_id);
     if (cmd->last_pid != 0) {
         g_string_append_printf(str, ", PID %d", cmd->last_pid);
     }
@@ -226,21 +226,22 @@ log_finished(const lrmd_cmd_t *cmd, int exec_time_ms, int queue_time_ms)
         g_string_append_printf(str, ") exited with status %d",
                                cmd->result.exit_status);
     } else {
-        g_string_append_printf(str, ") could not be executed: %s",
-                               pcmk_exec_status_str(cmd->result.execution_status));
+        pcmk__g_strcat(str, ") could not be executed: ",
+                       pcmk_exec_status_str(cmd->result.execution_status),
+                       NULL);
     }
     if (cmd->result.exit_reason != NULL) {
-        g_string_append_printf(str, " (%s)", cmd->result.exit_reason);
+        pcmk__g_strcat(str, " (", cmd->result.exit_reason, ")", NULL);
     }
 
 #ifdef PCMK__TIME_USE_CGT
-    g_string_append_printf(str, " (execution time %s",
-                           pcmk__readable_interval(exec_time_ms));
+    pcmk__g_strcat(str, " (execution time ",
+                   pcmk__readable_interval(exec_time_ms), NULL);
     if (queue_time_ms > 0) {
-        g_string_append_printf(str, " after being queued %s",
-                               pcmk__readable_interval(queue_time_ms));
+        pcmk__g_strcat(str, " after being queued ",
+                       pcmk__readable_interval(queue_time_ms), NULL);
     }
-    g_string_append(str, ")");
+    g_string_append_c(str, ')');
 #endif
 
     do_crm_log(log_level, "%s", str->str);

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -27,7 +27,7 @@ typedef struct stonith_device_s {
     char *namespace;
 
     /*! list of actions that must execute on the target node. Used for unfencing */
-    char *on_target_actions;
+    GString *on_target_actions;
     GList *targets;
     time_t targets_age;
     gboolean has_attr_map;

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -97,7 +97,7 @@ find_attr(cib_t *cib, const char *section, const char *node_uuid,
     g_string_append(xpath, xpath_base);
 
     if (pcmk__str_eq(node_type, XML_CIB_TAG_TICKETS, pcmk__str_casei)) {
-        g_string_append_printf(xpath, "//%s", node_type);
+        pcmk__g_strcat(xpath, "//", node_type, NULL);
 
     } else if (node_uuid) {
         const char *node_type = XML_CIB_TAG_NODE;
@@ -106,28 +106,28 @@ find_attr(cib_t *cib, const char *section, const char *node_uuid,
             node_type = XML_CIB_TAG_STATE;
             set_type = XML_TAG_TRANSIENT_NODEATTRS;
         }
-        g_string_append_printf(xpath, "//%s[@" XML_ATTR_ID "='%s']", node_type,
-                               node_uuid);
+        pcmk__g_strcat(xpath,
+                       "//", node_type, "[@" XML_ATTR_ID "='", node_uuid, "']",
+                       NULL);
     }
 
+    pcmk__g_strcat(xpath, "//", set_type, NULL);
     if (set_name) {
-        g_string_append_printf(xpath, "//%s[@" XML_ATTR_ID "='%s']", set_type,
-                               set_name);
-    } else {
-        g_string_append_printf(xpath, "//%s", set_type);
+        pcmk__g_strcat(xpath, "[@" XML_ATTR_ID "='", set_name, "']", NULL);
     }
 
     g_string_append(xpath, "//nvpair");
 
     if (attr_id && attr_name) {
-        g_string_append_printf(xpath,
-                               "[@" XML_ATTR_ID "='%s' and @" XML_ATTR_NAME
-                               "='%s']", attr_id, attr_name);
+        pcmk__g_strcat(xpath,
+                       "[@" XML_ATTR_ID "='", attr_id, "' "
+                       "and @" XML_ATTR_NAME "='", attr_name, "']", NULL);
+
     } else if (attr_id) {
-        g_string_append_printf(xpath, "[@" XML_ATTR_ID "='%s']", attr_id);
+        pcmk__g_strcat(xpath, "[@" XML_ATTR_ID "='", attr_id, "']", NULL);
 
     } else if (attr_name) {
-        g_string_append_printf(xpath, "[@" XML_ATTR_NAME "='%s']", attr_name);
+        pcmk__g_strcat(xpath, "[@" XML_ATTR_NAME "='", attr_name, "']", NULL);
     }
 
     rc = cib_internal_op(cib, PCMK__CIB_REQUEST_QUERY, NULL,

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -81,27 +81,29 @@ stonith__history_description(stonith_history_t *history, bool full_history,
         completed_time = time_t_string(history->completed);
     }
 
-    g_string_printf(str, "%s of %s",
-                    stonith_action_str(history->action), history->target);
+    pcmk__g_strcat(str,
+                   stonith_action_str(history->action), " of ", history->target,
+                   NULL);
 
     if (!pcmk_is_set(show_opts, pcmk_show_failed_detail)) {
         // More human-friendly
         if (((history->state == st_failed) || (history->state == st_done))
             && (history->delegate != NULL)) {
-            g_string_append_printf(str, " by %s", history->delegate);
+
+            pcmk__g_strcat(str, " by ", history->delegate, NULL);
         }
-        g_string_append_printf(str, " for %s@%s",
-                               history->client, history->origin);
+        pcmk__g_strcat(str, " for ", history->client, "@", history->origin,
+                       NULL);
         if (!full_history) {
             g_string_append(str, " last"); // For example, "last failed at ..."
         }
     }
 
-    g_string_append_printf(str, " %s", state_str(history));
+    pcmk__add_word(&str, 0, state_str(history));
 
     // For failed actions, add exit reason if available
     if ((history->state == st_failed) && (history->exit_reason != NULL)) {
-        g_string_append_printf(str, " (%s)", history->exit_reason);
+        pcmk__g_strcat(str, " (", history->exit_reason, ")", NULL);
     }
 
     if (pcmk_is_set(show_opts, pcmk_show_failed_detail)) {
@@ -112,12 +114,13 @@ stonith__history_description(stonith_history_t *history, bool full_history,
         if (((history->state == st_failed) || (history->state == st_done))
             && (history->delegate != NULL)) {
 
-            g_string_append_printf(str, "delegate=%s, ", history->delegate);
+            pcmk__g_strcat(str, "delegate=", history->delegate, ", ", NULL);
         }
 
         // Add information about originator
-        g_string_append_printf(str, "client=%s, origin=%s",
-                               history->client, history->origin);
+        pcmk__g_strcat(str,
+                       "client=", history->client, ", origin=", history->origin,
+                       NULL);
 
         // For completed actions, add completion time
         if (completed_time != NULL) {
@@ -128,17 +131,18 @@ stonith__history_description(stonith_history_t *history, bool full_history,
             } else {
                 g_string_append(str, ", last-successful");
             }
-            g_string_append_printf(str, "='%s'", completed_time);
+            pcmk__g_strcat(str, "='", completed_time, "'", NULL);
         }
     } else { // More human-friendly
         if (completed_time != NULL) {
-            g_string_append_printf(str, " at %s", completed_time);
+            pcmk__g_strcat(str, " at ", completed_time, NULL);
         }
     }
 
     if ((history->state == st_failed) && (later_succeeded != NULL)) {
-        g_string_append_printf(str, " (a later attempt from %s succeeded)",
-                               later_succeeded);
+        pcmk__g_strcat(str,
+                       " (a later attempt from ", later_succeeded,
+                       " succeeded)", NULL);
     }
 
     free(completed_time);

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1880,20 +1880,20 @@ attribute_default(pcmk__output_t *out, va_list args)
     GString *s = g_string_sized_new(50);
 
     if (!pcmk__str_empty(scope)) {
-        g_string_append_printf(s, "scope=\"%s\" ", scope);
+        pcmk__g_strcat(s, "scope=\"", scope, "\" ", NULL);
     }
 
     if (!pcmk__str_empty(instance)) {
-        g_string_append_printf(s, "id=\"%s\" ", instance);
+        pcmk__g_strcat(s, "id=\"", instance, "\" ", NULL);
     }
 
-    g_string_append_printf(s, "name=\"%s\" ", name);
+    pcmk__g_strcat(s, "name=\"", pcmk__s(name, ""), "\" ", NULL);
 
     if (!pcmk__str_empty(host)) {
-        g_string_append_printf(s, "host=\"%s\" ", host);
+        pcmk__g_strcat(s, "host=\"", host, "\" ", NULL);
     }
 
-    g_string_append_printf(s, "value=\"%s\"", value ? value : "");
+    pcmk__g_strcat(s, "value=\"", pcmk__s(value, ""), "\"", NULL);
 
     out->info(out, "%s", s->str);
     g_string_free(s, TRUE);

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -22,8 +22,6 @@
 
 #include "libpacemaker_private.h"
 
-#define STATUS_PATH_MAX 512
-
 static pcmk__output_t *out = NULL;
 static cib_t *fake_cib = NULL;
 static GList *fake_resource_list = NULL;
@@ -686,7 +684,7 @@ simulate_fencing_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 
     if (!pcmk__str_eq(op, "on", pcmk__str_casei)) {
         int rc = pcmk_ok;
-        char xpath[STATUS_PATH_MAX];
+        GString *xpath = g_string_sized_new(512);
 
         // Set node state to offline
         xmlNode *cib_node = pcmk__inject_node_state_change(fake_cib, target,
@@ -699,17 +697,23 @@ simulate_fencing_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
         CRM_ASSERT(rc == pcmk_ok);
 
         // Simulate controller clearing node's resource history and attributes
-        snprintf(xpath, STATUS_PATH_MAX, "//node_state[@uname='%s']/%s",
-                 target, XML_CIB_TAG_LRM);
-        fake_cib->cmds->remove(fake_cib, xpath, NULL,
+        pcmk__g_strcat(xpath,
+                       "//" XML_CIB_TAG_STATE
+                       "[@" XML_ATTR_UNAME "='", target, "']/" XML_CIB_TAG_LRM,
+                       NULL);
+        fake_cib->cmds->remove(fake_cib, (const char *) xpath->str, NULL,
                                cib_xpath|cib_sync_call|cib_scope_local);
 
-        snprintf(xpath, STATUS_PATH_MAX, "//node_state[@uname='%s']/%s",
-                 target, XML_TAG_TRANSIENT_NODEATTRS);
-        fake_cib->cmds->remove(fake_cib, xpath, NULL,
+        g_string_truncate(xpath, 0);
+        pcmk__g_strcat(xpath,
+                       "//" XML_CIB_TAG_STATE
+                       "[@" XML_ATTR_UNAME "='", target, "']"
+                       "/" XML_TAG_TRANSIENT_NODEATTRS, NULL);
+        fake_cib->cmds->remove(fake_cib, (const char *) xpath->str, NULL,
                                cib_xpath|cib_sync_call|cib_scope_local);
 
         free_xml(cib_node);
+        g_string_free(xpath, TRUE);
     }
 
     pcmk__set_graph_action_flags(action, pcmk__graph_action_confirmed);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -173,460 +173,215 @@ create_ip_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
     return TRUE;
 }
 
-static bool
-create_docker_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
-                       pe__bundle_replica_t *replica,
-                       pe_working_set_t *data_set)
+static const char*
+container_agent_str(enum pe__container_agent t)
 {
-        GString *buffer = g_string_sized_new(4096);
-        GString *dbuffer = g_string_sized_new(1024);
+    switch (t) {
+        case PE__CONTAINER_AGENT_DOCKER: return PE__CONTAINER_AGENT_DOCKER_S;
+        case PE__CONTAINER_AGENT_RKT:    return PE__CONTAINER_AGENT_RKT_S;
+        case PE__CONTAINER_AGENT_PODMAN: return PE__CONTAINER_AGENT_PODMAN_S;
+        default: // PE__CONTAINER_AGENT_UNKNOWN
+            break;
+    }
+    return PE__CONTAINER_AGENT_UNKNOWN_S;
+}
 
-        char *id = NULL;
-        xmlNode *xml_container = NULL;
-        xmlNode *xml_obj = NULL;
+static int
+create_container_resource(pe_resource_t *parent,
+                          const pe__bundle_variant_data_t *data,
+                          pe__bundle_replica_t *replica)
+{
+    char *id = NULL;
+    xmlNode *xml_container = NULL;
+    xmlNode *xml_obj = NULL;
 
-        id = crm_strdup_printf("%s-docker-%d", data->prefix, replica->offset);
-        crm_xml_sanitize_id(id);
-        xml_container = create_resource(id, "heartbeat",
-                                        PE__CONTAINER_AGENT_DOCKER_S);
-        free(id);
+    // Agent-specific
+    const char *hostname_opt = NULL;
+    const char *env_opt = NULL;
+    const char *agent_str = NULL;
+    int volid = 0;  // rkt-only
 
-        xml_obj = create_xml_node(xml_container, XML_TAG_ATTR_SETS);
-        crm_xml_set_id(xml_obj, "%s-attributes-%d",
-                       data->prefix, replica->offset);
+    GString *buffer = NULL;
+    GString *dbuffer = NULL;
 
-        crm_create_nvpair_xml(xml_obj, NULL, "image", data->image);
-        crm_create_nvpair_xml(xml_obj, NULL, "allow_pull", XML_BOOLEAN_TRUE);
-        crm_create_nvpair_xml(xml_obj, NULL, "force_kill", XML_BOOLEAN_FALSE);
-        crm_create_nvpair_xml(xml_obj, NULL, "reuse", XML_BOOLEAN_FALSE);
+    // Where syntax differences are drop-in replacements, set them now
+    switch (data->agent_type) {
+        case PE__CONTAINER_AGENT_DOCKER:
+        case PE__CONTAINER_AGENT_PODMAN:
+            hostname_opt = "-h ";
+            env_opt = "-e ";
+            break;
+        case PE__CONTAINER_AGENT_RKT:
+            hostname_opt = "--hostname=";
+            env_opt = "--environment=";
+            break;
+        default:    // PE__CONTAINER_AGENT_UNKNOWN
+            return pcmk_rc_unpack_error;
+    }
+    agent_str = container_agent_str(data->agent_type);
 
+    buffer = g_string_sized_new(4096);
+
+    id = crm_strdup_printf("%s-%s-%d", data->prefix, agent_str,
+                           replica->offset);
+    crm_xml_sanitize_id(id);
+    xml_container = create_resource(id, "heartbeat", agent_str);
+    free(id);
+
+    xml_obj = create_xml_node(xml_container, XML_TAG_ATTR_SETS);
+    crm_xml_set_id(xml_obj, "%s-attributes-%d", data->prefix, replica->offset);
+
+    crm_create_nvpair_xml(xml_obj, NULL, "image", data->image);
+    crm_create_nvpair_xml(xml_obj, NULL, "allow_pull", XML_BOOLEAN_TRUE);
+    crm_create_nvpair_xml(xml_obj, NULL, "force_kill", XML_BOOLEAN_FALSE);
+    crm_create_nvpair_xml(xml_obj, NULL, "reuse", XML_BOOLEAN_FALSE);
+
+    if (data->agent_type == PE__CONTAINER_AGENT_DOCKER) {
         g_string_append(buffer, " --restart=no");
+    }
 
-        /* Set a container hostname only if we have an IP to map it to.
-         * The user can set -h or --uts=host themselves if they want a nicer
-         * name for logs, but this makes applications happy who need their
-         * hostname to match the IP they bind to.
-         */
-        if (data->ip_range_start != NULL) {
-            g_string_append_printf(buffer, " -h %s-%d", data->prefix,
-                                   replica->offset);
+    /* Set a container hostname only if we have an IP to map it to. The user can
+     * set -h or --uts=host themselves if they want a nicer name for logs, but
+     * this makes applications happy who need their  hostname to match the IP
+     * they bind to.
+     */
+    if (data->ip_range_start != NULL) {
+        g_string_append_printf(buffer, " %s%s-%d", hostname_opt, data->prefix,
+                               replica->offset);
+    }
+    pcmk__g_strcat(buffer, " ", env_opt, "PCMK_stderr=1", NULL);
+
+    if (data->container_network != NULL) {
+        pcmk__g_strcat(buffer, " --net=", data->container_network, NULL);
+    }
+
+    if (data->control_port != NULL) {
+        pcmk__g_strcat(buffer, " ", env_opt, "PCMK_remote_port=",
+                      data->control_port, NULL);
+    } else {
+        g_string_append_printf(buffer, " %sPCMK_remote_port=%d", env_opt,
+                               DEFAULT_REMOTE_PORT);
+    }
+
+    for (GList *iter = data->mounts; iter != NULL; iter = iter->next) {
+        pe__bundle_mount_t *mount = (pe__bundle_mount_t *) iter->data;
+        char *source = NULL;
+
+        if (pcmk_is_set(mount->flags, pe__bundle_mount_subdir)) {
+            source = crm_strdup_printf("%s/%s-%d", mount->source, data->prefix,
+                                       replica->offset);
+            pcmk__add_separated_word(&dbuffer, 1024, source, ",");
         }
 
-        g_string_append(buffer, " -e PCMK_stderr=1");
+        switch (data->agent_type) {
+            case PE__CONTAINER_AGENT_DOCKER:
+            case PE__CONTAINER_AGENT_PODMAN:
+                pcmk__g_strcat(buffer,
+                               " -v ", pcmk__s(source, mount->source),
+                               ":", mount->target, NULL);
 
-        if (data->container_network) {
-            g_string_append_printf(buffer, " --net=%s",
-                                   data->container_network);
-        }
-
-        if(data->control_port) {
-            g_string_append_printf(buffer, " -e PCMK_remote_port=%s",
-                                   data->control_port);
-        } else {
-            g_string_append_printf(buffer, " -e PCMK_remote_port=%d",
-                                   DEFAULT_REMOTE_PORT);
-        }
-
-        for(GList *pIter = data->mounts; pIter != NULL; pIter = pIter->next) {
-            pe__bundle_mount_t *mount = pIter->data;
-
-            if (pcmk_is_set(mount->flags, pe__bundle_mount_subdir)) {
-                char *source = crm_strdup_printf(
-                    "%s/%s-%d", mount->source, data->prefix, replica->offset);
-
-                if (dbuffer->len > 0) {
-                    g_string_append_c(dbuffer, ',');
+                if (mount->options != NULL) {
+                    pcmk__g_strcat(buffer, ":", mount->options, NULL);
                 }
-                g_string_append(dbuffer, source);
-                g_string_append_printf(buffer, " -v %s:%s", source,
-                                       mount->target);
-                free(source);
-
-            } else {
-                g_string_append_printf(buffer, " -v %s:%s", mount->source,
-                                       mount->target);
-            }
-            if(mount->options) {
-                g_string_append_printf(buffer, ":%s", mount->options);
-            }
-        }
-
-        for(GList *pIter = data->ports; pIter != NULL; pIter = pIter->next) {
-            pe__bundle_port_t *port = pIter->data;
-
-            if (replica->ipaddr) {
-                g_string_append_printf(buffer, " -p %s:%s:%s", replica->ipaddr,
-                                       port->source, port->target);
-            } else if(!pcmk__str_eq(data->container_network, "host", pcmk__str_casei)) {
-                // No need to do port mapping if net=host
-                g_string_append_printf(buffer, " -p %s:%s", port->source,
-                                       port->target);
-            }
-        }
-
-        if (data->launcher_options) {
-            g_string_append_printf(buffer, " %s", data->launcher_options);
-        }
-
-        if (data->container_host_options) {
-            g_string_append_printf(buffer, " %s", data->container_host_options);
-        }
-
-        crm_create_nvpair_xml(xml_obj, NULL, "run_opts",
-                              (const char *) buffer->str);
-        g_string_free(buffer, TRUE);
-
-        crm_create_nvpair_xml(xml_obj, NULL, "mount_points",
-                              (const char *) dbuffer->str);
-        g_string_free(dbuffer, TRUE);
-
-        if (replica->child) {
-            if (data->container_command) {
-                crm_create_nvpair_xml(xml_obj, NULL,
-                                      "run_cmd", data->container_command);
-            } else {
-                crm_create_nvpair_xml(xml_obj, NULL,
-                                      "run_cmd", SBIN_DIR "/pacemaker-remoted");
-            }
-
-            /* TODO: Allow users to specify their own?
-             *
-             * We just want to know if the container is alive, we'll
-             * monitor the child independently
-             */
-            crm_create_nvpair_xml(xml_obj, NULL, "monitor_cmd", "/bin/true");
-#if 0
-        /* @TODO Consider supporting the use case where we can start and stop
-         * resources, but not proxy local commands (such as setting node
-         * attributes), by running the local executor in stand-alone mode.
-         * However, this would probably be better done via ACLs as with other
-         * Pacemaker Remote nodes.
-         */
-        } else if ((child != NULL) && data->untrusted) {
-            crm_create_nvpair_xml(xml_obj, NULL, "run_cmd",
-                                  CRM_DAEMON_DIR "/pacemaker-execd");
-            crm_create_nvpair_xml(xml_obj, NULL, "monitor_cmd",
-                                  CRM_DAEMON_DIR "/pacemaker/cts-exec-helper -c poke");
-#endif
-        } else {
-            if (data->container_command) {
-                crm_create_nvpair_xml(xml_obj, NULL,
-                                      "run_cmd", data->container_command);
-            }
-
-            /* TODO: Allow users to specify their own?
-             *
-             * We don't know what's in the container, so we just want
-             * to know if it is alive
-             */
-            crm_create_nvpair_xml(xml_obj, NULL, "monitor_cmd", "/bin/true");
-        }
-
-
-        xml_obj = create_xml_node(xml_container, "operations");
-        crm_create_op_xml(xml_obj, ID(xml_container), "monitor", "60s", NULL);
-
-        // TODO: Other ops? Timeouts and intervals from underlying resource?
-        if (pe__unpack_resource(xml_container, &replica->container, parent,
-                                data_set) != pcmk_rc_ok) {
-            return FALSE;
-        }
-        parent->children = g_list_append(parent->children, replica->container);
-        return TRUE;
-}
-
-static bool
-create_podman_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
-                       pe__bundle_replica_t *replica,
-                       pe_working_set_t *data_set)
-{
-        GString *buffer = g_string_sized_new(4096);
-        GString *dbuffer = g_string_sized_new(1024);
-
-        char *id = NULL;
-        xmlNode *xml_container = NULL;
-        xmlNode *xml_obj = NULL;
-
-        id = crm_strdup_printf("%s-podman-%d", data->prefix, replica->offset);
-        crm_xml_sanitize_id(id);
-        xml_container = create_resource(id, "heartbeat",
-                                        PE__CONTAINER_AGENT_PODMAN_S);
-        free(id);
-
-        xml_obj = create_xml_node(xml_container, XML_TAG_ATTR_SETS);
-        crm_xml_set_id(xml_obj, "%s-attributes-%d",
-                       data->prefix, replica->offset);
-
-        crm_create_nvpair_xml(xml_obj, NULL, "image", data->image);
-        crm_create_nvpair_xml(xml_obj, NULL, "allow_pull", XML_BOOLEAN_TRUE);
-        crm_create_nvpair_xml(xml_obj, NULL, "force_kill", XML_BOOLEAN_FALSE);
-        crm_create_nvpair_xml(xml_obj, NULL, "reuse", XML_BOOLEAN_FALSE);
-
-        /* Set a container hostname only if we have an IP to map it to.
-         * The user can set -h or --uts=host themselves if they want a nicer
-         * name for logs, but this makes applications happy who need their
-         * hostname to match the IP they bind to.
-         */
-        if (data->ip_range_start != NULL) {
-            g_string_append_printf(buffer, " -h %s-%d", data->prefix,
-                                   replica->offset);
-        }
-
-        g_string_append(buffer, " -e PCMK_stderr=1");
-
-        if (data->container_network) {
-            g_string_append_printf(buffer, " --net=%s",
-                                   data->container_network);
-        }
-
-        if(data->control_port) {
-            g_string_append_printf(buffer, " -e PCMK_remote_port=%s",
-                                   data->control_port);
-        } else {
-            g_string_append_printf(buffer, " -e PCMK_remote_port=%d",
-                                   DEFAULT_REMOTE_PORT);
-        }
-
-        for(GList *pIter = data->mounts; pIter != NULL; pIter = pIter->next) {
-            pe__bundle_mount_t *mount = pIter->data;
-
-            if (pcmk_is_set(mount->flags, pe__bundle_mount_subdir)) {
-                char *source = crm_strdup_printf(
-                    "%s/%s-%d", mount->source, data->prefix, replica->offset);
-
-                if (dbuffer->len > 0) {
-                    g_string_append_c(dbuffer, ',');
-                }
-                g_string_append(dbuffer, source);
-                g_string_append_printf(buffer, " -v %s:%s", source,
-                                       mount->target);
-                free(source);
-
-            } else {
-                g_string_append_printf(buffer, " -v %s:%s", mount->source,
-                                       mount->target);
-            }
-            if(mount->options) {
-                g_string_append_printf(buffer, ":%s", mount->options);
-            }
-        }
-
-        for(GList *pIter = data->ports; pIter != NULL; pIter = pIter->next) {
-            pe__bundle_port_t *port = pIter->data;
-
-            if (replica->ipaddr) {
-                g_string_append_printf(buffer, " -p %s:%s:%s", replica->ipaddr,
-                                       port->source, port->target);
-            } else if(!pcmk__str_eq(data->container_network, "host", pcmk__str_casei)) {
-                // No need to do port mapping if net=host
-                g_string_append_printf(buffer, " -p %s:%s", port->source,
-                                       port->target);
-            }
-        }
-
-        if (data->launcher_options) {
-            g_string_append_printf(buffer, " %s", data->launcher_options);
-        }
-
-        if (data->container_host_options) {
-            g_string_append_printf(buffer, " %s", data->container_host_options);
-        }
-
-        crm_create_nvpair_xml(xml_obj, NULL, "run_opts",
-                              (const char *) buffer->str);
-        g_string_free(buffer, TRUE);
-
-        crm_create_nvpair_xml(xml_obj, NULL, "mount_points",
-                              (const char *) dbuffer->str);
-        g_string_free(dbuffer, TRUE);
-
-        if (replica->child) {
-            if (data->container_command) {
-                crm_create_nvpair_xml(xml_obj, NULL,
-                                      "run_cmd", data->container_command);
-            } else {
-                crm_create_nvpair_xml(xml_obj, NULL,
-                                      "run_cmd", SBIN_DIR "/pacemaker-remoted");
-            }
-
-            /* TODO: Allow users to specify their own?
-             *
-             * We just want to know if the container is alive, we'll
-             * monitor the child independently
-             */
-            crm_create_nvpair_xml(xml_obj, NULL, "monitor_cmd", "/bin/true");
-#if 0
-        /* @TODO Consider supporting the use case where we can start and stop
-         * resources, but not proxy local commands (such as setting node
-         * attributes), by running the local executor in stand-alone mode.
-         * However, this would probably be better done via ACLs as with other
-         * Pacemaker Remote nodes.
-         */
-        } else if ((child != NULL) && data->untrusted) {
-            crm_create_nvpair_xml(xml_obj, NULL, "run_cmd",
-                                  CRM_DAEMON_DIR "/pacemaker-execd");
-            crm_create_nvpair_xml(xml_obj, NULL, "monitor_cmd",
-                                  CRM_DAEMON_DIR "/pacemaker/cts-exec-helper -c poke");
-#endif
-        } else {
-            if (data->container_command) {
-                crm_create_nvpair_xml(xml_obj, NULL,
-                                      "run_cmd", data->container_command);
-            }
-
-            /* TODO: Allow users to specify their own?
-             *
-             * We don't know what's in the container, so we just want
-             * to know if it is alive
-             */
-            crm_create_nvpair_xml(xml_obj, NULL, "monitor_cmd", "/bin/true");
-        }
-
-
-        xml_obj = create_xml_node(xml_container, "operations");
-        crm_create_op_xml(xml_obj, ID(xml_container), "monitor", "60s", NULL);
-
-        // TODO: Other ops? Timeouts and intervals from underlying resource?
-        if (pe__unpack_resource(xml_container, &replica->container, parent,
-                                data_set) != pcmk_rc_ok) {
-            return FALSE;
-        }
-        parent->children = g_list_append(parent->children, replica->container);
-        return TRUE;
-}
-
-static bool
-create_rkt_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
-                    pe__bundle_replica_t *replica, pe_working_set_t *data_set)
-{
-        GString *buffer = g_string_sized_new(4096);
-        GString *dbuffer = g_string_sized_new(1024);
-
-        char *id = NULL;
-        xmlNode *xml_container = NULL;
-        xmlNode *xml_obj = NULL;
-
-        int volid = 0;
-
-        id = crm_strdup_printf("%s-rkt-%d", data->prefix, replica->offset);
-        crm_xml_sanitize_id(id);
-        xml_container = create_resource(id, "heartbeat",
-                                        PE__CONTAINER_AGENT_RKT_S);
-        free(id);
-
-        xml_obj = create_xml_node(xml_container, XML_TAG_ATTR_SETS);
-        crm_xml_set_id(xml_obj, "%s-attributes-%d",
-                       data->prefix, replica->offset);
-
-        crm_create_nvpair_xml(xml_obj, NULL, "image", data->image);
-        crm_create_nvpair_xml(xml_obj, NULL, "allow_pull", "true");
-        crm_create_nvpair_xml(xml_obj, NULL, "force_kill", "false");
-        crm_create_nvpair_xml(xml_obj, NULL, "reuse", "false");
-
-        /* Set a container hostname only if we have an IP to map it to.
-         * The user can set -h or --uts=host themselves if they want a nicer
-         * name for logs, but this makes applications happy who need their
-         * hostname to match the IP they bind to.
-         */
-        if (data->ip_range_start != NULL) {
-            g_string_append_printf(buffer, " --hostname=%s-%d", data->prefix,
-                                   replica->offset);
-        }
-
-        g_string_append(buffer, " --environment=PCMK_stderr=1");
-
-        if (data->container_network) {
-            g_string_append_printf(buffer, " --net=%s",
-                                   data->container_network);
-        }
-
-        if(data->control_port) {
-            g_string_append_printf(buffer, " --environment=PCMK_remote_port=%s",
-                                   data->control_port);
-        } else {
-            g_string_append_printf(buffer, " --environment=PCMK_remote_port=%d",
-                                   DEFAULT_REMOTE_PORT);
-        }
-
-        for(GList *pIter = data->mounts; pIter != NULL; pIter = pIter->next) {
-            pe__bundle_mount_t *mount = pIter->data;
-
-            if (pcmk_is_set(mount->flags, pe__bundle_mount_subdir)) {
-                char *source = crm_strdup_printf(
-                    "%s/%s-%d", mount->source, data->prefix, replica->offset);
-
-                if (dbuffer->len > 0) {
-                    g_string_append_c(dbuffer, ',');
-                }
-                g_string_append(dbuffer, source);
+                break;
+            case PE__CONTAINER_AGENT_RKT:
                 g_string_append_printf(buffer,
-                                       " --volume vol%d,kind=host,source=%s",
-                                       volid, source);
-                if(mount->options) {
-                    g_string_append_printf(buffer, ",%s", mount->options);
-                }
-                g_string_append_printf(buffer,
-                                       " --mount volume=vol%d,target=%s",
+                                       " --volume vol%d,kind=host,"
+                                       "source=%s%s%s "
+                                       "--mount volume=vol%d,target=%s",
+                                       volid, pcmk__s(source, mount->source),
+                                       (mount->options != NULL)? "," : "",
+                                       pcmk__s(mount->options, ""),
                                        volid, mount->target);
-                free(source);
+                volid++;
+                break;
+            default:
+                break;
+        }
+        free(source);
+    }
 
-            } else {
-                g_string_append_printf(buffer,
-                                       " --volume vol%d,kind=host,source=%s",
-                                       volid, mount->source);
-                if(mount->options) {
-                    g_string_append_printf(buffer, ",%s", mount->options);
+    for (GList *iter = data->ports; iter != NULL; iter = iter->next) {
+        pe__bundle_port_t *port = (pe__bundle_port_t *) iter->data;
+
+        switch (data->agent_type) {
+            case PE__CONTAINER_AGENT_DOCKER:
+            case PE__CONTAINER_AGENT_PODMAN:
+                if (replica->ipaddr != NULL) {
+                    pcmk__g_strcat(buffer,
+                                   " -p ", replica->ipaddr, ":", port->source,
+                                   ":", port->target, NULL);
+
+                } else if (!pcmk__str_eq(data->container_network, "host",
+                                         pcmk__str_none)) {
+                    // No need to do port mapping if net == host
+                    pcmk__g_strcat(buffer,
+                                   " -p ", port->source, ":", port->target,
+                                   NULL);
                 }
-                g_string_append_printf(buffer,
-                                       " --mount volume=vol%d,target=%s",
-                                       volid, mount->target);
-            }
-            volid++;
+                break;
+            case PE__CONTAINER_AGENT_RKT:
+                if (replica->ipaddr != NULL) {
+                    pcmk__g_strcat(buffer,
+                                   " --port=", port->target,
+                                   ":", replica->ipaddr, ":", port->source,
+                                   NULL);
+                } else {
+                    pcmk__g_strcat(buffer,
+                                   " --port=", port->target, ":", port->source,
+                                   NULL);
+                }
+                break;
+            default:
+                break;
         }
+    }
 
-        for(GList *pIter = data->ports; pIter != NULL; pIter = pIter->next) {
-            pe__bundle_port_t *port = pIter->data;
+    /* @COMPAT: We should use pcmk__add_word() here, but we can't yet, because
+     * it would cause restarts during rolling upgrades.
+     *
+     * In a previous version of the container resource creation logic, if
+     * data->launcher_options is not NULL, we append
+     * (" %s", data->launcher_options) even if data->launcher_options is an
+     * empty string. Likewise for data->container_host_options. Using
+     *
+     *     pcmk__add_word(buffer, 0, data->launcher_options)
+     *
+     * removes that extra trailing space, causing a resource definition change.
+     */
+    if (data->launcher_options != NULL) {
+        pcmk__g_strcat(buffer, " ", data->launcher_options, NULL);
+    }
 
-            if (replica->ipaddr) {
-                g_string_append_printf(buffer, " --port=%s:%s:%s", port->target,
-                                       replica->ipaddr, port->source);
-            } else {
-                g_string_append_printf(buffer, " --port=%s:%s", port->target,
-                                       port->source);
-            }
-        }
+    if (data->container_host_options != NULL) {
+        pcmk__g_strcat(buffer, " ", data->container_host_options, NULL);
+    }
 
-        if (data->launcher_options) {
-            g_string_append_printf(buffer, " %s", data->launcher_options);
-        }
+    crm_create_nvpair_xml(xml_obj, NULL, "run_opts",
+                          (const char *) buffer->str);
+    g_string_free(buffer, TRUE);
 
-        if (data->container_host_options) {
-            g_string_append_printf(buffer, " %s", data->container_host_options);
-        }
-
-        crm_create_nvpair_xml(xml_obj, NULL, "run_opts",
-                              (const char *) buffer->str);
-        g_string_free(buffer, TRUE);
-
-        crm_create_nvpair_xml(xml_obj, NULL, "mount_points",
-                              (const char *) dbuffer->str);
+    crm_create_nvpair_xml(xml_obj, NULL, "mount_points",
+                          (dbuffer != NULL)? (const char *) dbuffer->str : "");
+    if (dbuffer != NULL) {
         g_string_free(dbuffer, TRUE);
+    }
 
-        if (replica->child) {
-            if (data->container_command) {
-                crm_create_nvpair_xml(xml_obj, NULL, "run_cmd",
-                                      data->container_command);
-            } else {
-                crm_create_nvpair_xml(xml_obj, NULL, "run_cmd",
-                                      SBIN_DIR "/pacemaker-remoted");
-            }
+    if (replica->child != NULL) {
+        if (data->container_command != NULL) {
+            crm_create_nvpair_xml(xml_obj, NULL, "run_cmd",
+                                  data->container_command);
+        } else {
+            crm_create_nvpair_xml(xml_obj, NULL, "run_cmd",
+                                  SBIN_DIR "/pacemaker-remoted");
+        }
 
-            /* TODO: Allow users to specify their own?
-             *
-             * We just want to know if the container is alive, we'll
-             * monitor the child independently
-             */
-            crm_create_nvpair_xml(xml_obj, NULL, "monitor_cmd", "/bin/true");
+        /* TODO: Allow users to specify their own?
+         *
+         * We just want to know if the container is alive; we'll monitor the
+         * child independently.
+         */
+        crm_create_nvpair_xml(xml_obj, NULL, "monitor_cmd", "/bin/true");
 #if 0
         /* @TODO Consider supporting the use case where we can start and stop
          * resources, but not proxy local commands (such as setting node
@@ -634,38 +389,37 @@ create_rkt_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
          * However, this would probably be better done via ACLs as with other
          * Pacemaker Remote nodes.
          */
-        } else if ((child != NULL) && data->untrusted) {
-            crm_create_nvpair_xml(xml_obj, NULL, "run_cmd",
-                                  CRM_DAEMON_DIR "/pacemaker-execd");
-            crm_create_nvpair_xml(xml_obj, NULL, "monitor_cmd",
-                                  CRM_DAEMON_DIR "/pacemaker/cts-exec-helper -c poke");
+    } else if ((child != NULL) && data->untrusted) {
+        crm_create_nvpair_xml(xml_obj, NULL, "run_cmd",
+                              CRM_DAEMON_DIR "/pacemaker-execd");
+        crm_create_nvpair_xml(xml_obj, NULL, "monitor_cmd",
+                              CRM_DAEMON_DIR "/pacemaker/cts-exec-helper -c poke");
 #endif
-        } else {
-            if (data->container_command) {
-                crm_create_nvpair_xml(xml_obj, NULL, "run_cmd",
-                                      data->container_command);
-            }
-
-            /* TODO: Allow users to specify their own?
-             *
-             * We don't know what's in the container, so we just want
-             * to know if it is alive
-             */
-            crm_create_nvpair_xml(xml_obj, NULL, "monitor_cmd", "/bin/true");
+    } else {
+        if (data->container_command != NULL) {
+            crm_create_nvpair_xml(xml_obj, NULL, "run_cmd",
+                                  data->container_command);
         }
 
+        /* TODO: Allow users to specify their own?
+         *
+         * We don't know what's in the container, so we just want to know if it
+         * is alive.
+         */
+        crm_create_nvpair_xml(xml_obj, NULL, "monitor_cmd", "/bin/true");
+    }
 
-        xml_obj = create_xml_node(xml_container, "operations");
-        crm_create_op_xml(xml_obj, ID(xml_container), "monitor", "60s", NULL);
+    xml_obj = create_xml_node(xml_container, "operations");
+    crm_create_op_xml(xml_obj, ID(xml_container), "monitor", "60s", NULL);
 
-        // TODO: Other ops? Timeouts and intervals from underlying resource?
+    // TODO: Other ops? Timeouts and intervals from underlying resource?
+    if (pe__unpack_resource(xml_container, &replica->container, parent,
+                            parent->cluster) != pcmk_rc_ok) {
+        return pcmk_rc_unpack_error;
+    }
+    parent->children = g_list_append(parent->children, replica->container);
 
-        if (pe__unpack_resource(xml_container, &replica->container, parent,
-                                data_set) != pcmk_rc_ok) {
-            return FALSE;
-        }
-        parent->children = g_list_append(parent->children, replica->container);
-        return TRUE;
+    return pcmk_rc_ok;
 }
 
 /*!
@@ -830,30 +584,12 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
 }
 
 static bool
-create_container(pe_resource_t *parent, pe__bundle_variant_data_t *data,
-                 pe__bundle_replica_t *replica, pe_working_set_t *data_set)
+create_replica_resources(pe_resource_t *parent, pe__bundle_variant_data_t *data,
+                         pe__bundle_replica_t *replica,
+                         pe_working_set_t *data_set)
 {
-
-    switch (data->agent_type) {
-        case PE__CONTAINER_AGENT_DOCKER:
-            if (!create_docker_resource(parent, data, replica, data_set)) {
-                return FALSE;
-            }
-            break;
-
-        case PE__CONTAINER_AGENT_PODMAN:
-            if (!create_podman_resource(parent, data, replica, data_set)) {
-                return FALSE;
-            }
-            break;
-
-        case PE__CONTAINER_AGENT_RKT:
-            if (!create_rkt_resource(parent, data, replica, data_set)) {
-                return FALSE;
-            }
-            break;
-        default: // PE__CONTAINER_AGENT_UNKNOWN
-            return FALSE;
+    if (create_container_resource(parent, data, replica) != pcmk_rc_ok) {
+        return false;
     }
 
     if (create_ip_resource(parent, data, replica, data_set) == FALSE) {
@@ -1298,7 +1034,7 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
          gIter = gIter->next) {
         pe__bundle_replica_t *replica = gIter->data;
 
-        if (!create_container(rsc, bundle_data, replica, data_set)) {
+        if (!create_replica_resources(rsc, bundle_data, replica, data_set)) {
             pe_err("Failed unpacking resource %s", rsc->id);
             rsc->fns->free(rsc);
             return FALSE;
@@ -1433,19 +1169,6 @@ print_rsc_in_list(pe_resource_t *rsc, const char *pre_text, long options,
             status_print("</li>\n");
         }
     }
-}
-
-static const char*
-container_agent_str(enum pe__container_agent t)
-{
-    switch (t) {
-        case PE__CONTAINER_AGENT_DOCKER: return PE__CONTAINER_AGENT_DOCKER_S;
-        case PE__CONTAINER_AGENT_RKT:    return PE__CONTAINER_AGENT_RKT_S;
-        case PE__CONTAINER_AGENT_PODMAN: return PE__CONTAINER_AGENT_PODMAN_S;
-        default: // PE__CONTAINER_AGENT_UNKNOWN
-            break;
-    }
-    return PE__CONTAINER_AGENT_UNKNOWN_S;
 }
 
 /*!

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -1235,10 +1235,12 @@ pe_fence_op(pe_node_t * node, const char *op, bool optional, const char *reason,
                     }
                 }
 
-                g_string_append_printf(digests_all, "%s:%s:%s,", match->id,
-                                       agent, data->digest_all_calc);
-                g_string_append_printf(digests_secure, "%s:%s:%s,", match->id,
-                                       agent, data->digest_secure_calc);
+                pcmk__g_strcat(digests_all,
+                               match->id, ":", agent, ":",
+                               data->digest_all_calc, ",", NULL);
+                pcmk__g_strcat(digests_secure,
+                               match->id, ":", agent, ":",
+                               data->digest_secure_calc, ",", NULL);
             }
             key = strdup(XML_OP_ATTR_DIGESTS_ALL);
             value = strdup((const char *) digests_all->str);

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1198,29 +1198,29 @@ failed_action_friendly(pcmk__output_t *out, xmlNodePtr xml_op,
 
     str = g_string_sized_new(256); // Should be sufficient for most messages
 
-    g_string_printf(str, "%s ", rsc_id);
+    pcmk__g_strcat(str, rsc_id, " ", NULL);
 
     if (interval_ms != 0) {
-        g_string_append_printf(str, "%s-interval ",
-                               pcmk__readable_interval(interval_ms));
+        pcmk__g_strcat(str, pcmk__readable_interval(interval_ms), "-interval ",
+                       NULL);
     }
-    g_string_append_printf(str, "%s on %s",
-                           crm_action_str(task, interval_ms), node_name);
+    pcmk__g_strcat(str, crm_action_str(task, interval_ms), " on ", node_name,
+                   NULL);
 
     if (status == PCMK_EXEC_DONE) {
-        g_string_append_printf(str, " returned '%s'",
-                               services_ocf_exitcode_str(rc));
+        pcmk__g_strcat(str, " returned '", services_ocf_exitcode_str(rc), "'",
+                       NULL);
         if (!pcmk__str_empty(exit_reason)) {
-            g_string_append_printf(str, " (%s)", exit_reason);
+            pcmk__g_strcat(str, " (", exit_reason, ")", NULL);
         }
 
     } else {
-        g_string_append_printf(str, " could not be executed (%s",
-                               pcmk_exec_status_str(status));
+        pcmk__g_strcat(str, " could not be executed (",
+                       pcmk_exec_status_str(status), NULL);
         if (!pcmk__str_empty(exit_reason)) {
-            g_string_append_printf(str, ": %s", exit_reason);
+            pcmk__g_strcat(str, ": ", exit_reason, NULL);
         }
-        g_string_append(str, ")");
+        g_string_append_c(str, ')');
     }
 
 
@@ -1228,7 +1228,7 @@ failed_action_friendly(pcmk__output_t *out, xmlNodePtr xml_op,
                                 &last_change_epoch) == pcmk_ok) {
         last_change_str = pcmk__epoch2str(&last_change_epoch);
         if (last_change_str != NULL) {
-            g_string_append_printf(str, " at %s", last_change_str);
+            pcmk__g_strcat(str, " at ", last_change_str, NULL);
         }
     }
     if (!pcmk__str_empty(exec_time)) {
@@ -1236,8 +1236,9 @@ failed_action_friendly(pcmk__output_t *out, xmlNodePtr xml_op,
 
         if ((pcmk__scan_min_int(exec_time, &exec_time_ms, 0) == pcmk_rc_ok)
             && (exec_time_ms > 0)) {
-            g_string_append_printf(str, " after %s",
-                                   pcmk__readable_interval(exec_time_ms));
+
+            pcmk__g_strcat(str, " after ",
+                           pcmk__readable_interval(exec_time_ms), NULL);
         }
     }
 
@@ -1275,30 +1276,30 @@ failed_action_technical(pcmk__output_t *out, xmlNodePtr xml_op,
         call_id = "unknown";
     }
 
-    str = g_string_sized_new(strlen(op_key) + strlen(node_name)
-                             + strlen(exit_status) + strlen(call_id)
-                             + strlen(lrm_status) + 50); // rough estimate
+    str = g_string_sized_new(256);
 
-    g_string_printf(str, "%s on %s '%s' (%d): call=%s, status='%s'",
-                    op_key, node_name, exit_status, rc, call_id, lrm_status);
+    g_string_append_printf(str, "%s on %s '%s' (%d): call=%s, status='%s'",
+                           op_key, node_name, exit_status, rc, call_id,
+                           lrm_status);
 
     if (!pcmk__str_empty(exit_reason)) {
-        g_string_append_printf(str, ", exitreason='%s'", exit_reason);
+        pcmk__g_strcat(str, ", exitreason='", exit_reason, "'", NULL);
     }
 
     if (crm_element_value_epoch(xml_op, XML_RSC_OP_LAST_CHANGE,
                                 &last_change_epoch) == pcmk_ok) {
         last_change_str = pcmk__epoch2str(&last_change_epoch);
         if (last_change_str != NULL) {
-            g_string_append_printf(str, ", " XML_RSC_OP_LAST_CHANGE "='%s'",
-                                   last_change_str);
+            pcmk__g_strcat(str,
+                           ", " XML_RSC_OP_LAST_CHANGE "="
+                           "'", last_change_str, "'", NULL);
         }
     }
     if (!pcmk__str_empty(queue_time)) {
-        g_string_append_printf(str, ", queued=%sms", queue_time);
+        pcmk__g_strcat(str, ", queued=", queue_time, "ms", NULL);
     }
     if (!pcmk__str_empty(exec_time)) {
-        g_string_append_printf(str, ", exec=%sms", exec_time);
+        pcmk__g_strcat(str, ", exec=", exec_time, "ms", NULL);
     }
 
     out->list_item(out, NULL, "%s", str->str);
@@ -1657,8 +1658,8 @@ node_text(pcmk__output_t *out, va_list args) {
         } else {
             g_string_append(str, "Node");
         }
-        g_string_append_printf(str, " %s: %s",
-                               node_name, node_text_status(node));
+        pcmk__g_strcat(str, " ", node_name, ": ", node_text_status(node), NULL);
+
         if (health < 0) {
             g_string_append(str, " (health is RED)");
         } else if (health == 0) {
@@ -1667,7 +1668,7 @@ node_text(pcmk__output_t *out, va_list args) {
         if (pcmk_is_set(show_opts, pcmk_show_feature_set)) {
             const char *feature_set = get_node_feature_set(node);
             if (feature_set != NULL) {
-                g_string_append_printf(str, ", feature set %s", feature_set);
+                pcmk__g_strcat(str, ", feature set ", feature_set, NULL);
             }
         }
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2593,23 +2593,23 @@ find_lrm_op(const char *resource, const char *op, const char *node, const char *
               return NULL);
 
     xpath = g_string_sized_new(256);
-    g_string_append_printf(xpath,
-                           "//" XML_CIB_TAG_STATE "[@" XML_ATTR_UNAME "='%s']"
-                           "//" XML_LRM_TAG_RESOURCE "[@" XML_ATTR_ID "='%s']"
-                           "/" XML_LRM_TAG_RSC_OP
-                           "[@" XML_LRM_ATTR_TASK "='%s'",
-                           node, resource, op);
+    pcmk__g_strcat(xpath,
+                   "//" XML_CIB_TAG_STATE "[@" XML_ATTR_UNAME "='", node, "']"
+                   "//" XML_LRM_TAG_RESOURCE
+                   "[@" XML_ATTR_ID "='", resource, "']"
+                   "/" XML_LRM_TAG_RSC_OP "[@" XML_LRM_ATTR_TASK "='", op, "'",
+                   NULL);
 
     /* Need to check against transition_magic too? */
     if ((source != NULL) && (strcmp(op, CRMD_ACTION_MIGRATE) == 0)) {
-        g_string_append_printf(xpath,
-                               "and @" XML_LRM_ATTR_MIGRATE_TARGET "='%s']",
-                               source);
+        pcmk__g_strcat(xpath,
+                       " and @" XML_LRM_ATTR_MIGRATE_TARGET "='", source, "']",
+                       NULL);
 
     } else if ((source != NULL) && (strcmp(op, CRMD_ACTION_MIGRATED) == 0)) {
-        g_string_append_printf(xpath,
-                               "and @" XML_LRM_ATTR_MIGRATE_SOURCE "='%s']",
-                               source);
+        pcmk__g_strcat(xpath,
+                       " and @" XML_LRM_ATTR_MIGRATE_SOURCE "='", source, "']",
+                       NULL);
     } else {
         g_string_append_c(xpath, ']');
     }
@@ -2641,10 +2641,12 @@ find_lrm_resource(const char *rsc_id, const char *node_name,
     CRM_CHECK((rsc_id != NULL) && (node_name != NULL), return NULL);
 
     xpath = g_string_sized_new(256);
-    g_string_append_printf(xpath,
-                           "//" XML_CIB_TAG_STATE "[@" XML_ATTR_UNAME "='%s']"
-                           "//" XML_LRM_TAG_RESOURCE "[@" XML_ATTR_ID "='%s']",
-                           node_name, rsc_id);
+    pcmk__g_strcat(xpath,
+                   "//" XML_CIB_TAG_STATE
+                   "[@" XML_ATTR_UNAME "='", node_name, "']"
+                   "//" XML_LRM_TAG_RESOURCE
+                   "[@" XML_ATTR_ID "='", rsc_id, "']",
+                   NULL);
 
     xml = get_xpath_object((const char *) xpath->str, data_set->input,
                            LOG_DEBUG);

--- a/tools/crm_resource_ban.c
+++ b/tools/crm_resource_ban.c
@@ -339,93 +339,86 @@ cli_resource_clear(const char *rsc_id, const char *host, GList *allnodes, cib_t 
     return rc;
 }
 
-static char *
-build_clear_xpath_string(xmlNode *constraint_node, const char *rsc, const char *node, gboolean promoted_role_only)
+static void
+build_clear_xpath_string(GString *buf, const xmlNode *constraint_node,
+                         const char *rsc, const char *node,
+                         bool promoted_role_only)
 {
-    char *xpath_string = NULL;
-    GString *first_half = NULL;
-    char *rsc_role_substr = NULL;
-    char *date_substr = NULL;
+    const char *cons_id = ID(constraint_node);
+    const char *cons_rsc = crm_element_value(constraint_node,
+                                             XML_LOC_ATTR_SOURCE);
+    GString *rsc_role_substr = NULL;
 
-    if (pcmk__starts_with(ID(constraint_node), "cli-ban-")) {
-        date_substr = crm_strdup_printf("//date_expression[@id='%s-lifetime']",
-                                        ID(constraint_node));
+    CRM_ASSERT(buf != NULL);
+    g_string_truncate(buf, 0);
 
-    } else if (pcmk__starts_with(ID(constraint_node), "cli-prefer-")) {
-        date_substr = crm_strdup_printf("//date_expression[@id='cli-prefer-lifetime-end-%s']",
-                                        crm_element_value(constraint_node, "rsc"));
-    } else {
-        return NULL;
+    if (!pcmk__starts_with(cons_id, "cli-ban-")
+        && !pcmk__starts_with(cons_id, "cli-prefer-")) {
+        return;
     }
 
-    first_half = g_string_sized_new(1024);
-    g_string_append(first_half, "//" XML_CONS_TAG_RSC_LOCATION);
+    g_string_append(buf, "//" XML_CONS_TAG_RSC_LOCATION);
 
-    if (node != NULL || rsc != NULL || promoted_role_only == TRUE) {
-        g_string_append_c(first_half, '[');
+    if ((node != NULL) || (rsc != NULL) || promoted_role_only) {
+        g_string_append_c(buf, '[');
 
         if (node != NULL) {
-            pcmk__g_strcat(first_half,
-                           "@" XML_CIB_TAG_NODE "='", node, "'", NULL);
+            pcmk__g_strcat(buf, "@" XML_CIB_TAG_NODE "='", node, "'", NULL);
 
-            if (rsc != NULL || promoted_role_only == TRUE) {
-                g_string_append(first_half, " and ");
+            if (promoted_role_only || (rsc != NULL)) {
+                g_string_append(buf, " and ");
             }
         }
 
-        if (rsc != NULL && promoted_role_only == TRUE) {
-            rsc_role_substr = crm_strdup_printf("@rsc='%s' and @role='%s'",
-                                                rsc, promoted_role_name());
-            pcmk__g_strcat(first_half,
+        if ((rsc != NULL) && promoted_role_only) {
+            rsc_role_substr = g_string_sized_new(64);
+            pcmk__g_strcat(rsc_role_substr,
                            "@" XML_LOC_ATTR_SOURCE "='", rsc, "' "
                            "and @" XML_RULE_ATTR_ROLE "='",
-                           promoted_role_name(), "']", NULL);
+                           promoted_role_name(), "'", NULL);
 
         } else if (rsc != NULL) {
-            rsc_role_substr = crm_strdup_printf("@rsc='%s'", rsc);
-            pcmk__g_strcat(first_half,
-                           "@" XML_LOC_ATTR_SOURCE "='", rsc, "']", NULL);
+            rsc_role_substr = g_string_sized_new(64);
+            pcmk__g_strcat(rsc_role_substr,
+                           "@" XML_LOC_ATTR_SOURCE "='", rsc, "'", NULL);
 
-        } else if (promoted_role_only == TRUE) {
-            rsc_role_substr = crm_strdup_printf("@role='%s'",
-                                                promoted_role_name());
-            pcmk__g_strcat(first_half,
+        } else if (promoted_role_only) {
+            rsc_role_substr = g_string_sized_new(64);
+            pcmk__g_strcat(rsc_role_substr,
                            "@" XML_RULE_ATTR_ROLE "='", promoted_role_name(),
-                           "']", NULL);
-
-        } else {
-            g_string_append_c(first_half, ']');
+                           "'", NULL);
         }
+
+        if (rsc_role_substr != NULL) {
+            g_string_append(buf, rsc_role_substr->str);
+        }
+        g_string_append_c(buf, ']');
     }
-
-#define XPATH_FMT_START "%s|//" XML_CONS_TAG_RSC_LOCATION
-
-#define XPATH_FMT_END   "/" XML_TAG_RULE "[" XML_TAG_EXPRESSION \
-                        "[@" XML_EXPR_ATTR_ATTRIBUTE "='" CRM_ATTR_UNAME \
-                        "' and @" XML_EXPR_ATTR_VALUE "='%s']]%s"
 
     if (node != NULL) {
+        g_string_append(buf, "|//" XML_CONS_TAG_RSC_LOCATION);
+
         if (rsc_role_substr != NULL) {
-            xpath_string = crm_strdup_printf(XPATH_FMT_START "[%s]"
-                                             XPATH_FMT_END,
-                                             (const char *) first_half->str,
-                                             rsc_role_substr, node,
-                                             date_substr);
-        } else {
-            xpath_string = crm_strdup_printf(XPATH_FMT_START XPATH_FMT_END,
-                                             (const char *) first_half->str,
-                                             node, date_substr);
+            pcmk__g_strcat(buf, "[", rsc_role_substr, "]", NULL);
         }
-    } else {
-        xpath_string = crm_strdup_printf("%s%s", (const char *) first_half->str,
-                                         date_substr);
+        pcmk__g_strcat(buf,
+                       "/" XML_TAG_RULE "[" XML_TAG_EXPRESSION
+                       "[@" XML_EXPR_ATTR_ATTRIBUTE "='" CRM_ATTR_UNAME "' "
+                       "and @" XML_EXPR_ATTR_VALUE "='", node, "']]", NULL);
     }
 
-    g_string_free(first_half, TRUE);
-    free(date_substr);
-    free(rsc_role_substr);
+    g_string_append(buf, "//" PCMK_XE_DATE_EXPRESSION "[@" XML_ATTR_ID "='");
+    if (pcmk__starts_with(cons_id, "cli-ban-")) {
+        pcmk__g_strcat(buf, cons_id, "-lifetime']", NULL);
 
-    return xpath_string;
+    } else {    // starts with "cli-prefer-"
+        pcmk__g_strcat(buf,
+                       "cli-prefer-lifetime-end-", cons_rsc, "']", NULL);
+    }
+
+    if (rsc_role_substr != NULL) {
+        g_string_free(rsc_role_substr, TRUE);
+    }
 }
 
 // \return Standard Pacemaker return code
@@ -433,6 +426,7 @@ int
 cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, int cib_options,
                                const char *rsc, const char *node, gboolean promoted_role_only)
 {
+    GString *buf = NULL;
     xmlXPathObject *xpathObj = NULL;
     xmlNode *cib_constraints = NULL;
     crm_time_t *now = crm_time_new(NULL);
@@ -446,16 +440,20 @@ cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, int cib_options,
         xmlNode *constraint_node = getXpathResult(xpathObj, i);
         xmlNode *date_expr_node = NULL;
         crm_time_t *end = NULL;
-        char *xpath_string = NULL;
 
-        xpath_string = build_clear_xpath_string(constraint_node, rsc, node, promoted_role_only);
-        if (xpath_string == NULL) {
+        if (buf == NULL) {
+            buf = g_string_sized_new(1024);
+        }
+
+        build_clear_xpath_string(buf, constraint_node, rsc, node,
+                                 promoted_role_only);
+        if (buf->len == 0) {
             continue;
         }
 
-        date_expr_node = get_xpath_object(xpath_string, constraint_node, LOG_DEBUG);
+        date_expr_node = get_xpath_object((const char *) buf->str,
+                                          constraint_node, LOG_DEBUG);
         if (date_expr_node == NULL) {
-            free(xpath_string);
             continue;
         }
 
@@ -478,7 +476,6 @@ cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, int cib_options,
             rc = pcmk_legacy2rc(rc);
 
             if (rc != pcmk_rc_ok) {
-                free(xpath_string);
                 goto done;
             }
 
@@ -486,10 +483,12 @@ cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, int cib_options,
         }
 
         crm_time_free(end);
-        free(xpath_string);
     }
 
 done:
+    if (buf != NULL) {
+        g_string_free(buf, TRUE);
+    }
     freeXpathObject(xpathObj);
     crm_time_free(now);
     return rc;


### PR DESCRIPTION
This hits most of the remaining places where it's reasonable to move from `snprintf()` to GStrings and the like.

The "Reduce duplication in container resource create" commit is definitely the hardest to review even though it doesn't do that much, just because of the way the diff is generated. The idea is that the three existing `create_X_resource()` functions for docker, podman, and rkt are almost identical. Likewise, the new function is almost identical to all of these, with `switch` and `if` statements where needed.