### PR TITLE
Functionize all of crm_shadow.c:main()

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -5899,3 +5899,685 @@ Active Resources:
 11
 =#=#=#= End test: Check that CIB_file="-" works - crmadmin - OK (0) =#=#=#=
 * Passed: cat            - Check that CIB_file="-" works - crmadmin
+=#=#=#= Begin test: Get active shadow instance (no active instance) =#=#=#=
+crm_shadow: No active shadow configuration defined
+=#=#=#= End test: Get active shadow instance (no active instance) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance (no active instance)
+=#=#=#= Begin test: Get active shadow instance's file name (no active instance) =#=#=#=
+crm_shadow: No active shadow configuration defined
+=#=#=#= End test: Get active shadow instance's file name (no active instance) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's file name (no active instance)
+=#=#=#= Begin test: Get active shadow instance's contents (no active instance) =#=#=#=
+crm_shadow: No active shadow configuration defined
+=#=#=#= End test: Get active shadow instance's contents (no active instance) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's contents (no active instance)
+=#=#=#= Begin test: Get active shadow instance's diff (no active instance) =#=#=#=
+crm_shadow: No active shadow configuration defined
+=#=#=#= End test: Get active shadow instance's diff (no active instance) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's diff (no active instance)
+=#=#=#= Begin test: Create copied shadow instance =#=#=#=
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Create copied shadow instance - OK (0) =#=#=#=
+* Passed: crm_shadow     - Create copied shadow instance
+=#=#=#= Begin test: Get active shadow instance (copied) =#=#=#=
+cts-cli
+=#=#=#= End test: Get active shadow instance (copied) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance (copied)
+=#=#=#= Begin test: Get active shadow instance's file name (copied) =#=#=#=
+cts-cli.shadow/shadow.cts-cli
+=#=#=#= End test: Get active shadow instance's file name (copied) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's file name (copied)
+=#=#=#= Begin test: Get active shadow instance's contents (copied) =#=#=#=
+<cib epoch="1" num_updates="173" admin_epoch="1" >
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-have-watchdog" name="have-watchdog" value="false"/>
+        <nvpair id="cib-bootstrap-options-dc-version" name="dc-version" value="2.0.4-1.e97f9675f.git.el7-e97f9675f"/>
+        <nvpair id="cib-bootstrap-options-cluster-infrastructure" name="cluster-infrastructure" value="corosync"/>
+        <nvpair id="cib-bootstrap-options-cluster-name" name="cluster-name" value="test-cluster"/>
+        <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
+        <nvpair id="cib-bootstrap-options-maintenance-mode" name="maintenance-mode" value="false"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="1" uname="cluster01">
+        <instance_attributes id="nodes-1">
+          <nvpair id="nodes-1-location" name="location" value="office"/>
+        </instance_attributes>
+      </node>
+      <node id="2" uname="cluster02"/>
+    </nodes>
+    <resources>
+      <clone id="ping-clone">
+        <primitive class="ocf" id="ping" provider="pacemaker" type="ping">
+          <instance_attributes id="ping-instance_attributes">
+            <nvpair id="ping-instance_attributes-dampen" name="dampen" value="5s"/>
+            <nvpair id="ping-instance_attributes-host_list" name="host_list" value="192.168.122.1"/>
+            <nvpair id="ping-instance_attributes-multiplier" name="multiplier" value="1000"/>
+          </instance_attributes>
+          <operations>
+            <op id="ping-monitor-interval-10s" interval="10s" name="monitor" timeout="60s"/>
+            <op id="ping-start-interval-0s" interval="0s" name="start" timeout="60s"/>
+            <op id="ping-stop-interval-0s" interval="0s" name="stop" timeout="20s"/>
+          </operations>
+        </primitive>
+      </clone>
+      <primitive class="stonith" id="Fencing" type="fence_xvm">
+        <instance_attributes id="Fencing-instance_attributes">
+          <nvpair id="Fencing-instance_attributes-ip_family" name="ip_family" value="ipv4"/>
+        </instance_attributes>
+        <operations>
+          <op id="Fencing-monitor-interval-60s" interval="60s" name="monitor"/>
+        </operations>
+      </primitive>
+      <primitive class="ocf" id="dummy" provider="pacemaker" type="Dummy">
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-op_sleep" name="op_sleep" value="6"/>
+        </instance_attributes>
+        <operations>
+          <op id="dummy-migrate_from-interval-0s" interval="0s" name="migrate_from" timeout="20s"/>
+          <op id="dummy-migrate_to-interval-0s" interval="0s" name="migrate_to" timeout="20s"/>
+          <op id="dummy-monitor-interval-60s" interval="60s" name="monitor" on-fail="stop"/>
+          <op id="dummy-reload-interval-0s" interval="0s" name="reload" timeout="20s"/>
+          <op id="dummy-start-interval-0s" interval="0s" name="start" timeout="20s"/>
+          <op id="dummy-stop-interval-0s" interval="0s" name="stop" timeout="20s"/>
+        </operations>
+      </primitive>
+      <clone id="inactive-clone">
+        <meta_attributes id="inactive-clone-meta_attributes">
+          <nvpair id="inactive-clone-meta_attributes-target-role" name="target-role" value="stopped"/>
+        </meta_attributes>
+        <primitive id="inactive-dhcpd" class="lsb" type="dhcpd"/>
+      </clone>
+      <group id="inactive-group">
+        <meta_attributes id="inactive-group-meta_attributes">
+          <nvpair id="inactive-group-meta_attributes-target-role" name="target-role" value="stopped"/>
+        </meta_attributes>
+        <primitive class="ocf" id="inactive-dummy-1" provider="pacemaker" type="Dummy"/>
+        <primitive class="ocf" id="inactive-dummy-2" provider="pacemaker" type="Dummy"/>
+      </group>
+      <bundle id="httpd-bundle">
+        <docker image="pcmk:http" replicas="3"/>
+        <network ip-range-start="192.168.122.131" host-netmask="24" host-interface="eth0">
+          <port-mapping id="httpd-port" port="80"/>
+        </network>
+        <storage>
+          <storage-mapping id="httpd-syslog" source-dir="/dev/log" target-dir="/dev/log" options="rw"/>
+          <storage-mapping id="httpd-root" source-dir="/srv/html" target-dir="/var/www/html" options="rw"/>
+          <storage-mapping id="httpd-logs" source-dir-root="/var/log/pacemaker/bundles" target-dir="/etc/httpd/logs" options="rw"/>
+        </storage>
+        <primitive class="ocf" id="httpd" provider="heartbeat" type="apache"/>
+        <meta_attributes id="bundle-meta_attributes">
+          <nvpair id="bundle-meta_attributes-target-role" name="target-role" value="Started"/>
+        </meta_attributes>
+      </bundle>
+      <group id="exim-group">
+        <primitive id="Public-IP" class="ocf" type="IPaddr" provider="heartbeat">
+          <instance_attributes id="params-public-ip">
+            <nvpair id="public-ip-addr" name="ip" value="192.168.1.1"/>
+          </instance_attributes>
+        </primitive>
+        <primitive id="Email" class="lsb" type="exim"/>
+      </group>
+      <clone id="mysql-clone-group">
+        <group id="mysql-group">
+          <primitive id="mysql-proxy" class="lsb" type="mysql-proxy">
+            <operations>
+              <op name="monitor" interval="10s" id="mysql-proxy_mon" timeout="20s"/>
+            </operations>
+          </primitive>
+        </group>
+      </clone>
+      <clone id="promotable-clone">
+        <meta_attributes id="promotable-clone-meta_attributes">
+          <nvpair id="promotable-clone-meta_attributes-promotable" name="promotable" value="true"/>
+        </meta_attributes>
+        <primitive id="promotable-rsc" class="ocf" provider="pacemaker" type="Stateful" description="test_description">
+          <operations id="promotable-rsc-operations">
+            <op id="promotable-rsc-monitor-promoted-5" name="monitor" interval="5" role="Promoted"/>
+            <op id="promotable-rsc-monitor-unpromoted-10" name="monitor" interval="10" role="Unpromoted"/>
+          </operations>
+        </primitive>
+      </clone>
+    </resources>
+    <constraints>
+      <rsc_location id="not-on-cluster1" rsc="dummy" node="cluster01" score="-INFINITY"/>
+      <rsc_location id="loc-promotable-clone" rsc="promotable-clone">
+        <rule id="loc-promotable-clone-rule" role="Promoted" score="10">
+          <expression attribute="#uname" id="loc-promotable-clone-expression" operation="eq" value="cluster02"/>
+        </rule>
+      </rsc_location>
+    </constraints>
+    <tags>
+      <tag id="all-nodes">
+        <obj_ref id="1"/>
+        <obj_ref id="2"/>
+      </tag>
+      <tag id="even-nodes">
+        <obj_ref id="2"/>
+      </tag>
+      <tag id="odd-nodes">
+        <obj_ref id="1"/>
+      </tag>
+      <tag id="inactive-rscs">
+        <obj_ref id="inactive-group"/>
+        <obj_ref id="inactive-clone"/>
+      </tag>
+      <tag id="fencing-rscs">
+        <obj_ref id="Fencing"/>
+      </tag>
+    </tags>
+    <op_defaults>
+      <meta_attributes id="op_defaults-options">
+        <nvpair id="op_defaults-options-timeout" name="timeout" value="5s"/>
+      </meta_attributes>
+    </op_defaults>
+  </configuration>
+  <status>
+    <node_state id="2" uname="cluster02" in_ccm="true" crmd="online" crm-debug-origin="do_update_resource" join="member" expected="member">
+      <lrm id="2">
+        <lrm_resources>
+          <lrm_resource id="ping" type="ping" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="ping_last_0" operation_key="ping_start_0" operation="start" crm-debug-origin="do_update_resource" transition-key="9:0:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" transition-magic="0:0;9:0:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" exit-reason="" on_node="cluster02" call-id="11" rc-code="0" op-status="0" interval="0" exec-time="2044" queue-time="0" op-digest="769dd6f95f1494d416ae9dc690960e17"/>
+            <lrm_rsc_op id="ping_monitor_10000" operation_key="ping_monitor_10000" operation="monitor" crm-debug-origin="do_update_resource" transition-key="10:0:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" transition-magic="0:0;10:0:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" exit-reason="" on_node="cluster02" call-id="12" rc-code="0" op-status="0" interval="10000" exec-time="2031" queue-time="0" op-digest="7beffd8be749b787fabea4aef5df21c9"/>
+          </lrm_resource>
+          <lrm_resource id="Fencing" type="fence_xvm" class="stonith">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_monitor_0" operation="monitor" crm-debug-origin="do_update_resource" transition-key="5:0:7:4a9e64d6-e1dd-4395-917c-1596312eafe4" transition-magic="0:7;5:0:7:4a9e64d6-e1dd-4395-917c-1596312eafe4" exit-reason="" on_node="cluster02" call-id="10" rc-code="7" op-status="0" interval="0" exec-time="3" queue-time="0" op-digest="7da16842ab2328e41f737cab5e5fc89c"/>
+          </lrm_resource>
+          <lrm_resource id="dummy" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="dummy_last_0" operation_key="dummy_start_0" operation="start" crm-debug-origin="do_update_resource" transition-key="14:1:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" transition-magic="0:0;14:1:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" exit-reason="" on_node="cluster02" call-id="18" rc-code="0" op-status="0" interval="0" exec-time="6020" queue-time="0" op-digest="aa0f9b7caf28600646551adb55bd9b95" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="aa0f9b7caf28600646551adb55bd9b95" op-secure-params=" passwd " op-secure-digest="aa0f9b7caf28600646551adb55bd9b95"/>
+            <lrm_rsc_op id="dummy_monitor_60000" operation_key="dummy_monitor_60000" operation="monitor" crm-debug-origin="do_update_resource" transition-key="16:2:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" transition-magic="0:0;16:2:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" exit-reason="" on_node="cluster02" call-id="19" rc-code="0" op-status="0" interval="60000" exec-time="6015" queue-time="0" op-digest="ccfee4afbb0618907016c9bef210b8b6" op-secure-params=" passwd " op-secure-digest="aa0f9b7caf28600646551adb55bd9b95"/>
+          </lrm_resource>
+          <lrm_resource id="Public-IP" class="ocf" provider="heartbeat" type="IPaddr">
+            <lrm_rsc_op id="Public-IP_last_0" operation_key="Public-IP_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="3bb21cd55b79809a3ae69333a8981fd4"/>
+          </lrm_resource>
+          <lrm_resource id="Email" class="lsb" type="exim">
+            <lrm_rsc_op id="Email_last_0" operation_key="Email_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="mysql-proxy" class="lsb" type="mysql-proxy">
+            <lrm_rsc_op id="mysql-proxy_last_0" operation_key="mysql-proxy_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="mysql-proxy_monitor_10000" operation_key="mysql-proxy_monitor_10000" operation="monitor" crm-debug-origin="crm_simulate" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="10000" exec-time="0" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd"/>
+          </lrm_resource>
+          <lrm_resource id="promotable-rsc" class="ocf" provider="pacemaker" type="Stateful">
+            <lrm_rsc_op id="promotable-rsc_last_0" operation_key="promotable-rsc_promote_0" operation="promote" crm-debug-origin="crm_simulate" transition-key="6:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;6:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="6" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="promotable-rsc_post_notify_start_0" operation_key="promotable-rsc_notify_0" operation="notify" crm-debug-origin="crm_simulate" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="promotable-rsc_monitor_10000" operation_key="promotable-rsc_monitor_10000" operation="monitor" crm-debug-origin="crm_simulate" transition-key="4:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;4:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="4" rc-code="0" op-status="0" interval="10000" exec-time="0" queue-time="0" op-digest="79643b49fcd2a15282788271c56eddb4"/>
+            <lrm_rsc_op id="promotable-rsc_cancel_10000" operation_key="promotable-rsc_cancel_10000" operation="cancel" crm-debug-origin="crm_simulate" transition-key="5:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;5:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="5" rc-code="0" op-status="0" interval="10000" exec-time="0" queue-time="0" op-digest="79643b49fcd2a15282788271c56eddb4"/>
+            <lrm_rsc_op id="promotable-rsc_monitor_5000" operation_key="promotable-rsc_monitor_5000" operation="monitor" crm-debug-origin="crm_simulate" transition-key="7:-1:8:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:8;7:-1:8:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="7" rc-code="8" op-status="0" interval="5000" exec-time="0" queue-time="0" op-digest="79643b49fcd2a15282788271c56eddb4"/>
+          </lrm_resource>
+          <lrm_resource id="inactive-dhcpd" class="lsb" type="dhcpd">
+            <lrm_rsc_op id="inactive-dhcpd_last_0" operation_key="inactive-dhcpd_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="inactive-dummy-1" class="ocf" provider="pacemaker" type="Dummy">
+            <lrm_rsc_op id="inactive-dummy-1_last_0" operation_key="inactive-dummy-1_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="inactive-dummy-2" class="ocf" provider="pacemaker" type="Dummy">
+            <lrm_rsc_op id="inactive-dummy-2_last_0" operation_key="inactive-dummy-2_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-ip-192.168.122.131" class="ocf" provider="heartbeat" type="IPaddr2">
+            <lrm_rsc_op id="httpd-bundle-ip-192.168.122.131_last_0" operation_key="httpd-bundle-ip-192.168.122.131_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="8656419d4ed26465c724189832393477"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-docker-0" class="ocf" provider="heartbeat" type="docker">
+            <lrm_rsc_op id="httpd-bundle-docker-0_last_0" operation_key="httpd-bundle-docker-0_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="02a1a0b2dfa1cade1893713b56939c55"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-ip-192.168.122.132" class="ocf" provider="heartbeat" type="IPaddr2">
+            <lrm_rsc_op id="httpd-bundle-ip-192.168.122.132_last_0" operation_key="httpd-bundle-ip-192.168.122.132_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="c3d96a2922c2946905f760df9a177cd1"/>
+            <lrm_rsc_op id="httpd-bundle-ip-192.168.122.132_monitor_60000" operation_key="httpd-bundle-ip-192.168.122.132_monitor_60000" operation="monitor" crm-debug-origin="crm_simulate" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="60000" exec-time="0" queue-time="0" op-digest="547dff7d7a9d7448dd07cde35966f08a"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-docker-1" class="ocf" provider="heartbeat" type="docker">
+            <lrm_rsc_op id="httpd-bundle-docker-1_last_0" operation_key="httpd-bundle-docker-1_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="2edb33b196e2261c6b3e30ce579e0590"/>
+            <lrm_rsc_op id="httpd-bundle-docker-1_monitor_60000" operation_key="httpd-bundle-docker-1_monitor_60000" operation="monitor" crm-debug-origin="crm_simulate" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="60000" exec-time="0" queue-time="0" op-digest="1ed1cced876b80101858caac9836e113"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-ip-192.168.122.133" class="ocf" provider="heartbeat" type="IPaddr2">
+            <lrm_rsc_op id="httpd-bundle-ip-192.168.122.133_last_0" operation_key="httpd-bundle-ip-192.168.122.133_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f318115a675fd430c293a0dc2705f398"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-docker-2" class="ocf" provider="heartbeat" type="docker">
+            <lrm_rsc_op id="httpd-bundle-docker-2_last_0" operation_key="httpd-bundle-docker-2_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="6680384ac1363763d9d5cca296be0b2d"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-0" class="ocf" provider="pacemaker" type="remote">
+            <lrm_rsc_op id="httpd-bundle-0_last_0" operation_key="httpd-bundle-0_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="c535429017a9ee0785106fbef2858a41"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-1" class="ocf" provider="pacemaker" type="remote">
+            <lrm_rsc_op id="httpd-bundle-1_last_0" operation_key="httpd-bundle-1_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="791bcda8f6693465cc318cba5302a8df"/>
+            <lrm_rsc_op id="httpd-bundle-1_monitor_30000" operation_key="httpd-bundle-1_monitor_30000" operation="monitor" crm-debug-origin="crm_simulate" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="30000" exec-time="0" queue-time="0" op-digest="7592cb10fa1499772a031adfd385f558"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+      <transient_attributes id="2">
+        <instance_attributes id="status-2">
+          <nvpair id="status-2-pingd" name="pingd" value="1000"/>
+        </instance_attributes>
+      </transient_attributes>
+    </node_state>
+    <node_state id="1" uname="cluster01" in_ccm="true" crmd="online" crm-debug-origin="do_update_resource" join="member" expected="member">
+      <lrm id="1">
+        <lrm_resources>
+          <lrm_resource id="ping" type="ping" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="ping_last_0" operation_key="ping_start_0" operation="start" crm-debug-origin="do_update_resource" transition-key="6:1:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" transition-magic="0:0;6:1:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" exit-reason="" on_node="cluster01" call-id="17" rc-code="0" op-status="0" interval="0" exec-time="2038" queue-time="0" op-digest="769dd6f95f1494d416ae9dc690960e17"/>
+            <lrm_rsc_op id="ping_monitor_10000" operation_key="ping_monitor_10000" operation="monitor" crm-debug-origin="do_update_resource" transition-key="7:1:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" transition-magic="0:0;7:1:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" exit-reason="" on_node="cluster01" call-id="18" rc-code="0" op-status="0" interval="10000" exec-time="2034" queue-time="0" op-digest="7beffd8be749b787fabea4aef5df21c9"/>
+          </lrm_resource>
+          <lrm_resource id="Fencing" type="fence_xvm" class="stonith">
+            <lrm_rsc_op id="Fencing_last_0" operation_key="Fencing_start_0" operation="start" crm-debug-origin="do_update_resource" transition-key="12:1:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" transition-magic="0:0;12:1:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" exit-reason="" on_node="cluster01" call-id="15" rc-code="0" op-status="0" interval="0" exec-time="36" queue-time="0" op-digest="7da16842ab2328e41f737cab5e5fc89c"/>
+            <lrm_rsc_op id="Fencing_monitor_60000" operation_key="Fencing_monitor_60000" operation="monitor" crm-debug-origin="crm_simulate" transition-key="20:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;20:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" on_node="cluster01" call-id="20" rc-code="0" op-status="0" interval="60000" exec-time="0" queue-time="0" op-digest="d4ee02dc1c7ce16eb0f72e06c2cc9193"/>
+          </lrm_resource>
+          <lrm_resource id="dummy" type="Dummy" class="ocf" provider="pacemaker">
+            <lrm_rsc_op id="dummy_last_0" operation_key="dummy_stop_0" operation="stop" crm-debug-origin="do_update_resource" transition-key="3:1:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" transition-magic="0:0;3:1:0:4a9e64d6-e1dd-4395-917c-1596312eafe4" exit-reason="" on_node="cluster01" call-id="16" rc-code="0" op-status="0" interval="0" exec-time="6048" queue-time="0" op-digest="aa0f9b7caf28600646551adb55bd9b95" op-force-restart=" envfile  op_sleep  passwd  state " op-restart-digest="aa0f9b7caf28600646551adb55bd9b95" op-secure-params=" passwd " op-secure-digest="aa0f9b7caf28600646551adb55bd9b95"/>
+          </lrm_resource>
+          <lrm_resource id="Public-IP" class="ocf" provider="heartbeat" type="IPaddr">
+            <lrm_rsc_op id="Public-IP_last_0" operation_key="Public-IP_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="3bb21cd55b79809a3ae69333a8981fd4"/>
+          </lrm_resource>
+          <lrm_resource id="Email" class="lsb" type="exim">
+            <lrm_rsc_op id="Email_last_0" operation_key="Email_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="mysql-proxy" class="lsb" type="mysql-proxy">
+            <lrm_rsc_op id="mysql-proxy_last_0" operation_key="mysql-proxy_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="mysql-proxy_monitor_10000" operation_key="mysql-proxy_monitor_10000" operation="monitor" crm-debug-origin="crm_simulate" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="10000" exec-time="0" queue-time="0" op-digest="4811cef7f7f94e3a35a70be7916cb2fd"/>
+          </lrm_resource>
+          <lrm_resource id="promotable-rsc" class="ocf" provider="pacemaker" type="Stateful">
+            <lrm_rsc_op id="promotable-rsc_last_0" operation_key="promotable-rsc_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="promotable-rsc_post_notify_start_0" operation_key="promotable-rsc_notify_0" operation="notify" crm-debug-origin="crm_simulate" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+            <lrm_rsc_op id="promotable-rsc_monitor_10000" operation_key="promotable-rsc_monitor_10000" operation="monitor" crm-debug-origin="crm_simulate" transition-key="4:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;4:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="4" rc-code="0" op-status="0" interval="10000" exec-time="0" queue-time="0" op-digest="79643b49fcd2a15282788271c56eddb4"/>
+          </lrm_resource>
+          <lrm_resource id="inactive-dhcpd" class="lsb" type="dhcpd">
+            <lrm_rsc_op id="inactive-dhcpd_last_0" operation_key="inactive-dhcpd_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="inactive-dummy-1" class="ocf" provider="pacemaker" type="Dummy">
+            <lrm_rsc_op id="inactive-dummy-1_last_0" operation_key="inactive-dummy-1_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="inactive-dummy-2" class="ocf" provider="pacemaker" type="Dummy">
+            <lrm_rsc_op id="inactive-dummy-2_last_0" operation_key="inactive-dummy-2_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-ip-192.168.122.131" class="ocf" provider="heartbeat" type="IPaddr2">
+            <lrm_rsc_op id="httpd-bundle-ip-192.168.122.131_last_0" operation_key="httpd-bundle-ip-192.168.122.131_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="8656419d4ed26465c724189832393477"/>
+            <lrm_rsc_op id="httpd-bundle-ip-192.168.122.131_monitor_60000" operation_key="httpd-bundle-ip-192.168.122.131_monitor_60000" operation="monitor" crm-debug-origin="crm_simulate" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="60000" exec-time="0" queue-time="0" op-digest="dfb531456299aa7b527d4e57805703da"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-docker-0" class="ocf" provider="heartbeat" type="docker">
+            <lrm_rsc_op id="httpd-bundle-docker-0_last_0" operation_key="httpd-bundle-docker-0_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="02a1a0b2dfa1cade1893713b56939c55"/>
+            <lrm_rsc_op id="httpd-bundle-docker-0_monitor_60000" operation_key="httpd-bundle-docker-0_monitor_60000" operation="monitor" crm-debug-origin="crm_simulate" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="60000" exec-time="0" queue-time="0" op-digest="377a66c466df6e6edf98a6e83cff9c22"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-ip-192.168.122.132" class="ocf" provider="heartbeat" type="IPaddr2">
+            <lrm_rsc_op id="httpd-bundle-ip-192.168.122.132_last_0" operation_key="httpd-bundle-ip-192.168.122.132_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="c3d96a2922c2946905f760df9a177cd1"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-docker-1" class="ocf" provider="heartbeat" type="docker">
+            <lrm_rsc_op id="httpd-bundle-docker-1_last_0" operation_key="httpd-bundle-docker-1_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="2edb33b196e2261c6b3e30ce579e0590"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-ip-192.168.122.133" class="ocf" provider="heartbeat" type="IPaddr2">
+            <lrm_rsc_op id="httpd-bundle-ip-192.168.122.133_last_0" operation_key="httpd-bundle-ip-192.168.122.133_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f318115a675fd430c293a0dc2705f398"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-docker-2" class="ocf" provider="heartbeat" type="docker">
+            <lrm_rsc_op id="httpd-bundle-docker-2_last_0" operation_key="httpd-bundle-docker-2_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="6680384ac1363763d9d5cca296be0b2d"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-0" class="ocf" provider="pacemaker" type="remote">
+            <lrm_rsc_op id="httpd-bundle-0_last_0" operation_key="httpd-bundle-0_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="c535429017a9ee0785106fbef2858a41"/>
+            <lrm_rsc_op id="httpd-bundle-0_monitor_30000" operation_key="httpd-bundle-0_monitor_30000" operation="monitor" crm-debug-origin="crm_simulate" transition-key="3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;3:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="3" rc-code="0" op-status="0" interval="30000" exec-time="0" queue-time="0" op-digest="6d63e20548871f169e287d33f3711637"/>
+          </lrm_resource>
+          <lrm_resource id="httpd-bundle-1" class="ocf" provider="pacemaker" type="remote">
+            <lrm_rsc_op id="httpd-bundle-1_last_0" operation_key="httpd-bundle-1_monitor_0" operation="monitor" crm-debug-origin="crm_simulate" transition-key="1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:7;1:-1:7:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="7" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="791bcda8f6693465cc318cba5302a8df"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+      <transient_attributes id="1">
+        <instance_attributes id="status-1">
+          <nvpair id="status-1-pingd" name="pingd" value="1000"/>
+        </instance_attributes>
+      </transient_attributes>
+    </node_state>
+    <node_state id="httpd-bundle-0" uname="httpd-bundle-0">
+      <lrm id="httpd-bundle-0">
+        <lrm_resources>
+          <lrm_resource id="httpd" class="ocf" provider="heartbeat" type="apache">
+            <lrm_rsc_op id="httpd_last_0" operation_key="httpd_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <node_state id="httpd-bundle-1" uname="httpd-bundle-1">
+      <lrm id="httpd-bundle-1">
+        <lrm_resources>
+          <lrm_resource id="httpd" class="ocf" provider="heartbeat" type="apache">
+            <lrm_rsc_op id="httpd_last_0" operation_key="httpd_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;1:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="1" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+  </status>
+</cib>
+=#=#=#= End test: Get active shadow instance's contents (copied) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's contents (copied)
+=#=#=#= Begin test: Get active shadow instance's diff (copied) =#=#=#=
+=#=#=#= End test: Get active shadow instance's diff (copied) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's diff (copied)
+=#=#=#= Begin test: Get active shadow instance's diff (after changes) =#=#=#=
+Diff: --- 1.1.173 2
+Diff: +++ 1.4.1 (null)
+-- /cib/configuration/op_defaults
++  /cib:  @epoch=4, @num_updates=1
++  /cib/configuration/resources/primitive[@id='dummy']:  @description=desc
+++ /cib/configuration/resources:  <primitive id="dummy1" class="ocf" provider="pacemaker" type="Dummy"/>
+++ /cib/status:  <node_state id="3" uname="cluster03" in_ccm="true" crmd="online" crm-debug-origin="do_update_resource" join="member" expected="member"/>
+=#=#=#= End test: Get active shadow instance's diff (after changes) - Error occurred (1) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's diff (after changes)
+=#=#=#= Begin test: Commit shadow instance =#=#=#=
+crm_shadow: The supplied command is considered dangerous.
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Commit shadow instance - Incorrect usage (64) =#=#=#=
+* Passed: crm_shadow     - Commit shadow instance
+=#=#=#= Begin test: Commit shadow instance (force) =#=#=#=
+Please remember to unset the CIB_shadow variable by pasting the following into your shell:
+  unset CIB_shadow
+=#=#=#= End test: Commit shadow instance (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Commit shadow instance (force)
+=#=#=#= Begin test: Get active shadow instance's diff (after commit) =#=#=#=
+Diff: --- 1.1.173 2
+Diff: +++ 1.4.1 (null)
+-- /cib/configuration/op_defaults
++  /cib:  @epoch=4, @num_updates=1
++  /cib/configuration/resources/primitive[@id='dummy']:  @description=desc
+++ /cib/configuration/resources:  <primitive id="dummy1" class="ocf" provider="pacemaker" type="Dummy"/>
+++ /cib/status:  <node_state id="3" uname="cluster03" in_ccm="true" crmd="online" crm-debug-origin="do_update_resource" join="member" expected="member"/>
+=#=#=#= End test: Get active shadow instance's diff (after commit) - Error occurred (1) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's diff (after commit)
+=#=#=#= Begin test: Commit shadow instance (force) (all) =#=#=#=
+Please remember to unset the CIB_shadow variable by pasting the following into your shell:
+  unset CIB_shadow
+=#=#=#= End test: Commit shadow instance (force) (all) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Commit shadow instance (force) (all)
+=#=#=#= Begin test: Get active shadow instance's diff (after commit all) =#=#=#=
+Diff: --- 1.1.173 2
+Diff: +++ 1.4.1 (null)
+-- /cib/configuration/op_defaults
++  /cib:  @epoch=4, @num_updates=1
++  /cib/configuration/resources/primitive[@id='dummy']:  @description=desc
+++ /cib/configuration/resources:  <primitive id="dummy1" class="ocf" provider="pacemaker" type="Dummy"/>
+++ /cib/status:  <node_state id="3" uname="cluster03" in_ccm="true" crmd="online" crm-debug-origin="do_update_resource" join="member" expected="member"/>
+=#=#=#= End test: Get active shadow instance's diff (after commit all) - Error occurred (1) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's diff (after commit all)
+=#=#=#= Begin test: Commit shadow instance (no active instance) =#=#=#=
+crm_shadow: The supplied command is considered dangerous.
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Commit shadow instance (no active instance) - Incorrect usage (64) =#=#=#=
+* Passed: crm_shadow     - Commit shadow instance (no active instance)
+=#=#=#= Begin test: Commit shadow instance (no active instance) (force) =#=#=#=
+Please remember to unset the CIB_shadow variable by pasting the following into your shell:
+  unset CIB_shadow
+=#=#=#= End test: Commit shadow instance (no active instance) (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Commit shadow instance (no active instance) (force)
+=#=#=#= Begin test: Commit shadow instance (mismatch) =#=#=#=
+crm_shadow: The supplied shadow instance (cts-cli) is not the same as the active one (nonexistent_shadow).
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Commit shadow instance (mismatch) - Incorrect usage (64) =#=#=#=
+* Passed: crm_shadow     - Commit shadow instance (mismatch)
+=#=#=#= Begin test: Commit shadow instance (mismatch) (force) =#=#=#=
+Please remember to unset the CIB_shadow variable by pasting the following into your shell:
+  unset CIB_shadow
+=#=#=#= End test: Commit shadow instance (mismatch) (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Commit shadow instance (mismatch) (force)
+=#=#=#= Begin test: Commit shadow instance (nonexistent shadow file) =#=#=#=
+crm_shadow: The supplied command is considered dangerous.
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Commit shadow instance (nonexistent shadow file) - Incorrect usage (64) =#=#=#=
+* Passed: crm_shadow     - Commit shadow instance (nonexistent shadow file)
+=#=#=#= Begin test: Commit shadow instance (nonexistent shadow file) (force) =#=#=#=
+crm_shadow: Could not access shadow instance 'nonexistent_shadow': No such file or directory
+=#=#=#= End test: Commit shadow instance (nonexistent shadow file) (force) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Commit shadow instance (nonexistent shadow file) (force)
+=#=#=#= Begin test: Get active shadow instance's diff (nonexistent shadow file) =#=#=#=
+crm_shadow: Could not access shadow instance 'nonexistent_shadow': No such file or directory
+=#=#=#= End test: Get active shadow instance's diff (nonexistent shadow file) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's diff (nonexistent shadow file)
+=#=#=#= Begin test: Commit shadow instance (nonexistent CIB file) =#=#=#=
+crm_shadow: The supplied command is considered dangerous.
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Commit shadow instance (nonexistent CIB file) - Incorrect usage (64) =#=#=#=
+* Passed: crm_shadow     - Commit shadow instance (nonexistent CIB file)
+=#=#=#= Begin test: Commit shadow instance (nonexistent CIB file) (force) =#=#=#=
+crm_shadow: Could not connect to CIB: No such device or address
+=#=#=#= End test: Commit shadow instance (nonexistent CIB file) (force) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Commit shadow instance (nonexistent CIB file) (force)
+=#=#=#= Begin test: Get active shadow instance's diff (nonexistent CIB file) =#=#=#=
+crm_shadow: Could not connect to CIB: No such device or address
+=#=#=#= End test: Get active shadow instance's diff (nonexistent CIB file) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's diff (nonexistent CIB file)
+=#=#=#= Begin test: Delete shadow instance =#=#=#=
+crm_shadow: The supplied command is considered dangerous.
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Delete shadow instance - Incorrect usage (64) =#=#=#=
+* Passed: crm_shadow     - Delete shadow instance
+=#=#=#= Begin test: Delete shadow instance (force) =#=#=#=
+Please remember to unset the CIB_shadow variable by pasting the following into your shell:
+  unset CIB_shadow
+=#=#=#= End test: Delete shadow instance (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Delete shadow instance (force)
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= Begin test: Delete shadow instance (no active instance) =#=#=#=
+crm_shadow: The supplied command is considered dangerous.
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Delete shadow instance (no active instance) - Incorrect usage (64) =#=#=#=
+* Passed: crm_shadow     - Delete shadow instance (no active instance)
+=#=#=#= Begin test: Delete shadow instance (no active instance) (force) =#=#=#=
+Please remember to unset the CIB_shadow variable by pasting the following into your shell:
+  unset CIB_shadow
+=#=#=#= End test: Delete shadow instance (no active instance) (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Delete shadow instance (no active instance) (force)
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= Begin test: Delete shadow instance (mismatch) =#=#=#=
+crm_shadow: The supplied shadow instance (cts-cli) is not the same as the active one (nonexistent_shadow).
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Delete shadow instance (mismatch) - Incorrect usage (64) =#=#=#=
+* Passed: crm_shadow     - Delete shadow instance (mismatch)
+=#=#=#= Begin test: Delete shadow instance (mismatch) (force) =#=#=#=
+Please remember to unset the CIB_shadow variable by pasting the following into your shell:
+  unset CIB_shadow
+=#=#=#= End test: Delete shadow instance (mismatch) (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Delete shadow instance (mismatch) (force)
+=#=#=#= Begin test: Delete shadow instance (nonexistent shadow file) =#=#=#=
+crm_shadow: The supplied command is considered dangerous.
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Delete shadow instance (nonexistent shadow file) - Incorrect usage (64) =#=#=#=
+* Passed: crm_shadow     - Delete shadow instance (nonexistent shadow file)
+=#=#=#= Begin test: Delete shadow instance (nonexistent shadow file) (force) =#=#=#=
+Please remember to unset the CIB_shadow variable by pasting the following into your shell:
+  unset CIB_shadow
+=#=#=#= End test: Delete shadow instance (nonexistent shadow file) (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Delete shadow instance (nonexistent shadow file) (force)
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= Begin test: Delete shadow instance (nonexistent CIB file) =#=#=#=
+crm_shadow: The supplied command is considered dangerous.
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Delete shadow instance (nonexistent CIB file) - Incorrect usage (64) =#=#=#=
+* Passed: crm_shadow     - Delete shadow instance (nonexistent CIB file)
+=#=#=#= Begin test: Delete shadow instance (nonexistent CIB file) (force) =#=#=#=
+Please remember to unset the CIB_shadow variable by pasting the following into your shell:
+  unset CIB_shadow
+=#=#=#= End test: Delete shadow instance (nonexistent CIB file) (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Delete shadow instance (nonexistent CIB file) (force)
+=#=#=#= Begin test: Create copied shadow instance (no active instance) =#=#=#=
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Create copied shadow instance (no active instance) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Create copied shadow instance (no active instance)
+=#=#=#= Begin test: Create copied shadow instance (mismatch) =#=#=#=
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Create copied shadow instance (mismatch) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Create copied shadow instance (mismatch)
+=#=#=#= Begin test: Create copied shadow instance (mismatch) (force) =#=#=#=
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Create copied shadow instance (mismatch) (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Create copied shadow instance (mismatch) (force)
+=#=#=#= Begin test: Create copied shadow instance (file already exists) =#=#=#=
+crm_shadow: A shadow instance 'cts-cli' already exists.
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Create copied shadow instance (file already exists) - Cannot create output file (73) =#=#=#=
+* Passed: crm_shadow     - Create copied shadow instance (file already exists)
+=#=#=#= Begin test: Create copied shadow instance (file already exists) (force) =#=#=#=
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Create copied shadow instance (file already exists) (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Create copied shadow instance (file already exists) (force)
+=#=#=#= Begin test: Create copied shadow instance (nonexistent CIB file) (force) =#=#=#=
+crm_shadow: Could not connect to CIB: No such device or address
+=#=#=#= End test: Create copied shadow instance (nonexistent CIB file) (force) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Create copied shadow instance (nonexistent CIB file) (force)
+=#=#=#= Begin test: Create empty shadow instance =#=#=#=
+Created new pacemaker configuration
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Create empty shadow instance - OK (0) =#=#=#=
+* Passed: crm_shadow     - Create empty shadow instance
+=#=#=#= Begin test: Create empty shadow instance (no active instance) =#=#=#=
+Created new pacemaker configuration
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Create empty shadow instance (no active instance) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Create empty shadow instance (no active instance)
+=#=#=#= Begin test: Create empty shadow instance (mismatch) =#=#=#=
+crm_shadow: The supplied shadow instance (cts-cli) is not the same as the active one (nonexistent_shadow).
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Create empty shadow instance (mismatch) - Incorrect usage (64) =#=#=#=
+* Passed: crm_shadow     - Create empty shadow instance (mismatch)
+=#=#=#= Begin test: Create empty shadow instance (mismatch) (force) =#=#=#=
+Created new pacemaker configuration
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Create empty shadow instance (mismatch) (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Create empty shadow instance (mismatch) (force)
+=#=#=#= Begin test: Create empty shadow instance (nonexistent CIB file) =#=#=#=
+Created new pacemaker configuration
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Create empty shadow instance (nonexistent CIB file) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Create empty shadow instance (nonexistent CIB file)
+=#=#=#= Begin test: Create empty shadow instance (file already exists) =#=#=#=
+crm_shadow: A shadow instance 'cts-cli' already exists.
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Create empty shadow instance (file already exists) - Cannot create output file (73) =#=#=#=
+* Passed: crm_shadow     - Create empty shadow instance (file already exists)
+=#=#=#= Begin test: Create empty shadow instance (file already exists) (force) =#=#=#=
+Created new pacemaker configuration
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Create empty shadow instance (file already exists) (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Create empty shadow instance (file already exists) (force)
+=#=#=#= Begin test: Get active shadow instance's contents (empty CIB) =#=#=#=
+<cib epoch="1" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config/>
+    <nodes/>
+    <resources/>
+    <constraints/>
+  </configuration>
+  <status/>
+</cib>
+=#=#=#= End test: Get active shadow instance's contents (empty CIB) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's contents (empty CIB)
+=#=#=#= Begin test: Get active shadow instance's diff (empty CIB) =#=#=#=
+Diff: --- 1.1.173 2
+Diff: +++ 0.1.0 (null)
+-- /cib/configuration/crm_config/cluster_property_set[@id='cib-bootstrap-options']
+-- /cib/configuration/nodes/node[@id='1']
+-- /cib/configuration/nodes/node[@id='2']
+-- /cib/configuration/resources/clone[@id='ping-clone']
+-- /cib/configuration/resources/primitive[@id='Fencing']
+-- /cib/configuration/resources/primitive[@id='dummy']
+-- /cib/configuration/resources/clone[@id='inactive-clone']
+-- /cib/configuration/resources/group[@id='inactive-group']
+-- /cib/configuration/resources/bundle[@id='httpd-bundle']
+-- /cib/configuration/resources/group[@id='exim-group']
+-- /cib/configuration/resources/clone[@id='mysql-clone-group']
+-- /cib/configuration/resources/clone[@id='promotable-clone']
+-- /cib/configuration/constraints/rsc_location[@id='not-on-cluster1']
+-- /cib/configuration/constraints/rsc_location[@id='loc-promotable-clone']
+-- /cib/configuration/tags
+-- /cib/configuration/op_defaults
+-- /cib/status/node_state[@id='2']
+-- /cib/status/node_state[@id='1']
+-- /cib/status/node_state[@id='httpd-bundle-0']
+-- /cib/status/node_state[@id='httpd-bundle-1']
++  /cib:  @crm_feature_set=3.17.4, @num_updates=0, @admin_epoch=0
+-- /cib:  @cib-last-written, @update-origin, @update-client, @update-user, @have-quorum, @dc-uuid
+=#=#=#= End test: Get active shadow instance's diff (empty CIB) - Error occurred (1) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's diff (empty CIB)
+=#=#=#= Begin test: Reset shadow instance =#=#=#=
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Reset shadow instance - OK (0) =#=#=#=
+* Passed: crm_shadow     - Reset shadow instance
+=#=#=#= Begin test: Get active shadow instance's diff (after reset) =#=#=#=
+=#=#=#= End test: Get active shadow instance's diff (after reset) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Get active shadow instance's diff (after reset)
+=#=#=#= Begin test: Reset shadow instance (no active instance) =#=#=#=
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Reset shadow instance (no active instance) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Reset shadow instance (no active instance)
+=#=#=#= Begin test: Reset shadow instance (mismatch) =#=#=#=
+crm_shadow: The supplied shadow instance (cts-cli) is not the same as the active one (nonexistent_shadow).
+To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+=#=#=#= End test: Reset shadow instance (mismatch) - Incorrect usage (64) =#=#=#=
+* Passed: crm_shadow     - Reset shadow instance (mismatch)
+=#=#=#= Begin test: Reset shadow instance (mismatch) (force) =#=#=#=
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Reset shadow instance (mismatch) (force) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Reset shadow instance (mismatch) (force)
+Created new pacemaker configuration
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= Begin test: Reset shadow instance (nonexistent CIB file) =#=#=#=
+crm_shadow: Could not connect to CIB: No such device or address
+=#=#=#= End test: Reset shadow instance (nonexistent CIB file) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Reset shadow instance (nonexistent CIB file)
+=#=#=#= Begin test: Reset shadow instance (nonexistent CIB file) (force) =#=#=#=
+crm_shadow: Could not connect to CIB: No such device or address
+=#=#=#= End test: Reset shadow instance (nonexistent CIB file) (force) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Reset shadow instance (nonexistent CIB file) (force)
+=#=#=#= Begin test: Reset shadow instance (nonexistent shadow file) =#=#=#=
+crm_shadow: Could not access shadow instance 'cts-cli': No such file or directory
+=#=#=#= End test: Reset shadow instance (nonexistent shadow file) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Reset shadow instance (nonexistent shadow file)
+=#=#=#= Begin test: Reset shadow instance (nonexistent shadow file) (force) =#=#=#=
+crm_shadow: Could not access shadow instance 'cts-cli': No such file or directory
+=#=#=#= End test: Reset shadow instance (nonexistent shadow file) (force) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Reset shadow instance (nonexistent shadow file) (force)
+Created new pacemaker configuration
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= Begin test: Switch to new shadow instance =#=#=#=
+Setting up shadow instance
+To switch to the named shadow instance, paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Switch to new shadow instance - OK (0) =#=#=#=
+* Passed: crm_shadow     - Switch to new shadow instance
+=#=#=#= Begin test: Switch to nonexistent shadow instance =#=#=#=
+crm_shadow: Could not access shadow instance 'cts-cli': No such file or directory
+=#=#=#= End test: Switch to nonexistent shadow instance - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Switch to nonexistent shadow instance
+=#=#=#= Begin test: Switch to nonexistent shadow instance (force) =#=#=#=
+crm_shadow: Could not access shadow instance 'cts-cli': No such file or directory
+=#=#=#= End test: Switch to nonexistent shadow instance (force) - No such object (105) =#=#=#=
+* Passed: crm_shadow     - Switch to nonexistent shadow instance (force)

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -6550,8 +6550,10 @@ crm_shadow: Could not access shadow instance 'cts-cli': No such file or director
 =#=#=#= End test: Reset shadow instance (nonexistent shadow file) - No such object (105) =#=#=#=
 * Passed: crm_shadow     - Reset shadow instance (nonexistent shadow file)
 =#=#=#= Begin test: Reset shadow instance (nonexistent shadow file) (force) =#=#=#=
-crm_shadow: Could not access shadow instance 'cts-cli': No such file or directory
-=#=#=#= End test: Reset shadow instance (nonexistent shadow file) (force) - No such object (105) =#=#=#=
+Setting up shadow instance
+A new shadow instance was created.  To begin using it paste the following into your shell:
+  CIB_shadow=cts-cli ; export CIB_shadow
+=#=#=#= End test: Reset shadow instance (nonexistent shadow file) (force) - OK (0) =#=#=#=
 * Passed: crm_shadow     - Reset shadow instance (nonexistent shadow file) (force)
 Created new pacemaker configuration
 Setting up shadow instance

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -6271,12 +6271,9 @@ Please remember to unset the CIB_shadow variable by pasting the following into y
 =#=#=#= End test: Commit shadow instance (force) - OK (0) =#=#=#=
 * Passed: crm_shadow     - Commit shadow instance (force)
 =#=#=#= Begin test: Get active shadow instance's diff (after commit) =#=#=#=
-Diff: --- 1.1.173 2
+Diff: --- 1.2.0 2
 Diff: +++ 1.4.1 (null)
--- /cib/configuration/op_defaults
 +  /cib:  @epoch=4, @num_updates=1
-+  /cib/configuration/resources/primitive[@id='dummy']:  @description=desc
-++ /cib/configuration/resources:  <primitive id="dummy1" class="ocf" provider="pacemaker" type="Dummy"/>
 ++ /cib/status:  <node_state id="3" uname="cluster03" in_ccm="true" crmd="online" crm-debug-origin="do_update_resource" join="member" expected="member"/>
 =#=#=#= End test: Get active shadow instance's diff (after commit) - Error occurred (1) =#=#=#=
 * Passed: crm_shadow     - Get active shadow instance's diff (after commit)
@@ -6286,13 +6283,9 @@ Please remember to unset the CIB_shadow variable by pasting the following into y
 =#=#=#= End test: Commit shadow instance (force) (all) - OK (0) =#=#=#=
 * Passed: crm_shadow     - Commit shadow instance (force) (all)
 =#=#=#= Begin test: Get active shadow instance's diff (after commit all) =#=#=#=
-Diff: --- 1.1.173 2
+Diff: --- 1.4.2 2
 Diff: +++ 1.4.1 (null)
--- /cib/configuration/op_defaults
-+  /cib:  @epoch=4, @num_updates=1
-+  /cib/configuration/resources/primitive[@id='dummy']:  @description=desc
-++ /cib/configuration/resources:  <primitive id="dummy1" class="ocf" provider="pacemaker" type="Dummy"/>
-++ /cib/status:  <node_state id="3" uname="cluster03" in_ccm="true" crmd="online" crm-debug-origin="do_update_resource" join="member" expected="member"/>
++  /cib:  @num_updates=1
 =#=#=#= End test: Get active shadow instance's diff (after commit all) - Error occurred (1) =#=#=#=
 * Passed: crm_shadow     - Get active shadow instance's diff (after commit all)
 =#=#=#= Begin test: Commit shadow instance (no active instance) =#=#=#=

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -6261,7 +6261,7 @@ Diff: +++ 1.4.1 (null)
 =#=#=#= End test: Get active shadow instance's diff (after changes) - Error occurred (1) =#=#=#=
 * Passed: crm_shadow     - Get active shadow instance's diff (after changes)
 =#=#=#= Begin test: Commit shadow instance =#=#=#=
-crm_shadow: The supplied command is considered dangerous.
+crm_shadow: The commit command overwrites the active cluster configuration.
 To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
 =#=#=#= End test: Commit shadow instance - Incorrect usage (64) =#=#=#=
 * Passed: crm_shadow     - Commit shadow instance
@@ -6289,7 +6289,7 @@ Diff: +++ 1.4.1 (null)
 =#=#=#= End test: Get active shadow instance's diff (after commit all) - Error occurred (1) =#=#=#=
 * Passed: crm_shadow     - Get active shadow instance's diff (after commit all)
 =#=#=#= Begin test: Commit shadow instance (no active instance) =#=#=#=
-crm_shadow: The supplied command is considered dangerous.
+crm_shadow: The commit command overwrites the active cluster configuration.
 To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
 =#=#=#= End test: Commit shadow instance (no active instance) - Incorrect usage (64) =#=#=#=
 * Passed: crm_shadow     - Commit shadow instance (no active instance)
@@ -6299,7 +6299,8 @@ Please remember to unset the CIB_shadow variable by pasting the following into y
 =#=#=#= End test: Commit shadow instance (no active instance) (force) - OK (0) =#=#=#=
 * Passed: crm_shadow     - Commit shadow instance (no active instance) (force)
 =#=#=#= Begin test: Commit shadow instance (mismatch) =#=#=#=
-crm_shadow: The supplied shadow instance (cts-cli) is not the same as the active one (nonexistent_shadow).
+crm_shadow: The commit command overwrites the active cluster configuration.
+Additionally, the supplied shadow instance (cts-cli) is not the same as the active one (nonexistent_shadow).
 To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
 =#=#=#= End test: Commit shadow instance (mismatch) - Incorrect usage (64) =#=#=#=
 * Passed: crm_shadow     - Commit shadow instance (mismatch)
@@ -6309,7 +6310,7 @@ Please remember to unset the CIB_shadow variable by pasting the following into y
 =#=#=#= End test: Commit shadow instance (mismatch) (force) - OK (0) =#=#=#=
 * Passed: crm_shadow     - Commit shadow instance (mismatch) (force)
 =#=#=#= Begin test: Commit shadow instance (nonexistent shadow file) =#=#=#=
-crm_shadow: The supplied command is considered dangerous.
+crm_shadow: The commit command overwrites the active cluster configuration.
 To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
 =#=#=#= End test: Commit shadow instance (nonexistent shadow file) - Incorrect usage (64) =#=#=#=
 * Passed: crm_shadow     - Commit shadow instance (nonexistent shadow file)
@@ -6322,7 +6323,7 @@ crm_shadow: Could not access shadow instance 'nonexistent_shadow': No such file 
 =#=#=#= End test: Get active shadow instance's diff (nonexistent shadow file) - No such object (105) =#=#=#=
 * Passed: crm_shadow     - Get active shadow instance's diff (nonexistent shadow file)
 =#=#=#= Begin test: Commit shadow instance (nonexistent CIB file) =#=#=#=
-crm_shadow: The supplied command is considered dangerous.
+crm_shadow: The commit command overwrites the active cluster configuration.
 To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
 =#=#=#= End test: Commit shadow instance (nonexistent CIB file) - Incorrect usage (64) =#=#=#=
 * Passed: crm_shadow     - Commit shadow instance (nonexistent CIB file)
@@ -6335,8 +6336,8 @@ crm_shadow: Could not connect to CIB: No such device or address
 =#=#=#= End test: Get active shadow instance's diff (nonexistent CIB file) - No such object (105) =#=#=#=
 * Passed: crm_shadow     - Get active shadow instance's diff (nonexistent CIB file)
 =#=#=#= Begin test: Delete shadow instance =#=#=#=
-crm_shadow: The supplied command is considered dangerous.
-To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+crm_shadow: The delete command removes the specified shadow file.
+To prevent accidental destruction of the shadow file, the --force flag is required in order to proceed.
 =#=#=#= End test: Delete shadow instance - Incorrect usage (64) =#=#=#=
 * Passed: crm_shadow     - Delete shadow instance
 =#=#=#= Begin test: Delete shadow instance (force) =#=#=#=
@@ -6348,8 +6349,8 @@ Setting up shadow instance
 A new shadow instance was created.  To begin using it paste the following into your shell:
   CIB_shadow=cts-cli ; export CIB_shadow
 =#=#=#= Begin test: Delete shadow instance (no active instance) =#=#=#=
-crm_shadow: The supplied command is considered dangerous.
-To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+crm_shadow: The delete command removes the specified shadow file.
+To prevent accidental destruction of the shadow file, the --force flag is required in order to proceed.
 =#=#=#= End test: Delete shadow instance (no active instance) - Incorrect usage (64) =#=#=#=
 * Passed: crm_shadow     - Delete shadow instance (no active instance)
 =#=#=#= Begin test: Delete shadow instance (no active instance) (force) =#=#=#=
@@ -6361,8 +6362,9 @@ Setting up shadow instance
 A new shadow instance was created.  To begin using it paste the following into your shell:
   CIB_shadow=cts-cli ; export CIB_shadow
 =#=#=#= Begin test: Delete shadow instance (mismatch) =#=#=#=
-crm_shadow: The supplied shadow instance (cts-cli) is not the same as the active one (nonexistent_shadow).
-To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+crm_shadow: The delete command removes the specified shadow file.
+Additionally, the supplied shadow instance (cts-cli) is not the same as the active one (nonexistent_shadow).
+To prevent accidental destruction of the shadow file, the --force flag is required in order to proceed.
 =#=#=#= End test: Delete shadow instance (mismatch) - Incorrect usage (64) =#=#=#=
 * Passed: crm_shadow     - Delete shadow instance (mismatch)
 =#=#=#= Begin test: Delete shadow instance (mismatch) (force) =#=#=#=
@@ -6371,8 +6373,8 @@ Please remember to unset the CIB_shadow variable by pasting the following into y
 =#=#=#= End test: Delete shadow instance (mismatch) (force) - OK (0) =#=#=#=
 * Passed: crm_shadow     - Delete shadow instance (mismatch) (force)
 =#=#=#= Begin test: Delete shadow instance (nonexistent shadow file) =#=#=#=
-crm_shadow: The supplied command is considered dangerous.
-To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+crm_shadow: The delete command removes the specified shadow file.
+To prevent accidental destruction of the shadow file, the --force flag is required in order to proceed.
 =#=#=#= End test: Delete shadow instance (nonexistent shadow file) - Incorrect usage (64) =#=#=#=
 * Passed: crm_shadow     - Delete shadow instance (nonexistent shadow file)
 =#=#=#= Begin test: Delete shadow instance (nonexistent shadow file) (force) =#=#=#=
@@ -6384,8 +6386,8 @@ Setting up shadow instance
 A new shadow instance was created.  To begin using it paste the following into your shell:
   CIB_shadow=cts-cli ; export CIB_shadow
 =#=#=#= Begin test: Delete shadow instance (nonexistent CIB file) =#=#=#=
-crm_shadow: The supplied command is considered dangerous.
-To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+crm_shadow: The delete command removes the specified shadow file.
+To prevent accidental destruction of the shadow file, the --force flag is required in order to proceed.
 =#=#=#= End test: Delete shadow instance (nonexistent CIB file) - Incorrect usage (64) =#=#=#=
 * Passed: crm_shadow     - Delete shadow instance (nonexistent CIB file)
 =#=#=#= Begin test: Delete shadow instance (nonexistent CIB file) (force) =#=#=#=
@@ -6522,7 +6524,7 @@ A new shadow instance was created.  To begin using it paste the following into y
 * Passed: crm_shadow     - Reset shadow instance (no active instance)
 =#=#=#= Begin test: Reset shadow instance (mismatch) =#=#=#=
 crm_shadow: The supplied shadow instance (cts-cli) is not the same as the active one (nonexistent_shadow).
-To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+To prevent accidental destruction of the shadow file, the --force flag is required in order to proceed.
 =#=#=#= End test: Reset shadow instance (mismatch) - Incorrect usage (64) =#=#=#=
 * Passed: crm_shadow     - Reset shadow instance (mismatch)
 =#=#=#= Begin test: Reset shadow instance (mismatch) (force) =#=#=#=

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -6413,7 +6413,7 @@ A new shadow instance was created.  To begin using it paste the following into y
 * Passed: crm_shadow     - Create copied shadow instance (mismatch) (force)
 =#=#=#= Begin test: Create copied shadow instance (file already exists) =#=#=#=
 crm_shadow: A shadow instance 'cts-cli' already exists.
-To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+To prevent accidental destruction of the shadow file, the --force flag is required in order to proceed.
 =#=#=#= End test: Create copied shadow instance (file already exists) - Cannot create output file (73) =#=#=#=
 * Passed: crm_shadow     - Create copied shadow instance (file already exists)
 =#=#=#= Begin test: Create copied shadow instance (file already exists) (force) =#=#=#=
@@ -6461,7 +6461,7 @@ A new shadow instance was created.  To begin using it paste the following into y
 * Passed: crm_shadow     - Create empty shadow instance (nonexistent CIB file)
 =#=#=#= Begin test: Create empty shadow instance (file already exists) =#=#=#=
 crm_shadow: A shadow instance 'cts-cli' already exists.
-To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
+To prevent accidental destruction of the shadow file, the --force flag is required in order to proceed.
 =#=#=#= End test: Create empty shadow instance (file already exists) - Cannot create output file (73) =#=#=#=
 * Passed: crm_shadow     - Create empty shadow instance (file already exists)
 =#=#=#= Begin test: Create empty shadow instance (file already exists) (force) =#=#=#=

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -6441,17 +6441,12 @@ A new shadow instance was created.  To begin using it paste the following into y
 =#=#=#= End test: Create empty shadow instance (no active instance) - OK (0) =#=#=#=
 * Passed: crm_shadow     - Create empty shadow instance (no active instance)
 =#=#=#= Begin test: Create empty shadow instance (mismatch) =#=#=#=
-crm_shadow: The supplied shadow instance (cts-cli) is not the same as the active one (nonexistent_shadow).
-To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.
-=#=#=#= End test: Create empty shadow instance (mismatch) - Incorrect usage (64) =#=#=#=
-* Passed: crm_shadow     - Create empty shadow instance (mismatch)
-=#=#=#= Begin test: Create empty shadow instance (mismatch) (force) =#=#=#=
 Created new pacemaker configuration
 Setting up shadow instance
 A new shadow instance was created.  To begin using it paste the following into your shell:
   CIB_shadow=cts-cli ; export CIB_shadow
-=#=#=#= End test: Create empty shadow instance (mismatch) (force) - OK (0) =#=#=#=
-* Passed: crm_shadow     - Create empty shadow instance (mismatch) (force)
+=#=#=#= End test: Create empty shadow instance (mismatch) - OK (0) =#=#=#=
+* Passed: crm_shadow     - Create empty shadow instance (mismatch)
 =#=#=#= Begin test: Create empty shadow instance (nonexistent CIB file) =#=#=#=
 Created new pacemaker configuration
 Setting up shadow instance

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1928,7 +1928,7 @@ function test_tools() {
 
     desc="Reset shadow instance (nonexistent shadow file) (force)"
     cmd="crm_shadow --reset $CIB_shadow --batch --force"
-    test_assert $CRM_EX_NOSUCH 0
+    test_assert $CRM_EX_OK 0
 
     # Switch shadow instances
     # In batch mode, this only displays a message

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1836,10 +1836,6 @@ function test_tools() {
 
     desc="Create empty shadow instance (mismatch)"
     cmd="crm_shadow --create-empty $shadow --batch"
-    test_assert $CRM_EX_USAGE 0
-
-    desc="Create empty shadow instance (mismatch) (force)"
-    cmd="crm_shadow --create-empty $shadow --batch --force"
     test_assert $CRM_EX_OK 0
 
     # CIB_shadow needs to be set for delete_shadow_resource_defaults()

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -83,6 +83,7 @@ CRM_EX_INSUFFICIENT_PRIV=4
 CRM_EX_NOT_CONFIGURED=6
 CRM_EX_USAGE=64
 CRM_EX_DATAERR=65
+CRM_EX_CANTCREAT=73
 CRM_EX_CONFIG=78
 CRM_EX_OLD=103
 CRM_EX_DIGEST=104
@@ -1555,6 +1556,405 @@ function test_tools() {
 
     unset CIB_file
     rm -f "$TMPXML" "$TMPORIG"
+
+
+    # crm_shadow tests
+
+    unset CIB_shadow
+    unset CIB_shadow_dir
+
+    # Query with no active shadow instance
+    desc="Get active shadow instance (no active instance)"
+    cmd="crm_shadow --which"
+    test_assert $CRM_EX_NOSUCH 0
+
+    desc="Get active shadow instance's file name (no active instance)"
+    cmd="crm_shadow --file"
+    test_assert $CRM_EX_NOSUCH 0
+
+    desc="Get active shadow instance's contents (no active instance)"
+    cmd="crm_shadow --display"
+    test_assert $CRM_EX_NOSUCH 0
+
+    desc="Get active shadow instance's diff (no active instance)"
+    cmd="crm_shadow --diff"
+    test_assert $CRM_EX_NOSUCH 0
+
+    # Create new shadow instance based on active CIB
+    # Don't use create_shadow_cib() here; test explicitly
+    export CIB_file="$test_home/cli/crm_mon.xml"
+    export CIB_shadow="$shadow"
+    export CIB_shadow_dir="$shadow_dir"
+
+    # Delete the shadow file if it already exists
+    crm_shadow --delete "$shadow" --force >/dev/null 2>&1
+
+    desc="Create copied shadow instance"
+    cmd="crm_shadow --create $shadow --batch"
+    test_assert $CRM_EX_OK 0
+
+    # Query shadow instance based on active CIB
+    desc="Get active shadow instance (copied)"
+    cmd="crm_shadow --which"
+    test_assert $CRM_EX_OK 0
+
+    desc="Get active shadow instance's file name (copied)"
+    cmd="crm_shadow --file"
+    test_assert $CRM_EX_OK 0
+
+    desc="Get active shadow instance's contents (copied)"
+    cmd="crm_shadow --display"
+    test_assert $CRM_EX_OK 0
+
+    desc="Get active shadow instance's diff (copied)"
+    cmd="crm_shadow --diff"
+    test_assert $CRM_EX_OK 0
+
+    # Make some changes to the shadow file
+    export CIB_file="$(crm_shadow --file)"
+
+    cibadmin --modify --xml-text '<primitive id="dummy" description="desc"/>'
+    cibadmin --delete --xml-text '<op_defaults/>'
+    cibadmin --create -o resources --xml-text \
+        '<primitive id="dummy1" class="ocf" provider="pacemaker" type="Dummy"/>'
+
+    state="<node_state id=\"3\" uname=\"cluster03\" in_ccm=\"true\""
+    state="$state crmd=\"online\" crm-debug-origin=\"do_update_resource\""
+    state="$state join=\"member\" expected=\"member\">"
+
+    cibadmin --create -o status --xml-text "$state"
+    unset state
+
+    export CIB_file="$test_home/cli/crm_mon.xml"
+
+    desc="Get active shadow instance's diff (after changes)"
+    cmd="crm_shadow --diff"
+    test_assert $CRM_EX_ERROR 0
+
+    # Commit the modified shadow CIB to a temp active CIB file
+    cp "$CIB_file" "$TMPXML"
+    export CIB_file="$TMPXML"
+
+    desc="Commit shadow instance"
+    cmd="crm_shadow --commit $shadow"
+    test_assert $CRM_EX_USAGE 0
+
+    desc="Commit shadow instance (force)"
+    cmd="crm_shadow --commit $shadow --force"
+    test_assert $CRM_EX_OK 0
+
+    desc="Get active shadow instance's diff (after commit)"
+    cmd="crm_shadow --diff"
+    test_assert $CRM_EX_ERROR 0
+
+    desc="Commit shadow instance (force) (all)"
+    cmd="crm_shadow --commit $shadow --force --all"
+    test_assert $CRM_EX_OK 0
+
+    desc="Get active shadow instance's diff (after commit all)"
+    cmd="crm_shadow --diff"
+    test_assert $CRM_EX_ERROR 0
+
+    # Commit an inactive shadow instance with no active instance
+    unset CIB_shadow
+
+    desc="Commit shadow instance (no active instance)"
+    cmd="crm_shadow --commit $shadow"
+    test_assert $CRM_EX_USAGE 0
+
+    desc="Commit shadow instance (no active instance) (force)"
+    cmd="crm_shadow --commit $shadow --force"
+    test_assert $CRM_EX_OK 0
+
+    # Commit an inactive shadow instance with an active instance
+    export CIB_shadow="nonexistent_shadow"
+
+    desc="Commit shadow instance (mismatch)"
+    cmd="crm_shadow --commit $shadow"
+    test_assert $CRM_EX_USAGE 0
+
+    desc="Commit shadow instance (mismatch) (force)"
+    cmd="crm_shadow --commit $shadow --force"
+    test_assert $CRM_EX_OK 0
+
+    # Commit an active shadow instance whose shadow file is missing
+    desc="Commit shadow instance (nonexistent shadow file)"
+    cmd="crm_shadow --commit $CIB_shadow"
+    test_assert $CRM_EX_USAGE 0
+
+    desc="Commit shadow instance (nonexistent shadow file) (force)"
+    cmd="crm_shadow --commit $CIB_shadow --force"
+    test_assert $CRM_EX_NOSUCH 0
+
+    desc="Get active shadow instance's diff (nonexistent shadow file)"
+    cmd="crm_shadow --diff"
+    test_assert $CRM_EX_NOSUCH 0
+
+    # Commit an active shadow instance when the CIB file is missing
+    export CIB_file="$test_home/cli/nonexistent_cib.xml"
+    export CIB_shadow="$shadow"
+
+    desc="Commit shadow instance (nonexistent CIB file)"
+    cmd="crm_shadow --commit $shadow"
+    test_assert $CRM_EX_USAGE 0
+
+    desc="Commit shadow instance (nonexistent CIB file) (force)"
+    cmd="crm_shadow --commit $shadow --force"
+    test_assert $CRM_EX_NOSUCH 0
+
+    desc="Get active shadow instance's diff (nonexistent CIB file)"
+    cmd="crm_shadow --diff"
+    test_assert $CRM_EX_NOSUCH 0
+
+    rm -f "$TMPXML"
+
+    # Delete an active shadow instance
+    export CIB_file="$test_home/cli/crm_mon.xml"
+    export CIB_shadow="$shadow"
+
+    desc="Delete shadow instance"
+    cmd="crm_shadow --delete $shadow"
+    test_assert $CRM_EX_USAGE 0
+
+    desc="Delete shadow instance (force)"
+    cmd="crm_shadow --delete $shadow --force"
+    test_assert $CRM_EX_OK 0
+
+    # Delete an inactive shadow instance with no active instance
+    create_shadow_cib --create
+    unset CIB_shadow
+
+    desc="Delete shadow instance (no active instance)"
+    cmd="crm_shadow --delete $shadow"
+    test_assert $CRM_EX_USAGE 0
+
+    desc="Delete shadow instance (no active instance) (force)"
+    cmd="crm_shadow --delete $shadow --force"
+    test_assert $CRM_EX_OK 0
+
+    # Delete an inactive shadow instance with an active instance
+    create_shadow_cib --create
+    export CIB_shadow="nonexistent_shadow"
+
+    desc="Delete shadow instance (mismatch)"
+    cmd="crm_shadow --delete $shadow"
+    test_assert $CRM_EX_USAGE 0
+
+    desc="Delete shadow instance (mismatch) (force)"
+    cmd="crm_shadow --delete $shadow --force"
+    test_assert $CRM_EX_OK 0
+
+    # Delete an active shadow instance whose shadow file is missing
+    desc="Delete shadow instance (nonexistent shadow file)"
+    cmd="crm_shadow --delete $CIB_shadow"
+    test_assert $CRM_EX_USAGE 0
+
+    desc="Delete shadow instance (nonexistent shadow file) (force)"
+    cmd="crm_shadow --delete $CIB_shadow --force"
+    test_assert $CRM_EX_OK 0
+
+    # Delete an active shadow instance when the CIB file is missing
+    export CIB_file="$test_home/cli/crm_mon.xml"
+    create_shadow_cib --create
+    export CIB_file="$test_home/cli/nonexistent_cib.xml"
+
+    desc="Delete shadow instance (nonexistent CIB file)"
+    cmd="crm_shadow --delete $shadow"
+    test_assert $CRM_EX_USAGE 0
+
+    desc="Delete shadow instance (nonexistent CIB file) (force)"
+    cmd="crm_shadow --delete $shadow --force"
+    test_assert $CRM_EX_OK 0
+
+    # Create new shadow instance based on active CIB with no instance active
+    crm_shadow --delete "$shadow" --force >/dev/null 2>&1
+    export CIB_file="$test_home/cli/crm_mon.xml"
+    unset CIB_shadow
+
+    desc="Create copied shadow instance (no active instance)"
+    cmd="crm_shadow --create $shadow --batch"
+    test_assert $CRM_EX_OK 0
+
+    # Create new shadow instance based on active CIB with other instance active
+    crm_shadow --delete "$shadow" --force >/dev/null 2>&1
+    export CIB_file="$test_home/cli/crm_mon.xml"
+    export CIB_shadow="nonexistent_shadow"
+
+    desc="Create copied shadow instance (mismatch)"
+    cmd="crm_shadow --create $shadow --batch"
+    test_assert $CRM_EX_OK 0
+
+    desc="Create copied shadow instance (mismatch) (force)"
+    cmd="crm_shadow --create $shadow --batch --force"
+    test_assert $CRM_EX_OK 0
+
+    # Create new shadow instance based on CIB (shadow file already exists)
+    export CIB_file="$test_home/cli/crm_mon.xml"
+
+    desc="Create copied shadow instance (file already exists)"
+    cmd="crm_shadow --create $shadow --batch"
+    test_assert $CRM_EX_CANTCREAT 0
+
+    desc="Create copied shadow instance (file already exists) (force)"
+    cmd="crm_shadow --create $shadow --batch --force"
+    test_assert $CRM_EX_OK 0
+
+    # Create new shadow instance based on active CIB when the CIB file is missing
+    crm_shadow --delete "$shadow" --force >/dev/null 2>&1
+    export CIB_file="$test_home/cli/nonexistent_cib.xml"
+    export CIB_shadow="$shadow"
+
+    desc="Create copied shadow instance (nonexistent CIB file) (force)"
+    cmd="crm_shadow --create $shadow --batch --force"
+    test_assert $CRM_EX_NOSUCH 0
+
+    # Create new empty shadow instance
+    crm_shadow --delete "$shadow" --force >/dev/null 2>&1
+    export CIB_shadow="$shadow"
+
+    desc="Create empty shadow instance"
+    cmd="crm_shadow --create-empty $shadow --batch"
+    test_assert $CRM_EX_OK 0
+
+    delete_shadow_resource_defaults
+
+    # Create empty shadow instance with no active instance
+    crm_shadow --delete "$shadow" --force >/dev/null 2>&1
+    unset CIB_shadow
+
+    desc="Create empty shadow instance (no active instance)"
+    cmd="crm_shadow --create-empty $shadow --batch"
+    test_assert $CRM_EX_OK 0
+
+    # CIB_shadow needs to be set for delete_shadow_resource_defaults()
+    export CIB_shadow="$shadow"
+    delete_shadow_resource_defaults
+
+    # Create empty shadow instance with other instance active
+    crm_shadow --delete "$shadow" --force >/dev/null 2>&1
+    export CIB_shadow="nonexistent_shadow"
+
+    desc="Create empty shadow instance (mismatch)"
+    cmd="crm_shadow --create-empty $shadow --batch"
+    test_assert $CRM_EX_USAGE 0
+
+    desc="Create empty shadow instance (mismatch) (force)"
+    cmd="crm_shadow --create-empty $shadow --batch --force"
+    test_assert $CRM_EX_OK 0
+
+    # CIB_shadow needs to be set for delete_shadow_resource_defaults()
+    export CIB_shadow="$shadow"
+    delete_shadow_resource_defaults
+
+    # Create empty shadow instance when the CIB file is missing
+    crm_shadow --delete "$shadow" --force >/dev/null 2>&1
+    export CIB_file="$test_home/cli/nonexistent_cib.xml"
+
+    desc="Create empty shadow instance (nonexistent CIB file)"
+    cmd="crm_shadow --create-empty $shadow --batch --force"
+    test_assert $CRM_EX_OK 0
+
+    delete_shadow_resource_defaults
+
+    # Create empty shadow instance (shadow file already exists)
+    export CIB_file="$test_home/cli/crm_mon.xml"
+
+    desc="Create empty shadow instance (file already exists)"
+    cmd="crm_shadow --create-empty $shadow --batch"
+    test_assert $CRM_EX_CANTCREAT 0
+
+    desc="Create empty shadow instance (file already exists) (force)"
+    cmd="crm_shadow --create-empty $shadow --batch --force"
+    test_assert $CRM_EX_OK 0
+
+    delete_shadow_resource_defaults
+
+    # Query shadow instance with an empty CIB.
+    # --which and --file queries were done earlier.
+    desc="Get active shadow instance's contents (empty CIB)"
+    cmd="crm_shadow --display"
+    test_assert $CRM_EX_OK 0
+
+    desc="Get active shadow instance's diff (empty CIB)"
+    cmd="crm_shadow --diff"
+    test_assert $CRM_EX_ERROR 0
+
+    # Reset shadow instance (overwrite existing shadow file based on active CIB)
+    export CIB_file="$test_home/cli/crm_mon.xml"
+    export CIB_shadow="$shadow"
+
+    desc="Reset shadow instance"
+    cmd="crm_shadow --reset $shadow --batch"
+    test_assert $CRM_EX_OK 0
+
+    desc="Get active shadow instance's diff (after reset)"
+    cmd="crm_shadow --diff"
+    test_assert $CRM_EX_OK 0
+
+    # Reset an inactive shadow instance with no active instance
+    unset CIB_shadow
+
+    desc="Reset shadow instance (no active instance)"
+    cmd="crm_shadow --reset $shadow --batch"
+    test_assert $CRM_EX_OK 0
+
+    # Reset an inactive shadow instance with an active instance
+    export CIB_shadow="nonexistent_shadow"
+
+    desc="Reset shadow instance (mismatch)"
+    cmd="crm_shadow --reset $shadow --batch"
+    test_assert $CRM_EX_USAGE 0
+
+    desc="Reset shadow instance (mismatch) (force)"
+    cmd="crm_shadow --reset $shadow --batch --force"
+    test_assert $CRM_EX_OK 0
+
+    # Reset an active shadow instance when the CIB file is missing
+    create_shadow_cib --create-empty
+    export CIB_file="$test_home/cli/nonexistent_cib.xml"
+
+    desc="Reset shadow instance (nonexistent CIB file)"
+    cmd="crm_shadow --reset $CIB_shadow --batch"
+    test_assert $CRM_EX_NOSUCH 0
+
+    desc="Reset shadow instance (nonexistent CIB file) (force)"
+    cmd="crm_shadow --reset $CIB_shadow --batch --force"
+    test_assert $CRM_EX_NOSUCH 0
+
+    # Reset an active shadow instance whose shadow file is missing
+    crm_shadow --delete "$shadow" --force >/dev/null 2>&1
+    export CIB_file="$test_home/cli/crm_mon.xml"
+    export CIB_shadow="$shadow"
+
+    desc="Reset shadow instance (nonexistent shadow file)"
+    cmd="crm_shadow --reset $CIB_shadow --batch"
+    test_assert $CRM_EX_NOSUCH 0
+
+    desc="Reset shadow instance (nonexistent shadow file) (force)"
+    cmd="crm_shadow --reset $CIB_shadow --batch --force"
+    test_assert $CRM_EX_NOSUCH 0
+
+    # Switch shadow instances
+    # In batch mode, this only displays a message
+    create_shadow_cib --create-empty
+
+    desc="Switch to new shadow instance"
+    cmd="crm_shadow --switch $CIB_shadow --batch"
+    test_assert $CRM_EX_OK 0
+
+    crm_shadow --delete "$shadow" --force >/dev/null 2>&1
+
+    desc="Switch to nonexistent shadow instance"
+    cmd="crm_shadow --switch $CIB_shadow --batch"
+    test_assert $CRM_EX_NOSUCH 0
+
+    desc="Switch to nonexistent shadow instance (force)"
+    cmd="crm_shadow --switch $CIB_shadow --batch --force"
+    test_assert $CRM_EX_NOSUCH 0
+
+    unset CIB_file
+    unset CIB_shadow
+    unset CIB_shadow_dir
 }
 
 INVALID_PERIODS=(
@@ -2583,6 +2983,7 @@ for t in $tests; do
         -e 's/.*\(update_validation\)@.*\.c:[0-9][0-9]*)/\1/g' \
         -e 's/.*\(apply_upgrade\)@.*\.c:[0-9][0-9]*)/\1/g' \
         -e "s/ last-rc-change=['\"][-+A-Za-z0-9: ]*['\"],\{0,1\}//" \
+        -e 's|^/tmp/cts-cli\.shadow\.[^/]*/|cts-cli.shadow/|' \
         -e 's|^/tmp/cts-cli\.validity\.bad.xml\.[^:]*:|validity.bad.xml:|'\
         -e 's/^Entity: line [0-9][0-9]*: //'\
         -e 's/\(validation ([0-9][0-9]* of \)[0-9][0-9]*\().*\)/\1X\2/' \

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -442,6 +442,24 @@ show_shadow_instance(GError **error)
     }
 }
 
+/*!
+ * \internal
+ * \brief Switch to the given shadow instance
+ *
+ * \param[out] error  Where to store error
+ */
+static void
+switch_shadow_instance(GError **error)
+{
+    char *filename = NULL;
+
+    filename = get_shadow_file(options.instance);
+    if (check_file_exists(filename, true, error) == pcmk_rc_ok) {
+        shadow_setup(options.instance, TRUE);
+    }
+    free(filename);
+}
+
 static gboolean
 command_cb(const gchar *option_name, const gchar *optarg, gpointer data,
            GError **error)
@@ -673,6 +691,9 @@ main(int argc, char **argv)
         case shadow_cmd_file:
             show_shadow_filename(&error);
             goto done;
+        case shadow_cmd_switch:
+            switch_shadow_instance(&error);
+            goto done;
         case shadow_cmd_which:
             show_shadow_instance(&error);
             goto done;
@@ -681,9 +702,7 @@ main(int argc, char **argv)
     }
 
     // Check for shadow instance mismatch
-    if ((options.cmd != shadow_cmd_switch)
-        && (options.cmd != shadow_cmd_create)) {
-
+    if (options.cmd != shadow_cmd_create) {
         const char *local = getenv("CIB_shadow");
 
         if (!options.force
@@ -782,11 +801,6 @@ main(int argc, char **argv)
                 }
                 shadow_setup(options.instance, FALSE);
             }
-            break;
-
-        case shadow_cmd_switch:
-            // Switch to the named shadow instance
-            shadow_setup(options.instance, TRUE);
             break;
 
         case shadow_cmd_commit:

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -690,11 +690,14 @@ main(int argc, char **argv)
     }
 
     // Check for shadow instance mismatch
-    if (options.cmd != shadow_cmd_create) {
+    if (!options.force
+        && ((options.cmd == shadow_cmd_commit)
+            || (options.cmd == shadow_cmd_delete)
+            || (options.cmd == shadow_cmd_reset))) {
+
         const char *local = getenv("CIB_shadow");
 
-        if (!options.force
-            && !pcmk__str_eq(local, options.instance, pcmk__str_null_matches)) {
+        if (!pcmk__str_eq(local, options.instance, pcmk__str_null_matches)) {
             exit_code = CRM_EX_USAGE;
             g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
                         "The supplied shadow instance (%s) is not the same as "

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -387,9 +387,8 @@ main(int argc, char **argv)
 
         const char *local = getenv("CIB_shadow");
 
-        if ((local != NULL)
-            && !pcmk__str_eq(local, options.shadow, pcmk__str_none)
-            && !options.force) {
+        if (!options.force
+            && !pcmk__str_eq(local, options.shadow, pcmk__str_null_matches)) {
             exit_code = CRM_EX_USAGE;
             g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
                         "The supplied shadow instance (%s) is not the same as "

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -164,6 +164,20 @@ cmd_is_dangerous(enum shadow_command cmd)
     }
 }
 
+/*!
+ * \internal
+ * \brief Show the active shadow instance
+ *
+ * \param[out] error  Where to store error
+ */
+static void
+show_shadow_instance(GError **error)
+{
+    if (get_instance_from_env(error) == pcmk_rc_ok) {
+        printf("%s\n", options.instance);
+    }
+}
+
 static gboolean
 command_cb(const gchar *option_name, const gchar *optarg, gpointer data,
            GError **error)
@@ -378,9 +392,19 @@ main(int argc, char **argv)
                               cib_quorum_override);
     }
 
-    // Some commands get options.instance from the environment
+    /* Run the command
+     * @TODO: Finish adding all commands here
+     */
     switch (options.cmd) {
         case shadow_cmd_which:
+            show_shadow_instance(&error);
+            goto done;
+        default:
+            break;
+    }
+
+    // Some commands get options.instance from the environment
+    switch (options.cmd) {
         case shadow_cmd_display:
         case shadow_cmd_diff:
         case shadow_cmd_file:
@@ -392,12 +416,6 @@ main(int argc, char **argv)
         default:
             // The rest already set options.instance from their optarg
             break;
-    }
-
-    if (options.cmd == shadow_cmd_which) {
-        // Show the active shadow instance
-        printf("%s\n", options.instance);
-        goto done;
     }
 
     // Check for shadow instance mismatch

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -166,6 +166,23 @@ cmd_is_dangerous(enum shadow_command cmd)
 
 /*!
  * \internal
+ * \brief Show the absolute path of the active shadow instance
+ *
+ * \param[out] error  Where to store error
+ */
+static void
+show_shadow_filename(GError **error)
+{
+    if (get_instance_from_env(error) == pcmk_rc_ok) {
+        char *filename = get_shadow_file(options.instance);
+
+        printf("%s\n", filename);
+        free(filename);
+    }
+}
+
+/*!
+ * \internal
  * \brief Show the active shadow instance
  *
  * \param[out] error  Where to store error
@@ -396,6 +413,9 @@ main(int argc, char **argv)
      * @TODO: Finish adding all commands here
      */
     switch (options.cmd) {
+        case shadow_cmd_file:
+            show_shadow_filename(&error);
+            goto done;
         case shadow_cmd_which:
             show_shadow_instance(&error);
             goto done;
@@ -407,7 +427,6 @@ main(int argc, char **argv)
     switch (options.cmd) {
         case shadow_cmd_display:
         case shadow_cmd_diff:
-        case shadow_cmd_file:
         case shadow_cmd_edit:
             if (get_instance_from_env(&error) != pcmk_rc_ok) {
                 goto done;
@@ -458,12 +477,6 @@ main(int argc, char **argv)
                         options.instance, strerror(errno));
         }
         needs_teardown = true;
-        goto done;
-    }
-
-    if (options.cmd == shadow_cmd_file) {
-        // Show the shadow file path
-        printf("%s\n", shadow_file);
         goto done;
     }
 

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -69,22 +69,6 @@ static struct {
     .cmd_options = cib_sync_call,
 };
 
-#if 0
-// @COMPAT Possibly enable this at next backward compatibility break
-#define SET_COMMAND(command) do {                                       \
-        if (options.cmd != shadow_cmd_none) {                           \
-            g_set_error(error, PCMK__EXITC_ERROR, CRM_EX_USAGE,         \
-                        "Only one command option may be specified");    \
-            return FALSE;                                               \
-        }                                                               \
-        options.cmd = (command);                                        \
-    } while (0)
-#else
-#define SET_COMMAND(command) do {   \
-        options.cmd = (command);    \
-    } while (0)
-#endif
-
 static char *
 get_shadow_prompt(const char *name)
 {
@@ -162,37 +146,37 @@ command_cb(const gchar *option_name, const gchar *optarg, gpointer data,
            GError **error)
 {
     if (pcmk__str_any_of(option_name, "-w", "--which", NULL)) {
-        SET_COMMAND(shadow_cmd_which);
+        options.cmd = shadow_cmd_which;
 
     } else if (pcmk__str_any_of(option_name, "-p", "--display", NULL)) {
-        SET_COMMAND(shadow_cmd_display);
+        options.cmd = shadow_cmd_display;
 
     } else if (pcmk__str_any_of(option_name, "-d", "--diff", NULL)) {
-        SET_COMMAND(shadow_cmd_diff);
+        options.cmd = shadow_cmd_diff;
 
     } else if (pcmk__str_any_of(option_name, "-F", "--file", NULL)) {
-        SET_COMMAND(shadow_cmd_file);
+        options.cmd = shadow_cmd_file;
 
     } else if (pcmk__str_any_of(option_name, "-c", "--create", NULL)) {
-        SET_COMMAND(shadow_cmd_create);
+        options.cmd = shadow_cmd_create;
 
     } else if (pcmk__str_any_of(option_name, "-e", "--create-empty", NULL)) {
-        SET_COMMAND(shadow_cmd_create_empty);
+        options.cmd = shadow_cmd_create_empty;
 
     } else if (pcmk__str_any_of(option_name, "-C", "--commit", NULL)) {
-        SET_COMMAND(shadow_cmd_commit);
+        options.cmd = shadow_cmd_commit;
 
     } else if (pcmk__str_any_of(option_name, "-D", "--delete", NULL)) {
-        SET_COMMAND(shadow_cmd_delete);
+        options.cmd = shadow_cmd_delete;
 
     } else if (pcmk__str_any_of(option_name, "-E", "--edit", NULL)) {
-        SET_COMMAND(shadow_cmd_edit);
+        options.cmd = shadow_cmd_edit;
 
     } else if (pcmk__str_any_of(option_name, "-r", "--reset", NULL)) {
-        SET_COMMAND(shadow_cmd_reset);
+        options.cmd = shadow_cmd_reset;
 
     } else if (pcmk__str_any_of(option_name, "-s", "--switch", NULL)) {
-        SET_COMMAND(shadow_cmd_switch);
+        options.cmd = shadow_cmd_switch;
 
     } else {
         // Should be impossible

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -686,6 +686,8 @@ done:
         shadow_teardown(options.shadow);
     }
     free(shadow_file);
+    cib_delete(real_cib);
+
     free(options.shadow);
     g_free(options.validate_with);
     crm_exit(exit_code);


### PR DESCRIPTION
One last step before formatted output. This is tedious but it ought to be done, and now is as good a time as any.

9e8a059 made the `crm_shadow.c` code somewhat easier to follow, but it's still a mess. The `main()` function is monolithic. Code is shared where possible -- often several commands share a particular initialization or validation step. This is typically handled by switch statements. However, it quickly becomes difficult to follow what any particular command is doing from start to finish. This makes it hard to reason about whether changes preserve existing behavior or not.

This PR improves `crm_shadow.c` by functionizing the logic of each command, after global option parsing. There is some duplication among the new functions, but the ease of maintenance justifies it.