### PR TITLE
Preserve attributes when attrd crashes

### DIFF
--- a/daemons/attrd/Makefile.am
+++ b/daemons/attrd/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2004-2022 the Pacemaker project contributors
+# Copyright 2004-2023 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -18,7 +18,8 @@ noinst_HEADERS  = pacemaker-attrd.h
 pacemaker_attrd_CFLAGS	= $(CFLAGS_HARDENED_EXE)
 pacemaker_attrd_LDFLAGS	= $(LDFLAGS_HARDENED_EXE)
 
-pacemaker_attrd_LDADD	= $(top_builddir)/lib/cluster/libcrmcluster.la	\
+pacemaker_attrd_LDADD	= $(top_builddir)/lib/pacemaker/libpacemaker.la \
+			  $(top_builddir)/lib/cluster/libcrmcluster.la	\
 			  $(top_builddir)/lib/pengine/libpe_rules.la	\
 			  $(top_builddir)/lib/common/libcrmcommon.la	\
 			  $(top_builddir)/lib/cib/libcib.la		\

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -541,7 +541,7 @@ attrd_peer_sync_response(const crm_node_t *peer, bool peer_won, xmlNode *xml)
          child = pcmk__xml_next(child)) {
         attrd_peer_update(peer, child,
                           crm_element_value(child, PCMK__XA_ATTR_NODE_NAME),
-                          true);
+                          !crm_is_true(getenv("PCMK_respawned")));
     }
 
     if (peer_won) {

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -103,11 +103,6 @@ attrd_erase_cb(xmlNode *msg, int call_id, int rc, xmlNode *output,
  * normally done by the DC's controller when this node leaves the cluster, but
  * this handles the case where the node restarted so quickly that the
  * cluster layer didn't notice.
- *
- * \todo If pacemaker-attrd respawns after crashing (see PCMK_respawned),
- *       ideally we'd skip this and sync our attributes from the writer.
- *       However, currently we reject any values for us that the writer has, in
- *       attrd_peer_update().
  */
 static void
 attrd_erase_attrs(void)
@@ -188,7 +183,9 @@ static void
 attrd_cib_init(void)
 {
     // We have no attribute values in memory, wipe the CIB to match
-    attrd_erase_attrs();
+    if (!crm_is_true(getenv("PCMK_respawned"))) {
+        attrd_erase_attrs();
+    }
 
     // Set a trigger for reading the CIB (for the alerts section)
     attrd_config_read = mainloop_add_trigger(G_PRIORITY_HIGH, attrd_read_options, NULL);

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -915,6 +915,7 @@ void pcmk__output_and_clear_error(GError **error, pcmk__output_t *out);
 int pcmk__xml_output_new(pcmk__output_t **out, xmlNodePtr *xml);
 void pcmk__xml_output_finish(pcmk__output_t *out, xmlNodePtr *xml);
 int pcmk__log_output_new(pcmk__output_t **out);
+int pcmk__none_output_new(pcmk__output_t **out);
 int pcmk__text_output_new(pcmk__output_t **out, const char *filename);
 
 /*!

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -290,6 +290,34 @@ pcmk__log_output_new(pcmk__output_t **out)
 
 /*!
  * \internal
+ * \brief Create a new output object using the "none" format
+ *
+ * \param[out] out       Where to store newly allocated output object
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+pcmk__none_output_new(pcmk__output_t **out)
+{
+    int rc = pcmk_rc_ok;
+    const char* argv[] = { "", NULL };
+    pcmk__supported_format_t formats[] = {
+        PCMK__SUPPORTED_FORMAT_NONE,
+        { NULL, NULL, NULL }
+    };
+
+    pcmk__register_formats(NULL, formats);
+    rc = pcmk__output_new(out, "none", NULL, (char **) argv);
+    if ((rc != pcmk_rc_ok) || (*out == NULL)) {
+        crm_err("Can't create none output object to internal error: %s",
+                pcmk_rc_str(rc));
+        return rc;
+    }
+    return pcmk_rc_ok;
+}
+
+/*!
+ * \internal
  * \brief Create a new output object using the "text" format
  *
  * \param[out] out       Where to store newly allocated output object


### PR DESCRIPTION
This is pretty easy, however I think perhaps I am syncing more attributes over than we really should:

```
May 11 13:38:23.841 rhel9-cluster-2 pacemaker-attrd     [2137] (update_attr_on_host)    notice: Setting #attrd-protocol[rhel9-cluster-1]: (unset) -> 5 | from rhel9-cluster-1 with no write delay
May 11 13:38:23.841 rhel9-cluster-2 pacemaker-attrd     [2137] (update_attr_on_host)    notice: Setting #attrd-protocol[rhel9-cluster-2]: (unset) -> 5 | from rhel9-cluster-1 with no write delay
May 11 13:38:23.841 rhel9-cluster-2 pacemaker-attrd     [2137] (update_attr_on_host)    notice: Setting master-stateful[remote01]: (unset) -> 5 | from rhel9-cluster-1 with no write delay
May 11 13:38:23.841 rhel9-cluster-2 pacemaker-attrd     [2137] (update_attr_on_host)    notice: Setting master-stateful[rhel9-cluster-1]: (unset) -> 5 | from rhel9-cluster-1 with no write delay
May 11 13:38:23.842 rhel9-cluster-2 pacemaker-attrd     [2137] (update_attr_on_host)    notice: Setting master-stateful[rhel9-cluster-2]: (unset) -> 5 | from rhel9-cluster-1 with no write delay
May 11 13:38:23.846 rhel9-cluster-2 pacemaker-attrd     [2137] (update_attr_on_host)    notice: Setting #feature-set[rhel9-cluster-1]: (unset) -> 3.17.4 | from rhel9-cluster-1 with no write delay
May 11 13:38:23.846 rhel9-cluster-2 pacemaker-attrd     [2137] (update_attr_on_host)    notice: Setting #feature-set[rhel9-cluster-2]: (unset) -> 3.17.4 | from rhel9-cluster-1 with no write delay
May 11 13:38:23.846 rhel9-cluster-2 pacemaker-attrd     [2137] (update_attr_on_host)    notice: Setting ABC[remote01]: (unset) -> 123 | from rhel9-cluster-1 with no write delay
```

ABC is the test attribute, obviously.  But it doesn't seem like we want to tell the respawned attrd which protocol it supports and which feature set it's using.