### PR TITLE
Low: libcrmcommon: Fix handling node=NULL in pcmk__attrd_api_query.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -415,7 +415,8 @@ yes_no_try "$with_corosync" "try"
 with_corosync=$?
 
 dnl Get default from corosync if possible.
-PKG_CHECK_VAR([PCMK__COROSYNC_CONF], [corosync], [corosysconfdir], [],
+PKG_CHECK_VAR([PCMK__COROSYNC_CONF], [corosync], [corosysconfdir],
+              [PCMK__COROSYNC_CONF="$PCMK__COROSYNC_CONF/corosync.conf"],
               [PCMK__COROSYNC_CONF="${sysconfdir}/corosync/corosync.conf"])
 AC_ARG_WITH([corosync-conf],
     [AS_HELP_STRING([--with-corosync-conf], m4_normalize([

--- a/cts/cts-attrd.in
+++ b/cts/cts-attrd.in
@@ -183,6 +183,33 @@ class AttributeTests(Tests):
                                   "name=\"DDD\" value=\"555\"")
         test.add_log_pattern("Processed 1 private change for DDD, id=n/a, set=foo")
 
+    def build_multiple_query_tests(self):
+        """ Add tests that set and query an attribute across multiple nodes """
+
+        # NOTE:  These tests make use of the fact that nothing in attrd actually
+        # cares about whether a node exists when you set or query an attribute.
+        # It just keeps creating new hash tables for each node you ask it about.
+
+        test = self.new_test("multi_query_1",
+                             "Query an attribute set across multiple nodes")
+        test.add_cmd("attrd_updater", "--name AAA -U 111 --node cluster1 --output-as=xml")
+        test.add_cmd("attrd_updater", "--name AAA -U 222 --node cluster2 --output-as=xml")
+        test.add_cmd_check_stdout("attrd_updater", "--name AAA -QA --output-as=xml",
+                                  r"""<attribute name="AAA" value="111" host="cluster1"/>\n.*<attribute name="AAA" value="222" host="cluster2"/>""")
+        test.add_cmd_check_stdout("attrd_updater", "--name AAA -Q --node=cluster1 --output-as=xml",
+                                  """<attribute name="AAA" value="111" host="cluster1"/>""")
+        test.add_cmd_check_stdout("attrd_updater", "--name AAA -Q --node=cluster2 --output-as=xml",
+                                  """<attribute name="AAA" value="222" host="cluster2"/>""")
+        test.add_cmd_check_stdout("attrd_updater", "--name AAA -QA --output-as=xml",
+                                  r"""<attribute name="AAA" value="111" host="cluster1"/>\n.*<attribute name="AAA" value="222" host="cluster2"/>""",
+                                  env={"OCF_RESKEY_CRM_meta_on_node": "cluster1"})
+        test.add_cmd_check_stdout("attrd_updater", "--name AAA -Q --output-as=xml",
+                                  """<attribute name="AAA" value="111" host="cluster1"/>""",
+                                  env={"OCF_RESKEY_CRM_meta_on_node": "cluster1"})
+        test.add_cmd_check_stdout("attrd_updater", "--name AAA -Q --node=cluster2 --output-as=xml",
+                                  """<attribute name="AAA" value="222" host="cluster2"/>""",
+                                  env={"OCF_RESKEY_CRM_meta_on_node": "cluster1"})
+
     def build_regex_tests(self):
         """ Add tests that use regexes """
 
@@ -289,6 +316,7 @@ def main():
         tests = AttributeTests(verbose=opts.verbose, logdir=logdir)
 
         tests.build_basic_tests()
+        tests.build_multiple_query_tests()
         tests.build_regex_tests()
         tests.build_utilization_tests()
         tests.build_sync_point_tests()

--- a/include/crm/common/attrd_internal.h
+++ b/include/crm/common/attrd_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -26,6 +26,7 @@ enum pcmk__node_attr_opts {
     pcmk__node_attr_sync_local     = (1 << 6),
     pcmk__node_attr_sync_cluster   = (1 << 7),
     pcmk__node_attr_utilization    = (1 << 8),
+    pcmk__node_attr_query_all      = (1 << 9),
 };
 
 #define pcmk__set_node_attr_flags(node_attr_flags, flags_to_set) do {   \

--- a/include/crm/common/ipc_attrd_internal.h
+++ b/include/crm/common/ipc_attrd_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -110,9 +110,12 @@ int pcmk__attrd_api_purge(pcmk_ipc_api_t *api, const char *node);
  *
  * \param[in,out] api           Connection to pacemaker-attrd
  * \param[in]     node          Look up the attribute for this node
- *                              (or NULL for all nodes)
+ *                              (or NULL for the local node)
  * \param[in]     name          Attribute name
  * \param[in]     options       Bitmask of pcmk__node_attr_opts
+ *
+ * \note Passing pcmk__node_attr_query_all will cause the function to query
+ *       the value of \p name on all nodes, regardless of the value of \p node.
  *
  * \return Standard Pacemaker return code
  */

--- a/lib/common/ipc_attrd.c
+++ b/lib/common/ipc_attrd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2022 the Pacemaker project contributors
+ * Copyright 2011-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -332,10 +332,14 @@ pcmk__attrd_api_query(pcmk_ipc_api_t *api, const char *node, const char *name,
         return EINVAL;
     }
 
-    target = pcmk__node_attr_target(node);
+    if (pcmk_is_set(options, pcmk__node_attr_query_all)) {
+        node = NULL;
+    } else {
+        target = pcmk__node_attr_target(node);
 
-    if (target != NULL) {
-        node = target;
+        if (target != NULL) {
+            node = target;
+        }
     }
 
     request = create_attrd_op(NULL);

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -431,6 +431,7 @@ static int
 send_attrd_query(pcmk__output_t *out, const char *attr_name,
                  const char *attr_node, gboolean query_all)
 {
+    uint32_t options = pcmk__node_attr_none;
     pcmk_ipc_api_t *attrd_api = NULL;
     int rc = pcmk_rc_ok;
 
@@ -455,10 +456,10 @@ send_attrd_query(pcmk__output_t *out, const char *attr_name,
 
     /* Decide which node(s) to query */
     if (query_all == TRUE) {
-        attr_node = NULL;
+        options |= pcmk__node_attr_query_all;
     }
 
-    rc = pcmk__attrd_api_query(attrd_api, attr_node, attr_name, 0);
+    rc = pcmk__attrd_api_query(attrd_api, attr_node, attr_name, options);
 
     if (rc != pcmk_rc_ok) {
         g_set_error(&error, PCMK__RC_ERROR, rc, "Could not query value of %s: %s (%d)",


### PR DESCRIPTION
According to the header file, if node is NULL, pcmk__attrd_api_query should query the value of the given attribute on all cluster nodes. This is also what the server expects and how attrd_updater is supposed to work.

However, pcmk__attrd_api_query does not correctly handle a NULL here. Instead, it will call pcmk__node_attr_target.  That function takes NULL to mean that it should probe the local cluster node for its name, returning that to pcmk__attrd_api_query.  If it returns non-NULL, that value will then be put into the XML IPC call which means the server will only return the value for that node.

In testing this was usually fine.  However, in pratice, the methods pcmk__node_attr_target uses to figure out the local cluster node name involves checking the OCF_RESKEY_CRM_meta_on_node environment variable among others.

This variable was never set in testing, but can be set in the real world.  This leads to circumstances where the user did "attrd_updater -QA" expecting to get the values on all nodes, but instead only got the value on the local cluster node.

In pacemaker-2.1.4 and prior, pcmk__node_attr_target was simply never called if the node was NULL but was called otherwise.  It's possible that we should never be calling this function for queries, but in the interests of restoring previous behavior, we're just going to skip it in the NULL case here.

Regression in 2.1.5 introduced by eb20a65577