### PR TITLE
Preserve transient attributes across remote connection hiccups

### DIFF
--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -196,6 +196,7 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
             }
 
             if (!appeared) {
+                node->peer_lost = time(NULL);
                 controld_remove_failed_sync_node(node->uname);
                 controld_remove_voter(node->uname);
             }

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -726,6 +726,7 @@ handle_lrm_delete(xmlNode *stored_msg)
 static enum crmd_fsa_input
 handle_remote_state(const xmlNode *msg)
 {
+    const char *conn_host = NULL;
     const char *remote_uname = ID(msg);
     crm_node_t *remote_peer;
     bool remote_is_up = false;
@@ -741,6 +742,14 @@ handle_remote_state(const xmlNode *msg)
     pcmk__update_peer_state(__func__, remote_peer,
                             remote_is_up ? CRM_NODE_MEMBER : CRM_NODE_LOST,
                             0);
+
+    conn_host = crm_element_value(msg, PCMK__XA_CONN_HOST);
+    if (conn_host) {
+        pcmk__str_update(&remote_peer->conn_host, conn_host);
+    } else if (remote_peer->conn_host) {
+        free(remote_peer->conn_host);
+        remote_peer->conn_host = NULL;
+    }
 
     return I_NULL;
 }

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -1284,8 +1284,14 @@ broadcast_remote_state_message(const char *node_name, bool node_up)
 
     crm_info("Notifying cluster of Pacemaker Remote node %s %s",
              node_name, node_up? "coming up" : "going down");
+
     crm_xml_add(msg, XML_ATTR_ID, node_name);
     pcmk__xe_set_bool_attr(msg, XML_NODE_IN_CLUSTER, node_up);
+
+    if (node_up) {
+        crm_xml_add(msg, PCMK__XA_CONN_HOST, controld_globals.our_nodename);
+    }
+
     send_cluster_message(NULL, crm_msg_crmd, msg, TRUE);
     free_xml(msg);
 }

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -741,6 +741,7 @@ handle_remote_state(const xmlNode *msg)
     pcmk__update_peer_state(__func__, remote_peer,
                             remote_is_up ? CRM_NODE_MEMBER : CRM_NODE_LOST,
                             0);
+
     return I_NULL;
 }
 
@@ -1010,10 +1011,6 @@ handle_request(xmlNode *stored_msg, enum crmd_fsa_cause cause)
         } else if (strcmp(op, CRM_OP_SHUTDOWN_REQ) == 0) {
             // Another controller wants to shut down its node
             return handle_shutdown_request(stored_msg);
-
-        } else if (strcmp(op, CRM_OP_REMOTE_STATE) == 0) {
-            /* a remote connection host is letting us know the node state */
-            return handle_remote_state(stored_msg);
         }
     }
 
@@ -1025,6 +1022,10 @@ handle_request(xmlNode *stored_msg, enum crmd_fsa_cause cause)
         register_fsa_input_adv(C_HA_MESSAGE, I_NULL, &fsa_input,
                                A_ELECTION_COUNT | A_ELECTION_CHECK, FALSE,
                                __func__);
+
+    } else if (strcmp(op, CRM_OP_REMOTE_STATE) == 0) {
+        /* a remote connection host is letting us know the node state */
+        return handle_remote_state(stored_msg);
 
     } else if (strcmp(op, CRM_OP_THROTTLE) == 0) {
         throttle_update(stored_msg);
@@ -1270,34 +1271,22 @@ delete_ha_msg_input(ha_msg_input_t * orig)
 
 /*!
  * \internal
- * \brief Notify the DC of a remote node state change
+ * \brief Notify the cluster of a remote node state change
  *
  * \param[in] node_name  Node's name
- * \param[in] node_up    TRUE if node is up, FALSE if down
+ * \param[in] node_up    true if node is up, false if down
  */
 void
-send_remote_state_message(const char *node_name, gboolean node_up)
+broadcast_remote_state_message(const char *node_name, bool node_up)
 {
-    /* If we don't have a DC, or the message fails, we have a failsafe:
-     * the DC will eventually pick up the change via the CIB node state.
-     * The message allows it to happen sooner if possible.
-     */
-    if (controld_globals.dc_name != NULL) {
-        xmlNode *msg = create_request(CRM_OP_REMOTE_STATE, NULL,
-                                      controld_globals.dc_name, CRM_SYSTEM_DC,
-                                      CRM_SYSTEM_CRMD, NULL);
+    xmlNode *msg = create_request(CRM_OP_REMOTE_STATE, NULL, NULL,
+                                  CRM_SYSTEM_CRMD, CRM_SYSTEM_CRMD, NULL);
 
-        crm_info("Notifying DC %s of Pacemaker Remote node %s %s",
-                 controld_globals.dc_name, node_name,
-                 node_up? "coming up" : "going down");
-        crm_xml_add(msg, XML_ATTR_ID, node_name);
-        pcmk__xe_set_bool_attr(msg, XML_NODE_IN_CLUSTER, node_up);
-        send_cluster_message(crm_get_peer(0, controld_globals.dc_name),
-                             crm_msg_crmd, msg, TRUE);
-        free_xml(msg);
-    } else {
-        crm_debug("No DC to notify of Pacemaker Remote node %s %s",
-                  node_name, (node_up? "coming up" : "going down"));
-    }
+    crm_info("Notifying cluster of Pacemaker Remote node %s %s",
+             node_name, node_up? "coming up" : "going down");
+    crm_xml_add(msg, XML_ATTR_ID, node_name);
+    pcmk__xe_set_bool_attr(msg, XML_NODE_IN_CLUSTER, node_up);
+    send_cluster_message(NULL, crm_msg_crmd, msg, TRUE);
+    free_xml(msg);
 }
 

--- a/daemons/controld/controld_messages.h
+++ b/daemons/controld/controld_messages.h
@@ -81,6 +81,6 @@ extern gboolean send_request(xmlNode * msg, char **msg_reference);
 
 extern ha_msg_input_t *copy_ha_msg_input(ha_msg_input_t * orig);
 
-void send_remote_state_message(const char *node_name, gboolean node_up);
+void broadcast_remote_state_message(const char *node_name, bool node_up);
 
 #endif

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -242,7 +242,7 @@ remote_node_up(const char *node_name)
      * so the DC will get it sooner (via message) or later (via CIB refresh),
      * and any other interested parties can query the CIB.
      */
-    send_remote_state_message(node_name, TRUE);
+    broadcast_remote_state_message(node_name, true);
 
     update = create_xml_node(NULL, XML_CIB_TAG_STATUS);
     state = create_node_state_update(node, node_update_cluster, update,
@@ -304,7 +304,7 @@ remote_node_down(const char *node_name, const enum down_opts opts)
     pcmk__update_peer_state(__func__, node, CRM_NODE_LOST, 0);
 
     /* Notify DC */
-    send_remote_state_message(node_name, FALSE);
+    broadcast_remote_state_message(node_name, false);
 
     /* Update CIB node state */
     update = create_xml_node(NULL, XML_CIB_TAG_STATUS);

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the Pacemaker project contributors
+ * Copyright 2012-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1472,6 +1472,7 @@ process_lrmd_signon(pcmk__client_t *client, xmlNode *request, int call_id,
                     xmlNode **reply)
 {
     int rc = pcmk_ok;
+    time_t now = time(NULL);
     const char *protocol_version = crm_element_value(request, F_LRMD_PROTOCOL_VERSION);
 
     if (compare_version(protocol_version, LRMD_MIN_PROTOCOL_VERSION) < 0) {
@@ -1500,6 +1501,7 @@ process_lrmd_signon(pcmk__client_t *client, xmlNode *request, int call_id,
     crm_xml_add(*reply, F_LRMD_OPERATION, CRM_OP_REGISTER);
     crm_xml_add(*reply, F_LRMD_CLIENTID, client->id);
     crm_xml_add(*reply, F_LRMD_PROTOCOL_VERSION, LRMD_PROTOCOL_VERSION);
+    crm_xml_add_ll(*reply, PCMK__XA_UPTIME, now - start_time);
 
     return rc;
 }

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -40,6 +40,7 @@ static GMainLoop *mainloop = NULL;
 static qb_ipcs_service_t *ipcs = NULL;
 static stonith_t *stonith_api = NULL;
 int lrmd_call_id = 0;
+time_t start_time;
 
 static struct {
     gchar **log_files;
@@ -514,6 +515,8 @@ main(int argc, char **argv, char **envp)
         setenv("PCMK_remote_port", options.port, 1);
     }
 #endif  // PCMK__COMPILE_REMOTE
+
+    start_time = time(NULL);
 
     crm_notice("Starting Pacemaker " EXECD_TYPE " executor");
 

--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -20,6 +20,7 @@
 #  endif
 
 extern GHashTable *rsc_list;
+extern time_t start_time;
 
 typedef struct lrmd_rsc_s {
     char *rsc_id;

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -75,7 +75,9 @@ typedef struct crm_peer_node_s {
     // Only used by controller
     enum crm_join_phase join;
     char *expected;
+
     time_t peer_lost;
+    char *conn_host;
 } crm_node_t;
 
 void crm_peer_init(void);

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -75,6 +75,7 @@ typedef struct crm_peer_node_s {
     // Only used by controller
     enum crm_join_phase join;
     char *expected;
+    time_t peer_lost;
 } crm_node_t;
 
 void crm_peer_init(void);

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the Pacemaker project contributors
+ * Copyright 2013-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -111,6 +111,7 @@ struct pcmk__remote_s {
     int auth_timeout;
     int tcp_socket;
     mainloop_io_t *source;
+    time_t uptime;
 
     /* CIB-only */
     char *token;

--- a/include/crm/lrmd_internal.h
+++ b/include/crm/lrmd_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the Pacemaker project contributors
+ * Copyright 2015-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -45,6 +45,8 @@ void lrmd__set_result(lrmd_event_data_t *event, enum ocf_exitcode rc,
                       int op_status, const char *exit_reason);
 
 void lrmd__reset_result(lrmd_event_data_t *event);
+
+time_t lrmd__uptime(lrmd_t *lrmd);
 
 /* Shared functions for IPC proxy back end */
 

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -86,6 +86,7 @@
 #define PCMK__XA_MODE                   "mode"
 #define PCMK__XA_TASK                   "task"
 #define PCMK__XA_UPTIME                 "uptime"
+#define PCMK__XA_CONN_HOST              "connection_host"
 
 
 /*

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the Pacemaker project contributors
+ * Copyright 2006-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -85,6 +85,7 @@
 #define PCMK__XA_GRAPH_WARNINGS         "graph-warnings"
 #define PCMK__XA_MODE                   "mode"
 #define PCMK__XA_TASK                   "task"
+#define PCMK__XA_UPTIME                 "uptime"
 
 
 /*

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -392,6 +392,7 @@ destroy_crm_node(gpointer data)
     free(node->state);
     free(node->uuid);
     free(node->expected);
+    free(node->conn_host);
     free(node);
 }
 

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the Pacemaker project contributors
+ * Copyright 2012-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -980,8 +980,17 @@ lrmd_handshake(lrmd_t * lrmd, const char *name)
         const char *version = crm_element_value(reply, F_LRMD_PROTOCOL_VERSION);
         const char *msg_type = crm_element_value(reply, F_LRMD_OPERATION);
         const char *tmp_ticket = crm_element_value(reply, F_LRMD_CLIENTID);
+        long long uptime = -1;
 
         crm_element_value_int(reply, F_LRMD_RC, &rc);
+
+        /* The remote executor may add its uptime to the XML reply, which is
+         * useful in handling transient attributes when the connection to the
+         * remote node unexpectedly drops.  If no parameter is given, just
+         * default to -1.
+         */
+        crm_element_value_ll(reply, PCMK__XA_UPTIME, &uptime);
+        native->remote->uptime = uptime;
 
         if (rc == -EPROTO) {
             crm_err("Executor protocol version mismatch between client (%s) and server (%s)",

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -2509,3 +2509,25 @@ lrmd__reset_result(lrmd_event_data_t *event)
     free((void *) event->output);
     event->output = NULL;
 }
+
+/*!
+ * \internal
+ * \brief Get the uptime of a remote resource connection
+ *
+ * When the cluster connects to a remote resource, part of that resource's
+ * handshake includes the uptime of the remote resource's connection.  This
+ * uptime is stored in the lrmd_t object.
+ *
+ * \return The connection's uptime, or -1 if unknown
+ */
+time_t
+lrmd__uptime(lrmd_t *lrmd)
+{
+    lrmd_private_t *native = lrmd->lrmd_private;
+
+    if (native->remote == NULL) {
+        return -1;
+    } else {
+        return native->remote->uptime;
+    }
+}


### PR DESCRIPTION
This is just like the previous PR against main, with the latest comments also taken into account.