### PR TITLE
Low: libcrmcommon: Fix problems with pcmk__output_and_clear_error.

### DIFF
--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -348,7 +348,7 @@ main(int argc, char **argv)
 
     g_strfreev(log_files);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
         out->finish(out, attrd_exit_status, true, NULL);

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -285,7 +285,7 @@ done:
     pcmk_cluster_free(crm_cluster);
     g_free(cib_root);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);

--- a/daemons/controld/pacemaker-controld.c
+++ b/daemons/controld/pacemaker-controld.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -154,7 +154,7 @@ done:
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);

--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the Pacemaker project contributors
+ * Copyright 2012-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -619,6 +619,6 @@ done:
     free(key);
     free(val);
 
-    pcmk__output_and_clear_error(error, NULL);
+    pcmk__output_and_clear_error(&error, NULL);
     return test_exit(exit_code);
 }

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -567,7 +567,7 @@ done:
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);

--- a/daemons/fenced/cts-fence-helper.c
+++ b/daemons/fenced/cts-fence-helper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2022 the Pacemaker project contributors
+ * Copyright 2009-2023 the Pacemaker project contributors
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -676,6 +676,6 @@ done:
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
 
-    pcmk__output_and_clear_error(error, NULL);
+    pcmk__output_and_clear_error(&error, NULL);
     crm_exit(exit_code);
 }

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -1726,7 +1726,7 @@ done:
     pcmk_cluster_free(cluster);
     pe_free_working_set(fenced_data_set);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (logger_out != NULL) {
         logger_out->finish(logger_out, exit_code, true, NULL);

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 the Pacemaker project contributors
+ * Copyright 2010-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -449,7 +449,7 @@ done:
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -151,7 +151,7 @@ done:
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
     pengine_shutdown(0);
 }
 

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -911,7 +911,7 @@ G_GNUC_NULL_TERMINATED;
  * \param[in,out] out   The output functions structure.  If NULL, any errors
  *                      will simply be printed to stderr.
  */
-void pcmk__output_and_clear_error(GError *error, pcmk__output_t *out);
+void pcmk__output_and_clear_error(GError **error, pcmk__output_t *out);
 
 int pcmk__xml_output_new(pcmk__output_t **out, xmlNodePtr *xml);
 void pcmk__xml_output_finish(pcmk__output_t *out, xmlNodePtr *xml);

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the Pacemaker project contributors
+ * Copyright 2019-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -169,19 +169,19 @@ pcmk__register_messages(pcmk__output_t *out, const pcmk__message_entry_t *table)
 }
 
 void
-pcmk__output_and_clear_error(GError *error, pcmk__output_t *out)
+pcmk__output_and_clear_error(GError **error, pcmk__output_t *out)
 {
-    if (error == NULL) {
+    if (error == NULL || *error == NULL) {
         return;
     }
 
     if (out != NULL) {
-        out->err(out, "%s: %s", g_get_prgname(), error->message);
+        out->err(out, "%s: %s", g_get_prgname(), (*error)->message);
     } else {
-        fprintf(stderr, "%s: %s\n", g_get_prgname(), error->message);
+        fprintf(stderr, "%s: %s\n", g_get_prgname(), (*error)->message);
     }
 
-    g_clear_error(&error);
+    g_clear_error(error);
 }
 
 /*!

--- a/lib/common/tests/output/pcmk__output_and_clear_error_test.c
+++ b/lib/common/tests/output/pcmk__output_and_clear_error_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -72,10 +72,10 @@ standard_usage(void **state) {
                 "some error message");
 
     expect_function_call(fake_text_err);
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     pcmk__output_free(out);
-    assert_null(error->message);
+    assert_null(error);
 }
 
 PCMK__UNIT_TEST(NULL, NULL,

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -369,7 +369,7 @@ done:
     g_free(options.attr_set);
     free(options.attr_value);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -881,7 +881,7 @@ done:
         exit_code = pcmk_rc2exitc(rc);
     }
 
-    pcmk__output_and_clear_error(error, NULL);
+    pcmk__output_and_clear_error(&error, NULL);
     crm_exit(exit_code);
 }
 

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -871,7 +871,7 @@ done:
 
     cib__clean_up_connection(&the_cib);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);

--- a/tools/crm_diff.c
+++ b/tools/crm_diff.c
@@ -381,6 +381,6 @@ done:
     free_xml(object_1);
     free_xml(object_2);
 
-    pcmk__output_and_clear_error(error, NULL);
+    pcmk__output_and_clear_error(&error, NULL);
     crm_exit(exit_code);
 }

--- a/tools/crm_error.c
+++ b/tools/crm_error.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the Pacemaker project contributors
+ * Copyright 2012-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -164,7 +164,7 @@ main(int argc, char **argv)
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -596,6 +596,6 @@ done:
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
 
-    pcmk__output_and_clear_error(error, NULL);
+    pcmk__output_and_clear_error(&error, NULL);
     return crm_exit(exit_code);
 }

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -200,7 +200,7 @@ static pcmk__supported_format_t formats[] = {
 static crm_exit_t
 bye(crm_exit_t ec)
 {
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
         out->finish(out, ec, true, NULL);

--- a/tools/crm_rule.c
+++ b/tools/crm_rule.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the Pacemaker project contributors
+ * Copyright 2019-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -215,7 +215,7 @@ done:
     crm_time_free(rule_date);
     free_xml(input);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -669,7 +669,7 @@ done:
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
 
-    pcmk__output_and_clear_error(error, NULL);
+    pcmk__output_and_clear_error(&error, NULL);
 
     if (needs_teardown) {
         // Teardown message should be the last thing we output

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2022 the Pacemaker project contributors
+ * Copyright 2009-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -547,7 +547,7 @@ main(int argc, char **argv)
                         options.dot_file);
 
   done:
-    pcmk__output_and_clear_error(error, NULL);
+    pcmk__output_and_clear_error(&error, NULL);
 
     /* There sure is a lot to free in options. */
     free(options.dot_file);

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the Pacemaker project contributors
+ * Copyright 2012-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1005,7 +1005,7 @@ main(int argc, char **argv)
     g_free(options.ticket_id);
     g_free(options.xml_file);
 
-    pcmk__output_and_clear_error(error, NULL);
+    pcmk__output_and_clear_error(&error, NULL);
 
     crm_exit(exit_code);
 }

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -273,7 +273,7 @@ main(int argc, char **argv)
         exit_code = pcmk_rc2exitc(rc);
     }
 
-    pcmk__output_and_clear_error(error, NULL);
+    pcmk__output_and_clear_error(&error, NULL);
 
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);

--- a/tools/crmadmin.c
+++ b/tools/crmadmin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -264,7 +264,7 @@ done:
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);

--- a/tools/iso8601.c
+++ b/tools/iso8601.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2022 the Pacemaker project contributors
+ * Copyright 2005-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -277,6 +277,6 @@ done:
     g_free(options.expected_s);
     g_free(options.period_s);
 
-    pcmk__output_and_clear_error(error, NULL);
+    pcmk__output_and_clear_error(&error, NULL);
     crm_exit(exit_code);
 }

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2022 the Pacemaker project contributors
+ * Copyright 2009-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -655,7 +655,7 @@ main(int argc, char **argv)
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
 
-    pcmk__output_and_clear_error(error, out);
+    pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
         out->finish(out, exit_code, true, NULL);


### PR DESCRIPTION
First, it should take a GError ** so that doing anything in the function modifies the error object that was passed to it.  Second, the test case should assert that the error is NULL, not that some element of it is NULL.