### PR TITLE
Best practices for remaining primitive-related functions in libpacemaker

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -490,7 +490,7 @@ pe_base_name_eq(pe_resource_t *rsc, const char *id)
 int pe__target_rc_from_xml(xmlNode *xml_op);
 
 gint pe__cmp_node_name(gconstpointer a, gconstpointer b);
-bool is_set_recursive(pe_resource_t * rsc, long long flag, bool any);
+bool is_set_recursive(const pe_resource_t *rsc, long long flag, bool any);
 
 enum rsc_digest_cmp_val {
     /*! Digests are the same */

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -563,7 +563,7 @@ const char *pe__add_bundle_remote_name(pe_resource_t *rsc,
 const char *pe_node_attribute_calculated(const pe_node_t *node,
                                          const char *name,
                                          const pe_resource_t *rsc);
-const char *pe_node_attribute_raw(pe_node_t *node, const char *name);
+const char *pe_node_attribute_raw(const pe_node_t *node, const char *name);
 bool pe__is_universal_clone(pe_resource_t *rsc,
                             pe_working_set_t *data_set);
 void pe__add_param_check(xmlNode *rsc_op, pe_resource_t *rsc, pe_node_t *node,

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -290,7 +290,7 @@ void pe__order_notifs_after_fencing(pe_action_t *action, pe_resource_t *rsc,
 
 
 static inline const char *
-pe__rsc_bool_str(pe_resource_t *rsc, uint64_t rsc_flag)
+pe__rsc_bool_str(const pe_resource_t *rsc, uint64_t rsc_flag)
 {
     return pcmk__btoa(pcmk_is_set(rsc->flags, rsc_flag));
 }

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -26,7 +26,8 @@ enum pe_action_flags group_action_flags(pe_action_t *action,
                                         const pe_node_t *node);
 void group_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);
 extern void group_append_meta(pe_resource_t * rsc, xmlNode * xml);
-void pcmk__group_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
+void pcmk__group_add_utilization(const pe_resource_t *rsc,
+                                 const pe_resource_t *orig_rsc,
                                  GList *all_rscs, GHashTable *utilization);
 void pcmk__group_shutdown_lock(pe_resource_t *rsc);
 
@@ -39,7 +40,8 @@ enum pe_action_flags pcmk__bundle_action_flags(pe_action_t *action,
                                                const pe_node_t *node);
 void pcmk__bundle_expand(pe_resource_t *rsc);
 void pcmk__bundle_append_meta(pe_resource_t *rsc, xmlNode *xml);
-void pcmk__bundle_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
+void pcmk__bundle_add_utilization(const pe_resource_t *rsc,
+                                  const pe_resource_t *orig_rsc,
                                   GList *all_rscs, GHashTable *utilization);
 void pcmk__bundle_shutdown_lock(pe_resource_t *rsc);
 
@@ -52,7 +54,8 @@ enum pe_action_flags clone_action_flags(pe_action_t *action,
 void clone_expand(pe_resource_t *rsc);
 bool clone_create_probe(pe_resource_t *rsc, pe_node_t *node);
 extern void clone_append_meta(pe_resource_t * rsc, xmlNode * xml);
-void pcmk__clone_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
+void pcmk__clone_add_utilization(const pe_resource_t *rsc,
+                                 const pe_resource_t *orig_rsc,
                                  GList *all_rscs, GHashTable *utilization);
 void pcmk__clone_shutdown_lock(pe_resource_t *rsc);
 

--- a/include/pcmki/pcmki_sched_allocate.h
+++ b/include/pcmki/pcmki_sched_allocate.h
@@ -19,7 +19,7 @@
 #  include <crm/common/xml.h>
 #  include <pcmki/pcmki_scheduler.h>
 
-pe_node_t *pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer);
+pe_node_t *pcmk__group_allocate(pe_resource_t *rsc, const pe_node_t *prefer);
 void group_create_actions(pe_resource_t *rsc);
 void group_internal_constraints(pe_resource_t *rsc);
 enum pe_action_flags group_action_flags(pe_action_t *action,
@@ -30,7 +30,7 @@ void pcmk__group_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                  GList *all_rscs, GHashTable *utilization);
 void pcmk__group_shutdown_lock(pe_resource_t *rsc);
 
-pe_node_t *pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *prefer);
+pe_node_t *pcmk__bundle_allocate(pe_resource_t *rsc, const pe_node_t *prefer);
 void pcmk__bundle_create_actions(pe_resource_t *rsc);
 bool pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node);
 void pcmk__bundle_internal_constraints(pe_resource_t *rsc);
@@ -43,7 +43,7 @@ void pcmk__bundle_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
                                   GList *all_rscs, GHashTable *utilization);
 void pcmk__bundle_shutdown_lock(pe_resource_t *rsc);
 
-pe_node_t *pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *prefer);
+pe_node_t *pcmk__clone_allocate(pe_resource_t *rsc, const pe_node_t *prefer);
 void clone_create_actions(pe_resource_t *rsc);
 void clone_internal_constraints(pe_resource_t *rsc);
 void clone_rsc_location(pe_resource_t *rsc, pe__location_t *constraint);

--- a/include/pcmki/pcmki_sched_utils.h
+++ b/include/pcmki/pcmki_sched_utils.h
@@ -27,8 +27,11 @@ GList *pcmk__copy_node_list(const GList *list, bool reset);
 pe_resource_t *find_compatible_child(pe_resource_t *local_child,
                                      pe_resource_t *rsc, enum rsc_role_e filter,
                                      gboolean current);
-pe_resource_t *find_compatible_child_by_node(pe_resource_t * local_child, pe_node_t * local_node, pe_resource_t * rsc,
-                                             enum rsc_role_e filter, gboolean current);
+pe_resource_t *find_compatible_child_by_node(const pe_resource_t *local_child,
+                                             const pe_node_t *local_node,
+                                             const pe_resource_t *rsc,
+                                             enum rsc_role_e filter,
+                                             gboolean current);
 gboolean is_child_compatible(const pe_resource_t *child_rsc,
                              const pe_node_t *local_node,
                              enum rsc_role_e filter, gboolean current);

--- a/include/pcmki/pcmki_sched_utils.h
+++ b/include/pcmki/pcmki_sched_utils.h
@@ -29,7 +29,9 @@ pe_resource_t *find_compatible_child(pe_resource_t *local_child,
                                      gboolean current);
 pe_resource_t *find_compatible_child_by_node(pe_resource_t * local_child, pe_node_t * local_node, pe_resource_t * rsc,
                                              enum rsc_role_e filter, gboolean current);
-gboolean is_child_compatible(pe_resource_t *child_rsc, pe_node_t * local_node, enum rsc_role_e filter, gboolean current);
+gboolean is_child_compatible(const pe_resource_t *child_rsc,
+                             const pe_node_t *local_node,
+                             enum rsc_role_e filter, gboolean current);
 enum pe_action_flags summary_action_flags(pe_action_t *action, GList *children,
                                           const pe_node_t *node);
 enum action_tasks clone_child_action(pe_action_t * action);

--- a/include/pcmki/pcmki_sched_utils.h
+++ b/include/pcmki/pcmki_sched_utils.h
@@ -24,9 +24,9 @@
 /* Constraint helper functions */
 GList *pcmk__copy_node_list(const GList *list, bool reset);
 
-pe_resource_t *find_compatible_child(pe_resource_t *local_child,
-                                     pe_resource_t *rsc, enum rsc_role_e filter,
-                                     gboolean current);
+pe_resource_t *find_compatible_child(const pe_resource_t *local_child,
+                                     const pe_resource_t *rsc,
+                                     enum rsc_role_e filter, gboolean current);
 pe_resource_t *find_compatible_child_by_node(const pe_resource_t *local_child,
                                              const pe_node_t *local_node,
                                              const pe_resource_t *rsc,

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -338,6 +338,9 @@ void pcmk__fence_guest(pe_node_t *node);
 G_GNUC_INTERNAL
 bool pcmk__node_unfenced(pe_node_t *node);
 
+G_GNUC_INTERNAL
+void pcmk__order_restart_vs_unfence(gpointer data, gpointer user_data);
+
 
 // Injected scheduler inputs (pcmk_sched_injections.c)
 

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -100,13 +100,14 @@ struct resource_alloc_functions_s {
      * allowed node weights (if we are still placing resources) or priority (if
      * we are choosing promotable clone instance roles).
      *
-     * \param[in] dependent      Dependent resource in colocation
-     * \param[in] primary        Primary resource in colocation
-     * \param[in] colocation     Colocation constraint to apply
-     * \param[in] for_dependent  true if called on behalf of dependent
+     * \param[in,out] dependent      Dependent resource in colocation
+     * \param[in]     primary        Primary resource in colocation
+     * \param[in]     colocation     Colocation constraint to apply
+     * \param[in]     for_dependent  true if called on behalf of dependent
      */
-    void (*apply_coloc_score) (pe_resource_t *dependent, pe_resource_t *primary,
-                               pcmk__colocation_t *colocation,
+    void (*apply_coloc_score) (pe_resource_t *dependent,
+                               const pe_resource_t *primary,
+                               const pcmk__colocation_t *colocation,
                                bool for_dependent);
 
     /*!
@@ -598,8 +599,8 @@ enum pe_action_flags pcmk__primitive_action_flags(pe_action_t *action,
 
 G_GNUC_INTERNAL
 void pcmk__primitive_apply_coloc_score(pe_resource_t *dependent,
-                                       pe_resource_t *primary,
-                                       pcmk__colocation_t *colocation,
+                                       const pe_resource_t *primary,
+                                       const pcmk__colocation_t *colocation,
                                        bool for_dependent);
 
 G_GNUC_INTERNAL
@@ -622,8 +623,8 @@ void pcmk__primitive_shutdown_lock(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
 void pcmk__group_apply_coloc_score(pe_resource_t *dependent,
-                                   pe_resource_t *primary,
-                                   pcmk__colocation_t *colocation,
+                                   const pe_resource_t *primary,
+                                   const pcmk__colocation_t *colocation,
                                    bool for_dependent);
 
 G_GNUC_INTERNAL
@@ -641,16 +642,16 @@ GList *pcmk__group_colocated_resources(pe_resource_t *rsc,
 
 G_GNUC_INTERNAL
 void pcmk__clone_apply_coloc_score(pe_resource_t *dependent,
-                                   pe_resource_t *primary,
-                                   pcmk__colocation_t *colocation,
+                                   const pe_resource_t *primary,
+                                   const pcmk__colocation_t *colocation,
                                    bool for_dependent);
 
 // Bundles (pcmk_sched_bundle.c)
 
 G_GNUC_INTERNAL
 void pcmk__bundle_apply_coloc_score(pe_resource_t *dependent,
-                                    pe_resource_t *primary,
-                                    pcmk__colocation_t *colocation,
+                                    const pe_resource_t *primary,
+                                    const pcmk__colocation_t *colocation,
                                     bool for_dependent);
 
 G_GNUC_INTERNAL

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -792,7 +792,7 @@ void pcmk__release_node_capacity(GHashTable *current_utilization,
                                  pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__ban_insufficient_capacity(pe_resource_t *rsc, pe_node_t **prefer);
+const pe_node_t *pcmk__ban_insufficient_capacity(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
 void pcmk__create_utilization_constraints(pe_resource_t *rsc,

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -391,20 +391,20 @@ enum pcmk__coloc_affects {
 };
 
 G_GNUC_INTERNAL
-enum pcmk__coloc_affects pcmk__colocation_affects(pe_resource_t *dependent,
-                                                  pe_resource_t *primary,
-                                                  pcmk__colocation_t *constraint,
+enum pcmk__coloc_affects pcmk__colocation_affects(const pe_resource_t *dependent,
+                                                  const pe_resource_t *primary,
+                                                  const pcmk__colocation_t *colocation,
                                                   bool preview);
 
 G_GNUC_INTERNAL
 void pcmk__apply_coloc_to_weights(pe_resource_t *dependent,
-                                  pe_resource_t *primary,
-                                  pcmk__colocation_t *constraint);
+                                  const pe_resource_t *primary,
+                                  const pcmk__colocation_t *colocation);
 
 G_GNUC_INTERNAL
 void pcmk__apply_coloc_to_priority(pe_resource_t *dependent,
-                                   pe_resource_t *primary,
-                                   pcmk__colocation_t *constraint);
+                                   const pe_resource_t *primary,
+                                   const pcmk__colocation_t *colocation);
 
 G_GNUC_INTERNAL
 void pcmk__add_colocated_node_scores(pe_resource_t *rsc, const char *log_id,

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -58,12 +58,12 @@ struct resource_alloc_functions_s {
      * \internal
      * \brief Assign a resource to a node
      *
-     * \param[in] rsc     Resource to assign to a node
-     * \param[in] prefer  Node to prefer, if all else is equal
+     * \param[in,out] rsc     Resource to assign to a node
+     * \param[in]     prefer  Node to prefer, if all else is equal
      *
      * \return Node that \p rsc is assigned to, if assigned entirely to one node
      */
-    pe_node_t *(*assign)(pe_resource_t *rsc, pe_node_t *prefer);
+    pe_node_t *(*assign)(pe_resource_t *rsc, const pe_node_t *prefer);
 
     /*!
      * \internal
@@ -584,7 +584,7 @@ void pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, pe_action_t *action);
 // Primitives (pcmk_sched_primitive.c)
 
 G_GNUC_INTERNAL
-pe_node_t *pcmk__primitive_assign(pe_resource_t *rsc, pe_node_t *prefer);
+pe_node_t *pcmk__primitive_assign(pe_resource_t *rsc, const pe_node_t *prefer);
 
 G_GNUC_INTERNAL
 void pcmk__primitive_create_actions(pe_resource_t *rsc);

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -550,14 +550,14 @@ G_GNUC_INTERNAL
 void pcmk__order_promotable_instances(pe_resource_t *clone);
 
 G_GNUC_INTERNAL
-void pcmk__update_dependent_with_promotable(pe_resource_t *primary,
+void pcmk__update_dependent_with_promotable(const pe_resource_t *primary,
                                             pe_resource_t *dependent,
-                                            pcmk__colocation_t *colocation);
+                                            const pcmk__colocation_t *colocation);
 
 G_GNUC_INTERNAL
-void pcmk__update_promotable_dependent_priority(pe_resource_t *primary,
+void pcmk__update_promotable_dependent_priority(const pe_resource_t *primary,
                                                 pe_resource_t *dependent,
-                                                pcmk__colocation_t *colocation);
+                                                const pcmk__colocation_t *colocation);
 
 
 // Pacemaker Remote nodes (pcmk_sched_remote.c)

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -790,7 +790,7 @@ void pcmk__consume_node_capacity(GHashTable *current_utilization,
 
 G_GNUC_INTERNAL
 void pcmk__release_node_capacity(GHashTable *current_utilization,
-                                 pe_resource_t *rsc);
+                                 const pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
 const pe_node_t *pcmk__ban_insufficient_capacity(pe_resource_t *rsc);

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -235,13 +235,14 @@ struct resource_alloc_functions_s {
      * the resource's utilization to the existing values, if the resource has
      * not yet been allocated to a node.
      *
-     * \param[in] rsc          Resource with utilization to add
-     * \param[in] orig_rsc     Resource being allocated (for logging only)
-     * \param[in] all_rscs     List of all resources that will be summed
-     * \param[in] utilization  Table of utilization values to add to
+     * \param[in]     rsc          Resource with utilization to add
+     * \param[in]     orig_rsc     Resource being allocated (for logging only)
+     * \param[in]     all_rscs     List of all resources that will be summed
+     * \param[in,out] utilization  Table of utilization values to add to
      */
-    void (*add_utilization)(pe_resource_t *rsc, pe_resource_t *orig_rsc,
-                            GList *all_rscs, GHashTable *utilization);
+    void (*add_utilization)(const pe_resource_t *rsc,
+                            const pe_resource_t *orig_rsc, GList *all_rscs,
+                            GHashTable *utilization);
 
     /*!
      * \internal
@@ -611,9 +612,9 @@ G_GNUC_INTERNAL
 void pcmk__primitive_add_graph_meta(pe_resource_t *rsc, xmlNode *xml);
 
 G_GNUC_INTERNAL
-void pcmk__primitive_add_utilization(pe_resource_t *rsc,
-                                     pe_resource_t *orig_rsc, GList *all_rscs,
-                                     GHashTable *utilization);
+void pcmk__primitive_add_utilization(const pe_resource_t *rsc,
+                                     const pe_resource_t *orig_rsc,
+                                     GList *all_rscs, GHashTable *utilization);
 
 G_GNUC_INTERNAL
 void pcmk__primitive_shutdown_lock(pe_resource_t *rsc);

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -1125,8 +1125,9 @@ pcmk__output_bundle_actions(pe_resource_t *rsc)
 
 // Bundle implementation of resource_alloc_functions_t:add_utilization()
 void
-pcmk__bundle_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
-                             GList *all_rscs, GHashTable *utilization)
+pcmk__bundle_add_utilization(const pe_resource_t *rsc,
+                             const pe_resource_t *orig_rsc, GList *all_rscs,
+                             GHashTable *utilization)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
     pe__bundle_replica_t *replica = NULL;

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -36,7 +36,7 @@ void distribute_children(pe_resource_t *rsc, GList *children, GList *nodes,
                          int max, int per_host_max, pe_working_set_t * data_set);
 
 static GList *
-get_container_list(pe_resource_t *rsc)
+get_container_list(const pe_resource_t *rsc)
 {
     GList *containers = NULL;
 
@@ -55,7 +55,7 @@ get_container_list(pe_resource_t *rsc)
 }
 
 static inline GList *
-get_containers_or_children(pe_resource_t *rsc)
+get_containers_or_children(const pe_resource_t *rsc)
 {
     return (rsc->variant == pe_container)?
            get_container_list(rsc) : rsc->children;
@@ -335,8 +335,9 @@ pcmk__bundle_internal_constraints(pe_resource_t *rsc)
 }
 
 static pe_resource_t *
-compatible_replica_for_node(pe_resource_t *rsc_lh, pe_node_t *candidate,
-                            pe_resource_t *rsc, enum rsc_role_e filter,
+compatible_replica_for_node(const pe_resource_t *rsc_lh,
+                            const pe_node_t *candidate,
+                            const pe_resource_t *rsc, enum rsc_role_e filter,
                             gboolean current)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
@@ -364,7 +365,7 @@ compatible_replica_for_node(pe_resource_t *rsc_lh, pe_node_t *candidate,
 }
 
 static pe_resource_t *
-compatible_replica(pe_resource_t *rsc_lh, pe_resource_t *rsc,
+compatible_replica(const pe_resource_t *rsc_lh, const pe_resource_t *rsc,
                    enum rsc_role_e filter, gboolean current,
                    pe_working_set_t *data_set)
 {
@@ -570,8 +571,10 @@ pcmk__bundle_action_flags(pe_action_t *action, const pe_node_t *node)
 }
 
 pe_resource_t *
-find_compatible_child_by_node(pe_resource_t * local_child, pe_node_t * local_node, pe_resource_t * rsc,
-                              enum rsc_role_e filter, gboolean current)
+find_compatible_child_by_node(const pe_resource_t *local_child,
+                              const pe_node_t *local_node,
+                              const pe_resource_t *rsc, enum rsc_role_e filter,
+                              gboolean current)
 {
     GList *gIter = NULL;
     GList *children = NULL;

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -65,13 +65,13 @@ get_containers_or_children(pe_resource_t *rsc)
  * \internal
  * \brief Assign a bundle resource to a node
  *
- * \param[in] rsc     Resource to assign to a node
- * \param[in] prefer  Node to prefer, if all else is equal
+ * \param[in,out] rsc     Resource to assign to a node
+ * \param[in]     prefer  Node to prefer, if all else is equal
  *
  * \return Node that \p rsc is assigned to, if assigned entirely to one node
  */
 pe_node_t *
-pcmk__bundle_allocate(pe_resource_t *rsc, pe_node_t *prefer)
+pcmk__bundle_allocate(pe_resource_t *rsc, const pe_node_t *prefer)
 {
     GList *containers = NULL;
     GList *nodes = NULL;

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -446,14 +446,15 @@ int copies_per_node(pe_resource_t * rsc)
  * allowed node weights (if we are still placing resources) or priority (if
  * we are choosing promotable clone instance roles).
  *
- * \param[in] dependent      Dependent resource in colocation
- * \param[in] primary        Primary resource in colocation
- * \param[in] colocation     Colocation constraint to apply
- * \param[in] for_dependent  true if called on behalf of dependent
+ * \param[in,out] dependent      Dependent resource in colocation
+ * \param[in]     primary        Primary resource in colocation
+ * \param[in]     colocation     Colocation constraint to apply
+ * \param[in]     for_dependent  true if called on behalf of dependent
  */
 void
-pcmk__bundle_apply_coloc_score(pe_resource_t *dependent, pe_resource_t *primary,
-                               pcmk__colocation_t *colocation,
+pcmk__bundle_apply_coloc_score(pe_resource_t *dependent,
+                               const pe_resource_t *primary,
+                               const pcmk__colocation_t *colocation,
                                bool for_dependent)
 {
     GList *allocated_primaries = NULL;

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -1145,8 +1145,9 @@ clone_append_meta(pe_resource_t * rsc, xmlNode * xml)
 
 // Clone implementation of resource_alloc_functions_t:add_utilization()
 void
-pcmk__clone_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
-                            GList *all_rscs, GHashTable *utilization)
+pcmk__clone_add_utilization(const pe_resource_t *rsc,
+                            const pe_resource_t *orig_rsc, GList *all_rscs,
+                            GHashTable *utilization)
 {
     bool existing = false;
     pe_resource_t *child = NULL;

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -649,8 +649,9 @@ is_child_compatible(const pe_resource_t *child_rsc, const pe_node_t *local_node,
 }
 
 pe_resource_t *
-find_compatible_child(pe_resource_t *local_child, pe_resource_t *rsc,
-                      enum rsc_role_e filter, gboolean current)
+find_compatible_child(const pe_resource_t *local_child,
+                      const pe_resource_t *rsc, enum rsc_role_e filter,
+                      gboolean current)
 {
     pe_resource_t *pair = NULL;
     GList *gIter = NULL;

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -283,13 +283,13 @@ distribute_children(pe_resource_t *rsc, GList *children, GList *nodes,
  * \internal
  * \brief Assign a clone resource to a node
  *
- * \param[in] rsc     Resource to assign to a node
- * \param[in] prefer  Node to prefer, if all else is equal
+ * \param[in,out] rsc     Resource to assign to a node
+ * \param[in]     prefer  Node to prefer, if all else is equal
  *
  * \return Node that \p rsc is assigned to, if assigned entirely to one node
  */
 pe_node_t *
-pcmk__clone_allocate(pe_resource_t *rsc, pe_node_t *prefer)
+pcmk__clone_allocate(pe_resource_t *rsc, const pe_node_t *prefer)
 {
     GList *nodes = NULL;
     clone_variant_data_t *clone_data = NULL;

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -690,14 +690,15 @@ find_compatible_child(const pe_resource_t *local_child,
  * allowed node weights (if we are still placing resources) or priority (if
  * we are choosing promotable clone instance roles).
  *
- * \param[in] dependent      Dependent resource in colocation
- * \param[in] primary        Primary resource in colocation
- * \param[in] colocation     Colocation constraint to apply
- * \param[in] for_dependent  true if called on behalf of dependent
+ * \param[in,out] dependent      Dependent resource in colocation
+ * \param[in]     primary        Primary resource in colocation
+ * \param[in]     colocation     Colocation constraint to apply
+ * \param[in]     for_dependent  true if called on behalf of dependent
  */
 void
-pcmk__clone_apply_coloc_score(pe_resource_t *dependent, pe_resource_t *primary,
-                              pcmk__colocation_t *colocation,
+pcmk__clone_apply_coloc_score(pe_resource_t *dependent,
+                              const pe_resource_t *primary,
+                              const pcmk__colocation_t *colocation,
                               bool for_dependent)
 {
     GList *gIter = NULL;

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -618,7 +618,8 @@ clone_internal_constraints(pe_resource_t *rsc)
 }
 
 gboolean
-is_child_compatible(pe_resource_t *child_rsc, pe_node_t * local_node, enum rsc_role_e filter, gboolean current) 
+is_child_compatible(const pe_resource_t *child_rsc, const pe_node_t *local_node,
+                    enum rsc_role_e filter, gboolean current)
 {
     pe_node_t *node = NULL;
     enum rsc_role_e next_role = child_rsc->fns->state(child_rsc, current);

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -964,7 +964,7 @@ pcmk__colocation_affects(const pe_resource_t *dependent,
 void
 pcmk__apply_coloc_to_weights(pe_resource_t *dependent,
                              const pe_resource_t *primary,
-                             pcmk__colocation_t *colocation)
+                             const pcmk__colocation_t *colocation)
 {
     const char *attribute = CRM_ATTR_ID;
     const char *value = NULL;

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -846,21 +846,22 @@ pcmk__block_colocated_starts(pe_action_t *action, pe_working_set_t *data_set)
  *
  * \param[in] dependent   Dependent resource in colocation
  * \param[in] primary     Primary resource in colocation
- * \param[in] constraint  Colocation constraint
+ * \param[in] colocation  Colocation constraint
  * \param[in] preview     If true, pretend resources have already been allocated
  *
  * \return How colocation constraint should be applied at this point
  */
 enum pcmk__coloc_affects
-pcmk__colocation_affects(pe_resource_t *dependent, pe_resource_t *primary,
-                         pcmk__colocation_t *constraint, bool preview)
+pcmk__colocation_affects(const pe_resource_t *dependent,
+                         const pe_resource_t *primary,
+                         const pcmk__colocation_t *colocation, bool preview)
 {
     if (!preview && pcmk_is_set(primary->flags, pe_rsc_provisional)) {
         // Primary resource has not been allocated yet, so we can't do anything
         return pcmk__coloc_affects_nothing;
     }
 
-    if ((constraint->dependent_role >= RSC_ROLE_UNPROMOTED)
+    if ((colocation->dependent_role >= RSC_ROLE_UNPROMOTED)
         && (dependent->parent != NULL)
         && pcmk_is_set(dependent->parent->flags, pe_rsc_promotable)
         && !pcmk_is_set(dependent->flags, pe_rsc_provisional)) {
@@ -882,9 +883,9 @@ pcmk__colocation_affects(pe_resource_t *dependent, pe_resource_t *primary,
 
         if (dependent->allocated_to == NULL) {
             crm_trace("Skipping colocation '%s': %s will not run anywhere",
-                      constraint->id, dependent->id);
+                      colocation->id, dependent->id);
 
-        } else if (constraint->score >= INFINITY) {
+        } else if (colocation->score >= INFINITY) {
             // Dependent resource must colocate with primary resource
 
             if ((primary_node == NULL) ||
@@ -895,7 +896,7 @@ pcmk__colocation_affects(pe_resource_t *dependent, pe_resource_t *primary,
                         pe__node_name(primary_node));
             }
 
-        } else if (constraint->score <= -CRM_SCORE_INFINITY) {
+        } else if (colocation->score <= -CRM_SCORE_INFINITY) {
             // Dependent resource must anti-colocate with primary resource
 
             if ((primary_node != NULL) &&
@@ -908,41 +909,41 @@ pcmk__colocation_affects(pe_resource_t *dependent, pe_resource_t *primary,
         return pcmk__coloc_affects_nothing;
     }
 
-    if ((constraint->score > 0)
-        && (constraint->dependent_role != RSC_ROLE_UNKNOWN)
-        && (constraint->dependent_role != dependent->next_role)) {
+    if ((colocation->score > 0)
+        && (colocation->dependent_role != RSC_ROLE_UNKNOWN)
+        && (colocation->dependent_role != dependent->next_role)) {
 
         crm_trace("Skipping colocation '%s': dependent limited to %s role "
                   "but %s next role is %s",
-                  constraint->id, role2text(constraint->dependent_role),
+                  colocation->id, role2text(colocation->dependent_role),
                   dependent->id, role2text(dependent->next_role));
         return pcmk__coloc_affects_nothing;
     }
 
-    if ((constraint->score > 0)
-        && (constraint->primary_role != RSC_ROLE_UNKNOWN)
-        && (constraint->primary_role != primary->next_role)) {
+    if ((colocation->score > 0)
+        && (colocation->primary_role != RSC_ROLE_UNKNOWN)
+        && (colocation->primary_role != primary->next_role)) {
 
         crm_trace("Skipping colocation '%s': primary limited to %s role "
                   "but %s next role is %s",
-                  constraint->id, role2text(constraint->primary_role),
+                  colocation->id, role2text(colocation->primary_role),
                   primary->id, role2text(primary->next_role));
         return pcmk__coloc_affects_nothing;
     }
 
-    if ((constraint->score < 0)
-        && (constraint->dependent_role != RSC_ROLE_UNKNOWN)
-        && (constraint->dependent_role == dependent->next_role)) {
+    if ((colocation->score < 0)
+        && (colocation->dependent_role != RSC_ROLE_UNKNOWN)
+        && (colocation->dependent_role == dependent->next_role)) {
         crm_trace("Skipping anti-colocation '%s': dependent role %s matches",
-                  constraint->id, role2text(constraint->dependent_role));
+                  colocation->id, role2text(colocation->dependent_role));
         return pcmk__coloc_affects_nothing;
     }
 
-    if ((constraint->score < 0)
-        && (constraint->primary_role != RSC_ROLE_UNKNOWN)
-        && (constraint->primary_role == primary->next_role)) {
+    if ((colocation->score < 0)
+        && (colocation->primary_role != RSC_ROLE_UNKNOWN)
+        && (colocation->primary_role == primary->next_role)) {
         crm_trace("Skipping anti-colocation '%s': primary role %s matches",
-                  constraint->id, role2text(constraint->primary_role));
+                  colocation->id, role2text(colocation->primary_role));
         return pcmk__coloc_affects_nothing;
     }
 
@@ -956,13 +957,14 @@ pcmk__colocation_affects(pe_resource_t *dependent, pe_resource_t *primary,
  * Update the allowed node weights of the dependent resource in a colocation,
  * for the purposes of allocating it to a node
  *
- * \param[in] dependent   Dependent resource in colocation
- * \param[in] primary     Primary resource in colocation
- * \param[in] constraint  Colocation constraint
+ * \param[in,out] dependent   Dependent resource in colocation
+ * \param[in]     primary     Primary resource in colocation
+ * \param[in]     colocation  Colocation constraint
  */
 void
-pcmk__apply_coloc_to_weights(pe_resource_t *dependent, pe_resource_t *primary,
-                             pcmk__colocation_t *constraint)
+pcmk__apply_coloc_to_weights(pe_resource_t *dependent,
+                             const pe_resource_t *primary,
+                             pcmk__colocation_t *colocation)
 {
     const char *attribute = CRM_ATTR_ID;
     const char *value = NULL;
@@ -970,14 +972,14 @@ pcmk__apply_coloc_to_weights(pe_resource_t *dependent, pe_resource_t *primary,
     GHashTableIter iter;
     pe_node_t *node = NULL;
 
-    if (constraint->node_attribute != NULL) {
-        attribute = constraint->node_attribute;
+    if (colocation->node_attribute != NULL) {
+        attribute = colocation->node_attribute;
     }
 
     if (primary->allocated_to != NULL) {
         value = pe_node_attribute_raw(primary->allocated_to, attribute);
 
-    } else if (constraint->score < 0) {
+    } else if (colocation->score < 0) {
         // Nothing to do (anti-colocation with something that is not running)
         return;
     }
@@ -988,29 +990,29 @@ pcmk__apply_coloc_to_weights(pe_resource_t *dependent, pe_resource_t *primary,
     while (g_hash_table_iter_next(&iter, NULL, (void **)&node)) {
         if (primary->allocated_to == NULL) {
             pe_rsc_trace(dependent, "%s: %s@%s -= %d (%s inactive)",
-                         constraint->id, dependent->id, pe__node_name(node),
-                         constraint->score, primary->id);
-            node->weight = pcmk__add_scores(-constraint->score, node->weight);
+                         colocation->id, dependent->id, pe__node_name(node),
+                         colocation->score, primary->id);
+            node->weight = pcmk__add_scores(-colocation->score, node->weight);
 
         } else if (pcmk__str_eq(pe_node_attribute_raw(node, attribute), value,
                                 pcmk__str_casei)) {
-            if (constraint->score < CRM_SCORE_INFINITY) {
+            if (colocation->score < CRM_SCORE_INFINITY) {
                 pe_rsc_trace(dependent, "%s: %s@%s += %d",
-                             constraint->id, dependent->id,
-                             pe__node_name(node), constraint->score);
-                node->weight = pcmk__add_scores(constraint->score,
+                             colocation->id, dependent->id,
+                             pe__node_name(node), colocation->score);
+                node->weight = pcmk__add_scores(colocation->score,
                                                 node->weight);
             }
 
-        } else if (constraint->score >= CRM_SCORE_INFINITY) {
+        } else if (colocation->score >= CRM_SCORE_INFINITY) {
             pe_rsc_trace(dependent, "%s: %s@%s -= %d (%s mismatch)",
-                         constraint->id, dependent->id, pe__node_name(node),
-                         constraint->score, attribute);
-            node->weight = pcmk__add_scores(-constraint->score, node->weight);
+                         colocation->id, dependent->id, pe__node_name(node),
+                         colocation->score, attribute);
+            node->weight = pcmk__add_scores(-colocation->score, node->weight);
         }
     }
 
-    if ((constraint->score <= -INFINITY) || (constraint->score >= INFINITY)
+    if ((colocation->score <= -INFINITY) || (colocation->score >= INFINITY)
         || pcmk__any_node_available(work)) {
 
         g_hash_table_destroy(dependent->allowed_nodes);
@@ -1035,13 +1037,14 @@ pcmk__apply_coloc_to_weights(pe_resource_t *dependent, pe_resource_t *primary,
  * Update the priority of the dependent resource in a colocation, for the
  * purposes of selecting its role
  *
- * \param[in] dependent   Dependent resource in colocation
- * \param[in] primary     Primary resource in colocation
- * \param[in] constraint  Colocation constraint
+ * \param[in,out] dependent   Dependent resource in colocation
+ * \param[in]     primary     Primary resource in colocation
+ * \param[in]     colocation  Colocation constraint
  */
 void
-pcmk__apply_coloc_to_priority(pe_resource_t *dependent, pe_resource_t *primary,
-                              pcmk__colocation_t *constraint)
+pcmk__apply_coloc_to_priority(pe_resource_t *dependent,
+                              const pe_resource_t *primary,
+                              const pcmk__colocation_t *colocation)
 {
     const char *dependent_value = NULL;
     const char *primary_value = NULL;
@@ -1052,31 +1055,31 @@ pcmk__apply_coloc_to_priority(pe_resource_t *dependent, pe_resource_t *primary,
         return;
     }
 
-    if (constraint->node_attribute != NULL) {
-        attribute = constraint->node_attribute;
+    if (colocation->node_attribute != NULL) {
+        attribute = colocation->node_attribute;
     }
 
     dependent_value = pe_node_attribute_raw(dependent->allocated_to, attribute);
     primary_value = pe_node_attribute_raw(primary->allocated_to, attribute);
 
     if (!pcmk__str_eq(dependent_value, primary_value, pcmk__str_casei)) {
-        if ((constraint->score == INFINITY)
-            && (constraint->dependent_role == RSC_ROLE_PROMOTED)) {
+        if ((colocation->score == INFINITY)
+            && (colocation->dependent_role == RSC_ROLE_PROMOTED)) {
             dependent->priority = -INFINITY;
         }
         return;
     }
 
-    if ((constraint->primary_role != RSC_ROLE_UNKNOWN)
-        && (constraint->primary_role != primary->next_role)) {
+    if ((colocation->primary_role != RSC_ROLE_UNKNOWN)
+        && (colocation->primary_role != primary->next_role)) {
         return;
     }
 
-    if (constraint->dependent_role == RSC_ROLE_UNPROMOTED) {
+    if (colocation->dependent_role == RSC_ROLE_UNPROMOTED) {
         score_multiplier = -1;
     }
 
-    dependent->priority = pcmk__add_scores(score_multiplier * constraint->score,
+    dependent->priority = pcmk__add_scores(score_multiplier * colocation->score,
                                            dependent->priority);
 }
 

--- a/lib/pacemaker/pcmk_sched_fencing.c
+++ b/lib/pacemaker/pcmk_sched_fencing.c
@@ -451,3 +451,48 @@ pcmk__node_unfenced(pe_node_t *node)
 
     return !pcmk__str_eq(unfenced, "0", pcmk__str_null_matches);
 }
+
+/*!
+ * \internal
+ * \brief Order a resource's start and stop relative to unfencing of a node
+ *
+ * \param[in]     data       Node that could be unfenced
+ * \param[in,out] user_data  Resource to order
+ */
+void
+pcmk__order_restart_vs_unfence(gpointer data, gpointer user_data)
+{
+    pe_node_t *node = (pe_node_t *) data;
+    pe_resource_t *rsc = (pe_resource_t *) user_data;
+
+    pe_action_t *unfence = pe_fence_op(node, "on", true, NULL, false,
+                                       rsc->cluster);
+
+    crm_debug("Ordering any stops of %s before %s, and any starts after",
+              rsc->id, unfence->uuid);
+
+    /*
+     * It would be more efficient to order clone resources once,
+     * rather than order each instance, but ordering the instance
+     * allows us to avoid unnecessary dependencies that might conflict
+     * with user constraints.
+     *
+     * @TODO: This constraint can still produce a transition loop if the
+     * resource has a stop scheduled on the node being unfenced, and
+     * there is a user ordering constraint to start some other resource
+     * (which will be ordered after the unfence) before stopping this
+     * resource. An example is "start some slow-starting cloned service
+     * before stopping an associated virtual IP that may be moving to
+     * it":
+     *       stop this -> unfencing -> start that -> stop this
+     */
+    pcmk__new_ordering(rsc, stop_key(rsc), NULL,
+                       NULL, strdup(unfence->uuid), unfence,
+                       pe_order_optional|pe_order_same_node,
+                       rsc->cluster);
+
+    pcmk__new_ordering(NULL, strdup(unfence->uuid), unfence,
+                       rsc, start_key(rsc), NULL,
+                       pe_order_implies_then_on_node|pe_order_same_node,
+                       rsc->cluster);
+}

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -688,8 +688,9 @@ pcmk__group_colocated_resources(pe_resource_t *rsc, pe_resource_t *orig_rsc,
 
 // Group implementation of resource_alloc_functions_t:add_utilization()
 void
-pcmk__group_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
-                            GList *all_rscs, GHashTable *utilization)
+pcmk__group_add_utilization(const pe_resource_t *rsc,
+                            const pe_resource_t *orig_rsc, GList *all_rscs,
+                            GHashTable *utilization)
 {
     group_variant_data_t *group_data = NULL;
     pe_resource_t *child = NULL;

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -85,13 +85,13 @@ expand_group_colocations(pe_resource_t *rsc)
  * \internal
  * \brief Assign a group resource to a node
  *
- * \param[in] rsc     Resource to assign to a node
- * \param[in] prefer  Node to prefer, if all else is equal
+ * \param[in,out] rsc     Resource to assign to a node
+ * \param[in]     prefer  Node to prefer, if all else is equal
  *
  * \return Node that \p rsc is assigned to, if assigned entirely to one node
  */
 pe_node_t *
-pcmk__group_allocate(pe_resource_t *rsc, pe_node_t *prefer)
+pcmk__group_allocate(pe_resource_t *rsc, const pe_node_t *prefer)
 {
     pe_node_t *node = NULL;
     pe_node_t *group_node = NULL;

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -372,14 +372,15 @@ group_internal_constraints(pe_resource_t *rsc)
  * allowed node weights (if we are still placing resources) or priority (if
  * we are choosing promotable clone instance roles).
  *
- * \param[in] dependent      Dependent resource in colocation
- * \param[in] primary        Primary resource in colocation
- * \param[in] colocation     Colocation constraint to apply
- * \param[in] for_dependent  true if called on behalf of dependent
+ * \param[in,out] dependent      Dependent resource in colocation
+ * \param[in]     primary        Primary resource in colocation
+ * \param[in]     colocation     Colocation constraint to apply
+ * \param[in]     for_dependent  true if called on behalf of dependent
  */
 void
-pcmk__group_apply_coloc_score(pe_resource_t *dependent, pe_resource_t *primary,
-                              pcmk__colocation_t *colocation,
+pcmk__group_apply_coloc_score(pe_resource_t *dependent,
+                              const pe_resource_t *primary,
+                              const pcmk__colocation_t *colocation,
                               bool for_dependent)
 {
     GList *gIter = NULL;

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -141,20 +141,23 @@ sorted_allowed_nodes(const pe_resource_t *rsc)
  * \internal
  * \brief Assign a resource to its best allowed node, if possible
  *
- * \param[in] rsc     Resource to choose a node for
- * \param[in] prefer  If not NULL, prefer this node when all else equal
+ * \param[in,out] rsc     Resource to choose a node for
+ * \param[in]     prefer  If not NULL, prefer this node when all else equal
  *
  * \return true if \p rsc could be assigned to a node, otherwise false
  */
 static bool
-assign_best_node(pe_resource_t *rsc, pe_node_t *prefer)
+assign_best_node(pe_resource_t *rsc, const pe_node_t *prefer)
 {
     GList *nodes = NULL;
     pe_node_t *chosen = NULL;
     pe_node_t *best = NULL;
     bool result = false;
+    const pe_node_t *most_free_node = pcmk__ban_insufficient_capacity(rsc);
 
-    pcmk__ban_insufficient_capacity(rsc, &prefer);
+    if (prefer == NULL) {
+        prefer = most_free_node;
+    }
 
     if (!pcmk_is_set(rsc->flags, pe_rsc_provisional)) {
         // We've already finished assignment of resources to nodes

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -1042,15 +1042,15 @@ pcmk__primitive_internal_constraints(pe_resource_t *rsc)
  * allowed node weights (if we are still placing resources) or priority (if
  * we are choosing promotable clone instance roles).
  *
- * \param[in] dependent      Dependent resource in colocation
- * \param[in] primary        Primary resource in colocation
- * \param[in] colocation     Colocation constraint to apply
+ * \param[in,out] dependent      Dependent resource in colocation
+ * \param[in]     primary        Primary resource in colocation
+ * \param[in]     colocation     Colocation constraint to apply
  * \param[in] for_dependent  true if called on behalf of dependent
  */
 void
 pcmk__primitive_apply_coloc_score(pe_resource_t *dependent,
-                                  pe_resource_t *primary,
-                                  pcmk__colocation_t *colocation,
+                                  const pe_resource_t *primary,
+                                  const pcmk__colocation_t *colocation,
                                   bool for_dependent)
 {
     enum pcmk__coloc_affects filter_results;

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -378,13 +378,13 @@ remote_connection_assigned(pe_resource_t *connection)
  * \internal
  * \brief Assign a primitive resource to a node
  *
- * \param[in] rsc     Resource to assign to a node
- * \param[in] prefer  Node to prefer, if all else is equal
+ * \param[in,out] rsc     Resource to assign to a node
+ * \param[in]     prefer  Node to prefer, if all else is equal
  *
  * \return Node that \p rsc is assigned to, if assigned entirely to one node
  */
 pe_node_t *
-pcmk__primitive_assign(pe_resource_t *rsc, pe_node_t *prefer)
+pcmk__primitive_assign(pe_resource_t *rsc, const pe_node_t *prefer)
 {
     CRM_ASSERT(rsc != NULL);
 

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -1435,8 +1435,9 @@ pcmk__primitive_add_graph_meta(pe_resource_t *rsc, xmlNode *xml)
 
 // Primitive implementation of resource_alloc_functions_t:add_utilization()
 void
-pcmk__primitive_add_utilization(pe_resource_t *rsc, pe_resource_t *orig_rsc,
-                                GList *all_rscs, GHashTable *utilization)
+pcmk__primitive_add_utilization(const pe_resource_t *rsc,
+                                const pe_resource_t *orig_rsc, GList *all_rscs,
+                                GHashTable *utilization)
 {
     if (!pcmk_is_set(rsc->flags, pe_rsc_provisional)) {
         return;

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -1129,14 +1129,14 @@ pcmk__order_promotable_instances(pe_resource_t *clone)
  * \internal
  * \brief Update dependent's allowed nodes for colocation with promotable
  *
- * \param[in] dependent     Dependent resource to update
- * \param[in] primary_node  Node where an instance of the primary will be
- * \param[in] colocation    Colocation constraint to apply
+ * \param[in,out] dependent     Dependent resource to update
+ * \param[in]     primary_node  Node where an instance of the primary will be
+ * \param[in]     colocation    Colocation constraint to apply
  */
 static void
 update_dependent_allowed_nodes(pe_resource_t *dependent,
-                               pe_node_t *primary_node,
-                               pcmk__colocation_t *colocation)
+                               const pe_node_t *primary_node,
+                               const pcmk__colocation_t *colocation)
 {
     GHashTableIter iter;
     pe_node_t *node = NULL;
@@ -1175,14 +1175,14 @@ update_dependent_allowed_nodes(pe_resource_t *dependent,
 /*!
  * \brief Update dependent for a colocation with a promotable clone
  *
- * \param[in] primary     Primary resource in the colocation
- * \param[in] dependent   Dependent resource in the colocation
- * \param[in] colocation  Colocation constraint to apply
+ * \param[in]     primary     Primary resource in the colocation
+ * \param[in,out] dependent   Dependent resource in the colocation
+ * \param[in]     colocation  Colocation constraint to apply
  */
 void
-pcmk__update_dependent_with_promotable(pe_resource_t *primary,
+pcmk__update_dependent_with_promotable(const pe_resource_t *primary,
                                        pe_resource_t *dependent,
-                                       pcmk__colocation_t *colocation)
+                                       const pcmk__colocation_t *colocation)
 {
     GList *affected_nodes = NULL;
 
@@ -1228,14 +1228,14 @@ pcmk__update_dependent_with_promotable(pe_resource_t *primary,
  * \internal
  * \brief Update dependent priority for colocation with promotable
  *
- * \param[in] primary     Primary resource in the colocation
- * \param[in] dependent   Dependent resource in the colocation
- * \param[in] colocation  Colocation constraint to apply
+ * \param[in]     primary     Primary resource in the colocation
+ * \param[in,out] dependent   Dependent resource in the colocation
+ * \param[in]     colocation  Colocation constraint to apply
  */
 void
-pcmk__update_promotable_dependent_priority(pe_resource_t *primary,
+pcmk__update_promotable_dependent_priority(const pe_resource_t *primary,
                                            pe_resource_t *dependent,
-                                           pcmk__colocation_t *colocation)
+                                           const pcmk__colocation_t *colocation)
 {
     pe_resource_t *primary_instance = NULL;
 

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -184,7 +184,8 @@ pcmk__consume_node_capacity(GHashTable *current_utilization, pe_resource_t *rsc)
  * \param[in] rsc                  Resource with utilization to add
  */
 void
-pcmk__release_node_capacity(GHashTable *current_utilization, pe_resource_t *rsc)
+pcmk__release_node_capacity(GHashTable *current_utilization,
+                            const pe_resource_t *rsc)
 {
     struct calculate_data data = {
         .current_utilization = current_utilization,

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -287,32 +287,34 @@ sum_resource_utilization(pe_resource_t *orig_rsc, GList *rscs)
  * \internal
  * \brief Ban resource from nodes with insufficient utilization capacity
  *
- * \param[in]     rsc       Resource to check
- * \param[in,out] prefer    Resource's preferred node (might be updated)
+ * \param[in] rsc  Resource to check
+ *
+ * \return Allowed node for \p rsc with most spare capacity, if there are no
+ *         nodes with enough capacity for \p rsc and all its colocated resources
  */
-void
-pcmk__ban_insufficient_capacity(pe_resource_t *rsc, pe_node_t **prefer)
+const pe_node_t *
+pcmk__ban_insufficient_capacity(pe_resource_t *rsc)
 {
     bool any_capable = false;
     char *rscs_id = NULL;
     pe_node_t *node = NULL;
-    pe_node_t *most_capable_node = NULL;
+    const pe_node_t *most_capable_node = NULL;
     GList *colocated_rscs = NULL;
     GHashTable *unallocated_utilization = NULL;
     GHashTableIter iter;
 
-    CRM_CHECK((rsc != NULL) && (prefer != NULL), return);
+    CRM_CHECK(rsc != NULL, return NULL);
 
     // The default placement strategy ignores utilization
     if (pcmk__str_eq(rsc->cluster->placement_strategy, "default",
                      pcmk__str_casei)) {
-        return;
+        return NULL;
     }
 
     // Check whether any resources are colocated with this one
     colocated_rscs = rsc->cmds->colocated_resources(rsc, NULL, NULL);
     if (colocated_rscs == NULL) {
-        return;
+        return NULL;
     }
 
     rscs_id = crm_strdup_printf("%s and its colocated resources", rsc->id);
@@ -356,12 +358,10 @@ pcmk__ban_insufficient_capacity(pe_resource_t *rsc, pe_node_t **prefer)
                                   rsc->cluster);
             }
         }
+        most_capable_node = NULL;
 
     } else {
         // Otherwise, ban from nodes with insufficient capacity for rsc alone
-        if (*prefer == NULL) {
-            *prefer = most_capable_node;
-        }
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
         while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
             if (pcmk__node_available(node, true, false)
@@ -380,6 +380,7 @@ pcmk__ban_insufficient_capacity(pe_resource_t *rsc, pe_node_t **prefer)
 
     pe__show_node_weights(true, rsc, "Post-utilization",
                           rsc->allowed_nodes, rsc->cluster);
+    return most_capable_node;
 }
 
 /*!

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -494,7 +494,8 @@ clone_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
     free(child_text);
 }
 
-bool is_set_recursive(pe_resource_t * rsc, long long flag, bool any)
+bool
+is_set_recursive(const pe_resource_t *rsc, long long flag, bool any)
 {
     GList *gIter;
     bool all = !any;

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -559,7 +559,7 @@ pe_node_attribute_calculated(const pe_node_t *node, const char *name,
 }
 
 const char *
-pe_node_attribute_raw(pe_node_t *node, const char *name)
+pe_node_attribute_raw(const pe_node_t *node, const char *name)
 {
     if(node == NULL) {
         return NULL;


### PR DESCRIPTION
This continues the project to bring libpacemaker up to current guidelines, finishing up pcmk_sched_primitive.c.