### PR TITLE
Minor fixes and changes to XML logging functions

### DIFF
--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -769,14 +769,14 @@ G_GNUC_NULL_TERMINATED;
 
 /*!
  * \internal
- * \brief Add the given node as a child of the current list parent.  This is
- *        used when implementing custom message functions.
+ * \brief Add a copy of the given node as a child of the current list parent.
+ *        This is used when implementing custom message functions.
  *
  * \param[in,out] out  The output functions structure.
- * \param[in]     node An XML node to be added as a child.
+ * \param[in]     node An XML node to copy as a child.
  */
 void
-pcmk__output_xml_add_node(pcmk__output_t *out, xmlNodePtr node);
+pcmk__output_xml_add_node_copy(pcmk__output_t *out, xmlNodePtr node);
 
 /*!
  * \internal

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -904,6 +904,7 @@ void pcmk__output_and_clear_error(GError *error, pcmk__output_t *out);
 int pcmk__xml_output_new(pcmk__output_t **out, xmlNodePtr *xml);
 void pcmk__xml_output_finish(pcmk__output_t *out, xmlNodePtr *xml);
 int pcmk__log_output_new(pcmk__output_t **out);
+int pcmk__text_output_new(pcmk__output_t **out, const char *filename);
 
 #if defined(PCMK__UNIT_TESTING)
 /* If we are building libcrmcommon_test.a, add this accessor function so we can

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -80,9 +80,8 @@ xmlNode *pcmk__xml_match(const xmlNode *haystack, const xmlNode *needle,
                          bool exact);
 
 G_GNUC_INTERNAL
-void pcmk__xml_log(int log_level, const char *file, const char *function,
-                   int line, const char *prefix, const xmlNode *data, int depth,
-                   int options);
+void pcmk__xml_log(int log_level, const char *prefix, const xmlNode *data,
+                   int depth, int options);
 
 G_GNUC_INTERNAL
 void pcmk__xml_update(xmlNode *parent, xmlNode *target, xmlNode *update,

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -252,3 +252,32 @@ pcmk__log_output_new(pcmk__output_t **out)
     }
     return pcmk_rc_ok;
 }
+
+/*!
+ * \internal
+ * \brief Create a new output object using the "text" format
+ *
+ * \param[out] out       Where to store newly allocated output object
+ * \param[in]  filename  Name of output destination file
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+pcmk__text_output_new(pcmk__output_t **out, const char *filename)
+{
+    int rc = pcmk_rc_ok;
+    const char* argv[] = { "", NULL };
+    pcmk__supported_format_t formats[] = {
+        PCMK__SUPPORTED_FORMAT_TEXT,
+        { NULL, NULL, NULL }
+    };
+
+    pcmk__register_formats(NULL, formats);
+    rc = pcmk__output_new(out, "text", filename, (char **) argv);
+    if ((rc != pcmk_rc_ok) || (*out == NULL)) {
+        crm_err("Can't create text output object to internal error: %s",
+                pcmk_rc_str(rc));
+        return rc;
+    }
+    return pcmk_rc_ok;
+}

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -236,7 +236,6 @@ xml_subprocess_output(pcmk__output_t *out, int exit_status,
         crm_xml_add(child_node, "source", "stderr");
     }
 
-    pcmk__output_xml_add_node(out, node);
     free(rc_as_str);
 }
 

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -453,16 +453,21 @@ pcmk__output_xml_create_parent(pcmk__output_t *out, const char *name, ...) {
 }
 
 void
-pcmk__output_xml_add_node(pcmk__output_t *out, xmlNodePtr node) {
+pcmk__output_xml_add_node_copy(pcmk__output_t *out, xmlNodePtr node) {
     private_data_t *priv = NULL;
+    xmlNodePtr parent = NULL;
 
     CRM_ASSERT(out != NULL && out->priv != NULL);
     CRM_ASSERT(node != NULL);
     CRM_CHECK(pcmk__str_any_of(out->fmt_name, "xml", "html", NULL), return);
 
     priv = out->priv;
+    parent = g_queue_peek_tail(priv->parent_q);
 
-    xmlAddChild(g_queue_peek_tail(priv->parent_q), node);
+    // Shouldn't happen unless the caller popped priv->root
+    CRM_CHECK(parent != NULL, return);
+
+    add_node_copy(parent, copy_xml(node));
 }
 
 xmlNodePtr

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -895,6 +895,7 @@ copy_xml(xmlNode * src)
     xmlDoc *doc = xmlNewDoc((pcmkXmlStr) "1.0");
     xmlNode *copy = xmlDocCopyNode(src, doc, 1);
 
+    CRM_ASSERT(copy != NULL);
     xmlDocSetRootElement(doc, copy);
     xmlSetTreeDoc(copy, doc);
     return copy;

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1745,8 +1745,6 @@ log_data_element(int log_level, const char *file, const char *function,
                  int line, const char *prefix, const xmlNode *data, int depth,
                  int options)
 {
-    xmlNode *a_child = NULL;
-
     char *prefix_m = NULL;
 
     if (log_level == LOG_NEVER) {
@@ -1793,9 +1791,10 @@ log_data_element(int log_level, const char *file, const char *function,
     if (pcmk_is_set(options, xml_log_option_diff_short)
                && !pcmk_is_set(options, xml_log_option_diff_all)) {
         /* Still searching for the actual change */
-        for (a_child = pcmk__xml_first_child(data); a_child != NULL;
-             a_child = pcmk__xml_next(a_child)) {
-            log_data_element(log_level, file, function, line, prefix, a_child, depth + 1, options);
+        for (const xmlNode *child = pcmk__xml_first_child(data); child != NULL;
+             child = pcmk__xml_next(child)) {
+            log_data_element(log_level, file, function, line, prefix, child,
+                             depth + 1, options);
         }
     } else {
         pcmk__xml_log(log_level, prefix, data, depth,

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1756,7 +1756,7 @@ log_data_element(int log_level, const char *file, const char *function,
     }
 
     if (data == NULL) {
-        do_crm_log(log_level, "%s: No data to dump as XML", prefix);
+        do_crm_log(log_level, "%sNo data to dump as XML", prefix);
         return;
     }
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -2100,10 +2100,8 @@ dump_xml_formatted_with_text(xmlNode * an_xml_node)
                    xml_log_option_formatted|xml_log_option_full_fledged,
                    g_buffer, 0);
 
-    if (g_buffer != NULL) {
-        buffer = strdup((const char *) g_buffer->str);
-        g_string_free(g_buffer, TRUE);
-    }
+    pcmk__str_update(&buffer, g_buffer->str);
+    g_string_free(g_buffer, TRUE);
     return buffer;
 }
 
@@ -2115,10 +2113,8 @@ dump_xml_formatted(xmlNode * an_xml_node)
 
     pcmk__xml2text(an_xml_node, xml_log_option_formatted, g_buffer, 0);
 
-    if (g_buffer != NULL) {
-        buffer = strdup((const char *) g_buffer->str);
-        g_string_free(g_buffer, TRUE);
-    }
+    pcmk__str_update(&buffer, g_buffer->str);
+    g_string_free(g_buffer, TRUE);
     return buffer;
 }
 
@@ -2130,10 +2126,8 @@ dump_xml_unformatted(xmlNode * an_xml_node)
 
     pcmk__xml2text(an_xml_node, 0, g_buffer, 0);
 
-    if (g_buffer != NULL) {
-        buffer = strdup((const char *) g_buffer->str);
-        g_string_free(g_buffer, TRUE);
-    }
+    pcmk__str_update(&buffer, g_buffer->str);
+    g_string_free(g_buffer, TRUE);
     return buffer;
 }
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1758,27 +1758,33 @@ log_data_element(int log_level, const char *file, const char *function,
     }
 
     if (data == NULL) {
-        do_crm_log(log_level, "%s: %s", prefix, "No data to dump as XML");
+        do_crm_log(log_level, "%s: No data to dump as XML", prefix);
         return;
     }
 
     if (pcmk_is_set(options, xml_log_option_dirty_add)) {
+        // log_xml_changes() writes to index 1 of a copy of prefix
+        CRM_CHECK((prefix[0] != '\0') && (prefix[1] != '\0'), return);
         log_xml_changes(log_level, prefix, data, depth, options);
         return;
     }
 
     if (pcmk_is_set(options, xml_log_option_formatted)) {
         if (pcmk_is_set(options, xml_log_option_diff_plus)
-            && (data->children == NULL || crm_element_value(data, XML_DIFF_MARKER))) {
+            && ((data->children == NULL)
+                || (crm_element_value(data, XML_DIFF_MARKER) != NULL))) {
+            CRM_CHECK((prefix[0] != '\0') && (prefix[1] != '\0'), return);
             options |= xml_log_option_diff_all;
-            prefix_m = strdup(prefix);
+            pcmk__str_update(&prefix_m, prefix);
             prefix_m[1] = '+';
             prefix = prefix_m;
 
         } else if (pcmk_is_set(options, xml_log_option_diff_minus)
-                   && (data->children == NULL || crm_element_value(data, XML_DIFF_MARKER))) {
+                   && ((data->children == NULL)
+                       || (crm_element_value(data, XML_DIFF_MARKER) != NULL))) {
+            CRM_CHECK((prefix[0] != '\0') && (prefix[1] != '\0'), return);
             options |= xml_log_option_diff_all;
-            prefix_m = strdup(prefix);
+            pcmk__str_update(&prefix_m, prefix);
             prefix_m[1] = '-';
             prefix = prefix_m;
         }


### PR DESCRIPTION
This is in preparation for formatted output in XML logging, which in turn is the last missing piece for `crm_shadow` formatted output.

There are plans to use `pcmk__output_get_log_level()` and `pcmk__text_output_new()`.