### PR TITLE
Fix: fencer: make sure all fencing delays are applied correctly and taken into account by fencing timeouts

### DIFF
--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -633,21 +633,21 @@ class FenceTests(Tests):
                                  negative=True)
             test.add_log_pattern("using true1 returned 0")
 
-        # make sure requested fencing delay is applied only for the first device in the first level
-        # make sure static delay from pcmk_delay_base is added
+        # make sure all fencing delays are applied correctly and taken into account by fencing timeouts with topology
         for test_type in test_types:
             if not test_type["use_cpg"]:
                 continue
 
-            test = self.new_test("%s_topology_delay" % test_type["prefix"],
-                                 "Verify requested fencing delay is applied only for the first device in the first level and pcmk_delay_base is added.",
+            test = self.new_test("%s_topology_delays" % test_type["prefix"],
+                                 "Verify all fencing delays are applied correctly and taken into account by fencing timeouts with topology.",
                                  test_type["use_cpg"])
             test.add_cmd("stonith_admin",
                          "--output-as=xml -R true1 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\" -o \"pcmk_delay_base=1\"")
             test.add_cmd("stonith_admin",
                          "--output-as=xml -R false1 -a fence_dummy -o \"mode=fail\" -o \"pcmk_host_list=node1 node2 node3\" -o \"pcmk_delay_base=1\"")
+            # Resulting "random" delay will always be 1 since (rand() % (delay_max - delay_base)) is always 0 here.
             test.add_cmd("stonith_admin",
-                         "--output-as=xml -R true2 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
+                         "--output-as=xml -R true2 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\" -o \"pcmk_delay_base=1\" -o \"pcmk_delay_max=2\"")
             test.add_cmd("stonith_admin",
                          "--output-as=xml -R true3 -a fence_dummy -o \"mode=pass\" -o \"pcmk_host_list=node1 node2 node3\"")
 
@@ -658,10 +658,28 @@ class FenceTests(Tests):
 
             test.add_cmd("stonith_admin", "--output-as=xml -F node3 --delay 1")
 
+            # Total fencing timeout takes all fencing delays into account.
+            test.add_log_pattern("Total timeout set to 576")
+
+            # Fencing timeout for the first device takes the requested fencing delay into account.
+            # Fencing timeout also takes pcmk_delay_base into account.
+            test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using true1 .*144s.*",
+                                 regex=True)
+            # Requested fencing delay is applied only for the first device in the first level.
+            # Static delay from pcmk_delay_base is added.
             test.add_log_pattern("Delaying 'off' action targeting node3 using true1 for 2s | timeout=120s requested_delay=1s base=1s max=1s")
+
+            # Fencing timeout no longer takes the requested fencing delay into account for further devices.
+            test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using false1 .*144s.*",
+                                 regex=True)
+            # Requested fencing delay is no longer applied for further devices.
             test.add_log_pattern("Delaying 'off' action targeting node3 using false1 for 1s | timeout=120s requested_delay=0s base=1s max=1s")
-            test.add_log_pattern("Delaying 'off' action targeting node3 using true2",
-                                 negative=True)
+
+            # Fencing timeout takes pcmk_delay_max into account.
+            test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using true2 .*144s.*",
+                                 regex=True)
+            test.add_log_pattern("Delaying 'off' action targeting node3 using true2 for 1s | timeout=120s requested_delay=0s base=1s max=2s")
+
             test.add_log_pattern("Delaying 'off' action targeting node3 using true3",
                                  negative=True)
 

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -659,7 +659,7 @@ class FenceTests(Tests):
             test.add_cmd("stonith_admin", "--output-as=xml -F node3 --delay 1")
 
             # Total fencing timeout takes all fencing delays into account.
-            test.add_log_pattern("Total timeout set to 577")
+            test.add_log_pattern("Total timeout set to 579")
 
             # Fencing timeout for the first device takes the requested fencing delay into account.
             # Fencing timeout also takes pcmk_delay_base into account.
@@ -676,9 +676,9 @@ class FenceTests(Tests):
             test.add_log_pattern("Delaying 'off' action targeting node3 using false1 for 1s | timeout=120s requested_delay=0s base=1s max=1s")
 
             # Fencing timeout takes pcmk_delay_max into account.
-            test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using true2 .*144s.*",
+            test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using true2 .*146s.*",
                                  regex=True)
-            test.add_log_pattern("Delaying 'off' action targeting node3 using true2 for 1s | timeout=120s requested_delay=0s base=1s max=2s")
+            test.add_log_pattern("Delaying 'off' action targeting node3 using true2 for 1s | timeout=122s requested_delay=0s base=1s max=2s")
 
             test.add_log_pattern("Delaying 'off' action targeting node3 using true3",
                                  negative=True)

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -659,7 +659,7 @@ class FenceTests(Tests):
             test.add_cmd("stonith_admin", "--output-as=xml -F node3 --delay 1")
 
             # Total fencing timeout takes all fencing delays into account.
-            test.add_log_pattern("Total timeout set to 576")
+            test.add_log_pattern("Total timeout set to 577")
 
             # Fencing timeout for the first device takes the requested fencing delay into account.
             # Fencing timeout also takes pcmk_delay_base into account.

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -663,7 +663,7 @@ class FenceTests(Tests):
 
             # Fencing timeout for the first device takes the requested fencing delay into account.
             # Fencing timeout also takes pcmk_delay_base into account.
-            test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using true1 .*144s.*",
+            test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using true1 .*145s.*",
                                  regex=True)
             # Requested fencing delay is applied only for the first device in the first level.
             # Static delay from pcmk_delay_base is added.

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -667,18 +667,18 @@ class FenceTests(Tests):
                                  regex=True)
             # Requested fencing delay is applied only for the first device in the first level.
             # Static delay from pcmk_delay_base is added.
-            test.add_log_pattern("Delaying 'off' action targeting node3 using true1 for 2s | timeout=121s requested_delay=1s base=1s max=1s")
+            test.add_log_pattern("Delaying 'off' action targeting node3 using true1 for 2s | timeout=120s requested_delay=1s base=1s max=1s")
 
             # Fencing timeout no longer takes the requested fencing delay into account for further devices.
             test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using false1 .*145s.*",
                                  regex=True)
             # Requested fencing delay is no longer applied for further devices.
-            test.add_log_pattern("Delaying 'off' action targeting node3 using false1 for 1s | timeout=121s requested_delay=0s base=1s max=1s")
+            test.add_log_pattern("Delaying 'off' action targeting node3 using false1 for 1s | timeout=120s requested_delay=0s base=1s max=1s")
 
             # Fencing timeout takes pcmk_delay_max into account.
             test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using true2 .*146s.*",
                                  regex=True)
-            test.add_log_pattern("Delaying 'off' action targeting node3 using true2 for 1s | timeout=122s requested_delay=0s base=1s max=2s")
+            test.add_log_pattern("Delaying 'off' action targeting node3 using true2 for 1s | timeout=120s requested_delay=0s base=1s max=2s")
 
             test.add_log_pattern("Delaying 'off' action targeting node3 using true3",
                                  negative=True)

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -659,21 +659,21 @@ class FenceTests(Tests):
             test.add_cmd("stonith_admin", "--output-as=xml -F node3 --delay 1")
 
             # Total fencing timeout takes all fencing delays into account.
-            test.add_log_pattern("Total timeout set to 579")
+            test.add_log_pattern("Total timeout set to 582")
 
             # Fencing timeout for the first device takes the requested fencing delay into account.
             # Fencing timeout also takes pcmk_delay_base into account.
-            test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using true1 .*145s.*",
+            test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using true1 .*146s.*",
                                  regex=True)
             # Requested fencing delay is applied only for the first device in the first level.
             # Static delay from pcmk_delay_base is added.
-            test.add_log_pattern("Delaying 'off' action targeting node3 using true1 for 2s | timeout=120s requested_delay=1s base=1s max=1s")
+            test.add_log_pattern("Delaying 'off' action targeting node3 using true1 for 2s | timeout=121s requested_delay=1s base=1s max=1s")
 
             # Fencing timeout no longer takes the requested fencing delay into account for further devices.
-            test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using false1 .*144s.*",
+            test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using false1 .*145s.*",
                                  regex=True)
             # Requested fencing delay is no longer applied for further devices.
-            test.add_log_pattern("Delaying 'off' action targeting node3 using false1 for 1s | timeout=120s requested_delay=0s base=1s max=1s")
+            test.add_log_pattern("Delaying 'off' action targeting node3 using false1 for 1s | timeout=121s requested_delay=0s base=1s max=1s")
 
             # Fencing timeout takes pcmk_delay_max into account.
             test.add_log_pattern(r"Requesting that .* perform 'off' action targeting node3 using true2 .*146s.*",

--- a/cts/lab/CTStests.py
+++ b/cts/lab/CTStests.py
@@ -723,7 +723,7 @@ class PartialStart(CTSTest):
         # We might do some fencing in the 2-node case if we make it up far enough
         return [
             r"Executing reboot fencing operation",
-            r"Requesting fencing \([^)]+\) of node ",
+            r"Requesting fencing \([^)]+\) targeting node ",
         ]
 
 #     Register StopOnebyOne as a good test to run

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -959,7 +959,8 @@ controld_execute_fence_action(pcmk__graph_t *graph,
     const char *priority_delay = NULL;
     int delay_i = 0;
     gboolean invalid_action = FALSE;
-    guint stonith_timeout = controld_globals.transition_graph->stonith_timeout;
+    int stonith_timeout = (int) (controld_globals.transition_graph->stonith_timeout
+                                 / 1000);
 
     CRM_CHECK(id != NULL, invalid_action = TRUE);
     CRM_CHECK(uuid != NULL, invalid_action = TRUE);
@@ -974,7 +975,7 @@ controld_execute_fence_action(pcmk__graph_t *graph,
     priority_delay = crm_meta_value(action->params, XML_CONFIG_ATTR_PRIORITY_FENCING_DELAY);
 
     crm_notice("Requesting fencing (%s) of node %s "
-               CRM_XS " action=%s timeout=%u%s%s",
+               CRM_XS " action=%s timeout=%i%s%s",
                type, target, id, stonith_timeout,
                priority_delay ? " priority_delay=" : "",
                priority_delay ? priority_delay : "");
@@ -988,7 +989,7 @@ controld_execute_fence_action(pcmk__graph_t *graph,
                                           action->id, 0,
                                           controld_globals.te_uuid),
     stonith_api->cmds->register_callback(stonith_api, rc,
-                                         ((int) (stonith_timeout / 1000)
+                                         (stonith_timeout
                                           + (delay_i > 0 ? delay_i : 0)),
                                          st_opt_timeout_updates, transition_key,
                                          "tengine_stonith_callback",

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -974,7 +974,7 @@ controld_execute_fence_action(pcmk__graph_t *graph,
 
     priority_delay = crm_meta_value(action->params, XML_CONFIG_ATTR_PRIORITY_FENCING_DELAY);
 
-    crm_notice("Requesting fencing (%s) of node %s "
+    crm_notice("Requesting fencing (%s) targeting node %s "
                CRM_XS " action=%s timeout=%i%s%s",
                type, target, id, stonith_timeout,
                priority_delay ? " priority_delay=" : "",

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2318,25 +2318,25 @@ add_action_specific_attributes(xmlNode *xml, const char *action,
 
     delay_max = get_action_delay_max(device, action);
     if (delay_max > 0) {
-        crm_trace("Action '%s' has maximum random delay %dms using %s",
+        crm_trace("Action '%s' has maximum random delay %ds using %s",
                   action, delay_max, device->id);
-        crm_xml_add_int(xml, F_STONITH_DELAY_MAX, delay_max / 1000);
+        crm_xml_add_int(xml, F_STONITH_DELAY_MAX, delay_max);
     }
 
     delay_base = get_action_delay_base(device, action, target);
     if (delay_base > 0) {
-        crm_xml_add_int(xml, F_STONITH_DELAY_BASE, delay_base / 1000);
+        crm_xml_add_int(xml, F_STONITH_DELAY_BASE, delay_base);
     }
 
     if ((delay_max > 0) && (delay_base == 0)) {
-        crm_trace("Action '%s' has maximum random delay %dms using %s",
+        crm_trace("Action '%s' has maximum random delay %ds using %s",
                   action, delay_max, device->id);
     } else if ((delay_max == 0) && (delay_base > 0)) {
-        crm_trace("Action '%s' has a static delay of %dms using %s",
+        crm_trace("Action '%s' has a static delay of %ds using %s",
                   action, delay_base, device->id);
     } else if ((delay_max > 0) && (delay_base > 0)) {
-        crm_trace("Action '%s' has a minimum delay of %dms and a randomly chosen "
-                  "maximum delay of %dms using %s",
+        crm_trace("Action '%s' has a minimum delay of %ds and a randomly chosen "
+                  "maximum delay of %ds using %s",
                   action, delay_base, delay_max, device->id);
     }
 }

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1597,7 +1597,11 @@ get_op_total_timeout(const remote_fencing_op_t *op,
         total_timeout = op->base_timeout;
     }
 
-    return total_timeout ? total_timeout : op->base_timeout;
+    /* Take any requested fencing delay into account to prevent it from eating
+     * up the total timeout.
+     */
+    return ((total_timeout ? total_timeout : op->base_timeout)
+            + (op->delay > 0 ? op->delay : 0));
 }
 
 static void

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -672,6 +672,14 @@ remote_op_timeout_one(gpointer userdata)
     pcmk__set_result(&op->result, CRM_EX_ERROR, PCMK_EXEC_TIMEOUT,
                      "Peer did not return fence result within timeout");
 
+    // The requested delay has been applied for the first device
+    if (op->delay > 0) {
+        op->delay = 0;
+        crm_trace("Try another device for '%s' action targeting %s "
+                  "for client %s without delay " CRM_XS " id=%.8s",
+                  op->action, op->target, op->client_name, op->id);
+    }
+
     // Try another device, if appropriate
     request_peer_fencing(op, NULL);
     return G_SOURCE_REMOVE;

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1454,6 +1454,7 @@ get_device_timeout(const remote_fencing_op_t *op,
                    const peer_device_info_t *peer, const char *device)
 {
     device_properties_t *props;
+    int delay = 0;
 
     if (!peer || !device) {
         return op->base_timeout;
@@ -1464,9 +1465,16 @@ get_device_timeout(const remote_fencing_op_t *op,
         return op->base_timeout;
     }
 
+    // op->delay < 0 means disable any static/random fencing delays
+    if (op->delay >= 0) {
+        // delay_base is eventually limited by delay_max
+        delay = (props->delay_max[op->phase] > 0 ?
+                 props->delay_max[op->phase] : props->delay_base[op->phase]);
+    }
+
     return (props->custom_action_timeout[op->phase]?
-           props->custom_action_timeout[op->phase] : op->base_timeout)
-           + props->delay_max[op->phase];
+            props->custom_action_timeout[op->phase] : op->base_timeout)
+           + delay;
 }
 
 struct timeout_data {

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -173,7 +173,8 @@ async_fence_helper(gpointer user_data)
 
     st->cmds->register_callback(st,
                                 call_id,
-                                async_fence_data.timeout/1000,
+                                (async_fence_data.timeout/1000
+                                + (async_fence_data.delay > 0 ? async_fence_data.delay : 0)),
                                 st_opt_timeout_updates, NULL, "callback", fence_callback);
 
     return TRUE;

--- a/python/pacemaker/_cts/patterns.py
+++ b/python/pacemaker/_cts/patterns.py
@@ -221,7 +221,7 @@ class Corosync2Patterns(BasePatterns):
             r"Lost connection to the CIB manager",
             r"pacemaker-controld.*:\s*Action A_RECOVER .* not supported",
             r"pacemaker-controld.*:\s*Performing A_EXIT_1 - forcefully exiting ",
-            r".*:\s*Requesting fencing \([^)]+\) of node ",
+            r".*:\s*Requesting fencing \([^)]+\) targeting node ",
             r"(Blackbox dump requested|Problem detected)",
         ]
 


### PR DESCRIPTION
... to prevent any delays from eating up the timeouts and causing constant fencing failures.

This also means, when configuring fencing timeouts, users won't need to take any fencing delays into account by themselves.