### PR TITLE
Feature: crm_verify: Add --quiet option to crm_verify

### DIFF
--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -85,10 +85,23 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
                               "Check the consistency of the configuration in the running cluster:\n\n"
                               "\tcrm_verify --live-check\n\n"
                               "Check the consistency of the configuration in a given file and "
+                              "produce quiet output:\n\n"
+                              "\tcrm_verify --xml-file file.xml --quiet\n\n"
+                              "Check the consistency of the configuration in a given file and "
                               "produce verbose output:\n\n"
                               "\tcrm_verify --xml-file file.xml --verbose\n\n";
 
+    GOptionEntry extra_prog_entries[] = {
+        { "quiet", 'q', 0, G_OPTION_ARG_NONE, &(args->quiet),
+          "Don't print verify information",
+          NULL },
+        { NULL }
+    };
+
     context = pcmk__build_arg_context(args, "text (default), xml", group, NULL);
+
+    pcmk__add_main_args(context, extra_prog_entries);
+
     g_option_context_set_description(context, description);
 
     pcmk__add_arg_group(context, "data", "Data sources:",
@@ -124,6 +137,10 @@ main(int argc, char **argv)
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
         exit_code = CRM_EX_USAGE;
         goto done;
+    }
+
+    if (args->verbosity > 0) {
+        args->verbosity -= args->quiet;
     }
 
     pcmk__cli_init_logging("crm_verify", args->verbosity);


### PR DESCRIPTION
This PR doesn't change the fact that the output is not verbose by default:

```
[root@pcmk-1 ~]# crm_verify --xml-file tmp.xml
crm_verify: Errors found during check: config not valid
-V may provide more details
```

So, you still need to specify that you want it to be verbose:

```
[root@pcmk-1 ~]# crm_verify --xml-file tmp.xml --verbose
(unpack_resources) 	error: Resource start-up disabled since no STONITH resources have been defined
(unpack_resources) 	error: Either configure some or disable STONITH with the stonith-enabled option
(unpack_resources) 	error: NOTE: Clusters with shared data need STONITH to ensure data integrity
crm_verify: Errors found during check: config not valid
```

This PR adds the ability to make it quiet:
```
[root@pcmk-1 ~]# crm_verify --xml-file tmp.xml --verbose --quiet
crm_verify: Errors found during check: config not valid
-V may provide more details
```

This is what happens when you only use ```--quiet```:
```
[root@pcmk-1 ~]# crm_verify --xml-file tmp.xml --quiet
crm_verify: Errors found during check: config not valid
-V may provide more details
```

Unlike ```--verbose``` (unsigned integer), ```--quiet``` (gboolean) can only be used once per command