### PR TITLE
Refactor: controller: Make global variables easier to follow (part 1)

### DIFF
--- a/daemons/controld/Makefile.am
+++ b/daemons/controld/Makefile.am
@@ -19,7 +19,6 @@ noinst_HEADERS	= controld_alerts.h		\
 		  controld_fencing.h		\
 		  controld_fsa.h		\
 		  controld_lrm.h		\
-		  controld_matrix.h		\
 		  controld_membership.h		\
 		  controld_messages.h		\
 		  controld_metadata.h		\
@@ -56,6 +55,7 @@ pacemaker_controld_SOURCES = pacemaker-controld.c	\
 			     controld_fsa.c		\
 			     controld_join_client.c	\
 			     controld_join_dc.c		\
+			     controld_matrix.c		\
 			     controld_membership.c	\
 			     controld_messages.c	\
 			     controld_metadata.c	\

--- a/daemons/controld/controld_alerts.c
+++ b/daemons/controld/controld_alerts.c
@@ -39,7 +39,7 @@ crmd_alert_node_event(crm_node_t *node)
         return;
     }
 
-    lrm_state = lrm_state_find(fsa_our_uname);
+    lrm_state = lrm_state_find(controld_globals.our_nodename);
     if (lrm_state == NULL) {
         return;
     }
@@ -58,7 +58,7 @@ crmd_alert_fencing_op(stonith_event_t * e)
         return;
     }
 
-    lrm_state = lrm_state_find(fsa_our_uname);
+    lrm_state = lrm_state_find(controld_globals.our_nodename);
     if (lrm_state == NULL) {
         return;
     }
@@ -78,7 +78,7 @@ crmd_alert_resource_op(const char *node, lrmd_event_data_t * op)
         return;
     }
 
-    lrm_state = lrm_state_find(fsa_our_uname);
+    lrm_state = lrm_state_find(controld_globals.our_nodename);
     if (lrm_state == NULL) {
         return;
     }

--- a/daemons/controld/controld_attrd.c
+++ b/daemons/controld/controld_attrd.c
@@ -39,7 +39,8 @@ node_type(bool is_remote)
 static inline const char *
 when(void)
 {
-    return pcmk_is_set(fsa_input_register, R_SHUTDOWN)? " at shutdown" : "";
+    return pcmk_is_set(controld_globals.fsa_input_register,
+                       R_SHUTDOWN)? " at shutdown" : "";
 }
 
 static void
@@ -52,7 +53,7 @@ handle_attr_error(void)
          */
         crmd_exit(CRM_EX_FATAL);
 
-    } else if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
+    } else if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
         // Fast-track shutdown since unable to request via attribute
         register_fsa_input(C_FSA_INTERNAL, I_FAIL, NULL);
     }

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -40,7 +40,8 @@ do_cib_replaced(const char *event, xmlNode * msg)
         return;
 
     } else if ((controld_globals.fsa_state == S_FINALIZE_JOIN)
-               && pcmk_is_set(fsa_input_register, R_CIB_ASKED)) {
+               && pcmk_is_set(controld_globals.fsa_input_register,
+                              R_CIB_ASKED)) {
         /* no need to restart the join - we asked for this replace op */
         return;
     }
@@ -144,7 +145,8 @@ do_cib_control(long long action,
             cib_retries = 0;
         }
 
-        if (!pcmk_is_set(fsa_input_register, R_CIB_CONNECTED)) {
+        if (!pcmk_is_set(controld_globals.fsa_input_register,
+                         R_CIB_CONNECTED)) {
 
             cib_retries++;
             crm_warn("Couldn't complete CIB registration %d"

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -18,7 +18,7 @@
 
 #include <pacemaker-controld.h>
 
-int cib_retries = 0;
+static int cib_retries = 0;
 
 void
 do_cib_updated(const char *event, xmlNode * msg)

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -39,7 +39,7 @@ do_cib_replaced(const char *event, xmlNode * msg)
     if (AM_I_DC == FALSE) {
         return;
 
-    } else if ((fsa_state == S_FINALIZE_JOIN)
+    } else if ((controld_globals.fsa_state == S_FINALIZE_JOIN)
                && pcmk_is_set(fsa_input_register, R_CIB_ASKED)) {
         /* no need to restart the join - we asked for this replace op */
         return;
@@ -174,8 +174,10 @@ crmd_cib_smart_opt(void)
 {
     int call_opt = cib_quorum_override;
 
-    if (fsa_state == S_ELECTION || fsa_state == S_PENDING) {
-        crm_info("Sending update to local CIB in state: %s", fsa_state2string(fsa_state));
+    if ((controld_globals.fsa_state == S_ELECTION)
+        || (controld_globals.fsa_state == S_PENDING)) {
+        crm_info("Sending update to local CIB in state: %s",
+                 fsa_state2string(controld_globals.fsa_state));
         cib__set_call_options(call_opt, "update", cib_scope_local);
     }
     return call_opt;

--- a/daemons/controld/controld_based.c
+++ b/daemons/controld/controld_based.c
@@ -24,7 +24,7 @@ void
 do_cib_updated(const char *event, xmlNode * msg)
 {
     if (pcmk__alert_in_patchset(msg, TRUE)) {
-        mainloop_set_trigger(config_read);
+        controld_trigger_config();
     }
 }
 

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -198,7 +198,8 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                 controld_remove_voter(node->uname);
             }
 
-            if (!pcmk_is_set(fsa_input_register, R_CIB_CONNECTED)) {
+            if (!pcmk_is_set(controld_globals.fsa_input_register,
+                             R_CIB_CONNECTED)) {
                 crm_trace("Ignoring peer status change because not connected to CIB");
                 return;
 
@@ -358,7 +359,7 @@ crmd_cib_connection_destroy(gpointer user_data)
     trigger_fsa();
     fsa_cib_conn->state = cib_disconnected;
 
-    if (!pcmk_is_set(fsa_input_register, R_CIB_CONNECTED)) {
+    if (!pcmk_is_set(controld_globals.fsa_input_register, R_CIB_CONNECTED)) {
         crm_info("Connection to the CIB manager terminated");
         return;
     }

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -227,7 +227,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                  * the only way to avoid fencing older DCs is to leave the
                  * transient attributes intact until it rejoins.
                  */
-                if (compare_version(fsa_our_dc_version, "3.0.9") > 0) {
+                if (compare_version(controld_globals.dc_version, "3.0.9") > 0) {
                     controld_delete_node_state(node->uname,
                                                controld_section_attrs,
                                                cib_scope_local);

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -32,7 +32,8 @@ crmd_ha_msg_filter(xmlNode * msg)
         if (pcmk__str_eq(sys_from, CRM_SYSTEM_DC, pcmk__str_casei)) {
             const char *from = crm_element_value(msg, F_ORIG);
 
-            if (!pcmk__str_eq(from, fsa_our_uname, pcmk__str_casei)) {
+            if (!pcmk__str_eq(from, controld_globals.our_nodename,
+                              pcmk__str_casei)) {
                 int level = LOG_INFO;
                 const char *op = crm_element_value(msg, F_CRM_TASK);
 
@@ -206,7 +207,9 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                 return;
             }
 
-            if (pcmk__str_eq(node->uname, fsa_our_uname, pcmk__str_casei) && !appeared) {
+            if (!appeared
+                && pcmk__str_eq(node->uname, controld_globals.our_nodename,
+                                pcmk__str_casei)) {
                 /* Did we get evicted? */
                 crm_notice("Our peer connection failed");
                 register_fsa_input(C_CRMD_STATUS_CALLBACK, I_ERROR, NULL);

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -172,16 +172,16 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
             appeared = pcmk_is_set(node->processes, crm_get_cluster_proc());
 
             {
-                const char *dc_s = "true";
+                const char *dc_s = controld_globals.dc_name;
 
-                if (!AM_I_DC) {
-                    dc_s = pcmk__s(controld_globals.dc_name, "<none>");
+                if ((dc_s == NULL) && AM_I_DC) {
+                    dc_s = "true";
                 }
 
                 crm_info("Node %s is %s a peer " CRM_XS
                          " DC=%s old=%#07x new=%#07x",
-                         node->uname, (appeared? "now" : "no longer"), dc_s,
-                         old, node->processes);
+                         node->uname, (appeared? "now" : "no longer"),
+                         pcmk__s(dc_s, "<none>"), old, node->processes);
             }
 
             if (!pcmk_is_set((node->processes ^ old), crm_get_cluster_proc())) {

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -99,8 +99,6 @@ node_alive(const crm_node_t *node)
 
 #define state_text(state) ((state)? (const char *)(state) : "in unknown state")
 
-bool controld_dc_left = false;
-
 void
 peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *data)
 {
@@ -224,7 +222,9 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                                                cib_scope_local);
                 }
 
-            } else if (AM_I_DC || controld_dc_left || (fsa_our_dc == NULL)) {
+            } else if (AM_I_DC
+                       || pcmk_is_set(controld_globals.flags, controld_dc_left)
+                       || (fsa_our_dc == NULL)) {
                 /* This only needs to be done once, so normally the DC should do
                  * it. However if there is no DC, every node must do it, since
                  * there is no other way to ensure some one node does it.

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -38,7 +38,7 @@ crmd_ha_msg_filter(xmlNode * msg)
                 const char *op = crm_element_value(msg, F_CRM_TASK);
 
                 /* make sure the election happens NOW */
-                if (fsa_state != S_ELECTION) {
+                if (controld_globals.fsa_state != S_ELECTION) {
                     ha_msg_input_t new_input;
 
                     level = LOG_WARNING;
@@ -202,7 +202,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                 crm_trace("Ignoring peer status change because not connected to CIB");
                 return;
 
-            } else if (fsa_state == S_STOPPING) {
+            } else if (controld_globals.fsa_state == S_STOPPING) {
                 crm_trace("Ignoring peer status change because stopping");
                 return;
             }
@@ -282,7 +282,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                 if (!is_remote) {
                     flags |= node_update_join | node_update_expected;
                     crmd_peer_down(node, FALSE);
-                    check_join_state(fsa_state, __func__);
+                    check_join_state(controld_globals.fsa_state, __func__);
                 }
                 if (alive >= 0) {
                     crm_info("%s of peer %s is in progress " CRM_XS " action=%d",
@@ -312,7 +312,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
             }
             if (!is_remote) {
                 crm_update_peer_join(__func__, node, crm_join_none);
-                check_join_state(fsa_state, __func__);
+                check_join_state(controld_globals.fsa_state, __func__);
             }
             abort_transition(INFINITY, pcmk__graph_restart, "Node failure",
                              NULL);

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -33,7 +33,6 @@ gboolean crm_read_options(gpointer user_data);
 
 crm_trigger_t *fsa_source = NULL;
 crm_trigger_t *config_read = NULL;
-bool no_quorum_suicide_escalation = FALSE;
 bool controld_shutdown_lock_enabled = false;
 
 /*	 A_HA_CONNECT	*/
@@ -737,7 +736,7 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 
     value = controller_option(config_hash, "no-quorum-policy");
     if (pcmk__str_eq(value, "suicide", pcmk__str_casei) && pcmk__locate_sbd()) {
-        no_quorum_suicide_escalation = TRUE;
+        controld_globals.flags |= controld_no_quorum_suicide;
     }
 
     set_fence_reaction(controller_option(config_hash,

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -754,7 +754,7 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 
     value = controller_option(config_hash, "no-quorum-policy");
     if (pcmk__str_eq(value, "suicide", pcmk__str_casei) && pcmk__locate_sbd()) {
-        controld_globals.flags |= controld_no_quorum_suicide;
+        controld_set_global_flags(controld_no_quorum_suicide);
     }
 
     set_fence_reaction(controller_option(config_hash,
@@ -786,9 +786,9 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 
     value = controller_option(config_hash, XML_CONFIG_ATTR_SHUTDOWN_LOCK);
     if (crm_is_true(value)) {
-        controld_globals.flags |= controld_shutdown_lock_enabled;
+        controld_set_global_flags(controld_shutdown_lock_enabled);
     } else {
-        controld_globals.flags &= ~controld_shutdown_lock_enabled;
+        controld_clear_global_flags(controld_shutdown_lock_enabled);
     }
 
     value = g_hash_table_lookup(config_hash, "cluster-name");

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -69,7 +69,7 @@ do_ha_control(long long action,
         if (registered) {
             controld_election_init(cluster->uname);
             controld_globals.our_nodename = cluster->uname;
-            fsa_our_uuid = cluster->uuid;
+            controld_globals.our_uuid = cluster->uuid;
             if(cluster->uuid == NULL) {
                 crm_err("Could not obtain local uuid");
                 registered = FALSE;
@@ -251,7 +251,8 @@ crmd_exit(crm_exit_t exit_code)
     free(controld_globals.our_nodename);
     controld_globals.our_nodename = NULL;
 
-    free(fsa_our_uuid); fsa_our_uuid = NULL;
+    free(controld_globals.our_uuid);
+    controld_globals.our_uuid = NULL;
 
     free(controld_globals.dc_name);
     controld_globals.dc_name = NULL;

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -239,7 +239,7 @@ crmd_exit(crm_exit_t exit_code)
     mainloop_destroy_trigger(config_read_trigger);
     config_read_trigger = NULL;
 
-    mainloop_destroy_trigger(transition_trigger); transition_trigger = NULL;
+    controld_destroy_transition_trigger();
 
     pcmk__client_cleanup();
     crm_peer_destroy();
@@ -349,7 +349,7 @@ do_startup(long long action,
 
     fsa_source = mainloop_add_trigger(G_PRIORITY_HIGH, crm_fsa_trigger, NULL);
 
-    transition_trigger = mainloop_add_trigger(G_PRIORITY_LOW, te_graph_trigger, NULL);
+    controld_init_transition_trigger();
 
     crm_debug("Creating CIB manager and executor objects");
     fsa_cib_conn = cib_new();

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -116,7 +116,7 @@ do_shutdown_req(long long action,
     controld_set_fsa_input_flags(R_SHUTDOWN);
     //controld_set_fsa_input_flags(R_STAYDOWN);
     crm_info("Sending shutdown request to all peers (DC is %s)",
-             (fsa_our_dc? fsa_our_dc : "not set"));
+             pcmk__s(controld_globals.dc_name, "not set"));
     msg = create_request(CRM_OP_SHUTDOWN_REQ, NULL, NULL, CRM_SYSTEM_CRMD, CRM_SYSTEM_CRMD, NULL);
 
     if (send_cluster_message(NULL, crm_msg_crmd, msg, TRUE) == FALSE) {
@@ -251,7 +251,9 @@ crmd_exit(crm_exit_t exit_code)
     free(fsa_our_dc_version); fsa_our_dc_version = NULL;
     free(fsa_our_uname); fsa_our_uname = NULL;
     free(fsa_our_uuid); fsa_our_uuid = NULL;
-    free(fsa_our_dc); fsa_our_dc = NULL;
+
+    free(controld_globals.dc_name);
+    controld_globals.dc_name = NULL;
 
     free(controld_globals.cluster_name);
     controld_globals.cluster_name = NULL;

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -33,7 +33,6 @@ gboolean crm_read_options(gpointer user_data);
 
 crm_trigger_t *fsa_source = NULL;
 crm_trigger_t *config_read = NULL;
-bool controld_shutdown_lock_enabled = false;
 
 /*	 A_HA_CONNECT	*/
 void
@@ -767,7 +766,11 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     finalization_timer->period_ms = crm_parse_interval_spec(value);
 
     value = controller_option(config_hash, XML_CONFIG_ATTR_SHUTDOWN_LOCK);
-    controld_shutdown_lock_enabled = crm_is_true(value);
+    if (crm_is_true(value)) {
+        controld_globals.flags |= controld_shutdown_lock_enabled;
+    } else {
+        controld_globals.flags &= ~controld_shutdown_lock_enabled;
+    }
 
     free(fsa_cluster_name);
     fsa_cluster_name = NULL;

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -253,7 +253,8 @@ crmd_exit(crm_exit_t exit_code)
     free(fsa_our_uuid); fsa_our_uuid = NULL;
     free(fsa_our_dc); fsa_our_dc = NULL;
 
-    free(fsa_cluster_name); fsa_cluster_name = NULL;
+    free(controld_globals.cluster_name);
+    controld_globals.cluster_name = NULL;
 
     free(te_uuid); te_uuid = NULL;
     free(failed_stop_offset); failed_stop_offset = NULL;
@@ -778,13 +779,8 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
         controld_globals.flags &= ~controld_shutdown_lock_enabled;
     }
 
-    free(fsa_cluster_name);
-    fsa_cluster_name = NULL;
-
     value = g_hash_table_lookup(config_hash, "cluster-name");
-    if (value) {
-        fsa_cluster_name = strdup(value);
-    }
+    pcmk__str_update(&(controld_globals.cluster_name), value);
 
     alerts = first_named_child(output, XML_CIB_TAG_ALERTS);
     crmd_unpack_alerts(alerts);

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -248,12 +248,14 @@ crmd_exit(crm_exit_t exit_code)
     te_cleanup_stonith_history_sync(NULL, TRUE);
     controld_free_sched_timer();
 
-    free(fsa_our_dc_version); fsa_our_dc_version = NULL;
     free(fsa_our_uname); fsa_our_uname = NULL;
     free(fsa_our_uuid); fsa_our_uuid = NULL;
 
     free(controld_globals.dc_name);
     controld_globals.dc_name = NULL;
+
+    free(controld_globals.dc_version);
+    controld_globals.dc_version = NULL;
 
     free(controld_globals.cluster_name);
     controld_globals.cluster_name = NULL;

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -127,8 +127,6 @@ do_shutdown_req(long long action,
     free_xml(msg);
 }
 
-extern GHashTable *resource_history;
-extern GHashTable *voted;
 extern pcmk__output_t *logger_out;
 
 void

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -153,7 +153,7 @@ crm_exit_t
 crmd_exit(crm_exit_t exit_code)
 {
     GList *gIter = NULL;
-    GMainLoop *mloop = crmd_mainloop;
+    GMainLoop *mloop = controld_globals.mainloop;
 
     static bool in_progress = FALSE;
 
@@ -187,7 +187,7 @@ crmd_exit(crm_exit_t exit_code)
     controld_shutdown_schedulerd_ipc();
     controld_disconnect_fencer(TRUE);
 
-    if ((exit_code == CRM_EX_OK) && (crmd_mainloop == NULL)) {
+    if ((exit_code == CRM_EX_OK) && (controld_globals.mainloop == NULL)) {
         crm_debug("No mainloop detected");
         exit_code = CRM_EX_ERROR;
     }
@@ -265,10 +265,10 @@ crmd_exit(crm_exit_t exit_code)
     /* leave SIGCHLD engaged as we might still want to drain some service-actions */
 
     if (mloop) {
-        GMainContext *ctx = g_main_loop_get_context(crmd_mainloop);
+        GMainContext *ctx = g_main_loop_get_context(controld_globals.mainloop);
 
         /* Don't re-enter this block */
-        crmd_mainloop = NULL;
+        controld_globals.mainloop = NULL;
 
         /* no signals on final draining anymore */
         mainloop_destroy_signal(SIGCHLD);
@@ -819,7 +819,8 @@ do_read_config(long long action,
 void
 crm_shutdown(int nsig)
 {
-    if ((crmd_mainloop == NULL) || !g_main_loop_is_running(crmd_mainloop)) {
+    if ((controld_globals.mainloop == NULL)
+        || !g_main_loop_is_running(controld_globals.mainloop)) {
         crmd_exit(CRM_EX_OK);
         return;
     }

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -130,13 +130,14 @@ extern pcmk__output_t *logger_out;
 void
 crmd_fast_exit(crm_exit_t exit_code)
 {
-    if (pcmk_is_set(fsa_input_register, R_STAYDOWN)) {
+    if (pcmk_is_set(controld_globals.fsa_input_register, R_STAYDOWN)) {
         crm_warn("Inhibiting respawn "CRM_XS" remapping exit code %d to %d",
                  exit_code, CRM_EX_FATAL);
         exit_code = CRM_EX_FATAL;
 
     } else if ((exit_code == CRM_EX_OK)
-               && pcmk_is_set(fsa_input_register, R_IN_RECOVERY)) {
+               && pcmk_is_set(controld_globals.fsa_input_register,
+                              R_IN_RECOVERY)) {
         crm_err("Could not recover from internal error");
         exit_code = CRM_EX_ERROR;
     }
@@ -462,31 +463,35 @@ do_started(long long action,
         crm_err("Start cancelled... %s", fsa_state2string(cur_state));
         return;
 
-    } else if (!pcmk_is_set(fsa_input_register, R_MEMBERSHIP)) {
+    } else if (!pcmk_is_set(controld_globals.fsa_input_register,
+                            R_MEMBERSHIP)) {
         crm_info("Delaying start, no membership data (%.16llx)", R_MEMBERSHIP);
 
         crmd_fsa_stall(TRUE);
         return;
 
-    } else if (!pcmk_is_set(fsa_input_register, R_LRM_CONNECTED)) {
+    } else if (!pcmk_is_set(controld_globals.fsa_input_register,
+                            R_LRM_CONNECTED)) {
         crm_info("Delaying start, not connected to executor (%.16llx)", R_LRM_CONNECTED);
 
         crmd_fsa_stall(TRUE);
         return;
 
-    } else if (!pcmk_is_set(fsa_input_register, R_CIB_CONNECTED)) {
+    } else if (!pcmk_is_set(controld_globals.fsa_input_register,
+                            R_CIB_CONNECTED)) {
         crm_info("Delaying start, CIB not connected (%.16llx)", R_CIB_CONNECTED);
 
         crmd_fsa_stall(TRUE);
         return;
 
-    } else if (!pcmk_is_set(fsa_input_register, R_READ_CONFIG)) {
+    } else if (!pcmk_is_set(controld_globals.fsa_input_register,
+                            R_READ_CONFIG)) {
         crm_info("Delaying start, Config not read (%.16llx)", R_READ_CONFIG);
 
         crmd_fsa_stall(TRUE);
         return;
 
-    } else if (!pcmk_is_set(fsa_input_register, R_PEER_DATA)) {
+    } else if (!pcmk_is_set(controld_globals.fsa_input_register, R_PEER_DATA)) {
 
         crm_info("Delaying start, No peer data (%.16llx)", R_PEER_DATA);
         crmd_fsa_stall(TRUE);
@@ -850,7 +855,7 @@ crm_shutdown(int nsig)
         return;
     }
 
-    if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
+    if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
         crm_err("Escalating shutdown");
         register_fsa_input_before(C_SHUTDOWN, I_ERROR, NULL);
         return;

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -22,7 +22,7 @@
 
 #include <pacemaker-controld.h>
 
-qb_ipcs_service_t *ipcs = NULL;
+static qb_ipcs_service_t *ipcs = NULL;
 
 #if SUPPORT_COROSYNC
 extern gboolean crm_connect_corosync(crm_cluster_t * cluster);

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -127,8 +127,6 @@ do_shutdown_req(long long action,
     free_xml(msg);
 }
 
-extern char *max_generation_from;
-extern xmlNode *max_generation_xml;
 extern GHashTable *resource_history;
 extern GHashTable *voted;
 extern pcmk__output_t *logger_out;
@@ -263,8 +261,7 @@ crmd_exit(crm_exit_t exit_code)
     free(failed_stop_offset); failed_stop_offset = NULL;
     free(failed_start_offset); failed_start_offset = NULL;
 
-    free(max_generation_from); max_generation_from = NULL;
-    free_xml(max_generation_xml); max_generation_xml = NULL;
+    free_max_generation();
 
     mainloop_destroy_signal(SIGPIPE);
     mainloop_destroy_signal(SIGUSR1);

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -66,9 +66,9 @@ do_ha_control(long long action,
 #endif
         }
 
-        if (registered == TRUE) {
+        if (registered) {
             controld_election_init(cluster->uname);
-            fsa_our_uname = cluster->uname;
+            controld_globals.our_nodename = cluster->uname;
             fsa_our_uuid = cluster->uuid;
             if(cluster->uuid == NULL) {
                 crm_err("Could not obtain local uuid");
@@ -76,7 +76,7 @@ do_ha_control(long long action,
             }
         }
 
-        if (registered == FALSE) {
+        if (!registered) {
             controld_set_fsa_input_flags(R_HA_DISCONNECTED);
             register_fsa_error(C_FSA_INTERNAL, I_ERROR, NULL);
             return;
@@ -248,7 +248,9 @@ crmd_exit(crm_exit_t exit_code)
     te_cleanup_stonith_history_sync(NULL, TRUE);
     controld_free_sched_timer();
 
-    free(fsa_our_uname); fsa_our_uname = NULL;
+    free(controld_globals.our_nodename);
+    controld_globals.our_nodename = NULL;
+
     free(fsa_our_uuid); fsa_our_uuid = NULL;
 
     free(controld_globals.dc_name);

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -213,7 +213,7 @@ crmd_exit(crm_exit_t exit_code)
 
         crm_info("Dropping %s: [ state=%s cause=%s origin=%s ]",
                  fsa_input2string(fsa_data->fsa_input),
-                 fsa_state2string(fsa_state),
+                 fsa_state2string(controld_globals.fsa_state),
                  fsa_cause2string(fsa_data->fsa_cause), fsa_data->origin);
         delete_fsa_input(fsa_data);
     }
@@ -229,7 +229,7 @@ crmd_exit(crm_exit_t exit_code)
 
     controld_disconnect_cib_manager();
 
-    verify_stopped(fsa_state, LOG_WARNING);
+    verify_stopped(controld_globals.fsa_state, LOG_WARNING);
     controld_clear_fsa_input_flags(R_LRM_CONNECTED);
     lrm_state_destroy_all();
 

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -31,7 +31,6 @@ extern gboolean crm_connect_corosync(crm_cluster_t * cluster);
 void crm_shutdown(int nsig);
 gboolean crm_read_options(gpointer user_data);
 
-gboolean fsa_has_quorum = FALSE;
 crm_trigger_t *fsa_source = NULL;
 crm_trigger_t *config_read = NULL;
 bool no_quorum_suicide_escalation = FALSE;

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -726,7 +726,7 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
                                    PCMK__NELEM(controller_options));
 
     value = controller_option(config_hash, XML_CONFIG_ATTR_DC_DEADTIME);
-    election_trigger->period_ms = crm_parse_interval_spec(value);
+    election_timer->period_ms = crm_parse_interval_spec(value);
 
     value = controller_option(config_hash, "node-action-limit");
     throttle_update_job_max(value);

--- a/daemons/controld/controld_corosync.c
+++ b/daemons/controld/controld_corosync.c
@@ -126,7 +126,7 @@ cpg_membership_callback(cpg_handle_t handle, const struct cpg_name *cpg_name,
         if (peer != NULL) {
             for (int i = 0; i < left_list_entries; ++i) {
                 if (left_list[i].nodeid == peer->id) {
-                    controld_globals.flags |= controld_dc_left;
+                    controld_set_global_flags(controld_dc_left);
                     break;
                 }
             }
@@ -138,7 +138,7 @@ cpg_membership_callback(cpg_handle_t handle, const struct cpg_name *cpg_name,
                         left_list, left_list_entries,
                         joined_list, joined_list_entries);
 
-    controld_globals.flags &= ~controld_dc_left;
+    controld_clear_global_flags(controld_dc_left);
 }
 
 extern gboolean crm_connect_corosync(crm_cluster_t * cluster);

--- a/daemons/controld/controld_corosync.c
+++ b/daemons/controld/controld_corosync.c
@@ -78,7 +78,7 @@ crmd_quorum_callback(unsigned long long seq, gboolean quorate)
 static void
 crmd_cs_destroy(gpointer user_data)
 {
-    if (!pcmk_is_set(fsa_input_register, R_HA_DISCONNECTED)) {
+    if (!pcmk_is_set(controld_globals.fsa_input_register, R_HA_DISCONNECTED)) {
         crm_crit("Lost connection to cluster layer, shutting down");
         crmd_exit(CRM_EX_DISCONNECT);
 

--- a/daemons/controld/controld_corosync.c
+++ b/daemons/controld/controld_corosync.c
@@ -119,9 +119,10 @@ cpg_membership_callback(cpg_handle_t handle, const struct cpg_name *cpg_name,
      * Here, we set a global boolean if the DC is among the nodes that left, for
      * use by the peer callback.
      */
-    if (fsa_our_dc != NULL) {
-        crm_node_t *peer = pcmk__search_cluster_node_cache(0, fsa_our_dc);
+    if (controld_globals.dc_name != NULL) {
+        crm_node_t *peer = NULL;
 
+        peer = pcmk__search_cluster_node_cache(0, controld_globals.dc_name);
         if (peer != NULL) {
             for (int i = 0; i < left_list_entries; ++i) {
                 if (left_list[i].nodeid == peer->id) {

--- a/daemons/controld/controld_corosync.c
+++ b/daemons/controld/controld_corosync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -87,8 +87,6 @@ crmd_cs_destroy(gpointer user_data)
     }
 }
 
-extern bool controld_dc_left;
-
 /*!
  * \brief Handle a Corosync notification of a CPG configuration change
  *
@@ -127,7 +125,7 @@ cpg_membership_callback(cpg_handle_t handle, const struct cpg_name *cpg_name,
         if (peer != NULL) {
             for (int i = 0; i < left_list_entries; ++i) {
                 if (left_list[i].nodeid == peer->id) {
-                    controld_dc_left = true;
+                    controld_globals.flags |= controld_dc_left;
                     break;
                 }
             }
@@ -139,7 +137,7 @@ cpg_membership_callback(cpg_handle_t handle, const struct cpg_name *cpg_name,
                         left_list, left_list_entries,
                         joined_list, joined_list_entries);
 
-    controld_dc_left = false;
+    controld_globals.flags &= ~controld_dc_left;
 }
 
 extern gboolean crm_connect_corosync(crm_cluster_t * cluster);

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -122,7 +122,7 @@ do_election_check(long long action,
                   enum crmd_fsa_state cur_state,
                   enum crmd_fsa_input current_input, fsa_data_t * msg_data)
 {
-    if (fsa_state == S_ELECTION) {
+    if (controld_globals.fsa_state == S_ELECTION) {
         election_check(fsa_election);
     } else {
         crm_debug("Ignoring election check because we are not in an election");

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -64,7 +64,7 @@ controld_set_election_period(const char *value)
 }
 
 void
-controld_stop_election_timer(void)
+controld_stop_current_election_timeout(void)
 {
     election_timeout_stop(fsa_election);
 }

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -261,7 +261,7 @@ do_dc_release(long long action,
 #endif
         if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
             xmlNode *update = NULL;
-            crm_node_t *node = crm_get_peer(0, fsa_our_uname);
+            crm_node_t *node = crm_get_peer(0, controld_globals.our_nodename);
 
             pcmk__update_peer_expected(__func__, node, CRMD_JOINSTATE_DOWN);
             update = create_node_state_update(node, node_update_expected, NULL,

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -222,7 +222,7 @@ do_dc_takeover(long long action,
                           cluster_type, NULL, NULL);
 
 #if SUPPORT_COROSYNC
-    if (fsa_cluster_name == NULL && is_corosync_cluster()) {
+    if ((controld_globals.cluster_name == NULL) && is_corosync_cluster()) {
         char *cluster_name = pcmk__corosync_cluster_name();
 
         if (cluster_name) {

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -97,7 +97,7 @@ do_election_vote(long long action,
     }
 
     if (not_voting == FALSE) {
-        if (pcmk_is_set(fsa_input_register, R_STARTING)) {
+        if (pcmk_is_set(controld_globals.fsa_input_register, R_STARTING)) {
             not_voting = TRUE;
         }
     }
@@ -140,7 +140,7 @@ do_election_count_vote(long long action,
     ha_msg_input_t *vote = fsa_typed_data(fsa_dt_ha_msg);
 
     if(crm_peer_cache == NULL) {
-        if (!pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
+        if (!pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
             crm_err("Internal error, no peer cache");
         }
         return;
@@ -156,7 +156,7 @@ do_election_count_vote(long long action,
         case election_lost:
             update_dc(NULL);
 
-            if (fsa_input_register & R_THE_DC) {
+            if (pcmk_is_set(controld_globals.fsa_input_register, R_THE_DC)) {
                 register_fsa_input(C_FSA_INTERNAL, I_RELEASE_DC, NULL);
                 fsa_cib_conn->cmds->set_secondary(fsa_cib_conn,
                                                   cib_scope_local);
@@ -259,7 +259,7 @@ do_dc_release(long long action,
             result = I_SHUTDOWN;
         }
 #endif
-        if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
+        if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
             xmlNode *update = NULL;
             crm_node_t *node = crm_get_peer(0, controld_globals.our_nodename);
 

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -42,7 +42,7 @@ controld_remove_voter(const char *uname)
 {
     election_remove(fsa_election, uname);
 
-    if (pcmk__str_eq(uname, fsa_our_dc, pcmk__str_casei)) {
+    if (pcmk__str_eq(uname, controld_globals.dc_name, pcmk__str_casei)) {
         /* Clear any election dampening in effect. Otherwise, if the lost DC had
          * just won, an immediate new election could fizzle out with no new DC.
          */

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -234,7 +234,7 @@ do_dc_takeover(long long action,
     }
 #endif
 
-    mainloop_set_trigger(config_read);
+    controld_trigger_config();
     free_xml(cib);
 }
 

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -55,7 +55,7 @@ static int do_update_resource(const char *node_name, lrmd_rsc_info_t *rsc,
 static void
 lrm_connection_destroy(void)
 {
-    if (pcmk_is_set(fsa_input_register, R_LRM_CONNECTED)) {
+    if (pcmk_is_set(controld_globals.fsa_input_register, R_LRM_CONNECTED)) {
         crm_crit("Connection to executor failed");
         register_fsa_input(C_FSA_INTERNAL, I_ERROR, NULL);
         controld_clear_fsa_input_flags(R_LRM_CONNECTED);
@@ -414,7 +414,7 @@ lrm_state_verify_stopped(lrm_state_t * lrm_state, enum crmd_fsa_state cur_state,
         log_level = LOG_ERR;
         when = "shutdown";
 
-    } else if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
+    } else if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
         when = "shutdown... waiting";
     }
 
@@ -444,7 +444,8 @@ lrm_state_verify_stopped(lrm_state_t * lrm_state, enum crmd_fsa_state cur_state,
                    counter, pcmk__plural_s(counter), when);
 
         if ((cur_state == S_TERMINATE)
-            || !pcmk_is_set(fsa_input_register, R_SENT_RSC_STOP)) {
+            || !pcmk_is_set(controld_globals.fsa_input_register,
+                            R_SENT_RSC_STOP)) {
             g_hash_table_iter_init(&gIter, lrm_state->pending_ops);
             while (g_hash_table_iter_next(&gIter, (gpointer*)&key, (gpointer*)&pending)) {
                 do_crm_log(log_level, "Pending action: %s (%s)", key, pending->op_key);
@@ -460,7 +461,7 @@ lrm_state_verify_stopped(lrm_state_t * lrm_state, enum crmd_fsa_state cur_state,
         return rc;
     }
 
-    if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
+    if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
         /* At this point we're not waiting, we're just shutting down */
         when = "shutdown";
     }
@@ -2292,7 +2293,7 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc, xmlNode *msg,
                crm_action_str(op->op_type, op->interval_ms), rsc->id, lrm_state->node_name,
                pcmk__s(transition, ""), rsc->id, operation, op->interval_ms);
 
-    if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)
+    if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)
         && pcmk__str_eq(operation, RSC_START, pcmk__str_casei)) {
 
         register_fsa_input(C_SHUTDOWN, I_SHUTDOWN, NULL);
@@ -2318,7 +2319,8 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc, xmlNode *msg,
         crm_notice("Discarding attempt to perform action %s on %s in state %s "
                    "(shutdown=%s)", operation, rsc->id,
                    fsa_state2string(controld_globals.fsa_state),
-                   pcmk__btoa(pcmk_is_set(fsa_input_register, R_SHUTDOWN)));
+                   pcmk__btoa(pcmk_is_set(controld_globals.fsa_input_register,
+                                          R_SHUTDOWN)));
 
         lrmd__set_result(op, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_INVALID,
                          nack_reason);

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -2425,7 +2425,7 @@ cib_rsc_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *use
 static bool
 should_preserve_lock(lrmd_event_data_t *op)
 {
-    if (!controld_shutdown_lock_enabled) {
+    if (!pcmk_is_set(controld_globals.flags, controld_shutdown_lock_enabled)) {
         return false;
     }
     if (!strcmp(op->op_type, RSC_STOP) && (op->rc == PCMK_OCF_OK)) {

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -532,7 +532,7 @@ build_parameter_list(const lrmd_event_data_t *op,
      * what scheduler does with calculate_secure_digest().
      */
     if (param_type == ra_param_private
-        && compare_version(fsa_our_dc_version, "3.16.0") >= 0) {
+        && compare_version(controld_globals.dc_version, "3.16.0") >= 0) {
         g_hash_table_foreach(op->params, hash2field, *result);
         pcmk__filter_op_for_digest(*result);
     }
@@ -2706,7 +2706,7 @@ process_lrm_event(lrm_state_t *lrm_state, lrmd_event_data_t *op,
     CRM_CHECK(op->rsc_id != NULL, return);
 
     // Remap new status codes for older DCs
-    if (compare_version(fsa_our_dc_version, "3.2.0") < 0) {
+    if (compare_version(controld_globals.dc_version, "3.2.0") < 0) {
         switch (op->op_status) {
             case PCMK_EXEC_NOT_CONNECTED:
                 lrmd__set_result(op, PCMK_OCF_CONNECTION_DIED,

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1559,7 +1559,7 @@ handle_reprobe_op(lrm_state_t *lrm_state, const char *from_sys,
 
         xmlNode *reply = create_request(CRM_OP_INVOKE_LRM, NULL, from_host,
                                         from_sys, CRM_SYSTEM_LRMD,
-                                        fsa_our_uuid);
+                                        controld_globals.our_uuid);
 
         crm_debug("ACK'ing re-probe from %s (%s)", from_sys, from_host);
 
@@ -2081,7 +2081,7 @@ controld_ack_event_directly(const char *to_host, const char *to_sys,
                                       __func__);
 
     iter = create_xml_node(update, XML_CIB_TAG_LRM);
-    crm_xml_add(iter, XML_ATTR_ID, fsa_our_uuid);
+    crm_xml_add(iter, XML_ATTR_ID, controld_globals.our_uuid);
     iter = create_xml_node(iter, XML_LRM_TAG_RESOURCES);
     iter = create_xml_node(iter, XML_LRM_TAG_RESOURCE);
 
@@ -2464,7 +2464,7 @@ do_update_resource(const char *node_name, lrmd_rsc_info_t *rsc,
 
     if (pcmk__str_eq(node_name, controld_globals.our_nodename,
                      pcmk__str_casei)) {
-        uuid = fsa_our_uuid;
+        uuid = controld_globals.our_uuid;
 
     } else {
         /* remote nodes uuid and uname are equal */

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -323,7 +323,7 @@ lrm_state_disconnect_only(lrm_state_t * lrm_state)
 
     ((lrmd_t *) lrm_state->conn)->cmds->disconnect(lrm_state->conn);
 
-    if (!pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
+    if (!pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
         removed = g_hash_table_foreach_remove(lrm_state->pending_ops, fail_pending_op, lrm_state);
         crm_trace("Synthesized %d operation failures for %s", removed, lrm_state->node_name);
     }

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -21,7 +21,7 @@
 #include <pacemaker-internal.h>
 #include <pacemaker-controld.h>
 
-GHashTable *lrm_state_table = NULL;
+static GHashTable *lrm_state_table = NULL;
 extern GHashTable *proxy_table;
 int lrmd_internal_proxy_send(lrmd_t * lrmd, xmlNode *msg);
 void lrmd_internal_set_proxy_callback(lrmd_t * lrmd, void *userdata, void (*callback)(lrmd_t *lrmd, void *userdata, xmlNode *msg));

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -93,16 +93,9 @@ fail_pending_op(gpointer key, gpointer value, gpointer user_data)
 gboolean
 lrm_state_is_local(lrm_state_t *lrm_state)
 {
-    if (lrm_state == NULL || fsa_our_uname == NULL) {
-        return FALSE;
-    }
-
-    if (strcmp(lrm_state->node_name, fsa_our_uname) != 0) {
-        return FALSE;
-    }
-
-    return TRUE;
-
+    return (lrm_state != NULL)
+           && pcmk__str_eq(lrm_state->node_name, controld_globals.our_nodename,
+                           pcmk__str_casei);
 }
 
 lrm_state_t *

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -573,13 +573,17 @@ handle_fence_notification(stonith_t *st, stonith_event_t *event)
                                  "External Fencing Operation", NULL);
             }
 
-            /* Assume it was our leader if we don't currently have one */
-        } else if (pcmk__str_eq(fsa_our_dc, event->target,
+        } else if (pcmk__str_eq(controld_globals.dc_name, event->target,
                                 pcmk__str_null_matches|pcmk__str_casei)
                    && !pcmk_is_set(peer->flags, crm_remote_node)) {
+            // Assume the target was our DC if we don't currently have one
 
-            crm_notice("Fencing target %s %s our leader",
-                       event->target, (fsa_our_dc? "was" : "may have been"));
+            if (controld_globals.dc_name != NULL) {
+                crm_notice("Fencing target %s was our DC", event->target);
+            } else {
+                crm_notice("Fencing target %s may have been our DC",
+                           event->target);
+            }
 
             /* Given the CIB resyncing that occurs around elections,
              * have one node update the CIB now and, if the new DC is different,

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -412,7 +412,7 @@ tengine_stonith_connection_destroy(stonith_t *st, stonith_event_t *e)
 {
     te_cleanup_stonith_history_sync(st, FALSE);
 
-    if (pcmk_is_set(fsa_input_register, R_ST_REQUIRED)) {
+    if (pcmk_is_set(controld_globals.fsa_input_register, R_ST_REQUIRED)) {
         crm_crit("Fencing daemon connection failed");
         mainloop_set_trigger(stonith_reconnect);
 
@@ -648,7 +648,8 @@ te_connect_stonith(gpointer user_data)
         // Non-blocking (retry failures later in main loop)
         rc = stonith_api->cmds->connect(stonith_api, crm_system_name, NULL);
         if (rc != pcmk_ok) {
-            if (pcmk_is_set(fsa_input_register, R_ST_REQUIRED)) {
+            if (pcmk_is_set(controld_globals.fsa_input_register,
+                            R_ST_REQUIRED)) {
                 crm_notice("Fencer connection failed (will retry): %s "
                            CRM_XS " rc=%d", pcmk_strerror(rc), rc);
                 mainloop_set_trigger(stonith_reconnect);

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -498,7 +498,8 @@ handle_fence_notification(stonith_t *st, stonith_event_t *event)
     }
 
     if (succeeded
-        && pcmk__str_eq(event->target, fsa_our_uname, pcmk__str_casei)) {
+        && pcmk__str_eq(event->target, controld_globals.our_nodename,
+                        pcmk__str_casei)) {
         /* We were notified of our own fencing. Most likely, either fencing was
          * misconfigured, or fabric fencing that doesn't cut cluster
          * communication is in use.
@@ -589,7 +590,7 @@ handle_fence_notification(stonith_t *st, stonith_event_t *event)
              * have one node update the CIB now and, if the new DC is different,
              * have them do so too after the election
              */
-            if (pcmk__str_eq(event->executioner, fsa_our_uname,
+            if (pcmk__str_eq(event->executioner, controld_globals.our_nodename,
                              pcmk__str_casei)) {
                 send_stonith_update(NULL, event->target, uuid);
             }
@@ -961,11 +962,12 @@ controld_execute_fence_action(pcmk__graph_t *graph,
 bool
 controld_verify_stonith_watchdog_timeout(const char *value)
 {
+    const char *our_nodename = controld_globals.our_nodename;
     gboolean rv = TRUE;
 
     if (stonith_api && (stonith_api->state != stonith_disconnected) &&
         stonith__watchdog_fencing_enabled_for_node_api(stonith_api,
-                                                       fsa_our_uname)) {
+                                                       our_nodename)) {
         rv = pcmk__valid_sbd_timeout(value);
     }
     return rv;

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -27,7 +27,6 @@
 #include <controld_matrix.h>
 
 cib_t *fsa_cib_conn = NULL;
-char *fsa_our_dc_version = NULL;
 
 char *fsa_our_uuid = NULL;
 char *fsa_our_uname = NULL;

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -40,7 +40,6 @@ uint64_t fsa_input_register = 0;
 uint64_t fsa_actions = A_NOTHING;
 enum crmd_fsa_state fsa_state = S_STARTING;
 
-extern uint highest_born_on;
 extern uint num_join_invites;
 
 #define DOT_PREFIX "actions:trace: "
@@ -567,9 +566,6 @@ do_state_transition(enum crmd_fsa_state cur_state,
 
     if (next_state != S_PENDING) {
         controld_set_fsa_action_flags(A_DC_TIMER_STOP);
-    }
-    if (next_state != S_ELECTION) {
-        highest_born_on = 0;
     }
     if (next_state != S_IDLE) {
         controld_stop_timer(recheck_timer);

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -543,7 +543,7 @@ do_state_transition(enum crmd_fsa_state cur_state,
                msg_data->origin);
 
     if (next_state != S_ELECTION && cur_state != S_RELEASE_DC) {
-        controld_stop_election_timer();
+        controld_stop_current_election_timeout();
     }
 #if 0
     if ((fsa_input_register & R_SHUTDOWN)) {

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -33,8 +33,6 @@ char *fsa_our_dc_version = NULL;
 char *fsa_our_uuid = NULL;
 char *fsa_our_uname = NULL;
 
-char *fsa_cluster_name = NULL;
-
 uint64_t fsa_input_register = 0;
 uint64_t fsa_actions = A_NOTHING;
 enum crmd_fsa_state fsa_state = S_STARTING;

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -215,7 +215,7 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
 
         /* update state variables */
         last_state = fsa_state;
-        fsa_state = crmd_fsa_state[fsa_data->fsa_input][fsa_state];
+        fsa_state = controld_fsa_next_state[fsa_data->fsa_input][fsa_state];
 
         /*
          * Remove certain actions during shutdown

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -26,7 +26,6 @@
 #include <pacemaker-controld.h>
 #include <controld_matrix.h>
 
-char *fsa_our_dc = NULL;
 cib_t *fsa_cib_conn = NULL;
 char *fsa_our_dc_version = NULL;
 
@@ -592,8 +591,8 @@ do_state_transition(enum crmd_fsa_state cur_state,
                 crm_info("(Re)Issuing shutdown request now" " that we have a new DC");
                 controld_set_fsa_action_flags(A_SHUTDOWN_REQ);
             }
-            CRM_LOG_ASSERT(fsa_our_dc != NULL);
-            if (fsa_our_dc == NULL) {
+            CRM_LOG_ASSERT(controld_globals.dc_name != NULL);
+            if (controld_globals.dc_name == NULL) {
                 crm_err("Reached S_NOT_DC without a DC" " being recorded");
             }
             break;

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -28,8 +28,6 @@
 
 cib_t *fsa_cib_conn = NULL;
 
-char *fsa_our_uuid = NULL;
-
 uint64_t fsa_input_register = 0;
 uint64_t fsa_actions = A_NOTHING;
 enum crmd_fsa_state fsa_state = S_STARTING;

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -584,7 +584,7 @@ do_state_transition(enum crmd_fsa_state cur_state,
             break;
 
         case S_NOT_DC:
-            election_trigger->counter = 0;
+            election_timer->counter = 0;
             purge_stonith_cleanup();
 
             if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
@@ -620,7 +620,7 @@ do_state_transition(enum crmd_fsa_state cur_state,
             break;
 
         case S_POLICY_ENGINE:
-            election_trigger->counter = 0;
+            election_timer->counter = 0;
             CRM_LOG_ASSERT(AM_I_DC);
             if (cause == C_TIMER_POPPED) {
                 crm_info("Progressed to state %s after %s",

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -24,7 +24,6 @@
 #include <crm/cluster.h>
 
 #include <pacemaker-controld.h>
-#include <controld_matrix.h>
 
 cib_t *fsa_cib_conn = NULL;
 
@@ -184,7 +183,8 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
         fsa_dump_actions(fsa_data->actions, "Restored actions");
 
         /* get the next batch of actions */
-        new_actions = crmd_fsa_actions[fsa_data->fsa_input][globals->fsa_state];
+        new_actions = controld_fsa_get_action(fsa_data->fsa_input,
+                                              globals->fsa_state);
         controld_set_fsa_action_flags(new_actions);
         fsa_dump_actions(new_actions, "New actions");
 
@@ -208,8 +208,8 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
 
         /* update state variables */
         last_state = globals->fsa_state;
-        globals->fsa_state
-            = controld_fsa_next_state[fsa_data->fsa_input][globals->fsa_state];
+        globals->fsa_state = controld_fsa_get_next_state(fsa_data->fsa_input,
+                                                         globals->fsa_state);
 
         /*
          * Remove certain actions during shutdown

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -155,7 +155,7 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
 
     fsa_dump_actions(controld_globals.fsa_actions, "Initial");
 
-    controld_globals.flags &= ~controld_fsa_is_stalled;
+    controld_clear_global_flags(controld_fsa_is_stalled);
     if ((fsa_message_queue == NULL)
         && (controld_globals.fsa_actions != A_NOTHING)) {
         /* fake the first message so we can get into the loop */

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -40,8 +40,6 @@ uint64_t fsa_input_register = 0;
 uint64_t fsa_actions = A_NOTHING;
 enum crmd_fsa_state fsa_state = S_STARTING;
 
-extern uint num_join_invites;
-
 #define DOT_PREFIX "actions:trace: "
 #define do_dot_log(fmt, args...)     crm_trace( fmt, ##args)
 

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -29,7 +29,6 @@
 cib_t *fsa_cib_conn = NULL;
 
 char *fsa_our_uuid = NULL;
-char *fsa_our_uname = NULL;
 
 uint64_t fsa_input_register = 0;
 uint64_t fsa_actions = A_NOTHING;

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -502,7 +502,6 @@ extern cib_t *fsa_cib_conn;
 extern char *fsa_our_uname;
 extern char *fsa_our_uuid;
 extern char *fsa_pe_ref;        // Last invocation of the scheduler
-extern char *fsa_our_dc_version;
 extern GList *fsa_message_queue;
 
 extern crm_trigger_t *fsa_source;

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -459,7 +459,6 @@ struct fsa_data_s {
 };
 
 /* Global FSA stuff */
-extern enum crmd_fsa_state fsa_state;
 extern uint64_t fsa_input_register;
 extern uint64_t fsa_actions;
 

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -459,25 +459,23 @@ struct fsa_data_s {
 };
 
 /* Global FSA stuff */
-extern uint64_t fsa_input_register;
 extern uint64_t fsa_actions;
 
-#define controld_set_fsa_input_flags(flags_to_set) do {                     \
-        fsa_input_register = pcmk__set_flags_as(__func__, __LINE__,         \
-                                                LOG_TRACE,                  \
-                                                "FSA input", "controller",  \
-                                                fsa_input_register,         \
-                                                (flags_to_set),             \
-                                                #flags_to_set);             \
+#define controld_set_fsa_input_flags(flags_to_set) do {                 \
+        controld_globals.fsa_input_register                             \
+            = pcmk__set_flags_as(__func__, __LINE__, LOG_TRACE,         \
+                                 "FSA input", "controller",             \
+                                 controld_globals.fsa_input_register,   \
+                                 (flags_to_set), #flags_to_set);        \
     } while (0)
 
-#define controld_clear_fsa_input_flags(flags_to_clear) do {                 \
-        fsa_input_register = pcmk__clear_flags_as(__func__, __LINE__,       \
-                                                  LOG_TRACE,                \
-                                                  "FSA input", "controller",\
-                                                  fsa_input_register,       \
-                                                  (flags_to_clear),         \
-                                                  #flags_to_clear);         \
+#define controld_clear_fsa_input_flags(flags_to_clear) do {             \
+        controld_globals.fsa_input_register                             \
+            = pcmk__clear_flags_as(__func__, __LINE__, LOG_TRACE,       \
+                                   "FSA input", "controller",           \
+                                   controld_globals.fsa_input_register, \
+                                   (flags_to_clear),                    \
+                                   #flags_to_clear);                    \
     } while (0)
 
 #define controld_set_fsa_action_flags(flags_to_set) do {                    \
@@ -519,8 +517,9 @@ enum crmd_fsa_state s_crmd_fsa(enum crmd_fsa_cause cause);
 
 void free_max_generation(void);
 
-#  define AM_I_DC pcmk_is_set(fsa_input_register, R_THE_DC)
-#  define AM_I_OPERATIONAL !pcmk_is_set(fsa_input_register, R_STARTING)
+#  define AM_I_DC pcmk_is_set(controld_globals.fsa_input_register, R_THE_DC)
+#  define AM_I_OPERATIONAL !pcmk_is_set(controld_globals.fsa_input_register, \
+                                        R_STARTING)
 #  define trigger_fsa() do {                    \
         if (fsa_source != NULL) {               \
             crm_trace("Triggering FSA");        \

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -499,7 +499,6 @@ extern uint64_t fsa_actions;
 
 extern cib_t *fsa_cib_conn;
 
-extern char *fsa_our_uname;
 extern char *fsa_our_uuid;
 extern char *fsa_pe_ref;        // Last invocation of the scheduler
 extern GList *fsa_message_queue;

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -509,7 +509,6 @@ extern GList *fsa_message_queue;
 extern char *fsa_cluster_name;
 
 extern crm_trigger_t *fsa_source;
-extern crm_trigger_t *config_read;
 
 extern unsigned long long saved_ccm_membership_id;
 

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -515,8 +515,6 @@ enum crmd_fsa_state s_crmd_fsa(enum crmd_fsa_cause cause);
 void free_max_generation(void);
 
 #  define AM_I_DC pcmk_is_set(controld_globals.fsa_input_register, R_THE_DC)
-#  define AM_I_OPERATIONAL !pcmk_is_set(controld_globals.fsa_input_register, \
-                                        R_STARTING)
 #  define trigger_fsa() do {                    \
         if (fsa_source != NULL) {               \
             crm_trace("Triggering FSA");        \

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -458,9 +458,6 @@ struct fsa_data_s {
     enum fsa_data_type data_type;
 };
 
-/* Global FSA stuff */
-extern uint64_t fsa_actions;
-
 #define controld_set_fsa_input_flags(flags_to_set) do {                 \
         controld_globals.fsa_input_register                             \
             = pcmk__set_flags_as(__func__, __LINE__, LOG_TRACE,         \
@@ -478,20 +475,20 @@ extern uint64_t fsa_actions;
                                    #flags_to_clear);                    \
     } while (0)
 
-#define controld_set_fsa_action_flags(flags_to_set) do {                    \
-        fsa_actions = pcmk__set_flags_as(__func__, __LINE__,                \
-                                         LOG_DEBUG,                         \
-                                         "FSA action", "controller",        \
-                                         fsa_actions, (flags_to_set),       \
-                                         #flags_to_set);                    \
+#define controld_set_fsa_action_flags(flags_to_set) do {            \
+        controld_globals.fsa_actions                                \
+            = pcmk__set_flags_as(__func__, __LINE__, LOG_DEBUG,     \
+                                 "FSA action", "controller",        \
+                                 controld_globals.fsa_actions,      \
+                                 (flags_to_set), #flags_to_set);    \
     } while (0)
 
-#define controld_clear_fsa_action_flags(flags_to_clear) do {                \
-        fsa_actions = pcmk__clear_flags_as(__func__, __LINE__,              \
-                                           LOG_DEBUG,                       \
-                                           "FSA action", "controller",      \
-                                           fsa_actions, (flags_to_clear),   \
-                                           #flags_to_clear);                \
+#define controld_clear_fsa_action_flags(flags_to_clear) do {            \
+        controld_globals.fsa_actions                                    \
+            = pcmk__clear_flags_as(__func__, __LINE__, LOG_DEBUG,       \
+                                   "FSA action", "controller",          \
+                                   controld_globals.fsa_actions,        \
+                                   (flags_to_clear), #flags_to_clear);  \
     } while (0)
 
 extern cib_t *fsa_cib_conn;

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -527,6 +527,8 @@ const char *fsa_action2string(long long action);
 
 enum crmd_fsa_state s_crmd_fsa(enum crmd_fsa_cause cause);
 
+void free_max_generation(void);
+
 #  define AM_I_DC pcmk_is_set(fsa_input_register, R_THE_DC)
 #  define AM_I_OPERATIONAL !pcmk_is_set(fsa_input_register, R_STARTING)
 #  define trigger_fsa() do {                    \

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -512,7 +512,6 @@ extern crm_trigger_t *fsa_source;
 extern crm_trigger_t *config_read;
 
 extern unsigned long long saved_ccm_membership_id;
-extern gboolean ever_had_quorum;
 
 // These should be moved elsewhere
 void do_update_cib_nodes(gboolean overwrite, const char *caller);

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -499,7 +499,6 @@ extern uint64_t fsa_actions;
 
 extern cib_t *fsa_cib_conn;
 
-extern char *fsa_our_uuid;
 extern char *fsa_pe_ref;        // Last invocation of the scheduler
 extern GList *fsa_message_queue;
 

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -459,7 +459,6 @@ struct fsa_data_s {
 };
 
 /* Global FSA stuff */
-extern gboolean do_fsa_stall;
 extern enum crmd_fsa_state fsa_state;
 extern uint64_t fsa_input_register;
 extern uint64_t fsa_actions;

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -506,8 +506,6 @@ extern char *fsa_our_dc;
 extern char *fsa_our_dc_version;
 extern GList *fsa_message_queue;
 
-extern char *fsa_cluster_name;
-
 extern crm_trigger_t *fsa_source;
 
 extern unsigned long long saved_ccm_membership_id;

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -502,7 +502,6 @@ extern cib_t *fsa_cib_conn;
 extern char *fsa_our_uname;
 extern char *fsa_our_uuid;
 extern char *fsa_pe_ref;        // Last invocation of the scheduler
-extern char *fsa_our_dc;
 extern char *fsa_our_dc_version;
 extern GList *fsa_message_queue;
 

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -512,6 +512,12 @@ const char *fsa_action2string(long long action);
 
 enum crmd_fsa_state s_crmd_fsa(enum crmd_fsa_cause cause);
 
+enum crmd_fsa_state controld_fsa_get_next_state(enum crmd_fsa_input input,
+                                                enum crmd_fsa_state state);
+
+uint64_t controld_fsa_get_action(enum crmd_fsa_input input,
+                                 enum crmd_fsa_state state);
+
 void free_max_generation(void);
 
 #  define AM_I_DC pcmk_is_set(controld_globals.fsa_input_register, R_THE_DC)

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -301,7 +301,9 @@ do_cl_join_finalize_respond(long long action,
          * are _NOT_ lucky, we will probe for the "wrong" instance of anonymous
          * clones and end up with multiple active instances on the machine.
          */
-        if (first_join && !pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
+        if (first_join
+            && !pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
+
             first_join = FALSE;
             if (start_state) {
                 set_join_state(start_state);

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -199,24 +199,25 @@ set_join_state(const char * start_state)
 {
     if (pcmk__str_eq(start_state, "standby", pcmk__str_casei)) {
         crm_notice("Forcing node %s to join in %s state per configured environment",
-                   fsa_our_uname, start_state);
+                   controld_globals.our_nodename, start_state);
         cib__update_node_attr(logger_out, fsa_cib_conn, cib_sync_call,
                               XML_CIB_TAG_NODES, fsa_our_uuid, NULL, NULL,
                               NULL, "standby", "on", NULL, NULL);
 
     } else if (pcmk__str_eq(start_state, "online", pcmk__str_casei)) {
         crm_notice("Forcing node %s to join in %s state per configured environment",
-                   fsa_our_uname, start_state);
+                   controld_globals.our_nodename, start_state);
         cib__update_node_attr(logger_out, fsa_cib_conn, cib_sync_call,
                               XML_CIB_TAG_NODES, fsa_our_uuid, NULL, NULL,
                               NULL, "standby", "off", NULL, NULL);
 
     } else if (pcmk__str_eq(start_state, "default", pcmk__str_casei)) {
-        crm_debug("Not forcing a starting state on node %s", fsa_our_uname);
+        crm_debug("Not forcing a starting state on node %s",
+                  controld_globals.our_nodename);
 
     } else {
         crm_warn("Unrecognized start state '%s', using 'default' (%s)",
-                 start_state, fsa_our_uname);
+                 start_state, controld_globals.our_nodename);
     }
 }
 
@@ -257,7 +258,9 @@ do_cl_join_finalize_respond(long long action,
         return;
     }
 
-    if (AM_I_DC == FALSE && pcmk__str_eq(welcome_from, fsa_our_uname, pcmk__str_casei)) {
+    if (!AM_I_DC
+        && pcmk__str_eq(welcome_from, controld_globals.our_nodename,
+                        pcmk__str_casei)) {
         crm_warn("Discarding our own welcome - we're no longer the DC");
         return;
     }
@@ -271,8 +274,8 @@ do_cl_join_finalize_respond(long long action,
     update_dc_expected(input->msg);
 
     /* record the node's feature set as a transient attribute */
-    update_attrd(fsa_our_uname, CRM_ATTR_FEATURE_SET, CRM_FEATURE_SET, NULL,
-                 FALSE);
+    update_attrd(controld_globals.our_nodename, CRM_ATTR_FEATURE_SET,
+                 CRM_FEATURE_SET, NULL, FALSE);
 
     /* send our status section to the DC */
     tmp1 = controld_query_executor_state();

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -79,7 +79,7 @@ do_cl_join_announce(long long action,
         return;
     }
 
-    if (AM_I_OPERATIONAL) {
+    if (!pcmk_is_set(controld_globals.fsa_input_register, R_STARTING)) {
         /* send as a broadcast */
         xmlNode *req = create_request(CRM_OP_JOIN_ANNOUNCE, NULL, NULL,
                                       CRM_SYSTEM_DC, CRM_SYSTEM_CRMD, NULL);

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -201,15 +201,15 @@ set_join_state(const char * start_state)
         crm_notice("Forcing node %s to join in %s state per configured environment",
                    controld_globals.our_nodename, start_state);
         cib__update_node_attr(logger_out, fsa_cib_conn, cib_sync_call,
-                              XML_CIB_TAG_NODES, fsa_our_uuid, NULL, NULL,
-                              NULL, "standby", "on", NULL, NULL);
+                              XML_CIB_TAG_NODES, controld_globals.our_uuid,
+                              NULL, NULL, NULL, "standby", "on", NULL, NULL);
 
     } else if (pcmk__str_eq(start_state, "online", pcmk__str_casei)) {
         crm_notice("Forcing node %s to join in %s state per configured environment",
                    controld_globals.our_nodename, start_state);
         cib__update_node_attr(logger_out, fsa_cib_conn, cib_sync_call,
-                              XML_CIB_TAG_NODES, fsa_our_uuid, NULL, NULL,
-                              NULL, "standby", "off", NULL, NULL);
+                              XML_CIB_TAG_NODES, controld_globals.our_uuid,
+                              NULL, NULL, NULL, "standby", "off", NULL, NULL);
 
     } else if (pcmk__str_eq(start_state, "default", pcmk__str_casei)) {
         crm_debug("Not forcing a starting state on node %s",

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -18,7 +18,6 @@
 
 extern pcmk__output_t *logger_out;
 
-int reannounce_count = 0;
 void join_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *user_data);
 
 extern ha_msg_input_t *copy_ha_msg_input(ha_msg_input_t * orig);

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -109,7 +109,8 @@ create_dc_message(const char *join_op, const char *host_to)
      * joining node from fencing the old DC if it becomes the new DC.
      */
     pcmk__xe_set_bool_attr(msg, F_CRM_DC_LEAVING,
-                           pcmk_is_set(fsa_input_register, R_SHUTDOWN));
+                           pcmk_is_set(controld_globals.fsa_input_register,
+                                       R_SHUTDOWN));
     return msg;
 }
 
@@ -442,7 +443,7 @@ do_dc_join_finalize(long long action,
         controld_set_fsa_input_flags(R_HAVE_CIB);
     }
 
-    if (pcmk_is_set(fsa_input_register, R_IN_TRANSITION)) {
+    if (pcmk_is_set(controld_globals.fsa_input_register, R_IN_TRANSITION)) {
         crm_warn("Delaying join-%d finalization while transition in progress",
                  current_join_id);
         crmd_join_phase_log(LOG_DEBUG);
@@ -450,7 +451,8 @@ do_dc_join_finalize(long long action,
         return;
     }
 
-    if (max_generation_from && !pcmk_is_set(fsa_input_register, R_HAVE_CIB)) {
+    if ((max_generation_from != NULL)
+        && !pcmk_is_set(controld_globals.fsa_input_register, R_HAVE_CIB)) {
         /* ask for the agreed best CIB */
         pcmk__str_update(&sync_from, max_generation_from);
         controld_set_fsa_input_flags(R_CIB_ASKED);
@@ -708,7 +710,7 @@ check_join_state(enum crmd_fsa_state cur_state, const char *source)
         }
 
     } else if (cur_state == S_FINALIZE_JOIN) {
-        if (!pcmk_is_set(fsa_input_register, R_HAVE_CIB)) {
+        if (!pcmk_is_set(controld_globals.fsa_input_register, R_HAVE_CIB)) {
             crm_debug("join-%d: Delaying finalization until we have CIB "
                       CRM_XS " state=%s for=%s",
                       current_join_id, fsa_state2string(cur_state), source);

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -432,7 +432,7 @@ do_dc_join_finalize(long long action,
         crm_debug("Finalization not needed for join-%d at the current time",
                   current_join_id);
         crmd_join_phase_log(LOG_DEBUG);
-        check_join_state(fsa_state, __func__);
+        check_join_state(controld_globals.fsa_state, __func__);
         return;
     }
 
@@ -500,16 +500,17 @@ finalize_sync_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, voi
     } else if (!AM_I_DC) {
         crm_debug("Sync'ed CIB for join-%d but no longer DC", current_join_id);
 
-    } else if (fsa_state != S_FINALIZE_JOIN) {
-        crm_debug("Sync'ed CIB for join-%d but no longer in S_FINALIZE_JOIN (%s)",
-                  current_join_id, fsa_state2string(fsa_state));
+    } else if (controld_globals.fsa_state != S_FINALIZE_JOIN) {
+        crm_debug("Sync'ed CIB for join-%d but no longer in S_FINALIZE_JOIN "
+                  "(%s)", current_join_id,
+                  fsa_state2string(controld_globals.fsa_state));
 
     } else {
         controld_set_fsa_input_flags(R_HAVE_CIB);
         controld_clear_fsa_input_flags(R_CIB_ASKED);
 
         /* make sure dc_uuid is re-set to us */
-        if (check_join_state(fsa_state, __func__) == FALSE) {
+        if (!check_join_state(controld_globals.fsa_state, __func__)) {
             int count_integrated = crmd_join_phase_count(crm_join_integrated);
 
             crm_debug("Notifying %d node%s of join-%d results",
@@ -528,7 +529,7 @@ join_update_complete_callback(xmlNode * msg, int call_id, int rc, xmlNode * outp
     if (rc == pcmk_ok) {
         crm_debug("join-%d node history update (via CIB call %d) complete",
                   current_join_id, call_id);
-        check_join_state(fsa_state, __func__);
+        check_join_state(controld_globals.fsa_state, __func__);
 
     } else {
         crm_err("join-%d node history update (via CIB call %d) failed: %s "

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -17,9 +17,8 @@
 
 #include <pacemaker-controld.h>
 
-char *max_epoch = NULL;
-char *max_generation_from = NULL;
-xmlNode *max_generation_xml = NULL;
+static char *max_generation_from = NULL;
+static xmlNodePtr max_generation_xml = NULL;
 
 void finalize_join_for(gpointer key, gpointer value, gpointer user_data);
 void finalize_sync_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *user_data);
@@ -468,6 +467,16 @@ do_dc_join_finalize(long long action,
 
     rc = fsa_cib_conn->cmds->sync_from(fsa_cib_conn, sync_from, NULL, cib_quorum_override);
     fsa_register_cib_callback(rc, FALSE, sync_from, finalize_sync_callback);
+}
+
+void
+free_max_generation(void)
+{
+    free(max_generation_from);
+    max_generation_from = NULL;
+
+    free_xml(max_generation_xml);
+    max_generation_xml = NULL;
 }
 
 void

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -595,7 +595,7 @@ do_dc_join_ack(long long action,
     /* Update CIB with node's current executor state. A new transition will be
      * triggered later, when the CIB notifies us of the change.
      */
-    if (controld_shutdown_lock_enabled) {
+    if (pcmk_is_set(controld_globals.flags, controld_shutdown_lock_enabled)) {
         section = controld_section_lrm_unlocked;
     }
     controld_delete_node_state(join_from, section, cib_scope_local);

--- a/daemons/controld/controld_matrix.c
+++ b/daemons/controld/controld_matrix.c
@@ -7,14 +7,17 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef XML_FSA_MATRIX__H
-#  define XML_FSA_MATRIX__H
+#include <crm_internal.h>
+
+#include <stdint.h>                 // uint64_t
+
+#include <pacemaker-controld.h>
 
 /*
  *	The state transition table.  The rows are inputs, and
  *	the columns are states.
  */
-static const enum crmd_fsa_state controld_fsa_next_state[MAXINPUT][MAXSTATE] = {
+static const enum crmd_fsa_state fsa_next_states[MAXINPUT][MAXSTATE] = {
 /* Got an I_NULL */
     {
      /* S_IDLE               ==> */ S_IDLE,
@@ -618,7 +621,7 @@ static const enum crmd_fsa_state controld_fsa_next_state[MAXINPUT][MAXSTATE] = {
 
 /* NOTE: In the fsa, the actions are extracted then state is updated. */
 
-static const uint64_t crmd_fsa_actions[MAXINPUT][MAXSTATE] = {
+static const uint64_t fsa_actions[MAXINPUT][MAXSTATE] = {
 
 /* Got an I_NULL */
     {
@@ -1218,4 +1221,25 @@ static const uint64_t crmd_fsa_actions[MAXINPUT][MAXSTATE] = {
      },
 };
 
-#endif
+/*!
+ * \internal
+ * \brief Get the next FSA state given an input and current state
+ * \return The next FSA state
+ */
+enum crmd_fsa_state
+controld_fsa_get_next_state(enum crmd_fsa_input input,
+                            enum crmd_fsa_state state)
+{
+    return fsa_next_states[input][state];
+}
+
+/*!
+ * \internal
+ * \brief Get the appropriate FSA action given an input and state
+ * \return The appropriate FSA action
+ */
+uint64_t
+controld_fsa_get_action(enum crmd_fsa_input input, enum crmd_fsa_state state)
+{
+    return fsa_actions[input][state];
+}

--- a/daemons/controld/controld_matrix.h
+++ b/daemons/controld/controld_matrix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,7 +14,7 @@
  *	The state transition table.  The rows are inputs, and
  *	the columns are states.
  */
-const enum crmd_fsa_state crmd_fsa_state[MAXINPUT][MAXSTATE] = {
+static const enum crmd_fsa_state controld_fsa_next_state[MAXINPUT][MAXSTATE] = {
 /* Got an I_NULL */
     {
      /* S_IDLE               ==> */ S_IDLE,
@@ -618,7 +618,7 @@ const enum crmd_fsa_state crmd_fsa_state[MAXINPUT][MAXSTATE] = {
 
 /* NOTE: In the fsa, the actions are extracted then state is updated. */
 
-const uint64_t crmd_fsa_actions[MAXINPUT][MAXSTATE] = {
+static const uint64_t crmd_fsa_actions[MAXINPUT][MAXSTATE] = {
 
 /* Got an I_NULL */
     {

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -402,7 +402,7 @@ crm_update_quorum(gboolean quorum, gboolean force_update)
     bool has_quorum = pcmk_is_set(controld_globals.flags, controld_has_quorum);
 
     if (quorum) {
-        controld_globals.flags |= controld_ever_had_quorum;
+        controld_set_global_flags(controld_ever_had_quorum);
 
     } else if (pcmk_all_flags_set(controld_globals.flags,
                                   controld_ever_had_quorum
@@ -451,8 +451,8 @@ crm_update_quorum(gboolean quorum, gboolean force_update)
     }
 
     if (quorum) {
-        controld_globals.flags |= controld_has_quorum;
+        controld_set_global_flags(controld_has_quorum);
     } else {
-        controld_globals.flags &= ~controld_has_quorum;
+        controld_clear_global_flags(controld_has_quorum);
     }
 }

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -22,8 +22,6 @@
 
 void post_cache_update(int instance);
 
-int last_peer_update = 0;
-
 extern gboolean check_join_state(enum crmd_fsa_state cur_state, const char *source);
 
 static void
@@ -92,8 +90,6 @@ static void
 crmd_node_update_complete(xmlNode * msg, int call_id, int rc, xmlNode * output, void *user_data)
 {
     fsa_data_t *msg_data = NULL;
-
-    last_peer_update = 0;
 
     if (rc == pcmk_ok) {
         crm_trace("Node update %d complete", call_id);
@@ -378,7 +374,6 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
 
         fsa_cib_update(XML_CIB_TAG_STATUS, node_list, call_options, call_id, NULL);
         fsa_register_cib_callback(call_id, FALSE, NULL, crmd_node_update_complete);
-        last_peer_update = call_id;
 
         free_xml(node_list);
     }

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -46,8 +46,9 @@ reap_dead_nodes(gpointer key, gpointer value, gpointer user_data)
             }
         }
 
-        if (fsa_state == S_INTEGRATION || fsa_state == S_FINALIZE_JOIN) {
-            check_join_state(fsa_state, __func__);
+        if ((controld_globals.fsa_state == S_INTEGRATION)
+            || (controld_globals.fsa_state == S_FINALIZE_JOIN)) {
+            check_join_state(controld_globals.fsa_state, __func__);
         }
         if(node && node->uuid) {
             fail_incompletable_actions(transition_graph, node->uuid);

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -52,8 +52,6 @@ reap_dead_nodes(gpointer key, gpointer value, gpointer user_data)
     }
 }
 
-gboolean ever_had_quorum = FALSE;
-
 void
 post_cache_update(int instance)
 {
@@ -397,9 +395,11 @@ cib_quorum_update_complete(xmlNode * msg, int call_id, int rc, xmlNode * output,
 void
 crm_update_quorum(gboolean quorum, gboolean force_update)
 {
-    ever_had_quorum |= quorum;
+    if (quorum) {
+        controld_globals.flags |= controld_ever_had_quorum;
 
-    if(ever_had_quorum && quorum == FALSE && no_quorum_suicide_escalation) {
+    } else if (pcmk_is_set(controld_globals.flags, controld_ever_had_quorum)
+               && no_quorum_suicide_escalation) {
         pcmk__panic(__func__);
     }
 

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -20,7 +20,6 @@
 
 #include <pacemaker-controld.h>
 
-gboolean membership_flux_hack = FALSE;
 void post_cache_update(int instance);
 
 int last_peer_update = 0;

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -33,7 +33,8 @@ reap_dead_nodes(gpointer key, gpointer value, gpointer user_data)
         crm_update_peer_join(__func__, node, crm_join_none);
 
         if(node && node->uname) {
-            if (pcmk__str_eq(fsa_our_uname, node->uname, pcmk__str_casei)) {
+            if (pcmk__str_eq(controld_globals.our_nodename, node->uname,
+                             pcmk__str_casei)) {
                 crm_err("We're not part of the cluster anymore");
                 register_fsa_input(C_FSA_INTERNAL, I_ERROR, NULL);
 

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -398,8 +398,9 @@ crm_update_quorum(gboolean quorum, gboolean force_update)
     if (quorum) {
         controld_globals.flags |= controld_ever_had_quorum;
 
-    } else if (pcmk_is_set(controld_globals.flags, controld_ever_had_quorum)
-               && no_quorum_suicide_escalation) {
+    } else if (pcmk_all_flags_set(controld_globals.flags,
+                                  controld_ever_had_quorum
+                                  |controld_no_quorum_suicide)) {
         pcmk__panic(__func__);
     }
 

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -24,7 +24,6 @@ gboolean membership_flux_hack = FALSE;
 void post_cache_update(int instance);
 
 int last_peer_update = 0;
-guint highest_born_on = -1;
 
 extern gboolean check_join_state(enum crmd_fsa_state cur_state, const char *source);
 

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -37,7 +37,9 @@ reap_dead_nodes(gpointer key, gpointer value, gpointer user_data)
                 crm_err("We're not part of the cluster anymore");
                 register_fsa_input(C_FSA_INTERNAL, I_ERROR, NULL);
 
-            } else if (AM_I_DC == FALSE && pcmk__str_eq(node->uname, fsa_our_dc, pcmk__str_casei)) {
+            } else if (!AM_I_DC
+                       && pcmk__str_eq(node->uname, controld_globals.dc_name,
+                                       pcmk__str_casei)) {
                 crm_warn("Our DC node (%s) left the cluster", node->uname);
                 register_fsa_input(C_FSA_INTERNAL, I_ELECTION, NULL);
             }

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -416,7 +416,7 @@ crm_update_quorum(gboolean quorum, gboolean force_update)
 
         update = create_xml_node(NULL, XML_TAG_CIB);
         crm_xml_add_int(update, XML_ATTR_HAVE_QUORUM, quorum);
-        crm_xml_add(update, XML_ATTR_DC_UUID, fsa_our_uuid);
+        crm_xml_add(update, XML_ATTR_DC_UUID, controld_globals.our_uuid);
 
         fsa_cib_update(XML_TAG_CIB, update, call_options, call_id, NULL);
         crm_debug("Updating quorum status to %s (call=%d)",

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -399,6 +399,8 @@ cib_quorum_update_complete(xmlNode * msg, int call_id, int rc, xmlNode * output,
 void
 crm_update_quorum(gboolean quorum, gboolean force_update)
 {
+    bool has_quorum = pcmk_is_set(controld_globals.flags, controld_has_quorum);
+
     if (quorum) {
         controld_globals.flags |= controld_ever_had_quorum;
 
@@ -409,7 +411,7 @@ crm_update_quorum(gboolean quorum, gboolean force_update)
     }
 
     if (AM_I_DC
-        && ((pcmk_is_set(controld_globals.flags, controld_has_quorum) != quorum)
+        && ((has_quorum && !quorum) || (!has_quorum && quorum)
             || force_update)) {
         int call_id = 0;
         xmlNode *update = NULL;

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -403,7 +403,9 @@ crm_update_quorum(gboolean quorum, gboolean force_update)
         pcmk__panic(__func__);
     }
 
-    if (AM_I_DC && (force_update || fsa_has_quorum != quorum)) {
+    if (AM_I_DC
+        && ((pcmk_is_set(controld_globals.flags, controld_has_quorum) != quorum)
+            || force_update)) {
         int call_id = 0;
         xmlNode *update = NULL;
         int call_options = cib_scope_local | cib_quorum_override;
@@ -440,5 +442,10 @@ crm_update_quorum(gboolean quorum, gboolean force_update)
                              NULL);
         }
     }
-    fsa_has_quorum = quorum;
+
+    if (quorum) {
+        controld_globals.flags |= controld_has_quorum;
+    } else {
+        controld_globals.flags &= ~controld_has_quorum;
+    }
 }

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -56,7 +56,7 @@ register_fsa_error_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
     register_fsa_input_adv(cause, input, new_data, A_NOTHING, TRUE, raised_from);
 }
 
-int
+void
 register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
                        void *data, uint64_t with_actions,
                        gboolean prepend, const char *raised_from)
@@ -71,7 +71,7 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
     if (input == I_NULL && with_actions == A_NOTHING /* && data == NULL */ ) {
         /* no point doing anything */
         crm_err("Cannot add entry to queue: no input and no action");
-        return 0;
+        return;
     }
 
     if (input == I_WAIT_FOR_EVENT) {
@@ -87,7 +87,7 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
         if (data == NULL) {
             controld_set_fsa_action_flags(with_actions);
             fsa_dump_actions(with_actions, "Restored");
-            return 0;
+            return;
         }
 
         /* Store everything in the new event and reset fsa_actions */
@@ -167,7 +167,6 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
         crm_trace("Triggering FSA");
         mainloop_set_trigger(fsa_source);
     }
-    return last_data_id;
 }
 
 void

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -908,7 +908,7 @@ handle_shutdown_self_ack(xmlNode *stored_msg)
 {
     const char *host_from = crm_element_value(stored_msg, F_CRM_HOST_FROM);
 
-    if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
+    if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
         // The expected case -- we initiated own shutdown sequence
         crm_info("Shutting down controller");
         return I_STOP;
@@ -949,7 +949,7 @@ handle_shutdown_ack(xmlNode *stored_msg)
     if ((controld_globals.dc_name == NULL)
         || (strcasecmp(host_from, controld_globals.dc_name) == 0)) {
 
-        if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
+        if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
             crm_info("Shutting down controller after confirmation from %s",
                      host_from);
         } else {

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -34,7 +34,7 @@ static enum crmd_fsa_input handle_shutdown_request(xmlNode *stored_msg);
 static void send_msg_via_ipc(xmlNode * msg, const char *sys);
 
 /* debug only, can wrap all it likes */
-int last_data_id = 0;
+static int last_data_id = 0;
 
 void
 register_fsa_error_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -75,7 +75,7 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
     }
 
     if (input == I_WAIT_FOR_EVENT) {
-        do_fsa_stall = TRUE;
+        controld_globals.flags |= controld_fsa_is_stalled;
         crm_debug("Stalling the FSA pending further input: source=%s cause=%s data=%p queue=%d",
                   raised_from, fsa_cause2string(cause), data, old_len);
 

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -759,7 +759,7 @@ handle_ping(const xmlNode *msg)
     crm_xml_add(ping, XML_PING_ATTR_SYSFROM, value);
 
     // Add controller state
-    value = fsa_state2string(fsa_state);
+    value = fsa_state2string(controld_globals.fsa_state);
     crm_xml_add(ping, XML_PING_ATTR_CRMDSTATE, value);
     crm_notice("Current ping state: %s", value); // CTS needs this
 
@@ -921,7 +921,7 @@ handle_shutdown_self_ack(xmlNode *stored_msg)
         return I_TERMINATE;
     }
 
-    if (fsa_state != S_STOPPING) {
+    if (controld_globals.fsa_state != S_STOPPING) {
         // Shouldn't happen -- non-DC confirming unrequested shutdown
         crm_err("Starting new DC election because %s is "
                 "confirming shutdown we did not request",
@@ -1044,7 +1044,7 @@ handle_request(xmlNode *stored_msg, enum crmd_fsa_cause cause)
                                __func__);
 
         /* Sometimes we _must_ go into S_ELECTION */
-        if (fsa_state == S_HALT) {
+        if (controld_globals.fsa_state == S_HALT) {
             crm_debug("Forcing an election from S_HALT");
             return I_ELECTION;
 #if 0
@@ -1192,7 +1192,8 @@ handle_shutdown_request(xmlNode * stored_msg)
         host_from = controld_globals.our_nodename;
     }
 
-    crm_info("Creating shutdown request for %s (state=%s)", host_from, fsa_state2string(fsa_state));
+    crm_info("Creating shutdown request for %s (state=%s)", host_from,
+             fsa_state2string(controld_globals.fsa_state));
     crm_log_xml_trace(stored_msg, "message");
 
     now_s = pcmk__ttoa(time(NULL));
@@ -1240,7 +1241,8 @@ send_msg_via_ipc(xmlNode * msg, const char *sys)
         fsa_data.origin = __func__;
         fsa_data.data_type = fsa_dt_ha_msg;
 
-        do_lrm_invoke(A_LRM_INVOKE, C_IPC_MESSAGE, fsa_state, I_MESSAGE, &fsa_data);
+        do_lrm_invoke(A_LRM_INVOKE, C_IPC_MESSAGE, controld_globals.fsa_state,
+                      I_MESSAGE, &fsa_data);
 
     } else if (crmd_is_proxy_session(sys)) {
         crmd_proxy_send(sys, msg);

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -838,7 +838,9 @@ handle_node_info_request(const xmlNode *msg)
     crm_xml_add(reply_data, XML_PING_ATTR_SYSFROM, CRM_SYSTEM_CRMD);
 
     // Add whether current partition has quorum
-    pcmk__xe_set_bool_attr(reply_data, XML_ATTR_HAVE_QUORUM, fsa_has_quorum);
+    pcmk__xe_set_bool_attr(reply_data, XML_ATTR_HAVE_QUORUM,
+                           pcmk_is_set(controld_globals.flags,
+                                       controld_has_quorum));
 
     // Check whether client requested node info by ID and/or name
     crm_element_value_int(msg, XML_ATTR_ID, &node_id);

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -75,7 +75,7 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
     }
 
     if (input == I_WAIT_FOR_EVENT) {
-        controld_globals.flags |= controld_fsa_is_stalled;
+        controld_set_global_flags(controld_fsa_is_stalled);
         crm_debug("Stalling the FSA pending further input: source=%s cause=%s data=%p queue=%d",
                   raised_from, fsa_cause2string(cause), data, old_len);
 

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -390,7 +390,8 @@ relay_message(xmlNode * msg, gboolean originated_locally)
             is_local = true;
         }
 
-    } else if (pcmk__str_eq(fsa_our_uname, host_to, pcmk__str_casei)) {
+    } else if (pcmk__str_eq(controld_globals.our_nodename, host_to,
+                            pcmk__str_casei)) {
         is_local = true;
     } else if (is_for_crm && pcmk__str_eq(task, CRM_OP_LRM_DELETE, pcmk__str_casei)) {
         xmlNode *msg_data = get_message_xml(msg, F_CRM_DATA);
@@ -851,7 +852,7 @@ handle_node_info_request(const xmlNode *msg)
 
     // Default to local node if none given
     if ((node_id == 0) && (value == NULL)) {
-        value = fsa_our_uname;
+        value = controld_globals.our_nodename;
     }
 
     node = pcmk__search_node_caches(node_id, value, CRM_GET_PEER_ANY);
@@ -1188,7 +1189,7 @@ handle_shutdown_request(xmlNode * stored_msg)
 
     if (host_from == NULL) {
         /* we're shutting down and the DC */
-        host_from = fsa_our_uname;
+        host_from = controld_globals.our_nodename;
     }
 
     crm_info("Creating shutdown request for %s (state=%s)", host_from, fsa_state2string(fsa_state));
@@ -1212,7 +1213,7 @@ send_msg_via_ipc(xmlNode * msg, const char *sys)
     client_channel = pcmk__find_client_by_id(sys);
 
     if (crm_element_value(msg, F_CRM_HOST_FROM) == NULL) {
-        crm_xml_add(msg, F_CRM_HOST_FROM, fsa_our_uname);
+        crm_xml_add(msg, F_CRM_HOST_FROM, controld_globals.our_nodename);
     }
 
     if (client_channel != NULL) {

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -41,16 +41,16 @@ register_fsa_error_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
                        fsa_data_t * cur_data, void *new_data, const char *raised_from)
 {
     /* save the current actions if any */
-    if (fsa_actions != A_NOTHING) {
+    if (controld_globals.fsa_actions != A_NOTHING) {
         register_fsa_input_adv(cur_data ? cur_data->fsa_cause : C_FSA_INTERNAL,
                                I_NULL, cur_data ? cur_data->data : NULL,
-                               fsa_actions, TRUE, __func__);
+                               controld_globals.fsa_actions, TRUE, __func__);
     }
 
     /* reset the action list */
     crm_info("Resetting the current action list");
-    fsa_dump_actions(fsa_actions, "Drop");
-    fsa_actions = A_NOTHING;
+    fsa_dump_actions(controld_globals.fsa_actions, "Drop");
+    controld_globals.fsa_actions = A_NOTHING;
 
     /* register the error */
     register_fsa_input_adv(cause, input, new_data, A_NOTHING, TRUE, raised_from);
@@ -90,9 +90,11 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
             return;
         }
 
-        /* Store everything in the new event and reset fsa_actions */
-        with_actions |= fsa_actions;
-        fsa_actions = A_NOTHING;
+        /* Store everything in the new event and reset
+         * controld_globals.fsa_actions
+         */
+        with_actions |= controld_globals.fsa_actions;
+        controld_globals.fsa_actions = A_NOTHING;
     }
 
     last_data_id++;

--- a/daemons/controld/controld_messages.h
+++ b/daemons/controld/controld_messages.h
@@ -36,9 +36,10 @@ extern void register_fsa_error_adv(enum crmd_fsa_cause cause, enum crmd_fsa_inpu
 #define register_fsa_error(cause, input, new_data)  \
     register_fsa_error_adv(cause, input, msg_data, new_data, __func__)
 
-extern int register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
-                                  void *data, uint64_t with_actions,
-                                  gboolean prepend, const char *raised_from);
+void register_fsa_input_adv(enum crmd_fsa_cause cause,
+                            enum crmd_fsa_input input, void *data,
+                            uint64_t with_actions, gboolean prepend,
+                            const char *raised_from);
 
 extern void fsa_dump_queue(int log_level);
 extern void route_message(enum crmd_fsa_cause cause, xmlNode * input);

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -187,7 +187,7 @@ remote_node_up(const char *node_name)
      * number of corner cases, clear them here as well, to be sure.
      */
     call_opt = crmd_cib_smart_opt();
-    if (controld_shutdown_lock_enabled) {
+    if (pcmk_is_set(controld_globals.flags, controld_shutdown_lock_enabled)) {
         section = controld_section_all_unlocked;
     }
     /* Purge node from attrd's memory */

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -511,7 +511,7 @@ synthesize_lrmd_success(lrm_state_t *lrm_state, const char *rsc_id, const char *
 
     if (lrm_state == NULL) {
         /* if lrm_state not given assume local */
-        lrm_state = lrm_state_find(fsa_our_uname);
+        lrm_state = lrm_state_find(controld_globals.our_nodename);
     }
     CRM_ASSERT(lrm_state != NULL);
 
@@ -912,7 +912,8 @@ is_remote_lrmd_ra(const char *agent, const char *provider, const char *id)
     if (agent && provider && !strcmp(agent, REMOTE_LRMD_RA) && !strcmp(provider, "pacemaker")) {
         return TRUE;
     }
-    if (id && lrm_state_find(id) && !pcmk__str_eq(id, fsa_our_uname, pcmk__str_casei)) {
+    if ((id != NULL) && (lrm_state_find(id) != NULL)
+        && !pcmk__str_eq(id, controld_globals.our_nodename, pcmk__str_casei)) {
         return TRUE;
     }
 

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -470,7 +470,9 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     pcmk__refresh_node_caches_from_cib(output);
 
     crm_xml_add(output, XML_ATTR_DC_UUID, fsa_our_uuid);
-    crm_xml_add_int(output, XML_ATTR_HAVE_QUORUM, fsa_has_quorum);
+    pcmk__xe_set_bool_attr(output, XML_ATTR_HAVE_QUORUM,
+                           pcmk_is_set(controld_globals.flags,
+                                       controld_has_quorum));
 
     force_local_option(output, XML_ATTR_HAVE_WATCHDOG, pcmk__btoa(watchdog));
 
@@ -488,7 +490,9 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     } else {
         CRM_ASSERT(ref != NULL);
         controld_expect_sched_reply(ref);
-        crm_debug("Invoking the scheduler: query=%d, ref=%s, seq=%llu, quorate=%d",
-                  fsa_pe_query, fsa_pe_ref, crm_peer_seq, fsa_has_quorum);
+        crm_debug("Invoking the scheduler: query=%d, ref=%s, seq=%llu, "
+                  "quorate=%s", fsa_pe_query, fsa_pe_ref, crm_peer_seq,
+                  pcmk__btoa(pcmk_is_set(controld_globals.flags,
+                                         controld_has_quorum)));
     }
 }

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -358,7 +358,7 @@ do_pe_invoke(long long action,
     fsa_pe_query = fsa_cib_conn->cmds->query(fsa_cib_conn, NULL, NULL, cib_scope_local);
 
     crm_debug("Query %d: Requesting the current CIB: %s", fsa_pe_query,
-              fsa_state2string(fsa_state));
+              fsa_state2string(controld_globals.fsa_state));
 
     controld_expect_sched_reply(NULL);
     fsa_register_cib_callback(fsa_pe_query, FALSE, NULL, do_pe_invoke_callback);
@@ -448,9 +448,9 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
         crm_debug("No need to invoke the scheduler anymore");
         return;
 
-    } else if (fsa_state != S_POLICY_ENGINE) {
+    } else if (controld_globals.fsa_state != S_POLICY_ENGINE) {
         crm_debug("Discarding scheduler request in state: %s",
-                  fsa_state2string(fsa_state));
+                  fsa_state2string(controld_globals.fsa_state));
         return;
 
     /* this callback counts as 1 */

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -234,7 +234,7 @@ do_pe_control(long long action,
     }
 }
 
-int fsa_pe_query = 0;
+static int fsa_pe_query = 0;
 char *fsa_pe_ref = NULL;
 static mainloop_timer_t *controld_sched_timer = NULL;
 

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -469,7 +469,7 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
      * scheduler is invoked */
     pcmk__refresh_node_caches_from_cib(output);
 
-    crm_xml_add(output, XML_ATTR_DC_UUID, fsa_our_uuid);
+    crm_xml_add(output, XML_ATTR_DC_UUID, controld_globals.our_uuid);
     pcmk__xe_set_bool_attr(output, XML_ATTR_HAVE_QUORUM,
                            pcmk_is_set(controld_globals.flags,
                                        controld_has_quorum));

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -474,7 +474,8 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 
     force_local_option(output, XML_ATTR_HAVE_WATCHDOG, pcmk__btoa(watchdog));
 
-    if (ever_had_quorum && crm_have_quorum == FALSE) {
+    if (pcmk_is_set(controld_globals.flags, controld_ever_had_quorum)
+        && !crm_have_quorum) {
         crm_xml_add_int(output, XML_ATTR_QUORUM_PANIC, 1);
     }
 

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -21,7 +21,7 @@
 #include <pacemaker-controld.h>
 
 char *te_uuid = NULL;
-GHashTable *te_targets = NULL;
+static GHashTable *te_targets = NULL;
 void send_rsc_command(pcmk__graph_action_t *action);
 static void te_update_job_count(pcmk__graph_action_t *action, int offset);
 

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -56,7 +56,8 @@ execute_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *pseudo)
         while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
             xmlNode *cmd = NULL;
 
-            if (pcmk__str_eq(fsa_our_uname, node->uname, pcmk__str_casei)) {
+            if (pcmk__str_eq(controld_globals.our_nodename, node->uname,
+                             pcmk__str_casei)) {
                 continue;
             }
 
@@ -129,12 +130,13 @@ execute_cluster_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
             const char *mode = crm_element_value(action->xml, PCMK__XA_MODE);
 
             if (pcmk__str_eq(mode, XML_TAG_CIB, pcmk__str_none)) {
-                router_node = fsa_our_uname;
+                router_node = controld_globals.our_nodename;
             }
         }
     }
 
-    if (pcmk__str_eq(router_node, fsa_our_uname, pcmk__str_casei)) {
+    if (pcmk__str_eq(router_node, controld_globals.our_nodename,
+                     pcmk__str_casei)) {
         is_local = TRUE;
     }
 
@@ -376,7 +378,8 @@ execute_rsc_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
                                    get_target_rc(action), te_uuid);
     crm_xml_add(rsc_op, XML_ATTR_TRANSITION_KEY, counter);
 
-    if (pcmk__str_eq(router_node, fsa_our_uname, pcmk__str_casei)) {
+    if (pcmk__str_eq(router_node, controld_globals.our_nodename,
+                     pcmk__str_casei)) {
         is_local = TRUE;
     }
 

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -412,7 +412,8 @@ execute_rsc_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
             .origin = __func__,
         };
 
-        do_lrm_invoke(A_LRM_INVOKE, C_FSA_INTERNAL, fsa_state, I_NULL, &msg);
+        do_lrm_invoke(A_LRM_INVOKE, C_FSA_INTERNAL, controld_globals.fsa_state,
+                      I_NULL, &msg);
 
     } else {
         rc = send_cluster_message(crm_get_peer(0, router_node), crm_msg_lrmd, cmd, TRUE);
@@ -672,27 +673,28 @@ notify_crmd(pcmk__graph_t *graph)
     const char *type = "unknown";
     enum crmd_fsa_input event = I_NULL;
 
-    crm_debug("Processing transition completion in state %s", fsa_state2string(fsa_state));
+    crm_debug("Processing transition completion in state %s",
+              fsa_state2string(controld_globals.fsa_state));
 
     CRM_CHECK(graph->complete, graph->complete = true);
 
     switch (graph->completion_action) {
         case pcmk__graph_wait:
             type = "stop";
-            if (fsa_state == S_TRANSITION_ENGINE) {
+            if (controld_globals.fsa_state == S_TRANSITION_ENGINE) {
                 event = I_TE_SUCCESS;
             }
             break;
         case pcmk__graph_done:
             type = "done";
-            if (fsa_state == S_TRANSITION_ENGINE) {
+            if (controld_globals.fsa_state == S_TRANSITION_ENGINE) {
                 event = I_TE_SUCCESS;
             }
             break;
 
         case pcmk__graph_restart:
             type = "restart";
-            if (fsa_state == S_TRANSITION_ENGINE) {
+            if (controld_globals.fsa_state == S_TRANSITION_ENGINE) {
                 if (transition_timer->period_ms > 0) {
                     controld_stop_timer(transition_timer);
                     controld_start_timer(transition_timer);
@@ -700,7 +702,7 @@ notify_crmd(pcmk__graph_t *graph)
                     event = I_PE_CALC;
                 }
 
-            } else if (fsa_state == S_POLICY_ENGINE) {
+            } else if (controld_globals.fsa_state == S_POLICY_ENGINE) {
                 controld_set_fsa_action_flags(A_PE_INVOKE);
                 trigger_fsa();
             }

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -710,7 +710,7 @@ notify_crmd(pcmk__graph_t *graph)
 
         case pcmk__graph_shutdown:
             type = "shutdown";
-            if (pcmk_is_set(fsa_input_register, R_SHUTDOWN)) {
+            if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
                 event = I_STOP;
 
             } else {

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -542,10 +542,11 @@ te_update_diff(const char *event, xmlNode * msg)
         return;
 
     } else if (transition_graph->complete
-               && fsa_state != S_IDLE
-               && fsa_state != S_TRANSITION_ENGINE
-               && fsa_state != S_POLICY_ENGINE) {
-        crm_trace("Filter state=%s (complete)", fsa_state2string(fsa_state));
+               && (controld_globals.fsa_state != S_IDLE)
+               && (controld_globals.fsa_state != S_TRANSITION_ENGINE)
+               && (controld_globals.fsa_state != S_POLICY_ENGINE)) {
+        crm_trace("Filter state=%s (complete)",
+                  fsa_state2string(controld_globals.fsa_state));
         return;
     }
 
@@ -555,7 +556,7 @@ te_update_diff(const char *event, xmlNode * msg)
     xml_patch_versions(diff, p_add, p_del);
     crm_debug("Processing (%s) diff: %d.%d.%d -> %d.%d.%d (%s)", op,
               p_del[0], p_del[1], p_del[2], p_add[0], p_add[1], p_add[2],
-              fsa_state2string(fsa_state));
+              fsa_state2string(controld_globals.fsa_state));
 
     crm_element_value_int(diff, "format", &format);
     switch (format) {

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -23,7 +23,6 @@ void te_update_confirm(const char *event, xmlNode * msg);
 
 extern char *te_uuid;
 pcmk__graph_t *transition_graph;
-crm_trigger_t *transition_trigger = NULL;
 
 #define RSC_OP_PREFIX "//" XML_TAG_DIFF_ADDED "//" XML_TAG_CIB \
                       "//" XML_LRM_TAG_RSC_OP "[@" XML_ATTR_ID "='"

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -22,7 +22,6 @@
 void te_update_confirm(const char *event, xmlNode * msg);
 
 extern char *te_uuid;
-gboolean shuttingdown = FALSE;
 pcmk__graph_t *transition_graph;
 crm_trigger_t *transition_trigger = NULL;
 

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -42,9 +42,10 @@ te_graph_trigger(gpointer user_data)
         return TRUE;
     }
 
-    crm_trace("Invoking graph %d in state %s", transition_graph->id, fsa_state2string(fsa_state));
+    crm_trace("Invoking graph %d in state %s", transition_graph->id,
+              fsa_state2string(controld_globals.fsa_state));
 
-    switch (fsa_state) {
+    switch (controld_globals.fsa_state) {
         case S_STARTING:
         case S_PENDING:
         case S_NOT_DC:
@@ -212,7 +213,7 @@ abort_transition_graph(int abort_priority, enum pcmk__graph_next abort_action,
 
     CRM_CHECK(transition_graph != NULL, return);
 
-    switch (fsa_state) {
+    switch (controld_globals.fsa_state) {
         case S_STARTING:
         case S_PENDING:
         case S_NOT_DC:
@@ -221,7 +222,7 @@ abort_transition_graph(int abort_priority, enum pcmk__graph_next abort_action,
         case S_STOPPING:
         case S_TERMINATE:
             crm_info("Abort %s suppressed: state=%s (%scomplete)",
-                     abort_text, fsa_state2string(fsa_state),
+                     abort_text, fsa_state2string(controld_globals.fsa_state),
                      (transition_graph->complete? "" : "in"));
             return;
         default:

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -14,6 +14,9 @@
 
 #include <pacemaker-controld.h>
 
+//! Triggers transition graph processing
+static crm_trigger_t *transition_trigger = NULL;
+
 gboolean
 stop_te_timer(pcmk__graph_action_t *action)
 {
@@ -31,7 +34,7 @@ stop_te_timer(pcmk__graph_action_t *action)
     return TRUE;
 }
 
-gboolean
+static gboolean
 te_graph_trigger(gpointer user_data)
 {
     if (transition_graph == NULL) {
@@ -83,6 +86,28 @@ te_graph_trigger(gpointer user_data)
     notify_crmd(transition_graph);
 
     return TRUE;
+}
+
+/*!
+ * \internal
+ * \brief Initialize transition trigger
+ */
+void
+controld_init_transition_trigger(void)
+{
+    transition_trigger = mainloop_add_trigger(G_PRIORITY_LOW, te_graph_trigger,
+                                              NULL);
+}
+
+/*!
+ * \internal
+ * \brief Destroy transition trigger
+ */
+void
+controld_destroy_transition_trigger(void)
+{
+    mainloop_destroy_trigger(transition_trigger);
+    transition_trigger = NULL;
 }
 
 void
@@ -331,5 +356,5 @@ abort_transition_graph(int abort_priority, enum pcmk__graph_next abort_action,
         return;
     }
 
-    mainloop_set_trigger(transition_trigger);
+    trigger_graph();
 }

--- a/daemons/controld/controld_timers.c
+++ b/daemons/controld/controld_timers.c
@@ -116,7 +116,8 @@ crm_timer_popped(gpointer data)
 
     if (timer->log_error) {
         crm_err("%s just popped in state %s! " CRM_XS " input=%s time=%ums",
-                get_timer_desc(timer), fsa_state2string(fsa_state),
+                get_timer_desc(timer),
+                fsa_state2string(controld_globals.fsa_state),
                 fsa_input2string(timer->fsa_input), timer->period_ms);
     } else {
         crm_info("%s just popped " CRM_XS " input=%s time=%ums",
@@ -146,13 +147,17 @@ crm_timer_popped(gpointer data)
             register_fsa_input_before(C_TIMER_POPPED, timer->fsa_input, NULL);
         }
 
-    } else if (timer == recheck_timer && fsa_state != S_IDLE) {
+    } else if ((timer == recheck_timer)
+               && (controld_globals.fsa_state != S_IDLE)) {
         crm_debug("Discarding %s event in state: %s",
-                  fsa_input2string(timer->fsa_input), fsa_state2string(fsa_state));
+                  fsa_input2string(timer->fsa_input),
+                  fsa_state2string(controld_globals.fsa_state));
 
-    } else if (timer == finalization_timer && fsa_state != S_FINALIZE_JOIN) {
+    } else if ((timer == finalization_timer)
+               && (controld_globals.fsa_state != S_FINALIZE_JOIN)) {
         crm_debug("Discarding %s event in state: %s",
-                  fsa_input2string(timer->fsa_input), fsa_state2string(fsa_state));
+                  fsa_input2string(timer->fsa_input),
+                  fsa_state2string(controld_globals.fsa_state));
 
     } else if (timer->fsa_input != I_NULL) {
         register_fsa_input(C_TIMER_POPPED, timer->fsa_input, NULL);

--- a/daemons/controld/controld_timers.c
+++ b/daemons/controld/controld_timers.c
@@ -23,7 +23,7 @@ fsa_timer_t *wait_timer = NULL;
 fsa_timer_t *recheck_timer = NULL;
 
 // Wait at start-up, or after an election, for DC to make contact
-fsa_timer_t *election_trigger = NULL;
+fsa_timer_t *election_timer = NULL;
 
 // Delay start of new transition with expectation something else might happen
 fsa_timer_t *transition_timer = NULL;
@@ -56,7 +56,7 @@ do_timer_control(long long action,
     gboolean timer_op_ok = TRUE;
 
     if (action & A_DC_TIMER_STOP) {
-        timer_op_ok = controld_stop_timer(election_trigger);
+        timer_op_ok = controld_stop_timer(election_timer);
 
     } else if (action & A_FINALIZE_TIMER_STOP) {
         timer_op_ok = controld_stop_timer(finalization_timer);
@@ -67,7 +67,7 @@ do_timer_control(long long action,
 
     /* don't start a timer that wasn't already running */
     if (action & A_DC_TIMER_START && timer_op_ok) {
-        controld_start_timer(election_trigger);
+        controld_start_timer(election_timer);
         if (AM_I_DC) {
             /* there can be only one */
             register_fsa_input(cause, I_ELECTION, NULL);
@@ -84,7 +84,7 @@ do_timer_control(long long action,
 static const char *
 get_timer_desc(fsa_timer_t * timer)
 {
-    if (timer == election_trigger) {
+    if (timer == election_timer) {
         return "Election Trigger";
 
     } else if (timer == shutdown_escalation_timer) {
@@ -125,10 +125,10 @@ crm_timer_popped(gpointer data)
         timer->counter++;
     }
 
-    if (timer == election_trigger && election_trigger->counter > 5) {
+    if ((timer == election_timer) && (election_timer->counter > 5)) {
         crm_notice("We appear to be in an election loop, something may be wrong");
         crm_write_blackbox(0, NULL);
-        election_trigger->counter = 0;
+        election_timer->counter = 0;
     }
 
     controld_stop_timer(timer);  // Make timer _not_ go off again
@@ -182,8 +182,8 @@ controld_init_fsa_timers(void)
         return FALSE;
     }
 
-    election_trigger = calloc(1, sizeof(fsa_timer_t));
-    if (election_trigger == NULL) {
+    election_timer = calloc(1, sizeof(fsa_timer_t));
+    if (election_timer == NULL) {
         return FALSE;
     }
 
@@ -202,11 +202,11 @@ controld_init_fsa_timers(void)
         return FALSE;
     }
 
-    election_trigger->source_id = 0;
-    election_trigger->period_ms = 0;
-    election_trigger->fsa_input = I_DC_TIMEOUT;
-    election_trigger->callback = crm_timer_popped;
-    election_trigger->log_error = FALSE;
+    election_timer->source_id = 0;
+    election_timer->period_ms = 0;
+    election_timer->fsa_input = I_DC_TIMEOUT;
+    election_timer->callback = crm_timer_popped;
+    election_timer->log_error = FALSE;
 
     transition_timer->source_id = 0;
     transition_timer->period_ms = 0;
@@ -264,7 +264,7 @@ controld_free_fsa_timers(void)
     controld_stop_timer(transition_timer);
     controld_stop_timer(integration_timer);
     controld_stop_timer(finalization_timer);
-    controld_stop_timer(election_trigger);
+    controld_stop_timer(election_timer);
     controld_stop_timer(shutdown_escalation_timer);
     controld_stop_timer(wait_timer);
     controld_stop_timer(recheck_timer);
@@ -272,7 +272,7 @@ controld_free_fsa_timers(void)
     free(transition_timer); transition_timer = NULL;
     free(integration_timer); integration_timer = NULL;
     free(finalization_timer); finalization_timer = NULL;
-    free(election_trigger); election_trigger = NULL;
+    free(election_timer); election_timer = NULL;
     free(shutdown_escalation_timer); shutdown_escalation_timer = NULL;
     free(wait_timer); wait_timer = NULL;
     free(recheck_timer); recheck_timer = NULL;

--- a/daemons/controld/controld_timers.c
+++ b/daemons/controld/controld_timers.c
@@ -81,7 +81,7 @@ do_timer_control(long long action,
     }
 }
 
-const char *
+static const char *
 get_timer_desc(fsa_timer_t * timer)
 {
     if (timer == election_trigger) {

--- a/daemons/controld/controld_timers.h
+++ b/daemons/controld/controld_timers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -23,7 +23,7 @@ typedef struct fsa_timer_s {
     int counter;                            // For detecting loops
 } fsa_timer_t;
 
-extern fsa_timer_t *election_trigger;
+extern fsa_timer_t *election_timer;
 extern fsa_timer_t *shutdown_escalation_timer;
 extern fsa_timer_t *transition_timer;
 extern fsa_timer_t *integration_timer;

--- a/daemons/controld/controld_timers.h
+++ b/daemons/controld/controld_timers.h
@@ -41,6 +41,4 @@ void controld_start_timer(fsa_timer_t *timer);
 void controld_start_recheck_timer(void);
 gboolean is_timer_started(fsa_timer_t *timer);
 
-const char *get_timer_desc(fsa_timer_t * timer);
-
 #endif

--- a/daemons/controld/controld_transition.c
+++ b/daemons/controld/controld_transition.c
@@ -192,15 +192,13 @@ do_te_invoke(long long action,
 
         te_reset_job_counts();
         value = crm_element_value(graph_data, "failed-stop-offset");
-        if (value) {
-            free(failed_stop_offset);
-            failed_stop_offset = strdup(value);
+        if (value != NULL) {
+            pcmk__str_update(&failed_stop_offset, value);
         }
 
         value = crm_element_value(graph_data, "failed-start-offset");
-        if (value) {
-            free(failed_start_offset);
-            failed_start_offset = strdup(value);
+        if (value != NULL) {
+            pcmk__str_update(&failed_start_offset, value);
         }
 
         if ((crm_element_value_epoch(graph_data, "recheck-by", &recheck_by)

--- a/daemons/controld/controld_transition.c
+++ b/daemons/controld/controld_transition.c
@@ -60,7 +60,8 @@ do_te_control(long long action,
     if ((action & A_TE_START) == 0) {
         return;
 
-    } else if (pcmk_is_set(fsa_input_register, R_TE_CONNECTED)) {
+    } else if (pcmk_is_set(controld_globals.fsa_input_register,
+                           R_TE_CONNECTED)) {
         crm_debug("The transitioner is already active");
         return;
 

--- a/daemons/controld/controld_transition.c
+++ b/daemons/controld/controld_transition.c
@@ -117,9 +117,12 @@ do_te_invoke(long long action,
              enum crmd_fsa_input current_input, fsa_data_t * msg_data)
 {
 
-    if (AM_I_DC == FALSE || (fsa_state != S_TRANSITION_ENGINE && (action & A_TE_INVOKE))) {
+    if (!AM_I_DC
+        || ((controld_globals.fsa_state != S_TRANSITION_ENGINE)
+            && pcmk_is_set(action, A_TE_INVOKE))) {
         crm_notice("No need to invoke the TE (%s) in state %s",
-                   fsa_action2string(action), fsa_state2string(fsa_state));
+                   fsa_action2string(action),
+                   fsa_state2string(controld_globals.fsa_state));
         return;
     }
 

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -30,7 +30,6 @@ const char *get_rsc_state(const char *task, enum pcmk_exec_status status);
 void process_te_message(xmlNode *msg, xmlNode *xml_data);
 
 extern pcmk__graph_t *transition_graph;
-extern crm_trigger_t *transition_trigger;
 
 extern char *te_uuid;
 
@@ -39,8 +38,10 @@ void notify_crmd(pcmk__graph_t * graph);
 void cib_action_updated(xmlNode *msg, int call_id, int rc, xmlNode *output,
                         void *user_data);
 gboolean action_timer_callback(gpointer data);
-gboolean te_graph_trigger(gpointer user_data);
 void te_update_diff(const char *event, xmlNode *msg);
+
+void controld_init_transition_trigger(void);
+void controld_destroy_transition_trigger(void);
 
 extern void trigger_graph_processing(const char *fn, int line);
 void abort_after_delay(int abort_priority, enum pcmk__graph_next abort_action,
@@ -53,8 +54,6 @@ void abort_transition_graph(int abort_priority,
 #  define trigger_graph()	trigger_graph_processing(__func__, __LINE__)
 #  define abort_transition(pri, action, text, reason)			\
 	abort_transition_graph(pri, action, text, reason,__func__,__LINE__);
-
-extern crm_trigger_t *transition_trigger;
 
 extern char *failed_stop_offset;
 extern char *failed_start_offset;

--- a/daemons/controld/controld_utils.c
+++ b/daemons/controld/controld_utils.c
@@ -730,7 +730,7 @@ update_dc(xmlNode * msg)
 
     controld_globals.dc_name = NULL;    // freed as last_dc
     pcmk__str_update(&(controld_globals.dc_name), welcome_from);
-    pcmk__str_update(&fsa_our_dc_version, dc_version);
+    pcmk__str_update(&(controld_globals.dc_version), dc_version);
 
     if (pcmk__str_eq(controld_globals.dc_name, last_dc, pcmk__str_casei)) {
         /* do nothing */
@@ -740,7 +740,7 @@ update_dc(xmlNode * msg)
 
         crm_info("Set DC to %s (%s)",
                  controld_globals.dc_name,
-                 pcmk__s(fsa_our_dc_version, "unknown version"));
+                 pcmk__s(controld_globals.dc_version, "unknown version"));
         pcmk__update_peer_expected(__func__, dc_node, CRMD_JOINSTATE_MEMBER);
 
     } else if (last_dc != NULL) {

--- a/daemons/controld/controld_utils.c
+++ b/daemons/controld/controld_utils.c
@@ -703,7 +703,9 @@ update_dc(xmlNode * msg)
         CRM_CHECK(dc_version != NULL, return FALSE);
         CRM_CHECK(welcome_from != NULL, return FALSE);
 
-        if (AM_I_DC && !pcmk__str_eq(welcome_from, fsa_our_uname, pcmk__str_casei)) {
+        if (AM_I_DC
+            && !pcmk__str_eq(welcome_from, controld_globals.our_nodename,
+                             pcmk__str_casei)) {
             invalid = TRUE;
 
         } else if ((controld_globals.dc_name != NULL)

--- a/daemons/controld/controld_utils.c
+++ b/daemons/controld/controld_utils.c
@@ -715,10 +715,9 @@ update_dc(xmlNode * msg)
         }
 
         if (invalid) {
-            CRM_CHECK(controld_globals.dc_name != NULL,
-                      crm_err("We have no DC"));
             if (AM_I_DC) {
-                crm_err("Not updating DC to %s (%s): we are also a DC", welcome_from, dc_version);
+                crm_err("Not updating DC to %s (%s): we are also a DC",
+                        welcome_from, dc_version);
             } else {
                 crm_warn("New DC %s is not %s",
                          welcome_from, controld_globals.dc_name);

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -51,7 +51,6 @@ fsa_cib_anon_update_discard_reply(const char *section, xmlNode *data) {
     }
 }
 
-extern gboolean fsa_has_quorum;
 extern bool controld_shutdown_lock_enabled;
 extern int last_resource_update;
 

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -51,7 +51,6 @@ fsa_cib_anon_update_discard_reply(const char *section, xmlNode *data) {
     }
 }
 
-extern bool controld_shutdown_lock_enabled;
 extern int last_resource_update;
 
 enum node_update_flags {

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -53,7 +53,6 @@ fsa_cib_anon_update_discard_reply(const char *section, xmlNode *data) {
 
 extern gboolean fsa_has_quorum;
 extern bool controld_shutdown_lock_enabled;
-extern int last_peer_update;
 extern int last_resource_update;
 
 enum node_update_flags {

--- a/daemons/controld/pacemaker-controld.c
+++ b/daemons/controld/pacemaker-controld.c
@@ -34,7 +34,9 @@ extern void init_dotfile(void);
 
 pcmk__output_t *logger_out = NULL;
 
-controld_globals_t controld_globals;
+controld_globals_t controld_globals = {
+    .fsa_state = S_STARTING,
+};
 
 static pcmk__cli_option_t long_options[] = {
     // long option, argument type, storage, short option, description, flags
@@ -150,7 +152,6 @@ crmd_init(void)
     crm_exit_t exit_code = CRM_EX_OK;
     enum crmd_fsa_state state;
 
-    fsa_state = S_STARTING;
     fsa_input_register = 0;     /* zero out the regester */
 
     init_dotfile();

--- a/daemons/controld/pacemaker-controld.c
+++ b/daemons/controld/pacemaker-controld.c
@@ -36,6 +36,8 @@ GMainLoop *crmd_mainloop = NULL;
 
 pcmk__output_t *logger_out = NULL;
 
+controld_globals_t controld_globals;
+
 static pcmk__cli_option_t long_options[] = {
     // long option, argument type, storage, short option, description, flags
     {

--- a/daemons/controld/pacemaker-controld.c
+++ b/daemons/controld/pacemaker-controld.c
@@ -152,8 +152,6 @@ crmd_init(void)
     crm_exit_t exit_code = CRM_EX_OK;
     enum crmd_fsa_state state;
 
-    fsa_input_register = 0;     /* zero out the regester */
-
     init_dotfile();
     register_fsa_input(C_STARTUP, I_STARTUP, NULL);
 
@@ -164,7 +162,7 @@ crmd_init(void)
         /* Create the mainloop and run it... */
         crm_trace("Starting %s's mainloop", crm_system_name);
         g_main_loop_run(controld_globals.mainloop);
-        if (pcmk_is_set(fsa_input_register, R_STAYDOWN)) {
+        if (pcmk_is_set(controld_globals.fsa_input_register, R_STAYDOWN)) {
             crm_info("Inhibiting automated respawn");
             exit_code = CRM_EX_FATAL;
         }

--- a/daemons/controld/pacemaker-controld.c
+++ b/daemons/controld/pacemaker-controld.c
@@ -36,6 +36,7 @@ pcmk__output_t *logger_out = NULL;
 
 controld_globals_t controld_globals = {
     .fsa_state = S_STARTING,
+    .fsa_actions = A_NOTHING,
 };
 
 static pcmk__cli_option_t long_options[] = {

--- a/daemons/controld/pacemaker-controld.c
+++ b/daemons/controld/pacemaker-controld.c
@@ -32,8 +32,6 @@ _Noreturn void crmd_init(void);
 void crmd_hamsg_callback(const xmlNode * msg, void *private_data);
 extern void init_dotfile(void);
 
-GMainLoop *crmd_mainloop = NULL;
-
 pcmk__output_t *logger_out = NULL;
 
 controld_globals_t controld_globals;
@@ -59,7 +57,7 @@ main(int argc, char **argv)
     int argerr = 0;
     crm_ipc_t *old_instance = NULL;
 
-    crmd_mainloop = g_main_loop_new(NULL, FALSE);
+    controld_globals.mainloop = g_main_loop_new(NULL, FALSE);
     crm_log_preinit(NULL, argc, argv);
     pcmk__set_cli_options(NULL, "[options]", long_options,
                           "daemon for coordinating a Pacemaker cluster's "
@@ -172,7 +170,7 @@ crmd_init(void)
     if (state == S_PENDING || state == S_STARTING) {
         /* Create the mainloop and run it... */
         crm_trace("Starting %s's mainloop", crm_system_name);
-        g_main_loop_run(crmd_mainloop);
+        g_main_loop_run(controld_globals.mainloop);
         if (pcmk_is_set(fsa_input_register, R_STAYDOWN)) {
             crm_info("Inhibiting automated respawn");
             exit_code = CRM_EX_FATAL;

--- a/daemons/controld/pacemaker-controld.c
+++ b/daemons/controld/pacemaker-controld.c
@@ -144,19 +144,11 @@ main(int argc, char **argv)
     return 0; // not reachable
 }
 
-static void
-log_deprecation_warnings(void)
-{
-    // Add deprecations here as needed
-}
-
 void
 crmd_init(void)
 {
     crm_exit_t exit_code = CRM_EX_OK;
     enum crmd_fsa_state state;
-
-    log_deprecation_warnings();
 
     fsa_state = S_STARTING;
     fsa_input_register = 0;     /* zero out the regester */

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -48,6 +48,9 @@ enum controld_flags {
 
     //! The local node has been in a quorate partition at some point
     controld_ever_had_quorum        = (1 << 2),
+
+    //! The local node is currently in a quorate partition
+    controld_has_quorum             = (1 << 3),
 };
 
 void do_cib_updated(const char *event, xmlNode * msg);

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -38,6 +38,9 @@ typedef struct {
     //! Designated controller name
     char *dc_name;
 
+    //! Designated controller's Pacemaker version
+    char *dc_version;
+
     //! Main event loop
     GMainLoop *mainloop;
 } controld_globals_t;

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -33,7 +33,7 @@ void controld_election_init(const char *uname);
 void controld_remove_voter(const char *uname);
 void controld_election_fini(void);
 void controld_set_election_period(const char *value);
-void controld_stop_election_timer(void);
+void controld_stop_current_election_timeout(void);
 void controld_disconnect_cib_manager(void);
 
 #endif

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -45,6 +45,9 @@ enum controld_flags {
 
     //! The FSA is stalled waiting for further input
     controld_fsa_is_stalled         = (1 << 1),
+
+    //! The local node has been in a quorate partition at some point
+    controld_ever_had_quorum        = (1 << 2),
 };
 
 void do_cib_updated(const char *event, xmlNode * msg);

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -30,6 +30,12 @@ typedef struct {
     uint32_t flags;
 
 
+    // Controller FSA
+
+    //! FSA state
+    enum crmd_fsa_state fsa_state;
+
+
     // Other
 
     //! Cluster name

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -35,6 +35,9 @@ typedef struct {
     //! FSA state
     enum crmd_fsa_state fsa_state;
 
+    //! FSA input register contents (group of \p R_* flags)
+    uint64_t fsa_input_register;
+
 
     // Other
 

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -23,8 +23,26 @@
 #include <controld_transition.h>
 #include <controld_utils.h>
 
+typedef struct {
+    // Booleans
+
+    //! Group of \p controld_flags values
+    uint32_t flags;
+} controld_globals_t;
+
 extern GMainLoop *crmd_mainloop;
 extern bool no_quorum_suicide_escalation;
+extern controld_globals_t controld_globals;
+
+/*!
+ * \internal
+ * \enum controld_flags
+ * \brief Bit flags to store various controller state and configuration info
+ */
+enum controld_flags {
+    //! The DC left in a membership change that is being processed
+    controld_dc_left                = (1 << 0),
+};
 
 void do_cib_updated(const char *event, xmlNode * msg);
 void do_cib_replaced(const char *event, xmlNode * msg);

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -44,6 +44,9 @@ typedef struct {
     //! Local node's node name
     char *our_nodename;
 
+    //! Local node's UUID
+    char *our_uuid;
+
     //! Main event loop
     GMainLoop *mainloop;
 } controld_globals_t;

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -28,9 +28,14 @@ typedef struct {
 
     //! Group of \p controld_flags values
     uint32_t flags;
+
+
+    // Mainloop
+
+    //! Main event loop
+    GMainLoop *mainloop;
 } controld_globals_t;
 
-extern GMainLoop *crmd_mainloop;
 extern controld_globals_t controld_globals;
 
 /*!

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -53,6 +53,9 @@ enum controld_flags {
 
     //! Panic the local node if it loses quorum
     controld_no_quorum_suicide      = (1 << 4),
+
+    //! Lock resources to the local node when it shuts down cleanly
+    controld_shutdown_lock_enabled  = (1 << 5),
 };
 
 void do_cib_updated(const char *event, xmlNode * msg);

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -35,6 +35,9 @@ typedef struct {
     //! FSA state
     enum crmd_fsa_state fsa_state;
 
+    //! FSA actions (group of \p A_* flags)
+    uint64_t fsa_actions;
+
     //! FSA input register contents (group of \p R_* flags)
     uint64_t fsa_input_register;
 

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -63,9 +63,13 @@ enum controld_flags {
     controld_shutdown_lock_enabled  = (1 << 5),
 };
 
+#  define controld_trigger_config()  \
+    controld_trigger_config_as(__func__, __LINE__)
+
 void do_cib_updated(const char *event, xmlNode * msg);
 void do_cib_replaced(const char *event, xmlNode * msg);
 void crmd_metadata(void);
+void controld_trigger_config_as(const char *fn, int line);
 void controld_election_init(const char *uname);
 void controld_remove_voter(const char *uname);
 void controld_election_fini(void);

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -30,7 +30,10 @@ typedef struct {
     uint32_t flags;
 
 
-    // Mainloop
+    // Other
+
+    //! Cluster name
+    char *cluster_name;
 
     //! Main event loop
     GMainLoop *mainloop;

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -31,7 +31,6 @@ typedef struct {
 } controld_globals_t;
 
 extern GMainLoop *crmd_mainloop;
-extern bool no_quorum_suicide_escalation;
 extern controld_globals_t controld_globals;
 
 /*!
@@ -51,6 +50,9 @@ enum controld_flags {
 
     //! The local node is currently in a quorate partition
     controld_has_quorum             = (1 << 3),
+
+    //! Panic the local node if it loses quorum
+    controld_no_quorum_suicide      = (1 << 4),
 };
 
 void do_cib_updated(const char *event, xmlNode * msg);

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -90,6 +90,22 @@ enum controld_flags {
     controld_shutdown_lock_enabled  = (1 << 5),
 };
 
+#  define controld_set_global_flags(flags_to_set) do {                      \
+        controld_globals.flags = pcmk__set_flags_as(__func__, __LINE__,     \
+                                                    LOG_TRACE,              \
+                                                    "Global", "controller", \
+                                                    controld_globals.flags, \
+                                                    (flags_to_set),         \
+                                                    #flags_to_set);         \
+    } while (0)
+
+#  define controld_clear_global_flags(flags_to_clear) do {                  \
+        controld_globals.flags                                              \
+            = pcmk__clear_flags_as(__func__, __LINE__, LOG_TRACE, "Global", \
+                                   "controller", controld_globals.flags,    \
+                                   (flags_to_clear), #flags_to_clear);      \
+    } while (0)
+
 #  define controld_trigger_config()  \
     controld_trigger_config_as(__func__, __LINE__)
 

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -42,6 +42,9 @@ extern controld_globals_t controld_globals;
 enum controld_flags {
     //! The DC left in a membership change that is being processed
     controld_dc_left                = (1 << 0),
+
+    //! The FSA is stalled waiting for further input
+    controld_fsa_is_stalled         = (1 << 1),
 };
 
 void do_cib_updated(const char *event, xmlNode * msg);

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -35,6 +35,9 @@ typedef struct {
     //! Cluster name
     char *cluster_name;
 
+    //! Designated controller name
+    char *dc_name;
+
     //! Main event loop
     GMainLoop *mainloop;
 } controld_globals_t;

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -41,6 +41,9 @@ typedef struct {
     //! Designated controller's Pacemaker version
     char *dc_version;
 
+    //! Local node's node name
+    char *our_nodename;
+
     //! Main event loop
     GMainLoop *mainloop;
 } controld_globals_t;

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -560,6 +560,7 @@ cluster_option_value(GHashTable *options, bool (*validate)(const char *),
  *
  * \param[in,out] options      Name/value pairs for configured options
  * \param[in]     option_list  Possible cluster options
+ * \param[in]     len          Length of \p option_list
  * \param[in]     name         (Primary) option name to look for
  *
  * \return Option value


### PR DESCRIPTION
This is the first part of https://github.com/ClusterLabs/pacemaker/pull/2940.

Changes to address review:
* Drop commented code in `controld_fsa.c`.
* Reverted all the `pcmk__str_none` for node name comparisons to `pcmk__str_casei` (and two `strcmp`s that were already present to `strcasecmp`)
* Changed "controld_globals.fsa_actions" to "fsa_actions" in a log message
* s/leader/DC/
* Use `_as` convention for macro's function target (`controld_trigger_config_as()` )
* Rename `crmd_fsa_next_state` to `controld_fsa_next_state`
* Added commits on top to:
  * drop AM_I_OPERATIONAL macro
  * make "DC=true" a fallback when `controld_globals.dc_name` is not set and `AM_I_DC` is true
  * make `controld_matrix.h` a C function
  * compare booleans by testing explicit cases instead of comparing directly
  * add set/clear macros for global flags