### PR TITLE
Build: INSTALL: Add libcmocka version dependency

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,7 @@ Also:
 | documentation (PDF)                             |                | latexmk texlive texlive-capt-of texlive-collection-xetex texlive-fncychap texlive-framed texlive-multirow texlive-needspace texlive-tabulary texlive-titlesec texlive-threeparttable texlive-upquote texlive-wrapfig texlive-xetex | texlive texlive-latex  | texlive texlive-latex-extra |
 | annotated source code as HTML via "make global" |                | global                  | global                  | global                  |
 | RPM packages via "make rpm"                     | 4.11 or later  | rpm                     | rpm                     | (n/a)                   |
-| unit tests                                      |                | libcmocka-devel         | libcmocka-devel         | libcmocka-dev           |
+| unit tests                                      | 1.1.0 or later | libcmocka-devel         | libcmocka-devel         | libcmocka-dev           |
 
 ## Optional testing dependencies
 * procps and psmisc (if running cts-exec, cts-fencing, or CTS)


### PR DESCRIPTION
We call function_called(), which was added in cmocka v1.1.0: https://gitlab.com/cmocka/cmocka/-/commit/443b0280.

Closes CLBZ#5518