### PR TITLE
WIP: Separate node XML ID from node cluster ID in CIB syntax

### DIFF
--- a/cts/cli/regression.upgrade.exp
+++ b/cts/cli/regression.upgrade.exp
@@ -96,8 +96,11 @@ update_validation 	debug: Configuration valid for schema: pacemaker-3.8
 update_validation 	debug: pacemaker-3.8-style configuration is also valid for pacemaker-3.9
 update_validation 	debug: Testing 'pacemaker-3.9' validation (23 of X)
 update_validation 	debug: Configuration valid for schema: pacemaker-3.9
-update_validation 	trace: Stopping at pacemaker-3.9
-update_validation 	info: Transformed the configuration from pacemaker-2.10 to pacemaker-3.9
+update_validation 	debug: pacemaker-3.9-style configuration is also valid for pacemaker-3.10
+update_validation 	debug: Testing 'pacemaker-3.10' validation (24 of X)
+update_validation 	debug: Configuration valid for schema: pacemaker-3.10
+update_validation 	trace: Stopping at pacemaker-3.10
+update_validation 	info: Transformed the configuration from pacemaker-2.10 to pacemaker-3.10
 =#=#=#= Current cib after: Upgrade to latest CIB schema (trigger 2.10.xsl + the wrapping) =#=#=#=
 <cib epoch="2" num_updates="0" admin_epoch="1">
   <configuration>

--- a/cts/cli/regression.validity.exp
+++ b/cts/cli/regression.validity.exp
@@ -128,7 +128,11 @@ update_validation 	debug: Testing 'pacemaker-3.9' validation (23 of X)
 element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
 element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 update_validation 	trace: pacemaker-3.9 validation failed
-Cannot upgrade configuration (claiming schema pacemaker-1.2) to at least pacemaker-3.0 because it does not validate with any schema from pacemaker-1.2 to pacemaker-3.9
+update_validation 	debug: Testing 'pacemaker-3.10' validation (24 of X)
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+update_validation 	trace: pacemaker-3.10 validation failed
+Cannot upgrade configuration (claiming schema pacemaker-1.2) to at least pacemaker-3.0 because it does not validate with any schema from pacemaker-1.2 to pacemaker-3.10
 =#=#=#= End test: Run crm_simulate with invalid CIB (enum violation) - Invalid configuration (78) =#=#=#=
 * Passed: crm_simulate   - Run crm_simulate with invalid CIB (enum violation)
 =#=#=#= Begin test: Try to make resulting CIB invalid (unrecognized validate-with) =#=#=#=
@@ -239,7 +243,10 @@ update_validation 	trace: pacemaker-3.8 validation failed
 update_validation 	debug: Testing 'pacemaker-3.9' validation (23 of X)
 element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
 update_validation 	trace: pacemaker-3.9 validation failed
-Cannot upgrade configuration (claiming schema pacemaker-9999.0) to at least pacemaker-3.0 because it does not validate with any schema from unknown to pacemaker-3.9
+update_validation 	debug: Testing 'pacemaker-3.10' validation (24 of X)
+element cib: Relax-NG validity error : Invalid attribute validate-with for element cib
+update_validation 	trace: pacemaker-3.10 validation failed
+Cannot upgrade configuration (claiming schema pacemaker-9999.0) to at least pacemaker-3.0 because it does not validate with any schema from unknown to pacemaker-3.10
 =#=#=#= End test: Run crm_simulate with invalid CIB (unrecognized validate-with) - Invalid configuration (78) =#=#=#=
 * Passed: crm_simulate   - Run crm_simulate with invalid CIB (unrecognized validate-with)
 =#=#=#= Begin test: Try to make resulting CIB invalid, but possibly recoverable (valid with X.Y+1) =#=#=#=
@@ -345,8 +352,11 @@ update_validation 	debug: Configuration valid for schema: pacemaker-3.8
 update_validation 	debug: pacemaker-3.8-style configuration is also valid for pacemaker-3.9
 update_validation 	debug: Testing 'pacemaker-3.9' validation (23 of X)
 update_validation 	debug: Configuration valid for schema: pacemaker-3.9
-update_validation 	trace: Stopping at pacemaker-3.9
-update_validation 	info: Transformed the configuration from pacemaker-1.2 to pacemaker-3.9
+update_validation 	debug: pacemaker-3.9-style configuration is also valid for pacemaker-3.10
+update_validation 	debug: Testing 'pacemaker-3.10' validation (24 of X)
+update_validation 	debug: Configuration valid for schema: pacemaker-3.10
+update_validation 	trace: Stopping at pacemaker-3.10
+update_validation 	info: Transformed the configuration from pacemaker-1.2 to pacemaker-3.10
 unpack_resources 	error: Resource start-up disabled since no STONITH resources have been defined
 unpack_resources 	error: Either configure some or disable STONITH with the stonith-enabled option
 unpack_resources 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
@@ -460,6 +470,8 @@ element rsc_order: Relax-NG validity error : Invalid attribute first-action for 
 element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
 element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
+element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 =#=#=#= Current cib after: Make resulting CIB invalid, and without validate-with attribute =#=#=#=
 <cib epoch="41" num_updates="0" admin_epoch="0" validate-with="none">
   <configuration>
@@ -479,6 +491,8 @@ element rsc_order: Relax-NG validity error : Element constraints has extra conte
 * Passed: cibadmin       - Make resulting CIB invalid, and without validate-with attribute
 =#=#=#= Begin test: Run crm_simulate with invalid CIB, also without validate-with attribute =#=#=#=
 Schema validation of configuration is disabled (enabling is encouraged and prevents common misconfigurations)
+validity.bad.xml:10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
+validity.bad.xml:10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 validity.bad.xml:10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order
 validity.bad.xml:10: element rsc_order: Relax-NG validity error : Element constraints has extra content: rsc_order
 validity.bad.xml:10: element rsc_order: Relax-NG validity error : Invalid attribute first-action for element rsc_order

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -169,6 +169,7 @@ extern "C" {
 #  define XML_ATTR_REQUEST		"request"
 #  define XML_ATTR_RESPONSE		"response"
 
+#  define PCMK_XA_CLUSTER_ID		"cluster-id"
 #  define XML_ATTR_UNAME		"uname"
 #  define XML_ATTR_REFERENCE		"reference"
 

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -173,6 +173,7 @@ enum pe_warn_once_e {
     pe_wo_upstart       = (1 << 13),
     pe_wo_nagios        = (1 << 14),
     pe_wo_set_ordering  = (1 << 15),
+    pe_wo_node_xml_id   = (1 << 16),
 };
 
 extern uint32_t pe_wo;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -562,6 +562,7 @@ unpack_nodes(xmlNode * xml_nodes, pe_working_set_t * data_set)
     xmlNode *xml_obj = NULL;
     pe_node_t *new_node = NULL;
     const char *id = NULL;
+    const char *cluster_id = NULL;
     const char *uname = NULL;
     const char *type = NULL;
     const char *score = NULL;
@@ -573,17 +574,28 @@ unpack_nodes(xmlNode * xml_nodes, pe_working_set_t * data_set)
             new_node = NULL;
 
             id = crm_element_value(xml_obj, XML_ATTR_ID);
+            cluster_id = crm_element_value(xml_obj, PCMK_XA_CLUSTER_ID);
             uname = crm_element_value(xml_obj, XML_ATTR_UNAME);
             type = crm_element_value(xml_obj, XML_ATTR_TYPE);
             score = crm_element_value(xml_obj, XML_RULE_ATTR_SCORE);
-            crm_trace("Processing node %s/%s", uname, id);
+
+            crm_trace("Unpacking node %s with cluster ID %s and name %s",
+                      pcmk__s(id, "<none>"), pcmk__s(cluster_id, "same as id"),
+                      pcmk__s(uname, "same as id"));
 
             if (id == NULL) {
                 pcmk__config_err("Ignoring <" XML_CIB_TAG_NODE
                                  "> entry in configuration without id");
                 continue;
             }
-            new_node = pe_create_node(id, uname, type, score, data_set);
+
+            if (cluster_id == NULL) {
+                cluster_id = id;
+            }
+            if (uname == NULL) {
+                uname = id;
+            }
+            new_node = pe_create_node(cluster_id, uname, type, score, data_set);
 
             if (new_node == NULL) {
                 return FALSE;

--- a/xml/nodes-3.10.rng
+++ b/xml/nodes-3.10.rng
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+      <ref name="element-nodes"/>
+  </start>
+
+  <define name="element-nodes">
+    <element name="nodes">
+      <zeroOrMore>
+        <element name="node">
+          <attribute name="id"><text/></attribute>
+          <attribute name="uname"><text/></attribute>
+          <optional>
+            <attribute name="type">
+              <choice>
+                <value>member</value>
+                <value>ping</value>
+                <value>remote</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="description"><text/></attribute>
+          </optional>
+          <optional>
+            <externalRef href="score.rng"/>
+          </optional>
+          <zeroOrMore>
+            <choice>
+              <element name="instance_attributes">
+                <externalRef href="nvset-3.9.rng"/>
+              </element>
+              <element name="utilization">
+                <externalRef href="nvset-3.9.rng"/>
+              </element>
+            </choice>
+          </zeroOrMore>
+        </element>
+      </zeroOrMore>
+    </element>
+  </define>
+
+</grammar>

--- a/xml/nodes-3.10.rng
+++ b/xml/nodes-3.10.rng
@@ -9,6 +9,10 @@
     <element name="nodes">
       <zeroOrMore>
         <element name="node">
+          <!--
+           @COMPAT: Using non-XML-ID strings in the id field is deprecated.
+           Support will be removed in a future release.
+           -->
           <attribute name="id"><text/></attribute>
           <optional>
             <attribute name="cluster-id"><text/></attribute>

--- a/xml/nodes-3.10.rng
+++ b/xml/nodes-3.10.rng
@@ -10,7 +10,12 @@
       <zeroOrMore>
         <element name="node">
           <attribute name="id"><text/></attribute>
-          <attribute name="uname"><text/></attribute>
+          <optional>
+            <attribute name="cluster-id"><text/></attribute>
+          </optional>
+          <optional>
+            <attribute name="uname"><text/></attribute>
+          </optional>
           <optional>
             <attribute name="type">
               <choice>


### PR DESCRIPTION
This isn't so much a draft as a start. I expect we'll want to make changes outside of just `unpack_nodes()`. I haven't looked through all the uses of `XML_ATTR_ID` for nodes yet. It's made more difficult by the fact that `XML_ATTR_ID` is used for so many types of CIB elements, not just nodes.

Additionally, `XML_ATTR_UUID` is also defined as `"id"`, so we'll probably need to consider that... not sure yet how to treat it.

Also not sure if any `XML_ATTR_UNAME` handling will need to be modified elsewhere (e.g., maybe in some cases for remote nodes even if not for cluster nodes).

Or maybe `unpack.c` is the only place we need the change and we're really lucky, but I doubt it.

No doc change yet.

Ref [T290](https://projects.clusterlabs.org/T290)