### PR TITLE
Feature: cts-cli: Add cts-cli option to display failures

### DIFF
--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -3382,6 +3382,11 @@ function print_or_remove_file() {
     rm -f "$TMPFILE"
   else
     echo "    $TMPFILE"
+    if [ $verbose -ne 0 ]; then
+      echo "======================================================"
+      cat "$TMPFILE"
+      echo "======================================================"
+    fi
   fi
 }
 


### PR DESCRIPTION
Adding this option to cts-cli means that all regression tests now have this option.

cts-cli was writing error messages to a file only. These now get written to the command line when the verbose option is used.

All other regression tests either always write errors to the command line (attrd, exec, fencing) or already have the behavior that cli now has (scheduler).

closes T514