### PR TITLE
Add support for cluster-wide sync points

### DIFF
--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -268,6 +268,7 @@ attrd_peer_change_cb(enum crm_status_type kind, crm_node_t *peer, const void *da
     // Remove votes from cluster nodes that leave, in case election in progress
     if (gone && !is_remote) {
         attrd_remove_voter(peer);
+        attrd_remove_peer_protocol_ver(peer->uname);
 
     // Ensure remote nodes that come up are in the remote node cache
     } else if (!gone && is_remote) {
@@ -395,7 +396,7 @@ attrd_peer_update_one(const crm_node_t *peer, xmlNode *xml, bool filter)
      * version, check to see if it's a new minimum version.
      */
     if (pcmk__str_eq(attr, CRM_ATTR_PROTOCOL, pcmk__str_none)) {
-        attrd_update_minimum_protocol_ver(value);
+        attrd_update_minimum_protocol_ver(peer->uname, value);
     }
 }
 

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -616,7 +616,7 @@ attrd_peer_update(const crm_node_t *peer, xmlNode *xml, const char *host,
      * point, process that now.
      */
     if (handle_sync_point) {
-        crm_debug("Hit local sync point for attribute update");
+        crm_trace("Hit local sync point for attribute update");
         attrd_ack_waitlist_clients(attrd_sync_point_local, xml);
     }
 }

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -74,7 +74,8 @@ attrd_peer_message(crm_node_t *peer, xmlNode *xml)
         /* Having finished handling the request, check to see if the originating
          * peer requested confirmation.  If so, send that confirmation back now.
          */
-        if (pcmk__xe_attr_is_true(xml, PCMK__XA_CONFIRM)) {
+        if (pcmk__xe_attr_is_true(xml, PCMK__XA_CONFIRM) &&
+            !pcmk__str_eq(request.op, PCMK__ATTRD_CMD_CONFIRM, pcmk__str_none)) {
             int callid = 0;
             xmlNode *reply = NULL;
 

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -269,6 +269,7 @@ attrd_peer_change_cb(enum crm_status_type kind, crm_node_t *peer, const void *da
     if (gone && !is_remote) {
         attrd_remove_voter(peer);
         attrd_remove_peer_protocol_ver(peer->uname);
+        attrd_do_not_expect_from_peer(peer->uname);
 
     // Ensure remote nodes that come up are in the remote node cache
     } else if (!gone && is_remote) {

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -124,7 +124,7 @@ broadcast_local_value(const attribute_t *a)
 
     crm_xml_add(sync, PCMK__XA_TASK, PCMK__ATTRD_CMD_SYNC_RESPONSE);
     attrd_add_value_xml(sync, a, v, false);
-    attrd_send_message(NULL, sync);
+    attrd_send_message(NULL, sync, false);
     free_xml(sync);
     return v;
 }
@@ -387,7 +387,7 @@ broadcast_unseen_local_values(void)
 
     if (sync != NULL) {
         crm_debug("Broadcasting local-only values");
-        attrd_send_message(NULL, sync);
+        attrd_send_message(NULL, sync, false);
         free_xml(sync);
     }
 }
@@ -539,7 +539,7 @@ attrd_peer_sync(crm_node_t *peer, xmlNode *xml)
     }
 
     crm_debug("Syncing values to %s", peer?peer->uname:"everyone");
-    attrd_send_message(peer, sync);
+    attrd_send_message(peer, sync, false);
     free_xml(sync);
 }
 

--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -254,7 +254,7 @@ attrd_client_update(pcmk__request_t *request)
      * two ways we can handle that.
      */
     if (xml_has_children(xml)) {
-        if (minimum_protocol_version >= 4) {
+        if (ATTRD_SUPPORTS_MULTI_MESSAGE(minimum_protocol_version)) {
             /* First, if all peers support a certain protocol version, we can
              * just broadcast the big message and they'll handle it.
              */

--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -105,7 +105,7 @@ attrd_client_clear_failure(pcmk__request_t *request)
         /* Propagate to all peers (including ourselves).
          * This ends up at attrd_peer_message().
          */
-        attrd_send_message(NULL, xml);
+        attrd_send_message(NULL, xml, false);
         pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
         return NULL;
     }
@@ -184,7 +184,7 @@ attrd_client_peer_remove(pcmk__request_t *request)
     if (host) {
         crm_info("Client %s is requesting all values for %s be removed",
                  pcmk__client_name(request->ipc_client), host);
-        attrd_send_message(NULL, xml); /* ends up at attrd_peer_message() */
+        attrd_send_message(NULL, xml, false); /* ends up at attrd_peer_message() */
         free(host_alloc);
     } else {
         crm_info("Ignoring request by client %s to remove all peer values without specifying peer",
@@ -258,7 +258,7 @@ attrd_client_update(pcmk__request_t *request)
             /* First, if all peers support a certain protocol version, we can
              * just broadcast the big message and they'll handle it.
              */
-            attrd_send_message(NULL, xml);
+            attrd_send_message(NULL, xml, false);
             pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
         } else {
             /* Second, if they do not support that protocol version, split it
@@ -302,7 +302,7 @@ attrd_client_update(pcmk__request_t *request)
                 if (status == 0) {
                     crm_trace("Matched %s with %s", attr, regex);
                     crm_xml_add(xml, PCMK__XA_ATTR_NAME, attr);
-                    attrd_send_message(NULL, xml);
+                    attrd_send_message(NULL, xml, false);
                 }
             }
 
@@ -362,7 +362,23 @@ attrd_client_update(pcmk__request_t *request)
 
     free(host);
 
-    attrd_send_message(NULL, xml); /* ends up at attrd_peer_message() */
+    if (pcmk__str_eq(attrd_request_sync_point(xml), PCMK__VALUE_CLUSTER, pcmk__str_none)) {
+        /* The client is waiting on the cluster-wide sync point.  In this case,
+         * the response ACK is not sent until this attrd broadcasts the update
+         * and receives its own confirmation back from all peers.
+         */
+        attrd_send_message(NULL, xml, true); /* ends up at attrd_peer_message() */
+
+    } else {
+        /* The client is either waiting on the local sync point or was not
+         * waiting on any sync point at all.  For the local sync point, the
+         * response ACK is sent in attrd_peer_update.  For clients not
+         * waiting on any sync point, the response ACK is sent in
+         * handle_update_request immediately before this function was called.
+         */
+        attrd_send_message(NULL, xml, false); /* ends up at attrd_peer_message() */
+    }
+
     pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
     return NULL;
 }

--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -367,6 +367,7 @@ attrd_client_update(pcmk__request_t *request)
          * the response ACK is not sent until this attrd broadcasts the update
          * and receives its own confirmation back from all peers.
          */
+        attrd_expect_confirmations(request, attrd_cluster_sync_point_update);
         attrd_send_message(NULL, xml, true); /* ends up at attrd_peer_message() */
 
     } else {
@@ -429,6 +430,9 @@ attrd_ipc_closed(qb_ipcs_connection_t *c)
 
         /* Remove the client from the sync point waitlist if it's present. */
         attrd_remove_client_from_waitlist(client);
+
+        /* And no longer wait for confirmations from any peers. */
+        attrd_do_not_wait_for_client(client);
 
         pcmk__free_client(client);
     }

--- a/daemons/attrd/attrd_messages.c
+++ b/daemons/attrd/attrd_messages.c
@@ -310,6 +310,8 @@ attrd_broadcast_protocol(void)
 gboolean
 attrd_send_message(crm_node_t *node, xmlNode *data, bool confirm)
 {
+    const char *op = crm_element_value(data, PCMK__XA_TASK);
+
     crm_xml_add(data, F_TYPE, T_ATTRD);
     crm_xml_add(data, PCMK__XA_ATTR_VERSION, ATTRD_PROTOCOL_VERSION);
 
@@ -317,7 +319,9 @@ attrd_send_message(crm_node_t *node, xmlNode *data, bool confirm)
      * be all if node is NULL) that the message has been received and
      * acted upon.
      */
-    pcmk__xe_set_bool_attr(data, PCMK__XA_CONFIRM, confirm);
+    if (!pcmk__str_eq(op, PCMK__ATTRD_CMD_CONFIRM, pcmk__str_none)) {
+        pcmk__xe_set_bool_attr(data, PCMK__XA_CONFIRM, confirm);
+    }
 
     attrd_xml_add_writer(data);
     return send_cluster_message(node, crm_msg_attrd, data, TRUE);

--- a/daemons/attrd/attrd_messages.c
+++ b/daemons/attrd/attrd_messages.c
@@ -279,16 +279,23 @@ attrd_broadcast_protocol(void)
     crm_debug("Broadcasting attrd protocol version %s for node %s",
               ATTRD_PROTOCOL_VERSION, attrd_cluster->uname);
 
-    attrd_send_message(NULL, attrd_op); /* ends up at attrd_peer_message() */
+    attrd_send_message(NULL, attrd_op, false); /* ends up at attrd_peer_message() */
 
     free_xml(attrd_op);
 }
 
 gboolean
-attrd_send_message(crm_node_t * node, xmlNode * data)
+attrd_send_message(crm_node_t *node, xmlNode *data, bool confirm)
 {
     crm_xml_add(data, F_TYPE, T_ATTRD);
     crm_xml_add(data, PCMK__XA_ATTR_VERSION, ATTRD_PROTOCOL_VERSION);
+
+    /* Request a confirmation from the destination peer node (which could
+     * be all if node is NULL) that the message has been received and
+     * acted upon.
+     */
+    pcmk__xe_set_bool_attr(data, PCMK__XA_CONFIRM, confirm);
+
     attrd_xml_add_writer(data);
     return send_cluster_message(node, crm_msg_attrd, data, TRUE);
 }

--- a/daemons/attrd/attrd_messages.c
+++ b/daemons/attrd/attrd_messages.c
@@ -66,6 +66,18 @@ handle_clear_failure_request(pcmk__request_t *request)
 }
 
 static xmlNode *
+handle_confirm_request(pcmk__request_t *request)
+{
+    if (request->peer != NULL) {
+        crm_debug("Received confirmation from %s", request->peer);
+        pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
+        return NULL;
+    } else {
+        return handle_unknown_request(request);
+    }
+}
+
+static xmlNode *
 handle_flush_request(pcmk__request_t *request)
 {
     if (request->peer != NULL) {
@@ -190,6 +202,7 @@ attrd_register_handlers(void)
 {
     pcmk__server_command_t handlers[] = {
         { PCMK__ATTRD_CMD_CLEAR_FAILURE, handle_clear_failure_request },
+        { PCMK__ATTRD_CMD_CONFIRM, handle_confirm_request },
         { PCMK__ATTRD_CMD_FLUSH, handle_flush_request },
         { PCMK__ATTRD_CMD_PEER_REMOVE, handle_remove_request },
         { PCMK__ATTRD_CMD_QUERY, handle_query_request },

--- a/daemons/attrd/attrd_messages.c
+++ b/daemons/attrd/attrd_messages.c
@@ -69,7 +69,17 @@ static xmlNode *
 handle_confirm_request(pcmk__request_t *request)
 {
     if (request->peer != NULL) {
+        int callid;
+
         crm_debug("Received confirmation from %s", request->peer);
+
+        if (crm_element_value_int(request->xml, XML_LRM_ATTR_CALLID, &callid) == -1) {
+            pcmk__set_result(&request->result, CRM_EX_PROTOCOL, PCMK_EXEC_INVALID,
+                             "Could not get callid from XML");
+        } else {
+            attrd_handle_confirmation(callid, request->peer);
+        }
+
         pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
         return NULL;
     } else {

--- a/daemons/attrd/attrd_sync.c
+++ b/daemons/attrd/attrd_sync.c
@@ -444,7 +444,7 @@ attrd_expect_confirmations(pcmk__request_t *request, attrd_confirmation_action_f
 
     g_hash_table_iter_init(&iter, peer_protocol_vers);
     while (g_hash_table_iter_next(&iter, &host, &ver)) {
-        if (GPOINTER_TO_INT(ver) >= 5) {
+        if (ATTRD_SUPPORTS_CONFIRMATION(GPOINTER_TO_INT(ver))) {
             char *s = strdup((char *) host);
 
             CRM_ASSERT(s != NULL);

--- a/daemons/attrd/attrd_sync.c
+++ b/daemons/attrd/attrd_sync.c
@@ -210,7 +210,7 @@ attrd_remove_client_from_waitlist(pcmk__client_t *client)
     while (g_hash_table_iter_next(&iter, NULL, &value)) {
         struct waitlist_node *wl = (struct waitlist_node *) value;
 
-        if (wl->client_id == client->id) {
+        if (pcmk__str_eq(wl->client_id, client->id, pcmk__str_none)) {
             g_hash_table_iter_remove(&iter);
             crm_trace("%d clients now on waitlist", g_hash_table_size(waitlist));
         }

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -99,6 +99,8 @@ attrd_shutdown(int nsig)
     mainloop_destroy_signal(SIGTRAP);
 
     attrd_free_waitlist();
+    attrd_free_confirmations();
+
     if (peer_protocol_vers != NULL) {
         g_hash_table_destroy(peer_protocol_vers);
         peer_protocol_vers = NULL;

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -191,8 +191,16 @@ enum attrd_sync_point {
     attrd_sync_point_cluster,
 };
 
+typedef int (*attrd_confirmation_action_fn)(xmlNode *);
+
 void attrd_add_client_to_waitlist(pcmk__request_t *request);
 void attrd_ack_waitlist_clients(enum attrd_sync_point sync_point, const xmlNode *xml);
+int attrd_cluster_sync_point_update(xmlNode *xml);
+void attrd_do_not_expect_from_peer(const char *host);
+void attrd_do_not_wait_for_client(pcmk__client_t *client);
+void attrd_expect_confirmations(pcmk__request_t *request, attrd_confirmation_action_fn fn);
+void attrd_free_confirmations(void);
+void attrd_handle_confirmation(int callid, const char *host);
 void attrd_remove_client_from_waitlist(pcmk__client_t *client);
 const char *attrd_request_sync_point(xmlNode *xml);
 bool attrd_request_has_sync_point(xmlNode *xml);

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -39,10 +39,11 @@
  *                      PCMK__ATTRD_CMD_UPDATE_DELAY
  *     2       1.1.17   PCMK__ATTRD_CMD_CLEAR_FAILURE
  *     3       2.1.1    PCMK__ATTRD_CMD_SYNC_RESPONSE indicates remote nodes
- *     4       2.2.0    Multiple attributes can be updated in a single IPC
+ *     4       2.1.5    Multiple attributes can be updated in a single IPC
  *                      message
+ *     5       2.1.5    Peers can request confirmation of a sent message
  */
-#define ATTRD_PROTOCOL_VERSION "4"
+#define ATTRD_PROTOCOL_VERSION "5"
 
 #define attrd_send_ack(client, id, flags) \
     pcmk__ipc_send_ack((client), (id), (flags), "ack", ATTRD_PROTOCOL_VERSION, CRM_EX_INDETERMINATE)
@@ -162,7 +163,7 @@ xmlNode *attrd_client_clear_failure(pcmk__request_t *request);
 xmlNode *attrd_client_update(pcmk__request_t *request);
 xmlNode *attrd_client_refresh(pcmk__request_t *request);
 xmlNode *attrd_client_query(pcmk__request_t *request);
-gboolean attrd_send_message(crm_node_t * node, xmlNode * data);
+gboolean attrd_send_message(crm_node_t *node, xmlNode *data, bool confirm);
 
 xmlNode *attrd_add_value_xml(xmlNode *parent, const attribute_t *a,
                              const attribute_value_t *v, bool force_write);

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -145,6 +145,7 @@ typedef struct attribute_value_s {
 
 extern crm_cluster_t *attrd_cluster;
 extern GHashTable *attributes;
+extern GHashTable *peer_protocol_vers;
 
 #define CIB_OP_TIMEOUT_S 120
 
@@ -177,7 +178,8 @@ void attrd_write_attributes(bool all, bool ignore_delay);
 void attrd_write_or_elect_attribute(attribute_t *a);
 
 extern int minimum_protocol_version;
-void attrd_update_minimum_protocol_ver(const char *value);
+void attrd_remove_peer_protocol_ver(const char *host);
+void attrd_update_minimum_protocol_ver(const char *host, const char *value);
 
 mainloop_timer_t *attrd_add_timer(const char *id, int timeout_ms, attribute_t *attr);
 

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -45,6 +45,9 @@
  */
 #define ATTRD_PROTOCOL_VERSION "5"
 
+#define ATTRD_SUPPORTS_MULTI_MESSAGE(x) ((x) >= 4)
+#define ATTRD_SUPPORTS_CONFIRMATION(x)  ((x) >= 5)
+
 #define attrd_send_ack(client, id, flags) \
     pcmk__ipc_send_ack((client), (id), (flags), "ack", ATTRD_PROTOCOL_VERSION, CRM_EX_INDETERMINATE)
 

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -79,6 +79,7 @@
 #define PCMK__XA_ATTR_WRITER            "attr_writer"
 #define PCMK__XA_CONFIG_ERRORS          "config-errors"
 #define PCMK__XA_CONFIG_WARNINGS        "config-warnings"
+#define PCMK__XA_CONFIRM                "confirm"
 #define PCMK__XA_GRAPH_ERRORS           "graph-errors"
 #define PCMK__XA_GRAPH_WARNINGS         "graph-warnings"
 #define PCMK__XA_MODE                   "mode"

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -108,6 +108,7 @@
 #define PCMK__ATTRD_CMD_SYNC            "sync"
 #define PCMK__ATTRD_CMD_SYNC_RESPONSE   "sync-response"
 #define PCMK__ATTRD_CMD_CLEAR_FAILURE   "clear-failure"
+#define PCMK__ATTRD_CMD_CONFIRM         "confirm"
 
 #define PCMK__CONTROLD_CMD_NODES        "list-nodes"
 

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -106,6 +106,10 @@ wait_cb (const gchar *option_name, const gchar *optarg, gpointer data, GError **
         pcmk__clear_node_attr_flags(options.attr_options, pcmk__node_attr_sync_local | pcmk__node_attr_sync_cluster);
         pcmk__set_node_attr_flags(options.attr_options, pcmk__node_attr_sync_local);
         return TRUE;
+    } else if (pcmk__str_eq(optarg, PCMK__VALUE_CLUSTER, pcmk__str_none)) {
+        pcmk__clear_node_attr_flags(options.attr_options, pcmk__node_attr_sync_local | pcmk__node_attr_sync_cluster);
+        pcmk__set_node_attr_flags(options.attr_options, pcmk__node_attr_sync_cluster);
+        return TRUE;
     } else {
         g_set_error(err, PCMK__EXITC_ERROR, CRM_EX_USAGE,
                     "--wait= must be one of 'no', 'local', 'cluster'");
@@ -193,10 +197,12 @@ static GOptionEntry addl_entries[] = {
 
     { "wait", 'W', 0, G_OPTION_ARG_CALLBACK, wait_cb,
       "Wait for some event to occur before returning.  Values are 'no' (wait\n"
-      INDENT "only for the attribute daemon to acknowledge the request) or\n"
+      INDENT "only for the attribute daemon to acknowledge the request),\n"
       INDENT "'local' (wait until the change has propagated to where a local\n"
       INDENT "query will return the request value, or the value set by a\n"
-      INDENT "later request).  Default is 'no'.",
+      INDENT "later request), or 'cluster' (wait until the change has propagated\n"
+      INDENT "to where a query anywhere on the cluster will return the requested\n"
+      INDENT "value, or the value set by a later request).  Default is 'no'.",
       "UNTIL" },
 
     { NULL }


### PR DESCRIPTION
I have some outstanding questions on this, however:

* [x] See the FIXME in attrd_peer_message - do I need to take dampening into account there?
* [x] I am taking nodes leaving the cluster into consideration when looking at each peer's protocol version, but not nodes being added to the cluster.  Is that something I need to look at?
* [ ] Is there the potential for two things to try to access a single attrd's peer_protocol_vers and expected_confirmations hash tables at the same time?  If so, I'll need to consider locking.
* [X] I think there's a problem where if a timeout is reached (like, a peer doesn't get around to confirming the request) the client will sit on the waitlist forever.  I haven't tested this though.