### PR TITLE
High: based: Fix double free() in pacemaker-based.c

### DIFF
--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -142,7 +142,8 @@ send_sync_request(const char *host)
 
     crm_xml_add(sync_me, F_TYPE, "cib");
     crm_xml_add(sync_me, F_CIB_OPERATION, PCMK__CIB_REQUEST_SYNC_TO_ONE);
-    crm_xml_add(sync_me, F_CIB_DELEGATED, cib_our_uname);
+    crm_xml_add(sync_me, F_CIB_DELEGATED,
+                stand_alone? "localhost" : crm_cluster->uname);
 
     send_cluster_message(host ? crm_get_peer(0, host) : NULL, crm_msg_cib, sync_me, FALSE);
     free_xml(sync_me);

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -39,7 +39,6 @@ crm_cluster_t *crm_cluster = NULL;
 
 GMainLoop *mainloop = NULL;
 gchar *cib_root = NULL;
-char *cib_our_uname = NULL;
 static gboolean preserve_status = FALSE;
 
 gboolean cib_writes_enabled = TRUE;
@@ -284,7 +283,6 @@ done:
     }
     pcmk__client_cleanup();
     pcmk_cluster_free(crm_cluster);
-    free(cib_our_uname);
     g_free(cib_root);
 
     pcmk__output_and_clear_error(error, out);
@@ -398,10 +396,6 @@ cib_init(void)
             crm_crit("Cannot sign in to the cluster... terminating");
             crm_exit(CRM_EX_FATAL);
         }
-        cib_our_uname = crm_cluster->uname;
-
-    } else {
-        cib_our_uname = strdup("localhost");
     }
 
     pcmk__serve_based_ipc(&ipcs_ro, &ipcs_rw, &ipcs_shm, &ipc_ro_callbacks,

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -68,7 +68,6 @@ extern gboolean legacy_mode;
 extern gboolean stand_alone;
 extern gboolean cib_shutdown_flag;
 extern gchar *cib_root;
-extern char *cib_our_uname;
 extern int cib_status;
 extern FILE *msg_cib_strm;
 


### PR DESCRIPTION
Moving the contents of the long-unused `cib_cleanup()` function to the done section in b8de0aa exposed a bug. We didn't `strdup(crm_cluster->uname)` before assigning to `cib_our_uname`, but we did `strdup("localhost")` if in stand-alone mode. So when we freed `cib_our_uname` after freeing `crm_cluster`, the same pointer would be freed twice if not in stand-alone mode.

`cib_our_uname` is used only as a const, so now we just replace it with `"localhost"` if stand-alone or `crm_cluster->uname` otherwise. We're avoiding a separate `const char *` global for future-proofing, in case `crm_cluster` or its `uname` member is ever freed and reassigned.