### PR TITLE
Fix: fenced: use enum fenced_target_by consistently

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2022 the Pacemaker project contributors
+ * Copyright 2009-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1603,7 +1603,7 @@ stonith_level_key(const xmlNode *level, enum fenced_target_by mode)
  *
  * \return How to identify target of \p level
  */
-static int
+static enum fenced_target_by
 unpack_level_kind(const xmlNode *level)
 {
     if (crm_element_value(level, XML_ATTR_STONITH_TARGET) != NULL) {

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2022 the Pacemaker project contributors
+ * Copyright 2009-2023 the Pacemaker project contributors
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -223,7 +223,7 @@ int stonith_device_register(xmlNode *msg, gboolean from_cib);
 
 void stonith_device_remove(const char *id, bool from_cib);
 
-char *stonith_level_key(const xmlNode *msg, int mode);
+char *stonith_level_key(const xmlNode *msg, enum fenced_target_by);
 void fenced_register_level(xmlNode *msg, char **desc,
                            pcmk__action_result_t *result);
 void fenced_unregister_level(xmlNode *msg, char **desc,


### PR DESCRIPTION
seems not to be covered by any of the open PRs.
guess it is new gcc being more picky.