### PR TITLE
XML logging best practices and log_data_element() deprecation

### DIFF
--- a/include/crm/common/logging.h
+++ b/include/crm/common/logging.h
@@ -131,10 +131,6 @@ void crm_enable_stderr(int enable);
 
 gboolean crm_is_callsite_active(struct qb_log_callsite *cs, uint8_t level, uint32_t tags);
 
-void log_data_element(int log_level, const char *file, const char *function,
-                      int line, const char *prefix, const xmlNode *data,
-                      int depth, gboolean formatted);
-
 /* returns the old value */
 unsigned int set_crm_log_level(unsigned int level);
 

--- a/include/crm/common/logging.h
+++ b/include/crm/common/logging.h
@@ -140,6 +140,8 @@ unsigned int set_crm_log_level(unsigned int level);
 
 unsigned int get_crm_log_level(void);
 
+void do_crm_log_xml(uint8_t level, const char *text, const xmlNode *xml);
+
 /*
  * Throughout the macros below, note the leading, pre-comma, space in the
  * various ' , ##args' occurrences to aid portability across versions of 'gcc'.
@@ -236,35 +238,6 @@ unsigned int get_crm_log_level(void);
 		        (core_cs? core_cs->targets: FALSE), TRUE);              \
 	        failure_action;						                        \
 	    }								                                \
-    } while(0)
-
-/*!
- * \brief Log XML line-by-line in a formatted fashion
- *
- * \param[in] level  Priority at which to log the messages
- * \param[in] text   Prefix for each line
- * \param[in] xml    XML to log
- *
- * \note This is a macro, and \p level may be evaluated more than once.
- *       This does nothing when level is LOG_STDOUT.
- */
-#  define do_crm_log_xml(level, text, xml) do {                             \
-        switch (level) {                                                    \
-            case LOG_STDOUT: case LOG_NEVER:                                \
-                break;                                                      \
-            default: {                                                      \
-                static struct qb_log_callsite *xml_cs = NULL;               \
-                if (xml_cs == NULL) {                                       \
-                    xml_cs = qb_log_callsite_get(__func__, __FILE__,        \
-                                        "xml-blob", (level), __LINE__, 0);  \
-                }                                                           \
-                if (crm_is_callsite_active(xml_cs, (level), 0)) {           \
-                    log_data_element((level), __FILE__, __func__,           \
-                         __LINE__, text, xml, 1, xml_log_option_formatted); \
-                }                                                           \
-            }                                                               \
-            break;                                                          \
-        }                                                                   \
     } while(0)
 
 /*!

--- a/include/crm/common/logging_compat.h
+++ b/include/crm/common/logging_compat.h
@@ -11,6 +11,7 @@
 #  define PCMK__CRM_COMMON_LOGGING_COMPAT__H
 
 #include <glib.h>
+#include <libxml/tree.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,6 +56,11 @@ gboolean crm_log_cli_init(const char *entity);
 
 //! \deprecated Do not use Pacemaker for general-purpose logging
 gboolean crm_add_logfile(const char *filename);
+
+//! \deprecated Do not use Pacemaker for general-purpose logging
+void log_data_element(int log_level, const char *file, const char *function,
+                      int line, const char *prefix, const xmlNode *data,
+                      int depth, gboolean formatted);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -285,7 +285,7 @@ void xml_track_changes(xmlNode * xml, const char *user, xmlNode *acl_source, boo
 void xml_calculate_changes(xmlNode *old_xml, xmlNode *new_xml);
 void xml_calculate_significant_changes(xmlNode *old_xml, xmlNode *new_xml);
 void xml_accept_changes(xmlNode * xml);
-void xml_log_changes(uint8_t level, const char *function, xmlNode *xml);
+void xml_log_changes(uint8_t level, const char *function, const xmlNode *xml);
 void xml_log_patchset(uint8_t level, const char *function, xmlNode *xml);
 bool xml_patch_versions(const xmlNode *patchset, int add[3], int del[3]);
 

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -286,7 +286,7 @@ void xml_calculate_changes(xmlNode *old_xml, xmlNode *new_xml);
 void xml_calculate_significant_changes(xmlNode *old_xml, xmlNode *new_xml);
 void xml_accept_changes(xmlNode * xml);
 void xml_log_changes(uint8_t level, const char *function, const xmlNode *xml);
-void xml_log_patchset(uint8_t level, const char *function, xmlNode *xml);
+void xml_log_patchset(uint8_t level, const char *function, const xmlNode *xml);
 bool xml_patch_versions(const xmlNode *patchset, int add[3], int del[3]);
 
 xmlNode *xml_create_patchset(

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -123,6 +123,9 @@ do {                                                                            
     }                                                                           \
 } while (0)
 
+void pcmk__xml_log(int log_level, const char *prefix, const xmlNode *data,
+                   int depth, int options);
+
 /* XML search strings for guest, remote and pacemaker_remote nodes */
 
 /* search string to find CIB resources entries for cluster nodes */

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -80,10 +80,6 @@ xmlNode *pcmk__xml_match(const xmlNode *haystack, const xmlNode *needle,
                          bool exact);
 
 G_GNUC_INTERNAL
-void pcmk__xml_log(int log_level, const char *prefix, const xmlNode *data,
-                   int depth, int options);
-
-G_GNUC_INTERNAL
 void pcmk__xml_update(xmlNode *parent, xmlNode *target, xmlNode *update,
                       bool as_diff);
 
@@ -250,6 +246,18 @@ pcmk__ipc_methods_t *pcmk__schedulerd_api_methods(void);
 /*
  * Logging
  */
+
+//! XML is newly created
+#define PCMK__XML_PREFIX_CREATED "++"
+
+//! XML has been deleted
+#define PCMK__XML_PREFIX_DELETED "--"
+
+//! XML has been modified
+#define PCMK__XML_PREFIX_MODIFIED "+ "
+
+//! XML has been moved
+#define PCMK__XML_PREFIX_MOVED "+~"
 
 /*!
  * \brief Check the authenticity of the IPC socket peer process

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -1099,6 +1099,47 @@ pcmk__cli_init_logging(const char *name, unsigned int verbosity)
     }
 }
 
+/*!
+ * \brief Log XML line-by-line in a formatted fashion
+ *
+ * \param[in] level  Priority at which to log the messages
+ * \param[in] text   Prefix for each line
+ * \param[in] xml    XML to log
+ *
+ * \note This does nothing when \p level is \p LOG_STDOUT.
+ */
+void
+do_crm_log_xml(uint8_t level, const char *text, const xmlNode *xml)
+{
+    static struct qb_log_callsite *xml_cs = NULL;
+
+    switch (level) {
+        case LOG_STDOUT:
+        case LOG_NEVER:
+            break;
+        default:
+            if (xml_cs == NULL) {
+                xml_cs = qb_log_callsite_get(__func__, __FILE__, "xml-blob",
+                                             level, __LINE__, 0);
+            }
+
+            if (crm_is_callsite_active(xml_cs, level, 0)) {
+                if (xml == NULL) {
+                    do_crm_log(level, "%s%sNo data to dump as XML",
+                               pcmk__s(text, ""),
+                               pcmk__str_empty(text)? "" : " ");
+                } else {
+                    pcmk__xml_log(level, text, xml, 1,
+                                  xml_log_option_formatted
+                                  |xml_log_option_open
+                                  |xml_log_option_children
+                                  |xml_log_option_close);
+                }
+            }
+            break;
+    }
+}
+
 // Deprecated functions kept only for backward API compatibility
 // LCOV_EXCL_START
 

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -522,6 +522,10 @@ xml_log_patchset_v1(uint8_t log_level, const xmlNode *patchset)
 
     xml_log_patchset_header(log_level, patchset);
 
+    /* It's not clear whether "- " or "+ " ever does *not* get overridden by
+     * "--" or "++" in practice. However, v1 patchsets can only exist during
+     * rolling upgrades from Pacemaker 1.1.11, so not worth worrying about.
+     */
     removed = find_xml_node(patchset, "diff-removed", FALSE);
     for (child = pcmk__xml_first_child(removed); child != NULL;
          child = pcmk__xml_next(child)) {

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -623,7 +623,8 @@ xml_log_patchset_v2(uint8_t log_level, const xmlNode *patchset)
         }
 
         if (strcmp(op, "create") == 0) {
-            char *prefix = crm_strdup_printf("++ %s: ", xpath);
+            char *prefix = crm_strdup_printf(PCMK__XML_PREFIX_CREATED " %s: ",
+                                             xpath);
 
             pcmk__xml_log(log_level, prefix, change->children, 0,
                           xml_log_option_formatted|xml_log_option_open);

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -656,7 +656,8 @@ xml_log_patchset_v2(uint8_t log_level, const xmlNode *patchset)
  * \param[in] patchset   XML patchset to log
  */
 void
-xml_log_patchset(uint8_t log_level, const char *function, xmlNode *patchset)
+xml_log_patchset(uint8_t log_level, const char *function,
+                 const xmlNode *patchset)
 {
     int format = 1;
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -413,33 +413,40 @@ pcmk__xml_match(const xmlNode *haystack, const xmlNode *needle, bool exact)
     }
 }
 
+/*!
+ * \brief Log changes to an XML node
+ *
+ * \param[in] log_level  Priority at which to log the message
+ * \param[in] function   Ignored
+ * \param[in] xml        XML node to log
+ */
 void
 xml_log_changes(uint8_t log_level, const char *function, const xmlNode *xml)
 {
-    GList *gIter = NULL;
     xml_doc_private_t *docpriv = NULL;
 
     if (log_level == LOG_NEVER) {
         return;
     }
 
-    CRM_ASSERT(xml);
-    CRM_ASSERT(xml->doc);
+    CRM_ASSERT(xml != NULL);
+    CRM_ASSERT(xml->doc != NULL);
 
     docpriv = xml->doc->_private;
     if (!pcmk_is_set(docpriv->flags, pcmk__xf_dirty)) {
         return;
     }
 
-    for(gIter = docpriv->deleted_objs; gIter; gIter = gIter->next) {
-        pcmk__deleted_xml_t *deleted_obj = gIter->data;
+    for (const GList *iter = docpriv->deleted_objs; iter != NULL;
+         iter = iter->next) {
+        const pcmk__deleted_xml_t *deleted_obj = iter->data;
 
         if (deleted_obj->position >= 0) {
-            do_crm_log(log_level, "-- %s (%d)",
+            do_crm_log(log_level, PREFIX_DELETED " %s (%d)",
                        deleted_obj->path, deleted_obj->position);
 
         } else {
-            do_crm_log(log_level, "-- %s", deleted_obj->path);
+            do_crm_log(log_level, PREFIX_DELETED " %s", deleted_obj->path);
         }
     }
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1632,7 +1632,9 @@ log_xml_element(GString *buffer, int log_level, const char *prefix,
             g_string_append(buffer, "/>");
         }
 
-        do_crm_log(log_level, "%s %s", prefix, buffer->str);
+        do_crm_log(log_level, "%s%s%s",
+                   pcmk__s(prefix, ""), pcmk__str_empty(prefix)? "" : " ",
+                   buffer->str);
     }
 
     if (!xml_has_children(data)) {
@@ -1651,7 +1653,9 @@ log_xml_element(GString *buffer, int log_level, const char *prefix,
     if (pcmk_is_set(options, xml_log_option_close)) {
         g_string_truncate(buffer, 0);
         insert_prefix(options, buffer, depth);
-        do_crm_log(log_level, "%s %s</%s>", prefix, buffer->str, name);
+        do_crm_log(log_level, "%s%s%s</%s>",
+                   pcmk__s(prefix, ""), pcmk__str_empty(prefix)? "" : " ",
+                   buffer->str, name);
     }
 }
 
@@ -1846,7 +1850,8 @@ log_data_element(int log_level, const char *file, const char *function,
     }
 
     if (data == NULL) {
-        do_crm_log(log_level, "%sNo data to dump as XML", prefix);
+        do_crm_log(log_level, "%s%sNo data to dump as XML",
+                   pcmk__s(prefix, ""), pcmk__str_empty(prefix)? "" : " ");
         return;
     }
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -75,7 +75,7 @@ pcmk__tracking_xml_changes(xmlNode *xml, bool lazy)
  * \param[in]     depth    Current indentation level
  */
 static inline void
-insert_prefix(int options, GString *buffer, int depth)
+insert_spaces(int options, GString *buffer, int depth)
 {
     int spaces = 0;
 
@@ -1553,7 +1553,7 @@ log_xml_comment(GString *buffer, int log_level, const xmlNode *data,
     if (pcmk_is_set(options, xml_log_option_open)) {
         g_string_truncate(buffer, 0);
 
-        insert_prefix(options, buffer, depth);
+        insert_spaces(options, buffer, depth);
         do_crm_log(log_level, "%s<!--%s-->",
                    buffer->str, (const char *) data->content);
     }
@@ -1588,7 +1588,7 @@ log_xml_element(GString *buffer, int log_level, const char *prefix,
         const char *hidden = crm_element_value(data, "hidden");
 
         g_string_truncate(buffer, 0);
-        insert_prefix(options, buffer, depth);
+        insert_spaces(options, buffer, depth);
         pcmk__g_strcat(buffer, "<", name, NULL);
 
         for (const xmlAttr *attr = pcmk__xe_first_attr(data); attr != NULL;
@@ -1650,7 +1650,7 @@ log_xml_element(GString *buffer, int log_level, const char *prefix,
 
     if (pcmk_is_set(options, xml_log_option_close)) {
         g_string_truncate(buffer, 0);
-        insert_prefix(options, buffer, depth);
+        insert_spaces(options, buffer, depth);
         do_crm_log(log_level, "%s%s%s</%s>",
                    pcmk__s(prefix, ""), pcmk__str_empty(prefix)? "" : " ",
                    buffer->str, name);
@@ -1866,7 +1866,7 @@ dump_xml_element(const xmlNode *data, int options, GString *buffer, int depth)
     name = crm_element_name(data);
     CRM_ASSERT(name != NULL);
 
-    insert_prefix(options, buffer, depth);
+    insert_spaces(options, buffer, depth);
     pcmk__g_strcat(buffer, "<", name, NULL);
 
     if (options & xml_log_option_filtered) {
@@ -1897,7 +1897,7 @@ dump_xml_element(const xmlNode *data, int options, GString *buffer, int depth)
             pcmk__xml2text(xChild, options, buffer, depth + 1);
         }
 
-        insert_prefix(options, buffer, depth);
+        insert_spaces(options, buffer, depth);
         pcmk__g_strcat(buffer, "</", name, ">", NULL);
 
         if (pcmk_is_set(options, xml_log_option_formatted)) {
@@ -1925,7 +1925,7 @@ dump_xml_text(const xmlNode *data, int options, GString *buffer, int depth)
         return;
     }
 
-    insert_prefix(options, buffer, depth);
+    insert_spaces(options, buffer, depth);
     g_string_append(buffer, (const gchar *) data->content);
 
     if (pcmk_is_set(options, xml_log_option_formatted)) {
@@ -1952,7 +1952,7 @@ dump_xml_cdata(const xmlNode *data, int options, GString *buffer, int depth)
         return;
     }
 
-    insert_prefix(options, buffer, depth);
+    insert_spaces(options, buffer, depth);
     pcmk__g_strcat(buffer, "<![CDATA[", (const char *) data->content, "]]>",
                    NULL);
 
@@ -1980,7 +1980,7 @@ dump_xml_comment(const xmlNode *data, int options, GString *buffer, int depth)
         return;
     }
 
-    insert_prefix(options, buffer, depth);
+    insert_spaces(options, buffer, depth);
     pcmk__g_strcat(buffer, "<!--", (const char *) data->content, "-->", NULL);
 
     if (pcmk_is_set(options, xml_log_option_formatted)) {

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -407,7 +407,7 @@ pcmk__xml_match(const xmlNode *haystack, const xmlNode *needle, bool exact)
 }
 
 void
-xml_log_changes(uint8_t log_level, const char *function, xmlNode * xml)
+xml_log_changes(uint8_t log_level, const char *function, const xmlNode *xml)
 {
     GList *gIter = NULL;
     xml_doc_private_t *docpriv = NULL;

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -2658,7 +2658,7 @@ pcmk__xc_update(xmlNode *parent, xmlNode *target, xmlNode *update)
  * \param[in]     update   Make the desired XML match this (must not be NULL)
  * \param[in]     as_diff  If false, expand "++" when making attributes match
  *
- * \note At least one of \parent and \target must be non-NULL
+ * \note At least one of \p parent and \p target must be non-NULL
  */
 void
 pcmk__xml_update(xmlNode *parent, xmlNode *target, xmlNode *update,


### PR DESCRIPTION
When we add formatted output support to XML logging, these changes will make it much easier to reason about.