### PR TITLE
Low: libcrmservice: Fix an error when coverage is enabled.

### DIFF
--- a/lib/services/dbus.c
+++ b/lib/services/dbus.c
@@ -594,6 +594,8 @@ handle_query_result(DBusMessage *reply, struct property_query *data)
     DBusMessageIter variant_iter;
     DBusBasicValue value;
 
+    dbus_error_init(&error);
+
     // First, check if the reply contains an error
     if (pcmk_dbus_find_error((void*)&error, reply, &error)) {
         crm_err("DBus query for %s property '%s' failed: %s",

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -717,6 +717,8 @@ process_unit_method_reply(DBusMessage *reply, svc_action_t *op)
 {
     DBusError error;
 
+    dbus_error_init(&error);
+
     /* The first use of error here is not used other than as a non-NULL flag to
      * indicate that a request was indeed sent
      */


### PR DESCRIPTION
For some reason that I haven't been able to track down, the following warning occurs only when you build with coverage enabled:

dbus.c: In function 'handle_query_result':
dbus.c:598:9: error: 'error' may be used uninitialized [-Werror=maybe-uninitialized]
  598 |     if (pcmk_dbus_find_error((void*)&error, reply, &error)) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

You don't even have to "make coverage".  Just configuring with coverage enabled and then building normally is enough.