### PR TITLE
 Refactor: libcrmcommon: Ensure log levels are in uint8_t range 

### DIFF
--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -11,6 +11,7 @@
 #  define PCMK__OUTPUT_INTERNAL__H
 
 #  include <stdbool.h>
+#  include <stdint.h>
 #  include <stdio.h>
 #  include <libxml/tree.h>
 #  include <libxml/HTMLtree.h>
@@ -745,7 +746,7 @@ pcmk__text_prompt(const char *prompt, bool echo, char **dest);
  *
  * \return Log level used by \p out
  */
-int
+uint8_t
 pcmk__output_get_log_level(const pcmk__output_t *out);
 
 /*!
@@ -761,7 +762,7 @@ pcmk__output_get_log_level(const pcmk__output_t *out);
  *       However, out->err will always log at LOG_ERR.
  */
 void
-pcmk__output_set_log_level(pcmk__output_t *out, int log_level);
+pcmk__output_set_log_level(pcmk__output_t *out, uint8_t log_level);
 
 /*!
  * \internal

--- a/lib/common/output_log.c
+++ b/lib/common/output_log.c
@@ -22,7 +22,7 @@ GOptionEntry pcmk__log_output_entries[] = {
 typedef struct private_data_s {
     /* gathered in log_begin_list */
     GQueue/*<char*>*/ *prefixes;
-    int log_level;
+    uint8_t log_level;
 } private_data_t;
 
 static void
@@ -329,7 +329,7 @@ pcmk__mk_log_output(char **argv) {
     return retval;
 }
 
-int
+uint8_t
 pcmk__output_get_log_level(const pcmk__output_t *out)
 {
     private_data_t *priv = NULL;
@@ -342,7 +342,7 @@ pcmk__output_get_log_level(const pcmk__output_t *out)
 }
 
 void
-pcmk__output_set_log_level(pcmk__output_t *out, int log_level) {
+pcmk__output_set_log_level(pcmk__output_t *out, uint8_t log_level) {
     private_data_t *priv = NULL;
 
     CRM_ASSERT(out != NULL && out->priv != NULL);

--- a/lib/common/xml_display.c
+++ b/lib/common/xml_display.c
@@ -380,6 +380,9 @@ log_data_element(int log_level, const char *file, const char *function,
     uint32_t options = 0;
     pcmk__output_t *out = NULL;
 
+    // Confine log_level to uint8_t range
+    log_level = pcmk__clip_log_level(log_level);
+
     if (data == NULL) {
         do_crm_log(log_level, "%s%sNo data to dump as XML",
                    pcmk__s(prefix, ""), pcmk__str_empty(prefix)? "" : " ");


### PR DESCRIPTION
libqb expects all log levels to be in the uint8_t range (0 to 255). Several Pacemaker functions and macros currently accept arbitrary integers and don't validate that they're in-range. This fixes that issue.
