### PR TITLE
Fix: schemas: False positives in best-match.sh

### DIFF
--- a/xml/best-match.sh
+++ b/xml/best-match.sh
@@ -25,7 +25,7 @@ prefix="$1"; shift
 cd "$(dirname $0)"
 
 list_candidates() {
-    ls -1 "${1}.rng" "${1}"-*.rng 2>/dev/null
+    ls -1 "${1}.rng" "${1}"-[0-9]*.rng 2>/dev/null
 }
 
 version_from_filename() {


### PR DESCRIPTION
The list_candidates() function is too lax and matches `pacemakerd-health-2.25.rng` when it looks for candidates for `"pacemakerd"`.

This caused an `api-result.rng` compile failure when updating to API version 2.26. Somehow it doesn't seem to cause issues on 2.25.

We shouldn't have to worry about any complicated version strings that contain hyphens or start with a non-digit.