### PR TITLE
Clean up pcmk__status() and display pcmkd state only if we can't get the CIB

### DIFF
--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -457,9 +457,8 @@ generate_params(void)
     }
 
     // Retrieve and update CIB
-    rc = cib__signon_query(NULL, &cib_xml_copy);
+    rc = cib__signon_query(NULL, NULL, &cib_xml_copy);
     if (rc != pcmk_rc_ok) {
-        crm_err("CIB query failed: %s", pcmk_rc_str(rc));
         return rc;
     }
     if (!cli_config_update(&cib_xml_copy, NULL, FALSE)) {

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -238,17 +238,22 @@ cib_callback_client_t* cib__lookup_id (int call_id);
 
 /*!
  * \internal
- * \brief Connect to, query, and optionally disconnect from the CIB, returning
- *        the resulting XML object.
+ * \brief Connect to, query, and optionally disconnect from the CIB
  *
- * \param[out] cib        If non-NULL, a pointer to where to store the CIB
- *                        connection.  In this case, it is up to the caller to
- *                        disconnect from the CIB when finished.
- * \param[out] cib_object A pointer to where to store the XML query result.
+ * Open a read-write connection to the CIB manager. Then query the CIB and store
+ * the resulting XML. Finally, disconnect if the new CIB connection isn't being
+ * returned to the caller.
  *
- * \return A standard Pacemaker return code
+ * \param[in,out] out         Output object (may be \p NULL)
+ * \param[out]    cib         If not \p NULL, where to store CIB connection
+ * \param[out]    cib_object  Where to store query result
+ *
+ * \return Standard Pacemaker return code
+ *
+ * \note If \p cib is not \p NULL, the caller is responsible for freeing \p *cib
+ *       using \p cib_delete().
  */
-int cib__signon_query(cib_t **cib, xmlNode **cib_object);
+int cib__signon_query(pcmk__output_t *out, cib_t **cib, xmlNode **cib_object);
 
 int cib__clean_up_connection(cib_t **cib);
 

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -240,18 +240,22 @@ cib_callback_client_t* cib__lookup_id (int call_id);
  * \internal
  * \brief Connect to, query, and optionally disconnect from the CIB
  *
- * Open a read-write connection to the CIB manager. Then query the CIB and store
- * the resulting XML. Finally, disconnect if the new CIB connection isn't being
- * returned to the caller.
+ * Open a read-write connection to the CIB manager if an already connected
+ * client is not passed in. Then query the CIB and store the resulting XML.
+ * Finally, disconnect if the CIB connection isn't being returned to the caller.
  *
  * \param[in,out] out         Output object (may be \p NULL)
- * \param[out]    cib         If not \p NULL, where to store CIB connection
+ * \param[in,out] cib         If not \p NULL, where to store CIB connection
  * \param[out]    cib_object  Where to store query result
  *
  * \return Standard Pacemaker return code
  *
  * \note If \p cib is not \p NULL, the caller is responsible for freeing \p *cib
  *       using \p cib_delete().
+ * \note If \p *cib points to an existing \p cib_t object, this function will
+ *       reuse it instead of creating a new one. If the existing client is
+ *       already connected, the connection will be reused, even if it's
+ *       read-only.
  */
 int cib__signon_query(pcmk__output_t *out, cib_t **cib, xmlNode **cib_object);
 

--- a/include/crm/common/iso8601_internal.h
+++ b/include/crm/common/iso8601_internal.h
@@ -26,6 +26,7 @@ void pcmk__time_hr_free(pcmk__time_hr_t *hr_dt);
 char *pcmk__time_format_hr(const char *format, const pcmk__time_hr_t *hr_dt);
 const char *pcmk__epoch2str(const time_t *when);
 const char *pcmk__readable_interval(guint interval_ms);
+crm_time_t *pcmk__copy_timet(time_t source);
 
 struct pcmk__time_us {
     int years;

--- a/include/crm/common/iso8601_internal.h
+++ b/include/crm/common/iso8601_internal.h
@@ -24,7 +24,7 @@ pcmk__time_hr_t *pcmk__time_hr_now(time_t *epoch);
 pcmk__time_hr_t *pcmk__time_hr_new(const char *date_time);
 void pcmk__time_hr_free(pcmk__time_hr_t *hr_dt);
 char *pcmk__time_format_hr(const char *format, const pcmk__time_hr_t *hr_dt);
-const char *pcmk__epoch2str(const time_t *when);
+char *pcmk__epoch2str(const time_t *source, uint32_t flags);
 const char *pcmk__readable_interval(guint interval_ms);
 crm_time_t *pcmk__copy_timet(time_t source);
 

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -378,6 +378,26 @@ struct pcmk__output_s {
 
     /*!
      * \internal
+     * \brief Like \p info() but for messages that should appear only
+     *        transiently. Not all formatters will do this.
+     *
+     * The originally envisioned use case is for console output, where a
+     * transient status-related message may be quickly overwritten by a refresh.
+     *
+     * \param[in,out] out     The output functions structure.
+     * \param[in]     format  The format string of the message to be printed.
+     * \param[in]     ...     Arguments to be formatted.
+     *
+     * \return A standard Pacemaker return code. Generally: \p pcmk_rc_ok if
+     *         output was produced and \p pcmk_rc_no_output if it was not. As
+     *         not all formatters implement this function, those that do not
+     *         will always just return \p pcmk_rc_no_output.
+     */
+    int (*transient) (pcmk__output_t *out, const char *format, ...)
+        G_GNUC_PRINTF(2, 3);
+
+    /*!
+     * \internal
      * \brief Format an error message that should be shown to an interactive
      *        user.  Not all formatters will do this.
      *

--- a/include/pcmki/pcmki_cluster_queries.h
+++ b/include/pcmki/pcmki_cluster_queries.h
@@ -22,7 +22,7 @@ int pcmk__controller_status(pcmk__output_t *out, const char *node_name,
 int pcmk__designated_controller(pcmk__output_t *out,
                                 unsigned int message_timeout_ms);
 int pcmk__pacemakerd_status(pcmk__output_t *out, const char *ipc_name,
-                            unsigned int message_timeout_ms,
+                            unsigned int message_timeout_ms, bool show_output,
                             enum pcmk_pacemakerd_state *state);
 int pcmk__list_nodes(pcmk__output_t *out, char *node_types, gboolean bash_export);
 

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -734,7 +734,9 @@ cib__signon_query(pcmk__output_t *out, cib_t **cib, xmlNode **cib_object)
     if (cib == NULL) {
         cib_conn = cib_new();
     } else {
-        *cib = cib_new();
+        if (*cib == NULL) {
+            *cib = cib_new();
+        }
         cib_conn = *cib;
     }
 
@@ -742,8 +744,10 @@ cib__signon_query(pcmk__output_t *out, cib_t **cib, xmlNode **cib_object)
         return ENOMEM;
     }
 
-    rc = cib_conn->cmds->signon(cib_conn, crm_system_name, cib_command);
-    rc = pcmk_legacy2rc(rc);
+    if (cib_conn->state == cib_disconnected) {
+        rc = cib_conn->cmds->signon(cib_conn, crm_system_name, cib_command);
+        rc = pcmk_legacy2rc(rc);
+    }
 
     if (rc != pcmk_rc_ok) {
         log_signon_query_err(out, "Could not connect to the CIB: %s",

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -715,8 +715,16 @@ cib_apply_patch_event(xmlNode *event, xmlNode *input, xmlNode **output,
     return rc;
 }
 
+#define log_signon_query_err(out, fmt, args...) do {    \
+        if (out != NULL) {                              \
+            out->err(out, fmt, ##args);                 \
+        } else {                                        \
+            crm_err(fmt, ##args);                       \
+        }                                               \
+    } while (0)
+
 int
-cib__signon_query(cib_t **cib, xmlNode **cib_object)
+cib__signon_query(pcmk__output_t *out, cib_t **cib, xmlNode **cib_object)
 {
     int rc = pcmk_rc_ok;
     cib_t *cib_conn = NULL;
@@ -737,11 +745,24 @@ cib__signon_query(cib_t **cib, xmlNode **cib_object)
     rc = cib_conn->cmds->signon(cib_conn, crm_system_name, cib_command);
     rc = pcmk_legacy2rc(rc);
 
-    if (rc == pcmk_rc_ok) {
-        rc = cib_conn->cmds->query(cib_conn, NULL, cib_object, cib_scope_local | cib_sync_call);
-        rc = pcmk_legacy2rc(rc);
+    if (rc != pcmk_rc_ok) {
+        log_signon_query_err(out, "Could not connect to the CIB: %s",
+                             pcmk_rc_str(rc));
+        goto done;
     }
 
+    if (out != NULL) {
+        out->transient(out, "Querying CIB...");
+    }
+    rc = cib_conn->cmds->query(cib_conn, NULL, cib_object,
+                               cib_scope_local|cib_sync_call);
+    rc = pcmk_legacy2rc(rc);
+
+    if (rc != pcmk_rc_ok) {
+        log_signon_query_err(out, "CIB query failed: %s", pcmk_rc_str(rc));
+    }
+
+done:
     if (cib == NULL) {
         cib__clean_up_connection(&cib_conn);
     }

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1726,38 +1726,37 @@ pcmk__time_format_hr(const char *format, const pcmk__time_hr_t *hr_dt)
 
 /*!
  * \internal
- * \brief Return human-friendly string corresponding to a time
+ * \brief Return a human-friendly string corresponding to an epoch time value
  *
- * \param[in] when   Pointer to epoch time value (or NULL for current time)
+ * \param[in]  source  Pointer to epoch time value (or \p NULL for current time)
+ * \param[in]  flags   Group of \p crm_time_* flags controlling display format
+ *                     format (0 to use \p ctime() with newline removed)
  *
- * \return Current time as string (as by ctime() but without newline) on
- *         success, NULL otherwise
- * \note The return value points to a statically allocated string which might be
- *       overwritten by subsequent calls to any of the C library date and time
- *       functions.
+ * \return String representation of \p source on success (may be empty depending
+ *         on \p flags; guaranteed not to be \p NULL)
+ *
+ * \note The caller is responsible for freeing the return value using \p free().
  */
-const char *
-pcmk__epoch2str(const time_t *when)
+char *
+pcmk__epoch2str(const time_t *source, uint32_t flags)
 {
-    char *since_epoch = NULL;
+    time_t epoch_time = (source == NULL)? time(NULL) : *source;
+    char *result = NULL;
 
-    if (when == NULL) {
-        time_t a_time = time(NULL);
+    if (flags == 0) {
+        const char *buf = pcmk__trim(ctime(&epoch_time));
 
-        if (a_time == (time_t) -1) {
-            return NULL;
-        } else {
-            since_epoch = ctime(&a_time);
+        if (buf != NULL) {
+            result = strdup(buf);
+            CRM_ASSERT(result != NULL);
         }
     } else {
-        since_epoch = ctime(when);
-    }
+        crm_time_t dt;
 
-    if (since_epoch == NULL) {
-        return NULL;
-    } else {
-        return pcmk__trim(since_epoch);
+        crm_time_set_timet(&dt, &epoch_time);
+        result = crm_time_as_string(&dt, flags);
     }
+    return result;
 }
 
 /*!

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -91,18 +91,11 @@ crm_get_utc_time(const crm_time_t *dt)
 crm_time_t *
 crm_time_new(const char *date_time)
 {
-    time_t tm_now;
-    crm_time_t *dt = NULL;
-
     tzset();
     if (date_time == NULL) {
-        tm_now = time(NULL);
-        dt = crm_time_new_undefined();
-        crm_time_set_timet(dt, &tm_now);
-    } else {
-        dt = parse_date(date_time);
+        return pcmk__copy_timet(time(NULL));
     }
-    return dt;
+    return parse_date(date_time);
 }
 
 /*!
@@ -1267,6 +1260,23 @@ pcmk_copy_time(const crm_time_t *source)
     crm_time_t *target = crm_time_new_undefined();
 
     crm_time_set(target, source);
+    return target;
+}
+
+/*!
+ * \internal
+ * \brief Convert a \p time_t time to a \p crm_time_t time
+ *
+ * \param[in] source  Time to convert
+ *
+ * \return A \p crm_time_t object representing \p source
+ */
+crm_time_t *
+pcmk__copy_timet(time_t source)
+{
+    crm_time_t *target = crm_time_new_undefined();
+
+    crm_time_set_timet(target, &source);
     return target;
 }
 

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -302,9 +302,11 @@ pcmk__format_nvpair(const char *name, const char *value, const char *units)
 char *
 pcmk__format_named_time(const char *name, time_t epoch_time)
 {
-    const char *now_str = pcmk__epoch2str(&epoch_time);
+    char *now_s = pcmk__epoch2str(&epoch_time, 0);
+    char *result = crm_strdup_printf("%s=\"%s\"", name, pcmk__s(now_s, ""));
 
-    return crm_strdup_printf("%s=\"%s\"", name, now_str ? now_str : "");
+    free(now_s);
+    return result;
 }
 
 // XML attribute handling

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -413,6 +413,7 @@ pcmk__mk_html_output(char **argv) {
     retval->subprocess_output = html_subprocess_output;
     retval->version = html_version;
     retval->info = html_info;
+    retval->transient = html_info;
     retval->err = html_err;
     retval->output_xml = html_output_xml;
 

--- a/lib/common/output_log.c
+++ b/lib/common/output_log.c
@@ -248,6 +248,29 @@ log_info(pcmk__output_t *out, const char *format, ...) {
     return pcmk_rc_ok;
 }
 
+G_GNUC_PRINTF(2, 3)
+static int
+log_transient(pcmk__output_t *out, const char *format, ...)
+{
+    private_data_t *priv = NULL;
+    int len = 0;
+    va_list ap;
+    char *buffer = NULL;
+
+    CRM_ASSERT(out != NULL && out->priv != NULL);
+    priv = out->priv;
+
+    va_start(ap, format);
+    len = vasprintf(&buffer, format, ap);
+    CRM_ASSERT(len >= 0);
+    va_end(ap);
+
+    do_crm_log(QB_MAX(priv->log_level, LOG_DEBUG), "%s", buffer);
+
+    free(buffer);
+    return pcmk_rc_ok;
+}
+
 static bool
 log_is_quiet(pcmk__output_t *out) {
     return false;
@@ -290,6 +313,7 @@ pcmk__mk_log_output(char **argv) {
     retval->subprocess_output = log_subprocess_output;
     retval->version = log_version;
     retval->info = log_info;
+    retval->transient = log_transient;
     retval->err = log_err;
     retval->output_xml = log_output_xml;
 

--- a/lib/common/output_none.c
+++ b/lib/common/output_none.c
@@ -134,6 +134,7 @@ pcmk__mk_none_output(char **argv) {
     retval->subprocess_output = none_subprocess_output;
     retval->version = none_version;
     retval->info = none_info;
+    retval->transient = none_info;
     retval->err = none_err;
     retval->output_xml = none_output_xml;
 

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -166,6 +166,13 @@ text_info(pcmk__output_t *out, const char *format, ...) {
     return pcmk_rc_ok;
 }
 
+G_GNUC_PRINTF(2, 3)
+static int
+text_transient(pcmk__output_t *out, const char *format, ...)
+{
+    return pcmk_rc_no_output;
+}
+
 static void
 text_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
     CRM_ASSERT(out != NULL);
@@ -312,6 +319,7 @@ pcmk__mk_text_output(char **argv) {
     retval->subprocess_output = text_subprocess_output;
     retval->version = text_version;
     retval->info = text_info;
+    retval->transient = text_transient;
     retval->err = text_err;
     retval->output_xml = text_output_xml;
 

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -418,6 +418,7 @@ pcmk__mk_xml_output(char **argv) {
     retval->subprocess_output = xml_subprocess_output;
     retval->version = xml_version;
     retval->info = xml_info;
+    retval->transient = xml_info;
     retval->err = xml_err;
     retval->output_xml = xml_output_xml;
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1177,10 +1177,13 @@ filename2xml(const char *filename)
 const char *
 pcmk__xe_add_last_written(xmlNode *xe)
 {
-    const char *now_str = pcmk__epoch2str(NULL);
+    char *now_s = pcmk__epoch2str(NULL, 0);
+    const char *result = NULL;
 
-    return crm_xml_add(xe, XML_CIB_ATTR_WRITTEN,
-                       now_str ? now_str : "Could not determine current time");
+    result = crm_xml_add(xe, XML_CIB_ATTR_WRITTEN,
+                         pcmk__s(now_s, "Could not determine current time"));
+    free(now_s);
+    return result;
 }
 
 /*!

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -24,11 +24,12 @@
 
 static char *
 time_t_string(time_t when) {
-    crm_time_t *crm_when = crm_time_new(NULL);
-    char *buf = NULL;
+    crm_time_t *crm_when = pcmk__copy_timet(when);
+    char *buf = crm_time_as_string(crm_when,
+                                   crm_time_log_date
+                                   |crm_time_log_timeofday
+                                   |crm_time_log_with_timezone);
 
-    crm_time_set_timet(crm_when, &when);
-    buf = crm_time_as_string(crm_when, crm_time_log_date | crm_time_log_timeofday | crm_time_log_with_timezone);
     crm_time_free(crm_when);
     return buf;
 }

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -542,15 +542,13 @@ pcmk__pacemakerd_status(pcmk__output_t *out, const char *ipc_name,
     } else if ((data.pcmkd_state == pcmk_pacemakerd_state_remote)
                && show_output) {
         // No API connection so the callback wasn't run
-        crm_time_t *when = crm_time_new(NULL);
-        char *when_s = crm_time_as_string(when,
-                                          crm_time_log_date
-                                          |crm_time_log_timeofday
-                                          |crm_time_log_with_timezone);
+        char *when_s = pcmk__epoch2str(NULL,
+                                       crm_time_log_date
+                                       |crm_time_log_timeofday
+                                       |crm_time_log_with_timezone);
 
         out->message(out, "pacemakerd-health",
                      "pacemaker-remoted", data.pcmkd_state, NULL, when_s);
-        crm_time_free(when);
         free(when_s);
     }
 

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -604,7 +604,7 @@ pcmk__list_nodes(pcmk__output_t *out, char *node_types, gboolean bash_export)
     xmlNode *xml_node = NULL;
     int rc;
 
-    rc = cib__signon_query(NULL, &xml_node);
+    rc = cib__signon_query(out, NULL, &xml_node);
 
     if (rc == pcmk_rc_ok) {
         struct node_data data = {

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -218,14 +218,11 @@ pacemakerd_event_cb(pcmk_ipc_api_t *pacemakerd_api,
     }
 
     if (reply->data.ping.status == pcmk_rc_ok) {
-        crm_time_t *when = crm_time_new_undefined();
-        char *when_s = NULL;
-
-        crm_time_set_timet(when, &reply->data.ping.last_good);
-        when_s = crm_time_as_string(when,
-                                    crm_time_log_date
-                                    |crm_time_log_timeofday
-                                    |crm_time_log_with_timezone);
+        crm_time_t *when = pcmk__copy_timet(reply->data.ping.last_good);
+        char *when_s = crm_time_as_string(when,
+                                          crm_time_log_date
+                                          |crm_time_log_timeofday
+                                          |crm_time_log_with_timezone);
 
         out->message(out, "pacemakerd-health",
                      reply->data.ping.sys_from, reply->data.ping.state, NULL,

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -218,23 +218,13 @@ pacemakerd_event_cb(pcmk_ipc_api_t *pacemakerd_api,
     }
 
     if (reply->data.ping.status == pcmk_rc_ok) {
-        crm_time_t *when = pcmk__copy_timet(reply->data.ping.last_good);
-        char *when_s = crm_time_as_string(when,
-                                          crm_time_log_date
-                                          |crm_time_log_timeofday
-                                          |crm_time_log_with_timezone);
-
         out->message(out, "pacemakerd-health",
                      reply->data.ping.sys_from, reply->data.ping.state, NULL,
-                     when_s);
-
-        crm_time_free(when);
-        free(when_s);
-
+                     reply->data.ping.last_good);
     } else {
         out->message(out, "pacemakerd-health",
                      reply->data.ping.sys_from, reply->data.ping.state,
-                     "query failed", NULL);
+                     "query failed", time(NULL));
     }
 }
 
@@ -542,14 +532,8 @@ pcmk__pacemakerd_status(pcmk__output_t *out, const char *ipc_name,
     } else if ((data.pcmkd_state == pcmk_pacemakerd_state_remote)
                && show_output) {
         // No API connection so the callback wasn't run
-        char *when_s = pcmk__epoch2str(NULL,
-                                       crm_time_log_date
-                                       |crm_time_log_timeofday
-                                       |crm_time_log_with_timezone);
-
         out->message(out, "pacemakerd-health",
-                     "pacemaker-remoted", data.pcmkd_state, NULL, when_s);
-        free(when_s);
+                     NULL, data.pcmkd_state, NULL, time(NULL));
     }
 
     if (state != NULL) {

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -585,7 +585,7 @@ pcmk__get_fencing_history(stonith_t *st, stonith_history_t **stonith_history,
 {
     int rc = pcmk_rc_ok;
 
-    if (st == NULL) {
+    if ((st == NULL) || (st->state == stonith_disconnected)) {
         rc = ENOTCONN;
     } else if (fence_history != pcmk__fence_history_none) {
         rc = st->cmds->history(st, st_opt_sync_call, NULL, stonith_history, 120);

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -648,7 +648,7 @@ health_xml(pcmk__output_t *out, va_list args)
 }
 
 PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
-                  "const char *")
+                  "long long")
 static int
 pacemakerd_health(pcmk__output_t *out, va_list args)
 {
@@ -656,18 +656,40 @@ pacemakerd_health(pcmk__output_t *out, va_list args)
     enum pcmk_pacemakerd_state state =
         (enum pcmk_pacemakerd_state) va_arg(args, int);
     const char *state_s = va_arg(args, const char *);
-    const char *last_updated = va_arg(args, const char *);
+    time_t last_updated = (time_t) va_arg(args, long long);
+
+    char *last_updated_s = NULL;
+    int rc = pcmk_rc_ok;
+
+    if (sys_from == NULL) {
+        if (state == pcmk_pacemakerd_state_remote) {
+            sys_from = "pacemaker-remoted";
+        } else {
+            sys_from = CRM_SYSTEM_MCP;
+        }
+    }
 
     if (state_s == NULL) {
         state_s = pcmk__pcmkd_state_enum2friendly(state);
     }
-    return out->info(out, "Status of %s: '%s' (last updated %s)",
-                     pcmk__s(sys_from, "unknown subsystem"), state_s,
-                     pcmk__s(last_updated, "at unknown time"));
+
+    if (last_updated != 0) {
+        last_updated_s = pcmk__epoch2str(&last_updated,
+                                         crm_time_log_date
+                                         |crm_time_log_timeofday
+                                         |crm_time_log_with_timezone);
+    }
+
+    rc = out->info(out, "Status of %s: '%s' (last updated %s)",
+                   sys_from, state_s,
+                   pcmk__s(last_updated_s, "at unknown time"));
+
+    free(last_updated_s);
+    return rc;
 }
 
 PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
-                  "const char *")
+                  "long long")
 static int
 pacemakerd_health_html(pcmk__output_t *out, va_list args)
 {
@@ -675,24 +697,42 @@ pacemakerd_health_html(pcmk__output_t *out, va_list args)
     enum pcmk_pacemakerd_state state =
         (enum pcmk_pacemakerd_state) va_arg(args, int);
     const char *state_s = va_arg(args, const char *);
-    const char *last_updated = va_arg(args, const char *);
+    time_t last_updated = (time_t) va_arg(args, long long);
+
+    char *last_updated_s = NULL;
     char *msg = NULL;
+
+    if (sys_from == NULL) {
+        if (state == pcmk_pacemakerd_state_remote) {
+            sys_from = "pacemaker-remoted";
+        } else {
+            sys_from = CRM_SYSTEM_MCP;
+        }
+    }
 
     if (state_s == NULL) {
         state_s = pcmk__pcmkd_state_enum2friendly(state);
     }
 
+    if (last_updated != 0) {
+        last_updated_s = pcmk__epoch2str(&last_updated,
+                                         crm_time_log_date
+                                         |crm_time_log_timeofday
+                                         |crm_time_log_with_timezone);
+    }
+
     msg = crm_strdup_printf("Status of %s: '%s' (last updated %s)",
-                            pcmk__s(sys_from, "unknown subsystem"), state_s,
-                            pcmk__s(last_updated, "at unknown time"));
+                            sys_from, state_s,
+                            pcmk__s(last_updated_s, "at unknown time"));
     pcmk__output_create_html_node(out, "li", NULL, NULL, msg);
 
     free(msg);
+    free(last_updated_s);
     return pcmk_rc_ok;
 }
 
 PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
-                  "const char *")
+                  "long long")
 static int
 pacemakerd_health_text(pcmk__output_t *out, va_list args)
 {
@@ -703,7 +743,7 @@ pacemakerd_health_text(pcmk__output_t *out, va_list args)
         enum pcmk_pacemakerd_state state =
             (enum pcmk_pacemakerd_state) va_arg(args, int);
         const char *state_s = va_arg(args, const char *);
-        const char *last_updated G_GNUC_UNUSED = va_arg(args, const char *);
+        time_t last_updated G_GNUC_UNUSED = (time_t) va_arg(args, long long);
 
         if (state_s == NULL) {
             state_s = pcmk_pacemakerd_api_daemon_state_enum2text(state);
@@ -714,7 +754,7 @@ pacemakerd_health_text(pcmk__output_t *out, va_list args)
 }
 
 PCMK__OUTPUT_ARGS("pacemakerd-health", "const char *", "int", "const char *",
-                  "const char *")
+                  "long long")
 static int
 pacemakerd_health_xml(pcmk__output_t *out, va_list args)
 {
@@ -722,17 +762,35 @@ pacemakerd_health_xml(pcmk__output_t *out, va_list args)
     enum pcmk_pacemakerd_state state =
         (enum pcmk_pacemakerd_state) va_arg(args, int);
     const char *state_s = va_arg(args, const char *);
-    const char *last_updated = va_arg(args, const char *);
+    time_t last_updated = (time_t) va_arg(args, long long);
+
+    char *last_updated_s = NULL;
+
+    if (sys_from == NULL) {
+        if (state == pcmk_pacemakerd_state_remote) {
+            sys_from = "pacemaker-remoted";
+        } else {
+            sys_from = CRM_SYSTEM_MCP;
+        }
+    }
 
     if (state_s == NULL) {
-        state_s = pcmk_pacemakerd_api_daemon_state_enum2text(state);
+        state_s = pcmk__pcmkd_state_enum2friendly(state);
+    }
+
+    if (last_updated != 0) {
+        last_updated_s = pcmk__epoch2str(&last_updated,
+                                         crm_time_log_date
+                                         |crm_time_log_timeofday
+                                         |crm_time_log_with_timezone);
     }
 
     pcmk__output_create_xml_node(out, "pacemakerd",
                                  "sys_from", sys_from,
                                  "state", state_s,
-                                 "last_updated", last_updated,
+                                 "last_updated", last_updated_s,
                                  NULL);
+    free(last_updated_s);
     return pcmk_rc_ok;
 }
 

--- a/lib/pacemaker/pcmk_rule.c
+++ b/lib/pacemaker/pcmk_rule.c
@@ -83,10 +83,9 @@ init_rule_check(pcmk__output_t *out, xmlNodePtr input, const crm_time_t *date,
         }
 
     } else {
-        int rc = cib__signon_query(NULL, &(new_data_set->input));
+        int rc = cib__signon_query(out, NULL, &(new_data_set->input));
 
         if (rc != pcmk_rc_ok) {
-            out->err(out, "CIB query failed: %s", pcmk_rc_str(rc));
             pe_free_working_set(new_data_set);
             return rc;
         }

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -788,7 +788,7 @@ pcmk__simulate(pe_working_set_t *data_set, pcmk__output_t *out,
     xmlNodePtr input = NULL;
     cib_t *cib = NULL;
 
-    rc = cib__signon_query(&cib, &input);
+    rc = cib__signon_query(out, &cib, &input);
     if (rc != pcmk_rc_ok) {
         goto simulate_done;
     }

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -437,10 +437,8 @@ set_effective_date(pe_working_set_t *data_set, bool print_original,
         crm_time_log(LOG_NOTICE, "Pretending 'now' is", data_set->now,
                      crm_time_log_date | crm_time_log_timeofday);
 
-    } else if (original_date) {
-
-        data_set->now = crm_time_new(NULL);
-        crm_time_set_timet(data_set->now, &original_date);
+    } else if (original_date != 0) {
+        data_set->now = pcmk__copy_timet(original_date);
 
         if (print_original) {
             char *when = crm_time_as_string(data_set->now,

--- a/lib/pacemaker/pcmk_status.c
+++ b/lib/pacemaker/pcmk_status.c
@@ -224,7 +224,8 @@ pcmk__status(pcmk__output_t *out, cib_t *cib,
         && (cib->state != cib_connected_query)
         && (cib->state != cib_connected_command)) {
 
-        rc = pcmk__pacemakerd_status(out, crm_system_name, timeout_ms, &state);
+        rc = pcmk__pacemakerd_status(out, crm_system_name, timeout_ms, true,
+                                     &state);
         if (rc != pcmk_rc_ok) {
             return rc;
         }

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1381,13 +1381,12 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
                                  &epoch) == pcmk_ok) && (epoch > 0)) {
         guint interval_ms = 0;
         char *s = NULL;
-        crm_time_t *crm_when = crm_time_new_undefined();
+        crm_time_t *crm_when = pcmk__copy_timet(epoch);
         char *rc_change = NULL;
 
         crm_element_value_ms(xml_op, XML_LRM_ATTR_INTERVAL_MS, &interval_ms);
         s = pcmk__itoa(interval_ms);
 
-        crm_time_set_timet(crm_when, &epoch);
         rc_change = crm_time_as_string(crm_when, crm_time_log_date | crm_time_log_timeofday | crm_time_log_with_timezone);
 
         pcmk__xe_set_props(node, XML_RSC_OP_LAST_CHANGE, rc_change,

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -359,6 +359,7 @@ crm_mon_mk_curses_output(char **argv) {
     retval->version = curses_ver;
     retval->err = curses_error;
     retval->info = curses_info;
+    retval->transient = curses_info;
     retval->output_xml = curses_output_xml;
 
     retval->begin_list = curses_begin_list;

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -342,7 +342,8 @@ static GOptionEntry source_entries[] = {
 };
 
 static int
-setup_input(const char *input, const char *output, GError **error)
+setup_input(pcmk__output_t *out, const char *input, const char *output,
+            GError **error)
 {
     int rc = pcmk_rc_ok;
     xmlNode *cib_object = NULL;
@@ -350,10 +351,9 @@ setup_input(const char *input, const char *output, GError **error)
 
     if (input == NULL) {
         /* Use live CIB */
-        rc = cib__signon_query(NULL, &cib_object);
+        rc = cib__signon_query(out, NULL, &cib_object);
         if (rc != pcmk_rc_ok) {
-            g_set_error(error, PCMK__RC_ERROR, rc,
-                        "CIB query failed: %s", pcmk_rc_str(rc));
+            // cib__signon_query() outputs any relevant error
             return rc;
         }
 
@@ -535,7 +535,9 @@ main(int argc, char **argv)
         goto done;
     }
 
-    rc = setup_input(options.xml_file, options.store ? options.xml_file : options.output_file, &error);
+    rc = setup_input(out, options.xml_file,
+                     options.store? options.xml_file : options.output_file,
+                     &error);
     if (rc != pcmk_rc_ok) {
         goto done;
     }

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -147,10 +147,10 @@ main(int argc, char **argv)
 
     if (options.use_live_cib) {
         crm_info("Reading XML from: live cluster");
-        rc = cib__signon_query(NULL, &cib_object);
+        rc = cib__signon_query(out, NULL, &cib_object);
 
         if (rc != pcmk_rc_ok) {
-            g_set_error(&error, PCMK__RC_ERROR, rc, "CIB query failed: %s", pcmk_rc_str(rc));
+            // cib__signon_query() outputs any relevant error
             goto done;
         }
 

--- a/tools/crmadmin.c
+++ b/tools/crmadmin.c
@@ -240,7 +240,8 @@ main(int argc, char **argv)
             break;
         case cmd_pacemakerd_health:
             rc = pcmk__pacemakerd_status(out, options.ipc_name,
-                                         (unsigned int) options.timeout, NULL);
+                                         (unsigned int) options.timeout, true,
+                                         NULL);
             break;
         case cmd_list_nodes:
             rc = pcmk__list_nodes(out, options.optarg, options.bash_export);


### PR DESCRIPTION
And some other supporting work to facilitate that, including making `cib__signon_query()` more versatile at the expense of a little bit of complexity.

The intent is to soon use the new transient output method in `crm_mon` as well.