### PR TITLE
Low: daemons: Set an attribute on the child of a multi-attr message.

### DIFF
--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -552,7 +552,7 @@ attrd_peer_update(const crm_node_t *peer, xmlNode *xml, const char *host,
              child = crm_next_same_xml(child)) {
             /* Set the node name on the child message, assuming it isn't already. */
             if (crm_element_value(child, PCMK__XA_ATTR_NODE_NAME) == NULL) {
-                pcmk__xe_add_node(xml, host, 0);
+                pcmk__xe_add_node(child, host, 0);
             }
 
             attrd_peer_update_one(peer, child, filter);


### PR DESCRIPTION
It's already set on the parent.  It doesn't need to be set there again. This was a thinko introduced with b2937595b2e83a836edb2953104e896be0ac9f5a.