### PR TITLE
Fix: libcrmcommon: allow crm_attribute to try OCF_RESOURCE_INSTANCE environment variable if -p is specified with an empty string

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -5865,12 +5865,12 @@ scope=status  name=master-promotable-rsc value=-INFINITY
 =#=#=#= End test: Query after updating a promotable score attribute to -INFINITY (XML) - OK (0) =#=#=#=
 * Passed: crm_attribute  - Query after updating a promotable score attribute to -INFINITY (XML)
 =#=#=#= Begin test: Try OCF_RESOURCE_INSTANCE if -p is specified with an empty string =#=#=#=
-crm_attribute: Error performing operation: No such device or address
-=#=#=#= End test: Try OCF_RESOURCE_INSTANCE if -p is specified with an empty string - No such object (105) =#=#=#=
+scope=status  name=master-promotable-rsc value=-INFINITY
+=#=#=#= End test: Try OCF_RESOURCE_INSTANCE if -p is specified with an empty string - OK (0) =#=#=#=
 * Passed: crm_attribute  - Try OCF_RESOURCE_INSTANCE if -p is specified with an empty string
 =#=#=#= Begin test: Return usage error if both -p and OCF_RESOURCE_INSTANCE are empty strings =#=#=#=
-crm_attribute: Error performing operation: No such device or address
-=#=#=#= End test: Return usage error if both -p and OCF_RESOURCE_INSTANCE are empty strings - No such object (105) =#=#=#=
+crm_attribute: -p/--promotion must be called from an OCF resource agent or with a resource ID specified
+=#=#=#= End test: Return usage error if both -p and OCF_RESOURCE_INSTANCE are empty strings - Incorrect usage (64) =#=#=#=
 * Passed: crm_attribute  - Return usage error if both -p and OCF_RESOURCE_INSTANCE are empty strings
 =#=#=#= Begin test: Check that CIB_file="-" works - crm_mon =#=#=#=
 Cluster Summary:

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -5864,6 +5864,14 @@ scope=status  name=master-promotable-rsc value=-INFINITY
 </pacemaker-result>
 =#=#=#= End test: Query after updating a promotable score attribute to -INFINITY (XML) - OK (0) =#=#=#=
 * Passed: crm_attribute  - Query after updating a promotable score attribute to -INFINITY (XML)
+=#=#=#= Begin test: Try OCF_RESOURCE_INSTANCE if -p is specified with an empty string =#=#=#=
+crm_attribute: Error performing operation: No such device or address
+=#=#=#= End test: Try OCF_RESOURCE_INSTANCE if -p is specified with an empty string - No such object (105) =#=#=#=
+* Passed: crm_attribute  - Try OCF_RESOURCE_INSTANCE if -p is specified with an empty string
+=#=#=#= Begin test: Return usage error if both -p and OCF_RESOURCE_INSTANCE are empty strings =#=#=#=
+crm_attribute: Error performing operation: No such device or address
+=#=#=#= End test: Return usage error if both -p and OCF_RESOURCE_INSTANCE are empty strings - No such object (105) =#=#=#=
+* Passed: crm_attribute  - Return usage error if both -p and OCF_RESOURCE_INSTANCE are empty strings
 =#=#=#= Begin test: Check that CIB_file="-" works - crm_mon =#=#=#=
 Cluster Summary:
   * Stack: corosync

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1558,6 +1558,16 @@ function test_tools() {
     cmd="crm_attribute -N cluster01 -p -G --output-as=xml"
     test_assert $CRM_EX_OK 0
 
+    desc="Try OCF_RESOURCE_INSTANCE if -p is specified with an empty string"
+    cmd="crm_attribute -N cluster01 -p '' -G"
+    test_assert $CRM_EX_NOSUCH 0
+
+    export OCF_RESOURCE_INSTANCE=""
+
+    desc="Return usage error if both -p and OCF_RESOURCE_INSTANCE are empty strings"
+    cmd="crm_attribute -N cluster01 -p '' -G"
+    test_assert $CRM_EX_NOSUCH 0
+
     unset CIB_file
     unset OCF_RESOURCE_INSTANCE
 

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1560,13 +1560,13 @@ function test_tools() {
 
     desc="Try OCF_RESOURCE_INSTANCE if -p is specified with an empty string"
     cmd="crm_attribute -N cluster01 -p '' -G"
-    test_assert $CRM_EX_NOSUCH 0
+    test_assert $CRM_EX_OK 0
 
     export OCF_RESOURCE_INSTANCE=""
 
     desc="Return usage error if both -p and OCF_RESOURCE_INSTANCE are empty strings"
     cmd="crm_attribute -N cluster01 -p '' -G"
-    test_assert $CRM_EX_NOSUCH 0
+    test_assert $CRM_EX_USAGE 0
 
     unset CIB_file
     unset OCF_RESOURCE_INSTANCE

--- a/lib/common/attrs.c
+++ b/lib/common/attrs.c
@@ -79,9 +79,9 @@ pcmk__node_attr_target(const char *name)
 char *
 pcmk_promotion_score_name(const char *rsc_id)
 {
-    if (rsc_id == NULL) {
+    if (pcmk__str_empty(rsc_id)) {
         rsc_id = getenv("OCF_RESOURCE_INSTANCE");
-        if (rsc_id == NULL) {
+        if (pcmk__str_empty(rsc_id)) {
             return NULL;
         }
     }


### PR DESCRIPTION
, rather than set/get a meaningless promotion score. And in case
OCF_RESOURCE_INSTANCE is also an empty string, return usage error.