### PR TITLE
Fix: tool: update crm_mon synopsis

### DIFF
--- a/tools/crm_mon.8.inc
+++ b/tools/crm_mon.8.inc
@@ -1,5 +1,5 @@
 [synopsis]
-crm_mon mode [options]
+crm_mon [options]
 
 /number of different formats/
 .SH OPTIONS


### PR DESCRIPTION
From a request in https://bugzilla.suse.com/show_bug.cgi?id=1208868: 

> The synopsis in the man page for crm_mon is:
> 
> SYNOPSIS
>        crm_mon mode [options]
> 
> I can only see optional options in the man page. There are no mode entries.
> 
> I think the synopsis should read as follows:
> 
> SYNOPSIS
>        crm_mon [options]