### PR TITLE
libcib, based, various: Minor fixes and improvements

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1493,12 +1493,6 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
     crm_trace("cleanup");
 
     if (operation != NULL) {
-        if (!pcmk_is_set(operation->flags, cib_op_attr_modifies)
-            && (output != current_cib)) {
-
-            free_xml(output);
-            output = NULL;
-        }
         operation->cleanup(call_options, &input, &output);
     }
 

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -546,13 +546,12 @@ parse_local_options_v2(const pcmk__client_t *cib_client, int call_type,
             *needs_reply = TRUE;
             *needs_forward = TRUE;
             *process = FALSE;
-            crm_trace("%s op from %s needs to be forwarded to client %s",
+            crm_trace("%s op from %s needs to be forwarded to %s",
                       op, pcmk__client_name(cib_client),
-                      pcmk__s(host, "the primary instance"));
+                      pcmk__s(host, "all nodes"));
             return;
         }
     }
-
 
     *process = TRUE;
     *needs_reply = FALSE;

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1302,7 +1302,9 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
 #define XPATH_STATUS    "//" XML_TAG_CIB "/" XML_CIB_TAG_STATUS
 
     // Calculate the hash value of the section before the change
-    if (pcmk__str_eq(PCMK__CIB_REQUEST_REPLACE, op, pcmk__str_none)) {
+    if (!pcmk_any_flags_set(call_options, cib_dryrun|cib_inhibit_notify)
+        && pcmk__str_eq(op, PCMK__CIB_REQUEST_REPLACE, pcmk__str_none)) {
+
         current_nodes_digest = calculate_section_digest(XPATH_NODES,
                                                         current_cib);
         current_alerts_digest = calculate_section_digest(XPATH_ALERTS,
@@ -1361,7 +1363,9 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
             cib_read_config(config_hash, result_cib);
         }
 
-        if (pcmk__str_eq(PCMK__CIB_REQUEST_REPLACE, op, pcmk__str_none)) {
+        if (!pcmk_is_set(call_options, cib_inhibit_notify)
+            && pcmk__str_eq(op, PCMK__CIB_REQUEST_REPLACE, pcmk__str_none)) {
+
             char *result_nodes_digest = NULL;
             char *result_alerts_digest = NULL;
             char *result_status_digest = NULL;
@@ -1406,12 +1410,14 @@ cib_process_command(xmlNode * request, xmlNode ** reply, xmlNode ** cib_diff, gb
             if (change_section != cib_change_section_none) {
                 send_r_notify = TRUE;
             }
-            
+
             free(result_nodes_digest);
             free(result_alerts_digest);
             free(result_status_digest);
 
-        } else if (pcmk__str_eq(PCMK__CIB_REQUEST_ERASE, op, pcmk__str_none)) {
+        } else if (!pcmk_is_set(call_options, cib_inhibit_notify)
+                   && pcmk__str_eq(op, PCMK__CIB_REQUEST_ERASE,
+                                   pcmk__str_none)) {
             send_r_notify = TRUE;
         }
 

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -109,8 +109,7 @@ static int
 cib_cleanup_query(int options, xmlNode ** data, xmlNode ** output)
 {
     CRM_LOG_ASSERT(*data == NULL);
-    if ((options & cib_no_children)
-        || pcmk__str_eq(crm_element_name(*output), "xpath-query", pcmk__str_casei)) {
+    if (*output != the_cib) {
         free_xml(*output);
     }
     return pcmk_ok;

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -141,11 +141,6 @@ cib_cleanup_none(int options, xmlNode ** data, xmlNode ** output)
 
 static const cib_operation_t cib_server_ops[] = {
     {
-        NULL,
-        cib_op_attr_none,
-        cib_prepare_none, cib_cleanup_none, cib_process_default
-    },
-    {
         PCMK__CIB_REQUEST_QUERY,
         cib_op_attr_none,
         cib_prepare_none, cib_cleanup_query, cib_process_query
@@ -252,7 +247,7 @@ cib_get_operation(const char *op, const cib_operation_t **operation)
     if (operation_hash == NULL) {
         operation_hash = pcmk__strkey_table(NULL, NULL);
 
-        for (int lpc = 1; lpc < PCMK__NELEM(cib_server_ops); lpc++) {
+        for (int lpc = 0; lpc < PCMK__NELEM(cib_server_ops); lpc++) {
             const cib_operation_t *oper = &(cib_server_ops[lpc]);
 
             g_hash_table_insert(operation_hash, (gpointer) oper->name,

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -318,10 +318,10 @@ cib_msg_copy(xmlNode *msg)
     return copy;
 }
 
-cib_op_t *
+cib_op_t
 cib_op_func(int call_type)
 {
-    return &(cib_server_ops[call_type].fn);
+    return cib_server_ops[call_type].fn;
 }
 
 gboolean

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -188,7 +188,7 @@ static const cib_operation_t cib_server_ops[] = {
     {
         PCMK__CIB_REQUEST_NOOP,
         cib_op_attr_none,
-        cib_prepare_none, cib_cleanup_none, cib_process_default
+        cib_prepare_none, cib_cleanup_none, cib_process_noop
     },
     {
         PCMK__CIB_REQUEST_ABS_DELETE,

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -257,13 +257,8 @@ cib_get_operation_id(const char *op, int *operation)
 }
 
 xmlNode *
-cib_msg_copy(xmlNode * msg, gboolean with_data)
+cib_msg_copy(xmlNode *msg)
 {
-    int lpc = 0;
-    const char *field = NULL;
-    const char *value = NULL;
-    xmlNode *value_struct = NULL;
-
     static const char *field_list[] = {
         F_XML_TAGNAME,
         F_TYPE,
@@ -288,28 +283,16 @@ cib_msg_copy(xmlNode * msg, gboolean with_data)
         F_CIB_NOTIFY_ACTIVATE
     };
 
-    static const char *data_list[] = {
-        F_CIB_CALLDATA,
-        F_CIB_UPDATE,
-        F_CIB_UPDATE_RESULT
-    };
-
     xmlNode *copy = create_xml_node(NULL, "copy");
 
     CRM_ASSERT(copy != NULL);
 
-    for (lpc = 0; lpc < PCMK__NELEM(field_list); lpc++) {
-        field = field_list[lpc];
-        value = crm_element_value(msg, field);
+    for (int lpc = 0; lpc < PCMK__NELEM(field_list); lpc++) {
+        const char *field = field_list[lpc];
+        const char *value = crm_element_value(msg, field);
+
         if (value != NULL) {
             crm_xml_add(copy, field, value);
-        }
-    }
-    for (lpc = 0; with_data && lpc < PCMK__NELEM(data_list); lpc++) {
-        field = data_list[lpc];
-        value_struct = get_message_xml(msg, field);
-        if (value_struct != NULL) {
-            add_message_xml(copy, field, value_struct);
         }
     }
 

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -386,7 +386,7 @@ sync_our_cib(xmlNode * request, gboolean all)
 
     CRM_CHECK(the_cib != NULL, return -EINVAL);
 
-    replace_request = cib_msg_copy(request, FALSE);
+    replace_request = cib_msg_copy(request);
     CRM_CHECK(replace_request != NULL, return -EINVAL);
 
     crm_debug("Syncing CIB to %s", all ? "all peers" : host);

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -365,6 +365,7 @@ cib_process_replace_svr(const char *op, int options, const char *section, xmlNod
     return rc;
 }
 
+// @COMPAT: Remove when PCMK__CIB_REQUEST_ABS_DELETE is removed
 int
 cib_process_delete_absolute(const char *op, int options, const char *section, xmlNode * req,
                             xmlNode * input, xmlNode * existing_cib, xmlNode ** result_cib,

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -61,25 +61,15 @@ cib_process_shutdown_req(const char *op, int options, const char *section, xmlNo
     return pcmk_ok;
 }
 
+// @COMPAT: Remove when PCMK__CIB_REQUEST_NOOP is removed
 int
-cib_process_default(const char *op, int options, const char *section, xmlNode * req,
-                    xmlNode * input, xmlNode * existing_cib, xmlNode ** result_cib,
-                    xmlNode ** answer)
+cib_process_noop(const char *op, int options, const char *section, xmlNode *req,
+                 xmlNode *input, xmlNode *existing_cib, xmlNode **result_cib,
+                 xmlNode **answer)
 {
-    int result = pcmk_ok;
-
     crm_trace("Processing \"%s\" event", op);
     *answer = NULL;
-
-    if (op == NULL) {
-        result = -EINVAL;
-        crm_err("No operation specified");
-
-    } else if (strcmp(PCMK__CIB_REQUEST_NOOP, op) != 0) {
-        result = -EPROTONOSUPPORT;
-        crm_err("Action [%s] is not supported by the CIB manager", op);
-    }
-    return result;
+    return pcmk_ok;
 }
 
 int

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -43,10 +43,20 @@ enum cib_client_flags {
     cib_is_daemon      = (UINT64_C(1) << 12),
 };
 
+/*!
+ * \internal
+ * \enum cib_op_attr
+ * \brief Bit flags for CIB operation attributes
+ */
+enum cib_op_attr {
+    cib_op_attr_none       = 0,         //!< No special attributes
+    cib_op_attr_modifies   = (1 << 1),  //!< Modifies CIB
+    cib_op_attr_privileged = (1 << 2),  //!< Requires privileges
+};
+
 typedef struct cib_operation_s {
     const char *operation;
-    gboolean modifies_cib;
-    gboolean needs_privileges;
+    uint32_t flags; //!< Group of <tt>enum cib_op_attr</tt> flags
     int (*prepare) (xmlNode *, xmlNode **, const char **);
     int (*cleanup) (int, xmlNode **, xmlNode **);
     int (*fn) (const char *, int, const char *, xmlNode *,

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -136,7 +136,7 @@ int sync_our_cib(xmlNode *request, gboolean all);
 
 xmlNode *cib_msg_copy(xmlNode *msg);
 int cib_get_operation_id(const char *op, int *operation);
-cib_op_t *cib_op_func(int call_type);
+cib_op_t cib_op_func(int call_type);
 gboolean cib_op_modifies(int call_type);
 int cib_op_prepare(int call_type, xmlNode *request, xmlNode **input,
                    const char **section);

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -124,7 +124,7 @@ int cib_process_upgrade_server(const char *op, int options, const char *section,
 void send_sync_request(const char *host);
 int sync_our_cib(xmlNode *request, gboolean all);
 
-xmlNode *cib_msg_copy(xmlNode *msg, gboolean with_data);
+xmlNode *cib_msg_copy(xmlNode *msg);
 int cib_get_operation_id(const char *op, int *operation);
 cib_op_t *cib_op_func(int call_type);
 gboolean cib_op_modifies(int call_type);

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -55,12 +55,11 @@ enum cib_op_attr {
 };
 
 typedef struct cib_operation_s {
-    const char *operation;
+    const char *name;
     uint32_t flags; //!< Group of <tt>enum cib_op_attr</tt> flags
     int (*prepare) (xmlNode *, xmlNode **, const char **);
     int (*cleanup) (int, xmlNode **, xmlNode **);
-    int (*fn) (const char *, int, const char *, xmlNode *,
-               xmlNode *, xmlNode *, xmlNode **, xmlNode **);
+    cib_op_t fn;
 } cib_operation_t;
 
 extern bool based_is_primary;
@@ -135,14 +134,7 @@ void send_sync_request(const char *host);
 int sync_our_cib(xmlNode *request, gboolean all);
 
 xmlNode *cib_msg_copy(xmlNode *msg);
-int cib_get_operation_id(const char *op, int *operation);
-cib_op_t cib_op_func(int call_type);
-gboolean cib_op_modifies(int call_type);
-int cib_op_prepare(int call_type, xmlNode *request, xmlNode **input,
-                   const char **section);
-int cib_op_cleanup(int call_type, int options, xmlNode **input,
-                   xmlNode **output);
-int cib_op_can_run(int call_type, int call_options, bool privileged);
+int cib_get_operation(const char *op, const cib_operation_t **operation);
 void cib_diff_notify(const char *op, int result, const char *call_id,
                      const char *client_id, const char *client_name,
                      const char *origin, xmlNode *update, xmlNode *diff);

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -101,9 +101,9 @@ int cib_process_shutdown_req(const char *op, int options, const char *section,
                              xmlNode *req, xmlNode *input,
                              xmlNode *existing_cib, xmlNode **result_cib,
                              xmlNode **answer);
-int cib_process_default(const char *op, int options, const char *section,
-                        xmlNode *req, xmlNode *input, xmlNode *existing_cib,
-                        xmlNode **result_cib, xmlNode **answer);
+int cib_process_noop(const char *op, int options, const char *section,
+                     xmlNode *req, xmlNode *input, xmlNode *existing_cib,
+                     xmlNode **result_cib, xmlNode **answer);
 int cib_process_ping(const char *op, int options, const char *section,
                      xmlNode *req, xmlNode *input, xmlNode *existing_cib,
                      xmlNode **result_cib, xmlNode **answer);

--- a/daemons/controld/controld_transition.c
+++ b/daemons/controld/controld_transition.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,11 +14,6 @@
 #include <crm/common/xml.h>
 
 #include <pacemaker-controld.h>
-
-static void
-global_cib_callback(const xmlNode * msg, int callid, int rc, xmlNode * output)
-{
-}
 
 static pcmk__graph_t *
 create_blank_graph(void)
@@ -80,12 +75,6 @@ do_te_control(long long action,
         if (cib_conn->cmds->add_notify_callback(cib_conn, T_CIB_DIFF_NOTIFY,
                                                 te_update_diff) != pcmk_ok) {
             crm_err("Could not set CIB notification callback");
-            init_ok = FALSE;
-        }
-
-        if (cib_conn->cmds->set_op_callback(cib_conn,
-                                            global_cib_callback) != pcmk_ok) {
-            crm_err("Could not set CIB global callback");
             init_ok = FALSE;
         }
     }

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -60,7 +60,25 @@ enum cib_call_options {
     cib_no_children     = (1 << 5),
     cib_xpath_address   = (1 << 6),
     cib_mixed_update    = (1 << 7),
+
+    /* @COMPAT: cib_scope_local is processed only in the legacy function
+     * parse_local_options_v1().
+     *
+     * If (host == NULL):
+     * * In legacy mode, the CIB manager forwards a request to the primary
+     *   instance unless cib_scope_local is set or the local node is primary.
+     * * Outside of legacy mode:
+     *   * If a request modifies the CIB, the CIB manager forwards it to all
+     *     nodes.
+     *   * Otherwise, the CIB manager processes the request locally.
+     *
+     * There is no current use case for this implementing this flag in
+     * non-legacy mode.
+     */
+
+    //! \deprecated This value will be removed in a future release
     cib_scope_local     = (1 << 8),
+
     cib_dryrun          = (1 << 9),
     cib_sync_call       = (1 << 12),
     cib_no_mtime        = (1 << 13),

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -101,7 +101,9 @@ typedef struct cib_api_operations_s {
     //! \deprecated This method will be removed and should not be used
     int (*inputfd) (cib_t *cib);
 
+    //! \deprecated This method will be removed and should not be used
     int (*noop) (cib_t *cib, int call_options);
+
     int (*ping) (cib_t *cib, xmlNode **output_data, int call_options);
     int (*query) (cib_t *cib, const char *section, xmlNode **output_data,
                   int call_options);

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -97,7 +97,10 @@ typedef struct cib_api_operations_s {
                                                   xmlNode *msg));
     int (*set_connection_dnotify) (cib_t *cib,
                                    void (*dnotify) (gpointer user_data));
+
+    //! \deprecated This method will be removed and should not be used
     int (*inputfd) (cib_t *cib);
+
     int (*noop) (cib_t *cib, int call_options);
     int (*ping) (cib_t *cib, xmlNode **output_data, int call_options);
     int (*query) (cib_t *cib, const char *section, xmlNode **output_data,

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -221,8 +221,11 @@ struct cib_s {
     void *delegate_fn;
 
     GList *notify_list;
+
+    //! \deprecated This method will be removed in a future release
     void (*op_callback) (const xmlNode *msg, int call_id, int rc,
                          xmlNode *output);
+
     cib_api_operations_t *cmds;
 };
 

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -141,7 +141,9 @@ typedef struct cib_api_operations_s {
     int (*delete_absolute) (cib_t *cib, const char *section, xmlNode *data,
                             int call_options);
 
+    //! \deprecated This method is not implemented and should not be used
     int (*quit) (cib_t *cib, int call_options);
+
     int (*register_notification) (cib_t *cib, const char *callback,
                                   int enabled);
     gboolean (*register_callback) (cib_t *cib, int call_id, int timeout,

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -86,9 +86,12 @@ typedef struct cib_api_operations_s {
                        int *event_fd);
     int (*signoff) (cib_t *cib);
     int (*free) (cib_t *cib);
+
+    //! \deprecated This method will be removed and should not be used
     int (*set_op_callback) (cib_t *cib, void (*callback) (const xmlNode *msg,
                                                           int callid, int rc,
                                                           xmlNode *output));
+
     int (*add_notify_callback) (cib_t *cib, const char *event,
                                 void (*callback) (const char *event,
                                                   xmlNode *msg));

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -129,7 +129,7 @@ typedef int (*cib_op_t) (const char *, int, const char *, xmlNode *,
 
 cib_t *cib_new_variant(void);
 
-int cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_query,
+int cib_perform_op(const char *op, int call_options, cib_op_t fn, gboolean is_query,
                    const char *section, xmlNode * req, xmlNode * input,
                    gboolean manage_counters, gboolean * config_changed,
                    xmlNode * current_cib, xmlNode ** result_cib, xmlNode ** diff,

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -622,7 +622,9 @@ cib_new_variant(void)
         return NULL;
     }
 
+    // Deprecated method
     new_cib->cmds->set_op_callback = cib_client_set_op_callback;
+
     new_cib->cmds->add_notify_callback = cib_client_add_notify_callback;
     new_cib->cmds->del_notify_callback = cib_client_del_notify_callback;
     new_cib->cmds->register_callback = cib_client_register_callback;

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -628,7 +628,7 @@ cib_new_variant(void)
     new_cib->cmds->register_callback = cib_client_register_callback;
     new_cib->cmds->register_callback_full = cib_client_register_callback_full;
 
-    new_cib->cmds->noop = cib_client_noop;
+    new_cib->cmds->noop = cib_client_noop; // Deprecated method
     new_cib->cmds->ping = cib_client_ping;
     new_cib->cmds->query = cib_client_query;
     new_cib->cmds->sync = cib_client_sync;

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -656,6 +656,7 @@ cib_new_variant(void)
     new_cib->cmds->remove = cib_client_delete;
     new_cib->cmds->erase = cib_client_erase;
 
+    // Deprecated method
     new_cib->cmds->delete_absolute = cib_client_delete_absolute;
 
     return new_cib;

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -138,7 +138,7 @@ cib_file_perform_op_delegate(cib_t *cib, const char *op, const char *host,
     xmlNode *output = NULL;
     xmlNode *cib_diff = NULL;
     xmlNode *result_cib = NULL;
-    cib_op_t *fn = NULL;
+    cib_op_t fn = NULL;
     int lpc = 0;
     static int max_msg_types = PCMK__NELEM(cib_file_ops);
     cib_file_opaque_t *private = cib->variant_opaque;
@@ -164,7 +164,7 @@ cib_file_perform_op_delegate(cib_t *cib, const char *op, const char *host,
 
     for (lpc = 0; lpc < max_msg_types; lpc++) {
         if (pcmk__str_eq(op, cib_file_ops[lpc].op, pcmk__str_casei)) {
-            fn = &(cib_file_ops[lpc].fn);
+            fn = cib_file_ops[lpc].fn;
             query = cib_file_ops[lpc].read_only;
             break;
         }

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -550,7 +550,7 @@ cib_file_new(const char *cib_location)
     cib->cmds->signon = cib_file_signon;
     cib->cmds->signoff = cib_file_signoff;
     cib->cmds->free = cib_file_free;
-    cib->cmds->inputfd = cib_file_inputfd;
+    cib->cmds->inputfd = cib_file_inputfd; // Deprecated method
 
     cib->cmds->register_notification = cib_file_register_notification;
     cib->cmds->set_connection_dnotify = cib_file_set_connection_dnotify;

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -215,6 +215,7 @@ cib_file_perform_op_delegate(cib_t *cib, const char *op, const char *host,
         cib_set_file_flags(private, cib_file_flag_dirty);
     }
 
+    // Global operation callback (deprecated)
     if (cib->op_callback != NULL) {
         cib->op_callback(NULL, cib->call_id, rc, output);
     }

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -614,7 +614,7 @@ cib_remote_new(const char *server, const char *user, const char *passwd, int por
     cib->cmds->signon = cib_remote_signon;
     cib->cmds->signoff = cib_remote_signoff;
     cib->cmds->free = cib_remote_free;
-    cib->cmds->inputfd = cib_remote_inputfd;
+    cib->cmds->inputfd = cib_remote_inputfd; // Deprecated method
 
     cib->cmds->register_notification = cib_remote_register_notification;
     cib->cmds->set_connection_dnotify = cib_remote_set_connection_dnotify;

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -142,7 +142,7 @@ cib_acl_enabled(xmlNode *xml, const char *user)
 }
 
 int
-cib_perform_op(const char *op, int call_options, cib_op_t * fn, gboolean is_query,
+cib_perform_op(const char *op, int call_options, cib_op_t fn, gboolean is_query,
                const char *section, xmlNode * req, xmlNode * input,
                gboolean manage_counters, gboolean * config_changed,
                xmlNode * current_cib, xmlNode ** result_cib, xmlNode ** diff, xmlNode ** output)

--- a/lib/common/io.c
+++ b/lib/common/io.c
@@ -460,11 +460,17 @@ pcmk__file_contents(const char *filename, char **contents)
             goto bail;
         }
         rewind(fp);
-        read_len = fread(*contents, 1, length, fp); /* Coverity: False positive */
+
+        read_len = fread(*contents, 1, length, fp);
         if (read_len != length) {
             free(*contents);
             *contents = NULL;
             rc = EIO;
+        } else {
+            /* Coverity thinks *contents isn't null-terminated. It doesn't
+             * understand calloc().
+             */
+            (*contents)[length] = '\0';
         }
     }
 

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -1022,6 +1022,10 @@ apply_v2_patchset(xmlNode *xml, const xmlNode *patchset)
             }
 
             child = xmlDocCopyNode(change->children, match->doc, 1);
+            if (child == NULL) {
+                return ENOMEM;
+            }
+
             if (match_child) {
                 crm_trace("Adding %s at position %d", child->name, position);
                 xmlAddPrevSibling(match_child, child);


### PR DESCRIPTION
This addresses some things that I found while working on T185. Highlights:
* Deprecate unused `cib_api_operations_t` functions (see [T656](https://projects.clusterlabs.org/T656)).
    * I'm not tied to all of these, since some of them (particularly `bump_epoch()` and `erase()`) are potentially useful methods. They just don't have internal callers. We could keep them in order to provide a more complete API for external users.
    * @kgaillot said in T656: "My long-term goal is to deprecate all of libcib, replaced with equivalent functionality in libcrmcommon (probably a long ways off though)."
    * `ping()` could also be deprecated if it turns out that sbd doesn't need it; see comment https://projects.clusterlabs.org/T656#9046, etc.
* Deprecate CIB global callbacks. There are no internal users. It's confusing because nothing about the nomenclature suggests that it's a global callback, and nothing about the per-call callbacks' nomenclature suggests that those are per-call.
* Apply `cib_inhibit_notify` to replace notifications. It applies only to diff notifications currently, and that seems incorrect.
* Deprecate `cib_scope_local` and document its behavior. It's processed only when `pacemaker-based` is in legacy mode, so we can drop it when we drop support for mixed-version clusters with Pacemaker 1.1.11. This flag is misleading, because setting it outside of legacy mode does nothing -- it does **not** specify that only the local CIB gets modified.
* Replace `cib_operation_t` booleans with new enum flags for readability.
* Return `cib_operation_t` objects directly to callers.
    * Currently we return the object's index in an internal array, and then we pass that index to various getter functions.
    * With this PR, we access the object's members directly. The getters are short and don't save much code in the callers.
    * I'm not tied to this either. We could keep the getters and isolate `cib_operation_t` to one `based_common.c`.

I'm currently running 100 CTSlab tests. I ran 25 recently and everything was fine. I've only made a couple of small tweaks since then.