### PR TITLE
Fix: fencer: Avoid double source remove of op_timer_total

### DIFF
--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -544,6 +544,9 @@ finalize_op(remote_fencing_op_t *op, xmlNode *data, bool dup)
 
     CRM_CHECK((op != NULL), return);
 
+    // This is a no-op if timers have already been cleared
+    clear_remote_op_timers(op);
+
     if (op->notify_sent) {
         // Most likely, this is a timed-out action that eventually completed
         crm_notice("Operation '%s'%s%s by %s for %s@%s%s: "
@@ -558,7 +561,6 @@ finalize_op(remote_fencing_op_t *op, xmlNode *data, bool dup)
     }
 
     set_fencing_completed(op);
-    clear_remote_op_timers(op);
     undo_op_remap(op);
 
     if (data == NULL) {
@@ -672,7 +674,7 @@ remote_op_timeout_one(gpointer userdata)
 
     // Try another device, if appropriate
     request_peer_fencing(op, NULL);
-    return FALSE;
+    return G_SOURCE_REMOVE;
 }
 
 /*!
@@ -685,8 +687,6 @@ remote_op_timeout_one(gpointer userdata)
 static void
 finalize_timed_out_op(remote_fencing_op_t *op, const char *reason)
 {
-    op->op_timer_total = 0;
-
     crm_debug("Action '%s' targeting %s for client %s timed out "
               CRM_XS " id=%.8s",
               op->action, op->target, op->client_name, op->id);
@@ -739,6 +739,7 @@ remote_op_query_timeout(gpointer data)
     remote_fencing_op_t *op = data;
 
     op->query_timer = 0;
+
     if (op->state == st_done) {
         crm_debug("Operation %.8s targeting %s already completed",
                   op->id, op->target);
@@ -753,15 +754,11 @@ remote_op_query_timeout(gpointer data)
     } else {
         crm_debug("Query %.8s targeting %s timed out (state=%s)",
                   op->id, op->target, stonith_op_state_str(op->state));
-        if (op->op_timer_total) {
-            g_source_remove(op->op_timer_total);
-            op->op_timer_total = 0;
-        }
         finalize_timed_out_op(op, "No capable peers replied to device query "
                                   "within timeout");
     }
 
-    return FALSE;
+    return G_SOURCE_REMOVE;
 }
 
 static gboolean

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -718,6 +718,8 @@ remote_op_timeout(gpointer userdata)
 {
     remote_fencing_op_t *op = userdata;
 
+    op->op_timer_total = 0;
+
     if (op->state == st_done) {
         crm_debug("Action '%s' targeting %s for client %s already completed "
                   CRM_XS " id=%.8s",


### PR DESCRIPTION
It's RHBZ#2166967 Part 2, Electric Boogaloo.

db10921 was correct to do, but it didn't solve the issue that QE encountered (see #3022).

The original "fix" zeroed out `op->op_timer_one` after calling `g_source_remove()` on that timer. That was still a good idea, but it obviously wasn't the root cause.

I've been able to reproduce this locally under the following conditions:
1. Set up a non-working fence device (missing fence agent script -- this may not be necessary, but I created it in order to match QE's test)
2. Configure sbd:
  * `have-watchdog=true`
  * `stonith-watchdog-timeout=10`
3. Block `node2`'s outbound communication on port 5405:
```
# ssh root@node2 'pcs cluster start && sleep 10 && firewall-cmd --direct --add-rule ipv4 filter OUTPUT 2 -p udp --dport=5405 -j DROP'
```
4. Sleep 180 seconds (not exact requirement but sufficient)
5. Stop pacemaker on `node1` (`pcs cluster stop --force`)

Or in one command line, assuming that Pacemaker is already running on both nodes:
```
# date \
&& ssh root@node2 'firewall-cmd --direct --add-rule ipv4 filter OUTPUT 2 -p udp --dport=5405 -j DROP' \
&& date \
&& sleep 180 \
&& date \
&& ssh root@node1 'pcs cluster stop --force'
```

The issue occurs when the `remote_op_timeout()` callback is called. If `op->state == op->done`, then we DO NOT call `finalize_timed_out_op()`, which would call `finalize_op()`, free `op->op_timer_total`, and zero out `op->op_timer_total`.

`remote_op_timeout()` returns `G_SOURCE_REMOVE`, which frees the source within the GLib main loop. Then, because we never zeroed out `op->op_timer_total`, `clear_remote_op_timers()` tries to remove the source again during Pacemaker shutdown

The simplest fix is to zero out `op->op_timer_total` at the beginning of `remote_op_timeout()`. We already zero out the relevant timer in other `GSourceFunc` timer callback functions, so this approach is consistent.

However, I believe it's worth examining more of the code (at a lower priority). Are we setting `op->state == st_done` when we shouldn't be? Should we be calling one of the `finalize*()` functions (which would zero out the timer for us) even if `op->state == st_done`? Et cetera.