### PR TITLE
Fix: controller: Don't nack joining node due to old CIB

### DIFF
--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -635,7 +635,9 @@ finalize_sync_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, voi
                    "Could not sync CIB from %s in join-%d: %s",
                    sync_from, current_join_id, pcmk_strerror(rc));
 
-        record_failed_sync_node(sync_from, current_join_id);
+        if (rc != -pcmk_err_old_data) {
+            record_failed_sync_node(sync_from, current_join_id);
+        }
 
         /* restart the whole join process */
         register_fsa_error_adv(C_FSA_INTERNAL, I_ELECTION_DC, NULL, NULL,


### PR DESCRIPTION
In the finalization stage, we sync the max_generation CIB across the cluster. It's possible for the sync_from() operation to return a -pcmk_err_old_data error ("Update was older than existing configuration"). That error is fairly normal (hence treating it as a warning already), and it shouldn't cause us to call a new election and nack the max_generation node.

Regression in ae899e8.