### PR TITLE
Fix: libpacemaker: crm_mon --one-shot can fail during pacemaker shutdown

### DIFF
--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -29,6 +29,7 @@ extern "C" {
 
 #include <crm_config.h>             // HAVE_GETPEEREID
 #include <crm/common/ipc.h>
+#include <crm/common/ipc_pacemakerd.h>  // enum pcmk_pacemakerd_state
 #include <crm/common/mainloop.h>    // mainloop_io_t
 
 /*
@@ -277,6 +278,8 @@ pcmk__ipc_sys_name(const char *ipc_name, const char *fallback)
 {
     return ipc_name ? ipc_name : ((crm_system_name ? crm_system_name : fallback));
 }
+
+const char *pcmk__pcmkd_state_enum2friendly(enum pcmk_pacemakerd_state state);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -28,7 +28,7 @@ extern "C" {
  */
 
 
-#  define PCMK__API_VERSION "2.24"
+#  define PCMK__API_VERSION "2.25"
 
 #if defined(PCMK__WITH_ATTRIBUTE_OUTPUT_ARGS)
 #  define PCMK__OUTPUT_ARGS(ARGS...) __attribute__((output_args(ARGS)))

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -111,7 +111,13 @@ void pcmk_free_injections(pcmk_injections_t *injections);
  *
  * \param[in,out] xml                 Destination for the result, as an XML tree
  * \param[in]     ipc_name            IPC name for request
- * \param[in]     message_timeout_ms  Message timeout
+ * \param[in]     message_timeout_ms  How long to wait for a reply from the
+ *                                    \p pacemakerd API. If 0,
+ *                                    \p pcmk_ipc_dispatch_sync will be used.
+ *                                    If positive, \p pcmk_ipc_dispatch_main
+ *                                    will be used, and a new mainloop will be
+ *                                    created for this purpose (freed before
+ *                                    return).
  *
  * \return Standard Pacemaker return code
  */

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -107,15 +107,16 @@ int pcmk_designated_controller(xmlNodePtr *xml, unsigned int message_timeout_ms)
 void pcmk_free_injections(pcmk_injections_t *injections);
 
 /*!
- * \brief Get pacemakerd status
+ * \brief Get and output \p pacemakerd status
  *
- * \param[in,out] xml                The destination for the result, as an XML tree.
- * \param[in]     ipc_name           IPC name for request
- * \param[in]     message_timeout_ms Message timeout
+ * \param[in,out] xml                 Destination for the result, as an XML tree
+ * \param[in]     ipc_name            IPC name for request
+ * \param[in]     message_timeout_ms  Message timeout
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_pacemakerd_status(xmlNodePtr *xml, char *ipc_name, unsigned int message_timeout_ms);
+int pcmk_pacemakerd_status(xmlNodePtr *xml, const char *ipc_name,
+                           unsigned int message_timeout_ms);
 
 /*!
  * \brief Calculate and output resource operation digests

--- a/include/pcmki/pcmki_cluster_queries.h
+++ b/include/pcmki/pcmki_cluster_queries.h
@@ -19,7 +19,8 @@
 
 int pcmk__controller_status(pcmk__output_t *out, char *dest_node, guint message_timeout_ms);
 int pcmk__designated_controller(pcmk__output_t *out, guint message_timeout_ms);
-int pcmk__pacemakerd_status(pcmk__output_t *out, char *ipc_name, guint message_timeout_ms);
+int pcmk__pacemakerd_status(pcmk__output_t *out, const char *ipc_name,
+                            guint message_timeout_ms);
 int pcmk__list_nodes(pcmk__output_t *out, char *node_types, gboolean bash_export);
 
 #endif

--- a/include/pcmki/pcmki_cluster_queries.h
+++ b/include/pcmki/pcmki_cluster_queries.h
@@ -20,7 +20,8 @@
 int pcmk__controller_status(pcmk__output_t *out, char *dest_node, guint message_timeout_ms);
 int pcmk__designated_controller(pcmk__output_t *out, guint message_timeout_ms);
 int pcmk__pacemakerd_status(pcmk__output_t *out, const char *ipc_name,
-                            guint message_timeout_ms);
+                            guint message_timeout_ms,
+                            enum pcmk_pacemakerd_state *state);
 int pcmk__list_nodes(pcmk__output_t *out, char *node_types, gboolean bash_export);
 
 #endif

--- a/include/pcmki/pcmki_status.h
+++ b/include/pcmki/pcmki_status.h
@@ -50,7 +50,7 @@ int pcmk__status(pcmk__output_t *out, cib_t *cib,
                  enum pcmk__fence_history fence_history, uint32_t show,
                  uint32_t show_opts, const char *only_node,
                  const char *only_rsc, const char *neg_location_prefix,
-                 bool simple_output);
+                 bool simple_output, guint timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/include/pcmki/pcmki_status.h
+++ b/include/pcmki/pcmki_status.h
@@ -38,15 +38,19 @@ extern "C" {
  */
 int pcmk__output_simple_status(pcmk__output_t *out, pe_working_set_t *data_set);
 
-int pcmk__output_cluster_status(pcmk__output_t *out, stonith_t *st, cib_t *cib,
-                                xmlNode *current_cib, enum pcmk__fence_history fence_history,
-                                uint32_t show, uint32_t show_opts, char *only_node,
-                                char *only_rsc, const char *neg_location_prefix,
+int pcmk__output_cluster_status(pcmk__output_t *out, stonith_t *stonith,
+                                cib_t *cib, xmlNode *current_cib,
+                                enum pcmk__fence_history fence_history,
+                                uint32_t show, uint32_t show_opts,
+                                const char *only_node, const char *only_rsc,
+                                const char *neg_location_prefix,
                                 bool simple_output);
 
-int pcmk__status(pcmk__output_t *out, cib_t *cib, enum pcmk__fence_history fence_history,
-                 uint32_t show, uint32_t show_opts, char *only_node, char *only_rsc,
-                 const char *neg_location_prefix, bool simple_output);
+int pcmk__status(pcmk__output_t *out, cib_t *cib,
+                 enum pcmk__fence_history fence_history, uint32_t show,
+                 uint32_t show_opts, const char *only_node,
+                 const char *only_rsc, const char *neg_location_prefix,
+                 bool simple_output);
 
 #ifdef __cplusplus
 }

--- a/lib/common/ipc_pacemakerd.c
+++ b/lib/common/ipc_pacemakerd.c
@@ -62,6 +62,39 @@ pcmk_pacemakerd_api_daemon_state_enum2text(
     return "invalid";
 }
 
+/*!
+ * \internal
+ * \brief Return a friendly string representation of a \p pacemakerd state
+ *
+ * \param[in] state  \p pacemakerd state
+ *
+ * \return A user-friendly string representation of \p state, or
+ *         <tt>"Invalid pacemakerd state"</tt>
+ */
+const char *
+pcmk__pcmkd_state_enum2friendly(enum pcmk_pacemakerd_state state)
+{
+    switch (state) {
+        case pcmk_pacemakerd_state_init:
+            return "Initializing pacemaker";
+        case pcmk_pacemakerd_state_starting_daemons:
+            return "Pacemaker daemons are starting";
+        case pcmk_pacemakerd_state_wait_for_ping:
+            return "Waiting for startup trigger from SBD";
+        case pcmk_pacemakerd_state_running:
+            return "Pacemaker is running";
+        case pcmk_pacemakerd_state_shutting_down:
+            return "Pacemaker daemons are shutting down";
+        case pcmk_pacemakerd_state_shutdown_complete:
+            /* Assuming pacemakerd won't process messages while in
+             * shutdown_complete state unless reporting to SBD
+             */
+            return "Pacemaker daemons are shut down (reporting to SBD)";
+        default:
+            return "Invalid pacemakerd state";
+    }
+}
+
 // \return Standard Pacemaker return code
 static int
 new_data(pcmk_ipc_api_t *api)

--- a/lib/common/ipc_pacemakerd.c
+++ b/lib/common/ipc_pacemakerd.c
@@ -213,7 +213,7 @@ dispatch(pcmk_ipc_api_t *api, xmlNode *reply)
         reply_data.data.ping.status =
             pcmk__str_eq(crm_element_value(msg_data, XML_PING_ATTR_STATUS), "ok",
                          pcmk__str_casei)?pcmk_rc_ok:pcmk_rc_error;
-        reply_data.data.ping.last_good = (time_t) value_ll;
+        reply_data.data.ping.last_good = (value_ll < 0)? 0 : (time_t) value_ll;
         reply_data.data.ping.sys_from = crm_element_value(msg_data,
                                             XML_PING_ATTR_SYSFROM);
     } else if (pcmk__str_eq(value, CRM_OP_QUIT, pcmk__str_none)) {

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -270,6 +270,7 @@ ipc_connect(data_t *data, enum pcmk_ipc_server server, pcmk_ipc_callback_t cb)
                 pcmk_ipc_name(api, true),
                 pcmk_rc_str(rc));
         data->rc = rc;
+        pcmk_free_ipc_api(api);
         return NULL;
     }
 

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -207,6 +207,7 @@ pacemakerd_event_cb(pcmk_ipc_api_t *pacemakerd_api,
         out->err(out, "error: Bad reply from pacemakerd: %s",
                 crm_exit_str(status));
         event_done(data, pacemakerd_api);
+        data->rc = EBADMSG;
         return;
     }
 
@@ -214,6 +215,7 @@ pacemakerd_event_cb(pcmk_ipc_api_t *pacemakerd_api,
         out->err(out, "error: Unknown reply type %d from pacemakerd",
                 reply->reply_type);
         event_done(data, pacemakerd_api);
+        data->rc = EBADMSG;
         return;
     }
 
@@ -375,7 +377,7 @@ pcmk__pacemakerd_status(pcmk__output_t *out, const char *ipc_name,
     data_t data = {
         .out = out,
         .mainloop = NULL,
-        .rc = pcmk_rc_ok,
+        .rc = pcmk_rc_ipc_unresponsive,
         .message_timer_id = 0,
         .message_timeout_ms = message_timeout_ms
     };

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -229,7 +229,7 @@ pacemakerd_event_cb(pcmk_ipc_api_t *pacemakerd_api,
         (reply->data.ping.status == pcmk_rc_ok)?
             pcmk_pacemakerd_api_daemon_state_enum2text(
                 reply->data.ping.state):"query failed",
-        (reply->data.ping.status == pcmk_rc_ok)?pinged_buf:"");
+        (reply->data.ping.status == pcmk_rc_ok)? pinged_buf : NULL);
     data->rc = pcmk_rc_ok;
     crm_time_free(crm_when);
     free(pinged_buf);

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -358,8 +358,19 @@ pcmk_designated_controller(xmlNodePtr *xml, unsigned int message_timeout_ms)
     return rc;
 }
 
+/*!
+ * \internal
+ * \brief Get and output \p pacemakerd status
+ *
+ * \param[in,out] out                 Output object
+ * \param[in]     ipc_name            IPC name for request
+ * \param[in]     message_timeout_ms  Message timeout
+ *
+ * \return Standard Pacemaker return code
+ */
 int
-pcmk__pacemakerd_status(pcmk__output_t *out, char *ipc_name, guint message_timeout_ms)
+pcmk__pacemakerd_status(pcmk__output_t *out, const char *ipc_name,
+                        guint message_timeout_ms)
 {
     data_t data = {
         .out = out,
@@ -385,8 +396,10 @@ pcmk__pacemakerd_status(pcmk__output_t *out, char *ipc_name, guint message_timeo
     return data.rc;
 }
 
+// Documented in header
 int
-pcmk_pacemakerd_status(xmlNodePtr *xml, char *ipc_name, unsigned int message_timeout_ms)
+pcmk_pacemakerd_status(xmlNodePtr *xml, const char *ipc_name,
+                       unsigned int message_timeout_ms)
 {
     pcmk__output_t *out = NULL;
     int rc = pcmk_rc_ok;

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -669,6 +669,31 @@ pacemakerd_health(pcmk__output_t *out, va_list args)
 PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
                   "const char *")
 static int
+pacemakerd_health_html(pcmk__output_t *out, va_list args)
+{
+    const char *sys_from = va_arg(args, const char *);
+    enum pcmk_pacemakerd_state state =
+        (enum pcmk_pacemakerd_state) va_arg(args, int);
+    const char *state_s = va_arg(args, const char *);
+    const char *last_updated = va_arg(args, const char *);
+    char *msg = NULL;
+
+    if (state_s == NULL) {
+        state_s = pcmk__pcmkd_state_enum2friendly(state);
+    }
+
+    msg = crm_strdup_printf("Status of %s: '%s' (last updated %s)",
+                            pcmk__s(sys_from, "unknown node"), state_s,
+                            pcmk__s(last_updated, "at unknown time"));
+    pcmk__output_create_html_node(out, "li", NULL, NULL, msg);
+
+    free(msg);
+    return pcmk_rc_ok;
+}
+
+PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
+                  "const char *")
+static int
 pacemakerd_health_text(pcmk__output_t *out, va_list args)
 {
     if (!out->is_quiet(out)) {
@@ -2132,6 +2157,7 @@ static pcmk__message_entry_t fmt_functions[] = {
     { "node-action", "default", node_action },
     { "node-action", "xml", node_action_xml },
     { "pacemakerd-health", "default", pacemakerd_health },
+    { "pacemakerd-health", "html", pacemakerd_health_html },
     { "pacemakerd-health", "text", pacemakerd_health_text },
     { "pacemakerd-health", "xml", pacemakerd_health_xml },
     { "profile", "default", profile_default, },

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -647,21 +647,27 @@ health_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "const char *", "const char *")
+PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
+                  "const char *")
 static int
 pacemakerd_health(pcmk__output_t *out, va_list args)
 {
     const char *sys_from = va_arg(args, const char *);
-    const char *state = va_arg(args, const char *);
+    enum pcmk_pacemakerd_state state =
+        (enum pcmk_pacemakerd_state) va_arg(args, int);
+    const char *state_s = va_arg(args, const char *);
     const char *last_updated = va_arg(args, const char *);
 
+    if (state_s == NULL) {
+        state_s = pcmk__pcmkd_state_enum2friendly(state);
+    }
     return out->info(out, "Status of %s: '%s' (last updated %s)",
-                     pcmk__s(sys_from, "unknown node"),
-                     pcmk__s(state, "unknown state"),
+                     pcmk__s(sys_from, "unknown node"), state_s,
                      pcmk__s(last_updated, "at unknown time"));
 }
 
-PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "const char *", "const char *")
+PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
+                  "const char *")
 static int
 pacemakerd_health_text(pcmk__output_t *out, va_list args)
 {
@@ -669,24 +675,36 @@ pacemakerd_health_text(pcmk__output_t *out, va_list args)
         return pacemakerd_health(out, args);
     } else {
         const char *sys_from G_GNUC_UNUSED = va_arg(args, const char *);
-        const char *state = va_arg(args, const char *);
+        enum pcmk_pacemakerd_state state =
+            (enum pcmk_pacemakerd_state) va_arg(args, int);
+        const char *state_s = va_arg(args, const char *);
         const char *last_updated G_GNUC_UNUSED = va_arg(args, const char *);
 
-        pcmk__formatted_printf(out, "%s\n", pcmk__s(state, "<null>"));
+        if (state_s == NULL) {
+            state_s = pcmk_pacemakerd_api_daemon_state_enum2text(state);
+        }
+        pcmk__formatted_printf(out, "%s\n", state_s);
         return pcmk_rc_ok;
     }
 }
 
-PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "const char *", "const char *")
+PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
+                  "const char *")
 static int
 pacemakerd_health_xml(pcmk__output_t *out, va_list args)
 {
     const char *sys_from = va_arg(args, const char *);
-    const char *state = va_arg(args, const char *);
+    enum pcmk_pacemakerd_state state =
+        (enum pcmk_pacemakerd_state) va_arg(args, int);
+    const char *state_s = va_arg(args, const char *);
     const char *last_updated = va_arg(args, const char *);
 
+    if (state_s == NULL) {
+        state_s = pcmk_pacemakerd_api_daemon_state_enum2text(state);
+    }
+
     pcmk__output_create_xml_node(out, pcmk__s(sys_from, "<null>"),
-                                 "state", pcmk__s(state, ""),
+                                 "state", state_s,
                                  "last_updated", pcmk__s(last_updated, ""),
                                  NULL);
     return pcmk_rc_ok;

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -662,7 +662,7 @@ pacemakerd_health(pcmk__output_t *out, va_list args)
         state_s = pcmk__pcmkd_state_enum2friendly(state);
     }
     return out->info(out, "Status of %s: '%s' (last updated %s)",
-                     pcmk__s(sys_from, "unknown node"), state_s,
+                     pcmk__s(sys_from, "unknown subsystem"), state_s,
                      pcmk__s(last_updated, "at unknown time"));
 }
 
@@ -683,7 +683,7 @@ pacemakerd_health_html(pcmk__output_t *out, va_list args)
     }
 
     msg = crm_strdup_printf("Status of %s: '%s' (last updated %s)",
-                            pcmk__s(sys_from, "unknown node"), state_s,
+                            pcmk__s(sys_from, "unknown subsystem"), state_s,
                             pcmk__s(last_updated, "at unknown time"));
     pcmk__output_create_html_node(out, "li", NULL, NULL, msg);
 

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -728,9 +728,10 @@ pacemakerd_health_xml(pcmk__output_t *out, va_list args)
         state_s = pcmk_pacemakerd_api_daemon_state_enum2text(state);
     }
 
-    pcmk__output_create_xml_node(out, pcmk__s(sys_from, "<null>"),
+    pcmk__output_create_xml_node(out, "pacemakerd",
+                                 "sys_from", sys_from,
                                  "state", state_s,
-                                 "last_updated", pcmk__s(last_updated, ""),
+                                 "last_updated", last_updated,
                                  NULL);
     return pcmk_rc_ok;
 }

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -844,9 +844,9 @@ pe__build_rsc_list(pe_working_set_t *data_set, const char *s) {
                 resources = g_list_prepend(resources, strdup(rsc_printable_id(rsc)));
             }
         } else {
-            /* The given string was not a valid resource name.  It's either
-             * a tag or it's a typo or something.  See build_uname_list for
-             * more detail.
+            /* The given string was not a valid resource name. It's a tag or a
+             * typo or something. See pe__build_node_name_list() for more
+             * detail.
              */
             resources = pe__rscs_with_tag(data_set, s);
         }

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -954,26 +954,26 @@ pacemakerd_status(void)
                     rc = ENOTCONN;
                     if ((output_format == mon_output_console) ||
                         (output_format == mon_output_plain)) {
+
+                        const char *state_str = NULL;
+                        state_str = pcmk__pcmkd_state_enum2friendly(state);
                         switch (state) {
                             case pcmk_pacemakerd_state_running:
                                 rc = pcmk_rc_ok;
                                 break;
                             case pcmk_pacemakerd_state_starting_daemons:
-                                out->info(out,"Pacemaker daemons starting ...");
+                                out->info(out, "%s", state_str);
                                 break;
                             case pcmk_pacemakerd_state_wait_for_ping:
-                                out->info(out,"Waiting for startup-trigger from SBD ...");
+                                out->info(out, "%s", state_str);
                                 break;
                             case pcmk_pacemakerd_state_shutting_down:
-                                out->info(out,"Pacemaker daemons shutting down ...");
+                                out->info(out, "%s", state_str);
                                 /* try our luck maybe CIB is still accessible */
                                 rc = pcmk_rc_ok;
                                 break;
                             case pcmk_pacemakerd_state_shutdown_complete:
-                                /* assuming pacemakerd doesn't dispatch any pings after entering
-                                * that state unless it is waiting for SBD
-                                */
-                                out->info(out,"Pacemaker daemons shut down - reporting to SBD ...");
+                                out->info(out, "%s", state_str);
                                 break;
                             default:
                                 break;

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1333,7 +1333,7 @@ one_shot(void)
     int rc = pcmk__status(out, cib, fence_history, show, show_opts,
                           options.only_node, options.only_rsc,
                           options.neg_location_prefix,
-                          output_format == mon_output_monitor);
+                          output_format == mon_output_monitor, 0);
 
     if (rc == pcmk_rc_ok) {
         clean_up(pcmk_rc2exitc(rc));

--- a/tools/crmadmin.c
+++ b/tools/crmadmin.c
@@ -238,7 +238,8 @@ main(int argc, char **argv)
             rc = pcmk__controller_status(out, options.optarg, options.timeout);
             break;
         case cmd_pacemakerd_health:
-            rc = pcmk__pacemakerd_status(out, options.ipc_name, options.timeout);
+            rc = pcmk__pacemakerd_status(out, options.ipc_name, options.timeout,
+                                         NULL);
             break;
         case cmd_list_nodes:
             rc = pcmk__list_nodes(out, options.optarg, options.bash_export);

--- a/xml/api/crm_mon-2.25.rng
+++ b/xml/api/crm_mon-2.25.rng
@@ -8,6 +8,9 @@
 
     <define name="element-crm-mon">
         <optional>
+            <externalRef href="pacemakerd-health-2.25.rng" />
+        </optional>
+        <optional>
             <ref name="element-summary" />
         </optional>
         <optional>

--- a/xml/api/crm_mon-2.25.rng
+++ b/xml/api/crm_mon-2.25.rng
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crm-mon"/>
+    </start>
+
+    <define name="element-crm-mon">
+        <optional>
+            <ref name="element-summary" />
+        </optional>
+        <optional>
+            <ref name="nodes-list" />
+        </optional>
+        <optional>
+            <ref name="resources-list" />
+        </optional>
+        <optional>
+            <ref name="node-attributes-list" />
+        </optional>
+        <optional>
+            <externalRef href="node-history-2.12.rng"/>
+        </optional>
+        <optional>
+            <ref name="failures-list" />
+        </optional>
+        <optional>
+            <ref name="fence-event-list" />
+        </optional>
+        <optional>
+            <ref name="tickets-list" />
+        </optional>
+        <optional>
+            <ref name="bans-list" />
+        </optional>
+    </define>
+
+    <define name="element-summary">
+        <element name="summary">
+            <optional>
+                <element name="stack">
+                    <attribute name="type"> <text /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="current_dc">
+                    <attribute name="present"> <data type="boolean" /> </attribute>
+                    <optional>
+                        <group>
+                            <attribute name="version"> <text /> </attribute>
+                            <attribute name="name"> <text /> </attribute>
+                            <attribute name="id"> <text /> </attribute>
+                            <attribute name="with_quorum"> <data type="boolean" /> </attribute>
+                        </group>
+                    </optional>
+                    <optional>
+                        <attribute name="mixed_version"> <data type="boolean" /> </attribute>
+                    </optional>
+                </element>
+            </optional>
+            <optional>
+                <element name="last_update">
+                    <attribute name="time"> <text /> </attribute>
+                </element>
+                <element name="last_change">
+                    <attribute name="time"> <text /> </attribute>
+                    <attribute name="user"> <text /> </attribute>
+                    <attribute name="client"> <text /> </attribute>
+                    <attribute name="origin"> <text /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="nodes_configured">
+                    <attribute name="number"> <data type="nonNegativeInteger" /> </attribute>
+                </element>
+                <element name="resources_configured">
+                    <attribute name="number"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="disabled"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="blocked"> <data type="nonNegativeInteger" /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="cluster_options">
+                    <attribute name="stonith-enabled"> <data type="boolean" /> </attribute>
+                    <attribute name="symmetric-cluster"> <data type="boolean" /> </attribute>
+                    <attribute name="no-quorum-policy"> <text /> </attribute>
+                    <attribute name="maintenance-mode"> <data type="boolean" /> </attribute>
+                    <attribute name="stop-all-resources"> <data type="boolean" /> </attribute>
+                    <attribute name="stonith-timeout-ms"> <data type="integer" /> </attribute>
+                    <attribute name="priority-fencing-delay-ms"> <data type="integer" /> </attribute>
+                </element>
+            </optional>
+        </element>
+    </define>
+
+    <define name="resources-list">
+        <element name="resources">
+            <zeroOrMore>
+                <externalRef href="resources-2.24.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="nodes-list">
+        <element name="nodes">
+            <zeroOrMore>
+                <externalRef href="nodes-2.24.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="node-attributes-list">
+        <element name="node_attributes">
+            <zeroOrMore>
+                <externalRef href="node-attrs-2.8.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="failures-list">
+        <element name="failures">
+            <zeroOrMore>
+                <externalRef href="failure-2.8.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="fence-event-list">
+        <element name="fence_history">
+            <optional>
+                <attribute name="status"> <data type="integer" /> </attribute>
+            </optional>
+            <zeroOrMore>
+                <externalRef href="fence-event-2.15.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="tickets-list">
+        <element name="tickets">
+            <zeroOrMore>
+                <ref name="element-ticket" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="bans-list">
+        <element name="bans">
+            <zeroOrMore>
+                <ref name="element-ban" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="element-ticket">
+        <element name="ticket">
+            <attribute name="id"> <text /> </attribute>
+            <attribute name="status">
+                <choice>
+                    <value>granted</value>
+                    <value>revoked</value>
+                </choice>
+            </attribute>
+            <attribute name="standby"> <data type="boolean" /> </attribute>
+            <optional>
+                <attribute name="last-granted"> <text /> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="element-ban">
+        <element name="ban">
+            <attribute name="id"> <text /> </attribute>
+            <attribute name="resource"> <text /> </attribute>
+            <attribute name="node"> <text /> </attribute>
+            <attribute name="weight"> <data type="integer" /> </attribute>
+            <attribute name="promoted-only"> <data type="boolean" /> </attribute>
+            <!-- DEPRECATED: master_only is a duplicate of promoted-only that is
+                 provided solely for API backward compatibility. It will be
+                 removed in a future release. Check promoted-only instead.
+              -->
+            <attribute name="master_only"> <data type="boolean" /> </attribute>
+        </element>
+    </define>
+</grammar>

--- a/xml/api/crmadmin-2.25.rng
+++ b/xml/api/crmadmin-2.25.rng
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crmadmin"/>
+    </start>
+
+    <define name="element-crmadmin">
+        <optional>
+            <ref name="element-status" />
+        </optional>
+        <optional>
+            <ref name="element-pacemakerd" />
+        </optional>
+        <optional>
+            <ref name="element-dc" />
+        </optional>
+        <optional>
+            <ref name="crmadmin-nodes-list" />
+        </optional>
+    </define>
+
+    <define name="element-status">
+        <element name="crmd">
+            <attribute name="node_name"> <text /> </attribute>
+            <attribute name="state"> <text /> </attribute>
+            <attribute name="result"> <text /> </attribute>
+        </element>
+    </define>
+
+    <define name="element-pacemakerd">
+        <element name="pacemakerd">
+            <attribute name="state"> <text /> </attribute>
+            <attribute name="last_updated"> <text /> </attribute>
+        </element>
+    </define>
+
+    <define name="element-dc">
+        <element name="dc">
+            <attribute name="node_name"> <text /> </attribute>
+        </element>
+    </define>
+
+    <define name="crmadmin-nodes-list">
+        <element name="nodes">
+            <zeroOrMore>
+                <ref name="element-crmadmin-node" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="element-crmadmin-node">
+        <element name="node">
+            <attribute name="type">
+                <choice>
+                    <value>unknown</value>
+                    <value>member</value>
+                    <value>remote</value>
+                    <value>ping</value>
+                </choice>
+            </attribute>
+
+            <attribute name="name"> <text/> </attribute>
+            <attribute name="id"> <text/> </attribute>
+        </element>
+    </define>
+</grammar>

--- a/xml/api/crmadmin-2.25.rng
+++ b/xml/api/crmadmin-2.25.rng
@@ -11,7 +11,7 @@
             <ref name="element-status" />
         </optional>
         <optional>
-            <ref name="element-pacemakerd" />
+            <externalRef href="pacemakerd-health-2.25.rng" />
         </optional>
         <optional>
             <ref name="element-dc" />
@@ -26,13 +26,6 @@
             <attribute name="node_name"> <text /> </attribute>
             <attribute name="state"> <text /> </attribute>
             <attribute name="result"> <text /> </attribute>
-        </element>
-    </define>
-
-    <define name="element-pacemakerd">
-        <element name="pacemakerd">
-            <attribute name="state"> <text /> </attribute>
-            <attribute name="last_updated"> <text /> </attribute>
         </element>
     </define>
 

--- a/xml/api/pacemakerd-health-2.25.rng
+++ b/xml/api/pacemakerd-health-2.25.rng
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-pacemakerd-health"/>
+    </start>
+
+    <define name="element-pacemakerd-health">
+        <element name="pacemakerd">
+            <optional>
+                <attribute name="sys_from"> <text /> </attribute>
+            </optional>
+            <attribute name="state"> <text /> </attribute>
+            <optional>
+                <attribute name="last_updated"> <text /> </attribute>
+            </optional>
+        </element>
+    </define>
+</grammar>


### PR DESCRIPTION
`crm_mon --one-shot` checks the pacemakerd state before trying to get a CIB connection. If `pacemakerd` is shutting down, it returns `ENOTCONN`. This can cause a resource agent that calls `crm_mon` (for example, `ocf:heartbeat:pgsql`) to fail to stop during shutdown.

This may be a regression introduced by commit 3f342e3. `crm_mon.c:pacemakerd_status()` returns `pcmk_rc_ok` if `pacemakerd` is shutting down, since 49ebe4c and 46d6edd (fixes for CLBZ#5471). 3f342e3 refactored `crm_mon --one-shot` to use library functions, and `pcmk_status.c:pacemakerd_status()` returns `ENOTCONN` if `pacemakerd` is shutting down. As a result, we don't try to connect to the CIB.

Fixes CLBZ#5501