### PR TITLE
Replace pcmk__log_else() with pcmk__if_tracing()

### DIFF
--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -667,7 +667,7 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
         if (docpriv->acls == NULL) {
             pcmk__set_xml_doc_flag(xml, pcmk__xf_acl_denied);
 
-            pcmk__log_else(LOG_TRACE, return false);
+            pcmk__if_tracing({}, return false);
             xpath = pcmk__element_xpath(xml);
             if (name != NULL) {
                 pcmk__g_strcat(xpath, "[@", name, "]", NULL);
@@ -703,7 +703,7 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
             } else if (pcmk_is_set(nodepriv->flags, pcmk__xf_acl_deny)) {
                 pcmk__set_xml_doc_flag(xml, pcmk__xf_acl_denied);
 
-                pcmk__log_else(LOG_TRACE, return false);
+                pcmk__if_tracing({}, return false);
                 xpath = pcmk__element_xpath(xml);
                 if (name != NULL) {
                     pcmk__g_strcat(xpath, "[@", name, "]", NULL);
@@ -723,7 +723,7 @@ pcmk__check_acl(xmlNode *xml, const char *name, enum xml_private_flags mode)
 
         pcmk__set_xml_doc_flag(xml, pcmk__xf_acl_denied);
 
-        pcmk__log_else(LOG_TRACE, return false);
+        pcmk__if_tracing({}, return false);
         xpath = pcmk__element_xpath(xml);
         if (name != NULL) {
             pcmk__g_strcat(xpath, "[@", name, "]", NULL);

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -242,27 +242,21 @@ pcmk__apply_acl(xmlNode *xml)
         max = numXpathResults(xpathObj);
 
         for (lpc = 0; lpc < max; lpc++) {
-            static struct qb_log_callsite *trace_cs = NULL;
             xmlNode *match = getXpathResult(xpathObj, lpc);
 
             nodepriv = match->_private;
             pcmk__set_xml_flags(nodepriv, acl->mode);
 
-            /* Build a GString only if tracing is enabled.
-             * Can't use pcmk__log_else() because the else_action would be
-             * continue.
-             */
-            if (trace_cs == NULL) {
-                trace_cs = qb_log_callsite_get(__func__, __FILE__, "apply_acl",
-                                               LOG_TRACE, __LINE__, 0);
-            }
-            if (crm_is_callsite_active(trace_cs, LOG_TRACE, 0)) {
-                GString *path = pcmk__element_xpath(match);
-                crm_trace("Applying %s ACL to %s matched by %s",
-                          acl_to_text(acl->mode), (const char *) path->str,
-                          acl->xpath);
-                g_string_free(path, TRUE);
-            }
+            // Build a GString only if tracing is enabled
+            pcmk__if_tracing(
+                {
+                    GString *path = pcmk__element_xpath(match);
+                    crm_trace("Applying %s ACL to %s matched by %s",
+                              acl_to_text(acl->mode), path->str, acl->xpath);
+                    g_string_free(path, TRUE);
+                },
+                {}
+            );
         }
         crm_trace("Applied %s ACL %s (%d match%s)",
                   acl_to_text(acl->mode), acl->xpath, max,

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -1480,32 +1480,22 @@ xml_apply_patchset(xmlNode *xml, xmlNode *patchset, bool check_version)
     }
 
     if ((rc == pcmk_ok) && (digest != NULL)) {
-        static struct qb_log_callsite *digest_cs = NULL;
-
         char *new_digest = NULL;
         char *version = crm_element_value_copy(xml, XML_ATTR_CRM_VERSION);
-
-        if (digest_cs == NULL) {
-            digest_cs = qb_log_callsite_get(__func__, __FILE__, "diff-digest",
-                                            LOG_TRACE, __LINE__,
-                                            crm_trace_nonlog);
-        }
 
         new_digest = calculate_xml_versioned_digest(xml, FALSE, TRUE, version);
         if (!pcmk__str_eq(new_digest, digest, pcmk__str_casei)) {
             crm_info("v%d digest mis-match: expected %s, calculated %s",
                      format, digest, new_digest);
             rc = -pcmk_err_diff_failed;
-
-            if ((digest_cs != NULL) && digest_cs->targets) {
-                save_xml_to_file(old,      "PatchDigest:input",  NULL);
-                save_xml_to_file(xml,      "PatchDigest:result", NULL);
-                save_xml_to_file(patchset, "PatchDigest:diff",   NULL);
-
-            } else {
-                crm_trace("%p %.6x", digest_cs,
-                          ((digest_cs != NULL)? digest_cs->targets : 0));
-            }
+            pcmk__if_tracing(
+                {
+                    save_xml_to_file(old, "PatchDigest:input", NULL);
+                    save_xml_to_file(xml, "PatchDigest:result", NULL);
+                    save_xml_to_file(patchset, "PatchDigest:diff", NULL);
+                },
+                {}
+            );
 
         } else {
             crm_trace("v%d digest matched: expected %s, calculated %s",

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -767,7 +767,7 @@ free_xml_with_position(xmlNode * child, int position)
         } else if (pcmk__check_acl(child, NULL, pcmk__xf_acl_write) == FALSE) {
             GString *xpath = NULL;
 
-            pcmk__log_else(LOG_TRACE, return);
+            pcmk__if_tracing({}, return);
             xpath = pcmk__element_xpath(child);
             qb_log_from_external_source(__func__, __FILE__,
                                         "Cannot remove %s %x", LOG_TRACE,

--- a/lib/common/xml_display.c
+++ b/lib/common/xml_display.c
@@ -25,23 +25,20 @@ void
 pcmk__log_xmllib_err(void *ctx, const char *fmt, ...)
 {
     va_list ap;
-    static struct qb_log_callsite *xml_error_cs = NULL;
-
-    if (xml_error_cs == NULL) {
-        xml_error_cs = qb_log_callsite_get(__func__, __FILE__,
-                                           "xml library error", LOG_TRACE,
-                                           __LINE__, crm_trace_nonlog);
-    }
 
     va_start(ap, fmt);
-    if ((xml_error_cs != NULL) && (xml_error_cs->targets != 0)) {
-        PCMK__XML_LOG_BASE(LOG_ERR, TRUE,
-                           crm_abort(__FILE__, __PRETTY_FUNCTION__, __LINE__,
-                                     "xml library error", TRUE, TRUE),
-                           "XML Error: ", fmt, ap);
-    } else {
-        PCMK__XML_LOG_BASE(LOG_ERR, TRUE, 0, "XML Error: ", fmt, ap);
-    }
+    pcmk__if_tracing(
+        {
+            PCMK__XML_LOG_BASE(LOG_ERR, TRUE,
+                               crm_abort(__FILE__, __PRETTY_FUNCTION__,
+                                         __LINE__, "xml library error", TRUE,
+                                         TRUE),
+                               "XML Error: ", fmt, ap);
+        },
+        {
+            PCMK__XML_LOG_BASE(LOG_ERR, TRUE, 0, "XML Error: ", fmt, ap);
+        }
+    );
     va_end(ap);
 }
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -246,7 +246,7 @@ pe__log_node_weights(const char *file, const char *function, int line,
     pe_node_t *node = NULL;
 
     // Don't waste time if we're not tracing at this point
-    pcmk__log_else(LOG_TRACE, return);
+    pcmk__if_tracing({}, return);
 
     g_hash_table_iter_init(&iter, nodes);
     while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {


### PR DESCRIPTION
This was on the to-do list anyway, and it simplifies converting the `pcmk__xml_log_changes()` call in `cib_perform_op` to use a `pcmk__output_t` argument (part of a WIP).

Feel free to nitpick the format I used in the callers. It was the least ugly way I found.

Note that in several places I treated an existing `if ((cs != NULL) && (cs->targets != 0))` as equivalent to `crm_is_callsite_active()`. The latter can also refilter but otherwise they seem to be the same. That allows us to use `pcmk__if_tracing()` in more places than we otherwise could.

I also got rid of a full log message that seems useless as well as a piece of another one.

Closes T559