### PR TITLE
fix watchdog-fencing with topology

### DIFF
--- a/cts/support/fence_dummy.in
+++ b/cts/support/fence_dummy.in
@@ -2,7 +2,7 @@
 """Dummy fence agent for testing
 """
 
-__copyright__ = "Copyright 2012-2022 the Pacemaker project contributors"
+__copyright__ = "Copyright 2012-2023 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import io
@@ -123,6 +123,15 @@ ALL_OPT = {
         "help" : "-d, --monitor_delay [seconds]  Wait X seconds before monitor completes",
         "required" : "0",
         "shortdesc" : "Wait X seconds before monitor completes",
+        "default" : "0",
+        "order" : 3
+        },
+    "off_delay" : {
+        "getopt" : "F:",
+        "longopt" : "off_delay",
+        "help" : "-F, --off_delay [seconds]      Wait additional X seconds before off action",
+        "required" : "0",
+        "shortdesc" : "Wait additional X seconds before off action",
         "default" : "0",
         "order" : 3
         },
@@ -499,6 +508,11 @@ def main():
                 exitcode = 0
         else:
             exitcode = 1
+
+    elif action == "off":
+        if "-F" in options:
+            time.sleep(int(options["-F"]))
+        exitcode = success_mode(options, "-M", "random")
 
     else:
         exitcode = success_mode(options, "-M", "random")

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1834,7 +1834,7 @@ request_peer_fencing(remote_fencing_op_t *op, peer_device_info_t *peer)
         if (!((stonith_watchdog_timeout_ms > 0)
               && (pcmk__str_eq(device, STONITH_WATCHDOG_ID, pcmk__str_none)
                   || (pcmk__str_eq(peer->host, op->target, pcmk__str_casei)
-                      && !pcmk__str_eq(op->action, "on", pcmk__str_none)))
+                      && pcmk__is_fencing_action(op->action)))
               && check_watchdog_fencing_and_wait(op))) {
 
             /* Some thoughts about self-fencing cases reaching this point:
@@ -1854,6 +1854,9 @@ request_peer_fencing(remote_fencing_op_t *op, peer_device_info_t *peer)
                  Otherwise the selection of stonith-watchdog-timeout at
                  least is questionable.
              */
+
+            /* coming here we're not waiting for watchdog timeout -
+               thus engage timer with timout evaluated before */
             op->op_timer_one = g_timeout_add((1000 * timeout_one), remote_op_timeout_one, op);
         }
 

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2022 the Pacemaker project contributors
+ * Copyright 2009-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1702,6 +1702,10 @@ check_watchdog_fencing_and_wait(remote_fencing_op_t * op)
                    "client %s " CRM_XS " id=%.8s",
                    (stonith_watchdog_timeout_ms / 1000),
                    op->target, op->action, op->client_name, op->id);
+
+        if (op->op_timer_one) {
+            g_source_remove(op->op_timer_one);
+        }
         op->op_timer_one = g_timeout_add(stonith_watchdog_timeout_ms,
                                          remote_op_watchdog_done, op);
         return TRUE;


### PR DESCRIPTION
When the node to be fenced via watchdog-fencing doesn't advertise self-fencing
calculation of overall fencing time in a topology doesn't take watchdog-timeout
into account.