### PR TITLE
Support transient utilization attributes

### DIFF
--- a/cts/scheduler/xml/utilization.xml
+++ b/cts/scheduler/xml/utilization.xml
@@ -16,7 +16,6 @@
       </node>
       <node id="host2" type="member" uname="host2">
         <utilization id="host2-utilization">
-          <nvpair id="host2-utilization-cpu" name="cpu" value="2"/>
           <nvpair id="host2-utilization-memory" name="memory" value="1024"/>
         </utilization>
       </node>
@@ -42,6 +41,12 @@
   </configuration>
   <status>
     <node_state id="host1" uname="host1" ha="active" in_ccm="true" crmd="online" join="member" expected="member" crm-debug-origin="do_update_resource" shutdown="0"/>
-    <node_state id="host2" uname="host2" ha="active" in_ccm="true" crmd="online" join="member" expected="member" crm-debug-origin="do_update_resource" shutdown="0"/>
+    <node_state id="host2" uname="host2" ha="active" in_ccm="true" crmd="online" join="member" expected="member" crm-debug-origin="do_update_resource" shutdown="0">
+      <transient_attributes id="host2-1">
+        <utilization id="status-host2-1">
+          <nvpair id="host2-utilization-cpu" name="cpu" value="2"/>
+        </utilization>
+      </transient_attributes>
+    </node_state>
   </status>
 </cib>

--- a/daemons/attrd/attrd_attributes.c
+++ b/daemons/attrd/attrd_attributes.c
@@ -30,7 +30,7 @@ attrd_create_attribute(xmlNode *xml)
     attribute_t *a = calloc(1, sizeof(attribute_t));
 
     a->id      = crm_element_value_copy(xml, PCMK__XA_ATTR_NAME);
-    a->set     = crm_element_value_copy(xml, PCMK__XA_ATTR_SET);
+    a->set_id  = crm_element_value_copy(xml, PCMK__XA_ATTR_SET);
     a->uuid    = crm_element_value_copy(xml, PCMK__XA_ATTR_UUID);
     a->values = pcmk__strikey_table(NULL, attrd_free_attribute_value);
 
@@ -116,7 +116,7 @@ attrd_add_value_xml(xmlNode *parent, const attribute_t *a,
     xmlNode *xml = create_xml_node(parent, __func__);
 
     crm_xml_add(xml, PCMK__XA_ATTR_NAME, a->id);
-    crm_xml_add(xml, PCMK__XA_ATTR_SET, a->set);
+    crm_xml_add(xml, PCMK__XA_ATTR_SET, a->set_id);
     crm_xml_add(xml, PCMK__XA_ATTR_UUID, a->uuid);
     crm_xml_add(xml, PCMK__XA_ATTR_USER, a->user);
     pcmk__xe_add_node(xml, v->nodename, v->nodeid);

--- a/daemons/attrd/attrd_attributes.c
+++ b/daemons/attrd/attrd_attributes.c
@@ -31,6 +31,7 @@ attrd_create_attribute(xmlNode *xml)
 
     a->id      = crm_element_value_copy(xml, PCMK__XA_ATTR_NAME);
     a->set_id  = crm_element_value_copy(xml, PCMK__XA_ATTR_SET);
+    a->set_type = crm_element_value_copy(xml, PCMK__XA_ATTR_SET_TYPE);
     a->uuid    = crm_element_value_copy(xml, PCMK__XA_ATTR_UUID);
     a->values = pcmk__strikey_table(NULL, attrd_free_attribute_value);
 

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -134,8 +134,8 @@ build_update_element(xmlNode *parent, attribute_t *a, const char *nodeid, const 
     crm_xml_add(xml_obj, XML_ATTR_ID, nodeid);
 
     xml_obj = create_xml_node(xml_obj, XML_TAG_ATTR_SETS);
-    if (a->set) {
-        crm_xml_set_id(xml_obj, "%s", a->set);
+    if (a->set_id) {
+        crm_xml_set_id(xml_obj, "%s", a->set_id);
     } else {
         crm_xml_set_id(xml_obj, "%s-%s", XML_CIB_TAG_STATUS, nodeid);
     }
@@ -310,7 +310,7 @@ attrd_write_attribute(attribute_t *a, bool ignore_delay)
     if (private_updates) {
         crm_info("Processed %d private change%s for %s, id=%s, set=%s",
                  private_updates, pcmk__plural_s(private_updates),
-                 a->id, pcmk__s(a->uuid, "n/a"), pcmk__s(a->set, "n/a"));
+                 a->id, pcmk__s(a->uuid, "n/a"), pcmk__s(a->set_id, "n/a"));
     }
     if (cib_updates) {
         crm_log_xml_trace(xml_top, __func__);
@@ -321,7 +321,7 @@ attrd_write_attribute(attribute_t *a, bool ignore_delay)
 
         crm_info("Sent CIB request %d with %d change%s for %s (id %s, set %s)",
                  a->update, cib_updates, pcmk__plural_s(cib_updates),
-                 a->id, pcmk__s(a->uuid, "n/a"), pcmk__s(a->set, "n/a"));
+                 a->id, pcmk__s(a->uuid, "n/a"), pcmk__s(a->set_id, "n/a"));
 
         the_cib->cmds->register_callback_full(the_cib, a->update,
                                               CIB_OP_TIMEOUT_S, FALSE,

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -133,7 +133,14 @@ build_update_element(xmlNode *parent, attribute_t *a, const char *nodeid, const 
     xml_obj = create_xml_node(xml_obj, XML_TAG_TRANSIENT_NODEATTRS);
     crm_xml_add(xml_obj, XML_ATTR_ID, nodeid);
 
-    xml_obj = create_xml_node(xml_obj, XML_TAG_ATTR_SETS);
+    if (pcmk__str_eq(a->set_type, XML_TAG_ATTR_SETS, pcmk__str_null_matches)) {
+        xml_obj = create_xml_node(xml_obj, XML_TAG_ATTR_SETS);
+    } else if (pcmk__str_eq(a->set_type, XML_TAG_UTILIZATION, pcmk__str_none)) {
+        xml_obj = create_xml_node(xml_obj, XML_TAG_UTILIZATION);
+    } else {
+        crm_err("Unknown set type attribute: %s", a->set_type);
+    }
+
     if (a->set_id) {
         crm_xml_set_id(xml_obj, "%s", a->set_id);
     } else {

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -273,7 +273,7 @@ attrd_free_attribute(gpointer data)
     attribute_t *a = data;
     if(a) {
         free(a->id);
-        free(a->set);
+        free(a->set_id);
         free(a->uuid);
         free(a->user);
 

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -274,6 +274,7 @@ attrd_free_attribute(gpointer data)
     if(a) {
         free(a->id);
         free(a->set_id);
+        free(a->set_type);
         free(a->uuid);
         free(a->user);
 

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -120,6 +120,7 @@ typedef struct attribute_s {
     char *uuid; /* TODO: Remove if at all possible */
     char *id;
     char *set_id;
+    char *set_type;
     GHashTable *values;
     int update;
     int timeout_ms;

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -119,7 +119,7 @@ void attrd_xml_add_writer(xmlNode *xml);
 typedef struct attribute_s {
     char *uuid; /* TODO: Remove if at all possible */
     char *id;
-    char *set;
+    char *set_id;
     GHashTable *values;
     int update;
     int timeout_ms;

--- a/doc/sphinx/Pacemaker_Explained/utilization.rst
+++ b/doc/sphinx/Pacemaker_Explained/utilization.rst
@@ -37,7 +37,7 @@ You can name utilization attributes according to your preferences and define as
 many name/value pairs as your configuration needs. However, the attributes'
 values must be integers.
 
-.. topic: Specifying CPU and RAM capacities of two nodes
+.. topic:: Specifying CPU and RAM capacities of two nodes
 
    .. code-block:: xml
 
@@ -82,6 +82,21 @@ capacity to satisfy the resource's requirements. The nature of the required
 or provided capacities is completely irrelevant to Pacemaker -- it just makes
 sure that all capacity requirements of a resource are satisfied before placing
 a resource to a node.
+
+Utilization attributes used on a node object can also be *transient* *(since 2.1.6)*.
+These attributes are added to a ``transient_attributes`` section for the node
+and are forgotten by the cluster when the node goes offline.  The ``attrd_updater``
+tool can be used to set these attributes.
+
+.. topic:: Transient utilization attribute for node cluster-1
+
+   .. code-block:: xml
+
+      <transient_attributes id="cluster-1">
+        <utilization id="status-cluster-1">
+          <nvpair id="status-cluster-1-cpu" name="cpu" value="1"/>
+        </utilization>
+      </transient_attributes>
 
 .. note::
 

--- a/include/crm/common/attrd_internal.h
+++ b/include/crm/common/attrd_internal.h
@@ -25,6 +25,7 @@ enum pcmk__node_attr_opts {
     pcmk__node_attr_perm           = (1 << 5),
     pcmk__node_attr_sync_local     = (1 << 6),
     pcmk__node_attr_sync_cluster   = (1 << 7),
+    pcmk__node_attr_utilization    = (1 << 8),
 };
 
 #define pcmk__set_node_attr_flags(node_attr_flags, flags_to_set) do {   \

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -71,6 +71,7 @@
 #define PCMK__XA_ATTR_RESOURCE          "attr_resource"
 #define PCMK__XA_ATTR_SECTION           "attr_section"
 #define PCMK__XA_ATTR_SET               "attr_set"
+#define PCMK__XA_ATTR_SET_TYPE          "attr_set_type"
 #define PCMK__XA_ATTR_SYNC_POINT        "attr_sync_point"
 #define PCMK__XA_ATTR_USER              "attr_user"
 #define PCMK__XA_ATTR_UUID              "attr_key"

--- a/lib/common/ipc_attrd.c
+++ b/lib/common/ipc_attrd.c
@@ -421,6 +421,12 @@ populate_update_op(xmlNode *op, const char *node, const char *name, const char *
         crm_xml_add(op, PCMK__XA_ATTR_NAME, name);
     }
 
+    if (pcmk_is_set(options, pcmk__node_attr_utilization)) {
+        crm_xml_add(op, PCMK__XA_ATTR_SET_TYPE, XML_TAG_UTILIZATION);
+    } else {
+        crm_xml_add(op, PCMK__XA_ATTR_SET_TYPE, XML_TAG_ATTR_SETS);
+    }
+
     add_op_attr(op, options);
 
     crm_xml_add(op, PCMK__XA_ATTR_VALUE, value);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -543,15 +543,6 @@ unpack_nodes(xmlNode * xml_nodes, pe_working_set_t * data_set)
     const char *type = NULL;
     const char *score = NULL;
 
-    pe_rule_eval_data_t rule_data = {
-        .node_hash = NULL,
-        .role = RSC_ROLE_UNKNOWN,
-        .now = data_set->now,
-        .match_data = NULL,
-        .rsc_data = NULL,
-        .op_data = NULL
-    };
-
     for (xml_obj = pcmk__xe_first_child(xml_nodes); xml_obj != NULL;
          xml_obj = pcmk__xe_next(xml_obj)) {
 
@@ -578,9 +569,6 @@ unpack_nodes(xmlNode * xml_nodes, pe_working_set_t * data_set)
             handle_startup_fencing(data_set, new_node);
 
             add_node_attrs(xml_obj, new_node, FALSE, data_set);
-            pe__unpack_dataset_nvpairs(xml_obj, XML_TAG_UTILIZATION, &rule_data,
-                                       new_node->details->utilization, NULL,
-                                       FALSE, data_set);
 
             crm_trace("Done with node %s", crm_element_value(xml_obj, XML_ATTR_UNAME));
         }
@@ -4244,6 +4232,10 @@ add_node_attrs(xmlNode *xml_obj, pe_node_t *node, bool overwrite,
 
     pe__unpack_dataset_nvpairs(xml_obj, XML_TAG_ATTR_SETS, &rule_data,
                                node->details->attrs, NULL, overwrite, data_set);
+
+    pe__unpack_dataset_nvpairs(xml_obj, XML_TAG_UTILIZATION, &rule_data,
+                               node->details->utilization, NULL,
+                               FALSE, data_set);
 
     if (pe_node_attribute_raw(node, CRM_ATTR_SITE_NAME) == NULL) {
         const char *site_name = pe_node_attribute_raw(node, "site-name");

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -98,6 +98,15 @@ section_cb (const gchar *option_name, const gchar *optarg, gpointer data, GError
 }
 
 static gboolean
+attr_set_type_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+    if (pcmk__str_any_of(option_name, "-z", "--utilization", NULL)) {
+        pcmk__set_node_attr_flags(options.attr_options, pcmk__node_attr_utilization);
+    }
+
+    return TRUE;
+}
+
+static gboolean
 wait_cb (const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     if (pcmk__str_eq(optarg, "no", pcmk__str_none)) {
         pcmk__clear_node_attr_flags(options.attr_options, pcmk__node_attr_sync_local | pcmk__node_attr_sync_cluster);
@@ -204,6 +213,13 @@ static GOptionEntry addl_entries[] = {
       INDENT "to where a query anywhere on the cluster will return the requested\n"
       INDENT "value, or the value set by a later request).  Default is 'no'.",
       "UNTIL" },
+
+    { "utilization", 'z', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, attr_set_type_cb,
+      "When creating a new attribute, create it as a node utilization attribute\n"
+      INDENT "instead of an instance attribute.  If the attribute already exists,\n"
+      INDENT "its existing type (utilization vs. instance) will be used regardless.\n"
+      INDENT "(with -B, -U, -Y)",
+      NULL },
 
     { NULL }
 };

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -793,6 +793,10 @@ main(int argc, char **argv)
         attrd_opts = pcmk__node_attr_remote;
     }
 
+    if (pcmk__str_eq(options.set_type, XML_TAG_UTILIZATION, pcmk__str_none)) {
+        attrd_opts |= pcmk__node_attr_utilization;
+    }
+
     if (try_ipc_update() &&
         (send_attrd_update(options.command, options.dest_uname, options.attr_name,
                            options.attr_value, options.set_name, NULL, attrd_opts) == pcmk_rc_ok)) {


### PR DESCRIPTION
This seems suspiciously easy.

Basically, you use attrd_updater -z when creating an attribute to specify it's a utilization attribute (just like in crm_attribute).  After that, you don't need to use -z when updating or deleting - it'll just know which block the attribute is in.  The CIB ends up with something like this in it:

```
      <transient_attributes id="1">
        <instance_attributes id="status-1">
          <nvpair id="status-1-.feature-set" name="#feature-set" value="3.16.2"/>
          <nvpair id="status-1-master-stateful" name="master-stateful" value="5"/>
          <nvpair id="status-1-last-failure-httpd-bundle-podman-0.start_0" name="last-failure-httpd-bundle-podman-0#start_0" value="1668202467"/>
          <nvpair id="status-1-fail-count-httpd-bundle-podman-0.start_0" name="fail-count-httpd-bundle-podman-0#start_0" value="INFINITY"/>
          <nvpair id="status-1-last-failure-httpd-bundle-podman-1.start_0" name="last-failure-httpd-bundle-podman-1#start_0" value="1668202472"/>
          <nvpair id="status-1-fail-count-httpd-bundle-podman-1.start_0" name="fail-count-httpd-bundle-podman-1#start_0" value="INFINITY"/>
        </instance_attributes>
        <utilization id="status-1">
          <nvpair id="status-1-ABC" name="ABC" value="123"/>
        </utilization>
      </transient_attributes>
    </node_state>
```

Things that still need to be tested:

* [x] Is it possible to have two attributes with the same name where one is a utilization attr and the other is an instance attr?
* [x] I haven't checked that the value of a transient utilization attr actually gets included when calculating utilization.
* [x] I haven't checked that a multi-attr message works here, but I don't see why it wouldn't.  As an aside - it'd be great to have a way to test this that doesn't involve hacking some code in here and there every time.  Some sort of test program, or compile-time #define, or something would be great.
* [x] I haven't tested this with sync points, but again I don't see why it wouldn't work.  Nothing has changed there.