### PR TITLE
Best practices for primitive-related methods in libpacemaker

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -657,4 +657,20 @@ pe__node_name(const pe_node_t *node)
         return "unidentified node";
     }
 }
+
+/*!
+ * \internal
+ * \brief Check whether two node objects refer to the same node
+ *
+ * \param[in] node1  First node object to compare
+ * \param[in] node2  Second node object to compare
+ *
+ * \return true if \p node1 and \p node2 refer to the same node
+ */
+static inline bool
+pe__same_node(const pe_node_t *node1, const pe_node_t *node2)
+{
+    return (node1 != NULL) && (node2 != NULL)
+           && (node1->details == node2->details);
+}
 #endif

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -19,11 +19,6 @@
 #  include <crm/common/xml.h>
 #  include <pcmki/pcmki_scheduler.h>
 
-void pcmk__primitive_add_utilization(pe_resource_t *rsc,
-                                     pe_resource_t *orig_rsc, GList *all_rscs,
-                                     GHashTable *utilization);
-void pcmk__primitive_shutdown_lock(pe_resource_t *rsc);
-
 pe_node_t *pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer);
 void group_create_actions(pe_resource_t *rsc);
 void group_internal_constraints(pe_resource_t *rsc);
@@ -60,8 +55,6 @@ extern void clone_append_meta(pe_resource_t * rsc, xmlNode * xml);
 void pcmk__clone_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                  GList *all_rscs, GHashTable *utilization);
 void pcmk__clone_shutdown_lock(pe_resource_t *rsc);
-
-void pcmk__add_promotion_scores(pe_resource_t *rsc);
 
 uint32_t group_update_actions(pe_action_t *first, pe_action_t *then,
                               pe_node_t *node, uint32_t flags, uint32_t filter,

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -19,7 +19,6 @@
 #  include <crm/common/xml.h>
 #  include <pcmki/pcmki_scheduler.h>
 
-extern void native_append_meta(pe_resource_t * rsc, xmlNode * xml);
 void pcmk__primitive_add_utilization(pe_resource_t *rsc,
                                      pe_resource_t *orig_rsc, GList *all_rscs,
                                      GHashTable *utilization);

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -532,6 +532,9 @@ void pcmk__unpack_rsc_ticket(xmlNode *xml_obj, pe_working_set_t *data_set);
 // Promotable clone resources (pcmk_sched_promotable.c)
 
 G_GNUC_INTERNAL
+void pcmk__add_promotion_scores(pe_resource_t *rsc);
+
+G_GNUC_INTERNAL
 void pcmk__require_promotion_tickets(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
@@ -605,6 +608,14 @@ void pcmk__schedule_cleanup(pe_resource_t *rsc, const pe_node_t *node,
 
 G_GNUC_INTERNAL
 void pcmk__primitive_add_graph_meta(pe_resource_t *rsc, xmlNode *xml);
+
+G_GNUC_INTERNAL
+void pcmk__primitive_add_utilization(pe_resource_t *rsc,
+                                     pe_resource_t *orig_rsc, GList *all_rscs,
+                                     GHashTable *utilization);
+
+G_GNUC_INTERNAL
+void pcmk__primitive_shutdown_lock(pe_resource_t *rsc);
 
 
 // Groups (pcmk_sched_group.c)

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -589,6 +589,11 @@ void pcmk__primitive_apply_coloc_score(pe_resource_t *dependent,
                                        pcmk__colocation_t *colocation,
                                        bool for_dependent);
 
+G_GNUC_INTERNAL
+void pcmk__schedule_cleanup(pe_resource_t *rsc, const pe_node_t *node,
+                            bool optional);
+
+
 // Groups (pcmk_sched_group.c)
 
 G_GNUC_INTERNAL

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -212,7 +212,17 @@ struct resource_alloc_functions_s {
      */
     void (*add_actions_to_graph)(pe_resource_t *rsc);
 
-    void (*append_meta) (pe_resource_t * rsc, xmlNode * xml);
+    /*!
+     * \internal
+     * \brief Add meta-attributes relevant to transition graph actions to XML
+     *
+     * If a given resource supports variant-specific meta-attributes that are
+     * needed for transition graph actions, add them to a given XML element.
+     *
+     * \param[in]     rsc  Resource whose meta-attributes should be added
+     * \param[in,out] xml  Transition graph action attributes XML to add to
+     */
+    void (*add_graph_meta)(pe_resource_t *rsc, xmlNode *xml);
 
     /*!
      * \internal

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -603,6 +603,9 @@ G_GNUC_INTERNAL
 void pcmk__schedule_cleanup(pe_resource_t *rsc, const pe_node_t *node,
                             bool optional);
 
+G_GNUC_INTERNAL
+void pcmk__primitive_add_graph_meta(pe_resource_t *rsc, xmlNode *xml);
+
 
 // Groups (pcmk_sched_group.c)
 

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -380,18 +380,11 @@ add_action_attributes(pe_action_t *action, xmlNode *action_xml)
 
     g_hash_table_foreach(action->meta, hash2metafield, args_xml);
     if (action->rsc != NULL) {
-        const char *value = g_hash_table_lookup(action->rsc->meta,
-                                                "external-ip");
         pe_resource_t *parent = action->rsc;
 
         while (parent != NULL) {
             parent->cmds->add_graph_meta(parent, args_xml);
             parent = parent->parent;
-        }
-
-        if (value != NULL) {
-            hash2smartfield((gpointer) "pcmk_external_ip", (gpointer) value,
-                            (gpointer) args_xml);
         }
 
         pcmk__add_bundle_meta_to_xml(args_xml, action);

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -385,7 +385,7 @@ add_action_attributes(pe_action_t *action, xmlNode *action_xml)
         pe_resource_t *parent = action->rsc;
 
         while (parent != NULL) {
-            parent->cmds->append_meta(parent, args_xml);
+            parent->cmds->add_graph_meta(parent, args_xml);
             parent = parent->parent;
         }
 

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -17,9 +17,6 @@
 #include <pacemaker-internal.h>
 #include "libpacemaker_private.h"
 
-extern gboolean DeleteRsc(pe_resource_t *rsc, pe_node_t *node,
-                          gboolean optional, pe_working_set_t *data_set);
-
 /*!
  * \internal
  * \brief Get the action flags relevant to ordering constraints
@@ -1764,14 +1761,14 @@ process_rsc_history(xmlNode *rsc_entry, pe_resource_t *rsc, pe_node_t *node)
             pe_rsc_trace(rsc,
                          "Skipping configuration check and scheduling clean-up "
                          "for orphaned resource %s", rsc->id);
-            DeleteRsc(rsc, node, FALSE, rsc->cluster);
+            pcmk__schedule_cleanup(rsc, node, false);
         }
         return;
     }
 
     if (pe_find_node_id(rsc->running_on, node->details->id) == NULL) {
         if (pcmk__rsc_agent_changed(rsc, node, rsc_entry, false)) {
-            DeleteRsc(rsc, node, FALSE, rsc->cluster);
+            pcmk__schedule_cleanup(rsc, node, false);
         }
         pe_rsc_trace(rsc,
                      "Skipping configuration check for %s "
@@ -1784,7 +1781,7 @@ process_rsc_history(xmlNode *rsc_entry, pe_resource_t *rsc, pe_node_t *node)
                  rsc->id, pe__node_name(node));
 
     if (pcmk__rsc_agent_changed(rsc, node, rsc_entry, true)) {
-        DeleteRsc(rsc, node, FALSE, rsc->cluster);
+        pcmk__schedule_cleanup(rsc, node, false);
     }
 
     sorted_op_list = rsc_history_as_list(rsc, rsc_entry, &start_index,

--- a/lib/pacemaker/pcmk_sched_migration.c
+++ b/lib/pacemaker/pcmk_sched_migration.c
@@ -16,9 +16,6 @@
 
 #include "libpacemaker_private.h"
 
-extern gboolean DeleteRsc(pe_resource_t *rsc, const pe_node_t *node,
-                          gboolean optional, pe_working_set_t *data_set);
-
 /*!
  * \internal
  * \brief Add migration source and target meta-attributes to an action
@@ -160,7 +157,7 @@ pcmk__abort_dangling_migration(void *data, void *user_data)
     stop = stop_action(rsc, dangling_source, FALSE);
     pe__set_action_flags(stop, pe_action_dangle);
     if (cleanup) {
-        DeleteRsc(rsc, dangling_source, FALSE, rsc->cluster);
+        pcmk__schedule_cleanup(rsc, dangling_source, false);
     }
 }
 

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -1421,6 +1421,15 @@ pcmk__primitive_add_graph_meta(pe_resource_t *rsc, xmlNode *xml)
                         parent->container->id);
         }
     }
+
+    /* Bundle replica children will get their external-ip set internally as a
+     * meta-attribute. The graph action needs it, but under a different naming
+     * convention than other meta-attributes.
+     */
+    value = g_hash_table_lookup(rsc->meta, "external-ip");
+    if (value != NULL) {
+        crm_xml_add(xml, "pcmk_external_ip", value);
+    }
 }
 
 // Primitive implementation of resource_alloc_functions_t:add_utilization()

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -20,7 +20,7 @@ gboolean DeleteRsc(pe_resource_t *rsc, const pe_node_t *node, gboolean optional,
                    pe_working_set_t *data_set);
 static void stop_resource(pe_resource_t *rsc, pe_node_t *node, bool optional);
 static void start_resource(pe_resource_t *rsc, pe_node_t *node, bool optional);
-static void DemoteRsc(pe_resource_t *rsc, pe_node_t *next, bool optional);
+static void demote_resource(pe_resource_t *rsc, pe_node_t *node, bool optional);
 static void promote_resource(pe_resource_t *rsc, pe_node_t *node,
                              bool optional);
 static void RoleError(pe_resource_t *rsc, pe_node_t *next, bool optional);
@@ -110,9 +110,9 @@ static rsc_transition_fn rsc_action_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX] = {
                             promote_resource,               /* Promoted */
                         },
     /* Promoted  */     {   RoleError,                      /* Unknown */
-                            DemoteRsc,                      /* Stopped */
-                            DemoteRsc,                      /* Started */
-                            DemoteRsc,                      /* Unpromoted */
+                            demote_resource,                /* Stopped */
+                            demote_resource,                /* Started */
+                            demote_resource,                /* Unpromoted */
                             NULL,                           /* Promoted */
                         },
 };
@@ -1298,27 +1298,38 @@ promote_resource(pe_resource_t *rsc, pe_node_t *node, bool optional)
     }
 }
 
+/*!
+ * \internal
+ * \brief Schedule actions needed to demote a resource wherever it is active
+ *
+ * \param[in,out] rsc       Resource being demoted
+ * \param[in]     node      Node where resource should be demoted
+ * \param[in]     optional  Whether actions should be optional
+ */
 static void
-DemoteRsc(pe_resource_t *rsc, pe_node_t *next, bool optional)
+demote_resource(pe_resource_t *rsc, pe_node_t *node, bool optional)
 {
-    GList *gIter = NULL;
+    CRM_ASSERT(node != NULL);
 
-    CRM_ASSERT(rsc);
-
-    if (is_expected_node(rsc, next)) {
+    if (is_expected_node(rsc, node)) {
         pe_rsc_trace(rsc,
                      "Skipping demote of multiply active resource %s "
                      "on expected node %s",
-                     rsc->id, pe__node_name(next));
+                     rsc->id, pe__node_name(node));
         return;
     }
 
-    pe_rsc_trace(rsc, "%s", rsc->id);
+    /* Since this will only be called for a primitive (possibly as an instance
+     * of a collective resource), the resource is multiply active if it is
+     * running on more than one node, so we want to demote on all of them as
+     * part of recovery, regardless of which one is the desired node.
+     */
+    for (GList *iter = rsc->running_on; iter != NULL; iter = iter->next) {
+        pe_node_t *current = (pe_node_t *) iter->data;
 
-    for (gIter = rsc->running_on; gIter != NULL; gIter = gIter->next) {
-        pe_node_t *current = (pe_node_t *) gIter->data;
-
-        pe_rsc_trace(rsc, "%s on %s", rsc->id, pe__node_name(next));
+        pe_rsc_trace(rsc, "Scheduling %s demotion of %s on %s",
+                     (optional? "optional" : "required"), rsc->id,
+                     pe__node_name(current));
         demote_action(rsc, current, optional);
     }
 }

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -23,7 +23,8 @@ static void start_resource(pe_resource_t *rsc, pe_node_t *node, bool optional);
 static void demote_resource(pe_resource_t *rsc, pe_node_t *node, bool optional);
 static void promote_resource(pe_resource_t *rsc, pe_node_t *node,
                              bool optional);
-static void RoleError(pe_resource_t *rsc, pe_node_t *next, bool optional);
+static void assert_role_error(pe_resource_t *rsc, pe_node_t *node,
+                              bool optional);
 
 static enum rsc_role_e rsc_state_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX] = {
     /* This array lists the immediate next role when transitioning from one role
@@ -85,31 +86,31 @@ static rsc_transition_fn rsc_action_matrix[RSC_ROLE_MAX][RSC_ROLE_MAX] = {
      * Current role         Transition function             Next role
      * ------------         -------------------             ----------
      */
-    /* Unknown */       {   RoleError,                      /* Unknown */
+    /* Unknown */       {   assert_role_error,              /* Unknown */
                             stop_resource,                  /* Stopped */
-                            RoleError,                      /* Started */
-                            RoleError,                      /* Unpromoted */
-                            RoleError,                      /* Promoted */
+                            assert_role_error,              /* Started */
+                            assert_role_error,              /* Unpromoted */
+                            assert_role_error,              /* Promoted */
                         },
-    /* Stopped */       {   RoleError,                      /* Unknown */
+    /* Stopped */       {   assert_role_error,              /* Unknown */
                             NULL,                           /* Stopped */
                             start_resource,                 /* Started */
                             start_resource,                 /* Unpromoted */
-                            RoleError,                      /* Promoted */
+                            assert_role_error,              /* Promoted */
                         },
-    /* Started */       {   RoleError,                      /* Unknown */
+    /* Started */       {   assert_role_error,              /* Unknown */
                             stop_resource,                  /* Stopped */
                             NULL,                           /* Started */
                             NULL,                           /* Unpromoted */
                             promote_resource,               /* Promoted */
                         },
-    /* Unpromoted */    {   RoleError,                      /* Unknown */
+    /* Unpromoted */    {   assert_role_error,              /* Unknown */
                             stop_resource,                  /* Stopped */
                             stop_resource,                  /* Started */
                             NULL,                           /* Unpromoted */
                             promote_resource,               /* Promoted */
                         },
-    /* Promoted  */     {   RoleError,                      /* Unknown */
+    /* Promoted  */     {   assert_role_error,              /* Unknown */
                             demote_resource,                /* Stopped */
                             demote_resource,                /* Started */
                             demote_resource,                /* Unpromoted */
@@ -1332,7 +1333,7 @@ demote_resource(pe_resource_t *rsc, pe_node_t *node, bool optional)
 }
 
 static void
-RoleError(pe_resource_t *rsc, pe_node_t *next, bool optional)
+assert_role_error(pe_resource_t *rsc, pe_node_t *node, bool optional)
 {
     CRM_ASSERT(false);
 }

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -31,7 +31,7 @@ static resource_alloc_functions_t allocation_methods[] = {
         pcmk__update_ordered_actions,
         pcmk__output_resource_actions,
         pcmk__add_rsc_actions_to_graph,
-        native_append_meta,
+        pcmk__primitive_add_graph_meta,
         pcmk__primitive_add_utilization,
         pcmk__primitive_shutdown_lock,
     },


### PR DESCRIPTION
This continues the project to bring libpacemaker up to current development guidelines, focusing on the remaining primitive methods.