### PR TITLE
Refactors and minor improvements related to cluster queries

### DIFF
--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -29,7 +29,8 @@ extern "C" {
 
 #include <crm_config.h>             // HAVE_GETPEEREID
 #include <crm/common/ipc.h>
-#include <crm/common/ipc_pacemakerd.h>  // enum pcmk_pacemakerd_state
+#include <crm/common/ipc_controld.h>    // pcmk_controld_api_reply
+#include <crm/common/ipc_pacemakerd.h>  // pcmk_pacemakerd_{api_reply,state}
 #include <crm/common/mainloop.h>    // mainloop_io_t
 
 /*
@@ -280,6 +281,9 @@ pcmk__ipc_sys_name(const char *ipc_name, const char *fallback)
 }
 
 const char *pcmk__pcmkd_state_enum2friendly(enum pcmk_pacemakerd_state state);
+
+const char *pcmk__controld_api_reply2str(enum pcmk_controld_api_reply reply);
+const char *pcmk__pcmkd_api_reply2str(enum pcmk_pacemakerd_api_reply reply);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/ipc_pacemakerd.h
+++ b/include/crm/common/ipc_pacemakerd.h
@@ -32,7 +32,8 @@ enum pcmk_pacemakerd_state {
     pcmk_pacemakerd_state_running,
     pcmk_pacemakerd_state_shutting_down,
     pcmk_pacemakerd_state_shutdown_complete,
-    pcmk_pacemakerd_state_max = pcmk_pacemakerd_state_shutdown_complete,
+    pcmk_pacemakerd_state_remote,
+    pcmk_pacemakerd_state_max = pcmk_pacemakerd_state_remote,
 };
 
 //! Possible types of pacemakerd replies

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -169,6 +169,7 @@ extern "C" {
 #  define XML_PING_ATTR_PACEMAKERDSTATE_RUNNING "running"
 #  define XML_PING_ATTR_PACEMAKERDSTATE_SHUTTINGDOWN "shutting_down"
 #  define XML_PING_ATTR_PACEMAKERDSTATE_SHUTDOWNCOMPLETE "shutdown_complete"
+#  define XML_PING_ATTR_PACEMAKERDSTATE_REMOTE "remote"
 
 #  define XML_TAG_FRAGMENT		"cib_fragment"
 

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -98,14 +98,22 @@ int pcmk_controller_status(xmlNodePtr *xml, const char *node_name,
                            unsigned int message_timeout_ms);
 
 /*!
- * \brief Get designated controller
+ * \brief Get and output designated controller node name
  *
- * \param[in,out] xml                The destination for the result, as an XML tree.
- * \param[in]     message_timeout_ms Message timeout
+ * \param[in,out] xml                 Destination for the result, as an XML tree
+ * \param[in]     message_timeout_ms  How long to wait for a reply from the
+ *                                    \p pacemaker-controld API. If 0,
+ *                                    \p pcmk_ipc_dispatch_sync will be used.
+ *                                    Otherwise, \p pcmk_ipc_dispatch_main will
+ *                                    be used, and a new mainloop will be
+ *                                    created for this purpose (freed before
+ *                                    return).
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_designated_controller(xmlNodePtr *xml, unsigned int message_timeout_ms);
+
+int pcmk_designated_controller(xmlNodePtr *xml,
+                               unsigned int message_timeout_ms);
 
 /*!
  * \brief Free a :pcmk_injections_t structure

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -79,15 +79,23 @@ typedef struct {
 } pcmk_injections_t;
 
 /*!
- * \brief Get controller status
+ * \brief Get and output controller status
  *
- * \param[in,out] xml                The destination for the result, as an XML tree.
- * \param[in]     dest_node          Destination node for request
- * \param[in]     message_timeout_ms Message timeout
+ * \param[in,out] xml                 Destination for the result, as an XML tree
+ * \param[in]     node_name           Name of node whose status is desired
+ *                                    (\p NULL for DC)
+ * \param[in]     message_timeout_ms  How long to wait for a reply from the
+ *                                    \p pacemaker-controld API. If 0,
+ *                                    \p pcmk_ipc_dispatch_sync will be used.
+ *                                    Otherwise, \p pcmk_ipc_dispatch_main will
+ *                                    be used, and a new mainloop will be
+ *                                    created for this purpose (freed before
+ *                                    return).
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_controller_status(xmlNodePtr *xml, char *dest_node, unsigned int message_timeout_ms);
+int pcmk_controller_status(xmlNodePtr *xml, const char *node_name,
+                           unsigned int message_timeout_ms);
 
 /*!
  * \brief Get designated controller

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -130,8 +130,8 @@ void pcmk_free_injections(pcmk_injections_t *injections);
  * \param[in]     message_timeout_ms  How long to wait for a reply from the
  *                                    \p pacemakerd API. If 0,
  *                                    \p pcmk_ipc_dispatch_sync will be used.
- *                                    If positive, \p pcmk_ipc_dispatch_main
- *                                    will be used, and a new mainloop will be
+ *                                    Otherwise, \p pcmk_ipc_dispatch_main will
+ *                                    be used, and a new mainloop will be
  *                                    created for this purpose (freed before
  *                                    return).
  *

--- a/include/pcmki/pcmki_cluster_queries.h
+++ b/include/pcmki/pcmki_cluster_queries.h
@@ -18,10 +18,11 @@
 #include <crm/common/ipc_pacemakerd.h>
 
 int pcmk__controller_status(pcmk__output_t *out, const char *node_name,
-                            guint message_timeout_ms);
-int pcmk__designated_controller(pcmk__output_t *out, guint message_timeout_ms);
+                            unsigned int message_timeout_ms);
+int pcmk__designated_controller(pcmk__output_t *out,
+                                unsigned int message_timeout_ms);
 int pcmk__pacemakerd_status(pcmk__output_t *out, const char *ipc_name,
-                            guint message_timeout_ms,
+                            unsigned int message_timeout_ms,
                             enum pcmk_pacemakerd_state *state);
 int pcmk__list_nodes(pcmk__output_t *out, char *node_types, gboolean bash_export);
 

--- a/include/pcmki/pcmki_cluster_queries.h
+++ b/include/pcmki/pcmki_cluster_queries.h
@@ -17,7 +17,8 @@
 #include <crm/common/ipc_controld.h>
 #include <crm/common/ipc_pacemakerd.h>
 
-int pcmk__controller_status(pcmk__output_t *out, char *dest_node, guint message_timeout_ms);
+int pcmk__controller_status(pcmk__output_t *out, const char *node_name,
+                            guint message_timeout_ms);
 int pcmk__designated_controller(pcmk__output_t *out, guint message_timeout_ms);
 int pcmk__pacemakerd_status(pcmk__output_t *out, const char *ipc_name,
                             guint message_timeout_ms,

--- a/include/pcmki/pcmki_status.h
+++ b/include/pcmki/pcmki_status.h
@@ -50,7 +50,7 @@ int pcmk__status(pcmk__output_t *out, cib_t *cib,
                  enum pcmk__fence_history fence_history, uint32_t show,
                  uint32_t show_opts, const char *only_node,
                  const char *only_rsc, const char *neg_location_prefix,
-                 bool simple_output, guint timeout_ms);
+                 bool simple_output, unsigned int timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -404,7 +404,10 @@ pcmk_poll_ipc(const pcmk_ipc_api_t *api, int timeout_ms)
     pollfd.events = POLLIN;
     rc = poll(&pollfd, 1, timeout_ms);
     if (rc < 0) {
-        return errno;
+        /* Some UNIX systems return negative and set EAGAIN for failure to
+         * allocate memory; standardize the return code in that case
+         */
+        return (errno == EAGAIN)? ENOMEM : errno;
     } else if (rc == 0) {
         return EAGAIN;
     }

--- a/lib/common/ipc_controld.c
+++ b/lib/common/ipc_controld.c
@@ -27,6 +27,33 @@ struct controld_api_private_s {
     unsigned int replies_expected;
 };
 
+/*!
+ * \internal
+ * \brief Get a string representation of a controller API reply type
+ *
+ * \param[in] reply  Controller API reply type
+ *
+ * \return String representation of a controller API reply type
+ */
+const char *
+pcmk__controld_api_reply2str(enum pcmk_controld_api_reply reply)
+{
+    switch (reply) {
+        case pcmk_controld_reply_reprobe:
+            return "reprobe";
+        case pcmk_controld_reply_info:
+            return "info";
+        case pcmk_controld_reply_resource:
+            return "resource";
+        case pcmk_controld_reply_ping:
+            return "ping";
+        case pcmk_controld_reply_nodes:
+            return "nodes";
+        default:
+            return "unknown";
+    }
+}
+
 // \return Standard Pacemaker return code
 static int
 new_data(pcmk_ipc_api_t *api)

--- a/lib/common/ipc_pacemakerd.c
+++ b/lib/common/ipc_pacemakerd.c
@@ -95,6 +95,27 @@ pcmk__pcmkd_state_enum2friendly(enum pcmk_pacemakerd_state state)
     }
 }
 
+/*!
+ * \internal
+ * \brief Get a string representation of a \p pacemakerd API reply type
+ *
+ * \param[in] reply  \p pacemakerd API reply type
+ *
+ * \return String representation of a \p pacemakerd API reply type
+ */
+const char *
+pcmk__pcmkd_api_reply2str(enum pcmk_pacemakerd_api_reply reply)
+{
+    switch (reply) {
+        case pcmk_pacemakerd_reply_ping:
+            return "ping";
+        case pcmk_pacemakerd_reply_shutdown:
+            return "shutdown";
+        default:
+            return "unknown";
+    }
+}
+
 // \return Standard Pacemaker return code
 static int
 new_data(pcmk_ipc_api_t *api)

--- a/lib/common/ipc_pacemakerd.c
+++ b/lib/common/ipc_pacemakerd.c
@@ -31,7 +31,8 @@ static const char *pacemakerd_state_str[] = {
     XML_PING_ATTR_PACEMAKERDSTATE_WAITPING,
     XML_PING_ATTR_PACEMAKERDSTATE_RUNNING,
     XML_PING_ATTR_PACEMAKERDSTATE_SHUTTINGDOWN,
-    XML_PING_ATTR_PACEMAKERDSTATE_SHUTDOWNCOMPLETE
+    XML_PING_ATTR_PACEMAKERDSTATE_SHUTDOWNCOMPLETE,
+    XML_PING_ATTR_PACEMAKERDSTATE_REMOTE,
 };
 
 enum pcmk_pacemakerd_state
@@ -90,6 +91,8 @@ pcmk__pcmkd_state_enum2friendly(enum pcmk_pacemakerd_state state)
              * shutdown_complete state unless reporting to SBD
              */
             return "Pacemaker daemons are shut down (reporting to SBD)";
+        case pcmk_pacemakerd_state_remote:
+            return "pacemaker-remoted is running (on a Pacemaker Remote node)";
         default:
             return "Invalid pacemakerd state";
     }

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1679,7 +1679,9 @@ stonith_api_free(stonith_t * stonith)
     crm_trace("Destroying %p", stonith);
 
     if (stonith->state != stonith_disconnected) {
-        crm_trace("Disconnecting %p first", stonith);
+        crm_trace("Unregistering notifications and disconnecting %p first",
+                  stonith);
+        stonith->cmds->remove_notification(stonith, NULL);
         rc = stonith->cmds->disconnect(stonith);
     }
 

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -56,7 +56,7 @@ validate_reply_event(data_t *data, const pcmk_ipc_api_t *api,
 {
     pcmk__output_t *out = data->out;
     bool valid_reply = false;
-    int reply_type = -1;
+    const char *reply_type = NULL;
 
     switch (event_type) {
         case pcmk_ipc_event_reply:
@@ -89,7 +89,7 @@ validate_reply_event(data_t *data, const pcmk_ipc_api_t *api,
 
                 reply = (const pcmk_controld_api_reply_t *) event_data;
                 valid_reply = (reply->reply_type == pcmk_controld_reply_ping);
-                reply_type = (int) reply->reply_type;
+                reply_type = pcmk__controld_api_reply2str(reply->reply_type);
             }
             break;
         case pcmk_ipc_pacemakerd:
@@ -98,7 +98,7 @@ validate_reply_event(data_t *data, const pcmk_ipc_api_t *api,
 
                 reply = (const pcmk_pacemakerd_api_reply_t *) event_data;
                 valid_reply = (reply->reply_type == pcmk_pacemakerd_reply_ping);
-                reply_type = (int) reply->reply_type;
+                reply_type = pcmk__pcmkd_api_reply2str(reply->reply_type);
             }
             break;
         default:
@@ -109,7 +109,7 @@ validate_reply_event(data_t *data, const pcmk_ipc_api_t *api,
     }
 
     if (!valid_reply) {
-        out->err(out, "error: Unknown reply type %d from %s",
+        out->err(out, "error: Unexpected reply type '%s' from %s",
                  reply_type, pcmk_ipc_name(api, true));
         data->rc = EBADMSG;
         return data->rc;

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -177,15 +177,28 @@ controller_status_event_cb(pcmk_ipc_api_t *controld_api,
     event_done(data, controld_api);
 }
 
+/*!
+ * \internal
+ * \brief Process a designated controller IPC event
+ *
+ * \param[in,out] controld_api  Controller connection
+ * \param[in]     event_type    Type of event that occurred
+ * \param[in]     status        Event status
+ * \param[in,out] event_data    \p pcmk_controld_api_reply_t object containing
+ *                              event-specific data
+ * \param[in,out] user_data     \p data_t object for API results and options
+ */
 static void
 designated_controller_event_cb(pcmk_ipc_api_t *controld_api,
-                    enum pcmk_ipc_event event_type, crm_exit_t status,
-                    void *event_data, void *user_data)
+                               enum pcmk_ipc_event event_type,
+                               crm_exit_t status, void *event_data,
+                               void *user_data)
 {
-    data_t *data = user_data;
+    data_t *data = (data_t *) user_data;
     pcmk__output_t *out = data->out;
     pcmk_controld_api_reply_t *reply = controld_event_reply(data, controld_api,
-        event_type, status, event_data);
+                                                            event_type, status,
+                                                            event_data);
 
     if (reply != NULL) {
         out->message(out, "dc", reply->host_from);
@@ -384,6 +397,21 @@ pcmk_controller_status(xmlNodePtr *xml, const char *node_name,
     return rc;
 }
 
+/*!
+ * \internal
+ * \brief Get and output designated controller node name
+ *
+ * \param[in,out] out                 Output object
+ * \param[in]     message_timeout_ms  How long to wait for a reply from the
+ *                                    \p pacemaker-controld API. If 0,
+ *                                    \p pcmk_ipc_dispatch_sync will be used.
+ *                                    Otherwise, \p pcmk_ipc_dispatch_main will
+ *                                    be used, and a new mainloop will be
+ *                                    created for this purpose (freed before
+ *                                    return).
+ *
+ * \return Standard Pacemaker return code
+ */
 int
 pcmk__designated_controller(pcmk__output_t *out, guint message_timeout_ms)
 {
@@ -408,7 +436,7 @@ pcmk__designated_controller(pcmk__output_t *out, guint message_timeout_ms)
     if (controld_api != NULL) {
         int rc = pcmk_controld_api_ping(controld_api, NULL);
         if (rc != pcmk_rc_ok) {
-            out->err(out, "error: Could not ping controller API: %s",
+            out->err(out, "error: Could not ping controller API on DC: %s",
                      pcmk_rc_str(rc));
             data.rc = rc;
         }
@@ -423,6 +451,7 @@ pcmk__designated_controller(pcmk__output_t *out, guint message_timeout_ms)
     return data.rc;
 }
 
+// Documented in header
 int
 pcmk_designated_controller(xmlNodePtr *xml, unsigned int message_timeout_ms)
 {

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -208,6 +208,17 @@ designated_controller_event_cb(pcmk_ipc_api_t *controld_api,
     event_done(data, controld_api);
 }
 
+/*!
+ * \internal
+ * \brief Process a \p pacemakerd status IPC event
+ *
+ * \param[in,out] pacemakerd_api  \p pacemakerd connection
+ * \param[in]     event_type      Type of event that occurred
+ * \param[in]     status          Event status
+ * \param[in,out] event_data      \p pcmk_pacemakerd_api_reply_t object
+ *                                containing event-specific data
+ * \param[in,out] user_data       \p data_t object for API results and options
+ */
 static void
 pacemakerd_event_cb(pcmk_ipc_api_t *pacemakerd_api,
                     enum pcmk_ipc_event event_type, crm_exit_t status,
@@ -239,7 +250,7 @@ pacemakerd_event_cb(pcmk_ipc_api_t *pacemakerd_api,
 
     if (status != CRM_EX_OK) {
         out->err(out, "error: Bad reply from pacemakerd: %s",
-                crm_exit_str(status));
+                 crm_exit_str(status));
         event_done(data, pacemakerd_api);
         data->rc = EBADMSG;
         return;
@@ -247,7 +258,7 @@ pacemakerd_event_cb(pcmk_ipc_api_t *pacemakerd_api,
 
     if (reply->reply_type != pcmk_pacemakerd_reply_ping) {
         out->err(out, "error: Unknown reply type %d from pacemakerd",
-                reply->reply_type);
+                 reply->reply_type);
         event_done(data, pacemakerd_api);
         data->rc = EBADMSG;
         return;
@@ -479,8 +490,8 @@ pcmk_designated_controller(xmlNodePtr *xml, unsigned int message_timeout_ms)
  * \param[in]     message_timeout_ms  How long to wait for a reply from the
  *                                    \p pacemakerd API. If 0,
  *                                    \p pcmk_ipc_dispatch_sync will be used.
- *                                    If positive, \p pcmk_ipc_dispatch_main
- *                                    will be used, and a new mainloop will be
+ *                                    Otherwise, \p pcmk_ipc_dispatch_main will
+ *                                    be used, and a new mainloop will be
  *                                    created for this purpose (freed before
  *                                    return).
  * \param[out]    state               Where to store the \p pacemakerd state, if

--- a/lib/pacemaker/pcmk_status.c
+++ b/lib/pacemaker/pcmk_status.c
@@ -239,7 +239,7 @@ pcmk__status(pcmk__output_t *out, cib_t *cib,
              enum pcmk__fence_history fence_history, uint32_t show,
              uint32_t show_opts, const char *only_node, const char *only_rsc,
              const char *neg_location_prefix, bool simple_output,
-             guint timeout_ms)
+             unsigned int timeout_ms)
 {
     xmlNode *current_cib = NULL;
     int rc = pcmk_rc_ok;

--- a/lib/pacemaker/pcmk_status.c
+++ b/lib/pacemaker/pcmk_status.c
@@ -290,19 +290,8 @@ pcmk__status(pcmk__output_t *out, cib_t *cib,
     }
 
 done:
-    if (stonith != NULL) {
-        if (stonith->state != stonith_disconnected) {
-            stonith->cmds->remove_notification(stonith, NULL);
-            stonith->cmds->disconnect(stonith);
-        }
-
-        stonith_api_delete(stonith);
-    }
-
-    if (current_cib != NULL) {
-        free_xml(current_cib);
-    }
-
+    stonith_api_delete(stonith);
+    free_xml(current_cib);
     return pcmk_rc_ok;
 }
 

--- a/lib/pacemaker/pcmk_status.c
+++ b/lib/pacemaker/pcmk_status.c
@@ -255,22 +255,17 @@ pcmk__status(pcmk__output_t *out, cib_t *cib,
         && (cib->state != cib_connected_command)) {
 
         rc = pcmk__pacemakerd_status(out, crm_system_name, timeout_ms, &state);
-        switch (rc) {
-            case pcmk_rc_ok:
-                switch (state) {
-                    case pcmk_pacemakerd_state_running:
-                    case pcmk_pacemakerd_state_shutting_down:
-                        // CIB may still be available while shutting down
-                        break;
-                    default:
-                        return rc;
-                }
-                break;
-            case EREMOTEIO:
-                /* We'll always get EREMOTEIO if we run this on a Pacemaker
-                 * Remote node. The fencer and CIB might be available.
+        if (rc != pcmk_rc_ok) {
+            return rc;
+        }
+
+        switch (state) {
+            case pcmk_pacemakerd_state_running:
+            case pcmk_pacemakerd_state_shutting_down:
+            case pcmk_pacemakerd_state_remote:
+                /* Fencer and CIB may still be available while shutting down or
+                 * running on a Pacemaker Remote node
                  */
-                rc = pcmk_rc_ok;
                 break;
             default:
                 return rc;

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -159,17 +159,16 @@ default_includes(mon_output_format_t fmt) {
         case mon_output_monitor:
         case mon_output_plain:
         case mon_output_console:
-            return pcmk_section_summary | pcmk_section_nodes | pcmk_section_resources |
-                   pcmk_section_failures;
+        case mon_output_html:
+        case mon_output_cgi:
+            return pcmk_section_summary
+                   |pcmk_section_nodes
+                   |pcmk_section_resources
+                   |pcmk_section_failures;
 
         case mon_output_xml:
         case mon_output_legacy_xml:
             return all_includes(fmt);
-
-        case mon_output_html:
-        case mon_output_cgi:
-            return pcmk_section_summary | pcmk_section_nodes | pcmk_section_resources |
-                   pcmk_section_failures;
 
         default:
             return 0;

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -132,7 +132,6 @@ struct {
     .reconnect_ms = RECONNECT_MSECS
 };
 
-static void clean_up_fencing_connection(void);
 static crm_exit_t clean_up(crm_exit_t exit_code);
 static void crm_diff_update(const char *event, xmlNode * msg);
 static void clean_up_on_connection_failure(int rc);
@@ -688,12 +687,13 @@ mon_cib_connection_destroy(gpointer user_data)
         g_source_remove(reconnect_timer);
         reconnect_timer = 0;
     }
-    if (st) {
-        /* the client API won't properly reconnect notifications
-         * if they are still in the table - so remove them
-         */
-        clean_up_fencing_connection();
-    }
+
+    /* the client API won't properly reconnect notifications if they are still
+     * in the table - so remove them
+     */
+    stonith_api_delete(st);
+    st = NULL;
+
     if (cib) {
         cib->cmds->signoff(cib);
         reconnect_timer = g_timeout_add(options.reconnect_ms,
@@ -765,7 +765,8 @@ fencing_connect(void)
             st->cmds->register_notification(st, T_STONITH_NOTIFY_HISTORY, mon_st_callback_display);
         }
     } else {
-        clean_up_fencing_connection();
+        stonith_api_delete(st);
+        st = NULL;
     }
 
     return rc;
@@ -823,7 +824,8 @@ cib_connect(void)
         if (rc != pcmk_rc_ok) {
             out->err(out, "Notification setup failed, could not monitor CIB actions");
             cib__clean_up_connection(&cib);
-            clean_up_fencing_connection();
+            stonith_api_delete(st);
+            st = NULL;
         }
     }
     return rc;
@@ -2099,22 +2101,6 @@ mon_st_callback_display(stonith_t * st, stonith_event_t * e)
     }
 }
 
-static void
-clean_up_fencing_connection(void)
-{
-    if (st == NULL) {
-        return;
-    }
-
-    if (st->state != stonith_disconnected) {
-        st->cmds->remove_notification(st, NULL);
-        st->cmds->disconnect(st);
-    }
-
-    stonith_api_delete(st);
-    st = NULL;
-}
-
 /*
  * De-init ncurses, disconnect from the CIB manager, disconnect fencing,
  * deallocate memory and show usage-message if requested.
@@ -2130,7 +2116,7 @@ clean_up(crm_exit_t exit_code)
 
     /* (1) Close connections, free things, etc. */
     cib__clean_up_connection(&cib);
-    clean_up_fencing_connection();
+    stonith_api_delete(st);
     free(options.neg_location_prefix);
     free(options.only_node);
     free(options.only_rsc);

--- a/tools/crmadmin.c
+++ b/tools/crmadmin.c
@@ -235,17 +235,19 @@ main(int argc, char **argv)
 
     switch (command) {
         case cmd_health:
-            rc = pcmk__controller_status(out, options.optarg, options.timeout);
+            rc = pcmk__controller_status(out, options.optarg,
+                                         (unsigned int) options.timeout);
             break;
         case cmd_pacemakerd_health:
-            rc = pcmk__pacemakerd_status(out, options.ipc_name, options.timeout,
-                                         NULL);
+            rc = pcmk__pacemakerd_status(out, options.ipc_name,
+                                         (unsigned int) options.timeout, NULL);
             break;
         case cmd_list_nodes:
             rc = pcmk__list_nodes(out, options.optarg, options.bash_export);
             break;
         case cmd_whois_dc:
-            rc = pcmk__designated_controller(out, options.timeout);
+            rc = pcmk__designated_controller(out,
+                                             (unsigned int) options.timeout);
             break;
         case cmd_none:
             rc = pcmk_rc_error;


### PR DESCRIPTION
My stack of commits related to the `crm_mon` disconnect stuff ([T15](https://projects.clusterlabs.org/T15)) has been growing. I realized that a bunch of them have merit on their own independent of the `crm_mon` disconnect work. I'm opening this PR now to get those reviewed and make eventual review of the rest easier.

I'm not super tied to the "Functionize reply validation" commit. It's a little bit clunky because of the need for different type casts. But it does reduce duplication, and that will be even more pronounced if we ever add more daemons to `pcmk_cluster_queries.c`.