### PR TITLE
Fix: tools: fix syntax on resetting options in crm_resource

### DIFF
--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -640,9 +640,9 @@ reset_options(void) {
     options.require_crmd = FALSE;
     options.require_node = FALSE;
 
-    options.require_cib = TRUE,
-    options.require_dataset = TRUE,
-    options.require_resource = TRUE,
+    options.require_cib = TRUE;
+    options.require_dataset = TRUE;
+    options.require_resource = TRUE;
 
     options.find_flags = 0;
 }


### PR DESCRIPTION
Somehow commas were used where semicolons are supposed to be.