### PR TITLE
Refactor: python: Use %r instead of calling repr in format strings.

### DIFF
--- a/python/pacemaker/_cts/audits.py
+++ b/python/pacemaker/_cts/audits.py
@@ -76,7 +76,7 @@ class LogAudit(ClusterAudit):
         if not nodes:
             nodes = self._cm.Env["nodes"]
 
-        self._cm.debug("Restarting logging on: %s" % repr(nodes))
+        self._cm.debug("Restarting logging on: %r" % nodes)
 
         for node in nodes:
             if self._cm.Env["have_systemd"]:
@@ -426,28 +426,24 @@ class PrimitiveAudit(ClusterAudit):
 
         if len(active) == 1:
             if quorum:
-                self.debug("Resource %s active on %s" % (resource.id, repr(active)))
+                self.debug("Resource %s active on %r" % (resource.id, active))
 
             elif resource.needs_quorum == 1:
-                self._cm.log("Resource %s active without quorum: %s"
-                            % (resource.id, repr(active)))
+                self._cm.log("Resource %s active without quorum: %r" % (resource.id, active))
                 rc = False
 
         elif not resource.managed:
-            self._cm.log("Resource %s not managed. Active on %s"
-                        % (resource.id, repr(active)))
+            self._cm.log("Resource %s not managed. Active on %r" % (resource.id, active))
 
         elif not resource.unique:
             # TODO: Figure out a clever way to actually audit these resource types
             if len(active) > 1:
-                self.debug("Non-unique resource %s is active on: %s"
-                              % (resource.id, repr(active)))
+                self.debug("Non-unique resource %s is active on: %r" % (resource.id, active))
             else:
                 self.debug("Non-unique resource %s is not active" % resource.id)
 
         elif len(active) > 1:
-            self._cm.log("Resource %s is active multiple times: %s"
-                        % (resource.id, repr(active)))
+            self._cm.log("Resource %s is active multiple times: %r" % (resource.id, active))
             rc = False
 
         elif resource.orphan:
@@ -459,15 +455,15 @@ class PrimitiveAudit(ClusterAudit):
 
         elif self._cm.Env["warn-inactive"]:
             if quorum or not resource.needs_quorum:
-                self._cm.log("WARN: Resource %s not served anywhere (Inactive nodes: %s)"
-                            % (resource.id, repr(self._inactive_nodes)))
+                self._cm.log("WARN: Resource %s not served anywhere (Inactive nodes: %r)"
+                            % (resource.id, self._inactive_nodes))
             else:
-                self.debug("Resource %s not served anywhere (Inactive nodes: %s)"
-                              % (resource.id, repr(self._inactive_nodes)))
+                self.debug("Resource %s not served anywhere (Inactive nodes: %r)"
+                              % (resource.id, self._inactive_nodes))
 
         elif quorum or not resource.needs_quorum:
-            self.debug("Resource %s not served anywhere (Inactive nodes: %s)"
-                          % (resource.id, repr(self._inactive_nodes)))
+            self.debug("Resource %s not served anywhere (Inactive nodes: %r)"
+                          % (resource.id, self._inactive_nodes))
 
         return rc
 
@@ -571,8 +567,8 @@ class GroupAudit(PrimitiveAudit):
 
                 if len(nodes) > 1:
                     result = False
-                    self._cm.log("Child %s of %s is active more than once: %s"
-                                % (child.id, group.id, repr(nodes)))
+                    self._cm.log("Child %s of %s is active more than once: %r"
+                                % (child.id, group.id, nodes))
 
                 elif not nodes:
                     # Groups are allowed to be partially active
@@ -675,11 +671,11 @@ class ColocationAudit(PrimitiveAudit):
                 for node in source:
                     if not node in target:
                         result = False
-                        self._cm.log("Colocation audit (%s): %s running on %s (not in %s)"
-                                    % (coloc.id, coloc.rsc, node, repr(target)))
+                        self._cm.log("Colocation audit (%s): %s running on %s (not in %r)"
+                                    % (coloc.id, coloc.rsc, node, target))
                     else:
-                        self.debug("Colocation audit (%s): %s running on %s (in %s)"
-                                      % (coloc.id, coloc.rsc, node, repr(target)))
+                        self.debug("Colocation audit (%s): %s running on %s (in %r)"
+                                      % (coloc.id, coloc.rsc, node, target))
 
         return result
 
@@ -722,8 +718,8 @@ class ControllerStateAudit(ClusterAudit):
 
         if len(unstable_list) > 0:
             result = False
-            self._cm.log("Cluster is not stable: %d (of %d): %s"
-                     % (len(unstable_list), self._cm.upcount(), repr(unstable_list)))
+            self._cm.log("Cluster is not stable: %d (of %d): %r"
+                     % (len(unstable_list), self._cm.upcount(), unstable_list))
 
         if up_are_down > 0:
             result = False

--- a/python/pacemaker/_cts/remote.py
+++ b/python/pacemaker/_cts/remote.py
@@ -71,7 +71,7 @@ class AsyncCmd(Thread):
         self._proc.wait()
 
         if self._delegate:
-            self._logger.debug("cmd: pid %d returned %d to %s" % (self._proc.pid, self._proc.returncode, repr(self._delegate)))
+            self._logger.debug("cmd: pid %d returned %d to %r" % (self._proc.pid, self._proc.returncode, self._delegate))
         else:
             self._logger.debug("cmd: pid %d returned %d" % (self._proc.pid, self._proc.returncode))
 

--- a/python/pacemaker/_cts/tests/partialstart.py
+++ b/python/pacemaker/_cts/tests/partialstart.py
@@ -53,7 +53,7 @@ class PartialStart(CTSTest):
         self._cm.StartaCMnoBlock(node)
         ret = watch.look_for_all()
         if not ret:
-            self._logger.log("Patterns not found: " + repr(watch.unmatched))
+            self._logger.log("Patterns not found: %r" % watch.unmatched)
             return self.failure("Setup of %s failed" % node)
 
         ret = self._stop(node)

--- a/python/pacemaker/_cts/tests/restartonebyone.py
+++ b/python/pacemaker/_cts/tests/restartonebyone.py
@@ -53,7 +53,6 @@ class RestartOnebyOne(CTSTest):
                 did_fail.append(node)
 
         if did_fail:
-            return self.failure("Could not restart %d nodes: %s"
-                                % (len(did_fail), repr(did_fail)))
+            return self.failure("Could not restart %d nodes: %r" % (len(did_fail), did_fail))
 
         return self.success()

--- a/python/pacemaker/_cts/tests/standbytest.py
+++ b/python/pacemaker/_cts/tests/standbytest.py
@@ -75,7 +75,7 @@ class StandbyTest(CTSTest):
 
         ret = watch.look_for_all()
         if not ret:
-            self._logger.log("Patterns not found: " + repr(watch.unmatched))
+            self._logger.log("Patterns not found: %r" % watch.unmatched)
             self._cm.SetStandbyMode(node, "off")
             return self.failure("cluster didn't react to standby change on %s" % node)
 
@@ -90,7 +90,7 @@ class StandbyTest(CTSTest):
         self.debug("Checking resources")
         rscs_on_node = self._cm.active_resources(node)
         if rscs_on_node:
-            rc = self.failure("%s set to standby, %s is still running on it" % (node, repr(rscs_on_node)))
+            rc = self.failure("%s set to standby, %r is still running on it" % (node, rscs_on_node))
             self.debug("Setting node %s to active mode" % node)
             self._cm.SetStandbyMode(node, "off")
             return rc

--- a/python/pacemaker/_cts/tests/startonebyone.py
+++ b/python/pacemaker/_cts/tests/startonebyone.py
@@ -50,6 +50,6 @@ class StartOnebyOne(CTSTest):
                 failed.append(node)
 
         if failed:
-            return self.failure("Some node failed to start: " + repr(failed))
+            return self.failure("Some node failed to start: %r" % failed)
 
         return self.success()

--- a/python/pacemaker/_cts/tests/stonithdtest.py
+++ b/python/pacemaker/_cts/tests/stonithdtest.py
@@ -96,7 +96,7 @@ class StonithdTest(CTSTest):
 
         self.set_timer("reform")
         if watch.unmatched:
-            self._logger.log("Patterns not found: " + repr(watch.unmatched))
+            self._logger.log("Patterns not found: %r" % watch.unmatched)
 
         self.debug("Waiting for the cluster to recover")
         self._cm.cluster_stable()

--- a/python/pacemaker/_cts/tests/stoponebyone.py
+++ b/python/pacemaker/_cts/tests/stoponebyone.py
@@ -51,6 +51,6 @@ class StopOnebyOne(CTSTest):
                 failed.append(node)
 
         if failed:
-            return self.failure("Some node failed to stop: " + repr(failed))
+            return self.failure("Some node failed to stop: %r" % failed)
 
         return self.success()

--- a/python/pacemaker/_cts/watcher.py
+++ b/python/pacemaker/_cts/watcher.py
@@ -139,7 +139,7 @@ class FileObj(SearchObj):
 
             if match:
                 self.offset = match.group(1)
-                self.debug("Got %d lines, new offset: %s  %s" % (len(out), self.offset, repr(self._delegate)))
+                self.debug("Got %d lines, new offset: %s  %r" % (len(out), self.offset, self._delegate))
             elif re.search(r"^CTSwatcher:.*truncated", line):
                 self.log(line)
             elif re.search(r"^CTSwatcher:", line):
@@ -413,7 +413,7 @@ class LogWatcher:
         for t in pending:
             t.join(60.0)
             if t.is_alive():
-                self._logger.log("%s: Aborting after 20s waiting for %s logging commands" % (self.name, repr(t)))
+                self._logger.log("%s: Aborting after 20s waiting for %r logging commands" % (self.name, t))
                 return
 
     def end(self):


### PR DESCRIPTION
This is the same thing, but without the explicit call to repr, which makes the lines a little shorter and gets rid of closing parens in places where there's already a pile of them.