### PR TITLE
Continue adding pcmk__output_t to XML display functions

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -357,23 +357,14 @@ process_ping_reply(xmlNode *reply)
 
             if(remote_cib && remote_cib->children) {
                 // Additional debug
-                int rc = pcmk_rc_ok;
-
-                /* Unclear whether this is needed for its side effects (it may
-                 * mark the_cib with pcmk__xf_skip) if we can't log the changes
-                 */
-                xml_calculate_changes(the_cib, remote_cib);
-
                 if (logger_out == NULL) {
-                    rc = pcmk__log_output_new(&logger_out);
-                    CRM_LOG_ASSERT(rc == pcmk_rc_ok);
+                    CRM_CHECK(pcmk__log_output_new(&logger_out) == pcmk_rc_ok,
+                              {free_xml(remote_cib); return;});
                 }
-
-                if (rc == pcmk_rc_ok) {
-                    pcmk__output_set_log_level(logger_out, LOG_INFO);
-                    pcmk__xml_show_changes(logger_out, remote_cib);
-                    crm_trace("End of differences");
-                }
+                pcmk__output_set_log_level(logger_out, LOG_INFO);
+                xml_calculate_changes(the_cib, remote_cib);
+                pcmk__xml_show_changes(logger_out, remote_cib);
+                crm_trace("End of differences");
             }
 
             free_xml(remote_cib);

--- a/include/crm/common/logging_internal.h
+++ b/include/crm/common/logging_internal.h
@@ -61,7 +61,8 @@ extern "C" {
                                            "if_tracing", LOG_TRACE,     \
                                            __LINE__, crm_trace_nonlog); \
         }                                                               \
-        if (crm_is_callsite_active(trace_cs, LOG_TRACE, 0)) {           \
+        if (crm_is_callsite_active(trace_cs, LOG_TRACE,                 \
+                                   crm_trace_nonlog)) {                 \
             if_action;                                                  \
         } else {                                                        \
             else_action;                                                \

--- a/include/crm/common/logging_internal.h
+++ b/include/crm/common/logging_internal.h
@@ -14,6 +14,8 @@ extern "C" {
 #ifndef PCMK__LOGGING_INTERNAL_H
 #  define PCMK__LOGGING_INTERNAL_H
 
+#  include <crm/common/logging.h>
+
 /*!
  * \internal
  * \brief Log a configuration error

--- a/include/crm/common/logging_internal.h
+++ b/include/crm/common/logging_internal.h
@@ -81,6 +81,8 @@ void pcmk__cli_init_logging(const char *name, unsigned int verbosity);
 
 int pcmk__add_logfile(const char *filename);
 
+void pcmk__free_common_logger(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the Pacemaker project contributors
+ * Copyright 2019-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -736,6 +736,17 @@ pcmk__formatted_vprintf(pcmk__output_t *out, const char *format, va_list args) G
  */
 void
 pcmk__text_prompt(const char *prompt, bool echo, char **dest);
+
+/*!
+ * \internal
+ * \brief Get the log level used by the formatted output logger
+ *
+ * \param[in] out  Output object
+ *
+ * \return Log level used by \p out
+ */
+int
+pcmk__output_get_log_level(const pcmk__output_t *out);
 
 /*!
  * \internal

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -166,7 +166,7 @@ enum pcmk__xml_fmt_options {
 
 void pcmk__xml_show(pcmk__output_t *out, const char *prefix,
                     const xmlNode *data, int depth, uint32_t options);
-void pcmk__xml_log_changes(uint8_t log_level, const xmlNode *xml);
+void pcmk__xml_show_changes(pcmk__output_t *out, const xmlNode *xml);
 void pcmk__xml_log_patchset(uint8_t log_level, const xmlNode *patchset);
 
 /* XML search strings for guest, remote and pacemaker_remote nodes */

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -164,7 +164,7 @@ enum pcmk__xml_fmt_options {
     pcmk__xml_fmt_diff_short = (1 << 9),
 };
 
-void pcmk__xml_show(pcmk__output_t *out, int log_level, const char *prefix,
+void pcmk__xml_show(pcmk__output_t *out, const char *prefix,
                     const xmlNode *data, int depth, uint32_t options);
 void pcmk__xml_log_changes(uint8_t log_level, const xmlNode *xml);
 void pcmk__xml_log_patchset(uint8_t log_level, const xmlNode *patchset);

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -19,6 +19,7 @@
 #  include <string.h>
 
 #  include <crm/crm.h>  /* transitively imports qblog.h */
+#  include <crm/common/output_internal.h>
 
 
 /*!
@@ -163,8 +164,8 @@ enum pcmk__xml_fmt_options {
     pcmk__xml_fmt_diff_short = (1 << 9),
 };
 
-void pcmk__xml_log(int log_level, const char *prefix, const xmlNode *data,
-                   int depth, uint32_t options);
+void pcmk__xml_show(pcmk__output_t *out, int log_level, const char *prefix,
+                    const xmlNode *data, int depth, uint32_t options);
 void pcmk__xml_log_changes(uint8_t log_level, const xmlNode *xml);
 void pcmk__xml_log_patchset(uint8_t log_level, const xmlNode *patchset);
 

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -154,7 +154,6 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
     xmlNode *local_diff = NULL;
 
     const char *new_version = NULL;
-    static struct qb_log_callsite *diff_cs = NULL;
     const char *user = crm_element_value(req, F_CIB_USER);
     bool with_digest = FALSE;
 
@@ -338,10 +337,6 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
     );
     xml_accept_changes(scratch);
 
-    if (diff_cs == NULL) {
-        diff_cs = qb_log_callsite_get(__PRETTY_FUNCTION__, __FILE__, "diff-validation", LOG_DEBUG, __LINE__, crm_trace_nonlog);
-    }
-
     if(local_diff) {
         patchset_process_digest(local_diff, current_cib, scratch, with_digest);
 
@@ -349,25 +344,33 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
         crm_log_xml_trace(local_diff, "raw patch");
     }
 
-    if (!pcmk_is_set(call_options, cib_zero_copy) // Original to compare against doesn't exist
-        && local_diff
-        && crm_is_callsite_active(diff_cs, LOG_TRACE, 0)) {
+    if (!pcmk_is_set(call_options, cib_zero_copy) && (local_diff != NULL)) {
+        // Original to compare against doesn't exist
+        pcmk__if_tracing(
+            {
+                // Validate the calculated patch set
+                int test_rc = pcmk_ok;
+                int format = 1;
+                xmlNode *cib_copy = copy_xml(current_cib);
 
-        /* Validate the calculated patch set */
-        int test_rc, format = 1;
-        xmlNode * c = copy_xml(current_cib);
+                crm_element_value_int(local_diff, "format", &format);
+                test_rc = xml_apply_patchset(cib_copy, local_diff,
+                                             manage_counters);
 
-        crm_element_value_int(local_diff, "format", &format);
-        test_rc = xml_apply_patchset(c, local_diff, manage_counters);
-
-        if(test_rc != pcmk_ok) {
-            save_xml_to_file(c,           "PatchApply:calculated", NULL);
-            save_xml_to_file(current_cib, "PatchApply:input", NULL);
-            save_xml_to_file(scratch,     "PatchApply:actual", NULL);
-            save_xml_to_file(local_diff,  "PatchApply:diff", NULL);
-            crm_err("v%d patchset error, patch failed to apply: %s (%d)", format, pcmk_strerror(test_rc), test_rc);
-        }
-        free_xml(c);
+                if (test_rc != pcmk_ok) {
+                    save_xml_to_file(cib_copy, "PatchApply:calculated", NULL);
+                    save_xml_to_file(current_cib, "PatchApply:input", NULL);
+                    save_xml_to_file(scratch, "PatchApply:actual", NULL);
+                    save_xml_to_file(local_diff, "PatchApply:diff", NULL);
+                    crm_err("v%d patchset error, patch failed to apply: %s "
+                            "(%d)",
+                            format, pcmk_rc_str(pcmk_legacy2rc(test_rc)),
+                            test_rc);
+                }
+                free_xml(cib_copy);
+            },
+            {}
+        );
     }
 
     if (pcmk__str_eq(section, XML_CIB_TAG_STATUS, pcmk__str_casei)) {

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -323,15 +323,14 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
     pcmk__if_tracing(
         {
             pcmk__output_t *out = NULL;
-            int rc = pcmk__log_output_new(&out);
+            rc = pcmk_rc2legacy(pcmk__log_output_new(&out));
 
-            CRM_LOG_ASSERT(rc == pcmk_rc_ok);
-            if (rc == pcmk_rc_ok) {
-                pcmk__output_set_log_level(out, LOG_TRACE);
-                pcmk__xml_show_changes(out, scratch);
-                out->finish(out, CRM_EX_OK, true, NULL);
-                pcmk__output_free(out);
-            }
+            CRM_CHECK(rc == pcmk_ok, goto done);
+
+            pcmk__output_set_log_level(out, LOG_TRACE);
+            pcmk__xml_show_changes(out, scratch);
+            out->finish(out, CRM_EX_OK, true, NULL);
+            pcmk__output_free(out);
         },
         {}
     );

--- a/lib/common/digest.c
+++ b/lib/common/digest.c
@@ -94,30 +94,27 @@ calculate_xml_digest_v2(xmlNode *source, gboolean do_filter)
     char *digest = NULL;
     GString *buffer = g_string_sized_new(1024);
 
-    static struct qb_log_callsite *digest_cs = NULL;
-
     crm_trace("Begin digest %s", do_filter?"filtered":"");
     pcmk__xml2text(source, (do_filter? pcmk__xml_fmt_filtered : 0), buffer, 0);
 
     CRM_ASSERT(buffer != NULL);
     digest = crm_md5sum((const char *) buffer->str);
 
-    if (digest_cs == NULL) {
-        digest_cs = qb_log_callsite_get(__func__, __FILE__, "cib-digest", LOG_TRACE, __LINE__,
-                                        crm_trace_nonlog);
-    }
-    if (digest_cs && digest_cs->targets) {
-        char *trace_file = crm_strdup_printf("%s/digest-%s",
-                                             pcmk__get_tmpdir(), digest);
+    pcmk__if_tracing(
+        {
+            char *trace_file = crm_strdup_printf("%s/digest-%s",
+                                                 pcmk__get_tmpdir(), digest);
 
-        crm_trace("Saving %s.%s.%s to %s",
-                  crm_element_value(source, XML_ATTR_GENERATION_ADMIN),
-                  crm_element_value(source, XML_ATTR_GENERATION),
-                  crm_element_value(source, XML_ATTR_NUMUPDATES), trace_file);
-        save_xml_to_file(source, "digest input", trace_file);
-        free(trace_file);
-    }
-
+            crm_trace("Saving %s.%s.%s to %s",
+                      crm_element_value(source, XML_ATTR_GENERATION_ADMIN),
+                      crm_element_value(source, XML_ATTR_GENERATION),
+                      crm_element_value(source, XML_ATTR_NUMUPDATES),
+                      trace_file);
+            save_xml_to_file(source, "digest input", trace_file);
+            free(trace_file);
+        },
+        {}
+    );
     g_string_free(buffer, TRUE);
     crm_trace("End digest");
     return digest;

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -66,12 +66,11 @@ crm_glib_handler(const gchar * log_domain, GLogLevelFlags flags, const gchar * m
                                       LOG_DEBUG, __LINE__, crm_trace_nonlog);
     }
 
-
     switch (msg_level) {
         case G_LOG_LEVEL_CRITICAL:
             log_level = LOG_CRIT;
 
-            if (crm_is_callsite_active(glib_cs, LOG_DEBUG, 0) == FALSE) {
+            if (!crm_is_callsite_active(glib_cs, LOG_DEBUG, crm_trace_nonlog)) {
                 /* log and record how we got here */
                 crm_abort(__FILE__, __func__, __LINE__, message, TRUE, TRUE);
             }

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1107,36 +1107,21 @@ pcmk__cli_init_logging(const char *name, unsigned int verbosity)
  * \param[in] xml    XML to log
  *
  * \note This does nothing when \p level is \p LOG_STDOUT.
+ * \note Do not call this function directly. It should be called only from the
+ *       \p do_crm_log_xml() macro.
  */
 void
-do_crm_log_xml(uint8_t level, const char *text, const xmlNode *xml)
+pcmk_log_xml_impl(uint8_t level, const char *text, const xmlNode *xml)
 {
-    static struct qb_log_callsite *xml_cs = NULL;
-
-    switch (level) {
-        case LOG_STDOUT:
-        case LOG_NEVER:
-            break;
-        default:
-            if (xml_cs == NULL) {
-                xml_cs = qb_log_callsite_get(__func__, __FILE__, "xml-blob",
-                                             level, __LINE__, 0);
-            }
-
-            if (crm_is_callsite_active(xml_cs, level, 0)) {
-                if (xml == NULL) {
-                    do_crm_log(level, "%s%sNo data to dump as XML",
-                               pcmk__s(text, ""),
-                               pcmk__str_empty(text)? "" : " ");
-                } else {
-                    pcmk__xml_log(level, text, xml, 1,
-                                  pcmk__xml_fmt_pretty
-                                  |pcmk__xml_fmt_open
-                                  |pcmk__xml_fmt_children
-                                  |pcmk__xml_fmt_close);
-                }
-            }
-            break;
+    if (xml == NULL) {
+        do_crm_log(level, "%s%sNo data to dump as XML",
+                   pcmk__s(text, ""), pcmk__str_empty(text)? "" : " ");
+    } else {
+        pcmk__xml_log(level, text, xml, 1,
+                      pcmk__xml_fmt_pretty
+                      |pcmk__xml_fmt_open
+                      |pcmk__xml_fmt_children
+                      |pcmk__xml_fmt_close);
     }
 }
 

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -1124,7 +1124,7 @@ pcmk_log_xml_impl(uint8_t level, const char *text, const xmlNode *xml)
         }
 
         pcmk__output_set_log_level(logger_out, level);
-        pcmk__xml_show(logger_out, 0, text, xml, 1,
+        pcmk__xml_show(logger_out, text, xml, 1,
                        pcmk__xml_fmt_pretty
                        |pcmk__xml_fmt_open
                        |pcmk__xml_fmt_children

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -1117,11 +1117,11 @@ pcmk_log_xml_impl(uint8_t level, const char *text, const xmlNode *xml)
         do_crm_log(level, "%s%sNo data to dump as XML",
                    pcmk__s(text, ""), pcmk__str_empty(text)? "" : " ");
     } else {
-        pcmk__xml_log(level, text, xml, 1,
-                      pcmk__xml_fmt_pretty
-                      |pcmk__xml_fmt_open
-                      |pcmk__xml_fmt_children
-                      |pcmk__xml_fmt_close);
+        pcmk__xml_show(NULL, level, text, xml, 1,
+                       pcmk__xml_fmt_pretty
+                       |pcmk__xml_fmt_open
+                       |pcmk__xml_fmt_children
+                       |pcmk__xml_fmt_close);
     }
 }
 

--- a/lib/common/output_log.c
+++ b/lib/common/output_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the Pacemaker project contributors
+ * Copyright 2019-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -327,6 +327,18 @@ pcmk__mk_log_output(char **argv) {
     retval->prompt = log_prompt;
 
     return retval;
+}
+
+int
+pcmk__output_get_log_level(const pcmk__output_t *out)
+{
+    private_data_t *priv = NULL;
+
+    CRM_ASSERT((out != NULL) && (out->priv != NULL));
+    CRM_CHECK(pcmk__str_eq(out->fmt_name, "log", pcmk__str_none), return 0);
+
+    priv = out->priv;
+    return priv->log_level;
 }
 
 void

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -528,7 +528,7 @@ xml_show_patchset_v1_recursive(pcmk__output_t *out, const char *prefix,
         }
 
     } else {
-        pcmk__xml_show(out, 0, prefix, data, depth,
+        pcmk__xml_show(out, prefix, data, depth,
                        options
                        |pcmk__xml_fmt_open
                        |pcmk__xml_fmt_children
@@ -622,7 +622,7 @@ xml_show_patchset_v2(pcmk__output_t *out, const xmlNode *patchset)
             char *prefix = crm_strdup_printf(PCMK__XML_PREFIX_CREATED " %s: ",
                                              xpath);
 
-            pcmk__xml_show(out, 0, prefix, change->children, 0,
+            pcmk__xml_show(out, prefix, change->children, 0,
                            pcmk__xml_fmt_pretty|pcmk__xml_fmt_open);
 
             // Overwrite all except the first two characters with spaces
@@ -630,7 +630,7 @@ xml_show_patchset_v2(pcmk__output_t *out, const xmlNode *patchset)
                 *ch = ' ';
             }
 
-            pcmk__xml_show(out, 0, prefix, change->children, 0,
+            pcmk__xml_show(out, prefix, change->children, 0,
                            pcmk__xml_fmt_pretty
                            |pcmk__xml_fmt_children
                            |pcmk__xml_fmt_close);

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -454,11 +454,10 @@ patchset_process_digest(xmlNode *patch, xmlNode *source, xmlNode *target,
 
 /*!
  * \internal
- * \brief Log an XML patchset header
+ * \brief Output an XML patchset header
  *
  * This function parses a header from an XML patchset (an \p XML_ATTR_DIFF
- * element and its children). Depending on the value of \p log_level, the output
- * may be written to \p stdout or to a log file.
+ * element and its children).
  *
  * All header lines contain three integers separated by dots, of the form
  * <tt>{0}.{1}.{2}</tt>:
@@ -470,11 +469,11 @@ patchset_process_digest(xmlNode *patch, xmlNode *source, xmlNode *target,
  * number. Lines containing \p "+++" describe additions and end with the patch
  * digest.
  *
- * \param[in] log_level  Priority at which to log the messages
- * \param[in] patchset   XML patchset to log
+ * \param[in,out] out       Output object
+ * \param[in]     patchset  XML patchset to output
  */
 static void
-xml_log_patchset_header(uint8_t log_level, const xmlNode *patchset)
+xml_show_patchset_header(pcmk__output_t *out, const xmlNode *patchset)
 {
     int add[] = { 0, 0, 0 };
     int del[] = { 0, 0, 0 };
@@ -485,30 +484,27 @@ xml_log_patchset_header(uint8_t log_level, const xmlNode *patchset)
         const char *fmt = crm_element_value(patchset, "format");
         const char *digest = crm_element_value(patchset, XML_ATTR_DIGEST);
 
-        do_crm_log(log_level, "Diff: --- %d.%d.%d %s",
-                   del[0], del[1], del[2], fmt);
-        do_crm_log(log_level, "Diff: +++ %d.%d.%d %s",
-                   add[0], add[1], add[2], digest);
+        out->info(out, "Diff: --- %d.%d.%d %s", del[0], del[1], del[2], fmt);
+        out->info(out, "Diff: +++ %d.%d.%d %s", add[0], add[1], add[2], digest);
 
     } else if ((add[0] != 0) || (add[1] != 0) || (add[2] != 0)) {
-        do_crm_log(log_level, "Local-only Change: %d.%d.%d",
-                   add[0], add[1], add[2]);
+        out->info(out, "Local-only Change: %d.%d.%d", add[0], add[1], add[2]);
     }
 }
 
 /*!
  * \internal
- * \brief Log a user-friendly form of XML additions or removals
+ * \brief Output a user-friendly form of XML additions or removals
  *
- * \param[in] log_level  Priority at which to log the messages
- * \param[in] prefix     String to prepend to every line of output
- * \param[in] data       XML node to log
- * \param[in] depth      Current indentation level
- * \param[in] options    Group of \p pcmk__xml_fmt_options flags
+ * \param[in,out] out      Output object
+ * \param[in]     prefix   String to prepend to every line of output
+ * \param[in]     data     XML node to output
+ * \param[in]     depth    Current indentation level
+ * \param[in]     options  Group of \p pcmk__xml_fmt_options flags
  */
 static void
-xml_log_patchset_v1_recursive(uint8_t log_level, const char *prefix,
-                              const xmlNode *data, int depth, uint32_t options)
+xml_show_patchset_v1_recursive(pcmk__output_t *out, const char *prefix,
+                               const xmlNode *data, int depth, uint32_t options)
 {
     if (!xml_has_children(data)
         || (crm_element_value(data, XML_DIFF_MARKER) != NULL)) {
@@ -527,12 +523,12 @@ xml_log_patchset_v1_recursive(uint8_t log_level, const char *prefix,
         // Keep looking for the actual change
         for (const xmlNode *child = pcmk__xml_first_child(data); child != NULL;
              child = pcmk__xml_next(child)) {
-            xml_log_patchset_v1_recursive(log_level, prefix, child, depth + 1,
-                                          options);
+            xml_show_patchset_v1_recursive(out, prefix, child, depth + 1,
+                                           options);
         }
 
     } else {
-        pcmk__xml_show(NULL, log_level, prefix, data, depth,
+        pcmk__xml_show(out, 0, prefix, data, depth,
                        options
                        |pcmk__xml_fmt_open
                        |pcmk__xml_fmt_children
@@ -542,17 +538,16 @@ xml_log_patchset_v1_recursive(uint8_t log_level, const char *prefix,
 
 /*!
  * \internal
- * \brief Log a user-friendly form of an XML patchset (format 1)
+ * \brief Output a user-friendly form of an XML patchset (format 1)
  *
  * This function parses an XML patchset (an \p XML_ATTR_DIFF element and its
- * children) into a user-friendly combined diff output. Depending on the value
- * of \p log_level, the output may be written to \p stdout or to a log file.
+ * children) into a user-friendly combined diff output.
  *
- * \param[in] log_level  Priority at which to log the messages
- * \param[in] patchset   XML patchset to log
+ * \param[in,out] out       Output object
+ * \param[in]     patchset  XML patchset to output
  */
 static void
-xml_log_patchset_v1(uint8_t log_level, const xmlNode *patchset)
+xml_show_patchset_v1(pcmk__output_t *out, const xmlNode *patchset)
 {
     uint32_t options = pcmk__xml_fmt_pretty;
     const xmlNode *removed = NULL;
@@ -560,11 +555,13 @@ xml_log_patchset_v1(uint8_t log_level, const xmlNode *patchset)
     const xmlNode *child = NULL;
     bool is_first = true;
 
-    if (log_level < LOG_DEBUG) {
+    // @FIXME: Use message functions to get rid of explicit fmt_name check
+    if (pcmk__str_eq(out->fmt_name, "log", pcmk__str_none)
+        && (pcmk__output_get_log_level(out) < LOG_DEBUG)) {
         options |= pcmk__xml_fmt_diff_short;
     }
 
-    xml_log_patchset_header(log_level, patchset);
+    xml_show_patchset_header(out, patchset);
 
     /* It's not clear whether "- " or "+ " ever does *not* get overridden by
      * PCMK__XML_PREFIX_DELETED or PCMK__XML_PREFIX_CREATED in practice.
@@ -574,12 +571,12 @@ xml_log_patchset_v1(uint8_t log_level, const xmlNode *patchset)
     removed = find_xml_node(patchset, "diff-removed", FALSE);
     for (child = pcmk__xml_first_child(removed); child != NULL;
          child = pcmk__xml_next(child)) {
-        xml_log_patchset_v1_recursive(log_level, "- ", child, 0,
-                                      options|pcmk__xml_fmt_diff_minus);
+        xml_show_patchset_v1_recursive(out, "- ", child, 0,
+                                       options|pcmk__xml_fmt_diff_minus);
         if (is_first) {
             is_first = false;
         } else {
-            do_crm_log(log_level, " --- ");
+            out->info(out, " --- ");
         }
     }
 
@@ -587,31 +584,30 @@ xml_log_patchset_v1(uint8_t log_level, const xmlNode *patchset)
     added = find_xml_node(patchset, "diff-added", FALSE);
     for (child = pcmk__xml_first_child(added); child != NULL;
          child = pcmk__xml_next(child)) {
-        xml_log_patchset_v1_recursive(log_level, "+ ", child, 0,
-                                      options|pcmk__xml_fmt_diff_plus);
+        xml_show_patchset_v1_recursive(out, "+ ", child, 0,
+                                       options|pcmk__xml_fmt_diff_plus);
         if (is_first) {
             is_first = false;
         } else {
-            do_crm_log(log_level, " +++ ");
+            out->info(out, " +++ ");
         }
     }
 }
 
 /*!
  * \internal
- * \brief Log a user-friendly form of an XML patchset (format 2)
+ * \brief Output a user-friendly form of an XML patchset (format 2)
  *
  * This function parses an XML patchset (an \p XML_ATTR_DIFF element and its
- * children) into a user-friendly combined diff output. Depending on the value
- * of \p log_level, the output may be written to \p stdout or to a log file.
+ * children) into a user-friendly combined diff output.
  *
- * \param[in] log_level  Priority at which to log the messages
- * \param[in] patchset   XML patchset to log
+ * \param[in,out] out       Output object
+ * \param[in]     patchset  XML patchset to output
  */
 static void
-xml_log_patchset_v2(uint8_t log_level, const xmlNode *patchset)
+xml_show_patchset_v2(pcmk__output_t *out, const xmlNode *patchset)
 {
-    xml_log_patchset_header(log_level, patchset);
+    xml_show_patchset_header(out, patchset);
 
     for (const xmlNode *change = pcmk__xml_first_child(patchset);
          change != NULL; change = pcmk__xml_next(change)) {
@@ -626,7 +622,7 @@ xml_log_patchset_v2(uint8_t log_level, const xmlNode *patchset)
             char *prefix = crm_strdup_printf(PCMK__XML_PREFIX_CREATED " %s: ",
                                              xpath);
 
-            pcmk__xml_show(NULL, log_level, prefix, change->children, 0,
+            pcmk__xml_show(out, 0, prefix, change->children, 0,
                            pcmk__xml_fmt_pretty|pcmk__xml_fmt_open);
 
             // Overwrite all except the first two characters with spaces
@@ -634,7 +630,7 @@ xml_log_patchset_v2(uint8_t log_level, const xmlNode *patchset)
                 *ch = ' ';
             }
 
-            pcmk__xml_show(NULL, log_level, prefix, change->children, 0,
+            pcmk__xml_show(out, 0, prefix, change->children, 0,
                            pcmk__xml_fmt_pretty
                            |pcmk__xml_fmt_children
                            |pcmk__xml_fmt_close);
@@ -643,9 +639,8 @@ xml_log_patchset_v2(uint8_t log_level, const xmlNode *patchset)
         } else if (strcmp(op, "move") == 0) {
             const char *position = crm_element_value(change, XML_DIFF_POSITION);
 
-            do_crm_log(log_level,
-                       PCMK__XML_PREFIX_MOVED " %s moved to offset %s",
-                       xpath, position);
+            out->info(out, PCMK__XML_PREFIX_MOVED " %s moved to offset %s",
+                      xpath, position);
 
         } else if (strcmp(op, "modify") == 0) {
             xmlNode *clist = first_named_child(change, XML_DIFF_LIST);
@@ -674,12 +669,12 @@ xml_log_patchset_v2(uint8_t log_level, const xmlNode *patchset)
             }
 
             if (buffer_set != NULL) {
-                do_crm_log(log_level, "+  %s:  %s", xpath, buffer_set->str);
+                out->info(out, "+  %s:  %s", xpath, buffer_set->str);
                 g_string_free(buffer_set, TRUE);
             }
 
             if (buffer_unset != NULL) {
-                do_crm_log(log_level, "-- %s:  %s", xpath, buffer_unset->str);
+                out->info(out, "-- %s:  %s", xpath, buffer_unset->str);
                 g_string_free(buffer_unset, TRUE);
             }
 
@@ -688,9 +683,9 @@ xml_log_patchset_v2(uint8_t log_level, const xmlNode *patchset)
 
             crm_element_value_int(change, XML_DIFF_POSITION, &position);
             if (position >= 0) {
-                do_crm_log(log_level, "-- %s (%d)", xpath, position);
+                out->info(out, "-- %s (%d)", xpath, position);
             } else {
-                do_crm_log(log_level, "-- %s", xpath);
+                out->info(out, "-- %s", xpath);
             }
         }
     }
@@ -711,42 +706,53 @@ void
 pcmk__xml_log_patchset(uint8_t log_level, const xmlNode *patchset)
 {
     int format = 1;
+    pcmk__output_t *out = NULL;
 
-    if (log_level == LOG_NEVER) {
-        return;
+    static struct qb_log_callsite *patchset_cs = NULL;
+
+    switch (log_level) {
+        case LOG_NEVER:
+            return;
+        case LOG_STDOUT:
+            CRM_CHECK(pcmk__text_output_new(&out, NULL) == pcmk_rc_ok, return);
+            break;
+        default:
+            if (patchset_cs == NULL) {
+                patchset_cs = qb_log_callsite_get(__func__, __FILE__,
+                                                  "xml-patchset", log_level,
+                                                  __LINE__, crm_trace_nonlog);
+            }
+            if (!crm_is_callsite_active(patchset_cs, log_level,
+                                        crm_trace_nonlog)) {
+                return;
+            }
+            CRM_CHECK(pcmk__log_output_new(&out) == pcmk_rc_ok, return);
+            pcmk__output_set_log_level(out, log_level);
+            break;
     }
 
     if (patchset == NULL) {
+        // Should come after the LOG_NEVER check
         crm_trace("Empty patch");
-        return;
-    }
-
-    if (log_level != LOG_STDOUT) {
-        static struct qb_log_callsite *patchset_cs = NULL;
-
-        if (patchset_cs == NULL) {
-            patchset_cs = qb_log_callsite_get(__func__, __FILE__,
-                                              "xml-patchset", log_level,
-                                              __LINE__, 0);
-        }
-
-        if (!crm_is_callsite_active(patchset_cs, log_level, 0)) {
-            return;
-        }
+        goto done;
     }
 
     crm_element_value_int(patchset, "format", &format);
     switch (format) {
         case 1:
-            xml_log_patchset_v1(log_level, patchset);
+            xml_show_patchset_v1(out, patchset);
             break;
         case 2:
-            xml_log_patchset_v2(log_level, patchset);
+            xml_show_patchset_v2(out, patchset);
             break;
         default:
             crm_err("Unknown patch format: %d", format);
             break;
     }
+
+done:
+    out->finish(out, CRM_EX_OK, true, NULL);
+    pcmk__output_free(out);
 }
 
 // Return true if attribute name is not "id"

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -532,11 +532,11 @@ xml_log_patchset_v1_recursive(uint8_t log_level, const char *prefix,
         }
 
     } else {
-        pcmk__xml_log(log_level, prefix, data, depth,
-                      options
-                      |pcmk__xml_fmt_open
-                      |pcmk__xml_fmt_children
-                      |pcmk__xml_fmt_close);
+        pcmk__xml_show(NULL, log_level, prefix, data, depth,
+                       options
+                       |pcmk__xml_fmt_open
+                       |pcmk__xml_fmt_children
+                       |pcmk__xml_fmt_close);
     }
 }
 
@@ -626,18 +626,18 @@ xml_log_patchset_v2(uint8_t log_level, const xmlNode *patchset)
             char *prefix = crm_strdup_printf(PCMK__XML_PREFIX_CREATED " %s: ",
                                              xpath);
 
-            pcmk__xml_log(log_level, prefix, change->children, 0,
-                          pcmk__xml_fmt_pretty|pcmk__xml_fmt_open);
+            pcmk__xml_show(NULL, log_level, prefix, change->children, 0,
+                           pcmk__xml_fmt_pretty|pcmk__xml_fmt_open);
 
             // Overwrite all except the first two characters with spaces
             for (char *ch = prefix + 2; *ch != '\0'; ch++) {
                 *ch = ' ';
             }
 
-            pcmk__xml_log(log_level, prefix, change->children, 0,
-                          pcmk__xml_fmt_pretty
-                          |pcmk__xml_fmt_children
-                          |pcmk__xml_fmt_close);
+            pcmk__xml_show(NULL, log_level, prefix, change->children, 0,
+                           pcmk__xml_fmt_pretty
+                           |pcmk__xml_fmt_children
+                           |pcmk__xml_fmt_close);
             free(prefix);
 
         } else if (strcmp(op, "move") == 0) {

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -875,6 +875,7 @@ crm_exit(crm_exit_t rc)
     } else {
         crm_trace("Exiting with status %d", rc);
     }
+    pcmk__free_common_logger();
     qb_log_fini(); // Don't log anything after this point
 
     exit(rc);

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -2106,6 +2106,7 @@ xml_calculate_significant_changes(xmlNode *old_xml, xmlNode *new_xml)
     xml_calculate_changes(old_xml, new_xml);
 }
 
+// Called functions may set the \p pcmk__xf_skip flag on parts of \p old_xml
 void
 xml_calculate_changes(xmlNode *old_xml, xmlNode *new_xml)
 {

--- a/lib/common/xml_display.c
+++ b/lib/common/xml_display.c
@@ -17,8 +17,9 @@
 #include <crm/common/xml_internal.h>  // PCMK__XML_LOG_BASE, etc.
 #include "crmcommon_private.h"
 
-static void log_xml_node(GString *buffer, int log_level, const char *prefix,
-                         const xmlNode *data, int depth, uint32_t options);
+static void show_xml_node(pcmk__output_t *out, GString *buffer,
+                          const char *prefix, const xmlNode *data, int depth,
+                          uint32_t options);
 
 // Log an XML library error
 void
@@ -44,48 +45,46 @@ pcmk__log_xmllib_err(void *ctx, const char *fmt, ...)
 
 /*!
  * \internal
- * \brief Log an XML comment with depth-based indentation
+ * \brief Output an XML comment with depth-based indentation
  *
- * Depending on the value of \p log_level, the output may be written to
- * \p stdout or to a log file.
+ * \param[in,out] out      Output object
+ * \param[in]     data     XML node to output
+ * \param[in]     depth    Current indentation level
+ * \param[in]     options  Group of \p pcmk__xml_fmt_options flags
  *
- * \param[in]     log_level  Priority at which to log the message
- * \param[in]     data       XML node to log
- * \param[in]     depth      Current indentation level
- * \param[in]     options    Group of \p pcmk__xml_fmt_options flags
+ * \note This currently produces output only for text-like output objects.
  */
 static void
-log_xml_comment(int log_level, const xmlNode *data, int depth, uint32_t options)
+show_xml_comment(pcmk__output_t *out, const xmlNode *data, int depth,
+                 uint32_t options)
 {
     if (pcmk_is_set(options, pcmk__xml_fmt_open)) {
-        do_crm_log(log_level, "%*s<!--%s-->",
-                   pcmk_is_set(options, pcmk__xml_fmt_pretty)? (2 * depth) : 0,
-                   "", (const char *) data->content);
+        out->info(out, "%*s<!--%s-->",
+                  pcmk_is_set(options, pcmk__xml_fmt_pretty)? (2 * depth) : 0,
+                  "", (const char *) data->content);
     }
 }
 
 /*!
  * \internal
- * \brief Log an XML element in a formatted way
+ * \brief Output an XML element in a formatted way
  *
- * Depending on the value of \p log_level, the output may be written to
- * \p stdout or to a log file.
+ * \param[in,out] out      Output object
+ * \param[in,out] buffer   Where to build output strings
+ * \param[in]     prefix   String to prepend to every line of output
+ * \param[in]     data     XML node to output
+ * \param[in]     depth    Current indentation level
+ * \param[in]     options  Group of \p pcmk__xml_fmt_options flags
  *
- * \param[in,out] buffer     Where to build output strings
- * \param[in]     log_level  Priority at which to log the messages
- * \param[in]     prefix     String to prepend to every line of output
- * \param[in]     data       XML node to log
- * \param[in]     depth      Current indentation level
- * \param[in]     options    Group of \p pcmk__xml_fmt_options flags
- *
- * \note This is a recursive helper function for \p log_xml_node().
+ * \note This is a recursive helper function for \p show_xml_node().
+ * \note This currently produces output only for text-like output objects.
  * \note \p buffer may be overwritten many times. The caller is responsible for
  *       freeing it using \p g_string_free() but should not rely on its
  *       contents.
  */
 static void
-log_xml_element(GString *buffer, int log_level, const char *prefix,
-                const xmlNode *data, int depth, uint32_t options)
+show_xml_element(pcmk__output_t *out, GString *buffer, const char *prefix,
+                 const xmlNode *data, int depth, uint32_t options)
 {
     const char *name = crm_element_name(data);
     int spaces = pcmk_is_set(options, pcmk__xml_fmt_pretty)? (2 * depth) : 0;
@@ -140,9 +139,9 @@ log_xml_element(GString *buffer, int log_level, const char *prefix,
             g_string_append(buffer, "/>");
         }
 
-        do_crm_log(log_level, "%s%s%s",
-                   pcmk__s(prefix, ""), pcmk__str_empty(prefix)? "" : " ",
-                   buffer->str);
+        out->info(out, "%s%s%s",
+                  pcmk__s(prefix, ""), pcmk__str_empty(prefix)? "" : " ",
+                  buffer->str);
     }
 
     if (!xml_has_children(data)) {
@@ -153,51 +152,49 @@ log_xml_element(GString *buffer, int log_level, const char *prefix,
         for (const xmlNode *child = pcmk__xml_first_child(data); child != NULL;
              child = pcmk__xml_next(child)) {
 
-            log_xml_node(buffer, log_level, prefix, child, depth + 1,
-                         options|pcmk__xml_fmt_open|pcmk__xml_fmt_close);
+            show_xml_node(out, buffer, prefix, child, depth + 1,
+                          options|pcmk__xml_fmt_open|pcmk__xml_fmt_close);
         }
     }
 
     if (pcmk_is_set(options, pcmk__xml_fmt_close)) {
-        do_crm_log(log_level, "%s%s%*s</%s>",
-                   pcmk__s(prefix, ""), pcmk__str_empty(prefix)? "" : " ",
-                   spaces, "", name);
+        out->info(out, "%s%s%*s</%s>",
+                  pcmk__s(prefix, ""), pcmk__str_empty(prefix)? "" : " ",
+                  spaces, "", name);
     }
 }
 
 /*!
  * \internal
- * \brief Log an XML element or comment in a formatted way
+ * \brief Output an XML element or comment in a formatted way
  *
- * Depending on the value of \p log_level, the output may be written to
- * \p stdout or to a log file.
+ * \param[in,out] out      Output object
+ * \param[in,out] buffer   Where to build output strings
+ * \param[in]     prefix   String to prepend to every line of output
+ * \param[in]     data     XML node to log
+ * \param[in]     depth    Current indentation level
+ * \param[in]     options  Group of \p pcmk__xml_fmt_options flags
  *
- * \param[in,out] buffer     Where to build output strings
- * \param[in]     log_level  Priority at which to log the messages
- * \param[in]     prefix     String to prepend to every line of output
- * \param[in]     data       XML node to log
- * \param[in]     depth      Current indentation level
- * \param[in]     options    Group of \p pcmk__xml_fmt_options flags
- *
- * \note This is a recursive helper function for \p pcmk__xml_log().
+ * \note This is a recursive helper function for \p pcmk__xml_show().
+ * \note This currently produces output only for text-like output objects.
  * \note \p buffer may be overwritten many times. The caller is responsible for
  *       freeing it using \p g_string_free() but should not rely on its
  *       contents.
  */
 static void
-log_xml_node(GString *buffer, int log_level, const char *prefix,
-             const xmlNode *data, int depth, uint32_t options)
+show_xml_node(pcmk__output_t *out, GString *buffer, const char *prefix,
+              const xmlNode *data, int depth, uint32_t options)
 {
-    if ((data == NULL) || (log_level == LOG_NEVER)) {
+    if (data == NULL) {
         return;
     }
 
     switch (data->type) {
         case XML_COMMENT_NODE:
-            log_xml_comment(log_level, data, depth, options);
+            show_xml_comment(out, data, depth, options);
             break;
         case XML_ELEMENT_NODE:
-            log_xml_element(buffer, log_level, prefix, data, depth, options);
+            show_xml_element(out, buffer, prefix, data, depth, options);
             break;
         default:
             break;
@@ -206,30 +203,56 @@ log_xml_node(GString *buffer, int log_level, const char *prefix,
 
 /*!
  * \internal
- * \brief Log an XML element or comment in a formatted way
+ * \brief Output an XML element or comment in a formatted way
  *
- * Depending on the value of \p log_level, the output may be written to
- * \p stdout or to a log file.
+ * \param[in,out] out        Output object
+ * \param[in]     log_level  Priority at which to log the messages (ignored if
+ *                           \p out is not \p NULL)
+ * \param[in]     prefix     String to prepend to every line of output
+ * \param[in]     data       XML node to output
+ * \param[in]     depth      Current nesting level
+ * \param[in]     options    Group of \p pcmk__xml_fmt_options flags
  *
- * \param[in] log_level  Priority at which to log the messages
- * \param[in] prefix     String to prepend to every line of output
- * \param[in] data       XML node to log
- * \param[in] depth      Current indentation level
- * \param[in] options    Group of \p pcmk__xml_fmt_options flags
+ * \note This currently produces output only for text-like output objects.
  */
 void
-pcmk__xml_log(int log_level, const char *prefix, const xmlNode *data, int depth,
-              uint32_t options)
+pcmk__xml_show(pcmk__output_t *out, int log_level, const char *prefix,
+               const xmlNode *data, int depth, uint32_t options)
 {
-    /* Allocate a buffer once, for log_xml_node() to truncate and reuse in
-     * recursive calls
-     */
-    GString *buffer = g_string_sized_new(1024);
+    GString *buffer = NULL;
+    bool need_output_free = false;
+
+    if (out == NULL) {
+        switch (log_level) {
+            case LOG_NEVER:
+                return;
+            case LOG_STDOUT:
+                CRM_CHECK(pcmk__text_output_new(&out, NULL) == pcmk_rc_ok,
+                          return);
+                break;
+            default:
+                CRM_CHECK(pcmk__log_output_new(&out) == pcmk_rc_ok, return);
+                pcmk__output_set_log_level(out, log_level);
+                break;
+        }
+
+        need_output_free = true;
+    }
 
     CRM_CHECK(depth >= 0, depth = 0);
 
-    log_xml_node(buffer, log_level, prefix, data, depth, options);
+    /* Allocate a buffer once, for show_xml_node() to truncate and reuse in
+     * recursive calls
+     */
+    buffer = g_string_sized_new(1024);
+
+    show_xml_node(out, buffer, prefix, data, depth, options);
+
     g_string_free(buffer, TRUE);
+    if (need_output_free) {
+        out->finish(out, CRM_EX_OK, true, NULL);
+        pcmk__output_free(out);
+    }
 }
 
 /*!
@@ -261,11 +284,11 @@ log_xml_changes_recursive(int log_level, const xmlNode *data, int depth,
 
     if (pcmk_all_flags_set(nodepriv->flags, pcmk__xf_dirty|pcmk__xf_created)) {
         // Newly created
-        pcmk__xml_log(log_level, PCMK__XML_PREFIX_CREATED, data, depth,
-                      options
-                      |pcmk__xml_fmt_open
-                      |pcmk__xml_fmt_children
-                      |pcmk__xml_fmt_close);
+        pcmk__xml_show(NULL, log_level, PCMK__XML_PREFIX_CREATED, data, depth,
+                       options
+                       |pcmk__xml_fmt_open
+                       |pcmk__xml_fmt_children
+                       |pcmk__xml_fmt_close);
         return;
     }
 
@@ -280,8 +303,8 @@ log_xml_changes_recursive(int log_level, const xmlNode *data, int depth,
         }
 
         // Log opening tag
-        pcmk__xml_log(log_level, prefix, data, depth,
-                      options|pcmk__xml_fmt_open);
+        pcmk__xml_show(NULL, log_level, prefix, data, depth,
+                       options|pcmk__xml_fmt_open);
 
         // Log changes to attributes
         for (const xmlAttr *attr = pcmk__xe_first_attr(data); attr != NULL;
@@ -323,8 +346,8 @@ log_xml_changes_recursive(int log_level, const xmlNode *data, int depth,
         }
 
         // Log closing tag
-        pcmk__xml_log(log_level, PCMK__XML_PREFIX_MODIFIED, data, depth,
-                      options|pcmk__xml_fmt_close);
+        pcmk__xml_show(NULL, log_level, PCMK__XML_PREFIX_MODIFIED, data, depth,
+                       options|pcmk__xml_fmt_close);
 
     } else {
         // This node hasn't changed, but check its children
@@ -474,11 +497,11 @@ log_data_element(int log_level, const char *file, const char *function,
         }
 
     } else {
-        pcmk__xml_log(log_level, prefix, data, depth,
-                      options
-                      |pcmk__xml_fmt_open
-                      |pcmk__xml_fmt_children
-                      |pcmk__xml_fmt_close);
+        pcmk__xml_show(NULL, log_level, prefix, data, depth,
+                       options
+                       |pcmk__xml_fmt_open
+                       |pcmk__xml_fmt_children
+                       |pcmk__xml_fmt_close);
     }
 }
 

--- a/tools/crm_diff.c
+++ b/tools/crm_diff.c
@@ -240,13 +240,12 @@ generate_patch(xmlNode *object_1, xmlNode *object_2, const char *xml_file_2,
         pcmk__output_t *logger_out = NULL;
         int rc = pcmk__log_output_new(&logger_out);
 
-        CRM_LOG_ASSERT(rc == pcmk_rc_ok);
-        if (rc == pcmk_rc_ok) {
-            pcmk__output_set_log_level(logger_out, LOG_INFO);
-            pcmk__xml_show_changes(logger_out, object_2);
-            logger_out->finish(logger_out, CRM_EX_OK, true, NULL);
-            pcmk__output_free(logger_out);
-        }
+        CRM_CHECK(rc == pcmk_rc_ok, {free_xml(output); return rc;});
+
+        pcmk__output_set_log_level(logger_out, LOG_INFO);
+        pcmk__xml_show_changes(logger_out, object_2);
+        logger_out->finish(logger_out, CRM_EX_OK, true, NULL);
+        pcmk__output_free(logger_out);
     }
 
     xml_accept_changes(object_2);

--- a/tools/crm_diff.c
+++ b/tools/crm_diff.c
@@ -236,7 +236,19 @@ generate_patch(xmlNode *object_1, xmlNode *object_2, const char *xml_file_2,
 
     output = xml_create_patchset(0, object_1, object_2, NULL, FALSE);
 
-    pcmk__xml_log_changes(LOG_INFO, object_2);
+    {
+        pcmk__output_t *logger_out = NULL;
+        int rc = pcmk__log_output_new(&logger_out);
+
+        CRM_LOG_ASSERT(rc == pcmk_rc_ok);
+        if (rc == pcmk_rc_ok) {
+            pcmk__output_set_log_level(logger_out, LOG_INFO);
+            pcmk__xml_show_changes(logger_out, object_2);
+            logger_out->finish(logger_out, CRM_EX_OK, true, NULL);
+            pcmk__output_free(logger_out);
+        }
+    }
+
     xml_accept_changes(object_2);
 
     if (output == NULL) {

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -607,7 +607,19 @@ main(int argc, char **argv)
                 diff = xml_create_patchset(0, old_config, new_config, NULL,
                                            false);
 
-                pcmk__xml_log_changes(LOG_INFO, new_config);
+                {
+                    pcmk__output_t *logger_out = NULL;
+                    int rc = pcmk__log_output_new(&logger_out);
+
+                    CRM_LOG_ASSERT(rc == pcmk_rc_ok);
+                    if (rc == pcmk_rc_ok) {
+                        pcmk__output_set_log_level(logger_out, LOG_INFO);
+                        pcmk__xml_show_changes(logger_out, new_config);
+                        logger_out->finish(logger_out, CRM_EX_OK, true, NULL);
+                        pcmk__output_free(logger_out);
+                    }
+                }
+
                 xml_accept_changes(new_config);
                 if (diff != NULL) {
                     /* @COMPAT: Exit with CRM_EX_DIGEST? This is not really an

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -609,15 +609,14 @@ main(int argc, char **argv)
 
                 {
                     pcmk__output_t *logger_out = NULL;
-                    int rc = pcmk__log_output_new(&logger_out);
+                    rc = pcmk_rc2legacy(pcmk__log_output_new(&logger_out));
 
-                    CRM_LOG_ASSERT(rc == pcmk_rc_ok);
-                    if (rc == pcmk_rc_ok) {
-                        pcmk__output_set_log_level(logger_out, LOG_INFO);
-                        pcmk__xml_show_changes(logger_out, new_config);
-                        logger_out->finish(logger_out, CRM_EX_OK, true, NULL);
-                        pcmk__output_free(logger_out);
-                    }
+                    CRM_CHECK(rc == pcmk_ok, goto done);
+
+                    pcmk__output_set_log_level(logger_out, LOG_INFO);
+                    pcmk__xml_show_changes(logger_out, new_config);
+                    logger_out->finish(logger_out, CRM_EX_OK, true, NULL);
+                    pcmk__output_free(logger_out);
                 }
 
                 xml_accept_changes(new_config);


### PR DESCRIPTION
We're not quite finished, but this is enough for one PR :)

The final big step that I'm aware of is to convert the "xml_log_patchset" family of functions to use message formatters instead. Those will be part of the API and need to support XML output in addition to the other formats.

In contrast, the functions that we refactor here only need to support text and log output formats. So for simplicity, we forego message formatters and instead just use `out->info()`. The downside is that if for some reason they're called with an XML output object, we won't return early like we would with message formatters. (They're internal so that shouldn't happen.) The upside is that we can avoid all the complexity of adding formatters that we don't really need.

At the time of filing this, the first two commits (related to `pcmk__if_tracing()`) are shared with #3014 and can be ignored.