### PR TITLE
Feature: tools: crm_mon detailed fencing history now shows nanoseconds

### DIFF
--- a/include/crm/common/iso8601.h
+++ b/include/crm/common/iso8601.h
@@ -73,6 +73,7 @@ void crm_time_log_alias(int log_level, const char *file, const char *function,
 #  define crm_time_weeks             0x020
 #  define crm_time_seconds           0x100
 #  define crm_time_epoch             0x200
+#  define crm_time_usecs             0x400
 
 crm_time_t *crm_time_parse_duration(const char *duration_str);
 crm_time_t *crm_time_calculate_duration(const crm_time_t *dt,

--- a/include/crm/common/iso8601_internal.h
+++ b/include/crm/common/iso8601_internal.h
@@ -25,6 +25,7 @@ pcmk__time_hr_t *pcmk__time_hr_new(const char *date_time);
 void pcmk__time_hr_free(pcmk__time_hr_t *hr_dt);
 char *pcmk__time_format_hr(const char *format, const pcmk__time_hr_t *hr_dt);
 char *pcmk__epoch2str(const time_t *source, uint32_t flags);
+char *pcmk__timespec2str(const struct timespec *ts, uint32_t flags);
 const char *pcmk__readable_interval(guint interval_ms);
 crm_time_t *pcmk__copy_timet(time_t source);
 

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -263,11 +263,7 @@ crm_time_get_sec(int sec, uint32_t *h, uint32_t *m, uint32_t *s)
 {
     uint32_t hours, minutes, seconds;
 
-    if (sec < 0) {
-        seconds = 0 - sec;
-    } else {
-        seconds = sec;
-    }
+    seconds = QB_ABS(sec);
 
     hours = seconds / HOUR_SECONDS;
     seconds -= HOUR_SECONDS * hours;
@@ -466,16 +462,19 @@ crm_duration_as_string(const crm_time_t *dt, char *result)
                            dt->days, pcmk__plural_s(dt->days));
     }
 
-    if (((offset == 0) || (dt->seconds != 0))
-        && (dt->seconds > -60) && (dt->seconds < 60)) {
+    // At least print seconds
+    if ((offset == 0) || (dt->seconds != 0)) {
         offset += snprintf(result + offset, DATE_MAX - offset, "%d second%s",
                            dt->seconds, pcmk__plural_s(dt->seconds));
-    } else if (dt->seconds) {
+    }
+
+    // More than one minute, so provide a more readable breakdown into units
+    if (QB_ABS(dt->seconds) >= 60) {
         uint32_t h = 0, m = 0, s = 0;
 
-        offset += snprintf(result + offset, DATE_MAX - offset, "%d seconds (",
-                           dt->seconds);
         crm_time_get_sec(dt->seconds, &h, &m, &s);
+
+        offset += snprintf(result + offset, DATE_MAX - offset, " (");
         if (h) {
             offset += snprintf(result + offset, DATE_MAX - offset,
                                "%" PRIu32 " hour%s%s", h, pcmk__plural_s(h),

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1847,7 +1847,7 @@ pcmk__time_format_hr(const char *format, const pcmk__time_hr_t *hr_dt)
  *
  * \param[in]  source  Pointer to epoch time value (or \p NULL for current time)
  * \param[in]  flags   Group of \p crm_time_* flags controlling display format
- *                     format (0 to use \p ctime() with newline removed)
+ *                     (0 to use \p ctime() with newline removed)
  *
  * \return String representation of \p source on success (may be empty depending
  *         on \p flags; guaranteed not to be \p NULL)

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1878,6 +1878,41 @@ pcmk__epoch2str(const time_t *source, uint32_t flags)
 
 /*!
  * \internal
+ * \brief Return a human-friendly string corresponding to seconds-and-
+ *        nanoseconds value
+ *
+ * Time is shown with microsecond resolution if \p crm_time_usecs is in \p
+ * flags.
+ *
+ * \param[in]  ts     Time in seconds and nanoseconds (or \p NULL for current
+ *                    time)
+ * \param[in]  flags  Group of \p crm_time_* flags controlling display format
+ *
+ * \return String representation of \p ts on success (may be empty depending on
+ *         \p flags; guaranteed not to be \p NULL)
+ *
+ * \note The caller is responsible for freeing the return value using \p free().
+ */
+char *
+pcmk__timespec2str(const struct timespec *ts, uint32_t flags)
+{
+    struct timespec tmp_ts;
+    crm_time_t dt;
+    char result[DATE_MAX] = { 0 };
+    char *result_copy = NULL;
+
+    if (ts == NULL) {
+        qb_util_timespec_from_epoch_get(&tmp_ts);
+        ts = &tmp_ts;
+    }
+    crm_time_set_timet(&dt, &ts->tv_sec);
+    time_as_string_common(&dt, ts->tv_nsec / QB_TIME_NS_IN_USEC, flags, result);
+    pcmk__str_update(&result_copy, result);
+    return result_copy;
+}
+
+/*!
+ * \internal
  * \brief Given a millisecond interval, return a log-friendly string
  *
  * \param[in] interval_ms  Interval in milliseconds

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -20,7 +20,6 @@
 #include <ctype.h>
 #include <float.h>  // DBL_MIN
 #include <limits.h>
-#include <math.h>   // fabs()
 #include <bzlib.h>
 #include <sys/types.h>
 
@@ -227,7 +226,7 @@ pcmk__scan_double(const char *text, double *result, const char *default_text,
              */
             const char *over_under;
 
-            if (fabs(*result) > DBL_MIN) {
+            if (QB_ABS(*result) > DBL_MIN) {
                 rc = EOVERFLOW;
                 over_under = "over";
             } else {
@@ -256,7 +255,7 @@ pcmk__scan_double(const char *text, double *result, const char *default_text,
                       "%.1f instead): No digits found", text,
                       PCMK__PARSE_DBL_DEFAULT);
 
-        } else if (fabs(*result) <= DBL_MIN) {
+        } else if (QB_ABS(*result) <= DBL_MIN) {
             /*
              * errno == 0 and text was parsed, but value might have
              * underflowed.

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -22,12 +22,31 @@
 #include <crm/fencing/internal.h>
 #include <crm/pengine/internal.h>
 
-static inline char *
-time_t_string(time_t when) {
-    return pcmk__epoch2str(&when,
-                           crm_time_log_date
-                           |crm_time_log_timeofday
-                           |crm_time_log_with_timezone);
+/*!
+ * \internal
+ * \brief Convert seconds and nanoseconds to a date/time/time-zone string
+ *
+ * \param[in] sec        Seconds
+ * \param[in] nsec       Nanoseconds
+ * \param[in] show_usec  Whether to show time in microseconds resolution (if
+ *                       false, use seconds resolution)
+ *
+ * \return A string representation of \p sec and \nsec
+ *
+ * \note The caller is responsible for freeing the return value using \p free().
+ */
+static char *
+timespec_string(time_t sec, long nsec, bool show_usec) {
+    const struct timespec ts = {
+        .tv_sec = sec,
+        .tv_nsec = nsec,
+    };
+
+    return pcmk__timespec2str(&ts,
+                              crm_time_log_date
+                              |crm_time_log_timeofday
+                              |crm_time_log_with_timezone
+                              |(show_usec? crm_time_usecs : 0));
 }
 
 /*!
@@ -72,10 +91,11 @@ stonith__history_description(stonith_history_t *history, bool full_history,
                              const char *later_succeeded, uint32_t show_opts)
 {
     GString *str = g_string_sized_new(256); // Generous starting size
-    char *completed_time = NULL;
+    char *completed_time_s = NULL;
 
     if ((history->state == st_failed) || (history->state == st_done)) {
-        completed_time = time_t_string(history->completed);
+        completed_time_s = timespec_string(history->completed,
+                                           history->completed_nsec, true);
     }
 
     pcmk__g_strcat(str,
@@ -120,7 +140,7 @@ stonith__history_description(stonith_history_t *history, bool full_history,
                        NULL);
 
         // For completed actions, add completion time
-        if (completed_time != NULL) {
+        if (completed_time_s != NULL) {
             if (full_history) {
                 g_string_append(str, ", completed");
             } else if (history->state == st_failed) {
@@ -128,12 +148,11 @@ stonith__history_description(stonith_history_t *history, bool full_history,
             } else {
                 g_string_append(str, ", last-successful");
             }
-            pcmk__g_strcat(str, "='", completed_time, "'", NULL);
+            pcmk__g_strcat(str, "='", completed_time_s, "'", NULL);
         }
-    } else { // More human-friendly
-        if (completed_time != NULL) {
-            pcmk__g_strcat(str, " at ", completed_time, NULL);
-        }
+    } else if (completed_time_s != NULL) {
+        // More human-friendly
+        pcmk__g_strcat(str, " at ", completed_time_s, NULL);
     }
 
     if ((history->state == st_failed) && (later_succeeded != NULL)) {
@@ -142,7 +161,7 @@ stonith__history_description(stonith_history_t *history, bool full_history,
                        " succeeded)", NULL);
     }
 
-    free(completed_time);
+    free(completed_time_s);
     return g_string_free(str, FALSE);
 }
 
@@ -322,7 +341,7 @@ last_fenced_xml(pcmk__output_t *out, va_list args) {
     time_t when = va_arg(args, time_t);
 
     if (when) {
-        char *buf = time_t_string(when);
+        char *buf = timespec_string(when, 0, false);
 
         pcmk__output_create_xml_node(out, "last-fenced",
                                      "target", target,
@@ -436,8 +455,6 @@ stonith_event_xml(pcmk__output_t *out, va_list args)
     const char *succeeded G_GNUC_UNUSED = va_arg(args, const char *);
     uint32_t show_opts G_GNUC_UNUSED = va_arg(args, uint32_t);
 
-    char *buf = NULL;
-
     xmlNodePtr node = pcmk__output_create_xml_node(out, "fence_event",
                                                    "action", event->action,
                                                    "target", event->target,
@@ -470,10 +487,12 @@ stonith_event_xml(pcmk__output_t *out, va_list args)
         crm_xml_add(node, "delegate", event->delegate);
     }
 
-    if (event->state == st_failed || event->state == st_done) {
-        buf = time_t_string(event->completed);
-        crm_xml_add(node, "completed", buf);
-        free(buf);
+    if ((event->state == st_failed) || (event->state == st_done)) {
+        char *time_s = timespec_string(event->completed, event->completed_nsec,
+                                       true);
+
+        crm_xml_add(node, "completed", time_s);
+        free(time_s);
     }
 
     return pcmk_rc_ok;

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -22,16 +22,12 @@
 #include <crm/fencing/internal.h>
 #include <crm/pengine/internal.h>
 
-static char *
+static inline char *
 time_t_string(time_t when) {
-    crm_time_t *crm_when = pcmk__copy_timet(when);
-    char *buf = crm_time_as_string(crm_when,
-                                   crm_time_log_date
-                                   |crm_time_log_timeofday
-                                   |crm_time_log_with_timezone);
-
-    crm_time_free(crm_when);
-    return buf;
+    return pcmk__epoch2str(&when,
+                           crm_time_log_date
+                           |crm_time_log_timeofday
+                           |crm_time_log_with_timezone);
 }
 
 /*!

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1436,23 +1436,23 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
     if ((crm_element_value_epoch(xml_op, XML_RSC_OP_LAST_CHANGE,
                                  &epoch) == pcmk_ok) && (epoch > 0)) {
         guint interval_ms = 0;
-        char *s = NULL;
+        char *interval_ms_s = NULL;
         char *rc_change = pcmk__epoch2str(&epoch,
                                           crm_time_log_date
                                           |crm_time_log_timeofday
                                           |crm_time_log_with_timezone);
 
         crm_element_value_ms(xml_op, XML_LRM_ATTR_INTERVAL_MS, &interval_ms);
-        s = pcmk__itoa(interval_ms);
+        interval_ms_s = crm_strdup_printf("%u", interval_ms);
 
         pcmk__xe_set_props(node, XML_RSC_OP_LAST_CHANGE, rc_change,
                            "queued", crm_element_value(xml_op, XML_RSC_OP_T_QUEUE),
                            "exec", crm_element_value(xml_op, XML_RSC_OP_T_EXEC),
-                           "interval", s,
+                           "interval", interval_ms_s,
                            "task", crm_element_value(xml_op, XML_LRM_ATTR_TASK),
                            NULL);
 
-        free(s);
+        free(interval_ms_s);
         free(rc_change);
     }
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1437,13 +1437,13 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
                                  &epoch) == pcmk_ok) && (epoch > 0)) {
         guint interval_ms = 0;
         char *s = NULL;
-        crm_time_t *crm_when = pcmk__copy_timet(epoch);
-        char *rc_change = NULL;
+        char *rc_change = pcmk__epoch2str(&epoch,
+                                          crm_time_log_date
+                                          |crm_time_log_timeofday
+                                          |crm_time_log_with_timezone);
 
         crm_element_value_ms(xml_op, XML_LRM_ATTR_INTERVAL_MS, &interval_ms);
         s = pcmk__itoa(interval_ms);
-
-        rc_change = crm_time_as_string(crm_when, crm_time_log_date | crm_time_log_timeofday | crm_time_log_with_timezone);
 
         pcmk__xe_set_props(node, XML_RSC_OP_LAST_CHANGE, rc_change,
                            "queued", crm_element_value(xml_op, XML_RSC_OP_T_QUEUE),
@@ -1454,7 +1454,6 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
 
         free(s);
         free(rc_change);
-        crm_time_free(crm_when);
     }
 
     free(reason_s);


### PR DESCRIPTION
When detailed fencing history is enabled or an XML output format is used, each fence history item now contains a high-resolution time of completion. A new value "completed-ns" denotes the quantity of nanoseconds to be added to the "completed" time.

Closes T178