### PR TITLE
Fix: extra/resources/SysInfo.in: This calculation of cpu_load returns an incorrect value in Darwin and Linux

### DIFF
--- a/extra/resources/SysInfo.in
+++ b/extra/resources/SysInfo.in
@@ -182,7 +182,7 @@ SysInfoStats() {
             cpu_type=$(system_profiler SPHardwareDataType | awk -F': ' '/^CPU Type/ {print $2; exit}')
             cpu_speed=$(system_profiler SPHardwareDataType | awk -F': ' '/^CPU Speed/ {print $2; exit}')
             cpu_cores=$(system_profiler SPHardwareDataType | awk -F': ' '/^Number Of/ {print $2; exit}')
-            cpu_load=$(uptime | awk '{ print $10 }')
+            cpu_load=$(uptime | awk -F 'load average: ' '{ print $2 }' | awk -F ', ' '{ print $2 }')
         ;;
         "FreeBSD")
             cpu_type=$(sysctl -in hw.model)
@@ -203,7 +203,7 @@ SysInfoStats() {
                 cpu_speed=$(awk -F': ' '/bogomips/ {print $2; exit}' /proc/cpuinfo)
                 cpu_cores=$(grep "^processor" /proc/cpuinfo | wc -l)
             fi
-            cpu_load=$(uptime | awk '{ print $10 }')
+            cpu_load=$(uptime | awk -F 'load average: ' '{ print $2 }' | awk -F ', ' '{ print $2 }')
 
             if [ -f /proc/meminfo ]; then
                 # meminfo results are in kB


### PR DESCRIPTION
When the system running time is greater than 1 h, cpu_load (uptime | awk '{print $10}') of the return value is wrong.