### PR TITLE
New "enabled" meta-attribute for alerts

### DIFF
--- a/cts/cli/regression.error_codes.exp
+++ b/cts/cli/regression.error_codes.exp
@@ -145,6 +145,7 @@ pcmk_rc_node_unknown - Node not found
 =#=#=#= End test: Get negative Pacemaker return code (with name) (XML) - OK (0) =#=#=#=
 * Passed: crm_error      - Get negative Pacemaker return code (with name) (XML)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) =#=#=#=
+-1034: Disabled
 -1033: Two or more XML elements have the same ID
 -1032: Unable to parse CIB XML
 -1031: Cluster simulation produced invalid transition
@@ -183,6 +184,7 @@ pcmk_rc_node_unknown - Node not found
 * Passed: crm_error      - List Pacemaker return codes (non-positive)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (XML) =#=#=#=
 <pacemaker-result api-version="X" request="crm_error -l -r --output-as=xml">
+  <result-code code="-1034" description="Disabled"/>
   <result-code code="-1033" description="Two or more XML elements have the same ID"/>
   <result-code code="-1032" description="Unable to parse CIB XML"/>
   <result-code code="-1031" description="Cluster simulation produced invalid transition"/>
@@ -221,6 +223,7 @@ pcmk_rc_node_unknown - Node not found
 =#=#=#= End test: List Pacemaker return codes (non-positive) (XML) - OK (0) =#=#=#=
 * Passed: crm_error      - List Pacemaker return codes (non-positive) (XML)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (with names) =#=#=#=
+-1034: pcmk_rc_disabled            Disabled
 -1033: pcmk_rc_duplicate_id        Two or more XML elements have the same ID
 -1032: pcmk_rc_unpack_error        Unable to parse CIB XML
 -1031: pcmk_rc_invalid_transition  Cluster simulation produced invalid transition
@@ -259,6 +262,7 @@ pcmk_rc_node_unknown - Node not found
 * Passed: crm_error      - List Pacemaker return codes (non-positive) (with names)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (with names) (XML) =#=#=#=
 <pacemaker-result api-version="X" request="crm_error -n -l -r --output-as=xml">
+  <result-code code="-1034" name="pcmk_rc_disabled" description="Disabled"/>
   <result-code code="-1033" name="pcmk_rc_duplicate_id" description="Two or more XML elements have the same ID"/>
   <result-code code="-1032" name="pcmk_rc_unpack_error" description="Unable to parse CIB XML"/>
   <result-code code="-1031" name="pcmk_rc_invalid_transition" description="Cluster simulation produced invalid transition"/>

--- a/doc/sphinx/Pacemaker_Explained/alerts.rst
+++ b/doc/sphinx/Pacemaker_Explained/alerts.rst
@@ -82,8 +82,8 @@ an e-mail address, a file name, whatever the particular agent supports.
 Alert Meta-Attributes
 #####################
    
-As with resource agents, meta-attributes can be configured for alert agents
-to affect how Pacemaker calls them.
+As with resources, meta-attributes can be configured for alerts to change
+whether and how Pacemaker calls them.
    
 .. table:: **Meta-Attributes of an Alert**
    :class: longtable
@@ -92,6 +92,16 @@ to affect how Pacemaker calls them.
    +------------------+---------------+-----------------------------------------------------+
    | Meta-Attribute   | Default       | Description                                         |
    +==================+===============+=====================================================+
+   | enabled          | true          | .. index::                                          |
+   |                  |               |    single: alert; meta-attribute, enabled           |
+   |                  |               |    single: meta-attribute; enabled (alert)          |
+   |                  |               |    single: enabled; alert meta-attribute            |
+   |                  |               |                                                     |
+   |                  |               | If false for an alert, the alert will not be used.  |
+   |                  |               | If true for an alert and false for a particular     |
+   |                  |               | recipient of that alert, that recipient will not be |
+   |                  |               | used.                                               |
+   +------------------+---------------+-----------------------------------------------------+
    | timestamp-format | %H:%M:%S.%06N | .. index::                                          |
    |                  |               |    single: alert; meta-attribute, timestamp-format  |
    |                  |               |    single: meta-attribute; timestamp-format (alert) |
@@ -110,7 +120,7 @@ to affect how Pacemaker calls them.
    |                  |               | amount of time, it will be terminated.              |
    +------------------+---------------+-----------------------------------------------------+
    
-Meta-attributes can be configured per alert agent and/or per recipient.
+Meta-attributes can be configured per alert and/or per recipient.
    
 .. topic:: Alert configuration with meta-attributes
 

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -108,6 +108,7 @@ enum pcmk_rc_e {
     /* When adding new values, use consecutively lower numbers, update the array
      * in lib/common/results.c, and test with crm_error.
      */
+    pcmk_rc_disabled            = -1034,
     pcmk_rc_duplicate_id        = -1033,
     pcmk_rc_unpack_error        = -1032,
     pcmk_rc_invalid_transition  = -1031,

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -24,9 +24,9 @@ extern "C" {
  * attribute names).
  *
  * For consistency, new constants should start with "PCMK_", followed by "XE"
- * for XML element names and "XA" for XML attribute names. Old names that don't
- * follow this policy should eventually be deprecated and replaced with names
- * that do.
+ * for XML element names, "XA" for XML attribute names, and "META" for meta
+ * attribute names. Old names that don't follow this policy should eventually be
+ * deprecated and replaced with names that do.
  */
 
 /*
@@ -48,6 +48,14 @@ extern "C" {
  */
 #define PCMK_XA_PROMOTED_MAX_LEGACY         "master-max"
 #define PCMK_XA_PROMOTED_NODE_MAX_LEGACY    "master-node-max"
+
+
+/*
+ * Meta attributes
+ */
+
+#  define PCMK_META_ENABLED                 "enabled"
+
 
 /*
  * Older constants that don't follow current naming

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -33,10 +33,15 @@ extern "C" {
  * XML elements
  */
 
+#define PCMK_XE_DATE_EXPRESSION             "date_expression"
+#define PCMK_XE_OP_EXPRESSION               "op_expression"
+
 /* This has been deprecated as a CIB element (an alias for <clone> with
  * "promotable" set to "true") since 2.0.0.
  */
 #define PCMK_XE_PROMOTABLE_LEGACY           "master"
+
+#define PCMK_XE_RSC_EXPRESSION              "rsc_expression"
 
 
 /*
@@ -54,7 +59,7 @@ extern "C" {
  * Meta attributes
  */
 
-#  define PCMK_META_ENABLED                 "enabled"
+#define PCMK_META_ENABLED                   "enabled"
 
 
 /*
@@ -347,9 +352,6 @@ extern "C" {
 #  define XML_RULE_ATTR_BOOLEAN_OP	"boolean-op"
 
 #  define XML_TAG_EXPRESSION		"expression"
-#  define PCMK_XE_DATE_EXPRESSION	"date_expression"
-#  define PCMK_XE_OP_EXPRESSION		"op_expression"
-#  define PCMK_XE_RSC_EXPRESSION	"rsc_expression"
 #  define XML_EXPR_ATTR_ATTRIBUTE	"attribute"
 #  define XML_EXPR_ATTR_OPERATION	"operation"
 #  define XML_EXPR_ATTR_VALUE		"value"

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -293,6 +293,10 @@ static const struct pcmk__rc_info {
       "Two or more XML elements have the same ID",
       -pcmk_err_generic,
     },
+    { "pcmk_rc_disabled",
+      "Disabled",
+      -pcmk_err_generic,
+    },
 };
 
 /*!

--- a/lib/pengine/rules_alerts.c
+++ b/lib/pengine/rules_alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the Pacemaker project contributors
+ * Copyright 2015-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -15,17 +15,35 @@
 #include <crm/common/xml_internal.h>
 #include <crm/pengine/rules_internal.h>
 
-static void
+/*!
+ * \internal
+ * \brief Unpack an alert's or alert recipient's meta attributes
+ *
+ * \param[in,out] basenode     Alert or recipient XML
+ * \param[in,out] entry        Where to store unpacked values
+ * \param[in,out] max_timeout  Max timeout of all alerts and recipients thus far
+ *
+ * \return Standard Pacemaker return code
+ */
+static int
 get_meta_attrs_from_cib(xmlNode *basenode, pcmk__alert_t *entry,
                         guint *max_timeout)
 {
     GHashTable *config_hash = pcmk__strkey_table(free, free);
     crm_time_t *now = crm_time_new(NULL);
     const char *value = NULL;
+    int rc = pcmk_rc_ok;
 
     pe_unpack_nvpairs(basenode, basenode, XML_TAG_META_SETS, NULL, config_hash,
                       NULL, FALSE, now, NULL);
     crm_time_free(now);
+
+    value = g_hash_table_lookup(config_hash, PCMK_META_ENABLED);
+    if ((value != NULL) && !crm_is_true(value)) {
+        // No need to continue unpacking
+        rc = pcmk_rc_disabled;
+        goto done;
+    }
 
     value = g_hash_table_lookup(config_hash, XML_ALERT_ATTR_TIMEOUT);
     if (value) {
@@ -57,7 +75,9 @@ get_meta_attrs_from_cib(xmlNode *basenode, pcmk__alert_t *entry,
                   entry->id, entry->tstamp_format);
     }
 
+done:
     g_hash_table_destroy(config_hash);
+    return rc;
 }
 
 static void
@@ -155,12 +175,27 @@ unpack_alert_filter(xmlNode *basenode, pcmk__alert_t *entry)
     }
 }
 
-static void
+/*!
+ * \internal
+ * \brief Unpack an alert or an alert recipient
+ *
+ * \param[in,out] alert        Alert or recipient XML
+ * \param[in,out] entry        Where to store unpacked values
+ * \param[in,out] max_timeout  Max timeout of all alerts and recipients thus far
+ *
+ * \return Standard Pacemaker return code
+ */
+static int
 unpack_alert(xmlNode *alert, pcmk__alert_t *entry, guint *max_timeout)
 {
+    int rc = pcmk_rc_ok;
+
     get_envvars_from_cib(alert, entry);
-    get_meta_attrs_from_cib(alert, entry, max_timeout);
-    unpack_alert_filter(alert, entry);
+    rc = get_meta_attrs_from_cib(alert, entry, max_timeout);
+    if (rc == pcmk_rc_ok) {
+        unpack_alert_filter(alert, entry);
+    }
+    return rc;
 }
 
 /*!
@@ -202,7 +237,12 @@ pe_unpack_alerts(const xmlNode *alerts)
 
         entry = pcmk__alert_new(alert_id, alert_path);
 
-        unpack_alert(alert, entry, &max_timeout);
+        if (unpack_alert(alert, entry, &max_timeout) != pcmk_rc_ok) {
+            // Don't allow recipients to override if entire alert is disabled
+            crm_debug("Alert %s is disabled", entry->id);
+            pcmk__free_alert(entry);
+            continue;
+        }
 
         if (entry->tstamp_format == NULL) {
             entry->tstamp_format = strdup(PCMK__ALERT_DEFAULT_TSTAMP_FORMAT);
@@ -220,7 +260,14 @@ pe_unpack_alerts(const xmlNode *alerts)
             recipients++;
             recipient_entry->recipient = strdup(crm_element_value(recipient,
                                                 XML_ALERT_ATTR_REC_VALUE));
-            unpack_alert(recipient, recipient_entry, &max_timeout);
+
+            if (unpack_alert(recipient, recipient_entry,
+                             &max_timeout) != pcmk_rc_ok) {
+                crm_debug("Alert %s: recipient %s is disabled",
+                          entry->id, recipient_entry->id);
+                pcmk__free_alert(recipient_entry);
+                continue;
+            }
             alert_list = g_list_prepend(alert_list, recipient_entry);
             crm_debug("Alert %s has recipient %s with value %s and %d envvars",
                       entry->id, ID(recipient), recipient_entry->recipient,


### PR DESCRIPTION
An `<alert>` element or an individual `<recipient>` element can now contain a boolean `enabled` meta attribute. The default value is "true". If `enabled` is set to "false", the alert or recipient will not be used.

If `enabled` is set to "false" at the `<alert>` level, all of the alert's recipients are disabled, regardless of the recipients' `enabled` value.

If `enabled` is set to "true" or is unset at the `<alert>` level, the alert's recipients are enabled or disabled based on their respective values of the `enabled` meta attribute.

Setting `enabled` to "false" can be useful to avoid spamming alert recipients during planned maintenance, for example.