### PR TITLE
Low: controller: Node exits fatally in response to join nack

### DIFF
--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -255,6 +255,7 @@ do_cl_join_finalize_respond(long long action,
         crm_err("Shutting down because cluster join with leader %s failed "
                 CRM_XS" join-%d NACK'd", welcome_from, join_id);
         register_fsa_error(C_FSA_INTERNAL, I_ERROR, NULL);
+        controld_set_fsa_input_flags(R_STAYDOWN);
         return;
     }
 

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -668,7 +668,10 @@ finalize_join_for(gpointer key, gpointer value, gpointer user_data)
             return;
     }
 
-    crm_trace("Updating node state for %s", join_to);
+    /* Update the <node> element with the node's name and UUID, in case they
+     * weren't known before
+     */
+    crm_trace("Updating node name and UUID in CIB for %s", join_to);
     tmp1 = create_xml_node(NULL, XML_CIB_TAG_NODE);
     set_uuid(tmp1, XML_ATTR_UUID, join_node);
     crm_xml_add(tmp1, XML_ATTR_UNAME, join_to);

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -33,6 +33,12 @@ extern unsigned long long crm_peer_seq;
 #define CRM_NODE_MEMBER    "member"
 
 enum crm_join_phase {
+    /* @COMPAT: crm_join_nack_quiet can be replaced by a new
+     *          crm_node_t:feature_set at a compatibility break.
+     */
+    //! Not allowed to join, but don't send a nack message
+    crm_join_nack_quiet = -2,
+
     crm_join_nack       = -1,
     crm_join_none       = 0,
     crm_join_welcomed   = 1,
@@ -201,14 +207,15 @@ static inline const char *
 crm_join_phase_str(enum crm_join_phase phase)
 {
     switch (phase) {
+        case crm_join_nack_quiet:   return "nack_quiet";
         case crm_join_nack:         return "nack";
         case crm_join_none:         return "none";
         case crm_join_welcomed:     return "welcomed";
         case crm_join_integrated:   return "integrated";
         case crm_join_finalized:    return "finalized";
         case crm_join_confirmed:    return "confirmed";
+        default:                    return "invalid";
     }
-    return "invalid";
 }
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -33,8 +33,8 @@ extern unsigned long long crm_peer_seq;
 #define CRM_NODE_MEMBER    "member"
 
 enum crm_join_phase {
-    /* @COMPAT: crm_join_nack_quiet can be replaced by a new
-     *          crm_node_t:feature_set at a compatibility break.
+    /* @COMPAT: crm_join_nack_quiet can be replaced by crm_node_t:user_data
+     *          at a compatibility break.
      */
     //! Not allowed to join, but don't send a nack message
     crm_join_nack_quiet = -2,

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -66,7 +66,7 @@ extern "C" {
  * >=3.0.13: Fail counts include operation name and interval
  * >=3.2.0:  DC supports PCMK_EXEC_INVALID and PCMK_EXEC_NOT_CONNECTED
  */
-#  define CRM_FEATURE_SET		"3.16.2"
+#  define CRM_FEATURE_SET		"3.17.0"
 
 /* Pacemaker's CPG protocols use fixed-width binary fields for the sender and
  * recipient of a CPG message. This imposes an arbitrary limit on cluster node


### PR DESCRIPTION
The client already listens for a nack in `do_cl_join_finalize_respond()`, but the DC never sends one. Rather, the DC only sends a finalization message if the node is integrated (acked).

The only change needed at the client end is to exit fatally with no respawn. Currently, if the client were to receive a nack, it would respawn and enter a rapid loop (observed after modifying the DC to send a nack).

The DC needs to send a nack, which means it needs to finalize if there are **either** integrated nodes **or** nacked nodes. There may be a better place to put the nack message than the `finalize_join_for()` function -- or perhaps the function should be renamed -- but this seems to work.

I'm open to other approaches if this isn't ideal. I'll have CTSlab running overnight. So far things have gone well. I added an if condition to `do_dc_join_filter_offer()` that rejects `node2`:
```
if (pcmk__str_eq(join_node, "node2", pcmk__str_none)) {
        crm_err("Rejecting join-%d request from node %s for testing purposes "
                CRM_XS " ref=%s", join_id, join_from, ref);
        ack_nack_bool = FALSE;

} else if (crm_is_peer_active(join_node) == FALSE) {
        ...
```

Before this commit, things sort of hang because the client never receives a nack message. If I only make the DC-side change (to send the nack), the client respawns repeatedly. After making the DC change and the client change, the client shuts down and stays down.

Closes T453

P.S. Not sure if this qualifies as a "Feature" for the commit message