### PR TITLE
 Fix: libcrmcommon: Don't parse "-INFINITY" as a list of cmdline options 

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -5846,6 +5846,38 @@ crm_attribute: Error performing operation: No such device or address
 </pacemaker-result>
 =#=#=#= End test: Query after deleting an existing promotable score attribute (XML) - No such object (105) =#=#=#=
 * Passed: crm_attribute  - Query after deleting an existing promotable score attribute (XML)
+=#=#=#= Begin test: Update a promotable score attribute to -INFINITY =#=#=#=
+Deprecated argument format '-NFINITY' used.
+Please use '-N FINITY' instead.  Support will be removed in a future release.
+crm_attribute: Could not map name=FINITY to a UUID
+=#=#=#= End test: Update a promotable score attribute to -INFINITY - No such object (105) =#=#=#=
+* Passed: crm_attribute  - Update a promotable score attribute to -INFINITY
+=#=#=#= Begin test: Update a promotable score attribute to -INFINITY (XML) =#=#=#=
+Deprecated argument format '-NFINITY' used.
+Please use '-N FINITY' instead.  Support will be removed in a future release.
+<pacemaker-result api-version="X" request="crm_attribute -N cluster01 -p -v -INFINITY --output-as=xml">
+  <status code="105" message="No such object">
+    <errors>
+      <error>crm_attribute: Could not map name=FINITY to a UUID</error>
+    </errors>
+  </status>
+</pacemaker-result>
+=#=#=#= End test: Update a promotable score attribute to -INFINITY (XML) - No such object (105) =#=#=#=
+* Passed: crm_attribute  - Update a promotable score attribute to -INFINITY (XML)
+=#=#=#= Begin test: Query after updating a promotable score attribute to -INFINITY =#=#=#=
+crm_attribute: Error performing operation: No such device or address
+=#=#=#= End test: Query after updating a promotable score attribute to -INFINITY - No such object (105) =#=#=#=
+* Passed: crm_attribute  - Query after updating a promotable score attribute to -INFINITY
+=#=#=#= Begin test: Query after updating a promotable score attribute to -INFINITY (XML) =#=#=#=
+<pacemaker-result api-version="X" request="crm_attribute -N cluster01 -p -G --output-as=xml">
+  <status code="105" message="No such object">
+    <errors>
+      <error>crm_attribute: Error performing operation: No such device or address</error>
+    </errors>
+  </status>
+</pacemaker-result>
+=#=#=#= End test: Query after updating a promotable score attribute to -INFINITY (XML) - No such object (105) =#=#=#=
+* Passed: crm_attribute  - Query after updating a promotable score attribute to -INFINITY (XML)
 =#=#=#= Begin test: Check that CIB_file="-" works - crm_mon =#=#=#=
 Cluster Summary:
   * Stack: corosync

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -5847,36 +5847,24 @@ crm_attribute: Error performing operation: No such device or address
 =#=#=#= End test: Query after deleting an existing promotable score attribute (XML) - No such object (105) =#=#=#=
 * Passed: crm_attribute  - Query after deleting an existing promotable score attribute (XML)
 =#=#=#= Begin test: Update a promotable score attribute to -INFINITY =#=#=#=
-Deprecated argument format '-NFINITY' used.
-Please use '-N FINITY' instead.  Support will be removed in a future release.
-crm_attribute: Could not map name=FINITY to a UUID
-=#=#=#= End test: Update a promotable score attribute to -INFINITY - No such object (105) =#=#=#=
+=#=#=#= End test: Update a promotable score attribute to -INFINITY - OK (0) =#=#=#=
 * Passed: crm_attribute  - Update a promotable score attribute to -INFINITY
 =#=#=#= Begin test: Update a promotable score attribute to -INFINITY (XML) =#=#=#=
-Deprecated argument format '-NFINITY' used.
-Please use '-N FINITY' instead.  Support will be removed in a future release.
 <pacemaker-result api-version="X" request="crm_attribute -N cluster01 -p -v -INFINITY --output-as=xml">
-  <status code="105" message="No such object">
-    <errors>
-      <error>crm_attribute: Could not map name=FINITY to a UUID</error>
-    </errors>
-  </status>
+  <status code="0" message="OK"/>
 </pacemaker-result>
-=#=#=#= End test: Update a promotable score attribute to -INFINITY (XML) - No such object (105) =#=#=#=
+=#=#=#= End test: Update a promotable score attribute to -INFINITY (XML) - OK (0) =#=#=#=
 * Passed: crm_attribute  - Update a promotable score attribute to -INFINITY (XML)
 =#=#=#= Begin test: Query after updating a promotable score attribute to -INFINITY =#=#=#=
-crm_attribute: Error performing operation: No such device or address
-=#=#=#= End test: Query after updating a promotable score attribute to -INFINITY - No such object (105) =#=#=#=
+scope=status  name=master-promotable-rsc value=-INFINITY
+=#=#=#= End test: Query after updating a promotable score attribute to -INFINITY - OK (0) =#=#=#=
 * Passed: crm_attribute  - Query after updating a promotable score attribute to -INFINITY
 =#=#=#= Begin test: Query after updating a promotable score attribute to -INFINITY (XML) =#=#=#=
 <pacemaker-result api-version="X" request="crm_attribute -N cluster01 -p -G --output-as=xml">
-  <status code="105" message="No such object">
-    <errors>
-      <error>crm_attribute: Error performing operation: No such device or address</error>
-    </errors>
-  </status>
+  <attribute name="master-promotable-rsc" value="-INFINITY" scope="status"/>
+  <status code="0" message="OK"/>
 </pacemaker-result>
-=#=#=#= End test: Query after updating a promotable score attribute to -INFINITY (XML) - No such object (105) =#=#=#=
+=#=#=#= End test: Query after updating a promotable score attribute to -INFINITY (XML) - OK (0) =#=#=#=
 * Passed: crm_attribute  - Query after updating a promotable score attribute to -INFINITY (XML)
 =#=#=#= Begin test: Check that CIB_file="-" works - crm_mon =#=#=#=
 Cluster Summary:

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1537,7 +1537,28 @@ function test_tools() {
     cmd="crm_attribute -N cluster01 -p promotable-rsc -G --output-as=xml"
     test_assert_validate $CRM_EX_NOSUCH 0
 
+    # Test for an issue with legacy command line parsing when the resource is
+    # specified in the environment (CLBZ#5509)
+    export OCF_RESOURCE_INSTANCE=promotable-rsc
+
+    desc="Update a promotable score attribute to -INFINITY"
+    cmd="crm_attribute -N cluster01 -p -v -INFINITY"
+    test_assert $CRM_EX_NOSUCH 0
+
+    desc="Update a promotable score attribute to -INFINITY (XML)"
+    cmd="crm_attribute -N cluster01 -p -v -INFINITY --output-as=xml"
+    test_assert $CRM_EX_NOSUCH 0
+
+    desc="Query after updating a promotable score attribute to -INFINITY"
+    cmd="crm_attribute -N cluster01 -p -G"
+    test_assert $CRM_EX_NOSUCH 0
+
+    desc="Query after updating a promotable score attribute to -INFINITY (XML)"
+    cmd="crm_attribute -N cluster01 -p -G --output-as=xml"
+    test_assert $CRM_EX_NOSUCH 0
+
     unset CIB_file
+    unset OCF_RESOURCE_INSTANCE
 
     export CIB_file="-"
 

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1543,19 +1543,19 @@ function test_tools() {
 
     desc="Update a promotable score attribute to -INFINITY"
     cmd="crm_attribute -N cluster01 -p -v -INFINITY"
-    test_assert $CRM_EX_NOSUCH 0
+    test_assert $CRM_EX_OK 0
 
     desc="Update a promotable score attribute to -INFINITY (XML)"
     cmd="crm_attribute -N cluster01 -p -v -INFINITY --output-as=xml"
-    test_assert $CRM_EX_NOSUCH 0
+    test_assert $CRM_EX_OK 0
 
     desc="Query after updating a promotable score attribute to -INFINITY"
     cmd="crm_attribute -N cluster01 -p -G"
-    test_assert $CRM_EX_NOSUCH 0
+    test_assert $CRM_EX_OK 0
 
     desc="Query after updating a promotable score attribute to -INFINITY (XML)"
     cmd="crm_attribute -N cluster01 -p -G --output-as=xml"
-    test_assert $CRM_EX_NOSUCH 0
+    test_assert $CRM_EX_OK 0
 
     unset CIB_file
     unset OCF_RESOURCE_INSTANCE

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -257,6 +257,14 @@ pcmk__cmdline_preproc(char *const *argv, const char *special) {
             continue;
         }
 
+        /* "-INFINITY" is almost certainly meant as a string, not as an option
+         * list
+         */
+        if (strcmp(argv[i], "-INFINITY") == 0) {
+            g_ptr_array_add(arr, g_strdup(argv[i]));
+            continue;
+        }
+
         /* This is a short argument, or perhaps several.  Iterate over it
          * and explode them out into individual arguments.
          */


### PR DESCRIPTION
For the `crm_attribute -p -v -INFINITY` command, when the resource (the `-p` argument) is specified via the `OCF_RESOURCE_INSTANCE` environment variable rather than explicitly on the command line, the string `"-INFINITY"` is
parsed incorrectly.

`pcmk__cmdline_preproc()` treats the leading `'I'` as an argument but skips it because it's not in the `special` string. It then parses the `'N'`, finds it in the `special` string, and treats `"FINITY"` as `N`'s argument. As a result, `crm_attribute` looks for a node (`-N` specifies a node) named `"FINITY"` instead of treating `"-INFINITY"` as the value to update the promotion score.

We should handle `"-INFINITY"` as a string and let GLib handle it instead.

Fixes CLBZ#5509