### PR TITLE
Handle IPC creation errors

### DIFF
--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -176,6 +176,11 @@ main(int argc, char **argv)
     crm_notice("Starting Pacemaker CIB manager");
 
     old_instance = crm_ipc_new(PCMK__SERVER_BASED_RO, 0);
+    if (old_instance == NULL) {
+        /* crm_ipc_new will have already printed an error message with crm_err. */
+        return CRM_EX_FATAL;
+    }
+
     if (crm_ipc_connect(old_instance)) {
         /* IPC end-point already up */
         crm_ipc_close(old_instance);

--- a/daemons/controld/pacemaker-controld.c
+++ b/daemons/controld/pacemaker-controld.c
@@ -102,6 +102,11 @@ main(int argc, char **argv)
     crm_notice("Starting Pacemaker controller");
 
     old_instance = crm_ipc_new(CRM_SYSTEM_CRMD, 0);
+    if (old_instance == NULL) {
+        /* crm_ipc_new will have already printed an error message with crm_err. */
+        return CRM_EX_FATAL;
+    }
+
     if (crm_ipc_connect(old_instance)) {
         /* IPC end-point already up */
         crm_ipc_close(old_instance);

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -1656,6 +1656,11 @@ main(int argc, char **argv)
     crm_notice("Starting Pacemaker fencer");
 
     old_instance = crm_ipc_new("stonith-ng", 0);
+    if (old_instance == NULL) {
+        /* crm_ipc_new will have already printed an error message with crm_err. */
+        return CRM_EX_FATAL;
+    }
+
     if (crm_ipc_connect(old_instance)) {
         // IPC end-point already up 
         crm_ipc_close(old_instance);

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -201,7 +201,7 @@ cib_native_signon_raw(cib_t * cib, const char *name, enum cib_conn_type type, in
         native->ipc = mainloop_get_ipc_client(native->source);
     }
 
-    if (rc != pcmk_ok || native->ipc == NULL || crm_ipc_connected(native->ipc) == FALSE) {
+    if (rc != pcmk_ok || native->ipc == NULL || !crm_ipc_connected(native->ipc)) {
         crm_info("Could not connect to CIB manager for %s", name);
         rc = -ENOTCONN;
     }
@@ -440,7 +440,7 @@ cib_native_perform_op_delegate(cib_t * cib, const char *op, const char *host, co
     }
 
   done:
-    if (crm_ipc_connected(native->ipc) == FALSE) {
+    if (!crm_ipc_connected(native->ipc)) {
         crm_err("The CIB manager disconnected");
         cib->state = cib_disconnected;
     }

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -854,6 +854,11 @@ crm_ipc_connect(crm_ipc_t *client)
     pid_t found_pid = 0; uid_t found_uid = 0; gid_t found_gid = 0;
     int rv;
 
+    if (client == NULL) {
+        errno = EINVAL;
+        return false;
+    }
+
     client->need_reply = FALSE;
     client->ipc = qb_ipcc_connect(client->server_name, client->buf_size);
 

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1008,7 +1008,7 @@ crm_ipc_ready(crm_ipc_t *client)
 
     CRM_ASSERT(client != NULL);
 
-    if (crm_ipc_connected(client) == FALSE) {
+    if (!crm_ipc_connected(client)) {
         return -ENOTCONN;
     }
 
@@ -1103,7 +1103,7 @@ crm_ipc_read(crm_ipc_t * client)
         }
     }
 
-    if (crm_ipc_connected(client) == FALSE || client->msg_size == -ENOTCONN) {
+    if (!crm_ipc_connected(client) || client->msg_size == -ENOTCONN) {
         crm_err("Connection to %s IPC failed", client->server_name);
     }
 
@@ -1181,7 +1181,7 @@ internal_ipc_get_reply(crm_ipc_t *client, int request_id, int ms_timeout,
                 crm_log_xml_notice(bad, "ImpossibleReply");
                 CRM_ASSERT(hdr->qb.id <= request_id);
             }
-        } else if (crm_ipc_connected(client) == FALSE) {
+        } else if (!crm_ipc_connected(client)) {
             crm_err("%s IPC provider disconnected while waiting for message %d",
                     client->server_name, request_id);
             break;
@@ -1225,7 +1225,7 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
                    message);
         return -ENOTCONN;
 
-    } else if (crm_ipc_connected(client) == FALSE) {
+    } else if (!crm_ipc_connected(client)) {
         /* Don't even bother */
         crm_notice("Can't send %s IPC requests: Connection closed",
                    client->server_name);
@@ -1343,7 +1343,7 @@ crm_ipc_send(crm_ipc_t * client, xmlNode * message, enum crm_ipc_flags flags, in
     }
 
   send_cleanup:
-    if (crm_ipc_connected(client) == FALSE) {
+    if (!crm_ipc_connected(client)) {
         crm_notice("Couldn't send %s IPC request %d: Connection closed "
                    CRM_XS " rc=%d", client->server_name, header->qb.id, rc);
 

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -842,7 +842,7 @@ crm_ipc_new(const char *name, size_t max_size)
  *
  * \param[in,out] client  Connection instance obtained from crm_ipc_new()
  *
- * \return TRUE on success, FALSE otherwise (in which case errno will be set;
+ * \return true on success, false otherwise (in which case errno will be set;
  *         specifically, in case of discovering the remote side is not
  *         authentic, its value is set to ECONNABORTED).
  */
@@ -860,7 +860,7 @@ crm_ipc_connect(crm_ipc_t *client)
     if (client->ipc == NULL) {
         crm_debug("Could not establish %s IPC connection: %s (%d)",
                   client->server_name, pcmk_rc_str(errno), errno);
-        return FALSE;
+        return false;
     }
 
     client->pfd.fd = crm_ipc_get_fd(client);
@@ -869,7 +869,7 @@ crm_ipc_connect(crm_ipc_t *client)
         /* message already omitted */
         crm_ipc_close(client);
         errno = rv;
-        return FALSE;
+        return false;
     }
 
     rv = pcmk_daemon_user(&cl_uid, &cl_gid);
@@ -877,7 +877,7 @@ crm_ipc_connect(crm_ipc_t *client)
         /* message already omitted */
         crm_ipc_close(client);
         errno = -rv;
-        return FALSE;
+        return false;
     }
 
     if ((rv = pcmk__crm_ipc_is_authentic_process(client->ipc, client->pfd.fd, cl_uid, cl_gid,
@@ -891,7 +891,7 @@ crm_ipc_connect(crm_ipc_t *client)
                 (long long) found_gid, (long long) cl_gid);
         crm_ipc_close(client);
         errno = ECONNABORTED;
-        return FALSE;
+        return false;
 
     } else if (rv != pcmk_rc_ok) {
         crm_perror(LOG_ERR, "Could not verify authenticity of %s IPC provider",
@@ -902,7 +902,7 @@ crm_ipc_connect(crm_ipc_t *client)
         } else {
             errno = ENOTCONN;
         }
-        return FALSE;
+        return false;
     }
 
     qb_ipcc_context_set(client->ipc, client);
@@ -913,7 +913,7 @@ crm_ipc_connect(crm_ipc_t *client)
         client->buffer = calloc(1, client->max_buf_size);
         client->buf_size = client->max_buf_size;
     }
-    return TRUE;
+    return true;
 }
 
 void

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -768,7 +768,7 @@ mainloop_gio_callback(GIOChannel *gio, GIOCondition condition, gpointer data)
         }
     }
 
-    if (client->ipc && crm_ipc_connected(client->ipc) == FALSE) {
+    if (client->ipc && !crm_ipc_connected(client->ipc)) {
         crm_err("Connection to %s closed " CRM_XS "client=%p condition=%d",
                 client->name, client, condition);
         rc = G_SOURCE_REMOVE;

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1634,7 +1634,7 @@ stonith_send_command(stonith_t * stonith, const char *op, xmlNode * data, xmlNod
     }
 
   done:
-    if (crm_ipc_connected(native->ipc) == FALSE) {
+    if (!crm_ipc_connected(native->ipc)) {
         crm_err("Fencer disconnected");
         free(native->token); native->token = NULL;
         stonith->state = stonith_disconnected;
@@ -1662,7 +1662,7 @@ stonith_dispatch(stonith_t * st)
             stonith_dispatch_internal(msg, strlen(msg), st);
         }
 
-        if (crm_ipc_connected(private->ipc) == FALSE) {
+        if (!crm_ipc_connected(private->ipc)) {
             crm_err("Connection closed");
             stay_connected = FALSE;
         }

--- a/lib/lrmd/proxy_common.c
+++ b/lib/lrmd/proxy_common.c
@@ -240,7 +240,7 @@ remote_proxy_cb(lrmd_t *lrmd, const char *node_name, xmlNode *msg)
         CRM_CHECK(proxy->is_local == FALSE,
                   remote_proxy_end_session(proxy); return);
 
-        if (crm_ipc_connected(proxy->ipc) == FALSE) {
+        if (!crm_ipc_connected(proxy->ipc)) {
             remote_proxy_end_session(proxy);
             return;
         }


### PR DESCRIPTION
It turns out there aren't that many places that call crm_ipc_new and weren't handling NULL.  A lot of the callers are already sort of indirectly doing so with constructions like this:

```
        native->ipc = crm_ipc_new("stonith-ng", 0);

        if (native->ipc && crm_ipc_connect(native->ipc)) {
            ...
        } else if (native->ipc) {
            ...
        }

    } else {
        ...
    }

    if (native->ipc == NULL) {
        rc = -ENOTCONN;
```

It's not especially obvious at first glance, but it looks like it works.  I could modify all these places to be more clear, though.