### PR TITLE
Various cleanups and fixes: mostly libcib, based, and controller

### DIFF
--- a/cts/cli/regression.daemons.exp
+++ b/cts/cli/regression.daemons.exp
@@ -117,6 +117,11 @@
       <shortdesc lang="en">Whether to lock resources to a cleanly shut down node</shortdesc>
       <content type="boolean" default=""/>
     </parameter>
+    <parameter name="shutdown-lock-limit">
+      <longdesc lang="en">If shutdown-lock is true and this is set to a nonzero time duration, shutdown locks will expire after this much time has passed since the shutdown was initiated, even if the node has not rejoined.</longdesc>
+      <shortdesc lang="en">Do not lock resources to a cleanly shut down node longer than this</shortdesc>
+      <content type="time" default=""/>
+    </parameter>
   </parameters>
 </resource-agent>
 =#=#=#= End test: Get controller metadata - OK (0) =#=#=#=

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the Pacemaker project contributors
+ * Copyright 2013-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -209,7 +209,7 @@ attrd_write_attribute(attribute_t *a, bool ignore_delay)
     xmlNode *xml_top = NULL;
     attribute_value_t *v = NULL;
     GHashTableIter iter;
-    enum cib_call_options flags = cib_quorum_override;
+    enum cib_call_options flags = cib_none;
     GHashTable *alert_attribute_value = NULL;
 
     if (a == NULL) {

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -118,8 +118,7 @@ attrd_erase_attrs(void)
     crm_info("Clearing transient attributes from CIB " CRM_XS " xpath=%s",
              xpath);
 
-    call_id = the_cib->cmds->remove(the_cib, xpath, NULL,
-                                    cib_quorum_override | cib_xpath);
+    call_id = the_cib->cmds->remove(the_cib, xpath, NULL, cib_xpath);
     the_cib->cmds->register_callback_full(the_cib, call_id, 120, FALSE, xpath,
                                           "attrd_erase_cb", attrd_erase_cb,
                                           free);

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1219,7 +1219,6 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     int rc2 = pcmk_ok;
 
     gboolean send_r_notify = FALSE;
-    gboolean global_update = FALSE;
     gboolean config_changed = FALSE;
     gboolean manage_counters = TRUE;
 
@@ -1248,7 +1247,7 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     rc = cib_get_operation_id(op, &call_type);
 
     if (rc == pcmk_ok && privileged == FALSE) {
-        rc = cib_op_can_run(call_type, call_options, privileged, global_update);
+        rc = cib_op_can_run(call_type, call_options, privileged);
     }
 
     rc2 = cib_op_prepare(call_type, request, &input, &section);

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1214,6 +1214,9 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     const char *op = NULL;
     const char *section = NULL;
     const char *call_id = crm_element_value(request, F_CIB_CALLID);
+    const char *client_id = crm_element_value(request, F_CIB_CLIENTID);
+    const char *client_name = crm_element_value(request, F_CIB_CLIENTNAME);
+    const char *origin = crm_element_value(request, F_ORIG);
 
     int rc = pcmk_ok;
     int rc2 = pcmk_ok;
@@ -1435,17 +1438,15 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     }
 
     if ((call_options & (cib_inhibit_notify|cib_dryrun)) == 0) {
-        const char *client = crm_element_value(request, F_CIB_CLIENTNAME);
-
         crm_trace("Sending notifications %d",
                   pcmk_is_set(call_options, cib_dryrun));
-        cib_diff_notify(call_options, client, call_id, op, input, rc, *cib_diff);
+        cib_diff_notify(op, rc, call_id, client_id, client_name, origin, input,
+                        *cib_diff);
     }
 
     if (send_r_notify) {
-        const char *origin = crm_element_value(request, F_ORIG);
-
-        cib_replace_notify(origin, the_cib, rc, *cib_diff, change_section);
+        cib_replace_notify(op, rc, call_id, client_id, client_name, origin,
+                           the_cib, *cib_diff, change_section);
     }
 
     pcmk__output_set_log_level(logger_out, LOG_TRACE);

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -140,85 +140,85 @@ cib_cleanup_none(int options, xmlNode ** data, xmlNode ** output)
 }
 
 static cib_operation_t cib_server_ops[] = {
-    // Booleans are modifies_cib, needs_privileges, needs_quorum
+    // Booleans are modifies_cib, needs_privileges
     {
-        NULL, FALSE, FALSE, FALSE,
+        NULL, FALSE, FALSE,
         cib_prepare_none, cib_cleanup_none, cib_process_default
     },
     {
-        PCMK__CIB_REQUEST_QUERY, FALSE, FALSE, FALSE,
+        PCMK__CIB_REQUEST_QUERY, FALSE, FALSE,
         cib_prepare_none, cib_cleanup_query, cib_process_query
     },
     {
-        PCMK__CIB_REQUEST_MODIFY, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_MODIFY, TRUE, TRUE,
         cib_prepare_data, cib_cleanup_data, cib_process_modify
     },
     {
-        PCMK__CIB_REQUEST_APPLY_PATCH, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_APPLY_PATCH, TRUE, TRUE,
         cib_prepare_diff, cib_cleanup_data, cib_server_process_diff
     },
     {
-        PCMK__CIB_REQUEST_REPLACE, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_REPLACE, TRUE, TRUE,
         cib_prepare_data, cib_cleanup_data, cib_process_replace_svr
     },
     {
-        PCMK__CIB_REQUEST_CREATE, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_CREATE, TRUE, TRUE,
         cib_prepare_data, cib_cleanup_data, cib_process_create
     },
     {
-        PCMK__CIB_REQUEST_DELETE, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_DELETE, TRUE, TRUE,
         cib_prepare_data, cib_cleanup_data, cib_process_delete
     },
     {
-        PCMK__CIB_REQUEST_SYNC_TO_ALL, FALSE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_SYNC_TO_ALL, FALSE, TRUE,
         cib_prepare_sync, cib_cleanup_none, cib_process_sync
     },
     {
-        PCMK__CIB_REQUEST_BUMP, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_BUMP, TRUE, TRUE,
         cib_prepare_none, cib_cleanup_output, cib_process_bump
     },
     {
-        PCMK__CIB_REQUEST_ERASE, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_ERASE, TRUE, TRUE,
         cib_prepare_none, cib_cleanup_output, cib_process_erase
     },
     {
-        PCMK__CIB_REQUEST_NOOP, FALSE, FALSE, FALSE,
+        PCMK__CIB_REQUEST_NOOP, FALSE, FALSE,
         cib_prepare_none, cib_cleanup_none, cib_process_default
     },
     {
-        PCMK__CIB_REQUEST_ABS_DELETE, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_ABS_DELETE, TRUE, TRUE,
         cib_prepare_data, cib_cleanup_data, cib_process_delete_absolute
     },
     {
-        PCMK__CIB_REQUEST_UPGRADE, TRUE, TRUE, TRUE,
+        PCMK__CIB_REQUEST_UPGRADE, TRUE, TRUE,
         cib_prepare_none, cib_cleanup_output, cib_process_upgrade_server
     },
     {
-        PCMK__CIB_REQUEST_SECONDARY, FALSE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_SECONDARY, FALSE, TRUE,
         cib_prepare_none, cib_cleanup_none, cib_process_readwrite
     },
     {
-        PCMK__CIB_REQUEST_ALL_SECONDARY, FALSE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_ALL_SECONDARY, FALSE, TRUE,
         cib_prepare_none, cib_cleanup_none, cib_process_readwrite
     },
     {
-        PCMK__CIB_REQUEST_SYNC_TO_ONE, FALSE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_SYNC_TO_ONE, FALSE, TRUE,
         cib_prepare_sync, cib_cleanup_none, cib_process_sync_one
     },
     {
-        PCMK__CIB_REQUEST_PRIMARY, TRUE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_PRIMARY, TRUE, TRUE,
         cib_prepare_data, cib_cleanup_data, cib_process_readwrite
     },
     {
-        PCMK__CIB_REQUEST_IS_PRIMARY, FALSE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_IS_PRIMARY, FALSE, TRUE,
         cib_prepare_none, cib_cleanup_none, cib_process_readwrite
     },
     {
-        PCMK__CIB_REQUEST_SHUTDOWN, FALSE, TRUE, FALSE,
+        PCMK__CIB_REQUEST_SHUTDOWN, FALSE, TRUE,
         cib_prepare_sync, cib_cleanup_none, cib_process_shutdown_req
     },
     {
-        CRM_OP_PING, FALSE, FALSE, FALSE,
+        CRM_OP_PING, FALSE, FALSE,
         cib_prepare_none, cib_cleanup_output, cib_process_ping
     },
 };

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2022 the Pacemaker project contributors
+ * Copyright 2008-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -336,14 +336,6 @@ cib_op_can_run(int call_type, int call_options, gboolean privileged, gboolean gl
         /* abort */
         return -EACCES;
     }
-#if 0
-    if (rc == pcmk_ok
-        && stand_alone == FALSE
-        && global_update == FALSE
-        && (call_options & cib_quorum_override) == 0 && cib_server_ops[call_type].needs_quorum) {
-        return -pcmk_err_no_quorum;
-    }
-#endif
     return pcmk_ok;
 }
 

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -330,10 +330,9 @@ cib_op_modifies(int call_type)
 }
 
 int
-cib_op_can_run(int call_type, int call_options, gboolean privileged, gboolean global_update)
+cib_op_can_run(int call_type, int call_options, bool privileged)
 {
-    if (privileged == FALSE && cib_server_ops[call_type].needs_privileges) {
-        /* abort */
+    if (!privileged && cib_server_ops[call_type].needs_privileges) {
         return -EACCES;
     }
     return pcmk_ok;

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -281,7 +281,6 @@ cib_msg_copy(xmlNode * msg, gboolean with_data)
         F_CIB_EXISTING,
         F_CIB_SEENCOUNT,
         F_CIB_TIMEOUT,
-        F_CIB_CALLBACK_TOKEN,
         F_CIB_GLOBAL_UPDATE,
         F_CIB_CLIENTNAME,
         F_CIB_USER,

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -166,7 +166,10 @@ cib_diff_notify(const char *op, int result, const char *call_id,
     cib_diff_version_details(diff, &add_admin_epoch, &add_epoch, &add_updates,
                              &del_admin_epoch, &del_epoch, &del_updates);
 
-    if (add_updates != del_updates) {
+    if ((add_admin_epoch != del_admin_epoch)
+        || (add_epoch != del_epoch)
+        || (add_updates != del_updates)) {
+
         do_crm_log(log_level,
                    "Updated CIB generation %d.%d.%d to %d.%d.%d from client "
                    "%s%s%s (%s) (%s)",
@@ -175,10 +178,14 @@ cib_diff_notify(const char *op, int result, const char *call_id,
                    client_name,
                    ((call_id != NULL)? " call " : ""), pcmk__s(call_id, ""),
                    pcmk__s(origin, "unspecified peer"), pcmk_strerror(result));
-    } else {
+
+    } else if ((add_admin_epoch != 0)
+               || (add_epoch != 0)
+               || (add_updates != 0)) {
+
         do_crm_log(log_level,
                    "Local-only change to CIB generation %d.%d.%d from client "
-                   "%s%s%s (%s)",
+                   "%s%s%s (%s) (%s)",
                    add_admin_epoch, add_epoch, add_updates,
                    client_name,
                    ((call_id != NULL)? " call " : ""), pcmk__s(call_id, ""),
@@ -248,7 +255,10 @@ cib_replace_notify(const char *op, int result, const char *call_id,
         crm_log_xml_debug(diff, "Bad replace diff");
     }
 
-    if (add_updates != del_updates) {
+    if ((add_admin_epoch != del_admin_epoch)
+        || (add_epoch != del_epoch)
+        || (add_updates != del_updates)) {
+
         do_crm_log(log_level,
                    "Replaced CIB generation %d.%d.%d with %d.%d.%d from client "
                    "%s%s%s (%s) (%s)",
@@ -257,10 +267,14 @@ cib_replace_notify(const char *op, int result, const char *call_id,
                    client_name,
                    ((call_id != NULL)? " call " : ""), pcmk__s(call_id, ""),
                    pcmk__s(origin, "unspecified peer"), pcmk_strerror(result));
-    } else {
+
+    } else if ((add_admin_epoch != 0)
+               || (add_epoch != 0)
+               || (add_updates != 0)) {
+
         do_crm_log(log_level,
                    "Local-only replace of CIB generation %d.%d.%d from client "
-                   "%s%s%s (%s)",
+                   "%s%s%s (%s) (%s)",
                    add_admin_epoch, add_epoch, add_updates,
                    client_name,
                    ((call_id != NULL)? " call " : ""), pcmk__s(call_id, ""),

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -29,15 +29,11 @@
 #include <crm/common/remote_internal.h>
 #include <pacemaker-based.h>
 
-int pending_updates = 0;
-
 struct cib_notification_s {
     xmlNode *msg;
     struct iovec *iov;
     int32_t iov_size;
 };
-
-void attach_cib_generation(xmlNode * msg, const char *field, xmlNode * a_cib);
 
 static void
 cib_notify_send_one(gpointer key, gpointer value, gpointer user_data)
@@ -129,6 +125,18 @@ cib_notify_send(xmlNode * xml)
     pcmk_free_ipc_event(iov);
 }
 
+static void
+attach_cib_generation(xmlNode *msg, const char *field, xmlNode *a_cib)
+{
+    xmlNode *generation = create_xml_node(NULL, XML_CIB_TAG_GENERATION_TUPPLE);
+
+    if (a_cib != NULL) {
+        copy_in_properties(generation, a_cib);
+    }
+    add_message_xml(msg, field, generation);
+    free_xml(generation);
+}
+
 void
 cib_diff_notify(int options, const char *client, const char *call_id, const char *op,
                 xmlNode * update, int result, xmlNode * diff)
@@ -201,18 +209,6 @@ cib_diff_notify(int options, const char *client, const char *call_id, const char
 
     cib_notify_send(update_msg);
     free_xml(update_msg);
-}
-
-void
-attach_cib_generation(xmlNode * msg, const char *field, xmlNode * a_cib)
-{
-    xmlNode *generation = create_xml_node(NULL, XML_CIB_TAG_GENERATION_TUPPLE);
-
-    if (a_cib != NULL) {
-        copy_in_properties(generation, a_cib);
-    }
-    add_message_xml(msg, field, generation);
-    free_xml(generation);
 }
 
 void

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -426,17 +426,6 @@ cib_handle_remote_msg(pcmk__client_t *client, xmlNode *command)
         }
     }
 
-    if (client->userdata == NULL) {
-        value = crm_element_value(command, F_CIB_CALLBACK_TOKEN);
-        if (value != NULL) {
-            client->userdata = strdup(value);
-            crm_trace("Callback channel for %s is %s", client->id, (char*)client->userdata);
-
-        } else {
-            client->userdata = strdup(client->id);
-        }
-    }
-
     /* unset dangerous options */
     xml_remove_prop(command, F_ORIG);
     xml_remove_prop(command, F_CIB_HOST);

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -133,8 +133,7 @@ int cib_op_prepare(int call_type, xmlNode *request, xmlNode **input,
                    const char **section);
 int cib_op_cleanup(int call_type, int options, xmlNode **input,
                    xmlNode **output);
-int cib_op_can_run(int call_type, int call_options, gboolean privileged,
-                   gboolean global_update);
+int cib_op_can_run(int call_type, int call_options, bool privileged);
 void cib_diff_notify(int options, const char *client, const char *call_id,
                      const char *op, xmlNode *update, int result,
                      xmlNode *old_cib);

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -133,11 +133,13 @@ int cib_op_prepare(int call_type, xmlNode *request, xmlNode **input,
 int cib_op_cleanup(int call_type, int options, xmlNode **input,
                    xmlNode **output);
 int cib_op_can_run(int call_type, int call_options, bool privileged);
-void cib_diff_notify(int options, const char *client, const char *call_id,
-                     const char *op, xmlNode *update, int result,
-                     xmlNode *old_cib);
-void cib_replace_notify(const char *origin, xmlNode *update, int result,
-                        xmlNode *diff, uint32_t change_section);
+void cib_diff_notify(const char *op, int result, const char *call_id,
+                     const char *client_id, const char *client_name,
+                     const char *origin, xmlNode *update, xmlNode *diff);
+void cib_replace_notify(const char *op, int result, const char *call_id,
+                        const char *client_id, const char *client_name,
+                        const char *origin, xmlNode *update, xmlNode *diff,
+                        uint32_t change_section);
 
 static inline const char *
 cib_config_lookup(const char *opt)

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -47,7 +47,6 @@ typedef struct cib_operation_s {
     const char *operation;
     gboolean modifies_cib;
     gboolean needs_privileges;
-    gboolean needs_quorum;
     int (*prepare) (xmlNode *, xmlNode **, const char **);
     int (*cleanup) (int, xmlNode **, xmlNode **);
     int (*fn) (const char *, int, const char *, xmlNode *,

--- a/daemons/controld/controld_cib.c
+++ b/daemons/controld/controld_cib.c
@@ -19,8 +19,6 @@
 
 #include <pacemaker-controld.h>
 
-static int cib_retries = 0;
-
 // Call ID of the most recent in-progress CIB resource update (or 0 if none)
 static int pending_rsc_update = 0;
 
@@ -126,6 +124,8 @@ do_cib_control(long long action,
                enum crmd_fsa_state cur_state,
                enum crmd_fsa_input current_input, fsa_data_t * msg_data)
 {
+    static int cib_retries = 0;
+
     cib_t *cib_conn = controld_globals.cib_conn;
 
     void (*dnotify_fn) (gpointer user_data) = handle_cib_disconnect;
@@ -188,6 +188,8 @@ do_cib_control(long long action,
     } else {
         controld_set_fsa_input_flags(R_CIB_CONNECTED);
         cib_retries = 0;
+        cib_conn->cmds->client_id(cib_conn, &controld_globals.cib_client_id,
+                                  NULL);
     }
 
     if (!pcmk_is_set(controld_globals.fsa_input_register, R_CIB_CONNECTED)) {

--- a/daemons/controld/controld_cib.c
+++ b/daemons/controld/controld_cib.c
@@ -252,7 +252,7 @@ cib_op_timeout(void)
 int
 crmd_cib_smart_opt(void)
 {
-    int call_opt = cib_quorum_override;
+    int call_opt = cib_none;
 
     if ((controld_globals.fsa_state == S_ELECTION)
         || (controld_globals.fsa_state == S_PENDING)) {
@@ -351,7 +351,7 @@ controld_delete_node_state(const char *uname, enum controld_section_e section,
         int call_id;
 
         cib__set_call_options(options, "node state deletion",
-                              cib_quorum_override|cib_xpath|cib_multiple);
+                              cib_xpath|cib_multiple);
         call_id = cib_conn->cmds->remove(cib_conn, xpath, NULL, options);
         crm_info("Deleting %s (via CIB call %d) " CRM_XS " xpath=%s",
                  desc, call_id, xpath);
@@ -939,7 +939,7 @@ controld_delete_action_history(const lrmd_event_data_t *op)
 
     controld_globals.cib_conn->cmds->remove(controld_globals.cib_conn,
                                             XML_CIB_TAG_STATUS, xml_top,
-                                            cib_quorum_override);
+                                            cib_none);
 
     crm_log_xml_trace(xml_top, "op:cancel");
     free_xml(xml_top);
@@ -998,8 +998,7 @@ controld_cib_delete_last_failure(const char *rsc_id, const char *node,
     free(last_failure_key);
 
     controld_globals.cib_conn->cmds->remove(controld_globals.cib_conn, xpath,
-                                            NULL,
-                                            cib_quorum_override|cib_xpath);
+                                            NULL, cib_xpath);
     free(xpath);
 }
 
@@ -1027,7 +1026,6 @@ controld_delete_action_history_by_key(const char *rsc_id, const char *node,
         xpath = crm_strdup_printf(XPATH_HISTORY_ID, node, rsc_id, key);
     }
     controld_globals.cib_conn->cmds->remove(controld_globals.cib_conn, xpath,
-                                            NULL,
-                                            cib_quorum_override|cib_xpath);
+                                            NULL, cib_xpath);
     free(xpath);
 }

--- a/daemons/controld/controld_cib.h
+++ b/daemons/controld/controld_cib.h
@@ -10,10 +10,14 @@
 #ifndef PCMK__CONTROLD_CIB__H
 #define PCMK__CONTROLD_CIB__H
 
+#include <crm_internal.h>
+
+#include <glib.h>
+
 #include <crm/crm.h>
 #include <crm/common/xml.h>
 #include <crm/cib/internal.h>   // PCMK__CIB_REQUEST_MODIFY
-#include <controld_globals.h>   // controld_globals.cib_conn
+#include "controld_globals.h"   // controld_globals.cib_conn
 
 static inline void
 fsa_cib_anon_update(const char *section, xmlNode *data) {
@@ -38,6 +42,11 @@ fsa_cib_anon_update_discard_reply(const char *section, xmlNode *data) {
                                                 |cib_discard_reply);
     }
 }
+
+void controld_record_cib_replace_call(int call_id);
+bool controld_forget_cib_replace_call(int call_id);
+void controld_forget_all_cib_replace_calls(void);
+void controld_destroy_cib_replacements_table(void);
 
 int controld_update_cib(const char *section, xmlNode *data, int options,
                         void (*callback)(xmlNode *, int, int, xmlNode *,

--- a/daemons/controld/controld_cib.h
+++ b/daemons/controld/controld_cib.h
@@ -20,10 +20,9 @@ fsa_cib_anon_update(const char *section, xmlNode *data) {
     if (controld_globals.cib_conn == NULL) {
         crm_err("No CIB connection available");
     } else {
-        const int opts = cib_scope_local|cib_quorum_override|cib_can_create;
-
         controld_globals.cib_conn->cmds->modify(controld_globals.cib_conn,
-                                                section, data, opts);
+                                                section, data,
+                                                cib_scope_local|cib_can_create);
     }
 }
 
@@ -32,13 +31,11 @@ fsa_cib_anon_update_discard_reply(const char *section, xmlNode *data) {
     if (controld_globals.cib_conn == NULL) {
         crm_err("No CIB connection available");
     } else {
-        const int opts = cib_scope_local
-                         |cib_quorum_override
-                         |cib_can_create
-                         |cib_discard_reply;
-
         controld_globals.cib_conn->cmds->modify(controld_globals.cib_conn,
-                                                section, data, opts);
+                                                section, data,
+                                                cib_scope_local
+                                                |cib_can_create
+                                                |cib_discard_reply);
     }
 }
 

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -265,6 +265,7 @@ crmd_exit(crm_exit_t exit_code)
     controld_globals.te_uuid = NULL;
 
     free_max_generation();
+    controld_destroy_cib_replacements_table();
     controld_destroy_failed_sync_table();
 
     mainloop_destroy_signal(SIGPIPE);

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -659,19 +659,30 @@ static pcmk__cluster_option_t controller_options[] = {
     {
         "no-quorum-policy", NULL, "select",
         "stop, freeze, ignore, demote, suicide", "stop", pcmk__valid_quorum,
-        "What to do when the cluster does not have quorum", NULL
+        N_("What to do when the cluster does not have quorum"), NULL
     },
     {
         XML_CONFIG_ATTR_SHUTDOWN_LOCK, NULL, "boolean", NULL,
         "false", pcmk__valid_boolean,
-        "Whether to lock resources to a cleanly shut down node",
-        "When true, resources active on a node when it is cleanly shut down "
+        N_("Whether to lock resources to a cleanly shut down node"),
+        N_("When true, resources active on a node when it is cleanly shut down "
             "are kept \"locked\" to that node (not allowed to run elsewhere) "
             "until they start again on that node after it rejoins (or for at "
             "most shutdown-lock-limit, if set). Stonith resources and "
             "Pacemaker Remote connections are never locked. Clone and bundle "
-            "instances and the promoted role of promotable clones are currently"
-            " never locked, though support could be added in a future release."
+            "instances and the promoted role of promotable clones are "
+            "currently never locked, though support could be added in a future "
+            "release.")
+    },
+    {
+        XML_CONFIG_ATTR_SHUTDOWN_LOCK_LIMIT, NULL, "time", NULL,
+        "0", pcmk__valid_interval_spec,
+        N_("Do not lock resources to a cleanly shut down node longer than "
+           "this"),
+        N_("If shutdown-lock is true and this is set to a nonzero time "
+            "duration, shutdown locks will expire after this much time has "
+            "passed since the shutdown was initiated, even if the node has not "
+            "rejoined.")
     },
 };
 
@@ -744,6 +755,11 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     } else {
         controld_clear_global_flags(controld_shutdown_lock_enabled);
     }
+
+    value = g_hash_table_lookup(config_hash,
+                                XML_CONFIG_ATTR_SHUTDOWN_LOCK_LIMIT);
+    controld_globals.shutdown_lock_limit = crm_parse_interval_spec(value)
+                                           / 1000;
 
     value = g_hash_table_lookup(config_hash, "cluster-name");
     pcmk__str_update(&(controld_globals.cluster_name), value);

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -267,6 +267,7 @@ crmd_exit(crm_exit_t exit_code)
     free_max_generation();
     controld_destroy_cib_replacements_table();
     controld_destroy_failed_sync_table();
+    controld_destroy_outside_events_table();
 
     mainloop_destroy_signal(SIGPIPE);
     mainloop_destroy_signal(SIGUSR1);

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -228,8 +228,7 @@ do_dc_takeover(long long action,
 
     cib = create_xml_node(NULL, XML_TAG_CIB);
     crm_xml_add(cib, XML_ATTR_CRM_VERSION, CRM_FEATURE_SET);
-    controld_update_cib(XML_TAG_CIB, cib, cib_quorum_override,
-                        feature_update_callback);
+    controld_update_cib(XML_TAG_CIB, cib, cib_none, feature_update_callback);
 
     dc_takeover_update_attr(XML_ATTR_HAVE_WATCHDOG, pcmk__btoa(watchdog));
     dc_takeover_update_attr("dc-version", PACEMAKER_VERSION "-" BUILD_VERSION);

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -98,7 +98,15 @@ lrm_state_is_local(lrm_state_t *lrm_state)
                            pcmk__str_casei);
 }
 
-lrm_state_t *
+/*!
+ * \internal
+ * \brief Create executor state entry for a node and add it to the state table
+ *
+ * \param[in]  node_name  Node to create entry for
+ *
+ * \return Newly allocated executor state object initialized for \p node_name
+ */
+static lrm_state_t *
 lrm_state_create(const char *node_name)
 {
     lrm_state_t *state = NULL;

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -254,8 +254,7 @@ send_stonith_update(pcmk__graph_action_t *action, const char *target,
 
     rc = controld_globals.cib_conn->cmds->update(controld_globals.cib_conn,
                                                  XML_CIB_TAG_STATUS, node_state,
-                                                 cib_quorum_override
-                                                 |cib_scope_local
+                                                 cib_scope_local
                                                  |cib_can_create);
 
     /* Delay processing the trigger until the update completes */
@@ -264,8 +263,7 @@ send_stonith_update(pcmk__graph_action_t *action, const char *target,
 
     // Make sure it sticks
     /* controld_globals.cib_conn->cmds->bump_epoch(controld_globals.cib_conn,
-     *                                             cib_quorum_override
-     *                                             |cib_scope_local);
+     *                                             cib_scope_local);
      */
 
     controld_delete_node_state(peer->uname, controld_section_all,

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -252,7 +252,7 @@ send_stonith_update(pcmk__graph_action_t *action, const char *target,
     /* Force our known ID */
     crm_xml_add(node_state, XML_ATTR_ID, uuid);
 
-    rc = controld_globals.cib_conn->cmds->update(controld_globals.cib_conn,
+    rc = controld_globals.cib_conn->cmds->modify(controld_globals.cib_conn,
                                                  XML_CIB_TAG_STATUS, node_state,
                                                  cib_scope_local
                                                  |cib_can_create);

--- a/daemons/controld/controld_fsa.h
+++ b/daemons/controld/controld_fsa.h
@@ -399,7 +399,6 @@ enum crmd_fsa_input {
 #  define R_CIB_DONE        0x00010000ULL
                                         /* Have we calculated the CIB? */
 #  define R_HAVE_CIB        0x00020000ULL   /* Do we have an up-to-date CIB */
-#  define R_CIB_ASKED       0x00040000ULL   /* Have we asked for an up-to-date CIB */
 
 #  define R_MEMBERSHIP      0x00100000ULL   /* Have we got cluster layer data yet */
 #  define R_PEER_DATA       0x00200000ULL   /* Have we got T_CL_STATUS data yet */

--- a/daemons/controld/controld_globals.h
+++ b/daemons/controld/controld_globals.h
@@ -45,6 +45,9 @@ typedef struct {
     //! Connection to the CIB
     cib_t *cib_conn;
 
+    //! CIB connection's client ID
+    const char *cib_client_id;
+
 
     // Scheduler
 

--- a/daemons/controld/controld_globals.h
+++ b/daemons/controld/controld_globals.h
@@ -90,6 +90,9 @@ typedef struct {
     //! Last saved cluster communication layer membership ID
     unsigned long long membership_id;
 
+    //! Max lifetime (in seconds) of a resource's shutdown lock to a node
+    guint shutdown_lock_limit;
+
     //! Main event loop
     GMainLoop *mainloop;
 } controld_globals_t;

--- a/daemons/controld/controld_globals.h
+++ b/daemons/controld/controld_globals.h
@@ -45,9 +45,6 @@ typedef struct {
     //! Connection to the CIB
     cib_t *cib_conn;
 
-    //! Call ID of the in-progress CIB resource update (or 0 if none)
-    int resource_update;
-
 
     // Scheduler
 

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -607,8 +607,7 @@ do_dc_join_finalize(long long action,
     crmd_join_phase_log(LOG_DEBUG);
 
     rc = controld_globals.cib_conn->cmds->sync_from(controld_globals.cib_conn,
-                                                    sync_from, NULL,
-                                                    cib_quorum_override);
+                                                    sync_from, NULL, cib_none);
     fsa_register_cib_callback(rc, sync_from, finalize_sync_callback);
 }
 
@@ -699,7 +698,7 @@ do_dc_join_ack(long long action,
     int join_id = -1;
     ha_msg_input_t *join_ack = fsa_typed_data(fsa_dt_ha_msg);
     enum controld_section_e section = controld_section_lrm;
-    const int cib_opts = cib_scope_local|cib_quorum_override|cib_can_create;
+    const int cib_opts = cib_scope_local|cib_can_create;
 
     const char *op = crm_element_value(join_ack->msg, F_CRM_TASK);
     const char *join_from = crm_element_value(join_ack->msg, F_CRM_HOST_FROM);

--- a/daemons/controld/controld_lrm.h
+++ b/daemons/controld/controld_lrm.h
@@ -109,11 +109,6 @@ gboolean lrm_state_init_local(void);
 void lrm_state_destroy_all(void);
 
 /*!
- * \brief Create executor connection entry
- */
-lrm_state_t *lrm_state_create(const char *node_name);
-
-/*!
  * \brief Destroy executor connection by node name
  */
 void lrm_state_destroy(const char *node_name);

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -256,9 +256,7 @@ search_conflicting_node_callback(xmlNode * msg, int call_id, int rc,
                        node_uuid, node_uname, new_node_uuid);
 
             delete_call_id = cib_conn->cmds->remove(cib_conn, XML_CIB_TAG_NODES,
-                                                    node_xml,
-                                                    cib_scope_local
-                                                    |cib_quorum_override);
+                                                    node_xml, cib_scope_local);
             fsa_register_cib_callback(delete_call_id, strdup(node_uuid),
                                       remove_conflicting_node_callback);
 
@@ -269,8 +267,7 @@ search_conflicting_node_callback(xmlNode * msg, int call_id, int rc,
             delete_call_id = cib_conn->cmds->remove(cib_conn,
                                                     XML_CIB_TAG_STATUS,
                                                     node_state_xml,
-                                                    cib_scope_local
-                                                    |cib_quorum_override);
+                                                    cib_scope_local);
             fsa_register_cib_callback(delete_call_id, strdup(node_uuid),
                                       remove_conflicting_node_callback);
             free_xml(node_state_xml);
@@ -302,7 +299,6 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
 
     int call_id = 0;
     gboolean from_hashtable = TRUE;
-    int call_options = cib_scope_local | cib_quorum_override;
     xmlNode *node_list = create_xml_node(NULL, XML_CIB_TAG_NODES);
 
 #if SUPPORT_COROSYNC
@@ -356,7 +352,7 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
 
     crm_trace("Populating <nodes> section from %s", from_hashtable ? "hashtable" : "cluster");
 
-    if ((controld_update_cib(XML_CIB_TAG_NODES, node_list, call_options,
+    if ((controld_update_cib(XML_CIB_TAG_NODES, node_list, cib_scope_local,
                              node_list_update_callback) == pcmk_rc_ok)
          && (crm_peer_cache != NULL) && AM_I_DC) {
         /*
@@ -381,7 +377,7 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
             }
         }
 
-        controld_update_cib(XML_CIB_TAG_STATUS, node_list, call_options,
+        controld_update_cib(XML_CIB_TAG_STATUS, node_list, cib_scope_local,
                             crmd_node_update_complete);
     }
     free_xml(node_list);
@@ -420,14 +416,13 @@ crm_update_quorum(gboolean quorum, gboolean force_update)
         && ((has_quorum && !quorum) || (!has_quorum && quorum)
             || force_update)) {
         xmlNode *update = NULL;
-        int call_options = cib_scope_local | cib_quorum_override;
 
         update = create_xml_node(NULL, XML_TAG_CIB);
         crm_xml_add_int(update, XML_ATTR_HAVE_QUORUM, quorum);
         crm_xml_add(update, XML_ATTR_DC_UUID, controld_globals.our_uuid);
 
         crm_debug("Updating quorum status to %s", pcmk__btoa(quorum));
-        controld_update_cib(XML_TAG_CIB, update, call_options,
+        controld_update_cib(XML_TAG_CIB, update, cib_scope_local,
                             cib_quorum_update_complete);
         free_xml(update);
 

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -419,11 +419,9 @@ relay_message(xmlNode * msg, gboolean originated_locally)
         } else if (originated_locally && !pcmk__strcase_any_of(sys_from, CRM_SYSTEM_PENGINE,
                                                                CRM_SYSTEM_TENGINE, NULL)) {
 
-#if SUPPORT_COROSYNC
             if (is_corosync_cluster()) {
                 dest = text2msg_type(sys_to);
             }
-#endif
             crm_trace("Relay message %s to DC", ref);
             send_cluster_message(host_to ? crm_get_peer(0, host_to) : NULL, dest, msg, TRUE);
 
@@ -448,7 +446,6 @@ relay_message(xmlNode * msg, gboolean originated_locally)
     } else {
         crm_node_t *node_to = NULL;
 
-#if SUPPORT_COROSYNC
         if (is_corosync_cluster()) {
             dest = text2msg_type(sys_to);
 
@@ -456,7 +453,6 @@ relay_message(xmlNode * msg, gboolean originated_locally)
                 dest = crm_msg_crmd;
             }
         }
-#endif
 
         if (host_to) {
             node_to = pcmk__search_cluster_node_cache(0, host_to);

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -297,7 +297,7 @@ controld_record_action_event(pcmk__graph_action_t *action,
     pcmk__create_history_xml(rsc, op, CRM_FEATURE_SET, target_rc, target,
                              __func__);
 
-    rc = cib_conn->cmds->update(cib_conn, XML_CIB_TAG_STATUS, state,
+    rc = cib_conn->cmds->modify(cib_conn, XML_CIB_TAG_STATUS, state,
                                 cib_scope_local);
     fsa_register_cib_callback(rc, NULL, cib_action_updated);
     free_xml(state);

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -257,7 +257,6 @@ controld_record_action_event(pcmk__graph_action_t *action,
     const char *task_uuid = crm_element_value(action->xml, XML_LRM_ATTR_TASK_KEY);
     const char *target_uuid = crm_element_value(action->xml, XML_LRM_ATTR_TARGET_UUID);
 
-    int call_options = cib_quorum_override | cib_scope_local;
     int target_rc = get_target_rc(action);
 
     action_rsc = find_xml_node(action->xml, XML_CIB_TAG_RESOURCE, TRUE);
@@ -299,7 +298,7 @@ controld_record_action_event(pcmk__graph_action_t *action,
                              __func__);
 
     rc = cib_conn->cmds->update(cib_conn, XML_CIB_TAG_STATUS, state,
-                                call_options);
+                                cib_scope_local);
     fsa_register_cib_callback(rc, NULL, cib_action_updated);
     free_xml(state);
 

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -570,7 +570,7 @@ te_update_diff(const char *event, xmlNode * msg)
             crm_warn("Ignoring malformed CIB update (unknown patch format %d)",
                      format);
     }
-    controld_destroy_outside_event_table();
+    controld_remove_all_outside_events();
 }
 
 void

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -34,10 +34,22 @@ static GHashTable *outside_events = NULL;
 
 /*!
  * \internal
+ * \brief Empty the hash table containing action numbers of outside events
+ */
+void
+controld_remove_all_outside_events(void)
+{
+    if (outside_events != NULL) {
+        g_hash_table_remove_all(outside_events);
+    }
+}
+
+/*!
+ * \internal
  * \brief Destroy the hash table containing action numbers of outside events
  */
 void
-controld_destroy_outside_event_table(void)
+controld_destroy_outside_events_table(void)
 {
     if (outside_events != NULL) {
         g_hash_table_destroy(outside_events);

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -20,7 +20,8 @@ bool confirm_cancel_action(const char *id, const char *node_id);
 
 void controld_record_action_timeout(pcmk__graph_action_t *action);
 
-void controld_destroy_outside_event_table(void);
+void controld_destroy_outside_events_table(void);
+void controld_remove_all_outside_events(void);
 
 gboolean fail_incompletable_actions(pcmk__graph_t *graph, const char *down_node);
 void process_graph_event(xmlNode *event, const char *event_node);

--- a/daemons/controld/controld_utils.c
+++ b/daemons/controld/controld_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -514,9 +514,6 @@ fsa_dump_inputs(int log_level, const char *text, long long input_register)
     }
     if (pcmk_is_set(input_register, R_HAVE_CIB)) {
         crm_trace("%s %.16llx (R_HAVE_CIB)", text, R_HAVE_CIB);
-    }
-    if (pcmk_is_set(input_register, R_CIB_ASKED)) {
-        crm_trace("%s %.16llx (R_CIB_ASKED)", text, R_CIB_ASKED);
     }
     if (pcmk_is_set(input_register, R_MEMBERSHIP)) {
         crm_trace("%s %.16llx (R_MEMBERSHIP)", text, R_MEMBERSHIP);

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -62,8 +62,15 @@ enum cib_call_options {
     cib_no_mtime        = (1 << 13),
     cib_zero_copy       = (1 << 14),
     cib_inhibit_notify  = (1 << 16),
+
+#if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+    //! \deprecated This value will be removed in a future release
     cib_quorum_override = (1 << 20),
-    cib_inhibit_bcast   = (1 << 24), //!< \deprecated Will be removed in future
+#endif // !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+
+    //! \deprecated This value will be removed in a future release
+    cib_inhibit_bcast   = (1 << 24),
+
     cib_force_diff      = (1 << 28),
 };
 

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -126,8 +126,11 @@ typedef struct cib_api_operations_s {
                    int call_options);
     int (*modify) (cib_t *cib, const char *section, xmlNode *data,
                    int call_options);
+
+    //! \deprecated Use the \p modify() method instead
     int (*update) (cib_t *cib, const char *section, xmlNode *data,
                    int call_options);
+
     int (*replace) (cib_t *cib, const char *section, xmlNode *data,
                     int call_options);
     int (*remove) (cib_t *cib, const char *section, xmlNode *data,

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -26,11 +26,15 @@ extern "C" {
  */
 
 enum cib_variant {
-    cib_undefined,
-    cib_native,
-    cib_file,
-    cib_remote,
-    cib_database,
+    cib_undefined = 0,
+    cib_native    = 1,
+    cib_file      = 2,
+    cib_remote    = 3,
+
+#if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+    //! \deprecated This value will be removed in a future release
+    cib_database  = 4,
+#endif // !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
 };
 
 enum cib_state {

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -175,6 +175,29 @@ typedef struct cib_api_operations_s {
      * \return Legacy Pacemaker return code (in particular, pcmk_ok on success)
      */
     int (*set_secondary)(cib_t *cib, int call_options);
+
+    /*!
+     * \brief Get the given CIB connection's unique client identifier(s)
+     *
+     * These can be used to check whether this client requested the action that
+     * triggered a CIB notification.
+     *
+     * \param[in]  cib       CIB connection
+     * \param[out] async_id  If not \p NULL, where to store asynchronous client
+     *                       ID
+     * \param[out] sync_id   If not \p NULL, where to store synchronous client
+     *                       ID
+     *
+     * \return Legacy Pacemaker return code
+     *
+     * \note The client IDs are assigned by \p pacemaker-based when the client
+     *       connects. \p cib_t variants that don't connect to
+     *       \p pacemaker-based may never be assigned a client ID.
+     * \note Some variants may have only one client for both asynchronous and
+     *       synchronous requests.
+     */
+    int (*client_id)(const cib_t *cib, const char **async_id,
+                     const char **sync_id);
 } cib_api_operations_t;
 
 struct cib_s {

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -50,7 +50,6 @@
 #  define F_CIB_SEENCOUNT	"cib_seen"
 #  define F_CIB_TIMEOUT	"cib_timeout"
 #  define F_CIB_UPDATE	"cib_update"
-#  define F_CIB_CALLBACK_TOKEN	"cib_async_id"
 #  define F_CIB_GLOBAL_UPDATE	"cib_update"
 #  define F_CIB_UPDATE_RESULT	"cib_update_result"
 #  define F_CIB_CLIENTNAME	"cib_clientname"
@@ -136,7 +135,7 @@ int cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_
                    xmlNode * current_cib, xmlNode ** result_cib, xmlNode ** diff,
                    xmlNode ** output);
 
-xmlNode *cib_create_op(int call_id, const char *token, const char *op, const char *host,
+xmlNode *cib_create_op(int call_id, const char *op, const char *host,
                        const char *section, xmlNode * data, int call_options,
                        const char *user_name);
 

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -282,7 +282,9 @@ extern "C" {
 #  define XML_AGENT_ATTR_CLASS		"class"
 #  define XML_AGENT_ATTR_PROVIDER	"provider"
 
+//! \deprecated Do not use (will be removed in a future release)
 #  define XML_CIB_ATTR_REPLACE       	"replace"
+
 #  define XML_CIB_ATTR_SOURCE       	"source"
 
 #  define XML_CIB_ATTR_PRIORITY     	"priority"

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -321,7 +321,7 @@ cib__update_node_attr(pcmk__output_t *out, cib_t *cib, int call_options, const c
 
     crm_log_xml_trace(xml_top, "update_attr");
     rc = cib_internal_op(cib, PCMK__CIB_REQUEST_MODIFY, NULL, section, xml_top,
-                         NULL, call_options|cib_quorum_override, user_name);
+                         NULL, call_options, user_name);
     if (rc < 0) {
         rc = pcmk_legacy2rc(rc);
 
@@ -397,7 +397,7 @@ cib__delete_node_attr(pcmk__output_t *out, cib_t *cib, int options, const char *
     xml_obj = crm_create_nvpair_xml(NULL, attr_id, attr_name, attr_value);
 
     rc = cib_internal_op(cib, PCMK__CIB_REQUEST_DELETE, NULL, section, xml_obj,
-                         NULL, options|cib_quorum_override, user_name);
+                         NULL, options, user_name);
     if (rc < 0) {
         rc = pcmk_legacy2rc(rc);
     } else {

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -356,14 +356,6 @@ cib_client_modify(cib_t * cib, const char *section, xmlNode * data, int call_opt
 }
 
 static int
-cib_client_update(cib_t * cib, const char *section, xmlNode * data, int call_options)
-{
-    op_common(cib);
-    return cib_internal_op(cib, PCMK__CIB_REQUEST_MODIFY, NULL, section, data,
-                           NULL, call_options, NULL);
-}
-
-static int
 cib_client_replace(cib_t * cib, const char *section, xmlNode * data, int call_options)
 {
     op_common(cib);
@@ -659,7 +651,7 @@ cib_new_variant(void)
 
     new_cib->cmds->create = cib_client_create;
     new_cib->cmds->modify = cib_client_modify;
-    new_cib->cmds->update = cib_client_update;
+    new_cib->cmds->update = cib_client_modify;
     new_cib->cmds->replace = cib_client_replace;
     new_cib->cmds->remove = cib_client_delete;
     new_cib->cmds->erase = cib_client_erase;

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -651,7 +651,7 @@ cib_new_variant(void)
 
     new_cib->cmds->create = cib_client_create;
     new_cib->cmds->modify = cib_client_modify;
-    new_cib->cmds->update = cib_client_modify;
+    new_cib->cmds->update = cib_client_modify; // Deprecated method
     new_cib->cmds->replace = cib_client_replace;
     new_cib->cmds->remove = cib_client_delete;
     new_cib->cmds->erase = cib_client_erase;

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -85,6 +85,34 @@ cib_file_register_notification(cib_t * cib, const char *callback, int enabled)
 
 /*!
  * \internal
+ * \brief Get the given CIB connection's unique client identifier
+ *
+ * \param[in]  cib       CIB connection
+ * \param[out] async_id  If not \p NULL, where to store asynchronous client ID
+ * \param[out] sync_id   If not \p NULL, where to store synchronous client ID
+ *
+ * \return Legacy Pacemaker return code (specifically, \p -EPROTONOSUPPORT)
+ *
+ * \note This is the \p cib_file variant implementation of
+ *       \p cib_api_operations_t:client_id().
+ * \note A \p cib_file object doesn't connect to the CIB and is never assigned a
+ *       client ID.
+ */
+static int
+cib_file_client_id(const cib_t *cib, const char **async_id,
+                   const char **sync_id)
+{
+    if (async_id != NULL) {
+        *async_id = NULL;
+    }
+    if (sync_id != NULL) {
+        *sync_id = NULL;
+    }
+    return -EPROTONOSUPPORT;
+}
+
+/*!
+ * \internal
  * \brief Compare the calculated digest of an XML tree against a signature file
  *
  * \param[in] root     Root of XML tree to compare
@@ -528,6 +556,8 @@ cib_file_new(const char *cib_location)
 
     cib->cmds->register_notification = cib_file_register_notification;
     cib->cmds->set_connection_dnotify = cib_file_set_connection_dnotify;
+
+    cib->cmds->client_id = cib_file_client_id;
 
     return cib;
 }

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -835,7 +835,8 @@ cib_file_perform_op_delegate(cib_t * cib, const char *op, const char *host, cons
     }
 
     cib->call_id++;
-    request = cib_create_op(cib->call_id, "dummy-token", op, host, section, data, call_options, user_name);
+    request = cib_create_op(cib->call_id, op, host, section, data, call_options,
+                            user_name);
     if(user_name) {
         crm_xml_add(request, XML_ACL_TAG_USER, user_name);
     }

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -359,11 +359,8 @@ cib_native_perform_op_delegate(cib_t * cib, const char *op, const char *host, co
         cib->call_id = 1;
     }
 
-    CRM_CHECK(native->token != NULL,;
-        );
-    op_msg =
-        cib_create_op(cib->call_id, native->token, op, host, section, data, call_options,
-                      user_name);
+    op_msg = cib_create_op(cib->call_id, op, host, section, data, call_options,
+                           user_name);
     if (op_msg == NULL) {
         return -EPROTO;
     }

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -71,6 +71,39 @@ cib_native_register_notification(cib_t *cib, const char *callback, int enabled)
     return rc;
 }
 
+/*!
+ * \internal
+ * \brief Get the given CIB connection's unique client identifier
+ *
+ * These can be used to check whether this client requested the action that
+ * triggered a CIB notification.
+ *
+ * \param[in]  cib       CIB connection
+ * \param[out] async_id  If not \p NULL, where to store asynchronous client ID
+ * \param[out] sync_id   If not \p NULL, where to store synchronous client ID
+ *
+ * \return Legacy Pacemaker return code (specifically, \p pcmk_ok)
+ *
+ * \note This is the \p cib_native variant implementation of
+ *       \p cib_api_operations_t:client_id().
+ * \note For \p cib_native objects, \p async_id and \p sync_id are the same.
+ * \note The client ID is assigned during CIB sign-on.
+ */
+static int
+cib_native_client_id(const cib_t *cib, const char **async_id,
+                     const char **sync_id)
+{
+    cib_native_opaque_t *native = cib->variant_opaque;
+
+    if (async_id != NULL) {
+        *async_id = native->token;
+    }
+    if (sync_id != NULL) {
+        *sync_id = native->token;
+    }
+    return pcmk_ok;
+}
+
 cib_t *
 cib_native_new(void)
 {
@@ -104,6 +137,8 @@ cib_native_new(void)
 
     cib->cmds->register_notification = cib_native_register_notification;
     cib->cmds->set_connection_dnotify = cib_native_set_connection_dnotify;
+
+    cib->cmds->client_id = cib_native_client_id;
 
     return cib;
 }

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -422,6 +422,7 @@ update_cib_object(xmlNode * parent, xmlNode * update)
               pcmk__s(object_id, ""),
               ((object_id == NULL)? "" : "'"));
 
+    // @COMPAT: XML_CIB_ATTR_REPLACE is unused internally. Remove at break.
     replace = crm_element_value(update, XML_CIB_ATTR_REPLACE);
     if (replace != NULL) {
         xmlNode *remove = NULL;

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -391,8 +391,8 @@ cib_remote_signon(cib_t * cib, const char *name, enum cib_conn_type type)
     }
 
     if (rc == pcmk_ok) {
-        xmlNode *hello =
-            cib_create_op(0, private->callback.token, CRM_OP_REGISTER, NULL, NULL, NULL, 0, NULL);
+        xmlNode *hello = cib_create_op(0, CRM_OP_REGISTER, NULL, NULL, NULL, 0,
+                                       NULL);
         crm_xml_add(hello, F_CIB_CLIENTNAME, name);
         pcmk__remote_send_xml(&private->command, hello);
         free_xml(hello);
@@ -482,9 +482,8 @@ cib_remote_perform_op(cib_t * cib, const char *op, const char *host, const char 
         cib->call_id = 1;
     }
 
-    op_msg =
-        cib_create_op(cib->call_id, private->callback.token, op, host, section, data, call_options,
-                      NULL);
+    op_msg = cib_create_op(cib->call_id, op, host, section, data, call_options,
+                           NULL);
     if (op_msg == NULL) {
         return -EPROTO;
     }

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -465,18 +465,17 @@ cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_quer
 }
 
 xmlNode *
-cib_create_op(int call_id, const char *token, const char *op, const char *host, const char *section,
-              xmlNode * data, int call_options, const char *user_name)
+cib_create_op(int call_id, const char *op, const char *host,
+              const char *section, xmlNode *data, int call_options,
+              const char *user_name)
 {
     xmlNode *op_msg = create_xml_node(NULL, "cib_command");
 
     CRM_CHECK(op_msg != NULL, return NULL);
-    CRM_CHECK(token != NULL, return NULL);
 
     crm_xml_add(op_msg, F_XML_TAGNAME, "cib_command");
 
     crm_xml_add(op_msg, F_TYPE, T_CIB);
-    crm_xml_add(op_msg, F_CIB_CALLBACK_TOKEN, token);
     crm_xml_add(op_msg, F_CIB_OPERATION, op);
     crm_xml_add(op_msg, F_CIB_HOST, host);
     crm_xml_add(op_msg, F_CIB_SECTION, section);

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -109,9 +109,8 @@ crm_cluster_disconnect(crm_cluster_t *cluster)
 #if SUPPORT_COROSYNC
             crm_peer_destroy();
             pcmk__corosync_disconnect(cluster);
-#else
-            break;
 #endif // SUPPORT_COROSYNC
+            break;
         default:
             break;
     }
@@ -208,11 +207,11 @@ get_node_name(uint32_t nodeid)
     enum cluster_type_e stack = get_cluster_type();
 
     switch (stack) {
-#  if SUPPORT_COROSYNC
         case pcmk_cluster_corosync:
+#if SUPPORT_COROSYNC
             name = pcmk__corosync_name(0, nodeid);
             break;
-#  endif
+#endif // SUPPORT_COROSYNC
 
         default:
             crm_err("Unknown cluster type: %s (%d)", name_for_cluster_type(stack), stack);
@@ -272,7 +271,6 @@ crm_peer_uname(const char *uuid)
     }
     node = NULL;
 
-#if SUPPORT_COROSYNC
     if (is_corosync_cluster()) {
         long long id;
 
@@ -291,7 +289,6 @@ crm_peer_uname(const char *uuid)
         }
         return NULL;
     }
-#endif
 
     return NULL;
 }

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -76,16 +76,19 @@ static pcmk__cluster_option_t pe_opts[] = {
             "until they start again on that node after it rejoins (or for at "
             "most shutdown-lock-limit, if set). Stonith resources and "
             "Pacemaker Remote connections are never locked. Clone and bundle "
-            "instances and the promoted role of promotable clones are currently"
-            " never locked, though support could be added in a future release.")
+            "instances and the promoted role of promotable clones are "
+            "currently never locked, though support could be added in a future "
+            "release.")
     },
     {
         XML_CONFIG_ATTR_SHUTDOWN_LOCK_LIMIT, NULL, "time", NULL,
         "0", pcmk__valid_interval_spec,
-        N_("Do not lock resources to a cleanly shut down node longer than this"),
-        N_("If shutdown-lock is true and this is set to a nonzero time duration, "
-            "shutdown locks will expire after this much time has passed since "
-            "the shutdown was initiated, even if the node has not rejoined.")
+        N_("Do not lock resources to a cleanly shut down node longer than "
+           "this"),
+        N_("If shutdown-lock is true and this is set to a nonzero time "
+            "duration, shutdown locks will expire after this much time has "
+            "passed since the shutdown was initiated, even if the node has not "
+            "rejoined.")
     },
 
     // Fencing-related options

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -619,12 +619,6 @@ main(int argc, char **argv)
                               cib_multiple);
     }
 
-    if (options.force) {
-        // Perform the action even without quorum
-        cib__set_call_options(options.cmd_options, crm_system_name,
-                              cib_quorum_override);
-    }
-
     if (options.get_node_path) {
         /* Enable getting node path of XPath query matches.
          * Meaningful only if options.section_type == cibadmin_section_xpath.

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1437,8 +1437,6 @@ main(int argc, char **argv)
                 fence_history_cb("--fence-history", "0", NULL, NULL);
                 break;
 
-            case cib_undefined:
-            case cib_database:
             default:
                 /* something is odd */
                 exit_on_invalid_cib();

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -2128,10 +2128,6 @@ main(int argc, char **argv)
 
     /* Convert rc into an exit code. */
     if (rc != pcmk_rc_ok && rc != pcmk_rc_no_output) {
-        if (rc == pcmk_rc_no_quorum) {
-            g_prefix_error(&error, "To ignore quorum, use the force option.\n");
-        }
-
         exit_code = pcmk_rc2exitc(rc);
     }
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -631,8 +631,8 @@ static GOptionEntry addl_entries[] = {
       INDENT "--restart, --wait, --force-*)",
       "N" },
     { "force", 'f', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &options.force,
-      "If making CIB changes, do so regardless of quorum. See help for\n"
-      INDENT "individual commands for additional behavior.",
+      "Force the action to be performed. See help for individual commands for\n"
+      INDENT "additional behavior.",
       NULL },
     { "xml-file", 'x', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_FILENAME, &options.xml_file,
       NULL,
@@ -1728,12 +1728,6 @@ main(int argc, char **argv)
     /*
      * Set up necessary connections
      */
-
-    if (options.force) {
-        crm_debug("Forcing...");
-        cib__set_call_options(options.cib_options, crm_system_name,
-                              cib_quorum_override);
-    }
 
     if (options.find_flags && options.rsc_id) {
         options.require_dataset = TRUE;

--- a/tools/crm_resource_ban.c
+++ b/tools/crm_resource_ban.c
@@ -145,7 +145,8 @@ cli_resource_ban(pcmk__output_t *out, const char *rsc_id, const char *host,
     }
 
     crm_log_xml_notice(fragment, "Modify");
-    rc = cib_conn->cmds->update(cib_conn, XML_CIB_TAG_CONSTRAINTS, fragment, cib_options);
+    rc = cib_conn->cmds->modify(cib_conn, XML_CIB_TAG_CONSTRAINTS, fragment,
+                                cib_options);
     rc = pcmk_legacy2rc(rc);
 
     free_xml(fragment);
@@ -211,7 +212,8 @@ cli_resource_prefer(pcmk__output_t *out,const char *rsc_id, const char *host,
     }
 
     crm_log_xml_info(fragment, "Modify");
-    rc = cib_conn->cmds->update(cib_conn, XML_CIB_TAG_CONSTRAINTS, fragment, cib_options);
+    rc = cib_conn->cmds->modify(cib_conn, XML_CIB_TAG_CONSTRAINTS, fragment,
+                                cib_options);
     rc = pcmk_legacy2rc(rc);
 
     free_xml(fragment);

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -1264,11 +1264,6 @@ main(int argc, char **argv)
                               cib_verbose);
     }
 
-    if (options.force) {
-        cib__set_call_options(options.cmd_options, crm_system_name,
-                              cib_quorum_override);
-    }
-
     // Run the command
     switch (options.cmd) {
         case shadow_cmd_commit:

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -990,10 +990,6 @@ main(int argc, char **argv)
 
     cib__clean_up_connection(&cib_conn);
 
-    if (rc == pcmk_rc_no_quorum) {
-        g_set_error(&error, PCMK__RC_ERROR, rc, "Use --force to ignore quorum");
-    }
-
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
     g_free(options.attr_default);


### PR DESCRIPTION
This is mostly a bunch of small, simple changes I made while investigating other things.
* Remove or deprecate a bunch of dead/obsolete code
* Make a few things static or global as needed
* Fix an unreported corner-case controller bug in "Low: controller: Ensure we don't ignore relevant CIB replacements".
* Add new `cib_api_operations_t:client_id()` method to support the above fix.
* When the controller deletes unlocked `<lrm_resource>` elements from node state, consider cleared (shutdown-lock="0") and expired (shutdown-lock + shutdown-lock-limit < current time) locks to be unlocked.