### PR TITLE
Low: tools: Fix crm_mon seg fault when curses is missing

### DIFF
--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -263,7 +263,6 @@ default_includes(mon_output_format_t fmt) {
                    |pcmk_section_failures;
 
         case mon_output_xml:
-        case mon_output_legacy_xml:
             return all_includes(fmt);
 
         default:
@@ -1640,7 +1639,7 @@ main(int argc, char **argv)
         }
     }
 
-    if (output_format == mon_output_xml || output_format == mon_output_legacy_xml) {
+    if (output_format == mon_output_xml) {
         show_opts |= pcmk_show_inactive_rscs | pcmk_show_timing;
 
         if (!options.daemonize) {

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -755,10 +755,6 @@ static GOptionEntry display_entries[] = {
       "Display pending state if 'record-pending' is enabled",
       NULL },
 
-    { "simple-status", 's', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, as_simple_cb,
-      "Display the cluster status once as a simple one line output (suitable for nagios)",
-      NULL },
-
     { NULL }
 };
 
@@ -771,6 +767,12 @@ static GOptionEntry deprecated_entries[] = {
     { "as-xml", 'X', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, as_xml_cb,
       "Write cluster status as XML to stdout. This will enable one-shot mode.\n"
       INDENT "Use --output-as=xml instead.",
+      NULL },
+
+    { "simple-status", 's', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK,
+      as_simple_cb,
+      "Display the cluster status once as a simple one line output\n"
+      INDENT "(suitable for nagios)",
       NULL },
 
     { "disable-ncurses", 'N', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, no_curses_cb,

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1492,12 +1492,28 @@ main(int argc, char **argv)
     }
 
     if (options.daemonize) {
-        if (!options.external_agent && (output_format == mon_output_console ||
-                                        output_format == mon_output_unset ||
-                                        output_format == mon_output_none)) {
-            g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_USAGE,
-                        "--daemonize requires --output-as=[html|text|xml]");
-            return clean_up(CRM_EX_USAGE);
+        if (!options.external_agent) {
+            switch (output_format) {
+                case mon_output_console:
+                    /* @TODO: We shouldn't be able to reach this point without
+                     * --output-to=X, which should default to text output if no
+                     * format is given. That will be fixed in an upcoming
+                     * commit.
+                     */
+                    g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_USAGE,
+                                "--daemonize requires at least one of "
+                                "--output-as=[html|text|xml] and "
+                                "--external-agent");
+                    return clean_up(CRM_EX_USAGE);
+
+                case mon_output_none:
+                    g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_USAGE,
+                                "--daemonize requires --external-agent if used "
+                                "with --output-as=none");
+                    return clean_up(CRM_EX_USAGE);
+                default:
+                    break;
+            }
         }
 
         crm_enable_stderr(FALSE);

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1181,6 +1181,11 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
         { NULL }
     };
 
+#if CURSES_ENABLED
+    const char *fmts = "console (default), html, text, xml, none";
+#else
+    const char *fmts = "text (default), html, xml, none";
+#endif // CURSES_ENABLED
     const char *description = "Notes:\n\n"
                               "If this program is called as crm_mon.cgi, --output-as=html --html-cgi will\n"
                               "automatically be added to the command line arguments.\n\n"
@@ -1212,11 +1217,7 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
                               "Start crm_mon and export the current cluster status as XML to stdout, then exit:\n\n"
                               "\tcrm_mon --output-as xml\n\n";
 
-#if CURSES_ENABLED
-    context = pcmk__build_arg_context(args, "console (default), html, text, xml", group, NULL);
-#else
-    context = pcmk__build_arg_context(args, "text (default), html, xml", group, NULL);
-#endif
+    context = pcmk__build_arg_context(args, fmts, group, NULL);
     pcmk__add_main_args(context, extra_prog_entries);
     g_option_context_set_description(context, description);
 
@@ -1279,7 +1280,9 @@ reconcile_output_format(pcmk__common_args_t *args) {
         return;
     }
 
-    if (pcmk__str_eq(args->output_ty, "html", pcmk__str_casei)) {
+    if (pcmk__str_eq(args->output_ty, "none", pcmk__str_casei)) {
+        output_format = mon_output_none;
+    } else if (pcmk__str_eq(args->output_ty, "html", pcmk__str_casei)) {
         char *dest = NULL;
 
         pcmk__str_update(&dest, args->output_dest);

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1308,11 +1308,16 @@ reconcile_output_format(pcmk__common_args_t *args)
         pcmk__str_update(&args->output_ty, "text");
         output_format = mon_output_plain;
 
-    } else {
-        /* Neither old nor new arguments were given, so set the default. */
+    } else if (pcmk__str_eq(args->output_ty, "console",
+                            pcmk__str_null_matches)) {
+        /* Default to console if no format was specified and none of the above
+         * overrides were hit
+         */
         pcmk__str_update(&args->output_ty, "console");
         output_format = mon_output_console;
     }
+
+    // Otherwise, invalid format. Let pcmk__output_new() throw an error.
 }
 
 static void

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1571,32 +1571,13 @@ main(int argc, char **argv)
     CRM_ASSERT(output_format != mon_output_unset);
 
     if (options.daemonize) {
-        if (!options.external_agent) {
-            switch (output_format) {
-                case mon_output_console:
-                    /* @TODO: We shouldn't be able to reach this point without
-                     * --output-to=X, which should default to text output if no
-                     * format is given. That will be fixed in an upcoming
-                     * commit.
-                     */
-                    g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_USAGE,
-                                "--daemonize requires at least one of "
-                                "--output-as=[html|text|xml] and "
-                                "--external-agent");
-                    return clean_up(CRM_EX_USAGE);
-
-                case mon_output_none:
-                    g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_USAGE,
-                                "--daemonize requires --external-agent if used "
-                                "with --output-as=none");
-                    return clean_up(CRM_EX_USAGE);
-                default:
-                    break;
-            }
+        if (!options.external_agent && (output_format == mon_output_none)) {
+            g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_USAGE,
+                        "--daemonize requires --external-agent if used with "
+                        "--output-as=none");
+            return clean_up(CRM_EX_USAGE);
         }
-
         crm_enable_stderr(FALSE);
-
         cib_delete(cib);
         cib = NULL;
         pcmk__daemonize(crm_system_name, options.pid_file);

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -2057,7 +2057,7 @@ mon_refresh_display(gpointer user_data)
 
     last_refresh = time(NULL);
 
-    if (output_format == mon_output_none || output_format == mon_output_unset) {
+    if (output_format == mon_output_none) {
         return G_SOURCE_REMOVE;
     }
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1504,28 +1504,15 @@ main(int argc, char **argv)
                 break;
         }
 
-        if (options.one_shot) {
-            if (output_format == mon_output_console) {
-                output_format = mon_output_plain;
-            }
+        if (options.daemonize
+            && !options.one_shot
+            && !options.external_agent
+            && pcmk__str_eq(args->output_dest, "-", pcmk__str_null_matches)) {
 
-        } else if (options.daemonize) {
-            if (pcmk__str_eq(args->output_dest, "-", pcmk__str_null_matches|pcmk__str_casei) &&
-                !options.external_agent) {
-                g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_USAGE,
-                            "--daemonize requires at least one of --output-to and --external-agent");
-                return clean_up(CRM_EX_USAGE);
-            }
-
-        } else if (output_format == mon_output_console) {
-#if CURSES_ENABLED
-            crm_enable_stderr(FALSE);
-#else
-            options.one_shot = TRUE;
-            output_format = mon_output_plain;
-            printf("Defaulting to one-shot mode\n");
-            printf("You need to have curses available at compile time to enable console mode\n");
-#endif
+            g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_USAGE,
+                        "--daemonize requires at least one of --output-to "
+                        "(with value not set to '-') and --external-agent");
+            return clean_up(CRM_EX_USAGE);
         }
     }
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1286,25 +1286,28 @@ reconcile_output_format(pcmk__common_args_t *args)
         return;
     }
 
-    if (pcmk__str_eq(args->output_ty, "none", pcmk__str_casei)) {
+    if (pcmk__str_eq(args->output_ty, "none", pcmk__str_none)) {
         output_format = mon_output_none;
-    } else if (pcmk__str_eq(args->output_ty, "html", pcmk__str_casei)) {
-        pcmk__str_update(&args->output_ty, "html");
+
+    } else if (pcmk__str_eq(args->output_ty, "html", pcmk__str_none)) {
         output_format = mon_output_html;
         umask(S_IWGRP | S_IWOTH);   // World-readable HTML
-    } else if (pcmk__str_eq(args->output_ty, "text", pcmk__str_casei)) {
-        pcmk__str_update(&args->output_ty, "text");
+
+    } else if (pcmk__str_eq(args->output_ty, "text", pcmk__str_none)) {
         output_format = mon_output_plain;
-    } else if (pcmk__str_eq(args->output_ty, "xml", pcmk__str_casei)) {
-        pcmk__str_update(&args->output_ty, "xml");
+
+    } else if (pcmk__str_eq(args->output_ty, "xml", pcmk__str_none)) {
         output_format = mon_output_xml;
+
     } else if (options.one_shot) {
         pcmk__str_update(&args->output_ty, "text");
         output_format = mon_output_plain;
+
     } else if (!options.daemonize && args->output_dest != NULL) {
         options.one_shot = TRUE;
         pcmk__str_update(&args->output_ty, "text");
         output_format = mon_output_plain;
+
     } else {
         /* Neither old nor new arguments were given, so set the default. */
         pcmk__str_update(&args->output_ty, "console");

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -56,9 +56,10 @@ typedef enum mon_output_format_e {
 } mon_output_format_t;
 
 enum mon_exec_mode {
-    mon_exec_interactive,
+    mon_exec_unset,
     mon_exec_daemonized,
     mon_exec_one_shot,
+    mon_exec_update,
 };
 
 void crm_mon_register_messages(pcmk__output_t *out);

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the Pacemaker project contributors
+ * Copyright 2019-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -54,6 +54,12 @@ typedef enum mon_output_format_e {
     mon_output_html,
     mon_output_cgi
 } mon_output_format_t;
+
+enum mon_exec_mode {
+    mon_exec_interactive,
+    mon_exec_daemonized,
+    mon_exec_one_shot,
+};
 
 void crm_mon_register_messages(pcmk__output_t *out);
 

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -115,19 +115,12 @@ curses_subprocess_output(pcmk__output_t *out, int exit_status,
 }
 
 /* curses_version is defined in curses.h, so we can't use that name here.
- * Note that this function prints out via text, not with curses.
+ * This function is empty because we create a text object instead of a console
+ * object if version is requested, so this is never called.
  */
 static void
 curses_ver(pcmk__output_t *out, bool extended) {
     CRM_ASSERT(out != NULL);
-
-    if (extended) {
-        printf("Pacemaker %s (Build: %s): %s\n", PACEMAKER_VERSION, BUILD_VERSION, CRM_FEATURES);
-    } else {
-        printf("Pacemaker %s\n", PACEMAKER_VERSION);
-        printf("Written by Andrew Beekhof and the "
-               "Pacemaker project contributors\n");
-    }
 }
 
 G_GNUC_PRINTF(2, 3)


### PR DESCRIPTION
If Pacemaker is built without curses, crm_mon in console mode exits immediately with a segmentation fault. There's no problem in one-shot mode.

Early in main(), we fail to initialize the "curses"-format pcmk__output_t object. In clean_up(), we call out->finish() without NULL-checking the output object.

This commit goes a little bit further than NULL-checking the output object. If we fail to create the curses object, we try to create a text object so that we can display the error.

Before:
```
[reid@laptop pacemaker]$ sudo crm_mon -1
Cluster Summary:
  * Stack: corosync (Pacemaker is running)
  * Current DC: NONE
  * Last updated: Mon Mar 27 18:13:16 2023 on laptop
  * Last change:  Fri Mar 24 00:41:47 2023 by hacluster via crmd on laptop
  * 1 node configured
  * 4 resource instances configured

Node List:
  * Node laptop: UNCLEAN (offline)

Active Resources:
  * No active resources


[reid@laptop pacemaker]$ sudo crm_mon
Segmentation fault
```

After:
```
[reid@laptop pacemaker]$ sudo crm_mon
crm_mon: Error creating output format console: Unknown output format
```

Fixes CLBZ#5512