### PR TITLE
Preserve transient attributes across remote resource hiccups

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -5961,10 +5961,10 @@ Transition Summary:
   * Move       Public-IP                           ( cluster02 -> cluster01 )
   * Move       Email                               ( cluster02 -> cluster01 )
   * Stop       mysql-proxy:0                       (              cluster02 )  due to node availability
-  * Stop       promotable-rsc:0                    (       Promoted cluster02 )  due to node availability
+  * Stop       promotable-rsc:0                    (     Promoted cluster02 )  due to node availability
 
 Executing Cluster Transition:
-  * Pseudo action:   httpd-bundle-1_stop_0
+  * Pseudo action:   httpd-bundle-1_stop_0 on cluster02
   * Pseudo action:   promotable-clone_demote_0
   * Pseudo action:   httpd-bundle_stop_0
   * Pseudo action:   httpd-bundle_start_0

--- a/cts/scheduler/exp/bug-rh-1097457.exp
+++ b/cts/scheduler/exp/bug-rh-1097457.exp
@@ -618,7 +618,7 @@
     <action_set>
       <rsc_op id="111" operation="start" operation_key="lamaVM2_start_0" on_node="lama3" on_node_uuid="2">
         <primitive id="lamaVM2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="VM2" CRM_meta_name="start" CRM_meta_on_node="lama3" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="VM2" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="lama3" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/bundle-connection-with-container.exp
+++ b/cts/scheduler/exp/bundle-connection-with-container.exp
@@ -167,7 +167,7 @@
     <action_set>
       <rsc_op id="30" operation="start" operation_key="httpd-bundle-0_start_0" on_node="rhel8-1" on_node_uuid="1">
         <primitive id="httpd-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="httpd-bundle-podman-0" CRM_meta_on_node="rhel8-1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="90000" addr="192.168.122.131"  port="9999"/>
+        <attributes CRM_meta_container="httpd-bundle-podman-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="rhel8-1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="90000" addr="192.168.122.131"  port="9999"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/bundle-interleave-start.exp
+++ b/cts/scheduler/exp/bundle-interleave-start.exp
@@ -297,7 +297,7 @@
     <action_set>
       <rsc_op id="66" operation="start" operation_key="base-bundle-0_start_0" on_node="node2" on_node_uuid="2">
         <primitive id="base-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="base-bundle-podman-0" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="node2"  port="3121"/>
+        <attributes CRM_meta_container="base-bundle-podman-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="node2"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -495,7 +495,7 @@
     <action_set>
       <rsc_op id="70" operation="start" operation_key="base-bundle-1_start_0" on_node="node3" on_node_uuid="3">
         <primitive id="base-bundle-1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="base-bundle-podman-1" CRM_meta_on_node="node3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="node3"  port="3121"/>
+        <attributes CRM_meta_container="base-bundle-podman-1" CRM_meta_expire_attrs="true" CRM_meta_on_node="node3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="node3"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -693,7 +693,7 @@
     <action_set>
       <rsc_op id="74" operation="start" operation_key="base-bundle-2_start_0" on_node="node4" on_node_uuid="4">
         <primitive id="base-bundle-2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="base-bundle-podman-2" CRM_meta_on_node="node4" CRM_meta_on_node_uuid="4" CRM_meta_timeout="20000" addr="node4"  port="3121"/>
+        <attributes CRM_meta_container="base-bundle-podman-2" CRM_meta_expire_attrs="true" CRM_meta_on_node="node4" CRM_meta_on_node_uuid="4" CRM_meta_timeout="20000" addr="node4"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1083,7 +1083,7 @@
     <action_set>
       <rsc_op id="100" operation="start" operation_key="app-bundle-0_start_0" on_node="node2" on_node_uuid="2">
         <primitive id="app-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="app-bundle-podman-0" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="node2"  port="3121"/>
+        <attributes CRM_meta_container="app-bundle-podman-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="node2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="node2"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1284,7 +1284,7 @@
     <action_set>
       <rsc_op id="104" operation="start" operation_key="app-bundle-1_start_0" on_node="node3" on_node_uuid="3">
         <primitive id="app-bundle-1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="app-bundle-podman-1" CRM_meta_on_node="node3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="node3"  port="3121"/>
+        <attributes CRM_meta_container="app-bundle-podman-1" CRM_meta_expire_attrs="true" CRM_meta_on_node="node3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="node3"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1485,7 +1485,7 @@
     <action_set>
       <rsc_op id="108" operation="start" operation_key="app-bundle-2_start_0" on_node="node4" on_node_uuid="4">
         <primitive id="app-bundle-2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="app-bundle-podman-2" CRM_meta_on_node="node4" CRM_meta_on_node_uuid="4" CRM_meta_timeout="20000" addr="node4"  port="3121"/>
+        <attributes CRM_meta_container="app-bundle-podman-2" CRM_meta_expire_attrs="true" CRM_meta_on_node="node4" CRM_meta_on_node_uuid="4" CRM_meta_timeout="20000" addr="node4"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/bundle-nested-colocation.exp
+++ b/cts/scheduler/exp/bundle-nested-colocation.exp
@@ -357,7 +357,7 @@
     <action_set>
       <rsc_op id="41" operation="start" operation_key="rabbitmq-bundle-0_start_0" on_node="overcloud-controller-0" on_node_uuid="1">
         <primitive id="rabbitmq-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="rabbitmq-bundle-docker-0" CRM_meta_on_node="overcloud-controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="overcloud-rabbit-0"  port="3121"/>
+        <attributes CRM_meta_container="rabbitmq-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="overcloud-controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="overcloud-rabbit-0"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -521,7 +521,7 @@
     <action_set>
       <rsc_op id="44" operation="start" operation_key="rabbitmq-bundle-1_start_0" on_node="overcloud-controller-1" on_node_uuid="2">
         <primitive id="rabbitmq-bundle-1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="rabbitmq-bundle-docker-1" CRM_meta_on_node="overcloud-controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="overcloud-rabbit-1"  port="3121"/>
+        <attributes CRM_meta_container="rabbitmq-bundle-docker-1" CRM_meta_expire_attrs="true" CRM_meta_on_node="overcloud-controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="overcloud-rabbit-1"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -685,7 +685,7 @@
     <action_set>
       <rsc_op id="47" operation="start" operation_key="rabbitmq-bundle-2_start_0" on_node="overcloud-controller-2" on_node_uuid="3">
         <primitive id="rabbitmq-bundle-2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="rabbitmq-bundle-docker-2" CRM_meta_on_node="overcloud-controller-2" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="overcloud-rabbit-2"  port="3121"/>
+        <attributes CRM_meta_container="rabbitmq-bundle-docker-2" CRM_meta_expire_attrs="true" CRM_meta_on_node="overcloud-controller-2" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="overcloud-rabbit-2"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/bundle-order-fencing.exp
+++ b/cts/scheduler/exp/bundle-order-fencing.exp
@@ -310,7 +310,7 @@
         <crm_event id="1" operation="stonith" operation_key="stonith-controller-0-reboot" on_node="controller-0" on_node_uuid="1"/>
       </trigger>
       <trigger>
-        <pseudo_event id="42" operation="stop" operation_key="rabbitmq-bundle-0_stop_0"/>
+        <pseudo_event id="42" operation="stop" operation_key="rabbitmq-bundle-0_stop_0" on_node="controller-0" on_node_uuid="1"/>
       </trigger>
       <trigger>
         <pseudo_event id="55" operation="stop" operation_key="rabbitmq-bundle_stop_0"/>
@@ -343,8 +343,11 @@
   </synapse>
   <synapse id="24">
     <action_set>
-      <pseudo_event id="42" operation="stop" operation_key="rabbitmq-bundle-0_stop_0">
-        <attributes CRM_meta_container="rabbitmq-bundle-docker-0" CRM_meta_notify_stop_resource="rabbitmq-bundle-0" CRM_meta_notify_stop_uname="controller-0" CRM_meta_timeout="20000" addr="controller-0"  port="3122"/>
+      <pseudo_event id="42" operation="stop" operation_key="rabbitmq-bundle-0_stop_0" on_node="controller-0" on_node_uuid="1">
+        <attributes CRM_meta_container="rabbitmq-bundle-docker-0" CRM_meta_notify_stop_resource="rabbitmq-bundle-0" CRM_meta_notify_stop_uname="controller-0" CRM_meta_on_node="controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="controller-0"  port="3122"/>
+        <downed>
+          <node id="rabbitmq-bundle-0"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
@@ -513,7 +516,7 @@
         <crm_event id="1" operation="stonith" operation_key="stonith-controller-0-reboot" on_node="controller-0" on_node_uuid="1"/>
       </trigger>
       <trigger>
-        <pseudo_event id="77" operation="stop" operation_key="galera-bundle-0_stop_0"/>
+        <pseudo_event id="77" operation="stop" operation_key="galera-bundle-0_stop_0" on_node="controller-0" on_node_uuid="1"/>
       </trigger>
       <trigger>
         <pseudo_event id="90" operation="stop" operation_key="galera-bundle_stop_0"/>
@@ -522,8 +525,11 @@
   </synapse>
   <synapse id="38">
     <action_set>
-      <pseudo_event id="77" operation="stop" operation_key="galera-bundle-0_stop_0">
-        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_timeout="20000" addr="controller-0"  port="3123"/>
+      <pseudo_event id="77" operation="stop" operation_key="galera-bundle-0_stop_0" on_node="controller-0" on_node_uuid="1">
+        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_on_node="controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="controller-0"  port="3123"/>
+        <downed>
+          <node id="galera-bundle-0"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
@@ -1272,7 +1278,7 @@
         <crm_event id="1" operation="stonith" operation_key="stonith-controller-0-reboot" on_node="controller-0" on_node_uuid="1"/>
       </trigger>
       <trigger>
-        <pseudo_event id="118" operation="stop" operation_key="redis-bundle-0_stop_0"/>
+        <pseudo_event id="118" operation="stop" operation_key="redis-bundle-0_stop_0" on_node="controller-0" on_node_uuid="1"/>
       </trigger>
       <trigger>
         <pseudo_event id="131" operation="stop" operation_key="redis-bundle_stop_0"/>
@@ -1305,8 +1311,11 @@
   </synapse>
   <synapse id="92">
     <action_set>
-      <pseudo_event id="118" operation="stop" operation_key="redis-bundle-0_stop_0">
-        <attributes CRM_meta_container="redis-bundle-docker-0" CRM_meta_notify_stop_resource="redis-bundle-0" CRM_meta_notify_stop_uname="controller-0" CRM_meta_timeout="20000" addr="controller-0"  port="3124"/>
+      <pseudo_event id="118" operation="stop" operation_key="redis-bundle-0_stop_0" on_node="controller-0" on_node_uuid="1">
+        <attributes CRM_meta_container="redis-bundle-docker-0" CRM_meta_notify_stop_resource="redis-bundle-0" CRM_meta_notify_stop_uname="controller-0" CRM_meta_on_node="controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="controller-0"  port="3124"/>
+        <downed>
+          <node id="redis-bundle-0"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/bundle-order-partial-start-2.exp
+++ b/cts/scheduler/exp/bundle-order-partial-start-2.exp
@@ -276,7 +276,7 @@
     <action_set>
       <rsc_op id="42" operation="start" operation_key="galera-bundle-0_start_0" on_node="undercloud" on_node_uuid="1">
         <primitive id="galera-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_on_node="undercloud" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="undercloud"  port="3123"/>
+        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="undercloud" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="undercloud"  port="3123"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/bundle-order-partial-start.exp
+++ b/cts/scheduler/exp/bundle-order-partial-start.exp
@@ -269,7 +269,7 @@
     <action_set>
       <rsc_op id="40" operation="start" operation_key="galera-bundle-0_start_0" on_node="undercloud" on_node_uuid="1">
         <primitive id="galera-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_on_node="undercloud" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="undercloud"  port="3123"/>
+        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="undercloud" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="undercloud"  port="3123"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/bundle-order-startup-clone-2.exp
+++ b/cts/scheduler/exp/bundle-order-startup-clone-2.exp
@@ -560,7 +560,7 @@
     <action_set>
       <rsc_op id="69" operation="start" operation_key="galera-bundle-0_start_0" on_node="metal-1" on_node_uuid="1">
         <primitive id="galera-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_on_node="metal-1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="metal-1"  port="3123"/>
+        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="metal-1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="metal-1"  port="3123"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -702,7 +702,7 @@
     <action_set>
       <rsc_op id="73" operation="start" operation_key="galera-bundle-1_start_0" on_node="metal-2" on_node_uuid="2">
         <primitive id="galera-bundle-1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="galera-bundle-docker-1" CRM_meta_on_node="metal-2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="metal-2"  port="3123"/>
+        <attributes CRM_meta_container="galera-bundle-docker-1" CRM_meta_expire_attrs="true" CRM_meta_on_node="metal-2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="metal-2"  port="3123"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -844,7 +844,7 @@
     <action_set>
       <rsc_op id="77" operation="start" operation_key="galera-bundle-2_start_0" on_node="metal-3" on_node_uuid="3">
         <primitive id="galera-bundle-2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="galera-bundle-docker-2" CRM_meta_on_node="metal-3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="metal-3"  port="3123"/>
+        <attributes CRM_meta_container="galera-bundle-docker-2" CRM_meta_expire_attrs="true" CRM_meta_on_node="metal-3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="metal-3"  port="3123"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1741,7 +1741,7 @@
     <action_set>
       <rsc_op id="116" operation="start" operation_key="redis-bundle-0_start_0" on_node="metal-1" on_node_uuid="1">
         <primitive id="redis-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="redis-bundle-docker-0" CRM_meta_on_node="metal-1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="metal-1"  port="3124"/>
+        <attributes CRM_meta_container="redis-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="metal-1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="metal-1"  port="3124"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1883,7 +1883,7 @@
     <action_set>
       <rsc_op id="120" operation="start" operation_key="redis-bundle-1_start_0" on_node="metal-2" on_node_uuid="2">
         <primitive id="redis-bundle-1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="redis-bundle-docker-1" CRM_meta_on_node="metal-2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="metal-2"  port="3124"/>
+        <attributes CRM_meta_container="redis-bundle-docker-1" CRM_meta_expire_attrs="true" CRM_meta_on_node="metal-2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="metal-2"  port="3124"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -2025,7 +2025,7 @@
     <action_set>
       <rsc_op id="124" operation="start" operation_key="redis-bundle-2_start_0" on_node="metal-3" on_node_uuid="3">
         <primitive id="redis-bundle-2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="redis-bundle-docker-2" CRM_meta_on_node="metal-3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="metal-3"  port="3124"/>
+        <attributes CRM_meta_container="redis-bundle-docker-2" CRM_meta_expire_attrs="true" CRM_meta_on_node="metal-3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="metal-3"  port="3124"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/bundle-order-startup-clone.exp
+++ b/cts/scheduler/exp/bundle-order-startup-clone.exp
@@ -353,7 +353,7 @@
     <action_set>
       <rsc_op id="68" operation="start" operation_key="redis-bundle-0_start_0" on_node="metal-2" on_node_uuid="2">
         <primitive id="redis-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="redis-bundle-docker-0" CRM_meta_on_node="metal-2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="metal-2"  port="3124"/>
+        <attributes CRM_meta_container="redis-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="metal-2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="metal-2"  port="3124"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/bundle-order-startup.exp
+++ b/cts/scheduler/exp/bundle-order-startup.exp
@@ -188,7 +188,7 @@
     <action_set>
       <rsc_op id="17" operation="start" operation_key="rabbitmq-bundle-0_start_0" on_node="undercloud" on_node_uuid="1">
         <primitive id="rabbitmq-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="rabbitmq-bundle-docker-0" CRM_meta_on_node="undercloud" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="undercloud"  port="3121"/>
+        <attributes CRM_meta_container="rabbitmq-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="undercloud" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="undercloud"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -349,7 +349,7 @@
     <action_set>
       <rsc_op id="39" operation="start" operation_key="galera-bundle-0_start_0" on_node="undercloud" on_node_uuid="1">
         <primitive id="galera-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_on_node="undercloud" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="undercloud"  port="3123"/>
+        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="undercloud" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="undercloud"  port="3123"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -585,7 +585,7 @@
     <action_set>
       <rsc_op id="62" operation="start" operation_key="redis-bundle-0_start_0" on_node="undercloud" on_node_uuid="1">
         <primitive id="redis-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="redis-bundle-docker-0" CRM_meta_on_node="undercloud" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="undercloud"  port="3124"/>
+        <attributes CRM_meta_container="redis-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="undercloud" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="undercloud"  port="3124"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/bundle-order-stop-on-remote.exp
+++ b/cts/scheduler/exp/bundle-order-stop-on-remote.exp
@@ -16,7 +16,7 @@
     <action_set>
       <rsc_op id="37" operation="start" operation_key="database-0_start_0" on_node="controller-0" on_node_uuid="1">
         <primitive id="database-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000"  reconnect_interval="60"/>
       </rsc_op>
     </action_set>
     <inputs/>
@@ -38,7 +38,7 @@
     <action_set>
       <rsc_op id="41" operation="start" operation_key="database-2_start_0" on_node="controller-1" on_node_uuid="2">
         <primitive id="database-2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
       </rsc_op>
     </action_set>
     <inputs/>
@@ -480,7 +480,7 @@
     <action_set>
       <rsc_op id="86" operation="start" operation_key="galera-bundle-0_start_0" on_node="controller-0" on_node_uuid="1">
         <primitive id="galera-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_on_node="controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="database-0"  port="3123"/>
+        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="database-0"  port="3123"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -579,7 +579,7 @@
     <action_set>
       <rsc_op id="95" operation="start" operation_key="galera-bundle-2_start_0" on_node="controller-1" on_node_uuid="2">
         <primitive id="galera-bundle-2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="galera-bundle-docker-2" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="database-2"  port="3123"/>
+        <attributes CRM_meta_container="galera-bundle-docker-2" CRM_meta_expire_attrs="true" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="database-2"  port="3123"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1094,7 +1094,7 @@
     <action_set>
       <rsc_op id="133" operation="start" operation_key="redis-bundle-1_start_0" on_node="controller-1" on_node_uuid="2">
         <primitive id="redis-bundle-1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="redis-bundle-docker-1" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="controller-1"  port="3124"/>
+        <attributes CRM_meta_container="redis-bundle-docker-1" CRM_meta_expire_attrs="true" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="controller-1"  port="3124"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/bundle-probe-remotes.exp
+++ b/cts/scheduler/exp/bundle-probe-remotes.exp
@@ -16,7 +16,7 @@
     <action_set>
       <rsc_op id="64" operation="start" operation_key="c09-h08-r630_start_0" on_node="c09-h05-r630" on_node_uuid="1">
         <primitive id="c09-h08-r630" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="c09-h05-r630" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="c09-h05-r630" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -75,7 +75,7 @@
     <action_set>
       <rsc_op id="66" operation="start" operation_key="c09-h09-r630_start_0" on_node="c09-h06-r630" on_node_uuid="2">
         <primitive id="c09-h09-r630" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="c09-h06-r630" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="c09-h06-r630" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -134,7 +134,7 @@
     <action_set>
       <rsc_op id="68" operation="start" operation_key="c09-h10-r630_start_0" on_node="c09-h07-r630" on_node_uuid="3">
         <primitive id="c09-h10-r630" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="c09-h07-r630" CRM_meta_on_node_uuid="3" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="c09-h07-r630" CRM_meta_on_node_uuid="3" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -693,7 +693,7 @@
     <action_set>
       <rsc_op id="72" operation="start" operation_key="scale1-bundle-0_start_0" on_node="c09-h05-r630" on_node_uuid="1">
         <primitive id="scale1-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="scale1-bundle-docker-0" CRM_meta_on_node="c09-h05-r630" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="c09-h05-r630"  port="3131"/>
+        <attributes CRM_meta_container="scale1-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="c09-h05-r630" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="c09-h05-r630"  port="3131"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -892,7 +892,7 @@
     <action_set>
       <rsc_op id="76" operation="start" operation_key="scale1-bundle-1_start_0" on_node="c09-h06-r630" on_node_uuid="2">
         <primitive id="scale1-bundle-1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="scale1-bundle-docker-1" CRM_meta_on_node="c09-h06-r630" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="c09-h06-r630"  port="3131"/>
+        <attributes CRM_meta_container="scale1-bundle-docker-1" CRM_meta_expire_attrs="true" CRM_meta_on_node="c09-h06-r630" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="c09-h06-r630"  port="3131"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1091,7 +1091,7 @@
     <action_set>
       <rsc_op id="80" operation="start" operation_key="scale1-bundle-2_start_0" on_node="c09-h07-r630" on_node_uuid="3">
         <primitive id="scale1-bundle-2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="scale1-bundle-docker-2" CRM_meta_on_node="c09-h07-r630" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="c09-h07-r630"  port="3131"/>
+        <attributes CRM_meta_container="scale1-bundle-docker-2" CRM_meta_expire_attrs="true" CRM_meta_on_node="c09-h07-r630" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="c09-h07-r630"  port="3131"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1296,7 +1296,7 @@
     <action_set>
       <rsc_op id="84" operation="start" operation_key="scale1-bundle-3_start_0" on_node="c09-h05-r630" on_node_uuid="1">
         <primitive id="scale1-bundle-3" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="scale1-bundle-docker-3" CRM_meta_on_node="c09-h05-r630" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="c09-h08-r630"  port="3131"/>
+        <attributes CRM_meta_container="scale1-bundle-docker-3" CRM_meta_expire_attrs="true" CRM_meta_on_node="c09-h05-r630" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="c09-h08-r630"  port="3131"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1501,7 +1501,7 @@
     <action_set>
       <rsc_op id="88" operation="start" operation_key="scale1-bundle-4_start_0" on_node="c09-h06-r630" on_node_uuid="2">
         <primitive id="scale1-bundle-4" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="scale1-bundle-docker-4" CRM_meta_on_node="c09-h06-r630" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="c09-h09-r630"  port="3131"/>
+        <attributes CRM_meta_container="scale1-bundle-docker-4" CRM_meta_expire_attrs="true" CRM_meta_on_node="c09-h06-r630" CRM_meta_on_node_uuid="2" CRM_meta_timeout="20000" addr="c09-h09-r630"  port="3131"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1706,7 +1706,7 @@
     <action_set>
       <rsc_op id="92" operation="start" operation_key="scale1-bundle-5_start_0" on_node="c09-h07-r630" on_node_uuid="3">
         <primitive id="scale1-bundle-5" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="scale1-bundle-docker-5" CRM_meta_on_node="c09-h07-r630" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="c09-h10-r630"  port="3131"/>
+        <attributes CRM_meta_container="scale1-bundle-docker-5" CRM_meta_expire_attrs="true" CRM_meta_on_node="c09-h07-r630" CRM_meta_on_node_uuid="3" CRM_meta_timeout="20000" addr="c09-h10-r630"  port="3131"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/bundle-replicas-change.exp
+++ b/cts/scheduler/exp/bundle-replicas-change.exp
@@ -214,7 +214,7 @@
     <action_set>
       <rsc_op id="18" operation="start" operation_key="httpd-bundle-0_start_0" on_node="rh74-test" on_node_uuid="3232287163">
         <primitive id="httpd-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="httpd-bundle-docker-0" CRM_meta_on_node="rh74-test" CRM_meta_on_node_uuid="3232287163" CRM_meta_timeout="20000" addr="192.168.20.188"  port="3121"/>
+        <attributes CRM_meta_container="httpd-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="rh74-test" CRM_meta_on_node_uuid="3232287163" CRM_meta_timeout="20000" addr="192.168.20.188"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -348,7 +348,7 @@
     <action_set>
       <rsc_op id="23" operation="start" operation_key="httpd-bundle-1_start_0" on_node="rh74-test" on_node_uuid="3232287163">
         <primitive id="httpd-bundle-1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="httpd-bundle-docker-1" CRM_meta_on_node="rh74-test" CRM_meta_on_node_uuid="3232287163" CRM_meta_timeout="20000" addr="192.168.20.189"  port="3121"/>
+        <attributes CRM_meta_container="httpd-bundle-docker-1" CRM_meta_expire_attrs="true" CRM_meta_on_node="rh74-test" CRM_meta_on_node_uuid="3232287163" CRM_meta_timeout="20000" addr="192.168.20.189"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -466,7 +466,7 @@
     <action_set>
       <rsc_op id="29" operation="start" operation_key="httpd-bundle-2_start_0" on_node="rh74-test" on_node_uuid="3232287163">
         <primitive id="httpd-bundle-2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="httpd-bundle-docker-2" CRM_meta_on_node="rh74-test" CRM_meta_on_node_uuid="3232287163" CRM_meta_timeout="20000" addr="192.168.20.190"  port="3121"/>
+        <attributes CRM_meta_container="httpd-bundle-docker-2" CRM_meta_expire_attrs="true" CRM_meta_on_node="rh74-test" CRM_meta_on_node_uuid="3232287163" CRM_meta_timeout="20000" addr="192.168.20.190"  port="3121"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/cancel-behind-moving-remote.exp
+++ b/cts/scheduler/exp/cancel-behind-moving-remote.exp
@@ -716,7 +716,7 @@
     <action_set>
       <rsc_op id="227" operation="start" operation_key="ovn-dbs-bundle-0_start_0" on_node="controller-2" on_node_uuid="3">
         <primitive id="ovn-dbs-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="ovn-dbs-bundle-podman-0" CRM_meta_on_node="controller-2" CRM_meta_on_node_uuid="3" CRM_meta_timeout="120000" addr="controller-2"  port="3125"/>
+        <attributes CRM_meta_container="ovn-dbs-bundle-podman-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="controller-2" CRM_meta_on_node_uuid="3" CRM_meta_timeout="120000" addr="controller-2"  port="3125"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -824,7 +824,7 @@
     <action_set>
       <rsc_op id="72" operation="start" operation_key="ovn-dbs-bundle-1_start_0" on_node="controller-0" on_node_uuid="1">
         <primitive id="ovn-dbs-bundle-1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="ovn-dbs-bundle-podman-1" CRM_meta_on_node="controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="120000" addr="controller-0"  port="3125"/>
+        <attributes CRM_meta_container="ovn-dbs-bundle-podman-1" CRM_meta_expire_attrs="true" CRM_meta_on_node="controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="120000" addr="controller-0"  port="3125"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/guest-node-cleanup.exp
+++ b/cts/scheduler/exp/guest-node-cleanup.exp
@@ -227,7 +227,7 @@
     <action_set>
       <rsc_op id="28" operation="start" operation_key="lxc1_start_0" on_node="rhel7-1" on_node_uuid="1">
         <primitive id="lxc1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container1" CRM_meta_name="start" CRM_meta_on_node="rhel7-1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container1" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="rhel7-1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/guest-node-host-dies.exp
+++ b/cts/scheduler/exp/guest-node-host-dies.exp
@@ -126,7 +126,7 @@
         <crm_event id="1" operation="stonith" operation_key="stonith-rhel7-1-reboot" on_node="rhel7-1" on_node_uuid="1"/>
       </trigger>
       <trigger>
-        <pseudo_event id="33" operation="stop" operation_key="lxc1_stop_0"/>
+        <pseudo_event id="33" operation="stop" operation_key="lxc1_stop_0" on_node="rhel7-1" on_node_uuid="1"/>
       </trigger>
     </inputs>
   </synapse>
@@ -163,7 +163,7 @@
         <crm_event id="1" operation="stonith" operation_key="stonith-rhel7-1-reboot" on_node="rhel7-1" on_node_uuid="1"/>
       </trigger>
       <trigger>
-        <pseudo_event id="36" operation="stop" operation_key="lxc2_stop_0"/>
+        <pseudo_event id="36" operation="stop" operation_key="lxc2_stop_0" on_node="rhel7-1" on_node_uuid="1"/>
       </trigger>
     </inputs>
   </synapse>
@@ -483,7 +483,7 @@
         <rsc_op id="15" operation="start" operation_key="container1_start_0" on_node="rhel7-2" on_node_uuid="2"/>
       </trigger>
       <trigger>
-        <pseudo_event id="33" operation="stop" operation_key="lxc1_stop_0"/>
+        <pseudo_event id="33" operation="stop" operation_key="lxc1_stop_0" on_node="rhel7-1" on_node_uuid="1"/>
       </trigger>
       <trigger>
         <pseudo_event id="39" operation="stonith" operation_key="stonith-lxc1-reboot" on_node="lxc1" on_node_uuid="lxc1"/>
@@ -495,8 +495,11 @@
   </synapse>
   <synapse id="27">
     <action_set>
-      <pseudo_event id="33" operation="stop" operation_key="lxc1_stop_0">
-        <attributes CRM_meta_container="container1" CRM_meta_timeout="20000" />
+      <pseudo_event id="33" operation="stop" operation_key="lxc1_stop_0" on_node="rhel7-1" on_node_uuid="1">
+        <attributes CRM_meta_container="container1" CRM_meta_on_node="rhel7-1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" />
+        <downed>
+          <node id="lxc1"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
@@ -562,7 +565,7 @@
         <rsc_op id="17" operation="start" operation_key="container2_start_0" on_node="rhel7-3" on_node_uuid="4"/>
       </trigger>
       <trigger>
-        <pseudo_event id="36" operation="stop" operation_key="lxc2_stop_0"/>
+        <pseudo_event id="36" operation="stop" operation_key="lxc2_stop_0" on_node="rhel7-1" on_node_uuid="1"/>
       </trigger>
       <trigger>
         <pseudo_event id="39" operation="stonith" operation_key="stonith-lxc1-reboot" on_node="lxc1" on_node_uuid="lxc1"/>
@@ -574,8 +577,11 @@
   </synapse>
   <synapse id="33">
     <action_set>
-      <pseudo_event id="36" operation="stop" operation_key="lxc2_stop_0">
-        <attributes CRM_meta_container="container2" CRM_meta_timeout="20000" />
+      <pseudo_event id="36" operation="stop" operation_key="lxc2_stop_0" on_node="rhel7-1" on_node_uuid="1">
+        <attributes CRM_meta_container="container2" CRM_meta_on_node="rhel7-1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" />
+        <downed>
+          <node id="lxc2"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/guest-node-host-dies.exp
+++ b/cts/scheduler/exp/guest-node-host-dies.exp
@@ -466,7 +466,7 @@
     <action_set>
       <rsc_op id="34" operation="start" operation_key="lxc1_start_0" on_node="rhel7-2" on_node_uuid="2">
         <primitive id="lxc1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container1" CRM_meta_name="start" CRM_meta_on_node="rhel7-2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container1" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="rhel7-2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -545,7 +545,7 @@
     <action_set>
       <rsc_op id="37" operation="start" operation_key="lxc2_start_0" on_node="rhel7-3" on_node_uuid="4">
         <primitive id="lxc2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container2" CRM_meta_name="start" CRM_meta_on_node="rhel7-3" CRM_meta_on_node_uuid="4" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container2" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="rhel7-3" CRM_meta_on_node_uuid="4" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/migration-behind-migrating-remote.exp
+++ b/cts/scheduler/exp/migration-behind-migrating-remote.exp
@@ -100,7 +100,7 @@
   <synapse id="8">
     <action_set>
       <pseudo_event id="13" operation="start" operation_key="remote1_start_0">
-        <attributes CRM_meta_timeout="20000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_timeout="20000" />
       </pseudo_event>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/nested-remote-recovery.exp
+++ b/cts/scheduler/exp/nested-remote-recovery.exp
@@ -279,7 +279,7 @@
     <action_set>
       <rsc_op id="69" operation="start" operation_key="galera-bundle-0_start_0" on_node="controller-0" on_node_uuid="1">
         <primitive id="galera-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_on_node="controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="database-0"  port="3123"/>
+        <attributes CRM_meta_container="galera-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="controller-0" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" addr="database-0"  port="3123"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/on_fail_demote4.exp
+++ b/cts/scheduler/exp/on_fail_demote4.exp
@@ -1530,7 +1530,7 @@
         <crm_event id="1" operation="stonith" operation_key="stonith-rhel7-4-reboot" on_node="rhel7-4" on_node_uuid="4"/>
       </trigger>
       <trigger>
-        <pseudo_event id="116" operation="stop" operation_key="stateful-bundle-2_stop_0"/>
+        <pseudo_event id="116" operation="stop" operation_key="stateful-bundle-2_stop_0" on_node="rhel7-4" on_node_uuid="4"/>
       </trigger>
       <trigger>
         <pseudo_event id="121" operation="stop" operation_key="stateful-bundle_stop_0"/>
@@ -1565,7 +1565,7 @@
         <rsc_op id="114" operation="start" operation_key="stateful-bundle-docker-2_start_0" on_node="rhel7-3" on_node_uuid="3"/>
       </trigger>
       <trigger>
-        <pseudo_event id="116" operation="stop" operation_key="stateful-bundle-2_stop_0"/>
+        <pseudo_event id="116" operation="stop" operation_key="stateful-bundle-2_stop_0" on_node="rhel7-4" on_node_uuid="4"/>
       </trigger>
       <trigger>
         <pseudo_event id="148" operation="stonith" operation_key="stonith-lxc2-reboot" on_node="lxc2" on_node_uuid="lxc2"/>
@@ -1574,8 +1574,11 @@
   </synapse>
   <synapse id="86">
     <action_set>
-      <pseudo_event id="116" operation="stop" operation_key="stateful-bundle-2_stop_0">
-        <attributes CRM_meta_container="stateful-bundle-docker-2" CRM_meta_timeout="90000" addr="192.168.122.133"  port="9999"/>
+      <pseudo_event id="116" operation="stop" operation_key="stateful-bundle-2_stop_0" on_node="rhel7-4" on_node_uuid="4">
+        <attributes CRM_meta_container="stateful-bundle-docker-2" CRM_meta_on_node="rhel7-4" CRM_meta_on_node_uuid="4" CRM_meta_timeout="90000" addr="192.168.122.133"  port="9999"/>
+        <downed>
+          <node id="stateful-bundle-2"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/on_fail_demote4.exp
+++ b/cts/scheduler/exp/on_fail_demote4.exp
@@ -631,7 +631,7 @@
     <action_set>
       <rsc_op id="81" operation="start" operation_key="remote-rhel7-2_start_0" on_node="rhel7-1" on_node_uuid="1">
         <primitive id="remote-rhel7-2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="rhel7-1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="120000"  server="rhel7-2"/>
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="rhel7-1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="120000"  server="rhel7-2"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1373,7 +1373,7 @@
     <action_set>
       <rsc_op id="103" operation="start" operation_key="stateful-bundle-0_start_0" on_node="rhel7-5" on_node_uuid="5">
         <primitive id="stateful-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="stateful-bundle-docker-0" CRM_meta_on_node="rhel7-5" CRM_meta_on_node_uuid="5" CRM_meta_timeout="90000" addr="192.168.122.131"  port="9999"/>
+        <attributes CRM_meta_container="stateful-bundle-docker-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="rhel7-5" CRM_meta_on_node_uuid="5" CRM_meta_timeout="90000" addr="192.168.122.131"  port="9999"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1554,7 +1554,7 @@
     <action_set>
       <rsc_op id="117" operation="start" operation_key="stateful-bundle-2_start_0" on_node="rhel7-3" on_node_uuid="3">
         <primitive id="stateful-bundle-2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="stateful-bundle-docker-2" CRM_meta_on_node="rhel7-3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="90000" addr="192.168.122.133"  port="9999"/>
+        <attributes CRM_meta_container="stateful-bundle-docker-2" CRM_meta_expire_attrs="true" CRM_meta_on_node="rhel7-3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="90000" addr="192.168.122.133"  port="9999"/>
       </rsc_op>
     </action_set>
     <inputs>
@@ -1584,7 +1584,7 @@
     <action_set>
       <rsc_op id="147" operation="start" operation_key="lxc2_start_0" on_node="rhel7-3" on_node_uuid="3">
         <primitive id="lxc2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container2" CRM_meta_name="start" CRM_meta_on_node="rhel7-3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container2" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="rhel7-3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/priority-fencing-delay.exp
+++ b/cts/scheduler/exp/priority-fencing-delay.exp
@@ -384,7 +384,7 @@
         <crm_event id="1" operation="stonith" operation_key="stonith-kiff-01-reboot" on_node="kiff-01" on_node_uuid="1"/>
       </trigger>
       <trigger>
-        <pseudo_event id="57" operation="stop" operation_key="lxc-01_kiff-01_stop_0"/>
+        <pseudo_event id="57" operation="stop" operation_key="lxc-01_kiff-01_stop_0" on_node="kiff-01" on_node_uuid="1"/>
       </trigger>
     </inputs>
   </synapse>
@@ -434,7 +434,7 @@
         <crm_event id="1" operation="stonith" operation_key="stonith-kiff-01-reboot" on_node="kiff-01" on_node_uuid="1"/>
       </trigger>
       <trigger>
-        <pseudo_event id="60" operation="stop" operation_key="lxc-02_kiff-01_stop_0"/>
+        <pseudo_event id="60" operation="stop" operation_key="lxc-02_kiff-01_stop_0" on_node="kiff-01" on_node_uuid="1"/>
       </trigger>
     </inputs>
   </synapse>
@@ -463,7 +463,7 @@
         <rsc_op id="50" operation="start" operation_key="R-lxc-01_kiff-01_start_0" on_node="kiff-02" on_node_uuid="2"/>
       </trigger>
       <trigger>
-        <pseudo_event id="57" operation="stop" operation_key="lxc-01_kiff-01_stop_0"/>
+        <pseudo_event id="57" operation="stop" operation_key="lxc-01_kiff-01_stop_0" on_node="kiff-01" on_node_uuid="1"/>
       </trigger>
       <trigger>
         <pseudo_event id="67" operation="stonith" operation_key="stonith-lxc-01_kiff-01-reboot" on_node="lxc-01_kiff-01" on_node_uuid="lxc-01_kiff-01"/>
@@ -475,8 +475,11 @@
   </synapse>
   <synapse id="31">
     <action_set>
-      <pseudo_event id="57" operation="stop" operation_key="lxc-01_kiff-01_stop_0">
-        <attributes CRM_meta_container="R-lxc-01_kiff-01" CRM_meta_timeout="20000" />
+      <pseudo_event id="57" operation="stop" operation_key="lxc-01_kiff-01_stop_0" on_node="kiff-01" on_node_uuid="1">
+        <attributes CRM_meta_container="R-lxc-01_kiff-01" CRM_meta_on_node="kiff-01" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" />
+        <downed>
+          <node id="lxc-01_kiff-01"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
@@ -506,7 +509,7 @@
         <rsc_op id="53" operation="start" operation_key="R-lxc-02_kiff-01_start_0" on_node="kiff-02" on_node_uuid="2"/>
       </trigger>
       <trigger>
-        <pseudo_event id="60" operation="stop" operation_key="lxc-02_kiff-01_stop_0"/>
+        <pseudo_event id="60" operation="stop" operation_key="lxc-02_kiff-01_stop_0" on_node="kiff-01" on_node_uuid="1"/>
       </trigger>
       <trigger>
         <pseudo_event id="67" operation="stonith" operation_key="stonith-lxc-01_kiff-01-reboot" on_node="lxc-01_kiff-01" on_node_uuid="lxc-01_kiff-01"/>
@@ -518,8 +521,11 @@
   </synapse>
   <synapse id="34">
     <action_set>
-      <pseudo_event id="60" operation="stop" operation_key="lxc-02_kiff-01_stop_0">
-        <attributes CRM_meta_container="R-lxc-02_kiff-01" CRM_meta_timeout="20000" />
+      <pseudo_event id="60" operation="stop" operation_key="lxc-02_kiff-01_stop_0" on_node="kiff-01" on_node_uuid="1">
+        <attributes CRM_meta_container="R-lxc-02_kiff-01" CRM_meta_on_node="kiff-01" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" />
+        <downed>
+          <node id="lxc-02_kiff-01"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/priority-fencing-delay.exp
+++ b/cts/scheduler/exp/priority-fencing-delay.exp
@@ -455,7 +455,7 @@
     <action_set>
       <rsc_op id="58" operation="start" operation_key="lxc-01_kiff-01_start_0" on_node="kiff-02" on_node_uuid="2">
         <primitive id="lxc-01_kiff-01" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="R-lxc-01_kiff-01" CRM_meta_name="start" CRM_meta_on_node="kiff-02" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="R-lxc-01_kiff-01" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="kiff-02" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -498,7 +498,7 @@
     <action_set>
       <rsc_op id="61" operation="start" operation_key="lxc-02_kiff-01_start_0" on_node="kiff-02" on_node_uuid="2">
         <primitive id="lxc-02_kiff-01" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="R-lxc-02_kiff-01" CRM_meta_name="start" CRM_meta_on_node="kiff-02" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="R-lxc-02_kiff-01" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="kiff-02" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/remote-connection-unrecoverable.exp
+++ b/cts/scheduler/exp/remote-connection-unrecoverable.exp
@@ -1,8 +1,11 @@
 <transition_graph cluster-delay="60s" stonith-timeout="60s" failed-stop-offset="INFINITY" failed-start-offset="INFINITY"  transition_id="0">
   <synapse id="0">
     <action_set>
-      <pseudo_event id="9" operation="stop" operation_key="remote1_stop_0">
-        <attributes CRM_meta_timeout="20000"  reconnect_interval="60"/>
+      <pseudo_event id="9" operation="stop" operation_key="remote1_stop_0" on_node="node1" on_node_uuid="1">
+        <attributes CRM_meta_on_node="node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000"  reconnect_interval="60"/>
+        <downed>
+          <node id="remote1"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/remote-fence-unclean.exp
+++ b/cts/scheduler/exp/remote-fence-unclean.exp
@@ -3,7 +3,7 @@
     <action_set>
       <rsc_op id="10" operation="start" operation_key="remote1_start_0" on_node="18node1" on_node_uuid="1">
         <primitive id="remote1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_on_node="18node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_on_node="18node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/remote-move.exp
+++ b/cts/scheduler/exp/remote-move.exp
@@ -72,7 +72,7 @@
   <synapse id="6">
     <action_set>
       <pseudo_event id="11" operation="start" operation_key="remote1_start_0">
-        <attributes CRM_meta_timeout="20000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_timeout="20000" />
       </pseudo_event>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/remote-partial-migrate.exp
+++ b/cts/scheduler/exp/remote-partial-migrate.exp
@@ -24,7 +24,7 @@
   <synapse id="2">
     <action_set>
       <pseudo_event id="53" operation="start" operation_key="pcmk_remote3_start_0">
-        <attributes CRM_meta_name="start" CRM_meta_timeout="10000"  server="172.17.201.3"/>
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_timeout="10000"  server="172.17.201.3"/>
       </pseudo_event>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/remote-partial-migrate2.exp
+++ b/cts/scheduler/exp/remote-partial-migrate2.exp
@@ -24,7 +24,7 @@
   <synapse id="2">
     <action_set>
       <pseudo_event id="61" operation="start" operation_key="pcmk_remote2_start_0">
-        <attributes CRM_meta_name="start" CRM_meta_timeout="10000"  server="172.17.201.2"/>
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_timeout="10000"  server="172.17.201.2"/>
       </pseudo_event>
     </action_set>
     <inputs>
@@ -66,7 +66,7 @@
     <action_set>
       <rsc_op id="66" operation="start" operation_key="pcmk_remote4_start_0" on_node="pcmk2" on_node_uuid="2">
         <primitive id="pcmk_remote4" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="pcmk2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="10000"  server="172.17.201.4"/>
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="pcmk2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="10000"  server="172.17.201.4"/>
       </rsc_op>
     </action_set>
     <inputs/>
@@ -109,7 +109,7 @@
   <synapse id="9">
     <action_set>
       <pseudo_event id="69" operation="start" operation_key="pcmk_remote5_start_0">
-        <attributes CRM_meta_name="start" CRM_meta_timeout="10000"  server="172.17.201.5"/>
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_timeout="10000"  server="172.17.201.5"/>
       </pseudo_event>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/remote-recover-all.exp
+++ b/cts/scheduler/exp/remote-recover-all.exp
@@ -1,8 +1,11 @@
 <transition_graph cluster-delay="60s" stonith-timeout="60s" failed-stop-offset="INFINITY" failed-start-offset="INFINITY"  transition_id="0">
   <synapse id="0">
     <action_set>
-      <pseudo_event id="24" operation="stop" operation_key="messaging-1_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="24" operation="stop" operation_key="messaging-1_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="messaging-1"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
@@ -29,7 +32,7 @@
     </action_set>
     <inputs>
       <trigger>
-        <pseudo_event id="27" operation="stop" operation_key="galera-0_stop_0"/>
+        <pseudo_event id="27" operation="stop" operation_key="galera-0_stop_0" on_node="controller-1" on_node_uuid="2"/>
       </trigger>
       <trigger>
         <crm_event id="132" operation="stonith" operation_key="stonith-galera-2-reboot" on_node="galera-2" on_node_uuid="galera-2"/>
@@ -41,16 +44,22 @@
   </synapse>
   <synapse id="3">
     <action_set>
-      <pseudo_event id="27" operation="stop" operation_key="galera-0_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="27" operation="stop" operation_key="galera-0_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="galera-0"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
   </synapse>
   <synapse id="4">
     <action_set>
-      <pseudo_event id="32" operation="stop" operation_key="galera-2_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="32" operation="stop" operation_key="galera-2_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="galera-2"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/remote-recover-connection.exp
+++ b/cts/scheduler/exp/remote-recover-connection.exp
@@ -21,14 +21,17 @@
     </action_set>
     <inputs>
       <trigger>
-        <pseudo_event id="24" operation="stop" operation_key="messaging-1_stop_0"/>
+        <pseudo_event id="24" operation="stop" operation_key="messaging-1_stop_0" on_node="controller-1" on_node_uuid="2"/>
       </trigger>
     </inputs>
   </synapse>
   <synapse id="2">
     <action_set>
-      <pseudo_event id="24" operation="stop" operation_key="messaging-1_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="24" operation="stop" operation_key="messaging-1_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="messaging-1"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
@@ -55,14 +58,17 @@
     </action_set>
     <inputs>
       <trigger>
-        <pseudo_event id="29" operation="stop" operation_key="galera-0_stop_0"/>
+        <pseudo_event id="29" operation="stop" operation_key="galera-0_stop_0" on_node="controller-1" on_node_uuid="2"/>
       </trigger>
     </inputs>
   </synapse>
   <synapse id="5">
     <action_set>
-      <pseudo_event id="29" operation="stop" operation_key="galera-0_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="29" operation="stop" operation_key="galera-0_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="galera-0"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
@@ -89,14 +95,17 @@
     </action_set>
     <inputs>
       <trigger>
-        <pseudo_event id="34" operation="stop" operation_key="galera-2_stop_0"/>
+        <pseudo_event id="34" operation="stop" operation_key="galera-2_stop_0" on_node="controller-1" on_node_uuid="2"/>
       </trigger>
     </inputs>
   </synapse>
   <synapse id="8">
     <action_set>
-      <pseudo_event id="34" operation="stop" operation_key="galera-2_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="34" operation="stop" operation_key="galera-2_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="galera-2"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/remote-recover-fail.exp
+++ b/cts/scheduler/exp/remote-recover-fail.exp
@@ -16,7 +16,7 @@
     <action_set>
       <rsc_op id="7" operation="start" operation_key="rhel7-auto4_start_0" on_node="rhel7-auto2" on_node_uuid="2">
         <primitive id="rhel7-auto4" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="rhel7-auto2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="rhel7-auto2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/remote-recover-no-resources.exp
+++ b/cts/scheduler/exp/remote-recover-no-resources.exp
@@ -1,8 +1,11 @@
 <transition_graph cluster-delay="60s" stonith-timeout="60s" failed-stop-offset="INFINITY" failed-start-offset="INFINITY"  transition_id="0">
   <synapse id="0">
     <action_set>
-      <pseudo_event id="23" operation="stop" operation_key="messaging-1_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="23" operation="stop" operation_key="messaging-1_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="messaging-1"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
@@ -29,7 +32,7 @@
     </action_set>
     <inputs>
       <trigger>
-        <pseudo_event id="26" operation="stop" operation_key="galera-0_stop_0"/>
+        <pseudo_event id="26" operation="stop" operation_key="galera-0_stop_0" on_node="controller-1" on_node_uuid="2"/>
       </trigger>
       <trigger>
         <crm_event id="129" operation="stonith" operation_key="stonith-messaging-1-reboot" on_node="messaging-1" on_node_uuid="messaging-1"/>
@@ -38,16 +41,22 @@
   </synapse>
   <synapse id="3">
     <action_set>
-      <pseudo_event id="26" operation="stop" operation_key="galera-0_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="26" operation="stop" operation_key="galera-0_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="galera-0"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
   </synapse>
   <synapse id="4">
     <action_set>
-      <pseudo_event id="31" operation="stop" operation_key="galera-2_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="31" operation="stop" operation_key="galera-2_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="galera-2"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/remote-recover-unknown.exp
+++ b/cts/scheduler/exp/remote-recover-unknown.exp
@@ -1,8 +1,11 @@
 <transition_graph cluster-delay="60s" stonith-timeout="60s" failed-stop-offset="INFINITY" failed-start-offset="INFINITY"  transition_id="0">
   <synapse id="0">
     <action_set>
-      <pseudo_event id="24" operation="stop" operation_key="messaging-1_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="24" operation="stop" operation_key="messaging-1_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="messaging-1"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
@@ -29,7 +32,7 @@
     </action_set>
     <inputs>
       <trigger>
-        <pseudo_event id="27" operation="stop" operation_key="galera-0_stop_0"/>
+        <pseudo_event id="27" operation="stop" operation_key="galera-0_stop_0" on_node="controller-1" on_node_uuid="2"/>
       </trigger>
       <trigger>
         <crm_event id="130" operation="stonith" operation_key="stonith-messaging-1-reboot" on_node="messaging-1" on_node_uuid="messaging-1"/>
@@ -41,16 +44,22 @@
   </synapse>
   <synapse id="3">
     <action_set>
-      <pseudo_event id="27" operation="stop" operation_key="galera-0_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="27" operation="stop" operation_key="galera-0_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="galera-0"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
   </synapse>
   <synapse id="4">
     <action_set>
-      <pseudo_event id="32" operation="stop" operation_key="galera-2_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="32" operation="stop" operation_key="galera-2_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="galera-2"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/remote-recover.exp
+++ b/cts/scheduler/exp/remote-recover.exp
@@ -38,7 +38,7 @@
     <action_set>
       <rsc_op id="4" operation="start" operation_key="rhel7-alt4_start_0" on_node="rhel7-alt1" on_node_uuid="1">
         <primitive id="rhel7-alt4" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="rhel7-alt1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="15000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="rhel7-alt1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="15000" />
       </rsc_op>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/remote-recovery.exp
+++ b/cts/scheduler/exp/remote-recovery.exp
@@ -21,14 +21,17 @@
     </action_set>
     <inputs>
       <trigger>
-        <pseudo_event id="24" operation="stop" operation_key="messaging-1_stop_0"/>
+        <pseudo_event id="24" operation="stop" operation_key="messaging-1_stop_0" on_node="controller-1" on_node_uuid="2"/>
       </trigger>
     </inputs>
   </synapse>
   <synapse id="2">
     <action_set>
-      <pseudo_event id="24" operation="stop" operation_key="messaging-1_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="24" operation="stop" operation_key="messaging-1_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="messaging-1"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
@@ -55,14 +58,17 @@
     </action_set>
     <inputs>
       <trigger>
-        <pseudo_event id="29" operation="stop" operation_key="galera-0_stop_0"/>
+        <pseudo_event id="29" operation="stop" operation_key="galera-0_stop_0" on_node="controller-1" on_node_uuid="2"/>
       </trigger>
     </inputs>
   </synapse>
   <synapse id="5">
     <action_set>
-      <pseudo_event id="29" operation="stop" operation_key="galera-0_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="29" operation="stop" operation_key="galera-0_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="galera-0"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
@@ -89,14 +95,17 @@
     </action_set>
     <inputs>
       <trigger>
-        <pseudo_event id="34" operation="stop" operation_key="galera-2_stop_0"/>
+        <pseudo_event id="34" operation="stop" operation_key="galera-2_stop_0" on_node="controller-1" on_node_uuid="2"/>
       </trigger>
     </inputs>
   </synapse>
   <synapse id="8">
     <action_set>
-      <pseudo_event id="34" operation="stop" operation_key="galera-2_stop_0">
-        <attributes CRM_meta_name="stop" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+      <pseudo_event id="34" operation="stop" operation_key="galera-2_stop_0" on_node="controller-1" on_node_uuid="2">
+        <attributes CRM_meta_name="stop" CRM_meta_on_node="controller-1" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000"  reconnect_interval="60"/>
+        <downed>
+          <node id="galera-2"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/remote-start-fail.exp
+++ b/cts/scheduler/exp/remote-start-fail.exp
@@ -16,7 +16,7 @@
     <action_set>
       <rsc_op id="5" operation="start" operation_key="rhel7-auto4_start_0" on_node="rhel7-auto3" on_node_uuid="3">
         <primitive id="rhel7-auto4" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="rhel7-auto3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="rhel7-auto3" CRM_meta_on_node_uuid="3" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/remote-startup-probes.exp
+++ b/cts/scheduler/exp/remote-startup-probes.exp
@@ -16,7 +16,7 @@
     <action_set>
       <rsc_op id="12" operation="start" operation_key="remote1_start_0" on_node="18builder" on_node_uuid="5">
         <primitive id="remote1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_on_node="18builder" CRM_meta_on_node_uuid="5" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_on_node="18builder" CRM_meta_on_node_uuid="5" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/remote-startup.exp
+++ b/cts/scheduler/exp/remote-startup.exp
@@ -113,7 +113,7 @@
     <action_set>
       <rsc_op id="13" operation="start" operation_key="remote1_start_0" on_node="18builder" on_node_uuid="5">
         <primitive id="remote1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_on_node="18builder" CRM_meta_on_node_uuid="5" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_on_node="18builder" CRM_meta_on_node_uuid="5" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/remote-unclean2.exp
+++ b/cts/scheduler/exp/remote-unclean2.exp
@@ -3,7 +3,7 @@
     <action_set>
       <rsc_op id="7" operation="start" operation_key="rhel7-auto4_start_0" on_node="rhel7-auto1" on_node_uuid="1">
         <primitive id="rhel7-auto4" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_name="start" CRM_meta_on_node="rhel7-auto1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="rhel7-auto1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/resource-discovery.exp
+++ b/cts/scheduler/exp/resource-discovery.exp
@@ -87,7 +87,7 @@
     <action_set>
       <rsc_op id="31" operation="start" operation_key="remote1_start_0" on_node="18node1" on_node_uuid="1">
         <primitive id="remote1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_on_node="18node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_on_node="18node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/rsc-discovery-per-node.exp
+++ b/cts/scheduler/exp/rsc-discovery-per-node.exp
@@ -34,7 +34,7 @@
     <action_set>
       <rsc_op id="37" operation="start" operation_key="remote1_start_0" on_node="18builder" on_node_uuid="5">
         <primitive id="remote1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_on_node="18builder" CRM_meta_on_node_uuid="5" CRM_meta_timeout="20000" />
+        <attributes CRM_meta_expire_attrs="true" CRM_meta_on_node="18builder" CRM_meta_on_node_uuid="5" CRM_meta_timeout="20000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/utilization-complex.exp
+++ b/cts/scheduler/exp/utilization-complex.exp
@@ -264,7 +264,7 @@
     <action_set>
       <rsc_op id="43" operation="start" operation_key="httpd-bundle-0_start_0" on_node="rhel8-5" on_node_uuid="5">
         <primitive id="httpd-bundle-0" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="httpd-bundle-podman-0" CRM_meta_on_node="rhel8-5" CRM_meta_on_node_uuid="5" CRM_meta_timeout="90000" addr="192.168.122.131"  port="9999"/>
+        <attributes CRM_meta_container="httpd-bundle-podman-0" CRM_meta_expire_attrs="true" CRM_meta_on_node="rhel8-5" CRM_meta_on_node_uuid="5" CRM_meta_timeout="90000" addr="192.168.122.131"  port="9999"/>
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/whitebox-asymmetric.exp
+++ b/cts/scheduler/exp/whitebox-asymmetric.exp
@@ -100,7 +100,7 @@
     <action_set>
       <rsc_op id="13" operation="start" operation_key="18node2_start_0" on_node="18builder" on_node_uuid="5">
         <primitive id="18node2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container2" CRM_meta_name="start" CRM_meta_on_node="18builder" CRM_meta_on_node_uuid="5" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container2" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="18builder" CRM_meta_on_node_uuid="5" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/whitebox-fail1.exp
+++ b/cts/scheduler/exp/whitebox-fail1.exp
@@ -222,7 +222,7 @@
     <action_set>
       <rsc_op id="44" operation="start" operation_key="lxc1_start_0" on_node="18node2" on_node_uuid="2">
         <primitive id="lxc1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container1" CRM_meta_name="start" CRM_meta_on_node="18node2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container1" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="18node2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/whitebox-fail2.exp
+++ b/cts/scheduler/exp/whitebox-fail2.exp
@@ -222,7 +222,7 @@
     <action_set>
       <rsc_op id="44" operation="start" operation_key="lxc1_start_0" on_node="18node2" on_node_uuid="2">
         <primitive id="lxc1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container1" CRM_meta_name="start" CRM_meta_on_node="18node2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container1" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="18node2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/whitebox-fail3.exp
+++ b/cts/scheduler/exp/whitebox-fail3.exp
@@ -173,7 +173,7 @@
     <action_set>
       <rsc_op id="33" operation="start" operation_key="18builder_start_0" on_node="dvossel-laptop2" on_node_uuid="24815808">
         <primitive id="18builder" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="vm" CRM_meta_name="start" CRM_meta_on_node="dvossel-laptop2" CRM_meta_on_node_uuid="24815808" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="vm" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="dvossel-laptop2" CRM_meta_on_node_uuid="24815808" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/whitebox-imply-stop-on-fence.exp
+++ b/cts/scheduler/exp/whitebox-imply-stop-on-fence.exp
@@ -301,7 +301,7 @@
         <crm_event id="1" operation="stonith" operation_key="stonith-kiff-01-reboot" on_node="kiff-01" on_node_uuid="1"/>
       </trigger>
       <trigger>
-        <pseudo_event id="57" operation="stop" operation_key="lxc-01_kiff-01_stop_0"/>
+        <pseudo_event id="57" operation="stop" operation_key="lxc-01_kiff-01_stop_0" on_node="kiff-01" on_node_uuid="1"/>
       </trigger>
     </inputs>
   </synapse>
@@ -351,7 +351,7 @@
         <crm_event id="1" operation="stonith" operation_key="stonith-kiff-01-reboot" on_node="kiff-01" on_node_uuid="1"/>
       </trigger>
       <trigger>
-        <pseudo_event id="60" operation="stop" operation_key="lxc-02_kiff-01_stop_0"/>
+        <pseudo_event id="60" operation="stop" operation_key="lxc-02_kiff-01_stop_0" on_node="kiff-01" on_node_uuid="1"/>
       </trigger>
     </inputs>
   </synapse>
@@ -463,7 +463,7 @@
         <rsc_op id="45" operation="start" operation_key="R-lxc-01_kiff-01_start_0" on_node="kiff-02" on_node_uuid="2"/>
       </trigger>
       <trigger>
-        <pseudo_event id="57" operation="stop" operation_key="lxc-01_kiff-01_stop_0"/>
+        <pseudo_event id="57" operation="stop" operation_key="lxc-01_kiff-01_stop_0" on_node="kiff-01" on_node_uuid="1"/>
       </trigger>
       <trigger>
         <pseudo_event id="67" operation="stonith" operation_key="stonith-lxc-01_kiff-01-reboot" on_node="lxc-01_kiff-01" on_node_uuid="lxc-01_kiff-01"/>
@@ -475,8 +475,11 @@
   </synapse>
   <synapse id="31">
     <action_set>
-      <pseudo_event id="57" operation="stop" operation_key="lxc-01_kiff-01_stop_0">
-        <attributes CRM_meta_container="R-lxc-01_kiff-01" CRM_meta_timeout="20000" />
+      <pseudo_event id="57" operation="stop" operation_key="lxc-01_kiff-01_stop_0" on_node="kiff-01" on_node_uuid="1">
+        <attributes CRM_meta_container="R-lxc-01_kiff-01" CRM_meta_on_node="kiff-01" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" />
+        <downed>
+          <node id="lxc-01_kiff-01"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>
@@ -506,7 +509,7 @@
         <rsc_op id="48" operation="start" operation_key="R-lxc-02_kiff-01_start_0" on_node="kiff-02" on_node_uuid="2"/>
       </trigger>
       <trigger>
-        <pseudo_event id="60" operation="stop" operation_key="lxc-02_kiff-01_stop_0"/>
+        <pseudo_event id="60" operation="stop" operation_key="lxc-02_kiff-01_stop_0" on_node="kiff-01" on_node_uuid="1"/>
       </trigger>
       <trigger>
         <pseudo_event id="67" operation="stonith" operation_key="stonith-lxc-01_kiff-01-reboot" on_node="lxc-01_kiff-01" on_node_uuid="lxc-01_kiff-01"/>
@@ -518,8 +521,11 @@
   </synapse>
   <synapse id="34">
     <action_set>
-      <pseudo_event id="60" operation="stop" operation_key="lxc-02_kiff-01_stop_0">
-        <attributes CRM_meta_container="R-lxc-02_kiff-01" CRM_meta_timeout="20000" />
+      <pseudo_event id="60" operation="stop" operation_key="lxc-02_kiff-01_stop_0" on_node="kiff-01" on_node_uuid="1">
+        <attributes CRM_meta_container="R-lxc-02_kiff-01" CRM_meta_on_node="kiff-01" CRM_meta_on_node_uuid="1" CRM_meta_timeout="20000" />
+        <downed>
+          <node id="lxc-02_kiff-01"/>
+        </downed>
       </pseudo_event>
     </action_set>
     <inputs/>

--- a/cts/scheduler/exp/whitebox-imply-stop-on-fence.exp
+++ b/cts/scheduler/exp/whitebox-imply-stop-on-fence.exp
@@ -455,7 +455,7 @@
     <action_set>
       <rsc_op id="58" operation="start" operation_key="lxc-01_kiff-01_start_0" on_node="kiff-02" on_node_uuid="2">
         <primitive id="lxc-01_kiff-01" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="R-lxc-01_kiff-01" CRM_meta_name="start" CRM_meta_on_node="kiff-02" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="R-lxc-01_kiff-01" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="kiff-02" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -498,7 +498,7 @@
     <action_set>
       <rsc_op id="61" operation="start" operation_key="lxc-02_kiff-01_start_0" on_node="kiff-02" on_node_uuid="2">
         <primitive id="lxc-02_kiff-01" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="R-lxc-02_kiff-01" CRM_meta_name="start" CRM_meta_on_node="kiff-02" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="R-lxc-02_kiff-01" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="kiff-02" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/whitebox-migrate1.exp
+++ b/cts/scheduler/exp/whitebox-migrate1.exp
@@ -184,7 +184,7 @@
   <synapse id="14">
     <action_set>
       <pseudo_event id="36" operation="start" operation_key="rhel7-node1_start_0">
-        <attributes CRM_meta_container="remote-rsc" CRM_meta_name="start" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="remote-rsc" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_timeout="60000" />
       </pseudo_event>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/whitebox-move.exp
+++ b/cts/scheduler/exp/whitebox-move.exp
@@ -199,7 +199,7 @@
     <action_set>
       <rsc_op id="33" operation="start" operation_key="lxc1_start_0" on_node="18node2" on_node_uuid="2">
         <primitive id="lxc1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container1" CRM_meta_name="start" CRM_meta_on_node="18node2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container1" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="18node2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/whitebox-ms-ordering-move.exp
+++ b/cts/scheduler/exp/whitebox-ms-ordering-move.exp
@@ -336,7 +336,7 @@
     <action_set>
       <rsc_op id="128" operation="start" operation_key="lxc1_start_0" on_node="rhel7-2" on_node_uuid="2">
         <primitive id="lxc1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container1" CRM_meta_name="start" CRM_meta_on_node="rhel7-2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container1" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="rhel7-2" CRM_meta_on_node_uuid="2" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/whitebox-ms-ordering.exp
+++ b/cts/scheduler/exp/whitebox-ms-ordering.exp
@@ -438,7 +438,7 @@
     <action_set>
       <rsc_op id="36" operation="start" operation_key="lxc1_start_0" on_node="18node1" on_node_uuid="1">
         <primitive id="lxc1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container1" CRM_meta_name="start" CRM_meta_on_node="18node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container1" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="18node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -506,7 +506,7 @@
     <action_set>
       <rsc_op id="38" operation="start" operation_key="lxc2_start_0" on_node="18node1" on_node_uuid="1">
         <primitive id="lxc2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container2" CRM_meta_name="start" CRM_meta_on_node="18node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container2" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="18node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/whitebox-nested-group.exp
+++ b/cts/scheduler/exp/whitebox-nested-group.exp
@@ -628,7 +628,7 @@
     <action_set>
       <rsc_op id="58" operation="start" operation_key="c7auto4_start_0" on_node="c7auto1" on_node_uuid="1">
         <primitive id="c7auto4" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container" CRM_meta_name="start" CRM_meta_on_node="c7auto1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="c7auto1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/whitebox-start.exp
+++ b/cts/scheduler/exp/whitebox-start.exp
@@ -187,7 +187,7 @@
     <action_set>
       <rsc_op id="41" operation="start" operation_key="lxc1_start_0" on_node="18node1" on_node_uuid="1">
         <primitive id="lxc1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="container1" CRM_meta_name="start" CRM_meta_on_node="18node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="container1" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="18node1" CRM_meta_on_node_uuid="1" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/exp/whitebox-unexpectedly-running.exp
+++ b/cts/scheduler/exp/whitebox-unexpectedly-running.exp
@@ -60,7 +60,7 @@
     <action_set>
       <rsc_op id="9" operation="start" operation_key="remote1_start_0" on_node="18builder" on_node_uuid="5">
         <primitive id="remote1" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="FAKE" CRM_meta_name="start" CRM_meta_on_node="18builder" CRM_meta_on_node_uuid="5" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="FAKE" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="18builder" CRM_meta_on_node_uuid="5" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>
@@ -98,7 +98,7 @@
     <action_set>
       <rsc_op id="11" operation="start" operation_key="remote2_start_0" on_node="18builder" on_node_uuid="5">
         <primitive id="remote2" class="ocf" provider="pacemaker" type="remote"/>
-        <attributes CRM_meta_container="FAKE-crashed" CRM_meta_name="start" CRM_meta_on_node="18builder" CRM_meta_on_node_uuid="5" CRM_meta_timeout="60000" />
+        <attributes CRM_meta_container="FAKE-crashed" CRM_meta_expire_attrs="true" CRM_meta_name="start" CRM_meta_on_node="18builder" CRM_meta_on_node_uuid="5" CRM_meta_timeout="60000" />
       </rsc_op>
     </action_set>
     <inputs>

--- a/cts/scheduler/summary/bundle-order-fencing.summary
+++ b/cts/scheduler/summary/bundle-order-fencing.summary
@@ -57,12 +57,12 @@ Transition Summary:
 
 Executing Cluster Transition:
   * Pseudo action:   rabbitmq-bundle-clone_pre_notify_stop_0
-  * Pseudo action:   rabbitmq-bundle-0_stop_0
+  * Pseudo action:   rabbitmq-bundle-0_stop_0 on controller-0
   * Resource action: rabbitmq-bundle-0 monitor on controller-2
   * Resource action: rabbitmq-bundle-0 monitor on controller-1
   * Resource action: rabbitmq-bundle-1 monitor on controller-2
   * Resource action: rabbitmq-bundle-2 monitor on controller-1
-  * Pseudo action:   galera-bundle-0_stop_0
+  * Pseudo action:   galera-bundle-0_stop_0 on controller-0
   * Resource action: galera-bundle-0 monitor on controller-2
   * Resource action: galera-bundle-0 monitor on controller-1
   * Resource action: galera-bundle-1 monitor on controller-2
@@ -70,7 +70,7 @@ Executing Cluster Transition:
   * Resource action: redis           cancel=45000 on redis-bundle-1
   * Resource action: redis           cancel=60000 on redis-bundle-1
   * Pseudo action:   redis-bundle-master_pre_notify_demote_0
-  * Pseudo action:   redis-bundle-0_stop_0
+  * Pseudo action:   redis-bundle-0_stop_0 on controller-0
   * Resource action: redis-bundle-0  monitor on controller-2
   * Resource action: redis-bundle-0  monitor on controller-1
   * Resource action: redis-bundle-1  monitor on controller-2

--- a/cts/scheduler/summary/guest-node-host-dies.summary
+++ b/cts/scheduler/summary/guest-node-host-dies.summary
@@ -27,11 +27,11 @@ Transition Summary:
 Executing Cluster Transition:
   * Resource action: Fencing         stop on rhel7-4
   * Pseudo action:   lxc-ms-master_demote_0
-  * Pseudo action:   lxc1_stop_0
+  * Pseudo action:   lxc1_stop_0 on rhel7-1
   * Resource action: lxc1            monitor on rhel7-5
   * Resource action: lxc1            monitor on rhel7-4
   * Resource action: lxc1            monitor on rhel7-3
-  * Pseudo action:   lxc2_stop_0
+  * Pseudo action:   lxc2_stop_0 on rhel7-1
   * Resource action: lxc2            monitor on rhel7-5
   * Resource action: lxc2            monitor on rhel7-4
   * Resource action: lxc2            monitor on rhel7-2

--- a/cts/scheduler/summary/on_fail_demote4.summary
+++ b/cts/scheduler/summary/on_fail_demote4.summary
@@ -62,7 +62,7 @@ Executing Cluster Transition:
   * Pseudo action:   rsc2-master_demote_0
   * Pseudo action:   lxc-ms-master_demote_0
   * Resource action: stateful-bundle-0 stop on rhel7-5
-  * Pseudo action:   stateful-bundle-2_stop_0
+  * Pseudo action:   stateful-bundle-2_stop_0 on rhel7-4
   * Resource action: lxc2            stop on rhel7-3
   * Pseudo action:   stateful-bundle_demote_0
   * Fencing remote-rhel7-2 (reboot)

--- a/cts/scheduler/summary/primitive-with-group-with-promoted.summary
+++ b/cts/scheduler/summary/primitive-with-group-with-promoted.summary
@@ -13,11 +13,11 @@ Current cluster status:
 
 Transition Summary:
   * Promote    rsc2:0         ( Stopped -> Promoted node5 )
-  * Start      rsc2:1         (                   node2 )
-  * Start      rsc2:2         (                   node3 )
-  * Start      rsc1           (                   node5 )
-  * Start      group1rsc1     (                   node5 )
-  * Start      group1rsc2     (                   node5 )
+  * Start      rsc2:1         (                     node2 )
+  * Start      rsc2:2         (                     node3 )
+  * Start      rsc1           (                     node5 )
+  * Start      group1rsc1     (                     node5 )
+  * Start      group1rsc2     (                     node5 )
 
 Executing Cluster Transition:
   * Resource action: rsc2:0          monitor on node5

--- a/cts/scheduler/summary/priority-fencing-delay.summary
+++ b/cts/scheduler/summary/priority-fencing-delay.summary
@@ -49,8 +49,8 @@ Executing Cluster Transition:
   * Resource action: clvmd           monitor on lxc-01_kiff-02
   * Resource action: shared0         monitor on lxc-02_kiff-02
   * Resource action: shared0         monitor on lxc-01_kiff-02
-  * Pseudo action:   lxc-01_kiff-01_stop_0
-  * Pseudo action:   lxc-02_kiff-01_stop_0
+  * Pseudo action:   lxc-01_kiff-01_stop_0 on kiff-01
+  * Pseudo action:   lxc-02_kiff-01_stop_0 on kiff-01
   * Fencing kiff-01 (reboot)
   * Pseudo action:   R-lxc-01_kiff-01_stop_0
   * Pseudo action:   R-lxc-02_kiff-01_stop_0

--- a/cts/scheduler/summary/promoted-partially-demoted-group.summary
+++ b/cts/scheduler/summary/promoted-partially-demoted-group.summary
@@ -25,8 +25,8 @@ Current cluster status:
 Transition Summary:
   * Move       vip-164                      (              sd01-1 -> sd01-0 )
   * Move       vip-165                      (              sd01-1 -> sd01-0 )
-  * Move       cdev-pool-0-iscsi-target     (       sd01-1 -> sd01-0 )
-  * Move       cdev-pool-0-iscsi-lun-1      (       sd01-1 -> sd01-0 )
+  * Move       cdev-pool-0-iscsi-target     (              sd01-1 -> sd01-0 )
+  * Move       cdev-pool-0-iscsi-lun-1      (              sd01-1 -> sd01-0 )
   * Demote     vip-164-fw:0                 ( Promoted -> Unpromoted sd01-1 )
   * Promote    vip-164-fw:1                 ( Unpromoted -> Promoted sd01-0 )
   * Promote    vip-165-fw:1                 ( Unpromoted -> Promoted sd01-0 )

--- a/cts/scheduler/summary/remote-connection-unrecoverable.summary
+++ b/cts/scheduler/summary/remote-connection-unrecoverable.summary
@@ -22,7 +22,7 @@ Transition Summary:
   * Stop       rsc2:0      (   Promoted node1 )  due to node availability
 
 Executing Cluster Transition:
-  * Pseudo action:   remote1_stop_0
+  * Pseudo action:   remote1_stop_0 on node1
   * Resource action: killer          stop on node2
   * Resource action: rsc1            monitor on node2
   * Fencing node1 (reboot)

--- a/cts/scheduler/summary/remote-recover-all.summary
+++ b/cts/scheduler/summary/remote-recover-all.summary
@@ -55,9 +55,9 @@ Transition Summary:
   * Move       stonith-fence_ipmilan-5254005bdbb5     ( controller-1 -> controller-2 )
 
 Executing Cluster Transition:
-  * Pseudo action:   messaging-1_stop_0
-  * Pseudo action:   galera-0_stop_0
-  * Pseudo action:   galera-2_stop_0
+  * Pseudo action:   messaging-1_stop_0 on controller-1
+  * Pseudo action:   galera-0_stop_0 on controller-1
+  * Pseudo action:   galera-2_stop_0 on controller-1
   * Pseudo action:   rabbitmq-clone_pre_notify_stop_0
   * Pseudo action:   galera-master_demote_0
   * Pseudo action:   redis-master_pre_notify_stop_0

--- a/cts/scheduler/summary/remote-recover-connection.summary
+++ b/cts/scheduler/summary/remote-recover-connection.summary
@@ -51,9 +51,9 @@ Transition Summary:
   * Move       stonith-fence_ipmilan-5254005bdbb5     ( controller-1 -> controller-2 )
 
 Executing Cluster Transition:
-  * Pseudo action:   messaging-1_stop_0
-  * Pseudo action:   galera-0_stop_0
-  * Pseudo action:   galera-2_stop_0
+  * Pseudo action:   messaging-1_stop_0 on controller-1
+  * Pseudo action:   galera-0_stop_0 on controller-1
+  * Pseudo action:   galera-2_stop_0 on controller-1
   * Pseudo action:   redis-master_pre_notify_stop_0
   * Pseudo action:   stonith-fence_ipmilan-5254005bdbb5_stop_0
   * Fencing controller-1 (reboot)

--- a/cts/scheduler/summary/remote-recover-no-resources.summary
+++ b/cts/scheduler/summary/remote-recover-no-resources.summary
@@ -53,9 +53,9 @@ Transition Summary:
   * Move       stonith-fence_ipmilan-5254005bdbb5     ( controller-1 -> controller-2 )
 
 Executing Cluster Transition:
-  * Pseudo action:   messaging-1_stop_0
-  * Pseudo action:   galera-0_stop_0
-  * Pseudo action:   galera-2_stop_0
+  * Pseudo action:   messaging-1_stop_0 on controller-1
+  * Pseudo action:   galera-0_stop_0 on controller-1
+  * Pseudo action:   galera-2_stop_0 on controller-1
   * Pseudo action:   rabbitmq-clone_pre_notify_stop_0
   * Pseudo action:   redis-master_pre_notify_stop_0
   * Pseudo action:   stonith-fence_ipmilan-5254005bdbb5_stop_0

--- a/cts/scheduler/summary/remote-recover-unknown.summary
+++ b/cts/scheduler/summary/remote-recover-unknown.summary
@@ -54,9 +54,9 @@ Transition Summary:
   * Move       stonith-fence_ipmilan-5254005bdbb5     ( controller-1 -> controller-2 )
 
 Executing Cluster Transition:
-  * Pseudo action:   messaging-1_stop_0
-  * Pseudo action:   galera-0_stop_0
-  * Pseudo action:   galera-2_stop_0
+  * Pseudo action:   messaging-1_stop_0 on controller-1
+  * Pseudo action:   galera-0_stop_0 on controller-1
+  * Pseudo action:   galera-2_stop_0 on controller-1
   * Pseudo action:   rabbitmq-clone_pre_notify_stop_0
   * Pseudo action:   redis-master_pre_notify_stop_0
   * Pseudo action:   stonith-fence_ipmilan-5254005bdbb5_stop_0

--- a/cts/scheduler/summary/remote-recovery.summary
+++ b/cts/scheduler/summary/remote-recovery.summary
@@ -51,9 +51,9 @@ Transition Summary:
   * Move       stonith-fence_ipmilan-5254005bdbb5     ( controller-1 -> controller-2 )
 
 Executing Cluster Transition:
-  * Pseudo action:   messaging-1_stop_0
-  * Pseudo action:   galera-0_stop_0
-  * Pseudo action:   galera-2_stop_0
+  * Pseudo action:   messaging-1_stop_0 on controller-1
+  * Pseudo action:   galera-0_stop_0 on controller-1
+  * Pseudo action:   galera-2_stop_0 on controller-1
   * Pseudo action:   redis-master_pre_notify_stop_0
   * Pseudo action:   stonith-fence_ipmilan-5254005bdbb5_stop_0
   * Fencing controller-1 (reboot)

--- a/cts/scheduler/summary/whitebox-imply-stop-on-fence.summary
+++ b/cts/scheduler/summary/whitebox-imply-stop-on-fence.summary
@@ -49,8 +49,8 @@ Executing Cluster Transition:
   * Resource action: shared0         monitor on lxc-01_kiff-02
   * Resource action: vm-fs           monitor on lxc-02_kiff-02
   * Resource action: vm-fs           monitor on lxc-01_kiff-02
-  * Pseudo action:   lxc-01_kiff-01_stop_0
-  * Pseudo action:   lxc-02_kiff-01_stop_0
+  * Pseudo action:   lxc-01_kiff-01_stop_0 on kiff-01
+  * Pseudo action:   lxc-02_kiff-01_stop_0 on kiff-01
   * Fencing kiff-01 (reboot)
   * Pseudo action:   R-lxc-01_kiff-01_stop_0
   * Pseudo action:   R-lxc-02_kiff-01_stop_0

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -196,6 +196,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
             }
 
             if (!appeared) {
+                node->peer_lost = time(NULL);
                 controld_remove_failed_sync_node(node->uname);
                 controld_remove_voter(node->uname);
             }

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1648,6 +1648,18 @@ construct_op(const lrm_state_t *lrm_state, const xmlNode *rsc_op,
         op->interval_ms = 0;
     }
 
+    /* If this is a start action with the special expire_attrs meta-attribute
+     * set to false (or missing entirely), go ahead and clear the purge bit from
+     * the connection resource's flags.
+     */
+    if (!crm_is_true(crm_meta_value(params, PCMK_META_EXPIRE_ATTRS))) {
+        lrm_state_t *connection_rsc = lrm_state_find(rsc_id);
+
+        if (connection_rsc && connection_rsc->remote_ra_data) {
+            remote_ra_clear_purge_attrs(connection_rsc);
+        }
+    }
+
     /* Use pcmk_monitor_timeout instead of meta timeout for stonith
        recurring monitor, if set */
     primitive = find_xml_node(rsc_op, XML_CIB_TAG_RESOURCE, FALSE);

--- a/daemons/controld/controld_lrm.h
+++ b/daemons/controld/controld_lrm.h
@@ -176,6 +176,8 @@ void remote_ra_process_pseudo(xmlNode *xml);
 gboolean remote_ra_is_in_maintenance(lrm_state_t * lrm_state);
 void remote_ra_process_maintenance_nodes(xmlNode *xml);
 gboolean remote_ra_controlling_guest(lrm_state_t * lrm_state);
+bool remote_ra_purge_attrs(lrm_state_t *lrm_state);
+void remote_ra_clear_purge_attrs(lrm_state_t *lrm_state);
 
 void process_lrm_event(lrm_state_t *lrm_state, lrmd_event_data_t *op,
                        active_op_t *pending, const xmlNode *action_xml);

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -101,6 +101,7 @@ enum remote_status {
      * the attributes aren't at hand.
      */
     controlling_guest   = (1 << 4),
+    purge_attrs         = (1 << 5),
 };
 
 typedef struct remote_ra_data_s {
@@ -906,6 +907,7 @@ remote_ra_data_init(lrm_state_t * lrm_state)
     ra_data = calloc(1, sizeof(remote_ra_data_t));
     ra_data->work = mainloop_add_trigger(G_PRIORITY_HIGH, handle_remote_ra_exec, lrm_state);
     lrm_state->remote_ra_data = ra_data;
+    lrm_remote_set_flags(lrm_state, purge_attrs);
 }
 
 void
@@ -1372,4 +1374,17 @@ remote_ra_controlling_guest(lrm_state_t * lrm_state)
 {
     remote_ra_data_t *ra_data = lrm_state->remote_ra_data;
     return pcmk_is_set(ra_data->status, controlling_guest);
+}
+
+bool
+remote_ra_purge_attrs(lrm_state_t *lrm_state)
+{
+    remote_ra_data_t *ra_data = lrm_state->remote_ra_data;
+    return pcmk_is_set(ra_data->status, purge_attrs);
+}
+
+void
+remote_ra_clear_purge_attrs(lrm_state_t *lrm_state)
+{
+    lrm_remote_clear_flags(lrm_state, purge_attrs);
 }

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the Pacemaker project contributors
+ * Copyright 2012-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1472,6 +1472,7 @@ process_lrmd_signon(pcmk__client_t *client, xmlNode *request, int call_id,
                     xmlNode **reply)
 {
     int rc = pcmk_ok;
+    time_t now = time(NULL);
     const char *protocol_version = crm_element_value(request, F_LRMD_PROTOCOL_VERSION);
 
     if (compare_version(protocol_version, LRMD_MIN_PROTOCOL_VERSION) < 0) {
@@ -1500,6 +1501,7 @@ process_lrmd_signon(pcmk__client_t *client, xmlNode *request, int call_id,
     crm_xml_add(*reply, F_LRMD_OPERATION, CRM_OP_REGISTER);
     crm_xml_add(*reply, F_LRMD_CLIENTID, client->id);
     crm_xml_add(*reply, F_LRMD_PROTOCOL_VERSION, LRMD_PROTOCOL_VERSION);
+    crm_xml_add_ll(*reply, PCMK__XA_UPTIME, now - start_time);
 
     return rc;
 }

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -40,6 +40,7 @@ static GMainLoop *mainloop = NULL;
 static qb_ipcs_service_t *ipcs = NULL;
 static stonith_t *stonith_api = NULL;
 int lrmd_call_id = 0;
+time_t start_time;
 
 static struct {
     gchar **log_files;
@@ -514,6 +515,8 @@ main(int argc, char **argv, char **envp)
         setenv("PCMK_remote_port", options.port, 1);
     }
 #endif  // PCMK__COMPILE_REMOTE
+
+    start_time = time(NULL);
 
     crm_notice("Starting Pacemaker " EXECD_TYPE " executor");
 

--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -20,6 +20,7 @@
 #  endif
 
 extern GHashTable *rsc_list;
+extern time_t start_time;
 
 typedef struct lrmd_rsc_s {
     char *rsc_id;

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -75,6 +75,7 @@ typedef struct crm_peer_node_s {
     // Only used by controller
     enum crm_join_phase join;
     char *expected;
+    time_t peer_lost;
 } crm_node_t;
 
 void crm_peer_init(void);

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the Pacemaker project contributors
+ * Copyright 2013-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -111,6 +111,7 @@ struct pcmk__remote_s {
     int auth_timeout;
     int tcp_socket;
     mainloop_io_t *source;
+    time_t uptime;
 
     /* CIB-only */
     char *token;

--- a/include/crm/lrmd_internal.h
+++ b/include/crm/lrmd_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the Pacemaker project contributors
+ * Copyright 2015-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -45,6 +45,8 @@ void lrmd__set_result(lrmd_event_data_t *event, enum ocf_exitcode rc,
                       int op_status, const char *exit_reason);
 
 void lrmd__reset_result(lrmd_event_data_t *event);
+
+time_t lrmd__uptime(lrmd_t *lrmd);
 
 /* Shared functions for IPC proxy back end */
 

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -60,6 +60,7 @@ extern "C" {
  */
 
 #define PCMK_META_ENABLED                   "enabled"
+#define PCMK_META_EXPIRE_ATTRS              "expire_attrs"
 
 
 /*

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the Pacemaker project contributors
+ * Copyright 2006-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -85,6 +85,7 @@
 #define PCMK__XA_GRAPH_WARNINGS         "graph-warnings"
 #define PCMK__XA_MODE                   "mode"
 #define PCMK__XA_TASK                   "task"
+#define PCMK__XA_UPTIME                 "uptime"
 
 
 /*

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the Pacemaker project contributors
+ * Copyright 2012-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -980,8 +980,17 @@ lrmd_handshake(lrmd_t * lrmd, const char *name)
         const char *version = crm_element_value(reply, F_LRMD_PROTOCOL_VERSION);
         const char *msg_type = crm_element_value(reply, F_LRMD_OPERATION);
         const char *tmp_ticket = crm_element_value(reply, F_LRMD_CLIENTID);
+        long long uptime = -1;
 
         crm_element_value_int(reply, F_LRMD_RC, &rc);
+
+        /* The remote executor may add its uptime to the XML reply, which is
+         * useful in handling transient attributes when the connection to the
+         * remote node unexpectedly drops.  If no parameter is given, just
+         * default to -1.
+         */
+        crm_element_value_ll(reply, PCMK__XA_UPTIME, &uptime);
+        native->remote->uptime = uptime;
 
         if (rc == -EPROTO) {
             crm_err("Executor protocol version mismatch between client (%s) and server (%s)",

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -2509,3 +2509,25 @@ lrmd__reset_result(lrmd_event_data_t *event)
     free((void *) event->output);
     event->output = NULL;
 }
+
+/*!
+ * \internal
+ * \brief Get the uptime of a remote resource connection
+ *
+ * When the cluster connects to a remote resource, part of that resource's
+ * handshake includes the uptime of the remote resource's connection.  This
+ * uptime is stored in the lrmd_t object.
+ *
+ * \return The connection's uptime, or -1 if unknown
+ */
+time_t
+lrmd__uptime(lrmd_t *lrmd)
+{
+    lrmd_private_t *native = lrmd->lrmd_private;
+
+    if (native->remote == NULL) {
+        return -1;
+    } else {
+        return native->remote->uptime;
+    }
+}

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -420,7 +420,13 @@ create_graph_action(xmlNode *parent, pe_action_t *action, bool skip_details,
             needs_maintenance_info = true;
         }
         action_xml = create_xml_node(parent, XML_GRAPH_TAG_PSEUDO_EVENT);
-        needs_node_info = false;
+
+        if (action->rsc && action->rsc->is_remote_node &&
+            pcmk__str_eq(action->task, RSC_STOP, pcmk__str_none)) {
+            needs_node_info = true;
+        } else {
+            needs_node_info = false;
+        }
 
     } else {
         action_xml = create_xml_node(parent, XML_GRAPH_TAG_RSC_OP);


### PR DESCRIPTION
I'm not sure this is done, but I might as well open it up to everyone else.  Things I'm not sure about:

* [ ] I might be confusing resource name and node name in a couple places.  See uses of `op->remote_nodename`.
* [ ] Very little of this involves the scheduler, and for the most part it's once again all async IPC stuff, so I'm not sure I can add any automated testing.  Some of the CTS sheduler tests do end up with CRM_meta_expire_attrs="true" added to them, so that's something.
* [ ] Speaking of testing, I've been able to verify that attributes get preserved by simply bringing down the network connection on the node running the remote connection resource, then watching that node get fenced and the resource restarted elsewhere.  Testing any of the cases where attributes should still be wiped is being more difficult.