### PR TITLE
Fix: controller: Avoid election storm due to incompatible CIB

### DIFF
--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -160,6 +160,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
                     remove_stonith_cleanup(node->uname);
                 }
             } else {
+                controld_remove_failed_sync_node(node->uname);
                 controld_remove_voter(node->uname);
             }
 
@@ -195,6 +196,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
             }
 
             if (!appeared) {
+                controld_remove_failed_sync_node(node->uname);
                 controld_remove_voter(node->uname);
             }
 

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -265,6 +265,7 @@ crmd_exit(crm_exit_t exit_code)
     controld_globals.te_uuid = NULL;
 
     free_max_generation();
+    controld_destroy_failed_sync_table();
 
     mainloop_destroy_signal(SIGPIPE);
     mainloop_destroy_signal(SIGUSR1);

--- a/daemons/controld/controld_membership.h
+++ b/daemons/controld/controld_membership.h
@@ -19,6 +19,9 @@ void post_cache_update(int instance);
 
 extern gboolean check_join_state(enum crmd_fsa_state cur_state, const char *source);
 
+void controld_destroy_failed_sync_table(void);
+void controld_remove_failed_sync_node(const char *node_name);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The DC accepts a joining node even if its local CIB manager will later reject the joining node's CIB (for example, due to schema version incompatibility). This can cause an election storm.

`do_dc_join_finalize()` calls `cib_t:cmds:sync_from()` against the joining node, syncing its CIB across the cluster. However, it may fail to apply the diff, and the DC won't notice until we get an error code via the sync callback.

Here, if a joining node has the max generation so far, we verify on the DC side that we recognize its schema name before accepting its join request. That eliminates most of the cases in which we would sync the CIB and then reject the CIB ourselves on the DC.

If the CIB sync does fail in the finalize step, then we add the node to a table of nodes whose CIB syncs have failed, and then we trigger a new election, this time nacking that node if it sends a join request. The node remains in the failed sync table until it leaves the cluster (which should happen after it's nacked).

Closes T455