### PR TITLE
Test: cts-cli: Allow daemon tests to run from installed packages

### DIFF
--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -2437,6 +2437,7 @@ if [ -x "$SRCDIR/tools/crm_simulate" ]; then
         echo "Using local schemas from: $PCMK_schema_directory"
     fi
 else
+    export PATH="@CRM_DAEMON_DIR@:$PATH"
     export PCMK_schema_directory=@CRM_SCHEMA_DIRECTORY@
 fi
 


### PR DESCRIPTION
Currently it runs only from a source directory since `CRM_DAEMON_DIR` isn't typically in the `PATH`.

Follow-up to fc22d59b.