### PR TITLE
Fix: controller: Don't double-increment failcount for simulated failures

### DIFF
--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -567,6 +567,7 @@ te_update_diff(const char *event, xmlNode * msg)
             crm_warn("Ignoring malformed CIB update (unknown patch format %d)",
                      format);
     }
+    controld_destroy_outside_event_table();
 }
 
 void

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -19,6 +19,9 @@ pcmk__graph_action_t *get_cancel_action(const char *id, const char *node);
 bool confirm_cancel_action(const char *id, const char *node_id);
 
 void controld_record_action_timeout(pcmk__graph_action_t *action);
+
+void controld_destroy_outside_event_table(void);
+
 gboolean fail_incompletable_actions(pcmk__graph_t *graph, const char *down_node);
 void process_graph_event(xmlNode *event, const char *event_node);
 


### PR DESCRIPTION
Currently, a simulated failure (for example, from `crm_resource --fail`) often causes the resource's failcount on the given node to be incremented twice: once for each of two incoming events.

A "_last_0" update event often comes in because the previous last event was a recurring monitor. A "_last_failure_0" update comes in because there is now a more recent failure (the newly simulated one).

Events generated by the cluster have corresponding actions in the transition graph. These actions can be marked as "confirmed" once they've been processed the first time. However, this can't be done for simulated events, which are not in the transition graph. They receive a dummy transition ID of -1 and a dummy action number that generally increases over time.

This commit stores a set of outside events that have been processed by process_graph_event() for the current update diff. The set is emptied when the diff is completely processed, so that it doesn't grow too large or risk generating a false match.

A potential future improvement would be to add a similar safeguard for foreign events (events with a different transitioner UUID) and late-arriving events (events from the local transitioner that are no longer in the current transition graph and thus can't be confirmed). Either that, or bail out of `update_failcount` if the event ID doesn't end in `_last_failure_0`.

Ref T602

(Originally, this was a draft PR for fixing an attrd value expansion issue.)