### PR TITLE
Support start state on remote nodes

### DIFF
--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -195,32 +195,31 @@ join_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *
     free_xml(generation);
 }
 
-static void
-set_join_state(const char * start_state)
+void
+set_join_state(const char *start_state, const char *node_name, const char *node_uuid)
 {
     if (pcmk__str_eq(start_state, "standby", pcmk__str_casei)) {
         crm_notice("Forcing node %s to join in %s state per configured "
-                   "environment", controld_globals.our_nodename, start_state);
+                   "environment", node_name, start_state);
         cib__update_node_attr(controld_globals.logger_out,
                               controld_globals.cib_conn, cib_sync_call,
-                              XML_CIB_TAG_NODES, controld_globals.our_uuid,
+                              XML_CIB_TAG_NODES, node_uuid,
                               NULL, NULL, NULL, "standby", "on", NULL, NULL);
 
     } else if (pcmk__str_eq(start_state, "online", pcmk__str_casei)) {
         crm_notice("Forcing node %s to join in %s state per configured "
-                   "environment", controld_globals.our_nodename, start_state);
+                   "environment", node_name, start_state);
         cib__update_node_attr(controld_globals.logger_out,
                               controld_globals.cib_conn, cib_sync_call,
-                              XML_CIB_TAG_NODES, controld_globals.our_uuid,
+                              XML_CIB_TAG_NODES, node_uuid,
                               NULL, NULL, NULL, "standby", "off", NULL, NULL);
 
     } else if (pcmk__str_eq(start_state, "default", pcmk__str_casei)) {
-        crm_debug("Not forcing a starting state on node %s",
-                  controld_globals.our_nodename);
+        crm_debug("Not forcing a starting state on node %s", node_name);
 
     } else {
         crm_warn("Unrecognized start state '%s', using 'default' (%s)",
-                 start_state, controld_globals.our_nodename);
+                 start_state, node_name);
     }
 }
 
@@ -335,7 +334,8 @@ do_cl_join_finalize_respond(long long action,
 
             first_join = FALSE;
             if (start_state) {
-                set_join_state(start_state);
+                set_join_state(start_state, controld_globals.our_nodename,
+                               controld_globals.our_uuid);
             }
         }
 

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -196,7 +196,8 @@ join_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *
 }
 
 void
-set_join_state(const char *start_state, const char *node_name, const char *node_uuid)
+set_join_state(const char *start_state, const char *node_name, const char *node_uuid,
+               bool remote)
 {
     if (pcmk__str_eq(start_state, "standby", pcmk__str_casei)) {
         crm_notice("Forcing node %s to join in %s state per configured "
@@ -204,7 +205,8 @@ set_join_state(const char *start_state, const char *node_name, const char *node_
         cib__update_node_attr(controld_globals.logger_out,
                               controld_globals.cib_conn, cib_sync_call,
                               XML_CIB_TAG_NODES, node_uuid,
-                              NULL, NULL, NULL, "standby", "on", NULL, NULL);
+                              NULL, NULL, NULL, "standby", "on", NULL,
+                              remote ? "remote" : NULL);
 
     } else if (pcmk__str_eq(start_state, "online", pcmk__str_casei)) {
         crm_notice("Forcing node %s to join in %s state per configured "
@@ -212,7 +214,8 @@ set_join_state(const char *start_state, const char *node_name, const char *node_
         cib__update_node_attr(controld_globals.logger_out,
                               controld_globals.cib_conn, cib_sync_call,
                               XML_CIB_TAG_NODES, node_uuid,
-                              NULL, NULL, NULL, "standby", "off", NULL, NULL);
+                              NULL, NULL, NULL, "standby", "off", NULL,
+                              remote ? "remote" : NULL);
 
     } else if (pcmk__str_eq(start_state, "default", pcmk__str_casei)) {
         crm_debug("Not forcing a starting state on node %s", node_name);
@@ -335,7 +338,7 @@ do_cl_join_finalize_respond(long long action,
             first_join = FALSE;
             if (start_state) {
                 set_join_state(start_state, controld_globals.our_nodename,
-                               controld_globals.our_uuid);
+                               controld_globals.our_uuid, false);
             }
         }
 

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -36,4 +36,7 @@ void controld_remove_voter(const char *uname);
 void controld_election_fini(void);
 void controld_stop_current_election_timeout(void);
 
+void set_join_state(const char *start_state, const char *node_name,
+                    const char *node_uuid);
+
 #endif

--- a/daemons/controld/pacemaker-controld.h
+++ b/daemons/controld/pacemaker-controld.h
@@ -37,6 +37,6 @@ void controld_election_fini(void);
 void controld_stop_current_election_timeout(void);
 
 void set_join_state(const char *start_state, const char *node_name,
-                    const char *node_uuid);
+                    const char *node_uuid, bool remote);
 
 #endif

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1474,6 +1474,7 @@ process_lrmd_signon(pcmk__client_t *client, xmlNode *request, int call_id,
     int rc = pcmk_ok;
     time_t now = time(NULL);
     const char *protocol_version = crm_element_value(request, F_LRMD_PROTOCOL_VERSION);
+    const char *start_state = pcmk__env_option(PCMK__ENV_NODE_START_STATE);
 
     if (compare_version(protocol_version, LRMD_MIN_PROTOCOL_VERSION) < 0) {
         crm_err("Cluster API version must be greater than or equal to %s, not %s",
@@ -1502,6 +1503,10 @@ process_lrmd_signon(pcmk__client_t *client, xmlNode *request, int call_id,
     crm_xml_add(*reply, F_LRMD_CLIENTID, client->id);
     crm_xml_add(*reply, F_LRMD_PROTOCOL_VERSION, LRMD_PROTOCOL_VERSION);
     crm_xml_add_ll(*reply, PCMK__XA_UPTIME, now - start_time);
+
+    if (start_state) {
+        crm_xml_add(*reply, PCMK__XA_NODE_START_STATE, start_state);
+    }
 
     return rc;
 }

--- a/etc/sysconfig/pacemaker.in
+++ b/etc/sysconfig/pacemaker.in
@@ -144,8 +144,7 @@
 # By default, the local host will join the cluster in an online or standby
 # state when Pacemaker first starts depending on whether it was previously put
 # into standby mode. If this variable is set to "standby" or "online", it will
-# force the local host to join in the specified state. This has no effect on
-# Pacemaker Remote nodes.
+# force the local host to join in the specified state.
 #
 # Default: PCMK_node_start_state="default"
 

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -112,6 +112,7 @@ struct pcmk__remote_s {
     int tcp_socket;
     mainloop_io_t *source;
     time_t uptime;
+    char *start_state;
 
     /* CIB-only */
     char *token;

--- a/include/crm/lrmd_internal.h
+++ b/include/crm/lrmd_internal.h
@@ -47,6 +47,7 @@ void lrmd__set_result(lrmd_event_data_t *event, enum ocf_exitcode rc,
 void lrmd__reset_result(lrmd_event_data_t *event);
 
 time_t lrmd__uptime(lrmd_t *lrmd);
+const char *lrmd__node_start_state(lrmd_t *lrmd);
 
 /* Shared functions for IPC proxy back end */
 

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -84,6 +84,7 @@
 #define PCMK__XA_GRAPH_ERRORS           "graph-errors"
 #define PCMK__XA_GRAPH_WARNINGS         "graph-warnings"
 #define PCMK__XA_MODE                   "mode"
+#define PCMK__XA_NODE_START_STATE       "node_start_state"
 #define PCMK__XA_TASK                   "task"
 #define PCMK__XA_UPTIME                 "uptime"
 #define PCMK__XA_CONN_HOST              "connection_host"

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -588,7 +588,9 @@ lrmd_tls_connection_destroy(gpointer userdata)
     }
 
     free(native->remote->buffer);
+    free(native->remote->start_state);
     native->remote->buffer = NULL;
+    native->remote->start_state = NULL;
     native->source = 0;
     native->sock = 0;
     native->psk_cred_c = NULL;
@@ -980,6 +982,7 @@ lrmd_handshake(lrmd_t * lrmd, const char *name)
         const char *version = crm_element_value(reply, F_LRMD_PROTOCOL_VERSION);
         const char *msg_type = crm_element_value(reply, F_LRMD_OPERATION);
         const char *tmp_ticket = crm_element_value(reply, F_LRMD_CLIENTID);
+        const char *start_state = crm_element_value(reply, PCMK__XA_NODE_START_STATE);
         long long uptime = -1;
 
         crm_element_value_int(reply, F_LRMD_RC, &rc);
@@ -991,6 +994,10 @@ lrmd_handshake(lrmd_t * lrmd, const char *name)
          */
         crm_element_value_ll(reply, PCMK__XA_UPTIME, &uptime);
         native->remote->uptime = uptime;
+
+        if (start_state) {
+            native->remote->start_state = strdup(start_state);
+        }
 
         if (rc == -EPROTO) {
             crm_err("Executor protocol version mismatch between client (%s) and server (%s)",

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -2538,3 +2538,15 @@ lrmd__uptime(lrmd_t *lrmd)
         return native->remote->uptime;
     }
 }
+
+const char *
+lrmd__node_start_state(lrmd_t *lrmd)
+{
+    lrmd_private_t *native = lrmd->lrmd_private;
+
+    if (native->remote == NULL) {
+        return NULL;
+    } else {
+        return native->remote->start_state;
+    }
+}


### PR DESCRIPTION
This is against 2.1, but it definitely doesn't need to go there.  It was just easier to write on that branch since it touches a lot of the same code as the persistent transient attrs PR.  Once that's also merged to main, I can redo this PR there too.  But in the mean time, we can at least talk about it.