### PR TITLE
Test: cts-cli: add test for text output of crm_resource --list-operations/-O

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -4395,6 +4395,20 @@ Resources colocated with gr2:
 =#=#=#= End test: Show resource digests with overrides - OK (0) =#=#=#=
 * Passed: crm_resource   - Show resource digests with overrides
 =#=#=#= Begin test: Show resource operations =#=#=#=
+rsc1	(ocf:pacemaker:Dummy):	 Started: rsc1_monitor_0 (node=node4, call=136, rc=7, last-rc-change=Sun Nov 22 21:22:53 2020, exec=28ms): complete
+Fencing	(stonith:fence_xvm):	 Started: Fencing_monitor_0 (node=node4, call=5, rc=7, last-rc-change=Sun Nov 22 21:17:07 2020, exec=2ms): complete
+rsc1	(ocf:pacemaker:Dummy):	 Started: rsc1_monitor_0 (node=node2, call=101, rc=7, last-rc-change=Sun Nov 22 21:22:53 2020, exec=45ms): complete
+Fencing	(stonith:fence_xvm):	 Started: Fencing_monitor_0 (node=node2, call=5, rc=7, last-rc-change=Sun Nov 22 21:17:07 2020, exec=4ms): complete
+Fencing	(stonith:fence_xvm):	 Started: Fencing_monitor_0 (node=node3, call=5, rc=7, last-rc-change=Sun Nov 22 21:17:07 2020, exec=24ms): complete
+rsc1	(ocf:pacemaker:Dummy):	 Started: rsc1_monitor_0 (node=node5, call=99, rc=193, last-rc-change=Sun Nov 22 21:22:53 2020, exec=27ms): pending
+Fencing	(stonith:fence_xvm):	 Started: Fencing_monitor_0 (node=node5, call=5, rc=7, last-rc-change=Sun Nov 22 21:17:07 2020, exec=14ms): complete
+rsc1	(ocf:pacemaker:Dummy):	 Started: rsc1_start_0 (node=node1, call=104, rc=0, last-rc-change=Sun Nov 22 21:45:16 2020, exec=22ms): complete
+rsc1	(ocf:pacemaker:Dummy):	 Started: rsc1_monitor_10000 (node=node1, call=106, rc=0, last-rc-change=Sun Nov 22 21:45:16 2020, exec=20ms): complete
+Fencing	(stonith:fence_xvm):	 Started: Fencing_start_0 (node=node1, call=10, rc=0, last-rc-change=Sun Nov 22 21:17:07 2020, exec=59ms): complete
+Fencing	(stonith:fence_xvm):	 Started: Fencing_monitor_120000 (node=node1, call=12, rc=0, last-rc-change=Sun Nov 22 21:17:07 2020, exec=70ms): complete
+=#=#=#= End test: Show resource operations - OK (0) =#=#=#=
+* Passed: crm_resource   - Show resource operations
+=#=#=#= Begin test: Show resource operations (XML) =#=#=#=
 <pacemaker-result api-version="X" request="crm_resource --list-operations --output-as=xml">
   <operations>
     <operation op="rsc1_monitor_0" node="node4" call="136" rc="7" status="complete" rsc="rsc1" agent="ocf:pacemaker:Dummy" exec-time="28"/>
@@ -4411,8 +4425,8 @@ Resources colocated with gr2:
   </operations>
   <status code="0" message="OK"/>
 </pacemaker-result>
-=#=#=#= End test: Show resource operations - OK (0) =#=#=#=
-* Passed: crm_resource   - Show resource operations
+=#=#=#= End test: Show resource operations (XML) - OK (0) =#=#=#=
+* Passed: crm_resource   - Show resource operations (XML)
 =#=#=#= Begin test: List all nodes =#=#=#=
 cluster node: overcloud-controller-0 (1)
 cluster node: overcloud-controller-1 (2)

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1262,6 +1262,10 @@ function test_tools() {
     test_assert $CRM_EX_OK 0
 
     desc="Show resource operations"
+    cmd="crm_resource --list-operations"
+    test_assert $CRM_EX_OK 0
+
+    desc="Show resource operations (XML)"
     cmd="crm_resource --list-operations --output-as=xml"
     test_assert_validate $CRM_EX_OK 0
 


### PR DESCRIPTION
So that it covers the case of correctly displaying pending operations also in text output addressed by fe9150bc4.