### PR TITLE
Clarify more pointer arguments in library functions

### DIFF
--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -162,7 +162,7 @@ void pcmk_cpg_membership(cpg_handle_t handle,
                          const struct cpg_address *joined_list, size_t joined_list_entries);
 gboolean crm_is_corosync_peer_active(const crm_node_t * node);
 gboolean send_cluster_text(enum crm_ais_msg_class msg_class, const char *data,
-                           gboolean local, crm_node_t * node,
+                           gboolean local, const crm_node_t *node,
                            enum crm_ais_msg_types dest);
 char *pcmk_message_common_cs(cpg_handle_t handle, uint32_t nodeid, uint32_t pid, void *msg,
                         uint32_t *kind, const char **from);

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -129,8 +129,9 @@ enum crm_get_peer_flags {
     CRM_GET_PEER_ANY       = CRM_GET_PEER_CLUSTER|CRM_GET_PEER_REMOTE,
 };
 
-gboolean send_cluster_message(crm_node_t *node, enum crm_ais_msg_types service,
-                              xmlNode *data, gboolean ordered);
+gboolean send_cluster_message(const crm_node_t *node,
+                              enum crm_ais_msg_types service, xmlNode *data,
+                              gboolean ordered);
 
 int crm_remote_peer_cache_size(void);
 

--- a/include/crm/cluster/election_internal.h
+++ b/include/crm/cluster/election_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 the Pacemaker project contributors
+ * Copyright 2009-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -74,8 +74,9 @@ void election_timeout_stop(election_t *e);
 void election_vote(election_t *e);
 bool election_check(election_t *e);
 void election_remove(election_t *e, const char *uname);
-enum election_result election_state(election_t *e);
-enum election_result election_count_vote(election_t *e, xmlNode *vote, bool can_win);
+enum election_result election_state(const election_t *e);
+enum election_result election_count_vote(election_t *e, const xmlNode *message,
+                                         bool can_win);
 void election_clear_dampening(election_t *e);
 
 #ifdef __cplusplus

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -67,7 +67,7 @@ gboolean decode_transition_key(const char *key, char **uuid, int *transition_id,
 gboolean decode_transition_magic(const char *magic, char **uuid,
                                  int *transition_id, int *action_id,
                                  int *op_status, int *op_rc, int *target_rc);
-int rsc_op_expected_rc(lrmd_event_data_t *event);
+int rsc_op_expected_rc(const lrmd_event_data_t *event);
 gboolean did_rsc_op_fail(lrmd_event_data_t *event, int target_rc);
 bool crm_op_needs_metadata(const char *rsc_class, const char *op);
 xmlNode *crm_create_op_xml(xmlNode *parent, const char *prefix,

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -72,7 +72,7 @@ xmlDoc *getDocPtr(xmlNode * node);
  *       custom extensions like said ACLs and "atomic increment" (that landed
  *       later on, anyway).
  */
-void copy_in_properties(xmlNode *target, xmlNode *src);
+void copy_in_properties(xmlNode *target, const xmlNode *src);
 
 void expand_plus_plus(xmlNode * target, const char *name, const char *value);
 void fix_plus_plus_recursive(xmlNode * target);

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -62,7 +62,7 @@ void stonith__destroy_action(stonith_action_t *action);
 pcmk__action_result_t *stonith__action_result(stonith_action_t *action);
 int stonith__result2rc(const pcmk__action_result_t *result);
 void stonith__xe_set_result(xmlNode *xml, const pcmk__action_result_t *result);
-void stonith__xe_get_result(xmlNode *xml, pcmk__action_result_t *result);
+void stonith__xe_get_result(const xmlNode *xml, pcmk__action_result_t *result);
 xmlNode *stonith__find_xe_with_result(xmlNode *xml);
 
 int stonith__execute_async(stonith_action_t *action, void *userdata,
@@ -92,8 +92,8 @@ void stonith__register_messages(pcmk__output_t *out);
 
 GList *stonith__parse_targets(const char *hosts);
 
-const char *stonith__later_succeeded(stonith_history_t *event,
-                                     stonith_history_t *top_history);
+const char *stonith__later_succeeded(const stonith_history_t *event,
+                                     const stonith_history_t *top_history);
 stonith_history_t *stonith__sort_history(stonith_history_t *history);
 
 void stonith__device_parameter_flags(uint32_t *device_flags,
@@ -189,15 +189,16 @@ bool stonith__event_state_neq(stonith_history_t *history, void *user_data);
 
 int stonith__legacy2status(int rc);
 
-int stonith__exit_status(stonith_callback_data_t *data);
-int stonith__execution_status(stonith_callback_data_t *data);
-const char *stonith__exit_reason(stonith_callback_data_t *data);
+int stonith__exit_status(const stonith_callback_data_t *data);
+int stonith__execution_status(const stonith_callback_data_t *data);
+const char *stonith__exit_reason(const stonith_callback_data_t *data);
 
-int stonith__event_exit_status(stonith_event_t *event);
-int stonith__event_execution_status(stonith_event_t *event);
-const char *stonith__event_exit_reason(stonith_event_t *event);
-char *stonith__event_description(stonith_event_t *event);
-gchar *stonith__history_description(stonith_history_t *event, bool full_history,
+int stonith__event_exit_status(const stonith_event_t *event);
+int stonith__event_execution_status(const stonith_event_t *event);
+const char *stonith__event_exit_reason(const stonith_event_t *event);
+char *stonith__event_description(const stonith_event_t *event);
+gchar *stonith__history_description(const stonith_history_t *event,
+                                    bool full_history,
                                     const char *later_succeeded,
                                     uint32_t show_opts);
 

--- a/include/crm/lrmd_internal.h
+++ b/include/crm/lrmd_internal.h
@@ -21,21 +21,21 @@
 
 int lrmd__new(lrmd_t **api, const char *nodename, const char *server, int port);
 
-int lrmd_send_attribute_alert(lrmd_t *lrmd, GList *alert_list,
+int lrmd_send_attribute_alert(lrmd_t *lrmd, const GList *alert_list,
                               const char *node, uint32_t nodeid,
                               const char *attr_name, const char *attr_value);
-int lrmd_send_node_alert(lrmd_t *lrmd, GList *alert_list,
+int lrmd_send_node_alert(lrmd_t *lrmd, const GList *alert_list,
                          const char *node, uint32_t nodeid, const char *state);
-int lrmd_send_fencing_alert(lrmd_t *lrmd, GList *alert_list,
+int lrmd_send_fencing_alert(lrmd_t *lrmd, const GList *alert_list,
                             const char *target, const char *task,
                             const char *desc, int op_rc);
-int lrmd_send_resource_alert(lrmd_t *lrmd, GList *alert_list,
-                             const char *node, lrmd_event_data_t *op);
+int lrmd_send_resource_alert(lrmd_t *lrmd, const GList *alert_list,
+                             const char *node, const lrmd_event_data_t *op);
 
 int lrmd__remote_send_xml(pcmk__remote_t *session, xmlNode *msg, uint32_t id,
                           const char *msg_type);
 
-int lrmd__metadata_async(lrmd_rsc_info_t *rsc,
+int lrmd__metadata_async(const lrmd_rsc_info_t *rsc,
                          void (*callback)(int pid,
                                           const pcmk__action_result_t *result,
                                           void *user_data),

--- a/include/crm/services_internal.h
+++ b/include/crm/services_internal.h
@@ -43,7 +43,7 @@ svc_action_t *services__create_resource_action(const char *name,
                                                int timeout, GHashTable *params,
                                                enum svc_action_flags flags);
 
-const char *services__exit_reason(svc_action_t *action);
+const char *services__exit_reason(const svc_action_t *action);
 char *services__grab_stdout(svc_action_t *action);
 char *services__grab_stderr(svc_action_t *action);
 

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -533,7 +533,7 @@ delete_attr_delegate(cib_t *cib, int options, const char *section, const char *n
  * \return pcmk_ok if UUID was successfully parsed, -ENXIO otherwise
  */
 static int
-get_uuid_from_result(xmlNode *result, char **uuid, int *is_remote)
+get_uuid_from_result(const xmlNode *result, char **uuid, int *is_remote)
 {
     int rc = -ENXIO;
     const char *tag;

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -447,10 +447,11 @@ cib_free_notify(cib_t *cib)
         cib->notify_list = NULL;
     }
 }
+
 /*!
  * \brief Free all callbacks for a CIB connection
  *
- * \param[in] cib  CIB connection to clean up
+ * \param[in,out] cib  CIB connection to clean up
  */
 void
 cib_free_callbacks(cib_t *cib)
@@ -463,7 +464,7 @@ cib_free_callbacks(cib_t *cib)
 /*!
  * \brief Free all memory used by CIB connection
  *
- * \param[in] cib  CIB connection to delete
+ * \param[in,out] cib  CIB connection to delete
  */
 void
 cib_delete(cib_t *cib)

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -90,8 +90,8 @@ cib_file_register_notification(cib_t * cib, const char *callback, int enabled)
  * \internal
  * \brief Compare the calculated digest of an XML tree against a signature file
  *
- * \param[in] root Root of XML tree to compare
- * \param[in] sigfile Name of signature file containing digest to compare
+ * \param[in] root     Root of XML tree to compare
+ * \param[in] sigfile  Name of signature file containing digest to compare
  *
  * \return TRUE if digests match or signature file does not exist, else FALSE
  */
@@ -126,9 +126,9 @@ cib_file_verify_digest(xmlNode *root, const char *sigfile)
  * \internal
  * \brief Read an XML tree from a file and verify its digest
  *
- * \param[in] filename Name of XML file to read
- * \param[in] sigfile Name of signature file containing digest to compare
- * \param[in] root If non-NULL, will be set to pointer to parsed XML tree
+ * \param[in]  filename  Name of XML file to read
+ * \param[in]  sigfile   Name of signature file containing digest to compare
+ * \param[out] root      If non-NULL, will be set to pointer to parsed XML tree
  *
  * \return 0 if file was successfully read, parsed and verified, otherwise:
  *         -errno on stat() failure,
@@ -323,7 +323,7 @@ cib_file_backup(const char *cib_dirname, const char *cib_filename)
  * Set num_updates to 0, set cib-last-written to the current timestamp,
  * and strip out the status section.
  *
- * \param[in] root Root of CIB XML tree
+ * \param[in,out] root  Root of CIB XML tree
  *
  * \return void
  */
@@ -349,9 +349,9 @@ cib_file_prepare_xml(xmlNode *root)
  * \internal
  * \brief Write CIB to disk, along with a signature file containing its digest
  *
- * \param[in] cib_root Root of XML tree to write
- * \param[in] cib_dirname Directory containing CIB and signature files
- * \param[in] cib_filename Name (relative to cib_dirname) of file to write
+ * \param[in,out] cib_root      Root of XML tree to write
+ * \param[in]     cib_dirname   Directory containing CIB and signature files
+ * \param[in]     cib_filename  Name (relative to cib_dirname) of file to write
  *
  * \return pcmk_ok on success,
  *         pcmk_err_cib_modified if existing cib_filename doesn't match digest,
@@ -616,7 +616,7 @@ cib_file_signon(cib_t * cib, const char *name, enum cib_conn_type type)
  * \internal
  * \brief Write out the in-memory CIB to a live CIB file
  *
- * param[in] path Full path to file to write
+ * param[in,out] path  Full path to file to write
  *
  * \return 0 on success, -1 on failure
  */
@@ -696,7 +696,7 @@ cib_file_write_live(char *path)
  * This will write the file to disk if needed, and free the in-memory CIB. If
  * the file is the live CIB, it will compute and write a signature as well.
  *
- * \param[in] cib CIB object to sign off
+ * \param[in,out] cib  CIB object to sign off
  *
  * \return pcmk_ok on success, pcmk_err_generic on failure
  * \todo This method should refuse to write the live CIB if the CIB manager is

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -162,7 +162,7 @@ pcmk_cluster_free(crm_cluster_t *cluster)
  * \return TRUE on success, otherwise FALSE
  */
 gboolean
-send_cluster_message(crm_node_t *node, enum crm_ais_msg_types service,
+send_cluster_message(const crm_node_t *node, enum crm_ais_msg_types service,
                      xmlNode *data, gboolean ordered)
 {
     switch (get_cluster_type()) {

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -30,7 +30,7 @@ CRM_TRACE_INIT_DATA(cluster);
 /*!
  * \brief Get (and set if needed) a node's UUID
  *
- * \param[in] peer  Node to check
+ * \param[in,out] peer  Node to check
  *
  * \return Node UUID of \p peer, or NULL if unknown
  */
@@ -67,7 +67,7 @@ crm_peer_uuid(crm_node_t *peer)
 /*!
  * \brief Connect to the cluster layer
  *
- * \param[in] Initialized cluster object to connect
+ * \param[in,out] Initialized cluster object to connect
  *
  * \return TRUE on success, otherwise FALSE
  */
@@ -96,7 +96,7 @@ crm_cluster_connect(crm_cluster_t *cluster)
 /*!
  * \brief Disconnect from the cluster layer
  *
- * \param[in] cluster  Cluster object to disconnect
+ * \param[in,out] cluster  Cluster object to disconnect
  */
 void
 crm_cluster_disconnect(crm_cluster_t *cluster)
@@ -303,7 +303,7 @@ crm_peer_uname(const char *uuid)
  *
  * \param[in,out] xml   XML element to add UUID to
  * \param[in]     attr  XML attribute name to set
- * \param[in]     node  Node whose UUID should be used as attribute value
+ * \param[in,out] node  Node whose UUID should be used as attribute value
  */
 void
 set_uuid(xmlNode *xml, const char *attr, crm_node_t *node)

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -52,7 +52,7 @@ static gboolean (*quorum_app_callback)(unsigned long long seq,
  * \note It is the caller's responsibility to free the result with free().
  */
 char *
-pcmk__corosync_uuid(crm_node_t *node)
+pcmk__corosync_uuid(const crm_node_t *node)
 {
     if ((node != NULL) && is_corosync_cluster()) {
         if (node->id > 0) {
@@ -217,7 +217,7 @@ bail:
  * \internal
  * \brief Disconnect from Corosync cluster
  *
- * \param[in] cluster  Cluster connection to disconnect
+ * \param[in,out] cluster  Cluster connection to disconnect
  */
 void
 pcmk__corosync_disconnect(crm_cluster_t *cluster)
@@ -445,7 +445,7 @@ pcmk__corosync_quorum_connect(gboolean (*dispatch)(unsigned long long,
  * \internal
  * \brief Connect to Corosync cluster layer
  *
- * \param[in] cluster   Initialized cluster object to connect
+ * \param[in,out] cluster   Initialized cluster object to connect
  */
 gboolean
 pcmk__corosync_connect(crm_cluster_t *cluster)
@@ -551,7 +551,7 @@ crm_is_corosync_peer_active(const crm_node_t *node)
  * \internal
  * \brief Load Corosync node list (via CMAP) into peer cache and optionally XML
  *
- * \param[in] xml_parent  If not NULL, add a <node> entry to this for each node
+ * \param[in,out] xml_parent  If not NULL, add <node> entry here for each node
  *
  * \return true if any nodes were found, false otherwise
  */

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -914,7 +914,8 @@ pcmk__cpg_send_xml(xmlNode *msg, crm_node_t *node, enum crm_ais_msg_types dest)
  */
 gboolean
 send_cluster_text(enum crm_ais_msg_class msg_class, const char *data,
-                  gboolean local, crm_node_t *node, enum crm_ais_msg_types dest)
+                  gboolean local, const crm_node_t *node,
+                  enum crm_ais_msg_types dest)
 {
     static int msg_id = 0;
     static int local_pid = 0;

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -89,7 +89,7 @@ static void crm_cs_flush(gpointer data);
 /*!
  * \brief Disconnect from Corosync CPG
  *
- * \param[in] Cluster to disconnect
+ * \param[in,out] cluster  Cluster to disconnect
  */
 void
 cluster_disconnect_cpg(crm_cluster_t *cluster)
@@ -271,7 +271,7 @@ crm_cs_flush(gpointer data)
  * \internal
  * \brief Dispatch function for CPG handle
  *
- * \param[in] user_data  Cluster object
+ * \param[in,out] user_data  Cluster object
  *
  * \return 0 on success, -1 on error (per mainloop_io_t interface)
  */
@@ -424,15 +424,15 @@ check_message_sanity(const pcmk__cpg_msg_t *msg)
 /*!
  * \brief Extract text data from a Corosync CPG message
  *
- * \param[in]  handle   CPG connection (to get local node ID if not yet known)
- * \param[in]  nodeid   Corosync ID of node that sent message
- * \param[in]  pid      Process ID of message sender (for logging only)
- * \param[in]  content  CPG message
- * \param[out] kind     If not NULL, will be set to CPG header ID
- *                      (which should be an enum crm_ais_msg_class value,
- *                      currently always crm_class_cluster)
- * \param[out] from     If not NULL, will be set to sender uname
- *                      (valid for the lifetime of \p content)
+ * \param[in]     handle   CPG connection (to get local node ID if not known)
+ * \param[in]     nodeid   Corosync ID of node that sent message
+ * \param[in]     pid      Process ID of message sender (for logging only)
+ * \param[in,out] content  CPG message
+ * \param[out]    kind     If not NULL, will be set to CPG header ID
+ *                         (which should be an enum crm_ais_msg_class value,
+ *                         currently always crm_class_cluster)
+ * \param[out]    from     If not NULL, will be set to sender uname
+ *                         (valid for the lifetime of \p content)
  *
  * \return Newly allocated string with message data
  * \note It is the caller's responsibility to free the return value with free().
@@ -599,7 +599,7 @@ cpgreason2str(cpg_reason_t reason)
  * \return Node's uname, or readable string if not known
  */
 static inline const char *
-peer_name(crm_node_t *peer)
+peer_name(const crm_node_t *peer)
 {
     if (peer == NULL) {
         return "unknown node";
@@ -777,7 +777,7 @@ pcmk_cpg_membership(cpg_handle_t handle,
 /*!
  * \brief Connect to Corosync CPG
  *
- * \param[in] cluster  Cluster object
+ * \param[in,out] cluster  Cluster object
  *
  * \return TRUE on success, otherwise FALSE
  */
@@ -889,7 +889,8 @@ cluster_connect_cpg(crm_cluster_t *cluster)
  * \return TRUE on success, otherwise FALSE
  */
 gboolean
-pcmk__cpg_send_xml(xmlNode *msg, crm_node_t *node, enum crm_ais_msg_types dest)
+pcmk__cpg_send_xml(xmlNode *msg, const crm_node_t *node,
+                   enum crm_ais_msg_types dest)
 {
     gboolean rc = TRUE;
     char *data = NULL;

--- a/lib/cluster/crmcluster_private.h
+++ b/lib/cluster/crmcluster_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the Pacemaker project contributors
+ * Copyright 2020-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -28,7 +28,7 @@ G_GNUC_INTERNAL
 bool pcmk__corosync_has_nodelist(void);
 
 G_GNUC_INTERNAL
-char *pcmk__corosync_uuid(crm_node_t *peer);
+char *pcmk__corosync_uuid(const crm_node_t *peer);
 
 G_GNUC_INTERNAL
 char *pcmk__corosync_name(uint64_t /*cmap_handle_t */ cmap_handle,
@@ -41,7 +41,7 @@ G_GNUC_INTERNAL
 void pcmk__corosync_disconnect(crm_cluster_t *cluster);
 
 G_GNUC_INTERNAL
-gboolean pcmk__cpg_send_xml(xmlNode *msg, crm_node_t *node,
+gboolean pcmk__cpg_send_xml(xmlNode *msg, const crm_node_t *node,
                             enum crm_ais_msg_types dest);
 
 #endif  // PCMK__CRMCLUSTER_PRIVATE__H

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -163,7 +163,7 @@ crm_remote_peer_cache_remove(const char *node_name)
  *       backward compatibility with older controllers that don't set it.
  */
 static const char *
-remote_state_from_cib(xmlNode *node_state)
+remote_state_from_cib(const xmlNode *node_state)
 {
     bool status = false;
 
@@ -190,7 +190,7 @@ struct refresh_data {
 static void
 remote_cache_refresh_helper(xmlNode *result, void *user_data)
 {
-    struct refresh_data *data = user_data;
+    const struct refresh_data *data = user_data;
     const char *remote = crm_element_value(result, data->field);
     const char *state = NULL;
     crm_node_t *node;
@@ -768,8 +768,8 @@ crm_get_peer(unsigned int id, const char *uname)
  * \internal
  * \brief Update a node's uname
  *
- * \param[in] node        Node object to update
- * \param[in] uname       New name to set
+ * \param[in,out] node   Node object to update
+ * \param[in]     uname  New name to set
  *
  * \note This function should not be called within a peer cache iteration,
  *       because in some cases it can remove conflicting cache entries,
@@ -856,10 +856,10 @@ proc2text(enum crm_proc_flag proc)
  * \internal
  * \brief Update a node's process information (and potentially state)
  *
- * \param[in] source      Caller's function name (for log messages)
- * \param[in] node        Node object to update
- * \param[in] flag        Bitmask of new process information
- * \param[in] status      node status (online, offline, etc.)
+ * \param[in]     source  Caller's function name (for log messages)
+ * \param[in,out] node    Node object to update
+ * \param[in]     flag    Bitmask of new process information
+ * \param[in]     status  node status (online, offline, etc.)
  *
  * \return NULL if any node was reaped from peer caches, value of node otherwise
  *
@@ -990,11 +990,11 @@ pcmk__update_peer_expected(const char *source, crm_node_t *node,
  * \internal
  * \brief Update a node's state and membership information
  *
- * \param[in] source      Caller's function name (for log messages)
- * \param[in] node        Node object to update
- * \param[in] state       Node's new state
- * \param[in] membership  Node's new membership ID
- * \param[in] iter        If not NULL, pointer to node's peer cache iterator
+ * \param[in]     source      Caller's function name (for log messages)
+ * \param[in,out] node        Node object to update
+ * \param[in]     state       Node's new state
+ * \param[in]     membership  Node's new membership ID
+ * \param[in,out] iter        If not NULL, pointer to node's peer cache iterator
  *
  * \return NULL if any node was reaped, value of node otherwise
  *
@@ -1059,10 +1059,10 @@ update_peer_state_iter(const char *source, crm_node_t *node, const char *state,
 /*!
  * \brief Update a node's state and membership information
  *
- * \param[in] source      Caller's function name (for log messages)
- * \param[in] node        Node object to update
- * \param[in] state       Node's new state
- * \param[in] membership  Node's new membership ID
+ * \param[in]     source      Caller's function name (for log messages)
+ * \param[in,out] node        Node object to update
+ * \param[in]     state       Node's new state
+ * \param[in]     membership  Node's new membership ID
  *
  * \return NULL if any node was reaped, value of node otherwise
  *

--- a/lib/common/operations.c
+++ b/lib/common/operations.c
@@ -423,7 +423,7 @@ pcmk__filter_op_for_digest(xmlNode *param_set)
 }
 
 int
-rsc_op_expected_rc(lrmd_event_data_t * op)
+rsc_op_expected_rc(const lrmd_event_data_t *op)
 {
     int rc = 0;
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -544,7 +544,7 @@ pcmk__xe_match(const xmlNode *parent, const char *node_name,
 }
 
 void
-copy_in_properties(xmlNode * target, xmlNode * src)
+copy_in_properties(xmlNode *target, const xmlNode *src)
 {
     if (src == NULL) {
         crm_warn("No node to copy properties from");

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -57,8 +57,8 @@ static void log_action(stonith_action_t *action, pid_t pid);
  * \internal
  * \brief Set an action's result based on services library result
  *
- * \param[in] action      Fence action to set result for
- * \param[in] svc_action  Service action to get result from
+ * \param[in,out] action      Fence action to set result for
+ * \param[in,out] svc_action  Service action to get result from
  */
 static void
 set_result_from_svc_action(stonith_action_t *action, svc_action_t *svc_action)
@@ -427,8 +427,8 @@ stonith__legacy2status(int rc)
  * \internal
  * \brief Add a fencing result to an XML element as attributes
  *
- * \param[in] xml     XML element to add result to
- * \param[in] result  Fencing result to add (assume success if NULL)
+ * \param[in,out] xml     XML element to add result to
+ * \param[in]     result  Fencing result to add (assume success if NULL)
  */
 void
 stonith__xe_set_result(xmlNode *xml, const pcmk__action_result_t *result)
@@ -467,7 +467,7 @@ stonith__xe_set_result(xmlNode *xml, const pcmk__action_result_t *result)
  *
  * \param[in]  xml     XML element to search
  *
- * \return \p xml or descendent of it that contains a fencing result, else NULL
+ * \return \p xml or descendant of it that contains a fencing result, else NULL
  */
 xmlNode *
 stonith__find_xe_with_result(xmlNode *xml)
@@ -491,7 +491,7 @@ stonith__find_xe_with_result(xmlNode *xml)
  * \param[out] result  Where to store fencing result
  */
 void
-stonith__xe_get_result(xmlNode *xml, pcmk__action_result_t *result)
+stonith__xe_get_result(const xmlNode *xml, pcmk__action_result_t *result)
 {
     int exit_status = CRM_EX_OK;
     int execution_status = PCMK_EXEC_DONE;

--- a/lib/fencing/st_lha.c
+++ b/lib/fencing/st_lha.c
@@ -72,24 +72,24 @@ find_library_function(void **handle, const char *lib, const char *fn)
 }
 
 /*!
- * \brief Determine namespace of a fence agent
+ * \internal
+ * \brief Check whether a given fence agent is an LHA agent
  *
  * \param[in] agent        Fence agent type
- * \param[in] namespace_s  Name of agent namespace as string, if known
  *
- * \return Namespace of specified agent, as enum value
+ * \return true if \p agent is an LHA agent, otherwise false
  */
 bool
 stonith__agent_is_lha(const char *agent)
 {
     Stonith *stonith_obj = NULL;
 
-    static gboolean need_init = TRUE;
+    static bool need_init = true;
     static Stonith *(*st_new_fn) (const char *) = NULL;
     static void (*st_del_fn) (Stonith *) = NULL;
 
     if (need_init) {
-        need_init = FALSE;
+        need_init = false;
         st_new_fn = find_library_function(&lha_agents_lib, LHA_STONITH_LIBRARY,
                                           "stonith_new");
         st_del_fn = find_library_function(&lha_agents_lib, LHA_STONITH_LIBRARY,
@@ -100,10 +100,10 @@ stonith__agent_is_lha(const char *agent)
         stonith_obj = (*st_new_fn) (agent);
         if (stonith_obj) {
             (*st_del_fn) (stonith_obj);
-            return TRUE;
+            return true;
         }
     }
-    return FALSE;
+    return false;
 }
 
 int

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -60,7 +60,7 @@ timespec_string(time_t sec, long nsec, bool show_usec) {
  *       for cluster status) instead of developer-oriented (for debug logs).
  */
 static const char *
-state_str(stonith_history_t *history)
+state_str(const stonith_history_t *history)
 {
     switch (history->state) {
         case st_failed: return "failed";
@@ -87,8 +87,9 @@ state_str(stonith_history_t *history)
  *       event notifications (stonith_event_t) in log messages.
  */
 gchar *
-stonith__history_description(stonith_history_t *history, bool full_history,
-                             const char *later_succeeded, uint32_t show_opts)
+stonith__history_description(const stonith_history_t *history,
+                             bool full_history, const char *later_succeeded,
+                             uint32_t show_opts)
 {
     GString *str = g_string_sized_new(256); // Generous starting size
     char *completed_time_s = NULL;

--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the Pacemaker project contributors
+ * Copyright 2015-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -74,7 +74,7 @@ set_ev_kv(gpointer key, gpointer value, gpointer user_data)
 }
 
 static lrmd_key_value_t *
-alert_envvar2params(lrmd_key_value_t *head, pcmk__alert_t *entry)
+alert_envvar2params(lrmd_key_value_t *head, const pcmk__alert_t *entry)
 {
     if (entry->envvars) {
         g_hash_table_foreach(entry->envvars, set_ev_kv, &head);
@@ -113,7 +113,7 @@ is_target_alert(char **list, const char *value)
  * \internal
  * \brief Execute alert agents for an event
  *
- * \param[in]     lrmd        Executor connection to use
+ * \param[in,out] lrmd        Executor connection to use
  * \param[in]     alert_list  Alerts to execute
  * \param[in]     kind        Type of event that is being alerted for
  * \param[in]     attr_name   If pcmk__alert_attribute, the attribute name
@@ -124,8 +124,9 @@ is_target_alert(char **list, const char *value)
  * \retval -2 if all alerts failed
  */
 static int
-exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum pcmk__alert_flags kind,
-                const char *attr_name, lrmd_key_value_t *params)
+exec_alert_list(lrmd_t *lrmd, const GList *alert_list,
+                enum pcmk__alert_flags kind, const char *attr_name,
+                lrmd_key_value_t *params)
 {
     bool any_success = FALSE, any_failure = FALSE;
     const char *kind_s = pcmk__alert_flag2text(kind);
@@ -138,8 +139,9 @@ exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum pcmk__alert_flags kind,
     params = alert_key2param(params, PCMK__alert_key_version,
                              PACEMAKER_VERSION);
 
-    for (GList *iter = g_list_first(alert_list); iter; iter = g_list_next(iter)) {
-        pcmk__alert_t *entry = (pcmk__alert_t *)(iter->data);
+    for (const GList *iter = alert_list;
+         iter != NULL; iter = g_list_next(iter)) {
+        const pcmk__alert_t *entry = (pcmk__alert_t *) (iter->data);
         lrmd_key_value_t *copy_params = NULL;
         lrmd_key_value_t *head = NULL;
         int rc;
@@ -220,19 +222,19 @@ exec_alert_list(lrmd_t *lrmd, GList *alert_list, enum pcmk__alert_flags kind,
  * \internal
  * \brief Send an alert for a node attribute change
  *
- * \param[in] lrmd        Executor connection to use
- * \param[in] alert_list  List of alert agents to execute
- * \param[in] node        Name of node with attribute change
- * \param[in] nodeid      Node ID of node with attribute change
- * \param[in] attr_name   Name of attribute that changed
- * \param[in] attr_value  New value of attribute that changed
+ * \param[in,out] lrmd        Executor connection to use
+ * \param[in]     alert_list  List of alert agents to execute
+ * \param[in]     node        Name of node with attribute change
+ * \param[in]     nodeid      Node ID of node with attribute change
+ * \param[in]     attr_name   Name of attribute that changed
+ * \param[in]     attr_value  New value of attribute that changed
  *
  * \retval pcmk_ok on success
  * \retval -1 if some alert agents failed
  * \retval -2 if all alert agents failed
  */
 int
-lrmd_send_attribute_alert(lrmd_t *lrmd, GList *alert_list,
+lrmd_send_attribute_alert(lrmd_t *lrmd, const GList *alert_list,
                           const char *node, uint32_t nodeid,
                           const char *attr_name, const char *attr_value)
 {
@@ -259,18 +261,18 @@ lrmd_send_attribute_alert(lrmd_t *lrmd, GList *alert_list,
  * \internal
  * \brief Send an alert for a node membership event
  *
- * \param[in] lrmd        Executor connection to use
- * \param[in] alert_list  List of alert agents to execute
- * \param[in] node        Name of node with change
- * \param[in] nodeid      Node ID of node with change
- * \param[in] state       New state of node with change
+ * \param[in,out] lrmd        Executor connection to use
+ * \param[in]     alert_list  List of alert agents to execute
+ * \param[in]     node        Name of node with change
+ * \param[in]     nodeid      Node ID of node with change
+ * \param[in]     state       New state of node with change
  *
  * \retval pcmk_ok on success
  * \retval -1 if some alert agents failed
  * \retval -2 if all alert agents failed
  */
 int
-lrmd_send_node_alert(lrmd_t *lrmd, GList *alert_list,
+lrmd_send_node_alert(lrmd_t *lrmd, const GList *alert_list,
                      const char *node, uint32_t nodeid, const char *state)
 {
     int rc = pcmk_ok;
@@ -293,19 +295,19 @@ lrmd_send_node_alert(lrmd_t *lrmd, GList *alert_list,
  * \internal
  * \brief Send an alert for a fencing event
  *
- * \param[in] lrmd        Executor connection to use
- * \param[in] alert_list  List of alert agents to execute
- * \param[in] target      Name of fence target node
- * \param[in] task        Type of fencing event that occurred
- * \param[in] desc        Readable description of event
- * \param[in] op_rc       Result of fence action
+ * \param[in,out] lrmd        Executor connection to use
+ * \param[in]     alert_list  List of alert agents to execute
+ * \param[in]     target      Name of fence target node
+ * \param[in]     task        Type of fencing event that occurred
+ * \param[in]     desc        Readable description of event
+ * \param[in]     op_rc       Result of fence action
  *
  * \retval pcmk_ok on success
  * \retval -1 if some alert agents failed
  * \retval -2 if all alert agents failed
  */
 int
-lrmd_send_fencing_alert(lrmd_t *lrmd, GList *alert_list,
+lrmd_send_fencing_alert(lrmd_t *lrmd, const GList *alert_list,
                         const char *target, const char *task, const char *desc,
                         int op_rc)
 {
@@ -330,18 +332,18 @@ lrmd_send_fencing_alert(lrmd_t *lrmd, GList *alert_list,
  * \internal
  * \brief Send an alert for a resource operation
  *
- * \param[in] lrmd        Executor connection to use
- * \param[in] alert_list  List of alert agents to execute
- * \param[in] node        Name of node that executed operation
- * \param[in] op          Resource operation
+ * \param[in,out] lrmd        Executor connection to use
+ * \param[in]     alert_list  List of alert agents to execute
+ * \param[in]     node        Name of node that executed operation
+ * \param[in]     op          Resource operation
  *
  * \retval pcmk_ok on success
  * \retval -1 if some alert agents failed
  * \retval -2 if all alert agents failed
  */
 int
-lrmd_send_resource_alert(lrmd_t *lrmd, GList *alert_list,
-                         const char *node, lrmd_event_data_t *op)
+lrmd_send_resource_alert(lrmd_t *lrmd, const GList *alert_list,
+                         const char *node, const lrmd_event_data_t *op)
 {
     int rc = pcmk_ok;
     int target_rc = pcmk_ok;

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -180,7 +180,7 @@ lrmd_key_value_freeall(lrmd_key_value_t * head)
 }
 
 /*!
- * Create a new lrmd_event_data_t object
+ * \brief Create a new lrmd_event_data_t object
  *
  * \param[in] rsc_id       ID of resource involved in event
  * \param[in] task         Action name
@@ -237,7 +237,7 @@ lrmd_copy_event(lrmd_event_data_t * event)
 /*!
  * \brief Free an executor event
  *
- * \param[in]  Executor event object to free
+ * \param[in,out]  Executor event object to free
  */
 void
 lrmd_free_event(lrmd_event_data_t *event)
@@ -365,7 +365,7 @@ remote_executor_connected(lrmd_t * lrmd)
  * \internal
  * \brief TLS dispatch function (for both trigger and file descriptor sources)
  *
- * \param[in] userdata  API connection
+ * \param[in,out] userdata  API connection
  *
  * \return Always return a nonnegative value, which as a file descriptor
  *         dispatch function means keep the mainloop source, and as a
@@ -829,17 +829,17 @@ lrmd_api_is_connected(lrmd_t * lrmd)
  * \internal
  * \brief Send a prepared API command to the executor
  *
- * \param[in]  lrmd          Existing connection to the executor
- * \param[in]  op            Name of API command to send
- * \param[in]  data          Command data XML to add to the sent command
- * \param[out] output_data   If expecting a reply, it will be stored here
- * \param[in]  timeout       Timeout in milliseconds (if 0, defaults to
- *                           a sensible value per the type of connection,
- *                           standard vs. pacemaker remote);
- *                           also propagated to the command XML
- * \param[in]  call_options  Call options to pass to server when sending
- * \param[in]  expect_reply  If TRUE, wait for a reply from the server;
- *                           must be TRUE for IPC (as opposed to TLS) clients
+ * \param[in,out] lrmd          Existing connection to the executor
+ * \param[in]     op            Name of API command to send
+ * \param[in]     data          Command data XML to add to the sent command
+ * \param[out]    output_data   If expecting a reply, it will be stored here
+ * \param[in]     timeout       Timeout in milliseconds (if 0, defaults to
+ *                              a sensible value per the type of connection,
+ *                              standard vs. pacemaker remote);
+ *                              also propagated to the command XML
+ * \param[in]     call_options  Call options to pass to server when sending
+ * \param[in]     expect_reply  If TRUE, wait for a reply from the server;
+ *                              must be TRUE for IPC (as opposed to TLS) clients
  *
  * \return pcmk_ok on success, -errno on error
  */
@@ -1340,8 +1340,8 @@ lrmd__tls_client_handshake(pcmk__remote_t *remote)
  * \internal
  * \brief Add trigger and file descriptor mainloop sources for TLS
  *
- * \param[in] lrmd          API connection with established TLS session
- * \param[in] do_handshake  Whether to perform executor handshake
+ * \param[in,out] lrmd          API connection with established TLS session
+ * \param[in]     do_handshake  Whether to perform executor handshake
  *
  * \return Standard Pacemaker return code
  */
@@ -2353,7 +2353,7 @@ struct metadata_cb {
  * \internal
  * \brief Process asynchronous metadata completion
  *
- * \param[in] action  Metadata action that completed
+ * \param[in,out] action  Metadata action that completed
  */
 static void
 metadata_complete(svc_action_t *action)
@@ -2376,12 +2376,12 @@ metadata_complete(svc_action_t *action)
  * \internal
  * \brief Retrieve agent metadata asynchronously
  *
- * \param[in] rsc        Resource agent specification
- * \param[in] callback   Function to call with result (this will always be
- *                       called, whether by this function directly or later via
- *                       the main loop, and on success the metadata will be in
- *                       its result argument's action_stdout)
- * \param[in] user_data  User data to pass to callback
+ * \param[in]     rsc        Resource agent specification
+ * \param[in]     callback   Function to call with result (this will always be
+ *                           called, whether by this function directly or later
+ *                           via the main loop, and on success the metadata will
+ *                           be in its result argument's action_stdout)
+ * \param[in,out] user_data  User data to pass to callback
  *
  * \return Standard Pacemaker return code
  * \note This function is not a lrmd_api_operations_t method because it does not
@@ -2389,7 +2389,7 @@ metadata_complete(svc_action_t *action)
  *       executes the agent directly.
  */
 int
-lrmd__metadata_async(lrmd_rsc_info_t *rsc,
+lrmd__metadata_async(const lrmd_rsc_info_t *rsc,
                      void (*callback)(int pid,
                                       const pcmk__action_result_t *result,
                                       void *user_data),
@@ -2485,7 +2485,7 @@ lrmd__set_result(lrmd_event_data_t *event, enum ocf_exitcode rc, int op_status,
  * \internal
  * \brief Clear an executor event's exit reason, output, and error output
  *
- * \param[in] event  Executor event to reset
+ * \param[in,out] event  Executor event to reset
  */
 void
 lrmd__reset_result(lrmd_event_data_t *event)

--- a/lib/lrmd/proxy_common.c
+++ b/lib/lrmd/proxy_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the Pacemaker project contributors
+ * Copyright 2015-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -37,9 +37,10 @@ remote_proxy_notify_destroy(lrmd_t *lrmd, const char *session_id)
 }
 
 /*!
- * \brief Send an acknowledgment of a remote proxy shutdown request.
+ * \internal
+ * \brief Acknowledge a remote proxy shutdown request
  *
- * \param[in] lrmd  Connection to proxy
+ * \param[in,out] lrmd  Connection to proxy
  */
 void
 remote_proxy_ack_shutdown(lrmd_t *lrmd)
@@ -51,10 +52,10 @@ remote_proxy_ack_shutdown(lrmd_t *lrmd)
 }
 
 /*!
- * \brief We're not going to shutdown as response to
- *        a remote proxy shutdown request.
+ * \internal
+ * \brief Reject a remote proxy shutdown request
  *
- * \param[in] lrmd  Connection to proxy
+ * \param[in,out] lrmd  Connection to proxy
  */
 void
 remote_proxy_nack_shutdown(lrmd_t *lrmd)

--- a/lib/services/dbus.c
+++ b/lib/services/dbus.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the Pacemaker project contributors
+ * Copyright 2014-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -96,7 +96,7 @@ dbus_watch_flags_to_string(int flags)
  * \internal
  * \brief Dispatch data available on a DBus file descriptor watch
  *
- * \param[in] userdata  Pointer to the DBus watch
+ * \param[in,out] userdata  Pointer to the DBus watch
  *
  * \return Always 0
  * \note This is suitable for use as a dispatch function in
@@ -327,7 +327,7 @@ pcmk_dbus_disconnect(DBusConnection *connection)
  *       done using it.
  */
 bool
-pcmk_dbus_find_error(DBusPendingCall *pending, DBusMessage *reply,
+pcmk_dbus_find_error(const DBusPendingCall *pending, DBusMessage *reply,
                      DBusError *ret)
 {
     DBusError error;
@@ -397,10 +397,10 @@ pcmk_dbus_find_error(DBusPendingCall *pending, DBusMessage *reply,
  * \internal
  * \brief Send a DBus request and wait for the reply
  *
- * \param[in]  msg         DBus request to send
- * \param[in]  connection  DBus connection to use
- * \param[out] error       If non-NULL, will be set to error, if any
- * \param[in]  timeout     Timeout to use for request
+ * \param[in]     msg         DBus request to send
+ * \param[in,out] connection  DBus connection to use
+ * \param[out]    error       If non-NULL, will be set to error, if any
+ * \param[in]     timeout     Timeout to use for request
  *
  * \return DBus reply
  *
@@ -462,7 +462,7 @@ pcmk_dbus_send_recv(DBusMessage *msg, DBusConnection *connection,
  * \internal
  * \brief Send a DBus message with a callback for the reply
  *
- * \param[in]     msg         DBus message to send
+ * \param[in,out] msg         DBus message to send
  * \param[in,out] connection  DBus connection to send on
  * \param[in]     done        Function to call when pending call completes
  * \param[in]     user_data   Data to pass to done callback
@@ -673,17 +673,17 @@ async_query_result_cb(DBusPendingCall *pending, void *user_data)
  * \internal
  * \brief Query a property on a DBus object
  *
- * \param[in]  connection  An active connection to DBus
- * \param[in]  target      DBus name that the query should be sent to
- * \param[in]  obj         DBus object path for object with the property
- * \param[in]  iface       DBus interface for property to query
- * \param[in]  name        Name of property to query
- * \param[in]  callback    If not NULL, perform query asynchronously, and call
- *                         this function when query completes
- * \param[in]  userdata    Caller-provided data to provide to \p callback
- * \param[out] pending     If \p callback is not NULL, this will be set to the
- *                         handle for the reply (or NULL on error)
- * \param[in]  timeout     Abort query if it takes longer than this (ms)
+ * \param[in,out] connection  An active connection to DBus
+ * \param[in]     target      DBus name that the query should be sent to
+ * \param[in]     obj         DBus object path for object with the property
+ * \param[in]     iface       DBus interface for property to query
+ * \param[in]     name        Name of property to query
+ * \param[in]     callback    If not NULL, perform query asynchronously and call
+ *                            this function when query completes
+ * \param[in]     userdata    Caller-provided data to provide to \p callback
+ * \param[out]    pending     If \p callback is not NULL, this will be set to
+ *                            handle for the reply (or NULL on error)
+ * \param[in]     timeout     Abort query if it takes longer than this (ms)
  *
  * \return NULL if \p callback is non-NULL (i.e. asynchronous), otherwise a
  *         newly allocated string with property value

--- a/lib/services/pcmk-dbus.h
+++ b/lib/services/pcmk-dbus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the Pacemaker project contributors
+ * Copyright 2014-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -39,7 +39,7 @@ char *pcmk_dbus_get_property(
     DBusPendingCall **pending, int timeout);
 
 G_GNUC_INTERNAL
-bool pcmk_dbus_find_error(DBusPendingCall *pending, DBusMessage *reply,
+bool pcmk_dbus_find_error(const DBusPendingCall *pending, DBusMessage *reply,
                           DBusError *error);
 
 #endif  /* PCMK_DBUS__H */

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -106,7 +106,7 @@ init_recurring_actions(void)
  * \return TRUE if op is in-flight systemd or upstart op
  */
 static inline gboolean
-inflight_systemd_or_upstart(svc_action_t *op)
+inflight_systemd_or_upstart(const svc_action_t *op)
 {
     return pcmk__strcase_any_of(op->standard, PCMK_RESOURCE_CLASS_SYSTEMD,
                            PCMK_RESOURCE_CLASS_UPSTART, NULL) &&
@@ -429,7 +429,7 @@ services_alert_create(const char *id, const char *exec, int timeout,
 /*!
  * \brief Set the user and group that an action will execute as
  *
- * \param[in,out] action  Action to modify
+ * \param[in,out] op      Action to modify
  * \param[in]     user    Name of user to execute action as
  * \param[in]     group   Name of group to execute action as
  *
@@ -451,8 +451,8 @@ services_action_user(svc_action_t *op, const char *user)
 /*!
  * \brief Execute an alert agent action
  *
- * \param[in] action  Action to execute
- * \param[in] cb      Function to call when action completes
+ * \param[in,out] action  Action to execute
+ * \param[in]     cb      Function to call when action completes
  *
  * \return TRUE if the library will free action, FALSE otherwise
  *
@@ -760,12 +760,12 @@ services_action_kick(const char *name, const char *action, guint interval_ms)
  * \internal
  * \brief Add a new recurring operation, checking for duplicates
  *
- * \param[in] op               Operation to add
+ * \param[in,out] op  Operation to add
  *
  * \return TRUE if duplicate found (and reschedule), FALSE otherwise
  */
 static gboolean
-handle_duplicate_recurring(svc_action_t * op)
+handle_duplicate_recurring(svc_action_t *op)
 {
     svc_action_t * dup = NULL;
 
@@ -799,7 +799,7 @@ handle_duplicate_recurring(svc_action_t * op)
  * \internal
  * \brief Execute an action appropriately according to its standard
  *
- * \param[in] op  Action to execute
+ * \param[in,out] op  Action to execute
  *
  * \return Standard Pacemaker return code
  * \retval EBUSY          Recurring operation could not be initiated
@@ -853,7 +853,7 @@ services_add_inflight_op(svc_action_t * op)
  * \param[in] op  Operation to stop tracking
  */
 void
-services_untrack_op(svc_action_t *op)
+services_untrack_op(const svc_action_t *op)
 {
     /* Op is no longer in-flight or blocked */
     inflight_ops = g_list_remove(inflight_ops, op);
@@ -964,7 +964,7 @@ handle_blocked_ops(void)
  * \internal
  * \brief Execute a meta-data action appropriately to standard
  *
- * \param[in] op  Meta-data action to execute
+ * \param[in,out] op  Meta-data action to execute
  *
  * \return Standard Pacemaker return code
  */
@@ -1349,7 +1349,7 @@ services__set_cancelled(svc_action_t *action)
  * \return Readable name for the kind of \p action
  */
 const char *
-services__action_kind(svc_action_t *action)
+services__action_kind(const svc_action_t *action)
 {
     if ((action == NULL) || (action->standard == NULL)) {
         return "Process";
@@ -1373,7 +1373,7 @@ services__action_kind(svc_action_t *action)
  * \return Action's exit reason (or NULL if none)
  */
 const char *
-services__exit_reason(svc_action_t *action)
+services__exit_reason(const svc_action_t *action)
 {
     return action->opaque->exit_reason;
 }
@@ -1382,7 +1382,7 @@ services__exit_reason(svc_action_t *action)
  * \internal
  * \brief Steal stdout from an action
  *
- * \param[in] action  Action whose stdout is desired
+ * \param[in,out] action  Action whose stdout is desired
  *
  * \return Action's stdout (which may be NULL)
  * \note Upon return, \p action will no longer track the output, so it is the
@@ -1401,7 +1401,7 @@ services__grab_stdout(svc_action_t *action)
  * \internal
  * \brief Steal stderr from an action
  *
- * \param[in] action  Action whose stderr is desired
+ * \param[in,out] action  Action whose stderr is desired
  *
  * \return Action's stderr (which may be NULL)
  * \note Upon return, \p action will no longer track the output, so it is the

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -238,7 +238,7 @@ sigchld_cleanup(struct sigchld_data_s *data)
  * \internal
  * \brief Close the two file descriptors of a pipe
  *
- * \param[in] fildes  Array of file descriptors opened by pipe()
+ * \param[in,out] fildes  Array of file descriptors opened by pipe()
  */
 static void
 close_pipe(int fildes[])
@@ -642,11 +642,11 @@ parse_exit_reason_from_stderr(svc_action_t *op)
  * \internal
  * \brief Process the completion of an asynchronous child process
  *
- * \param[in] p         Child process that completed
- * \param[in] pid       Process ID of child
- * \param[in] core      (unused)
- * \param[in] signo     Signal that interrupted child, if any
- * \param[in] exitcode  Exit status of child process
+ * \param[in,out] p         Child process that completed
+ * \param[in]     pid       Process ID of child
+ * \param[in]     core      (Unused)
+ * \param[in]     signo     Signal that interrupted child, if any
+ * \param[in]     exitcode  Exit status of child process
  */
 static void
 async_action_complete(mainloop_child_t *p, pid_t pid, int core, int signo,
@@ -718,7 +718,7 @@ async_action_complete(mainloop_child_t *p, pid_t pid, int core, int signo,
  * \note Actions without a standard will get PCMK_OCF_UNKNOWN_ERROR.
  */
 int
-services__generic_error(svc_action_t *op)
+services__generic_error(const svc_action_t *op)
 {
     if ((op == NULL) || (op->standard == NULL)) {
         return PCMK_OCF_UNKNOWN_ERROR;
@@ -753,7 +753,7 @@ services__generic_error(svc_action_t *op)
  * \note Actions without a standard will get PCMK_OCF_UNKNOWN_ERROR.
  */
 int
-services__not_installed_error(svc_action_t *op)
+services__not_installed_error(const svc_action_t *op)
 {
     if ((op == NULL) || (op->standard == NULL)) {
         return PCMK_OCF_UNKNOWN_ERROR;
@@ -788,7 +788,7 @@ services__not_installed_error(svc_action_t *op)
  * \note Actions without a standard will get PCMK_OCF_UNKNOWN_ERROR.
  */
 int
-services__authorization_error(svc_action_t *op)
+services__authorization_error(const svc_action_t *op)
 {
     if ((op == NULL) || (op->standard == NULL)) {
         return PCMK_OCF_UNKNOWN_ERROR;
@@ -824,7 +824,7 @@ services__authorization_error(svc_action_t *op)
  * \note Actions without a standard will get PCMK_OCF_UNKNOWN_ERROR.
  */
 int
-services__configuration_error(svc_action_t *op, bool is_fatal)
+services__configuration_error(const svc_action_t *op, bool is_fatal)
 {
     if ((op == NULL) || (op->standard == NULL)) {
         return PCMK_OCF_UNKNOWN_ERROR;
@@ -898,7 +898,7 @@ services__handle_exec_error(svc_action_t * op, int error)
  * \param[in] exit_reason  Exit reason to output if for OCF agent
  */
 static void
-exit_child(svc_action_t *op, int exit_status, const char *exit_reason)
+exit_child(const svc_action_t *op, int exit_status, const char *exit_reason)
 {
     if ((op != NULL) && (exit_reason != NULL)
         && pcmk__str_eq(op->standard, PCMK_RESOURCE_CLASS_OCF,
@@ -1014,8 +1014,8 @@ action_launch_child(svc_action_t *op)
  * \internal
  * \brief Wait for synchronous action to complete, and set its result
  *
- * \param[in] op    Action to wait for
- * \param[in] data  Child signal data
+ * \param[in,out] op    Action to wait for
+ * \param[in,out] data  Child signal data
  */
 static void
 wait_for_sync_result(svc_action_t *op, struct sigchld_data_s *data)
@@ -1152,7 +1152,7 @@ wait_for_sync_result(svc_action_t *op, struct sigchld_data_s *data)
  * \internal
  * \brief Execute an action whose standard uses executable files
  *
- * \param[in] op  Action to execute
+ * \param[in,out] op  Action to execute
  *
  * \return Standard Pacemaker return value
  * \retval EBUSY          Recurring operation could not be initiated

--- a/lib/services/services_lsb.c
+++ b/lib/services/services_lsb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 the Pacemaker project contributors
+ * Copyright 2010-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -261,12 +261,12 @@ services__lsb_agent_exists(const char *agent)
  * \internal
  * \brief Prepare an LSB action
  *
- * \param[in] op  Action to prepare
+ * \param[in,out] op  Action to prepare
  *
  * \return Standard Pacemaker return code
  */
 int
-services__lsb_prepare(svc_action_t *op)
+services__lsb_prepare(const svc_action_t *op)
 {
     op->opaque->exec = pcmk__full_path(op->agent, PCMK__LSB_INIT_DIR);
     op->opaque->args[0] = strdup(op->opaque->exec);

--- a/lib/services/services_lsb.h
+++ b/lib/services/services_lsb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 the Pacemaker project contributors
+ * Copyright 2010-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -13,7 +13,7 @@
 G_GNUC_INTERNAL int services__get_lsb_metadata(const char *type, char **output);
 G_GNUC_INTERNAL GList *services__list_lsb_agents(void);
 G_GNUC_INTERNAL bool services__lsb_agent_exists(const char *agent);
-G_GNUC_INTERNAL int services__lsb_prepare(svc_action_t *op);
+G_GNUC_INTERNAL int services__lsb_prepare(const svc_action_t *op);
 
 G_GNUC_INTERNAL
 enum ocf_exitcode services__lsb2ocf(const char *action, int exit_status);

--- a/lib/services/services_nagios.c
+++ b/lib/services/services_nagios.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 the Pacemaker project contributors
+ * Copyright 2010-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -36,7 +36,7 @@
  * \internal
  * \brief Prepare a Nagios action
  *
- * \param[in] op  Action to prepare
+ * \param[in,out] op  Action to prepare
  *
  * \return Standard Pacemaker return code
  */

--- a/lib/services/services_ocf.c
+++ b/lib/services/services_ocf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the Pacemaker project contributors
+ * Copyright 2012-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -115,7 +115,7 @@ services__ocf_agent_exists(const char *provider, const char *agent)
  * \internal
  * \brief Prepare an OCF action
  *
- * \param[in] op  Action to prepare
+ * \param[in,out] op  Action to prepare
  *
  * \return Standard Pacemaker return code
  */

--- a/lib/services/services_private.h
+++ b/lib/services/services_private.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2010-2011 Red Hat, Inc.
- * Later changes copyright 2012-2021 the Pacemaker project contributors
+ * Later changes copyright 2012-2022 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -45,7 +45,7 @@ struct svc_action_private_s {
 };
 
 G_GNUC_INTERNAL
-const char *services__action_kind(svc_action_t *action);
+const char *services__action_kind(const svc_action_t *action);
 
 G_GNUC_INTERNAL
 GList *services_os_get_single_directory_list(const char *root, gboolean files,
@@ -67,16 +67,16 @@ G_GNUC_INTERNAL
 int services__finalize_async_op(svc_action_t *op);
 
 G_GNUC_INTERNAL
-int services__generic_error(svc_action_t *op);
+int services__generic_error(const svc_action_t *op);
 
 G_GNUC_INTERNAL
-int services__not_installed_error(svc_action_t *op);
+int services__not_installed_error(const svc_action_t *op);
 
 G_GNUC_INTERNAL
-int services__authorization_error(svc_action_t *op);
+int services__authorization_error(const svc_action_t *op);
 
 G_GNUC_INTERNAL
-int services__configuration_error(svc_action_t *op, bool is_fatal);
+int services__configuration_error(const svc_action_t *op, bool is_fatal);
 
 G_GNUC_INTERNAL
 void services__handle_exec_error(svc_action_t * op, int error);
@@ -88,7 +88,7 @@ G_GNUC_INTERNAL
 void services_add_inflight_op(svc_action_t *op);
 
 G_GNUC_INTERNAL
-void services_untrack_op(svc_action_t *op);
+void services_untrack_op(const svc_action_t *op);
 
 G_GNUC_INTERNAL
 gboolean is_op_blocked(const char *rsc);

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -31,7 +31,7 @@ static void invoke_unit_by_path(svc_action_t *op, const char *unit);
  * \internal
  * \brief Prepare a systemd action
  *
- * \param[in] op  Action to prepare
+ * \param[in,out] op  Action to prepare
  *
  * \return Standard Pacemaker return code
  */
@@ -295,8 +295,8 @@ systemd_daemon_reload(int timeout)
  * \internal
  * \brief Set an action result based on a method error
  *
- * \param[in] op     Action to set result for
- * \param[in] error  Method error
+ * \param[in,out] op     Action to set result for
+ * \param[in]     error  Method error
  */
 static void
 set_result_from_method_error(svc_action_t *op, const DBusError *error)
@@ -331,8 +331,8 @@ set_result_from_method_error(svc_action_t *op, const DBusError *error)
  * \internal
  * \brief Extract unit path from LoadUnit reply, and execute action
  *
- * \param[in] reply  LoadUnit reply
- * \param[in] op     Action to execute (or NULL to just return path)
+ * \param[in]     reply  LoadUnit reply
+ * \param[in,out] op     Action to execute (or NULL to just return path)
  *
  * \return DBus object path for specified unit if successful (only valid for
  *         lifetime of \p reply), otherwise NULL
@@ -389,8 +389,8 @@ execute_after_loadunit(DBusMessage *reply, svc_action_t *op)
  * \internal
  * \brief Execute a systemd action after its LoadUnit completes
  *
- * \param[in] pending    If not NULL, DBus call associated with LoadUnit request
- * \param[in] user_data  Action to execute
+ * \param[in,out] pending    If not NULL, DBus call associated with LoadUnit
+ * \param[in,out] user_data  Action to execute
  */
 static void
 loadunit_completed(DBusPendingCall *pending, void *user_data)
@@ -420,10 +420,10 @@ loadunit_completed(DBusPendingCall *pending, void *user_data)
  * \internal
  * \brief Execute a systemd action, given the unit name
  *
- * \param[in]  arg_name  Unit name (possibly shortened, i.e. without ".service")
- * \param[in]  op        Action to execute (if NULL, just get the object path)
- * \param[out] path      If non-NULL and \p op is NULL or synchronous, where to
- *                       store DBus object path for specified unit
+ * \param[in]     arg_name  Unit name (possibly without ".service" extension)
+ * \param[in,out] op        Action to execute (if NULL, just get object path)
+ * \param[out]    path      If non-NULL and \p op is NULL or synchronous, where
+ *                          to store DBus object path for specified unit
  *
  * \return Standard Pacemaker return code (for NULL \p op, pcmk_rc_ok means unit
  *         was found; for synchronous actions, pcmk_rc_ok means unit was
@@ -709,8 +709,8 @@ systemd_unit_metadata(const char *name, int timeout)
  * \internal
  * \brief Determine result of method from reply
  *
- * \param[in] reply  Reply to start, stop, or restart request
- * \param[in] op     Action that was executed
+ * \param[in]     reply  Reply to start, stop, or restart request
+ * \param[in,out] op     Action that was executed
  */
 static void
 process_unit_method_reply(DBusMessage *reply, svc_action_t *op)
@@ -748,8 +748,8 @@ process_unit_method_reply(DBusMessage *reply, svc_action_t *op)
  * \internal
  * \brief Process the completion of an asynchronous unit start, stop, or restart
  *
- * \param[in] pending    If not NULL, DBus call associated with request
- * \param[in] user_data  Action that was executed
+ * \param[in,out] pending    If not NULL, DBus call associated with request
+ * \param[in,out] user_data  Action that was executed
  */
 static void
 unit_method_complete(DBusPendingCall *pending, void *user_data)
@@ -883,9 +883,9 @@ systemd_remove_override(const char *agent, int timeout)
  * Set a status action's exit status and execution status based on a DBus
  * property check result, and finalize the action if asynchronous.
  *
- * \param[in] name      DBus interface name for property that was checked
- * \param[in] state     Property value
- * \param[in] userdata  Status action that check was done for
+ * \param[in]     name      DBus interface name for property that was checked
+ * \param[in]     state     Property value
+ * \param[in,out] userdata  Status action that check was done for
  */
 static void
 parse_status_result(const char *name, const char *state, void *userdata)
@@ -922,8 +922,8 @@ parse_status_result(const char *name, const char *state, void *userdata)
  * \internal
  * \brief Invoke a systemd unit, given its DBus object path
  *
- * \param[in] op    Action to execute
- * \param[in] unit  DBus object path of systemd unit to invoke
+ * \param[in,out] op    Action to execute
+ * \param[in]     unit  DBus object path of systemd unit to invoke
  */
 static void
 invoke_unit_by_path(svc_action_t *op, const char *unit)
@@ -1039,7 +1039,7 @@ systemd_timeout_callback(gpointer p)
  * \internal
  * \brief Execute a systemd action
  *
- * \param[in] op  Action to execute
+ * \param[in,out] op  Action to execute
  *
  * \return Standard Pacemaker return code
  * \retval EBUSY          Recurring operation could not be initiated

--- a/lib/services/upstart.c
+++ b/lib/services/upstart.c
@@ -41,7 +41,7 @@ static DBusConnection *upstart_proxy = NULL;
  * \internal
  * \brief Prepare an Upstart action
  *
- * \param[in] op  Action to prepare
+ * \param[in,out] op  Action to prepare
  *
  * \return Standard Pacemaker return code
  */
@@ -349,9 +349,9 @@ get_first_instance(const gchar * job, int timeout)
  * \internal
  * \brief Parse result of Upstart status check
  *
- * \param[in] name      DBus interface name for property that was checked
- * \param[in] state     Property value
- * \param[in] userdata  Status action that check was done for
+ * \param[in] name          DBus interface name for property that was checked
+ * \param[in] state         Property value
+ * \param[in,out] userdata  Status action that check was done for
  */
 static void
 parse_status_result(const char *name, const char *state, void *userdata)
@@ -401,8 +401,8 @@ upstart_job_metadata(const char *name)
  * \internal
  * \brief Set an action result based on a method error
  *
- * \param[in] op     Action to set result for
- * \param[in] error  Method error
+ * \param[in,out] op     Action to set result for
+ * \param[in]     error  Method error
  */
 static void
 set_result_from_method_error(svc_action_t *op, const DBusError *error)
@@ -441,8 +441,8 @@ set_result_from_method_error(svc_action_t *op, const DBusError *error)
  * \internal
  * \brief Process the completion of an asynchronous job start, stop, or restart
  *
- * \param[in] pending    If not NULL, DBus call associated with request
- * \param[in] user_data  Action that was executed
+ * \param[in,out] pending    If not NULL, DBus call associated with request
+ * \param[in,out] user_data  Action that was executed
  */
 static void
 job_method_complete(DBusPendingCall *pending, void *user_data)
@@ -500,7 +500,7 @@ job_method_complete(DBusPendingCall *pending, void *user_data)
  * \internal
  * \brief Execute an Upstart action
  *
- * \param[in] op  Action to execute
+ * \param[in,out] op  Action to execute
  *
  * \return Standard Pacemaker return code
  * \retval EBUSY          Recurring operation could not be initiated


### PR DESCRIPTION
This continues the project to clarify doxygen blocks and const pointers for function pointers in libraries. Functions documented in headers were handled previously; this handles functions documents in the source, for libcrmcommon, libcrmcluster, libcrmservice, liblrmd, and libstonithd.