### PR TITLE
Feature: libcib, based: Support CIB transactions

### DIFF
--- a/cts/cli/regression.error_codes.exp
+++ b/cts/cli/regression.error_codes.exp
@@ -145,6 +145,7 @@ pcmk_rc_node_unknown - Node not found
 =#=#=#= End test: Get negative Pacemaker return code (with name) (XML) - OK (0) =#=#=#=
 * Passed: crm_error      - Get negative Pacemaker return code (with name) (XML)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) =#=#=#=
+-1037: No active transaction found
 -1036: Bad XML patch format
 -1035: Bad input value provided
 -1034: Disabled
@@ -186,6 +187,7 @@ pcmk_rc_node_unknown - Node not found
 * Passed: crm_error      - List Pacemaker return codes (non-positive)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (XML) =#=#=#=
 <pacemaker-result api-version="X" request="crm_error -l -r --output-as=xml">
+  <result-code code="-1037" description="No active transaction found"/>
   <result-code code="-1036" description="Bad XML patch format"/>
   <result-code code="-1035" description="Bad input value provided"/>
   <result-code code="-1034" description="Disabled"/>
@@ -227,6 +229,7 @@ pcmk_rc_node_unknown - Node not found
 =#=#=#= End test: List Pacemaker return codes (non-positive) (XML) - OK (0) =#=#=#=
 * Passed: crm_error      - List Pacemaker return codes (non-positive) (XML)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (with names) =#=#=#=
+-1037: pcmk_rc_no_transaction      No active transaction found
 -1036: pcmk_rc_bad_xml_patch       Bad XML patch format
 -1035: pcmk_rc_bad_input           Bad input value provided
 -1034: pcmk_rc_disabled            Disabled
@@ -268,6 +271,7 @@ pcmk_rc_node_unknown - Node not found
 * Passed: crm_error      - List Pacemaker return codes (non-positive) (with names)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (with names) (XML) =#=#=#=
 <pacemaker-result api-version="X" request="crm_error -n -l -r --output-as=xml">
+  <result-code code="-1037" name="pcmk_rc_no_transaction" description="No active transaction found"/>
   <result-code code="-1036" name="pcmk_rc_bad_xml_patch" description="Bad XML patch format"/>
   <result-code code="-1035" name="pcmk_rc_bad_input" description="Bad input value provided"/>
   <result-code code="-1034" name="pcmk_rc_disabled" description="Disabled"/>

--- a/daemons/based/Makefile.am
+++ b/daemons/based/Makefile.am
@@ -18,7 +18,8 @@ COMMONLIBS	= $(top_builddir)/lib/common/libcrmcommon.la \
 
 halib_PROGRAMS	= pacemaker-based
 
-noinst_HEADERS	= pacemaker-based.h
+noinst_HEADERS	= based_transaction.h \
+		  pacemaker-based.h
 
 pacemaker_based_CFLAGS	= $(CFLAGS_HARDENED_EXE)
 pacemaker_based_LDFLAGS	= $(LDFLAGS_HARDENED_EXE)
@@ -32,7 +33,8 @@ pacemaker_based_SOURCES	= pacemaker-based.c \
 			  based_io.c \
 			  based_messages.c \
 			  based_notify.c \
-			  based_remote.c
+			  based_remote.c \
+			  based_transaction.c
 
 clean-generic:
 	rm -f *.log *.debug *.xml *~

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1416,7 +1416,7 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
 
     if (!pcmk_is_set(operation->flags, cib_op_attr_modifies)) {
         rc = cib_perform_op(op, call_options, operation->fn, TRUE, section,
-                            request, input, FALSE, &config_changed, the_cib,
+                            request, input, FALSE, &config_changed, &the_cib,
                             &result_cib, NULL, &output);
 
         CRM_CHECK(result_cib == NULL, free_xml(result_cib));
@@ -1469,7 +1469,7 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
     // result_cib must not be modified after cib_perform_op() returns
     rc = cib_perform_op(op, call_options, operation->fn, FALSE, section,
                         request, input, manage_counters, &config_changed,
-                        the_cib, &result_cib, cib_diff, &output);
+                        &the_cib, &result_cib, cib_diff, &output);
 
     // @COMPAT: Legacy code
     if (!manage_counters) {

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -31,7 +31,6 @@
 #include <pacemaker-based.h>
 
 #define EXIT_ESCALATION_MS 10000
-#define OUR_NODENAME (stand_alone? "localhost" : crm_cluster->uname)
 
 static unsigned long cib_local_bcast_num = 0;
 

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1429,8 +1429,8 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
 
     int rc = pcmk_ok;
 
-    gboolean config_changed = FALSE;
-    gboolean manage_counters = TRUE;
+    bool config_changed = false;
+    bool manage_counters = true;
 
     static mainloop_timer_t *digest_timer = NULL;
 
@@ -1462,8 +1462,8 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
     }
 
     if (!pcmk_is_set(operation->flags, cib_op_attr_modifies)) {
-        rc = cib_perform_op(op, call_options, operation->fn, TRUE, section,
-                            request, input, FALSE, &config_changed, &the_cib,
+        rc = cib_perform_op(op, call_options, operation->fn, true, section,
+                            request, input, false, &config_changed, &the_cib,
                             &result_cib, NULL, &output);
 
         CRM_CHECK(result_cib == NULL, free_xml(result_cib));
@@ -1478,7 +1478,7 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
      * whether to update version/epoch info.
      */
     if (pcmk__xe_attr_is_true(request, F_CIB_GLOBAL_UPDATE)) {
-        manage_counters = FALSE;
+        manage_counters = false;
         cib__set_call_options(call_options, "call", cib_force_diff);
         crm_trace("Global update detected");
 
@@ -1491,7 +1491,7 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
     ping_modified_since = TRUE;
     if (pcmk_is_set(call_options, cib_inhibit_bcast)) {
         crm_trace("Skipping update: inhibit broadcast");
-        manage_counters = FALSE;
+        manage_counters = false;
     }
 
     if (!pcmk_is_set(call_options, cib_dryrun)
@@ -1524,7 +1524,7 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
     }
 
     // result_cib must not be modified after cib_perform_op() returns
-    rc = cib_perform_op(op, call_options, operation->fn, FALSE, section,
+    rc = cib_perform_op(op, call_options, operation->fn, false, section,
                         request, input, manage_counters, &config_changed,
                         &the_cib, &result_cib, cib_diff, &output);
 
@@ -1548,7 +1548,7 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
     if ((rc == pcmk_ok)
         && pcmk_is_set(operation->flags, cib_op_attr_writes_through)) {
 
-        config_changed = TRUE;
+        config_changed = true;
     }
 
     if ((rc == pcmk_ok)

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -146,12 +146,12 @@ static const cib_operation_t cib_server_ops[] = {
     },
     {
         PCMK__CIB_REQUEST_MODIFY,
-        cib_op_attr_modifies|cib_op_attr_privileged,
+        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
         cib_prepare_data, cib_cleanup_data, cib_process_modify
     },
     {
         PCMK__CIB_REQUEST_APPLY_PATCH,
-        cib_op_attr_modifies|cib_op_attr_privileged,
+        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
         cib_prepare_diff, cib_cleanup_data, cib_server_process_diff
     },
     {
@@ -159,17 +159,18 @@ static const cib_operation_t cib_server_ops[] = {
         cib_op_attr_modifies
         |cib_op_attr_privileged
         |cib_op_attr_replaces
-        |cib_op_attr_writes_through,
+        |cib_op_attr_writes_through
+        |cib_op_attr_transaction,
         cib_prepare_data, cib_cleanup_data, cib_process_replace_svr
     },
     {
         PCMK__CIB_REQUEST_CREATE,
-        cib_op_attr_modifies|cib_op_attr_privileged,
+        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
         cib_prepare_data, cib_cleanup_data, cib_process_create
     },
     {
         PCMK__CIB_REQUEST_DELETE,
-        cib_op_attr_modifies|cib_op_attr_privileged,
+        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
         cib_prepare_data, cib_cleanup_data, cib_process_delete
     },
     {
@@ -179,12 +180,15 @@ static const cib_operation_t cib_server_ops[] = {
     },
     {
         PCMK__CIB_REQUEST_BUMP,
-        cib_op_attr_modifies|cib_op_attr_privileged,
+        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
         cib_prepare_none, cib_cleanup_output, cib_process_bump
     },
     {
         PCMK__CIB_REQUEST_ERASE,
-        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_replaces,
+        cib_op_attr_modifies
+        |cib_op_attr_privileged
+        |cib_op_attr_replaces
+        |cib_op_attr_transaction,
         cib_prepare_none, cib_cleanup_output, cib_process_erase
     },
     {
@@ -199,7 +203,10 @@ static const cib_operation_t cib_server_ops[] = {
     },
     {
         PCMK__CIB_REQUEST_UPGRADE,
-        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_writes_through,
+        cib_op_attr_modifies
+        |cib_op_attr_privileged
+        |cib_op_attr_writes_through
+        |cib_op_attr_transaction,
         cib_prepare_none, cib_cleanup_output, cib_process_upgrade_server
     },
     {
@@ -232,6 +239,30 @@ static const cib_operation_t cib_server_ops[] = {
         CRM_OP_PING,
         cib_op_attr_none,
         cib_prepare_none, cib_cleanup_output, cib_process_ping
+    },
+
+    /* PCMK__CIB_REQUEST_*_TRANSACT requests must be processed locally because
+     * they depend on the client table. Requests that manage transactions on
+     * other nodes would likely be problematic in many other ways as well.
+     */
+    {
+        PCMK__CIB_REQUEST_INIT_TRANSACT,
+        cib_op_attr_privileged|cib_op_attr_local,
+        cib_prepare_none, cib_cleanup_none, cib_process_init_transaction,
+    },
+    {
+        PCMK__CIB_REQUEST_COMMIT_TRANSACT,
+        cib_op_attr_modifies
+        |cib_op_attr_privileged
+        |cib_op_attr_local
+        |cib_op_attr_replaces
+        |cib_op_attr_writes_through,
+        cib_prepare_none, cib_cleanup_none, cib_process_commit_transaction,
+    },
+    {
+        PCMK__CIB_REQUEST_DISCARD_TRANSACT,
+        cib_op_attr_privileged|cib_op_attr_local,
+        cib_prepare_none, cib_cleanup_none, cib_process_discard_transaction,
     },
 };
 

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -41,9 +41,10 @@ cib_prepare_common(xmlNode * root, const char *section)
     /* extract the CIB from the fragment */
     if (root == NULL) {
         return NULL;
+    }
 
-    } else if (pcmk__strcase_any_of(crm_element_name(root), XML_TAG_FRAGMENT,
-                                    F_CRM_DATA, F_CIB_CALLDATA, NULL)) {
+    if (pcmk__str_any_of(crm_element_name(root), F_CRM_DATA, F_CIB_CALLDATA,
+                         NULL)) {
         data = first_named_child(root, XML_TAG_CIB);
 
     } else {

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -449,3 +449,134 @@ sync_our_cib(xmlNode * request, gboolean all)
     free(digest);
     return result;
 }
+
+int
+cib_process_init_transaction(const char *op, int options, const char *section,
+                             xmlNode *req, xmlNode *input,
+                             xmlNode *existing_cib, xmlNode **result_cib,
+                             xmlNode **answer)
+{
+    const char *client_id = crm_element_value(req, F_CIB_CLIENTID);
+    pcmk__client_t *client = NULL;
+
+    const char *reason = NULL;
+    int rc = pcmk_ok;
+
+    if (client_id == NULL) {
+        reason = "No client ID";
+        rc = -EINVAL;
+        goto done;
+    }
+
+    client = pcmk__find_client_by_id(client_id);
+    if (client == NULL) {
+        reason = "Client not found";
+        rc = -ENXIO;
+        goto done;
+    }
+
+    rc = based_init_transaction(client);
+
+    if (rc != pcmk_rc_ok) {
+        reason = pcmk_rc_str(rc);
+    }
+    rc = pcmk_rc2legacy(rc);
+
+done:
+    if (rc != pcmk_ok) {
+        const char *client_name = crm_element_value(req, F_CIB_CLIENTNAME);
+
+        crm_err("Could not initiate transaction for client %s (%s): %s",
+                pcmk__s(client_name, "unspecified"),
+                pcmk__s(client_id, "unknown"),
+                pcmk__s(reason, "unknown reason (bug?)"));
+    }
+    return rc;
+}
+
+int
+cib_process_commit_transaction(const char *op, int options, const char *section,
+                               xmlNode *req, xmlNode *input,
+                               xmlNode *existing_cib, xmlNode **result_cib,
+                               xmlNode **answer)
+{
+    /* On success, our caller will activate *result_cib locally, trigger a
+     * replace notification if appropriate, and sync *result_cib to all nodes.
+     * On failure, our caller will free *result_cib.
+     */
+
+    const char *client_id = crm_element_value(req, F_CIB_CLIENTID);
+    pcmk__client_t *client = NULL;
+
+    const char *reason = NULL;
+    int rc = pcmk_ok;
+
+    if (client_id == NULL) {
+        reason = "No client ID";
+        rc = -EINVAL;
+        goto done;
+    }
+
+    client = pcmk__find_client_by_id(client_id);
+    if (client == NULL) {
+        reason = "Client not found";
+        rc = -ENXIO;
+        goto done;
+    }
+
+    rc = based_commit_transaction(client, result_cib);
+    if (rc != pcmk_rc_ok) {
+        reason = pcmk_rc_str(rc);
+        rc = pcmk_rc2legacy(rc);
+    }
+
+done:
+    if (rc != pcmk_ok) {
+        const char *client_name = crm_element_value(req, F_CIB_CLIENTNAME);
+
+        crm_err("Could not commit transaction for client %s (%s): %s",
+                pcmk__s(client_name, "unspecified"),
+                pcmk__s(client_id, "unknown"),
+                pcmk__s(reason, "unknown reason (bug?)"));
+    }
+    return rc;
+}
+
+int
+cib_process_discard_transaction(const char *op, int options,
+                                const char *section, xmlNode *req,
+                                xmlNode *input, xmlNode *existing_cib,
+                                xmlNode **result_cib, xmlNode **answer)
+{
+    const char *client_id = crm_element_value(req, F_CIB_CLIENTID);
+    pcmk__client_t *client = NULL;
+
+    const char *reason = NULL;
+    int rc = pcmk_ok;
+
+    if (client_id == NULL) {
+        reason = "No client ID";
+        rc = -EINVAL;
+        goto done;
+    }
+
+    client = pcmk__find_client_by_id(client_id);
+    if (client == NULL) {
+        reason = "Client not found";
+        rc = -ENXIO;
+        goto done;
+    }
+
+    based_discard_transaction(client);
+
+done:
+    if (rc != pcmk_ok) {
+        const char *client_name = crm_element_value(req, F_CIB_CLIENTNAME);
+
+        crm_err("Could not discard transaction for client %s (%s): %s",
+                pcmk__s(client_name, "unspecified"),
+                pcmk__s(client_id, "unknown"),
+                pcmk__s(reason, "unknown reason (bug?)"));
+    }
+    return rc;
+}

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -396,6 +396,7 @@ cib_remote_connection_destroy(gpointer user_data)
         close(csock);
     }
 
+    based_discard_transaction(client);
     pcmk__free_client(client);
 
     crm_trace("Freed the cib client");

--- a/daemons/based/based_transaction.c
+++ b/daemons/based/based_transaction.c
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2023 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <glib.h>
+#include <libxml/tree.h>
+
+#include "pacemaker-based.h"
+
+struct request_data {
+    pcmk__client_t *client;
+    xmlNodePtr request;
+    bool privileged;
+};
+
+/* Table of uncommitted CIB transactions
+ * key: client ID (const char *), value: GQueue of struct request_data
+ */
+static GHashTable *transactions = NULL;
+
+/*!
+ * \internal
+ * \brief Create a new a CIB request data object
+ *
+ * \param[in] client      CIB client
+ * \param[in] request     CIB request
+ * \param[in] privileged  If \p true, the request has write privileges
+ */
+static struct request_data *
+create_request_data(pcmk__client_t *client, xmlNodePtr request,
+                    bool privileged)
+{
+    struct request_data *data = calloc(1, sizeof(struct request_data));
+
+    if (data == NULL) {
+        return NULL;
+    }
+
+    /* Caller owns client and request. The client's transaction is always
+     * discarded before the client is freed, so we can safely use it when
+     * processing requests in the transaction. The request is freed before we
+     * use it, so make a copy.
+     */
+    data->client = client;
+    data->request = copy_xml(request);
+    data->privileged = privileged;
+
+    return data;
+}
+
+/*!
+ * \internal
+ * \brief Free a CIB request data object
+ *
+ * \param[in,out] data  Request data object to free
+ */
+static void
+free_request_data(gpointer data)
+{
+    struct request_data *req_data = (struct request_data *) data;
+
+    if (req_data != NULL) {
+        // req_data doesn't own req_data->client
+        free_xml(req_data->request);
+        free(req_data);
+    }
+}
+
+/*!
+ * \internal
+ * \brief Free a CIB transaction and the requests it contains
+ *
+ * \param[in,out] data  Transaction to free
+ */
+static inline void
+free_transaction(gpointer data)
+{
+    g_queue_free_full((GQueue *) data, (GDestroyNotify) free_request_data);
+}
+
+/*!
+ * \internal
+ * \brief Get a CIB client's uncommitted transaction, if any
+ *
+ * \param[in] client  Client to look up
+ *
+ * \return The client's uncommitted transaction, if any
+ *
+ * \note The caller must not free the return value directly. Transactions must
+ *       be freed by \p based_discard_transaction() or by
+ *       \p based_free_transaction_table().
+ */
+static inline GQueue *
+get_transaction(const pcmk__client_t *client)
+{
+    if (transactions == NULL) {
+        return NULL;
+    }
+    return g_hash_table_lookup(transactions, client->id);
+}
+
+/*!
+ * \internal
+ * \brief Create a new transaction for a given CIB client
+ *
+ * \param[in] client  Client to initiate a transaction for
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+based_init_transaction(const pcmk__client_t *client)
+{
+    CRM_ASSERT(client != NULL);
+
+    if (client->id == NULL) {
+        crm_warn("Can't initiate transaction for client without id");
+        return EINVAL;
+    }
+
+    // A client can have at most one transaction at a time
+    if (get_transaction(client) != NULL) {
+        return pcmk_rc_already;
+    }
+
+    crm_trace("Initiating transaction for client %s (%s)",
+              pcmk__client_name(client), client->id);
+
+    if (transactions == NULL) {
+        transactions = pcmk__strkey_table(NULL, free_transaction);
+    }
+    g_hash_table_insert(transactions, client->id, g_queue_new());
+    return pcmk_rc_ok;
+}
+
+/*!
+ * \internal
+ * \brief Validate that a CIB request is supported in a transaction
+ *
+ * \param[in] request  CIB request
+ *
+ * \return Standard Pacemaker return code
+ */
+static int
+validate_transaction_request(const xmlNode *request)
+{
+    const char *op = crm_element_value(request, F_CIB_OPERATION);
+    const char *host = crm_element_value(request, F_CIB_HOST);
+
+    const cib_operation_t *operation = NULL;
+    int rc = cib_get_operation(op, &operation);
+
+    rc = pcmk_legacy2rc(rc);
+    if (rc != pcmk_rc_ok) {
+        // cib_get_operation() logs error
+        return rc;
+    }
+
+    if (!pcmk_is_set(operation->flags, cib_op_attr_transaction)) {
+        crm_err("Operation '%s' is not supported in CIB transaction", op);
+        return EOPNOTSUPP;
+    }
+
+    if (!pcmk__str_eq(host, OUR_NODENAME,
+                      pcmk__str_casei|pcmk__str_null_matches)) {
+        crm_err("Operation targeting another node (%s) is not supported in CIB "
+                "transaction",
+                host);
+        return EOPNOTSUPP;
+    }
+
+    return pcmk_rc_ok;
+}
+
+/*!
+ * \internal
+ * \brief Add a new CIB request to an existing transaction
+ *
+ * \param[in] client      Client whose transaction to extend
+ * \param[in] request     CIB request
+ * \param[in] privileged  If \p true, the request has write privileges
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+based_extend_transaction(pcmk__client_t *client, xmlNodePtr request,
+                         bool privileged)
+{
+    struct request_data *data = NULL;
+    GQueue *transaction = NULL;
+    int rc = pcmk_rc_ok;
+
+    CRM_ASSERT((client != NULL) && (request != NULL));
+
+    transaction = get_transaction(client);
+    if (transaction == NULL) {
+        return pcmk_rc_no_transaction;
+    }
+
+    rc = validate_transaction_request(request);
+    if (rc != pcmk_rc_ok) {
+        return rc;
+    }
+
+    data = create_request_data(client, request, privileged);
+    if (data == NULL) {
+        return ENOMEM;
+    }
+
+    g_queue_push_tail(transaction, data);
+    return pcmk_rc_ok;
+}
+
+/*!
+ * \internal
+ * \brief Free a CIB client's transaction (if any) and its requests
+ *
+ * \param[in] client  Client whose transaction to discard
+ */
+void
+based_discard_transaction(const pcmk__client_t *client)
+{
+    bool found = false;
+
+    CRM_ASSERT(client != NULL);
+
+    if (transactions != NULL) {
+        found = g_hash_table_remove(transactions, client->id);
+    }
+
+    crm_trace("%s for client %s (%s)",
+              (found? "Found and removed transaction" : "No transaction found"),
+              pcmk__client_name(client),
+              pcmk__s(client->id, "unidentified"));
+}
+
+/*!
+ * \internal
+ * \brief Process requests in a transaction
+ *
+ * Stop when a request fails or when all requests have been processed.
+ *
+ * \param[in,out] transaction  Transaction to process
+ * \param[in]     client_name  Client name (for logging only)
+ * \param[in]     client_id    Client ID (for logging only)
+ *
+ * \return Standard Pacemaker return code
+ */
+static int
+process_transaction_requests(GQueue *transaction, const char *client_name,
+                             const char *client_id)
+{
+    for (struct request_data *data = g_queue_pop_head(transaction);
+         data != NULL; data = g_queue_pop_head(transaction)) {
+
+        const char *op = crm_element_value(data->request, F_CIB_OPERATION);
+
+        int rc = cib_process_request(data->request, data->privileged,
+                                     data->client);
+
+        rc = pcmk_legacy2rc(rc);
+        if (rc != pcmk_rc_ok) {
+            crm_err("Aborting CIB transaction for client %s (%s) due to failed "
+                    "%s request: %s",
+                    client_name, client_id, op, pcmk_rc_str(rc));
+            crm_log_xml_info(data->request, "Failed request");
+            free_request_data(data);
+            return rc;
+        }
+
+        crm_trace("Applied %s request to transaction working CIB for client %s "
+                  "(%s)",
+                  op, client_name, client_id);
+        crm_log_xml_trace(data->request, "Successful request");
+        free_request_data(data);
+    }
+
+    return pcmk_rc_ok;
+}
+
+/*!
+ * \internal
+ * \brief Commit a given CIB client's transaction to a working CIB copy
+ *
+ * \param[in]     client      Client whose transaction to commit
+ * \param[in,out] result_cib  Where to store result CIB
+ *
+ * \return Standard Pacemaker return code
+ *
+ * \note This function is expected to be called only by
+ *       \p cib_process_commit_transaction().
+ * \note \p result_cib is expected to be a copy of the current CIB as created by
+ *       \p cib_perform_op().
+ * \note The caller is responsible for activating and syncing \p result_cib on
+ *       success, and for freeing it on failure.
+ */
+int
+based_commit_transaction(const pcmk__client_t *client, xmlNodePtr *result_cib)
+{
+    GQueue *transaction = NULL;
+    const char *client_name = NULL;
+    const char *client_id = NULL;
+    xmlNodePtr saved_cib = the_cib;
+    int rc = pcmk_rc_ok;
+
+    CRM_ASSERT((client != NULL) && (result_cib != NULL));
+
+    /* *result_cib should be a copy of the_cib (created by cib_perform_op()). If
+     * not, make a copy now. Change tracking isn't strictly required here
+     * because:
+     * * Each request in the transaction will have changes tracked and ACLs
+     *   checked if appropriate.
+     * * cib_perform_op() will infer changes for the commit request at the end.
+     */
+    CRM_CHECK((*result_cib != NULL) && (*result_cib != the_cib),
+              *result_cib = copy_xml(the_cib));
+
+    transaction = get_transaction(client);
+    if (transaction == NULL) {
+        return pcmk_rc_no_transaction;
+    }
+
+    client_name = pcmk__client_name(client);
+    client_id = pcmk__s(client->id, "unidentified");
+
+    crm_trace("Committing transaction for client %s (%s) to working CIB",
+              client_name, client_id);
+
+    // Apply all changes to a working copy of the CIB
+    the_cib = *result_cib;
+
+    rc = process_transaction_requests(transaction, client_name, client_id);
+
+    crm_trace("Transaction commit %s for client %s (%s); discarding queue",
+              ((rc != pcmk_rc_ok)? "succeeded" : "failed"), client_name,
+              client_id);
+
+    // Free the transaction and (if aborted) free any remaining requests
+    based_discard_transaction(client);
+
+    /* Some request types (for example, erase) may have freed the_cib (the
+     * working copy) and pointed it at a new XML object. In that case, it
+     * follows that *result_cib (the working copy) was freed.
+     *
+     * Point *result_cib at the updated working copy stored in the_cib.
+     */
+    *result_cib = the_cib;
+
+    // Point the_cib back to the unchanged original copy
+    the_cib = saved_cib;
+
+    return rc;
+}
+
+/*!
+ * \internal
+ * \brief Free the transaction table and any uncommitted transactions
+ */
+void
+based_free_transaction_table(void)
+{
+    if (transactions != NULL) {
+        g_hash_table_destroy(transactions);
+    }
+}

--- a/daemons/based/based_transaction.h
+++ b/daemons/based/based_transaction.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef BASED_TRANSACTION__H
+#define BASED_TRANSACTION__H
+
+#include <crm_internal.h>
+
+#include <libxml/tree.h>
+
+int based_init_transaction(const pcmk__client_t *client);
+int based_extend_transaction(pcmk__client_t *client, xmlNodePtr request,
+                             bool privileged);
+void based_discard_transaction(const pcmk__client_t *client);
+int based_commit_transaction(const pcmk__client_t *client,
+                             xmlNodePtr *result_cib);
+void based_free_transaction_table(void);
+
+#endif // BASED_TRANSACTION__H

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -292,6 +292,7 @@ done:
     if (config_hash != NULL) {
         g_hash_table_destroy(config_hash);
     }
+    based_free_transaction_table();
     pcmk__client_cleanup();
     pcmk_cluster_free(crm_cluster);
     g_free(cib_root);

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -30,6 +30,8 @@
 #  include <gnutls/gnutls.h>
 #endif
 
+#define OUR_NODENAME (stand_alone? "localhost" : crm_cluster->uname)
+
 // CIB-specific client flags
 enum cib_client_flags {
     // Notifications

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -47,29 +47,6 @@ enum cib_client_flags {
     cib_is_daemon      = (UINT64_C(1) << 12),
 };
 
-/*!
- * \internal
- * \enum cib_op_attr
- * \brief Bit flags for CIB operation attributes
- */
-enum cib_op_attr {
-    cib_op_attr_none           = 0,         //!< No special attributes
-    cib_op_attr_modifies       = (1 << 1),  //!< Modifies CIB
-    cib_op_attr_privileged     = (1 << 2),  //!< Requires privileges
-    cib_op_attr_local          = (1 << 3),  //!< Must only be processed locally
-    cib_op_attr_replaces       = (1 << 4),  //!< Replaces CIB
-    cib_op_attr_writes_through = (1 << 5),  //!< Writes to disk on success
-    cib_op_attr_transaction    = (1 << 6),  //!< Supported in a transaction
-};
-
-typedef struct cib_operation_s {
-    const char *name;
-    uint32_t flags; //!< Group of <tt>enum cib_op_attr</tt> flags
-    int (*prepare) (xmlNode *, xmlNode **, const char **);
-    int (*cleanup) (int, xmlNode **, xmlNode **);
-    cib_op_t fn;
-} cib_operation_t;
-
 extern bool based_is_primary;
 extern GHashTable *config_hash;
 extern xmlNode *the_cib;

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -26,6 +26,8 @@
 #include <crm/common/mainloop.h>
 #include <crm/cib/internal.h>
 
+#include "based_transaction.h"
+
 #ifdef HAVE_GNUTLS_GNUTLS_H
 #  include <gnutls/gnutls.h>
 #endif
@@ -57,6 +59,7 @@ enum cib_op_attr {
     cib_op_attr_local          = (1 << 3),  //!< Must only be processed locally
     cib_op_attr_replaces       = (1 << 4),  //!< Replaces CIB
     cib_op_attr_writes_through = (1 << 5),  //!< Writes to disk on success
+    cib_op_attr_transaction    = (1 << 6),  //!< Supported in a transaction
 };
 
 typedef struct cib_operation_s {
@@ -137,6 +140,18 @@ int cib_process_upgrade_server(const char *op, int options, const char *section,
                                xmlNode *req, xmlNode *input,
                                xmlNode *existing_cib, xmlNode **result_cib,
                                xmlNode **answer);
+int cib_process_init_transaction(const char *op, int options,
+                                 const char *section, xmlNode *req,
+                                 xmlNode *input, xmlNode *existing_cib,
+                                 xmlNode **result_cib, xmlNode **answer);
+int cib_process_commit_transaction(const char *op, int options,
+                                   const char *section, xmlNode *req,
+                                   xmlNode *input, xmlNode *existing_cib,
+                                   xmlNode **result_cib, xmlNode **answer);
+int cib_process_discard_transaction(const char *op, int options,
+                                    const char *section, xmlNode *req,
+                                    xmlNode *input, xmlNode *existing_cib,
+                                    xmlNode **result_cib, xmlNode **answer);
 void send_sync_request(const char *host);
 int sync_our_cib(xmlNode *request, gboolean all);
 

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -93,6 +93,8 @@ void cib_peer_callback(xmlNode *msg, void *private_data);
 void cib_common_callback_worker(uint32_t id, uint32_t flags,
                                 xmlNode *op_request, pcmk__client_t *cib_client,
                                 gboolean privileged);
+int cib_process_request(xmlNode *request, gboolean privileged,
+                        const pcmk__client_t *cib_client);
 void cib_shutdown(int nsig);
 void terminate_cib(const char *caller, int fast);
 gboolean cib_legacy_mode(void);

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -222,9 +222,6 @@ typedef struct cib_api_operations_s {
      *
      * \return Legacy Pacemaker return code
      *
-     * \note The client IDs are assigned by \p pacemaker-based when the client
-     *       connects. \p cib_t variants that don't connect to
-     *       \p pacemaker-based may never be assigned a client ID.
      * \note Some variants may have only one client for both asynchronous and
      *       synchronous requests.
      */

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -86,7 +86,12 @@ enum cib_call_options {
 
     cib_sync_call       = (1 << 12),
     cib_no_mtime        = (1 << 13),
+
+#if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+    //! \deprecated This value will be removed in a future release
     cib_zero_copy       = (1 << 14),
+#endif // !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+
     cib_inhibit_notify  = (1 << 16),
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -80,6 +80,10 @@ enum cib_call_options {
     cib_scope_local     = (1 << 8),
 
     cib_dryrun          = (1 << 9),
+
+    //! Add request to the client's CIB transaction instead of processing
+    cib_transaction     = (1 << 10),
+
     cib_sync_call       = (1 << 12),
     cib_no_mtime        = (1 << 13),
     cib_zero_copy       = (1 << 14),

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -31,6 +31,9 @@
 #define PCMK__CIB_REQUEST_ABS_DELETE    "cib_delete_alt"
 #define PCMK__CIB_REQUEST_NOOP          "noop"
 #define PCMK__CIB_REQUEST_SHUTDOWN      "cib_shutdown_req"
+#define PCMK__CIB_REQUEST_INIT_TRANSACT     "cib_init_transact"
+#define PCMK__CIB_REQUEST_COMMIT_TRANSACT   "cib_commit_transact"
+#define PCMK__CIB_REQUEST_DISCARD_TRANSACT  "cib_discard_transact"
 
 #  define F_CIB_CLIENTID  "cib_clientid"
 #  define F_CIB_CALLOPTS  "cib_callopt"

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -141,11 +141,11 @@ typedef int (*cib_op_t) (const char *, int, const char *, xmlNode *,
 
 cib_t *cib_new_variant(void);
 
-int cib_perform_op(const char *op, int call_options, cib_op_t fn, gboolean is_query,
-                   const char *section, xmlNode * req, xmlNode * input,
-                   gboolean manage_counters, gboolean * config_changed,
-                   xmlNode * current_cib, xmlNode ** result_cib, xmlNode ** diff,
-                   xmlNode ** output);
+int cib_perform_op(const char *op, int call_options, cib_op_t fn,
+                   gboolean is_query, const char *section, xmlNode *req,
+                   xmlNode *input, gboolean manage_counters,
+                   gboolean *config_changed, xmlNode **current_cib,
+                   xmlNode **result_cib, xmlNode **diff, xmlNode **output);
 
 xmlNode *cib_create_op(int call_id, const char *op, const char *host,
                        const char *section, xmlNode * data, int call_options,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -145,10 +145,10 @@ typedef int (*cib_op_t) (const char *, int, const char *, xmlNode *,
 cib_t *cib_new_variant(void);
 
 int cib_perform_op(const char *op, int call_options, cib_op_t fn,
-                   gboolean is_query, const char *section, xmlNode *req,
-                   xmlNode *input, gboolean manage_counters,
-                   gboolean *config_changed, xmlNode **current_cib,
-                   xmlNode **result_cib, xmlNode **diff, xmlNode **output);
+                   bool is_query, const char *section, xmlNode *req,
+                   xmlNode *input, bool manage_counters, bool *config_changed,
+                   xmlNode **current_cib, xmlNode **result_cib, xmlNode **diff,
+                   xmlNode **output);
 
 xmlNode *cib_create_op(int call_id, const char *op, const char *host,
                        const char *section, xmlNode * data, int call_options,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -86,6 +86,21 @@ enum cib_change_section_info {
 
 /*!
  * \internal
+ * \enum cib_op_attr
+ * \brief Flags for CIB operation attributes
+ */
+enum cib_op_attr {
+    cib_op_attr_none           = 0,         //!< No special attributes
+    cib_op_attr_modifies       = (1 << 1),  //!< Modifies CIB
+    cib_op_attr_privileged     = (1 << 2),  //!< Requires privileges
+    cib_op_attr_local          = (1 << 3),  //!< Must only be processed locally
+    cib_op_attr_replaces       = (1 << 4),  //!< Replaces CIB
+    cib_op_attr_writes_through = (1 << 5),  //!< Writes to disk on success
+    cib_op_attr_transaction    = (1 << 6),  //!< Supported in a transaction
+};
+
+/*!
+ * \internal
  * \brief Set given <tt>enum cib_change_section_info</tt> flags
  *
  * \param[in,out] flags_orig    Group of flags to update
@@ -102,6 +117,17 @@ gboolean cib_diff_version_details(xmlNode * diff, int *admin_epoch, int *epoch, 
                                   int *_admin_epoch, int *_epoch, int *_updates);
 
 gboolean cib_read_config(GHashTable * options, xmlNode * current_cib);
+
+typedef int (*cib_op_t) (const char *, int, const char *, xmlNode *,
+                         xmlNode *, xmlNode *, xmlNode **, xmlNode **);
+
+typedef struct cib_operation_s {
+    const char *name;
+    uint32_t flags; //!< Group of <tt>enum cib_op_attr</tt> flags
+    int (*prepare) (xmlNode *, xmlNode **, const char **);
+    int (*cleanup) (int, xmlNode **, xmlNode **);
+    cib_op_t fn;
+} cib_operation_t;
 
 typedef struct cib_notify_client_s {
     const char *event;
@@ -138,9 +164,6 @@ struct timer_rec_s {
             LOG_TRACE, "CIB call", (call_for), (cib_call_opts),                \
             (flags_to_clear), #flags_to_clear);                                \
     } while (0)
-
-typedef int (*cib_op_t) (const char *, int, const char *, xmlNode *,
-                         xmlNode *, xmlNode *, xmlNode **, xmlNode **);
 
 cib_t *cib_new_variant(void);
 

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -108,6 +108,7 @@ enum pcmk_rc_e {
     /* When adding new values, use consecutively lower numbers, update the array
      * in lib/common/results.c, and test with crm_error.
      */
+    pcmk_rc_no_transaction      = -1037,
     pcmk_rc_bad_xml_patch       = -1036,
     pcmk_rc_bad_input           = -1035,
     pcmk_rc_disabled            = -1034,

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -183,8 +183,6 @@ extern "C" {
 #  define XML_PING_ATTR_PACEMAKERDSTATE_SHUTDOWNCOMPLETE "shutdown_complete"
 #  define XML_PING_ATTR_PACEMAKERDSTATE_REMOTE "remote"
 
-#  define XML_TAG_FRAGMENT		"cib_fragment"
-
 #  define XML_FAIL_TAG_CIB		"failed_update"
 
 #  define XML_FAILCIB_ATTR_ID		"id"

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -47,6 +47,9 @@ extern "C" {
 #define XML_ATTR_RA_VERSION "ra-version"
 
 //! \deprecated Do not use (will be removed in a future release)
+#define XML_TAG_FRAGMENT "cib_fragment"
+
+//! \deprecated Do not use (will be removed in a future release)
 #define XML_TAG_RSC_VER_ATTRS "rsc_versioned_attrs"
 
 //! \deprecated Do not use (will be removed in a future release)

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -387,6 +387,28 @@ cib_client_erase(cib_t * cib, xmlNode ** output_data, int call_options)
                            output_data, call_options, NULL);
 }
 
+static int
+cib_client_init_transaction(cib_t *cib, int call_options)
+{
+    op_common(cib);
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_INIT_TRANSACT, NULL, NULL,
+                           NULL, NULL, call_options, NULL);
+}
+
+static int
+cib_client_end_transaction(cib_t *cib, bool commit, int call_options)
+{
+    op_common(cib);
+
+    if (commit) {
+        return cib_internal_op(cib, PCMK__CIB_REQUEST_COMMIT_TRANSACT, NULL,
+                               NULL, NULL, NULL, call_options, NULL);
+    } else {
+        return cib_internal_op(cib, PCMK__CIB_REQUEST_DISCARD_TRANSACT, NULL,
+                               NULL, NULL, NULL, call_options, NULL);
+    }
+}
+
 static void
 cib_destroy_op_callback(gpointer data)
 {
@@ -660,6 +682,9 @@ cib_new_variant(void)
 
     // Deprecated method
     new_cib->cmds->delete_absolute = cib_client_delete_absolute;
+
+    new_cib->cmds->init_transaction = cib_client_init_transaction;
+    new_cib->cmds->end_transaction = cib_client_end_transaction;
 
     return new_cib;
 }

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -317,8 +317,10 @@ cib_file_process_request(cib_t *cib, xmlNode *request, xmlNode **output)
         pcmk__output_free(out);
         rc = pcmk_ok;
 
-        free_xml(private->cib_xml);
-        private->cib_xml = result_cib;
+        if (result_cib != private->cib_xml) {
+            free_xml(private->cib_xml);
+            private->cib_xml = result_cib;
+        }
         cib_set_file_flags(private, cib_file_flag_dirty);
     }
 

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -376,10 +376,15 @@ cib_file_perform_op_delegate(cib_t *cib, const char *op, const char *host,
     rc = cib_file_process_request(cib, request, &output);
 
     if ((output_data != NULL) && (output != NULL)) {
-        *output_data = (output == private->cib_xml)? copy_xml(output) : output;
+        if (output->doc == private->cib_xml->doc) {
+            *output_data = copy_xml(output);
+        } else {
+            *output_data = output;
+        }
     }
 
-    if ((output != private->cib_xml)
+    if ((output != NULL)
+        && (output->doc != private->cib_xml->doc)
         && ((output_data == NULL) || (output != *output_data))) {
 
         free_xml(output);

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -186,8 +186,8 @@ cib_file_perform_op_delegate(cib_t *cib, const char *op, const char *host,
         data = pcmk_find_cib_element(data, section);
     }
 
-    rc = cib_perform_op(op, call_options, fn, query,
-                        section, request, data, TRUE, &changed, in_mem_cib, &result_cib, &cib_diff,
+    rc = cib_perform_op(op, call_options, fn, query, section, request, data,
+                        TRUE, &changed, &in_mem_cib, &result_cib, &cib_diff,
                         &output);
 
     free_xml(request);

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -49,20 +49,20 @@ typedef struct cib_file_opaque_s {
 
 struct cib_func_entry {
     const char *op;
-    gboolean read_only;
+    bool read_only;
     cib_op_t fn;
 };
 
 static struct cib_func_entry cib_file_ops[] = {
-    { PCMK__CIB_REQUEST_QUERY,       TRUE,   cib_process_query },
-    { PCMK__CIB_REQUEST_MODIFY,      FALSE,  cib_process_modify },
-    { PCMK__CIB_REQUEST_APPLY_PATCH, FALSE,  cib_process_diff },
-    { PCMK__CIB_REQUEST_BUMP,        FALSE,  cib_process_bump },
-    { PCMK__CIB_REQUEST_REPLACE,     FALSE,  cib_process_replace },
-    { PCMK__CIB_REQUEST_CREATE,      FALSE,  cib_process_create },
-    { PCMK__CIB_REQUEST_DELETE,      FALSE,  cib_process_delete },
-    { PCMK__CIB_REQUEST_ERASE,       FALSE,  cib_process_erase },
-    { PCMK__CIB_REQUEST_UPGRADE,     FALSE,  cib_process_upgrade },
+    { PCMK__CIB_REQUEST_QUERY,       true,   cib_process_query },
+    { PCMK__CIB_REQUEST_MODIFY,      false,  cib_process_modify },
+    { PCMK__CIB_REQUEST_APPLY_PATCH, false,  cib_process_diff },
+    { PCMK__CIB_REQUEST_BUMP,        false,  cib_process_bump },
+    { PCMK__CIB_REQUEST_REPLACE,     false,  cib_process_replace },
+    { PCMK__CIB_REQUEST_CREATE,      false,  cib_process_create },
+    { PCMK__CIB_REQUEST_DELETE,      false,  cib_process_delete },
+    { PCMK__CIB_REQUEST_ERASE,       false,  cib_process_erase },
+    { PCMK__CIB_REQUEST_UPGRADE,     false,  cib_process_upgrade },
 };
 
 static xmlNode *in_mem_cib = NULL;
@@ -132,8 +132,8 @@ cib_file_perform_op_delegate(cib_t *cib, const char *op, const char *host,
 {
     int rc = pcmk_ok;
     char *effective_user = NULL;
-    gboolean query = FALSE;
-    gboolean changed = FALSE;
+    bool query = false;
+    bool changed = false;
     xmlNode *request = NULL;
     xmlNode *output = NULL;
     xmlNode *cib_diff = NULL;
@@ -187,7 +187,7 @@ cib_file_perform_op_delegate(cib_t *cib, const char *op, const char *host,
     }
 
     rc = cib_perform_op(op, call_options, fn, query, section, request, data,
-                        TRUE, &changed, &in_mem_cib, &result_cib, &cib_diff,
+                        true, &changed, &in_mem_cib, &result_cib, &cib_diff,
                         &output);
 
     free_xml(request);
@@ -198,7 +198,7 @@ cib_file_perform_op_delegate(cib_t *cib, const char *op, const char *host,
     if (rc != pcmk_ok) {
         free_xml(result_cib);
 
-    } else if (query == FALSE) {
+    } else if (!query) {
         pcmk__output_t *out = NULL;
 
         rc = pcmk_rc2legacy(pcmk__log_output_new(&out));

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -107,12 +107,14 @@ cib_process_erase(const char *op, int options, const char *section, xmlNode * re
     int result = pcmk_ok;
 
     crm_trace("Processing \"%s\" event", op);
-    *answer = NULL;
-    free_xml(*result_cib);
-    *result_cib = createEmptyCib(0);
 
+    if (*result_cib != existing_cib) {
+        free_xml(*result_cib);
+    }
+    *result_cib = createEmptyCib(0);
     copy_in_properties(*result_cib, existing_cib);
     update_counter(*result_cib, XML_ATTR_GENERATION_ADMIN, false);
+    *answer = NULL;
 
     return result;
 }
@@ -262,7 +264,9 @@ cib_process_replace(const char *op, int options, const char *section, xmlNode * 
                      replace_admin_epoch, replace_epoch, replace_updates, peer);
         }
 
-        free_xml(*result_cib);
+        if (*result_cib != existing_cib) {
+            free_xml(*result_cib);
+        }
         *result_cib = copy_xml(input);
 
     } else {
@@ -646,8 +650,11 @@ cib_process_diff(const char *op, int options, const char *section, xmlNode * req
               op, originator,
               (pcmk_is_set(options, cib_force_diff)? " (global update)" : ""));
 
-    free_xml(*result_cib);
+    if (*result_cib != existing_cib) {
+        free_xml(*result_cib);
+    }
     *result_cib = copy_xml(existing_cib);
+
     return xml_apply_patchset(*result_cib, input, TRUE);
 }
 

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -142,14 +142,14 @@ cib_acl_enabled(xmlNode *xml, const char *user)
 }
 
 int
-cib_perform_op(const char *op, int call_options, cib_op_t fn, gboolean is_query,
+cib_perform_op(const char *op, int call_options, cib_op_t fn, bool is_query,
                const char *section, xmlNode *req, xmlNode *input,
-               gboolean manage_counters, gboolean *config_changed,
+               bool manage_counters, bool *config_changed,
                xmlNode **current_cib, xmlNode **result_cib, xmlNode **diff,
                xmlNode **output)
 {
     int rc = pcmk_ok;
-    gboolean check_schema = TRUE;
+    bool check_schema = true;
     xmlNode *top = NULL;
     xmlNode *scratch = NULL;
     xmlNode *patchset_cib = NULL;
@@ -157,7 +157,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t fn, gboolean is_query,
 
     const char *new_version = NULL;
     const char *user = crm_element_value(req, F_CIB_USER);
-    bool with_digest = FALSE;
+    bool with_digest = false;
 
     pcmk__output_t *out = NULL;
     int out_rc = pcmk_rc_no_output;
@@ -176,7 +176,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t fn, gboolean is_query,
     }
 
     *result_cib = NULL;
-    *config_changed = FALSE;
+    *config_changed = false;
 
     if (fn == NULL) {
         return -EINVAL;
@@ -249,7 +249,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t fn, gboolean is_query,
         rc = (*fn) (op, call_options, section, req, input, *current_cib,
                     &scratch, output);
 
-        if(scratch && xml_tracking_changes(scratch) == FALSE) {
+        if ((scratch != NULL) && !xml_tracking_changes(scratch)) {
             crm_trace("Inferring changes after %s op", op);
             xml_track_changes(scratch, user, *current_cib,
                               cib_acl_enabled(*current_cib, user));
@@ -322,8 +322,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t fn, gboolean is_query,
          * format only needs it for the top-level version fields
          */
         local_diff = xml_create_patchset(2, patchset_cib, scratch,
-                                         (bool*) config_changed,
-                                         manage_counters);
+                                         config_changed, manage_counters);
 
     } else {
         static time_t expires = 0;
@@ -331,12 +330,11 @@ cib_perform_op(const char *op, int call_options, cib_op_t fn, gboolean is_query,
 
         if (expires < tm_now) {
             expires = tm_now + 60;  /* Validate clients are correctly applying v2-style diffs at most once a minute */
-            with_digest = TRUE;
+            with_digest = true;
         }
 
         local_diff = xml_create_patchset(0, patchset_cib, scratch,
-                                         (bool*) config_changed,
-                                         manage_counters);
+                                         config_changed, manage_counters);
     }
 
     // Create a log output object only if we're going to use it
@@ -408,7 +406,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t fn, gboolean is_query,
          * a) we don't really care whats in the status section
          * b) we don't validate any of its contents at the moment anyway
          */
-        check_schema = FALSE;
+        check_schema = false;
     }
 
     /* === scratch must not be modified after this point ===
@@ -449,7 +447,7 @@ cib_perform_op(const char *op, int call_options, cib_op_t fn, gboolean is_query,
     }
 
     crm_trace("Perform validation: %s", pcmk__btoa(check_schema));
-    if ((rc == pcmk_ok) && check_schema && !validate_xml(scratch, NULL, TRUE)) {
+    if ((rc == pcmk_ok) && check_schema && !validate_xml(scratch, NULL, true)) {
         const char *current_schema = crm_element_value(scratch,
                                                        XML_ATTR_VALIDATION);
 

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -305,6 +305,10 @@ static const struct pcmk__rc_info {
       "Bad XML patch format",
       -pcmk_err_generic,
     },
+    { "pcmk_rc_no_transaction",
+      "No active transaction found",
+      -pcmk_err_generic,
+    },
 };
 
 /*!
@@ -759,6 +763,7 @@ pcmk_rc2exitc(int rc)
         case ENODEV:
         case ENOENT:
         case ENXIO:
+        case pcmk_rc_no_transaction:
         case pcmk_rc_unknown_format:
             return CRM_EX_NOSUCH;
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -850,7 +850,6 @@ copy_xml(xmlNode * src)
 
     CRM_ASSERT(copy != NULL);
     xmlDocSetRootElement(doc, copy);
-    xmlSetTreeDoc(copy, doc);
     return copy;
 }
 


### PR DESCRIPTION
This pull request adds a new feature: atomic CIB transactions. It adds `init_transaction()` and `end_transaction()` methods to `cib_api_operations_t`. Transactions are supported for all three variants of `cib_t` clients: native, file, and remote. Native and remote share an implementation.

The basic idea is that a client can initiate a transaction, append requests to the transaction, and either commit or discard the transaction. Requests that are appended (via the `cib_transaction` value of `enum cib_call_options`) get queued until the transaction is committed. When a transaction is committed, all requests are processed in FIFO order. If any request fails, the transaction is aborted, and the CIB is left in its initial state. The CIB is modified only if all requests in the transaction succeed.

Supported requests are those that meet the following conditions:
* can be processed synchronously (with any changes applied to a working CIB copy)
* are not queries
* do not involve other nodes
* do not affect the state of pacemaker-based itself

In other words, the same types of requests are supported both in CIB file requests and in transactions.

(The following paragraph applies only to native and remote clients.) Replies are sent when a request is added to a transaction, **not** when the request is processed. This means callbacks are run at the client side after `pacemaker-based` tries to add the request to the transaction. Notifications are also not sent for individual requests. However, replies and notifications work normally for "commit-transaction" requests, and replies work normally for "init-transaction" and "discard-transaction" requests (which don't modify the CIB).