### PR TITLE
Feature: tools: crm_mon now shows last_update origin

### DIFF
--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -37,6 +37,9 @@
  */
 extern bool pcmk__is_daemon;
 
+//! Node name of the local node
+extern char *pcmk__our_nodename;
+
 // Number of elements in a statically defined array
 #define PCMK__NELEM(a) ((int) (sizeof(a)/sizeof(a[0])) )
 

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -28,7 +28,7 @@ extern "C" {
  */
 
 
-#  define PCMK__API_VERSION "2.26"
+#  define PCMK__API_VERSION "2.27"
 
 #if defined(PCMK__WITH_ATTRIBUTE_OUTPUT_ARGS)
 #  define PCMK__OUTPUT_ARGS(ARGS...) __attribute__((output_args(ARGS)))

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -119,6 +119,42 @@ int pcmk_designated_controller(xmlNodePtr *xml,
 void pcmk_free_injections(pcmk_injections_t *injections);
 
 /*!
+ * \brief Get and optionally output node info corresponding to a node ID from
+ *        the controller
+ *
+ * \param[in,out] xml                 Destination for the result, as an XML tree
+ * \param[in,out] node_id             ID of node whose name to get. If \p NULL
+ *                                    or 0, get the local node name. If not
+ *                                    \p NULL, store the true node ID here on
+ *                                    success.
+ * \param[out]    node_name           If not \p NULL, where to store the node
+ *                                    name
+ * \param[out]    uuid                If not \p NULL, where to store the node
+ *                                    UUID
+ * \param[out]    state               If not \p NULL, where to store the
+ *                                    membership state
+ * \param[out]    is_remote           If not \p NULL, where to store whether the
+ *                                    node is a Pacemaker Remote node
+ * \param[out]    have_quorum         If not \p NULL, where to store whether the
+ *                                    node has quorum
+ * \param[in]     show_output         Whether to output the node info
+ * \param[in]     message_timeout_ms  How long to wait for a reply from the
+ *                                    \p pacemaker-controld API. If 0,
+ *                                    \p pcmk_ipc_dispatch_sync will be used.
+ *                                    Otherwise, \p pcmk_ipc_dispatch_poll will
+ *                                    be used.
+ *
+ * \return Standard Pacemaker return code
+ *
+ * \note The caller is responsible for freeing \p *node_name, \p *uuid, and
+ *       \p *state using \p free().
+ */
+int pcmk_query_node_info(xmlNodePtr *xml, uint32_t *node_id, char **node_name,
+                         char **uuid, char **state, bool *have_quorum,
+                         bool *is_remote, bool show_output,
+                         unsigned int message_timeout_ms);
+
+/*!
  * \brief Get and output \p pacemakerd status
  *
  * \param[in,out] xml                 Destination for the result, as an XML tree

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -155,6 +155,32 @@ int pcmk_query_node_info(xmlNodePtr *xml, uint32_t *node_id, char **node_name,
                          unsigned int message_timeout_ms);
 
 /*!
+ * \brief Get the node name corresponding to a node ID from the controller
+ *
+ * \param[in,out] xml                 Destination for the result, as an XML tree
+ * \param[in,out] node_id             ID of node whose name to get (or 0 for the
+ *                                    local node)
+ * \param[out]    node_name           If not \p NULL, where to store the node
+ *                                    name
+ * \param[in]     message_timeout_ms  How long to wait for a reply from the
+ *                                    \p pacemaker-controld API. If 0,
+ *                                    \p pcmk_ipc_dispatch_sync will be used.
+ *                                    Otherwise, \p pcmk_ipc_dispatch_poll will
+ *                                    be used.
+ *
+ * \return Standard Pacemaker return code
+ *
+ * \note The caller is responsible for freeing \p *node_name using \p free().
+ */
+static inline int
+pcmk_query_node_name(xmlNodePtr *xml, uint32_t node_id, char **node_name,
+                     unsigned int message_timeout_ms)
+{
+    return pcmk_query_node_info(xml, &node_id, node_name, NULL, NULL, NULL,
+                                NULL, false, message_timeout_ms);
+}
+
+/*!
  * \brief Get and output \p pacemakerd status
  *
  * \param[in,out] xml                 Destination for the result, as an XML tree

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -87,10 +87,8 @@ typedef struct {
  * \param[in]     message_timeout_ms  How long to wait for a reply from the
  *                                    \p pacemaker-controld API. If 0,
  *                                    \p pcmk_ipc_dispatch_sync will be used.
- *                                    Otherwise, \p pcmk_ipc_dispatch_main will
- *                                    be used, and a new mainloop will be
- *                                    created for this purpose (freed before
- *                                    return).
+ *                                    Otherwise, \p pcmk_ipc_dispatch_poll will
+ *                                    be used.
  *
  * \return Standard Pacemaker return code
  */
@@ -104,10 +102,8 @@ int pcmk_controller_status(xmlNodePtr *xml, const char *node_name,
  * \param[in]     message_timeout_ms  How long to wait for a reply from the
  *                                    \p pacemaker-controld API. If 0,
  *                                    \p pcmk_ipc_dispatch_sync will be used.
- *                                    Otherwise, \p pcmk_ipc_dispatch_main will
- *                                    be used, and a new mainloop will be
- *                                    created for this purpose (freed before
- *                                    return).
+ *                                    Otherwise, \p pcmk_ipc_dispatch_poll will
+ *                                    be used.
  *
  * \return Standard Pacemaker return code
  */
@@ -130,10 +126,8 @@ void pcmk_free_injections(pcmk_injections_t *injections);
  * \param[in]     message_timeout_ms  How long to wait for a reply from the
  *                                    \p pacemakerd API. If 0,
  *                                    \p pcmk_ipc_dispatch_sync will be used.
- *                                    Otherwise, \p pcmk_ipc_dispatch_main will
- *                                    be used, and a new mainloop will be
- *                                    created for this purpose (freed before
- *                                    return).
+ *                                    Otherwise, \p pcmk_ipc_dispatch_poll will
+ *                                    be used.
  *
  * \return Standard Pacemaker return code
  */

--- a/include/pcmki/pcmki_cluster_queries.h
+++ b/include/pcmki/pcmki_cluster_queries.h
@@ -25,10 +25,40 @@ int pcmk__controller_status(pcmk__output_t *out, const char *node_name,
                             unsigned int message_timeout_ms);
 int pcmk__designated_controller(pcmk__output_t *out,
                                 unsigned int message_timeout_ms);
+int pcmk__pacemakerd_status(pcmk__output_t *out, const char *ipc_name,
+                            unsigned int message_timeout_ms, bool show_output,
+                            enum pcmk_pacemakerd_state *state);
 int pcmk__query_node_info(pcmk__output_t *out, uint32_t *node_id,
                           char **node_name, char **uuid, char **state,
                           bool *have_quorum, bool *is_remote, bool show_output,
                           unsigned int message_timeout_ms);
+
+/*!
+ * \internal
+ * \brief Get the node name corresponding to a node ID from the controller
+ *
+ * \param[in,out] out                 Output object
+ * \param[in]     node_id             ID of node whose name to get (or 0 for
+ *                                    the local node)
+ * \param[out]    node_name           If not \p NULL, where to store the node
+ *                                    name
+ * \param[in]     message_timeout_ms  How long to wait for a reply from the
+ *                                    \p pacemaker-controld API. If 0,
+ *                                    \p pcmk_ipc_dispatch_sync will be used.
+ *                                    Otherwise, \p pcmk_ipc_dispatch_poll will
+ *                                    be used.
+ *
+ * \return Standard Pacemaker return code
+ *
+ * \note The caller is responsible for freeing \p *node_name using \p free().
+ */
+static inline int
+pcmk__query_node_name(pcmk__output_t *out, uint32_t nodeid, char **node_name,
+                      unsigned int message_timeout_ms)
+{
+    return pcmk__query_node_info(out, &nodeid, node_name, NULL, NULL, NULL,
+                                 NULL, false, message_timeout_ms);
+}
 
 // pacemakerd queries
 int pcmk__pacemakerd_status(pcmk__output_t *out, const char *ipc_name,

--- a/include/pcmki/pcmki_cluster_queries.h
+++ b/include/pcmki/pcmki_cluster_queries.h
@@ -17,13 +17,22 @@
 #include <crm/common/ipc_controld.h>
 #include <crm/common/ipc_pacemakerd.h>
 
+// CIB queries
+int pcmk__list_nodes(pcmk__output_t *out, char *node_types, gboolean bash_export);
+
+// Controller queries
 int pcmk__controller_status(pcmk__output_t *out, const char *node_name,
                             unsigned int message_timeout_ms);
 int pcmk__designated_controller(pcmk__output_t *out,
                                 unsigned int message_timeout_ms);
+int pcmk__query_node_info(pcmk__output_t *out, uint32_t *node_id,
+                          char **node_name, char **uuid, char **state,
+                          bool *have_quorum, bool *is_remote, bool show_output,
+                          unsigned int message_timeout_ms);
+
+// pacemakerd queries
 int pcmk__pacemakerd_status(pcmk__output_t *out, const char *ipc_name,
                             unsigned int message_timeout_ms, bool show_output,
                             enum pcmk_pacemakerd_state *state);
-int pcmk__list_nodes(pcmk__output_t *out, char *node_types, gboolean bash_export);
 
 #endif

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -45,6 +45,7 @@ typedef time_t log_time_t;
 unsigned int crm_log_level = LOG_INFO;
 unsigned int crm_trace_nonlog = 0;
 bool pcmk__is_daemon = false;
+char *pcmk__our_nodename = NULL;
 
 static unsigned int crm_log_priority = LOG_NOTICE;
 static GLogFunc glib_log_default = NULL;

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -869,6 +869,8 @@ crm_exit(crm_exit_t rc)
 
     pcmk__cli_option_cleanup();
 
+    free(pcmk__our_nodename);
+
     if (crm_system_name) {
         crm_info("Exiting %s " CRM_XS " with status %d", crm_system_name, rc);
         free(crm_system_name);

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -747,9 +747,11 @@ pcmk_rc2exitc(int rc)
         case ENODEV:
         case ENOENT:
         case ENXIO:
-        case pcmk_rc_node_unknown:
         case pcmk_rc_unknown_format:
             return CRM_EX_NOSUCH;
+
+        case pcmk_rc_node_unknown:
+            return CRM_EX_NOHOST;
 
         case ETIME:
         case ETIMEDOUT:

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -26,6 +26,20 @@
 #include <crm/common/ipc_controld.h>
 #include <crm/common/ipc_pacemakerd.h>
 
+//! Object to store node info from the controller API
+typedef struct {
+    /* Adapted from pcmk_controld_api_reply_t:data:node_info.
+     * (char **) are convenient here for use within callbacks: we can skip
+     * copying strings unless the caller passes a non-NULL value.
+     */
+    uint32_t id;
+    char **node_name;
+    char **uuid;
+    char **state;
+    bool have_quorum;
+    bool is_remote;
+} node_info_t;
+
 //! Object to store API results, a timeout, and an output object
 typedef struct {
     pcmk__output_t *out;
@@ -34,6 +48,7 @@ typedef struct {
     bool reply_received;
     unsigned int message_timeout_ms;
     enum pcmk_pacemakerd_state pcmkd_state;
+    node_info_t node_info;
 } data_t;
 
 /*!
@@ -225,6 +240,60 @@ designated_controller_event_cb(pcmk_ipc_api_t *controld_api,
 
     reply = (const pcmk_controld_api_reply_t *) event_data;
     out->message(out, "dc", reply->host_from);
+    data->rc = pcmk_rc_ok;
+}
+
+/*!
+ * \internal
+ * \brief Process a node info IPC event
+ *
+ * \param[in,out] controld_api  Controller connection
+ * \param[in]     event_type    Type of event that occurred
+ * \param[in]     status        Event status
+ * \param[in,out] event_data    \p pcmk_controld_api_reply_t object containing
+ *                              event-specific data
+ * \param[in,out] user_data     \p data_t object for API results and options
+ */
+static void
+node_info_event_cb(pcmk_ipc_api_t *controld_api, enum pcmk_ipc_event event_type,
+                   crm_exit_t status, void *event_data, void *user_data)
+{
+    data_t *data = (data_t *) user_data;
+    pcmk__output_t *out = data->out;
+
+    const pcmk_controld_api_reply_t *reply = NULL;
+
+    int rc = validate_controld_reply(data, controld_api, event_type, status,
+                                     event_data, pcmk_controld_reply_info);
+
+    if (rc != pcmk_rc_ok) {
+        return;
+    }
+
+    reply = (const pcmk_controld_api_reply_t *) event_data;
+
+    if (reply->data.node_info.uname == NULL) {
+        out->err(out, "Node is not known to cluster");
+        data->rc = pcmk_rc_node_unknown;
+        return;
+    }
+
+    data->node_info.have_quorum = reply->data.node_info.have_quorum;
+    data->node_info.is_remote = reply->data.node_info.is_remote;
+    data->node_info.id = (uint32_t) reply->data.node_info.id;
+
+    pcmk__str_update(data->node_info.node_name, reply->data.node_info.uname);
+    pcmk__str_update(data->node_info.uuid, reply->data.node_info.uuid);
+    pcmk__str_update(data->node_info.state, reply->data.node_info.state);
+
+    if (data->show_output) {
+        out->message(out, "node-info",
+                     reply->data.node_info.id, reply->data.node_info.uname,
+                     reply->data.node_info.uuid, reply->data.node_info.state,
+                     reply->data.node_info.have_quorum,
+                     reply->data.node_info.is_remote);
+    }
+
     data->rc = pcmk_rc_ok;
 }
 
@@ -521,6 +590,110 @@ pcmk_designated_controller(xmlNodePtr *xml, unsigned int message_timeout_ms)
 
 /*!
  * \internal
+ * \brief Get and optionally output node info corresponding to a node ID from
+ *        the controller
+ *
+ * \param[in,out] out                 Output object
+ * \param[in,out] node_id             ID of node whose name to get. If \p NULL
+ *                                    or 0, get the local node name. If not
+ *                                    \p NULL, store the true node ID here on
+ *                                    success.
+ * \param[out]    node_name           If not \p NULL, where to store the node
+ *                                    name
+ * \param[out]    uuid                If not \p NULL, where to store the node
+ *                                    UUID
+ * \param[out]    state               If not \p NULL, where to store the
+ *                                    membership state
+ * \param[out]    is_remote           If not \p NULL, where to store whether the
+ *                                    node is a Pacemaker Remote node
+ * \param[out]    have_quorum         If not \p NULL, where to store whether the
+ *                                    node has quorum
+ * \param[in]     show_output         Whether to show the node info
+ * \param[in]     message_timeout_ms  How long to wait for a reply from the
+ *                                    \p pacemaker-controld API. If 0,
+ *                                    \p pcmk_ipc_dispatch_sync will be used.
+ *                                    Otherwise, \p pcmk_ipc_dispatch_poll will
+ *                                    be used.
+ *
+ * \return Standard Pacemaker return code
+ *
+ * \note The caller is responsible for freeing \p *node_name, \p *uuid, and
+ *       \p *state using \p free().
+ */
+int
+pcmk__query_node_info(pcmk__output_t *out, uint32_t *node_id, char **node_name,
+                      char **uuid, char **state, bool *have_quorum,
+                      bool *is_remote, bool show_output,
+                      unsigned int message_timeout_ms)
+{
+    data_t data = {
+        .out = out,
+        .show_output = show_output,
+        .rc = pcmk_rc_ok,
+        .message_timeout_ms = message_timeout_ms,
+        .node_info = {
+            .id = (node_id == NULL)? 0 : *node_id,
+            .node_name = node_name,
+            .uuid = uuid,
+            .state = state,
+        },
+    };
+    enum pcmk_ipc_dispatch dispatch_type = pcmk_ipc_dispatch_poll;
+    pcmk_ipc_api_t *controld_api = NULL;
+
+    if (node_name != NULL) {
+        *node_name = NULL;
+    }
+    if (uuid != NULL) {
+        *uuid = NULL;
+    }
+    if (state != NULL) {
+        *state = NULL;
+    }
+
+    if (message_timeout_ms == 0) {
+        dispatch_type = pcmk_ipc_dispatch_sync;
+    }
+    controld_api = ipc_connect(&data, pcmk_ipc_controld, node_info_event_cb,
+                               dispatch_type, false);
+
+    if (controld_api != NULL) {
+        int rc = pcmk_controld_api_node_info(controld_api,
+                                             (node_id != NULL)? *node_id : 0);
+
+        if (rc != pcmk_rc_ok) {
+            out->err(out,
+                     "error: Could not send request to controller API on local "
+                     "node: %s", pcmk_rc_str(rc));
+            data.rc = rc;
+        }
+
+        if (dispatch_type == pcmk_ipc_dispatch_poll) {
+            poll_until_reply(&data, controld_api, "local node");
+        }
+        pcmk_free_ipc_api(controld_api);
+    }
+
+    if (data.rc != pcmk_rc_ok) {
+        return data.rc;
+    }
+
+    // String outputs are set in callback
+    if (node_id != NULL) {
+        *node_id = data.node_info.id;
+    }
+    if (have_quorum != NULL) {
+        *have_quorum = data.node_info.have_quorum;
+    }
+    if (is_remote != NULL) {
+        *is_remote = data.node_info.is_remote;
+    }
+
+    return data.rc;
+}
+
+/*!
+ * \internal
  * \brief Get and optionally output \p pacemakerd status
  *
  * \param[in,out] out                 Output object
@@ -530,7 +703,7 @@ pcmk_designated_controller(xmlNodePtr *xml, unsigned int message_timeout_ms)
  *                                    \p pcmk_ipc_dispatch_sync will be used.
  *                                    Otherwise, \p pcmk_ipc_dispatch_poll will
  *                                    be used.
- * \param[in]     show_output         Whether to show the \p pacemakerd state
+ * \param[in]     show_output         Whether to output the \p pacemakerd state
  * \param[out]    state               Where to store the \p pacemakerd state, if
  *                                    not \p NULL
  *

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -179,17 +179,20 @@ controller_status_event_cb(pcmk_ipc_api_t *controld_api,
 {
     data_t *data = (data_t *) user_data;
     pcmk__output_t *out = data->out;
-    pcmk_controld_api_reply_t *reply = (pcmk_controld_api_reply_t *) event_data;
+    const pcmk_controld_api_reply_t *reply = NULL;
 
     int rc = validate_controld_reply(data, controld_api, event_type, status,
                                      event_data, pcmk_controld_reply_ping);
 
-    if (rc == pcmk_rc_ok) {
-        out->message(out, "health",
-                     reply->data.ping.sys_from, reply->host_from,
-                     reply->data.ping.fsa_state, reply->data.ping.result);
-        data->rc = pcmk_rc_ok;
+    if (rc != pcmk_rc_ok) {
+        return;
     }
+
+    reply = (const pcmk_controld_api_reply_t *) event_data;
+    out->message(out, "health",
+                 reply->data.ping.sys_from, reply->host_from,
+                 reply->data.ping.fsa_state, reply->data.ping.result);
+    data->rc = pcmk_rc_ok;
 }
 
 /*!
@@ -211,15 +214,18 @@ designated_controller_event_cb(pcmk_ipc_api_t *controld_api,
 {
     data_t *data = (data_t *) user_data;
     pcmk__output_t *out = data->out;
-    pcmk_controld_api_reply_t *reply = (pcmk_controld_api_reply_t *) event_data;
+    const pcmk_controld_api_reply_t *reply = NULL;
 
     int rc = validate_controld_reply(data, controld_api, event_type, status,
                                      event_data, pcmk_controld_reply_ping);
 
-    if (rc == pcmk_rc_ok) {
-        out->message(out, "dc", reply->host_from);
-        data->rc = pcmk_rc_ok;
+    if (rc != pcmk_rc_ok) {
+        return;
     }
+
+    reply = (const pcmk_controld_api_reply_t *) event_data;
+    out->message(out, "dc", reply->host_from);
+    data->rc = pcmk_rc_ok;
 }
 
 /*!
@@ -240,8 +246,7 @@ pacemakerd_event_cb(pcmk_ipc_api_t *pacemakerd_api,
 {
     data_t *data = user_data;
     pcmk__output_t *out = data->out;
-    pcmk_pacemakerd_api_reply_t *reply =
-        (pcmk_pacemakerd_api_reply_t *) event_data;
+    const pcmk_pacemakerd_api_reply_t *reply = NULL;
 
     int rc = validate_pcmkd_reply(data, pacemakerd_api, event_type, status,
                                   event_data, pcmk_pacemakerd_reply_ping);
@@ -251,6 +256,8 @@ pacemakerd_event_cb(pcmk_ipc_api_t *pacemakerd_api,
     }
 
     // Parse desired information from reply
+    reply = (const pcmk_pacemakerd_api_reply_t *) event_data;
+
     data->rc = pcmk_rc_ok;
     data->pcmkd_state = reply->data.ping.state;
 

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -692,6 +692,32 @@ pcmk__query_node_info(pcmk__output_t *out, uint32_t *node_id, char **node_name,
     return data.rc;
 }
 
+// Documented in header
+int
+pcmk_query_node_info(xmlNodePtr *xml, uint32_t *node_id, char **node_name,
+                     char **uuid, char **state, bool *have_quorum,
+                     bool *is_remote, bool show_output,
+                     unsigned int message_timeout_ms)
+{
+    pcmk__output_t *out = NULL;
+    int rc = pcmk_rc_ok;
+
+    CRM_ASSERT(node_name != NULL);
+
+    rc = pcmk__xml_output_new(&out, xml);
+    if (rc != pcmk_rc_ok) {
+        return rc;
+    }
+
+    pcmk__register_lib_messages(out);
+
+    rc = pcmk__query_node_info(out, node_id, node_name, uuid, state,
+                               have_quorum, is_remote, show_output,
+                               message_timeout_ms);
+    pcmk__xml_output_finish(out, xml);
+    return rc;
+}
+
 /*!
  * \internal
  * \brief Get and optionally output \p pacemakerd status

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -795,6 +795,15 @@ pcmk__simulate(pe_working_set_t *data_set, pcmk__output_t *out,
     reset(data_set, input, out, use_date, flags);
     cluster_status(data_set);
 
+    if ((cib->variant == cib_native)
+        && pcmk_is_set(section_opts, pcmk_section_times)) {
+        if (pcmk__our_nodename == NULL) {
+            // Currently used only in the times section
+            pcmk__query_node_name(out, 0, &pcmk__our_nodename, 0);
+        }
+        data_set->localhost = pcmk__our_nodename;
+    }
+
     if (!out->is_quiet(out)) {
         if (pcmk_is_set(data_set->flags, pe_flag_maintenance_mode)) {
             printed = out->message(out, "maint-mode", data_set->flags);

--- a/lib/pacemaker/pcmk_status.c
+++ b/lib/pacemaker/pcmk_status.c
@@ -107,6 +107,14 @@ pcmk__output_cluster_status(pcmk__output_t *out, stonith_t *stonith, cib_t *cib,
     data_set->priv = out;
     cluster_status(data_set);
 
+    if ((cib->variant == cib_native) && pcmk_is_set(show, pcmk_section_times)) {
+        if (pcmk__our_nodename == NULL) {
+            // Currently used only in the times section
+            pcmk__query_node_name(out, 0, &pcmk__our_nodename, 0);
+        }
+        data_set->localhost = pcmk__our_nodename;
+    }
+
     /* Unpack constraints if any section will need them
      * (tickets may be referenced in constraints but not granted yet,
      * and bans need negative location constraints) */

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -37,7 +37,7 @@
 #include <crm/common/output_internal.h>
 #include <sys/utsname.h>
 
-#include <pcmki/pcmki_output.h>
+#include <pacemaker-internal.h>
 
 #define SUMMARY "crm_attribute - query and update Pacemaker cluster options and node attributes"
 
@@ -280,41 +280,6 @@ static GOptionEntry deprecated_entries[] = {
 };
 
 static void
-controller_event_cb(pcmk_ipc_api_t *controld_api,
-                    enum pcmk_ipc_event event_type, crm_exit_t status,
-                    void *event_data, void *user_data)
-{
-    pcmk_controld_api_reply_t *reply = event_data;
-
-    if (event_type != pcmk_ipc_event_reply) {
-        return;
-    }
-
-    if (status != CRM_EX_OK) {
-        exit_code = status;
-        g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
-                    "Bad reply from controller: %s", crm_exit_str(exit_code));
-        return;
-    }
-
-    if (reply->reply_type != pcmk_controld_reply_info) {
-        exit_code = CRM_EX_PROTOCOL;
-        g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
-                    "Unknown reply type %d from controller", reply->reply_type);
-        return;
-    }
-
-    if (reply->data.node_info.uname == NULL) {
-        exit_code = CRM_EX_NOHOST;
-        g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
-                    "Node is not known to cluster");
-    }
-
-    exit_code = CRM_EX_OK;
-    pcmk__str_update(&options.dest_uname, reply->data.node_info.uname);
-}
-
-static void
 get_node_name_from_local(void)
 {
     char *hostname = pcmk_hostname();
@@ -327,51 +292,6 @@ get_node_name_from_local(void)
      */
     options.dest_uname = g_strdup(hostname);
     free(hostname);
-}
-
-static int
-get_node_name_from_controller(void)
-{
-    int rc = pcmk_rc_ok;
-    pcmk_ipc_api_t *controld_api = NULL;
-
-    rc = pcmk_new_ipc_api(&controld_api, pcmk_ipc_controld);
-    if (controld_api == NULL) {
-        g_set_error(&error, PCMK__RC_ERROR, rc, "Could not connect to controller: %s",
-                    pcmk_rc_str(rc));
-        return rc;
-    }
-
-    pcmk_register_ipc_callback(controld_api, controller_event_cb, NULL);
-
-    rc = pcmk_connect_ipc(controld_api, pcmk_ipc_dispatch_sync);
-    if (rc != pcmk_rc_ok) {
-        g_set_error(&error, PCMK__RC_ERROR, rc, "Could not connect to controller: %s",
-                    pcmk_rc_str(rc));
-        pcmk_free_ipc_api(controld_api);
-        return rc;
-    }
-
-    rc = pcmk_controld_api_node_info(controld_api, 0);
-
-    if (rc != pcmk_rc_ok) {
-        g_set_error(&error, PCMK__RC_ERROR, rc, "Could not ping controller: %s",
-                    pcmk_rc_str(rc));
-    }
-
-    /* This is a synchronous call, so we have already received and processed
-     * the reply, which means controller_event_cb has been called.  If
-     * exit_code was set, return some generic error here.  The caller can
-     * then check for that and fail with exit_code.
-     */
-    if (exit_code != CRM_EX_OK) {
-        rc = pcmk_rc_error;
-    }
-
-    pcmk_disconnect_ipc(controld_api);
-    pcmk_free_ipc_api(controld_api);
-
-    return rc;
 }
 
 static int
@@ -825,20 +745,17 @@ main(int argc, char **argv)
         }
 
         if (options.dest_uname == NULL) {
-            rc = get_node_name_from_controller();
+            char *node_name = NULL;
 
-            if (rc == pcmk_rc_error) {
-                /* The callback failed with some error condition that is stored in
-                 * exit_code.
-                 */
-                goto done;
-            } else if (rc != pcmk_rc_ok) {
-                /* get_node_name_from_controller failed in some other way.  Convert
-                 * the return code to an exit code.
-                 */
+            rc = pcmk__query_node_name(out, 0, &node_name, 0);
+
+            if (rc != pcmk_rc_ok) {
                 exit_code = pcmk_rc2exitc(rc);
+                free(node_name);
                 goto done;
             }
+            options.dest_uname = g_strdup(node_name);
+            free(node_name);
         }
 
         rc = query_node_uuid(the_cib, options.dest_uname, &options.dest_node, &is_remote_node);

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -321,7 +321,10 @@ print_node_name(void)
         return;
 
     } else {
-        // Otherwise ask the controller
+        /* Otherwise ask the controller.
+         * FIXME: Use pcmk__query_node_name() after conversion to formatted
+         * output.
+         */
         run_controller_mainloop(0, false);
     }
 }
@@ -576,6 +579,9 @@ main(int argc, char **argv)
         case 'i':
         case 'q':
         case 'N':
+            /* FIXME: Use pcmk__query_node_name() after conversion to formatted
+             * output
+             */
             run_controller_mainloop(options.nodeid, false);
             break;
         case 'l':

--- a/xml/api/crm_mon-2.27.rng
+++ b/xml/api/crm_mon-2.27.rng
@@ -86,6 +86,9 @@
             <optional>
                 <element name="last_update">
                     <attribute name="time"> <text /> </attribute>
+                    <optional>
+                        <attribute name="origin"> <text /> </attribute>
+                    </optional>
                 </element>
                 <element name="last_change">
                     <attribute name="time"> <text /> </attribute>

--- a/xml/api/crm_mon-2.27.rng
+++ b/xml/api/crm_mon-2.27.rng
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crm-mon"/>
+    </start>
+
+    <define name="element-crm-mon">
+        <choice>
+            <ref name="element-crm-mon-disconnected" />
+            <group>
+                <optional>
+                    <externalRef href="pacemakerd-health-2.25.rng" />
+                </optional>
+                <optional>
+                    <ref name="element-summary" />
+                </optional>
+                <optional>
+                    <ref name="nodes-list" />
+                </optional>
+                <optional>
+                    <ref name="resources-list" />
+                </optional>
+                <optional>
+                    <ref name="node-attributes-list" />
+                </optional>
+                <optional>
+                    <externalRef href="node-history-2.12.rng"/>
+                </optional>
+                <optional>
+                    <ref name="failures-list" />
+                </optional>
+                <optional>
+                    <ref name="fence-event-list" />
+                </optional>
+                <optional>
+                    <ref name="tickets-list" />
+                </optional>
+                <optional>
+                    <ref name="bans-list" />
+                </optional>
+            </group>
+        </choice>
+    </define>
+
+    <define name="element-crm-mon-disconnected">
+        <element name="crm-mon-disconnected">
+            <optional>
+                <attribute name="description"> <text /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="pacemakerd-state"> <text /> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="element-summary">
+        <element name="summary">
+            <optional>
+                <element name="stack">
+                    <attribute name="type"> <text /> </attribute>
+                    <optional>
+                        <attribute name="pacemakerd-state">
+                            <text />
+                        </attribute>
+                    </optional>
+                </element>
+            </optional>
+            <optional>
+                <element name="current_dc">
+                    <attribute name="present"> <data type="boolean" /> </attribute>
+                    <optional>
+                        <group>
+                            <attribute name="version"> <text /> </attribute>
+                            <attribute name="name"> <text /> </attribute>
+                            <attribute name="id"> <text /> </attribute>
+                            <attribute name="with_quorum"> <data type="boolean" /> </attribute>
+                        </group>
+                    </optional>
+                    <optional>
+                        <attribute name="mixed_version"> <data type="boolean" /> </attribute>
+                    </optional>
+                </element>
+            </optional>
+            <optional>
+                <element name="last_update">
+                    <attribute name="time"> <text /> </attribute>
+                </element>
+                <element name="last_change">
+                    <attribute name="time"> <text /> </attribute>
+                    <attribute name="user"> <text /> </attribute>
+                    <attribute name="client"> <text /> </attribute>
+                    <attribute name="origin"> <text /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="nodes_configured">
+                    <attribute name="number"> <data type="nonNegativeInteger" /> </attribute>
+                </element>
+                <element name="resources_configured">
+                    <attribute name="number"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="disabled"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="blocked"> <data type="nonNegativeInteger" /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="cluster_options">
+                    <attribute name="stonith-enabled"> <data type="boolean" /> </attribute>
+                    <attribute name="symmetric-cluster"> <data type="boolean" /> </attribute>
+                    <attribute name="no-quorum-policy"> <text /> </attribute>
+                    <attribute name="maintenance-mode"> <data type="boolean" /> </attribute>
+                    <attribute name="stop-all-resources"> <data type="boolean" /> </attribute>
+                    <attribute name="stonith-timeout-ms"> <data type="integer" /> </attribute>
+                    <attribute name="priority-fencing-delay-ms"> <data type="integer" /> </attribute>
+                </element>
+            </optional>
+        </element>
+    </define>
+
+    <define name="resources-list">
+        <element name="resources">
+            <zeroOrMore>
+                <externalRef href="resources-2.24.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="nodes-list">
+        <element name="nodes">
+            <zeroOrMore>
+                <externalRef href="nodes-2.24.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="node-attributes-list">
+        <element name="node_attributes">
+            <zeroOrMore>
+                <externalRef href="node-attrs-2.8.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="failures-list">
+        <element name="failures">
+            <zeroOrMore>
+                <externalRef href="failure-2.8.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="fence-event-list">
+        <element name="fence_history">
+            <optional>
+                <attribute name="status"> <data type="integer" /> </attribute>
+            </optional>
+            <zeroOrMore>
+                <externalRef href="fence-event-2.15.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="tickets-list">
+        <element name="tickets">
+            <zeroOrMore>
+                <ref name="element-ticket" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="bans-list">
+        <element name="bans">
+            <zeroOrMore>
+                <ref name="element-ban" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="element-ticket">
+        <element name="ticket">
+            <attribute name="id"> <text /> </attribute>
+            <attribute name="status">
+                <choice>
+                    <value>granted</value>
+                    <value>revoked</value>
+                </choice>
+            </attribute>
+            <attribute name="standby"> <data type="boolean" /> </attribute>
+            <optional>
+                <attribute name="last-granted"> <text /> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="element-ban">
+        <element name="ban">
+            <attribute name="id"> <text /> </attribute>
+            <attribute name="resource"> <text /> </attribute>
+            <attribute name="node"> <text /> </attribute>
+            <attribute name="weight"> <data type="integer" /> </attribute>
+            <attribute name="promoted-only"> <data type="boolean" /> </attribute>
+            <!-- DEPRECATED: master_only is a duplicate of promoted-only that is
+                 provided solely for API backward compatibility. It will be
+                 removed in a future release. Check promoted-only instead.
+              -->
+            <attribute name="master_only"> <data type="boolean" /> </attribute>
+        </element>
+    </define>
+</grammar>


### PR DESCRIPTION
`crm_mon` shows which node the update came from, when run against a native (live) CIB. The `last_update` origin is not reliably meaningful[1] for CIB files or remote CIB connections and is thus not shown.

For simplicity, the `last_update` origin is also not shown if for some reason we fail to get the node name from the controller when using a native CIB. If desired, we can show "on unknown node" or similar in the output in that situation.

Closes T174

[1] By "not reliably meaningful," I mean that there are a few possibilities. For example:
* The requester node (the node running `crm_mon`) is a member of the source cluster (the cluster that we're getting the CIB from via a file or CIB remote). In this case, the node name is meaningful, but we certainly can't rely on this and can't check it conclusively.
* The requester node is not a member of the source cluster, and there is no node with the same name in the source cluster. This is a bit confusing but not terribly so.
* The requester node is not a member of the source cluster, and there is a node with the same name in the source cluster. This could be quite confusing.
Even if we use use the requester node's hostname instead of getting its node name (if the controller is available), that doesn't necessarily avoid any of the above.

It seems like the clearest approach is either to omit the `last_updated` origin for non-native CIB (as I've done here) or explicitly say "on unknown node".